### PR TITLE
fix: resolve provider for agent sessions

### DIFF
--- a/pkg/agentcompose/agent_definition_test.go
+++ b/pkg/agentcompose/agent_definition_test.go
@@ -254,6 +254,37 @@ func TestAgentDefinitionCreateSession(t *testing.T) {
 	testAgentDefinitionCreateSession(t)
 }
 
+func TestAgentSessionMessageUsesDefinitionProvider(t *testing.T) {
+	ctx := context.Background()
+	service, runtime, _ := newTestServiceAPIHarness(t)
+	created, err := service.CreateAgentDefinition(ctx, connect.NewRequest(&agentcomposev1.CreateAgentDefinitionRequest{
+		Name:     "Claude Runner",
+		Enabled:  true,
+		Provider: "claude",
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	sessionResp, err := service.CreateAgentSession(ctx, connect.NewRequest(&agentcomposev1.CreateAgentSessionRequest{
+		AgentId: created.Msg.GetAgent().GetAgentId(),
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentSession returned error: %v", err)
+	}
+	sessionID := sessionResp.Msg.GetSession().GetSummary().GetSessionId()
+	_, err = service.SendAgentMessage(ctx, connect.NewRequest(&agentcomposev1.SendAgentMessageRequest{
+		SessionId: sessionID,
+		Agent:     "codex",
+		Message:   "summarize",
+	}))
+	if err != nil {
+		t.Fatalf("SendAgentMessage returned error: %v", err)
+	}
+	if len(runtime.providers) != 1 || runtime.providers[0] != "claude" {
+		t.Fatalf("runtime providers = %v, want [claude]", runtime.providers)
+	}
+}
+
 func testAgentDefinitionCreateSession(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -697,7 +697,8 @@ func (s *Service) SendAgentMessage(ctx context.Context, req *connect.Request[age
 	if message == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("message is required"))
 	}
-	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgent(ctx, session, req.Msg.GetAgent(), message)
+	agent := s.resolveSessionAgentProvider(ctx, session, req.Msg.GetAgent())
+	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgent(ctx, session, agent, message)
 	_ = cell
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -719,6 +720,7 @@ func (s *Service) SendAgentMessageStream(ctx context.Context, req *connect.Reque
 	if message == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("message is required"))
 	}
+	agent := s.resolveSessionAgentProvider(ctx, session, req.Msg.GetAgent())
 
 	streamErr := func(sendErr error) error {
 		if sendErr == nil {
@@ -727,7 +729,7 @@ func (s *Service) SendAgentMessageStream(ctx context.Context, req *connect.Reque
 		return connect.NewError(connect.CodeUnknown, sendErr)
 	}
 
-	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgentStream(ctx, session, req.Msg.GetAgent(), message, AgentExecutionStream{
+	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgentStream(ctx, session, agent, message, AgentExecutionStream{
 		OnStart: func(cell NotebookCell) error {
 			return streamErr(stream.Send(&agentcomposev1.SendAgentMessageStreamResponse{
 				EventType: agentcomposev1.SendAgentMessageStreamEventType_SEND_AGENT_MESSAGE_STREAM_EVENT_TYPE_STARTED,
@@ -761,6 +763,34 @@ func (s *Service) SendAgentMessageStream(ctx context.Context, req *connect.Reque
 		UserEvent:      toProtoEvent(userEvent),
 		AssistantEvent: toProtoEvent(assistantEvent),
 	}))
+}
+
+func (s *Service) resolveSessionAgentProvider(ctx context.Context, session *Session, requested string) string {
+	provider := normalizeAgentKind(requested)
+	if session == nil {
+		return provider
+	}
+	agentID := sessionTagValue(session.Summary.Tags, agentSessionTagID)
+	if agentID == "" || !sessionHasAgentTag(session, agentID) {
+		return provider
+	}
+	agent, err := s.configDB.GetAgentDefinition(ctx, agentID)
+	if err != nil {
+		return provider
+	}
+	if saved := normalizeAgentKind(agent.Provider); saved != "" {
+		return saved
+	}
+	return provider
+}
+
+func sessionTagValue(tags []SessionTag, name string) string {
+	for _, tag := range tags {
+		if strings.TrimSpace(tag.Name) == name {
+			return strings.TrimSpace(tag.Value)
+		}
+	}
+	return ""
 }
 
 func prepareStreamingHeaders(headers http.Header) {


### PR DESCRIPTION
  ## Summary

  - Resolve agent provider from the saved agent definition for agent-created sessions.
  - Apply the same provider resolution to both unary and streaming agent message APIs.
  - Add regression coverage for the case where the request provider does not match the session's agent definition.

  ## Why

  Agent sessions are tagged with the originating agent definition. The frontend can sometimes send a fallback provider such as `codex` when replying from the generic runs page, even though the session was created
  from a `claude` agent definition.

  In that case, the backend should trust the persisted agent definition associated with the session instead of the request fallback provider.

  ## Validation

  ```bash
  go test ./pkg/agentcompose -run 'TestAgentSessionMessageUsesDefinitionProvider|TestAgentDefinitionCreateSession|TestServiceSessionKernelAgentAndLLMAPIs'