### PR TITLE
Fix empty capset override for agent sessions

### DIFF
--- a/pkg/agentcompose/agent_definition_test.go
+++ b/pkg/agentcompose/agent_definition_test.go
@@ -254,6 +254,59 @@ func TestAgentDefinitionCreateSession(t *testing.T) {
 	testAgentDefinitionCreateSession(t)
 }
 
+func TestAgentDefinitionCreateSessionCapsetOverride(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.sessions.cap = newTestCapabilityProvider("", "agent-compose:9100")
+	created, err := service.CreateAgentDefinition(ctx, connect.NewRequest(&agentcomposev1.CreateAgentDefinitionRequest{
+		Name:      "Capability Runner",
+		Enabled:   true,
+		Provider:  "codex",
+		CapsetIds: []string{"dev"},
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+
+	inherited, err := service.CreateAgentSession(ctx, connect.NewRequest(&agentcomposev1.CreateAgentSessionRequest{
+		AgentId: created.Msg.GetAgent().GetAgentId(),
+		Title:   "inherits agent capsets",
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentSession(inherit) returned error: %v", err)
+	}
+	inheritedSession, err := service.store.GetSession(ctx, inherited.Msg.GetSession().GetSummary().GetSessionId())
+	if err != nil {
+		t.Fatalf("GetSession(inherit) returned error: %v", err)
+	}
+	if capsets := sessionCapabilityCapsets(inheritedSession); len(capsets) != 1 || capsets[0] != "dev" {
+		t.Fatalf("inherited capsets = %+v, want [dev]", capsets)
+	}
+
+	cleared, err := service.CreateAgentSession(ctx, connect.NewRequest(&agentcomposev1.CreateAgentSessionRequest{
+		AgentId:   created.Msg.GetAgent().GetAgentId(),
+		Title:     "clears agent capsets",
+		CapsetIds: []string{},
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentSession(clear) returned error: %v", err)
+	}
+	clearedSession, err := service.store.GetSession(ctx, cleared.Msg.GetSession().GetSummary().GetSessionId())
+	if err != nil {
+		t.Fatalf("GetSession(clear) returned error: %v", err)
+	}
+	if capsets := sessionCapabilityCapsets(clearedSession); len(capsets) != 0 {
+		t.Fatalf("cleared capsets = %+v, want none", capsets)
+	}
+	env := map[string]string{}
+	for _, item := range clearedSession.EnvItems {
+		env[item.Name] = item.Value
+	}
+	if env[capProxyTargetEnvName] != "" || env[capabilitySessionTokenEnvName] != "" {
+		t.Fatalf("cleared session capability env = %+v, want no capability vars", env)
+	}
+}
+
 func TestAgentSessionMessageUsesDefinitionProvider(t *testing.T) {
 	ctx := context.Background()
 	service, runtime, _ := newTestServiceAPIHarness(t)

--- a/pkg/agentcompose/agent_service.go
+++ b/pkg/agentcompose/agent_service.go
@@ -283,8 +283,8 @@ func (s *Service) CreateAgentSession(ctx context.Context, req *connect.Request[a
 	}
 	envItems := mergeEnvItems(agent.EnvItems, envItemsFromProto(req.Msg.GetEnvItems()))
 	capsetIDs := agent.CapsetIDs
-	if reqCapsets := req.Msg.GetCapsetIds(); len(reqCapsets) > 0 {
-		capsetIDs = reqCapsets
+	if req.Msg.CapsetIds != nil || req.Header().Get(createAgentSessionCapsetIDsPresentHeader) == "true" {
+		capsetIDs = req.Msg.CapsetIds
 	}
 	createReq := &agentcomposev1.CreateSessionRequest{
 		Title:       title,

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -3,9 +3,11 @@ package agentcompose
 import (
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -148,7 +150,7 @@ func Register(di do.Injector) {
 	path, handler = agentcomposev1connect.NewAgentServiceHandler(service)
 	app.Any(path+"*", echo.WrapHandler(handler))
 	path, handler = agentcomposev1connect.NewAgentDefinitionServiceHandler(service)
-	app.Any(path+"*", echo.WrapHandler(handler))
+	app.Any(path+"*", echo.WrapHandler(markCreateAgentSessionCapsetPresence(handler)))
 	path, handler = agentcomposev1connect.NewLLMServiceHandler(service)
 	app.Any(path+"*", echo.WrapHandler(handler))
 	path, handler = agentcomposev1connect.NewConfigServiceHandler(service)
@@ -173,6 +175,40 @@ func Register(di do.Injector) {
 	registerRuntimeLLMFacadeRoutes(app, service)
 	registerProxyRoutes(app, service)
 	registerWorkspaceRoutes(app, service)
+}
+
+const createAgentSessionCapsetIDsPresentHeader = "Agent-Compose-Capset-Ids-Present"
+
+func markCreateAgentSessionCapsetPresence(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost ||
+			r.URL.Path != agentcomposev1connect.AgentDefinitionServiceCreateAgentSessionProcedure ||
+			!strings.Contains(strings.ToLower(r.Header.Get("Content-Type")), "json") ||
+			r.Body == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		if err == nil && jsonObjectHasAnyKey(body, "capsetIds", "capset_ids") {
+			r.Header.Set(createAgentSessionCapsetIDsPresentHeader, "true")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func jsonObjectHasAnyKey(body []byte, keys ...string) bool {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return false
+	}
+	for _, key := range keys {
+		if _, ok := raw[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func StartBackground(di do.Injector) error {

--- a/pkg/agentcompose/service_api_test.go
+++ b/pkg/agentcompose/service_api_test.go
@@ -5,6 +5,7 @@ import (
 	driverpkg "agent-compose/pkg/driver"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -818,6 +819,60 @@ func newTestServiceAPIHarness(t *testing.T) (*Service, *fakeLoaderAgentRuntime, 
 		sessions:  sessions,
 	}
 	return service, runtime, driver
+}
+
+func TestAgentDefinitionHTTPCreateSessionEmptyCapsetsOverride(t *testing.T) {
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.sessions.cap = newTestCapabilityProvider("", "agent-compose:9100")
+	created, err := service.CreateAgentDefinition(context.Background(), connect.NewRequest(&agentcomposev1.CreateAgentDefinitionRequest{
+		Name:      "HTTP Capability Runner",
+		Enabled:   true,
+		Provider:  "codex",
+		CapsetIds: []string{"dev"},
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	path, handler := agentcomposev1connect.NewAgentDefinitionServiceHandler(service)
+	server := httptest.NewServer(markCreateAgentSessionCapsetPresence(handler))
+	t.Cleanup(server.Close)
+
+	body := strings.NewReader(fmt.Sprintf(`{"agentId":%q,"title":"http clears capsets","capsetIds":[]}`, created.Msg.GetAgent().GetAgentId()))
+	resp, err := http.Post(server.URL+path+"CreateAgentSession", "application/json", body)
+	if err != nil {
+		t.Fatalf("HTTP CreateAgentSession returned error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("HTTP CreateAgentSession status = %d", resp.StatusCode)
+	}
+	var decoded struct {
+		Session struct {
+			Summary struct {
+				SessionID string `json:"sessionId"`
+				Tags      []struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				} `json:"tags"`
+			} `json:"summary"`
+			EnvItems []struct {
+				Name string `json:"name"`
+			} `json:"envItems"`
+		} `json:"session"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode HTTP CreateAgentSession response: %v", err)
+	}
+	for _, tag := range decoded.Session.Summary.Tags {
+		if tag.Name == capabilityCapsetTagName {
+			t.Fatalf("HTTP cleared session has capability tag %q", tag.Value)
+		}
+	}
+	for _, item := range decoded.Session.EnvItems {
+		if item.Name == capProxyTargetEnvName || item.Name == capabilitySessionTokenEnvName {
+			t.Fatalf("HTTP cleared session has capability env %q", item.Name)
+		}
+	}
 }
 
 func testServiceConfigAndLoaderAPIs(t *testing.T) {


### PR DESCRIPTION
## Summary
- let CreateAgentSession treat an explicitly provided empty capset list as an override instead of falling back to the agent definition
- preserve JSON field presence for Connect HTTP requests where proto repeated fields lose empty-array presence after decoding
- add direct service and raw HTTP regression coverage

Fixes #106

## Verification
- go test ./pkg/agentcompose -run '^(TestAgentDefinitionHTTPCreateSessionEmptyCapsetsOverride|TestAgentDefinitionCreateSessionCapsetOverride)$' -count=1
- go test ./pkg/agentcompose -count=1
- GOFLAGS=-buildvcs=false task lint:go
- GOFLAGS=-buildvcs=false task build:agent-compose
- Real daemon/Docker verification on 2026-06-25 from commit 6dc6b53:
  - started ./build/agent-compose daemon with DATA_ROOT=/tmp/agent-compose-issue106-final-hrMqPl, HTTP_LISTEN=127.0.0.1:18412, RUNTIME_DRIVER=docker, DEFAULT_IMAGE=agent-compose-guest:latest, CAP_GRPC_TARGET=agent-compose:9100
  - created agent definition with capsetIds=["dev"] via Connect HTTP
  - created session with explicit JSON capsetIds=[] via Connect HTTP
  - verified API response and metadata had no capset tag and no CAP_GRPC_TARGET/CAP_TOKEN env
  - verified Docker container agent-compose-2267aa50-145e-4bab-8e56-188f1276ec7a ran with agent-compose-guest:latest, then stopped it through the API