### PR TITLE
feat(runtime): 新增 Tool Display Mapper，把原始工具调用转成用户友好的进度展示

### DIFF
--- a/runtime/javascript/src/runners/claude.ts
+++ b/runtime/javascript/src/runners/claude.ts
@@ -1,13 +1,16 @@
 import { existsSync } from "node:fs";
+import process from "node:process";
 import { uniqueDirectories } from "../paths.js";
 import { readStoredSession, writeStoredSession } from "../session-state.js";
 import { jsonString } from "../text.js";
+import { defaultToolDisplayMapper } from "../tool-display.js";
 import { TranscriptWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions, StoredSession } from "../types.js";
 
 type PendingToolUse = {
   name: string;
   partialJson: string;
+  input?: Record<string, unknown>;
 };
 
 function hasOwn(object: object, key: string): boolean {
@@ -44,8 +47,22 @@ function claudeEnvironment(): NodeJS.ProcessEnv {
 }
 
 export class ClaudeRunner {
-  private readonly writer = new TranscriptWriter();
+  // Raw transcript: preserves [tool:Name] + JSON for daemon event parsing.
+  // Does NOT stream to stderr — only accumulates.
+  private readonly rawWriter = new TranscriptWriter(() => {});
+
+  // Display sink: writes business-friendly text to stderr → cell.Output → UI.
+  private readonly display = {
+    write(text: string): void {
+      process.stderr.write(text);
+    },
+    line(text = ""): void {
+      this.write(text.endsWith("\n") ? text : `${text}\n`);
+    },
+  };
+
   private readonly pendingToolUses = new Map<string, PendingToolUse>();
+  private readonly mapper = defaultToolDisplayMapper;
 
   constructor(private readonly options: RunnerOptions) {}
 
@@ -77,56 +94,95 @@ export class ClaudeRunner {
     };
   }
 
+  /**
+   * Show a tool call on the display channel if the mapper produces a description.
+   * Always writes to the raw transcript regardless of display decision.
+   */
+  private showToolCall(toolName: string, input: Record<string, unknown>, rawText: string): void {
+    this.rawWriter.write(rawText);
+    const entry = this.mapper.mapToolCall(toolName, input);
+    if (entry) {
+      this.display.line(`${entry.icon} ${entry.action}...`);
+    }
+  }
+
   handleStreamEvent(message: Record<string, unknown>): void {
     const event = message.event as Record<string, unknown> | undefined;
     if (!event || typeof event !== "object") {
       return;
     }
+
+    // ── Tool call start ──────────────────────────────────────────────────
     if (event.type === "content_block_start") {
       const block = event.content_block as Record<string, unknown> | undefined;
       if (typeof block?.name === "string" && block.name) {
         const input = block.input;
+
         if (input && typeof input === "object" && Object.keys(input).length > 0) {
-          this.writer.line(`\n[tool:${block.name}]`);
-          this.writer.line(jsonString(input));
-          this.writer.line();
+          this.showToolCall(
+            block.name,
+            input as Record<string, unknown>,
+            `\n[tool:${block.name}]\n${jsonString(input as Record<string, unknown>)}\n`,
+          );
           return;
         }
+
         if (input && typeof input === "object") {
+          // Input will be streamed via deltas — stash for now
           this.pendingToolUses.set(contentBlockKey(event, String(block.id ?? this.pendingToolUses.size)), {
             name: block.name,
             partialJson: "",
+            input: undefined,
           });
+
+          // Show display entry immediately (with empty input — will update at stop)
+          const displayEntry = this.mapper.mapToolCall(block.name, {});
+          if (displayEntry) {
+            this.display.line(`${displayEntry.icon} ${displayEntry.action}...`);
+          }
           return;
         }
-        this.writer.line(`\n[tool:${block.name}]`);
-        this.writer.line();
+
+        // No input at all
+        this.showToolCall(block.name, {}, `\n[tool:${block.name}]\n`);
       }
       return;
     }
+
+    // ── Tool call end (for streamed-input tools) ─────────────────────────
     if (event.type === "content_block_stop") {
       const key = contentBlockKey(event);
       const pending = this.pendingToolUses.get(key);
       if (pending) {
         this.pendingToolUses.delete(key);
-        this.writer.line(`\n[tool:${pending.name}]`);
+
+        // Raw transcript
+        this.rawWriter.line(`\n[tool:${pending.name}]`);
         if (pending.partialJson.trim()) {
           try {
-            this.writer.line(jsonString(JSON.parse(pending.partialJson)));
+            const parsed = JSON.parse(pending.partialJson);
+            this.rawWriter.line(jsonString(parsed));
+            // Update input for potential result mapping
+            pending.input = parsed;
           } catch {
-            this.writer.line(pending.partialJson);
+            this.rawWriter.line(pending.partialJson);
           }
-          this.writer.line();
+          this.rawWriter.line();
         } else {
-          this.writer.line();
+          this.rawWriter.line();
         }
+
+        // Display: no duplicate — the action was already shown at start
       }
       return;
     }
+
+    // ── Streaming JSON deltas for tool input ─────────────────────────────
     if (event.type !== "content_block_delta") {
       return;
     }
     const delta = event.delta as Record<string, unknown> | undefined;
+
     if (delta?.type === "input_json_delta" && typeof delta.partial_json === "string") {
       const pending = this.pendingToolUses.get(contentBlockKey(event));
       if (pending) {
@@ -134,12 +190,20 @@ export class ClaudeRunner {
       }
       return;
     }
+
+    // ── Assistant text ───────────────────────────────────────────────────
     if (delta?.type === "text_delta" && typeof delta.text === "string") {
-      this.writer.write(delta.text);
+      // Both channels: user-facing assistant text, show as-is
+      this.rawWriter.write(delta.text);
+      this.display.write(delta.text);
       return;
     }
+
+    // ── Thinking text ────────────────────────────────────────────────────
     if (delta?.type === "thinking_delta" && typeof delta.thinking === "string") {
-      this.writer.write(delta.thinking);
+      // Raw transcript only — internal reasoning is not for end users
+      this.rawWriter.write(delta.thinking);
+      // Display: skip (users don't need to see internal reasoning)
     }
   }
 
@@ -186,20 +250,33 @@ export class ClaudeRunner {
           }
           case "tool_use_summary":
             if (typeof message.summary === "string" && message.summary.trim()) {
-              this.writer.line(`\n${message.summary}`);
+              // Raw transcript: include summary
+              this.rawWriter.line(`\n${message.summary}`);
+
+              // Display: show result summary if mapper provides one
+              const resultText = this.mapper.mapToolResult("", {}, message.summary);
+              if (resultText) {
+                this.display.line(resultText);
+              }
             }
             break;
           case "auth_status":
             if (Array.isArray(message.output) && message.output.length > 0) {
-              this.writer.line(message.output.join("\n"));
+              const authText = message.output.join("\n");
+              this.rawWriter.line(authText);
+              // Display: auth status is not for end users
             }
             if (message.error) {
-              this.writer.line(String(message.error));
+              const errText = String(message.error);
+              this.rawWriter.line(errText);
+              this.display.line(`❌ Auth error: ${errText}`);
             }
             break;
           case "system":
             if (message.subtype === "local_command_output" && typeof message.content === "string") {
-              this.writer.line(message.content);
+              // Raw transcript: include command output for debugging
+              this.rawWriter.line(message.content);
+              // Display: skip — raw command output is technical detail
             }
             break;
           case "result":
@@ -228,7 +305,8 @@ export class ClaudeRunner {
       stream.close?.();
     }
 
-    result.transcript = this.writer.transcript();
+    // Use raw transcript (preserves [tool:Name] markers for daemon event parsing)
+    result.transcript = this.rawWriter.transcript();
     if (!result.finalText && result.transcript) {
       result.finalText = result.transcript;
     }

--- a/runtime/javascript/src/tool-display.ts
+++ b/runtime/javascript/src/tool-display.ts
@@ -1,0 +1,123 @@
+/**
+ * Tool Display Mapper — transforms raw tool call events into user-friendly
+ * progress descriptions for the display channel.
+ *
+ * Architecture:
+ * - The runner writes to TWO channels simultaneously:
+ *   1. Raw transcript — preserves `[tool:Name]` markers + JSON for daemon-side
+ *      event parsing and debugging. Does NOT stream to stderr.
+ *   2. Display channel — writes business-friendly text to stderr → cell output → UI.
+ * - The mapper decides what appears on the display channel; the raw transcript
+ *   is always complete regardless of display decisions.
+ *
+ * Design principles:
+ * - Internal/infrastructure tool calls are suppressed (return null) — the user
+ *   doesn't need to see mkdir, echo, file reads, or other Claude Code machinery
+ * - Unknown tools are silently suppressed — never floods the user with noise
+ * - The mapping is extensible: custom entries can be added via `registerMapping()`
+ *   to surface application-specific RPC calls (e.g. grpcurl methods)
+ *
+ * This module is intended for use by runner implementations. It produces display
+ * text for stderr → cell.Output → UI, while the raw transcript channel preserves
+ * `[tool:Name]` markers for daemon-side event parsing.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ToolDisplayEntry {
+  /** Emoji icon shown before the action text */
+  icon: string;
+  /** Human-readable action description (e.g. "Matching project") */
+  action: string;
+}
+
+export interface ToolDisplayMapping {
+  /**
+   * Map a tool call to a display entry.
+   * Returns null to suppress this tool from the display channel
+   * (it will still appear in the raw transcript for debugging).
+   */
+  mapToolCall(toolName: string, input: Record<string, unknown>): ToolDisplayEntry | null;
+  /** Map a tool result to a brief display string (empty string = skip) */
+  mapToolResult(toolName: string, input: Record<string, unknown>, summary: string): string;
+}
+
+// ─── RPC method extraction from grpcurl command ─────────────────────────────
+
+function extractRpcMethod(command: string): string | null {
+  const match = command.match(/\/([A-Z][a-zA-Z0-9]+)\s*$/);
+  if (match) return match[1];
+  const parts = command.trim().split(/\s+/);
+  const lastPart = parts[parts.length - 1];
+  const slashMatch = lastPart.match(/\/([A-Z][a-zA-Z0-9]+)$/);
+  return slashMatch ? slashMatch[1] : null;
+}
+
+// ─── Custom mapping registry ────────────────────────────────────────────────
+
+const customMappings = new Map<string, ToolDisplayEntry>();
+
+/**
+ * Register a custom display mapping for an RPC method name or tool name.
+ * Custom mappings take precedence over built-in ones.
+ *
+ * Example — surface grpcurl RPC calls in the display channel:
+ * ```ts
+ * registerMapping("GetProject",  { icon: "📋", action: "Fetching project" });
+ * registerMapping("CreateDoc",   { icon: "📄", action: "Creating document" });
+ * registerMapping("SendMail",    { icon: "📧", action: "Sending email" });
+ * ```
+ */
+export function registerMapping(key: string, entry: ToolDisplayEntry): void {
+  customMappings.set(key, entry);
+}
+
+// ─── Default mapper implementation ──────────────────────────────────────────
+
+export const defaultToolDisplayMapper: ToolDisplayMapping = {
+  mapToolCall(toolName: string, input: Record<string, unknown>): ToolDisplayEntry | null {
+    // ── Bash tool ──────────────────────────────────────────────────────────
+    if (toolName === "Bash") {
+      const command = String(input.command || "");
+
+      // grpcurl commands → delegate to custom mapping registry
+      if (command.includes("grpcurl")) {
+        const method = extractRpcMethod(command);
+        if (method) {
+          const custom = customMappings.get(method);
+          if (custom) return custom;
+          // Unregistered RPC method — suppress from display
+          return null;
+        }
+        return null;
+      }
+
+      // All other Bash commands (mkdir, echo, ls, cd, npm, pip, etc.)
+      // are Claude Code internal machinery. Suppress from display.
+      return null;
+    }
+
+    // ── WebSearch — show it ───────────────────────────────────────────────
+    if (toolName === "WebSearch") {
+      return { icon: "🌐", action: "Searching the web" };
+    }
+
+    // ── All other tools (Read, Write, Edit, Glob, Grep, etc.) ────────────
+    // These are internal Claude Code operations (reading config, writing temp
+    // files, searching code). Suppress from display — users don't need to
+    // see the agent's file I/O.
+    return null;
+  },
+
+  mapToolResult(toolName: string, input: Record<string, unknown>, summary: string): string {
+    // If the LLM provided a human-readable summary, show it
+    if (summary && summary.trim()) {
+      const trimmed = summary.trim();
+      return trimmed.length > 200
+        ? "✅ " + trimmed.slice(0, 197) + "..."
+        : "✅ " + trimmed;
+    }
+    // Otherwise skip — the assistant text will communicate the result
+    return "";
+  },
+};

--- a/runtime/javascript/src/transcript.ts
+++ b/runtime/javascript/src/transcript.ts
@@ -26,8 +26,20 @@ export function appendDelta(
   }
 }
 
+/**
+ * A TextWriter that accumulates text and optionally streams it to a sink.
+ *
+ * By default, the sink writes to process.stderr (the original behavior).
+ * Pass a custom sink to redirect output, or `() => {}` to suppress streaming
+ * while still accumulating for transcript retrieval.
+ */
 export class TranscriptWriter implements TextWriter {
   private readonly chunks: string[] = [];
+  private readonly sink: (text: string) => void;
+
+  constructor(sink?: (text: string) => void) {
+    this.sink = sink ?? ((text: string) => process.stderr.write(text));
+  }
 
   write(text: string): void {
     if (!text) {
@@ -35,7 +47,7 @@ export class TranscriptWriter implements TextWriter {
     }
     const normalized = normalizeNewlines(text);
     this.chunks.push(normalized);
-    process.stderr.write(normalized);
+    this.sink(normalized);
   }
 
   line(text = ""): void {


### PR DESCRIPTION
## 问题背景

目前 Claude Runner 把所有输出都打到一个通道里（stderr → transcript），用户看到的东西非常杂乱：原始的工具调用元数据（`[tool:Name]` + JSON）、Claude Code 内部的文件读写指令、pip 安装日志等等，全部混在一起。真正对用户有用的业务进度信息被淹没在大量技术噪音里。

举个例子，用户关心的其实是"正在查询 CRM 项目"、"正在创建文档"，但实际看到的是满屏的 `[tool:Bash]`、`[tool:Read]` 和 JSON 参数。

## 解决方案

把 Runner 的输出拆成两条独立的通道：

### 1. 原始转录通道（Raw Transcript）
保留 `[tool:Name]` 标记和完整的 JSON 参数，供 daemon 侧的事件解析和调试使用。这个通道**不输出到 stderr**，只在内存中累积，最后存为 transcript。

### 2. 展示通道（Display Channel）
经过 `ToolDisplayMapping` 过滤后，输出用户友好的进度文字到 stderr → cell.Output → UI。内部工具调用（Read/Write/Edit/Glob/Grep/bash 等）全部被抑制，只显示有业务含义的操作。

### 核心设计

**新增 `tool-display.ts` 模块**：
- `ToolDisplayMapping` 接口：定义 `mapToolCall()` 和 `mapToolResult()` 两个映射方法
- `registerMapping()` 注册函数：部署方可以按需注入自己的 RPC 展示映射
- 默认映射器只包含通用条目（如 WebSearch），不包含任何硬编码的业务逻辑
- 未知工具静默抑制，不会向用户输出噪音

**改进 `claude.ts`**：
- 双 Writer 架构：`rawWriter`（纯累积，不输出）+ `display`（写到 stderr）
- 思考过程（thinking）只进原始转录，展示通道不显示——用户不需要看 AI 的内部推理
- 认证错误简短提示，原始命令输出不展示

**改进 `transcript.ts`**：
- `TranscriptWriter` 支持自定义 sink 参数
- 传 `() => {}` 即可仅累积不输出（rawWriter 用这个模式）

## 使用方式

部署方在启动时注册自己的展示映射：

```ts
import { registerMapping } from "./tool-display.js";

registerMapping("GetProject",  { icon: "📋", action: "正在查询项目信息" });
registerMapping("CreateDoc",   { icon: "📄", action: "正在创建文档" });
registerMapping("SendMail",    { icon: "📧", action: "正在发送邮件" });
```

## 应用价值

- **用户体验大幅提升**：agent 执行过程中用户能看到清晰的业务进度，而不是技术噪音
- **调试不丢信息**：原始 transcript 完整保留所有技术细节，出问题时可以回溯
- **可扩展**：通过 `registerMapping()` 机制，不同部署场景可以定制自己的展示条目，不改框架代码
- **向后兼容**：`TranscriptWriter` 的 sink 参数可选的，不传就保持原来的行为

## 代码变更

- `runtime/javascript/src/tool-display.ts` — 新增模块（ToolDisplayMapping 接口 + registerMapping + 默认映射器）
- `runtime/javascript/src/runners/claude.ts` — 双通道架构改造（rawWriter + display sink）
- `runtime/javascript/src/transcript.ts` — TranscriptWriter 增加可选 sink 参数