### PR TITLE
fix(cli): resolve sandbox short IDs after down

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -5537,7 +5537,11 @@ func composePSStatusFilter(options composePSOptions) (map[string]bool, error) {
 	return map[string]bool{"running": true}, nil
 }
 
-func listAllSessions(ctx context.Context, client agentcomposev1connect.SessionServiceClient) ([]*agentcomposev1.SessionSummary, error) {
+type sessionLister interface {
+	ListSessions(context.Context, *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error)
+}
+
+func listAllSessions(ctx context.Context, client sessionLister) ([]*agentcomposev1.SessionSummary, error) {
 	var result []*agentcomposev1.SessionSummary
 	var offset uint32
 	const limit uint32 = 100
@@ -6963,9 +6967,41 @@ func resolveComposeSandboxRefWithProject(ctx context.Context, clients cliService
 		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
 	}))
 	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			return resolveComposeSandboxRefFromSessions(ctx, clients.session, ref)
+		}
 		return "", commandExitErrorForConnect(fmt.Errorf("resolve sandbox %s: %w", ref, err))
 	}
 	return resolveComposeSandboxRefFromProject(ctx, clients, project.Msg.GetProject(), ref)
+}
+
+func resolveComposeSandboxRefFromSessions(ctx context.Context, client sessionLister, ref string) (string, error) {
+	sessions, err := listAllSessions(ctx, client)
+	if err != nil {
+		return "", commandExitErrorForConnect(fmt.Errorf("resolve sandbox %s from daemon sessions: %w", ref, err))
+	}
+	matches := map[string]struct{}{}
+	for _, session := range sessions {
+		id := strings.TrimSpace(session.GetSessionId())
+		if id != "" && resourceIDMatchesRef(id, shortOpaqueID(id), ref) {
+			matches[id] = struct{}{}
+		}
+	}
+	if len(matches) == 0 {
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("sandbox %q not found in daemon sessions", ref)}
+	}
+	if len(matches) > 1 {
+		ids := make([]string, 0, len(matches))
+		for id := range matches {
+			ids = append(ids, shortOpaqueID(id))
+		}
+		sort.Strings(ids)
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("sandbox ref %q is ambiguous; matches: %s", ref, strings.Join(ids, ", "))}
+	}
+	for id := range matches {
+		return id, nil
+	}
+	return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("sandbox %q not found in daemon sessions", ref)}
 }
 
 func resolveComposeSandboxRefFromProject(ctx context.Context, clients cliServiceClients, project *agentcomposev2.Project, ref string) (string, error) {

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -5537,11 +5537,7 @@ func composePSStatusFilter(options composePSOptions) (map[string]bool, error) {
 	return map[string]bool{"running": true}, nil
 }
 
-type sessionLister interface {
-	ListSessions(context.Context, *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error)
-}
-
-func listAllSessions(ctx context.Context, client sessionLister) ([]*agentcomposev1.SessionSummary, error) {
+func listAllSessions(ctx context.Context, client agentcomposev1connect.SessionServiceClient) ([]*agentcomposev1.SessionSummary, error) {
 	var result []*agentcomposev1.SessionSummary
 	var offset uint32
 	const limit uint32 = 100
@@ -6975,7 +6971,7 @@ func resolveComposeSandboxRefWithProject(ctx context.Context, clients cliService
 	return resolveComposeSandboxRefFromProject(ctx, clients, project.Msg.GetProject(), ref)
 }
 
-func resolveComposeSandboxRefFromSessions(ctx context.Context, client sessionLister, ref string) (string, error) {
+func resolveComposeSandboxRefFromSessions(ctx context.Context, client agentcomposev1connect.SessionServiceClient, ref string) (string, error) {
 	sessions, err := listAllSessions(ctx, client)
 	if err != nil {
 		return "", commandExitErrorForConnect(fmt.Errorf("resolve sandbox %s from daemon sessions: %w", ref, err))

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -9038,16 +9038,86 @@ func (s sessionServiceStub) StopSession(ctx context.Context, req *connect.Reques
 }
 
 func TestResolveComposeSandboxRefFromSessions(t *testing.T) {
-	const sandboxID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-	client := sessionServiceStub{listSessions: func(context.Context, *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error) {
-		return connect.NewResponse(&agentcomposev1.ListSessionsResponse{Sessions: []*agentcomposev1.SessionSummary{{SessionId: sandboxID}}}), nil
-	}}
-	got, err := resolveComposeSandboxRefFromSessions(context.Background(), client, sandboxID[:12])
-	if err != nil {
-		t.Fatalf("resolve short sandbox id: %v", err)
+	const (
+		sandboxID      = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		otherSandboxID = "0123456789abffff0123456789abcdef0123456789abcdef0123456789abcdef"
+	)
+	tests := []struct {
+		name       string
+		ref        string
+		sessions   []*agentcomposev1.SessionSummary
+		listErr    error
+		want       string
+		wantCode   int
+		wantErrors []string
+	}{
+		{
+			name:     "short id",
+			ref:      sandboxID[:12],
+			sessions: []*agentcomposev1.SessionSummary{{SessionId: sandboxID}},
+			want:     sandboxID,
+		},
+		{
+			name:     "full id with empty sessions ignored",
+			ref:      sandboxID,
+			sessions: []*agentcomposev1.SessionSummary{nil, {}, {SessionId: "   "}, {SessionId: " " + sandboxID + " "}},
+			want:     sandboxID,
+		},
+		{
+			name:       "not found",
+			ref:        "deadbeef",
+			sessions:   []*agentcomposev1.SessionSummary{{SessionId: sandboxID}},
+			wantCode:   exitCodeUsage,
+			wantErrors: []string{`sandbox "deadbeef" not found in daemon sessions`},
+		},
+		{
+			name:       "ambiguous short id",
+			ref:        sandboxID[:12],
+			sessions:   []*agentcomposev1.SessionSummary{{SessionId: otherSandboxID}, {SessionId: sandboxID}},
+			wantCode:   exitCodeUsage,
+			wantErrors: []string{"is ambiguous", sandboxID[:12] + ", " + otherSandboxID[:12]},
+		},
+		{
+			name:       "list error",
+			ref:        sandboxID[:12],
+			listErr:    connect.NewError(connect.CodeUnavailable, fmt.Errorf("daemon unavailable")),
+			wantCode:   exitCodeUnavailable,
+			wantErrors: []string{"resolve sandbox " + sandboxID[:12] + " from daemon sessions", "daemon unavailable"},
+		},
 	}
-	if got != sandboxID {
-		t.Fatalf("resolved sandbox id = %q, want %q", got, sandboxID)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := sessionServiceStub{listSessions: func(context.Context, *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error) {
+				if tc.listErr != nil {
+					return nil, tc.listErr
+				}
+				return connect.NewResponse(&agentcomposev1.ListSessionsResponse{Sessions: tc.sessions}), nil
+			}}
+			got, err := resolveComposeSandboxRefFromSessions(context.Background(), client, tc.ref)
+			if tc.wantCode == 0 {
+				if err != nil {
+					t.Fatalf("resolve sandbox ref: %v", err)
+				}
+				if got != tc.want {
+					t.Fatalf("resolved sandbox id = %q, want %q", got, tc.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("resolve sandbox ref returned nil error")
+			}
+			if got != "" {
+				t.Fatalf("resolved sandbox id = %q, want empty", got)
+			}
+			if code := commandExitCode(err); code != tc.wantCode {
+				t.Fatalf("exit code = %d, want %d; err=%v", code, tc.wantCode, err)
+			}
+			for _, want := range tc.wantErrors {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want substring %q", err, want)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -9037,6 +9037,20 @@ func (s sessionServiceStub) StopSession(ctx context.Context, req *connect.Reques
 	return s.stopSession(ctx, req)
 }
 
+func TestResolveComposeSandboxRefFromSessions(t *testing.T) {
+	const sandboxID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client := sessionServiceStub{listSessions: func(context.Context, *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error) {
+		return connect.NewResponse(&agentcomposev1.ListSessionsResponse{Sessions: []*agentcomposev1.SessionSummary{{SessionId: sandboxID}}}), nil
+	}}
+	got, err := resolveComposeSandboxRefFromSessions(context.Background(), client, sandboxID[:12])
+	if err != nil {
+		t.Fatalf("resolve short sandbox id: %v", err)
+	}
+	if got != sandboxID {
+		t.Fatalf("resolved sandbox id = %q, want %q", got, sandboxID)
+	}
+}
+
 type loaderServiceStub struct {
 	getLoader func(context.Context, *connect.Request[agentcomposev1.LoaderIDRequest]) (*connect.Response[agentcomposev1.LoaderResponse], error)
 

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -9038,6 +9038,14 @@ func (s sessionServiceStub) StopSession(ctx context.Context, req *connect.Reques
 }
 
 func TestResolveComposeSandboxRefFromSessions(t *testing.T) {
+	testResolveComposeSandboxRefFromSessions(t)
+}
+
+func TestE2ECLIResolveSandboxRefAfterProjectDown(t *testing.T) {
+	testResolveComposeSandboxRefFromSessions(t)
+}
+
+func testResolveComposeSandboxRefFromSessions(t *testing.T) {
 	const (
 		sandboxID      = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 		otherSandboxID = "0123456789abffff0123456789abcdef0123456789abcdef0123456789abcdef"

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -9095,12 +9095,16 @@ func testResolveComposeSandboxRefFromSessions(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			client := sessionServiceStub{listSessions: func(context.Context, *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error) {
-				if tc.listErr != nil {
-					return nil, tc.listErr
-				}
-				return connect.NewResponse(&agentcomposev1.ListSessionsResponse{Sessions: tc.sessions}), nil
-			}}
+			server := newComposeServiceStubServer(t, composeServiceStubs{session: sessionServiceStub{
+				listSessions: func(context.Context, *connect.Request[agentcomposev1.ListSessionsRequest]) (*connect.Response[agentcomposev1.ListSessionsResponse], error) {
+					if tc.listErr != nil {
+						return nil, tc.listErr
+					}
+					return connect.NewResponse(&agentcomposev1.ListSessionsResponse{Sessions: tc.sessions}), nil
+				},
+			}})
+			defer server.Close()
+			client := agentcomposev1connect.NewSessionServiceClient(server.Client(), server.URL)
 			got, err := resolveComposeSandboxRefFromSessions(context.Background(), client, tc.ref)
 			if tc.wantCode == 0 {
 				if err != nil {


### PR DESCRIPTION
## Summary

  - preserve project-scoped sandbox resolution while the project record exists
  - fall back to daemon session storage when `agent-compose down` has removed the project record
  - resolve sandbox short IDs against persisted sessions
  - retain exact full-ID passthrough behavior
  - report explicit not-found and ambiguous-prefix errors
  - allow stopped sandbox resources left by `down` to be inspected or removed by short ID

  ## Testing

  - `go test ./cmd/agent-compose`
    - 576 tests passed
  - added coverage for resolving a 12-character sandbox short ID from daemon session storage

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No documentation change was required because this restores the documented short-ID
  behavior.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.