### PR TITLE
Fix OpenCode OpenAI facade config

### DIFF
--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -629,7 +629,7 @@ func TestEnsureSessionOpenCodeCustomProviderWritesConfig(t *testing.T) {
 	if env["AGENT_COMPOSE_SESSION_TOKEN"] == "" || env["AGENT_COMPOSE_SESSION_TOKEN"] != env["LLM_API_KEY"] {
 		t.Fatalf("managed facade env missing token aliases: %#v", env)
 	}
-	if env["OPENCODE_CONFIG"] != "/root/.opencode/agent-compose.json" {
+	if env["OPENCODE_CONFIG"] != "/root/.config/opencode/opencode.json" {
 		t.Fatalf("OPENCODE_CONFIG = %q, want guest opencode config path", env["OPENCODE_CONFIG"])
 	}
 	if strings.Contains(strings.Join([]string{env["LLM_API_KEY"], env["OPENAI_API_KEY"]}, " "), "provider-key") {
@@ -642,7 +642,7 @@ func TestEnsureSessionOpenCodeCustomProviderWritesConfig(t *testing.T) {
 	if token.ProviderID != "chaitin" || token.Model != "kimi-k2.6" || token.WireAPI != llmAPIProtocolChatCompletions {
 		t.Fatalf("facade token = %#v, want chaitin/kimi-k2.6 chat facade", token)
 	}
-	configPath := filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")
+	configPath := filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json")
 	payload, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("ReadFile(%s) returned error: %v", configPath, err)
@@ -701,7 +701,7 @@ func TestEnsureSessionOpenCodeCustomProviderBootstrapsFromDefaultEnv(t *testing.
 	if len(providers) != 1 || providers[0].ID != "chaitin" || providers[0].APIKey != "default-env-key" {
 		t.Fatalf("providers = %#v, want single chaitin provider from default env", providers)
 	}
-	if env["OPENCODE_CONFIG"] != "/root/.opencode/agent-compose.json" {
+	if env["OPENCODE_CONFIG"] != "/root/.config/opencode/opencode.json" {
 		t.Fatalf("OPENCODE_CONFIG = %q, want custom opencode config path", env["OPENCODE_CONFIG"])
 	}
 }
@@ -719,7 +719,7 @@ func TestEnsureSessionOpenCodeNativeProviderUsesOpenCodeConfig(t *testing.T) {
 	if len(env) != 0 {
 		t.Fatalf("env = %#v, want no managed facade env for opencode native provider", env)
 	}
-	if _, err := os.Stat(filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json")); !os.IsNotExist(err) {
 		t.Fatalf("opencode config file should not exist for native provider, stat err=%v", err)
 	}
 }
@@ -750,10 +750,17 @@ func TestEnsureSessionOpenCodeOpenAIWritesRequestedModelConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
 	}
-	if env["OPENCODE_CONFIG"] != "/root/.opencode/agent-compose.json" {
+	if env["OPENCODE_CONFIG"] != "/root/.config/opencode/opencode.json" {
 		t.Fatalf("OPENCODE_CONFIG = %q, want guest opencode config path", env["OPENCODE_CONFIG"])
 	}
-	payload, err := os.ReadFile(filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json"))
+	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.ProviderID != "default" || token.Model != "kimi-k2.6" || token.WireAPI != llmAPIProtocolResponses {
+		t.Fatalf("facade token = %#v, want default/kimi-k2.6 responses facade", token)
+	}
+	payload, err := os.ReadFile(filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json"))
 	if err != nil {
 		t.Fatalf("ReadFile returned error: %v", err)
 	}
@@ -761,7 +768,11 @@ func TestEnsureSessionOpenCodeOpenAIWritesRequestedModelConfig(t *testing.T) {
 	if err := json.Unmarshal(payload, &decoded); err != nil {
 		t.Fatalf("decode opencode config: %v\n%s", err, string(payload))
 	}
-	models := decoded["provider"].(map[string]any)["openai"].(map[string]any)["models"].(map[string]any)
+	openai := decoded["provider"].(map[string]any)["openai"].(map[string]any)
+	if openai["npm"] != "@ai-sdk/openai" {
+		t.Fatalf("opencode openai npm = %#v, want @ai-sdk/openai", openai["npm"])
+	}
+	models := openai["models"].(map[string]any)
 	if _, ok := models["kimi-k2.6"]; !ok {
 		t.Fatalf("opencode openai models = %#v, want requested model", models)
 	}
@@ -816,7 +827,7 @@ func TestEnsureSessionOpenCodeAnthropicUsesFacadeEnv(t *testing.T) {
 	if env["OPENCODE_CONFIG"] != "" {
 		t.Fatalf("OPENCODE_CONFIG = %q, want no custom config for built-in anthropic provider", env["OPENCODE_CONFIG"])
 	}
-	if _, err := os.Stat(filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json")); !os.IsNotExist(err) {
 		t.Fatalf("opencode config file should not exist for built-in anthropic provider, stat err=%v", err)
 	}
 	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -197,7 +197,7 @@ func ensureSessionOpenCodeOpenAIFacadeEnv(ctx context.Context, config *appconfig
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llmAPIProtocolChatCompletions, source, runID)
+	tokenValue, token, err := newLLMFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llmAPIProtocolResponses, source, runID)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func ensureSessionOpenCodeOpenAIFacadeEnv(ctx context.Context, config *appconfig
 		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
 		"LLM_API_ENDPOINT":            openAIBaseURL,
 		"LLM_API_KEY":                 tokenValue,
-		"LLM_API_PROTOCOL":            llmAPIProtocolChatCompletions,
+		"LLM_API_PROTOCOL":            llmAPIProtocolResponses,
 		"OPENAI_API_KEY":              tokenValue,
 		"OPENAI_BASE_URL":             openAIBaseURL,
 		"OPENCODE_CONFIG":             guestOpenCodeLLMConfigPath(config),
@@ -369,7 +369,11 @@ func writeOpenCodeLLMConfig(session *Session, providerID, model, baseURL string)
 	if providerID == "" || model == "" || baseURL == "" {
 		return nil
 	}
-	path := filepath.Join(hostSessionHome(session), ".opencode", "agent-compose.json")
+	providerPackage := "@ai-sdk/openai-compatible"
+	if providerID == "openai" {
+		providerPackage = "@ai-sdk/openai"
+	}
+	path := filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create opencode config dir: %w", err)
 	}
@@ -377,7 +381,7 @@ func writeOpenCodeLLMConfig(session *Session, providerID, model, baseURL string)
 		"$schema": "https://opencode.ai/config.json",
 		"provider": map[string]any{
 			providerID: map[string]any{
-				"npm":  "@ai-sdk/openai-compatible",
+				"npm":  providerPackage,
 				"name": "agent-compose " + providerID,
 				"options": map[string]any{
 					"baseURL": baseURL,
@@ -401,7 +405,7 @@ func writeOpenCodeLLMConfig(session *Session, providerID, model, baseURL string)
 
 func guestOpenCodeLLMConfigPath(config *appconfig.Config) string {
 	appconfig.ApplyDefaultGuestPaths(config)
-	return filepath.Join(guestSessionHome(config), ".opencode", "agent-compose.json")
+	return filepath.Join(guestSessionHome(config), ".config", "opencode", "opencode.json")
 }
 
 func guestRuntimeLLMBaseURL(config *appconfig.Config, session *Session) string {

--- a/pkg/driver/runtime_mount_manifest.go
+++ b/pkg/driver/runtime_mount_manifest.go
@@ -197,6 +197,7 @@ func runtimeMountSpecsForDocker(config *appconfig.Config, session *Session) []ru
 		{hostPath: filepath.Join(home, ".config", "claude"), guestPath: filepath.Join(config.GuestHomePath, ".config", "claude")},
 		{hostPath: filepath.Join(home, ".config", "Claude"), guestPath: filepath.Join(config.GuestHomePath, ".config", "Claude")},
 		{hostPath: filepath.Join(home, ".config", "gemini"), guestPath: filepath.Join(config.GuestHomePath, ".config", "gemini")},
+		{hostPath: filepath.Join(home, ".config", "opencode"), guestPath: filepath.Join(config.GuestHomePath, ".config", "opencode")},
 		{hostPath: filepath.Join(home, ".local", "share", "gemini"), guestPath: filepath.Join(config.GuestHomePath, ".local", "share", "gemini")},
 	}
 }

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -60,6 +60,7 @@ func TestPrepareRuntimeMountManifestForDockerIncludesRequiredMountsOnly(t *testi
 		"/root/.config/claude":      filepath.Join(root, "home", ".config", "claude"),
 		"/root/.config/Claude":      filepath.Join(root, "home", ".config", "Claude"),
 		"/root/.config/gemini":      filepath.Join(root, "home", ".config", "gemini"),
+		"/root/.config/opencode":    filepath.Join(root, "home", ".config", "opencode"),
 		"/root/.local/share/gemini": filepath.Join(root, "home", ".local", "share", "gemini"),
 	}
 	if len(got) != len(want) {
@@ -102,6 +103,7 @@ func TestPrepareRuntimeMountManifestIgnoresCustomGuestHomePath(t *testing.T) {
 		"/root/.config/claude",
 		"/root/.config/Claude",
 		"/root/.config/gemini",
+		"/root/.config/opencode",
 		"/root/.local/share/gemini",
 	} {
 		if got[guestPath] == "" {


### PR DESCRIPTION
## Summary
- write generated OpenCode provider config to the current OpenCode config path
- mount the OpenCode config directory into Docker guest runtimes
- use the OpenAI AI SDK provider and responses facade token for OpenCode `openai/...` models

## Root Cause
OpenCode now reads configuration from the standard config directory and its OpenAI provider path expects a responses-capable provider. The previous generated config path and chat-completions token caused OpenCode OpenAI runs to fail before producing a usable agent result.

## Validation
- `go test ./pkg/agentcompose -run 'TestEnsureSessionOpenCode'`
- `go test ./pkg/driver -run 'TestPrepareRuntimeMountManifest'`
