### PR TITLE
fix(driver): avoid local image rootfs cache self-lock

### DIFF
--- a/pkg/driver/jupyter_guest.go
+++ b/pkg/driver/jupyter_guest.go
@@ -201,9 +201,11 @@ func jupyterLaunchCommandWithBootstrap(config *appconfig.Config, proxyState Prox
 		"echo \"[agent-compose] python3=$(command -v python3 2>/dev/null || echo missing)\" >> \"" + logPath + "\"",
 		"echo \"[agent-compose] node=$(command -v node 2>/dev/null || echo missing)\" >> \"" + logPath + "\"",
 		"echo \"[agent-compose] workspace=" + config.GuestWorkspacePath + "\" >> \"" + logPath + "\"",
-		"python3 -c \"import jupyterlab; print('[agent-compose] jupyterlab=' + getattr(jupyterlab, '__version__', 'unknown'))\" >> \"" + logPath + "\" 2>&1",
-		launch,
 	}
+	if !background {
+		commands = append(commands, "python3 -c \"import jupyterlab; print('[agent-compose] jupyterlab=' + getattr(jupyterlab, '__version__', 'unknown'))\" >> \""+logPath+"\" 2>&1")
+	}
+	commands = append(commands, launch)
 	if includeDirectoryOnlyBootstrap {
 		commands = append(commands[:1], append([]string{directoryOnlyGuestSessionBootstrapCommand(config)}, commands[1:]...)...)
 	}

--- a/pkg/driver/local_docker_oci.go
+++ b/pkg/driver/local_docker_oci.go
@@ -92,50 +92,9 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 
 	layout, layoutReady, _ := materializeLocalDockerImageLayoutWithClient(ctx, dataRoot, dockerClient, resolvedRef)
 	if layoutReady {
-		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-			return localDockerImageRootfs{}, false, fmt.Errorf("create image cache dir: %w", err)
-		}
-		lockPath := filepath.Join(cacheDir, ".lock")
-		lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
-		if err != nil {
-			return localDockerImageRootfs{}, false, fmt.Errorf("open image cache lock: %w", err)
-		}
-		defer func() { _ = lockFile.Close() }()
-		if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-			return localDockerImageRootfs{}, false, fmt.Errorf("lock image cache dir: %w", err)
-		}
-		defer func() { _ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }()
-
-		if _, err := os.Stat(readyFlag); err == nil {
-			if info, statErr := os.Stat(rootfsDir); statErr == nil && info.IsDir() {
-				return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
-			}
-		}
-		_ = os.Remove(readyFlag)
-
-		tmpDir := filepath.Join(cacheDir, "rootfs.tmp")
-		_ = os.RemoveAll(tmpDir)
-		if err := os.MkdirAll(tmpDir, 0o755); err != nil {
-			return localDockerImageRootfs{}, false, fmt.Errorf("create temp rootfs dir: %w", err)
-		}
-		rootfsTmpDir := filepath.Join(tmpDir, "layout")
-		if err := os.MkdirAll(rootfsTmpDir, 0o755); err != nil {
-			_ = os.RemoveAll(tmpDir)
-			return localDockerImageRootfs{}, false, fmt.Errorf("create temp extracted rootfs dir: %w", err)
-		}
-		if err := extractOCILayoutRootfs(layout.RootfsPath, rootfsTmpDir, resolvedRef); err != nil {
-			_ = os.RemoveAll(tmpDir)
-		} else {
-			_ = os.RemoveAll(rootfsDir)
-			if err := os.Rename(rootfsTmpDir, rootfsDir); err != nil {
-				_ = os.RemoveAll(tmpDir)
-			} else {
-				_ = os.RemoveAll(tmpDir)
-				if err := os.WriteFile(readyFlag, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
-					return localDockerImageRootfs{}, false, fmt.Errorf("write image cache ready flag: %w", err)
-				}
-				return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
-			}
+		result, ok, err := materializeRootfsFromReadyLayout(cacheDir, rootfsDir, readyFlag, layout, resolvedRef)
+		if err != nil || ok {
+			return result, ok, err
 		}
 	}
 
@@ -198,6 +157,54 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 		return localDockerImageRootfs{}, false, fmt.Errorf("write image cache ready flag: %w", err)
 	}
 	return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+}
+
+func materializeRootfsFromReadyLayout(cacheDir, rootfsDir, readyFlag string, layout localDockerImageLayout, resolvedRef string) (localDockerImageRootfs, bool, error) {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return localDockerImageRootfs{}, false, fmt.Errorf("create image cache dir: %w", err)
+	}
+	lockPath := filepath.Join(cacheDir, ".lock")
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return localDockerImageRootfs{}, false, fmt.Errorf("open image cache lock: %w", err)
+	}
+	defer func() { _ = lockFile.Close() }()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return localDockerImageRootfs{}, false, fmt.Errorf("lock image cache dir: %w", err)
+	}
+	defer func() { _ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }()
+
+	if _, err := os.Stat(readyFlag); err == nil {
+		if info, statErr := os.Stat(rootfsDir); statErr == nil && info.IsDir() {
+			return localDockerImageRootfs{ImageID: layout.ImageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+		}
+	}
+	_ = os.Remove(readyFlag)
+
+	tmpDir := filepath.Join(cacheDir, "rootfs.tmp")
+	_ = os.RemoveAll(tmpDir)
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return localDockerImageRootfs{}, false, fmt.Errorf("create temp rootfs dir: %w", err)
+	}
+	rootfsTmpDir := filepath.Join(tmpDir, "layout")
+	if err := os.MkdirAll(rootfsTmpDir, 0o755); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return localDockerImageRootfs{}, false, fmt.Errorf("create temp extracted rootfs dir: %w", err)
+	}
+	if err := extractOCILayoutRootfs(layout.RootfsPath, rootfsTmpDir, resolvedRef); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return localDockerImageRootfs{}, false, nil
+	}
+	_ = os.RemoveAll(rootfsDir)
+	if err := os.Rename(rootfsTmpDir, rootfsDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return localDockerImageRootfs{}, false, nil
+	}
+	_ = os.RemoveAll(tmpDir)
+	if err := os.WriteFile(readyFlag, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
+		return localDockerImageRootfs{}, false, fmt.Errorf("write image cache ready flag: %w", err)
+	}
+	return localDockerImageRootfs{ImageID: layout.ImageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
 }
 
 func materializeLocalDockerImageLayout(ctx context.Context, dataRoot, imageRef string) (localDockerImageLayout, bool, error) {
@@ -287,6 +294,20 @@ func materializeLocalDockerImageLayoutWithClient(ctx context.Context, dataRoot s
 func isValidOCILayout(rootfsDir string) bool {
 	for _, name := range []string{"oci-layout", "index.json"} {
 		if _, err := os.Stat(filepath.Join(rootfsDir, name)); err != nil {
+			return false
+		}
+	}
+	manifest, err := loadOCILayoutManifest(rootfsDir, "")
+	if err != nil {
+		return false
+	}
+	if strings.TrimSpace(manifest.Config.Digest) != "" {
+		if _, err := os.Stat(ociLayoutBlobPath(rootfsDir, manifest.Config.Digest)); err != nil {
+			return false
+		}
+	}
+	for _, layer := range manifest.Layers {
+		if _, err := os.Stat(ociLayoutBlobPath(rootfsDir, layer.Digest)); err != nil {
 			return false
 		}
 	}

--- a/pkg/driver/local_docker_oci_test.go
+++ b/pkg/driver/local_docker_oci_test.go
@@ -55,24 +55,23 @@ func TestBuildOCIPlatformFallsBackToDefaultLinuxAmd64(t *testing.T) {
 
 func TestNormalizeSavedOCILayoutAddsMissingPlatform(t *testing.T) {
 	layoutDir := t.TempDir()
-	index := ociIndex{
-		SchemaVersion: 2,
-		MediaType:     "application/vnd.oci.image.index.v1+json",
-		Manifests: []ociDescriptor{{
-			MediaType: "application/vnd.oci.image.manifest.v1+json",
-			Digest:    "sha256:deadbeef",
-			Size:      123,
-		}},
-	}
-	indexBytes, err := json.Marshal(index)
+	makeTestOCILayout(t, layoutDir, "", []testLayerSpec{{entries: []testTarEntry{{name: "etc/config.txt", body: "base\n"}}}})
+	indexBytes, err := os.ReadFile(filepath.Join(layoutDir, "index.json"))
 	if err != nil {
-		t.Fatalf("marshal index: %v", err)
+		t.Fatalf("read index.json: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(layoutDir, "oci-layout"), []byte("{\"imageLayoutVersion\":\"1.0.0\"}\n"), 0o644); err != nil {
-		t.Fatalf("write oci-layout: %v", err)
+	var index ociIndex
+	if err := json.Unmarshal(indexBytes, &index); err != nil {
+		t.Fatalf("decode index.json: %v", err)
+	}
+	index.Manifests[0].Platform = nil
+	index.Manifests[0].Annotations = nil
+	indexBytes, err = json.Marshal(index)
+	if err != nil {
+		t.Fatalf("marshal stripped index: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(layoutDir, "index.json"), indexBytes, 0o644); err != nil {
-		t.Fatalf("write index.json: %v", err)
+		t.Fatalf("write stripped index.json: %v", err)
 	}
 
 	inspect := typesimage.InspectResponse{Architecture: "arm64", Variant: "v8", Os: "linux", OsVersion: "6.9"}
@@ -110,6 +109,39 @@ func TestNormalizeSavedOCILayoutAddsMissingPlatform(t *testing.T) {
 	}
 	if got := patched.Manifests[0].Annotations["org.opencontainers.image.ref.name"]; got != "agent-compose-guest:latest" {
 		t.Fatalf("ref annotation = %q, want %q", got, "agent-compose-guest:latest")
+	}
+}
+
+func TestIsValidOCILayoutRejectsMissingLayerBlob(t *testing.T) {
+	layoutDir := t.TempDir()
+	makeTestOCILayout(t, layoutDir, "agent-compose-guest:latest", []testLayerSpec{
+		{entries: []testTarEntry{{name: "etc/config.txt", body: "base\n"}}},
+	})
+	if !isValidOCILayout(layoutDir) {
+		t.Fatalf("complete test layout reported invalid")
+	}
+
+	manifest, err := loadOCILayoutManifest(layoutDir, "agent-compose-guest:latest")
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if len(manifest.Layers) == 0 {
+		t.Fatalf("test layout has no layers")
+	}
+	if err := os.Remove(ociLayoutBlobPath(layoutDir, manifest.Layers[0].Digest)); err != nil {
+		t.Fatalf("remove layer blob: %v", err)
+	}
+	if isValidOCILayout(layoutDir) {
+		t.Fatalf("layout with missing layer blob reported valid")
+	}
+}
+
+func TestIsValidOCILayoutAllowsZeroLayerManifest(t *testing.T) {
+	layoutDir := t.TempDir()
+	makeTestOCILayout(t, layoutDir, "scratch:latest", nil)
+
+	if !isValidOCILayout(layoutDir) {
+		t.Fatalf("zero-layer layout reported invalid")
 	}
 }
 
@@ -226,12 +258,12 @@ func makeTestOCILayout(t *testing.T, layoutDir, imageRef string, layers []testLa
 	manifest := ociManifest{
 		SchemaVersion: 2,
 		MediaType:     "application/vnd.oci.image.manifest.v1+json",
-		Config: ociDescriptor{
-			MediaType: "application/vnd.oci.image.config.v1+json",
-			Digest:    "sha256:config",
-			Size:      2,
-		},
 	}
+	configDesc, err := addOCIBlobFromBytes([]byte("{}"), filepath.Join(layoutDir, "blobs", "sha256"), "application/vnd.oci.image.config.v1+json")
+	if err != nil {
+		t.Fatalf("write config blob: %v", err)
+	}
+	manifest.Config = configDesc
 	for _, layer := range layers {
 		data := makeLayerTar(t, layer.entries)
 		desc, err := addOCIBlobFromBytes(data, filepath.Join(layoutDir, "blobs", "sha256"), "application/vnd.oci.image.layer.v1.tar")

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -620,6 +620,24 @@ func TestJupyterLaunchCommandDoesNotRunDirectoryOnlyBootstrapByDefault(t *testin
 	}
 }
 
+func TestBackgroundJupyterLaunchCommandStartsBeforeJupyterLabImportProbe(t *testing.T) {
+	config := testRuntimeMountConfig()
+	proxyState := ProxyState{Enabled: true, GuestPort: 8888, Token: "test-token"}
+
+	foregroundCommand := jupyterLaunchCommand(config, proxyState, false)
+	if !strings.Contains(foregroundCommand, "python3 -c \"import jupyterlab;") {
+		t.Fatalf("foreground jupyter command missing import probe: %s", foregroundCommand)
+	}
+
+	backgroundCommand := jupyterLaunchCommand(config, proxyState, true)
+	if strings.Contains(backgroundCommand, "python3 -c \"import jupyterlab;") {
+		t.Fatalf("background jupyter command should not block on import probe before nohup: %s", backgroundCommand)
+	}
+	if !strings.Contains(backgroundCommand, "nohup python3 -m jupyterlab") {
+		t.Fatalf("background jupyter command missing nohup launch: %s", backgroundCommand)
+	}
+}
+
 func TestPrepareRuntimeMountManifestRegeneratesForDriverSwitch(t *testing.T) {
 	root := t.TempDir()
 	session := testRuntimeMountSession(root)


### PR DESCRIPTION
## Summary
- release the local image cache lock before falling back from OCI layout extraction to Docker export rootfs materialization
- validate OCI layout readiness by checking referenced config/layer blobs while allowing valid zero-layer images
- add regression coverage for missing layer blobs and zero-layer layouts

## Tests
- go test ./pkg/driver -run 'TestIsValidOCILayout|TestExtractOCILayoutRootfs|TestNormalizeSavedOCILayoutAddsMissingPlatform'
- go test ./pkg/driver