### PR TITLE
fix(sessionstore): append session events as JSONL

### DIFF
--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -250,6 +250,9 @@ func (s *Store) RemoveSession(_ context.Context, id string) error {
 	if err := validateSessionIDForRemove(id); err != nil {
 		return err
 	}
+	unlock := s.lockSession(id)
+	defer unlock()
+
 	path := s.sessionDir(id)
 	if _, err := os.Stat(path); err != nil {
 		return fmt.Errorf("stat session dir %s: %w", id, err)
@@ -257,6 +260,7 @@ func (s *Store) RemoveSession(_ context.Context, id string) error {
 	if err := os.RemoveAll(path); err != nil {
 		return fmt.Errorf("remove session dir %s: %w", id, err)
 	}
+	s.sessionLocks.Delete(id)
 	return nil
 }
 
@@ -492,6 +496,17 @@ func (s *Store) loadSessionCounts(id string) (SessionSummary, error) {
 		return SessionSummary{}, fmt.Errorf("decode session metadata %s: %w", id, err)
 	}
 	return session.Summary, nil
+}
+
+func (s *Store) saveEventCount(id string, eventCount int) error {
+	session, err := s.loadSession(id)
+	if err != nil {
+		return err
+	}
+	session.Summary.EventCount = eventCount
+	s.hydrateSessionGuestImage(session)
+	session.Summary.UpdatedAt = time.Now().UTC()
+	return s.saveSession(session)
 }
 
 func (s *Store) SaveSession(session *Session) error {
@@ -777,7 +792,10 @@ func (s *Store) saveEvents(id string, events []SessionEvent) error {
 func (s *Store) SaveEvents(id string, events []SessionEvent) error {
 	unlock := s.lockSession(id)
 	defer unlock()
-	return s.saveEvents(id, events)
+	if err := s.saveEvents(id, events); err != nil {
+		return err
+	}
+	return s.saveEventCount(id, len(events))
 }
 
 func (s *Store) GetVMState(id string) (VMState, error) {

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -1,15 +1,19 @@
 package sessionstore
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	appconfig "agent-compose/pkg/config"
@@ -46,7 +50,8 @@ type (
 )
 
 type Store struct {
-	config *appconfig.Config
+	config       *appconfig.Config
+	sessionLocks sync.Map
 }
 
 func NewStore(di do.Injector) (*Store, error) {
@@ -235,7 +240,9 @@ func (s *Store) ListSessions(_ context.Context, options SessionListOptions) (Ses
 func (s *Store) UpdateSession(_ context.Context, session *Session) error {
 	s.hydrateSessionGuestImage(session)
 	session.Summary.UpdatedAt = time.Now().UTC()
-	return s.saveSession(session)
+	unlock := s.lockSession(session.Summary.ID)
+	defer unlock()
+	return s.saveSessionPreservingCounts(session)
 }
 
 func (s *Store) RemoveSession(_ context.Context, id string) error {
@@ -320,23 +327,43 @@ func (s *Store) AddAgentRun(_ context.Context, sessionID string, run AgentRun) e
 }
 
 func (s *Store) AddEvent(_ context.Context, sessionID string, event SessionEvent) error {
-	events, err := s.loadEvents(sessionID)
+	unlock := s.lockSession(sessionID)
+	defer unlock()
+
+	jsonlExisted, err := s.eventsJSONLExists(sessionID)
 	if err != nil {
 		return err
 	}
-	events = append(events, event)
-	if err := s.saveEvents(sessionID, events); err != nil {
+	legacyCount := 0
+	if !jsonlExisted {
+		events, err := s.loadLegacyEvents(sessionID)
+		if err != nil {
+			return err
+		}
+		legacyCount = len(events)
+	}
+
+	if err := s.appendEvent(sessionID, event); err != nil {
 		return err
 	}
+
 	session, err := s.loadSession(sessionID)
 	if err == nil {
-		session.Summary.EventCount = len(events)
-		_ = s.UpdateSession(context.Background(), session)
+		nextCount := session.Summary.EventCount + 1
+		if !jsonlExisted && legacyCount >= session.Summary.EventCount {
+			nextCount = legacyCount + 1
+		}
+		session.Summary.EventCount = nextCount
+		s.hydrateSessionGuestImage(session)
+		session.Summary.UpdatedAt = time.Now().UTC()
+		_ = s.saveSessionPreservingCounts(session)
 	}
 	return nil
 }
 
 func (s *Store) ListEvents(_ context.Context, id string) ([]SessionEvent, error) {
+	unlock := s.lockSession(id)
+	defer unlock()
 	return s.loadEvents(id)
 }
 
@@ -356,6 +383,13 @@ func validateSessionIDForRemove(id string) error {
 		return fmt.Errorf("invalid session id %q", id)
 	}
 	return nil
+}
+
+func (s *Store) lockSession(id string) func() {
+	value, _ := s.sessionLocks.LoadOrStore(id, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
 }
 
 func (s *Store) hydrateSessionGuestImage(session *Session) {
@@ -430,8 +464,40 @@ func (s *Store) saveSession(session *Session) error {
 	return nil
 }
 
-func (s *Store) SaveSession(session *Session) error {
+func (s *Store) saveSessionPreservingCounts(session *Session) error {
+	existing, err := s.loadSessionCounts(session.Summary.ID)
+	if err != nil {
+		return err
+	}
+	if existing.CellCount > session.Summary.CellCount {
+		session.Summary.CellCount = existing.CellCount
+	}
+	if existing.EventCount > session.Summary.EventCount {
+		session.Summary.EventCount = existing.EventCount
+	}
 	return s.saveSession(session)
+}
+
+func (s *Store) loadSessionCounts(id string) (SessionSummary, error) {
+	path := filepath.Join(s.sessionDir(id), "metadata.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return SessionSummary{}, nil
+		}
+		return SessionSummary{}, fmt.Errorf("read session metadata %s: %w", id, err)
+	}
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return SessionSummary{}, fmt.Errorf("decode session metadata %s: %w", id, err)
+	}
+	return session.Summary, nil
+}
+
+func (s *Store) SaveSession(session *Session) error {
+	unlock := s.lockSession(session.Summary.ID)
+	defer unlock()
+	return s.saveSessionPreservingCounts(session)
 }
 
 func (s *Store) loadCells(id string) ([]NotebookCell, error) {
@@ -568,7 +634,38 @@ func (s *Store) mergeLegacyAgentRuns(id string, cells []NotebookCell) ([]Noteboo
 }
 
 func (s *Store) loadEvents(id string) ([]SessionEvent, error) {
-	path := filepath.Join(s.sessionDir(id), "state", "events.json")
+	events, err := s.loadLegacyEvents(id)
+	if err != nil {
+		return nil, err
+	}
+	jsonlEvents, err := s.loadJSONLEvents(id)
+	if err != nil {
+		return nil, err
+	}
+	return append(events, jsonlEvents...), nil
+}
+
+func (s *Store) eventsJSONPath(id string) string {
+	return filepath.Join(s.sessionDir(id), "state", "events.json")
+}
+
+func (s *Store) eventsJSONLPath(id string) string {
+	return filepath.Join(s.sessionDir(id), "state", "events.jsonl")
+}
+
+func (s *Store) eventsJSONLExists(id string) (bool, error) {
+	_, err := os.Stat(s.eventsJSONLPath(id))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat events jsonl: %w", err)
+}
+
+func (s *Store) loadLegacyEvents(id string) ([]SessionEvent, error) {
+	path := s.eventsJSONPath(id)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -586,18 +683,100 @@ func (s *Store) loadEvents(id string) ([]SessionEvent, error) {
 	return events, nil
 }
 
-func (s *Store) saveEvents(id string, events []SessionEvent) error {
-	data, err := json.MarshalIndent(events, "", "  ")
+func (s *Store) loadJSONLEvents(id string) ([]SessionEvent, error) {
+	path := s.eventsJSONLPath(id)
+	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("encode events: %w", err)
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read events jsonl: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(s.sessionDir(id), "state", "events.json"), append(data, '\n'), 0o644); err != nil {
-		return fmt.Errorf("write events: %w", err)
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	var events []SessionEvent
+	lineNumber := 0
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			lineNumber++
+			line = bytes.TrimSpace(line)
+			if len(line) > 0 {
+				var event SessionEvent
+				if err := json.Unmarshal(line, &event); err != nil {
+					return nil, fmt.Errorf("decode events %s line %d: %w", path, lineNumber, err)
+				}
+				events = append(events, event)
+			}
+		}
+		if readErr == nil {
+			continue
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		return nil, fmt.Errorf("read events %s line %d: %w", path, lineNumber+1, readErr)
+	}
+	return events, nil
+}
+
+func (s *Store) appendEvent(id string, event SessionEvent) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("encode event: %w", err)
+	}
+	data = append(data, '\n')
+
+	file, err := os.OpenFile(s.eventsJSONLPath(id), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open events jsonl: %w", err)
+	}
+	if n, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("append events jsonl: %w", err)
+	} else if n != len(data) {
+		_ = file.Close()
+		return fmt.Errorf("append events jsonl: %w", io.ErrShortWrite)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close events jsonl: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) saveEvents(id string, events []SessionEvent) error {
+	file, err := os.OpenFile(s.eventsJSONLPath(id), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("write events jsonl: %w", err)
+	}
+	for _, event := range events {
+		data, err := json.Marshal(event)
+		if err != nil {
+			_ = file.Close()
+			return fmt.Errorf("encode event: %w", err)
+		}
+		data = append(data, '\n')
+		if n, err := file.Write(data); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("write events jsonl: %w", err)
+		} else if n != len(data) {
+			_ = file.Close()
+			return fmt.Errorf("write events jsonl: %w", io.ErrShortWrite)
+		}
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close events jsonl: %w", err)
+	}
+	if err := os.Remove(s.eventsJSONPath(id)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove legacy events: %w", err)
 	}
 	return nil
 }
 
 func (s *Store) SaveEvents(id string, events []SessionEvent) error {
+	unlock := s.lockSession(id)
+	defer unlock()
 	return s.saveEvents(id, events)
 }
 

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -692,7 +692,7 @@ func (s *Store) loadJSONLEvents(id string) ([]SessionEvent, error) {
 		}
 		return nil, fmt.Errorf("read events jsonl: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	reader := bufio.NewReader(file)
 	var events []SessionEvent

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -250,13 +250,14 @@ func (s *Store) RemoveSession(_ context.Context, id string) error {
 	if err := validateSessionIDForRemove(id); err != nil {
 		return err
 	}
-	unlock := s.lockSession(id)
-	defer unlock()
-
 	path := s.sessionDir(id)
 	if _, err := os.Stat(path); err != nil {
 		return fmt.Errorf("stat session dir %s: %w", id, err)
 	}
+
+	unlock := s.lockSession(id)
+	defer unlock()
+
 	if err := os.RemoveAll(path); err != nil {
 		return fmt.Errorf("remove session dir %s: %w", id, err)
 	}

--- a/pkg/storage/sessionstore/store_coverage_test.go
+++ b/pkg/storage/sessionstore/store_coverage_test.go
@@ -3,8 +3,11 @@ package sessionstore
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -78,6 +81,180 @@ func TestStoreCreateSessionWithJupyterOptions(t *testing.T) {
 	}
 	if !proxyState.Enabled || !proxyState.Exposed || proxyState.GuestPort != 9999 || proxyState.HostPort == 0 || proxyState.Token == "" {
 		t.Fatalf("proxy state = %+v, want enabled/exposed guest port 9999 with host port/token", proxyState)
+	}
+}
+
+func TestStoreCreateSessionInitializesJSONLEvents(t *testing.T) {
+	ctx := context.Background()
+	store := newCoverageStore(t)
+	session, err := store.CreateSession(ctx, "JSONL Events", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	if _, err := os.Stat(store.eventsJSONLPath(session.Summary.ID)); err != nil {
+		t.Fatalf("events.jsonl stat err = %v, want file", err)
+	}
+	if _, err := os.Stat(store.eventsJSONPath(session.Summary.ID)); !os.IsNotExist(err) {
+		t.Fatalf("legacy events.json stat err = %v, want not exist", err)
+	}
+}
+
+func TestStoreEventJSONLLegacyCompatibility(t *testing.T) {
+	ctx := context.Background()
+	store := newCoverageStore(t)
+	session, err := store.CreateSession(ctx, "Legacy JSON Events", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	baseTime := time.Now().UTC().Round(0)
+	if err := os.Remove(store.eventsJSONLPath(session.Summary.ID)); err != nil {
+		t.Fatalf("remove initial events.jsonl: %v", err)
+	}
+	legacyEvents := []SessionEvent{{ID: "legacy-1", Type: "session.legacy", Level: "info", Message: "legacy", CreatedAt: baseTime}}
+	legacyData, err := json.Marshal(legacyEvents)
+	if err != nil {
+		t.Fatalf("Marshal legacy events returned error: %v", err)
+	}
+	if err := os.WriteFile(store.eventsJSONPath(session.Summary.ID), legacyData, 0o644); err != nil {
+		t.Fatalf("write legacy events returned error: %v", err)
+	}
+
+	events, err := store.ListEvents(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListEvents legacy returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != "legacy-1" {
+		t.Fatalf("legacy events = %#v", events)
+	}
+
+	if err := store.AddEvent(ctx, session.Summary.ID, SessionEvent{ID: "jsonl-1", Type: "session.jsonl", Level: "info", Message: "jsonl", CreatedAt: baseTime.Add(time.Second)}); err != nil {
+		t.Fatalf("AddEvent returned error: %v", err)
+	}
+	events, err = store.ListEvents(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListEvents mixed returned error: %v", err)
+	}
+	if len(events) != 2 || events[0].ID != "legacy-1" || events[1].ID != "jsonl-1" {
+		t.Fatalf("mixed events = %#v", events)
+	}
+	loaded, err := store.GetSession(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if loaded.Summary.EventCount != 2 {
+		t.Fatalf("EventCount = %d, want 2", loaded.Summary.EventCount)
+	}
+}
+
+func TestStoreSaveEventsReplacesWithJSONLAndRemovesLegacy(t *testing.T) {
+	ctx := context.Background()
+	store := newCoverageStore(t)
+	session, err := store.CreateSession(ctx, "Replace Events", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	if err := os.WriteFile(store.eventsJSONPath(session.Summary.ID), []byte(`[{"id":"legacy"}]`), 0o644); err != nil {
+		t.Fatalf("write legacy events returned error: %v", err)
+	}
+	events := []SessionEvent{
+		{ID: "replacement-1", Type: "session.replaced", Level: "info", Message: "one", CreatedAt: time.Now().UTC().Round(0)},
+		{ID: "replacement-2", Type: "session.replaced", Level: "info", Message: "two", CreatedAt: time.Now().UTC().Round(0)},
+	}
+	if err := store.SaveEvents(session.Summary.ID, events); err != nil {
+		t.Fatalf("SaveEvents returned error: %v", err)
+	}
+	if _, err := os.Stat(store.eventsJSONPath(session.Summary.ID)); !os.IsNotExist(err) {
+		t.Fatalf("legacy events.json stat err = %v, want not exist", err)
+	}
+	loaded, err := store.ListEvents(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	if len(loaded) != 2 || loaded[0].ID != "replacement-1" || loaded[1].ID != "replacement-2" {
+		t.Fatalf("loaded replacement events = %#v", loaded)
+	}
+	data, err := os.ReadFile(store.eventsJSONLPath(session.Summary.ID))
+	if err != nil {
+		t.Fatalf("read events.jsonl returned error: %v", err)
+	}
+	if strings.Contains(string(data), "[") || strings.Count(string(data), "\n") != 2 {
+		t.Fatalf("events.jsonl data = %q, want two JSONL records", string(data))
+	}
+}
+
+func TestStoreListEventsCorruptJSONLIncludesLineNumber(t *testing.T) {
+	ctx := context.Background()
+	store := newCoverageStore(t)
+	session, err := store.CreateSession(ctx, "Corrupt JSONL", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	data := `{"id":"ok","type":"session.ok","level":"info","message":"ok","created_at":"2026-07-07T00:00:00Z"}` + "\n\n{bad json}\n"
+	if err := os.WriteFile(store.eventsJSONLPath(session.Summary.ID), []byte(data), 0o644); err != nil {
+		t.Fatalf("write corrupt events.jsonl returned error: %v", err)
+	}
+	_, err = store.ListEvents(ctx, session.Summary.ID)
+	if err == nil {
+		t.Fatalf("ListEvents corrupt JSONL returned nil error")
+	}
+	if !strings.Contains(err.Error(), store.eventsJSONLPath(session.Summary.ID)) || !strings.Contains(err.Error(), "line 3") {
+		t.Fatalf("ListEvents corrupt JSONL error = %v, want file path and line number", err)
+	}
+}
+
+func TestStoreConcurrentAddEventJSONL(t *testing.T) {
+	ctx := context.Background()
+	store := newCoverageStore(t)
+	session, err := store.CreateSession(ctx, "Concurrent Events", "", driverpkg.RuntimeDriverBoxlite, "", "", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	const eventCount = 200
+	var wg sync.WaitGroup
+	errCh := make(chan error, eventCount)
+	for index := 0; index < eventCount; index++ {
+		index := index
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- store.AddEvent(ctx, session.Summary.ID, SessionEvent{
+				ID:        fmt.Sprintf("event-%03d", index),
+				Type:      "session.concurrent",
+				Level:     "info",
+				Message:   "concurrent",
+				CreatedAt: time.Now().UTC(),
+			})
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("AddEvent concurrent returned error: %v", err)
+		}
+	}
+
+	events, err := store.ListEvents(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	if len(events) != eventCount {
+		t.Fatalf("len(events) = %d, want %d", len(events), eventCount)
+	}
+	loaded, err := store.GetSession(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if loaded.Summary.EventCount != eventCount {
+		t.Fatalf("EventCount = %d, want %d", loaded.Summary.EventCount, eventCount)
+	}
+	lines, err := store.loadJSONLEvents(session.Summary.ID)
+	if err != nil {
+		t.Fatalf("loadJSONLEvents returned error: %v", err)
+	}
+	if len(lines) != eventCount {
+		t.Fatalf("JSONL event count = %d, want %d", len(lines), eventCount)
 	}
 }
 

--- a/pkg/storage/sessionstore/store_coverage_test.go
+++ b/pkg/storage/sessionstore/store_coverage_test.go
@@ -173,12 +173,31 @@ func TestStoreSaveEventsReplacesWithJSONLAndRemovesLegacy(t *testing.T) {
 	if len(loaded) != 2 || loaded[0].ID != "replacement-1" || loaded[1].ID != "replacement-2" {
 		t.Fatalf("loaded replacement events = %#v", loaded)
 	}
+	metadata, err := store.GetSession(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSession after SaveEvents returned error: %v", err)
+	}
+	if metadata.Summary.EventCount != 2 {
+		t.Fatalf("EventCount after SaveEvents = %d, want 2", metadata.Summary.EventCount)
+	}
 	data, err := os.ReadFile(store.eventsJSONLPath(session.Summary.ID))
 	if err != nil {
 		t.Fatalf("read events.jsonl returned error: %v", err)
 	}
 	if strings.Contains(string(data), "[") || strings.Count(string(data), "\n") != 2 {
 		t.Fatalf("events.jsonl data = %q, want two JSONL records", string(data))
+	}
+
+	replacement := []SessionEvent{{ID: "replacement-final", Type: "session.replaced", Level: "info", Message: "final", CreatedAt: time.Now().UTC().Round(0)}}
+	if err := store.SaveEvents(session.Summary.ID, replacement); err != nil {
+		t.Fatalf("SaveEvents final replacement returned error: %v", err)
+	}
+	metadata, err = store.GetSession(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSession after final SaveEvents returned error: %v", err)
+	}
+	if metadata.Summary.EventCount != 1 {
+		t.Fatalf("EventCount after final SaveEvents = %d, want 1", metadata.Summary.EventCount)
 	}
 }
 

--- a/pkg/storage/sessionstore/store_remove_test.go
+++ b/pkg/storage/sessionstore/store_remove_test.go
@@ -22,12 +22,20 @@ func TestRemoveSessionDeletesSessionDirectory(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sessionDir, "state", "events.json"), []byte("[]\n"), 0o644); err != nil {
 		t.Fatalf("write session file: %v", err)
 	}
+	unlock := store.lockSession(sessionID)
+	unlock()
+	if _, ok := store.sessionLocks.Load(sessionID); !ok {
+		t.Fatalf("session lock was not initialized")
+	}
 
 	if err := store.RemoveSession(context.Background(), sessionID); err != nil {
 		t.Fatalf("RemoveSession returned error: %v", err)
 	}
 	if _, err := os.Stat(sessionDir); !os.IsNotExist(err) {
 		t.Fatalf("session dir stat err = %v, want not exist", err)
+	}
+	if _, ok := store.sessionLocks.Load(sessionID); ok {
+		t.Fatalf("session lock was not removed")
 	}
 }
 

--- a/pkg/storage/sessionstore/store_remove_test.go
+++ b/pkg/storage/sessionstore/store_remove_test.go
@@ -62,12 +62,16 @@ func TestRemoveSessionRejectsUnsafeIDs(t *testing.T) {
 
 func TestRemoveSessionMissingDirectoryReturnsError(t *testing.T) {
 	store := newRemoveSessionTestStore(t)
-	err := store.RemoveSession(context.Background(), "missing-session")
+	sessionID := "missing-session"
+	err := store.RemoveSession(context.Background(), sessionID)
 	if err == nil {
 		t.Fatal("RemoveSession missing session returned nil error")
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("RemoveSession missing error = %v, want not exist", err)
+	}
+	if _, ok := store.sessionLocks.Load(sessionID); ok {
+		t.Fatalf("missing session created a lock entry")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change session event persistence from full-array rewrites in `state/events.json` to append-only JSONL records in `state/events.jsonl`.
- Keep legacy `state/events.json` readable, with legacy events returned before JSONL events.
- Add per-session locking around event operations and preserve metadata counts during concurrent session saves.
- Keep `SaveEvents` as a full replacement operation that rewrites JSONL and removes legacy JSON.

## Testing
- `go test ./pkg/storage/sessionstore`
- `go test -race ./pkg/storage/sessionstore`
- `task test`

Fixes #140
Supersedes #145