### PR TITLE
fix cli up down resource output

### DIFF
--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -202,6 +202,29 @@ func testComposeProjectPureHelpers(t *testing.T) {
 	if !strings.Contains(out.String(), "MESSAGE") || !strings.Contains(out.String(), "timer") || !strings.Contains(out.String(), "stop failed") || strings.Contains(out.String(), "loader") {
 		t.Fatalf("compose down text = %q", out.String())
 	}
+	sharedTriggerSpec := &compose.NormalizedProjectSpec{Agents: []compose.NormalizedAgentSpec{
+		{
+			Name:      "worker-a",
+			Scheduler: &compose.NormalizedSchedulerSpec{Triggers: []compose.NormalizedTriggerSpec{{Name: "hourly"}}},
+		},
+		{
+			Name:      "worker-b",
+			Scheduler: &compose.NormalizedSchedulerSpec{Triggers: []compose.NormalizedTriggerSpec{{Name: "hourly"}}},
+		},
+	}}
+	sharedTriggerChanges := composeDisplayChangesFromProjectChanges([]*agentcomposev2.ProjectChange{
+		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED, ResourceType: "project_scheduler", ResourceId: "scheduler-a", Name: "worker-a"},
+		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED, ResourceType: "project_scheduler", ResourceId: "scheduler-b", Name: "worker-b"},
+	}, sharedTriggerSpec)
+	sharedTriggerCount := 0
+	for _, change := range sharedTriggerChanges {
+		if change.ResourceType == "trigger" && change.Name == "hourly" {
+			sharedTriggerCount++
+		}
+	}
+	if sharedTriggerCount != 2 {
+		t.Fatalf("shared trigger display changes = %#v, want 2 hourly triggers", sharedTriggerChanges)
+	}
 	unchangedDown := composeDownOutputFromResponse(&agentcomposev2.RemoveProjectResponse{Project: &agentcomposev2.Project{Summary: projectSummary}})
 	if unchangedDown.Status != "unchanged" {
 		t.Fatalf("unchanged down output = %#v", unchangedDown)

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -145,10 +145,17 @@ func testComposeProjectPureHelpers(t *testing.T) {
 	}
 	changes := []*agentcomposev2.ProjectChange{
 		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED, ResourceType: "agent", ResourceId: "agent-1", Name: "worker"},
-		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UPDATED, ResourceType: "scheduler", ResourceId: "scheduler-1", Name: "timer"},
+		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UPDATED, ResourceType: "project_scheduler", ResourceId: "scheduler-1", Name: "worker"},
+		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UPDATED, ResourceType: "loader", ResourceId: "loader-1", Name: "worker scheduler"},
 		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_REMOVED, ResourceType: "session", ResourceId: "session-1", Name: "old"},
 		{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UNCHANGED, ResourceType: "session", ResourceId: "session-2", Message: "stop failed"},
 	}
+	displaySpec := &compose.NormalizedProjectSpec{Agents: []compose.NormalizedAgentSpec{{
+		Name: "worker",
+		Scheduler: &compose.NormalizedSchedulerSpec{Triggers: []compose.NormalizedTriggerSpec{{
+			Name: "timer",
+		}}},
+	}}}
 	upResp := &agentcomposev2.ApplyProjectResponse{
 		Project: &agentcomposev2.Project{Summary: projectSummary},
 		Revision: &agentcomposev2.ProjectRevision{
@@ -163,35 +170,36 @@ func testComposeProjectPureHelpers(t *testing.T) {
 		t.Fatalf("composeUpOutputFromResponse = %#v", upOutput)
 	}
 	out.Reset()
-	if err := writeComposeUpText(&out, upResp); err != nil {
+	if err := writeComposeUpText(&out, composeDisplayChangesFromProjectChanges(upResp.GetChanges(), displaySpec)); err != nil {
 		t.Fatalf("writeComposeUpText returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "ACTION") || !strings.Contains(out.String(), "created") {
+	if !strings.Contains(out.String(), "ACTION") || !strings.Contains(out.String(), "timer") || strings.Contains(out.String(), "loader") {
 		t.Fatalf("compose up text = %q", out.String())
 	}
 	out.Reset()
 	upResp.Applied = false
-	if err := writeComposeUpText(&out, upResp); err != nil || !strings.Contains(out.String(), "ACTION") {
+	if err := writeComposeUpText(&out, composeDisplayChangesFromProjectChanges(upResp.GetChanges(), displaySpec)); err != nil || !strings.Contains(out.String(), "ACTION") {
 		t.Fatalf("compose up not-applied text = %q err=%v", out.String(), err)
 	}
 	out.Reset()
 	upResp.Unchanged = true
-	if err := writeComposeUpText(&out, upResp); err != nil || !strings.Contains(out.String(), "ACTION") {
+	if err := writeComposeUpText(&out, composeDisplayChangesFromProjectChanges(upResp.GetChanges(), displaySpec)); err != nil || !strings.Contains(out.String(), "ACTION") {
 		t.Fatalf("compose up unchanged text = %q err=%v", out.String(), err)
 	}
 
-	downOutput := composeDownOutputFromResponse(&agentcomposev2.RemoveProjectResponse{
+	downResp := &agentcomposev2.RemoveProjectResponse{
 		Project: &agentcomposev2.Project{Summary: projectSummary},
 		Changes: changes,
-	})
+	}
+	downOutput := composeDownOutputFromResponse(downResp)
 	if downOutput.Status != "partial-failure" || downOutput.FailedSessionStops != 1 || len(composeChangeOutputs(changes)) != len(changes) {
 		t.Fatalf("composeDownOutputFromResponse = %#v", downOutput)
 	}
 	out.Reset()
-	if err := writeComposeDownText(&out, downOutput); err != nil {
+	if err := writeComposeDownText(&out, composeDownDisplayChanges(downResp, displaySpec)); err != nil {
 		t.Fatalf("writeComposeDownText returned error: %v", err)
 	}
-	if !strings.Contains(out.String(), "partial-failure") || !strings.Contains(out.String(), "stop failed") {
+	if !strings.Contains(out.String(), "MESSAGE") || !strings.Contains(out.String(), "timer") || !strings.Contains(out.String(), "stop failed") || strings.Contains(out.String(), "loader") {
 		t.Fatalf("compose down text = %q", out.String())
 	}
 	unchangedDown := composeDownOutputFromResponse(&agentcomposev2.RemoveProjectResponse{Project: &agentcomposev2.Project{Summary: projectSummary}})

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3883,6 +3883,7 @@ type composeDisplayChangeOutput struct {
 	ResourceType string
 	ID           string
 	Name         string
+	Owner        string
 	Message      string
 }
 
@@ -4558,6 +4559,7 @@ func (b *composeDisplayChangeBuilder) addTriggerChanges(action, id, agentName, m
 			ResourceType: "trigger",
 			ID:           id,
 			Name:         agentName,
+			Owner:        agentName,
 			Message:      message,
 		})
 		return
@@ -4568,6 +4570,7 @@ func (b *composeDisplayChangeBuilder) addTriggerChanges(action, id, agentName, m
 			ResourceType: "trigger",
 			ID:           id,
 			Name:         triggerName,
+			Owner:        agentName,
 			Message:      message,
 		})
 	}
@@ -4594,7 +4597,10 @@ func composeTriggerNamesForAgent(spec *compose.NormalizedProjectSpec, agentName 
 }
 
 func composeDisplayChangeKey(change composeDisplayChangeOutput) string {
-	if (change.ResourceType == "agent" || change.ResourceType == "trigger") && change.Name != "" {
+	if change.ResourceType == "trigger" && change.Owner != "" && change.Name != "" {
+		return change.ResourceType + "\x00" + change.Owner + "\x00" + change.Name
+	}
+	if change.ResourceType == "agent" && change.Name != "" {
 		return change.ResourceType + "\x00" + change.Name
 	}
 	identity := change.ID

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -1319,7 +1319,7 @@ func runComposeUpCommand(cmd *cobra.Command, cli cliOptions) error {
 		}
 		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
 	}
-	return writeComposeUpText(cmd.OutOrStdout(), msg)
+	return writeComposeUpText(cmd.OutOrStdout(), composeDisplayChangesFromProjectChanges(msg.GetChanges(), normalized))
 }
 
 func runComposeDownCommand(cmd *cobra.Command, cli cliOptions) error {
@@ -1346,7 +1346,7 @@ func runComposeDownCommand(cmd *cobra.Command, cli cliOptions) error {
 		if err := writeCommandOutput(cmd.OutOrStdout(), append(data, '\n')); err != nil {
 			return err
 		}
-	} else if err := writeComposeDownText(cmd.OutOrStdout(), output); err != nil {
+	} else if err := writeComposeDownText(cmd.OutOrStdout(), composeDownDisplayChanges(resp.Msg, normalized)); err != nil {
 		return err
 	}
 	if output.FailedSessionStops > 0 {
@@ -3878,6 +3878,14 @@ type composeUpChangeOutput struct {
 	Message      string `json:"message,omitempty"`
 }
 
+type composeDisplayChangeOutput struct {
+	Action       string
+	ResourceType string
+	ID           string
+	Name         string
+	Message      string
+}
+
 type composeRunOutput struct {
 	ID             string   `json:"id"`
 	ShortID        string   `json:"short_id"`
@@ -4352,27 +4360,6 @@ func composeChangeOutputs(changes []*agentcomposev2.ProjectChange) []composeUpCh
 	return output
 }
 
-func writeComposeUpText(out io.Writer, resp *agentcomposev2.ApplyProjectResponse) error {
-	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "ID\tNAME\tTYPE\tACTION"); err != nil {
-		return err
-	}
-	for _, change := range resp.GetChanges() {
-		if change.GetResourceType() == "project_revision" {
-			continue
-		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-			shortOpaqueID(change.GetResourceId()),
-			change.GetName(),
-			change.GetResourceType(),
-			projectChangeActionText(change.GetAction()),
-		); err != nil {
-			return err
-		}
-	}
-	return tw.Flush()
-}
-
 func writeProjectListText(out io.Writer, projects []composeProjectListItem, verbose bool) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	if verbose {
@@ -4429,31 +4416,233 @@ func projectListStatus(project composeProjectListItem) string {
 	return "active"
 }
 
-func writeComposeDownText(out io.Writer, output composeDownOutput) error {
-	if _, err := fmt.Fprintf(out, "Project: %s\nID: %s\nStatus: %s\nFailed sandbox stops: %d\n\n",
-		output.Project.Name,
-		output.Project.ID,
-		output.Status,
-		output.FailedSessionStops,
-	); err != nil {
-		return err
+func writeComposeUpText(out io.Writer, changes []composeDisplayChangeOutput) error {
+	return writeComposeChangeTable(out, changes)
+}
+
+func writeComposeDownText(out io.Writer, changes []composeDisplayChangeOutput) error {
+	return writeComposeChangeTable(out, changes)
+}
+
+func writeComposeChangeTable(out io.Writer, changes []composeDisplayChangeOutput) error {
+	hasMessage := false
+	for _, change := range changes {
+		if strings.TrimSpace(change.Message) != "" {
+			hasMessage = true
+			break
+		}
 	}
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "ACTION\tTYPE\tNAME\tID\tMESSAGE"); err != nil {
+	header := "ID\tNAME\tTYPE\tACTION"
+	if hasMessage {
+		header += "\tMESSAGE"
+	}
+	if _, err := fmt.Fprintln(tw, header); err != nil {
 		return err
 	}
-	for _, change := range output.Changes {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
-			change.Action,
-			change.ResourceType,
-			change.Name,
+	for _, change := range changes {
+		format := "%s\t%s\t%s\t%s\n"
+		args := []any{
 			change.ID,
-			change.Message,
-		); err != nil {
+			change.Name,
+			change.ResourceType,
+			change.Action,
+		}
+		if hasMessage {
+			format = "%s\t%s\t%s\t%s\t%s\n"
+			args = append(args, change.Message)
+		}
+		if _, err := fmt.Fprintf(tw, format, args...); err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
+}
+
+func composeDisplayChangesFromProjectChanges(changes []*agentcomposev2.ProjectChange, spec *compose.NormalizedProjectSpec) []composeDisplayChangeOutput {
+	builder := newComposeDisplayChangeBuilder()
+	for _, change := range changes {
+		builder.addProjectChange(change, spec)
+	}
+	return builder.items
+}
+
+func composeDownDisplayChanges(resp *agentcomposev2.RemoveProjectResponse, spec *compose.NormalizedProjectSpec) []composeDisplayChangeOutput {
+	builder := newComposeDisplayChangeBuilder()
+	removed := false
+	for _, change := range resp.GetChanges() {
+		if change.GetResourceType() == "project" && change.GetAction() == agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_REMOVED {
+			removed = true
+		}
+		builder.addProjectChange(change, spec)
+	}
+	project := resp.GetProject()
+	summary := project.GetSummary()
+	if summary.GetRemovedAt() != "" {
+		removed = true
+	}
+	if len(builder.items) == 0 && summary.GetProjectId() != "" {
+		builder.add(composeDisplayChangeOutput{
+			Action:       "unchanged",
+			ResourceType: "project",
+			ID:           shortOpaqueID(summary.GetProjectId()),
+			Name:         summary.GetName(),
+		})
+	}
+	if removed {
+		for _, agent := range project.GetAgents() {
+			builder.add(composeDisplayChangeOutput{
+				Action:       "removed",
+				ResourceType: "agent",
+				ID:           shortOpaqueID(agent.GetManagedAgentId()),
+				Name:         agent.GetAgentName(),
+			})
+		}
+		for _, scheduler := range project.GetSchedulers() {
+			builder.addTriggerChanges("removed", shortOpaqueID(scheduler.GetSchedulerId()), scheduler.GetAgentName(), "", spec)
+		}
+	}
+	return builder.items
+}
+
+type composeDisplayChangeBuilder struct {
+	items   []composeDisplayChangeOutput
+	seenKey map[string]int
+}
+
+func newComposeDisplayChangeBuilder() *composeDisplayChangeBuilder {
+	return &composeDisplayChangeBuilder{
+		seenKey: make(map[string]int),
+	}
+}
+
+func (b *composeDisplayChangeBuilder) add(change composeDisplayChangeOutput) {
+	if change.ResourceType == "" || change.ResourceType == "project_revision" {
+		return
+	}
+	key := composeDisplayChangeKey(change)
+	if index, ok := b.seenKey[key]; ok {
+		b.items[index] = mergeComposeDisplayChange(b.items[index], change)
+		return
+	}
+	b.seenKey[key] = len(b.items)
+	b.items = append(b.items, change)
+}
+
+func (b *composeDisplayChangeBuilder) addProjectChange(change *agentcomposev2.ProjectChange, spec *compose.NormalizedProjectSpec) {
+	resourceType := composeDisplayResourceType(change.GetResourceType())
+	if resourceType == "trigger" {
+		b.addTriggerChanges(
+			projectChangeActionText(change.GetAction()),
+			shortOpaqueID(change.GetResourceId()),
+			change.GetName(),
+			change.GetMessage(),
+			spec,
+		)
+		return
+	}
+	b.add(composeDisplayChangeOutput{
+		Action:       projectChangeActionText(change.GetAction()),
+		ResourceType: resourceType,
+		ID:           shortOpaqueID(change.GetResourceId()),
+		Name:         change.GetName(),
+		Message:      change.GetMessage(),
+	})
+}
+
+func (b *composeDisplayChangeBuilder) addTriggerChanges(action, id, agentName, message string, spec *compose.NormalizedProjectSpec) {
+	triggerNames := composeTriggerNamesForAgent(spec, agentName)
+	if len(triggerNames) == 0 {
+		b.add(composeDisplayChangeOutput{
+			Action:       action,
+			ResourceType: "trigger",
+			ID:           id,
+			Name:         agentName,
+			Message:      message,
+		})
+		return
+	}
+	for _, triggerName := range triggerNames {
+		b.add(composeDisplayChangeOutput{
+			Action:       action,
+			ResourceType: "trigger",
+			ID:           id,
+			Name:         triggerName,
+			Message:      message,
+		})
+	}
+}
+
+func composeTriggerNamesForAgent(spec *compose.NormalizedProjectSpec, agentName string) []string {
+	if spec == nil {
+		return nil
+	}
+	for _, agent := range spec.Agents {
+		if agent.Name != agentName || agent.Scheduler == nil {
+			continue
+		}
+		names := make([]string, 0, len(agent.Scheduler.Triggers))
+		for _, trigger := range agent.Scheduler.Triggers {
+			if strings.TrimSpace(trigger.Name) == "" {
+				continue
+			}
+			names = append(names, trigger.Name)
+		}
+		return names
+	}
+	return nil
+}
+
+func composeDisplayChangeKey(change composeDisplayChangeOutput) string {
+	if (change.ResourceType == "agent" || change.ResourceType == "trigger") && change.Name != "" {
+		return change.ResourceType + "\x00" + change.Name
+	}
+	identity := change.ID
+	if identity == "" {
+		identity = change.Name
+	}
+	return change.ResourceType + "\x00" + identity
+}
+
+func mergeComposeDisplayChange(existing, next composeDisplayChangeOutput) composeDisplayChangeOutput {
+	if projectChangeActionRank(next.Action) > projectChangeActionRank(existing.Action) {
+		if strings.TrimSpace(next.Message) == "" {
+			next.Message = existing.Message
+		}
+		return next
+	}
+	if existing.Message == "" {
+		existing.Message = next.Message
+	}
+	return existing
+}
+
+func projectChangeActionRank(action string) int {
+	switch action {
+	case "removed":
+		return 4
+	case "updated":
+		return 3
+	case "created":
+		return 2
+	case "unchanged":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func composeDisplayResourceType(resourceType string) string {
+	switch resourceType {
+	case "agent_definition", "project_agent":
+		return "agent"
+	case "project_scheduler":
+		return "trigger"
+	case "loader":
+		return ""
+	default:
+		return resourceType
+	}
 }
 
 func countProjectDownFailedSessionStops(changes []*agentcomposev2.ProjectChange) int {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -943,7 +943,7 @@ func TestIntegrationCLIUpAppliesInlineSchedulerScriptAndPSJSON(t *testing.T) {
 	if firstErr != "" {
 		t.Fatalf("up inline first stderr = %q, want empty", firstErr)
 	}
-	for _, want := range []string{"ID", "NAME", "TYPE", "ACTION", "project_scheduler"} {
+	for _, want := range []string{"ID", "NAME", "TYPE", "ACTION", "trigger"} {
 		if !strings.Contains(firstOut, want) {
 			t.Fatalf("up inline first stdout %q does not contain %q", firstOut, want)
 		}
@@ -1021,9 +1021,14 @@ agents:
 	if runCount != 0 {
 		t.Fatalf("daemon runner called %d times, want 0", runCount)
 	}
-	for _, want := range []string{"ID", "NAME", "TYPE", "ACTION", "created", "project_agent", "project_scheduler"} {
+	for _, want := range []string{"ID", "NAME", "TYPE", "ACTION", "created", "agent", "trigger", "hourly"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("up first stdout %q does not contain %q", stdout, want)
+		}
+	}
+	for _, unwanted := range []string{"project_agent", "agent_definition", "project_scheduler", "loader"} {
+		if strings.Contains(stdout, unwanted) {
+			t.Fatalf("up first stdout %q unexpectedly contains %q", stdout, unwanted)
 		}
 	}
 
@@ -1121,6 +1126,7 @@ agents:
 						return connect.NewResponse(&agentcomposev2.RemoveProjectResponse{
 							Project: project,
 							Changes: []*agentcomposev2.ProjectChange{
+								{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_REMOVED, ResourceType: "project", ResourceId: "project-down", Name: "cli-down-demo", Message: "removed by project down"},
 								{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UPDATED, ResourceType: "project_scheduler", ResourceId: "scheduler-reviewer", Name: "reviewer", Message: "disabled by project down"},
 								{Action: agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UPDATED, ResourceType: "session", ResourceId: "session-1", Name: "reviewer run", Message: "stopped by project down"},
 							},
@@ -1136,9 +1142,14 @@ agents:
 		if exitCode != 0 || stderr != "" {
 			t.Fatalf("down first code/stderr = %d / %q", exitCode, stderr)
 		}
-		for _, want := range []string{"Project: cli-down-demo", "Status: down", "updated", "project_scheduler", "session-1", "stopped by project down"} {
+		for _, want := range []string{"ID", "NAME", "TYPE", "ACTION", "MESSAGE", "project-down", "cli-down-demo", "removed", "trigger", "hourly", "session-1", "stopped by project down"} {
 			if !strings.Contains(stdout, want) {
 				t.Fatalf("down first stdout %q does not contain %q", stdout, want)
+			}
+		}
+		for _, unwanted := range []string{"Project:", "Status:", "Failed sandbox stops:", "project_scheduler", "loader"} {
+			if strings.Contains(stdout, unwanted) {
+				t.Fatalf("down first stdout %q unexpectedly contains %q", stdout, unwanted)
 			}
 		}
 
@@ -1146,7 +1157,7 @@ agents:
 		if repeatedCode != 0 || repeatedErr != "" {
 			t.Fatalf("down repeated code/stderr = %d / %q", repeatedCode, repeatedErr)
 		}
-		for _, want := range []string{"Project: cli-down-demo", "Status: unchanged", "Failed sandbox stops: 0"} {
+		for _, want := range []string{"ID", "NAME", "TYPE", "ACTION", "project-down", "cli-down-demo", "project", "unchanged"} {
 			if !strings.Contains(repeatedOut, want) {
 				t.Fatalf("down repeated stdout %q does not contain %q", repeatedOut, want)
 			}
@@ -1225,7 +1236,7 @@ agents:
 		if !strings.Contains(stderr, "completed with 1 sandbox stop failure") {
 			t.Fatalf("down partial stderr = %q", stderr)
 		}
-		for _, want := range []string{"Status: partial-failure", "Failed sandbox stops: 1", "session-failed", "forced stop failure"} {
+		for _, want := range []string{"ID", "NAME", "TYPE", "ACTION", "MESSAGE", "session-fail", "forced stop failure"} {
 			if !strings.Contains(stdout, want) {
 				t.Fatalf("down partial stdout %q does not contain %q", stdout, want)
 			}
@@ -6004,7 +6015,7 @@ func TestCLIOutputHelpersCoverEdgeBranches(t *testing.T) {
 		t.Fatalf("composeUpOutputFromResponse = %#v", output)
 	}
 	var text bytes.Buffer
-	if err := writeComposeUpText(&text, applyResp); err != nil {
+	if err := writeComposeUpText(&text, composeDisplayChangesFromProjectChanges(applyResp.GetChanges(), nil)); err != nil {
 		t.Fatalf("writeComposeUpText returned error: %v", err)
 	}
 	if !strings.Contains(text.String(), "ACTION") || !strings.Contains(text.String(), "reviewer") {
@@ -6026,10 +6037,10 @@ func TestCLIOutputHelpersCoverEdgeBranches(t *testing.T) {
 		t.Fatalf("composeDownOutputFromResponse = %#v", down)
 	}
 	text.Reset()
-	if err := writeComposeDownText(&text, down); err != nil {
+	if err := writeComposeDownText(&text, composeDownDisplayChanges(removeResp, nil)); err != nil {
 		t.Fatalf("writeComposeDownText returned error: %v", err)
 	}
-	if !strings.Contains(text.String(), "partial-failure") || !strings.Contains(text.String(), "stop failed") {
+	if !strings.Contains(text.String(), "MESSAGE") || !strings.Contains(text.String(), "stop failed") {
 		t.Fatalf("compose down text = %q", text.String())
 	}
 


### PR DESCRIPTION
## Summary

  - Make `agent-compose up` and `down` text output use the same table shape: `ID NAME TYPE ACTION`, with `MESSAGE` only when needed.
  - Simplify user-facing resource rows by hiding loader internals, collapsing `project_agent`/`agent_definition` into `agent`, and showing schedulers as
  `trigger`.
  - Use compose trigger names from YAML for trigger rows, so output shows names like `run-once-after-15-seconds`.
  - Keep JSON output detailed for full raw change information.

  ## Testing

  - `go test ./cmd/agent-compose`
  - `task build`

  ## Checklist

  - [ ] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.