### PR TITLE
Fix microsandbox dev export build target

### DIFF
--- a/scripts/export-microsandbox-dev-artifact.sh
+++ b/scripts/export-microsandbox-dev-artifact.sh
@@ -33,7 +33,7 @@ trap cleanup EXIT
 docker build \
   --iidfile "$iidfile" \
   -f "$DOCKERFILE" \
-  --target microsandbox-build \
+  --target microsandbox-fetch \
   --build-arg "HTTP_PROXY=$HTTP_PROXY_VALUE" \
   --build-arg "HTTPS_PROXY=$HTTPS_PROXY_VALUE" \
   --build-arg "ALL_PROXY=$ALL_PROXY_VALUE" \


### PR DESCRIPTION
## Summary
- fix the microsandbox dev artifact export script to target the existing `microsandbox-fetch` stage
- align the helper script with the current multi-stage Dockerfile

## Verification
- verified the script now targets `microsandbox-fetch` in the current checkout
- ran `bash -n scripts/export-microsandbox-dev-artifact.sh`
- started `./scripts/export-microsandbox-dev-artifact.sh /tmp/agent-compose-microsandbox-check` and confirmed it enters the `microsandbox-fetch` build path instead of failing with a missing target stage error