### PR TITLE
fix(loaders): restore LOADER_RUN_TIMEOUT env by injecting RunTimeout

### DIFF
--- a/pkg/agentcompose/app/loader_controller.go
+++ b/pkg/agentcompose/app/loader_controller.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/samber/do/v2"
 
@@ -30,7 +31,16 @@ func NewLoaderController(di do.Injector) (*loaders.Controller, error) {
 		notifier = hub
 	}
 	controller = loaders.NewController(loaders.ControllerDependencies{
-		RootCtx:   do.MustInvoke[context.Context](di),
+		RootCtx: do.MustInvoke[context.Context](di),
+		RunTimeout: func(override time.Duration) time.Duration {
+			if override > 0 {
+				return override
+			}
+			if config.LoaderRunTimeout > 0 {
+				return config.LoaderRunTimeout
+			}
+			return 20 * time.Minute
+		},
 		Store:     configDB,
 		Engine:    do.MustInvoke[loaders.LoaderEngine](di),
 		Publisher: bus,


### PR DESCRIPTION
## 问题

`LOADER_RUN_TIMEOUT` 环境变量在当前代码里是**死配置**——设成任何值都不生效,所有 webhook / event / scheduled 触发的 loader run 都被硬编码的 20 分钟超时掐断。

## 根因

PR #174 (remove-service-stack) 重构时,把 loader run 总超时逻辑从旧的 `LoaderManager.loaderRunTimeout()` 搬到了 `loaders.Controller`,但**搬家时漏掉了"读 `config.LoaderRunTimeout`"这一步**。

- `Controller` 预留了可选注入点 `deps.RunTimeout func(time.Duration) time.Duration`,`runTimeout()` 在它非 nil 时会调用它。
- 但 `NewLoaderController` 组装 `ControllerDependencies{}` 时从未注入 `RunTimeout`,导致它恒为 `nil`。
- 于是 `runTimeout()` 回落到只剩 `override > 0` 和 `20 * time.Minute` 两段的默认逻辑,**中间那段"读 config.LoaderRunTimeout"没了**。
- 结果:`config.LoaderRunTimeout` 字段被解析、被赋值,但全局零读取(可 `grep LoaderRunTimeout` 验证:只有定义 + 赋值两处),env 形同虚设。

对照重构前 `loader_manager.go` 的实现,三段式语义本应是:

```go
func (m *LoaderManager) loaderRunTimeout(override time.Duration) time.Duration {
    if override > 0 { return override }
    if m.config != nil && m.config.LoaderRunTimeout > 0 { return m.config.LoaderRunTimeout }
    return 20 * time.Minute
}
```

## 修复

在 `NewLoaderController` 组装 `ControllerDependencies{}` 时注入 `RunTimeout` 闭包,**精确恢复重构前的三段式优先级**(override > config.LoaderRunTimeout > 20m 默认)。利用重构后架构预留的注入口,`Controller` 无需直接依赖 app config,由持有 config 的 app 层注入读 config 的闭包——这正是该注入口设计的本意。

手动 `RunLoaderNow` 的 timeout 覆盖之前就通过 `override` 分支生效;本次恢复的是**自动 run 的 config/env 路径**。

## 影响

- `LOADER_RUN_TIMEOUT` env 重新生效,可覆盖 20 分钟默认。
- 修复了真实 webhook 触发的 project-agent 任务被 20 分钟误杀的问题(症状:run 在 session 就绪约 20 分钟后失败,error 为被掩盖的 `insert loader event ... context deadline exceeded`)。

## 验证

- `gofmt -l` 无输出
- `go build ./pkg/agentcompose/app/...` 通过
- `go test ./pkg/loaders/...` 通过

改动仅新增一个闭包注入(11 增 1 删),不触碰任何现有调用点。
