### PR TITLE
fix: harden attach stream shutdown

### DIFF
--- a/cmd/agent-compose/listen_security_test.go
+++ b/cmd/agent-compose/listen_security_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestIsLoopbackListenAddress(t *testing.T) {
+	tests := []struct {
+		address string
+		want    bool
+	}{
+		{address: "127.0.0.1:7410", want: true},
+		{address: "[::1]:7410", want: true},
+		{address: "localhost:7410", want: true},
+		{address: "0.0.0.0:7410", want: false},
+		{address: ":7410", want: false},
+		{address: "192.0.2.1:7410", want: false},
+		{address: "invalid", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.address, func(t *testing.T) {
+			if got := isLoopbackListenAddress(tt.address); got != tt.want {
+				t.Fatalf("isLoopbackListenAddress(%q) = %t, want %t", tt.address, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -238,10 +238,26 @@ func (a *DaemonApp) listen() (*daemonServers, error) {
 			shutdownErr := servers.shutdown(context.Background())
 			return nil, errors.Join(fmt.Errorf("listen HTTP_LISTEN %q: %w", a.Config.HttpListen, err), shutdownErr)
 		}
+		if !isLoopbackListenAddress(a.Config.HttpListen) {
+			a.Logger.Warn("HTTP_LISTEN exposes unencrypted h2c traffic; use a TLS-terminating reverse proxy before exposing this listener", "address", a.Config.HttpListen)
+		}
 		servers.add("HTTP_LISTEN", a.Config.HttpListen, tcpListener, a.Echo, nil)
 	}
 
 	return servers, nil
+}
+
+func isLoopbackListenAddress(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return false
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (s *daemonServers) add(name, value string, listener net.Listener, handler http.Handler, cleanup func() error) {

--- a/pkg/agentcompose/api/attach_input_test.go
+++ b/pkg/agentcompose/api/attach_input_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	driverpkg "agent-compose/pkg/driver"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestPumpExecAttachInputClosesRuntimeInputOnReceiveError(t *testing.T) {
+	interaction := &execClosingRuntimeInteraction{}
+	pumpExecAttachInput(func() (*agentcomposev2.ExecAttachRequest, error) {
+		return nil, errors.New("stream reset")
+	}, interaction)
+	if interaction.closeCalls != 1 {
+		t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
+	}
+}
+
+type execClosingRuntimeInteraction struct {
+	closeCalls int
+}
+
+func (*execClosingRuntimeInteraction) Send(driverpkg.RuntimeInputFrame) error { return nil }
+
+func (i *execClosingRuntimeInteraction) CloseSend() error {
+	i.closeCalls++
+	return nil
+}
+
+func (*execClosingRuntimeInteraction) Recv() (driverpkg.RuntimeOutputFrame, error) {
+	return driverpkg.RuntimeOutputFrame{}, errors.New("unused")
+}
+
+func (*execClosingRuntimeInteraction) Wait() (driverpkg.RuntimeResult, error) {
+	return driverpkg.RuntimeResult{}, errors.New("unused")
+}

--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -371,12 +371,10 @@ func (h *ExecHandler) prepareExecAttach(ctx context.Context, start *agentcompose
 }
 
 func pumpExecAttachInput(receive execAttachReceiver, interaction driverpkg.RuntimeInteraction) {
+	defer func() { _ = interaction.CloseSend() }()
 	for {
 		req, err := receive()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				_ = interaction.CloseSend()
-			}
 			return
 		}
 		frame, ok := runtimeInputFrameFromExecAttach(req)

--- a/pkg/runs/attach_input_test.go
+++ b/pkg/runs/attach_input_test.go
@@ -1,0 +1,60 @@
+package runs
+
+import (
+	"errors"
+	"testing"
+
+	driverpkg "agent-compose/pkg/driver"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
+	receiveErr := errors.New("stream reset")
+
+	t.Run("command", func(t *testing.T) {
+		interaction := &closingRuntimeInteraction{}
+		pumpRunAttachInput(func() (*agentcomposev2.RunAttachRequest, error) {
+			return nil, receiveErr
+		}, interaction)
+		if interaction.closeCalls != 1 {
+			t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
+		}
+	})
+
+	t.Run("prompt", func(t *testing.T) {
+		interaction := &closingRuntimeInteraction{}
+		input := &promptWrapperInput{interaction: interaction}
+		pumpRunPromptAttachInput(func() (*agentcomposev2.RunAttachRequest, error) {
+			return nil, receiveErr
+		}, input, nil)
+		if interaction.closeCalls != 1 {
+			t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
+		}
+		if len(interaction.sent) != 1 || string(interaction.sent[0].Data) != "{\"seq\":0,\"type\":\"eof\",\"v\":1}\n" {
+			t.Fatalf("sent frames = %#v, want prompt EOF", interaction.sent)
+		}
+	})
+}
+
+type closingRuntimeInteraction struct {
+	sent       []driverpkg.RuntimeInputFrame
+	closeCalls int
+}
+
+func (i *closingRuntimeInteraction) Send(frame driverpkg.RuntimeInputFrame) error {
+	i.sent = append(i.sent, frame)
+	return nil
+}
+
+func (i *closingRuntimeInteraction) CloseSend() error {
+	i.closeCalls++
+	return nil
+}
+
+func (*closingRuntimeInteraction) Recv() (driverpkg.RuntimeOutputFrame, error) {
+	return driverpkg.RuntimeOutputFrame{}, errors.New("unused")
+}
+
+func (*closingRuntimeInteraction) Wait() (driverpkg.RuntimeResult, error) {
+	return driverpkg.RuntimeResult{}, errors.New("unused")
+}

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1243,12 +1243,10 @@ func errorFromRuntimeResult(result driverpkg.RuntimeResult) error {
 }
 
 func pumpRunAttachInput(receive RunAttachReceiver, interaction driverpkg.RuntimeInteraction) {
+	defer func() { _ = interaction.CloseSend() }()
 	for {
 		req, err := receive()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				_ = interaction.CloseSend()
-			}
 			return
 		}
 		frame, ok := runtimeInputFrameFromRunAttach(req)
@@ -1337,13 +1335,11 @@ func (w *promptWrapperInput) send(frame map[string]any) error {
 }
 
 func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInput, onHumanMessage func(string) error) {
+	defer func() { _ = input.interaction.CloseSend() }()
 	for {
 		req, err := receive()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				_ = input.EOF()
-				_ = input.interaction.CloseSend()
-			}
+			_ = input.EOF()
 			return
 		}
 		switch frame := req.GetFrame().(type) {
@@ -1369,11 +1365,9 @@ func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInp
 			}
 		case *agentcomposev2.RunAttachRequest_StdinEof:
 			_ = input.EOF()
-			_ = input.interaction.CloseSend()
 			return
 		case *agentcomposev2.RunAttachRequest_Cancel:
 			_ = input.Cancel(frame.Cancel.GetReason())
-			_ = input.interaction.CloseSend()
 			return
 		default:
 			_ = input.Cancel("invalid run prompt attach frame")


### PR DESCRIPTION
## Summary

  - Ensure command, prompt, and exec attach input pumps close runtime stdin on every exit path, including non-EOF transport errors.
  - Send the prompt protocol EOF frame before closing runtime input when the client stream disconnects unexpectedly.
  - Warn operators when `HTTP_LISTEN` exposes unencrypted h2c traffic on a non-loopback address and recommend TLS termination.
  - Add regression tests for attach input shutdown and loopback listener classification.
  - Re-audit the remaining MonkeyScan findings from #240:
    - `promptAttachProjector` does not hold `p.mu` in `Project`, so the reported reentrant mutex path is not present.
    - `RunLogHub` send and close operations are synchronized by its RWMutex.
    - Dropped hub notifications do not lose persisted logs because `FollowRunLogs` reconciles the log file by offset.

  ## Testing

  - `task lint`
  - `task build`
  - `task test`
  - `go test ./pkg/runs ./pkg/agentcompose/api ./cmd/agent-compose`
  - `go test -race ./pkg/runs ./pkg/agentcompose/api`
  - `git diff --check`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.