### PR TITLE
fix(microsandbox): drop redundant bootstrap from jupyter launch so it starts in time

### DIFF
--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -969,9 +969,15 @@ func microsandboxPullPolicyForImageRef(imageRef string, perCallPolicy string) mi
 }
 
 func (r *microsandboxRuntime) launchJupyter(ctx context.Context, sandbox *microsandbox.Sandbox, proxyState ProxyState) error {
-	command := directoryOnlyJupyterLaunchCommand(r.config, proxyState, true)
-	// Run from "/" (not GuestWorkspacePath): /workspace is created by the bootstrap
-	// inside command itself, so cwd=/workspace would fail chdir before the script runs.
+	// Use the launch command WITHOUT the directory-only bootstrap: the guest
+	// session bootstrap already ran unconditionally in ensureDirectoryOnlyGuestSessionBootstrap
+	// before this call, so re-running it here is redundant. Worse, the embedded
+	// bootstrap (~1.5s of symlink setup) can consume the entire observeCtx window
+	// below before the script reaches "nohup jupyterlab", so closing the exec
+	// handle tears the still-bootstrapping process down and jupyter never starts.
+	command := jupyterLaunchCommand(r.config, proxyState, true)
+	// Run from "/" (not GuestWorkspacePath): /workspace is a symlink created by the
+	// earlier bootstrap, so cwd=/workspace could fail chdir if anything is off.
 	// Matches the boxlite driver; jupyter still serves /workspace via --ServerApp.root_dir.
 	handle, err := sandbox.ExecStream(ctx, "/bin/bash", []string{"-lc", command}, r.execOptions(ctx, ExecSpec{Cwd: "/"})...)
 	if err != nil {


### PR DESCRIPTION
## 问题

在 microsandbox driver 上，jupyter 始终无法就绪——每次 run 都在就绪 gate 失败（`JUPYTER_NOT_READY`，约 50s 超时）。实际上 jupyter 进程根本没被创建。

## 根因（已实验证明）

`launchJupyter` 是「点火即走」（fire-and-forget）：它通过一条 exec stream 启动 jupyter launch 脚本，用一个固定 **1500ms** 的观察窗口（`observeCtx`）盯着它，然后返回并关闭 exec handle。关闭 handle 会让 microsandbox 清理这条 exec session 上仍在运行的进程。

`directoryOnlyJupyterLaunchCommand(..., true)` 构造的 launch 脚本**在开头嵌入了一整段 directory-only bootstrap**（建约 11 个 home symlink），耗时约 1.5s。这正好吃满 1500ms 窗口，导致脚本**还没执行到 `nohup python3 -m jupyterlab`** 就被关闭 handle 触发的 cleanup 杀掉——jupyter 从没被启动，它的日志从没被写，随后那个 30s 的就绪探测一直在探一个不存在的 server。

而这段嵌入的 bootstrap 是**冗余的**：`ensureDirectoryOnlyGuestSessionBootstrap` 在 `launchJupyter` 之前**已经无条件跑过一遍完全相同（字节级一致、且幂等）的 bootstrap**。当初加独立前置 bootstrap 步骤时，忘了把 launch 脚本换成不含 bootstrap 的版本，于是 bootstrap 跑了两遍。

## 修复

把 `directoryOnlyJupyterLaunchCommand(...)` 换成已存在的 `jupyterLaunchCommand(...)`（**不含**嵌入 bootstrap 的版本——docker driver 一直在用它）。这样 launch 脚本一进来就直奔 `nohup jupyterlab`，在 1500ms 窗口内轻松完成点火。`observeCtx` 那个窗口**刻意保持不动**——它是一个合理的「快速失败」观察哨，本次修复只是让它原本「点火近乎瞬时」的假设重新成立。

一行代码改动 + 注释。bootstrap 本身行为不变（仍然只在前置步骤跑一次）。

## 证据

- **单变量对照（窗口）**：在同一个 v2607.4.0 镜像上，只把 `1500*time.Millisecond` 改成 `10*time.Second`，jupyter 就能起来、gate 通过（run 健康 `running` 6 分钟以上；而所有 1500ms 的 run 都在约 50s 失败 `JUPYTER_NOT_READY`）。这坐实了「窗口时长 / bootstrap 耗时」的时序竞态就是根因。
- **本 PR 的修复已在 dev180 坐实**：只删掉冗余 bootstrap、`observeCtx` 窗口保持原样 1500ms（`microsandbox_runtime.go:978` 改动、`:991` 窗口不动），触发的 msb run 跳出 `JUPYTER_NOT_READY`，稳定 `running`（60s+，远超之前约 50s 就失败的死亡点），jupyter gate 通过。这也证明前置 bootstrap 建的 symlink 跨 exec 存活、`/workspace` 正常（否则 jupyter 会因 dangling symlink 崩、过不了 gate）。
- **已排除**（独立实验）：bind mount 的 quota / `QuotaMiB` **与此无关**——本机 FFI 复现显示 v0.6.4 对 bind mount 的 quota 是静默丢弃（no-op）；且单变量「禁用 quota」的 run 仍然失败 `JUPYTER_NOT_READY`。

## 给 reviewer 的说明

- 只动了 microsandbox 路径。`docker` 和 `boxlite` 不受影响（docker 本来就用 `jupyterLaunchCommand`；boxlite 走自己的路径）。
- 前置 bootstrap（`ensureDirectoryOnlyGuestSessionBootstrap`）是超集——它在每条 ensure/exec 路径上都会跑，是真正建立 symlink 的地方；launch 脚本里那份是严格子集，删掉是安全的。
