### PR TITLE
feat: allow loader scripts to enable Jupyter on spawned sessions

### DIFF
--- a/pkg/agentcompose/adapters/loader_session_runner.go
+++ b/pkg/agentcompose/adapters/loader_session_runner.go
@@ -125,7 +125,7 @@ func (r *LoaderSessionRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	if agentDefinition != nil {
 		tags = append(tags, api.SessionTagsFromProto(api.AgentDefinitionTagsToProto(*agentDefinition))...)
 	}
-	session, err := r.Store.CreateSession(ctx, title, "", driver, guestImage, workspaceID, domain.SessionTypeScript+":"+loader.Summary.ID, workspaceSnapshot, envItems, tags)
+	session, err := r.Store.CreateSessionWithOptions(ctx, title, "", driver, guestImage, workspaceID, domain.SessionTypeScript+":"+loader.Summary.ID, workspaceSnapshot, envItems, tags, sessionstore.CreateSessionOptions{JupyterEnabled: request.JupyterEnabled})
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/loaders/engine.go
+++ b/pkg/loaders/engine.go
@@ -999,6 +999,7 @@ func parseLoaderAgentRequest(args []*qjs.Value) (domain.LoaderAgentRequest, erro
 	request.Driver = loaderStringOption(options, "driver")
 	request.GuestImage = loaderStringOption(options, "guestImage", "guest_image")
 	request.WorkspaceID = loaderStringOption(options, "workspaceId", "workspace_id")
+	request.JupyterEnabled = loaderBoolOption(options, "jupyter")
 	request.SessionEnv, err = loaderSessionEnvOption(options)
 	if err != nil {
 		return domain.LoaderAgentRequest{}, err
@@ -1142,12 +1143,13 @@ func parseLoaderShellRequest(args []*qjs.Value) (domain.LoaderCommandRequest, er
 func loaderCommandRequestFromOptions(options map[string]any, apiName string) (domain.LoaderCommandRequest, error) {
 	var err error
 	request := domain.LoaderCommandRequest{
-		Cwd:           loaderStringOption(options, "cwd"),
-		SessionPolicy: normalizeLoaderSessionPolicy(loaderStringOption(options, "sessionPolicy", "session_policy")),
-		Title:         loaderStringOption(options, "title"),
-		Driver:        loaderStringOption(options, "driver"),
-		GuestImage:    loaderStringOption(options, "guestImage", "guest_image"),
-		WorkspaceID:   loaderStringOption(options, "workspaceId", "workspace_id"),
+		Cwd:            loaderStringOption(options, "cwd"),
+		SessionPolicy:  normalizeLoaderSessionPolicy(loaderStringOption(options, "sessionPolicy", "session_policy")),
+		Title:          loaderStringOption(options, "title"),
+		Driver:         loaderStringOption(options, "driver"),
+		GuestImage:     loaderStringOption(options, "guestImage", "guest_image"),
+		WorkspaceID:    loaderStringOption(options, "workspaceId", "workspace_id"),
+		JupyterEnabled: loaderBoolOption(options, "jupyter"),
 	}
 	request.Env, err = loaderStringMapOption(options, "env")
 	if err != nil {
@@ -1218,6 +1220,19 @@ func loaderStringOption(options map[string]any, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+func loaderBoolOption(options map[string]any, keys ...string) bool {
+	for _, key := range keys {
+		value, ok := options[key]
+		if !ok || value == nil {
+			continue
+		}
+		if raw, ok := value.(bool); ok {
+			return raw
+		}
+	}
+	return false
 }
 
 func loaderStringArrayOption(options map[string]any, keys ...string) ([]string, error) {

--- a/pkg/loaders/engine_jupyter_option_test.go
+++ b/pkg/loaders/engine_jupyter_option_test.go
@@ -1,0 +1,56 @@
+package loaders
+
+import (
+	"context"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+// The loader session-spawning APIs (scheduler.agent, scheduler.shell,
+// scheduler.exec) accept a `jupyter: true` option that must reach the request
+// struct so LoaderSessionRunner.Ensure can enable Jupyter on the session.
+func TestLoaderJupyterOptionThreadsThroughRequests(t *testing.T) {
+	run := func(t *testing.T, script string) *coverageEngineHost {
+		t.Helper()
+		host := &coverageEngineHost{state: map[string]string{}}
+		if _, err := (&QJSLoaderEngine{}).Execute(context.Background(), LoaderExecutionRequest{
+			Runtime: domain.LoaderRuntimeScheduler,
+			Script:  script,
+		}, host); err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		return host
+	}
+
+	t.Run("scheduler.agent jupyter true", func(t *testing.T) {
+		host := run(t, `function main() { scheduler.agent("p", { jupyter: true }); }`)
+		if len(host.agentCalls) != 1 || !host.agentCalls[0].JupyterEnabled {
+			t.Fatalf("expected agent request with JupyterEnabled=true, got %#v", host.agentCalls)
+		}
+	})
+
+	t.Run("scheduler.shell jupyter true", func(t *testing.T) {
+		host := run(t, `function main() { scheduler.shell("echo hi", { jupyter: true }); }`)
+		if len(host.commandCalls) != 1 || !host.commandCalls[0].JupyterEnabled {
+			t.Fatalf("expected command request with JupyterEnabled=true, got %#v", host.commandCalls)
+		}
+	})
+
+	t.Run("scheduler.exec jupyter true", func(t *testing.T) {
+		host := run(t, `function main() { scheduler.exec({ command: "python3", jupyter: true }); }`)
+		if len(host.commandCalls) != 1 || !host.commandCalls[0].JupyterEnabled {
+			t.Fatalf("expected exec request with JupyterEnabled=true, got %#v", host.commandCalls)
+		}
+	})
+
+	t.Run("omitted jupyter defaults false", func(t *testing.T) {
+		host := run(t, `function main() { scheduler.agent("p", {}); scheduler.shell("echo hi", {}); }`)
+		if len(host.agentCalls) != 1 || host.agentCalls[0].JupyterEnabled {
+			t.Fatalf("expected agent request with JupyterEnabled=false, got %#v", host.agentCalls)
+		}
+		if len(host.commandCalls) != 1 || host.commandCalls[0].JupyterEnabled {
+			t.Fatalf("expected command request with JupyterEnabled=false, got %#v", host.commandCalls)
+		}
+	})
+}

--- a/pkg/loaders/run_host.go
+++ b/pkg/loaders/run_host.go
@@ -289,12 +289,13 @@ func (h *RuntimeHost) ProjectAgent(ctx context.Context, prompt string, request d
 func (h *RuntimeHost) Command(ctx context.Context, request domain.LoaderCommandRequest) (domain.LoaderCommandResult, error) {
 	cleanupSession := h.commandRequiresCleanup(request)
 	agentRequest := domain.LoaderAgentRequest{
-		SessionPolicy: request.SessionPolicy,
-		Title:         request.Title,
-		Driver:        request.Driver,
-		GuestImage:    request.GuestImage,
-		WorkspaceID:   request.WorkspaceID,
-		SessionEnv:    request.SessionEnv,
+		SessionPolicy:  request.SessionPolicy,
+		Title:          request.Title,
+		Driver:         request.Driver,
+		GuestImage:     request.GuestImage,
+		WorkspaceID:    request.WorkspaceID,
+		JupyterEnabled: request.JupyterEnabled,
+		SessionEnv:     request.SessionEnv,
 	}
 	session, eventType, err := h.ensureCommandSession(ctx, agentRequest, cleanupSession)
 	if err != nil {

--- a/pkg/model/loader_model.go
+++ b/pkg/model/loader_model.go
@@ -117,15 +117,16 @@ type LoaderBinding struct {
 }
 
 type LoaderAgentRequest struct {
-	Agent         string          `json:"agent,omitempty"`
-	SessionPolicy string          `json:"sessionPolicy,omitempty"`
-	Timeout       time.Duration   `json:"timeout,omitempty"`
-	Title         string          `json:"title,omitempty"`
-	Driver        string          `json:"driver,omitempty"`
-	GuestImage    string          `json:"guestImage,omitempty"`
-	WorkspaceID   string          `json:"workspaceId,omitempty"`
-	SessionEnv    []SessionEnvVar `json:"sessionEnv,omitempty"`
-	OutputSchema  string          `json:"outputSchema,omitempty"`
+	Agent          string          `json:"agent,omitempty"`
+	SessionPolicy  string          `json:"sessionPolicy,omitempty"`
+	Timeout        time.Duration   `json:"timeout,omitempty"`
+	Title          string          `json:"title,omitempty"`
+	Driver         string          `json:"driver,omitempty"`
+	GuestImage     string          `json:"guestImage,omitempty"`
+	WorkspaceID    string          `json:"workspaceId,omitempty"`
+	JupyterEnabled bool            `json:"jupyter,omitempty"`
+	SessionEnv     []SessionEnvVar `json:"sessionEnv,omitempty"`
+	OutputSchema   string          `json:"outputSchema,omitempty"`
 }
 
 type LoaderAgentResult struct {
@@ -156,6 +157,7 @@ type LoaderCommandRequest struct {
 	Driver         string            `json:"driver,omitempty"`
 	GuestImage     string            `json:"guestImage,omitempty"`
 	WorkspaceID    string            `json:"workspaceId,omitempty"`
+	JupyterEnabled bool              `json:"jupyter,omitempty"`
 	SessionEnv     []SessionEnvVar   `json:"sessionEnv,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- loader 的会话拉起入口(`scheduler.agent` / `scheduler.shell` / `scheduler.exec`)现在接受 `jupyter: true` 选项。
- 该选项经 `LoaderAgentRequest` / `LoaderCommandRequest` 穿透到 `CreateSessionWithOptions`,使 loader/自动化任务创建的会话能像手动 run 一样启用 Jupyter。
- 此前 loader 路径的 `LoaderSessionRunner.Ensure` 调用的是 `CreateSession(...)`(空 options),`JupyterEnabled` 恒为 false,导致自动化会话在 UI 上点"打开 Jupyter"/"打开终端"始终报 `jupyter is not enabled for session`。

## 范围（YAGNI）

- 仅 enabled 开关;guest 端口用全局默认(`JUPYTER_GUEST_PORT`,默认 8888)。
- 不做 `expose`、不做 per-session guest 端口、不改会话生命周期。
- `ProjectAgent`(managed 项目)路径不变——它已通过 `RunProjectAgent` 尊重 `AgentSpec.jupyter`。

## 改动

- `pkg/model/loader_model.go`:`LoaderAgentRequest` / `LoaderCommandRequest` 各加 `JupyterEnabled bool`。
- `pkg/loaders/engine.go`:新增 `loaderBoolOption`;`scheduler.agent` 与 `scheduler.shell`/`exec` 两处解析读取 `jupyter`。
- `pkg/loaders/run_host.go`:`Command` 构造 `LoaderAgentRequest` 时带上 `JupyterEnabled`。
- `pkg/agentcompose/adapters/loader_session_runner.go`:`CreateSession(...)` → `CreateSessionWithOptions(..., {JupyterEnabled})`(关键改动)。

## 验证

- 新单测 `TestLoaderJupyterOptionThreadsThroughRequests`:`jupyter:true` 经 agent/shell/exec 穿到 request;省略时为 false。
- 既有 `store_coverage_test.go` 已覆盖 options → `proxyState.Enabled`。
- `go build ./...`、受影响包测试、`go vet` 均通过。
- 端到端(adp 验证机):shell 路径与 agent 路径分别创建的会话均 `proxyState.Enabled=true`、`GetSessionProxy` 返回 notebookUrl、JupyterLab 页 200 可打开。
