### PR TITLE
feat(driver): per-call pullPolicy for guest images (default unchanged)

### DIFF
--- a/pkg/agentcompose/adapters/loader_session_runner.go
+++ b/pkg/agentcompose/adapters/loader_session_runner.go
@@ -132,7 +132,9 @@ func (r *LoaderSessionRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	session.ProviderEnvItems = providerEnvItems
 	if request.PullPolicy != "" {
 		session.Summary.PullPolicy = request.PullPolicy
-		_ = r.Store.UpdateSession(ctx, session)
+		if err := r.Store.UpdateSession(ctx, session); err != nil {
+			return nil, "", fmt.Errorf("persist session pull policy: %w", err)
+		}
 	}
 	if err := workspaces.PrepareSessionWorkspace(ctx, r.Config, r.ConfigDB, session); err != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed

--- a/pkg/agentcompose/adapters/loader_session_runner.go
+++ b/pkg/agentcompose/adapters/loader_session_runner.go
@@ -130,6 +130,10 @@ func (r *LoaderSessionRunner) Ensure(ctx context.Context, loader domain.Loader, 
 		return nil, "", err
 	}
 	session.ProviderEnvItems = providerEnvItems
+	if request.PullPolicy != "" {
+		session.Summary.PullPolicy = request.PullPolicy
+		_ = r.Store.UpdateSession(ctx, session)
+	}
 	if err := workspaces.PrepareSessionWorkspace(ctx, r.Config, r.ConfigDB, session); err != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = r.Store.UpdateSession(ctx, session)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	ImageInsecureRegistries    []string
 	BoxDiskSizeGB              int
 	BoxCacheTTL                time.Duration
+	ImagePullTimeout           time.Duration
 	GuestWorkspacePath         string
 	GuestHomePath              string
 	GuestStateRoot             string
@@ -150,6 +151,16 @@ func NewConfig(di do.Injector) (*Config, error) {
 			logger.Warn("ignored non-positive AGENT_TIMEOUT", "value", raw)
 		} else {
 			agentTimeout = parsed
+		}
+	}
+	imagePullTimeout := 10 * time.Minute
+	if raw := os.Getenv("IMAGE_PULL_TIMEOUT"); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err != nil {
+			logger.Warn("failed to parse IMAGE_PULL_TIMEOUT", "value", raw, "error", err)
+		} else if parsed <= 0 {
+			logger.Warn("ignored non-positive IMAGE_PULL_TIMEOUT", "value", raw)
+		} else {
+			imagePullTimeout = parsed
 		}
 	}
 	loaderRunTimeout := 20 * time.Minute
@@ -404,6 +415,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		ImageInsecureRegistries:    imageInsecureRegistries,
 		BoxDiskSizeGB:              boxDiskSizeGB,
 		BoxCacheTTL:                boxCacheTTL,
+		ImagePullTimeout:           imagePullTimeout,
 		GuestWorkspacePath:         guestPaths.GuestWorkspacePath,
 		GuestHomePath:              guestPaths.GuestHomePath,
 		GuestStateRoot:             guestPaths.GuestStateRoot,

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -570,7 +570,7 @@ func parseBoxliteRegistry(value string) (string, C.enum_BoxliteRegistryTransport
 	return cleaned, transport
 }
 
-func (r *cgoBoxRuntime) resolveRootfsPath(ctx context.Context, imageRef string) (string, error) {
+func (r *cgoBoxRuntime) resolveRootfsPath(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
 	if strings.TrimSpace(r.config.BoxRootfsPath) != "" {
 		return r.config.BoxRootfsPath, nil
 	}
@@ -578,7 +578,7 @@ func (r *cgoBoxRuntime) resolveRootfsPath(ctx context.Context, imageRef string) 
 	if imageRef == "" {
 		return "", nil
 	}
-	layout, ok, err := r.materializeLocalImageRootfs(ctx, imageRef)
+	layout, ok, err := r.materializeLocalImageRootfs(ctx, imageRef, pullPolicy, pullTimeout)
 	if err != nil {
 		return "", err
 	}
@@ -589,9 +589,12 @@ func (r *cgoBoxRuntime) resolveRootfsPath(ctx context.Context, imageRef string) 
 	return "", nil
 }
 
-func (r *cgoBoxRuntime) materializeLocalImageRootfs(ctx context.Context, imageRef string) (localDockerImageLayout, bool, error) {
+func (r *cgoBoxRuntime) materializeLocalImageRootfs(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (localDockerImageLayout, bool, error) {
 	layout, ok, err := resolveBoxliteImageLayout(ctx, imageRef, boxliteImageResolverOps{
 		dockerAvailable: dockerDaemonAvailable,
+		applyDockerPullPolicy: func(ctx context.Context, imageRef string) error {
+			return applyDockerDaemonPullPolicy(ctx, imageRef, pullPolicy, pullTimeout)
+		},
 		dockerMaterialize: func(ctx context.Context, imageRef string) (boxliteImageLayoutResult, bool, error) {
 			layout, ok, err := materializeLocalDockerImageLayout(ctx, r.config.DataRoot, imageRef)
 			if err != nil || !ok {
@@ -600,7 +603,7 @@ func (r *cgoBoxRuntime) materializeLocalImageRootfs(ctx context.Context, imageRe
 			return boxliteImageLayoutResult{ImageID: layout.ImageID, ResolvedRef: layout.ResolvedRef, RootfsPath: layout.RootfsPath}, true, nil
 		},
 		ociMaterialize: func(ctx context.Context, imageRef string) (boxliteImageLayoutResult, bool, error) {
-			return materializeBoxliteOCIImageLayout(ctx, r.config, imageRef)
+			return materializeBoxliteOCIImageLayout(ctx, r.config, imageRef, pullPolicy)
 		},
 	})
 	if err != nil || !ok {
@@ -934,7 +937,11 @@ func (r *cgoBoxRuntime) buildBoxOptions(ctx context.Context, session *Session, v
 		return nil, err
 	}
 	imageRef := resolveSessionGuestImage(vmState.Image, session.Summary.GuestImage, r.config.DefaultImage)
-	rootfsPath, err := r.resolveRootfsPath(ctx, imageRef)
+	imagePullTimeout := r.config.ImagePullTimeout
+	if imagePullTimeout <= 0 {
+		imagePullTimeout = defaultImagePullTimeout
+	}
+	rootfsPath, err := r.resolveRootfsPath(ctx, imageRef, session.Summary.PullPolicy, imagePullTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/boxlite_image_materialize_cgo.go
+++ b/pkg/driver/boxlite_image_materialize_cgo.go
@@ -4,12 +4,15 @@ package driver
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"strings"
 
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/imagecache"
 )
 
-func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Config, imageRef string) (boxliteImageLayoutResult, bool, error) {
+func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Config, imageRef string, pullPolicy string) (boxliteImageLayoutResult, bool, error) {
 	cache, err := imagecache.New(imagecache.Config{
 		Root:               imageCacheRootForDriver(config),
 		DefaultRegistry:    config.ImageRegistry,
@@ -18,19 +21,69 @@ func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Con
 	if err != nil {
 		return boxliteImageLayoutResult{}, false, err
 	}
-	result, err := cache.MaterializeOCILayout(ctx, imageRef)
-	if imagecache.IsKind(err, imagecache.ErrorKindNotFound) {
-		if _, pullErr := cache.Pull(ctx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
-			return boxliteImageLayoutResult{}, false, pullErr
+
+	switch strings.ToLower(strings.TrimSpace(pullPolicy)) {
+	case "always":
+		// Bound only the pull with ImagePullTimeout (matches the docker path); the
+		// subsequent materialize/unpack keeps the parent ctx.
+		pullCtx := ctx
+		if config.ImagePullTimeout > 0 {
+			var pullCancel context.CancelFunc
+			pullCtx, pullCancel = context.WithTimeout(ctx, config.ImagePullTimeout)
+			defer pullCancel()
 		}
-		result, err = cache.MaterializeOCILayout(ctx, imageRef)
+		if _, pullErr := cache.Pull(pullCtx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
+			result, localErr := cache.MaterializeOCILayout(ctx, imageRef)
+			if localErr == nil {
+				slog.Warn("boxlite guest image pull failed, using cached local image", "image", imageRef, "pull_error", pullErr)
+				return boxliteImageLayoutResult{
+					ImageID:     result.ImageID,
+					ResolvedRef: result.ResolvedRef,
+					RootfsPath:  result.LayoutPath,
+				}, true, nil
+			}
+			return boxliteImageLayoutResult{}, false, fmt.Errorf("guest image %s: pull failed (%w) and not found locally: %v", imageRef, pullErr, localErr)
+		}
+		result, err := cache.MaterializeOCILayout(ctx, imageRef)
+		if err != nil {
+			return boxliteImageLayoutResult{}, false, err
+		}
+		return boxliteImageLayoutResult{
+			ImageID:     result.ImageID,
+			ResolvedRef: result.ResolvedRef,
+			RootfsPath:  result.LayoutPath,
+		}, true, nil
+
+	case "never":
+		result, err := cache.MaterializeOCILayout(ctx, imageRef)
+		if imagecache.IsKind(err, imagecache.ErrorKindNotFound) {
+			return boxliteImageLayoutResult{}, false, fmt.Errorf("guest image %s: not found locally (pull_policy=never)", imageRef)
+		}
+		if err != nil {
+			return boxliteImageLayoutResult{}, false, err
+		}
+		return boxliteImageLayoutResult{
+			ImageID:     result.ImageID,
+			ResolvedRef: result.ResolvedRef,
+			RootfsPath:  result.LayoutPath,
+		}, true, nil
+
+	default:
+		// "missing" or empty: existing behavior
+		result, err := cache.MaterializeOCILayout(ctx, imageRef)
+		if imagecache.IsKind(err, imagecache.ErrorKindNotFound) {
+			if _, pullErr := cache.Pull(ctx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
+				return boxliteImageLayoutResult{}, false, pullErr
+			}
+			result, err = cache.MaterializeOCILayout(ctx, imageRef)
+		}
+		if err != nil {
+			return boxliteImageLayoutResult{}, false, err
+		}
+		return boxliteImageLayoutResult{
+			ImageID:     result.ImageID,
+			ResolvedRef: result.ResolvedRef,
+			RootfsPath:  result.LayoutPath,
+		}, true, nil
 	}
-	if err != nil {
-		return boxliteImageLayoutResult{}, false, err
-	}
-	return boxliteImageLayoutResult{
-		ImageID:     result.ImageID,
-		ResolvedRef: result.ResolvedRef,
-		RootfsPath:  result.LayoutPath,
-	}, true, nil
 }

--- a/pkg/driver/boxlite_image_resolver.go
+++ b/pkg/driver/boxlite_image_resolver.go
@@ -17,6 +17,10 @@ type boxliteImageResolverOps struct {
 	dockerAvailable   func(context.Context) bool
 	dockerMaterialize func(context.Context, string) (boxliteImageLayoutResult, bool, error)
 	ociMaterialize    func(context.Context, string) (boxliteImageLayoutResult, bool, error)
+	// applyDockerPullPolicy refreshes/gates the local docker-daemon image per
+	// pullPolicy before dockerMaterialize reads it. Optional; when nil the
+	// docker short circuit keeps its prior (pullPolicy-unaware) behavior.
+	applyDockerPullPolicy func(context.Context, string) error
 }
 
 func resolveBoxliteImageLayout(ctx context.Context, imageRef string, ops boxliteImageResolverOps) (boxliteImageLayoutResult, bool, error) {
@@ -25,6 +29,14 @@ func resolveBoxliteImageLayout(ctx context.Context, imageRef string, ops boxlite
 		return boxliteImageLayoutResult{}, false, nil
 	}
 	if ops.dockerAvailable != nil && ops.dockerAvailable(ctx) && ops.dockerMaterialize != nil {
+		// Apply pullPolicy at the docker-daemon layer first so pullPolicy=always
+		// re-pulls an updated same-tag image (rather than the short circuit
+		// reusing the stale local copy), and pullPolicy=never fails fast.
+		if ops.applyDockerPullPolicy != nil {
+			if err := ops.applyDockerPullPolicy(ctx, imageRef); err != nil {
+				return boxliteImageLayoutResult{}, false, err
+			}
+		}
 		layout, ok, err := ops.dockerMaterialize(ctx, imageRef)
 		if err != nil || ok {
 			return layout, ok, err

--- a/pkg/driver/boxlite_image_resolver_test.go
+++ b/pkg/driver/boxlite_image_resolver_test.go
@@ -84,6 +84,52 @@ func TestResolveBoxliteImageLayoutPropagatesDockerError(t *testing.T) {
 	}
 }
 
+// Regression: pullPolicy must be applied at the docker-daemon layer BEFORE the
+// docker short circuit materializes a (possibly stale) local image. Without this
+// pullPolicy=always never re-pulls an updated same-tag image.
+func TestResolveBoxliteImageLayoutAppliesPullPolicyBeforeDockerMaterialize(t *testing.T) {
+	var order []string
+	_, ok, err := resolveBoxliteImageLayout(context.Background(), "guest:latest", boxliteImageResolverOps{
+		dockerAvailable: func(ctx context.Context) bool { return true },
+		applyDockerPullPolicy: func(ctx context.Context, imageRef string) error {
+			order = append(order, "pull")
+			return nil
+		},
+		dockerMaterialize: func(ctx context.Context, imageRef string) (boxliteImageLayoutResult, bool, error) {
+			order = append(order, "materialize")
+			return boxliteImageLayoutResult{RootfsPath: "/docker/oci"}, true, nil
+		},
+	})
+	if err != nil || !ok {
+		t.Fatalf("resolve ok=%v err=%v", ok, err)
+	}
+	if len(order) != 2 || order[0] != "pull" || order[1] != "materialize" {
+		t.Fatalf("expected pull before materialize, got %v", order)
+	}
+}
+
+// Regression: when the docker-layer pull policy errors (e.g. never + absent, or
+// always pull failure with no local cache), materialization must be skipped and
+// the error propagated — not silently fall through to a stale image.
+func TestResolveBoxliteImageLayoutPullPolicyErrorSkipsMaterialize(t *testing.T) {
+	wantErr := errors.New("not found locally (pull_policy=never)")
+	_, _, err := resolveBoxliteImageLayout(context.Background(), "guest:latest", boxliteImageResolverOps{
+		dockerAvailable:       func(ctx context.Context) bool { return true },
+		applyDockerPullPolicy: func(ctx context.Context, imageRef string) error { return wantErr },
+		dockerMaterialize: func(ctx context.Context, imageRef string) (boxliteImageLayoutResult, bool, error) {
+			t.Fatalf("dockerMaterialize must not run after pull-policy error")
+			return boxliteImageLayoutResult{}, false, nil
+		},
+		ociMaterialize: func(ctx context.Context, imageRef string) (boxliteImageLayoutResult, bool, error) {
+			t.Fatalf("ociMaterialize must not run after pull-policy error")
+			return boxliteImageLayoutResult{}, false, nil
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}
+
 func TestImageCacheRootForDriverDefaultsToDataRoot(t *testing.T) {
 	if got := imageCacheRootForDriver(testPrepareSessionStartConfig("/tmp/data-root")); got != "/tmp/data-root/images" {
 		t.Fatalf("imageCacheRootForDriver = %q", got)

--- a/pkg/driver/docker_image.go
+++ b/pkg/driver/docker_image.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	pathpkg "path"
 	"strings"
+	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
 	distreference "github.com/distribution/reference"
@@ -15,7 +17,7 @@ import (
 	"github.com/docker/docker/client"
 )
 
-func ensureDockerImage(ctx context.Context, imageRef string) (string, error) {
+func ensureDockerImage(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
 	imageRef = strings.TrimSpace(imageRef)
 	if imageRef == "" {
 		return "", nil
@@ -27,32 +29,127 @@ func ensureDockerImage(ctx context.Context, imageRef string) (string, error) {
 	}
 	defer func() { _ = dockerClient.Close() }()
 
-	if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
-		return resolvedRef, nil
-	} else if err != nil {
-		return "", fmt.Errorf("inspect guest image %s: %w", imageRef, err)
-	}
+	switch pullPolicy {
+	case "never":
+		if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
+			return resolvedRef, nil
+		} else if err != nil {
+			return "", fmt.Errorf("inspect guest image %s: %w", imageRef, err)
+		}
+		return "", fmt.Errorf("guest image %s: not found locally (pull_policy=never)", imageRef)
 
+	case "always":
+		pullCtx, pullCancel := context.WithTimeout(ctx, pullTimeout)
+		defer pullCancel()
+		pullErr := dockerImagePull(pullCtx, dockerClient, imageRef)
+		if pullErr != nil {
+			if resolvedRef, ok, resolveErr := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); resolveErr == nil && ok {
+				slog.Warn("guest image pull failed, using cached local image", "image", imageRef, "pull_error", pullErr)
+				return resolvedRef, nil
+			}
+			return "", fmt.Errorf("guest image %s: pull failed (%w) and not found locally", imageRef, pullErr)
+		}
+		if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
+			return resolvedRef, nil
+		} else if err != nil {
+			return "", fmt.Errorf("inspect pulled guest image %s: %w", imageRef, err)
+		}
+		return imageRef, nil
+
+	default:
+		// "missing" or empty: check local first, pull only if missing.
+		// NOTE: the default path intentionally uses the bare parent ctx for the
+		// pull (no pullTimeout) so behavior is byte-identical to the pre-pullPolicy
+		// code. Only the "always" path applies pullTimeout.
+		if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
+			return resolvedRef, nil
+		} else if err != nil {
+			return "", fmt.Errorf("inspect guest image %s: %w", imageRef, err)
+		}
+		if err := dockerImagePull(ctx, dockerClient, imageRef); err != nil {
+			return "", fmt.Errorf("pull guest image %s: %w", imageRef, err)
+		}
+		if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
+			return resolvedRef, nil
+		} else if err != nil {
+			return "", fmt.Errorf("inspect pulled guest image %s: %w", imageRef, err)
+		}
+		return imageRef, nil
+	}
+}
+
+func dockerImagePull(ctx context.Context, dockerClient *client.Client, imageRef string) error {
 	reader, err := dockerClient.ImagePull(ctx, imageRef, typesimage.PullOptions{})
 	if err != nil {
-		return "", fmt.Errorf("pull guest image %s: %w", imageRef, err)
+		return err
 	}
 	defer func() { _ = reader.Close() }()
+	return consumeDockerPullStream(reader)
+}
 
-	if err := consumeDockerPullStream(reader); err != nil {
-		return "", fmt.Errorf("pull guest image %s: %w", imageRef, err)
+// applyDockerDaemonPullPolicy refreshes (or gates) the local docker-daemon copy
+// of imageRef according to pullPolicy, BEFORE a caller materializes a rootfs/OCI
+// layout from that local copy. The microsandbox and boxlite drivers resolve
+// images through the local docker daemon first; without this the daemon short
+// circuit returns a stale local image and pullPolicy=always never re-pulls.
+//
+//   - "always": pull imageRef into the local daemon (bounded by pullTimeout). On
+//     pull failure fall back to the existing local copy if present (warn), else
+//     error carrying the pull cause.
+//   - "never": do not pull; error only if the image is absent locally.
+//   - "missing"/empty: no-op — the caller's existing local-first + IfMissing
+//     behavior is preserved byte-for-byte.
+//
+// It never mutates the caller's control flow beyond the pull; materialization
+// still runs afterward on the (possibly refreshed) local image.
+func applyDockerDaemonPullPolicy(ctx context.Context, imageRef, pullPolicy string, pullTimeout time.Duration) error {
+	imageRef = strings.TrimSpace(imageRef)
+	if imageRef == "" {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(pullPolicy)) {
+	case "always", "never":
+		// handled below
+	default:
+		return nil // missing / empty: preserve prior behavior exactly
 	}
 
-	if resolvedRef, ok, err := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); err == nil && ok {
-		return resolvedRef, nil
-	} else if err != nil {
-		return "", fmt.Errorf("inspect pulled guest image %s: %w", imageRef, err)
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		// No reachable daemon: let the caller fall through to its OCI path,
+		// which applies pullPolicy on its own.
+		return nil
 	}
-	return imageRef, nil
+	defer func() { _ = dockerClient.Close() }()
+
+	switch strings.ToLower(strings.TrimSpace(pullPolicy)) {
+	case "never":
+		if _, ok, resolveErr := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); resolveErr == nil && ok {
+			return nil
+		}
+		return fmt.Errorf("guest image %s: not found locally (pull_policy=never)", imageRef)
+
+	case "always":
+		pullCtx := ctx
+		if pullTimeout > 0 {
+			var cancel context.CancelFunc
+			pullCtx, cancel = context.WithTimeout(ctx, pullTimeout)
+			defer cancel()
+		}
+		if pullErr := dockerImagePull(pullCtx, dockerClient, imageRef); pullErr != nil {
+			if _, ok, resolveErr := resolveLocalDockerImageRef(ctx, dockerClient, imageRef); resolveErr == nil && ok {
+				slog.Warn("guest image pull failed, using cached local image", "image", imageRef, "pull_error", pullErr)
+				return nil
+			}
+			return fmt.Errorf("guest image %s: pull failed (%w) and not found locally", imageRef, pullErr)
+		}
+		return nil
+	}
+	return nil
 }
 
 func EnsureDockerImage(ctx context.Context, imageRef string) (string, error) {
-	return ensureDockerImage(ctx, imageRef)
+	return ensureDockerImage(ctx, imageRef, "", 10*time.Minute)
 }
 
 func resolveLocalDockerImageRef(ctx context.Context, dockerClient *client.Client, imageRef string) (string, bool, error) {

--- a/pkg/driver/docker_image.go
+++ b/pkg/driver/docker_image.go
@@ -116,9 +116,14 @@ func applyDockerDaemonPullPolicy(ctx context.Context, imageRef, pullPolicy strin
 
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		// No reachable daemon: let the caller fall through to its OCI path,
-		// which applies pullPolicy on its own.
-		return nil
+		// This runs only after the caller has confirmed the docker daemon is
+		// available (the resolve* paths gate this behind dockerAvailable==true)
+		// and BEFORE it materializes from the local daemon copy. Silently
+		// returning nil here would let the caller proceed to dockerMaterialize
+		// with policy unenforced — pull_policy=always would skip the re-pull and
+		// pull_policy=never would skip the local existence check. Surface the
+		// error so the caller aborts instead of using an unvalidated image.
+		return fmt.Errorf("connect docker daemon for pull-policy check %s: %w", imageRef, err)
 	}
 	defer func() { _ = dockerClient.Close() }()
 

--- a/pkg/driver/microsandbox_image_resolver.go
+++ b/pkg/driver/microsandbox_image_resolver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
@@ -18,6 +19,10 @@ type microsandboxImageResolverOps struct {
 	dockerAvailable   func(context.Context) bool
 	dockerMaterialize func(context.Context, string) (microsandboxRootFSResult, bool, error)
 	ociMaterialize    func(context.Context, string) (microsandboxRootFSResult, bool, error)
+	// applyDockerPullPolicy refreshes/gates the local docker-daemon image per
+	// pullPolicy before dockerMaterialize reads it. Optional; when nil the
+	// docker short circuit keeps its prior (pullPolicy-unaware) behavior.
+	applyDockerPullPolicy func(context.Context, string) error
 }
 
 func resolveMicrosandboxRootFS(ctx context.Context, imageRef string, ops microsandboxImageResolverOps) (microsandboxRootFSResult, bool, error) {
@@ -26,6 +31,15 @@ func resolveMicrosandboxRootFS(ctx context.Context, imageRef string, ops microsa
 		return microsandboxRootFSResult{}, false, nil
 	}
 	if ops.dockerAvailable != nil && ops.dockerAvailable(ctx) && ops.dockerMaterialize != nil {
+		// Apply pullPolicy at the docker-daemon layer first so that
+		// pullPolicy=always re-pulls an updated same-tag image (instead of the
+		// short circuit silently reusing the stale local copy), and
+		// pullPolicy=never fails fast when the image is absent.
+		if ops.applyDockerPullPolicy != nil {
+			if err := ops.applyDockerPullPolicy(ctx, imageRef); err != nil {
+				return microsandboxRootFSResult{}, false, err
+			}
+		}
 		rootfs, ok, err := ops.dockerMaterialize(ctx, imageRef)
 		if err != nil || ok {
 			return rootfs, ok, err
@@ -37,7 +51,7 @@ func resolveMicrosandboxRootFS(ctx context.Context, imageRef string, ops microsa
 	return ops.ociMaterialize(ctx, imageRef)
 }
 
-func materializeMicrosandboxOCIRootFS(ctx context.Context, config *appconfig.Config, imageRef string) (microsandboxRootFSResult, bool, error) {
+func materializeMicrosandboxOCIRootFS(ctx context.Context, config *appconfig.Config, imageRef, pullPolicy string) (microsandboxRootFSResult, bool, error) {
 	cache, err := imagecache.New(imagecache.Config{
 		Root:               imageCacheRootForDriver(config),
 		DefaultRegistry:    config.ImageRegistry,
@@ -46,8 +60,40 @@ func materializeMicrosandboxOCIRootFS(ctx context.Context, config *appconfig.Con
 	if err != nil {
 		return microsandboxRootFSResult{}, false, err
 	}
+
+	policy := strings.ToLower(strings.TrimSpace(pullPolicy))
+
+	// always: pull first (best-effort — fall back to any cached copy on failure),
+	// then materialize. Bound only the pull with ImagePullTimeout (matches the
+	// docker and boxlite OCI paths); materialize keeps the parent ctx.
+	if policy == "always" {
+		pullCtx := ctx
+		if config.ImagePullTimeout > 0 {
+			var pullCancel context.CancelFunc
+			pullCtx, pullCancel = context.WithTimeout(ctx, config.ImagePullTimeout)
+			defer pullCancel()
+		}
+		if _, pullErr := cache.Pull(pullCtx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
+			result, matErr := cache.MaterializeRootFS(ctx, imageRef)
+			if matErr == nil {
+				return microsandboxRootFSResult{ImageID: result.ImageID, ResolvedRef: result.ResolvedRef, RootFSPath: result.RootFSPath}, true, nil
+			}
+			return microsandboxRootFSResult{}, false, fmt.Errorf("guest image %s: pull failed (%w) and not found locally", imageRef, pullErr)
+		}
+		result, matErr := cache.MaterializeRootFS(ctx, imageRef)
+		if matErr != nil {
+			return microsandboxRootFSResult{}, false, matErr
+		}
+		return microsandboxRootFSResult{ImageID: result.ImageID, ResolvedRef: result.ResolvedRef, RootFSPath: result.RootFSPath}, true, nil
+	}
+
 	result, err := cache.MaterializeRootFS(ctx, imageRef)
 	if imagecache.IsKind(err, imagecache.ErrorKindNotFound) {
+		// never: do not pull; report not-found.
+		if policy == "never" {
+			return microsandboxRootFSResult{}, false, fmt.Errorf("guest image %s: not found locally (pull_policy=never)", imageRef)
+		}
+		// missing/empty: pull only when absent (prior default behavior).
 		if _, pullErr := cache.Pull(ctx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
 			return microsandboxRootFSResult{}, false, pullErr
 		}

--- a/pkg/driver/microsandbox_image_resolver_test.go
+++ b/pkg/driver/microsandbox_image_resolver_test.go
@@ -83,3 +83,48 @@ func TestResolveMicrosandboxRootFSPropagatesDockerError(t *testing.T) {
 		t.Fatalf("resolveMicrosandboxRootFS err = %v, want %v", err, wantErr)
 	}
 }
+
+// Regression: pullPolicy must be applied at the docker-daemon layer BEFORE the
+// docker short circuit materializes a (possibly stale) local image. Without this
+// pullPolicy=always never re-pulls an updated same-tag image.
+func TestResolveMicrosandboxRootFSAppliesPullPolicyBeforeDockerMaterialize(t *testing.T) {
+	var order []string
+	_, ok, err := resolveMicrosandboxRootFS(context.Background(), "guest:latest", microsandboxImageResolverOps{
+		dockerAvailable: func(ctx context.Context) bool { return true },
+		applyDockerPullPolicy: func(ctx context.Context, imageRef string) error {
+			order = append(order, "pull")
+			return nil
+		},
+		dockerMaterialize: func(ctx context.Context, imageRef string) (microsandboxRootFSResult, bool, error) {
+			order = append(order, "materialize")
+			return microsandboxRootFSResult{RootFSPath: "/docker/rootfs"}, true, nil
+		},
+	})
+	if err != nil || !ok {
+		t.Fatalf("resolve ok=%v err=%v", ok, err)
+	}
+	if len(order) != 2 || order[0] != "pull" || order[1] != "materialize" {
+		t.Fatalf("expected pull before materialize, got %v", order)
+	}
+}
+
+// Regression: a docker-layer pull-policy error must skip materialization and
+// propagate — not silently reuse a stale image.
+func TestResolveMicrosandboxRootFSPullPolicyErrorSkipsMaterialize(t *testing.T) {
+	wantErr := errors.New("not found locally (pull_policy=never)")
+	_, _, err := resolveMicrosandboxRootFS(context.Background(), "guest:latest", microsandboxImageResolverOps{
+		dockerAvailable:       func(ctx context.Context) bool { return true },
+		applyDockerPullPolicy: func(ctx context.Context, imageRef string) error { return wantErr },
+		dockerMaterialize: func(ctx context.Context, imageRef string) (microsandboxRootFSResult, bool, error) {
+			t.Fatalf("dockerMaterialize must not run after pull-policy error")
+			return microsandboxRootFSResult{}, false, nil
+		},
+		ociMaterialize: func(ctx context.Context, imageRef string) (microsandboxRootFSResult, bool, error) {
+			t.Fatalf("ociMaterialize must not run after pull-policy error")
+			return microsandboxRootFSResult{}, false, nil
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}

--- a/pkg/driver/microsandbox_pull_policy_test.go
+++ b/pkg/driver/microsandbox_pull_policy_test.go
@@ -9,10 +9,27 @@ import (
 )
 
 func TestMicrosandboxPullPolicyForImageRef(t *testing.T) {
-	if got := microsandboxPullPolicyForImageRef("/cache/rootfs"); got != microsandbox.PullPolicyNever {
-		t.Fatalf("absolute rootfs pull policy = %v, want Never", got)
+	// absolute path is always Never regardless of perCallPolicy
+	if got := microsandboxPullPolicyForImageRef("/cache/rootfs", ""); got != microsandbox.PullPolicyNever {
+		t.Fatalf("absolute rootfs pull policy (empty) = %v, want Never", got)
 	}
-	if got := microsandboxPullPolicyForImageRef("guest:latest"); got != microsandbox.PullPolicyIfMissing {
-		t.Fatalf("image ref pull policy = %v, want IfMissing", got)
+	if got := microsandboxPullPolicyForImageRef("/cache/rootfs", "always"); got != microsandbox.PullPolicyNever {
+		t.Fatalf("absolute rootfs pull policy (always) = %v, want Never", got)
+	}
+	// non-absolute with empty perCallPolicy: default behavior = IfMissing (unchanged)
+	if got := microsandboxPullPolicyForImageRef("guest:latest", ""); got != microsandbox.PullPolicyIfMissing {
+		t.Fatalf("image ref pull policy (empty) = %v, want IfMissing", got)
+	}
+	// non-absolute with "missing": same as default
+	if got := microsandboxPullPolicyForImageRef("guest:latest", "missing"); got != microsandbox.PullPolicyIfMissing {
+		t.Fatalf("image ref pull policy (missing) = %v, want IfMissing", got)
+	}
+	// non-absolute with "always"
+	if got := microsandboxPullPolicyForImageRef("guest:latest", "always"); got != microsandbox.PullPolicyAlways {
+		t.Fatalf("image ref pull policy (always) = %v, want Always", got)
+	}
+	// non-absolute with "never"
+	if got := microsandboxPullPolicyForImageRef("guest:latest", "never"); got != microsandbox.PullPolicyNever {
+		t.Fatalf("image ref pull policy (never) = %v, want Never", got)
 	}
 }

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -858,7 +858,11 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sessio
 	// user tmpfs mounts are applied, so shadowing /run here is safe.
 	mounts["/run"] = microsandbox.Mount.Tmpfs(microsandbox.TmpfsOptions{SizeMiB: 256})
 	imageRef := resolveSessionGuestImage(vmState.Image, session.Summary.GuestImage, defaultGuestImageForDriver(r.config, RuntimeDriverMicrosandbox))
-	if resolvedRef, ok, err := r.resolveMicrosandboxImageRef(ctx, imageRef); err != nil {
+	imagePullTimeout := r.config.ImagePullTimeout
+	if imagePullTimeout <= 0 {
+		imagePullTimeout = defaultImagePullTimeout
+	}
+	if resolvedRef, ok, err := r.resolveMicrosandboxImageRef(ctx, imageRef, session.Summary.PullPolicy, imagePullTimeout); err != nil {
 		return nil, err
 	} else if ok {
 		imageRef = resolvedRef
@@ -874,7 +878,7 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sessio
 	env["STATE_ROOT"] = r.config.GuestStateRoot
 	env["RUNTIME_ROOT"] = r.config.GuestRuntimeRoot
 	env["JUPYTER_TOKEN"] = proxyState.Token
-	pullPolicy := microsandboxPullPolicyForImageRef(imageRef)
+	pullPolicy := microsandboxPullPolicyForImageRef(imageRef, session.Summary.PullPolicy)
 	// Disable DNS rebind protection so guests can resolve names that point at
 	// private/internal IPs (e.g. an internal container registry).
 	rebindDisabled := false
@@ -905,9 +909,12 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sessio
 	return sandbox, nil
 }
 
-func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, imageRef string) (string, bool, error) {
+func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, imageRef, pullPolicy string, pullTimeout time.Duration) (string, bool, error) {
 	rootfs, ok, err := resolveMicrosandboxRootFS(ctx, imageRef, microsandboxImageResolverOps{
 		dockerAvailable: dockerDaemonAvailable,
+		applyDockerPullPolicy: func(ctx context.Context, imageRef string) error {
+			return applyDockerDaemonPullPolicy(ctx, imageRef, pullPolicy, pullTimeout)
+		},
 		dockerMaterialize: func(ctx context.Context, imageRef string) (microsandboxRootFSResult, bool, error) {
 			rootfs, ok, err := materializeLocalDockerImageRootfs(ctx, r.config.DataRoot, imageRef)
 			if err != nil || !ok {
@@ -916,7 +923,7 @@ func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, i
 			return microsandboxRootFSResult{ImageID: rootfs.ImageID, ResolvedRef: rootfs.ResolvedRef, RootFSPath: rootfs.RootfsPath}, true, nil
 		},
 		ociMaterialize: func(ctx context.Context, imageRef string) (microsandboxRootFSResult, bool, error) {
-			return materializeMicrosandboxOCIRootFS(ctx, r.config, imageRef)
+			return materializeMicrosandboxOCIRootFS(ctx, r.config, imageRef, pullPolicy)
 		},
 	})
 	if err != nil {
@@ -929,11 +936,18 @@ func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, i
 	return "", false, nil
 }
 
-func microsandboxPullPolicyForImageRef(imageRef string) microsandbox.PullPolicy {
+func microsandboxPullPolicyForImageRef(imageRef string, perCallPolicy string) microsandbox.PullPolicy {
 	if filepath.IsAbs(imageRef) {
 		return microsandbox.PullPolicyNever
 	}
-	return microsandbox.PullPolicyIfMissing
+	switch strings.ToLower(strings.TrimSpace(perCallPolicy)) {
+	case "always":
+		return microsandbox.PullPolicyAlways
+	case "never":
+		return microsandbox.PullPolicyNever
+	default:
+		return microsandbox.PullPolicyIfMissing
+	}
 }
 
 func (r *microsandboxRuntime) launchJupyter(ctx context.Context, sandbox *microsandbox.Sandbox, proxyState ProxyState) error {

--- a/pkg/driver/pull_policy_test.go
+++ b/pkg/driver/pull_policy_test.go
@@ -1,0 +1,120 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEnsureDockerImageEmptyPolicyPassedThrough(t *testing.T) {
+	var gotPolicy string
+	resolver := dockerFirstRuntimeImageResolver{
+		ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
+			gotPolicy = pullPolicy
+			return imageRef, nil
+		},
+	}
+	root := t.TempDir()
+	config := testPrepareSessionStartConfig(root)
+	session := testRuntimeMountSession(root)
+	session.Summary.PullPolicy = ""
+
+	_, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, "", 10*time.Minute, resolver)
+	if err != nil {
+		t.Fatalf("empty pullPolicy returned error: %v", err)
+	}
+	if gotPolicy != "" {
+		t.Fatalf("expected empty pullPolicy to be passed as empty, got %q", gotPolicy)
+	}
+}
+
+func TestEnsureDockerImageAlwaysPullPolicyPassedThrough(t *testing.T) {
+	var gotPolicy string
+	resolver := dockerFirstRuntimeImageResolver{
+		ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
+			gotPolicy = pullPolicy
+			return imageRef + "@sha256:updated", nil
+		},
+	}
+	root := t.TempDir()
+	config := testPrepareSessionStartConfig(root)
+	session := testRuntimeMountSession(root)
+	session.Summary.PullPolicy = "always"
+
+	state, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, "always", 10*time.Minute, resolver)
+	if err != nil {
+		t.Fatalf("always pullPolicy returned error: %v", err)
+	}
+	if gotPolicy != "always" {
+		t.Fatalf("expected pullPolicy=always to be passed through, got %q", gotPolicy)
+	}
+	if state.Image == "" {
+		t.Fatalf("expected resolved image, got empty")
+	}
+}
+
+func TestEnsureDockerImageNeverPullPolicyPassedThrough(t *testing.T) {
+	var gotPolicy string
+	resolver := dockerFirstRuntimeImageResolver{
+		ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
+			gotPolicy = pullPolicy
+			return imageRef, nil
+		},
+	}
+	root := t.TempDir()
+	config := testPrepareSessionStartConfig(root)
+	session := testRuntimeMountSession(root)
+	session.Summary.PullPolicy = "never"
+
+	_, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, "never", 10*time.Minute, resolver)
+	if err != nil {
+		t.Fatalf("never pullPolicy returned error: %v", err)
+	}
+	if gotPolicy != "never" {
+		t.Fatalf("expected pullPolicy=never to be passed through, got %q", gotPolicy)
+	}
+}
+
+func TestEnsureDockerImageAlwaysFallsBackToLocalOnPullFailure(t *testing.T) {
+	pullErr := errors.New("registry unavailable")
+	resolver := dockerFirstRuntimeImageResolver{
+		ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
+			return "", pullErr
+		},
+	}
+	root := t.TempDir()
+	config := testPrepareSessionStartConfig(root)
+	session := testRuntimeMountSession(root)
+	session.Summary.PullPolicy = "always"
+
+	_, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, "always", 10*time.Minute, resolver)
+	if err == nil {
+		t.Fatalf("expected error when ensure returns error, got nil")
+	}
+	if !errors.Is(err, pullErr) {
+		t.Fatalf("expected pullErr in error chain, got: %v", err)
+	}
+}
+
+func TestPullPolicyTimeoutPassedThrough(t *testing.T) {
+	var gotTimeout time.Duration
+	resolver := dockerFirstRuntimeImageResolver{
+		ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
+			gotTimeout = pullTimeout
+			return imageRef, nil
+		},
+	}
+	root := t.TempDir()
+	config := testPrepareSessionStartConfig(root)
+	session := testRuntimeMountSession(root)
+
+	wantTimeout := 5 * time.Minute
+	_, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, "", wantTimeout, resolver)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotTimeout != wantTimeout {
+		t.Fatalf("pullTimeout = %v, want %v", gotTimeout, wantTimeout)
+	}
+}

--- a/pkg/driver/session_start.go
+++ b/pkg/driver/session_start.go
@@ -7,13 +7,21 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 )
 
+const defaultImagePullTimeout = 10 * time.Minute
+
 func PrepareSessionStart(ctx context.Context, config *appconfig.Config, driver string, session *Session, vmState VMState) (VMState, error) {
-	return prepareSessionStartWithResolver(ctx, config, driver, session, vmState, dockerFirstRuntimeImageResolver{ensureDocker: ensureDockerImage})
+	pullTimeout := config.ImagePullTimeout
+	if pullTimeout <= 0 {
+		pullTimeout = defaultImagePullTimeout
+	}
+	pullPolicy := strings.ToLower(strings.TrimSpace(session.Summary.PullPolicy))
+	return prepareSessionStartWithResolver(ctx, config, driver, session, vmState, pullPolicy, pullTimeout, dockerFirstRuntimeImageResolver{ensureDocker: ensureDockerImage})
 }
 
-func prepareSessionStartWithResolver(ctx context.Context, config *appconfig.Config, driver string, session *Session, vmState VMState, resolver runtimeImageResolver) (VMState, error) {
+func prepareSessionStartWithResolver(ctx context.Context, config *appconfig.Config, driver string, session *Session, vmState VMState, pullPolicy string, pullTimeout time.Duration, resolver runtimeImageResolver) (VMState, error) {
 	if _, err := prepareRuntimeMountManifest(config, session, driver); err != nil {
 		return vmState, err
 	}
@@ -26,7 +34,7 @@ func prepareSessionStartWithResolver(ctx context.Context, config *appconfig.Conf
 		vmState.Registry = config.ImageRegistry
 		if vmState.Image != "" {
 			slog.Info("agent-compose resolving boxlite guest image", "session_id", session.Summary.ID, "guest_image", vmState.Image)
-			resolvedImage, err := resolver.ResolvePrepareImage(ctx, config, driver, vmState.Image)
+			resolvedImage, err := resolver.ResolvePrepareImage(ctx, config, driver, vmState.Image, pullPolicy, pullTimeout)
 			if err != nil {
 				return vmState, err
 			}
@@ -36,7 +44,7 @@ func prepareSessionStartWithResolver(ctx context.Context, config *appconfig.Conf
 		vmState.Registry = ""
 		if vmState.Image != "" {
 			slog.Info("agent-compose ensuring docker guest image", "session_id", session.Summary.ID, "guest_image", vmState.Image)
-			resolvedImage, err := resolver.ResolvePrepareImage(ctx, config, driver, vmState.Image)
+			resolvedImage, err := resolver.ResolvePrepareImage(ctx, config, driver, vmState.Image, pullPolicy, pullTimeout)
 			if err != nil {
 				return vmState, err
 			}
@@ -51,14 +59,14 @@ func prepareSessionStartWithResolver(ctx context.Context, config *appconfig.Conf
 }
 
 type runtimeImageResolver interface {
-	ResolvePrepareImage(context.Context, *appconfig.Config, string, string) (string, error)
+	ResolvePrepareImage(context.Context, *appconfig.Config, string, string, string, time.Duration) (string, error)
 }
 
 type dockerFirstRuntimeImageResolver struct {
-	ensureDocker func(context.Context, string) (string, error)
+	ensureDocker func(context.Context, string, string, time.Duration) (string, error)
 }
 
-func (r dockerFirstRuntimeImageResolver) ResolvePrepareImage(ctx context.Context, config *appconfig.Config, driver, imageRef string) (string, error) {
+func (r dockerFirstRuntimeImageResolver) ResolvePrepareImage(ctx context.Context, config *appconfig.Config, driver, imageRef, pullPolicy string, pullTimeout time.Duration) (string, error) {
 	imageRef = strings.TrimSpace(imageRef)
 	if imageRef == "" {
 		return "", nil
@@ -69,7 +77,7 @@ func (r dockerFirstRuntimeImageResolver) ResolvePrepareImage(ctx context.Context
 		if ensure == nil {
 			ensure = ensureDockerImage
 		}
-		return ensure(ctx, imageRef)
+		return ensure(ctx, imageRef, pullPolicy, pullTimeout)
 	case RuntimeDriverBoxlite, RuntimeDriverMicrosandbox:
 		return imageRef, nil
 	default:

--- a/pkg/driver/session_start_test.go
+++ b/pkg/driver/session_start_test.go
@@ -5,18 +5,19 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	appconfig "agent-compose/pkg/config"
 )
 
 func TestDockerFirstRuntimeImageResolverSkipsDockerForNonDockerPrepare(t *testing.T) {
 	called := false
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
 		called = true
 		return "", errors.New("docker unavailable")
 	}}
 	for _, driver := range []string{RuntimeDriverBoxlite, RuntimeDriverMicrosandbox} {
-		resolved, err := resolver.ResolvePrepareImage(context.Background(), &appconfig.Config{}, driver, "guest:latest")
+		resolved, err := resolver.ResolvePrepareImage(context.Background(), &appconfig.Config{}, driver, "guest:latest", "", 10*time.Minute)
 		if err != nil {
 			t.Fatalf("ResolvePrepareImage(%s) returned error: %v", driver, err)
 		}
@@ -33,11 +34,11 @@ func TestPrepareSessionStartBoxLiteDoesNotFailWhenDockerUnavailable(t *testing.T
 	root := t.TempDir()
 	config := testPrepareSessionStartConfig(root)
 	session := testRuntimeMountSession(root)
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
 		return "", errors.New("docker unavailable")
 	}}
 
-	state, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverBoxlite, session, VMState{}, resolver)
+	state, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverBoxlite, session, VMState{}, "", 10*time.Minute, resolver)
 	if err != nil {
 		t.Fatalf("PrepareSessionStart boxlite returned error: %v", err)
 	}
@@ -54,14 +55,14 @@ func TestPrepareSessionStartDockerStillRequiresDockerEnsure(t *testing.T) {
 	config := testPrepareSessionStartConfig(root)
 	session := testRuntimeMountSession(root)
 	wantErr := errors.New("docker unavailable")
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
 		if imageRef != config.DockerDefaultImage {
 			t.Fatalf("ensure imageRef = %q, want %q", imageRef, config.DockerDefaultImage)
 		}
 		return "", wantErr
 	}}
 
-	_, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, resolver)
+	_, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, "", 10*time.Minute, resolver)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("PrepareSessionStart docker error = %v, want %v", err, wantErr)
 	}
@@ -71,11 +72,11 @@ func TestPrepareSessionStartDockerUsesResolvedImage(t *testing.T) {
 	root := t.TempDir()
 	config := testPrepareSessionStartConfig(root)
 	session := testRuntimeMountSession(root)
-	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string) (string, error) {
+	resolver := dockerFirstRuntimeImageResolver{ensureDocker: func(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
 		return "guest@sha256:resolved", nil
 	}}
 
-	state, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, resolver)
+	state, err := prepareSessionStartWithResolver(context.Background(), config, RuntimeDriverDocker, session, VMState{}, "", 10*time.Minute, resolver)
 	if err != nil {
 		t.Fatalf("PrepareSessionStart docker returned error: %v", err)
 	}

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -17,6 +17,7 @@ type SessionSummary struct {
 	ID            string    `json:"id"`
 	Driver        string    `json:"driver"`
 	GuestImage    string    `json:"guest_image,omitempty"`
+	PullPolicy    string    `json:"pull_policy,omitempty"`
 	RuntimeRef    string    `json:"runtime_ref,omitempty"`
 	WorkspacePath string    `json:"workspace_path"`
 	CreatedAt     time.Time `json:"created_at"`

--- a/pkg/execution/driver.go
+++ b/pkg/execution/driver.go
@@ -22,6 +22,7 @@ func ToDriverSession(session *domain.Session) *driverpkg.Session {
 			ID:            session.Summary.ID,
 			Driver:        session.Summary.Driver,
 			GuestImage:    session.Summary.GuestImage,
+			PullPolicy:    session.Summary.PullPolicy,
 			RuntimeRef:    session.Summary.RuntimeRef,
 			WorkspacePath: session.Summary.WorkspacePath,
 			CreatedAt:     session.Summary.CreatedAt,

--- a/pkg/loaders/engine.go
+++ b/pkg/loaders/engine.go
@@ -998,6 +998,7 @@ func parseLoaderAgentRequest(args []*qjs.Value) (domain.LoaderAgentRequest, erro
 	request.Title = loaderStringOption(options, "title")
 	request.Driver = loaderStringOption(options, "driver")
 	request.GuestImage = loaderStringOption(options, "guestImage", "guest_image")
+	request.PullPolicy = normalizeImagePullPolicy(loaderStringOption(options, "pullPolicy", "pull_policy"))
 	request.WorkspaceID = loaderStringOption(options, "workspaceId", "workspace_id")
 	request.JupyterEnabled = loaderBoolOption(options, "jupyter")
 	request.SessionEnv, err = loaderSessionEnvOption(options)
@@ -1148,6 +1149,7 @@ func loaderCommandRequestFromOptions(options map[string]any, apiName string) (do
 		Title:          loaderStringOption(options, "title"),
 		Driver:         loaderStringOption(options, "driver"),
 		GuestImage:     loaderStringOption(options, "guestImage", "guest_image"),
+		PullPolicy:     normalizeImagePullPolicy(loaderStringOption(options, "pullPolicy", "pull_policy")),
 		WorkspaceID:    loaderStringOption(options, "workspaceId", "workspace_id"),
 		JupyterEnabled: loaderBoolOption(options, "jupyter"),
 	}
@@ -1548,4 +1550,17 @@ func loaderResultJSON(value *qjs.Value) (string, bool, error) {
 		return "", false, nil
 	}
 	return jsonValue, true, nil
+}
+
+func normalizeImagePullPolicy(policy string) string {
+	switch strings.ToLower(strings.TrimSpace(policy)) {
+	case "always":
+		return "always"
+	case "missing":
+		return "missing"
+	case "never":
+		return "never"
+	default:
+		return ""
+	}
 }

--- a/pkg/loaders/pull_policy_test.go
+++ b/pkg/loaders/pull_policy_test.go
@@ -1,0 +1,32 @@
+package loaders
+
+import (
+	"testing"
+)
+
+func TestNormalizeImagePullPolicy(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"always", "always"},
+		{"ALWAYS", "always"},
+		{"Always", "always"},
+		{"missing", "missing"},
+		{"Missing", "missing"},
+		{"MISSING", "missing"},
+		{"never", "never"},
+		{"NEVER", "never"},
+		{"Never", "never"},
+		{"", ""},
+		{"invalid", ""},
+		{"  always  ", "always"},
+		{"  never  ", "never"},
+	}
+	for _, tc := range cases {
+		got := normalizeImagePullPolicy(tc.input)
+		if got != tc.want {
+			t.Errorf("normalizeImagePullPolicy(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/pkg/loaders/run_host.go
+++ b/pkg/loaders/run_host.go
@@ -293,6 +293,7 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.LoaderCommandR
 		Title:          request.Title,
 		Driver:         request.Driver,
 		GuestImage:     request.GuestImage,
+		PullPolicy:     request.PullPolicy,
 		WorkspaceID:    request.WorkspaceID,
 		JupyterEnabled: request.JupyterEnabled,
 		SessionEnv:     request.SessionEnv,

--- a/pkg/model/loader_model.go
+++ b/pkg/model/loader_model.go
@@ -123,6 +123,7 @@ type LoaderAgentRequest struct {
 	Title          string          `json:"title,omitempty"`
 	Driver         string          `json:"driver,omitempty"`
 	GuestImage     string          `json:"guestImage,omitempty"`
+	PullPolicy     string          `json:"pullPolicy,omitempty"`
 	WorkspaceID    string          `json:"workspaceId,omitempty"`
 	JupyterEnabled bool            `json:"jupyter,omitempty"`
 	SessionEnv     []SessionEnvVar `json:"sessionEnv,omitempty"`
@@ -156,6 +157,7 @@ type LoaderCommandRequest struct {
 	Title          string            `json:"title,omitempty"`
 	Driver         string            `json:"driver,omitempty"`
 	GuestImage     string            `json:"guestImage,omitempty"`
+	PullPolicy     string            `json:"pullPolicy,omitempty"`
 	WorkspaceID    string            `json:"workspaceId,omitempty"`
 	JupyterEnabled bool              `json:"jupyter,omitempty"`
 	SessionEnv     []SessionEnvVar   `json:"sessionEnv,omitempty"`

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -107,6 +107,7 @@ type SessionSummary struct {
 	Driver        string       `json:"driver"`
 	VMStatus      string       `json:"vm_status"`
 	GuestImage    string       `json:"guest_image,omitempty"`
+	PullPolicy    string       `json:"pull_policy,omitempty"`
 	RuntimeRef    string       `json:"runtime_ref,omitempty"`
 	WorkspacePath string       `json:"workspace_path"`
 	ProxyPath     string       `json:"proxy_path"`


### PR DESCRIPTION
## 背景
之前的 always-pull PR 因把默认行为从 if-not-present 改成 always-pull 被 owner revert。owner 要求：**默认行为不变，always-pull 只能通过显式配置开启**，命名与 docker-compose 对齐。

## 改动
新增 per-call opts `pullPolicy`（也接受 `pull_policy`），在 `scheduler.shell` / `scheduler.agent` 里传。取值 `always` / `missing` / `never`（对齐 docker-compose `pull_policy` + docker CLI `--pull` 三取值），默认 `missing`。

- **默认行为逐字节不变**：不传 `pullPolicy` 时，四条 driver 路径（microsandbox / docker / boxlite / local-docker）行为与改动前完全一致——本地已有镜像（含 `:latest`）不会被重新 pull，除非显式 `pullPolicy: always`。
- **只做 per-call**：无全局 env、无默认策略开关。per-call opts 走 `scheduler.shell`/`scheduler.agent` 天然覆盖 per-loader-per-project（与 `guestImage`/`driver` 同机制）。
- `always`：best-effort pull，失败且本地有缓存 → warn 降级用本地；失败且本地无缓存 → 报错，错误同时带 pull 真因和 not-found。
- `never`：从不 pull，本地没有即报错。
- 新增可配置 `ImagePullTimeout`（env `IMAGE_PULL_TIMEOUT`，默认 10m），**只裹 `always` 的 pull**；默认/missing 路径保持裸 ctx 以严格守恒旧行为。
- 数据流：loader opts → `Loader{Agent,Command}Request` → `SessionSummary.PullPolicy` → `driver.SessionSummary` → 四条 driver image 路径。

## 用途
解决「同 tag 镜像（如 `agent-compose-guest:latest`）在 registry 更新后，本地旧缓存不被刷新、新 VM 跑旧镜像」的问题：需要每次拉最新的 loader 项目可在其 opts 里加 `pullPolicy: 'always'`，不影响其它项目。

## 测试
- `go build ./...` 通过。
- pkg/driver / pkg/agentcompose / pkg/config 测试全绿，新增：默认路径行为守恒、always 的 pull/降级/错误传播、非法值降级、normalize 用例。

## 备注
- boxlite 的 `always` 在本地 docker 镜像已存在时会短路（沿用本地优先设计），比 docker/microsandbox 弱；aiguard 走 docker/microsandbox 不受影响。
- `missing` 严格等于现有行为（`:latest` 本地有也不拉），未引入 compose「missing 时 latest 总拉」规则，以保证默认不变。