### PR TITLE
fix: preserve Windows Docker host session root

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -392,7 +392,10 @@ func NewConfig(di do.Injector) (*Config, error) {
 	boxliteHome = mustAbs(boxliteHome)
 	boxliteRuntimeDir = mustAbs(boxliteRuntimeDir)
 	dockerHome = mustAbs(dockerHome)
-	dockerHostSessionRoot = mustAbs(dockerHostSessionRoot)
+	dockerHostSessionRoot, err = normalizeDockerHostSessionRoot(dockerHostSessionRoot)
+	if err != nil {
+		return nil, err
+	}
 	microsandboxHome = mustAbs(microsandboxHome)
 	microsandboxMSBPath = mustAbs(microsandboxMSBPath)
 	microsandboxLibPath = mustAbs(microsandboxLibPath)
@@ -408,9 +411,6 @@ func NewConfig(di do.Injector) (*Config, error) {
 		"DOCKER_HOME":       dockerHome,
 		"IMAGE_CACHE_ROOT":  imageCacheRoot,
 		"MICROSANDBOX_HOME": microsandboxHome,
-	}
-	if dockerHostSessionRoot != "" {
-		dirs["DOCKER_HOST_SESSION_ROOT"] = dockerHostSessionRoot
 	}
 	for name, dir := range dirs {
 		if err := ensureDirExists(dir); err != nil {
@@ -621,6 +621,45 @@ func mustAbs(path string) string {
 		return path
 	}
 	return resolved
+}
+
+func normalizeDockerHostSessionRoot(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", nil
+	}
+	if isWindowsHostPath(trimmed) {
+		if hasParentPathSegment(trimmed) {
+			return "", fmt.Errorf("invalid DOCKER_HOST_SESSION_ROOT %q: parent path segments are not allowed", path)
+		}
+		return trimmed, nil
+	}
+	return mustAbs(trimmed), nil
+}
+
+func isWindowsHostPath(path string) bool {
+	if strings.HasPrefix(path, `\\`) {
+		return true
+	}
+	if len(path) < 3 {
+		return false
+	}
+	drive := path[0]
+	if (drive < 'A' || drive > 'Z') && (drive < 'a' || drive > 'z') {
+		return false
+	}
+	return path[1] == ':' && (path[2] == '\\' || path[2] == '/')
+}
+
+func hasParentPathSegment(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func ensureDirExists(path string) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -412,13 +412,12 @@ func testNewConfigEnsuresHostDirectoriesExist(t *testing.T) {
 	}
 
 	for name, dir := range map[string]string{
-		"DataRoot":              config.DataRoot,
-		"SessionRoot":           config.SessionRoot,
-		"BoxliteHome":           config.BoxliteHome,
-		"DockerHome":            config.DockerHome,
-		"DockerHostSessionRoot": config.DockerHostSessionRoot,
-		"ImageCacheRoot":        config.ImageCacheRoot,
-		"MicrosandboxHome":      config.MicrosandboxHome,
+		"DataRoot":         config.DataRoot,
+		"SessionRoot":      config.SessionRoot,
+		"BoxliteHome":      config.BoxliteHome,
+		"DockerHome":       config.DockerHome,
+		"ImageCacheRoot":   config.ImageCacheRoot,
+		"MicrosandboxHome": config.MicrosandboxHome,
 	} {
 		info, err := os.Stat(dir)
 		if err != nil {
@@ -427,6 +426,60 @@ func testNewConfigEnsuresHostDirectoriesExist(t *testing.T) {
 		if !info.IsDir() {
 			t.Fatalf("%s path %s is not a directory", name, dir)
 		}
+	}
+	if config.DockerHostSessionRoot != dockerHostSessionRoot {
+		t.Fatalf("DockerHostSessionRoot = %q, want %q", config.DockerHostSessionRoot, dockerHostSessionRoot)
+	}
+}
+
+func TestNewConfigPreservesWindowsDockerHostSessionRoot(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DATA_ROOT", filepath.Join(root, "data"))
+	t.Setenv("DOCKER_HOST_SESSION_ROOT", `E:/program/agent-compose-main/data/agent-compose/sessions`)
+	t.Setenv("HTTP_ROOT", filepath.Join(root, "dist"))
+
+	di := do.New()
+	do.ProvideValue(di, slog.Default())
+	config, err := NewConfig(di)
+	if err != nil {
+		t.Fatalf("NewConfig returned error: %v", err)
+	}
+
+	want := `E:/program/agent-compose-main/data/agent-compose/sessions`
+	if config.DockerHostSessionRoot != want {
+		t.Fatalf("DockerHostSessionRoot = %q, want %q", config.DockerHostSessionRoot, want)
+	}
+}
+
+func TestNewConfigPreservesUNCDockerHostSessionRoot(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DATA_ROOT", filepath.Join(root, "data"))
+	t.Setenv("DOCKER_HOST_SESSION_ROOT", `\\server\share\agent-compose\sessions`)
+	t.Setenv("HTTP_ROOT", filepath.Join(root, "dist"))
+
+	di := do.New()
+	do.ProvideValue(di, slog.Default())
+	config, err := NewConfig(di)
+	if err != nil {
+		t.Fatalf("NewConfig returned error: %v", err)
+	}
+
+	want := `\\server\share\agent-compose\sessions`
+	if config.DockerHostSessionRoot != want {
+		t.Fatalf("DockerHostSessionRoot = %q, want %q", config.DockerHostSessionRoot, want)
+	}
+}
+
+func TestNewConfigRejectsWindowsDockerHostSessionRootParentSegment(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DATA_ROOT", filepath.Join(root, "data"))
+	t.Setenv("DOCKER_HOST_SESSION_ROOT", `E:\program\..\agent-compose\sessions`)
+	t.Setenv("HTTP_ROOT", filepath.Join(root, "dist"))
+
+	di := do.New()
+	do.ProvideValue(di, slog.Default())
+	if _, err := NewConfig(di); err == nil || !strings.Contains(err.Error(), "DOCKER_HOST_SESSION_ROOT") {
+		t.Fatalf("NewConfig error = %v, want DOCKER_HOST_SESSION_ROOT validation error", err)
 	}
 }
 

--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -444,7 +444,36 @@ func rebasePathUnderRoot(path, oldRoot, newRoot string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(newRoot, relativeDir), nil
+	return joinDockerHostPath(newRoot, relativeDir), nil
+}
+
+func joinDockerHostPath(root, relativePath string) string {
+	root = strings.TrimSpace(root)
+	relativePath = filepath.Clean(strings.TrimSpace(relativePath))
+	if relativePath == "." || relativePath == "" {
+		return root
+	}
+	if isWindowsHostPath(root) && strings.Contains(root, "\\") {
+		return strings.TrimRight(root, `\/`) + `\` + strings.ReplaceAll(relativePath, "/", `\`)
+	}
+	if isWindowsHostPath(root) || strings.Contains(root, "/") {
+		return strings.TrimRight(root, "/") + "/" + filepath.ToSlash(relativePath)
+	}
+	return filepath.Join(root, relativePath)
+}
+
+func isWindowsHostPath(path string) bool {
+	if strings.HasPrefix(path, `\\`) {
+		return true
+	}
+	if len(path) < 3 {
+		return false
+	}
+	drive := path[0]
+	if (drive < 'A' || drive > 'Z') && (drive < 'a' || drive > 'z') {
+		return false
+	}
+	return path[1] == ':' && (path[2] == '\\' || path[2] == '/')
 }
 
 func relativePathUnderRoot(path, root string) (string, error) {

--- a/pkg/driver/docker_runtime_test.go
+++ b/pkg/driver/docker_runtime_test.go
@@ -100,6 +100,50 @@ func TestRebasePathUnderRoot(t *testing.T) {
 	}
 }
 
+func TestRebasePathUnderRootPreservesWindowsHostRoot(t *testing.T) {
+	got, err := rebasePathUnderRoot("/data/sessions/session-1/workspace", "/data/sessions", `E:\program\agent-compose-main\data\agent-compose\sessions`)
+	if err != nil {
+		t.Fatalf("rebasePathUnderRoot returned error: %v", err)
+	}
+	want := `E:\program\agent-compose-main\data\agent-compose\sessions\session-1\workspace`
+	if got != want {
+		t.Fatalf("rebasePathUnderRoot returned %q, want %q", got, want)
+	}
+}
+
+func TestRebasePathUnderRootPreservesWindowsHostRootWithSlashes(t *testing.T) {
+	got, err := rebasePathUnderRoot("/data/sessions/session-1/workspace", "/data/sessions", "E:/program/agent-compose-main/data/agent-compose/sessions")
+	if err != nil {
+		t.Fatalf("rebasePathUnderRoot returned error: %v", err)
+	}
+	want := "E:/program/agent-compose-main/data/agent-compose/sessions/session-1/workspace"
+	if got != want {
+		t.Fatalf("rebasePathUnderRoot returned %q, want %q", got, want)
+	}
+}
+
+func TestRebasePathUnderRootPreservesWindowsUNCHostRoot(t *testing.T) {
+	got, err := rebasePathUnderRoot("/data/sessions/session-1/workspace", "/data/sessions", `\\server\share\agent-compose\sessions`)
+	if err != nil {
+		t.Fatalf("rebasePathUnderRoot returned error: %v", err)
+	}
+	want := `\\server\share\agent-compose\sessions\session-1\workspace`
+	if got != want {
+		t.Fatalf("rebasePathUnderRoot returned %q, want %q", got, want)
+	}
+}
+
+func TestRebasePathUnderRootDoesNotTreatLinuxBackslashAsWindowsRoot(t *testing.T) {
+	got, err := rebasePathUnderRoot("/data/sessions/session-1/workspace", "/data/sessions", `/srv/agent-compose\weird/sessions`)
+	if err != nil {
+		t.Fatalf("rebasePathUnderRoot returned error: %v", err)
+	}
+	want := filepath.Join(`/srv/agent-compose\weird/sessions`, "session-1", "workspace")
+	if got != want {
+		t.Fatalf("rebasePathUnderRoot returned %q, want %q", got, want)
+	}
+}
+
 func TestDockerRuntimeMountsConsumeManifestAndRebaseEachSource(t *testing.T) {
 	root := t.TempDir()
 	config := &appconfig.Config{


### PR DESCRIPTION
## Summary
- Preserve Windows-style and UNC `DOCKER_HOST_SESSION_ROOT` values instead of converting them through the Linux container filesystem.
- Stop creating `DOCKER_HOST_SESSION_ROOT` as a daemon-local directory because it represents the Docker daemon host path.
- Reject Windows host roots with `..` path segments to avoid ambiguous host-path rebasing.
- Preserve Windows path separators only for explicit Windows host roots when rebasing Docker bind mount sources.

Fixes #34

## Tests
- `go test ./pkg/config ./pkg/driver`