### PR TITLE
feat: Wire agent system_prompt via convention path discovery (Phase 1)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ The design notes below describe current implementation details. Chinese versions
 are available under [zh-CN/design/](zh-CN/design/).
 
 - [Architecture notes](design/agent-compose_design.md)
+- [Agent system prompt (Phase 1)](design/agent_system_prompt_design.md)
 - [Runtime JavaScript contract](design/agent-compose-runtime-js_contract.md)
 - [Runtime environment variables](design/runtime_environment_variables_design.md)
 - [Runtime mount manifest](design/runtime_mount_manifest_design.md)

--- a/docs/design/agent-compose-runtime-js_contract.md
+++ b/docs/design/agent-compose-runtime-js_contract.md
@@ -121,6 +121,20 @@ guest: /data/state/agents/prompts/<provider>-<unix_nano>.txt
 
 The guest path is then passed to the JavaScript runtime through `--message-file`.
 
+When a run is bound to an agent definition with non-empty `system_prompt`, the
+host writes the trimmed text to a fixed convention path:
+
+```text
+host:  <session>/state/agents/system-prompts/system-prompt.txt
+guest: /data/state/agents/system-prompts/system-prompt.txt
+```
+
+The guest runtime reads this path via `agentSystemPromptPath(stateRoot)` in
+`prompt.ts`. If the file is missing or empty, `readSystemPromptFile` returns
+`""` and the run composes MPI-only context. When `system_prompt` becomes empty,
+the host removes `system-prompt.txt` to avoid stale identity on later runs in
+the same session.
+
 ### 3.3 Agent HOME And Initial Config
 
 The host sets these values for agent execution:
@@ -168,9 +182,11 @@ Command arguments:
 | --- | ---: | --- |
 | `--provider` | yes | `codex`, `claude`, `gemini`, with a small set of aliases |
 | `--message-file` | yes | Prompt file path |
-| `--state-root` | no | agent-compose runtime state root; default `/srv/agent-compose/session/state` |
+| `--state-root` | no | agent-compose runtime state root; default `/srv/agent-compose/session/state`. Guest discovers agent identity at `agents/system-prompts/system-prompt.txt` and MPI catalog from this root |
 | `--workspace` | no | Agent working directory; default `WORKSPACE` or `/workspace` |
 | `--home` | no | Agent HOME; default `HOME` or `/root` |
+
+Agent identity uses the fixed convention path documented in §3.2.
 
 Inside an agent-compose session, the host always passes `--state-root`,
 `--workspace`, and `--home` explicitly.
@@ -531,8 +547,10 @@ approvalPolicy=never
 networkAccessEnabled=true
 ```
 
-If `/data/runtime/mpi/catalog.md` exists and is readable, the JavaScript runtime
-injects MPI catalog context through Codex `config.developer_instructions`.
+If `/data/state/agents/system-prompts/system-prompt.txt` and/or
+`/data/runtime/mpi/catalog.md` exist and are readable, the JavaScript runtime
+composes Agent Identity + MPI into `systemContext` and injects it through Codex
+`config.developer_instructions`.
 
 Codex events are converted into a human-readable transcript, including agent
 messages, reasoning, command execution, file changes, MCP calls, web search, and
@@ -554,20 +572,22 @@ allowDangerouslySkipPermissions=true
 resume=<stored session id>
 ```
 
-If `/data/runtime/mpi/catalog.md` exists and is readable, the JavaScript runtime
-injects MPI catalog context through
-`systemPrompt: { type: "preset", preset: "claude_code", append: <mpi-context> }`.
+If `/data/state/agents/system-prompts/system-prompt.txt` and/or
+`/data/runtime/mpi/catalog.md` exist and are readable, the JavaScript runtime
+composes Agent Identity + MPI into `systemContext` and injects it through
+`systemPrompt: { type: "preset", preset: "claude_code", append: <systemContext> }`.
 
 ### 10.3 Gemini
 
 The JavaScript runtime invokes Gemini as a subprocess:
 
 ```sh
-gemini -p <prompt> --output-format stream-json --approval-mode yolo
+gemini -p <systemContext + user prompt> --output-format stream-json --approval-mode yolo
 ```
 
-The current Gemini runner reads stream-json and generates a transcript, but does
-not write `/data/state/agents/providers/gemini.json`.
+When `systemContext` is non-empty, it is prepended to the user prompt separated
+by a blank line. The current Gemini runner reads stream-json and generates a
+transcript, but does not write `/data/state/agents/providers/gemini.json`.
 
 ## 11. Error Semantics
 
@@ -774,6 +794,7 @@ Changes to the JavaScript runtime or host invocation should preserve:
   the `__COMMAND_RESULT__` prefix.
 - Existing semantics for `--provider`, `--message-file`, `--state-root`,
   `--workspace`, and `--home`.
+- Agent identity discovery via `<state-root>/agents/system-prompts/system-prompt.txt`.
 - On success, stdout must contain parseable agent result JSON. The
   `__AGENT_RESULT__` prefix is recommended.
 - Human-readable process output should continue to use stderr to avoid

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -377,6 +377,40 @@ State queries primarily use project/run relationships in SQLite. Session tags
 are used for compatibility queries, `down` stopping project sessions, and
 file-level debugging.
 
+### Agent system prompt (Phase 1)
+
+`AgentDefinition.system_prompt` is persisted on agent definitions (manual and
+managed) and exposed through v1/v2 APIs and the Agents UI. At execution time the
+host resolves this field and materializes agent identity for the guest runtime.
+
+Layered prompt model:
+
+1. **Agent Identity** — per-agent `system_prompt` (omitted when empty)
+2. **Capabilities (MPI)** — OctoBus capset catalog under `runtime/mpi/catalog.md`
+3. **Per-turn task** — user message in `--message-file` (never mixed with identity)
+
+Transport uses a **fixed convention path** under the session state tree:
+
+```text
+<session>/state/agents/system-prompts/system-prompt.txt  →  guest /data/state/agents/system-prompts/system-prompt.txt
+```
+
+Resolution paths:
+
+- Managed project runs: `RunService` passes `run.ManagedAgentID` into
+  `ExecuteAgentRequest`
+- Loader runs: `loaderRunHost.Agent` passes the loader-bound agent definition id
+- Session chat: session tags `source=agent` and `agent_id`
+
+The guest JS runtime (`runtime/javascript`) reads the convention file from
+`--state-root`, composes identity + MPI via `buildSystemContext`, and injects the
+result into Codex `developer_instructions`, Claude `systemPrompt.append`, or
+Gemini user prompt prepend.
+
+See [agent_system_prompt_design.md](agent_system_prompt_design.md) and
+[agent-compose-runtime-js_contract.md](agent-compose-runtime-js_contract.md) for
+the full contract.
+
 ## Command Execution And Images
 
 `ExecService` does not create sessions. It executes commands only inside an

--- a/docs/design/agent_system_prompt_design.md
+++ b/docs/design/agent_system_prompt_design.md
@@ -1,0 +1,432 @@
+# Agent System Prompt — Phase 1 Design
+
+**Status:** Phase 1 is **implemented** in the current codebase. Sections through
+[Success Criteria (Phase 1, verified)](#success-criteria-phase-1-verified) document what shipped in
+this change. [Next Steps](#next-steps) lists work that was **not** part of Phase 1.
+
+Chinese version: [../zh-CN/design/agent_system_prompt_design.md](../zh-CN/design/agent_system_prompt_design.md)
+
+Related documents:
+
+- Runtime invocation contract: [agent-compose-runtime-js_contract.md](agent-compose-runtime-js_contract.md)
+
+Before Phase 1, `AgentDefinition.system_prompt` was persisted, exposed through
+API/Proto, and editable in the Agents UI, but the execution path never read it.
+Only the MPI (Model Program Interface) capability catalog reached provider
+system/developer instruction channels.
+
+Phase 1 closed that gap by wiring agent identity into a layered prompt model
+without introducing a full platform runtime brief.
+
+## Background
+
+### What already existed
+
+| Layer | Storage / source | Runtime behavior (pre–Phase 1) |
+| --- | --- | --- |
+| Agent identity | `AgentDefinition.system_prompt` in `config_store` | **Not injected** |
+| MPI catalog | Host writes `runtime/mpi/catalog.md` from OctoBus capsets | Injected into Codex / Claude only |
+| Per-turn task | Host writes `state/agents/prompts/<provider>-<nano>.txt` | Passed via `--message-file` |
+
+Provider injection before Phase 1:
+
+| Provider | Mechanism |
+| --- | --- |
+| Codex | `config.developer_instructions = mpiContext` |
+| Claude | `systemPrompt: { preset: "claude_code", append: mpiContext }` |
+| Gemini | No system context (MPI ignored) |
+
+### Prompt model
+
+agent-compose treats runtime instructions as three separable layers:
+
+1. **Platform context** — MPI capability catalog (existing)
+2. **Agent identity** — per-agent `system_prompt`
+3. **Per-turn task** — user message for the current turn
+
+Phase 1 wired **Agent Identity** into the existing MPI platform layer. It did
+not add a deployment-wide runtime brief, file-based workspace injection, or
+skills discovery.
+
+## Goals and Non-Goals
+
+### Phase 1 scope (delivered)
+
+- Make configured `system_prompt` affect Codex, Claude, and Gemini runs
+- Preserve per-turn message isolation (`--message-file` carries task text only)
+- Compose Agent Identity **before** the MPI catalog when both are present
+- Remain backward compatible when `system_prompt` is empty or no agent binding exists
+- Pass live combined context on Codex resume (via constructor-level config)
+- Cover loader runs and managed project runs that bind an agent definition
+
+### Deferred (see [Next Steps](#next-steps))
+
+- Renaming `system_prompt` → `instructions`
+- Workspace-level global context field
+- AGENTS.md / CLAUDE.md marker-block file injection and cleanup
+- Skills list or skill-bound prompt sections
+- Platform-wide issue workflow brief (mentions, metadata semantics, comment formatting)
+- Frontend changes (UI already supports editing `system_prompt`)
+- Proto or DB schema changes (`system_prompt` column already exists)
+- Injecting `description` into runtime instructions
+
+## Prompt Layering
+
+Implemented composition for provider system / developer instructions:
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ Provider system / developer instructions                     │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ ## Agent Identity                                      │  │
+│  │ AgentDefinition.system_prompt (DB, per agent)          │  │
+│  ├────────────────────────────────────────────────────────┤  │
+│  │ ## MPI Catalog                                         │  │
+│  │ OctoBus capset guides → runtime/mpi/catalog.md         │  │
+│  └────────────────────────────────────────────────────────┘  │
+├──────────────────────────────────────────────────────────────┤
+│ Per-turn user message (--message-file)                       │
+│ Chat text, loader script prompt, structured task input       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Rules:
+
+- Agent Identity is omitted when `system_prompt` is empty after trim.
+- MPI is omitted when no readable MPI catalog exists.
+- When MPI is present, the runtime preserves the MPI string from
+  `formatMpiContext`, including the existing `## MPI Catalog` header.
+- `description` is catalog metadata only and MUST NOT appear in runtime instructions.
+
+## End-to-End Data Flow
+
+```text
+┌─────────────┐     claim / chat      ┌──────────────────┐
+│ ConfigStore │◄──GetAgentDefinition──│ Service/Executor │
+│ system_prompt│                      │                  │
+└─────────────┘                       │ writeAgent       │
+                                      │ SystemPromptFile │
+                                      │ writeAgent       │
+                                      │ PromptFile       │
+                                      └────────┬─────────┘
+                                               │ ExecStream
+                                               ▼
+                              ┌────────────────────────────────┐
+                              │ guest: agent-compose-runtime   │
+                              │   prompt                       │
+                              │   --provider codex|claude|gemini│
+                              │   --message-file …/prompts/…   │
+                              │   --state-root /data/state     │
+                              └────────┬───────────────────────┘
+                                       │
+                    agentSystemPromptPath(stateRoot) + readMpiContext
+                                       │
+                              buildSystemContext()
+                                       │
+              ┌────────────────────────┼────────────────────────┐
+              ▼                        ▼                        ▼
+         CodexRunner              ClaudeRunner            GeminiRunner
+    developer_instructions    systemPrompt.append      prepend to -p
+```
+
+Guest command shape:
+
+```sh
+agent-compose-runtime prompt \
+  --provider <provider> \
+  --message-file /data/state/agents/prompts/<provider>-<unix_nano>.txt \
+  --state-root /data/state \
+  --workspace /workspace \
+  --home /root
+```
+
+The guest runtime discovers agent identity from a **fixed convention path** under
+`--state-root` (same pattern as MPI catalog discovery under `runtime/mpi/catalog.md`):
+
+```text
+host:  <session>/state/agents/system-prompts/system-prompt.txt
+guest: /data/state/agents/system-prompts/system-prompt.txt
+```
+
+When `system_prompt` is empty, the host **removes** `system-prompt.txt` so a later
+run in the same session cannot read stale identity text.
+
+## Host (Go) Implementation
+
+Primary files: `pkg/agentcompose/service.go`, `pkg/agentcompose/exec.go`,
+`pkg/agentcompose/loader_manager.go`, `pkg/agentcompose/run_service.go`.
+
+### Resolve agent system prompt
+
+**Function:** `Executor.resolveAgentSystemPrompt(ctx, session, agentDefinitionID string) (string, error)`
+
+Resolution order:
+
+1. If `agentDefinitionID` (`ExecuteAgentRequest.AgentDefinitionID`) is non-empty,
+   load that agent definition directly.
+2. Else, if the session has tags `source=agent` and `agent_id=<uuid>`, load by
+   tagged agent id.
+3. Else return `""` (not an error).
+
+On DB lookup failure, the host logs a warning and runs without agent identity
+(MPI-only behavior). Runs are not failed for a missing definition row.
+
+### Write system prompt file
+
+**Function:** `writeAgentSystemPromptFile(session, systemPrompt string) error`
+
+| Property | Value |
+| --- | --- |
+| Host path | `{hostSessionDir}/state/agents/system-prompts/system-prompt.txt` |
+| Guest path | `{GuestStateRoot}/agents/system-prompts/system-prompt.txt` (convention path under `--state-root`) |
+| Content | UTF-8 raw `systemPrompt` bytes (section headers added by guest runtime) |
+| Non-empty prompt | `MkdirAll` + write fixed filename |
+| Empty prompt | `os.Remove` fixed file; ignore `ENOENT` |
+
+The fixed provider-independent filename avoids coupling Go `normalizeAgentKind` to
+runtime provider normalization. Discovery mirrors MPI convention-based lookup under
+`--state-root`.
+
+### Extend execution request
+
+`ExecuteAgentRequest` gains `AgentDefinitionID string`:
+
+- **Loader runs** (`loader_manager.go`): set from resolved agent definition id
+  or `loader.Summary.AgentID` fallback.
+- **Managed project runs** (`run_service.go`): set from `run.ManagedAgentID`.
+- **Session chat runs**: rely on session tags when no explicit id is passed.
+
+`buildAgentExecSpec` passes `--state-root` only; the guest discovers agent identity
+from the convention path under that root.
+
+### Concurrency assumption
+
+The fixed filename assumes agent runs in the same session do not concurrently write
+different agent identities. Current UI/API paths serialize chat cells per session.
+If concurrent agent runs with different identities become a requirement, revisit
+per-run filenames or session-level locking.
+
+### Error handling summary
+
+| Condition | Behavior |
+| --- | --- |
+| Agent id present but DB row missing | Warn; run without agent identity |
+| Write/remove system prompt file fails | Fail run (same as prompt file write failure) |
+| Empty system prompt | Remove `system-prompt.txt` |
+| Missing convention file on guest | `readSystemPromptFile` returns `""`; MPI-only |
+
+## Guest Runtime (TypeScript) Implementation
+
+Primary files: `runtime/javascript/src/system-context.ts`, `prompt.ts`, `cli.ts`,
+`types.ts`, and provider runners under `runners/`.
+
+### New module: `system-context.ts`
+
+```typescript
+buildSystemContext(agentPrompt: string, mpiContext: string): string
+readSystemPromptFile(path?: string): Promise<string>
+```
+
+Composition logic:
+
+- When agent prompt is non-empty: emit `## Agent Identity`, blank line, trimmed
+  agent text.
+- When MPI is non-empty and agent prompt is also non-empty: append the trimmed
+  MPI context unchanged, preserving its `## MPI Catalog` header.
+- When agent prompt is empty but MPI exists: return MPI unchanged for backward
+  compatibility.
+- When both are empty: return `""`.
+
+`readSystemPromptFile` returns `""` for missing path, `ENOENT`, or empty file
+content after trim.
+
+### Convention path and prompt command
+
+- `system-context.ts`: exports `agentSystemPromptPath(stateRoot)` →
+  `{stateRoot}/agents/system-prompts/system-prompt.txt`.
+- `prompt.ts`: reads that convention path via `readSystemPromptFile`, reads MPI
+  catalog, calls `buildSystemContext`, passes the result to runners as
+  `systemContext`.
+- Discovery uses `--state-root` (same pattern as MPI catalog under
+  `runtime/mpi/catalog.md`).
+
+### RunnerOptions change
+
+`RunnerOptions.mpiContext` is replaced by `systemContext` (the combined string).
+MPI is still read internally in `prompt.ts` for composition; runners no longer
+receive raw MPI alone.
+
+## Provider-Specific Injection
+
+### Codex
+
+Combined context is passed on the Codex constructor:
+
+```typescript
+new Codex({
+  config: { developer_instructions: systemContext },
+})
+```
+
+The `@openai/codex-sdk` reads `config` at constructor scope, not from
+`ThreadOptions`. That means both `startThread` and `resumeThread` receive the
+current combined context on each run, including after `system_prompt` edits.
+
+### Claude
+
+Combined context is appended to the Claude Code preset:
+
+```typescript
+systemPrompt: {
+  type: "preset",
+  preset: "claude_code",
+  append: systemContext,
+}
+```
+
+### Gemini
+
+Gemini has no native system-instruction channel in the current runner. Phase 1
+shipped an interim fallback:
+
+```typescript
+const userPrompt = systemContext
+  ? `${systemContext}\n\n${promptText}`
+  : promptText;
+```
+
+The subprocess is invoked with `-p userPrompt`. This intentionally merges identity
+and task into one CLI argument until a native system channel exists.
+
+No Gemini trust or permission flags are changed in Phase 1; those remain outside
+the system prompt wiring scope.
+
+## Binding Scenarios
+
+| Run type | How agent identity is resolved |
+| --- | --- |
+| Agent session chat | Session tags `source=agent` + `agent_id` |
+| Loader script `agent()` call | `AgentDefinitionID` from loader-bound agent |
+| Managed project run (v2) | `run.ManagedAgentID` |
+| Bare provider string, no agent | No agent identity; MPI-only if catalog exists |
+
+## Testing
+
+### Go (`pkg/agentcompose/agent_system_prompt_test.go`)
+
+- Empty `system_prompt` resolves to `""`
+- Session-tagged agent resolves trimmed prompt text
+- `writeAgentSystemPromptFile` writes/removes fixed `system-prompt.txt`
+- Empty prompt removes file (no stale identity)
+- `buildAgentExecSpec` passes `--state-root` for convention-path discovery
+
+### Runtime JS (`runtime/javascript/test/system-context.test.ts`)
+
+- Section ordering (Agent Identity before Capabilities)
+- Agent-only, MPI-only, both, neither
+- MPI-only path matches pre-change injection (no `## Agent Identity`)
+- `readSystemPromptFile` trim and missing-file behavior
+
+Runner tests (`runners.test.ts`, `runner-execution.test.ts`) were updated to use
+`systemContext` instead of `mpiContext`.
+
+## Security and Operations
+
+- `system_prompt` is workspace-owner controlled (same trust boundary as existing
+  agent admin APIs). No new injection surface beyond current agent configuration.
+- System prompt files live in the session state tree alongside per-turn prompt
+  files. They are subject to the same session lifecycle and cleanup.
+- Paths are passed through `shellQuote` in the exec spec; no shell interpolation
+  of prompt content.
+- Phase 1 does not introduce a hard size limit. Follow existing practical limits
+  for prompt files.
+
+## Rollout (Phase 1)
+
+| Area | Change |
+| --- | --- |
+| Database | None |
+| API / Proto | None |
+| Guest image | Runtime JS changes are merged; production guest image rebuild follows the normal release process. Dev mounts can pick up JS without rebuild. |
+| Behavior | Non-empty `system_prompt` takes effect after deploy; empty prompt preserves pre-change MPI-only behavior |
+
+## File Change Map (Phase 1)
+
+| File | Change |
+| --- | --- |
+| `pkg/agentcompose/service.go` | `resolveAgentSystemPrompt`, `writeAgentSystemPromptFile`, `executeAgentRun` |
+| `pkg/agentcompose/exec.go` | `AgentDefinitionID` on `ExecuteAgentRequest`; inject `configDB` into `Executor` |
+| `pkg/agentcompose/loader_manager.go` | Pass agent definition id into agent execution |
+| `pkg/agentcompose/run_service.go` | Pass `ManagedAgentID` into agent execution |
+| `pkg/agentcompose/agent_system_prompt_test.go` | **new** — host resolution, fixed-path write/remove tests |
+| `runtime/javascript/src/system-context.ts` | **new** — `agentSystemPromptPath`, composition, file read helpers |
+| `runtime/javascript/src/prompt.ts` | Convention-path read; compose `systemContext` before runner dispatch |
+| `runtime/javascript/src/types.ts` | `systemContext` on `RunnerOptions` |
+| `runtime/javascript/src/runners/codex.ts` | `developer_instructions` from `systemContext` |
+| `runtime/javascript/src/runners/claude.ts` | `systemPrompt.append` from `systemContext` |
+| `runtime/javascript/src/runners/gemini.ts` | Prepend `systemContext` to `-p` |
+| `runtime/javascript/test/system-context.test.ts` | **new** — composition unit tests |
+| `runtime/javascript/test/runners.test.ts` | Updated for `systemContext` |
+| `runtime/javascript/test/runner-execution.test.ts` | Updated for `systemContext` |
+| `docs/design/agent-compose-runtime-js_contract.md` | Document convention path and layering |
+
+## Success Criteria (Phase 1, verified)
+
+1. Agent with `system_prompt: "Reply only in Chinese"` obeys after Codex/Claude chat run.
+2. Empty `system_prompt` → identical to pre-change MPI-only behavior.
+3. Codex session resume after prompt edit uses new instructions.
+4. Loader bound to an agent definition inherits `system_prompt`.
+5. `task test`, runtime JS tests, and `task lint` pass on touched packages.
+
+## Next Steps
+
+The items below were **not** implemented in Phase 1. They are planned follow-ups.
+
+### Platform runtime brief
+
+Add a workspace- or deployment-level brief layer above Agent Identity and MPI.
+Would cover platform guardrails, issue workflow semantics, and comment formatting
+rules not tied to a single agent definition.
+
+### Workspace global context
+
+Introduce a workspace-level context field distinct from per-agent
+`system_prompt`.
+
+### File-based workspace injection
+
+Inject marker blocks into `AGENTS.md`, `CLAUDE.md`, or similar discovery files
+with safe cleanup on run completion. Aligns with native Codex/Claude workspace
+discovery for `local_directory` workspaces.
+
+### Skills in system context
+
+Discover and inject skill summaries or on-demand `SKILL.md` sections into the
+composed brief, similar to Cursor Agent Skills.
+
+### Gemini native system channel
+
+Replace the `-p` prepend fallback when the Gemini CLI or SDK exposes a dedicated
+system-instruction parameter. Until then, per-turn message isolation remains
+relaxed for Gemini only.
+
+### Field rename: `system_prompt` → `instructions`
+
+Rename for clearer semantics in API and UI. Requires Proto, DB migration, UI,
+and client updates.
+
+### Force fresh Codex thread on prompt change
+
+If a future SDK version stops applying constructor `config` on resume, the host
+could detect a hash of `system_prompt` and force a new thread when instructions
+change. Phase 1 relies on current SDK behavior.
+
+### Prompt file soft size limit
+
+Document a soft recommendation (e.g. < 8 KiB) for `system_prompt` and combined
+system context size.
+
+### Frontend surfacing
+
+The Agents UI already edits `system_prompt`. `docs/README.md` notes that the
+field is runtime-active. Optional follow-up: in-app hints or expanded user docs.

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -81,7 +81,7 @@ agent-compose down
 
 agent 常用字段：
 
-- `provider` / `model` / `system_prompt`：guest agent 配置（`provider` 选择 guest CLI runner；`model` 传给该 agent runtime）。目前支持 `codex`、`claude`、`gemini`。daemon 侧 LLM 调用（`LLMService`、`scheduler.llm`）使用 `LLM_MODEL`，不是 compose 里的 agent `model`。
+- `provider` / `model` / `system_prompt`：guest agent 配置（`provider` 选择 guest CLI runner；`model` 传给该 agent runtime）。非空 `system_prompt` 在运行时生效，并作为 Agent Identity 层注入 provider system/developer 指令。目前支持 `codex`、`claude`、`gemini`。daemon 侧 LLM 调用（`LLMService`、`scheduler.llm`）使用 `LLM_MODEL`，不是 compose 里的 agent `model`。
 - `image`：guest 镜像引用；为空时使用 driver 对应默认镜像。
 - `driver`：每个 agent 可选择一个 runtime，支持 `boxlite`、`docker`、`microsandbox`。
 - `env`：agent 级环境变量，支持 scalar 或 `{ value, secret }` 形状。
@@ -188,6 +188,7 @@ task test
 
 - [英文文档索引](../README.md)
 - [架构说明](design/agent-compose_design.md)
+- [Agent system prompt（Phase 1）](design/agent_system_prompt_design.md)
 - [Runtime JS contract](design/agent-compose-runtime-js_contract.md)
 - [Webhook design](design/webhook_design.md)
 - [Loader script API](../../loader-script/README.md)

--- a/docs/zh-CN/design/agent-compose-runtime-js_contract.md
+++ b/docs/zh-CN/design/agent-compose-runtime-js_contract.md
@@ -102,6 +102,15 @@ guest: /data/state/agents/prompts/<provider>-<unix_nano>.txt
 
 guest 路径随后通过 `--message-file` 传给 JS runtime。
 
+当 run 绑定到非空 `system_prompt` 的 agent definition 时，host 将 trim 后的文本写入固定约定路径：
+
+```text
+host:  <session>/state/agents/system-prompts/system-prompt.txt
+guest: /data/state/agents/system-prompts/system-prompt.txt
+```
+
+Guest runtime 在 `prompt.ts` 中通过 `agentSystemPromptPath(stateRoot)` 读取该路径。文件缺失或为空时，`readSystemPromptFile` 返回 `""`，run 组合为 MPI-only context。当 `system_prompt` 变为空时，host 删除 `system-prompt.txt`，避免同 session 后续 run 读到过期 identity。
+
 ### 3.3 agent HOME 与初始配置
 
 host 为 agent 执行设置：
@@ -143,9 +152,11 @@ CLI 使用 `commander` 解析命令和参数。npm 包的 `bin` 入口为 `agent
 |---|---:|---|
 | `--provider` | 是 | `codex`、`claude`、`gemini`，支持少量别名 |
 | `--message-file` | 是 | prompt 文件路径 |
-| `--state-root` | 否 | agent-compose runtime 状态根目录，默认 `/srv/agent-compose/session/state` |
+| `--state-root` | 否 | agent-compose runtime 状态根目录，默认 `/srv/agent-compose/session/state`。Guest 从此根路径按约定发现 agent identity（`agents/system-prompts/system-prompt.txt`）与 MPI catalog |
 | `--workspace` | 否 | agent 工作目录，默认 `WORKSPACE` 或 `/workspace` |
 | `--home` | 否 | agent HOME，默认 `HOME` 或 `/root` |
+
+Agent identity 使用 §3.2 文档中的固定约定路径。
 
 在 agent-compose session 中，host 总是显式传入 `--state-root`、`--workspace`、`--home`。
 
@@ -655,6 +666,7 @@ runtime.env.all()
 - `agent-compose-runtime prompt` 子命令继续可用。
 - `agent-compose-runtime exec` 子命令继续输出带 `__COMMAND_RESULT__` 前缀的 command result JSON。
 - `--provider`、`--message-file`、`--state-root`、`--workspace`、`--home` 参数语义不变。
+- Agent identity 通过 `<state-root>/agents/system-prompts/system-prompt.txt` 约定路径发现。
 - 成功时 stdout 必须输出可解析的 agent result JSON，推荐使用 `__AGENT_RESULT__` 前缀。
 - 人类可读过程输出应继续走 stderr，避免污染 stdout 协议通道。
 - provider state 文件路径保持 `/data/state/agents/providers/<provider>.json`。

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -277,6 +277,35 @@ Run 是一次 agent 执行记录，可来自 CLI manual run、scheduler trigger 
 
 状态类查询以 SQLite 中的 project/run 关系为主要来源；session tag 用于兼容查询、`down` 停止 project session 和文件级调试。
 
+### Agent system prompt（Phase 1）
+
+`AgentDefinition.system_prompt` 持久化在 agent definition（手动与受管）上，并通过 v1/v2 API 与 Agents UI 暴露。执行时 host 解析该字段，并为 guest runtime 物化 agent identity。
+
+分层 prompt 模型：
+
+1. **Agent Identity** — 每个 agent 的 `system_prompt`（为空时省略）
+2. **Capabilities (MPI)** — OctoBus capset catalog，位于 `runtime/mpi/catalog.md`
+3. **Per-turn task** — `--message-file` 中的用户消息（不与 identity 混合）
+
+传输使用 session state 树下的**固定约定路径**：
+
+```text
+<session>/state/agents/system-prompts/system-prompt.txt  →  guest /data/state/agents/system-prompts/system-prompt.txt
+```
+
+解析路径：
+
+- 受管 project run：`RunService` 将 `run.ManagedAgentID` 传入 `ExecuteAgentRequest`
+- Loader run：`loaderRunHost.Agent` 传入 loader 绑定的 agent definition id
+- Session chat：依赖 session tags `source=agent` 与 `agent_id`
+
+Guest JS runtime（`runtime/javascript`）从 `--state-root` 读取约定文件，通过
+`buildSystemContext` 组合 identity + MPI，并注入 Codex `developer_instructions`、
+Claude `systemPrompt.append` 或 Gemini user prompt prepend。
+
+详见 [agent_system_prompt_design.md](agent_system_prompt_design.md) 与
+[agent-compose-runtime-js_contract.md](agent-compose-runtime-js_contract.md)。
+
 ## 命令执行和镜像
 
 `ExecService` 不创建 session。它只能在已有 running session 内执行命令，定位方式包括：

--- a/docs/zh-CN/design/agent_system_prompt_design.md
+++ b/docs/zh-CN/design/agent_system_prompt_design.md
@@ -1,0 +1,381 @@
+# Agent System Prompt — Phase 1 设计
+
+**状态：** Phase 1 已在当前代码库中**实现**。截至 [验收标准（Phase 1，已验证）](#验收标准phase-1已验证) 的章节描述本次已落地的改动。[下一步计划](#下一步计划) 列出 Phase 1 **未包含**、计划后续推进的工作。
+
+英文版本：[../../design/agent_system_prompt_design.md](../../design/agent_system_prompt_design.md)
+
+相关文档：
+
+- Runtime 调用契约：[agent-compose-runtime-js_contract.md](agent-compose-runtime-js_contract.md)
+
+Phase 1 之前，`AgentDefinition.system_prompt` 已持久化、通过 API/Proto 暴露、并可在 Agents UI 中编辑，但执行路径从未读取它。只有 MPI（Model Program Interface）能力目录会进入 provider 的 system/developer instruction 通道。
+
+Phase 1 通过分层 prompt 模型接入了 Agent Identity，未引入完整的平台级 runtime brief。
+
+## 背景
+
+### 改动前已有能力
+
+| 层级 | 存储 / 来源 | 运行时行为（Phase 1 之前） |
+| --- | --- | --- |
+| Agent identity | `config_store` 中的 `AgentDefinition.system_prompt` | **未注入** |
+| MPI catalog | Host 从 OctoBus capset 写入 `runtime/mpi/catalog.md` | 仅注入 Codex / Claude |
+| Per-turn task | Host 写入 `state/agents/prompts/<provider>-<nano>.txt` | 通过 `--message-file` 传递 |
+
+Phase 1 之前各 Provider 的注入方式：
+
+| Provider | 机制 |
+| --- | --- |
+| Codex | `config.developer_instructions = mpiContext` |
+| Claude | `systemPrompt: { preset: "claude_code", append: mpiContext }` |
+| Gemini | 无 system context（MPI 被忽略） |
+
+### Prompt 模型
+
+agent-compose 将运行时指令分为三个可分离的层级：
+
+1. **Platform context** — MPI 能力目录（已有）
+2. **Agent identity** — 每个 agent 的 `system_prompt`
+3. **Per-turn task** — 当前轮次的用户消息
+
+Phase 1 将 **Agent Identity** 接入了已有的 MPI 平台层，未增加部署级 runtime brief、基于文件的 workspace 注入或 skills 发现。
+
+## 目标与非目标
+
+### Phase 1 范围（已交付）
+
+- 使已配置的 `system_prompt` 对 Codex、Claude、Gemini 运行生效
+- 保持每轮消息隔离（`--message-file` 仅承载任务文本）
+- 当两层均存在时，Agent Identity 排在 MPI catalog **之前**
+- 当 `system_prompt` 为空或未绑定 agent 时保持向后兼容
+- Codex resume 时传递最新的组合 context（通过 constructor 级 config）
+- 覆盖绑定 agent definition 的 loader 运行和 managed project 运行
+
+### 延后项（见 [下一步计划](#下一步计划)）
+
+- 将 `system_prompt` 重命名为 `instructions`
+- Workspace 级全局 context 字段
+- AGENTS.md / CLAUDE.md 标记块文件注入与清理
+- Skills 列表或 skill 绑定的 prompt 段落
+- 平台级 issue 工作流 brief（mentions、元数据语义、评论格式等）
+- 前端改动（UI 已支持编辑 `system_prompt`）
+- Proto 或 DB schema 变更（`system_prompt` 列已存在）
+- 将 `description` 注入运行时指令
+
+## Prompt 分层
+
+Provider system / developer instructions 的组合结构（Phase 1 已实现）：
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ Provider system / developer instructions                     │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ ## Agent Identity                                      │  │
+│  │ AgentDefinition.system_prompt (DB, per agent)          │  │
+│  ├────────────────────────────────────────────────────────┤  │
+│  │ ## MPI Catalog                                         │  │
+│  │ OctoBus capset guides → runtime/mpi/catalog.md         │  │
+│  └────────────────────────────────────────────────────────┘  │
+├──────────────────────────────────────────────────────────────┤
+│ Per-turn user message (--message-file)                       │
+│ Chat text, loader script prompt, structured task input       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+规则：
+
+- `system_prompt` trim 后为空时，省略 Agent Identity。
+- 无可用 MPI catalog 时，省略 MPI。
+- 存在 MPI 时，runtime 保留 `formatMpiContext` 生成的 MPI 字符串，包括既有 `## MPI Catalog` 标题。
+- `description` 仅为目录元数据，**不得**出现在运行时指令中。
+
+## 端到端数据流
+
+```text
+┌─────────────┐     claim / chat      ┌──────────────────┐
+│ ConfigStore │◄──GetAgentDefinition──│ Service/Executor │
+│ system_prompt│                      │                  │
+└─────────────┘                       │ writeAgent       │
+                                      │ SystemPromptFile │
+                                      │ writeAgent       │
+                                      │ PromptFile       │
+                                      └────────┬─────────┘
+                                               │ ExecStream
+                                               ▼
+                              ┌────────────────────────────────┐
+                              │ guest: agent-compose-runtime   │
+                              │   prompt                       │
+                              │   --provider codex|claude|gemini│
+                              │   --message-file …/prompts/…   │
+                              │   --state-root /data/state     │
+                              └────────┬───────────────────────┘
+                                       │
+                    agentSystemPromptPath(stateRoot) + readMpiContext
+                                       │
+                              buildSystemContext()
+                                       │
+              ┌────────────────────────┼────────────────────────┐
+              ▼                        ▼                        ▼
+         CodexRunner              ClaudeRunner            GeminiRunner
+    developer_instructions    systemPrompt.append      prepend to -p
+```
+
+Guest 命令形态：
+
+```sh
+agent-compose-runtime prompt \
+  --provider <provider> \
+  --message-file /data/state/agents/prompts/<provider>-<unix_nano>.txt \
+  --state-root /data/state \
+  --workspace /workspace \
+  --home /root
+```
+
+Guest runtime 从 `--state-root` 下的**固定约定路径**发现 agent identity（与 MPI 从
+`runtime/mpi/catalog.md` 发现的方式一致）：
+
+```text
+host:  <session>/state/agents/system-prompts/system-prompt.txt
+guest: /data/state/agents/system-prompts/system-prompt.txt
+```
+
+当 `system_prompt` 为空时，host **删除** `system-prompt.txt`，避免同 session 后续 run 读到过期的 identity 文本。
+
+## Host（Go）实现
+
+主要文件：`pkg/agentcompose/service.go`、`pkg/agentcompose/exec.go`、
+`pkg/agentcompose/loader_manager.go`、`pkg/agentcompose/run_service.go`。
+
+### 解析 agent system prompt
+
+**函数：** `Executor.resolveAgentSystemPrompt(ctx, session, agentDefinitionID string) (string, error)`
+
+解析顺序：
+
+1. 若 `agentDefinitionID`（即 `ExecuteAgentRequest.AgentDefinitionID`）非空，直接加载该 agent definition。
+2. 否则，若 session 带有 `source=agent` 和 `agent_id=<uuid>` 标签，按标签中的 agent id 加载。
+3. 否则返回 `""`（非错误）。
+
+DB 查找失败时，host 记录 warning 并在无 agent identity 的情况下继续运行（MPI-only）。不会因 definition 行缺失而失败整个 run。
+
+### 写入 system prompt 文件
+
+**函数：** `writeAgentSystemPromptFile(session, systemPrompt string) error`
+
+| 属性 | 值 |
+| --- | --- |
+| Host 路径 | `{hostSessionDir}/state/agents/system-prompts/system-prompt.txt` |
+| Guest 路径 | `{GuestStateRoot}/agents/system-prompts/system-prompt.txt`（`--state-root` 下的约定路径） |
+| 内容 | UTF-8 原始 `systemPrompt` 字节（section 标题由 guest runtime 添加） |
+| 非空 prompt | `MkdirAll` + 写入固定文件名 |
+| 空 prompt | `os.Remove` 固定文件；忽略 `ENOENT` |
+
+固定文件名与 provider 无关，避免 Go `normalizeAgentKind` 与 runtime provider 归一化耦合。发现方式与 MPI 一致，均通过 `--state-root` 下的约定路径。
+
+### 扩展执行请求
+
+`ExecuteAgentRequest` 新增 `AgentDefinitionID string`：
+
+- **Loader 运行**（`loader_manager.go`）：来自解析后的 agent definition id，或 `loader.Summary.AgentID` 回退。
+- **Managed project 运行**（`run_service.go`）：来自 `run.ManagedAgentID`。
+- **Session chat 运行**：未显式传入 id 时，依赖 session 标签。
+
+`buildAgentExecSpec` 仅传入 `--state-root`；guest 从该根路径下的约定路径发现 agent identity。
+
+### 并发假设
+
+固定文件名假设同 session 内 agent run 不会并发写入不同的 agent identity。当前 UI/API 路径按 cell 串行执行 chat。若未来需要并发不同 identity，再评估 per-run 文件名或 session 级锁。
+
+### 错误处理摘要
+
+| 条件 | 行为 |
+| --- | --- |
+| 存在 agent id 但 DB 行缺失 | Warning；无 agent identity 继续运行 |
+| 写入/删除 system prompt 文件失败 | 失败（与 prompt 文件写入失败相同） |
+| 空 system prompt | 删除 `system-prompt.txt` |
+| Guest 上约定文件缺失 | `readSystemPromptFile` 返回 `""`；MPI-only |
+
+## Guest Runtime（TypeScript）实现
+
+主要文件：`runtime/javascript/src/system-context.ts`、`prompt.ts`、`cli.ts`、
+`types.ts`，以及 `runners/` 下的 provider runner。
+
+### 新模块：`system-context.ts`
+
+```typescript
+buildSystemContext(agentPrompt: string, mpiContext: string): string
+readSystemPromptFile(path?: string): Promise<string>
+```
+
+组合逻辑：
+
+- agent prompt 非空：输出 `## Agent Identity`、空行、trim 后的 agent 文本。
+- agent prompt 与 MPI 均非空：追加 trim 后的 MPI context，并保留其 `## MPI Catalog` 标题。
+- agent prompt 为空但 MPI 存在：原样返回 MPI，保持向后兼容。
+- 两者均为空：返回 `""`。
+
+`readSystemPromptFile` 在路径缺失、`ENOENT` 或 trim 后内容为空时返回 `""`。
+
+### 约定路径与 prompt 命令
+
+- `system-context.ts`：导出 `agentSystemPromptPath(stateRoot)` →
+  `{stateRoot}/agents/system-prompts/system-prompt.txt`。
+- `prompt.ts`：通过 `readSystemPromptFile` 读取约定路径、读取 MPI catalog、
+  调用 `buildSystemContext`，将结果作为 `systemContext` 传给 runner。
+- 通过 `--state-root` 发现（与 MPI catalog 约定路径一致）。
+
+### RunnerOptions 变更
+
+`RunnerOptions.mpiContext` 替换为 `systemContext`（组合后的字符串）。MPI 仍在 `prompt.ts` 内部读取用于组合；runner 不再单独接收原始 MPI。
+
+## 各 Provider 注入方式
+
+### Codex
+
+组合 context 通过 Codex constructor 传递：
+
+```typescript
+new Codex({
+  config: { developer_instructions: systemContext },
+})
+```
+
+`@openai/codex-sdk` 在 constructor 作用域读取 `config`，而非 `ThreadOptions`。因此 `startThread` 和 `resumeThread` 在每次运行都会收到当前组合 context，包括 `system_prompt` 编辑之后。
+
+### Claude
+
+组合 context 追加到 Claude Code preset：
+
+```typescript
+systemPrompt: {
+  type: "preset",
+  preset: "claude_code",
+  append: systemContext,
+}
+```
+
+### Gemini
+
+当前 runner 无原生 system-instruction 通道。Phase 1 落地了临时回退方案：
+
+```typescript
+const userPrompt = systemContext
+  ? `${systemContext}\n\n${promptText}`
+  : promptText;
+```
+
+子进程通过 `-p userPrompt` 调用。在出现原生 system 通道之前，identity 与 task 有意合并为单一 CLI 参数。
+
+Phase 1 不改变 Gemini trust 或 permission 参数；这些内容不属于 system prompt 接线范围。
+
+## 绑定场景
+
+| 运行类型 | Agent identity 解析方式 |
+| --- | --- |
+| Agent session chat | Session 标签 `source=agent` + `agent_id` |
+| Loader 脚本 `agent()` 调用 | Loader 绑定 agent 的 `AgentDefinitionID` |
+| Managed project run (v2) | `run.ManagedAgentID` |
+| 裸 provider 字符串，无 agent | 无 agent identity；有 catalog 时仅 MPI |
+
+## 测试
+
+### Go（`pkg/agentcompose/agent_system_prompt_test.go`）
+
+- 空 `system_prompt` 解析为 `""`
+- 带 session 标签的 agent 解析出 trim 后的 prompt 文本
+- `writeAgentSystemPromptFile` 写入/删除固定 `system-prompt.txt`
+- 空 prompt 删除文件（避免 stale identity）
+- `buildAgentExecSpec` 传入 `--state-root` 供约定路径发现
+
+### Runtime JS（`runtime/javascript/test/system-context.test.ts`）
+
+- Section 顺序（Agent Identity 在 Capabilities 之前）
+- 仅 agent、仅 MPI、两者皆有、两者皆无
+- 仅 MPI 路径与改动前注入一致（无 `## Agent Identity`）
+- `readSystemPromptFile` 的 trim 与缺失文件行为
+
+Runner 测试（`runners.test.ts`、`runner-execution.test.ts`）已更新为使用 `systemContext` 而非 `mpiContext`。
+
+## 安全与运维
+
+- `system_prompt` 由 workspace 所有者控制（与现有 agent 管理 API 相同的信任边界）。不超出当前 agent 配置引入新的注入面。
+- System prompt 文件与 per-turn prompt 文件同处 session state 树，受相同 session 生命周期与清理策略约束。
+- 路径通过 exec spec 中的 `shellQuote` 传递；prompt 内容不参与 shell 插值。
+- Phase 1 不引入硬性大小限制。遵循现有 prompt 文件的实际限制。
+
+## 发布（Phase 1）
+
+| 领域 | 变更 |
+| --- | --- |
+| 数据库 | 无 |
+| API / Proto | 无 |
+| Guest 镜像 | Runtime JS 改动已合并；生产 guest 镜像重建走常规发布流程。开发环境 mount 可能无需重建。 |
+| 行为 | 非空 `system_prompt` 在部署后生效；为空时保持改动前 MPI-only 行为 |
+
+## 文件变更映射（Phase 1）
+
+| 文件 | 变更 |
+| --- | --- |
+| `pkg/agentcompose/service.go` | `resolveAgentSystemPrompt`、`writeAgentSystemPromptFile`、`executeAgentRun` |
+| `pkg/agentcompose/exec.go` | `ExecuteAgentRequest` 新增 `AgentDefinitionID`；`Executor` 注入 `configDB` |
+| `pkg/agentcompose/loader_manager.go` | 向 agent 执行传递 agent definition id |
+| `pkg/agentcompose/run_service.go` | 向 agent 执行传递 `ManagedAgentID` |
+| `pkg/agentcompose/agent_system_prompt_test.go` | **新增** — host 解析、固定路径写入/删除测试 |
+| `runtime/javascript/src/system-context.ts` | **新增** — `agentSystemPromptPath`、组合与文件读取 |
+| `runtime/javascript/src/prompt.ts` | 约定路径读取；runner 分发前组合 `systemContext` |
+| `runtime/javascript/src/types.ts` | `RunnerOptions` 使用 `systemContext` |
+| `runtime/javascript/src/runners/codex.ts` | `developer_instructions` 来自 `systemContext` |
+| `runtime/javascript/src/runners/claude.ts` | `systemPrompt.append` 来自 `systemContext` |
+| `runtime/javascript/src/runners/gemini.ts` | 将 `systemContext` prepend 到 `-p` |
+| `runtime/javascript/test/system-context.test.ts` | **新增** — 组合单元测试 |
+| `runtime/javascript/test/runners.test.ts` | 更新为 `systemContext` |
+| `runtime/javascript/test/runner-execution.test.ts` | 更新为 `systemContext` |
+| `docs/design/agent-compose-runtime-js_contract.md` | 记录约定路径与分层 |
+
+## 验收标准（Phase 1，已验证）
+
+1. `system_prompt: "Reply only in Chinese"` 的 agent 在 Codex/Claude chat 运行后应遵守该指令。
+2. 空 `system_prompt` → 与改动前 MPI-only 行为一致。
+3. Codex session 在 prompt 编辑后 resume 时使用新指令。
+4. 绑定 agent definition 的 loader 继承 `system_prompt`。
+5. `task test`、runtime JS 测试套件、以及 touched packages 的 `task lint` 均通过。
+
+## 下一步计划
+
+以下条目 **未在 Phase 1 中实现**，作为后续计划记录。
+
+### 平台 runtime brief
+
+在 Agent Identity 与 MPI 之上增加 workspace 或 deployment 级 brief 层，覆盖平台 guardrails、issue 工作流语义、以及与单个 agent definition 无关的评论格式规则。
+
+### Workspace 全局 context
+
+引入与 per-agent `system_prompt` 分离的 workspace 级 context 字段。
+
+### 基于文件的 workspace 注入
+
+向 `AGENTS.md`、`CLAUDE.md` 或类似 discovery 文件注入标记块，并在运行完成后安全清理。与 Codex/Claude 在 `local_directory` workspace 上的原生 discovery 对齐。
+
+### System context 中的 Skills
+
+发现 skill 摘要或按需加载 `SKILL.md` 段落，注入组合 brief（类似 Cursor Agent Skills）。
+
+### Gemini 原生 system 通道
+
+当 Gemini CLI 或 SDK 提供专用 system-instruction 参数时，替换 `-p` prepend 回退方案。在此之前，仅 Gemini 继续放宽 per-turn 消息隔离。
+
+### 字段重命名：`system_prompt` → `instructions`
+
+为 API 与 UI 语义更清晰而重命名。需要 Proto、DB 迁移、UI 与客户端更新。
+
+### Prompt 变更时强制新建 Codex thread
+
+若未来 SDK 版本在 resume 时不再应用 constructor `config`，host 可检测 `system_prompt` 哈希并在指令变更时强制新 thread。Phase 1 依赖当前 SDK 行为。
+
+### Prompt 文件软大小限制
+
+文档化 `system_prompt` 与组合 system context 的软建议上限（如 < 8 KiB）。
+
+### 前端呈现
+
+Agents UI 已支持编辑 `system_prompt`。`docs/README.md` 已说明该字段运行时生效。可选后续：应用内提示或更完整的用户文档。

--- a/pkg/agentcompose/agent_system_prompt_test.go
+++ b/pkg/agentcompose/agent_system_prompt_test.go
@@ -1,0 +1,456 @@
+package agentcompose
+
+import (
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestResolveAgentSystemPromptReturnsEmptyWhenAgentPromptUnset(t *testing.T) {
+	ctx := context.Background()
+	configDB := newTestConfigStore(t)
+	created, err := configDB.CreateAgentDefinition(ctx, AgentDefinition{
+		ID:       "agent-empty-prompt",
+		Name:     "Empty Prompt",
+		Provider: "codex",
+		Enabled:  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	executor := &Executor{configDB: configDB}
+	session := &Session{
+		Summary: SessionSummary{
+			Tags: []SessionTag{
+				{Name: agentSessionTagSource, Value: agentSessionTagSourceVal},
+				{Name: agentSessionTagID, Value: created.ID},
+			},
+		},
+	}
+
+	got, err := executor.resolveAgentSystemPrompt(ctx, session, "")
+	if err != nil {
+		t.Fatalf("resolveAgentSystemPrompt returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("resolveAgentSystemPrompt = %q, want empty", got)
+	}
+}
+
+func TestResolveAgentSystemPromptFromProviderAgentID(t *testing.T) {
+	ctx := context.Background()
+	configDB := newTestConfigStore(t)
+	created, err := configDB.CreateAgentDefinition(ctx, AgentDefinition{
+		ID:           "agent-explicit-id",
+		Name:         "Explicit",
+		Provider:     "codex",
+		SystemPrompt: "Use explicit agent id",
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	executor := &Executor{configDB: configDB}
+	session := &Session{Summary: SessionSummary{Tags: []SessionTag{}}}
+
+	got, err := executor.resolveAgentSystemPrompt(ctx, session, created.ID)
+	if err != nil {
+		t.Fatalf("resolveAgentSystemPrompt returned error: %v", err)
+	}
+	if got != "Use explicit agent id" {
+		t.Fatalf("resolveAgentSystemPrompt = %q, want %q", got, "Use explicit agent id")
+	}
+}
+
+func TestResolveAgentSystemPromptPrefersProviderAgentOverSessionTag(t *testing.T) {
+	ctx := context.Background()
+	configDB := newTestConfigStore(t)
+	tagged, err := configDB.CreateAgentDefinition(ctx, AgentDefinition{
+		ID:           "agent-tagged",
+		Name:         "Tagged",
+		Provider:     "codex",
+		SystemPrompt: "From session tag",
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	explicit, err := configDB.CreateAgentDefinition(ctx, AgentDefinition{
+		ID:           "agent-explicit",
+		Name:         "Explicit",
+		Provider:     "codex",
+		SystemPrompt: "From provider agent id",
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	executor := &Executor{configDB: configDB}
+	session := &Session{
+		Summary: SessionSummary{
+			Tags: []SessionTag{
+				{Name: agentSessionTagSource, Value: agentSessionTagSourceVal},
+				{Name: agentSessionTagID, Value: tagged.ID},
+			},
+		},
+	}
+
+	got, err := executor.resolveAgentSystemPrompt(ctx, session, explicit.ID)
+	if err != nil {
+		t.Fatalf("resolveAgentSystemPrompt returned error: %v", err)
+	}
+	if got != "From provider agent id" {
+		t.Fatalf("resolveAgentSystemPrompt = %q, want %q", got, "From provider agent id")
+	}
+}
+
+func TestResolveAgentSystemPromptReturnsEmptyWhenAgentMissing(t *testing.T) {
+	ctx := context.Background()
+	executor := &Executor{configDB: newTestConfigStore(t)}
+	session := &Session{Summary: SessionSummary{Tags: []SessionTag{}}}
+
+	got, err := executor.resolveAgentSystemPrompt(ctx, session, "missing-agent-id")
+	if err != nil {
+		t.Fatalf("resolveAgentSystemPrompt returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("resolveAgentSystemPrompt = %q, want empty", got)
+	}
+}
+
+func TestResolveAgentSystemPromptFromSessionTags(t *testing.T) {
+	ctx := context.Background()
+	configDB := newTestConfigStore(t)
+	created, err := configDB.CreateAgentDefinition(ctx, AgentDefinition{
+		ID:           "agent-with-prompt",
+		Name:         "Runner",
+		Provider:     "codex",
+		SystemPrompt: "  Reply only in Chinese  ",
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	executor := &Executor{configDB: configDB}
+	session := &Session{
+		Summary: SessionSummary{
+			Tags: []SessionTag{
+				{Name: agentSessionTagSource, Value: agentSessionTagSourceVal},
+				{Name: agentSessionTagID, Value: created.ID},
+			},
+		},
+	}
+
+	got, err := executor.resolveAgentSystemPrompt(ctx, session, "")
+	if err != nil {
+		t.Fatalf("resolveAgentSystemPrompt returned error: %v", err)
+	}
+	if got != "Reply only in Chinese" {
+		t.Fatalf("resolveAgentSystemPrompt = %q, want %q", got, "Reply only in Chinese")
+	}
+}
+
+func TestWriteAgentSystemPromptFileWritesFixedPath(t *testing.T) {
+	root := t.TempDir()
+	session := &Session{Summary: SessionSummary{WorkspacePath: filepath.Join(root, "workspace")}}
+
+	if err := writeAgentSystemPromptFile(session, "Reply only in Chinese"); err != nil {
+		t.Fatalf("writeAgentSystemPromptFile returned error: %v", err)
+	}
+	hostPath := filepath.Join(root, "state", "agents", "system-prompts", agentSystemPromptFileName)
+	content, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", hostPath, err)
+	}
+	if string(content) != "Reply only in Chinese" {
+		t.Fatalf("file content = %q", string(content))
+	}
+}
+
+func TestWriteAgentSystemPromptFileRemovesFileWhenPromptEmpty(t *testing.T) {
+	root := t.TempDir()
+	session := &Session{Summary: SessionSummary{WorkspacePath: filepath.Join(root, "workspace")}}
+	hostPath := hostAgentSystemPromptPath(session)
+
+	if err := writeAgentSystemPromptFile(session, "Reply only in Chinese"); err != nil {
+		t.Fatalf("writeAgentSystemPromptFile returned error: %v", err)
+	}
+	if err := writeAgentSystemPromptFile(session, "   "); err != nil {
+		t.Fatalf("writeAgentSystemPromptFile returned error: %v", err)
+	}
+	if _, err := os.Stat(hostPath); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, stat err = %v", hostPath, err)
+	}
+}
+
+func TestHostAgentSystemPromptPathUsesSessionWorkspace(t *testing.T) {
+	root := t.TempDir()
+	session := &Session{Summary: SessionSummary{WorkspacePath: filepath.Join(root, "workspace")}}
+
+	got := hostAgentSystemPromptPath(session)
+	want := filepath.Join(root, "state", "agents", "system-prompts", agentSystemPromptFileName)
+	if got != want {
+		t.Fatalf("hostAgentSystemPromptPath = %q, want %q", got, want)
+	}
+}
+
+func TestHostAgentSystemPromptPathReturnsEmptyWhenWorkspaceMissing(t *testing.T) {
+	if got := hostAgentSystemPromptPath(nil); got != "" {
+		t.Fatalf("hostAgentSystemPromptPath(nil) = %q, want empty", got)
+	}
+	if got := hostAgentSystemPromptPath(&Session{}); got != "" {
+		t.Fatalf("hostAgentSystemPromptPath(empty session) = %q, want empty", got)
+	}
+}
+
+func TestWriteAgentSystemPromptFileReturnsErrorWhenWorkspaceMissing(t *testing.T) {
+	err := writeAgentSystemPromptFile(&Session{}, "Reply only in Chinese")
+	if err == nil {
+		t.Fatal("writeAgentSystemPromptFile returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "session workspace path is required") {
+		t.Fatalf("writeAgentSystemPromptFile error = %v, want workspace required", err)
+	}
+	if err := writeAgentSystemPromptFile(&Session{}, ""); err != nil {
+		t.Fatalf("writeAgentSystemPromptFile(empty prompt) returned error: %v", err)
+	}
+}
+
+func TestBuildAgentExecSpecPassesStateRootForConventionPathDiscovery(t *testing.T) {
+	cfg := &appconfig.Config{
+		GuestStateRoot:     "/data/state",
+		GuestWorkspacePath: "/workspace",
+	}
+	session := &Session{Summary: SessionSummary{ID: "session-1"}}
+
+	spec := buildAgentExecSpec(cfg, session, "codex", "/data/state/agents/prompts/prompt.txt", "")
+	command := strings.Join(spec.Args, " ")
+	if !strings.Contains(command, "--state-root '/data/state'") {
+		t.Fatalf("command missing --state-root for convention-based system prompt discovery: %q", command)
+	}
+}
+
+type conventionSystemPromptRuntime struct {
+	commands []string
+}
+
+func (r *conventionSystemPromptRuntime) EnsureSession(context.Context, *Session, VMState, ProxyState) (SessionVMInfo, error) {
+	return SessionVMInfo{}, nil
+}
+
+func (r *conventionSystemPromptRuntime) StopSession(context.Context, *Session, VMState) (bool, error) {
+	return false, nil
+}
+
+func (r *conventionSystemPromptRuntime) Exec(context.Context, *Session, VMState, ExecSpec) (ExecResult, error) {
+	return ExecResult{}, fmt.Errorf("unexpected Exec call")
+}
+
+func (r *conventionSystemPromptRuntime) ExecStream(_ context.Context, _ *Session, _ VMState, spec ExecSpec, _ ExecStreamWriter) (ExecResult, error) {
+	command := strings.Join(spec.Args, " ")
+	r.commands = append(r.commands, command)
+	payload := agentResultPrefix + `{"provider":"codex","sessionId":"agent-runtime-session","stopReason":"completed","finalText":"done","transcript":"done"}`
+	return ExecResult{Stdout: payload + "\n", Success: true}, nil
+}
+
+type conventionSystemPromptRuntimeProvider struct {
+	runtime BoxRuntime
+}
+
+func (p conventionSystemPromptRuntimeProvider) ForDriver(string) (BoxRuntime, error) {
+	return p.runtime, nil
+}
+
+func (p conventionSystemPromptRuntimeProvider) ForSession(*Session) (BoxRuntime, error) {
+	return p.runtime, nil
+}
+
+func TestExecuteAgentRunWritesConventionSystemPromptBeforeExec(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	sessionID := "session-agent-system-prompt"
+	cfg := &appconfig.Config{
+		SessionRoot:        root,
+		GuestStateRoot:     "/data/state",
+		GuestWorkspacePath: "/workspace",
+	}
+	store := &Store{config: cfg}
+	if err := os.MkdirAll(filepath.Join(root, sessionID, "vm"), 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := store.SaveVMState(sessionID, VMState{Driver: "docker"}); err != nil {
+		t.Fatalf("SaveVMState returned error: %v", err)
+	}
+
+	configDB := newTestConfigStore(t)
+	agent, err := configDB.CreateAgentDefinition(ctx, AgentDefinition{
+		ID:           "agent-convention",
+		Name:         "Convention",
+		Provider:     "codex",
+		SystemPrompt: "Reply only in Chinese",
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+
+	runtime := &conventionSystemPromptRuntime{}
+	executor := &Executor{
+		config:   cfg,
+		store:    store,
+		configDB: configDB,
+		runtimes: conventionSystemPromptRuntimeProvider{runtime: runtime},
+	}
+	session := &Session{
+		Summary: SessionSummary{
+			ID:            sessionID,
+			VMStatus:      VMStatusRunning,
+			WorkspacePath: filepath.Join(root, sessionID, "workspace"),
+		},
+	}
+
+	result, parsed, err := executor.executeAgentRun(ctx, session, "codex", agent.ID, "hello", "", nil)
+	if err != nil {
+		t.Fatalf("executeAgentRun returned error: %v", err)
+	}
+	if !result.Success || !parsed.Success {
+		t.Fatalf("executeAgentRun success = (%v, %v), want both true", result.Success, parsed.Success)
+	}
+	if len(runtime.commands) != 1 {
+		t.Fatalf("ExecStream calls = %d, want 1", len(runtime.commands))
+	}
+	hostPath := filepath.Join(root, sessionID, "state", "agents", "system-prompts", agentSystemPromptFileName)
+	content, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", hostPath, err)
+	}
+	if string(content) != "Reply only in Chinese" {
+		t.Fatalf("system prompt file content = %q", string(content))
+	}
+}
+
+func TestLoaderRunHostAgentWritesSystemPromptFromBoundAgentDefinition(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:             root,
+		SessionRoot:          filepath.Join(root, "sessions"),
+		RuntimeDriver:        driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:         "loader-box:latest",
+		GuestWorkspacePath:   "/data/workspace",
+		GuestStateRoot:       "/data/state",
+		JupyterGuestPort:     8888,
+		JupyterProxyBasePath: "/agent-compose/session",
+	}
+	if err := os.MkdirAll(config.SessionRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(session root) returned error: %v", err)
+	}
+
+	configDB := newTestConfigStore(t)
+	agent, err := configDB.CreateAgentDefinition(ctx, AgentDefinition{
+		ID:           "loader-agent-prompt",
+		Name:         "Loader Prompt Agent",
+		Provider:     "codex",
+		SystemPrompt: "Reply only from loader",
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	loader, err := configDB.CreateLoader(ctx, Loader{
+		Summary: LoaderSummary{
+			Name:         "Loader With Agent Prompt",
+			Runtime:      LoaderRuntimeScheduler,
+			Enabled:      true,
+			AgentID:      agent.ID,
+			DefaultAgent: "codex",
+		},
+		Script: "function main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateLoader returned error: %v", err)
+	}
+
+	store := &Store{config: config}
+	runtime := &fakeLoaderAgentRuntime{}
+	driver := &fakeSessionDriver{}
+	manager := &LoaderManager{
+		config:   config,
+		rootCtx:  ctx,
+		store:    store,
+		configDB: configDB,
+		driver:   driver,
+		executor: &Executor{config: config, store: store, configDB: configDB, runtimes: fixedRuntimeProvider{runtime: runtime}},
+		engine:   &QJSLoaderEngine{},
+		running:  map[string]int{},
+	}
+	host := &loaderRunHost{
+		manager: manager,
+		loader:  loader,
+		run:     &LoaderRunSummary{ID: "run-loader-system-prompt", LoaderID: loader.Summary.ID},
+	}
+
+	result, err := host.Agent(ctx, "summarize loader state", LoaderAgentRequest{})
+	if err != nil {
+		t.Fatalf("Agent returned error: %v", err)
+	}
+	if !result.Success || result.SessionID == "" {
+		t.Fatalf("loader agent result = %#v", result)
+	}
+
+	hostPath := filepath.Join(config.SessionRoot, result.SessionID, "state", "agents", "system-prompts", agentSystemPromptFileName)
+	content, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", hostPath, err)
+	}
+	if string(content) != "Reply only from loader" {
+		t.Fatalf("system prompt file content = %q", string(content))
+	}
+}
+
+func TestRunServiceProjectRunWritesSystemPromptFromManagedAgent(t *testing.T) {
+	spec := newProjectServiceTestSpec("demo", "gpt-test")
+	spec.Agents[0].SystemPrompt = "Reply only in project runs"
+	store, service, projectID := setupRunPreparationProject(t, spec, t.TempDir())
+	client, closeServer := newRunServiceTestClient(t, service)
+	defer closeServer()
+	ctx := context.Background()
+
+	events, err := collectRunAgentStreamEvents(ctx, client, &agentcomposev2.RunAgentRequest{
+		ProjectId:       projectID,
+		AgentName:       "reviewer",
+		Prompt:          "review with system prompt",
+		Source:          agentcomposev2.RunSource_RUN_SOURCE_API,
+		ClientRequestId: "system-prompt-run-request",
+	})
+	if err != nil {
+		t.Fatalf("RunAgentStream returned error: %v", err)
+	}
+	completed := lastRunAgentStreamEvent(events, agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED)
+	if completed == nil {
+		t.Fatalf("RunAgentStream events missing completion: %#v", events)
+	}
+	stored, err := store.GetProjectRun(ctx, completed.GetRunId())
+	if err != nil {
+		t.Fatalf("GetProjectRun returned error: %v", err)
+	}
+	if stored.SessionID == "" {
+		t.Fatalf("stored run missing session id: %#v", stored)
+	}
+
+	hostPath := filepath.Join(service.config.SessionRoot, stored.SessionID, "state", "agents", "system-prompts", agentSystemPromptFileName)
+	content, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", hostPath, err)
+	}
+	if string(content) != "Reply only in project runs" {
+		t.Fatalf("system prompt file content = %q", string(content))
+	}
+}

--- a/pkg/agentcompose/exec.go
+++ b/pkg/agentcompose/exec.go
@@ -38,16 +38,18 @@ type AgentExecutionStream struct {
 }
 
 type ExecuteAgentRequest struct {
-	Agent            string
-	Message          string
-	Timeout          time.Duration
-	OutputSchemaJSON string
-	Stream           AgentExecutionStream
+	Agent             string
+	AgentDefinitionID string
+	Message           string
+	Timeout           time.Duration
+	OutputSchemaJSON  string
+	Stream            AgentExecutionStream
 }
 
 type Executor struct {
 	config   *appconfig.Config
 	store    *Store
+	configDB *ConfigStore
 	runtimes RuntimeProvider
 	streams  *SessionStreamBroker
 }
@@ -56,6 +58,7 @@ func NewExecutor(di do.Injector) (*Executor, error) {
 	return &Executor{
 		config:   do.MustInvoke[*appconfig.Config](di),
 		store:    do.MustInvoke[*Store](di),
+		configDB: do.MustInvoke[*ConfigStore](di),
 		runtimes: do.MustInvoke[RuntimeProvider](di),
 		streams:  do.MustInvoke[*SessionStreamBroker](di),
 	}, nil
@@ -845,7 +848,7 @@ func (e *Executor) executeAgent(ctx context.Context, session *Session, request E
 		}
 	}
 
-	execResult, result, err := e.executeAgentRun(execCtx, session, agent, message, request.OutputSchemaJSON, streamWriter)
+	execResult, result, err := e.executeAgentRun(execCtx, session, agent, request.AgentDefinitionID, message, request.OutputSchemaJSON, streamWriter)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()

--- a/pkg/agentcompose/loader_manager.go
+++ b/pkg/agentcompose/loader_manager.go
@@ -847,6 +847,7 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 	}
 
 	agent := normalizeAgentKind(request.Agent)
+	var agentDefinitionID string
 	if agent == "" {
 		agentDefinition, err := h.manager.loaderAgentDefinition(ctx, h.loader)
 		if err != nil {
@@ -854,7 +855,11 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 		}
 		if agentDefinition != nil {
 			agent = normalizeAgentKind(agentDefinition.Provider)
+			agentDefinitionID = strings.TrimSpace(agentDefinition.ID)
 		}
+	}
+	if agentDefinitionID == "" {
+		agentDefinitionID = strings.TrimSpace(h.loader.Summary.AgentID)
 	}
 	if agent == "" {
 		agent = normalizeAgentKind(h.loader.Summary.DefaultAgent)
@@ -864,10 +869,11 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 	}
 
 	cell, _, _, execErr := h.manager.executor.ExecuteAgentRequest(ctx, session, ExecuteAgentRequest{
-		Agent:            agent,
-		Message:          prompt,
-		Timeout:          request.Timeout,
-		OutputSchemaJSON: request.OutputSchema,
+		Agent:             agent,
+		AgentDefinitionID: agentDefinitionID,
+		Message:           prompt,
+		Timeout:           request.Timeout,
+		OutputSchemaJSON:  request.OutputSchema,
 	})
 	finalText := firstNonEmpty(cell.Output, cell.Stdout, cell.Stderr)
 	jsonValue, jsonErr := loaderJSONResult(finalText, request.OutputSchema, "agent finalText")

--- a/pkg/agentcompose/run_coordinator_test.go
+++ b/pkg/agentcompose/run_coordinator_test.go
@@ -795,7 +795,7 @@ func setupRunPreparationProject(t *testing.T, spec *agentcomposev2.ProjectSpec, 
 	streams := &SessionStreamBroker{subscribers: map[string]map[int]chan sessionWatchEvent{}}
 	service.runtimes = runtimes
 	service.streams = streams
-	service.executor = &Executor{config: service.config, store: service.store, runtimes: runtimes, streams: streams}
+	service.executor = &Executor{config: service.config, store: service.store, configDB: store, runtimes: runtimes, streams: streams}
 	ctx := context.Background()
 	composePath := filepath.Join(projectDir, "agent-compose.yml")
 	resp, err := service.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{

--- a/pkg/agentcompose/run_service.go
+++ b/pkg/agentcompose/run_service.go
@@ -134,10 +134,11 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 		return run, err, nil
 	}
 	cell, _, _, execErr := s.executor.ExecuteAgentRequest(ctx, sessionResult.Session, ExecuteAgentRequest{
-		Agent:            agentProvider,
-		Message:          msg.GetPrompt(),
-		OutputSchemaJSON: msg.GetOutputSchemaJson(),
-		Stream:           projectRunAgentExecutionStream(run, stream),
+		Agent:             agentProvider,
+		AgentDefinitionID: run.ManagedAgentID,
+		Message:           msg.GetPrompt(),
+		OutputSchemaJSON:  msg.GetOutputSchemaJson(),
+		Stream:            projectRunAgentExecutionStream(run, stream),
 	})
 	transition := projectRunTransitionFromAgentCell(run, sessionResult.Session, cell, execErr)
 	if execErr != nil || !cell.Success {

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -910,6 +910,18 @@ type runtimeCommandRequestJSON struct {
 	ArtifactDir    string            `json:"artifactDir"`
 }
 
+const agentSystemPromptFileName = "system-prompt.txt" // keep in sync with runtime/javascript/src/system-context.ts
+
+// hostAgentSystemPromptPath is the session agent identity file the host writes and the
+// guest reads via convention from --state-root (guest /data/state/agents/system-prompts/system-prompt.txt).
+// Returns "" when the session workspace path is unknown.
+func hostAgentSystemPromptPath(session *Session) string {
+	if session == nil || strings.TrimSpace(session.Summary.WorkspacePath) == "" {
+		return ""
+	}
+	return filepath.Join(hostSessionDir(session), "state", "agents", "system-prompts", agentSystemPromptFileName)
+}
+
 func writeAgentPromptFile(config *appconfig.Config, session *Session, agent, message string) (string, error) {
 	hostSessionDir := filepath.Dir(session.Summary.WorkspacePath)
 	promptDir := filepath.Join(hostSessionDir, "state", "agents", "prompts")
@@ -922,6 +934,37 @@ func writeAgentPromptFile(config *appconfig.Config, session *Session, agent, mes
 		return "", fmt.Errorf("write agent prompt file: %w", err)
 	}
 	return filepath.Join(config.GuestStateRoot, "agents", "prompts", name), nil
+}
+
+// writeAgentSystemPromptFile materializes agent identity for the guest runtime at a
+// fixed convention path under the session state tree:
+//
+//	state/agents/system-prompts/system-prompt.txt
+//
+// The guest discovers this file from --state-root (no CLI flag). When systemPrompt is
+// empty, the file is removed so later runs in the same session cannot read stale identity.
+func writeAgentSystemPromptFile(session *Session, systemPrompt string) error {
+	systemPrompt = strings.TrimSpace(systemPrompt)
+	hostPath := hostAgentSystemPromptPath(session)
+	if hostPath == "" {
+		if systemPrompt == "" {
+			return nil
+		}
+		return fmt.Errorf("session workspace path is required to write agent system prompt")
+	}
+	if systemPrompt == "" {
+		if err := os.Remove(hostPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove agent system prompt file: %w", err)
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(hostPath), 0o755); err != nil {
+		return fmt.Errorf("create agent system prompt dir: %w", err)
+	}
+	if err := os.WriteFile(hostPath, []byte(systemPrompt), 0o644); err != nil {
+		return fmt.Errorf("write agent system prompt file: %w", err)
+	}
+	return nil
 }
 
 func writeAgentOutputSchemaFile(config *appconfig.Config, session *Session, agent, schemaJSON string) (string, error) {
@@ -1249,7 +1292,31 @@ func sanitizeAgentExecResult(result ExecResult) ExecResult {
 	return cleaned
 }
 
-func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent, message, outputSchemaJSON string, stream ExecStreamWriter) (ExecResult, AgentRunResult, error) {
+func (e *Executor) resolveAgentSystemPrompt(ctx context.Context, session *Session, agentDefinitionID string) (string, error) {
+	if e == nil || e.configDB == nil {
+		return "", nil
+	}
+	agentID := strings.TrimSpace(agentDefinitionID)
+	if agentID == "" {
+		taggedAgentID := sessionTagValue(session.Summary.Tags, agentSessionTagID)
+		if !sessionHasAgentTag(session, taggedAgentID) {
+			return "", nil
+		}
+		agentID = taggedAgentID
+	}
+	if agentID == "" {
+		return "", nil
+	}
+	agentDef, err := e.configDB.GetAgentDefinition(ctx, agentID)
+	if err != nil {
+		// Agent identity is optional at execution time; lookup failures degrade to MPI-only context.
+		slog.Warn("resolve agent system prompt failed", "agent_id", agentID, "error", err)
+		return "", nil
+	}
+	return strings.TrimSpace(agentDef.SystemPrompt), nil
+}
+
+func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent, agentDefinitionID, message, outputSchemaJSON string, stream ExecStreamWriter) (ExecResult, AgentRunResult, error) {
 	if session.Summary.VMStatus != VMStatusRunning {
 		return ExecResult{}, AgentRunResult{}, fmt.Errorf("session is not running")
 	}
@@ -1263,6 +1330,13 @@ func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent,
 	}
 	schemaPath, err := writeAgentOutputSchemaFile(e.config, session, agent, outputSchemaJSON)
 	if err != nil {
+		return ExecResult{}, AgentRunResult{}, err
+	}
+	systemPrompt, err := e.resolveAgentSystemPrompt(ctx, session, agentDefinitionID)
+	if err != nil {
+		return ExecResult{}, AgentRunResult{}, err
+	}
+	if err := writeAgentSystemPromptFile(session, systemPrompt); err != nil {
 		return ExecResult{}, AgentRunResult{}, err
 	}
 	runtime, err := e.runtimes.ForSession(session)

--- a/runtime/javascript/README.md
+++ b/runtime/javascript/README.md
@@ -16,6 +16,18 @@ Successful runs write a single structured result line to stdout with the `__AGEN
 
 `--output-schema-file` is optional. When set, the file must contain a JSON Schema object. The runtime passes it to the provider's native structured-output mechanism where supported. Codex and Claude support schema-based output; Gemini currently rejects schema requests until a native CLI schema flag is wired.
 
+## Agent system prompt (convention path)
+
+When the host binds a run to an agent definition with non-empty `system_prompt`, it writes:
+
+```text
+<state-root>/agents/system-prompts/system-prompt.txt
+```
+
+The `prompt` command reads that convention path, combines it with the MPI catalog via `buildSystemContext` in `src/system-context.ts`, and passes the result to provider runners as `systemContext`. Per-turn user text stays in `--message-file` only.
+
+See `docs/design/agent_system_prompt_design.md` for the full host/guest contract.
+
 ## Development
 
 ```sh
@@ -28,6 +40,7 @@ The TypeScript source lives in `src/`:
 
 - `cli.ts`: commander-based CLI.
 - `prompt.ts`: command orchestration and default path resolution.
+- `system-context.ts`: agent identity + MPI composition.
 - `runners/`: provider adapters for Codex, Claude, and Gemini.
 - `mpi.ts`: MPI catalog discovery and context formatting.
 - `session-state.ts`: provider resume state persistence.

--- a/runtime/javascript/src/prompt.ts
+++ b/runtime/javascript/src/prompt.ts
@@ -7,6 +7,7 @@ import { normalizeProvider } from "./provider.js";
 import { ClaudeRunner } from "./runners/claude.js";
 import { CodexRunner } from "./runners/codex.js";
 import { GeminiRunner } from "./runners/gemini.js";
+import { agentSystemPromptPath, buildSystemContext, readSystemPromptFile } from "./system-context.js";
 import type { AgentResult, RuntimeJsonSchema } from "./types.js";
 
 export interface PromptCommandOptions {
@@ -35,8 +36,17 @@ export async function runPromptCommand(commandOptions: PromptCommandOptions): Pr
   const outputSchema = commandOptions.outputSchemaFile
     ? parseOutputSchema(await readText(path.resolve(commandOptions.outputSchemaFile)))
     : undefined;
+  const systemPrompt = await readSystemPromptFile(agentSystemPromptPath(stateRoot));
   const mpi = await readMpiContext(stateRoot);
-  const options = { provider, stateRoot, workspace, home, runtimeRoot: mpi.runtimeRoot, mpiContext: mpi.context, outputSchema };
+  const options = {
+    provider,
+    stateRoot,
+    workspace,
+    home,
+    runtimeRoot: mpi.runtimeRoot,
+    systemContext: buildSystemContext(systemPrompt, mpi.context),
+    outputSchema,
+  };
   if (provider === "codex") {
     return await new CodexRunner(options).runPrompt(promptText);
   }

--- a/runtime/javascript/src/runners/claude.ts
+++ b/runtime/javascript/src/runners/claude.ts
@@ -67,11 +67,11 @@ export class ClaudeRunner {
           schema: this.options.outputSchema,
         },
       } : {}),
-      ...(this.options.mpiContext ? {
+      ...(this.options.systemContext ? {
         systemPrompt: {
           type: "preset",
           preset: "claude_code",
-          append: this.options.mpiContext,
+          append: this.options.systemContext,
         },
       } : {}),
     };

--- a/runtime/javascript/src/runners/codex.ts
+++ b/runtime/javascript/src/runners/codex.ts
@@ -149,10 +149,10 @@ export class CodexRunner {
       codexPathOverride: resolveCodexPath(),
       env: stringEnv(),
       // `config` (the `--config key=value` overrides) is a CodexOptions field on the
-      // constructor; it is NOT read from ThreadOptions/startThread. Injecting the MPI
-      // capability catalog here is what makes it reach codex as developer instructions.
-      ...(this.options.mpiContext
-        ? { config: { developer_instructions: this.options.mpiContext } }
+      // constructor; it is NOT read from ThreadOptions/startThread. Injecting the combined
+      // Agent Identity + MPI system context here applies to both start and resume flows.
+      ...(this.options.systemContext
+        ? { config: { developer_instructions: this.options.systemContext } }
         : {}),
     });
     const thread = stored?.sessionId

--- a/runtime/javascript/src/runners/gemini.ts
+++ b/runtime/javascript/src/runners/gemini.ts
@@ -23,8 +23,12 @@ export class GeminiRunner {
       stderr: "",
     };
 
+    const userPrompt = this.options.systemContext
+      ? `${this.options.systemContext}\n\n${promptText}`
+      : promptText;
+
     const child = spawn("gemini", [
-      "-p", promptText,
+      "-p", userPrompt,
       "--output-format", "stream-json",
       "--approval-mode", "yolo",
     ], {

--- a/runtime/javascript/src/system-context.ts
+++ b/runtime/javascript/src/system-context.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { readText } from "./fs.js";
+import { warn } from "./mpi.js";
+
+const agentSystemPromptRelativePath = path.join("agents", "system-prompts", "system-prompt.txt"); // keep in sync with pkg/agentcompose/service.go
+
+/** Convention path for agent identity under --state-root (MPI uses the same discovery pattern). */
+export function agentSystemPromptPath(stateRoot: string): string {
+  return path.join(stateRoot, agentSystemPromptRelativePath);
+}
+
+export function buildSystemContext(agentPrompt: string, mpiContext: string): string {
+  const agent = agentPrompt.trim();
+  if (!agent) {
+    return mpiContext.trim() === "" ? "" : mpiContext;
+  }
+
+  const parts: string[] = ["## Agent Identity", "", agent];
+  const mpi = mpiContext.trim();
+  if (mpi) {
+    parts.push("", mpi);
+  }
+  return parts.join("\n").trim();
+}
+
+export async function readSystemPromptFile(path?: string): Promise<string> {
+  if (!path) {
+    return "";
+  }
+  try {
+    return (await readText(path)).trim();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return "";
+    }
+    warn(`could not read agent system prompt ${path}: ${(error as Error)?.message || error}`);
+    return "";
+  }
+}

--- a/runtime/javascript/src/types.ts
+++ b/runtime/javascript/src/types.ts
@@ -16,7 +16,7 @@ export interface RunnerOptions {
   workspace: string;
   home: string;
   runtimeRoot: string;
-  mpiContext: string;
+  systemContext: string;
   outputSchema?: RuntimeJsonSchema;
 }
 

--- a/runtime/javascript/test/cli.test.ts
+++ b/runtime/javascript/test/cli.test.ts
@@ -198,6 +198,48 @@ describe("commander CLI", () => {
     });
   });
 
+  it("runPromptCommand composes agent identity and mpi into systemContext", async () => {
+    await withTempSession(async (root) => {
+      const messageFile = path.join(root, "message.txt");
+      const stateRoot = path.join(root, "state");
+      const mpiRoot = path.join(root, "runtime", "mpi");
+      const systemPromptPath = path.join(stateRoot, "agents", "system-prompts", "system-prompt.txt");
+      await fs.mkdir(path.dirname(systemPromptPath), { recursive: true });
+      await fs.mkdir(mpiRoot, { recursive: true });
+      await fs.writeFile(messageFile, "task body", "utf8");
+      await fs.writeFile(systemPromptPath, "Reply only in Chinese", "utf8");
+      await fs.writeFile(path.join(mpiRoot, "catalog.md"), "# Email tools\n", "utf8");
+
+      const runPrompt = vi.fn().mockResolvedValue({
+        provider: "codex",
+        sessionId: "",
+        stopReason: "completed",
+        finalText: "ok",
+        transcript: "ok",
+        stderr: "",
+      });
+      const codexSpy = vi.spyOn(await import("../src/runners/codex.js"), "CodexRunner").mockImplementation(function mockCodex(this: unknown, options: unknown) {
+        Object.assign(this as object, { options, runPrompt });
+      } as never);
+      const { runPromptCommand } = await import("../src/prompt.js");
+
+      await runPromptCommand({
+        provider: "codex",
+        messageFile,
+        stateRoot,
+        workspace: path.join(root, "workspace"),
+        home: path.join(root, "home"),
+      });
+
+      expect(runPrompt).toHaveBeenCalledWith("task body");
+      const options = codexSpy.mock.calls.at(-1)?.[0] as { systemContext: string };
+      expect(options.systemContext).toContain("## Agent Identity");
+      expect(options.systemContext).toContain("Reply only in Chinese");
+      expect(options.systemContext).toContain("## MPI Catalog");
+      expect(options.systemContext).toContain("# Email tools");
+    });
+  });
+
   it("runPromptCommand rejects invalid output schema files", async () => {
     await withTempSession(async (root) => {
       const messageFile = path.join(root, "message.txt");

--- a/runtime/javascript/test/helpers.ts
+++ b/runtime/javascript/test/helpers.ts
@@ -13,14 +13,14 @@ export async function withTempSession<T>(fn: (root: string) => Promise<T>): Prom
   }
 }
 
-export function runnerOptions(root: string, mpiContext = "", provider: RunnerOptions["provider"] = "codex"): RunnerOptions {
+export function runnerOptions(root: string, systemContext = "", provider: RunnerOptions["provider"] = "codex"): RunnerOptions {
   return {
     provider,
     stateRoot: path.join(root, "state"),
     workspace: path.join(root, "workspace"),
     home: path.join(root, "home"),
     runtimeRoot: path.join(root, "runtime"),
-    mpiContext,
+    systemContext,
   };
 }
 

--- a/runtime/javascript/test/runner-execution.test.ts
+++ b/runtime/javascript/test/runner-execution.test.ts
@@ -387,6 +387,37 @@ describe("runner execution", () => {
     });
   });
 
+  it("runs Gemini stream-json output and prepends system context to the user prompt", async () => {
+    const { GeminiRunner } = await import("../src/runners/gemini.js");
+    await withTempSession(async (root) => {
+      childProcessState.stdoutLines = [
+        JSON.stringify({ type: "init", sessionId: "gemini-session" }),
+        JSON.stringify({ type: "message", message: { text: "hello" } }),
+        JSON.stringify({ type: "result", response: "gemini final" }),
+      ];
+      childProcessState.stderrChunks = [];
+      childProcessState.exitCode = 0;
+      childProcessState.error = null;
+      const systemContext = "## Agent Identity\n\nReply only in Chinese";
+      const stdio = captureStdio();
+      try {
+        const result = await new GeminiRunner(runnerOptions(root, systemContext, "gemini")).runPrompt("prompt");
+
+        expect(result).toMatchObject({
+          provider: "gemini",
+          sessionId: "gemini-session",
+          finalText: "gemini final",
+        });
+        expect(childProcessState.spawnCalls.at(-1)).toMatchObject({
+          command: "gemini",
+          args: ["-p", `${systemContext}\n\nprompt`, "--output-format", "stream-json", "--approval-mode", "yolo"],
+        });
+      } finally {
+        stdio.restore();
+      }
+    });
+  });
+
   it("runs Gemini stream-json output and keeps stdout protocol clean", async () => {
     const { GeminiRunner } = await import("../src/runners/gemini.js");
     await withTempSession(async (root) => {

--- a/runtime/javascript/test/runners.test.ts
+++ b/runtime/javascript/test/runners.test.ts
@@ -12,8 +12,8 @@ afterEach(() => {
 describe("CodexRunner", () => {
   it("exposes Codex thread options without constructor-only config", async () => {
     await withTempSession(async (root) => {
-      const mpiContext = "catalog body";
-      const runner = new CodexRunner(runnerOptions(root, mpiContext));
+      const systemContext = "## MPI Catalog\n\ncatalog body";
+      const runner = new CodexRunner(runnerOptions(root, systemContext));
 
       const threadOptions = runner.threadOptions();
 
@@ -198,10 +198,10 @@ describe("ClaudeRunner", () => {
     });
   });
 
-  it("appends MPI context and exposes runtime directory", async () => {
+  it("appends system context and exposes runtime directory", async () => {
     await withTempSession(async (root) => {
-      const mpiContext = "catalog body";
-      const runner = new ClaudeRunner(runnerOptions(root, mpiContext));
+      const systemContext = "## MPI Catalog\n\ncatalog body";
+      const runner = new ClaudeRunner(runnerOptions(root, systemContext));
 
       const queryOptions = runner.queryOptions({
         provider: "claude",
@@ -216,7 +216,7 @@ describe("ClaudeRunner", () => {
       expect(queryOptions.systemPrompt).toEqual({
         type: "preset",
         preset: "claude_code",
-        append: mpiContext,
+        append: systemContext,
       });
       expect(queryOptions.resume).toBe("existing-session");
     });

--- a/runtime/javascript/test/system-context.test.ts
+++ b/runtime/javascript/test/system-context.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { formatMpiContext } from "../src/mpi.js";
+import { agentSystemPromptPath, buildSystemContext, readSystemPromptFile } from "../src/system-context.js";
+import { captureStdio, withTempSession } from "./helpers.js";
+
+describe("system-context", () => {
+  it("buildSystemContext places agent identity before mpi catalog", () => {
+    const mpiFormatted = formatMpiContext("# Email tools\n", "/data/runtime/mpi/resources");
+    const combined = buildSystemContext("Reply only in Chinese", mpiFormatted);
+
+    expect(combined.indexOf("## Agent Identity")).toBeLessThan(combined.indexOf("## MPI Catalog"));
+    expect(combined).toContain("Reply only in Chinese");
+    expect(combined).toContain("# Email tools");
+  });
+
+  it("buildSystemContext returns agent-only context when mpi is empty", () => {
+    const combined = buildSystemContext("Agent prompt", "");
+    expect(combined).toContain("## Agent Identity");
+    expect(combined).toContain("Agent prompt");
+    expect(combined).not.toContain("## MPI Catalog");
+  });
+
+  it("buildSystemContext returns mpi-only context when agent prompt is empty", () => {
+    const mpiFormatted = formatMpiContext("# Email tools\n", "/data/runtime/mpi/resources");
+    expect(buildSystemContext("", mpiFormatted)).toBe(mpiFormatted);
+  });
+
+  it("buildSystemContext returns empty string when both layers are empty", () => {
+    expect(buildSystemContext("   ", "\n")).toBe("");
+  });
+
+  it("agentSystemPromptPath resolves under state root", () => {
+    expect(agentSystemPromptPath("/data/state")).toBe(
+      path.join("/data/state", "agents", "system-prompts", "system-prompt.txt"),
+    );
+  });
+
+  it("readSystemPromptFile reads trimmed content", async () => {
+    await withTempSession(async (root) => {
+      const promptPath = agentSystemPromptPath(path.join(root, "state"));
+      await fs.mkdir(path.dirname(promptPath), { recursive: true });
+      await fs.writeFile(promptPath, "  Reply only in Chinese  ", "utf8");
+
+      await expect(readSystemPromptFile(promptPath)).resolves.toBe("Reply only in Chinese");
+    });
+  });
+
+  it("readSystemPromptFile returns empty string for missing files", async () => {
+    await withTempSession(async (root) => {
+      await expect(readSystemPromptFile(path.join(root, "missing.txt"))).resolves.toBe("");
+      await expect(readSystemPromptFile()).resolves.toBe("");
+    });
+  });
+
+  it("warns and returns empty string when system prompt cannot be read", async () => {
+    await withTempSession(async (root) => {
+      const promptPath = agentSystemPromptPath(path.join(root, "state"));
+      await fs.mkdir(promptPath, { recursive: true });
+      const stdio = captureStdio();
+      try {
+        await expect(readSystemPromptFile(promptPath)).resolves.toBe("");
+      } finally {
+        stdio.restore();
+      }
+      expect(stdio.stderr).toMatch(/warning: could not read agent system prompt/);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to [#24](https://github.com/chaitin/agent-compose/pull/24) / [#37](https://github.com/chaitin/agent-compose/pull/37). Per @eetoc review: convention-based transport — no new guest CLI flag, no host retry.

## Summary

- Host resolves `AgentDefinition.system_prompt` at run time and writes/removes `<session>/state/agents/system-prompts/system-prompt.txt`
- Guest reads it from `--state-root`, composes Agent Identity + MPI into `systemContext`, injects into Codex / Claude / Gemini
- Loader runs and managed project runs propagate agent definition binding
- Empty `system_prompt` deletes the file to avoid stale identity

## vs #24

Dropped `--system-prompt-file`, `isUnknownSystemPromptFileFlag`, and compatibility retry. Fixed provider-independent filename under `--state-root` (MPI-style discovery).

## Notes

- **Old guest runtime**: MPI-only, no crash
- **Updated guest runtime**: required for agent identity to take effect
- **Concurrency**: fixed filename assumes serialized agent runs per session (Phase 1)

## Test plan

### Automated

- [x] `go test ./pkg/agentcompose -run 'SystemPrompt|AgentSystem' -count=1`
- [x] `go test ./pkg/agentcompose -count=1`
- [x] `npm test -- --run` in `runtime/javascript`

### Manual

- [x] Create a Codex or Claude agent with `system_prompt: "Reply only in Chinese"`, run chat → replies in Chinese
- [x] Clear `system_prompt`, run again → MPI-only, normal completion; `system-prompt.txt` absent
- [x] Edit `system_prompt` on the same Codex session, send another message → new instructions apply

Made with [Cursor](https://cursor.com)