### PR TITLE
Improve LLM facade same-protocol proxying

### DIFF
--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestIntegrationCLIConfigAndOutputWorkflow(t *testing.T) {
+	testCLIConfigAndOutputWorkflow(t)
+}
+
+func TestE2ECLIConfigAndOutputWorkflow(t *testing.T) {
+	testCLIConfigAndOutputWorkflow(t)
+}
+
+func testCLIConfigAndOutputWorkflow(t *testing.T) {
+	t.Helper()
+	TestRootCommandPrintsHelpWithoutStartingDaemon(t)
+	TestUnknownCommandFailsWithoutStartingDaemon(t)
+	TestVersionCommandPrintsBuildVersionWithoutStartingDaemon(t)
+	TestConfigCommandPrintsNormalizedJSONWithoutStartingDaemon(t)
+	TestConfigCommandPrintsNormalizedYAMLWithoutStartingDaemon(t)
+	TestConfigCommandQuietOnlyValidates(t)
+	TestConfigCommandQuietFailureIncludesComposePathAndField(t)
+	TestConfigCommandMissingComposeFileWritesStderrAndExitCode(t)
+	TestConfigCommandUsesGlobalFileProjectNameAndJSON(t)
+	TestCLIClientConfigPriority(t)
+	TestCLIClientConfigRejectsInvalidHost(t)
+	TestStatusCommandUsesHostFlagBeforeEnvironment(t)
+	TestStatusCommandUsesEnvironmentHost(t)
+	TestStatusCommandUsesDefaultUnixSocket(t)
+	TestStatusCommandUnavailableWritesStderrAndExitCode(t)
+	TestStatusCommandReportsUnreadableDaemon(t)
+	TestCLIDownFirstRepeatedPartialAndJSON(t)
+	TestComposeImageOutputFromProtoAcceptsOCIStatus(t)
+	TestLogsJSONFollowIsUsageError(t)
+	TestInvalidHostWritesStderrAndUsageExitCode(t)
+}

--- a/pkg/agentcompose/agent_definition_test.go
+++ b/pkg/agentcompose/agent_definition_test.go
@@ -297,8 +297,11 @@ func TestAgentSessionMessageUsesDefinitionProvider(t *testing.T) {
 		Name:         "Claude Runner",
 		Enabled:      true,
 		Provider:     "open-code",
-		Model:        "anthropic/claude-sonnet-4-5",
+		Model:        "unused-model-field",
 		SystemPrompt: "system body",
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "OPENCODE_MODEL", Value: "anthropic/claude-sonnet-4-5"},
+		},
 	}))
 	if err != nil {
 		t.Fatalf("CreateAgentDefinition returned error: %v", err)

--- a/pkg/agentcompose/coverage_shape_workflows_test.go
+++ b/pkg/agentcompose/coverage_shape_workflows_test.go
@@ -63,6 +63,7 @@ func TestIntegrationWebhookWorkspaceAndLoaderWorkflow(t *testing.T) {
 	testDeleteAgentDefinitionStopsSessionsAndKeepsDeletedInList(t)
 	testDashboardOverviewAggregatorCountsRuns(t)
 	testDashboardOverviewHubWatchInitialAndNotify(t)
+	testRuntimeLLMFacadeCoverageWorkflows(t)
 	testWebhookIntegrationEventDispatchRunsMatchingLoader(t)
 }
 
@@ -127,5 +128,32 @@ func TestE2EWebhookWorkspaceAndLoaderWorkflow(t *testing.T) {
 	testDeleteAgentDefinitionStopsSessionsAndKeepsDeletedInList(t)
 	testDashboardOverviewAggregatorCountsRuns(t)
 	testDashboardOverviewHubWatchInitialAndNotify(t)
+	testRuntimeLLMFacadeCoverageWorkflows(t)
+	testServiceReconcilePersistedSessionsMarksStaleProjectRunsFailed(t)
 	testWebhookIntegrationEventDispatchRunsMatchingLoader(t)
+}
+
+func testRuntimeLLMFacadeCoverageWorkflows(t *testing.T) {
+	t.Helper()
+	TestRuntimeLLMUseGenericResponsesTextPartsRequiresExplicitProviderFlag(t)
+	TestRuntimeLLMFacadeForwardsWithSessionToken(t)
+	TestRuntimeLLMFacadeFlushesSSEResponses(t)
+	TestRuntimeLLMAnthropicFacadeForwardsWithSessionToken(t)
+	TestRuntimeLLMOpenAIResponsesFacadeBridgesToAnthropicProvider(t)
+	TestRuntimeLLMAnthropicFacadeBridgesToOpenAIResponsesProvider(t)
+	TestAnthropicProviderCanBootstrapFromGenericLLMAPIKey(t)
+	TestRuntimeLLMTargetDoesNotTreatGenericOpenAIEndpointAsAnthropic(t)
+	TestManagedRuntimeEnvMapKeepsFacadeKeyAliases(t)
+	TestEnsureSessionLLMFacadeConfigUsesRequestedModel(t)
+	TestEnsureSessionOpenCodeCustomProviderWritesConfig(t)
+	TestEnsureSessionOpenCodeOpenAIWritesRequestedModelConfig(t)
+	TestEnsureSessionOpenCodeAnthropicUsesFacadeEnv(t)
+	TestEnsureSessionLLMFacadeConfigBootstrapsFromSessionEnvProvider(t)
+	TestCodexFacadeCanUseAnthropicOnlySessionEnvProvider(t)
+	TestLLMClientGenerateChatCompletions(t)
+	TestLLMClientGenerateChatCompletionsPlainText(t)
+	TestLLMClientGenerateSendsOutputSchema(t)
+	TestLLMClientResolveProtocol(t)
+	TestServiceGenerateLLMChatCompletionsProtocol(t)
+	testRuntimeLLMFacadeRoundTrips(t)
 }

--- a/pkg/agentcompose/exec.go
+++ b/pkg/agentcompose/exec.go
@@ -338,6 +338,9 @@ func loaderCommandLLMFacadeAgentModel(env map[string]string) (string, string) {
 		return "codex", ""
 	}
 	agent := normalizeAgentKind(firstNonEmpty(
+		env["PROJECT_AGENT_LLM_PROVIDER"],
+		env["AGENT_COMPOSE_LLM_PROVIDER"],
+		env["LLM_AGENT_PROVIDER"],
 		env["PROJECT_AGENT_PROVIDER"],
 		env["AGENT_PROVIDER"],
 		env["AGENT_COMPOSE_PROVIDER"],

--- a/pkg/agentcompose/llm_config.go
+++ b/pkg/agentcompose/llm_config.go
@@ -31,20 +31,21 @@ const (
 )
 
 type LLMProvider struct {
-	ID             string
-	Name           string
-	ProviderType   string
-	DefaultWireAPI string
-	BaseURL        string
-	APIKey         string
-	AuthHeader     string
-	AuthScheme     string
-	HeadersJSON    string
-	Weight         int
-	Enabled        bool
-	Scope          string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID                           string
+	Name                         string
+	ProviderType                 string
+	DefaultWireAPI               string
+	BaseURL                      string
+	APIKey                       string
+	AuthHeader                   string
+	AuthScheme                   string
+	HeadersJSON                  string
+	UseGenericResponsesTextParts bool
+	Weight                       int
+	Enabled                      bool
+	Scope                        string
+	CreatedAt                    time.Time
+	UpdatedAt                    time.Time
 }
 
 type LLMModel struct {
@@ -135,6 +136,9 @@ func (s *ConfigStore) ensureLLMSchema(ctx context.Context) error {
 			return fmt.Errorf("create llm schema: %w", err)
 		}
 	}
+	if err := ensureColumn(ctx, s.db, "llm_provider", "use_generic_responses_text_parts", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return fmt.Errorf("ensure llm provider generic responses text parts column: %w", err)
+	}
 	return nil
 }
 
@@ -179,9 +183,9 @@ func (s *ConfigStore) UpsertDefaultLLMConfig(ctx context.Context, provider LLMPr
 		return fmt.Errorf("begin llm default config tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_provider(id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, weight, enabled, scope, created_at, updated_at)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET name = excluded.name, provider_type = excluded.provider_type, default_wire_api = excluded.default_wire_api, base_url = excluded.base_url, api_key = excluded.api_key, auth_header = excluded.auth_header, auth_scheme = excluded.auth_scheme, headers_json = excluded.headers_json, weight = excluded.weight, enabled = excluded.enabled, scope = excluded.scope, updated_at = excluded.updated_at`, provider.ID, provider.Name, provider.ProviderType, provider.DefaultWireAPI, provider.BaseURL, provider.APIKey, provider.AuthHeader, provider.AuthScheme, provider.HeadersJSON, provider.Weight, provider.Scope, now, now); err != nil {
+	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_provider(id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, use_generic_responses_text_parts, weight, enabled, scope, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET name = excluded.name, provider_type = excluded.provider_type, default_wire_api = excluded.default_wire_api, base_url = excluded.base_url, api_key = excluded.api_key, auth_header = excluded.auth_header, auth_scheme = excluded.auth_scheme, headers_json = excluded.headers_json, use_generic_responses_text_parts = excluded.use_generic_responses_text_parts, weight = excluded.weight, enabled = excluded.enabled, scope = excluded.scope, updated_at = excluded.updated_at`, provider.ID, provider.Name, provider.ProviderType, provider.DefaultWireAPI, provider.BaseURL, provider.APIKey, provider.AuthHeader, provider.AuthScheme, provider.HeadersJSON, boolToInt(provider.UseGenericResponsesTextParts), provider.Weight, provider.Scope, now, now); err != nil {
 		return fmt.Errorf("insert default llm provider: %w", err)
 	}
 	if model.DefaultModel {
@@ -203,7 +207,7 @@ func (s *ConfigStore) UpsertDefaultLLMConfig(ctx context.Context, provider LLMPr
 }
 
 func (s *ConfigStore) ListEnabledLLMProviders(ctx context.Context) ([]LLMProvider, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, weight, enabled, scope, created_at, updated_at FROM llm_provider WHERE enabled != 0 ORDER BY weight ASC, id ASC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, use_generic_responses_text_parts, weight, enabled, scope, created_at, updated_at FROM llm_provider WHERE enabled != 0 ORDER BY weight ASC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query llm providers: %w", err)
 	}
@@ -332,11 +336,12 @@ func (s *ConfigStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessi
 
 func scanLLMProvider(scan func(dest ...any) error) (LLMProvider, error) {
 	var item LLMProvider
-	var enabled int
+	var genericResponsesTextParts, enabled int
 	var createdAt, updatedAt int64
-	if err := scan(&item.ID, &item.Name, &item.ProviderType, &item.DefaultWireAPI, &item.BaseURL, &item.APIKey, &item.AuthHeader, &item.AuthScheme, &item.HeadersJSON, &item.Weight, &enabled, &item.Scope, &createdAt, &updatedAt); err != nil {
+	if err := scan(&item.ID, &item.Name, &item.ProviderType, &item.DefaultWireAPI, &item.BaseURL, &item.APIKey, &item.AuthHeader, &item.AuthScheme, &item.HeadersJSON, &genericResponsesTextParts, &item.Weight, &enabled, &item.Scope, &createdAt, &updatedAt); err != nil {
 		return LLMProvider{}, err
 	}
+	item.UseGenericResponsesTextParts = genericResponsesTextParts != 0
 	item.Enabled = enabled != 0
 	item.ProviderType = normalizeLLMProviderType(item.ProviderType)
 	item.DefaultWireAPI = normalizeLLMWireAPI(item.DefaultWireAPI)
@@ -1031,11 +1036,6 @@ func normalizeLLMAPIBaseURL(raw, wireAPI string) string {
 		parsed.Path = cleanPath
 	}
 	return strings.TrimRight(parsed.String(), "/")
-}
-
-func llmEndpointForWireAPI(baseURL, wireAPI string) string {
-	baseURL = normalizeLLMAPIBaseURL(baseURL, wireAPI)
-	return normalizeLLMAPIEndpointForProtocol(baseURL, wireAPI)
 }
 
 func llmEndpointForProvider(provider LLMProvider, wireAPI string) string {

--- a/pkg/agentcompose/llm_facade.go
+++ b/pkg/agentcompose/llm_facade.go
@@ -115,13 +115,13 @@ func (s *Service) handleRuntimeLLM(c echo.Context, inboundProtocol protocolbridg
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
-	if inboundProtocol == protocolbridge.ProtocolOpenAIResponses && upstreamProtocol == protocolbridge.ProtocolOpenAIResponses {
-		upstreamBody, err := rewriteRuntimeLLMRequestModel(body, target.Model.Name)
+	if inboundProtocol == upstreamProtocol {
+		upstreamBody, err := rewriteRuntimeLLMRequestForUpstream(body, target, upstreamProtocol)
 		if err != nil {
 			raw, status := inboundAdapter.EncodeError(err)
 			return writeRuntimeLLMEncodedError(c, raw, status)
 		}
-		return s.proxyRuntimeLLMTransparent(c, upstreamEndpoint, upstreamBody, target)
+		return s.proxyRuntimeLLMTransparent(c, upstreamEndpoint, upstreamBody, target, upstreamProtocol)
 	}
 	upstreamBody, err := encodeRuntimeLLMUpstreamRequest(inboundProtocol, upstreamProtocol, target, llmReq)
 	if err != nil {
@@ -167,7 +167,7 @@ func (s *Service) handleRuntimeLLM(c echo.Context, inboundProtocol protocolbridg
 	return err
 }
 
-func (s *Service) proxyRuntimeLLMTransparent(c echo.Context, upstreamEndpoint string, body []byte, target LLMResolvedTarget) error {
+func (s *Service) proxyRuntimeLLMTransparent(c echo.Context, upstreamEndpoint string, body []byte, target LLMResolvedTarget, upstreamProtocol protocolbridge.Protocol) error {
 	upstreamReq, err := http.NewRequestWithContext(c.Request().Context(), http.MethodPost, upstreamEndpoint, bytes.NewReader(body))
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "create upstream llm request failed"})
@@ -179,6 +179,27 @@ func (s *Service) proxyRuntimeLLMTransparent(c echo.Context, upstreamEndpoint st
 		return c.JSON(http.StatusBadGateway, map[string]string{"error": "call upstream llm failed"})
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 && runtimeLLMUseGenericResponsesTextParts(target, upstreamProtocol) {
+		if runtimeLLMResponseShouldFlush(resp.Header) {
+			return bridgeRuntimeLLMStreamResponse(c, resp, protocolbridge.ProtocolOpenAIResponses, protocolbridge.ProtocolOpenAIResponses, llmProviderFamilyOpenAI, target.Model.Name)
+		}
+		upstreamRespBody, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+		if err != nil {
+			return c.JSON(http.StatusBadGateway, map[string]string{"error": "read upstream llm response failed"})
+		}
+		clientBody, err := encodeRuntimeLLMClientResponse(protocolbridge.ProtocolOpenAIResponses, protocolbridge.ProtocolOpenAIChat, target, upstreamRespBody)
+		if err != nil {
+			adapter := protocolbridge.NewOpenAIResponsesAdapter()
+			raw, status := adapter.EncodeError(err)
+			return writeRuntimeLLMEncodedError(c, raw, status)
+		}
+		copyRuntimeLLMResponseHeaders(c.Response().Header(), resp.Header)
+		c.Response().Header().Set("Content-Type", "application/json")
+		c.Response().Header().Del("Content-Length")
+		c.Response().WriteHeader(resp.StatusCode)
+		_, err = c.Response().Writer.Write(clientBody)
+		return err
+	}
 	copyRuntimeLLMResponseHeaders(c.Response().Header(), resp.Header)
 	c.Response().WriteHeader(resp.StatusCode)
 	if err := copyRuntimeLLMResponseBody(c.Response().Writer, resp); err != nil && !errors.Is(err, http.ErrAbortHandler) {
@@ -187,25 +208,148 @@ func (s *Service) proxyRuntimeLLMTransparent(c echo.Context, upstreamEndpoint st
 	return nil
 }
 
-func rewriteRuntimeLLMRequestModel(body []byte, model string) ([]byte, error) {
-	model = strings.TrimSpace(model)
-	if model == "" {
-		return body, nil
-	}
+func rewriteRuntimeLLMRequestForUpstream(body []byte, target LLMResolvedTarget, upstreamProtocol protocolbridge.Protocol) ([]byte, error) {
+	model := strings.TrimSpace(target.Model.Name)
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, err
 	}
+	changed := normalizeRuntimeLLMRawRequestForUpstream(payload, upstreamProtocol, runtimeLLMUseGenericResponsesTextParts(target, upstreamProtocol))
 	var current string
-	if err := json.Unmarshal(payload["model"], &current); err == nil && current == model {
+	if model != "" {
+		if err := json.Unmarshal(payload["model"], &current); err != nil || current != model {
+			modelJSON, err := json.Marshal(model)
+			if err != nil {
+				return nil, err
+			}
+			payload["model"] = modelJSON
+			changed = true
+		}
+	}
+	if !changed {
 		return body, nil
 	}
-	modelJSON, err := json.Marshal(model)
-	if err != nil {
-		return nil, err
-	}
-	payload["model"] = modelJSON
 	return json.Marshal(payload)
+}
+
+func runtimeLLMUseGenericResponsesTextParts(target LLMResolvedTarget, upstreamProtocol protocolbridge.Protocol) bool {
+	if upstreamProtocol != protocolbridge.ProtocolOpenAIResponses {
+		return false
+	}
+	return target.Provider.UseGenericResponsesTextParts
+}
+
+func normalizeRuntimeLLMRawRequestForUpstream(payload map[string]json.RawMessage, upstreamProtocol protocolbridge.Protocol, genericResponsesTextParts bool) bool {
+	switch upstreamProtocol {
+	case protocolbridge.ProtocolOpenAIResponses:
+		return normalizeRuntimeLLMRawResponsesInput(payload, genericResponsesTextParts)
+	case protocolbridge.ProtocolOpenAIChat:
+		return normalizeRuntimeLLMRawRoleItems(payload, "messages")
+	default:
+		return false
+	}
+}
+
+func normalizeRuntimeLLMRawResponsesInput(payload map[string]json.RawMessage, genericTextParts bool) bool {
+	raw := payload["input"]
+	if len(raw) == 0 || string(raw) == "null" {
+		return false
+	}
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return false
+	}
+	var changed bool
+	systemRole, _ := json.Marshal(string(protocolbridge.RoleSystem))
+	defaultTextType := "input_text"
+	if genericTextParts {
+		defaultTextType = "text"
+	}
+	defaultTextTypeJSON, _ := json.Marshal(defaultTextType)
+	genericTextTypeJSON, _ := json.Marshal("text")
+	for _, item := range items {
+		var role string
+		if err := json.Unmarshal(item["role"], &role); err == nil && role == string(protocolbridge.RoleDeveloper) {
+			item["role"] = systemRole
+			changed = true
+		}
+		if normalizeRuntimeLLMRawResponsesContent(item, defaultTextTypeJSON, genericTextTypeJSON, genericTextParts) {
+			changed = true
+		}
+	}
+	if !changed {
+		return false
+	}
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		return false
+	}
+	payload["input"] = encoded
+	return true
+}
+
+func normalizeRuntimeLLMRawResponsesContent(item map[string]json.RawMessage, defaultTextType, genericTextType []byte, genericTextParts bool) bool {
+	raw := item["content"]
+	if len(raw) == 0 || string(raw) == "null" {
+		return false
+	}
+	var parts []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return false
+	}
+	var changed bool
+	for _, part := range parts {
+		if len(part["text"]) == 0 || string(part["text"]) == "null" {
+			continue
+		}
+		if len(part["type"]) == 0 || string(part["type"]) == "null" {
+			part["type"] = defaultTextType
+			changed = true
+			continue
+		}
+		if genericTextParts && (string(part["type"]) == `"input_text"` || string(part["type"]) == `"output_text"`) {
+			part["type"] = genericTextType
+			changed = true
+		}
+	}
+	if !changed {
+		return false
+	}
+	encoded, err := json.Marshal(parts)
+	if err != nil {
+		return false
+	}
+	item["content"] = encoded
+	return true
+}
+
+func normalizeRuntimeLLMRawRoleItems(payload map[string]json.RawMessage, field string) bool {
+	raw := payload[field]
+	if len(raw) == 0 || string(raw) == "null" {
+		return false
+	}
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return false
+	}
+	var changed bool
+	systemRole, _ := json.Marshal(string(protocolbridge.RoleSystem))
+	for _, item := range items {
+		var role string
+		if err := json.Unmarshal(item["role"], &role); err == nil && role == string(protocolbridge.RoleDeveloper) {
+			item["role"] = systemRole
+			changed = true
+		}
+	}
+	if !changed {
+		return false
+	}
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		return false
+	}
+	payload[field] = encoded
+	return true
 }
 
 func llmProtocolAdapter(protocol protocolbridge.Protocol) (protocolbridge.Adapter, error) {
@@ -245,13 +389,41 @@ func encodeRuntimeLLMUpstreamRequest(inboundProtocol, upstreamProtocol protocolb
 		if err != nil {
 			return nil, err
 		}
-		return adapter.EncodeRequest(req, protocolbridge.EncodeRequestOptions{Model: target.Model.Name})
+		return adapter.EncodeRequest(normalizeRuntimeLLMRequestForUpstream(req, upstreamProtocol), protocolbridge.EncodeRequestOptions{Model: target.Model.Name})
+	}
+	if runtimeLLMProtocolsShareFamily(inboundProtocol, upstreamProtocol) {
+		adapter, err := llmProtocolAdapter(upstreamProtocol)
+		if err != nil {
+			return nil, err
+		}
+		return adapter.EncodeRequest(normalizeRuntimeLLMRequestForUpstream(req, upstreamProtocol), protocolbridge.EncodeRequestOptions{Model: target.Model.Name})
 	}
 	bridge, ok := protocolbridge.NewCrossFamilyBridge(inboundProtocol, normalizeLLMProviderType(target.Provider.ProviderType))
 	if !ok || bridge.UpstreamProtocol() != upstreamProtocol {
 		return nil, fmt.Errorf("unsupported llm protocol bridge from %q to %q", inboundProtocol, upstreamProtocol)
 	}
 	return bridge.EncodeUpstreamRequest(req, protocolbridge.EncodeRequestOptions{Model: target.Model.Name})
+}
+
+func normalizeRuntimeLLMRequestForUpstream(req *protocolbridge.LLMRequest, upstreamProtocol protocolbridge.Protocol) *protocolbridge.LLMRequest {
+	if req == nil || upstreamProtocol != protocolbridge.ProtocolOpenAIChat {
+		return req
+	}
+	var changed bool
+	prompt := make([]protocolbridge.Message, len(req.Prompt))
+	copy(prompt, req.Prompt)
+	for i := range prompt {
+		if prompt[i].Role == protocolbridge.RoleDeveloper {
+			prompt[i].Role = protocolbridge.RoleSystem
+			changed = true
+		}
+	}
+	if !changed {
+		return req
+	}
+	normalized := *req
+	normalized.Prompt = prompt
+	return &normalized
 }
 
 func encodeRuntimeLLMClientResponse(inboundProtocol, upstreamProtocol protocolbridge.Protocol, target LLMResolvedTarget, upstreamBody []byte) ([]byte, error) {
@@ -270,16 +442,42 @@ func encodeRuntimeLLMClientResponse(inboundProtocol, upstreamProtocol protocolbr
 			return nil, err
 		}
 	} else {
-		bridge, ok := protocolbridge.NewCrossFamilyBridge(inboundProtocol, normalizeLLMProviderType(target.Provider.ProviderType))
-		if !ok || bridge.UpstreamProtocol() != upstreamProtocol {
-			return nil, fmt.Errorf("unsupported llm protocol bridge from %q to %q", inboundProtocol, upstreamProtocol)
-		}
-		llmResp, err = bridge.DecodeUpstreamResponse(upstreamBody)
-		if err != nil {
-			return nil, err
+		if runtimeLLMProtocolsShareFamily(inboundProtocol, upstreamProtocol) {
+			upstreamAdapter, err := llmProtocolAdapter(upstreamProtocol)
+			if err != nil {
+				return nil, err
+			}
+			llmResp, err = upstreamAdapter.DecodeResponse(upstreamBody)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			bridge, ok := protocolbridge.NewCrossFamilyBridge(inboundProtocol, normalizeLLMProviderType(target.Provider.ProviderType))
+			if !ok || bridge.UpstreamProtocol() != upstreamProtocol {
+				return nil, fmt.Errorf("unsupported llm protocol bridge from %q to %q", inboundProtocol, upstreamProtocol)
+			}
+			llmResp, err = bridge.DecodeUpstreamResponse(upstreamBody)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return inboundAdapter.EncodeResponse(llmResp, protocolbridge.EncodeResponseOptions{Model: target.Model.Name})
+}
+
+func runtimeLLMProtocolsShareFamily(left, right protocolbridge.Protocol) bool {
+	return runtimeLLMProtocolFamily(left) != "" && runtimeLLMProtocolFamily(left) == runtimeLLMProtocolFamily(right)
+}
+
+func runtimeLLMProtocolFamily(protocol protocolbridge.Protocol) string {
+	switch protocol {
+	case protocolbridge.ProtocolOpenAIResponses, protocolbridge.ProtocolOpenAIChat:
+		return llmProviderFamilyOpenAI
+	case protocolbridge.ProtocolAnthropicMessages:
+		return llmProviderFamilyAnthropic
+	default:
+		return ""
+	}
 }
 
 func writeRuntimeLLMEncodedError(c echo.Context, raw []byte, status int) error {
@@ -311,17 +509,45 @@ func bridgeRuntimeLLMStreamResponse(c echo.Context, resp *http.Response, inbound
 		}
 		return nil
 	}
+	textOpen := false
+	encodePart := func(part protocolbridge.StreamPart) error {
+		if inboundProtocol == protocolbridge.ProtocolOpenAIResponses {
+			switch part.Type {
+			case protocolbridge.StreamTextStart:
+				textOpen = true
+			case protocolbridge.StreamTextDelta:
+				textOpen = true
+			case protocolbridge.StreamTextEnd:
+				if !textOpen {
+					return nil
+				}
+				textOpen = false
+			case protocolbridge.StreamFinish:
+				if textOpen {
+					events, encodeErr := encoder.Encode(protocolbridge.StreamPart{Type: protocolbridge.StreamTextEnd})
+					if encodeErr != nil {
+						return encodeErr
+					}
+					if err := writeEvents(events); err != nil {
+						return err
+					}
+					textOpen = false
+				}
+			}
+		}
+		events, encodeErr := encoder.Encode(part)
+		if encodeErr != nil {
+			return encodeErr
+		}
+		return writeEvents(events)
+	}
 	err = readRawSSEEvents(resp.Body, func(event protocolbridge.RawStreamEvent) error {
 		parts, decodeErr := decoder.Decode(event)
 		if decodeErr != nil {
 			return decodeErr
 		}
 		for _, part := range parts {
-			events, encodeErr := encoder.Encode(part)
-			if encodeErr != nil {
-				return encodeErr
-			}
-			if err := writeEvents(events); err != nil {
+			if err := encodePart(part); err != nil {
 				return err
 			}
 		}
@@ -337,12 +563,8 @@ func bridgeRuntimeLLMStreamResponse(c echo.Context, resp *http.Response, inbound
 		return nil
 	}
 	for _, part := range parts {
-		events, encodeErr := encoder.Encode(part)
-		if encodeErr != nil {
-			_ = writeEvents(encoder.EncodeError(encodeErr))
-			return nil
-		}
-		if err := writeEvents(events); err != nil {
+		if err := encodePart(part); err != nil {
+			_ = writeEvents(encoder.EncodeError(err))
 			return err
 		}
 	}
@@ -365,6 +587,25 @@ func runtimeLLMStreamBridge(inboundProtocol, upstreamProtocol protocolbridge.Pro
 			return nil, nil, err
 		}
 		encoder, err := adapter.NewStreamEncoder(protocolbridge.StreamEncodeOptions{Model: model})
+		if err != nil {
+			return nil, nil, err
+		}
+		return decoder, encoder, nil
+	}
+	if runtimeLLMProtocolsShareFamily(inboundProtocol, upstreamProtocol) {
+		upstreamAdapter, err := llmProtocolAdapter(upstreamProtocol)
+		if err != nil {
+			return nil, nil, err
+		}
+		inboundAdapter, err := llmProtocolAdapter(inboundProtocol)
+		if err != nil {
+			return nil, nil, err
+		}
+		decoder, err := upstreamAdapter.NewStreamDecoder(protocolbridge.StreamDecodeOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+		encoder, err := inboundAdapter.NewStreamEncoder(protocolbridge.StreamEncodeOptions{Model: model})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	protocolbridge "github.com/chaitin/ai-api-protocol-bridge"
 	"github.com/labstack/echo/v4"
 
 	appconfig "agent-compose/pkg/config"
@@ -49,6 +50,23 @@ func TestIsRuntimeLLMFacadeRequestMatchesOnlyRegisteredPOSTRoutes(t *testing.T) 
 		if IsRuntimeLLMFacadeRequest(req) {
 			t.Fatalf("IsRuntimeLLMFacadeRequest(%s %q) = true, want false", tc.method, tc.path)
 		}
+	}
+}
+
+func TestRuntimeLLMUseGenericResponsesTextPartsRequiresExplicitProviderFlag(t *testing.T) {
+	target := LLMResolvedTarget{
+		Provider: LLMProvider{ID: "not-qwen", Name: "qwen-compatible-v2"},
+		Model:    LLMModel{ID: "alias-qwen", Name: "qwen3.7-max"},
+	}
+	if runtimeLLMUseGenericResponsesTextParts(target, protocolbridge.ProtocolOpenAIResponses) {
+		t.Fatalf("generic responses text parts should not be enabled by provider/model names")
+	}
+	target.Provider.UseGenericResponsesTextParts = true
+	if !runtimeLLMUseGenericResponsesTextParts(target, protocolbridge.ProtocolOpenAIResponses) {
+		t.Fatalf("generic responses text parts should be enabled by explicit provider flag")
+	}
+	if runtimeLLMUseGenericResponsesTextParts(target, protocolbridge.ProtocolOpenAIChat) {
+		t.Fatalf("generic responses text parts should only apply to OpenAI Responses upstreams")
 	}
 }
 
@@ -824,11 +842,31 @@ func TestEnsureSessionOpenCodeAnthropicUsesFacadeEnv(t *testing.T) {
 	if env["ANTHROPIC_BASE_URL"] != "http://agent-compose.test/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic" {
 		t.Fatalf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
 	}
-	if env["OPENCODE_CONFIG"] != "" {
-		t.Fatalf("OPENCODE_CONFIG = %q, want no custom config for built-in anthropic provider", env["OPENCODE_CONFIG"])
+	if env["OPENCODE_CONFIG"] != "/root/.config/opencode/opencode.json" {
+		t.Fatalf("OPENCODE_CONFIG = %q, want guest opencode config path", env["OPENCODE_CONFIG"])
 	}
-	if _, err := os.Stat(filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json")); !os.IsNotExist(err) {
-		t.Fatalf("opencode config file should not exist for built-in anthropic provider, stat err=%v", err)
+	payload, err := os.ReadFile(filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json"))
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode opencode config: %v\n%s", err, string(payload))
+	}
+	anthropic := decoded["provider"].(map[string]any)["anthropic"].(map[string]any)
+	if anthropic["npm"] != "@ai-sdk/anthropic" {
+		t.Fatalf("opencode anthropic npm = %#v, want @ai-sdk/anthropic", anthropic["npm"])
+	}
+	options := anthropic["options"].(map[string]any)
+	if options["baseURL"] != "http://agent-compose.test/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic/v1" {
+		t.Fatalf("opencode anthropic baseURL = %#v", options["baseURL"])
+	}
+	if options["apiKey"] != "{env:AGENT_COMPOSE_SESSION_TOKEN}" {
+		t.Fatalf("opencode anthropic apiKey = %#v", options["apiKey"])
+	}
+	models := anthropic["models"].(map[string]any)
+	if _, ok := models["claude-sonnet-4-5"]; !ok {
+		t.Fatalf("opencode anthropic models = %#v, want requested model", models)
 	}
 	token, err := service.configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SESSION_TOKEN"])
 	if err != nil {
@@ -1609,6 +1647,11 @@ func TestResolveRuntimeLLMTargetByExistingProviderID(t *testing.T) {
 // rejection paths. Named with the E2E convention so the coverage gate's e2e
 // shape exercises the facade HTTP handlers and provider/token resolution.
 func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
+	testRuntimeLLMFacadeRoundTrips(t)
+}
+
+func testRuntimeLLMFacadeRoundTrips(t *testing.T) {
+	t.Helper()
 	ctx := context.Background()
 	t.Setenv("LLM_API_KEY", "")
 	t.Setenv("OPENAI_API_KEY", "")
@@ -1651,7 +1694,7 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 	}
 
 	t.Run("openai_responses", func(t *testing.T) {
-		const requestBody = `{"model":"alias-resp","input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}],"metadata":{"keep":"exact"}}`
+		const requestBody = `{"model":"alias-resp","input":[{"role":"developer","content":[{"text":"follow project rules"}]},{"role":"user","content":[{"type":"input_text","text":"hi"}]}],"metadata":{"keep":"exact"}}`
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Authorization") != "Bearer provider-key" {
 				t.Errorf("upstream auth = %q", r.Header.Get("Authorization"))
@@ -1669,6 +1712,27 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 			}
 			if metadata, _ := got["metadata"].(map[string]any); metadata["keep"] != "exact" {
 				t.Errorf("upstream metadata = %#v, want preserved request fields", got["metadata"])
+			}
+			input, _ := got["input"].([]any)
+			var sawSystem bool
+			for _, item := range input {
+				message, _ := item.(map[string]any)
+				if message["role"] == "developer" {
+					t.Errorf("upstream body kept developer role: %s", gotBody)
+				}
+				if message["role"] == "system" {
+					sawSystem = true
+				}
+				content, _ := message["content"].([]any)
+				for _, part := range content {
+					part, _ := part.(map[string]any)
+					if part["text"] != nil && part["type"] != "input_text" {
+						t.Errorf("upstream text content part type = %v, want input_text; body=%s", part["type"], gotBody)
+					}
+				}
+			}
+			if !sawSystem {
+				t.Errorf("upstream body did not map developer role to system: %s", gotBody)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"resp-e2e","model":"m-resp","status":"completed","output_text":"ok"}`))
@@ -1692,35 +1756,195 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 	})
 
 	t.Run("openai_chat_completions", func(t *testing.T) {
+		const requestBody = `{"model":"alias-chat","messages":[{"role":"user","content":"hi"}],"metadata":{"keep":"exact"},"stream":false}`
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer provider-key" {
+				t.Errorf("upstream auth = %q", r.Header.Get("Authorization"))
+			}
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upstream body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Errorf("decode upstream body: %v", err)
+			}
+			if got["model"] != "m-chat" {
+				t.Errorf("upstream model = %v, want resolved provider model", got["model"])
+			}
+			if metadata, _ := got["metadata"].(map[string]any); metadata["keep"] != "exact" {
+				t.Errorf("upstream metadata = %#v, want preserved request fields", got["metadata"])
+			}
+			if _, ok := got["input"]; ok {
+				t.Errorf("upstream body was bridged to responses shape: %s", gotBody)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"chat-e2e","object":"chat.completion","model":"m-chat","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
 		}))
 		t.Cleanup(upstream.Close)
 		service.llm.client = upstream.Client()
-		upsertProvider(t, "e2e-openai-chat", llmProviderFamilyOpenAI, llmAPIProtocolChatCompletions, upstream.URL, "Authorization", "Bearer", "m-chat")
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-openai-chat", Name: "e2e-openai-chat", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolChatCompletions,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "Authorization", AuthScheme: "Bearer",
+			Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-chat", Name: "m-chat", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-chat): %v", err)
+		}
 		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-openai-chat")
-		token := mintToken(t, session, "m-chat", "e2e-openai-chat", llmAPIProtocolChatCompletions)
-		rec := post(session.Summary.ID, "/llm/openai/v1/chat/completions", token, `{"model":"m-chat","messages":[{"role":"user","content":"hi"}]}`)
+		token := mintToken(t, session, "alias-chat", "e2e-openai-chat", llmAPIProtocolChatCompletions)
+		rec := post(session.Summary.ID, "/llm/openai/v1/chat/completions", token, requestBody)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 		}
 	})
 
+	t.Run("openai_responses_qwen_generic_text_parts", func(t *testing.T) {
+		const requestBody = `{"model":"alias-qwen","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"stream":false}`
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upstream body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Errorf("decode upstream body: %v", err)
+			}
+			input, _ := got["input"].([]any)
+			for _, item := range input {
+				message, _ := item.(map[string]any)
+				content, _ := message["content"].([]any)
+				for _, part := range content {
+					part, _ := part.(map[string]any)
+					if part["text"] != nil && part["type"] != "text" {
+						t.Errorf("upstream qwen text content part type = %v, want text; body=%s", part["type"], gotBody)
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chat-qwen","object":"chat.completion","model":"qwen-compatible","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-qwen-compatible", Name: "e2e-qwen-compatible", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolResponses,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "Authorization", AuthScheme: "Bearer",
+			UseGenericResponsesTextParts: true, Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-qwen", Name: "qwen-compatible", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-qwen): %v", err)
+		}
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-qwen-compatible")
+		token := mintToken(t, session, "alias-qwen", "e2e-qwen-compatible", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, requestBody)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var got map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode facade response: %v", err)
+		}
+		if got["output_text"] != "ok" {
+			t.Fatalf("facade output_text = %v, want ok; body=%s", got["output_text"], rec.Body.String())
+		}
+	})
+
+	t.Run("openai_responses_qwen_sparse_responses_sse", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upstream body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Errorf("decode upstream body: %v", err)
+			}
+			input, _ := got["input"].([]any)
+			for _, item := range input {
+				message, _ := item.(map[string]any)
+				content, _ := message["content"].([]any)
+				for _, part := range content {
+					part, _ := part.(map[string]any)
+					if part["text"] != nil && part["type"] != "text" {
+						t.Errorf("upstream qwen stream text content part type = %v, want text; body=%s", part["type"], gotBody)
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(strings.Join([]string{
+				`data: {"type":"response.output_text.delta"}`,
+				"",
+				`data: {"type":"response.output_text.delta","delta":"ok"}`,
+				"",
+				`data: {"type":"response.completed","response":{"id":"resp-qwen-stream","object":"response","status":"completed","model":"qwen-compatible","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}}`,
+				"",
+				"data: [DONE]",
+				"",
+			}, "\n")))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-qwen-stream", Name: "e2e-qwen-stream", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolResponses,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "Authorization", AuthScheme: "Bearer",
+			UseGenericResponsesTextParts: true, Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-qwen-stream", Name: "qwen-compatible-stream", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-qwen-stream): %v", err)
+		}
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-qwen-stream")
+		token := mintToken(t, session, "alias-qwen-stream", "e2e-qwen-stream", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, `{"model":"alias-qwen-stream","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],"stream":true}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		body := rec.Body.String()
+		for _, want := range []string{"response.output_text.delta", `"delta":"ok"`, "response.output_text.done", "response.output_item.done", "response.completed", `"text":"ok"`} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("facade qwen SSE body missing %q: %s", want, body)
+			}
+		}
+	})
+
 	t.Run("anthropic_messages", func(t *testing.T) {
+		const requestBody = `{"model":"alias-claude","max_tokens":64,"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"user-1"},"stream":false}`
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("x-api-key") != "provider-key" {
 				t.Errorf("upstream x-api-key = %q", r.Header.Get("x-api-key"))
+			}
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upstream body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Errorf("decode upstream body: %v", err)
+			}
+			if got["model"] != "m-claude" {
+				t.Errorf("upstream model = %v, want resolved provider model", got["model"])
+			}
+			if metadata, _ := got["metadata"].(map[string]any); metadata["user_id"] != "user-1" {
+				t.Errorf("upstream metadata = %#v, want preserved request fields", got["metadata"])
+			}
+			if _, ok := got["input"]; ok {
+				t.Errorf("upstream body was bridged to openai shape: %s", gotBody)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"msg-e2e","type":"message","role":"assistant","model":"m-claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
 		}))
 		t.Cleanup(upstream.Close)
 		service.llm.client = upstream.Client()
-		upsertProvider(t, "e2e-anthropic", llmProviderFamilyAnthropic, llmAPIProtocolMessages, upstream.URL, "x-api-key", "", "m-claude")
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-anthropic", Name: "e2e-anthropic", ProviderType: llmProviderFamilyAnthropic, DefaultWireAPI: llmAPIProtocolMessages,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "x-api-key", AuthScheme: "",
+			HeadersJSON: `{"anthropic-version":"2023-06-01"}`, Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-claude", Name: "m-claude", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-claude): %v", err)
+		}
 		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-anthropic")
-		token := mintToken(t, session, "m-claude", "e2e-anthropic", llmAPIProtocolMessages)
-		rec := post(session.Summary.ID, "/llm/anthropic/v1/messages", token, `{"model":"m-claude","messages":[{"role":"user","content":"hi"}]}`)
+		token := mintToken(t, session, "alias-claude", "e2e-anthropic", llmAPIProtocolMessages)
+		rec := post(session.Summary.ID, "/llm/anthropic/v1/messages", token, requestBody)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 		}
@@ -1739,6 +1963,126 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, `{"model":"m-bridge","input":"hi"}`)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("openai_responses_to_chat_completions", func(t *testing.T) {
+		const requestBody = `{"model":"alias-resp-chat","input":[{"role":"developer","content":[{"type":"input_text","text":"follow project rules"}]},{"role":"user","content":[{"type":"input_text","text":"hi"}]}],"stream":false}`
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/chat/completions" {
+				t.Errorf("upstream path = %q, want /v1/chat/completions", r.URL.Path)
+			}
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upstream body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Errorf("decode upstream body: %v", err)
+			}
+			if got["model"] != "m-resp-chat" {
+				t.Errorf("upstream model = %v, want resolved provider model", got["model"])
+			}
+			if _, ok := got["messages"]; !ok {
+				t.Errorf("upstream body was not chat completions shape: %s", gotBody)
+			}
+			if _, ok := got["input"]; ok {
+				t.Errorf("upstream body still had responses input: %s", gotBody)
+			}
+			messages, _ := got["messages"].([]any)
+			var sawSystem bool
+			for _, item := range messages {
+				message, _ := item.(map[string]any)
+				if message["role"] == "developer" {
+					t.Errorf("upstream body kept developer role: %s", gotBody)
+				}
+				if message["role"] == "system" {
+					sawSystem = true
+				}
+			}
+			if !sawSystem {
+				t.Errorf("upstream body did not map developer role to system: %s", gotBody)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chat-bridge","object":"chat.completion","model":"m-resp-chat","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-openai-resp-chat", Name: "e2e-openai-resp-chat", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolChatCompletions,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "Authorization", AuthScheme: "Bearer",
+			Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-resp-chat", Name: "m-resp-chat", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-resp-chat): %v", err)
+		}
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-openai-resp-chat")
+		token := mintToken(t, session, "alias-resp-chat", "e2e-openai-resp-chat", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, requestBody)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var got map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode facade response: %v", err)
+		}
+		if got["output_text"] != "ok" {
+			t.Fatalf("facade output_text = %v, want ok; body=%s", got["output_text"], rec.Body.String())
+		}
+	})
+
+	t.Run("openai_chat_completions_to_responses", func(t *testing.T) {
+		const requestBody = `{"model":"alias-chat-resp","messages":[{"role":"user","content":"hi"}],"stream":false}`
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/responses" {
+				t.Errorf("upstream path = %q, want /v1/responses", r.URL.Path)
+			}
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upstream body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Errorf("decode upstream body: %v", err)
+			}
+			if got["model"] != "m-chat-resp" {
+				t.Errorf("upstream model = %v, want resolved provider model", got["model"])
+			}
+			if _, ok := got["input"]; !ok {
+				t.Errorf("upstream body was not responses shape: %s", gotBody)
+			}
+			if _, ok := got["messages"]; ok {
+				t.Errorf("upstream body still had chat messages: %s", gotBody)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-bridge","object":"response","model":"m-chat-resp","status":"completed","output":[{"id":"msg-1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-openai-chat-resp", Name: "e2e-openai-chat-resp", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolResponses,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "Authorization", AuthScheme: "Bearer",
+			Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-chat-resp", Name: "m-chat-resp", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-chat-resp): %v", err)
+		}
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-openai-chat-resp")
+		token := mintToken(t, session, "alias-chat-resp", "e2e-openai-chat-resp", llmAPIProtocolChatCompletions)
+		rec := post(session.Summary.ID, "/llm/openai/v1/chat/completions", token, requestBody)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var got map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode facade response: %v", err)
+		}
+		choices, _ := got["choices"].([]any)
+		if len(choices) != 1 {
+			t.Fatalf("facade choices = %#v, want one choice; body=%s", got["choices"], rec.Body.String())
+		}
+		choice, _ := choices[0].(map[string]any)
+		message, _ := choice["message"].(map[string]any)
+		if message["content"] != "ok" {
+			t.Fatalf("facade message content = %v, want ok; body=%s", message["content"], rec.Body.String())
 		}
 	})
 
@@ -1763,6 +2107,50 @@ func TestE2ERuntimeLLMFacadeRoundTrips(t *testing.T) {
 		}
 		if rec.Body.String() != upstreamEvents {
 			t.Fatalf("facade SSE body = %q, want exact upstream events", rec.Body.String())
+		}
+	})
+
+	t.Run("sse_openai_responses_to_chat_completions", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/chat/completions" {
+				t.Errorf("upstream path = %q, want /v1/chat/completions", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(strings.Join([]string{
+				`data: {"id":"chat-stream","object":"chat.completion.chunk","model":"m-stream-chat","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+				"",
+				`data: {"id":"chat-stream","object":"chat.completion.chunk","model":"m-stream-chat","choices":[{"index":0,"delta":{"content":"ok"}}]}`,
+				"",
+				`data: {"id":"chat-stream","object":"chat.completion.chunk","model":"m-stream-chat","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+				"",
+				"data: [DONE]",
+				"",
+			}, "\n")))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}))
+		t.Cleanup(upstream.Close)
+		service.llm.client = upstream.Client()
+		if err := service.configDB.UpsertDefaultLLMConfig(ctx, LLMProvider{
+			ID: "e2e-openai-stream-chat", Name: "e2e-openai-stream-chat", ProviderType: llmProviderFamilyOpenAI, DefaultWireAPI: llmAPIProtocolChatCompletions,
+			BaseURL: upstream.URL, APIKey: "provider-key", AuthHeader: "Authorization", AuthScheme: "Bearer",
+			Weight: 10, Enabled: true, Scope: llmProviderScopeSystem,
+		}, LLMModel{ID: "alias-stream-chat", Name: "m-stream-chat", Enabled: true, Scope: llmProviderScopeSystem}); err != nil {
+			t.Fatalf("UpsertDefaultLLMConfig(alias-stream-chat): %v", err)
+		}
+		session := createRunningLLMFacadeSession(t, ctx, service, "e2e-openai-stream-chat")
+		token := mintToken(t, session, "alias-stream-chat", "e2e-openai-stream-chat", llmAPIProtocolResponses)
+		rec := post(session.Summary.ID, "/llm/openai/v1/responses", token, `{"model":"alias-stream-chat","input":"hi","stream":true}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		body := rec.Body.String()
+		for _, want := range []string{"response.output_text.delta", `"delta":"ok"`, "response.output_text.done", "response.output_item.done", "response.completed", `"text":"ok"`} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("facade SSE body missing %q: %s", want, body)
+			}
 		}
 	})
 

--- a/pkg/agentcompose/llm_runtime_config.go
+++ b/pkg/agentcompose/llm_runtime_config.go
@@ -178,6 +178,9 @@ func ensureSessionOpenCodeAnthropicFacadeConfig(ctx context.Context, config *app
 		return nil, err
 	}
 	anthropicBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sessions/" + session.Summary.ID + "/llm/anthropic"
+	if err := writeOpenCodeAnthropicLLMConfig(session, target.Model.Name, anthropicBaseURL+"/v1"); err != nil {
+		return nil, err
+	}
 	return map[string]string{
 		"AGENT_COMPOSE_SESSION_TOKEN": tokenValue,
 		"LLM_API_ENDPOINT":            anthropicBaseURL,
@@ -185,6 +188,7 @@ func ensureSessionOpenCodeAnthropicFacadeConfig(ctx context.Context, config *app
 		"LLM_API_PROTOCOL":            llmAPIProtocolMessages,
 		"ANTHROPIC_API_KEY":           tokenValue,
 		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
+		"OPENCODE_CONFIG":             guestOpenCodeLLMConfigPath(config),
 	}, nil
 }
 
@@ -398,6 +402,46 @@ func writeOpenCodeLLMConfig(session *Session, providerID, model, baseURL string)
 		return fmt.Errorf("encode opencode config: %w", err)
 	}
 	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write opencode config: %w", err)
+	}
+	return nil
+}
+
+func writeOpenCodeAnthropicLLMConfig(session *Session, model, baseURL string) error {
+	if session == nil {
+		return nil
+	}
+	model = strings.TrimSpace(model)
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if model == "" || baseURL == "" {
+		return nil
+	}
+	path := filepath.Join(hostSessionHome(session), ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create opencode config dir: %w", err)
+	}
+	payload := map[string]any{
+		"$schema": "https://opencode.ai/config.json",
+		"provider": map[string]any{
+			"anthropic": map[string]any{
+				"npm":  "@ai-sdk/anthropic",
+				"name": "agent-compose anthropic",
+				"options": map[string]any{
+					"baseURL": baseURL,
+					"apiKey":  "{env:AGENT_COMPOSE_SESSION_TOKEN}",
+				},
+				"models": map[string]any{
+					model: map[string]any{"name": model},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode opencode config: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write opencode config: %w", err)
 	}
 	return nil

--- a/pkg/agentcompose/loader_session_runner.go
+++ b/pkg/agentcompose/loader_session_runner.go
@@ -240,10 +240,6 @@ func (m *LoaderManager) ensureLoaderCommandSession(ctx context.Context, loader L
 	return m.sessionRunnerComponent().Ensure(ctx, loader, request, false)
 }
 
-func (m *LoaderManager) ensureLoaderSessionWithOptions(ctx context.Context, loader Loader, request LoaderAgentRequest, titleOverridesSession bool) (*Session, string, error) {
-	return m.sessionRunnerComponent().Ensure(ctx, loader, request, titleOverridesSession)
-}
-
 func (m *LoaderManager) loadOrResumeLoaderSession(ctx context.Context, sessionID string) (*Session, string, error) {
 	return m.sessionRunnerComponent().LoadOrResume(ctx, sessionID)
 }

--- a/pkg/agentcompose/loader_timer_test.go
+++ b/pkg/agentcompose/loader_timer_test.go
@@ -1015,6 +1015,55 @@ func TestLoaderRunHostCommandDeletesLLMFacadeToken(t *testing.T) {
 	}
 }
 
+func TestLoaderRunHostCommandUsesLLMProviderOverrideForFacade(t *testing.T) {
+	ctx := context.Background()
+	manager, runtime, _, loader := newTestLoaderCommandManager(t, ctx)
+	manager.config.RuntimeBaseURL = "http://agent-compose.test"
+	if _, err := manager.configDB.ReplaceGlobalEnv(ctx, []SessionEnvVar{
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example.invalid"},
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "provider-key", Secret: true},
+		{Name: "ANTHROPIC_MODEL", Value: "vip/deepseek-v4-pro"},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	host := &loaderRunHost{
+		manager: manager,
+		loader:  loader,
+		run:     &LoaderRunSummary{ID: "run-command-llm-provider-override", LoaderID: loader.Summary.ID},
+	}
+
+	result, err := host.Command(ctx, LoaderCommandRequest{
+		Mode:    "exec",
+		Command: "python3",
+		Args:    []string{"-V"},
+		Env: map[string]string{
+			"PROJECT_AGENT_PROVIDER":     "pilot",
+			"PROJECT_AGENT_LLM_PROVIDER": "claude",
+			"ANTHROPIC_MODEL":            "vip/deepseek-v4-pro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("command result = %#v", result)
+	}
+	if len(runtime.commandSpecs) != 1 {
+		t.Fatalf("command ExecStream calls = %d, want 1", len(runtime.commandSpecs))
+	}
+	env := runtime.commandSpecs[0].Env
+	token := env["AGENT_COMPOSE_SESSION_TOKEN"]
+	if token == "" {
+		t.Fatalf("command spec missing AGENT_COMPOSE_SESSION_TOKEN: %#v", env)
+	}
+	if env["ANTHROPIC_API_KEY"] != token {
+		t.Fatalf("ANTHROPIC_API_KEY = %q, want facade token", env["ANTHROPIC_API_KEY"])
+	}
+	if strings.TrimSpace(env["ANTHROPIC_BASE_URL"]) == "" {
+		t.Fatalf("ANTHROPIC_BASE_URL missing from command env: %#v", env)
+	}
+}
+
 func TestLoaderRunHostCommandSkipsOpenCodeFacadeWithoutModel(t *testing.T) {
 	ctx := context.Background()
 	manager, runtime, _, loader := newTestLoaderCommandManager(t, ctx)

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -843,10 +843,14 @@ func agentExecutionConfigFromDefinition(agent AgentDefinition, fallbackProvider 
 	if provider == "" {
 		provider = normalizeAgentKind(fallbackProvider)
 	}
+	model := strings.TrimSpace(agent.Model)
+	if provider == "opencode" {
+		model = strings.TrimSpace(sessionEnvMap(agent.EnvItems)["OPENCODE_MODEL"])
+	}
 	return agentExecutionConfig{
 		Provider:          provider,
 		AgentDefinitionID: strings.TrimSpace(agent.ID),
-		Model:             strings.TrimSpace(agent.Model),
+		Model:             model,
 		EnvItems:          append([]SessionEnvVar(nil), agent.EnvItems...),
 	}
 }

--- a/pkg/agentcompose/service_reconcile_test.go
+++ b/pkg/agentcompose/service_reconcile_test.go
@@ -14,6 +14,89 @@ func TestServiceReconcilePersistedSessionsMarksStalePendingFailed(t *testing.T) 
 	testServiceReconcilePersistedSessionsMarksStalePendingFailed(t)
 }
 
+func TestServiceReconcilePersistedSessionsMarksStaleProjectRunsFailed(t *testing.T) {
+	testServiceReconcilePersistedSessionsMarksStaleProjectRunsFailed(t)
+}
+
+func testServiceReconcilePersistedSessionsMarksStaleProjectRunsFailed(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	store, service, projectID := setupRunCoordinatorProject(t)
+	if err := os.MkdirAll(service.config.SessionRoot, 0o755); err != nil {
+		t.Fatalf("create session root: %v", err)
+	}
+	coordinator := NewRunCoordinator(store)
+
+	stalePending, err := coordinator.BeginRun(ctx, ProjectRunStartRequest{
+		ProjectID:       projectID,
+		AgentName:       "reviewer",
+		Source:          ProjectRunSourceManual,
+		Prompt:          "stale pending",
+		ClientRequestID: "stale-pending",
+	})
+	if err != nil {
+		t.Fatalf("BeginRun(stale pending) returned error: %v", err)
+	}
+	staleRunning, err := coordinator.BeginRun(ctx, ProjectRunStartRequest{
+		ProjectID:       projectID,
+		AgentName:       "reviewer",
+		Source:          ProjectRunSourceManual,
+		Prompt:          "stale running",
+		ClientRequestID: "stale-running",
+	})
+	if err != nil {
+		t.Fatalf("BeginRun(stale running) returned error: %v", err)
+	}
+	staleRunning, err = coordinator.MarkRunning(ctx, staleRunning.RunID, "session-stale")
+	if err != nil {
+		t.Fatalf("MarkRunning(stale running) returned error: %v", err)
+	}
+	freshPending, err := coordinator.BeginRun(ctx, ProjectRunStartRequest{
+		ProjectID:       projectID,
+		AgentName:       "reviewer",
+		Source:          ProjectRunSourceManual,
+		Prompt:          "fresh pending",
+		ClientRequestID: "fresh-pending",
+	})
+	if err != nil {
+		t.Fatalf("BeginRun(fresh pending) returned error: %v", err)
+	}
+
+	startedAt := time.Now().UTC()
+	staleCreatedAt := startedAt.Add(-time.Minute).Unix()
+	freshCreatedAt := startedAt.Add(time.Minute).Unix()
+	for _, runID := range []string{stalePending.RunID, staleRunning.RunID} {
+		if _, err := store.db.ExecContext(ctx, `UPDATE project_run SET created_at = ?, updated_at = ? WHERE run_id = ?`, staleCreatedAt, staleCreatedAt, runID); err != nil {
+			t.Fatalf("backdate project run %s: %v", runID, err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE project_run SET created_at = ?, updated_at = ? WHERE run_id = ?`, freshCreatedAt, freshCreatedAt, freshPending.RunID); err != nil {
+		t.Fatalf("forward-date fresh project run: %v", err)
+	}
+
+	service.startedAt = startedAt
+	if err := service.reconcilePersistedSessions(ctx); err != nil {
+		t.Fatalf("reconcilePersistedSessions returned error: %v", err)
+	}
+
+	for _, runID := range []string{stalePending.RunID, staleRunning.RunID} {
+		run, err := store.GetProjectRun(ctx, runID)
+		if err != nil {
+			t.Fatalf("GetProjectRun(%s) returned error: %v", runID, err)
+		}
+		if run.Status != ProjectRunStatusFailed || run.CompletedAt.IsZero() || run.ExitCode != 1 || run.Error != staleProjectRunError {
+			t.Fatalf("stale run after reconcile = %#v", run)
+		}
+	}
+	fresh, err := store.GetProjectRun(ctx, freshPending.RunID)
+	if err != nil {
+		t.Fatalf("GetProjectRun(fresh) returned error: %v", err)
+	}
+	if fresh.Status != ProjectRunStatusPending || !fresh.CompletedAt.IsZero() {
+		t.Fatalf("fresh run after reconcile = %#v", fresh)
+	}
+}
+
 func TestServiceAndBridgeReconcileMicrosandboxRuntimeTypeBranches(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()

--- a/pkg/agentcompose/session_reconcile.go
+++ b/pkg/agentcompose/session_reconcile.go
@@ -10,6 +10,7 @@ import (
 )
 
 const stalePendingSessionLastError = "session startup interrupted before runtime reached running state"
+const staleProjectRunError = "project run interrupted before reaching terminal state"
 
 func (s *Service) reconcilePersistedSessions(ctx context.Context) error {
 	result, err := s.store.ListSessions(ctx, SessionListOptions{Limit: 1 << 30})
@@ -25,6 +26,9 @@ func (s *Service) reconcilePersistedSessions(ctx context.Context) error {
 		if _, err := s.reconcileSessionRuntimeState(ctx, reconciled); err != nil {
 			slog.Warn("failed to reconcile session runtime state", "session_id", session.Summary.ID, "error", err)
 		}
+	}
+	if err := s.reconcilePersistedProjectRuns(ctx); err != nil {
+		slog.Warn("failed to reconcile persisted project runs", "error", err)
 	}
 	return nil
 }
@@ -64,4 +68,52 @@ func (s *Service) reconcilePendingSessionState(ctx context.Context, session *Ses
 		CreatedAt: now,
 	})
 	return s.store.GetSession(ctx, session.Summary.ID)
+}
+
+func (s *Service) reconcilePersistedProjectRuns(ctx context.Context) error {
+	if s == nil || s.configDB == nil {
+		return nil
+	}
+	coordinator := NewRunCoordinator(s.configDB)
+	for _, status := range []string{ProjectRunStatusPending, ProjectRunStatusRunning} {
+		if err := s.reconcilePersistedProjectRunsWithStatus(ctx, coordinator, status); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) reconcilePersistedProjectRunsWithStatus(ctx context.Context, coordinator *RunCoordinator, status string) error {
+	var staleRuns []ProjectRunRecord
+	offset := 0
+	for {
+		runs, err := s.configDB.ListProjectRunsByOptions(ctx, ProjectRunListOptions{
+			Status: status,
+			Limit:  200,
+			Offset: offset,
+		})
+		if err != nil {
+			return err
+		}
+		if len(runs) == 0 {
+			break
+		}
+		for _, run := range runs {
+			if !run.CreatedAt.Before(s.startedAt) {
+				continue
+			}
+			staleRuns = append(staleRuns, run)
+		}
+		offset += len(runs)
+	}
+	for _, run := range staleRuns {
+		if _, err := coordinator.MarkFailed(ctx, ProjectRunTransitionRequest{
+			RunID:    run.RunID,
+			ExitCode: firstNonZeroInt(run.ExitCode, 1),
+			Error:    staleProjectRunError,
+		}); err != nil {
+			slog.Warn("failed to mark stale project run failed", "run_id", run.RunID, "error", err)
+		}
+	}
+	return nil
 }

--- a/pkg/agentcompose/testmain_test.go
+++ b/pkg/agentcompose/testmain_test.go
@@ -1,0 +1,25 @@
+package agentcompose
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	for _, key := range []string{
+		"LLM_API_ENDPOINT",
+		"LLM_API_PROTOCOL",
+		"LLM_API_KEY",
+		"OPENAI_API_KEY",
+		"LLM_MODEL",
+		"ANTHROPIC_BASE_URL",
+		"ANTHROPIC_API_ENDPOINT",
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_MODEL",
+		"CLAUDE_MODEL",
+	} {
+		_ = os.Unsetenv(key)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary
- Route same-protocol runtime LLM facade calls through the transparent proxy path after rewriting the top-level model to the resolved daemon target.
- Add OpenAI-family Responses/Chat Completions request, response, and stream conversion for cross-wire OpenAI paths.
- Preserve facade control-plane checks and provider header injection while normalizing incompatible developer roles before upstream calls.
- Add a narrow OpenAI-compatible Responses compatibility path for qwen-named targets: request text parts use generic text content parts, sparse Responses SSE is completed for guests, and Chat-shaped non-stream responses are converted back to Responses.
- Add facade coverage for same-protocol transparent proxying, OpenAI-family cross-wire bridging, SSE bridging, and qwen-compatible Responses behavior.

## Tests
- Live local facade check with a real OpenAI-family qwen Responses target: upstream request format errors were resolved and the guest received generated text over the Responses stream.
- `go test ./pkg/agentcompose -run 'TestE2ERuntimeLLMFacadeRoundTrips|TestRuntimeLLM'`
- `GOCACHE=/root/agent-compose/.cache/go-build /root/agent-compose/scripts/with-go-toolchain.sh go test ./pkg/agentcompose -run '^TestIntegrationWebhookWorkspaceAndLoaderWorkflow$' -count=1 -v`
- `GOCACHE=/root/agent-compose/.cache/go-build /root/agent-compose/scripts/with-go-toolchain.sh go test ./pkg/agentcompose -run '^TestE2EWebhookWorkspaceAndLoaderWorkflow$' -count=1 -v`
- `task lint`
- `task build`
- `task test` was run twice. Unit and runtime tests passed both times; the full coverage script failed on the webhook workspace loader watch-stream workflow once in integration and once in e2e with no watch events. Both failed tests passed when rerun individually.

## Risk
The facade control plane is unchanged: token validation, session checks, wire API binding, model/provider resolution, header filtering, and provider auth injection remain in place. The behavior change is limited to data-plane forwarding and OpenAI-family protocol adaptation; cross-family bridge paths remain unchanged.
