### PR TITLE
fix(microsandbox): launch jupyter from / instead of /workspace

### DIFF
--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -673,7 +673,10 @@ func microsandboxPullPolicyForImageRef(imageRef string) microsandbox.PullPolicy 
 
 func (r *microsandboxRuntime) launchJupyter(ctx context.Context, sandbox *microsandbox.Sandbox, proxyState ProxyState) error {
 	command := jupyterLaunchCommand(r.config, proxyState, true)
-	handle, err := sandbox.ExecStream(ctx, "/bin/bash", []string{"-lc", command}, r.execOptions(ctx, ExecSpec{Cwd: r.config.GuestWorkspacePath})...)
+	// Run from "/" (not GuestWorkspacePath): /workspace is created by the bootstrap
+	// inside command itself, so cwd=/workspace would fail chdir before the script runs.
+	// Matches the boxlite driver; jupyter still serves /workspace via --ServerApp.root_dir.
+	handle, err := sandbox.ExecStream(ctx, "/bin/bash", []string{"-lc", command}, r.execOptions(ctx, ExecSpec{Cwd: "/"})...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

修复 microsandbox driver 起 guest 时 jupyter exec 的工作目录问题。

microsandbox driver 用 `cwd=/workspace` 发 jupyter 这条 exec，但在 directory-only 挂载布局下 `/workspace` 此时还不存在——它由这条 exec 自己脚本内的 symlink bootstrap（`ln -s /data/workspace /workspace`）创建。agentd 在跑脚本之前先 `chdir` 进 exec 的 cwd，所以 `chdir(/workspace)` 因目录不存在失败，被误报成 `spawn "/bin/bash": No such file or directory`，guest 起不来。

改为从 `/`（始终存在）启动，对齐 boxlite driver；jupyter 仍通过 `--ServerApp.root_dir=/workspace` 服务 /workspace（与进程 cwd 无关）。

## Testing

在装有 microsandbox 的环境实测：
- 修复前：guest 启动报 `spawn "/bin/bash": No such file or directory`。
- 修复后：jupyter 正常启动（`Serving notebooks from local directory: /workspace`），guest 可用。

## Checklist

- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
- [ ] Documentation updated when behavior or configuration changed.
- [ ] Tests added or updated for user-visible behavior.