### PR TITLE
fix: reject capability tokens for stopped sessions

### DIFF
--- a/pkg/agentcompose/capability_proxy.go
+++ b/pkg/agentcompose/capability_proxy.go
@@ -47,6 +47,9 @@ func (s *Store) ResolveCapabilitySession(ctx context.Context, token string) (cap
 		if sessionCapabilityToken(session) != token {
 			continue
 		}
+		if session.Summary.VMStatus != VMStatusRunning {
+			return capproxy.SessionBinding{}, fmt.Errorf("capability session token is not active")
+		}
 		capsetIDs := sessionCapabilityCapsets(session)
 		if len(capsetIDs) == 0 {
 			return capproxy.SessionBinding{}, fmt.Errorf("session %s has no capability capset", session.Summary.ID)

--- a/pkg/agentcompose/capability_proxy_test.go
+++ b/pkg/agentcompose/capability_proxy_test.go
@@ -16,6 +16,10 @@ func TestResolveCapabilitySession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	session.Summary.VMStatus = VMStatusRunning
+	if err := bridge.store.UpdateSession(ctx, session); err != nil {
+		t.Fatal(err)
+	}
 
 	binding, err := bridge.store.ResolveCapabilitySession(ctx, "session-token")
 	if err != nil {
@@ -26,5 +30,13 @@ func TestResolveCapabilitySession(t *testing.T) {
 	}
 	if len(binding.CapsetIDs) != 2 || binding.CapsetIDs[0] != "dev" || binding.CapsetIDs[1] != "data" {
 		t.Fatalf("unexpected capset set %+v", binding.CapsetIDs)
+	}
+
+	session.Summary.VMStatus = VMStatusStopped
+	if err := bridge.store.UpdateSession(ctx, session); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bridge.store.ResolveCapabilitySession(ctx, "session-token"); err == nil {
+		t.Fatal("expected stopped session capability token to be rejected")
 	}
 }


### PR DESCRIPTION
## Summary
- reject capability session tokens unless the matched session is currently running
- cover the stopped-session case in capability token resolution tests

## Verification
- go test ./pkg/agentcompose -run '^TestResolveCapabilitySession$' -count=1
- go test ./pkg/capproxy ./pkg/agentcompose -run 'Capability|CapProxy|ResolveCapabilitySession' -count=1
- go test ./pkg/agentcompose -count=1

Fixes #58