### PR TITLE
fix: stop docker sandboxes without timeout

### DIFF
--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -77,13 +77,13 @@ func (d *SessionDriver) saveSessionStartInfo(session *domain.Session, vmState do
 }
 
 func (d *SessionDriver) StopSessionVM(ctx context.Context, session *domain.Session) error {
-	ctx, cancel := context.WithTimeout(ctx, d.Config.SessionStopTimeout)
-	defer cancel()
-
 	driver, err := driverpkg.ResolveSessionRuntimeDriver(session.Summary.Driver, d.Config.RuntimeDriver)
 	if err != nil {
 		return err
 	}
+	ctx, cancel := context.WithTimeout(ctx, driverpkg.SessionStopContextTimeout(driver, d.Config.SessionStopTimeout))
+	defer cancel()
+
 	runtime, err := d.Runtimes.ForDriver(driver)
 	if err != nil {
 		return err

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -32,6 +32,30 @@ func (r fakeSessionRuntime) ExecStream(context.Context, *domain.Session, domain.
 	return domain.ExecResult{}, nil
 }
 
+type fakeStopDeadlineRuntime struct {
+	remaining time.Duration
+}
+
+func (r *fakeStopDeadlineRuntime) EnsureSession(context.Context, *domain.Session, domain.VMState, domain.ProxyState) (domain.SessionVMInfo, error) {
+	return domain.SessionVMInfo{}, nil
+}
+
+func (r *fakeStopDeadlineRuntime) StopSession(ctx context.Context, _ *domain.Session, _ domain.VMState) (bool, error) {
+	deadline, ok := ctx.Deadline()
+	if ok {
+		r.remaining = time.Until(deadline)
+	}
+	return false, nil
+}
+
+func (r *fakeStopDeadlineRuntime) Exec(context.Context, *domain.Session, domain.VMState, domain.ExecSpec) (domain.ExecResult, error) {
+	return domain.ExecResult{}, nil
+}
+
+func (r *fakeStopDeadlineRuntime) ExecStream(context.Context, *domain.Session, domain.VMState, domain.ExecSpec, domain.ExecStreamWriter) (domain.ExecResult, error) {
+	return domain.ExecResult{}, nil
+}
+
 type fakeDriverRuntime struct {
 	alive bool
 }
@@ -120,5 +144,43 @@ func TestSessionDriverStartSessionVMSavesRuntimeState(t *testing.T) {
 	}
 	if vmState.BoxID != "container-1" || vmState.BootstrapRef != updatedProxyState.JupyterURL {
 		t.Fatalf("vm state = %+v, want box id and bootstrap ref from runtime", vmState)
+	}
+}
+
+func TestSessionDriverStopSessionVMAddsDockerStopContextMargin(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:            root,
+		SessionRoot:         filepath.Join(root, "sessions"),
+		RuntimeDriver:       driverpkg.RuntimeDriverDocker,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		SessionStartTimeout: 2 * time.Second,
+		SessionStopTimeout:  2 * time.Second,
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	session, err := store.CreateSession(ctx, "adapter session", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	runtime := &fakeStopDeadlineRuntime{}
+	driver := NewSessionDriver(config, store, nil, fakeRuntimeProvider{runtime: runtime})
+
+	if err := driver.StopSessionVM(ctx, session); err != nil {
+		t.Fatalf("StopSessionVM returned error: %v", err)
+	}
+	if runtime.remaining <= config.SessionStopTimeout+4*time.Second {
+		t.Fatalf("StopSessionVM context remaining = %s, want docker stop timeout plus API margin", runtime.remaining)
+	}
+	vmState, err := store.GetVMState(session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetVMState returned error: %v", err)
+	}
+	if vmState.StoppedAt.IsZero() || vmState.LastError != "" {
+		t.Fatalf("vm state after stop = %+v", vmState)
 	}
 }

--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -29,6 +29,9 @@ const (
 	dockerSessionLabelPrefix = "agent-compose"
 	dockerSessionLabelID     = dockerSessionLabelPrefix + ".session_id"
 	dockerSessionLabelDriver = dockerSessionLabelPrefix + ".driver"
+
+	dockerStopAPIMargin             = 5 * time.Second
+	dockerStopFallbackActionTimeout = 5 * time.Second
 )
 
 type dockerRuntime struct {
@@ -150,10 +153,16 @@ func (r *dockerRuntime) StopSession(ctx context.Context, session *Session, vmSta
 			timeoutSeconds = 0
 		}
 		if err := dockerClient.ContainerStop(ctx, containerInfo.ID, containerapi.StopOptions{Timeout: &timeoutSeconds}); err != nil && !isDockerNotFound(err) {
-			return false, fmt.Errorf("stop docker container %s: %w", containerInfo.ID, err)
+			if stopped, inspectErr := r.containerStoppedAfterStopError(containerInfo.ID); inspectErr != nil {
+				return false, fmt.Errorf("stop docker container %s: %w; inspect after stop failure: %v", containerInfo.ID, err, inspectErr)
+			} else if !stopped {
+				return false, fmt.Errorf("stop docker container %s: %w", containerInfo.ID, err)
+			}
 		}
 	}
-	if err := dockerClient.ContainerRemove(ctx, containerInfo.ID, containerapi.RemoveOptions{Force: true}); err != nil && !isDockerNotFound(err) {
+	removeCtx, cancel := dockerFallbackContextIfDone(ctx)
+	defer cancel()
+	if err := dockerClient.ContainerRemove(removeCtx, containerInfo.ID, containerapi.RemoveOptions{Force: true}); err != nil && !isDockerNotFound(err) {
 		return false, fmt.Errorf("remove docker container %s: %w", containerInfo.ID, err)
 	}
 	return false, nil
@@ -312,12 +321,7 @@ func (r *dockerRuntime) getOrCreateContainer(ctx context.Context, dockerClient *
 			dockerSessionLabelDriver: RuntimeDriverDocker,
 		},
 	}
-	hostConfig := &containerapi.HostConfig{
-		Mounts:       mounts,
-		PortBindings: portBindings,
-		AutoRemove:   false,
-		NetworkMode:  networkMode,
-	}
+	hostConfig := dockerSessionHostConfig(mounts, portBindings, networkMode)
 	createResp, err := dockerClient.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, name)
 	if err != nil {
 		return containerapi.InspectResponse{}, false, fmt.Errorf("create docker container for session %s: %w", session.Summary.ID, err)
@@ -327,6 +331,60 @@ func (r *dockerRuntime) getOrCreateContainer(ctx context.Context, dockerClient *
 		return containerapi.InspectResponse{}, false, fmt.Errorf("inspect docker container %s: %w", createResp.ID, err)
 	}
 	return containerInfo, true, nil
+}
+
+func (r *dockerRuntime) containerStoppedAfterStopError(containerID string) (bool, error) {
+	inspectCtx, cancel := context.WithTimeout(context.Background(), dockerStopFallbackActionTimeout)
+	defer cancel()
+	dockerClient, err := r.newClient()
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = dockerClient.Close() }()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		containerInfo, err := dockerClient.ContainerInspect(inspectCtx, containerID)
+		if isDockerNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if containerInfo.State == nil || !containerInfo.State.Running {
+			return true, nil
+		}
+		select {
+		case <-inspectCtx.Done():
+			return false, nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func dockerFallbackContextIfDone(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx.Err() == nil {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(context.Background(), dockerStopFallbackActionTimeout)
+}
+
+func dockerSessionHostConfig(mounts []mountapi.Mount, portBindings nat.PortMap, networkMode containerapi.NetworkMode) *containerapi.HostConfig {
+	useInit := true
+	return &containerapi.HostConfig{
+		Mounts:       mounts,
+		PortBindings: portBindings,
+		AutoRemove:   false,
+		NetworkMode:  networkMode,
+		Init:         &useInit,
+	}
+}
+
+func SessionStopContextTimeout(driver string, stopTimeout time.Duration) time.Duration {
+	if driver != RuntimeDriverDocker || stopTimeout <= 0 {
+		return stopTimeout
+	}
+	return stopTimeout + dockerStopAPIMargin
 }
 
 func (r *dockerRuntime) dockerGuestNetworkMode(ctx context.Context, dockerClient *client.Client) containerapi.NetworkMode {

--- a/pkg/driver/docker_runtime_test.go
+++ b/pkg/driver/docker_runtime_test.go
@@ -65,6 +65,36 @@ func TestDockerRuntimeContainerEnvUsesRuntimeWorkspaceVariable(t *testing.T) {
 	}
 }
 
+func TestDockerSessionHostConfigEnablesInit(t *testing.T) {
+	hostConfig := dockerSessionHostConfig(
+		[]mountapi.Mount{{Type: mountapi.TypeBind, Source: "/host/workspace", Target: "/workspace"}},
+		nil,
+		containerapi.NetworkMode("bridge"),
+	)
+	if hostConfig.Init == nil || !*hostConfig.Init {
+		t.Fatalf("docker session host config Init = %v, want true", hostConfig.Init)
+	}
+	if hostConfig.AutoRemove {
+		t.Fatalf("docker session host config AutoRemove = true, want false")
+	}
+	if hostConfig.NetworkMode != containerapi.NetworkMode("bridge") || len(hostConfig.Mounts) != 1 {
+		t.Fatalf("docker session host config = %+v", hostConfig)
+	}
+}
+
+func TestSessionStopContextTimeoutAddsDockerAPIMargin(t *testing.T) {
+	stopTimeout := 30 * time.Second
+	if got := SessionStopContextTimeout(RuntimeDriverDocker, stopTimeout); got != 35*time.Second {
+		t.Fatalf("docker stop context timeout = %s, want 35s", got)
+	}
+	if got := SessionStopContextTimeout(RuntimeDriverBoxlite, stopTimeout); got != stopTimeout {
+		t.Fatalf("boxlite stop context timeout = %s, want %s", got, stopTimeout)
+	}
+	if got := SessionStopContextTimeout(RuntimeDriverDocker, 0); got != 0 {
+		t.Fatalf("zero docker stop context timeout = %s, want 0", got)
+	}
+}
+
 func TestDockerStatsFromResponseMapsStableMetrics(t *testing.T) {
 	startedAt := time.Date(2026, 7, 4, 8, 0, 0, 0, time.UTC)
 	sampledAt := startedAt.Add(90 * time.Second)


### PR DESCRIPTION
## Summary
- enable Docker init for sandbox containers so PID 1 forwards SIGTERM and `tail -f /dev/null` exits promptly
- give Docker stop API calls a small context margin beyond the container stop grace period
- recover from stop context errors by re-inspecting exited containers and continuing cleanup

## Tests
- `go test ./pkg/driver ./pkg/agentcompose/adapters ./pkg/runs -count=1`
- `task lint`
- `task build`
- `task test`

## Manual verification
- ran a temporary daemon with `RUNTIME_DRIVER=docker` and `SESSION_STOP_TIMEOUT=3s`
- verified `run minimal --command 'echo hi'` completed in 0.52s\n- verified a kept sandbox had `HostConfig.Init: true` and `agent-compose stop <sandbox>` completed in 0.18s