### PR TITLE
fix(runs): preserve reused running sandboxes

### DIFF
--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -164,6 +164,11 @@ Additional positional arguments are not supported.
 | `-d, --detach` | Submit the run to the daemon and return immediately with the run id, initial status, and a `logs --follow` command. |
 | `-i, --interactive` | Enter prompt or command REPL mode. Must be combined with `--prompt` or `--command`. |
 
+By default, a sandbox created or started by the run is stopped when the run
+finishes. When `--sandbox` reuses a sandbox that was already running, the
+run leaves it running. Use `--keep-running` to keep a newly created or resumed
+sandbox running as well.
+
 Examples:
 
 ```bash

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -124,8 +124,9 @@ Current main commands:
 - `ps`: query project, agent, latest run, and running sandbox state.
 - `run <agent>`: call `RunService.RunAgentStream` for a manual agent run;
   creates a new sandbox by default, supports reusing an existing sandbox with
-  `--sandbox`, stops the runtime after completion by default, and can keep it
-  running with `--keep-running`.
+  `--sandbox`, stops sandboxes created or started by the run after completion
+  by default, preserves reused sandboxes that were already running, and can keep
+  newly created or resumed sandboxes running with `--keep-running`.
 - `logs`: inspect run output by project, agent, run id, or sandbox id; supports
   `--follow`.
 - `exec`: call `ExecService.ExecStream` inside a running sandbox; target the

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -169,6 +169,10 @@ prompt 输入必须使用 `--prompt`；非交互 run 必须选择 `--prompt` 或
 | `-d, --detach` | 将 run 提交给 daemon 后立即返回；输出 run id、初始状态和 `logs --follow` 查看命令。 |
 | `-i, --interactive` | 进入 prompt 或 command REPL；必须与 `--prompt` 或 `--command` 组合。 |
 
+默认情况下，本次 run 创建或启动的 sandbox 会在运行结束后停止。通过
+`--sandbox` 复用调用前已经处于 running 状态的 sandbox 时，run 会保留其
+运行状态。若要让本次新建或恢复的 sandbox 也继续运行，请使用 `--keep-running`。
+
 示例：
 
 ```bash

--- a/docs/zh-CN/design/agent-compose_design.md
+++ b/docs/zh-CN/design/agent-compose_design.md
@@ -88,7 +88,7 @@ CLI 不直接操作 runtime、sandbox 文件或 SQLite reconcile 逻辑。它读
 - `up`：调用 `ProjectService.ApplyProject`，创建或更新 project、revision、受管 agent definition 和 scheduler/loader；不会直接创建 run/sandbox。
 - `down`：调用 `ProjectService.RemoveProject`，禁用受管 scheduler/loader，并停止该 project 的 running sandboxes；默认保留 project、run 和 sandbox 历史。
 - `ps`：查询 project、agent、latest run 和 running sandbox 状态。
-- `run <agent>`：调用 `RunService.RunAgentStream` 手动执行一次 agent；默认创建新 sandbox，支持 `--sandbox` 复用已有 sandbox，默认完成后停止 runtime，`--keep-running` 可保留。
+- `run <agent>`：调用 `RunService.RunAgentStream` 手动执行一次 agent；默认创建新 sandbox，支持 `--sandbox` 复用已有 sandbox。默认在完成后停止本次创建或启动的 runtime；若复用调用前已 running 的 sandbox，则保留其运行状态。`--keep-running` 可让本次新建或恢复的 sandbox 继续运行。
 - `logs`：按 project、agent、run id 或 sandbox id 查看 run 输出，支持 `--follow`。
 - `exec`：调用 `ExecService.ExecStream` 在 running sandbox 内执行命令；用 positional `<sandbox>` 定位目标。
 - `images`、`image ls`、`pull`、`image pull`、`rmi`、`image rm`、`image inspect`：调用 `ImageService` 管理 daemon image store。默认 store 由 daemon 的 `IMAGE_STORE_MODE` 决定。

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1859,9 +1859,10 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 			}
 			warnings = append(warnings, fmt.Sprintf("sticky sandbox %s is unavailable; creating a replacement", sandboxID))
 		} else {
+			wasRunning := sandbox.Summary.VMStatus == domain.VMStatusRunning
 			if sandbox.Summary.VMStatus != domain.VMStatusRunning {
 				if err := c.applyJupyterOptionsToSandbox(sandbox.Summary.ID, jupyterOptions); err != nil {
-					return SandboxResult{Sandbox: sandbox}, err
+					return SandboxResult{Sandbox: sandbox, WasRunning: wasRunning}, err
 				}
 				driver, err := driverpkg.ResolveSandboxRuntimeDriver(sandbox.Summary.Driver, c.config.RuntimeDriver)
 				if err != nil {
@@ -1874,15 +1875,15 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 					ProjectName: run.ProjectName,
 					AgentName:   run.AgentName,
 				}); err != nil {
-					return SandboxResult{Sandbox: sandbox}, err
+					return SandboxResult{Sandbox: sandbox, WasRunning: wasRunning}, err
 				}
 			}
 			sandbox.EnvItems = domain.MergeEnvItems(sandbox.EnvItems, capabilityVars)
 			sandbox.Summary.Tags = MergeSandboxTags(sandbox.Summary.Tags, tags)
 			if err := c.startProjectRunSandbox(ctx, sandbox, "sandbox.resumed", "sandbox resumed for project run"); err != nil {
-				return SandboxResult{Sandbox: sandbox}, err
+				return SandboxResult{Sandbox: sandbox, WasRunning: wasRunning}, err
 			}
-			return SandboxResult{Sandbox: sandbox, Warnings: warnings}, nil
+			return SandboxResult{Sandbox: sandbox, WasRunning: wasRunning, Warnings: warnings}, nil
 		}
 	}
 
@@ -2075,6 +2076,9 @@ func (c *Controller) cleanupProjectRunSandbox(ctx context.Context, coordinator *
 
 func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandboxResult SandboxResult, policy agentcomposev2.RunSandboxCleanupPolicy) error {
 	sandbox := sandboxResult.Sandbox
+	if sandboxResult.WasRunning && !CleanupPolicyRemovesSandbox(policy) {
+		return nil
+	}
 	if CleanupPolicyRemovesSandbox(policy) && sandboxResult.Created {
 		if err := c.stopProjectRunSandbox(ctx, sandbox); err != nil {
 			return err

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -1108,6 +1108,38 @@ func uuidForTest(name string) string {
 	return strings.NewReplacer("/", "-", " ", "-").Replace(name)
 }
 
+func TestRunsControllerRunProjectAgentStopOnCompletionPreservesRunningSandbox(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	sandbox, err := fixture.store.CreateSandbox(fixture.ctx, "existing", "", "boxlite", "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandbox.Summary.VMStatus = domain.VMStatusRunning
+	if err := fixture.store.UpdateSandbox(fixture.ctx, sandbox); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+
+	run, execErr, err := fixture.controller.RunProjectAgent(fixture.ctx, RunAgentRequest{
+		ProjectID:       "project-1",
+		AgentName:       "worker",
+		Prompt:          "do work",
+		SandboxID:       sandbox.Summary.ID,
+		Source:          domain.ProjectRunSourceAPI,
+		ClientRequestID: uuidForTest(t.Name()),
+		CleanupPolicy:   agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION,
+	}, nil)
+	if err != nil || execErr != nil {
+		t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
+	}
+	loaded, err := fixture.store.GetSandbox(fixture.ctx, sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if loaded.Summary.VMStatus != domain.VMStatusRunning || fixture.driver.started || fixture.driver.stopped {
+		t.Fatalf("sandbox status=%s driver=%#v", loaded.Summary.VMStatus, fixture.driver)
+	}
+}
+
 func TestRunsControllerRunProjectAgentRemoveOnCompletionCleanup(t *testing.T) {
 	t.Run("success removes created sandbox", func(t *testing.T) {
 		fixture := newControllerRunFixture(t)

--- a/pkg/runs/session.go
+++ b/pkg/runs/session.go
@@ -8,9 +8,10 @@ import (
 )
 
 type SandboxResult struct {
-	Sandbox  *domain.Sandbox
-	Created  bool
-	Warnings []string
+	Sandbox    *domain.Sandbox
+	Created    bool
+	WasRunning bool
+	Warnings   []string
 }
 
 func SandboxTitle(run domain.ProjectRunRecord) string {


### PR DESCRIPTION
  ## Summary

  - Preserve a reused sandbox when it was already running before the run started.
  - Continue stopping sandboxes that were created or started by the current run under the default `STOP_ON_COMPLETION` policy.
  - Keep the existing explicit `REMOVE_ON_COMPLETION` behavior unchanged.
  - Track the sandbox's initial runtime state so cleanup can distinguish borrowed running sandboxes from sandboxes started by the run.
  - Update the English and Chinese CLI and design documentation to describe the lifecycle behavior.

  ## Testing

  - `go test ./pkg/runs`
    - Passed: 55 tests in 1 package.
  - `task test`
    - All Go packages passed.
    - The frontend runtime test stage could not run because `vitest` is not installed in the local environment.
  - `git diff --check`
    - Passed.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.