### PR TITLE
fix(cli): handle exec prompt EOF and turn boundaries

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3408,8 +3408,12 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 		}
 	}
 	if inputErr != nil {
-		if err := <-inputErr; err != nil {
-			return err
+		select {
+		case err := <-inputErr:
+			if err != nil {
+				return err
+			}
+		default:
 		}
 	}
 	if err := output.Finish(); err != nil {

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3317,6 +3317,16 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 	}
 	scanner := bufio.NewScanner(stdin)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	stdinIsTerminal := false
+	if fd, ok := terminalFileDescriptor(stdin); ok {
+		stdinIsTerminal = isTerminalFD(fd)
+	}
+	var inputErr <-chan error
+	if !stdinIsTerminal {
+		ch := make(chan error, 1)
+		inputErr = ch
+		go func() { ch <- pumpExecPromptMessages(scanner, send, closeRequest) }()
+	}
 	lastOutputEndedWithNewline := true
 	inputPrompt := promptAttachInputPrompt{
 		SandboxID: req.GetSandboxId(),
@@ -3385,14 +3395,21 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 				lastOutputEndedWithNewline = strings.HasSuffix(text, "\n")
 			}
 		case *agentcomposev2.ExecAttachResponse_AgentTurnCompleted:
-			if err := promptForInput(); err != nil {
-				return err
+			if stdinIsTerminal {
+				if err := promptForInput(); err != nil {
+					return err
+				}
 			}
 		case *agentcomposev2.ExecAttachResponse_Result:
 			result = frame.Result
 			inputPrompt.UpdateFromRun(result.GetRun())
 		case *agentcomposev2.ExecAttachResponse_Error:
 			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("exec project %s prompt attach failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
+		}
+	}
+	if inputErr != nil {
+		if err := <-inputErr; err != nil {
+			return err
 		}
 	}
 	if err := output.Finish(); err != nil {
@@ -3409,6 +3426,26 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 		return commandExitError{Code: attachResultExitCode(result), Err: fmt.Errorf("run %s in project %s failed: %s", firstNonEmptyString(runID, "attach"), projectName, firstNonEmptyString(result.GetError(), result.GetOutput(), "prompt failed"))}
 	}
 	return nil
+}
+
+func pumpExecPromptMessages(scanner *bufio.Scanner, send func(*agentcomposev2.ExecAttachRequest) error, closeRequest func() error) (err error) {
+	defer func() { err = errors.Join(err, closeRequest()) }()
+	for scanner.Scan() {
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		if text == "/exit" {
+			break
+		}
+		if err := send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}}}); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}})
 }
 
 func pumpExecAttachStdin(stdin io.Reader, send func(*agentcomposev2.ExecAttachRequest) error, closeRequest func() error) (err error) {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -4963,6 +4963,36 @@ func TestCLIExecPromptAttachUsesExecAttachClient(t *testing.T) {
 	}
 }
 
+func TestCLIExecPromptAttachDoesNotWaitForOpenStdin(t *testing.T) {
+	stream := newFakeExecAttachStream(nil)
+	stream.recvErr = io.EOF
+	stdin, stdinWriter := io.Pipe()
+	defer stdin.Close()
+	defer stdinWriter.Close()
+
+	cmd := &cobra.Command{Use: "exec"}
+	cmd.SetContext(context.Background())
+	cmd.SetIn(stdin)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runComposeExecPromptAttachCommand(cmd, "cli-exec-prompt", &fakeExecAttachClient{stream: stream}, &agentcomposev2.ExecRequest{
+			Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
+		}, composeExecOptions{Interactive: true, Prompt: "hi"})
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "completed without result") {
+			t.Fatalf("exec prompt attach error = %v, want missing result", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("exec prompt attach waited for stdin after the response stream completed")
+	}
+}
+
 func TestCLIExecInteractiveUnsupportedUsesUnsupportedExitCode(t *testing.T) {
 	client := &fakeExecAttachClient{stream: &fakeExecAttachStream{
 		closedCh: make(chan struct{}),

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -4967,8 +4967,8 @@ func TestCLIExecPromptAttachDoesNotWaitForOpenStdin(t *testing.T) {
 	stream := newFakeExecAttachStream(nil)
 	stream.recvErr = io.EOF
 	stdin, stdinWriter := io.Pipe()
-	defer stdin.Close()
-	defer stdinWriter.Close()
+	defer func() { _ = stdin.Close() }()
+	defer func() { _ = stdinWriter.Close() }()
 
 	cmd := &cobra.Command{Use: "exec"}
 	cmd.SetContext(context.Background())

--- a/pkg/runs/attach_input_test.go
+++ b/pkg/runs/attach_input_test.go
@@ -1,8 +1,13 @@
 package runs
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"sync"
 	"testing"
+	"time"
 
 	driverpkg "agent-compose/pkg/driver"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
@@ -24,9 +29,9 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 	t.Run("prompt", func(t *testing.T) {
 		interaction := &closingRuntimeInteraction{}
 		input := &promptWrapperInput{interaction: interaction}
-		pumpRunPromptAttachInput(func() (*agentcomposev2.RunAttachRequest, error) {
+		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.RunAttachRequest, error) {
 			return nil, receiveErr
-		}, input, nil)
+		}, input, nil, nil)
 		if interaction.closeCalls != 1 {
 			t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
 		}
@@ -34,6 +39,164 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 			t.Fatalf("sent frames = %#v, want prompt EOF", interaction.sent)
 		}
 	})
+}
+
+func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t *testing.T) {
+	requests := make(chan *agentcomposev2.RunAttachRequest, 2)
+	received := make(chan struct{}, 2)
+	interaction := newObservedRuntimeInteraction()
+	input := &promptWrapperInput{interaction: interaction}
+	turnReady := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.RunAttachRequest, error) {
+			req, ok := <-requests
+			if !ok {
+				return nil, io.EOF
+			}
+			received <- struct{}{}
+			return req, nil
+		}, input, turnReady, nil)
+	}()
+
+	requests <- humanMessageAttachRequest("human-2")
+	requests <- humanMessageAttachRequest("human-3")
+	close(requests)
+	<-received
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	turnReady <- struct{}{}
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-2")
+	<-received
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	turnReady <- struct{}{}
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-3")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "eof", "")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("prompt input pump did not exit after EOF")
+	}
+	if interaction.closeCallCount() != 1 {
+		t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCallCount())
+	}
+}
+
+func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	requests := make(chan *agentcomposev2.RunAttachRequest, 1)
+	received := make(chan struct{}, 1)
+	interaction := newObservedRuntimeInteraction()
+	input := &promptWrapperInput{interaction: interaction}
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		pumpRunPromptAttachInput(ctx, func() (*agentcomposev2.RunAttachRequest, error) {
+			req := <-requests
+			received <- struct{}{}
+			return req, nil
+		}, input, make(chan struct{}, 1), nil)
+	}()
+
+	requests <- humanMessageAttachRequest("queued")
+	<-received
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("prompt input pump did not exit after cancellation")
+	}
+	assertNoRuntimeInputFrame(t, interaction.sent)
+	if interaction.closeCallCount() != 1 {
+		t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCallCount())
+	}
+}
+
+func humanMessageAttachRequest(message string) *agentcomposev2.RunAttachRequest {
+	return &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_HumanMessage{
+		HumanMessage: &agentcomposev2.AttachHumanMessage{Text: message},
+	}}
+}
+
+func receiveRuntimeInputFrame(t *testing.T, frames <-chan driverpkg.RuntimeInputFrame) driverpkg.RuntimeInputFrame {
+	t.Helper()
+	select {
+	case frame := <-frames:
+		return frame
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runtime input frame")
+	}
+	return driverpkg.RuntimeInputFrame{}
+}
+
+func assertNoRuntimeInputFrame(t *testing.T, frames <-chan driverpkg.RuntimeInputFrame) {
+	t.Helper()
+	select {
+	case frame := <-frames:
+		t.Fatalf("unexpected runtime input frame: %s", frame.Data)
+	default:
+	}
+}
+
+func assertPromptRuntimeFrame(t *testing.T, frame driverpkg.RuntimeInputFrame, frameType, message string) {
+	t.Helper()
+	var payload struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(frame.Data, &payload); err != nil {
+		t.Fatalf("decode runtime input frame: %v", err)
+	}
+	if payload.Type != frameType || payload.Message != message {
+		t.Fatalf("runtime input frame = %#v, want type=%q message=%q", payload, frameType, message)
+	}
+}
+
+type observedRuntimeInteraction struct {
+	sent       chan driverpkg.RuntimeInputFrame
+	closed     chan struct{}
+	closeOnce  sync.Once
+	mu         sync.Mutex
+	closeCalls int
+}
+
+func newObservedRuntimeInteraction() *observedRuntimeInteraction {
+	return &observedRuntimeInteraction{
+		sent:   make(chan driverpkg.RuntimeInputFrame, 4),
+		closed: make(chan struct{}),
+	}
+}
+
+func (i *observedRuntimeInteraction) Send(frame driverpkg.RuntimeInputFrame) error {
+	i.sent <- frame
+	return nil
+}
+
+func (i *observedRuntimeInteraction) CloseSend() error {
+	i.mu.Lock()
+	i.closeCalls++
+	i.mu.Unlock()
+	i.closeOnce.Do(func() { close(i.closed) })
+	return nil
+}
+
+func (*observedRuntimeInteraction) Recv() (driverpkg.RuntimeOutputFrame, error) {
+	return driverpkg.RuntimeOutputFrame{}, errors.New("unused")
+}
+
+func (*observedRuntimeInteraction) Wait() (driverpkg.RuntimeResult, error) {
+	return driverpkg.RuntimeResult{}, errors.New("unused")
+}
+
+func (i *observedRuntimeInteraction) closeCallCount() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.closeCalls
 }
 
 type closingRuntimeInteraction struct {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -896,14 +896,19 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 		transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 		return transition, err
 	}
+	inputCtx, cancelInput := context.WithCancel(ctx)
+	defer cancelInput()
+	turnReady := make(chan struct{}, 1)
 	if prompt := strings.TrimSpace(req.Prompt); prompt != "" {
 		if err := input.HumanMessage(prompt); err != nil {
 			transition.ExitCode = 1
 			transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 			return transition, err
 		}
+	} else {
+		releasePromptTurn(turnReady)
 	}
-	go pumpRunPromptAttachInput(receive, input, projector.AppendHumanMessage)
+	go pumpRunPromptAttachInput(inputCtx, receive, input, turnReady, projector.AppendHumanMessage)
 	var promptTransition *TransitionRequest
 	for {
 		frame, err := interaction.Recv()
@@ -954,19 +959,19 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 					transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 					return transition, err
 				}
+				if resp.GetAgentTurnCompleted() != nil {
+					releasePromptTurn(turnReady)
+				}
 			}
 			if nextTransition != nil {
 				promptTransition = nextTransition
 			}
 		case driverpkg.RuntimeOutputStderr:
-			chunk := domain.ExecChunk{Text: string(frame.Data), Stream: domain.StdioStderr}
-			offset, err := appendProjectRunLogChunk(logsPath, chunk)
-			if err != nil {
+			if err := projector.AppendStderr(string(frame.Data)); err != nil {
 				transition.ExitCode = 1
 				transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 				return transition, err
 			}
-			c.publishRunLogChunk(run.RunID, chunk, offset)
 			if err := send(runAttachOutputResponse(frame.Data, agentcomposev2.StdioStream_STDIO_STREAM_STDERR, false)); err != nil {
 				transition.ExitCode = 1
 				transition.Error = fmt.Sprintf("agent execution failed: %v", err)
@@ -1334,7 +1339,7 @@ func (w *promptWrapperInput) send(frame map[string]any) error {
 	return w.interaction.Send(driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: data})
 }
 
-func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInput, onHumanMessage func(string) error) {
+func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, input *promptWrapperInput, turnReady <-chan struct{}, onHumanMessage func(string) error) {
 	defer func() { _ = input.interaction.CloseSend() }()
 	for {
 		req, err := receive()
@@ -1345,23 +1350,13 @@ func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInp
 		switch frame := req.GetFrame().(type) {
 		case *agentcomposev2.RunAttachRequest_HumanMessage:
 			text := frame.HumanMessage.GetText()
-			if err := input.HumanMessage(text); err != nil {
+			if !forwardPromptHumanMessage(ctx, input, turnReady, text, onHumanMessage) {
 				return
-			}
-			if onHumanMessage != nil {
-				if err := onHumanMessage(text); err != nil {
-					return
-				}
 			}
 		case *agentcomposev2.RunAttachRequest_Stdin:
 			text := string(frame.Stdin.GetData())
-			if err := input.HumanMessage(text); err != nil {
+			if !forwardPromptHumanMessage(ctx, input, turnReady, text, onHumanMessage) {
 				return
-			}
-			if onHumanMessage != nil {
-				if err := onHumanMessage(text); err != nil {
-					return
-				}
 			}
 		case *agentcomposev2.RunAttachRequest_StdinEof:
 			_ = input.EOF()
@@ -1376,15 +1371,40 @@ func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInp
 	}
 }
 
+func forwardPromptHumanMessage(ctx context.Context, input *promptWrapperInput, turnReady <-chan struct{}, text string, onHumanMessage func(string) error) bool {
+	if turnReady != nil {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-turnReady:
+		}
+	}
+	if onHumanMessage != nil {
+		if err := onHumanMessage(text); err != nil {
+			return false
+		}
+	}
+	return input.HumanMessage(text) == nil
+}
+
+func releasePromptTurn(turnReady chan<- struct{}) {
+	select {
+	case turnReady <- struct{}{}:
+	default:
+	}
+}
+
 type promptAttachProjector struct {
-	run        domain.ProjectRunRecord
-	sandbox    *domain.Sandbox
-	logsPath   string
-	runLogs    *RunLogHub
-	mu         sync.Mutex
-	buffer     []byte
-	itemTexts  map[string]string
-	loggedText string
+	run                domain.ProjectRunRecord
+	sandbox            *domain.Sandbox
+	logsPath           string
+	runLogs            *RunLogHub
+	mu                 sync.Mutex
+	buffer             []byte
+	itemTexts          map[string]string
+	loggedText         string
+	hasLoggedText      bool
+	logEndsWithNewline bool
 }
 
 func newPromptAttachProjector(run domain.ProjectRunRecord, sandbox *domain.Sandbox, logsPath string, hub *RunLogHub) *promptAttachProjector {
@@ -1521,7 +1541,7 @@ func (p *promptAttachProjector) appendLogText(text string) error {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if err := p.appendLogChunkLocked(text); err != nil {
+	if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text}); err != nil {
 		return err
 	}
 	p.loggedText += text
@@ -1539,14 +1559,14 @@ func (p *promptAttachProjector) appendLogFinalText(finalText string) error {
 		if text == "" {
 			return nil
 		}
-		if err := p.appendLogChunkLocked(text); err != nil {
+		if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text}); err != nil {
 			return err
 		}
 		p.loggedText += text
 		return nil
 	}
 	if p.loggedText == "" {
-		if err := p.appendLogChunkLocked(finalText); err != nil {
+		if err := p.appendLogChunkLocked(domain.ExecChunk{Text: finalText}); err != nil {
 			return err
 		}
 		p.loggedText = finalText
@@ -1556,30 +1576,44 @@ func (p *promptAttachProjector) appendLogFinalText(finalText string) error {
 
 func (p *promptAttachProjector) AppendHumanMessage(message string) error {
 	text := promptAttachHumanLogText(message)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if text != "" {
+		if p.hasLoggedText && !p.logEndsWithNewline {
+			text = "\n" + text
+		}
+		if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text}); err != nil {
+			return err
+		}
+	}
+	p.loggedText = ""
+	return nil
+}
+
+func (p *promptAttachProjector) AppendStderr(text string) error {
 	if text == "" {
 		return nil
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.loggedText != "" && !strings.HasSuffix(p.loggedText, "\n") {
-		text = "\n" + text
-	}
-	return p.appendLogChunkLocked(text)
+	return p.appendLogChunkLocked(domain.ExecChunk{Text: text, Stream: domain.StdioStderr})
 }
 
-func (p *promptAttachProjector) appendLogChunkLocked(text string) error {
-	chunk := domain.ExecChunk{Text: text}
+func (p *promptAttachProjector) appendLogChunkLocked(chunk domain.ExecChunk) error {
 	offset, err := appendProjectRunLogChunk(p.logsPath, chunk)
 	if err != nil {
 		return err
+	}
+	if chunk.Text != "" {
+		p.hasLoggedText = true
+		p.logEndsWithNewline = strings.HasSuffix(chunk.Text, "\n")
 	}
 	publishRunLogChunk(p.runLogs, p.run.RunID, chunk, offset)
 	return nil
 }
 
 func promptAttachHumanLogText(message string) string {
-	message = strings.TrimSpace(message)
-	if message == "" {
+	if strings.TrimSpace(message) == "" {
 		return ""
 	}
 	if strings.HasSuffix(message, "\n") {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1561,6 +1561,9 @@ func (p *promptAttachProjector) AppendHumanMessage(message string) error {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.loggedText != "" && !strings.HasSuffix(p.loggedText, "\n") {
+		text = "\n" + text
+	}
 	return p.appendLogChunkLocked(text)
 }
 

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -866,6 +866,24 @@ func TestPromptAttachProjectorLogsTurnFinalTextWithoutAgentEventText(t *testing.
 	}
 }
 
+func TestPromptAttachProjectorSeparatesHumanMessageAfterUnterminatedAgentText(t *testing.T) {
+	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+	projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-boundary"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-boundary"}}, logsPath, nil)
+	if _, _, err := projector.Project([]byte(`{"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"first answer"}}}` + "\n")); err != nil {
+		t.Fatalf("project agent text: %v", err)
+	}
+	if err := projector.AppendHumanMessage("next question"); err != nil {
+		t.Fatalf("append human message: %v", err)
+	}
+	transcript, err := os.ReadFile(logsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if string(transcript) != "first answer\nnext question\n" {
+		t.Fatalf("transcript = %q", string(transcript))
+	}
+}
+
 func receiveProjectorRunLogEvent(t *testing.T, sub *RunLogSubscription) RunLogEvent {
 	t.Helper()
 	select {

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -803,6 +804,94 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	}
 }
 
+func TestRunsControllerRunProjectPromptAttachGatesQueuedTurnsAndOrdersTranscript(t *testing.T) {
+	ctx := context.Background()
+	controller, configDB, runtime := newTestRunAttachController(t, nil)
+	interaction := newScriptedRunAttachInteraction()
+	runtime.interactionOverride = interaction
+
+	requests := make(chan *agentcomposev2.RunAttachRequest, 4)
+	requests <- &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+		Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "human-1"},
+		Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
+	}}}
+	requests <- humanMessageAttachRequest("human-2")
+	requests <- humanMessageAttachRequest("human-3")
+	requests <- &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}}
+	close(requests)
+
+	var responses []*agentcomposev2.RunAttachResponse
+	done := make(chan error, 1)
+	go func() {
+		done <- controller.RunProjectCommandAttach(ctx, func() (*agentcomposev2.RunAttachRequest, error) {
+			req, ok := <-requests
+			if !ok {
+				return nil, io.EOF
+			}
+			return req, nil
+		}, func(resp *agentcomposev2.RunAttachResponse) error {
+			responses = append(responses, resp)
+			return nil
+		})
+	}()
+
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "start", "")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-1")
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	interaction.frames <- driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputStarted}
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":0,"type":"started","provider":"codex","sessionId":"thread-1"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":1,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"agent-1\n"}}}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-1\n"}`)
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-2")
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":3,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m2","type":"agent_message","text":"agent-2\n"}}}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":4,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-2\n"}`)
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-3")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "eof", "")
+
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":5,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m3","type":"agent_message","text":"agent-3\n"}}}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":6,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-3\n"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":7,"type":"result","provider":"codex","sessionId":"thread-1","stopReason":"eof","finalText":"agent-3\n","transcript":"agent-1\nagent-2\nagent-3\n"}`)
+	interaction.frames <- driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", Success: true}}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunProjectCommandAttach returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunProjectCommandAttach did not finish")
+	}
+
+	var result *agentcomposev2.AttachResult
+	for _, response := range responses {
+		if response.GetResult() != nil {
+			result = response.GetResult()
+		}
+	}
+	if result == nil || result.GetRun() == nil {
+		t.Fatalf("prompt attach responses have no result: %#v", responses)
+	}
+	stored, err := configDB.GetProjectRun(ctx, result.GetRun().GetRunId())
+	if err != nil {
+		t.Fatalf("get stored run: %v", err)
+	}
+	transcript, err := os.ReadFile(stored.LogsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	const expected = "agent-1\nhuman-2\nagent-2\nhuman-3\nagent-3\n"
+	if string(transcript) != expected {
+		t.Fatalf("transcript = %q, want %q", string(transcript), expected)
+	}
+}
+
+func promptRuntimeStdoutFrame(line string) driverpkg.RuntimeOutputFrame {
+	return driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputStdout, Data: []byte(line + "\n")}
+}
+
 func TestPromptAttachProjectorLogsResultFinalTextWithoutAgentEventText(t *testing.T) {
 	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
 	projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-final"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-final"}}, logsPath, nil)
@@ -831,11 +920,11 @@ func TestPromptAttachProjectorLogsHumanMessagesAndTurnFinalText(t *testing.T) {
 	if _, _, err := projector.Project([]byte(`{"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"first answer\n"}}}` + "\n")); err != nil {
 		t.Fatalf("project first answer: %v", err)
 	}
-	if err := projector.AppendHumanMessage("next question"); err != nil {
-		t.Fatalf("append human message: %v", err)
-	}
 	if _, _, err := projector.Project([]byte(`{"type":"agent_turn_completed","finalText":"first answer\n"}` + "\n")); err != nil {
 		t.Fatalf("project first turn completion: %v", err)
+	}
+	if err := projector.AppendHumanMessage("next question"); err != nil {
+		t.Fatalf("append human message: %v", err)
 	}
 	transcript, err := os.ReadFile(logsPath)
 	if err != nil {
@@ -881,6 +970,56 @@ func TestPromptAttachProjectorSeparatesHumanMessageAfterUnterminatedAgentText(t 
 	}
 	if string(transcript) != "first answer\nnext question\n" {
 		t.Fatalf("transcript = %q", string(transcript))
+	}
+}
+
+func TestPromptAttachProjectorDoesNotDuplicateSeparatorsBetweenQueuedHumanMessages(t *testing.T) {
+	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+	projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-human-tail"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-human-tail"}}, logsPath, nil)
+	if _, _, err := projector.Project([]byte(`{"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"agent"}}}` + "\n")); err != nil {
+		t.Fatalf("project agent text: %v", err)
+	}
+	if err := projector.AppendHumanMessage("human-2"); err != nil {
+		t.Fatalf("append first human message: %v", err)
+	}
+	if err := projector.AppendHumanMessage("  human-3  "); err != nil {
+		t.Fatalf("append second human message: %v", err)
+	}
+	transcript, err := os.ReadFile(logsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if string(transcript) != "agent\nhuman-2\n  human-3  \n" {
+		t.Fatalf("transcript = %q", string(transcript))
+	}
+}
+
+func TestPromptAttachProjectorSeparatesHumanMessageFromStderrTail(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+	}{
+		{name: "terminated", stderr: "warning\n"},
+		{name: "unterminated", stderr: "warning"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+			projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-stderr-tail"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-stderr-tail"}}, logsPath, nil)
+			if err := projector.AppendStderr(test.stderr); err != nil {
+				t.Fatalf("append stderr: %v", err)
+			}
+			if err := projector.AppendHumanMessage("next"); err != nil {
+				t.Fatalf("append human message: %v", err)
+			}
+			transcript, err := os.ReadFile(logsPath)
+			if err != nil {
+				t.Fatalf("read transcript: %v", err)
+			}
+			if string(transcript) != "warning\nnext\n" {
+				t.Fatalf("transcript = %q", string(transcript))
+			}
+		})
 	}
 }
 
@@ -1967,15 +2106,56 @@ func newTestRunAttachController(t *testing.T, frames []driverpkg.RuntimeOutputFr
 
 type fakeRunAttachRuntime struct {
 	fakeControllerRuntime
-	spec        driverpkg.RuntimeStartSpec
-	frames      []driverpkg.RuntimeOutputFrame
-	interaction *fakeRunAttachInteraction
+	spec                driverpkg.RuntimeStartSpec
+	frames              []driverpkg.RuntimeOutputFrame
+	interaction         *fakeRunAttachInteraction
+	interactionOverride driverpkg.RuntimeInteraction
 }
 
 func (r *fakeRunAttachRuntime) OpenInteraction(_ context.Context, _ *domain.Sandbox, _ domain.VMState, spec driverpkg.RuntimeStartSpec) (driverpkg.RuntimeInteraction, error) {
 	r.spec = spec
+	if r.interactionOverride != nil {
+		return r.interactionOverride, nil
+	}
 	r.interaction = &fakeRunAttachInteraction{frames: append([]driverpkg.RuntimeOutputFrame(nil), r.frames...)}
 	return r.interaction, nil
+}
+
+type scriptedRunAttachInteraction struct {
+	frames    chan driverpkg.RuntimeOutputFrame
+	sent      chan driverpkg.RuntimeInputFrame
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newScriptedRunAttachInteraction() *scriptedRunAttachInteraction {
+	return &scriptedRunAttachInteraction{
+		frames: make(chan driverpkg.RuntimeOutputFrame, 16),
+		sent:   make(chan driverpkg.RuntimeInputFrame, 8),
+		closed: make(chan struct{}),
+	}
+}
+
+func (i *scriptedRunAttachInteraction) Send(frame driverpkg.RuntimeInputFrame) error {
+	i.sent <- frame
+	return nil
+}
+
+func (i *scriptedRunAttachInteraction) CloseSend() error {
+	i.closeOnce.Do(func() { close(i.closed) })
+	return nil
+}
+
+func (i *scriptedRunAttachInteraction) Recv() (driverpkg.RuntimeOutputFrame, error) {
+	frame, ok := <-i.frames
+	if !ok {
+		return driverpkg.RuntimeOutputFrame{}, io.EOF
+	}
+	return frame, nil
+}
+
+func (*scriptedRunAttachInteraction) Wait() (driverpkg.RuntimeResult, error) {
+	return driverpkg.RuntimeResult{Success: true}, nil
 }
 
 type fakeRunAttachInteraction struct {

--- a/runtime/javascript/src/interactive.ts
+++ b/runtime/javascript/src/interactive.ts
@@ -28,7 +28,9 @@ export class UnsupportedProviderError extends Error {
 
 export class CodexInteractiveSession {
   private readonly runner: CodexRunner;
+  private readonly writer: BufferedTextWriter;
   private readonly result: AgentResult;
+  private turnCount = 0;
   private thread?: {
     id?: string | null;
     runStreamed(input: string, options?: unknown): Promise<{ events: AsyncIterable<unknown> }>;
@@ -38,7 +40,8 @@ export class CodexInteractiveSession {
     private readonly options: RunnerOptions,
     private readonly emit: EmitInteractiveFrame,
   ) {
-    this.runner = new CodexRunner(options, new BufferedTextWriter());
+    this.writer = new BufferedTextWriter();
+    this.runner = new CodexRunner(options, this.writer);
     this.result = {
       provider: "codex",
       threadId: "",
@@ -74,6 +77,10 @@ export class CodexInteractiveSession {
     if (!this.thread) {
       throw new Error("stream has not been started");
     }
+    if (this.turnCount > 0) {
+      this.writer.beginTurn();
+    }
+    this.turnCount++;
     const { events } = await this.thread.runStreamed(
       message,
       this.options.outputSchema ? { outputSchema: this.options.outputSchema } : undefined,
@@ -121,6 +128,16 @@ class BufferedTextWriter implements TextWriter {
 
   line(text = ""): void {
     this.write(text.endsWith("\n") ? text : `${text}\n`);
+  }
+
+  beginTurn(): void {
+    if (this.chunks.length === 0) {
+      return;
+    }
+    const last = this.chunks[this.chunks.length - 1] || "";
+    if (!last.endsWith("\n")) {
+      this.chunks.push("\n");
+    }
   }
 
   transcript(): string {

--- a/runtime/javascript/test/runtime.e2e.test.ts
+++ b/runtime/javascript/test/runtime.e2e.test.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { EventEmitter } from "node:events";
-import { Readable } from "node:stream";
+import { Readable, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { createProgram } from "../src/cli.js";
 import { runExecCommand } from "../src/command.js";
 import { COMMAND_RESULT_PREFIX, RESULT_PREFIX } from "../src/constants.js";
+import { runStreamCommand } from "../src/stream.js";
 import { captureStdio, withTempSession } from "./helpers.js";
 
 const codexMockState = vi.hoisted(() => ({
@@ -121,6 +122,38 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 describe("runtime JavaScript E2E", () => {
+	it("preserves turn boundaries across interactive Codex messages", async () => {
+		await withTempSession(async (root) => {
+			let output = "";
+			const stdout = new Writable({
+				write(chunk, _encoding, callback) {
+					output += chunk.toString();
+					callback();
+				},
+			});
+			const frame = (seq: number, type: string, fields: Record<string, unknown> = {}) =>
+				JSON.stringify({ v: 1, seq, type, ...fields }) + "\n";
+
+			await runStreamCommand({
+				stdin: Readable.from([
+					frame(0, "start", { provider: "codex", stateRoot: path.join(root, "state") }),
+					frame(1, "human_message", { message: "first" }),
+					frame(2, "human_message", { message: "second" }),
+					frame(3, "eof"),
+				]),
+				stdout,
+			});
+
+			const frames = output.trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+			expect(frames.at(-1)).toMatchObject({
+				type: "result",
+				threadId: "e2e-codex-thread",
+				stopReason: "eof",
+				transcript: '{"input":"first"}\n{"input":"second"}',
+			});
+		});
+	});
+
   it("runs a production-like command workflow through request and artifact files", async () => {
     await withTempSession(async (root) => {
       const workspace = path.join(root, "workspace");

--- a/runtime/javascript/test/stream.test.ts
+++ b/runtime/javascript/test/stream.test.ts
@@ -104,6 +104,7 @@ describe("runStreamCommand", () => {
         threadId: "thread-1",
         stopReason: "eof",
         finalText: "answer 2",
+        transcript: "answer 1\nanswer 2",
       });
       expect(parseOutput(stdout.text)).toHaveLength(8);
     });


### PR DESCRIPTION
## Summary

  - move non-TTY `exec -i --prompt` stdin processing into an independent input pump
  - forward piped human messages without waiting for the previous turn to request input
  - send stdin EOF and close the request side when piped input ends
  - preserve the existing terminal-driven multi-turn and Ctrl+D behavior
  - avoid waiting indefinitely when non-TTY stdin has already reached EOF
  - add explicit transcript boundaries between interactive agent turns
  - ensure run logs insert a newline before a human message when the preceding agent output is unterminated
  - preserve individual streaming chunks without appending a newline to every chunk

  ## Testing

  - `go test ./cmd/agent-compose ./pkg/runs`
    - 630 tests passed
  - `npm test -- --run`
    - 16 test files passed
    - 143 tests passed
  - `npm run typecheck`
  - combined integration with `fix/exec-prompt-command-contract`:
    - `go test ./cmd/agent-compose ./pkg/runs`
    - 632 tests passed

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No documentation change was required because the existing `-i`, pipe, Ctrl+D, and
  transcript contracts are preserved.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.