### PR TITLE
Fix compose ls resource counts

### DIFF
--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -76,6 +76,7 @@ func testComposeProjectPureHelpers(t *testing.T) {
 		SpecHash:        "hash",
 		AgentCount:      2,
 		SchedulerCount:  1,
+		TriggerCount:    5,
 		RunningRunCount: 4,
 		LatestRunId:     "run-1",
 		UpdatedAt:       "2026-07-04T00:00:00Z",
@@ -84,22 +85,19 @@ func testComposeProjectPureHelpers(t *testing.T) {
 	if item.ProjectDir != "/tmp/project" || projectListStatus(item) != "removed" {
 		t.Fatalf("project list item = %#v", item)
 	}
-	count := uint32(5)
-	item.ServiceCount = &count
 	var out bytes.Buffer
 	if err := writeProjectListText(&out, []composeProjectListItem{item}, true); err != nil {
 		t.Fatalf("writeProjectListText verbose returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "SERVICES") || !strings.Contains(out.String(), "removed") || projectServiceCountText(item.ServiceCount) != "5" {
+	if !strings.Contains(out.String(), "TRIGGERS") || strings.Contains(out.String(), "SERVICES") || !strings.Contains(out.String(), "removed") || !strings.Contains(out.String(), "5") {
 		t.Fatalf("verbose project list output = %q", out.String())
 	}
 	out.Reset()
 	item.RemovedAt = ""
-	item.ServiceCount = nil
 	if err := writeProjectListText(&out, []composeProjectListItem{item}, false); err != nil {
 		t.Fatalf("writeProjectListText returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "-") || projectListStatus(item) != "active" || projectServiceCountText(nil) != "-" {
+	if !strings.Contains(out.String(), "5") || projectListStatus(item) != "active" {
 		t.Fatalf("project list output = %q", out.String())
 	}
 

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3322,20 +3322,20 @@ type composeProjectListOutput struct {
 }
 
 type composeProjectListItem struct {
-	ID              string  `json:"id"`
-	Name            string  `json:"name"`
-	ConfigFile      string  `json:"config_file"`
-	ProjectDir      string  `json:"project_dir,omitempty"`
-	Revision        uint64  `json:"revision"`
-	SpecHash        string  `json:"spec_hash,omitempty"`
-	AgentCount      uint32  `json:"agent_count"`
-	SchedulerCount  uint32  `json:"scheduler_count"`
-	ServiceCount    *uint32 `json:"service_count"`
-	RunningRunCount uint32  `json:"running_run_count"`
-	LatestRunID     string  `json:"latest_run_id,omitempty"`
-	CreatedAt       string  `json:"created_at,omitempty"`
-	UpdatedAt       string  `json:"updated_at,omitempty"`
-	RemovedAt       string  `json:"removed_at,omitempty"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	ConfigFile      string `json:"config_file"`
+	ProjectDir      string `json:"project_dir,omitempty"`
+	Revision        uint64 `json:"revision"`
+	SpecHash        string `json:"spec_hash,omitempty"`
+	AgentCount      uint32 `json:"agent_count"`
+	SchedulerCount  uint32 `json:"scheduler_count"`
+	TriggerCount    uint32 `json:"trigger_count"`
+	RunningRunCount uint32 `json:"running_run_count"`
+	LatestRunID     string `json:"latest_run_id,omitempty"`
+	CreatedAt       string `json:"created_at,omitempty"`
+	UpdatedAt       string `json:"updated_at,omitempty"`
+	RemovedAt       string `json:"removed_at,omitempty"`
 }
 
 type composeUpProjectOutput struct {
@@ -3700,7 +3700,7 @@ func composeProjectListItemFromSummary(summary *agentcomposev2.ProjectSummary) c
 		SpecHash:        summary.GetSpecHash(),
 		AgentCount:      summary.GetAgentCount(),
 		SchedulerCount:  summary.GetSchedulerCount(),
-		ServiceCount:    nil,
+		TriggerCount:    summary.GetTriggerCount(),
 		RunningRunCount: summary.GetRunningRunCount(),
 		LatestRunID:     summary.GetLatestRunId(),
 		CreatedAt:       summary.GetCreatedAt(),
@@ -3814,17 +3814,17 @@ func writeComposeUpText(out io.Writer, resp *agentcomposev2.ApplyProjectResponse
 func writeProjectListText(out io.Writer, projects []composeProjectListItem, verbose bool) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	if verbose {
-		if _, err := fmt.Fprintln(tw, "PROJECT\tCONFIG FILE\tREVISION\tAGENTS\tSCHEDULERS\tSERVICES\tPROJECT ID\tPROJECT DIR\tSPEC HASH\tUPDATED\tSTATUS"); err != nil {
+		if _, err := fmt.Fprintln(tw, "PROJECT\tCONFIG FILE\tREVISION\tAGENTS\tSCHEDULERS\tTRIGGERS\tPROJECT ID\tPROJECT DIR\tSPEC HASH\tUPDATED\tSTATUS"); err != nil {
 			return err
 		}
 		for _, project := range projects {
-			if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\n",
 				project.Name,
 				firstNonEmptyString(project.ConfigFile, "-"),
 				project.Revision,
 				project.AgentCount,
 				project.SchedulerCount,
-				projectServiceCountText(project.ServiceCount),
+				project.TriggerCount,
 				firstNonEmptyString(project.ID, "-"),
 				firstNonEmptyString(project.ProjectDir, "-"),
 				firstNonEmptyString(project.SpecHash, "-"),
@@ -3836,29 +3836,22 @@ func writeProjectListText(out io.Writer, projects []composeProjectListItem, verb
 		}
 		return tw.Flush()
 	}
-	if _, err := fmt.Fprintln(tw, "PROJECT\tCONFIG FILE\tREVISION\tAGENTS\tSCHEDULERS\tSERVICES"); err != nil {
+	if _, err := fmt.Fprintln(tw, "PROJECT\tCONFIG FILE\tREVISION\tAGENTS\tSCHEDULERS\tTRIGGERS"); err != nil {
 		return err
 	}
 	for _, project := range projects {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\n",
 			project.Name,
 			firstNonEmptyString(project.ConfigFile, "-"),
 			project.Revision,
 			project.AgentCount,
 			project.SchedulerCount,
-			projectServiceCountText(project.ServiceCount),
+			project.TriggerCount,
 		); err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
-}
-
-func projectServiceCountText(count *uint32) string {
-	if count == nil {
-		return "-"
-	}
-	return strconv.FormatUint(uint64(*count), 10)
 }
 
 func projectListStatus(project composeProjectListItem) string {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -5579,7 +5579,6 @@ func TestCLIOutputHelpersCoverEdgeBranches(t *testing.T) {
 		t.Fatalf("compose down text = %q", text.String())
 	}
 
-	serviceCount := uint32(3)
 	projects := []composeProjectListItem{{
 		ID:             "project-1",
 		Name:           "Project",
@@ -5589,7 +5588,7 @@ func TestCLIOutputHelpersCoverEdgeBranches(t *testing.T) {
 		SpecHash:       "hash",
 		AgentCount:     1,
 		SchedulerCount: 1,
-		ServiceCount:   &serviceCount,
+		TriggerCount:   3,
 		UpdatedAt:      "2026-07-06T00:00:00Z",
 	}, {
 		ID:        "project-removed",
@@ -5600,7 +5599,7 @@ func TestCLIOutputHelpersCoverEdgeBranches(t *testing.T) {
 	if err := writeProjectListText(&text, projects, true); err != nil {
 		t.Fatalf("writeProjectListText verbose returned error: %v", err)
 	}
-	if !strings.Contains(text.String(), "SERVICES") || !strings.Contains(text.String(), "removed") || projectServiceCountText(nil) != "-" {
+	if !strings.Contains(text.String(), "TRIGGERS") || strings.Contains(text.String(), "SERVICES") || !strings.Contains(text.String(), "removed") {
 		t.Fatalf("project list text = %q", text.String())
 	}
 
@@ -6483,6 +6482,7 @@ func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 							SpecHash:        "sha256:reviewer",
 							AgentCount:      2,
 							SchedulerCount:  1,
+							TriggerCount:    2,
 							UpdatedAt:       "2026-07-03T10:00:00Z",
 						}},
 						TotalCount: 2,
@@ -6499,6 +6499,7 @@ func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 							SpecHash:        "sha256:builder",
 							AgentCount:      1,
 							SchedulerCount:  0,
+							TriggerCount:    0,
 							UpdatedAt:       "2026-07-03T11:00:00Z",
 						}},
 						TotalCount: 2,
@@ -6516,10 +6517,13 @@ func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("ls code/stderr = %d / %q", exitCode, stderr)
 	}
-	for _, want := range []string{"PROJECT", "CONFIG FILE", "SERVICES", "reviewer", "/path/to/reviewer/agent-compose.yml", "builder", "-"} {
+	for _, want := range []string{"PROJECT", "CONFIG FILE", "TRIGGERS", "reviewer", "/path/to/reviewer/agent-compose.yml", "builder"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("ls output %q does not contain %q", stdout, want)
 		}
+	}
+	if strings.Contains(stdout, "SERVICES") {
+		t.Fatalf("ls output still contains SERVICES: %q", stdout)
 	}
 
 	verboseOut, verboseErr, _, verboseCode := executeCLICommand("ls", "--host", server.URL, "--verbose")
@@ -6543,7 +6547,7 @@ func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 	if decoded.TotalCount != 2 || len(decoded.Projects) != 2 {
 		t.Fatalf("ls JSON = %#v", decoded)
 	}
-	if decoded.Projects[0].Name != "reviewer" || decoded.Projects[0].AgentCount != 2 || decoded.Projects[0].SchedulerCount != 1 || decoded.Projects[0].ServiceCount != nil {
+	if decoded.Projects[0].Name != "reviewer" || decoded.Projects[0].AgentCount != 2 || decoded.Projects[0].SchedulerCount != 1 || decoded.Projects[0].TriggerCount != 2 {
 		t.Fatalf("ls first project JSON = %#v", decoded.Projects[0])
 	}
 	if requests != 6 {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -618,6 +618,25 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	}
 }
 
+func TestProjectSummaryTriggerCountBounds(t *testing.T) {
+	summary := ProjectSummaryToProto(domain.ProjectRecord{ID: "project-1", Name: "Project"}, nil, []domain.ProjectSchedulerRecord{
+		{TriggerCount: -1},
+		{TriggerCount: 2},
+	})
+	if summary.GetTriggerCount() != 2 {
+		t.Fatalf("negative trigger count should be ignored, got %d", summary.GetTriggerCount())
+	}
+
+	maxInt := int(^uint(0) >> 1)
+	summary = ProjectSummaryToProto(domain.ProjectRecord{ID: "project-1", Name: "Project"}, nil, []domain.ProjectSchedulerRecord{
+		{TriggerCount: maxInt},
+		{TriggerCount: 1},
+	})
+	if summary.GetTriggerCount() != nonNegativeUint32(maxInt) {
+		t.Fatalf("overflow trigger count = %d, want %d", summary.GetTriggerCount(), nonNegativeUint32(maxInt))
+	}
+}
+
 func TestFollowRunLogsStreamsOffsetsTailAndFinal(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := tempDir + "/output.txt"

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -581,6 +581,12 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	if summary := listProjects.Msg.GetProjects()[0]; summary.GetAgentCount() != 1 || summary.GetSchedulerCount() != 1 || summary.GetTriggerCount() != 2 {
 		t.Fatalf("ListProjects summary counts = %#v", summary)
 	}
+	store.summaryCountsErr = errors.New("count query failed")
+	listProjects, err = projectHandler.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{Query: "Project", Limit: 10}))
+	if err != nil || len(listProjects.Msg.GetProjects()) != 1 || listProjects.Msg.GetProjects()[0].GetTriggerCount() != 0 {
+		t.Fatalf("ListProjects degraded counts resp=%#v err=%v", listProjects, err)
+	}
+	store.summaryCountsErr = nil
 	store.projects = append(store.projects, domain.ProjectRecord{ID: "project-2", Name: "Project"})
 	if _, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Name: "Project"}})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("expected ambiguous project error, got %v", err)
@@ -917,11 +923,12 @@ func (r *apiStatsRuntime) Stats(_ context.Context, session *domain.Session, vmSt
 }
 
 type apiProjectRunStore struct {
-	projects   []domain.ProjectRecord
-	agents     []domain.ProjectAgentRecord
-	schedulers []domain.ProjectSchedulerRecord
-	revision   domain.ProjectRevisionRecord
-	runs       map[string]domain.ProjectRunRecord
+	projects         []domain.ProjectRecord
+	agents           []domain.ProjectAgentRecord
+	schedulers       []domain.ProjectSchedulerRecord
+	summaryCountsErr error
+	revision         domain.ProjectRevisionRecord
+	runs             map[string]domain.ProjectRunRecord
 }
 
 func (s *apiProjectRunStore) GetProject(_ context.Context, projectID string) (domain.ProjectRecord, error) {
@@ -935,6 +942,27 @@ func (s *apiProjectRunStore) GetProject(_ context.Context, projectID string) (do
 
 func (s *apiProjectRunStore) ListProjects(_ context.Context, _ domain.ProjectListOptions) (domain.ProjectListResult, error) {
 	return domain.ProjectListResult{Projects: s.projects, TotalCount: len(s.projects)}, nil
+}
+
+func (s *apiProjectRunStore) ListProjectSummaryCounts(context.Context, []string) (map[string]domain.ProjectSummaryCounts, error) {
+	if s.summaryCountsErr != nil {
+		return nil, s.summaryCountsErr
+	}
+	counts := map[string]domain.ProjectSummaryCounts{}
+	for _, agent := range s.agents {
+		summary := counts[agent.ProjectID]
+		summary.AgentCount++
+		counts[agent.ProjectID] = summary
+	}
+	for _, scheduler := range s.schedulers {
+		summary := counts[scheduler.ProjectID]
+		summary.SchedulerCount++
+		if scheduler.TriggerCount > 0 {
+			summary.TriggerCount += scheduler.TriggerCount
+		}
+		counts[scheduler.ProjectID] = summary
+	}
+	return counts, nil
 }
 
 func (s *apiProjectRunStore) ListProjectAgents(context.Context, string) ([]domain.ProjectAgentRecord, error) {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -560,7 +560,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 		agents: []domain.ProjectAgentRecord{{
 			ProjectID: "project-1", AgentName: "worker", ManagedAgentID: "agent-1", Driver: "boxlite", Image: "guest:latest",
 		}},
-		schedulers: []domain.ProjectSchedulerRecord{{ProjectID: "project-1", SchedulerID: "scheduler-1", AgentName: "worker", Enabled: true}},
+		schedulers: []domain.ProjectSchedulerRecord{{ProjectID: "project-1", SchedulerID: "scheduler-1", AgentName: "worker", Enabled: true, TriggerCount: 2}},
 		revision:   domain.ProjectRevisionRecord{ProjectID: "project-1", Revision: 1, SpecJSON: `{"agents":[{"name":"worker"}]}`},
 		runs: map[string]domain.ProjectRunRecord{
 			"run-1": {RunID: "run-1", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", Status: domain.ProjectRunStatusRunning, Source: domain.ProjectRunSourceAPI, ResultJSON: "{}"},
@@ -577,6 +577,9 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	listProjects, err := projectHandler.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{Query: "Project", Limit: 10}))
 	if err != nil || len(listProjects.Msg.GetProjects()) != 1 {
 		t.Fatalf("ListProjects resp=%#v err=%v", listProjects, err)
+	}
+	if summary := listProjects.Msg.GetProjects()[0]; summary.GetAgentCount() != 1 || summary.GetSchedulerCount() != 1 || summary.GetTriggerCount() != 2 {
+		t.Fatalf("ListProjects summary counts = %#v", summary)
 	}
 	store.projects = append(store.projects, domain.ProjectRecord{ID: "project-2", Name: "Project"})
 	if _, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Name: "Project"}})); connect.CodeOf(err) != connect.CodeInvalidArgument {

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -26,17 +26,25 @@ func ProjectToProto(project domain.ProjectRecord, spec *agentcomposev2.ProjectSp
 func ProjectSummaryToProto(project domain.ProjectRecord, agents []domain.ProjectAgentRecord, schedulers []domain.ProjectSchedulerRecord) *agentcomposev2.ProjectSummary {
 	triggerCount := 0
 	for _, scheduler := range schedulers {
-		triggerCount += scheduler.TriggerCount
+		triggerCount = addNonNegativeCount(triggerCount, scheduler.TriggerCount)
 	}
+	return ProjectSummaryWithCountsToProto(project, domain.ProjectSummaryCounts{
+		AgentCount:     len(agents),
+		SchedulerCount: len(schedulers),
+		TriggerCount:   triggerCount,
+	})
+}
+
+func ProjectSummaryWithCountsToProto(project domain.ProjectRecord, counts domain.ProjectSummaryCounts) *agentcomposev2.ProjectSummary {
 	return &agentcomposev2.ProjectSummary{
 		ProjectId:       project.ID,
 		Name:            project.Name,
 		SourcePath:      project.SourcePath,
 		CurrentRevision: uint64(project.CurrentRevision),
 		SpecHash:        project.SpecHash,
-		AgentCount:      uint32(len(agents)),
-		SchedulerCount:  uint32(len(schedulers)),
-		TriggerCount:    uint32(triggerCount),
+		AgentCount:      nonNegativeUint32(counts.AgentCount),
+		SchedulerCount:  nonNegativeUint32(counts.SchedulerCount),
+		TriggerCount:    nonNegativeUint32(counts.TriggerCount),
 		CreatedAt:       FormatProjectTime(project.CreatedAt),
 		UpdatedAt:       FormatProjectTime(project.UpdatedAt),
 		RemovedAt:       FormatProjectTime(project.RemovedAt),
@@ -79,10 +87,31 @@ func ProjectSchedulersToProto(schedulers []domain.ProjectSchedulerRecord) []*age
 			SchedulerId:     scheduler.SchedulerID,
 			ManagedLoaderId: scheduler.ManagedLoaderID,
 			Enabled:         scheduler.Enabled,
-			TriggerCount:    uint32(scheduler.TriggerCount),
+			TriggerCount:    nonNegativeUint32(scheduler.TriggerCount),
 		})
 	}
 	return items
+}
+
+func nonNegativeUint32(value int) uint32 {
+	if value <= 0 {
+		return 0
+	}
+	if int64(value) > int64(^uint32(0)) {
+		return ^uint32(0)
+	}
+	return uint32(value)
+}
+
+func addNonNegativeCount(total, value int) int {
+	if value <= 0 {
+		return total
+	}
+	maxUint32 := int(^uint32(0))
+	if total >= maxUint32 || value > maxUint32-total {
+		return maxUint32
+	}
+	return total + value
 }
 
 func ProjectApplyChanges(project domain.ProjectRecord, existing domain.ProjectRecord, found bool, revision domain.ProjectRevisionRecord, revisionCreated bool) []*agentcomposev2.ProjectChange {

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -107,9 +107,12 @@ func addNonNegativeCount(total, value int) int {
 	if value <= 0 {
 		return total
 	}
-	maxUint32 := int(^uint32(0))
-	if total >= maxUint32 || value > maxUint32-total {
-		return maxUint32
+	if total < 0 {
+		total = 0
+	}
+	maxInt := int(^uint(0) >> 1)
+	if value > maxInt-total {
+		return maxInt
 	}
 	return total + value
 }

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -24,6 +24,10 @@ func ProjectToProto(project domain.ProjectRecord, spec *agentcomposev2.ProjectSp
 }
 
 func ProjectSummaryToProto(project domain.ProjectRecord, agents []domain.ProjectAgentRecord, schedulers []domain.ProjectSchedulerRecord) *agentcomposev2.ProjectSummary {
+	triggerCount := 0
+	for _, scheduler := range schedulers {
+		triggerCount += scheduler.TriggerCount
+	}
 	return &agentcomposev2.ProjectSummary{
 		ProjectId:       project.ID,
 		Name:            project.Name,
@@ -32,6 +36,7 @@ func ProjectSummaryToProto(project domain.ProjectRecord, agents []domain.Project
 		SpecHash:        project.SpecHash,
 		AgentCount:      uint32(len(agents)),
 		SchedulerCount:  uint32(len(schedulers)),
+		TriggerCount:    uint32(triggerCount),
 		CreatedAt:       FormatProjectTime(project.CreatedAt),
 		UpdatedAt:       FormatProjectTime(project.UpdatedAt),
 		RemovedAt:       FormatProjectTime(project.RemovedAt),

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -24,6 +25,7 @@ type ProjectDelegate interface {
 type ProjectStore interface {
 	GetProject(context.Context, string) (domain.ProjectRecord, error)
 	ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error)
+	ListProjectSummaryCounts(context.Context, []string) (map[string]domain.ProjectSummaryCounts, error)
 	ListProjectAgents(context.Context, string) ([]domain.ProjectAgentRecord, error)
 	ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error)
 	GetProjectRevision(context.Context, string, int64) (domain.ProjectRevisionRecord, error)
@@ -110,16 +112,17 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *connect.Request[
 		HasMore:    result.HasMore,
 		NextOffset: uint32(result.NextOffset),
 	}
+	projectIDs := make([]string, 0, len(result.Projects))
 	for _, project := range result.Projects {
-		agents, err := h.store.ListProjectAgents(ctx, project.ID)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list project agents %s: %w", project.ID, err))
-		}
-		schedulers, err := h.store.ListProjectSchedulers(ctx, project.ID)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list project schedulers %s: %w", project.ID, err))
-		}
-		resp.Projects = append(resp.Projects, ProjectSummaryToProto(project, agents, schedulers))
+		projectIDs = append(projectIDs, project.ID)
+	}
+	countsByProject, err := h.store.ListProjectSummaryCounts(ctx, projectIDs)
+	if err != nil {
+		slog.Warn("failed to load project summary counts", "error", err)
+		countsByProject = map[string]domain.ProjectSummaryCounts{}
+	}
+	for _, project := range result.Projects {
+		resp.Projects = append(resp.Projects, ProjectSummaryWithCountsToProto(project, countsByProject[project.ID]))
 	}
 	return connect.NewResponse(resp), nil
 }

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -111,7 +111,15 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *connect.Request[
 		NextOffset: uint32(result.NextOffset),
 	}
 	for _, project := range result.Projects {
-		resp.Projects = append(resp.Projects, ProjectSummaryToProto(project, nil, nil))
+		agents, err := h.store.ListProjectAgents(ctx, project.ID)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list project agents %s: %w", project.ID, err))
+		}
+		schedulers, err := h.store.ListProjectSchedulers(ctx, project.ID)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list project schedulers %s: %w", project.ID, err))
+		}
+		resp.Projects = append(resp.Projects, ProjectSummaryToProto(project, agents, schedulers))
 	}
 	return connect.NewResponse(resp), nil
 }

--- a/pkg/model/project_model.go
+++ b/pkg/model/project_model.go
@@ -62,6 +62,12 @@ type ProjectSchedulerRecord struct {
 	UpdatedAt       time.Time `json:"updated_at"`
 }
 
+type ProjectSummaryCounts struct {
+	AgentCount     int `json:"agent_count"`
+	SchedulerCount int `json:"scheduler_count"`
+	TriggerCount   int `json:"trigger_count"`
+}
+
 type ProjectRunRecord struct {
 	RunID           string    `json:"run_id"`
 	ProjectID       string    `json:"project_id"`

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -234,6 +234,71 @@ func (s *projectStore) ListProjects(ctx context.Context, options ProjectListOpti
 	}, nil
 }
 
+func (s *projectStore) ListProjectSummaryCounts(ctx context.Context, projectIDs []string) (map[string]domain.ProjectSummaryCounts, error) {
+	countsByProject := make(map[string]domain.ProjectSummaryCounts, len(projectIDs))
+	args := make([]any, 0, len(projectIDs))
+	for _, projectID := range projectIDs {
+		projectID = strings.TrimSpace(projectID)
+		if projectID == "" {
+			continue
+		}
+		if _, ok := countsByProject[projectID]; ok {
+			continue
+		}
+		countsByProject[projectID] = domain.ProjectSummaryCounts{}
+		args = append(args, projectID)
+	}
+	if len(args) == 0 {
+		return countsByProject, nil
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT project_id, COUNT(*)
+		FROM project_agent WHERE project_id IN (`+placeholders(len(args))+`) GROUP BY project_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query project agent counts: %w", err)
+	}
+	for rows.Next() {
+		var projectID string
+		var agentCount int
+		if err := rows.Scan(&projectID, &agentCount); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan project agent counts: %w", err)
+		}
+		counts := countsByProject[projectID]
+		counts.AgentCount = agentCount
+		countsByProject[projectID] = counts
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close project agent counts: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate project agent counts: %w", err)
+	}
+
+	rows, err = s.db.QueryContext(ctx, `SELECT project_id, COUNT(*), COALESCE(SUM(CASE WHEN trigger_count > 0 THEN trigger_count ELSE 0 END), 0)
+		FROM project_scheduler WHERE project_id IN (`+placeholders(len(args))+`) GROUP BY project_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query project scheduler counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var projectID string
+		var schedulerCount int
+		var triggerCount int
+		if err := rows.Scan(&projectID, &schedulerCount, &triggerCount); err != nil {
+			return nil, fmt.Errorf("scan project scheduler counts: %w", err)
+		}
+		counts := countsByProject[projectID]
+		counts.SchedulerCount = schedulerCount
+		counts.TriggerCount = triggerCount
+		countsByProject[projectID] = counts
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate project scheduler counts: %w", err)
+	}
+	return countsByProject, nil
+}
+
 func (s *projectStore) GetProjectRevision(ctx context.Context, projectID string, revision int64) (ProjectRevisionRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, revision, spec_hash, spec_json, created_at
 		FROM project_revision WHERE project_id = ? AND revision = ?`, strings.TrimSpace(projectID), revision)

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -197,6 +197,20 @@ func testConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 	if schedulers, err := store.ListProjectSchedulers(ctx, project.ID); err != nil || len(schedulers) != 1 {
 		t.Fatalf("ListProjectSchedulers schedulers=%#v err=%v", schedulers, err)
 	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE project_scheduler SET trigger_count = -3 WHERE project_id = ? AND scheduler_id = ?`, project.ID, scheduler.SchedulerID); err != nil {
+		t.Fatalf("set negative scheduler trigger count: %v", err)
+	}
+	counts, err := store.ListProjectSummaryCounts(ctx, []string{project.ID, "project-2", project.ID})
+	if err != nil {
+		t.Fatalf("ListProjectSummaryCounts returned error: %v", err)
+	}
+	if counts[project.ID].AgentCount != 1 || counts[project.ID].SchedulerCount != 1 || counts[project.ID].TriggerCount != 0 {
+		t.Fatalf("ListProjectSummaryCounts project counts=%#v", counts[project.ID])
+	}
+	if counts["project-2"].AgentCount != 0 || counts["project-2"].SchedulerCount != 0 || counts["project-2"].TriggerCount != 0 {
+		t.Fatalf("ListProjectSummaryCounts empty project counts=%#v", counts["project-2"])
+	}
+	scheduler.TriggerCount = 0
 
 	managedAgent, err := store.UpsertManagedAgentDefinition(ctx, domain.AgentDefinition{ID: "managed-agent-1", Name: "Managed", Enabled: true, Provider: "codex", ManagedProjectID: project.ID, ManagedAgentName: "worker", Driver: driverpkg.RuntimeDriverBoxlite, GuestImage: "guest:latest"})
 	if err != nil {

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -1738,6 +1738,7 @@ type ProjectSummary struct {
 	CreatedAt       string                 `protobuf:"bytes,10,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	UpdatedAt       string                 `protobuf:"bytes,11,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
 	RemovedAt       string                 `protobuf:"bytes,12,opt,name=removed_at,json=removedAt,proto3" json:"removed_at,omitempty"`
+	TriggerCount    uint32                 `protobuf:"varint,13,opt,name=trigger_count,json=triggerCount,proto3" json:"trigger_count,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1854,6 +1855,13 @@ func (x *ProjectSummary) GetRemovedAt() string {
 		return x.RemovedAt
 	}
 	return ""
+}
+
+func (x *ProjectSummary) GetTriggerCount() uint32 {
+	if x != nil {
+		return x.TriggerCount
+	}
+	return 0
 }
 
 type ProjectRevision struct {
@@ -7635,7 +7643,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x06agents\x18\x03 \x03(\v2\x1d.agentcompose.v2.ProjectAgentR\x06agents\x12A\n" +
 	"\n" +
 	"schedulers\x18\x04 \x03(\v2!.agentcompose.v2.ProjectSchedulerR\n" +
-	"schedulers\"\xa3\x03\n" +
+	"schedulers\"\xc8\x03\n" +
 	"\x0eProjectSummary\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x12\n" +
@@ -7655,7 +7663,8 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"updated_at\x18\v \x01(\tR\tupdatedAt\x12\x1d\n" +
 	"\n" +
-	"removed_at\x18\f \x01(\tR\tremovedAt\"\xba\x01\n" +
+	"removed_at\x18\f \x01(\tR\tremovedAt\x12#\n" +
+	"\rtrigger_count\x18\r \x01(\rR\ftriggerCount\"\xba\x01\n" +
 	"\x0fProjectRevision\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1a\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -262,6 +262,7 @@ message ProjectSummary {
   string created_at = 10;
   string updated_at = 11;
   string removed_at = 12;
+  uint32 trigger_count = 13;
 }
 
 message ProjectRevision {


### PR DESCRIPTION
## Summary
- populate project list summaries with real agent, scheduler, and trigger counts
- replace the misleading SERVICES column with TRIGGERS in compose ls output
- add trigger_count to v2 ProjectSummary for CLI JSON output

## Tests
- go test ./pkg/agentcompose/api ./cmd/agent-compose
- go test ./cmd/... ./pkg/... ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect
- task lint
- real local daemon CLI regression for up and ls text/JSON output