### PR TITLE
feat: add runtime llm facade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,21 @@ HTTP_LISTEN=127.0.0.1:7410
 # LLM_MODEL=your-model
 # chat_completions outputSchema: prompt + json_object (not Responses strict schema)
 
+# Anthropic-family facade bootstrap (Claude-compatible clients).
+# ANTHROPIC_BASE_URL=https://api.anthropic.com
+# ANTHROPIC_API_ENDPOINT=
+# ANTHROPIC_API_KEY=
+# ANTHROPIC_AUTH_TOKEN=
+# ANTHROPIC_MODEL=
+# CLAUDE_MODEL=
+
 # Runtime
 RUNTIME_DRIVER=docker
 DEFAULT_IMAGE=debian:bookworm-slim
+# Guest-reachable daemon URL used by runtime LLM facade config.
+# Docker Compose defaults to http://agent-compose:7410; host-based Docker setups
+# should set a concrete host IP/name and port.
+# AGENT_COMPOSE_RUNTIME_BASE_URL=
 # DOCKER_DEFAULT_IMAGE=debian:bookworm-slim
 # MICROSANDBOX_DEFAULT_IMAGE=debian:bookworm-slim
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Daemon LLM client (`LLMService`, `scheduler.llm`, SDK `runtime.llm`):
 - `LLM_API_ENDPOINT`, `LLM_API_KEY`, `OPENAI_API_KEY`, `LLM_MODEL`, `LLM_TIMEOUT`
 - `LLM_API_PROTOCOL`: `responses` (default) or `chat_completions` for OpenAI-compatible backends (aliases: `chat`, `chat_completion`)
 - `chat_completions` structured output uses prompt guidance + `json_object`; use `responses` for strict JSON Schema enforcement
+- Runtime LLM Facade bootstrap also supports `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_ENDPOINT`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`, `CLAUDE_MODEL`, and optional guest-reachable `AGENT_COMPOSE_RUNTIME_BASE_URL`
 - Guest agent providers remain `codex`, `claude`, and `gemini` CLI runners in guest containers
 
 ## Persistence

--- a/README.md
+++ b/README.md
@@ -246,10 +246,18 @@ Important variables include:
 - `HTTP_BASIC_AUTH`: base64-encoded `username:password` for additional HTTP
   Basic authentication.
 - `LLM_API_ENDPOINT`, `LLM_API_PROTOCOL`, `LLM_API_KEY`, `OPENAI_API_KEY`,
-  `LLM_MODEL`, `LLM_TIMEOUT`: LLM client settings for the daemon `LLMService`
-  only. These do not inject API keys into guest agent runtimes. Set
+  `LLM_MODEL`, `LLM_TIMEOUT`: daemon-side OpenAI-family LLM settings for
+  `LLMService`, `scheduler.llm`, and runtime agent LLM facade bootstrap. These
+  values are not injected as provider keys into guest agent runtimes. Set
   `LLM_API_PROTOCOL=chat_completions` for OpenAI-compatible chat completions
   backends (aliases: `chat`, `chat_completion`).
+- `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_ENDPOINT`, `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`, `CLAUDE_MODEL`: daemon-side
+  Anthropic-family LLM facade bootstrap settings.
+- `AGENT_COMPOSE_RUNTIME_BASE_URL`: optional guest-reachable daemon base URL
+  used when generating runtime LLM facade configuration. Docker Compose
+  defaults this to `http://agent-compose:7410`; host-based Docker setups should
+  set it to a concrete host IP/name and port.
 - `CAP_GRPC_LISTEN`, `CAP_GRPC_TARGET`: required only when agents need to call
   OctoBus gRPC capabilities. `CAP_GRPC_LISTEN` starts the agent-compose
   capability proxy; `CAP_GRPC_TARGET` is the guest-reachable address injected
@@ -274,15 +282,20 @@ Important variables include:
 ### Agent providers
 
 Guest agent sessions run provider CLIs inside the guest container
-(`agent-compose-runtime-js`). API keys for Codex, Claude, and Gemini must be
-supplied as session or global environment variables (for example through the UI:
-Settings -> Global environment variables), not only in the daemon `.env`.
+(`agent-compose-runtime-js`). Codex and Claude calls use the Runtime LLM Facade:
+provider keys stay in the daemon-side LLM provider configuration, while guest
+runtimes receive session-scoped facade tokens and facade base URLs. LLM provider
+key names such as `LLM_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`ANTHROPIC_AUTH_TOKEN`, `GOOGLE_API_KEY`, and `GEMINI_API_KEY` are filtered from
+user-supplied runtime environment variables. Compatibility aliases such as
+`LLM_API_KEY` and `LLM_API_ENDPOINT` may still appear in the runtime, but they
+are daemon-managed facade values, not upstream provider credentials.
 
 | Provider | Typical env vars | Notes |
 | --- | --- | --- |
-| `codex` | `OPENAI_API_KEY` or provider-specific keys in `assets/.codex/config.toml` | Uses Codex CLI/SDK in the guest image |
-| `claude` | `ANTHROPIC_API_KEY` | Uses Claude Code CLI in the guest image |
-| `gemini` | `GEMINI_API_KEY` | Uses Gemini CLI in the guest image |
+| `codex` | daemon LLM provider config; runtime receives `AGENT_COMPOSE_SESSION_TOKEN`, `LLM_API_KEY`, `LLM_API_ENDPOINT`, `OPENAI_BASE_URL`, and facade-token API key aliases | Uses Codex CLI/SDK in the guest image |
+| `claude` | daemon Anthropic-family provider config; runtime receives `AGENT_COMPOSE_SESSION_TOKEN`, `LLM_API_KEY`, `LLM_API_ENDPOINT`, `ANTHROPIC_BASE_URL`, and facade-token API key aliases | Uses Claude Code CLI in the guest image |
+| `gemini` | not yet routed through the LLM facade | Uses Gemini CLI in the guest image |
 
 After changing guest runtime code or provider support, rebuild the guest image:
 
@@ -292,6 +305,20 @@ task image:agent-compose-guest
 
 Create a new session (or resume one) so the updated image and environment
 variables are picked up.
+
+> **Upgrade note (breaking for some Docker setups):** Because provider keys are
+> no longer passed through to guest runtimes, Codex/Claude now reach their LLM
+> upstream through the daemon facade and need a guest-reachable daemon URL. The
+> bundled `docker-compose.yml` / `docker-compose.deploy.yml` set
+> `AGENT_COMPOSE_RUNTIME_BASE_URL=http://agent-compose:7410` for you. If you run
+> the daemon directly on a host with the Docker driver and an
+> `HTTP_LISTEN=127.0.0.1:...` bind, the container cannot reach that loopback
+> address, so facade config is skipped and agent runs will have no working LLM
+> credentials. Set `AGENT_COMPOSE_RUNTIME_BASE_URL` to a concrete
+> host-reachable IP/name and port (for example `http://host.docker.internal:7410`).
+
+The Runtime LLM Facade design is documented in
+[`docs/zh-CN/design/agent-compose-runtime-llm-facade.md`](docs/zh-CN/design/agent-compose-runtime-llm-facade.md).
 
 ### Chat Completions LLM Protocol
 

--- a/assets/.codex/config.toml
+++ b/assets/.codex/config.toml
@@ -1,22 +1,3 @@
-model_provider = "baizhi_cloud"
-model = "svip/gpt-5.4"
-
-[model_providers.openrouter]
-name = "openrouter"
-base_url = "https://openrouter.ai/api/v1"
-env_key = "LLM_API_KEY"
-wire_api = "responses"
-query_params = {}
-
-[model_providers.baizhi_cloud]
-name = "Baizhi Cloud"
-base_url = "https://ai-api-gateway.app.baizhi.cloud/api/openai"
-env_key = "LLM_API_KEY"
-wire_api = "responses"
-request_max_retries = 30
-stream_max_retries = 50
-stream_idle_timeout_ms = 120000
-
 [sandbox_workspace_write]
 exclude_tmpdir_env_var = false
 exclude_slash_tmp = false

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -164,6 +164,7 @@ func installDaemonMiddleware(app *echo.Echo, conf *config.Config) {
 		OAuthUserInfoURL:      conf.OAuthUserInfoURL,
 		OAuthClientAuthMethod: conf.OAuthClientAuthMethod,
 		Bypass:                isLocalUnixSocketRequest,
+		Skipper:               agentcompose.IsRuntimeLLMFacadeRequest,
 	})
 	authManager.RegisterRoutes(app)
 	app.Use(authManager.Middleware)
@@ -179,7 +180,7 @@ func installDaemonMiddleware(app *echo.Echo, conf *config.Config) {
 			// Same local-trust rule as AuthManager: CLI requests over the Unix
 			// socket skip basic auth too.
 			Skipper: func(c echo.Context) bool {
-				return isLocalUnixSocketRequest(c.Request())
+				return isLocalUnixSocketRequest(c.Request()) || agentcompose.IsRuntimeLLMFacadeRequest(c.Request())
 			},
 			Realm: "Password Required",
 			Validator: func(u, p string, c echo.Context) (bool, error) {

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -13,6 +13,7 @@ services:
       SESSION_ROOT: /data/sessions
       DOCKER_HOST_SESSION_ROOT: ${DOCKER_HOST_SESSION_ROOT:-$PWD/data/agent-compose/sessions}
       HTTP_LISTEN: 0.0.0.0:7410
+      AGENT_COMPOSE_RUNTIME_BASE_URL: ${AGENT_COMPOSE_RUNTIME_BASE_URL:-http://agent-compose:7410}
       AUTH_USERNAME: ${AUTH_USERNAME:-}
       AUTH_PASSWORD: ${AUTH_PASSWORD:?AUTH_PASSWORD is required for deployment}
       AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required for deployment}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       SESSION_ROOT: /data/sessions
       DOCKER_HOST_SESSION_ROOT: ${DOCKER_HOST_SESSION_ROOT:-$PWD/data/agent-compose/sessions}
       HTTP_LISTEN: 0.0.0.0:7410
+      AGENT_COMPOSE_RUNTIME_BASE_URL: ${AGENT_COMPOSE_RUNTIME_BASE_URL:-http://agent-compose:7410}
       RUNTIME_DRIVER: docker
       DEFAULT_IMAGE: ${DEFAULT_IMAGE:-debian:bookworm-slim}
       GUEST_WORKSPACE: /workspace

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ are available under [zh-CN/design/](zh-CN/design/).
 
 - [Architecture notes](design/agent-compose_design.md)
 - [Agent system prompt (Phase 1)](design/agent_system_prompt_design.md)
+- [Runtime LLM Facade](zh-CN/design/agent-compose-runtime-llm-facade.md)
 - [Runtime JavaScript contract](design/agent-compose-runtime-js_contract.md)
 - [Runtime environment variables](design/runtime_environment_variables_design.md)
 - [Runtime mount manifest](design/runtime_mount_manifest_design.md)

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -124,20 +124,22 @@ npm run dev:ui
 - `AUTH_USERNAME`、`AUTH_PASSWORD`、`AUTH_SECRET`、`AUTH_SESSION_TTL`：密码登录设置。
 - `OAUTH_*`：OAuth 登录设置。
 - `HTTP_BASIC_AUTH`：额外 HTTP Basic 认证（base64 编码的 `username:password`）。
-- `LLM_API_ENDPOINT`、`LLM_API_PROTOCOL`、`LLM_API_KEY`、`OPENAI_API_KEY`、`LLM_MODEL`、`LLM_TIMEOUT`：daemon 侧 `LLMService` 配置。这些变量不会注入 guest agent runtime。对接 OpenAI 兼容 Chat Completions 后端时设置 `LLM_API_PROTOCOL=chat_completions`。
+- `LLM_API_ENDPOINT`、`LLM_API_PROTOCOL`、`LLM_API_KEY`、`OPENAI_API_KEY`、`LLM_MODEL`、`LLM_TIMEOUT`：daemon 侧 OpenAI family LLM 配置，供 `LLMService`、`scheduler.llm` 和 runtime agent LLM facade bootstrap 使用。这些值不会作为 provider key 注入 guest agent runtime。对接 OpenAI 兼容 Chat Completions 后端时设置 `LLM_API_PROTOCOL=chat_completions`。
+- `ANTHROPIC_BASE_URL`、`ANTHROPIC_API_ENDPOINT`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_MODEL`、`CLAUDE_MODEL`：daemon 侧 Anthropic family LLM facade bootstrap 配置。
+- `AGENT_COMPOSE_RUNTIME_BASE_URL`：可选的 runtime 内可访问 daemon base URL，用于生成 Runtime LLM Facade 配置。Docker Compose 默认使用 `http://agent-compose:7410`；宿主机 Docker 场景应配置具体的宿主机 IP/名称和端口。
 - `CAP_GRPC_LISTEN`、`CAP_GRPC_TARGET`：仅在 Agent 需要调用 OctoBus gRPC capability 时必须配置。`CAP_GRPC_LISTEN` 启动 agent-compose capability proxy；`CAP_GRPC_TARGET` 是注入新 session 的 guest 可达地址。修改后需要重启 daemon 并新建 session。
 - `RUNTIME_DRIVER`：默认 runtime driver。
 - `DEFAULT_IMAGE`、`DOCKER_DEFAULT_IMAGE`、`MICROSANDBOX_DEFAULT_IMAGE`：guest 镜像默认值。
 
 ### Agent Provider
 
-Guest agent session 在 guest 容器内运行 provider CLI（`agent-compose-runtime-js`）。Codex、Claude、Gemini 的 API key 需通过 session 或全局环境变量配置（例如 UI：Settings -> Global environment variables），不能只在 daemon `.env` 中设置。
+Guest agent session 在 guest 容器内运行 provider CLI（`agent-compose-runtime-js`）。Codex 和 Claude 通过 Runtime LLM Facade 调用：真实 provider key 保存在 daemon 侧 LLM provider 配置中，runtime 只拿 session-scoped facade token 和 facade base URL。`LLM_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`GOOGLE_API_KEY`、`GEMINI_API_KEY` 等 provider key 名称会从用户提供的 runtime env 中过滤。兼容别名 `LLM_API_KEY`、`LLM_API_ENDPOINT` 仍可能出现在 runtime 中，但它们是 daemon 写入的 facade 值，不是上游 provider 凭据。
 
 | Provider | 典型环境变量 | 说明 |
 | --- | --- | --- |
-| `codex` | `OPENAI_API_KEY` 或 `assets/.codex/config.toml` 中的 provider key | 使用 guest 镜像中的 Codex CLI/SDK |
-| `claude` | `ANTHROPIC_API_KEY` | 使用 guest 镜像中的 Claude Code CLI |
-| `gemini` | `GEMINI_API_KEY` | 使用 guest 镜像中的 Gemini CLI |
+| `codex` | daemon LLM provider 配置；runtime 获取 `AGENT_COMPOSE_SESSION_TOKEN`、`LLM_API_KEY`、`LLM_API_ENDPOINT`、`OPENAI_BASE_URL` 和 facade-token API key aliases | 使用 guest 镜像中的 Codex CLI/SDK |
+| `claude` | daemon Anthropic family provider 配置；runtime 获取 `AGENT_COMPOSE_SESSION_TOKEN`、`LLM_API_KEY`、`LLM_API_ENDPOINT`、`ANTHROPIC_BASE_URL` 和 facade-token API key aliases | 使用 guest 镜像中的 Claude Code CLI |
+| `gemini` | 暂未接入 LLM facade | 使用 guest 镜像中的 Gemini CLI |
 
 修改 guest runtime 代码或 provider 支持后，需重建 guest 镜像：
 
@@ -146,6 +148,10 @@ task image:agent-compose-guest
 ```
 
 创建新 session（或 resume 已有 session）以加载更新后的镜像和环境变量。
+
+> **升级注意（部分 Docker 部署存在破坏性变更）：** provider key 不再透传进 guest runtime，Codex/Claude 改为通过 daemon facade 访问上游 LLM，需要一个 runtime 内可达的 daemon URL。自带的 `docker-compose.yml` / `docker-compose.deploy.yml` 已默认设置 `AGENT_COMPOSE_RUNTIME_BASE_URL=http://agent-compose:7410`。如果你在宿主机上直接运行 daemon（Docker driver）且 `HTTP_LISTEN=127.0.0.1:...`，容器无法访问该 loopback 地址，facade 配置会被跳过，agent run 将没有可用的 LLM 凭据。此时需要把 `AGENT_COMPOSE_RUNTIME_BASE_URL` 设为宿主机可达的具体 IP/名称和端口（例如 `http://host.docker.internal:7410`）。
+
+Runtime LLM Facade 设计见 [design/agent-compose-runtime-llm-facade.md](design/agent-compose-runtime-llm-facade.md)。
 
 ### Chat Completions LLM 协议
 

--- a/docs/zh-CN/design/agent-compose-runtime-llm-facade.md
+++ b/docs/zh-CN/design/agent-compose-runtime-llm-facade.md
@@ -1,0 +1,379 @@
+# agent-compose Runtime LLM Facade 设计
+
+本文档描述 agent-compose 的 Runtime LLM Facade 设计：daemon 统一管理 LLM provider、provider key、session-scoped 调用 token、协议转换和 runtime env 注入，runtime 内的 agent 不再接触真实 provider key。
+
+Runtime LLM Facade 是 agent-compose 进程内能力，不是独立外部服务，也不要求依赖 OctoBus。它是一个受控 LLM 调用面：所有成功请求都会进入协议层 decode/encode 管线，协议兼容边界由 agent-compose 和 `github.com/chaitin/ai-api-protocol-bridge` 共同承担。
+
+## 相关代码
+
+- 配置加载：`pkg/config/config.go`
+- 全局 env 存储：`pkg/agentcompose/config_store.go`
+- session 创建和 env 合并：`pkg/agentcompose/session_rpc_bridge.go`、`pkg/agentcompose/loader_manager.go`、`pkg/agentcompose/run_preparation.go`
+- runtime env 注入：`pkg/driver/docker_runtime.go`、`pkg/driver/microsandbox_runtime.go`、`pkg/driver/boxlite_cgo.go`
+- 默认 guest home assets：`assets/`、`pkg/driver/runtime_mount_manifest.go`
+- LLM service：`pkg/agentcompose/llm_client.go`、`pkg/agentcompose/service.go`
+- Runtime LLM Facade：`pkg/agentcompose/llm_config.go`、`pkg/agentcompose/llm_runtime_config.go`、`pkg/agentcompose/llm_facade.go`
+- 协议转换：`github.com/chaitin/ai-api-protocol-bridge`
+
+## 架构目标
+
+```text
+Codex / Claude / runtime SDK / OpenAI or Anthropic compatible client
+  |
+  | session token + facade URL
+  v
+agent-compose daemon
+  |
+  | auth, provider resolve, protocol decode/encode, key injection
+  v
+configured upstream LLM provider
+```
+
+核心边界：
+
+- daemon 是 LLM provider、model、provider key 和 provider headers 的状态权威。
+- runtime 只拿 session-scoped facade token，不拿真实 `LLM_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`。
+- Runtime LLM Facade 对外提供 OpenAI Responses、OpenAI Chat Completions 和 Anthropic Messages 三类入口。
+- 所有成功请求都通过 `ai-api-protocol-bridge` 的 adapter 或 cross-family bridge 做协议 decode/encode。
+- agent-compose 负责 HTTP handler、session token 鉴权、provider 选择、真实 key 注入、header 过滤、SSE parser、SSE flush 和错误分类。
+- `.codex/config.toml` 不从静态 assets 写死 provider、model 和 upstream base URL，而是按 session 动态生成。
+
+## Provider And Model
+
+当前实现使用 daemon-side provider/model 配置，`system` scope 作为默认 scope。数据库字段 `provider_type` 保留不改名，语义上表示 API family。
+
+建议表结构：
+
+```sql
+llm_provider(
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  provider_type TEXT NOT NULL DEFAULT 'openai_compatible',
+  default_wire_api TEXT NOT NULL DEFAULT 'responses',
+  base_url TEXT NOT NULL,
+  api_key TEXT NOT NULL DEFAULT '',
+  auth_header TEXT NOT NULL DEFAULT 'Authorization',
+  auth_scheme TEXT NOT NULL DEFAULT 'Bearer',
+  headers_json TEXT NOT NULL DEFAULT '{}',
+  weight INTEGER NOT NULL DEFAULT 10,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  scope TEXT NOT NULL DEFAULT 'system',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+llm_model(
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  default_model INTEGER NOT NULL DEFAULT 0,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  scope TEXT NOT NULL DEFAULT 'system',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+llm_provider_model(
+  provider_id TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  wire_api TEXT NOT NULL DEFAULT '',
+  weight INTEGER NOT NULL DEFAULT 10,
+  PRIMARY KEY(provider_id, model_id)
+);
+```
+
+`provider_type` 归一化规则：
+
+- `openai_compatible`、`openai-compatible`、`openai` -> `openai`
+- `anthropic`、`claude`、`anthropic_messages` -> `anthropic`
+
+不使用 `anthropic_compatible` 这类非官方兼容性命名。已有数据库字段名保持不变，避免破坏现有 SQLite 配置。
+
+`default_wire_api` 表示 provider 的默认上游 API 形态。OpenAI family 支持：
+
+- `responses` -> `<base_url>/responses`
+- `chat_completions` -> `<base_url>/chat/completions`
+
+Anthropic family 使用 Messages API：
+
+- `messages` -> `<base_url>/messages`
+
+`base_url` 存 API root，不存单个 operation endpoint。bootstrap 旧配置时，如果 `LLM_API_ENDPOINT` 已经带 `/v1/responses`、`/v1/chat/completions` 或 `/v1/messages`，保存 provider 时剥离 operation suffix。
+
+`api_key` 和 `headers_json` 是 server-side sensitive config。它们可以来自 daemon 环境变量或 `global_env` bootstrap，但不能写入 session metadata、runtime env、guest home config 或 driver runtime 配置。HTTP API 返回 provider 时必须脱敏 key 和敏感 header。
+
+provider key 注入规则：
+
+- facade 先设置协议必需 header。
+- `headers_json` 只能补充 provider 自定义 header。
+- `headers_json` 不能覆盖 `auth_header`，也不能设置 `Authorization`、`Proxy-Authorization`、`Host`、`Content-Length`、`Cookie`、`Set-Cookie`。
+- facade 最后根据 `auth_header`、`auth_scheme`、`api_key` 注入真实 provider auth。
+
+bootstrap 输入：
+
+```text
+OpenAI family:
+LLM_API_ENDPOINT, LLM_API_KEY, OPENAI_API_KEY, LLM_MODEL, LLM_API_PROTOCOL
+
+Anthropic family:
+ANTHROPIC_BASE_URL, ANTHROPIC_API_ENDPOINT, ANTHROPIC_API_KEY,
+ANTHROPIC_AUTH_TOKEN, ANTHROPIC_MODEL, CLAUDE_MODEL, LLM_API_ENDPOINT, LLM_API_KEY
+```
+
+当数据库已有对应 family 的 enabled provider 时，不再用 bootstrap 覆盖数据库 provider。provider/model 表是运行时权威。
+
+## HTTP Facade
+
+daemon 暴露 session-scoped LLM facade：
+
+```text
+POST /api/runtime/sessions/:session_id/llm/openai/v1/responses
+POST /api/runtime/sessions/:session_id/llm/openai/v1/chat/completions
+POST /api/runtime/sessions/:session_id/llm/anthropic/v1/messages
+```
+
+facade path 决定入口协议：
+
+- `/llm/openai/v1/responses` -> `ProtocolOpenAIResponses`
+- `/llm/openai/v1/chat/completions` -> `ProtocolOpenAIChat`
+- `/llm/anthropic/v1/messages` -> `ProtocolAnthropicMessages`
+
+provider `provider_type` 和 `wire_api` 决定上游协议：
+
+- `openai` + `responses` -> `ProtocolOpenAIResponses`
+- `openai` + `chat_completions` -> `ProtocolOpenAIChat`
+- `anthropic` -> `ProtocolAnthropicMessages`
+
+处理流程：
+
+```text
+runtime request
+  -> validate session-scoped facade token
+  -> validate session is available
+  -> decode inbound request with inbound adapter
+  -> resolve model/provider from token scope and request model
+  -> encode upstream request with adapter or cross-family bridge
+  -> inject real provider auth and provider headers
+  -> call upstream
+  -> decode upstream response
+  -> encode response back to inbound protocol
+  -> return to runtime
+```
+
+SSE 流式处理：
+
+```text
+upstream HTTP body
+  -> agent-compose SSE parser
+  -> RawStreamEvent
+  -> bridge StreamDecoder
+  -> StreamPart
+  -> bridge StreamEncoder
+  -> RawStreamEvent
+  -> agent-compose SSE writer + Flush
+```
+
+`ai-api-protocol-bridge` 不提供 HTTP handler、auth、provider routing、SSE parser、network I/O、flush 或日志能力；这些由 agent-compose 负责。
+
+上游非 2xx 响应按上游状态和 body 返回，不按成功协议转换，避免把 provider 错误误编码成成功响应。
+
+## Token Scope
+
+LLM facade token 独立于 Jupyter `ProxyState.Token`，使用单独的 `LLMFacadeToken` 记录。原始 token 只进入 runtime env，不持久化明文；数据库只保存 hash 和 fingerprint。
+
+token scope：
+
+```text
+session_id
+model
+provider_id
+wire_api
+source
+run_id
+issued_at
+expires_at
+revoked_at
+```
+
+`expires_at` 为 0 表示 token 随 session 生命周期有效，不使用固定 24h 过期时间；session 停止或需要失效时通过 `revoked_at` 撤销。
+
+校验规则：
+
+- token 必须属于 path 中的 `session_id`。
+- token 未撤销且未过期。
+- session 存在且未停止。
+- 请求 body 中的 `model` 必须与 token scope model 一致。
+- token scope 中有 `provider_id` 时，只能使用该 provider。
+- token scope 中有 `wire_api` 时，请求路径必须与入口 wire API 一致。
+
+## Runtime Env
+
+使用 facade 后，runtime 侧环境变量收敛为 session token 和 facade URL。长期 provider key 只属于 daemon。
+
+通用 runtime SDK 需要：
+
+```bash
+AGENT_COMPOSE_SESSION_TOKEN=<llm_facade_token>
+LLM_API_KEY=<llm_facade_token>
+LLM_API_ENDPOINT=<guest-reachable-facade-family-base-url>
+LLM_API_PROTOCOL=<responses|chat_completions|messages>
+```
+
+Codex 兼容映射：
+
+```bash
+AGENT_COMPOSE_SESSION_TOKEN=<llm_facade_token>
+LLM_API_KEY=<llm_facade_token>
+LLM_API_ENDPOINT=<guest-reachable-agent-compose-url>/api/runtime/sessions/<session_id>/llm/openai/v1
+LLM_API_PROTOCOL=<responses|chat_completions>
+OPENAI_API_KEY=<llm_facade_token>
+OPENAI_BASE_URL=<guest-reachable-agent-compose-url>/api/runtime/sessions/<session_id>/llm/openai/v1
+```
+
+Claude 兼容映射：
+
+```bash
+AGENT_COMPOSE_SESSION_TOKEN=<llm_facade_token>
+LLM_API_KEY=<llm_facade_token>
+LLM_API_ENDPOINT=<guest-reachable-agent-compose-url>/api/runtime/sessions/<session_id>/llm/anthropic
+LLM_API_PROTOCOL=messages
+ANTHROPIC_API_KEY=<llm_facade_token>
+ANTHROPIC_BASE_URL=<guest-reachable-agent-compose-url>/api/runtime/sessions/<session_id>/llm/anthropic
+```
+
+`LLM_API_KEY`、`OPENAI_API_KEY` 和 `ANTHROPIC_API_KEY` 在 runtime 中是 daemon 写入的 facade token，不是 provider key。`LLM_API_ENDPOINT` 在 runtime 中也由 daemon 覆盖为 facade endpoint，避免旧代码把 facade token 发往真实 provider endpoint。daemon 在过滤用户 env 后写入这些受管变量，防止用户配置的长期 key 穿透到 runtime。
+
+禁止进入 runtime 的长期 key：
+
+```text
+LLM_API_KEY
+OPENAI_API_KEY
+ANTHROPIC_API_KEY
+ANTHROPIC_AUTH_TOKEN
+OPENROUTER_API_KEY
+AZURE_OPENAI_API_KEY
+GOOGLE_API_KEY
+GEMINI_API_KEY
+```
+
+过滤发生在两层：
+
+- session 准备层：合并 global/project/agent/request env 后，从 `Session.EnvItems` 移除 LLM provider key。
+- runtime env 组装层：Docker、Microsandbox、BoxLite 启动 env 和 `ExecSpec.Env` 再次过滤用户 env 中的 LLM key denylist，然后写入 daemon 生成的 facade token 和 base URL。非 LLM 的 `secret=true` env 保持原有行为，仍可进入 runtime。
+
+## Session Home Config
+
+`assets/.codex/config.toml` 不写死 upstream provider。daemon 按 session effective model 和 guest-reachable facade URL 动态生成：
+
+```toml
+model_provider = "agent_compose"
+model = "<selected-model>"
+
+[model_providers.agent_compose]
+name = "agent-compose"
+base_url = "<guest-reachable-agent-compose-url>/api/runtime/sessions/<session_id>/llm/openai/v1"
+env_key = "AGENT_COMPOSE_SESSION_TOKEN"
+wire_api = "responses"
+request_max_retries = 30
+stream_max_retries = 50
+stream_idle_timeout_ms = 120000
+```
+
+model 解析优先级：
+
+```text
+explicit request model
+> project run request model
+> compose agent model
+> agent definition model
+> loader / scheduler default model
+> llm_model default
+> LLM_MODEL env
+```
+
+provider 解析优先级：
+
+```text
+token scope provider_id
+> explicit request provider_id
+> model 绑定的 enabled provider 按 weight 选择
+> 默认 enabled provider 按 weight 选择
+```
+
+入口 wire API 和上游 wire API 分开处理：
+
+- token `wire_api` 约束 runtime 请求路径，也就是入口 facade wire API。
+- provider/model `wire_api` 决定上游 OpenAI family operation。
+- 当 Codex 入口使用 OpenAI facade 且上游 provider 是 Anthropic family 时，token `wire_api` 仍是 `responses`，上游协议由 provider family 解析为 Anthropic Messages。
+
+## Header And Log Rules
+
+runtime 请求中的敏感 header 一律丢弃：
+
+```text
+Authorization
+Proxy-Authorization
+Cookie
+Set-Cookie
+Host
+Content-Length
+任何包含 token、secret、api-key、apikey、auth 的 header
+```
+
+日志允许记录：
+
+```text
+session_id, agent_id, loader_id, run_id, request_id,
+model, provider_id, provider_scope, stream,
+upstream_status, upstream_request_id, token_fingerprint, failure_kind
+```
+
+日志不得记录：
+
+```text
+provider api key
+Authorization
+request body
+response body
+prompt 正文
+完整敏感错误正文
+```
+
+## Compatibility
+
+现有 daemon 部署变量继续支持：
+
+```bash
+LLM_API_ENDPOINT
+LLM_API_KEY
+OPENAI_API_KEY
+LLM_API_PROTOCOL
+LLM_MODEL
+ANTHROPIC_BASE_URL
+ANTHROPIC_API_ENDPOINT
+ANTHROPIC_API_KEY
+ANTHROPIC_AUTH_TOKEN
+ANTHROPIC_MODEL
+CLAUDE_MODEL
+```
+
+这些变量只作为 daemon bootstrap 或 server-side provider key 来源，不作为 runtime env 注入依据。
+
+`runtime.llm()` 保持现有 SDK API。它调用 Connect `LLMService/Generate` 时也复用 daemon-side provider/model 解析和 server-side key 注入逻辑，不能从 runtime env 读取 provider key。
+
+Gemini CLI 当前 runner 是直接 spawn `gemini`，本仓库代码里没有可验证的 base URL 注入点。当前实现先保证 `GOOGLE_API_KEY` / `GEMINI_API_KEY` 等长期 key 不进入 session metadata 或 runtime env；Gemini facade 入口需要在确认 CLI/SDK endpoint 机制后接入。
+
+## Implementation Scope
+
+- system scope provider/model 表。
+- 从 daemon env 和 `global_env` bootstrap OpenAI / Anthropic provider。
+- OpenAI Responses、OpenAI Chat Completions、Anthropic Messages facade route。
+- session-scoped LLM facade token，包含 AuthManager / BasicAuth skipper 和 fail-closed token auth。
+- 统一 SDK 协议管线：请求 decode/encode、响应 decode/encode、SSE event decode/encode。
+- OpenAI / Anthropic cross-family conversion。
+- guest-reachable agent-compose URL 的 driver 注入。
+- 动态生成 `.codex/config.toml`。
+- session 准备层过滤 LLM provider key，避免真实 key 进入新的 `Session.EnvItems`。
+- Docker、Microsandbox、BoxLite session 启动 env 和 `ExecSpec.Env` 过滤用户 env 中的 LLM key denylist。
+- agent/loader run 通过 per-run `ExecSpec.Env` 注入 facade token 和 facade URL。
+- 测试覆盖 key 不进入 runtime、config 不写死 upstream、OpenAI/Anthropic facade 鉴权、跨协议非流式转换、SSE 转换与 flush、401/403 分类和 key 脱敏返回。

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	connectrpc.com/connect v1.19.2
+	github.com/chaitin/ai-api-protocol-bridge v1.0.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v28.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chaitin/ai-api-protocol-bridge v1.0.0 h1:JKV+KRIzSe2ZlM0BxUdvPhVxroCc/cLQbILJR/iAvig=
+github.com/chaitin/ai-api-protocol-bridge v1.0.0/go.mod h1:hSbqFEyrkL/j6r4k9NooMaV3gkjXzMR96GddRH/AObA=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/pkg/agentcompose/agent_system_prompt_test.go
+++ b/pkg/agentcompose/agent_system_prompt_test.go
@@ -316,7 +316,7 @@ func TestExecuteAgentRunWritesConventionSystemPromptBeforeExec(t *testing.T) {
 		},
 	}
 
-	result, parsed, err := executor.executeAgentRun(ctx, session, "codex", agent.ID, "hello", "", nil)
+	result, parsed, err := executor.executeAgentRun(ctx, session, "codex", agent.ID, "", "", "hello", "", nil)
 	if err != nil {
 		t.Fatalf("executeAgentRun returned error: %v", err)
 	}

--- a/pkg/agentcompose/config_store.go
+++ b/pkg/agentcompose/config_store.go
@@ -58,6 +58,9 @@ func (s *ConfigStore) initSchema(ctx context.Context) error {
 	if err := s.ensureGlobalEnvSchema(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureLLMSchema(ctx); err != nil {
+		return err
+	}
 	if err := s.ensureCapabilityGatewaySchema(ctx); err != nil {
 		return err
 	}

--- a/pkg/agentcompose/exec.go
+++ b/pkg/agentcompose/exec.go
@@ -40,6 +40,8 @@ type AgentExecutionStream struct {
 type ExecuteAgentRequest struct {
 	Agent             string
 	AgentDefinitionID string
+	Model             string
+	RunID             string
 	Message           string
 	Timeout           time.Duration
 	OutputSchemaJSON  string
@@ -848,7 +850,7 @@ func (e *Executor) executeAgent(ctx context.Context, session *Session, request E
 		}
 	}
 
-	execResult, result, err := e.executeAgentRun(execCtx, session, agent, request.AgentDefinitionID, message, request.OutputSchemaJSON, streamWriter)
+	execResult, result, err := e.executeAgentRun(execCtx, session, agent, request.AgentDefinitionID, request.Model, request.RunID, message, request.OutputSchemaJSON, streamWriter)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()

--- a/pkg/agentcompose/llm_client.go
+++ b/pkg/agentcompose/llm_client.go
@@ -295,21 +295,6 @@ func (c *LLMClient) resolveSetting(ctx context.Context, fallback string, keys ..
 	return ""
 }
 
-func (c *LLMClient) resolveAPIKey(ctx context.Context, keys ...string) string {
-	if value := strings.TrimSpace(c.lookupGlobalEnv(ctx, keys...)); value != "" {
-		return value
-	}
-	for _, key := range keys {
-		if value := strings.TrimSpace(os.Getenv(strings.TrimSpace(key))); value != "" {
-			return value
-		}
-	}
-	if c != nil && c.config != nil {
-		return strings.TrimSpace(c.config.LLMAPIKey)
-	}
-	return ""
-}
-
 func (c *LLMClient) resolveEndpoint(ctx context.Context) string {
 	return c.resolveEndpointForProtocol(ctx, c.resolveProtocol(ctx))
 }

--- a/pkg/agentcompose/llm_client.go
+++ b/pkg/agentcompose/llm_client.go
@@ -32,6 +32,7 @@ type LLMGenerateResult struct {
 const (
 	llmAPIProtocolResponses       = "responses"
 	llmAPIProtocolChatCompletions = "chat_completions"
+	llmAPIProtocolMessages        = "messages"
 )
 
 type llmAPIRequest struct {
@@ -129,17 +130,21 @@ func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSO
 	if prompt == "" {
 		return LLMGenerateResult{}, fmt.Errorf("prompt is required")
 	}
-	protocol := c.resolveProtocol(ctx)
-	endpoint := strings.TrimSpace(c.resolveEndpointForProtocol(ctx, protocol))
+	target, err := resolveLLMTarget(ctx, c.config, c.configDB, model)
+	if err != nil {
+		return LLMGenerateResult{}, err
+	}
+	protocol := normalizeLLMWireAPI(target.WireAPI)
+	endpoint := strings.TrimSpace(target.Endpoint)
 	if endpoint == "" {
 		return LLMGenerateResult{}, fmt.Errorf("llm api endpoint is not configured")
 	}
-	model = strings.TrimSpace(firstNonEmpty(model, c.resolveSetting(ctx, c.config.LLMModel, "LLM_MODEL")))
+	model = strings.TrimSpace(firstNonEmpty(model, target.Model.Name, target.Model.ID))
 	if model == "" {
 		return LLMGenerateResult{}, fmt.Errorf("llm model is required")
 	}
 	if protocol == llmAPIProtocolChatCompletions {
-		return c.generateChatCompletions(ctx, endpoint, prompt, model, outputSchemaJSON)
+		return c.generateChatCompletions(ctx, endpoint, prompt, model, outputSchemaJSON, target.Headers)
 	}
 	if protocol != llmAPIProtocolResponses {
 		return LLMGenerateResult{}, fmt.Errorf("unsupported llm api protocol %q", protocol)
@@ -166,10 +171,7 @@ func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSO
 	if err != nil {
 		return LLMGenerateResult{}, fmt.Errorf("create llm request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if apiKey := strings.TrimSpace(c.resolveAPIKey(ctx, "LLM_API_KEY", "OPENAI_API_KEY")); apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
+	applyLLMForwardHeaders(req.Header, target.Headers)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return LLMGenerateResult{}, fmt.Errorf("call llm endpoint: %w", err)
@@ -208,7 +210,7 @@ func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSO
 
 // generateChatCompletions calls an OpenAI-compatible Chat Completions backend for
 // unary prompt-to-response text generation (LLMService, scheduler.llm).
-func (c *LLMClient) generateChatCompletions(ctx context.Context, endpoint, prompt, model, outputSchemaJSON string) (LLMGenerateResult, error) {
+func (c *LLMClient) generateChatCompletions(ctx context.Context, endpoint, prompt, model, outputSchemaJSON string, headers http.Header) (LLMGenerateResult, error) {
 	messages := []llmChatCompletionsMessage{{Role: "user", Content: prompt}}
 	request := llmChatCompletionsRequest{Model: model, Messages: messages}
 	if schema := strings.TrimSpace(outputSchemaJSON); schema != "" {
@@ -229,10 +231,7 @@ func (c *LLMClient) generateChatCompletions(ctx context.Context, endpoint, promp
 	if err != nil {
 		return LLMGenerateResult{}, fmt.Errorf("create llm chat completions request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if apiKey := strings.TrimSpace(c.resolveAPIKey(ctx, "LLM_API_KEY", "OPENAI_API_KEY")); apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
+	applyLLMForwardHeaders(req.Header, headers)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return LLMGenerateResult{}, fmt.Errorf("call llm chat completions endpoint: %w", err)
@@ -270,6 +269,15 @@ func (c *LLMClient) generateChatCompletions(ctx context.Context, endpoint, promp
 		ResponseID:   strings.TrimSpace(parsed.ID),
 		FinishReason: extractLLMChatCompletionsFinishReason(parsed),
 	}, nil
+}
+
+func applyLLMForwardHeaders(dst http.Header, src http.Header) {
+	dst.Set("Content-Type", "application/json")
+	for key, values := range src {
+		for _, value := range values {
+			dst.Set(key, value)
+		}
+	}
 }
 
 func (c *LLMClient) resolveSetting(ctx context.Context, fallback string, keys ...string) string {

--- a/pkg/agentcompose/llm_client_test.go
+++ b/pkg/agentcompose/llm_client_test.go
@@ -66,6 +66,90 @@ func TestLLMClientGenerateHandlesSuccessAndFailures(t *testing.T) {
 	testLLMClientGenerateHandlesSuccessAndFailures(t)
 }
 
+func TestLLMClientGenerateKeepsCustomEndpointPath(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-custom","model":"model-a","status":"completed","output_text":"ok"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &LLMClient{
+		config: &appconfig.Config{
+			LLMAPIEndpoint: server.URL + "/custom/path",
+			LLMModel:       "model-a",
+		},
+		configDB: store,
+		client:   server.Client(),
+	}
+	if _, err := client.Generate(ctx, "prompt", "", ""); err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if gotPath != "/custom/path" {
+		t.Fatalf("request path = %q, want custom endpoint path without appended operation", gotPath)
+	}
+}
+
+func TestLLMClientGenerateRefreshesDefaultEnvProviderFromGlobalEnv(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+
+	var firstAuth, firstBody string
+	firstServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		firstAuth = r.Header.Get("Authorization")
+		firstBody = readRequestBodyForTest(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-1","model":"model-one","status":"completed","output_text":"one"}`))
+	}))
+	t.Cleanup(firstServer.Close)
+
+	if _, err := store.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: firstServer.URL, Secret: false},
+		{Name: "LLM_API_KEY", Value: "key-one", Secret: true},
+		{Name: "LLM_MODEL", Value: "model-one", Secret: false},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv(first) returned error: %v", err)
+	}
+	client := &LLMClient{config: &appconfig.Config{}, configDB: store, client: firstServer.Client()}
+	if _, err := client.Generate(ctx, "prompt", "", ""); err != nil {
+		t.Fatalf("Generate(first) returned error: %v", err)
+	}
+	if firstAuth != "Bearer key-one" || !strings.Contains(firstBody, `"model":"model-one"`) {
+		t.Fatalf("first request auth/body = %q / %s, want key-one and model-one", firstAuth, firstBody)
+	}
+
+	var secondAuth, secondBody string
+	secondServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondAuth = r.Header.Get("Authorization")
+		secondBody = readRequestBodyForTest(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-2","model":"model-two","status":"completed","output_text":"two"}`))
+	}))
+	t.Cleanup(secondServer.Close)
+
+	if _, err := store.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: secondServer.URL, Secret: false},
+		{Name: "LLM_API_KEY", Value: "key-two", Secret: true},
+		{Name: "LLM_MODEL", Value: "model-two", Secret: false},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv(second) returned error: %v", err)
+	}
+	client.client = secondServer.Client()
+	if _, err := client.Generate(ctx, "prompt", "", ""); err != nil {
+		t.Fatalf("Generate(second) returned error: %v", err)
+	}
+	if secondAuth != "Bearer key-two" || !strings.Contains(secondBody, `"model":"model-two"`) {
+		t.Fatalf("second request auth/body = %q / %s, want key-two and model-two", secondAuth, secondBody)
+	}
+}
+
 func testLLMClientGenerateHandlesSuccessAndFailures(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
@@ -116,9 +200,12 @@ func testLLMClientGenerateHandlesSuccessAndFailures(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":{"message":"bad request"}}`))
 	}))
 	t.Cleanup(failureServer.Close)
-	client.config.LLMAPIEndpoint = failureServer.URL
-	client.client = failureServer.Client()
-	if _, err := client.Generate(ctx, "prompt", "model-a", ""); err == nil || !strings.Contains(err.Error(), "bad request") {
+	failureClient := &LLMClient{
+		config:   &appconfig.Config{LLMAPIEndpoint: failureServer.URL, LLMAPIKey: "fallback-key", LLMModel: "model-a"},
+		configDB: newTestConfigStore(t),
+		client:   failureServer.Client(),
+	}
+	if _, err := failureClient.Generate(ctx, "prompt", "model-a", ""); err == nil || !strings.Contains(err.Error(), "bad request") {
 		t.Fatalf("Generate(failure response) error = %v, want bad request", err)
 	}
 }
@@ -407,7 +494,7 @@ func TestLoaderRunHostLLMChatCompletionsProtocol(t *testing.T) {
 	}
 	host := &loaderRunHost{
 		manager: manager,
-		loader: Loader{Summary: LoaderSummary{ID: "loader-1"}},
+		loader:  Loader{Summary: LoaderSummary{ID: "loader-1"}},
 		run:     &LoaderRunSummary{ID: "run-1", LoaderID: "loader-1"},
 	}
 

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -917,7 +917,7 @@ func providerForwardHeaders(provider LLMProvider) (http.Header, error) {
 			if forbiddenProviderHeader(key, provider.AuthHeader) {
 				continue
 			}
-			headers.Set(http.CanonicalHeaderKey(strings.TrimSpace(key)), value)
+			headers.Set(strings.TrimSpace(key), value)
 		}
 	}
 	authHeader := firstNonEmpty(strings.TrimSpace(provider.AuthHeader), "Authorization")

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -1,0 +1,1144 @@
+package agentcompose
+
+import (
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	pathpkg "path"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	llmProviderFamilyOpenAI       = "openai"
+	llmProviderFamilyAnthropic    = "anthropic"
+	llmProviderScopeSystem        = "system"
+	llmProviderScopeEnvDefault    = "env_default"
+	llmProviderScopeSessionEnv    = "session_env"
+	llmProviderIDDefaultOpenAI    = "default"
+	llmProviderIDDefaultAnthropic = "anthropic"
+)
+
+type LLMProvider struct {
+	ID             string
+	Name           string
+	ProviderType   string
+	DefaultWireAPI string
+	BaseURL        string
+	APIKey         string
+	AuthHeader     string
+	AuthScheme     string
+	HeadersJSON    string
+	Weight         int
+	Enabled        bool
+	Scope          string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type LLMModel struct {
+	ID           string
+	Name         string
+	Description  string
+	DefaultModel bool
+	Enabled      bool
+	Scope        string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type LLMResolvedTarget struct {
+	Provider LLMProvider
+	Model    LLMModel
+	WireAPI  string
+	Endpoint string
+	Headers  http.Header
+}
+
+type LLMFacadeToken struct {
+	SessionID        string
+	TokenHash        string
+	TokenFingerprint string
+	Model            string
+	ProviderID       string
+	WireAPI          string
+	Source           string
+	RunID            string
+	IssuedAt         time.Time
+	ExpiresAt        time.Time
+	RevokedAt        time.Time
+}
+
+func (s *ConfigStore) ensureLLMSchema(ctx context.Context) error {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS llm_provider (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			provider_type TEXT NOT NULL DEFAULT 'openai_compatible',
+			default_wire_api TEXT NOT NULL DEFAULT 'responses',
+			base_url TEXT NOT NULL,
+			api_key TEXT NOT NULL DEFAULT '',
+			auth_header TEXT NOT NULL DEFAULT 'Authorization',
+			auth_scheme TEXT NOT NULL DEFAULT 'Bearer',
+			headers_json TEXT NOT NULL DEFAULT '{}',
+			weight INTEGER NOT NULL DEFAULT 10,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			scope TEXT NOT NULL DEFAULT 'system',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);`,
+		`CREATE TABLE IF NOT EXISTS llm_model (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			default_model INTEGER NOT NULL DEFAULT 0,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			scope TEXT NOT NULL DEFAULT 'system',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);`,
+		`CREATE TABLE IF NOT EXISTS llm_provider_model (
+			provider_id TEXT NOT NULL,
+			model_id TEXT NOT NULL,
+			wire_api TEXT NOT NULL DEFAULT '',
+			weight INTEGER NOT NULL DEFAULT 10,
+			PRIMARY KEY(provider_id, model_id)
+		);`,
+		`CREATE TABLE IF NOT EXISTS llm_facade_token (
+			token_hash TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			token_fingerprint TEXT NOT NULL,
+			model TEXT NOT NULL DEFAULT '',
+			provider_id TEXT NOT NULL DEFAULT '',
+			wire_api TEXT NOT NULL DEFAULT '',
+			source TEXT NOT NULL DEFAULT '',
+			run_id TEXT NOT NULL DEFAULT '',
+			issued_at INTEGER NOT NULL,
+			expires_at INTEGER NOT NULL,
+			revoked_at INTEGER NOT NULL DEFAULT 0
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_llm_facade_token_session ON llm_facade_token(session_id, revoked_at, expires_at);`,
+	}
+	for _, stmt := range statements {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("create llm schema: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *ConfigStore) HasLLMProviders(ctx context.Context) (bool, error) {
+	var count int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM llm_provider`).Scan(&count); err != nil {
+		return false, fmt.Errorf("count llm providers: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (s *ConfigStore) UpsertDefaultLLMConfig(ctx context.Context, provider LLMProvider, model LLMModel) error {
+	now := time.Now().UTC().Unix()
+	provider.ID = firstNonEmpty(strings.TrimSpace(provider.ID), "default")
+	provider.Name = firstNonEmpty(strings.TrimSpace(provider.Name), "default")
+	provider.ProviderType = normalizeLLMProviderType(provider.ProviderType)
+	provider.DefaultWireAPI = normalizeLLMWireAPI(provider.DefaultWireAPI)
+	if provider.ProviderType == llmProviderFamilyAnthropic {
+		provider.BaseURL = normalizeAnthropicAPIBaseURL(provider.BaseURL)
+	} else {
+		provider.BaseURL = normalizeLLMAPIBaseURL(provider.BaseURL, provider.DefaultWireAPI)
+	}
+	provider.AuthHeader = firstNonEmpty(strings.TrimSpace(provider.AuthHeader), "Authorization")
+	provider.AuthScheme = strings.TrimSpace(provider.AuthScheme)
+	if provider.AuthScheme == "" && strings.EqualFold(provider.AuthHeader, "Authorization") {
+		provider.AuthScheme = "Bearer"
+	}
+	provider.HeadersJSON = firstNonEmpty(strings.TrimSpace(provider.HeadersJSON), "{}")
+	if provider.Weight == 0 {
+		provider.Weight = 10
+	}
+	provider.Scope = firstNonEmpty(strings.TrimSpace(provider.Scope), llmProviderScopeSystem)
+	model.ID = firstNonEmpty(strings.TrimSpace(model.ID), strings.TrimSpace(model.Name))
+	model.Name = firstNonEmpty(strings.TrimSpace(model.Name), model.ID)
+	model.Enabled = true
+	model.Scope = firstNonEmpty(strings.TrimSpace(model.Scope), llmProviderScopeSystem)
+	if model.ID == "" || model.Name == "" {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin llm default config tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_provider(id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, weight, enabled, scope, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET name = excluded.name, provider_type = excluded.provider_type, default_wire_api = excluded.default_wire_api, base_url = excluded.base_url, api_key = excluded.api_key, auth_header = excluded.auth_header, auth_scheme = excluded.auth_scheme, headers_json = excluded.headers_json, weight = excluded.weight, enabled = excluded.enabled, scope = excluded.scope, updated_at = excluded.updated_at`, provider.ID, provider.Name, provider.ProviderType, provider.DefaultWireAPI, provider.BaseURL, provider.APIKey, provider.AuthHeader, provider.AuthScheme, provider.HeadersJSON, provider.Weight, provider.Scope, now, now); err != nil {
+		return fmt.Errorf("insert default llm provider: %w", err)
+	}
+	if model.DefaultModel {
+		if _, err := tx.ExecContext(ctx, `UPDATE llm_model SET default_model = 0 WHERE default_model != 0`); err != nil {
+			return fmt.Errorf("reset default llm models: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_model(id, name, description, default_model, enabled, scope, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET name = excluded.name, description = excluded.description, default_model = excluded.default_model, enabled = excluded.enabled, scope = excluded.scope, updated_at = excluded.updated_at`, model.ID, model.Name, model.Description, boolToInt(model.DefaultModel), boolToInt(model.Enabled), model.Scope, now, now); err != nil {
+		return fmt.Errorf("insert default llm model: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_provider_model(provider_id, model_id, wire_api, weight)
+		VALUES(?, ?, '', 10)
+		ON CONFLICT(provider_id, model_id) DO NOTHING`, provider.ID, model.ID); err != nil {
+		return fmt.Errorf("insert default llm provider model: %w", err)
+	}
+	return tx.Commit()
+}
+
+func (s *ConfigStore) ListEnabledLLMProviders(ctx context.Context) ([]LLMProvider, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, weight, enabled, scope, created_at, updated_at FROM llm_provider WHERE enabled != 0 ORDER BY weight ASC, id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query llm providers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var providers []LLMProvider
+	for rows.Next() {
+		item, err := scanLLMProvider(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		providers = append(providers, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate llm providers: %w", err)
+	}
+	return providers, nil
+}
+
+func (s *ConfigStore) ListEnabledLLMModels(ctx context.Context) ([]LLMModel, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, description, default_model, enabled, scope, created_at, updated_at FROM llm_model WHERE enabled != 0 ORDER BY default_model DESC, id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query llm models: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var models []LLMModel
+	for rows.Next() {
+		item, err := scanLLMModel(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		models = append(models, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate llm models: %w", err)
+	}
+	return models, nil
+}
+
+func (s *ConfigStore) LLMProviderModelWireAPI(ctx context.Context, providerID, modelID string) (string, bool, error) {
+	var wireAPI string
+	err := s.db.QueryRowContext(ctx, `SELECT wire_api FROM llm_provider_model WHERE provider_id = ? AND model_id = ?`, strings.TrimSpace(providerID), strings.TrimSpace(modelID)).Scan(&wireAPI)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("query llm provider model: %w", err)
+	}
+	wireAPI = strings.TrimSpace(wireAPI)
+	if wireAPI == "" {
+		return "", true, nil
+	}
+	return normalizeLLMWireAPI(wireAPI), true, nil
+}
+
+func (s *ConfigStore) SaveLLMFacadeToken(ctx context.Context, token LLMFacadeToken) error {
+	if strings.TrimSpace(token.TokenHash) == "" || strings.TrimSpace(token.SessionID) == "" {
+		return fmt.Errorf("llm facade token hash and session id are required")
+	}
+	if token.IssuedAt.IsZero() {
+		token.IssuedAt = time.Now().UTC()
+	}
+	revokedAt := int64(0)
+	if !token.RevokedAt.IsZero() {
+		revokedAt = token.RevokedAt.Unix()
+	}
+	expiresAt := int64(0)
+	if !token.ExpiresAt.IsZero() {
+		expiresAt = token.ExpiresAt.Unix()
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO llm_facade_token(token_hash, session_id, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(token_hash) DO UPDATE SET session_id = excluded.session_id, token_fingerprint = excluded.token_fingerprint, model = excluded.model, provider_id = excluded.provider_id, wire_api = excluded.wire_api, source = excluded.source, run_id = excluded.run_id, issued_at = excluded.issued_at, expires_at = excluded.expires_at, revoked_at = excluded.revoked_at`,
+		token.TokenHash, token.SessionID, token.TokenFingerprint, token.Model, token.ProviderID, token.WireAPI, token.Source, token.RunID, token.IssuedAt.Unix(), expiresAt, revokedAt)
+	if err != nil {
+		return fmt.Errorf("save llm facade token: %w", err)
+	}
+	return nil
+}
+
+// DeleteLLMFacadeToken removes a single facade token by its raw value. It is used
+// to retire a per-run agent token as soon as that run completes, so live tokens
+// never accumulate over the lifetime of a long-running session.
+func (s *ConfigStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) error {
+	if strings.TrimSpace(rawToken) == "" {
+		return nil
+	}
+	hash, _ := hashLLMFacadeToken(rawToken)
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE token_hash = ?`, hash); err != nil {
+		return fmt.Errorf("delete llm facade token: %w", err)
+	}
+	return nil
+}
+
+func (s *ConfigStore) GetLLMFacadeToken(ctx context.Context, rawToken string) (LLMFacadeToken, error) {
+	hash, fingerprint := hashLLMFacadeToken(rawToken)
+	row := s.db.QueryRowContext(ctx, `SELECT session_id, token_hash, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at FROM llm_facade_token WHERE token_hash = ?`, hash)
+	token, err := scanLLMFacadeToken(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return LLMFacadeToken{}, fmt.Errorf("llm facade token %s not found: %w", fingerprint, err)
+		}
+		return LLMFacadeToken{}, err
+	}
+	return token, nil
+}
+
+// llmFacadeTokenRetention is how long a revoked facade token row is kept before
+// it is physically pruned. The grace window keeps recently-revoked tokens around
+// for debugging while bounding table growth from completed sessions.
+const llmFacadeTokenRetention = time.Hour
+
+func (s *ConfigStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessionID string) error {
+	now := time.Now().UTC()
+	if _, err := s.db.ExecContext(ctx, `UPDATE llm_facade_token SET revoked_at = ? WHERE session_id = ? AND revoked_at = 0`, now.Unix(), strings.TrimSpace(sessionID)); err != nil {
+		return fmt.Errorf("revoke llm facade tokens for session: %w", err)
+	}
+	// Opportunistically prune long-dead rows (revoked beyond the retention grace,
+	// or expired) so the table stays bounded across sessions. Both states already
+	// fail closed at the handler, so deleting them changes nothing observable.
+	cutoff := now.Add(-llmFacadeTokenRetention).Unix()
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE (revoked_at != 0 AND revoked_at < ?) OR (expires_at != 0 AND expires_at < ?)`, cutoff, now.Unix()); err != nil {
+		return fmt.Errorf("prune llm facade tokens: %w", err)
+	}
+	return nil
+}
+
+func scanLLMProvider(scan func(dest ...any) error) (LLMProvider, error) {
+	var item LLMProvider
+	var enabled int
+	var createdAt, updatedAt int64
+	if err := scan(&item.ID, &item.Name, &item.ProviderType, &item.DefaultWireAPI, &item.BaseURL, &item.APIKey, &item.AuthHeader, &item.AuthScheme, &item.HeadersJSON, &item.Weight, &enabled, &item.Scope, &createdAt, &updatedAt); err != nil {
+		return LLMProvider{}, err
+	}
+	item.Enabled = enabled != 0
+	item.ProviderType = normalizeLLMProviderType(item.ProviderType)
+	item.DefaultWireAPI = normalizeLLMWireAPI(item.DefaultWireAPI)
+	item.CreatedAt = parseStoredTime(createdAt)
+	item.UpdatedAt = parseStoredTime(updatedAt)
+	return item, nil
+}
+
+func scanLLMModel(scan func(dest ...any) error) (LLMModel, error) {
+	var item LLMModel
+	var defaultModel, enabled int
+	var createdAt, updatedAt int64
+	if err := scan(&item.ID, &item.Name, &item.Description, &defaultModel, &enabled, &item.Scope, &createdAt, &updatedAt); err != nil {
+		return LLMModel{}, err
+	}
+	item.DefaultModel = defaultModel != 0
+	item.Enabled = enabled != 0
+	item.CreatedAt = parseStoredTime(createdAt)
+	item.UpdatedAt = parseStoredTime(updatedAt)
+	return item, nil
+}
+
+func scanLLMFacadeToken(scan func(dest ...any) error) (LLMFacadeToken, error) {
+	var item LLMFacadeToken
+	var issuedAt, expiresAt, revokedAt int64
+	if err := scan(&item.SessionID, &item.TokenHash, &item.TokenFingerprint, &item.Model, &item.ProviderID, &item.WireAPI, &item.Source, &item.RunID, &issuedAt, &expiresAt, &revokedAt); err != nil {
+		return LLMFacadeToken{}, err
+	}
+	item.IssuedAt = parseStoredTime(issuedAt)
+	item.ExpiresAt = parseStoredTime(expiresAt)
+	item.RevokedAt = parseStoredTime(revokedAt)
+	return item, nil
+}
+
+func bootstrapDefaultLLMConfig(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
+	if hasConfiguredLLMProviderForFamily(ctx, store, llmProviderFamilyOpenAI) {
+		return nil
+	}
+	return ensureDefaultOpenAIEnvProvider(ctx, config, store, requestedModel)
+}
+
+// llmEnvProviderLookup resolves an environment value for LLM provider bootstrap.
+// It accepts candidate keys and returns the first non-empty value scanning
+// sources in priority order (source-major): an earlier source wins across all
+// candidate keys before a later source is consulted. This preserves the exact
+// precedence the bootstrap paths relied on when they used nested firstNonEmpty.
+type llmEnvProviderLookup func(keys ...string) string
+
+// defaultLLMEnvProviderLookup reads from global env, then the process env, then
+// daemon config. Used by the env_default bootstrap providers.
+func defaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store *ConfigStore) llmEnvProviderLookup {
+	return func(keys ...string) string {
+		for _, key := range keys {
+			if v := lookupEnvValue(ctx, store, key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		for _, key := range keys {
+			if v := os.Getenv(key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		for _, key := range keys {
+			if v := configLLMEnvValue(config, key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		return ""
+	}
+}
+
+// sessionLLMEnvProviderLookup reads only from per-session env items. Used by the
+// session_env bootstrap providers.
+func sessionLLMEnvProviderLookup(envItems []SessionEnvVar) llmEnvProviderLookup {
+	return func(keys ...string) string {
+		for _, key := range keys {
+			if v := lookupEnvItemValue(envItems, key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		return ""
+	}
+}
+
+func configLLMEnvValue(config *appconfig.Config, key string) string {
+	if config == nil {
+		return ""
+	}
+	switch strings.ToUpper(strings.TrimSpace(key)) {
+	case "LLM_API_ENDPOINT":
+		return config.LLMAPIEndpoint
+	case "LLM_API_PROTOCOL":
+		return config.LLMAPIProtocol
+	case "LLM_API_KEY":
+		return config.LLMAPIKey
+	case "LLM_MODEL":
+		return config.LLMModel
+	default:
+		return ""
+	}
+}
+
+// ensureOpenAIEnvProvider upserts an OpenAI-family provider from a resolved env
+// lookup. It returns the provider id (empty when nothing was configured).
+func ensureOpenAIEnvProvider(ctx context.Context, store *ConfigStore, lookup llmEnvProviderLookup, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+	endpoint := firstNonEmpty(lookup("LLM_API_ENDPOINT"), "https://api.openai.com")
+	if looksLikeAnthropicMessagesEndpoint(endpoint) {
+		return "", nil
+	}
+	protocol := normalizeLLMWireAPI(lookup("LLM_API_PROTOCOL"))
+	apiKey := lookup("LLM_API_KEY", "OPENAI_API_KEY")
+	model := strings.TrimSpace(firstNonEmpty(requestedModel, lookup("LLM_MODEL")))
+	if providerID == "" || model == "" {
+		return "", nil
+	}
+	return providerID, store.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             providerID,
+		Name:           name,
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: protocol,
+		BaseURL:        endpoint,
+		APIKey:         apiKey,
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    "{}",
+		Weight:         10,
+		Enabled:        true,
+		Scope:          scope,
+	}, LLMModel{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
+}
+
+// ensureAnthropicEnvProvider upserts an Anthropic-family provider from a resolved
+// env lookup. It returns the provider id (empty when nothing was configured).
+func ensureAnthropicEnvProvider(ctx context.Context, store *ConfigStore, lookup llmEnvProviderLookup, authHeader, authScheme, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+	anthropicEndpoint := lookup("ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT")
+	genericEndpoint := lookup("LLM_API_ENDPOINT")
+	anthropicKey := lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+	anthropicModel := lookup("ANTHROPIC_MODEL", "CLAUDE_MODEL")
+	genericModel := lookup("LLM_MODEL")
+	useGenericEndpoint := anthropicEndpoint == "" && looksLikeAnthropicMessagesEndpoint(genericEndpoint)
+	if useGenericEndpoint {
+		anthropicEndpoint = genericEndpoint
+	}
+	if genericModel != "" && (useGenericEndpoint || anthropicEndpoint != "" || anthropicKey != "" || anthropicModel != "") {
+		anthropicModel = firstNonEmpty(anthropicModel, genericModel)
+	}
+	if anthropicEndpoint == "" && strings.TrimSpace(anthropicKey) == "" && strings.TrimSpace(anthropicModel) == "" {
+		return "", nil
+	}
+	endpoint := firstNonEmpty(anthropicEndpoint, "https://api.anthropic.com")
+	apiKey := firstNonEmpty(anthropicKey, lookup("LLM_API_KEY"))
+	model := strings.TrimSpace(firstNonEmpty(requestedModel, anthropicModel))
+	if providerID == "" || model == "" {
+		return "", nil
+	}
+	return providerID, store.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             providerID,
+		Name:           name,
+		ProviderType:   llmProviderFamilyAnthropic,
+		DefaultWireAPI: llmAPIProtocolMessages,
+		BaseURL:        endpoint,
+		APIKey:         apiKey,
+		AuthHeader:     authHeader,
+		AuthScheme:     authScheme,
+		HeadersJSON:    `{"anthropic-version":"2023-06-01"}`,
+		Weight:         10,
+		Enabled:        true,
+		Scope:          scope,
+	}, LLMModel{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
+}
+
+func ensureDefaultOpenAIEnvProvider(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
+	_, err := ensureOpenAIEnvProvider(ctx, store, defaultLLMEnvProviderLookup(ctx, config, store), llmProviderIDDefaultOpenAI, "default", llmProviderScopeEnvDefault, requestedModel, true)
+	return err
+}
+
+func resolveLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) (LLMResolvedTarget, error) {
+	return resolveLLMTargetForProviderFamily(ctx, config, store, llmProviderFamilyOpenAI, requestedModel)
+}
+
+func resolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel, providerID string) (LLMResolvedTarget, error) {
+	return resolveRuntimeLLMTargetWithEnv(ctx, config, store, "", "", requestedModel, providerID, nil)
+}
+
+func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store *ConfigStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []SessionEnvVar) (LLMResolvedTarget, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	preferredProviderFamily = normalizeOptionalLLMProviderType(preferredProviderFamily)
+	requestedModel = strings.TrimSpace(requestedModel)
+	providerID = strings.TrimSpace(providerID)
+	hasSessionEnvProvider := sessionID != "" && hasSessionEnvProviderInput(envItems)
+	sessionProviderID := ""
+	// Skip the env/default bootstrap entirely when the request already names a
+	// provider that exists. The facade hot path always passes a concrete
+	// provider id from the token scope, so this avoids a redundant pair of
+	// idempotent provider upserts on every LLM request.
+	bootstrapProviders := (providerID == "" || !isSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
+	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, llmProviderFamilyOpenAI) {
+		openAIModel := firstNonEmpty(requestedModel, lookupEnvItemValue(envItems, "LLM_MODEL"))
+		if sessionID != "" && hasOpenAIEnvProviderInput(envItems) {
+			id, err := ensureSessionOpenAIEnvProvider(ctx, store, sessionID, openAIModel, envItems)
+			if err != nil {
+				return LLMResolvedTarget{}, err
+			}
+			sessionProviderID = chooseSessionEnvProviderID(sessionProviderID, id, llmProviderFamilyOpenAI, preferredProviderFamily)
+		} else if !hasSessionEnvProvider {
+			if err := ensureDefaultOpenAIEnvProvider(ctx, config, store, openAIModel); err != nil {
+				return LLMResolvedTarget{}, err
+			}
+		}
+	}
+	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, llmProviderFamilyAnthropic) {
+		anthropicModel := firstNonEmpty(requestedModel, sessionAnthropicEnvModel(envItems))
+		if sessionID != "" && hasAnthropicEnvProviderInput(envItems) {
+			id, err := ensureSessionAnthropicEnvProvider(ctx, store, sessionID, anthropicModel, envItems)
+			if err != nil {
+				return LLMResolvedTarget{}, err
+			}
+			sessionProviderID = chooseSessionEnvProviderID(sessionProviderID, id, llmProviderFamilyAnthropic, preferredProviderFamily)
+		} else if !hasSessionEnvProvider {
+			if err := ensureDefaultAnthropicEnvProvider(ctx, config, store, anthropicModel); err != nil {
+				return LLMResolvedTarget{}, err
+			}
+		}
+	}
+	providerID = firstNonEmpty(providerID, sessionProviderID)
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	if len(models) == 0 {
+		return LLMResolvedTarget{}, fmt.Errorf("llm model is required")
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	if len(providers) == 0 {
+		return LLMResolvedTarget{}, fmt.Errorf("llm provider is not configured")
+	}
+	model, provider, wireAPI, ok, err := selectLLMModelAndProvider(ctx, store, models, providers, requestedModel, "", providerID)
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	if !ok {
+		if requestedModel != "" && providerID != "" {
+			return LLMResolvedTarget{}, fmt.Errorf("llm model %q is not configured for provider %q", requestedModel, providerID)
+		}
+		if requestedModel != "" {
+			return LLMResolvedTarget{}, fmt.Errorf("llm model %q is not configured", requestedModel)
+		}
+		if providerID != "" {
+			return LLMResolvedTarget{}, fmt.Errorf("llm provider %q is not configured", providerID)
+		}
+		return LLMResolvedTarget{}, fmt.Errorf("llm provider is not configured")
+	}
+	endpoint := llmEndpointForProvider(provider, wireAPI)
+	headers, err := providerForwardHeaders(provider)
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	return LLMResolvedTarget{Provider: provider, Model: model, WireAPI: wireAPI, Endpoint: endpoint, Headers: headers}, nil
+}
+
+func bootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
+	if hasConfiguredLLMProviderForFamily(ctx, store, llmProviderFamilyAnthropic) {
+		return nil
+	}
+	return ensureDefaultAnthropicEnvProvider(ctx, config, store, requestedModel)
+}
+
+func ensureDefaultAnthropicEnvProvider(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
+	lookup := defaultLLMEnvProviderLookup(ctx, config, store)
+	authHeader, authScheme := anthropicProviderAuthFromLookup(lookup)
+	_, err := ensureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, llmProviderIDDefaultAnthropic, "anthropic", llmProviderScopeEnvDefault, requestedModel, false)
+	return err
+}
+
+func looksLikeAnthropicMessagesEndpoint(endpoint string) bool {
+	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if endpoint == "" {
+		return false
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return strings.HasSuffix(endpoint, "/messages")
+	}
+	return strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), "/messages")
+}
+
+// anthropicProviderAuthFromLookup chooses the Anthropic auth header from the same
+// env source(s) the provider's API key is resolved from, so a provider never
+// mixes a key from one scope with a header decided by another scope.
+func anthropicProviderAuthFromLookup(lookup llmEnvProviderLookup) (string, string) {
+	if strings.TrimSpace(lookup("ANTHROPIC_API_KEY")) != "" {
+		return "x-api-key", ""
+	}
+	if strings.TrimSpace(lookup("ANTHROPIC_AUTH_TOKEN")) != "" {
+		return "Authorization", "Bearer"
+	}
+	return "x-api-key", ""
+}
+
+func ensureSessionOpenAIEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []SessionEnvVar) (string, error) {
+	providerID := sessionEnvProviderID(sessionID, llmProviderFamilyOpenAI)
+	return ensureOpenAIEnvProvider(ctx, store, sessionLLMEnvProviderLookup(envItems), providerID, providerID, llmProviderScopeSessionEnv, requestedModel, false)
+}
+
+func ensureSessionAnthropicEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []SessionEnvVar) (string, error) {
+	providerID := sessionEnvProviderID(sessionID, llmProviderFamilyAnthropic)
+	lookup := sessionLLMEnvProviderLookup(envItems)
+	authHeader, authScheme := anthropicProviderAuthFromLookup(lookup)
+	return ensureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, providerID, providerID, llmProviderScopeSessionEnv, requestedModel, false)
+}
+
+func hasEnabledLLMProviderID(ctx context.Context, store *ConfigStore, providerID string) bool {
+	providerID = strings.TrimSpace(providerID)
+	if store == nil || providerID == "" {
+		return false
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return false
+	}
+	for _, provider := range providers {
+		if provider.ID == providerID {
+			return true
+		}
+	}
+	return false
+}
+
+func hasConfiguredLLMProviderForFamily(ctx context.Context, store *ConfigStore, providerFamily string) bool {
+	if store == nil {
+		return false
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return false
+	}
+	for _, provider := range providers {
+		if normalizeLLMProviderType(provider.ProviderType) != normalizeLLMProviderType(providerFamily) {
+			continue
+		}
+		if llmProviderScopeIsConfigured(provider.Scope) {
+			return true
+		}
+	}
+	return false
+}
+
+func llmProviderScopeIsConfigured(scope string) bool {
+	switch strings.TrimSpace(scope) {
+	case llmProviderScopeEnvDefault, llmProviderScopeSessionEnv:
+		return false
+	default:
+		return true
+	}
+}
+
+func hasOpenAIEnvProviderInput(envItems []SessionEnvVar) bool {
+	endpoint := lookupEnvItemValue(envItems, "LLM_API_ENDPOINT")
+	if looksLikeAnthropicMessagesEndpoint(endpoint) {
+		return false
+	}
+	return strings.TrimSpace(firstNonEmpty(
+		endpoint,
+		lookupEnvItemValue(envItems, "LLM_API_KEY"),
+		lookupEnvItemValue(envItems, "OPENAI_API_KEY"),
+	)) != ""
+}
+
+func hasAnthropicEnvProviderInput(envItems []SessionEnvVar) bool {
+	return strings.TrimSpace(firstNonEmpty(
+		lookupEnvItemValue(envItems, "ANTHROPIC_BASE_URL"),
+		lookupEnvItemValue(envItems, "ANTHROPIC_API_ENDPOINT"),
+		lookupEnvItemValue(envItems, "ANTHROPIC_API_KEY"),
+		lookupEnvItemValue(envItems, "ANTHROPIC_AUTH_TOKEN"),
+	)) != "" || looksLikeAnthropicMessagesEndpoint(lookupEnvItemValue(envItems, "LLM_API_ENDPOINT"))
+}
+
+func hasSessionEnvProviderInput(envItems []SessionEnvVar) bool {
+	return hasOpenAIEnvProviderInput(envItems) || hasAnthropicEnvProviderInput(envItems)
+}
+
+func sessionAnthropicEnvModel(envItems []SessionEnvVar) string {
+	genericModel := lookupEnvItemValue(envItems, "LLM_MODEL")
+	return firstNonEmpty(
+		lookupEnvItemValue(envItems, "ANTHROPIC_MODEL"),
+		lookupEnvItemValue(envItems, "CLAUDE_MODEL"),
+		genericModel,
+	)
+}
+
+func sessionEnvProviderID(sessionID, providerFamily string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	providerFamily = normalizeOptionalLLMProviderType(providerFamily)
+	if sessionID == "" || providerFamily == "" {
+		return ""
+	}
+	return "session-env:" + sessionID + ":" + providerFamily
+}
+
+func isSessionEnvProviderID(providerID string) bool {
+	return strings.HasPrefix(strings.TrimSpace(providerID), "session-env:")
+}
+
+func chooseSessionEnvProviderID(current, next, nextFamily, preferredFamily string) string {
+	next = strings.TrimSpace(next)
+	if next == "" {
+		return current
+	}
+	if strings.TrimSpace(current) == "" {
+		return next
+	}
+	preferredFamily = normalizeOptionalLLMProviderType(preferredFamily)
+	if preferredFamily != "" && normalizeLLMProviderType(nextFamily) == preferredFamily {
+		return next
+	}
+	return current
+}
+
+func resolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store *ConfigStore, providerFamily, requestedModel string) (LLMResolvedTarget, error) {
+	if strings.TrimSpace(providerFamily) != "" {
+		providerFamily = normalizeLLMProviderType(providerFamily)
+	}
+	switch providerFamily {
+	case llmProviderFamilyAnthropic:
+		if err := bootstrapAnthropicLLMConfig(ctx, config, store, strings.TrimSpace(requestedModel)); err != nil {
+			return LLMResolvedTarget{}, err
+		}
+	default:
+		if err := bootstrapDefaultLLMConfig(ctx, config, store, strings.TrimSpace(requestedModel)); err != nil {
+			return LLMResolvedTarget{}, err
+		}
+	}
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	if len(models) == 0 {
+		return LLMResolvedTarget{}, fmt.Errorf("llm model is required")
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	if len(providers) == 0 {
+		return LLMResolvedTarget{}, fmt.Errorf("llm provider is not configured")
+	}
+	model, provider, wireAPI, ok, err := selectLLMModelAndProvider(ctx, store, models, providers, requestedModel, providerFamily, "")
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	if !ok {
+		if strings.TrimSpace(requestedModel) != "" {
+			return LLMResolvedTarget{}, fmt.Errorf("llm model %q is not configured for provider family %q", strings.TrimSpace(requestedModel), providerFamily)
+		}
+		return LLMResolvedTarget{}, fmt.Errorf("llm provider is not configured for provider family %q", providerFamily)
+	}
+	endpoint := llmEndpointForProvider(provider, wireAPI)
+	headers, err := providerForwardHeaders(provider)
+	if err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	return LLMResolvedTarget{Provider: provider, Model: model, WireAPI: wireAPI, Endpoint: endpoint, Headers: headers}, nil
+}
+
+func selectLLMModel(models []LLMModel, requested string) LLMModel {
+	requested = strings.TrimSpace(requested)
+	for _, model := range models {
+		if requested != "" && (model.ID == requested || model.Name == requested) {
+			return model
+		}
+	}
+	if requested != "" {
+		return LLMModel{}
+	}
+	for _, model := range models {
+		if model.DefaultModel {
+			return model
+		}
+	}
+	return models[0]
+}
+
+func selectLLMModelAndProvider(ctx context.Context, store *ConfigStore, models []LLMModel, providers []LLMProvider, requestedModel, providerFamily, providerID string) (LLMModel, LLMProvider, string, bool, error) {
+	if strings.TrimSpace(requestedModel) != "" {
+		requested := selectLLMModel(models, requestedModel)
+		if strings.TrimSpace(requested.ID) == "" {
+			return LLMModel{}, LLMProvider{}, "", false, nil
+		}
+		provider, wireAPI, ok, err := selectLLMProviderForModel(ctx, store, providers, requested.ID, providerFamily, providerID)
+		return requested, provider, wireAPI, ok, err
+	}
+	ordered := append([]LLMModel(nil), models...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].DefaultModel != ordered[j].DefaultModel {
+			return ordered[i].DefaultModel
+		}
+		return ordered[i].ID < ordered[j].ID
+	})
+	for _, model := range ordered {
+		provider, wireAPI, ok, err := selectLLMProviderForModel(ctx, store, providers, model.ID, providerFamily, providerID)
+		if err != nil {
+			return LLMModel{}, LLMProvider{}, "", false, err
+		}
+		if ok {
+			return model, provider, wireAPI, true, nil
+		}
+	}
+	return LLMModel{}, LLMProvider{}, "", false, nil
+}
+
+func selectLLMProviderForModel(ctx context.Context, store *ConfigStore, providers []LLMProvider, modelID, providerFamily, providerID string) (LLMProvider, string, bool, error) {
+	type candidate struct {
+		provider LLMProvider
+		wireAPI  string
+		priority int
+	}
+	if strings.TrimSpace(providerFamily) != "" {
+		providerFamily = normalizeLLMProviderType(providerFamily)
+	}
+	providerID = strings.TrimSpace(providerID)
+	var candidates []candidate
+	for _, provider := range providers {
+		if providerFamily != "" && normalizeLLMProviderType(provider.ProviderType) != providerFamily {
+			continue
+		}
+		if providerID != "" && provider.ID != providerID {
+			continue
+		}
+		if providerID == "" && strings.TrimSpace(provider.Scope) == llmProviderScopeSessionEnv {
+			continue
+		}
+		wireAPI, ok, err := store.LLMProviderModelWireAPI(ctx, provider.ID, modelID)
+		if err != nil {
+			return LLMProvider{}, "", false, err
+		}
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate{provider: provider, wireAPI: firstNonEmpty(wireAPI, normalizeLLMWireAPI(provider.DefaultWireAPI)), priority: llmProviderSelectionPriority(provider.Scope)})
+	}
+	if len(candidates) == 0 {
+		return LLMProvider{}, "", false, nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].priority != candidates[j].priority {
+			return candidates[i].priority < candidates[j].priority
+		}
+		if candidates[i].provider.Weight == candidates[j].provider.Weight {
+			return candidates[i].provider.ID < candidates[j].provider.ID
+		}
+		return candidates[i].provider.Weight < candidates[j].provider.Weight
+	})
+	return candidates[0].provider, candidates[0].wireAPI, true, nil
+}
+
+func llmProviderSelectionPriority(scope string) int {
+	switch strings.TrimSpace(scope) {
+	case llmProviderScopeSessionEnv:
+		return 2
+	case llmProviderScopeEnvDefault:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func providerForwardHeaders(provider LLMProvider) (http.Header, error) {
+	headers := http.Header{}
+	if raw := strings.TrimSpace(provider.HeadersJSON); raw != "" && raw != "{}" {
+		custom := map[string]string{}
+		if err := json.Unmarshal([]byte(raw), &custom); err != nil {
+			return nil, fmt.Errorf("decode llm provider headers: %w", err)
+		}
+		for key, value := range custom {
+			if forbiddenProviderHeader(key, provider.AuthHeader) {
+				continue
+			}
+			headers.Set(http.CanonicalHeaderKey(strings.TrimSpace(key)), value)
+		}
+	}
+	authHeader := firstNonEmpty(strings.TrimSpace(provider.AuthHeader), "Authorization")
+	apiKey := strings.TrimSpace(provider.APIKey)
+	if apiKey != "" {
+		if scheme := strings.TrimSpace(provider.AuthScheme); scheme != "" {
+			headers.Set(authHeader, scheme+" "+apiKey)
+		} else {
+			headers.Set(authHeader, apiKey)
+		}
+	}
+	return headers, nil
+}
+
+func forbiddenProviderHeader(name, authHeader string) bool {
+	canonical := strings.ToLower(strings.TrimSpace(name))
+	if canonical == "" || canonical == strings.ToLower(strings.TrimSpace(authHeader)) {
+		return true
+	}
+	switch canonical {
+	case "authorization", "proxy-authorization", "host", "content-length", "content-type", "cookie", "set-cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeLLMWireAPI(value string) string {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(value)), "-", "_") {
+	case "", llmAPIProtocolResponses:
+		return llmAPIProtocolResponses
+	case "chat", "chat_completion", llmAPIProtocolChatCompletions:
+		return llmAPIProtocolChatCompletions
+	case "message", llmAPIProtocolMessages:
+		return llmAPIProtocolMessages
+	default:
+		return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(value)), "-", "_")
+	}
+}
+
+func normalizeLLMProviderType(value string) string {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(value)), "-", "_") {
+	case "", "openai", "openai_compatible":
+		return llmProviderFamilyOpenAI
+	case "anthropic", "claude", "anthropic_messages":
+		return llmProviderFamilyAnthropic
+	default:
+		return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(value)), "-", "_")
+	}
+}
+
+func normalizeOptionalLLMProviderType(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return normalizeLLMProviderType(value)
+}
+
+func normalizeLLMAPIBaseURL(raw, wireAPI string) string {
+	raw = strings.TrimRight(strings.TrimSpace(raw), "/")
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	cleanPath := strings.TrimRight(parsed.Path, "/")
+	switch {
+	case strings.HasSuffix(cleanPath, "/responses"):
+		parsed.Path = strings.TrimSuffix(cleanPath, "/responses")
+	case strings.HasSuffix(cleanPath, "/chat/completions"):
+		parsed.Path = strings.TrimSuffix(cleanPath, "/chat/completions")
+	default:
+		parsed.Path = cleanPath
+	}
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func llmEndpointForWireAPI(baseURL, wireAPI string) string {
+	baseURL = normalizeLLMAPIBaseURL(baseURL, wireAPI)
+	return normalizeLLMAPIEndpointForProtocol(baseURL, wireAPI)
+}
+
+func llmEndpointForProvider(provider LLMProvider, wireAPI string) string {
+	if normalizeLLMProviderType(provider.ProviderType) == llmProviderFamilyAnthropic {
+		baseURL := normalizeAnthropicAPIBaseURL(provider.BaseURL)
+		parsed, err := url.Parse(baseURL)
+		if err != nil {
+			return strings.TrimRight(baseURL, "/") + "/messages"
+		}
+		parsed.Path = pathpkg.Join(parsed.Path, "messages")
+		return parsed.String()
+	}
+	return llmEndpointForWireAPI(provider.BaseURL, wireAPI)
+}
+
+func normalizeAnthropicAPIBaseURL(raw string) string {
+	raw = strings.TrimRight(strings.TrimSpace(raw), "/")
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	cleanPath := strings.TrimRight(parsed.Path, "/")
+	switch {
+	case strings.HasSuffix(cleanPath, "/messages"):
+		parsed.Path = strings.TrimSuffix(cleanPath, "/messages")
+	case cleanPath == "":
+		parsed.Path = "/v1"
+	default:
+		parsed.Path = cleanPath
+	}
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func lookupEnvValue(ctx context.Context, store *ConfigStore, key string) string {
+	if store == nil {
+		return ""
+	}
+	items, err := store.ListGlobalEnv(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, item := range items {
+		if item.Name == key {
+			return item.Value
+		}
+	}
+	return ""
+}
+
+func lookupEnvItemValue(items []SessionEnvVar, key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	for _, item := range normalizeEnvItems(items) {
+		if strings.EqualFold(strings.TrimSpace(item.Name), key) {
+			return strings.TrimSpace(item.Value)
+		}
+	}
+	return ""
+}
+
+func newLLMFacadeToken(sessionID, model, providerID, wireAPI, source, runID string) (string, LLMFacadeToken, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", LLMFacadeToken{}, err
+	}
+	tokenValue := "ac_llm_" + hex.EncodeToString(raw)
+	hash, fingerprint := hashLLMFacadeToken(tokenValue)
+	now := time.Now().UTC()
+	return tokenValue, LLMFacadeToken{
+		SessionID:        strings.TrimSpace(sessionID),
+		TokenHash:        hash,
+		TokenFingerprint: fingerprint,
+		Model:            strings.TrimSpace(model),
+		ProviderID:       strings.TrimSpace(providerID),
+		WireAPI:          normalizeLLMWireAPI(wireAPI),
+		Source:           strings.TrimSpace(source),
+		RunID:            strings.TrimSpace(runID),
+		IssuedAt:         now,
+	}, nil
+}
+
+func hashLLMFacadeToken(value string) (string, string) {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	hash := hex.EncodeToString(sum[:])
+	if len(hash) < 12 {
+		return hash, hash
+	}
+	return hash, hash[:12]
+}
+
+func llmProviderKeyName(name string) bool {
+	return driverpkg.LLMProviderKeyName(name)
+}
+
+func filterPersistedRuntimeEnv(items []SessionEnvVar) []SessionEnvVar {
+	result := make([]SessionEnvVar, 0, len(items))
+	for _, item := range normalizeEnvItems(items) {
+		if llmProviderKeyName(item.Name) {
+			continue
+		}
+		result = append(result, item)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func runtimeEnvMap(items []SessionEnvVar) map[string]string {
+	env := make(map[string]string, len(items))
+	for _, item := range normalizeEnvItems(items) {
+		name := strings.TrimSpace(item.Name)
+		if name == "" || llmProviderKeyName(name) {
+			continue
+		}
+		env[name] = item.Value
+	}
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
+func managedRuntimeEnvMap(items []SessionEnvVar) map[string]string {
+	env := make(map[string]string, len(items))
+	for _, item := range normalizeEnvItems(items) {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		env[name] = item.Value
+	}
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -528,6 +528,19 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	providerID = strings.TrimSpace(providerID)
 	hasSessionEnvProvider := sessionID != "" && hasSessionEnvProviderInput(envItems)
 	sessionProviderID := ""
+	// Reuse an already-persisted session-env provider when this session can no
+	// longer supply a key from env. The raw key env (Session.ProviderEnvItems) is
+	// intentionally not persisted, so after a stop/resume the only durable home
+	// for a session-scoped credential is the llm_provider row written at creation.
+	// Pin its provider id here so resolution selects it (session-env providers are
+	// otherwise skipped without an explicit id) and does not clobber its key with
+	// the now-empty env. Only when the env still has no key for the family — an env
+	// that carries a (possibly rotated) key must keep re-bootstrapping it.
+	if providerID == "" && sessionID != "" && preferredProviderFamily != "" && !envHasProviderKeyForFamily(envItems, preferredProviderFamily) {
+		if candidate := sessionEnvProviderID(sessionID, preferredProviderFamily); hasEnabledLLMProviderID(ctx, store, candidate) {
+			providerID = candidate
+		}
+	}
 	// Skip the env/default bootstrap entirely when the request already names a
 	// provider that exists. The facade hot path always passes a concrete
 	// provider id from the token scope, so this avoids a redundant pair of
@@ -666,6 +679,29 @@ func hasEnabledLLMProviderID(ctx context.Context, store *ConfigStore, providerID
 		}
 	}
 	return false
+}
+
+// envHasProviderKeyForFamily reports whether the given env carries a usable
+// provider credential for the family. Unlike hasOpenAIEnvProviderInput it checks
+// for an actual key (not just an endpoint), so callers can distinguish "the env
+// can (re)bootstrap a provider with a fresh key" from "the env has no key and we
+// should reuse the already-persisted session-env provider".
+func envHasProviderKeyForFamily(envItems []SessionEnvVar, providerFamily string) bool {
+	switch normalizeLLMProviderType(providerFamily) {
+	case llmProviderFamilyAnthropic:
+		return strings.TrimSpace(firstNonEmpty(
+			lookupEnvItemValue(envItems, "ANTHROPIC_API_KEY"),
+			lookupEnvItemValue(envItems, "ANTHROPIC_AUTH_TOKEN"),
+			lookupEnvItemValue(envItems, "LLM_API_KEY"),
+		)) != ""
+	case llmProviderFamilyOpenAI:
+		return strings.TrimSpace(firstNonEmpty(
+			lookupEnvItemValue(envItems, "LLM_API_KEY"),
+			lookupEnvItemValue(envItems, "OPENAI_API_KEY"),
+		)) != ""
+	default:
+		return false
+	}
 }
 
 func hasConfiguredLLMProviderForFamily(ctx context.Context, store *ConfigStore, providerFamily string) bool {

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -589,7 +589,7 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	if len(providers) == 0 {
 		return LLMResolvedTarget{}, fmt.Errorf("llm provider is not configured")
 	}
-	model, provider, wireAPI, ok, err := selectLLMModelAndProvider(ctx, store, models, providers, requestedModel, "", providerID)
+	model, provider, wireAPI, ok, err := selectLLMModelAndProvider(ctx, store, models, providers, requestedModel, preferredProviderFamily, providerID)
 	if err != nil {
 		return LLMResolvedTarget{}, err
 	}

--- a/pkg/agentcompose/llm_facade.go
+++ b/pkg/agentcompose/llm_facade.go
@@ -1,0 +1,520 @@
+package agentcompose
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	protocolbridge "github.com/chaitin/ai-api-protocol-bridge"
+	"github.com/labstack/echo/v4"
+)
+
+const runtimeLLMFacadePrefix = "/api/runtime/sessions/"
+
+func IsRuntimeLLMFacadeRequest(r *http.Request) bool {
+	if r == nil || r.Method != http.MethodPost {
+		return false
+	}
+	path := r.URL.Path
+	if !strings.HasPrefix(path, runtimeLLMFacadePrefix) {
+		return false
+	}
+	parts := strings.Split(strings.TrimPrefix(path, runtimeLLMFacadePrefix), "/")
+	if len(parts) < 5 || parts[0] == "" || parts[1] != "llm" {
+		return false
+	}
+	switch {
+	case len(parts) == 5 && parts[2] == "openai" && parts[3] == "v1" && parts[4] == "responses":
+		return true
+	case len(parts) == 6 && parts[2] == "openai" && parts[3] == "v1" && parts[4] == "chat" && parts[5] == "completions":
+		return true
+	case len(parts) == 5 && parts[2] == "anthropic" && parts[3] == "v1" && parts[4] == "messages":
+		return true
+	default:
+		return false
+	}
+}
+
+func registerRuntimeLLMFacadeRoutes(app *echo.Echo, service *Service) {
+	app.POST("/api/runtime/sessions/:session_id/llm/openai/v1/responses", service.handleRuntimeLLMResponses)
+	app.POST("/api/runtime/sessions/:session_id/llm/openai/v1/chat/completions", service.handleRuntimeLLMChatCompletions)
+	app.POST("/api/runtime/sessions/:session_id/llm/anthropic/v1/messages", service.handleRuntimeLLMAnthropicMessages)
+}
+
+func (s *Service) handleRuntimeLLMResponses(c echo.Context) error {
+	return s.handleRuntimeLLM(c, protocolbridge.ProtocolOpenAIResponses, llmAPIProtocolResponses)
+}
+
+func (s *Service) handleRuntimeLLMChatCompletions(c echo.Context) error {
+	return s.handleRuntimeLLM(c, protocolbridge.ProtocolOpenAIChat, llmAPIProtocolChatCompletions)
+}
+
+func (s *Service) handleRuntimeLLMAnthropicMessages(c echo.Context) error {
+	return s.handleRuntimeLLM(c, protocolbridge.ProtocolAnthropicMessages, llmAPIProtocolMessages)
+}
+
+func (s *Service) handleRuntimeLLM(c echo.Context, inboundProtocol protocolbridge.Protocol, facadeWireAPI string) error {
+	sessionID := strings.TrimSpace(c.Param("session_id"))
+	rawToken := bearerToken(c.Request().Header.Get("Authorization"))
+	if sessionID == "" || rawToken == "" {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "llm facade token is required"})
+	}
+	token, err := s.configDB.GetLLMFacadeToken(c.Request().Context(), rawToken)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid llm facade token"})
+	}
+	now := time.Now().UTC()
+	if token.SessionID != sessionID || !token.RevokedAt.IsZero() || (!token.ExpiresAt.IsZero() && now.After(token.ExpiresAt)) {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "llm facade token is not valid for this session"})
+	}
+	if token.WireAPI != "" && normalizeLLMWireAPI(token.WireAPI) != normalizeLLMWireAPI(facadeWireAPI) {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "llm facade token wire api mismatch"})
+	}
+	session, err := s.store.GetSession(c.Request().Context(), sessionID)
+	if err != nil {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "session is not available"})
+	}
+	if session.Summary.VMStatus == VMStatusStopped || session.Summary.VMStatus == VMStatusFailed {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "session is not running"})
+	}
+	body, err := io.ReadAll(io.LimitReader(c.Request().Body, 64<<20))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "read llm request failed"})
+	}
+	inboundAdapter, err := llmProtocolAdapter(inboundProtocol)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	llmReq, err := inboundAdapter.DecodeRequest(body)
+	if err != nil {
+		raw, status := inboundAdapter.EncodeError(err)
+		return writeRuntimeLLMEncodedError(c, raw, status)
+	}
+	model := strings.TrimSpace(llmReq.Model)
+	if model == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "llm model is required"})
+	}
+	if token.Model != "" && model != "" && token.Model != model {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "llm facade token model mismatch"})
+	}
+	target, err := resolveRuntimeLLMTarget(c.Request().Context(), s.config, s.configDB, firstNonEmpty(token.Model, model), token.ProviderID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	if token.ProviderID != "" && token.ProviderID != target.Provider.ID {
+		return c.JSON(http.StatusForbidden, map[string]string{"error": "llm facade token provider mismatch"})
+	}
+	upstreamProtocol, upstreamEndpoint, err := llmUpstreamProtocolAndEndpoint(target)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	upstreamBody, err := encodeRuntimeLLMUpstreamRequest(inboundProtocol, upstreamProtocol, target, llmReq)
+	if err != nil {
+		raw, status := inboundAdapter.EncodeError(err)
+		return writeRuntimeLLMEncodedError(c, raw, status)
+	}
+	upstreamReq, err := http.NewRequestWithContext(c.Request().Context(), http.MethodPost, upstreamEndpoint, bytes.NewReader(upstreamBody))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "create upstream llm request failed"})
+	}
+	copyRuntimeLLMHeaders(upstreamReq.Header, c.Request().Header)
+	applyLLMForwardHeaders(upstreamReq.Header, target.Headers)
+	resp, err := s.llm.client.Do(upstreamReq)
+	if err != nil {
+		return c.JSON(http.StatusBadGateway, map[string]string{"error": "call upstream llm failed"})
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		copyRuntimeLLMResponseHeaders(c.Response().Header(), resp.Header)
+		c.Response().WriteHeader(resp.StatusCode)
+		if err := copyRuntimeLLMResponseBody(c.Response().Writer, resp); err != nil && !errors.Is(err, http.ErrAbortHandler) {
+			return err
+		}
+		return nil
+	}
+	if runtimeLLMResponseShouldFlush(resp.Header) {
+		return bridgeRuntimeLLMStreamResponse(c, resp, inboundProtocol, upstreamProtocol, normalizeLLMProviderType(target.Provider.ProviderType), target.Model.Name)
+	}
+	upstreamRespBody, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if err != nil {
+		return c.JSON(http.StatusBadGateway, map[string]string{"error": "read upstream llm response failed"})
+	}
+	clientBody, err := encodeRuntimeLLMClientResponse(inboundProtocol, upstreamProtocol, target, upstreamRespBody)
+	if err != nil {
+		raw, status := inboundAdapter.EncodeError(err)
+		return writeRuntimeLLMEncodedError(c, raw, status)
+	}
+	copyRuntimeLLMResponseHeaders(c.Response().Header(), resp.Header)
+	c.Response().Header().Set("Content-Type", "application/json")
+	c.Response().Header().Del("Content-Length")
+	c.Response().WriteHeader(resp.StatusCode)
+	_, err = c.Response().Writer.Write(clientBody)
+	return err
+}
+
+func llmProtocolAdapter(protocol protocolbridge.Protocol) (protocolbridge.Adapter, error) {
+	switch protocol {
+	case protocolbridge.ProtocolOpenAIResponses:
+		return protocolbridge.NewOpenAIResponsesAdapter(), nil
+	case protocolbridge.ProtocolOpenAIChat:
+		return protocolbridge.NewOpenAIChatAdapter(), nil
+	case protocolbridge.ProtocolAnthropicMessages:
+		return protocolbridge.NewAnthropicMessagesAdapter(), nil
+	default:
+		return nil, fmt.Errorf("unsupported llm protocol %q", protocol)
+	}
+}
+
+func llmUpstreamProtocolAndEndpoint(target LLMResolvedTarget) (protocolbridge.Protocol, string, error) {
+	switch normalizeLLMProviderType(target.Provider.ProviderType) {
+	case llmProviderFamilyAnthropic:
+		return protocolbridge.ProtocolAnthropicMessages, llmEndpointForProvider(target.Provider, llmAPIProtocolMessages), nil
+	case llmProviderFamilyOpenAI:
+		switch normalizeLLMWireAPI(target.WireAPI) {
+		case llmAPIProtocolChatCompletions:
+			return protocolbridge.ProtocolOpenAIChat, llmEndpointForProvider(target.Provider, llmAPIProtocolChatCompletions), nil
+		case llmAPIProtocolResponses:
+			return protocolbridge.ProtocolOpenAIResponses, llmEndpointForProvider(target.Provider, llmAPIProtocolResponses), nil
+		default:
+			return "", "", fmt.Errorf("unsupported openai wire api %q", target.WireAPI)
+		}
+	default:
+		return "", "", fmt.Errorf("unsupported llm provider family %q", target.Provider.ProviderType)
+	}
+}
+
+func encodeRuntimeLLMUpstreamRequest(inboundProtocol, upstreamProtocol protocolbridge.Protocol, target LLMResolvedTarget, req *protocolbridge.LLMRequest) ([]byte, error) {
+	if inboundProtocol == upstreamProtocol {
+		adapter, err := llmProtocolAdapter(upstreamProtocol)
+		if err != nil {
+			return nil, err
+		}
+		return adapter.EncodeRequest(req, protocolbridge.EncodeRequestOptions{Model: target.Model.Name})
+	}
+	bridge, ok := protocolbridge.NewCrossFamilyBridge(inboundProtocol, normalizeLLMProviderType(target.Provider.ProviderType))
+	if !ok || bridge.UpstreamProtocol() != upstreamProtocol {
+		return nil, fmt.Errorf("unsupported llm protocol bridge from %q to %q", inboundProtocol, upstreamProtocol)
+	}
+	return bridge.EncodeUpstreamRequest(req, protocolbridge.EncodeRequestOptions{Model: target.Model.Name})
+}
+
+func encodeRuntimeLLMClientResponse(inboundProtocol, upstreamProtocol protocolbridge.Protocol, target LLMResolvedTarget, upstreamBody []byte) ([]byte, error) {
+	inboundAdapter, err := llmProtocolAdapter(inboundProtocol)
+	if err != nil {
+		return nil, err
+	}
+	var llmResp *protocolbridge.LLMResponse
+	if inboundProtocol == upstreamProtocol {
+		upstreamAdapter, err := llmProtocolAdapter(upstreamProtocol)
+		if err != nil {
+			return nil, err
+		}
+		llmResp, err = upstreamAdapter.DecodeResponse(upstreamBody)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		bridge, ok := protocolbridge.NewCrossFamilyBridge(inboundProtocol, normalizeLLMProviderType(target.Provider.ProviderType))
+		if !ok || bridge.UpstreamProtocol() != upstreamProtocol {
+			return nil, fmt.Errorf("unsupported llm protocol bridge from %q to %q", inboundProtocol, upstreamProtocol)
+		}
+		llmResp, err = bridge.DecodeUpstreamResponse(upstreamBody)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return inboundAdapter.EncodeResponse(llmResp, protocolbridge.EncodeResponseOptions{Model: target.Model.Name})
+}
+
+func writeRuntimeLLMEncodedError(c echo.Context, raw []byte, status int) error {
+	if status == 0 {
+		status = http.StatusBadRequest
+	}
+	return c.Blob(status, "application/json", raw)
+}
+
+func bridgeRuntimeLLMStreamResponse(c echo.Context, resp *http.Response, inboundProtocol, upstreamProtocol protocolbridge.Protocol, upstreamFamily, model string) error {
+	decoder, encoder, err := runtimeLLMStreamBridge(inboundProtocol, upstreamProtocol, upstreamFamily, model)
+	if err != nil {
+		return err
+	}
+	copyRuntimeLLMResponseHeaders(c.Response().Header(), resp.Header)
+	c.Response().Header().Set("Content-Type", "text/event-stream")
+	c.Response().Header().Del("Content-Length")
+	c.Response().Header().Del("Content-Encoding")
+	c.Response().WriteHeader(resp.StatusCode)
+	flusher, _ := c.Response().Writer.(http.Flusher)
+	writeEvents := func(events []protocolbridge.RawStreamEvent) error {
+		for _, event := range events {
+			if err := writeRawSSEEvent(c.Response().Writer, event); err != nil {
+				return err
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		return nil
+	}
+	err = readRawSSEEvents(resp.Body, func(event protocolbridge.RawStreamEvent) error {
+		parts, decodeErr := decoder.Decode(event)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		for _, part := range parts {
+			events, encodeErr := encoder.Encode(part)
+			if encodeErr != nil {
+				return encodeErr
+			}
+			if err := writeEvents(events); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		_ = writeEvents(encoder.EncodeError(err))
+		return nil
+	}
+	parts, err := decoder.Close()
+	if err != nil {
+		_ = writeEvents(encoder.EncodeError(err))
+		return nil
+	}
+	for _, part := range parts {
+		events, encodeErr := encoder.Encode(part)
+		if encodeErr != nil {
+			_ = writeEvents(encoder.EncodeError(encodeErr))
+			return nil
+		}
+		if err := writeEvents(events); err != nil {
+			return err
+		}
+	}
+	events, err := encoder.Close()
+	if err != nil {
+		_ = writeEvents(encoder.EncodeError(err))
+		return nil
+	}
+	return writeEvents(events)
+}
+
+func runtimeLLMStreamBridge(inboundProtocol, upstreamProtocol protocolbridge.Protocol, upstreamFamily string, model string) (protocolbridge.StreamDecoder, protocolbridge.StreamEncoder, error) {
+	if inboundProtocol == upstreamProtocol {
+		adapter, err := llmProtocolAdapter(inboundProtocol)
+		if err != nil {
+			return nil, nil, err
+		}
+		decoder, err := adapter.NewStreamDecoder(protocolbridge.StreamDecodeOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+		encoder, err := adapter.NewStreamEncoder(protocolbridge.StreamEncodeOptions{Model: model})
+		if err != nil {
+			return nil, nil, err
+		}
+		return decoder, encoder, nil
+	}
+	bridge, ok := protocolbridge.NewCrossFamilyBridge(inboundProtocol, upstreamFamily)
+	if !ok || bridge.UpstreamProtocol() != upstreamProtocol {
+		return nil, nil, fmt.Errorf("unsupported llm stream bridge from %q to %q", inboundProtocol, upstreamProtocol)
+	}
+	decoder, err := bridge.NewStreamDecoder(protocolbridge.StreamDecodeOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	encoder, err := bridge.NewStreamEncoder(protocolbridge.StreamEncodeOptions{Model: model})
+	if err != nil {
+		return nil, nil, err
+	}
+	return decoder, encoder, nil
+}
+
+func bearerToken(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 7 && strings.EqualFold(value[:7], "Bearer ") {
+		return strings.TrimSpace(value[7:])
+	}
+	return ""
+}
+
+func copyRuntimeLLMHeaders(dst http.Header, src http.Header) {
+	for key, values := range src {
+		if forbiddenRuntimeLLMHeader(key) {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func copyRuntimeLLMResponseHeaders(dst http.Header, src http.Header) {
+	for key, values := range src {
+		if forbiddenRuntimeLLMResponseHeader(key) {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func forbiddenRuntimeLLMResponseHeader(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "content-length", "content-encoding":
+		return true
+	default:
+		return false
+	}
+}
+
+func copyRuntimeLLMResponseBody(dst io.Writer, resp *http.Response) error {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+	if !runtimeLLMResponseShouldFlush(resp.Header) {
+		_, err := io.Copy(dst, resp.Body)
+		return err
+	}
+	flusher, ok := dst.(http.Flusher)
+	if !ok {
+		_, err := io.Copy(dst, resp.Body)
+		return err
+	}
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
+				return writeErr
+			}
+			flusher.Flush()
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return readErr
+		}
+	}
+}
+
+func runtimeLLMResponseShouldFlush(header http.Header) bool {
+	contentType := strings.ToLower(header.Get("Content-Type"))
+	return strings.Contains(contentType, "text/event-stream")
+}
+
+func forbiddenRuntimeLLMHeader(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return true
+	}
+	if runtimeLLMHeaderNameContainsSensitiveToken(lower) {
+		return true
+	}
+	switch lower {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie", "host", "content-length", "accept-encoding":
+		return true
+	default:
+		return false
+	}
+}
+
+func runtimeLLMHeaderNameContainsSensitiveToken(lower string) bool {
+	parts := strings.FieldsFunc(lower, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.'
+	})
+	for _, part := range parts {
+		switch part {
+		case "token", "secret", "apikey", "auth":
+			return true
+		}
+	}
+	return strings.Contains(lower, "api-key")
+}
+
+func readRawSSEEvents(r io.Reader, handle func(protocolbridge.RawStreamEvent) error) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	var event protocolbridge.RawStreamEvent
+	var data []string
+	flush := func() error {
+		if event.Event == "" && event.ID == "" && event.Retry == nil && len(data) == 0 {
+			return nil
+		}
+		event.Data = []byte(strings.Join(data, "\n"))
+		if err := handle(event); err != nil {
+			return err
+		}
+		event = protocolbridge.RawStreamEvent{}
+		data = nil
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := flush(); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, ok := strings.Cut(line, ":")
+		if ok && strings.HasPrefix(value, " ") {
+			value = value[1:]
+		}
+		if !ok {
+			field = line
+			value = ""
+		}
+		switch field {
+		case "event":
+			event.Event = value
+		case "data":
+			data = append(data, value)
+		case "id":
+			event.ID = value
+		case "retry":
+			if retry, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+				event.Retry = &retry
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return flush()
+}
+
+func writeRawSSEEvent(w io.Writer, event protocolbridge.RawStreamEvent) error {
+	if event.ID != "" {
+		if _, err := fmt.Fprintf(w, "id: %s\n", event.ID); err != nil {
+			return err
+		}
+	}
+	if event.Event != "" {
+		if _, err := fmt.Fprintf(w, "event: %s\n", event.Event); err != nil {
+			return err
+		}
+	}
+	for _, line := range strings.Split(string(event.Data), "\n") {
+		if _, err := fmt.Fprintf(w, "data: %s\n", line); err != nil {
+			return err
+		}
+	}
+	if event.Retry != nil {
+		if _, err := fmt.Fprintf(w, "retry: %d\n", *event.Retry); err != nil {
+			return err
+		}
+	}
+	_, err := io.WriteString(w, "\n")
+	return err
+}

--- a/pkg/agentcompose/llm_facade.go
+++ b/pkg/agentcompose/llm_facade.go
@@ -61,7 +61,7 @@ func (s *Service) handleRuntimeLLMAnthropicMessages(c echo.Context) error {
 
 func (s *Service) handleRuntimeLLM(c echo.Context, inboundProtocol protocolbridge.Protocol, facadeWireAPI string) error {
 	sessionID := strings.TrimSpace(c.Param("session_id"))
-	rawToken := bearerToken(c.Request().Header.Get("Authorization"))
+	rawToken := runtimeLLMFacadeToken(c.Request().Header)
 	if sessionID == "" || rawToken == "" {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "llm facade token is required"})
 	}
@@ -341,6 +341,13 @@ func bearerToken(value string) string {
 		return strings.TrimSpace(value[7:])
 	}
 	return ""
+}
+
+func runtimeLLMFacadeToken(header http.Header) string {
+	if token := bearerToken(header.Get("Authorization")); token != "" {
+		return token
+	}
+	return strings.TrimSpace(header.Get("x-api-key"))
 }
 
 func copyRuntimeLLMHeaders(dst http.Header, src http.Header) {

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -1,0 +1,1407 @@
+package agentcompose
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/labstack/echo/v4"
+
+	appconfig "agent-compose/pkg/config"
+	agentcomposev1 "agent-compose/proto/agentcompose/v1"
+)
+
+func TestIsRuntimeLLMFacadeRequestMatchesOnlyRegisteredPOSTRoutes(t *testing.T) {
+	valid := []string{
+		"/api/runtime/sessions/session-1/llm/openai/v1/responses",
+		"/api/runtime/sessions/session-1/llm/openai/v1/chat/completions",
+		"/api/runtime/sessions/session-1/llm/anthropic/v1/messages",
+	}
+	for _, path := range valid {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		if !IsRuntimeLLMFacadeRequest(req) {
+			t.Fatalf("IsRuntimeLLMFacadeRequest(%q) = false, want true", path)
+		}
+	}
+
+	invalid := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/runtime/sessions/session-1/llm/openai/v1/responses"},
+		{http.MethodPost, "/api/runtime/sessions/session-1/llm/openai/v1/responses/extra"},
+		{http.MethodPost, "/api/runtime/sessions/session-1/not-llm/openai/v1/responses"},
+		{http.MethodPost, "/api/runtime/sessions/session-1/llm/openai/v1/unknown"},
+		{http.MethodPost, "/api/runtime/sessions/session-1/llm/anthropic/v1/messages/extra"},
+		{http.MethodPost, "/api/other/session-1/llm/openai/v1/responses"},
+	}
+	for _, tc := range invalid {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		if IsRuntimeLLMFacadeRequest(req) {
+			t.Fatalf("IsRuntimeLLMFacadeRequest(%s %q) = true, want false", tc.method, tc.path)
+		}
+	}
+}
+
+func TestRuntimeLLMFacadeForwardsWithSessionToken(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.LLMAPIKey = "provider-key"
+
+	var gotAuth string
+	var gotRuntimeAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotRuntimeAuth = r.Header.Get("X-Runtime-Auth")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-facade","model":"model-a","status":"completed","output_text":"ok"}`))
+	}))
+	t.Cleanup(upstream.Close)
+	service.config.LLMAPIEndpoint = upstream.URL
+	service.llm.client = upstream.Client()
+
+	session, err := service.store.CreateSession(ctx, "facade", "", "boxlite", "guest:latest", "", SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session.Summary.VMStatus = VMStatusRunning
+	if err := service.store.UpdateSession(ctx, session); err != nil {
+		t.Fatalf("UpdateSession returned error: %v", err)
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, "model-a", "default", llmAPIProtocolResponses, "test", "run-1")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken returned error: %v", err)
+	}
+	token.ExpiresAt = time.Now().Add(time.Hour)
+	if err := service.configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
+	}
+
+	app := echo.New()
+	registerRuntimeLLMFacadeRoutes(app, service)
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+session.Summary.ID+"/llm/openai/v1/responses", bytes.NewBufferString(`{"model":"model-a","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer "+tokenValue)
+	req.Header.Set("X-Runtime-Auth", "should-not-forward")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("facade status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer provider-key" {
+		t.Fatalf("upstream Authorization = %q, want provider auth", gotAuth)
+	}
+	if gotRuntimeAuth != "" {
+		t.Fatalf("runtime sensitive header forwarded: %q", gotRuntimeAuth)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+session.Summary.ID+"/llm/openai/v1/responses", bytes.NewBufferString(`{"model":"model-a","input":"hello"}`))
+	rec = httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token status = %d, want 401", rec.Code)
+	}
+}
+
+func TestRuntimeLLMFacadeFlushesSSEResponses(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.LLMAPIKey = "provider-key"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("event: message\ndata: hello\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte("event: done\ndata: [DONE]\n\n"))
+	}))
+	t.Cleanup(upstream.Close)
+	service.config.LLMAPIEndpoint = upstream.URL
+	service.llm.client = upstream.Client()
+
+	session, err := service.store.CreateSession(ctx, "facade-sse", "", "boxlite", "guest:latest", "", SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session.Summary.VMStatus = VMStatusRunning
+	if err := service.store.UpdateSession(ctx, session); err != nil {
+		t.Fatalf("UpdateSession returned error: %v", err)
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, "model-a", "default", llmAPIProtocolResponses, "test", "run-1")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken returned error: %v", err)
+	}
+	token.ExpiresAt = time.Now().Add(time.Hour)
+	if err := service.configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
+	}
+
+	app := echo.New()
+	registerRuntimeLLMFacadeRoutes(app, service)
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+session.Summary.ID+"/llm/openai/v1/responses", bytes.NewBufferString(`{"model":"model-a","input":"hello","stream":true}`))
+	req.Header.Set("Authorization", "Bearer "+tokenValue)
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("facade status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !rec.Flushed {
+		t.Fatalf("sse response was not flushed")
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "event: raw") || !strings.Contains(body, "event: response.completed") {
+		t.Fatalf("unexpected SSE body: %q", body)
+	}
+}
+
+func TestRuntimeLLMAnthropicFacadeForwardsWithSessionToken(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+
+	var gotAPIKey string
+	var gotAuth string
+	var gotVersion string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Errorf("upstream path = %q, want /v1/messages", r.URL.Path)
+		}
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotAuth = r.Header.Get("Authorization")
+		gotVersion = r.Header.Get("anthropic-version")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_facade","type":"message","model":"claude-test","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+	service.llm.client = upstream.Client()
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "anthropic",
+		Name:           "anthropic",
+		ProviderType:   llmProviderFamilyAnthropic,
+		DefaultWireAPI: llmAPIProtocolMessages,
+		BaseURL:        upstream.URL,
+		APIKey:         "provider-key",
+		AuthHeader:     "x-api-key",
+		AuthScheme:     "",
+		HeadersJSON:    `{"anthropic-version":"2023-06-01"}`,
+		Weight:         10,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "claude-test", Name: "claude-test", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+
+	session, err := service.store.CreateSession(ctx, "facade-claude", "", "boxlite", "guest:latest", "", SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session.Summary.VMStatus = VMStatusRunning
+	if err := service.store.UpdateSession(ctx, session); err != nil {
+		t.Fatalf("UpdateSession returned error: %v", err)
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, "claude-test", "anthropic", llmAPIProtocolMessages, "test", "run-1")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken returned error: %v", err)
+	}
+	token.ExpiresAt = time.Now().Add(time.Hour)
+	if err := service.configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
+	}
+
+	app := echo.New()
+	registerRuntimeLLMFacadeRoutes(app, service)
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic/v1/messages", bytes.NewBufferString(`{"model":"claude-test","messages":[{"role":"user","content":"hello"}]}`))
+	req.Header.Set("Authorization", "Bearer "+tokenValue)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("facade status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotAPIKey != "provider-key" {
+		t.Fatalf("upstream x-api-key = %q, want provider key", gotAPIKey)
+	}
+	if gotAuth != "" {
+		t.Fatalf("runtime Authorization forwarded to anthropic upstream: %q", gotAuth)
+	}
+	if gotVersion != "2023-06-01" {
+		t.Fatalf("upstream anthropic-version = %q, want 2023-06-01", gotVersion)
+	}
+}
+
+func TestRuntimeLLMOpenAIResponsesFacadeBridgesToAnthropicProvider(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+
+	var gotPath string
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		if r.Header.Get("x-api-key") != "provider-key" {
+			t.Errorf("upstream x-api-key = %q, want provider-key", r.Header.Get("x-api-key"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_bridge","type":"message","role":"assistant","model":"claude-test","content":[{"type":"text","text":"bridged"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":4}}`))
+	}))
+	t.Cleanup(upstream.Close)
+	service.llm.client = upstream.Client()
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "anthropic",
+		Name:           "anthropic",
+		ProviderType:   llmProviderFamilyAnthropic,
+		DefaultWireAPI: llmAPIProtocolMessages,
+		BaseURL:        upstream.URL,
+		APIKey:         "provider-key",
+		AuthHeader:     "x-api-key",
+		AuthScheme:     "",
+		HeadersJSON:    `{"anthropic-version":"2023-06-01"}`,
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "claude-test", Name: "claude-test", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+	session := createRunningLLMFacadeSession(t, ctx, service, "bridge-openai-anthropic")
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, "claude-test", "anthropic", llmAPIProtocolResponses, "test", "run-1")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken returned error: %v", err)
+	}
+	token.ExpiresAt = time.Now().Add(time.Hour)
+	if err := service.configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
+	}
+
+	app := echo.New()
+	registerRuntimeLLMFacadeRoutes(app, service)
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+session.Summary.ID+"/llm/openai/v1/responses", bytes.NewBufferString(`{"model":"claude-test","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer "+tokenValue)
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("facade status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/v1/messages" {
+		t.Fatalf("upstream path = %q, want /v1/messages", gotPath)
+	}
+	if !strings.Contains(gotBody, `"messages"`) || !strings.Contains(gotBody, `"model":"claude-test"`) {
+		t.Fatalf("upstream body was not anthropic messages: %s", gotBody)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"object":"response"`) || !strings.Contains(body, "bridged") {
+		t.Fatalf("facade body was not openai responses: %s", body)
+	}
+}
+
+func TestRuntimeLLMAnthropicFacadeBridgesToOpenAIResponsesProvider(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+
+	var gotPath string
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		if r.Header.Get("Authorization") != "Bearer provider-key" {
+			t.Errorf("upstream Authorization = %q, want provider auth", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_bridge","object":"response","status":"completed","model":"gpt-test","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"bridged"}]}],"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7}}`))
+	}))
+	t.Cleanup(upstream.Close)
+	service.llm.client = upstream.Client()
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "default",
+		Name:           "default",
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: llmAPIProtocolResponses,
+		BaseURL:        upstream.URL,
+		APIKey:         "provider-key",
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    `{}`,
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "gpt-test", Name: "gpt-test", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+	session := createRunningLLMFacadeSession(t, ctx, service, "bridge-anthropic-openai")
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, "gpt-test", "default", llmAPIProtocolMessages, "test", "run-1")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken returned error: %v", err)
+	}
+	token.ExpiresAt = time.Now().Add(time.Hour)
+	if err := service.configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
+	}
+
+	app := echo.New()
+	registerRuntimeLLMFacadeRoutes(app, service)
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic/v1/messages", bytes.NewBufferString(`{"model":"gpt-test","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}`))
+	req.Header.Set("Authorization", "Bearer "+tokenValue)
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("facade status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("upstream path = %q, want /v1/responses", gotPath)
+	}
+	if !strings.Contains(gotBody, `"input"`) || !strings.Contains(gotBody, `"model":"gpt-test"`) {
+		t.Fatalf("upstream body was not openai responses: %s", gotBody)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"type":"message"`) || !strings.Contains(body, "bridged") {
+		t.Fatalf("facade body was not anthropic messages: %s", body)
+	}
+}
+
+func TestAnthropicProviderCanBootstrapFromGenericLLMAPIKey(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_API_ENDPOINT", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	t.Setenv("LLM_API_KEY", "generic-provider-key")
+	t.Setenv("LLM_API_ENDPOINT", "https://anthropic.example.invalid/v1/messages")
+
+	target, err := resolveLLMTargetForProviderFamily(ctx, service.config, service.configDB, llmProviderFamilyAnthropic, "claude-test")
+	if err != nil {
+		t.Fatalf("resolveLLMTargetForProviderFamily returned error: %v", err)
+	}
+	if target.Provider.ID != "anthropic" {
+		t.Fatalf("provider id = %q, want anthropic", target.Provider.ID)
+	}
+	if target.Headers.Get("x-api-key") != "generic-provider-key" {
+		t.Fatalf("x-api-key = %q, want generic provider key", target.Headers.Get("x-api-key"))
+	}
+	if target.Provider.BaseURL != "https://anthropic.example.invalid/v1" {
+		t.Fatalf("provider base url = %q, want normalized anthropic base url", target.Provider.BaseURL)
+	}
+	if target.Endpoint != "https://anthropic.example.invalid/v1/messages" {
+		t.Fatalf("endpoint = %q, want anthropic messages endpoint", target.Endpoint)
+	}
+}
+
+func TestRuntimeLLMTargetDoesNotTreatGenericOpenAIEndpointAsAnthropic(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_API_ENDPOINT", "")
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("CLAUDE_MODEL", "")
+	t.Setenv("LLM_API_KEY", "generic-provider-key")
+	t.Setenv("LLM_API_ENDPOINT", "https://openai.example.invalid/v1/responses")
+	service, _, _ := newTestServiceAPIHarness(t)
+
+	target, err := resolveRuntimeLLMTarget(ctx, service.config, service.configDB, "gpt-test", "")
+	if err != nil {
+		t.Fatalf("resolveRuntimeLLMTarget returned error: %v", err)
+	}
+	if target.Provider.ID != "default" {
+		t.Fatalf("provider id = %q, want default openai provider", target.Provider.ID)
+	}
+	if target.Provider.ProviderType != llmProviderFamilyOpenAI {
+		t.Fatalf("provider type = %q, want openai", target.Provider.ProviderType)
+	}
+}
+
+func createRunningLLMFacadeSession(t *testing.T, ctx context.Context, service *Service, title string) *Session {
+	t.Helper()
+	session, err := service.store.CreateSession(ctx, title, "", "boxlite", "guest:latest", "", SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session.Summary.VMStatus = VMStatusRunning
+	if err := service.store.UpdateSession(ctx, session); err != nil {
+		t.Fatalf("UpdateSession returned error: %v", err)
+	}
+	return session
+}
+
+func TestAnthropicProviderCanBootstrapFromAuthToken(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "auth-token")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://aiapi.chaitin.net")
+	service, _, _ := newTestServiceAPIHarness(t)
+
+	target, err := resolveLLMTargetForProviderFamily(ctx, service.config, service.configDB, llmProviderFamilyAnthropic, "kimi-k2.6")
+	if err != nil {
+		t.Fatalf("resolveLLMTargetForProviderFamily returned error: %v", err)
+	}
+	if target.Headers.Get("Authorization") != "Bearer auth-token" {
+		t.Fatalf("Authorization = %q, want bearer auth token", target.Headers.Get("Authorization"))
+	}
+	if target.Headers.Get("x-api-key") != "" {
+		t.Fatalf("x-api-key = %q, want empty when auth token is used", target.Headers.Get("x-api-key"))
+	}
+	if target.Provider.BaseURL != "https://aiapi.chaitin.net/v1" {
+		t.Fatalf("provider base url = %q, want normalized aiapi base url", target.Provider.BaseURL)
+	}
+}
+
+func TestProviderForwardHeadersFiltersManagedHeaders(t *testing.T) {
+	headers, err := providerForwardHeaders(LLMProvider{
+		APIKey:      "provider-key",
+		AuthHeader:  "Authorization",
+		AuthScheme:  "Bearer",
+		HeadersJSON: `{"Content-Type":"text/plain","Authorization":"Bearer wrong","X-Provider":"ok"}`,
+	})
+	if err != nil {
+		t.Fatalf("providerForwardHeaders returned error: %v", err)
+	}
+	if got := headers.Get("Content-Type"); got != "" {
+		t.Fatalf("Content-Type = %q, want filtered", got)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer provider-key" {
+		t.Fatalf("Authorization = %q, want provider auth", got)
+	}
+	if got := headers.Get("X-Provider"); got != "ok" {
+		t.Fatalf("X-Provider = %q, want ok", got)
+	}
+}
+
+func TestNewLLMFacadeTokenDoesNotExpireByDefault(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	tokenValue, token, err := newLLMFacadeToken("session-1", "model-a", "default", llmAPIProtocolResponses, "test", "run-1")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken returned error: %v", err)
+	}
+	if !token.ExpiresAt.IsZero() {
+		t.Fatalf("ExpiresAt = %v, want zero for session-scoped token", token.ExpiresAt)
+	}
+	if err := service.configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
+	}
+	stored, err := service.configDB.GetLLMFacadeToken(ctx, tokenValue)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if !stored.ExpiresAt.IsZero() {
+		t.Fatalf("stored ExpiresAt = %v, want zero for session-scoped token", stored.ExpiresAt)
+	}
+}
+
+func TestManagedRuntimeEnvMapKeepsFacadeKeyAliases(t *testing.T) {
+	userEnv := runtimeEnvMap([]SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://provider.example.invalid/v1"},
+		{Name: "OPENAI_API_KEY", Value: "provider-key"},
+		{Name: "DATABASE_PASSWORD", Value: "db-secret", Secret: true},
+	})
+	if _, ok := userEnv["OPENAI_API_KEY"]; ok {
+		t.Fatalf("OPENAI_API_KEY leaked from user runtime env: %#v", userEnv)
+	}
+	if userEnv["DATABASE_PASSWORD"] != "db-secret" {
+		t.Fatalf("DATABASE_PASSWORD = %q, want db-secret", userEnv["DATABASE_PASSWORD"])
+	}
+
+	managedEnv := managedRuntimeEnvMap([]SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "http://agent-compose.test/api/runtime/sessions/s1/llm/openai/v1"},
+		{Name: "LLM_API_KEY", Value: "facade-token"},
+		{Name: "LLM_API_PROTOCOL", Value: llmAPIProtocolResponses},
+		{Name: "OPENAI_API_KEY", Value: "facade-token"},
+	})
+	if managedEnv["OPENAI_API_KEY"] != "facade-token" {
+		t.Fatalf("managed OPENAI_API_KEY = %q, want facade token", managedEnv["OPENAI_API_KEY"])
+	}
+	if managedEnv["LLM_API_KEY"] != "facade-token" {
+		t.Fatalf("managed LLM_API_KEY = %q, want facade token", managedEnv["LLM_API_KEY"])
+	}
+	if managedEnv["LLM_API_ENDPOINT"] != "http://agent-compose.test/api/runtime/sessions/s1/llm/openai/v1" {
+		t.Fatalf("managed LLM_API_ENDPOINT = %q, want facade endpoint", managedEnv["LLM_API_ENDPOINT"])
+	}
+}
+
+func TestEnsureSessionLLMFacadeConfigUsesRequestedModel(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "default",
+		Name:           "default",
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: llmAPIProtocolResponses,
+		BaseURL:        "https://llm.example.invalid/v1",
+		APIKey:         "provider-key",
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    "{}",
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "model-a", Name: "model-a", DefaultModel: true, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig model-a returned error: %v", err)
+	}
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "default",
+		Name:           "default",
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: llmAPIProtocolResponses,
+		BaseURL:        "https://llm.example.invalid/v1",
+		APIKey:         "provider-key",
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    "{}",
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "model-b", Name: "model-b", DefaultModel: false, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig model-b returned error: %v", err)
+	}
+	session := createRunningLLMFacadeSession(t, ctx, service, "requested-model")
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "model-b", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["AGENT_COMPOSE_SESSION_TOKEN"] == "" {
+		t.Fatalf("AGENT_COMPOSE_SESSION_TOKEN missing from managed env: %#v", env)
+	}
+	if env["LLM_API_KEY"] != env["AGENT_COMPOSE_SESSION_TOKEN"] {
+		t.Fatalf("LLM_API_KEY = %q, want facade token alias", env["LLM_API_KEY"])
+	}
+	if env["LLM_API_ENDPOINT"] != "http://agent-compose.test/api/runtime/sessions/"+session.Summary.ID+"/llm/openai/v1" {
+		t.Fatalf("LLM_API_ENDPOINT = %q, want facade endpoint alias", env["LLM_API_ENDPOINT"])
+	}
+	configPath := filepath.Join(hostSessionHome(session), ".codex", "config.toml")
+	payload, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", configPath, err)
+	}
+	if !strings.Contains(string(payload), `model = "model-b"`) {
+		t.Fatalf("codex config did not use requested model-b: %s", string(payload))
+	}
+}
+
+func TestEnsureSessionLLMFacadeConfigBootstrapsFromSessionEnvProvider(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-provider-env")
+	session.EnvItems = []SessionEnvVar{{Name: "SAFE_ENV", Value: "safe"}}
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-openai.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-provider-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "session-model"},
+	}
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["AGENT_COMPOSE_SESSION_TOKEN"] == "" {
+		t.Fatalf("AGENT_COMPOSE_SESSION_TOKEN missing from managed env: %#v", env)
+	}
+	if env["LLM_API_KEY"] != env["AGENT_COMPOSE_SESSION_TOKEN"] || env["OPENAI_API_KEY"] != env["AGENT_COMPOSE_SESSION_TOKEN"] {
+		t.Fatalf("managed env did not replace provider keys with facade token: %#v", env)
+	}
+	if strings.Contains(strings.Join([]string{env["LLM_API_KEY"], env["OPENAI_API_KEY"]}, " "), "session-provider-key") {
+		t.Fatalf("session provider key leaked into managed env: %#v", env)
+	}
+	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1: %#v", len(providers), providers)
+	}
+	if providers[0].ID != sessionEnvProviderID(session.Summary.ID, llmProviderFamilyOpenAI) || providers[0].Scope != llmProviderScopeSessionEnv {
+		t.Fatalf("provider identity = %#v, want session env provider", providers[0])
+	}
+	if providers[0].APIKey != "session-provider-key" {
+		t.Fatalf("provider API key = %q, want session provider key", providers[0].APIKey)
+	}
+	if providers[0].BaseURL != "https://session-openai.example.invalid/v1" {
+		t.Fatalf("provider base url = %q, want session endpoint", providers[0].BaseURL)
+	}
+	if envMap := sessionEnvMap(session.EnvItems); envMap["LLM_API_KEY"] != "" || envMap["OPENAI_API_KEY"] != "" {
+		t.Fatalf("provider key present in session env: %#v", session.EnvItems)
+	}
+}
+
+func TestSessionEnvProviderDoesNotOverrideConfiguredProvider(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "default",
+		Name:           "default",
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: llmAPIProtocolResponses,
+		BaseURL:        "https://configured.example.invalid/v1",
+		APIKey:         "configured-key",
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    "{}",
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "configured-model", Name: "configured-model", DefaultModel: true, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+	session := createRunningLLMFacadeSession(t, ctx, service, "configured-provider")
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "session-model"},
+	}
+
+	if _, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "configured-model", "test", "run-1"); err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1: %#v", len(providers), providers)
+	}
+	if providers[0].APIKey != "configured-key" || providers[0].BaseURL != "https://configured.example.invalid/v1" {
+		t.Fatalf("configured provider was overridden: %#v", providers[0])
+	}
+}
+
+func TestSessionEnvGenericMessagesEndpointBootstrapsOnlyAnthropicProvider(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-anthropic-provider-env")
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-anthropic.example.invalid/v1/messages"},
+		{Name: "LLM_API_KEY", Value: "session-provider-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "claude-session"},
+	}
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "claude", "", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["ANTHROPIC_API_KEY"] != env["AGENT_COMPOSE_SESSION_TOKEN"] {
+		t.Fatalf("ANTHROPIC_API_KEY = %q, want facade token", env["ANTHROPIC_API_KEY"])
+	}
+	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want only anthropic provider: %#v", len(providers), providers)
+	}
+	if providers[0].ID != sessionEnvProviderID(session.Summary.ID, llmProviderFamilyAnthropic) || providers[0].ProviderType != llmProviderFamilyAnthropic || providers[0].Scope != llmProviderScopeSessionEnv {
+		t.Fatalf("provider = %#v, want session-scoped anthropic provider", providers[0])
+	}
+	if providers[0].BaseURL != "https://session-anthropic.example.invalid/v1" {
+		t.Fatalf("provider base url = %q, want normalized anthropic base url", providers[0].BaseURL)
+	}
+}
+
+func TestSessionEnvProvidersAreScopedPerSession(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+
+	sessionA := createRunningLLMFacadeSession(t, ctx, service, "session-env-a")
+	sessionA.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-a.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-key-a", Secret: true},
+		{Name: "LLM_MODEL", Value: "session-model-a"},
+	}
+	sessionB := createRunningLLMFacadeSession(t, ctx, service, "session-env-b")
+	sessionB.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-b.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-key-b", Secret: true},
+		{Name: "LLM_MODEL", Value: "session-model-b"},
+	}
+
+	if _, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, sessionA, "codex", "", "test", "run-a"); err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig(session A) returned error: %v", err)
+	}
+	if _, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, sessionB, "codex", "", "test", "run-b"); err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig(session B) returned error: %v", err)
+	}
+
+	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	byID := map[string]LLMProvider{}
+	for _, provider := range providers {
+		byID[provider.ID] = provider
+	}
+	providerA := byID[sessionEnvProviderID(sessionA.Summary.ID, llmProviderFamilyOpenAI)]
+	providerB := byID[sessionEnvProviderID(sessionB.Summary.ID, llmProviderFamilyOpenAI)]
+	if providerA.APIKey != "session-key-a" || providerA.BaseURL != "https://session-a.example.invalid/v1" || providerA.Scope != llmProviderScopeSessionEnv {
+		t.Fatalf("session A provider = %#v", providerA)
+	}
+	if providerB.APIKey != "session-key-b" || providerB.BaseURL != "https://session-b.example.invalid/v1" || providerB.Scope != llmProviderScopeSessionEnv {
+		t.Fatalf("session B provider = %#v", providerB)
+	}
+	models, err := service.configDB.ListEnabledLLMModels(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMModels returned error: %v", err)
+	}
+	modelsByID := map[string]bool{}
+	for _, model := range models {
+		modelsByID[model.ID] = true
+	}
+	if !modelsByID["session-model-a"] || !modelsByID["session-model-b"] {
+		t.Fatalf("models = %#v, want both session models", models)
+	}
+}
+
+func TestSessionEnvProviderSelectionUsesAgentFamilyPreference(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_API_ENDPOINT", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("CLAUDE_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-env-agent-family")
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-openai.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-openai-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "shared-session-model"},
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://session-anthropic.example.invalid/v1"},
+		{Name: "ANTHROPIC_API_KEY", Value: "session-anthropic-key", Secret: true},
+		{Name: "ANTHROPIC_MODEL", Value: "shared-session-model"},
+	}
+
+	claudeEnv, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "claude", "", "test", "run-claude")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig(claude) returned error: %v", err)
+	}
+	claudeToken, err := service.configDB.GetLLMFacadeToken(ctx, claudeEnv["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken(claude) returned error: %v", err)
+	}
+	if claudeToken.ProviderID != sessionEnvProviderID(session.Summary.ID, llmProviderFamilyAnthropic) {
+		t.Fatalf("claude provider id = %q, want anthropic session provider", claudeToken.ProviderID)
+	}
+
+	codexEnv, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "", "test", "run-codex")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig(codex) returned error: %v", err)
+	}
+	codexToken, err := service.configDB.GetLLMFacadeToken(ctx, codexEnv["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken(codex) returned error: %v", err)
+	}
+	if codexToken.ProviderID != sessionEnvProviderID(session.Summary.ID, llmProviderFamilyOpenAI) {
+		t.Fatalf("codex provider id = %q, want openai session provider", codexToken.ProviderID)
+	}
+}
+
+func TestSessionEnvProviderIsNotSelectedWithoutProviderID(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-env-isolated")
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-only.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-only-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "session-only-model"},
+	}
+	if _, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "", "test", "run-1"); err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+
+	target, err := resolveLLMTarget(ctx, service.config, service.configDB, "session-only-model")
+	if err != nil {
+		t.Fatalf("resolveLLMTarget returned error: %v", err)
+	}
+	if target.Provider.ID == sessionEnvProviderID(session.Summary.ID, llmProviderFamilyOpenAI) || target.Provider.APIKey == "session-only-key" {
+		t.Fatalf("daemon target selected session env provider: %#v", target.Provider)
+	}
+	if target.Provider.ID != llmProviderIDDefaultOpenAI || target.Provider.Scope != llmProviderScopeEnvDefault {
+		t.Fatalf("daemon target = %#v, want default env provider", target.Provider)
+	}
+}
+
+func TestSessionEnvProviderResolutionWithProviderIDDoesNotBootstrapDefault(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-env-provider-id")
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-provider-id.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-provider-id-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "session-provider-id-model"},
+	}
+	if _, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "", "test", "run-1"); err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+
+	providerID := sessionEnvProviderID(session.Summary.ID, llmProviderFamilyOpenAI)
+	target, err := resolveRuntimeLLMTarget(ctx, service.config, service.configDB, "session-provider-id-model", providerID)
+	if err != nil {
+		t.Fatalf("resolveRuntimeLLMTarget returned error: %v", err)
+	}
+	if target.Provider.ID != providerID {
+		t.Fatalf("target provider = %#v, want session env provider", target.Provider)
+	}
+	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 || providers[0].ID != providerID {
+		t.Fatalf("providers = %#v, want only session env provider", providers)
+	}
+}
+
+func TestSessionEnvModelOnlyUsesDefaultEnvProvider(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = "https://default-env.example.invalid/v1"
+	service.config.LLMAPIKey = "default-env-key"
+	service.config.LLMModel = ""
+
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-env-model-only")
+	session.ProviderEnvItems = []SessionEnvVar{{Name: "LLM_MODEL", Value: "session-model-only"}}
+	if _, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "", "test", "run-1"); err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+
+	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1: %#v", len(providers), providers)
+	}
+	if providers[0].ID != llmProviderIDDefaultOpenAI || providers[0].Scope != llmProviderScopeEnvDefault || providers[0].APIKey != "default-env-key" {
+		t.Fatalf("provider = %#v, want default env provider", providers[0])
+	}
+	models, err := service.configDB.ListEnabledLLMModels(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMModels returned error: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "session-model-only" {
+		t.Fatalf("models = %#v, want session model on default env provider", models)
+	}
+}
+
+func TestConfiguredProviderTakesPriorityOverDefaultEnvProvider(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	if _, err := service.configDB.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://env-default.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "env-default-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "shared-model"},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	if _, err := resolveLLMTarget(ctx, service.config, service.configDB, "shared-model"); err != nil {
+		t.Fatalf("resolveLLMTarget(default env) returned error: %v", err)
+	}
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "configured-openai",
+		Name:           "configured-openai",
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: llmAPIProtocolResponses,
+		BaseURL:        "https://configured-priority.example.invalid/v1",
+		APIKey:         "configured-key",
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    "{}",
+		Weight:         10,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "shared-model", Name: "shared-model", DefaultModel: true, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+
+	target, err := resolveLLMTarget(ctx, service.config, service.configDB, "shared-model")
+	if err != nil {
+		t.Fatalf("resolveLLMTarget(configured) returned error: %v", err)
+	}
+	if target.Provider.ID != "configured-openai" || target.Provider.APIKey != "configured-key" {
+		t.Fatalf("target provider = %#v, want configured provider", target.Provider)
+	}
+}
+
+func TestGuestRuntimeLLMBaseURLDockerRequiresReachableBaseForLoopback(t *testing.T) {
+	config := &appconfig.Config{HttpListen: "127.0.0.1:7410"}
+	session := &Session{Summary: SessionSummary{Driver: "docker"}}
+	if got := guestRuntimeLLMBaseURL(config, session); got != "" {
+		t.Fatalf("docker loopback base url = %q, want empty without explicit runtime base url", got)
+	}
+
+	config.RuntimeBaseURL = "http://agent-compose:7410"
+	if got := guestRuntimeLLMBaseURL(config, session); got != "http://agent-compose:7410" {
+		t.Fatalf("explicit docker runtime base url = %q, want compose service URL", got)
+	}
+
+	config.RuntimeBaseURL = ""
+	config.HttpListen = "192.0.2.10:7410"
+	if got := guestRuntimeLLMBaseURL(config, session); got != "http://192.0.2.10:7410" {
+		t.Fatalf("docker concrete listen base url = %q, want concrete host URL", got)
+	}
+}
+
+func TestForbiddenRuntimeLLMHeaderDoesNotOvermatchAuthSubstring(t *testing.T) {
+	if forbiddenRuntimeLLMHeader("X-Authored-By") {
+		t.Fatalf("X-Authored-By should not be treated as a sensitive auth header")
+	}
+	if !forbiddenRuntimeLLMHeader("X-Runtime-Auth") {
+		t.Fatalf("X-Runtime-Auth should be treated as sensitive")
+	}
+	if !forbiddenRuntimeLLMHeader("X-Session-Token") {
+		t.Fatalf("X-Session-Token should be treated as sensitive")
+	}
+}
+
+func TestCreateSessionFiltersLLMProviderKeysFromPersistedEnv(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	if _, err := service.configDB.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "OPENAI_API_KEY", Value: "global-provider-key", Secret: false},
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "global-provider-key", Secret: false},
+		{Name: "GOOGLE_API_KEY", Value: "global-provider-key", Secret: false},
+		{Name: "SAFE_ENV", Value: "safe", Secret: false},
+		{Name: "SAFE_SECRET_ENV", Value: "safe-secret", Secret: true},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	resp, err := service.sessions.CreateSession(ctx, connect.NewRequest(&agentcomposev1.CreateSessionRequest{
+		Title: "env-filter",
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "LLM_API_KEY", Value: "request-provider-key", Secret: false},
+			{Name: "GEMINI_API_KEY", Value: "request-provider-key", Secret: false},
+			{Name: "REQUEST_ENV", Value: "request", Secret: false},
+			{Name: "REQUEST_SECRET_ENV", Value: "request-secret", Secret: true},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session, err := service.store.GetSession(ctx, resp.Msg.GetSession().GetSummary().GetSessionId())
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	env := sessionEnvMap(session.EnvItems)
+	for _, name := range []string{"OPENAI_API_KEY", "LLM_API_KEY", "ANTHROPIC_AUTH_TOKEN", "GOOGLE_API_KEY", "GEMINI_API_KEY"} {
+		if _, ok := env[name]; ok {
+			t.Fatalf("%s persisted in session env: %#v", name, session.EnvItems)
+		}
+	}
+	if env["SAFE_ENV"] != "safe" || env["REQUEST_ENV"] != "request" {
+		t.Fatalf("safe env missing after filter: %#v", session.EnvItems)
+	}
+	if env["SAFE_SECRET_ENV"] != "safe-secret" || env["REQUEST_SECRET_ENV"] != "request-secret" {
+		t.Fatalf("non-LLM secret env missing after filter: %#v", session.EnvItems)
+	}
+	for _, item := range session.EnvItems {
+		if strings.Contains(item.Value, "provider-key") {
+			t.Fatalf("provider key value persisted: %#v", session.EnvItems)
+		}
+	}
+}
+
+func TestRuntimeEnvMapKeepsNonLLMSecretEnv(t *testing.T) {
+	env := runtimeEnvMap([]SessionEnvVar{
+		{Name: "DATABASE_PASSWORD", Value: "db-secret", Secret: true},
+		{Name: "OPENAI_API_KEY", Value: "provider-key", Secret: true},
+	})
+	if env["DATABASE_PASSWORD"] != "db-secret" {
+		t.Fatalf("DATABASE_PASSWORD = %q, want non-LLM secret env to be preserved", env["DATABASE_PASSWORD"])
+	}
+	if _, ok := env["OPENAI_API_KEY"]; ok {
+		t.Fatalf("OPENAI_API_KEY leaked into runtime env: %#v", env)
+	}
+}
+
+func TestEnsureSessionAnthropicEnvProviderAuthUsesSessionEnvOnly(t *testing.T) {
+	// A session-env Anthropic provider derives its API key only from session env
+	// items, so its auth header choice must depend only on those items too. A
+	// daemon-level ANTHROPIC_API_KEY must not flip a session token provider to
+	// the x-api-key header.
+	t.Setenv("ANTHROPIC_API_KEY", "daemon-api-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+	sessionID := "sess-anthropic-auth"
+	envItems := []SessionEnvVar{
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "session-auth-token"},
+		{Name: "ANTHROPIC_MODEL", Value: "claude-test"},
+	}
+	providerID, err := ensureSessionAnthropicEnvProvider(ctx, store, sessionID, "", envItems)
+	if err != nil {
+		t.Fatalf("ensureSessionAnthropicEnvProvider returned error: %v", err)
+	}
+	if providerID == "" {
+		t.Fatalf("expected a session anthropic provider to be created")
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	var found *LLMProvider
+	for i := range providers {
+		if providers[i].ID == providerID {
+			found = &providers[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("session anthropic provider %q not found", providerID)
+	}
+	if found.AuthHeader != "Authorization" || found.AuthScheme != "Bearer" {
+		t.Fatalf("session provider auth = %q/%q, want Authorization/Bearer (session env has only ANTHROPIC_AUTH_TOKEN)", found.AuthHeader, found.AuthScheme)
+	}
+}
+
+func TestRevokeLLMFacadeTokensForSessionPrunesDeadRows(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Active token for the target session: revoked by the call, but kept (within retention).
+	activeVal, active, err := newLLMFacadeToken("sess-x", "m", "default", llmAPIProtocolResponses, "agent", "r-active")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken: %v", err)
+	}
+	if err := store.SaveLLMFacadeToken(ctx, active); err != nil {
+		t.Fatalf("save active: %v", err)
+	}
+	// Token revoked long ago: should be pruned.
+	oldVal, old, err := newLLMFacadeToken("sess-y", "m", "default", llmAPIProtocolResponses, "agent", "r-old")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken: %v", err)
+	}
+	old.RevokedAt = now.Add(-2 * llmFacadeTokenRetention)
+	if err := store.SaveLLMFacadeToken(ctx, old); err != nil {
+		t.Fatalf("save old: %v", err)
+	}
+	// Expired token: should be pruned.
+	expVal, exp, err := newLLMFacadeToken("sess-z", "m", "default", llmAPIProtocolResponses, "agent", "r-exp")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken: %v", err)
+	}
+	exp.ExpiresAt = now.Add(-time.Minute)
+	if err := store.SaveLLMFacadeToken(ctx, exp); err != nil {
+		t.Fatalf("save expired: %v", err)
+	}
+
+	if err := store.RevokeLLMFacadeTokensForSession(ctx, "sess-x"); err != nil {
+		t.Fatalf("RevokeLLMFacadeTokensForSession: %v", err)
+	}
+
+	got, err := store.GetLLMFacadeToken(ctx, activeVal)
+	if err != nil {
+		t.Fatalf("active token should remain: %v", err)
+	}
+	if got.RevokedAt.IsZero() {
+		t.Fatalf("active token should be marked revoked")
+	}
+	if _, err := store.GetLLMFacadeToken(ctx, oldVal); err == nil {
+		t.Fatalf("long-revoked token should be pruned")
+	}
+	if _, err := store.GetLLMFacadeToken(ctx, expVal); err == nil {
+		t.Fatalf("expired token should be pruned")
+	}
+}
+
+func TestDeleteLLMFacadeToken(t *testing.T) {
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+	val, token, err := newLLMFacadeToken("sess", "m", "default", llmAPIProtocolResponses, "agent", "run-1")
+	if err != nil {
+		t.Fatalf("newLLMFacadeToken: %v", err)
+	}
+	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := store.GetLLMFacadeToken(ctx, val); err != nil {
+		t.Fatalf("token should exist before delete: %v", err)
+	}
+	if err := store.DeleteLLMFacadeToken(ctx, val); err != nil {
+		t.Fatalf("DeleteLLMFacadeToken: %v", err)
+	}
+	if _, err := store.GetLLMFacadeToken(ctx, val); err == nil {
+		t.Fatalf("token should be gone after delete")
+	}
+	if err := store.DeleteLLMFacadeToken(ctx, ""); err != nil {
+		t.Fatalf("deleting empty token should be a no-op: %v", err)
+	}
+}
+
+func TestResolveRuntimeLLMTargetByExistingProviderID(t *testing.T) {
+	// No LLM env present; resolution must rely purely on the existing provider.
+	for _, k := range []string{"LLM_API_KEY", "OPENAI_API_KEY", "LLM_API_ENDPOINT", "LLM_MODEL", "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL", "CLAUDE_MODEL"} {
+		t.Setenv(k, "")
+	}
+	store := newTestConfigStore(t)
+	ctx := context.Background()
+	if err := store.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID: "p1", Name: "p1", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolResponses,
+		BaseURL: "https://api.example.com", APIKey: "k", AuthHeader: "Authorization", AuthScheme: "Bearer",
+		Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+	}, LLMModel{ID: "m1", Name: "m1", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig: %v", err)
+	}
+
+	target, err := resolveRuntimeLLMTarget(ctx, &appconfig.Config{}, store, "m1", "p1")
+	if err != nil {
+		t.Fatalf("resolveRuntimeLLMTarget: %v", err)
+	}
+	if target.Provider.ID != "p1" || target.Model.ID != "m1" {
+		t.Fatalf("resolved %q/%q, want p1/m1", target.Provider.ID, target.Model.ID)
+	}
+	// The existing provider must satisfy resolution without fabricating bootstrap providers.
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("expected exactly 1 provider, got %d: %+v", len(providers), providers)
+	}
+}
+
+// TestE2ERuntimeLLMFacadeRoundTrips drives the full daemon-side facade across
+// every inbound protocol, the cross-family bridge, SSE streaming, and the main
+// rejection paths. Named with the E2E convention so the coverage gate's e2e
+// shape exercises the facade HTTP handlers and provider/token resolution.
+func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+
+	app := echo.New()
+	registerRuntimeLLMFacadeRoutes(app, service)
+
+	upsertProvider := func(t *testing.T, id, family, wireAPI, baseURL, authHeader, authScheme, model string) {
+		t.Helper()
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: id, Name: id, ProviderType: family, DefaultWireAPI: wireAPI,
+			BaseURL: baseURL, APIKey: "provider-key", AuthHeader: authHeader, AuthScheme: authScheme,
+			HeadersJSON: `{"anthropic-version":"2023-06-01"}`, Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: model, Name: model, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(%s): %v", id, err)
+		}
+	}
+	mintToken := func(t *testing.T, session *Session, model, providerID, wireAPI string) string {
+		t.Helper()
+		val, token, err := newLLMFacadeToken(session.Summary.ID, model, providerID, wireAPI, "test", "run-e2e")
+		if err != nil {
+			t.Fatalf("newLLMFacadeToken: %v", err)
+		}
+		token.ExpiresAt = time.Now().Add(time.Hour)
+		if err := service.configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+			t.Fatalf("SaveLLMFacadeToken: %v", err)
+		}
+		return val
+	}
+	post := func(sessionID, path, token, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+sessionID+path, bytes.NewBufferString(body))
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		rec := httptest.NewRecorder()
+		app.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("openai_responses", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer provider-key" {
+				t.Errorf("upstream auth = %q", r.Header.Get("Authorization"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-e2e","model":"m-resp","status":"completed","output_text":"ok"}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		upsertProvider(t, "e2e-openai-resp", llmProviderFamilyOpenAI, llmAPIProtocolResponses, upstream.URL, "Authorization", "Bearer", "m-resp")
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-openai-resp")
+		token := mintToken(t, session, "m-resp", "e2e-openai-resp", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, `{"model":"m-resp","input":"hi"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("openai_chat_completions", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chat-e2e","object":"chat.completion","model":"m-chat","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		upsertProvider(t, "e2e-openai-chat", llmProviderFamilyOpenAI, llmAPIProtocolChatCompletions, upstream.URL, "Authorization", "Bearer", "m-chat")
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-openai-chat")
+		token := mintToken(t, session, "m-chat", "e2e-openai-chat", llmAPIProtocolChatCompletions)
+		rec := post(session.Summary.ID, "/llm/openai/v1/chat/completions", token, `{"model":"m-chat","messages":[{"role":"user","content":"hi"}]}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("anthropic_messages", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("x-api-key") != "provider-key" {
+				t.Errorf("upstream x-api-key = %q", r.Header.Get("x-api-key"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"msg-e2e","type":"message","role":"assistant","model":"m-claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		upsertProvider(t, "e2e-anthropic", llmProviderFamilyAnthropic, llmAPIProtocolMessages, upstream.URL, "x-api-key", "", "m-claude")
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-anthropic")
+		token := mintToken(t, session, "m-claude", "e2e-anthropic", llmAPIProtocolMessages)
+		rec := post(session.Summary.ID, "/llm/anthropic/v1/messages", token, `{"model":"m-claude","messages":[{"role":"user","content":"hi"}]}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("cross_family_openai_to_anthropic", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"msg-bridge","type":"message","role":"assistant","model":"m-bridge","content":[{"type":"text","text":"bridged"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		upsertProvider(t, "e2e-bridge", llmProviderFamilyAnthropic, llmAPIProtocolMessages, upstream.URL, "x-api-key", "", "m-bridge")
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-bridge")
+		token := mintToken(t, session, "m-bridge", "e2e-bridge", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, `{"model":"m-bridge","input":"hi"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("sse_stream", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("event: message\ndata: hello\n\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			_, _ = w.Write([]byte("event: done\ndata: [DONE]\n\n"))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		upsertProvider(t, "e2e-sse", llmProviderFamilyOpenAI, llmAPIProtocolResponses, upstream.URL, "Authorization", "Bearer", "m-sse")
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-sse")
+		token := mintToken(t, session, "m-sse", "e2e-sse", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, `{"model":"m-sse","input":"hi","stream":true}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "data:") {
+			t.Fatalf("expected SSE data in response, got %q", rec.Body.String())
+		}
+	})
+
+	t.Run("rejections", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"x","model":"m-rej","status":"completed","output_text":"ok"}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		upsertProvider(t, "e2e-rej", llmProviderFamilyOpenAI, llmAPIProtocolResponses, upstream.URL, "Authorization", "Bearer", "m-rej")
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-rej")
+		token := mintToken(t, session, "m-rej", "e2e-rej", llmAPIProtocolResponses)
+		path := "/llm/openai/v1/responses"
+
+		if rec := post(session.Summary.ID, path, "", `{"model":"m-rej","input":"hi"}`); rec.Code != http.StatusUnauthorized {
+			t.Fatalf("missing token: status=%d", rec.Code)
+		}
+		if rec := post(session.Summary.ID, path, "ac_llm_bogus", `{"model":"m-rej","input":"hi"}`); rec.Code != http.StatusUnauthorized {
+			t.Fatalf("bad token: status=%d", rec.Code)
+		}
+		if rec := post("other-session", path, token, `{"model":"m-rej","input":"hi"}`); rec.Code != http.StatusForbidden {
+			t.Fatalf("wrong session: status=%d", rec.Code)
+		}
+		if rec := post(session.Summary.ID, path, token, `{"model":"mismatch","input":"hi"}`); rec.Code != http.StatusForbidden {
+			t.Fatalf("model mismatch: status=%d", rec.Code)
+		}
+	})
+}

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -1405,3 +1405,42 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 		}
 	})
 }
+
+// A session-only Anthropic key with no model anywhere must fail fast at config
+// time: request-time resolution runs without session env, so the key can never
+// resolve a provider. The facade must not inject an unbound token that defers
+// the failure to every runtime request.
+func TestEnsureSessionClaudeFacadeFailsFastWhenSessionKeyHasNoModel(t *testing.T) {
+	ctx := context.Background()
+	for _, k := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL", "CLAUDE_MODEL", "LLM_API_KEY", "LLM_API_ENDPOINT", "LLM_MODEL", "OPENAI_API_KEY"} {
+		t.Setenv(k, "")
+	}
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-claude-key-no-model")
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "ANTHROPIC_API_KEY", Value: "session-only-key", Secret: true},
+	}
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "claude", "", "test", "run-1")
+	if err == nil {
+		t.Fatalf("expected fail-fast error, got env=%#v", env)
+	}
+	if env != nil {
+		t.Fatalf("expected no facade env on failure, got %#v", env)
+	}
+	if !strings.Contains(err.Error(), "model") {
+		t.Fatalf("error = %v, want it to mention the missing model", err)
+	}
+	providers, perr := service.configDB.ListEnabledLLMProviders(ctx)
+	if perr != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", perr)
+	}
+	if len(providers) != 0 {
+		t.Fatalf("no provider should be created, got %#v", providers)
+	}
+}

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -1444,3 +1444,67 @@ func TestEnsureSessionClaudeFacadeFailsFastWhenSessionKeyHasNoModel(t *testing.T
 		t.Fatalf("no provider should be created, got %#v", providers)
 	}
 }
+
+// A session whose LLM key came only from per-session env must keep working after
+// a stop/resume. The raw key env (ProviderEnvItems) is not persisted, so on
+// resume resolution sees only the key-filtered env; it must reuse the
+// session-env provider persisted at creation (with its key intact) rather than
+// skip it or overwrite its key with the now-empty env.
+func TestResolveRuntimeLLMTargetReusesSessionProviderAfterResume(t *testing.T) {
+	ctx := context.Background()
+	for _, k := range []string{"LLM_API_KEY", "OPENAI_API_KEY", "LLM_API_ENDPOINT", "LLM_MODEL", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL", "CLAUDE_MODEL"} {
+		t.Setenv(k, "")
+	}
+	store := newTestConfigStore(t)
+	cfg := &appconfig.Config{}
+	sessionID := "sess-resume"
+
+	// Creation: full env with the session-scoped key (mirrors ProviderEnvItems).
+	creationEnv := []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-llm.example.invalid"},
+		{Name: "LLM_API_KEY", Value: "session-real-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "m-resume"},
+	}
+	target, err := resolveRuntimeLLMTargetWithEnv(ctx, cfg, store, sessionID, llmProviderFamilyOpenAI, "", "", creationEnv)
+	if err != nil {
+		t.Fatalf("creation resolve: %v", err)
+	}
+	wantID := sessionEnvProviderID(sessionID, llmProviderFamilyOpenAI)
+	if target.Provider.ID != wantID || target.Provider.APIKey != "session-real-key" {
+		t.Fatalf("creation target = %q/%q, want %q/session-real-key", target.Provider.ID, target.Provider.APIKey, wantID)
+	}
+
+	// Resume: key-filtered env (filterPersistedRuntimeEnv stripped LLM_API_KEY).
+	resumeEnv := []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-llm.example.invalid"},
+		{Name: "LLM_MODEL", Value: "m-resume"},
+	}
+	resumed, err := resolveRuntimeLLMTargetWithEnv(ctx, cfg, store, sessionID, llmProviderFamilyOpenAI, "", "", resumeEnv)
+	if err != nil {
+		t.Fatalf("resume resolve: %v", err)
+	}
+	if resumed.Provider.ID != wantID {
+		t.Fatalf("resume provider = %q, want persisted session provider %q", resumed.Provider.ID, wantID)
+	}
+	if resumed.Provider.APIKey != "session-real-key" {
+		t.Fatalf("resume provider key = %q, want preserved session-real-key (not clobbered)", resumed.Provider.APIKey)
+	}
+	if resumed.Headers.Get("Authorization") != "Bearer session-real-key" {
+		t.Fatalf("resume auth header = %q, want Bearer session-real-key", resumed.Headers.Get("Authorization"))
+	}
+
+	// Rotation: a resume-time env that *does* carry a new key must update it,
+	// not get pinned to the stale persisted key.
+	rotatedEnv := []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-llm.example.invalid"},
+		{Name: "LLM_API_KEY", Value: "rotated-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "m-resume"},
+	}
+	rotated, err := resolveRuntimeLLMTargetWithEnv(ctx, cfg, store, sessionID, llmProviderFamilyOpenAI, "", "", rotatedEnv)
+	if err != nil {
+		t.Fatalf("rotation resolve: %v", err)
+	}
+	if rotated.Provider.APIKey != "rotated-key" {
+		t.Fatalf("rotation provider key = %q, want rotated-key", rotated.Provider.APIKey)
+	}
+}

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -226,7 +226,7 @@ func TestRuntimeLLMAnthropicFacadeForwardsWithSessionToken(t *testing.T) {
 	app := echo.New()
 	registerRuntimeLLMFacadeRoutes(app, service)
 	req := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic/v1/messages", bytes.NewBufferString(`{"model":"claude-test","messages":[{"role":"user","content":"hello"}]}`))
-	req.Header.Set("Authorization", "Bearer "+tokenValue)
+	req.Header.Set("x-api-key", tokenValue)
 	req.Header.Set("anthropic-version", "2023-06-01")
 	rec := httptest.NewRecorder()
 	app.ServeHTTP(rec, req)
@@ -719,6 +719,9 @@ func TestSessionEnvGenericMessagesEndpointBootstrapsOnlyAnthropicProvider(t *tes
 	}
 	if env["ANTHROPIC_API_KEY"] != env["AGENT_COMPOSE_SESSION_TOKEN"] {
 		t.Fatalf("ANTHROPIC_API_KEY = %q, want facade token", env["ANTHROPIC_API_KEY"])
+	}
+	if env["ANTHROPIC_MODEL"] != "claude-session" || env["CLAUDE_MODEL"] != "claude-session" {
+		t.Fatalf("claude model env = ANTHROPIC_MODEL:%q CLAUDE_MODEL:%q, want claude-session", env["ANTHROPIC_MODEL"], env["CLAUDE_MODEL"])
 	}
 	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
 	if err != nil {

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -852,6 +852,45 @@ func TestSessionEnvProviderSelectionUsesAgentFamilyPreference(t *testing.T) {
 	}
 }
 
+func TestDaemonEnvProviderSelectionUsesAgentFamilyPreference(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://anthropic.example.invalid")
+	t.Setenv("ANTHROPIC_API_ENDPOINT", "")
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_MODEL", "shared-model")
+	t.Setenv("CLAUDE_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = "https://openai.example.invalid"
+	service.config.LLMAPIKey = "openai-key"
+	service.config.LLMAPIProtocol = llmAPIProtocolChatCompletions
+	service.config.LLMModel = "shared-model"
+
+	session := createRunningLLMFacadeSession(t, ctx, service, "daemon-env-agent-family")
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "", "test", "run-codex")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig(codex) returned error: %v", err)
+	}
+	if env["LLM_API_PROTOCOL"] != llmAPIProtocolResponses {
+		t.Fatalf("LLM_API_PROTOCOL = %q, want responses facade wire API", env["LLM_API_PROTOCOL"])
+	}
+	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.ProviderID != llmProviderIDDefaultOpenAI {
+		t.Fatalf("codex provider id = %q, want default OpenAI provider", token.ProviderID)
+	}
+	if token.WireAPI != llmAPIProtocolResponses {
+		t.Fatalf("codex token wire api = %q, want responses facade wire API", token.WireAPI)
+	}
+}
+
 func TestSessionEnvProviderIsNotSelectedWithoutProviderID(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("LLM_API_ENDPOINT", "")

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -1,0 +1,239 @@
+package agentcompose
+
+import (
+	appconfig "agent-compose/pkg/config"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// llmFacadeTokenSourceAgent marks a per-agent-run facade token. Such a token is
+// only used for the duration of a single bounded agent run, so the caller is
+// expected to delete it when that run completes (see executeAgentRun) rather
+// than letting it live for the whole session lifetime.
+const llmFacadeTokenSourceAgent = "agent"
+
+func ensureSessionLLMFacadeConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, agent, model, source, runID string) (map[string]string, error) {
+	if config == nil || configDB == nil || session == nil {
+		return nil, nil
+	}
+	if normalizeAgentKind(agent) == "claude" {
+		return ensureSessionClaudeLLMFacadeConfig(ctx, config, configDB, session, model, source, runID)
+	}
+	return ensureSessionCodexLLMFacadeConfig(ctx, config, configDB, session, model, source, runID)
+}
+
+func ensureSessionCodexLLMFacadeConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, model, source, runID string) (map[string]string, error) {
+	target, err := resolveRuntimeLLMTargetWithEnv(ctx, config, configDB, session.Summary.ID, llmProviderFamilyOpenAI, model, "", sessionLLMProviderEnvItems(session))
+	if err != nil {
+		if strings.Contains(err.Error(), "llm model is required") || strings.Contains(err.Error(), "llm provider is not configured") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	baseURL := guestRuntimeLLMBaseURL(config, session)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	facadeWireAPI := target.WireAPI
+	if normalizeLLMProviderType(target.Provider.ProviderType) != llmProviderFamilyOpenAI {
+		facadeWireAPI = llmAPIProtocolResponses
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, facadeWireAPI, source, runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sessions/" + session.Summary.ID + "/llm/openai/v1"
+	if err := writeCodexLLMConfig(session, target.Model.Name, openAIBaseURL, facadeWireAPI); err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            openAIBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            facadeWireAPI,
+		"OPENAI_API_KEY":              tokenValue,
+		"OPENAI_BASE_URL":             openAIBaseURL,
+	}, nil
+}
+
+func ensureSessionClaudeLLMFacadeConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, model, source, runID string) (map[string]string, error) {
+	baseURL := guestRuntimeLLMBaseURL(config, session)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	providerEnv := sessionLLMProviderEnvItems(session)
+	target, err := resolveRuntimeLLMTargetWithEnv(ctx, config, configDB, session.Summary.ID, llmProviderFamilyAnthropic, model, "", providerEnv)
+	tokenModel := ""
+	tokenProvider := ""
+	if err != nil {
+		if !isOptionalLLMFacadeConfigError(err) || !hasAnthropicProviderKey(ctx, config, configDB, providerEnv) {
+			return nil, err
+		}
+	} else {
+		tokenModel = target.Model.Name
+		tokenProvider = target.Provider.ID
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, tokenModel, tokenProvider, llmAPIProtocolMessages, source, runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	anthropicBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sessions/" + session.Summary.ID + "/llm/anthropic"
+	return map[string]string{
+		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            anthropicBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            llmAPIProtocolMessages,
+		"ANTHROPIC_API_KEY":           tokenValue,
+		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
+	}, nil
+}
+
+func isOptionalLLMFacadeConfigError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "llm model is required") ||
+		strings.Contains(message, "llm provider is not configured") ||
+		strings.Contains(message, "is not configured for provider family")
+}
+
+func hasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, envItems []SessionEnvVar) bool {
+	configKey := ""
+	if config != nil {
+		configKey = config.LLMAPIKey
+	}
+	return strings.TrimSpace(firstNonEmpty(
+		lookupEnvValue(ctx, configDB, "ANTHROPIC_API_KEY"),
+		lookupEnvValue(ctx, configDB, "ANTHROPIC_AUTH_TOKEN"),
+		lookupEnvValue(ctx, configDB, "LLM_API_KEY"),
+		os.Getenv("ANTHROPIC_API_KEY"),
+		os.Getenv("ANTHROPIC_AUTH_TOKEN"),
+		os.Getenv("LLM_API_KEY"),
+		configKey,
+		lookupEnvItemValue(envItems, "ANTHROPIC_API_KEY"),
+		lookupEnvItemValue(envItems, "ANTHROPIC_AUTH_TOKEN"),
+		lookupEnvItemValue(envItems, "LLM_API_KEY"),
+	)) != ""
+}
+
+func sessionLLMProviderEnvItems(session *Session) []SessionEnvVar {
+	if session == nil {
+		return nil
+	}
+	if len(session.ProviderEnvItems) > 0 {
+		return session.ProviderEnvItems
+	}
+	return session.EnvItems
+}
+
+func writeCodexLLMConfig(session *Session, model, baseURL, wireAPI string) error {
+	if session == nil {
+		return nil
+	}
+	model = strings.TrimSpace(model)
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if model == "" || baseURL == "" {
+		return nil
+	}
+	path := filepath.Join(hostSessionHome(session), ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create codex config dir: %w", err)
+	}
+	payload := fmt.Sprintf(`model_provider = "agent_compose"
+model = %q
+
+[model_providers.agent_compose]
+name = "agent-compose"
+base_url = %q
+env_key = "AGENT_COMPOSE_SESSION_TOKEN"
+wire_api = %q
+request_max_retries = 30
+stream_max_retries = 50
+stream_idle_timeout_ms = 120000
+
+[sandbox_workspace_write]
+exclude_tmpdir_env_var = false
+exclude_slash_tmp = false
+network_access = true
+
+[shell_environment_policy]
+inherit = "all"
+ignore_default_excludes = false
+
+[history]
+persistence = "save-all"
+`, model, baseURL, normalizeLLMWireAPI(wireAPI))
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		return fmt.Errorf("write codex config: %w", err)
+	}
+	return nil
+}
+
+func guestRuntimeLLMBaseURL(config *appconfig.Config, session *Session) string {
+	if config == nil {
+		return ""
+	}
+	if base := strings.TrimRight(strings.TrimSpace(config.RuntimeBaseURL), "/"); base != "" {
+		return base
+	}
+	listen := strings.TrimSpace(config.HttpListen)
+	if listen == "" {
+		return ""
+	}
+	host, port, ok := strings.Cut(listen, ":")
+	if !ok {
+		return ""
+	}
+	host = strings.Trim(host, "[]")
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	if session != nil && strings.EqualFold(session.Summary.Driver, "docker") && (host == "127.0.0.1" || host == "localhost") {
+		return ""
+	}
+	return "http://" + host + ":" + port
+}
+
+func mergeManagedExecEnv(base map[string]string, managed map[string]string) map[string]string {
+	if len(base) == 0 && len(managed) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(base)+len(managed))
+	for key, value := range base {
+		if llmProviderKeyName(key) {
+			continue
+		}
+		result[key] = value
+	}
+	for key, value := range managed {
+		result[key] = value
+	}
+	return result
+}
+
+func envItemsFromMap(values map[string]string, secret bool) []SessionEnvVar {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	items := make([]SessionEnvVar, 0, len(keys))
+	for _, key := range keys {
+		items = append(items, SessionEnvVar{Name: key, Value: values[key], Secret: secret})
+	}
+	return items
+}

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -73,7 +73,7 @@ func ensureSessionClaudeLLMFacadeConfig(ctx context.Context, config *appconfig.C
 	tokenModel := ""
 	tokenProvider := ""
 	if err != nil {
-		if !isOptionalLLMFacadeConfigError(err) || !hasAnthropicProviderKey(ctx, config, configDB, providerEnv) {
+		if !isOptionalLLMFacadeConfigError(err) || !hasAnthropicProviderKey(ctx, config, configDB) {
 			return nil, err
 		}
 	} else {
@@ -108,7 +108,13 @@ func isOptionalLLMFacadeConfigError(err error) bool {
 		strings.Contains(message, "is not configured for provider family")
 }
 
-func hasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, envItems []SessionEnvVar) bool {
+// hasAnthropicProviderKey reports whether a daemon-level Anthropic credential
+// exists. It intentionally ignores per-session env items: request-time provider
+// resolution runs without session env, so a session-scoped key (without a model
+// to persist a provider) would never let a runtime request resolve. Tolerating a
+// missing model is only safe when a daemon-level key can bootstrap a provider
+// from the request's model at call time.
+func hasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, configDB *ConfigStore) bool {
 	configKey := ""
 	if config != nil {
 		configKey = config.LLMAPIKey
@@ -121,9 +127,6 @@ func hasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, conf
 		os.Getenv("ANTHROPIC_AUTH_TOKEN"),
 		os.Getenv("LLM_API_KEY"),
 		configKey,
-		lookupEnvItemValue(envItems, "ANTHROPIC_API_KEY"),
-		lookupEnvItemValue(envItems, "ANTHROPIC_AUTH_TOKEN"),
-		lookupEnvItemValue(envItems, "LLM_API_KEY"),
 	)) != ""
 }
 

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -88,14 +88,19 @@ func ensureSessionClaudeLLMFacadeConfig(ctx context.Context, config *appconfig.C
 		return nil, err
 	}
 	anthropicBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sessions/" + session.Summary.ID + "/llm/anthropic"
-	return map[string]string{
+	env := map[string]string{
 		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
 		"LLM_API_ENDPOINT":            anthropicBaseURL,
 		"LLM_API_KEY":                 tokenValue,
 		"LLM_API_PROTOCOL":            llmAPIProtocolMessages,
 		"ANTHROPIC_API_KEY":           tokenValue,
 		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
-	}, nil
+	}
+	if tokenModel != "" {
+		env["ANTHROPIC_MODEL"] = tokenModel
+		env["CLAUDE_MODEL"] = tokenModel
+	}
+	return env, nil
 }
 
 func isOptionalLLMFacadeConfigError(err error) bool {

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -38,10 +38,7 @@ func ensureSessionCodexLLMFacadeConfig(ctx context.Context, config *appconfig.Co
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	facadeWireAPI := target.WireAPI
-	if normalizeLLMProviderType(target.Provider.ProviderType) != llmProviderFamilyOpenAI {
-		facadeWireAPI = llmAPIProtocolResponses
-	}
+	facadeWireAPI := llmAPIProtocolResponses
 	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, facadeWireAPI, source, runID)
 	if err != nil {
 		return nil, err

--- a/pkg/agentcompose/loader_manager.go
+++ b/pkg/agentcompose/loader_manager.go
@@ -848,6 +848,7 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 
 	agent := normalizeAgentKind(request.Agent)
 	var agentDefinitionID string
+	model := ""
 	if agent == "" {
 		agentDefinition, err := h.manager.loaderAgentDefinition(ctx, h.loader)
 		if err != nil {
@@ -856,6 +857,7 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 		if agentDefinition != nil {
 			agent = normalizeAgentKind(agentDefinition.Provider)
 			agentDefinitionID = strings.TrimSpace(agentDefinition.ID)
+			model = agentDefinition.Model
 		}
 	}
 	if agentDefinitionID == "" {
@@ -871,6 +873,8 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 	cell, _, _, execErr := h.manager.executor.ExecuteAgentRequest(ctx, session, ExecuteAgentRequest{
 		Agent:             agent,
 		AgentDefinitionID: agentDefinitionID,
+		Model:             model,
+		RunID:             h.run.ID,
 		Message:           prompt,
 		Timeout:           request.Timeout,
 		OutputSchemaJSON:  request.OutputSchema,
@@ -1195,6 +1199,8 @@ func (m *LoaderManager) ensureLoaderSessionWithOptions(ctx context.Context, load
 	}
 	envItems = mergeEnvItems(envItems, loader.EnvItems)
 	envItems = mergeEnvItems(envItems, request.SessionEnv)
+	providerEnvItems := envItems
+	envItems = filterPersistedRuntimeEnv(envItems)
 	capabilityVars, capabilityTags := buildCapabilityGatewaySessionVars(capabilityGatewayProxyTarget(m.cap), loader.Summary.CapsetIDs)
 	envItems = mergeEnvItems(envItems, capabilityVars)
 	tags := []SessionTag{{Name: "origin", Value: "loader"}, {Name: "loader_id", Value: loader.Summary.ID}, {Name: "loader_name", Value: loader.Summary.Name}}
@@ -1244,6 +1250,7 @@ func (m *LoaderManager) ensureLoaderSessionWithOptions(ctx context.Context, load
 	if err != nil {
 		return nil, "", err
 	}
+	session.ProviderEnvItems = providerEnvItems
 	if err := prepareSessionWorkspace(ctx, m.config, m.configDB, session); err != nil {
 		session.Summary.VMStatus = VMStatusFailed
 		_ = m.store.UpdateSession(ctx, session)
@@ -1270,6 +1277,7 @@ func (m *LoaderManager) ensureLoaderSessionWithOptions(ctx context.Context, load
 	if err != nil {
 		return nil, "", err
 	}
+	restoreSessionTransientFields(loaded, session)
 	m.Publish("agent-compose.session.created", map[string]any{
 		"sessionId":     loaded.Summary.ID,
 		"title":         loaded.Summary.Title,
@@ -1345,6 +1353,7 @@ func (m *LoaderManager) loadOrResumeLoaderSession(ctx context.Context, sessionID
 	if err != nil {
 		return nil, "", err
 	}
+	restoreSessionTransientFields(loaded, session)
 	m.Publish("agent-compose.session.resumed", map[string]any{
 		"sessionId": loaded.Summary.ID,
 		"title":     loaded.Summary.Title,

--- a/pkg/agentcompose/model.go
+++ b/pkg/agentcompose/model.go
@@ -26,12 +26,16 @@ type SessionEnvVar struct {
 	Secret bool   `json:"secret,omitempty"`
 }
 
-func sessionEnvMap(items []SessionEnvVar) map[string]string {
-	if len(items) == 0 {
+func sessionEnvMap(groups ...[]SessionEnvVar) map[string]string {
+	var merged []SessionEnvVar
+	for _, items := range groups {
+		merged = append(merged, items...)
+	}
+	if len(merged) == 0 {
 		return nil
 	}
-	env := make(map[string]string, len(items))
-	for _, item := range items {
+	env := make(map[string]string, len(merged))
+	for _, item := range merged {
 		name := strings.TrimSpace(item.Name)
 		if name == "" {
 			continue
@@ -91,11 +95,25 @@ type SessionWorkspace struct {
 }
 
 type Session struct {
-	Summary       SessionSummary    `json:"summary"`
-	BaseWorkspace string            `json:"base_workspace,omitempty"`
-	WorkspaceID   string            `json:"workspace_id,omitempty"`
-	Workspace     *SessionWorkspace `json:"workspace,omitempty"`
-	EnvItems      []SessionEnvVar   `json:"env_items,omitempty"`
+	Summary          SessionSummary    `json:"summary"`
+	BaseWorkspace    string            `json:"base_workspace,omitempty"`
+	WorkspaceID      string            `json:"workspace_id,omitempty"`
+	Workspace        *SessionWorkspace `json:"workspace,omitempty"`
+	EnvItems         []SessionEnvVar   `json:"env_items,omitempty"`
+	RuntimeEnvItems  []SessionEnvVar   `json:"-"`
+	ProviderEnvItems []SessionEnvVar   `json:"-"`
+}
+
+func restoreSessionTransientFields(dst, src *Session) {
+	if dst == nil || src == nil {
+		return
+	}
+	if len(src.RuntimeEnvItems) > 0 {
+		dst.RuntimeEnvItems = append([]SessionEnvVar(nil), src.RuntimeEnvItems...)
+	}
+	if len(src.ProviderEnvItems) > 0 {
+		dst.ProviderEnvItems = append([]SessionEnvVar(nil), src.ProviderEnvItems...)
+	}
 }
 
 type WorkspaceConfig struct {

--- a/pkg/agentcompose/run_coordinator_test.go
+++ b/pkg/agentcompose/run_coordinator_test.go
@@ -342,6 +342,61 @@ func TestRunAgentStreamSendFailurePersistsTerminalRun(t *testing.T) {
 	}
 }
 
+func TestRunAgentSessionEnvProviderUsesAgentDefinitionModelAfterSessionReload(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	spec := newProjectServiceTestSpec("session-provider-env", "session-agent-model")
+	spec.Variables = []*agentcomposev2.EnvVarSpec{
+		{Name: "LLM_API_ENDPOINT", Value: "https://session-openai.example.invalid/v1"},
+		{Name: "LLM_API_KEY", Value: "session-provider-key", Secret: true},
+	}
+	store, service, projectID := setupRunPreparationProject(t, spec, t.TempDir())
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+
+	resp, err := service.RunAgent(ctx, connect.NewRequest(&agentcomposev2.RunAgentRequest{
+		ProjectId:       projectID,
+		AgentName:       "reviewer",
+		Prompt:          "use session provider env",
+		ClientRequestId: "session-provider-env-request",
+	}))
+	if err != nil {
+		t.Fatalf("RunAgent returned error: %v", err)
+	}
+	summary := resp.Msg.GetRun().GetSummary()
+	if summary.GetStatus() != agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED || summary.GetSessionId() == "" {
+		t.Fatalf("RunAgent summary = %#v", summary)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1: %#v", len(providers), providers)
+	}
+	if providers[0].APIKey != "session-provider-key" || providers[0].BaseURL != "https://session-openai.example.invalid/v1" || providers[0].Scope != llmProviderScopeSessionEnv {
+		t.Fatalf("provider was not bootstrapped from session env: %#v", providers[0])
+	}
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMModels returned error: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "session-agent-model" {
+		t.Fatalf("models = %#v, want session-agent-model", models)
+	}
+	session, err := service.store.GetSession(ctx, summary.GetSessionId())
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	for _, item := range session.EnvItems {
+		if llmProviderKeyName(item.Name) || strings.Contains(item.Value, "session-provider-key") {
+			t.Fatalf("provider key leaked into persisted session env: %#v", session.EnvItems)
+		}
+	}
+}
+
 func TestIntegrationRunAgentCleanupFailureRecordsRunCleanupError(t *testing.T) {
 	testRunAgentCleanupFailureRecordsRunCleanupError(t)
 }

--- a/pkg/agentcompose/run_preparation.go
+++ b/pkg/agentcompose/run_preparation.go
@@ -14,9 +14,10 @@ import (
 )
 
 type ProjectRunPreparation struct {
-	EnvItems        []SessionEnvVar
-	WorkspaceConfig *WorkspaceConfig
-	Workspace       *SessionWorkspace
+	EnvItems         []SessionEnvVar
+	ProviderEnvItems []SessionEnvVar
+	WorkspaceConfig  *WorkspaceConfig
+	Workspace        *SessionWorkspace
 }
 
 func (s *Service) prepareProjectRun(ctx context.Context, run ProjectRunRecord, requestEnv []*agentcomposev2.EnvVarSpec) (ProjectRunPreparation, error) {
@@ -53,11 +54,13 @@ func (s *Service) prepareProjectRun(ctx context.Context, run ProjectRunRecord, r
 		agent.EnvItems,
 		sessionEnvItemsFromV2(requestEnv),
 	)
+	providerEnvItems := envItems
+	envItems = filterPersistedRuntimeEnv(envItems)
 	workspace, err := s.prepareProjectRunWorkspace(ctx, run, project, composeWorkspaceSpecFromV2(spec.GetWorkspace()), composeWorkspaceSpecFromV2(agentSpec.GetWorkspace()))
 	if err != nil {
 		return ProjectRunPreparation{}, err
 	}
-	prepared := ProjectRunPreparation{EnvItems: envItems}
+	prepared := ProjectRunPreparation{EnvItems: envItems, ProviderEnvItems: providerEnvItems}
 	if workspace != nil {
 		prepared.WorkspaceConfig = workspace
 		prepared.Workspace = toSessionWorkspaceSnapshot(*workspace)

--- a/pkg/agentcompose/run_service.go
+++ b/pkg/agentcompose/run_service.go
@@ -107,7 +107,7 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	if err != nil {
 		return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, err)
 	}
-	agentProvider, err := s.projectRunAgentProvider(ctx, run)
+	agentDefinition, err := s.projectRunAgentDefinition(ctx, run)
 	if err != nil {
 		run, markErr := coordinator.MarkFailed(ctx, ProjectRunTransitionRequest{
 			RunID:     run.RunID,
@@ -119,6 +119,10 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 			return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, markErr)
 		}
 		return run, err, nil
+	}
+	agentProvider := normalizeAgentKind(agentDefinition.Provider)
+	if agentProvider == "" {
+		agentProvider = defaultAgentProvider
 	}
 	if s.executor == nil {
 		err = fmt.Errorf("executor is required")
@@ -136,6 +140,8 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	cell, _, _, execErr := s.executor.ExecuteAgentRequest(ctx, sessionResult.Session, ExecuteAgentRequest{
 		Agent:             agentProvider,
 		AgentDefinitionID: run.ManagedAgentID,
+		Model:             agentDefinition.Model,
+		RunID:             run.RunID,
 		Message:           msg.GetPrompt(),
 		OutputSchemaJSON:  msg.GetOutputSchemaJson(),
 		Stream:            projectRunAgentExecutionStream(run, stream),
@@ -157,16 +163,12 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	return run, nil, nil
 }
 
-func (s *Service) projectRunAgentProvider(ctx context.Context, run ProjectRunRecord) (string, error) {
+func (s *Service) projectRunAgentDefinition(ctx context.Context, run ProjectRunRecord) (AgentDefinition, error) {
 	agent, err := s.configDB.GetAgentDefinition(ctx, run.ManagedAgentID)
 	if err != nil {
-		return "", fmt.Errorf("resolve managed agent definition %s: %w", run.ManagedAgentID, err)
+		return AgentDefinition{}, fmt.Errorf("resolve managed agent definition %s: %w", run.ManagedAgentID, err)
 	}
-	provider := normalizeAgentKind(agent.Provider)
-	if provider == "" {
-		provider = defaultAgentProvider
-	}
-	return provider, nil
+	return agent, nil
 }
 
 func projectRunAgentExecutionStream(run ProjectRunRecord, sink *projectRunStreamSink) AgentExecutionStream {

--- a/pkg/agentcompose/run_session.go
+++ b/pkg/agentcompose/run_session.go
@@ -79,6 +79,7 @@ func (s *Service) ensureProjectRunSession(ctx context.Context, run ProjectRunRec
 	if err != nil {
 		return ProjectRunSessionResult{}, err
 	}
+	session.ProviderEnvItems = prepared.ProviderEnvItems
 	if err := s.startProjectRunSession(ctx, session, "session.created", "session started for project run"); err != nil {
 		return ProjectRunSessionResult{Session: session, Created: true}, err
 	}
@@ -110,6 +111,7 @@ func (s *Service) startProjectRunSession(ctx context.Context, session *Session, 
 	if err != nil {
 		return err
 	}
+	restoreSessionTransientFields(loaded, session)
 	*session = *loaded
 	return nil
 }

--- a/pkg/agentcompose/runtime_provider.go
+++ b/pkg/agentcompose/runtime_provider.go
@@ -132,6 +132,10 @@ func toDriverSession(session *Session) *driverpkg.Session {
 	for _, item := range session.EnvItems {
 		envItems = append(envItems, driverpkg.SessionEnvVar{Name: item.Name, Value: item.Value, Secret: item.Secret})
 	}
+	runtimeEnvItems := make([]driverpkg.SessionEnvVar, 0, len(session.RuntimeEnvItems))
+	for _, item := range session.RuntimeEnvItems {
+		runtimeEnvItems = append(runtimeEnvItems, driverpkg.SessionEnvVar{Name: item.Name, Value: item.Value, Secret: item.Secret})
+	}
 	return &driverpkg.Session{
 		Summary: driverpkg.SessionSummary{
 			ID:            session.Summary.ID,
@@ -142,7 +146,8 @@ func toDriverSession(session *Session) *driverpkg.Session {
 			CreatedAt:     session.Summary.CreatedAt,
 			UpdatedAt:     session.Summary.UpdatedAt,
 		},
-		EnvItems: envItems,
+		EnvItems:        envItems,
+		RuntimeEnvItems: runtimeEnvItems,
 	}
 }
 

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -170,6 +170,7 @@ func Register(di do.Injector) {
 	app.Any(path+"*", echo.WrapHandler(handler))
 
 	registerWebhookRoutes(app, service)
+	registerRuntimeLLMFacadeRoutes(app, service)
 	registerProxyRoutes(app, service)
 	registerWorkspaceRoutes(app, service)
 }
@@ -553,6 +554,9 @@ func (s *Service) reconcileSessionRuntimeState(ctx context.Context, session *Ses
 	session.Summary.VMStatus = VMStatusStopped
 	if err := s.store.UpdateSession(ctx, session); err != nil {
 		return nil, err
+	}
+	if s.configDB != nil {
+		_ = s.configDB.RevokeLLMFacadeTokensForSession(ctx, session.Summary.ID)
 	}
 	_ = s.store.AddEvent(ctx, session.Summary.ID, SessionEvent{
 		ID:        uuid.NewString(),
@@ -1191,9 +1195,12 @@ func buildLoaderCommandExecSpec(config *appconfig.Config, session *Session, gues
 
 func buildSessionExecEnv(config *appconfig.Config, session *Session, home string) map[string]string {
 	appconfig.ApplyDefaultGuestPaths(config)
-	env := sessionEnvMap(session.EnvItems)
+	env := runtimeEnvMap(session.EnvItems)
 	if env == nil {
 		env = map[string]string{}
+	}
+	for key, value := range managedRuntimeEnvMap(session.RuntimeEnvItems) {
+		env[key] = value
 	}
 	env["GOPATH"] = "/usr/local/go"
 	env["PATH"] = "/root/.local/bin:/usr/local/go/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -1316,7 +1323,7 @@ func (e *Executor) resolveAgentSystemPrompt(ctx context.Context, session *Sessio
 	return strings.TrimSpace(agentDef.SystemPrompt), nil
 }
 
-func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent, agentDefinitionID, message, outputSchemaJSON string, stream ExecStreamWriter) (ExecResult, AgentRunResult, error) {
+func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent, agentDefinitionID, model, runID, message, outputSchemaJSON string, stream ExecStreamWriter) (ExecResult, AgentRunResult, error) {
 	if session.Summary.VMStatus != VMStatusRunning {
 		return ExecResult{}, AgentRunResult{}, fmt.Errorf("session is not running")
 	}
@@ -1343,7 +1350,24 @@ func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent,
 	if err != nil {
 		return ExecResult{}, AgentRunResult{}, err
 	}
-	result, err := runtime.ExecStream(ctx, session, vmState, buildAgentExecSpec(e.config, session, agent, promptPath, schemaPath), stream)
+	spec := buildAgentExecSpec(e.config, session, agent, promptPath, schemaPath)
+	managedEnv, err := ensureSessionLLMFacadeConfig(ctx, e.config, e.configDB, session, agent, model, llmFacadeTokenSourceAgent, runID)
+	if err != nil {
+		return ExecResult{}, AgentRunResult{}, err
+	}
+	if len(managedEnv) > 0 {
+		spec.Env = mergeManagedExecEnv(spec.Env, managedEnv)
+		// The per-run facade token is only needed while this bounded run executes.
+		// Retire it as soon as the run returns so live tokens never accumulate over
+		// the lifetime of a long-running session. Use a detached context because the
+		// run context may already be cancelled (e.g. timeout) by the time this runs.
+		if e.configDB != nil {
+			if token := managedEnv["AGENT_COMPOSE_SESSION_TOKEN"]; token != "" {
+				defer func() { _ = e.configDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), token) }()
+			}
+		}
+	}
+	result, err := runtime.ExecStream(ctx, session, vmState, spec, stream)
 	if err != nil {
 		return sanitizeAgentExecResult(result), AgentRunResult{}, err
 	}

--- a/pkg/agentcompose/session_driver.go
+++ b/pkg/agentcompose/session_driver.go
@@ -17,6 +17,7 @@ type Driver interface {
 type SessionDriver struct {
 	config   *appconfig.Config
 	store    *Store
+	configDB *ConfigStore
 	runtimes RuntimeProvider
 }
 
@@ -24,6 +25,7 @@ func NewDriver(di do.Injector) (Driver, error) {
 	return &SessionDriver{
 		config:   do.MustInvoke[*appconfig.Config](di),
 		store:    do.MustInvoke[*Store](di),
+		configDB: do.MustInvoke[*ConfigStore](di),
 		runtimes: do.MustInvoke[RuntimeProvider](di),
 	}, nil
 }
@@ -115,6 +117,11 @@ func (d *SessionDriver) StopSessionVM(ctx context.Context, session *Session) err
 	if missing {
 		vmState.BoxID = ""
 	}
+	if d.configDB != nil {
+		if err := d.configDB.RevokeLLMFacadeTokensForSession(ctx, session.Summary.ID); err != nil {
+			return err
+		}
+	}
 	return d.store.SaveVMState(session.Summary.ID, vmState)
 }
 
@@ -122,6 +129,13 @@ func (d *SessionDriver) prepareSessionStart(ctx context.Context, driver string, 
 	prepared, err := driverpkg.PrepareSessionStart(ctx, d.config, driver, toDriverSession(session), toDriverVMState(*vmState))
 	if err != nil {
 		return err
+	}
+	managedEnv, err := ensureSessionLLMFacadeConfig(ctx, d.config, d.configDB, session, "codex", "", "session", "")
+	if err != nil {
+		return err
+	}
+	if len(managedEnv) > 0 {
+		session.RuntimeEnvItems = envItemsFromMap(managedEnv, false)
 	}
 	*vmState = fromDriverVMState(prepared)
 	return nil

--- a/pkg/agentcompose/session_rpc_bridge.go
+++ b/pkg/agentcompose/session_rpc_bridge.go
@@ -179,6 +179,8 @@ func (b *SessionRPCBridge) createSession(ctx context.Context, req *connect.Reque
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	envItems = mergeEnvItems(globalEnvItems, envItems)
+	providerEnvItems := envItems
+	envItems = filterPersistedRuntimeEnv(envItems)
 	capabilityVars, capabilityTags := buildCapabilityGatewaySessionVars(capabilityGatewayProxyTarget(b.cap), req.Msg.GetCapsetIds())
 	envItems = mergeEnvItems(envItems, capabilityVars)
 	tags = append(tags, capabilityTags...)
@@ -202,6 +204,7 @@ func (b *SessionRPCBridge) createSession(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	session.ProviderEnvItems = providerEnvItems
 	if err := prepareSessionWorkspace(ctx, b.config, b.configDB, session); err != nil {
 		session.Summary.VMStatus = VMStatusFailed
 		_ = b.store.UpdateSession(ctx, session)
@@ -232,6 +235,7 @@ func (b *SessionRPCBridge) createSession(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	restoreSessionTransientFields(loaded, session)
 	b.publishLoaderTopic("agent-compose.session.created", sessionTopicPayload(loaded, source))
 	return connect.NewResponse(&agentcomposev1.SessionResponse{Session: toProtoSessionDetail(loaded)}), nil
 }
@@ -265,6 +269,7 @@ func (b *SessionRPCBridge) resumeSession(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	restoreSessionTransientFields(loaded, session)
 	b.publishLoaderTopic("agent-compose.session.resumed", sessionTopicPayload(loaded, source))
 	return connect.NewResponse(&agentcomposev1.SessionResponse{Session: toProtoSessionDetail(loaded)}), nil
 }
@@ -316,6 +321,9 @@ func (b *SessionRPCBridge) reconcileSessionRuntimeState(ctx context.Context, ses
 	session.Summary.VMStatus = VMStatusStopped
 	if err := b.store.UpdateSession(ctx, session); err != nil {
 		return nil, err
+	}
+	if b.configDB != nil {
+		_ = b.configDB.RevokeLLMFacadeTokensForSession(ctx, session.Summary.ID)
 	}
 	b.streams.PublishSessionUpdated(&session.Summary)
 	b.notifyDashboard("session_updated")

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -43,6 +43,7 @@ type AuthManager struct {
 	secret         []byte
 	ttl            time.Duration
 	bypass         func(*http.Request) bool
+	skipper        func(*http.Request) bool
 	oauthEnabled   bool
 	oauthUser      string
 	oauthUserInfo  string
@@ -57,6 +58,7 @@ type Config struct {
 	AuthSecret            string
 	AuthSessionTTL        time.Duration
 	Bypass                func(*http.Request) bool
+	Skipper               func(*http.Request) bool
 	OAuthAPIKey           string
 	OAuthSecret           string
 	OAuthScopes           []string
@@ -82,6 +84,7 @@ func NewAuthManager(config *Config) *AuthManager {
 		password:       config.AuthPassword,
 		ttl:            config.AuthSessionTTL,
 		bypass:         config.Bypass,
+		skipper:        config.Skipper,
 		oauthStateTTL:  5 * time.Minute,
 		oauthCookieTTL: config.AuthSessionTTL,
 	}
@@ -149,6 +152,9 @@ func (a *AuthManager) RegisterRoutes(e *echo.Echo) {
 func (a *AuthManager) Middleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		if !a.enabled || isPublicAuthPath(c.Request().URL.Path) {
+			return next(c)
+		}
+		if a.skipper != nil && a.skipper(c.Request()) {
 			return next(c)
 		}
 		if a.bypass != nil && a.bypass(c.Request()) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	LLMAPIKey                 string
 	LLMModel                  string
 	LLMTimeout                time.Duration
+	RuntimeBaseURL            string
 	AgentTimeout              time.Duration
 	LoaderRunTimeout          time.Duration
 	RuntimeDriver             string
@@ -147,6 +148,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 	llmAPIKey := getenvFirst("LLM_API_KEY", "OPENAI_API_KEY")
 
 	llmModel := os.Getenv("LLM_MODEL")
+	runtimeBaseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("AGENT_COMPOSE_RUNTIME_BASE_URL")), "/")
 
 	llmTimeout := 60 * time.Second
 	if raw := os.Getenv("LLM_TIMEOUT"); raw != "" {
@@ -450,6 +452,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		LLMAPIKey:                 llmAPIKey,
 		LLMModel:                  llmModel,
 		LLMTimeout:                llmTimeout,
+		RuntimeBaseURL:            runtimeBaseURL,
 		AgentTimeout:              agentTimeout,
 		LoaderRunTimeout:          loaderRunTimeout,
 		RuntimeDriver:             runtimeDriver,

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -947,7 +947,7 @@ func (r *cgoBoxRuntime) buildBoxOptions(ctx context.Context, session *Session, v
 	defer freeCommand()
 	C.boxlite_options_set_cmd(options, command, C.int(commandLen))
 
-	baseEnv := sessionEnvMap(session.EnvItems)
+	baseEnv := sessionEnvMap(session.EnvItems, session.RuntimeEnvItems)
 	if baseEnv == nil {
 		baseEnv = map[string]string{}
 	}

--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -538,7 +538,7 @@ func (r *dockerRuntime) containerName(session *Session, vmState VMState) string 
 
 func (r *dockerRuntime) containerEnv(session *Session, proxyState ProxyState) []string {
 	appconfig.ApplyDefaultGuestPaths(r.config)
-	env := sessionEnvMap(session.EnvItems)
+	env := sessionEnvMap(session.EnvItems, session.RuntimeEnvItems)
 	if env == nil {
 		env = map[string]string{}
 	}

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -615,7 +615,7 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sessio
 	} else if ok {
 		imageRef = resolvedRef
 	}
-	env := sessionEnvMap(session.EnvItems)
+	env := sessionEnvMap(session.EnvItems, session.RuntimeEnvItems)
 	if env == nil {
 		env = map[string]string{}
 	}

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -24,8 +24,9 @@ type SessionSummary struct {
 }
 
 type Session struct {
-	Summary  SessionSummary  `json:"summary"`
-	EnvItems []SessionEnvVar `json:"env_items,omitempty"`
+	Summary         SessionSummary  `json:"summary"`
+	EnvItems        []SessionEnvVar `json:"env_items,omitempty"`
+	RuntimeEnvItems []SessionEnvVar `json:"-"`
 }
 
 type VMState struct {
@@ -86,22 +87,36 @@ type BoxRuntime interface {
 	ExecStream(context.Context, *Session, VMState, ExecSpec, ExecStreamWriter) (ExecResult, error)
 }
 
-func sessionEnvMap(items []SessionEnvVar) map[string]string {
-	if len(items) == 0 {
+func sessionEnvMap(groups ...[]SessionEnvVar) map[string]string {
+	if len(groups) == 0 {
 		return nil
 	}
-	env := make(map[string]string, len(items))
-	for _, item := range items {
-		name := strings.TrimSpace(item.Name)
-		if name == "" {
-			continue
+	env := make(map[string]string)
+	for groupIndex, items := range groups {
+		for _, item := range items {
+			name := strings.TrimSpace(item.Name)
+			if name == "" || (groupIndex == 0 && LLMProviderKeyName(name)) {
+				continue
+			}
+			env[name] = item.Value
 		}
-		env[name] = item.Value
 	}
 	if len(env) == 0 {
 		return nil
 	}
 	return env
+}
+
+// LLMProviderKeyName reports whether name is a long-lived LLM provider credential
+// that must never be passed through to a guest runtime. It is the canonical
+// denylist shared by the driver env assembly and the agent-compose facade layer.
+func LLMProviderKeyName(name string) bool {
+	switch strings.ToUpper(strings.TrimSpace(name)) {
+	case "LLM_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY", "AZURE_OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY":
+		return true
+	default:
+		return false
+	}
 }
 
 func firstNonEmpty(values ...string) string {

--- a/pkg/driver/types_test.go
+++ b/pkg/driver/types_test.go
@@ -1,0 +1,18 @@
+package driver
+
+import "testing"
+
+func TestSessionEnvMapKeepsNonLLMSecretEnv(t *testing.T) {
+	env := sessionEnvMap([]SessionEnvVar{
+		{Name: "DATABASE_PASSWORD", Value: "db-secret", Secret: true},
+		{Name: "OPENAI_API_KEY", Value: "provider-key", Secret: true},
+	}, []SessionEnvVar{
+		{Name: "OPENAI_API_KEY", Value: "facade-token", Secret: false},
+	})
+	if env["DATABASE_PASSWORD"] != "db-secret" {
+		t.Fatalf("DATABASE_PASSWORD = %q, want non-LLM secret env to be preserved", env["DATABASE_PASSWORD"])
+	}
+	if env["OPENAI_API_KEY"] != "facade-token" {
+		t.Fatalf("OPENAI_API_KEY = %q, want managed facade token", env["OPENAI_API_KEY"])
+	}
+}


### PR DESCRIPTION
## Summary

Adds a daemon-side Runtime LLM Facade so guest runtimes no longer receive upstream provider keys directly. The daemon now owns provider/model resolution, session-scoped facade tokens, key/header injection, and OpenAI/Anthropic protocol conversion through `ai-api-protocol-bridge`.

## What changed

- Add daemon-side LLM provider/model config, facade token storage, and runtime LLM facade routes.
- Support OpenAI Responses, OpenAI Chat Completions, and Anthropic Messages inbound facade APIs.
- Bridge OpenAI-family and Anthropic-family requests/responses, including SSE streams.
- Inject daemon-managed facade env aliases into runtime sessions and agent runs, including `LLM_API_KEY`, `LLM_API_ENDPOINT`, provider-specific key aliases, and facade base URLs.
- Filter real LLM provider keys from user-supplied runtime env while preserving unrelated `secret=true` env vars.
- Generate per-session Codex config dynamically instead of hardcoding upstream provider settings in assets.
- Document runtime LLM facade behavior and supported environment variables.

## Token lifecycle & resolution hardening

- Scope per-agent-run facade tokens to the run: mint at run start and delete on completion, so live tokens never accumulate over the lifetime of a long-running session.
- Prune revoked/expired token rows on session stop/reconcile as a crash backstop, keeping the token table bounded.
- Carry `run_id` in the facade token scope for auditability.
- Resolve the Anthropic auth header (`x-api-key` vs `Authorization: Bearer`) from the same env source the provider key is resolved from, so a session-scoped provider never mixes a key from one scope with a header decided by another.
- Skip the redundant env/default provider bootstrap on the facade hot path when the requested provider already exists.
- Internal cleanup: unify the OpenAI/Anthropic env-provider bootstrap behind a shared source-major lookup, share the LLM provider-key denylist between the driver and facade layers, and drop dead code.

## Compatibility

> **Breaking for some Docker setups.** Because provider keys are no longer passed through to guest runtimes, Codex/Claude reach their LLM upstream through the daemon facade and need a guest-reachable daemon URL. The bundled `docker-compose.yml` / `docker-compose.deploy.yml` default `AGENT_COMPOSE_RUNTIME_BASE_URL=http://agent-compose:7410`. A daemon run directly on a host with the Docker driver and an `HTTP_LISTEN=127.0.0.1:...` bind must set `AGENT_COMPOSE_RUNTIME_BASE_URL` to a host-reachable IP/name and port (e.g. `http://host.docker.internal:7410`); otherwise facade config is skipped and agent runs have no working LLM credentials.

## Related issues

Fixes #27

Related but not closed: #14, #20, #22, #31.

## Validation

Rebased onto latest `main` (incl. #61 agent system prompt convention); both feature sets coexist.

- `go test ./pkg/agentcompose ./pkg/driver` (full packages, all green)
- Targeted: `go test ./pkg/agentcompose -run 'TestRuntimeLLM|TestEnsureSessionLLMFacadeConfig|TestEnsureSessionAnthropicEnvProviderAuthUsesSessionEnvOnly|TestRevokeLLMFacadeTokensForSessionPrunesDeadRows|TestDeleteLLMFacadeToken|TestResolveRuntimeLLMTargetByExistingProviderID|TestManagedRuntimeEnvMapKeepsFacadeKeyAliases|TestCreateSessionFiltersLLMProviderKeysFromPersistedEnv|TestAnthropicProvider|TestProviderForwardHeaders'`
- `go build ./...`, `go vet ./pkg/agentcompose ./pkg/driver`, `gofmt` clean
