### PR TITLE
fix(webhooks): support custom token header

### DIFF
--- a/pkg/events/webhooks/coverage_shape_workflows_test.go
+++ b/pkg/events/webhooks/coverage_shape_workflows_test.go
@@ -167,6 +167,75 @@ func TestWebhookHTTPRoutesCoverageWorkflow(t *testing.T) {
 	}
 }
 
+func TestWebhookHTTPRoutesCustomTokenHeader(t *testing.T) {
+	store := newWebhookRouteStore()
+	app := echo.New()
+	RegisterRoutes(app, RouteOptions{Store: store, WebhookBodyLimit: 1 << 20, NewEventID: func() string { return "event-custom" }})
+
+	req := httptest.NewRequest(http.MethodPut, "/api/webhook-sources/github", strings.NewReader(`{"name":"GitHub","enabled":true,"provider":"github","topic_prefix":"webhook.github.","token":"custom-token","token_header":"X-GitHub-Token"}`))
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT source status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", strings.NewReader(`{"intent":"push"}`))
+	req.Header.Set("X-GitHub-Token", "custom-token")
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook with custom token header status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	for _, header := range []string{"Authorization", "X-WEBHOOK-TOKEN"} {
+		req = httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", strings.NewReader(`{"intent":"push"}`))
+		req.Header.Set(header, "custom-token")
+		if header == "Authorization" {
+			req.Header.Set(header, "Bearer custom-token")
+		}
+		req.Header.Set("Content-Type", "application/json")
+		rec = httptest.NewRecorder()
+		app.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("webhook with legacy header %s status=%d body=%s", header, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestWebhookHTTPRoutesLegacyTokenHeaderFallbacks(t *testing.T) {
+	for _, header := range []string{"Authorization", "X-WEBHOOK-TOKEN"} {
+		store := newWebhookRouteStore()
+		app := echo.New()
+		RegisterRoutes(app, RouteOptions{Store: store, WebhookBodyLimit: 1 << 20, NewEventID: func() string { return "event-legacy-" + header }})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", strings.NewReader(`{"intent":"push"}`))
+		req.Header.Set(header, "token")
+		if header == "Authorization" {
+			req.Header.Set(header, "Bearer token")
+		}
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		app.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("webhook with legacy header %s status=%d body=%s", header, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestWebhookHTTPRoutesRejectInvalidTokenHeader(t *testing.T) {
+	store := newWebhookRouteStore()
+	app := echo.New()
+	RegisterRoutes(app, RouteOptions{Store: store, WebhookBodyLimit: 1 << 20})
+
+	req := httptest.NewRequest(http.MethodPut, "/api/webhook-sources/github", strings.NewReader(`{"name":"GitHub","enabled":true,"provider":"github","topic_prefix":"webhook.github.","token":"custom-token","token_header":"Bad Header"}`))
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT source with invalid token header status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestIntegrationWebhookHTTPRoutesCoverageWorkflow(t *testing.T) {
 	TestWebhookHTTPRoutesCoverageWorkflow(t)
 }
@@ -260,6 +329,11 @@ func (s *webhookRouteStore) GetWebhookSource(_ context.Context, sourceID string)
 }
 
 func (s *webhookRouteStore) UpsertWebhookSource(_ context.Context, source domain.WebhookSource) (domain.WebhookSource, error) {
+	tokenHeader, err := domain.NormalizeHTTPHeaderName(source.TokenHeader)
+	if err != nil {
+		return domain.WebhookSource{}, err
+	}
+	source.TokenHeader = tokenHeader
 	s.sources[source.ID] = source
 	return source, nil
 }

--- a/pkg/events/webhooks/dto.go
+++ b/pkg/events/webhooks/dto.go
@@ -52,17 +52,18 @@ type EventSessionJSON struct {
 }
 
 type SourceRequest struct {
-	Name            string `json:"name"`
-	Enabled         *bool  `json:"enabled,omitempty"`
-	Provider        string `json:"provider"`
-	TopicPrefix     string `json:"topic_prefix"`
-	Token           string `json:"token"`
-	TokenHash       string `json:"token_hash"`
-	ClearToken      bool   `json:"clear_token"`
-	SignatureType   string `json:"signature_type"`
-	SignatureSecret string `json:"signature_secret"`
-	ClearSignature  bool   `json:"clear_signature"`
-	BodyLimitBytes  int64  `json:"body_limit_bytes"`
+	Name            string  `json:"name"`
+	Enabled         *bool   `json:"enabled,omitempty"`
+	Provider        string  `json:"provider"`
+	TopicPrefix     string  `json:"topic_prefix"`
+	Token           string  `json:"token"`
+	TokenHash       string  `json:"token_hash"`
+	TokenHeader     *string `json:"token_header,omitempty"`
+	ClearToken      bool    `json:"clear_token"`
+	SignatureType   string  `json:"signature_type"`
+	SignatureSecret string  `json:"signature_secret"`
+	ClearSignature  bool    `json:"clear_signature"`
+	BodyLimitBytes  int64   `json:"body_limit_bytes"`
 }
 
 type SourceJSON struct {
@@ -72,6 +73,7 @@ type SourceJSON struct {
 	Provider           string `json:"provider"`
 	TopicPrefix        string `json:"topic_prefix"`
 	HasToken           bool   `json:"has_token"`
+	TokenHeader        string `json:"token_header,omitempty"`
 	SignatureType      string `json:"signature_type,omitempty"`
 	HasSignatureSecret bool   `json:"has_signature_secret"`
 	BodyLimitBytes     int64  `json:"body_limit_bytes,omitempty"`

--- a/pkg/events/webhooks/helpers.go
+++ b/pkg/events/webhooks/helpers.go
@@ -15,7 +15,19 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
-func PresentedToken(r *http.Request) string {
+func PresentedToken(r *http.Request, tokenHeader ...string) string {
+	headerName := ""
+	if len(tokenHeader) > 0 {
+		headerName = strings.TrimSpace(tokenHeader[0])
+	}
+	if headerName != "" {
+		presented := strings.TrimSpace(r.Header.Get(headerName))
+		if strings.EqualFold(headerName, "Authorization") && strings.HasPrefix(strings.ToLower(presented), "bearer ") {
+			return strings.TrimSpace(presented[len("bearer "):])
+		}
+		return presented
+	}
+
 	presented := ""
 	if auth := strings.TrimSpace(r.Header.Get("Authorization")); strings.HasPrefix(strings.ToLower(auth), "bearer ") {
 		presented = strings.TrimSpace(auth[len("bearer "):])
@@ -31,9 +43,9 @@ func TokenHash(token string) string {
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
-func ValidTokenHash(r *http.Request, hash string) bool {
+func ValidTokenHash(r *http.Request, hash string, tokenHeader ...string) bool {
 	hash = strings.TrimSpace(hash)
-	token := PresentedToken(r)
+	token := PresentedToken(r, tokenHeader...)
 	if hash == "" || token == "" {
 		return false
 	}

--- a/pkg/events/webhooks/http.go
+++ b/pkg/events/webhooks/http.go
@@ -289,10 +289,17 @@ func (h routeHandler) handlePutWebhookSource(c echo.Context) error {
 		enabled = *req.Enabled
 	}
 	tokenHash := strings.TrimSpace(req.TokenHash)
+	tokenHeader := ""
+	if req.TokenHeader != nil {
+		tokenHeader = strings.TrimSpace(*req.TokenHeader)
+	}
 	if existing, ok, err := h.store().GetWebhookSource(c.Request().Context(), sourceID); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load webhook source"})
 	} else if ok {
 		tokenHash = existing.TokenHash
+		if req.TokenHeader == nil {
+			tokenHeader = existing.TokenHeader
+		}
 		if strings.TrimSpace(req.SignatureType) == "" {
 			req.SignatureType = existing.SignatureType
 		}
@@ -316,6 +323,7 @@ func (h routeHandler) handlePutWebhookSource(c echo.Context) error {
 		Provider:        req.Provider,
 		TopicPrefix:     req.TopicPrefix,
 		TokenHash:       tokenHash,
+		TokenHeader:     tokenHeader,
 		SignatureType:   req.SignatureType,
 		SignatureSecret: req.SignatureSecret,
 		BodyLimitBytes:  req.BodyLimitBytes,
@@ -350,7 +358,7 @@ func (h routeHandler) authorizeWebhookRequest(c echo.Context, topic string) (dom
 	}
 	matches := make([]domain.WebhookSource, 0, 1)
 	for _, source := range sources {
-		if source.TokenHash != "" && ValidTokenHash(c.Request(), source.TokenHash) {
+		if source.TokenHash != "" && ValidTokenHash(c.Request(), source.TokenHash, source.TokenHeader) {
 			matches = append(matches, source)
 		}
 	}

--- a/pkg/events/webhooks/response.go
+++ b/pkg/events/webhooks/response.go
@@ -16,6 +16,7 @@ func SourceToJSON(source domain.WebhookSource) SourceJSON {
 		Provider:           source.Provider,
 		TopicPrefix:        source.TopicPrefix,
 		HasToken:           strings.TrimSpace(source.TokenHash) != "",
+		TokenHeader:        source.TokenHeader,
 		SignatureType:      source.SignatureType,
 		HasSignatureSecret: strings.TrimSpace(source.SignatureSecret) != "",
 		BodyLimitBytes:     source.BodyLimitBytes,

--- a/pkg/model/topic_event_model.go
+++ b/pkg/model/topic_event_model.go
@@ -29,6 +29,7 @@ const (
 )
 
 var topicEventNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+var httpHeaderNamePattern = regexp.MustCompile("^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
 
 type TopicEventRecord struct {
 	ID              string    `json:"event_id"`
@@ -74,6 +75,7 @@ type WebhookSource struct {
 	Provider        string    `json:"provider"`
 	TopicPrefix     string    `json:"topic_prefix"`
 	TokenHash       string    `json:"token_hash,omitempty"`
+	TokenHeader     string    `json:"token_header,omitempty"`
 	SignatureType   string    `json:"signature_type,omitempty"`
 	SignatureSecret string    `json:"signature_secret,omitempty"`
 	BodyLimitBytes  int64     `json:"body_limit_bytes,omitempty"`
@@ -126,6 +128,17 @@ func ValidateTopicEventName(topic string) error {
 		return fmt.Errorf("topic contains invalid characters")
 	}
 	return nil
+}
+
+func NormalizeHTTPHeaderName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", nil
+	}
+	if !httpHeaderNamePattern.MatchString(name) {
+		return "", fmt.Errorf("header name contains invalid characters")
+	}
+	return name, nil
 }
 
 func NormalizeTopicEventSource(source string) string {

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -453,12 +453,12 @@ func testConfigStoreTopicEventCoverageWorkflows(t *testing.T) {
 
 	webhook, err := store.UpsertWebhookSource(ctx, domain.WebhookSource{
 		ID: "github", Name: "GitHub", Enabled: true, Provider: "github", TopicPrefix: "webhook.github.",
-		TokenHash: "hash", SignatureType: "hmac-sha256", SignatureSecret: "secret", BodyLimitBytes: 1024,
+		TokenHash: "hash", TokenHeader: "x-github-token", SignatureType: "hmac-sha256", SignatureSecret: "secret", BodyLimitBytes: 1024,
 	})
 	if err != nil {
 		t.Fatalf("UpsertWebhookSource returned error: %v", err)
 	}
-	if webhook.Name != "GitHub" {
+	if webhook.Name != "GitHub" || webhook.TokenHeader != "x-github-token" {
 		t.Fatalf("webhook source = %#v", webhook)
 	}
 	if !WebhookSourceTopicMatches("webhook.github.push", "webhook.github.") || WebhookSourceTopicMatches("", "webhook.github.") {
@@ -470,8 +470,11 @@ func testConfigStoreTopicEventCoverageWorkflows(t *testing.T) {
 	if sources, err := store.ListWebhookSources(ctx); err != nil || len(sources) != 1 {
 		t.Fatalf("ListWebhookSources sources=%#v err=%v", sources, err)
 	}
-	if got, found, err := store.GetWebhookSource(ctx, webhook.ID); err != nil || !found || got.ID != webhook.ID {
+	if got, found, err := store.GetWebhookSource(ctx, webhook.ID); err != nil || !found || got.ID != webhook.ID || got.TokenHeader != "x-github-token" {
 		t.Fatalf("GetWebhookSource got=%#v found=%v err=%v", got, found, err)
+	}
+	if _, err := store.UpsertWebhookSource(ctx, domain.WebhookSource{ID: "bad", TopicPrefix: "webhook.bad.", TokenHeader: "Bad Header"}); err == nil {
+		t.Fatalf("UpsertWebhookSource with invalid token header returned nil error")
 	}
 	if err := store.DeleteWebhookSource(ctx, webhook.ID); err != nil {
 		t.Fatalf("DeleteWebhookSource returned error: %v", err)

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -52,6 +52,7 @@ func (s *eventStore) ensureEventSchema(ctx context.Context) error {
 			provider TEXT NOT NULL DEFAULT '',
 			topic_prefix TEXT NOT NULL,
 			token_hash TEXT NOT NULL DEFAULT '',
+			token_header TEXT NOT NULL DEFAULT '',
 			signature_type TEXT NOT NULL DEFAULT '',
 			signature_secret TEXT NOT NULL DEFAULT '',
 			body_limit_bytes INTEGER NOT NULL DEFAULT 0,
@@ -102,6 +103,13 @@ func (s *eventStore) ensureEventSchema(ctx context.Context) error {
 	} {
 		if err := ensureColumn(ctx, s.db, "event", column, definition); err != nil {
 			return fmt.Errorf("ensure event %s column: %w", column, err)
+		}
+	}
+	for column, definition := range map[string]string{
+		"token_header": "TEXT NOT NULL DEFAULT ''",
+	} {
+		if err := ensureColumn(ctx, s.db, "webhook_source", column, definition); err != nil {
+			return fmt.Errorf("ensure webhook source %s column: %w", column, err)
 		}
 	}
 	indexStatements := []string{
@@ -644,7 +652,7 @@ func (s *eventStore) ListEnabledWebhookSourcesForTopic(ctx context.Context, topi
 	if topic == "" {
 		return nil, fmt.Errorf("topic is required")
 	}
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, token_header, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
 		FROM webhook_source WHERE enabled = 1 ORDER BY length(topic_prefix) DESC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query webhook sources: %w", err)
@@ -656,7 +664,7 @@ func (s *eventStore) ListEnabledWebhookSourcesForTopic(ctx context.Context, topi
 		var enabled int
 		var createdAtRaw int64
 		var updatedAtRaw int64
-		if err := rows.Scan(&item.ID, &item.Name, &enabled, &item.Provider, &item.TopicPrefix, &item.TokenHash, &item.SignatureType, &item.SignatureSecret, &item.BodyLimitBytes, &createdAtRaw, &updatedAtRaw); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &enabled, &item.Provider, &item.TopicPrefix, &item.TokenHash, &item.TokenHeader, &item.SignatureType, &item.SignatureSecret, &item.BodyLimitBytes, &createdAtRaw, &updatedAtRaw); err != nil {
 			return nil, fmt.Errorf("scan webhook source: %w", err)
 		}
 		item.Enabled = enabled != 0
@@ -689,7 +697,7 @@ func WebhookSourceTopicMatches(topic, topicPrefix string) bool {
 }
 
 func (s *eventStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSource, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, token_header, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
 		FROM webhook_source ORDER BY id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("query webhook sources: %w", err)
@@ -701,7 +709,7 @@ func (s *eventStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSo
 		var enabled int
 		var createdAtRaw int64
 		var updatedAtRaw int64
-		if err := rows.Scan(&item.ID, &item.Name, &enabled, &item.Provider, &item.TopicPrefix, &item.TokenHash, &item.SignatureType, &item.SignatureSecret, &item.BodyLimitBytes, &createdAtRaw, &updatedAtRaw); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &enabled, &item.Provider, &item.TopicPrefix, &item.TokenHash, &item.TokenHeader, &item.SignatureType, &item.SignatureSecret, &item.BodyLimitBytes, &createdAtRaw, &updatedAtRaw); err != nil {
 			return nil, fmt.Errorf("scan webhook source: %w", err)
 		}
 		item.Enabled = enabled != 0
@@ -720,13 +728,13 @@ func (s *eventStore) GetWebhookSource(ctx context.Context, sourceID string) (dom
 	if sourceID == "" {
 		return domain.WebhookSource{}, false, fmt.Errorf("webhook source id is required")
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, token_header, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
 		FROM webhook_source WHERE id = ?`, sourceID)
 	var item domain.WebhookSource
 	var enabled int
 	var createdAtRaw int64
 	var updatedAtRaw int64
-	if err := row.Scan(&item.ID, &item.Name, &enabled, &item.Provider, &item.TopicPrefix, &item.TokenHash, &item.SignatureType, &item.SignatureSecret, &item.BodyLimitBytes, &createdAtRaw, &updatedAtRaw); err != nil {
+	if err := row.Scan(&item.ID, &item.Name, &enabled, &item.Provider, &item.TopicPrefix, &item.TokenHash, &item.TokenHeader, &item.SignatureType, &item.SignatureSecret, &item.BodyLimitBytes, &createdAtRaw, &updatedAtRaw); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return domain.WebhookSource{}, false, nil
 		}
@@ -744,6 +752,11 @@ func (s *eventStore) UpsertWebhookSource(ctx context.Context, source domain.Webh
 	source.Provider = strings.TrimSpace(source.Provider)
 	source.TopicPrefix = strings.TrimSpace(source.TopicPrefix)
 	source.TokenHash = strings.TrimSpace(source.TokenHash)
+	tokenHeader, err := domain.NormalizeHTTPHeaderName(source.TokenHeader)
+	if err != nil {
+		return domain.WebhookSource{}, fmt.Errorf("webhook source token header is invalid: %w", err)
+	}
+	source.TokenHeader = tokenHeader
 	source.SignatureType = strings.TrimSpace(source.SignatureType)
 	source.SignatureSecret = strings.TrimSpace(source.SignatureSecret)
 	if source.ID == "" || source.TopicPrefix == "" {
@@ -770,10 +783,10 @@ func (s *eventStore) UpsertWebhookSource(ctx context.Context, source domain.Webh
 	if source.Enabled {
 		enabled = 1
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO webhook_source(id, name, enabled, provider, topic_prefix, token_hash, signature_type, signature_secret, body_limit_bytes, created_at, updated_at)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	_, err = s.db.ExecContext(ctx, `INSERT INTO webhook_source(id, name, enabled, provider, topic_prefix, token_hash, token_header, signature_type, signature_secret, body_limit_bytes, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET name = excluded.name, enabled = excluded.enabled, provider = excluded.provider, topic_prefix = excluded.topic_prefix,
-			token_hash = excluded.token_hash, signature_type = excluded.signature_type, signature_secret = excluded.signature_secret,
+			token_hash = excluded.token_hash, token_header = excluded.token_header, signature_type = excluded.signature_type, signature_secret = excluded.signature_secret,
 			body_limit_bytes = excluded.body_limit_bytes, updated_at = excluded.updated_at`,
 		source.ID,
 		source.Name,
@@ -781,6 +794,7 @@ func (s *eventStore) UpsertWebhookSource(ctx context.Context, source domain.Webh
 		source.Provider,
 		source.TopicPrefix,
 		source.TokenHash,
+		source.TokenHeader,
 		source.SignatureType,
 		source.SignatureSecret,
 		source.BodyLimitBytes,


### PR DESCRIPTION
## Summary
- add per-webhook-source token_header configuration for token auth
- keep existing Authorization Bearer and X-WEBHOOK-TOKEN fallback behavior when token_header is unset
- persist token_header in configstore with migration and validation

Fixes #152

## Tests
- git diff --check
- task lint
- env -u LLM_API_KEY -u OPENAI_API_KEY -u LLM_API_ENDPOINT -u LLM_MODEL -u LLM_API_PROTOCOL -u ANTHROPIC_BASE_URL -u ANTHROPIC_API_ENDPOINT -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_MODEL -u CLAUDE_MODEL task test
  - Unit: 79.23%
  - Integration: 71.48%
  - E2E: 69.36%
  - Combined: 81.82%
- task build

Note: running task test with the ambient shell environment failed in pkg/llms because LLM_API_KEY was set externally; rerunning with LLM-related environment variables unset passed.