### PR TITLE
chore: default guest image to ghcr

### DIFF
--- a/frontend/src/model/runtime.ts
+++ b/frontend/src/model/runtime.ts
@@ -1,0 +1,1 @@
+export const defaultGuestImage = 'ghcr.io/chaitin/agent-compose-guest:latest';

--- a/frontend/src/pages/AgentsPage.svelte
+++ b/frontend/src/pages/AgentsPage.svelte
@@ -16,14 +16,13 @@
   import { listCapabilitySets, listWorkspacePresets, type CapabilitySet, type WorkspacePreset } from '../api/config';
   import { appPath } from '../paths';
   import { formatBeijingTime } from '../time';
+  import { defaultGuestImage } from '../model/runtime';
   import { currentQueryParams, updateQueryParams } from '../url';
 
   type WorkSource = 'empty' | 'file' | 'git';
   type AgentDraft = AgentDefinition & {
     workSource: WorkSource;
   };
-
-  const defaultGuestImage = 'agent-compose-guest:latest';
 
   let agents: AgentDraft[] = [];
   let selectedAgent: AgentDraft | null = null;

--- a/frontend/src/pages/RunsPage.svelte
+++ b/frontend/src/pages/RunsPage.svelte
@@ -23,12 +23,12 @@
   } from '../api/sessions';
   import { automationRunToRun, sessionToRun, type ProductRun } from '../model/runs';
   import { CellType } from '../gen/proto/agentcompose/v1/agentcompose_pb.js';
+  import { defaultGuestImage } from '../model/runtime';
   import { appPath } from '../paths';
   import { formatBeijingTime } from '../time';
   import { currentQueryParams, updateQueryParams } from '../url';
 
   const dispatch = createEventDispatcher<{ debug: string }>();
-  const defaultGuestImage = 'agent-compose-guest:latest';
   type TerminalActionParams = { id?: string; text: string; running: boolean };
   type RunView = 'run' | 'agent' | 'task' | 'agent_task';
   type GroupTab = 'runs' | 'timeline' | 'artifacts' | 'automation';

--- a/frontend/src/pages/SettingsPage.svelte
+++ b/frontend/src/pages/SettingsPage.svelte
@@ -26,6 +26,7 @@
   } from '../api/config';
   import { getAuthStatus, type AuthStatus } from '../api/auth';
   import { formatBeijingTime } from '../time';
+  import { defaultGuestImage } from '../model/runtime';
   import { currentQueryParams, updateQueryParams } from '../url';
 
   let envItems: EnvItem[] = [];
@@ -54,8 +55,8 @@
   };
   let capabilitySets: CapabilitySetView[] = [];
   // System runtime image is fixed for now (managed at deploy time); shown
-  // read-only. Matches AgentsPage's defaultGuestImage.
-  const runtimeImage = 'agent-compose-guest:latest';
+  // read-only using the shared frontend default guest image.
+  const runtimeImage = defaultGuestImage;
   let authStatus: AuthStatus | null = null;
 
   type SettingsSection = 'workspace' | 'env' | 'runtime' | 'auth' | 'gateway' | 'webhook';


### PR DESCRIPTION
## 背景
当前前端在创建或运行智能体时，默认运行镜像写死为：
```text
agent-compose-guest:latest
```
该镜像名没有 registry 前缀，Docker 会默认从 Docker Hub 拉取：
```
docker.io/library/agent-compose-guest:latest
```
这个时候会导致 docker pulll 失败
