### PR TITLE
fix: use agent-compose-ui frontend image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ DEFAULT_IMAGE=debian:bookworm-slim
 
 # Images
 # AGENT_COMPOSE_IMAGE=ghcr.io/chaitin/agent-compose:latest
-# AGENT_COMPOSE_FRONTEND_IMAGE=ghcr.io/chaitin/agent-compose-frontend:latest
+# AGENT_COMPOSE_FRONTEND_IMAGE=ghcr.io/chaitin/agent-compose-ui:latest
 # AGENT_COMPOSE_HTTP_PORT=80
 IMAGE_STORE_MODE=auto
 # IMAGE_REGISTRY=docker.io

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -225,7 +225,7 @@ jobs:
           {
             echo "AGENT_COMPOSE_IMAGE=${IMAGE_PREFIX}/agent-compose:${VERSION}"
             echo "AGENT_COMPOSE_FRONTEND_VERSION=${frontend_version}"
-            echo "AGENT_COMPOSE_FRONTEND_IMAGE=${IMAGE_PREFIX}/agent-compose-frontend:${frontend_version}"
+            echo "AGENT_COMPOSE_FRONTEND_IMAGE=${IMAGE_PREFIX}/agent-compose-ui:${frontend_version}"
             echo "DEFAULT_IMAGE=${IMAGE_PREFIX}/agent-compose-guest:${VERSION}"
           } > "${payload}/images/manifest.env"
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ generated API client from the published
 package, which is built from this repository's `proto/` via `proto-client/`.
 
 The daemon does not host the Web UI. The frontend repository builds an nginx
-image (`ghcr.io/chaitin/agent-compose-frontend`) that serves the built UI and
+image (`ghcr.io/chaitin/agent-compose-ui`) that serves the built UI and
 reverse-proxies API and Jupyter routes to the daemon. The `docker-compose.yml`
 and `docker-compose.deploy.yml` here reference that published image.
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -28,7 +28,7 @@ AGENT_COMPOSE_IMAGE=ghcr.io/chaitin/agent-compose:latest
 # Frontend is released from agent-compose-ui. Keep latest by default, or pin a
 # specific frontend release when you need a reproducible full-stack install.
 AGENT_COMPOSE_FRONTEND_VERSION=latest
-AGENT_COMPOSE_FRONTEND_IMAGE=ghcr.io/chaitin/agent-compose-frontend:latest
+AGENT_COMPOSE_FRONTEND_IMAGE=ghcr.io/chaitin/agent-compose-ui:latest
 
 # ---------------------------------------------------------------------------
 # Runtime

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -124,7 +124,7 @@ apply_image_refs() { # $1=file $2=mode(set-missing|overwrite)
     for pair in \
       "AGENT_COMPOSE_IMAGE=${IMAGE_PREFIX}/agent-compose:${IMAGE_VERSION}" \
       "AGENT_COMPOSE_FRONTEND_VERSION=${FRONTEND_VERSION}" \
-      "AGENT_COMPOSE_FRONTEND_IMAGE=${IMAGE_PREFIX}/agent-compose-frontend:${FRONTEND_VERSION}" \
+      "AGENT_COMPOSE_FRONTEND_IMAGE=${IMAGE_PREFIX}/agent-compose-ui:${FRONTEND_VERSION}" \
       "DEFAULT_IMAGE=${IMAGE_PREFIX}/agent-compose-guest:${IMAGE_VERSION}"; do
       key="${pair%%=*}"
       value="${pair#*=}"

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -38,7 +38,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   agent-compose-frontend:
-    image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-frontend:latest}
+    image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-ui:latest}
     container_name: agent-compose-frontend
     restart: always
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   agent-compose-frontend:
-    image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-frontend:latest}
+    image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-ui:latest}
     container_name: agent-compose-frontend
     restart: always
     depends_on:

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -104,7 +104,7 @@ agent 常用字段：
 
 Web UI 在独立仓库 [agent-compose-ui](https://github.com/chaitin/agent-compose-ui)。它通过已发布的 [`@chaitin-ai/agent-compose-client`](https://www.npmjs.com/package/@chaitin-ai/agent-compose-client) 包消费 API 客户端——该包由本仓库的 `proto/` 经 `proto-client/` 生成发布。
 
-daemon 不托管 Web UI。前端仓库构建一个 nginx 镜像（`ghcr.io/chaitin/agent-compose-frontend`），负责托管构建后的前端并把 API、Jupyter proxy 路由反向代理到 daemon。本仓库的 `docker-compose.yml` 和 `docker-compose.deploy.yml` 直接引用该已发布镜像。
+daemon 不托管 Web UI。前端仓库构建一个 nginx 镜像（`ghcr.io/chaitin/agent-compose-ui`），负责托管构建后的前端并把 API、Jupyter proxy 路由反向代理到 daemon。本仓库的 `docker-compose.yml` 和 `docker-compose.deploy.yml` 直接引用该已发布镜像。
 
 ## 配置
 

--- a/playground/docker-compose.yml
+++ b/playground/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   agent-compose-frontend:
-    image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-frontend:latest}
+    image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-ui:latest}
     container_name: agent-compose-frontend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary
- point default frontend image refs at ghcr.io/chaitin/agent-compose-ui
- update installer manifest generation and deployment examples
- keep the compose service name unchanged as agent-compose-frontend

## Validation
- git diff --check
- bash -n deploy/install.sh