### PR TITLE
feat(driver): always-pull guest images so updated tags are picked up

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,7 @@ type Config struct {
 	JupyterGuestPort           int
 	SessionStartTimeout        time.Duration
 	SessionStopTimeout         time.Duration
+	ImagePullTimeout           time.Duration
 	JupyterProxyBasePath       string
 	CapGRPCListen              string
 	CapGRPCTarget              string
@@ -303,6 +304,17 @@ func NewConfig(di do.Injector) (*Config, error) {
 		}
 	}
 
+	imagePullTimeout := 10 * time.Minute
+	if raw := os.Getenv("IMAGE_PULL_TIMEOUT"); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err != nil {
+			logger.Warn("failed to parse IMAGE_PULL_TIMEOUT", "value", raw, "error", err)
+		} else if parsed <= 0 {
+			logger.Warn("ignored non-positive IMAGE_PULL_TIMEOUT", "value", raw)
+		} else {
+			imagePullTimeout = parsed
+		}
+	}
+
 	basicAuth := ""
 	if raw := os.Getenv("HTTP_BASIC_AUTH"); raw != "" {
 		if decoded, err := base64.StdEncoding.DecodeString(raw); err != nil {
@@ -487,6 +499,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		JupyterGuestPort:           jupyterGuestPort,
 		SessionStartTimeout:        startTimeout,
 		SessionStopTimeout:         stopTimeout,
+		ImagePullTimeout:           imagePullTimeout,
 		JupyterProxyBasePath:       jupyterProxyBase,
 		CapGRPCListen:              strings.TrimSpace(os.Getenv("CAP_GRPC_LISTEN")),
 		CapGRPCTarget:              strings.TrimSpace(os.Getenv("CAP_GRPC_TARGET")),

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -551,7 +551,7 @@ func (r *cgoBoxRuntime) materializeLocalImageRootfs(ctx context.Context, imageRe
 	layout, ok, err := resolveBoxliteImageLayout(ctx, imageRef, boxliteImageResolverOps{
 		dockerAvailable: dockerDaemonAvailable,
 		dockerMaterialize: func(ctx context.Context, imageRef string) (boxliteImageLayoutResult, bool, error) {
-			layout, ok, err := materializeLocalDockerImageLayout(ctx, r.config.DataRoot, imageRef)
+			layout, ok, err := materializeLocalDockerImageLayout(ctx, r.config.DataRoot, imageRef, r.config.ImagePullTimeout)
 			if err != nil || !ok {
 				return boxliteImageLayoutResult{}, ok, err
 			}

--- a/pkg/driver/boxlite_image_materialize_cgo.go
+++ b/pkg/driver/boxlite_image_materialize_cgo.go
@@ -4,6 +4,8 @@ package driver
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/imagecache"
@@ -18,14 +20,17 @@ func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Con
 	if err != nil {
 		return boxliteImageLayoutResult{}, false, err
 	}
-	result, err := cache.MaterializeOCILayout(ctx, imageRef)
-	if imagecache.IsKind(err, imagecache.ErrorKindNotFound) {
-		if _, pullErr := cache.Pull(ctx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
-			return boxliteImageLayoutResult{}, false, pullErr
-		}
-		result, err = cache.MaterializeOCILayout(ctx, imageRef)
+	pullCtx, pullCancel := context.WithTimeout(ctx, config.ImagePullTimeout)
+	_, pullErr := cache.Pull(pullCtx, imagecache.PullRequest{Reference: imageRef})
+	pullCancel()
+	if pullErr != nil {
+		slog.Warn("agent-compose boxlite: pull guest image failed, falling back to local cache", "image", imageRef, "error", pullErr)
 	}
+	result, err := cache.MaterializeOCILayout(ctx, imageRef)
 	if err != nil {
+		if imagecache.IsKind(err, imagecache.ErrorKindNotFound) && pullErr != nil {
+			return boxliteImageLayoutResult{}, false, fmt.Errorf("guest image %s not available: pull failed (%w) and not found in local cache", imageRef, pullErr)
+		}
 		return boxliteImageLayoutResult{}, false, err
 	}
 	return boxliteImageLayoutResult{

--- a/pkg/driver/docker_image.go
+++ b/pkg/driver/docker_image.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	pathpkg "path"
 	"strings"
+	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
 	distreference "github.com/distribution/reference"
@@ -15,7 +17,7 @@ import (
 	"github.com/docker/docker/client"
 )
 
-func ensureDockerImage(ctx context.Context, imageRef string) (string, error) {
+func ensureDockerImage(ctx context.Context, imageRef string, pullTimeout time.Duration) (string, error) {
 	imageRef = strings.TrimSpace(imageRef)
 	if imageRef == "" {
 		return "", nil
@@ -27,20 +29,32 @@ func ensureDockerImage(ctx context.Context, imageRef string) (string, error) {
 	}
 	defer func() { _ = dockerClient.Close() }()
 
-	if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
-		return resolvedRef, nil
-	} else if err != nil {
-		return "", fmt.Errorf("inspect guest image %s: %w", imageRef, err)
+	pullOK := true
+	var pullFailureErr error
+	pullCtx, pullCancel := context.WithTimeout(ctx, pullTimeout)
+	reader, pullErr := dockerClient.ImagePull(pullCtx, imageRef, typesimage.PullOptions{})
+	if pullErr != nil {
+		pullCancel()
+		slog.Warn("agent-compose docker: pull guest image failed, falling back to local cache", "image", imageRef, "error", pullErr)
+		pullOK = false
+		pullFailureErr = pullErr
+	} else {
+		if streamErr := consumeDockerPullStream(reader); streamErr != nil {
+			slog.Warn("agent-compose docker: pull guest image stream failed, falling back to local cache", "image", imageRef, "error", streamErr)
+			pullOK = false
+			pullFailureErr = streamErr
+		}
+		_ = reader.Close()
+		pullCancel()
 	}
 
-	reader, err := dockerClient.ImagePull(ctx, imageRef, typesimage.PullOptions{})
-	if err != nil {
-		return "", fmt.Errorf("pull guest image %s: %w", imageRef, err)
-	}
-	defer func() { _ = reader.Close() }()
-
-	if err := consumeDockerPullStream(reader); err != nil {
-		return "", fmt.Errorf("pull guest image %s: %w", imageRef, err)
+	if !pullOK {
+		if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
+			return resolvedRef, nil
+		} else if err != nil {
+			return "", fmt.Errorf("inspect local guest image %s after failed pull: %w", imageRef, err)
+		}
+		return "", fmt.Errorf("guest image %s not found locally and pull failed: %w", imageRef, pullFailureErr)
 	}
 
 	if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
@@ -48,11 +62,14 @@ func ensureDockerImage(ctx context.Context, imageRef string) (string, error) {
 	} else if err != nil {
 		return "", fmt.Errorf("inspect pulled guest image %s: %w", imageRef, err)
 	}
+	slog.Warn("agent-compose docker: pull reported success but guest image not found locally, falling back to original ref", "image", imageRef)
 	return imageRef, nil
 }
 
+const defaultImagePullTimeout = 10 * time.Minute
+
 func EnsureDockerImage(ctx context.Context, imageRef string) (string, error) {
-	return ensureDockerImage(ctx, imageRef)
+	return ensureDockerImage(ctx, imageRef, defaultImagePullTimeout)
 }
 
 func resolveLocalDockerImageRef(ctx context.Context, dockerClient *client.Client, imageRef string) (string, bool, error) {

--- a/pkg/driver/local_docker_oci.go
+++ b/pkg/driver/local_docker_oci.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,23 +49,36 @@ var (
 	_ = addOCIBlobFromBytes
 )
 
-func materializeLocalDockerImageRootfs(ctx context.Context, dataRoot, imageRef string) (localDockerImageRootfs, bool, error) {
+func materializeLocalDockerImageRootfs(ctx context.Context, dataRoot, imageRef string, pullTimeout time.Duration) (localDockerImageRootfs, bool, error) {
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return localDockerImageRootfs{}, false, nil
 	}
 	defer func() { _ = dockerClient.Close() }()
-	return materializeLocalDockerImageRootfsWithClient(ctx, dataRoot, dockerClient, imageRef)
+	return materializeLocalDockerImageRootfsWithClient(ctx, dataRoot, dockerClient, imageRef, pullTimeout)
 }
 
-func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot string, dockerClient *client.Client, imageRef string) (localDockerImageRootfs, bool, error) {
+func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot string, dockerClient *client.Client, imageRef string, pullTimeout time.Duration) (localDockerImageRootfs, bool, error) {
 	imageRef = strings.TrimSpace(imageRef)
 	if imageRef == "" {
 		return localDockerImageRootfs{}, false, nil
 	}
 
+	pullCtxRootfs, pullCancelRootfs := context.WithTimeout(ctx, pullTimeout)
+	if pullReader, pullErr := dockerClient.ImagePull(pullCtxRootfs, imageRef, typesimage.PullOptions{}); pullErr != nil {
+		pullCancelRootfs()
+		slog.Warn("agent-compose local-docker: pull guest image failed, falling back to local cache", "image", imageRef, "error", pullErr)
+	} else {
+		if streamErr := consumeDockerPullStream(pullReader); streamErr != nil {
+			slog.Warn("agent-compose local-docker: pull guest image stream failed, falling back to local cache", "image", imageRef, "error", streamErr)
+		}
+		_ = pullReader.Close()
+		pullCancelRootfs()
+	}
+
 	resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef)
 	if err != nil || !ok {
+		slog.Warn("agent-compose local-docker: guest image not available after pull (pull failed and not found locally), skipping this materialization path", "image", imageRef, "error", err)
 		return localDockerImageRootfs{}, false, nil
 	}
 
@@ -94,7 +108,7 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 	}
 	_ = os.Remove(readyFlag)
 
-	layout, layoutReady, _ := materializeLocalDockerImageLayoutWithClient(ctx, dataRoot, dockerClient, resolvedRef)
+	layout, layoutReady, _ := materializeLocalDockerImageLayoutWithClient(ctx, dataRoot, dockerClient, resolvedRef, pullTimeout, true)
 	if layoutReady {
 		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 			return localDockerImageRootfs{}, false, fmt.Errorf("create image cache dir: %w", err)
@@ -204,23 +218,38 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 	return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
 }
 
-func materializeLocalDockerImageLayout(ctx context.Context, dataRoot, imageRef string) (localDockerImageLayout, bool, error) {
+func materializeLocalDockerImageLayout(ctx context.Context, dataRoot, imageRef string, pullTimeout time.Duration) (localDockerImageLayout, bool, error) {
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return localDockerImageLayout{}, false, nil
 	}
 	defer func() { _ = dockerClient.Close() }()
-	return materializeLocalDockerImageLayoutWithClient(ctx, dataRoot, dockerClient, imageRef)
+	return materializeLocalDockerImageLayoutWithClient(ctx, dataRoot, dockerClient, imageRef, pullTimeout, false)
 }
 
-func materializeLocalDockerImageLayoutWithClient(ctx context.Context, dataRoot string, dockerClient *client.Client, imageRef string) (localDockerImageLayout, bool, error) {
+func materializeLocalDockerImageLayoutWithClient(ctx context.Context, dataRoot string, dockerClient *client.Client, imageRef string, pullTimeout time.Duration, skipPull bool) (localDockerImageLayout, bool, error) {
 	imageRef = strings.TrimSpace(imageRef)
 	if imageRef == "" {
 		return localDockerImageLayout{}, false, nil
 	}
 
+	if !skipPull {
+		pullCtxLayout, pullCancelLayout := context.WithTimeout(ctx, pullTimeout)
+		if pullReader, pullErr := dockerClient.ImagePull(pullCtxLayout, imageRef, typesimage.PullOptions{}); pullErr != nil {
+			pullCancelLayout()
+			slog.Warn("agent-compose local-docker: pull guest image layout failed, falling back to local cache", "image", imageRef, "error", pullErr)
+		} else {
+			if streamErr := consumeDockerPullStream(pullReader); streamErr != nil {
+				slog.Warn("agent-compose local-docker: pull guest image layout stream failed, falling back to local cache", "image", imageRef, "error", streamErr)
+			}
+			_ = pullReader.Close()
+			pullCancelLayout()
+		}
+	}
+
 	resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef)
 	if err != nil || !ok {
+		slog.Warn("agent-compose local-docker: guest image not available after pull (pull failed and not found locally), skipping this materialization path", "image", imageRef, "error", err)
 		return localDockerImageLayout{}, false, nil
 	}
 

--- a/pkg/driver/microsandbox_image_resolver.go
+++ b/pkg/driver/microsandbox_image_resolver.go
@@ -2,6 +2,8 @@ package driver
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
@@ -46,14 +48,17 @@ func materializeMicrosandboxOCIRootFS(ctx context.Context, config *appconfig.Con
 	if err != nil {
 		return microsandboxRootFSResult{}, false, err
 	}
-	result, err := cache.MaterializeRootFS(ctx, imageRef)
-	if imagecache.IsKind(err, imagecache.ErrorKindNotFound) {
-		if _, pullErr := cache.Pull(ctx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
-			return microsandboxRootFSResult{}, false, pullErr
-		}
-		result, err = cache.MaterializeRootFS(ctx, imageRef)
+	pullCtx, pullCancel := context.WithTimeout(ctx, config.ImagePullTimeout)
+	_, pullErr := cache.Pull(pullCtx, imagecache.PullRequest{Reference: imageRef})
+	pullCancel()
+	if pullErr != nil {
+		slog.Warn("agent-compose microsandbox: pull guest image failed, falling back to local cache", "image", imageRef, "error", pullErr)
 	}
+	result, err := cache.MaterializeRootFS(ctx, imageRef)
 	if err != nil {
+		if imagecache.IsKind(err, imagecache.ErrorKindNotFound) && pullErr != nil {
+			return microsandboxRootFSResult{}, false, fmt.Errorf("guest image %s not available: pull failed (%w) and not found in local cache", imageRef, pullErr)
+		}
 		return microsandboxRootFSResult{}, false, err
 	}
 	return microsandboxRootFSResult{

--- a/pkg/driver/microsandbox_image_resolver_error_test.go
+++ b/pkg/driver/microsandbox_image_resolver_error_test.go
@@ -1,0 +1,58 @@
+package driver
+
+// TestMaterializeMicrosandboxOCIRootFSErrorPropagationNoCachedImage verifies
+// the error propagation change from task A: when pull fails AND the image is
+// not in the local cache, materializeMicrosandboxOCIRootFS must return an error
+// that contains both "pull failed" and "not found in local cache", and the pull
+// cause must be reachable via errors unwrapping.
+//
+// This test calls the real driver function (not a replica), so reverting the
+// task-A change in microsandbox_image_resolver.go causes this test to FAIL.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	appconfig "agent-compose/pkg/config"
+)
+
+func TestMaterializeMicrosandboxOCIRootFSErrorPropagationNoCachedImage(t *testing.T) {
+	// Use a short timeout so the test fails fast when the registry is unreachable.
+	imageRef := "127.0.0.1:19999/no-such/image:latest"
+
+	config := &appconfig.Config{
+		// ImageCacheRoot points to an empty temp dir so there is no pre-cached image.
+		ImageCacheRoot: t.TempDir(),
+		// Mark the unreachable host as insecure so the client does not upgrade to TLS.
+		ImageInsecureRegistries: []string{"127.0.0.1:19999"},
+		// Short timeout to avoid blocking the test suite.
+		ImagePullTimeout: 2 * time.Second,
+	}
+
+	_, _, err := materializeMicrosandboxOCIRootFS(context.Background(), config, imageRef)
+	if err == nil {
+		t.Fatal("materializeMicrosandboxOCIRootFS returned nil error; want error with pull failure and not-found")
+	}
+
+	errMsg := err.Error()
+	t.Logf("error returned: %v", errMsg)
+
+	if !strings.Contains(errMsg, "pull failed") {
+		t.Errorf("error missing 'pull failed': %q", errMsg)
+	}
+	if !strings.Contains(errMsg, "not found in local cache") {
+		t.Errorf("error missing 'not found in local cache': %q", errMsg)
+	}
+
+	// The pull cause must be reachable: the error string should contain evidence
+	// of a pull/network failure (not just the not-found wrapper).
+	// We verify via strings.Contains rather than errors.Is because the exact
+	// pullErr type is internal to the imagecache package.
+	if !strings.Contains(errMsg, "127.0.0.1:19999") {
+		t.Errorf("error does not mention the unreachable host; pull cause may be lost: %q", errMsg)
+	}
+
+	t.Logf("PASS: error correctly carries both pull failure and not-found causes")
+}

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -753,7 +753,7 @@ func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, i
 	rootfs, ok, err := resolveMicrosandboxRootFS(ctx, imageRef, microsandboxImageResolverOps{
 		dockerAvailable: dockerDaemonAvailable,
 		dockerMaterialize: func(ctx context.Context, imageRef string) (microsandboxRootFSResult, bool, error) {
-			rootfs, ok, err := materializeLocalDockerImageRootfs(ctx, r.config.DataRoot, imageRef)
+			rootfs, ok, err := materializeLocalDockerImageRootfs(ctx, r.config.DataRoot, imageRef, r.config.ImagePullTimeout)
 			if err != nil || !ok {
 				return microsandboxRootFSResult{}, ok, err
 			}

--- a/pkg/driver/session_start.go
+++ b/pkg/driver/session_start.go
@@ -7,10 +7,11 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 )
 
 func PrepareSessionStart(ctx context.Context, config *appconfig.Config, driver string, session *Session, vmState VMState) (VMState, error) {
-	return prepareSessionStartWithResolver(ctx, config, driver, session, vmState, dockerFirstRuntimeImageResolver{ensureDocker: ensureDockerImage})
+	return prepareSessionStartWithResolver(ctx, config, driver, session, vmState, dockerFirstRuntimeImageResolver{ensureDocker: ensureDockerImage, pullTimeout: config.ImagePullTimeout})
 }
 
 func prepareSessionStartWithResolver(ctx context.Context, config *appconfig.Config, driver string, session *Session, vmState VMState, resolver runtimeImageResolver) (VMState, error) {
@@ -55,7 +56,8 @@ type runtimeImageResolver interface {
 }
 
 type dockerFirstRuntimeImageResolver struct {
-	ensureDocker func(context.Context, string) (string, error)
+	ensureDocker func(context.Context, string, time.Duration) (string, error)
+	pullTimeout  time.Duration
 }
 
 func (r dockerFirstRuntimeImageResolver) ResolvePrepareImage(ctx context.Context, config *appconfig.Config, driver, imageRef string) (string, error) {
@@ -69,7 +71,11 @@ func (r dockerFirstRuntimeImageResolver) ResolvePrepareImage(ctx context.Context
 		if ensure == nil {
 			ensure = ensureDockerImage
 		}
-		return ensure(ctx, imageRef)
+		pullTimeout := r.pullTimeout
+		if pullTimeout <= 0 {
+			pullTimeout = config.ImagePullTimeout
+		}
+		return ensure(ctx, imageRef, pullTimeout)
 	case RuntimeDriverBoxlite, RuntimeDriverMicrosandbox:
 		return imageRef, nil
 	default:

--- a/pkg/driver/session_start_test.go
+++ b/pkg/driver/session_start_test.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	appconfig "agent-compose/pkg/config"
 )
 
 func TestDockerFirstRuntimeImageResolverSkipsDockerForNonDockerPrepare(t *testing.T) {
 	called := false
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullTimeout time.Duration) (string, error) {
 		called = true
 		return "", errors.New("docker unavailable")
 	}}
@@ -33,7 +34,7 @@ func TestPrepareSessionStartBoxLiteDoesNotFailWhenDockerUnavailable(t *testing.T
 	root := t.TempDir()
 	config := testPrepareSessionStartConfig(root)
 	session := testRuntimeMountSession(root)
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullTimeout time.Duration) (string, error) {
 		return "", errors.New("docker unavailable")
 	}}
 
@@ -54,7 +55,7 @@ func TestPrepareSessionStartDockerStillRequiresDockerEnsure(t *testing.T) {
 	config := testPrepareSessionStartConfig(root)
 	session := testRuntimeMountSession(root)
 	wantErr := errors.New("docker unavailable")
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullTimeout time.Duration) (string, error) {
 		if imageRef != config.DockerDefaultImage {
 			t.Fatalf("ensure imageRef = %q, want %q", imageRef, config.DockerDefaultImage)
 		}
@@ -71,7 +72,7 @@ func TestPrepareSessionStartDockerUsesResolvedImage(t *testing.T) {
 	root := t.TempDir()
 	config := testPrepareSessionStartConfig(root)
 	session := testRuntimeMountSession(root)
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullTimeout time.Duration) (string, error) {
 		return "guest@sha256:resolved", nil
 	}}
 

--- a/pkg/imagecache/always_pull_integration_test.go
+++ b/pkg/imagecache/always_pull_integration_test.go
@@ -1,0 +1,125 @@
+package imagecache
+
+// Integration tests for the always-pull mechanism using an in-process httptest
+// registry. These tests do not require a Docker daemon.
+//
+// Two mechanisms are tested:
+//   1. Always-pull detects same-tag content update (imageID changes after push of new digest).
+//   2. Pull failure degrades to local cache (materialize still succeeds).
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+)
+
+// TestIntegrationAlwaysPullDetectsSameTagUpdate verifies that after pushing new
+// content under the same tag, a second Pull+MaterializeRootFS call returns a
+// different ImageID, proving that always-pull actually picked up the updated
+// image rather than serving the stale local cache.
+func TestIntegrationAlwaysPullDetectsSameTagUpdate(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(registry.New())
+	t.Cleanup(server.Close)
+	host := strings.TrimPrefix(server.URL, "http://")
+	refString := host + "/always-pull/app:latest"
+
+	cache := newPullTestCache(t, host)
+
+	// Push version A.
+	imgA := newRegistryTestImage(t, Platform{OS: "linux", Architecture: "amd64"}, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), map[string]string{"version": "A"})
+	pushTestImage(t, ctx, refString, imgA)
+
+	// Pull and materialize version A.
+	_, err := cache.Pull(ctx, PullRequest{Reference: refString, Platform: Platform{OS: "linux", Architecture: "amd64"}})
+	if err != nil {
+		t.Fatalf("Pull (version A) returned error: %v", err)
+	}
+	resultA, err := cache.MaterializeRootFS(ctx, refString)
+	if err != nil {
+		t.Fatalf("MaterializeRootFS (version A) returned error: %v", err)
+	}
+	imageIDA := resultA.ImageID
+	if imageIDA == "" {
+		t.Fatalf("MaterializeRootFS (version A) returned empty ImageID")
+	}
+	t.Logf("version A ImageID: %s", imageIDA)
+
+	// Push version B (different content, same tag — simulates registry update).
+	imgB := newRegistryTestImage(t, Platform{OS: "linux", Architecture: "amd64"}, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), map[string]string{"version": "B"})
+	pushTestImage(t, ctx, refString, imgB)
+
+	// Pull again — always-pull must fetch updated digest.
+	_, err = cache.Pull(ctx, PullRequest{Reference: refString, Platform: Platform{OS: "linux", Architecture: "amd64"}})
+	if err != nil {
+		t.Fatalf("Pull (version B) returned error: %v", err)
+	}
+	resultB, err := cache.MaterializeRootFS(ctx, refString)
+	if err != nil {
+		t.Fatalf("MaterializeRootFS (version B) returned error: %v", err)
+	}
+	imageIDB := resultB.ImageID
+	if imageIDB == "" {
+		t.Fatalf("MaterializeRootFS (version B) returned empty ImageID")
+	}
+	t.Logf("version B ImageID: %s", imageIDB)
+
+	if imageIDA == imageIDB {
+		t.Fatalf("always-pull did not detect content update: ImageID unchanged %s", imageIDA)
+	}
+	t.Logf("PASS: ImageID changed from %s to %s — always-pull replaced local cache", imageIDA, imageIDB)
+}
+
+// TestIntegrationAlwaysPullFallsBackToLocalOnRegistryFailure verifies that
+// when the registry becomes unreachable after a successful first pull (i.e.
+// the image exists in local cache), pull failure is tolerated and
+// MaterializeRootFS still succeeds using the cached image.
+func TestIntegrationAlwaysPullFallsBackToLocalOnRegistryFailure(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(registry.New())
+	host := strings.TrimPrefix(server.URL, "http://")
+	refString := host + "/fallback/app:latest"
+
+	cache := newPullTestCache(t, host)
+
+	// Push an image and pull it once so the local cache is populated.
+	img := newRegistryTestImage(t, Platform{OS: "linux", Architecture: "amd64"}, time.Now().UTC(), nil)
+	pushTestImage(t, ctx, refString, img)
+
+	_, err := cache.Pull(ctx, PullRequest{Reference: refString, Platform: Platform{OS: "linux", Architecture: "amd64"}})
+	if err != nil {
+		t.Fatalf("initial Pull returned error: %v", err)
+	}
+	firstResult, err := cache.MaterializeRootFS(ctx, refString)
+	if err != nil {
+		t.Fatalf("initial MaterializeRootFS returned error: %v", err)
+	}
+	t.Logf("initial ImageID: %s", firstResult.ImageID)
+
+	// Shut down the registry to simulate unavailability.
+	server.Close()
+
+	// Pull should fail (registry down); we ignore the pull error because the
+	// always-pull mechanism treats it as best-effort.
+	_, pullErr := cache.Pull(ctx, PullRequest{Reference: refString, Platform: Platform{OS: "linux", Architecture: "amd64"}})
+	if pullErr == nil {
+		t.Logf("Pull after server close returned nil (possibly cached by transport); continuing")
+	} else {
+		t.Logf("Pull after server close returned error (expected): %v", pullErr)
+	}
+
+	// MaterializeRootFS must still succeed using the local cache.
+	fallbackResult, err := cache.MaterializeRootFS(ctx, refString)
+	if err != nil {
+		t.Fatalf("MaterializeRootFS after registry failure returned error: %v", err)
+	}
+	if fallbackResult.ImageID == "" {
+		t.Fatalf("MaterializeRootFS returned empty ImageID after registry failure")
+	}
+	t.Logf("PASS: MaterializeRootFS succeeded with ImageID %s after registry became unreachable", fallbackResult.ImageID)
+}
+


### PR DESCRIPTION
## 问题

起 guest VM 时镜像拉取策略是 if-not-present：本地有该 tag 就不再 pull。结果同一个镜像 tag 在 registry 更新后（同 tag、新 digest），agent-compose 仍用本地旧缓存，新起的 VM 跑的是旧镜像。

## 改动

把 microsandbox / docker / boxlite 三个 driver 的镜像准备从 if-not-present 改成 **best-effort always-pull**：每次起 VM 先尝试 pull 刷新。物化层按内容 digest 寻址不变——digest 没变复用旧 rootfs，变了才重新解包，所以本地已是最新时不浪费。

健壮性：
- **best-effort 降级**：pull 失败时 warn 并降级用本地缓存，不让 VM 起不来；只有 pull 失败且本地也没有该镜像时才失败。
- **错误传播**：pull 失败且本地无缓存时，microsandbox / boxlite resolver 把 pull 真因（registry 不可达 / 鉴权失败等）包进返回的错误，便于排查。
- **pull 子超时**：新增 `IMAGE_PULL_TIMEOUT`（默认 10 分钟），registry 不可达时不再拖到 `SESSION_START_TIMEOUT`（30 分钟）才降级。子超时只裹 pull，不裹物化（大镜像解包仍用原 ctx）。

## 测试

- `pkg/imagecache`：用 httptest 内存 registry 的集成测试，验证「同 tag 更新被检测到」「pull 失败降级用本地」。
- `pkg/driver`：回归测试直接调真实 resolver，验证「pull 失败 + 本地无缓存」时错误同时带 pull 真因和 not-found。已做有效性验证（回退改动测试即 FAIL）。

## 备注

- always-pull 当前是写死的默认行为，未来可考虑做成可配置 / per-loader 开关。
