### PR TITLE
Fix stats default project sandbox scope

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -569,11 +569,11 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	psCmd.Flags().BoolVar(&psOptions.Verbose, "verbose", false, "Show more sandbox details")
 
 	statsCmd := &cobra.Command{
-		Use:   "stats <sandbox>",
+		Use:   "stats [sandbox]",
 		Short: "Print sandbox resource stats",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComposeStatsCommand(cmd, options, args[0])
+			return runComposeStatsCommand(cmd, options, args)
 		},
 	}
 
@@ -1106,17 +1106,28 @@ func removeSandbox(ctx context.Context, client agentcomposev2connect.SandboxServ
 	return err
 }
 
-func runComposeStatsCommand(cmd *cobra.Command, cli cliOptions, sandboxID string) error {
+func runComposeStatsCommand(cmd *cobra.Command, cli cliOptions, args []string) error {
+	if len(args) > 0 {
+		return runComposeSingleStatsCommand(cmd, cli, args[0])
+	}
+	_, normalized, projectID, err := resolveComposeProject(cli)
+	if err != nil {
+		return err
+	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
 	}
-	sandboxID = strings.TrimSpace(sandboxID)
-	resp, err := clients.sandbox.GetSandboxStats(cmd.Context(), connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
+	project, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
+	}))
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("get sandbox %s stats: %w", sandboxID, err))
+		return commandExitErrorForConnect(fmt.Errorf("get project %s: %w", normalized.Name, err))
 	}
-	output := composeStatsOutputFromProto(resp.Msg.GetStats())
+	output, err := composeProjectStatsOutputFromProject(cmd.Context(), clients, project.Msg.GetProject())
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("build stats for project %s: %w", normalized.Name, err))
+	}
 	if cli.JSON {
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
@@ -1124,7 +1135,30 @@ func runComposeStatsCommand(cmd *cobra.Command, cli cliOptions, sandboxID string
 		}
 		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
 	}
-	return writeStatsText(cmd.OutOrStdout(), output)
+	return writeStatsText(cmd.OutOrStdout(), output.Stats)
+}
+
+func runComposeSingleStatsCommand(cmd *cobra.Command, cli cliOptions, sandboxID string) error {
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("stats requires non-empty sandbox")}
+	}
+	output, err := composeStatsOutputForSandbox(cmd.Context(), clients.sandbox, sandboxID)
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("get sandbox %s stats: %w", sandboxID, err))
+	}
+	if cli.JSON {
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
+	}
+	return writeStatsText(cmd.OutOrStdout(), []composeStatsOutput{output})
 }
 
 func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRunOptions, args []string) error {
@@ -2300,6 +2334,11 @@ type composeStatsOutput struct {
 	UptimeSeconds    composeMetricOutput `json:"uptime_seconds"`
 }
 
+type composeProjectStatsOutput struct {
+	Project composeUpProjectOutput `json:"project"`
+	Stats   []composeStatsOutput   `json:"stats"`
+}
+
 type composeMetricOutput struct {
 	Value   *float64 `json:"value"`
 	Unit    string   `json:"unit"`
@@ -2979,6 +3018,33 @@ func composeStatsOutputFromProto(stats *agentcomposev2.SandboxStats) composeStat
 	}
 }
 
+func composeStatsOutputForSandbox(ctx context.Context, client agentcomposev2connect.SandboxServiceClient, sandboxID string) (composeStatsOutput, error) {
+	resp, err := client.GetSandboxStats(ctx, connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
+	if err != nil {
+		return composeStatsOutput{}, err
+	}
+	return composeStatsOutputFromProto(resp.Msg.GetStats()), nil
+}
+
+func composeProjectStatsOutputFromProject(ctx context.Context, clients cliServiceClients, project *agentcomposev2.Project) (composeProjectStatsOutput, error) {
+	output := composeProjectStatsOutput{
+		Project: composeProjectSummaryOutput(project.GetSummary()),
+	}
+	psOutput, err := composePSOutputFromProject(ctx, clients, project, composePSOptions{})
+	if err != nil {
+		return composeProjectStatsOutput{}, err
+	}
+	output.Stats = make([]composeStatsOutput, 0, len(psOutput.Sandboxes))
+	for _, sandbox := range psOutput.Sandboxes {
+		stats, err := composeStatsOutputForSandbox(ctx, clients.sandbox, sandbox.Sandbox)
+		if err != nil {
+			return composeProjectStatsOutput{}, fmt.Errorf("get sandbox %s stats: %w", sandbox.Sandbox, err)
+		}
+		output.Stats = append(output.Stats, stats)
+	}
+	return output, nil
+}
+
 func composeMetricOutputFromProto(metric *agentcomposev2.MetricValue) composeMetricOutput {
 	if metric == nil {
 		return composeMetricOutput{Status: "unknown"}
@@ -3004,25 +3070,27 @@ func metricStatusText(status agentcomposev2.MetricStatus) string {
 	}
 }
 
-func writeStatsText(out io.Writer, output composeStatsOutput) error {
+func writeStatsText(out io.Writer, stats []composeStatsOutput) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	if _, err := fmt.Fprintln(tw, "SANDBOX\tDRIVER\tCPU%\tMEM\tMEM_LIMIT\tMEM%\tNET_RX\tNET_TX\tBLOCK_READ\tBLOCK_WRITE\tUPTIME"); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-		output.Sandbox,
-		firstNonEmptyString(output.Driver, "-"),
-		formatMetricForText(output.CPUPercent),
-		formatMetricForText(output.MemoryUsageBytes),
-		formatMetricForText(output.MemoryLimitBytes),
-		formatMetricForText(output.MemoryPercent),
-		formatMetricForText(output.NetworkRxBytes),
-		formatMetricForText(output.NetworkTxBytes),
-		formatMetricForText(output.BlockReadBytes),
-		formatMetricForText(output.BlockWriteBytes),
-		formatMetricForText(output.UptimeSeconds),
-	); err != nil {
-		return err
+	for _, output := range stats {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			output.Sandbox,
+			firstNonEmptyString(output.Driver, "-"),
+			formatMetricForText(output.CPUPercent),
+			formatMetricForText(output.MemoryUsageBytes),
+			formatMetricForText(output.MemoryLimitBytes),
+			formatMetricForText(output.MemoryPercent),
+			formatMetricForText(output.NetworkRxBytes),
+			formatMetricForText(output.NetworkTxBytes),
+			formatMetricForText(output.BlockReadBytes),
+			formatMetricForText(output.BlockWriteBytes),
+			formatMetricForText(output.UptimeSeconds),
+		); err != nil {
+			return err
+		}
 	}
 	return tw.Flush()
 }

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -2603,6 +2604,157 @@ func TestIntegrationCLIStatsTableAndJSON(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("GetSandboxStats calls = %d, want 2", calls)
+	}
+}
+
+func TestIntegrationCLIStatsWithoutSandboxUsesProjectRunningSandboxes(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-stats-demo
+agents:
+  reviewer:
+    provider: codex
+  worker:
+    provider: codex
+`)
+	project := testCLIProject("project-cli-stats", "cli-stats-demo", composePath)
+	sessions := []*agentcomposev1.SessionSummary{
+		testCLISessionSummary("session-one", "RUNNING", "project-cli-stats", "reviewer", "run-one"),
+		testCLISessionSummary("session-two", "RUNNING", "project-cli-stats", "worker", "run-two"),
+		testCLISessionSummary("session-stopped", "STOPPED", "project-cli-stats", "reviewer", "run-stopped"),
+		testCLISessionSummary("session-foreign", "RUNNING", "foreign-project", "reviewer", "run-foreign"),
+	}
+	runs := []*agentcomposev2.RunSummary{
+		{RunId: "run-one", ProjectId: project.GetSummary().GetProjectId(), AgentName: "reviewer", Status: agentcomposev2.RunStatus_RUN_STATUS_RUNNING, SessionId: "session-one", UpdatedAt: "2026-06-11T00:00:01Z"},
+		{RunId: "run-two", ProjectId: project.GetSummary().GetProjectId(), AgentName: "worker", Status: agentcomposev2.RunStatus_RUN_STATUS_RUNNING, SessionId: "session-two", UpdatedAt: "2026-06-11T00:00:02Z"},
+		{RunId: "run-stopped", ProjectId: project.GetSummary().GetProjectId(), AgentName: "reviewer", Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, SessionId: "session-stopped", UpdatedAt: "2026-06-11T00:00:03Z"},
+	}
+	var statsCalls []string
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
+			},
+		},
+		run: runServiceStub{
+			listRuns: func(ctx context.Context, req *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
+				if req.Msg.GetProjectId() != project.GetSummary().GetProjectId() || req.Msg.GetLimit() < 100 {
+					t.Fatalf("ListRuns request = %#v", req.Msg)
+				}
+				return connect.NewResponse(&agentcomposev2.ListRunsResponse{Runs: runs}), nil
+			},
+		},
+		session: sessionServiceStub{
+			listSessions: func(ctx context.Context, req *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error) {
+				if req.Msg.GetLimit() < 100 {
+					t.Fatalf("ListSessions request = %#v", req.Msg)
+				}
+				return connect.NewResponse(&agentcomposev1.ListSessionsResponse{Sessions: sessions}), nil
+			},
+		},
+		sandbox: sandboxServiceStub{
+			getStats: func(ctx context.Context, req *connect.Request[agentcomposev2.GetSandboxStatsRequest]) (*connect.Response[agentcomposev2.GetSandboxStatsResponse], error) {
+				statsCalls = append(statsCalls, req.Msg.GetSandboxId())
+				value := float64(len(statsCalls) * 10)
+				return connect.NewResponse(&agentcomposev2.GetSandboxStatsResponse{Stats: &agentcomposev2.SandboxStats{
+					SandboxId:        req.Msg.GetSandboxId(),
+					Driver:           "boxlite",
+					SampledAt:        "2026-07-04T08:00:00Z",
+					CpuPercent:       testStatsMetric(value, "percent"),
+					MemoryUsageBytes: testStatsMetric(value*100, "bytes"),
+					UptimeSeconds:    testStatsMetric(value, "seconds"),
+				}}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("stats", "--host", server.URL, "--file", composePath)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("stats code/stderr = %d / %q", exitCode, stderr)
+	}
+	for _, want := range []string{"SANDBOX", "session-one", "session-two", "boxlite", "10.00", "20.00"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stats output %q does not contain %q", stdout, want)
+		}
+	}
+	for _, notWant := range []string{"session-stopped", "session-foreign"} {
+		if strings.Contains(stdout, notWant) {
+			t.Fatalf("stats output %q contains %q", stdout, notWant)
+		}
+	}
+
+	jsonOut, jsonErr, _, jsonCode := executeCLICommand("stats", "--host", server.URL, "--file", composePath, "--json")
+	if jsonCode != 0 || jsonErr != "" {
+		t.Fatalf("stats --json code/stderr = %d / %q", jsonCode, jsonErr)
+	}
+	var decoded composeProjectStatsOutput
+	if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
+		t.Fatalf("stats JSON decode failed: %v\n%s", err, jsonOut)
+	}
+	if decoded.Project.Name != "cli-stats-demo" || len(decoded.Stats) != 2 {
+		t.Fatalf("stats JSON project/stats = %#v", decoded)
+	}
+	if decoded.Stats[0].Sandbox != "session-one" || decoded.Stats[1].Sandbox != "session-two" {
+		t.Fatalf("stats JSON order = %#v", decoded.Stats)
+	}
+	if strings.Contains(jsonOut, "session-stopped") || strings.Contains(jsonOut, "session-foreign") {
+		t.Fatalf("stats JSON includes non-running or foreign sandbox: %s", jsonOut)
+	}
+	wantCalls := []string{"session-one", "session-two", "session-one", "session-two"}
+	if !reflect.DeepEqual(statsCalls, wantCalls) {
+		t.Fatalf("stats calls = %#v, want %#v", statsCalls, wantCalls)
+	}
+}
+
+func TestIntegrationCLIStatsWithoutSandboxAllowsNoRunningSandboxes(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-stats-empty
+agents:
+  reviewer:
+    provider: codex
+`)
+	project := testCLIProject("project-cli-stats-empty", "cli-stats-empty", composePath)
+	sessions := []*agentcomposev1.SessionSummary{
+		testCLISessionSummary("session-stopped", "STOPPED", "project-cli-stats-empty", "reviewer", "run-stopped"),
+		testCLISessionSummary("session-foreign", "RUNNING", "foreign-project", "reviewer", "run-foreign"),
+	}
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
+			},
+		},
+		run: runServiceStub{
+			listRuns: func(ctx context.Context, req *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
+				return connect.NewResponse(&agentcomposev2.ListRunsResponse{Runs: []*agentcomposev2.RunSummary{}}), nil
+			},
+		},
+		session: sessionServiceStub{
+			listSessions: func(ctx context.Context, req *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error) {
+				return connect.NewResponse(&agentcomposev1.ListSessionsResponse{Sessions: sessions}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("stats", "--host", server.URL, "--file", composePath)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("stats empty code/stderr = %d / %q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "SANDBOX") || strings.Contains(stdout, "session-stopped") || strings.Contains(stdout, "session-foreign") {
+		t.Fatalf("stats empty output = %q", stdout)
+	}
+
+	jsonOut, jsonErr, _, jsonCode := executeCLICommand("stats", "--host", server.URL, "--file", composePath, "--json")
+	if jsonCode != 0 || jsonErr != "" {
+		t.Fatalf("stats empty --json code/stderr = %d / %q", jsonCode, jsonErr)
+	}
+	var decoded composeProjectStatsOutput
+	if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
+		t.Fatalf("stats empty JSON decode failed: %v\n%s", err, jsonOut)
+	}
+	if decoded.Project.Name != "cli-stats-empty" || len(decoded.Stats) != 0 {
+		t.Fatalf("stats empty JSON = %#v", decoded)
 	}
 }
 

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -227,9 +227,11 @@ Default columns:
 
 ## `stats`: Show Sandbox Resource Stats
 
-Show a single resource stats snapshot for a running sandbox.
+Show resource stats snapshots for running sandboxes. Without a sandbox argument, the command shows all running sandboxes for the current compose project.
 
 ```bash
+agent-compose stats
+agent-compose stats --json
 agent-compose stats <sandbox>
 agent-compose stats <sandbox> --json
 ```

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -233,9 +233,11 @@ agent-compose ps --json
 
 ## `stats`：查看 sandbox 资源统计
 
-查看运行中 sandbox 的单次资源统计快照。
+查看运行中 sandbox 的资源统计快照。未指定 sandbox 参数时，显示当前 compose project 下所有 running sandbox 的统计。
 
 ```bash
+agent-compose stats
+agent-compose stats --json
 agent-compose stats <sandbox>
 agent-compose stats <sandbox> --json
 ```

--- a/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
+++ b/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
@@ -51,7 +51,7 @@ CLI 是 agent-compose daemon 的操作入口。它负责读取本地 project 配
 | `run` | 调用 v2 `RunService` 创建 run，支持 trigger、prompt、command、detach、interactive、Jupyter 和 cleanup policy。 |
 | `logs` | 读取 run 日志，支持 agent/run/sandbox filter、tail、timestamp 和 server streaming follow。 |
 | `ps` | 以 sandbox 视图列出当前 project 的运行态，默认只显示 running sandbox。 |
-| `stats` | 通过 v2 `SandboxService.GetSandboxStats` 获取 running sandbox 的单次资源统计。 |
+| `stats` | 通过 v2 `SandboxService.GetSandboxStats` 获取指定 sandbox 或当前 project 所有 running sandbox 的资源统计。 |
 | `stop` | 基于 v1 `SessionService.StopSession` 停止 sandbox。 |
 | `resume` | 基于 v1 `SessionService.ResumeSession` 恢复 sandbox。 |
 | `rm` | 调用 v2 `SandboxService.RemoveSandbox` 删除 sandbox；running sandbox 需要 `--force`。 |
@@ -190,7 +190,7 @@ run 日志的权威文件由 `project_run.logs_path` 指向：
 
 ## Stats
 
-`agent-compose stats <sandbox>` 调用 v2 `SandboxService.GetSandboxStats`。service 解析 sandbox/session、runtime state 和对应 driver optional stats 能力。
+`agent-compose stats [sandbox]` 调用 v2 `SandboxService.GetSandboxStats`。指定 sandbox 时直接查询该 sandbox；未指定 sandbox 时先按当前 compose project 枚举 running sandbox，再逐个查询 stats。service 解析 sandbox/session、runtime state 和对应 driver optional stats 能力。
 
 JSON 字段集合保持稳定：
 


### PR DESCRIPTION
## Summary
- allow `agent-compose stats` without a sandbox argument
- list stats for all running sandboxes in the current compose project when no target is provided
- preserve existing single-sandbox stats behavior and JSON shape
- document the updated CLI semantics

## Tests
- `go test ./cmd/agent-compose -run 'Stats|PS'`
- `task test`
- `task lint`
- `task build`