### PR TITLE
fix(microsandbox): destroy sandbox metadata on stop so restart rebuilds disk

### DIFF
--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -126,7 +126,13 @@ func (r *microsandboxRuntime) StopSession(ctx context.Context, session *Session,
 		return false, err
 	}
 	if handle.Status() != microsandbox.SandboxStatusRunning && handle.Status() != microsandbox.SandboxStatusDraining {
+		// Already stopped, but the sandbox metadata still persists in the
+		// daemon. Destroy it (and its docker disk) so a restart rebuilds
+		// from scratch instead of remounting the deleted disk. See
+		// removeSandboxState.
 		r.discardLifecycleHandle(name)
+		r.removeDockerDisk(session.Summary.ID)
+		r.removeSandboxState(ctx, name)
 		return false, nil
 	}
 
@@ -146,6 +152,7 @@ func (r *microsandboxRuntime) StopSession(ctx context.Context, session *Session,
 			return false, err
 		}
 		r.removeDockerDisk(session.Summary.ID)
+		r.removeSandboxState(ctx, name)
 		return false, nil
 	}
 
@@ -156,6 +163,7 @@ func (r *microsandboxRuntime) StopSession(ctx context.Context, session *Session,
 	if stale || sandbox == nil {
 		r.discardLifecycleHandle(name)
 		r.removeDockerDisk(session.Summary.ID)
+		r.removeSandboxState(ctx, name)
 		return true, nil
 	}
 	defer r.releaseSandboxHandle(name, sandbox)
@@ -167,6 +175,7 @@ func (r *microsandboxRuntime) StopSession(ctx context.Context, session *Session,
 		return false, err
 	}
 	r.removeDockerDisk(session.Summary.ID)
+	r.removeSandboxState(ctx, name)
 	return false, nil
 }
 
@@ -517,6 +526,23 @@ func (r *microsandboxRuntime) removeDockerDisk(sessionID string) {
 	path := r.dockerDiskPath(sessionID)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		slog.Warn("agent-compose microsandbox: failed to remove docker disk image", "path", path, "error", err)
+	}
+}
+
+// removeSandboxState purges a stopped sandbox's persisted metadata from the
+// microsandbox daemon so a later GetSandbox(name) returns ErrSandboxNotFound.
+// This matches the docker driver, which fully removes the container on stop:
+// without it, a restart would take the getOrCreateSandbox handle.Start() path
+// and remount the per-session docker disk that StopSession already deleted,
+// failing with "host path not found". Best-effort — a purge failure must not
+// mask the stop result; the daemon's gc reclaims any residue on restart.
+func (r *microsandboxRuntime) removeSandboxState(ctx context.Context, name string) {
+	if strings.TrimSpace(name) == "" {
+		return
+	}
+	if err := microsandbox.RemoveSandbox(ctx, name); err != nil &&
+		!microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound) {
+		slog.Warn("agent-compose microsandbox: failed to remove sandbox state", "name", name, "error", err)
 	}
 }
 


### PR DESCRIPTION
## 问题

microsandbox driver 的 session 重启（ResumeSession）会失败：

```
[internal] failed to start "agent-compose-<sessionid>":
disk var_lib_doc_<hash>: host path not found:
/data/microsandbox/docker-disks/<sessionID>.raw
```

## 根因

microsandbox 每个 session 是一个 microVM，VM 内跑 docker 需要一块 per-session 的 `<sessionID>.raw` 磁盘当 `/var/lib/docker`（guest root 是 virtiofs，内核拒绝 overlayfs，所以外挂真实块设备）。

`StopSession` 停止 session 时调 `removeDockerDisk` 删掉这块盘，但**没有删除 microsandbox daemon 里的 sandbox 元数据**。于是之后 `ResumeSession` 重启这条 session 时，`getOrCreateSandbox` 发现元数据还在（非 Running）→ 走 `handle.Start(ctx)` 复用旧配置 → 尝试重新挂载那块已被删除的 `.raw` 盘 → `host path not found`。

对比 docker driver：它 stop 时 `ContainerRemove(Force:true)` 彻底删容器，restart 查不到容器就全新建 → 不会有这个问题。microsandbox 的 stop「只删盘不删元数据」是半保留状态，与 restart「复用旧元数据」的假设不匹配，才出 bug。

## 修复

让 microsandbox 的 stop 语义对齐 docker driver：`StopSession` 在 `Stop` + `removeDockerDisk` 之后，再调 SDK 的 `microsandbox.RemoveSandbox` 彻底删除 daemon 侧元数据。这样后续 `GetSandbox` 返回 `ErrSandboxNotFound`，restart 走 `createSandbox` 全新建盘，不再复用已删的盘。

- 新增 `removeSandboxState` helper（best-effort：删除失败只 log，退回原行为，`gcDockerDisks` 兜底）。
- 在 `StopSession` 的 4 条 stop-成功 / 已停止路径调用它。
- 所有调用点都在 sandbox 已 stopped 之后，满足 SDK `RemoveSandbox` 的 "must be stopped" 契约。

## 验证

dev152 microsandbox 环境端到端实测：

- **修复前（基线）**：对一条 STOPPED 的 microsandbox session 调 ResumeSession → HTTP 500 `host path not found`（复现 bug）。
- **修复后**：用修复版跑一条新 microsandbox session 使其 stop（走修复版 StopSession，元数据被删）→ ResumeSession → **HTTP 200, vmStatus:RUNNING**，日志显示走 `createSandbox` 全新建盘路径。stop 后 daemon 侧 `agent-compose-<sid>` sandbox 元数据确认已消失。

改动仅 `pkg/driver/microsandbox_runtime.go`（+26 行），已独立 code review 通过。未加 FFI 路径单测，遵循仓库对 microsandbox driver 的既有测试惯例（靠端到端实测），与现有 microsandbox 测试策略一致。