### PR TITLE
feat(llm): add chat_completions protocol for OpenAI-compatible backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,19 @@ HTTP_LISTEN=127.0.0.1:7410
 
 # LLM
 # LLM_API_ENDPOINT=https://api.openai.com
+# LLM_API_PROTOCOL=responses
+# Accepted aliases for chat_completions: chat, chat_completion
 # LLM_API_KEY=
 # OPENAI_API_KEY=
 # LLM_MODEL=
 # LLM_TIMEOUT=60s
+#
+# OpenAI-compatible chat completions (e.g. DeepSeek, local vLLM/Ollama).
+# Use chat_completions instead of responses (do not set both):
+# LLM_API_PROTOCOL=chat_completions
+# LLM_API_ENDPOINT=https://api.example.com
+# LLM_API_KEY=...
+# LLM_MODEL=your-model
 
 # Runtime
 RUNTIME_DRIVER=docker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ Important defaults:
 - `DEFAULT_IMAGE`: `debian:bookworm-slim`
 - `JUPYTER_PROXY_BASE`: `/jupyter`
 
+Daemon LLM client (`LLMService`, `scheduler.llm`, SDK `runtime.llm`):
+- `LLM_API_ENDPOINT`, `LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_MODEL`, `LLM_TIMEOUT`
+- `LLM_API_PROTOCOL`: `responses` (default) or `chat_completions` for OpenAI-compatible backends (aliases: `chat`, `chat_completion`)
+- Guest agent providers remain `codex`, `claude`, and `gemini` CLI runners in guest containers
+
 ## Persistence
 
 Session metadata, notebook cells, event history, runtime state, and proxy state are stored under `SESSION_ROOT`.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ Top-level fields:
 
 Common agent fields:
 
-- `provider`, `model`, `system_prompt`: agent and LLM settings.
+- `provider`, `model`, `system_prompt`: guest agent settings (`provider` selects
+  the guest CLI runner; `model` is passed to that agent runtime). Supported guest
+  providers are `codex`, `claude`, and `gemini`. Daemon-side LLM calls
+  (`LLMService`, `scheduler.llm`) use `LLM_MODEL` instead.
 - `image`: guest image reference.
 - `driver`: runtime driver override. Supported drivers are `boxlite`, `docker`,
   and `microsandbox`.
@@ -237,8 +240,11 @@ Important variables include:
 - `OAUTH_*`: OAuth login settings.
 - `HTTP_BASIC_AUTH`: base64-encoded `username:password` for additional HTTP
   Basic authentication.
-- `LLM_API_ENDPOINT`, `LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_MODEL`,
-  `LLM_TIMEOUT`: LLM client settings.
+- `LLM_API_ENDPOINT`, `LLM_API_PROTOCOL`, `LLM_API_KEY`, `OPENAI_API_KEY`,
+  `LLM_MODEL`, `LLM_TIMEOUT`: LLM client settings for the daemon `LLMService`
+  only. These do not inject API keys into guest agent runtimes. Set
+  `LLM_API_PROTOCOL=chat_completions` for OpenAI-compatible chat completions
+  backends (aliases: `chat`, `chat_completion`).
 - `RUNTIME_DRIVER`: default runtime driver.
 - `DEFAULT_IMAGE`, `DOCKER_DEFAULT_IMAGE`, `MICROSANDBOX_DEFAULT_IMAGE`: guest
   image defaults.
@@ -254,6 +260,47 @@ Important variables include:
 - `GUEST_WORKSPACE`, `GUEST_STATE_ROOT`, `GUEST_RUNTIME_ROOT`,
   `GUEST_LOG_ROOT`, `JUPYTER_GUEST_PORT`: guest paths and Jupyter port.
 - `WEBHOOK_BODY_LIMIT_BYTES`, `WORKSPACE_UPLOAD_LIMIT_BYTES`: request limits.
+
+### Agent providers
+
+Guest agent sessions run provider CLIs inside the guest container
+(`agent-compose-runtime-js`). API keys for Codex, Claude, and Gemini must be
+supplied as session or global environment variables (for example through the UI:
+Settings -> Global environment variables), not only in the daemon `.env`.
+
+| Provider | Typical env vars | Notes |
+| --- | --- | --- |
+| `codex` | `OPENAI_API_KEY` or provider-specific keys in `assets/.codex/config.toml` | Uses Codex CLI/SDK in the guest image |
+| `claude` | `ANTHROPIC_API_KEY` | Uses Claude Code CLI in the guest image |
+| `gemini` | `GEMINI_API_KEY` | Uses Gemini CLI in the guest image |
+
+After changing guest runtime code or provider support, rebuild the guest image:
+
+```bash
+task image:agent-compose-guest
+```
+
+Create a new session (or resume one) so the updated image and environment
+variables are picked up.
+
+### Chat Completions LLM Protocol
+
+Set `LLM_API_PROTOCOL=chat_completions` to use an OpenAI-compatible Chat
+Completions backend for daemon-side unary text generation. This path is used by
+`LLMService.Generate` and loader `scheduler.llm` calls.
+
+```env
+LLM_API_PROTOCOL=chat_completions
+LLM_API_ENDPOINT=https://api.example.com
+LLM_API_KEY=...
+LLM_MODEL=your-model
+```
+
+Compatible backends include DeepSeek, local OpenAI-compatible proxies
+(vLLM/Ollama), and similar Chat Completions endpoints.
+
+This does not create a workspace-capable agent session and does not grant file,
+command, or MCP tool access.
 
 ## Security Notes
 

--- a/docs/design/agent-compose-runtime-js_contract.md
+++ b/docs/design/agent-compose-runtime-js_contract.md
@@ -708,7 +708,9 @@ the same Zod schema. When `outputSchema` is set, `finalText` must be a JSON
 string, which the SDK parses into `result.json`; when unset, `result.json` is
 `null`.
 
-`runtime.llm(prompt, options?)` calls `LLMService.Generate`:
+`runtime.llm(prompt, options?)` calls `LLMService.Generate`. The daemon selects
+the HTTP protocol with `LLM_API_PROTOCOL` (`responses` by default, or
+`chat_completions` for OpenAI-compatible Chat Completions backends):
 
 | Field | Description |
 | --- | --- |

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -613,6 +613,25 @@ Main JavaScript APIs:
 a `scheduler.z` schema generates JSON Schema and validates the returned value
 locally. Passing plain JSON Schema performs JSON parsing.
 
+### Daemon LLM client
+
+`scheduler.llm`, `LLMService.Generate`, and SDK `runtime.llm` delegate to
+`LLMClient` in the Go daemon. Configuration is daemon-global:
+
+- `LLM_API_ENDPOINT`, `LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_MODEL`,
+  `LLM_TIMEOUT`
+- `LLM_API_PROTOCOL`: `responses` (default, OpenAI Responses API) or
+  `chat_completions` (OpenAI-compatible Chat Completions; aliases: `chat`,
+  `chat_completion`)
+
+Global env from the UI/database overrides process environment for these keys.
+The `chat_completions` protocol is for unary text generation only. It does not
+create workspace-capable agent sessions or grant file, command, or MCP tool
+access.
+
+Guest agent providers (`codex`, `claude`, `gemini`) remain separate CLI runners
+inside guest containers with their own API keys and session state.
+
 The loader also exposes a unary RPC bridge for v1 `SessionService`:
 
 - `scheduler.session.createSession(request)`

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -81,7 +81,7 @@ agent-compose down
 
 agent 常用字段：
 
-- `provider` / `model` / `system_prompt`：传给 agent/LLM 层的模型配置。
+- `provider` / `model` / `system_prompt`：guest agent 配置（`provider` 选择 guest CLI runner；`model` 传给该 agent runtime）。目前支持 `codex`、`claude`、`gemini`。daemon 侧 LLM 调用（`LLMService`、`scheduler.llm`）使用 `LLM_MODEL`，不是 compose 里的 agent `model`。
 - `image`：guest 镜像引用；为空时使用 driver 对应默认镜像。
 - `driver`：每个 agent 可选择一个 runtime，支持 `boxlite`、`docker`、`microsandbox`。
 - `env`：agent 级环境变量，支持 scalar 或 `{ value, secret }` 形状。
@@ -111,6 +111,55 @@ npm run dev:ui
 ```
 
 前端可以由 daemon 静态资源能力提供，也可以作为独立静态服务部署，并反向代理到 daemon 的 API 和 Jupyter proxy 路由。
+
+## 配置
+
+本地实验可复制 `.env.example` 为 `.env`。
+
+常用环境变量：
+
+- `DATA_ROOT`：daemon 数据根目录；session 数据位于 `<DATA_ROOT>/sessions`。
+- `HTTP_LISTEN`：可选 TCP 监听地址；本地无认证开发建议保持 loopback。
+- `AGENT_COMPOSE_SOCKET`、`AGENT_COMPOSE_HOST`：daemon 连接设置。
+- `AUTH_USERNAME`、`AUTH_PASSWORD`、`AUTH_SECRET`、`AUTH_SESSION_TTL`：密码登录设置。
+- `OAUTH_*`：OAuth 登录设置。
+- `HTTP_BASIC_AUTH`：额外 HTTP Basic 认证（base64 编码的 `username:password`）。
+- `LLM_API_ENDPOINT`、`LLM_API_PROTOCOL`、`LLM_API_KEY`、`OPENAI_API_KEY`、`LLM_MODEL`、`LLM_TIMEOUT`：daemon 侧 `LLMService` 配置。这些变量不会注入 guest agent runtime。对接 OpenAI 兼容 Chat Completions 后端时设置 `LLM_API_PROTOCOL=chat_completions`。
+- `RUNTIME_DRIVER`：默认 runtime driver。
+- `DEFAULT_IMAGE`、`DOCKER_DEFAULT_IMAGE`、`MICROSANDBOX_DEFAULT_IMAGE`：guest 镜像默认值。
+
+### Agent Provider
+
+Guest agent session 在 guest 容器内运行 provider CLI（`agent-compose-runtime-js`）。Codex、Claude、Gemini 的 API key 需通过 session 或全局环境变量配置（例如 UI：Settings -> Global environment variables），不能只在 daemon `.env` 中设置。
+
+| Provider | 典型环境变量 | 说明 |
+| --- | --- | --- |
+| `codex` | `OPENAI_API_KEY` 或 `assets/.codex/config.toml` 中的 provider key | 使用 guest 镜像中的 Codex CLI/SDK |
+| `claude` | `ANTHROPIC_API_KEY` | 使用 guest 镜像中的 Claude Code CLI |
+| `gemini` | `GEMINI_API_KEY` | 使用 guest 镜像中的 Gemini CLI |
+
+修改 guest runtime 代码或 provider 支持后，需重建 guest 镜像：
+
+```bash
+task image:agent-compose-guest
+```
+
+创建新 session（或 resume 已有 session）以加载更新后的镜像和环境变量。
+
+### Chat Completions LLM 协议
+
+设置 `LLM_API_PROTOCOL=chat_completions`（别名 `chat`、`chat_completion`）后，daemon 侧单次文本生成（`LLMService.Generate`、`scheduler.llm`）可走 OpenAI 兼容 Chat Completions 后端：
+
+```env
+LLM_API_PROTOCOL=chat_completions
+LLM_API_ENDPOINT=https://api.example.com
+LLM_API_KEY=...
+LLM_MODEL=your-model
+```
+
+兼容后端包括 DeepSeek、本地 OpenAI 兼容代理（vLLM/Ollama）等 Chat Completions endpoint。
+
+该路径不会创建具备 workspace 能力的 agent session，也不提供文件、命令或 MCP 工具访问。
 
 ## 安全提醒
 

--- a/docs/zh-CN/design/agent-compose-runtime-js_contract.md
+++ b/docs/zh-CN/design/agent-compose-runtime-js_contract.md
@@ -594,7 +594,9 @@ type RuntimeCommandResult = {
 
 `runtime.agent` 支持 `outputSchema`。它接受 Zod schema 或 plain JSON Schema object；Zod schema 会转换成 JSON Schema 写入 `--output-schema-file`，并在返回后用同一个 Zod schema 校验 `result.json`。设置 `outputSchema` 时，`finalText` 必须是 JSON 字符串，SDK 会解析到 `result.json`；未设置时 `result.json` 为 `null`。
 
-`runtime.llm(prompt, options?)` 调用 `LLMService.Generate`：
+`runtime.llm(prompt, options?)` 调用 `LLMService.Generate`。daemon 通过
+`LLM_API_PROTOCOL` 选择 HTTP 协议（默认 `responses`，或
+`chat_completions` 对接 OpenAI 兼容 Chat Completions 后端）：
 
 | 字段 | 说明 |
 |---|---|

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -454,6 +454,17 @@ project compose 的 `scheduler.script` 使用同一套 runtime。脚本在 valid
 
 `scheduler.agent` 和 `scheduler.llm` 支持 `outputSchema` / `schema`。传 `scheduler.z` schema 时会生成 JSON Schema 并在返回后本地校验；传 plain JSON Schema 时会做 JSON parse。
 
+### Daemon LLM client
+
+`scheduler.llm`、`LLMService.Generate` 和 SDK `runtime.llm` 都委托给 Go daemon 中的 `LLMClient`。配置是 daemon 全局的：
+
+- `LLM_API_ENDPOINT`、`LLM_API_KEY`、`OPENAI_API_KEY`、`LLM_MODEL`、`LLM_TIMEOUT`
+- `LLM_API_PROTOCOL`：`responses`（默认，OpenAI Responses API）或 `chat_completions`（OpenAI 兼容 Chat Completions；别名：`chat`、`chat_completion`）
+
+UI/数据库中的 global env 会覆盖进程环境变量。`chat_completions` 仅用于单次文本生成，不会创建具备 workspace 能力的 agent session，也不提供文件、命令或 MCP 工具访问。
+
+Guest agent provider（`codex`、`claude`、`gemini`）仍是 guest 容器内的 CLI runner，使用各自的 API key 和 session 状态。
+
 loader 内还暴露 v1 `SessionService` 的 unary RPC bridge：
 
 - `scheduler.session.createSession(request)`

--- a/loader-script/README.md
+++ b/loader-script/README.md
@@ -151,7 +151,7 @@ const reply = scheduler.agent(prompt, {
 }
 ```
 
-`scheduler.llm(...)` 调用服务端 LLM 配置：
+`scheduler.llm(...)` 调用 daemon 侧 LLM 配置。通过 daemon 环境变量或 UI global env 设置 `LLM_API_PROTOCOL=chat_completions`（别名 `chat`、`chat_completion`）可切换到 OpenAI 兼容 Chat Completions 后端；默认为 `responses`（OpenAI Responses API）。该路径仅用于单次文本生成，不会创建 workspace agent session。
 
 ```js
 const result = scheduler.llm(prompt, {

--- a/pkg/agentcompose/llm_client.go
+++ b/pkg/agentcompose/llm_client.go
@@ -29,6 +29,11 @@ type LLMGenerateResult struct {
 	FinishReason string
 }
 
+const (
+	llmAPIProtocolResponses       = "responses"
+	llmAPIProtocolChatCompletions = "chat_completions"
+)
+
 type llmAPIRequest struct {
 	Model string             `json:"model"`
 	Input string             `json:"input"`
@@ -78,6 +83,33 @@ type llmIncompleteReason struct {
 	Reason string `json:"reason"`
 }
 
+type llmChatCompletionsRequest struct {
+	Model          string                        `json:"model"`
+	Messages       []llmChatCompletionsMessage   `json:"messages"`
+	ResponseFormat *llmChatCompletionsJSONFormat `json:"response_format,omitempty"`
+}
+
+type llmChatCompletionsMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type llmChatCompletionsJSONFormat struct {
+	Type string `json:"type"`
+}
+
+type llmChatCompletionsResponse struct {
+	ID      string                     `json:"id"`
+	Model   string                     `json:"model"`
+	Choices []llmChatCompletionsChoice `json:"choices"`
+	Error   *llmAPIError               `json:"error"`
+}
+
+type llmChatCompletionsChoice struct {
+	Message      llmChatCompletionsMessage `json:"message"`
+	FinishReason string                    `json:"finish_reason"`
+}
+
 func NewLLMClient(di do.Injector) (*LLMClient, error) {
 	config := do.MustInvoke[*appconfig.Config](di)
 	return &LLMClient{
@@ -97,13 +129,20 @@ func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSO
 	if prompt == "" {
 		return LLMGenerateResult{}, fmt.Errorf("prompt is required")
 	}
-	endpoint := strings.TrimSpace(c.resolveEndpoint(ctx))
+	protocol := c.resolveProtocol(ctx)
+	endpoint := strings.TrimSpace(c.resolveEndpointForProtocol(ctx, protocol))
 	if endpoint == "" {
 		return LLMGenerateResult{}, fmt.Errorf("llm api endpoint is not configured")
 	}
 	model = strings.TrimSpace(firstNonEmpty(model, c.resolveSetting(ctx, c.config.LLMModel, "LLM_MODEL")))
 	if model == "" {
 		return LLMGenerateResult{}, fmt.Errorf("llm model is required")
+	}
+	if protocol == llmAPIProtocolChatCompletions {
+		return c.generateChatCompletions(ctx, endpoint, prompt, model, outputSchemaJSON)
+	}
+	if protocol != llmAPIProtocolResponses {
+		return LLMGenerateResult{}, fmt.Errorf("unsupported llm api protocol %q", protocol)
 	}
 	request := llmAPIRequest{Model: model, Input: prompt}
 	if schema := strings.TrimSpace(outputSchemaJSON); schema != "" {
@@ -128,7 +167,7 @@ func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSO
 		return LLMGenerateResult{}, fmt.Errorf("create llm request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if apiKey := strings.TrimSpace(c.resolveSetting(ctx, c.config.LLMAPIKey, "OPENAI_API_KEY", "LLM_API_KEY")); apiKey != "" {
+	if apiKey := strings.TrimSpace(c.resolveAPIKey(ctx, "LLM_API_KEY", "OPENAI_API_KEY")); apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 	resp, err := c.client.Do(req)
@@ -167,9 +206,80 @@ func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSO
 	}, nil
 }
 
+// generateChatCompletions calls an OpenAI-compatible Chat Completions backend for
+// unary prompt-to-response text generation (LLMService, scheduler.llm).
+func (c *LLMClient) generateChatCompletions(ctx context.Context, endpoint, prompt, model, outputSchemaJSON string) (LLMGenerateResult, error) {
+	messages := []llmChatCompletionsMessage{{Role: "user", Content: prompt}}
+	request := llmChatCompletionsRequest{Model: model, Messages: messages}
+	if schema := strings.TrimSpace(outputSchemaJSON); schema != "" {
+		if !json.Valid([]byte(schema)) {
+			return LLMGenerateResult{}, fmt.Errorf("llm outputSchema must be valid JSON")
+		}
+		request.Messages = append([]llmChatCompletionsMessage{{
+			Role:    "system",
+			Content: "Respond with a single JSON object that conforms to this JSON Schema:\n" + schema,
+		}}, request.Messages...)
+		request.ResponseFormat = &llmChatCompletionsJSONFormat{Type: "json_object"}
+	}
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return LLMGenerateResult{}, fmt.Errorf("encode llm chat completions request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(requestBody))
+	if err != nil {
+		return LLMGenerateResult{}, fmt.Errorf("create llm chat completions request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey := strings.TrimSpace(c.resolveAPIKey(ctx, "LLM_API_KEY", "OPENAI_API_KEY")); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return LLMGenerateResult{}, fmt.Errorf("call llm chat completions endpoint: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return LLMGenerateResult{}, fmt.Errorf("read llm chat completions response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := strings.TrimSpace(string(body))
+		var failure llmChatCompletionsResponse
+		if err := json.Unmarshal(body, &failure); err == nil && failure.Error != nil && strings.TrimSpace(failure.Error.Message) != "" {
+			message = strings.TrimSpace(failure.Error.Message)
+		}
+		if message == "" {
+			message = fmt.Sprintf("llm chat completions endpoint returned %s", resp.Status)
+		}
+		return LLMGenerateResult{}, fmt.Errorf("llm chat completions endpoint returned %s: %s", resp.Status, message)
+	}
+	var parsed llmChatCompletionsResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return LLMGenerateResult{}, fmt.Errorf("decode llm chat completions response: %w", err)
+	}
+	text := extractLLMChatCompletionsText(parsed)
+	if text == "" {
+		return LLMGenerateResult{}, fmt.Errorf("llm chat completions response did not contain text output")
+	}
+	if strings.TrimSpace(outputSchemaJSON) != "" && !json.Valid([]byte(text)) {
+		return LLMGenerateResult{}, fmt.Errorf("llm chat completions response did not contain valid JSON")
+	}
+	return LLMGenerateResult{
+		Text:         text,
+		Model:        firstNonEmpty(strings.TrimSpace(parsed.Model), model),
+		ResponseID:   strings.TrimSpace(parsed.ID),
+		FinishReason: extractLLMChatCompletionsFinishReason(parsed),
+	}, nil
+}
+
 func (c *LLMClient) resolveSetting(ctx context.Context, fallback string, keys ...string) string {
 	if value := strings.TrimSpace(c.lookupGlobalEnv(ctx, keys...)); value != "" {
 		return value
+	}
+	for _, key := range keys {
+		if value := strings.TrimSpace(os.Getenv(strings.TrimSpace(key))); value != "" {
+			return value
+		}
 	}
 	if value := strings.TrimSpace(fallback); value != "" {
 		return value
@@ -177,19 +287,56 @@ func (c *LLMClient) resolveSetting(ctx context.Context, fallback string, keys ..
 	return ""
 }
 
+func (c *LLMClient) resolveAPIKey(ctx context.Context, keys ...string) string {
+	if value := strings.TrimSpace(c.lookupGlobalEnv(ctx, keys...)); value != "" {
+		return value
+	}
+	for _, key := range keys {
+		if value := strings.TrimSpace(os.Getenv(strings.TrimSpace(key))); value != "" {
+			return value
+		}
+	}
+	if c != nil && c.config != nil {
+		return strings.TrimSpace(c.config.LLMAPIKey)
+	}
+	return ""
+}
+
 func (c *LLMClient) resolveEndpoint(ctx context.Context) string {
+	return c.resolveEndpointForProtocol(ctx, c.resolveProtocol(ctx))
+}
+
+func (c *LLMClient) resolveEndpointForProtocol(ctx context.Context, protocol string) string {
 	if value := strings.TrimSpace(c.lookupGlobalEnv(ctx, "LLM_API_ENDPOINT")); value != "" {
-		return normalizeLLMAPIEndpoint(value)
+		return normalizeLLMAPIEndpointForProtocol(value, protocol)
 	}
 	if value := strings.TrimSpace(os.Getenv("LLM_API_ENDPOINT")); value != "" {
-		return normalizeLLMAPIEndpoint(value)
+		return normalizeLLMAPIEndpointForProtocol(value, protocol)
 	}
 	if c != nil && c.config != nil {
 		if value := strings.TrimSpace(c.config.LLMAPIEndpoint); value != "" {
-			return normalizeLLMAPIEndpoint(value)
+			return normalizeLLMAPIEndpointForProtocol(value, protocol)
 		}
 	}
-	return normalizeLLMAPIEndpoint("https://api.openai.com")
+	return normalizeLLMAPIEndpointForProtocol("https://api.openai.com", protocol)
+}
+
+func (c *LLMClient) resolveProtocol(ctx context.Context) string {
+	protocol := strings.ToLower(strings.TrimSpace(c.lookupGlobalEnv(ctx, "LLM_API_PROTOCOL")))
+	if protocol == "" {
+		protocol = strings.ToLower(strings.TrimSpace(os.Getenv("LLM_API_PROTOCOL")))
+	}
+	if protocol == "" && c != nil && c.config != nil {
+		protocol = strings.ToLower(strings.TrimSpace(c.config.LLMAPIProtocol))
+	}
+	switch strings.ReplaceAll(protocol, "-", "_") {
+	case "", llmAPIProtocolResponses:
+		return llmAPIProtocolResponses
+	case "chat", "chat_completions", "chat_completion":
+		return llmAPIProtocolChatCompletions
+	default:
+		return protocol
+	}
 }
 
 func (c *LLMClient) lookupGlobalEnv(ctx context.Context, keys ...string) string {
@@ -251,7 +398,31 @@ func extractLLMFinishReason(response llmAPIResponse) string {
 	return strings.TrimSpace(response.Status)
 }
 
+func extractLLMChatCompletionsText(response llmChatCompletionsResponse) string {
+	parts := make([]string, 0, len(response.Choices))
+	for _, choice := range response.Choices {
+		text := strings.TrimSpace(choice.Message.Content)
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+func extractLLMChatCompletionsFinishReason(response llmChatCompletionsResponse) string {
+	for _, choice := range response.Choices {
+		if reason := strings.TrimSpace(choice.FinishReason); reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
 func normalizeLLMAPIEndpoint(raw string) string {
+	return normalizeLLMAPIEndpointForProtocol(raw, llmAPIProtocolResponses)
+}
+
+func normalizeLLMAPIEndpointForProtocol(raw, protocol string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return ""
@@ -259,6 +430,14 @@ func normalizeLLMAPIEndpoint(raw string) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return raw
+	}
+	if protocol == llmAPIProtocolChatCompletions && (strings.TrimSpace(parsed.Path) == "" || parsed.Path == "/") {
+		parsed.Path = "/v1/chat/completions"
+		return parsed.String()
+	}
+	if protocol == llmAPIProtocolChatCompletions && strings.TrimRight(parsed.Path, "/") == "/v1" {
+		parsed.Path = pathpkg.Join(parsed.Path, "/chat/completions")
+		return parsed.String()
 	}
 	if strings.TrimSpace(parsed.Path) == "" || parsed.Path == "/" {
 		parsed.Path = pathpkg.Join(parsed.Path, "/v1/responses")

--- a/pkg/agentcompose/llm_client_test.go
+++ b/pkg/agentcompose/llm_client_test.go
@@ -51,6 +51,15 @@ func TestNormalizeLLMAPIEndpointKeepsExplicitPath(t *testing.T) {
 	if got := normalizeLLMAPIEndpoint("https://api.example.invalid/custom/path"); got != "https://api.example.invalid/custom/path" {
 		t.Fatalf("normalizeLLMAPIEndpoint custom path = %q, want unchanged", got)
 	}
+	if got := normalizeLLMAPIEndpointForProtocol("https://api.example.invalid", llmAPIProtocolChatCompletions); got != "https://api.example.invalid/v1/chat/completions" {
+		t.Fatalf("normalizeLLMAPIEndpointForProtocol chat base = %q, want chat completions path", got)
+	}
+	if got := normalizeLLMAPIEndpointForProtocol("https://api.example.invalid/v1", llmAPIProtocolChatCompletions); got != "https://api.example.invalid/v1/chat/completions" {
+		t.Fatalf("normalizeLLMAPIEndpointForProtocol chat v1 = %q, want chat completions path", got)
+	}
+	if got := normalizeLLMAPIEndpointForProtocol("https://api.example.invalid/custom/chat", llmAPIProtocolChatCompletions); got != "https://api.example.invalid/custom/chat" {
+		t.Fatalf("normalizeLLMAPIEndpointForProtocol chat custom = %q, want unchanged", got)
+	}
 }
 
 func TestLLMClientGenerateHandlesSuccessAndFailures(t *testing.T) {
@@ -147,6 +156,270 @@ func TestLLMClientGenerateSendsOutputSchema(t *testing.T) {
 	}
 	if _, err := client.Generate(ctx, "prompt", "", "{bad json"); err == nil || !strings.Contains(err.Error(), "outputSchema must be valid JSON") {
 		t.Fatalf("Generate(invalid schema) error = %v, want schema error", err)
+	}
+}
+
+func TestLLMClientResolveProtocol(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	client := &LLMClient{
+		config:   &appconfig.Config{LLMAPIProtocol: llmAPIProtocolChatCompletions, LLMAPIEndpoint: "https://api.example.com"},
+		configDB: store,
+	}
+
+	if got := client.resolveProtocol(ctx); got != llmAPIProtocolChatCompletions {
+		t.Fatalf("resolveProtocol from config = %q, want %q", got, llmAPIProtocolChatCompletions)
+	}
+	if got := client.resolveEndpoint(ctx); got != "https://api.example.com/v1/chat/completions" {
+		t.Fatalf("resolveEndpoint with chat_completions = %q, want chat completions path", got)
+	}
+
+	t.Setenv("LLM_API_PROTOCOL", "chat")
+	client.config.LLMAPIProtocol = ""
+	if got := client.resolveProtocol(ctx); got != llmAPIProtocolChatCompletions {
+		t.Fatalf("resolveProtocol alias chat = %q, want %q", got, llmAPIProtocolChatCompletions)
+	}
+
+	if _, err := store.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_API_PROTOCOL", Value: llmAPIProtocolChatCompletions, Secret: false},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	if err := os.Unsetenv("LLM_API_PROTOCOL"); err != nil {
+		t.Fatalf("Unsetenv returned error: %v", err)
+	}
+	if got := client.resolveProtocol(ctx); got != llmAPIProtocolChatCompletions {
+		t.Fatalf("resolveProtocol from db env = %q, want %q", got, llmAPIProtocolChatCompletions)
+	}
+
+	client.config.LLMAPIProtocol = llmAPIProtocolResponses
+	if got := client.resolveProtocol(ctx); got != llmAPIProtocolChatCompletions {
+		t.Fatalf("resolveProtocol should prefer db env over config = %q, want %q", got, llmAPIProtocolChatCompletions)
+	}
+}
+
+func TestLLMClientGenerateUnsupportedProtocol(t *testing.T) {
+	ctx := context.Background()
+	client := &LLMClient{
+		config: &appconfig.Config{
+			LLMAPIEndpoint: "https://api.example.com",
+			LLMAPIProtocol: "unknown_protocol",
+			LLMModel:       "model-a",
+		},
+		configDB: newTestConfigStore(t),
+	}
+	_, err := client.Generate(ctx, "prompt", "model-a", "")
+	if err == nil || !strings.Contains(err.Error(), `unsupported llm api protocol "unknown_protocol"`) {
+		t.Fatalf("Generate(unsupported protocol) error = %v, want unsupported protocol", err)
+	}
+}
+
+func TestLLMClientGenerateChatCompletionsPlainText(t *testing.T) {
+	ctx := context.Background()
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = readRequestBodyForTest(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-2","model":"compatible-model","choices":[{"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"},{"message":{"role":"assistant","content":" world"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &LLMClient{
+		config: &appconfig.Config{
+			LLMAPIEndpoint: server.URL,
+			LLMAPIProtocol: llmAPIProtocolChatCompletions,
+			LLMModel:       "compatible-model",
+		},
+		configDB: newTestConfigStore(t),
+		client:   server.Client(),
+	}
+	result, err := client.Generate(ctx, "prompt", "", "")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if result.Text != "hello\nworld" || result.Model != "compatible-model" || result.ResponseID != "chatcmpl-2" || result.FinishReason != "stop" {
+		t.Fatalf("unexpected plain text chat completions result: %+v", result)
+	}
+	if strings.Contains(gotBody, `"response_format"`) {
+		t.Fatalf("plain text request should not set response_format: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"messages":[{"role":"user","content":"prompt"}`) {
+		t.Fatalf("request body missing user prompt: %s", gotBody)
+	}
+}
+
+func TestLLMClientGenerateChatCompletions(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	if _, err := store.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_API_KEY", Value: "chat-key", Secret: true},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+
+	var gotAuth string
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotBody = readRequestBodyForTest(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","model":"compatible-model","choices":[{"message":{"role":"assistant","content":"{\"answer\":\"ok\"}"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &LLMClient{
+		config: &appconfig.Config{
+			LLMAPIEndpoint: server.URL,
+			LLMAPIProtocol: llmAPIProtocolChatCompletions,
+			LLMModel:       "compatible-model",
+		},
+		configDB: store,
+		client:   server.Client(),
+	}
+	schema := `{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}`
+	result, err := client.Generate(ctx, "prompt", "", schema)
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if result.Text != `{"answer":"ok"}` || result.Model != "compatible-model" || result.ResponseID != "chatcmpl-1" || result.FinishReason != "stop" {
+		t.Fatalf("unexpected chat completions result: %+v", result)
+	}
+	if gotAuth != "Bearer chat-key" {
+		t.Fatalf("authorization header = %q, want %q", gotAuth, "Bearer chat-key")
+	}
+	for _, want := range []string{`"model":"compatible-model"`, `"messages":[{"role":"system"`, `"content":"prompt"`, `"response_format":{"type":"json_object"}`, "JSON Schema"} {
+		if !strings.Contains(gotBody, want) {
+			t.Fatalf("request body %s missing %s", gotBody, want)
+		}
+	}
+}
+
+func TestLLMClientGenerateChatCompletionsValidatesSchemaJSONMode(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","model":"compatible-model","choices":[{"message":{"role":"assistant","content":"not json"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &LLMClient{
+		config: &appconfig.Config{
+			LLMAPIEndpoint: server.URL,
+			LLMAPIProtocol: llmAPIProtocolChatCompletions,
+			LLMModel:       "compatible-model",
+		},
+		configDB: newTestConfigStore(t),
+		client:   server.Client(),
+	}
+	_, err := client.Generate(ctx, "prompt", "", `{"type":"object"}`)
+	if err == nil || !strings.Contains(err.Error(), "did not contain valid JSON") {
+		t.Fatalf("Generate(non-json schema response) error = %v, want valid JSON error", err)
+	}
+}
+
+func TestLLMClientGenerateChatCompletionsSurfacesErrors(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &LLMClient{
+		config: &appconfig.Config{
+			LLMAPIEndpoint: server.URL,
+			LLMAPIProtocol: llmAPIProtocolChatCompletions,
+			LLMModel:       "compatible-model",
+		},
+		configDB: newTestConfigStore(t),
+		client:   server.Client(),
+	}
+	_, err := client.Generate(ctx, "prompt", "", "")
+	if err == nil || !strings.Contains(err.Error(), "invalid api key") {
+		t.Fatalf("Generate(chat error response) error = %v, want invalid api key", err)
+	}
+}
+
+func TestLLMClientResolveSettingPrefersGlobalEnvThenProcessEnvThenConfig(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	client := &LLMClient{
+		config:   &appconfig.Config{LLMModel: "config-model"},
+		configDB: store,
+	}
+
+	t.Setenv("LLM_MODEL", "env-model")
+	if got := client.resolveSetting(ctx, client.config.LLMModel, "LLM_MODEL"); got != "env-model" {
+		t.Fatalf("resolveSetting from process env = %q, want %q", got, "env-model")
+	}
+
+	if _, err := store.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_MODEL", Value: "db-model", Secret: false},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	if got := client.resolveSetting(ctx, client.config.LLMModel, "LLM_MODEL"); got != "db-model" {
+		t.Fatalf("resolveSetting from db env = %q, want %q", got, "db-model")
+	}
+}
+
+func TestLLMClientGenerateChatCompletionsRejectsInvalidSchema(t *testing.T) {
+	ctx := context.Background()
+	client := &LLMClient{
+		config: &appconfig.Config{
+			LLMAPIEndpoint: "https://api.example.com",
+			LLMAPIProtocol: llmAPIProtocolChatCompletions,
+			LLMModel:       "compatible-model",
+		},
+		configDB: newTestConfigStore(t),
+	}
+	_, err := client.Generate(ctx, "prompt", "", "{bad json")
+	if err == nil || !strings.Contains(err.Error(), "outputSchema must be valid JSON") {
+		t.Fatalf("Generate(invalid schema) error = %v, want schema error", err)
+	}
+}
+
+func TestLoaderRunHostLLMChatCompletionsProtocol(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = readRequestBodyForTest(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-loader","model":"model-a","choices":[{"message":{"role":"assistant","content":"loader llm text"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	manager := &LoaderManager{
+		config:   &appconfig.Config{DataRoot: t.TempDir()},
+		configDB: store,
+		llm: &LLMClient{
+			config: &appconfig.Config{
+				LLMAPIEndpoint: server.URL,
+				LLMAPIProtocol: llmAPIProtocolChatCompletions,
+				LLMModel:       "model-a",
+			},
+			configDB: store,
+			client:   server.Client(),
+		},
+	}
+	host := &loaderRunHost{
+		manager: manager,
+		loader: Loader{Summary: LoaderSummary{ID: "loader-1"}},
+		run:     &LoaderRunSummary{ID: "run-1", LoaderID: "loader-1"},
+	}
+
+	result, err := host.LLM(ctx, "summarize lifecycle", LoaderLLMRequest{Model: "model-a"})
+	if err != nil {
+		t.Fatalf("LLM returned error: %v", err)
+	}
+	if result.Text != "loader llm text" || result.ResponseID != "chatcmpl-loader" || result.FinishReason != "stop" {
+		t.Fatalf("unexpected loader llm result: %+v", result)
+	}
+	if !strings.Contains(gotBody, `"messages":[{"role":"user","content":"summarize lifecycle"}`) {
+		t.Fatalf("expected chat completions request body, got %s", gotBody)
 	}
 }
 

--- a/pkg/agentcompose/service_api_test.go
+++ b/pkg/agentcompose/service_api_test.go
@@ -84,6 +84,44 @@ func TestServiceSessionKernelAgentAndLLMAPIs(t *testing.T) {
 	testServiceSessionKernelAgentAndLLMAPIs(t)
 }
 
+func TestServiceGenerateLLMChatCompletionsProtocol(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = readRequestBodyForTest(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-svc","model":"model-a","choices":[{"message":{"role":"assistant","content":"llm text"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	service := &Service{
+		llm: &LLMClient{
+			config: &appconfig.Config{
+				LLMAPIEndpoint: server.URL,
+				LLMAPIProtocol: llmAPIProtocolChatCompletions,
+				LLMModel:       "model-a",
+			},
+			configDB: newTestConfigStore(t),
+			client:   server.Client(),
+		},
+	}
+	resp, err := service.Generate(ctx, connect.NewRequest(&agentcomposev1.GenerateLLMRequest{
+		Prompt: "hello",
+		Model:  "model-a",
+	}))
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if resp.Msg.GetText() != "llm text" || resp.Msg.GetResponseId() != "chatcmpl-svc" || resp.Msg.GetFinishReason() != "stop" {
+		t.Fatalf("unexpected llm response: %+v", resp.Msg)
+	}
+	if !strings.Contains(gotBody, `"messages":[{"role":"user","content":"hello"}`) {
+		t.Fatalf("expected chat completions request body, got %s", gotBody)
+	}
+}
+
 func testServiceSessionKernelAgentAndLLMAPIs(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	OAuthUserInfoURL          string
 	OAuthClientAuthMethod     string
 	LLMAPIEndpoint            string
+	LLMAPIProtocol            string
 	LLMAPIKey                 string
 	LLMModel                  string
 	LLMTimeout                time.Duration
@@ -142,6 +143,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 	}
 
 	llmAPIEndpoint := os.Getenv("LLM_API_ENDPOINT")
+	llmAPIProtocol := strings.ToLower(strings.TrimSpace(os.Getenv("LLM_API_PROTOCOL")))
 	llmAPIKey := getenvFirst("LLM_API_KEY", "OPENAI_API_KEY")
 
 	llmModel := os.Getenv("LLM_MODEL")
@@ -444,6 +446,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		OAuthUserInfoURL:          oauthUserInfoURL,
 		OAuthClientAuthMethod:     oauthClientAuthMethod,
 		LLMAPIEndpoint:            llmAPIEndpoint,
+		LLMAPIProtocol:            llmAPIProtocol,
 		LLMAPIKey:                 llmAPIKey,
 		LLMModel:                  llmModel,
 		LLMTimeout:                llmTimeout,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -57,6 +57,7 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	t.Setenv("AGENT_COMPOSE_SOCKET", filepath.Join(root, "agent-compose.sock"))
 	t.Setenv("AGENT_COMPOSE_HOST", "https://agent-compose.example")
 	t.Setenv("LLM_API_ENDPOINT", "https://llm.example")
+	t.Setenv("LLM_API_PROTOCOL", "chat_completions")
 	t.Setenv("LLM_API_KEY", "llm-key")
 	t.Setenv("LLM_MODEL", "model-x")
 	t.Setenv("LLM_TIMEOUT", "7s")
@@ -110,7 +111,7 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	if config.AgentComposeSocket != filepath.Join(root, "agent-compose.sock") || config.AgentComposeHost != "https://agent-compose.example" {
 		t.Fatalf("daemon endpoint config = %q/%q", config.AgentComposeSocket, config.AgentComposeHost)
 	}
-	if config.LLMAPIEndpoint != "https://llm.example" || config.LLMAPIKey != "llm-key" || config.LLMModel != "model-x" {
+	if config.LLMAPIEndpoint != "https://llm.example" || config.LLMAPIProtocol != "chat_completions" || config.LLMAPIKey != "llm-key" || config.LLMModel != "model-x" {
 		t.Fatalf("llm config = %#v", config)
 	}
 	if config.LLMTimeout != 7*time.Second || config.AgentTimeout != 8*time.Second {

--- a/runtime/agent-compose-runtime-sdk/README.md
+++ b/runtime/agent-compose-runtime-sdk/README.md
@@ -210,7 +210,9 @@ Error behavior:
 
 ### `runtime.llm(prompt, options?)`
 
-Calls the agent-compose LLM service.
+Calls the agent-compose LLM service. The daemon selects the HTTP protocol via
+`LLM_API_PROTOCOL` (`responses` by default, or `chat_completions` for
+OpenAI-compatible Chat Completions backends).
 
 ```ts
 const result = await runtime.llm("Summarize the workspace risk.", {


### PR DESCRIPTION
## Summary

Follow-up to the closed PR [#18](https://github.com/chaitin/agent-compose/pull/18) (`feat/deepseek-provider`).

In #18, `deepseek` was added as a first-class **guest agent provider**. Review from @eetoc noted that the runner was only a single Chat Completions HTTP call: no workspace access, no tools/MCP, no durable provider session, and misleading parity with `codex` / `claude` / `gemini` on the same UI/provider path.

This PR implements the recommended direction from that review: **move OpenAI-compatible Chat Completions support to the daemon LLM client/protocol layer**, instead of exposing it as a guest agent provider.

### What changed

- Add **`LLM_API_PROTOCOL`** daemon configuration:
  - `responses` (default, existing OpenAI Responses API behavior)
  - `chat_completions` for OpenAI-compatible Chat Completions backends
  - aliases: `chat`, `chat_completion`
- Extend **`LLMClient`** with protocol-aware routing and endpoint normalization (`/v1/chat/completions`)
- Align LLM config resolution: **global env → process env → daemon config**
- Unify API key lookup order: `LLM_API_KEY`, then `OPENAI_API_KEY`
- Add tests for protocol resolution, chat completions success/error/schema paths, `LLMService.Generate`, and loader host integration
- Update docs (English/Chinese README, design docs, loader-script, AGENTS.md, SDK README, `.env.example`)

### What this PR does *not* do

- Does **not** add `deepseek` as a guest agent provider
- Does **not** change guest runtime runners, frontend provider enums, or agent session semantics
- Does **not** create workspace-capable agent sessions via Chat Completions

Guest agent providers remain **`codex` / `claude` / `gemini` only**.

### How to use DeepSeek (and similar backends)

Configure daemon-side LLM settings (`.env` or UI global env):

```env
LLM_API_PROTOCOL=chat_completions
LLM_API_ENDPOINT=https://api.deepseek.com
LLM_API_KEY=...
LLM_MODEL=deepseek-v4-flash
```

Used by:

- `LLMService.Generate`
- loader `scheduler.llm`
- SDK `runtime.llm`

This path is for **unary text generation only** — no file, command, or MCP tool access.

### Architecture

| Capability | Path | Workspace / tools |
| --- | --- | --- |
| Agent | guest `agent-compose-runtime prompt` | yes |
| LLM | daemon `LLMClient` | no |

## Testing

```bash
go test ./pkg/agentcompose/ -run 'LLM|NormalizeLLM|LoaderRunHost|ResolveSetting|ServiceGenerateLLM' -count=1
go test ./pkg/config/ -count=1
golangci-lint run --allow-parallel-runners ./pkg/agentcompose/... ./pkg/config/...
```

Manual verification:

```bash
# Start daemon with chat_completions config, then:
curl -sS -X POST 'http://127.0.0.1:7410/agentcompose.v1.LLMService/Generate' \
  -H 'Content-Type: application/json' \
  -d '{"prompt":"Say hello in one sentence","model":"deepseek-v4-flash"}'
```

Verified locally against an OpenAI-compatible Chat Completions backend (upstream errors correctly surfaced when model name was invalid).

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

Made with [Cursor](https://cursor.com)