### PR TITLE
fix: resolve debug sessions from run ids

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -134,12 +134,12 @@
     }
   }
 
-  function navigateRunsWithRun(runId: string): void {
+  function navigateRunsWithRun(sessionId: string): void {
     activePage = 'runs';
-    const nextPath = runId ? appPath(`/runs?runId=${encodeURIComponent(runId)}`) : appPath('/runs');
+    const nextPath = sessionId ? appPath(`/runs?sessionId=${encodeURIComponent(sessionId)}`) : appPath('/runs');
     const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
     if (current !== nextPath) {
-      history.pushState({ page: 'runs', runId }, '', nextPath);
+      history.pushState({ page: 'runs', sessionId }, '', nextPath);
     }
   }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -12,6 +12,7 @@ import {
   LoaderService,
   SessionService,
 } from '../gen/proto/agentcompose/v1/agentcompose_connect.js';
+import { RunService } from '../gen/proto/agentcompose/v2/agentcompose_connect.js';
 import { HealthService } from '../gen/proto/health/v1/health_connect.js';
 import { connectBaseUrl } from '../paths';
 
@@ -29,3 +30,4 @@ export const configClient = createClient(ConfigService, grpcWebTransport);
 export const capabilityClient = createClient(CapabilityService, grpcWebTransport);
 export const dashboardClient = createClient(DashboardService, grpcWebTransport);
 export const healthClient = createClient(HealthService, grpcWebTransport);
+export const runClient = createClient(RunService, grpcWebTransport);

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -1,0 +1,21 @@
+import { runClient } from './client';
+
+export type ProjectRunDebugTarget = {
+  runId: string;
+  sessionId: string;
+};
+
+export async function getProjectRunDebugTarget(runId: string): Promise<ProjectRunDebugTarget> {
+  const response = await runClient.getRun({ runId });
+  const summary = response.run?.summary;
+  if (!summary) {
+    throw new Error('运行记录不存在');
+  }
+  if (!summary.sessionId) {
+    throw new Error('当前运行没有关联的调试会话');
+  }
+  return {
+    runId: summary.runId,
+    sessionId: summary.sessionId,
+  };
+}

--- a/frontend/src/pages/DebugRunPage.svelte
+++ b/frontend/src/pages/DebugRunPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from 'svelte';
 
+  import { getProjectRunDebugTarget } from '../api/runs';
   import { getWorkSession, type WorkSessionDetail } from '../api/sessions';
   import { formatBeijingTime } from '../time';
 
@@ -14,6 +15,7 @@
   let notebookUrl = '';
   let debugStatus = '未知';
   let debugMessage = '';
+  let sessionId = '';
 
   $: notebookUrl = statusLabel(session?.status || '') === '运行中' ? session?.notebookUrl || '' : '';
   $: debugStatus = statusLabel(session?.status || '');
@@ -27,13 +29,24 @@
     if (!runId) return;
     loading = true;
     error = '';
+    sessionId = '';
     try {
-      session = await getWorkSession(runId);
+      session = await loadDebugSession(runId);
+      sessionId = session.id;
     } catch (err) {
       session = null;
       error = err instanceof Error ? err.message : String(err);
     } finally {
       loading = false;
+    }
+  }
+
+  async function loadDebugSession(id: string): Promise<WorkSessionDetail> {
+    try {
+      return await getWorkSession(id);
+    } catch {
+      const target = await getProjectRunDebugTarget(id);
+      return getWorkSession(target.sessionId);
     }
   }
 
@@ -86,7 +99,7 @@
     <h2>调试工具</h2>
   </div>
   <div class="toolbar">
-    <button on:click={() => dispatch('navigateRuns', runId)}>返回运行中心</button>
+    <button on:click={() => dispatch('navigateRuns', sessionId || runId)}>返回运行中心</button>
     <button on:click={load}>{loading ? '连接中...' : '刷新 / 重新连接'}</button>
   </div>
 </div>
@@ -98,6 +111,7 @@
     </div>
     <div class="descriptions-small debug-descriptions">
       <div><span>runId</span><b>{#if runId}<span class="mono-text">{runId}</span>{:else}<span class="muted">-</span>{/if}</b></div>
+      <div><span>sessionId</span><b>{#if sessionId}<span class="mono-text">{sessionId}</span>{:else}<span class="muted">-</span>{/if}</b></div>
       <div>
         <span>Jupyter 状态</span>
         <b><em class={`home-pill ${statusTone(session?.status || '')}`}>{debugStatus}</em></b>

--- a/frontend/src/pages/RunsPage.svelte
+++ b/frontend/src/pages/RunsPage.svelte
@@ -401,7 +401,11 @@
     activeMode = workbenchMode;
     selectedConversationId = params.get('conversationId') || '';
     conversationId = selectedConversationId;
-    selectedRunId = workbenchMode === 'chat' ? (selectedConversationId || params.get('runId') || '') : (params.get('runId') || selectedConversationId);
+    const requestedSessionId = params.get('sessionId') || '';
+    const requestedRunId = params.get('runId') || '';
+    selectedRunId = workbenchMode === 'chat'
+      ? (selectedConversationId || requestedSessionId || requestedRunId)
+      : (requestedRunId || requestedSessionId || selectedConversationId);
     selectedAgentId = rawAgentId;
     selectedGroupKey = selectedAgentId;
     selectedContextKey = selectedTaskId ? `task:${selectedTaskId}` : (selectedRunId ? '' : 'overview');
@@ -463,6 +467,7 @@
       q: timelineQuery.trim() || null,
       mock: null,
       runId: selectedRunParam(),
+      sessionId: selectedSessionParam(),
       detailTab: null,
       groupKey: null,
       groupTab: null,
@@ -488,7 +493,18 @@
   function selectedRunParam(): string | null {
     if (workbenchMode === 'chat') return null;
     if (!selectedRunId) return null;
-    return selectedRunId;
+    return selectedRunForURL()?.type === 'automation_run' ? selectedRunId : null;
+  }
+
+  function selectedSessionParam(): string | null {
+    if (!selectedRunId) return null;
+    if (workbenchMode === 'chat') return selectedConversationId || selectedRunId;
+    return selectedRunForURL()?.type === 'work_session' ? selectedRunId : null;
+  }
+
+  function selectedRunForURL(): ProductRun | null {
+    if (!selectedRunId) return null;
+    return runs.find((run) => run.id === selectedRunId) || selectedRun || selectedChatRun || null;
   }
 
   function mirrorTimelineState(): void {


### PR DESCRIPTION
## Summary
- add a frontend v2 RunService client helper to resolve a project run to its linked session
- let the debug page accept either a session id or a v2 run id, then open the linked work session
- write work-session selections as `sessionId` in the Runs page URL while keeping legacy `runId` input readable

## Verification
- npm config set registry https://npm.in.chaitin.net
- npm ci
- npm run check:ui

Fixes #60
Fixes #42
