### PR TITLE
fix(cli): unify sandbox and run flags

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -773,7 +773,7 @@
   - 依赖：6.2、8.1。
   - 工作内容：
     - 更新 `cmd/agent-compose/main.go` 中 v2 client request/response 使用 `sandbox_id`、`RunSandboxCleanupPolicy`、`ExecSandboxSelector`。
-    - CLI 命令和 help 使用 `run --sandbox-id`、`ps` 的 `SANDBOX ID`、`exec <sandbox>`、`logs --sandbox`、`inspect sandbox`、`sandbox stop|resume|rm|prune`、`stats <sandbox>`。
+    - CLI 命令和 help 使用 `run --sandbox`、`ps` 的 `SANDBOX ID`、`exec <sandbox>`、`logs --sandbox`、`inspect sandbox`、`sandbox stop|resume|rm|prune`、`stats <sandbox>`。
     - JSON 输出只包含 `sandbox_id`、`sandbox_short_id`、`agent_thread_id`、`thread_id`、`linked_sandbox_id`、`linked_agent_thread_id`。
     - `inspect session <sandbox>` 保留 deprecated alias，stderr 输出 warning，JSON shape 仍为 sandbox output。
   - 可并行子任务：
@@ -805,7 +805,7 @@
 - [x] 9.2 补齐 CLI/E2E 和 compose env 工作流测试
   - 依赖：9.1。
   - 工作内容：
-    - 覆盖 `agent-compose run <agent> --sandbox-id <id>`。
+    - 覆盖 `agent-compose run <agent> --sandbox <id>`。
     - 覆盖 `agent-compose ps --json` 不包含 `session_id`。
     - 覆盖 `agent-compose exec <sandbox> --command ...`。
     - 覆盖 `agent-compose logs --sandbox <sandbox>`。
@@ -824,7 +824,7 @@
   - 完成总结：
     - 状态：已完成。
     - 变更：
-      - 新增 `cmd/agent-compose/cli_sandbox_workflows_e2e_test.go`，用 `TestE2ECLISandboxNamingUserWorkflows` 显式聚合 9.2 要求的 CLI 用户工作流：`run --sandbox-id`、`ps --json` sandbox shape、`exec <sandbox> --command`、`logs --sandbox`、`inspect sandbox`/deprecated `inspect session`、`sandbox stop|resume|rm|prune`。
+      - 新增 `cmd/agent-compose/cli_sandbox_workflows_e2e_test.go`，用 `TestE2ECLISandboxNamingUserWorkflows` 显式聚合 9.2 要求的 CLI 用户工作流：`run --sandbox`、`ps --json` sandbox shape、`exec <sandbox> --command`、`logs --sandbox`、`inspect sandbox`/deprecated `inspect session`、`sandbox stop|resume|rm|prune`。
       - 新增 `cmd/agent-compose/compose_env_e2e_test.go`，解析 `docker-compose.yml` 并审计 `.env.example`、`Dockerfile`，固定远端 compose 使用 published image、`DOCKER_HOST_SANDBOX_ROOT`、`SANDBOX_ROOT=/data/sandboxes`、`./data:/data` 和 `/data/work/.env` 挂载，不暴露 copyable legacy session env 默认值。
     - 验证：
       - `go test ./cmd/agent-compose -run 'TestE2E(CLISandboxNamingUserWorkflows|DockerComposeSandboxEnvContract)$'`

--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -29,7 +29,7 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "run",
 			args: []string{"run", "--help"},
-			want: []string{"Run a project agent", "--prompt", "--command", "--sandbox-id", "--driver", "--keep-running", "--rm", "--jupyter", "--jupyter-expose", "--detach", "--interactive"},
+			want: []string{"Run a project agent", "--prompt", "--command", "--sandbox", "--driver", "--keep-running", "--rm", "--jupyter", "--jupyter-expose", "--detach", "--interactive"},
 		},
 		{
 			name: "scheduler",
@@ -39,12 +39,12 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "scheduler trigger",
 			args: []string{"scheduler", "trigger", "--help"},
-			want: []string{"Manually run a scheduler trigger", "--sandbox-id", "--driver", "--keep-running", "--rm", "--jupyter", "--jupyter-expose", "--detach"},
+			want: []string{"Manually run a scheduler trigger", "--sandbox", "--driver", "--keep-running", "--rm", "--jupyter", "--jupyter-expose", "--detach"},
 		},
 		{
 			name: "logs",
 			args: []string{"logs", "--help"},
-			want: []string{"Print project run logs", "--agent", "--run-id", "--sandbox", "--follow", "--tail", "--timestamp"},
+			want: []string{"Print project run logs", "--agent", "--run", "--sandbox", "--follow", "--tail", "--timestamp"},
 		},
 		{
 			name: "ps",
@@ -59,7 +59,7 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "exec",
 			args: []string{"exec", "--help"},
-			want: []string{"Execute a command in a running sandbox", "--run-id", "--command", "--prompt", "--interactive", "--tty", "--cwd"},
+			want: []string{"Execute a command in a running sandbox", "--run", "--command", "--prompt", "--interactive", "--tty", "--cwd"},
 		},
 		{
 			name: "images",
@@ -126,5 +126,17 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestE2ECLILegacyRunIDFlagIsRejected(t *testing.T) {
+	for _, args := range [][]string{
+		{"logs", "--run-id", "run-1"},
+		{"exec", "--run-id", "run-1", "--command", "true"},
+	} {
+		stdout, stderr, runCount, exitCode := executeCLICommand(args...)
+		if exitCode != exitCodeUsage || stdout != "" || runCount != 0 || !strings.Contains(stderr, "unknown flag: --run-id") {
+			t.Fatalf("%v code/stdout/stderr/runCount = %d / %q / %q / %d", args, exitCode, stdout, stderr, runCount)
+		}
 	}
 }

--- a/cmd/agent-compose/cli_sandbox_workflows_e2e_test.go
+++ b/cmd/agent-compose/cli_sandbox_workflows_e2e_test.go
@@ -8,7 +8,7 @@ func TestE2ECLISandboxNamingUserWorkflows(t *testing.T) {
 		run  func(*testing.T)
 	}{
 		{
-			name: "run --sandbox-id",
+			name: "run --sandbox",
 			run:  TestIntegrationCLIRunStreamsOutputAndSupportsSandboxReuse,
 		},
 		{

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -584,9 +584,9 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 	if err := composeExecArgs(execCmd, nil); err == nil {
 		t.Fatalf("composeExecArgs without target returned nil error")
 	}
-	execCmd.Flags().String("run-id", "", "")
-	if err := execCmd.Flags().Set("run-id", "run-1"); err != nil {
-		t.Fatalf("set exec run-id: %v", err)
+	execCmd.Flags().String("run", "", "")
+	if err := execCmd.Flags().Set("run", "run-1"); err != nil {
+		t.Fatalf("set exec run: %v", err)
 	}
 	if err := composeExecArgs(execCmd, nil); err != nil {
 		t.Fatalf("composeExecArgs with legacy target returned error: %v", err)
@@ -612,8 +612,8 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 		{
 			name: "empty run flag",
 			setup: func(cmd *cobra.Command) composeExecOptions {
-				cmd.Flags().String("run-id", "", "")
-				_ = cmd.Flags().Set("run-id", " ")
+				cmd.Flags().String("run", "", "")
+				_ = cmd.Flags().Set("run", " ")
 				return composeExecOptions{RunID: " ", Command: "pwd"}
 			},
 			wantErr: "requires a value",

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -513,7 +513,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	}
 	runCmd.Flags().StringVar(&runOptions.Prompt, "prompt", "", "Prompt to send to the agent")
 	runCmd.Flags().StringVar(&runOptions.Command, "command", "", "Bash command to execute in the agent sandbox")
-	runCmd.Flags().StringVar(&runOptions.SandboxID, "sandbox-id", "", "Reuse an existing sandbox")
+	runCmd.Flags().StringVar(&runOptions.SandboxID, "sandbox", "", "Reuse an existing sandbox")
 	runCmd.Flags().StringVar(&runOptions.Driver, "driver", "", "Runtime driver override for a new sandbox")
 	runCmd.Flags().BoolVar(&runOptions.KeepRunning, "keep-running", false, "Keep the sandbox runtime running after completion")
 	runCmd.Flags().BoolVar(&runOptions.Remove, "rm", false, "Remove the sandbox after a successful run")
@@ -553,7 +553,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 			return runComposeSchedulerTriggerCommand(cmd, options, schedulerTriggerOptions, args[0], args[1])
 		},
 	}
-	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.SandboxID, "sandbox-id", "", "Reuse an existing sandbox")
+	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.SandboxID, "sandbox", "", "Reuse an existing sandbox")
 	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.Driver, "driver", "", "Runtime driver override for a new sandbox")
 	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.KeepRunning, "keep-running", false, "Keep the sandbox runtime running after completion")
 	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.Remove, "rm", false, "Remove the sandbox after a successful run")
@@ -580,7 +580,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		},
 	}
 	logsCmd.Flags().StringVar(&logsOptions.AgentName, "agent", "", "Filter logs by agent name")
-	logsCmd.Flags().StringVar(&logsOptions.RunID, "run-id", "", "Filter logs by run id")
+	logsCmd.Flags().StringVar(&logsOptions.RunID, "run", "", "Filter logs by run id")
 	logsCmd.Flags().StringVar(&logsOptions.SandboxID, "sandbox", "", "Filter logs by sandbox id")
 	logsCmd.Flags().BoolVar(&logsOptions.Follow, "follow", false, "Follow running run output")
 	logsCmd.Flags().IntVarP(&logsOptions.TailLines, "tail", "n", -1, "Show the last N lines of run output")
@@ -710,7 +710,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		},
 	}
 	// Deprecated: use `agent-compose exec <sandbox>` instead.
-	execCmd.Flags().StringVar(&execOptions.RunID, "run-id", "", "Deprecated target selection by run; use exec <sandbox>")
+	execCmd.Flags().StringVar(&execOptions.RunID, "run", "", "Deprecated target selection by run; use exec <sandbox>")
 	execCmd.Flags().StringVar(&execOptions.Command, "command", "", "Shell command to execute in the sandbox")
 	execCmd.Flags().StringVar(&execOptions.Prompt, "prompt", "", "Prompt the sandbox agent and attach to the response")
 	execCmd.Flags().BoolVarP(&execOptions.Interactive, "interactive", "i", false, "Attach stdin to the sandbox command")
@@ -2001,7 +2001,7 @@ func normalizeComposeSchedulerTriggerOptions(options composeSchedulerTriggerOpti
 		options.Driver = driver
 	}
 	if options.SandboxID != "" && options.Driver != "" {
-		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --driver cannot be combined with --sandbox-id")}
+		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --driver cannot be combined with --sandbox")}
 	}
 	return options, nil
 }
@@ -2492,7 +2492,7 @@ func normalizeComposeRunOptions(cmd *cobra.Command, options composeRunOptions) (
 		options.Driver = driver
 	}
 	if options.SandboxID != "" && options.Driver != "" {
-		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run --driver cannot be combined with --sandbox-id")}
+		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run --driver cannot be combined with --sandbox")}
 	}
 	return options, nil
 }
@@ -2767,7 +2767,7 @@ func shouldResolveComposeLogResourceRef(ref string) bool {
 }
 
 func composeExecArgs(cmd *cobra.Command, args []string) error {
-	if cmd.Flags().Changed("run-id") {
+	if cmd.Flags().Changed("run") {
 		return nil
 	}
 	return cobra.MinimumNArgs(1)(cmd, args)
@@ -3515,8 +3515,8 @@ func normalizeComposeExecRequest(cmd *cobra.Command, clients cliServiceClients, 
 		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires --command or --prompt")}
 	}
 	legacyTargetFlags := []string{}
-	if cmd.Flags().Changed("run-id") {
-		legacyTargetFlags = append(legacyTargetFlags, "--run-id")
+	if cmd.Flags().Changed("run") {
+		legacyTargetFlags = append(legacyTargetFlags, "--run")
 	}
 	if len(legacyTargetFlags) > 1 {
 		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec target can only be specified once")}
@@ -3534,10 +3534,10 @@ func normalizeComposeExecRequest(cmd *cobra.Command, clients cliServiceClients, 
 			Cwd:     strings.TrimSpace(options.Cwd),
 		}
 		switch legacyTargetFlags[0] {
-		case "--run-id":
+		case "--run":
 			runID := strings.TrimSpace(options.RunID)
 			if runID == "" {
-				return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec --run-id requires a value")}
+				return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec --run requires a value")}
 			}
 			runID, err = resolveComposeRunIDRef(cmd.Context(), clients.run, projectID, "", runID)
 			if err != nil {
@@ -7843,7 +7843,7 @@ func detachedRunLogsCommand(cli cliOptions, runID string) string {
 	if value := strings.TrimSpace(cli.ProjectName); value != "" {
 		parts = append(parts, "--project-name", value)
 	}
-	parts = append(parts, "logs", "--run-id", strings.TrimSpace(runID), "--follow")
+	parts = append(parts, "logs", "--run", strings.TrimSpace(runID), "--follow")
 	for i, part := range parts {
 		parts[i] = shellQuoteCLIArg(part)
 	}

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -2592,7 +2592,7 @@ agents:
           cron: "0 2 * * *"
           prompt: review nightly
 `)
-	var sawRequest bool
+	var requestedSandboxIDs []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
@@ -2601,8 +2601,8 @@ agents:
 		},
 		run: runServiceStub{
 			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				sawRequest = true
-				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) || req.Msg.GetSandboxId() != "sandbox-existing" || req.Msg.GetPrompt() != "" || req.Msg.GetCommand() != "" {
+				requestedSandboxIDs = append(requestedSandboxIDs, req.Msg.GetSandboxId())
+				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) || req.Msg.GetPrompt() != "" || req.Msg.GetCommand() != "" {
 					t.Fatalf("RunAgentStream scheduler trigger request = %#v", req.Msg)
 				}
 				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
@@ -2624,12 +2624,25 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "trigger", "--host", server.URL, "--file", composePath, "--sandbox", "sandbox-existing", "reviewer", "nightly")
-	if exitCode != 0 || stdout != "" || stderr != "" {
-		t.Fatalf("scheduler trigger code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	for _, tc := range []struct {
+		name      string
+		extraArgs []string
+	}{
+		{name: "creates sandbox"},
+		{name: "reuses sandbox", extraArgs: []string{"--sandbox", "sandbox-existing"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"scheduler", "trigger", "--host", server.URL, "--file", composePath}
+			args = append(args, tc.extraArgs...)
+			args = append(args, "reviewer", "nightly")
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != 0 || stdout != "" || stderr != "" {
+				t.Fatalf("scheduler trigger code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+			}
+		})
 	}
-	if !sawRequest {
-		t.Fatal("RunAgentStream was not called")
+	if !reflect.DeepEqual(requestedSandboxIDs, []string{"", "sandbox-existing"}) {
+		t.Fatalf("scheduler trigger sandbox IDs = %#v", requestedSandboxIDs)
 	}
 }
 

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1666,7 +1666,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox-id", "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
+	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox", "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
 	if exitCode != 0 {
 		t.Fatalf("run success exit code = %d, stderr=%q", exitCode, stderr)
 	}
@@ -1684,7 +1684,7 @@ agents:
 		name string
 		flag string
 	}{
-		{name: "legacy sandbox flag", flag: "--sandbox"},
+		{name: "legacy sandbox id flag", flag: "--sandbox-id"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			legacyOut, legacyErr, _, legacyCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, tc.flag, "session-reuse", "--keep-running", "reviewer", "--prompt", "check this")
@@ -1747,7 +1747,7 @@ agents:
 		"Run: run-detached",
 		"Sandbox: sandbox-detached",
 		"Status: pending",
-		"Logs: agent-compose --host " + server.URL + " --file " + composePath + " logs --run-id run-detached --follow",
+		"Logs: agent-compose --host " + server.URL + " --file " + composePath + " logs --run run-detached --follow",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("run -d stdout %q does not contain %q", stdout, want)
@@ -1802,7 +1802,7 @@ agents:
 	if decoded.ID != "run-detached-json" || decoded.SandboxID != "sandbox-json" || decoded.Status != "running" {
 		t.Fatalf("run -d JSON decoded = %#v", decoded)
 	}
-	if !strings.Contains(decoded.LogsCommand, "logs --run-id run-detached-json --follow") || len(decoded.Warnings) != 2 {
+	if !strings.Contains(decoded.LogsCommand, "logs --run run-detached-json --follow") || len(decoded.Warnings) != 2 {
 		t.Fatalf("run -d JSON logs/warnings = %#v", decoded)
 	}
 }
@@ -1871,7 +1871,7 @@ agents:
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("run -d --command code/stderr = %d / %q", exitCode, stderr)
 	}
-	logOut, logErr, _, logCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-detached-logs", "--follow", "--tail", "3")
+	logOut, logErr, _, logCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run", "run-detached-logs", "--follow", "--tail", "3")
 	runPrefix := "reviewer-run-detached-log | "
 	wantLogOut := expectedLogSeparator(runPrefix, ">") +
 		"reviewer-run-detached-log | test prompt\n" +
@@ -2364,9 +2364,9 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommandWithInput("", "run", "--host", server.URL, "--file", composePath, "--rm", "--sandbox-id", "sandbox-existing", "reviewer", "-i", "--prompt", "first")
+	stdout, stderr, _, exitCode := executeCLICommandWithInput("", "run", "--host", server.URL, "--file", composePath, "--rm", "--sandbox", "sandbox-existing", "reviewer", "-i", "--prompt", "first")
 	if exitCode != 0 || stdout != "" || stderr != "" {
-		t.Fatalf("run -i --rm --sandbox-id code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+		t.Fatalf("run -i --rm --sandbox code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 }
 
@@ -2602,7 +2602,7 @@ agents:
 		run: runServiceStub{
 			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
 				sawRequest = true
-				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) || req.Msg.GetPrompt() != "" || req.Msg.GetCommand() != "" {
+				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) || req.Msg.GetSandboxId() != "sandbox-existing" || req.Msg.GetPrompt() != "" || req.Msg.GetCommand() != "" {
 					t.Fatalf("RunAgentStream scheduler trigger request = %#v", req.Msg)
 				}
 				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
@@ -2624,7 +2624,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "trigger", "--host", server.URL, "--file", composePath, "reviewer", "nightly")
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "trigger", "--host", server.URL, "--file", composePath, "--sandbox", "sandbox-existing", "reviewer", "nightly")
 	if exitCode != 0 || stdout != "" || stderr != "" {
 		t.Fatalf("scheduler trigger code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
@@ -2743,9 +2743,9 @@ agents:
 			want: "unknown flag: --trigger",
 		},
 		{
-			name: "legacy sandbox flag unsupported",
-			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--sandbox", "sandbox-1", "--prompt", "check"},
-			want: "unknown flag: --sandbox",
+			name: "legacy sandbox id flag unsupported",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--sandbox-id", "sandbox-1", "--prompt", "check"},
+			want: "unknown flag: --sandbox-id",
 		},
 		{
 			name: "legacy session flag unsupported",
@@ -2759,8 +2759,8 @@ agents:
 		},
 		{
 			name: "driver with sandbox id",
-			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--sandbox-id", "sandbox-1", "--driver", "docker", "--prompt", "check"},
-			want: "run --driver cannot be combined with --sandbox-id",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--sandbox", "sandbox-1", "--driver", "docker", "--prompt", "check"},
+			want: "run --driver cannot be combined with --sandbox",
 		},
 		{
 			name: "command and prompt flags",
@@ -3145,14 +3145,14 @@ agents:
 		t.Fatalf("logs --session-id code/stdout/stderr = %d / %q / %q", legacyCode, legacyOut, legacyErr)
 	}
 
-	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", identity.ShortID(runID))
+	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run", identity.ShortID(runID))
 	runPrefix := "reviewer-run-" + identity.ShortID(runID) + " | "
 	wantRunOut := expectedLogSeparator(runPrefix, ">") +
 		"reviewer-run-" + identity.ShortID(runID) + " | test prompt\n" +
 		expectedLogSeparator(runPrefix, "<") +
 		"reviewer-run-" + identity.ShortID(runID) + " | stored log output\n"
 	if runCode != 0 || runErr != "" || runOut != wantRunOut {
-		t.Fatalf("logs --run-id code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
+		t.Fatalf("logs --run code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
 	}
 }
 
@@ -3203,13 +3203,13 @@ agents:
 		t.Fatalf("logs --tail JSON = %#v", decoded)
 	}
 
-	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "run-tail", "-n", "1")
+	runOut, runErr, _, runCode := executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run", "run-tail", "-n", "1")
 	wantRunTail := expectedLogSeparator(tailPrefix, ">") +
 		"reviewer-run-tail | test prompt\n" +
 		expectedLogSeparator(tailPrefix, "<") +
 		"reviewer-run-tail | three\n"
 	if runCode != 0 || runErr != "" || runOut != wantRunTail {
-		t.Fatalf("logs --run-id --tail code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
+		t.Fatalf("logs --run --tail code/stdout/stderr = %d / %q / %q", runCode, runOut, runErr)
 	}
 }
 
@@ -4323,8 +4323,8 @@ agents:
 	if _, stderr, _, exitCode := executeCLICommand("inspect", "--host", server.URL, "--file", composePath, "--json", "run", runShort); exitCode != 0 || stderr != "" {
 		t.Fatalf("inspect run short id code/stderr = %d / %q", exitCode, stderr)
 	}
-	if _, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox-id", sandboxShort, "reviewer", "--prompt", "hello"); exitCode != 0 || stderr != "" {
-		t.Fatalf("run --sandbox-id short code/stderr = %d / %q", exitCode, stderr)
+	if _, stderr, _, exitCode := executeCLICommand("run", "--host", server.URL, "--file", composePath, "--sandbox", sandboxShort, "reviewer", "--prompt", "hello"); exitCode != 0 || stderr != "" {
+		t.Fatalf("run --sandbox short code/stderr = %d / %q", exitCode, stderr)
 	}
 	if !reflect.DeepEqual(stopped, []string{sandboxID}) || !reflect.DeepEqual(resumed, []string{sandboxID}) || execSandbox != sandboxID || inspectedRun != runID || runSandbox != sandboxID {
 		t.Fatalf("resolved ids stopped=%#v resumed=%#v exec=%q inspect=%q run=%q", stopped, resumed, execSandbox, inspectedRun, runSandbox)
@@ -7891,7 +7891,7 @@ agents:
 		if exitCode != 42 || stdout != "" || !strings.Contains(stderr, "exec-failed") || !strings.Contains(stderr, "boom") {
 			t.Fatalf("exec failed code/stdout/stderr = %d/%q/%q", exitCode, stdout, stderr)
 		}
-		stdout, stderr, _, exitCode = executeCLICommand("exec", "--host", server.URL, "--file", composePath, "--run-id", "run-stream-error", "--command", "true")
+		stdout, stderr, _, exitCode = executeCLICommand("exec", "--host", server.URL, "--file", composePath, "--run", "run-stream-error", "--command", "true")
 		if exitCode != exitCodeUnavailable || stdout != "" || !strings.Contains(stderr, "exec stream down") {
 			t.Fatalf("exec stream error code/stdout/stderr = %d/%q/%q", exitCode, stdout, stderr)
 		}
@@ -7899,7 +7899,7 @@ agents:
 			args []string
 			want string
 		}{
-			{args: []string{"exec", "--file", composePath, "--run-id", "", "--command", "true"}, want: "requires a value"},
+			{args: []string{"exec", "--file", composePath, "--run", "", "--command", "true"}, want: "requires a value"},
 			{args: []string{"exec", "--file", composePath, "--agent", "", "true"}, want: "unknown flag: --agent"},
 		} {
 			stdout, stderr, _, exitCode := executeCLICommand(tc.args...)
@@ -7945,7 +7945,7 @@ agents:
 		if exitCode != exitCodeUnavailable || stdout != "" || !strings.Contains(stderr, "list unavailable") {
 			t.Fatalf("logs list error code/stdout/stderr = %d/%q/%q", exitCode, stdout, stderr)
 		}
-		stdout, stderr, _, exitCode = executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run-id", "missing")
+		stdout, stderr, _, exitCode = executeCLICommand("logs", "--host", server.URL, "--file", composePath, "--run", "missing")
 		if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "run missing") {
 			t.Fatalf("logs get error code/stdout/stderr = %d/%q/%q", exitCode, stdout, stderr)
 		}

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -138,7 +138,7 @@ Start a sandbox for an agent, or continue work in an existing sandbox.
 ```bash
 agent-compose run <agent> --prompt "..."
 agent-compose run <agent> --command "..."
-agent-compose run <agent> --sandbox-id <sandbox> --prompt "..."
+agent-compose run <agent> --sandbox <sandbox> --prompt "..."
 ```
 
 Input modes:
@@ -149,7 +149,7 @@ Input modes:
 | command | `run <agent> --command "..."` | Start or reuse the agent sandbox and execute a shell command through guest `agent-compose-runtime exec`; stdout/stderr transcript is streamed and persisted to the run record without protocol payload markers. |
 | prompt REPL | `run <agent> -i --prompt` | Read prompts line by line from stdin. Each non-empty input creates one run and reuses the same sandbox. |
 | command REPL | `run <agent> -i --command` | Read commands line by line from stdin. Each non-empty input creates one run and reuses the same sandbox. |
-| sandbox reuse | `run <agent> --sandbox-id <sandbox> --prompt "..."` | Continue in a specific sandbox. |
+| sandbox reuse | `run <agent> --sandbox <sandbox> --prompt "..."` | Continue in a specific sandbox. |
 
 Prompt input must use `--prompt`, and non-interactive runs must choose `--prompt` or `--command`. Positional prompt arguments are not supported.
 Additional positional arguments are not supported.
@@ -157,7 +157,7 @@ Additional positional arguments are not supported.
 | Option | Description |
 | --- | --- |
 | `--keep-running` | Keep the sandbox runtime after the run completes. |
-| `--sandbox-id <sandbox>` | Reuse an existing sandbox. |
+| `--sandbox <sandbox>` | Reuse an existing sandbox. |
 | `--rm` | Remove the sandbox after the run reaches a terminal state. |
 | `--jupyter` | Enable Jupyter for this run. When unset, the agent YAML default is used; when YAML is unset, Jupyter is disabled. |
 | `--jupyter-expose` | Mark the Jupyter agent-compose proxy endpoint for this run as explicitly exposed. This does not request runtime-driver host port exposure and also enables Jupyter. |
@@ -173,7 +173,7 @@ agent-compose run tester --command "task test" --keep-running
 agent-compose run tester --command "task test" -d
 agent-compose run reviewer -i --prompt
 agent-compose run tester -i --command
-agent-compose run reviewer --sandbox-id sandbox_123 --prompt "Continue the review"
+agent-compose run reviewer --sandbox sandbox_123 --prompt "Continue the review"
 agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the notebook state"
 ```
 
@@ -185,7 +185,7 @@ Rules:
 - `run -i/--interactive` must select `--prompt` or `--command`; it cannot be combined with `--json`.
 - Empty REPL lines do not create runs. Enter `/exit` or press Ctrl+D to exit.
 - REPL mode is not TTY/PTY or running stdin passthrough. Each input is one independent `RunAgentStream` call that reuses the same sandbox.
-- Detached runs can be observed with the printed `agent-compose logs --run-id <run-id> --follow` command, or managed later with `stop` and `logs`.
+- Detached runs can be observed with the printed `agent-compose logs --run <run-id> --follow` command, or managed later with `stop` and `logs`.
 - `run -i --prompt` supports providers with reusable provider conversations: Codex, Claude/cc, and OpenCode. Gemini currently returns unsupported.
 - `StopRun` requests cancellation for active in-daemon runs. Pending/running runs left behind after daemon restart are reconciled to failed with a `daemon interrupted` error.
 
@@ -370,7 +370,7 @@ agent-compose exec <sandbox> --command "..."
 | `--command "..."` | Pass a shell command as a flag. It is executed as `bash -lc "..."` in the sandbox. |
 | `--cwd <path>` | Set the working directory inside the sandbox. |
 | `--agent <agent>` | Deprecated target selection option; use `exec <sandbox>` instead. |
-| `--run-id <run-id>` | Deprecated target selection option; use `exec <sandbox>` instead. |
+| `--run <run-id>` | Deprecated target selection option; use `exec <sandbox>` instead. |
 
 Examples:
 
@@ -394,7 +394,7 @@ Current `logs` output is based on run log artifacts returned by the v2 RunServic
 agent-compose logs
 agent-compose logs <agent>
 agent-compose logs --agent reviewer
-agent-compose logs --run-id <run-id>
+agent-compose logs --run <run-id>
 agent-compose logs --sandbox <sandbox>
 agent-compose logs --follow
 agent-compose logs -n 100
@@ -407,7 +407,7 @@ agent-compose logs -t
 | `--follow` | Follow log output. |
 | `-t, --timestamp` | Prefix text log lines with a run-level timestamp. Current output does not have per-chunk timestamps; the CLI uses the best available run timestamp. |
 | `--agent <agent>` | Filter by agent. |
-| `--run-id <run-id>` | Filter by run id. |
+| `--run <run-id>` | Filter by run id. |
 | `--sandbox <sandbox>` | Filter by sandbox. |
 
 Examples:
@@ -417,7 +417,7 @@ agent-compose logs
 agent-compose logs reviewer
 agent-compose logs --agent reviewer --tail 200
 agent-compose logs --sandbox sandbox_123 --follow -t
-agent-compose logs --run-id run_123 --json
+agent-compose logs --run run_123 --json
 ```
 
 ## `inspect`: Inspect Resources

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -124,7 +124,7 @@ Current main commands:
 - `ps`: query project, agent, latest run, and running sandbox state.
 - `run <agent>`: call `RunService.RunAgentStream` for a manual agent run;
   creates a new sandbox by default, supports reusing an existing sandbox with
-  `--sandbox-id`, stops the runtime after completion by default, and can keep it
+  `--sandbox`, stops the runtime after completion by default, and can keep it
   running with `--keep-running`.
 - `logs`: inspect run output by project, agent, run id, or sandbox id; supports
   `--follow`.
@@ -393,7 +393,7 @@ scheduler trigger, or future API clients.
 3. Merge runtime environment. Priority from low to high is global env, project
    variables, agent env, then run request env.
 4. Prepare local/Git workspace snapshot from project/agent workspace spec.
-5. Create a new sandbox or reuse an existing sandbox with `--sandbox-id`.
+5. Create a new sandbox or reuse an existing sandbox with `--sandbox`.
 6. Write project, agent, run_id, scheduler_id, source, and related tags to the
    sandbox.
 7. Mark run as running and call the existing agent executor.

--- a/docs/plan/sandbox-naming-implementation-plan.md
+++ b/docs/plan/sandbox-naming-implementation-plan.md
@@ -357,7 +357,7 @@
 
 1. 更新 `cmd/agent-compose/main.go` 中所有 v2 client request/response 使用 `sandbox_id`、`RunSandboxCleanupPolicy`、`ExecSandboxSelector`。
 2. CLI 命令保持或调整为：
-   - `run --sandbox-id`
+   - `run --sandbox`
    - `ps` 显示 `SANDBOX ID`
    - `exec <sandbox>`
    - `logs --sandbox`
@@ -373,7 +373,7 @@
 
 - `go test ./cmd/agent-compose`
 - E2E/CLI 测试覆盖：
-  - `agent-compose run <agent> --sandbox-id <id>`
+  - `agent-compose run <agent> --sandbox <id>`
   - `agent-compose ps --json` 不包含 `session_id`
   - `agent-compose exec <sandbox> --command ...`
   - `agent-compose logs --sandbox <sandbox>`

--- a/docs/spec/sandbox-naming-spec.md
+++ b/docs/spec/sandbox-naming-spec.md
@@ -160,7 +160,7 @@ Docker label、boxlite runtime ref、microsandbox cache references、mount manif
 
 CLI 是 daemon client，不直接读写 sandbox 文件或 SQLite。用户可见命令使用 sandbox：
 
-- `run --sandbox-id`
+- `run --sandbox`
 - `ps` 显示 `SANDBOX ID`
 - `exec <sandbox>`
 - `logs --sandbox`
@@ -528,7 +528,7 @@ protoc -I proto \
 
 覆盖：
 
-- `agent-compose run <agent> --sandbox-id <id>`。
+- `agent-compose run <agent> --sandbox <id>`。
 - `agent-compose ps --json` 不包含 `session_id`。
 - `agent-compose exec <sandbox> --command ...`。
 - `agent-compose logs --sandbox <sandbox>`。

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -141,7 +141,7 @@ agent-compose -f /path/to/project/agent-compose.yml down
 ```bash
 agent-compose run <agent> --prompt "..."
 agent-compose run <agent> --command "..."
-agent-compose run <agent> --sandbox-id <sandbox> --prompt "..."
+agent-compose run <agent> --sandbox <sandbox> --prompt "..."
 ```
 
 输入模式：
@@ -152,7 +152,7 @@ agent-compose run <agent> --sandbox-id <sandbox> --prompt "..."
 | command | `run <agent> --command "..."` | 启动或复用该 agent 的 sandbox 后通过 guest `agent-compose-runtime exec` 执行 shell 命令；命令 transcript 会实时输出，并写入该次 run 记录。 |
 | prompt REPL | `run <agent> -i --prompt` | 从 stdin 逐行读取 prompt；每条非空输入创建一次 run，并复用同一个 sandbox。 |
 | command REPL | `run <agent> -i --command` | 从 stdin 逐行读取 command；每条非空输入创建一次 run，并复用同一个 sandbox。 |
-| sandbox 复用 | `run <agent> --sandbox-id <sandbox> --prompt "..."` | 在指定 sandbox 中继续运行。 |
+| sandbox 复用 | `run <agent> --sandbox <sandbox> --prompt "..."` | 在指定 sandbox 中继续运行。 |
 
 prompt 输入必须使用 `--prompt`；非交互 run 必须选择 `--prompt` 或 `--command`。不再支持 positional prompt 参数。
 不支持额外的位置参数。
@@ -162,7 +162,7 @@ prompt 输入必须使用 `--prompt`；非交互 run 必须选择 `--prompt` 或
 | 参数 | 说明 |
 | --- | --- |
 | `--keep-running` | 运行结束后保留 sandbox runtime。 |
-| `--sandbox-id <sandbox>` | 指定已有 sandbox。 |
+| `--sandbox <sandbox>` | 指定已有 sandbox。 |
 | `--rm` | 运行结束后删除 sandbox。 |
 | `--jupyter` | 为本次 run 启用 Jupyter；未设置时使用 agent YAML 默认，YAML 未设置时默认关闭。 |
 | `--jupyter-expose` | 标记本次 run 的 Jupyter agent-compose proxy 入口为显式暴露意图；该参数不请求 runtime driver 暴露 host port，并会同时启用 Jupyter。 |
@@ -178,7 +178,7 @@ agent-compose run tester --command "task test" --keep-running
 agent-compose run tester --command "task test" -d
 agent-compose run reviewer -i --prompt
 agent-compose run tester -i --command
-agent-compose run reviewer --sandbox-id sandbox_123 --prompt "Continue the review"
+agent-compose run reviewer --sandbox sandbox_123 --prompt "Continue the review"
 agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the notebook state"
 ```
 
@@ -190,7 +190,7 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 - `run -i/--interactive` 必须选择 `--prompt` 或 `--command`，不能与 `--json` 组合。
 - REPL 中空行不会创建 run；输入 `/exit` 或 Ctrl+D 退出。
 - REPL 不是 TTY/PTY 或运行中 stdin 透传；每条输入都是一次独立 `RunAgentStream`，但复用同一个 sandbox。
-- detached run 可通过输出的 `agent-compose logs --run-id <run-id> --follow` 命令观察输出，也可继续使用 `stop`/`logs` 操作该 run。
+- detached run 可通过输出的 `agent-compose logs --run <run-id> --follow` 命令观察输出，也可继续使用 `stop`/`logs` 操作该 run。
 - `run -i --prompt` 仅支持可复用 provider conversation 的 Codex、Claude/cc 和 OpenCode；Gemini 当前会返回 unsupported。
 - `StopRun` 会请求 daemon 内当前活动 run 取消；daemon 重启后遗留的 running/pending run 会在启动 reconcile 中标记为 failed，并带 `daemon interrupted` 错误。
 
@@ -381,7 +381,7 @@ agent-compose exec <sandbox> --command "..."
 | `--command "..."` | 以 flag 形式传入 shell 命令，等价于在 sandbox 中执行 `bash -lc "..."`。 |
 | `--cwd <path>` | 指定 sandbox 内工作目录。 |
 | `--agent <agent>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
-| `--run-id <run-id>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
+| `--run <run-id>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
 
 示例：
 
@@ -405,7 +405,7 @@ agent-compose exec sandbox_123 --cwd /workspace --command "pwd"
 agent-compose logs
 agent-compose logs <agent>
 agent-compose logs --agent reviewer
-agent-compose logs --run-id <run-id>
+agent-compose logs --run <run-id>
 agent-compose logs --sandbox <sandbox>
 agent-compose logs --follow
 agent-compose logs -n 100
@@ -420,7 +420,7 @@ agent-compose logs -t
 | `--follow` | 持续跟随日志输出。 |
 | `-t, --timestamp` | 文本输出显示 run 级时间戳。当前没有逐 chunk 时间戳，会使用该 run 的 `completed_at`、`updated_at`、`started_at` 中最合适的可用时间。 |
 | `--agent <agent>` | 按 agent 过滤。 |
-| `--run-id <run-id>` | 按 run 过滤。 |
+| `--run <run-id>` | 按 run 过滤。 |
 | `--sandbox <sandbox>` | 按 sandbox 过滤。 |
 
 示例：
@@ -430,7 +430,7 @@ agent-compose logs
 agent-compose logs reviewer
 agent-compose logs --agent reviewer --tail 200
 agent-compose logs --sandbox sandbox_123 --follow -t
-agent-compose logs --run-id run_123 --json
+agent-compose logs --run run_123 --json
 ```
 
 ## `inspect`：查看资源详情

--- a/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
+++ b/docs/zh-CN/design/agent-compose-cli-improvement-plan.md
@@ -128,7 +128,7 @@ agents:
 - `--prompt`、`--command` 一次只能选择一种。
 - 使用 `--prompt` 或 `--command` 后不能再传额外位置参数。
 - prompt 输入必须使用 `--prompt`；`run <agent> <trigger-name>` 的第二个位置参数不再作为 prompt 处理。
-- 复用 sandbox 使用 `--sandbox-id`。
+- 复用 sandbox 使用 `--sandbox`。
 
 ### Trigger 解析
 
@@ -147,7 +147,7 @@ v2 `RunSessionCleanupPolicy` 当前包括：
 - `KEEP_RUNNING`：`--keep-running`，run 完成后保留 runtime。
 - `REMOVE_ON_COMPLETION`：`--rm`，run terminal 后删除本次 run 创建的 sandbox。
 
-`--rm` 由 service 端 `pkg/runs.Controller` 负责，不依赖 CLI 进程存活。它覆盖 succeeded、failed、canceled 等 terminal 状态。显式传入已有 `--sandbox-id` 时，不删除该 sandbox。cleanup 失败写入 `project_run.cleanup_error`；run 原始错误优先于 cleanup 错误。
+`--rm` 由 service 端 `pkg/runs.Controller` 负责，不依赖 CLI 进程存活。它覆盖 succeeded、failed、canceled 等 terminal 状态。显式传入已有 `--sandbox` 时，不删除该 sandbox。cleanup 失败写入 `project_run.cleanup_error`；run 原始错误优先于 cleanup 错误。
 
 ### Detach 和 StopRun
 

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -88,7 +88,7 @@ CLI 不直接操作 runtime、sandbox 文件或 SQLite reconcile 逻辑。它读
 - `up`：调用 `ProjectService.ApplyProject`，创建或更新 project、revision、受管 agent definition 和 scheduler/loader；不会直接创建 run/sandbox。
 - `down`：调用 `ProjectService.RemoveProject`，禁用受管 scheduler/loader，并停止该 project 的 running sandboxes；默认保留 project、run 和 sandbox 历史。
 - `ps`：查询 project、agent、latest run 和 running sandbox 状态。
-- `run <agent>`：调用 `RunService.RunAgentStream` 手动执行一次 agent；默认创建新 sandbox，支持 `--sandbox-id` 复用已有 sandbox，默认完成后停止 runtime，`--keep-running` 可保留。
+- `run <agent>`：调用 `RunService.RunAgentStream` 手动执行一次 agent；默认创建新 sandbox，支持 `--sandbox` 复用已有 sandbox，默认完成后停止 runtime，`--keep-running` 可保留。
 - `logs`：按 project、agent、run id 或 sandbox id 查看 run 输出，支持 `--follow`。
 - `exec`：调用 `ExecService.ExecStream` 在 running sandbox 内执行命令；用 positional `<sandbox>` 定位目标。
 - `images`、`image ls`、`pull`、`image pull`、`rmi`、`image rm`、`image inspect`：调用 `ImageService` 管理 daemon image store。默认 store 由 daemon 的 `IMAGE_STORE_MODE` 决定。
@@ -278,7 +278,7 @@ Run 是一次 agent 执行记录，可来自 CLI manual run、scheduler trigger 
 2. 创建 `project_run` pending 记录，记录 source、scheduler/trigger、prompt、driver、image 等元数据。
 3. 合并运行环境，优先级从低到高为 global env、project variables、agent env、run request env。
 4. 按 project/agent workspace spec 准备 local/git workspace snapshot。
-5. 创建新 sandbox，或按 `--sandbox-id` 复用已有 sandbox。
+5. 创建新 sandbox，或按 `--sandbox` 复用已有 sandbox。
 6. 给 sandbox 写入 project、agent、run_id、scheduler_id、source 等 tag。
 7. 标记 run 为 running，并调用现有 agent executor。
 8. streaming 请求实时发送 start/output/completed 事件。

--- a/examples/agent-compose/docker-scheduler-timeout/README.md
+++ b/examples/agent-compose/docker-scheduler-timeout/README.md
@@ -60,7 +60,7 @@ agent-compose up
 sleep 35
 agent-compose ps
 agent-compose inspect run <run-id>
-agent-compose logs --run-id <run-id>
+agent-compose logs --run <run-id>
 agent-compose down
 ```
 
@@ -72,7 +72,7 @@ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeou
 sleep 35
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml ps
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml inspect run <run-id>
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run-id <run-id>
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run <run-id>
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml down
 ```
 
@@ -84,7 +84,7 @@ Expected result:
 - `up` creates or updates the managed scheduler and loader.
 - After the timeout fires once, `ps` shows a scheduler-created run.
 - `inspect run <run-id>` shows `source: scheduler`, `status: succeeded`, `driver: docker`, and output from the agent.
-- `logs --run-id <run-id>` prints the agent output.
+- `logs --run <run-id>` prints the agent output.
 - `down` disables the managed scheduler and loader.
 
 ## Verification output
@@ -168,7 +168,7 @@ $ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-time
 ### 5. Run logs
 
 ```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run-id run-reviewer-28c0ef985c8d
+$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run run-reviewer-28c0ef985c8d
 timeout scheduler ok
 ```
 

--- a/examples/agent-compose/docker-scheduler-timeout/README.zh-CN.md
+++ b/examples/agent-compose/docker-scheduler-timeout/README.zh-CN.md
@@ -59,7 +59,7 @@ agent-compose up
 sleep 35
 agent-compose ps
 agent-compose inspect run <run-id>
-agent-compose logs --run-id <run-id>
+agent-compose logs --run <run-id>
 agent-compose down
 ```
 
@@ -71,7 +71,7 @@ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeou
 sleep 35
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml ps
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml inspect run <run-id>
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run-id <run-id>
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run <run-id>
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml down
 ```
 
@@ -83,7 +83,7 @@ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeou
 - `up` 创建或更新 managed scheduler 和 loader。
 - 等待 timeout 触发一次后，`ps` 显示 scheduler 创建的 run。
 - `inspect run <run-id>` 显示 `source: scheduler`、`status: succeeded`、`driver: docker`，并包含 agent 输出。
-- `logs --run-id <run-id>` 输出 agent 日志。
+- `logs --run <run-id>` 输出 agent 日志。
 - `down` 禁用 managed scheduler 和 loader。
 
 ## 验证输出
@@ -166,7 +166,7 @@ $ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-time
 ### 5. Run 日志
 
 ```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run-id run-reviewer-28c0ef985c8d
+$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run run-reviewer-28c0ef985c8d
 timeout scheduler ok
 ```
 


### PR DESCRIPTION
  ## Summary

  - Unify CLI flags that reference sandboxes by replacing `--sandbox-id` with `--sandbox`.
  - Unify CLI flags that reference runs by replacing `--run-id` with `--run`.
  - Update detached-run log commands, validation messages, help output, documentation, and examples.
  - Add and update tests for the new flags and verify that legacy flags are rejected.
  - Keep internal protobuf and API fields such as `sandbox_id` and `run_id` unchanged.

  ## Testing

  - `go test ./cmd/agent-compose`
    - 573 tests passed.
  - `task lint`
    - 0 issues.
  - `git diff --check`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.