### PR TITLE
feat: add proto-client package for publishing the generated client to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,22 @@ jobs:
           cache-dependency-path: runtime/javascript/package-lock.json
       - run: npm ci
       - run: npm run test:unit
+
+  proto-client:
+    name: Proto client build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: proto-client
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: proto-client/package-lock.json
+      - run: npm ci
+      - run: npm run gen
+      - run: npm run build

--- a/.github/workflows/publish-proto-client.yml
+++ b/.github/workflows/publish-proto-client.yml
@@ -1,0 +1,59 @@
+name: Publish proto client
+
+on:
+  push:
+    tags:
+      - "client-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish @chaitin-ai/agent-compose-client
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: proto-client
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: proto-client/package-lock.json
+
+      - name: Verify tag matches package version
+        if: github.event_name == 'push'
+        run: |
+          tag_version="${GITHUB_REF_NAME#client-v}"
+          package_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$package_version" ]; then
+            echo "::error::tag version '$tag_version' does not match package.json version '$package_version'"
+            exit 1
+          fi
+
+      - run: npm ci
+      - run: npm run gen
+      - run: npm run build
+
+      - name: Check npm token
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is required to publish @chaitin-ai/agent-compose-client"
+            exit 1
+          fi
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/.github/workflows/publish-proto-client.yml
+++ b/.github/workflows/publish-proto-client.yml
@@ -41,8 +41,6 @@ jobs:
           fi
 
       - run: npm ci
-      - run: npm run gen
-      - run: npm run build
 
       - name: Check npm token
         env:

--- a/proto-client/.gitignore
+++ b/proto-client/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+src/
+dist/
+*.tgz

--- a/proto-client/LICENSE
+++ b/proto-client/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/proto-client/README.md
+++ b/proto-client/README.md
@@ -1,0 +1,25 @@
+# @chaitin-ai/agent-compose-client
+
+agent-compose 的 ConnectRPC/protobuf TypeScript 客户端，由 `proto/` 生成。
+
+## 安装
+
+```bash
+npm install @chaitin-ai/agent-compose-client
+```
+
+## 使用
+
+```ts
+import { createPromiseClient } from "@connectrpc/connect";
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { HealthService } from "@chaitin-ai/agent-compose-client/health/v1/health_connect.js";
+
+const transport = createConnectTransport({ baseUrl: "/" });
+const health = createPromiseClient(HealthService, transport);
+```
+
+## 维护
+
+本包不提交生成代码；CI 在打 `client-v*` tag 时从 `proto/` 现生成并发布。
+本地可运行 `npm install && npm run gen && npm run build` 验证。

--- a/proto-client/package-lock.json
+++ b/proto-client/package-lock.json
@@ -1,0 +1,164 @@
+{
+  "name": "@chaitin-ai/agent-compose-client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@chaitin-ai/agent-compose-client",
+      "version": "0.1.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1"
+      },
+      "devDependencies": {
+        "@bufbuild/protoc-gen-es": "^1.10.1",
+        "@connectrpc/protoc-gen-connect-es": "^1.7.0",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@bufbuild/protoc-gen-es": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-1.10.1.tgz",
+      "integrity": "sha512-YADugbvibIdZSb0NGf5OF87IyKTuMvMFZ7vMHgm6pL1SCfDwJ/ZRianTdrPG9hq/gOipK+NwHmXBViyS3J7nxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1",
+        "@bufbuild/protoplugin": "1.10.1"
+      },
+      "bin": {
+        "protoc-gen-es": "bin/protoc-gen-es"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "1.10.1"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protoplugin": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-1.10.1.tgz",
+      "integrity": "sha512-LaSbfwabAFIvbVnbn8jWwElRoffCIxhVraO8arliVwWupWezHLXgqPHEYLXZY/SsAR+/YsFBQJa8tAGtNPJyaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.1",
+        "@typescript/vfs": "^1.4.0",
+        "typescript": "4.5.2"
+      }
+    },
+    "node_modules/@bufbuild/protoplugin/node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@connectrpc/protoc-gen-connect-es": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/protoc-gen-connect-es/-/protoc-gen-connect-es-1.7.0.tgz",
+      "integrity": "sha512-g2rE799dxGgXtwSTBOJoSlzCy3HN0IX/Es8uKsCgXRmco8o277/bb5nz1X8TmvBooCBGNdtEdUDG50olcvS9jQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@bufbuild/protoplugin": "^1.10.0"
+      },
+      "bin": {
+        "protoc-gen-connect-es": "bin/protoc-gen-connect-es"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protoc-gen-es": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protoc-gen-es": {
+          "optional": true
+        },
+        "@connectrpc/connect": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript/vfs": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.4.tgz",
+      "integrity": "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/proto-client/package.json
+++ b/proto-client/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@chaitin-ai/agent-compose-client",
+  "version": "0.1.0",
+  "description": "Generated ConnectRPC/protobuf client for agent-compose.",
+  "license": "LGPL-3.0-only",
+  "type": "module",
+  "exports": {
+    "./*": "./dist/*"
+  },
+  "files": ["dist"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chaitin/agent-compose.git",
+    "directory": "proto-client"
+  },
+  "homepage": "https://github.com/chaitin/agent-compose#readme",
+  "bugs": { "url": "https://github.com/chaitin/agent-compose/issues" },
+  "keywords": ["agent-compose", "connectrpc", "protobuf", "client"],
+  "engines": { "node": ">=20" },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "clean": "rm -rf src dist",
+    "gen": "rm -rf src && mkdir -p src && protoc --plugin=./node_modules/.bin/protoc-gen-es --plugin=./node_modules/.bin/protoc-gen-connect-es -I ../proto --es_out src --es_opt target=ts,import_extension=.js --connect-es_out src --connect-es_opt target=ts,import_extension=.js health/v1/health.proto agentcompose/v1/agentcompose.proto agentcompose/v2/agentcompose.proto",
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run gen && npm run build"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^1.10.1"
+  },
+  "devDependencies": {
+    "@bufbuild/protoc-gen-es": "^1.10.1",
+    "@connectrpc/protoc-gen-connect-es": "^1.7.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/proto-client/tsconfig.json
+++ b/proto-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds the infrastructure to publish a generated ConnectRPC/protobuf TypeScript client — `@chaitin-ai/agent-compose-client` — to public npm, so the frontend (to be moved to its own repo) can consume the API contract via `npm install` instead of carrying `proto/`.

## How

- **`proto-client/`** — a small, permanent packaging directory that lives next to `proto/`. It holds only config (`package.json`, `tsconfig.json`, `.gitignore`, `README.md`, `LICENSE`); the generated client code is **not** committed — CI generates it from `proto/` at publish time.
- **Publish workflow** (`.github/workflows/publish-proto-client.yml`) — triggered on `client-v*` tags: installs protoc, generates + builds, verifies the tag matches the package version, and runs `npm publish --access public --provenance`. Fails clearly if `NPM_TOKEN` is missing.
- **CI build-check** — a job in `ci.yml` runs gen + build on every PR so a `proto/` change cannot silently break the generated client.

## Notes

- **Non-breaking / purely additive.** The only existing file modified is `ci.yml` (one new job). `frontend/`, root `package.json`, `nginx/Dockerfile`, `Taskfile.yml`, and `docker-compose*.yml` are untouched — the current frontend keeps building exactly as before.
- Licensed `LGPL-3.0-only` (consistent with `@chaitin-ai/octobus-sdk`), appropriate for a consumed client library.
- **Before the first publish:** `NPM_TOKEN` must be available to this repo (org-level grant or a repo secret). Then tag `client-v0.1.0` to publish.
- Follow-up (separate work): move the frontend to its own repo and switch it to `npm install @chaitin-ai/agent-compose-client`.