### PR TITLE
fix disabled capset listing

### DIFF
--- a/pkg/agentcompose/capability_e2e_test.go
+++ b/pkg/agentcompose/capability_e2e_test.go
@@ -36,6 +36,7 @@ func startFakeOctobus(t *testing.T) *fakeOctobus {
 		case r.URL.Path == "/admin/v1/capsets":
 			_ = json.NewEncoder(w).Encode(map[string]any{"capsets": []map[string]any{
 				{"id": "dev", "name": "Dev", "description": "dev capset", "enabled": true},
+				{"id": "disabled", "name": "Disabled", "description": "disabled capset", "enabled": false},
 			}})
 		case r.URL.Path == "/admin/v1/catalog/dev" && r.URL.Query().Get("format") == "md":
 			w.Header().Set("Content-Type", "text/markdown")
@@ -111,7 +112,9 @@ func TestCapabilityGatewayControlPlaneE2E(t *testing.T) {
 		t.Fatalf("OctoBus saw auth %q, want %q", octo.auth(), "Bearer secret")
 	}
 
-	// 4. Capsets and catalog flow through and are normalized.
+	// 4. Enabled capsets and catalog flow through and are normalized. Disabled
+	// capsets are hidden so callers cannot select capabilities OctoBus will
+	// reject at runtime.
 	capsets, err := service.ListCapabilitySets(ctx, connect.NewRequest(&agentcomposev1.ListCapabilitySetsRequest{}))
 	if err != nil {
 		t.Fatalf("list capsets: %v", err)

--- a/pkg/agentcompose/capability_service.go
+++ b/pkg/agentcompose/capability_service.go
@@ -120,6 +120,9 @@ func (s *Service) ListCapabilitySets(ctx context.Context, req *connect.Request[a
 	}
 	resp := &agentcomposev1.ListCapabilitySetsResponse{}
 	for _, item := range capsets {
+		if !item.Enabled {
+			continue
+		}
 		resp.Capsets = append(resp.Capsets, &agentcomposev1.CapabilitySet{
 			Id:          item.ID,
 			Name:        item.Name,


### PR DESCRIPTION
Fixes #102.

## Summary
- filter disabled OctoBus capsets from agent-compose ListCapabilitySets responses
- keep the UI capability picker aligned with capsets that OctoBus exposes at runtime
- extend the capability control-plane E2E test with a disabled capset fixture

## Validation
- go test ./pkg/agentcompose -run TestCapabilityGateway -count=1