### PR TITLE
fix: fail project runs after agent cancellation

### DIFF
--- a/pkg/agentcompose/loader_timer_test.go
+++ b/pkg/agentcompose/loader_timer_test.go
@@ -1879,6 +1879,7 @@ type fakeLoaderAgentRuntime struct {
 	agentStderr            string
 	agentOutput            string
 	agentNoPayload         bool
+	agentWaitForContext    bool
 	commandSpecs           []ExecSpec
 	commandExitCode        int
 	commandStdout          string
@@ -2029,6 +2030,19 @@ func (r *fakeLoaderAgentRuntime) ExecStream(ctx context.Context, session *Sessio
 		stream(ExecChunk{Text: "loader agent transcript\n", IsStderr: true})
 	}
 	exitCode := r.agentExitCode
+	if r.agentWaitForContext {
+		<-ctx.Done()
+		stdout := r.agentStdout
+		stderr := r.agentStderr
+		output := firstNonEmpty(r.agentOutput, stdout+stderr)
+		return ExecResult{
+			Stdout:   stdout,
+			Stderr:   stderr,
+			Output:   output,
+			ExitCode: firstNonZeroInt(exitCode, 1),
+			Success:  false,
+		}, ctx.Err()
+	}
 	if r.agentNoPayload {
 		stdout := r.agentStdout
 		stderr := r.agentStderr

--- a/pkg/agentcompose/loader_timer_test.go
+++ b/pkg/agentcompose/loader_timer_test.go
@@ -1875,6 +1875,10 @@ type fakeLoaderAgentRuntime struct {
 	providers              []string
 	agentSpecs             []ExecSpec
 	agentDeadlineDurations []time.Duration
+	agentStdout            string
+	agentStderr            string
+	agentOutput            string
+	agentNoPayload         bool
 	commandSpecs           []ExecSpec
 	commandExitCode        int
 	commandStdout          string
@@ -2025,6 +2029,18 @@ func (r *fakeLoaderAgentRuntime) ExecStream(ctx context.Context, session *Sessio
 		stream(ExecChunk{Text: "loader agent transcript\n", IsStderr: true})
 	}
 	exitCode := r.agentExitCode
+	if r.agentNoPayload {
+		stdout := r.agentStdout
+		stderr := r.agentStderr
+		output := firstNonEmpty(r.agentOutput, stdout+stderr)
+		return ExecResult{
+			Stdout:   stdout,
+			Stderr:   stderr,
+			Output:   output,
+			ExitCode: exitCode,
+			Success:  exitCode == 0,
+		}, nil
+	}
 	payload := agentResultPrefix + fmt.Sprintf(`{"provider":%q,"sessionId":"agent-runtime-session","stopReason":"completed","finalText":"loader agent transcript","transcript":"loader agent transcript"}`, provider)
 	return ExecResult{
 		Stdout:   payload,

--- a/pkg/agentcompose/run_coordinator_test.go
+++ b/pkg/agentcompose/run_coordinator_test.go
@@ -527,6 +527,53 @@ func TestRunAgentStreamSendFailurePersistsTerminalRun(t *testing.T) {
 	}
 }
 
+func TestRunAgentContextCancelPersistsTerminalRun(t *testing.T) {
+	store, service, projectID := setupRunCoordinatorProject(t)
+	runtime := runServiceFakeRuntime(t, service)
+	runtime.agentWaitForContext = true
+	runtime.agentStdout = "partial agent output\n"
+	runtime.agentStderr = "agent stderr before cancel\n"
+	runtime.agentOutput = runtime.agentStdout + runtime.agentStderr
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var outputAttempts int
+	sink := projectRunStreamSink{
+		send: func(resp *agentcomposev2.RunAgentStreamResponse) error {
+			if resp.GetEventType() == agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT {
+				outputAttempts++
+				cancel()
+			}
+			return nil
+		},
+	}
+	run, execErr, err := service.runProjectAgent(ctx, &agentcomposev2.RunAgentRequest{
+		ProjectId:       projectID,
+		AgentName:       "reviewer",
+		Prompt:          "cancel while agent is running",
+		ClientRequestId: "agent-context-cancel-request",
+	}, &sink)
+	if err != nil {
+		t.Fatalf("runProjectAgent returned control-plane error: %v", err)
+	}
+	if !errors.Is(execErr, context.Canceled) {
+		t.Fatalf("runProjectAgent execErr = %v, want context canceled", execErr)
+	}
+	if outputAttempts != 1 {
+		t.Fatalf("output send attempts = %d, want 1", outputAttempts)
+	}
+	if run.Status != ProjectRunStatusFailed || run.SessionID == "" || run.CompletedAt.IsZero() || !strings.Contains(run.Error, "context canceled") {
+		t.Fatalf("canceled run = %#v", run)
+	}
+	stored, err := store.GetProjectRun(context.Background(), run.RunID)
+	if err != nil {
+		t.Fatalf("GetProjectRun canceled run returned error: %v", err)
+	}
+	if stored.Status != ProjectRunStatusFailed || stored.CompletedAt.IsZero() || stored.SessionID != run.SessionID || !strings.Contains(stored.Error, "context canceled") {
+		t.Fatalf("stored canceled run = %#v", stored)
+	}
+}
+
 func TestRunAgentSessionEnvProviderUsesAgentDefinitionModelAfterSessionReload(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("LLM_API_ENDPOINT", "")

--- a/pkg/agentcompose/run_coordinator_test.go
+++ b/pkg/agentcompose/run_coordinator_test.go
@@ -416,6 +416,45 @@ func TestE2ERunAgentStreamAgentFailurePersistsRun(t *testing.T) {
 	testRunAgentStreamAgentFailurePersistsRun(t)
 }
 
+func TestRunAgentStreamEmptyStdoutFailureIncludesProviderStderr(t *testing.T) {
+	_, service, projectID := setupRunCoordinatorProject(t)
+	runtime := runServiceFakeRuntime(t, service)
+	runtime.agentExitCode = 1
+	runtime.agentNoPayload = true
+	runtime.agentStderr = `Codex provider config error: wire_api = "chat" is no longer supported`
+	client, closeServer := newRunServiceTestClient(t, service)
+	defer closeServer()
+	ctx := context.Background()
+
+	events, err := collectRunAgentStreamEvents(ctx, client, &agentcomposev2.RunAgentRequest{
+		ProjectId:       projectID,
+		AgentName:       "reviewer",
+		Prompt:          "trigger provider config failure",
+		ClientRequestId: "stream-agent-empty-stdout-request",
+	})
+	if err != nil {
+		t.Fatalf("RunAgentStream empty stdout failure returned RPC error: %v", err)
+	}
+	completed := lastRunAgentStreamEvent(events, agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED)
+	if completed == nil || completed.GetRun().GetStatus() != agentcomposev2.RunStatus_RUN_STATUS_FAILED {
+		t.Fatalf("completed failure event = %#v events=%#v", completed, events)
+	}
+	if !strings.Contains(completed.GetRun().GetError(), "wire_api") || !strings.Contains(completed.GetRun().GetError(), "chat") {
+		t.Fatalf("completed failure error = %q, want provider stderr", completed.GetRun().GetError())
+	}
+	session, err := service.store.GetSession(ctx, completed.GetRun().GetSessionId())
+	if err != nil {
+		t.Fatalf("GetSession failure returned error: %v", err)
+	}
+	cells, err := service.store.ListCells(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListCells failure returned error: %v", err)
+	}
+	if len(cells) == 0 || !strings.Contains(cells[len(cells)-1].Stderr, "wire_api") {
+		t.Fatalf("failed cell stderr missing provider error: %#v", cells)
+	}
+}
+
 func testRunAgentStreamAgentFailurePersistsRun(t *testing.T) {
 	store, service, projectID := setupRunCoordinatorProject(t)
 	runServiceFakeRuntime(t, service).agentExitCode = 7

--- a/pkg/agentcompose/run_service.go
+++ b/pkg/agentcompose/run_service.go
@@ -77,9 +77,10 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	if err != nil {
 		return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	transitionCtx := context.WithoutCancel(ctx)
 	prepared, err := s.prepareProjectRun(ctx, run, msg.GetEnv())
 	if err != nil {
-		run, markErr := coordinator.MarkFailed(ctx, ProjectRunTransitionRequest{
+		run, markErr := coordinator.MarkFailed(transitionCtx, ProjectRunTransitionRequest{
 			RunID: run.RunID,
 			Error: fmt.Sprintf("workspace preparation failed: %v", err),
 		})
@@ -97,19 +98,19 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 		if sessionResult.Session != nil {
 			transition.SessionID = sessionResult.Session.Summary.ID
 		}
-		run, markErr := coordinator.MarkFailed(ctx, transition)
+		run, markErr := coordinator.MarkFailed(transitionCtx, transition)
 		if markErr != nil {
 			return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, markErr)
 		}
 		return run, err, nil
 	}
-	run, err = coordinator.MarkRunning(ctx, run.RunID, sessionResult.Session.Summary.ID)
+	run, err = coordinator.MarkRunning(transitionCtx, run.RunID, sessionResult.Session.Summary.ID)
 	if err != nil {
 		return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, err)
 	}
 	agentConfig, err := s.projectRunAgentConfig(ctx, run)
 	if err != nil {
-		run, markErr := coordinator.MarkFailed(ctx, ProjectRunTransitionRequest{
+		run, markErr := coordinator.MarkFailed(transitionCtx, ProjectRunTransitionRequest{
 			RunID:     run.RunID,
 			SessionID: sessionResult.Session.Summary.ID,
 			ExitCode:  1,
@@ -122,7 +123,7 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	}
 	if s.executor == nil {
 		err = fmt.Errorf("executor is required")
-		run, markErr := coordinator.MarkFailed(ctx, ProjectRunTransitionRequest{
+		run, markErr := coordinator.MarkFailed(transitionCtx, ProjectRunTransitionRequest{
 			RunID:     run.RunID,
 			SessionID: sessionResult.Session.Summary.ID,
 			ExitCode:  1,
@@ -144,18 +145,18 @@ func (s *Service) runProjectAgent(ctx context.Context, msg *agentcomposev2.RunAg
 	})
 	transition := projectRunTransitionFromAgentCell(run, sessionResult.Session, cell, execErr)
 	if execErr != nil || !cell.Success {
-		run, err = coordinator.MarkFailed(ctx, transition)
+		run, err = coordinator.MarkFailed(transitionCtx, transition)
 		if err != nil {
 			return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, err)
 		}
-		run = s.cleanupProjectRunSession(context.WithoutCancel(ctx), coordinator, run, sessionResult.Session, msg.GetCleanupPolicy())
+		run = s.cleanupProjectRunSession(transitionCtx, coordinator, run, sessionResult.Session, msg.GetCleanupPolicy())
 		return run, execErr, nil
 	}
-	run, err = coordinator.MarkSucceeded(ctx, transition)
+	run, err = coordinator.MarkSucceeded(transitionCtx, transition)
 	if err != nil {
 		return ProjectRunRecord{}, nil, connect.NewError(connect.CodeInternal, err)
 	}
-	run = s.cleanupProjectRunSession(context.WithoutCancel(ctx), coordinator, run, sessionResult.Session, msg.GetCleanupPolicy())
+	run = s.cleanupProjectRunSession(transitionCtx, coordinator, run, sessionResult.Session, msg.GetCleanupPolicy())
 	return run, nil, nil
 }
 


### PR DESCRIPTION
## Summary
- preserve provider stderr when agent executions return no structured result payload
- persist project run terminal transitions with a context that is not canceled with the client request
- add regression coverage for both empty-stdout/provider-stderr propagation and client/request cancellation during agent execution

Fixes #31

## Root Cause
`runProjectAgent` correctly observed the agent execution failure, but when the client request context was canceled or interrupted it reused that same canceled context for `MarkFailed` / `MarkSucceeded` / cleanup transitions. That meant the failed cell could be written while the project run record stayed `running`.

The provider-error half of #31 was already covered by the empty stdout regression: if Codex exits without an agent result payload but does emit stderr, the failed run and persisted cell include that stderr instead of reducing the error to only `agent codex returned empty stdout`.

## Verification
- Added `TestRunAgentStreamEmptyStdoutFailureIncludesProviderStderr` for the no-payload/provider-stderr case.
- Added `TestRunAgentContextCancelPersistsTerminalRun` for request cancellation during a streaming agent run.
- Ran: `go test ./pkg/agentcompose -run 'TestRunAgentContextCancelPersistsTerminalRun|TestRunAgentStreamSendFailurePersistsTerminalRun|TestRunAgentStreamEmptyStdoutFailureIncludesProviderStderr|TestIntegrationRunAgentStreamAgentFailurePersistsRun|TestE2ERunAgentStreamAgentFailurePersistsRun'`
- Ran: `go test ./pkg/agentcompose`

Real Docker guest validation:
- Started a local daemon from this branch on `0.0.0.0:18431` with Docker guest image `agent-compose-guest:latest`.
- Applied this compose project:

```yaml
name: issue31-real
workspace:
  provider: local
  path: workspace
agents:
  calculator:
    provider: codex
    model: gpt-test
    image: agent-compose-guest:latest
    driver:
      docker: {}
    env:
      LLM_API_ENDPOINT: http://127.0.0.1:18531
      LLM_API_KEY:
        value: test-key
        secret: true
      LLM_MODEL: gpt-test
```

- The fake OpenAI endpoint listened on `127.0.0.1:18531` and returned HTTP 400 for `/v1/responses` with:

```json
{"error":{"message":"wire_api = \"chat\" is no longer supported","type":"invalid_request_error"}}
```

- Ran: `agent-compose run calculator --prompt '请计算 20 + 22。你只需要回答结果数字。' --json`.
- Result: run `run-calculator-96a48b2432bf` completed as `failed`, `duration_ms=735`, `ps` showed `failed` rather than `running`, and CLI / `inspect run` / `logs --json` all included the provider error text.
