### PR TITLE
make LLM provider base URL completion generic

### DIFF
--- a/pkg/agentcompose/llm_client.go
+++ b/pkg/agentcompose/llm_client.go
@@ -429,11 +429,19 @@ func normalizeLLMAPIEndpointForProtocol(raw, protocol string) string {
 		return parsed.String()
 	}
 	cleanPath := strings.TrimRight(parsed.Path, "/")
-	if protocol == llmAPIProtocolChatCompletions && cleanPath == "/v1" {
+	if protocol == llmAPIProtocolChatCompletions && (cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/openai/v1")) {
 		parsed.Path = pathpkg.Join(parsed.Path, "/chat/completions")
 		return parsed.String()
 	}
-	if protocol == llmAPIProtocolResponses && cleanPath == "/v1" {
+	if protocol == llmAPIProtocolChatCompletions && strings.HasSuffix(cleanPath, "/openai") {
+		parsed.Path = pathpkg.Join(parsed.Path, "/v1/chat/completions")
+		return parsed.String()
+	}
+	if protocol == llmAPIProtocolResponses && strings.HasSuffix(cleanPath, "/openai") {
+		parsed.Path = pathpkg.Join(parsed.Path, "/v1/responses")
+		return parsed.String()
+	}
+	if protocol == llmAPIProtocolResponses && (cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/openai/v1")) {
 		parsed.Path = pathpkg.Join(parsed.Path, "/responses")
 		return parsed.String()
 	}

--- a/pkg/agentcompose/llm_client.go
+++ b/pkg/agentcompose/llm_client.go
@@ -429,19 +429,11 @@ func normalizeLLMAPIEndpointForProtocol(raw, protocol string) string {
 		return parsed.String()
 	}
 	cleanPath := strings.TrimRight(parsed.Path, "/")
-	if protocol == llmAPIProtocolChatCompletions && (cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/openai/v1")) {
+	if protocol == llmAPIProtocolChatCompletions && cleanPath == "/v1" {
 		parsed.Path = pathpkg.Join(parsed.Path, "/chat/completions")
 		return parsed.String()
 	}
-	if protocol == llmAPIProtocolChatCompletions && strings.HasSuffix(cleanPath, "/openai") {
-		parsed.Path = pathpkg.Join(parsed.Path, "/v1/chat/completions")
-		return parsed.String()
-	}
-	if protocol == llmAPIProtocolResponses && strings.HasSuffix(cleanPath, "/openai") {
-		parsed.Path = pathpkg.Join(parsed.Path, "/v1/responses")
-		return parsed.String()
-	}
-	if protocol == llmAPIProtocolResponses && strings.HasSuffix(cleanPath, "/openai/v1") {
+	if protocol == llmAPIProtocolResponses && cleanPath == "/v1" {
 		parsed.Path = pathpkg.Join(parsed.Path, "/responses")
 		return parsed.String()
 	}

--- a/pkg/agentcompose/llm_client_test.go
+++ b/pkg/agentcompose/llm_client_test.go
@@ -57,6 +57,12 @@ func TestNormalizeLLMAPIEndpointKeepsExplicitPath(t *testing.T) {
 	if got := normalizeLLMAPIEndpointForProtocol("https://api.example.invalid/v1", llmAPIProtocolChatCompletions); got != "https://api.example.invalid/v1/chat/completions" {
 		t.Fatalf("normalizeLLMAPIEndpointForProtocol chat v1 = %q, want chat completions path", got)
 	}
+	if got := normalizeLLMAPIEndpoint("https://api.example.invalid/openai"); got != "https://api.example.invalid/openai/v1/responses" {
+		t.Fatalf("normalizeLLMAPIEndpoint openai base = %q, want openai responses path", got)
+	}
+	if got := normalizeLLMAPIEndpointForProtocol("https://api.example.invalid/openai/v1", llmAPIProtocolChatCompletions); got != "https://api.example.invalid/openai/v1/chat/completions" {
+		t.Fatalf("normalizeLLMAPIEndpointForProtocol openai v1 chat = %q, want openai chat completions path", got)
+	}
 	if got := normalizeLLMAPIEndpointForProtocol("https://api.example.invalid/custom/chat", llmAPIProtocolChatCompletions); got != "https://api.example.invalid/custom/chat" {
 		t.Fatalf("normalizeLLMAPIEndpointForProtocol chat custom = %q, want unchanged", got)
 	}
@@ -76,6 +82,10 @@ func TestLLMEndpointForProviderBaseURLAppendsProtocolPath(t *testing.T) {
 	provider.BaseURL = "https://openai-compatible.example.invalid/api/v1"
 	if got := llmEndpointForProvider(provider, llmAPIProtocolResponses); got != "https://openai-compatible.example.invalid/api/v1/responses" {
 		t.Fatalf("llmEndpointForProvider v1 responses = %q, want provider v1 base URL plus responses path", got)
+	}
+	provider.BaseURL = "https://openai-compatible.example.invalid"
+	if got := llmEndpointForProvider(provider, llmAPIProtocolChatCompletions); got != "https://openai-compatible.example.invalid/v1/chat/completions" {
+		t.Fatalf("llmEndpointForProvider root chat = %q, want provider root base URL plus chat path", got)
 	}
 }
 

--- a/pkg/agentcompose/llm_client_test.go
+++ b/pkg/agentcompose/llm_client_test.go
@@ -65,13 +65,17 @@ func TestNormalizeLLMAPIEndpointKeepsExplicitPath(t *testing.T) {
 func TestLLMEndpointForProviderBaseURLAppendsProtocolPath(t *testing.T) {
 	provider := LLMProvider{
 		ProviderType: llmProviderFamilyOpenAI,
-		BaseURL:      "https://openai-compatible.example.invalid/openai",
+		BaseURL:      "https://openai-compatible.example.invalid/api",
 	}
-	if got := llmEndpointForProvider(provider, llmAPIProtocolChatCompletions); got != "https://openai-compatible.example.invalid/openai/v1/chat/completions" {
+	if got := llmEndpointForProvider(provider, llmAPIProtocolChatCompletions); got != "https://openai-compatible.example.invalid/api/v1/chat/completions" {
 		t.Fatalf("llmEndpointForProvider chat = %q, want provider base URL plus chat path", got)
 	}
-	if got := llmEndpointForProvider(provider, llmAPIProtocolResponses); got != "https://openai-compatible.example.invalid/openai/v1/responses" {
+	if got := llmEndpointForProvider(provider, llmAPIProtocolResponses); got != "https://openai-compatible.example.invalid/api/v1/responses" {
 		t.Fatalf("llmEndpointForProvider responses = %q, want provider base URL plus responses path", got)
+	}
+	provider.BaseURL = "https://openai-compatible.example.invalid/api/v1"
+	if got := llmEndpointForProvider(provider, llmAPIProtocolResponses); got != "https://openai-compatible.example.invalid/api/v1/responses" {
+		t.Fatalf("llmEndpointForProvider v1 responses = %q, want provider v1 base URL plus responses path", got)
 	}
 }
 

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -1073,18 +1073,26 @@ func appendLLMAPIEndpointToBaseURL(baseURL, wireAPI string) string {
 	switch normalizeLLMWireAPI(wireAPI) {
 	case llmAPIProtocolChatCompletions:
 		if cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/v1") {
-			parsed.Path = pathpkg.Join(cleanPath, "chat/completions")
+			joinLLMAPIBasePath(parsed, cleanPath, "chat/completions")
 		} else {
-			parsed.Path = pathpkg.Join(cleanPath, "v1/chat/completions")
+			joinLLMAPIBasePath(parsed, cleanPath, "v1/chat/completions")
 		}
 	default:
 		if cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/v1") {
-			parsed.Path = pathpkg.Join(cleanPath, "responses")
+			joinLLMAPIBasePath(parsed, cleanPath, "responses")
 		} else {
-			parsed.Path = pathpkg.Join(cleanPath, "v1/responses")
+			joinLLMAPIBasePath(parsed, cleanPath, "v1/responses")
 		}
 	}
 	return parsed.String()
+}
+
+func joinLLMAPIBasePath(parsed *url.URL, basePath, suffix string) {
+	joined := pathpkg.Join(basePath, suffix)
+	if parsed != nil && parsed.Host != "" && !strings.HasPrefix(joined, "/") {
+		joined = "/" + joined
+	}
+	parsed.Path = joined
 }
 
 func normalizeAnthropicAPIBaseURL(raw string) string {

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -1048,7 +1048,43 @@ func llmEndpointForProvider(provider LLMProvider, wireAPI string) string {
 		parsed.Path = pathpkg.Join(parsed.Path, "messages")
 		return parsed.String()
 	}
-	return llmEndpointForWireAPI(provider.BaseURL, wireAPI)
+	baseURL := normalizeLLMAPIBaseURL(provider.BaseURL, wireAPI)
+	if !llmProviderScopeIsConfigured(provider.Scope) {
+		return normalizeLLMAPIEndpointForProtocol(baseURL, wireAPI)
+	}
+	return appendLLMAPIEndpointToBaseURL(baseURL, wireAPI)
+}
+
+func appendLLMAPIEndpointToBaseURL(baseURL, wireAPI string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		switch normalizeLLMWireAPI(wireAPI) {
+		case llmAPIProtocolChatCompletions:
+			return baseURL + "/v1/chat/completions"
+		default:
+			return baseURL + "/v1/responses"
+		}
+	}
+	cleanPath := strings.TrimRight(parsed.Path, "/")
+	switch normalizeLLMWireAPI(wireAPI) {
+	case llmAPIProtocolChatCompletions:
+		if cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/v1") {
+			parsed.Path = pathpkg.Join(cleanPath, "chat/completions")
+		} else {
+			parsed.Path = pathpkg.Join(cleanPath, "v1/chat/completions")
+		}
+	default:
+		if cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/v1") {
+			parsed.Path = pathpkg.Join(cleanPath, "responses")
+		} else {
+			parsed.Path = pathpkg.Join(cleanPath, "v1/responses")
+		}
+	}
+	return parsed.String()
 }
 
 func normalizeAnthropicAPIBaseURL(raw string) string {

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -1088,8 +1088,11 @@ func appendLLMAPIEndpointToBaseURL(baseURL, wireAPI string) string {
 }
 
 func joinLLMAPIBasePath(parsed *url.URL, basePath, suffix string) {
+	if parsed == nil {
+		return
+	}
 	joined := pathpkg.Join(basePath, suffix)
-	if parsed != nil && parsed.Host != "" && !strings.HasPrefix(joined, "/") {
+	if parsed.Host != "" && !strings.HasPrefix(joined, "/") {
 		joined = "/" + joined
 	}
 	parsed.Path = joined

--- a/pkg/agentcompose/loader_timer_test.go
+++ b/pkg/agentcompose/loader_timer_test.go
@@ -979,7 +979,7 @@ func TestLoaderRunHostCommandDeletesLLMFacadeToken(t *testing.T) {
 	manager, runtime, _, loader := newTestLoaderCommandManager(t, ctx)
 	manager.config.RuntimeBaseURL = "http://agent-compose.test"
 	if _, err := manager.configDB.ReplaceGlobalEnv(ctx, []SessionEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://openai-compatible.example.invalid/openai"},
+		{Name: "LLM_API_ENDPOINT", Value: "https://openai-compatible.example.invalid/api"},
 		{Name: "LLM_API_KEY", Value: "provider-key", Secret: true},
 		{Name: "LLM_MODEL", Value: "svip/gpt-5.5"},
 	}); err != nil {
@@ -1020,7 +1020,7 @@ func TestLoaderRunHostCommandSkipsOpenCodeFacadeWithoutModel(t *testing.T) {
 	manager, runtime, _, loader := newTestLoaderCommandManager(t, ctx)
 	manager.config.RuntimeBaseURL = "http://agent-compose.test"
 	if _, err := manager.configDB.ReplaceGlobalEnv(ctx, []SessionEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://openai-compatible.example.invalid/openai"},
+		{Name: "LLM_API_ENDPOINT", Value: "https://openai-compatible.example.invalid/api"},
 		{Name: "LLM_API_KEY", Value: "provider-key", Secret: true},
 	}); err != nil {
 		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)


### PR DESCRIPTION
## Summary
- remove provider endpoint normalization special-cases tied to a specific path suffix
- add generic OpenAI-compatible provider base URL completion for arbitrary base paths
- preserve existing custom LLM_API_ENDPOINT behavior for env/default providers
- update tests to use neutral OpenAI-compatible example URLs

## Root Cause
Provider base URLs and explicit daemon endpoints have different semantics. Provider configuration should be treated as a base URL and completed to the selected wire API path, while explicit env/default endpoints must keep their existing custom-path compatibility.

## Validation
- go test ./pkg/agentcompose -count=1
- git diff --check
