### PR TITLE
fix(compose): allow omitted agent workspace

### DIFF
--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -274,7 +274,7 @@ func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]
 				return resolved, nil
 			}
 		case 0:
-			return nil, &ValidationError{Path: path, Message: "workspace is required when project workspaces is empty"}
+			return nil, nil
 		default:
 			return nil, &ValidationError{Path: path, Message: "workspace is required when project workspaces has multiple entries"}
 		}
@@ -283,9 +283,7 @@ func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]
 	hasName := trimmed.Name != ""
 	hasInline := trimmed.Provider != "" || trimmed.URL != "" || trimmed.Branch != "" || trimmed.Path != ""
 	switch {
-	case hasName && hasInline:
-		return nil, &ValidationError{Path: path, Message: "workspace reference cannot set name together with provider, url, branch, or path"}
-	case hasName:
+	case hasName && !hasInline:
 		workspace, ok := globals[trimmed.Name]
 		if !ok {
 			return nil, &ValidationError{Path: path + ".name", Message: fmt.Sprintf("workspace %q is not defined", trimmed.Name)}
@@ -294,7 +292,7 @@ func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]
 		resolved.Name = ""
 		return resolved, nil
 	case hasInline:
-		return normalizeInlineWorkspaceSpec(path, trimmed, "")
+		return normalizeInlineWorkspaceSpec(path, trimmed, trimmed.Name)
 	default:
 		return nil, &ValidationError{Path: path, Message: "workspace is required"}
 	}
@@ -305,9 +303,7 @@ func normalizeInlineWorkspaceSpec(path string, spec *WorkspaceSpec, defaultName 
 		return nil, &ValidationError{Path: path, Message: "workspace is required"}
 	}
 	workspace := cloneWorkspaceSpec(spec)
-	if workspace.Name != "" {
-		return nil, &ValidationError{Path: path + ".name", Message: "inline workspace cannot set name"}
-	}
+	workspace.Name = strings.TrimSpace(workspace.Name)
 	provider := strings.ToLower(strings.TrimSpace(workspace.Provider))
 	if provider == "" {
 		return nil, &ValidationError{Path: path + ".provider", Message: "workspace provider is required"}

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -825,7 +825,70 @@ agents:
 	}
 }
 
-func TestNormalizeRejectsMixedAgentWorkspaceDefinition(t *testing.T) {
+func TestNormalizeAllowsOmittedAgentWorkspaceWithoutGlobals(t *testing.T) {
+	spec, err := Parse([]byte(`
+name: no-workspace
+agents:
+  reviewer:
+    provider: codex
+`))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	if normalized.Agents[0].Workspace != nil {
+		t.Fatalf("workspace = %#v, want nil", normalized.Agents[0].Workspace)
+	}
+}
+
+func TestNormalizeRejectsEmptyAgentWorkspaceObject(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: empty-workspace
+workspaces:
+  repo-root:
+    provider: local
+    path: .
+agents:
+  reviewer:
+    provider: codex
+    workspace: {}
+`)
+
+	_, err := Normalize(spec, NormalizeOptions{})
+	if err == nil {
+		t.Fatalf("expected Normalize to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "agents.reviewer.workspace") || !strings.Contains(got, "required") {
+		t.Fatalf("error = %q, want empty workspace validation error", got)
+	}
+}
+
+func TestNormalizeRejectsEmptyAgentWorkspaceObjectWithoutGlobals(t *testing.T) {
+	spec, err := Parse([]byte(`
+name: empty-workspace-no-globals
+agents:
+  reviewer:
+    provider: codex
+    workspace: {}
+`))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	_, err = Normalize(spec, NormalizeOptions{})
+	if err == nil {
+		t.Fatalf("expected Normalize to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "agents.reviewer.workspace") || !strings.Contains(got, "required") {
+		t.Fatalf("error = %q, want empty workspace validation error", got)
+	}
+}
+
+func TestNormalizeAllowsNamedInlineAgentWorkspaceDefinition(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: mixed-workspace
 workspaces:
@@ -841,12 +904,12 @@ agents:
       path: .
 `)
 
-	_, err := Normalize(spec, NormalizeOptions{})
-	if err == nil {
-		t.Fatalf("expected Normalize to fail")
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
 	}
-	if got := err.Error(); !strings.Contains(got, "agents.reviewer.workspace") || !strings.Contains(got, "name") {
-		t.Fatalf("error = %q, want mixed workspace error", got)
+	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Name != "repo-root" || normalized.Agents[0].Workspace.Provider != "local" || normalized.Agents[0].Workspace.Path != "." {
+		t.Fatalf("workspace = %#v", normalized.Agents[0].Workspace)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow agents to omit `workspace` entirely without requiring project-level workspaces
- keep `workspace: {}` invalid so explicit empty workspace configs still fail validation
- support `agent.workspace.name` as an inline workspace alias when provider/url/path fields are also present

## Testing
- `task lint`
- `task build`
- `task test`

## Coverage
- Unit: 78.44%
- Integration: 68.99%
- E2E: 65.47%
- Combined: 80.06%