### PR TITLE
fix(store): converge orphaned running cells on daemon startup

### DIFF
--- a/pkg/agentcompose/store.go
+++ b/pkg/agentcompose/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -27,7 +28,73 @@ func NewStore(di do.Injector) (*Store, error) {
 	if err := os.MkdirAll(config.SessionRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("create session root: %w", err)
 	}
-	return &Store{config: config}, nil
+	s := &Store{config: config}
+	s.convergeOrphanedRunningCells()
+	return s, nil
+}
+
+// convergeOrphanedRunningCells recovers cell state left behind when an agent
+// run is interrupted by a daemon restart. It runs once from NewStore, i.e.
+// before the server serves any request, so no run is active at this point and
+// every cell persisted with Running=true is an orphan. Without this, the UI
+// would stay stuck on "replying" and block further interaction with the
+// session. Orphan cells are marked finished (non-success, non-zero exit) with
+// an explanatory StopReason. Reads/writes the raw cells.json without hydration
+// so artifact files are not duplicated into cells.json. Best-effort: per-session
+// errors are logged and skipped.
+//
+// This MUST run only at startup. Calling it while a run is active would
+// incorrectly mark a genuinely running cell as finished.
+func (s *Store) convergeOrphanedRunningCells() {
+	entries, err := os.ReadDir(s.config.SessionRoot)
+	if err != nil {
+		slog.Warn("orphan cell recovery: read session root failed", "error", err)
+		return
+	}
+	const note = "run interrupted by daemon restart"
+	converged := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionID := entry.Name()
+		path := filepath.Join(s.sessionDir(sessionID), "state", "cells.json")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				slog.Warn("orphan cell recovery: read cells failed", "session_id", sessionID, "error", err)
+			}
+			continue
+		}
+		if len(data) == 0 {
+			continue
+		}
+		var cells []NotebookCell
+		if err := json.Unmarshal(data, &cells); err != nil {
+			slog.Warn("orphan cell recovery: decode cells failed", "session_id", sessionID, "error", err)
+			continue
+		}
+		changed := false
+		for i := range cells {
+			if !cells[i].Running {
+				continue
+			}
+			cells[i].Running = false
+			cells[i].Success = false
+			cells[i].ExitCode = 1
+			cells[i].StopReason = note
+			changed = true
+			converged++
+		}
+		if changed {
+			if err := s.saveCells(sessionID, cells); err != nil {
+				slog.Warn("orphan cell recovery: save cells failed", "session_id", sessionID, "error", err)
+			}
+		}
+	}
+	if converged > 0 {
+		slog.Info("orphan cell recovery: converged interrupted cells", "count", converged)
+	}
 }
 
 func cloneSessionWorkspace(item *SessionWorkspace) *SessionWorkspace {

--- a/pkg/agentcompose/store_orphan_cells_test.go
+++ b/pkg/agentcompose/store_orphan_cells_test.go
@@ -1,0 +1,136 @@
+package agentcompose
+
+import (
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/samber/do/v2"
+)
+
+// TestStoreConvergesOrphanedRunningCellsOnStartup verifies that a cell left
+// with Running=true by an interrupted run (e.g. daemon killed mid-run) is
+// converged to a finished state when the store is created at startup, so the
+// session UI is not stuck on "replying". A normally finished cell must be
+// left untouched.
+func TestStoreConvergesOrphanedRunningCellsOnStartup(t *testing.T) {
+	config := &appconfig.Config{
+		SessionRoot:   filepath.Join(t.TempDir(), "sessions"),
+		RuntimeDriver: driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:  "default-box:latest",
+		GuestHomePath: "/home/agent-compose",
+	}
+	cellsDir := filepath.Join(config.SessionRoot, uuid.NewString(), "state")
+	if err := os.MkdirAll(cellsDir, 0o755); err != nil {
+		t.Fatalf("mkdir cells dir: %v", err)
+	}
+
+	now := time.Now().UTC()
+	orphanID := uuid.NewString()
+	normalID := uuid.NewString()
+	sessionID := filepath.Base(filepath.Dir(cellsDir))
+	cells := []NotebookCell{
+		{ID: orphanID, Type: CellTypeAgent, Source: "interrupted run", Running: true, CreatedAt: now},
+		{ID: normalID, Type: CellTypeAgent, Source: "finished run", Running: false, Success: true, ExitCode: 0, CreatedAt: now},
+	}
+	raw, err := json.Marshal(cells)
+	if err != nil {
+		t.Fatalf("marshal cells: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cellsDir, "cells.json"), raw, 0o644); err != nil {
+		t.Fatalf("write cells.json: %v", err)
+	}
+
+	// NewStore runs convergeOrphanedRunningCells once at startup.
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := NewStore(di)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	got, err := store.ListCells(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListCells: %v", err)
+	}
+	byID := make(map[string]NotebookCell, len(got))
+	for _, c := range got {
+		byID[c.ID] = c
+	}
+
+	orphan, ok := byID[orphanID]
+	if !ok {
+		t.Fatalf("orphan cell missing after recovery")
+	}
+	if orphan.Running {
+		t.Errorf("orphan cell still Running=true after recovery")
+	}
+	if orphan.Success {
+		t.Errorf("orphan cell marked Success=true")
+	}
+	if orphan.ExitCode != 1 {
+		t.Errorf("orphan cell ExitCode=%d, want 1", orphan.ExitCode)
+	}
+	if orphan.StopReason != "run interrupted by daemon restart" {
+		t.Errorf("orphan cell StopReason=%q, want interrupted note", orphan.StopReason)
+	}
+
+	normal, ok := byID[normalID]
+	if !ok {
+		t.Fatalf("normal cell missing after recovery")
+	}
+	if normal.Running || !normal.Success || normal.ExitCode != 0 {
+		t.Errorf("finished cell was modified by recovery: %+v", normal)
+	}
+}
+
+// TestStoreConvergeOrphanedRunningCellsIdempotent verifies that running the
+// recovery twice (e.g. two consecutive daemon restarts) does not double-write
+// or corrupt already-converged cells.
+func TestStoreConvergeOrphanedRunningCellsIdempotent(t *testing.T) {
+	config := &appconfig.Config{
+		SessionRoot:   filepath.Join(t.TempDir(), "sessions"),
+		RuntimeDriver: driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:  "default-box:latest",
+		GuestHomePath: "/home/agent-compose",
+	}
+	cellsDir := filepath.Join(config.SessionRoot, uuid.NewString(), "state")
+	if err := os.MkdirAll(cellsDir, 0o755); err != nil {
+		t.Fatalf("mkdir cells dir: %v", err)
+	}
+	sessionID := filepath.Base(filepath.Dir(cellsDir))
+	raw, err := json.Marshal([]NotebookCell{
+		{ID: uuid.NewString(), Type: CellTypeAgent, Source: "interrupted", Running: true, CreatedAt: time.Now().UTC()},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cellsDir, "cells.json"), raw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := NewStore(di)
+	if err != nil {
+		t.Fatalf("NewStore first: %v", err)
+	}
+	// Re-run recovery directly; no cell should still be Running, so this is a no-op.
+	store.convergeOrphanedRunningCells()
+
+	got, err := store.ListCells(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListCells: %v", err)
+	}
+	for _, c := range got {
+		if c.Running {
+			t.Errorf("cell still Running after second recovery: %+v", c)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When the daemon restarts while an agent run is in progress (e.g. `docker compose up -d --force-recreate`, an upgrade, OOM recovery), the run is killed before its cleanup path sets `cell.Running = false`. The persisted `cells.json` keeps `Running=true`, so after restart the session UI stays stuck on "replying" and blocks further interaction with the session. Refreshing / re-entering the session does not help.

Fixes #160.

## Fix

Recover orphaned running cells at daemon startup. `NewStore` now walks each session's `cells.json` and marks any cell with `Running=true` as finished:

- `Running = false`
- `Success = false`
- `ExitCode = 1` (matches the existing failed-cell convention in `exec.go`)
- `StopReason = "run interrupted by daemon restart"`

This runs from `NewStore`, i.e. during DI wiring before the server serves any request, so no run is active at that point and every `Running=true` cell is guaranteed to be an orphan.

## Design choices / safety

- **Reads/writes raw `cells.json`** (not via `loadCells`) so the hydration step (which pulls `stdout.txt`/`stderr.txt` into the cell) does not duplicate artifact contents into `cells.json`.
- **Best-effort**: per-session read/decode/write errors are logged (`slog.Warn`) and skipped; recovery never blocks daemon startup.
- **Idempotent**: only touches cells with `Running=true`; running it twice (e.g. two consecutive restarts) is a no-op on already-converged cells.
- **Startup-only**: the recovery relies on "no run is active at startup". This is documented on the method; calling it while a run is active would incorrectly mark a genuinely running cell as finished.

## Tests

- `TestStoreConvergesOrphanedRunningCellsOnStartup` — an orphan (`Running=true`) cell is converged to a finished state with the expected fields; a normally finished cell is left untouched.
- `TestStoreConvergeOrphanedRunningCellsIdempotent` — a second recovery pass is a no-op.

```
go build ./pkg/agentcompose/   # ok
go test ./pkg/agentcompose/ -run TestStoreConverge -v   # PASS
```

## Trade-off

Recovery walks all session directories at startup (O(sessions), one small file read each). For typical deployments this is sub-second; for very large session counts it adds a bounded, best-effort cost at startup. Kept synchronous so the cleanup is guaranteed before any request is served. Open to making it async if reviewers prefer.

## Out of scope (possible follow-ups)

- Emitting an `agent.assistant.failed` event for the interrupted cell (currently only the cell state is converged; the cell's `StopReason` carries the explanation). The cell-state convergence is sufficient to unstick the UI; an event would be a UX nicety.
