### PR TITLE
Improve status command text output

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -104,9 +104,13 @@ func NewEcho(di do.Injector) (*echo.Echo, error) {
 	conf := do.MustInvoke[*config.Config](di)
 
 	e.GET("/api/version", func(c echo.Context) error {
+		now := time.Now()
+		timezone, timezoneOffset := now.Zone()
 		return c.JSON(http.StatusOK, restful.NewResponse[map[string]any, restful.StrStatusResp[map[string]any]](nil, codes.OK.String(), map[string]any{
-			"version":   conf.Version,
-			"timestamp": float64(time.Now().UnixNano()) / 1e9,
+			"version":         conf.Version,
+			"timestamp":       float64(now.UnixNano()) / 1e9,
+			"timezone":        timezone,
+			"timezone_offset": timezoneOffset,
 		}))
 	})
 	e.GET("/api/null", echofn.EchoWrap(restful.NullHandler[restful.StrStatusResp[any]]))
@@ -427,8 +431,11 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 			if err != nil {
 				return err
 			}
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), string(body))
-			return err
+			if options.JSON {
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+				return err
+			}
+			return writeDaemonStatusText(cmd.OutOrStdout(), body)
 		},
 	}
 
@@ -6797,6 +6804,61 @@ func fetchDaemonVersion(ctx context.Context, clientConfig cliClientConfig) ([]by
 		return nil, fmt.Errorf("daemon via %s %q returned HTTP %d: %s", clientConfig.Source, clientConfig.SourceValue, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return body, nil
+}
+
+type daemonStatusResponse struct {
+	Err  json.RawMessage `json:"err"`
+	Msg  string          `json:"msg"`
+	Data struct {
+		Timestamp      float64 `json:"timestamp"`
+		Timezone       string  `json:"timezone"`
+		TimezoneOffset *int    `json:"timezone_offset"`
+		Version        string  `json:"version"`
+	} `json:"data"`
+}
+
+func writeDaemonStatusText(out io.Writer, body []byte) error {
+	var response daemonStatusResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("decode daemon status response: %w", err)
+	}
+
+	status := strings.TrimSpace(response.Msg)
+	if status == "" {
+		status = "unknown"
+	}
+	if len(response.Err) > 0 && string(response.Err) != "null" {
+		status = "error"
+	}
+	uptime := "-"
+	if response.Data.Timestamp > 0 {
+		uptime = formatDaemonStatusTime(response.Data.Timestamp, response.Data.Timezone, response.Data.TimezoneOffset)
+	}
+	version := strings.TrimSpace(response.Data.Version)
+	if version == "" {
+		version = "-"
+	}
+
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "STATUS\tUPTIME\tVERSION"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", status, uptime, version); err != nil {
+		return err
+	}
+	return tw.Flush()
+}
+
+func formatDaemonStatusTime(timestamp float64, timezone string, timezoneOffset *int) string {
+	location := time.UTC
+	if timezoneOffset != nil {
+		name := strings.TrimSpace(timezone)
+		if name == "" {
+			name = "UTC"
+		}
+		location = time.FixedZone(name, *timezoneOffset)
+	}
+	return time.Unix(0, int64(timestamp*float64(time.Second))).In(location).Format("2006-01-02 15:04:05 MST -0700")
 }
 
 func newDaemonHTTPClient(clientConfig cliClientConfig) *http.Client {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -382,7 +382,7 @@ func testStatusCommandUsesHostFlagBeforeEnvironment(t *testing.T) {
 		if r.URL.Path != "/api/version" {
 			t.Fatalf("request path = %q, want /api/version", r.URL.Path)
 		}
-		_, _ = io.WriteString(w, `{"version":"flag"}`)
+		_, _ = io.WriteString(w, `{"err":null,"msg":"OK","data":{"timestamp":1783501631.2438176,"timezone":"CST","timezone_offset":28800,"version":"flag"}}`)
 	}))
 	defer server.Close()
 	t.Setenv("AGENT_COMPOSE_HOST", "http://127.0.0.1:1")
@@ -391,11 +391,40 @@ func testStatusCommandUsesHostFlagBeforeEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status command returned error: %v", err)
 	}
-	if !strings.Contains(stdout, `"version":"flag"`) {
-		t.Fatalf("status stdout = %q, want flag response", stdout)
+	for _, want := range []string{"STATUS", "UPTIME", "VERSION", "OK", "2026-07-08 17:07:11 CST +0800", "flag"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("status stdout = %q, want %q", stdout, want)
+		}
+	}
+	if strings.Contains(stdout, `"version"`) {
+		t.Fatalf("status stdout = %q, want text output", stdout)
 	}
 	if stderr != "" {
 		t.Fatalf("status stderr = %q, want empty", stderr)
+	}
+	if runCount != 0 {
+		t.Fatalf("daemon runner called %d times, want 0", runCount)
+	}
+}
+
+func TestStatusCommandJSONPrintsRawDaemonResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/version" {
+			t.Fatalf("request path = %q, want /api/version", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"err":null,"msg":"OK","data":{"timestamp":1783501631.2438176,"version":"json"}}`)
+	}))
+	defer server.Close()
+
+	stdout, stderr, runCount, err := executeCommand("status", "--json", "--host", server.URL)
+	if err != nil {
+		t.Fatalf("status --json command returned error: %v", err)
+	}
+	if strings.TrimSpace(stdout) != `{"err":null,"msg":"OK","data":{"timestamp":1783501631.2438176,"version":"json"}}` {
+		t.Fatalf("status --json stdout = %q, want raw daemon response", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("status --json stderr = %q, want empty", stderr)
 	}
 	if runCount != 0 {
 		t.Fatalf("daemon runner called %d times, want 0", runCount)
@@ -410,7 +439,7 @@ func TestStatusCommandUsesRemoteAuthFromEnvironment(t *testing.T) {
 		if !ok || username != "reviewer" || password != "secret" {
 			t.Fatalf("BasicAuth = %q/%q/%v", username, password, ok)
 		}
-		_, _ = w.Write([]byte(`{"version":"test"}`))
+		_, _ = w.Write([]byte(`{"err":null,"msg":"OK","data":{"timestamp":1783501631.2438176,"timezone":"CST","timezone_offset":28800,"version":"test"}}`))
 	}))
 	defer server.Close()
 
@@ -418,8 +447,10 @@ func TestStatusCommandUsesRemoteAuthFromEnvironment(t *testing.T) {
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("status auth code/stderr = %d / %q", exitCode, stderr)
 	}
-	if !strings.Contains(stdout, `"version":"test"`) {
-		t.Fatalf("status auth stdout = %q", stdout)
+	for _, want := range []string{"STATUS", "UPTIME", "VERSION", "OK", "2026-07-08 17:07:11 CST +0800", "test"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("status auth stdout = %q, want %q", stdout, want)
+		}
 	}
 	if runCount != 0 {
 		t.Fatalf("daemon runner called %d times, want 0", runCount)
@@ -436,7 +467,7 @@ func testStatusCommandUsesEnvironmentHost(t *testing.T) {
 		if r.URL.Path != "/api/version" {
 			t.Fatalf("request path = %q, want /api/version", r.URL.Path)
 		}
-		_, _ = io.WriteString(w, `{"version":"env"}`)
+		_, _ = io.WriteString(w, `{"err":null,"msg":"OK","data":{"timestamp":1783501631.2438176,"timezone":"CST","timezone_offset":28800,"version":"env"}}`)
 	}))
 	defer server.Close()
 	t.Setenv("AGENT_COMPOSE_HOST", server.URL)
@@ -445,8 +476,10 @@ func testStatusCommandUsesEnvironmentHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status command returned error: %v", err)
 	}
-	if !strings.Contains(stdout, `"version":"env"`) {
-		t.Fatalf("status stdout = %q, want env response", stdout)
+	for _, want := range []string{"STATUS", "UPTIME", "VERSION", "OK", "2026-07-08 17:07:11 CST +0800", "env"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("status stdout = %q, want %q", stdout, want)
+		}
 	}
 	if runCount != 0 {
 		t.Fatalf("daemon runner called %d times, want 0", runCount)
@@ -477,14 +510,26 @@ func testStatusCommandUsesDefaultUnixSocket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status command returned error: %v", err)
 	}
-	if !strings.Contains(stdout, `"version"`) {
-		t.Fatalf("status stdout = %q, want daemon version response", stdout)
+	for _, want := range []string{"STATUS", "UPTIME", "VERSION", "OK", config.BuildVersion} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("status stdout = %q, want %q", stdout, want)
+		}
 	}
 	if stderr != "" {
 		t.Fatalf("status stderr = %q, want empty", stderr)
 	}
 	if runCount != 0 {
 		t.Fatalf("daemon runner called %d times, want 0", runCount)
+	}
+}
+
+func TestFormatDaemonStatusTime(t *testing.T) {
+	offset := 8 * 60 * 60
+	if got := formatDaemonStatusTime(1783501631.2438176, "CST", &offset); got != "2026-07-08 17:07:11 CST +0800" {
+		t.Fatalf("formatDaemonStatusTime() = %q, want server timezone time", got)
+	}
+	if got := formatDaemonStatusTime(1783501631.2438176, "", nil); got != "2026-07-08 09:07:11 UTC +0000" {
+		t.Fatalf("formatDaemonStatusTime() = %q, want legacy UTC fallback time", got)
 	}
 }
 
@@ -6924,6 +6969,18 @@ func testNewDaemonAppBuildsHandlerWithoutListening(t *testing.T) {
 	app.Echo.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("/api/version status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var decoded struct {
+		Data struct {
+			Timezone       string `json:"timezone"`
+			TimezoneOffset *int   `json:"timezone_offset"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("/api/version JSON decode failed: %v", err)
+	}
+	if decoded.Data.Timezone == "" || decoded.Data.TimezoneOffset == nil {
+		t.Fatalf("/api/version timezone fields = %q/%v, want server timezone", decoded.Data.Timezone, decoded.Data.TimezoneOffset)
 	}
 }
 

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -532,6 +532,24 @@ Compatibility:
 - `agent-compose image inspect <image>` is deprecated; use `agent-compose inspect image <image>`.
 - The old `image` command tree still works and prints warnings to stderr, but it may be removed in a future release.
 
+## `status`: Query Daemon Status
+
+Check the selected daemon status and version.
+
+```bash
+agent-compose status
+agent-compose --host http://127.0.0.1:7410 status
+agent-compose status --json
+```
+
+Default columns:
+
+- `STATUS`: daemon response status.
+- `UPTIME`: daemon-reported timestamp rendered in the daemon timezone when available.
+- `VERSION`: daemon build version.
+
+Use `--json` to print the raw daemon status response for automation.
+
 ## Other Commands
 
 ```bash

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -545,6 +545,24 @@ agent-compose cache rm <cache-id> --force
 - `agent-compose image inspect <image>` 已废弃，请使用 `agent-compose inspect image <image>`。
 - 旧 `image` 命令树仍可用，但会在 stderr 输出 deprecated warning，后续版本会评估删除。
 
+## `status`：检查 daemon 状态
+
+检查当前选择的 daemon 状态和版本。
+
+```bash
+agent-compose status
+agent-compose --host http://127.0.0.1:7410 status
+agent-compose status --json
+```
+
+默认输出字段：
+
+- `STATUS`：daemon 响应状态。
+- `UPTIME`：daemon 返回的时间戳；如果 daemon 返回了时区信息，则按 daemon 时区展示。
+- `VERSION`：daemon 构建版本。
+
+自动化场景使用 `--json` 输出 daemon 原始 status 响应。
+
 ## 其他命令
 
 ```bash


### PR DESCRIPTION
## Summary

  - Change `agent-compose status` default output from raw JSON to a human-readable table with `STATUS`, `UPTIME`, and `VERSION`.
  - Keep raw daemon response output behind `--json` for automation.
  - Add daemon timezone metadata to `/api/version` so status timestamps render in the daemon timezone when available, with UTC fallback for older daemons.
  - Document the updated `status` output in English and Chinese CLI manuals.

  ## Testing

  - `go test ./cmd/agent-compose -run 'TestStatusCommand|TestFormatDaemonStatusTime|TestNewDaemonAppBuildsHandlerWithoutListening|TestIntegrationCLIStatus|
  TestDaemonApp'`
  - `go test ./cmd/agent-compose`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.