### PR TITLE
fix: pass workspace from YAML import to agent definition

### DIFF
--- a/pkg/agentcompose/config_store.go
+++ b/pkg/agentcompose/config_store.go
@@ -379,6 +379,50 @@ func (s *ConfigStore) UpdateWorkspaceConfig(ctx context.Context, item WorkspaceC
 	return normalized, nil
 }
 
+func (s *ConfigStore) getWorkspaceConfigIfExists(ctx context.Context, id string) (WorkspaceConfig, bool, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, name, type, config_json, comment, created_at, updated_at FROM workspace_config WHERE id = ?`, strings.TrimSpace(id))
+	item, err := scanWorkspaceConfig(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WorkspaceConfig{}, false, nil
+		}
+		return WorkspaceConfig{}, false, err
+	}
+	return item, true, nil
+}
+
+func (s *ConfigStore) UpsertWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
+	normalized, err := normalizeWorkspaceConfig(item, false)
+	if err != nil {
+		return WorkspaceConfig{}, err
+	}
+	now := time.Now().UTC()
+	existing, found, err := s.getWorkspaceConfigIfExists(ctx, normalized.ID)
+	if err != nil {
+		return WorkspaceConfig{}, err
+	}
+	if found {
+		normalized.CreatedAt = existing.CreatedAt
+		normalized.UpdatedAt = now
+		result, err := s.db.ExecContext(ctx, `UPDATE workspace_config SET name = ?, type = ?, config_json = ?, comment = ?, updated_at = ? WHERE id = ?`,
+			normalized.Name, normalized.Type, normalized.ConfigJSON, normalized.Comment, normalized.UpdatedAt.Unix(), normalized.ID)
+		if err != nil {
+			return WorkspaceConfig{}, fmt.Errorf("update workspace config %s: %w", normalized.ID, err)
+		}
+		if rows, _ := result.RowsAffected(); rows == 0 {
+			return WorkspaceConfig{}, fmt.Errorf("workspace config %s not found", normalized.ID)
+		}
+		return s.GetWorkspaceConfig(ctx, normalized.ID)
+	}
+	normalized.CreatedAt = now
+	normalized.UpdatedAt = now
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO workspace_config(id, name, type, config_json, comment, created_at, updated_at) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		normalized.ID, normalized.Name, normalized.Type, normalized.ConfigJSON, normalized.Comment, normalized.CreatedAt.Unix(), normalized.UpdatedAt.Unix()); err != nil {
+		return WorkspaceConfig{}, fmt.Errorf("insert workspace config %s: %w", normalized.ID, err)
+	}
+	return normalized, nil
+}
+
 func (s *ConfigStore) DeleteWorkspaceConfig(ctx context.Context, id string) error {
 	trimmedID := strings.TrimSpace(id)
 	if trimmedID == "" {

--- a/pkg/agentcompose/project_service.go
+++ b/pkg/agentcompose/project_service.go
@@ -149,6 +149,11 @@ func (s *Service) ApplyProject(ctx context.Context, req *connect.Request[agentco
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("apply project %s: %w", normalized.spec.Name, err))
 	}
+	// Materialize workspace configs referenced by managed agent definitions
+	// so that CreateAgentSession and agent validation can resolve them.
+	if err := s.upsertProjectWorkspaceConfigs(ctx, project, normalized.spec); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("apply project %s: %w", normalized.spec.Name, err))
+	}
 	changes := projectApplyChanges(project, existingProject, projectFound, revision, revisionCreated)
 	agentsUnchanged := true
 	for _, agent := range agentRecords {
@@ -697,6 +702,76 @@ func projectManagedAgentDefinitionFromSpec(project ProjectRecord, revision int64
 		ManagedProjectRevision: revision,
 		ManagedAgentName:       agent.Name,
 	}, nil
+}
+
+// projectWorkspaceConfigFromSpec builds a WorkspaceConfig model from a compose
+// WorkspaceSpec using the deterministic stable workspace ID.  The caller is
+// expected to persist the result via UpsertWorkspaceConfig.
+func (s *Service) projectWorkspaceConfigFromSpec(project ProjectRecord, ws *compose.WorkspaceSpec) (WorkspaceConfig, error) {
+	id := compose.StableWorkspaceID(ws)
+	name := strings.TrimSpace(project.Name)
+	if name == "" {
+		name = project.ID
+	}
+	provider := strings.ToLower(strings.TrimSpace(ws.Provider))
+	switch provider {
+	case "git":
+		cfg := gitWorkspaceConfig{
+			URL:         strings.TrimSpace(ws.URL),
+			Branch:      strings.TrimSpace(ws.Branch),
+			CloneTarget: strings.TrimSpace(ws.Path),
+		}
+		data, err := json.Marshal(cfg)
+		if err != nil {
+			return WorkspaceConfig{}, fmt.Errorf("encode git workspace config: %w", err)
+		}
+		return WorkspaceConfig{
+			ID:         id,
+			Name:       name + "/workspace/" + id[:8],
+			Type:       "git",
+			ConfigJSON: string(data),
+		}, nil
+	case "local", "":
+		return WorkspaceConfig{
+			ID:         id,
+			Name:       name + "/workspace/" + id[:8],
+			Type:       "file",
+			ConfigJSON: defaultFileWorkspaceConfigJSON(s.config, id),
+		}, nil
+	default:
+		return WorkspaceConfig{}, fmt.Errorf("unsupported workspace provider %q", ws.Provider)
+	}
+}
+
+// upsertProjectWorkspaceConfigs ensures every workspace referenced by managed
+// agent definitions has a corresponding WorkspaceConfig row before the agent
+// definitions are reconciled.  Without this, CreateAgentSession fails because
+// agentWorkspace → GetWorkspaceConfig returns "not found" for the deterministic
+// IDs written by projectManagedAgentDefinitionFromSpec.
+func (s *Service) upsertProjectWorkspaceConfigs(ctx context.Context, project ProjectRecord, spec *compose.NormalizedProjectSpec) error {
+	seen := make(map[string]struct{})
+	for _, agent := range spec.Agents {
+		ws := agent.Workspace
+		if ws == nil {
+			ws = spec.Workspace
+		}
+		if ws == nil {
+			continue
+		}
+		id := compose.StableWorkspaceID(ws)
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		wc, err := s.projectWorkspaceConfigFromSpec(project, ws)
+		if err != nil {
+			return err
+		}
+		if _, err := s.configDB.UpsertWorkspaceConfig(ctx, wc); err != nil {
+			return fmt.Errorf("upsert workspace config %s: %w", id, err)
+		}
+	}
+	return nil
 }
 
 func sessionEnvItemsFromCompose(values map[string]compose.EnvVarSpec) []SessionEnvVar {

--- a/pkg/agentcompose/project_service.go
+++ b/pkg/agentcompose/project_service.go
@@ -656,7 +656,7 @@ func projectAgentRecordsFromSpec(projectID string, revision int64, spec *compose
 func projectManagedAgentDefinitionsFromSpec(project ProjectRecord, revision int64, spec *compose.NormalizedProjectSpec) ([]AgentDefinition, error) {
 	agents := make([]AgentDefinition, 0, len(spec.Agents))
 	for _, agent := range spec.Agents {
-		record, err := projectManagedAgentDefinitionFromSpec(project, revision, agent)
+		record, err := projectManagedAgentDefinitionFromSpec(project, revision, spec.Workspace, agent)
 		if err != nil {
 			return nil, err
 		}
@@ -665,7 +665,7 @@ func projectManagedAgentDefinitionsFromSpec(project ProjectRecord, revision int6
 	return agents, nil
 }
 
-func projectManagedAgentDefinitionFromSpec(project ProjectRecord, revision int64, agent compose.NormalizedAgentSpec) (AgentDefinition, error) {
+func projectManagedAgentDefinitionFromSpec(project ProjectRecord, revision int64, projectWorkspace *compose.WorkspaceSpec, agent compose.NormalizedAgentSpec) (AgentDefinition, error) {
 	managedAgentID, err := StableManagedAgentID(project.ID, agent.Name)
 	if err != nil {
 		return AgentDefinition{}, err
@@ -673,6 +673,13 @@ func projectManagedAgentDefinitionFromSpec(project ProjectRecord, revision int64
 	driver := ""
 	if agent.Driver != nil {
 		driver = agent.Driver.Name
+	}
+	// Resolve workspace: agent-level takes precedence, fall back to project-level.
+	workspaceID := ""
+	if agent.Workspace != nil {
+		workspaceID = compose.StableWorkspaceID(agent.Workspace)
+	} else if projectWorkspace != nil {
+		workspaceID = compose.StableWorkspaceID(projectWorkspace)
 	}
 	return AgentDefinition{
 		ID:                     managedAgentID,
@@ -685,6 +692,7 @@ func projectManagedAgentDefinitionFromSpec(project ProjectRecord, revision int64
 		GuestImage:             agent.Image,
 		EnvItems:               sessionEnvItemsFromCompose(agent.Env),
 		ConfigJSON:             "{}",
+		WorkspaceID:            workspaceID,
 		ManagedProjectID:       project.ID,
 		ManagedProjectRevision: revision,
 		ManagedAgentName:       agent.Name,

--- a/pkg/agentcompose/project_service.go
+++ b/pkg/agentcompose/project_service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -714,6 +715,9 @@ func (s *Service) projectWorkspaceConfigFromSpec(project ProjectRecord, ws *comp
 		name = project.ID
 	}
 	provider := strings.ToLower(strings.TrimSpace(ws.Provider))
+	if provider == "" && strings.TrimSpace(ws.URL) != "" {
+		provider = "git"
+	}
 	switch provider {
 	case "git":
 		cfg := gitWorkspaceConfig{
@@ -732,15 +736,58 @@ func (s *Service) projectWorkspaceConfigFromSpec(project ProjectRecord, ws *comp
 			ConfigJSON: string(data),
 		}, nil
 	case "local", "":
-		return WorkspaceConfig{
+		wc := WorkspaceConfig{
 			ID:         id,
 			Name:       name + "/workspace/" + id[:8],
 			Type:       "file",
 			ConfigJSON: defaultFileWorkspaceConfigJSON(s.config, id),
-		}, nil
+		}
+		// For local workspaces with an explicit path, snapshot the source
+		// directory into the workspace content root so that agent sessions
+		// start with the project files rather than an empty directory.
+		if strings.TrimSpace(ws.Path) != "" {
+			if err := s.materializeProjectApplyLocalWorkspace(project, wc, ws); err != nil {
+				return WorkspaceConfig{}, err
+			}
+		}
+		return wc, nil
 	default:
 		return WorkspaceConfig{}, fmt.Errorf("unsupported workspace provider %q", ws.Provider)
 	}
+}
+
+// materializeProjectApplyLocalWorkspace snapshots the local directory referenced
+// by a file-type workspace into the workspace content root.  This follows the
+// same pattern as materializeLocalProjectRunWorkspace but uses the stable
+// workspace ID so that re-imports are safe.
+func (s *Service) materializeProjectApplyLocalWorkspace(project ProjectRecord, wc WorkspaceConfig, ws *compose.WorkspaceSpec) error {
+	if s == nil || s.config == nil {
+		return fmt.Errorf("config is required")
+	}
+	sourceDir, err := resolveLocalProjectWorkspacePath(project, ws.Path)
+	if err != nil {
+		return err
+	}
+	if _, err := validateFileWorkspaceConfig(s.config, wc.ID, wc.ConfigJSON); err != nil {
+		return err
+	}
+	if err := resetFileWorkspaceSnapshotContent(s.config, wc.ID); err != nil {
+		return err
+	}
+	content, err := openFileWorkspaceContent(s.config, wc)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = content.Root.Close() }()
+	sourceRoot, err := os.OpenRoot(sourceDir)
+	if err != nil {
+		return fmt.Errorf("open local workspace source %s: %w", sourceDir, err)
+	}
+	defer func() { _ = sourceRoot.Close() }()
+	if err := copyRootDirectoryContents(sourceRoot, content.AbsRoot); err != nil {
+		return fmt.Errorf("materialize local workspace snapshot: %w", err)
+	}
+	return nil
 }
 
 // upsertProjectWorkspaceConfigs ensures every workspace referenced by managed

--- a/pkg/agentcompose/project_service_test.go
+++ b/pkg/agentcompose/project_service_test.go
@@ -2,6 +2,7 @@ package agentcompose
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1165,6 +1166,181 @@ func TestProjectServiceApplyProjectUpsertsWorkspaceConfigs(t *testing.T) {
 			t.Fatalf("project workspace config %s not found: %v", projectWSID, err)
 		}
 	})
+
+	t.Run("git auto-detection from URL", func(t *testing.T) {
+		store3 := newTestConfigStore(t)
+		service3 := newProjectServiceTestService(t, store3)
+		ctx3 := context.Background()
+
+		// Workspace with URL/branch/path but no explicit provider
+		// must auto-detect as git, not file.
+		autoSpec := &agentcomposev2.ProjectSpec{
+			Name: "auto-detect-test",
+			Workspace: &agentcomposev2.WorkspaceSpec{
+				Url:    "https://github.com/example/auto-repo.git",
+				Branch: "main",
+				Path:   "src",
+			},
+			Agents: []*agentcomposev2.AgentSpec{
+				{
+					Name:     "reviewer",
+					Provider: "codex",
+					Model:    "gpt-test",
+					Image:    "guest:v1",
+					Driver:   &agentcomposev2.DriverSpec{Name: "boxlite"},
+				},
+			},
+		}
+		resp, err := service3.ApplyProject(ctx3, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+			Spec:   autoSpec,
+			Source: &agentcomposev2.ProjectSource{ComposePath: filepath.Join(t.TempDir(), "agent-compose.yml")},
+		}))
+		if err != nil {
+			t.Fatalf("ApplyProject auto-detect returned error: %v", err)
+		}
+		if !resp.Msg.GetApplied() || len(resp.Msg.GetIssues()) != 0 {
+			t.Fatalf("ApplyProject auto-detect response = %#v", resp.Msg)
+		}
+
+		autoWSID := compose.StableWorkspaceID(&compose.WorkspaceSpec{
+			URL:    "https://github.com/example/auto-repo.git",
+			Branch: "main",
+			Path:   "src",
+		})
+		autoWc, err := store3.GetWorkspaceConfig(ctx3, autoWSID)
+		if err != nil {
+			t.Fatalf("GetWorkspaceConfig auto-detect(%s) returned error: %v", autoWSID, err)
+		}
+		if autoWc.Type != "git" {
+			t.Fatalf("auto-detected workspace config type = %q, want git", autoWc.Type)
+		}
+
+		// Explicit provider: git with the same URL/branch/path
+		// must also produce type "git" (different ID because
+		// provider is part of the stable hash).
+		explicitWSID := compose.StableWorkspaceID(&compose.WorkspaceSpec{
+			Provider: "git",
+			URL:      "https://github.com/example/auto-repo.git",
+			Branch:   "main",
+			Path:     "src",
+		})
+		if autoWSID == explicitWSID {
+			t.Fatalf("auto-detected (%s) and explicit git (%s) workspace IDs should differ", autoWSID, explicitWSID)
+		}
+
+		explicitSpec := &agentcomposev2.ProjectSpec{
+			Name: "explicit-git-test",
+			Workspace: &agentcomposev2.WorkspaceSpec{
+				Provider: "git",
+				Url:      "https://github.com/example/auto-repo.git",
+				Branch:   "main",
+				Path:     "src",
+			},
+			Agents: []*agentcomposev2.AgentSpec{
+				{
+					Name:     "reviewer",
+					Provider: "codex",
+					Model:    "gpt-test",
+					Image:    "guest:v1",
+					Driver:   &agentcomposev2.DriverSpec{Name: "boxlite"},
+				},
+			},
+		}
+		explicitResp, err := service3.ApplyProject(ctx3, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+			Spec:   explicitSpec,
+			Source: &agentcomposev2.ProjectSource{ComposePath: filepath.Join(t.TempDir(), "agent-compose.yml")},
+		}))
+		if err != nil {
+			t.Fatalf("ApplyProject explicit returned error: %v", err)
+		}
+		if !explicitResp.Msg.GetApplied() || len(explicitResp.Msg.GetIssues()) != 0 {
+			t.Fatalf("ApplyProject explicit response = %#v", explicitResp.Msg)
+		}
+		explicitWc, err := store3.GetWorkspaceConfig(ctx3, explicitWSID)
+		if err != nil {
+			t.Fatalf("GetWorkspaceConfig explicit(%s) returned error: %v", explicitWSID, err)
+		}
+		if explicitWc.Type != "git" {
+			t.Fatalf("explicit git workspace config type = %q, want git", explicitWc.Type)
+		}
+	})
+}
+
+func TestProjectServiceApplyProjectUpsertsLocalWorkspaceContent(t *testing.T) {
+	store := newTestConfigStore(t)
+	service := newProjectServiceTestService(t, store)
+	ctx := context.Background()
+	projectDir := t.TempDir()
+
+	// Create test files in the project directory.
+	if err := os.WriteFile(filepath.Join(projectDir, "README.md"), []byte("# Test Project\n"), 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "src"), 0755); err != nil {
+		t.Fatalf("create src dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "src", "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write test source file: %v", err)
+	}
+	source := &agentcomposev2.ProjectSource{ComposePath: filepath.Join(projectDir, "agent-compose.yml")}
+
+	spec := &agentcomposev2.ProjectSpec{
+		Name: "local-workspace-test",
+		Workspace: &agentcomposev2.WorkspaceSpec{
+			Provider: "local",
+			Path:     ".",
+		},
+		Agents: []*agentcomposev2.AgentSpec{
+			{
+				Name:     "reviewer",
+				Provider: "codex",
+				Model:    "gpt-test",
+				Image:    "guest:v1",
+				Driver:   &agentcomposev2.DriverSpec{Name: "boxlite"},
+			},
+		},
+	}
+
+	resp, err := service.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec:   spec,
+		Source: source,
+	}))
+	if err != nil {
+		t.Fatalf("ApplyProject returned error: %v", err)
+	}
+	if !resp.Msg.GetApplied() || len(resp.Msg.GetIssues()) != 0 {
+		t.Fatalf("ApplyProject response = %#v", resp.Msg)
+	}
+
+	// Verify the workspace config was created as a file type.
+	wsSpec := &compose.WorkspaceSpec{
+		Provider: "local",
+		Path:     ".",
+	}
+	wantID := compose.StableWorkspaceID(wsSpec)
+	wc, err := store.GetWorkspaceConfig(ctx, wantID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceConfig(%s) after ApplyProject returned error: %v", wantID, err)
+	}
+	if wc.Type != "file" {
+		t.Fatalf("workspace config type = %q, want file", wc.Type)
+	}
+
+	// Verify the content root contains the test files.
+	content, err := openFileWorkspaceContent(service.config, wc)
+	if err != nil {
+		t.Fatalf("openFileWorkspaceContent returned error: %v", err)
+	}
+	defer func() { _ = content.Root.Close() }()
+
+	// README.md should exist in the content root.
+	if _, err := content.Root.Lstat("README.md"); err != nil {
+		t.Fatalf("content root missing README.md: %v", err)
+	}
+	// src/main.go should exist in the content root.
+	if _, err := content.Root.Lstat("src/main.go"); err != nil {
+		t.Fatalf("content root missing src/main.go: %v", err)
+	}
 }
 
 func managedAgentIDByName(t *testing.T, agents []*agentcomposev2.ProjectAgent, name string) string {

--- a/pkg/agentcompose/project_service_test.go
+++ b/pkg/agentcompose/project_service_test.go
@@ -1027,6 +1027,146 @@ func assertProjectServiceAgent(t *testing.T, agents []*agentcomposev2.ProjectAge
 	t.Fatalf("agent %s not found in %#v", name, agents)
 }
 
+func TestProjectServiceApplyProjectUpsertsWorkspaceConfigs(t *testing.T) {
+	store := newTestConfigStore(t)
+	service := newProjectServiceTestService(t, store)
+	ctx := context.Background()
+	source := &agentcomposev2.ProjectSource{ComposePath: filepath.Join(t.TempDir(), "agent-compose.yml")}
+
+	// Spec with a project-level git workspace and one agent.
+	spec := &agentcomposev2.ProjectSpec{
+		Name: "workspace-test",
+		Workspace: &agentcomposev2.WorkspaceSpec{
+			Url:    "https://github.com/example/repo.git",
+			Branch: "main",
+			Path:   "subdir",
+		},
+		Agents: []*agentcomposev2.AgentSpec{
+			{
+				Name:     "reviewer",
+				Provider: "codex",
+				Model:    "gpt-test",
+				Image:    "guest:v1",
+				Driver:   &agentcomposev2.DriverSpec{Name: "boxlite"},
+			},
+		},
+	}
+
+	resp, err := service.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec:   spec,
+		Source: source,
+	}))
+	if err != nil {
+		t.Fatalf("ApplyProject returned error: %v", err)
+	}
+	if !resp.Msg.GetApplied() || len(resp.Msg.GetIssues()) != 0 {
+		t.Fatalf("ApplyProject response = %#v", resp.Msg)
+	}
+
+	// Verify the workspace config was created with the deterministic stable ID.
+	wsSpec := &compose.WorkspaceSpec{
+		URL:    "https://github.com/example/repo.git",
+		Branch: "main",
+		Path:   "subdir",
+	}
+	wantID := compose.StableWorkspaceID(wsSpec)
+	wc, err := store.GetWorkspaceConfig(ctx, wantID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceConfig(%s) after ApplyProject returned error: %v", wantID, err)
+	}
+	if wc.Type != "git" {
+		t.Fatalf("workspace config type = %q, want git", wc.Type)
+	}
+	if !strings.Contains(wc.ConfigJSON, "https://github.com/example/repo.git") {
+		t.Fatalf("workspace config JSON = %q, want git url", wc.ConfigJSON)
+	}
+
+	// Re-apply with same spec — must be idempotent, workspace config should still exist.
+	repeated, err := service.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec:   spec,
+		Source: source,
+	}))
+	if err != nil {
+		t.Fatalf("ApplyProject repeated returned error: %v", err)
+	}
+	if !repeated.Msg.GetApplied() {
+		t.Fatalf("ApplyProject repeated response = %#v", repeated.Msg)
+	}
+	wc2, err := store.GetWorkspaceConfig(ctx, wantID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceConfig(%s) after repeated ApplyProject returned error: %v", wantID, err)
+	}
+	if wc2.Type != "git" {
+		t.Fatalf("workspace config type after re-apply = %q, want git", wc2.Type)
+	}
+
+	t.Run("agent level workspace override", func(t *testing.T) {
+		store2 := newTestConfigStore(t)
+		service2 := newProjectServiceTestService(t, store2)
+		ctx2 := context.Background()
+		source2 := &agentcomposev2.ProjectSource{ComposePath: filepath.Join(t.TempDir(), "agent-compose.yml")}
+
+		agentGitSpec := &agentcomposev2.WorkspaceSpec{
+			Url:    "https://github.com/agent/agent-repo.git",
+			Branch: "dev",
+		}
+		projectGitSpec := &agentcomposev2.WorkspaceSpec{
+			Url:    "https://github.com/project/project-repo.git",
+			Branch: "main",
+		}
+
+		spec2 := &agentcomposev2.ProjectSpec{
+			Name:      "override-test",
+			Workspace: projectGitSpec,
+			Agents: []*agentcomposev2.AgentSpec{
+				{
+					Name:      "reviewer",
+					Provider:  "codex",
+					Model:     "gpt-test",
+					Image:     "guest:v1",
+					Driver:    &agentcomposev2.DriverSpec{Name: "boxlite"},
+					Workspace: agentGitSpec,
+				},
+				{
+					Name:     "worker",
+					Provider: "claude",
+					Driver:   &agentcomposev2.DriverSpec{Name: "docker"},
+					// No agent workspace — falls back to project-level.
+				},
+			},
+		}
+
+		resp, err := service2.ApplyProject(ctx2, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+			Spec:   spec2,
+			Source: source2,
+		}))
+		if err != nil {
+			t.Fatalf("ApplyProject returned error: %v", err)
+		}
+		if !resp.Msg.GetApplied() || len(resp.Msg.GetIssues()) != 0 {
+			t.Fatalf("ApplyProject response = %#v", resp.Msg)
+		}
+
+		// Agent-level workspace should exist.
+		agentWSID := compose.StableWorkspaceID(&compose.WorkspaceSpec{
+			URL:    "https://github.com/agent/agent-repo.git",
+			Branch: "dev",
+		})
+		if _, err := store2.GetWorkspaceConfig(ctx2, agentWSID); err != nil {
+			t.Fatalf("agent workspace config %s not found: %v", agentWSID, err)
+		}
+
+		// Project-level workspace should exist (referenced by "worker" agent).
+		projectWSID := compose.StableWorkspaceID(&compose.WorkspaceSpec{
+			URL:    "https://github.com/project/project-repo.git",
+			Branch: "main",
+		})
+		if _, err := store2.GetWorkspaceConfig(ctx2, projectWSID); err != nil {
+			t.Fatalf("project workspace config %s not found: %v", projectWSID, err)
+		}
+	})
+}
+
 func managedAgentIDByName(t *testing.T, agents []*agentcomposev2.ProjectAgent, name string) string {
 	t.Helper()
 	for _, agent := range agents {

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -1,6 +1,8 @@
 package compose
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -410,6 +412,23 @@ func cloneWorkspaceSpec(value *WorkspaceSpec) *WorkspaceSpec {
 	cloned.Branch = strings.TrimSpace(cloned.Branch)
 	cloned.Path = strings.TrimSpace(cloned.Path)
 	return &cloned
+}
+
+// StableWorkspaceID returns a deterministic ID derived from the workspace spec
+// fields.  Two specs with the same provider + URL + branch + path produce the
+// same ID, so repeated YAML imports don't create duplicate workspace configs.
+func StableWorkspaceID(ws *WorkspaceSpec) string {
+	if ws == nil {
+		return ""
+	}
+	parts := []string{
+		strings.TrimSpace(ws.Provider),
+		strings.TrimSpace(ws.URL),
+		strings.TrimSpace(ws.Branch),
+		strings.TrimSpace(ws.Path),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return "ws-" + hex.EncodeToString(sum[:])[:12]
 }
 
 func cloneBoxliteDriverSpec(value *BoxliteDriverSpec) *BoxliteDriverSpec {


### PR DESCRIPTION
## Summary

When importing a project via YAML, the workspace was parsed and stored in the normalized spec but never bound to the agent. `AgentDefinition.WorkspaceID` was always empty, so agents started in an empty directory.

Agent-level workspace takes precedence; project-level workspace is used as fallback.

## Testing

`go build ./pkg/compose/` and `go build ./pkg/agentcompose/` pass.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

Fixes #33