### PR TITLE
fix loader LLM facade responses proxy

### DIFF
--- a/pkg/agentcompose/exec.go
+++ b/pkg/agentcompose/exec.go
@@ -119,6 +119,13 @@ func (e *Executor) ExecuteLoaderCommand(ctx context.Context, session *Session, r
 		CreatedAt: startedAt,
 		Running:   true,
 	}
+	execSession, facadeToken, err := e.prepareLoaderCommandLLMFacadeEnv(ctx, session, request, cellID)
+	if err != nil {
+		return LoaderCommandResult{}, err
+	}
+	if e.configDB != nil && facadeToken != "" {
+		defer func() { _ = e.configDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), facadeToken) }()
+	}
 	if err := e.store.AddCell(ctx, session, cell); err != nil {
 		return LoaderCommandResult{}, err
 	}
@@ -230,7 +237,7 @@ func (e *Executor) ExecuteLoaderCommand(ctx context.Context, session *Session, r
 		}
 		e.streams.PublishCellOutput(session.Summary.ID, snapshot.ID, chunk.Text, chunk.IsStderr)
 	}
-	execResult, err := runtime.ExecStream(execCtx, session, vmState, buildLoaderCommandExecSpec(e.config, session, filepath.Join(guestCellDir, "command-request.json")), streamWriter)
+	execResult, err := runtime.ExecStream(execCtx, execSession, vmState, buildLoaderCommandExecSpec(e.config, execSession, filepath.Join(guestCellDir, "command-request.json")), streamWriter)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()
@@ -290,6 +297,65 @@ func (e *Executor) ExecuteLoaderCommand(ctx context.Context, session *Session, r
 		CellID:          cellID,
 		Artifacts:       artifacts,
 	}, nil
+}
+
+func (e *Executor) prepareLoaderCommandLLMFacadeEnv(ctx context.Context, session *Session, request LoaderCommandRequest, runID string) (*Session, string, error) {
+	if e == nil || e.config == nil || e.configDB == nil || session == nil {
+		return session, "", nil
+	}
+	agent, model := loaderCommandLLMFacadeAgentModel(request.Env)
+	if agent == "" {
+		return session, "", nil
+	}
+
+	execSession := *session
+	execSession.EnvItems = append([]SessionEnvVar(nil), session.EnvItems...)
+	execSession.RuntimeEnvItems = append([]SessionEnvVar(nil), session.RuntimeEnvItems...)
+	execSession.ProviderEnvItems = append([]SessionEnvVar(nil), session.ProviderEnvItems...)
+	if len(execSession.ProviderEnvItems) == 0 {
+		globalEnv, err := e.configDB.ListGlobalEnv(ctx)
+		if err != nil {
+			return nil, "", err
+		}
+		providerEnv := mergeEnvItems(globalEnv, session.EnvItems)
+		providerEnv = mergeEnvItems(providerEnv, request.SessionEnv)
+		execSession.ProviderEnvItems = providerEnv
+	}
+
+	managedEnv, err := ensureSessionLLMFacadeConfig(ctx, e.config, e.configDB, &execSession, agent, model, llmFacadeTokenSourceLoaderCommand, runID)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(managedEnv) > 0 {
+		execSession.RuntimeEnvItems = mergeEnvItems(execSession.RuntimeEnvItems, envItemsFromMap(managedEnv, false))
+	}
+	return &execSession, managedEnv["AGENT_COMPOSE_SESSION_TOKEN"], nil
+}
+
+func loaderCommandLLMFacadeAgentModel(env map[string]string) (string, string) {
+	if env == nil {
+		return "codex", ""
+	}
+	agent := normalizeAgentKind(firstNonEmpty(
+		env["PROJECT_AGENT_PROVIDER"],
+		env["AGENT_PROVIDER"],
+		env["AGENT_COMPOSE_PROVIDER"],
+		"codex",
+	))
+	switch agent {
+	case "codex":
+		return agent, firstNonEmpty(env["CODEX_MODEL"], env["LLM_MODEL"])
+	case "claude":
+		return agent, firstNonEmpty(env["ANTHROPIC_MODEL"], env["CLAUDE_MODEL"], env["LLM_MODEL"])
+	case "opencode":
+		model := firstNonEmpty(env["OPENCODE_MODEL"], env["LLM_MODEL"])
+		if strings.TrimSpace(model) == "" {
+			return "", ""
+		}
+		return agent, model
+	default:
+		return "", ""
+	}
 }
 
 func (e *Executor) executeCell(ctx context.Context, session *Session, cellType, source string, stream CellExecutionStream) (NotebookCell, error) {

--- a/pkg/agentcompose/llm_client.go
+++ b/pkg/agentcompose/llm_client.go
@@ -428,8 +428,21 @@ func normalizeLLMAPIEndpointForProtocol(raw, protocol string) string {
 		parsed.Path = "/v1/chat/completions"
 		return parsed.String()
 	}
-	if protocol == llmAPIProtocolChatCompletions && strings.TrimRight(parsed.Path, "/") == "/v1" {
+	cleanPath := strings.TrimRight(parsed.Path, "/")
+	if protocol == llmAPIProtocolChatCompletions && (cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/openai/v1")) {
 		parsed.Path = pathpkg.Join(parsed.Path, "/chat/completions")
+		return parsed.String()
+	}
+	if protocol == llmAPIProtocolChatCompletions && strings.HasSuffix(cleanPath, "/openai") {
+		parsed.Path = pathpkg.Join(parsed.Path, "/v1/chat/completions")
+		return parsed.String()
+	}
+	if protocol == llmAPIProtocolResponses && strings.HasSuffix(cleanPath, "/openai") {
+		parsed.Path = pathpkg.Join(parsed.Path, "/v1/responses")
+		return parsed.String()
+	}
+	if protocol == llmAPIProtocolResponses && strings.HasSuffix(cleanPath, "/openai/v1") {
+		parsed.Path = pathpkg.Join(parsed.Path, "/responses")
 		return parsed.String()
 	}
 	if strings.TrimSpace(parsed.Path) == "" || parsed.Path == "/" {

--- a/pkg/agentcompose/llm_client_test.go
+++ b/pkg/agentcompose/llm_client_test.go
@@ -62,6 +62,19 @@ func TestNormalizeLLMAPIEndpointKeepsExplicitPath(t *testing.T) {
 	}
 }
 
+func TestLLMEndpointForProviderBaseURLAppendsProtocolPath(t *testing.T) {
+	provider := LLMProvider{
+		ProviderType: llmProviderFamilyOpenAI,
+		BaseURL:      "https://openai-compatible.example.invalid/openai",
+	}
+	if got := llmEndpointForProvider(provider, llmAPIProtocolChatCompletions); got != "https://openai-compatible.example.invalid/openai/v1/chat/completions" {
+		t.Fatalf("llmEndpointForProvider chat = %q, want provider base URL plus chat path", got)
+	}
+	if got := llmEndpointForProvider(provider, llmAPIProtocolResponses); got != "https://openai-compatible.example.invalid/openai/v1/responses" {
+		t.Fatalf("llmEndpointForProvider responses = %q, want provider base URL plus responses path", got)
+	}
+}
+
 func TestLLMClientGenerateHandlesSuccessAndFailures(t *testing.T) {
 	testLLMClientGenerateHandlesSuccessAndFailures(t)
 }

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -898,7 +898,7 @@ func selectLLMProviderForModel(ctx context.Context, store *ConfigStore, provider
 	providerID = strings.TrimSpace(providerID)
 	var candidates []candidate
 	for _, provider := range providers {
-		if providerFamily != "" && normalizeLLMProviderType(provider.ProviderType) != providerFamily {
+		if providerID == "" && providerFamily != "" && normalizeLLMProviderType(provider.ProviderType) != providerFamily {
 			continue
 		}
 		if providerID != "" && provider.ID != providerID {

--- a/pkg/agentcompose/llm_facade.go
+++ b/pkg/agentcompose/llm_facade.go
@@ -3,6 +3,7 @@ package agentcompose
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -114,6 +115,14 @@ func (s *Service) handleRuntimeLLM(c echo.Context, inboundProtocol protocolbridg
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
+	if inboundProtocol == protocolbridge.ProtocolOpenAIResponses && upstreamProtocol == protocolbridge.ProtocolOpenAIResponses {
+		upstreamBody, err := rewriteRuntimeLLMRequestModel(body, target.Model.Name)
+		if err != nil {
+			raw, status := inboundAdapter.EncodeError(err)
+			return writeRuntimeLLMEncodedError(c, raw, status)
+		}
+		return s.proxyRuntimeLLMTransparent(c, upstreamEndpoint, upstreamBody, target)
+	}
 	upstreamBody, err := encodeRuntimeLLMUpstreamRequest(inboundProtocol, upstreamProtocol, target, llmReq)
 	if err != nil {
 		raw, status := inboundAdapter.EncodeError(err)
@@ -156,6 +165,47 @@ func (s *Service) handleRuntimeLLM(c echo.Context, inboundProtocol protocolbridg
 	c.Response().WriteHeader(resp.StatusCode)
 	_, err = c.Response().Writer.Write(clientBody)
 	return err
+}
+
+func (s *Service) proxyRuntimeLLMTransparent(c echo.Context, upstreamEndpoint string, body []byte, target LLMResolvedTarget) error {
+	upstreamReq, err := http.NewRequestWithContext(c.Request().Context(), http.MethodPost, upstreamEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "create upstream llm request failed"})
+	}
+	copyRuntimeLLMHeaders(upstreamReq.Header, c.Request().Header)
+	applyLLMForwardHeaders(upstreamReq.Header, target.Headers)
+	resp, err := s.llm.client.Do(upstreamReq)
+	if err != nil {
+		return c.JSON(http.StatusBadGateway, map[string]string{"error": "call upstream llm failed"})
+	}
+	defer func() { _ = resp.Body.Close() }()
+	copyRuntimeLLMResponseHeaders(c.Response().Header(), resp.Header)
+	c.Response().WriteHeader(resp.StatusCode)
+	if err := copyRuntimeLLMResponseBody(c.Response().Writer, resp); err != nil && !errors.Is(err, http.ErrAbortHandler) {
+		return err
+	}
+	return nil
+}
+
+func rewriteRuntimeLLMRequestModel(body []byte, model string) ([]byte, error) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return body, nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	var current string
+	if err := json.Unmarshal(payload["model"], &current); err == nil && current == model {
+		return body, nil
+	}
+	modelJSON, err := json.Marshal(model)
+	if err != nil {
+		return nil, err
+	}
+	payload["model"] = modelJSON
+	return json.Marshal(payload)
 }
 
 func llmProtocolAdapter(protocol protocolbridge.Protocol) (protocolbridge.Adapter, error) {

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -120,14 +120,14 @@ func TestRuntimeLLMFacadeFlushesSSEResponses(t *testing.T) {
 	service, _, _ := newTestServiceAPIHarness(t)
 	service.config.LLMAPIKey = "provider-key"
 
+	const upstreamEvents = "event: message\ndata: hello\n\nevent: done\ndata: [DONE]\n\n"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("event: message\ndata: hello\n\n"))
+		_, _ = w.Write([]byte(upstreamEvents))
 		if flusher, ok := w.(http.Flusher); ok {
 			flusher.Flush()
 		}
-		_, _ = w.Write([]byte("event: done\ndata: [DONE]\n\n"))
 	}))
 	t.Cleanup(upstream.Close)
 	service.config.LLMAPIEndpoint = upstream.URL
@@ -165,7 +165,7 @@ func TestRuntimeLLMFacadeFlushesSSEResponses(t *testing.T) {
 	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
 		t.Fatalf("Content-Type = %q, want text/event-stream", got)
 	}
-	if body := rec.Body.String(); !strings.Contains(body, "event: raw") || !strings.Contains(body, "event: response.completed") {
+	if body := rec.Body.String(); body != upstreamEvents {
 		t.Fatalf("unexpected SSE body: %q", body)
 	}
 }
@@ -1096,6 +1096,38 @@ func TestSessionEnvProviderSelectionUsesAgentFamilyPreference(t *testing.T) {
 	}
 }
 
+func TestCodexFacadeCanUseAnthropicOnlySessionEnvProvider(t *testing.T) {
+	ctx := context.Background()
+	for _, k := range []string{"LLM_API_ENDPOINT", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_MODEL", "ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL", "CLAUDE_MODEL"} {
+		t.Setenv(k, "")
+	}
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+
+	session := createRunningLLMFacadeSession(t, ctx, service, "session-env-anthropic-only-codex")
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://session-anthropic.example.invalid"},
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "session-anthropic-token", Secret: true},
+		{Name: "ANTHROPIC_MODEL", Value: "kimi-k2.6"},
+	}
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "codex", "", "test", "run-codex")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig(codex) returned error: %v", err)
+	}
+	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	wantProviderID := sessionEnvProviderID(session.Summary.ID, llmProviderFamilyAnthropic)
+	if token.ProviderID != wantProviderID || token.Model != "kimi-k2.6" || token.WireAPI != llmAPIProtocolResponses {
+		t.Fatalf("facade token = %#v, want provider %q, model kimi-k2.6, responses facade", token, wantProviderID)
+	}
+}
+
 func TestDaemonEnvProviderSelectionUsesAgentFamilyPreference(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("LLM_API_ENDPOINT", "")
@@ -1572,19 +1604,41 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 	}
 
 	t.Run("openai_responses", func(t *testing.T) {
+		const requestBody = `{"model":"alias-resp","input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}],"metadata":{"keep":"exact"}}`
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Authorization") != "Bearer provider-key" {
 				t.Errorf("upstream auth = %q", r.Header.Get("Authorization"))
+			}
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upstream body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Errorf("decode upstream body: %v", err)
+			}
+			if got["model"] != "m-resp" {
+				t.Errorf("upstream model = %v, want resolved provider model", got["model"])
+			}
+			if metadata, _ := got["metadata"].(map[string]any); metadata["keep"] != "exact" {
+				t.Errorf("upstream metadata = %#v, want preserved request fields", got["metadata"])
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"resp-e2e","model":"m-resp","status":"completed","output_text":"ok"}`))
 		}))
 		t.Cleanup(upstream.Close)
 		service.llm.client = upstream.Client()
-		upsertProvider(t, "e2e-openai-resp", llmProviderFamilyOpenAI, llmAPIProtocolResponses, upstream.URL, "Authorization", "Bearer", "m-resp")
+		upsertProvider(t, "e2e-openai-resp", llmProviderFamilyOpenAI, llmAPIProtocolResponses, upstream.URL, "Authorization", "Bearer", "alias-resp")
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-openai-resp", Name: "e2e-openai-resp", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolResponses,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "Authorization", AuthScheme: "Bearer",
+			Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-resp", Name: "m-resp", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-resp): %v", err)
+		}
 		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-openai-resp")
-		token := mintToken(t, session, "m-resp", "e2e-openai-resp", llmAPIProtocolResponses)
-		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, `{"model":"m-resp","input":"hi"}`)
+		token := mintToken(t, session, "alias-resp", "e2e-openai-resp", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, requestBody)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 		}
@@ -1642,14 +1696,14 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 	})
 
 	t.Run("sse_stream", func(t *testing.T) {
+		const upstreamEvents = "event: response.output_text.delta\ndata: {\"delta\":\"hello\"}\n\nevent: response.completed\ndata: {\"status\":\"completed\"}\n\n"
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("event: message\ndata: hello\n\n"))
+			_, _ = w.Write([]byte(upstreamEvents))
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
-			_, _ = w.Write([]byte("event: done\ndata: [DONE]\n\n"))
 		}))
 		t.Cleanup(upstream.Close)
 		service.llm.client = upstream.Client()
@@ -1660,8 +1714,8 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 		}
-		if !strings.Contains(rec.Body.String(), "data:") {
-			t.Fatalf("expected SSE data in response, got %q", rec.Body.String())
+		if rec.Body.String() != upstreamEvents {
+			t.Fatalf("facade SSE body = %q, want exact upstream events", rec.Body.String())
 		}
 	})
 

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -11,11 +11,17 @@ import (
 	"strings"
 )
 
-// llmFacadeTokenSourceAgent marks a per-agent-run facade token. Such a token is
-// only used for the duration of a single bounded agent run, so the caller is
-// expected to delete it when that run completes (see executeAgentRun) rather
-// than letting it live for the whole session lifetime.
-const llmFacadeTokenSourceAgent = "agent"
+const (
+	// llmFacadeTokenSourceAgent marks a per-agent-run facade token. Such a token is
+	// only used for the duration of a single bounded agent run, so the caller is
+	// expected to delete it when that run completes (see executeAgentRun) rather
+	// than letting it live for the whole session lifetime.
+	llmFacadeTokenSourceAgent = "agent"
+
+	// llmFacadeTokenSourceLoaderCommand marks a per-loader-command facade token.
+	// The caller must delete it when the bounded command returns.
+	llmFacadeTokenSourceLoaderCommand = "loader_command"
+)
 
 type agentRuntimeLLMConfig struct {
 	Env map[string]string

--- a/pkg/agentcompose/loader_timer_test.go
+++ b/pkg/agentcompose/loader_timer_test.go
@@ -974,6 +974,83 @@ func TestLoaderRunHostCommandPersistsRunningCellOutput(t *testing.T) {
 	}
 }
 
+func TestLoaderRunHostCommandDeletesLLMFacadeToken(t *testing.T) {
+	ctx := context.Background()
+	manager, runtime, _, loader := newTestLoaderCommandManager(t, ctx)
+	manager.config.RuntimeBaseURL = "http://agent-compose.test"
+	if _, err := manager.configDB.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://openai-compatible.example.invalid/openai"},
+		{Name: "LLM_API_KEY", Value: "provider-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "svip/gpt-5.5"},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	host := &loaderRunHost{
+		manager: manager,
+		loader:  loader,
+		run:     &LoaderRunSummary{ID: "run-command-facade-token", LoaderID: loader.Summary.ID},
+	}
+
+	result, err := host.Command(ctx, LoaderCommandRequest{
+		Mode:    "exec",
+		Command: "python3",
+		Args:    []string{"-V"},
+		Env:     map[string]string{"PROJECT_AGENT_PROVIDER": "codex"},
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("command result = %#v", result)
+	}
+	if len(runtime.commandSpecs) != 1 {
+		t.Fatalf("command ExecStream calls = %d, want 1", len(runtime.commandSpecs))
+	}
+	token := runtime.commandSpecs[0].Env["AGENT_COMPOSE_SESSION_TOKEN"]
+	if token == "" {
+		t.Fatalf("command spec missing AGENT_COMPOSE_SESSION_TOKEN: %#v", runtime.commandSpecs[0].Env)
+	}
+	if _, err := manager.configDB.GetLLMFacadeToken(ctx, token); err == nil {
+		t.Fatalf("loader command facade token should be deleted after command returns")
+	}
+}
+
+func TestLoaderRunHostCommandSkipsOpenCodeFacadeWithoutModel(t *testing.T) {
+	ctx := context.Background()
+	manager, runtime, _, loader := newTestLoaderCommandManager(t, ctx)
+	manager.config.RuntimeBaseURL = "http://agent-compose.test"
+	if _, err := manager.configDB.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://openai-compatible.example.invalid/openai"},
+		{Name: "LLM_API_KEY", Value: "provider-key", Secret: true},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	host := &loaderRunHost{
+		manager: manager,
+		loader:  loader,
+		run:     &LoaderRunSummary{ID: "run-command-opencode-no-model", LoaderID: loader.Summary.ID},
+	}
+
+	result, err := host.Command(ctx, LoaderCommandRequest{
+		Mode:    "exec",
+		Command: "python3",
+		Args:    []string{"-V"},
+		Env:     map[string]string{"PROJECT_AGENT_PROVIDER": "opencode"},
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("command result = %#v", result)
+	}
+	if len(runtime.commandSpecs) != 1 {
+		t.Fatalf("command ExecStream calls = %d, want 1", len(runtime.commandSpecs))
+	}
+	if token := runtime.commandSpecs[0].Env["AGENT_COMPOSE_SESSION_TOKEN"]; token != "" {
+		t.Fatalf("opencode command without model should not receive facade token %q", token)
+	}
+}
+
 func testLoaderRunHostCommandPersistsShellCellArtifactsAndEvents(t *testing.T) {
 	ctx := context.Background()
 	manager, runtime, _, loader := newTestLoaderCommandManager(t, ctx)
@@ -1815,7 +1892,7 @@ func newTestLoaderCommandManager(t *testing.T, ctx context.Context) (*LoaderMana
 		store:    store,
 		configDB: configDB,
 		driver:   driver,
-		executor: &Executor{config: config, store: store, runtimes: fixedRuntimeProvider{runtime: runtime}},
+		executor: &Executor{config: config, store: store, configDB: configDB, runtimes: fixedRuntimeProvider{runtime: runtime}},
 		engine:   &QJSLoaderEngine{},
 		running:  map[string]int{},
 	}


### PR DESCRIPTION
## Summary
- regenerate loader-command LLM facade env at execution time so reloaded sessions still get runtime LLM config
- keep OpenAI Responses requests on the Responses facade path with minimal model rewriting and transparent response/SSE forwarding
- normalize OpenAI-compatible base URLs, honor explicit session-env provider IDs, and clean up per-command facade tokens
- skip opencode facade setup for loader commands that do not specify an opencode model

## Root Cause
Loader commands can run after session state has been persisted and reloaded, but managed runtime env is not persisted. That left bounded command executions without the daemon-provided LLM facade config. The facade also transformed OpenAI Responses streams too aggressively for some OpenAI-compatible backends, and provider URL/model selection had edge cases around session-scoped providers and base URL path completion.

## Validation
- go test ./pkg/agentcompose -count=1
- git diff --check
- manually re-triggered a loader event with minimal env: LLM_API_ENDPOINT, LLM_API_KEY, LLM_MODEL
