### PR TITLE
Refine run sandbox and driver options

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -1436,6 +1436,9 @@ func runInteractiveComposeRun(cmd *cobra.Command, options composeRunOptions, pro
 		}
 		runReq := proto.Clone(baseReq).(*agentcomposev2.RunAgentRequest)
 		runReq.SessionId = sessionID
+		if strings.TrimSpace(sessionID) != "" {
+			runReq.Driver = ""
+		}
 		runReq.ClientRequestId = manualRunClientRequestID(projectName, baseReq.GetAgentName(), input)
 		if promptMode {
 			runReq.Prompt = input

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -41,6 +41,7 @@ import (
 	"agent-compose/pkg/auth"
 	"agent-compose/pkg/compose"
 	"agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/health"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/projects"
@@ -525,9 +526,8 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	}
 	runCmd.Flags().StringVar(&runOptions.Prompt, "prompt", "", "Prompt to send to the agent")
 	runCmd.Flags().StringVar(&runOptions.Command, "command", "", "Bash command to execute in the agent sandbox")
-	runCmd.Flags().StringVar(&runOptions.SandboxID, "sandbox", "", "Reuse an existing sandbox")
-	// Deprecated: use --sandbox instead.
-	runCmd.Flags().StringVar(&runOptions.SessionID, "session-id", "", "Reuse an existing session")
+	runCmd.Flags().StringVar(&runOptions.SandboxID, "sandbox-id", "", "Reuse an existing sandbox")
+	runCmd.Flags().StringVar(&runOptions.Driver, "driver", "", "Runtime driver override for a new sandbox")
 	runCmd.Flags().BoolVar(&runOptions.KeepRunning, "keep-running", false, "Keep the session runtime running after completion")
 	runCmd.Flags().BoolVar(&runOptions.Remove, "rm", false, "Remove the sandbox after a successful run")
 	runCmd.Flags().BoolVar(&runOptions.Jupyter, "jupyter", false, "Enable Jupyter for this run")
@@ -761,8 +761,8 @@ type composeListProjectsOptions struct {
 type composeRunOptions struct {
 	Prompt        string
 	Command       string
-	SessionID     string
 	SandboxID     string
+	Driver        string
 	KeepRunning   bool
 	Remove        bool
 	Jupyter       bool
@@ -1274,7 +1274,8 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 		Prompt:          prompt,
 		Command:         commandText,
 		Source:          agentcomposev2.RunSource_RUN_SOURCE_MANUAL,
-		SessionId:       strings.TrimSpace(normalizedOptions.SessionID),
+		SessionId:       strings.TrimSpace(normalizedOptions.SandboxID),
+		Driver:          strings.TrimSpace(normalizedOptions.Driver),
 		TriggerId:       triggerID,
 		CleanupPolicy:   cleanupPolicy,
 		ClientRequestId: manualRunClientRequestID(normalized.Name, agentName, firstNonEmptyString(prompt, triggerID, commandText)),
@@ -1531,16 +1532,17 @@ func writeDetachedRunText(out io.Writer, run *agentcomposev2.RunSummary, logsCom
 }
 
 func normalizeComposeRunOptions(cmd *cobra.Command, options composeRunOptions) (composeRunOptions, error) {
-	if cmd.Flags().Changed("session-id") {
-		if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose run --session-id", "agent-compose run --sandbox"); err != nil {
-			return options, err
+	options.SandboxID = strings.TrimSpace(options.SandboxID)
+	options.Driver = strings.TrimSpace(options.Driver)
+	if options.Driver != "" {
+		driver, err := driverpkg.ResolveSessionRuntimeDriver(options.Driver, "")
+		if err != nil {
+			return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run --driver: %w", err)}
 		}
-		if strings.TrimSpace(options.SandboxID) == "" {
-			options.SandboxID = options.SessionID
-		}
+		options.Driver = driver
 	}
-	if strings.TrimSpace(options.SandboxID) != "" {
-		options.SessionID = options.SandboxID
+	if options.SandboxID != "" && options.Driver != "" {
+		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run --driver cannot be combined with --sandbox-id")}
 	}
 	return options, nil
 }

--- a/cmd/agent-compose/main_integration_test.go
+++ b/cmd/agent-compose/main_integration_test.go
@@ -36,7 +36,7 @@ func testDaemonListenConfigWorkflow(t *testing.T) {
 	t.Run("cli up applies project first repeated modified and json", testCLIUpAppliesProjectFirstRepeatedModifiedAndJSON)
 	t.Run("cli up applies scheduler script and ps json", TestIntegrationCLIUpAppliesInlineSchedulerScriptAndPSJSON)
 	t.Run("cli down first repeated partial and json", testCLIDownFirstRepeatedPartialAndJSON)
-	t.Run("cli run streams output and supports session reuse", TestIntegrationCLIRunStreamsOutputAndSupportsSessionReuse)
+	t.Run("cli run streams output and supports sandbox reuse", TestIntegrationCLIRunStreamsOutputAndSupportsSandboxReuse)
 	t.Run("cli run detach starts background run", TestIntegrationCLIRunDetachStartsBackgroundRun)
 	t.Run("cli run detach json", TestIntegrationCLIRunDetachJSON)
 	t.Run("cli run detach command logs follow", TestIntegrationCLIRunDetachCommandCanBeFollowedByLogs)

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1540,6 +1540,70 @@ agents:
 	}
 }
 
+func TestIntegrationCLIRunInteractiveDriverOnlySentForInitialSandbox(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-run-interactive-driver
+agents:
+  reviewer:
+    provider: codex
+`)
+	var drivers []string
+	var prompts []string
+	var sessions []string
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		run: runServiceStub{
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+				drivers = append(drivers, req.Msg.GetDriver())
+				prompts = append(prompts, req.Msg.GetPrompt())
+				sessions = append(sessions, req.Msg.GetSessionId())
+				if req.Msg.GetCommand() != "" || req.Msg.GetTriggerId() != "" {
+					t.Fatalf("RunAgentStream interactive prompt request = %#v", req.Msg)
+				}
+				runID := fmt.Sprintf("run-driver-repl-%d", len(prompts))
+				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
+					EventType:  agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+					RunId:      runID,
+					Transcript: &agentcomposev2.TranscriptEvent{Text: fmt.Sprintf("driver %d output\n", len(prompts))},
+				}); err != nil {
+					return err
+				}
+				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
+					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+					RunId:     runID,
+					Run: &agentcomposev2.RunSummary{
+						RunId:     runID,
+						ProjectId: req.Msg.GetProjectId(),
+						AgentName: "reviewer",
+						Status:    agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
+						SessionId: "sandbox-driver-repl",
+					},
+				})
+			},
+			getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
+				return connect.NewResponse(&agentcomposev2.GetRunResponse{Run: testRunDetail(req.Msg.GetProjectId(), req.Msg.GetRunId(), "reviewer", "sandbox-driver-repl", agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, 0, "")}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommandWithInput("second prompt\n/exit\n", "run", "--host", server.URL, "--file", composePath, "--driver", "msb", "reviewer", "-i", "--prompt", "first prompt")
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("run -i --driver --prompt code/stderr = %d / %q", exitCode, stderr)
+	}
+	if stdout != "driver 1 output\ndriver 2 output\n" {
+		t.Fatalf("run -i --driver --prompt stdout = %q", stdout)
+	}
+	if strings.Join(prompts, "|") != "first prompt|second prompt" {
+		t.Fatalf("prompts = %#v", prompts)
+	}
+	if strings.Join(sessions, "|") != "|sandbox-driver-repl" {
+		t.Fatalf("sessions = %#v", sessions)
+	}
+	if strings.Join(drivers, "|") != "microsandbox|" {
+		t.Fatalf("drivers = %#v", drivers)
+	}
+}
+
 func TestIntegrationCLIRunInteractiveCommandReusesSession(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
 name: cli-run-interactive-command

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1132,7 +1132,7 @@ agents:
 	})
 }
 
-func TestIntegrationCLIRunStreamsOutputAndSupportsSessionReuse(t *testing.T) {
+func TestIntegrationCLIRunStreamsOutputAndSupportsSandboxReuse(t *testing.T) {
 	dir := t.TempDir()
 	composePath := writeComposeFile(t, dir, `
 name: cli-run-demo
@@ -1181,7 +1181,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox", "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
+	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox-id", "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
 	if exitCode != 0 {
 		t.Fatalf("run success exit code = %d, stderr=%q", exitCode, stderr)
 	}
@@ -1195,12 +1195,22 @@ agents:
 		t.Fatal("RunAgentStream was not called")
 	}
 
-	legacyOut, legacyErr, _, legacyCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--session-id", "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
-	if legacyCode != 0 {
-		t.Fatalf("run --session-id exit code = %d, stderr=%q", legacyCode, legacyErr)
-	}
-	if legacyOut != "live output\n" || !strings.Contains(legacyErr, "agent-compose run --session-id is deprecated") || strings.Contains(legacyOut, "deprecated") {
-		t.Fatalf("run --session-id stdout/stderr = %q / %q", legacyOut, legacyErr)
+	for _, tc := range []struct {
+		name string
+		flag string
+	}{
+		{name: "legacy sandbox flag", flag: "--sandbox"},
+		{name: "legacy session flag", flag: "--session-id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			legacyOut, legacyErr, _, legacyCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, tc.flag, "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
+			if legacyCode != exitCodeUsage {
+				t.Fatalf("run %s exit code = %d, want %d; stderr=%q", tc.flag, legacyCode, exitCodeUsage, legacyErr)
+			}
+			if legacyOut != "" || !strings.Contains(legacyErr, "unknown flag: "+tc.flag) {
+				t.Fatalf("run %s stdout/stderr = %q / %q", tc.flag, legacyOut, legacyErr)
+			}
+		})
 	}
 }
 
@@ -1217,7 +1227,7 @@ agents:
 			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
 				sawStart = true
 				runReq := req.Msg.GetRun()
-				if runReq.GetAgentName() != "reviewer" || runReq.GetCommand() != "echo detached" || runReq.GetSessionId() != "sandbox-detached" {
+				if runReq.GetAgentName() != "reviewer" || runReq.GetCommand() != "echo detached" || runReq.GetSessionId() != "" || runReq.GetDriver() != "microsandbox" {
 					t.Fatalf("StartRun request = %#v", runReq)
 				}
 				if runReq.GetSource() != agentcomposev2.RunSource_RUN_SOURCE_MANUAL {
@@ -1245,7 +1255,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("run", "-d", "--host", server.URL, "--file", composePath, "--sandbox", "sandbox-detached", "reviewer", "--command", "echo detached")
+	stdout, stderr, _, exitCode := executeCLICommand("run", "-d", "--host", server.URL, "--file", composePath, "--driver", "msb", "reviewer", "--command", "echo detached")
 	if exitCode != 0 {
 		t.Fatalf("run -d exit code = %d, stderr=%q", exitCode, stderr)
 	}
@@ -1678,9 +1688,9 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommandWithInput("", "run", "--host", server.URL, "--file", composePath, "--rm", "--sandbox", "sandbox-existing", "reviewer", "-i", "--prompt", "first")
+	stdout, stderr, _, exitCode := executeCLICommandWithInput("", "run", "--host", server.URL, "--file", composePath, "--rm", "--sandbox-id", "sandbox-existing", "reviewer", "-i", "--prompt", "first")
 	if exitCode != 0 || stdout != "" || stderr != "" {
-		t.Fatalf("run -i --rm --sandbox code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+		t.Fatalf("run -i --rm --sandbox-id code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 }
 
@@ -1871,6 +1881,26 @@ agents:
 			name: "trigger flag unsupported",
 			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--trigger", "nightly"},
 			want: "unknown flag: --trigger",
+		},
+		{
+			name: "legacy sandbox flag unsupported",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--sandbox", "sandbox-1", "--prompt", "check"},
+			want: "unknown flag: --sandbox",
+		},
+		{
+			name: "legacy session flag unsupported",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--session-id", "sandbox-1", "--prompt", "check"},
+			want: "unknown flag: --session-id",
+		},
+		{
+			name: "bad driver",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--driver", "bad", "--prompt", "check"},
+			want: "unsupported agent-compose runtime driver",
+		},
+		{
+			name: "driver with sandbox id",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--sandbox-id", "sandbox-1", "--driver", "docker", "--prompt", "check"},
+			want: "run --driver cannot be combined with --sandbox-id",
 		},
 		{
 			name: "command and prompt flags",

--- a/pkg/agentcompose/app/app_test.go
+++ b/pkg/agentcompose/app/app_test.go
@@ -76,9 +76,10 @@ func TestRunAgentRequestFromProtoPreservesCommand(t *testing.T) {
 		Prompt:    "prompt",
 		Command:   "echo hi",
 		TriggerId: "trigger-1",
+		Driver:    "microsandbox",
 		Jupyter:   &agentcomposev2.RunJupyterSpec{Enabled: true, Expose: true},
 	})
-	if req.ProjectID != "project-1" || req.AgentName != "worker" || req.Prompt != "prompt" || req.Command != "echo hi" || req.TriggerID != "trigger-1" {
+	if req.ProjectID != "project-1" || req.AgentName != "worker" || req.Prompt != "prompt" || req.Command != "echo hi" || req.TriggerID != "trigger-1" || req.Driver != "microsandbox" {
 		t.Fatalf("mapped request = %#v", req)
 	}
 	if req.Jupyter == nil || !req.Jupyter.GetEnabled() || !req.Jupyter.GetExpose() {

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -139,6 +139,7 @@ func runAgentRequestFromProto(msg *agentcomposev2.RunAgentRequest) runs.RunAgent
 		ClientRequestID:  msg.GetClientRequestId(),
 		Env:              msg.GetEnv(),
 		SessionID:        msg.GetSessionId(),
+		Driver:           msg.GetDriver(),
 		OutputSchemaJSON: msg.GetOutputSchemaJson(),
 		CleanupPolicy:    msg.GetCleanupPolicy(),
 		Jupyter:          msg.GetJupyter(),

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -125,6 +125,7 @@ type RunAgentRequest struct {
 	ClientRequestID  string
 	Env              []*agentcomposev2.EnvVarSpec
 	SessionID        string
+	Driver           string
 	OutputSchemaJSON string
 	CleanupPolicy    agentcomposev2.RunSessionCleanupPolicy
 	Jupyter          *agentcomposev2.RunJupyterSpec
@@ -157,6 +158,9 @@ func (c *Controller) StartProjectRun(ctx context.Context, req RunAgentRequest) (
 	if commandText != "" && (strings.TrimSpace(req.Prompt) != "" || strings.TrimSpace(req.TriggerID) != "") {
 		return StartedProjectRun{}, fmt.Errorf("%w: run requires only one of command, prompt, or trigger", ErrInvalidRequest)
 	}
+	if strings.TrimSpace(req.SessionID) != "" && strings.TrimSpace(req.Driver) != "" {
+		return StartedProjectRun{}, fmt.Errorf("%w: run driver cannot be combined with an existing sandbox", ErrInvalidRequest)
+	}
 	resolved, err := c.resolveTriggerForManualRun(ctx, req)
 	if err != nil {
 		return StartedProjectRun{}, err
@@ -171,6 +175,7 @@ func (c *Controller) StartProjectRun(ctx context.Context, req RunAgentRequest) (
 		SchedulerID:     req.SchedulerID,
 		TriggerID:       req.TriggerID,
 		Prompt:          req.Prompt,
+		Driver:          req.Driver,
 		ClientRequestID: req.ClientRequestID,
 	})
 	if err != nil {

--- a/pkg/runs/coordinator.go
+++ b/pkg/runs/coordinator.go
@@ -1,6 +1,7 @@
 package runs
 
 import (
+	driverpkg "agent-compose/pkg/driver"
 	domain "agent-compose/pkg/model"
 	"context"
 	"database/sql"
@@ -19,6 +20,7 @@ type StartRequest struct {
 	SchedulerID     string
 	TriggerID       string
 	Prompt          string
+	Driver          string
 	ClientRequestID string
 }
 
@@ -91,6 +93,7 @@ func (c *Coordinator) BeginRun(ctx context.Context, req StartRequest) (domain.Pr
 	req.Source = NormalizeSource(req.Source)
 	req.SchedulerID = strings.TrimSpace(req.SchedulerID)
 	req.TriggerID = strings.TrimSpace(req.TriggerID)
+	req.Driver = strings.TrimSpace(req.Driver)
 	req.ClientRequestID = strings.TrimSpace(req.ClientRequestID)
 	if req.ProjectID == "" || req.AgentName == "" {
 		return domain.ProjectRunRecord{}, fmt.Errorf("project id and agent name are required")
@@ -116,6 +119,13 @@ func (c *Coordinator) BeginRun(ctx context.Context, req StartRequest) (domain.Pr
 	if agent.ManagedProjectID != project.ID || agent.ManagedAgentName != projectAgent.AgentName {
 		return domain.ProjectRunRecord{}, fmt.Errorf("managed agent definition %s does not belong to project agent %s/%s", agent.ID, project.ID, projectAgent.AgentName)
 	}
+	driver := firstNonEmpty(req.Driver, agent.Driver, projectAgent.Driver)
+	if driver != "" {
+		driver, err = driverpkg.ResolveSessionRuntimeDriver(driver, "")
+		if err != nil {
+			return domain.ProjectRunRecord{}, err
+		}
+	}
 	runID, err := c.stableRunID(project.ID, projectAgent.AgentName, req.Source, req.ClientRequestID)
 	if err != nil {
 		return domain.ProjectRunRecord{}, err
@@ -132,7 +142,7 @@ func (c *Coordinator) BeginRun(ctx context.Context, req StartRequest) (domain.Pr
 		TriggerID:       req.TriggerID,
 		Status:          domain.ProjectRunStatusPending,
 		Prompt:          req.Prompt,
-		Driver:          firstNonEmpty(agent.Driver, projectAgent.Driver),
+		Driver:          driver,
 		ImageRef:        firstNonEmpty(agent.GuestImage, projectAgent.Image),
 		ResultJSON:      "{}",
 	}

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -14,6 +14,7 @@ import (
 
 	"agent-compose/pkg/compose"
 	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
 	"agent-compose/pkg/images"
 	"agent-compose/pkg/loaders"
@@ -48,6 +49,20 @@ func TestRunsCoordinatorAndHelperWorkflows(t *testing.T) {
 	}
 	if existing, err := coord.BeginRun(ctx, StartRequest{ProjectID: "project-1", AgentName: "worker", Source: domain.ProjectRunSourceAPI, ClientRequestID: "request-1"}); err != nil || existing.RunID != run.RunID {
 		t.Fatalf("idempotent BeginRun existing=%#v err=%v", existing, err)
+	}
+	if override, err := coord.BeginRun(ctx, StartRequest{ProjectID: "project-1", AgentName: "worker", Source: domain.ProjectRunSourceAPI, ClientRequestID: "request-driver", Driver: "msb"}); err != nil || override.Driver != driverpkg.RuntimeDriverMicrosandbox {
+		t.Fatalf("driver override run=%#v err=%v", override, err)
+	}
+	store.agent.Driver = ""
+	if fallback, err := coord.BeginRun(ctx, StartRequest{ProjectID: "project-1", AgentName: "worker", Source: domain.ProjectRunSourceAPI, ClientRequestID: "request-project-driver"}); err != nil || fallback.Driver != driverpkg.RuntimeDriverBoxlite {
+		t.Fatalf("project driver fallback run=%#v err=%v", fallback, err)
+	}
+	beforeInvalid := len(store.runs)
+	if _, err := coord.BeginRun(ctx, StartRequest{ProjectID: "project-1", AgentName: "worker", Source: domain.ProjectRunSourceAPI, ClientRequestID: "request-bad-driver", Driver: "bad"}); err == nil {
+		t.Fatalf("expected invalid driver error")
+	}
+	if len(store.runs) != beforeInvalid {
+		t.Fatalf("invalid driver created run: before=%d after=%d", beforeInvalid, len(store.runs))
 	}
 	if running, err := coord.MarkRunning(ctx, run.RunID, "session-1"); err != nil || running.Status != domain.ProjectRunStatusRunning || running.SessionID != "session-1" {
 		t.Fatalf("MarkRunning run=%#v err=%v", running, err)
@@ -690,6 +705,17 @@ func TestRunsControllerRunProjectAgentRemoveOnCompletionCleanup(t *testing.T) {
 		}
 		if run.SessionID != session.Summary.ID || loaded.Summary.VMStatus != domain.VMStatusStopped {
 			t.Fatalf("run=%#v loaded session=%#v", run, loaded.Summary)
+		}
+	})
+
+	t.Run("driver cannot be combined with existing session", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		run, execErr, err := runAgentWithRemoveOnCompletion(t, fixture, func(req *RunAgentRequest) {
+			req.SessionID = "existing"
+			req.Driver = "docker"
+		})
+		if !errors.Is(err, ErrInvalidRequest) || execErr != nil {
+			t.Fatalf("RunProjectAgent run=%#v err=%v execErr=%v", run, err, execErr)
 		}
 	})
 }

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -2924,6 +2924,7 @@ type RunAgentRequest struct {
 	ClientRequestId  string                  `protobuf:"bytes,11,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
 	Command          string                  `protobuf:"bytes,12,opt,name=command,proto3" json:"command,omitempty"`
 	Jupyter          *RunJupyterSpec         `protobuf:"bytes,13,opt,name=jupyter,proto3" json:"jupyter,omitempty"`
+	Driver           string                  `protobuf:"bytes,14,opt,name=driver,proto3" json:"driver,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -3047,6 +3048,13 @@ func (x *RunAgentRequest) GetJupyter() *RunJupyterSpec {
 		return x.Jupyter
 	}
 	return nil
+}
+
+func (x *RunAgentRequest) GetDriver() string {
+	if x != nil {
+		return x.Driver
+	}
+	return ""
 }
 
 type RunAgentResponse struct {
@@ -6514,7 +6522,7 @@ const file_proto_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x10DockerDriverSpec\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\"2\n" +
 	"\x16MicrosandboxDriverSpec\x12\x18\n" +
-	"\aprofile\x18\x01 \x01(\tR\aprofile\"\xab\x04\n" +
+	"\aprofile\x18\x01 \x01(\tR\aprofile\"\xc3\x04\n" +
 	"\x0fRunAgentRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1d\n" +
@@ -6533,7 +6541,8 @@ const file_proto_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	" \x01(\tR\x10outputSchemaJson\x12*\n" +
 	"\x11client_request_id\x18\v \x01(\tR\x0fclientRequestId\x12\x18\n" +
 	"\acommand\x18\f \x01(\tR\acommand\x129\n" +
-	"\ajupyter\x18\r \x01(\v2\x1f.agentcompose.v2.RunJupyterSpecR\ajupyter\"\\\n" +
+	"\ajupyter\x18\r \x01(\v2\x1f.agentcompose.v2.RunJupyterSpecR\ajupyter\x12\x16\n" +
+	"\x06driver\x18\x0e \x01(\tR\x06driver\"\\\n" +
 	"\x10RunAgentResponse\x12,\n" +
 	"\x03run\x18\x01 \x01(\v2\x1a.agentcompose.v2.RunDetailR\x03run\x12\x1a\n" +
 	"\bwarnings\x18\x02 \x03(\tR\bwarnings\"\xf0\x02\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -372,6 +372,7 @@ message RunAgentRequest {
   string client_request_id = 11;
   string command = 12;
   RunJupyterSpec jupyter = 13;
+  string driver = 14;
 }
 
 message RunAgentResponse {


### PR DESCRIPTION
## Summary
- rename run sandbox reuse flag to --sandbox-id and remove run --sandbox/--session-id compatibility
- add run --driver override with runtime driver validation and sandbox reuse mutual exclusion
- carry driver through v2 RunAgentRequest into run records while preserving existing fallback behavior

## Verification
- npm run gen && npm run build (proto-client)
- GOCACHE=/home/inno/workspaces/github/chaitin/agent-compose/.cache/go-build ./scripts/with-go-toolchain.sh go test ./cmd/agent-compose ./pkg/runs ./pkg/agentcompose/app ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect
- task build