### PR TITLE
fix(cli): use sandbox terminology in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Images & Release](https://github.com/chaitin/agent-compose/actions/workflows/images.yml/badge.svg?branch=main)](https://github.com/chaitin/agent-compose/actions/workflows/images.yml)
 
 agent-compose is an experimental control plane for running isolated agent
-sessions. It provides a daemon, CLI, Connect APIs, runtime drivers, workspace
+sandboxes. It provides a daemon, CLI, Connect APIs, runtime drivers, workspace
 provisioning, scheduler automation, event history, and a Jupyter proxy for
 notebook-style guest runtimes.
 
@@ -138,8 +138,8 @@ The main commands are:
 - `agent-compose run <agent> <trigger-name>`: run a configured trigger by name.
 - `agent-compose run <agent> --prompt "..."` / `--command "..."`: run ad hoc prompt or shell command work.
 - `agent-compose logs`: inspect project run logs.
-- `agent-compose ps`: list project agents, recent runs, and active sessions.
-- `agent-compose down`: disable managed schedulers and stop running sessions.
+- `agent-compose ps`: list project agents, recent runs, and active sandboxes.
+- `agent-compose down`: disable managed schedulers and stop running sandboxes.
 - `agent-compose images`, `pull`, `rmi`, `image inspect`: manage daemon-side images.
 - `agent-compose cache ls|inspect|prune|rm`: inspect and explicitly clean daemon runtime caches. `prune` and `rm` are dry-run unless `--force` is set.
 
@@ -288,13 +288,13 @@ Important variables include:
   used when generating runtime LLM facade configuration. Docker Compose
   defaults this to `http://agent-compose:7410`; host-based Docker setups should
   set it to a concrete host IP/name and port.
-- `DOCKER_HOST_SESSION_ROOT`: host path for session data bind-mounted into guest
+- `DOCKER_HOST_SESSION_ROOT`: host path for sandbox data bind-mounted into guest
   containers. Docker Compose defaults this to `./data/agent-compose/sessions`.
 - `CAP_GRPC_LISTEN`, `CAP_GRPC_TARGET`: required only when agents need to call
   OctoBus gRPC capabilities. `CAP_GRPC_LISTEN` starts the agent-compose
   capability proxy; `CAP_GRPC_TARGET` is the guest-reachable address injected
-  into new sessions. After changing either value, restart the daemon and create
-  a new session.
+  into new sandboxes. After changing either value, restart the daemon and create
+  a new sandbox.
 - `IMAGE_STORE_MODE`, `IMAGE_CACHE_ROOT`, `IMAGE_REGISTRY`,
   `IMAGE_INSECURE_REGISTRIES`: image store and OCI cache settings.
 - `BOXLITE_HOME`, `BOXLITE_RUNTIME_DIR`, `BOX_ROOTFS_PATH`, `BOX_CACHE_TTL`:
@@ -312,10 +312,10 @@ Important variables include:
 
 ### Agent providers
 
-Guest agent sessions run provider CLIs through the `agent-compose-runtime` CLI,
+Guest agent sandboxes run provider CLIs through the `agent-compose-runtime` CLI,
 provided by the `@chaitin-ai/agent-compose-runtime` npm package. Codex and Claude calls use the Runtime LLM Facade:
 provider keys stay in the daemon-side LLM provider configuration, while guest
-runtimes receive session-scoped facade tokens and facade base URLs. LLM provider
+runtimes receive sandbox-scoped facade tokens and facade base URLs. LLM provider
 key names such as `LLM_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 `ANTHROPIC_AUTH_TOKEN`, `GOOGLE_API_KEY`, and `GEMINI_API_KEY` are filtered from
 user-supplied runtime environment variables. Compatibility aliases such as
@@ -337,7 +337,7 @@ After changing guest runtime code or provider support, rebuild the guest image:
 task image:agent-compose-guest
 ```
 
-Create a new session (or resume one) so the updated image and environment
+Create a new sandbox (or resume one) so the updated image and environment
 variables are picked up.
 
 > **Upgrade note (breaking for some Docker setups):** Because provider keys are
@@ -370,7 +370,7 @@ LLM_MODEL=your-model
 Compatible backends include DeepSeek, local OpenAI-compatible proxies
 (vLLM/Ollama), and similar Chat Completions endpoints.
 
-This does not create a workspace-capable agent session and does not grant file,
+This does not create a workspace-capable agent sandbox and does not grant file,
 command, or MCP tool access.
 
 With `outputSchema`, `chat_completions` uses prompt guidance and

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -524,14 +524,14 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 		t.Fatalf("logs agent conflict err=%v code=%d", err, commandExitCode(err))
 	}
 	logsCmd = &cobra.Command{Use: "logs"}
-	logsCmd.Flags().String("session-id", "", "")
-	if err := logsCmd.Flags().Set("session-id", "legacy-session"); err != nil {
-		t.Fatalf("set session-id flag: %v", err)
+	logsCmd.Flags().String("sandbox", "", "")
+	if err := logsCmd.Flags().Set("sandbox", "sandbox-logs"); err != nil {
+		t.Fatalf("set sandbox flag: %v", err)
 	}
 	out.Reset()
 	logsCmd.SetErr(&out)
-	logOptions, err := normalizeComposeLogsOptions(logsCmd, composeLogsOptions{SessionID: "legacy-session", TailLines: -1}, nil)
-	if err != nil || logOptions.SessionID != "legacy-session" || !strings.Contains(out.String(), "deprecated") {
+	logOptions, err := normalizeComposeLogsOptions(logsCmd, composeLogsOptions{SandboxID: "sandbox-logs", TailLines: -1}, nil)
+	if err != nil || logOptions.SessionID != "sandbox-logs" || out.String() != "" {
 		t.Fatalf("normalizeComposeLogsOptions options=%#v err=%v stderr=%q", logOptions, err, out.String())
 	}
 	if _, err := normalizeComposeLogsOptions(&cobra.Command{Use: "logs"}, composeLogsOptions{TailLines: -2}, nil); commandExitCode(err) != exitCodeUsage {
@@ -542,9 +542,9 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 	if err := composeExecArgs(execCmd, nil); err == nil {
 		t.Fatalf("composeExecArgs without target returned nil error")
 	}
-	execCmd.Flags().String("session-id", "", "")
-	if err := execCmd.Flags().Set("session-id", "session-1"); err != nil {
-		t.Fatalf("set exec session-id: %v", err)
+	execCmd.Flags().String("run-id", "", "")
+	if err := execCmd.Flags().Set("run-id", "run-1"); err != nil {
+		t.Fatalf("set exec run-id: %v", err)
 	}
 	if err := composeExecArgs(execCmd, nil); err != nil {
 		t.Fatalf("composeExecArgs with legacy target returned error: %v", err)
@@ -570,20 +570,20 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 		{
 			name: "multiple legacy targets",
 			setup: func(cmd *cobra.Command) composeExecOptions {
-				cmd.Flags().String("session-id", "", "")
+				cmd.Flags().String("agent", "", "")
 				cmd.Flags().String("run-id", "", "")
-				_ = cmd.Flags().Set("session-id", "session-1")
+				_ = cmd.Flags().Set("agent", "reviewer")
 				_ = cmd.Flags().Set("run-id", "run-1")
-				return composeExecOptions{SessionID: "session-1", RunID: "run-1"}
+				return composeExecOptions{AgentName: "reviewer", RunID: "run-1"}
 			},
 			wantErr: "target can only be specified once",
 		},
 		{
-			name: "empty session flag",
+			name: "empty run flag",
 			setup: func(cmd *cobra.Command) composeExecOptions {
-				cmd.Flags().String("session-id", "", "")
-				_ = cmd.Flags().Set("session-id", " ")
-				return composeExecOptions{SessionID: " "}
+				cmd.Flags().String("run-id", "", "")
+				_ = cmd.Flags().Set("run-id", " ")
+				return composeExecOptions{RunID: " "}
 			},
 			wantErr: "requires a value",
 		},

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -508,7 +508,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 
 	downCmd := &cobra.Command{
 		Use:   "down",
-		Short: "Stop project schedulers and running sessions",
+		Short: "Stop project schedulers and running sandboxes",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runComposeDownCommand(cmd, options)
@@ -528,7 +528,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	runCmd.Flags().StringVar(&runOptions.Command, "command", "", "Bash command to execute in the agent sandbox")
 	runCmd.Flags().StringVar(&runOptions.SandboxID, "sandbox-id", "", "Reuse an existing sandbox")
 	runCmd.Flags().StringVar(&runOptions.Driver, "driver", "", "Runtime driver override for a new sandbox")
-	runCmd.Flags().BoolVar(&runOptions.KeepRunning, "keep-running", false, "Keep the session runtime running after completion")
+	runCmd.Flags().BoolVar(&runOptions.KeepRunning, "keep-running", false, "Keep the sandbox runtime running after completion")
 	runCmd.Flags().BoolVar(&runOptions.Remove, "rm", false, "Remove the sandbox after a successful run")
 	runCmd.Flags().BoolVar(&runOptions.Jupyter, "jupyter", false, "Enable Jupyter for this run")
 	runCmd.Flags().BoolVar(&runOptions.JupyterExpose, "jupyter-expose", false, "Mark the Jupyter proxy endpoint for this run as user-accessible")
@@ -550,8 +550,6 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	logsCmd.Flags().StringVar(&logsOptions.AgentName, "agent", "", "Filter logs by agent name")
 	logsCmd.Flags().StringVar(&logsOptions.RunID, "run-id", "", "Filter logs by run id")
 	logsCmd.Flags().StringVar(&logsOptions.SandboxID, "sandbox", "", "Filter logs by sandbox id")
-	// Deprecated: use --sandbox instead.
-	logsCmd.Flags().StringVar(&logsOptions.SessionID, "session-id", "", "Filter logs by session id")
 	logsCmd.Flags().BoolVar(&logsOptions.Follow, "follow", false, "Follow running run output")
 	logsCmd.Flags().IntVarP(&logsOptions.TailLines, "tail", "n", -1, "Show the last N lines of run output")
 	logsCmd.Flags().BoolVarP(&logsOptions.Timestamp, "timestamp", "t", false, "Prefix text log lines with a run-level timestamp")
@@ -617,11 +615,9 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		},
 	}
 	// Deprecated: use `agent-compose exec <sandbox>` instead.
-	execCmd.Flags().StringVar(&execOptions.AgentName, "agent", "", "Select a running session by agent")
+	execCmd.Flags().StringVar(&execOptions.AgentName, "agent", "", "Deprecated target selection by agent; use exec <sandbox>")
 	// Deprecated: use `agent-compose exec <sandbox>` instead.
-	execCmd.Flags().StringVar(&execOptions.RunID, "run-id", "", "Execute in the session linked to a run")
-	// Deprecated: use `agent-compose exec <sandbox>` instead.
-	execCmd.Flags().StringVar(&execOptions.SessionID, "session-id", "", "Execute in a specific session")
+	execCmd.Flags().StringVar(&execOptions.RunID, "run-id", "", "Deprecated target selection by run; use exec <sandbox>")
 	execCmd.Flags().StringVar(&execOptions.Command, "command", "", "Shell command to execute in the sandbox")
 	execCmd.Flags().BoolVarP(&execOptions.Interactive, "interactive", "i", false, "Reserved for future interactive exec")
 	execCmd.Flags().StringVar(&execOptions.Cwd, "cwd", "", "Guest working directory")
@@ -777,8 +773,8 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	imageCmd.AddCommand(imageLSCmd, imagePullCmd, imageRemoveCmd, imageInspectCmd)
 
 	inspectCmd := &cobra.Command{
-		Use:   "inspect <project|agent|run|sandbox|session|image|cache> [name-or-id]",
-		Short: "Inspect project, agent, run, sandbox, session, image, or cache details",
+		Use:   "inspect <project|agent|run|sandbox|image|cache> [name-or-id]",
+		Short: "Inspect project, agent, run, sandbox, image, or cache details",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runComposeInspectCommand(cmd, options, args)
@@ -838,7 +834,6 @@ type composePSOptions struct {
 type composeExecOptions struct {
 	AgentName   string
 	RunID       string
-	SessionID   string
 	Command     string
 	Cwd         string
 	Interactive bool
@@ -907,7 +902,7 @@ func addImageRemoveFlags(cmd *cobra.Command, options *composeImageRemoveOptions)
 
 func addCacheFilterFlags(cmd *cobra.Command, options *composeCacheFilterOptions) {
 	cmd.Flags().StringVar(&options.Driver, "driver", "", "Filter caches by driver: docker, boxlite, microsandbox, or all")
-	cmd.Flags().StringVar(&options.Type, "type", "", "Filter caches by type: oci, materialized, runtime, or session")
+	cmd.Flags().StringVar(&options.Type, "type", "", "Filter caches by type: oci, materialized, runtime, or sandbox")
 	cmd.Flags().StringVar(&options.Status, "status", "", "Filter caches by status: active, referenced, unused, expired, orphaned, or unknown")
 }
 
@@ -1106,7 +1101,7 @@ func runComposeDownCommand(cmd *cobra.Command, cli cliOptions) error {
 	if output.FailedSessionStops > 0 {
 		return commandExitError{
 			Code: exitCodeGeneral,
-			Err:  fmt.Errorf("down project %s completed with %d session stop failure(s)", normalized.Name, output.FailedSessionStops),
+			Err:  fmt.Errorf("down project %s completed with %d sandbox stop failure(s)", normalized.Name, output.FailedSessionStops),
 		}
 	}
 	return nil
@@ -1800,14 +1795,6 @@ func normalizeComposeLogsOptions(cmd *cobra.Command, options composeLogsOptions,
 		}
 		options.AgentName = args[0]
 	}
-	if cmd.Flags().Changed("session-id") {
-		if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose logs --session-id", "agent-compose logs --sandbox"); err != nil {
-			return options, err
-		}
-		if strings.TrimSpace(options.SandboxID) == "" {
-			options.SandboxID = options.SessionID
-		}
-	}
 	if strings.TrimSpace(options.SandboxID) != "" {
 		options.SessionID = options.SandboxID
 	}
@@ -1818,7 +1805,7 @@ func normalizeComposeLogsOptions(cmd *cobra.Command, options composeLogsOptions,
 }
 
 func composeExecArgs(cmd *cobra.Command, args []string) error {
-	if cmd.Flags().Changed("session-id") || cmd.Flags().Changed("run-id") || cmd.Flags().Changed("agent") {
+	if cmd.Flags().Changed("run-id") || cmd.Flags().Changed("agent") {
 		return nil
 	}
 	return cobra.MinimumNArgs(1)(cmd, args)
@@ -1904,16 +1891,13 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 		}
 	}
 	if !result.GetSuccess() {
-		return commandExitError{Code: execResultExitCode(result), Err: fmt.Errorf("exec %s in session %s failed: %s", result.GetExecId(), result.GetSessionId(), firstNonEmptyString(result.GetError(), result.GetStderr(), result.GetOutput(), "command failed"))}
+		return commandExitError{Code: execResultExitCode(result), Err: fmt.Errorf("exec %s in sandbox %s failed: %s", result.GetExecId(), result.GetSessionId(), firstNonEmptyString(result.GetError(), result.GetStderr(), result.GetOutput(), "command failed"))}
 	}
 	return nil
 }
 
 func normalizeComposeExecRequest(cmd *cobra.Command, projectName, projectID string, options composeExecOptions, args []string) (*agentcomposev2.ExecRequest, error) {
 	legacyTargetFlags := []string{}
-	if cmd.Flags().Changed("session-id") {
-		legacyTargetFlags = append(legacyTargetFlags, "--session-id")
-	}
 	if cmd.Flags().Changed("run-id") {
 		legacyTargetFlags = append(legacyTargetFlags, "--run-id")
 	}
@@ -1936,12 +1920,6 @@ func normalizeComposeExecRequest(cmd *cobra.Command, projectName, projectID stri
 			Cwd:     strings.TrimSpace(options.Cwd),
 		}
 		switch legacyTargetFlags[0] {
-		case "--session-id":
-			sessionID := strings.TrimSpace(options.SessionID)
-			if sessionID == "" {
-				return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec --session-id requires a value")}
-			}
-			req.Target = &agentcomposev2.ExecRequest_SessionId{SessionId: sessionID}
 		case "--run-id":
 			runID := strings.TrimSpace(options.RunID)
 			if runID == "" {
@@ -2429,11 +2407,11 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 			return err
 		}
 		if target == "" {
-			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect session requires a session id")}
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect session requires a sandbox")}
 		}
 		output, err = composeSandboxInspectOutputFor(cmd.Context(), clients, target)
 		if err != nil {
-			return commandExitErrorForConnect(fmt.Errorf("inspect session %s: %w", target, err))
+			return commandExitErrorForConnect(fmt.Errorf("inspect sandbox %s: %w", target, err))
 		}
 	default:
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("unsupported inspect target %q", kind)}
@@ -3055,7 +3033,7 @@ func projectListStatus(project composeProjectListItem) string {
 }
 
 func writeComposeDownText(out io.Writer, output composeDownOutput) error {
-	if _, err := fmt.Fprintf(out, "Project: %s\nID: %s\nStatus: %s\nFailed session stops: %d\n\n",
+	if _, err := fmt.Fprintf(out, "Project: %s\nID: %s\nStatus: %s\nFailed sandbox stops: %d\n\n",
 		output.Project.Name,
 		output.Project.ID,
 		output.Status,
@@ -3543,7 +3521,7 @@ func composeAgentInspectOutputFor(ctx context.Context, clients cliServiceClients
 		output.LatestRun = latest
 	}
 	if session, err := firstRunningSessionOutput(ctx, clients, project.GetSummary().GetProjectId(), agentName); err != nil {
-		return composeAgentInspectOutput{}, commandExitErrorForConnect(fmt.Errorf("list running session for agent %s: %w", agentName, err))
+		return composeAgentInspectOutput{}, commandExitErrorForConnect(fmt.Errorf("list running sandbox for agent %s: %w", agentName, err))
 	} else if session != nil {
 		output.RunningSessions = append(output.RunningSessions, *session)
 	}
@@ -3896,9 +3874,8 @@ func writeCacheInspectText(out io.Writer, output composeCacheInspectOutput) erro
 		}
 	}
 	if cache.SessionID != "" || cache.SandboxID != "" {
-		if _, err := fmt.Fprintf(out, "Session: %s\nSandbox: %s\n",
-			firstNonEmptyString(cache.SessionID, "-"),
-			firstNonEmptyString(cache.SandboxID, "-"),
+		if _, err := fmt.Fprintf(out, "Sandbox: %s\n",
+			firstNonEmptyString(cache.SandboxID, cache.SessionID, "-"),
 		); err != nil {
 			return err
 		}
@@ -4491,8 +4468,10 @@ func cacheTypeFilterValue(value string) (string, error) {
 		return "", nil
 	case "oci", "materialized", "runtime", "session":
 		return strings.ToLower(strings.TrimSpace(value)), nil
+	case "sandbox":
+		return "session", nil
 	default:
-		return "", fmt.Errorf("invalid --type %q: expected oci, materialized, runtime, or session", value)
+		return "", fmt.Errorf("invalid --type %q: expected oci, materialized, runtime, or sandbox", value)
 	}
 }
 
@@ -4537,7 +4516,7 @@ func cacheDomainText(domain agentcomposev2.CacheDomain) string {
 	case agentcomposev2.CacheDomain_CACHE_DOMAIN_RUNTIME_DERIVED_CACHE:
 		return "runtime-derived-cache"
 	case agentcomposev2.CacheDomain_CACHE_DOMAIN_SESSION_EPHEMERAL_STATE:
-		return "session-ephemeral-state"
+		return "sandbox-ephemeral-state"
 	default:
 		return "unspecified"
 	}
@@ -4552,7 +4531,7 @@ func cacheTypeText(domain agentcomposev2.CacheDomain) string {
 	case agentcomposev2.CacheDomain_CACHE_DOMAIN_RUNTIME_DERIVED_CACHE:
 		return "runtime"
 	case agentcomposev2.CacheDomain_CACHE_DOMAIN_SESSION_EPHEMERAL_STATE:
-		return "session"
+		return "sandbox"
 	default:
 		return "unspecified"
 	}

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -181,6 +181,29 @@ func TestRunHelpHidesOptionalModeFlagSentinel(t *testing.T) {
 	}
 }
 
+func TestCLIHelpUsesSandboxTerminology(t *testing.T) {
+	commands := [][]string{
+		{"--help"},
+		{"run", "--help"},
+		{"logs", "--help"},
+		{"exec", "--help"},
+		{"inspect", "--help"},
+		{"cache", "ls", "--help"},
+		{"cache", "prune", "--help"},
+	}
+	for _, args := range commands {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != 0 || stderr != "" {
+				t.Fatalf("%v code/stderr = %d / %q", args, exitCode, stderr)
+			}
+			if strings.Contains(strings.ToLower(stdout), "session") {
+				t.Fatalf("%v help contains session terminology:\n%s", args, stdout)
+			}
+		})
+	}
+}
+
 func TestUnknownCommandFailsWithoutStartingDaemon(t *testing.T) {
 	_, _, runCount, err := executeCommand("does-not-exist")
 	if err == nil {
@@ -1048,7 +1071,7 @@ agents:
 		if repeatedCode != 0 || repeatedErr != "" {
 			t.Fatalf("down repeated code/stderr = %d / %q", repeatedCode, repeatedErr)
 		}
-		for _, want := range []string{"Project: cli-down-demo", "Status: unchanged", "Failed session stops: 0"} {
+		for _, want := range []string{"Project: cli-down-demo", "Status: unchanged", "Failed sandbox stops: 0"} {
 			if !strings.Contains(repeatedOut, want) {
 				t.Fatalf("down repeated stdout %q does not contain %q", repeatedOut, want)
 			}
@@ -1122,10 +1145,10 @@ agents:
 		if exitCode != exitCodeGeneral {
 			t.Fatalf("down partial exit code = %d, want %d; stderr=%q", exitCode, exitCodeGeneral, stderr)
 		}
-		if !strings.Contains(stderr, "completed with 1 session stop failure") {
+		if !strings.Contains(stderr, "completed with 1 sandbox stop failure") {
 			t.Fatalf("down partial stderr = %q", stderr)
 		}
-		for _, want := range []string{"Status: partial-failure", "Failed session stops: 1", "session-failed", "forced stop failure"} {
+		for _, want := range []string{"Status: partial-failure", "Failed sandbox stops: 1", "session-failed", "forced stop failure"} {
 			if !strings.Contains(stdout, want) {
 				t.Fatalf("down partial stdout %q does not contain %q", stdout, want)
 			}
@@ -1201,7 +1224,6 @@ agents:
 		flag string
 	}{
 		{name: "legacy sandbox flag", flag: "--sandbox"},
-		{name: "legacy session flag", flag: "--session-id"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			legacyOut, legacyErr, _, legacyCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, tc.flag, "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
@@ -2347,18 +2369,8 @@ agents:
 	}
 
 	legacyOut, legacyErr, _, legacyCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--agent", "reviewer", "--session-id", "session-logs", "--json")
-	if legacyCode != 0 {
-		t.Fatalf("logs --session-id exit code = %d, stderr=%q", legacyCode, legacyErr)
-	}
-	if !strings.Contains(legacyErr, "agent-compose logs --session-id is deprecated") || !strings.Contains(legacyErr, "agent-compose logs --sandbox") {
-		t.Fatalf("logs --session-id stderr = %q, want deprecated warning", legacyErr)
-	}
-	var legacyDecoded composeLogsOutput
-	if err := json.Unmarshal([]byte(legacyOut), &legacyDecoded); err != nil {
-		t.Fatalf("logs --session-id JSON decode failed: %v\n%s", err, legacyOut)
-	}
-	if len(legacyDecoded.Runs) != 1 || legacyDecoded.Runs[0].RunID != "run-logs" {
-		t.Fatalf("logs --session-id JSON = %#v", legacyDecoded)
+	if legacyCode != exitCodeUsage || legacyOut != "" || !strings.Contains(legacyErr, "unknown flag: --session-id") {
+		t.Fatalf("logs --session-id code/stdout/stderr = %d / %q / %q", legacyCode, legacyOut, legacyErr)
 	}
 
 	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-logs")
@@ -3213,12 +3225,12 @@ agents:
 		t.Fatal("ExecStream selector was not used")
 	}
 
-	jsonOut, jsonErr, _, jsonCode := executeCLICommand("exec", "--host", server.URL, "--file", composePath, "--json", "--session-id", "session-exec", "bash")
+	jsonOut, jsonErr, _, jsonCode := executeCLICommand("exec", "--host", server.URL, "--file", composePath, "--json", "session-exec", "bash")
 	if jsonCode != 0 {
 		t.Fatalf("exec --json code/stderr = %d / %q", jsonCode, jsonErr)
 	}
-	if !strings.Contains(jsonErr, "agent-compose exec --session-id is deprecated") || strings.Contains(jsonOut, "deprecated") {
-		t.Fatalf("exec --session-id json stdout/stderr = %q / %q", jsonOut, jsonErr)
+	if jsonErr != "" || strings.Contains(jsonOut, "deprecated") {
+		t.Fatalf("exec positional json stdout/stderr = %q / %q", jsonOut, jsonErr)
 	}
 	if strings.Contains(jsonErr, "exec stderr") {
 		t.Fatalf("exec --json leaked transcript stdout/stderr = %q / %q", jsonOut, jsonErr)
@@ -3231,19 +3243,9 @@ agents:
 		t.Fatalf("exec JSON = %#v", decoded)
 	}
 
-	commandAliasOut, commandAliasErr, _, commandAliasCode := executeCLICommand("exec", "--host", server.URL, "--file", composePath, "--json", "--session-id", "session-exec", "--command", "printf alias")
-	if commandAliasCode != 0 {
-		t.Fatalf("exec --session-id --command code/stderr = %d / %q", commandAliasCode, commandAliasErr)
-	}
-	if !strings.Contains(commandAliasErr, "agent-compose exec --session-id is deprecated") || strings.Contains(commandAliasOut, "deprecated") {
-		t.Fatalf("exec --session-id --command json stdout/stderr = %q / %q", commandAliasOut, commandAliasErr)
-	}
-	var commandAliasDecoded composeExecOutput
-	if err := json.Unmarshal([]byte(commandAliasOut), &commandAliasDecoded); err != nil {
-		t.Fatalf("exec --session-id --command JSON decode failed: %v\n%s", err, commandAliasOut)
-	}
-	if commandAliasDecoded.ExecID != "exec-cli" || !commandAliasDecoded.Success {
-		t.Fatalf("exec --session-id --command JSON = %#v", commandAliasDecoded)
+	legacyExecOut, legacyExecErr, _, legacyExecCode := executeCLICommand("exec", "--host", server.URL, "--file", composePath, "--json", "--session-id", "session-exec", "--command", "printf alias")
+	if legacyExecCode != exitCodeUsage || legacyExecOut != "" || !strings.Contains(legacyExecErr, "unknown flag: --session-id") {
+		t.Fatalf("exec --session-id code/stdout/stderr = %d / %q / %q", legacyExecCode, legacyExecOut, legacyExecErr)
 	}
 
 	ambiguousOut, ambiguousErr, _, ambiguousCode := executeCLICommand("exec", "--host", server.URL, "--file", composePath, "sandbox-command", "--command", "pwd", "whoami")
@@ -3548,11 +3550,15 @@ func TestIntegrationCLICacheListFilterValuesAndUsageErrors(t *testing.T) {
 		{
 			name:   "type",
 			flag:   "--type",
-			values: []string{"oci", "materialized", "runtime", "session"},
+			values: []string{"oci", "materialized", "runtime", "sandbox", "session"},
 			assert: func(t *testing.T, filter *agentcomposev2.CacheFilter, value string) {
 				t.Helper()
-				if filter.GetType() != value {
-					t.Fatalf("type filter = %q, want %q", filter.GetType(), value)
+				want := value
+				if value == "sandbox" {
+					want = "session"
+				}
+				if filter.GetType() != want {
+					t.Fatalf("type filter = %q, want %q", filter.GetType(), want)
 				}
 			},
 		},
@@ -3845,7 +3851,7 @@ func TestIntegrationCLICachePruneFilterMappings(t *testing.T) {
 		},
 		{
 			name: "common filters",
-			args: []string{"--driver", "microsandbox", "--type", "session", "--status", "unknown"},
+			args: []string{"--driver", "microsandbox", "--type", "sandbox", "--status", "unknown"},
 			assert: func(t *testing.T, req *agentcomposev2.PruneCachesRequest) {
 				t.Helper()
 				filter := req.GetFilter()

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -162,7 +162,6 @@ a usage error; use `--prompt` or `--command` for ad hoc work.
 | --- | --- |
 | `--keep-running` | Keep the sandbox runtime after the run completes. |
 | `--sandbox <sandbox>` | Reuse an existing sandbox. |
-| `--session-id <session-id>` | Deprecated alias for `--sandbox`; prints a warning to stderr. |
 | `--rm` | Remove the sandbox after the run reaches a terminal state. |
 | `--jupyter` | Enable Jupyter for this run. When unset, the agent YAML default is used; when YAML is unset, Jupyter is disabled. |
 | `--jupyter-expose` | Mark the Jupyter agent-compose proxy endpoint for this run as explicitly exposed. This does not request runtime-driver host port exposure and also enables Jupyter. |
@@ -193,7 +192,7 @@ Rules:
 - Empty REPL lines do not create runs. Enter `/exit` or press Ctrl+D to exit.
 - REPL mode is not TTY/PTY or running stdin passthrough. Each input is one independent `RunAgentStream` call that reuses the same sandbox.
 - Detached runs can be observed with the printed `agent-compose logs --run-id <run-id> --follow` command, or managed later with `stop` and `logs`.
-- `run -i --prompt` supports providers with reusable provider sessions: Codex, Claude/cc, and OpenCode. Gemini currently returns unsupported.
+- `run -i --prompt` supports providers with reusable provider conversations: Codex, Claude/cc, and OpenCode. Gemini currently returns unsupported.
 - `StopRun` requests cancellation for active in-daemon runs. Pending/running runs left behind after daemon restart are reconciled to failed with a `daemon interrupted` error.
 
 ## `ps`: List Sandboxes
@@ -319,7 +318,6 @@ agent-compose exec <sandbox> --command "..."
 | --- | --- |
 | `--command "..."` | Pass a shell command as a flag. It is executed as `bash -lc "..."` in the sandbox. |
 | `--cwd <path>` | Set the working directory inside the sandbox. |
-| `--session-id <sandbox>` | Deprecated alias for positional `<sandbox>`; prints a warning to stderr. |
 | `--agent <agent>` | Deprecated target selection option; use `exec <sandbox>` instead. |
 | `--run-id <run-id>` | Deprecated target selection option; use `exec <sandbox>` instead. |
 
@@ -360,7 +358,6 @@ agent-compose logs -t
 | `--agent <agent>` | Filter by agent. |
 | `--run-id <run-id>` | Filter by run id. |
 | `--sandbox <sandbox>` | Filter by sandbox. |
-| `--session-id <sandbox>` | Deprecated alias for `--sandbox`; prints a warning to stderr. |
 
 Examples:
 
@@ -382,7 +379,6 @@ agent-compose inspect project
 agent-compose inspect agent <agent>
 agent-compose inspect run <run-id>
 agent-compose inspect sandbox <sandbox>
-agent-compose inspect session <sandbox>
 agent-compose inspect image <image>
 agent-compose inspect cache <cache-id>
 ```
@@ -393,7 +389,6 @@ Details:
 - `inspect agent <agent>` shows agent config and runtime summary.
 - `inspect run <run-id>` shows one run record.
 - `inspect sandbox <sandbox>` shows sandbox/runtime details.
-- `inspect session <sandbox>` is a deprecated compatibility entrypoint; use `inspect sandbox`.
 - `inspect image <image>` shows image details.
 - `inspect cache <cache-id>` shows one daemon runtime cache item, including references, blocked reasons, and warnings.
 
@@ -414,7 +409,7 @@ Commands:
 - `images`: list images.
 - `pull`: pull all agent images referenced by the current project.
 - `pull <image>`: pull a specific image. If the local OCI image backend/store already has the image, the command succeeds directly with a skipped/already exists warning and does not pull again.
-- `rmi <image>`: remove an image metadata/store entry. It does not delete materialized image cache, runtime-derived cache, or session ephemeral state.
+- `rmi <image>`: remove an image metadata/store entry. It does not delete materialized image cache, runtime-derived cache, or sandbox ephemeral state.
 - `inspect image <image>`: inspect an image.
 
 Common options:
@@ -444,12 +439,12 @@ Cache domains are shown as command-level `--type` values:
 - `oci`: daemon OCI image store metadata/layout.
 - `materialized`: runtime input generated from images, such as BoxLite OCI layout or Microsandbox rootfs.
 - `runtime`: runtime-derived cache under driver homes, such as BoxLite image artifacts.
-- `session`: session-scoped runtime state, such as Microsandbox docker disks.
+- `sandbox`: sandbox-scoped runtime state, such as Microsandbox docker disks.
 
 Protection status:
 
 - `active`: currently used by a running/resuming runtime; never removed.
-- `referenced`: not active, but still referenced by stopped session, project/image metadata, or runtime metadata. Skipped by default; `cache prune --include-referenced --force` can remove it.
+- `referenced`: not active, but still referenced by a stopped sandbox, project/image metadata, or runtime metadata. Skipped by default; `cache prune --include-referenced --force` can remove it.
 - `unused`, `expired`, `orphaned`: eligible for removal when `--force` is set.
 - `unknown`: reference or safety checks were incomplete; never removed.
 
@@ -458,7 +453,7 @@ Common options:
 | Command | Option | Description |
 | --- | --- | --- |
 | `cache ls`, `cache prune` | `--driver <docker|boxlite|microsandbox|all>` | Filter by runtime driver. |
-| `cache ls`, `cache prune` | `--type <oci|materialized|runtime|session>` | Filter by cache type. |
+| `cache ls`, `cache prune` | `--type <oci|materialized|runtime|sandbox>` | Filter by cache type. |
 | `cache ls`, `cache prune` | `--status <active|referenced|unused|expired|orphaned|unknown>` | Filter by protection status. |
 | `cache prune` | `--unused`, `--orphaned`, `--expired` | Status shortcuts; mutually exclusive with each other and with `--status`. |
 | `cache prune` | `--older-than <duration>` | Match caches older than a duration such as `7d` or `168h`. |
@@ -471,7 +466,7 @@ Examples:
 agent-compose cache ls --type materialized
 agent-compose cache inspect <cache-id>
 agent-compose cache prune --driver boxlite --unused
-agent-compose cache prune --type session --orphaned --force
+agent-compose cache prune --type sandbox --orphaned --force
 agent-compose cache prune --older-than 7d --force
 agent-compose cache rm <cache-id> --force
 ```

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -116,17 +116,17 @@ Current main commands:
   revision, managed agent definitions, and scheduler/loader; does not directly
   create a run or session.
 - `down`: call `ProjectService.RemoveProject`; disable managed
-  scheduler/loader and stop running sessions for the project; preserves project,
-  run, and session history by default.
-- `ps`: query project, agent, latest run, and running session state.
+  scheduler/loader and stop running sandboxes for the project; preserves project,
+  run, and sandbox history by default.
+- `ps`: query project, agent, latest run, and running sandbox state.
 - `run <agent>`: call `RunService.RunAgentStream` for a manual agent run;
-  creates a new session by default, supports reusing an existing session with
-  `--session-id`, stops the runtime after completion by default, and can keep it
+  creates a new sandbox by default, supports reusing an existing sandbox with
+  `--sandbox-id`, stops the runtime after completion by default, and can keep it
   running with `--keep-running`.
-- `logs`: inspect run output by project, agent, run id, or session id; supports
+- `logs`: inspect run output by project, agent, run id, or sandbox id; supports
   `--follow`.
-- `exec`: call `ExecService.ExecStream` inside a running session; can locate the
-  target by session id, run id, or project/agent selector.
+- `exec`: call `ExecService.ExecStream` inside a running sandbox; target the
+  sandbox with positional `<sandbox>`.
 - `images`, `image ls`, `pull`, `image pull`, `rmi`, `image rm`,
   `image inspect`: call `ImageService` to manage the daemon image store. The
   default store is selected by daemon `IMAGE_STORE_MODE`.
@@ -379,9 +379,9 @@ scheduler trigger, or future API clients.
 3. Merge runtime environment. Priority from low to high is global env, project
    variables, agent env, then run request env.
 4. Prepare local/Git workspace snapshot from project/agent workspace spec.
-5. Create a new session or reuse an existing session with `--session-id`.
+5. Create a new sandbox or reuse an existing sandbox with `--sandbox-id`.
 6. Write project, agent, run_id, scheduler_id, source, and related tags to the
-   session.
+   sandbox.
 7. Mark run as running and call the existing agent executor.
 8. Stream start/output/completed events for streaming requests.
 9. Persist terminal run state for success, failure, cancellation, workspace

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,6 +1,6 @@
 # agent-compose 中文文档
 
-agent-compose 是一个 daemon + CLI 形态的 agent/session 控制面。daemon 负责持久化状态、scheduler、runtime 生命周期、Connect API 和 Jupyter 代理；CLI 负责读取本地 `agent-compose.yml`，连接 daemon，并执行 `up`、`run`、`logs`、`ps`、`down`、`image` 等操作。
+agent-compose 是一个 daemon + CLI 形态的 agent/sandbox 控制面。daemon 负责持久化状态、scheduler、runtime 生命周期、Connect API 和 Jupyter 代理；CLI 负责读取本地 `agent-compose.yml`，连接 daemon，并执行 `up`、`run`、`logs`、`ps`、`down`、`image` 等操作。
 
 当前项目正在准备首次公开发布，建议按 preview/experimental 项目使用。API、运行时打包、部署默认值和生产环境建议后续仍可能调整。
 
@@ -68,8 +68,8 @@ agent-compose down
 - `agent-compose run <agent> <trigger-name>`：按名称运行已配置的 trigger。
 - `agent-compose run <agent> --prompt "..."` / `--command "..."`：手动执行临时 prompt 或 shell command。
 - `agent-compose logs`：查看 project run 日志。
-- `agent-compose ps`：查看 project agent、latest run 和 running session 状态。
-- `agent-compose down`：禁用 daemon 管理的 scheduler，并停止该 project 的 running sessions。
+- `agent-compose ps`：查看 project agent、latest run 和 running sandbox 状态。
+- `agent-compose down`：禁用 daemon 管理的 scheduler，并停止该 project 的 running sandboxes。
 - `agent-compose images|pull|rmi|image inspect`：管理 daemon 侧 image store。
 - `agent-compose cache ls|inspect|prune|rm`：查看并显式清理 daemon runtime cache；`prune` 和 `rm` 默认 dry-run，只有传 `--force` 才会删除。
 
@@ -140,12 +140,12 @@ docker compose --profile with-ui up -d
 - `LLM_API_ENDPOINT`、`LLM_API_PROTOCOL`、`LLM_API_KEY`、`OPENAI_API_KEY`、`LLM_MODEL`、`LLM_TIMEOUT`：daemon 侧 OpenAI family LLM 配置，供 `LLMService`、`scheduler.llm` 和 runtime agent LLM facade bootstrap 使用。这些值不会作为 provider key 注入 guest agent runtime。对接 OpenAI 兼容 Chat Completions 后端时设置 `LLM_API_PROTOCOL=chat_completions`。
 - `ANTHROPIC_BASE_URL`、`ANTHROPIC_API_ENDPOINT`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_MODEL`、`CLAUDE_MODEL`：daemon 侧 Anthropic family LLM facade bootstrap 配置。
 - `AGENT_COMPOSE_RUNTIME_BASE_URL`：可选的 runtime 内可访问 daemon base URL，用于生成 Runtime LLM Facade 配置。Docker Compose 默认使用 `http://agent-compose:7410`；宿主机 Docker 场景应配置具体的宿主机 IP/名称和端口。
-- `DOCKER_HOST_SESSION_ROOT`：guest 容器 bind mount 使用的宿主机 session 数据路径。Docker Compose 默认使用 `./data/agent-compose/sessions`。
-- `CAP_GRPC_LISTEN`、`CAP_GRPC_TARGET`：仅在 Agent 需要调用 OctoBus gRPC capability 时必须配置。`CAP_GRPC_LISTEN` 启动 agent-compose capability proxy；`CAP_GRPC_TARGET` 是注入新 session 的 guest 可达地址。修改后需要重启 daemon 并新建 session。
+- `DOCKER_HOST_SESSION_ROOT`：guest 容器 bind mount 使用的宿主机 sandbox 数据路径。Docker Compose 默认使用 `./data/agent-compose/sessions`。
+- `CAP_GRPC_LISTEN`、`CAP_GRPC_TARGET`：仅在 Agent 需要调用 OctoBus gRPC capability 时必须配置。`CAP_GRPC_LISTEN` 启动 agent-compose capability proxy；`CAP_GRPC_TARGET` 是注入新 sandbox 的 guest 可达地址。修改后需要重启 daemon 并新建 sandbox。
 
 ### Agent Provider
 
-Guest agent session 在 guest 容器内通过 `agent-compose-runtime` CLI 运行 provider CLI；该 CLI 由 `@chaitin-ai/agent-compose-runtime` npm 包提供。Codex 和 Claude 通过 Runtime LLM Facade 调用：真实 provider key 保存在 daemon 侧 LLM provider 配置中，runtime 只拿 session-scoped facade token 和 facade base URL。`LLM_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`GOOGLE_API_KEY`、`GEMINI_API_KEY` 等 provider key 名称会从用户提供的 runtime env 中过滤。兼容别名 `LLM_API_KEY`、`LLM_API_ENDPOINT` 仍可能出现在 runtime 中，但它们是 daemon 写入的 facade 值，不是上游 provider 凭据。Gemini 和 OpenCode 仍直接使用各自 provider CLI；OpenCode 凭据取决于所选 OpenCode model provider。
+Guest agent sandbox 在 guest 容器内通过 `agent-compose-runtime` CLI 运行 provider CLI；该 CLI 由 `@chaitin-ai/agent-compose-runtime` npm 包提供。Codex 和 Claude 通过 Runtime LLM Facade 调用：真实 provider key 保存在 daemon 侧 LLM provider 配置中，runtime 只拿 sandbox-scoped facade token 和 facade base URL。`LLM_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`GOOGLE_API_KEY`、`GEMINI_API_KEY` 等 provider key 名称会从用户提供的 runtime env 中过滤。兼容别名 `LLM_API_KEY`、`LLM_API_ENDPOINT` 仍可能出现在 runtime 中，但它们是 daemon 写入的 facade 值，不是上游 provider 凭据。Gemini 和 OpenCode 仍直接使用各自 provider CLI；OpenCode 凭据取决于所选 OpenCode model provider。
 
 | Provider | 典型环境变量 | 说明 |
 | --- | --- | --- |
@@ -160,7 +160,7 @@ Guest agent session 在 guest 容器内通过 `agent-compose-runtime` CLI 运行
 task image:agent-compose-guest
 ```
 
-创建新 session（或 resume 已有 session）以加载更新后的镜像和环境变量。
+创建新 sandbox（或 resume 已有 sandbox）以加载更新后的镜像和环境变量。
 
 > **升级注意（部分 Docker 部署存在破坏性变更）：** provider key 不再透传进 guest runtime，Codex/Claude 改为通过 daemon facade 访问上游 LLM，需要一个 runtime 内可达的 daemon URL。自带的 `docker-compose.yml` 已默认设置 `AGENT_COMPOSE_RUNTIME_BASE_URL=http://agent-compose:7410`。如果你在宿主机上直接运行 daemon（Docker driver）且 `HTTP_LISTEN=127.0.0.1:...`，容器无法访问该 loopback 地址，facade 配置会被跳过，agent run 将没有可用的 LLM 凭据。此时需要把 `AGENT_COMPOSE_RUNTIME_BASE_URL` 设为宿主机可达的具体 IP/名称和端口（例如 `http://host.docker.internal:7410`）。
 
@@ -179,7 +179,7 @@ LLM_MODEL=your-model
 
 兼容后端包括 DeepSeek、本地 OpenAI 兼容代理（vLLM/Ollama）等 Chat Completions endpoint。
 
-该路径不会创建具备 workspace 能力的 agent session，也不提供文件、命令或 MCP 工具访问。
+该路径不会创建具备 workspace 能力的 agent sandbox，也不提供文件、命令或 MCP 工具访问。
 
 使用 `outputSchema` 时，`chat_completions` 通过 prompt 引导并设置 `response_format: json_object`，不等价于 Responses API 的 strict JSON Schema。
 

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -165,7 +165,6 @@ prompt 输入必须使用 `--prompt`。不再支持 positional prompt 参数。
 | --- | --- |
 | `--keep-running` | 运行结束后保留 sandbox runtime。 |
 | `--sandbox <sandbox>` | 指定已有 sandbox。 |
-| `--session-id <session-id>` | 兼容旧参数，等价于 `--sandbox`，会输出 deprecated warning。 |
 | `--rm` | 运行结束后删除 sandbox。 |
 | `--jupyter` | 为本次 run 启用 Jupyter；未设置时使用 agent YAML 默认，YAML 未设置时默认关闭。 |
 | `--jupyter-expose` | 标记本次 run 的 Jupyter agent-compose proxy 入口为显式暴露意图；该参数不请求 runtime driver 暴露 host port，并会同时启用 Jupyter。 |
@@ -196,7 +195,7 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 - REPL 中空行不会创建 run；输入 `/exit` 或 Ctrl+D 退出。
 - REPL 不是 TTY/PTY 或运行中 stdin 透传；每条输入都是一次独立 `RunAgentStream`，但复用同一个 sandbox。
 - detached run 可通过输出的 `agent-compose logs --run-id <run-id> --follow` 命令观察输出，也可继续使用 `stop`/`logs` 操作该 run。
-- `run -i --prompt` 仅支持可复用 provider session 的 Codex、Claude/cc 和 OpenCode；Gemini 当前会返回 unsupported。
+- `run -i --prompt` 仅支持可复用 provider conversation 的 Codex、Claude/cc 和 OpenCode；Gemini 当前会返回 unsupported。
 - `StopRun` 会请求 daemon 内当前活动 run 取消；daemon 重启后遗留的 running/pending run 会在启动 reconcile 中标记为 failed，并带 `daemon interrupted` 错误。
 
 ## `ps`：查看 sandbox
@@ -328,7 +327,6 @@ agent-compose exec <sandbox> --command "..."
 | --- | --- |
 | `--command "..."` | 以 flag 形式传入 shell 命令，等价于在 sandbox 中执行 `bash -lc "..."`。 |
 | `--cwd <path>` | 指定 sandbox 内工作目录。 |
-| `--session-id <sandbox>` | 兼容旧参数，等价于 positional `<sandbox>`，会输出 deprecated warning。 |
 | `--agent <agent>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
 | `--run-id <run-id>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
 
@@ -371,7 +369,6 @@ agent-compose logs -t
 | `--agent <agent>` | 按 agent 过滤。 |
 | `--run-id <run-id>` | 按 run 过滤。 |
 | `--sandbox <sandbox>` | 按 sandbox 过滤。 |
-| `--session-id <sandbox>` | 兼容旧参数，等价于 `--sandbox`，会输出 deprecated warning。 |
 
 示例：
 
@@ -393,7 +390,6 @@ agent-compose inspect project
 agent-compose inspect agent <agent>
 agent-compose inspect run <run-id>
 agent-compose inspect sandbox <sandbox>
-agent-compose inspect session <sandbox>
 agent-compose inspect image <image>
 agent-compose inspect cache <cache-id>
 ```
@@ -404,7 +400,6 @@ agent-compose inspect cache <cache-id>
 - `inspect agent <agent>` 查看 agent 配置和运行摘要。
 - `inspect run <run-id>` 查看一次 run 的详情。
 - `inspect sandbox <sandbox>` 查看 sandbox/runtime 详情。
-- `inspect session <sandbox>` 是兼容旧入口，会输出 deprecated warning；新命令应使用 `inspect sandbox`。
 - `inspect image <image>` 查看镜像详情。
 - `inspect cache <cache-id>` 查看一个 daemon runtime cache item，包括引用、阻止删除原因和 warnings。
 
@@ -425,7 +420,7 @@ agent-compose inspect image <image>
 - `images`：列出镜像。
 - `pull`：拉取当前 project 中所有 agent 引用的镜像。
 - `pull <image>`：拉取指定镜像；如果本地 OCI image backend/store 已存在该镜像，会直接成功并输出 skipped/already exists warning，不会再次 pull。
-- `rmi <image>`：删除镜像 metadata/store entry，不删除 materialized image cache、runtime-derived cache 或 session ephemeral state。
+- `rmi <image>`：删除镜像 metadata/store entry，不删除 materialized image cache、runtime-derived cache 或 sandbox ephemeral state。
 - `inspect image <image>`：查看镜像详情。
 
 常用选项：
@@ -455,12 +450,12 @@ Cache domain 在 CLI 中用 `--type` 表示：
 - `oci`：daemon OCI image store metadata/layout。
 - `materialized`：从镜像派生出的 runtime 输入，例如 BoxLite OCI layout 或 Microsandbox rootfs。
 - `runtime`：runtime driver home 下的派生缓存，例如 BoxLite image artifacts。
-- `session`：session 级 runtime state，例如 Microsandbox docker disks。
+- `sandbox`：sandbox 级 runtime state，例如 Microsandbox docker disks。
 
 保护状态：
 
 - `active`：正在被 running/resuming runtime 使用，永不删除。
-- `referenced`：当前不 active，但仍被 stopped session、project/image metadata 或 runtime metadata 引用。默认跳过；`cache prune --include-referenced --force` 可以删除。
+- `referenced`：当前不 active，但仍被 stopped sandbox、project/image metadata 或 runtime metadata 引用。默认跳过；`cache prune --include-referenced --force` 可以删除。
 - `unused`、`expired`、`orphaned`：设置 `--force` 后可删除。
 - `unknown`：引用或安全检查不完整，永不删除。
 
@@ -469,7 +464,7 @@ Cache domain 在 CLI 中用 `--type` 表示：
 | 命令 | 参数 | 说明 |
 | --- | --- | --- |
 | `cache ls`, `cache prune` | `--driver <docker|boxlite|microsandbox|all>` | 按 runtime driver 过滤。 |
-| `cache ls`, `cache prune` | `--type <oci|materialized|runtime|session>` | 按 cache type 过滤。 |
+| `cache ls`, `cache prune` | `--type <oci|materialized|runtime|sandbox>` | 按 cache type 过滤。 |
 | `cache ls`, `cache prune` | `--status <active|referenced|unused|expired|orphaned|unknown>` | 按保护状态过滤。 |
 | `cache prune` | `--unused`, `--orphaned`, `--expired` | status 快捷参数；彼此互斥，也不能与 `--status` 同用。 |
 | `cache prune` | `--older-than <duration>` | 匹配超过指定时长的 cache，例如 `7d` 或 `168h`。 |
@@ -482,7 +477,7 @@ Cache domain 在 CLI 中用 `--type` 表示：
 agent-compose cache ls --type materialized
 agent-compose cache inspect <cache-id>
 agent-compose cache prune --driver boxlite --unused
-agent-compose cache prune --type session --orphaned --force
+agent-compose cache prune --type sandbox --orphaned --force
 agent-compose cache prune --older-than 7d --force
 agent-compose cache rm <cache-id> --force
 ```

--- a/docs/zh-CN/command-line-test-report.md
+++ b/docs/zh-CN/command-line-test-report.md
@@ -148,7 +148,7 @@ AUTH_USERNAME=admin AUTH_PASSWORD=... \
 | 查看运行中 sandbox | `<prefix> ps` | 无 | 默认展示 running sandbox | 通过 |
 | 查看所有 sandbox JSON | `<prefix> --json ps --all` | `--json`、`--all` | 展示 running/stopped 等所有 sandbox | 通过 |
 | 按状态过滤并显示详细列 | `<prefix> ps --all --status running --verbose` | `--status`、`--verbose` | 仅展示匹配状态的 sandbox，并包含 driver/image/workspace 等详细列 | 通过 |
-| 查看 sandbox 详情 | `<prefix> --json inspect sandbox <sandbox>` | `inspect sandbox` | 返回 sandbox/session runtime 详情 | 通过 |
+| 查看 sandbox 详情 | `<prefix> --json inspect sandbox <sandbox>` | `inspect sandbox` | 返回 sandbox runtime 详情 | 通过 |
 | 兼容查看 session | `<prefix> --json inspect session <sandbox>` | `inspect session` | 返回详情，并在 stderr 输出 deprecated warning | 通过 |
 | 查看 run 详情 | `<prefix> --json inspect run <run-id>` | `inspect run` | 返回 run 详情 | 通过 |
 | 删除 running sandbox 被拒绝 | `<prefix> rm <sandbox>` | `rm` | 返回 `is running`，退出码非 0 | 通过 |
@@ -164,9 +164,7 @@ AUTH_USERNAME=admin AUTH_PASSWORD=... \
 | --- | --- | --- | --- | --- |
 | 使用 `--command` 执行命令 | `<prefix> exec <sandbox> --command 'printf cli-exec-ok'` | `exec <sandbox>`、`--command` | 输出 `cli-exec-ok` | 通过 |
 | 使用 positional command 执行命令 | `<prefix> exec <sandbox> printf cli-exec-args-ok` | `exec <sandbox> [command] [args...]` | 输出 `cli-exec-args-ok` | 通过 |
-| 兼容旧 `--session-id` | `<prefix> --json exec --session-id <sandbox> --command 'printf legacy-exec-ok'` | `--session-id`、`--json` | stdout 为 JSON；stderr 输出 deprecated warning | 通过 |
-
-结论：新的 `exec <sandbox>` 语义可用，旧 `--session-id` 入口仍兼容，且 deprecated warning 不污染 JSON stdout。
+结论：新的 `exec <sandbox>` 语义可用。
 
 ## 7. Logs 命令测试
 
@@ -174,10 +172,9 @@ AUTH_USERNAME=admin AUTH_PASSWORD=... \
 | --- | --- | --- | --- | --- |
 | 查看 agent 日志 | `<prefix> logs reviewer --tail 20` | positional agent、`--tail` | 输出 reviewer 的 run 日志 | 通过 |
 | 查看 sandbox 日志 JSON | `<prefix> --json logs --sandbox <sandbox> --tail 20 --timestamp` | `--sandbox`、`--tail`、`--timestamp`、`--json` | 返回指定 sandbox 日志，包含时间信息 | 通过 |
-| 兼容旧 `--session-id` | `<prefix> --json logs --session-id <sandbox> --tail 5` | `--session-id`、`--json` | stdout 为 JSON；stderr 输出 deprecated warning | 通过 |
 | 跟随日志 | `<prefix> logs reviewer --follow --tail 5` | `--follow`、`--tail` | 输出已有日志；当前 run 已结束时命令可正常返回 | 通过 |
 
-结论：`logs` 可按 agent/sandbox/session 兼容入口读取日志，`--tail`、`--timestamp`、`--follow` 均完成基础验证。
+结论：`logs` 可按 agent/sandbox 读取日志，兼容入口、`--tail`、`--timestamp`、`--follow` 均完成基础验证。
 
 ## 8. 镜像命令测试
 
@@ -224,19 +221,7 @@ AUTH_USERNAME=admin AUTH_PASSWORD=... \
 
 ## 11. 测试中发现的问题
 
-### 11.1 `exec --session-id <sandbox> --command` 参数校验问题
-
-问题：旧兼容入口 `exec --session-id <sandbox> --command ... --json` 曾被 Cobra positional args 校验拦截，报 `requires at least 1 arg(s)`。
-
-处理：已修复，提交为：
-
-```text
-ee40224 fix(cli): allow legacy exec target with command flag
-```
-
-复测结果：通过。旧入口可用，deprecated warning 输出到 stderr，JSON stdout 保持干净。
-
-### 11.2 `pull` 无参数遇到本地镜像时会失败
+### 11.1 `pull` 无参数遇到本地镜像时会失败
 
 现象：
 
@@ -254,7 +239,7 @@ pull access denied for agent-compose-guest
 
 建议：后续可考虑优化错误信息，提示用户该镜像可能是本地镜像或私有镜像，需要先登录 registry 或改用可拉取镜像。
 
-### 11.3 外部 timeout 中断 `run` 可能留下 runtime 容器
+### 11.2 外部 timeout 中断 `run` 可能留下 runtime 容器
 
 现象：测试脚本曾使用：
 
@@ -274,7 +259,7 @@ timeout 60s <prefix> run reviewer --command 'sleep 300' --keep-running
 | --- | ---: | --- |
 | 确定性通过测试项 | 59 | 已实现命令、关键参数、JSON 输出、deprecated warning、认证、sandbox 生命周期、镜像命令。 |
 | 历史延期命令边界项 | 3 | 历史测试时 `stats`、`build`、`push` 尚未发布；当前 `stats` 已实现，`build`/`push` 仍暂缓。 |
-| 已修复问题 | 1 | `exec --session-id ... --command` 兼容入口参数校验问题。 |
+| 已修复问题 | 0 | 本轮未新增已修复问题条目。 |
 | 新发现待跟进问题 | 2 | 本地镜像 `pull` 报错提示可优化；外部 timeout 中断 `run` 后可能遗留 runtime 容器。 |
 | 当前阻塞发布的问题 | 0 | 除已明确延期项和异常中断清理边界外，已实现 CLI 命令通过本轮复测。 |
 

--- a/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
+++ b/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
@@ -56,10 +56,10 @@ CLI 是 agent-compose daemon 的操作入口。它负责读取本地 project 配
 | `resume` | 基于 v1 `SessionService.ResumeSession` 恢复 sandbox。 |
 | `rm` | 调用 v2 `SandboxService.RemoveSandbox` 删除 sandbox；running sandbox 需要 `--force`。 |
 | `exec` | 调用 v2 `ExecService.ExecStream` 在已有 sandbox 中执行一次 command transcript。 |
-| `inspect` | 查看 project、agent、run、sandbox/session、image 或 cache 详情。 |
+| `inspect` | 查看 project、agent、run、sandbox、image 或 cache 详情。 |
 | `images` | 列出 daemon image store 中的镜像。 |
 | `pull` | 拉取当前 project 的 agent images，或拉取指定 OCI image reference。 |
-| `rmi` | 删除镜像 metadata/store entry；不删除 materialized/runtime/session cache。 |
+| `rmi` | 删除镜像 metadata/store entry；不删除 materialized/runtime/sandbox cache。 |
 | `cache` | 查看、dry-run 和显式清理 daemon runtime cache inventory，包含 `ls`、`inspect`、`prune`、`rm`。 |
 | `image` | 旧 image 命令树，保留兼容并输出 deprecated warning。 |
 
@@ -128,7 +128,7 @@ agents:
 - trigger name、`--prompt`、`--command` 一次只能选择一种。
 - 使用 `--prompt` 或 `--command` 后不能再传额外位置参数。
 - prompt 输入必须使用 `--prompt`；`run <agent> <trigger-name>` 的第二个位置参数不再作为 prompt 处理。
-- `--session-id` 是 `--sandbox` 的 deprecated alias。
+- 复用 sandbox 使用 `--sandbox-id`。
 
 ### Trigger 解析
 
@@ -147,7 +147,7 @@ v2 `RunSessionCleanupPolicy` 当前包括：
 - `KEEP_RUNNING`：`--keep-running`，run 完成后保留 runtime。
 - `REMOVE_ON_COMPLETION`：`--rm`，run terminal 后删除本次 run 创建的 sandbox。
 
-`--rm` 由 service 端 `pkg/runs.Controller` 负责，不依赖 CLI 进程存活。它覆盖 succeeded、failed、canceled 等 terminal 状态。显式传入已有 `--sandbox`/`--session-id` 时，不删除该 sandbox。cleanup 失败写入 `project_run.cleanup_error`；run 原始错误优先于 cleanup 错误。
+`--rm` 由 service 端 `pkg/runs.Controller` 负责，不依赖 CLI 进程存活。它覆盖 succeeded、failed、canceled 等 terminal 状态。显式传入已有 `--sandbox-id` 时，不删除该 sandbox。cleanup 失败写入 `project_run.cleanup_error`；run 原始错误优先于 cleanup 错误。
 
 ### Detach 和 StopRun
 
@@ -162,7 +162,7 @@ v2 `RunSessionCleanupPolicy` 当前包括：
 - stdin 每条非空输入创建一条独立 `ProjectRun`。
 - 同一 REPL 复用同一个 sandbox。
 - prompt 模式复用 provider conversation；当前支持 Codex、Claude/cc 和 OpenCode，Gemini 返回 unsupported。
-- command 模式复用同一 workspace/home/state/runtime session。
+- command 模式复用同一 workspace/home/state/runtime sandbox。
 - 输入 `/exit` 或 Ctrl+D 退出。
 - 不提供 TTY、PTY、terminal resize、WebSocket TTY、Connect bidi stdin 或运行中 stdin 透传。
 
@@ -192,7 +192,7 @@ run 日志的权威文件由 `project_run.logs_path` 指向：
 
 ## Stats
 
-`agent-compose stats [sandbox]` 调用 v2 `SandboxService.GetSandboxStats`。指定 sandbox 时直接查询该 sandbox；未指定 sandbox 时先按当前 compose project 枚举 running sandbox，再逐个查询 stats。service 解析 sandbox/session、runtime state 和对应 driver optional stats 能力。
+`agent-compose stats [sandbox]` 调用 v2 `SandboxService.GetSandboxStats`。指定 sandbox 时直接查询该 sandbox；未指定 sandbox 时先按当前 compose project 枚举 running sandbox，再逐个查询 stats。service 解析 sandbox、runtime state 和对应 driver optional stats 能力。
 
 JSON 字段集合保持稳定：
 
@@ -218,7 +218,7 @@ Jupyter 默认关闭。启用来源包括：
 - `run --jupyter`
 - `run --jupyter-expose`
 
-`--jupyter-expose` 会同时启用 Jupyter，并把 session proxy state 标记为 exposed。它只表达“通过 agent-compose proxy 暴露可访问入口”的意图，不要求 Docker、BoxLite 或 Microsandbox runtime driver 做外部 host port bind。
+`--jupyter-expose` 会同时启用 Jupyter，并把 sandbox proxy state 标记为 exposed。它只表达“通过 agent-compose proxy 暴露可访问入口”的意图，不要求 Docker、BoxLite 或 Microsandbox runtime driver 做外部 host port bind。
 
 session store 会把 Jupyter options 写入 `proxy/jupyter.json`。driver 启动 runtime 时读取 session proxy state。`GetSessionProxy` 只返回 proxy 入口信息；真实 HTTP/WebSocket 转发由 `pkg/agentcompose/proxy` 的 proxy routes 处理。
 
@@ -238,7 +238,7 @@ session store 会把 Jupyter options 写入 `proxy/jupyter.json`。driver 启动
 
 Docker daemon 只是可选 image backend；OCI cache 是 daemonless backend。BoxLite 和 Microsandbox 可以在启动 runtime 时从 OCI image 派生自身 artifact，但 `pull` 不属于 runtime driver 能力。
 
-`rmi` 同样只面向 image store/backend。materialized image cache、runtime-derived driver cache 和 session-ephemeral state 的清理由 `cache ls|inspect|prune|rm` 显式完成，并复用 `CacheService` 的 dry-run、`--force`、保护状态和安全路径检查。
+`rmi` 同样只面向 image store/backend。materialized image cache、runtime-derived driver cache 和 sandbox-ephemeral state 的清理由 `cache ls|inspect|prune|rm` 显式完成，并复用 `CacheService` 的 dry-run、`--force`、保护状态和安全路径检查。
 
 ## Sandbox lifecycle
 
@@ -248,10 +248,10 @@ Docker daemon 只是可选 image backend；OCI cache 是 daemonless backend。Bo
 
 - 非 running sandbox 可直接删除。
 - running sandbox 无 `--force` 时返回 failed precondition，并提示 `is running`。
-- running sandbox 带 `--force` 时先 stop，再删除 session/sandbox metadata 和相关运行态资源。
+- running sandbox 带 `--force` 时先 stop，再删除 sandbox metadata 和相关运行态资源。
 - `rm` 不删除 project 配置。
 
-`inspect session`、`--session-id` 等旧入口保留兼容并输出 deprecated warning。
+`inspect session` 旧入口保留兼容并输出 deprecated warning。
 
 ## Deprecated 兼容项
 
@@ -261,9 +261,6 @@ Docker daemon 只是可选 image backend；OCI cache 是 daemonless backend。Bo
 | `agent-compose image pull <image>` | `agent-compose pull <image>` |
 | `agent-compose image rm <image>` | `agent-compose rmi <image>` |
 | `agent-compose image inspect <image>` | `agent-compose inspect image <image>` |
-| `agent-compose run --session-id <id>` | `agent-compose run --sandbox <sandbox>` |
-| `agent-compose exec --agent/--run-id/--session-id ...` | `agent-compose exec <sandbox> ...` |
-| `agent-compose logs --session-id <id>` | `agent-compose logs --sandbox <sandbox>` |
 | `agent-compose inspect session <id>` | `agent-compose inspect sandbox <sandbox>` |
 
 兼容入口必须满足：

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -86,12 +86,12 @@ CLI 不直接操作 runtime、session 文件或 SQLite reconcile 逻辑。它读
 当前主命令：
 
 - `config`：本地解析和规范化 `agent-compose.yml`，支持 `--json` 和 `--quiet`，不连接 daemon。
-- `up`：调用 `ProjectService.ApplyProject`，创建或更新 project、revision、受管 agent definition 和 scheduler/loader；不会直接创建 run/session。
-- `down`：调用 `ProjectService.RemoveProject`，禁用受管 scheduler/loader，并停止该 project 的 running sessions；默认保留 project、run 和 session 历史。
-- `ps`：查询 project、agent、latest run 和 running session 状态。
-- `run <agent>`：调用 `RunService.RunAgentStream` 手动执行一次 agent；默认创建新 session，支持 `--session-id` 复用已有 session，默认完成后停止 runtime，`--keep-running` 可保留。
-- `logs`：按 project、agent、run id 或 session id 查看 run 输出，支持 `--follow`。
-- `exec`：调用 `ExecService.ExecStream` 在 running session 内执行命令；可按 session id、run id 或 project/agent selector 定位。
+- `up`：调用 `ProjectService.ApplyProject`，创建或更新 project、revision、受管 agent definition 和 scheduler/loader；不会直接创建 run/sandbox。
+- `down`：调用 `ProjectService.RemoveProject`，禁用受管 scheduler/loader，并停止该 project 的 running sandboxes；默认保留 project、run 和 sandbox 历史。
+- `ps`：查询 project、agent、latest run 和 running sandbox 状态。
+- `run <agent>`：调用 `RunService.RunAgentStream` 手动执行一次 agent；默认创建新 sandbox，支持 `--sandbox-id` 复用已有 sandbox，默认完成后停止 runtime，`--keep-running` 可保留。
+- `logs`：按 project、agent、run id 或 sandbox id 查看 run 输出，支持 `--follow`。
+- `exec`：调用 `ExecService.ExecStream` 在 running sandbox 内执行命令；用 positional `<sandbox>` 定位目标。
 - `images`、`image ls`、`pull`、`image pull`、`rmi`、`image rm`、`image inspect`：调用 `ImageService` 管理 daemon image store。默认 store 由 daemon 的 `IMAGE_STORE_MODE` 决定。
 - `cache ls`、`cache inspect`、`cache prune`、`cache rm`：调用 `CacheService` 查看、检查、dry-run 和显式删除 daemon runtime cache items。CLI 不直接读取或删除 daemon cache path。
 - `inspect <project|agent|run|session>`：查看 project 相关对象详情。
@@ -279,8 +279,8 @@ Run 是一次 agent 执行记录，可来自 CLI manual run、scheduler trigger 
 2. 创建 `project_run` pending 记录，记录 source、scheduler/trigger、prompt、driver、image 等元数据。
 3. 合并运行环境，优先级从低到高为 global env、project variables、agent env、run request env。
 4. 按 project/agent workspace spec 准备 local/git workspace snapshot。
-5. 创建新 session，或按 `--session-id` 复用已有 session。
-6. 给 session 写入 project、agent、run_id、scheduler_id、source 等 tag。
+5. 创建新 sandbox，或按 `--sandbox-id` 复用已有 sandbox。
+6. 给 sandbox 写入 project、agent、run_id、scheduler_id、source 等 tag。
 7. 标记 run 为 running，并调用现有 agent executor。
 8. streaming 请求实时发送 start/output/completed 事件。
 9. 成功、失败、取消、workspace 准备失败、session 启动失败、agent 执行失败和 stream 发送失败都会落库为终态 run。


### PR DESCRIPTION
  ## Summary

  - Updated CLI help/output/docs to use sandbox terminology instead of session for user-visible command descriptions.
  - Removed legacy `--session-id` CLI flag compatibility from `logs` and `exec`; use `--sandbox` for logs and positional `<sandbox>` for exec.
  - Updated cache CLI terminology so `--type sandbox` is shown publicly while still mapping to the existing backend type.
  - Added/updated tests covering sandbox terminology in help and removed legacy flag behavior.

  ## Testing

  - `go test ./cmd/agent-compose -run 'Test(RunHelpHidesOptionalModeFlagSentinel|CLIHelpUsesSandboxTerminology|RootCommandPrintsHelpWithoutStartingDaemon|
  CLIDownFirstRepeatedPartialAndJSON|IntegrationCLIDownFirstRepeatedPartialAndJSON|E2ECLIDownFirstRepeatedPartialAndJSON|IntegrationCLILogsFiltersRunAgentSessionAndJSON|
  IntegrationCLIExecStreamsAndSupportsJSON|CLIExecRejectsEmptySandboxUsageError|IntegrationCLIInspectProjectAgentRunSandboxSessionJSON|IntegrationCLICacheListTextJSONAndFilters|
  IntegrationCLICacheListFilterValuesAndUsageErrors|IntegrationCLICacheInspectTextJSONAndNotFound|IntegrationCLICachePruneDryRunForceAndJSON|IntegrationCLICachePruneFilterMappings|
  CLICachePruneUsageErrors)'`
  - `go test ./cmd/agent-compose -run 'Test(CLIConfigAndOutputWorkflow|IntegrationCLIConfigAndOutputWorkflow|E2ECLIConfigAndOutputWorkflow)'`
  - Verified `agent-compose --help`, `run/logs/exec/inspect/cache ls/cache prune --help` contain no `session` terminology.
  - `git diff --check`

  Note: full `go test ./cmd/agent-compose` was run earlier and fails in daemon auth tests with `/api/version` returning 401; that appears unrelated to this change.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.