### PR TITLE
feat(microsandbox): size the docker disk via BOX_DISK_SIZE_GB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,7 @@ IMAGE_STORE_MODE=auto
 # BOXLITE_HOME=./data/agent-compose/boxlite
 # BOXLITE_RUNTIME_DIR=./build/boxlite/runtime
 # BOX_ROOTFS_PATH=
+# Shared guest disk size for VM-type drivers (boxlite box disk and microsandbox docker disk). Default: 6 GiB.
 # BOX_DISK_SIZE_GB=6
 # BOX_CACHE_TTL=168h
 

--- a/README.md
+++ b/README.md
@@ -271,8 +271,10 @@ Important variables include:
   images.
 - `IMAGE_STORE_MODE`, `IMAGE_CACHE_ROOT`, `IMAGE_REGISTRY`,
   `IMAGE_INSECURE_REGISTRIES`: image store and OCI cache settings.
-- `BOXLITE_HOME`, `BOXLITE_RUNTIME_DIR`, `BOX_ROOTFS_PATH`, `BOX_DISK_SIZE_GB`,
-  `BOX_CACHE_TTL`: BoxLite settings.
+- `BOXLITE_HOME`, `BOXLITE_RUNTIME_DIR`, `BOX_ROOTFS_PATH`, `BOX_CACHE_TTL`:
+  BoxLite settings.
+- `BOX_DISK_SIZE_GB`: shared guest disk size for VM-type drivers (the boxlite
+  box disk and the microsandbox docker disk). Default 6 GiB.
 - `DOCKER_HOME`, `DOCKER_HOST_SESSION_ROOT`: Docker runtime settings.
 - `MICROSANDBOX_HOME`, `MICROSANDBOX_MSB_PATH`, `MICROSANDBOX_LIB_PATH`,
   `MICROSANDBOX_INSECURE_REGISTRIES`: Microsandbox settings.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -504,3 +504,49 @@ func testDefaultDataRootFallsBackToHome(t *testing.T) {
 		t.Fatalf("defaultDataRoot = %q, want %q", got, want)
 	}
 }
+
+func TestBoxDiskSizeGB(t *testing.T) {
+	newCfg := func(t *testing.T) *Config {
+		t.Helper()
+		root := t.TempDir()
+		t.Setenv("DATA_ROOT", filepath.Join(root, "data"))
+		di := do.New()
+		do.ProvideValue(di, slog.Default())
+		cfg, err := NewConfig(di)
+		if err != nil {
+			t.Fatalf("NewConfig returned error: %v", err)
+		}
+		return cfg
+	}
+
+	t.Run("default is 6 for all VM-type drivers", func(t *testing.T) {
+		cfg := newCfg(t)
+		if cfg.BoxDiskSizeGB != 6 {
+			t.Fatalf("BoxDiskSizeGB = %d, want 6 (default)", cfg.BoxDiskSizeGB)
+		}
+	})
+
+	t.Run("BOX_DISK_SIZE_GB sets the value", func(t *testing.T) {
+		t.Setenv("BOX_DISK_SIZE_GB", "11")
+		cfg := newCfg(t)
+		if cfg.BoxDiskSizeGB != 11 {
+			t.Fatalf("BoxDiskSizeGB = %d, want 11", cfg.BoxDiskSizeGB)
+		}
+	})
+
+	t.Run("invalid value keeps the default", func(t *testing.T) {
+		t.Setenv("BOX_DISK_SIZE_GB", "abc")
+		cfg := newCfg(t)
+		if cfg.BoxDiskSizeGB != 6 {
+			t.Fatalf("BoxDiskSizeGB = %d, want 6", cfg.BoxDiskSizeGB)
+		}
+	})
+
+	t.Run("non-positive value keeps the default", func(t *testing.T) {
+		t.Setenv("BOX_DISK_SIZE_GB", "-3")
+		cfg := newCfg(t)
+		if cfg.BoxDiskSizeGB != 6 {
+			t.Fatalf("BoxDiskSizeGB = %d, want 6", cfg.BoxDiskSizeGB)
+		}
+	})
+}

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -466,12 +466,18 @@ func (r *microsandboxRuntime) ensureDockerDisk(sessionID string) (string, error)
 		// Disk already exists; reuse it (idempotent for session reconnects).
 		return path, nil
 	}
-	// Create a sparse 8 GiB raw file then format it as ext4.
+	// Create a sparse raw file then format it as ext4. Sized by
+	// BOX_DISK_SIZE_GB (shared with the boxlite driver; config default 6 GiB).
+	// Existing .raw files are reused as-is (see os.Stat check above).
+	sizeGB := r.config.BoxDiskSizeGB
+	if sizeGB <= 0 {
+		sizeGB = 6 // defensive: config normally guarantees a positive value
+	}
 	f, err := os.Create(path)
 	if err != nil {
 		return "", fmt.Errorf("create docker disk image %s: %w", path, err)
 	}
-	if err := f.Truncate(8 << 30); err != nil {
+	if err := f.Truncate(int64(sizeGB) << 30); err != nil {
 		_ = f.Close()
 		_ = os.Remove(path)
 		return "", fmt.Errorf("size docker disk image %s: %w", path, err)


### PR DESCRIPTION
## 动机

microsandbox driver 的 per-session docker 磁盘（VM 内 /var/lib/docker 的 .raw 镜像）大小此前硬编码 8 GiB（`ensureDockerDisk` 里 `Truncate(8 << 30)`），没有配置通道。boxlite 已有 `BOX_DISK_SIZE_GB`。docker driver 不涉及（容器直接用宿主存储）。

**直接复用现有 `BOX_DISK_SIZE_GB`，两个 VM 型 driver 共享同一个变量、同一个默认值（6 GiB）**——不引入新变量、不动 config 解析、不动 boxlite 消费路径。

## 改动（极简）

- `pkg/driver/microsandbox_runtime.go`：`ensureDockerDisk` 从写死 `8 << 30` 改为读 `config.BoxDiskSizeGB`（config 默认 6；带一个防御性 `<=0 → 6` 兜底，防手工构造的零值 Config）
- `pkg/config/config_test.go`：补默认值/覆盖/非法值用例
- `.env.example` / `README.md`：注明该变量同时作用于两个 VM 型 driver
- **`pkg/config/config.go` 与 `pkg/driver/boxlite_cgo.go` 零改动**（与 main 完全一致）

## 行为变化（有意为之，需知悉）

- 从未设置 `BOX_DISK_SIZE_GB` 的 microsandbox 部署：**新建** session 的 docker 盘默认从 8 GiB 变为 6 GiB。若 guest 内 docker 需要更大空间（拉大镜像），部署环境设 `BOX_DISK_SIZE_GB=8` 即恢复原大小。
- 已存在的 .raw 盘走 os.Stat 复用分支，大小不变；运行中/已停止的 session 不受影响。
- 已为 boxlite 设置该变量的环境：同一个值现在也作用于 microsandbox 新建盘（共享变量的本义）。

## 验证

- `go build ./...`、`go vet ./pkg/driver/ ./pkg/config/` 通过
- `go test ./pkg/config/` 全过（含新增 4 个子用例：默认 6 / 覆盖 11 / 非法值保持 6 / 非正数保持 6）