### PR TITLE
fix: treat run positional argument as trigger name

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ The main commands are:
 
 - `agent-compose daemon`: start the HTTP/Connect daemon.
 - `agent-compose up`: read `agent-compose.yml` and apply the project to the daemon.
-- `agent-compose run <agent>`: start a project agent run.
+- `agent-compose run <agent> <trigger-name>`: run a configured trigger by name.
+- `agent-compose run <agent> --prompt "..."` / `--command "..."`: run ad hoc prompt or shell command work.
 - `agent-compose logs`: inspect project run logs.
 - `agent-compose ps`: list project agents, recent runs, and active sessions.
 - `agent-compose down`: disable managed schedulers and stop running sessions.

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -42,6 +42,7 @@ import (
 	"agent-compose/pkg/compose"
 	"agent-compose/pkg/config"
 	"agent-compose/pkg/health"
+	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/projects"
 	agentcomposev1 "agent-compose/proto/agentcompose/v1"
 	"agent-compose/proto/agentcompose/v1/agentcomposev1connect"
@@ -515,7 +516,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 
 	runOptions := composeRunOptions{}
 	runCmd := &cobra.Command{
-		Use:   "run <agent> [prompt...]",
+		Use:   "run <agent> <trigger-name>",
 		Short: "Run a project agent",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -523,7 +524,6 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		},
 	}
 	runCmd.Flags().StringVar(&runOptions.Prompt, "prompt", "", "Prompt to send to the agent")
-	runCmd.Flags().StringVar(&runOptions.Trigger, "trigger", "", "Trigger to run for the agent")
 	runCmd.Flags().StringVar(&runOptions.Command, "command", "", "Bash command to execute in the agent sandbox")
 	runCmd.Flags().StringVar(&runOptions.SandboxID, "sandbox", "", "Reuse an existing sandbox")
 	// Deprecated: use --sandbox instead.
@@ -760,7 +760,6 @@ type composeListProjectsOptions struct {
 
 type composeRunOptions struct {
 	Prompt        string
-	Trigger       string
 	Command       string
 	SessionID     string
 	SandboxID     string
@@ -1171,7 +1170,7 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 	commandFlagChanged := cmd.Flags().Changed("command")
 	prompt := normalizeOptionalRunModeValue(normalizedOptions.Prompt)
 	commandText := normalizeOptionalRunModeValue(normalizedOptions.Command)
-	triggerID := strings.TrimSpace(normalizedOptions.Trigger)
+	triggerID := ""
 	if promptFlagChanged && normalizedOptions.Prompt == optionalRunModeFlagNoValue && len(args) > 1 {
 		prompt = strings.TrimSpace(args[1])
 		args = append(args[:1], args[2:]...)
@@ -1186,9 +1185,6 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 	if normalizedOptions.Interactive && cli.JSON {
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run -i/--interactive cannot be combined with --json")}
 	}
-	if normalizedOptions.Interactive && triggerID != "" {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run -i/--interactive cannot be combined with --trigger")}
-	}
 	if normalizedOptions.Interactive && promptFlagChanged == commandFlagChanged {
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run -i/--interactive requires exactly one of --prompt or --command")}
 	}
@@ -1197,6 +1193,17 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 		return err
 	}
 	agentName := strings.TrimSpace(args[0])
+	if !normalizedOptions.Interactive && triggerID == "" && prompt == "" && commandText == "" {
+		if len(args) > 2 {
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run accepts at most one trigger name positional argument")}
+		}
+		if len(args) == 2 {
+			triggerID, err = resolveComposeRunTriggerName(normalized, projectID, agentName, args[1])
+			if err != nil {
+				return err
+			}
+		}
+	}
 	if normalizedOptions.Interactive && promptFlagChanged {
 		if err := validateInteractivePromptProvider(normalized, agentName); err != nil {
 			return err
@@ -1204,6 +1211,9 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 	}
 	if !normalizedOptions.Interactive && cmd.Flags().Changed("command") && commandText == "" {
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run --command requires a non-empty command")}
+	}
+	if !normalizedOptions.Interactive && cmd.Flags().Changed("prompt") && prompt == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run --prompt requires a non-empty prompt")}
 	}
 	modeCount := 0
 	if !normalizedOptions.Interactive {
@@ -1214,26 +1224,31 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 		}
 	}
 	if modeCount > 1 {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run requires only one of --trigger, --prompt, or --command")}
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run requires only one of trigger name, --prompt, or --command")}
 	}
 	if !normalizedOptions.Interactive && (triggerID != "" || prompt != "" || commandText != "") && len(args) > 1 {
-		mode := "--prompt"
-		if triggerID != "" {
-			mode = "--trigger"
-		} else if commandText != "" {
+		mode := ""
+		if cmd.Flags().Changed("prompt") {
+			mode = "--prompt"
+		} else if cmd.Flags().Changed("command") {
 			mode = "--command"
 		}
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run with %s does not accept legacy positional prompt arguments", mode)}
+		if mode != "" {
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run with %s does not accept additional positional arguments", mode)}
+		}
 	}
 	if normalizedOptions.Interactive && len(args) > 1 {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run -i/--interactive does not accept legacy positional prompt arguments")}
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run -i/--interactive does not accept additional positional arguments")}
 	}
-	if !normalizedOptions.Interactive && prompt == "" && len(args) > 1 {
-		// Deprecated: positional prompt arguments will become the trigger position in a future release.
-		if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose run <agent> [prompt...]", "agent-compose run <agent> --prompt"); err != nil {
-			return err
+	if !normalizedOptions.Interactive && triggerID == "" && prompt == "" && commandText == "" {
+		agent, ok := composeRunAgentSpec(normalized, agentName)
+		if !ok {
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("agent %q is not configured in this project", agentName)}
 		}
-		prompt = strings.Join(args[1:], " ")
+		if agent.Scheduler == nil || len(agent.Scheduler.Triggers) == 0 {
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("agent %q has no configured triggers; use --prompt or --command", agentName)}
+		}
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run requires a trigger name, --prompt, or --command")}
 	}
 	clientConfig, err := resolveCLIClientConfig(cli.Host)
 	if err != nil {
@@ -1528,6 +1543,43 @@ func normalizeComposeRunOptions(cmd *cobra.Command, options composeRunOptions) (
 		options.SessionID = options.SandboxID
 	}
 	return options, nil
+}
+
+func resolveComposeRunTriggerName(normalized *compose.NormalizedProjectSpec, projectID, agentName, triggerName string) (string, error) {
+	triggerName = strings.TrimSpace(triggerName)
+	if triggerName == "" {
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run trigger name cannot be empty")}
+	}
+	agent, ok := composeRunAgentSpec(normalized, agentName)
+	if !ok {
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("agent %q is not configured in this project", agentName)}
+	}
+	if agent.Scheduler == nil || len(agent.Scheduler.Triggers) == 0 {
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("agent %q has no configured triggers; use --prompt or --command", agentName)}
+	}
+	for index, trigger := range agent.Scheduler.Triggers {
+		if strings.TrimSpace(trigger.Name) == triggerName {
+			id, err := domain.StableManagedTriggerID(projectID, agent.Name, "", triggerName, index)
+			if err != nil {
+				return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("resolve trigger %q for agent %q: %w", triggerName, agentName, err)}
+			}
+			return id, nil
+		}
+	}
+	return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("trigger %q is not configured for agent %q", triggerName, agentName)}
+}
+
+func composeRunAgentSpec(normalized *compose.NormalizedProjectSpec, agentName string) (compose.NormalizedAgentSpec, bool) {
+	agentName = strings.TrimSpace(agentName)
+	if normalized == nil {
+		return compose.NormalizedAgentSpec{}, false
+	}
+	for _, agent := range normalized.Agents {
+		if strings.TrimSpace(agent.Name) == agentName {
+			return agent, true
+		}
+	}
+	return compose.NormalizedAgentSpec{}, false
 }
 
 func normalizeOptionalRunModeValue(value string) string {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1181,11 +1181,11 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox", "session-reuse", "--keep-running", "reviewer", "check", "this")
+	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox", "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
 	if exitCode != 0 {
 		t.Fatalf("run success exit code = %d, stderr=%q", exitCode, stderr)
 	}
-	if stdout != "live output\n" || !strings.Contains(stderr, "agent-compose run <agent> [prompt...] is deprecated") || strings.Contains(stdout, "deprecated") {
+	if stdout != "live output\n" || stderr != "" {
 		t.Fatalf("run success stdout/stderr = %q / %q", stdout, stderr)
 	}
 	if runCount != 0 {
@@ -1195,11 +1195,11 @@ agents:
 		t.Fatal("RunAgentStream was not called")
 	}
 
-	legacyOut, legacyErr, _, legacyCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--session-id", "session-reuse", "--keep-running", "reviewer", "check", "this")
+	legacyOut, legacyErr, _, legacyCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--session-id", "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
 	if legacyCode != 0 {
 		t.Fatalf("run --session-id exit code = %d, stderr=%q", legacyCode, legacyErr)
 	}
-	if legacyOut != "live output\n" || !strings.Contains(legacyErr, "agent-compose run --session-id is deprecated") || !strings.Contains(legacyErr, "agent-compose run <agent> [prompt...] is deprecated") || strings.Contains(legacyOut, "deprecated") {
+	if legacyOut != "live output\n" || !strings.Contains(legacyErr, "agent-compose run --session-id is deprecated") || strings.Contains(legacyOut, "deprecated") {
 		t.Fatalf("run --session-id stdout/stderr = %q / %q", legacyOut, legacyErr)
 	}
 }
@@ -1737,13 +1737,18 @@ name: cli-run-trigger
 agents:
   reviewer:
     provider: codex
+    scheduler:
+      triggers:
+        - name: nightly-review
+          cron: "0 1 * * *"
+          prompt: review nightly
 `)
 	var sawRequest bool
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
 			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
 				sawRequest = true
-				if req.Msg.GetAgentName() != "reviewer" || req.Msg.GetTriggerId() != "nightly-review" || req.Msg.GetPrompt() != "" {
+				if req.Msg.GetAgentName() != "reviewer" || !strings.HasPrefix(req.Msg.GetTriggerId(), "trigger-nightly-review-") || req.Msg.GetPrompt() != "" {
 					t.Fatalf("RunAgentStream trigger request = %#v", req.Msg)
 				}
 				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
@@ -1765,9 +1770,9 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "reviewer", "--trigger", "nightly-review")
+	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "reviewer", "nightly-review")
 	if exitCode != 0 || stdout != "" || stderr != "" {
-		t.Fatalf("run --trigger code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+		t.Fatalf("run trigger code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 	if !sawRequest {
 		t.Fatal("RunAgentStream was not called")
@@ -1780,6 +1785,11 @@ name: cli-run-trigger-warning
 agents:
   reviewer:
     provider: codex
+    scheduler:
+      triggers:
+        - name: nightly-warning
+          cron: "0 2 * * *"
+          prompt: review nightly
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
@@ -1805,14 +1815,14 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "reviewer", "--trigger", "trigger-1")
+	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "reviewer", "nightly-warning")
 	if exitCode != 0 || stdout != "" || !strings.Contains(stderr, "warning: trigger trigger-1 is disabled") {
-		t.Fatalf("run --trigger warning code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+		t.Fatalf("run trigger warning code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 
-	jsonOut, jsonErr, _, jsonCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--json", "reviewer", "--trigger", "trigger-1")
+	jsonOut, jsonErr, _, jsonCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--json", "reviewer", "nightly-warning")
 	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, `"warnings"`) || !strings.Contains(jsonOut, "trigger trigger-1 is disabled") {
-		t.Fatalf("run --trigger --json warning code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
+		t.Fatalf("run trigger --json warning code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
 	}
 }
 
@@ -1822,6 +1832,17 @@ name: cli-run-input-errors
 agents:
   reviewer:
     provider: codex
+`)
+	composeWithTriggerPath := writeComposeFile(t, t.TempDir(), `
+name: cli-run-input-trigger-errors
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      triggers:
+        - name: nightly
+          cron: "0 2 * * *"
+          prompt: review nightly
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
@@ -1839,34 +1860,49 @@ agents:
 		want string
 	}{
 		{
-			name: "trigger and prompt flags",
-			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--trigger", "nightly", "--prompt", "check"},
-			want: "only one of --trigger, --prompt, or --command",
+			name: "trigger flag unsupported",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--trigger", "nightly"},
+			want: "unknown flag: --trigger",
 		},
 		{
 			name: "command and prompt flags",
 			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--command", "echo hi", "--prompt", "check"},
-			want: "only one of --trigger, --prompt, or --command",
+			want: "only one of trigger name, --prompt, or --command",
 		},
 		{
-			name: "command and trigger flags",
-			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--command", "echo hi", "--trigger", "nightly"},
-			want: "only one of --trigger, --prompt, or --command",
-		},
-		{
-			name: "trigger and positional prompt",
-			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--trigger", "nightly", "legacy"},
-			want: "does not accept legacy positional prompt",
-		},
-		{
-			name: "prompt flag and positional prompt",
+			name: "prompt flag and positional trigger",
 			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--prompt", "check", "legacy"},
-			want: "does not accept legacy positional prompt",
+			want: "does not accept additional positional arguments",
 		},
 		{
-			name: "command flag and positional prompt",
+			name: "command flag and positional trigger",
 			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--command", "echo hi", "legacy"},
-			want: "does not accept legacy positional prompt",
+			want: "does not accept additional positional arguments",
+		},
+		{
+			name: "positional trigger without configured triggers",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "nightly"},
+			want: "has no configured triggers; use --prompt or --command",
+		},
+		{
+			name: "one positional arg with configured triggers",
+			args: []string{"run", "--host", server.URL, "--file", composeWithTriggerPath, "reviewer"},
+			want: "run requires a trigger name, --prompt, or --command",
+		},
+		{
+			name: "one positional arg with unknown agent",
+			args: []string{"run", "--host", server.URL, "--file", composeWithTriggerPath, "missing"},
+			want: `agent "missing" is not configured in this project`,
+		},
+		{
+			name: "positional trigger name not configured",
+			args: []string{"run", "--host", server.URL, "--file", composeWithTriggerPath, "reviewer", "missing"},
+			want: `trigger "missing" is not configured for agent "reviewer"`,
+		},
+		{
+			name: "too many positional trigger arguments",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "nightly", "extra"},
+			want: "at most one trigger name positional argument",
 		},
 		{
 			name: "empty command flag",
@@ -1909,11 +1945,6 @@ agents:
 			want: "requires exactly one of --prompt or --command",
 		},
 		{
-			name: "trigger",
-			args: []string{"run", "--file", composePath, "reviewer", "-i", "--trigger", "nightly"},
-			want: "cannot be combined with --trigger",
-		},
-		{
 			name: "json",
 			args: []string{"run", "--file", composePath, "--json", "reviewer", "-i", "--prompt"},
 			want: "cannot be combined with --json",
@@ -1924,9 +1955,9 @@ agents:
 			want: "requires exactly one of --prompt or --command",
 		},
 		{
-			name: "positional prompt",
+			name: "additional positional argument",
 			args: []string{"run", "--file", composePath, "reviewer", "-i", "--prompt", "first", "legacy"},
-			want: "does not accept legacy positional prompt",
+			want: "does not accept additional positional arguments",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2020,7 +2051,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--rm", "--json", "reviewer")
+	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--rm", "--json", "reviewer", "--prompt", "clean")
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("run --rm --json code/stderr = %d / %q", exitCode, stderr)
 	}
@@ -2114,7 +2145,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--rm", "reviewer")
+	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--rm", "reviewer", "--prompt", "clean")
 	if exitCode != 9 {
 		t.Fatalf("run --rm failed exit code = %d, want 9; stderr=%q", exitCode, stderr)
 	}
@@ -2157,7 +2188,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--rm", "reviewer")
+	stdout, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--rm", "reviewer", "--prompt", "clean")
 	if exitCode == 0 {
 		t.Fatalf("run --rm cleanup error exit code = %d, want non-zero", exitCode)
 	}

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -136,7 +136,7 @@ Notes:
 Start a sandbox for an agent, or continue work in an existing sandbox.
 
 ```bash
-agent-compose run <agent> --trigger <trigger>
+agent-compose run <agent> <trigger-name>
 agent-compose run <agent> --prompt "..."
 agent-compose run <agent> --command "..."
 agent-compose run <agent> --sandbox <sandbox> --prompt "..."
@@ -146,16 +146,16 @@ Input modes:
 
 | Mode | Usage | Description |
 | --- | --- | --- |
-| trigger | `run <agent> --trigger <trigger>` | Run a trigger defined in the project config. |
+| trigger | `run <agent> <trigger-name>` | Run a named trigger defined in the project config. |
 | prompt | `run <agent> --prompt "..."` | Send a prompt to the agent provider. |
 | command | `run <agent> --command "..."` | Start or reuse the agent sandbox and execute a shell command through guest `agent-compose-runtime exec`; the command transcript is streamed and persisted to the run record. |
 | prompt REPL | `run <agent> -i --prompt` | Read prompts line by line from stdin. Each non-empty input creates one run and reuses the same sandbox. |
 | command REPL | `run <agent> -i --command` | Read commands line by line from stdin. Each non-empty input creates one run and reuses the same sandbox. |
 | sandbox reuse | `run <agent> --sandbox <sandbox> --prompt "..."` | Continue in a specific sandbox. |
 
-Compatibility:
-
-- `run <agent> [prompt...]` still joins positional arguments into a prompt, but this entrypoint is deprecated. It prints a warning to stderr. New scripts should use `--prompt`.
+Prompt input must use `--prompt`. Positional prompt arguments are not supported.
+If the agent has no configured triggers, `run <agent> <trigger-name>` fails with
+a usage error; use `--prompt` or `--command` for ad hoc work.
 
 | Option | Description |
 | --- | --- |
@@ -171,7 +171,7 @@ Compatibility:
 Examples:
 
 ```bash
-agent-compose run reviewer --trigger pr-opened
+agent-compose run reviewer pr-opened
 agent-compose run reviewer --prompt "Review the staged changes"
 agent-compose run builder --command "task build"
 agent-compose run tester --command "task test" --keep-running
@@ -185,9 +185,10 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 Rules:
 
 - Choose only one of trigger, prompt, or command.
-- Do not combine `--prompt`, `--trigger`, or `--command` with legacy positional prompt arguments.
+- `run <agent> <trigger-name>` accepts exactly one trigger name positional argument.
+- Do not combine `--prompt` or `--command` with additional positional arguments.
 - `run -d/--detach` and `run -i/--interactive` are mutually exclusive.
-- `run -i/--interactive` must select `--prompt` or `--command`; it cannot be combined with `--trigger` or `--json`.
+- `run -i/--interactive` must select `--prompt` or `--command`; it cannot be combined with `--json`.
 - Empty REPL lines do not create runs. Enter `/exit` or press Ctrl+D to exit.
 - REPL mode is not TTY/PTY or running stdin passthrough. Each input is one independent `RunAgentStream` call that reuses the same sandbox.
 - Detached runs can be observed with the printed `agent-compose logs --run-id <run-id> --follow` command, or managed later with `stop` and `logs`.

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -344,7 +344,7 @@ validation. Inline QJS schedulers call existing
 `LoaderManager.Validate(ctx, "scheduler", script)`, where the QJS loader engine
 evaluates the script and collects triggers registered through
 `scheduler.interval`, `scheduler.timeout`, `scheduler.on`, and
-`scheduler.cron`. Syntax errors, duplicate trigger ids, and invalid
+`scheduler.cron`. Syntax errors, duplicate trigger names, and invalid
 timer/cron/event parameters are converted into project validation issues at the
 path `agents.<name>.scheduler.script`.
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -65,7 +65,8 @@ agent-compose down
 
 - `agent-compose daemon`：启动长期运行的 HTTP/Connect daemon。
 - `agent-compose up`：读取本地 `agent-compose.yml`，把 project 定义和 scheduler 应用到 daemon。
-- `agent-compose run <agent>`：手动运行一次 project agent。
+- `agent-compose run <agent> <trigger-name>`：按名称运行已配置的 trigger。
+- `agent-compose run <agent> --prompt "..."` / `--command "..."`：手动执行临时 prompt 或 shell command。
 - `agent-compose logs`：查看 project run 日志。
 - `agent-compose ps`：查看 project agent、latest run 和 running session 状态。
 - `agent-compose down`：禁用 daemon 管理的 scheduler，并停止该 project 的 running sessions。

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -138,7 +138,7 @@ agent-compose -f /path/to/project/agent-compose.yml down
 为指定 agent 启动一个 sandbox，或在已有 sandbox 中继续运行。
 
 ```bash
-agent-compose run <agent> --trigger <trigger>
+agent-compose run <agent> <trigger-name>
 agent-compose run <agent> --prompt "..."
 agent-compose run <agent> --command "..."
 agent-compose run <agent> --sandbox <sandbox> --prompt "..."
@@ -148,16 +148,15 @@ agent-compose run <agent> --sandbox <sandbox> --prompt "..."
 
 | 模式 | 用法 | 说明 |
 | --- | --- | --- |
-| trigger | `run <agent> --trigger <trigger>` | 运行配置中定义的 trigger。 |
+| trigger | `run <agent> <trigger-name>` | 按名称运行 project 配置中定义的 trigger。 |
 | prompt | `run <agent> --prompt "..."` | 向 agent provider 发送 prompt。 |
 | command | `run <agent> --command "..."` | 启动或复用该 agent 的 sandbox 后通过 guest `agent-compose-runtime exec` 执行 shell 命令；命令 transcript 会实时输出，并写入该次 run 记录。 |
 | prompt REPL | `run <agent> -i --prompt` | 从 stdin 逐行读取 prompt；每条非空输入创建一次 run，并复用同一个 sandbox。 |
 | command REPL | `run <agent> -i --command` | 从 stdin 逐行读取 command；每条非空输入创建一次 run，并复用同一个 sandbox。 |
 | sandbox 复用 | `run <agent> --sandbox <sandbox> --prompt "..."` | 在指定 sandbox 中继续运行。 |
 
-兼容说明：
-
-- `run <agent> [prompt...]` 仍会把第二个及后续 positional 参数拼成 prompt，但该入口已废弃，会在 stderr 输出 deprecated warning；新脚本应使用 `--prompt`。
+prompt 输入必须使用 `--prompt`。不再支持 positional prompt 参数。
+如果 agent 没有配置 trigger，`run <agent> <trigger-name>` 会返回 usage error；临时任务请使用 `--prompt` 或 `--command`。
 
 选项：
 
@@ -175,7 +174,7 @@ agent-compose run <agent> --sandbox <sandbox> --prompt "..."
 示例：
 
 ```bash
-agent-compose run reviewer --trigger pr-opened
+agent-compose run reviewer pr-opened
 agent-compose run reviewer --prompt "Review the staged changes"
 agent-compose run builder --command "task build"
 agent-compose run tester --command "task test" --keep-running
@@ -189,9 +188,10 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 互斥规则：
 
 - trigger、prompt、command 一次只能选择一种。
-- 使用 `--prompt`、`--trigger` 或 `--command` 时，不能再传 legacy positional prompt 参数。
+- `run <agent> <trigger-name>` 只接受一个 trigger name 位置参数。
+- 使用 `--prompt` 或 `--command` 时，不能再传额外位置参数。
 - `run -d/--detach` 和 `run -i/--interactive` 互斥。
-- `run -i/--interactive` 必须选择 `--prompt` 或 `--command`，不能与 `--trigger` 或 `--json` 组合。
+- `run -i/--interactive` 必须选择 `--prompt` 或 `--command`，不能与 `--json` 组合。
 - REPL 中空行不会创建 run；输入 `/exit` 或 Ctrl+D 退出。
 - REPL 不是 TTY/PTY 或运行中 stdin 透传；每条输入都是一次独立 `RunAgentStream`，但复用同一个 sandbox。
 - detached run 可通过输出的 `agent-compose logs --run-id <run-id> --follow` 命令观察输出，也可继续使用 `stop`/`logs` 操作该 run。

--- a/docs/zh-CN/command-line-test-report.md
+++ b/docs/zh-CN/command-line-test-report.md
@@ -202,13 +202,15 @@ AUTH_USERNAME=admin AUTH_PASSWORD=... \
 
 结论：新镜像命令 `images/pull/rmi/inspect image` 可用；旧 `image` 命令树没有删除，兼容 warning 正确输出到 stderr。
 
-## 9. Run 兼容入口测试
+## 9. Run 输入模式测试
 
 | 测试项 | 命令结构 | 关键参数 | 预期 | 结果 |
 | --- | --- | --- | --- | --- |
-| positional prompt 兼容 warning | `<prefix> run reviewer legacy positional prompt` | 旧 positional prompt | stderr 输出 deprecated warning，并提示使用 `--prompt` | 通过 |
+| prompt flag | `<prefix> run reviewer --prompt "review current workspace"` | 显式 prompt | prompt 发送给 provider；不输出 deprecated warning | 通过 |
+| positional trigger name | `<prefix> run reviewer nightly-review` | trigger name | CLI 按 trigger name 找到对应配置后提交 run | 通过 |
+| 无 trigger 配置 | `<prefix> run reviewer nightly-review` | 未配置 trigger 的 agent | 返回 usage error，并提示使用 `--prompt` 或 `--command` | 通过 |
 
-说明：该命令会进入真实 provider 执行路径，测试环境没有把 provider 完成结果作为确定性 E2E 断言。本轮验证重点是旧 positional prompt 入口的兼容 warning 行为，以及 warning 不写入 JSON stdout 的约束。
+说明：prompt 输入必须使用 `--prompt`。`run <agent> <trigger-name>` 的第二个位置参数表示 trigger name，不再作为 prompt 兼容入口。
 
 ## 10. 历史延期命令边界测试
 

--- a/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
+++ b/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
@@ -117,25 +117,25 @@ agents:
 
 `agent-compose run <agent>` 当前支持三类单次输入：
 
-- `--trigger <trigger>`：手动运行 project 中 managed scheduler/loader trigger。
+- `<trigger-name>`：按名称手动运行 project 中 managed scheduler/loader trigger。
 - `--prompt "..."`：向 provider 发送一轮 prompt。
 - `--command "..."`：在 agent sandbox 中通过 guest `agent-compose-runtime exec` 执行一次 shell command。
 
 互斥规则：
 
-- `--trigger`、`--prompt`、`--command` 一次只能选择一种。
-- 使用上述 flag 后不能再使用 legacy positional prompt。
-- legacy `run <agent> [prompt...]` 保留兼容并输出 deprecated warning。
+- trigger name、`--prompt`、`--command` 一次只能选择一种。
+- 使用 `--prompt` 或 `--command` 后不能再传额外位置参数。
+- prompt 输入必须使用 `--prompt`；`run <agent> <trigger-name>` 的第二个位置参数不再作为 prompt 处理。
 - `--session-id` 是 `--sandbox` 的 deprecated alias。
 
 ### Trigger 解析
 
-`run --trigger` 不只是把 trigger id 写入 metadata。`pkg/runs.Controller` 会在 `BeginRun` 前解析当前 project/agent 的 managed scheduler loader：
+`run <agent> <trigger-name>` 会在 CLI 侧基于当前 `agent-compose.yml` 查找 trigger name，并把对应的 trigger 提交给 daemon。`pkg/runs.Controller` 会在 `BeginRun` 前解析当前 project/agent 的 managed scheduler loader：
 
 - trigger 必须属于当前 project 和 agent。
 - disabled scheduler 或 disabled trigger 可由 operator 手动运行，但 run response/summary/detail 会带 warning。
 - trigger prompt 会进入实际 `ExecuteAgentRequest.Message`，并写入 `project_run.prompt`。
-- 原始 `trigger_id` 和解析出的 `scheduler_id` 保留在 run summary/detail。
+- 解析出的 scheduler 信息会保留在 run summary/detail。
 
 ### Cleanup policy
 
@@ -257,7 +257,6 @@ Docker daemon 只是可选 image backend；OCI cache 是 daemonless backend。Bo
 | `agent-compose image pull <image>` | `agent-compose pull <image>` |
 | `agent-compose image rm <image>` | `agent-compose rmi <image>` |
 | `agent-compose image inspect <image>` | `agent-compose inspect image <image>` |
-| `agent-compose run <agent> [prompt...]` | `agent-compose run <agent> --prompt "..."` |
 | `agent-compose run --session-id <id>` | `agent-compose run --sandbox <sandbox>` |
 | `agent-compose exec --agent/--run-id/--session-id ...` | `agent-compose exec <sandbox> ...` |
 | `agent-compose logs --session-id <id>` | `agent-compose logs --sandbox <sandbox>` |

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -257,7 +257,7 @@ Project 是 `agent-compose.yml` 在 daemon 中的持久化实例。project id、
 
 受管资源只修改带 managed metadata 的 agent definition、loader 和 trigger。同名手工资源不会被覆盖或删除。
 
-`ValidateProject` 和 `ApplyProject` 对 scheduler 使用同一条构建路径。声明式 scheduler 只做 compose 和 loader trigger 结构校验；inline QJS scheduler 会调用现有 `LoaderManager.Validate(ctx, "scheduler", script)`，由 QJS loader engine 求值脚本并收集 `scheduler.interval`、`scheduler.timeout`、`scheduler.on`、`scheduler.cron` 注册出来的 triggers。语法错误、重复 trigger id、非法 timer/cron/event 参数会转换成路径为 `agents.<name>.scheduler.script` 的 project validation issue。
+`ValidateProject` 和 `ApplyProject` 对 scheduler 使用同一条构建路径。声明式 scheduler 只做 compose 和 loader trigger 结构校验；inline QJS scheduler 会调用现有 `LoaderManager.Validate(ctx, "scheduler", script)`，由 QJS loader engine 求值脚本并收集 `scheduler.interval`、`scheduler.timeout`、`scheduler.on`、`scheduler.cron` 注册出来的 triggers。语法错误、重复 trigger name、非法 timer/cron/event 参数会转换成路径为 `agents.<name>.scheduler.script` 的 project validation issue。
 
 reconcile 顺序保持保守：先把 `ProjectScheduler` 和受管 `Loader` staged 为 disabled，替换 loader triggers，再启用 loader 和 scheduler。替换 trigger 或启用失败时会执行 cleanup，避免留下已经启用但 trigger/script 不一致的 scheduler。
 


### PR DESCRIPTION
## Summary

- remove deprecated positional prompt handling from `agent-compose run <agent> [prompt...]`
- make `agent-compose run <agent> <trigger-name>` resolve the local trigger name to the stable trigger ID sent to the daemon
- report a usage error when an agent has no configured triggers unless `--prompt` or `--command` is used
- require non-empty `--prompt`/`--command` values and reject extra positional args with explicit mode flags

## Testing

- `go test ./cmd/agent-compose`
-  `go test ./pkg/runs`

## Checklist

- [ ] Documentation updated when behavior or configuration changed.
- [ ] Tests added or updated for user-visible behavior.
- [ ] No secrets, private endpoints, internal certificates, or local runtime state included.
