### PR TITLE
Inject anthropic facade env into microsandbox

### DIFF
--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	appconfig "agent-compose/pkg/config"
@@ -21,6 +22,8 @@ type SessionDriver struct {
 	ConfigDB *configstore.ConfigStore
 	Runtimes RuntimeProvider
 }
+
+var ensureSessionLLMFacadeConfig = runtimefacade.EnsureSessionLLMFacadeConfig
 
 func NewSessionDriver(config *appconfig.Config, store *sessionstore.Store, configDB *configstore.ConfigStore, runtimes RuntimeProvider) *SessionDriver {
 	return &SessionDriver{Config: config, Store: store, ConfigDB: configDB, Runtimes: runtimes}
@@ -120,14 +123,14 @@ func (d *SessionDriver) prepareSessionStart(ctx context.Context, driver string, 
 	}
 	managedEnv := map[string]string{}
 	for _, agent := range []string{"codex", "claude"} {
-		agentEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, d.Config, d.ConfigDB, session, agent, "", "session", "")
+		agentEnv, err := ensureSessionLLMFacadeConfig(ctx, d.Config, d.ConfigDB, session, agent, "", "session", "")
 		if err != nil {
 			if agent == "claude" && runtimefacade.IsOptionalConfigError(err) {
 				continue
 			}
 			return err
 		}
-		for key, value := range agentEnv {
+		for key, value := range startupFacadeEnv(agent, agentEnv) {
 			managedEnv[key] = value
 		}
 	}
@@ -136,4 +139,23 @@ func (d *SessionDriver) prepareSessionStart(ctx context.Context, driver string, 
 	}
 	*vmState = execution.FromDriverVMState(prepared)
 	return nil
+}
+
+func startupFacadeEnv(agent string, env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	if strings.EqualFold(strings.TrimSpace(agent), "claude") {
+		filtered := make(map[string]string, len(env))
+		for _, key := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL", "CLAUDE_MODEL"} {
+			if value := strings.TrimSpace(env[key]); value != "" {
+				filtered[key] = value
+			}
+		}
+		if len(filtered) == 0 {
+			return nil
+		}
+		return filtered
+	}
+	return env
 }

--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -118,9 +118,18 @@ func (d *SessionDriver) prepareSessionStart(ctx context.Context, driver string, 
 	if err != nil {
 		return err
 	}
-	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, d.Config, d.ConfigDB, session, "codex", "", "session", "")
-	if err != nil {
-		return err
+	managedEnv := map[string]string{}
+	for _, agent := range []string{"codex", "claude"} {
+		agentEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, d.Config, d.ConfigDB, session, agent, "", "session", "")
+		if err != nil {
+			if agent == "claude" && runtimefacade.IsOptionalConfigError(err) {
+				continue
+			}
+			return err
+		}
+		for key, value := range agentEnv {
+			managedEnv[key] = value
+		}
 	}
 	if len(managedEnv) > 0 {
 		session.RuntimeEnvItems = llms.EnvItemsFromMap(managedEnv, false)

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -259,6 +260,12 @@ func TestSessionDriverStartSessionVMInjectsOpenAIAndAnthropicFacadeEnv(t *testin
 	if runtimeEnv["OPENAI_API_KEY"] == "" {
 		t.Fatalf("OPENAI_API_KEY is empty")
 	}
+	if runtimeEnv["LLM_API_PROTOCOL"] != "responses" {
+		t.Fatalf("LLM_API_PROTOCOL = %q", runtimeEnv["LLM_API_PROTOCOL"])
+	}
+	if runtimeEnv["LLM_API_ENDPOINT"] != runtimeEnv["OPENAI_BASE_URL"] {
+		t.Fatalf("LLM_API_ENDPOINT = %q, want openai base %q", runtimeEnv["LLM_API_ENDPOINT"], runtimeEnv["OPENAI_BASE_URL"])
+	}
 	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] == "" {
 		t.Fatalf("ANTHROPIC_AUTH_TOKEN is empty")
 	}
@@ -267,5 +274,87 @@ func TestSessionDriverStartSessionVMInjectsOpenAIAndAnthropicFacadeEnv(t *testin
 	}
 	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] == "anthropic-secret" {
 		t.Fatalf("expected managed anthropic facade token, got raw provider token")
+	}
+	if runtimeEnv["AGENT_COMPOSE_SESSION_TOKEN"] == runtimeEnv["ANTHROPIC_AUTH_TOKEN"] {
+		t.Fatalf("expected generic session token to remain openai facade token")
+	}
+}
+
+func TestSessionDriverStartSessionVMIgnoresOptionalClaudeConfigError(t *testing.T) {
+	ctx := context.Background()
+	originalEnsure := ensureSessionLLMFacadeConfig
+	defer func() { ensureSessionLLMFacadeConfig = originalEnsure }()
+	ensureSessionLLMFacadeConfig = func(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, agent, model, source, runID string) (map[string]string, error) {
+		switch agent {
+		case "codex":
+			return map[string]string{
+				"AGENT_COMPOSE_SESSION_TOKEN": "openai-token",
+				"LLM_API_ENDPOINT":            "http://agent-compose.test:7410/api/runtime/sessions/" + session.Summary.ID + "/llm/openai/v1",
+				"LLM_API_KEY":                 "openai-token",
+				"LLM_API_PROTOCOL":            "responses",
+				"OPENAI_API_KEY":              "openai-token",
+				"OPENAI_BASE_URL":             "http://agent-compose.test:7410/api/runtime/sessions/" + session.Summary.ID + "/llm/openai/v1",
+			}, nil
+		case "claude":
+			return nil, domain.ClassifyError(domain.ErrRequired, "anthropic provider is required", nil)
+		default:
+			return nil, errors.New("unexpected agent")
+		}
+	}
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:             root,
+		DbAddr:               filepath.Join(root, "data.db"),
+		SessionRoot:          filepath.Join(root, "sessions"),
+		RuntimeDriver:        driverpkg.RuntimeDriverMicrosandbox,
+		MicrosandboxHome:     filepath.Join(root, "microsandbox"),
+		DefaultImage:         "guest:latest",
+		GuestWorkspacePath:   "/workspace",
+		JupyterGuestPort:     8888,
+		JupyterProxyBasePath: "/agent-compose/session",
+		SessionStartTimeout:  2 * time.Second,
+		RuntimeBaseURL:       "http://agent-compose.test:7410",
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	configDB, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session, err := store.CreateSession(ctx, "adapter session", "", driverpkg.RuntimeDriverMicrosandbox, "guest:latest", "", domain.SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	updatedProxyState := domain.ProxyState{
+		ProxyPath:  session.Summary.ProxyPath,
+		GuestHost:  "agent-compose-session-1",
+		HostPort:   39000,
+		GuestPort:  8888,
+		JupyterURL: "http://127.0.0.1:39000/lab?token=secret",
+		Token:      "secret",
+	}
+	var runtimeEnv map[string]string
+	driver := NewSessionDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{
+		info: domain.SessionVMInfo{BoxID: "container-1", JupyterURL: updatedProxyState.JupyterURL, ProxyState: &updatedProxyState},
+		ensureHook: func(session *domain.Session) {
+			runtimeEnv = map[string]string{}
+			for _, item := range session.RuntimeEnvItems {
+				runtimeEnv[item.Name] = item.Value
+			}
+		},
+	}})
+
+	if err := driver.StartSessionVM(ctx, session); err != nil {
+		t.Fatalf("StartSessionVM returned error: %v", err)
+	}
+	if runtimeEnv["OPENAI_BASE_URL"] == "" || runtimeEnv["OPENAI_API_KEY"] == "" {
+		t.Fatalf("missing openai facade env: %#v", runtimeEnv)
+	}
+	if runtimeEnv["ANTHROPIC_BASE_URL"] != "" || runtimeEnv["ANTHROPIC_AUTH_TOKEN"] != "" || runtimeEnv["ANTHROPIC_API_KEY"] != "" {
+		t.Fatalf("expected optional claude env to be skipped, got %#v", runtimeEnv)
 	}
 }

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -9,14 +9,21 @@ import (
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/configstore"
 	"agent-compose/pkg/storage/sessionstore"
+
+	"github.com/samber/do/v2"
 )
 
 type fakeSessionRuntime struct {
-	info domain.SessionVMInfo
+	info       domain.SessionVMInfo
+	ensureHook func(*domain.Session)
 }
 
-func (r fakeSessionRuntime) EnsureSession(context.Context, *domain.Session, domain.VMState, domain.ProxyState) (domain.SessionVMInfo, error) {
+func (r fakeSessionRuntime) EnsureSession(_ context.Context, session *domain.Session, _ domain.VMState, _ domain.ProxyState) (domain.SessionVMInfo, error) {
+	if r.ensureHook != nil {
+		r.ensureHook(session)
+	}
 	return r.info, nil
 }
 
@@ -182,5 +189,83 @@ func TestSessionDriverStopSessionVMAddsDockerStopContextMargin(t *testing.T) {
 	}
 	if vmState.StoppedAt.IsZero() || vmState.LastError != "" {
 		t.Fatalf("vm state after stop = %+v", vmState)
+	}
+}
+
+func TestSessionDriverStartSessionVMInjectsOpenAIAndAnthropicFacadeEnv(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:             root,
+		DbAddr:               filepath.Join(root, "data.db"),
+		SessionRoot:          filepath.Join(root, "sessions"),
+		RuntimeDriver:        driverpkg.RuntimeDriverMicrosandbox,
+		MicrosandboxHome:     filepath.Join(root, "microsandbox"),
+		DefaultImage:         "guest:latest",
+		GuestWorkspacePath:   "/workspace",
+		JupyterGuestPort:     8888,
+		JupyterProxyBasePath: "/agent-compose/session",
+		SessionStartTimeout:  2 * time.Second,
+		RuntimeBaseURL:       "http://agent-compose.test:7410",
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	configDB, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session, err := store.CreateSession(ctx, "adapter session", "", driverpkg.RuntimeDriverMicrosandbox, "guest:latest", "", domain.SessionTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session.ProviderEnvItems = []domain.SessionEnvVar{
+		{Name: "LLM_MODEL", Value: "gpt-test"},
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example.test"},
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "anthropic-secret"},
+		{Name: "ANTHROPIC_MODEL", Value: "claude-test"},
+	}
+	updatedProxyState := domain.ProxyState{
+		ProxyPath:  session.Summary.ProxyPath,
+		GuestHost:  "agent-compose-session-1",
+		HostPort:   39000,
+		GuestPort:  8888,
+		JupyterURL: "http://127.0.0.1:39000/lab?token=secret",
+		Token:      "secret",
+	}
+	var runtimeEnv map[string]string
+	driver := NewSessionDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{
+		info: domain.SessionVMInfo{BoxID: "container-1", JupyterURL: updatedProxyState.JupyterURL, ProxyState: &updatedProxyState},
+		ensureHook: func(session *domain.Session) {
+			runtimeEnv = map[string]string{}
+			for _, item := range session.RuntimeEnvItems {
+				runtimeEnv[item.Name] = item.Value
+			}
+		},
+	}})
+
+	if err := driver.StartSessionVM(ctx, session); err != nil {
+		t.Fatalf("StartSessionVM returned error: %v", err)
+	}
+	if runtimeEnv["OPENAI_BASE_URL"] != "http://agent-compose.test:7410/api/runtime/sessions/"+session.Summary.ID+"/llm/openai/v1" {
+		t.Fatalf("OPENAI_BASE_URL = %q", runtimeEnv["OPENAI_BASE_URL"])
+	}
+	if runtimeEnv["ANTHROPIC_BASE_URL"] != "http://agent-compose.test:7410/api/runtime/sessions/"+session.Summary.ID+"/llm/anthropic" {
+		t.Fatalf("ANTHROPIC_BASE_URL = %q", runtimeEnv["ANTHROPIC_BASE_URL"])
+	}
+	if runtimeEnv["OPENAI_API_KEY"] == "" {
+		t.Fatalf("OPENAI_API_KEY is empty")
+	}
+	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] == "" {
+		t.Fatalf("ANTHROPIC_AUTH_TOKEN is empty")
+	}
+	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] != runtimeEnv["ANTHROPIC_API_KEY"] {
+		t.Fatalf("anthropic token mismatch auth=%q api=%q", runtimeEnv["ANTHROPIC_AUTH_TOKEN"], runtimeEnv["ANTHROPIC_API_KEY"])
+	}
+	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] == "anthropic-secret" {
+		t.Fatalf("expected managed anthropic facade token, got raw provider token")
 	}
 }

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -113,6 +113,7 @@ func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, st
 		"LLM_API_KEY":                 tokenValue,
 		"LLM_API_PROTOCOL":            llms.APIProtocolMessages,
 		"ANTHROPIC_API_KEY":           tokenValue,
+		"ANTHROPIC_AUTH_TOKEN":        tokenValue,
 		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
 	}
 	if tokenModel != "" {
@@ -169,6 +170,7 @@ func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config
 		"LLM_API_KEY":                 tokenValue,
 		"LLM_API_PROTOCOL":            llms.APIProtocolMessages,
 		"ANTHROPIC_API_KEY":           tokenValue,
+		"ANTHROPIC_AUTH_TOKEN":        tokenValue,
 		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
 		"OPENCODE_CONFIG":             llms.GuestOpenCodeConfigPath(config),
 	}, nil
@@ -265,6 +267,10 @@ func isOptionalConfigError(err error) bool {
 		return false
 	}
 	return errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition)
+}
+
+func IsOptionalConfigError(err error) bool {
+	return isOptionalConfigError(err)
 }
 
 func HasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore) bool {

--- a/pkg/llms/runtimefacade/config_test.go
+++ b/pkg/llms/runtimefacade/config_test.go
@@ -101,6 +101,9 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 	if claude.Env["LLM_API_PROTOCOL"] != llms.APIProtocolMessages || claude.Env["ANTHROPIC_MODEL"] != "claude-test" {
 		t.Fatalf("claude env = %#v", claude.Env)
 	}
+	if claude.Env["ANTHROPIC_BASE_URL"] == "" || claude.Env["ANTHROPIC_AUTH_TOKEN"] == "" || claude.Env["ANTHROPIC_AUTH_TOKEN"] != claude.Env["ANTHROPIC_API_KEY"] {
+		t.Fatalf("claude anthropic facade env = %#v", claude.Env)
+	}
 	if _, err := store.GetLLMFacadeToken(ctx, claude.Env["AGENT_COMPOSE_SESSION_TOKEN"]); err != nil {
 		t.Fatalf("claude token not stored: %v", err)
 	}
@@ -117,7 +120,7 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig opencode anthropic returned error: %v", err)
 	}
-	if anthropic.Env["LLM_API_PROTOCOL"] != llms.APIProtocolMessages || anthropic.Env["ANTHROPIC_BASE_URL"] == "" || anthropic.Env["OPENCODE_CONFIG"] == "" {
+	if anthropic.Env["LLM_API_PROTOCOL"] != llms.APIProtocolMessages || anthropic.Env["ANTHROPIC_BASE_URL"] == "" || anthropic.Env["ANTHROPIC_AUTH_TOKEN"] == "" || anthropic.Env["OPENCODE_CONFIG"] == "" {
 		t.Fatalf("opencode anthropic env = %#v", anthropic.Env)
 	}
 


### PR DESCRIPTION
## Summary
- inject both codex and claude facade env when starting a session VM
- expose `ANTHROPIC_AUTH_TOKEN` alongside the existing anthropic facade settings
- add tests covering startup injection and anthropic facade env generation

## Testing
- `go test ./pkg/agentcompose/adapters ./pkg/llms/runtimefacade`