### PR TITLE
fix: tighten compose authentication defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ service for this layout.
 For a deployment that uses published container images:
 
 ```bash
+export AUTH_PASSWORD="$(openssl rand -base64 24)"
+export AUTH_SECRET="$(openssl rand -hex 32)"
 docker compose -f docker-compose.deploy.yml pull
 docker compose -f docker-compose.deploy.yml up -d
 ```

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -14,8 +14,6 @@ AGENT_COMPOSE_HTTP_PORT=80
 # On first run `install.sh` generates a random AUTH_PASSWORD and AUTH_SECRET if
 # these are empty, writes them here, and prints the credentials to the terminal.
 # AUTH_SECRET must be a stable, high-entropy value so sessions survive restarts.
-# To run unauthenticated (loopback / trusted networks only) pass
-# `install.sh --no-auth`, which leaves AUTH_PASSWORD empty.
 # ---------------------------------------------------------------------------
 AUTH_USERNAME=admin
 AUTH_PASSWORD=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,7 +60,6 @@ On first run the installer generates an admin password and prints it once:
 ./install.sh --version v1.2.3         # specific release (remote mode)
 ./install.sh --image-prefix registry.example.com/agent-compose   # mirror / private registry
 ./install.sh --upgrade                # update an existing install to this release
-./install.sh --no-auth                # run unauthenticated (trusted networks only)
 ./install.sh --no-start               # write files but don't pull images or start
 ```
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -21,7 +21,6 @@ VERSION="latest"
 IMAGE_PREFIX=""
 PORT=""
 NO_START=0
-NO_AUTH=0
 UPGRADE=0
 
 log()  { printf '\033[0;36m==>\033[0m %s\n' "$*"; }
@@ -42,7 +41,6 @@ Options:
   --image-prefix <ref>   Pull images from this prefix (mirror / private registry)
                          instead of the default registry
   --upgrade              Update existing image refs to this installer version
-  --no-auth              Do not generate a password; run unauthenticated
   --no-start             Lay down files but do not pull images or start
   -h, --help             Show this help
 
@@ -62,7 +60,6 @@ while [ $# -gt 0 ]; do
     --version)      VERSION="${2:?--version needs a value}"; shift 2 ;;
     --image-prefix) IMAGE_PREFIX="${2:?--image-prefix needs a value}"; shift 2 ;;
     --upgrade)      UPGRADE=1; shift ;;
-    --no-auth)      NO_AUTH=1; shift ;;
     --no-start)     NO_START=1; shift ;;
     -h|--help)      usage; exit 0 ;;
     *)              die "unknown option: $1 (try --help)" ;;
@@ -226,13 +223,8 @@ if [ ! -f "$ENV_FILE" ]; then
 
   set_env "$ENV_FILE" AUTH_SECRET "$(gen_hex 32)"
 
-  if [ "$NO_AUTH" -eq 1 ]; then
-    set_env "$ENV_FILE" AUTH_PASSWORD ""
-    warn "running without authentication (--no-auth); bind to loopback / trusted networks only"
-  else
-    GENERATED_PASSWORD="$(gen_password)"
-    set_env "$ENV_FILE" AUTH_PASSWORD "$GENERATED_PASSWORD"
-  fi
+  GENERATED_PASSWORD="$(gen_password)"
+  set_env "$ENV_FILE" AUTH_PASSWORD "$GENERATED_PASSWORD"
 
   apply_image_refs "$ENV_FILE" overwrite
   [ -n "$PORT" ] && set_env "$ENV_FILE" AGENT_COMPOSE_HTTP_PORT "$PORT"
@@ -242,10 +234,7 @@ else
     set_env "$ENV_FILE" AUTH_SECRET "$(gen_hex 32)"
     log "Generated missing AUTH_SECRET in $ENV_FILE"
   fi
-  if [ "$NO_AUTH" -eq 1 ]; then
-    set_env "$ENV_FILE" AUTH_PASSWORD ""
-    warn "running without authentication (--no-auth); bind to loopback / trusted networks only"
-  elif [ -z "$(get_env "$ENV_FILE" AUTH_PASSWORD)" ]; then
+  if [ -z "$(get_env "$ENV_FILE" AUTH_PASSWORD)" ]; then
     GENERATED_PASSWORD="$(gen_password)"
     set_env "$ENV_FILE" AUTH_PASSWORD "$GENERATED_PASSWORD"
     log "Generated missing AUTH_PASSWORD in $ENV_FILE"
@@ -283,8 +272,6 @@ if [ -n "$GENERATED_PASSWORD" ]; then
   printf '    Username: %s\n' "$USERNAME"
   printf '    Password: \033[1m%s\033[0m\n' "$GENERATED_PASSWORD"
   printf '  Stored in %s (key AUTH_PASSWORD).\n' "$ENV_FILE"
-elif [ "$NO_AUTH" -eq 1 ]; then
-  printf '\n  Authentication is DISABLED. Restrict network access.\n'
 else
   printf '\n  Credentials unchanged; see AUTH_PASSWORD in %s.\n' "$ENV_FILE"
 fi

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -12,8 +12,8 @@ services:
       DOCKER_HOST_SESSION_ROOT: ${DOCKER_HOST_SESSION_ROOT:-$PWD/data/agent-compose/sessions}
       HTTP_LISTEN: 0.0.0.0:7410
       AUTH_USERNAME: ${AUTH_USERNAME:-}
-      AUTH_PASSWORD: ${AUTH_PASSWORD:-}
-      AUTH_SECRET: ${AUTH_SECRET:-}
+      AUTH_PASSWORD: ${AUTH_PASSWORD:?AUTH_PASSWORD is required for deployment}
+      AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET is required for deployment}
       AUTH_SESSION_TTL: ${AUTH_SESSION_TTL:-24h}
       RUNTIME_DRIVER: ${RUNTIME_DRIVER:-docker}
       DEFAULT_IMAGE: ${DEFAULT_IMAGE:-ghcr.io/chaitin/agent-compose-guest:latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     devices:
       - /dev/kvm:/dev/kvm
     ports:
-      - "7410:7410"
+      - "127.0.0.1:7410:7410"
     environment:
       DATA_ROOT: /data
       SESSION_ROOT: /data/sessions


### PR DESCRIPTION
## Summary
- Bind the local development daemon port to host loopback only.
- Require `AUTH_PASSWORD` and `AUTH_SECRET` when rendering the deployment compose file.
- Remove the installer `--no-auth` path so installer behavior matches the required deployment auth defaults.
- Document auth generation for manual deployment compose usage.

Fixes #29

## Tests
- `bash -n deploy/install.sh`
- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose.deploy.yml config` fails without auth variables as expected
- `AUTH_PASSWORD=test-password AUTH_SECRET=test-secret docker compose -f docker-compose.deploy.yml config`