### PR TITLE
docs(llm): clarify chat_completions outputSchema semantics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ HTTP_LISTEN=127.0.0.1:7410
 # LLM_API_ENDPOINT=https://api.example.com
 # LLM_API_KEY=...
 # LLM_MODEL=your-model
+# chat_completions outputSchema: prompt + json_object (not Responses strict schema)
 
 # Runtime
 RUNTIME_DRIVER=docker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Important defaults:
 Daemon LLM client (`LLMService`, `scheduler.llm`, SDK `runtime.llm`):
 - `LLM_API_ENDPOINT`, `LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_MODEL`, `LLM_TIMEOUT`
 - `LLM_API_PROTOCOL`: `responses` (default) or `chat_completions` for OpenAI-compatible backends (aliases: `chat`, `chat_completion`)
+- `chat_completions` structured output uses prompt guidance + `json_object`; use `responses` for strict JSON Schema enforcement
 - Guest agent providers remain `codex`, `claude`, and `gemini` CLI runners in guest containers
 
 ## Persistence

--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ Compatible backends include DeepSeek, local OpenAI-compatible proxies
 This does not create a workspace-capable agent session and does not grant file,
 command, or MCP tool access.
 
+With `outputSchema`, `chat_completions` uses prompt guidance and
+`response_format: json_object` (not Responses API strict JSON Schema).
+
 ## Security Notes
 
 The default configuration is designed for local development. Review and harden

--- a/docs/design/agent-compose-runtime-js_contract.md
+++ b/docs/design/agent-compose-runtime-js_contract.md
@@ -731,10 +731,12 @@ type RuntimeLLMResult<T = unknown> = {
 };
 ```
 
-`runtime.llm` structured output semantics match `runtime.agent`: schema is sent
-to LLM service as `output_schema`; when schema is set, `text` must be a JSON
-string, which the SDK parses into `json`. Zod schemas are validated a second time
-inside the SDK.
+With `outputSchema`, the SDK sends JSON Schema to `LLMService.Generate` as
+`output_schema`. When schema is set, `text` must be a JSON string; the SDK
+parses it into `json` and validates Zod schemas again locally. With
+`LLM_API_PROTOCOL=responses`, the daemon enforces strict JSON Schema via the
+Responses API. With `chat_completions`, it uses prompt guidance and
+`response_format: json_object` instead.
 
 `runtime.env` provides:
 

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -627,7 +627,8 @@ locally. Passing plain JSON Schema performs JSON parsing.
 Global env from the UI/database overrides process environment for these keys.
 The `chat_completions` protocol is for unary text generation only. It does not
 create workspace-capable agent sessions or grant file, command, or MCP tool
-access.
+access. With `outputSchema`, it uses prompt guidance and `json_object` instead
+of Responses API strict JSON Schema.
 
 Guest agent providers (`codex`, `claude`, `gemini`) remain separate CLI runners
 inside guest containers with their own API keys and session state.

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -161,6 +161,8 @@ LLM_MODEL=your-model
 
 该路径不会创建具备 workspace 能力的 agent session，也不提供文件、命令或 MCP 工具访问。
 
+使用 `outputSchema` 时，`chat_completions` 通过 prompt 引导并设置 `response_format: json_object`，不等价于 Responses API 的 strict JSON Schema。
+
 ## 安全提醒
 
 默认配置面向本地开发。公开部署前需要审查并加固：

--- a/docs/zh-CN/design/agent-compose-runtime-js_contract.md
+++ b/docs/zh-CN/design/agent-compose-runtime-js_contract.md
@@ -617,7 +617,11 @@ type RuntimeLLMResult<T = unknown> = {
 };
 ```
 
-`runtime.llm` 的结构化输出语义与 `runtime.agent` 一致：schema 会作为 `output_schema` 字符串发给 LLM service；设置 schema 时，`text` 必须是 JSON 字符串，SDK 会解析并把对象放入 `json`。Zod schema 会在 SDK 侧二次校验。
+设置 `outputSchema` 时，SDK 会将 JSON Schema 作为 `output_schema` 发给
+`LLMService.Generate`；`text` 必须是 JSON 字符串，SDK 解析到 `json` 并对 Zod
+schema 二次校验。`LLM_API_PROTOCOL=responses` 时，daemon 通过 Responses API
+做 strict JSON Schema 约束；`chat_completions` 则改为 prompt 引导并设置
+`json_object`。
 
 `runtime.env` 提供：
 

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -461,7 +461,7 @@ project compose 的 `scheduler.script` 使用同一套 runtime。脚本在 valid
 - `LLM_API_ENDPOINT`、`LLM_API_KEY`、`OPENAI_API_KEY`、`LLM_MODEL`、`LLM_TIMEOUT`
 - `LLM_API_PROTOCOL`：`responses`（默认，OpenAI Responses API）或 `chat_completions`（OpenAI 兼容 Chat Completions；别名：`chat`、`chat_completion`）
 
-UI/数据库中的 global env 会覆盖进程环境变量。`chat_completions` 仅用于单次文本生成，不会创建具备 workspace 能力的 agent session，也不提供文件、命令或 MCP 工具访问。
+UI/数据库中的 global env 会覆盖进程环境变量。`chat_completions` 仅用于单次文本生成，不会创建具备 workspace 能力的 agent session，也不提供文件、命令或 MCP 工具访问。使用 `outputSchema` 时，`chat_completions` 通过 prompt 引导并设置 `json_object`，不等价于 Responses API strict JSON Schema。
 
 Guest agent provider（`codex`、`claude`、`gemini`）仍是 guest 容器内的 CLI runner，使用各自的 API key 和 session 状态。
 

--- a/loader-script/README.md
+++ b/loader-script/README.md
@@ -151,7 +151,7 @@ const reply = scheduler.agent(prompt, {
 }
 ```
 
-`scheduler.llm(...)` 调用 daemon 侧 LLM 配置。通过 daemon 环境变量或 UI global env 设置 `LLM_API_PROTOCOL=chat_completions`（别名 `chat`、`chat_completion`）可切换到 OpenAI 兼容 Chat Completions 后端；默认为 `responses`（OpenAI Responses API）。该路径仅用于单次文本生成，不会创建 workspace agent session。
+`scheduler.llm(...)` 调用 daemon 侧 LLM 配置。通过 daemon 环境变量或 UI global env 设置 `LLM_API_PROTOCOL=chat_completions`（别名 `chat`、`chat_completion`）可切换到 OpenAI 兼容 Chat Completions 后端；默认为 `responses`（OpenAI Responses API）。该路径仅用于单次文本生成，不会创建 workspace agent session。使用 `outputSchema` 时，`chat_completions` 通过 prompt 引导并设置 `json_object`，不等价于 Responses API strict JSON Schema。
 
 ```js
 const result = scheduler.llm(prompt, {

--- a/runtime/agent-compose-runtime-sdk/README.md
+++ b/runtime/agent-compose-runtime-sdk/README.md
@@ -212,7 +212,9 @@ Error behavior:
 
 Calls the agent-compose LLM service. The daemon selects the HTTP protocol via
 `LLM_API_PROTOCOL` (`responses` by default, or `chat_completions` for
-OpenAI-compatible Chat Completions backends).
+OpenAI-compatible Chat Completions backends). With `outputSchema`,
+`chat_completions` uses prompt guidance and `response_format: json_object`, not
+Responses API strict JSON Schema.
 
 ```ts
 const result = await runtime.llm("Summarize the workspace risk.", {


### PR DESCRIPTION
## Summary

Follow-up documentation for [PR #36](https://github.com/chaitin/agent-compose/pull/36) (`feat(llm): add chat_completions protocol for OpenAI-compatible backends`).

Addresses the non-blocking review note from @eetoc:

> For `chat_completions`, `outputSchema` uses prompt guidance + `response_format=json_object`, so it is not equivalent to Responses API strict schema enforcement. This can be documented separately.

Documents the protocol difference across README, design docs, runtime contract, SDK README, loader-script, AGENTS.md, and `.env.example`. Also corrects the runtime contract wording that previously implied `runtime.llm` structured output always matches `runtime.agent` semantics.

## Related

- Closes follow-up from: https://github.com/chaitin/agent-compose/pull/36#issuecomment (eetoc review)
- Builds on merged PR: https://github.com/chaitin/agent-compose/pull/36

## Test plan

- [x] Docs-only change; no code behavior change
- [x] Verify wording is consistent across EN/ZH docs