### PR TITLE
feat: Add DeepSeek provider with configurable default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ HTTP_LISTEN=127.0.0.1:7410
 # OPENAI_API_KEY=
 # LLM_MODEL=
 # LLM_TIMEOUT=60s
+#
+# DeepSeek agent provider uses DEEPSEEK_API_KEY in guest containers (HTTP API, no CLI config).
+# Optional: DEEPSEEK_MODEL=deepseek-v4-flash, DEEPSEEK_API_BASE=https://api.deepseek.com
+# DEEPSEEK_API_KEY=sk-...
 
 # Runtime
 RUNTIME_DRIVER=docker

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ Top-level fields:
 
 Common agent fields:
 
-- `provider`, `model`, `system_prompt`: agent and LLM settings.
+- `provider`, `model`, `system_prompt`: agent and LLM settings. Supported guest
+  providers are `codex`, `claude`, `gemini`, and `deepseek`.
 - `image`: guest image reference.
 - `driver`: runtime driver override. Supported drivers are `boxlite`, `docker`,
   and `microsandbox`.
@@ -238,7 +239,8 @@ Important variables include:
 - `HTTP_BASIC_AUTH`: base64-encoded `username:password` for additional HTTP
   Basic authentication.
 - `LLM_API_ENDPOINT`, `LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_MODEL`,
-  `LLM_TIMEOUT`: LLM client settings.
+  `LLM_TIMEOUT`: LLM client settings for the daemon `LLMService` only. These do
+  not inject API keys into guest agent runtimes.
 - `RUNTIME_DRIVER`: default runtime driver.
 - `DEFAULT_IMAGE`, `DOCKER_DEFAULT_IMAGE`, `MICROSANDBOX_DEFAULT_IMAGE`: guest
   image defaults.
@@ -254,6 +256,54 @@ Important variables include:
 - `GUEST_WORKSPACE`, `GUEST_STATE_ROOT`, `GUEST_RUNTIME_ROOT`,
   `GUEST_LOG_ROOT`, `JUPYTER_GUEST_PORT`: guest paths and Jupyter port.
 - `WEBHOOK_BODY_LIMIT_BYTES`, `WORKSPACE_UPLOAD_LIMIT_BYTES`: request limits.
+
+### Agent providers
+
+Guest agent sessions run provider CLIs or HTTP clients inside the guest
+container (`agent-compose-runtime-js`). API keys for Codex, Claude, Gemini, and
+DeepSeek must be supplied as session or global environment variables (for
+example through the UI: Settings -> Global environment variables), not only in
+the daemon `.env`.
+
+| Provider | Typical env vars | Notes |
+| --- | --- | --- |
+| `codex` | `OPENAI_API_KEY` or provider-specific keys in `assets/.codex/config.toml` | Uses Codex CLI/SDK in the guest image |
+| `claude` | `ANTHROPIC_API_KEY` | Uses Claude Code CLI in the guest image |
+| `gemini` | `GEMINI_API_KEY` | Uses Gemini CLI in the guest image |
+| `deepseek` | `DEEPSEEK_API_KEY` | HTTP API via `agent-compose-runtime-js`; no separate CLI |
+
+After changing guest runtime code or provider support, rebuild the guest image:
+
+```bash
+task image:agent-compose-guest
+```
+
+Create a new session (or resume one) so the updated image and environment
+variables are picked up.
+
+#### DeepSeek
+
+DeepSeek uses the OpenAI-compatible chat completions API from inside the guest
+runtime. Configure it in the UI or compose env, then set the agent provider to
+`deepseek`:
+
+```yaml
+agents:
+  assistant:
+    provider: deepseek
+    env:
+      DEEPSEEK_API_KEY:
+        value: ${DEEPSEEK_API_KEY}
+        secret: true
+```
+
+Optional guest environment variables:
+
+- `DEEPSEEK_MODEL`: defaults to `deepseek-v4-flash`
+- `DEEPSEEK_API_BASE`: defaults to `https://api.deepseek.com`
+
+DeepSeek is a chat API provider only: unlike Codex or Claude Code, it does not
+ship a full tool-using agent CLI in the guest image.
 
 ## Security Notes
 

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -141,7 +141,7 @@ export async function createAgentDefinitionSession(input: {
 
 function normalizeAgentProvider(value: string): string {
   const provider = value.trim().toLowerCase();
-  if (provider === 'claude' || provider === 'gemini' || provider === 'codex') {
+  if (provider === 'claude' || provider === 'gemini' || provider === 'codex' || provider === 'deepseek') {
     return provider;
   }
   throw new Error(`不支持的智能体 Provider：${value || '-'}`);

--- a/frontend/src/pages/AgentsPage.svelte
+++ b/frontend/src/pages/AgentsPage.svelte
@@ -599,6 +599,7 @@
             <option value="codex">codex</option>
             <option value="claude">claude</option>
             <option value="gemini">gemini</option>
+            <option value="deepseek">deepseek</option>
           </select>
         </label>
         <label class="form-item">

--- a/pkg/agentcompose/agent_definition.go
+++ b/pkg/agentcompose/agent_definition.go
@@ -90,7 +90,7 @@ func normalizeAgentDefinition(item AgentDefinition, assignDefaults bool) (AgentD
 	if item.Provider == "" {
 		return AgentDefinition{}, fmt.Errorf("agent definition provider is required")
 	}
-	if item.Provider != "codex" && item.Provider != "claude" && item.Provider != "gemini" {
+	if item.Provider != "codex" && item.Provider != "claude" && item.Provider != "gemini" && item.Provider != "deepseek" {
 		return AgentDefinition{}, fmt.Errorf("agent definition provider %q is not supported", item.Provider)
 	}
 	if !isJSONObject(item.ConfigJSON) {

--- a/pkg/agentcompose/loader_engine.go
+++ b/pkg/agentcompose/loader_engine.go
@@ -1415,7 +1415,7 @@ func loaderSecretEnvName(name string) bool {
 		return true
 	}
 	switch name {
-	case "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY", "LLM_API_KEY":
+	case "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY", "DEEPSEEK_API_KEY", "LLM_API_KEY":
 		return true
 	default:
 		return false

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -848,6 +848,8 @@ func normalizeAgentKind(agent string) string {
 		return "claude"
 	case "gemini", "gemini-cli", "gemini_cli":
 		return "gemini"
+	case "deepseek":
+		return "deepseek"
 	default:
 		return agent
 	}

--- a/runtime/agent-compose-runtime-sdk/src/agent.ts
+++ b/runtime/agent-compose-runtime-sdk/src/agent.ts
@@ -18,7 +18,7 @@ const AGENT_RESULT_PREFIX = "__AGENT_RESULT__";
 export type RuntimeAgentOutputSchema = RuntimeOutputSchema;
 
 export interface RuntimeAgentOptions<S extends RuntimeAgentOutputSchema = RuntimeAgentOutputSchema> {
-  provider?: "codex" | "claude" | "gemini";
+  provider?: "codex" | "claude" | "gemini" | "deepseek";
   stateRoot?: string;
   workspace?: string;
   home?: string;

--- a/runtime/javascript/src/cli.ts
+++ b/runtime/javascript/src/cli.ts
@@ -20,7 +20,7 @@ export function createProgram(options: { exitOverride?: boolean } = {}): Command
 
   program
     .command("prompt")
-    .requiredOption("--provider <provider>", "agent provider: codex, claude, or gemini")
+    .requiredOption("--provider <provider>", "agent provider: codex, claude, gemini, or deepseek")
     .requiredOption("--message-file <path>", "prompt file path")
     .option("--state-root <path>", "agent-compose runtime state root")
     .option("--workspace <path>", "agent working directory")

--- a/runtime/javascript/src/index.ts
+++ b/runtime/javascript/src/index.ts
@@ -6,6 +6,7 @@ export { normalizeProvider } from "./provider.js";
 export { runPromptCommand } from "./prompt.js";
 export { ClaudeRunner } from "./runners/claude.js";
 export { CodexRunner } from "./runners/codex.js";
+export { DeepSeekRunner } from "./runners/deepseek.js";
 export { GeminiRunner } from "./runners/gemini.js";
 export { readStoredSession, sessionStatePath, writeStoredSession } from "./session-state.js";
 export { appendDelta, TranscriptWriter } from "./transcript.js";

--- a/runtime/javascript/src/prompt.ts
+++ b/runtime/javascript/src/prompt.ts
@@ -6,6 +6,7 @@ import { readMpiContext } from "./mpi.js";
 import { normalizeProvider } from "./provider.js";
 import { ClaudeRunner } from "./runners/claude.js";
 import { CodexRunner } from "./runners/codex.js";
+import { DeepSeekRunner } from "./runners/deepseek.js";
 import { GeminiRunner } from "./runners/gemini.js";
 import type { AgentResult, RuntimeJsonSchema } from "./types.js";
 
@@ -42,6 +43,9 @@ export async function runPromptCommand(commandOptions: PromptCommandOptions): Pr
   }
   if (provider === "claude") {
     return await new ClaudeRunner(options).runPrompt(promptText);
+  }
+  if (provider === "deepseek") {
+    return await new DeepSeekRunner(options).runPrompt(promptText);
   }
   return await new GeminiRunner(options).runPrompt(promptText);
 }

--- a/runtime/javascript/src/provider.ts
+++ b/runtime/javascript/src/provider.ts
@@ -14,6 +14,8 @@ export function normalizeProvider(raw: unknown): Provider {
     case "gemini-cli":
     case "gemini_cli":
       return "gemini";
+    case "deepseek":
+      return "deepseek";
     default:
       throw new Error(`unsupported provider ${JSON.stringify(raw)}`);
   }

--- a/runtime/javascript/src/runners/deepseek.ts
+++ b/runtime/javascript/src/runners/deepseek.ts
@@ -1,0 +1,127 @@
+import process from "node:process";
+import { TranscriptWriter } from "../transcript.js";
+import type { AgentResult, RunnerOptions } from "../types.js";
+
+function deepseekChatCompletionsURL(base: string): string {
+  const trimmed = base.replace(/\/$/, "");
+  if (trimmed.endsWith("/chat/completions")) {
+    return trimmed;
+  }
+  if (trimmed.endsWith("/v1")) {
+    return `${trimmed}/chat/completions`;
+  }
+  return `${trimmed}/chat/completions`;
+}
+
+export class DeepSeekRunner {
+  private readonly writer = new TranscriptWriter();
+
+  constructor(private readonly options: RunnerOptions) {}
+
+  async runPrompt(promptText: string): Promise<AgentResult> {
+    const apiKey = process.env.DEEPSEEK_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error("Missing environment variable: DEEPSEEK_API_KEY");
+    }
+
+    const baseUrl = process.env.DEEPSEEK_API_BASE?.trim() || "https://api.deepseek.com";
+    const model = process.env.DEEPSEEK_MODEL?.trim() || "deepseek-v4-flash";
+    const messages: Array<{ role: "system" | "user"; content: string }> = [];
+    const mpiContext = this.options.mpiContext.trim();
+    if (mpiContext) {
+      messages.push({ role: "system", content: mpiContext });
+    }
+    if (this.options.outputSchema) {
+      messages.push({
+        role: "system",
+        content: "Respond with a single JSON object that matches the requested schema.",
+      });
+    }
+    messages.push({ role: "user", content: promptText });
+
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      stream: true,
+    };
+    if (this.options.outputSchema) {
+      body.response_format = { type: "json_object" };
+    }
+
+    const response = await fetch(deepseekChatCompletionsURL(baseUrl), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`deepseek API error ${response.status}: ${text}`);
+    }
+    if (!response.body) {
+      throw new Error("deepseek response has no body");
+    }
+
+    const result: AgentResult = {
+      provider: "deepseek",
+      sessionId: "",
+      stopReason: "completed",
+      finalText: "",
+      transcript: "",
+      stderr: "",
+    };
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let content = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+        const data = line.slice(6).trim();
+        if (!data || data === "[DONE]") {
+          continue;
+        }
+        let event: Record<string, unknown>;
+        try {
+          event = JSON.parse(data) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        if (typeof event.id === "string" && event.id) {
+          result.sessionId = event.id;
+        }
+        const choices = Array.isArray(event.choices) ? event.choices : [];
+        const choice = choices[0] as Record<string, unknown> | undefined;
+        const delta = choice?.delta as Record<string, unknown> | undefined;
+        const deltaContent = delta?.content;
+        if (typeof deltaContent === "string" && deltaContent) {
+          content += deltaContent;
+          this.writer.write(deltaContent);
+        }
+        const finishReason = choice?.finish_reason;
+        if (finishReason === "stop" || finishReason === "length") {
+          result.stopReason = "completed";
+        } else if (finishReason) {
+          result.stopReason = "error";
+        }
+      }
+    }
+
+    result.finalText = content;
+    result.transcript = this.writer.transcript();
+    return result;
+  }
+}

--- a/runtime/javascript/src/types.ts
+++ b/runtime/javascript/src/types.ts
@@ -1,4 +1,4 @@
-export type Provider = "codex" | "claude" | "gemini";
+export type Provider = "codex" | "claude" | "gemini" | "deepseek";
 export type RuntimeJsonSchema = Record<string, unknown>;
 
 export interface AgentResult {

--- a/runtime/javascript/test/deepseek.test.ts
+++ b/runtime/javascript/test/deepseek.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureStdio, runnerOptions, withTempSession } from "./helpers.js";
+
+const fetchState = vi.hoisted(() => ({
+  calls: [] as Array<{ url: string; init: RequestInit }>,
+  response: {
+    ok: true,
+    status: 200,
+    body: null as ReadableStream<Uint8Array> | null,
+    text: async () => "",
+  },
+}));
+
+vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+  fetchState.calls.push({ url: String(url), init: init || {} });
+  return fetchState.response;
+}));
+
+function sseBody(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let index = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(chunks[index]));
+      index += 1;
+    },
+  });
+}
+
+describe("DeepSeekRunner", () => {
+  beforeEach(() => {
+    fetchState.calls = [];
+    fetchState.response = {
+      ok: true,
+      status: 200,
+      body: sseBody([
+        'data: {"id":"chat-1","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}\n\n',
+        'data: {"id":"chat-1","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}\n\n',
+        "data: [DONE]\n\n",
+      ]),
+      text: async () => "",
+    };
+    vi.stubEnv("DEEPSEEK_API_KEY", "test-key");
+    vi.stubEnv("DEEPSEEK_API_BASE", undefined);
+    vi.stubEnv("DEEPSEEK_MODEL", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("streams chat completions and returns transcript", async () => {
+    const { DeepSeekRunner } = await import("../src/runners/deepseek.js");
+    await withTempSession(async (root) => {
+      const stdio = captureStdio();
+      try {
+        const result = await new DeepSeekRunner(runnerOptions(root, "mpi context", "deepseek")).runPrompt("prompt");
+
+        expect(result).toMatchObject({
+          provider: "deepseek",
+          sessionId: "chat-1",
+          finalText: "hello world",
+          stopReason: "completed",
+        });
+        expect(result.transcript).toBe("hello world");
+        expect(fetchState.calls.at(-1)?.url).toBe("https://api.deepseek.com/chat/completions");
+        const body = JSON.parse(String(fetchState.calls.at(-1)?.init.body));
+        expect(body.model).toBe("deepseek-v4-flash");
+        expect(body.messages).toEqual([
+          { role: "system", content: "mpi context" },
+          { role: "user", content: "prompt" },
+        ]);
+      } finally {
+        stdio.restore();
+      }
+    });
+  });
+
+  it("requires DEEPSEEK_API_KEY", async () => {
+    vi.stubEnv("DEEPSEEK_API_KEY", undefined);
+    const { DeepSeekRunner } = await import("../src/runners/deepseek.js");
+    await withTempSession(async (root) => {
+      await expect(new DeepSeekRunner(runnerOptions(root, "", "deepseek")).runPrompt("prompt")).rejects.toThrow(
+        "Missing environment variable: DEEPSEEK_API_KEY",
+      );
+    });
+  });
+
+  it("surfaces API errors", async () => {
+    fetchState.response = {
+      ok: false,
+      status: 401,
+      body: null,
+      text: async () => "invalid key",
+    };
+    const { DeepSeekRunner } = await import("../src/runners/deepseek.js");
+    await withTempSession(async (root) => {
+      await expect(new DeepSeekRunner(runnerOptions(root, "", "deepseek")).runPrompt("prompt")).rejects.toThrow(
+        "deepseek API error 401: invalid key",
+      );
+    });
+  });
+});

--- a/runtime/javascript/test/provider.test.ts
+++ b/runtime/javascript/test/provider.test.ts
@@ -10,6 +10,7 @@ describe("provider normalization", () => {
     ["claude_code", "claude"],
     ["gemini-cli", "gemini"],
     ["gemini_cli", "gemini"],
+    ["deepseek", "deepseek"],
   ])("maps %j to %s", (input, expected) => {
     expect(normalizeProvider(input)).toBe(expected);
   });


### PR DESCRIPTION
## Summary

This PR adds `deepseek` as a first-class guest agent provider in agent-compose.

- Runtime support via DeepSeek OpenAI-compatible Chat Completions API (streaming).
- Backend/loader support to accept `deepseek` and pass `DEEPSEEK_API_KEY` as a guest secret.
- Frontend and SDK provider enums updated.
- Docs updated (`README.md`, `.env.example`).

## Configuration

DeepSeek is configured through global environment variables:

- `DEEPSEEK_API_KEY` (required)
- `DEEPSEEK_MODEL` (optional, default: `deepseek-v4-flash`)
- `DEEPSEEK_API_BASE` (optional, default: `https://api.deepseek.com`)

To change model behavior, set `DEEPSEEK_MODEL` globally (no code change required).

## Notes

- DeepSeek provider is HTTP-based only (no Codex/Claude-style CLI toolchain).
- Rebuild guest image before creating new sessions:
  - `task image:agent-compose-guest`

## Testing

- [x] `go test ./pkg/agentcompose -count=1`
- [x] `cd runtime/javascript && npm run build && npm run test:unit`
- [x] `cd runtime/agent-compose-runtime-sdk && npm test`
- [x] `npm run build:ui`

## Checklist

- [x] Documentation updated for behavior/config changes.
- [x] Tests added/updated for user-visible behavior.
- [x] No secrets or local runtime state included.