### PR TITLE
fix cli logs sandbox lookup

### DIFF
--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -512,7 +512,7 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 	out.Reset()
 	logsCmd.SetErr(&out)
 	logOptions, err := normalizeComposeLogsOptions(logsCmd, composeLogsOptions{SandboxID: "sandbox-logs", TailLines: -1}, nil)
-	if err != nil || logOptions.SessionID != "sandbox-logs" || out.String() != "" {
+	if err != nil || logOptions.SandboxID != "sandbox-logs" || logOptions.SessionID != "" || out.String() != "" {
 		t.Fatalf("normalizeComposeLogsOptions options=%#v err=%v stderr=%q", logOptions, err, out.String())
 	}
 	if _, err := normalizeComposeLogsOptions(&cobra.Command{Use: "logs"}, composeLogsOptions{TailLines: -2}, nil); commandExitCode(err) != exitCodeUsage {

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -4633,7 +4633,7 @@ func listProjectRuns(ctx context.Context, client agentcomposev2connect.RunServic
 func latestRunsBySession(runs []*agentcomposev2.RunSummary) map[string]*agentcomposev2.RunSummary {
 	result := map[string]*agentcomposev2.RunSummary{}
 	for _, run := range runs {
-		sessionID := runSummarySandboxID(run)
+		sessionID := strings.TrimSpace(run.GetSessionId())
 		if sessionID == "" {
 			continue
 		}
@@ -4721,7 +4721,7 @@ func firstRunningSessionOutput(ctx context.Context, clients cliServiceClients, p
 	}
 	seen := map[string]struct{}{}
 	for _, run := range resp.Msg.GetRuns() {
-		sessionID := runSummarySandboxID(run)
+		sessionID := strings.TrimSpace(run.GetSessionId())
 		if sessionID == "" {
 			continue
 		}

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -2643,9 +2643,6 @@ func normalizeComposeLogsOptions(cmd *cobra.Command, options composeLogsOptions,
 		}
 		options.AgentName = args[0]
 	}
-	if strings.TrimSpace(options.SandboxID) != "" {
-		options.SessionID = options.SandboxID
-	}
 	if options.TailLines < -1 {
 		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("logs --tail must be -1 or greater")}
 	}
@@ -2667,8 +2664,8 @@ func resolveComposeLogRefs(ctx context.Context, client agentcomposev2connect.Run
 		}
 		options.RunID = runID
 	}
-	if shouldResolveComposeLogResourceRef(options.SessionID) {
-		sandboxID, err := resolveComposeSandboxIDRefFromRuns(ctx, client, projectID, options.AgentName, options.SessionID)
+	if shouldResolveComposeLogResourceRef(options.SandboxID) {
+		sandboxID, err := resolveComposeSandboxIDRefFromRuns(ctx, client, projectID, options.AgentName, options.SandboxID)
 		if err != nil {
 			return options, err
 		}
@@ -4636,7 +4633,7 @@ func listProjectRuns(ctx context.Context, client agentcomposev2connect.RunServic
 func latestRunsBySession(runs []*agentcomposev2.RunSummary) map[string]*agentcomposev2.RunSummary {
 	result := map[string]*agentcomposev2.RunSummary{}
 	for _, run := range runs {
-		sessionID := strings.TrimSpace(run.GetSessionId())
+		sessionID := runSummarySandboxID(run)
 		if sessionID == "" {
 			continue
 		}
@@ -4649,6 +4646,13 @@ func latestRunsBySession(runs []*agentcomposev2.RunSummary) map[string]*agentcom
 
 func runSortTime(run *agentcomposev2.RunSummary) string {
 	return firstNonEmptyString(run.GetUpdatedAt(), run.GetCreatedAt(), run.GetStartedAt(), run.GetCompletedAt())
+}
+
+func runSummarySandboxID(run *agentcomposev2.RunSummary) string {
+	if run == nil {
+		return ""
+	}
+	return firstNonEmptyString(strings.TrimSpace(run.GetSandboxId()), strings.TrimSpace(run.GetSessionId()))
 }
 
 func composePSSessionBelongsToProject(session *agentcomposev1.SessionSummary, project *agentcomposev2.Project, runsBySession map[string]*agentcomposev2.RunSummary) bool {
@@ -4717,7 +4721,7 @@ func firstRunningSessionOutput(ctx context.Context, clients cliServiceClients, p
 	}
 	seen := map[string]struct{}{}
 	for _, run := range resp.Msg.GetRuns() {
-		sessionID := strings.TrimSpace(run.GetSessionId())
+		sessionID := runSummarySandboxID(run)
 		if sessionID == "" {
 			continue
 		}
@@ -4976,6 +4980,7 @@ func composeRunOutputFromDetail(run *agentcomposev2.RunDetail) composeRunOutput 
 }
 
 func composeRunOutputFromSummary(run *agentcomposev2.RunSummary, projectName, logsCommand string) composeRunOutput {
+	sandboxID := runSummarySandboxID(run)
 	return composeRunOutput{
 		ID:             displayOpaqueID(run.GetRunId()),
 		ShortID:        shortOpaqueID(run.GetRunId()),
@@ -4984,8 +4989,8 @@ func composeRunOutputFromSummary(run *agentcomposev2.RunSummary, projectName, lo
 		AgentName:      run.GetAgentName(),
 		Source:         runSourceText(run.GetSource()),
 		Status:         runStatusText(run.GetStatus()),
-		SandboxID:      displayOpaqueID(run.GetSessionId()),
-		SandboxShortID: shortOpaqueID(run.GetSessionId()),
+		SandboxID:      displayOpaqueID(sandboxID),
+		SandboxShortID: shortOpaqueID(sandboxID),
 		ExitCode:       run.GetExitCode(),
 		Error:          run.GetError(),
 		StartedAt:      run.GetStartedAt(),
@@ -4998,6 +5003,7 @@ func composeRunOutputFromSummary(run *agentcomposev2.RunSummary, projectName, lo
 
 func composeRunOutputFromDetailWithOptions(run *agentcomposev2.RunDetail, options composeLogsOptions) composeRunOutput {
 	summary := run.GetSummary()
+	sandboxID := runSummarySandboxID(summary)
 	return composeRunOutput{
 		ID:             displayOpaqueID(summary.GetRunId()),
 		ShortID:        shortOpaqueID(summary.GetRunId()),
@@ -5006,8 +5012,8 @@ func composeRunOutputFromDetailWithOptions(run *agentcomposev2.RunDetail, option
 		AgentName:      summary.GetAgentName(),
 		Source:         runSourceText(summary.GetSource()),
 		Status:         runStatusText(summary.GetStatus()),
-		SandboxID:      displayOpaqueID(summary.GetSessionId()),
-		SandboxShortID: shortOpaqueID(summary.GetSessionId()),
+		SandboxID:      displayOpaqueID(sandboxID),
+		SandboxShortID: shortOpaqueID(sandboxID),
 		ExitCode:       summary.GetExitCode(),
 		Error:          summary.GetError(),
 		StartedAt:      summary.GetStartedAt(),
@@ -5876,7 +5882,7 @@ func listLogRuns(ctx context.Context, client agentcomposev2connect.RunServiceCli
 	resp, err := client.ListRuns(ctx, connect.NewRequest(&agentcomposev2.ListRunsRequest{
 		ProjectId: projectID,
 		AgentName: strings.TrimSpace(options.AgentName),
-		SessionId: strings.TrimSpace(options.SessionID),
+		SandboxId: strings.TrimSpace(options.SandboxID),
 		Limit:     20,
 	}))
 	if err != nil {
@@ -6033,7 +6039,7 @@ func resolveComposeSandboxIDRefFromRuns(ctx context.Context, client agentcompose
 	}
 	matches := map[string]struct{}{}
 	for _, run := range runs {
-		sandboxID := strings.TrimSpace(run.GetSessionId())
+		sandboxID := runSummarySandboxID(run)
 		if sandboxID == "" {
 			continue
 		}

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -2538,12 +2538,12 @@ agents:
 		listRuns: func(ctx context.Context, req *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
 			switch req.Msg.GetLimit() {
 			case 200:
-				if req.Msg.GetSessionId() != "" {
+				if req.Msg.GetSessionId() != "" || req.Msg.GetSandboxId() != "" {
 					t.Fatalf("ListRuns resolver request = %#v", req.Msg)
 				}
 			case 20:
 				sawFilteredList = true
-				if req.Msg.GetAgentName() != "reviewer" || req.Msg.GetSessionId() != sandboxID {
+				if req.Msg.GetAgentName() != "reviewer" || req.Msg.GetSandboxId() != sandboxID || req.Msg.GetSessionId() != "" {
 					t.Fatalf("ListRuns filtered request = %#v", req.Msg)
 				}
 			default:
@@ -2554,7 +2554,7 @@ agents:
 				ProjectId: req.Msg.GetProjectId(),
 				AgentName: "reviewer",
 				Status:    agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
-				SessionId: sandboxID,
+				SandboxId: sandboxID,
 			}}}), nil
 		},
 		getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
@@ -3535,7 +3535,7 @@ agents:
 		ProjectId: projectID,
 		AgentName: "reviewer",
 		Status:    agentcomposev2.RunStatus_RUN_STATUS_RUNNING,
-		SessionId: sandboxID,
+		SandboxId: sandboxID,
 		UpdatedAt: "2026-06-11T00:00:01Z",
 	}
 	var stopped []string


### PR DESCRIPTION
## Summary

  Fix `agent-compose logs --sandbox` lookup after run summaries moved sandbox identity to `sandbox_id`.

  The CLI was resolving sandbox refs from `RunSummary.session_id`, while the daemon now returns sandbox identity in `RunSummary.sandbox_id` and leaves
  `session_id` empty. This caused short sandbox IDs shown by `ps -a` to fail with `sandbox "... " not found in current project runs`.

  This change updates logs filtering and sandbox ref resolution to use `sandbox_id`, while keeping `session_id` as a compatibility fallback for older responses.

  ## Testing

  - `go test ./cmd/agent-compose -run 'TestIntegrationCLILogsFiltersRunAgentSessionAndJSON|TestIntegrationCLIResolvesShortResourceIDsBeforeDaemonRequests|
  TestIntegrationCLILogsTailTextJSONAndRunID|TestIntegrationCLILogsFollowUsesServerStream|TestIntegrationCLIRunDetachCommandCanBeFollowedByLogs'`

  ## Checklist

  - [ ] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.