### PR TITLE
refactor: decouple storage layer (sever reverse edges, split config store)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Main entrypoints:
 - `pkg/agentcompose/api/`: Connect handlers and protobuf/domain mapping.
 - `pkg/agentcompose/adapters/`: daemon-only runtime, session, loader, capability, and LLM adapters.
 - `pkg/agentcompose/proxy/`: HTTP proxy routes for Jupyter, workspaces, and runtime LLM facade.
-- Owner packages under `pkg/` contain shared domain code: `model`, `storage`, `loaders`, `projects`, `runs`, `sessions`, `execution`, `llms`, `events`, `images`, `dashboard`, `capabilities`, and `bus`.
+- Owner packages under `pkg/` contain shared domain code: `model`, `storage`, `loaders`, `projects`, `runs`, `sessions`, `execution`, `llms`, `events`, `images`, `dashboard`, and `capabilities`. Event bus code lives in `loaders`; small dependency-free storage helpers (e.g. stored-time decoding) live in `pkg/storage/storeutil`.
 - `proto/agentcompose/v1/`: agent-compose Connect API definitions and generated Go code.
 - `proto/agentcompose/v2/`: agent-compose v2 Connect API definitions and generated Go code.
 - `proto/health/v1/`: health Connect API definitions and generated Go code.

--- a/pkg/agentcompose/adapters/agent_runner.go
+++ b/pkg/agentcompose/adapters/agent_runner.go
@@ -27,6 +27,18 @@ type AgentRunner struct {
 	runtimes RuntimeProvider
 }
 
+// facadeStoreFor converts a possibly-nil concrete config store into a
+// runtimefacade.FacadeStore. Returning a true nil interface (instead of an
+// interface wrapping a nil pointer) keeps runtimefacade's plain `store == nil`
+// guard working, so a daemon running without an LLM store skips LLM config
+// instead of panicking on a typed-nil dereference.
+func facadeStoreFor(configDB *configstore.ConfigStore) runtimefacade.FacadeStore {
+	if configDB == nil {
+		return nil
+	}
+	return configDB
+}
+
 func NewAgentRunner(config *appconfig.Config, store *sessionstore.Store, configDB *configstore.ConfigStore, agents AgentDefinitionStore, runtimes RuntimeProvider) *AgentRunner {
 	return &AgentRunner{config: config, store: store, configDB: configDB, agents: agents, runtimes: runtimes}
 }
@@ -60,7 +72,7 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sessi
 		return domain.ExecResult{}, domain.AgentRunResult{}, err
 	}
 	spec := BuildAgentExecSpec(r.config, session, agent, model, promptPath, schemaPath)
-	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, r.config, r.configDB, session, agent, model, runtimefacade.TokenSourceAgent, runID)
+	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, r.config, facadeStoreFor(r.configDB), session, agent, model, runtimefacade.TokenSourceAgent, runID)
 	if err != nil {
 		return domain.ExecResult{}, domain.AgentRunResult{}, err
 	}

--- a/pkg/agentcompose/adapters/llm_client.go
+++ b/pkg/agentcompose/adapters/llm_client.go
@@ -33,7 +33,7 @@ func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSO
 	if c == nil {
 		return llms.GenerateResult{}, fmt.Errorf("llm client is unavailable")
 	}
-	target, err := configstore.ResolveLLMTarget(ctx, c.config, c.store, model)
+	target, err := llms.ResolveLLMTarget(ctx, c.config, c.store, model)
 	if err != nil {
 		return llms.GenerateResult{}, err
 	}

--- a/pkg/agentcompose/adapters/loader_command_executor.go
+++ b/pkg/agentcompose/adapters/loader_command_executor.go
@@ -269,7 +269,7 @@ func (e *LoaderCommandExecutor) prepareLoaderCommandLLMFacadeEnv(ctx context.Con
 		execSession.ProviderEnvItems = providerEnv
 	}
 
-	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, e.Config, e.ConfigDB, &execSession, agent, model, runtimefacade.TokenSourceLoaderCommand, runID)
+	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, e.Config, facadeStoreFor(e.ConfigDB), &execSession, agent, model, runtimefacade.TokenSourceLoaderCommand, runID)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -123,7 +123,7 @@ func (d *SessionDriver) prepareSessionStart(ctx context.Context, driver string, 
 	}
 	managedEnv := map[string]string{}
 	for _, agent := range []string{"codex", "claude"} {
-		agentEnv, err := ensureSessionLLMFacadeConfig(ctx, d.Config, d.ConfigDB, session, agent, "", "session", "")
+		agentEnv, err := ensureSessionLLMFacadeConfig(ctx, d.Config, facadeStoreFor(d.ConfigDB), session, agent, "", "session", "")
 		if err != nil {
 			if agent == "claude" && runtimefacade.IsOptionalConfigError(err) {
 				continue

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -9,6 +9,7 @@ import (
 
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/llms/runtimefacade"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/storage/configstore"
 	"agent-compose/pkg/storage/sessionstore"
@@ -284,7 +285,7 @@ func TestSessionDriverStartSessionVMIgnoresOptionalClaudeConfigError(t *testing.
 	ctx := context.Background()
 	originalEnsure := ensureSessionLLMFacadeConfig
 	defer func() { ensureSessionLLMFacadeConfig = originalEnsure }()
-	ensureSessionLLMFacadeConfig = func(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, agent, model, source, runID string) (map[string]string, error) {
+	ensureSessionLLMFacadeConfig = func(ctx context.Context, config *appconfig.Config, store runtimefacade.FacadeStore, session *domain.Session, agent, model, source, runID string) (map[string]string, error) {
 		switch agent {
 		case "codex":
 			return map[string]string{

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -356,7 +356,7 @@ func registerRuntimeLLMFacadeRoutes(app *echo.Echo, di do.Injector) {
 		Tokens:   configDB,
 		Sessions: do.MustInvoke[*sessionstore.Store](di),
 		ResolveTarget: func(ctx context.Context, requestedModel, providerID string) (llms.ResolvedTarget, error) {
-			return configstore.ResolveRuntimeLLMTarget(ctx, config, configDB, requestedModel, providerID)
+			return llms.ResolveRuntimeLLMTarget(ctx, config, configDB, requestedModel, providerID)
 		},
 		Client: &http.Client{Timeout: config.LLMTimeout},
 	})

--- a/pkg/events/scan.go
+++ b/pkg/events/scan.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	domain "agent-compose/pkg/model"
-	"agent-compose/pkg/storage/configstore"
+	"agent-compose/pkg/storage/storeutil"
 )
 
 func ScanTopicEvents(rows *sql.Rows) ([]domain.TopicEventRecord, error) {
@@ -59,11 +59,11 @@ func ScanTopicEvent(scan func(dest ...any) error) (domain.TopicEventRecord, erro
 	); err != nil {
 		return domain.TopicEventRecord{}, fmt.Errorf("scan event: %w", err)
 	}
-	item.ClaimUntil = configstore.ParseStoredUnixTimeAuto(claimUntilRaw)
-	item.NextAttemptAt = configstore.ParseStoredUnixTimeAuto(nextAttemptAtRaw)
-	item.DeadLetterAt = configstore.ParseStoredUnixTimeAuto(deadLetterAtRaw)
-	item.CreatedAt = configstore.ParseStoredUnixTimeAuto(createdAtRaw)
-	item.DispatchedAt = configstore.ParseStoredUnixTimeAuto(dispatchedAtRaw)
+	item.ClaimUntil = storeutil.ParseStoredUnixTimeAuto(claimUntilRaw)
+	item.NextAttemptAt = storeutil.ParseStoredUnixTimeAuto(nextAttemptAtRaw)
+	item.DeadLetterAt = storeutil.ParseStoredUnixTimeAuto(deadLetterAtRaw)
+	item.CreatedAt = storeutil.ParseStoredUnixTimeAuto(createdAtRaw)
+	item.DispatchedAt = storeutil.ParseStoredUnixTimeAuto(dispatchedAtRaw)
 	return item, nil
 }
 

--- a/pkg/llms/resolver.go
+++ b/pkg/llms/resolver.go
@@ -1,0 +1,348 @@
+package llms
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+// LLMResolverStore is the persistence surface the LLM target-resolution and
+// provider-bootstrap logic needs. *configstore.ConfigStore satisfies it. Keeping
+// the dependency as a locally-defined interface (rather than importing
+// configstore) keeps llms free of any storage dependency and avoids an import
+// cycle, while letting the resolution logic live in its own domain package.
+type LLMResolverStore interface {
+	DefaultConfigStore
+	ProviderListStore
+	ProviderModelWireAPIStore
+	GlobalEnvStore
+	ListEnabledLLMModels(ctx context.Context) ([]Model, error)
+}
+
+// firstNonEmptyTrimmed returns the first value that is non-empty after trimming,
+// returning the trimmed form. It is intentionally distinct from firstNonEmpty
+// (which returns the raw value) to preserve the exact trimming behavior the LLM
+// resolution paths relied on before this logic moved out of the config store.
+func firstNonEmptyTrimmed(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func bootstrapDefaultLLMConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
+	if hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyOpenAI) {
+		return nil
+	}
+	return ensureDefaultOpenAIEnvProvider(ctx, config, store, requestedModel)
+}
+
+func BootstrapDefaultLLMConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
+	return bootstrapDefaultLLMConfig(ctx, config, store, requestedModel)
+}
+
+// EnvProviderLookup resolves an environment value for LLM provider bootstrap.
+// It accepts candidate keys and returns the first non-empty value scanning
+// sources in priority order (source-major): an earlier source wins across all
+// candidate keys before a later source is consulted. This preserves the exact
+// precedence the bootstrap paths relied on when they used nested firstNonEmpty.
+// defaultLLMEnvProviderLookup reads from global env, then the process env, then
+// daemon config. Used by the env_default bootstrap providers.
+func defaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store LLMResolverStore) EnvProviderLookup {
+	return func(keys ...string) string {
+		for _, key := range keys {
+			if v := lookupEnvValue(ctx, store, key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		for _, key := range keys {
+			if v := os.Getenv(key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		for _, key := range keys {
+			if v := configLLMEnvValue(config, key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		return ""
+	}
+}
+
+func DefaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store LLMResolverStore) EnvProviderLookup {
+	return defaultLLMEnvProviderLookup(ctx, config, store)
+}
+
+// sessionLLMEnvProviderLookup reads only from per-session env items. Used by the
+// session_env bootstrap providers.
+func sessionLLMEnvProviderLookup(envItems []domain.SessionEnvVar) EnvProviderLookup {
+	return func(keys ...string) string {
+		for _, key := range keys {
+			if v := EnvItemValue(envItems, key); strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		return ""
+	}
+}
+
+func configLLMEnvValue(config *appconfig.Config, key string) string {
+	if config == nil {
+		return ""
+	}
+	switch strings.ToUpper(strings.TrimSpace(key)) {
+	case "LLM_API_ENDPOINT":
+		return config.LLMAPIEndpoint
+	case "LLM_API_PROTOCOL":
+		return config.LLMAPIProtocol
+	case "LLM_API_KEY":
+		return config.LLMAPIKey
+	case "LLM_MODEL":
+		return config.LLMModel
+	default:
+		return ""
+	}
+}
+
+func ensureDefaultOpenAIEnvProvider(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
+	_, err := EnsureOpenAIEnvProvider(ctx, store, defaultLLMEnvProviderLookup(ctx, config, store), ProviderIDDefaultOpenAI, "default", ProviderScopeEnvDefault, requestedModel, true)
+	return err
+}
+
+func resolveLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) (ResolvedTarget, error) {
+	return resolveLLMTargetForProviderFamily(ctx, config, store, ProviderFamilyOpenAI, requestedModel)
+}
+
+func ResolveLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) (ResolvedTarget, error) {
+	return resolveLLMTarget(ctx, config, store, requestedModel)
+}
+
+func resolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel, providerID string) (ResolvedTarget, error) {
+	return resolveRuntimeLLMTargetWithEnv(ctx, config, store, "", "", requestedModel, providerID, nil)
+}
+
+func ResolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel, providerID string) (ResolvedTarget, error) {
+	return resolveRuntimeLLMTarget(ctx, config, store, requestedModel, providerID)
+}
+
+func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []domain.SessionEnvVar) (ResolvedTarget, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	preferredProviderFamily = NormalizeOptionalProviderType(preferredProviderFamily)
+	requestedModel = strings.TrimSpace(requestedModel)
+	providerID = strings.TrimSpace(providerID)
+	hasSessionEnvProvider := sessionID != "" && HasSessionEnvProviderInput(envItems)
+	sessionProviderID := ""
+	// Reuse an already-persisted session-env provider when this session can no
+	// longer supply a key from env. The raw key env (Session.ProviderEnvItems) is
+	// intentionally not persisted, so after a stop/resume the only durable home
+	// for a session-scoped credential is the llm_provider row written at creation.
+	// Pin its provider id here so resolution selects it (session-env providers are
+	// otherwise skipped without an explicit id) and does not clobber its key with
+	// the now-empty env. Only when the env still has no key for the family — an env
+	// that carries a (possibly rotated) key must keep re-bootstrapping it.
+	if providerID == "" && sessionID != "" && preferredProviderFamily != "" && !EnvHasProviderKeyForFamily(envItems, preferredProviderFamily) {
+		if candidate := SessionEnvProviderID(sessionID, preferredProviderFamily); hasEnabledLLMProviderID(ctx, store, candidate) {
+			providerID = candidate
+		}
+	}
+	// Skip the env/default bootstrap entirely when the request already names a
+	// provider that exists. The facade hot path always passes a concrete
+	// provider id from the token scope, so this avoids a redundant pair of
+	// idempotent provider upserts on every LLM request.
+	bootstrapProviders := (providerID == "" || !IsSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
+	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyOpenAI) {
+		openAIModel := firstNonEmptyTrimmed(requestedModel, EnvItemValue(envItems, "LLM_MODEL"))
+		if sessionID != "" && HasOpenAIEnvProviderInput(envItems) {
+			id, err := ensureSessionOpenAIEnvProvider(ctx, store, sessionID, openAIModel, envItems)
+			if err != nil {
+				return ResolvedTarget{}, err
+			}
+			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyOpenAI, preferredProviderFamily)
+		} else if !hasSessionEnvProvider {
+			if err := ensureDefaultOpenAIEnvProvider(ctx, config, store, openAIModel); err != nil {
+				return ResolvedTarget{}, err
+			}
+		}
+	}
+	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyAnthropic) {
+		anthropicModel := firstNonEmptyTrimmed(requestedModel, SessionAnthropicEnvModel(envItems))
+		if sessionID != "" && HasAnthropicEnvProviderInput(envItems) {
+			id, err := ensureSessionAnthropicEnvProvider(ctx, store, sessionID, anthropicModel, envItems)
+			if err != nil {
+				return ResolvedTarget{}, err
+			}
+			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyAnthropic, preferredProviderFamily)
+		} else if !hasSessionEnvProvider {
+			if err := ensureDefaultAnthropicEnvProvider(ctx, config, store, anthropicModel); err != nil {
+				return ResolvedTarget{}, err
+			}
+		}
+	}
+	providerID = firstNonEmptyTrimmed(providerID, sessionProviderID)
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if len(models) == 0 {
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrRequired, "llm model is required", nil)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if len(providers) == 0 {
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
+	}
+	model, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, store, models, providers, requestedModel, preferredProviderFamily, providerID)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if !ok {
+		if requestedModel != "" && providerID != "" {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm model %q is not configured for provider %q", requestedModel, providerID), nil)
+		}
+		if requestedModel != "" {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm model %q is not configured", requestedModel), nil)
+		}
+		if providerID != "" {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm provider %q is not configured", providerID), nil)
+		}
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
+	}
+	endpoint := EndpointForProvider(provider, wireAPI)
+	headers, err := ProviderForwardHeaders(provider)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	return ResolvedTarget{Provider: provider, Model: model, WireAPI: wireAPI, Endpoint: endpoint, Headers: headers}, nil
+}
+
+func ResolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []domain.SessionEnvVar) (ResolvedTarget, error) {
+	return resolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, preferredProviderFamily, requestedModel, providerID, envItems)
+}
+
+func bootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
+	if hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyAnthropic) {
+		return nil
+	}
+	return ensureDefaultAnthropicEnvProvider(ctx, config, store, requestedModel)
+}
+
+func BootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
+	return bootstrapAnthropicLLMConfig(ctx, config, store, requestedModel)
+}
+
+func ensureDefaultAnthropicEnvProvider(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
+	lookup := defaultLLMEnvProviderLookup(ctx, config, store)
+	authHeader, authScheme := AnthropicProviderAuthFromLookup(lookup)
+	_, err := EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, ProviderIDDefaultAnthropic, "anthropic", ProviderScopeEnvDefault, requestedModel, false)
+	return err
+}
+
+func ensureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SessionEnvVar) (string, error) {
+	providerID := SessionEnvProviderID(sessionID, ProviderFamilyOpenAI)
+	return EnsureOpenAIEnvProvider(ctx, store, sessionLLMEnvProviderLookup(envItems), providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+}
+
+func EnsureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SessionEnvVar) (string, error) {
+	return ensureSessionOpenAIEnvProvider(ctx, store, sessionID, requestedModel, envItems)
+}
+
+func ensureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SessionEnvVar) (string, error) {
+	providerID := SessionEnvProviderID(sessionID, ProviderFamilyAnthropic)
+	lookup := sessionLLMEnvProviderLookup(envItems)
+	authHeader, authScheme := AnthropicProviderAuthFromLookup(lookup)
+	return EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+}
+
+func EnsureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SessionEnvVar) (string, error) {
+	return ensureSessionAnthropicEnvProvider(ctx, store, sessionID, requestedModel, envItems)
+}
+
+func hasEnabledLLMProviderID(ctx context.Context, store LLMResolverStore, providerID string) bool {
+	return HasEnabledProviderID(ctx, store, providerID)
+}
+
+func HasEnabledLLMProviderID(ctx context.Context, store LLMResolverStore, providerID string) bool {
+	return hasEnabledLLMProviderID(ctx, store, providerID)
+}
+
+func hasConfiguredLLMProviderForFamily(ctx context.Context, store LLMResolverStore, providerFamily string) bool {
+	return HasConfiguredProviderForFamily(ctx, store, providerFamily)
+}
+
+func resolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store LLMResolverStore, providerFamily, requestedModel string) (ResolvedTarget, error) {
+	if strings.TrimSpace(providerFamily) != "" {
+		providerFamily = NormalizeProviderType(providerFamily)
+	}
+	switch providerFamily {
+	case ProviderFamilyAnthropic:
+		if err := bootstrapAnthropicLLMConfig(ctx, config, store, strings.TrimSpace(requestedModel)); err != nil {
+			return ResolvedTarget{}, err
+		}
+	default:
+		if err := bootstrapDefaultLLMConfig(ctx, config, store, strings.TrimSpace(requestedModel)); err != nil {
+			return ResolvedTarget{}, err
+		}
+	}
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if len(models) == 0 {
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrRequired, "llm model is required", nil)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if len(providers) == 0 {
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
+	}
+	model, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, store, models, providers, requestedModel, providerFamily, "")
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if !ok {
+		if strings.TrimSpace(requestedModel) != "" {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm model %q is not configured for provider family %q", strings.TrimSpace(requestedModel), providerFamily), nil)
+		}
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm provider is not configured for provider family %q", providerFamily), nil)
+	}
+	endpoint := EndpointForProvider(provider, wireAPI)
+	headers, err := ProviderForwardHeaders(provider)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	return ResolvedTarget{Provider: provider, Model: model, WireAPI: wireAPI, Endpoint: endpoint, Headers: headers}, nil
+}
+
+func ResolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store LLMResolverStore, providerFamily, requestedModel string) (ResolvedTarget, error) {
+	return resolveLLMTargetForProviderFamily(ctx, config, store, providerFamily, requestedModel)
+}
+
+func lookupEnvValue(ctx context.Context, store LLMResolverStore, key string) string {
+	if store == nil {
+		return ""
+	}
+	items, err := store.ListGlobalEnv(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, item := range items {
+		if item.Name == key {
+			return item.Value
+		}
+	}
+	return ""
+}
+
+func LookupEnvValue(ctx context.Context, store LLMResolverStore, key string) string {
+	return lookupEnvValue(ctx, store, key)
+}

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"reflect"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
@@ -12,27 +11,14 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
-// isNilStore reports whether store is absent, treating a nil concrete pointer
-// wrapped in the interface as nil too. Callers such as the adapters hold a
-// *configstore.ConfigStore that can be nil (e.g. in tests without an LLM store);
-// a plain store == nil check would miss that typed-nil and panic on first use.
-func isNilStore(store FacadeStore) bool {
-	if store == nil {
-		return true
-	}
-	rv := reflect.ValueOf(store)
-	switch rv.Kind() {
-	case reflect.Pointer, reflect.Interface:
-		return rv.IsNil()
-	default:
-		return false
-	}
-}
-
 // FacadeStore is the persistence surface the runtime LLM facade needs: the LLM
 // resolution / provider-bootstrap surface plus facade-token persistence.
 // *configstore.ConfigStore satisfies it; depending on this interface keeps the
 // facade off a direct configstore import.
+//
+// Callers that hold a possibly-nil concrete store must pass a true nil
+// interface when the store is absent (see adapters.facadeStoreFor); wrapping a
+// nil pointer in the interface would bypass the `store == nil` guards here.
 type FacadeStore interface {
 	llms.LLMResolverStore
 	SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error
@@ -56,7 +42,7 @@ func EnsureSessionLLMFacadeConfig(ctx context.Context, config *appconfig.Config,
 }
 
 func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, agent, model, source, runID string) (AgentRuntimeConfig, error) {
-	if config == nil || isNilStore(store) || session == nil {
+	if config == nil || store == nil || session == nil {
 		return AgentRuntimeConfig{}, nil
 	}
 	switch domain.NormalizeAgentKind(agent) {

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -4,13 +4,39 @@ import (
 	"context"
 	"errors"
 	"os"
+	"reflect"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
-	"agent-compose/pkg/storage/configstore"
 )
+
+// isNilStore reports whether store is absent, treating a nil concrete pointer
+// wrapped in the interface as nil too. Callers such as the adapters hold a
+// *configstore.ConfigStore that can be nil (e.g. in tests without an LLM store);
+// a plain store == nil check would miss that typed-nil and panic on first use.
+func isNilStore(store FacadeStore) bool {
+	if store == nil {
+		return true
+	}
+	rv := reflect.ValueOf(store)
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+// FacadeStore is the persistence surface the runtime LLM facade needs: the LLM
+// resolution / provider-bootstrap surface plus facade-token persistence.
+// *configstore.ConfigStore satisfies it; depending on this interface keeps the
+// facade off a direct configstore import.
+type FacadeStore interface {
+	llms.LLMResolverStore
+	SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error
+}
 
 const (
 	TokenSourceAgent         = "agent"
@@ -21,7 +47,7 @@ type AgentRuntimeConfig struct {
 	Env map[string]string
 }
 
-func EnsureSessionLLMFacadeConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, agent, model, source, runID string) (map[string]string, error) {
+func EnsureSessionLLMFacadeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, agent, model, source, runID string) (map[string]string, error) {
 	runtimeConfig, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, agent, model, source, runID)
 	if err != nil {
 		return nil, err
@@ -29,8 +55,8 @@ func EnsureSessionLLMFacadeConfig(ctx context.Context, config *appconfig.Config,
 	return runtimeConfig.Env, nil
 }
 
-func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, agent, model, source, runID string) (AgentRuntimeConfig, error) {
-	if config == nil || store == nil || session == nil {
+func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, agent, model, source, runID string) (AgentRuntimeConfig, error) {
+	if config == nil || isNilStore(store) || session == nil {
 		return AgentRuntimeConfig{}, nil
 	}
 	switch domain.NormalizeAgentKind(agent) {
@@ -48,8 +74,8 @@ func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Conf
 	}
 }
 
-func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
-	target, err := configstore.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", sessionProviderEnvItems(session))
+func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", sessionProviderEnvItems(session))
 	if err != nil {
 		if isOptionalConfigError(err) {
 			return nil, nil
@@ -82,13 +108,13 @@ func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, sto
 	}, nil
 }
 
-func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
+func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
 	baseURL := llms.GuestRuntimeBaseURL(config, session)
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
 	providerEnv := sessionProviderEnvItems(session)
-	target, err := configstore.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
 	tokenModel := ""
 	tokenProvider := ""
 	if err != nil {
@@ -123,7 +149,7 @@ func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, st
 	return env, nil
 }
 
-func ensureSessionOpenCodeConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
+func ensureSessionOpenCodeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
 	providerID, modelName, err := llms.SplitOpenCodeModel(model)
 	if err != nil {
 		return nil, err
@@ -144,12 +170,12 @@ func ensureSessionOpenCodeConfig(ctx context.Context, config *appconfig.Config, 
 	}
 }
 
-func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
+func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
 	baseURL := llms.GuestRuntimeBaseURL(config, session)
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	target, err := configstore.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", sessionProviderEnvItems(session))
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", sessionProviderEnvItems(session))
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +202,8 @@ func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config
 	}, nil
 }
 
-func ensureOpenCodeOpenAIConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
-	target, err := configstore.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", sessionProviderEnvItems(session))
+func ensureOpenCodeOpenAIConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, model, source, runID string) (map[string]string, error) {
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", sessionProviderEnvItems(session))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +233,7 @@ func ensureOpenCodeOpenAIConfig(ctx context.Context, config *appconfig.Config, s
 	}, nil
 }
 
-func ensureOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, providerID, model, source, runID string) (map[string]string, error) {
+func ensureOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, providerID, model, source, runID string) (map[string]string, error) {
 	target, err := resolveOpenCodeCustomProviderTarget(ctx, config, store, session, providerID, model)
 	if err != nil {
 		return nil, err
@@ -238,28 +264,28 @@ func ensureOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.C
 	}, nil
 }
 
-func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore, session *domain.Session, providerID, model string) (llms.ResolvedTarget, error) {
+func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Session, providerID, model string) (llms.ResolvedTarget, error) {
 	envItems := sessionProviderEnvItems(session)
 	sessionID := ""
 	if session != nil {
 		sessionID = session.Summary.ID
 	}
-	if configstore.HasEnabledLLMProviderID(ctx, store, providerID) {
-		return configstore.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
+	if llms.HasEnabledLLMProviderID(ctx, store, providerID) {
+		return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
 	}
 	if sessionID != "" && llms.HasOpenAIEnvProviderInput(envItems) {
-		sessionProviderID, err := configstore.EnsureSessionOpenAIEnvProvider(ctx, store, sessionID, model, envItems)
+		sessionProviderID, err := llms.EnsureSessionOpenAIEnvProvider(ctx, store, sessionID, model, envItems)
 		if err != nil {
 			return llms.ResolvedTarget{}, err
 		}
 		if strings.TrimSpace(sessionProviderID) != "" {
-			return configstore.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, sessionProviderID, envItems)
+			return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, sessionProviderID, envItems)
 		}
 	}
-	if _, err := llms.EnsureOpenAIEnvProvider(ctx, store, configstore.DefaultLLMEnvProviderLookup(ctx, config, store), providerID, providerID, llms.ProviderScopeEnvDefault, model, false); err != nil {
+	if _, err := llms.EnsureOpenAIEnvProvider(ctx, store, llms.DefaultLLMEnvProviderLookup(ctx, config, store), providerID, providerID, llms.ProviderScopeEnvDefault, model, false); err != nil {
 		return llms.ResolvedTarget{}, err
 	}
-	return configstore.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
+	return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
 }
 
 func isOptionalConfigError(err error) bool {
@@ -273,15 +299,15 @@ func IsOptionalConfigError(err error) bool {
 	return isOptionalConfigError(err)
 }
 
-func HasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, store *configstore.ConfigStore) bool {
+func HasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, store FacadeStore) bool {
 	configKey := ""
 	if config != nil {
 		configKey = config.LLMAPIKey
 	}
 	return strings.TrimSpace(firstNonEmpty(
-		configstore.LookupEnvValue(ctx, store, "ANTHROPIC_API_KEY"),
-		configstore.LookupEnvValue(ctx, store, "ANTHROPIC_AUTH_TOKEN"),
-		configstore.LookupEnvValue(ctx, store, "LLM_API_KEY"),
+		llms.LookupEnvValue(ctx, store, "ANTHROPIC_API_KEY"),
+		llms.LookupEnvValue(ctx, store, "ANTHROPIC_AUTH_TOKEN"),
+		llms.LookupEnvValue(ctx, store, "LLM_API_KEY"),
 		os.Getenv("ANTHROPIC_API_KEY"),
 		os.Getenv("ANTHROPIC_AUTH_TOKEN"),
 		os.Getenv("LLM_API_KEY"),

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -67,9 +67,27 @@ type TriggerResolverStore interface {
 	GetLoader(context.Context, string) (domain.Loader, error)
 }
 
+// SessionRuntimeStore is the subset of session runtime persistence the run
+// controller needs: session lifecycle plus VM, proxy, and Jupyter-port state.
+// Keeping it narrow decouples the controller from the concrete
+// sessionstore.Store (and its full method set) and lets tests substitute a
+// fake. It is distinct from SessionStore in statuses.go, which exposes only
+// domain-typed lookups for status listing.
+type SessionRuntimeStore interface {
+	CreateSessionWithOptions(ctx context.Context, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *sessionstore.SessionWorkspace, envItems []sessionstore.SessionEnvVar, tags []sessionstore.SessionTag, options sessionstore.CreateSessionOptions) (*sessionstore.Session, error)
+	GetSession(ctx context.Context, id string) (*sessionstore.Session, error)
+	UpdateSession(ctx context.Context, session *sessionstore.Session) error
+	RemoveSession(ctx context.Context, id string) error
+	AddEvent(ctx context.Context, sessionID string, event sessionstore.SessionEvent) error
+	GetVMState(id string) (sessionstore.VMState, error)
+	GetProxyState(id string) (sessionstore.ProxyState, error)
+	SaveProxyState(id string, state sessionstore.ProxyState) error
+	AllocateHostPortForJupyter() (int, error)
+}
+
 type Controller struct {
 	config       *appconfig.Config
-	store        *sessionstore.Store
+	store        SessionRuntimeStore
 	configDB     ControllerStore
 	driver       SessionDriver
 	executor     AgentExecutor
@@ -84,7 +102,7 @@ type Controller struct {
 
 type ControllerDependencies struct {
 	Config       *appconfig.Config
-	Store        *sessionstore.Store
+	Store        SessionRuntimeStore
 	ConfigDB     ControllerStore
 	Driver       SessionDriver
 	Executor     AgentExecutor
@@ -834,7 +852,7 @@ func (c *Controller) stopProjectRunSession(ctx context.Context, session *domain.
 	return nil
 }
 
-func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, store *sessionstore.Store, streams *sessions.StreamBroker, session *domain.Session, capsetIDs []string) {
+func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, store SessionRuntimeStore, streams *sessions.StreamBroker, session *domain.Session, capsetIDs []string) {
 	ids := capabilities.NormalizeCapsetIDs(capsetIDs)
 	if len(ids) == 0 || provider == nil || session == nil {
 		return
@@ -876,7 +894,7 @@ func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, s
 	}
 }
 
-func recordCapabilityGuideWarning(ctx context.Context, store *sessionstore.Store, streams *sessions.StreamBroker, sessionID, message string) {
+func recordCapabilityGuideWarning(ctx context.Context, store SessionRuntimeStore, streams *sessions.StreamBroker, sessionID, message string) {
 	if store == nil || strings.TrimSpace(sessionID) == "" {
 		return
 	}

--- a/pkg/storage/configstore/capability_gateway_store.go
+++ b/pkg/storage/configstore/capability_gateway_store.go
@@ -11,15 +11,15 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
-// CapabilityGatewayStore owns the capability gateway settings row.
-type CapabilityGatewayStore struct {
+// capabilityGatewayStore owns the capability gateway settings row.
+type capabilityGatewayStore struct {
 	db *sql.DB
 }
 
 // capabilityGatewayRowID pins the settings to a single row.
 const capabilityGatewayRowID = 1
 
-func (s *CapabilityGatewayStore) ensureCapabilityGatewaySchema(ctx context.Context) error {
+func (s *capabilityGatewayStore) ensureCapabilityGatewaySchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS capability_gateway (
 		id INTEGER PRIMARY KEY CHECK (id = 1),
 		addr TEXT NOT NULL DEFAULT '',
@@ -32,13 +32,13 @@ func (s *CapabilityGatewayStore) ensureCapabilityGatewaySchema(ctx context.Conte
 	return nil
 }
 
-func (s *CapabilityGatewayStore) EnsureCapabilityGatewaySchema(ctx context.Context) error {
+func (s *capabilityGatewayStore) EnsureCapabilityGatewaySchema(ctx context.Context) error {
 	return s.ensureCapabilityGatewaySchema(ctx)
 }
 
 // GetCapabilityGateway returns the stored OctoBus connection. An empty addr
 // means the gateway is not configured.
-func (s *CapabilityGatewayStore) GetCapabilityGateway(ctx context.Context) (domain.CapabilityGatewaySettings, error) {
+func (s *capabilityGatewayStore) GetCapabilityGateway(ctx context.Context) (domain.CapabilityGatewaySettings, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT addr, token FROM capability_gateway WHERE id = ?`, capabilityGatewayRowID)
 	var settings domain.CapabilityGatewaySettings
 	switch err := row.Scan(&settings.Addr, &settings.Token); {
@@ -51,7 +51,7 @@ func (s *CapabilityGatewayStore) GetCapabilityGateway(ctx context.Context) (doma
 }
 
 // SaveCapabilityGateway upserts the OctoBus connection settings.
-func (s *CapabilityGatewayStore) SaveCapabilityGateway(ctx context.Context, settings domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
+func (s *capabilityGatewayStore) SaveCapabilityGateway(ctx context.Context, settings domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
 	settings.Addr = strings.TrimSpace(settings.Addr)
 	settings.Token = strings.TrimSpace(settings.Token)
 	if _, err := s.db.ExecContext(ctx,

--- a/pkg/storage/configstore/capability_gateway_store.go
+++ b/pkg/storage/configstore/capability_gateway_store.go
@@ -11,10 +11,15 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
+// CapabilityGatewayStore owns the capability gateway settings row.
+type CapabilityGatewayStore struct {
+	db *sql.DB
+}
+
 // capabilityGatewayRowID pins the settings to a single row.
 const capabilityGatewayRowID = 1
 
-func (s *ConfigStore) ensureCapabilityGatewaySchema(ctx context.Context) error {
+func (s *CapabilityGatewayStore) ensureCapabilityGatewaySchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS capability_gateway (
 		id INTEGER PRIMARY KEY CHECK (id = 1),
 		addr TEXT NOT NULL DEFAULT '',
@@ -27,13 +32,13 @@ func (s *ConfigStore) ensureCapabilityGatewaySchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) EnsureCapabilityGatewaySchema(ctx context.Context) error {
+func (s *CapabilityGatewayStore) EnsureCapabilityGatewaySchema(ctx context.Context) error {
 	return s.ensureCapabilityGatewaySchema(ctx)
 }
 
 // GetCapabilityGateway returns the stored OctoBus connection. An empty addr
 // means the gateway is not configured.
-func (s *ConfigStore) GetCapabilityGateway(ctx context.Context) (domain.CapabilityGatewaySettings, error) {
+func (s *CapabilityGatewayStore) GetCapabilityGateway(ctx context.Context) (domain.CapabilityGatewaySettings, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT addr, token FROM capability_gateway WHERE id = ?`, capabilityGatewayRowID)
 	var settings domain.CapabilityGatewaySettings
 	switch err := row.Scan(&settings.Addr, &settings.Token); {
@@ -46,7 +51,7 @@ func (s *ConfigStore) GetCapabilityGateway(ctx context.Context) (domain.Capabili
 }
 
 // SaveCapabilityGateway upserts the OctoBus connection settings.
-func (s *ConfigStore) SaveCapabilityGateway(ctx context.Context, settings domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
+func (s *CapabilityGatewayStore) SaveCapabilityGateway(ctx context.Context, settings domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
 	settings.Addr = strings.TrimSpace(settings.Addr)
 	settings.Token = strings.TrimSpace(settings.Token)
 	if _, err := s.db.ExecContext(ctx,

--- a/pkg/storage/configstore/core_store.go
+++ b/pkg/storage/configstore/core_store.go
@@ -32,8 +32,25 @@ type (
 	ProjectListResult      = domain.ProjectListResult
 )
 
+// CoreStore owns the shared configuration domains: global env vars, workspace
+// configs, and agent definitions.
+type CoreStore struct {
+	db *sql.DB
+}
+
+// ConfigStore is the composite persistence facade over DATA_ROOT/data.db. Each
+// domain lives on its own sub-store sharing the same *sql.DB; embedding
+// promotes every domain method onto ConfigStore, so callers and the domain
+// packages' consumer interfaces are unaffected by the internal split.
 type ConfigStore struct {
 	db *sql.DB
+
+	*CoreStore
+	*LoaderStore
+	*EventStore
+	*ProjectStore
+	*LLMStore
+	*CapabilityGatewayStore
 }
 
 func NewConfigStore(di do.Injector) (*ConfigStore, error) {
@@ -48,7 +65,7 @@ func NewConfigStore(di do.Injector) (*ConfigStore, error) {
 	}
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
-	store := &ConfigStore{db: db}
+	store := FromDB(db)
 	if err := store.initSchema(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -57,7 +74,15 @@ func NewConfigStore(di do.Injector) (*ConfigStore, error) {
 }
 
 func FromDB(db *sql.DB) *ConfigStore {
-	return &ConfigStore{db: db}
+	return &ConfigStore{
+		db:                     db,
+		CoreStore:              &CoreStore{db: db},
+		LoaderStore:            &LoaderStore{db: db},
+		EventStore:             &EventStore{db: db},
+		ProjectStore:           &ProjectStore{db: db},
+		LLMStore:               &LLMStore{db: db},
+		CapabilityGatewayStore: &CapabilityGatewayStore{db: db},
+	}
 }
 
 func (s *ConfigStore) DB() *sql.DB {
@@ -67,7 +92,7 @@ func (s *ConfigStore) DB() *sql.DB {
 	return s.db
 }
 
-func (s *ConfigStore) InitCoreSchema(ctx context.Context) error {
+func (s *CoreStore) InitCoreSchema(ctx context.Context) error {
 	statements := []string{
 		`PRAGMA journal_mode = WAL;`,
 		`PRAGMA foreign_keys = ON;`,
@@ -118,7 +143,7 @@ func (s *ConfigStore) InitSchema(ctx context.Context) error {
 	return s.initSchema(ctx)
 }
 
-func (s *ConfigStore) ensureGlobalEnvSchema(ctx context.Context) error {
+func (s *CoreStore) ensureGlobalEnvSchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS global_env (
 		name TEXT PRIMARY KEY,
 		value TEXT NOT NULL,
@@ -138,11 +163,11 @@ func (s *ConfigStore) ensureGlobalEnvSchema(ctx context.Context) error {
 	return s.rebuildGlobalEnvTable(ctx)
 }
 
-func (s *ConfigStore) EnsureGlobalEnvSchema(ctx context.Context) error {
+func (s *CoreStore) EnsureGlobalEnvSchema(ctx context.Context) error {
 	return s.ensureGlobalEnvSchema(ctx)
 }
 
-func (s *ConfigStore) ensureWorkspaceConfigSchema(ctx context.Context) error {
+func (s *CoreStore) ensureWorkspaceConfigSchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS workspace_config (
 		id TEXT PRIMARY KEY,
 		name TEXT NOT NULL,
@@ -165,11 +190,11 @@ func (s *ConfigStore) ensureWorkspaceConfigSchema(ctx context.Context) error {
 	return s.rebuildWorkspaceConfigTable(ctx)
 }
 
-func (s *ConfigStore) EnsureWorkspaceConfigSchema(ctx context.Context) error {
+func (s *CoreStore) EnsureWorkspaceConfigSchema(ctx context.Context) error {
 	return s.ensureWorkspaceConfigSchema(ctx)
 }
 
-func (s *ConfigStore) ensureAgentDefinitionSchema(ctx context.Context) error {
+func (s *CoreStore) ensureAgentDefinitionSchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS agent_definition (
 		id TEXT PRIMARY KEY,
 		name TEXT NOT NULL,
@@ -219,15 +244,15 @@ func (s *ConfigStore) ensureAgentDefinitionSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) EnsureAgentDefinitionSchema(ctx context.Context) error {
+func (s *CoreStore) EnsureAgentDefinitionSchema(ctx context.Context) error {
 	return s.ensureAgentDefinitionSchema(ctx)
 }
 
-func (s *ConfigStore) tableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
+func (s *CoreStore) tableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
 	return TableColumnTypes(ctx, s.db, tableName)
 }
 
-func (s *ConfigStore) TableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
+func (s *CoreStore) TableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
 	return s.tableColumnTypes(ctx, tableName)
 }
 
@@ -245,7 +270,7 @@ func ensureColumn(ctx context.Context, db *sql.DB, table, column, definition str
 	return nil
 }
 
-func (s *ConfigStore) rebuildGlobalEnvTable(ctx context.Context) error {
+func (s *CoreStore) rebuildGlobalEnvTable(ctx context.Context) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin global env migration tx: %w", err)
@@ -277,11 +302,11 @@ func (s *ConfigStore) rebuildGlobalEnvTable(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) RebuildGlobalEnvTable(ctx context.Context) error {
+func (s *CoreStore) RebuildGlobalEnvTable(ctx context.Context) error {
 	return s.rebuildGlobalEnvTable(ctx)
 }
 
-func (s *ConfigStore) rebuildWorkspaceConfigTable(ctx context.Context) error {
+func (s *CoreStore) rebuildWorkspaceConfigTable(ctx context.Context) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin workspace config migration tx: %w", err)
@@ -317,11 +342,11 @@ func (s *ConfigStore) rebuildWorkspaceConfigTable(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) RebuildWorkspaceConfigTable(ctx context.Context) error {
+func (s *CoreStore) RebuildWorkspaceConfigTable(ctx context.Context) error {
 	return s.rebuildWorkspaceConfigTable(ctx)
 }
 
-func (s *ConfigStore) ListGlobalEnv(ctx context.Context) ([]SessionEnvVar, error) {
+func (s *CoreStore) ListGlobalEnv(ctx context.Context) ([]SessionEnvVar, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT name, value, secret FROM global_env ORDER BY name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query global env: %w", err)
@@ -344,7 +369,7 @@ func (s *ConfigStore) ListGlobalEnv(ctx context.Context) ([]SessionEnvVar, error
 	return items, nil
 }
 
-func (s *ConfigStore) ReplaceGlobalEnv(ctx context.Context, items []SessionEnvVar) ([]SessionEnvVar, error) {
+func (s *CoreStore) ReplaceGlobalEnv(ctx context.Context, items []SessionEnvVar) ([]SessionEnvVar, error) {
 	normalized := domain.NormalizeEnvItems(items)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -366,7 +391,7 @@ func (s *ConfigStore) ReplaceGlobalEnv(ctx context.Context, items []SessionEnvVa
 	return normalized, nil
 }
 
-func (s *ConfigStore) ListWorkspaceConfigs(ctx context.Context) ([]WorkspaceConfig, error) {
+func (s *CoreStore) ListWorkspaceConfigs(ctx context.Context) ([]WorkspaceConfig, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, type, config_json, comment, created_at, updated_at FROM workspace_config ORDER BY name ASC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query workspace configs: %w", err)
@@ -387,7 +412,7 @@ func (s *ConfigStore) ListWorkspaceConfigs(ctx context.Context) ([]WorkspaceConf
 	return items, nil
 }
 
-func (s *ConfigStore) GetWorkspaceConfig(ctx context.Context, id string) (WorkspaceConfig, error) {
+func (s *CoreStore) GetWorkspaceConfig(ctx context.Context, id string) (WorkspaceConfig, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT id, name, type, config_json, comment, created_at, updated_at FROM workspace_config WHERE id = ?`, strings.TrimSpace(id))
 	item, err := ScanWorkspaceConfig(row.Scan)
 	if err != nil {
@@ -400,7 +425,7 @@ func (s *ConfigStore) GetWorkspaceConfig(ctx context.Context, id string) (Worksp
 	return item, nil
 }
 
-func (s *ConfigStore) CreateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
+func (s *CoreStore) CreateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
 	normalized, err := NormalizeWorkspaceConfig(item, true)
 	if err != nil {
 		return WorkspaceConfig{}, err
@@ -414,7 +439,7 @@ func (s *ConfigStore) CreateWorkspaceConfig(ctx context.Context, item WorkspaceC
 	return normalized, nil
 }
 
-func (s *ConfigStore) UpdateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
+func (s *CoreStore) UpdateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
 	normalized, err := NormalizeWorkspaceConfig(item, false)
 	if err != nil {
 		return WorkspaceConfig{}, err
@@ -435,7 +460,7 @@ func (s *ConfigStore) UpdateWorkspaceConfig(ctx context.Context, item WorkspaceC
 	return normalized, nil
 }
 
-func (s *ConfigStore) DeleteWorkspaceConfig(ctx context.Context, id string) error {
+func (s *CoreStore) DeleteWorkspaceConfig(ctx context.Context, id string) error {
 	trimmedID := strings.TrimSpace(id)
 	if trimmedID == "" {
 		return fmt.Errorf("workspace config id is required")
@@ -453,7 +478,7 @@ func (s *ConfigStore) DeleteWorkspaceConfig(ctx context.Context, id string) erro
 	return nil
 }
 
-func (s *ConfigStore) CreateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
+func (s *CoreStore) CreateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
 	normalized, err := domain.NormalizeAgentDefinition(item, true)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -482,7 +507,7 @@ func (s *ConfigStore) CreateAgentDefinition(ctx context.Context, item domain.Age
 	return normalized, nil
 }
 
-func (s *ConfigStore) UpdateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
+func (s *CoreStore) UpdateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
 	normalized, err := domain.NormalizeAgentDefinition(item, true)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -523,7 +548,7 @@ func (s *ConfigStore) UpdateAgentDefinition(ctx context.Context, item domain.Age
 	return normalized, nil
 }
 
-func (s *ConfigStore) UpsertManagedAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
+func (s *CoreStore) UpsertManagedAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
 	normalized, err := domain.NormalizeAgentDefinition(item, true)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -579,15 +604,15 @@ func (s *ConfigStore) UpsertManagedAgentDefinition(ctx context.Context, item dom
 	return normalized, nil
 }
 
-func (s *ConfigStore) GetAgentDefinition(ctx context.Context, id string) (domain.AgentDefinition, error) {
+func (s *CoreStore) GetAgentDefinition(ctx context.Context, id string) (domain.AgentDefinition, error) {
 	return s.getAgentDefinition(ctx, id, false)
 }
 
-func (s *ConfigStore) GetAgentDefinitionIncludingDeleted(ctx context.Context, id string) (domain.AgentDefinition, error) {
+func (s *CoreStore) GetAgentDefinitionIncludingDeleted(ctx context.Context, id string) (domain.AgentDefinition, error) {
 	return s.getAgentDefinition(ctx, id, true)
 }
 
-func (s *ConfigStore) getAgentDefinition(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, error) {
+func (s *CoreStore) getAgentDefinition(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, error) {
 	item, found, err := s.getAgentDefinitionIfExists(ctx, id, includeDeleted)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -599,7 +624,7 @@ func (s *ConfigStore) getAgentDefinition(ctx context.Context, id string, include
 	return item, nil
 }
 
-func (s *ConfigStore) getAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
+func (s *CoreStore) getAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
 	where := "id = ? AND deleted_at = 0"
 	if includeDeleted {
 		where = "id = ?"
@@ -617,11 +642,11 @@ func (s *ConfigStore) getAgentDefinitionIfExists(ctx context.Context, id string,
 	return item, true, nil
 }
 
-func (s *ConfigStore) GetAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
+func (s *CoreStore) GetAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
 	return s.getAgentDefinitionIfExists(ctx, id, includeDeleted)
 }
 
-func (s *ConfigStore) ListAgentDefinitions(ctx context.Context, options domain.AgentDefinitionListOptions) (domain.AgentDefinitionListResult, error) {
+func (s *CoreStore) ListAgentDefinitions(ctx context.Context, options domain.AgentDefinitionListOptions) (domain.AgentDefinitionListResult, error) {
 	limit := options.Limit
 	if limit <= 0 {
 		limit = 50
@@ -677,7 +702,7 @@ func (s *ConfigStore) ListAgentDefinitions(ctx context.Context, options domain.A
 	}, nil
 }
 
-func (s *ConfigStore) ListManagedAgentDefinitions(ctx context.Context, projectID string, includeDeleted bool) ([]domain.AgentDefinition, error) {
+func (s *CoreStore) ListManagedAgentDefinitions(ctx context.Context, projectID string, includeDeleted bool) ([]domain.AgentDefinition, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return nil, fmt.Errorf("project id is required")
@@ -707,7 +732,7 @@ func (s *ConfigStore) ListManagedAgentDefinitions(ctx context.Context, projectID
 	return items, nil
 }
 
-func (s *ConfigStore) DeleteAgentDefinition(ctx context.Context, id string) error {
+func (s *CoreStore) DeleteAgentDefinition(ctx context.Context, id string) error {
 	trimmedID := strings.TrimSpace(id)
 	if trimmedID == "" {
 		return fmt.Errorf("agent definition id is required")
@@ -723,7 +748,7 @@ func (s *ConfigStore) DeleteAgentDefinition(ctx context.Context, id string) erro
 	return nil
 }
 
-func (s *ConfigStore) SetAgentDefinitionEnabled(ctx context.Context, id string, enabled bool) (domain.AgentDefinition, error) {
+func (s *CoreStore) SetAgentDefinitionEnabled(ctx context.Context, id string, enabled bool) (domain.AgentDefinition, error) {
 	trimmedID := strings.TrimSpace(id)
 	if trimmedID == "" {
 		return domain.AgentDefinition{}, fmt.Errorf("agent definition id is required")
@@ -739,7 +764,7 @@ func (s *ConfigStore) SetAgentDefinitionEnabled(ctx context.Context, id string, 
 	return s.GetAgentDefinition(ctx, trimmedID)
 }
 
-func (s *ConfigStore) ensureWorkspaceNotReferencedByAgent(ctx context.Context, workspaceID string) error {
+func (s *CoreStore) ensureWorkspaceNotReferencedByAgent(ctx context.Context, workspaceID string) error {
 	trimmedID := strings.TrimSpace(workspaceID)
 	if trimmedID == "" {
 		return nil

--- a/pkg/storage/configstore/core_store.go
+++ b/pkg/storage/configstore/core_store.go
@@ -32,9 +32,9 @@ type (
 	ProjectListResult      = domain.ProjectListResult
 )
 
-// CoreStore owns the shared configuration domains: global env vars, workspace
+// coreStore owns the shared configuration domains: global env vars, workspace
 // configs, and agent definitions.
-type CoreStore struct {
+type coreStore struct {
 	db *sql.DB
 }
 
@@ -42,15 +42,20 @@ type CoreStore struct {
 // domain lives on its own sub-store sharing the same *sql.DB; embedding
 // promotes every domain method onto ConfigStore, so callers and the domain
 // packages' consumer interfaces are unaffected by the internal split.
+//
+// ConfigStore must be constructed via NewConfigStore or FromDB, which wire the
+// embedded sub-stores. The zero value (or a struct literal) leaves them nil and
+// every promoted method would panic; the sub-store types are unexported to keep
+// direct construction confined to this package.
 type ConfigStore struct {
 	db *sql.DB
 
-	*CoreStore
-	*LoaderStore
-	*EventStore
-	*ProjectStore
-	*LLMStore
-	*CapabilityGatewayStore
+	*coreStore
+	*loaderStore
+	*eventStore
+	*projectStore
+	*llmStore
+	*capabilityGatewayStore
 }
 
 func NewConfigStore(di do.Injector) (*ConfigStore, error) {
@@ -76,12 +81,12 @@ func NewConfigStore(di do.Injector) (*ConfigStore, error) {
 func FromDB(db *sql.DB) *ConfigStore {
 	return &ConfigStore{
 		db:                     db,
-		CoreStore:              &CoreStore{db: db},
-		LoaderStore:            &LoaderStore{db: db},
-		EventStore:             &EventStore{db: db},
-		ProjectStore:           &ProjectStore{db: db},
-		LLMStore:               &LLMStore{db: db},
-		CapabilityGatewayStore: &CapabilityGatewayStore{db: db},
+		coreStore:              &coreStore{db: db},
+		loaderStore:            &loaderStore{db: db},
+		eventStore:             &eventStore{db: db},
+		projectStore:           &projectStore{db: db},
+		llmStore:               &llmStore{db: db},
+		capabilityGatewayStore: &capabilityGatewayStore{db: db},
 	}
 }
 
@@ -92,7 +97,7 @@ func (s *ConfigStore) DB() *sql.DB {
 	return s.db
 }
 
-func (s *CoreStore) InitCoreSchema(ctx context.Context) error {
+func (s *coreStore) InitCoreSchema(ctx context.Context) error {
 	statements := []string{
 		`PRAGMA journal_mode = WAL;`,
 		`PRAGMA foreign_keys = ON;`,
@@ -143,7 +148,7 @@ func (s *ConfigStore) InitSchema(ctx context.Context) error {
 	return s.initSchema(ctx)
 }
 
-func (s *CoreStore) ensureGlobalEnvSchema(ctx context.Context) error {
+func (s *coreStore) ensureGlobalEnvSchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS global_env (
 		name TEXT PRIMARY KEY,
 		value TEXT NOT NULL,
@@ -163,11 +168,11 @@ func (s *CoreStore) ensureGlobalEnvSchema(ctx context.Context) error {
 	return s.rebuildGlobalEnvTable(ctx)
 }
 
-func (s *CoreStore) EnsureGlobalEnvSchema(ctx context.Context) error {
+func (s *coreStore) EnsureGlobalEnvSchema(ctx context.Context) error {
 	return s.ensureGlobalEnvSchema(ctx)
 }
 
-func (s *CoreStore) ensureWorkspaceConfigSchema(ctx context.Context) error {
+func (s *coreStore) ensureWorkspaceConfigSchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS workspace_config (
 		id TEXT PRIMARY KEY,
 		name TEXT NOT NULL,
@@ -190,11 +195,11 @@ func (s *CoreStore) ensureWorkspaceConfigSchema(ctx context.Context) error {
 	return s.rebuildWorkspaceConfigTable(ctx)
 }
 
-func (s *CoreStore) EnsureWorkspaceConfigSchema(ctx context.Context) error {
+func (s *coreStore) EnsureWorkspaceConfigSchema(ctx context.Context) error {
 	return s.ensureWorkspaceConfigSchema(ctx)
 }
 
-func (s *CoreStore) ensureAgentDefinitionSchema(ctx context.Context) error {
+func (s *coreStore) ensureAgentDefinitionSchema(ctx context.Context) error {
 	const createStmt = `CREATE TABLE IF NOT EXISTS agent_definition (
 		id TEXT PRIMARY KEY,
 		name TEXT NOT NULL,
@@ -244,15 +249,15 @@ func (s *CoreStore) ensureAgentDefinitionSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *CoreStore) EnsureAgentDefinitionSchema(ctx context.Context) error {
+func (s *coreStore) EnsureAgentDefinitionSchema(ctx context.Context) error {
 	return s.ensureAgentDefinitionSchema(ctx)
 }
 
-func (s *CoreStore) tableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
+func (s *coreStore) tableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
 	return TableColumnTypes(ctx, s.db, tableName)
 }
 
-func (s *CoreStore) TableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
+func (s *coreStore) TableColumnTypes(ctx context.Context, tableName string) (map[string]string, error) {
 	return s.tableColumnTypes(ctx, tableName)
 }
 
@@ -270,7 +275,7 @@ func ensureColumn(ctx context.Context, db *sql.DB, table, column, definition str
 	return nil
 }
 
-func (s *CoreStore) rebuildGlobalEnvTable(ctx context.Context) error {
+func (s *coreStore) rebuildGlobalEnvTable(ctx context.Context) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin global env migration tx: %w", err)
@@ -302,11 +307,11 @@ func (s *CoreStore) rebuildGlobalEnvTable(ctx context.Context) error {
 	return nil
 }
 
-func (s *CoreStore) RebuildGlobalEnvTable(ctx context.Context) error {
+func (s *coreStore) RebuildGlobalEnvTable(ctx context.Context) error {
 	return s.rebuildGlobalEnvTable(ctx)
 }
 
-func (s *CoreStore) rebuildWorkspaceConfigTable(ctx context.Context) error {
+func (s *coreStore) rebuildWorkspaceConfigTable(ctx context.Context) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin workspace config migration tx: %w", err)
@@ -342,11 +347,11 @@ func (s *CoreStore) rebuildWorkspaceConfigTable(ctx context.Context) error {
 	return nil
 }
 
-func (s *CoreStore) RebuildWorkspaceConfigTable(ctx context.Context) error {
+func (s *coreStore) RebuildWorkspaceConfigTable(ctx context.Context) error {
 	return s.rebuildWorkspaceConfigTable(ctx)
 }
 
-func (s *CoreStore) ListGlobalEnv(ctx context.Context) ([]SessionEnvVar, error) {
+func (s *coreStore) ListGlobalEnv(ctx context.Context) ([]SessionEnvVar, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT name, value, secret FROM global_env ORDER BY name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query global env: %w", err)
@@ -369,7 +374,7 @@ func (s *CoreStore) ListGlobalEnv(ctx context.Context) ([]SessionEnvVar, error) 
 	return items, nil
 }
 
-func (s *CoreStore) ReplaceGlobalEnv(ctx context.Context, items []SessionEnvVar) ([]SessionEnvVar, error) {
+func (s *coreStore) ReplaceGlobalEnv(ctx context.Context, items []SessionEnvVar) ([]SessionEnvVar, error) {
 	normalized := domain.NormalizeEnvItems(items)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -391,7 +396,7 @@ func (s *CoreStore) ReplaceGlobalEnv(ctx context.Context, items []SessionEnvVar)
 	return normalized, nil
 }
 
-func (s *CoreStore) ListWorkspaceConfigs(ctx context.Context) ([]WorkspaceConfig, error) {
+func (s *coreStore) ListWorkspaceConfigs(ctx context.Context) ([]WorkspaceConfig, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, type, config_json, comment, created_at, updated_at FROM workspace_config ORDER BY name ASC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query workspace configs: %w", err)
@@ -412,7 +417,7 @@ func (s *CoreStore) ListWorkspaceConfigs(ctx context.Context) ([]WorkspaceConfig
 	return items, nil
 }
 
-func (s *CoreStore) GetWorkspaceConfig(ctx context.Context, id string) (WorkspaceConfig, error) {
+func (s *coreStore) GetWorkspaceConfig(ctx context.Context, id string) (WorkspaceConfig, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT id, name, type, config_json, comment, created_at, updated_at FROM workspace_config WHERE id = ?`, strings.TrimSpace(id))
 	item, err := ScanWorkspaceConfig(row.Scan)
 	if err != nil {
@@ -425,7 +430,7 @@ func (s *CoreStore) GetWorkspaceConfig(ctx context.Context, id string) (Workspac
 	return item, nil
 }
 
-func (s *CoreStore) CreateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
+func (s *coreStore) CreateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
 	normalized, err := NormalizeWorkspaceConfig(item, true)
 	if err != nil {
 		return WorkspaceConfig{}, err
@@ -439,7 +444,7 @@ func (s *CoreStore) CreateWorkspaceConfig(ctx context.Context, item WorkspaceCon
 	return normalized, nil
 }
 
-func (s *CoreStore) UpdateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
+func (s *coreStore) UpdateWorkspaceConfig(ctx context.Context, item WorkspaceConfig) (WorkspaceConfig, error) {
 	normalized, err := NormalizeWorkspaceConfig(item, false)
 	if err != nil {
 		return WorkspaceConfig{}, err
@@ -460,7 +465,7 @@ func (s *CoreStore) UpdateWorkspaceConfig(ctx context.Context, item WorkspaceCon
 	return normalized, nil
 }
 
-func (s *CoreStore) DeleteWorkspaceConfig(ctx context.Context, id string) error {
+func (s *coreStore) DeleteWorkspaceConfig(ctx context.Context, id string) error {
 	trimmedID := strings.TrimSpace(id)
 	if trimmedID == "" {
 		return fmt.Errorf("workspace config id is required")
@@ -478,7 +483,7 @@ func (s *CoreStore) DeleteWorkspaceConfig(ctx context.Context, id string) error 
 	return nil
 }
 
-func (s *CoreStore) CreateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
+func (s *coreStore) CreateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
 	normalized, err := domain.NormalizeAgentDefinition(item, true)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -507,7 +512,7 @@ func (s *CoreStore) CreateAgentDefinition(ctx context.Context, item domain.Agent
 	return normalized, nil
 }
 
-func (s *CoreStore) UpdateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
+func (s *coreStore) UpdateAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
 	normalized, err := domain.NormalizeAgentDefinition(item, true)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -548,7 +553,7 @@ func (s *CoreStore) UpdateAgentDefinition(ctx context.Context, item domain.Agent
 	return normalized, nil
 }
 
-func (s *CoreStore) UpsertManagedAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
+func (s *coreStore) UpsertManagedAgentDefinition(ctx context.Context, item domain.AgentDefinition) (domain.AgentDefinition, error) {
 	normalized, err := domain.NormalizeAgentDefinition(item, true)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -604,15 +609,15 @@ func (s *CoreStore) UpsertManagedAgentDefinition(ctx context.Context, item domai
 	return normalized, nil
 }
 
-func (s *CoreStore) GetAgentDefinition(ctx context.Context, id string) (domain.AgentDefinition, error) {
+func (s *coreStore) GetAgentDefinition(ctx context.Context, id string) (domain.AgentDefinition, error) {
 	return s.getAgentDefinition(ctx, id, false)
 }
 
-func (s *CoreStore) GetAgentDefinitionIncludingDeleted(ctx context.Context, id string) (domain.AgentDefinition, error) {
+func (s *coreStore) GetAgentDefinitionIncludingDeleted(ctx context.Context, id string) (domain.AgentDefinition, error) {
 	return s.getAgentDefinition(ctx, id, true)
 }
 
-func (s *CoreStore) getAgentDefinition(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, error) {
+func (s *coreStore) getAgentDefinition(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, error) {
 	item, found, err := s.getAgentDefinitionIfExists(ctx, id, includeDeleted)
 	if err != nil {
 		return domain.AgentDefinition{}, err
@@ -624,7 +629,7 @@ func (s *CoreStore) getAgentDefinition(ctx context.Context, id string, includeDe
 	return item, nil
 }
 
-func (s *CoreStore) getAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
+func (s *coreStore) getAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
 	where := "id = ? AND deleted_at = 0"
 	if includeDeleted {
 		where = "id = ?"
@@ -642,11 +647,11 @@ func (s *CoreStore) getAgentDefinitionIfExists(ctx context.Context, id string, i
 	return item, true, nil
 }
 
-func (s *CoreStore) GetAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
+func (s *coreStore) GetAgentDefinitionIfExists(ctx context.Context, id string, includeDeleted bool) (domain.AgentDefinition, bool, error) {
 	return s.getAgentDefinitionIfExists(ctx, id, includeDeleted)
 }
 
-func (s *CoreStore) ListAgentDefinitions(ctx context.Context, options domain.AgentDefinitionListOptions) (domain.AgentDefinitionListResult, error) {
+func (s *coreStore) ListAgentDefinitions(ctx context.Context, options domain.AgentDefinitionListOptions) (domain.AgentDefinitionListResult, error) {
 	limit := options.Limit
 	if limit <= 0 {
 		limit = 50
@@ -702,7 +707,7 @@ func (s *CoreStore) ListAgentDefinitions(ctx context.Context, options domain.Age
 	}, nil
 }
 
-func (s *CoreStore) ListManagedAgentDefinitions(ctx context.Context, projectID string, includeDeleted bool) ([]domain.AgentDefinition, error) {
+func (s *coreStore) ListManagedAgentDefinitions(ctx context.Context, projectID string, includeDeleted bool) ([]domain.AgentDefinition, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return nil, fmt.Errorf("project id is required")
@@ -732,7 +737,7 @@ func (s *CoreStore) ListManagedAgentDefinitions(ctx context.Context, projectID s
 	return items, nil
 }
 
-func (s *CoreStore) DeleteAgentDefinition(ctx context.Context, id string) error {
+func (s *coreStore) DeleteAgentDefinition(ctx context.Context, id string) error {
 	trimmedID := strings.TrimSpace(id)
 	if trimmedID == "" {
 		return fmt.Errorf("agent definition id is required")
@@ -748,7 +753,7 @@ func (s *CoreStore) DeleteAgentDefinition(ctx context.Context, id string) error 
 	return nil
 }
 
-func (s *CoreStore) SetAgentDefinitionEnabled(ctx context.Context, id string, enabled bool) (domain.AgentDefinition, error) {
+func (s *coreStore) SetAgentDefinitionEnabled(ctx context.Context, id string, enabled bool) (domain.AgentDefinition, error) {
 	trimmedID := strings.TrimSpace(id)
 	if trimmedID == "" {
 		return domain.AgentDefinition{}, fmt.Errorf("agent definition id is required")
@@ -764,7 +769,7 @@ func (s *CoreStore) SetAgentDefinitionEnabled(ctx context.Context, id string, en
 	return s.GetAgentDefinition(ctx, trimmedID)
 }
 
-func (s *CoreStore) ensureWorkspaceNotReferencedByAgent(ctx context.Context, workspaceID string) error {
+func (s *coreStore) ensureWorkspaceNotReferencedByAgent(ctx context.Context, workspaceID string) error {
 	trimmedID := strings.TrimSpace(workspaceID)
 	if trimmedID == "" {
 		return nil

--- a/pkg/storage/configstore/helpers.go
+++ b/pkg/storage/configstore/helpers.go
@@ -11,11 +11,10 @@ import (
 	"github.com/google/uuid"
 
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/storeutil"
 )
 
-const StoredUnixMillisecondThreshold int64 = 10_000_000_000
-
-const storedUnixMillisecondThreshold int64 = StoredUnixMillisecondThreshold
+const storedUnixMillisecondThreshold int64 = storeutil.StoredUnixMillisecondThreshold
 
 func EnsureColumn(ctx context.Context, db *sql.DB, table, column, definition string) error {
 	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")")
@@ -109,26 +108,16 @@ func ScanWorkspaceConfig(scan func(dest ...any) error) (domain.WorkspaceConfig, 
 	return item, nil
 }
 
-func ParseStoredUnixTimeAuto(value int64) time.Time {
-	if value <= 0 {
-		return time.Time{}
-	}
-	if value >= StoredUnixMillisecondThreshold {
-		return time.UnixMilli(value).UTC()
-	}
-	return time.Unix(value, 0).UTC()
-}
-
 func ParseStoredLoaderTriggerTime(value any) time.Time {
 	switch typed := value.(type) {
 	case nil:
 		return time.Time{}
 	case int64:
-		return ParseStoredUnixTimeAuto(typed)
+		return storeutil.ParseStoredUnixTimeAuto(typed)
 	case int:
-		return ParseStoredUnixTimeAuto(int64(typed))
+		return storeutil.ParseStoredUnixTimeAuto(int64(typed))
 	case float64:
-		return ParseStoredUnixTimeAuto(int64(typed))
+		return storeutil.ParseStoredUnixTimeAuto(int64(typed))
 	case []byte:
 		return ParseStoredLoaderTriggerTime(string(typed))
 	case string:
@@ -137,7 +126,7 @@ func ParseStoredLoaderTriggerTime(value any) time.Time {
 			return time.Time{}
 		}
 		if unixValue, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
-			return ParseStoredUnixTimeAuto(unixValue)
+			return storeutil.ParseStoredUnixTimeAuto(unixValue)
 		}
 		return ParseStoredTime(trimmed)
 	default:
@@ -150,11 +139,11 @@ func ParseStoredTime(value any) time.Time {
 	case nil:
 		return time.Time{}
 	case int64:
-		return ParseStoredUnixTimeAuto(typed)
+		return storeutil.ParseStoredUnixTimeAuto(typed)
 	case int:
-		return ParseStoredUnixTimeAuto(int64(typed))
+		return storeutil.ParseStoredUnixTimeAuto(int64(typed))
 	case float64:
-		return ParseStoredUnixTimeAuto(int64(typed))
+		return storeutil.ParseStoredUnixTimeAuto(int64(typed))
 	case []byte:
 		return ParseStoredTime(string(typed))
 	case string:
@@ -163,7 +152,7 @@ func ParseStoredTime(value any) time.Time {
 			return time.Time{}
 		}
 		if unixValue, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
-			return ParseStoredUnixTimeAuto(unixValue)
+			return storeutil.ParseStoredUnixTimeAuto(unixValue)
 		}
 		for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05.000Z"} {
 			if parsed, err := time.Parse(layout, trimmed); err == nil {

--- a/pkg/storage/configstore/llm_config.go
+++ b/pkg/storage/configstore/llm_config.go
@@ -11,7 +11,12 @@ import (
 	"time"
 )
 
-func (s *ConfigStore) ensureLLMSchema(ctx context.Context) error {
+// LLMStore owns LLM provider/model configuration and facade tokens.
+type LLMStore struct {
+	db *sql.DB
+}
+
+func (s *LLMStore) ensureLLMSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS llm_provider (
 			id TEXT PRIMARY KEY,
@@ -72,7 +77,7 @@ func (s *ConfigStore) ensureLLMSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) HasLLMProviders(ctx context.Context) (bool, error) {
+func (s *LLMStore) HasLLMProviders(ctx context.Context) (bool, error) {
 	var count int
 	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM llm_provider`).Scan(&count); err != nil {
 		return false, fmt.Errorf("count llm providers: %w", err)
@@ -80,7 +85,7 @@ func (s *ConfigStore) HasLLMProviders(ctx context.Context) (bool, error) {
 	return count > 0, nil
 }
 
-func (s *ConfigStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.Provider, model llms.Model) error {
+func (s *LLMStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.Provider, model llms.Model) error {
 	now := time.Now().UTC().Unix()
 	var ok bool
 	provider, model, ok = llms.NormalizeDefaultConfig(provider, model)
@@ -115,7 +120,7 @@ func (s *ConfigStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.
 	return tx.Commit()
 }
 
-func (s *ConfigStore) ListEnabledLLMProviders(ctx context.Context) ([]llms.Provider, error) {
+func (s *LLMStore) ListEnabledLLMProviders(ctx context.Context) ([]llms.Provider, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, use_generic_responses_text_parts, weight, enabled, scope, created_at, updated_at FROM llm_provider WHERE enabled != 0 ORDER BY weight ASC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query llm providers: %w", err)
@@ -135,7 +140,7 @@ func (s *ConfigStore) ListEnabledLLMProviders(ctx context.Context) ([]llms.Provi
 	return providers, nil
 }
 
-func (s *ConfigStore) ListEnabledLLMModels(ctx context.Context) ([]llms.Model, error) {
+func (s *LLMStore) ListEnabledLLMModels(ctx context.Context) ([]llms.Model, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, description, default_model, enabled, scope, created_at, updated_at FROM llm_model WHERE enabled != 0 ORDER BY default_model DESC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query llm models: %w", err)
@@ -155,7 +160,7 @@ func (s *ConfigStore) ListEnabledLLMModels(ctx context.Context) ([]llms.Model, e
 	return models, nil
 }
 
-func (s *ConfigStore) LLMProviderModelWireAPI(ctx context.Context, providerID, modelID string) (string, bool, error) {
+func (s *LLMStore) LLMProviderModelWireAPI(ctx context.Context, providerID, modelID string) (string, bool, error) {
 	var wireAPI string
 	err := s.db.QueryRowContext(ctx, `SELECT wire_api FROM llm_provider_model WHERE provider_id = ? AND model_id = ?`, strings.TrimSpace(providerID), strings.TrimSpace(modelID)).Scan(&wireAPI)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -171,7 +176,7 @@ func (s *ConfigStore) LLMProviderModelWireAPI(ctx context.Context, providerID, m
 	return llms.NormalizeWireAPI(wireAPI), true, nil
 }
 
-func (s *ConfigStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error {
+func (s *LLMStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error {
 	if strings.TrimSpace(token.TokenHash) == "" || strings.TrimSpace(token.SessionID) == "" {
 		return fmt.Errorf("llm facade token hash and session id are required")
 	}
@@ -199,7 +204,7 @@ func (s *ConfigStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeT
 // DeleteLLMFacadeToken removes a single facade token by its raw value. It is used
 // to retire a per-run agent token as soon as that run completes, so live tokens
 // never accumulate over the lifetime of a long-running session.
-func (s *ConfigStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) error {
+func (s *LLMStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) error {
 	if strings.TrimSpace(rawToken) == "" {
 		return nil
 	}
@@ -210,7 +215,7 @@ func (s *ConfigStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string)
 	return nil
 }
 
-func (s *ConfigStore) GetLLMFacadeToken(ctx context.Context, rawToken string) (llms.FacadeToken, error) {
+func (s *LLMStore) GetLLMFacadeToken(ctx context.Context, rawToken string) (llms.FacadeToken, error) {
 	hash, fingerprint := llms.HashFacadeToken(rawToken)
 	row := s.db.QueryRowContext(ctx, `SELECT session_id, token_hash, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at FROM llm_facade_token WHERE token_hash = ?`, hash)
 	token, err := llms.ScanFacadeToken(row.Scan)
@@ -230,7 +235,7 @@ const llmFacadeTokenRetention = time.Hour
 
 const LLMFacadeTokenRetention = llmFacadeTokenRetention
 
-func (s *ConfigStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessionID string) error {
+func (s *LLMStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessionID string) error {
 	now := time.Now().UTC()
 	if _, err := s.db.ExecContext(ctx, `UPDATE llm_facade_token SET revoked_at = ? WHERE session_id = ? AND revoked_at = 0`, now.Unix(), strings.TrimSpace(sessionID)); err != nil {
 		return fmt.Errorf("revoke llm facade tokens for session: %w", err)

--- a/pkg/storage/configstore/llm_config.go
+++ b/pkg/storage/configstore/llm_config.go
@@ -8,19 +8,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 )
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
-}
 
 func (s *ConfigStore) ensureLLMSchema(ctx context.Context) error {
 	statements := []string{
@@ -256,313 +246,34 @@ func (s *ConfigStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessi
 	return nil
 }
 
-func bootstrapDefaultLLMConfig(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
-	if hasConfiguredLLMProviderForFamily(ctx, store, llms.ProviderFamilyOpenAI) {
-		return nil
-	}
-	return ensureDefaultOpenAIEnvProvider(ctx, config, store, requestedModel)
-}
-
-func BootstrapDefaultLLMConfig(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
-	return bootstrapDefaultLLMConfig(ctx, config, store, requestedModel)
-}
-
-// llms.EnvProviderLookup resolves an environment value for LLM provider bootstrap.
-// It accepts candidate keys and returns the first non-empty value scanning
-// sources in priority order (source-major): an earlier source wins across all
-// candidate keys before a later source is consulted. This preserves the exact
-// precedence the bootstrap paths relied on when they used nested firstNonEmpty.
-// defaultLLMEnvProviderLookup reads from global env, then the process env, then
-// daemon config. Used by the env_default bootstrap providers.
-func defaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store *ConfigStore) llms.EnvProviderLookup {
-	return func(keys ...string) string {
-		for _, key := range keys {
-			if v := lookupEnvValue(ctx, store, key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		for _, key := range keys {
-			if v := os.Getenv(key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		for _, key := range keys {
-			if v := configLLMEnvValue(config, key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		return ""
-	}
-}
+// The LLM target-resolution and provider-bootstrap logic now lives in pkg/llms.
+// These thin wrappers keep the existing configstore call sites compiling; they
+// are removed in the follow-up once callers depend on llms directly.
 
 func DefaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store *ConfigStore) llms.EnvProviderLookup {
-	return defaultLLMEnvProviderLookup(ctx, config, store)
-}
-
-// sessionLLMEnvProviderLookup reads only from per-session env items. Used by the
-// session_env bootstrap providers.
-func sessionLLMEnvProviderLookup(envItems []SessionEnvVar) llms.EnvProviderLookup {
-	return func(keys ...string) string {
-		for _, key := range keys {
-			if v := llms.EnvItemValue(envItems, key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		return ""
-	}
-}
-
-func configLLMEnvValue(config *appconfig.Config, key string) string {
-	if config == nil {
-		return ""
-	}
-	switch strings.ToUpper(strings.TrimSpace(key)) {
-	case "LLM_API_ENDPOINT":
-		return config.LLMAPIEndpoint
-	case "LLM_API_PROTOCOL":
-		return config.LLMAPIProtocol
-	case "LLM_API_KEY":
-		return config.LLMAPIKey
-	case "LLM_MODEL":
-		return config.LLMModel
-	default:
-		return ""
-	}
-}
-
-func ensureDefaultOpenAIEnvProvider(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
-	_, err := llms.EnsureOpenAIEnvProvider(ctx, store, defaultLLMEnvProviderLookup(ctx, config, store), llms.ProviderIDDefaultOpenAI, "default", llms.ProviderScopeEnvDefault, requestedModel, true)
-	return err
-}
-
-func resolveLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) (llms.ResolvedTarget, error) {
-	return resolveLLMTargetForProviderFamily(ctx, config, store, llms.ProviderFamilyOpenAI, requestedModel)
+	return llms.DefaultLLMEnvProviderLookup(ctx, config, store)
 }
 
 func ResolveLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) (llms.ResolvedTarget, error) {
-	return resolveLLMTarget(ctx, config, store, requestedModel)
-}
-
-func resolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel, providerID string) (llms.ResolvedTarget, error) {
-	return resolveRuntimeLLMTargetWithEnv(ctx, config, store, "", "", requestedModel, providerID, nil)
+	return llms.ResolveLLMTarget(ctx, config, store, requestedModel)
 }
 
 func ResolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel, providerID string) (llms.ResolvedTarget, error) {
-	return resolveRuntimeLLMTarget(ctx, config, store, requestedModel, providerID)
+	return llms.ResolveRuntimeLLMTarget(ctx, config, store, requestedModel, providerID)
 }
 
-func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store *ConfigStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []SessionEnvVar) (llms.ResolvedTarget, error) {
-	sessionID = strings.TrimSpace(sessionID)
-	preferredProviderFamily = llms.NormalizeOptionalProviderType(preferredProviderFamily)
-	requestedModel = strings.TrimSpace(requestedModel)
-	providerID = strings.TrimSpace(providerID)
-	hasSessionEnvProvider := sessionID != "" && llms.HasSessionEnvProviderInput(envItems)
-	sessionProviderID := ""
-	// Reuse an already-persisted session-env provider when this session can no
-	// longer supply a key from env. The raw key env (Session.ProviderEnvItems) is
-	// intentionally not persisted, so after a stop/resume the only durable home
-	// for a session-scoped credential is the llm_provider row written at creation.
-	// Pin its provider id here so resolution selects it (session-env providers are
-	// otherwise skipped without an explicit id) and does not clobber its key with
-	// the now-empty env. Only when the env still has no key for the family — an env
-	// that carries a (possibly rotated) key must keep re-bootstrapping it.
-	if providerID == "" && sessionID != "" && preferredProviderFamily != "" && !llms.EnvHasProviderKeyForFamily(envItems, preferredProviderFamily) {
-		if candidate := llms.SessionEnvProviderID(sessionID, preferredProviderFamily); hasEnabledLLMProviderID(ctx, store, candidate) {
-			providerID = candidate
-		}
-	}
-	// Skip the env/default bootstrap entirely when the request already names a
-	// provider that exists. The facade hot path always passes a concrete
-	// provider id from the token scope, so this avoids a redundant pair of
-	// idempotent provider upserts on every LLM request.
-	bootstrapProviders := (providerID == "" || !llms.IsSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
-	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, llms.ProviderFamilyOpenAI) {
-		openAIModel := firstNonEmpty(requestedModel, llms.EnvItemValue(envItems, "LLM_MODEL"))
-		if sessionID != "" && llms.HasOpenAIEnvProviderInput(envItems) {
-			id, err := ensureSessionOpenAIEnvProvider(ctx, store, sessionID, openAIModel, envItems)
-			if err != nil {
-				return llms.ResolvedTarget{}, err
-			}
-			sessionProviderID = llms.ChooseSessionEnvProviderID(sessionProviderID, id, llms.ProviderFamilyOpenAI, preferredProviderFamily)
-		} else if !hasSessionEnvProvider {
-			if err := ensureDefaultOpenAIEnvProvider(ctx, config, store, openAIModel); err != nil {
-				return llms.ResolvedTarget{}, err
-			}
-		}
-	}
-	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, llms.ProviderFamilyAnthropic) {
-		anthropicModel := firstNonEmpty(requestedModel, llms.SessionAnthropicEnvModel(envItems))
-		if sessionID != "" && llms.HasAnthropicEnvProviderInput(envItems) {
-			id, err := ensureSessionAnthropicEnvProvider(ctx, store, sessionID, anthropicModel, envItems)
-			if err != nil {
-				return llms.ResolvedTarget{}, err
-			}
-			sessionProviderID = llms.ChooseSessionEnvProviderID(sessionProviderID, id, llms.ProviderFamilyAnthropic, preferredProviderFamily)
-		} else if !hasSessionEnvProvider {
-			if err := ensureDefaultAnthropicEnvProvider(ctx, config, store, anthropicModel); err != nil {
-				return llms.ResolvedTarget{}, err
-			}
-		}
-	}
-	providerID = firstNonEmpty(providerID, sessionProviderID)
-	models, err := store.ListEnabledLLMModels(ctx)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	if len(models) == 0 {
-		return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrRequired, "llm model is required", nil)
-	}
-	providers, err := store.ListEnabledLLMProviders(ctx)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	if len(providers) == 0 {
-		return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
-	}
-	model, provider, wireAPI, ok, err := llms.SelectModelAndProvider(ctx, store, models, providers, requestedModel, preferredProviderFamily, providerID)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	if !ok {
-		if requestedModel != "" && providerID != "" {
-			return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm model %q is not configured for provider %q", requestedModel, providerID), nil)
-		}
-		if requestedModel != "" {
-			return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm model %q is not configured", requestedModel), nil)
-		}
-		if providerID != "" {
-			return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm provider %q is not configured", providerID), nil)
-		}
-		return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
-	}
-	endpoint := llms.EndpointForProvider(provider, wireAPI)
-	headers, err := llms.ProviderForwardHeaders(provider)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	return llms.ResolvedTarget{Provider: provider, Model: model, WireAPI: wireAPI, Endpoint: endpoint, Headers: headers}, nil
+func ResolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store *ConfigStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []domain.SessionEnvVar) (llms.ResolvedTarget, error) {
+	return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, preferredProviderFamily, requestedModel, providerID, envItems)
 }
 
-func ResolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store *ConfigStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []SessionEnvVar) (llms.ResolvedTarget, error) {
-	return resolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, preferredProviderFamily, requestedModel, providerID, envItems)
-}
-
-func bootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
-	if hasConfiguredLLMProviderForFamily(ctx, store, llms.ProviderFamilyAnthropic) {
-		return nil
-	}
-	return ensureDefaultAnthropicEnvProvider(ctx, config, store, requestedModel)
-}
-
-func BootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
-	return bootstrapAnthropicLLMConfig(ctx, config, store, requestedModel)
-}
-
-func ensureDefaultAnthropicEnvProvider(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) error {
-	lookup := defaultLLMEnvProviderLookup(ctx, config, store)
-	authHeader, authScheme := llms.AnthropicProviderAuthFromLookup(lookup)
-	_, err := llms.EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, llms.ProviderIDDefaultAnthropic, "anthropic", llms.ProviderScopeEnvDefault, requestedModel, false)
-	return err
-}
-
-func ensureSessionOpenAIEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []SessionEnvVar) (string, error) {
-	providerID := llms.SessionEnvProviderID(sessionID, llms.ProviderFamilyOpenAI)
-	return llms.EnsureOpenAIEnvProvider(ctx, store, sessionLLMEnvProviderLookup(envItems), providerID, providerID, llms.ProviderScopeSessionEnv, requestedModel, false)
-}
-
-func EnsureSessionOpenAIEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []SessionEnvVar) (string, error) {
-	return ensureSessionOpenAIEnvProvider(ctx, store, sessionID, requestedModel, envItems)
-}
-
-func ensureSessionAnthropicEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []SessionEnvVar) (string, error) {
-	providerID := llms.SessionEnvProviderID(sessionID, llms.ProviderFamilyAnthropic)
-	lookup := sessionLLMEnvProviderLookup(envItems)
-	authHeader, authScheme := llms.AnthropicProviderAuthFromLookup(lookup)
-	return llms.EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, providerID, providerID, llms.ProviderScopeSessionEnv, requestedModel, false)
-}
-
-func EnsureSessionAnthropicEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []SessionEnvVar) (string, error) {
-	return ensureSessionAnthropicEnvProvider(ctx, store, sessionID, requestedModel, envItems)
-}
-
-func hasEnabledLLMProviderID(ctx context.Context, store *ConfigStore, providerID string) bool {
-	return llms.HasEnabledProviderID(ctx, store, providerID)
+func EnsureSessionOpenAIEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []domain.SessionEnvVar) (string, error) {
+	return llms.EnsureSessionOpenAIEnvProvider(ctx, store, sessionID, requestedModel, envItems)
 }
 
 func HasEnabledLLMProviderID(ctx context.Context, store *ConfigStore, providerID string) bool {
-	return hasEnabledLLMProviderID(ctx, store, providerID)
-}
-
-func hasConfiguredLLMProviderForFamily(ctx context.Context, store *ConfigStore, providerFamily string) bool {
-	return llms.HasConfiguredProviderForFamily(ctx, store, providerFamily)
-}
-
-func resolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store *ConfigStore, providerFamily, requestedModel string) (llms.ResolvedTarget, error) {
-	if strings.TrimSpace(providerFamily) != "" {
-		providerFamily = llms.NormalizeProviderType(providerFamily)
-	}
-	switch providerFamily {
-	case llms.ProviderFamilyAnthropic:
-		if err := bootstrapAnthropicLLMConfig(ctx, config, store, strings.TrimSpace(requestedModel)); err != nil {
-			return llms.ResolvedTarget{}, err
-		}
-	default:
-		if err := bootstrapDefaultLLMConfig(ctx, config, store, strings.TrimSpace(requestedModel)); err != nil {
-			return llms.ResolvedTarget{}, err
-		}
-	}
-	models, err := store.ListEnabledLLMModels(ctx)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	if len(models) == 0 {
-		return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrRequired, "llm model is required", nil)
-	}
-	providers, err := store.ListEnabledLLMProviders(ctx)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	if len(providers) == 0 {
-		return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
-	}
-	model, provider, wireAPI, ok, err := llms.SelectModelAndProvider(ctx, store, models, providers, requestedModel, providerFamily, "")
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	if !ok {
-		if strings.TrimSpace(requestedModel) != "" {
-			return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm model %q is not configured for provider family %q", strings.TrimSpace(requestedModel), providerFamily), nil)
-		}
-		return llms.ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm provider is not configured for provider family %q", providerFamily), nil)
-	}
-	endpoint := llms.EndpointForProvider(provider, wireAPI)
-	headers, err := llms.ProviderForwardHeaders(provider)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	return llms.ResolvedTarget{Provider: provider, Model: model, WireAPI: wireAPI, Endpoint: endpoint, Headers: headers}, nil
-}
-
-func ResolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store *ConfigStore, providerFamily, requestedModel string) (llms.ResolvedTarget, error) {
-	return resolveLLMTargetForProviderFamily(ctx, config, store, providerFamily, requestedModel)
-}
-
-func lookupEnvValue(ctx context.Context, store *ConfigStore, key string) string {
-	if store == nil {
-		return ""
-	}
-	items, err := store.ListGlobalEnv(ctx)
-	if err != nil {
-		return ""
-	}
-	for _, item := range items {
-		if item.Name == key {
-			return item.Value
-		}
-	}
-	return ""
+	return llms.HasEnabledLLMProviderID(ctx, store, providerID)
 }
 
 func LookupEnvValue(ctx context.Context, store *ConfigStore, key string) string {
-	return lookupEnvValue(ctx, store, key)
+	return llms.LookupEnvValue(ctx, store, key)
 }

--- a/pkg/storage/configstore/llm_config.go
+++ b/pkg/storage/configstore/llm_config.go
@@ -11,12 +11,12 @@ import (
 	"time"
 )
 
-// LLMStore owns LLM provider/model configuration and facade tokens.
-type LLMStore struct {
+// llmStore owns LLM provider/model configuration and facade tokens.
+type llmStore struct {
 	db *sql.DB
 }
 
-func (s *LLMStore) ensureLLMSchema(ctx context.Context) error {
+func (s *llmStore) ensureLLMSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS llm_provider (
 			id TEXT PRIMARY KEY,
@@ -77,7 +77,7 @@ func (s *LLMStore) ensureLLMSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *LLMStore) HasLLMProviders(ctx context.Context) (bool, error) {
+func (s *llmStore) HasLLMProviders(ctx context.Context) (bool, error) {
 	var count int
 	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM llm_provider`).Scan(&count); err != nil {
 		return false, fmt.Errorf("count llm providers: %w", err)
@@ -85,7 +85,7 @@ func (s *LLMStore) HasLLMProviders(ctx context.Context) (bool, error) {
 	return count > 0, nil
 }
 
-func (s *LLMStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.Provider, model llms.Model) error {
+func (s *llmStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.Provider, model llms.Model) error {
 	now := time.Now().UTC().Unix()
 	var ok bool
 	provider, model, ok = llms.NormalizeDefaultConfig(provider, model)
@@ -120,7 +120,7 @@ func (s *LLMStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.Pro
 	return tx.Commit()
 }
 
-func (s *LLMStore) ListEnabledLLMProviders(ctx context.Context) ([]llms.Provider, error) {
+func (s *llmStore) ListEnabledLLMProviders(ctx context.Context) ([]llms.Provider, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, use_generic_responses_text_parts, weight, enabled, scope, created_at, updated_at FROM llm_provider WHERE enabled != 0 ORDER BY weight ASC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query llm providers: %w", err)
@@ -140,7 +140,7 @@ func (s *LLMStore) ListEnabledLLMProviders(ctx context.Context) ([]llms.Provider
 	return providers, nil
 }
 
-func (s *LLMStore) ListEnabledLLMModels(ctx context.Context) ([]llms.Model, error) {
+func (s *llmStore) ListEnabledLLMModels(ctx context.Context) ([]llms.Model, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, description, default_model, enabled, scope, created_at, updated_at FROM llm_model WHERE enabled != 0 ORDER BY default_model DESC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query llm models: %w", err)
@@ -160,7 +160,7 @@ func (s *LLMStore) ListEnabledLLMModels(ctx context.Context) ([]llms.Model, erro
 	return models, nil
 }
 
-func (s *LLMStore) LLMProviderModelWireAPI(ctx context.Context, providerID, modelID string) (string, bool, error) {
+func (s *llmStore) LLMProviderModelWireAPI(ctx context.Context, providerID, modelID string) (string, bool, error) {
 	var wireAPI string
 	err := s.db.QueryRowContext(ctx, `SELECT wire_api FROM llm_provider_model WHERE provider_id = ? AND model_id = ?`, strings.TrimSpace(providerID), strings.TrimSpace(modelID)).Scan(&wireAPI)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -176,7 +176,7 @@ func (s *LLMStore) LLMProviderModelWireAPI(ctx context.Context, providerID, mode
 	return llms.NormalizeWireAPI(wireAPI), true, nil
 }
 
-func (s *LLMStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error {
+func (s *llmStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error {
 	if strings.TrimSpace(token.TokenHash) == "" || strings.TrimSpace(token.SessionID) == "" {
 		return fmt.Errorf("llm facade token hash and session id are required")
 	}
@@ -204,7 +204,7 @@ func (s *LLMStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToke
 // DeleteLLMFacadeToken removes a single facade token by its raw value. It is used
 // to retire a per-run agent token as soon as that run completes, so live tokens
 // never accumulate over the lifetime of a long-running session.
-func (s *LLMStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) error {
+func (s *llmStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) error {
 	if strings.TrimSpace(rawToken) == "" {
 		return nil
 	}
@@ -215,7 +215,7 @@ func (s *LLMStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) er
 	return nil
 }
 
-func (s *LLMStore) GetLLMFacadeToken(ctx context.Context, rawToken string) (llms.FacadeToken, error) {
+func (s *llmStore) GetLLMFacadeToken(ctx context.Context, rawToken string) (llms.FacadeToken, error) {
 	hash, fingerprint := llms.HashFacadeToken(rawToken)
 	row := s.db.QueryRowContext(ctx, `SELECT session_id, token_hash, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at FROM llm_facade_token WHERE token_hash = ?`, hash)
 	token, err := llms.ScanFacadeToken(row.Scan)
@@ -235,7 +235,7 @@ const llmFacadeTokenRetention = time.Hour
 
 const LLMFacadeTokenRetention = llmFacadeTokenRetention
 
-func (s *LLMStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessionID string) error {
+func (s *llmStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessionID string) error {
 	now := time.Now().UTC()
 	if _, err := s.db.ExecContext(ctx, `UPDATE llm_facade_token SET revoked_at = ? WHERE session_id = ? AND revoked_at = 0`, now.Unix(), strings.TrimSpace(sessionID)); err != nil {
 		return fmt.Errorf("revoke llm facade tokens for session: %w", err)

--- a/pkg/storage/configstore/llm_config.go
+++ b/pkg/storage/configstore/llm_config.go
@@ -1,7 +1,6 @@
 package configstore
 
 import (
-	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
 	"context"
@@ -244,36 +243,4 @@ func (s *ConfigStore) RevokeLLMFacadeTokensForSession(ctx context.Context, sessi
 		return fmt.Errorf("prune llm facade tokens: %w", err)
 	}
 	return nil
-}
-
-// The LLM target-resolution and provider-bootstrap logic now lives in pkg/llms.
-// These thin wrappers keep the existing configstore call sites compiling; they
-// are removed in the follow-up once callers depend on llms directly.
-
-func DefaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store *ConfigStore) llms.EnvProviderLookup {
-	return llms.DefaultLLMEnvProviderLookup(ctx, config, store)
-}
-
-func ResolveLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel string) (llms.ResolvedTarget, error) {
-	return llms.ResolveLLMTarget(ctx, config, store, requestedModel)
-}
-
-func ResolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store *ConfigStore, requestedModel, providerID string) (llms.ResolvedTarget, error) {
-	return llms.ResolveRuntimeLLMTarget(ctx, config, store, requestedModel, providerID)
-}
-
-func ResolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store *ConfigStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []domain.SessionEnvVar) (llms.ResolvedTarget, error) {
-	return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, preferredProviderFamily, requestedModel, providerID, envItems)
-}
-
-func EnsureSessionOpenAIEnvProvider(ctx context.Context, store *ConfigStore, sessionID, requestedModel string, envItems []domain.SessionEnvVar) (string, error) {
-	return llms.EnsureSessionOpenAIEnvProvider(ctx, store, sessionID, requestedModel, envItems)
-}
-
-func HasEnabledLLMProviderID(ctx context.Context, store *ConfigStore, providerID string) bool {
-	return llms.HasEnabledLLMProviderID(ctx, store, providerID)
-}
-
-func LookupEnvValue(ctx context.Context, store *ConfigStore, key string) string {
-	return llms.LookupEnvValue(ctx, store, key)
 }

--- a/pkg/storage/configstore/loader_store.go
+++ b/pkg/storage/configstore/loader_store.go
@@ -13,12 +13,12 @@ import (
 	"time"
 )
 
-// LoaderStore owns loader definitions, triggers, runs, and loader events.
-type LoaderStore struct {
+// loaderStore owns loader definitions, triggers, runs, and loader events.
+type loaderStore struct {
 	db *sql.DB
 }
 
-func (s *LoaderStore) ensureLoaderSchema(ctx context.Context) error {
+func (s *loaderStore) ensureLoaderSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS loader (
             id TEXT PRIMARY KEY,
@@ -126,11 +126,11 @@ func (s *LoaderStore) ensureLoaderSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *LoaderStore) EnsureLoaderSchema(ctx context.Context) error {
+func (s *loaderStore) EnsureLoaderSchema(ctx context.Context) error {
 	return s.ensureLoaderSchema(ctx)
 }
 
-func (s *LoaderStore) ensureLoaderManagedColumns(ctx context.Context) error {
+func (s *loaderStore) ensureLoaderManagedColumns(ctx context.Context) error {
 	columns := []struct {
 		name       string
 		definition string
@@ -148,7 +148,7 @@ func (s *LoaderStore) ensureLoaderManagedColumns(ctx context.Context) error {
 	return nil
 }
 
-func (s *LoaderStore) ensureLoaderCapabilityColumn(ctx context.Context) error {
+func (s *loaderStore) ensureLoaderCapabilityColumn(ctx context.Context) error {
 	columnTypes, err := TableColumnTypes(ctx, s.db, "loader")
 	if err != nil {
 		return err
@@ -162,14 +162,14 @@ func (s *LoaderStore) ensureLoaderCapabilityColumn(ctx context.Context) error {
 	return nil
 }
 
-func (s *LoaderStore) ensureLoaderAgentIDColumn(ctx context.Context) error {
+func (s *loaderStore) ensureLoaderAgentIDColumn(ctx context.Context) error {
 	if err := ensureColumn(ctx, s.db, "loader", "agent_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return fmt.Errorf("ensure loader agent_id column: %w", err)
 	}
 	return nil
 }
 
-func (s *LoaderStore) migrateLoaderTimestampPrecision(ctx context.Context) error {
+func (s *loaderStore) migrateLoaderTimestampPrecision(ctx context.Context) error {
 	statements := []string{
 		fmt.Sprintf(`UPDATE loader_trigger SET next_fire_at = next_fire_at * 1000 WHERE next_fire_at > 0 AND next_fire_at < %d`, storedUnixMillisecondThreshold),
 		fmt.Sprintf(`UPDATE loader_trigger SET last_fired_at = last_fired_at * 1000 WHERE last_fired_at > 0 AND last_fired_at < %d`, storedUnixMillisecondThreshold),
@@ -185,7 +185,7 @@ func (s *LoaderStore) migrateLoaderTimestampPrecision(ctx context.Context) error
 	return nil
 }
 
-func (s *LoaderStore) CreateLoader(ctx context.Context, item Loader) (Loader, error) {
+func (s *loaderStore) CreateLoader(ctx context.Context, item Loader) (Loader, error) {
 	normalized, err := loaders.NormalizeLoader(item, true)
 	if err != nil {
 		return Loader{}, err
@@ -234,7 +234,7 @@ func (s *LoaderStore) CreateLoader(ctx context.Context, item Loader) (Loader, er
 	return normalized, nil
 }
 
-func (s *LoaderStore) UpdateLoader(ctx context.Context, item Loader) (Loader, error) {
+func (s *loaderStore) UpdateLoader(ctx context.Context, item Loader) (Loader, error) {
 	normalized, err := loaders.NormalizeLoader(item, false)
 	if err != nil {
 		return Loader{}, err
@@ -299,7 +299,7 @@ func (s *LoaderStore) UpdateLoader(ctx context.Context, item Loader) (Loader, er
 	return normalized, nil
 }
 
-func (s *LoaderStore) UpsertManagedLoader(ctx context.Context, item Loader) (Loader, error) {
+func (s *loaderStore) UpsertManagedLoader(ctx context.Context, item Loader) (Loader, error) {
 	normalized, err := loaders.NormalizeLoader(item, false)
 	if err != nil {
 		return Loader{}, err
@@ -316,7 +316,7 @@ func (s *LoaderStore) UpsertManagedLoader(ctx context.Context, item Loader) (Loa
 	return s.CreateLoader(ctx, normalized)
 }
 
-func (s *LoaderStore) getLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
+func (s *loaderStore) getLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
 	item, err := s.GetLoader(ctx, loaderID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -327,11 +327,11 @@ func (s *LoaderStore) getLoaderIfExists(ctx context.Context, loaderID string) (L
 	return item, true, nil
 }
 
-func (s *LoaderStore) GetLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
+func (s *loaderStore) GetLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
 	return s.getLoaderIfExists(ctx, loaderID)
 }
 
-func (s *LoaderStore) DeleteLoader(ctx context.Context, loaderID string) error {
+func (s *loaderStore) DeleteLoader(ctx context.Context, loaderID string) error {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return fmt.Errorf("loader id is required")
@@ -347,7 +347,7 @@ func (s *LoaderStore) DeleteLoader(ctx context.Context, loaderID string) error {
 	return nil
 }
 
-func (s *LoaderStore) DisableLoadersByDefaultAgent(ctx context.Context, agentID string) (int, error) {
+func (s *loaderStore) DisableLoadersByDefaultAgent(ctx context.Context, agentID string) (int, error) {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return 0, fmt.Errorf("agent id is required")
@@ -361,7 +361,7 @@ func (s *LoaderStore) DisableLoadersByDefaultAgent(ctx context.Context, agentID 
 	return int(rows), nil
 }
 
-func (s *LoaderStore) ListLoaderSummaries(ctx context.Context) ([]domain.LoaderSummary, error) {
+func (s *loaderStore) ListLoaderSummaries(ctx context.Context) ([]domain.LoaderSummary, error) {
 	rows, err := s.db.QueryContext(ctx, loaders.SelectLoaderSummarySQL()+`
         ORDER BY l.updated_at DESC, l.created_at DESC, l.id DESC`)
 	if err != nil {
@@ -383,7 +383,7 @@ func (s *LoaderStore) ListLoaderSummaries(ctx context.Context) ([]domain.LoaderS
 	return items, nil
 }
 
-func (s *LoaderStore) GetLoader(ctx context.Context, loaderID string) (Loader, error) {
+func (s *loaderStore) GetLoader(ctx context.Context, loaderID string) (Loader, error) {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return Loader{}, fmt.Errorf("loader id is required")
@@ -407,7 +407,7 @@ func (s *LoaderStore) GetLoader(ctx context.Context, loaderID string) (Loader, e
 	return item, nil
 }
 
-func (s *LoaderStore) ListLoaders(ctx context.Context) ([]Loader, error) {
+func (s *loaderStore) ListLoaders(ctx context.Context) ([]Loader, error) {
 	summaries, err := s.ListLoaderSummaries(ctx)
 	if err != nil {
 		return nil, err
@@ -423,7 +423,7 @@ func (s *LoaderStore) ListLoaders(ctx context.Context) ([]Loader, error) {
 	return items, nil
 }
 
-func (s *LoaderStore) ListManagedLoaders(ctx context.Context, projectID string) ([]Loader, error) {
+func (s *loaderStore) ListManagedLoaders(ctx context.Context, projectID string) ([]Loader, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return nil, fmt.Errorf("project id is required")
@@ -455,7 +455,7 @@ func (s *LoaderStore) ListManagedLoaders(ctx context.Context, projectID string) 
 	return items, nil
 }
 
-func (s *LoaderStore) hydrateLoaderSummaryCounts(ctx context.Context, summary *domain.LoaderSummary) error {
+func (s *loaderStore) hydrateLoaderSummaryCounts(ctx context.Context, summary *domain.LoaderSummary) error {
 	if summary == nil || strings.TrimSpace(summary.ID) == "" {
 		return nil
 	}
@@ -478,7 +478,7 @@ func (s *LoaderStore) hydrateLoaderSummaryCounts(ctx context.Context, summary *d
 	return nil
 }
 
-func (s *LoaderStore) ReplaceLoaderTriggers(ctx context.Context, loaderID string, triggers []domain.LoaderTrigger) ([]domain.LoaderTrigger, error) {
+func (s *loaderStore) ReplaceLoaderTriggers(ctx context.Context, loaderID string, triggers []domain.LoaderTrigger) ([]domain.LoaderTrigger, error) {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return nil, fmt.Errorf("loader id is required")
@@ -580,7 +580,7 @@ func (s *LoaderStore) ReplaceLoaderTriggers(ctx context.Context, loaderID string
 	return normalized, nil
 }
 
-func (s *LoaderStore) listLoaderTriggers(ctx context.Context, loaderID string) ([]domain.LoaderTrigger, error) {
+func (s *loaderStore) listLoaderTriggers(ctx context.Context, loaderID string) ([]domain.LoaderTrigger, error) {
 	rows, err := s.db.QueryContext(ctx, loaders.SelectLoaderTriggerSQL()+` WHERE loader_id = ? ORDER BY kind ASC, trigger_id ASC`, loaderID)
 	if err != nil {
 		return nil, fmt.Errorf("query loader triggers: %w", err)
@@ -601,7 +601,7 @@ func (s *LoaderStore) listLoaderTriggers(ctx context.Context, loaderID string) (
 	return items, nil
 }
 
-func (s *LoaderStore) SetLoaderEnabled(ctx context.Context, loaderID string, enabled bool) error {
+func (s *loaderStore) SetLoaderEnabled(ctx context.Context, loaderID string, enabled bool) error {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return fmt.Errorf("loader id is required")
@@ -654,7 +654,7 @@ func (s *LoaderStore) SetLoaderEnabled(ctx context.Context, loaderID string, ena
 	return nil
 }
 
-func (s *LoaderStore) SetLoaderTriggerEnabled(ctx context.Context, loaderID, triggerID string, enabled bool) error {
+func (s *loaderStore) SetLoaderTriggerEnabled(ctx context.Context, loaderID, triggerID string, enabled bool) error {
 	loaderID = strings.TrimSpace(loaderID)
 	triggerID = strings.TrimSpace(triggerID)
 	if loaderID == "" || triggerID == "" {
@@ -689,7 +689,7 @@ func (s *LoaderStore) SetLoaderTriggerEnabled(ctx context.Context, loaderID, tri
 	return nil
 }
 
-func (s *LoaderStore) UpdateLoaderLastError(ctx context.Context, loaderID, lastError string) error {
+func (s *loaderStore) UpdateLoaderLastError(ctx context.Context, loaderID, lastError string) error {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return fmt.Errorf("loader id is required")
@@ -701,7 +701,7 @@ func (s *LoaderStore) UpdateLoaderLastError(ctx context.Context, loaderID, lastE
 	return nil
 }
 
-func (s *LoaderStore) MarkLoaderTriggerFired(ctx context.Context, loaderID, triggerID string, lastFiredAt, nextFireAt time.Time) error {
+func (s *loaderStore) MarkLoaderTriggerFired(ctx context.Context, loaderID, triggerID string, lastFiredAt, nextFireAt time.Time) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE loader_trigger SET last_fired_at = ?, next_fire_at = ? WHERE loader_id = ? AND trigger_id = ?`, domain.NonZeroTimeUnixMilli(lastFiredAt), domain.NonZeroTimeUnixMilli(nextFireAt), strings.TrimSpace(loaderID), strings.TrimSpace(triggerID))
 	if err != nil {
 		return fmt.Errorf("update loader trigger fire state: %w", err)
@@ -709,7 +709,7 @@ func (s *LoaderStore) MarkLoaderTriggerFired(ctx context.Context, loaderID, trig
 	return nil
 }
 
-func (s *LoaderStore) CreateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
+func (s *loaderStore) CreateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO loader_run(
         loader_id, run_id, trigger_id, trigger_kind, trigger_source, status, started_at, completed_at, duration_ms, error, result_json, payload_json, source_script_sha256, artifacts_dir
     ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -734,7 +734,7 @@ func (s *LoaderStore) CreateLoaderRun(ctx context.Context, run domain.LoaderRunS
 	return nil
 }
 
-func (s *LoaderStore) UpdateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
+func (s *loaderStore) UpdateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
 	result, err := s.db.ExecContext(ctx, `UPDATE loader_run SET
         trigger_id = ?, trigger_kind = ?, trigger_source = ?, status = ?, started_at = ?, completed_at = ?, duration_ms = ?, error = ?, result_json = ?, payload_json = ?, source_script_sha256 = ?, artifacts_dir = ?
         WHERE loader_id = ? AND run_id = ?`,
@@ -763,7 +763,7 @@ func (s *LoaderStore) UpdateLoaderRun(ctx context.Context, run domain.LoaderRunS
 	return nil
 }
 
-func (s *LoaderStore) GetLoaderRun(ctx context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {
+func (s *loaderStore) GetLoaderRun(ctx context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {
 	row := s.db.QueryRowContext(ctx, loaders.SelectLoaderRunSQL()+` WHERE loader_id = ? AND run_id = ?`, strings.TrimSpace(loaderID), strings.TrimSpace(runID))
 	item, err := loaders.ScanLoaderRun(row.Scan)
 	if err != nil {
@@ -776,7 +776,7 @@ func (s *LoaderStore) GetLoaderRun(ctx context.Context, loaderID, runID string) 
 	return item, nil
 }
 
-func (s *LoaderStore) ListLoaderRuns(ctx context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error) {
+func (s *loaderStore) ListLoaderRuns(ctx context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -800,7 +800,7 @@ func (s *LoaderStore) ListLoaderRuns(ctx context.Context, loaderID string, limit
 	return items, nil
 }
 
-func (s *LoaderStore) ListRecentLoaderRuns(ctx context.Context, limit int) ([]domain.LoaderRunSummary, error) {
+func (s *loaderStore) ListRecentLoaderRuns(ctx context.Context, limit int) ([]domain.LoaderRunSummary, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -824,7 +824,7 @@ func (s *LoaderStore) ListRecentLoaderRuns(ctx context.Context, limit int) ([]do
 	return items, nil
 }
 
-func (s *LoaderStore) AddLoaderEvent(ctx context.Context, event domain.LoaderEvent) error {
+func (s *loaderStore) AddLoaderEvent(ctx context.Context, event domain.LoaderEvent) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO loader_event(
         loader_id, event_id, run_id, trigger_id, type, level, message, payload_json, linked_session_id, linked_cell_id, linked_agent_session_id, created_at
     ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -847,7 +847,7 @@ func (s *LoaderStore) AddLoaderEvent(ctx context.Context, event domain.LoaderEve
 	return nil
 }
 
-func (s *LoaderStore) ListLoaderEvents(ctx context.Context, loaderID string, limit int) ([]domain.LoaderEvent, error) {
+func (s *loaderStore) ListLoaderEvents(ctx context.Context, loaderID string, limit int) ([]domain.LoaderEvent, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -871,7 +871,7 @@ func (s *LoaderStore) ListLoaderEvents(ctx context.Context, loaderID string, lim
 	return items, nil
 }
 
-func (s *LoaderStore) GetLoaderState(ctx context.Context, loaderID, key string) (string, bool, error) {
+func (s *loaderStore) GetLoaderState(ctx context.Context, loaderID, key string) (string, bool, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT value_json FROM loader_state WHERE loader_id = ? AND key = ?`, strings.TrimSpace(loaderID), strings.TrimSpace(key))
 	var value string
 	if err := row.Scan(&value); err != nil {
@@ -883,7 +883,7 @@ func (s *LoaderStore) GetLoaderState(ctx context.Context, loaderID, key string) 
 	return value, true, nil
 }
 
-func (s *LoaderStore) SetLoaderState(ctx context.Context, loaderID, key, valueJSON string) error {
+func (s *loaderStore) SetLoaderState(ctx context.Context, loaderID, key, valueJSON string) error {
 	loaderID = strings.TrimSpace(loaderID)
 	key = strings.TrimSpace(key)
 	if loaderID == "" || key == "" {
@@ -897,7 +897,7 @@ func (s *LoaderStore) SetLoaderState(ctx context.Context, loaderID, key, valueJS
 	return nil
 }
 
-func (s *LoaderStore) DeleteLoaderState(ctx context.Context, loaderID, key string) error {
+func (s *loaderStore) DeleteLoaderState(ctx context.Context, loaderID, key string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM loader_state WHERE loader_id = ? AND key = ?`, strings.TrimSpace(loaderID), strings.TrimSpace(key))
 	if err != nil {
 		return fmt.Errorf("delete loader state: %w", err)
@@ -905,7 +905,7 @@ func (s *LoaderStore) DeleteLoaderState(ctx context.Context, loaderID, key strin
 	return nil
 }
 
-func (s *LoaderStore) GetLoaderBinding(ctx context.Context, loaderID string) (domain.LoaderBinding, bool, error) {
+func (s *loaderStore) GetLoaderBinding(ctx context.Context, loaderID string) (domain.LoaderBinding, bool, error) {
 	row := s.db.QueryRowContext(ctx, loaders.SelectLoaderBindingSQL()+` WHERE loader_id = ?`, strings.TrimSpace(loaderID))
 	item, err := loaders.ScanLoaderBinding(row.Scan)
 	if err != nil {
@@ -917,7 +917,7 @@ func (s *LoaderStore) GetLoaderBinding(ctx context.Context, loaderID string) (do
 	return item, true, nil
 }
 
-func (s *LoaderStore) UpsertLoaderBinding(ctx context.Context, binding domain.LoaderBinding) error {
+func (s *loaderStore) UpsertLoaderBinding(ctx context.Context, binding domain.LoaderBinding) error {
 	binding.LoaderID = strings.TrimSpace(binding.LoaderID)
 	binding.SessionID = strings.TrimSpace(binding.SessionID)
 	if binding.LoaderID == "" || binding.SessionID == "" {

--- a/pkg/storage/configstore/loader_store.go
+++ b/pkg/storage/configstore/loader_store.go
@@ -13,7 +13,12 @@ import (
 	"time"
 )
 
-func (s *ConfigStore) ensureLoaderSchema(ctx context.Context) error {
+// LoaderStore owns loader definitions, triggers, runs, and loader events.
+type LoaderStore struct {
+	db *sql.DB
+}
+
+func (s *LoaderStore) ensureLoaderSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS loader (
             id TEXT PRIMARY KEY,
@@ -121,11 +126,11 @@ func (s *ConfigStore) ensureLoaderSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) EnsureLoaderSchema(ctx context.Context) error {
+func (s *LoaderStore) EnsureLoaderSchema(ctx context.Context) error {
 	return s.ensureLoaderSchema(ctx)
 }
 
-func (s *ConfigStore) ensureLoaderManagedColumns(ctx context.Context) error {
+func (s *LoaderStore) ensureLoaderManagedColumns(ctx context.Context) error {
 	columns := []struct {
 		name       string
 		definition string
@@ -143,8 +148,8 @@ func (s *ConfigStore) ensureLoaderManagedColumns(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) ensureLoaderCapabilityColumn(ctx context.Context) error {
-	columnTypes, err := s.tableColumnTypes(ctx, "loader")
+func (s *LoaderStore) ensureLoaderCapabilityColumn(ctx context.Context) error {
+	columnTypes, err := TableColumnTypes(ctx, s.db, "loader")
 	if err != nil {
 		return err
 	}
@@ -157,14 +162,14 @@ func (s *ConfigStore) ensureLoaderCapabilityColumn(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) ensureLoaderAgentIDColumn(ctx context.Context) error {
+func (s *LoaderStore) ensureLoaderAgentIDColumn(ctx context.Context) error {
 	if err := ensureColumn(ctx, s.db, "loader", "agent_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return fmt.Errorf("ensure loader agent_id column: %w", err)
 	}
 	return nil
 }
 
-func (s *ConfigStore) migrateLoaderTimestampPrecision(ctx context.Context) error {
+func (s *LoaderStore) migrateLoaderTimestampPrecision(ctx context.Context) error {
 	statements := []string{
 		fmt.Sprintf(`UPDATE loader_trigger SET next_fire_at = next_fire_at * 1000 WHERE next_fire_at > 0 AND next_fire_at < %d`, storedUnixMillisecondThreshold),
 		fmt.Sprintf(`UPDATE loader_trigger SET last_fired_at = last_fired_at * 1000 WHERE last_fired_at > 0 AND last_fired_at < %d`, storedUnixMillisecondThreshold),
@@ -180,7 +185,7 @@ func (s *ConfigStore) migrateLoaderTimestampPrecision(ctx context.Context) error
 	return nil
 }
 
-func (s *ConfigStore) CreateLoader(ctx context.Context, item Loader) (Loader, error) {
+func (s *LoaderStore) CreateLoader(ctx context.Context, item Loader) (Loader, error) {
 	normalized, err := loaders.NormalizeLoader(item, true)
 	if err != nil {
 		return Loader{}, err
@@ -229,7 +234,7 @@ func (s *ConfigStore) CreateLoader(ctx context.Context, item Loader) (Loader, er
 	return normalized, nil
 }
 
-func (s *ConfigStore) UpdateLoader(ctx context.Context, item Loader) (Loader, error) {
+func (s *LoaderStore) UpdateLoader(ctx context.Context, item Loader) (Loader, error) {
 	normalized, err := loaders.NormalizeLoader(item, false)
 	if err != nil {
 		return Loader{}, err
@@ -294,7 +299,7 @@ func (s *ConfigStore) UpdateLoader(ctx context.Context, item Loader) (Loader, er
 	return normalized, nil
 }
 
-func (s *ConfigStore) UpsertManagedLoader(ctx context.Context, item Loader) (Loader, error) {
+func (s *LoaderStore) UpsertManagedLoader(ctx context.Context, item Loader) (Loader, error) {
 	normalized, err := loaders.NormalizeLoader(item, false)
 	if err != nil {
 		return Loader{}, err
@@ -311,7 +316,7 @@ func (s *ConfigStore) UpsertManagedLoader(ctx context.Context, item Loader) (Loa
 	return s.CreateLoader(ctx, normalized)
 }
 
-func (s *ConfigStore) getLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
+func (s *LoaderStore) getLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
 	item, err := s.GetLoader(ctx, loaderID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -322,11 +327,11 @@ func (s *ConfigStore) getLoaderIfExists(ctx context.Context, loaderID string) (L
 	return item, true, nil
 }
 
-func (s *ConfigStore) GetLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
+func (s *LoaderStore) GetLoaderIfExists(ctx context.Context, loaderID string) (Loader, bool, error) {
 	return s.getLoaderIfExists(ctx, loaderID)
 }
 
-func (s *ConfigStore) DeleteLoader(ctx context.Context, loaderID string) error {
+func (s *LoaderStore) DeleteLoader(ctx context.Context, loaderID string) error {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return fmt.Errorf("loader id is required")
@@ -342,7 +347,7 @@ func (s *ConfigStore) DeleteLoader(ctx context.Context, loaderID string) error {
 	return nil
 }
 
-func (s *ConfigStore) DisableLoadersByDefaultAgent(ctx context.Context, agentID string) (int, error) {
+func (s *LoaderStore) DisableLoadersByDefaultAgent(ctx context.Context, agentID string) (int, error) {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return 0, fmt.Errorf("agent id is required")
@@ -356,7 +361,7 @@ func (s *ConfigStore) DisableLoadersByDefaultAgent(ctx context.Context, agentID 
 	return int(rows), nil
 }
 
-func (s *ConfigStore) ListLoaderSummaries(ctx context.Context) ([]domain.LoaderSummary, error) {
+func (s *LoaderStore) ListLoaderSummaries(ctx context.Context) ([]domain.LoaderSummary, error) {
 	rows, err := s.db.QueryContext(ctx, loaders.SelectLoaderSummarySQL()+`
         ORDER BY l.updated_at DESC, l.created_at DESC, l.id DESC`)
 	if err != nil {
@@ -378,7 +383,7 @@ func (s *ConfigStore) ListLoaderSummaries(ctx context.Context) ([]domain.LoaderS
 	return items, nil
 }
 
-func (s *ConfigStore) GetLoader(ctx context.Context, loaderID string) (Loader, error) {
+func (s *LoaderStore) GetLoader(ctx context.Context, loaderID string) (Loader, error) {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return Loader{}, fmt.Errorf("loader id is required")
@@ -402,7 +407,7 @@ func (s *ConfigStore) GetLoader(ctx context.Context, loaderID string) (Loader, e
 	return item, nil
 }
 
-func (s *ConfigStore) ListLoaders(ctx context.Context) ([]Loader, error) {
+func (s *LoaderStore) ListLoaders(ctx context.Context) ([]Loader, error) {
 	summaries, err := s.ListLoaderSummaries(ctx)
 	if err != nil {
 		return nil, err
@@ -418,7 +423,7 @@ func (s *ConfigStore) ListLoaders(ctx context.Context) ([]Loader, error) {
 	return items, nil
 }
 
-func (s *ConfigStore) ListManagedLoaders(ctx context.Context, projectID string) ([]Loader, error) {
+func (s *LoaderStore) ListManagedLoaders(ctx context.Context, projectID string) ([]Loader, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return nil, fmt.Errorf("project id is required")
@@ -450,7 +455,7 @@ func (s *ConfigStore) ListManagedLoaders(ctx context.Context, projectID string) 
 	return items, nil
 }
 
-func (s *ConfigStore) hydrateLoaderSummaryCounts(ctx context.Context, summary *domain.LoaderSummary) error {
+func (s *LoaderStore) hydrateLoaderSummaryCounts(ctx context.Context, summary *domain.LoaderSummary) error {
 	if summary == nil || strings.TrimSpace(summary.ID) == "" {
 		return nil
 	}
@@ -473,7 +478,7 @@ func (s *ConfigStore) hydrateLoaderSummaryCounts(ctx context.Context, summary *d
 	return nil
 }
 
-func (s *ConfigStore) ReplaceLoaderTriggers(ctx context.Context, loaderID string, triggers []domain.LoaderTrigger) ([]domain.LoaderTrigger, error) {
+func (s *LoaderStore) ReplaceLoaderTriggers(ctx context.Context, loaderID string, triggers []domain.LoaderTrigger) ([]domain.LoaderTrigger, error) {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return nil, fmt.Errorf("loader id is required")
@@ -575,7 +580,7 @@ func (s *ConfigStore) ReplaceLoaderTriggers(ctx context.Context, loaderID string
 	return normalized, nil
 }
 
-func (s *ConfigStore) listLoaderTriggers(ctx context.Context, loaderID string) ([]domain.LoaderTrigger, error) {
+func (s *LoaderStore) listLoaderTriggers(ctx context.Context, loaderID string) ([]domain.LoaderTrigger, error) {
 	rows, err := s.db.QueryContext(ctx, loaders.SelectLoaderTriggerSQL()+` WHERE loader_id = ? ORDER BY kind ASC, trigger_id ASC`, loaderID)
 	if err != nil {
 		return nil, fmt.Errorf("query loader triggers: %w", err)
@@ -596,7 +601,7 @@ func (s *ConfigStore) listLoaderTriggers(ctx context.Context, loaderID string) (
 	return items, nil
 }
 
-func (s *ConfigStore) SetLoaderEnabled(ctx context.Context, loaderID string, enabled bool) error {
+func (s *LoaderStore) SetLoaderEnabled(ctx context.Context, loaderID string, enabled bool) error {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return fmt.Errorf("loader id is required")
@@ -649,7 +654,7 @@ func (s *ConfigStore) SetLoaderEnabled(ctx context.Context, loaderID string, ena
 	return nil
 }
 
-func (s *ConfigStore) SetLoaderTriggerEnabled(ctx context.Context, loaderID, triggerID string, enabled bool) error {
+func (s *LoaderStore) SetLoaderTriggerEnabled(ctx context.Context, loaderID, triggerID string, enabled bool) error {
 	loaderID = strings.TrimSpace(loaderID)
 	triggerID = strings.TrimSpace(triggerID)
 	if loaderID == "" || triggerID == "" {
@@ -684,7 +689,7 @@ func (s *ConfigStore) SetLoaderTriggerEnabled(ctx context.Context, loaderID, tri
 	return nil
 }
 
-func (s *ConfigStore) UpdateLoaderLastError(ctx context.Context, loaderID, lastError string) error {
+func (s *LoaderStore) UpdateLoaderLastError(ctx context.Context, loaderID, lastError string) error {
 	loaderID = strings.TrimSpace(loaderID)
 	if loaderID == "" {
 		return fmt.Errorf("loader id is required")
@@ -696,7 +701,7 @@ func (s *ConfigStore) UpdateLoaderLastError(ctx context.Context, loaderID, lastE
 	return nil
 }
 
-func (s *ConfigStore) MarkLoaderTriggerFired(ctx context.Context, loaderID, triggerID string, lastFiredAt, nextFireAt time.Time) error {
+func (s *LoaderStore) MarkLoaderTriggerFired(ctx context.Context, loaderID, triggerID string, lastFiredAt, nextFireAt time.Time) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE loader_trigger SET last_fired_at = ?, next_fire_at = ? WHERE loader_id = ? AND trigger_id = ?`, domain.NonZeroTimeUnixMilli(lastFiredAt), domain.NonZeroTimeUnixMilli(nextFireAt), strings.TrimSpace(loaderID), strings.TrimSpace(triggerID))
 	if err != nil {
 		return fmt.Errorf("update loader trigger fire state: %w", err)
@@ -704,7 +709,7 @@ func (s *ConfigStore) MarkLoaderTriggerFired(ctx context.Context, loaderID, trig
 	return nil
 }
 
-func (s *ConfigStore) CreateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
+func (s *LoaderStore) CreateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO loader_run(
         loader_id, run_id, trigger_id, trigger_kind, trigger_source, status, started_at, completed_at, duration_ms, error, result_json, payload_json, source_script_sha256, artifacts_dir
     ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -729,7 +734,7 @@ func (s *ConfigStore) CreateLoaderRun(ctx context.Context, run domain.LoaderRunS
 	return nil
 }
 
-func (s *ConfigStore) UpdateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
+func (s *LoaderStore) UpdateLoaderRun(ctx context.Context, run domain.LoaderRunSummary) error {
 	result, err := s.db.ExecContext(ctx, `UPDATE loader_run SET
         trigger_id = ?, trigger_kind = ?, trigger_source = ?, status = ?, started_at = ?, completed_at = ?, duration_ms = ?, error = ?, result_json = ?, payload_json = ?, source_script_sha256 = ?, artifacts_dir = ?
         WHERE loader_id = ? AND run_id = ?`,
@@ -758,7 +763,7 @@ func (s *ConfigStore) UpdateLoaderRun(ctx context.Context, run domain.LoaderRunS
 	return nil
 }
 
-func (s *ConfigStore) GetLoaderRun(ctx context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {
+func (s *LoaderStore) GetLoaderRun(ctx context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {
 	row := s.db.QueryRowContext(ctx, loaders.SelectLoaderRunSQL()+` WHERE loader_id = ? AND run_id = ?`, strings.TrimSpace(loaderID), strings.TrimSpace(runID))
 	item, err := loaders.ScanLoaderRun(row.Scan)
 	if err != nil {
@@ -771,7 +776,7 @@ func (s *ConfigStore) GetLoaderRun(ctx context.Context, loaderID, runID string) 
 	return item, nil
 }
 
-func (s *ConfigStore) ListLoaderRuns(ctx context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error) {
+func (s *LoaderStore) ListLoaderRuns(ctx context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -795,7 +800,7 @@ func (s *ConfigStore) ListLoaderRuns(ctx context.Context, loaderID string, limit
 	return items, nil
 }
 
-func (s *ConfigStore) ListRecentLoaderRuns(ctx context.Context, limit int) ([]domain.LoaderRunSummary, error) {
+func (s *LoaderStore) ListRecentLoaderRuns(ctx context.Context, limit int) ([]domain.LoaderRunSummary, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -819,7 +824,7 @@ func (s *ConfigStore) ListRecentLoaderRuns(ctx context.Context, limit int) ([]do
 	return items, nil
 }
 
-func (s *ConfigStore) AddLoaderEvent(ctx context.Context, event domain.LoaderEvent) error {
+func (s *LoaderStore) AddLoaderEvent(ctx context.Context, event domain.LoaderEvent) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO loader_event(
         loader_id, event_id, run_id, trigger_id, type, level, message, payload_json, linked_session_id, linked_cell_id, linked_agent_session_id, created_at
     ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -842,7 +847,7 @@ func (s *ConfigStore) AddLoaderEvent(ctx context.Context, event domain.LoaderEve
 	return nil
 }
 
-func (s *ConfigStore) ListLoaderEvents(ctx context.Context, loaderID string, limit int) ([]domain.LoaderEvent, error) {
+func (s *LoaderStore) ListLoaderEvents(ctx context.Context, loaderID string, limit int) ([]domain.LoaderEvent, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -866,7 +871,7 @@ func (s *ConfigStore) ListLoaderEvents(ctx context.Context, loaderID string, lim
 	return items, nil
 }
 
-func (s *ConfigStore) GetLoaderState(ctx context.Context, loaderID, key string) (string, bool, error) {
+func (s *LoaderStore) GetLoaderState(ctx context.Context, loaderID, key string) (string, bool, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT value_json FROM loader_state WHERE loader_id = ? AND key = ?`, strings.TrimSpace(loaderID), strings.TrimSpace(key))
 	var value string
 	if err := row.Scan(&value); err != nil {
@@ -878,7 +883,7 @@ func (s *ConfigStore) GetLoaderState(ctx context.Context, loaderID, key string) 
 	return value, true, nil
 }
 
-func (s *ConfigStore) SetLoaderState(ctx context.Context, loaderID, key, valueJSON string) error {
+func (s *LoaderStore) SetLoaderState(ctx context.Context, loaderID, key, valueJSON string) error {
 	loaderID = strings.TrimSpace(loaderID)
 	key = strings.TrimSpace(key)
 	if loaderID == "" || key == "" {
@@ -892,7 +897,7 @@ func (s *ConfigStore) SetLoaderState(ctx context.Context, loaderID, key, valueJS
 	return nil
 }
 
-func (s *ConfigStore) DeleteLoaderState(ctx context.Context, loaderID, key string) error {
+func (s *LoaderStore) DeleteLoaderState(ctx context.Context, loaderID, key string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM loader_state WHERE loader_id = ? AND key = ?`, strings.TrimSpace(loaderID), strings.TrimSpace(key))
 	if err != nil {
 		return fmt.Errorf("delete loader state: %w", err)
@@ -900,7 +905,7 @@ func (s *ConfigStore) DeleteLoaderState(ctx context.Context, loaderID, key strin
 	return nil
 }
 
-func (s *ConfigStore) GetLoaderBinding(ctx context.Context, loaderID string) (domain.LoaderBinding, bool, error) {
+func (s *LoaderStore) GetLoaderBinding(ctx context.Context, loaderID string) (domain.LoaderBinding, bool, error) {
 	row := s.db.QueryRowContext(ctx, loaders.SelectLoaderBindingSQL()+` WHERE loader_id = ?`, strings.TrimSpace(loaderID))
 	item, err := loaders.ScanLoaderBinding(row.Scan)
 	if err != nil {
@@ -912,7 +917,7 @@ func (s *ConfigStore) GetLoaderBinding(ctx context.Context, loaderID string) (do
 	return item, true, nil
 }
 
-func (s *ConfigStore) UpsertLoaderBinding(ctx context.Context, binding domain.LoaderBinding) error {
+func (s *LoaderStore) UpsertLoaderBinding(ctx context.Context, binding domain.LoaderBinding) error {
 	binding.LoaderID = strings.TrimSpace(binding.LoaderID)
 	binding.SessionID = strings.TrimSpace(binding.SessionID)
 	if binding.LoaderID == "" || binding.SessionID == "" {

--- a/pkg/storage/configstore/project_schema.go
+++ b/pkg/storage/configstore/project_schema.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (s *ConfigStore) ensureProjectSchema(ctx context.Context) error {
+func (s *ProjectStore) ensureProjectSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS project (
 			id TEXT PRIMARY KEY,
@@ -109,11 +109,11 @@ func (s *ConfigStore) ensureProjectSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) EnsureProjectSchema(ctx context.Context) error {
+func (s *ProjectStore) EnsureProjectSchema(ctx context.Context) error {
 	return s.ensureProjectSchema(ctx)
 }
 
-func (s *ConfigStore) ensureManagedResourceColumns(ctx context.Context) error {
+func (s *ProjectStore) ensureManagedResourceColumns(ctx context.Context) error {
 	agentColumns := []struct {
 		name       string
 		definition string

--- a/pkg/storage/configstore/project_schema.go
+++ b/pkg/storage/configstore/project_schema.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (s *ProjectStore) ensureProjectSchema(ctx context.Context) error {
+func (s *projectStore) ensureProjectSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS project (
 			id TEXT PRIMARY KEY,
@@ -109,11 +109,11 @@ func (s *ProjectStore) ensureProjectSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *ProjectStore) EnsureProjectSchema(ctx context.Context) error {
+func (s *projectStore) EnsureProjectSchema(ctx context.Context) error {
 	return s.ensureProjectSchema(ctx)
 }
 
-func (s *ProjectStore) ensureManagedResourceColumns(ctx context.Context) error {
+func (s *projectStore) ensureManagedResourceColumns(ctx context.Context) error {
 	agentColumns := []struct {
 		name       string
 		definition string

--- a/pkg/storage/configstore/project_session.go
+++ b/pkg/storage/configstore/project_session.go
@@ -9,7 +9,7 @@ import (
 	"agent-compose/pkg/projects"
 )
 
-func (s *ProjectStore) ListProjectSessionRuns(ctx context.Context, filter domain.ProjectSessionRelationFilter) ([]ProjectRunRecord, error) {
+func (s *projectStore) ListProjectSessionRuns(ctx context.Context, filter domain.ProjectSessionRelationFilter) ([]ProjectRunRecord, error) {
 	query := projects.SelectProjectRunSQL() + ` WHERE session_id != ''`
 	args := make([]any, 0, 4+len(filter.Statuses))
 	if projectID := strings.TrimSpace(filter.ProjectID); projectID != "" {
@@ -61,7 +61,7 @@ func (s *ProjectStore) ListProjectSessionRuns(ctx context.Context, filter domain
 	return items, nil
 }
 
-func (s *ProjectStore) ListProjectRunsForSession(ctx context.Context, sessionID string) ([]ProjectRunRecord, error) {
+func (s *projectStore) ListProjectRunsForSession(ctx context.Context, sessionID string) ([]ProjectRunRecord, error) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
 		return nil, fmt.Errorf("session id is required")

--- a/pkg/storage/configstore/project_session.go
+++ b/pkg/storage/configstore/project_session.go
@@ -9,7 +9,7 @@ import (
 	"agent-compose/pkg/projects"
 )
 
-func (s *ConfigStore) ListProjectSessionRuns(ctx context.Context, filter domain.ProjectSessionRelationFilter) ([]ProjectRunRecord, error) {
+func (s *ProjectStore) ListProjectSessionRuns(ctx context.Context, filter domain.ProjectSessionRelationFilter) ([]ProjectRunRecord, error) {
 	query := projects.SelectProjectRunSQL() + ` WHERE session_id != ''`
 	args := make([]any, 0, 4+len(filter.Statuses))
 	if projectID := strings.TrimSpace(filter.ProjectID); projectID != "" {
@@ -61,7 +61,7 @@ func (s *ConfigStore) ListProjectSessionRuns(ctx context.Context, filter domain.
 	return items, nil
 }
 
-func (s *ConfigStore) ListProjectRunsForSession(ctx context.Context, sessionID string) ([]ProjectRunRecord, error) {
+func (s *ProjectStore) ListProjectRunsForSession(ctx context.Context, sessionID string) ([]ProjectRunRecord, error) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
 		return nil, fmt.Errorf("session id is required")

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -14,7 +14,12 @@ import (
 	"agent-compose/pkg/runs"
 )
 
-func (s *ConfigStore) UpsertProject(ctx context.Context, project ProjectRecord) (ProjectRecord, error) {
+// ProjectStore owns projects, revisions, agents, schedulers, runs, and sessions.
+type ProjectStore struct {
+	db *sql.DB
+}
+
+func (s *ProjectStore) UpsertProject(ctx context.Context, project ProjectRecord) (ProjectRecord, error) {
 	project, err := projects.NormalizeRecord(project)
 	if err != nil {
 		return ProjectRecord{}, err
@@ -56,7 +61,7 @@ func (s *ConfigStore) UpsertProject(ctx context.Context, project ProjectRecord) 
 	return s.GetProject(ctx, project.ID)
 }
 
-func (s *ConfigStore) MarkProjectRemoved(ctx context.Context, projectID string) (ProjectRecord, error) {
+func (s *ProjectStore) MarkProjectRemoved(ctx context.Context, projectID string) (ProjectRecord, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return ProjectRecord{}, fmt.Errorf("project id is required")
@@ -83,7 +88,7 @@ func (s *ConfigStore) MarkProjectRemoved(ctx context.Context, projectID string) 
 	return s.getProjectRequired(ctx, projectID, true)
 }
 
-func (s *ConfigStore) SaveProjectRevision(ctx context.Context, revision ProjectRevisionRecord) (ProjectRevisionRecord, bool, error) {
+func (s *ProjectStore) SaveProjectRevision(ctx context.Context, revision ProjectRevisionRecord) (ProjectRevisionRecord, bool, error) {
 	revision.ProjectID = strings.TrimSpace(revision.ProjectID)
 	revision.SpecHash = strings.TrimSpace(revision.SpecHash)
 	revision.SpecJSON = strings.TrimSpace(revision.SpecJSON)
@@ -135,7 +140,7 @@ func (s *ConfigStore) SaveProjectRevision(ctx context.Context, revision ProjectR
 	return revision, true, nil
 }
 
-func (s *ConfigStore) GetProject(ctx context.Context, projectID string) (ProjectRecord, error) {
+func (s *ProjectStore) GetProject(ctx context.Context, projectID string) (ProjectRecord, error) {
 	item, found, err := s.getProject(ctx, projectID, false)
 	if err != nil {
 		return ProjectRecord{}, err
@@ -147,7 +152,7 @@ func (s *ConfigStore) GetProject(ctx context.Context, projectID string) (Project
 	return item, nil
 }
 
-func (s *ConfigStore) ListProjects(ctx context.Context, options ProjectListOptions) (ProjectListResult, error) {
+func (s *ProjectStore) ListProjects(ctx context.Context, options ProjectListOptions) (ProjectListResult, error) {
 	limit := options.Limit
 	if limit <= 0 {
 		limit = 50
@@ -200,7 +205,7 @@ func (s *ConfigStore) ListProjects(ctx context.Context, options ProjectListOptio
 	}, nil
 }
 
-func (s *ConfigStore) GetProjectRevision(ctx context.Context, projectID string, revision int64) (ProjectRevisionRecord, error) {
+func (s *ProjectStore) GetProjectRevision(ctx context.Context, projectID string, revision int64) (ProjectRevisionRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, revision, spec_hash, spec_json, created_at
 		FROM project_revision WHERE project_id = ? AND revision = ?`, strings.TrimSpace(projectID), revision)
 	item, err := projects.ScanProjectRevision(row.Scan)
@@ -214,7 +219,7 @@ func (s *ConfigStore) GetProjectRevision(ctx context.Context, projectID string, 
 	return item, nil
 }
 
-func (s *ConfigStore) UpsertProjectAgent(ctx context.Context, agent ProjectAgentRecord) (ProjectAgentRecord, error) {
+func (s *ProjectStore) UpsertProjectAgent(ctx context.Context, agent ProjectAgentRecord) (ProjectAgentRecord, error) {
 	agent, err := projects.NormalizeAgentRecord(agent)
 	if err != nil {
 		return ProjectAgentRecord{}, err
@@ -243,7 +248,7 @@ func (s *ConfigStore) UpsertProjectAgent(ctx context.Context, agent ProjectAgent
 	return s.GetProjectAgent(ctx, agent.ProjectID, agent.AgentName)
 }
 
-func (s *ConfigStore) GetProjectAgent(ctx context.Context, projectID, agentName string) (ProjectAgentRecord, error) {
+func (s *ProjectStore) GetProjectAgent(ctx context.Context, projectID, agentName string) (ProjectAgentRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, agent_name, managed_agent_id, revision, provider, model, image, driver, scheduler_enabled, spec_json, created_at, updated_at
 		FROM project_agent WHERE project_id = ? AND agent_name = ?`, strings.TrimSpace(projectID), strings.TrimSpace(agentName))
 	item, err := projects.ScanProjectAgent(row.Scan)
@@ -257,7 +262,7 @@ func (s *ConfigStore) GetProjectAgent(ctx context.Context, projectID, agentName 
 	return item, nil
 }
 
-func (s *ConfigStore) ListProjectAgents(ctx context.Context, projectID string) ([]ProjectAgentRecord, error) {
+func (s *ProjectStore) ListProjectAgents(ctx context.Context, projectID string) ([]ProjectAgentRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT project_id, agent_name, managed_agent_id, revision, provider, model, image, driver, scheduler_enabled, spec_json, created_at, updated_at
 		FROM project_agent WHERE project_id = ? ORDER BY agent_name ASC`, strings.TrimSpace(projectID))
 	if err != nil {
@@ -278,7 +283,7 @@ func (s *ConfigStore) ListProjectAgents(ctx context.Context, projectID string) (
 	return items, nil
 }
 
-func (s *ConfigStore) UpsertProjectScheduler(ctx context.Context, scheduler ProjectSchedulerRecord) (ProjectSchedulerRecord, error) {
+func (s *ProjectStore) UpsertProjectScheduler(ctx context.Context, scheduler ProjectSchedulerRecord) (ProjectSchedulerRecord, error) {
 	scheduler, err := projects.NormalizeSchedulerRecord(scheduler)
 	if err != nil {
 		return ProjectSchedulerRecord{}, err
@@ -307,7 +312,7 @@ func (s *ConfigStore) UpsertProjectScheduler(ctx context.Context, scheduler Proj
 	return s.GetProjectScheduler(ctx, scheduler.ProjectID, scheduler.SchedulerID)
 }
 
-func (s *ConfigStore) GetProjectScheduler(ctx context.Context, projectID, schedulerID string) (ProjectSchedulerRecord, error) {
+func (s *ProjectStore) GetProjectScheduler(ctx context.Context, projectID, schedulerID string) (ProjectSchedulerRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, scheduler_id, agent_name, managed_loader_id, revision, enabled, trigger_count, spec_json, created_at, updated_at
 		FROM project_scheduler WHERE project_id = ? AND scheduler_id = ?`, strings.TrimSpace(projectID), strings.TrimSpace(schedulerID))
 	item, err := projects.ScanProjectScheduler(row.Scan)
@@ -321,7 +326,7 @@ func (s *ConfigStore) GetProjectScheduler(ctx context.Context, projectID, schedu
 	return item, nil
 }
 
-func (s *ConfigStore) SetProjectSchedulerEnabled(ctx context.Context, projectID, schedulerID string, enabled bool) (ProjectSchedulerRecord, error) {
+func (s *ProjectStore) SetProjectSchedulerEnabled(ctx context.Context, projectID, schedulerID string, enabled bool) (ProjectSchedulerRecord, error) {
 	projectID = strings.TrimSpace(projectID)
 	schedulerID = strings.TrimSpace(schedulerID)
 	if projectID == "" || schedulerID == "" {
@@ -339,7 +344,7 @@ func (s *ConfigStore) SetProjectSchedulerEnabled(ctx context.Context, projectID,
 	return s.GetProjectScheduler(ctx, projectID, schedulerID)
 }
 
-func (s *ConfigStore) ListProjectSchedulers(ctx context.Context, projectID string) ([]ProjectSchedulerRecord, error) {
+func (s *ProjectStore) ListProjectSchedulers(ctx context.Context, projectID string) ([]ProjectSchedulerRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT project_id, scheduler_id, agent_name, managed_loader_id, revision, enabled, trigger_count, spec_json, created_at, updated_at
 		FROM project_scheduler WHERE project_id = ? ORDER BY agent_name ASC, scheduler_id ASC`, strings.TrimSpace(projectID))
 	if err != nil {
@@ -360,7 +365,7 @@ func (s *ConfigStore) ListProjectSchedulers(ctx context.Context, projectID strin
 	return items, nil
 }
 
-func (s *ConfigStore) CreateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
+func (s *ProjectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
 	run, err := projects.NormalizeRunRecord(run)
 	if err != nil {
 		return ProjectRunRecord{}, err
@@ -381,7 +386,7 @@ func (s *ConfigStore) CreateProjectRun(ctx context.Context, run ProjectRunRecord
 	return s.GetProjectRun(ctx, run.RunID)
 }
 
-func (s *ConfigStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
+func (s *ProjectStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
 	run, err := projects.NormalizeRunRecord(run)
 	if err != nil {
 		return ProjectRunRecord{}, err
@@ -404,7 +409,7 @@ func (s *ConfigStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecord
 	return s.GetProjectRun(ctx, run.RunID)
 }
 
-func (s *ConfigStore) GetProjectRun(ctx context.Context, runID string) (ProjectRunRecord, error) {
+func (s *ProjectStore) GetProjectRun(ctx context.Context, runID string) (ProjectRunRecord, error) {
 	row := s.db.QueryRowContext(ctx, projects.SelectProjectRunSQL()+` WHERE run_id = ?`, strings.TrimSpace(runID))
 	item, err := projects.ScanProjectRun(row.Scan)
 	if err != nil {
@@ -417,11 +422,11 @@ func (s *ConfigStore) GetProjectRun(ctx context.Context, runID string) (ProjectR
 	return item, nil
 }
 
-func (s *ConfigStore) ListProjectRuns(ctx context.Context, projectID string, limit int) ([]ProjectRunRecord, error) {
+func (s *ProjectStore) ListProjectRuns(ctx context.Context, projectID string, limit int) ([]ProjectRunRecord, error) {
 	return s.ListProjectRunsByOptions(ctx, ProjectRunListOptions{ProjectID: projectID, Limit: limit})
 }
 
-func (s *ConfigStore) ListProjectRunsByOptions(ctx context.Context, options ProjectRunListOptions) ([]ProjectRunRecord, error) {
+func (s *ProjectStore) ListProjectRunsByOptions(ctx context.Context, options ProjectRunListOptions) ([]ProjectRunRecord, error) {
 	limit := options.Limit
 	if limit <= 0 {
 		limit = 50
@@ -484,7 +489,7 @@ func (s *ConfigStore) ListProjectRunsByOptions(ctx context.Context, options Proj
 	return items, nil
 }
 
-func (s *ConfigStore) getProject(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
+func (s *ProjectStore) getProject(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return ProjectRecord{}, false, fmt.Errorf("project id is required")
@@ -505,7 +510,7 @@ func (s *ConfigStore) getProject(ctx context.Context, projectID string, includeR
 	return item, true, nil
 }
 
-func (s *ConfigStore) getProjectRequired(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, error) {
+func (s *ProjectStore) getProjectRequired(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, error) {
 	item, found, err := s.getProject(ctx, projectID, includeRemoved)
 	if err != nil {
 		return ProjectRecord{}, err
@@ -517,6 +522,6 @@ func (s *ConfigStore) getProjectRequired(ctx context.Context, projectID string, 
 	return item, nil
 }
 
-func (s *ConfigStore) GetProjectIfExists(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
+func (s *ProjectStore) GetProjectIfExists(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
 	return s.getProject(ctx, projectID, includeRemoved)
 }

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -14,12 +14,12 @@ import (
 	"agent-compose/pkg/runs"
 )
 
-// ProjectStore owns projects, revisions, agents, schedulers, runs, and sessions.
-type ProjectStore struct {
+// projectStore owns projects, revisions, agents, schedulers, runs, and sessions.
+type projectStore struct {
 	db *sql.DB
 }
 
-func (s *ProjectStore) UpsertProject(ctx context.Context, project ProjectRecord) (ProjectRecord, error) {
+func (s *projectStore) UpsertProject(ctx context.Context, project ProjectRecord) (ProjectRecord, error) {
 	project, err := projects.NormalizeRecord(project)
 	if err != nil {
 		return ProjectRecord{}, err
@@ -61,7 +61,7 @@ func (s *ProjectStore) UpsertProject(ctx context.Context, project ProjectRecord)
 	return s.GetProject(ctx, project.ID)
 }
 
-func (s *ProjectStore) MarkProjectRemoved(ctx context.Context, projectID string) (ProjectRecord, error) {
+func (s *projectStore) MarkProjectRemoved(ctx context.Context, projectID string) (ProjectRecord, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return ProjectRecord{}, fmt.Errorf("project id is required")
@@ -88,7 +88,7 @@ func (s *ProjectStore) MarkProjectRemoved(ctx context.Context, projectID string)
 	return s.getProjectRequired(ctx, projectID, true)
 }
 
-func (s *ProjectStore) SaveProjectRevision(ctx context.Context, revision ProjectRevisionRecord) (ProjectRevisionRecord, bool, error) {
+func (s *projectStore) SaveProjectRevision(ctx context.Context, revision ProjectRevisionRecord) (ProjectRevisionRecord, bool, error) {
 	revision.ProjectID = strings.TrimSpace(revision.ProjectID)
 	revision.SpecHash = strings.TrimSpace(revision.SpecHash)
 	revision.SpecJSON = strings.TrimSpace(revision.SpecJSON)
@@ -140,7 +140,7 @@ func (s *ProjectStore) SaveProjectRevision(ctx context.Context, revision Project
 	return revision, true, nil
 }
 
-func (s *ProjectStore) GetProject(ctx context.Context, projectID string) (ProjectRecord, error) {
+func (s *projectStore) GetProject(ctx context.Context, projectID string) (ProjectRecord, error) {
 	item, found, err := s.getProject(ctx, projectID, false)
 	if err != nil {
 		return ProjectRecord{}, err
@@ -152,7 +152,7 @@ func (s *ProjectStore) GetProject(ctx context.Context, projectID string) (Projec
 	return item, nil
 }
 
-func (s *ProjectStore) ListProjects(ctx context.Context, options ProjectListOptions) (ProjectListResult, error) {
+func (s *projectStore) ListProjects(ctx context.Context, options ProjectListOptions) (ProjectListResult, error) {
 	limit := options.Limit
 	if limit <= 0 {
 		limit = 50
@@ -205,7 +205,7 @@ func (s *ProjectStore) ListProjects(ctx context.Context, options ProjectListOpti
 	}, nil
 }
 
-func (s *ProjectStore) GetProjectRevision(ctx context.Context, projectID string, revision int64) (ProjectRevisionRecord, error) {
+func (s *projectStore) GetProjectRevision(ctx context.Context, projectID string, revision int64) (ProjectRevisionRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, revision, spec_hash, spec_json, created_at
 		FROM project_revision WHERE project_id = ? AND revision = ?`, strings.TrimSpace(projectID), revision)
 	item, err := projects.ScanProjectRevision(row.Scan)
@@ -219,7 +219,7 @@ func (s *ProjectStore) GetProjectRevision(ctx context.Context, projectID string,
 	return item, nil
 }
 
-func (s *ProjectStore) UpsertProjectAgent(ctx context.Context, agent ProjectAgentRecord) (ProjectAgentRecord, error) {
+func (s *projectStore) UpsertProjectAgent(ctx context.Context, agent ProjectAgentRecord) (ProjectAgentRecord, error) {
 	agent, err := projects.NormalizeAgentRecord(agent)
 	if err != nil {
 		return ProjectAgentRecord{}, err
@@ -248,7 +248,7 @@ func (s *ProjectStore) UpsertProjectAgent(ctx context.Context, agent ProjectAgen
 	return s.GetProjectAgent(ctx, agent.ProjectID, agent.AgentName)
 }
 
-func (s *ProjectStore) GetProjectAgent(ctx context.Context, projectID, agentName string) (ProjectAgentRecord, error) {
+func (s *projectStore) GetProjectAgent(ctx context.Context, projectID, agentName string) (ProjectAgentRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, agent_name, managed_agent_id, revision, provider, model, image, driver, scheduler_enabled, spec_json, created_at, updated_at
 		FROM project_agent WHERE project_id = ? AND agent_name = ?`, strings.TrimSpace(projectID), strings.TrimSpace(agentName))
 	item, err := projects.ScanProjectAgent(row.Scan)
@@ -262,7 +262,7 @@ func (s *ProjectStore) GetProjectAgent(ctx context.Context, projectID, agentName
 	return item, nil
 }
 
-func (s *ProjectStore) ListProjectAgents(ctx context.Context, projectID string) ([]ProjectAgentRecord, error) {
+func (s *projectStore) ListProjectAgents(ctx context.Context, projectID string) ([]ProjectAgentRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT project_id, agent_name, managed_agent_id, revision, provider, model, image, driver, scheduler_enabled, spec_json, created_at, updated_at
 		FROM project_agent WHERE project_id = ? ORDER BY agent_name ASC`, strings.TrimSpace(projectID))
 	if err != nil {
@@ -283,7 +283,7 @@ func (s *ProjectStore) ListProjectAgents(ctx context.Context, projectID string) 
 	return items, nil
 }
 
-func (s *ProjectStore) UpsertProjectScheduler(ctx context.Context, scheduler ProjectSchedulerRecord) (ProjectSchedulerRecord, error) {
+func (s *projectStore) UpsertProjectScheduler(ctx context.Context, scheduler ProjectSchedulerRecord) (ProjectSchedulerRecord, error) {
 	scheduler, err := projects.NormalizeSchedulerRecord(scheduler)
 	if err != nil {
 		return ProjectSchedulerRecord{}, err
@@ -312,7 +312,7 @@ func (s *ProjectStore) UpsertProjectScheduler(ctx context.Context, scheduler Pro
 	return s.GetProjectScheduler(ctx, scheduler.ProjectID, scheduler.SchedulerID)
 }
 
-func (s *ProjectStore) GetProjectScheduler(ctx context.Context, projectID, schedulerID string) (ProjectSchedulerRecord, error) {
+func (s *projectStore) GetProjectScheduler(ctx context.Context, projectID, schedulerID string) (ProjectSchedulerRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, scheduler_id, agent_name, managed_loader_id, revision, enabled, trigger_count, spec_json, created_at, updated_at
 		FROM project_scheduler WHERE project_id = ? AND scheduler_id = ?`, strings.TrimSpace(projectID), strings.TrimSpace(schedulerID))
 	item, err := projects.ScanProjectScheduler(row.Scan)
@@ -326,7 +326,7 @@ func (s *ProjectStore) GetProjectScheduler(ctx context.Context, projectID, sched
 	return item, nil
 }
 
-func (s *ProjectStore) SetProjectSchedulerEnabled(ctx context.Context, projectID, schedulerID string, enabled bool) (ProjectSchedulerRecord, error) {
+func (s *projectStore) SetProjectSchedulerEnabled(ctx context.Context, projectID, schedulerID string, enabled bool) (ProjectSchedulerRecord, error) {
 	projectID = strings.TrimSpace(projectID)
 	schedulerID = strings.TrimSpace(schedulerID)
 	if projectID == "" || schedulerID == "" {
@@ -344,7 +344,7 @@ func (s *ProjectStore) SetProjectSchedulerEnabled(ctx context.Context, projectID
 	return s.GetProjectScheduler(ctx, projectID, schedulerID)
 }
 
-func (s *ProjectStore) ListProjectSchedulers(ctx context.Context, projectID string) ([]ProjectSchedulerRecord, error) {
+func (s *projectStore) ListProjectSchedulers(ctx context.Context, projectID string) ([]ProjectSchedulerRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT project_id, scheduler_id, agent_name, managed_loader_id, revision, enabled, trigger_count, spec_json, created_at, updated_at
 		FROM project_scheduler WHERE project_id = ? ORDER BY agent_name ASC, scheduler_id ASC`, strings.TrimSpace(projectID))
 	if err != nil {
@@ -365,7 +365,7 @@ func (s *ProjectStore) ListProjectSchedulers(ctx context.Context, projectID stri
 	return items, nil
 }
 
-func (s *ProjectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
+func (s *projectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
 	run, err := projects.NormalizeRunRecord(run)
 	if err != nil {
 		return ProjectRunRecord{}, err
@@ -386,7 +386,7 @@ func (s *ProjectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecor
 	return s.GetProjectRun(ctx, run.RunID)
 }
 
-func (s *ProjectStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
+func (s *projectStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
 	run, err := projects.NormalizeRunRecord(run)
 	if err != nil {
 		return ProjectRunRecord{}, err
@@ -409,7 +409,7 @@ func (s *ProjectStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecor
 	return s.GetProjectRun(ctx, run.RunID)
 }
 
-func (s *ProjectStore) GetProjectRun(ctx context.Context, runID string) (ProjectRunRecord, error) {
+func (s *projectStore) GetProjectRun(ctx context.Context, runID string) (ProjectRunRecord, error) {
 	row := s.db.QueryRowContext(ctx, projects.SelectProjectRunSQL()+` WHERE run_id = ?`, strings.TrimSpace(runID))
 	item, err := projects.ScanProjectRun(row.Scan)
 	if err != nil {
@@ -422,11 +422,11 @@ func (s *ProjectStore) GetProjectRun(ctx context.Context, runID string) (Project
 	return item, nil
 }
 
-func (s *ProjectStore) ListProjectRuns(ctx context.Context, projectID string, limit int) ([]ProjectRunRecord, error) {
+func (s *projectStore) ListProjectRuns(ctx context.Context, projectID string, limit int) ([]ProjectRunRecord, error) {
 	return s.ListProjectRunsByOptions(ctx, ProjectRunListOptions{ProjectID: projectID, Limit: limit})
 }
 
-func (s *ProjectStore) ListProjectRunsByOptions(ctx context.Context, options ProjectRunListOptions) ([]ProjectRunRecord, error) {
+func (s *projectStore) ListProjectRunsByOptions(ctx context.Context, options ProjectRunListOptions) ([]ProjectRunRecord, error) {
 	limit := options.Limit
 	if limit <= 0 {
 		limit = 50
@@ -489,7 +489,7 @@ func (s *ProjectStore) ListProjectRunsByOptions(ctx context.Context, options Pro
 	return items, nil
 }
 
-func (s *ProjectStore) getProject(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
+func (s *projectStore) getProject(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return ProjectRecord{}, false, fmt.Errorf("project id is required")
@@ -510,7 +510,7 @@ func (s *ProjectStore) getProject(ctx context.Context, projectID string, include
 	return item, true, nil
 }
 
-func (s *ProjectStore) getProjectRequired(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, error) {
+func (s *projectStore) getProjectRequired(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, error) {
 	item, found, err := s.getProject(ctx, projectID, includeRemoved)
 	if err != nil {
 		return ProjectRecord{}, err
@@ -522,6 +522,6 @@ func (s *ProjectStore) getProjectRequired(ctx context.Context, projectID string,
 	return item, nil
 }
 
-func (s *ProjectStore) GetProjectIfExists(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
+func (s *projectStore) GetProjectIfExists(ctx context.Context, projectID string, includeRemoved bool) (ProjectRecord, bool, error) {
 	return s.getProject(ctx, projectID, includeRemoved)
 }

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -79,7 +79,7 @@ func TestE2EConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 func testConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
-	store := &ConfigStore{db: newMemoryDB(t)}
+	store := FromDB(newMemoryDB(t))
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("initSchema returned error: %v", err)
 	}
@@ -208,7 +208,7 @@ func testConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 func testConfigStoreTopicEventCoverageWorkflows(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
-	store := &ConfigStore{db: newMemoryDB(t)}
+	store := FromDB(newMemoryDB(t))
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("initSchema returned error: %v", err)
 	}
@@ -351,7 +351,7 @@ func testConfigStoreTopicEventCoverageWorkflows(t *testing.T) {
 func testConfigStoreCRUDCoverageWorkflows(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
-	store := &ConfigStore{db: newMemoryDB(t)}
+	store := FromDB(newMemoryDB(t))
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("initSchema returned error: %v", err)
 	}
@@ -657,7 +657,7 @@ func testConfigStoreMigrationAndTimeParsingWorkflows(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	store := &ConfigStore{db: db}
+	store := FromDB(db)
 
 	if _, err := store.tableColumnTypes(ctx, " "); err == nil {
 		t.Fatalf("empty table name returned nil error")
@@ -745,7 +745,7 @@ func testConfigStoreProjectSchemaMigrationWorkflows(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	store := &ConfigStore{db: db}
+	store := FromDB(db)
 
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("initSchema on empty db returned error: %v", err)
@@ -757,7 +757,7 @@ func testConfigStoreProjectSchemaMigrationWorkflows(t *testing.T) {
 	assertProjectSchema(t, store)
 
 	existingDB := newMemoryDB(t)
-	configDB := &ConfigStore{db: existingDB}
+	configDB := FromDB(existingDB)
 	for _, ensure := range []func(context.Context) error{
 		configDB.ensureGlobalEnvSchema,
 		configDB.ensureCapabilityGatewaySchema,

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -585,12 +585,12 @@ func testConfigStoreCRUDCoverageWorkflows(t *testing.T) {
 
 func testConfigStoreLLMBootstrapResolveCoverage(t *testing.T, ctx context.Context) {
 	t.Helper()
-	store := &ConfigStore{db: newMemoryDB(t)}
+	store := FromDB(newMemoryDB(t))
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("initSchema for LLM bootstrap returned error: %v", err)
 	}
 	config := &appconfig.Config{LLMAPIEndpoint: "https://config.example/v1", LLMAPIProtocol: "chat_completions", LLMAPIKey: "config-key", LLMModel: "config-model"}
-	if lookup := DefaultLLMEnvProviderLookup(ctx, config, store); lookup("LLM_API_ENDPOINT") != "https://config.example/v1" {
+	if lookup := llms.DefaultLLMEnvProviderLookup(ctx, config, store); lookup("LLM_API_ENDPOINT") != "https://config.example/v1" {
 		t.Fatalf("config LLM lookup failed")
 	}
 	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SessionEnvVar{
@@ -601,14 +601,14 @@ func testConfigStoreLLMBootstrapResolveCoverage(t *testing.T, ctx context.Contex
 	}); err != nil {
 		t.Fatalf("ReplaceGlobalEnv for LLM returned error: %v", err)
 	}
-	target, err := ResolveLLMTarget(ctx, config, store, "")
+	target, err := llms.ResolveLLMTarget(ctx, config, store, "")
 	if err != nil {
 		t.Fatalf("ResolveLLMTarget returned error: %v", err)
 	}
 	if target.Provider.ID != llms.ProviderIDDefaultOpenAI || target.Provider.APIKey != "global-key" || target.Model.ID != "global-model" || target.WireAPI != llms.APIProtocolChatCompletions {
 		t.Fatalf("OpenAI resolved target = %#v", target)
 	}
-	runtimeTarget, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, "session-1", llms.ProviderFamilyOpenAI, "session-model", "", []SessionEnvVar{
+	runtimeTarget, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, "session-1", llms.ProviderFamilyOpenAI, "session-model", "", []domain.SessionEnvVar{
 		{Name: "LLM_API_ENDPOINT", Value: "https://session.example/v1"},
 		{Name: "LLM_API_KEY", Value: "session-key", Secret: true},
 		{Name: "LLM_MODEL", Value: "session-model"},
@@ -619,32 +619,32 @@ func testConfigStoreLLMBootstrapResolveCoverage(t *testing.T, ctx context.Contex
 	if runtimeTarget.Provider.ID == target.Provider.ID || runtimeTarget.Provider.Scope != llms.ProviderScopeSessionEnv || runtimeTarget.Model.ID != "session-model" {
 		t.Fatalf("session OpenAI target = %#v", runtimeTarget)
 	}
-	if HasEnabledLLMProviderID(ctx, store, runtimeTarget.Provider.ID) != true {
+	if llms.HasEnabledLLMProviderID(ctx, store, runtimeTarget.Provider.ID) != true {
 		t.Fatalf("expected session provider to be enabled")
 	}
-	reusedRuntimeTarget, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, "session-1", llms.ProviderFamilyOpenAI, "session-model", "", nil)
+	reusedRuntimeTarget, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, "session-1", llms.ProviderFamilyOpenAI, "session-model", "", nil)
 	if err != nil || reusedRuntimeTarget.Provider.ID != runtimeTarget.Provider.ID {
 		t.Fatalf("reused session OpenAI target=%#v err=%v", reusedRuntimeTarget, err)
 	}
-	if _, err := ResolveRuntimeLLMTarget(ctx, config, store, "missing-model", "missing-provider"); err == nil {
+	if _, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "missing-model", "missing-provider"); err == nil {
 		t.Fatalf("expected missing runtime LLM target error")
 	}
 
-	anthropicStore := &ConfigStore{db: newMemoryDB(t)}
+	anthropicStore := FromDB(newMemoryDB(t))
 	if err := anthropicStore.initSchema(ctx); err != nil {
 		t.Fatalf("initSchema for Anthropic returned error: %v", err)
 	}
 	t.Setenv("ANTHROPIC_BASE_URL", "https://anthropic.example")
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
 	t.Setenv("ANTHROPIC_MODEL", "claude-test")
-	anthropicTarget, err := ResolveLLMTargetForProviderFamily(ctx, &appconfig.Config{}, anthropicStore, llms.ProviderFamilyAnthropic, "")
+	anthropicTarget, err := llms.ResolveLLMTargetForProviderFamily(ctx, &appconfig.Config{}, anthropicStore, llms.ProviderFamilyAnthropic, "")
 	if err != nil {
 		t.Fatalf("ResolveLLMTargetForProviderFamily Anthropic returned error: %v", err)
 	}
 	if anthropicTarget.Provider.ProviderType != llms.ProviderFamilyAnthropic || anthropicTarget.WireAPI != llms.APIProtocolMessages || anthropicTarget.Model.ID != "claude-test" {
 		t.Fatalf("Anthropic target = %#v", anthropicTarget)
 	}
-	sessionAnthropicID, err := EnsureSessionAnthropicEnvProvider(ctx, anthropicStore, "session-2", "claude-session", []SessionEnvVar{
+	sessionAnthropicID, err := llms.EnsureSessionAnthropicEnvProvider(ctx, anthropicStore, "session-2", "claude-session", []domain.SessionEnvVar{
 		{Name: "ANTHROPIC_API_KEY", Value: "session-anthropic-key", Secret: true},
 		{Name: "ANTHROPIC_MODEL", Value: "claude-session"},
 	})

--- a/pkg/storage/configstore/topic_event_helpers.go
+++ b/pkg/storage/configstore/topic_event_helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/storeutil"
 )
 
 func normalizeTopicEventRecord(item domain.TopicEventRecord, assignID bool) (domain.TopicEventRecord, error) {
@@ -131,11 +132,11 @@ func scanTopicEvent(scan func(dest ...any) error) (domain.TopicEventRecord, erro
 	); err != nil {
 		return domain.TopicEventRecord{}, fmt.Errorf("scan event: %w", err)
 	}
-	item.ClaimUntil = ParseStoredUnixTimeAuto(claimUntilRaw)
-	item.NextAttemptAt = ParseStoredUnixTimeAuto(nextAttemptAtRaw)
-	item.DeadLetterAt = ParseStoredUnixTimeAuto(deadLetterAtRaw)
-	item.CreatedAt = ParseStoredUnixTimeAuto(createdAtRaw)
-	item.DispatchedAt = ParseStoredUnixTimeAuto(dispatchedAtRaw)
+	item.ClaimUntil = storeutil.ParseStoredUnixTimeAuto(claimUntilRaw)
+	item.NextAttemptAt = storeutil.ParseStoredUnixTimeAuto(nextAttemptAtRaw)
+	item.DeadLetterAt = storeutil.ParseStoredUnixTimeAuto(deadLetterAtRaw)
+	item.CreatedAt = storeutil.ParseStoredUnixTimeAuto(createdAtRaw)
+	item.DispatchedAt = storeutil.ParseStoredUnixTimeAuto(dispatchedAtRaw)
 	return item, nil
 }
 

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -11,7 +11,12 @@ import (
 	"time"
 )
 
-func (s *ConfigStore) ensureEventSchema(ctx context.Context) error {
+// EventStore owns topic events, webhook sources, deliveries, and session links.
+type EventStore struct {
+	db *sql.DB
+}
+
+func (s *EventStore) ensureEventSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS event (
 			sequence INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -115,11 +120,11 @@ func (s *ConfigStore) ensureEventSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *ConfigStore) EnsureEventSchema(ctx context.Context) error {
+func (s *EventStore) EnsureEventSchema(ctx context.Context) error {
 	return s.ensureEventSchema(ctx)
 }
 
-func (s *ConfigStore) CreateEvent(ctx context.Context, item domain.TopicEventRecord) (domain.TopicEventRecord, error) {
+func (s *EventStore) CreateEvent(ctx context.Context, item domain.TopicEventRecord) (domain.TopicEventRecord, error) {
 	normalized, err := normalizeTopicEventRecord(item, true)
 	if err != nil {
 		return domain.TopicEventRecord{}, err
@@ -175,7 +180,7 @@ func (s *ConfigStore) CreateEvent(ctx context.Context, item domain.TopicEventRec
 	return s.GetEvent(ctx, normalized.ID)
 }
 
-func (s *ConfigStore) GetEvent(ctx context.Context, eventID string) (domain.TopicEventRecord, error) {
+func (s *EventStore) GetEvent(ctx context.Context, eventID string) (domain.TopicEventRecord, error) {
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return domain.TopicEventRecord{}, fmt.Errorf("event id is required")
@@ -191,7 +196,7 @@ func (s *ConfigStore) GetEvent(ctx context.Context, eventID string) (domain.Topi
 	return item, nil
 }
 
-func (s *ConfigStore) FindEventByIdempotencyKey(ctx context.Context, topic, key string) (domain.TopicEventRecord, bool, error) {
+func (s *EventStore) FindEventByIdempotencyKey(ctx context.Context, topic, key string) (domain.TopicEventRecord, bool, error) {
 	topic = strings.TrimSpace(topic)
 	key = strings.TrimSpace(key)
 	if topic == "" || key == "" {
@@ -208,7 +213,7 @@ func (s *ConfigStore) FindEventByIdempotencyKey(ctx context.Context, topic, key 
 	return item, true, nil
 }
 
-func (s *ConfigStore) ListPendingEvents(ctx context.Context, limit int) ([]domain.TopicEventRecord, error) {
+func (s *EventStore) ListPendingEvents(ctx context.Context, limit int) ([]domain.TopicEventRecord, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
@@ -220,7 +225,7 @@ func (s *ConfigStore) ListPendingEvents(ctx context.Context, limit int) ([]domai
 	return scanTopicEvents(rows)
 }
 
-func (s *ConfigStore) ListEvents(ctx context.Context, filter domain.TopicEventFilter) ([]domain.TopicEventRecord, error) {
+func (s *EventStore) ListEvents(ctx context.Context, filter domain.TopicEventFilter) ([]domain.TopicEventRecord, error) {
 	if strings.TrimSpace(filter.Topic) == "" && strings.TrimSpace(filter.CorrelationID) == "" {
 		return nil, fmt.Errorf("topic or correlation id is required")
 	}
@@ -262,7 +267,7 @@ func (s *ConfigStore) ListEvents(ctx context.Context, filter domain.TopicEventFi
 	return scanTopicEvents(rows)
 }
 
-func (s *ConfigStore) MarkEventPublished(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
+func (s *EventStore) MarkEventPublished(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	if eventID == "" || claimID == "" {
@@ -289,7 +294,7 @@ func (s *ConfigStore) MarkEventPublished(ctx context.Context, eventID, claimID s
 	return nil
 }
 
-func (s *ConfigStore) UpdateEventPayload(ctx context.Context, eventID, payloadJSON string) error {
+func (s *EventStore) UpdateEventPayload(ctx context.Context, eventID, payloadJSON string) error {
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return fmt.Errorf("event id is required")
@@ -316,7 +321,7 @@ func (s *ConfigStore) UpdateEventPayload(ctx context.Context, eventID, payloadJS
 	return nil
 }
 
-func (s *ConfigStore) ListDispatchableEvents(ctx context.Context, now time.Time, limit int) ([]domain.TopicEventRecord, error) {
+func (s *EventStore) ListDispatchableEvents(ctx context.Context, now time.Time, limit int) ([]domain.TopicEventRecord, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
@@ -336,7 +341,7 @@ func (s *ConfigStore) ListDispatchableEvents(ctx context.Context, now time.Time,
 	return scanTopicEvents(rows)
 }
 
-func (s *ConfigStore) ClaimEvent(ctx context.Context, eventID, claimID string, now, until time.Time) (bool, error) {
+func (s *EventStore) ClaimEvent(ctx context.Context, eventID, claimID string, now, until time.Time) (bool, error) {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	if eventID == "" || claimID == "" {
@@ -369,7 +374,7 @@ func (s *ConfigStore) ClaimEvent(ctx context.Context, eventID, claimID string, n
 	return affected > 0, nil
 }
 
-func (s *ConfigStore) ReleaseEventClaim(ctx context.Context, eventID, claimID, status, lastError string, nextAttemptAt time.Time) error {
+func (s *EventStore) ReleaseEventClaim(ctx context.Context, eventID, claimID, status, lastError string, nextAttemptAt time.Time) error {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	status = domain.NormalizeTopicEventDispatchStatus(status)
@@ -389,7 +394,7 @@ func (s *ConfigStore) ReleaseEventClaim(ctx context.Context, eventID, claimID, s
 	return nil
 }
 
-func (s *ConfigStore) MarkEventNoSubscriber(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
+func (s *EventStore) MarkEventNoSubscriber(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	if eventID == "" || claimID == "" {
@@ -420,7 +425,7 @@ func (s *ConfigStore) MarkEventNoSubscriber(ctx context.Context, eventID, claimI
 	return nil
 }
 
-func (s *ConfigStore) UpsertEventDelivery(ctx context.Context, delivery domain.EventDelivery) error {
+func (s *EventStore) UpsertEventDelivery(ctx context.Context, delivery domain.EventDelivery) error {
 	delivery.EventID = strings.TrimSpace(delivery.EventID)
 	delivery.LoaderID = strings.TrimSpace(delivery.LoaderID)
 	delivery.TriggerID = strings.TrimSpace(delivery.TriggerID)
@@ -467,7 +472,7 @@ func (s *ConfigStore) UpsertEventDelivery(ctx context.Context, delivery domain.E
 	return nil
 }
 
-func (s *ConfigStore) AddEventSessionLink(ctx context.Context, link domain.EventSessionLink) error {
+func (s *EventStore) AddEventSessionLink(ctx context.Context, link domain.EventSessionLink) error {
 	link.EventID = strings.TrimSpace(link.EventID)
 	link.SessionID = strings.TrimSpace(link.SessionID)
 	link.Relation = strings.TrimSpace(link.Relation)
@@ -498,7 +503,7 @@ func (s *ConfigStore) AddEventSessionLink(ctx context.Context, link domain.Event
 	return nil
 }
 
-func (s *ConfigStore) ListEventDeliveries(ctx context.Context, eventIDs []string) ([]domain.EventDelivery, error) {
+func (s *EventStore) ListEventDeliveries(ctx context.Context, eventIDs []string) ([]domain.EventDelivery, error) {
 	seen := map[string]struct{}{}
 	ids := make([]string, 0, len(eventIDs))
 	for _, id := range eventIDs {
@@ -545,7 +550,7 @@ func (s *ConfigStore) ListEventDeliveries(ctx context.Context, eventIDs []string
 	return items, nil
 }
 
-func (s *ConfigStore) ListEventSessionLinks(ctx context.Context, eventIDs []string) ([]domain.EventSessionTraceItem, error) {
+func (s *EventStore) ListEventSessionLinks(ctx context.Context, eventIDs []string) ([]domain.EventSessionTraceItem, error) {
 	seen := map[string]struct{}{}
 	ids := make([]string, 0, len(eventIDs))
 	for _, id := range eventIDs {
@@ -590,7 +595,7 @@ func (s *ConfigStore) ListEventSessionLinks(ctx context.Context, eventIDs []stri
 	return items, nil
 }
 
-func (s *ConfigStore) ListDescendantEventIDs(ctx context.Context, rootEventID string, limit int) ([]string, error) {
+func (s *EventStore) ListDescendantEventIDs(ctx context.Context, rootEventID string, limit int) ([]string, error) {
 	rootEventID = strings.TrimSpace(rootEventID)
 	if rootEventID == "" {
 		return nil, fmt.Errorf("event id is required")
@@ -634,7 +639,7 @@ func (s *ConfigStore) ListDescendantEventIDs(ctx context.Context, rootEventID st
 	return ids, nil
 }
 
-func (s *ConfigStore) ListEnabledWebhookSourcesForTopic(ctx context.Context, topic string) ([]domain.WebhookSource, error) {
+func (s *EventStore) ListEnabledWebhookSourcesForTopic(ctx context.Context, topic string) ([]domain.WebhookSource, error) {
 	topic = strings.TrimSpace(topic)
 	if topic == "" {
 		return nil, fmt.Errorf("topic is required")
@@ -683,7 +688,7 @@ func WebhookSourceTopicMatches(topic, topicPrefix string) bool {
 	return webhookSourceTopicMatches(topic, topicPrefix)
 }
 
-func (s *ConfigStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSource, error) {
+func (s *EventStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSource, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
 		FROM webhook_source ORDER BY id ASC`)
 	if err != nil {
@@ -710,7 +715,7 @@ func (s *ConfigStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookS
 	return items, nil
 }
 
-func (s *ConfigStore) GetWebhookSource(ctx context.Context, sourceID string) (domain.WebhookSource, bool, error) {
+func (s *EventStore) GetWebhookSource(ctx context.Context, sourceID string) (domain.WebhookSource, bool, error) {
 	sourceID = strings.TrimSpace(sourceID)
 	if sourceID == "" {
 		return domain.WebhookSource{}, false, fmt.Errorf("webhook source id is required")
@@ -733,7 +738,7 @@ func (s *ConfigStore) GetWebhookSource(ctx context.Context, sourceID string) (do
 	return item, true, nil
 }
 
-func (s *ConfigStore) UpsertWebhookSource(ctx context.Context, source domain.WebhookSource) (domain.WebhookSource, error) {
+func (s *EventStore) UpsertWebhookSource(ctx context.Context, source domain.WebhookSource) (domain.WebhookSource, error) {
 	source.ID = strings.TrimSpace(source.ID)
 	source.Name = strings.TrimSpace(source.Name)
 	source.Provider = strings.TrimSpace(source.Provider)
@@ -788,7 +793,7 @@ func (s *ConfigStore) UpsertWebhookSource(ctx context.Context, source domain.Web
 	return source, nil
 }
 
-func (s *ConfigStore) DeleteWebhookSource(ctx context.Context, sourceID string) error {
+func (s *EventStore) DeleteWebhookSource(ctx context.Context, sourceID string) error {
 	sourceID = strings.TrimSpace(sourceID)
 	if sourceID == "" {
 		return fmt.Errorf("webhook source id is required")

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -11,12 +11,12 @@ import (
 	"time"
 )
 
-// EventStore owns topic events, webhook sources, deliveries, and session links.
-type EventStore struct {
+// eventStore owns topic events, webhook sources, deliveries, and session links.
+type eventStore struct {
 	db *sql.DB
 }
 
-func (s *EventStore) ensureEventSchema(ctx context.Context) error {
+func (s *eventStore) ensureEventSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS event (
 			sequence INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -120,11 +120,11 @@ func (s *EventStore) ensureEventSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *EventStore) EnsureEventSchema(ctx context.Context) error {
+func (s *eventStore) EnsureEventSchema(ctx context.Context) error {
 	return s.ensureEventSchema(ctx)
 }
 
-func (s *EventStore) CreateEvent(ctx context.Context, item domain.TopicEventRecord) (domain.TopicEventRecord, error) {
+func (s *eventStore) CreateEvent(ctx context.Context, item domain.TopicEventRecord) (domain.TopicEventRecord, error) {
 	normalized, err := normalizeTopicEventRecord(item, true)
 	if err != nil {
 		return domain.TopicEventRecord{}, err
@@ -180,7 +180,7 @@ func (s *EventStore) CreateEvent(ctx context.Context, item domain.TopicEventReco
 	return s.GetEvent(ctx, normalized.ID)
 }
 
-func (s *EventStore) GetEvent(ctx context.Context, eventID string) (domain.TopicEventRecord, error) {
+func (s *eventStore) GetEvent(ctx context.Context, eventID string) (domain.TopicEventRecord, error) {
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return domain.TopicEventRecord{}, fmt.Errorf("event id is required")
@@ -196,7 +196,7 @@ func (s *EventStore) GetEvent(ctx context.Context, eventID string) (domain.Topic
 	return item, nil
 }
 
-func (s *EventStore) FindEventByIdempotencyKey(ctx context.Context, topic, key string) (domain.TopicEventRecord, bool, error) {
+func (s *eventStore) FindEventByIdempotencyKey(ctx context.Context, topic, key string) (domain.TopicEventRecord, bool, error) {
 	topic = strings.TrimSpace(topic)
 	key = strings.TrimSpace(key)
 	if topic == "" || key == "" {
@@ -213,7 +213,7 @@ func (s *EventStore) FindEventByIdempotencyKey(ctx context.Context, topic, key s
 	return item, true, nil
 }
 
-func (s *EventStore) ListPendingEvents(ctx context.Context, limit int) ([]domain.TopicEventRecord, error) {
+func (s *eventStore) ListPendingEvents(ctx context.Context, limit int) ([]domain.TopicEventRecord, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
@@ -225,7 +225,7 @@ func (s *EventStore) ListPendingEvents(ctx context.Context, limit int) ([]domain
 	return scanTopicEvents(rows)
 }
 
-func (s *EventStore) ListEvents(ctx context.Context, filter domain.TopicEventFilter) ([]domain.TopicEventRecord, error) {
+func (s *eventStore) ListEvents(ctx context.Context, filter domain.TopicEventFilter) ([]domain.TopicEventRecord, error) {
 	if strings.TrimSpace(filter.Topic) == "" && strings.TrimSpace(filter.CorrelationID) == "" {
 		return nil, fmt.Errorf("topic or correlation id is required")
 	}
@@ -267,7 +267,7 @@ func (s *EventStore) ListEvents(ctx context.Context, filter domain.TopicEventFil
 	return scanTopicEvents(rows)
 }
 
-func (s *EventStore) MarkEventPublished(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
+func (s *eventStore) MarkEventPublished(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	if eventID == "" || claimID == "" {
@@ -294,7 +294,7 @@ func (s *EventStore) MarkEventPublished(ctx context.Context, eventID, claimID st
 	return nil
 }
 
-func (s *EventStore) UpdateEventPayload(ctx context.Context, eventID, payloadJSON string) error {
+func (s *eventStore) UpdateEventPayload(ctx context.Context, eventID, payloadJSON string) error {
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return fmt.Errorf("event id is required")
@@ -321,7 +321,7 @@ func (s *EventStore) UpdateEventPayload(ctx context.Context, eventID, payloadJSO
 	return nil
 }
 
-func (s *EventStore) ListDispatchableEvents(ctx context.Context, now time.Time, limit int) ([]domain.TopicEventRecord, error) {
+func (s *eventStore) ListDispatchableEvents(ctx context.Context, now time.Time, limit int) ([]domain.TopicEventRecord, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
@@ -341,7 +341,7 @@ func (s *EventStore) ListDispatchableEvents(ctx context.Context, now time.Time, 
 	return scanTopicEvents(rows)
 }
 
-func (s *EventStore) ClaimEvent(ctx context.Context, eventID, claimID string, now, until time.Time) (bool, error) {
+func (s *eventStore) ClaimEvent(ctx context.Context, eventID, claimID string, now, until time.Time) (bool, error) {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	if eventID == "" || claimID == "" {
@@ -374,7 +374,7 @@ func (s *EventStore) ClaimEvent(ctx context.Context, eventID, claimID string, no
 	return affected > 0, nil
 }
 
-func (s *EventStore) ReleaseEventClaim(ctx context.Context, eventID, claimID, status, lastError string, nextAttemptAt time.Time) error {
+func (s *eventStore) ReleaseEventClaim(ctx context.Context, eventID, claimID, status, lastError string, nextAttemptAt time.Time) error {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	status = domain.NormalizeTopicEventDispatchStatus(status)
@@ -394,7 +394,7 @@ func (s *EventStore) ReleaseEventClaim(ctx context.Context, eventID, claimID, st
 	return nil
 }
 
-func (s *EventStore) MarkEventNoSubscriber(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
+func (s *eventStore) MarkEventNoSubscriber(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {
 	eventID = strings.TrimSpace(eventID)
 	claimID = strings.TrimSpace(claimID)
 	if eventID == "" || claimID == "" {
@@ -425,7 +425,7 @@ func (s *EventStore) MarkEventNoSubscriber(ctx context.Context, eventID, claimID
 	return nil
 }
 
-func (s *EventStore) UpsertEventDelivery(ctx context.Context, delivery domain.EventDelivery) error {
+func (s *eventStore) UpsertEventDelivery(ctx context.Context, delivery domain.EventDelivery) error {
 	delivery.EventID = strings.TrimSpace(delivery.EventID)
 	delivery.LoaderID = strings.TrimSpace(delivery.LoaderID)
 	delivery.TriggerID = strings.TrimSpace(delivery.TriggerID)
@@ -472,7 +472,7 @@ func (s *EventStore) UpsertEventDelivery(ctx context.Context, delivery domain.Ev
 	return nil
 }
 
-func (s *EventStore) AddEventSessionLink(ctx context.Context, link domain.EventSessionLink) error {
+func (s *eventStore) AddEventSessionLink(ctx context.Context, link domain.EventSessionLink) error {
 	link.EventID = strings.TrimSpace(link.EventID)
 	link.SessionID = strings.TrimSpace(link.SessionID)
 	link.Relation = strings.TrimSpace(link.Relation)
@@ -503,7 +503,7 @@ func (s *EventStore) AddEventSessionLink(ctx context.Context, link domain.EventS
 	return nil
 }
 
-func (s *EventStore) ListEventDeliveries(ctx context.Context, eventIDs []string) ([]domain.EventDelivery, error) {
+func (s *eventStore) ListEventDeliveries(ctx context.Context, eventIDs []string) ([]domain.EventDelivery, error) {
 	seen := map[string]struct{}{}
 	ids := make([]string, 0, len(eventIDs))
 	for _, id := range eventIDs {
@@ -550,7 +550,7 @@ func (s *EventStore) ListEventDeliveries(ctx context.Context, eventIDs []string)
 	return items, nil
 }
 
-func (s *EventStore) ListEventSessionLinks(ctx context.Context, eventIDs []string) ([]domain.EventSessionTraceItem, error) {
+func (s *eventStore) ListEventSessionLinks(ctx context.Context, eventIDs []string) ([]domain.EventSessionTraceItem, error) {
 	seen := map[string]struct{}{}
 	ids := make([]string, 0, len(eventIDs))
 	for _, id := range eventIDs {
@@ -595,7 +595,7 @@ func (s *EventStore) ListEventSessionLinks(ctx context.Context, eventIDs []strin
 	return items, nil
 }
 
-func (s *EventStore) ListDescendantEventIDs(ctx context.Context, rootEventID string, limit int) ([]string, error) {
+func (s *eventStore) ListDescendantEventIDs(ctx context.Context, rootEventID string, limit int) ([]string, error) {
 	rootEventID = strings.TrimSpace(rootEventID)
 	if rootEventID == "" {
 		return nil, fmt.Errorf("event id is required")
@@ -639,7 +639,7 @@ func (s *EventStore) ListDescendantEventIDs(ctx context.Context, rootEventID str
 	return ids, nil
 }
 
-func (s *EventStore) ListEnabledWebhookSourcesForTopic(ctx context.Context, topic string) ([]domain.WebhookSource, error) {
+func (s *eventStore) ListEnabledWebhookSourcesForTopic(ctx context.Context, topic string) ([]domain.WebhookSource, error) {
 	topic = strings.TrimSpace(topic)
 	if topic == "" {
 		return nil, fmt.Errorf("topic is required")
@@ -688,7 +688,7 @@ func WebhookSourceTopicMatches(topic, topicPrefix string) bool {
 	return webhookSourceTopicMatches(topic, topicPrefix)
 }
 
-func (s *EventStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSource, error) {
+func (s *eventStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSource, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
 		FROM webhook_source ORDER BY id ASC`)
 	if err != nil {
@@ -715,7 +715,7 @@ func (s *EventStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSo
 	return items, nil
 }
 
-func (s *EventStore) GetWebhookSource(ctx context.Context, sourceID string) (domain.WebhookSource, bool, error) {
+func (s *eventStore) GetWebhookSource(ctx context.Context, sourceID string) (domain.WebhookSource, bool, error) {
 	sourceID = strings.TrimSpace(sourceID)
 	if sourceID == "" {
 		return domain.WebhookSource{}, false, fmt.Errorf("webhook source id is required")
@@ -738,7 +738,7 @@ func (s *EventStore) GetWebhookSource(ctx context.Context, sourceID string) (dom
 	return item, true, nil
 }
 
-func (s *EventStore) UpsertWebhookSource(ctx context.Context, source domain.WebhookSource) (domain.WebhookSource, error) {
+func (s *eventStore) UpsertWebhookSource(ctx context.Context, source domain.WebhookSource) (domain.WebhookSource, error) {
 	source.ID = strings.TrimSpace(source.ID)
 	source.Name = strings.TrimSpace(source.Name)
 	source.Provider = strings.TrimSpace(source.Provider)
@@ -793,7 +793,7 @@ func (s *EventStore) UpsertWebhookSource(ctx context.Context, source domain.Webh
 	return source, nil
 }
 
-func (s *EventStore) DeleteWebhookSource(ctx context.Context, sourceID string) error {
+func (s *eventStore) DeleteWebhookSource(ctx context.Context, sourceID string) error {
 	sourceID = strings.TrimSpace(sourceID)
 	if sourceID == "" {
 		return fmt.Errorf("webhook source id is required")

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -2,6 +2,7 @@ package configstore
 
 import (
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/storeutil"
 	"context"
 	"database/sql"
 	"errors"
@@ -534,8 +535,8 @@ func (s *ConfigStore) ListEventDeliveries(ctx context.Context, eventIDs []string
 		if err := rows.Scan(&item.EventID, &item.LoaderID, &item.TriggerID, &item.RunID, &item.Status, &item.Error, &createdAtRaw, &updatedAtRaw); err != nil {
 			return nil, fmt.Errorf("scan event delivery: %w", err)
 		}
-		item.CreatedAt = ParseStoredUnixTimeAuto(createdAtRaw)
-		item.UpdatedAt = ParseStoredUnixTimeAuto(updatedAtRaw)
+		item.CreatedAt = storeutil.ParseStoredUnixTimeAuto(createdAtRaw)
+		item.UpdatedAt = storeutil.ParseStoredUnixTimeAuto(updatedAtRaw)
 		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -580,7 +581,7 @@ func (s *ConfigStore) ListEventSessionLinks(ctx context.Context, eventIDs []stri
 		if err := rows.Scan(&item.EventID, &item.SessionID, &item.Relation, &item.LoaderID, &item.RunID, &item.TriggerID, &item.LoaderEventID, &createdAtRaw); err != nil {
 			return nil, fmt.Errorf("scan event session link: %w", err)
 		}
-		item.CreatedAt = ParseStoredUnixTimeAuto(createdAtRaw)
+		item.CreatedAt = storeutil.ParseStoredUnixTimeAuto(createdAtRaw)
 		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -654,8 +655,8 @@ func (s *ConfigStore) ListEnabledWebhookSourcesForTopic(ctx context.Context, top
 			return nil, fmt.Errorf("scan webhook source: %w", err)
 		}
 		item.Enabled = enabled != 0
-		item.CreatedAt = ParseStoredUnixTimeAuto(createdAtRaw)
-		item.UpdatedAt = ParseStoredUnixTimeAuto(updatedAtRaw)
+		item.CreatedAt = storeutil.ParseStoredUnixTimeAuto(createdAtRaw)
+		item.UpdatedAt = storeutil.ParseStoredUnixTimeAuto(updatedAtRaw)
 		if webhookSourceTopicMatches(topic, item.TopicPrefix) {
 			items = append(items, item)
 		}
@@ -699,8 +700,8 @@ func (s *ConfigStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookS
 			return nil, fmt.Errorf("scan webhook source: %w", err)
 		}
 		item.Enabled = enabled != 0
-		item.CreatedAt = ParseStoredUnixTimeAuto(createdAtRaw)
-		item.UpdatedAt = ParseStoredUnixTimeAuto(updatedAtRaw)
+		item.CreatedAt = storeutil.ParseStoredUnixTimeAuto(createdAtRaw)
+		item.UpdatedAt = storeutil.ParseStoredUnixTimeAuto(updatedAtRaw)
 		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -727,8 +728,8 @@ func (s *ConfigStore) GetWebhookSource(ctx context.Context, sourceID string) (do
 		return domain.WebhookSource{}, false, fmt.Errorf("get webhook source: %w", err)
 	}
 	item.Enabled = enabled != 0
-	item.CreatedAt = ParseStoredUnixTimeAuto(createdAtRaw)
-	item.UpdatedAt = ParseStoredUnixTimeAuto(updatedAtRaw)
+	item.CreatedAt = storeutil.ParseStoredUnixTimeAuto(createdAtRaw)
+	item.UpdatedAt = storeutil.ParseStoredUnixTimeAuto(updatedAtRaw)
 	return item, true, nil
 }
 

--- a/pkg/storage/storeutil/time.go
+++ b/pkg/storage/storeutil/time.go
@@ -1,0 +1,25 @@
+// Package storeutil holds small, dependency-free helpers shared across the
+// storage layer and its consumers, such as decoding timestamps persisted by the
+// stores. Keeping these primitives here lets packages parse stored values
+// without depending on a concrete store implementation.
+package storeutil
+
+import "time"
+
+// StoredUnixMillisecondThreshold is the boundary used to tell stored
+// unix-second timestamps apart from unix-millisecond timestamps. Values at or
+// above the threshold are treated as milliseconds.
+const StoredUnixMillisecondThreshold int64 = 10_000_000_000
+
+// ParseStoredUnixTimeAuto interprets a stored integer timestamp as either unix
+// seconds or unix milliseconds based on StoredUnixMillisecondThreshold, and
+// returns a UTC time. Non-positive values yield the zero time.
+func ParseStoredUnixTimeAuto(value int64) time.Time {
+	if value <= 0 {
+		return time.Time{}
+	}
+	if value >= StoredUnixMillisecondThreshold {
+		return time.UnixMilli(value).UTC()
+	}
+	return time.Unix(value, 0).UTC()
+}

--- a/pkg/storage/storeutil/time_test.go
+++ b/pkg/storage/storeutil/time_test.go
@@ -1,0 +1,44 @@
+package storeutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseStoredUnixTimeAuto(t *testing.T) {
+	cases := []struct {
+		name  string
+		value int64
+		want  time.Time
+	}{
+		{name: "zero yields zero time", value: 0, want: time.Time{}},
+		{name: "negative yields zero time", value: -1, want: time.Time{}},
+		{
+			name:  "below threshold treated as seconds",
+			value: 1_700_000_000,
+			want:  time.Unix(1_700_000_000, 0).UTC(),
+		},
+		{
+			name:  "at threshold treated as milliseconds",
+			value: StoredUnixMillisecondThreshold,
+			want:  time.UnixMilli(StoredUnixMillisecondThreshold).UTC(),
+		},
+		{
+			name:  "above threshold treated as milliseconds",
+			value: 1_700_000_000_000,
+			want:  time.UnixMilli(1_700_000_000_000).UTC(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseStoredUnixTimeAuto(tc.value)
+			if !got.Equal(tc.want) {
+				t.Fatalf("ParseStoredUnixTimeAuto(%d) = %v, want %v", tc.value, got, tc.want)
+			}
+			if !got.IsZero() && got.Location() != time.UTC {
+				t.Errorf("expected UTC location, got %v", got.Location())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 动机

依赖图审计（`go list` 编译级依赖）发现持久层与领域层存在双向耦合：

- `configstore` 被 `events`、`llms/runtimefacade` **反向依赖**，同时内部藏有 ~25 个 LLM 领域函数（错层）
- run 控制器直接持有 22 方法的具体 `*sessionstore.Store`
- `ConfigStore` 本体是横跨全部配置域的 **136 方法上帝仓储**

本 PR 消除全部反向边、领域逻辑归位、DAO 按域纵切，行为零变化。

## 改动（按 commit 递进，可逐个 review）

1. **storeutil 抽取**：纯时间原语 `ParseStoredUnixTimeAuto` 移入零依赖叶子包 `storage/storeutil`，断 `events → configstore`
2. **runs 接口倒置**：引入 `SessionRuntimeStore` 窄接口（会话生命周期 + VM/proxy/jupyter-port），控制器不再依赖具体 Store，DI 装配不变
3. **llms 归位 (3a)**：LLM 解析/引导簇（~25 个互调函数）从 `configstore/llm_config.go` 迁回 `pkg/llms/resolver.go`，面向本地 `LLMResolverStore` 接口（现有 llms 接口组合），configstore 暂留 7 个委托保持编译
4. **调用方切换 (3b)**：runtimefacade/adapters/app 直连 `llms.*`，删除委托，断 `runtimefacade → configstore`；顺带修复接口化引入的 typed-nil 守卫（保持原"无 store 则跳过 LLM 配置"语义）
5. **docs**：AGENTS.md 移除已并入 loaders 的 bus 包描述，补 storeutil
6. **configstore 纵切 (Move 2a)**：136 方法按域切为 CoreStore/LoaderStore/EventStore/ProjectStore/LLMStore/CapabilityGatewayStore 六个子 store（共享同一 `*sql.DB`），`ConfigStore` 变为嵌入组合体——方法提升保证**包外零改动**

## 依赖图变化

```
改前:  events ──► configstore ◄── llms/runtimefacade   （反向边）
       configstore 内含 LLM 领域逻辑

改后:  events ──► storeutil（叶子）
       runtimefacade ──► llms（领域内）
       configstore = 纯持久化门面 + 6 个按域子 store
```

## 验证

- `task lint`：0 issues
- `task build`：通过
- `task test`：全套通过（Go 单测/集成/E2E + JS runtime），Combined 覆盖率 72.93%
- `go list` 确认：`events`、`llms/runtimefacade` 不再 import configstore；configstore 依赖边与改前一致
- Move 2a 纵切 commit 改动仅限 `pkg/storage/configstore/`（9 文件）
