### PR TITLE
Draft: fix(runtime): reset Codex thread on system context change

### DIFF
--- a/docs/design/agent-compose-runtime-js_contract.md
+++ b/docs/design/agent-compose-runtime-js_contract.md
@@ -443,13 +443,23 @@ Content:
 {
   "provider": "codex",
   "sessionId": "<provider-session-id>",
-  "updatedAt": "2026-01-01T00:00:00.000Z"
+  "updatedAt": "2026-01-01T00:00:00.000Z",
+  "systemContextHash": "<sha256-hex-of-systemContext>",
+  "systemContextHashVersion": 1
 }
 ```
 
+`systemContextHash` and `systemContextHashVersion` are written by the Codex
+runner only. Claude and other providers omit these fields.
+
 Codex and Claude read this file on the next call and resume:
 
-- Codex: `codex.resumeThread(sessionId, ...)`
+- Codex: `codex.resumeThread(sessionId, ...)` when `sessionId` exists **and**
+  `systemContextHash` matches the current composed system context (or is absent
+  for legacy state — see lazy migration below); otherwise `codex.startThread(...)`.
+  When a hash mismatch forces a new thread, the runtime writes
+  `[agent-compose-runtime] warning: system context changed; started new Codex thread`
+  to stderr.
 - Claude: `resume: sessionId`
 
 Gemini currently does not write provider state.
@@ -553,6 +563,10 @@ If `/data/state/agents/system-prompts/system-prompt.txt` and/or
 `/data/runtime/mpi/catalog.md` exist and are readable, the JavaScript runtime
 composes Agent Identity + MPI into `systemContext` and injects it through Codex
 `config.developer_instructions`.
+
+Thread selection compares the SHA-256 hash of `systemContext` against
+`codex.json.systemContextHash`. Resume when the hash matches (or is absent in
+legacy state); otherwise start a fresh thread. See §8.
 
 Codex events are converted into a human-readable transcript, including agent
 messages, reasoning, command execution, file changes, MCP calls, web search, and

--- a/docs/design/agent_system_prompt_design.md
+++ b/docs/design/agent_system_prompt_design.md
@@ -269,8 +269,16 @@ new Codex({
 ```
 
 The `@openai/codex-sdk` reads `config` at constructor scope, not from
-`ThreadOptions`. That means both `startThread` and `resumeThread` receive the
-current combined context on each run, including after `system_prompt` edits.
+`ThreadOptions`. Constructor `config` is passed on every run, but upstream
+[codex#19045](https://github.com/openai/codex/issues/19045) means **resume does
+not guarantee the model sees updated `developer_instructions` on the first turn**.
+
+**Phase 2 (implemented):** The guest runtime SHA-256-hashes the full
+`systemContext` and stores it in `codex.json` as `systemContextHash`. Codex
+resumes only when `sessionId` exists **and** the hash matches; otherwise it
+calls `startThread`. A stderr warning is emitted when a hash mismatch forces a
+new thread. Legacy state files without `systemContextHash` resume once, then
+record the hash (lazy migration).
 
 ### Claude
 
@@ -374,7 +382,7 @@ Runner tests (`runners.test.ts`, `runner-execution.test.ts`) were updated to use
 
 1. Agent with `system_prompt: "Reply only in Chinese"` obeys after Codex/Claude chat run.
 2. Empty `system_prompt` → identical to pre-change MPI-only behavior.
-3. Codex session resume after prompt edit uses new instructions.
+3. Codex session resume preserves continuity when `systemContext` is unchanged; when it changes, a fresh thread is started (Phase 2).
 4. Loader bound to an agent definition inherits `system_prompt`.
 5. `task test`, runtime JS tests, and `task lint` pass on touched packages.
 
@@ -415,11 +423,12 @@ relaxed for Gemini only.
 Rename for clearer semantics in API and UI. Requires Proto, DB migration, UI,
 and client updates.
 
-### Force fresh Codex thread on prompt change
+### Force fresh Codex thread on prompt change — **implemented (Phase 2)**
 
-If a future SDK version stops applying constructor `config` on resume, the host
-could detect a hash of `system_prompt` and force a new thread when instructions
-change. Phase 1 relies on current SDK behavior.
+When the SHA-256 hash of the composed `systemContext` differs from
+`codex.json.systemContextHash`, `CodexRunner` calls `startThread` instead of
+`resumeThread`, working around [codex#19045](https://github.com/openai/codex/issues/19045).
+See [codex-start-thread-on-system-prompt-change.md](issues/codex-start-thread-on-system-prompt-change.md).
 
 ### Prompt file soft size limit
 

--- a/docs/zh-CN/design/agent-compose-runtime-js_contract.md
+++ b/docs/zh-CN/design/agent-compose-runtime-js_contract.md
@@ -382,13 +382,17 @@ JS runtime 负责保存 provider 级续接索引：
 {
   "provider": "codex",
   "sessionId": "<provider-session-id>",
-  "updatedAt": "2026-01-01T00:00:00.000Z"
+  "updatedAt": "2026-01-01T00:00:00.000Z",
+  "systemContextHash": "<sha256-hex-of-systemContext>",
+  "systemContextHashVersion": 1
 }
 ```
 
+`systemContextHash` 与 `systemContextHashVersion` 仅由 Codex runner 写入，Claude 及其他 provider 不写这两个字段。
+
 Codex 和 Claude 会在下一次调用时读取该文件并 resume：
 
-- Codex：`codex.resumeThread(sessionId, ...)`
+- Codex：当 `sessionId` 存在**且** `systemContextHash` 与当前组合 system context 匹配（或属于无 hash 的旧状态——见下文 lazy migration）时执行 `codex.resumeThread(sessionId, ...)`；否则执行 `codex.startThread(...)`。当因 hash 不匹配而强制新建 thread 时，runtime 会向 stderr 写入 `[agent-compose-runtime] warning: system context changed; started new Codex thread`。
 - Claude：`resume: sessionId`
 
 Gemini 当前不写该 provider state。
@@ -473,6 +477,8 @@ networkAccessEnabled=true
 ```
 
 如果 `/data/runtime/mpi/catalog.md` 存在且可读，JS runtime 会通过 Codex `config.developer_instructions` 注入 MPI catalog 上下文。
+
+线程选择会将 `systemContext` 的 SHA-256 哈希与 `codex.json.systemContextHash` 比较：哈希匹配（或旧状态无 hash）时 resume，否则新建 thread。详见 §8。
 
 Codex 事件会被转换成人类可读 transcript，包括 agent message、reasoning、command execution、file change、MCP call、web search、todo list 等。
 

--- a/docs/zh-CN/design/agent_system_prompt_design.md
+++ b/docs/zh-CN/design/agent_system_prompt_design.md
@@ -240,7 +240,9 @@ new Codex({
 })
 ```
 
-`@openai/codex-sdk` 在 constructor 作用域读取 `config`，而非 `ThreadOptions`。因此 `startThread` 和 `resumeThread` 在每次运行都会收到当前组合 context，包括 `system_prompt` 编辑之后。
+`@openai/codex-sdk` 在 constructor 作用域读取 `config`，而非 `ThreadOptions`。constructor `config` 在每次运行都会传入，但上游缺陷 [codex#19045](https://github.com/openai/codex/issues/19045) 意味着 **resume 时无法保证模型在首轮看到更新后的 `developer_instructions`**。
+
+**Phase 2（已实现）：** guest runtime 对完整 `systemContext` 计算 SHA-256，并以 `systemContextHash` 存入 `codex.json`。仅当 `sessionId` 存在**且**哈希匹配时才 resume，否则调用 `startThread`。因 hash 不匹配而强制新建 thread 时会向 stderr 写入一条 warning。无 `systemContextHash` 的旧状态会先 resume 一次，随后补写 hash（lazy migration）。
 
 ### Claude
 
@@ -336,7 +338,7 @@ Runner 测试（`runners.test.ts`、`runner-execution.test.ts`）已更新为使
 
 1. `system_prompt: "Reply only in Chinese"` 的 agent 在 Codex/Claude chat 运行后应遵守该指令。
 2. 空 `system_prompt` → 与改动前 MPI-only 行为一致。
-3. Codex session 在 prompt 编辑后 resume 时使用新指令。
+3. `systemContext` 未变时 Codex session resume 保留连续性；变更时新建 thread（Phase 2）。
 4. 绑定 agent definition 的 loader 继承 `system_prompt`。
 5. `task test`、runtime JS 测试套件、以及 touched packages 的 `task lint` 均通过。
 
@@ -368,9 +370,9 @@ Runner 测试（`runners.test.ts`、`runner-execution.test.ts`）已更新为使
 
 为 API 与 UI 语义更清晰而重命名。需要 Proto、DB 迁移、UI 与客户端更新。
 
-### Prompt 变更时强制新建 Codex thread
+### Prompt 变更时强制新建 Codex thread —— **已实现（Phase 2）**
 
-若未来 SDK 版本在 resume 时不再应用 constructor `config`，host 可检测 `system_prompt` 哈希并在指令变更时强制新 thread。Phase 1 依赖当前 SDK 行为。
+当组合 `systemContext` 的 SHA-256 哈希与 `codex.json.systemContextHash` 不一致时，`CodexRunner` 改为调用 `startThread` 而非 `resumeThread`，以规避 [codex#19045](https://github.com/openai/codex/issues/19045)。详见 [issues/codex-start-thread-on-system-prompt-change.md](issues/codex-start-thread-on-system-prompt-change.md)。
 
 ### Prompt 文件软大小限制
 

--- a/runtime/javascript/src/index.ts
+++ b/runtime/javascript/src/index.ts
@@ -8,6 +8,12 @@ export { ClaudeRunner } from "./runners/claude.js";
 export { CodexRunner } from "./runners/codex.js";
 export { GeminiRunner } from "./runners/gemini.js";
 export { OpenCodeRunner } from "./runners/opencode.js";
-export { readStoredSession, sessionStatePath, writeStoredSession } from "./session-state.js";
+export {
+  hashSystemContext,
+  readStoredSession,
+  sessionStatePath,
+  shouldResumeCodexThread,
+  writeStoredSession,
+} from "./session-state.js";
 export { appendDelta, TranscriptWriter } from "./transcript.js";
 export type { AgentResult, Provider, RunnerOptions, StoredSession } from "./types.js";

--- a/runtime/javascript/src/runners/codex.ts
+++ b/runtime/javascript/src/runners/codex.ts
@@ -1,7 +1,13 @@
 import { resolveCodexPath } from "../codex-path.js";
 import { stringEnv } from "../env.js";
 import { uniqueDirectories } from "../paths.js";
-import { readStoredSession, writeStoredSession } from "../session-state.js";
+import { warn } from "../mpi.js";
+import {
+  hashSystemContext,
+  readStoredSession,
+  shouldResumeCodexThread,
+  writeStoredSession,
+} from "../session-state.js";
 import { extractText } from "../text.js";
 import { appendDelta, TranscriptWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions } from "../types.js";
@@ -155,9 +161,15 @@ export class CodexRunner {
         ? { config: { developer_instructions: this.options.systemContext } }
         : {}),
     });
-    const thread = stored?.sessionId
-      ? codex.resumeThread(stored.sessionId, this.threadOptions())
+    const hashNow = hashSystemContext(this.options.systemContext ?? "");
+    const resume = shouldResumeCodexThread(stored, hashNow);
+    const thread = resume
+      ? codex.resumeThread(stored!.sessionId, this.threadOptions())
       : codex.startThread(this.threadOptions());
+
+    if (stored?.sessionId && !resume && stored.systemContextHash && stored.systemContextHash !== hashNow) {
+      warn("system context changed; started new Codex thread");
+    }
 
     const result: AgentResult = {
       provider: "codex",
@@ -180,7 +192,7 @@ export class CodexRunner {
     if (!result.finalText && result.transcript) {
       result.finalText = result.transcript;
     }
-    await writeStoredSession(this.options.stateRoot, "codex", result.sessionId);
+    await writeStoredSession(this.options.stateRoot, "codex", result.sessionId, new Date(), hashNow);
     return result;
   }
 }

--- a/runtime/javascript/src/session-state.ts
+++ b/runtime/javascript/src/session-state.ts
@@ -1,17 +1,60 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ensureDir, readText } from "./fs.js";
 import type { Provider, StoredSession } from "./types.js";
 
+export const SYSTEM_CONTEXT_HASH_VERSION = 1;
+
 export function sessionStatePath(stateRoot: string, provider: Provider): string {
   return path.join(stateRoot, "agents", "providers", `${provider}.json`);
+}
+
+export function hashSystemContext(context: string): string {
+  return crypto.createHash("sha256").update(context, "utf8").digest("hex");
+}
+
+export function shouldResumeCodexThread(stored: StoredSession | null, hashNow: string): boolean {
+  if (!stored?.sessionId) {
+    return false;
+  }
+  if (!stored.systemContextHash) {
+    return true;
+  }
+  if (
+    stored.systemContextHashVersion !== undefined
+    && stored.systemContextHashVersion !== SYSTEM_CONTEXT_HASH_VERSION
+  ) {
+    return false;
+  }
+  return stored.systemContextHash === hashNow;
+}
+
+function parseStoredSession(payload: unknown, provider: Provider): StoredSession | null {
+  if (typeof payload !== "object" || payload === null || typeof (payload as StoredSession).sessionId !== "string") {
+    return null;
+  }
+  const record = payload as StoredSession;
+  const session: StoredSession = {
+    provider: typeof record.provider === "string" ? record.provider : provider,
+    sessionId: record.sessionId,
+  };
+  if (typeof record.updatedAt === "string") {
+    session.updatedAt = record.updatedAt;
+  }
+  if (typeof record.systemContextHash === "string") {
+    session.systemContextHash = record.systemContextHash;
+  }
+  if (typeof record.systemContextHashVersion === "number") {
+    session.systemContextHashVersion = record.systemContextHashVersion;
+  }
+  return session;
 }
 
 export async function readStoredSession(stateRoot: string, provider: Provider): Promise<StoredSession | null> {
   try {
     const raw = await readText(sessionStatePath(stateRoot, provider));
-    const payload = JSON.parse(raw);
-    return typeof payload?.sessionId === "string" ? payload : null;
+    return parseStoredSession(JSON.parse(raw), provider);
   } catch {
     return null;
   }
@@ -22,16 +65,21 @@ export async function writeStoredSession(
   provider: Provider,
   sessionId: string,
   now: Date = new Date(),
+  systemContextHash?: string,
 ): Promise<void> {
   if (!sessionId) {
     return;
   }
   const target = sessionStatePath(stateRoot, provider);
   await ensureDir(path.dirname(target));
-  const payload = {
+  const payload: StoredSession = {
     provider,
     sessionId,
     updatedAt: now.toISOString(),
   };
+  if (systemContextHash !== undefined) {
+    payload.systemContextHash = systemContextHash;
+    payload.systemContextHashVersion = SYSTEM_CONTEXT_HASH_VERSION;
+  }
   await fs.writeFile(target, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }

--- a/runtime/javascript/src/types.ts
+++ b/runtime/javascript/src/types.ts
@@ -25,4 +25,6 @@ export interface StoredSession {
   provider: string;
   sessionId: string;
   updatedAt?: string;
+  systemContextHash?: string;
+  systemContextHashVersion?: number;
 }

--- a/runtime/javascript/test/runner-execution.test.ts
+++ b/runtime/javascript/test/runner-execution.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { captureStdio, runnerOptions, withTempSession } from "./helpers.js";
+import { hashSystemContext } from "../src/session-state.js";
 
 const codexState = vi.hoisted(() => ({
   constructorOptions: [] as Array<Record<string, unknown>>,
@@ -149,6 +150,8 @@ describe("runner execution", () => {
       });
       const stored = JSON.parse(await fs.readFile(path.join(root, "state", "agents", "providers", "codex.json"), "utf8"));
       expect(stored.sessionId).toBe("thread-new");
+      expect(stored.systemContextHash).toBe(hashSystemContext("catalog body"));
+      expect(stored.systemContextHashVersion).toBe(1);
     });
   });
 
@@ -193,6 +196,111 @@ describe("runner execution", () => {
         stdio.restore();
       }
       expect(codexState.resumed).toBe("old-thread");
+      const stored = JSON.parse(await fs.readFile(path.join(providerRoot, "codex.json"), "utf8"));
+      expect(stored.systemContextHash).toBe(hashSystemContext(""));
+      expect(stored.systemContextHashVersion).toBe(1);
+    });
+  });
+
+  it("resumes a stored Codex thread when the system context hash matches", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      const systemContext = "catalog body";
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        sessionId: "old-thread",
+        systemContextHash: hashSystemContext(systemContext),
+        systemContextHashVersion: 1,
+      }), "utf8");
+      codexState.events = [{ type: "item.completed", item: { id: "a2", type: "agent_message", text: "resumed" } }];
+      const stdio = captureStdio();
+      try {
+        const result = await new CodexRunner(runnerOptions(root, systemContext)).runPrompt("prompt");
+        expect(result.sessionId).toBe("thread-resumed");
+      } finally {
+        stdio.restore();
+      }
+      expect(codexState.resumed).toBe("old-thread");
+    });
+  });
+
+  it("starts a new Codex thread when the system context hash changes", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        sessionId: "old-thread",
+        systemContextHash: hashSystemContext("old context"),
+        systemContextHashVersion: 1,
+      }), "utf8");
+      codexState.events = [{ type: "item.completed", item: { id: "a3", type: "agent_message", text: "fresh" } }];
+      const stdio = captureStdio();
+      try {
+        const result = await new CodexRunner(runnerOptions(root, "new context")).runPrompt("prompt");
+        expect(result.sessionId).toBe("thread-new");
+        expect(stdio.stderr).toMatch(/warning: system context changed; started new Codex thread/);
+      } finally {
+        stdio.restore();
+      }
+      expect(codexState.resumed).toBe("");
+      const stored = JSON.parse(await fs.readFile(path.join(providerRoot, "codex.json"), "utf8"));
+      expect(stored.sessionId).toBe("thread-new");
+      expect(stored.systemContextHash).toBe(hashSystemContext("new context"));
+    });
+  });
+
+  it("starts a new Codex thread when the stored hash version is unsupported", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      const systemContext = "catalog body";
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        sessionId: "old-thread",
+        systemContextHash: hashSystemContext(systemContext),
+        systemContextHashVersion: 999,
+      }), "utf8");
+      codexState.events = [{ type: "item.completed", item: { id: "a3", type: "agent_message", text: "fresh" } }];
+      const stdio = captureStdio();
+      try {
+        const result = await new CodexRunner(runnerOptions(root, systemContext)).runPrompt("prompt");
+        expect(result.sessionId).toBe("thread-new");
+      } finally {
+        stdio.restore();
+      }
+      expect(codexState.resumed).toBe("");
+      const stored = JSON.parse(await fs.readFile(path.join(providerRoot, "codex.json"), "utf8"));
+      expect(stored.sessionId).toBe("thread-new");
+      expect(stored.systemContextHash).toBe(hashSystemContext(systemContext));
+      expect(stored.systemContextHashVersion).toBe(1);
+    });
+  });
+
+  it("starts a new Codex thread when system context changes from non-empty to empty", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        sessionId: "old-thread",
+        systemContextHash: hashSystemContext("old context"),
+        systemContextHashVersion: 1,
+      }), "utf8");
+      codexState.events = [{ type: "item.completed", item: { id: "a4", type: "agent_message", text: "cleared" } }];
+      const stdio = captureStdio();
+      try {
+        await new CodexRunner(runnerOptions(root)).runPrompt("prompt");
+        expect(stdio.stderr).toMatch(/warning: system context changed; started new Codex thread/);
+      } finally {
+        stdio.restore();
+      }
+      expect(codexState.resumed).toBe("");
     });
   });
 

--- a/runtime/javascript/test/session-state.test.ts
+++ b/runtime/javascript/test/session-state.test.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { readStoredSession, sessionStatePath, writeStoredSession } from "../src/session-state.js";
+import {
+  hashSystemContext,
+  readStoredSession,
+  sessionStatePath,
+  shouldResumeCodexThread,
+  writeStoredSession,
+} from "../src/session-state.js";
 import { withTempSession } from "./helpers.js";
 
 describe("provider session state", () => {
@@ -49,5 +55,80 @@ describe("provider session state", () => {
 
       await expect(fs.stat(sessionStatePath(stateRoot, "gemini"))).rejects.toMatchObject({ code: "ENOENT" });
     });
+  });
+
+  it("hashes system context deterministically", () => {
+    expect(hashSystemContext("catalog body")).toBe(hashSystemContext("catalog body"));
+    expect(hashSystemContext("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    expect(hashSystemContext("a")).not.toBe(hashSystemContext("b"));
+  });
+
+  it("writes and reads system context hash for Codex", async () => {
+    await withTempSession(async (root) => {
+      const stateRoot = path.join(root, "state");
+      const hash = hashSystemContext("catalog body");
+      const now = new Date("2026-01-01T00:00:00.000Z");
+
+      await writeStoredSession(stateRoot, "codex", "session-1", now, hash);
+
+      await expect(readStoredSession(stateRoot, "codex")).resolves.toEqual({
+        provider: "codex",
+        sessionId: "session-1",
+        updatedAt: now.toISOString(),
+        systemContextHash: hash,
+        systemContextHashVersion: 1,
+      });
+    });
+  });
+});
+
+describe("shouldResumeCodexThread", () => {
+  it("returns false when no stored session exists", () => {
+    expect(shouldResumeCodexThread(null, hashSystemContext(""))).toBe(false);
+  });
+
+  it("returns false when session id is missing", () => {
+    expect(shouldResumeCodexThread({ provider: "codex", sessionId: "" }, hashSystemContext(""))).toBe(false);
+  });
+
+  it("returns true for legacy state without a stored hash", () => {
+    expect(shouldResumeCodexThread({ provider: "codex", sessionId: "old-thread" }, hashSystemContext("ctx"))).toBe(true);
+  });
+
+  it("returns true when the stored hash and version match", () => {
+    const hash = hashSystemContext("ctx");
+    expect(shouldResumeCodexThread({
+      provider: "codex",
+      sessionId: "old-thread",
+      systemContextHash: hash,
+      systemContextHashVersion: 1,
+    }, hash)).toBe(true);
+  });
+
+  it("returns true when a legacy hashed state has no version", () => {
+    const hash = hashSystemContext("ctx");
+    expect(shouldResumeCodexThread({
+      provider: "codex",
+      sessionId: "old-thread",
+      systemContextHash: hash,
+    }, hash)).toBe(true);
+  });
+
+  it("returns false when the hash version does not match", () => {
+    const hash = hashSystemContext("ctx");
+    expect(shouldResumeCodexThread({
+      provider: "codex",
+      sessionId: "old-thread",
+      systemContextHash: hash,
+      systemContextHashVersion: 999,
+    }, hash)).toBe(false);
+  });
+
+  it("returns false when the stored hash differs", () => {
+    expect(shouldResumeCodexThread({
+      provider: "codex",
+      sessionId: "old-thread",
+      systemContextHash: hashSystemContext("old"),
+    }, hashSystemContext("new"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- This PR is a standalone follow-up to Phase 1 system prompt wiring, focused on Codex resume safety.
- Add a persisted `systemContext` hash gate in `codex.json` so runtime resumes only when context is unchanged; otherwise it starts a fresh thread.
- Work around upstream Codex resume behavior ([openai/codex#19045](https://github.com/openai/codex/issues/19045)) where updated `developer_instructions` may not be applied on the first resumed turn.

## Owner Decision Needed
@eetoc Should we keep this local adaptation before Codex upstream resolves the issue?

- **Option A: ship now**
  - Merge this safeguard and keep deterministic behavior in our runtime.
- **Option B: wait for upstream**
  - Do not ship this workaround yet; continue relying on current upstream resume behavior.

## What changed
- Persist `systemContextHash` and `systemContextHashVersion` for Codex provider state.
- Resume decision now requires compatible hash match; otherwise `startThread`.
- Legacy state without hash can resume once (lazy migration), then writes hash.
- Unsupported hash version forces fresh thread and rewrites current version.
- Emit stderr warning when hash mismatch triggers reset.
- Update design/contract docs to reflect Phase 1 follow-up behavior.

## Test plan
- [ ] Not started yet (manual validation has not started)
- [ ] Context unchanged -> resumes existing Codex thread
- [ ] Context changed -> starts fresh Codex thread
- [ ] Legacy `codex.json` without hash -> one-time resume + hash backfill
- [ ] Unsupported hash version -> forced fresh thread
- [ ] Warning visibility validated in stderr/log pipeline

## Notes
- Scope is runtime JS + docs only.
- No Go/Proto API schema changes.
- Other providers keep current behavior.

Made with [Cursor](https://cursor.com)