### PR TITLE
fix runtime provider error list

### DIFF
--- a/runtime/javascript/src/provider.ts
+++ b/runtime/javascript/src/provider.ts
@@ -1,9 +1,11 @@
 import type { Provider } from "./types.js";
 
+const providerList = "codex, claude, gemini, opencode";
+
 export function normalizeProvider(raw: unknown): Provider {
   const provider = String(raw ?? "").trim().toLowerCase();
   if (!provider) {
-    throw new Error("provider is required; expected one of: codex, claude, gemini");
+    throw new Error(`provider is required; expected one of: ${providerList}`);
   }
   switch (provider) {
     case "codex":
@@ -21,6 +23,6 @@ export function normalizeProvider(raw: unknown): Provider {
     case "open_code":
       return "opencode";
     default:
-      throw new Error(`unsupported provider ${JSON.stringify(raw)}; expected one of: codex, claude, gemini`);
+      throw new Error(`unsupported provider ${JSON.stringify(raw)}; expected one of: ${providerList}`);
   }
 }

--- a/runtime/javascript/test/provider.test.ts
+++ b/runtime/javascript/test/provider.test.ts
@@ -17,7 +17,7 @@ describe("provider normalization", () => {
   });
 
   it("rejects unsupported providers", () => {
-    expect(() => normalizeProvider("qwen")).toThrow(/unsupported provider "qwen"; expected one of: codex, claude, gemini/);
+    expect(() => normalizeProvider("qwen")).toThrow(/unsupported provider "qwen"; expected one of: codex, claude, gemini, opencode/);
   });
 
   it.each([
@@ -26,7 +26,7 @@ describe("provider normalization", () => {
     undefined,
     null,
   ])("rejects missing provider %j", (input) => {
-    expect(() => normalizeProvider(input)).toThrow(/provider is required/);
+    expect(() => normalizeProvider(input)).toThrow(/provider is required; expected one of: codex, claude, gemini, opencode/);
   });
 
   it("trims provider names before normalization", () => {


### PR DESCRIPTION
Fixes #108.

## Summary
- include opencode in runtime provider validation error messages
- share the supported provider list between missing and unsupported provider errors
- update provider normalization tests for the new message

## Validation
- npm exec -- vitest run test/provider.test.ts
- npm run typecheck