### PR TITLE
chore: disable UI by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,19 +4,20 @@
 #   cp .env.example .env
 #   # edit .env
 #   docker compose up -d
+#   # To also start the web UI:
+#   # docker compose --profile with-ui up -d
 
 # ---------------------------------------------------------------------------
-# Networking
+# Published services
+# These variables are consumed by docker-compose.yml before the daemon starts.
+# Override images to pin versions or use a mirror/private registry.
 # ---------------------------------------------------------------------------
-# Host port published by the web UI and reverse proxy.
+AGENT_COMPOSE_IMAGE=ghcr.io/chaitin/agent-compose:latest
+# Used only when the with-ui profile is enabled.
+AGENT_COMPOSE_FRONTEND_IMAGE=ghcr.io/chaitin/agent-compose-ui:latest
+# Host port published by the web UI and reverse proxy when the with-ui profile
+# is enabled.
 AGENT_COMPOSE_HTTP_PORT=80
-
-# Jupyter proxy base path. Keep this in sync with any external reverse proxy.
-JUPYTER_PROXY_BASE=/jupyter
-
-# Guest-reachable daemon URL used by runtime LLM facade config.
-# Docker Compose defaults this to http://agent-compose:7410.
-# AGENT_COMPOSE_RUNTIME_BASE_URL=
 
 # ---------------------------------------------------------------------------
 # Authentication
@@ -30,42 +31,74 @@ AUTH_SECRET=
 AUTH_SESSION_TTL=24h
 
 # ---------------------------------------------------------------------------
-# Container images
-# Override these to pin versions or use a mirror/private registry.
+# Daemon network and storage
+# These are daemon-level settings. The published Docker image already provides
+# the same container defaults, but keeping them here makes remote deployments
+# explicit and easy to audit.
 # ---------------------------------------------------------------------------
-AGENT_COMPOSE_IMAGE=ghcr.io/chaitin/agent-compose:latest
-AGENT_COMPOSE_FRONTEND_IMAGE=ghcr.io/chaitin/agent-compose-ui:latest
+HTTP_LISTEN=0.0.0.0:7410
+DATA_ROOT=/data
+
+# Jupyter proxy base path. Keep this in sync with any external reverse proxy.
+JUPYTER_PROXY_BASE=/jupyter
+
+# Guest-reachable daemon URL used by runtime LLM facade config.
+# Docker Compose defaults this to http://agent-compose:7410.
+# AGENT_COMPOSE_RUNTIME_BASE_URL=
+
+# ---------------------------------------------------------------------------
+# Runtime selection
+# The default driver is docker. DEFAULT_IMAGE is the guest image used for new
+# sessions unless a more specific driver image is configured.
+# ---------------------------------------------------------------------------
+RUNTIME_DRIVER=docker
 DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 
 # ---------------------------------------------------------------------------
-# Runtime
-# The docker image already contains defaults for internal runtime paths.
-# Change these only when your deployment environment requires it.
+# Runtime internals (advanced)
+# Change these only when your deployment environment requires custom runtime
+# paths, image cache behavior, or driver-specific images.
 # ---------------------------------------------------------------------------
-RUNTIME_DRIVER=docker
-DATA_ROOT=/data
-SESSION_ROOT=/data/sessions
-HTTP_LISTEN=0.0.0.0:7410
-# Container default: TZ=Asia/Shanghai.
-# Guest path defaults: GUEST_WORKSPACE=/workspace,
-# GUEST_STATE_ROOT=/data/state, GUEST_RUNTIME_ROOT=/data/runtime,
-# GUEST_LOG_ROOT=/data/logs, JUPYTER_GUEST_PORT=8888.
-# Runtime artifact defaults:
+# Daemon process timezone.
+# TZ=Asia/Shanghai
+
+# Guest paths and ports.
+# --------------------------------------
+# GUEST_WORKSPACE=/workspace
+# GUEST_STATE_ROOT=/data/state
+# GUEST_RUNTIME_ROOT=/data/runtime
+# GUEST_LOG_ROOT=/data/logs
+# JUPYTER_GUEST_PORT=8888
+
+# Driver artifact paths.
+# --------------------------------------
 # BOXLITE_RUNTIME_DIR=/app/boxlite/runtime
 # MICROSANDBOX_HOME=/data/microsandbox
 # MICROSANDBOX_MSB_PATH=/app/microsandbox/bin/msb
 # MICROSANDBOX_LIB_PATH=/app/microsandbox/lib/libmicrosandbox_go_ffi.so
 # DOCKER_HOST_SESSION_ROOT=/absolute/host/path/to/data/agent-compose/sessions
+
+# Driver-specific images.
+# --------------------------------------
 # DOCKER_DEFAULT_IMAGE=debian:bookworm-slim
 # MICROSANDBOX_DEFAULT_IMAGE=debian:bookworm-slim
+
+# Image registry and cache.
+# --------------------------------------
 # IMAGE_REGISTRY=docker.io
 # IMAGE_STORE_MODE=auto
 # IMAGE_CACHE_ROOT=/data/images
 # IMAGE_INSECURE_REGISTRIES=
+
+# BoxLite runtime storage.
+# --------------------------------------
 # BOXLITE_HOME=/data/boxlite
 # BOX_ROOTFS_PATH=
 # BOX_DISK_SIZE_GB=6
 # BOX_CACHE_TTL=168h
+
+# Docker and MicroSandbox storage.
+# --------------------------------------
 # DOCKER_HOME=/data/docker
 # MICROSANDBOX_INSECURE_REGISTRIES=
 
@@ -80,9 +113,11 @@ HTTP_LISTEN=0.0.0.0:7410
 # LLM_TIMEOUT=60s
 
 # OpenAI-compatible chat completions.
+# --------------------------------------
 # LLM_API_PROTOCOL=chat_completions
 
 # Anthropic-family facade bootstrap.
+# --------------------------------------
 # ANTHROPIC_BASE_URL=https://api.anthropic.com
 # ANTHROPIC_API_ENDPOINT=
 # ANTHROPIC_API_KEY=

--- a/README.md
+++ b/README.md
@@ -222,32 +222,40 @@ openssl rand -base64 24 # use this value for AUTH_PASSWORD
 openssl rand -hex 32    # use this value for AUTH_SECRET
 docker compose pull
 docker compose up -d
+# To also pull and start the web UI:
+docker compose --profile with-ui pull
+docker compose --profile with-ui up -d
 ```
 
 Edit `.env` before the first start. At minimum, replace `AUTH_PASSWORD` and
-`AUTH_SECRET`; set `AGENT_COMPOSE_HTTP_PORT` if port `80` is not suitable.
-Override `AGENT_COMPOSE_IMAGE`, `AGENT_COMPOSE_FRONTEND_IMAGE`, or
-`DEFAULT_IMAGE` to pin release tags or use a mirror/private registry. The
-frontend is released independently by `agent-compose-ui`.
+`AUTH_SECRET`; enable the `with-ui` profile when you want the web UI, and set
+`AGENT_COMPOSE_HTTP_PORT` if port `80` is not suitable. Override
+`AGENT_COMPOSE_IMAGE`, `AGENT_COMPOSE_FRONTEND_IMAGE`, or `DEFAULT_IMAGE` to
+pin release tags or use a mirror/private registry. The frontend is released
+independently by `agent-compose-ui`; `AGENT_COMPOSE_FRONTEND_IMAGE` is used only
+when the `with-ui` profile is enabled.
 
 For local development, Docker Compose automatically loads
 `docker-compose.override.yml`, which builds the backend image from the local
 Dockerfile while keeping the same service topology. Use
-`docker compose up -d --build` when you want to rebuild the local backend image.
+`docker compose up -d --build` when you want to rebuild the local backend image,
+or `docker compose --profile with-ui up -d --build` when you also want the web
+UI.
 
 ## Configuration
 
 Copy `.env.example` to `.env`, edit the values for your environment, then run
-`docker compose up -d`.
+`docker compose up -d`. Add `--profile with-ui` to also start the web UI.
 
 Important variables include:
 
 - `AUTH_USERNAME`, `AUTH_PASSWORD`, `AUTH_SECRET`, `AUTH_SESSION_TTL`: password
   login settings. Replace the example password and secret before exposing a
   deployment.
-- `AGENT_COMPOSE_HTTP_PORT`: host port for the web UI and reverse proxy.
+- `AGENT_COMPOSE_HTTP_PORT`: host port for the web UI and reverse proxy when
+  the `with-ui` profile is enabled.
 - `AGENT_COMPOSE_IMAGE`, `AGENT_COMPOSE_FRONTEND_IMAGE`: Docker Compose service
-  images.
+  images; the frontend image is used only with the `with-ui` profile.
 - `DEFAULT_IMAGE`, `DOCKER_DEFAULT_IMAGE`, `MICROSANDBOX_DEFAULT_IMAGE`: guest
   image defaults.
 - `RUNTIME_DRIVER`: default runtime driver.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
   agent-compose-frontend:
     image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-ui:latest}
     container_name: agent-compose-frontend
+    profiles:
+      - with-ui
     restart: always
     depends_on:
       - agent-compose

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -116,19 +116,22 @@ openssl rand -base64 24 # 将输出写入 AUTH_PASSWORD
 openssl rand -hex 32    # 将输出写入 AUTH_SECRET
 docker compose pull
 docker compose up -d
+# 如需同时拉取并启动 Web UI：
+docker compose --profile with-ui pull
+docker compose --profile with-ui up -d
 ```
 
-首次启动前编辑 `.env`。至少替换 `AUTH_PASSWORD` 和 `AUTH_SECRET`；如果不能使用宿主机 `80` 端口，修改 `AGENT_COMPOSE_HTTP_PORT`。本地开发时，Docker Compose 会自动加载 `docker-compose.override.yml`，使用本地 Dockerfile 构建后端镜像；需要重建时执行 `docker compose up -d --build`。
+首次启动前编辑 `.env`。至少替换 `AUTH_PASSWORD` 和 `AUTH_SECRET`；需要 Web UI 时启用 `with-ui` profile，如果不能使用宿主机 `80` 端口，修改 `AGENT_COMPOSE_HTTP_PORT`。本地开发时，Docker Compose 会自动加载 `docker-compose.override.yml`，使用本地 Dockerfile 构建后端镜像；需要重建时执行 `docker compose up -d --build`，需要同时启动 Web UI 时执行 `docker compose --profile with-ui up -d --build`。
 
 ## 配置
 
-复制 `.env.example` 为 `.env`，按部署环境修改后执行 `docker compose up -d`。
+复制 `.env.example` 为 `.env`，按部署环境修改后执行 `docker compose up -d`。如需同时启动 Web UI，添加 `--profile with-ui`。
 
 常用环境变量：
 
 - `AUTH_USERNAME`、`AUTH_PASSWORD`、`AUTH_SECRET`、`AUTH_SESSION_TTL`：密码登录设置。对外部署前应替换示例密码和 secret。
-- `AGENT_COMPOSE_HTTP_PORT`：Web UI 和反向代理发布到宿主机的端口。
-- `AGENT_COMPOSE_IMAGE`、`AGENT_COMPOSE_FRONTEND_IMAGE`：Docker Compose 服务镜像。
+- `AGENT_COMPOSE_HTTP_PORT`：启用 `with-ui` profile 时，Web UI 和反向代理发布到宿主机的端口。
+- `AGENT_COMPOSE_IMAGE`、`AGENT_COMPOSE_FRONTEND_IMAGE`：Docker Compose 服务镜像；前端镜像仅在启用 `with-ui` profile 时使用。
 - `DEFAULT_IMAGE`、`DOCKER_DEFAULT_IMAGE`、`MICROSANDBOX_DEFAULT_IMAGE`：guest 镜像默认值。
 - `RUNTIME_DRIVER`：默认 runtime driver。
 - `OAUTH_*`：OAuth 登录设置。


### PR DESCRIPTION
## Summary
- disable the frontend UI service by default in Docker Compose without removing it
- document how to opt in to the UI and related deployment variables
- update English and Chinese README guidance

## Tests
- Not run (documentation and compose configuration only)