### PR TITLE
fix: correct workbench overview and runs navigation

### DIFF
--- a/frontend/src/pages/RunsPage.svelte
+++ b/frontend/src/pages/RunsPage.svelte
@@ -23,6 +23,7 @@
   } from '../api/sessions';
   import { automationRunToRun, sessionToRun, type ProductRun } from '../model/runs';
   import { CellType } from '../gen/proto/agentcompose/v1/agentcompose_pb.js';
+  import { appPath } from '../paths';
   import { formatBeijingTime } from '../time';
   import { currentQueryParams, updateQueryParams } from '../url';
 
@@ -1496,14 +1497,14 @@
 
   function goAgentDetail(agent: AgentObservation): void {
     if (!agent.agentId || agent.deleted) return;
-    window.location.assign(`/ui/agents?agent=${encodeURIComponent(agent.agentId)}`);
+    window.location.assign(appPath(`/agents?agent=${encodeURIComponent(agent.agentId)}`));
   }
 
   function goAgentManualRun(agent: AgentObservation): void {
     if (!agent.agentId || agent.deleted) return;
     const def = agentDefinitions.find((item) => item.id === agent.agentId);
     if (!def) {
-      window.location.assign(`/ui/agents?agent=${encodeURIComponent(agent.agentId)}`);
+      window.location.assign(appPath(`/agents?agent=${encodeURIComponent(agent.agentId)}`));
       return;
     }
     openRun(def);
@@ -1701,7 +1702,7 @@
 
   function goTaskDetail(run: ProductRun): void {
     if (!run.automationId || isRunTaskDeleted(run)) return;
-    window.location.assign(`/ui/automation-tasks?task=${encodeURIComponent(run.automationId)}`);
+    window.location.assign(appPath(`/automation-tasks?task=${encodeURIComponent(run.automationId)}`));
   }
 
   function mergeSessionUpdate(existing: ProductRun, updated: ReturnType<typeof sessionToRun>): ProductRun {
@@ -3892,7 +3893,7 @@
       <div class="empty-state-icon"><AntIcon definition={InboxOutlined} /></div>
       <h3>还没有智能体</h3>
       <p>先创建智能体，再从智能体页运行或创建自动化任务。</p>
-      <div class="empty-state-actions"><button class="primary" on:click={() => window.location.assign('/ui/agents')}>创建智能体</button></div>
+      <div class="empty-state-actions"><button class="primary" on:click={() => window.location.assign(appPath('/agents'))}>创建智能体</button></div>
     </div>
   {:else if filteredAgentObservations.length === 0}
     <div class="empty-state">
@@ -4417,7 +4418,7 @@
                       <div><span>失败记录</span><b>{selectedAutomationTaskItem.failedCount > 0 ? `${selectedAutomationTaskItem.failedCount} 次` : '无'}</b></div>
                     </div>
                     <div class="toolbar">
-                      <button disabled={selectedAutomationTaskItem.deletedTask} on:click={() => window.location.assign(`/ui/automation-tasks?task=${encodeURIComponent(selectedAutomationTaskItem.taskId)}`)}>{selectedAutomationTaskItem.deletedTask ? '任务已删除' : '查看任务详情'}</button>
+                      <button disabled={selectedAutomationTaskItem.deletedTask} on:click={() => window.location.assign(appPath(`/automation-tasks?task=${encodeURIComponent(selectedAutomationTaskItem.taskId)}`))}>{selectedAutomationTaskItem.deletedTask ? '任务已删除' : '查看任务详情'}</button>
                       <button on:click={clearTaskFilter}>清除任务筛选</button>
                     </div>
                   </section>

--- a/frontend/src/pages/WorkbenchPage.svelte
+++ b/frontend/src/pages/WorkbenchPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from 'svelte';
 
+  import { getCapabilityStatus } from '../api/config';
   import { listAgentDefinitions } from '../api/agents';
   import { listAutomationTasks, listRecentAutomationRuns } from '../api/loaders';
   import { listWorkSessions } from '../api/sessions';
@@ -19,17 +20,13 @@
   let runCount = 0;
   let capabilityCount = 0;
   let attentionCount = 0;
-  let recentItems: Array<{ id: string; title: string; type: string; status: string }> = [];
+  let recentItems: Array<{ id: string; title: string; type: string; status: string; at: string }> = [];
   let timelineRange: '12h' | '24h' | '36h' | '48h' | 'custom' = '24h';
   let customFrom = '';
   let customTo = '';
 
   $: attentionItems = recentItems.filter((item) => isAttentionStatus(item.status));
   $: timelineItems = recentItems
-    .map((item, index) => ({
-      ...item,
-      at: new Date(Date.now() - index * 45 * 60 * 1000).toISOString(),
-    }))
     .filter((item) => inTimelineRange(item.at))
     .sort((left, right) => new Date(right.at).getTime() - new Date(left.at).getTime());
 
@@ -39,21 +36,22 @@
     loading = true;
     error = '';
     try {
-      const [agents, sessions, tasks] = await Promise.all([
+      const [agents, sessions, tasks, capabilityStatus] = await Promise.all([
         listAgentDefinitions(),
         listWorkSessions(5).then((r) => r.sessions),
         listAutomationTasks(),
+        getCapabilityStatus().catch(() => null),
       ]);
       agentCount = agents.length;
       taskCount = tasks.length;
       const runs = await listRecentAutomationRuns(tasks.map((item) => item.id), 5);
       runCount = sessions.length + runs.length;
       recentItems = [
-        ...sessions.map((item) => ({ id: item.id, title: item.title || item.id, type: '工作会话', status: mapSessionStatus(item.status) })),
-        ...runs.map((item) => ({ id: item.id, title: item.id, type: '自动化运行', status: mapLoaderRunStatus(item.status) })),
-      ].slice(0, 6);
+        ...sessions.map((item) => ({ id: item.id, title: item.title || item.id, type: '工作会话', status: mapSessionStatus(item.status), at: item.updatedAt || item.createdAt })),
+        ...runs.map((item) => ({ id: item.id, title: item.id, type: '自动化运行', status: mapLoaderRunStatus(item.status), at: item.completedAt || item.startedAt })),
+      ].sort((left, right) => new Date(right.at).getTime() - new Date(left.at).getTime()).slice(0, 6);
       attentionCount = recentItems.filter((item) => isAttentionStatus(item.status)).length;
-      capabilityCount = 0;
+      capabilityCount = capabilityStatus?.serviceCount ?? 0;
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {


### PR DESCRIPTION
## Summary
- use appPath() for Runs page links so navigation respects the configured frontend base path
- show the Workbench capability count from the Capability Gateway status API
- use real work session and automation run timestamps for the Workbench recent timeline

Fixes #89
Fixes #87
Fixes #86

## Tests
- `npm run build:ui`