### PR TITLE
fix event session links and jupyter proxy prefix

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -63,6 +63,26 @@ server {
         access_log /var/log/nginx/agent-compose.jupyter.log agent_compose;
     }
 
+    location ~ ^/jupyter/ {
+        rewrite ^/jupyter/(.*)$ ${NGINX_JUPYTER_PROXY_BASE}/$1 break;
+        proxy_pass http://agent_compose_backend;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_buffering off;
+
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+        send_timeout 300s;
+
+        access_log /var/log/nginx/agent-compose.jupyter.log agent_compose;
+    }
+
     location ^~ /agentcompose.v1. {
         proxy_pass http://agent_compose_backend;
         proxy_http_version 1.1;

--- a/pkg/agentcompose/loader_manager.go
+++ b/pkg/agentcompose/loader_manager.go
@@ -692,6 +692,15 @@ func (h *loaderRunHost) CallSessionRPC(ctx context.Context, method, requestJSON 
 	return responseJSON, nil
 }
 
+func (h *loaderRunHost) addLinkedLoaderEvent(ctx context.Context, eventType, level, message string, payload any, linkedSessionID, linkedCellID, linkedAgentSessionID string) error {
+	event, err := h.manager.addLoaderEventRecord(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventType, level, message, payload, linkedSessionID, linkedCellID, linkedAgentSessionID)
+	if err != nil {
+		return err
+	}
+	h.addEventSessionLink(ctx, event, linkedSessionID, event.Type)
+	return nil
+}
+
 func (h *loaderRunHost) addEventSessionLink(ctx context.Context, event LoaderEvent, sessionID, relation string) {
 	if h == nil || h.manager == nil || h.manager.configDB == nil || strings.TrimSpace(sessionID) == "" || h.triggerEvent.EventID == "" {
 		return
@@ -704,6 +713,7 @@ func (h *loaderRunHost) addEventSessionLink(ctx context.Context, event LoaderEve
 		RunID:         h.run.ID,
 		TriggerID:     h.run.TriggerID,
 		LoaderEventID: event.ID,
+		CreatedAt:     event.CreatedAt,
 	}); err != nil {
 		slog.Warn("failed to add event session link", "event_id", h.triggerEvent.EventID, "session_id", sessionID, "run_id", h.run.ID, "error", err)
 	}
@@ -735,10 +745,10 @@ func (h *loaderRunHost) cleanupCommandSessions(ctx context.Context) {
 	for _, sessionID := range sessionIDs {
 		if err := h.manager.shutdownLoaderSession(ctx, sessionID); err != nil {
 			slog.Warn("failed to stop loader command session after run", "loader_id", h.loader.Summary.ID, "session_id", sessionID, "error", err)
-			_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, "loader.session.stop_failed", "error", err.Error(), map[string]any{"sessionId": sessionID}, sessionID, "", "")
+			_ = h.addLinkedLoaderEvent(ctx, "loader.session.stop_failed", "error", err.Error(), map[string]any{"sessionId": sessionID}, sessionID, "", "")
 			continue
 		}
-		_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, "loader.session.stopped", "info", "loader command session stopped after run", map[string]any{"sessionId": sessionID}, sessionID, "", "")
+		_ = h.addLinkedLoaderEvent(ctx, "loader.session.stopped", "info", "loader command session stopped after run", map[string]any{"sessionId": sessionID}, sessionID, "", "")
 	}
 }
 
@@ -766,7 +776,7 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 		return LoaderAgentResult{}, err
 	}
 	if eventType != "" {
-		_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventType, "info", "loader session ready", map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedLoaderEvent(ctx, eventType, "info", "loader session ready", map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 
 	agentConfig := agentExecutionConfig{Provider: normalizeAgentKind(request.Agent)}
@@ -825,7 +835,7 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 		eventName = "loader.agent.failed"
 		result.Text = firstNonEmpty(result.Text, execErr.Error())
 	}
-	_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventName, level, firstNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SessionID, result.CellID, result.AgentSessionID)
+	_ = h.addLinkedLoaderEvent(ctx, eventName, level, firstNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SessionID, result.CellID, result.AgentSessionID)
 	h.manager.Publish("agent-compose.agent.completed", map[string]any{
 		"sessionId":      result.SessionID,
 		"cellId":         result.CellID,
@@ -839,9 +849,9 @@ func (h *loaderRunHost) Agent(ctx context.Context, prompt string, request Loader
 	shutdownErr := h.manager.shutdownLoaderSession(ctx, session.Summary.ID)
 	if shutdownErr != nil {
 		slog.Warn("failed to stop loader session after agent run", "loader_id", h.loader.Summary.ID, "session_id", session.Summary.ID, "error", shutdownErr)
-		_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, "loader.session.stop_failed", "error", shutdownErr.Error(), map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedLoaderEvent(ctx, "loader.session.stop_failed", "error", shutdownErr.Error(), map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
 	} else {
-		_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, "loader.session.stopped", "info", "loader session stopped after agent run", map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedLoaderEvent(ctx, "loader.session.stopped", "info", "loader session stopped after agent run", map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 	if execErr != nil {
 		return result, execErr
@@ -887,7 +897,7 @@ func (h *loaderRunHost) ProjectAgent(ctx context.Context, prompt string, request
 		eventName = "loader.agent.failed"
 		result.Text = firstNonEmpty(result.Text, run.Error, execErrString(execErr))
 	}
-	_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventName, level, firstNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SessionID, result.CellID, result.AgentSessionID)
+	_ = h.addLinkedLoaderEvent(ctx, eventName, level, firstNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SessionID, result.CellID, result.AgentSessionID)
 	h.manager.Publish("agent-compose.agent.completed", map[string]any{
 		"sessionId":      result.SessionID,
 		"cellId":         result.CellID,
@@ -973,20 +983,20 @@ func (h *loaderRunHost) Command(ctx context.Context, request LoaderCommandReques
 		return LoaderCommandResult{}, err
 	}
 	if eventType != "" {
-		_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventType, "info", "loader command session ready", map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedLoaderEvent(ctx, eventType, "info", "loader command session ready", map[string]any{"sessionId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 	h.trackCommandSession(session.Summary.ID, cleanupSession)
 
 	result, err := h.manager.executor.ExecuteLoaderCommand(ctx, session, request)
 	if err != nil {
-		_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, "loader.command.failed", "error", err.Error(), loaderCommandEventPayload(request, result), result.SessionID, result.CellID, "")
+		_ = h.addLinkedLoaderEvent(ctx, "loader.command.failed", "error", err.Error(), loaderCommandEventPayload(request, result), result.SessionID, result.CellID, "")
 		return result, err
 	}
 	level := "info"
 	if !result.Success {
 		level = "error"
 	}
-	_ = h.manager.addLoaderEvent(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, "loader.command.completed", level, firstNonEmpty(result.Output, result.Stdout, result.Stderr, "loader command completed"), loaderCommandEventPayload(request, result), result.SessionID, result.CellID, "")
+	_ = h.addLinkedLoaderEvent(ctx, "loader.command.completed", level, firstNonEmpty(result.Output, result.Stdout, result.Stderr, "loader command completed"), loaderCommandEventPayload(request, result), result.SessionID, result.CellID, "")
 	return result, nil
 }
 

--- a/pkg/agentcompose/topic_event_store_test.go
+++ b/pkg/agentcompose/topic_event_store_test.go
@@ -574,6 +574,79 @@ func TestLoaderRunHostPublishEventStoresDerivedEvent(t *testing.T) {
 	}
 }
 
+func TestLoaderRunHostLinkedLoaderEventStoresEventSessionLink(t *testing.T) {
+	ctx := context.Background()
+	store := newTopicEventTestConfigStore(t)
+	manager := &LoaderManager{configDB: store}
+	loader := createTestLoader(t, ctx, store)
+	run := LoaderRunSummary{
+		ID:            "run-link",
+		LoaderID:      loader.Summary.ID,
+		TriggerID:     "trigger-link",
+		TriggerKind:   LoaderTriggerKindEvent,
+		TriggerSource: "event",
+		Status:        LoaderRunStatusRunning,
+		StartedAt:     time.Now().UTC(),
+	}
+	if err := store.CreateLoaderRun(ctx, run); err != nil {
+		t.Fatalf("CreateLoaderRun returned error: %v", err)
+	}
+	host := &loaderRunHost{
+		manager: manager,
+		loader:  loader,
+		run:     &run,
+		triggerEvent: loaderTriggerEventMetadata{
+			EventID: "evt-link",
+		},
+	}
+
+	if err := host.addLinkedLoaderEvent(ctx, "loader.command.completed", "info", "command completed", map[string]any{"sessionId": "session-link"}, "session-link", "cell-link", ""); err != nil {
+		t.Fatalf("addLinkedLoaderEvent returned error: %v", err)
+	}
+	links, err := store.ListEventSessionLinks(ctx, []string{"evt-link"})
+	if err != nil {
+		t.Fatalf("ListEventSessionLinks returned error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("event session links = %#v, want one link", links)
+	}
+	link := links[0]
+	if link.EventID != "evt-link" || link.SessionID != "session-link" || link.Relation != "loader.command.completed" {
+		t.Fatalf("event session link identity = %#v", link)
+	}
+	if link.LoaderID != loader.Summary.ID || link.RunID != "run-link" || link.TriggerID != "trigger-link" || link.LoaderEventID == "" {
+		t.Fatalf("event session link metadata = %#v", link)
+	}
+
+	noEventRun := LoaderRunSummary{
+		ID:            "run-no-event",
+		LoaderID:      loader.Summary.ID,
+		TriggerID:     "trigger-link",
+		TriggerKind:   LoaderTriggerKindEvent,
+		TriggerSource: "event",
+		Status:        LoaderRunStatusRunning,
+		StartedAt:     time.Now().UTC(),
+	}
+	if err := store.CreateLoaderRun(ctx, noEventRun); err != nil {
+		t.Fatalf("CreateLoaderRun without trigger event returned error: %v", err)
+	}
+	noEventHost := &loaderRunHost{
+		manager: manager,
+		loader:  loader,
+		run:     &noEventRun,
+	}
+	if err := noEventHost.addLinkedLoaderEvent(ctx, "loader.command.completed", "info", "command completed", nil, "session-no-event", "", ""); err != nil {
+		t.Fatalf("addLinkedLoaderEvent without trigger event returned error: %v", err)
+	}
+	links, err = store.ListEventSessionLinks(ctx, []string{"evt-link"})
+	if err != nil {
+		t.Fatalf("ListEventSessionLinks after no-event run returned error: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("event session links after no-event run = %#v, want original link only", links)
+	}
+}
+
 func TestConfigStoreEventSchemaCreated(t *testing.T) {
 	store := newTopicEventTestConfigStore(t)
 	var name string


### PR DESCRIPTION
## Summary

- write event_session_link records when loader events are created with linked sessions for event-triggered runs
- keep event/session trace lookup backed by explicit links instead of query-time inference
- add nginx compatibility for devboard prefix stripping so /jupyter/... reaches the configured Jupyter proxy base

## Root Cause

Loader runs were recording linked sessions on loader_event, but most host paths did not also persist event_session_link. Event detail pages read event_session_link directly, so event-triggered sessions could appear missing.

For Jupyter, devboard forwards /agent-compose/jupyter/... to the 212 deployment as /jupyter/..., while the backend is configured with JUPYTER_PROXY_BASE=/agent-compose/jupyter. The nginx fallback was returning the frontend app for /jupyter/... instead of proxying it.

## Validation

- go test ./pkg/agentcompose -run TestLoaderRunHostLinkedLoaderEventStoresEventSessionLink
- go test ./pkg/agentcompose
- nginx -t with JUPYTER_PROXY_BASE=/jupyter
- nginx -t with JUPYTER_PROXY_BASE=/agent-compose/jupyter
- verified /jupyter/... on 10.2.96.212 returns JupyterLab after the nginx template update
