### PR TITLE
fix(frontend): enable scrolling for long agent system prompts

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1285,9 +1285,11 @@ fieldset input {
 .agent-detail-panel {
   gap: 18px;
   padding: 20px 22px;
+  max-height: calc(100vh - 200px);
+  min-height: 0;
+  overflow: auto;
 }
 
-.agent-detail-panel,
 .task-detail-panel {
   align-content: start;
 }
@@ -1564,13 +1566,19 @@ fieldset input {
 
 .agent-prompt-panel pre {
   min-height: 120px;
+  max-height: 320px;
   margin: 0;
   padding: 14px 16px;
   border: 1px solid var(--line);
   border-radius: 6px;
   background: var(--surface-2);
   color: var(--text);
+  font-family: var(--mono);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-body);
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  overflow: auto;
 }
 
 .agent-config-preview {


### PR DESCRIPTION
## Summary

- 修复智能体详情页在「系统提示词」过长时无法纵向滚动查看完整内容的问题
- 为 `.agent-prompt-panel pre` 增加 `max-height` 与 `overflow: auto`，提示词区域可在框内滚动
- 为 `.agent-detail-panel` 增加视口高度限制与滚动，避免详情内容超出页面后无法查看

对应 Bug：https://github.com/chaitin/agent-compose/issues/26

## Changed files

- `frontend/src/styles.css`

## Test plan

- [x] 打开 `http://127.0.0.1:5174/agents?agent=<id>`，选择一个系统提示词较长的智能体
- [x] 确认系统提示词区域出现纵向滚动条，可查看完整内容
- [x] 确认右侧详情面板在内容超出视口时也可滚动
- [x] 确认提示词较短时布局无明显异常


Made with [Cursor](https://cursor.com)