### PR TITLE
fix(cli): split missing project guidance into two lines

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -7943,7 +7943,7 @@ func commandExitErrorForComposeProject(err error, command, projectName, composeP
 		return commandExitError{
 			Code: exitCodeUsage,
 			Err: fmt.Errorf(
-				"project %q has not been started on this daemon or was removed by `agent-compose down`; run `agent-compose up --file %s` before `agent-compose %s`",
+				"project %q is not running: it has not been started on this daemon or was removed by `agent-compose down`.\nTo start it, run `agent-compose up --file %s` before `agent-compose %s`",
 				projectName,
 				composePath,
 				command,

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -4189,14 +4189,11 @@ agents:
 			if stdout != "" {
 				t.Fatalf("%s missing project stdout = %q, want empty", tc.name, stdout)
 			}
-			for _, want := range []string{
-				`project "cli-ps-missing" has not been started on this daemon or was removed by ` + "`agent-compose down`",
-				"agent-compose up --file " + composePath,
-				"before `agent-compose " + tc.wantCommand + "`",
-			} {
-				if !strings.Contains(stderr, want) {
-					t.Fatalf("%s missing project stderr = %q, want %q", tc.name, stderr, want)
-				}
+			want := `project "cli-ps-missing" is not running: it has not been started on this daemon or was removed by ` +
+				"`agent-compose down`.\n" +
+				"To start it, run `agent-compose up --file " + composePath + "` before `agent-compose " + tc.wantCommand + "`"
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("%s missing project stderr = %q, want two-line message %q", tc.name, stderr, want)
 			}
 			for _, notWant := range []string{"not_found", "sql: no rows"} {
 				if strings.Contains(stderr, notWant) {


### PR DESCRIPTION
## Summary

  - Split the missing-project CLI error into two lines for better readability.
  - Clearly separate the project status and possible cause from the suggested recovery command.
  - Update integration tests to verify the two-line output for `ps`, `stats`, and `inspect`.
  - No documentation update is required because this only improves existing CLI error formatting.

  ## Testing

  - `go test ./cmd/agent-compose -run '^TestIntegrationCLIProjectCommandsMissingProjectAreFriendly$' -count=1`
  - `go test ./cmd/agent-compose -count=1`
  - `git diff --check`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.