### PR TITLE
Preserve unchanged secret env values

### DIFF
--- a/frontend/src/pages/SettingsPage.svelte
+++ b/frontend/src/pages/SettingsPage.svelte
@@ -278,9 +278,9 @@
   }
 
   async function saveEnvItems(): Promise<void> {
-    const unknownSecrets = envItems.filter((item) => item.secret && !item.valueKnown);
-    if (unknownSecrets.length > 0) {
-      error = `请重新输入或删除这些 Secret 后再保存：${unknownSecrets.map((item) => item.name || '未命名').join(', ')}`;
+    const emptyKnownSecrets = envItems.filter((item) => item.secret && item.valueKnown && item.value.trim() === '');
+    if (emptyKnownSecrets.length > 0) {
+      error = `请填写这些 Secret 的值，或删除对应变量：${emptyKnownSecrets.map((item) => item.name || '未命名').join(', ')}`;
       return;
     }
     savingEnv = true;
@@ -288,9 +288,7 @@
     message = '';
     try {
       await updateEnvItems(envItems);
-      envItems = envItems
-        .filter((item) => item.name.trim())
-        .map((item) => ({ ...item, name: item.name.trim(), valueKnown: true }));
+      envItems = await listEnvItems();
       envDirty = false;
       message = '全局环境变量已保存';
     } catch (err) {

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -254,11 +254,43 @@ func (s *Service) UpdateGlobalEnvConfig(ctx context.Context, req *connect.Reques
 	for _, item := range req.Msg.GetEnvItems() {
 		items = append(items, SessionEnvVar{Name: item.GetName(), Value: item.GetValue(), Secret: item.GetSecret()})
 	}
+	items = normalizeEnvItems(items)
+	items, err := s.preserveUnchangedGlobalEnvSecrets(ctx, items)
+	if err != nil {
+		return nil, err
+	}
 	saved, err := s.configDB.ReplaceGlobalEnv(ctx, items)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(toProtoGlobalEnvConfig(saved)), nil
+}
+
+func (s *Service) preserveUnchangedGlobalEnvSecrets(ctx context.Context, items []SessionEnvVar) ([]SessionEnvVar, error) {
+	existingItems, err := s.configDB.ListGlobalEnv(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	existingByName := make(map[string]SessionEnvVar, len(existingItems))
+	for _, item := range existingItems {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		existingByName[name] = item
+	}
+	for index, item := range items {
+		name := strings.TrimSpace(item.Name)
+		if name == "" || !item.Secret || strings.TrimSpace(item.Value) != "" {
+			continue
+		}
+		existing, ok := existingByName[name]
+		if !ok || !existing.Secret || existing.Value == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("secret env %s requires a value", name))
+		}
+		items[index].Value = existing.Value
+	}
+	return items, nil
 }
 
 func (s *Service) ListWorkspaceConfigs(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[agentcomposev1.ListWorkspaceConfigsResponse], error) {

--- a/pkg/agentcompose/service_api_test.go
+++ b/pkg/agentcompose/service_api_test.go
@@ -26,6 +26,60 @@ func TestServiceConfigAndLoaderAPIs(t *testing.T) {
 	testServiceConfigAndLoaderAPIs(t)
 }
 
+func TestUpdateGlobalEnvConfigPreservesUnchangedSecrets(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+
+	if _, err := service.UpdateGlobalEnvConfig(ctx, connect.NewRequest(&agentcomposev1.UpdateGlobalEnvConfigRequest{
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "PLAIN", Value: "visible"},
+			{Name: "TOKEN", Value: "secret-value", Secret: true},
+		},
+	})); err != nil {
+		t.Fatalf("UpdateGlobalEnvConfig(initial) returned error: %v", err)
+	}
+	if _, err := service.UpdateGlobalEnvConfig(ctx, connect.NewRequest(&agentcomposev1.UpdateGlobalEnvConfigRequest{
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "FOO", Value: "bar"},
+			{Name: "PLAIN", Value: "visible"},
+			{Name: "TOKEN", Value: "", Secret: true},
+		},
+	})); err != nil {
+		t.Fatalf("UpdateGlobalEnvConfig(preserve secret) returned error: %v", err)
+	}
+	stored, err := service.configDB.ListGlobalEnv(ctx)
+	if err != nil {
+		t.Fatalf("ListGlobalEnv returned error: %v", err)
+	}
+	env := sessionEnvMap(stored)
+	if got := env["TOKEN"]; got != "secret-value" {
+		t.Fatalf("stored TOKEN = %q, want preserved secret value", got)
+	}
+	if got := env["FOO"]; got != "bar" {
+		t.Fatalf("stored FOO = %q, want bar", got)
+	}
+
+	if _, err := service.UpdateGlobalEnvConfig(ctx, connect.NewRequest(&agentcomposev1.UpdateGlobalEnvConfigRequest{
+		EnvItems: []*agentcomposev1.SessionEnvVar{{Name: "NEW_TOKEN", Value: "", Secret: true}},
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("UpdateGlobalEnvConfig(new empty secret) code = %v, want invalid_argument", connect.CodeOf(err))
+	}
+
+	if _, err := service.UpdateGlobalEnvConfig(ctx, connect.NewRequest(&agentcomposev1.UpdateGlobalEnvConfigRequest{
+		EnvItems: []*agentcomposev1.SessionEnvVar{{Name: "PLAIN", Value: "visible"}},
+	})); err != nil {
+		t.Fatalf("UpdateGlobalEnvConfig(delete secret) returned error: %v", err)
+	}
+	stored, err = service.configDB.ListGlobalEnv(ctx)
+	if err != nil {
+		t.Fatalf("ListGlobalEnv(after delete) returned error: %v", err)
+	}
+	env = sessionEnvMap(stored)
+	if _, ok := env["TOKEN"]; ok {
+		t.Fatalf("TOKEN was preserved after deletion request: %#v", stored)
+	}
+}
+
 func TestServiceSessionKernelAgentAndLLMAPIs(t *testing.T) {
 	testServiceSessionKernelAgentAndLLMAPIs(t)
 }


### PR DESCRIPTION
## Summary

Fixes #25 by allowing existing masked global Secret environment variables to be saved without re-entering their values.

## Details

- Treat an empty incoming Secret value as "preserve the existing Secret" only when that Secret already exists in global env storage.
- Reject new empty Secret values with  so empty strings do not become valid Secret payloads.
- Keep deletion semantics unchanged: removing an env item from the submitted list deletes it.
- Update the settings page so unknown existing Secrets can be saved, while newly entered empty Secrets are still blocked.
- Reload global env items after save so preserved Secrets return to the masked/unknown state in the UI.

## Validation

- ok  	agent-compose/pkg/agentcompose	(cached)
- 
> check:ui
> vite build --config frontend/vite.config.ts

4:42:22 PM [vite-plugin-svelte] no Svelte config found at /private/tmp/agent-compose-fix-secret/frontend - using default configuration.
vite v7.3.2 building client environment for production...
transforming...
✓ 273 modules transformed.
rendering chunks...
computing gzip size...
../dist-ui/index.html                   0.37 kB │ gzip:   0.26 kB
../dist-ui/assets/index-DzucqM_C.css  112.91 kB │ gzip:  18.82 kB
../dist-ui/assets/index-420bYWVw.js   703.94 kB │ gzip: 189.13 kB
✓ built in 5.05s