### PR TITLE
fix(cli): clarify missing compose project errors

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -1110,7 +1110,7 @@ func runComposeStatsCommand(cmd *cobra.Command, cli cliOptions, args []string) e
 	if len(args) > 0 {
 		return runComposeSingleStatsCommand(cmd, cli, args[0])
 	}
-	_, normalized, projectID, err := resolveComposeProject(cli)
+	composePath, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
 	}
@@ -1122,7 +1122,7 @@ func runComposeStatsCommand(cmd *cobra.Command, cli cliOptions, args []string) e
 		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
 	}))
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("get project %s: %w", normalized.Name, err))
+		return commandExitErrorForComposeProject(fmt.Errorf("get project %s: %w", normalized.Name, err), "stats", normalized.Name, composePath)
 	}
 	output, err := composeProjectStatsOutputFromProject(cmd.Context(), clients, project.Msg.GetProject())
 	if err != nil {
@@ -1718,7 +1718,7 @@ func composeExecArgs(cmd *cobra.Command, args []string) error {
 }
 
 func runComposePSCommand(cmd *cobra.Command, cli cliOptions, options composePSOptions) error {
-	_, normalized, projectID, err := resolveComposeProject(cli)
+	composePath, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
 	}
@@ -1730,7 +1730,7 @@ func runComposePSCommand(cmd *cobra.Command, cli cliOptions, options composePSOp
 		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
 	}))
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("get project %s: %w", normalized.Name, err))
+		return commandExitErrorForComposeProject(fmt.Errorf("get project %s: %w", normalized.Name, err), "ps", normalized.Name, composePath)
 	}
 	output, err := composePSOutputFromProject(cmd.Context(), clients, project.Msg.GetProject(), options)
 	if err != nil {
@@ -2111,7 +2111,7 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 		}
 		return runComposeImageInspectCommand(cmd, cli, target)
 	}
-	_, normalized, projectID, err := resolveComposeProject(cli)
+	composePath, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
 	}
@@ -2127,7 +2127,7 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 			IncludeSpec: true,
 		}))
 		if err != nil {
-			return commandExitErrorForConnect(fmt.Errorf("inspect project %s: %w", normalized.Name, err))
+			return commandExitErrorForComposeProject(fmt.Errorf("inspect project %s: %w", normalized.Name, err), "inspect project", normalized.Name, composePath)
 		}
 		output = composeProjectOutputFromProject(project.Msg.GetProject())
 	case "agent":
@@ -2139,7 +2139,7 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 			IncludeSpec: true,
 		}))
 		if err != nil {
-			return commandExitErrorForConnect(fmt.Errorf("inspect agent %s in project %s: %w", target, normalized.Name, err))
+			return commandExitErrorForComposeProject(fmt.Errorf("inspect agent %s in project %s: %w", target, normalized.Name, err), "inspect agent", normalized.Name, composePath)
 		}
 		agent, err := composeAgentInspectOutputFor(cmd.Context(), clients, project.Msg.GetProject(), target)
 		if err != nil {
@@ -3950,6 +3950,21 @@ func commandExitErrorForConnect(err error) error {
 	default:
 		return err
 	}
+}
+
+func commandExitErrorForComposeProject(err error, command, projectName, composePath string) error {
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return commandExitError{
+			Code: exitCodeUsage,
+			Err: fmt.Errorf(
+				"project %q has not been started on this daemon or was removed by `agent-compose down`; run `agent-compose up --file %s` before `agent-compose %s`",
+				projectName,
+				composePath,
+				command,
+			),
+		}
+	}
+	return commandExitErrorForConnect(err)
 }
 
 func runDaemon(ctx context.Context) error {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -2562,6 +2562,65 @@ agents:
 	}
 }
 
+func TestIntegrationCLIProjectCommandsMissingProjectAreFriendly(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-ps-missing
+agents:
+  reviewer:
+    provider: codex
+`)
+	tests := []struct {
+		name        string
+		args        []string
+		wantCommand string
+	}{
+		{name: "ps", args: []string{"ps", "--host", "%s", "--file", composePath}, wantCommand: "ps"},
+		{name: "stats", args: []string{"stats", "--host", "%s", "--file", composePath}, wantCommand: "stats"},
+		{name: "inspect project", args: []string{"inspect", "--host", "%s", "--file", composePath, "project"}, wantCommand: "inspect project"},
+		{name: "inspect agent", args: []string{"inspect", "--host", "%s", "--file", composePath, "agent", "reviewer"}, wantCommand: "inspect agent"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newComposeServiceStubServer(t, composeServiceStubs{
+				project: projectServiceStub{
+					getProject: func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+						return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project project-cli-ps-missing not found: sql: no rows in result set"))
+					},
+				},
+			})
+			defer server.Close()
+
+			args := append([]string(nil), tc.args...)
+			for i, arg := range args {
+				if arg == "%s" {
+					args[i] = server.URL
+				}
+			}
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != exitCodeUsage {
+				t.Fatalf("%s missing project exit code = %d, want %d; stderr=%q", tc.name, exitCode, exitCodeUsage, stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("%s missing project stdout = %q, want empty", tc.name, stdout)
+			}
+			for _, want := range []string{
+				`project "cli-ps-missing" has not been started on this daemon or was removed by ` + "`agent-compose down`",
+				"agent-compose up --file " + composePath,
+				"before `agent-compose " + tc.wantCommand + "`",
+			} {
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("%s missing project stderr = %q, want %q", tc.name, stderr, want)
+				}
+			}
+			for _, notWant := range []string{"not_found", "sql: no rows"} {
+				if strings.Contains(stderr, notWant) {
+					t.Fatalf("%s missing project stderr = %q, should not expose %q", tc.name, stderr, notWant)
+				}
+			}
+		})
+	}
+}
+
 func TestIntegrationCLIStopSandbox(t *testing.T) {
 	var stopped []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -198,6 +198,7 @@ Rules:
 ## `ps`: List Sandboxes
 
 List sandboxes in the current project. By default, only running sandboxes are shown.
+The project must already exist on the daemon; after `agent-compose down`, run `agent-compose up` again before using `ps`.
 
 ```bash
 agent-compose ps
@@ -229,6 +230,7 @@ Default columns:
 ## `stats`: Show Sandbox Resource Stats
 
 Show resource stats snapshots for running sandboxes. Without a sandbox argument, the command shows all running sandboxes for the current compose project.
+Project-wide stats require the project to already exist on the daemon; after `agent-compose down`, run `agent-compose up` again before using `stats` without a sandbox.
 
 ```bash
 agent-compose stats
@@ -372,6 +374,7 @@ agent-compose logs --run-id run_123 --json
 ## `inspect`: Inspect Resources
 
 Inspect project resources or daemon images.
+`inspect project` and `inspect agent <agent>` require the project to already exist on the daemon; after `agent-compose down`, run `agent-compose up` again before using them.
 
 ```bash
 agent-compose inspect project

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -201,6 +201,7 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 ## `ps`：查看 sandbox
 
 查看当前 project 下的 sandbox。默认只显示运行中的 sandbox。
+该 project 必须已经存在于 daemon 中；执行 `agent-compose down` 后，需要先重新执行 `agent-compose up`，再使用 `ps`。
 
 ```bash
 agent-compose ps
@@ -234,6 +235,7 @@ agent-compose ps --json
 ## `stats`：查看 sandbox 资源统计
 
 查看运行中 sandbox 的资源统计快照。未指定 sandbox 参数时，显示当前 compose project 下所有 running sandbox 的统计。
+project 级 stats 要求该 project 已存在于 daemon 中；执行 `agent-compose down` 后，需要先重新执行 `agent-compose up`，再使用不带 sandbox 参数的 `stats`。
 
 ```bash
 agent-compose stats
@@ -383,6 +385,7 @@ agent-compose logs --run-id run_123 --json
 ## `inspect`：查看资源详情
 
 查看 project 下资源或 daemon image 的详细信息。
+`inspect project` 和 `inspect agent <agent>` 要求该 project 已存在于 daemon 中；执行 `agent-compose down` 后，需要先重新执行 `agent-compose up`，再使用它们。
 
 ```bash
 agent-compose inspect project


### PR DESCRIPTION
## Summary

  Clarify CLI errors when project-scoped commands are run after the compose project has not been started on the daemon or was removed by `agent-compose down`.

  This adds a shared CLI helper for missing compose project errors and applies it to the commands that first resolve the current project via `GetProject`:

  - `agent-compose ps`
  - `agent-compose stats` without a sandbox argument
  - `agent-compose inspect project`
  - `agent-compose inspect agent <agent>`

  The new message tells users to run `agent-compose up --file <compose-file>` before retrying, and avoids leaking internal `not_found` / `sql: no rows` details. CLI manual docs were
  updated in English and Chinese.

  ## Testing

  - `go test ./cmd/agent-compose -run 'TestIntegrationCLIProjectCommandsMissingProjectAreFriendly|TestIntegrationCLIPSTableAndJSON|
  TestIntegrationCLIStatsWithoutSandboxUsesProjectRunningSandboxes|TestIntegrationCLIInspectProjectAgentRunSandboxSessionJSON|TestCommandExitErrorForConnectClassifiesRPCFailures'`
  - `go test ./cmd/agent-compose`
  - `task lint`
  - `task build`
  - `git diff --check`

  Also ran `task test`; it still fails in an unrelated existing test:
  `pkg/llms/runtimefacade TestEnsureSessionLLMFacadeConfigCreatesCodexEnvAndToken`.
  The `cmd/agent-compose` package and other listed checks pass.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.