### PR TITLE
fix: interpolate compose agent model env refs

### DIFF
--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -158,10 +158,14 @@ func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions) (Nor
 	if err != nil {
 		return NormalizedAgentSpec{}, err
 	}
+	model, err := interpolateEnvValue(joinPath("agents", name)+".model", strings.TrimSpace(agent.Model), options)
+	if err != nil {
+		return NormalizedAgentSpec{}, err
+	}
 	return NormalizedAgentSpec{
 		Name:         name,
 		Provider:     strings.TrimSpace(agent.Provider),
-		Model:        strings.TrimSpace(agent.Model),
+		Model:        model,
 		SystemPrompt: agent.SystemPrompt,
 		Image:        strings.TrimSpace(agent.Image),
 		Driver:       driver,

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -193,6 +193,42 @@ agents:
 	}
 }
 
+func TestNormalizeInterpolatesAgentModelFromEnvironment(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: model-env
+agents:
+  reviewer:
+    provider: claude
+    model: ${ANTHROPIC_MODEL}
+`)
+
+	normalized, err := Normalize(spec, NormalizeOptions{Env: map[string]string{"ANTHROPIC_MODEL": "kimi-k2.6"}})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	if got := normalized.Agents[0].Model; got != "kimi-k2.6" {
+		t.Fatalf("agent model = %q, want kimi-k2.6", got)
+	}
+}
+
+func TestNormalizeRequiresAgentModelEnvironmentReference(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: model-env
+agents:
+  reviewer:
+    provider: claude
+    model: ${ANTHROPIC_MODEL}
+`)
+
+	_, err := Normalize(spec, NormalizeOptions{Env: map[string]string{}})
+	if err == nil {
+		t.Fatalf("expected Normalize to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "agents.reviewer.model") || !strings.Contains(got, "ANTHROPIC_MODEL") {
+		t.Fatalf("error = %q, want model env reference path", got)
+	}
+}
+
 func TestNormalizeRejectsEmptyDriver(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: invalid-driver


### PR DESCRIPTION
## Summary

- Interpolate `${VAR}` references in compose agent `model` fields using the same environment lookup path as env values.
- Add regression coverage for successful `model: ${ANTHROPIC_MODEL}` expansion and missing-variable errors on `agents.<name>.model`.

## Context

Found while verifying #20. The original issue's `env` interpolation path works on current `main`, but `model: ${ANTHROPIC_MODEL}` remained a literal string in normalized config. This PR handles that focused follow-up without closing #20.

## Validation

- `go test ./pkg/compose ./cmd/agent-compose -run 'TestNormalize|TestConfigCommandPrintsNormalized' -count=1`
- `go test ./pkg/compose -count=1`
- `git diff --check`