### PR TITLE
fix: refresh capability guide on resume

### DIFF
--- a/pkg/agentcompose/capability_gateway.go
+++ b/pkg/agentcompose/capability_gateway.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -72,10 +73,10 @@ func buildCapabilityGatewaySessionVars(publicTarget string, capsetIDs []string) 
 // writes the concatenation as the session's MPI catalog (guest
 // /data/runtime/mpi/catalog.md), which agent-compose-runtime-js injects into the agent
 // system prompt (codex developer_instructions, claude systemPrompt append). It
-// is best-effort: any failure is logged and ignored so it never blocks
-// session/loader startup. Must be called after the session directory exists and
-// before the runtime mounts it.
-func writeCapabilityGuide(ctx context.Context, provider CapabilityProvider, session *Session, capsetIDs []string) {
+// is best-effort: failures are logged and recorded as warning events, but never
+// block session/loader startup. Must be called after the session directory
+// exists and before the runtime mounts it.
+func writeCapabilityGuide(ctx context.Context, provider CapabilityProvider, store *Store, streams *SessionStreamBroker, session *Session, capsetIDs []string) {
 	ids := normalizeCapsetIDs(capsetIDs)
 	if len(ids) == 0 || provider == nil || session == nil {
 		return
@@ -90,6 +91,7 @@ func writeCapabilityGuide(ctx context.Context, provider CapabilityProvider, sess
 		guide, err := provider.CapabilityGuide(ctx, id)
 		if err != nil {
 			slog.Warn("capability guide render skipped", "capset", id, "session_id", session.Summary.ID, "error", err)
+			recordCapabilityGuideWarning(ctx, store, streams, session.Summary.ID, fmt.Sprintf("capability guide render skipped for capset %s", id))
 			continue
 		}
 		if rendered {
@@ -107,10 +109,32 @@ func writeCapabilityGuide(ctx context.Context, provider CapabilityProvider, sess
 	}
 	if err := os.MkdirAll(filepath.Dir(catalogPath), 0o755); err != nil {
 		slog.Warn("capability guide dir create failed", "session_id", session.Summary.ID, "error", err)
+		recordCapabilityGuideWarning(ctx, store, streams, session.Summary.ID, "capability guide directory create failed")
 		return
 	}
 	if err := os.WriteFile(catalogPath, []byte(content), 0o644); err != nil {
 		slog.Warn("capability guide write failed", "session_id", session.Summary.ID, "error", err)
+		recordCapabilityGuideWarning(ctx, store, streams, session.Summary.ID, "capability guide write failed")
+	}
+}
+
+func recordCapabilityGuideWarning(ctx context.Context, store *Store, streams *SessionStreamBroker, sessionID, message string) {
+	if store == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	event := SessionEvent{
+		ID:        uuid.NewString(),
+		Type:      "capability.guide.warning",
+		Level:     "warning",
+		Message:   message,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := store.AddEvent(ctx, sessionID, event); err != nil {
+		slog.Warn("capability guide warning event failed", "session_id", sessionID, "error", err)
+		return
+	}
+	if streams != nil {
+		streams.PublishEventAdded(sessionID, event)
 	}
 }
 

--- a/pkg/agentcompose/loader_manager.go
+++ b/pkg/agentcompose/loader_manager.go
@@ -1243,7 +1243,7 @@ func (m *LoaderManager) ensureLoaderSessionWithOptions(ctx context.Context, load
 		_ = m.store.UpdateSession(ctx, session)
 		return nil, "", err
 	}
-	writeCapabilityGuide(ctx, m.cap, session, loader.Summary.CapsetIDs)
+	writeCapabilityGuide(ctx, m.cap, m.store, m.streams, session, loader.Summary.CapsetIDs)
 	if err := m.driver.StartSessionVM(ctx, session); err != nil {
 		session.Summary.VMStatus = VMStatusFailed
 		_ = m.store.UpdateSession(ctx, session)
@@ -1323,6 +1323,7 @@ func (m *LoaderManager) loadOrResumeLoaderSession(ctx context.Context, sessionID
 	if err := prepareSessionWorkspace(ctx, m.config, m.configDB, session); err != nil {
 		return nil, "", err
 	}
+	writeCapabilityGuide(ctx, m.cap, m.store, m.streams, session, sessionCapabilityCapsets(session))
 	if err := m.driver.StartSessionVM(ctx, session); err != nil {
 		return nil, "", err
 	}

--- a/pkg/agentcompose/session_rpc_bridge.go
+++ b/pkg/agentcompose/session_rpc_bridge.go
@@ -207,7 +207,7 @@ func (b *SessionRPCBridge) createSession(ctx context.Context, req *connect.Reque
 		_ = b.store.UpdateSession(ctx, session)
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	writeCapabilityGuide(ctx, b.cap, session, req.Msg.GetCapsetIds())
+	writeCapabilityGuide(ctx, b.cap, b.store, b.streams, session, req.Msg.GetCapsetIds())
 	if err := b.driver.StartSessionVM(ctx, session); err != nil {
 		session.Summary.VMStatus = VMStatusFailed
 		_ = b.store.UpdateSession(ctx, session)
@@ -248,6 +248,7 @@ func (b *SessionRPCBridge) resumeSession(ctx context.Context, req *connect.Reque
 	if err := prepareSessionWorkspace(ctx, b.config, b.configDB, session); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	writeCapabilityGuide(ctx, b.cap, b.store, b.streams, session, sessionCapabilityCapsets(session))
 	if err := b.driver.StartSessionVM(ctx, session); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}

--- a/pkg/agentcompose/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/session_rpc_bridge_test.go
@@ -351,6 +351,51 @@ func TestSessionRPCBridgeCreateSessionInjectsCapabilityGatewayVars(t *testing.T)
 	}
 }
 
+func TestSessionRPCBridgeResumeSessionRefreshesCapabilityGuide(t *testing.T) {
+	ctx := context.Background()
+	bridge, _ := newTestSessionRPCBridge(t)
+	catalog := "# Catalog: dev\n\ninitial"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/admin/v1/catalog/dev" && r.URL.Query().Get("format") == "md" {
+			w.Header().Set("Content-Type", "text/markdown")
+			_, _ = w.Write([]byte(catalog))
+			return
+		}
+		t.Errorf("unexpected request %s?%s", r.URL.Path, r.URL.RawQuery)
+		http.Error(w, "unexpected", http.StatusBadRequest)
+	}))
+	defer server.Close()
+	bridge.cap = newTestCapabilityProvider(server.URL, "agent-compose:9100")
+
+	resp, err := bridge.CreateSession(ctx, connect.NewRequest(&agentcomposev1.CreateSessionRequest{Title: "capability", CapsetIds: []string{"dev"}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID := resp.Msg.GetSession().GetSummary().GetSessionId()
+	session, err := bridge.store.GetSession(ctx, sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guidePath := sessionCapabilityGuidePath(session)
+	if err := os.Remove(guidePath); err != nil {
+		t.Fatalf("remove capability guide returned error: %v", err)
+	}
+	catalog = "# Catalog: dev\n\nrefreshed"
+	if _, err := bridge.StopSession(ctx, connect.NewRequest(&agentcomposev1.SessionIDRequest{SessionId: sessionID})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bridge.ResumeSession(ctx, connect.NewRequest(&agentcomposev1.SessionIDRequest{SessionId: sessionID})); err != nil {
+		t.Fatal(err)
+	}
+	guide, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("capability guide not refreshed on resume: %v", err)
+	}
+	if !strings.Contains(string(guide), "refreshed") {
+		t.Fatalf("capability guide content was not refreshed: %s", guide)
+	}
+}
+
 func TestSessionRPCBridgeCapabilityInjectionIsBestEffort(t *testing.T) {
 	ctx := context.Background()
 	bridge, _ := newTestSessionRPCBridge(t)
@@ -375,6 +420,22 @@ func TestSessionRPCBridgeCapabilityInjectionIsBestEffort(t *testing.T) {
 	if _, err := os.Stat(sessionCapabilityGuidePath(session)); !os.IsNotExist(err) {
 		t.Fatalf("expected no capability guide when OctoBus unreachable, stat err = %v", err)
 	}
+	events, err := bridge.store.ListEvents(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	if !sessionEventsContain(events, "capability.guide.warning") {
+		t.Fatalf("expected capability guide warning event, got %#v", events)
+	}
+}
+
+func sessionEventsContain(events []SessionEvent, eventType string) bool {
+	for _, event := range events {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
 }
 
 func TestLoaderEngineExecuteSupportsSessionRPCBindings(t *testing.T) {


### PR DESCRIPTION
## Summary
- refresh the injected capability guide before starting resumed manual sessions
- refresh sticky loader session guides before restart as well
- record best-effort capability guide render/write failures as session warning events while keeping startup non-blocking

Fixes #79
Fixes #76

## Tests
- `go test ./pkg/agentcompose ./pkg/capability ./pkg/capproxy -count=1 -timeout=3m`