### PR TITLE
docs: fix docker-minimal driver default (docker, not boxlite)

### DIFF
--- a/examples/agent-compose/docker-minimal/README.md
+++ b/examples/agent-compose/docker-minimal/README.md
@@ -60,8 +60,8 @@ driver:
   docker: {}
 ```
 
-If the agent omits `driver`, the compose normalizer currently defaults to
-`boxlite`, not Docker.
+If the agent omits `driver`, the compose normalizer defaults to `docker`.
+This example sets `docker: {}` explicitly to document the intended runtime.
 
 ## Run the example
 

--- a/examples/agent-compose/docker-minimal/README.zh-CN.md
+++ b/examples/agent-compose/docker-minimal/README.zh-CN.md
@@ -60,8 +60,8 @@ driver:
   docker: {}
 ```
 
-如果 agent 省略 `driver`，当前 compose normalizer 会默认使用
-`boxlite`，不是 Docker。
+如果 agent 省略 `driver`，compose normalizer 会默认使用 `docker`。
+本示例显式设置 `docker: {}`，是为了明确说明预期的 runtime。
 
 ## 运行示例
 


### PR DESCRIPTION
## Summary

- Fix incorrect driver default documentation in `examples/agent-compose/docker-minimal/README.md` and `README.zh-CN.md`.
- The docs previously claimed that omitting `driver` defaults to `boxlite`; the compose normalizer actually defaults to `docker`.

**Source of truth (`pkg/compose/normalize.go`):**

When `driver` is omitted (`nil`), `normalizeDriverSpec` returns `DriverDocker`:

```go
func normalizeDriverSpec(path string, driver *DriverSpec) (*NormalizedDriverSpec, error) {
	if driver == nil {
		return &NormalizedDriverSpec{Name: DriverDocker, Docker: &DockerDriverSpec{}}, nil
	}
	// ...
}
```

This matches the global runtime default documented elsewhere (`RUNTIME_DRIVER` empty → `docker` in `pkg/driver/runtime_driver.go` and `deploy/.env.example`).

The example still sets `driver: { docker: {} }` explicitly; the README now explains that this documents the intended runtime rather than working around a boxlite default.

## Test plan

- [x] Verified only README text changed; no code changes.
- [ ] Reviewer confirms wording matches `normalizeDriverSpec` behavior.


Made with [Cursor](https://cursor.com)