### PR TITLE
fix(microsandbox driver): mount per-VM tmpfs on /run to stop runtime-state leaks across sessions

### DIFF
--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -702,6 +702,15 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sessio
 		}
 	}()
 	mounts["/var/lib/docker"] = microsandbox.Mount.Disk(rawPath, microsandbox.DiskOptions{Format: "raw", Fstype: "ext4"})
+	// /run must be a per-VM tmpfs (standard Linux boot semantics). The guest
+	// root is a shared, session-reused rootfs dir on virtiofs and the msb guest
+	// init does not mount /run itself, so without this, runtime state written
+	// under /run (dockerd pid files, unix sockets) outlives the VM and leaks
+	// into every later session of the same image — a stale
+	// /run/docker/containerd/containerd.pid then makes dockerd kill its own
+	// containerd and refuse to start. agentd recreates /run/microsandbox after
+	// user tmpfs mounts are applied, so shadowing /run here is safe.
+	mounts["/run"] = microsandbox.Mount.Tmpfs(microsandbox.TmpfsOptions{SizeMiB: 256})
 	hostPort := uint16(proxyState.HostPort)
 	guestPort := uint16(r.config.JupyterGuestPort)
 	imageRef := resolveSessionGuestImage(vmState.Image, session.Summary.GuestImage, defaultGuestImageForDriver(r.config, RuntimeDriverMicrosandbox))


### PR DESCRIPTION
## 问题

在 microsandbox driver 下，同一个 guest 镜像的所有 session 共用宿主上同一份物化 rootfs 目录（`image-cache/<imageID>/rootfs`）作为 virtiofs 根，而 msb 的 guest init 不会给 `/run` 挂 tmpfs。于是写到 `/run` 下的运行时状态会活过 VM 的生命周期，泄漏给之后所有同镜像的 session。

具体表现：任务里起过 dockerd 之后，`/run/docker/containerd/containerd.pid` 会留在共享 rootfs 里。下一台 VM 出生就带着这个陈旧 pid 文件；由于 VM 启动序列高度确定，新的 managed containerd 往往落在相同（或相邻）的 PID 上，触发 moby 的 pidfile 防重检查（`pidfile.Write` 报 "process with PID N is still running"），dockerd 随即杀掉自己刚拉起的 containerd（`containerd did not exit successfully ... signal: killed`）然后退出。生产环境上 scanmatrix 项目的 `dockerd did not become ready within 120s` 就是这个机制。

## 修复

在 driver 的 mounts 表里给每台 VM 的 `/run` 挂一块 per-VM tmpfs（256 MiB），与现有的 per-session ext4 docker 盘（`/var/lib/docker`）并列。这恢复了 `/run` 的标准 Linux 启动语义：

- 每台 VM 出生时 `/run` 为空、彼此独立；已被污染的缓存 rootfs 也同时被无害化——陈旧文件被 tmpfs 遮蔽，不需要额外清理；
- `/run` 的写入只进 VM 内存、随 VM 销毁而消失，不会再泄漏到共享 rootfs，也不会在并发的同镜像 VM 之间互相踩踏。

挂载顺序安全性已核实：msb agentd 是在应用用户 tmpfs 挂载**之后**才创建自己的 `/run/microsandbox`（`agentd/lib/init.rs`：`apply_tmpfs_mounts` 先于 `create_run_dir`），实测 VM 内该目录正常存在。

## 验证（自部署测试机）

修复前复现（3 轮 webhook 触发、同一 guest 镜像、真实平台路径）：

- 第 1 轮：出生干净，dockerd 正常，结束后共享 rootfs 里留下 `containerd.pid=501`（宿主侧带 mtime 确认）；
- 第 2 轮：VM 出生即读到陈旧的 `501`（跨 session 泄漏复现）；
- 第 3 轮：出生读到陈旧的 `500`，dockerd 与生产逐字相同地失败：`failed to save daemon pid to disk: process with PID 500 is still running`。

部署本修复后（同一台机器、同一个 loader，宿主上的陈旧 `containerd.pid=500` **故意原地保留**）：

- 3/3 轮：出生状态干净，`findmnt /run` = `tmpfs rw,size=262144k`，`project-agent-start-dockerd` exit=0，docker info 正常；
- 三轮结束后宿主侧陈旧文件内容与 mtime 一字未动——`/run` 写入不再穿透到共享 rootfs；
- VM 内 `/run/microsandbox` 存在（agentd 不受影响）。

## 备注

- 本修复消灭的是最危险的一类泄漏（运行时 pid/socket 状态），但不是完整的 per-session rootfs 隔离：`/tmp`、`/root`、`/etc` 等路径的写入仍会直达共享 rootfs。彻底的 per-session 隔离（如 msb 的 OciErofs lower+upper 模式或每 session 拷贝）值得另开 issue 跟进。
- 可考虑向上游 microsandbox 反馈：guest init 默认给 `/run` 挂 tmpfs，向标准 Linux 启动语义看齐。
