### PR TITLE
fix prepare npm dependency install paths

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,7 +59,11 @@ tasks:
           echo "Installing nilaway..."
           {{.GO_TOOLCHAIN_ENV}} go install go.uber.org/nilaway/cmd/nilaway@latest || true
         fi
-      - npm install
+      - |
+        for dir in proto-client runtime/agent-compose-runtime-sdk runtime/javascript; do
+          echo "Installing npm dependencies in ${dir}..."
+          (cd "${dir}" && npm ci --no-audit --no-fund)
+        done
       - echo "Deps ready"
 
   clean:


### PR DESCRIPTION
## Summary
- Stop running `npm install` from the repository root in `task prepare`.
- Install dependencies only in existing Node package directories with `npm ci`.

## Testing
- `task prepare`
- `task --list-all`
- `git diff --check`

Fixes #139