### PR TITLE
Fix agent provider env facade token setup

### DIFF
--- a/pkg/agentcompose/agent_definition_test.go
+++ b/pkg/agentcompose/agent_definition_test.go
@@ -335,6 +335,81 @@ func TestAgentSessionMessageUsesDefinitionProvider(t *testing.T) {
 	}
 }
 
+func TestAgentSessionMessageUsesDefinitionProviderEnvForFacade(t *testing.T) {
+	ctx := context.Background()
+	service, runtime, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = "http://agent-compose.test"
+	created, err := service.CreateAgentDefinition(ctx, connect.NewRequest(&agentcomposev1.CreateAgentDefinitionRequest{
+		Name:     "Claude Env Runner",
+		Enabled:  true,
+		Provider: "claude",
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "ANTHROPIC_API_KEY", Value: "agent-anthropic-key", Secret: true},
+			{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example.invalid"},
+			{Name: "ANTHROPIC_MODEL", Value: "claude-test"},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	sessionResp, err := service.CreateAgentSession(ctx, connect.NewRequest(&agentcomposev1.CreateAgentSessionRequest{
+		AgentId: created.Msg.GetAgent().GetAgentId(),
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgentSession returned error: %v", err)
+	}
+	sessionID := sessionResp.Msg.GetSession().GetSummary().GetSessionId()
+	createdSession, err := service.store.GetSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if env := sessionEnvMap(createdSession.EnvItems); env["ANTHROPIC_API_KEY"] != "" {
+		t.Fatalf("ANTHROPIC_API_KEY persisted in session env: %#v", createdSession.EnvItems)
+	}
+	if len(createdSession.ProviderEnvItems) != 0 {
+		t.Fatalf("ProviderEnvItems unexpectedly set before execution: %#v", createdSession.ProviderEnvItems)
+	}
+	storedAgent, err := service.configDB.GetAgentDefinition(ctx, created.Msg.GetAgent().GetAgentId())
+	if err != nil {
+		t.Fatalf("GetAgentDefinition returned error: %v", err)
+	}
+	if env := sessionEnvMap(storedAgent.EnvItems); env["ANTHROPIC_API_KEY"] != "agent-anthropic-key" {
+		t.Fatalf("stored agent env missing key: %#v", storedAgent.EnvItems)
+	}
+	agentConfig := service.resolveSessionAgentConfig(ctx, createdSession, "codex")
+	if env := sessionEnvMap(agentConfig.EnvItems); env["ANTHROPIC_API_KEY"] != "agent-anthropic-key" || agentConfig.Provider != "claude" {
+		t.Fatalf("resolved agent config = %#v env=%#v", agentConfig, agentConfig.EnvItems)
+	}
+	_, err = service.SendAgentMessage(ctx, connect.NewRequest(&agentcomposev1.SendAgentMessageRequest{
+		SessionId: sessionID,
+		Agent:     "codex",
+		Message:   "hello",
+	}))
+	if err != nil {
+		t.Fatalf("SendAgentMessage returned error: %v", err)
+	}
+	if len(createdSession.ProviderEnvItems) != 0 {
+		t.Fatalf("SendAgentMessage mutated source session ProviderEnvItems: %#v", createdSession.ProviderEnvItems)
+	}
+	if len(runtime.agentSpecs) != 1 {
+		t.Fatalf("runtime agent specs = %d, want 1", len(runtime.agentSpecs))
+	}
+	env := runtime.agentSpecs[0].Env
+	token := env["AGENT_COMPOSE_SESSION_TOKEN"]
+	if token == "" {
+		t.Fatalf("agent exec env missing facade token: providers=%v env=%#v", runtime.providers, env)
+	}
+	if env["ANTHROPIC_API_KEY"] != token {
+		t.Fatalf("ANTHROPIC_API_KEY = %q, want facade token", env["ANTHROPIC_API_KEY"])
+	}
+	if env["ANTHROPIC_BASE_URL"] != "http://agent-compose.test/api/runtime/sessions/"+sessionID+"/llm/anthropic" {
+		t.Fatalf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
+	}
+	if env["ANTHROPIC_MODEL"] != "claude-test" {
+		t.Fatalf("ANTHROPIC_MODEL = %q, want claude-test", env["ANTHROPIC_MODEL"])
+	}
+}
+
 func testAgentDefinitionCreateSession(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/agentcompose/exec.go
+++ b/pkg/agentcompose/exec.go
@@ -41,6 +41,7 @@ type ExecuteAgentRequest struct {
 	Agent             string
 	AgentDefinitionID string
 	Model             string
+	ProviderEnvItems  []SessionEnvVar
 	RunID             string
 	Message           string
 	Timeout           time.Duration
@@ -917,7 +918,8 @@ func (e *Executor) executeAgent(ctx context.Context, session *Session, request E
 		}
 	}
 
-	execResult, result, err := e.executeAgentRun(execCtx, session, agent, request.AgentDefinitionID, model, request.RunID, message, request.OutputSchemaJSON, streamWriter)
+	execSession := cloneSessionForAgentExecution(session, request.ProviderEnvItems)
+	execResult, result, err := e.executeAgentRun(execCtx, execSession, agent, request.AgentDefinitionID, model, request.RunID, message, request.OutputSchemaJSON, streamWriter)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()
@@ -977,6 +979,18 @@ func (e *Executor) executeAgent(ctx context.Context, session *Session, request E
 	}
 	e.streams.PublishEventAdded(session.Summary.ID, assistantEvent)
 	return cellSnapshot, userEvent, assistantEvent, nil
+}
+
+func cloneSessionForAgentExecution(session *Session, providerEnvItems []SessionEnvVar) *Session {
+	if session == nil {
+		return nil
+	}
+	execSession := *session
+	execSession.EnvItems = append([]SessionEnvVar(nil), session.EnvItems...)
+	execSession.RuntimeEnvItems = append([]SessionEnvVar(nil), session.RuntimeEnvItems...)
+	execSession.ProviderEnvItems = append([]SessionEnvVar(nil), session.ProviderEnvItems...)
+	applyAgentProviderEnv(&execSession, providerEnvItems)
+	return &execSession
 }
 
 func shellQuote(value string) string {

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -993,6 +993,42 @@ func TestSessionEnvGenericMessagesEndpointBootstrapsOnlyAnthropicProvider(t *tes
 	}
 }
 
+func TestDockerClaudeFacadeUsesSessionRuntimeBaseURL(t *testing.T) {
+	ctx := context.Background()
+	for _, k := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL", "CLAUDE_MODEL", "LLM_API_KEY", "LLM_API_ENDPOINT", "LLM_MODEL", "OPENAI_API_KEY"} {
+		t.Setenv(k, "")
+	}
+	service, _, _ := newTestServiceAPIHarness(t)
+	service.config.RuntimeBaseURL = ""
+	service.config.HttpListen = "0.0.0.0:7410"
+	service.config.LLMAPIEndpoint = ""
+	service.config.LLMAPIKey = ""
+	service.config.LLMModel = ""
+	session, err := service.store.CreateSession(ctx, "docker-session-runtime-base", "", "docker", "guest:latest", "", SessionTypeManual, nil, []SessionEnvVar{
+		{Name: "AGENT_COMPOSE_RUNTIME_BASE_URL", Value: "http://172.17.0.1:7410"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session.Summary.VMStatus = VMStatusRunning
+	session.ProviderEnvItems = []SessionEnvVar{
+		{Name: "ANTHROPIC_API_KEY", Value: "session-provider-key", Secret: true},
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example.invalid"},
+		{Name: "ANTHROPIC_MODEL", Value: "claude-session"},
+	}
+
+	env, err := ensureSessionLLMFacadeConfig(ctx, service.config, service.configDB, session, "claude", "", "test", "run-1")
+	if err != nil {
+		t.Fatalf("ensureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["AGENT_COMPOSE_SESSION_TOKEN"] == "" {
+		t.Fatalf("AGENT_COMPOSE_SESSION_TOKEN missing from env: %#v", env)
+	}
+	if env["ANTHROPIC_BASE_URL"] != "http://172.17.0.1:7410/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic" {
+		t.Fatalf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
+	}
+}
+
 func TestSessionEnvProvidersAreScopedPerSession(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("LLM_API_ENDPOINT", "")

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -412,6 +412,9 @@ func guestRuntimeLLMBaseURL(config *appconfig.Config, session *Session) string {
 	if config == nil {
 		return ""
 	}
+	if base := strings.TrimRight(strings.TrimSpace(lookupRuntimeBaseURLEnv(session)), "/"); base != "" {
+		return base
+	}
 	if base := strings.TrimRight(strings.TrimSpace(config.RuntimeBaseURL), "/"); base != "" {
 		return base
 	}
@@ -431,6 +434,18 @@ func guestRuntimeLLMBaseURL(config *appconfig.Config, session *Session) string {
 		return ""
 	}
 	return "http://" + host + ":" + port
+}
+
+func lookupRuntimeBaseURLEnv(session *Session) string {
+	if session == nil {
+		return ""
+	}
+	for _, items := range [][]SessionEnvVar{session.ProviderEnvItems, session.RuntimeEnvItems, session.EnvItems} {
+		if value := lookupEnvItemValue(items, "AGENT_COMPOSE_RUNTIME_BASE_URL"); strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func mergeManagedExecEnv(base map[string]string, managed map[string]string) map[string]string {

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -738,6 +738,7 @@ func (s *Service) SendAgentMessage(ctx context.Context, req *connect.Request[age
 		Agent:             agentConfig.Provider,
 		AgentDefinitionID: agentConfig.AgentDefinitionID,
 		Model:             agentConfig.Model,
+		ProviderEnvItems:  agentConfig.EnvItems,
 		Message:           message,
 	})
 	_ = cell
@@ -774,6 +775,7 @@ func (s *Service) SendAgentMessageStream(ctx context.Context, req *connect.Reque
 		Agent:             agentConfig.Provider,
 		AgentDefinitionID: agentConfig.AgentDefinitionID,
 		Model:             agentConfig.Model,
+		ProviderEnvItems:  agentConfig.EnvItems,
 		Message:           message,
 		Stream: AgentExecutionStream{
 			OnStart: func(cell NotebookCell) error {
@@ -816,6 +818,7 @@ type agentExecutionConfig struct {
 	Provider          string
 	AgentDefinitionID string
 	Model             string
+	EnvItems          []SessionEnvVar
 }
 
 func (s *Service) resolveSessionAgentConfig(ctx context.Context, session *Session, requested string) agentExecutionConfig {
@@ -844,7 +847,19 @@ func agentExecutionConfigFromDefinition(agent AgentDefinition, fallbackProvider 
 		Provider:          provider,
 		AgentDefinitionID: strings.TrimSpace(agent.ID),
 		Model:             strings.TrimSpace(agent.Model),
+		EnvItems:          append([]SessionEnvVar(nil), agent.EnvItems...),
 	}
+}
+
+func applyAgentProviderEnv(session *Session, agentEnv []SessionEnvVar) {
+	if session == nil || len(agentEnv) == 0 {
+		return
+	}
+	providerEnv := session.ProviderEnvItems
+	if len(providerEnv) == 0 {
+		providerEnv = session.EnvItems
+	}
+	session.ProviderEnvItems = mergeEnvItems(agentEnv, providerEnv)
 }
 
 func sessionTagValue(tags []SessionTag, name string) string {

--- a/pkg/agentcompose/service_api_test.go
+++ b/pkg/agentcompose/service_api_test.go
@@ -775,7 +775,7 @@ func newTestServiceAPIHarness(t *testing.T) (*Service, *fakeLoaderAgentRuntime, 
 	runtimes := fixedRuntimeProvider{runtime: runtime}
 	driver := &fakeSessionDriver{}
 	streams := &SessionStreamBroker{subscribers: map[string]map[int]chan sessionWatchEvent{}}
-	executor := &Executor{config: config, store: store, runtimes: runtimes, streams: streams}
+	executor := &Executor{config: config, store: store, configDB: configDB, runtimes: runtimes, streams: streams}
 	bus := &LoaderBus{ch: make(chan LoaderTopicEvent, 256)}
 	aggregator := &DashboardOverviewAggregator{
 		store:    store,


### PR DESCRIPTION
## Summary
- pass agent definition env through agent message execution for facade token generation
- use session AGENT_COMPOSE_RUNTIME_BASE_URL when building guest-reachable LLM facade URLs
- add regression tests for Claude agent env and Docker runtime base URL handling

## Root Cause
Agent-scoped provider keys were intentionally filtered from persisted session env, but later SendAgentMessage paths reloaded sessions without restoring agent EnvItems into ProviderEnvItems. In Docker mode, facade URL resolution also ignored the session-scoped AGENT_COMPOSE_RUNTIME_BASE_URL, so it could return empty for loopback host configuration.

## Validation
- go test ./pkg/agentcompose