### PR TITLE
Remove capset override from agent session API

### DIFF
--- a/frontend/src/gen/proto/agentcompose/v1/agentcompose_pb.ts
+++ b/frontend/src/gen/proto/agentcompose/v1/agentcompose_pb.ts
@@ -3128,11 +3128,6 @@ export class CreateAgentSessionRequest extends Message<CreateAgentSessionRequest
    */
   guestImage = "";
 
-  /**
-   * @generated from field: repeated string capset_ids = 7;
-   */
-  capsetIds: string[] = [];
-
   constructor(data?: PartialMessage<CreateAgentSessionRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -3147,7 +3142,6 @@ export class CreateAgentSessionRequest extends Message<CreateAgentSessionRequest
     { no: 4, name: "workspace_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 5, name: "driver", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "guest_image", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 7, name: "capset_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateAgentSessionRequest {

--- a/pkg/agentcompose/agent_definition_test.go
+++ b/pkg/agentcompose/agent_definition_test.go
@@ -254,6 +254,42 @@ func TestAgentDefinitionCreateSession(t *testing.T) {
 	testAgentDefinitionCreateSession(t)
 }
 
+func TestAgentDefinitionCreateSessionUsesDefinitionCapsets(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.sessions.cap = newTestCapabilityProvider("", "agent-compose:9100")
+	created, err := service.CreateAgentDefinition(ctx, connect.NewRequest(&agentcomposev1.CreateAgentDefinitionRequest{
+		Name:      "Capability Runner",
+		Enabled:   true,
+		Provider:  "codex",
+		CapsetIds: []string{"dev"},
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	sessionResp, err := service.CreateAgentSession(ctx, connect.NewRequest(&agentcomposev1.CreateAgentSessionRequest{
+		AgentId: created.Msg.GetAgent().GetAgentId(),
+		Title:   "uses definition capsets",
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentSession returned error: %v", err)
+	}
+	session, err := service.store.GetSession(ctx, sessionResp.Msg.GetSession().GetSummary().GetSessionId())
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if capsets := sessionCapabilityCapsets(session); len(capsets) != 1 || capsets[0] != "dev" {
+		t.Fatalf("session capsets = %+v, want [dev]", capsets)
+	}
+	env := map[string]string{}
+	for _, item := range session.EnvItems {
+		env[item.Name] = item.Value
+	}
+	if env[capProxyTargetEnvName] != "agent-compose:9100" || env[capabilitySessionTokenEnvName] == "" {
+		t.Fatalf("session capability env = %+v", env)
+	}
+}
+
 func TestAgentSessionMessageUsesDefinitionProvider(t *testing.T) {
 	ctx := context.Background()
 	service, runtime, _ := newTestServiceAPIHarness(t)

--- a/pkg/agentcompose/agent_service.go
+++ b/pkg/agentcompose/agent_service.go
@@ -282,10 +282,6 @@ func (s *Service) CreateAgentSession(ctx context.Context, req *connect.Request[a
 		title = agent.Name + " 工作会话"
 	}
 	envItems := mergeEnvItems(agent.EnvItems, envItemsFromProto(req.Msg.GetEnvItems()))
-	capsetIDs := agent.CapsetIDs
-	if reqCapsets := req.Msg.GetCapsetIds(); len(reqCapsets) > 0 {
-		capsetIDs = reqCapsets
-	}
 	createReq := &agentcomposev1.CreateSessionRequest{
 		Title:       title,
 		Tags:        agentDefinitionTags(agent),
@@ -293,7 +289,7 @@ func (s *Service) CreateAgentSession(ctx context.Context, req *connect.Request[a
 		WorkspaceId: workspaceID,
 		Driver:      driver,
 		GuestImage:  guestImage,
-		CapsetIds:   capsetIDs,
+		CapsetIds:   agent.CapsetIDs,
 	}
 	return s.sessions.CreateSession(ctx, connect.NewRequest(createReq))
 }

--- a/proto/agentcompose/v1/agentcompose.pb.go
+++ b/proto/agentcompose/v1/agentcompose.pb.go
@@ -3988,7 +3988,6 @@ type CreateAgentSessionRequest struct {
 	WorkspaceId   string                 `protobuf:"bytes,4,opt,name=workspace_id,json=workspaceId,proto3" json:"workspace_id,omitempty"`
 	Driver        string                 `protobuf:"bytes,5,opt,name=driver,proto3" json:"driver,omitempty"`
 	GuestImage    string                 `protobuf:"bytes,6,opt,name=guest_image,json=guestImage,proto3" json:"guest_image,omitempty"`
-	CapsetIds     []string               `protobuf:"bytes,7,rep,name=capset_ids,json=capsetIds,proto3" json:"capset_ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4063,13 +4062,6 @@ func (x *CreateAgentSessionRequest) GetGuestImage() string {
 		return x.GuestImage
 	}
 	return ""
-}
-
-func (x *CreateAgentSessionRequest) GetCapsetIds() []string {
-	if x != nil {
-		return x.CapsetIds
-	}
-	return nil
 }
 
 type UpdateGlobalEnvConfigRequest struct {
@@ -7141,7 +7133,7 @@ const file_proto_agentcompose_v1_agentcompose_proto_rawDesc = "" +
 	"\x13availability_status\x18\x01 \x01(\x0e2(.agentcompose.v1.AgentAvailabilityStatusR\x12availabilityStatus\x12G\n" +
 	"\rhealth_status\x18\x02 \x01(\x0e2\".agentcompose.v1.AgentHealthStatusR\fhealthStatus\x12\x1a\n" +
 	"\bwarnings\x18\x03 \x03(\tR\bwarnings\x12\x16\n" +
-	"\x06errors\x18\x04 \x03(\tR\x06errors\"\x84\x02\n" +
+	"\x06errors\x18\x04 \x03(\tR\x06errors\"\xf7\x01\n" +
 	"\x19CreateAgentSessionRequest\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12;\n" +
@@ -7149,9 +7141,8 @@ const file_proto_agentcompose_v1_agentcompose_proto_rawDesc = "" +
 	"\fworkspace_id\x18\x04 \x01(\tR\vworkspaceId\x12\x16\n" +
 	"\x06driver\x18\x05 \x01(\tR\x06driver\x12\x1f\n" +
 	"\vguest_image\x18\x06 \x01(\tR\n" +
-	"guestImage\x12\x1d\n" +
-	"\n" +
-	"capset_ids\x18\a \x03(\tR\tcapsetIds\"[\n" +
+	"guestImageJ\x04\b\a\x10\bR\n" +
+	"capset_ids\"[\n" +
 	"\x1cUpdateGlobalEnvConfigRequest\x12;\n" +
 	"\tenv_items\x18\x01 \x03(\v2\x1e.agentcompose.v1.SessionEnvVarR\benvItems\"V\n" +
 	"\x17GlobalEnvConfigResponse\x12;\n" +

--- a/proto/agentcompose/v1/agentcompose.proto
+++ b/proto/agentcompose/v1/agentcompose.proto
@@ -515,13 +515,15 @@ message ValidateAgentDefinitionResponse {
 }
 
 message CreateAgentSessionRequest {
+  reserved 7;
+  reserved "capset_ids";
+
   string agent_id = 1;
   string title = 2;
   repeated SessionEnvVar env_items = 3;
   string workspace_id = 4;
   string driver = 5;
   string guest_image = 6;
-  repeated string capset_ids = 7;
 }
 
 message UpdateGlobalEnvConfigRequest {


### PR DESCRIPTION
## Summary
- remove `capset_ids` from `CreateAgentSessionRequest` and reserve its field number/name
- make agent-created sessions always use the agent definition capsets
- regenerate Go and TypeScript protocol clients
- add coverage proving agent sessions receive capability injection from the agent definition

This keeps capset ownership on the agent definition. Direct `CreateSession`, loaders, and project agent specs still have their existing capset fields.

Related to #106.

## Verification
- go test ./pkg/agentcompose -run ^TestAgentDefinitionCreateSessionUsesDefinitionCapsets -count=1 -v
- go test ./proto/agentcompose/v1 ./proto/agentcompose/v1/agentcomposev1connect
- npm run check:ui
- go test ./pkg/agentcompose -count=1
- GOFLAGS=-buildvcs=false task build:agent-compose
- GOFLAGS=-buildvcs=false task lint:go
- Real daemon/Docker verification on 2026-06-25 from commit 3590098:
  - started ./build/agent-compose daemon with DATA_ROOT=/tmp/agent-compose-no-session-capsets-185ceD, HTTP_LISTEN=127.0.0.1:18413, RUNTIME_DRIVER=docker, DEFAULT_IMAGE=agent-compose-guest:latest, CAP_GRPC_TARGET=agent-compose:9100
  - created an agent definition with capsetIds=["dev"] through Connect HTTP
  - sent a CreateAgentSession request containing legacy capsetIds=[]; the generated API no longer exposes the field, and the server ignored the unknown raw JSON field
  - verified the created Docker session inherited the agent definition capset and injected capset=dev plus CAP_GRPC_TARGET/CAP_TOKEN
  - stopped the session through the API and confirmed no related Docker container remained