### PR TITLE
fix responses facade developer role

### DIFF
--- a/pkg/agentcompose/llm_facade.go
+++ b/pkg/agentcompose/llm_facade.go
@@ -260,7 +260,6 @@ func normalizeRuntimeLLMRawResponsesInput(payload map[string]json.RawMessage, ge
 		return false
 	}
 	var changed bool
-	systemRole, _ := json.Marshal(string(protocolbridge.RoleSystem))
 	defaultTextType := "input_text"
 	if genericTextParts {
 		defaultTextType = "text"
@@ -268,11 +267,6 @@ func normalizeRuntimeLLMRawResponsesInput(payload map[string]json.RawMessage, ge
 	defaultTextTypeJSON, _ := json.Marshal(defaultTextType)
 	genericTextTypeJSON, _ := json.Marshal("text")
 	for _, item := range items {
-		var role string
-		if err := json.Unmarshal(item["role"], &role); err == nil && role == string(protocolbridge.RoleDeveloper) {
-			item["role"] = systemRole
-			changed = true
-		}
 		if normalizeRuntimeLLMRawResponsesContent(item, defaultTextTypeJSON, genericTextTypeJSON, genericTextParts) {
 			changed = true
 		}

--- a/pkg/agentcompose/llm_facade_test.go
+++ b/pkg/agentcompose/llm_facade_test.go
@@ -1714,14 +1714,11 @@ func testRuntimeLLMFacadeRoundTrips(t *testing.T) {
 				t.Errorf("upstream metadata = %#v, want preserved request fields", got["metadata"])
 			}
 			input, _ := got["input"].([]any)
-			var sawSystem bool
+			var sawDeveloper bool
 			for _, item := range input {
 				message, _ := item.(map[string]any)
 				if message["role"] == "developer" {
-					t.Errorf("upstream body kept developer role: %s", gotBody)
-				}
-				if message["role"] == "system" {
-					sawSystem = true
+					sawDeveloper = true
 				}
 				content, _ := message["content"].([]any)
 				for _, part := range content {
@@ -1731,8 +1728,8 @@ func testRuntimeLLMFacadeRoundTrips(t *testing.T) {
 					}
 				}
 			}
-			if !sawSystem {
-				t.Errorf("upstream body did not map developer role to system: %s", gotBody)
+			if !sawDeveloper {
+				t.Errorf("upstream body did not preserve developer role: %s", gotBody)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"resp-e2e","model":"m-resp","status":"completed","output_text":"ok"}`))


### PR DESCRIPTION
## Summary

Fix the runtime LLM facade for OpenAI Responses requests by preserving the `developer` role when forwarding same-protocol Responses traffic upstream.

## Root Cause

`e7cb84a` added request normalization for same-protocol facade proxying and mapped `developer` messages to `system` for OpenAI Responses. The current responses gateway rejects `system` messages with an SSE error (`System messages are not allowed`). Codex expects a `response.completed` event, so the error stream was reported as `stream closed before response.completed`.

Chat Completions normalization is unchanged; only OpenAI Responses stops rewriting `developer` to `system`.

## Validation

- `go test ./pkg/agentcompose -run 'TestRuntimeLLMFacade|TestNewLLMFacadeToken|TestRevokeLLMFacadeTokens|TestDeleteLLMFacadeToken'`
- `go test ./pkg/agentcompose`
