### PR TITLE
fix cli missing image errors

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -2502,7 +2502,7 @@ func runComposeImageRemoveCommand(cmd *cobra.Command, cli cliOptions, options co
 		PruneChildren: options.PruneChildren,
 	}))
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("remove image %s: %w", strings.TrimSpace(imageRef), err))
+		return commandExitErrorForImageTarget("remove image", strings.TrimSpace(imageRef), err)
 	}
 	output := composeImageRemoveOutputFromResponse(resp.Msg)
 	if cli.JSON {
@@ -2529,6 +2529,16 @@ func runComposeImageRemoveCommand(cmd *cobra.Command, cli cliOptions, options co
 	return nil
 }
 
+func commandExitErrorForImageTarget(operation, imageRef string, err error) error {
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return commandExitError{
+			Code: exitCodeUsage,
+			Err:  fmt.Errorf("image %s does not exist", imageRef),
+		}
+	}
+	return commandExitErrorForConnect(fmt.Errorf("%s %s: %w", operation, imageRef, err))
+}
+
 func runComposeImageInspectCommand(cmd *cobra.Command, cli cliOptions, imageRef string) error {
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
@@ -2538,7 +2548,7 @@ func runComposeImageInspectCommand(cmd *cobra.Command, cli cliOptions, imageRef 
 		ImageRef: strings.TrimSpace(imageRef),
 	}))
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("inspect image %s: %w", strings.TrimSpace(imageRef), err))
+		return commandExitErrorForImageTarget("inspect image", strings.TrimSpace(imageRef), err)
 	}
 	output := composeImageInspectOutputFromResponse(resp.Msg)
 	data, err := json.MarshalIndent(output, "", "  ")

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -4666,6 +4666,31 @@ func TestIntegrationCLIImageRemoveAliasesAndJSON(t *testing.T) {
 	}
 }
 
+func TestIntegrationCLIImageRemoveMissingImageMessage(t *testing.T) {
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		image: imageServiceStub{
+			removeImage: func(ctx context.Context, req *connect.Request[agentcomposev2.RemoveImageRequest]) (*connect.Response[agentcomposev2.RemoveImageResponse], error) {
+				if req.Msg.GetImageRef() != "missing:latest" {
+					t.Fatalf("RemoveImage image_ref = %q", req.Msg.GetImageRef())
+				}
+				return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("remove image: image %s: endpoint unix:///var/run/docker.sock: Error response from daemon: No such image: %s", req.Msg.GetImageRef(), req.Msg.GetImageRef()))
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("rmi", "--host", server.URL, "missing:latest")
+	if exitCode != exitCodeUsage {
+		t.Fatalf("rmi missing image exit code = %d, want %d; stderr=%q", exitCode, exitCodeUsage, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("rmi missing image stdout = %q", stdout)
+	}
+	if want := "image missing:latest does not exist\n"; stderr != want {
+		t.Fatalf("rmi missing image stderr = %q, want %q", stderr, want)
+	}
+}
+
 func TestIntegrationCLIImageInspectJSON(t *testing.T) {
 	calls := 0
 	server := newComposeServiceStubServer(t, composeServiceStubs{
@@ -4714,6 +4739,31 @@ func TestIntegrationCLIImageInspectJSON(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("InspectImage calls = %d, want 2", calls)
+	}
+}
+
+func TestIntegrationCLIImageInspectMissingImageMessage(t *testing.T) {
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		image: imageServiceStub{
+			inspectImage: func(ctx context.Context, req *connect.Request[agentcomposev2.InspectImageRequest]) (*connect.Response[agentcomposev2.InspectImageResponse], error) {
+				if req.Msg.GetImageRef() != "missing:latest" {
+					t.Fatalf("InspectImage image_ref = %q", req.Msg.GetImageRef())
+				}
+				return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("inspect image: image %s: endpoint unix:///var/run/docker.sock: Error response from daemon: No such image: %s", req.Msg.GetImageRef(), req.Msg.GetImageRef()))
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("inspect", "--host", server.URL, "image", "missing:latest")
+	if exitCode != exitCodeUsage {
+		t.Fatalf("inspect image missing exit code = %d, want %d; stderr=%q", exitCode, exitCodeUsage, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("inspect image missing stdout = %q", stdout)
+	}
+	if want := "image missing:latest does not exist\n"; stderr != want {
+		t.Fatalf("inspect image missing stderr = %q, want %q", stderr, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

  - Normalize CLI errors for target image-not-found cases.
  - `agent-compose rmi`, `agent-compose image rm`, `agent-compose inspect image`, and `agent-compose image inspect` now report `image <ref> does not exist`
  instead of leaking long Connect/Docker backend details.
  - Kept pull/build behavior unchanged because those paths can represent remote pull failures, base image failures, or build internals rather than a missing
  target image.

  ## Testing

  - `go test ./cmd/agent-compose -run 'TestIntegrationCLIImage(Remove|Inspect)(AliasesAndJSON|JSON|MissingImageMessage)$|
  TestCommandExitErrorForConnectClassifiesRPCFailures'`
  - `go test ./cmd/agent-compose`
  - `go build ./cmd/agent-compose`
  - `git diff --check`

  ## Checklist

  - [ ] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.