### PR TITLE
ci: add Go lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+      - name: Install Task
+        run: go install github.com/go-task/task/v3/cmd/task@v3.40.1
+      - name: Run lint
+        run: task lint
+
   go-test:
     name: Go tests
     runs-on: ubuntu-latest

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -269,11 +269,6 @@ func isTrustedUnixSocketConn(conn net.Conn) bool {
 	return uid == os.Getuid() || uid == 0
 }
 
-func isLocalUnixSocketRequest(r *http.Request) bool {
-	ok, _ := r.Context().Value(localUnixSocketRequestKey{}).(bool)
-	return ok
-}
-
 func (s *daemonServers) serve(logger *slog.Logger) <-chan error {
 	errCh := make(chan error, len(s.items))
 	for _, item := range s.items {


### PR DESCRIPTION
## Summary
- add a dedicated CI lint job for Go packages
- run golangci-lint fmt --diff and golangci-lint run with the same package scope as Taskfile.yml
- remove an unused helper surfaced by the lint gate

## Verification
- GOCACHE="/root/workspace/agent-compose/.cache/go-build" GOLANGCI_LINT_CACHE="/root/workspace/agent-compose/.cache/golangci-lint" ./scripts/with-go-toolchain.sh golangci-lint fmt --no-config --diff ./cmd/... ./pkg/... ./proto/health/v1 ./proto/health/v1/healthv1connect ./proto/agentcompose/v1 ./proto/agentcompose/v1/agentcomposev1connect ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect
- GOCACHE="/root/workspace/agent-compose/.cache/go-build" GOLANGCI_LINT_CACHE="/root/workspace/agent-compose/.cache/golangci-lint" ./scripts/with-go-toolchain.sh golangci-lint run --no-config --allow-parallel-runners ./cmd/... ./pkg/... ./proto/health/v1 ./proto/health/v1/healthv1connect ./proto/agentcompose/v1 ./proto/agentcompose/v1/agentcomposev1connect ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect
