### PR TITLE
fix(volume): make forced removal transactional

### DIFF
--- a/pkg/storage/configstore/volume_store.go
+++ b/pkg/storage/configstore/volume_store.go
@@ -205,12 +205,23 @@ func (s *volumeStore) DeleteVolume(ctx context.Context, nameOrID string) error {
 	if err != nil {
 		return err
 	}
-	result, err := s.db.ExecContext(ctx, `DELETE FROM volumes WHERE id = ?`, item.ID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin delete volume %s: %w", item.Name, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM project_volumes WHERE volume_id = ?`, item.ID); err != nil {
+		return fmt.Errorf("delete project references for volume %s: %w", item.Name, err)
+	}
+	result, err := tx.ExecContext(ctx, `DELETE FROM volumes WHERE id = ?`, item.ID)
 	if err != nil {
 		return fmt.Errorf("delete volume %s: %w", item.Name, err)
 	}
 	if rows, _ := result.RowsAffected(); rows == 0 {
 		return domain.ResourceError(domain.ErrNotFound, "volume", item.Name, fmt.Sprintf("volume %s not found", item.Name), nil)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit delete volume %s: %w", item.Name, err)
 	}
 	return nil
 }

--- a/pkg/storage/configstore/volume_store_test.go
+++ b/pkg/storage/configstore/volume_store_test.go
@@ -106,3 +106,67 @@ func TestVolumeStoreCRUDAndReferences(t *testing.T) {
 		t.Fatalf("GetVolume after DeleteVolume err = %v, want ErrNotFound", err)
 	}
 }
+
+func TestDeleteVolumeRemovesProjectReferencesTransactionally(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	store := FromDB(db)
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("initSchema: %v", err)
+	}
+	created, err := store.CreateVolume(ctx, domain.VolumeRecord{
+		ID:     "vol-force-remove",
+		Name:   "force-remove-cache",
+		Driver: domain.VolumeDriverLocal,
+		Path:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	if err := store.ReplaceProjectVolumes(ctx, "project-1", map[string]domain.ProjectVolumeLink{
+		"cache": {VolumeID: created.ID},
+	}); err != nil {
+		t.Fatalf("ReplaceProjectVolumes: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `CREATE TRIGGER fail_volume_delete
+		BEFORE DELETE ON volumes BEGIN SELECT RAISE(ABORT, 'forced delete failure'); END;`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	if err := store.DeleteVolume(ctx, created.ID); err == nil {
+		t.Fatal("DeleteVolume with failing volume delete returned nil")
+	}
+	if _, err := store.GetVolume(ctx, created.ID); err != nil {
+		t.Fatalf("GetVolume after rolled back delete: %v", err)
+	}
+	projectVolumes, err := store.ListProjectVolumes(ctx, "project-1")
+	if err != nil {
+		t.Fatalf("ListProjectVolumes after rolled back delete: %v", err)
+	}
+	if projectVolumes["cache"].ID != created.ID {
+		t.Fatalf("project volumes after rolled back delete = %#v, want volume %s", projectVolumes, created.ID)
+	}
+
+	if _, err := db.ExecContext(ctx, `DROP TRIGGER fail_volume_delete`); err != nil {
+		t.Fatalf("drop failure trigger: %v", err)
+	}
+	if err := store.DeleteVolume(ctx, created.ID); err != nil {
+		t.Fatalf("DeleteVolume: %v", err)
+	}
+	if _, err := store.GetVolume(ctx, created.ID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("GetVolume after DeleteVolume err = %v, want ErrNotFound", err)
+	}
+	projectVolumes, err = store.ListProjectVolumes(ctx, "project-1")
+	if err != nil {
+		t.Fatalf("ListProjectVolumes after DeleteVolume: %v", err)
+	}
+	if len(projectVolumes) != 0 {
+		t.Fatalf("project volumes after DeleteVolume = %#v, want none", projectVolumes)
+	}
+}

--- a/pkg/volumes/manager_integration_test.go
+++ b/pkg/volumes/manager_integration_test.go
@@ -95,3 +95,56 @@ func TestIntegrationManagerPersistsProjectVolumeLifecycle(t *testing.T) {
 		t.Fatalf("project volume path stat err = %v, want not exist", err)
 	}
 }
+
+func TestIntegrationManagerForceRemoveDeletesProjectLinksAndData(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	store := configstore.FromDB(db)
+	if err := store.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	manager := volumes.NewManager(store, volumes.LocalDriver{DataRoot: t.TempDir()})
+	volume, err := manager.Create(ctx, domain.VolumeRecord{Name: "force-remove-cache"})
+	if err != nil {
+		t.Fatalf("Create volume: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(volume.Path, "value.txt"), []byte("preserve until removal\n"), 0o644); err != nil {
+		t.Fatalf("write volume data: %v", err)
+	}
+	if err := manager.ReplaceProjectVolumes(ctx, "project-1", map[string]domain.ProjectVolumeLink{
+		"cache": {VolumeID: volume.ID},
+	}); err != nil {
+		t.Fatalf("ReplaceProjectVolumes: %v", err)
+	}
+
+	if err := manager.Remove(ctx, volume.Name, false); !errors.Is(err, domain.ErrReferenced) {
+		t.Fatalf("Remove without force err = %v, want ErrReferenced", err)
+	}
+	if _, err := os.Stat(volume.Path); err != nil {
+		t.Fatalf("volume path after rejected removal: %v", err)
+	}
+
+	if err := manager.Remove(ctx, volume.Name, true); err != nil {
+		t.Fatalf("Remove with force: %v", err)
+	}
+	if _, err := store.GetVolume(ctx, volume.ID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("GetVolume after force removal err = %v, want ErrNotFound", err)
+	}
+	projectVolumes, err := store.ListProjectVolumes(ctx, "project-1")
+	if err != nil {
+		t.Fatalf("ListProjectVolumes after force removal: %v", err)
+	}
+	if len(projectVolumes) != 0 {
+		t.Fatalf("project volumes after force removal = %#v, want none", projectVolumes)
+	}
+	if _, err := os.Stat(volume.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("volume path stat after force removal err = %v, want not exist", err)
+	}
+}


### PR DESCRIPTION
## Summary

- remove project-volume links and the volume record in one SQLite transaction during forced removal
- preserve the existing force semantics: config references are bypassed, while active sandbox references remain protected
- add store-level rollback coverage and a real SQLite + local volume driver integration regression test

## AC-VOLUME-001 reproduction

Before this change, removing a project-linked volume with force produced:

- a FOREIGN KEY constraint failure from deleting the volume record
- a remaining volumes row
- a remaining project_volumes row
- an already-deleted local volume directory

This left the daemon in a partial deletion state even though the operation returned an error.

After this change, the same scenario succeeds and removes the project link, volume record, and local directory. If deleting the volume record fails, the project-link deletion rolls back in the same transaction.

## Validation

- independent SQLite + local driver reproduction before and after the fix
- task lint
- task test
  - Unit: 76.89%
  - Integration: 64.41%
  - E2E: 61.57%
  - Combined: 79.54%
- task build
- git diff --check
