### PR TITLE
fix: align OctoBus instance routing

### DIFF
--- a/docs/design/octobus_integration.md
+++ b/docs/design/octobus_integration.md
@@ -153,12 +153,12 @@ uses `?format=md&grpc=true` to render capability instructions into the guest
 
 OctoBus catalog structure: `?all=true` returns three parallel arrays: `grpc`,
 `mcp`, and `connect_rpc`; each method appears once in each array. gRPC entries
-include a complete metadata triple: `x-octobus-capset`,
-`x-octobus-service`, and `x-octobus-instance`. agent-compose merges entries by
-join key `(service_id, instance_id, method_full_name)` into
-`CapabilityMethod`, using `endpoints` to represent gRPC / MCP / Connect entry
-types. `endpoints` are for UI display only and do not include the OctoBus
-address.
+include routing metadata for `x-octobus-capset` and `x-octobus-instance`.
+`service_id` remains a catalog/UI field, but it is not part of the current
+OctoBus gRPC routing metadata. agent-compose merges entries by join key
+`(service_id, instance_id, method_full_name)` into `CapabilityMethod`, using
+`endpoints` to represent gRPC / MCP / Connect entry types. `endpoints` are for
+UI display only and do not include the OctoBus address.
 
 ## Data-Plane Forwarding: gRPC Only
 
@@ -168,30 +168,27 @@ injected capability guide markdown:
 
 ```text
 x-capability-session-token: <CAP_TOKEN>
-x-octobus-service: <service_id>     # provided by guest
 x-octobus-instance: <instance_id>   # provided by guest
 ```
 
 Boundary: **capset is the session-level isolation boundary enforced by
-capproxy; service / instance is routing inside the capset and is selected by the
-guest.** capproxy handles each stream:
+capproxy; instance is routing inside the capset and is selected by the guest.**
+OctoBus instance ids are globally unique and already identify the service.
+capproxy handles each stream:
 
 ```text
 1. Look up in-memory index by token -> (session, allowed_capsets)
 2. Validate guest-provided x-octobus-capset is in the session's allowed_capsets
 3. Reflection methods (grpc.reflection.*): require only x-octobus-capset and pass through
 4. Business methods:
-     - guest already provides x-octobus-service / x-octobus-instance -> pass both through
-     - guest does not provide them -> look up catalog by (capset, method_full_name):
-       unique match -> fill automatically; zero matches -> NotFound; multiple matches -> FailedPrecondition
+     - require x-octobus-instance from the guest
      - inject OctoBus token read from ConfigStore
      - forward to OctoBus daemon
 ```
 
-OctoBus business methods strictly require all three metadata values:
-`x-octobus-capset` / `x-octobus-service` / `x-octobus-instance`
-(`findGRPCExposedMethod`). capset is enforced by capproxy, while service /
-instance are provided by the guest or filled by capproxy.
+OctoBus business methods require `x-octobus-capset` and `x-octobus-instance`
+(`findGRPCExposedMethod`). capset is enforced by capproxy, while instance is
+provided by the guest from the injected capability guide.
 
 Implementation notes:
 
@@ -201,16 +198,15 @@ Implementation notes:
   `token -> (session_id, capset_ids)`: rebuilt from existing sessions at
   startup, incrementally maintained on session create/stop.
 - capproxy validates `x-octobus-capset` belongs to the session binding set,
-  injects OctoBus token, and passes through guest `x-octobus-service` /
-  `x-octobus-instance`.
-- Normalized catalog used for filling missing routing metadata is cached by
-  capset with TTL; after expiry, the next resolution pulls again.
+  requires guest `x-octobus-instance` for business calls, and injects the
+  OctoBus token.
 - OctoBus addr / token are read from `ConfigStore` during forwarding.
 - Auth and isolation: capset set is bound to the session; guest can choose only
-  within the bound set. service / instance is routing inside a capset and may be
-  specified by the guest. `CAP_TOKEN` is an agent-compose-issued session
-  credential used only to resolve session -> capset binding. It cannot access
-  OctoBus. OctoBus token stays server-side and does not enter the guest.
+  within the bound set. instance is routing inside a capset and must be
+  specified by the guest for business calls. `CAP_TOKEN` is an
+  agent-compose-issued session credential used only to resolve session ->
+  capset binding. It cannot access OctoBus. OctoBus token stays server-side and
+  does not enter the guest.
 
 ## Session / Loader Injection
 
@@ -255,10 +251,10 @@ guide markdown, then write it to the **session MPI catalog**
 (preset `claude_code` + `append`). Therefore, once a session is created, the
 agent knows available capabilities as soon as it starts without having to cat
 the file itself. Rendered content includes each gRPC method, its `x-octobus-*`
-metadata (capset / service / instance), and guidance to use server reflection to
-obtain descriptors. The guest uses this to include `x-octobus-capset`,
-`x-octobus-service`, and `x-octobus-instance` when calling. It does not include
-OctoBus address or token and uses only the `grpc` section. **If OctoBus is
+metadata (capset / instance), and guidance to use server reflection to obtain
+descriptors. The guest uses this to include `x-octobus-capset` and
+`x-octobus-instance` when calling. It does not include OctoBus address or token
+and uses only the `grpc` section. **If OctoBus is
 unreachable or rendering fails, record an event and continue; session/loader
 starts normally.**
 
@@ -319,8 +315,8 @@ Session creation and loader:
 | Control-plane OctoBus returns non-2xx | Return Connect error with HTTP status |
 | Control-plane `GetCapabilityCatalog` capset not found | not found / invalid argument |
 | Injection-stage OctoBus unreachable / markdown render failure | **Does not block**: record session event + log; session/loader is still created and runs best-effort |
-| Data-plane method not in capset, when guest did not specify instance and fill lookup misses | gRPC `NotFound` |
-| Data-plane guest did not specify instance and method has multiple instances | gRPC `FailedPrecondition`; guest must include `x-octobus-service` / `x-octobus-instance` |
+| Data-plane business call missing `x-octobus-instance` | gRPC `FailedPrecondition`; guest must include `x-octobus-instance` |
+| Data-plane method / instance not exposed by capset | OctoBus gRPC status is passed through |
 | Data-plane OctoBus returns gRPC status | Status code / message are passed through |
 
 Errors returned to frontend must not leak private network parameters. HTTP
@@ -340,9 +336,8 @@ Backend:
    on every call.
 4. Data-plane capproxy: read OctoBus addr / token from `ConfigStore`; maintain
    token -> session in-memory index; validate guest `x-octobus-capset` belongs
-   to session binding; pass through guest `x-octobus-service` /
-   `x-octobus-instance`; when missing, fill from normalized catalog cache by
-   capset; run a dedicated gRPC listener.
+   to session binding; require guest `x-octobus-instance` for business calls;
+   run a dedicated gRPC listener.
 5. Two-step injection shared by work sessions and loader runs:
    `buildCapabilityGatewaySessionVars` before DB creation to generate
    `CAP_GRPC_TARGET` / `CAP_TOKEN` env + `capset` tags; `writeCapabilityGuide`
@@ -362,13 +357,12 @@ Tests:
 
 8. Control plane: unconfigured, connection failure, capsets normalization,
    catalog normalization, capset not found.
-9. Data plane: validate guest capset belongs to session binding; pass through
-   guest service / instance; fill unique service / instance when missing;
-   reflection stream validates capset; inject OctoBus token; method not in
-   capset -> `NotFound`; missing instance with multiple matches ->
-   `FailedPrecondition`.
+9. Data plane: validate guest capset belongs to session binding; require and
+   pass through guest instance; reflection stream validates capset; inject
+   OctoBus token; missing instance ->
+   `FailedPrecondition`; OctoBus routing errors are passed through.
 10. Injection consistency and tolerance: loader and work session share the same
     injection result; capability guide markdown is written into MPI catalog
-    (`runtime/mpi/catalog.md`, not workspace) and includes method service /
-    instance; **when OctoBus is unreachable or markdown render fails, session
+    (`runtime/mpi/catalog.md`, not workspace) and includes method instance
+    routing metadata; **when OctoBus is unreachable or markdown render fails, session
     and loader still create and run successfully (best-effort, non-blocking).**

--- a/docs/zh-CN/design/octobus_integration.md
+++ b/docs/zh-CN/design/octobus_integration.md
@@ -131,7 +131,7 @@ message GetCapabilityCatalogResponse {
 
 > 同一 catalog 端点还提供 `?format=md`（`text/markdown`，由 OctoBus `RenderCatalogMarkdown` 渲染）；agent-compose 在 session 注入时用 `?format=md&grpc=true` 渲染能力说明写入 guest（见 [session / loader 注入](#session--loader-注入)）。
 
-OctoBus catalog 结构：`?all=true` 返回 `grpc` / `mcp` / `connect_rpc` 三个并列数组，每个方法在三者各出现一次；gRPC 条目的 `metadata` 自带完整三元组 `x-octobus-capset` / `x-octobus-service` / `x-octobus-instance`。agent-compose 按 join key `(service_id, instance_id, method_full_name)` 合并成 `CapabilityMethod`，用 `endpoints` 表达 gRPC / MCP / Connect 三类入口。`endpoints` 仅供 UI 展示，不含 OctoBus 地址。
+OctoBus catalog 结构：`?all=true` 返回 `grpc` / `mcp` / `connect_rpc` 三个并列数组，每个方法在三者各出现一次；gRPC 条目的 `metadata` 自带 `x-octobus-capset` / `x-octobus-instance` 路由信息。`service_id` 仍是 catalog/UI 字段，但不再属于当前 OctoBus gRPC 路由 metadata。agent-compose 按 join key `(service_id, instance_id, method_full_name)` 合并成 `CapabilityMethod`，用 `endpoints` 表达 gRPC / MCP / Connect 三类入口。`endpoints` 仅供 UI 展示，不含 OctoBus 地址。
 
 ## 数据面转发（仅 gRPC）
 
@@ -139,33 +139,30 @@ guest 连接 `CAP_GRPC_TARGET`，按 `method_full_name` 发起 gRPC 调用，met
 
 ```text
 x-capability-session-token: <CAP_TOKEN>
-x-octobus-service: <service_id>     # guest 提供
 x-octobus-instance: <instance_id>   # guest 提供
 ```
 
-边界划分：**capset 是会话级隔离边界，由 capproxy 校验；service / instance 是 capset 内的路由，由 guest 选择。** capproxy 处理每个流：
+边界划分：**capset 是会话级隔离边界，由 capproxy 校验；instance 是 capset 内的路由，由 guest 选择。** OctoBus instance id 全局唯一，且已关联 service。capproxy 处理每个流：
 
 ```text
 1. 按 token 查内存索引 -> (session, allowed_capsets)
 2. 校验 guest 传入的 x-octobus-capset 属于 session 绑定的 allowed_capsets，guest 不能越权到别的 capset
 3. reflection 方法（grpc.reflection.*）：只需 x-octobus-capset，透传
 4. 业务方法：
-     - guest 已带 x-octobus-service / x-octobus-instance -> 透传该二者
-     - guest 未带 -> 按 (capset, method_full_name) 查 catalog 补齐：唯一命中自动填，命中 0 条 -> NotFound，命中多条 -> FailedPrecondition
+     - 要求 guest 带 x-octobus-instance
      - 注入 OctoBus token（从 ConfigStore 读）
      - 透传到 OctoBus daemon
 ```
 
-OctoBus 侧业务方法硬性要求 `x-octobus-capset` / `x-octobus-service` / `x-octobus-instance` 三者齐全（`findGRPCExposedMethod`）：capset 由 capproxy 强制，service / instance 由 guest 提供或 capproxy 补齐。
+OctoBus 侧业务方法要求 `x-octobus-capset` / `x-octobus-instance`（`findGRPCExposedMethod`）：capset 由 capproxy 强制，instance 由 guest 根据注入的能力说明提供。
 
 实现要点：
 
 - gRPC server 用 `UnknownServiceHandler` + raw passthrough codec，双向流式透传帧到 OctoBus daemon（`grpc.NewClient` + raw codec）。
 - token → session 绑定用内存索引 `token -> (session_id, capset_ids)`：启动时从已有 session 重建，session 创建/停止时增量维护。
-- capproxy 校验 `x-octobus-capset` 属于 session 绑定集合并注入 OctoBus token，guest 的 `x-octobus-service` / `x-octobus-instance` 透传。
-- 补齐用的归一 catalog 按 capset 缓存，带 TTL；过期后下次解析重新拉取。
+- capproxy 校验 `x-octobus-capset` 属于 session 绑定集合；业务调用要求 guest 带 `x-octobus-instance`；注入 OctoBus token。
 - OctoBus addr / token 在转发时从 `ConfigStore` 读取。
-- 鉴权与隔离：capset 集合由 session 绑定，guest 只能在绑定集合内选择；service / instance 是 capset 内路由，允许 guest 指定。`CAP_TOKEN` 是 agent-compose 签发的 session 凭证，只用于解析 session→capset 绑定，不能用于访问 OctoBus；OctoBus token 只在服务端，不进入 guest。
+- 鉴权与隔离：capset 集合由 session 绑定，guest 只能在绑定集合内选择；instance 是 capset 内路由，业务调用必须由 guest 指定。`CAP_TOKEN` 是 agent-compose 签发的 session 凭证，只用于解析 session→capset 绑定，不能用于访问 OctoBus；OctoBus token 只在服务端，不进入 guest。
 
 ## session / loader 注入
 
@@ -182,7 +179,7 @@ CAP_TOKEN=<每会话新生成 uuid>   # secret
 
 tag：每个能力集一个 `capset=<capset_id>`。前提仅是至少一个 capset 已选 + `CAP_GRPC_TARGET` 已配置；后者缺失则跳过能力注入并记 warning，不阻塞创建。
 
-**步骤 2：`writeCapabilityGuide(session, capset_ids)`（`prepareSessionWorkspace` 之后、`StartSessionVM` 之前，best-effort）** —— 对每个 capset 调 OctoBus `GET /admin/v1/catalog/{capset_id}?format=md&grpc=true` 渲染能力说明 markdown，写入**会话 MPI catalog** `<sessionDir>/runtime/mpi/catalog.md`（经挂载出现在 guest `/data/runtime/mpi/catalog.md`）。`agent-compose-runtime-js`（`runtime/javascript`）的 `readMpiContext` 会读这个 catalog，把它作为**高优先级上下文注入 agent system prompt**：codex 进 `config.developer_instructions`，claude 进 `systemPrompt`（preset `claude_code` + `append`）。所以创建会话后 agent 一启动就知道有哪些能力可调，无需自己 cat 文件。渲染内容含每个 gRPC 方法及其 `x-octobus-*` metadata（capset / service / instance）和「用 server reflection 获取描述符」的指引，guest 据此在调用时携带 `x-octobus-capset` / `x-octobus-service` / `x-octobus-instance`。不含 OctoBus 地址与 token（只取 `grpc` 段）。**OctoBus 不可达 / 渲染失败时记事件并继续，session/loader 照常启动**。
+**步骤 2：`writeCapabilityGuide(session, capset_ids)`（`prepareSessionWorkspace` 之后、`StartSessionVM` 之前，best-effort）** —— 对每个 capset 调 OctoBus `GET /admin/v1/catalog/{capset_id}?format=md&grpc=true` 渲染能力说明 markdown，写入**会话 MPI catalog** `<sessionDir>/runtime/mpi/catalog.md`（经挂载出现在 guest `/data/runtime/mpi/catalog.md`）。`agent-compose-runtime-js`（`runtime/javascript`）的 `readMpiContext` 会读这个 catalog，把它作为**高优先级上下文注入 agent system prompt**：codex 进 `config.developer_instructions`，claude 进 `systemPrompt`（preset `claude_code` + `append`）。所以创建会话后 agent 一启动就知道有哪些能力可调，无需自己 cat 文件。渲染内容含每个 gRPC 方法及其 `x-octobus-*` metadata（capset / instance）和「用 server reflection 获取描述符」的指引，guest 据此在调用时携带 `x-octobus-capset` / `x-octobus-instance`。不含 OctoBus 地址与 token（只取 `grpc` 段）。**OctoBus 不可达 / 渲染失败时记事件并继续，session/loader 照常启动**。
 
 > 覆盖范围：codex、claude 经 `mpiContext` 注入 system prompt；gemini runner 当前未消费 `mpiContext`（已有 gap，本期不处理）。
 
@@ -230,8 +227,8 @@ agent definition、创建会话与 loader 都保存能力集选择，`capset_ids
 | 控制面 OctoBus 返回非 2xx | 返回 Connect error，含 HTTP status |
 | 控制面 `GetCapabilityCatalog` 的 capset 不存在 | not found / invalid argument |
 | 注入阶段 OctoBus 不可达 / md 渲染失败 | **不阻塞**：记 session event + log，session/loader 照常创建运行（best-effort） |
-| 数据面方法不在 capset（guest 未指定 instance 时补齐查无） | gRPC `NotFound` |
-| 数据面 guest 未指定 instance 且方法多实例 | gRPC `FailedPrecondition`（需 guest 带 `x-octobus-service` / `x-octobus-instance`） |
+| 数据面业务调用缺少 `x-octobus-instance` | gRPC `FailedPrecondition`（需 guest 带 `x-octobus-instance`） |
+| 数据面 method / instance 未暴露给 capset | 透传 OctoBus gRPC status |
 | 数据面 OctoBus 返回 gRPC status | 透传 status code / message |
 
 响应给前端的错误不泄漏敏感网络参数；HTTP client 设置 timeout。
@@ -243,7 +240,7 @@ agent definition、创建会话与 loader 都保存能力集选择，`capset_ids
 1. `ConfigStore` 增加 `capability_gateway` 表（单行 `addr`、`token`）与 `Get` / `Save`。
 2. proto：`ConfigService` 增加 `GetCapabilityGatewayConfig` / `UpdateCapabilityGatewayConfig`；`CreateSessionRequest`、agent definition 与 loader messages 增加 `capset_ids`；`CapabilityService` 三个 rpc。重新生成 Go / TS。
 3. 控制面 provider 依赖 `ConfigStore`，每次调用读 `addr` / `token`。
-4. 数据面 capproxy：从 `ConfigStore` 读 OctoBus addr / token；token→session 内存索引；校验 `x-octobus-capset` 属于 session 绑定集合、透传 guest 的 `x-octobus-service` / `x-octobus-instance`、未带时按 capset 缓存的归一 catalog 补齐；专用 gRPC listener。
+4. 数据面 capproxy：从 `ConfigStore` 读 OctoBus addr / token；token→session 内存索引；校验 `x-octobus-capset` 属于 session 绑定集合；业务调用要求 guest 带 `x-octobus-instance`；专用 gRPC listener。
 5. 两步注入，工作会话与 loader run 共用：`buildCapabilityGatewaySessionVars`（建库前，生成 `CAP_GRPC_TARGET` / `CAP_TOKEN` env + `capset` tags）；`writeCapabilityGuide`（建库后、VM 启动前，`?format=md&grpc=true` 渲染能力说明 md 写入会话 MPI catalog `runtime/mpi/catalog.md`，由 `agent-compose-runtime-js` 注入 codex / claude 的 system prompt）。
 
 前端：
@@ -254,5 +251,5 @@ agent definition、创建会话与 loader 都保存能力集选择，`capset_ids
 测试：
 
 8. 控制面：未配置、连接失败、capsets 归一、catalog 归一、capset 不存在。
-9. 数据面：校验 guest 传入的 capset 属于 session 绑定集合、透传 guest 的 service / instance、未带 service / instance 时唯一命中补齐、reflection 流校验 capset、OctoBus token 注入、方法不在 capset → `NotFound`、未指定且多实例 → `FailedPrecondition`。
-10. 注入一致性与容错：loader 与工作会话经同一函数注入结果一致；能力说明 md 已写入 MPI catalog（`runtime/mpi/catalog.md`，非工作区）且含方法的 service / instance；**OctoBus 不可达 / md 渲染失败时 session、loader 仍成功创建运行（best-effort，不阻塞）**。
+9. 数据面：校验 guest 传入的 capset 属于 session 绑定集合；要求并透传 guest 的 instance；reflection 流校验 capset；OctoBus token 注入；缺少 instance → `FailedPrecondition`；OctoBus 路由错误透传。
+10. 注入一致性与容错：loader 与工作会话经同一函数注入结果一致；能力说明 md 已写入 MPI catalog（`runtime/mpi/catalog.md`，非工作区）且含方法的 instance 路由 metadata；**OctoBus 不可达 / md 渲染失败时 session、loader 仍成功创建运行（best-effort，不阻塞）**。

--- a/pkg/agentcompose/capability_e2e_test.go
+++ b/pkg/agentcompose/capability_e2e_test.go
@@ -39,7 +39,7 @@ func startFakeOctobus(t *testing.T) *fakeOctobus {
 			}})
 		case r.URL.Path == "/admin/v1/catalog/dev" && r.URL.Query().Get("format") == "md":
 			w.Header().Set("Content-Type", "text/markdown")
-			_, _ = w.Write([]byte("# Catalog: dev\n\n## gRPC\n\n| Method | Metadata |\n| --- | --- |\n| `/pkg.Service/Call` | `x-octobus-service=svc, x-octobus-instance=inst` |\n"))
+			_, _ = w.Write([]byte("# Catalog: dev\n\n## gRPC\n\n| Method | Metadata |\n| --- | --- |\n| `/pkg.Service/Call` | `x-octobus-capset=dev, x-octobus-instance=inst` |\n"))
 		case r.URL.Path == "/admin/v1/catalog/dev":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"capset_id": "dev",
@@ -51,7 +51,6 @@ func startFakeOctobus(t *testing.T) *fakeOctobus {
 					"method_path":      "/pkg.Service/Call",
 					"metadata": map[string]string{
 						"x-octobus-capset":   "dev",
-						"x-octobus-service":  "svc",
 						"x-octobus-instance": "inst",
 					},
 				}},

--- a/pkg/agentcompose/capability_gateway.go
+++ b/pkg/agentcompose/capability_gateway.go
@@ -131,7 +131,7 @@ any method in the catalog below:
 
 - Endpoint: %s (plaintext HTTP/2 gRPC; also in env CAP_GRPC_TARGET)
 - On every call, send metadata `+"`%s: $CAP_TOKEN`"+` (token value is in env CAP_TOKEN)
-- Also send the per-method `+"`x-octobus-capset` / `x-octobus-service` / `x-octobus-instance`"+`
+- Also send the per-method `+"`x-octobus-capset` / `x-octobus-instance`"+`
   metadata shown in the table below
 - Schemas can be discovered via gRPC server reflection using the same
   `+"`x-octobus-capset`"+` metadata

--- a/pkg/agentcompose/capability_proxy.go
+++ b/pkg/agentcompose/capability_proxy.go
@@ -24,7 +24,7 @@ func NewCapProxyServer(di do.Injector) (*capproxy.Server, error) {
 			}
 			return settings.Addr, settings.Token, true
 		},
-	}, do.MustInvoke[*Store](di), do.MustInvoke[capabilityIntegration](di)), nil
+	}, do.MustInvoke[*Store](di)), nil
 }
 
 func (s *Store) ResolveCapabilitySession(ctx context.Context, token string) (capproxy.SessionBinding, error) {

--- a/pkg/agentcompose/capability_service.go
+++ b/pkg/agentcompose/capability_service.go
@@ -28,14 +28,7 @@ type CapabilityProvider interface {
 	ProxyTarget() string
 }
 
-type CapabilityBindingResolver interface {
-	ResolveCapabilityBinding(ctx context.Context, capsetID, methodFullName string) (map[string]string, error)
-}
-
-type capabilityIntegration interface {
-	CapabilityProvider
-	CapabilityBindingResolver
-}
+type capabilityIntegration interface{ CapabilityProvider }
 
 // capabilityProvider reads the OctoBus connection from source on every call, so
 // page edits take effect without a restart. An empty addr means disabled.
@@ -100,22 +93,6 @@ func (p *capabilityProvider) CapabilityGuide(ctx context.Context, capsetID strin
 
 func (p *capabilityProvider) ProxyTarget() string {
 	return p.proxyTarget
-}
-
-func (p *capabilityProvider) ResolveCapabilityBinding(ctx context.Context, capsetID, methodFullName string) (map[string]string, error) {
-	client, ok := p.client(ctx)
-	if !ok {
-		return nil, capability.ErrNotConfigured
-	}
-	binding, err := client.ResolveBinding(ctx, capsetID, methodFullName)
-	if err != nil {
-		return nil, err
-	}
-	metadata := make(map[string]string, len(binding.Metadata))
-	for key, value := range binding.Metadata {
-		metadata[key] = value
-	}
-	return metadata, nil
 }
 
 func (s *Service) GetCapabilityStatus(ctx context.Context, req *connect.Request[agentcomposev1.GetCapabilityStatusRequest]) (*connect.Response[agentcomposev1.CapabilityStatusResponse], error) {
@@ -201,8 +178,6 @@ func toProtoCapabilityGatewayConfig(settings CapabilityGatewaySettings) *agentco
 func capabilityConnectError(err error) error {
 	switch {
 	case errors.Is(err, capability.ErrNotConfigured):
-		return connect.NewError(connect.CodeFailedPrecondition, err)
-	case errors.Is(err, capability.ErrConflict):
 		return connect.NewError(connect.CodeFailedPrecondition, err)
 	case errors.Is(err, capability.ErrInvalidCatalog):
 		return connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/agentcompose/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/session_rpc_bridge_test.go
@@ -308,7 +308,7 @@ func TestSessionRPCBridgeCreateSessionInjectsCapabilityGatewayVars(t *testing.T)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/admin/v1/catalog/dev" && r.URL.Query().Get("format") == "md" {
 			w.Header().Set("Content-Type", "text/markdown")
-			_, _ = w.Write([]byte("# Catalog: dev\n\n## gRPC\n\n| Method | Metadata |\n| --- | --- |\n| `/pkg.Service/Call` | `x-octobus-service=svc, x-octobus-instance=inst` |\n"))
+			_, _ = w.Write([]byte("# Catalog: dev\n\n## gRPC\n\n| Method | Metadata |\n| --- | --- |\n| `/pkg.Service/Call` | `x-octobus-capset=dev, x-octobus-instance=inst` |\n"))
 			return
 		}
 		t.Errorf("unexpected request %s?%s", r.URL.Path, r.URL.RawQuery)
@@ -346,7 +346,7 @@ func TestSessionRPCBridgeCreateSessionInjectsCapabilityGatewayVars(t *testing.T)
 	if err != nil {
 		t.Fatalf("capability guide not written to MPI catalog: %v", err)
 	}
-	if !strings.Contains(string(guide), "x-octobus-service=svc") {
+	if !strings.Contains(string(guide), "x-octobus-instance=inst") {
 		t.Fatalf("capability guide missing routing info: %s", guide)
 	}
 }

--- a/pkg/capability/client.go
+++ b/pkg/capability/client.go
@@ -112,40 +112,6 @@ func (c *Client) CatalogMarkdown(ctx context.Context, capsetID string) ([]byte, 
 	return io.ReadAll(resp.Body)
 }
 
-func (c *Client) ResolveBinding(ctx context.Context, capsetID, methodFullName string) (Binding, error) {
-	catalog, err := c.Catalog(ctx, capsetID)
-	if err != nil {
-		return Binding{}, err
-	}
-	methodFullName = strings.TrimPrefix(strings.TrimSpace(methodFullName), "/")
-	var matches []Binding
-	for _, method := range catalog.Methods {
-		if method.MethodFullName != methodFullName {
-			continue
-		}
-		for _, endpoint := range method.Endpoints {
-			if endpoint.Protocol != ProtocolGRPC {
-				continue
-			}
-			matches = append(matches, Binding{
-				CapsetID:       catalog.CapsetID,
-				MethodFullName: method.MethodFullName,
-				ServiceID:      method.ServiceID,
-				InstanceID:     method.InstanceID,
-				Metadata:       cloneMap(endpoint.Metadata),
-			})
-		}
-	}
-	switch len(matches) {
-	case 0:
-		return Binding{}, fmt.Errorf("%w: method %q is not exposed by capset %q", ErrMethodNotFound, methodFullName, capsetID)
-	case 1:
-		return matches[0], nil
-	default:
-		return Binding{}, fmt.Errorf("%w: capset %q method %q has %d grpc bindings", ErrConflict, capsetID, methodFullName, len(matches))
-	}
-}
-
 func (c *Client) getJSON(ctx context.Context, path string, target any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.addr+path, nil)
 	if err != nil {
@@ -173,6 +139,4 @@ func (c *Client) getJSON(ctx context.Context, path string, target any) error {
 var (
 	ErrNotConfigured  = errors.New("octobus is not configured")
 	ErrInvalidCatalog = errors.New("invalid capability catalog")
-	ErrConflict       = errors.New("capability method binding conflict")
-	ErrMethodNotFound = errors.New("capability method not found")
 )

--- a/pkg/capability/client_test.go
+++ b/pkg/capability/client_test.go
@@ -3,7 +3,6 @@ package capability
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -146,52 +145,5 @@ func TestNormalizeCatalogAllowsDuplicateGRPCMethodBindings(t *testing.T) {
 	}
 	if len(catalog.Methods) != 2 {
 		t.Fatalf("expected duplicate method bindings to be preserved, got %+v", catalog.Methods)
-	}
-}
-
-func TestResolveBinding(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(octobusCatalogResponse{
-			CapsetID: "dev",
-			GRPC: []octobusGRPCItem{{
-				ServiceID:      "svc",
-				InstanceID:     "inst",
-				MethodFullName: "pkg.Service/Call",
-				Metadata: map[string]string{
-					"x-octobus-capset":   "dev",
-					"x-octobus-service":  "svc",
-					"x-octobus-instance": "inst",
-				},
-			}},
-		})
-	}))
-	defer server.Close()
-
-	client := NewClient(Config{Addr: server.URL})
-	binding, err := client.ResolveBinding(context.Background(), "dev", "/pkg.Service/Call")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if binding.ServiceID != "svc" || binding.InstanceID != "inst" || binding.Metadata["x-octobus-service"] != "svc" {
-		t.Fatalf("unexpected binding %+v", binding)
-	}
-}
-
-func TestResolveBindingRejectsAmbiguousMethod(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(octobusCatalogResponse{
-			CapsetID: "dev",
-			GRPC: []octobusGRPCItem{
-				{ServiceID: "svc-a", InstanceID: "inst-a", MethodFullName: "pkg.Service/Call"},
-				{ServiceID: "svc-b", InstanceID: "inst-b", MethodFullName: "pkg.Service/Call"},
-			},
-		})
-	}))
-	defer server.Close()
-
-	client := NewClient(Config{Addr: server.URL})
-	_, err := client.ResolveBinding(context.Background(), "dev", "/pkg.Service/Call")
-	if !errors.Is(err, ErrConflict) {
-		t.Fatalf("expected conflict, got %v", err)
 	}
 }

--- a/pkg/capability/types.go
+++ b/pkg/capability/types.go
@@ -57,11 +57,3 @@ type Catalog struct {
 	Description string
 	Methods     []Method
 }
-
-type Binding struct {
-	CapsetID       string
-	MethodFullName string
-	ServiceID      string
-	InstanceID     string
-	Metadata       map[string]string
-}

--- a/pkg/capproxy/proxy.go
+++ b/pkg/capproxy/proxy.go
@@ -32,10 +32,6 @@ type SessionResolver interface {
 	ResolveCapabilitySession(ctx context.Context, token string) (SessionBinding, error)
 }
 
-type BindingResolver interface {
-	ResolveCapabilityBinding(ctx context.Context, capsetID, methodFullName string) (map[string]string, error)
-}
-
 // OctoBusResolver returns the current OctoBus dial target and token. ok is
 // false when the gateway is not configured, so the data plane stays in sync
 // with page edits without a restart.
@@ -45,7 +41,6 @@ type Server struct {
 	listen     string
 	octobus    OctoBusResolver
 	sessions   SessionResolver
-	bindings   BindingResolver
 	grpcServer *grpc.Server
 }
 
@@ -54,17 +49,16 @@ type Config struct {
 	OctoBus OctoBusResolver
 }
 
-func NewServer(config Config, sessions SessionResolver, bindings BindingResolver) *Server {
+func NewServer(config Config, sessions SessionResolver) *Server {
 	return &Server{
 		listen:   strings.TrimSpace(config.Listen),
 		octobus:  config.OctoBus,
 		sessions: sessions,
-		bindings: bindings,
 	}
 }
 
 func (s *Server) Configured() bool {
-	return s != nil && s.listen != "" && s.octobus != nil && s.sessions != nil && s.bindings != nil
+	return s != nil && s.listen != "" && s.octobus != nil && s.sessions != nil
 }
 
 func (s *Server) Serve(ctx context.Context) error {
@@ -112,21 +106,10 @@ func (s *Server) handleUnknown(_ any, stream grpc.ServerStream) error {
 	}
 	outgoing := buildOutgoingMetadata(stream.Context(), capset)
 	if !isReflectionMethod(method) {
-		// Business call. The guest supplies x-octobus-service / x-octobus-instance
-		// from the injected capability guide; we forward them as-is. Only when the
-		// guest omits one do we fill the triple from the resolved capset's catalog.
-		if firstMetadata(outgoing, "x-octobus-service") == "" || firstMetadata(outgoing, "x-octobus-instance") == "" {
-			fill, err := s.bindings.ResolveCapabilityBinding(stream.Context(), capset, strings.TrimPrefix(method, "/"))
-			if err != nil {
-				if strings.Contains(err.Error(), "not found") {
-					return status.Error(codes.NotFound, err.Error())
-				}
-				return status.Error(codes.FailedPrecondition, err.Error())
-			}
-			for key, value := range fill {
-				outgoing.Set(key, value)
-			}
-			outgoing.Set("x-octobus-capset", capset)
+		// Business calls route by capset + instance + method. The instance comes
+		// from the injected guide.
+		if firstMetadata(outgoing, "x-octobus-instance") == "" {
+			return status.Error(codes.FailedPrecondition, "x-octobus-instance is required")
 		}
 	}
 	return s.proxyStream(stream, method, outgoing)
@@ -160,9 +143,10 @@ func containsString(values []string, target string) bool {
 }
 
 // buildOutgoingMetadata forwards the guest's incoming metadata to OctoBus,
-// except agent-compose's own session credential and any authorization (OctoBus auth
-// is injected in proxyStream). x-octobus-capset is forced to the resolved,
-// session-allowed value so the guest cannot reach a capset outside its set.
+// except agent-compose's own session credential and any authorization (OctoBus
+// auth is injected in proxyStream).
+// x-octobus-capset is forced to the resolved, session-allowed value so the guest
+// cannot reach a capset outside its set.
 func buildOutgoingMetadata(ctx context.Context, capset string) metadata.MD {
 	incoming, _ := metadata.FromIncomingContext(ctx)
 	outgoing := incoming.Copy()

--- a/pkg/capproxy/proxy_test.go
+++ b/pkg/capproxy/proxy_test.go
@@ -17,8 +17,6 @@ type testResolver struct {
 	binding SessionBinding
 }
 
-type testBindingResolver struct{}
-
 func (r testResolver) ResolveCapabilitySession(_ context.Context, token string) (SessionBinding, error) {
 	if token != "session-token" {
 		return SessionBinding{}, status.Error(codes.Unauthenticated, "bad token")
@@ -26,25 +24,10 @@ func (r testResolver) ResolveCapabilitySession(_ context.Context, token string) 
 	return r.binding, nil
 }
 
-func (testBindingResolver) ResolveCapabilityBinding(_ context.Context, _, _ string) (map[string]string, error) {
-	return map[string]string{
-		"x-octobus-service":  "svc",
-		"x-octobus-instance": "inst",
-	}, nil
-}
-
 func staticOctoBus(addr, token string) OctoBusResolver {
 	return func(context.Context) (string, string, bool) {
 		return addr, token, true
 	}
-}
-
-// recordingBindingResolver flags whether the catalog fill path was invoked.
-type recordingBindingResolver struct{ called bool }
-
-func (r *recordingBindingResolver) ResolveCapabilityBinding(context.Context, string, string) (map[string]string, error) {
-	r.called = true
-	return map[string]string{"x-octobus-service": "from-catalog", "x-octobus-instance": "from-catalog"}, nil
 }
 
 func TestProxyInjectsOctoBusMetadata(t *testing.T) {
@@ -66,7 +49,10 @@ func TestProxyInjectsOctoBusMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = conn.Close() }()
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(SessionTokenMetadata, "session-token"))
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		SessionTokenMetadata, "session-token",
+		"x-octobus-instance", "inst",
+	))
 	out := rawFrame(nil)
 	if err := conn.Invoke(ctx, "/pkg.Service/Call", rawFrame("ping"), &out); err != nil {
 		t.Fatal(err)
@@ -76,7 +62,6 @@ func TestProxyInjectsOctoBusMetadata(t *testing.T) {
 	}
 	for key, want := range map[string]string{
 		"x-octobus-capset":   "dev",
-		"x-octobus-service":  "svc",
 		"x-octobus-instance": "inst",
 		"authorization":      "Bearer octo-token",
 	} {
@@ -86,7 +71,7 @@ func TestProxyInjectsOctoBusMetadata(t *testing.T) {
 	}
 }
 
-func TestProxyForwardsGuestSuppliedRouting(t *testing.T) {
+func TestProxyForwardsGuestInstance(t *testing.T) {
 	var received metadata.MD
 	octoAddr, stopOcto := startTestRawGRPC(t, func(_ any, stream grpc.ServerStream) error {
 		received, _ = metadata.FromIncomingContext(stream.Context())
@@ -97,8 +82,7 @@ func TestProxyForwardsGuestSuppliedRouting(t *testing.T) {
 		return stream.SendMsg(rawFrame("ok:" + string(req)))
 	})
 	defer stopOcto()
-	bindings := &recordingBindingResolver{}
-	proxyAddr, stopProxy := startTestProxyWithBindings(t, Config{Listen: "127.0.0.1:0", OctoBus: staticOctoBus(octoAddr, "")}, testResolver{binding: SessionBinding{SessionID: "s1", CapsetIDs: []string{"dev"}}}, bindings)
+	proxyAddr, stopProxy := startTestProxy(t, Config{Listen: "127.0.0.1:0", OctoBus: staticOctoBus(octoAddr, "")}, testResolver{binding: SessionBinding{SessionID: "s1", CapsetIDs: []string{"dev"}}})
 	defer stopProxy()
 
 	conn, err := grpc.NewClient(proxyAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.ForceCodec(rawCodec{})))
@@ -106,11 +90,8 @@ func TestProxyForwardsGuestSuppliedRouting(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = conn.Close() }()
-	// Guest supplies an allowed capset plus its own service/instance (from the
-	// injected guide); all three are forwarded and the catalog fill is skipped.
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.MD{
 		SessionTokenMetadata: []string{"session-token"},
-		"x-octobus-service":  []string{"guest-svc"},
 		"x-octobus-instance": []string{"guest-inst"},
 		"x-octobus-capset":   []string{"dev"},
 	})
@@ -118,17 +99,32 @@ func TestProxyForwardsGuestSuppliedRouting(t *testing.T) {
 	if err := conn.Invoke(ctx, "/pkg.Service/Call", rawFrame("ping"), &out); err != nil {
 		t.Fatal(err)
 	}
-	if bindings.called {
-		t.Fatalf("catalog fill must be skipped when guest supplies service/instance")
-	}
 	for key, want := range map[string]string{
-		"x-octobus-capset":   "dev",        // guest-supplied, validated in the allowed set
-		"x-octobus-service":  "guest-svc",  // guest value forwarded
-		"x-octobus-instance": "guest-inst", // guest value forwarded
+		"x-octobus-capset":   "dev",
+		"x-octobus-instance": "guest-inst",
 	} {
 		if got := firstMetadata(received, key); got != want {
 			t.Fatalf("metadata %s = %q, want %q", key, got, want)
 		}
+	}
+}
+
+func TestProxyRejectsMissingInstanceForBusinessCall(t *testing.T) {
+	octoAddr, stopOcto := startTestRawGRPC(t, func(_ any, stream grpc.ServerStream) error { return nil })
+	defer stopOcto()
+	proxyAddr, stopProxy := startTestProxy(t, Config{Listen: "127.0.0.1:0", OctoBus: staticOctoBus(octoAddr, "")}, testResolver{binding: SessionBinding{SessionID: "s1", CapsetIDs: []string{"dev"}}})
+	defer stopProxy()
+
+	conn, err := grpc.NewClient(proxyAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.ForceCodec(rawCodec{})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(SessionTokenMetadata, "session-token"))
+	out := rawFrame(nil)
+	err = conn.Invoke(ctx, "/pkg.Service/Call", rawFrame("ping"), &out)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for missing instance, got %v", err)
 	}
 }
 
@@ -174,10 +170,6 @@ func TestProxyRejectsMissingSessionToken(t *testing.T) {
 }
 
 func startTestProxy(t *testing.T, config Config, resolver SessionResolver) (string, func()) {
-	return startTestProxyWithBindings(t, config, resolver, testBindingResolver{})
-}
-
-func startTestProxyWithBindings(t *testing.T, config Config, resolver SessionResolver, bindings BindingResolver) (string, func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", config.Listen)
 	if err != nil {
@@ -185,7 +177,7 @@ func startTestProxyWithBindings(t *testing.T, config Config, resolver SessionRes
 	}
 	addr := ln.Addr().String()
 	config.Listen = addr
-	server := NewServer(config, resolver, bindings)
+	server := NewServer(config, resolver)
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() { errCh <- server.serve(ctx, ln) }()


### PR DESCRIPTION
## Summary
- align agent-compose OctoBus docs with the current instance-based gRPC routing contract
- remove the obsolete catalog binding fallback path from capproxy
- require guest-supplied `x-octobus-instance` for business gRPC calls while capproxy still enforces the session-bound capset
- keep `service_id` only as catalog/UI display data, not routing metadata

Fixes #75
Related: #59

## Tests
- `go test ./pkg/capproxy ./pkg/capability ./pkg/agentcompose -count=1 -timeout=3m`