### PR TITLE
Clean up deployment release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,26 @@ jobs:
           cache: true
       - run: go test ./cmd/... ./pkg/...
 
+  coverage:
+    name: Coverage gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: runtime/javascript/package-lock.json
+      - name: Install runtime test dependencies
+        working-directory: runtime/javascript
+        run: npm ci
+      - name: Run coverage thresholds
+        run: ./scripts/test-coverage.sh
+
   frontend:
     name: Frontend build
     runs-on: ubuntu-latest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -196,67 +196,12 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
 
-  binary:
-    name: Build binary (${{ matrix.goos }}/${{ matrix.goarch }})
-    if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: "0"
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME}"
-          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
-            version="$(git describe --always --tags --long 2>/dev/null || git rev-parse --short=12 HEAD)"
-          fi
-          package="agent-compose-${version}-${GOOS}-${GOARCH}"
-          mkdir -p "dist/${package}"
-          go build \
-            -trimpath \
-            -tags netgo,osusergo \
-            -ldflags "-s -w -X agent-compose/pkg/config.BuildVersion=${version}" \
-            -o "dist/${package}/agent-compose" \
-            ./cmd/agent-compose
-          go version -m "dist/${package}/agent-compose"
-          tar -C dist -czf "dist/${package}.tar.gz" "${package}"
-          sha256sum "dist/${package}.tar.gz" > "dist/${package}.tar.gz.sha256"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: agent-compose-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: |
-            dist/*.tar.gz
-            dist/*.sha256
-          if-no-files-found: error
-
   # Publish the installer assets. The stack pulls its multi-arch images from the
-  # registry at install time, so no per-arch image artifacts are shipped here.
+  # registry at install time, so no per-arch binary artifacts are shipped here.
   release:
     name: Publish GitHub release
     if: github.ref_type == 'tag'
     needs:
-      - binary
       - merge
     runs-on: ubuntu-latest
     permissions:
@@ -264,21 +209,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Download binary artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-assets
-          pattern: agent-compose-*
-          merge-multiple: true
       - name: Build installer assets
         env:
           VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          sudo apt-get update -qq && sudo apt-get install -y -qq makeself
           out="${PWD}/upload"
           mkdir -p "${out}"
-          find release-assets -type f \( -name '*.tar.gz' -o -name '*.sha256' \) -exec cp {} "${out}/" \;
 
           # Standalone installer script for the `curl ... | bash` one-liner.
           cp deploy/install.sh "${out}/install.sh"
@@ -298,13 +235,10 @@ jobs:
             echo "DEFAULT_IMAGE=${IMAGE_PREFIX}/agent-compose-guest:${VERSION}"
           } > "${payload}/images/manifest.env"
 
-          # Tar archive (used by `curl | bash` remote mode) and a single-file
-          # self-extracting installer.
+          # Tar archive used by `curl | bash` remote mode and manual installs.
           tar -C "$(dirname "${payload}")" -czf "${out}/agent-compose-installer.tar.gz" agent-compose-installer
-          makeself --gzip "${payload}" "${out}/agent-compose-installer.run" \
-            "agent-compose installer ${VERSION}" ./install.sh
 
-          ( cd "${out}" && sha256sum ./*.tar.gz ./*.run > SHASUMS256.txt )
+          ( cd "${out}" && sha256sum ./*.tar.gz > SHASUMS256.txt )
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,6 +61,7 @@ On first run the installer generates an admin password and prints it once:
 ./install.sh --image-prefix registry.example.com/agent-compose   # mirror / private registry
 ./install.sh --upgrade                # update an existing install to this release
 ./install.sh --no-start               # write files but don't pull images or start
+./install.sh --yes                    # skip the confirmation prompt
 ```
 
 ## Requirements
@@ -89,3 +90,7 @@ secrets or image refs, but it does not overwrite image refs already set in
 `.env` unless `--upgrade` is passed. Use `--upgrade` with a newer
 `agent-compose-installer.run` to update an existing installation to that
 release and restart the stack.
+
+Before changing the installation directory, the installer prints a deployment
+plan and asks for confirmation. Use `--yes` or `AGENT_COMPOSE_YES=1` for
+non-interactive automation.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,24 +9,11 @@ automatically), so the installer itself is tiny.
 
 | Asset | Purpose |
 |-------|---------|
-| `agent-compose-installer.run` | Single-file self-extracting installer (arch-agnostic) |
-| `agent-compose-installer.tar.gz` | Same installer as a tar archive |
+| `agent-compose-installer.tar.gz` | Docker Compose installer bundle |
 | `install.sh` | Standalone installer for `curl \| bash` |
-| `agent-compose-<version>-<os>-<arch>.tar.gz` | Go binary archive |
-| `agent-compose-<version>-<os>-<arch>.tar.gz.sha256` | Per-binary checksum |
 | `SHASUMS256.txt` | Checksums |
 
 ## Quick start
-
-### Single-file installer (recommended)
-
-```bash
-chmod +x agent-compose-installer.run
-./agent-compose-installer.run                      # install with defaults
-./agent-compose-installer.run -- --dir /opt/agent-compose --port 8080
-```
-
-Arguments after `--` are passed to the embedded installer (see Options below).
 
 ### One-line install
 
@@ -40,6 +27,13 @@ curl -fsSL https://github.com/chaitin/agent-compose/releases/latest/download/ins
 tar -xzf agent-compose-installer.tar.gz
 cd agent-compose-installer
 ./install.sh
+```
+
+### Specific install directory
+
+```bash
+curl -fsSL https://github.com/chaitin/agent-compose/releases/latest/download/install.sh | \
+  bash -s -- --dir /opt/agent-compose --port 8080
 ```
 
 On first run the installer generates an admin password and prints it once:
@@ -88,8 +82,8 @@ before exposing the daemon beyond a trusted network.
 Re-running the installer refreshes the compose/nginx files and fills missing
 secrets or image refs, but it does not overwrite image refs already set in
 `.env` unless `--upgrade` is passed. Use `--upgrade` with a newer
-`agent-compose-installer.run` to update an existing installation to that
-release and restart the stack.
+installer to update an existing installation to that release and restart the
+stack.
 
 Before changing the installation directory, the installer prints a deployment
 plan and asks for confirmation. Use `--yes` or `AGENT_COMPOSE_YES=1` for

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -22,6 +22,7 @@ IMAGE_PREFIX=""
 PORT=""
 NO_START=0
 UPGRADE=0
+YES="${AGENT_COMPOSE_YES:-0}"
 
 log()  { printf '\033[0;36m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[0;33mwarn:\033[0m %s\n' "$*" >&2; }
@@ -42,11 +43,13 @@ Options:
                          instead of the default registry
   --upgrade              Update existing image refs to this installer version
   --no-start             Lay down files but do not pull images or start
+  -y, --yes              Run without the interactive confirmation prompt
   -h, --help             Show this help
 
 Environment:
   AGENT_COMPOSE_REPO          GitHub repo for downloads (owner/name)
   AGENT_COMPOSE_INSTALL_DIR   Same as --dir
+  AGENT_COMPOSE_YES=1         Same as --yes
 EOF
 }
 
@@ -61,6 +64,7 @@ while [ $# -gt 0 ]; do
     --image-prefix) IMAGE_PREFIX="${2:?--image-prefix needs a value}"; shift 2 ;;
     --upgrade)      UPGRADE=1; shift ;;
     --no-start)     NO_START=1; shift ;;
+    -y|--yes)       YES=1; shift ;;
     -h|--help)      usage; exit 0 ;;
     *)              die "unknown option: $1 (try --help)" ;;
   esac
@@ -102,6 +106,13 @@ set_env() { # $1=file $2=key $3=value
 
 get_env() { # $1=file $2=key -> value (may be empty)
   grep "^$2=" "$1" 2>/dev/null | head -n1 | cut -d= -f2- || true
+}
+
+truthy() {
+  case "${1:-}" in
+    1|yes|YES|true|TRUE|y|Y) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 apply_image_refs() { # $1=file $2=mode(set-missing|overwrite)
@@ -193,6 +204,49 @@ else
   die "docker compose (v2) is required"
 fi
 [ -e /dev/kvm ] || warn "/dev/kvm not present; the boxlite/microsandbox drivers need it (the default docker driver does not)"
+
+# --------------------------------------------------------------------------
+# Explicit confirmation before changing the installation directory
+# --------------------------------------------------------------------------
+if [ -f "$INSTALL_DIR/.env" ]; then
+  ENV_STATE="existing .env will be preserved"
+else
+  ENV_STATE="new .env will be created with generated credentials"
+fi
+if [ "$UPGRADE" -eq 1 ]; then
+  IMAGE_STATE="image refs in .env will be updated to this installer version"
+else
+  IMAGE_STATE="existing image refs in .env will be kept"
+fi
+if [ "$NO_START" -eq 1 ]; then
+  START_STATE="stack will not be started (--no-start)"
+else
+  START_STATE="images will be pulled and the stack will be started"
+fi
+
+cat <<EOF
+
+agent-compose deployment plan
+  Source:       $BUNDLE_SRC
+  Target dir:   $INSTALL_DIR
+  Data dir:     $INSTALL_DIR/data/agent-compose
+  Config:       $ENV_STATE
+  Images:       $IMAGE_STATE
+  Start:        $START_STATE
+
+EOF
+
+if ! truthy "$YES"; then
+  if [ ! -r /dev/tty ]; then
+    die "confirmation requires a TTY; rerun with --yes or AGENT_COMPOSE_YES=1"
+  fi
+  printf 'Continue? [y/N] ' > /dev/tty
+  read -r answer < /dev/tty
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *) die "installation cancelled" ;;
+  esac
+fi
 
 # --------------------------------------------------------------------------
 # Lay down files

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -6,9 +6,8 @@
 # multi-arch container images from the registry (ghcr.io by default; Docker
 # selects the right architecture automatically).
 #
-# Run it from an extracted installer archive, from the self-extracting
-# installer, or via `curl ... | bash`. On first run it generates an admin
-# password and prints it to the terminal.
+# Run it from an extracted installer archive or via `curl ... | bash`. On first
+# run it generates an admin password and prints it to the terminal.
 
 set -euo pipefail
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -6,6 +6,8 @@ services:
     restart: always
     privileged: true
     command: ["/app/agent-compose", "daemon"]
+    devices:
+      - /dev/kvm:/dev/kvm
     environment:
       DATA_ROOT: /data
       SESSION_ROOT: /data/sessions


### PR DESCRIPTION
## Summary
- keep docker-compose.deploy.yml as the release deployment template and add the missing /dev/kvm device mount
- add an explicit installer deployment plan prompt with --yes / AGENT_COMPOSE_YES=1 for automation
- simplify release assets to install.sh, agent-compose-installer.tar.gz, and SHASUMS256.txt
- add a CI coverage gate using the existing scripts/test-coverage.sh thresholds

## Checks
- python YAML parse for .github/workflows/ci.yml and .github/workflows/images.yml
- bash -n deploy/install.sh
- docker compose -f docker-compose.deploy.yml config

Note: full coverage execution was not completed locally; only syntax/config checks were run before committing.