### PR TITLE
feat: add OpenCode provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ Top-level fields:
 Common agent fields:
 
 - `provider`, `model`, `system_prompt`: guest agent settings (`provider` selects
-  the guest CLI runner; `model` is passed to that agent runtime). Supported guest
-  providers are `codex`, `claude`, and `gemini`. Daemon-side LLM calls
+  the guest CLI runner; `model` is passed to provider runtimes that support
+  explicit model selection). Supported guest providers are `codex`, `claude`,
+  `gemini`, and `opencode`. Daemon-side LLM calls
   (`LLMService`, `scheduler.llm`) use `LLM_MODEL` instead.
 - `image`: guest image reference.
 - `driver`: runtime driver override. Supported drivers are `boxlite`, `docker`,
@@ -289,13 +290,16 @@ key names such as `LLM_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 `ANTHROPIC_AUTH_TOKEN`, `GOOGLE_API_KEY`, and `GEMINI_API_KEY` are filtered from
 user-supplied runtime environment variables. Compatibility aliases such as
 `LLM_API_KEY` and `LLM_API_ENDPOINT` may still appear in the runtime, but they
-are daemon-managed facade values, not upstream provider credentials.
+are daemon-managed facade values, not upstream provider credentials. Gemini and
+OpenCode still use their provider CLIs directly; OpenCode credentials depend on
+the selected OpenCode model provider.
 
 | Provider | Typical env vars | Notes |
 | --- | --- | --- |
 | `codex` | daemon LLM provider config; runtime receives `AGENT_COMPOSE_SESSION_TOKEN`, `LLM_API_KEY`, `LLM_API_ENDPOINT`, `OPENAI_BASE_URL`, and facade-token API key aliases | Uses Codex CLI/SDK in the guest image |
 | `claude` | daemon Anthropic-family provider config; runtime receives `AGENT_COMPOSE_SESSION_TOKEN`, `LLM_API_KEY`, `LLM_API_ENDPOINT`, `ANTHROPIC_BASE_URL`, and facade-token API key aliases | Uses Claude Code CLI in the guest image |
 | `gemini` | not yet routed through the LLM facade | Uses Gemini CLI in the guest image |
+| `opencode` | Provider-specific keys for the selected OpenCode model, for example `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` | Uses OpenCode CLI in the guest image |
 
 After changing guest runtime code or provider support, rebuild the guest image:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ are available under [zh-CN/design/](zh-CN/design/).
 - [Agent system prompt (Phase 1)](design/agent_system_prompt_design.md)
 - [Runtime LLM Facade](zh-CN/design/agent-compose-runtime-llm-facade.md)
 - [Runtime JavaScript contract](design/agent-compose-runtime-js_contract.md)
+- [OpenCode CLI provider support](design/opencode_cli_support.md)
 - [Runtime environment variables](design/runtime_environment_variables_design.md)
 - [Runtime mount manifest](design/runtime_mount_manifest_design.md)
 - [Driver-specific runtime mount behavior](design/runtime_mount_manifest_driver_specific_design.md)

--- a/docs/design/agent-compose-runtime-js_contract.md
+++ b/docs/design/agent-compose-runtime-js_contract.md
@@ -180,11 +180,13 @@ Command arguments:
 
 | Argument | Required | Description |
 | --- | ---: | --- |
-| `--provider` | yes | `codex`, `claude`, `gemini`, with a small set of aliases |
+| `--provider` | yes | `codex`, `claude`, `gemini`, `opencode`, with a small set of aliases |
 | `--message-file` | yes | Prompt file path |
 | `--state-root` | no | agent-compose runtime state root; default `/srv/agent-compose/session/state`. Guest discovers agent identity at `agents/system-prompts/system-prompt.txt` and MPI catalog from this root |
 | `--workspace` | no | Agent working directory; default `WORKSPACE` or `/workspace` |
 | `--home` | no | Agent HOME; default `HOME` or `/root` |
+| `--model` | no | Agent model; consumed by providers that support explicit model selection |
+| `--system-prompt-file` | no | System prompt file path; currently consumed by providers that need prompt-level system instructions |
 
 Agent identity uses the fixed convention path documented in §3.2.
 
@@ -588,6 +590,23 @@ gemini -p <systemContext + user prompt> --output-format stream-json --approval-m
 When `systemContext` is non-empty, it is prepended to the user prompt separated
 by a blank line. The current Gemini runner reads stream-json and generates a
 transcript, but does not write `/data/state/agents/providers/gemini.json`.
+
+### 10.4 OpenCode
+
+The JavaScript runtime invokes OpenCode as a subprocess:
+
+```sh
+opencode run <prompt> --format json --dir /workspace --dangerously-skip-permissions
+```
+
+When a model is provided by the host, the runner appends `--model <model>`.
+When a stored provider session exists, the runner appends
+`--session <stored session id>`. The runner sets
+`OPENCODE_DISABLE_AUTOUPDATE=true` unless the environment already defines it.
+
+OpenCode raw JSON events are converted into a human-readable transcript. The
+runner writes `/data/state/agents/providers/opencode.json` after a successful
+run with a non-empty provider session id.
 
 ## 11. Error Semantics
 

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -664,7 +664,7 @@ create workspace-capable agent sessions or grant file, command, or MCP tool
 access. With `outputSchema`, it uses prompt guidance and `json_object` instead
 of Responses API strict JSON Schema.
 
-Guest agent providers (`codex`, `claude`, `gemini`) remain separate CLI runners
+Guest agent providers (`codex`, `claude`, `gemini`, `opencode`) remain separate CLI runners
 inside guest containers with their own API keys and session state.
 
 The loader also exposes a unary RPC bridge for v1 `SessionService`:

--- a/docs/design/opencode_cli_support.md
+++ b/docs/design/opencode_cli_support.md
@@ -1,0 +1,220 @@
+# OpenCode CLI Provider Support
+
+Chinese version: [../zh-CN/design/opencode_cli_support.md](../zh-CN/design/opencode_cli_support.md)
+
+This document records the implementation for adding `opencode` as a guest agent
+provider. It follows the current runtime contract in
+[agent-compose-runtime-js_contract.md](agent-compose-runtime-js_contract.md):
+the Go control plane creates sessions and executes one unified runtime command
+inside the guest, while `runtime/javascript` adapts provider-specific CLIs.
+
+## Current Code Shape
+
+Provider handling is split across four layers:
+
+- Go control plane: `normalizeAgentKind` in `pkg/agentcompose/service.go`,
+  `normalizeAgentDefinition` in `pkg/agentcompose/agent_definition.go`, loader
+  default-agent validation, and run/session orchestration currently pass a
+  provider string to the guest runtime.
+- JavaScript runtime: `runtime/javascript/src/provider.ts` normalizes provider
+  aliases, `runtime/javascript/src/prompt.ts` selects a runner, and
+  `runtime/javascript/src/runners/` contains the provider adapters.
+- Guest image: `guest-images/Dockerfile.agent-compose-guest` installs provider
+  CLIs and links stable executable paths such as `/usr/bin/codex`.
+- UI and docs: `frontend/src/pages/AgentsPage.svelte`, `README.md`, and design
+  docs list supported providers.
+
+The compose schema does not currently restrict provider names in `pkg/compose`;
+daemon-side agent definition validation does. Proto fields are strings, so this
+change should not require protobuf changes.
+
+`model` and `system_prompt` already exist in the compose, v1, v2, and store
+models. The OpenCode integration forwards them through `ExecuteAgentRequest`
+and `agent-compose-runtime prompt`; existing Codex, Claude, and Gemini runners
+keep their previous behavior unless they explicitly consume those fields later.
+
+## OpenCode CLI Facts
+
+As of the current OpenCode CLI documentation at
+<https://opencode.ai/docs/cli/>, the relevant non-interactive command is:
+
+```sh
+opencode run [message..]
+```
+
+Relevant flags for the agent-compose runner are:
+
+- `--format json`: emit raw JSON events.
+- `--session <id>` and `--continue`: resume a session.
+- `--model <provider/model>`: select the model.
+- `--agent <agent>`: select an OpenCode agent profile.
+- `--dir <path>`: run in a working directory.
+- `--dangerously-skip-permissions`: auto-approve permissions not explicitly
+  denied.
+- `--attach <url>`: attach to an already running OpenCode server. This is not
+  part of the first integration because agent-compose already owns session
+  lifecycle and does not start a persistent OpenCode server per session.
+
+The package install command in OpenCode docs is `npm install -g opencode-ai`.
+
+## Target Behavior
+
+Users should be able to set:
+
+```yaml
+agents:
+  reviewer:
+    provider: opencode
+    model: anthropic/claude-sonnet-4-5
+```
+
+or create an agent definition with provider `opencode` in the UI/API.
+
+Agent execution should:
+
+- call `agent-compose-runtime prompt --provider opencode ...`;
+- run `opencode run` inside `/workspace`;
+- persist and reuse the OpenCode session id in
+  `/data/state/agents/providers/opencode.json`;
+- stream human-readable transcript text back through stderr, consistent with
+  other runners;
+- return the final `AgentResult` JSON on stdout through the existing
+  `__AGENT_RESULT__` protocol;
+- fail clearly when `opencode` exits non-zero or emits an error event.
+
+## Implementation Summary
+
+1. Add provider normalization.
+
+   Both provider normalizers support OpenCode:
+
+   - `runtime/javascript/src/types.ts`: extend `Provider` with `"opencode"`.
+   - `runtime/javascript/src/provider.ts`: map `opencode`, `open-code`, and
+     `open_code` to `opencode`.
+   - `pkg/agentcompose/service.go`: update `normalizeAgentKind`.
+   - `pkg/agentcompose/agent_definition.go`: allow `opencode` in the provider
+     whitelist.
+
+2. Add `OpenCodeRunner`.
+
+   `runtime/javascript/src/runners/opencode.ts` uses
+   `spawn("opencode", args, ...)` rather than an SDK, because the documented
+   integration surface is the CLI.
+
+   Initial command shape:
+
+   ```text
+   opencode run <prompt> --format json --dir <workspace>
+     --dangerously-skip-permissions
+     [--model <model>]
+     [--session <stored-session-id>]
+   ```
+
+   Implementation details:
+
+   - read the previous session with `readStoredSession(stateRoot, "opencode")`;
+   - include `OPENCODE_DISABLE_AUTOUPDATE=true` in the child environment unless
+     the user already set it;
+   - pass the model only when `RunnerOptions.model` exists;
+   - parse line-delimited JSON events when possible, and tolerate non-JSON lines
+     by writing them to the transcript;
+   - extract session id from common event fields such as `sessionID`,
+     `sessionId`, or `session_id`;
+   - extract final text from common message/result fields with `extractText`;
+   - write session state only after a non-empty session id is observed.
+
+3. Wire runner selection.
+
+   - Import/export `OpenCodeRunner` in `runtime/javascript/src/prompt.ts` and
+     `runtime/javascript/src/index.ts`.
+   - Update CLI help text in `runtime/javascript/src/cli.ts`.
+
+4. Agent model and system prompt plumbing.
+
+   OpenCode needs `model` to select the target provider/model. The host forwards
+   model and system prompt explicitly instead of relying on stored metadata:
+
+   - a small execution-config helper resolves provider, model, and
+     system prompt from an agent definition when a session has agent tags;
+   - `ExecuteAgentRequest` includes `Model` and `SystemPrompt`;
+   - managed project agent definitions set those fields in
+     `runProjectAgent`;
+   - v1 agent definition sessions set those fields when executing via
+     `SendAgentMessage` / `SendAgentMessageStream`;
+   - loaders linked to an agent definition set those fields when using
+     `scheduler.agent`;
+   - the runtime CLI accepts `--model` and `--system-prompt-file`;
+   - `PromptCommandOptions` and `RunnerOptions` include `model?: string` and
+     `systemPrompt?: string`.
+
+5. Install the CLI in the guest image.
+
+   `guest-images/Dockerfile.agent-compose-guest`:
+
+   - adds `opencode-ai` to the global npm install line;
+   - links the executable to `/usr/bin/opencode`;
+   - creates `/root/.opencode`.
+
+6. Update UI and docs.
+
+   - `frontend/src/pages/AgentsPage.svelte` and `frontend/src/api/agents.ts`
+     accept `opencode`.
+   - `README.md`, SDK docs, and runtime contract docs list the new provider.
+   - OpenCode environment-variable guidance notes that the exact provider key depends
+     on the selected OpenCode model provider, so document common cases rather
+     than a single universal key.
+
+7. Tests.
+
+   Runtime JS tests:
+
+   - provider normalization accepts `opencode`, `open-code`, `open_code`;
+   - `OpenCodeRunner` builds expected args for fresh and resumed sessions;
+   - event parsing records transcript, final text, stderr, exit failures, and
+     session id.
+
+   Go tests:
+
+   - `normalizeAgentKind` maps aliases;
+   - agent definition validation accepts `opencode`;
+   - loader/default-agent paths keep accepting normalized `opencode`;
+   - service API tests cover sending an `open-code` alias through to normalized
+     `opencode`.
+
+   Image verification should include `task image:agent-compose-guest` and a
+   container smoke check for `opencode --help` when image build infrastructure
+   is available.
+
+## Structured Output
+
+The existing runtime supports structured JSON output for Codex and Claude, but
+Gemini currently rejects `outputSchema`. OpenCode CLI docs list `--format json`
+as raw event formatting, not strict schema enforcement. The first implementation
+should therefore reject `outputSchema` for `opencode` with a clear error unless
+OpenCode exposes a documented structured-output contract during implementation.
+
+If structured output is later required, add it as a separate change with a
+provider-specific contract and tests.
+
+## Compatibility And Migration
+
+No data migration is needed. Provider session state is stored per provider name,
+so OpenCode will use a new file:
+
+```text
+/data/state/agents/providers/opencode.json
+```
+
+Existing `codex`, `claude`, and `gemini` sessions continue using their current
+state files and command paths.
+
+## Remaining Follow-Up Checks
+
+- Confirm the exact JSON event shapes emitted by the installed `opencode-ai`
+  version in the guest image against a real model backend.
+- Confirm whether OpenCode honors common provider API keys directly from the
+  environment, or whether a default config file should be mounted under
+  `/root/.opencode`.
+- Decide separately whether existing Codex/Claude/Gemini runners should consume
+  forwarded `model` / `system_prompt` or leave them as OpenCode-only runtime
+  options.

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -81,7 +81,7 @@ agent-compose down
 
 agent 常用字段：
 
-- `provider` / `model` / `system_prompt`：guest agent 配置（`provider` 选择 guest CLI runner；`model` 传给该 agent runtime）。非空 `system_prompt` 在运行时生效，并作为 Agent Identity 层注入 provider system/developer 指令。目前支持 `codex`、`claude`、`gemini`。daemon 侧 LLM 调用（`LLMService`、`scheduler.llm`）使用 `LLM_MODEL`，不是 compose 里的 agent `model`。
+- `provider` / `model` / `system_prompt`：guest agent 配置（`provider` 选择 guest CLI runner；`model` 会传给支持显式模型选择的 provider runtime）。非空 `system_prompt` 在运行时生效，并作为 Agent Identity 层注入 provider system/developer 指令。目前支持 `codex`、`claude`、`gemini`、`opencode`。daemon 侧 LLM 调用（`LLMService`、`scheduler.llm`）使用 `LLM_MODEL`，不是 compose 里的 agent `model`。
 - `image`：guest 镜像引用；为空时使用 driver 对应默认镜像。
 - `driver`：每个 agent 可选择一个 runtime，支持 `boxlite`、`docker`、`microsandbox`。
 - `env`：agent 级环境变量，支持 scalar 或 `{ value, secret }` 形状。
@@ -133,13 +133,14 @@ npm run dev:ui
 
 ### Agent Provider
 
-Guest agent session 在 guest 容器内运行 provider CLI（`agent-compose-runtime-js`）。Codex 和 Claude 通过 Runtime LLM Facade 调用：真实 provider key 保存在 daemon 侧 LLM provider 配置中，runtime 只拿 session-scoped facade token 和 facade base URL。`LLM_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`GOOGLE_API_KEY`、`GEMINI_API_KEY` 等 provider key 名称会从用户提供的 runtime env 中过滤。兼容别名 `LLM_API_KEY`、`LLM_API_ENDPOINT` 仍可能出现在 runtime 中，但它们是 daemon 写入的 facade 值，不是上游 provider 凭据。
+Guest agent session 在 guest 容器内运行 provider CLI（`agent-compose-runtime-js`）。Codex 和 Claude 通过 Runtime LLM Facade 调用：真实 provider key 保存在 daemon 侧 LLM provider 配置中，runtime 只拿 session-scoped facade token 和 facade base URL。`LLM_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`GOOGLE_API_KEY`、`GEMINI_API_KEY` 等 provider key 名称会从用户提供的 runtime env 中过滤。兼容别名 `LLM_API_KEY`、`LLM_API_ENDPOINT` 仍可能出现在 runtime 中，但它们是 daemon 写入的 facade 值，不是上游 provider 凭据。Gemini 和 OpenCode 仍直接使用各自 provider CLI；OpenCode 凭据取决于所选 OpenCode model provider。
 
 | Provider | 典型环境变量 | 说明 |
 | --- | --- | --- |
 | `codex` | daemon LLM provider 配置；runtime 获取 `AGENT_COMPOSE_SESSION_TOKEN`、`LLM_API_KEY`、`LLM_API_ENDPOINT`、`OPENAI_BASE_URL` 和 facade-token API key aliases | 使用 guest 镜像中的 Codex CLI/SDK |
 | `claude` | daemon Anthropic family provider 配置；runtime 获取 `AGENT_COMPOSE_SESSION_TOKEN`、`LLM_API_KEY`、`LLM_API_ENDPOINT`、`ANTHROPIC_BASE_URL` 和 facade-token API key aliases | 使用 guest 镜像中的 Claude Code CLI |
 | `gemini` | 暂未接入 LLM facade | 使用 guest 镜像中的 Gemini CLI |
+| `opencode` | 取决于所选 OpenCode model provider，例如 `ANTHROPIC_API_KEY` 或 `OPENAI_API_KEY` | 使用 guest 镜像中的 OpenCode CLI |
 
 修改 guest runtime 代码或 provider 支持后，需重建 guest 镜像：
 
@@ -197,5 +198,6 @@ task test
 - [架构说明](design/agent-compose_design.md)
 - [Agent system prompt（Phase 1）](design/agent_system_prompt_design.md)
 - [Runtime JS contract](design/agent-compose-runtime-js_contract.md)
+- [OpenCode CLI Provider 支持](design/opencode_cli_support.md)
 - [Webhook design](design/webhook_design.md)
 - [Loader script API](../../loader-script/README.md)

--- a/docs/zh-CN/design/agent-compose-runtime-js_contract.md
+++ b/docs/zh-CN/design/agent-compose-runtime-js_contract.md
@@ -150,11 +150,13 @@ CLI 使用 `commander` 解析命令和参数。npm 包的 `bin` 入口为 `agent
 
 | 参数 | 必填 | 说明 |
 |---|---:|---|
-| `--provider` | 是 | `codex`、`claude`、`gemini`，支持少量别名 |
+| `--provider` | 是 | `codex`、`claude`、`gemini`、`opencode`，支持少量别名 |
 | `--message-file` | 是 | prompt 文件路径 |
 | `--state-root` | 否 | agent-compose runtime 状态根目录，默认 `/srv/agent-compose/session/state`。Guest 从此根路径按约定发现 agent identity（`agents/system-prompts/system-prompt.txt`）与 MPI catalog |
 | `--workspace` | 否 | agent 工作目录，默认 `WORKSPACE` 或 `/workspace` |
 | `--home` | 否 | agent HOME，默认 `HOME` 或 `/root` |
+| `--model` | 否 | agent model；由支持显式模型选择的 provider 使用 |
+| `--system-prompt-file` | 否 | system prompt 文件路径；当前由需要 prompt 级 system instructions 的 provider 使用 |
 
 Agent identity 使用 §3.2 文档中的固定约定路径。
 
@@ -501,6 +503,22 @@ gemini -p <prompt> --output-format stream-json --approval-mode yolo
 ```
 
 当前 Gemini runner 读取 stream-json 并生成 transcript，但不写 `/data/state/agents/providers/gemini.json`。
+
+### 10.4 OpenCode
+
+JS runtime 通过子进程调用 OpenCode：
+
+```sh
+opencode run <prompt> --format json --dir /workspace --dangerously-skip-permissions
+```
+
+当 host 提供 model 时，runner 会追加 `--model <model>`。当已有 provider session
+state 时，runner 会追加 `--session <stored session id>`。runner 会默认设置
+`OPENCODE_DISABLE_AUTOUPDATE=true`，除非环境变量中已经显式设置。
+
+OpenCode 原始 JSON events 会被转换成人类可读 transcript。成功运行且拿到非空
+provider session id 后，runner 会写入
+`/data/state/agents/providers/opencode.json`。
 
 ## 11. 错误语义
 

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -492,7 +492,7 @@ project compose 的 `scheduler.script` 使用同一套 runtime。脚本在 valid
 
 UI/数据库中的 global env 会覆盖进程环境变量。`chat_completions` 仅用于单次文本生成，不会创建具备 workspace 能力的 agent session，也不提供文件、命令或 MCP 工具访问。使用 `outputSchema` 时，`chat_completions` 通过 prompt 引导并设置 `json_object`，不等价于 Responses API strict JSON Schema。
 
-Guest agent provider（`codex`、`claude`、`gemini`）仍是 guest 容器内的 CLI runner，使用各自的 API key 和 session 状态。
+Guest agent provider（`codex`、`claude`、`gemini`、`opencode`）仍是 guest 容器内的 CLI runner，使用各自的 API key 和 session 状态。
 
 loader 内还暴露 v1 `SessionService` 的 unary RPC bridge：
 

--- a/docs/zh-CN/design/opencode_cli_support.md
+++ b/docs/zh-CN/design/opencode_cli_support.md
@@ -1,0 +1,199 @@
+# OpenCode CLI Provider 支持
+
+英文版见：[../../design/opencode_cli_support.md](../../design/opencode_cli_support.md)
+
+本文档记录把 `opencode` 接入为 guest agent provider 的实现方案。它遵循当前
+[agent-compose-runtime-js_contract.md](agent-compose-runtime-js_contract.md)：
+Go 控制面负责创建 session 并在 guest 内执行统一 runtime 命令，
+`runtime/javascript` 负责适配各 provider CLI。
+
+## 当前代码结构
+
+Provider 相关逻辑分在四层：
+
+- Go 控制面：`pkg/agentcompose/service.go` 的 `normalizeAgentKind`、
+  `pkg/agentcompose/agent_definition.go` 的 `normalizeAgentDefinition`、
+  loader 默认 agent 校验，以及 run/session 编排当前会把 provider 字符串传给
+  guest runtime。
+- JavaScript runtime：`runtime/javascript/src/provider.ts` 归一化 provider
+  alias，`runtime/javascript/src/prompt.ts` 选择 runner，
+  `runtime/javascript/src/runners/` 存放 provider adapter。
+- Guest 镜像：`guest-images/Dockerfile.agent-compose-guest` 安装 provider
+  CLI，并创建 `/usr/bin/codex` 这类稳定可执行路径。
+- UI 和文档：`frontend/src/pages/AgentsPage.svelte`、`README.md`、设计文档
+  显示支持的 provider 列表。
+
+`pkg/compose` 当前不限制 provider 名称；真正拒绝未知 provider 的位置在 daemon
+侧 agent definition 校验。Proto 字段是 string，因此本变更不需要改 protobuf。
+
+`model` 和 `system_prompt` 已经存在于 compose、v1、v2 和 store model 中。
+OpenCode 集成会把它们透传到 `ExecuteAgentRequest` 和
+`agent-compose-runtime prompt`；现有 Codex、Claude、Gemini runner 仍保持原行为，
+除非后续显式消费这些字段。
+
+## OpenCode CLI 事实
+
+根据当前 OpenCode CLI 文档 <https://opencode.ai/docs/cli/>，和 agent-compose
+相关的非交互命令是：
+
+```sh
+opencode run [message..]
+```
+
+需要使用或关注的 flags：
+
+- `--format json`：输出原始 JSON events。
+- `--session <id>` 和 `--continue`：续接 session。
+- `--model <provider/model>`：选择模型。
+- `--agent <agent>`：选择 OpenCode agent profile。
+- `--dir <path>`：指定工作目录。
+- `--dangerously-skip-permissions`：自动批准未显式拒绝的权限。
+- `--attach <url>`：连接已运行的 OpenCode server。首版不接入该模式，因为
+  agent-compose 已经负责 session 生命周期，不会为每个 session 额外维护一个
+  OpenCode server。
+
+OpenCode 文档中的 npm 安装命令是 `npm install -g opencode-ai`。
+
+## 目标行为
+
+用户可以在 compose 中配置：
+
+```yaml
+agents:
+  reviewer:
+    provider: opencode
+    model: anthropic/claude-sonnet-4-5
+```
+
+也可以在 UI/API 中创建 provider 为 `opencode` 的 agent definition。
+
+执行 agent 时应当：
+
+- 调用 `agent-compose-runtime prompt --provider opencode ...`；
+- 在 `/workspace` 中运行 `opencode run`；
+- 将 OpenCode session id 保存到
+  `/data/state/agents/providers/opencode.json` 并在后续运行中复用；
+- 通过 stderr 持续输出可读 transcript，和现有 runners 保持一致；
+- 通过 stdout 的 `__AGENT_RESULT__` 协议返回最终 `AgentResult` JSON；
+- 当 `opencode` 非零退出或输出错误事件时，给出清晰失败信息。
+
+## 实现概要
+
+1. 增加 provider 归一化。
+
+   两侧 provider normalizer 都支持 OpenCode：
+
+   - `runtime/javascript/src/types.ts`：`Provider` 增加 `"opencode"`。
+   - `runtime/javascript/src/provider.ts`：把 `opencode`、`open-code`、
+     `open_code` 归一化为 `opencode`。
+   - `pkg/agentcompose/service.go`：更新 `normalizeAgentKind`。
+   - `pkg/agentcompose/agent_definition.go`：provider 白名单允许
+     `opencode`。
+
+2. 增加 `OpenCodeRunner`。
+
+   `runtime/javascript/src/runners/opencode.ts` 使用
+   `spawn("opencode", args, ...)`，因为当前明确文档化的接入面是 CLI。
+
+   首版命令形态：
+
+   ```text
+   opencode run <prompt> --format json --dir <workspace>
+     --dangerously-skip-permissions
+     [--model <model>]
+     [--session <stored-session-id>]
+   ```
+
+   实现要点：
+
+   - 使用 `readStoredSession(stateRoot, "opencode")` 读取已有 session；
+   - 子进程环境里默认设置 `OPENCODE_DISABLE_AUTOUPDATE=true`，除非用户已显式
+     设置；
+   - 仅当 `RunnerOptions.model` 存在时传 `--model`；
+   - 尽量按行解析 JSON events；非 JSON 行不丢弃，写入 transcript；
+   - 从 `sessionID`、`sessionId`、`session_id` 等常见字段提取 session id；
+   - 用 `extractText` 从 message/result 字段提取最终文本；
+   - 只有拿到非空 session id 后才写 provider session state。
+
+3. 接入 runner 选择。
+
+   - 在 `runtime/javascript/src/prompt.ts` 和 `runtime/javascript/src/index.ts`
+     import/export `OpenCodeRunner`。
+   - 更新 `runtime/javascript/src/cli.ts` 的 provider 帮助文本。
+
+4. Agent model 和 system prompt 透传。
+
+   OpenCode 需要 `model` 来选择目标 provider/model。host 显式透传这些字段，而不是
+   依赖已保存的 metadata：
+
+   - 执行配置 helper 会在 session 有 agent tags 时，从 agent definition
+     解析 provider、model、system prompt；
+   - `ExecuteAgentRequest` 包含 `Model` 和 `SystemPrompt`；
+   - `runProjectAgent` 会从 managed project agent definition 设置这些字段；
+   - 通过 `SendAgentMessage` / `SendAgentMessageStream` 执行 v1 agent definition
+     session 时，也要设置这些字段；
+   - loader 绑定 agent definition 并调用 `scheduler.agent` 时，也会设置这些字段；
+   - runtime CLI 支持 `--model`、`--system-prompt-file`；
+   - `PromptCommandOptions` 和 `RunnerOptions` 包含 `model?: string` 和
+     `systemPrompt?: string`。
+
+5. 在 guest 镜像中安装 CLI。
+
+   `guest-images/Dockerfile.agent-compose-guest`：
+
+   - 全局 npm install 增加 `opencode-ai`；
+   - 链接 executable 到 `/usr/bin/opencode`；
+   - 创建 `/root/.opencode`。
+
+6. 更新 UI 和文档。
+
+   - `frontend/src/pages/AgentsPage.svelte` 和 `frontend/src/api/agents.ts`
+     接受 `opencode`。
+   - `README.md`、SDK 文档和 runtime contract 中的支持列表增加 OpenCode。
+   - OpenCode 环境变量说明会指出：OpenCode 使用哪个 provider key 取决于其
+     `model` 的 provider，因此文档应写常见情况，不写成单一固定 key。
+
+7. 测试。
+
+   Runtime JS 测试：
+
+   - provider normalization 接受 `opencode`、`open-code`、`open_code`；
+   - `OpenCodeRunner` 在新 session 和续接 session 下构造正确 args；
+   - event 解析覆盖 transcript、final text、stderr、退出失败和 session id。
+
+   Go 测试：
+
+   - `normalizeAgentKind` 映射 alias；
+   - agent definition 校验接受 `opencode`；
+   - loader/default-agent 路径接受归一化后的 `opencode`；
+   - service API 测试覆盖 `open-code` alias 归一化为 `opencode`。
+
+   镜像验证应在具备镜像构建条件时覆盖 `task image:agent-compose-guest` 和容器内
+   `opencode --help` smoke check。
+
+## Structured Output
+
+当前 runtime 对 Codex 和 Claude 支持 structured JSON output，但 Gemini 会拒绝
+`outputSchema`。OpenCode CLI 文档中的 `--format json` 是原始事件格式，不是 strict
+schema enforcement。因此首版应在 `opencode` runner 中遇到 `outputSchema` 时返回清晰
+错误，除非实现时确认 OpenCode 已有文档化的 structured-output 合约。
+
+如果后续需要 structured output，应作为独立变更加入 provider 专属合约和测试。
+
+## 兼容性和迁移
+
+不需要数据迁移。Provider session state 按 provider 名称拆分，OpenCode 会使用新文件：
+
+```text
+/data/state/agents/providers/opencode.json
+```
+
+已有 `codex`、`claude`、`gemini` session 继续使用当前 state 文件和命令路径。
+
+## 后续待确认
+
+- 用真实模型后端确认 guest 镜像中实际安装的 `opencode-ai` 版本输出的 JSON event 形状。
+- 确认 OpenCode 是否直接读取常见 provider API key 环境变量，还是需要在
+  `/root/.opencode` 下准备默认配置文件。
+- 另行决定现有 Codex/Claude/Gemini runners 是否消费透传后的
+  `model` / `system_prompt`，还是仅作为 OpenCode runtime 选项使用。

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -141,7 +141,7 @@ export async function createAgentDefinitionSession(input: {
 
 function normalizeAgentProvider(value: string): string {
   const provider = value.trim().toLowerCase();
-  if (provider === 'claude' || provider === 'gemini' || provider === 'codex') {
+  if (provider === 'claude' || provider === 'gemini' || provider === 'codex' || provider === 'opencode') {
     return provider;
   }
   throw new Error(`不支持的智能体 Provider：${value || '-'}`);

--- a/frontend/src/pages/AgentsPage.svelte
+++ b/frontend/src/pages/AgentsPage.svelte
@@ -601,6 +601,7 @@
             <option value="codex">codex</option>
             <option value="claude">claude</option>
             <option value="gemini">gemini</option>
+            <option value="opencode">opencode</option>
           </select>
         </label>
         <label class="form-item">

--- a/frontend/src/pages/RunsPage.svelte
+++ b/frontend/src/pages/RunsPage.svelte
@@ -1645,7 +1645,7 @@
       if (ctx.initialMessageSent || !initialMessage) return;
       ctx.initialMessageSent = true;
       const provider = (agent.provider || 'codex').trim().toLowerCase();
-      if (provider === 'claude' || provider === 'gemini' || provider === 'codex') {
+      if (provider === 'claude' || provider === 'gemini' || provider === 'codex' || provider === 'opencode') {
         void sendWorkSessionMessageStream(sessionId, provider, initialMessage, () => {}).catch(() => {});
       }
     }

--- a/guest-images/Dockerfile.agent-compose-guest
+++ b/guest-images/Dockerfile.agent-compose-guest
@@ -111,6 +111,8 @@ RUN mkdir -p /opt/agent-compose/npm && \
 ENV HOME=/root \
     GOPATH=/root/go \
     GOPROXY=${GOPROXY} \
+    OPENCODE_DISABLE_AUTOUPDATE=true \
+    OPENCODE_DISABLE_MODELS_FETCH=1 \
     PATH=/root/.local/bin:/usr/local/go/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN printf '%s\n' \
@@ -120,6 +122,8 @@ RUN printf '%s\n' \
   'export HOME=${HOME:-/root}' \
   'export GOPATH=${GOPATH:-/root/go}' \
   'export GOPROXY=${GOPROXY:-https://goproxy.cn,direct}' \
+  'export OPENCODE_DISABLE_AUTOUPDATE=${OPENCODE_DISABLE_AUTOUPDATE:-true}' \
+  'export OPENCODE_DISABLE_MODELS_FETCH=${OPENCODE_DISABLE_MODELS_FETCH:-1}' \
   'export PATH=/root/.local/bin:/usr/local/go/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
   'exec "$@"' > /usr/local/bin/agent-compose-env && chmod +x /usr/local/bin/agent-compose-env
 

--- a/guest-images/Dockerfile.agent-compose-guest
+++ b/guest-images/Dockerfile.agent-compose-guest
@@ -75,9 +75,9 @@ RUN set -e; \
       arm64) CLAUDE_CODE_PLATFORM_PACKAGE=@anthropic-ai/claude-code-linux-arm64 ;; \
       *) echo "unsupported Claude Code target arch: ${target_arch}" >&2; exit 1 ;; \
     esac; \
-    npm install -g @openai/codex @anthropic-ai/claude-code "${CLAUDE_CODE_PLATFORM_PACKAGE}" @google/gemini-cli
+    npm install -g @openai/codex @anthropic-ai/claude-code "${CLAUDE_CODE_PLATFORM_PACKAGE}" @google/gemini-cli opencode-ai
 
-RUN mkdir -p /usr/local/share/jupyter/kernels/javascript /root/.codex /root/.local/bin /root/.cargo/bin /root/go/bin /workspace /data/state /data/runtime /data/logs
+RUN mkdir -p /usr/local/share/jupyter/kernels/javascript /root/.codex /root/.opencode /root/.local/bin /root/.cargo/bin /root/go/bin /workspace /data/state /data/runtime /data/logs
 
 COPY ./assets/.codex/ /root/.codex/
 COPY ./assets/.claude/ /root/.claude/
@@ -96,7 +96,8 @@ RUN cd /tmp/agent-compose-runtime && \
     ln -sv ../lib/node_modules/agent-compose-runtime-js/dist/cli.js /usr/bin/agent-compose-runtime && \
     ln -sf ../lib/node_modules/@openai/codex/bin/codex.js /usr/bin/codex && \
     ln -sf ../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe /usr/bin/claude && \
-    ln -sf ../lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/bin/gemini
+    ln -sf ../lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/bin/gemini && \
+    ln -sf ../lib/node_modules/opencode-ai/bin/opencode.exe /usr/bin/opencode
 
 RUN mkdir -p /opt/agent-compose/npm && \
     cd /tmp/agent-compose-runtime-sdk && \
@@ -115,7 +116,7 @@ ENV HOME=/root \
 RUN printf '%s\n' \
   '#!/usr/bin/env bash' \
   'set -euo pipefail' \
-  'mkdir -p /root/.codex /root/.local/bin /root/.cargo/bin /root/go/bin /workspace /data/state /data/runtime /data/logs' \
+  'mkdir -p /root/.codex /root/.opencode /root/.local/bin /root/.cargo/bin /root/go/bin /workspace /data/state /data/runtime /data/logs' \
   'export HOME=${HOME:-/root}' \
   'export GOPATH=${GOPATH:-/root/go}' \
   'export GOPROXY=${GOPROXY:-https://goproxy.cn,direct}' \

--- a/pkg/agentcompose/agent_definition.go
+++ b/pkg/agentcompose/agent_definition.go
@@ -90,7 +90,7 @@ func normalizeAgentDefinition(item AgentDefinition, assignDefaults bool) (AgentD
 	if item.Provider == "" {
 		return AgentDefinition{}, fmt.Errorf("agent definition provider is required")
 	}
-	if item.Provider != "codex" && item.Provider != "claude" && item.Provider != "gemini" {
+	if item.Provider != "codex" && item.Provider != "claude" && item.Provider != "gemini" && item.Provider != "opencode" {
 		return AgentDefinition{}, fmt.Errorf("agent definition provider %q is not supported", item.Provider)
 	}
 	if !isJSONObject(item.ConfigJSON) {

--- a/pkg/agentcompose/agent_definition_test.go
+++ b/pkg/agentcompose/agent_definition_test.go
@@ -258,9 +258,11 @@ func TestAgentSessionMessageUsesDefinitionProvider(t *testing.T) {
 	ctx := context.Background()
 	service, runtime, _ := newTestServiceAPIHarness(t)
 	created, err := service.CreateAgentDefinition(ctx, connect.NewRequest(&agentcomposev1.CreateAgentDefinitionRequest{
-		Name:     "Claude Runner",
-		Enabled:  true,
-		Provider: "claude",
+		Name:         "Claude Runner",
+		Enabled:      true,
+		Provider:     "open-code",
+		Model:        "anthropic/claude-sonnet-4-5",
+		SystemPrompt: "system body",
 	}))
 	if err != nil {
 		t.Fatalf("CreateAgentDefinition returned error: %v", err)
@@ -280,8 +282,20 @@ func TestAgentSessionMessageUsesDefinitionProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SendAgentMessage returned error: %v", err)
 	}
-	if len(runtime.providers) != 1 || runtime.providers[0] != "claude" {
-		t.Fatalf("runtime providers = %v, want [claude]", runtime.providers)
+	if len(runtime.providers) != 1 || runtime.providers[0] != "opencode" {
+		t.Fatalf("runtime providers = %v, want [opencode]", runtime.providers)
+	}
+	if len(runtime.agentSpecs) != 1 {
+		t.Fatalf("runtime agent specs = %d, want 1", len(runtime.agentSpecs))
+	}
+	command := strings.Join(runtime.agentSpecs[0].Args, " ")
+	for _, want := range []string{"--provider 'opencode'", "--model 'anthropic/claude-sonnet-4-5'"} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("agent command %q does not contain %q", command, want)
+		}
+	}
+	if strings.Contains(command, "--system-prompt-file") {
+		t.Fatalf("agent command %q contains deprecated --system-prompt-file flag", command)
 	}
 }
 

--- a/pkg/agentcompose/agent_system_prompt_test.go
+++ b/pkg/agentcompose/agent_system_prompt_test.go
@@ -230,7 +230,7 @@ func TestBuildAgentExecSpecPassesStateRootForConventionPathDiscovery(t *testing.
 	}
 	session := &Session{Summary: SessionSummary{ID: "session-1"}}
 
-	spec := buildAgentExecSpec(cfg, session, "codex", "/data/state/agents/prompts/prompt.txt", "")
+	spec := buildAgentExecSpec(cfg, session, "codex", "", "/data/state/agents/prompts/prompt.txt", "")
 	command := strings.Join(spec.Args, " ")
 	if !strings.Contains(command, "--state-root '/data/state'") {
 		t.Fatalf("command missing --state-root for convention-based system prompt discovery: %q", command)

--- a/pkg/agentcompose/exec.go
+++ b/pkg/agentcompose/exec.go
@@ -708,6 +708,7 @@ func shouldIncludeAgentJSONL(path, provider, sessionID string) bool {
 
 func (e *Executor) executeAgent(ctx context.Context, session *Session, request ExecuteAgentRequest) (NotebookCell, SessionEvent, SessionEvent, error) {
 	agent := request.Agent
+	model := strings.TrimSpace(request.Model)
 	message := request.Message
 	stream := request.Stream
 	message = strings.TrimSpace(message)
@@ -850,7 +851,7 @@ func (e *Executor) executeAgent(ctx context.Context, session *Session, request E
 		}
 	}
 
-	execResult, result, err := e.executeAgentRun(execCtx, session, agent, request.AgentDefinitionID, request.Model, request.RunID, message, request.OutputSchemaJSON, streamWriter)
+	execResult, result, err := e.executeAgentRun(execCtx, session, agent, request.AgentDefinitionID, model, request.RunID, message, request.OutputSchemaJSON, streamWriter)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -3,6 +3,7 @@ package agentcompose
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -596,6 +597,249 @@ func TestEnsureSessionLLMFacadeConfigUsesRequestedModel(t *testing.T) {
 	}
 	if !strings.Contains(string(payload), `model = "model-b"`) {
 		t.Fatalf("codex config did not use requested model-b: %s", string(payload))
+	}
+}
+
+func TestEnsureSessionOpenCodeCustomProviderWritesConfig(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "chaitin",
+		Name:           "chaitin",
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: llmAPIProtocolChatCompletions,
+		BaseURL:        "https://aiapi.example.invalid/v1",
+		APIKey:         "provider-key",
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    "{}",
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "kimi-k2.6", Name: "kimi-k2.6", DefaultModel: true, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+	session := createRunningLLMFacadeSession(t, ctx, service, "opencode-custom")
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "opencode", "chaitin/kimi-k2.6", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["AGENT_COMPOSE_SESSION_TOKEN"] == "" || env["AGENT_COMPOSE_SESSION_TOKEN"] != env["LLM_API_KEY"] {
+		t.Fatalf("managed facade env missing token aliases: %#v", env)
+	}
+	if env["OPENCODE_CONFIG"] != "/root/.opencode/agent-compose.json" {
+		t.Fatalf("OPENCODE_CONFIG = %q, want guest opencode config path", env["OPENCODE_CONFIG"])
+	}
+	if strings.Contains(strings.Join([]string{env["LLM_API_KEY"], env["OPENAI_API_KEY"]}, " "), "provider-key") {
+		t.Fatalf("provider key leaked into runtime env: %#v", env)
+	}
+	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.ProviderID != "chaitin" || token.Model != "kimi-k2.6" || token.WireAPI != llmAPIProtocolChatCompletions {
+		t.Fatalf("facade token = %#v, want chaitin/kimi-k2.6 chat facade", token)
+	}
+	configPath := filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")
+	payload, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", configPath, err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode opencode config: %v\n%s", err, string(payload))
+	}
+	providers := decoded["provider"].(map[string]any)
+	chaitin := providers["chaitin"].(map[string]any)
+	if chaitin["npm"] != "@ai-sdk/openai-compatible" {
+		t.Fatalf("opencode provider npm = %#v", chaitin["npm"])
+	}
+	options := chaitin["options"].(map[string]any)
+	if options["baseURL"] != "http://agent-compose.test/api/runtime/sessions/"+session.Summary.ID+"/llm/openai/v1" {
+		t.Fatalf("opencode baseURL = %#v", options["baseURL"])
+	}
+	if options["apiKey"] != "{env:AGENT_COMPOSE_SESSION_TOKEN}" {
+		t.Fatalf("opencode apiKey = %#v", options["apiKey"])
+	}
+	models := chaitin["models"].(map[string]any)
+	if _, ok := models["kimi-k2.6"]; !ok {
+		t.Fatalf("opencode models = %#v, want kimi-k2.6", models)
+	}
+}
+
+func TestEnsureSessionOpenCodeCustomProviderBootstrapsFromDefaultEnv(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("LLM_API_ENDPOINT", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = "https://aiapi.example.invalid"
+	service.config.LLMAPIProtocol = llmAPIProtocolChatCompletions
+	service.config.LLMAPIKey = "default-env-key"
+	service.config.LLMModel = "kimi-k2.6"
+	session := createRunningLLMFacadeSession(t, ctx, service, "opencode-custom-default-env")
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "opencode", "chaitin/kimi-k2.6", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.ProviderID != "chaitin" || token.Model != "kimi-k2.6" {
+		t.Fatalf("facade token = %#v, want bootstrapped chaitin/kimi-k2.6", token)
+	}
+	providers, err := service.configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 || providers[0].ID != "chaitin" || providers[0].APIKey != "default-env-key" {
+		t.Fatalf("providers = %#v, want single chaitin provider from default env", providers)
+	}
+	if env["OPENCODE_CONFIG"] != "/root/.opencode/agent-compose.json" {
+		t.Fatalf("OPENCODE_CONFIG = %q, want custom opencode config path", env["OPENCODE_CONFIG"])
+	}
+}
+
+func TestEnsureSessionOpenCodeNativeProviderUsesOpenCodeConfig(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	session := createRunningLLMFacadeSession(t, ctx, service, "opencode-native")
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "opencode", "opencode/big-pickle", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("env = %#v, want no managed facade env for opencode native provider", env)
+	}
+	if _, err := os.Stat(filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")); !os.IsNotExist(err) {
+		t.Fatalf("opencode config file should not exist for native provider, stat err=%v", err)
+	}
+}
+
+func TestEnsureSessionOpenCodeOpenAIWritesRequestedModelConfig(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "default",
+		Name:           "default",
+		ProviderType:   llmProviderFamilyOpenAI,
+		DefaultWireAPI: llmAPIProtocolChatCompletions,
+		BaseURL:        "https://aiapi.example.invalid/v1",
+		APIKey:         "provider-key",
+		AuthHeader:     "Authorization",
+		AuthScheme:     "Bearer",
+		HeadersJSON:    "{}",
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "kimi-k2.6", Name: "kimi-k2.6", DefaultModel: true, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+	session := createRunningLLMFacadeSession(t, ctx, service, "opencode-openai")
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "opencode", "openai/kimi-k2.6", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["OPENCODE_CONFIG"] != "/root/.opencode/agent-compose.json" {
+		t.Fatalf("OPENCODE_CONFIG = %q, want guest opencode config path", env["OPENCODE_CONFIG"])
+	}
+	payload, err := os.ReadFile(filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json"))
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode opencode config: %v\n%s", err, string(payload))
+	}
+	models := decoded["provider"].(map[string]any)["openai"].(map[string]any)["models"].(map[string]any)
+	if _, ok := models["kimi-k2.6"]; !ok {
+		t.Fatalf("opencode openai models = %#v, want requested model", models)
+	}
+}
+
+func TestSplitOpenCodeModelPreservesNestedModelID(t *testing.T) {
+	providerID, modelName, err := splitOpenCodeModel("openrouter/meta-llama/llama-3.1-8b")
+	if err != nil {
+		t.Fatalf("splitOpenCodeModel returned error: %v", err)
+	}
+	if providerID != "openrouter" || modelName != "meta-llama/llama-3.1-8b" {
+		t.Fatalf("splitOpenCodeModel = %q, %q; want provider and nested model id preserved", providerID, modelName)
+	}
+}
+
+func TestEnsureSessionOpenCodeAnthropicUsesFacadeEnv(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_MODEL", "")
+	t.Setenv("LLM_API_KEY", "")
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+		ID:             "anthropic",
+		Name:           "anthropic",
+		ProviderType:   llmProviderFamilyAnthropic,
+		DefaultWireAPI: llmAPIProtocolMessages,
+		BaseURL:        "https://anthropic.example.invalid",
+		APIKey:         "anthropic-provider-key",
+		AuthHeader:     "x-api-key",
+		HeadersJSON:    `{"anthropic-version":"2023-06-01"}`,
+		Weight:         1,
+		Enabled:        true,
+		Scope:          llmProviderScopeSystem,
+	}, LLMModel{ID: "claude-sonnet-4-5", Name: "claude-sonnet-4-5", DefaultModel: true, Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+	session := createRunningLLMFacadeSession(t, ctx, service, "opencode-anthropic")
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "opencode", "anthropic/claude-sonnet-4-5", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["ANTHROPIC_API_KEY"] != env["AGENT_COMPOSE_SESSION_TOKEN"] {
+		t.Fatalf("ANTHROPIC_API_KEY = %q, want facade token", env["ANTHROPIC_API_KEY"])
+	}
+	if env["ANTHROPIC_BASE_URL"] != "http://agent-compose.test/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic" {
+		t.Fatalf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
+	}
+	if env["OPENCODE_CONFIG"] != "" {
+		t.Fatalf("OPENCODE_CONFIG = %q, want no custom config for built-in anthropic provider", env["OPENCODE_CONFIG"])
+	}
+	if _, err := os.Stat(filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")); !os.IsNotExist(err) {
+		t.Fatalf("opencode config file should not exist for built-in anthropic provider, stat err=%v", err)
+	}
+	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.ProviderID != "anthropic" || token.Model != "claude-sonnet-4-5" || token.WireAPI != llmAPIProtocolMessages {
+		t.Fatalf("facade token = %#v, want anthropic messages facade", token)
+	}
+}
+
+func TestEnsureSessionOpenCodeModelRequiresProviderPrefix(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	session := createRunningLLMFacadeSession(t, ctx, service, "opencode-invalid-model")
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "opencode", "kimi-k2.6", "test", "run-1")
+	if err == nil {
+		t.Fatalf("expected opencode provider/model error, got env=%#v", env)
+	}
+	if !strings.Contains(err.Error(), "provider/model") {
+		t.Fatalf("error = %v, want provider/model guidance", err)
 	}
 }
 

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -3,6 +3,7 @@ package agentcompose
 import (
 	appconfig "agent-compose/pkg/config"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,14 +17,35 @@ import (
 // than letting it live for the whole session lifetime.
 const llmFacadeTokenSourceAgent = "agent"
 
+type agentRuntimeLLMConfig struct {
+	Env map[string]string
+}
+
 func ensureSessionLLMFacadeConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, agent, model, source, runID string) (map[string]string, error) {
+	runtimeConfig, err := ensureSessionAgentRuntimeLLMConfig(ctx, config, configDB, session, agent, model, source, runID)
+	if err != nil {
+		return nil, err
+	}
+	return runtimeConfig.Env, nil
+}
+
+func ensureSessionAgentRuntimeLLMConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, agent, model, source, runID string) (agentRuntimeLLMConfig, error) {
 	if config == nil || configDB == nil || session == nil {
-		return nil, nil
+		return agentRuntimeLLMConfig{}, nil
 	}
-	if normalizeAgentKind(agent) == "claude" {
-		return ensureSessionClaudeLLMFacadeConfig(ctx, config, configDB, session, model, source, runID)
+	switch normalizeAgentKind(agent) {
+	case "codex":
+		env, err := ensureSessionCodexLLMFacadeConfig(ctx, config, configDB, session, model, source, runID)
+		return agentRuntimeLLMConfig{Env: env}, err
+	case "claude":
+		env, err := ensureSessionClaudeLLMFacadeConfig(ctx, config, configDB, session, model, source, runID)
+		return agentRuntimeLLMConfig{Env: env}, err
+	case "opencode":
+		env, err := ensureSessionOpenCodeLLMFacadeConfig(ctx, config, configDB, session, model, source, runID)
+		return agentRuntimeLLMConfig{Env: env}, err
+	default:
+		return agentRuntimeLLMConfig{}, nil
 	}
-	return ensureSessionCodexLLMFacadeConfig(ctx, config, configDB, session, model, source, runID)
 }
 
 func ensureSessionCodexLLMFacadeConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, model, source, runID string) (map[string]string, error) {
@@ -98,6 +120,152 @@ func ensureSessionClaudeLLMFacadeConfig(ctx context.Context, config *appconfig.C
 		env["CLAUDE_MODEL"] = tokenModel
 	}
 	return env, nil
+}
+
+func ensureSessionOpenCodeLLMFacadeConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, model, source, runID string) (map[string]string, error) {
+	providerID, modelName, err := splitOpenCodeModel(model)
+	if err != nil {
+		return nil, err
+	}
+	baseURL := guestRuntimeLLMBaseURL(config, session)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	switch providerID {
+	case "opencode":
+		return nil, nil
+	case "anthropic":
+		return ensureSessionOpenCodeAnthropicFacadeConfig(ctx, config, configDB, session, modelName, source, runID)
+	case "openai":
+		return ensureSessionOpenCodeOpenAIFacadeEnv(ctx, config, configDB, session, modelName, source, runID)
+	default:
+		return ensureSessionOpenCodeCustomProviderConfig(ctx, config, configDB, session, providerID, modelName, source, runID)
+	}
+}
+
+func splitOpenCodeModel(model string) (string, string, error) {
+	model = strings.TrimSpace(model)
+	providerID, modelName, ok := strings.Cut(model, "/")
+	providerID = strings.TrimSpace(providerID)
+	modelName = strings.TrimSpace(modelName)
+	if !ok || providerID == "" || modelName == "" {
+		return "", "", fmt.Errorf("opencode model must be in provider/model format")
+	}
+	return providerID, modelName, nil
+}
+
+func ensureSessionOpenCodeAnthropicFacadeConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, model, source, runID string) (map[string]string, error) {
+	baseURL := guestRuntimeLLMBaseURL(config, session)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	providerEnv := sessionLLMProviderEnvItems(session)
+	target, err := resolveRuntimeLLMTargetWithEnv(ctx, config, configDB, session.Summary.ID, llmProviderFamilyAnthropic, model, "", providerEnv)
+	if err != nil {
+		return nil, err
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llmAPIProtocolMessages, source, runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	anthropicBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sessions/" + session.Summary.ID + "/llm/anthropic"
+	return map[string]string{
+		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            anthropicBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            llmAPIProtocolMessages,
+		"ANTHROPIC_API_KEY":           tokenValue,
+		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
+	}, nil
+}
+
+func ensureSessionOpenCodeOpenAIFacadeEnv(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, model, source, runID string) (map[string]string, error) {
+	target, err := resolveRuntimeLLMTargetWithEnv(ctx, config, configDB, session.Summary.ID, llmProviderFamilyOpenAI, model, "", sessionLLMProviderEnvItems(session))
+	if err != nil {
+		return nil, err
+	}
+	baseURL := guestRuntimeLLMBaseURL(config, session)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llmAPIProtocolChatCompletions, source, runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sessions/" + session.Summary.ID + "/llm/openai/v1"
+	if err := writeOpenCodeLLMConfig(session, "openai", target.Model.Name, openAIBaseURL); err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            openAIBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            llmAPIProtocolChatCompletions,
+		"OPENAI_API_KEY":              tokenValue,
+		"OPENAI_BASE_URL":             openAIBaseURL,
+		"OPENCODE_CONFIG":             guestOpenCodeLLMConfigPath(config),
+	}, nil
+}
+
+func ensureSessionOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, providerID, model, source, runID string) (map[string]string, error) {
+	target, err := resolveOpenCodeCustomProviderTarget(ctx, config, configDB, session, providerID, model)
+	if err != nil {
+		return nil, err
+	}
+	baseURL := guestRuntimeLLMBaseURL(config, session)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llmAPIProtocolChatCompletions, source, runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sessions/" + session.Summary.ID + "/llm/openai/v1"
+	if err := writeOpenCodeLLMConfig(session, providerID, target.Model.Name, openAIBaseURL); err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            openAIBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            llmAPIProtocolChatCompletions,
+		"OPENAI_API_KEY":              tokenValue,
+		"OPENAI_BASE_URL":             openAIBaseURL,
+		"OPENCODE_CONFIG":             guestOpenCodeLLMConfigPath(config),
+	}, nil
+}
+
+func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.Config, configDB *ConfigStore, session *Session, providerID, model string) (LLMResolvedTarget, error) {
+	envItems := sessionLLMProviderEnvItems(session)
+	sessionID := ""
+	if session != nil {
+		sessionID = session.Summary.ID
+	}
+	if hasEnabledLLMProviderID(ctx, configDB, providerID) {
+		return resolveRuntimeLLMTargetWithEnv(ctx, config, configDB, sessionID, llmProviderFamilyOpenAI, model, providerID, envItems)
+	}
+	if sessionID != "" && hasOpenAIEnvProviderInput(envItems) {
+		sessionProviderID, err := ensureSessionOpenAIEnvProvider(ctx, configDB, sessionID, model, envItems)
+		if err != nil {
+			return LLMResolvedTarget{}, err
+		}
+		if strings.TrimSpace(sessionProviderID) != "" {
+			return resolveRuntimeLLMTargetWithEnv(ctx, config, configDB, sessionID, llmProviderFamilyOpenAI, model, sessionProviderID, envItems)
+		}
+	}
+	if _, err := ensureOpenAIEnvProvider(ctx, configDB, defaultLLMEnvProviderLookup(ctx, config, configDB), providerID, providerID, llmProviderScopeEnvDefault, model, false); err != nil {
+		return LLMResolvedTarget{}, err
+	}
+	return resolveRuntimeLLMTargetWithEnv(ctx, config, configDB, sessionID, llmProviderFamilyOpenAI, model, providerID, envItems)
 }
 
 func isOptionalLLMFacadeConfigError(err error) bool {
@@ -183,6 +351,51 @@ persistence = "save-all"
 		return fmt.Errorf("write codex config: %w", err)
 	}
 	return nil
+}
+
+func writeOpenCodeLLMConfig(session *Session, providerID, model, baseURL string) error {
+	if session == nil {
+		return nil
+	}
+	providerID = strings.TrimSpace(providerID)
+	model = strings.TrimSpace(model)
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if providerID == "" || model == "" || baseURL == "" {
+		return nil
+	}
+	path := filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create opencode config dir: %w", err)
+	}
+	payload := map[string]any{
+		"$schema": "https://opencode.ai/config.json",
+		"provider": map[string]any{
+			providerID: map[string]any{
+				"npm":  "@ai-sdk/openai-compatible",
+				"name": "agent-compose " + providerID,
+				"options": map[string]any{
+					"baseURL": baseURL,
+					"apiKey":  "{env:AGENT_COMPOSE_SESSION_TOKEN}",
+				},
+				"models": map[string]any{
+					model: map[string]any{"name": model},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode opencode config: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write opencode config: %w", err)
+	}
+	return nil
+}
+
+func guestOpenCodeLLMConfigPath(config *appconfig.Config) string {
+	appconfig.ApplyDefaultGuestPaths(config)
+	return filepath.Join(guestSessionHome(config), ".opencode", "agent-compose.json")
 }
 
 func guestRuntimeLLMBaseURL(config *appconfig.Config, session *Session) string {

--- a/pkg/agentcompose/loader_manager.go
+++ b/pkg/agentcompose/loader_manager.go
@@ -846,34 +846,32 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 		_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventType, "info", "loader session ready", map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 
-	agent := normalizeAgentKind(request.Agent)
+	agentConfig := agentExecutionConfig{Provider: normalizeAgentKind(request.Agent)}
 	var agentDefinitionID string
-	model := ""
-	if agent == "" {
+	if agentConfig.Provider == "" {
 		agentDefinition, err := h.manager.loaderAgentDefinition(ctx, h.loader)
 		if err != nil {
 			return LoaderAgentResult{}, err
 		}
 		if agentDefinition != nil {
-			agent = normalizeAgentKind(agentDefinition.Provider)
+			agentConfig = agentExecutionConfigFromDefinition(*agentDefinition, "")
 			agentDefinitionID = strings.TrimSpace(agentDefinition.ID)
-			model = agentDefinition.Model
 		}
 	}
 	if agentDefinitionID == "" {
 		agentDefinitionID = strings.TrimSpace(h.loader.Summary.AgentID)
 	}
-	if agent == "" {
-		agent = normalizeAgentKind(h.loader.Summary.DefaultAgent)
+	if agentConfig.Provider == "" {
+		agentConfig.Provider = normalizeAgentKind(h.loader.Summary.DefaultAgent)
 	}
-	if agent == "" {
-		agent = "codex"
+	if agentConfig.Provider == "" {
+		agentConfig.Provider = "codex"
 	}
 
 	cell, _, _, execErr := h.manager.executor.ExecuteAgentRequest(ctx, session, ExecuteAgentRequest{
-		Agent:             agent,
+		Agent:             agentConfig.Provider,
 		AgentDefinitionID: agentDefinitionID,
-		Model:             model,
+		Model:             agentConfig.Model,
 		RunID:             h.run.ID,
 		Message:           prompt,
 		Timeout:           request.Timeout,
@@ -891,7 +889,7 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 		JSON:           jsonValue,
 		SessionID:      session.Summary.ID,
 		CellID:         cell.ID,
-		Agent:          firstNonEmpty(cell.Agent, agent),
+		Agent:          firstNonEmpty(cell.Agent, agentConfig.Provider),
 		AgentSessionID: cell.AgentSessionID,
 		StopReason:     cell.StopReason,
 		Success:        cell.Success,

--- a/pkg/agentcompose/loader_timer_test.go
+++ b/pkg/agentcompose/loader_timer_test.go
@@ -1873,6 +1873,7 @@ func (p fixedRuntimeProvider) ForSession(*Session) (BoxRuntime, error) {
 type fakeLoaderAgentRuntime struct {
 	execCalls              int
 	providers              []string
+	agentSpecs             []ExecSpec
 	agentDeadlineDurations []time.Duration
 	commandSpecs           []ExecSpec
 	commandExitCode        int
@@ -2019,6 +2020,7 @@ func (r *fakeLoaderAgentRuntime) ExecStream(ctx context.Context, session *Sessio
 		break
 	}
 	r.providers = append(r.providers, provider)
+	r.agentSpecs = append(r.agentSpecs, spec)
 	if stream != nil {
 		stream(ExecChunk{Text: "loader agent transcript\n", IsStderr: true})
 	}

--- a/pkg/agentcompose/run_service.go
+++ b/pkg/agentcompose/run_service.go
@@ -107,7 +107,7 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	if err != nil {
 		return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, err)
 	}
-	agentDefinition, err := s.projectRunAgentDefinition(ctx, run)
+	agentConfig, err := s.projectRunAgentConfig(ctx, run)
 	if err != nil {
 		run, markErr := coordinator.MarkFailed(ctx, ProjectRunTransitionRequest{
 			RunID:     run.RunID,
@@ -119,10 +119,6 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 			return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, markErr)
 		}
 		return run, err, nil
-	}
-	agentProvider := normalizeAgentKind(agentDefinition.Provider)
-	if agentProvider == "" {
-		agentProvider = defaultAgentProvider
 	}
 	if s.executor == nil {
 		err = fmt.Errorf("executor is required")
@@ -138,9 +134,9 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 		return run, err, nil
 	}
 	cell, _, _, execErr := s.executor.ExecuteAgentRequest(ctx, sessionResult.Session, ExecuteAgentRequest{
-		Agent:             agentProvider,
+		Agent:             agentConfig.Provider,
 		AgentDefinitionID: run.ManagedAgentID,
-		Model:             agentDefinition.Model,
+		Model:             agentConfig.Model,
 		RunID:             run.RunID,
 		Message:           msg.GetPrompt(),
 		OutputSchemaJSON:  msg.GetOutputSchemaJson(),
@@ -163,12 +159,16 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	return run, nil, nil
 }
 
-func (s *Service) projectRunAgentDefinition(ctx context.Context, run ProjectRunRecord) (AgentDefinition, error) {
+func (s *Service) projectRunAgentConfig(ctx context.Context, run ProjectRunRecord) (agentExecutionConfig, error) {
 	agent, err := s.configDB.GetAgentDefinition(ctx, run.ManagedAgentID)
 	if err != nil {
-		return AgentDefinition{}, fmt.Errorf("resolve managed agent definition %s: %w", run.ManagedAgentID, err)
+		return agentExecutionConfig{}, fmt.Errorf("resolve managed agent definition %s: %w", run.ManagedAgentID, err)
 	}
-	return agent, nil
+	config := agentExecutionConfigFromDefinition(agent, defaultAgentProvider)
+	if config.Provider == "" {
+		config.Provider = defaultAgentProvider
+	}
+	return config, nil
 }
 
 func projectRunAgentExecutionStream(run ProjectRunRecord, sink *projectRunStreamSink) AgentExecutionStream {

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -733,8 +733,13 @@ func (s *Service) SendAgentMessage(ctx context.Context, req *connect.Request[age
 	if message == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("message is required"))
 	}
-	agent := s.resolveSessionAgentProvider(ctx, session, req.Msg.GetAgent())
-	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgent(ctx, session, agent, message)
+	agentConfig := s.resolveSessionAgentConfig(ctx, session, req.Msg.GetAgent())
+	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgentRequest(ctx, session, ExecuteAgentRequest{
+		Agent:             agentConfig.Provider,
+		AgentDefinitionID: agentConfig.AgentDefinitionID,
+		Model:             agentConfig.Model,
+		Message:           message,
+	})
 	_ = cell
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -756,7 +761,7 @@ func (s *Service) SendAgentMessageStream(ctx context.Context, req *connect.Reque
 	if message == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("message is required"))
 	}
-	agent := s.resolveSessionAgentProvider(ctx, session, req.Msg.GetAgent())
+	agentConfig := s.resolveSessionAgentConfig(ctx, session, req.Msg.GetAgent())
 
 	streamErr := func(sendErr error) error {
 		if sendErr == nil {
@@ -765,22 +770,28 @@ func (s *Service) SendAgentMessageStream(ctx context.Context, req *connect.Reque
 		return connect.NewError(connect.CodeUnknown, sendErr)
 	}
 
-	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgentStream(ctx, session, agent, message, AgentExecutionStream{
-		OnStart: func(cell NotebookCell) error {
-			return streamErr(stream.Send(&agentcomposev1.SendAgentMessageStreamResponse{
-				EventType: agentcomposev1.SendAgentMessageStreamEventType_SEND_AGENT_MESSAGE_STREAM_EVENT_TYPE_STARTED,
-				Session:   toProtoSessionSummary(&session.Summary),
-				Run:       toProtoAgentRun(cell),
-				RunId:     cell.ID,
-			}))
-		},
-		OnChunk: func(cellID string, chunk ExecChunk) error {
-			return streamErr(stream.Send(&agentcomposev1.SendAgentMessageStreamResponse{
-				EventType: agentcomposev1.SendAgentMessageStreamEventType_SEND_AGENT_MESSAGE_STREAM_EVENT_TYPE_OUTPUT,
-				RunId:     cellID,
-				Chunk:     chunk.Text,
-				IsStderr:  chunk.IsStderr,
-			}))
+	cell, userEvent, assistantEvent, err := s.executor.ExecuteAgentRequest(ctx, session, ExecuteAgentRequest{
+		Agent:             agentConfig.Provider,
+		AgentDefinitionID: agentConfig.AgentDefinitionID,
+		Model:             agentConfig.Model,
+		Message:           message,
+		Stream: AgentExecutionStream{
+			OnStart: func(cell NotebookCell) error {
+				return streamErr(stream.Send(&agentcomposev1.SendAgentMessageStreamResponse{
+					EventType: agentcomposev1.SendAgentMessageStreamEventType_SEND_AGENT_MESSAGE_STREAM_EVENT_TYPE_STARTED,
+					Session:   toProtoSessionSummary(&session.Summary),
+					Run:       toProtoAgentRun(cell),
+					RunId:     cell.ID,
+				}))
+			},
+			OnChunk: func(cellID string, chunk ExecChunk) error {
+				return streamErr(stream.Send(&agentcomposev1.SendAgentMessageStreamResponse{
+					EventType: agentcomposev1.SendAgentMessageStreamEventType_SEND_AGENT_MESSAGE_STREAM_EVENT_TYPE_OUTPUT,
+					RunId:     cellID,
+					Chunk:     chunk.Text,
+					IsStderr:  chunk.IsStderr,
+				}))
+			},
 		},
 	})
 	if err != nil {
@@ -801,23 +812,39 @@ func (s *Service) SendAgentMessageStream(ctx context.Context, req *connect.Reque
 	}))
 }
 
-func (s *Service) resolveSessionAgentProvider(ctx context.Context, session *Session, requested string) string {
+type agentExecutionConfig struct {
+	Provider          string
+	AgentDefinitionID string
+	Model             string
+}
+
+func (s *Service) resolveSessionAgentConfig(ctx context.Context, session *Session, requested string) agentExecutionConfig {
 	provider := normalizeAgentKind(requested)
+	config := agentExecutionConfig{Provider: provider}
 	if session == nil {
-		return provider
+		return config
 	}
 	agentID := sessionTagValue(session.Summary.Tags, agentSessionTagID)
-	if agentID == "" || !sessionHasAgentTag(session, agentID) {
-		return provider
+	if agentID == "" || !sessionHasAgentTag(session, agentID) || s.configDB == nil {
+		return config
 	}
 	agent, err := s.configDB.GetAgentDefinition(ctx, agentID)
 	if err != nil {
-		return provider
+		return config
 	}
-	if saved := normalizeAgentKind(agent.Provider); saved != "" {
-		return saved
+	return agentExecutionConfigFromDefinition(agent, provider)
+}
+
+func agentExecutionConfigFromDefinition(agent AgentDefinition, fallbackProvider string) agentExecutionConfig {
+	provider := normalizeAgentKind(agent.Provider)
+	if provider == "" {
+		provider = normalizeAgentKind(fallbackProvider)
 	}
-	return provider
+	return agentExecutionConfig{
+		Provider:          provider,
+		AgentDefinitionID: strings.TrimSpace(agent.ID),
+		Model:             strings.TrimSpace(agent.Model),
+	}
 }
 
 func sessionTagValue(tags []SessionTag, name string) string {
@@ -884,6 +911,8 @@ func normalizeAgentKind(agent string) string {
 		return "claude"
 	case "gemini", "gemini-cli", "gemini_cli":
 		return "gemini"
+	case "opencode", "open-code", "open_code":
+		return "opencode"
 	default:
 		return agent
 	}
@@ -1327,6 +1356,7 @@ func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent,
 	if session.Summary.VMStatus != VMStatusRunning {
 		return ExecResult{}, AgentRunResult{}, fmt.Errorf("session is not running")
 	}
+	appconfig.ApplyDefaultGuestPaths(e.config)
 	vmState, err := e.store.GetVMState(session.Summary.ID)
 	if err != nil {
 		return ExecResult{}, AgentRunResult{}, err
@@ -1350,7 +1380,7 @@ func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent,
 	if err != nil {
 		return ExecResult{}, AgentRunResult{}, err
 	}
-	spec := buildAgentExecSpec(e.config, session, agent, promptPath, schemaPath)
+	spec := buildAgentExecSpec(e.config, session, agent, model, promptPath, schemaPath)
 	managedEnv, err := ensureSessionLLMFacadeConfig(ctx, e.config, e.configDB, session, agent, model, llmFacadeTokenSourceAgent, runID)
 	if err != nil {
 		return ExecResult{}, AgentRunResult{}, err
@@ -1378,7 +1408,7 @@ func (e *Executor) executeAgentRun(ctx context.Context, session *Session, agent,
 	return sanitizeAgentExecResult(result), parsed, nil
 }
 
-func buildAgentExecSpec(config *appconfig.Config, session *Session, agent, promptPath, schemaPath string) ExecSpec {
+func buildAgentExecSpec(config *appconfig.Config, session *Session, agent, model, promptPath, schemaPath string) ExecSpec {
 	appconfig.ApplyDefaultGuestPaths(config)
 	agentHome := guestSessionHome(config)
 	env := buildSessionExecEnv(config, session, agentHome)
@@ -1389,6 +1419,9 @@ func buildAgentExecSpec(config *appconfig.Config, session *Session, agent, promp
 		" --state-root " + shellQuote(config.GuestStateRoot) +
 		" --workspace " + shellQuote(config.GuestWorkspacePath) +
 		" --home " + shellQuote(agentHome)
+	if strings.TrimSpace(model) != "" {
+		promptCommand += " --model " + shellQuote(strings.TrimSpace(model))
+	}
 	if strings.TrimSpace(schemaPath) != "" {
 		promptCommand += " --output-schema-file " + shellQuote(schemaPath)
 	}

--- a/pkg/driver/runtime_mount_manifest.go
+++ b/pkg/driver/runtime_mount_manifest.go
@@ -190,6 +190,7 @@ func runtimeMountSpecsForDocker(config *appconfig.Config, session *Session) []ru
 		{hostPath: filepath.Join(hostSessionDir(session), "logs"), guestPath: config.GuestLogRoot},
 		{hostPath: filepath.Join(home, ".codex"), guestPath: filepath.Join(config.GuestHomePath, ".codex")},
 		{hostPath: filepath.Join(home, ".claude"), guestPath: filepath.Join(config.GuestHomePath, ".claude")},
+		{hostPath: filepath.Join(home, ".opencode"), guestPath: filepath.Join(config.GuestHomePath, ".opencode")},
 		{hostPath: filepath.Join(home, ".claude.json"), guestPath: filepath.Join(config.GuestHomePath, ".claude.json"), isFile: true},
 		{hostPath: filepath.Join(home, ".gitconfig"), guestPath: filepath.Join(config.GuestHomePath, ".gitconfig"), isFile: true},
 		{hostPath: filepath.Join(home, ".gemini"), guestPath: filepath.Join(config.GuestHomePath, ".gemini")},

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -53,6 +53,7 @@ func TestPrepareRuntimeMountManifestForDockerIncludesRequiredMountsOnly(t *testi
 		"/data/logs":                filepath.Join(root, "logs"),
 		"/root/.codex":              filepath.Join(root, "home", ".codex"),
 		"/root/.claude":             filepath.Join(root, "home", ".claude"),
+		"/root/.opencode":           filepath.Join(root, "home", ".opencode"),
 		"/root/.claude.json":        filepath.Join(root, "home", ".claude.json"),
 		"/root/.gitconfig":          filepath.Join(root, "home", ".gitconfig"),
 		"/root/.gemini":             filepath.Join(root, "home", ".gemini"),
@@ -94,6 +95,7 @@ func TestPrepareRuntimeMountManifestIgnoresCustomGuestHomePath(t *testing.T) {
 	for _, guestPath := range []string{
 		"/root/.codex",
 		"/root/.claude",
+		"/root/.opencode",
 		"/root/.claude.json",
 		"/root/.gitconfig",
 		"/root/.gemini",

--- a/runtime/agent-compose-runtime-sdk/README.md
+++ b/runtime/agent-compose-runtime-sdk/README.md
@@ -175,7 +175,7 @@ Options:
 
 | Option | Description |
 | --- | --- |
-| `provider` | Agent provider. One of `codex`, `claude`, or `gemini`. Defaults to `codex`. |
+| `provider` | Agent provider. One of `codex`, `claude`, `gemini`, or `opencode`. Defaults to `codex`. |
 | `stateRoot` | Agent state root directory. Defaults to `runtime.paths.stateRoot`. |
 | `workspace` | Workspace path. Defaults to `runtime.paths.workspace`. |
 | `home` | Home directory. Defaults to `runtime.paths.home`. |

--- a/runtime/agent-compose-runtime-sdk/src/agent.ts
+++ b/runtime/agent-compose-runtime-sdk/src/agent.ts
@@ -18,7 +18,7 @@ const AGENT_RESULT_PREFIX = "__AGENT_RESULT__";
 export type RuntimeAgentOutputSchema = RuntimeOutputSchema;
 
 export interface RuntimeAgentOptions<S extends RuntimeAgentOutputSchema = RuntimeAgentOutputSchema> {
-  provider?: "codex" | "claude" | "gemini";
+  provider?: "codex" | "claude" | "gemini" | "opencode";
   stateRoot?: string;
   workspace?: string;
   home?: string;

--- a/runtime/javascript/src/cli.ts
+++ b/runtime/javascript/src/cli.ts
@@ -20,11 +20,12 @@ export function createProgram(options: { exitOverride?: boolean } = {}): Command
 
   program
     .command("prompt")
-    .requiredOption("--provider <provider>", "agent provider: codex, claude, or gemini")
+    .requiredOption("--provider <provider>", "agent provider: codex, claude, gemini, or opencode")
     .requiredOption("--message-file <path>", "prompt file path")
     .option("--state-root <path>", "agent-compose runtime state root")
     .option("--workspace <path>", "agent working directory")
     .option("--home <path>", "agent HOME directory")
+    .option("--model <model>", "agent model")
     .option("--output-schema-file <path>", "JSON schema file for structured output")
     .action(async (options: {
       provider: string;
@@ -32,6 +33,7 @@ export function createProgram(options: { exitOverride?: boolean } = {}): Command
       stateRoot?: string;
       workspace?: string;
       home?: string;
+      model?: string;
       outputSchemaFile?: string;
     }) => {
       const result = await runPromptCommand(options);

--- a/runtime/javascript/src/index.ts
+++ b/runtime/javascript/src/index.ts
@@ -7,6 +7,7 @@ export { runPromptCommand } from "./prompt.js";
 export { ClaudeRunner } from "./runners/claude.js";
 export { CodexRunner } from "./runners/codex.js";
 export { GeminiRunner } from "./runners/gemini.js";
+export { OpenCodeRunner } from "./runners/opencode.js";
 export { readStoredSession, sessionStatePath, writeStoredSession } from "./session-state.js";
 export { appendDelta, TranscriptWriter } from "./transcript.js";
 export type { AgentResult, Provider, RunnerOptions, StoredSession } from "./types.js";

--- a/runtime/javascript/src/prompt.ts
+++ b/runtime/javascript/src/prompt.ts
@@ -7,6 +7,7 @@ import { normalizeProvider } from "./provider.js";
 import { ClaudeRunner } from "./runners/claude.js";
 import { CodexRunner } from "./runners/codex.js";
 import { GeminiRunner } from "./runners/gemini.js";
+import { OpenCodeRunner } from "./runners/opencode.js";
 import { agentSystemPromptPath, buildSystemContext, readSystemPromptFile } from "./system-context.js";
 import type { AgentResult, RuntimeJsonSchema } from "./types.js";
 
@@ -16,6 +17,7 @@ export interface PromptCommandOptions {
   stateRoot?: string;
   workspace?: string;
   home?: string;
+  model?: string;
   outputSchemaFile?: string;
 }
 
@@ -40,6 +42,7 @@ export async function runPromptCommand(commandOptions: PromptCommandOptions): Pr
   const mpi = await readMpiContext(stateRoot);
   const options = {
     provider,
+    model: commandOptions.model,
     stateRoot,
     workspace,
     home,
@@ -52,6 +55,9 @@ export async function runPromptCommand(commandOptions: PromptCommandOptions): Pr
   }
   if (provider === "claude") {
     return await new ClaudeRunner(options).runPrompt(promptText);
+  }
+  if (provider === "opencode") {
+    return await new OpenCodeRunner(options).runPrompt(promptText);
   }
   return await new GeminiRunner(options).runPrompt(promptText);
 }

--- a/runtime/javascript/src/provider.ts
+++ b/runtime/javascript/src/provider.ts
@@ -16,6 +16,10 @@ export function normalizeProvider(raw: unknown): Provider {
     case "gemini-cli":
     case "gemini_cli":
       return "gemini";
+    case "opencode":
+    case "open-code":
+    case "open_code":
+      return "opencode";
     default:
       throw new Error(`unsupported provider ${JSON.stringify(raw)}; expected one of: codex, claude, gemini`);
   }

--- a/runtime/javascript/src/runners/opencode.ts
+++ b/runtime/javascript/src/runners/opencode.ts
@@ -35,6 +35,7 @@ export class OpenCodeRunner {
     return {
       ...process.env,
       OPENCODE_DISABLE_AUTOUPDATE: process.env.OPENCODE_DISABLE_AUTOUPDATE || "true",
+      OPENCODE_DISABLE_MODELS_FETCH: process.env.OPENCODE_DISABLE_MODELS_FETCH || "1",
     };
   }
 

--- a/runtime/javascript/src/runners/opencode.ts
+++ b/runtime/javascript/src/runners/opencode.ts
@@ -1,0 +1,160 @@
+import { spawn } from "node:child_process";
+import readline from "node:readline";
+import { readStoredSession, writeStoredSession } from "../session-state.js";
+import { extractText, jsonString } from "../text.js";
+import { TranscriptWriter } from "../transcript.js";
+import type { AgentResult, RunnerOptions, StoredSession } from "../types.js";
+
+export class OpenCodeRunner {
+  private readonly writer = new TranscriptWriter();
+
+  constructor(private readonly options: RunnerOptions) {}
+
+  buildArgs(promptText: string, stored: StoredSession | null): string[] {
+    const userPrompt = this.options.systemContext
+      ? `${this.options.systemContext}\n\n${promptText}`
+      : promptText;
+    const args = [
+      "run",
+      userPrompt,
+      "--format", "json",
+      "--dir", this.options.workspace,
+      "--dangerously-skip-permissions",
+    ];
+    const model = String(this.options.model || "").trim();
+    if (model) {
+      args.push("--model", model);
+    }
+    if (stored?.sessionId) {
+      args.push("--session", stored.sessionId);
+    }
+    return args;
+  }
+
+  environment(): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      OPENCODE_DISABLE_AUTOUPDATE: process.env.OPENCODE_DISABLE_AUTOUPDATE || "true",
+    };
+  }
+
+  handleEvent(event: Record<string, unknown>, result: AgentResult): void {
+    const sessionId = stringField(event, "sessionID", "sessionId", "session_id");
+    if (sessionId) {
+      result.sessionId = sessionId;
+    }
+
+    const eventType = String(event.type || event.event || "");
+    if (eventType === "error") {
+      const errorText = extractText(event.error) || extractText(event.message) || jsonString(event);
+      this.writer.line(errorText);
+      throw new Error(errorText);
+    }
+
+    if (eventType === "tool_use" || eventType === "tool") {
+      const tool = event.tool as Record<string, unknown> | undefined;
+      const toolName = stringField(event, "name", "toolName") || String(tool?.name || "tool");
+      this.writer.line(`\n[tool:${toolName}]`);
+      return;
+    }
+
+    if (eventType === "tool_result") {
+      const text = extractText(event.result) || extractText(event.content) || jsonString(event.result || event);
+      if (text.trim()) {
+        this.writer.line(text);
+      }
+      return;
+    }
+
+    const text = extractText(event.message) ||
+      extractText(event.content) ||
+      extractText(event.part) ||
+      extractText(event.text) ||
+      extractText(event.delta);
+    if (text) {
+      this.writer.write(text);
+    }
+
+    if (eventType === "result" || eventType === "complete" || eventType === "completed") {
+      const finalText = extractText(event.response) || extractText(event.result) || text;
+      if (finalText) {
+        result.finalText = finalText;
+      }
+      result.stopReason = stringField(event, "stopReason", "stop_reason", "finishReason", "finish_reason") || result.stopReason;
+    }
+  }
+
+  async runPrompt(promptText: string): Promise<AgentResult> {
+    if (this.options.outputSchema) {
+      throw new Error("structured JSON output is not supported by opencode runner");
+    }
+
+    const stored = await readStoredSession(this.options.stateRoot, "opencode");
+    const result: AgentResult = {
+      provider: "opencode",
+      sessionId: stored?.sessionId || "",
+      stopReason: "completed",
+      finalText: "",
+      transcript: "",
+      stderr: "",
+    };
+
+    const child = spawn("opencode", this.buildArgs(promptText, stored), {
+      cwd: this.options.workspace,
+      env: this.environment(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const stderrChunks: string[] = [];
+    child.stderr?.on("data", (chunk) => {
+      const text = String(chunk || "");
+      stderrChunks.push(text);
+      this.writer.write(text);
+    });
+
+    const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) {
+          continue;
+        }
+        let event: Record<string, unknown>;
+        try {
+          event = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          this.writer.line(line);
+          continue;
+        }
+        this.handleEvent(event, result);
+      }
+    } catch (error) {
+      child.kill("SIGTERM");
+      throw error;
+    }
+
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code) => resolve(code ?? 1));
+    });
+    if (exitCode !== 0) {
+      throw new Error(`opencode exited with code ${exitCode}: ${stderrChunks.join("")}`);
+    }
+
+    result.transcript = this.writer.transcript();
+    if (!result.finalText && result.transcript) {
+      result.finalText = result.transcript;
+    }
+    await writeStoredSession(this.options.stateRoot, "opencode", result.sessionId);
+    return result;
+  }
+}
+
+function stringField(record: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return "";
+}

--- a/runtime/javascript/src/types.ts
+++ b/runtime/javascript/src/types.ts
@@ -1,4 +1,4 @@
-export type Provider = "codex" | "claude" | "gemini";
+export type Provider = "codex" | "claude" | "gemini" | "opencode";
 export type RuntimeJsonSchema = Record<string, unknown>;
 
 export interface AgentResult {
@@ -12,6 +12,7 @@ export interface AgentResult {
 
 export interface RunnerOptions {
   provider: Provider;
+  model?: string;
   stateRoot: string;
   workspace: string;
   home: string;

--- a/runtime/javascript/test/cli.test.ts
+++ b/runtime/javascript/test/cli.test.ts
@@ -39,6 +39,8 @@ describe("commander CLI", () => {
         "/data/workspace",
         "--home",
         "/data/home",
+        "--model",
+        "anthropic/claude-sonnet-4-5",
         "--output-schema-file",
         "/tmp/schema.json",
       ]);
@@ -52,6 +54,7 @@ describe("commander CLI", () => {
       stateRoot: "/data/state",
       workspace: "/data/workspace",
       home: "/data/home",
+      model: "anthropic/claude-sonnet-4-5",
       outputSchemaFile: "/tmp/schema.json",
     });
     expect(stdio.stdout).toBe(`${RESULT_PREFIX}{"provider":"codex","sessionId":"s1","stopReason":"completed","finalText":"done","json":null,"transcript":"done","stderr":""}\n`);
@@ -173,9 +176,12 @@ describe("commander CLI", () => {
       const messageFile = path.join(root, "message.txt");
       const schemaFile = path.join(root, "schema.json");
       const stateRoot = path.join(root, "state");
+      const systemPromptPath = path.join(stateRoot, "agents", "system-prompts", "system-prompt.txt");
       await fs.mkdir(stateRoot, { recursive: true });
+      await fs.mkdir(path.dirname(systemPromptPath), { recursive: true });
       await fs.writeFile(messageFile, "hello", "utf8");
       await fs.writeFile(schemaFile, JSON.stringify({ type: "object", properties: { answer: { type: "string" } } }), "utf8");
+      await fs.writeFile(systemPromptPath, "system body", "utf8");
       const runPrompt = vi.fn().mockResolvedValue({
         provider: "gemini",
         sessionId: "",
@@ -194,6 +200,7 @@ describe("commander CLI", () => {
         const result = await runPromptCommand({
           provider: "gemini",
           messageFile,
+          model: "models/gemini-test",
           outputSchemaFile: schemaFile,
           stateRoot,
           home: path.join(root, "home"),
@@ -205,6 +212,8 @@ describe("commander CLI", () => {
           provider: "gemini",
           workspace: path.join(root, "workspace-from-env"),
           home: path.join(root, "home"),
+          model: "models/gemini-test",
+          systemContext: expect.stringContaining("system body"),
           runtimeRoot: path.join(root, "runtime"),
           outputSchema: { type: "object", properties: { answer: { type: "string" } } },
         }));

--- a/runtime/javascript/test/provider.test.ts
+++ b/runtime/javascript/test/provider.test.ts
@@ -9,6 +9,9 @@ describe("provider normalization", () => {
     ["claude_code", "claude"],
     ["gemini-cli", "gemini"],
     ["gemini_cli", "gemini"],
+    ["opencode", "opencode"],
+    ["open-code", "opencode"],
+    ["open_code", "opencode"],
   ])("maps %j to %s", (input, expected) => {
     expect(normalizeProvider(input)).toBe(expected);
   });

--- a/runtime/javascript/test/runners.test.ts
+++ b/runtime/javascript/test/runners.test.ts
@@ -331,6 +331,17 @@ describe("OpenCodeRunner", () => {
     });
   });
 
+  it("disables OpenCode model catalog fetch by default", async () => {
+    await withTempSession(async (root) => {
+      const runner = new OpenCodeRunner(runnerOptions(root, "", "opencode"));
+
+      expect(runner.environment().OPENCODE_DISABLE_MODELS_FETCH).toBe("1");
+
+      vi.stubEnv("OPENCODE_DISABLE_MODELS_FETCH", "0");
+      expect(runner.environment().OPENCODE_DISABLE_MODELS_FETCH).toBe("0");
+    });
+  });
+
   it("translates OpenCode JSON events into transcript and final text", async () => {
     await withTempSession(async (root) => {
       const runner = new OpenCodeRunner(runnerOptions(root, "", "opencode"));

--- a/runtime/javascript/test/runners.test.ts
+++ b/runtime/javascript/test/runners.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClaudeRunner } from "../src/runners/claude.js";
 import { CodexRunner } from "../src/runners/codex.js";
 import { GeminiRunner } from "../src/runners/gemini.js";
+import { OpenCodeRunner } from "../src/runners/opencode.js";
 import { captureStdio, runnerOptions, withTempSession } from "./helpers.js";
 
 afterEach(() => {
@@ -294,6 +295,90 @@ describe("GeminiRunner", () => {
     await withTempSession(async (root) => {
       const runner = new GeminiRunner(runnerOptions(root, "", "gemini"));
       expect(runner).toBeInstanceOf(GeminiRunner);
+    });
+  });
+});
+
+describe("OpenCodeRunner", () => {
+  it("builds non-interactive args for fresh and resumed sessions", async () => {
+    await withTempSession(async (root) => {
+      const runner = new OpenCodeRunner({
+        ...runnerOptions(root, "be concise", "opencode"),
+        model: "anthropic/claude-sonnet-4-5",
+      });
+
+      expect(runner.buildArgs("review", null)).toEqual([
+        "run",
+        "be concise\n\nreview",
+        "--format",
+        "json",
+        "--dir",
+        `${root}/workspace`,
+        "--dangerously-skip-permissions",
+        "--model",
+        "anthropic/claude-sonnet-4-5",
+      ]);
+      expect(runner.buildArgs("review", { provider: "opencode", sessionId: "ses_1" })).toContain("ses_1");
+    });
+  });
+
+  it("keeps explicit OpenCode auto-update environment overrides", async () => {
+    await withTempSession(async (root) => {
+      vi.stubEnv("OPENCODE_DISABLE_AUTOUPDATE", "false");
+      const runner = new OpenCodeRunner(runnerOptions(root, "", "opencode"));
+
+      expect(runner.environment().OPENCODE_DISABLE_AUTOUPDATE).toBe("false");
+    });
+  });
+
+  it("translates OpenCode JSON events into transcript and final text", async () => {
+    await withTempSession(async (root) => {
+      const runner = new OpenCodeRunner(runnerOptions(root, "", "opencode"));
+      const result = {
+        provider: "opencode" as const,
+        sessionId: "",
+        stopReason: "completed",
+        finalText: "",
+        transcript: "",
+        stderr: "",
+      };
+      const stdio = captureStdio();
+      try {
+        runner.handleEvent({ type: "message", sessionId: "session-1", message: { content: "hello" } }, result);
+        runner.handleEvent({ type: "text", part: { type: "text", text: " from part" } }, result);
+        runner.handleEvent({ type: "tool_use", name: "bash" }, result);
+        runner.handleEvent({ type: "tool_result", result: { text: "tool output" } }, result);
+        runner.handleEvent({ type: "result", response: "done", stopReason: "completed" }, result);
+      } finally {
+        stdio.restore();
+      }
+
+      expect(result.sessionId).toBe("session-1");
+      expect(result.finalText).toBe("done");
+      expect(stdio.stderr).toContain("hello");
+      expect(stdio.stderr).toContain(" from part");
+      expect(stdio.stderr).toContain("[tool:bash]");
+      expect(stdio.stderr).toContain("tool output");
+    });
+  });
+
+  it("throws OpenCode event errors and rejects structured output", async () => {
+    await withTempSession(async (root) => {
+      const runner = new OpenCodeRunner(runnerOptions(root, "", "opencode"));
+      expect(() => runner.handleEvent({ type: "error", error: { text: "bad" } }, {
+        provider: "opencode",
+        sessionId: "",
+        stopReason: "completed",
+        finalText: "",
+        transcript: "",
+        stderr: "",
+      })).toThrow("bad");
+
+      const schemaRunner = new OpenCodeRunner({
+        ...runnerOptions(root, "", "opencode"),
+        outputSchema: { type: "object" },
+      });
+      await expect(schemaRunner.runPrompt("hello")).rejects.toThrow("structured JSON output is not supported by opencode runner");
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `opencode` provider normalization, validation, UI selection, SDK/docs coverage
- add OpenCode CLI runner in `agent-compose-runtime-js` with model/system prompt plumbing and session state reuse
- install and link `opencode-ai` in the guest image

## Tests
- `npm run typecheck && npm run test:unit` in `runtime/javascript`
- `task test`
- `GOFLAGS=-buildvcs=false task lint`
- `GOFLAGS=-buildvcs=false task build`
- `git diff --check`

Note: plain Go build/lint VCS stamping fails in this `/tmp` worktree with `error obtaining VCS status`; the same gates pass with `GOFLAGS=-buildvcs=false`.
