### PR TITLE
fix: remove projects from ls after down

### DIFF
--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -43,6 +43,7 @@ type ControllerStore interface {
 	GetProjectIfExists(context.Context, string, bool) (domain.ProjectRecord, bool, error)
 	ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error)
 	UpsertProject(context.Context, domain.ProjectRecord) (domain.ProjectRecord, error)
+	MarkProjectRemoved(context.Context, string) (domain.ProjectRecord, error)
 	SaveProjectRevision(context.Context, domain.ProjectRevisionRecord) (domain.ProjectRevisionRecord, bool, error)
 	GetProjectAgent(context.Context, string, string) (domain.ProjectAgentRecord, error)
 	UpsertProjectAgent(context.Context, domain.ProjectAgentRecord) (domain.ProjectAgentRecord, error)
@@ -303,7 +304,7 @@ func (c *Controller) RemoveProject(ctx context.Context, req RemoveRequest) (Remo
 	if req.RemoveHistory {
 		return RemoveResult{}, ErrUnimplemented
 	}
-	project, err := c.ResolveProjectRef(ctx, req.Project)
+	project, err := c.resolveProjectRef(ctx, req.Project, true)
 	if err != nil {
 		return RemoveResult{}, err
 	}
@@ -318,6 +319,20 @@ func (c *Controller) RemoveProject(ctx context.Context, req RemoveRequest) (Remo
 	if err != nil {
 		return RemoveResult{Project: project, Changes: changes}, err
 	}
+	if project.RemovedAt.IsZero() {
+		removedProject, err := c.store.MarkProjectRemoved(ctx, project.ID)
+		if err != nil {
+			return RemoveResult{Project: project, Changes: changes}, err
+		}
+		project = removedProject
+		changes = append(changes, Change{
+			Action:       ChangeActionRemoved,
+			ResourceType: "project",
+			ResourceID:   project.ID,
+			Name:         project.Name,
+			Message:      "removed by project down",
+		})
+	}
 	agents, err := c.store.ListProjectAgents(ctx, project.ID)
 	if err != nil {
 		return RemoveResult{}, err
@@ -330,10 +345,24 @@ func (c *Controller) RemoveProject(ctx context.Context, req RemoveRequest) (Remo
 }
 
 func (c *Controller) ResolveProjectRef(ctx context.Context, ref ProjectRef) (domain.ProjectRecord, error) {
+	return c.resolveProjectRef(ctx, ref, false)
+}
+
+func (c *Controller) resolveProjectRef(ctx context.Context, ref ProjectRef, includeRemoved bool) (domain.ProjectRecord, error) {
 	if c.store == nil {
 		return domain.ProjectRecord{}, fmt.Errorf("config store is required")
 	}
 	if projectID := strings.TrimSpace(ref.ProjectID); projectID != "" {
+		if includeRemoved {
+			project, found, err := c.store.GetProjectIfExists(ctx, projectID, true)
+			if err != nil {
+				return domain.ProjectRecord{}, err
+			}
+			if found {
+				return project, nil
+			}
+			return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", projectID, fmt.Sprintf("project %s not found", projectID), sql.ErrNoRows)
+		}
 		return c.store.GetProject(ctx, projectID)
 	}
 	name := strings.TrimSpace(ref.Name)
@@ -343,12 +372,22 @@ func (c *Controller) ResolveProjectRef(ctx context.Context, ref ProjectRef) (dom
 		if err != nil {
 			return domain.ProjectRecord{}, err
 		}
+		if includeRemoved {
+			project, found, err := c.store.GetProjectIfExists(ctx, projectID, true)
+			if err != nil {
+				return domain.ProjectRecord{}, err
+			}
+			if found {
+				return project, nil
+			}
+			return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", projectID, fmt.Sprintf("project %s not found", projectID), sql.ErrNoRows)
+		}
 		return c.store.GetProject(ctx, projectID)
 	}
 	if name == "" {
 		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project id or name is required", nil)
 	}
-	result, err := c.store.ListProjects(ctx, domain.ProjectListOptions{Query: name, Limit: 200})
+	result, err := c.store.ListProjects(ctx, domain.ProjectListOptions{Query: name, IncludeRemoved: includeRemoved, Limit: 200})
 	if err != nil {
 		return domain.ProjectRecord{}, err
 	}

--- a/pkg/projects/controller_coverage_test.go
+++ b/pkg/projects/controller_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"agent-compose/pkg/compose"
 	appconfig "agent-compose/pkg/config"
@@ -92,6 +93,36 @@ agents:
 	}
 }
 
+func TestControllerRemoveProjectMarksProjectRemovedAndIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := &controllerCoverageStore{
+		projects: []domain.ProjectRecord{{ID: "project-1", Name: "down-project", SourcePath: "/repo/agent-compose.yaml"}},
+	}
+	controller := NewController(ControllerDependencies{
+		Store:    store,
+		Sessions: controllerCoverageSessionStore{},
+	})
+	removed, err := controller.RemoveProject(ctx, RemoveRequest{Project: ProjectRef{ProjectID: "project-1"}})
+	if err != nil {
+		t.Fatalf("RemoveProject returned error: %v", err)
+	}
+	if removed.Project.RemovedAt.IsZero() {
+		t.Fatalf("RemoveProject project was not marked removed: %#v", removed.Project)
+	}
+	assertProjectChange(t, removed.Changes, ChangeActionRemoved, "project", "project-1")
+	if result, err := store.ListProjects(ctx, domain.ProjectListOptions{}); err != nil || result.TotalCount != 0 {
+		t.Fatalf("ListProjects after remove result=%#v err=%v", result, err)
+	}
+
+	repeated, err := controller.RemoveProject(ctx, RemoveRequest{Project: ProjectRef{ProjectID: "project-1"}})
+	if err != nil {
+		t.Fatalf("repeated RemoveProject returned error: %v", err)
+	}
+	if len(repeated.Changes) != 0 {
+		t.Fatalf("repeated RemoveProject changes=%#v, want unchanged", repeated.Changes)
+	}
+}
+
 func TestIntegrationControllerValidateApplyDryRunAndResolveWorkflows(t *testing.T) {
 	TestControllerValidateApplyDryRunAndResolveWorkflows(t)
 }
@@ -116,23 +147,53 @@ type controllerCoverageStore struct {
 
 func (s *controllerCoverageStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, error) {
 	for _, project := range s.projects {
-		if project.ID == id {
+		if project.ID == id && project.RemovedAt.IsZero() {
 			return project, nil
 		}
 	}
 	return domain.ProjectRecord{}, sql.ErrNoRows
 }
 
-func (s *controllerCoverageStore) GetProjectIfExists(context.Context, string, bool) (domain.ProjectRecord, bool, error) {
+func (s *controllerCoverageStore) GetProjectIfExists(_ context.Context, id string, includeRemoved bool) (domain.ProjectRecord, bool, error) {
+	for _, project := range s.projects {
+		if project.ID == id && (includeRemoved || project.RemovedAt.IsZero()) {
+			return project, true, nil
+		}
+	}
 	return domain.ProjectRecord{}, false, nil
 }
 
-func (s *controllerCoverageStore) ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error) {
-	return domain.ProjectListResult{Projects: s.projects}, nil
+func (s *controllerCoverageStore) ListProjects(_ context.Context, options domain.ProjectListOptions) (domain.ProjectListResult, error) {
+	var projects []domain.ProjectRecord
+	query := strings.TrimSpace(options.Query)
+	for _, project := range s.projects {
+		if !options.IncludeRemoved && !project.RemovedAt.IsZero() {
+			continue
+		}
+		if query != "" && project.Name != query {
+			continue
+		}
+		projects = append(projects, project)
+	}
+	return domain.ProjectListResult{Projects: projects, TotalCount: len(projects)}, nil
 }
 
 func (s *controllerCoverageStore) UpsertProject(context.Context, domain.ProjectRecord) (domain.ProjectRecord, error) {
 	return domain.ProjectRecord{}, nil
+}
+
+func (s *controllerCoverageStore) MarkProjectRemoved(_ context.Context, projectID string) (domain.ProjectRecord, error) {
+	for i, project := range s.projects {
+		if project.ID == projectID {
+			if project.RemovedAt.IsZero() {
+				project.RemovedAt = time.Now().UTC()
+				project.UpdatedAt = project.RemovedAt
+				s.projects[i] = project
+			}
+			return project, nil
+		}
+	}
+	return domain.ProjectRecord{}, sql.ErrNoRows
 }
 
 func (s *controllerCoverageStore) SaveProjectRevision(context.Context, domain.ProjectRevisionRecord) (domain.ProjectRevisionRecord, bool, error) {
@@ -197,4 +258,20 @@ func (s *controllerCoverageStore) ReplaceLoaderTriggers(context.Context, string,
 
 func (s *controllerCoverageStore) SetLoaderEnabled(context.Context, string, bool) error {
 	return nil
+}
+
+type controllerCoverageSessionStore struct{}
+
+func (controllerCoverageSessionStore) ListSessions(context.Context, domain.SessionListOptions) (domain.SessionListResult, error) {
+	return domain.SessionListResult{}, nil
+}
+
+func assertProjectChange(t *testing.T, changes []Change, action, resourceType, resourceID string) {
+	t.Helper()
+	for _, change := range changes {
+		if change.Action == action && change.ResourceType == resourceType && change.ResourceID == resourceID {
+			return
+		}
+	}
+	t.Fatalf("changes %#v did not contain %s %s %s", changes, action, resourceType, resourceID)
 }

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -56,6 +56,33 @@ func (s *ConfigStore) UpsertProject(ctx context.Context, project ProjectRecord) 
 	return s.GetProject(ctx, project.ID)
 }
 
+func (s *ConfigStore) MarkProjectRemoved(ctx context.Context, projectID string) (ProjectRecord, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return ProjectRecord{}, fmt.Errorf("project id is required")
+	}
+	existing, found, err := s.getProject(ctx, projectID, true)
+	if err != nil {
+		return ProjectRecord{}, err
+	}
+	if !found {
+		return ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", projectID, fmt.Sprintf("project %s not found", projectID), sql.ErrNoRows)
+	}
+	if !existing.RemovedAt.IsZero() {
+		return existing, nil
+	}
+	now := time.Now().UTC()
+	result, err := s.db.ExecContext(ctx, `UPDATE project SET updated_at = ?, removed_at = ? WHERE id = ? AND removed_at = 0`,
+		now.Unix(), now.Unix(), projectID)
+	if err != nil {
+		return ProjectRecord{}, fmt.Errorf("mark project %s removed: %w", projectID, err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return s.getProjectRequired(ctx, projectID, true)
+	}
+	return s.getProjectRequired(ctx, projectID, true)
+}
+
 func (s *ConfigStore) SaveProjectRevision(ctx context.Context, revision ProjectRevisionRecord) (ProjectRevisionRecord, bool, error) {
 	revision.ProjectID = strings.TrimSpace(revision.ProjectID)
 	revision.SpecHash = strings.TrimSpace(revision.SpecHash)
@@ -476,6 +503,18 @@ func (s *ConfigStore) getProject(ctx context.Context, projectID string, includeR
 		return ProjectRecord{}, false, err
 	}
 	return item, true, nil
+}
+
+func (s *ConfigStore) getProjectRequired(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, error) {
+	item, found, err := s.getProject(ctx, projectID, includeRemoved)
+	if err != nil {
+		return ProjectRecord{}, err
+	}
+	if !found {
+		id := strings.TrimSpace(projectID)
+		return ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", id, fmt.Sprintf("project %s not found", id), sql.ErrNoRows)
+	}
+	return item, nil
 }
 
 func (s *ConfigStore) GetProjectIfExists(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -3,6 +3,7 @@ package configstore
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -181,6 +182,23 @@ func testConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 	}
 	if runs, err := store.ListProjectRunsForSession(ctx, "session-1"); err != nil || len(runs) != 1 {
 		t.Fatalf("ListProjectRunsForSession runs=%#v err=%v", runs, err)
+	}
+	removed, err := store.MarkProjectRemoved(ctx, project.ID)
+	if err != nil || removed.RemovedAt.IsZero() {
+		t.Fatalf("MarkProjectRemoved removed=%#v err=%v", removed, err)
+	}
+	if _, err := store.GetProject(ctx, project.ID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("GetProject after remove err=%v, want not found", err)
+	}
+	if result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "updated", Limit: 10}); err != nil || result.TotalCount != 0 {
+		t.Fatalf("ListProjects after remove result=%#v err=%v", result, err)
+	}
+	if result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "updated", IncludeRemoved: true, Limit: 10}); err != nil || result.TotalCount != 1 || result.Projects[0].RemovedAt.IsZero() {
+		t.Fatalf("ListProjects include removed result=%#v err=%v", result, err)
+	}
+	reactivated, err := store.UpsertProject(ctx, project)
+	if err != nil || !reactivated.RemovedAt.IsZero() {
+		t.Fatalf("UpsertProject reactivated=%#v err=%v", reactivated, err)
 	}
 	if placeholders(0) != "" || placeholders(3) != "?,?,?" {
 		t.Fatalf("placeholders returned unexpected values")


### PR DESCRIPTION
## Summary
- mark projects as removed after `agent-compose down` completes shutdown work
- keep repeated `down` idempotent by resolving already removed projects
- add controller and config store coverage for removed project filtering/reactivation

## Tests
- `task lint`
- `task build`
- `task test`