### PR TITLE
fix(cli): improve volume project display

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -794,6 +794,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		},
 	}
 	addVolumeListFlags(volumeLSCmd, &volumeLSOptions)
+	volumeLSCmd.Flags().BoolVar(&volumeLSOptions.Verbose, "verbose", false, "Show the full project id")
 	volumeCreateOptions := composeVolumeCreateOptions{}
 	volumeCreateCmd := &cobra.Command{
 		Use:   "create <name>",
@@ -1102,6 +1103,7 @@ type composeVolumeListOptions struct {
 	Query     string
 	Driver    string
 	ProjectID string
+	Verbose   bool
 }
 
 type composeVolumeCreateOptions struct {
@@ -3646,6 +3648,11 @@ func runComposeVolumeListCommand(cmd *cobra.Command, cli cliOptions, options com
 		return commandExitErrorForConnect(fmt.Errorf("list volumes: %w", err))
 	}
 	output := composeVolumeListOutputFromResponse(resp.Msg)
+	projects, err := listAllProjects(cmd.Context(), clients.project)
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("list projects for volumes: %w", err))
+	}
+	setComposeVolumeProjectNames(output.Volumes, projects.Projects)
 	if cli.JSON {
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
@@ -3653,7 +3660,7 @@ func runComposeVolumeListCommand(cmd *cobra.Command, cli cliOptions, options com
 		}
 		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
 	}
-	return writeVolumesText(cmd.OutOrStdout(), output.Volumes)
+	return writeVolumesText(cmd.OutOrStdout(), output.Volumes, options.Verbose)
 }
 
 func runComposeVolumeCreateCommand(cmd *cobra.Command, cli cliOptions, options composeVolumeCreateOptions, name string) error {
@@ -4883,14 +4890,15 @@ type composeVolumePruneOutput struct {
 }
 
 type composeVolumeOutput struct {
-	Name      string            `json:"name"`
-	Driver    string            `json:"driver"`
-	Path      string            `json:"path,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	Options   map[string]string `json:"options,omitempty"`
-	ProjectID string            `json:"project_id,omitempty"`
-	CreatedAt string            `json:"created_at,omitempty"`
-	UpdatedAt string            `json:"updated_at,omitempty"`
+	Name        string            `json:"name"`
+	Driver      string            `json:"driver"`
+	Path        string            `json:"path,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Options     map[string]string `json:"options,omitempty"`
+	ProjectID   string            `json:"project_id,omitempty"`
+	ProjectName string            `json:"project_name,omitempty"`
+	CreatedAt   string            `json:"created_at,omitempty"`
+	UpdatedAt   string            `json:"updated_at,omitempty"`
 }
 
 type composeCacheOutput struct {
@@ -6097,6 +6105,16 @@ func composeVolumeListOutputFromResponse(resp *agentcomposev2.ListVolumesRespons
 	return output
 }
 
+func setComposeVolumeProjectNames(volumes []composeVolumeOutput, projects []composeProjectListItem) {
+	projectNames := make(map[string]string, len(projects))
+	for _, project := range projects {
+		projectNames[project.ID] = project.Name
+	}
+	for index := range volumes {
+		volumes[index].ProjectName = projectNames[displayOpaqueID(volumes[index].ProjectID)]
+	}
+}
+
 func composeVolumePruneOutputFromResponse(resp *agentcomposev2.PruneVolumesResponse) composeVolumePruneOutput {
 	output := composeVolumePruneOutput{
 		DryRun:  resp.GetDryRun(),
@@ -6417,18 +6435,28 @@ func writeCacheInspectText(out io.Writer, output composeCacheInspectOutput) erro
 	return nil
 }
 
-func writeVolumesText(out io.Writer, volumes []composeVolumeOutput) error {
+func writeVolumesText(out io.Writer, volumes []composeVolumeOutput, verbose bool) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "NAME\tDRIVER\tPROJECT\tPATH"); err != nil {
+	header := "NAME\tDRIVER\tPROJECT\tPATH"
+	if verbose {
+		header = "NAME\tDRIVER\tPROJECT\tPROJECT ID\tPATH"
+	}
+	if _, err := fmt.Fprintln(tw, header); err != nil {
 		return err
 	}
 	for _, volume := range volumes {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-			firstNonEmptyString(volume.Name, "-"),
-			firstNonEmptyString(volume.Driver, "-"),
-			firstNonEmptyString(volume.ProjectID, "-"),
-			firstNonEmptyString(volume.Path, "-"),
-		); err != nil {
+		project := firstNonEmptyString(volume.ProjectName, shortOpaqueID(volume.ProjectID), "-")
+		var err error
+		if verbose {
+			_, err = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				firstNonEmptyString(volume.Name, "-"), firstNonEmptyString(volume.Driver, "-"), project,
+				firstNonEmptyString(volume.ProjectID, "-"), firstNonEmptyString(volume.Path, "-"))
+		} else {
+			_, err = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+				firstNonEmptyString(volume.Name, "-"), firstNonEmptyString(volume.Driver, "-"), project,
+				firstNonEmptyString(volume.Path, "-"))
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -5510,6 +5510,14 @@ func TestIntegrationCLIVolumeCommands(t *testing.T) {
 	var createdLabel string
 	var removed []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			listProjects: func(context.Context, *connect.Request[agentcomposev2.ListProjectsRequest]) (*connect.Response[agentcomposev2.ListProjectsResponse], error) {
+				return connect.NewResponse(&agentcomposev2.ListProjectsResponse{Projects: []*agentcomposev2.ProjectSummary{{
+					ProjectId: "project-1",
+					Name:      "volume-sharing",
+				}}}), nil
+			},
+		},
 		volume: volumeServiceStub{
 			listVolumes: func(ctx context.Context, req *connect.Request[agentcomposev2.ListVolumesRequest]) (*connect.Response[agentcomposev2.ListVolumesResponse], error) {
 				listCalls++
@@ -5551,6 +5559,16 @@ func TestIntegrationCLIVolumeCommands(t *testing.T) {
 	})
 	defer server.Close()
 
+	textOut, textErr, _, textCode := executeCLICommand("volume", "ls", "--host", server.URL, "--query", "cac", "--driver", "local")
+	if textCode != 0 || textErr != "" || !strings.Contains(textOut, "volume-sharing") || strings.Contains(textOut, "project-1") {
+		t.Fatalf("volume ls text code/stdout/stderr = %d / %q / %q", textCode, textOut, textErr)
+	}
+
+	verboseOut, verboseErr, _, verboseCode := executeCLICommand("volume", "ls", "--host", server.URL, "--verbose", "--query", "cac", "--driver", "local")
+	if verboseCode != 0 || verboseErr != "" || !strings.Contains(verboseOut, "PROJECT ID") || !strings.Contains(verboseOut, "volume-sharing") || !strings.Contains(verboseOut, "project-1") {
+		t.Fatalf("volume ls --verbose code/stdout/stderr = %d / %q / %q", verboseCode, verboseOut, verboseErr)
+	}
+
 	listOut, listErr, _, listCode := executeCLICommand("volume", "ls", "--host", server.URL, "--json", "--query", "cac", "--driver", "local")
 	if listCode != 0 || listErr != "" {
 		t.Fatalf("volume ls code/stderr = %d / %q", listCode, listErr)
@@ -5559,7 +5577,7 @@ func TestIntegrationCLIVolumeCommands(t *testing.T) {
 	if err := json.Unmarshal([]byte(listOut), &listDecoded); err != nil {
 		t.Fatalf("volume ls JSON decode failed: %v\n%s", err, listOut)
 	}
-	if len(listDecoded.Volumes) != 1 || listDecoded.Volumes[0].Name != "cache" {
+	if len(listDecoded.Volumes) != 1 || listDecoded.Volumes[0].Name != "cache" || listDecoded.Volumes[0].ProjectName != "volume-sharing" || listDecoded.Volumes[0].ProjectID != "project-1" {
 		t.Fatalf("volume ls JSON = %#v", listDecoded)
 	}
 
@@ -5579,7 +5597,7 @@ func TestIntegrationCLIVolumeCommands(t *testing.T) {
 	}
 
 	pruneOut, pruneErr, _, pruneCode := executeCLICommand("volume", "prune", "--host", server.URL, "--driver", "local", "--force")
-	if pruneCode != 0 || pruneErr != "" || !strings.Contains(pruneOut, "Removed 1 volume") || listCalls != 1 {
+	if pruneCode != 0 || pruneErr != "" || !strings.Contains(pruneOut, "Removed 1 volume") || listCalls != 3 {
 		t.Fatalf("volume prune code/stdout/stderr/listCalls = %d / %q / %q / %d", pruneCode, pruneOut, pruneErr, listCalls)
 	}
 }


### PR DESCRIPTION
  ## Summary

  - Prefer the project name in the `PROJECT` column of `agent-compose volume ls`.
  - Fall back to the short project ID when the project name cannot be resolved.
  - Add `--verbose` support to display the full project ID in a separate `PROJECT ID` column.
  - Include both `project_name` and the full `project_id` in JSON output.
  - Update integration tests for default, verbose, and JSON output.

  ## Testing

  - `go test ./cmd/agent-compose -run 'TestIntegrationCLIVolumeCommands|TestCLIHelpUsesSandboxTerminology'`
  - `task lint`
  - `task test`
    - All Go unit tests passed.
    - The runtime frontend test stage could not start because `vitest` is not installed in the local environment.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.