### PR TITLE
fix(microsandbox): use safe docker disk filenames

### DIFF
--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -4,6 +4,7 @@ package driver
 
 import (
 	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/identity"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -603,7 +604,14 @@ func (r *microsandboxRuntime) sandboxStateDir(name string) string {
 }
 
 func (r *microsandboxRuntime) dockerDiskPath(sessionID string) string {
-	return filepath.Join(r.config.MicrosandboxHome, "docker-disks", sessionID+".raw")
+	return filepath.Join(r.config.MicrosandboxHome, "docker-disks", microsandboxDockerDiskName(sessionID)+".raw")
+}
+
+func microsandboxDockerDiskName(sessionID string) string {
+	if hash, err := identity.Hash(sessionID); err == nil {
+		return hash
+	}
+	return sessionID
 }
 
 func (r *microsandboxRuntime) ensureDockerDisk(sessionID string) (string, error) {

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/identity"
 	"agent-compose/pkg/runtimecache"
 )
 
@@ -147,6 +149,25 @@ func TestMicrosandboxRemoveDockerDiskOnlyCurrentSession(t *testing.T) {
 	}
 	if _, err := os.Stat(other); err != nil {
 		t.Fatalf("other disk missing after removeDockerDisk: %v", err)
+	}
+}
+
+func TestMicrosandboxDockerDiskPathUsesIdentityHash(t *testing.T) {
+	config := testMicrosandboxConfig(t)
+	runtime := &microsandboxRuntime{config: config}
+	sessionID := identity.NewRandomID(identity.ResourceSandbox)
+	hash, err := identity.Hash(sessionID)
+	if err != nil {
+		t.Fatalf("hash session id: %v", err)
+	}
+
+	got := runtime.dockerDiskPath(sessionID)
+	want := filepath.Join(config.MicrosandboxHome, "docker-disks", hash+".raw")
+	if got != want {
+		t.Fatalf("dockerDiskPath = %q, want %q", got, want)
+	}
+	if strings.ContainsAny(filepath.Base(got), ",:;") {
+		t.Fatalf("docker disk basename = %q, want no runtime-forbidden characters", filepath.Base(got))
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive microsandbox docker disk filenames from the session identity hash
- avoid runtime-forbidden ':' characters while keeping canonical session IDs unchanged
- add focused coverage for hashed disk paths

## Tests
- go test ./pkg/driver