### PR TITLE
chore: upgrade BoxLite and Microsandbox runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG GOPROXY=https://goproxy.cn,direct
 FROM ${REGISTRY_MIRROR}/library/golang:1-alpine AS golang-toolchain
 
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS boxlite-build
-ARG BOXLITE_VERSION=v0.9.5
+ARG BOXLITE_VERSION=v0.9.7
 ARG TARGETARCH
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -26,7 +26,7 @@ RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     c
 # published checksums. This keeps the FFI lib in lockstep with the
 # microsandbox/sdk/go module pinned in go.mod.
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS microsandbox-fetch
-ARG MICROSANDBOX_VERSION=v0.5.8
+ARG MICROSANDBOX_VERSION=v0.6.4
 ARG TARGETARCH
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -39,7 +39,7 @@ ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
 RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl binutils tar &&     rm -rf /var/lib/apt/lists/*
-RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     case "${target_arch}" in       amd64) MICROSANDBOX_ARCH=x86_64 ;;       arm64) MICROSANDBOX_ARCH=aarch64 ;;       *) echo "unsupported Microsandbox target arch: ${target_arch}" >&2; exit 1 ;;     esac;     base="https://github.com/superradcompany/microsandbox/releases/download/${MICROSANDBOX_VERSION}";     mkdir -p /tmp/microsandbox/extract /out/bin /out/lib;     cd /tmp/microsandbox;     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/agentd-${MICROSANDBOX_ARCH}";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/libmicrosandbox_go_ffi-linux-${target_arch}.so";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/checksums.sha256";     sha256sum -c --ignore-missing checksums.sha256;     tar -xzf "microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz" -C /tmp/microsandbox/extract;     install -m755 /tmp/microsandbox/extract/msb /out/bin/msb;     install -m755 "agentd-${MICROSANDBOX_ARCH}" /out/bin/agentd;     install -m644 /tmp/microsandbox/extract/libkrunfw.so.5.2.1 /out/lib/libkrunfw.so.5.2.1;     ln -sf libkrunfw.so.5.2.1 /out/lib/libkrunfw.so.5;     ln -sf libkrunfw.so.5 /out/lib/libkrunfw.so;     install -m644 "libmicrosandbox_go_ffi-linux-${target_arch}.so" /out/lib/libmicrosandbox_go_ffi.so;     strip --strip-unneeded /out/lib/libmicrosandbox_go_ffi.so 2>/dev/null || true
+RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     case "${target_arch}" in       amd64) MICROSANDBOX_ARCH=x86_64 ;;       arm64) MICROSANDBOX_ARCH=aarch64 ;;       *) echo "unsupported Microsandbox target arch: ${target_arch}" >&2; exit 1 ;;     esac;     base="https://github.com/superradcompany/microsandbox/releases/download/${MICROSANDBOX_VERSION}";     mkdir -p /tmp/microsandbox/extract /out/bin /out/lib;     cd /tmp/microsandbox;     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/agentd-${MICROSANDBOX_ARCH}";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/libmicrosandbox_go_ffi-linux-${target_arch}.so";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/checksums.sha256";     sha256sum -c --ignore-missing checksums.sha256;     tar -xzf "microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz" -C /tmp/microsandbox/extract;     install -m755 /tmp/microsandbox/extract/msb /out/bin/msb;     install -m755 "agentd-${MICROSANDBOX_ARCH}" /out/bin/agentd;     krunfw="$(find /tmp/microsandbox/extract -maxdepth 1 -type f -name 'libkrunfw.so.*' | sort | tail -n 1)";     test -n "${krunfw}";     krunfw_name="$(basename "${krunfw}")";     install -m644 "${krunfw}" "/out/lib/${krunfw_name}";     ln -sf "${krunfw_name}" /out/lib/libkrunfw.so.5;     ln -sf libkrunfw.so.5 /out/lib/libkrunfw.so;     install -m644 "libmicrosandbox_go_ffi-linux-${target_arch}.so" /out/lib/libmicrosandbox_go_ffi.so;     strip --strip-unneeded /out/lib/libmicrosandbox_go_ffi.so 2>/dev/null || true
 
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS go-build
 ARG VERSION=0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -187,7 +187,7 @@ tasks:
     generates:
       - build/microsandbox/bin/msb
       - build/microsandbox/bin/agentd
-      - build/microsandbox/lib/libkrunfw.so.5.2.1
+      - build/microsandbox/lib/libkrunfw.so
       - build/microsandbox/lib/libmicrosandbox_go_ffi.so
     cmds:
       - HTTP_PROXY={{.BUILD_HTTP_PROXY}} HTTPS_PROXY={{.BUILD_HTTPS_PROXY}} ALL_PROXY={{.BUILD_ALL_PROXY}} REGISTRY_MIRROR={{.BUILD_REGISTRY_MIRROR}} ./scripts/export-microsandbox-dev-artifact.sh ./build/microsandbox

--- a/go.mod
+++ b/go.mod
@@ -16,14 +16,12 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/lmittmann/tint v1.1.3
-	github.com/moby/docker-image-spec v1.3.1
-	github.com/opencontainers/image-spec v1.1.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/do/v2 v2.0.0
 	github.com/samber/mo v1.16.0
 	github.com/samber/oops v1.21.0
 	github.com/spf13/cobra v1.10.1
-	github.com/superradcompany/microsandbox/sdk/go v0.5.8
+	github.com/superradcompany/microsandbox/sdk/go v0.6.4
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.45.0
@@ -52,6 +50,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
@@ -60,6 +59,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/samber/go-type-to-string v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/superradcompany/microsandbox/sdk/go v0.5.8 h1:zXQ3S1RokzB8YAGmV5lG+cjrTpebFNKB1lTtrjjF1OY=
-github.com/superradcompany/microsandbox/sdk/go v0.5.8/go.mod h1:Nqi2S7Xm1lgsUyV2vo21EVTL4de68lVC/YRDApB+2R0=
+github.com/superradcompany/microsandbox/sdk/go v0.6.4 h1:ITJhhuwM6FTZWgKpA0u2013bav+K4hBCJjCjJBueYqM=
+github.com/superradcompany/microsandbox/sdk/go v0.6.4/go.mod h1:Nqi2S7Xm1lgsUyV2vo21EVTL4de68lVC/YRDApB+2R0=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -982,7 +982,16 @@ func (r *cgoBoxRuntime) buildBoxOptions(ctx context.Context, session *Session, v
 	}
 
 	if jupyterEnabled(proxyState) && proxyState.HostPort > 0 {
-		C.boxlite_options_add_port(options, C.int(proxyState.GuestPort), C.int(proxyState.HostPort))
+		code := C.boxlite_options_add_port(
+			options,
+			C.uint16_t(proxyState.HostPort),
+			C.uint16_t(proxyState.GuestPort),
+			C.BoxlitePortProtocolTcp,
+			nil,
+		)
+		if err := boxliteStatusError(code, nil, "add jupyter port forwarding"); err != nil {
+			return nil, err
+		}
 	}
 
 	entrypoint, entrypointLen, freeEntrypoint := cStringArray([]string{"sh", "-lc"})

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -377,13 +378,78 @@ func (r *microsandboxRuntime) prepareEnvironment() error {
 
 func (r *microsandboxRuntime) resolveLibkrunfwPath() string {
 	libDir := filepath.Dir(r.config.MicrosandboxLibPath)
-	for _, name := range []string{"libkrunfw.so.5.2.1", "libkrunfw.so.5", "libkrunfw.so"} {
+	matches, _ := filepath.Glob(filepath.Join(libDir, "libkrunfw.so.*"))
+	var selected string
+	var selectedVersion []int
+	for _, match := range matches {
+		info, err := os.Lstat(match)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		version, ok := parseLibkrunfwVersion(filepath.Base(match))
+		if !ok {
+			continue
+		}
+		if selected == "" || compareIntVersions(version, selectedVersion) > 0 {
+			selected = match
+			selectedVersion = version
+		}
+	}
+	if selected != "" {
+		return selected
+	}
+	for _, name := range []string{"libkrunfw.so.5", "libkrunfw.so"} {
 		path := filepath.Join(libDir, name)
 		if _, err := os.Stat(path); err == nil {
 			return path
 		}
 	}
 	return ""
+}
+
+func parseLibkrunfwVersion(name string) ([]int, bool) {
+	const prefix = "libkrunfw.so."
+	versionText, ok := strings.CutPrefix(name, prefix)
+	if !ok || versionText == "" {
+		return nil, false
+	}
+	parts := strings.Split(versionText, ".")
+	version := make([]int, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return nil, false
+		}
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, false
+		}
+		version = append(version, value)
+	}
+	return version, true
+}
+
+func compareIntVersions(left []int, right []int) int {
+	maxLen := len(left)
+	if len(right) > maxLen {
+		maxLen = len(right)
+	}
+	for i := 0; i < maxLen; i++ {
+		var leftValue int
+		if i < len(left) {
+			leftValue = left[i]
+		}
+		var rightValue int
+		if i < len(right) {
+			rightValue = right[i]
+		}
+		if leftValue > rightValue {
+			return 1
+		}
+		if leftValue < rightValue {
+			return -1
+		}
+	}
+	return 0
 }
 
 func (r *microsandboxRuntime) installMicrosandboxRuntime(msbPath string, libkrunfwPath string) error {

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -2,7 +2,12 @@
 
 package driver
 
-import "testing"
+import (
+	appconfig "agent-compose/pkg/config"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestMicrosandboxExecCollectorMapsStdioStreams(t *testing.T) {
 	var streamed []ExecChunk
@@ -29,5 +34,47 @@ func TestMicrosandboxExecCollectorMapsStdioStreams(t *testing.T) {
 		if streamed[i] != want[i] {
 			t.Fatalf("streamed[%d] = %#v, want %#v", i, streamed[i], want[i])
 		}
+	}
+}
+
+func TestMicrosandboxResolveLibkrunfwPrefersVersionedRealFile(t *testing.T) {
+	libDir := t.TempDir()
+	versioned := filepath.Join(libDir, "libkrunfw.so.5.5.0")
+	if err := os.WriteFile(versioned, []byte("krun"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("libkrunfw.so.5.5.0", filepath.Join(libDir, "libkrunfw.so.5")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("libkrunfw.so.5", filepath.Join(libDir, "libkrunfw.so")); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime := &microsandboxRuntime{config: &appconfig.Config{
+		MicrosandboxLibPath: filepath.Join(libDir, "libmicrosandbox_go_ffi.so"),
+	}}
+	if got := runtime.resolveLibkrunfwPath(); got != versioned {
+		t.Fatalf("resolveLibkrunfwPath() = %q, want %q", got, versioned)
+	}
+}
+
+func TestMicrosandboxResolveLibkrunfwUsesNumericVersionOrder(t *testing.T) {
+	libDir := t.TempDir()
+	for _, name := range []string{
+		"libkrunfw.so.5.2.1",
+		"libkrunfw.so.5.10.0",
+		"libkrunfw.so.5.99.0.bak",
+	} {
+		if err := os.WriteFile(filepath.Join(libDir, name), []byte("krun"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runtime := &microsandboxRuntime{config: &appconfig.Config{
+		MicrosandboxLibPath: filepath.Join(libDir, "libmicrosandbox_go_ffi.so"),
+	}}
+	want := filepath.Join(libDir, "libkrunfw.so.5.10.0")
+	if got := runtime.resolveLibkrunfwPath(); got != want {
+		t.Fatalf("resolveLibkrunfwPath() = %q, want %q", got, want)
 	}
 }

--- a/scripts/export-microsandbox-dev-artifact.sh
+++ b/scripts/export-microsandbox-dev-artifact.sh
@@ -14,7 +14,7 @@ mkdir -p "$OUT_DIR"
 
 if [ -x "$OUT_DIR/bin/msb" ] &&
   [ -x "$OUT_DIR/bin/agentd" ] &&
-  [ -s "$OUT_DIR/lib/libkrunfw.so.5.2.1" ] &&
+  [ -s "$OUT_DIR/lib/libkrunfw.so" ] &&
   [ -s "$OUT_DIR/lib/libmicrosandbox_go_ffi.so" ]; then
   echo "Microsandbox dev artifacts already exist in $OUT_DIR"
   exit 0

--- a/scripts/prepare-agent-compose-boxlite.sh
+++ b/scripts/prepare-agent-compose-boxlite.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 OUT_DIR=${1:-"$ROOT_DIR/build/boxlite"}
 TMP_DIR=${BOXLITE_WORKDIR:-${AGENT_COMPOSE_BOXLITE_WORKDIR:-"$ROOT_DIR/build/.agent-compose-boxlite-src"}}
-BOXLITE_VERSION=${BOXLITE_VERSION:-v0.8.2}
+BOXLITE_VERSION=${BOXLITE_VERSION:-v0.9.7}
 GO_TOOLCHAIN_ENV="$ROOT_DIR/scripts/with-go-toolchain.sh"
 HOST_GOROOT=${HOST_GOROOT:-$("$GO_TOOLCHAIN_ENV" go env GOROOT)}
 HOST_GOPROXY=${HOST_GOPROXY:-$("$GO_TOOLCHAIN_ENV" go env GOPROXY 2>/dev/null || echo 'https://goproxy.cn,direct')}


### PR DESCRIPTION
## Summary
- Upgrade BoxLite runtime/C SDK artifacts to `v0.9.7`
- Upgrade Microsandbox artifacts and Go SDK to `v0.6.4`
- Make Microsandbox `libkrunfw` artifact handling version-flexible for the new `libkrunfw.so.5.5.0` layout
- Sync local BoxLite/Microsandbox dev artifact checks with the upgraded runtime assets

## Verification
- `go test ./cmd/... ./pkg/...`
- `GOFLAGS=-buildvcs=false task lint`
- Checked BoxLite `v0.9.7` release tar layout for runtime and C SDK assets
- Checked Microsandbox `v0.6.4` release asset URLs and verified `libkrunfw` symlink installation layout

## Notes
- Plain `task lint` hit Go VCS stamping failure in this temporary worktree: `error obtaining VCS status: exit status 128`; reran with `GOFLAGS=-buildvcs=false` and lint reported `0 issues`.
- Docker stage builds could not complete because pulling `docker.io/library/golang:1-alpine` timed out before reaching artifact download steps.
