### PR TITLE
fix: keep default home config files writable

### DIFF
--- a/pkg/driver/runtime_mount_manifest.go
+++ b/pkg/driver/runtime_mount_manifest.go
@@ -319,6 +319,9 @@ func copyEmbeddedHomeFile(assetPath, target string, mode fs.FileMode) error {
 	if perm == 0 {
 		perm = 0o644
 	}
+	if perm&0o200 == 0 {
+		perm |= 0o200
+	}
 	if err := os.WriteFile(target, data, perm); err != nil {
 		return fmt.Errorf("write default home file %s: %w", target, err)
 	}

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -341,6 +341,25 @@ func testRuntimeMountManifestDriverSpecificStartPreparationWorkflow(t *testing.T
 	}
 }
 
+func TestInitializeSessionHomeDefaultsCreatesWritableCodexConfig(t *testing.T) {
+	root := t.TempDir()
+	session := testRuntimeMountSession(root)
+	if err := initializeSessionHomeDefaults(session); err != nil {
+		t.Fatalf("initializeSessionHomeDefaults returned error: %v", err)
+	}
+	codexConfig := filepath.Join(root, "home", ".codex", "config.toml")
+	info, err := os.Stat(codexConfig)
+	if err != nil {
+		t.Fatalf("Stat(%s) returned error: %v", codexConfig, err)
+	}
+	if info.Mode().Perm()&0o200 == 0 {
+		t.Fatalf("codex config mode = %v, want owner-writable", info.Mode().Perm())
+	}
+	if err := os.WriteFile(codexConfig, []byte("model = \"test\"\n"), 0o644); err != nil {
+		t.Fatalf("codex config should be writable after defaults initialization: %v", err)
+	}
+}
+
 func TestInitializeSessionHomeDefaultsDoesNotOverwriteExistingTargets(t *testing.T) {
 	root := t.TempDir()
 	session := testRuntimeMountSession(root)


### PR DESCRIPTION
## Summary

Fixes Codex agent session startup failures caused by read-only default home config files.

- Ensures copied default home assets are owner-writable before writing them into session homes.
- Adds a regression test proving `.codex/config.toml` is writable after `initializeSessionHomeDefaults`.

This prevents runtime LLM facade setup from failing when it rewrites Codex config at session start.

## Test plan

- [x] `go test ./pkg/driver ./pkg/agentcompose -run 'TestInitializeSessionHomeDefaultsCreatesWritableCodexConfig|TestEnsureSession.*Codex|TestEnsureSessionLLMFacadeConfig|Test.*Codex'`
- [x] `go test ./pkg/driver ./pkg/agentcompose`

## Issue context

Observed failure:

```text
[internal] write codex config: open /data/agent-compose/sessions/<session-id>/home/.codex/config.toml: permission denied
```

Root cause: default home asset copying preserved a read-only mode from embedded assets, then `writeCodexLLMConfig` attempted to overwrite `.codex/config.toml`.
