### PR TITLE
fix: daemon defaults and jupyter readiness checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 # MICROSANDBOX_HOME=/data/microsandbox
 # MICROSANDBOX_MSB_PATH=/app/microsandbox/bin/msb
 # MICROSANDBOX_LIB_PATH=/app/microsandbox/lib/libmicrosandbox_go_ffi.so
-# DOCKER_HOST_SESSION_ROOT=/absolute/host/path/to/data/agent-compose/sessions
+# DOCKER_HOST_SESSION_ROOT=/absolute/host/path/to/data/sessions
 
 # Driver-specific images.
 # --------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update &&     apt-get install -y --no-install-recommends ca-certific
 RUN ln -sfv /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo "Asia/Shanghai" > /etc/timezone
 WORKDIR /app
 COPY --from=go-build /out/agent-compose /app/agent-compose
+RUN ln -sf /app/agent-compose /usr/local/bin/agent-compose
 COPY --from=boxlite-build /out/runtime /app/boxlite/runtime
 COPY --from=microsandbox-fetch /out /app/microsandbox
 ENV RUNTIME_DRIVER=docker
@@ -93,5 +94,5 @@ ENV MICROSANDBOX_HOME=/data/microsandbox
 ENV MICROSANDBOX_MSB_PATH=/app/microsandbox/bin/msb
 ENV MICROSANDBOX_LIB_PATH=/app/microsandbox/lib/libmicrosandbox_go_ffi.so
 ENV LD_LIBRARY_PATH=/app/boxlite/runtime:/app/microsandbox/lib
-ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["/app/agent-compose", "daemon"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/agent-compose"]
+CMD ["daemon"]

--- a/Dockerfile.agent-compose-local
+++ b/Dockerfile.agent-compose-local
@@ -45,6 +45,7 @@ RUN apt-get update &&     apt-get install -y --no-install-recommends ca-certific
 RUN ln -sfv /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo "Asia/Shanghai" > /etc/timezone
 WORKDIR /app
 COPY --from=go-build /out/agent-compose /app/agent-compose
+RUN ln -sf /app/agent-compose /usr/local/bin/agent-compose
 COPY --from=boxlite-local /out/runtime /app/boxlite/runtime
 COPY --from=microsandbox-local /out /app/microsandbox
 ENV RUNTIME_DRIVER=docker
@@ -61,5 +62,5 @@ ENV MICROSANDBOX_HOME=/data/microsandbox
 ENV MICROSANDBOX_MSB_PATH=/app/microsandbox/bin/msb
 ENV MICROSANDBOX_LIB_PATH=/app/microsandbox/lib/libmicrosandbox_go_ffi.so
 ENV LD_LIBRARY_PATH=/app/boxlite/runtime:/app/microsandbox/lib
-ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["/app/agent-compose", "daemon"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/agent-compose"]
+CMD ["daemon"]

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3309,11 +3309,7 @@ func normalizeCLIHost(name, value string) (string, error) {
 func resolveAgentComposeSocketForCLI(value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		if runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); runtimeDir != "" {
-			value = filepath.Join(runtimeDir, "agent-compose.sock")
-		} else {
-			value = filepath.Join(os.TempDir(), fmt.Sprintf("agent-compose-%d.sock", os.Getuid()))
-		}
+		value = config.DefaultAgentComposeSocket()
 	}
 	if value == "" {
 		return "", fmt.Errorf("AGENT_COMPOSE_SOCKET is empty")

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -24,9 +25,49 @@ import (
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"agent-compose/proto/health/v1/healthv1connect"
+	"github.com/joho/godotenv"
 	"github.com/samber/do/v2"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func TestMain(m *testing.M) {
+	clearDaemonTestEnv()
+	os.Exit(m.Run())
+}
+
+func clearDaemonTestEnv() {
+	envFile, err := findDaemonTestEnvFile()
+	if err != nil {
+		return
+	}
+	values, err := godotenv.Read(envFile)
+	if err != nil {
+		return
+	}
+	for key := range values {
+		_ = os.Unsetenv(key)
+	}
+}
+
+func findDaemonTestEnvFile() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		path := filepath.Join(dir, ".env")
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}
 
 func executeCommand(args ...string) (string, string, int, error) {
 	var stdout bytes.Buffer
@@ -132,6 +173,18 @@ func TestDaemonCommandStartsDaemon(t *testing.T) {
 
 func TestCLIClientConfigPriority(t *testing.T) {
 	testCLIClientConfigPriority(t)
+}
+
+func TestResolveAgentComposeSocketForCLIFallsBackToVarRun(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	socketPath, err := resolveAgentComposeSocketForCLI("")
+	if err != nil {
+		t.Fatalf("resolveAgentComposeSocketForCLI returned error: %v", err)
+	}
+	if socketPath != config.DefaultAgentComposeSocketPath {
+		t.Fatalf("socketPath = %q, want %q", socketPath, config.DefaultAgentComposeSocketPath)
+	}
 }
 
 func testCLIClientConfigPriority(t *testing.T) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,16 @@ services:
     container_name: agent-compose
     restart: always
     privileged: true
-    command: ["/app/agent-compose", "daemon"]
     devices:
       - /dev/kvm:/dev/kvm
     environment:
-      DOCKER_HOST_SESSION_ROOT: ${DOCKER_HOST_SESSION_ROOT:-${PWD}/data/agent-compose/sessions}
+      DOCKER_HOST_SESSION_ROOT: ${DOCKER_HOST_SESSION_ROOT:-${PWD}/data/sessions}
       AGENT_COMPOSE_RUNTIME_BASE_URL: ${AGENT_COMPOSE_RUNTIME_BASE_URL:-http://agent-compose:7410}
     volumes:
-      - ./.env:/app/.env:ro
-      - ./data/agent-compose:/data
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./data:/data
+      - ./.env:/data/work/.env:ro
+    working_dir: /data/work
 
   agent-compose-frontend:
     image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-ghcr.io/chaitin/agent-compose-ui:latest}

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -86,7 +86,7 @@ The daemon listens on a Unix socket by default:
 
 - `AGENT_COMPOSE_SOCKET` is used when explicitly set.
 - Otherwise `$XDG_RUNTIME_DIR/agent-compose.sock` is preferred.
-- Otherwise `/tmp/agent-compose-<uid>.sock` is used.
+- Otherwise `/var/run/agent-compose.sock` is used.
 
 A TCP HTTP/Connect listener is enabled only when `HTTP_LISTEN` is explicitly
 set. CLI connection priority is `--host`, then `AGENT_COMPOSE_HOST`, then the

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -67,7 +67,7 @@ daemon 默认监听 Unix socket：
 
 - `AGENT_COMPOSE_SOCKET` 显式设置时使用该路径。
 - 未设置时优先使用 `$XDG_RUNTIME_DIR/agent-compose.sock`。
-- 否则使用 `/tmp/agent-compose-<uid>.sock`。
+- 否则使用 `/var/run/agent-compose.sock`。
 
 只有显式设置 `HTTP_LISTEN` 时才额外启用 TCP HTTP/Connect listener。CLI 连接优先级是 `--host`、`AGENT_COMPOSE_HOST`、默认 Unix socket。
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ import (
 )
 
 const DefaultWorkspaceUploadLimitBytes int64 = 1 << 30
+const DefaultAgentComposeSocketPath = "/var/run/agent-compose.sock"
 const defaultGuestHomePath = "/root"
 
 const (
@@ -516,10 +517,14 @@ func resolveAgentComposeSocket(value string) (string, error) {
 }
 
 func defaultAgentComposeSocket() string {
+	return DefaultAgentComposeSocket()
+}
+
+func DefaultAgentComposeSocket() string {
 	if runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); runtimeDir != "" {
 		return filepath.Join(runtimeDir, "agent-compose.sock")
 	}
-	return filepath.Join(os.TempDir(), fmt.Sprintf("agent-compose-%d.sock", os.Getuid()))
+	return DefaultAgentComposeSocketPath
 }
 
 func validateTCPListenAddress(name, value string) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/base64"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -9,8 +10,48 @@ import (
 	"testing"
 	"time"
 
+	"github.com/joho/godotenv"
 	"github.com/samber/do/v2"
 )
+
+func TestMain(m *testing.M) {
+	clearConfigTestEnv()
+	os.Exit(m.Run())
+}
+
+func clearConfigTestEnv() {
+	envFile, err := findConfigTestEnvFile()
+	if err != nil {
+		return
+	}
+	values, err := godotenv.Read(envFile)
+	if err != nil {
+		return
+	}
+	for key := range values {
+		_ = os.Unsetenv(key)
+	}
+}
+
+func findConfigTestEnvFile() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		path := filepath.Join(dir, ".env")
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}
 
 func TestNewConfigParsesEnvironment(t *testing.T) {
 	testNewConfigParsesEnvironment(t)
@@ -179,6 +220,26 @@ func testNewConfigAllowsDefaultRootsAndRequiresValidDriver(t *testing.T) {
 
 func TestNewConfigDefaultsDaemonListenConfig(t *testing.T) {
 	testNewConfigDefaultsDaemonListenConfig(t)
+}
+
+func TestNewConfigDefaultsDaemonSocketToVarRunWithoutRuntimeDir(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DATA_ROOT", filepath.Join(root, "data"))
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("HTTP_LISTEN", "")
+	t.Setenv("AGENT_COMPOSE_SOCKET", "")
+	t.Setenv("AGENT_COMPOSE_HOST", "")
+
+	di := do.New()
+	do.ProvideValue(di, slog.Default())
+	config, err := NewConfig(di)
+	if err != nil {
+		t.Fatalf("NewConfig returned error: %v", err)
+	}
+
+	if config.AgentComposeSocket != DefaultAgentComposeSocketPath {
+		t.Fatalf("AgentComposeSocket = %q, want %q", config.AgentComposeSocket, DefaultAgentComposeSocketPath)
+	}
 }
 
 func testNewConfigDefaultsDaemonListenConfig(t *testing.T) {

--- a/pkg/driver/boxlite_guest_cgo.go
+++ b/pkg/driver/boxlite_guest_cgo.go
@@ -70,7 +70,7 @@ func JupyterKernelspecsURL(proxyState ProxyState) string {
 
 func waitForJupyterProxy(ctx context.Context, proxyState ProxyState) error {
 	urlValue := jupyterKernelspecsURL(proxyState)
-	client := &http.Client{Timeout: 5 * time.Second}
+	client := newJupyterReadyHTTPClient(5 * time.Second)
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
@@ -114,6 +114,15 @@ func waitForJupyterProxy(ctx context.Context, proxyState ProxyState) error {
 			return fmt.Errorf("jupyter did not become ready on %s: %w", urlValue, ctx.Err())
 		case <-ticker.C:
 		}
+	}
+}
+
+func newJupyterReadyHTTPClient(timeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
 	}
 }
 

--- a/pkg/driver/boxlite_guest_test.go
+++ b/pkg/driver/boxlite_guest_test.go
@@ -1,0 +1,23 @@
+package driver
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewJupyterReadyHTTPClientDisablesProxyFromEnvironment(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+	t.Setenv("http_proxy", "http://127.0.0.1:1")
+	t.Setenv("https_proxy", "http://127.0.0.1:1")
+
+	client := newJupyterReadyHTTPClient(time.Second)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("jupyter ready client transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatalf("jupyter ready client should not use proxy environment")
+	}
+}


### PR DESCRIPTION
## Summary
- update daemon/container defaults for deployment behavior
- bypass configured proxy for Jupyter readiness checks
- add focused tests for config defaults, basic auth setup, and BoxLite guest behavior

## Testing
- Not run locally before PR creation