### PR TITLE
fix OctoBus token clearing

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -23,7 +23,7 @@ export async function getCapabilityGatewayConfig(): Promise<CapabilityGatewayCon
 }
 
 // updateCapabilityGatewayConfig saves the OctoBus connection. An empty token
-// keeps the existing one (the backend never returns the token).
+// clears the stored token.
 export async function updateCapabilityGatewayConfig(addr: string, token: string): Promise<CapabilityGatewayConfig> {
   const response = await configClient.updateCapabilityGatewayConfig({ addr, token });
   return { addr: response.addr, tokenSet: response.tokenSet };

--- a/frontend/src/pages/SettingsPage.svelte
+++ b/frontend/src/pages/SettingsPage.svelte
@@ -41,7 +41,7 @@
   let lastSyncedAt = '';
   let gatewayAddr = '';
   let savedGatewayAddr = '';
-  let gatewayToken = ''; // write-only; blank keeps the existing token
+  let gatewayToken = ''; // write-only; blank clears the existing token
   let gatewayTokenSet = false;
   let gatewaySaving = false;
 
@@ -698,7 +698,7 @@
     </div>
     <div class="description-grid compact">
       <label>OctoBus 地址<input bind:value={gatewayAddr} placeholder="http://127.0.0.1:9000"></label>
-      <label>访问 Token<input type="password" bind:value={gatewayToken} placeholder={gatewayTokenSet ? '已设置（留空保持不变）' : '可选'}></label>
+      <label>访问 Token<input type="password" bind:value={gatewayToken} placeholder={gatewayTokenSet ? '已设置（留空清空）' : '可选'}></label>
       <div><span>连接状态</span><b><span class="chip {gatewayStatusChip}">{gatewayStatusLabel}</span></b></div>
       <div><span>可用服务数量</span><b>{capabilityCount}</b></div>
       <div><span>最近同步</span><b>{formatDateTime(lastSyncedAt)}</b></div>

--- a/pkg/agentcompose/capability_e2e_test.go
+++ b/pkg/agentcompose/capability_e2e_test.go
@@ -129,10 +129,9 @@ func TestCapabilityGatewayControlPlaneE2E(t *testing.T) {
 	}
 }
 
-// TestCapabilityGatewayUpdatePreservesToken verifies that updating the addr
-// without supplying a token keeps the existing one (the read response never
-// echoes the token, so the UI cannot resend it).
-func TestCapabilityGatewayUpdatePreservesToken(t *testing.T) {
+// TestCapabilityGatewayUpdateClearsToken verifies that an empty token follows
+// the API contract and clears any previously saved OctoBus token.
+func TestCapabilityGatewayUpdateClearsToken(t *testing.T) {
 	ctx := context.Background()
 	configDB := newTestConfigStore(t)
 	service := &Service{configDB: configDB, cap: &capabilityProvider{source: configDB}}
@@ -140,16 +139,20 @@ func TestCapabilityGatewayUpdatePreservesToken(t *testing.T) {
 	if _, err := service.UpdateCapabilityGatewayConfig(ctx, connect.NewRequest(&agentcomposev1.UpdateCapabilityGatewayConfigRequest{Addr: "http://octo:9000", Token: "keep-me"})); err != nil {
 		t.Fatalf("initial update: %v", err)
 	}
-	if _, err := service.UpdateCapabilityGatewayConfig(ctx, connect.NewRequest(&agentcomposev1.UpdateCapabilityGatewayConfigRequest{Addr: "http://octo2:9000"})); err != nil {
-		t.Fatalf("addr-only update: %v", err)
+	cleared, err := service.UpdateCapabilityGatewayConfig(ctx, connect.NewRequest(&agentcomposev1.UpdateCapabilityGatewayConfigRequest{Addr: "http://octo:9000", Token: ""}))
+	if err != nil {
+		t.Fatalf("clear token update: %v", err)
+	}
+	if cleared.Msg.GetTokenSet() {
+		t.Fatalf("token_set = true after clear, want false")
 	}
 
 	settings, err := configDB.GetCapabilityGateway(ctx)
 	if err != nil {
 		t.Fatalf("get settings: %v", err)
 	}
-	if settings.Addr != "http://octo2:9000" || settings.Token != "keep-me" {
-		t.Fatalf("token not preserved on addr-only update: %+v", settings)
+	if settings.Addr != "http://octo:9000" || settings.Token != "" {
+		t.Fatalf("token not cleared: %+v", settings)
 	}
 }
 

--- a/pkg/agentcompose/capability_service.go
+++ b/pkg/agentcompose/capability_service.go
@@ -149,15 +149,6 @@ func (s *Service) GetCapabilityGatewayConfig(ctx context.Context, req *connect.R
 
 func (s *Service) UpdateCapabilityGatewayConfig(ctx context.Context, req *connect.Request[agentcomposev1.UpdateCapabilityGatewayConfigRequest]) (*connect.Response[agentcomposev1.CapabilityGatewayConfig], error) {
 	token := strings.TrimSpace(req.Msg.GetToken())
-	if token == "" {
-		// An empty token means "keep existing": the read response never returns
-		// the token, so the UI cannot echo it back when editing only the addr.
-		existing, err := s.configDB.GetCapabilityGateway(ctx)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		token = existing.Token
-	}
 	saved, err := s.configDB.SaveCapabilityGateway(ctx, CapabilityGatewaySettings{
 		Addr:  req.Msg.GetAddr(),
 		Token: token,


### PR DESCRIPTION
Fixes #103.

## Summary
- treat an empty OctoBus gateway token as a clear operation instead of preserving the old token
- update the gateway E2E test to verify token_set=false after clearing
- align frontend comments and Settings page copy with the clear-token behavior

## Validation
- go test ./pkg/agentcompose -run TestCapabilityGateway -count=1
- npm run check:ui