### PR TITLE
set microsandbox bind mount quota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,9 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 # Docker and MicroSandbox storage.
 # --------------------------------------
 # DOCKER_HOME=/data/docker
+# Microsandbox bind mounts get this guest-write quota. Defaults to
+# BOX_DISK_SIZE_GB when unset.
+# MICROSANDBOX_BIND_QUOTA_GB=6
 # MICROSANDBOX_INSECURE_REGISTRIES=
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -322,10 +322,12 @@ Important variables include:
   explicit `agent-compose cache prune --older-than ... --force` for cache
   cleanup.
 - `BOX_DISK_SIZE_GB`: shared guest disk size for VM-type drivers (the boxlite
-  box disk and the microsandbox docker disk). Default 6 GiB.
+  box disk and the microsandbox docker disk). It also defaults the microsandbox
+  bind mount quota. Default 6 GiB.
 - `DOCKER_HOME`: Docker runtime state directory.
 - `MICROSANDBOX_HOME`, `MICROSANDBOX_MSB_PATH`, `MICROSANDBOX_LIB_PATH`,
-  `MICROSANDBOX_INSECURE_REGISTRIES`: Microsandbox settings.
+  `MICROSANDBOX_BIND_QUOTA_GB`, `MICROSANDBOX_INSECURE_REGISTRIES`:
+  Microsandbox settings.
 - `GUEST_WORKSPACE`, `GUEST_STATE_ROOT`, `GUEST_RUNTIME_ROOT`,
   `GUEST_LOG_ROOT`, `JUPYTER_GUEST_PORT`: guest paths and Jupyter port.
 - `WEBHOOK_BODY_LIMIT_BYTES`, `WORKSPACE_UPLOAD_LIMIT_BYTES`: request limits.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	MicrosandboxLibPath        string
 	MicrosandboxDefaultImage   string
 	MicrosandboxInsecure       []string
+	MicrosandboxBindQuotaGB    int
 	DefaultImage               string
 	BoxRootfsPath              string
 	ImageRegistry              string
@@ -244,6 +245,15 @@ func NewConfig(di do.Injector) (*Config, error) {
 			boxDiskSizeGB = parsed
 		}
 	}
+	microsandboxBindQuotaGB := boxDiskSizeGB
+	if raw := os.Getenv("MICROSANDBOX_BIND_QUOTA_GB"); raw != "" {
+		var parsed int
+		if _, err := fmt.Sscanf(raw, "%d", &parsed); err != nil || parsed <= 0 {
+			logger.Warn("failed to parse MICROSANDBOX_BIND_QUOTA_GB", "value", raw, "error", err)
+		} else {
+			microsandboxBindQuotaGB = parsed
+		}
+	}
 
 	boxCacheTTL := 7 * 24 * time.Hour
 	if raw := os.Getenv("BOX_CACHE_TTL"); raw != "" {
@@ -396,6 +406,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		MicrosandboxLibPath:        microsandboxLibPath,
 		MicrosandboxDefaultImage:   microsandboxDefaultImage,
 		MicrosandboxInsecure:       microsandboxInsecure,
+		MicrosandboxBindQuotaGB:    microsandboxBindQuotaGB,
 		DefaultImage:               defaultImage,
 		BoxRootfsPath:              boxRootfsPath,
 		ImageRegistry:              imageRegistry,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -656,3 +656,60 @@ func TestBoxDiskSizeGB(t *testing.T) {
 		}
 	})
 }
+
+func TestMicrosandboxBindQuotaGB(t *testing.T) {
+	newCfg := func(t *testing.T) *Config {
+		t.Helper()
+		root := t.TempDir()
+		t.Setenv("DATA_ROOT", filepath.Join(root, "data"))
+		di := do.New()
+		do.ProvideValue(di, slog.Default())
+		cfg, err := NewConfig(di)
+		if err != nil {
+			t.Fatalf("NewConfig returned error: %v", err)
+		}
+		return cfg
+	}
+
+	t.Run("defaults to box disk size", func(t *testing.T) {
+		cfg := newCfg(t)
+		if cfg.MicrosandboxBindQuotaGB != 6 {
+			t.Fatalf("MicrosandboxBindQuotaGB = %d, want 6", cfg.MicrosandboxBindQuotaGB)
+		}
+	})
+
+	t.Run("follows BOX_DISK_SIZE_GB", func(t *testing.T) {
+		t.Setenv("BOX_DISK_SIZE_GB", "60")
+		cfg := newCfg(t)
+		if cfg.MicrosandboxBindQuotaGB != 60 {
+			t.Fatalf("MicrosandboxBindQuotaGB = %d, want 60", cfg.MicrosandboxBindQuotaGB)
+		}
+	})
+
+	t.Run("override sets the value", func(t *testing.T) {
+		t.Setenv("BOX_DISK_SIZE_GB", "60")
+		t.Setenv("MICROSANDBOX_BIND_QUOTA_GB", "96")
+		cfg := newCfg(t)
+		if cfg.MicrosandboxBindQuotaGB != 96 {
+			t.Fatalf("MicrosandboxBindQuotaGB = %d, want 96", cfg.MicrosandboxBindQuotaGB)
+		}
+	})
+
+	t.Run("invalid override keeps the inherited default", func(t *testing.T) {
+		t.Setenv("BOX_DISK_SIZE_GB", "60")
+		t.Setenv("MICROSANDBOX_BIND_QUOTA_GB", "abc")
+		cfg := newCfg(t)
+		if cfg.MicrosandboxBindQuotaGB != 60 {
+			t.Fatalf("MicrosandboxBindQuotaGB = %d, want 60", cfg.MicrosandboxBindQuotaGB)
+		}
+	})
+
+	t.Run("non-positive override keeps the inherited default", func(t *testing.T) {
+		t.Setenv("BOX_DISK_SIZE_GB", "60")
+		t.Setenv("MICROSANDBOX_BIND_QUOTA_GB", "0")
+		cfg := newCfg(t)
+		if cfg.MicrosandboxBindQuotaGB != 60 {
+			t.Fatalf("MicrosandboxBindQuotaGB = %d, want 60", cfg.MicrosandboxBindQuotaGB)
+		}
+	})
+}

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -825,7 +825,7 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sessio
 	}
 	mounts := make(map[string]microsandbox.MountConfig, len(manifest.Mounts)+1)
 	for _, mount := range manifest.Mounts {
-		mounts[mount.GuestPath] = microsandbox.Mount.Bind(mount.HostPath, microsandbox.MountOptions{Readonly: mount.ReadOnly})
+		mounts[mount.GuestPath] = r.microsandboxBindMount(mount.HostPath, mount.ReadOnly)
 	}
 	// Give docker its own disk-backed ext4 volume. The guest root is virtiofs,
 	// on which the kernel rejects overlayfs (docker's default storage driver)
@@ -903,6 +903,24 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sessio
 	}
 	sandboxCreated = true
 	return sandbox, nil
+}
+
+func (r *microsandboxRuntime) microsandboxBindMount(hostPath string, readonly bool) microsandbox.MountConfig {
+	mount := microsandbox.Mount.Bind(hostPath, microsandbox.MountOptions{Readonly: readonly})
+	if quotaGB := r.microsandboxBindQuotaGB(); quotaGB > 0 {
+		mount.QuotaMiB = uint32(quotaGB) * 1024
+	}
+	return mount
+}
+
+func (r *microsandboxRuntime) microsandboxBindQuotaGB() int {
+	if r.config == nil {
+		return 0
+	}
+	if r.config.MicrosandboxBindQuotaGB > 0 {
+		return r.config.MicrosandboxBindQuotaGB
+	}
+	return r.config.BoxDiskSizeGB
 }
 
 func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, imageRef string) (string, bool, error) {

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -150,6 +150,42 @@ func TestMicrosandboxRemoveDockerDiskOnlyCurrentSession(t *testing.T) {
 	}
 }
 
+func TestMicrosandboxBindMountSetsConfiguredQuota(t *testing.T) {
+	runtime := &microsandboxRuntime{config: &appconfig.Config{MicrosandboxBindQuotaGB: 60}}
+
+	mount := runtime.microsandboxBindMount("/host/session", false)
+
+	if mount.QuotaMiB != 60*1024 {
+		t.Fatalf("QuotaMiB = %d, want %d", mount.QuotaMiB, 60*1024)
+	}
+	if mount.Readonly {
+		t.Fatalf("Readonly = true, want false")
+	}
+}
+
+func TestMicrosandboxBindMountPreservesReadonly(t *testing.T) {
+	runtime := &microsandboxRuntime{config: &appconfig.Config{MicrosandboxBindQuotaGB: 11}}
+
+	mount := runtime.microsandboxBindMount("/host/session", true)
+
+	if mount.QuotaMiB != 11*1024 {
+		t.Fatalf("QuotaMiB = %d, want %d", mount.QuotaMiB, 11*1024)
+	}
+	if !mount.Readonly {
+		t.Fatalf("Readonly = false, want true")
+	}
+}
+
+func TestMicrosandboxBindMountFallsBackToBoxDiskSize(t *testing.T) {
+	runtime := &microsandboxRuntime{config: &appconfig.Config{BoxDiskSizeGB: 42}}
+
+	mount := runtime.microsandboxBindMount("/host/session", false)
+
+	if mount.QuotaMiB != 42*1024 {
+		t.Fatalf("QuotaMiB = %d, want %d", mount.QuotaMiB, 42*1024)
+	}
+}
+
 func TestListMicrosandboxSessionEphemeralCaches(t *testing.T) {
 	home := t.TempDir()
 	diskPath := writeMicrosandboxFile(t, home, "docker-disks", "running.raw")


### PR DESCRIPTION
## Summary
- add MICROSANDBOX_BIND_QUOTA_GB for microsandbox bind mount guest-write quota
- default the bind quota to BOX_DISK_SIZE_GB so existing 60G deployments also get 60G /data headroom
- explicitly set QuotaMiB on microsandbox bind mounts to avoid upstream's 4GiB default

## Root Cause
Microsandbox v0.5.10+ applies a default 4GiB guest-write quota to bind mounts. Agent Compose did not pass an explicit quota for the directory-only /data bind mount, so /data was limited to baseline + 4GiB even when BOX_DISK_SIZE_GB configured the docker disk to 60G.

## Validation
- go test ./pkg/config ./pkg/driver