### PR TITLE
fix(store): daemon 重启时自动收敛孤儿的 Running Cell，避免状态卡死

### DIFF
--- a/pkg/agentcompose/service_reconcile_test.go
+++ b/pkg/agentcompose/service_reconcile_test.go
@@ -225,3 +225,127 @@ func testServiceReconcilePersistedSessionsMarksStalePendingFailed(t *testing.T) 
 		t.Fatalf("fresh session vm status = %q, want %q", got, want)
 	}
 }
+
+func TestServiceReconcileOrphanedRunningCells(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:                 root,
+		SessionRoot:              filepath.Join(root, "sessions"),
+		RuntimeDriver:            driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:             "debian:bookworm-slim",
+		MicrosandboxDefaultImage: "devbox:archlinux",
+		GuestWorkspacePath:       "/data/workspace",
+		JupyterGuestPort:         8888,
+		JupyterProxyBasePath:     "/agent-compose/session",
+	}
+	store := &Store{config: config}
+
+	session, err := store.CreateSession(ctx, "orphaned-cells", "", driverpkg.RuntimeDriverMicrosandbox, "devbox:archlinux", "", SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	// Add a running cell that was created before daemon started (orphaned).
+	orphanedCell := NotebookCell{
+		ID:        "cell-orphaned",
+		Type:      CellTypeShell,
+		Source:    "sleep 60",
+		Running:   true,
+		CreatedAt: time.Now().UTC().Add(-time.Minute),
+	}
+	if err := store.AddCell(ctx, session, orphanedCell); err != nil {
+		t.Fatalf("AddCell(orphaned) returned error: %v", err)
+	}
+
+	// Add a completed cell that should be left untouched.
+	completedCell := NotebookCell{
+		ID:        "cell-completed",
+		Type:      CellTypeShell,
+		Source:    "echo done",
+		Running:   false,
+		Success:   true,
+		ExitCode:  0,
+		CreatedAt: time.Now().UTC().Add(-time.Minute),
+	}
+	if err := store.AddCell(ctx, session, completedCell); err != nil {
+		t.Fatalf("AddCell(completed) returned error: %v", err)
+	}
+
+	// Add a running cell created after daemon started (fresh, should not be converged).
+	startedAt := time.Now().UTC()
+	freshRunningCell := NotebookCell{
+		ID:        "cell-fresh-running",
+		Type:      CellTypeShell,
+		Source:    "sleep 10",
+		Running:   true,
+		CreatedAt: startedAt.Add(time.Minute),
+	}
+	if err := store.AddCell(ctx, session, freshRunningCell); err != nil {
+		t.Fatalf("AddCell(fresh-running) returned error: %v", err)
+	}
+
+	service := &Service{config: config, store: store, startedAt: startedAt}
+	if err := service.reconcileOrphanedRunningCells(ctx, session); err != nil {
+		t.Fatalf("reconcileOrphanedRunningCells returned error: %v", err)
+	}
+
+	// Verify orphaned cell was converged.
+	cells, err := store.ListCells(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListCells returned error: %v", err)
+	}
+
+	cellByID := make(map[string]NotebookCell)
+	for _, c := range cells {
+		cellByID[c.ID] = c
+	}
+
+	// Orphaned cell should no longer be running.
+	orphaned, ok := cellByID["cell-orphaned"]
+	if !ok {
+		t.Fatalf("orphaned cell not found in cells")
+	}
+	if orphaned.Running {
+		t.Fatalf("orphaned cell still running, want Running=false")
+	}
+	if orphaned.Success {
+		t.Fatalf("orphaned cell Success=true, want false")
+	}
+	if orphaned.ExitCode != 1 {
+		t.Fatalf("orphaned cell ExitCode=%d, want 1", orphaned.ExitCode)
+	}
+
+	// Completed cell should be unchanged.
+	completed, ok := cellByID["cell-completed"]
+	if !ok {
+		t.Fatalf("completed cell not found in cells")
+	}
+	if !completed.Success || completed.ExitCode != 0 {
+		t.Fatalf("completed cell was modified: Success=%v ExitCode=%d", completed.Success, completed.ExitCode)
+	}
+
+	// Fresh running cell should still be running.
+	fresh, ok := cellByID["cell-fresh-running"]
+	if !ok {
+		t.Fatalf("fresh running cell not found in cells")
+	}
+	if !fresh.Running {
+		t.Fatalf("fresh running cell was converged, want Running=true")
+	}
+
+	// Verify an event was recorded for the converged cell.
+	events, err := store.ListEvents(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	var interruptedCount int
+	for _, e := range events {
+		if e.Type == "cell.execution_interrupted" {
+			interruptedCount++
+		}
+	}
+	if interruptedCount != 1 {
+		t.Fatalf("expected 1 cell.execution_interrupted event, got %d", interruptedCount)
+	}
+}

--- a/pkg/agentcompose/session_reconcile.go
+++ b/pkg/agentcompose/session_reconcile.go
@@ -11,6 +11,7 @@ import (
 
 const stalePendingSessionLastError = "session startup interrupted before runtime reached running state"
 const staleProjectRunError = "project run interrupted before reaching terminal state"
+const orphanedRunningCellError = "cell execution interrupted by daemon restart"
 
 func (s *Service) reconcilePersistedSessions(ctx context.Context) error {
 	result, err := s.store.ListSessions(ctx, SessionListOptions{Limit: 1 << 30})
@@ -25,6 +26,9 @@ func (s *Service) reconcilePersistedSessions(ctx context.Context) error {
 		}
 		if _, err := s.reconcileSessionRuntimeState(ctx, reconciled); err != nil {
 			slog.Warn("failed to reconcile session runtime state", "session_id", session.Summary.ID, "error", err)
+		}
+		if err := s.reconcileOrphanedRunningCells(ctx, session); err != nil {
+			slog.Warn("failed to reconcile orphaned running cells", "session_id", session.Summary.ID, "error", err)
 		}
 	}
 	if err := s.reconcilePersistedProjectRuns(ctx); err != nil {
@@ -116,4 +120,63 @@ func (s *Service) reconcilePersistedProjectRunsWithStatus(ctx context.Context, c
 		}
 	}
 	return nil
+}
+
+// reconcileOrphanedRunningCells converges cells that were marked as Running
+// when the daemon previously stopped. These orphaned cells will otherwise
+// remain in Running state indefinitely, presenting a false view to users
+// and schedulers.
+func (s *Service) reconcileOrphanedRunningCells(ctx context.Context, session *Session) error {
+	if session == nil {
+		return nil
+	}
+	cells, err := s.store.ListCells(ctx, session.Summary.ID)
+	if err != nil {
+		return err
+	}
+	var converged int
+	now := time.Now().UTC()
+	for i := range cells {
+		if !cells[i].Running {
+			continue
+		}
+		// Only converge cells created before this daemon instance started.
+		// Cells created after startedAt belong to the current daemon lifecycle.
+		if !cells[i].CreatedAt.Before(s.startedAt) {
+			continue
+		}
+		cells[i].Running = false
+		cells[i].Success = false
+		cells[i].ExitCode = 1
+		converged++
+		slog.Info("converged orphaned running cell",
+			"session_id", session.Summary.ID,
+			"cell_id", cells[i].ID,
+			"cell_type", cells[i].Type,
+			"cell_source", truncateCellSource(cells[i].Source, 80),
+		)
+		_ = s.store.AddEvent(ctx, session.Summary.ID, SessionEvent{
+			ID:        uuid.NewString(),
+			Type:      "cell.execution_interrupted",
+			Level:     "warn",
+			Message:   orphanedRunningCellError,
+			CreatedAt: now,
+		})
+	}
+	if converged == 0 {
+		return nil
+	}
+	if err := s.store.saveCells(session.Summary.ID, cells); err != nil {
+		return err
+	}
+	slog.Info("converged orphaned running cells", "session_id", session.Summary.ID, "count", converged)
+	return nil
+}
+
+// truncateCellSource returns a truncated version of source for logging.
+func truncateCellSource(source string, maxLen int) string {
+	if len(source) <= maxLen {
+		return source
+	}
+	return source[:maxLen] + "..."
 }

--- a/pkg/agentcompose/session_reconcile.go
+++ b/pkg/agentcompose/session_reconcile.go
@@ -64,13 +64,18 @@ func (s *Service) reconcilePendingSessionState(ctx context.Context, session *Ses
 	if err := s.store.UpdateSession(ctx, session); err != nil {
 		return nil, err
 	}
-	_ = s.store.AddEvent(ctx, session.Summary.ID, SessionEvent{
+	if err := s.store.AddEvent(ctx, session.Summary.ID, SessionEvent{
 		ID:        uuid.NewString(),
 		Type:      "session.startup_interrupted",
 		Level:     "warn",
 		Message:   "session marked failed after a previous startup was interrupted before the VM became ready",
 		CreatedAt: now,
-	})
+	}); err != nil {
+		slog.Warn("failed to record session.startup_interrupted event (session already marked failed)",
+			"session_id", session.Summary.ID,
+			"error", err,
+		)
+	}
 	return s.store.GetSession(ctx, session.Summary.ID)
 }
 

--- a/pkg/agentcompose/session_reconcile.go
+++ b/pkg/agentcompose/session_reconcile.go
@@ -135,13 +135,19 @@ func (s *Service) reconcileOrphanedRunningCells(ctx context.Context, session *Se
 		return err
 	}
 	var converged int
+	// Collect events first, then persist cells and events together.
+	// This prevents the inconsistency where cells are saved but events are lost
+	// (AddEvent error was previously silently ignored).
+	type cellEvent struct {
+		CellID  string
+		EventID string
+	}
+	var cellEvents []cellEvent
 	now := time.Now().UTC()
 	for i := range cells {
 		if !cells[i].Running {
 			continue
 		}
-		// Only converge cells created before this daemon instance started.
-		// Cells created after startedAt belong to the current daemon lifecycle.
 		if !cells[i].CreatedAt.Before(s.startedAt) {
 			continue
 		}
@@ -149,25 +155,37 @@ func (s *Service) reconcileOrphanedRunningCells(ctx context.Context, session *Se
 		cells[i].Success = false
 		cells[i].ExitCode = 1
 		converged++
+		eventID := uuid.NewString()
+		cellEvents = append(cellEvents, cellEvent{CellID: cells[i].ID, EventID: eventID})
 		slog.Info("converged orphaned running cell",
 			"session_id", session.Summary.ID,
 			"cell_id", cells[i].ID,
 			"cell_type", cells[i].Type,
 			"cell_source", truncateCellSource(cells[i].Source, 80),
 		)
-		_ = s.store.AddEvent(ctx, session.Summary.ID, SessionEvent{
-			ID:        uuid.NewString(),
-			Type:      "cell.execution_interrupted",
-			Level:     "warn",
-			Message:   orphanedRunningCellError,
-			CreatedAt: now,
-		})
 	}
 	if converged == 0 {
 		return nil
 	}
+	// Save cells first (the mutation we must not lose)
 	if err := s.store.saveCells(session.Summary.ID, cells); err != nil {
 		return err
+	}
+	// Save events after cells succeed (best-effort: log and continue on failure)
+	for _, ce := range cellEvents {
+		if err := s.store.AddEvent(ctx, session.Summary.ID, SessionEvent{
+			ID:        ce.EventID,
+			Type:      "cell.execution_interrupted",
+			Level:     "warn",
+			Message:   orphanedRunningCellError,
+			CreatedAt: now,
+		}); err != nil {
+			slog.Warn("failed to record cell.execution_interrupted event (cell already converged)",
+				"session_id", session.Summary.ID,
+				"cell_id", ce.CellID,
+				"error", err,
+			)
+		}
 	}
 	slog.Info("converged orphaned running cells", "session_id", session.Summary.ID, "count", converged)
 	return nil


### PR DESCRIPTION
## 问题背景

当 agent-compose 的 daemon 进程重启后（比如升级、崩溃恢复、手动重启），之前正在执行中的 notebook cell 会永远卡在 `Running` 状态。因为驱动这些 cell 的进程已经随着 daemon 一起死掉了，没有人会再去更新它们的状态。结果用户看到的 UI 上一直显示"正在执行中"，但实际上什么也没在跑。

这个问题在生产环境中很常见——任何 daemon 重启都会触发，而且之前没有机制去发现和修复这种"孤儿"状态。

## 解决方案

在 daemon 启动时的 session 对账（reconciliation）流程中新增一步 `reconcileOrphanedRunningCells()`，专门收敛孤儿 Running Cell：

1. 遍历所有 session 中标记为 `Running` 的 cell
2. 如果 `cell.CreatedAt < daemon.startedAt`（cell 创建于本次 daemon 启动之前），说明它是孤儿的
3. 将孤儿 cell 收敛为：`Running=false, Success=false, ExitCode=1`
4. 为每个被收敛的 cell 记录一条 `cell.execution_interrupted` 事件，方便排查

**关键设计点**：通过 `daemon.startedAt` 时间戳来区分"孤儿"和"正常"。如果 cell 的创建时间晚于 daemon 启动时间，说明它是本轮生命周期的合法 cell，不去碰它。

## 应用价值

- **消除假死状态**：daemon 重启后不会残留"正在执行"的假象
- **提升运维体验**：调度器和用户不再被假 Running 状态误导
- **可追溯**：每次收敛都记事件日志，出了问题可以查到哪些 cell 被中断了
- **零副作用**：不触碰正常运行的 cell，只处理确实已经死掉的

## 代码变更

- `pkg/agentcompose/session_reconcile.go` — 新增 `reconcileOrphanedRunningCells()` 方法 + `truncateCellSource()` 辅助函数
- `pkg/agentcompose/service_reconcile_test.go` — 新增完整测试用例，覆盖孤儿/已完成/正常三种 cell 场景