### PR TITLE
fix: require runtime provider value

### DIFF
--- a/runtime/javascript/src/provider.ts
+++ b/runtime/javascript/src/provider.ts
@@ -1,9 +1,11 @@
 import type { Provider } from "./types.js";
 
 export function normalizeProvider(raw: unknown): Provider {
-  const provider = String(raw || "").trim().toLowerCase();
+  const provider = String(raw ?? "").trim().toLowerCase();
+  if (!provider) {
+    throw new Error("provider is required; expected one of: codex, claude, gemini");
+  }
   switch (provider) {
-    case "":
     case "codex":
       return "codex";
     case "claude":
@@ -15,6 +17,6 @@ export function normalizeProvider(raw: unknown): Provider {
     case "gemini_cli":
       return "gemini";
     default:
-      throw new Error(`unsupported provider ${JSON.stringify(raw)}`);
+      throw new Error(`unsupported provider ${JSON.stringify(raw)}; expected one of: codex, claude, gemini`);
   }
 }

--- a/runtime/javascript/test/cli.test.ts
+++ b/runtime/javascript/test/cli.test.ts
@@ -69,6 +69,26 @@ describe("commander CLI", () => {
     }
   });
 
+  it("rejects an empty prompt provider", async () => {
+    const runPrompt = vi.spyOn(promptModule, "runPromptCommand");
+    const program = createProgram({ exitOverride: true });
+    const stdio = captureStdio();
+    try {
+      await expect(program.parseAsync([
+        "node",
+        "cli",
+        "prompt",
+        "--provider",
+        "",
+        "--message-file",
+        "/tmp/message.txt",
+      ])).rejects.toThrow(/provider is required/);
+    } finally {
+      stdio.restore();
+    }
+    expect(runPrompt).toHaveBeenCalledTimes(1);
+  });
+
   it("prints the prefixed result for exec command", async () => {
     const runExec = vi.spyOn(commandModule, "runExecCommand").mockResolvedValue({
       stdout: "ok\n",

--- a/runtime/javascript/test/provider.test.ts
+++ b/runtime/javascript/test/provider.test.ts
@@ -3,7 +3,6 @@ import { normalizeProvider } from "../src/provider.js";
 
 describe("provider normalization", () => {
   it.each([
-    ["", "codex"],
     ["codex", "codex"],
     ["CLAUDE", "claude"],
     ["claude-code", "claude"],
@@ -15,7 +14,16 @@ describe("provider normalization", () => {
   });
 
   it("rejects unsupported providers", () => {
-    expect(() => normalizeProvider("qwen")).toThrow(/unsupported provider/);
+    expect(() => normalizeProvider("qwen")).toThrow(/unsupported provider "qwen"; expected one of: codex, claude, gemini/);
+  });
+
+  it.each([
+    "",
+    "   ",
+    undefined,
+    null,
+  ])("rejects missing provider %j", (input) => {
+    expect(() => normalizeProvider(input)).toThrow(/provider is required/);
   });
 
   it("trims provider names before normalization", () => {


### PR DESCRIPTION
## Summary
- reject missing runtime provider values instead of silently defaulting to codex
- keep provider alias normalization for codex, claude, and gemini
- cover empty provider handling in provider and CLI tests

## Verification
- npm ci
- npm run test:unit -- test/provider.test.ts test/cli.test.ts
- npm run typecheck
- npm run test:unit
- npm run build

Fixes #48
