### PR TITLE
fix: use bare sha256 hashes for resource ids

### DIFF
--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -139,7 +139,7 @@ func TestMicrosandboxPrepareEnvironmentPreservesDockerDisks(t *testing.T) {
 func TestMicrosandboxRemoveDockerDiskOnlyCurrentSession(t *testing.T) {
 	config := testMicrosandboxConfig(t)
 	runtime := &microsandboxRuntime{config: config}
-	currentID := identity.NewRandomID(identity.ResourceSandbox)
+	currentID := identity.Prefix + identity.NewRandomID(identity.ResourceSandbox)
 	otherID := identity.NewRandomID(identity.ResourceSandbox)
 	current := writeMicrosandboxFile(t, config.MicrosandboxHome, "docker-disks", microsandboxDockerDiskName(currentID)+".raw")
 	legacyCurrent := writeMicrosandboxFile(t, config.MicrosandboxHome, "docker-disks", currentID+".raw")
@@ -161,7 +161,7 @@ func TestMicrosandboxRemoveDockerDiskOnlyCurrentSession(t *testing.T) {
 func TestMicrosandboxEnsureDockerDiskMigratesLegacyPath(t *testing.T) {
 	config := testMicrosandboxConfig(t)
 	runtime := &microsandboxRuntime{config: config}
-	sandboxID := identity.NewRandomID(identity.ResourceSandbox)
+	sandboxID := identity.Prefix + identity.NewRandomID(identity.ResourceSandbox)
 	legacy := writeMicrosandboxFile(t, config.MicrosandboxHome, "docker-disks", sandboxID+".raw")
 
 	got, err := runtime.ensureDockerDisk(sandboxID)

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -10,12 +10,15 @@ import (
 )
 
 const (
-	idPrefix      = "sha256:"
-	hashHexLength = sha256.Size * 2
-	shortIDLength = 12
+	legacyIDPrefix = "sha256:"
+	hashHexLength  = sha256.Size * 2
+	shortIDLength  = 12
 )
 
-const Prefix = idPrefix
+// Prefix is retained for callers that need to recognize identities written by
+// releases that included the digest algorithm in the ID. New IDs are bare
+// SHA-256 hex values.
+const Prefix = legacyIDPrefix
 
 type ResourceKind string
 
@@ -37,7 +40,7 @@ func NewID(kind ResourceKind, parts ...string) string {
 	for _, part := range parts {
 		writePart(h, part)
 	}
-	return idPrefix + hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func NewRandomID(kind ResourceKind) string {
@@ -49,16 +52,16 @@ func NewRandomID(kind ResourceKind) string {
 }
 
 func ShortID(id string) string {
-	id = strings.TrimSpace(id)
-	if !IsID(id) {
+	hash, err := Hash(id)
+	if err != nil {
 		return ""
 	}
-	return id[len(idPrefix) : len(idPrefix)+shortIDLength]
+	return hash[:shortIDLength]
 }
 
 func Hash(id string) (string, error) {
 	id = strings.TrimSpace(strings.ToLower(id))
-	id = strings.TrimPrefix(id, idPrefix)
+	id = strings.TrimPrefix(id, legacyIDPrefix)
 	if len(id) != hashHexLength || !isLowerHex(id) {
 		return "", fmt.Errorf("invalid sha256 identity")
 	}
@@ -67,15 +70,13 @@ func Hash(id string) (string, error) {
 
 func IsID(id string) bool {
 	id = strings.TrimSpace(id)
-	if len(id) != len(idPrefix)+hashHexLength || !strings.HasPrefix(id, idPrefix) {
-		return false
-	}
-	return isLowerHex(id[len(idPrefix):])
+	id = strings.TrimPrefix(id, legacyIDPrefix)
+	return len(id) == hashHexLength && isLowerHex(id)
 }
 
 func IsIDPrefix(id string) bool {
 	id = strings.TrimSpace(strings.ToLower(id))
-	id = strings.TrimPrefix(id, idPrefix)
+	id = strings.TrimPrefix(id, legacyIDPrefix)
 	return len(id) >= shortIDLength && len(id) <= hashHexLength && isLowerHex(id)
 }
 

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -9,6 +9,9 @@ import (
 
 func TestNewIDAndShortID(t *testing.T) {
 	id := identity.NewID(identity.ResourceProject, "demo", "/repo/agent-compose.yml")
+	if strings.HasPrefix(id, identity.Prefix) || len(id) != 64 {
+		t.Fatalf("NewID = %q, want bare SHA-256 hex", id)
+	}
 	if !identity.IsID(id) {
 		t.Fatalf("NewID = %q, want sha256 id", id)
 	}
@@ -50,5 +53,19 @@ func TestIDValidationRejectsInvalidForms(t *testing.T) {
 		if identity.IsShortID(value) {
 			t.Fatalf("IsShortID(%q) = true, want false", value)
 		}
+	}
+}
+
+func TestLegacyPrefixedIDRemainsReadable(t *testing.T) {
+	id := identity.NewID(identity.ResourceProject, "legacy")
+	legacyID := identity.Prefix + id
+	if !identity.IsID(legacyID) {
+		t.Fatalf("IsID(%q) = false, want legacy compatibility", legacyID)
+	}
+	if got := identity.ShortID(legacyID); got != id[:12] {
+		t.Fatalf("ShortID(%q) = %q, want %q", legacyID, got, id[:12])
+	}
+	if got, err := identity.Hash(legacyID); err != nil || got != id {
+		t.Fatalf("Hash(%q) = %q, %v, want %q", legacyID, got, err, id)
 	}
 }

--- a/pkg/runtimecache/id.go
+++ b/pkg/runtimecache/id.go
@@ -49,7 +49,7 @@ func ParseCacheID(cacheID string) (ParsedCacheID, error) {
 	if err != nil {
 		return ParsedCacheID{}, fmt.Errorf("%w: %v", ErrInvalidCacheID, err)
 	}
-	return ParsedCacheID{ID: identity.Prefix + hash, Hash: hash}, nil
+	return ParsedCacheID{ID: hash, Hash: hash}, nil
 }
 
 func ShortCacheID(cacheID string) string {
@@ -71,7 +71,8 @@ func ResolveCacheID(items []Item, ref string) (string, error) {
 	ref = strings.TrimSpace(strings.ToLower(ref))
 	if parsed, err := ParseCacheID(ref); err == nil {
 		for _, item := range items {
-			if strings.EqualFold(item.CacheID, parsed.ID) {
+			itemHash, hashErr := identity.Hash(item.CacheID)
+			if hashErr == nil && itemHash == parsed.Hash {
 				return item.CacheID, nil
 			}
 		}

--- a/pkg/runtimecache/id_path_test.go
+++ b/pkg/runtimecache/id_path_test.go
@@ -11,7 +11,7 @@ import (
 	"agent-compose/pkg/identity"
 )
 
-var testCacheIDRE = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+var testCacheIDRE = regexp.MustCompile(`^[a-f0-9]{64}$`)
 
 func TestGenerateCacheIDIsStableAndDistinct(t *testing.T) {
 	item := Item{
@@ -46,7 +46,7 @@ func TestGenerateCacheIDIsStableAndDistinct(t *testing.T) {
 	if !testCacheIDRE.MatchString(first) {
 		t.Fatalf("GenerateCacheID = %q, want full sha256 id", first)
 	}
-	if got := ShortCacheID(first); got != strings.TrimPrefix(first, "sha256:")[:12] {
+	if got := ShortCacheID(first); got != first[:12] {
 		t.Fatalf("ShortCacheID = %q", got)
 	}
 
@@ -54,7 +54,7 @@ func TestGenerateCacheIDIsStableAndDistinct(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseCacheID returned error: %v", err)
 	}
-	if parsed.ID != first || parsed.Hash != strings.TrimPrefix(first, "sha256:") {
+	if parsed.ID != first || parsed.Hash != first {
 		t.Fatalf("ParseCacheID = %#v", parsed)
 	}
 }
@@ -114,13 +114,17 @@ func TestResolveCacheIDExactAndPrefix(t *testing.T) {
 		t.Fatalf("ResolveCacheID exact = %q, want %q", resolved, first.CacheID)
 	}
 
-	bareFirst := strings.TrimPrefix(first.CacheID, identity.Prefix)
-	resolved, err = ResolveCacheID(items, bareFirst)
+	legacyFirst := identity.Prefix + first.CacheID
+	resolved, err = ResolveCacheID(items, legacyFirst)
 	if err != nil {
-		t.Fatalf("ResolveCacheID bare exact returned error: %v", err)
+		t.Fatalf("ResolveCacheID legacy exact returned error: %v", err)
 	}
 	if resolved != first.CacheID {
-		t.Fatalf("ResolveCacheID bare exact = %q, want %q", resolved, first.CacheID)
+		t.Fatalf("ResolveCacheID legacy exact = %q, want %q", resolved, first.CacheID)
+	}
+	parsedLegacy, err := ParseCacheID(legacyFirst)
+	if err != nil || parsedLegacy.ID != first.CacheID {
+		t.Fatalf("ParseCacheID legacy = %#v, %v", parsedLegacy, err)
 	}
 
 	prefix := ShortCacheID(second.CacheID)
@@ -136,7 +140,7 @@ func TestResolveCacheIDExactAndPrefix(t *testing.T) {
 func TestResolveCacheIDRejectsInvalidMissingAndAmbiguous(t *testing.T) {
 	first := mustCacheIDItemForResolve(t, "/tmp/runtime-cache-test/first")
 	second := first
-	second.CacheID = "sha256:" + strings.TrimPrefix(first.CacheID, "sha256:")[:12] + strings.Repeat("0", 52)
+	second.CacheID = first.CacheID[:12] + strings.Repeat("0", 52)
 
 	if _, err := ResolveCacheID([]Item{first}, "../bad"); !errors.Is(err, ErrInvalidCacheID) {
 		t.Fatalf("invalid error = %v, want ErrInvalidCacheID", err)


### PR DESCRIPTION
 ## Summary

  - Change generated resource IDs to use bare 64-character SHA-256 hex values instead of the `sha256:<hash>` form.
  - Apply the canonical format to project, agent, scheduler, trigger, loader, run, sandbox, workspace, and runtime cache IDs through the shared identity
  package.
  - Continue accepting legacy `sha256:<hash>` values as input so existing data and CLI references remain compatible.
  - Normalize runtime cache parsing and matching across canonical and legacy ID formats.
  - Keep `sha256:` for OCI digests, spec hashes, webhook token hashes, and event payload checksums because these are algorithm-qualified digests rather than
  resource IDs.

  ## Testing

  - `go test ./pkg/identity ./pkg/runtimecache`
  - `go test ./pkg/identity ./pkg/runtimecache ./pkg/model ./pkg/storage/sessionstore ./pkg/agentcompose/... ./cmd/agent-compose`
  - `task lint`
  - `task build`
  - `task test`
  - `git diff --check`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No operator configuration changed; compatibility behavior is documented inline.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.