### PR TITLE
feat(yml-global-workspaces): support top-level workspaces in compose yaml

### DIFF
--- a/cmd/agent-compose/e2e_docker_scheduler_test.go
+++ b/cmd/agent-compose/e2e_docker_scheduler_test.go
@@ -69,6 +69,10 @@ func TestE2EDockerSchedulerScriptHelloWorldFlow(t *testing.T) {
 	t.Setenv("AGENT_COMPOSE_SOCKET", socketPath)
 	composePath := writeComposeFile(t, filepath.Join(root, "project"), fmt.Sprintf(`
 name: e2e-docker-script
+workspaces:
+  default:
+    provider: local
+    path: .
 agents:
   hello:
     provider: codex

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -562,6 +562,10 @@ func testStatusCommandReportsUnreadableDaemon(t *testing.T) {
 func TestConfigCommandPrintsNormalizedYAMLWithoutStartingDaemon(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "review-project")
 	writeComposeFile(t, dir, `
+workspaces:
+  default:
+    provider: local
+    path: .
 variables:
   API_KEY:
     value: ${API_KEY}
@@ -606,6 +610,10 @@ variables:
   TOKEN:
     value: ${TOKEN}
     secret: true
+workspaces:
+  default:
+    provider: local
+    path: .
 agents:
   reviewer:
     provider: codex
@@ -907,6 +915,14 @@ func TestIntegrationCLIUpAppliesProjectFirstRepeatedModifiedAndJSON(t *testing.T
 	testCLIUpAppliesProjectFirstRepeatedModifiedAndJSON(t)
 }
 
+func TestIntegrationCLIWorkspaceRegistryConfigAndApply(t *testing.T) {
+	testCLIWorkspaceRegistryConfigAndApply(t)
+}
+
+func TestE2ECLIWorkspaceRegistryConfigAndApply(t *testing.T) {
+	testCLIWorkspaceRegistryConfigAndApply(t)
+}
+
 func TestIntegrationCLIUpAppliesInlineSchedulerScriptAndPSJSON(t *testing.T) {
 	composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "cli-inline-project"), inlineSchedulerComposeYAML("cli-inline-demo", 60000))
 	configOut, configErr, configRunCount, err := executeCommand("config", "--file", composePath)
@@ -1052,6 +1068,10 @@ agents:
 
 	if err := os.WriteFile(composePath, []byte(`
 name: cli-up-demo
+workspaces:
+  default:
+    provider: local
+    path: .
 agents:
   reviewer:
     provider: codex
@@ -1083,6 +1103,179 @@ agents:
 	}
 	assertComposeUpChange(t, changed.Changes, "updated", "project_agent", "reviewer")
 	assertComposeUpChange(t, changed.Changes, "updated", "agent_definition", "reviewer")
+}
+
+func testCLIWorkspaceRegistryConfigAndApply(t *testing.T) {
+	t.Helper()
+	socketPath := shortUnixSocketPath(t)
+	app, cancel := newTestDaemonAppWithSocketAndTCP(t, socketPath, "", nil)
+	defer cancel()
+	runCtx, stop := context.WithCancel(context.Background())
+	errCh := runDaemonAppAsync(app, runCtx)
+	t.Cleanup(func() {
+		stop()
+		waitForDaemonExit(t, errCh)
+	})
+	waitForHTTPStatus(t, newUnixHTTPClient(socketPath), "http://agent-compose/api/version", http.StatusOK)
+	t.Setenv("AGENT_COMPOSE_SOCKET", socketPath)
+	t.Setenv("AGENT_COMPOSE_HOST", "")
+
+	t.Run("single global workspace becomes default", func(t *testing.T) {
+		composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "workspace-default"), `
+name: workspace-default
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+agents:
+  reviewer:
+    provider: codex
+    image: guest:v1
+    driver:
+      boxlite: {}
+`)
+
+		stdout, stderr, _, exitCode := executeCLICommand("config", "--file", composePath, "--json")
+		if exitCode != 0 || stderr != "" {
+			t.Fatalf("config code/stderr = %d / %q", exitCode, stderr)
+		}
+		var decoded struct {
+			Workspaces []struct {
+				Key      string `json:"key"`
+				Provider string `json:"provider"`
+				Path     string `json:"path"`
+			} `json:"workspaces"`
+			Agents []struct {
+				Name      string `json:"name"`
+				Workspace struct {
+					Provider string `json:"provider"`
+					Path     string `json:"path"`
+				} `json:"workspace"`
+			} `json:"agents"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+			t.Fatalf("config json decode failed: %v\n%s", err, stdout)
+		}
+		if len(decoded.Workspaces) != 1 || decoded.Workspaces[0].Key != "repo-root" || decoded.Workspaces[0].Provider != "local" {
+			t.Fatalf("decoded workspaces = %#v", decoded.Workspaces)
+		}
+		if len(decoded.Agents) != 1 || decoded.Agents[0].Workspace.Provider != "local" || decoded.Agents[0].Workspace.Path != "." {
+			t.Fatalf("decoded agents = %#v", decoded.Agents)
+		}
+
+		upOut, upErr, _, upCode := executeCLICommand("up", "--file", composePath, "--json")
+		if upCode != 0 || upErr != "" {
+			t.Fatalf("up code/stderr = %d / %q", upCode, upErr)
+		}
+		up := decodeComposeUpOutput(t, upOut)
+		if up.Project.Name != "workspace-default" || !up.Applied {
+			t.Fatalf("up output = %#v", up)
+		}
+	})
+
+	t.Run("agent workspace name resolves global reference", func(t *testing.T) {
+		composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "workspace-reference"), `
+name: workspace-reference
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+  docs-repo:
+    provider: git
+    url: https://example.test/docs.git
+    path: docs
+agents:
+  reviewer:
+    provider: codex
+    image: guest:v1
+    driver:
+      boxlite: {}
+    workspace:
+      name: repo-root
+`)
+
+		stdout, stderr, _, exitCode := executeCLICommand("config", "--file", composePath, "--json")
+		if exitCode != 0 || stderr != "" {
+			t.Fatalf("config code/stderr = %d / %q", exitCode, stderr)
+		}
+		var decoded struct {
+			Workspaces []struct {
+				Key string `json:"key"`
+			} `json:"workspaces"`
+			Agents []struct {
+				Workspace struct {
+					Provider string `json:"provider"`
+					Path     string `json:"path"`
+					Name     string `json:"name"`
+				} `json:"workspace"`
+			} `json:"agents"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+			t.Fatalf("config json decode failed: %v\n%s", err, stdout)
+		}
+		if len(decoded.Workspaces) != 2 || decoded.Workspaces[0].Key != "docs-repo" || decoded.Workspaces[1].Key != "repo-root" {
+			t.Fatalf("decoded workspaces = %#v", decoded.Workspaces)
+		}
+		if len(decoded.Agents) != 1 || decoded.Agents[0].Workspace.Provider != "local" || decoded.Agents[0].Workspace.Path != "." || decoded.Agents[0].Workspace.Name != "" {
+			t.Fatalf("decoded agents = %#v", decoded.Agents)
+		}
+
+		upOut, upErr, _, upCode := executeCLICommand("up", "--file", composePath, "--json")
+		if upCode != 0 || upErr != "" {
+			t.Fatalf("up code/stderr = %d / %q", upCode, upErr)
+		}
+		up := decodeComposeUpOutput(t, upOut)
+		if up.Project.Name != "workspace-reference" || !up.Applied {
+			t.Fatalf("up output = %#v", up)
+		}
+	})
+
+	t.Run("multiple globals without agent workspace fails", func(t *testing.T) {
+		composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "workspace-ambiguous"), `
+name: workspace-ambiguous
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+  docs-repo:
+    provider: git
+    url: https://example.test/docs.git
+agents:
+  reviewer:
+    provider: codex
+`)
+
+		_, stderr, _, exitCode := executeCLICommand("config", "--file", composePath, "--json")
+		if exitCode == 0 {
+			t.Fatalf("expected config to fail")
+		}
+		if !strings.Contains(stderr, "project workspaces has multiple entries") {
+			t.Fatalf("stderr = %q", stderr)
+		}
+	})
+
+	t.Run("missing named workspace fails", func(t *testing.T) {
+		composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "workspace-missing-ref"), `
+name: workspace-missing-ref
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+agents:
+  reviewer:
+    provider: codex
+    workspace:
+      name: missing
+`)
+
+		_, stderr, _, exitCode := executeCLICommand("config", "--file", composePath, "--json")
+		if exitCode == 0 {
+			t.Fatalf("expected config to fail")
+		}
+		if !strings.Contains(stderr, `workspace "missing" is not defined`) {
+			t.Fatalf("stderr = %q", stderr)
+		}
+	})
 }
 
 func TestCLIDownFirstRepeatedPartialAndJSON(t *testing.T) {
@@ -7732,6 +7925,10 @@ func writeComposeFileNamed(t *testing.T, dir string, name string, content string
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("create compose dir: %v", err)
+	}
+	trimmed := strings.TrimSpace(content)
+	if strings.HasPrefix(name, "agent-compose.") && !strings.Contains(trimmed, "\nworkspaces:") && !strings.HasPrefix(trimmed, "workspaces:") {
+		content = "workspaces:\n  default:\n    provider: local\n    path: .\n" + content
 	}
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {

--- a/pkg/agentcompose/api/coverage_shape_workflows_test.go
+++ b/pkg/agentcompose/api/coverage_shape_workflows_test.go
@@ -201,10 +201,10 @@ func TestAPIMappingCoverageWorkflows(t *testing.T) {
 		t.Fatalf("DryRunProjectChanges = %#v", dryRun)
 	}
 	normalizedSpec := &compose.NormalizedProjectSpec{
-		Name:      "Project",
-		Variables: map[string]compose.EnvVarSpec{"B": {Value: "2"}, "A": {Value: "1", Secret: true}},
-		Workspace: &compose.WorkspaceSpec{Provider: "git", URL: "https://example.test/repo.git", Branch: "main", Path: "src"},
-		Network:   &compose.NetworkSpec{Mode: "host"},
+		Name:       "Project",
+		Variables:  map[string]compose.EnvVarSpec{"B": {Value: "2"}, "A": {Value: "1", Secret: true}},
+		Workspaces: map[string]compose.WorkspaceSpec{"repo": {Name: "repo", Provider: "git", URL: "https://example.test/repo.git", Branch: "main", Path: "src"}},
+		Network:    &compose.NetworkSpec{Mode: "host"},
 		Agents: []compose.NormalizedAgentSpec{{
 			Name: "worker", Provider: "codex", Model: "gpt", SystemPrompt: "system", Image: "guest:latest", CapsetIDs: []string{"dev"},
 			Build: &compose.NormalizedBuildSpec{

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -145,12 +145,31 @@ func ProjectSpecToProto(spec *compose.NormalizedProjectSpec) *agentcomposev2.Pro
 		return nil
 	}
 	return &agentcomposev2.ProjectSpec{
-		Name:      spec.Name,
-		Variables: EnvVarSpecsToProto(spec.Variables),
-		Agents:    AgentSpecsToProto(spec.Agents),
-		Network:   NetworkSpecToProto(spec.Network),
-		Volumes:   ProjectVolumeSpecsToProto(spec.Volumes),
+		Name:       spec.Name,
+		Variables:  EnvVarSpecsToProto(spec.Variables),
+		Workspaces: NamedWorkspaceSpecsToProto(spec.Workspaces),
+		Agents:     AgentSpecsToProto(spec.Agents),
+		Network:    NetworkSpecToProto(spec.Network),
+		Volumes:    ProjectVolumeSpecsToProto(spec.Volumes),
 	}
+}
+
+func NamedWorkspaceSpecsToProto(workspaces map[string]compose.WorkspaceSpec) []*agentcomposev2.NamedWorkspaceSpec {
+	keys := make([]string, 0, len(workspaces))
+	for key := range workspaces {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	items := make([]*agentcomposev2.NamedWorkspaceSpec, 0, len(keys))
+	for _, key := range keys {
+		workspace := workspaces[key]
+		workspace.Name = ""
+		items = append(items, &agentcomposev2.NamedWorkspaceSpec{
+			Name:      key,
+			Workspace: WorkspaceSpecToProto(&workspace),
+		})
+	}
+	return items
 }
 
 func AgentSpecsToProto(agents []compose.NormalizedAgentSpec) []*agentcomposev2.AgentSpec {
@@ -254,6 +273,7 @@ func WorkspaceSpecToProto(workspace *compose.WorkspaceSpec) *agentcomposev2.Work
 		return nil
 	}
 	return &agentcomposev2.WorkspaceSpec{
+		Name:     workspace.Name,
 		Provider: workspace.Provider,
 		Url:      workspace.URL,
 		Branch:   workspace.Branch,
@@ -341,8 +361,10 @@ func ProjectSpecYAMLShape(spec *agentcomposev2.ProjectSpec) (map[string]any, []*
 	} else if len(variables) > 0 {
 		root["variables"] = variables
 	}
-	if workspace := WorkspaceYAMLShape(spec.GetWorkspace()); len(workspace) > 0 {
-		root["workspace"] = workspace
+	if workspaces, issues := NamedWorkspaceYAMLMap(spec.GetWorkspaces()); len(issues) > 0 {
+		return nil, issues
+	} else if len(workspaces) > 0 {
+		root["workspaces"] = workspaces
 	}
 	if agents, issues := AgentYAMLMap(spec.GetAgents()); len(issues) > 0 {
 		return nil, issues
@@ -637,6 +659,9 @@ func WorkspaceYAMLShape(workspace *agentcomposev2.WorkspaceSpec) map[string]any 
 		return nil
 	}
 	raw := map[string]any{}
+	if strings.TrimSpace(workspace.GetName()) != "" {
+		raw["name"] = workspace.GetName()
+	}
 	if strings.TrimSpace(workspace.GetProvider()) != "" {
 		raw["provider"] = workspace.GetProvider()
 	}
@@ -650,6 +675,23 @@ func WorkspaceYAMLShape(workspace *agentcomposev2.WorkspaceSpec) map[string]any 
 		raw["path"] = workspace.GetPath()
 	}
 	return raw
+}
+
+func NamedWorkspaceYAMLMap(workspaces []*agentcomposev2.NamedWorkspaceSpec) (map[string]any, []*agentcomposev2.ProjectValidationIssue) {
+	values := make(map[string]any, len(workspaces))
+	for i, item := range workspaces {
+		name := strings.TrimSpace(item.GetName())
+		if name == "" {
+			return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(fmt.Sprintf("workspaces[%d].name", i), "workspace name is required")}
+		}
+		if _, ok := values[name]; ok {
+			return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(fmt.Sprintf("workspaces[%d].name", i), fmt.Sprintf("duplicate workspace %q", name))}
+		}
+		workspace := WorkspaceYAMLShape(item.GetWorkspace())
+		delete(workspace, "name")
+		values[name] = workspace
+	}
+	return values, nil
 }
 
 func NetworkYAMLShape(network *agentcomposev2.NetworkSpec) map[string]any {

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -147,7 +147,6 @@ func ProjectSpecToProto(spec *compose.NormalizedProjectSpec) *agentcomposev2.Pro
 	return &agentcomposev2.ProjectSpec{
 		Name:      spec.Name,
 		Variables: EnvVarSpecsToProto(spec.Variables),
-		Workspace: WorkspaceSpecToProto(spec.Workspace),
 		Agents:    AgentSpecsToProto(spec.Agents),
 		Network:   NetworkSpecToProto(spec.Network),
 		Volumes:   ProjectVolumeSpecsToProto(spec.Volumes),

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"agent-compose/pkg/compose"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
 func TestProjectSpecToProtoIncludesSchedulerScript(t *testing.T) {
@@ -58,5 +59,64 @@ func TestProjectSpecToProtoIncludesJupyter(t *testing.T) {
 	jupyter := response.GetAgents()[0].GetJupyter()
 	if !jupyter.GetEnabled() || jupyter.GetGuestPort() != 8888 {
 		t.Fatalf("jupyter = %#v, want enabled guest port 8888", jupyter)
+	}
+}
+
+func TestIntegrationProjectSpecToProtoIncludesWorkspaceRegistry(t *testing.T) {
+	spec := &compose.NormalizedProjectSpec{
+		Name: "workspace-registry",
+		Workspaces: map[string]compose.WorkspaceSpec{
+			"docs": {Name: "docs", Provider: "git", URL: "https://example.test/docs.git", Path: "docs"},
+			"repo": {Name: "repo", Provider: "local", Path: "."},
+		},
+		Agents: []compose.NormalizedAgentSpec{{
+			Name:      "reviewer",
+			Workspace: &compose.WorkspaceSpec{Provider: "local", Path: "."},
+			Driver:    &compose.NormalizedDriverSpec{Name: compose.DriverDocker, Docker: &compose.DockerDriverSpec{}},
+		}},
+	}
+
+	response := ProjectSpecToProto(spec)
+	if response == nil || len(response.GetWorkspaces()) != 2 {
+		t.Fatalf("ProjectSpecToProto workspaces = %#v", response)
+	}
+	if response.GetWorkspaces()[0].GetName() != "docs" || response.GetWorkspaces()[0].GetWorkspace().GetProvider() != "git" {
+		t.Fatalf("first workspace = %#v", response.GetWorkspaces()[0])
+	}
+	if response.GetWorkspaces()[1].GetName() != "repo" || response.GetWorkspaces()[1].GetWorkspace().GetName() != "" {
+		t.Fatalf("second workspace = %#v", response.GetWorkspaces()[1])
+	}
+}
+
+func TestIntegrationProjectSpecYAMLShapeIncludesWorkspaceRegistry(t *testing.T) {
+	shape, issues := ProjectSpecYAMLShape(&agentcomposev2.ProjectSpec{
+		Name: "workspace-shape",
+		Workspaces: []*agentcomposev2.NamedWorkspaceSpec{{
+			Name:      "repo",
+			Workspace: &agentcomposev2.WorkspaceSpec{Provider: "local", Path: "."},
+		}},
+		Agents: []*agentcomposev2.AgentSpec{{
+			Name:      "reviewer",
+			Workspace: &agentcomposev2.WorkspaceSpec{Name: "repo"},
+		}},
+	})
+	if len(issues) != 0 {
+		t.Fatalf("ProjectSpecYAMLShape issues = %#v", issues)
+	}
+	workspaces, ok := shape["workspaces"].(map[string]any)
+	if !ok || len(workspaces) != 1 {
+		t.Fatalf("workspaces shape = %#v", shape["workspaces"])
+	}
+	agents, ok := shape["agents"].(map[string]any)
+	if !ok {
+		t.Fatalf("agents shape = %#v", shape["agents"])
+	}
+	reviewer, ok := agents["reviewer"].(map[string]any)
+	if !ok {
+		t.Fatalf("reviewer shape = %#v", agents["reviewer"])
+	}
+	workspace, ok := reviewer["workspace"].(map[string]any)
+	if !ok || workspace["name"] != "repo" {
+		t.Fatalf("reviewer workspace = %#v", reviewer["workspace"])
 	}
 }

--- a/pkg/agentcompose/app/controller_helpers_coverage_test.go
+++ b/pkg/agentcompose/app/controller_helpers_coverage_test.go
@@ -27,6 +27,10 @@ func TestAppProjectControllerHelperCoverage(t *testing.T) {
 	}
 	validSpec := &agentcomposev2.ProjectSpec{
 		Name: "app-project",
+		Workspaces: []*agentcomposev2.NamedWorkspaceSpec{{
+			Name:      "default",
+			Workspace: &agentcomposev2.WorkspaceSpec{Provider: "local", Path: "."},
+		}},
 		Agents: []*agentcomposev2.AgentSpec{{
 			Name:     "worker",
 			Provider: "codex",

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -269,7 +269,9 @@ func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]
 		switch len(globals) {
 		case 1:
 			for _, workspace := range globals {
-				return cloneWorkspaceSpec(&workspace), nil
+				resolved := cloneWorkspaceSpec(&workspace)
+				resolved.Name = ""
+				return resolved, nil
 			}
 		case 0:
 			return nil, &ValidationError{Path: path, Message: "workspace is required when project workspaces is empty"}
@@ -288,7 +290,9 @@ func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]
 		if !ok {
 			return nil, &ValidationError{Path: path + ".name", Message: fmt.Sprintf("workspace %q is not defined", trimmed.Name)}
 		}
-		return cloneWorkspaceSpec(&workspace), nil
+		resolved := cloneWorkspaceSpec(&workspace)
+		resolved.Name = ""
+		return resolved, nil
 	case hasInline:
 		return normalizeInlineWorkspaceSpec(path, trimmed, "")
 	default:

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -31,12 +31,12 @@ type NormalizeOptions struct {
 }
 
 type NormalizedProjectSpec struct {
-	Name      string                          `yaml:"name" json:"name"`
-	Variables map[string]EnvVarSpec           `yaml:"variables,omitempty" json:"variables,omitempty"`
-	Workspace *WorkspaceSpec                  `yaml:"workspace,omitempty" json:"workspace,omitempty"`
-	Volumes   map[string]NormalizedVolumeSpec `yaml:"volumes,omitempty" json:"volumes,omitempty"`
-	Agents    []NormalizedAgentSpec           `yaml:"agents,omitempty" json:"agents,omitempty"`
-	Network   *NetworkSpec                    `yaml:"network,omitempty" json:"network,omitempty"`
+	Name       string                          `yaml:"name" json:"name"`
+	Variables  map[string]EnvVarSpec           `yaml:"variables,omitempty" json:"variables,omitempty"`
+	Workspaces map[string]WorkspaceSpec        `yaml:"workspaces,omitempty" json:"workspaces,omitempty"`
+	Volumes    map[string]NormalizedVolumeSpec `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	Agents     []NormalizedAgentSpec           `yaml:"agents,omitempty" json:"agents,omitempty"`
+	Network    *NetworkSpec                    `yaml:"network,omitempty" json:"network,omitempty"`
 }
 
 type NormalizedAgentSpec struct {
@@ -132,7 +132,6 @@ func Normalize(spec *ProjectSpec, options NormalizeOptions) (*NormalizedProjectS
 	normalized := &NormalizedProjectSpec{
 		Name:      name,
 		Variables: nil,
-		Workspace: cloneWorkspaceSpec(spec.Workspace),
 		Network:   normalizeNetworkDefault(spec.Network),
 	}
 	variables, err := normalizeEnvVarMap("variables", spec.Variables, options)
@@ -140,6 +139,11 @@ func Normalize(spec *ProjectSpec, options NormalizeOptions) (*NormalizedProjectS
 		return nil, err
 	}
 	normalized.Variables = variables
+	workspaces, err := normalizeProjectWorkspaces(spec.Workspaces)
+	if err != nil {
+		return nil, err
+	}
+	normalized.Workspaces = workspaces
 	if err := validateNetworkSpec(normalized.Network); err != nil {
 		return nil, err
 	}
@@ -160,7 +164,7 @@ func Normalize(spec *ProjectSpec, options NormalizeOptions) (*NormalizedProjectS
 			return nil, err
 		}
 		agent := spec.Agents[agentName]
-		normalizedAgent, err := normalizeAgent(agentName, agent, options, normalized.Volumes)
+		normalizedAgent, err := normalizeAgent(agentName, agent, options, normalized.Volumes, normalized.Workspaces)
 		if err != nil {
 			return nil, err
 		}
@@ -182,7 +186,7 @@ func NormalizeFile(path string) (*NormalizedProjectSpec, error) {
 	return normalized, nil
 }
 
-func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, projectVolumes map[string]NormalizedVolumeSpec) (NormalizedAgentSpec, error) {
+func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, projectVolumes map[string]NormalizedVolumeSpec, projectWorkspaces map[string]WorkspaceSpec) (NormalizedAgentSpec, error) {
 	driver, err := normalizeDriverSpec(joinPath("agents", name)+".driver", agent.Driver)
 	if err != nil {
 		return NormalizedAgentSpec{}, err
@@ -211,6 +215,10 @@ func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, proj
 	if err != nil {
 		return NormalizedAgentSpec{}, err
 	}
+	workspace, err := resolveAgentWorkspace(joinPath("agents", name)+".workspace", agent.Workspace, projectWorkspaces)
+	if err != nil {
+		return NormalizedAgentSpec{}, err
+	}
 	return NormalizedAgentSpec{
 		Name:         name,
 		Provider:     strings.TrimSpace(agent.Provider),
@@ -222,10 +230,130 @@ func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, proj
 		Env:          env,
 		CapsetIDs:    normalizeStringList(agent.CapsetIDs),
 		Volumes:      volumes,
-		Workspace:    cloneWorkspaceSpec(agent.Workspace),
+		Workspace:    workspace,
 		Scheduler:    scheduler,
 		Jupyter:      jupyter,
 	}, nil
+}
+
+func normalizeProjectWorkspaces(values map[string]WorkspaceSpec) (map[string]WorkspaceSpec, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	normalized := make(map[string]WorkspaceSpec, len(values))
+	for _, rawKey := range keys {
+		key := strings.TrimSpace(rawKey)
+		if err := validateStableIdentifier(joinPath("workspaces", rawKey), key, "workspace name"); err != nil {
+			return nil, err
+		}
+		if _, exists := normalized[key]; exists {
+			return nil, &ValidationError{Path: joinPath("workspaces", rawKey), Message: fmt.Sprintf("duplicate workspace %q", key)}
+		}
+		item := values[rawKey]
+		workspace, err := normalizeInlineWorkspaceSpec(joinPath("workspaces", key), &item, key)
+		if err != nil {
+			return nil, err
+		}
+		normalized[key] = *workspace
+	}
+	return normalized, nil
+}
+
+func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]WorkspaceSpec) (*WorkspaceSpec, error) {
+	if spec == nil {
+		switch len(globals) {
+		case 1:
+			for _, workspace := range globals {
+				return cloneWorkspaceSpec(&workspace), nil
+			}
+		case 0:
+			return nil, &ValidationError{Path: path, Message: "workspace is required when project workspaces is empty"}
+		default:
+			return nil, &ValidationError{Path: path, Message: "workspace is required when project workspaces has multiple entries"}
+		}
+	}
+	trimmed := cloneWorkspaceSpec(spec)
+	hasName := trimmed.Name != ""
+	hasInline := trimmed.Provider != "" || trimmed.URL != "" || trimmed.Branch != "" || trimmed.Path != ""
+	switch {
+	case hasName && hasInline:
+		return nil, &ValidationError{Path: path, Message: "workspace reference cannot set name together with provider, url, branch, or path"}
+	case hasName:
+		workspace, ok := globals[trimmed.Name]
+		if !ok {
+			return nil, &ValidationError{Path: path + ".name", Message: fmt.Sprintf("workspace %q is not defined", trimmed.Name)}
+		}
+		return cloneWorkspaceSpec(&workspace), nil
+	case hasInline:
+		return normalizeInlineWorkspaceSpec(path, trimmed, "")
+	default:
+		return nil, &ValidationError{Path: path, Message: "workspace is required"}
+	}
+}
+
+func normalizeInlineWorkspaceSpec(path string, spec *WorkspaceSpec, defaultName string) (*WorkspaceSpec, error) {
+	if spec == nil {
+		return nil, &ValidationError{Path: path, Message: "workspace is required"}
+	}
+	workspace := cloneWorkspaceSpec(spec)
+	if workspace.Name != "" {
+		return nil, &ValidationError{Path: path + ".name", Message: "inline workspace cannot set name"}
+	}
+	provider := strings.ToLower(strings.TrimSpace(workspace.Provider))
+	if provider == "" {
+		return nil, &ValidationError{Path: path + ".provider", Message: "workspace provider is required"}
+	}
+	workspace.Provider = provider
+	workspace.Name = defaultName
+	switch provider {
+	case "local":
+		if strings.TrimSpace(workspace.URL) != "" {
+			return nil, &ValidationError{Path: path + ".url", Message: "local workspace does not support url"}
+		}
+		if strings.TrimSpace(workspace.Branch) != "" {
+			return nil, &ValidationError{Path: path + ".branch", Message: "local workspace does not support branch"}
+		}
+		if _, err := cleanComposeLocalWorkspacePath(workspace.Path); err != nil {
+			return nil, &ValidationError{Path: path + ".path", Message: err.Error()}
+		}
+	case "git":
+		if strings.TrimSpace(workspace.URL) == "" {
+			return nil, &ValidationError{Path: path + ".url", Message: "git workspace url is required"}
+		}
+		if strings.TrimSpace(workspace.Path) != "" {
+			cleanPath := filepath.Clean(workspace.Path)
+			if filepath.IsAbs(workspace.Path) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+				return nil, &ValidationError{Path: path + ".path", Message: fmt.Sprintf("git workspace path %q must stay within workspace root", workspace.Path)}
+			}
+			workspace.Path = cleanPath
+		} else {
+			workspace.Path = "."
+		}
+		workspace.URL = strings.TrimSpace(workspace.URL)
+	default:
+		return nil, &ValidationError{Path: path + ".provider", Message: fmt.Sprintf("unsupported workspace provider %q", workspace.Provider)}
+	}
+	return workspace, nil
+}
+
+func cleanComposeLocalWorkspacePath(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("local workspace path is required")
+	}
+	if filepath.IsAbs(trimmed) {
+		return "", fmt.Errorf("local workspace path %q must be relative", trimmed)
+	}
+	clean := filepath.Clean(trimmed)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("local workspace path %q escapes project root", trimmed)
+	}
+	return clean, nil
 }
 
 func normalizeProjectVolumes(values map[string]VolumeSpec) (map[string]NormalizedVolumeSpec, error) {
@@ -689,6 +817,7 @@ func cloneWorkspaceSpec(value *WorkspaceSpec) *WorkspaceSpec {
 		return nil
 	}
 	cloned := *value
+	cloned.Name = strings.TrimSpace(cloned.Name)
 	cloned.Provider = strings.TrimSpace(cloned.Provider)
 	cloned.URL = strings.TrimSpace(cloned.URL)
 	cloned.Branch = strings.TrimSpace(cloned.Branch)

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -799,7 +799,7 @@ agents:
 	if err != nil {
 		t.Fatalf("Normalize returned error: %v", err)
 	}
-	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Provider != "local" || normalized.Agents[0].Workspace.Path != "." || normalized.Agents[0].Workspace.Name != "repo-root" {
+	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Provider != "local" || normalized.Agents[0].Workspace.Path != "." || normalized.Agents[0].Workspace.Name != "" {
 		t.Fatalf("workspace = %#v", normalized.Agents[0].Workspace)
 	}
 }
@@ -820,7 +820,7 @@ agents:
 	if err != nil {
 		t.Fatalf("Normalize returned error: %v", err)
 	}
-	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Name != "repo-root" {
+	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Provider != "local" || normalized.Agents[0].Workspace.Path != "." || normalized.Agents[0].Workspace.Name != "" {
 		t.Fatalf("workspace = %#v", normalized.Agents[0].Workspace)
 	}
 }

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -14,6 +14,10 @@ func TestNormalizeDefaultsProjectNameFromComposeDirectory(t *testing.T) {
 	}
 	path := filepath.Join(dir, "agent-compose.yml")
 	if err := os.WriteFile(path, []byte(`
+workspaces:
+  default:
+    provider: local
+    path: .
 agents:
   reviewer:
     provider: codex
@@ -38,6 +42,10 @@ func TestNormalizeDefaultsProjectNameFromRelativeComposePath(t *testing.T) {
 	}
 	path := filepath.Join(dir, "custom.yml")
 	if err := os.WriteFile(path, []byte(`
+workspaces:
+  default:
+    provider: local
+    path: .
 agents:
   reviewer:
     provider: codex
@@ -102,7 +110,8 @@ agents:
 
 func TestNormalizeSortsAgentsForStableOutput(t *testing.T) {
 	spec := &ProjectSpec{
-		Name: "stable",
+		Name:       "stable",
+		Workspaces: map[string]WorkspaceSpec{"default": {Provider: "local", Path: "."}},
 		Agents: map[string]AgentSpec{
 			"worker":   {Provider: "codex"},
 			"reviewer": {Provider: "codex"},
@@ -230,10 +239,7 @@ agents:
         source: /tmp/data
         target: /host-data
 `)
-	spec, err := Parse(raw)
-	if err != nil {
-		t.Fatalf("Parse returned error: %v", err)
-	}
+	spec := mustParseCompose(t, string(raw))
 	normalized, err := Normalize(spec, NormalizeOptions{})
 	if err != nil {
 		t.Fatalf("Normalize returned error: %v", err)
@@ -258,7 +264,8 @@ agents:
 
 func TestNormalizePreservesValidAgentNames(t *testing.T) {
 	spec := &ProjectSpec{
-		Name: "valid-agents",
+		Name:       "valid-agents",
+		Workspaces: map[string]WorkspaceSpec{"default": {Provider: "local", Path: "."}},
 		Agents: map[string]AgentSpec{
 			"a1":          {Provider: "codex"},
 			"agent_1":     {Provider: "codex"},
@@ -294,7 +301,8 @@ func TestNormalizeRejectsInvalidAgentName(t *testing.T) {
 	for _, name := range tests {
 		t.Run(name, func(t *testing.T) {
 			spec := &ProjectSpec{
-				Name: "invalid-agent",
+				Name:       "invalid-agent",
+				Workspaces: map[string]WorkspaceSpec{"default": {Provider: "local", Path: "."}},
 				Agents: map[string]AgentSpec{
 					name: {Provider: "codex"},
 				},
@@ -515,7 +523,8 @@ func TestNormalizeRejectsInvalidJupyterGuestPort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := &ProjectSpec{
-				Name: "invalid-jupyter",
+				Name:       "invalid-jupyter",
+				Workspaces: map[string]WorkspaceSpec{"default": {Provider: "local", Path: "."}},
 				Agents: map[string]AgentSpec{
 					"reviewer": {
 						Provider: "codex",
@@ -772,11 +781,107 @@ agents:
 	}
 }
 
+func TestNormalizeResolvesAgentWorkspaceReference(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: reference-workspace
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+agents:
+  reviewer:
+    provider: codex
+    workspace:
+      name: repo-root
+`)
+
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Provider != "local" || normalized.Agents[0].Workspace.Path != "." || normalized.Agents[0].Workspace.Name != "repo-root" {
+		t.Fatalf("workspace = %#v", normalized.Agents[0].Workspace)
+	}
+}
+
+func TestNormalizeUsesOnlyGlobalWorkspaceByDefault(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: default-workspace
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+agents:
+  reviewer:
+    provider: codex
+`)
+
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Name != "repo-root" {
+		t.Fatalf("workspace = %#v", normalized.Agents[0].Workspace)
+	}
+}
+
+func TestNormalizeRejectsMixedAgentWorkspaceDefinition(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: mixed-workspace
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+agents:
+  reviewer:
+    provider: codex
+    workspace:
+      name: repo-root
+      provider: local
+      path: .
+`)
+
+	_, err := Normalize(spec, NormalizeOptions{})
+	if err == nil {
+		t.Fatalf("expected Normalize to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "agents.reviewer.workspace") || !strings.Contains(got, "name") {
+		t.Fatalf("error = %q, want mixed workspace error", got)
+	}
+}
+
+func TestNormalizeRejectsAmbiguousDefaultWorkspace(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: ambiguous-workspace
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+  docs-repo:
+    provider: git
+    url: https://example.test/docs.git
+agents:
+  reviewer:
+    provider: codex
+`)
+
+	_, err := Normalize(spec, NormalizeOptions{})
+	if err == nil {
+		t.Fatalf("expected Normalize to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "agents.reviewer.workspace") || !strings.Contains(got, "multiple") {
+		t.Fatalf("error = %q, want ambiguous default workspace error", got)
+	}
+}
+
 func mustParseCompose(t *testing.T, raw string) *ProjectSpec {
 	t.Helper()
 	spec, err := Parse([]byte(raw))
 	if err != nil {
 		t.Fatalf("Parse returned error: %v", err)
+	}
+	if len(spec.Workspaces) == 0 {
+		spec.Workspaces = map[string]WorkspaceSpec{"default": {Provider: "local", Path: "."}}
 	}
 	return spec
 }

--- a/pkg/compose/output.go
+++ b/pkg/compose/output.go
@@ -18,12 +18,21 @@ type orderedEnvVarSpec struct {
 }
 
 type orderedProjectSpec struct {
-	Name      string              `yaml:"name" json:"name"`
-	Variables []orderedEnvVarSpec `yaml:"variables,omitempty" json:"variables,omitempty"`
-	Workspace *WorkspaceSpec      `yaml:"workspace,omitempty" json:"workspace,omitempty"`
-	Volumes   []orderedVolumeSpec `yaml:"volumes,omitempty" json:"volumes,omitempty"`
-	Agents    []orderedAgentSpec  `yaml:"agents,omitempty" json:"agents,omitempty"`
-	Network   *NetworkSpec        `yaml:"network,omitempty" json:"network,omitempty"`
+	Name       string                  `yaml:"name" json:"name"`
+	Variables  []orderedEnvVarSpec     `yaml:"variables,omitempty" json:"variables,omitempty"`
+	Workspaces []orderedNamedWorkspace `yaml:"workspaces,omitempty" json:"workspaces,omitempty"`
+	Volumes    []orderedVolumeSpec     `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	Agents     []orderedAgentSpec      `yaml:"agents,omitempty" json:"agents,omitempty"`
+	Network    *NetworkSpec            `yaml:"network,omitempty" json:"network,omitempty"`
+}
+
+type orderedNamedWorkspace struct {
+	Key      string `yaml:"key" json:"key"`
+	Name     string `yaml:"name,omitempty" json:"name,omitempty"`
+	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
+	URL      string `yaml:"url,omitempty" json:"url,omitempty"`
+	Branch   string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
 type orderedAgentSpec struct {
@@ -101,23 +110,23 @@ func (s *NormalizedProjectSpec) ordered(redactSecrets bool) orderedProjectSpec {
 		return compareString(a.Name, b.Name)
 	})
 	return orderedProjectSpec{
-		Name:      s.Name,
-		Variables: orderedEnvVars(s.Variables, redactSecrets),
-		Workspace: cloneWorkspaceSpec(s.Workspace),
-		Volumes:   orderedVolumes(s.Volumes),
-		Agents:    agents,
-		Network:   cloneNetworkSpecForOutput(s.Network),
+		Name:       s.Name,
+		Variables:  orderedEnvVars(s.Variables, redactSecrets),
+		Workspaces: orderedWorkspaces(s.Workspaces),
+		Volumes:    orderedVolumes(s.Volumes),
+		Agents:     agents,
+		Network:    cloneNetworkSpecForOutput(s.Network),
 	}
 }
 
 func (s *NormalizedProjectSpec) clone(redactSecrets bool) *NormalizedProjectSpec {
 	ordered := s.ordered(redactSecrets)
 	cloned := &NormalizedProjectSpec{
-		Name:      ordered.Name,
-		Variables: envVarMapFromOrdered(ordered.Variables),
-		Workspace: ordered.Workspace,
-		Volumes:   volumeMapFromOrdered(ordered.Volumes),
-		Network:   ordered.Network,
+		Name:       ordered.Name,
+		Variables:  envVarMapFromOrdered(ordered.Variables),
+		Workspaces: workspaceMapFromOrdered(ordered.Workspaces),
+		Volumes:    volumeMapFromOrdered(ordered.Volumes),
+		Network:    ordered.Network,
 	}
 	for _, agent := range ordered.Agents {
 		cloned.Agents = append(cloned.Agents, NormalizedAgentSpec{
@@ -137,6 +146,47 @@ func (s *NormalizedProjectSpec) clone(redactSecrets bool) *NormalizedProjectSpec
 		})
 	}
 	return cloned
+}
+
+func orderedWorkspaces(values map[string]WorkspaceSpec) []orderedNamedWorkspace {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	out := make([]orderedNamedWorkspace, 0, len(keys))
+	for _, key := range keys {
+		value := values[key]
+		out = append(out, orderedNamedWorkspace{
+			Key:      key,
+			Name:     value.Name,
+			Provider: value.Provider,
+			URL:      value.URL,
+			Branch:   value.Branch,
+			Path:     value.Path,
+		})
+	}
+	return out
+}
+
+func workspaceMapFromOrdered(values []orderedNamedWorkspace) map[string]WorkspaceSpec {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]WorkspaceSpec, len(values))
+	for _, value := range values {
+		out[value.Key] = WorkspaceSpec{
+			Name:     value.Name,
+			Provider: value.Provider,
+			URL:      value.URL,
+			Branch:   value.Branch,
+			Path:     value.Path,
+		}
+	}
+	return out
 }
 
 func orderedVolumes(values map[string]NormalizedVolumeSpec) []orderedVolumeSpec {

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -9,12 +9,12 @@ import (
 )
 
 type ProjectSpec struct {
-	Name      string                `yaml:"name,omitempty" json:"name,omitempty"`
-	Variables map[string]EnvVarSpec `yaml:"variables,omitempty" json:"variables,omitempty"`
-	Workspace *WorkspaceSpec        `yaml:"workspace,omitempty" json:"workspace,omitempty"`
-	Volumes   map[string]VolumeSpec `yaml:"volumes,omitempty" json:"volumes,omitempty"`
-	Agents    map[string]AgentSpec  `yaml:"agents,omitempty" json:"agents,omitempty"`
-	Network   *NetworkSpec          `yaml:"network,omitempty" json:"network,omitempty"`
+	Name       string                   `yaml:"name,omitempty" json:"name,omitempty"`
+	Variables  map[string]EnvVarSpec    `yaml:"variables,omitempty" json:"variables,omitempty"`
+	Workspaces map[string]WorkspaceSpec `yaml:"workspaces,omitempty" json:"workspaces,omitempty"`
+	Volumes    map[string]VolumeSpec    `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	Agents     map[string]AgentSpec     `yaml:"agents,omitempty" json:"agents,omitempty"`
+	Network    *NetworkSpec             `yaml:"network,omitempty" json:"network,omitempty"`
 }
 
 type AgentSpec struct {
@@ -88,6 +88,7 @@ type EventTriggerSpec struct {
 }
 
 type WorkspaceSpec struct {
+	Name     string `yaml:"name,omitempty" json:"name,omitempty"`
 	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
 	URL      string `yaml:"url,omitempty" json:"url,omitempty"`
 	Branch   string `yaml:"branch,omitempty" json:"branch,omitempty"`
@@ -285,13 +286,17 @@ type nodeValidator func(node *yaml.Node, path string) error
 
 func validateProjectNode(node *yaml.Node) error {
 	return validateMapping(node, "", map[string]nodeValidator{
-		"name":      validateScalar,
-		"variables": validateEnvVarMap,
-		"workspace": validateWorkspace,
-		"volumes":   validateVolumeMap,
-		"agents":    validateAgentMap,
-		"network":   validateNetwork,
+		"name":       validateScalar,
+		"variables":  validateEnvVarMap,
+		"workspaces": validateWorkspaceMap,
+		"volumes":    validateVolumeMap,
+		"agents":     validateAgentMap,
+		"network":    validateNetwork,
 	})
+}
+
+func validateWorkspaceMap(node *yaml.Node, path string) error {
+	return validateNamedMap(node, path, validateWorkspace)
 }
 
 func validateAgentMap(node *yaml.Node, path string) error {
@@ -442,6 +447,7 @@ func validateEventTrigger(node *yaml.Node, path string) error {
 
 func validateWorkspace(node *yaml.Node, path string) error {
 	return validateMapping(node, path, map[string]nodeValidator{
+		"name":     validateScalar,
 		"provider": validateScalar,
 		"url":      validateScalar,
 		"branch":   validateScalar,

--- a/pkg/compose/spec_test.go
+++ b/pkg/compose/spec_test.go
@@ -36,10 +36,11 @@ variables:
   OPENAI_API_KEY:
     value: ${OPENAI_API_KEY}
     secret: true
-workspace:
-  provider: git
-  url: https://github.com/org/repo.git
-  branch: main
+workspaces:
+  repo:
+    provider: git
+    url: https://github.com/org/repo.git
+    branch: main
 agents:
   reviewer:
     provider: codex
@@ -74,8 +75,8 @@ network:
 	if got := spec.Variables["OPENAI_API_KEY"]; got.Value != "${OPENAI_API_KEY}" || !got.Secret {
 		t.Fatalf("OPENAI_API_KEY = %#v", got)
 	}
-	if spec.Workspace == nil || spec.Workspace.Provider != "git" || spec.Workspace.Branch != "main" {
-		t.Fatalf("workspace = %#v", spec.Workspace)
+	if spec.Workspaces["repo"].Provider != "git" || spec.Workspaces["repo"].Branch != "main" {
+		t.Fatalf("workspaces = %#v", spec.Workspaces)
 	}
 	agent := spec.Agents["reviewer"]
 	if agent.Driver == nil || agent.Driver.Boxlite == nil || agent.Driver.Boxlite.Kernel != "s3://bucket/kernel" {

--- a/pkg/projects/controller_coverage_test.go
+++ b/pkg/projects/controller_coverage_test.go
@@ -20,6 +20,10 @@ func TestControllerValidateApplyDryRunAndResolveWorkflows(t *testing.T) {
 name: coverage-project
 variables:
   SHARED: value
+workspaces:
+  default:
+    provider: local
+    path: .
 agents:
   worker:
     provider: codex

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -137,7 +137,7 @@ func TestRunsPreparationWorkspaceAndStatusWorkflows(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sourceDir, "README.md"), []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	spec := `{"variables":[{"name":"PROJECT_VAR","value":"project"}],"workspace":{"provider":"git","url":"https://example.test/repo.git","branch":"main","path":"."},"agents":[{"name":"worker","workspace":{"provider":"local","path":"."}}]}`
+	spec := `{"variables":[{"name":"PROJECT_VAR","value":"project"}],"agents":[{"name":"worker","workspace":{"provider":"local","path":"."}}]}`
 	store := &fakePreparationStore{
 		project:  domain.ProjectRecord{ID: "project-1", Name: "Project", SourcePath: sourceDir},
 		revision: domain.ProjectRevisionRecord{ProjectID: "project-1", Revision: 1, SpecJSON: spec},
@@ -189,16 +189,16 @@ func TestRunsPreparationWorkspaceAndStatusWorkflows(t *testing.T) {
 	if _, err := projectRunGitWorkspaceConfig(run, &compose.WorkspaceSpec{Provider: "git"}); err == nil {
 		t.Fatalf("expected git workspace url error")
 	}
-	if workspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, nil, nil); err != nil || workspace != nil {
+	if workspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, nil); err != nil || workspace != nil {
 		t.Fatalf("nil workspace = %#v/%v", workspace, err)
 	}
-	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, &compose.WorkspaceSpec{}, nil); err == nil || !strings.Contains(err.Error(), "provider is required") {
+	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, &compose.WorkspaceSpec{}); err == nil || !strings.Contains(err.Error(), "provider is required") {
 		t.Fatalf("missing provider err=%v", err)
 	}
-	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, &compose.WorkspaceSpec{Provider: "s3"}, nil); err == nil || !strings.Contains(err.Error(), "unsupported") {
+	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, &compose.WorkspaceSpec{Provider: "s3"}); err == nil || !strings.Contains(err.Error(), "unsupported") {
 		t.Fatalf("unsupported provider err=%v", err)
 	}
-	localWorkspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, &compose.WorkspaceSpec{Provider: "git", URL: "https://example.test/project.git", Path: "."}, &compose.WorkspaceSpec{Provider: "local", Path: "."})
+	localWorkspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, &compose.WorkspaceSpec{Provider: "local", Path: "."})
 	if err != nil || localWorkspace == nil || localWorkspace.Type != "file" {
 		t.Fatalf("agent local workspace = %#v/%v", localWorkspace, err)
 	}

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -25,7 +25,7 @@ type PreparationStore interface {
 }
 
 type WorkspaceResolver interface {
-	ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, projectWorkspace, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SessionWorkspace, error)
+	ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SessionWorkspace, error)
 }
 
 type Preparation struct {
@@ -92,7 +92,7 @@ func PrepareProjectRun(ctx context.Context, store PreparationStore, resolver Wor
 	if resolver == nil {
 		return prepared, nil
 	}
-	workspaceConfig, workspaceSnapshot, err := resolver.ResolveProjectRunWorkspace(ctx, run, project, ComposeWorkspaceSpecFromV2(spec.GetWorkspace()), ComposeWorkspaceSpecFromV2(agentSpec.GetWorkspace()))
+	workspaceConfig, workspaceSnapshot, err := resolver.ResolveProjectRunWorkspace(ctx, run, project, ComposeWorkspaceSpecFromV2(agentSpec.GetWorkspace()))
 	if err != nil {
 		return Preparation{}, err
 	}
@@ -167,6 +167,7 @@ func ComposeWorkspaceSpecFromV2(workspace *agentcomposev2.WorkspaceSpec) *compos
 		return nil
 	}
 	return &compose.WorkspaceSpec{
+		Name:     workspace.GetName(),
 		Provider: workspace.GetProvider(),
 		URL:      workspace.GetUrl(),
 		Branch:   workspace.GetBranch(),

--- a/pkg/runs/workspace.go
+++ b/pkg/runs/workspace.go
@@ -17,23 +17,20 @@ type projectRunWorkspaceResolver struct {
 	controller *Controller
 }
 
-func (r projectRunWorkspaceResolver) ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, projectWorkspace, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SessionWorkspace, error) {
-	workspace, err := r.controller.prepareProjectRunWorkspace(ctx, run, project, projectWorkspace, agentWorkspace)
+func (r projectRunWorkspaceResolver) ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SessionWorkspace, error) {
+	workspace, err := r.controller.prepareProjectRunWorkspace(ctx, run, project, agentWorkspace)
 	if err != nil || workspace == nil {
 		return workspace, nil, err
 	}
 	return workspace, toSessionWorkspaceSnapshot(*workspace), nil
 }
 
-func (c *Controller) prepareProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, projectWorkspace, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, error) {
+func (c *Controller) prepareProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, error) {
 	_ = ctx
-	workspace := projectWorkspace
-	if agentWorkspace != nil {
-		workspace = agentWorkspace
-	}
-	if workspace == nil {
+	if agentWorkspace == nil {
 		return nil, nil
 	}
+	workspace := agentWorkspace
 	provider := strings.ToLower(strings.TrimSpace(workspace.Provider))
 	switch provider {
 	case "local":

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -2256,10 +2256,10 @@ type ProjectSpec struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Variables     []*EnvVarSpec          `protobuf:"bytes,2,rep,name=variables,proto3" json:"variables,omitempty"`
-	Workspace     *WorkspaceSpec         `protobuf:"bytes,3,opt,name=workspace,proto3" json:"workspace,omitempty"`
 	Agents        []*AgentSpec           `protobuf:"bytes,4,rep,name=agents,proto3" json:"agents,omitempty"`
 	Network       *NetworkSpec           `protobuf:"bytes,5,opt,name=network,proto3" json:"network,omitempty"`
 	Volumes       []*ProjectVolumeSpec   `protobuf:"bytes,6,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	Workspaces    []*NamedWorkspaceSpec  `protobuf:"bytes,7,rep,name=workspaces,proto3" json:"workspaces,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2308,13 +2308,6 @@ func (x *ProjectSpec) GetVariables() []*EnvVarSpec {
 	return nil
 }
 
-func (x *ProjectSpec) GetWorkspace() *WorkspaceSpec {
-	if x != nil {
-		return x.Workspace
-	}
-	return nil
-}
-
 func (x *ProjectSpec) GetAgents() []*AgentSpec {
 	if x != nil {
 		return x.Agents
@@ -2332,6 +2325,65 @@ func (x *ProjectSpec) GetNetwork() *NetworkSpec {
 func (x *ProjectSpec) GetVolumes() []*ProjectVolumeSpec {
 	if x != nil {
 		return x.Volumes
+	}
+	return nil
+}
+
+func (x *ProjectSpec) GetWorkspaces() []*NamedWorkspaceSpec {
+	if x != nil {
+		return x.Workspaces
+	}
+	return nil
+}
+
+type NamedWorkspaceSpec struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Workspace     *WorkspaceSpec         `protobuf:"bytes,2,opt,name=workspace,proto3" json:"workspace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NamedWorkspaceSpec) Reset() {
+	*x = NamedWorkspaceSpec{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NamedWorkspaceSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NamedWorkspaceSpec) ProtoMessage() {}
+
+func (x *NamedWorkspaceSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NamedWorkspaceSpec.ProtoReflect.Descriptor instead.
+func (*NamedWorkspaceSpec) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *NamedWorkspaceSpec) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *NamedWorkspaceSpec) GetWorkspace() *WorkspaceSpec {
+	if x != nil {
+		return x.Workspace
 	}
 	return nil
 }
@@ -2357,7 +2409,7 @@ type AgentSpec struct {
 
 func (x *AgentSpec) Reset() {
 	*x = AgentSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[22]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2369,7 +2421,7 @@ func (x *AgentSpec) String() string {
 func (*AgentSpec) ProtoMessage() {}
 
 func (x *AgentSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[22]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2382,7 +2434,7 @@ func (x *AgentSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentSpec.ProtoReflect.Descriptor instead.
 func (*AgentSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{22}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *AgentSpec) GetName() string {
@@ -2490,7 +2542,7 @@ type ProjectVolumeSpec struct {
 
 func (x *ProjectVolumeSpec) Reset() {
 	*x = ProjectVolumeSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[23]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2502,7 +2554,7 @@ func (x *ProjectVolumeSpec) String() string {
 func (*ProjectVolumeSpec) ProtoMessage() {}
 
 func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[23]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2515,7 +2567,7 @@ func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectVolumeSpec.ProtoReflect.Descriptor instead.
 func (*ProjectVolumeSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{23}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ProjectVolumeSpec) GetKey() string {
@@ -2572,7 +2624,7 @@ type VolumeMountSpec struct {
 
 func (x *VolumeMountSpec) Reset() {
 	*x = VolumeMountSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[24]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2584,7 +2636,7 @@ func (x *VolumeMountSpec) String() string {
 func (*VolumeMountSpec) ProtoMessage() {}
 
 func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[24]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2597,7 +2649,7 @@ func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeMountSpec.ProtoReflect.Descriptor instead.
 func (*VolumeMountSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{24}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *VolumeMountSpec) GetType() string {
@@ -2644,7 +2696,7 @@ type BuildSpec struct {
 
 func (x *BuildSpec) Reset() {
 	*x = BuildSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[25]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2656,7 +2708,7 @@ func (x *BuildSpec) String() string {
 func (*BuildSpec) ProtoMessage() {}
 
 func (x *BuildSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[25]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2669,7 +2721,7 @@ func (x *BuildSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildSpec.ProtoReflect.Descriptor instead.
 func (*BuildSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{25}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *BuildSpec) GetContext() string {
@@ -2739,7 +2791,7 @@ type EnvVarSpec struct {
 
 func (x *EnvVarSpec) Reset() {
 	*x = EnvVarSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[26]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2751,7 +2803,7 @@ func (x *EnvVarSpec) String() string {
 func (*EnvVarSpec) ProtoMessage() {}
 
 func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[26]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2764,7 +2816,7 @@ func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVarSpec.ProtoReflect.Descriptor instead.
 func (*EnvVarSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{26}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *EnvVarSpec) GetName() string {
@@ -2794,13 +2846,14 @@ type WorkspaceSpec struct {
 	Url           string                 `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
 	Branch        string                 `protobuf:"bytes,3,opt,name=branch,proto3" json:"branch,omitempty"`
 	Path          string                 `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`
+	Name          string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WorkspaceSpec) Reset() {
 	*x = WorkspaceSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[27]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2812,7 +2865,7 @@ func (x *WorkspaceSpec) String() string {
 func (*WorkspaceSpec) ProtoMessage() {}
 
 func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[27]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2825,7 +2878,7 @@ func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspaceSpec.ProtoReflect.Descriptor instead.
 func (*WorkspaceSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{27}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *WorkspaceSpec) GetProvider() string {
@@ -2856,6 +2909,13 @@ func (x *WorkspaceSpec) GetPath() string {
 	return ""
 }
 
+func (x *WorkspaceSpec) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 type NetworkSpec struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Mode          string                 `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
@@ -2865,7 +2925,7 @@ type NetworkSpec struct {
 
 func (x *NetworkSpec) Reset() {
 	*x = NetworkSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[28]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2877,7 +2937,7 @@ func (x *NetworkSpec) String() string {
 func (*NetworkSpec) ProtoMessage() {}
 
 func (x *NetworkSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[28]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2890,7 +2950,7 @@ func (x *NetworkSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkSpec.ProtoReflect.Descriptor instead.
 func (*NetworkSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{28}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *NetworkSpec) GetMode() string {
@@ -2911,7 +2971,7 @@ type SchedulerSpec struct {
 
 func (x *SchedulerSpec) Reset() {
 	*x = SchedulerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[29]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2923,7 +2983,7 @@ func (x *SchedulerSpec) String() string {
 func (*SchedulerSpec) ProtoMessage() {}
 
 func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[29]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2936,7 +2996,7 @@ func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerSpec.ProtoReflect.Descriptor instead.
 func (*SchedulerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{29}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SchedulerSpec) GetEnabled() bool {
@@ -2975,7 +3035,7 @@ type TriggerSpec struct {
 
 func (x *TriggerSpec) Reset() {
 	*x = TriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2987,7 +3047,7 @@ func (x *TriggerSpec) String() string {
 func (*TriggerSpec) ProtoMessage() {}
 
 func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3000,7 +3060,7 @@ func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerSpec.ProtoReflect.Descriptor instead.
 func (*TriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{30}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *TriggerSpec) GetName() string {
@@ -3061,7 +3121,7 @@ type EventTriggerSpec struct {
 
 func (x *EventTriggerSpec) Reset() {
 	*x = EventTriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3073,7 +3133,7 @@ func (x *EventTriggerSpec) String() string {
 func (*EventTriggerSpec) ProtoMessage() {}
 
 func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3086,7 +3146,7 @@ func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventTriggerSpec.ProtoReflect.Descriptor instead.
 func (*EventTriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{31}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *EventTriggerSpec) GetTopic() string {
@@ -3108,7 +3168,7 @@ type DriverSpec struct {
 
 func (x *DriverSpec) Reset() {
 	*x = DriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3120,7 +3180,7 @@ func (x *DriverSpec) String() string {
 func (*DriverSpec) ProtoMessage() {}
 
 func (x *DriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3133,7 +3193,7 @@ func (x *DriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DriverSpec.ProtoReflect.Descriptor instead.
 func (*DriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{32}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DriverSpec) GetName() string {
@@ -3174,7 +3234,7 @@ type BoxliteDriverSpec struct {
 
 func (x *BoxliteDriverSpec) Reset() {
 	*x = BoxliteDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3186,7 +3246,7 @@ func (x *BoxliteDriverSpec) String() string {
 func (*BoxliteDriverSpec) ProtoMessage() {}
 
 func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3199,7 +3259,7 @@ func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoxliteDriverSpec.ProtoReflect.Descriptor instead.
 func (*BoxliteDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{33}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *BoxliteDriverSpec) GetKernel() string {
@@ -3225,7 +3285,7 @@ type DockerDriverSpec struct {
 
 func (x *DockerDriverSpec) Reset() {
 	*x = DockerDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3237,7 +3297,7 @@ func (x *DockerDriverSpec) String() string {
 func (*DockerDriverSpec) ProtoMessage() {}
 
 func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3250,7 +3310,7 @@ func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerDriverSpec.ProtoReflect.Descriptor instead.
 func (*DockerDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{34}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DockerDriverSpec) GetHost() string {
@@ -3269,7 +3329,7 @@ type MicrosandboxDriverSpec struct {
 
 func (x *MicrosandboxDriverSpec) Reset() {
 	*x = MicrosandboxDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3281,7 +3341,7 @@ func (x *MicrosandboxDriverSpec) String() string {
 func (*MicrosandboxDriverSpec) ProtoMessage() {}
 
 func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3354,7 @@ func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosandboxDriverSpec.ProtoReflect.Descriptor instead.
 func (*MicrosandboxDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{35}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *MicrosandboxDriverSpec) GetProfile() string {
@@ -3328,7 +3388,7 @@ type RunAgentRequest struct {
 
 func (x *RunAgentRequest) Reset() {
 	*x = RunAgentRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3340,7 +3400,7 @@ func (x *RunAgentRequest) String() string {
 func (*RunAgentRequest) ProtoMessage() {}
 
 func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3353,7 +3413,7 @@ func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentRequest.ProtoReflect.Descriptor instead.
 func (*RunAgentRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{36}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RunAgentRequest) GetProjectId() string {
@@ -3478,7 +3538,7 @@ type RunAgentResponse struct {
 
 func (x *RunAgentResponse) Reset() {
 	*x = RunAgentResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3490,7 +3550,7 @@ func (x *RunAgentResponse) String() string {
 func (*RunAgentResponse) ProtoMessage() {}
 
 func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3503,7 +3563,7 @@ func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{37}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *RunAgentResponse) GetRun() *RunDetail {
@@ -3536,7 +3596,7 @@ type RunAgentStreamResponse struct {
 
 func (x *RunAgentStreamResponse) Reset() {
 	*x = RunAgentStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3548,7 +3608,7 @@ func (x *RunAgentStreamResponse) String() string {
 func (*RunAgentStreamResponse) ProtoMessage() {}
 
 func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3561,7 +3621,7 @@ func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentStreamResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{38}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *RunAgentStreamResponse) GetEventType() RunAgentStreamEventType {
@@ -3633,7 +3693,7 @@ type TranscriptEvent struct {
 
 func (x *TranscriptEvent) Reset() {
 	*x = TranscriptEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3645,7 +3705,7 @@ func (x *TranscriptEvent) String() string {
 func (*TranscriptEvent) ProtoMessage() {}
 
 func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3658,7 +3718,7 @@ func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TranscriptEvent.ProtoReflect.Descriptor instead.
 func (*TranscriptEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{39}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *TranscriptEvent) GetStream() StdioStream {
@@ -3706,7 +3766,7 @@ type GetRunRequest struct {
 
 func (x *GetRunRequest) Reset() {
 	*x = GetRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3718,7 +3778,7 @@ func (x *GetRunRequest) String() string {
 func (*GetRunRequest) ProtoMessage() {}
 
 func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3731,7 +3791,7 @@ func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunRequest.ProtoReflect.Descriptor instead.
 func (*GetRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{40}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetRunRequest) GetRunId() string {
@@ -3757,7 +3817,7 @@ type GetRunResponse struct {
 
 func (x *GetRunResponse) Reset() {
 	*x = GetRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3769,7 +3829,7 @@ func (x *GetRunResponse) String() string {
 func (*GetRunResponse) ProtoMessage() {}
 
 func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3782,7 +3842,7 @@ func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunResponse.ProtoReflect.Descriptor instead.
 func (*GetRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{41}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *GetRunResponse) GetRun() *RunDetail {
@@ -3811,7 +3871,7 @@ type ListRunsRequest struct {
 
 func (x *ListRunsRequest) Reset() {
 	*x = ListRunsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3823,7 +3883,7 @@ func (x *ListRunsRequest) String() string {
 func (*ListRunsRequest) ProtoMessage() {}
 
 func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3836,7 +3896,7 @@ func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ListRunsRequest) GetProjectId() string {
@@ -3925,7 +3985,7 @@ type ListRunsResponse struct {
 
 func (x *ListRunsResponse) Reset() {
 	*x = ListRunsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3937,7 +3997,7 @@ func (x *ListRunsResponse) String() string {
 func (*ListRunsResponse) ProtoMessage() {}
 
 func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3950,7 +4010,7 @@ func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ListRunsResponse) GetRuns() []*RunSummary {
@@ -3973,7 +4033,7 @@ type FollowRunLogsRequest struct {
 
 func (x *FollowRunLogsRequest) Reset() {
 	*x = FollowRunLogsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3985,7 +4045,7 @@ func (x *FollowRunLogsRequest) String() string {
 func (*FollowRunLogsRequest) ProtoMessage() {}
 
 func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4058,7 @@ func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FollowRunLogsRequest.ProtoReflect.Descriptor instead.
 func (*FollowRunLogsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *FollowRunLogsRequest) GetProjectId() string {
@@ -4049,7 +4109,7 @@ type RunLogChunk struct {
 
 func (x *RunLogChunk) Reset() {
 	*x = RunLogChunk{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4061,7 +4121,7 @@ func (x *RunLogChunk) String() string {
 func (*RunLogChunk) ProtoMessage() {}
 
 func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4074,7 +4134,7 @@ func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunLogChunk.ProtoReflect.Descriptor instead.
 func (*RunLogChunk) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *RunLogChunk) GetData() string {
@@ -4122,7 +4182,7 @@ type StopRunRequest struct {
 
 func (x *StopRunRequest) Reset() {
 	*x = StopRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4134,7 +4194,7 @@ func (x *StopRunRequest) String() string {
 func (*StopRunRequest) ProtoMessage() {}
 
 func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4147,7 +4207,7 @@ func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunRequest.ProtoReflect.Descriptor instead.
 func (*StopRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *StopRunRequest) GetRunId() string {
@@ -4174,7 +4234,7 @@ type StopRunResponse struct {
 
 func (x *StopRunResponse) Reset() {
 	*x = StopRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4186,7 +4246,7 @@ func (x *StopRunResponse) String() string {
 func (*StopRunResponse) ProtoMessage() {}
 
 func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4199,7 +4259,7 @@ func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunResponse.ProtoReflect.Descriptor instead.
 func (*StopRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *StopRunResponse) GetRun() *RunDetail {
@@ -4226,7 +4286,7 @@ type RemoveSandboxRequest struct {
 
 func (x *RemoveSandboxRequest) Reset() {
 	*x = RemoveSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4238,7 +4298,7 @@ func (x *RemoveSandboxRequest) String() string {
 func (*RemoveSandboxRequest) ProtoMessage() {}
 
 func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4251,7 +4311,7 @@ func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *RemoveSandboxRequest) GetSandboxId() string {
@@ -4279,7 +4339,7 @@ type RemoveSandboxResponse struct {
 
 func (x *RemoveSandboxResponse) Reset() {
 	*x = RemoveSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4291,7 +4351,7 @@ func (x *RemoveSandboxResponse) String() string {
 func (*RemoveSandboxResponse) ProtoMessage() {}
 
 func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4304,7 +4364,7 @@ func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *RemoveSandboxResponse) GetSandboxId() string {
@@ -4337,7 +4397,7 @@ type GetSandboxStatsRequest struct {
 
 func (x *GetSandboxStatsRequest) Reset() {
 	*x = GetSandboxStatsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4349,7 +4409,7 @@ func (x *GetSandboxStatsRequest) String() string {
 func (*GetSandboxStatsRequest) ProtoMessage() {}
 
 func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4362,7 +4422,7 @@ func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GetSandboxStatsRequest) GetSandboxId() string {
@@ -4381,7 +4441,7 @@ type GetSandboxStatsResponse struct {
 
 func (x *GetSandboxStatsResponse) Reset() {
 	*x = GetSandboxStatsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4393,7 +4453,7 @@ func (x *GetSandboxStatsResponse) String() string {
 func (*GetSandboxStatsResponse) ProtoMessage() {}
 
 func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4406,7 +4466,7 @@ func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GetSandboxStatsResponse) GetStats() *SandboxStats {
@@ -4428,7 +4488,7 @@ type MetricValue struct {
 
 func (x *MetricValue) Reset() {
 	*x = MetricValue{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4440,7 +4500,7 @@ func (x *MetricValue) String() string {
 func (*MetricValue) ProtoMessage() {}
 
 func (x *MetricValue) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4453,7 +4513,7 @@ func (x *MetricValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetricValue.ProtoReflect.Descriptor instead.
 func (*MetricValue) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *MetricValue) GetValue() float64 {
@@ -4504,7 +4564,7 @@ type SandboxStats struct {
 
 func (x *SandboxStats) Reset() {
 	*x = SandboxStats{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4516,7 +4576,7 @@ func (x *SandboxStats) String() string {
 func (*SandboxStats) ProtoMessage() {}
 
 func (x *SandboxStats) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4529,7 +4589,7 @@ func (x *SandboxStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStats.ProtoReflect.Descriptor instead.
 func (*SandboxStats) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *SandboxStats) GetSandboxId() string {
@@ -4646,7 +4706,7 @@ type RunSummary struct {
 
 func (x *RunSummary) Reset() {
 	*x = RunSummary{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4658,7 +4718,7 @@ func (x *RunSummary) String() string {
 func (*RunSummary) ProtoMessage() {}
 
 func (x *RunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4671,7 +4731,7 @@ func (x *RunSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSummary.ProtoReflect.Descriptor instead.
 func (*RunSummary) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *RunSummary) GetRunId() string {
@@ -4846,7 +4906,7 @@ type RunDetail struct {
 
 func (x *RunDetail) Reset() {
 	*x = RunDetail{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4858,7 +4918,7 @@ func (x *RunDetail) String() string {
 func (*RunDetail) ProtoMessage() {}
 
 func (x *RunDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4871,7 +4931,7 @@ func (x *RunDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunDetail.ProtoReflect.Descriptor instead.
 func (*RunDetail) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *RunDetail) GetSummary() *RunSummary {
@@ -4963,7 +5023,7 @@ type ExecRequest struct {
 
 func (x *ExecRequest) Reset() {
 	*x = ExecRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4975,7 +5035,7 @@ func (x *ExecRequest) String() string {
 func (*ExecRequest) ProtoMessage() {}
 
 func (x *ExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4988,7 +5048,7 @@ func (x *ExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecRequest.ProtoReflect.Descriptor instead.
 func (*ExecRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ExecRequest) GetTarget() isExecRequest_Target {
@@ -5093,7 +5153,7 @@ type ExecSessionSelector struct {
 
 func (x *ExecSessionSelector) Reset() {
 	*x = ExecSessionSelector{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5105,7 +5165,7 @@ func (x *ExecSessionSelector) String() string {
 func (*ExecSessionSelector) ProtoMessage() {}
 
 func (x *ExecSessionSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5118,7 +5178,7 @@ func (x *ExecSessionSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSessionSelector.ProtoReflect.Descriptor instead.
 func (*ExecSessionSelector) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ExecSessionSelector) GetProjectId() string {
@@ -5152,7 +5212,7 @@ type ExecCommand struct {
 
 func (x *ExecCommand) Reset() {
 	*x = ExecCommand{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5164,7 +5224,7 @@ func (x *ExecCommand) String() string {
 func (*ExecCommand) ProtoMessage() {}
 
 func (x *ExecCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5177,7 +5237,7 @@ func (x *ExecCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecCommand.ProtoReflect.Descriptor instead.
 func (*ExecCommand) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ExecCommand) GetCommand() string {
@@ -5203,7 +5263,7 @@ type ExecResponse struct {
 
 func (x *ExecResponse) Reset() {
 	*x = ExecResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5215,7 +5275,7 @@ func (x *ExecResponse) String() string {
 func (*ExecResponse) ProtoMessage() {}
 
 func (x *ExecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5228,7 +5288,7 @@ func (x *ExecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResponse.ProtoReflect.Descriptor instead.
 func (*ExecResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ExecResponse) GetResult() *ExecResult {
@@ -5254,7 +5314,7 @@ type ExecStreamResponse struct {
 
 func (x *ExecStreamResponse) Reset() {
 	*x = ExecStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5266,7 +5326,7 @@ func (x *ExecStreamResponse) String() string {
 func (*ExecStreamResponse) ProtoMessage() {}
 
 func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5279,7 +5339,7 @@ func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecStreamResponse.ProtoReflect.Descriptor instead.
 func (*ExecStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ExecStreamResponse) GetEventType() ExecStreamEventType {
@@ -5360,7 +5420,7 @@ type ExecResult struct {
 
 func (x *ExecResult) Reset() {
 	*x = ExecResult{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5372,7 +5432,7 @@ func (x *ExecResult) String() string {
 func (*ExecResult) ProtoMessage() {}
 
 func (x *ExecResult) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5385,7 +5445,7 @@ func (x *ExecResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResult.ProtoReflect.Descriptor instead.
 func (*ExecResult) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ExecResult) GetExecId() string {
@@ -5500,7 +5560,7 @@ type ListImagesRequest struct {
 
 func (x *ListImagesRequest) Reset() {
 	*x = ListImagesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5512,7 +5572,7 @@ func (x *ListImagesRequest) String() string {
 func (*ListImagesRequest) ProtoMessage() {}
 
 func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5525,7 +5585,7 @@ func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesRequest.ProtoReflect.Descriptor instead.
 func (*ListImagesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListImagesRequest) GetStore() ImageStoreKind {
@@ -5583,7 +5643,7 @@ type ListImagesResponse struct {
 
 func (x *ListImagesResponse) Reset() {
 	*x = ListImagesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5595,7 +5655,7 @@ func (x *ListImagesResponse) String() string {
 func (*ListImagesResponse) ProtoMessage() {}
 
 func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5608,7 +5668,7 @@ func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesResponse.ProtoReflect.Descriptor instead.
 func (*ListImagesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ListImagesResponse) GetImages() []*Image {
@@ -5657,7 +5717,7 @@ type PullImageRequest struct {
 
 func (x *PullImageRequest) Reset() {
 	*x = PullImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5669,7 +5729,7 @@ func (x *PullImageRequest) String() string {
 func (*PullImageRequest) ProtoMessage() {}
 
 func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5682,7 +5742,7 @@ func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageRequest.ProtoReflect.Descriptor instead.
 func (*PullImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *PullImageRequest) GetImageRef() string {
@@ -5719,7 +5779,7 @@ type PullImageResponse struct {
 
 func (x *PullImageResponse) Reset() {
 	*x = PullImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5731,7 +5791,7 @@ func (x *PullImageResponse) String() string {
 func (*PullImageResponse) ProtoMessage() {}
 
 func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5744,7 +5804,7 @@ func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageResponse.ProtoReflect.Descriptor instead.
 func (*PullImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *PullImageResponse) GetImage() *Image {
@@ -5793,7 +5853,7 @@ type InspectImageRequest struct {
 
 func (x *InspectImageRequest) Reset() {
 	*x = InspectImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5805,7 +5865,7 @@ func (x *InspectImageRequest) String() string {
 func (*InspectImageRequest) ProtoMessage() {}
 
 func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5818,7 +5878,7 @@ func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageRequest.ProtoReflect.Descriptor instead.
 func (*InspectImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *InspectImageRequest) GetImageRef() string {
@@ -5852,7 +5912,7 @@ type InspectImageResponse struct {
 
 func (x *InspectImageResponse) Reset() {
 	*x = InspectImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5864,7 +5924,7 @@ func (x *InspectImageResponse) String() string {
 func (*InspectImageResponse) ProtoMessage() {}
 
 func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5877,7 +5937,7 @@ func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageResponse.ProtoReflect.Descriptor instead.
 func (*InspectImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *InspectImageResponse) GetImage() *Image {
@@ -5906,7 +5966,7 @@ type RemoveImageRequest struct {
 
 func (x *RemoveImageRequest) Reset() {
 	*x = RemoveImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5918,7 +5978,7 @@ func (x *RemoveImageRequest) String() string {
 func (*RemoveImageRequest) ProtoMessage() {}
 
 func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5931,7 +5991,7 @@ func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageRequest.ProtoReflect.Descriptor instead.
 func (*RemoveImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *RemoveImageRequest) GetImageRef() string {
@@ -5974,7 +6034,7 @@ type RemoveImageResponse struct {
 
 func (x *RemoveImageResponse) Reset() {
 	*x = RemoveImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5986,7 +6046,7 @@ func (x *RemoveImageResponse) String() string {
 func (*RemoveImageResponse) ProtoMessage() {}
 
 func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5999,7 +6059,7 @@ func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageResponse.ProtoReflect.Descriptor instead.
 func (*RemoveImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *RemoveImageResponse) GetImageRef() string {
@@ -6047,7 +6107,7 @@ type BuildImageRequest struct {
 
 func (x *BuildImageRequest) Reset() {
 	*x = BuildImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6059,7 +6119,7 @@ func (x *BuildImageRequest) String() string {
 func (*BuildImageRequest) ProtoMessage() {}
 
 func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6072,7 +6132,7 @@ func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageRequest.ProtoReflect.Descriptor instead.
 func (*BuildImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *BuildImageRequest) GetContextDir() string {
@@ -6153,7 +6213,7 @@ type BuildImageEvent struct {
 
 func (x *BuildImageEvent) Reset() {
 	*x = BuildImageEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6165,7 +6225,7 @@ func (x *BuildImageEvent) String() string {
 func (*BuildImageEvent) ProtoMessage() {}
 
 func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6178,7 +6238,7 @@ func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageEvent.ProtoReflect.Descriptor instead.
 func (*BuildImageEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *BuildImageEvent) GetStatus() ImageOperationStatus {
@@ -6244,7 +6304,7 @@ type CacheFilter struct {
 
 func (x *CacheFilter) Reset() {
 	*x = CacheFilter{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6256,7 +6316,7 @@ func (x *CacheFilter) String() string {
 func (*CacheFilter) ProtoMessage() {}
 
 func (x *CacheFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6269,7 +6329,7 @@ func (x *CacheFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheFilter.ProtoReflect.Descriptor instead.
 func (*CacheFilter) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *CacheFilter) GetDriver() string {
@@ -6323,7 +6383,7 @@ type ListCachesRequest struct {
 
 func (x *ListCachesRequest) Reset() {
 	*x = ListCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6335,7 +6395,7 @@ func (x *ListCachesRequest) String() string {
 func (*ListCachesRequest) ProtoMessage() {}
 
 func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6348,7 +6408,7 @@ func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesRequest.ProtoReflect.Descriptor instead.
 func (*ListCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListCachesRequest) GetFilter() *CacheFilter {
@@ -6368,7 +6428,7 @@ type ListCachesResponse struct {
 
 func (x *ListCachesResponse) Reset() {
 	*x = ListCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6380,7 +6440,7 @@ func (x *ListCachesResponse) String() string {
 func (*ListCachesResponse) ProtoMessage() {}
 
 func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6393,7 +6453,7 @@ func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesResponse.ProtoReflect.Descriptor instead.
 func (*ListCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ListCachesResponse) GetCaches() []*CacheItem {
@@ -6419,7 +6479,7 @@ type InspectCacheRequest struct {
 
 func (x *InspectCacheRequest) Reset() {
 	*x = InspectCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6431,7 +6491,7 @@ func (x *InspectCacheRequest) String() string {
 func (*InspectCacheRequest) ProtoMessage() {}
 
 func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6444,7 +6504,7 @@ func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheRequest.ProtoReflect.Descriptor instead.
 func (*InspectCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *InspectCacheRequest) GetCacheId() string {
@@ -6464,7 +6524,7 @@ type InspectCacheResponse struct {
 
 func (x *InspectCacheResponse) Reset() {
 	*x = InspectCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6476,7 +6536,7 @@ func (x *InspectCacheResponse) String() string {
 func (*InspectCacheResponse) ProtoMessage() {}
 
 func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6489,7 +6549,7 @@ func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheResponse.ProtoReflect.Descriptor instead.
 func (*InspectCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *InspectCacheResponse) GetCache() *CacheItem {
@@ -6517,7 +6577,7 @@ type PruneCachesRequest struct {
 
 func (x *PruneCachesRequest) Reset() {
 	*x = PruneCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6529,7 +6589,7 @@ func (x *PruneCachesRequest) String() string {
 func (*PruneCachesRequest) ProtoMessage() {}
 
 func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6542,7 +6602,7 @@ func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesRequest.ProtoReflect.Descriptor instead.
 func (*PruneCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *PruneCachesRequest) GetFilter() *CacheFilter {
@@ -6579,7 +6639,7 @@ type PruneCachesResponse struct {
 
 func (x *PruneCachesResponse) Reset() {
 	*x = PruneCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6591,7 +6651,7 @@ func (x *PruneCachesResponse) String() string {
 func (*PruneCachesResponse) ProtoMessage() {}
 
 func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6604,7 +6664,7 @@ func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesResponse.ProtoReflect.Descriptor instead.
 func (*PruneCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *PruneCachesResponse) GetDryRun() bool {
@@ -6652,7 +6712,7 @@ type RemoveCacheRequest struct {
 
 func (x *RemoveCacheRequest) Reset() {
 	*x = RemoveCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6664,7 +6724,7 @@ func (x *RemoveCacheRequest) String() string {
 func (*RemoveCacheRequest) ProtoMessage() {}
 
 func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6677,7 +6737,7 @@ func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *RemoveCacheRequest) GetCacheId() string {
@@ -6707,7 +6767,7 @@ type RemoveCacheResponse struct {
 
 func (x *RemoveCacheResponse) Reset() {
 	*x = RemoveCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6719,7 +6779,7 @@ func (x *RemoveCacheResponse) String() string {
 func (*RemoveCacheResponse) ProtoMessage() {}
 
 func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6732,7 +6792,7 @@ func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheResponse.ProtoReflect.Descriptor instead.
 func (*RemoveCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *RemoveCacheResponse) GetDryRun() bool {
@@ -6796,7 +6856,7 @@ type CacheItem struct {
 
 func (x *CacheItem) Reset() {
 	*x = CacheItem{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6808,7 +6868,7 @@ func (x *CacheItem) String() string {
 func (*CacheItem) ProtoMessage() {}
 
 func (x *CacheItem) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6821,7 +6881,7 @@ func (x *CacheItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheItem.ProtoReflect.Descriptor instead.
 func (*CacheItem) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *CacheItem) GetCacheId() string {
@@ -6964,7 +7024,7 @@ type CacheReference struct {
 
 func (x *CacheReference) Reset() {
 	*x = CacheReference{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6976,7 +7036,7 @@ func (x *CacheReference) String() string {
 func (*CacheReference) ProtoMessage() {}
 
 func (x *CacheReference) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6989,7 +7049,7 @@ func (x *CacheReference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheReference.ProtoReflect.Descriptor instead.
 func (*CacheReference) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *CacheReference) GetType() string {
@@ -7045,7 +7105,7 @@ type ListVolumesRequest struct {
 
 func (x *ListVolumesRequest) Reset() {
 	*x = ListVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7057,7 +7117,7 @@ func (x *ListVolumesRequest) String() string {
 func (*ListVolumesRequest) ProtoMessage() {}
 
 func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7070,7 +7130,7 @@ func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesRequest.ProtoReflect.Descriptor instead.
 func (*ListVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *ListVolumesRequest) GetQuery() string {
@@ -7103,7 +7163,7 @@ type ListVolumesResponse struct {
 
 func (x *ListVolumesResponse) Reset() {
 	*x = ListVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7115,7 +7175,7 @@ func (x *ListVolumesResponse) String() string {
 func (*ListVolumesResponse) ProtoMessage() {}
 
 func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7128,7 +7188,7 @@ func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesResponse.ProtoReflect.Descriptor instead.
 func (*ListVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ListVolumesResponse) GetVolumes() []*Volume {
@@ -7150,7 +7210,7 @@ type CreateVolumeRequest struct {
 
 func (x *CreateVolumeRequest) Reset() {
 	*x = CreateVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7162,7 +7222,7 @@ func (x *CreateVolumeRequest) String() string {
 func (*CreateVolumeRequest) ProtoMessage() {}
 
 func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7175,7 +7235,7 @@ func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeRequest.ProtoReflect.Descriptor instead.
 func (*CreateVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *CreateVolumeRequest) GetName() string {
@@ -7216,7 +7276,7 @@ type CreateVolumeResponse struct {
 
 func (x *CreateVolumeResponse) Reset() {
 	*x = CreateVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7228,7 +7288,7 @@ func (x *CreateVolumeResponse) String() string {
 func (*CreateVolumeResponse) ProtoMessage() {}
 
 func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7241,7 +7301,7 @@ func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeResponse.ProtoReflect.Descriptor instead.
 func (*CreateVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *CreateVolumeResponse) GetVolume() *Volume {
@@ -7267,7 +7327,7 @@ type InspectVolumeRequest struct {
 
 func (x *InspectVolumeRequest) Reset() {
 	*x = InspectVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7279,7 +7339,7 @@ func (x *InspectVolumeRequest) String() string {
 func (*InspectVolumeRequest) ProtoMessage() {}
 
 func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7292,7 +7352,7 @@ func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeRequest.ProtoReflect.Descriptor instead.
 func (*InspectVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *InspectVolumeRequest) GetName() string {
@@ -7311,7 +7371,7 @@ type InspectVolumeResponse struct {
 
 func (x *InspectVolumeResponse) Reset() {
 	*x = InspectVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7323,7 +7383,7 @@ func (x *InspectVolumeResponse) String() string {
 func (*InspectVolumeResponse) ProtoMessage() {}
 
 func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7336,7 +7396,7 @@ func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeResponse.ProtoReflect.Descriptor instead.
 func (*InspectVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *InspectVolumeResponse) GetVolume() *Volume {
@@ -7356,7 +7416,7 @@ type RemoveVolumeRequest struct {
 
 func (x *RemoveVolumeRequest) Reset() {
 	*x = RemoveVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7368,7 +7428,7 @@ func (x *RemoveVolumeRequest) String() string {
 func (*RemoveVolumeRequest) ProtoMessage() {}
 
 func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7381,7 +7441,7 @@ func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *RemoveVolumeRequest) GetName() string {
@@ -7408,7 +7468,7 @@ type RemoveVolumeResponse struct {
 
 func (x *RemoveVolumeResponse) Reset() {
 	*x = RemoveVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7420,7 +7480,7 @@ func (x *RemoveVolumeResponse) String() string {
 func (*RemoveVolumeResponse) ProtoMessage() {}
 
 func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7433,7 +7493,7 @@ func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeResponse.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *RemoveVolumeResponse) GetName() string {
@@ -7462,7 +7522,7 @@ type PruneVolumesRequest struct {
 
 func (x *PruneVolumesRequest) Reset() {
 	*x = PruneVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7474,7 +7534,7 @@ func (x *PruneVolumesRequest) String() string {
 func (*PruneVolumesRequest) ProtoMessage() {}
 
 func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7487,7 +7547,7 @@ func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesRequest.ProtoReflect.Descriptor instead.
 func (*PruneVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *PruneVolumesRequest) GetQuery() string {
@@ -7530,7 +7590,7 @@ type PruneVolumesResponse struct {
 
 func (x *PruneVolumesResponse) Reset() {
 	*x = PruneVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7542,7 +7602,7 @@ func (x *PruneVolumesResponse) String() string {
 func (*PruneVolumesResponse) ProtoMessage() {}
 
 func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7555,7 +7615,7 @@ func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesResponse.ProtoReflect.Descriptor instead.
 func (*PruneVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *PruneVolumesResponse) GetDryRun() bool {
@@ -7602,7 +7662,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7614,7 +7674,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7627,7 +7687,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *Volume) GetName() string {
@@ -7711,7 +7771,7 @@ type Image struct {
 
 func (x *Image) Reset() {
 	*x = Image{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7723,7 +7783,7 @@ func (x *Image) String() string {
 func (*Image) ProtoMessage() {}
 
 func (x *Image) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7736,7 +7796,7 @@ func (x *Image) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Image.ProtoReflect.Descriptor instead.
 func (*Image) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *Image) GetImageId() string {
@@ -7870,7 +7930,7 @@ type ImagePlatform struct {
 
 func (x *ImagePlatform) Reset() {
 	*x = ImagePlatform{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7882,7 +7942,7 @@ func (x *ImagePlatform) String() string {
 func (*ImagePlatform) ProtoMessage() {}
 
 func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7895,7 +7955,7 @@ func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePlatform.ProtoReflect.Descriptor instead.
 func (*ImagePlatform) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ImagePlatform) GetOs() string {
@@ -7938,7 +7998,7 @@ type ImageStoreStatus struct {
 
 func (x *ImageStoreStatus) Reset() {
 	*x = ImageStoreStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7950,7 +8010,7 @@ func (x *ImageStoreStatus) String() string {
 func (*ImageStoreStatus) ProtoMessage() {}
 
 func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7963,7 +8023,7 @@ func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageStoreStatus.ProtoReflect.Descriptor instead.
 func (*ImageStoreStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ImageStoreStatus) GetStore() ImageStoreKind {
@@ -8005,7 +8065,7 @@ type DockerImageStatus struct {
 
 func (x *DockerImageStatus) Reset() {
 	*x = DockerImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8017,7 +8077,7 @@ func (x *DockerImageStatus) String() string {
 func (*DockerImageStatus) ProtoMessage() {}
 
 func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8030,7 +8090,7 @@ func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerImageStatus.ProtoReflect.Descriptor instead.
 func (*DockerImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *DockerImageStatus) GetLocal() bool {
@@ -8068,7 +8128,7 @@ type OCIImageStatus struct {
 
 func (x *OCIImageStatus) Reset() {
 	*x = OCIImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8080,7 +8140,7 @@ func (x *OCIImageStatus) String() string {
 func (*OCIImageStatus) ProtoMessage() {}
 
 func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8093,7 +8153,7 @@ func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OCIImageStatus.ProtoReflect.Descriptor instead.
 func (*OCIImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *OCIImageStatus) GetLayoutCached() bool {
@@ -8151,7 +8211,7 @@ type ImagePullProgress struct {
 
 func (x *ImagePullProgress) Reset() {
 	*x = ImagePullProgress{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8163,7 +8223,7 @@ func (x *ImagePullProgress) String() string {
 func (*ImagePullProgress) ProtoMessage() {}
 
 func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8176,7 +8236,7 @@ func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePullProgress.ProtoReflect.Descriptor instead.
 func (*ImagePullProgress) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ImagePullProgress) GetId() string {
@@ -8224,7 +8284,7 @@ type JupyterSpec struct {
 
 func (x *JupyterSpec) Reset() {
 	*x = JupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8236,7 +8296,7 @@ func (x *JupyterSpec) String() string {
 func (*JupyterSpec) ProtoMessage() {}
 
 func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8249,7 +8309,7 @@ func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JupyterSpec.ProtoReflect.Descriptor instead.
 func (*JupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *JupyterSpec) GetEnabled() bool {
@@ -8277,7 +8337,7 @@ type RunJupyterSpec struct {
 
 func (x *RunJupyterSpec) Reset() {
 	*x = RunJupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8289,7 +8349,7 @@ func (x *RunJupyterSpec) String() string {
 func (*RunJupyterSpec) ProtoMessage() {}
 
 func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8302,7 +8362,7 @@ func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunJupyterSpec.ProtoReflect.Descriptor instead.
 func (*RunJupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *RunJupyterSpec) GetEnabled() bool {
@@ -8335,7 +8395,7 @@ type StartRunRequest struct {
 
 func (x *StartRunRequest) Reset() {
 	*x = StartRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8347,7 +8407,7 @@ func (x *StartRunRequest) String() string {
 func (*StartRunRequest) ProtoMessage() {}
 
 func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8360,7 +8420,7 @@ func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunRequest.ProtoReflect.Descriptor instead.
 func (*StartRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *StartRunRequest) GetRun() *RunAgentRequest {
@@ -8381,7 +8441,7 @@ type StartRunResponse struct {
 
 func (x *StartRunResponse) Reset() {
 	*x = StartRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8393,7 +8453,7 @@ func (x *StartRunResponse) String() string {
 func (*StartRunResponse) ProtoMessage() {}
 
 func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8406,7 +8466,7 @@ func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunResponse.ProtoReflect.Descriptor instead.
 func (*StartRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *StartRunResponse) GetRun() *RunSummary {
@@ -8562,14 +8622,19 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\vresource_id\x18\x03 \x01(\tR\n" +
 	"resourceId\x12\x12\n" +
 	"\x04name\x18\x04 \x01(\tR\x04name\x12\x18\n" +
-	"\amessage\x18\x05 \x01(\tR\amessage\"\xc4\x02\n" +
+	"\amessage\x18\x05 \x01(\tR\amessage\"\xdc\x02\n" +
 	"\vProjectSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
-	"\tvariables\x18\x02 \x03(\v2\x1b.agentcompose.v2.EnvVarSpecR\tvariables\x12<\n" +
-	"\tworkspace\x18\x03 \x01(\v2\x1e.agentcompose.v2.WorkspaceSpecR\tworkspace\x122\n" +
+	"\tvariables\x18\x02 \x03(\v2\x1b.agentcompose.v2.EnvVarSpecR\tvariables\x122\n" +
 	"\x06agents\x18\x04 \x03(\v2\x1a.agentcompose.v2.AgentSpecR\x06agents\x126\n" +
 	"\anetwork\x18\x05 \x01(\v2\x1c.agentcompose.v2.NetworkSpecR\anetwork\x12<\n" +
-	"\avolumes\x18\x06 \x03(\v2\".agentcompose.v2.ProjectVolumeSpecR\avolumes\"\xb1\x04\n" +
+	"\avolumes\x18\x06 \x03(\v2\".agentcompose.v2.ProjectVolumeSpecR\avolumes\x12C\n" +
+	"\n" +
+	"workspaces\x18\a \x03(\v2#.agentcompose.v2.NamedWorkspaceSpecR\n" +
+	"workspacesJ\x04\b\x03\x10\x04R\tworkspace\"f\n" +
+	"\x12NamedWorkspaceSpec\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12<\n" +
+	"\tworkspace\x18\x02 \x01(\v2\x1e.agentcompose.v2.WorkspaceSpecR\tworkspace\"\xb1\x04\n" +
 	"\tAgentSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\bprovider\x18\x02 \x01(\tR\bprovider\x12\x14\n" +
@@ -8622,12 +8687,13 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"EnvVarSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\x12\x16\n" +
-	"\x06secret\x18\x03 \x01(\bR\x06secret\"i\n" +
+	"\x06secret\x18\x03 \x01(\bR\x06secret\"}\n" +
 	"\rWorkspaceSpec\x12\x1a\n" +
 	"\bprovider\x18\x01 \x01(\tR\bprovider\x12\x10\n" +
 	"\x03url\x18\x02 \x01(\tR\x03url\x12\x16\n" +
 	"\x06branch\x18\x03 \x01(\tR\x06branch\x12\x12\n" +
-	"\x04path\x18\x04 \x01(\tR\x04path\"!\n" +
+	"\x04path\x18\x04 \x01(\tR\x04path\x12\x12\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\"!\n" +
 	"\vNetworkSpec\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\"{\n" +
 	"\rSchedulerSpec\x12\x18\n" +
@@ -9294,7 +9360,7 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 }
 
 var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 15)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 113)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 114)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),  // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),        // 1: agentcompose.v2.ProjectChangeAction
@@ -9333,97 +9399,98 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*ProjectValidationIssue)(nil),  // 34: agentcompose.v2.ProjectValidationIssue
 	(*ProjectChange)(nil),           // 35: agentcompose.v2.ProjectChange
 	(*ProjectSpec)(nil),             // 36: agentcompose.v2.ProjectSpec
-	(*AgentSpec)(nil),               // 37: agentcompose.v2.AgentSpec
-	(*ProjectVolumeSpec)(nil),       // 38: agentcompose.v2.ProjectVolumeSpec
-	(*VolumeMountSpec)(nil),         // 39: agentcompose.v2.VolumeMountSpec
-	(*BuildSpec)(nil),               // 40: agentcompose.v2.BuildSpec
-	(*EnvVarSpec)(nil),              // 41: agentcompose.v2.EnvVarSpec
-	(*WorkspaceSpec)(nil),           // 42: agentcompose.v2.WorkspaceSpec
-	(*NetworkSpec)(nil),             // 43: agentcompose.v2.NetworkSpec
-	(*SchedulerSpec)(nil),           // 44: agentcompose.v2.SchedulerSpec
-	(*TriggerSpec)(nil),             // 45: agentcompose.v2.TriggerSpec
-	(*EventTriggerSpec)(nil),        // 46: agentcompose.v2.EventTriggerSpec
-	(*DriverSpec)(nil),              // 47: agentcompose.v2.DriverSpec
-	(*BoxliteDriverSpec)(nil),       // 48: agentcompose.v2.BoxliteDriverSpec
-	(*DockerDriverSpec)(nil),        // 49: agentcompose.v2.DockerDriverSpec
-	(*MicrosandboxDriverSpec)(nil),  // 50: agentcompose.v2.MicrosandboxDriverSpec
-	(*RunAgentRequest)(nil),         // 51: agentcompose.v2.RunAgentRequest
-	(*RunAgentResponse)(nil),        // 52: agentcompose.v2.RunAgentResponse
-	(*RunAgentStreamResponse)(nil),  // 53: agentcompose.v2.RunAgentStreamResponse
-	(*TranscriptEvent)(nil),         // 54: agentcompose.v2.TranscriptEvent
-	(*GetRunRequest)(nil),           // 55: agentcompose.v2.GetRunRequest
-	(*GetRunResponse)(nil),          // 56: agentcompose.v2.GetRunResponse
-	(*ListRunsRequest)(nil),         // 57: agentcompose.v2.ListRunsRequest
-	(*ListRunsResponse)(nil),        // 58: agentcompose.v2.ListRunsResponse
-	(*FollowRunLogsRequest)(nil),    // 59: agentcompose.v2.FollowRunLogsRequest
-	(*RunLogChunk)(nil),             // 60: agentcompose.v2.RunLogChunk
-	(*StopRunRequest)(nil),          // 61: agentcompose.v2.StopRunRequest
-	(*StopRunResponse)(nil),         // 62: agentcompose.v2.StopRunResponse
-	(*RemoveSandboxRequest)(nil),    // 63: agentcompose.v2.RemoveSandboxRequest
-	(*RemoveSandboxResponse)(nil),   // 64: agentcompose.v2.RemoveSandboxResponse
-	(*GetSandboxStatsRequest)(nil),  // 65: agentcompose.v2.GetSandboxStatsRequest
-	(*GetSandboxStatsResponse)(nil), // 66: agentcompose.v2.GetSandboxStatsResponse
-	(*MetricValue)(nil),             // 67: agentcompose.v2.MetricValue
-	(*SandboxStats)(nil),            // 68: agentcompose.v2.SandboxStats
-	(*RunSummary)(nil),              // 69: agentcompose.v2.RunSummary
-	(*RunDetail)(nil),               // 70: agentcompose.v2.RunDetail
-	(*ExecRequest)(nil),             // 71: agentcompose.v2.ExecRequest
-	(*ExecSessionSelector)(nil),     // 72: agentcompose.v2.ExecSessionSelector
-	(*ExecCommand)(nil),             // 73: agentcompose.v2.ExecCommand
-	(*ExecResponse)(nil),            // 74: agentcompose.v2.ExecResponse
-	(*ExecStreamResponse)(nil),      // 75: agentcompose.v2.ExecStreamResponse
-	(*ExecResult)(nil),              // 76: agentcompose.v2.ExecResult
-	(*ListImagesRequest)(nil),       // 77: agentcompose.v2.ListImagesRequest
-	(*ListImagesResponse)(nil),      // 78: agentcompose.v2.ListImagesResponse
-	(*PullImageRequest)(nil),        // 79: agentcompose.v2.PullImageRequest
-	(*PullImageResponse)(nil),       // 80: agentcompose.v2.PullImageResponse
-	(*InspectImageRequest)(nil),     // 81: agentcompose.v2.InspectImageRequest
-	(*InspectImageResponse)(nil),    // 82: agentcompose.v2.InspectImageResponse
-	(*RemoveImageRequest)(nil),      // 83: agentcompose.v2.RemoveImageRequest
-	(*RemoveImageResponse)(nil),     // 84: agentcompose.v2.RemoveImageResponse
-	(*BuildImageRequest)(nil),       // 85: agentcompose.v2.BuildImageRequest
-	(*BuildImageEvent)(nil),         // 86: agentcompose.v2.BuildImageEvent
-	(*CacheFilter)(nil),             // 87: agentcompose.v2.CacheFilter
-	(*ListCachesRequest)(nil),       // 88: agentcompose.v2.ListCachesRequest
-	(*ListCachesResponse)(nil),      // 89: agentcompose.v2.ListCachesResponse
-	(*InspectCacheRequest)(nil),     // 90: agentcompose.v2.InspectCacheRequest
-	(*InspectCacheResponse)(nil),    // 91: agentcompose.v2.InspectCacheResponse
-	(*PruneCachesRequest)(nil),      // 92: agentcompose.v2.PruneCachesRequest
-	(*PruneCachesResponse)(nil),     // 93: agentcompose.v2.PruneCachesResponse
-	(*RemoveCacheRequest)(nil),      // 94: agentcompose.v2.RemoveCacheRequest
-	(*RemoveCacheResponse)(nil),     // 95: agentcompose.v2.RemoveCacheResponse
-	(*CacheItem)(nil),               // 96: agentcompose.v2.CacheItem
-	(*CacheReference)(nil),          // 97: agentcompose.v2.CacheReference
-	(*ListVolumesRequest)(nil),      // 98: agentcompose.v2.ListVolumesRequest
-	(*ListVolumesResponse)(nil),     // 99: agentcompose.v2.ListVolumesResponse
-	(*CreateVolumeRequest)(nil),     // 100: agentcompose.v2.CreateVolumeRequest
-	(*CreateVolumeResponse)(nil),    // 101: agentcompose.v2.CreateVolumeResponse
-	(*InspectVolumeRequest)(nil),    // 102: agentcompose.v2.InspectVolumeRequest
-	(*InspectVolumeResponse)(nil),   // 103: agentcompose.v2.InspectVolumeResponse
-	(*RemoveVolumeRequest)(nil),     // 104: agentcompose.v2.RemoveVolumeRequest
-	(*RemoveVolumeResponse)(nil),    // 105: agentcompose.v2.RemoveVolumeResponse
-	(*PruneVolumesRequest)(nil),     // 106: agentcompose.v2.PruneVolumesRequest
-	(*PruneVolumesResponse)(nil),    // 107: agentcompose.v2.PruneVolumesResponse
-	(*Volume)(nil),                  // 108: agentcompose.v2.Volume
-	(*Image)(nil),                   // 109: agentcompose.v2.Image
-	(*ImagePlatform)(nil),           // 110: agentcompose.v2.ImagePlatform
-	(*ImageStoreStatus)(nil),        // 111: agentcompose.v2.ImageStoreStatus
-	(*DockerImageStatus)(nil),       // 112: agentcompose.v2.DockerImageStatus
-	(*OCIImageStatus)(nil),          // 113: agentcompose.v2.OCIImageStatus
-	(*ImagePullProgress)(nil),       // 114: agentcompose.v2.ImagePullProgress
-	(*JupyterSpec)(nil),             // 115: agentcompose.v2.JupyterSpec
-	(*RunJupyterSpec)(nil),          // 116: agentcompose.v2.RunJupyterSpec
-	(*StartRunRequest)(nil),         // 117: agentcompose.v2.StartRunRequest
-	(*StartRunResponse)(nil),        // 118: agentcompose.v2.StartRunResponse
-	nil,                             // 119: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                             // 120: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                             // 121: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                             // 122: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                             // 123: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                             // 124: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                             // 125: agentcompose.v2.Volume.LabelsEntry
-	nil,                             // 126: agentcompose.v2.Volume.OptionsEntry
-	nil,                             // 127: agentcompose.v2.Image.LabelsEntry
+	(*NamedWorkspaceSpec)(nil),      // 37: agentcompose.v2.NamedWorkspaceSpec
+	(*AgentSpec)(nil),               // 38: agentcompose.v2.AgentSpec
+	(*ProjectVolumeSpec)(nil),       // 39: agentcompose.v2.ProjectVolumeSpec
+	(*VolumeMountSpec)(nil),         // 40: agentcompose.v2.VolumeMountSpec
+	(*BuildSpec)(nil),               // 41: agentcompose.v2.BuildSpec
+	(*EnvVarSpec)(nil),              // 42: agentcompose.v2.EnvVarSpec
+	(*WorkspaceSpec)(nil),           // 43: agentcompose.v2.WorkspaceSpec
+	(*NetworkSpec)(nil),             // 44: agentcompose.v2.NetworkSpec
+	(*SchedulerSpec)(nil),           // 45: agentcompose.v2.SchedulerSpec
+	(*TriggerSpec)(nil),             // 46: agentcompose.v2.TriggerSpec
+	(*EventTriggerSpec)(nil),        // 47: agentcompose.v2.EventTriggerSpec
+	(*DriverSpec)(nil),              // 48: agentcompose.v2.DriverSpec
+	(*BoxliteDriverSpec)(nil),       // 49: agentcompose.v2.BoxliteDriverSpec
+	(*DockerDriverSpec)(nil),        // 50: agentcompose.v2.DockerDriverSpec
+	(*MicrosandboxDriverSpec)(nil),  // 51: agentcompose.v2.MicrosandboxDriverSpec
+	(*RunAgentRequest)(nil),         // 52: agentcompose.v2.RunAgentRequest
+	(*RunAgentResponse)(nil),        // 53: agentcompose.v2.RunAgentResponse
+	(*RunAgentStreamResponse)(nil),  // 54: agentcompose.v2.RunAgentStreamResponse
+	(*TranscriptEvent)(nil),         // 55: agentcompose.v2.TranscriptEvent
+	(*GetRunRequest)(nil),           // 56: agentcompose.v2.GetRunRequest
+	(*GetRunResponse)(nil),          // 57: agentcompose.v2.GetRunResponse
+	(*ListRunsRequest)(nil),         // 58: agentcompose.v2.ListRunsRequest
+	(*ListRunsResponse)(nil),        // 59: agentcompose.v2.ListRunsResponse
+	(*FollowRunLogsRequest)(nil),    // 60: agentcompose.v2.FollowRunLogsRequest
+	(*RunLogChunk)(nil),             // 61: agentcompose.v2.RunLogChunk
+	(*StopRunRequest)(nil),          // 62: agentcompose.v2.StopRunRequest
+	(*StopRunResponse)(nil),         // 63: agentcompose.v2.StopRunResponse
+	(*RemoveSandboxRequest)(nil),    // 64: agentcompose.v2.RemoveSandboxRequest
+	(*RemoveSandboxResponse)(nil),   // 65: agentcompose.v2.RemoveSandboxResponse
+	(*GetSandboxStatsRequest)(nil),  // 66: agentcompose.v2.GetSandboxStatsRequest
+	(*GetSandboxStatsResponse)(nil), // 67: agentcompose.v2.GetSandboxStatsResponse
+	(*MetricValue)(nil),             // 68: agentcompose.v2.MetricValue
+	(*SandboxStats)(nil),            // 69: agentcompose.v2.SandboxStats
+	(*RunSummary)(nil),              // 70: agentcompose.v2.RunSummary
+	(*RunDetail)(nil),               // 71: agentcompose.v2.RunDetail
+	(*ExecRequest)(nil),             // 72: agentcompose.v2.ExecRequest
+	(*ExecSessionSelector)(nil),     // 73: agentcompose.v2.ExecSessionSelector
+	(*ExecCommand)(nil),             // 74: agentcompose.v2.ExecCommand
+	(*ExecResponse)(nil),            // 75: agentcompose.v2.ExecResponse
+	(*ExecStreamResponse)(nil),      // 76: agentcompose.v2.ExecStreamResponse
+	(*ExecResult)(nil),              // 77: agentcompose.v2.ExecResult
+	(*ListImagesRequest)(nil),       // 78: agentcompose.v2.ListImagesRequest
+	(*ListImagesResponse)(nil),      // 79: agentcompose.v2.ListImagesResponse
+	(*PullImageRequest)(nil),        // 80: agentcompose.v2.PullImageRequest
+	(*PullImageResponse)(nil),       // 81: agentcompose.v2.PullImageResponse
+	(*InspectImageRequest)(nil),     // 82: agentcompose.v2.InspectImageRequest
+	(*InspectImageResponse)(nil),    // 83: agentcompose.v2.InspectImageResponse
+	(*RemoveImageRequest)(nil),      // 84: agentcompose.v2.RemoveImageRequest
+	(*RemoveImageResponse)(nil),     // 85: agentcompose.v2.RemoveImageResponse
+	(*BuildImageRequest)(nil),       // 86: agentcompose.v2.BuildImageRequest
+	(*BuildImageEvent)(nil),         // 87: agentcompose.v2.BuildImageEvent
+	(*CacheFilter)(nil),             // 88: agentcompose.v2.CacheFilter
+	(*ListCachesRequest)(nil),       // 89: agentcompose.v2.ListCachesRequest
+	(*ListCachesResponse)(nil),      // 90: agentcompose.v2.ListCachesResponse
+	(*InspectCacheRequest)(nil),     // 91: agentcompose.v2.InspectCacheRequest
+	(*InspectCacheResponse)(nil),    // 92: agentcompose.v2.InspectCacheResponse
+	(*PruneCachesRequest)(nil),      // 93: agentcompose.v2.PruneCachesRequest
+	(*PruneCachesResponse)(nil),     // 94: agentcompose.v2.PruneCachesResponse
+	(*RemoveCacheRequest)(nil),      // 95: agentcompose.v2.RemoveCacheRequest
+	(*RemoveCacheResponse)(nil),     // 96: agentcompose.v2.RemoveCacheResponse
+	(*CacheItem)(nil),               // 97: agentcompose.v2.CacheItem
+	(*CacheReference)(nil),          // 98: agentcompose.v2.CacheReference
+	(*ListVolumesRequest)(nil),      // 99: agentcompose.v2.ListVolumesRequest
+	(*ListVolumesResponse)(nil),     // 100: agentcompose.v2.ListVolumesResponse
+	(*CreateVolumeRequest)(nil),     // 101: agentcompose.v2.CreateVolumeRequest
+	(*CreateVolumeResponse)(nil),    // 102: agentcompose.v2.CreateVolumeResponse
+	(*InspectVolumeRequest)(nil),    // 103: agentcompose.v2.InspectVolumeRequest
+	(*InspectVolumeResponse)(nil),   // 104: agentcompose.v2.InspectVolumeResponse
+	(*RemoveVolumeRequest)(nil),     // 105: agentcompose.v2.RemoveVolumeRequest
+	(*RemoveVolumeResponse)(nil),    // 106: agentcompose.v2.RemoveVolumeResponse
+	(*PruneVolumesRequest)(nil),     // 107: agentcompose.v2.PruneVolumesRequest
+	(*PruneVolumesResponse)(nil),    // 108: agentcompose.v2.PruneVolumesResponse
+	(*Volume)(nil),                  // 109: agentcompose.v2.Volume
+	(*Image)(nil),                   // 110: agentcompose.v2.Image
+	(*ImagePlatform)(nil),           // 111: agentcompose.v2.ImagePlatform
+	(*ImageStoreStatus)(nil),        // 112: agentcompose.v2.ImageStoreStatus
+	(*DockerImageStatus)(nil),       // 113: agentcompose.v2.DockerImageStatus
+	(*OCIImageStatus)(nil),          // 114: agentcompose.v2.OCIImageStatus
+	(*ImagePullProgress)(nil),       // 115: agentcompose.v2.ImagePullProgress
+	(*JupyterSpec)(nil),             // 116: agentcompose.v2.JupyterSpec
+	(*RunJupyterSpec)(nil),          // 117: agentcompose.v2.RunJupyterSpec
+	(*StartRunRequest)(nil),         // 118: agentcompose.v2.StartRunRequest
+	(*StartRunResponse)(nil),        // 119: agentcompose.v2.StartRunResponse
+	nil,                             // 120: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                             // 121: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                             // 122: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                             // 123: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                             // 124: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                             // 125: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                             // 126: agentcompose.v2.Volume.LabelsEntry
+	nil,                             // 127: agentcompose.v2.Volume.OptionsEntry
+	nil,                             // 128: agentcompose.v2.Image.LabelsEntry
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	36,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
@@ -9453,182 +9520,183 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	36,  // 24: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
 	0,   // 25: agentcompose.v2.ProjectValidationIssue.severity:type_name -> agentcompose.v2.ProjectValidationSeverity
 	1,   // 26: agentcompose.v2.ProjectChange.action:type_name -> agentcompose.v2.ProjectChangeAction
-	41,  // 27: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
-	42,  // 28: agentcompose.v2.ProjectSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	37,  // 29: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
-	43,  // 30: agentcompose.v2.ProjectSpec.network:type_name -> agentcompose.v2.NetworkSpec
-	38,  // 31: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
-	47,  // 32: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
-	41,  // 33: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
-	42,  // 34: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	44,  // 35: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
-	115, // 36: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
-	40,  // 37: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
-	39,  // 38: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	119, // 39: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	120, // 40: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	121, // 41: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
-	45,  // 42: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
-	46,  // 43: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
-	48,  // 44: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
-	49,  // 45: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
-	50,  // 46: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
-	4,   // 47: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
-	41,  // 48: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	6,   // 49: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSessionCleanupPolicy
-	116, // 50: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
-	39,  // 51: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	70,  // 52: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
-	5,   // 53: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
-	69,  // 54: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
-	8,   // 55: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	54,  // 56: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	8,   // 57: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
-	70,  // 58: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	3,   // 59: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
-	4,   // 60: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
-	69,  // 61: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
-	3,   // 62: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
-	70,  // 63: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	68,  // 64: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
-	12,  // 65: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	67,  // 66: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
-	67,  // 67: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
-	67,  // 68: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
-	67,  // 69: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
-	67,  // 70: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
-	67,  // 71: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
-	67,  // 72: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
-	67,  // 73: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
-	67,  // 74: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
-	4,   // 75: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
-	3,   // 76: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	69,  // 77: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	72,  // 78: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSessionSelector
-	73,  // 79: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
-	41,  // 80: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	76,  // 81: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
-	7,   // 82: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
-	8,   // 83: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	76,  // 84: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
-	54,  // 85: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	73,  // 86: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
-	9,   // 87: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	109, // 88: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
-	111, // 89: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	9,   // 90: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	110, // 91: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	109, // 92: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
-	11,  // 93: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
-	114, // 94: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
-	9,   // 95: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	109, // 96: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
-	111, // 97: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	9,   // 98: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	122, // 99: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	9,   // 100: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	110, // 101: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	11,  // 102: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
-	109, // 103: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
-	13,  // 104: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
-	14,  // 105: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
-	87,  // 106: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	96,  // 107: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
-	96,  // 108: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
-	87,  // 109: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	96,  // 110: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
-	96,  // 111: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	96,  // 112: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
-	96,  // 113: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	13,  // 114: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
-	14,  // 115: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	97,  // 116: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
-	108, // 117: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	123, // 118: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	124, // 119: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	108, // 120: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	108, // 121: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	108, // 122: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
-	108, // 123: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
-	108, // 124: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	125, // 125: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	126, // 126: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	9,   // 127: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
-	10,  // 128: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
-	110, // 129: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	112, // 130: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
-	113, // 131: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	127, // 132: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
-	9,   // 133: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
-	51,  // 134: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
-	69,  // 135: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
-	15,  // 136: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	17,  // 137: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	19,  // 138: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	21,  // 139: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	23,  // 140: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	25,  // 141: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	51,  // 142: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	117, // 143: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	51,  // 144: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	55,  // 145: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	57,  // 146: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	59,  // 147: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	61,  // 148: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	71,  // 149: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	71,  // 150: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	77,  // 151: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	79,  // 152: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	81,  // 153: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	83,  // 154: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	85,  // 155: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	88,  // 156: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	90,  // 157: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	92,  // 158: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	94,  // 159: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	98,  // 160: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	100, // 161: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	102, // 162: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	104, // 163: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	106, // 164: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	63,  // 165: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	65,  // 166: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	16,  // 167: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	18,  // 168: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	20,  // 169: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	22,  // 170: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	24,  // 171: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	26,  // 172: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	52,  // 173: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	118, // 174: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	53,  // 175: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	56,  // 176: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	58,  // 177: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	60,  // 178: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	62,  // 179: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	74,  // 180: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	75,  // 181: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	78,  // 182: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	80,  // 183: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	82,  // 184: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	84,  // 185: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	86,  // 186: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	89,  // 187: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	91,  // 188: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	93,  // 189: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	95,  // 190: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	99,  // 191: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	101, // 192: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	103, // 193: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	105, // 194: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	107, // 195: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	64,  // 196: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	66,  // 197: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	167, // [167:198] is the sub-list for method output_type
-	136, // [136:167] is the sub-list for method input_type
-	136, // [136:136] is the sub-list for extension type_name
-	136, // [136:136] is the sub-list for extension extendee
-	0,   // [0:136] is the sub-list for field type_name
+	42,  // 27: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
+	38,  // 28: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
+	44,  // 29: agentcompose.v2.ProjectSpec.network:type_name -> agentcompose.v2.NetworkSpec
+	39,  // 30: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
+	37,  // 31: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
+	43,  // 32: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	48,  // 33: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
+	42,  // 34: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
+	43,  // 35: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	45,  // 36: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
+	116, // 37: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
+	41,  // 38: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
+	40,  // 39: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	120, // 40: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	121, // 41: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	122, // 42: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	46,  // 43: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
+	47,  // 44: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
+	49,  // 45: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
+	50,  // 46: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
+	51,  // 47: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
+	4,   // 48: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
+	42,  // 49: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	6,   // 50: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSessionCleanupPolicy
+	117, // 51: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
+	40,  // 52: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	71,  // 53: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
+	5,   // 54: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
+	70,  // 55: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
+	8,   // 56: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	55,  // 57: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	8,   // 58: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
+	71,  // 59: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	3,   // 60: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
+	4,   // 61: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
+	70,  // 62: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
+	3,   // 63: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
+	71,  // 64: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	69,  // 65: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
+	12,  // 66: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
+	68,  // 67: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
+	68,  // 68: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
+	68,  // 69: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
+	68,  // 70: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
+	68,  // 71: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
+	68,  // 72: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
+	68,  // 73: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
+	68,  // 74: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
+	68,  // 75: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
+	4,   // 76: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
+	3,   // 77: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
+	70,  // 78: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
+	73,  // 79: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSessionSelector
+	74,  // 80: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
+	42,  // 81: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	77,  // 82: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
+	7,   // 83: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
+	8,   // 84: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	77,  // 85: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
+	55,  // 86: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	74,  // 87: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
+	9,   // 88: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	110, // 89: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
+	112, // 90: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	9,   // 91: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	111, // 92: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	110, // 93: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
+	11,  // 94: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
+	115, // 95: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
+	9,   // 96: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	110, // 97: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
+	112, // 98: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	9,   // 99: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	123, // 100: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	9,   // 101: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	111, // 102: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	11,  // 103: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
+	110, // 104: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
+	13,  // 105: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
+	14,  // 106: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
+	88,  // 107: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	97,  // 108: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
+	97,  // 109: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
+	88,  // 110: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	97,  // 111: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
+	97,  // 112: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	97,  // 113: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
+	97,  // 114: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	13,  // 115: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
+	14,  // 116: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
+	98,  // 117: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
+	109, // 118: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
+	124, // 119: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	125, // 120: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	109, // 121: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	109, // 122: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	109, // 123: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
+	109, // 124: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
+	109, // 125: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
+	126, // 126: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	127, // 127: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	9,   // 128: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
+	10,  // 129: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
+	111, // 130: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
+	113, // 131: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
+	114, // 132: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
+	128, // 133: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	9,   // 134: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
+	52,  // 135: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
+	70,  // 136: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	15,  // 137: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	17,  // 138: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	19,  // 139: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	21,  // 140: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	23,  // 141: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	25,  // 142: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	52,  // 143: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	118, // 144: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
+	52,  // 145: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
+	56,  // 146: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	58,  // 147: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	60,  // 148: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	62,  // 149: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	72,  // 150: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	72,  // 151: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
+	78,  // 152: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	80,  // 153: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	82,  // 154: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	84,  // 155: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	86,  // 156: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	89,  // 157: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	91,  // 158: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	93,  // 159: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	95,  // 160: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	99,  // 161: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	101, // 162: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	103, // 163: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	105, // 164: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	107, // 165: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	64,  // 166: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	66,  // 167: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	16,  // 168: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	18,  // 169: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	20,  // 170: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	22,  // 171: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	24,  // 172: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	26,  // 173: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	53,  // 174: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	119, // 175: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
+	54,  // 176: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
+	57,  // 177: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	59,  // 178: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	61,  // 179: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	63,  // 180: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	75,  // 181: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	76,  // 182: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
+	79,  // 183: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	81,  // 184: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	83,  // 185: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	85,  // 186: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	87,  // 187: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	90,  // 188: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	92,  // 189: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	94,  // 190: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	96,  // 191: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	100, // 192: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	102, // 193: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	104, // 194: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	106, // 195: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	108, // 196: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	65,  // 197: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	67,  // 198: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	168, // [168:199] is the sub-list for method output_type
+	137, // [137:168] is the sub-list for method input_type
+	137, // [137:137] is the sub-list for extension type_name
+	137, // [137:137] is the sub-list for extension extendee
+	0,   // [0:137] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }
@@ -9636,8 +9704,8 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 	if File_agentcompose_v2_agentcompose_proto != nil {
 		return
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[52].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[56].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[53].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[57].OneofWrappers = []any{
 		(*ExecRequest_SessionId)(nil),
 		(*ExecRequest_RunId)(nil),
 		(*ExecRequest_Selector)(nil),
@@ -9648,7 +9716,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
 			NumEnums:      15,
-			NumMessages:   113,
+			NumMessages:   114,
 			NumExtensions: 0,
 			NumServices:   7,
 		},

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -317,10 +317,17 @@ message ProjectChange {
 message ProjectSpec {
   string name = 1;
   repeated EnvVarSpec variables = 2;
-  WorkspaceSpec workspace = 3;
+  reserved 3;
+  reserved "workspace";
   repeated AgentSpec agents = 4;
   NetworkSpec network = 5;
   repeated ProjectVolumeSpec volumes = 6;
+  repeated NamedWorkspaceSpec workspaces = 7;
+}
+
+message NamedWorkspaceSpec {
+  string name = 1;
+  WorkspaceSpec workspace = 2;
 }
 
 message AgentSpec {
@@ -377,6 +384,7 @@ message WorkspaceSpec {
   string url = 2;
   string branch = 3;
   string path = 4;
+  string name = 5;
 }
 
 message NetworkSpec {


### PR DESCRIPTION
## Background

This PR adds top-level `workspaces` support to `agent-compose.yml`, allows `agent.workspace.name` to reference a top-level workspace, and removes the old `project.workspace` semantics in favor of a clearer unified model.

## Design

- Add top-level `workspaces` to the compose spec
- Keep `agent.workspace`, with two supported modes:
  - inline workspace definition
  - `name` reference to a top-level workspace
- Resolution rules:
  - if `agent.workspace` is explicitly configured, it always wins
  - if `agent.workspace` is empty:
    - use the workspace automatically when there is exactly one top-level workspace
    - return an error when there are zero or multiple top-level workspaces
- Resolve workspace references during normalize time
- Runtime logic only consumes the final resolved agent workspace
- Sync top-level `workspaces` support into v2 proto and API output

## Main Changes

### Compose

- add `ProjectSpec.Workspaces`
- add `Name` to `WorkspaceSpec`
- add top-level workspace normalization and agent workspace resolution

### API / Proto

- add proto and YAML-shape mapping for top-level `workspaces`
- add `workspaces` to `ProjectSpec`
- add `name` to `WorkspaceSpec`

### Runs

- runtime now uses only the final resolved agent workspace
- remove dependency on the old `project.workspace` behavior

## Tests

Added and updated unit, integration, and E2E tests covering:

- single global workspace defaulting
- `agent.workspace.name` reference resolution
- agent inline workspace override
- ambiguous multiple-global-workspace error
- missing referenced workspace error
- real runtime mount validation:
  - start sandbox
  - verify actual files under `/workspace` via `exec`

Also added a local development test suite for feature-focused verification:

- `data/ai_analyse/ai-test-suit/suit-yml-global-workspaces`

## Quality Gates

- `git diff --check` passed
- `task lint` passed
- `task test` passed
  - Unit: `78.42%`
  - Integration: `70.02%`
  - E2E: `66.44%`
  - Combined: `81.23%`
- `task build` passed
