### PR TITLE
fix store timeline concurrent writes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 ARG REGISTRY_MIRROR=docker.io
 ARG GOPROXY=https://goproxy.cn,direct
+ARG APT_MIRROR_HOST=
+ARG APT_RETRIES=5
 
 FROM ${REGISTRY_MIRROR}/library/golang:1-alpine AS golang-toolchain
 
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS boxlite-build
 ARG BOXLITE_VERSION=v0.9.5
 ARG TARGETARCH
+ARG APT_MIRROR_HOST
+ARG APT_RETRIES
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG ALL_PROXY
@@ -15,8 +19,8 @@ ENV HTTPS_PROXY=${HTTPS_PROXY}
 ENV ALL_PROXY=${ALL_PROXY}
 ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl python3 tar &&     rm -rf /var/lib/apt/lists/*
+RUN if [ -n "${APT_MIRROR_HOST}" ]; then       if [ -f /etc/apt/sources.list ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list;       fi;       if [ -f /etc/apt/sources.list.d/debian.sources ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list.d/debian.sources;       fi;     fi
+RUN apt-get -o Acquire::Retries=${APT_RETRIES} update && apt-get -o Acquire::Retries=${APT_RETRIES} install -y --no-install-recommends ca-certificates curl python3 tar &&     rm -rf /var/lib/apt/lists/*
 RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     case "${target_arch}" in       amd64) BOXLITE_ARCH=x64 ;;       arm64) BOXLITE_ARCH=arm64 ;;       *) echo "unsupported BoxLite target arch: ${target_arch}" >&2; exit 1 ;;     esac;     mkdir -p /tmp/boxlite/runtime /tmp/boxlite/sdk /out/include /out/lib /out/runtime &&     BOXLITE_RUNTIME_NAME=boxlite-runtime-${BOXLITE_VERSION}-linux-${BOXLITE_ARCH}-gnu.tar.gz &&     BOXLITE_C_NAME=boxlite-c-${BOXLITE_VERSION}-linux-${BOXLITE_ARCH}-gnu.tar.gz &&     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -o /tmp/boxlite/${BOXLITE_RUNTIME_NAME} https://github.com/boxlite-ai/boxlite/releases/download/${BOXLITE_VERSION}/${BOXLITE_RUNTIME_NAME} &&     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -o /tmp/boxlite/${BOXLITE_C_NAME} https://github.com/boxlite-ai/boxlite/releases/download/${BOXLITE_VERSION}/${BOXLITE_C_NAME} &&     tar -xzf /tmp/boxlite/${BOXLITE_RUNTIME_NAME} -C /tmp/boxlite/runtime &&     tar -xzf /tmp/boxlite/${BOXLITE_C_NAME} -C /tmp/boxlite/sdk &&     cp -a /tmp/boxlite/runtime/boxlite-runtime/. /out/runtime/ &&     cp /tmp/boxlite/sdk/*/include/boxlite.h /out/include/boxlite.h &&     cp -a /tmp/boxlite/sdk/*/lib/libboxlite.* /out/lib/
 
 # Fetch the prebuilt microsandbox artifacts for the target architecture. The Go
@@ -28,6 +32,8 @@ RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     c
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS microsandbox-fetch
 ARG MICROSANDBOX_VERSION=v0.5.8
 ARG TARGETARCH
+ARG APT_MIRROR_HOST
+ARG APT_RETRIES
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG ALL_PROXY
@@ -37,14 +43,16 @@ ENV HTTPS_PROXY=${HTTPS_PROXY}
 ENV ALL_PROXY=${ALL_PROXY}
 ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl binutils tar &&     rm -rf /var/lib/apt/lists/*
+RUN if [ -n "${APT_MIRROR_HOST}" ]; then       if [ -f /etc/apt/sources.list ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list;       fi;       if [ -f /etc/apt/sources.list.d/debian.sources ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list.d/debian.sources;       fi;     fi
+RUN apt-get -o Acquire::Retries=${APT_RETRIES} update && apt-get -o Acquire::Retries=${APT_RETRIES} install -y --no-install-recommends ca-certificates curl binutils tar &&     rm -rf /var/lib/apt/lists/*
 RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     case "${target_arch}" in       amd64) MICROSANDBOX_ARCH=x86_64 ;;       arm64) MICROSANDBOX_ARCH=aarch64 ;;       *) echo "unsupported Microsandbox target arch: ${target_arch}" >&2; exit 1 ;;     esac;     base="https://github.com/superradcompany/microsandbox/releases/download/${MICROSANDBOX_VERSION}";     mkdir -p /tmp/microsandbox/extract /out/bin /out/lib;     cd /tmp/microsandbox;     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/agentd-${MICROSANDBOX_ARCH}";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/libmicrosandbox_go_ffi-linux-${target_arch}.so";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/checksums.sha256";     sha256sum -c --ignore-missing checksums.sha256;     tar -xzf "microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz" -C /tmp/microsandbox/extract;     install -m755 /tmp/microsandbox/extract/msb /out/bin/msb;     install -m755 "agentd-${MICROSANDBOX_ARCH}" /out/bin/agentd;     install -m644 /tmp/microsandbox/extract/libkrunfw.so.5.2.1 /out/lib/libkrunfw.so.5.2.1;     ln -sf libkrunfw.so.5.2.1 /out/lib/libkrunfw.so.5;     ln -sf libkrunfw.so.5 /out/lib/libkrunfw.so;     install -m644 "libmicrosandbox_go_ffi-linux-${target_arch}.so" /out/lib/libmicrosandbox_go_ffi.so;     strip --strip-unneeded /out/lib/libmicrosandbox_go_ffi.so 2>/dev/null || true
 
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS go-build
 ARG VERSION=0
 ARG TARGETARCH
 ARG GOPROXY
+ARG APT_MIRROR_HOST
+ARG APT_RETRIES
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG ALL_PROXY
@@ -54,8 +62,8 @@ ENV HTTPS_PROXY=${HTTPS_PROXY}
 ENV ALL_PROXY=${ALL_PROXY}
 ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates curl git tar && rm -rf /var/lib/apt/lists/*
+RUN if [ -n "${APT_MIRROR_HOST}" ]; then       if [ -f /etc/apt/sources.list ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list;       fi;       if [ -f /etc/apt/sources.list.d/debian.sources ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list.d/debian.sources;       fi;     fi
+RUN apt-get -o Acquire::Retries=${APT_RETRIES} update && apt-get -o Acquire::Retries=${APT_RETRIES} install -y --no-install-recommends build-essential ca-certificates curl git tar && rm -rf /var/lib/apt/lists/*
 COPY --from=golang-toolchain /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:${PATH}
 WORKDIR /app
@@ -72,8 +80,10 @@ FROM scratch AS agent-compose-artifact
 COPY --from=go-build /out/agent-compose /out/agent-compose
 
 FROM ${REGISTRY_MIRROR}/library/debian:trixie-slim
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
-RUN apt-get update &&     apt-get install -y --no-install-recommends ca-certificates git python3 tini tzdata e2fsprogs &&     rm -rf /var/lib/apt/lists/*
+ARG APT_MIRROR_HOST
+ARG APT_RETRIES
+RUN if [ -n "${APT_MIRROR_HOST}" ]; then       if [ -f /etc/apt/sources.list ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list;       fi;       if [ -f /etc/apt/sources.list.d/debian.sources ]; then         sed -i -e "s|deb.debian.org|${APT_MIRROR_HOST}|g" -e "s|security.debian.org|${APT_MIRROR_HOST}|g" /etc/apt/sources.list.d/debian.sources;       fi;     fi
+RUN apt-get -o Acquire::Retries=${APT_RETRIES} update &&     apt-get -o Acquire::Retries=${APT_RETRIES} install -y --no-install-recommends ca-certificates git python3 tini tzdata e2fsprogs &&     rm -rf /var/lib/apt/lists/*
 RUN ln -sfv /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo "Asia/Shanghai" > /etc/timezone
 WORKDIR /app
 COPY --from=go-build /out/agent-compose /app/agent-compose

--- a/pkg/agentcompose/store.go
+++ b/pkg/agentcompose/store.go
@@ -150,10 +150,12 @@ func (s *Store) ListSessions(_ context.Context, options SessionListOptions) (Ses
 		return SessionListResult{}, fmt.Errorf("read session root: %w", err)
 	}
 	var sessions []*Session
+	existingSessionIDs := make(map[string]struct{}, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
+		existingSessionIDs[entry.Name()] = struct{}{}
 		session, err := s.loadSession(entry.Name())
 		if err != nil {
 			continue
@@ -164,6 +166,7 @@ func (s *Store) ListSessions(_ context.Context, options SessionListOptions) (Ses
 		}
 		sessions = append(sessions, session)
 	}
+	s.pruneTimelineLocks(existingSessionIDs)
 	sort.Slice(sessions, func(i, j int) bool {
 		return sessions[i].Summary.UpdatedAt.After(sessions[j].Summary.UpdatedAt)
 	})
@@ -295,6 +298,16 @@ func (s *Store) timelineLock(id string) *sync.Mutex {
 		s.timelineLocks[id] = lock
 	}
 	return lock
+}
+
+func (s *Store) pruneTimelineLocks(existingSessionIDs map[string]struct{}) {
+	s.timelineLocksMu.Lock()
+	defer s.timelineLocksMu.Unlock()
+	for id := range s.timelineLocks {
+		if _, ok := existingSessionIDs[id]; !ok {
+			delete(s.timelineLocks, id)
+		}
+	}
 }
 
 func (s *Store) sessionDir(id string) string {

--- a/pkg/agentcompose/store.go
+++ b/pkg/agentcompose/store.go
@@ -150,12 +150,10 @@ func (s *Store) ListSessions(_ context.Context, options SessionListOptions) (Ses
 		return SessionListResult{}, fmt.Errorf("read session root: %w", err)
 	}
 	var sessions []*Session
-	existingSessionIDs := make(map[string]struct{}, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		existingSessionIDs[entry.Name()] = struct{}{}
 		session, err := s.loadSession(entry.Name())
 		if err != nil {
 			continue
@@ -166,7 +164,7 @@ func (s *Store) ListSessions(_ context.Context, options SessionListOptions) (Ses
 		}
 		sessions = append(sessions, session)
 	}
-	s.pruneTimelineLocks(existingSessionIDs)
+	s.pruneTimelineLocks()
 	sort.Slice(sessions, func(i, j int) bool {
 		return sessions[i].Summary.UpdatedAt.After(sessions[j].Summary.UpdatedAt)
 	})
@@ -300,11 +298,11 @@ func (s *Store) timelineLock(id string) *sync.Mutex {
 	return lock
 }
 
-func (s *Store) pruneTimelineLocks(existingSessionIDs map[string]struct{}) {
+func (s *Store) pruneTimelineLocks() {
 	s.timelineLocksMu.Lock()
 	defer s.timelineLocksMu.Unlock()
 	for id := range s.timelineLocks {
-		if _, ok := existingSessionIDs[id]; !ok {
+		if _, err := os.Stat(s.sessionDir(id)); os.IsNotExist(err) {
 			delete(s.timelineLocks, id)
 		}
 	}

--- a/pkg/agentcompose/store.go
+++ b/pkg/agentcompose/store.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,7 +20,9 @@ import (
 )
 
 type Store struct {
-	config *appconfig.Config
+	config          *appconfig.Config
+	timelineLocks   map[string]*sync.Mutex
+	timelineLocksMu sync.Mutex
 }
 
 func NewStore(di do.Injector) (*Store, error) {
@@ -186,6 +189,10 @@ func (s *Store) UpdateSession(_ context.Context, session *Session) error {
 }
 
 func (s *Store) AddCell(_ context.Context, session *Session, cell NotebookCell) error {
+	lock := s.timelineLock(session.Summary.ID)
+	lock.Lock()
+	defer lock.Unlock()
+
 	cells, err := s.loadCells(session.Summary.ID)
 	if err != nil {
 		return err
@@ -216,6 +223,10 @@ func (s *Store) AddCell(_ context.Context, session *Session, cell NotebookCell) 
 }
 
 func (s *Store) ListCells(_ context.Context, id string) ([]NotebookCell, error) {
+	lock := s.timelineLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
 	return s.loadCells(id)
 }
 
@@ -240,18 +251,14 @@ func (s *Store) AddAgentRun(_ context.Context, sessionID string, run AgentRun) e
 	if err := s.AddCell(context.Background(), session, cell); err != nil {
 		return err
 	}
-	session, err = s.loadSession(sessionID)
-	if err == nil {
-		timelineCells, loadErr := s.loadCells(sessionID)
-		if loadErr == nil {
-			session.Summary.CellCount = len(timelineCells)
-		}
-		_ = s.UpdateSession(context.Background(), session)
-	}
 	return nil
 }
 
 func (s *Store) AddEvent(_ context.Context, sessionID string, event SessionEvent) error {
+	lock := s.timelineLock(sessionID)
+	lock.Lock()
+	defer lock.Unlock()
+
 	events, err := s.loadEvents(sessionID)
 	if err != nil {
 		return err
@@ -269,7 +276,25 @@ func (s *Store) AddEvent(_ context.Context, sessionID string, event SessionEvent
 }
 
 func (s *Store) ListEvents(_ context.Context, id string) ([]SessionEvent, error) {
+	lock := s.timelineLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
 	return s.loadEvents(id)
+}
+
+func (s *Store) timelineLock(id string) *sync.Mutex {
+	s.timelineLocksMu.Lock()
+	defer s.timelineLocksMu.Unlock()
+	if s.timelineLocks == nil {
+		s.timelineLocks = make(map[string]*sync.Mutex)
+	}
+	lock := s.timelineLocks[id]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		s.timelineLocks[id] = lock
+	}
+	return lock
 }
 
 func (s *Store) sessionDir(id string) string {

--- a/pkg/agentcompose/store_test.go
+++ b/pkg/agentcompose/store_test.go
@@ -5,8 +5,10 @@ import (
 	driverpkg "agent-compose/pkg/driver"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +25,143 @@ func TestStorePersistenceErrorAndUpdateBranches(t *testing.T) {
 
 func TestStoreCreateSessionUsesConfiguredJupyterProxyBase(t *testing.T) {
 	testStoreCreateSessionUsesConfiguredJupyterProxyBase(t)
+}
+
+func TestStoreAddEventConcurrentWritesDoNotDropEvents(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newTestTimelineStore(t)
+	session, err := store.CreateSession(ctx, "Concurrent Events", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	const eventCount = 200
+	var wg sync.WaitGroup
+	errs := make(chan error, eventCount)
+	for index := range eventCount {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			errs <- store.AddEvent(ctx, session.Summary.ID, SessionEvent{
+				ID:        fmt.Sprintf("event-%03d", index),
+				Type:      "session.concurrent",
+				Level:     "info",
+				Message:   fmt.Sprintf("event %d", index),
+				CreatedAt: time.Now().UTC(),
+			})
+		}(index)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("AddEvent returned error: %v", err)
+		}
+	}
+
+	events, err := store.ListEvents(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	if len(events) != eventCount {
+		t.Fatalf("event count = %d, want %d", len(events), eventCount)
+	}
+	seen := make(map[string]struct{}, len(events))
+	for _, event := range events {
+		seen[event.ID] = struct{}{}
+	}
+	for index := range eventCount {
+		id := fmt.Sprintf("event-%03d", index)
+		if _, ok := seen[id]; !ok {
+			t.Fatalf("missing event %q after concurrent writes", id)
+		}
+	}
+	loaded, err := store.GetSession(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if loaded.Summary.EventCount != eventCount {
+		t.Fatalf("session event count = %d, want %d", loaded.Summary.EventCount, eventCount)
+	}
+}
+
+func TestStoreAddCellConcurrentWritesDoNotDropCells(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newTestTimelineStore(t)
+	session, err := store.CreateSession(ctx, "Concurrent Cells", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	const cellCount = 200
+	var wg sync.WaitGroup
+	errs := make(chan error, cellCount)
+	for index := range cellCount {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			errs <- store.AddCell(ctx, session, NotebookCell{
+				ID:        fmt.Sprintf("cell-%03d", index),
+				Type:      CellTypeShell,
+				Source:    fmt.Sprintf("echo %d", index),
+				Success:   true,
+				CreatedAt: time.Now().UTC(),
+			})
+		}(index)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("AddCell returned error: %v", err)
+		}
+	}
+
+	cells, err := store.ListCells(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListCells returned error: %v", err)
+	}
+	if len(cells) != cellCount {
+		t.Fatalf("cell count = %d, want %d", len(cells), cellCount)
+	}
+	seen := make(map[string]struct{}, len(cells))
+	for _, cell := range cells {
+		seen[cell.ID] = struct{}{}
+	}
+	for index := range cellCount {
+		id := fmt.Sprintf("cell-%03d", index)
+		if _, ok := seen[id]; !ok {
+			t.Fatalf("missing cell %q after concurrent writes", id)
+		}
+	}
+	loaded, err := store.GetSession(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if loaded.Summary.CellCount != cellCount {
+		t.Fatalf("session cell count = %d, want %d", loaded.Summary.CellCount, cellCount)
+	}
+}
+
+func newTestTimelineStore(t *testing.T) *Store {
+	t.Helper()
+	config := &appconfig.Config{
+		SessionRoot:          filepath.Join(t.TempDir(), "sessions"),
+		RuntimeDriver:        driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:         "default-box:latest",
+		GuestHomePath:        "/home/agent-compose",
+		JupyterGuestPort:     8888,
+		JupyterProxyBasePath: "/agent-compose/session",
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := NewStore(di)
+	if err != nil {
+		t.Fatalf("NewStore returned error: %v", err)
+	}
+	return store
 }
 
 func testStoreCreateSessionUsesConfiguredJupyterProxyBase(t *testing.T) {

--- a/pkg/agentcompose/store_test.go
+++ b/pkg/agentcompose/store_test.go
@@ -145,6 +145,42 @@ func TestStoreAddCellConcurrentWritesDoNotDropCells(t *testing.T) {
 	}
 }
 
+func TestStoreListSessionsPrunesTimelineLocksForRemovedSessionDirs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newTestTimelineStore(t)
+	first, err := store.CreateSession(ctx, "Removed", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession first returned error: %v", err)
+	}
+	second, err := store.CreateSession(ctx, "Kept", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession second returned error: %v", err)
+	}
+	if err := store.AddEvent(ctx, first.Summary.ID, SessionEvent{ID: "event-removed", Type: "session.test", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("AddEvent first returned error: %v", err)
+	}
+	if err := store.AddEvent(ctx, second.Summary.ID, SessionEvent{ID: "event-kept", Type: "session.test", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("AddEvent second returned error: %v", err)
+	}
+	if err := os.RemoveAll(store.sessionDir(first.Summary.ID)); err != nil {
+		t.Fatalf("RemoveAll first session dir: %v", err)
+	}
+
+	if _, err := store.ListSessions(ctx, SessionListOptions{}); err != nil {
+		t.Fatalf("ListSessions returned error: %v", err)
+	}
+
+	store.timelineLocksMu.Lock()
+	defer store.timelineLocksMu.Unlock()
+	if _, ok := store.timelineLocks[first.Summary.ID]; ok {
+		t.Fatalf("timeline lock for removed session %q was not pruned", first.Summary.ID)
+	}
+	if _, ok := store.timelineLocks[second.Summary.ID]; !ok {
+		t.Fatalf("timeline lock for existing session %q was pruned", second.Summary.ID)
+	}
+}
+
 func newTestTimelineStore(t *testing.T) *Store {
 	t.Helper()
 	config := &appconfig.Config{


### PR DESCRIPTION
## Summary
- Add per-session timeline locking for Store cell/event writes and reads.
- Cover concurrent AddEvent/AddCell writes with regression tests that verify all entries and summary counts are preserved.

## Testing
- ./scripts/with-go-toolchain.sh go test ./pkg/agentcompose -run 'TestStore' -count=1 -v
- ./scripts/with-go-toolchain.sh go test -race ./pkg/agentcompose -run 'TestStoreAdd(Event|Cell)ConcurrentWritesDoNotDrop' -count=1 -v
- GOCACHE=/Users/shicheng/Desktop/demo/chaitin/agent-compose/agent-compose/agent-compose/.cache/go-build ./scripts/with-go-toolchain.sh go test ./cmd/... ./pkg/... ./proto/health/v1 ./proto/health/v1/healthv1connect ./proto/agentcompose/v1 ./proto/agentcompose/v1/agentcomposev1connect ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect -count=1

Fixes #140