### PR TITLE
revert: downgrade microsandbox to 0.5.8 to escape 4GiB bind-mount quota default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     c
 # published checksums. This keeps the FFI lib in lockstep with the
 # microsandbox/sdk/go module pinned in go.mod.
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS microsandbox-fetch
-ARG MICROSANDBOX_VERSION=v0.6.4
+ARG MICROSANDBOX_VERSION=v0.5.8
 ARG TARGETARCH
 ARG HTTP_PROXY
 ARG HTTPS_PROXY

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -188,7 +188,7 @@ tasks:
     generates:
       - build/microsandbox/bin/msb
       - build/microsandbox/bin/agentd
-      - build/microsandbox/lib/libkrunfw.so
+      - build/microsandbox/lib/libkrunfw.so.5.2.1
       - build/microsandbox/lib/libmicrosandbox_go_ffi.so
     cmds:
       - HTTP_PROXY={{.BUILD_HTTP_PROXY}} HTTPS_PROXY={{.BUILD_HTTPS_PROXY}} ALL_PROXY={{.BUILD_ALL_PROXY}} REGISTRY_MIRROR={{.BUILD_REGISTRY_MIRROR}} ./scripts/export-microsandbox-dev-artifact.sh ./build/microsandbox

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/samber/mo v1.16.0
 	github.com/samber/oops v1.21.0
 	github.com/spf13/cobra v1.10.1
-	github.com/superradcompany/microsandbox/sdk/go v0.6.4
+	github.com/superradcompany/microsandbox/sdk/go v0.5.8
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/superradcompany/microsandbox/sdk/go v0.6.4 h1:ITJhhuwM6FTZWgKpA0u2013bav+K4hBCJjCjJBueYqM=
-github.com/superradcompany/microsandbox/sdk/go v0.6.4/go.mod h1:Nqi2S7Xm1lgsUyV2vo21EVTL4de68lVC/YRDApB+2R0=
+github.com/superradcompany/microsandbox/sdk/go v0.5.8 h1:zXQ3S1RokzB8YAGmV5lG+cjrTpebFNKB1lTtrjjF1OY=
+github.com/superradcompany/microsandbox/sdk/go v0.5.8/go.mod h1:Nqi2S7Xm1lgsUyV2vo21EVTL4de68lVC/YRDApB+2R0=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/scripts/export-microsandbox-dev-artifact.sh
+++ b/scripts/export-microsandbox-dev-artifact.sh
@@ -14,7 +14,7 @@ mkdir -p "$OUT_DIR"
 
 if [ -x "$OUT_DIR/bin/msb" ] &&
   [ -x "$OUT_DIR/bin/agentd" ] &&
-  [ -s "$OUT_DIR/lib/libkrunfw.so" ] &&
+  [ -s "$OUT_DIR/lib/libkrunfw.so.5.2.1" ] &&
   [ -s "$OUT_DIR/lib/libmicrosandbox_go_ffi.so" ]; then
   echo "Microsandbox dev artifacts already exist in $OUT_DIR"
   exit 0


### PR DESCRIPTION
## Background

microsandbox v0.5.10 onward (introduced in PR #1020, commit `db631a58`, dated 2026-06-24) forces a 4 GiB guest-write default quota on every directory-type bind mount, with no way to disable it.

agent-compose's commit `16a7be1` (2026-07-06) bumped microsandbox from 0.5.8 to 0.6.4, crossing that line. As a result, the microsandbox VM's `/data` bind mount (the bind mount backing the entire session sandbox directory) gets capped at "existing content + 4GiB", and any large-workspace task hits ENOSPC deterministically. Project "jupiter" (git clone alone is 4.1G) hit this and caused production incident `evt_2732645e`.

Additionally, the Go SDK's bind-mount code path silently drops the `QuotaMiB` value agent-compose explicitly sets (an FFI gap), so there is no way to override the default via `MICROSANDBOX_BIND_QUOTA_GB` either.

This PR reverts microsandbox back to the last version WITHOUT the forced default quota: **0.5.8** (the verified production config from four days before the bad bump). This is a stop-gap; the real fix (forwarding quota through the Go SDK) is being worked on upstream in microsandbox in parallel.

## Changes

- **`go.mod` / `go.sum`**: `github.com/superradcompany/microsandbox/sdk/go` `v0.6.4` -> `v0.5.8` (via `go get ...@v0.5.8` + `go mod tidy`).
- **`Dockerfile`**: `MICROSANDBOX_VERSION` build arg `v0.6.4` -> `v0.5.8`. This is the precompiled-artifact pin (msb/agentd/libkrunfw/libmicrosandbox_go_ffi.so) - the 4GiB default is compiled into that FFI `.so`/runtime binary, so reverting only `go.mod` would not actually change the enforced behavior at runtime.
- **`Taskfile.yml`** / **`scripts/export-microsandbox-dev-artifact.sh`**: the generated/expected libkrunfw artifact filename reverts to the real (non-symlink) file the 0.5.8 release ships, `libkrunfw.so.5.2.1` (0.6.4 shipped a differently-versioned file, which is why `16a7be1` switched these to the generic `libkrunfw.so` symlink name).

### Deliberately NOT changed

- **boxlite stays at v0.9.7** (untouched by this revert). `BOXLITE_VERSION` and `MICROSANDBOX_VERSION` are already independent Dockerfile ARGs with no shared pin, so no split was needed.
- **`pkg/driver/microsandbox_runtime.go`'s `resolveLibkrunfwPath`** (the glob + numeric-version-comparison lookup added in `16a7be1`) is left exactly as-is. It scans the lib directory for real (non-symlink) files matching `libkrunfw.so.<N>[.<N>...]` and picks the highest version - this correctly matches 0.5.8's `libkrunfw.so.5.2.1` artifact (a real file, highest/only version present). Existing unit tests (`TestMicrosandboxResolveLibkrunfwUsesNumericVersionOrder`, and the smoke-test fixture at `microsandbox_runtime_test.go:430`) already exercise this exact filename pattern and pass.
- **Commit `c89bfc5`** (sets `QuotaMiB` on bind mounts) is left in place. That struct field exists in the 0.5.8 SDK too - it compiles fine and 0.5.8 just ignores/no-ops it at runtime, so it will activate automatically once a future upgrade restores real quota support.

## Verification

- `go build ./...` - clean pass, no output/errors.
- `go test ./pkg/...` - 35 packages pass. `pkg/volumes` fails (`TestManagerResolveBindAndNamedVolumeMounts`, `TestBindResolverResolvesRelativeAbsoluteAndSymlinkDirectories`), but this failure is **pre-existing and unrelated**: reproduced identically on unmodified `main` in a clean checkout, it's a macOS `/private/var` vs `/var` symlink-resolution artifact of the local test environment, not caused by this change. All microsandbox-specific tests in `pkg/driver` (35 tests including `resolveLibkrunfw*` and the `QuotaMiB` bind-mount tests) pass.

## Note

Deploy decision is left to the reviewer; the proper Go SDK quota-forwarding fix is being worked on upstream in parallel.
