### PR TITLE
feat: make jupyter readiness timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,10 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 # LOADER_RUN_TIMEOUT=20m
 # SESSION_START_TIMEOUT=30m
 # SESSION_STOP_TIMEOUT=30s
+# Max time to wait for Jupyter to become ready inside a guest before failing the
+# session start. Raise this on busy/cold hosts where guest boot exceeds 30s.
+# Non-positive or unparseable values fall back to the 30s default.
+# JUPYTER_READY_TIMEOUT=30s
 # WEBHOOK_BODY_LIMIT_BYTES=1048576
 # WEBHOOK_QUEUE_DEFAULT_WORKERS=8
 # WEBHOOK_QUEUE_RULES_JSON=[{"name":"repo-agent-compose","workers":2,"match":{"topic":"webhook.github.push","payload":{"body.repository.full_name":"chaitin/agent-compose"}}}]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	JupyterGuestPort           int
 	SessionStartTimeout        time.Duration
 	SessionStopTimeout         time.Duration
+	JupyterReadyTimeout        time.Duration
 	JupyterProxyBasePath       string
 	CapGRPCListen              string
 	CapGRPCTarget              string
@@ -311,6 +312,17 @@ func NewConfig(di do.Injector) (*Config, error) {
 		}
 	}
 
+	jupyterReadyTimeout := 30 * time.Second
+	if raw := os.Getenv("JUPYTER_READY_TIMEOUT"); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err != nil {
+			logger.Warn("failed to parse JUPYTER_READY_TIMEOUT", "value", raw, "error", err)
+		} else if parsed <= 0 {
+			logger.Warn("ignoring non-positive JUPYTER_READY_TIMEOUT, using default", "value", raw, "default", jupyterReadyTimeout)
+		} else {
+			jupyterReadyTimeout = parsed
+		}
+	}
+
 	webhookBodyLimitBytes := int64(1 << 20)
 	if raw := os.Getenv("WEBHOOK_BODY_LIMIT_BYTES"); raw != "" {
 		var parsed int64
@@ -435,6 +447,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		JupyterGuestPort:           jupyterGuestPort,
 		SessionStartTimeout:        startTimeout,
 		SessionStopTimeout:         stopTimeout,
+		JupyterReadyTimeout:        jupyterReadyTimeout,
 		JupyterProxyBasePath:       jupyterProxyBase,
 		CapGRPCListen:              strings.TrimSpace(os.Getenv("CAP_GRPC_LISTEN")),
 		CapGRPCTarget:              strings.TrimSpace(os.Getenv("CAP_GRPC_TARGET")),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -116,6 +116,7 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	t.Setenv("JUPYTER_PROXY_BASE", "/agent-compose/jupyter/")
 	t.Setenv("SESSION_START_TIMEOUT", "9s")
 	t.Setenv("SESSION_STOP_TIMEOUT", "10s")
+	t.Setenv("JUPYTER_READY_TIMEOUT", "45s")
 	t.Setenv("WEBHOOK_BODY_LIMIT_BYTES", "1234")
 	t.Setenv("WEBHOOK_QUEUE_RULES_JSON", `[{"name":"repo-a","workers":2,"match":{"topic":"webhook.github.push"}}]`)
 	t.Setenv("WEBHOOK_QUEUE_DEFAULT_WORKERS", "6")
@@ -152,6 +153,9 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	if config.JupyterGuestPort != 9999 || config.SessionStartTimeout != 9*time.Second || config.SessionStopTimeout != 10*time.Second {
 		t.Fatalf("session config = %#v", config)
 	}
+	if config.JupyterReadyTimeout != 45*time.Second {
+		t.Fatalf("jupyter ready timeout = %s", config.JupyterReadyTimeout)
+	}
 	if config.GuestWorkspacePath != "/workspace" || config.GuestHomePath != "/root" || config.GuestStateRoot != "/state" || config.GuestRuntimeRoot != "/runtime" || config.GuestLogRoot != "/logs" {
 		t.Fatalf("guest paths = %#v", config)
 	}
@@ -187,6 +191,35 @@ func testNewConfigAllowsDefaultRootsAndRequiresValidDriver(t *testing.T) {
 	t.Setenv("RUNTIME_DRIVER", "bad-driver")
 	if _, err := NewConfig(di); err == nil {
 		t.Fatalf("expected invalid runtime driver to fail")
+	}
+}
+
+func TestNewConfigJupyterReadyTimeoutDefaultAndGuard(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string // "" means unset
+		want  time.Duration
+	}{
+		{"default when unset", "", 30 * time.Second},
+		{"custom value honored", "90s", 90 * time.Second},
+		{"zero falls back to default", "0s", 30 * time.Second},
+		{"negative falls back to default", "-5s", 30 * time.Second},
+		{"invalid falls back to default", "not-a-duration", 30 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DATA_ROOT", filepath.Join(t.TempDir(), "data"))
+			t.Setenv("JUPYTER_READY_TIMEOUT", tc.value)
+			di := do.New()
+			do.ProvideValue(di, slog.Default())
+			config, err := NewConfig(di)
+			if err != nil {
+				t.Fatalf("NewConfig returned error: %v", err)
+			}
+			if config.JupyterReadyTimeout != tc.want {
+				t.Fatalf("JupyterReadyTimeout = %s, want %s", config.JupyterReadyTimeout, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -114,7 +114,7 @@ func (r *dockerRuntime) EnsureSession(ctx context.Context, session *Session, vmS
 		return SessionVMInfo{BoxID: containerInfo.ID, ProxyState: &proxyState}, nil
 	}
 
-	readyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	readyCtx, cancel := context.WithTimeout(ctx, r.config.JupyterReadyTimeout)
 	readyErr := waitForJupyterProxy(readyCtx, proxyState)
 	cancel()
 	if readyErr != nil {

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -101,7 +101,7 @@ func (r *microsandboxRuntime) EnsureSession(ctx context.Context, session *Sessio
 		}
 	}
 	if jupyterEnabled(proxyState) {
-		readyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		readyCtx, cancel := context.WithTimeout(ctx, r.config.JupyterReadyTimeout)
 		readyErr := waitForJupyterProxy(readyCtx, proxyState)
 		cancel()
 		if readyErr != nil {


### PR DESCRIPTION
## Background

A loader run failed with:

> `jupyter did not become ready on http://127.0.0.1:.../api/kernelspecs?token=...: context deadline exceeded`

Investigation showed the guest booted fine, but Jupyter did not respond to the readiness probe within a **hardcoded 30s window** during a cold/busy-host start. The 30s was set as an inner child context in the docker and microsandbox drivers, so the existing `SESSION_START_TIMEOUT` (default 30m) could not extend it — the readiness wait was effectively `min(SESSION_START_TIMEOUT, 30s)` and not tunable.

## Change

- Add `JUPYTER_READY_TIMEOUT` config knob (env, default `30s`) in `pkg/config`.
- Both `docker` and `microsandbox` drivers now use `config.JupyterReadyTimeout` instead of the hardcoded `30*time.Second`.
- Non-positive or unparseable values fall back to the `30s` default (a non-positive duration would produce an already-expired context and insta-fail every session start).
- Document the knob in `.env.example`.

Default behavior is unchanged (30s). Operators on busy/cold hosts can now set e.g. `JUPYTER_READY_TIMEOUT=60s`.

## Scope

Intentionally minimal: no retry logic, no boxlite changes, the 2s microsandbox probe is untouched.

## Tests

- Extended the env-parsing test to assert `JUPYTER_READY_TIMEOUT` maps to the field.
- Added a table test covering default / custom / zero / negative / invalid inputs.
- `go build ./...`, `go vet`, `gofmt -l`, and `pkg/config` + `pkg/driver` tests all pass.