### PR TITLE
preserve loader secret env values on update

### DIFF
--- a/pkg/agentcompose/loader_service.go
+++ b/pkg/agentcompose/loader_service.go
@@ -79,6 +79,10 @@ func (s *Service) UpdateLoader(ctx context.Context, req *connect.Request[agentco
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	envItems, err := s.preserveUnchangedLoaderEnvSecrets(ctx, req.Msg.GetLoaderId(), protoEnvItemsToModel(req.Msg.GetEnvItems()))
+	if err != nil {
+		return nil, err
+	}
 	item, err := s.loaders.UpdateLoader(ctx, Loader{
 		Summary: LoaderSummary{
 			ID:                req.Msg.GetLoaderId(),
@@ -96,7 +100,7 @@ func (s *Service) UpdateLoader(ctx context.Context, req *connect.Request[agentco
 			CapsetIDs:         req.Msg.GetCapsetIds(),
 		},
 		Script:   req.Msg.GetScript(),
-		EnvItems: protoEnvItemsToModel(req.Msg.GetEnvItems()),
+		EnvItems: envItems,
 	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
@@ -257,6 +261,33 @@ func toProtoLoaderDetail(item Loader) *agentcomposev1.LoaderDetail {
 		resp.EnvItems = append(resp.EnvItems, &agentcomposev1.SessionEnvVar{Name: envItem.Name, Value: value, Secret: envItem.Secret})
 	}
 	return resp
+}
+
+func (s *Service) preserveUnchangedLoaderEnvSecrets(ctx context.Context, loaderID string, items []SessionEnvVar) ([]SessionEnvVar, error) {
+	existing, err := s.configDB.GetLoader(ctx, loaderID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	existingByName := make(map[string]SessionEnvVar, len(existing.EnvItems))
+	for _, item := range existing.EnvItems {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		existingByName[name] = item
+	}
+	for index, item := range items {
+		name := strings.TrimSpace(item.Name)
+		if name == "" || !item.Secret || item.Value != "********" {
+			continue
+		}
+		existingItem, ok := existingByName[name]
+		if !ok || !existingItem.Secret || existingItem.Value == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("secret env %s requires a value", name))
+		}
+		items[index].Value = existingItem.Value
+	}
+	return items, nil
 }
 
 func toProtoLoaderTrigger(item LoaderTrigger) *agentcomposev1.LoaderTrigger {

--- a/pkg/agentcompose/loader_service.go
+++ b/pkg/agentcompose/loader_service.go
@@ -256,7 +256,7 @@ func toProtoLoaderDetail(item Loader) *agentcomposev1.LoaderDetail {
 	for _, envItem := range item.EnvItems {
 		value := envItem.Value
 		if envItem.Secret && value != "" {
-			value = "********"
+			value = maskedSecretValue
 		}
 		resp.EnvItems = append(resp.EnvItems, &agentcomposev1.SessionEnvVar{Name: envItem.Name, Value: value, Secret: envItem.Secret})
 	}
@@ -278,7 +278,7 @@ func (s *Service) preserveUnchangedLoaderEnvSecrets(ctx context.Context, loaderI
 	}
 	for index, item := range items {
 		name := strings.TrimSpace(item.Name)
-		if name == "" || !item.Secret || item.Value != "********" {
+		if name == "" || !item.Secret || item.Value != maskedSecretValue {
 			continue
 		}
 		existingItem, ok := existingByName[name]

--- a/pkg/agentcompose/service.go
+++ b/pkg/agentcompose/service.go
@@ -64,6 +64,10 @@ type Service struct {
 	agentcomposev2connect.UnimplementedImageServiceHandler
 }
 
+// maskedSecretValue is returned for non-empty secret values. Loader updates
+// also accept it as a keep-existing placeholder during UI round-trips.
+const maskedSecretValue = "********"
+
 func NewService(di do.Injector) (*Service, error) {
 	config := do.MustInvoke[*appconfig.Config](di)
 	dashboard, _ := do.Invoke[*DashboardOverviewHub](di)
@@ -1475,7 +1479,7 @@ func toProtoSessionDetail(session *Session) *agentcomposev1.SessionDetail {
 	for _, item := range session.EnvItems {
 		value := item.Value
 		if item.Secret && value != "" {
-			value = "********"
+			value = maskedSecretValue
 		}
 		resp.EnvItems = append(resp.EnvItems, &agentcomposev1.SessionEnvVar{Name: item.Name, Value: value, Secret: item.Secret})
 	}
@@ -1508,7 +1512,7 @@ func toProtoGlobalEnvConfig(items []SessionEnvVar) *agentcomposev1.GlobalEnvConf
 	for _, item := range items {
 		value := item.Value
 		if item.Secret && value != "" {
-			value = "********"
+			value = maskedSecretValue
 		}
 		resp.EnvItems = append(resp.EnvItems, &agentcomposev1.SessionEnvVar{Name: item.Name, Value: value, Secret: item.Secret})
 	}

--- a/pkg/agentcompose/service_api_test.go
+++ b/pkg/agentcompose/service_api_test.go
@@ -105,8 +105,17 @@ func TestUpdateLoaderPreservesMaskedSecretEnvValues(t *testing.T) {
 		t.Fatalf("GetLoader returned error: %v", err)
 	}
 	envItems := detailResp.Msg.GetLoader().GetEnvItems()
-	if len(envItems) != 2 || envItems[0].GetName() != "LOADER_SECRET" || envItems[0].GetValue() != "********" {
-		t.Fatalf("loader env detail = %+v, want masked secret first", envItems)
+	envByName := make(map[string]*agentcomposev1.SessionEnvVar, len(envItems))
+	for _, item := range envItems {
+		envByName[item.GetName()] = item
+	}
+	secretItem := envByName["LOADER_SECRET"]
+	if len(envItems) != 2 || secretItem == nil || secretItem.GetValue() != "********" || !secretItem.GetSecret() {
+		t.Fatalf("loader env detail = %+v, want masked LOADER_SECRET", envItems)
+	}
+	visibleItem := envByName["VISIBLE"]
+	if visibleItem == nil || visibleItem.GetValue() != "visible" || visibleItem.GetSecret() {
+		t.Fatalf("loader env detail = %+v, want visible VISIBLE", envItems)
 	}
 
 	if _, err := service.UpdateLoader(ctx, connect.NewRequest(&agentcomposev1.UpdateLoaderRequest{

--- a/pkg/agentcompose/service_api_test.go
+++ b/pkg/agentcompose/service_api_test.go
@@ -110,7 +110,7 @@ func TestUpdateLoaderPreservesMaskedSecretEnvValues(t *testing.T) {
 		envByName[item.GetName()] = item
 	}
 	secretItem := envByName["LOADER_SECRET"]
-	if len(envItems) != 2 || secretItem == nil || secretItem.GetValue() != "********" || !secretItem.GetSecret() {
+	if len(envItems) != 2 || secretItem == nil || secretItem.GetValue() != maskedSecretValue || !secretItem.GetSecret() {
 		t.Fatalf("loader env detail = %+v, want masked LOADER_SECRET", envItems)
 	}
 	visibleItem := envByName["VISIBLE"]
@@ -177,11 +177,56 @@ func TestUpdateLoaderPreservesMaskedSecretEnvValues(t *testing.T) {
 		ConcurrencyPolicy: LoaderConcurrencyPolicyParallel,
 		Enabled:           true,
 		EnvItems: []*agentcomposev1.SessionEnvVar{
-			{Name: "NEW_SECRET", Value: "********", Secret: true},
+			{Name: "NEW_SECRET", Value: maskedSecretValue, Secret: true},
 		},
 	}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("UpdateLoader(new masked secret) code = %v, want invalid_argument", connect.CodeOf(err))
+	}
+}
+
+func TestUpdateLoaderMaskedSecretSentinelPreservesExistingValue(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	createResp, err := service.CreateLoader(ctx, connect.NewRequest(&agentcomposev1.CreateLoaderRequest{
+		Name:              "Secret Loader",
+		Runtime:           LoaderRuntimeScheduler,
+		Script:            `scheduler.interval("tick", function(){ scheduler.log("tick"); }, 60000);`,
+		DefaultAgent:      "codex",
+		SessionPolicy:     LoaderSessionPolicyNew,
+		ConcurrencyPolicy: LoaderConcurrencyPolicyParallel,
+		Enabled:           true,
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "LOADER_SECRET", Value: "real-secret", Secret: true},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("CreateLoader returned error: %v", err)
+	}
+	loaderID := createResp.Msg.GetLoader().GetSummary().GetLoaderId()
+
+	if _, err := service.UpdateLoader(ctx, connect.NewRequest(&agentcomposev1.UpdateLoaderRequest{
+		LoaderId:          loaderID,
+		Name:              "Secret Loader",
+		Runtime:           LoaderRuntimeScheduler,
+		Script:            `scheduler.interval("tick", function(){ scheduler.log("tick"); }, 60000);`,
+		DefaultAgent:      "codex",
+		SessionPolicy:     LoaderSessionPolicyNew,
+		ConcurrencyPolicy: LoaderConcurrencyPolicyParallel,
+		Enabled:           true,
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "LOADER_SECRET", Value: maskedSecretValue, Secret: true},
+		},
+	})); err != nil {
+		t.Fatalf("UpdateLoader(masked secret sentinel) returned error: %v", err)
+	}
+	stored, err := service.configDB.GetLoader(ctx, loaderID)
+	if err != nil {
+		t.Fatalf("GetLoader stored returned error: %v", err)
+	}
+	env := sessionEnvMap(stored.EnvItems)
+	if got := env["LOADER_SECRET"]; got != "real-secret" {
+		t.Fatalf("stored LOADER_SECRET = %q, want original secret", got)
 	}
 }
 
@@ -516,11 +561,11 @@ func testServiceProtoConversionHelpers(t *testing.T) {
 	if detail.GetSummary().GetSessionId() != "session-proto" || detail.GetWorkspace().GetId() != "workspace-1" {
 		t.Fatalf("session detail = %+v", detail)
 	}
-	if len(detail.GetEnvItems()) != 2 || detail.GetEnvItems()[1].GetValue() != "********" {
+	if len(detail.GetEnvItems()) != 2 || detail.GetEnvItems()[1].GetValue() != maskedSecretValue {
 		t.Fatalf("session env items = %+v", detail.GetEnvItems())
 	}
 	globalEnv := toProtoGlobalEnvConfig([]SessionEnvVar{{Name: "VISIBLE", Value: "visible"}, {Name: "TOKEN", Value: "token", Secret: true}})
-	if len(globalEnv.GetEnvItems()) != 2 || globalEnv.GetEnvItems()[1].GetValue() != "********" {
+	if len(globalEnv.GetEnvItems()) != 2 || globalEnv.GetEnvItems()[1].GetValue() != maskedSecretValue {
 		t.Fatalf("global env = %+v", globalEnv.GetEnvItems())
 	}
 	if toSessionWorkspaceSnapshot(WorkspaceConfig{ID: "ws", Name: "WS", Type: "git", ConfigJSON: "{}"}).Type != "git" {
@@ -1057,7 +1102,7 @@ func testServiceConfigAndLoaderAPIs(t *testing.T) {
 	if loaderID == "" {
 		t.Fatalf("expected loader id")
 	}
-	if created.Msg.GetLoader().GetEnvItems()[0].GetValue() != "********" {
+	if created.Msg.GetLoader().GetEnvItems()[0].GetValue() != maskedSecretValue {
 		t.Fatalf("expected secret env item to be masked")
 	}
 

--- a/pkg/agentcompose/service_api_test.go
+++ b/pkg/agentcompose/service_api_test.go
@@ -80,6 +80,102 @@ func TestUpdateGlobalEnvConfigPreservesUnchangedSecrets(t *testing.T) {
 	}
 }
 
+func TestUpdateLoaderPreservesMaskedSecretEnvValues(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newTestServiceAPIHarness(t)
+	createResp, err := service.CreateLoader(ctx, connect.NewRequest(&agentcomposev1.CreateLoaderRequest{
+		Name:              "Secret Loader",
+		Runtime:           LoaderRuntimeScheduler,
+		Script:            `scheduler.interval("tick", function(){ scheduler.log("tick"); }, 60000);`,
+		DefaultAgent:      "codex",
+		SessionPolicy:     LoaderSessionPolicyNew,
+		ConcurrencyPolicy: LoaderConcurrencyPolicyParallel,
+		Enabled:           true,
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "LOADER_SECRET", Value: "real-secret", Secret: true},
+			{Name: "VISIBLE", Value: "visible"},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("CreateLoader returned error: %v", err)
+	}
+	loaderID := createResp.Msg.GetLoader().GetSummary().GetLoaderId()
+	detailResp, err := service.GetLoader(ctx, connect.NewRequest(&agentcomposev1.LoaderIDRequest{LoaderId: loaderID}))
+	if err != nil {
+		t.Fatalf("GetLoader returned error: %v", err)
+	}
+	envItems := detailResp.Msg.GetLoader().GetEnvItems()
+	if len(envItems) != 2 || envItems[0].GetName() != "LOADER_SECRET" || envItems[0].GetValue() != "********" {
+		t.Fatalf("loader env detail = %+v, want masked secret first", envItems)
+	}
+
+	if _, err := service.UpdateLoader(ctx, connect.NewRequest(&agentcomposev1.UpdateLoaderRequest{
+		LoaderId:          loaderID,
+		Name:              "Secret Loader",
+		Description:       "description changed",
+		Runtime:           LoaderRuntimeScheduler,
+		Script:            `scheduler.interval("tick", function(){ scheduler.log("tick"); }, 60000);`,
+		DefaultAgent:      "codex",
+		SessionPolicy:     LoaderSessionPolicyNew,
+		ConcurrencyPolicy: LoaderConcurrencyPolicyParallel,
+		Enabled:           true,
+		EnvItems:          envItems,
+	})); err != nil {
+		t.Fatalf("UpdateLoader(masked secret) returned error: %v", err)
+	}
+	stored, err := service.configDB.GetLoader(ctx, loaderID)
+	if err != nil {
+		t.Fatalf("GetLoader stored returned error: %v", err)
+	}
+	env := sessionEnvMap(stored.EnvItems)
+	if got := env["LOADER_SECRET"]; got != "real-secret" {
+		t.Fatalf("stored LOADER_SECRET = %q, want original secret", got)
+	}
+
+	if _, err := service.UpdateLoader(ctx, connect.NewRequest(&agentcomposev1.UpdateLoaderRequest{
+		LoaderId:          loaderID,
+		Name:              "Secret Loader",
+		Description:       "secret changed",
+		Runtime:           LoaderRuntimeScheduler,
+		Script:            `scheduler.interval("tick", function(){ scheduler.log("tick"); }, 60000);`,
+		DefaultAgent:      "codex",
+		SessionPolicy:     LoaderSessionPolicyNew,
+		ConcurrencyPolicy: LoaderConcurrencyPolicyParallel,
+		Enabled:           true,
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "LOADER_SECRET", Value: "new-secret", Secret: true},
+			{Name: "VISIBLE", Value: "visible"},
+		},
+	})); err != nil {
+		t.Fatalf("UpdateLoader(new secret) returned error: %v", err)
+	}
+	stored, err = service.configDB.GetLoader(ctx, loaderID)
+	if err != nil {
+		t.Fatalf("GetLoader stored after new secret returned error: %v", err)
+	}
+	env = sessionEnvMap(stored.EnvItems)
+	if got := env["LOADER_SECRET"]; got != "new-secret" {
+		t.Fatalf("stored LOADER_SECRET = %q, want updated secret", got)
+	}
+
+	_, err = service.UpdateLoader(ctx, connect.NewRequest(&agentcomposev1.UpdateLoaderRequest{
+		LoaderId:          loaderID,
+		Name:              "Secret Loader",
+		Runtime:           LoaderRuntimeScheduler,
+		Script:            `scheduler.interval("tick", function(){ scheduler.log("tick"); }, 60000);`,
+		DefaultAgent:      "codex",
+		SessionPolicy:     LoaderSessionPolicyNew,
+		ConcurrencyPolicy: LoaderConcurrencyPolicyParallel,
+		Enabled:           true,
+		EnvItems: []*agentcomposev1.SessionEnvVar{
+			{Name: "NEW_SECRET", Value: "********", Secret: true},
+		},
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("UpdateLoader(new masked secret) code = %v, want invalid_argument", connect.CodeOf(err))
+	}
+}
+
 func TestServiceSessionKernelAgentAndLLMAPIs(t *testing.T) {
 	testServiceSessionKernelAgentAndLLMAPIs(t)
 }


### PR DESCRIPTION
## Summary
- Preserve existing loader secret env values when an update sends back the masked `********` placeholder.
- Reject new masked secret values that cannot be resolved to an existing stored secret.
- Add regression coverage for preserving existing loader secrets and explicitly changing them.

## Testing
- `./scripts/with-go-toolchain.sh go test ./pkg/agentcompose -run 'TestUpdateLoaderPreservesMaskedSecretEnvValues|TestUpdateGlobalEnvConfigPreservesUnchangedSecrets|TestServiceConfigAndLoaderAPIs' -count=1 -v`
- `./scripts/with-go-toolchain.sh go test ./pkg/agentcompose -count=1`
- `git diff --check`

Fixes #117