### PR TITLE
fix(cli): hide optional run flag sentinel in help

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -536,6 +536,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	runCmd.Flags().BoolVarP(&runOptions.Interactive, "interactive", "i", false, "Reserved for future interactive runs")
 	runCmd.Flags().Lookup("prompt").NoOptDefVal = optionalRunModeFlagNoValue
 	runCmd.Flags().Lookup("command").NoOptDefVal = optionalRunModeFlagNoValue
+	hideOptionalFlagNoValueInUsage(runCmd, "prompt", "command")
 
 	logsOptions := composeLogsOptions{}
 	logsCmd := &cobra.Command{
@@ -1500,6 +1501,39 @@ func normalizeOptionalRunModeValue(value string) string {
 		return ""
 	}
 	return strings.TrimSpace(value)
+}
+
+func hideOptionalFlagNoValueInUsage(cmd *cobra.Command, flagNames ...string) {
+	usageFunc := cmd.UsageFunc()
+	cmd.SetUsageFunc(func(c *cobra.Command) error {
+		return withHiddenOptionalFlagNoValue(c, flagNames, func() error {
+			return usageFunc(c)
+		})
+	})
+}
+
+func withHiddenOptionalFlagNoValue(cmd *cobra.Command, flagNames []string, fn func() error) error {
+	type flagRestore struct {
+		name        string
+		noOptDefVal string
+	}
+	var restores []flagRestore
+	for _, name := range flagNames {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil || flag.NoOptDefVal != optionalRunModeFlagNoValue {
+			continue
+		}
+		restores = append(restores, flagRestore{name: name, noOptDefVal: flag.NoOptDefVal})
+		flag.NoOptDefVal = ""
+	}
+	defer func() {
+		for _, restore := range restores {
+			if flag := cmd.Flags().Lookup(restore.name); flag != nil {
+				flag.NoOptDefVal = restore.noOptDefVal
+			}
+		}
+	}()
+	return fn()
 }
 
 func validateInteractivePromptProvider(project *compose.NormalizedProjectSpec, agentName string) error {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -150,6 +150,35 @@ func TestDaemonHelpDoesNotStartDaemon(t *testing.T) {
 	}
 }
 
+func TestRunHelpHidesOptionalModeFlagSentinel(t *testing.T) {
+	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--help")
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("run --help code/stderr = %d / %q", exitCode, stderr)
+	}
+	if runCount != 0 {
+		t.Fatalf("daemon runner called %d times, want 0", runCount)
+	}
+	for _, unexpected := range []string{
+		"agent-compose-run-mode",
+		"\x00",
+		`[="`,
+	} {
+		if strings.Contains(stdout, unexpected) {
+			t.Fatalf("run --help contains %q:\n%s", unexpected, stdout)
+		}
+	}
+	for _, want := range []string{
+		"--prompt string",
+		"--command string",
+		"Prompt to send to the agent",
+		"Bash command to execute in the agent sandbox",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("run --help does not contain %q:\n%s", want, stdout)
+		}
+	}
+}
+
 func TestUnknownCommandFailsWithoutStartingDaemon(t *testing.T) {
 	_, _, runCount, err := executeCommand("does-not-exist")
 	if err == nil {


### PR DESCRIPTION
## Summary

Fix `agent-compose run --help` output for the optional `--prompt` and `--command` flags.

  Before this change, the help text exposed the internal optional-run-mode sentinel and rendered the flag columns incorrectly, for example:

  ```text
  --prompt string[="                             agent-compose-run-mode"]Prompt to send to the agent
  --command string[="                            agent-compose-run-mode"]Bash command to execute in the agent sandbox
  ```
  Root cause: agent-compose run uses pflag NoOptDefVal so --prompt / --command can be passed without a value for interactive mode. The internal sentinel is \x00agent-compose-run-mode.
  pflag includes non-empty NoOptDefVal values in generated usage text, so the sentinel leaked into help output; the NUL byte also disrupted alignment.

  This change keeps the existing parsing behavior intact and only hides the internal sentinel while Cobra/pflag generates usage/help text for the run command.

## Testing

  go test ./cmd/agent-compose

  Result: 370 passed in 1 packages.


## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
