### PR TITLE
Improve logs input output display

### DIFF
--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -383,18 +383,41 @@ func testComposeRunLogAndExecHelpers(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := writeLogDetails(&out, []*agentcomposev2.RunDetail{detail}, map[string]int{}, composeLogsOptions{TailLines: 1, Timestamp: true}); err != nil {
+	if err := writeLogDetails(&out, []*agentcomposev2.RunDetail{detail}, map[string]runLogPrintState{}, composeLogsOptions{TailLines: 1, Timestamp: true}); err != nil {
 		t.Fatalf("writeLogDetails returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "reviewer-run-1 [completed]| line3") {
+	logPrefix := "reviewer-run-1 [completed]| "
+	if !strings.Contains(out.String(), expectedLogSeparator(logPrefix, ">")) ||
+		!strings.Contains(out.String(), "reviewer-run-1 [completed]| prompt\n") ||
+		!strings.Contains(out.String(), expectedLogSeparator(logPrefix, "<")) ||
+		!strings.Contains(out.String(), "reviewer-run-1 [completed]| line3") {
 		t.Fatalf("log details = %q", out.String())
 	}
 	out.Reset()
 	if err := writeLogsForRun(&out, detail, true, composeLogsOptions{TailLines: 1}); err != nil {
 		t.Fatalf("writeLogsForRun json returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), `"run_id": "run-1"`) || !strings.Contains(out.String(), "line3") {
+	if !strings.Contains(out.String(), `"run_id": "run-1"`) || !strings.Contains(out.String(), `"prompt": "prompt"`) || !strings.Contains(out.String(), "line3") {
 		t.Fatalf("json logs = %q", out.String())
+	}
+	commandDetail := &agentcomposev2.RunDetail{ResultJson: `{"mode":"command","command":" echo hi\n"}`}
+	if got := runLogPrompt(commandDetail); got != " echo hi\n" {
+		t.Fatalf("runLogPrompt command fallback = %q", got)
+	}
+	if got := runLogPrompt(&agentcomposev2.RunDetail{Prompt: "  explicit prompt  ", ResultJson: `{"mode":"command","command":"echo hi"}`}); got != "  explicit prompt  " {
+		t.Fatalf("runLogPrompt prompt precedence = %q", got)
+	}
+	if got := runLogConversationText(&out, nil, "", "", false); got != "" {
+		t.Fatalf("empty conversation text = %q", got)
+	}
+	if got := runLogConversationText(&out, nil, "ask", "", false); got != strings.Repeat(">", 76)+"\nask\n" {
+		t.Fatalf("prompt-only conversation text = %q", got)
+	}
+	if got := runLogConversationText(&out, nil, "  ask\n\n", "answer", false); got != strings.Repeat(">", 76)+"\n  ask\n\n"+strings.Repeat("<", 76)+"\nanswer\n" {
+		t.Fatalf("preserved prompt conversation text = %q", got)
+	}
+	if got := runLogConversationText(&out, nil, "", "answer", false); got != strings.Repeat("<", 76)+"\nanswer\n" {
+		t.Fatalf("output-only conversation text = %q", got)
 	}
 	out.Reset()
 	if err := writePrefixedRunOutput(&out, &agentcomposev2.RunSummary{RunId: "fallback"}, "last-line", false); err != nil {

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"text/tabwriter"
 	"time"
+	"unicode"
 
 	"connectrpc.com/connect"
 	"github.com/joho/godotenv"
@@ -30,6 +31,7 @@ import (
 	"github.com/lmittmann/tint"
 	"github.com/samber/do/v2"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/width"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
@@ -3914,6 +3916,7 @@ type composeLogRunOutput struct {
 	RunID      string `json:"run_id"`
 	RunShortID string `json:"run_short_id,omitempty"`
 	Time       string `json:"time,omitempty"`
+	Prompt     string `json:"prompt,omitempty"`
 	Content    string `json:"content"`
 }
 
@@ -5818,7 +5821,7 @@ func followOrPrintProjectLogs(cmd *cobra.Command, cli cliOptions, client agentco
 		}
 		return nil
 	}
-	printed := map[string]int{}
+	printed := map[string]runLogPrintState{}
 	for {
 		runs, err := listLogRuns(cmd.Context(), client, projectID, options)
 		if err != nil {
@@ -6080,6 +6083,45 @@ func followRunLogStream(ctx context.Context, out io.Writer, client agentcomposev
 	if summary == nil {
 		return nil
 	}
+	detailResp, err := getRunDetail(ctx, client, projectID, summary.GetRunId())
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", summary.GetRunId(), projectID, err))
+	}
+	detailRun := detailResp.Msg.GetRun()
+	displaySummary := summary
+	if detailSummary := detailRun.GetSummary(); detailSummary != nil {
+		displaySummary = detailSummary
+	}
+	prompt := runLogPrompt(detailRun)
+	promptPrinted := false
+	refreshPrompt := func() error {
+		if promptPrinted || prompt != "" {
+			return nil
+		}
+		detailResp, err := getRunDetail(ctx, client, projectID, summary.GetRunId())
+		if err != nil {
+			return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", summary.GetRunId(), projectID, err))
+		}
+		detailRun = detailResp.Msg.GetRun()
+		if detailSummary := detailRun.GetSummary(); detailSummary != nil {
+			displaySummary = detailSummary
+		}
+		prompt = runLogPrompt(detailRun)
+		return nil
+	}
+	printPrompt := func() error {
+		if prompt == "" || promptPrinted {
+			return nil
+		}
+		if err := writePrefixedRunOutput(out, displaySummary, runLogConversationText(out, displaySummary, prompt, "", options.Timestamp), options.Timestamp); err != nil {
+			return err
+		}
+		promptPrinted = true
+		return nil
+	}
+	if err := printPrompt(); err != nil {
+		return err
+	}
 	tailLines := uint32(0)
 	if options.TailLines > 0 {
 		tailLines = uint32(options.TailLines)
@@ -6093,14 +6135,37 @@ func followRunLogStream(ctx context.Context, out io.Writer, client agentcomposev
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("follow run %s logs: %w", summary.GetRunId(), err))
 	}
+	assistantStarted := false
 	for stream.Receive() {
 		chunk := stream.Msg()
 		if chunk.GetData() != "" {
-			if err := writePrefixedRunOutputWithTimestamp(out, summary, chunk.GetData(), options.Timestamp, chunk.GetCreatedAt()); err != nil {
+			if !assistantStarted && !promptPrinted && prompt == "" {
+				if err := refreshPrompt(); err != nil {
+					return err
+				}
+				if err := printPrompt(); err != nil {
+					return err
+				}
+			}
+			if !assistantStarted {
+				if err := writePrefixedRunOutput(out, displaySummary, runLogAssistantSeparator(out, displaySummary, options.Timestamp), options.Timestamp); err != nil {
+					return err
+				}
+				assistantStarted = true
+			}
+			if err := writePrefixedRunOutput(out, displaySummary, chunk.GetData(), options.Timestamp); err != nil {
 				return err
 			}
 		}
 		if chunk.GetIsFinal() {
+			if !assistantStarted && !promptPrinted && prompt == "" {
+				if err := refreshPrompt(); err != nil {
+					return err
+				}
+				if err := printPrompt(); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 	}
@@ -6125,7 +6190,7 @@ func writeLogsForRun(out io.Writer, run *agentcomposev2.RunDetail, asJSON bool, 
 		}
 		return writeCommandOutput(out, append(data, '\n'))
 	}
-	return writeLogDetails(out, []*agentcomposev2.RunDetail{run}, map[string]int{}, options)
+	return writeLogDetails(out, []*agentcomposev2.RunDetail{run}, map[string]runLogPrintState{}, options)
 }
 
 func composeLogRunOutputFromDetail(run *agentcomposev2.RunDetail, options composeLogsOptions) composeLogRunOutput {
@@ -6135,34 +6200,163 @@ func composeLogRunOutputFromDetail(run *agentcomposev2.RunDetail, options compos
 		RunID:      displayOpaqueID(summary.GetRunId()),
 		RunShortID: shortOpaqueID(summary.GetRunId()),
 		Time:       formatComposeLogTimestamp(runLogTimestamp(summary)),
+		Prompt:     runLogPrompt(run),
 		Content:    tailLogOutput(run.GetOutput(), options.TailLines),
 	}
 }
 
-func writeLogDetails(out io.Writer, details []*agentcomposev2.RunDetail, printed map[string]int, options composeLogsOptions) error {
+type runLogPrintState struct {
+	outputPos     int
+	promptPrinted bool
+}
+
+func writeLogDetails(out io.Writer, details []*agentcomposev2.RunDetail, printed map[string]runLogPrintState, options composeLogsOptions) error {
 	for _, detail := range details {
 		summary := detail.GetSummary()
+		runID := summary.GetRunId()
 		output := detail.GetOutput()
+		prompt := runLogPrompt(detail)
+		state := printed[runID]
 		start := 0
 		if options.Follow {
-			start = printed[summary.GetRunId()]
+			start = state.outputPos
 			if start > len(output) {
 				start = 0
 			}
 		}
-		if start == len(output) {
+		promptChunk := ""
+		if prompt != "" && !state.promptPrinted {
+			promptChunk = prompt
+		}
+		if start == len(output) && promptChunk == "" {
 			continue
 		}
 		chunk := output[start:]
 		if options.TailLines >= 0 && (!options.Follow || start == 0) {
 			chunk = tailLogOutput(chunk, options.TailLines)
 		}
-		if err := writePrefixedRunOutput(out, summary, chunk, options.Timestamp); err != nil {
+		text := runLogConversationText(out, summary, promptChunk, chunk, options.Timestamp)
+		if err := writePrefixedRunOutput(out, summary, text, options.Timestamp); err != nil {
 			return err
 		}
-		printed[summary.GetRunId()] = len(output)
+		state.outputPos = len(output)
+		state.promptPrinted = state.promptPrinted || promptChunk != ""
+		printed[runID] = state
 	}
 	return nil
+}
+
+func runLogPrompt(run *agentcomposev2.RunDetail) string {
+	if run == nil {
+		return ""
+	}
+	if prompt := run.GetPrompt(); strings.TrimSpace(prompt) != "" {
+		return prompt
+	}
+	var result struct {
+		Mode    string `json:"mode"`
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal([]byte(run.GetResultJson()), &result); err != nil {
+		return ""
+	}
+	if strings.TrimSpace(result.Mode) == "command" && strings.TrimSpace(result.Command) != "" {
+		return result.Command
+	}
+	return ""
+}
+
+func runLogConversationText(out io.Writer, summary *agentcomposev2.RunSummary, prompt, output string, timestamp bool) string {
+	var builder strings.Builder
+	if prompt != "" {
+		builder.WriteString(runLogUserSeparator(out, summary, timestamp))
+		builder.WriteString(prompt)
+		if !strings.HasSuffix(prompt, "\n") {
+			builder.WriteString("\n")
+		}
+	}
+	if output != "" {
+		builder.WriteString(runLogAssistantSeparator(out, summary, timestamp))
+		builder.WriteString(output)
+		if !strings.HasSuffix(output, "\n") {
+			builder.WriteString("\n")
+		}
+	}
+	return builder.String()
+}
+
+func runLogUserSeparator(out io.Writer, summary *agentcomposev2.RunSummary, timestamp bool) string {
+	return runLogSeparator(out, summary, timestamp, '>')
+}
+
+func runLogAssistantSeparator(out io.Writer, summary *agentcomposev2.RunSummary, timestamp bool) string {
+	return runLogSeparator(out, summary, timestamp, '<')
+}
+
+func runLogSeparator(out io.Writer, summary *agentcomposev2.RunSummary, timestamp bool, marker rune) string {
+	width := runLogSeparatorWidth(out, summary, timestamp)
+	if width < 8 {
+		width = 8
+	}
+	return strings.Repeat(string(marker), width) + "\n"
+}
+
+func runLogSeparatorWidth(out io.Writer, summary *agentcomposev2.RunSummary, timestamp bool) int {
+	width := terminalOutputWidth(out)
+	if width <= 0 {
+		width = 80
+	}
+	prefixWidth := runLogLinePrefixWidth(summary, runLogTimestamp(summary), timestamp)
+	if width > prefixWidth {
+		return width - prefixWidth
+	}
+	return width
+}
+
+func terminalOutputWidth(out io.Writer) int {
+	file, ok := out.(*os.File)
+	if !ok {
+		return 80
+	}
+	width := terminalFileWidth(file)
+	if width <= 0 {
+		return 80
+	}
+	return width
+}
+
+func runLogLinePrefixWidth(summary *agentcomposev2.RunSummary, timestampValue string, timestamp bool) int {
+	prefixWidth := displayStringWidth(runLogPrefix(summary))
+	runTime := ""
+	if timestamp {
+		runTime = formatComposeLogTimestamp(timestampValue)
+	}
+	if runTime != "" {
+		return prefixWidth + displayStringWidth(runTime) + len(" []| ")
+	}
+	return prefixWidth + len(" | ")
+}
+
+func displayStringWidth(value string) int {
+	total := 0
+	for _, r := range value {
+		switch {
+		case r == '\n' || r == '\r':
+			continue
+		case r == '\t':
+			total++
+		case unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Me, r) || unicode.Is(unicode.Cf, r):
+			continue
+		default:
+			switch width.LookupRune(r).Kind() {
+			case width.EastAsianFullwidth, width.EastAsianWide:
+				total += 2
+			default:
+				total++
+			}
+		}
+	}
+	return total
 }
 
 func writePrefixedRunOutput(out io.Writer, summary *agentcomposev2.RunSummary, output string, timestamp bool) error {
@@ -6174,7 +6368,10 @@ func writePrefixedRunOutputWithTimestamp(out io.Writer, summary *agentcomposev2.
 		return nil
 	}
 	prefix := runLogPrefix(summary)
-	runTime := formatComposeLogTimestamp(timestampValue)
+	runTime := ""
+	if timestamp {
+		runTime = formatComposeLogTimestamp(timestampValue)
+	}
 	for len(output) > 0 {
 		line := output
 		rest := ""

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1469,7 +1469,12 @@ agents:
 		t.Fatalf("run -d --command code/stderr = %d / %q", exitCode, stderr)
 	}
 	logOut, logErr, _, logCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-detached-logs", "--follow")
-	if logCode != 0 || logErr != "" || logOut != "reviewer-run-detached-log | detached output\n" {
+	runPrefix := "reviewer-run-detached-log | "
+	wantLogOut := expectedLogSeparator(runPrefix, ">") +
+		"reviewer-run-detached-log | test prompt\n" +
+		expectedLogSeparator(runPrefix, "<") +
+		"reviewer-run-detached-log | detached output\n"
+	if logCode != 0 || logErr != "" || logOut != wantLogOut {
 		t.Fatalf("logs --follow code/stdout/stderr = %d / %q / %q", logCode, logOut, logErr)
 	}
 	if !sawCommand || !sawFollow {
@@ -2577,7 +2582,7 @@ agents:
 	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
 		t.Fatalf("logs JSON decode failed: %v\n%s", err, stdout)
 	}
-	if len(decoded.Runs) != 1 || decoded.Runs[0].RunID != displayOpaqueID(runID) || decoded.Runs[0].Content != "stored log output\n" {
+	if len(decoded.Runs) != 1 || decoded.Runs[0].RunID != displayOpaqueID(runID) || decoded.Runs[0].Prompt != "test prompt" || decoded.Runs[0].Content != "stored log output\n" {
 		t.Fatalf("logs JSON = %#v", decoded)
 	}
 	if !sawFilteredList {
@@ -2590,7 +2595,12 @@ agents:
 	}
 
 	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", identity.ShortID(runID))
-	if runCode != 0 || runErr != "" || runOut != "reviewer-run-"+identity.ShortID(runID)+" [2026-06-11T00:00:01.000Z]| stored log output\n" {
+	runPrefix := "reviewer-run-" + identity.ShortID(runID) + " | "
+	wantRunOut := expectedLogSeparator(runPrefix, ">") +
+		"reviewer-run-" + identity.ShortID(runID) + " | test prompt\n" +
+		expectedLogSeparator(runPrefix, "<") +
+		"reviewer-run-" + identity.ShortID(runID) + " | stored log output\n"
+	if runCode != 0 || runErr != "" || runOut != wantRunOut {
 		t.Fatalf("logs --run-id code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
 	}
 }
@@ -2620,7 +2630,13 @@ agents:
 	defer server.Close()
 
 	stdout, stderr, _, exitCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--tail", "2")
-	if exitCode != 0 || stderr != "" || stdout != "reviewer-run-tail [2026-06-11T00:00:01.000Z]| two\nreviewer-run-tail [2026-06-11T00:00:01.000Z]| three\n" {
+	tailPrefix := "reviewer-run-tail | "
+	wantTail := expectedLogSeparator(tailPrefix, ">") +
+		"reviewer-run-tail | test prompt\n" +
+		expectedLogSeparator(tailPrefix, "<") +
+		"reviewer-run-tail | two\n" +
+		"reviewer-run-tail | three\n"
+	if exitCode != 0 || stderr != "" || stdout != wantTail {
 		t.Fatalf("logs --tail text code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 
@@ -2632,12 +2648,16 @@ agents:
 	if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
 		t.Fatalf("logs --tail JSON decode failed: %v\n%s", err, jsonOut)
 	}
-	if len(decoded.Runs) != 1 || decoded.Runs[0].Content != "two\nthree\n" {
+	if len(decoded.Runs) != 1 || decoded.Runs[0].Prompt != "test prompt" || decoded.Runs[0].Content != "two\nthree\n" {
 		t.Fatalf("logs --tail JSON = %#v", decoded)
 	}
 
 	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-tail", "-n", "1")
-	if runCode != 0 || runErr != "" || runOut != "reviewer-run-tail [2026-06-11T00:00:01.000Z]| three\n" {
+	wantRunTail := expectedLogSeparator(tailPrefix, ">") +
+		"reviewer-run-tail | test prompt\n" +
+		expectedLogSeparator(tailPrefix, "<") +
+		"reviewer-run-tail | three\n"
+	if runCode != 0 || runErr != "" || runOut != wantRunTail {
 		t.Fatalf("logs --run-id --tail code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
 	}
 }
@@ -2694,8 +2714,16 @@ agents:
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("logs --timestamp code/stderr = %d / %q", exitCode, stderr)
 	}
-	want := "writer-run-writer [2026-06-11T00:00:04.000Z]| write one\n" +
+	writerPrefix := "writer-run-writer [2026-06-11T00:00:04.000Z]| "
+	reviewerPrefix := "reviewer-run-reviewer [2026-06-11T00:00:03.000Z]| "
+	want := expectedLogSeparator(writerPrefix, ">") +
+		"writer-run-writer [2026-06-11T00:00:04.000Z]| test prompt\n" +
+		expectedLogSeparator(writerPrefix, "<") +
+		"writer-run-writer [2026-06-11T00:00:04.000Z]| write one\n" +
 		"writer-run-writer [2026-06-11T00:00:04.000Z]| write two\n" +
+		expectedLogSeparator(reviewerPrefix, ">") +
+		"reviewer-run-reviewer [2026-06-11T00:00:03.000Z]| test prompt\n" +
+		expectedLogSeparator(reviewerPrefix, "<") +
 		"reviewer-run-reviewer [2026-06-11T00:00:03.000Z]| review one\n"
 	if stdout != want {
 		t.Fatalf("logs --timestamp stdout = %q, want %q", stdout, want)
@@ -2727,6 +2755,71 @@ func TestLogsAgentFlagAndPositionalIsUsageError(t *testing.T) {
 	}
 }
 
+func expectedLogSeparator(prefix, marker string) string {
+	width := 80 - len(prefix)
+	if width < 8 {
+		width = 8
+	}
+	return prefix + strings.Repeat(marker, width) + "\n"
+}
+
+func TestRunLogLinePrefixWidthUsesDisplayWidth(t *testing.T) {
+	summary := &agentcomposev2.RunSummary{
+		RunId:       "run-123456789abc",
+		AgentName:   "审查",
+		CompletedAt: "2026-06-11T00:00:03Z",
+	}
+	if got, want := runLogLinePrefixWidth(summary, "", false), 24; got != want {
+		t.Fatalf("runLogLinePrefixWidth without timestamp = %d, want %d", got, want)
+	}
+	if got, want := runLogLinePrefixWidth(summary, summary.GetCompletedAt(), true), 50; got != want {
+		t.Fatalf("runLogLinePrefixWidth with timestamp = %d, want %d", got, want)
+	}
+}
+
+func TestWritePrefixedRunOutputHonorsTimestampFlag(t *testing.T) {
+	summary := &agentcomposev2.RunSummary{
+		RunId:       "run-123456789abc",
+		AgentName:   "reviewer",
+		CompletedAt: "2026-06-11T00:00:03Z",
+	}
+	var out strings.Builder
+	if err := writePrefixedRunOutput(&out, summary, "line\n", false); err != nil {
+		t.Fatalf("writePrefixedRunOutput returned error: %v", err)
+	}
+	if got, want := out.String(), "reviewer-run-123456789abc | line\n"; got != want {
+		t.Fatalf("writePrefixedRunOutput without timestamp = %q, want %q", got, want)
+	}
+}
+
+func TestWriteLogDetailsFollowPrintsPromptOnce(t *testing.T) {
+	detail := testRunDetail("project-logs", "run-follow-repeat", "reviewer", "session-follow-repeat", agentcomposev2.RunStatus_RUN_STATUS_RUNNING, 0, "first\n")
+	printed := map[string]runLogPrintState{}
+	options := composeLogsOptions{Follow: true, TailLines: -1}
+	var out bytes.Buffer
+	if err := writeLogDetails(&out, []*agentcomposev2.RunDetail{detail}, printed, options); err != nil {
+		t.Fatalf("writeLogDetails first follow call returned error: %v", err)
+	}
+	detail.Output = "first\nsecond\n"
+	if err := writeLogDetails(&out, []*agentcomposev2.RunDetail{detail}, printed, options); err != nil {
+		t.Fatalf("writeLogDetails second follow call returned error: %v", err)
+	}
+	if err := writeLogDetails(&out, []*agentcomposev2.RunDetail{detail}, printed, options); err != nil {
+		t.Fatalf("writeLogDetails third follow call returned error: %v", err)
+	}
+	got := out.String()
+	promptPrefix := runLogPrefix(detail.GetSummary()) + " | "
+	promptSeparator := expectedLogSeparator(promptPrefix, ">")
+	if strings.Count(got, promptSeparator) != 1 {
+		t.Fatalf("follow log prompt printed %d times; output = %q", strings.Count(got, promptSeparator), got)
+	}
+	if !strings.Contains(got, "| test prompt\n") ||
+		!strings.Contains(got, "| first\n") ||
+		!strings.Contains(got, "| second\n") {
+		t.Fatalf("follow log output missing expected content: %q", got)
+	}
+}
+
 func TestIntegrationCLILogsFollowUsesServerStream(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
 name: cli-logs-follow
@@ -2735,6 +2828,7 @@ agents:
     provider: codex
 `)
 	var listCalls int
+	var getCalls int
 	var followCalls int
 	server := newRunServiceStubServer(t, runServiceStub{
 		listRuns: func(ctx context.Context, req *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
@@ -2746,6 +2840,21 @@ agents:
 				Status:    agentcomposev2.RunStatus_RUN_STATUS_RUNNING,
 				SessionId: "session-follow",
 			}}}), nil
+		},
+		getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
+			getCalls++
+			if req.Msg.GetRunId() != "run-follow" {
+				t.Fatalf("GetRun request = %#v", req.Msg)
+			}
+			run := testRunDetail(req.Msg.GetProjectId(), "run-follow", "reviewer", "session-follow", agentcomposev2.RunStatus_RUN_STATUS_RUNNING, 0, "")
+			if getCalls == 1 {
+				run.Prompt = ""
+				run.ResultJson = "{}"
+			} else {
+				run.Prompt = ""
+				run.ResultJson = `{"mode":"command","command":"echo delayed prompt"}`
+			}
+			return connect.NewResponse(&agentcomposev2.GetRunResponse{Run: run}), nil
 		},
 		followRunLogs: func(ctx context.Context, req *connect.Request[agentcomposev2.FollowRunLogsRequest], stream *connect.ServerStream[agentcomposev2.RunLogChunk]) error {
 			followCalls++
@@ -2767,11 +2876,64 @@ agents:
 	if stderr != "" {
 		t.Fatalf("logs follow stderr = %q, want empty", stderr)
 	}
-	if stdout != "reviewer-run-follow [2026-07-06T08:01:36.372Z]| first\nreviewer-run-follow [2026-07-06T08:01:36.875Z]| second\n" {
+	followPrefix := "reviewer-run-follow [2026-06-11T00:00:01.000Z]| "
+	want := expectedLogSeparator(followPrefix, ">") +
+		"reviewer-run-follow [2026-06-11T00:00:01.000Z]| echo delayed prompt\n" +
+		expectedLogSeparator(followPrefix, "<") +
+		"reviewer-run-follow [2026-06-11T00:00:01.000Z]| first\n" +
+		"reviewer-run-follow [2026-06-11T00:00:01.000Z]| second\n"
+	if stdout != want {
 		t.Fatalf("logs follow stdout = %q", stdout)
 	}
-	if listCalls != 1 || followCalls != 1 {
-		t.Fatalf("logs follow list/follow calls = %d/%d, want 1/1", listCalls, followCalls)
+	if listCalls != 1 || getCalls != 2 || followCalls != 1 {
+		t.Fatalf("logs follow list/get/follow calls = %d/%d/%d, want 1/2/1", listCalls, getCalls, followCalls)
+	}
+}
+
+func TestIntegrationCLILogsFollowPrintsDelayedPromptWithoutOutput(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-logs-follow-empty
+agents:
+  reviewer:
+    provider: codex
+`)
+	var getCalls int
+	server := newRunServiceStubServer(t, runServiceStub{
+		listRuns: func(ctx context.Context, req *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
+			return connect.NewResponse(&agentcomposev2.ListRunsResponse{Runs: []*agentcomposev2.RunSummary{{
+				RunId:     "run-follow-empty",
+				ProjectId: req.Msg.GetProjectId(),
+				AgentName: "reviewer",
+				Status:    agentcomposev2.RunStatus_RUN_STATUS_RUNNING,
+				SessionId: "session-follow-empty",
+			}}}), nil
+		},
+		getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
+			getCalls++
+			run := testRunDetail(req.Msg.GetProjectId(), "run-follow-empty", "reviewer", "session-follow-empty", agentcomposev2.RunStatus_RUN_STATUS_RUNNING, 0, "")
+			run.Prompt = ""
+			if getCalls == 1 {
+				run.ResultJson = "{}"
+			} else {
+				run.ResultJson = `{"mode":"command","command":"true"}`
+			}
+			return connect.NewResponse(&agentcomposev2.GetRunResponse{Run: run}), nil
+		},
+		followRunLogs: func(ctx context.Context, req *connect.Request[agentcomposev2.FollowRunLogsRequest], stream *connect.ServerStream[agentcomposev2.RunLogChunk]) error {
+			return stream.Send(&agentcomposev2.RunLogChunk{RunStatus: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, IsFinal: true})
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--follow", "--timestamp")
+	followEmptyPrefix := "reviewer-run-follow-empty [2026-06-11T00:00:01.000Z]| "
+	want := expectedLogSeparator(followEmptyPrefix, ">") +
+		"reviewer-run-follow-empty [2026-06-11T00:00:01.000Z]| true\n"
+	if exitCode != 0 || stderr != "" || stdout != want {
+		t.Fatalf("logs follow no output code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+	if getCalls != 2 {
+		t.Fatalf("GetRun calls = %d, want 2", getCalls)
 	}
 }
 

--- a/cmd/agent-compose/terminal_width_other.go
+++ b/cmd/agent-compose/terminal_width_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly && !solaris && !aix
+
+package main
+
+import "os"
+
+func terminalFileWidth(_ *os.File) int {
+	return 0
+}

--- a/cmd/agent-compose/terminal_width_unix.go
+++ b/cmd/agent-compose/terminal_width_unix.go
@@ -1,0 +1,17 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly || solaris || aix
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func terminalFileWidth(file *os.File) int {
+	size, err := unix.IoctlGetWinsize(int(file.Fd()), unix.TIOCGWINSZ)
+	if err != nil || size == nil || size.Col == 0 {
+		return 0
+	}
+	return int(size.Col)
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/superradcompany/microsandbox/sdk/go v0.6.4
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	golang.org/x/sys v0.45.0
+	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -80,7 +81,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gotest.tools/v3 v3.5.2 // indirect


### PR DESCRIPTION
## Summary
- show USER and ASSISTANT sections in text logs by default
- include prompt in logs JSON while keeping content as output
- handle delayed prompts for follow streams, including command runs with no output

## Validation
- go test ./cmd/agent-compose
- docker build agent-compose:latest with Dockerfile.agent-compose-dockeronly
- docker compose recreate agent-compose
- container CLI follow logs validation for command runs with and without output

<img width="1352" height="312" alt="image" src="https://github.com/user-attachments/assets/01149db9-6ce1-4075-94fb-16be50e55f23" />

