### PR TITLE
Fix runtime bind paths for sha256 session IDs

### DIFF
--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -269,7 +269,7 @@ func (s *Store) RemoveSession(_ context.Context, id string) error {
 	if err := os.RemoveAll(path); err != nil {
 		return fmt.Errorf("remove session dir %s: %w", id, err)
 	}
-	s.sessionLocks.Delete(id)
+	s.sessionLocks.Delete(sessionLockKey(id))
 	return nil
 }
 
@@ -381,7 +381,7 @@ func (s *Store) ListEvents(_ context.Context, id string) ([]SessionEvent, error)
 }
 
 func (s *Store) sessionDir(id string) string {
-	return filepath.Join(s.config.SessionRoot, id)
+	return filepath.Join(s.config.SessionRoot, sessionDirName(id))
 }
 
 func (s *Store) SessionDir(id string) string {
@@ -398,11 +398,22 @@ func validateSessionIDForRemove(id string) error {
 	return nil
 }
 
+func sessionDirName(id string) string {
+	if hash, err := identity.Hash(id); err == nil {
+		return hash
+	}
+	return id
+}
+
 func (s *Store) lockSession(id string) func() {
-	value, _ := s.sessionLocks.LoadOrStore(id, &sync.Mutex{})
+	value, _ := s.sessionLocks.LoadOrStore(sessionLockKey(id), &sync.Mutex{})
 	mu := value.(*sync.Mutex)
 	mu.Lock()
 	return mu.Unlock
+}
+
+func sessionLockKey(id string) string {
+	return sessionDirName(id)
 }
 
 func (s *Store) hydrateSessionGuestImage(session *Session) {

--- a/pkg/storage/sessionstore/store_coverage_test.go
+++ b/pkg/storage/sessionstore/store_coverage_test.go
@@ -58,6 +58,16 @@ func TestStoreCreateSessionUsesConfiguredJupyterProxyBase(t *testing.T) {
 	if session.Summary.RuntimeRef != "agent-compose-"+session.Summary.ShortID {
 		t.Fatalf("runtime ref = %q, want short-id ref", session.Summary.RuntimeRef)
 	}
+	sessionDir := store.SessionDir(session.Summary.ID)
+	if strings.ContainsAny(filepath.Base(sessionDir), ",:;") {
+		t.Fatalf("session dir basename = %q, want no runtime-forbidden characters", filepath.Base(sessionDir))
+	}
+	if filepath.Base(sessionDir) != strings.TrimPrefix(session.Summary.ID, identity.Prefix) {
+		t.Fatalf("session dir = %q, want hash identity path", sessionDir)
+	}
+	if session.Summary.WorkspacePath != filepath.Join(sessionDir, "workspace") {
+		t.Fatalf("workspace path = %q, want under session dir %q", session.Summary.WorkspacePath, sessionDir)
+	}
 	wantProxyPath := "/agent-compose/session/" + session.Summary.ID + "/lab"
 	if session.Summary.ProxyPath != wantProxyPath {
 		t.Fatalf("session proxy path = %q, want %q", session.Summary.ProxyPath, wantProxyPath)
@@ -71,6 +81,24 @@ func TestStoreCreateSessionUsesConfiguredJupyterProxyBase(t *testing.T) {
 	}
 	if proxyState.Enabled || proxyState.GuestPort != 0 || proxyState.HostPort != 0 || proxyState.Token != "" {
 		t.Fatalf("default proxy state = %+v, want jupyter disabled without ports/token", proxyState)
+	}
+}
+
+func TestSessionLockKeyUsesSessionDirName(t *testing.T) {
+	id := identity.NewID(identity.ResourceSandbox, "lock-key")
+	if got, want := sessionLockKey(id), sessionDirName(id); got != want {
+		t.Fatalf("sessionLockKey(%q) = %q, want %q", id, got, want)
+	}
+	if sessionLockKey(id) != sessionLockKey(strings.TrimPrefix(id, identity.Prefix)) {
+		t.Fatalf("session lock key should match canonical and directory-form ids")
+	}
+}
+
+func TestSessionDirNameFallbackPreservesInvalidInput(t *testing.T) {
+	for _, id := range []string{" . ", " .. ", "   "} {
+		if got := sessionDirName(id); got != id {
+			t.Fatalf("sessionDirName(%q) = %q, want unchanged fallback", id, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- store new sha256 session directories using the raw hash instead of the public `sha256:<hash>` ID
- keep public session IDs, proxy paths, and runtime refs unchanged
- cover the safe session directory behavior in sessionstore tests

## Tests
- `go test ./pkg/storage/sessionstore ./pkg/driver`