### PR TITLE
Fix live project run log following

### DIFF
--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -362,7 +362,7 @@ func testComposeRunLogAndExecHelpers(t *testing.T) {
 	if err := writeLogDetails(&out, []*agentcomposev2.RunDetail{detail}, map[string]int{}, composeLogsOptions{TailLines: 1, Timestamp: true}); err != nil {
 		t.Fatalf("writeLogDetails returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "reviewer | completed line3") {
+	if !strings.Contains(out.String(), "reviewer-run-1 | time=completed line3") {
 		t.Fatalf("log details = %q", out.String())
 	}
 	out.Reset()

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3579,7 +3579,7 @@ func followRunLogStream(ctx context.Context, out io.Writer, client agentcomposev
 	for stream.Receive() {
 		chunk := stream.Msg()
 		if chunk.GetData() != "" {
-			if err := writePrefixedRunOutput(out, summary, chunk.GetData(), options.Timestamp); err != nil {
+			if err := writePrefixedRunOutputWithTimestamp(out, summary, chunk.GetData(), options.Timestamp, chunk.GetCreatedAt()); err != nil {
 				return err
 			}
 		}
@@ -3638,11 +3638,15 @@ func writeLogDetails(out io.Writer, details []*agentcomposev2.RunDetail, printed
 }
 
 func writePrefixedRunOutput(out io.Writer, summary *agentcomposev2.RunSummary, output string, timestamp bool) error {
+	return writePrefixedRunOutputWithTimestamp(out, summary, output, timestamp, runLogTimestamp(summary))
+}
+
+func writePrefixedRunOutputWithTimestamp(out io.Writer, summary *agentcomposev2.RunSummary, output string, timestamp bool, timestampValue string) error {
 	if output == "" {
 		return nil
 	}
-	agentName := firstNonEmptyString(summary.GetAgentName(), summary.GetRunId(), "-")
-	runTime := runLogTimestamp(summary)
+	prefix := runLogPrefix(summary)
+	runTime := formatComposeLogTimestamp(timestampValue)
 	for len(output) > 0 {
 		line := output
 		rest := ""
@@ -3650,11 +3654,11 @@ func writePrefixedRunOutput(out io.Writer, summary *agentcomposev2.RunSummary, o
 			line = output[:idx+1]
 			rest = output[idx+1:]
 		}
-		if _, err := fmt.Fprintf(out, "%s | ", agentName); err != nil {
+		if _, err := fmt.Fprintf(out, "%s | ", prefix); err != nil {
 			return err
 		}
 		if timestamp && runTime != "" {
-			if _, err := fmt.Fprintf(out, "%s ", runTime); err != nil {
+			if _, err := fmt.Fprintf(out, "time=%s ", runTime); err != nil {
 				return err
 			}
 		}
@@ -3669,6 +3673,26 @@ func writePrefixedRunOutput(out io.Writer, summary *agentcomposev2.RunSummary, o
 		output = rest
 	}
 	return nil
+}
+
+func runLogPrefix(summary *agentcomposev2.RunSummary) string {
+	runID := strings.TrimSpace(summary.GetRunId())
+	agentName := strings.TrimSpace(summary.GetAgentName())
+	if agentName == "" {
+		return firstNonEmptyString(runID, "-")
+	}
+	if runID == "" || runID == agentName {
+		return agentName
+	}
+	return agentName + "-" + shortRunID(runID)
+}
+
+func shortRunID(runID string) string {
+	runID = strings.TrimSpace(runID)
+	if len(runID) <= 8 {
+		return runID
+	}
+	return runID[:8]
 }
 
 func tailLogOutput(output string, lines int) string {
@@ -3695,6 +3719,18 @@ func tailLogOutput(output string, lines int) string {
 
 func runLogTimestamp(summary *agentcomposev2.RunSummary) string {
 	return firstNonEmptyString(summary.GetCompletedAt(), summary.GetUpdatedAt(), summary.GetStartedAt())
+}
+
+func formatComposeLogTimestamp(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return value
+	}
+	return parsed.UTC().Format("2006-01-02T15:04:05.000Z")
 }
 
 func manualRunClientRequestID(projectName, agentName, prompt string) string {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1359,7 +1359,7 @@ agents:
 		t.Fatalf("run -d --command code/stderr = %d / %q", exitCode, stderr)
 	}
 	logOut, logErr, _, logCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-detached-logs", "--follow")
-	if logCode != 0 || logErr != "" || logOut != "reviewer | detached output\n" {
+	if logCode != 0 || logErr != "" || logOut != "reviewer-run-deta | detached output\n" {
 		t.Fatalf("logs --follow code/stdout/stderr = %d / %q / %q", logCode, logOut, logErr)
 	}
 	if !sawCommand || !sawFollow {
@@ -2267,7 +2267,7 @@ agents:
 	}
 
 	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-logs")
-	if runCode != 0 || runErr != "" || runOut != "reviewer | stored log output\n" {
+	if runCode != 0 || runErr != "" || runOut != "reviewer-run-logs | stored log output\n" {
 		t.Fatalf("logs --run-id code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
 	}
 }
@@ -2297,7 +2297,7 @@ agents:
 	defer server.Close()
 
 	stdout, stderr, _, exitCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--tail", "2")
-	if exitCode != 0 || stderr != "" || stdout != "reviewer | two\nreviewer | three\n" {
+	if exitCode != 0 || stderr != "" || stdout != "reviewer-run-tail | two\nreviewer-run-tail | three\n" {
 		t.Fatalf("logs --tail text code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 
@@ -2314,7 +2314,7 @@ agents:
 	}
 
 	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-tail", "-n", "1")
-	if runCode != 0 || runErr != "" || runOut != "reviewer | three\n" {
+	if runCode != 0 || runErr != "" || runOut != "reviewer-run-tail | three\n" {
 		t.Fatalf("logs --run-id --tail code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
 	}
 }
@@ -2367,9 +2367,9 @@ agents:
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("logs --timestamp code/stderr = %d / %q", exitCode, stderr)
 	}
-	want := "reviewer | 2026-06-11T00:00:02Z review one\n" +
-		"writer | 2026-06-11T00:00:01Z write one\n" +
-		"writer | 2026-06-11T00:00:01Z write two\n"
+	want := "reviewer-run-revi | time=2026-06-11T00:00:02.000Z review one\n" +
+		"writer-run-writ | time=2026-06-11T00:00:01.000Z write one\n" +
+		"writer-run-writ | time=2026-06-11T00:00:01.000Z write two\n"
 	if stdout != want {
 		t.Fatalf("logs --timestamp stdout = %q, want %q", stdout, want)
 	}
@@ -2413,22 +2413,22 @@ agents:
 			if req.Msg.GetRunId() != "run-follow" || !req.Msg.GetFollow() || req.Msg.GetTailLines() != 2 {
 				t.Fatalf("FollowRunLogs request = %#v", req.Msg)
 			}
-			if err := stream.Send(&agentcomposev2.RunLogChunk{Data: "first\n", Offset: 6, RunStatus: agentcomposev2.RunStatus_RUN_STATUS_RUNNING}); err != nil {
+			if err := stream.Send(&agentcomposev2.RunLogChunk{Data: "first\n", Offset: 6, RunStatus: agentcomposev2.RunStatus_RUN_STATUS_RUNNING, CreatedAt: "2026-07-06T08:01:36.372Z"}); err != nil {
 				return err
 			}
-			return stream.Send(&agentcomposev2.RunLogChunk{Data: "second\n", Offset: 13, RunStatus: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, IsFinal: true})
+			return stream.Send(&agentcomposev2.RunLogChunk{Data: "second\n", Offset: 13, RunStatus: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, CreatedAt: "2026-07-06T08:01:36.875Z", IsFinal: true})
 		},
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--follow", "--tail", "2")
+	stdout, stderr, _, exitCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--follow", "--tail", "2", "--timestamp")
 	if exitCode != 0 {
 		t.Fatalf("logs follow exit code = %d, stderr=%q", exitCode, stderr)
 	}
 	if stderr != "" {
 		t.Fatalf("logs follow stderr = %q, want empty", stderr)
 	}
-	if stdout != "reviewer | first\nreviewer | second\n" {
+	if stdout != "reviewer-run-foll | time=2026-07-06T08:01:36.372Z first\nreviewer-run-foll | time=2026-07-06T08:01:36.875Z second\n" {
 		t.Fatalf("logs follow stdout = %q", stdout)
 	}
 	if listCalls != 1 || followCalls != 1 {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -552,6 +552,11 @@ func TestFollowRunLogsStreamsOffsetsTailAndFinal(t *testing.T) {
 		t.Fatalf("all chunks = %#v", all)
 	}
 
+	followAll := collectRunLogChunks(t, client, &agentcomposev2.FollowRunLogsRequest{ProjectId: "project-1", RunId: "run-1", Follow: true})
+	if len(followAll) != 2 || followAll[0].GetData() != "one\ntwo\nthree\n" || followAll[0].GetOffset() != 14 || !followAll[1].GetIsFinal() {
+		t.Fatalf("follow all chunks = %#v", followAll)
+	}
+
 	tail := collectRunLogChunks(t, client, &agentcomposev2.FollowRunLogsRequest{ProjectId: "project-1", RunId: "run-1", TailLines: 2, Follow: true})
 	if len(tail) != 2 || tail[0].GetData() != "two\nthree\n" || tail[0].GetOffset() != 14 || !tail[1].GetIsFinal() {
 		t.Fatalf("tail chunks = %#v", tail)

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -174,22 +174,12 @@ func (h *RunHandler) projectRunForLogRequest(ctx context.Context, projectID, run
 	return run, nil
 }
 
-func initialRunLogOffset(path string, tailLines int, startOffset uint64, follow bool) (uint64, error) {
+func initialRunLogOffset(path string, tailLines int, startOffset uint64, _ bool) (uint64, error) {
 	if tailLines > 0 {
 		return tailRunLogOffset(path, tailLines)
 	}
 	if startOffset > 0 {
 		return startOffset, nil
-	}
-	if follow {
-		info, err := os.Stat(path)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return 0, nil
-			}
-			return 0, err
-		}
-		return uint64(info.Size()), nil
 	}
 	return 0, nil
 }

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -306,7 +306,7 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 		RunID:             run.RunID,
 		Message:           req.Prompt,
 		OutputSchemaJSON:  req.OutputSchemaJSON,
-		Stream:            projectRunAgentExecutionStream(run, sessionResult.Session, stream),
+		Stream:            projectRunAgentExecutionStream(transitionCtx, coordinator, run, sessionResult.Session, stream),
 	})
 	transition := TransitionFromAgentCell(run, sessionResult.Session, cell, execErr)
 	if execErr != nil || !cell.Success {
@@ -459,9 +459,21 @@ func (c *Controller) projectRunAgentConfig(ctx context.Context, run domain.Proje
 	return config, nil
 }
 
-func projectRunAgentExecutionStream(run domain.ProjectRunRecord, session *domain.Session, sink *StreamSink) execution.AgentExecutionStream {
+func projectRunAgentExecutionStream(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, session *domain.Session, sink *StreamSink) execution.AgentExecutionStream {
 	return execution.AgentExecutionStream{
-		OnStart: func(domain.NotebookCell) error {
+		OnStart: func(cell domain.NotebookCell) error {
+			if coordinator != nil {
+				logsPath := projectRunAgentCellOutputPath(session, cell.ID)
+				if strings.TrimSpace(logsPath) != "" {
+					if _, err := coordinator.TransitionRun(ctx, TransitionRequest{
+						RunID:    run.RunID,
+						Status:   domain.ProjectRunStatusRunning,
+						LogsPath: logsPath,
+					}); err != nil {
+						return err
+					}
+				}
+			}
 			if sink == nil || sink.SendStarted == nil {
 				return nil
 			}

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -242,6 +242,7 @@ func TestRunsControllerRunProjectAgentSuccessWorkflow(t *testing.T) {
 		Dashboard: dashboard,
 	})
 	var started bool
+	var startedLogsPath string
 	var chunks []domain.ExecChunk
 	run, execErr, err := controller.RunProjectAgent(ctx, RunAgentRequest{
 		ProjectID:       "project-1",
@@ -251,8 +252,9 @@ func TestRunsControllerRunProjectAgentSuccessWorkflow(t *testing.T) {
 		ClientRequestID: "request-1",
 		CleanupPolicy:   agentcomposev2.RunSessionCleanupPolicy_RUN_SESSION_CLEANUP_POLICY_STOP_ON_COMPLETION,
 	}, &StreamSink{
-		SendStarted: func(domain.ProjectRunRecord, time.Time) error {
+		SendStarted: func(run domain.ProjectRunRecord, _ time.Time) error {
 			started = true
+			startedLogsPath = configDB.runs[run.RunID].LogsPath
 			return nil
 		},
 		SendChunk: func(_ string, chunk domain.ExecChunk, _ time.Time) error {
@@ -268,6 +270,9 @@ func TestRunsControllerRunProjectAgentSuccessWorkflow(t *testing.T) {
 	}
 	if !started || len(chunks) != 1 || !driver.started || !driver.stopped || executor.request.Message != "do work" {
 		t.Fatalf("started=%v chunks=%#v driver=%#v request=%#v", started, chunks, driver, executor.request)
+	}
+	if startedLogsPath == "" || filepath.Base(startedLogsPath) != "output.txt" {
+		t.Fatalf("started logs path = %q, want cell output path", startedLogsPath)
 	}
 	if data, err := os.ReadFile(run.LogsPath); err != nil || string(data) != "chunk" {
 		t.Fatalf("agent run logs_path content = %q err=%v", string(data), err)


### PR DESCRIPTION
## Summary

  - Fix `agent-compose logs --follow` for long-running agent runs by persisting the agent cell log path as soon as the cell starts, allowing the follow stream to read live log output
  before the run finishes.
  - Make `logs --follow` print existing logs before following new output, matching `docker compose logs -f` behavior for completed and running runs.
  - Improve text log prefixes to include a short run id suffix so repeated runs of the same agent are distinguishable.
  - Format `--timestamp` output as `time=<RFC3339-ms>` and use streamed chunk timestamps when following logs.

  ## Testing

  - `go test ./cmd/agent-compose`
  - `go test ./pkg/runs`
  - `go test ./pkg/agentcompose/api`

  ## Checklist

  - [ ] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.