### PR TITLE
fix(config): ignore legacy sessions file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -672,7 +672,7 @@ func pathHasEntries(path string) (bool, error) {
 		return false, err
 	}
 	if !info.IsDir() {
-		return true, nil
+		return false, nil
 	}
 	entries, err := os.ReadDir(path)
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -253,6 +253,29 @@ func TestNewConfigUsesNonEmptyLegacySessionsRootByDefault(t *testing.T) {
 	}
 }
 
+func TestNewConfigIgnoresLegacySessionsRootFile(t *testing.T) {
+	dataRoot := filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(dataRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyRoot := filepath.Join(dataRoot, "sessions")
+	if err := os.WriteFile(legacyRoot, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DATA_ROOT", dataRoot)
+	di := do.New()
+	do.ProvideValue(di, slog.Default())
+	config, err := NewConfig(di)
+	if err != nil {
+		t.Fatalf("NewConfig returned error: %v", err)
+	}
+	want := filepath.Join(dataRoot, "sandboxes")
+	if config.SandboxRoot != want || config.SandboxRootExplicit {
+		t.Fatalf("SandboxRoot = %q, explicit = %t; want %q, false", config.SandboxRoot, config.SandboxRootExplicit, want)
+	}
+}
+
 func TestNewConfigUsesSandboxEnvironmentWhenLegacyAlsoSet(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("DATA_ROOT", filepath.Join(root, "data"))


### PR DESCRIPTION
## Summary

- treat an existing non-directory legacy sessions path as having no migratable entries
- fall back to the default sandboxes root instead of selecting a file as `SandboxRoot`
- add a regression test for a regular file at `<DATA_ROOT>/sessions`

## Testing

- `task lint`
- `task test`

## Checklist

- [x] Documentation not required; this restores the intended default-root behavior.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.