### PR TITLE
fix(cli): support exec prompt and positional commands

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/net/http2/h2c" //nolint:staticcheck // h2c is required for unencrypted HTTP/2 compatibility with Connect bidi streams.
 	"golang.org/x/text/width"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 
@@ -702,7 +703,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 
 	execOptions := composeExecOptions{}
 	execCmd := &cobra.Command{
-		Use:   "exec <sandbox> [command] [args...]",
+		Use:   "exec <sandbox> (--command <shell-command> | --prompt <prompt> | -- <command> [args...])",
 		Short: "Execute a command in a running sandbox",
 		Args:  composeExecArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -2811,9 +2812,6 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 	if cli.JSON && (options.Interactive || options.TTY) {
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec --json cannot be used with -i/--interactive or -t/--tty")}
 	}
-	if strings.TrimSpace(options.Prompt) != "" && !options.Interactive {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec --prompt requires -i/--interactive")}
-	}
 	_, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
@@ -2835,6 +2833,13 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 			return runComposeExecPromptAttachCommand(cmd, normalized.Name, connectExecAttachClient{client: attachClient}, req, options)
 		}
 		return runComposeExecAttachCommand(cmd, normalized.Name, connectExecAttachClient{client: attachClient}, req, options)
+	}
+	if strings.TrimSpace(options.Prompt) != "" {
+		attachClient, err := newCLIExecAttachServiceClient(cli)
+		if err != nil {
+			return err
+		}
+		return runComposeExecPromptOnceCommand(cmd, normalized.Name, connectExecAttachClient{client: attachClient}, req, options, cli.JSON)
 	}
 	stream, err := clients.exec.ExecStream(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
@@ -2878,6 +2883,69 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 	}
 	if !result.GetSuccess() {
 		return commandExitError{Code: execResultExitCode(result), Err: fmt.Errorf("exec %s in sandbox %s failed: %s", result.GetExecId(), result.GetSandboxId(), firstNonEmptyString(result.GetError(), result.GetStderr(), result.GetOutput(), "command failed"))}
+	}
+	return nil
+}
+
+func runComposeExecPromptOnceCommand(cmd *cobra.Command, projectName string, client execAttachClient, req *agentcomposev2.ExecRequest, options composeExecOptions, jsonOutput bool) error {
+	stream := client.ExecAttach(cmd.Context())
+	if err := stream.Send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Start{Start: &agentcomposev2.ExecAttachStart{
+		Request: req, Mode: agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
+		Prompt: strings.TrimSpace(options.Prompt), AttachStdin: false, Tty: false,
+	}}}); err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("exec project %s prompt start: %w", projectName, err))
+	}
+	if err := stream.CloseRequest(); err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("exec project %s prompt close request: %w", projectName, err))
+	}
+	var result *agentcomposev2.AttachResult
+	output := newTerminalStreamOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	for {
+		event, err := stream.Receive()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return commandExitErrorForConnect(fmt.Errorf("exec project %s prompt: %w", projectName, err))
+		}
+		switch frame := event.GetFrame().(type) {
+		case *agentcomposev2.ExecAttachResponse_Output:
+			if !jsonOutput {
+				if err := writeExecAttachOutput(output, frame.Output); err != nil {
+					return err
+				}
+			}
+		case *agentcomposev2.ExecAttachResponse_AgentEvent:
+			if !jsonOutput && frame.AgentEvent.GetText() != "" {
+				if _, err := io.WriteString(cmd.OutOrStdout(), frame.AgentEvent.GetText()); err != nil {
+					return err
+				}
+			}
+		case *agentcomposev2.ExecAttachResponse_Result:
+			result = frame.Result
+		case *agentcomposev2.ExecAttachResponse_Error:
+			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("exec project %s prompt failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
+		}
+	}
+	if !jsonOutput {
+		if err := output.Finish(); err != nil {
+			return err
+		}
+	}
+	if result == nil {
+		return fmt.Errorf("exec project %s prompt completed without result", projectName)
+	}
+	if jsonOutput {
+		data, err := protojson.MarshalOptions{Indent: "  ", UseProtoNames: true}.Marshal(result)
+		if err != nil {
+			return err
+		}
+		if err := writeCommandOutput(cmd.OutOrStdout(), append(data, '\n')); err != nil {
+			return err
+		}
+	}
+	if !result.GetSuccess() {
+		return commandExitError{Code: attachResultExitCode(result), Err: fmt.Errorf("exec prompt in project %s failed: %s", projectName, firstNonEmptyString(result.GetError(), result.GetOutput(), "prompt failed"))}
 	}
 	return nil
 }
@@ -3513,8 +3581,12 @@ func normalizeComposeExecRequest(cmd *cobra.Command, clients cliServiceClients, 
 	if commandText != "" && promptText != "" {
 		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires only one of --command or --prompt")}
 	}
-	if commandText == "" && promptText == "" {
-		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires --command or --prompt")}
+	positionalCommand := len(args) > 1
+	if commandText == "" && promptText == "" && !positionalCommand {
+		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires --command, --prompt, or a command after --")}
+	}
+	if positionalCommand && (commandText != "" || promptText != "") {
+		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec positional command cannot be combined with --command or --prompt")}
 	}
 	legacyTargetFlags := []string{}
 	if cmd.Flags().Changed("run") {
@@ -3553,14 +3625,11 @@ func normalizeComposeExecRequest(cmd *cobra.Command, clients cliServiceClients, 
 	if sandbox == "" {
 		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires non-empty sandbox")}
 	}
-	if len(args) > 1 {
-		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec command must be specified with --command")}
-	}
 	sandbox, err := resolveComposeSandboxRefWithProject(cmd.Context(), clients, projectID, sandbox)
 	if err != nil {
 		return nil, err
 	}
-	command, err := composeExecCommandFromArgs(options, nil)
+	command, err := composeExecCommandFromArgs(options, args[1:])
 	if err != nil {
 		return nil, err
 	}
@@ -3582,7 +3651,10 @@ func composeExecCommandFromArgs(options composeExecOptions, args []string) (*age
 	if strings.TrimSpace(options.Prompt) != "" {
 		return nil, nil
 	}
-	return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires --command or --prompt")}
+	if len(args) > 0 {
+		return &agentcomposev2.ExecCommand{Command: args[0], Args: append([]string(nil), args[1:]...)}, nil
+	}
+	return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires --command, --prompt, or a command after --")}
 }
 
 func runComposeImageListCommand(cmd *cobra.Command, cli cliOptions, options composeImageListOptions) error {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -4838,8 +4838,47 @@ agents:
 	if ambiguousCode != exitCodeUsage {
 		t.Fatalf("exec --command ambiguous exit code = %d, want %d", ambiguousCode, exitCodeUsage)
 	}
-	if ambiguousOut != "" || !strings.Contains(ambiguousErr, "exec command must be specified with --command") {
+	if ambiguousOut != "" || !strings.Contains(ambiguousErr, "positional command cannot be combined with --command") {
 		t.Fatalf("exec --command ambiguous stdout/stderr = %q / %q", ambiguousOut, ambiguousErr)
+	}
+}
+
+func TestComposeExecCommandFromPositionalArgs(t *testing.T) {
+	command, err := composeExecCommandFromArgs(composeExecOptions{}, []string{"ps", "axu", "--sort=-pid"})
+	if err != nil {
+		t.Fatalf("composeExecCommandFromArgs returned error: %v", err)
+	}
+	if command.GetCommand() != "ps" || !reflect.DeepEqual(command.GetArgs(), []string{"axu", "--sort=-pid"}) {
+		t.Fatalf("positional command = %#v", command)
+	}
+}
+
+func TestRunComposeExecPromptOnceCommand(t *testing.T) {
+	stream := newFakeExecAttachStream([]*agentcomposev2.ExecAttachResponse{
+		{Frame: &agentcomposev2.ExecAttachResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "prompt reply\n"}}},
+		{Frame: &agentcomposev2.ExecAttachResponse_Result{Result: &agentcomposev2.AttachResult{Success: true, Run: &agentcomposev2.RunSummary{RunId: "run-prompt", SandboxId: "sandbox-prompt"}}}},
+	})
+	client := &fakeExecAttachClient{stream: stream}
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{Use: "exec"}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+	err := runComposeExecPromptOnceCommand(cmd, "project", client, &agentcomposev2.ExecRequest{
+		Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-prompt"},
+	}, composeExecOptions{Prompt: "hello"}, false)
+	if err != nil {
+		t.Fatalf("prompt once returned error: %v", err)
+	}
+	if stdout.String() != "prompt reply\n" {
+		t.Fatalf("prompt once stdout = %q", stdout.String())
+	}
+	sent := stream.sentFrames()
+	if len(sent) != 1 || sent[0].GetStart().GetPrompt() != "hello" || sent[0].GetStart().GetAttachStdin() {
+		t.Fatalf("prompt once start = %#v", sent)
+	}
+	if !stream.closedRequest() {
+		t.Fatal("prompt once request was not closed")
 	}
 }
 

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -360,14 +360,15 @@ agent-compose rm --force sandbox_789
 Execute a command in a running sandbox, similar to `docker compose exec`.
 
 ```bash
-agent-compose exec <sandbox>
-agent-compose exec <sandbox> <command> [args...]
+agent-compose exec <sandbox> -- <command> [args...]
 agent-compose exec <sandbox> --command "..."
+agent-compose exec <sandbox> --prompt "..."
 ```
 
 | Option | Description |
 | --- | --- |
 | `--command "..."` | Pass a shell command as a flag. It is executed as `bash -lc "..."` in the sandbox. |
+| `--prompt "..."` | Run one agent prompt in the existing sandbox and exit after the response. Add `-i` (and optionally `-t`) for a multi-turn attached session. |
 | `--cwd <path>` | Set the working directory inside the sandbox. |
 | `--agent <agent>` | Deprecated target selection option; use `exec <sandbox>` instead. |
 | `--run <run-id>` | Deprecated target selection option; use `exec <sandbox>` instead. |
@@ -375,10 +376,10 @@ agent-compose exec <sandbox> --command "..."
 Examples:
 
 ```bash
-agent-compose exec sandbox_123
-agent-compose exec sandbox_123 pwd
-agent-compose exec sandbox_123 bash -lc "task test"
+agent-compose exec sandbox_123 -- pwd
+agent-compose exec sandbox_123 -- bash -lc "task test"
 agent-compose exec sandbox_123 --command "git status --short"
+agent-compose exec sandbox_123 --prompt "summarize the workspace"
 agent-compose exec sandbox_123 --cwd /workspace --command "pwd"
 ```
 

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -369,9 +369,9 @@ agent-compose rm --force sandbox_789
 在运行中的 sandbox 内执行命令，语义类似 `docker compose exec`。
 
 ```bash
-agent-compose exec <sandbox>
-agent-compose exec <sandbox> <command> [args...]
+agent-compose exec <sandbox> -- <command> [args...]
 agent-compose exec <sandbox> --command "..."
+agent-compose exec <sandbox> --prompt "..."
 ```
 
 选项：
@@ -379,6 +379,7 @@ agent-compose exec <sandbox> --command "..."
 | 参数 | 说明 |
 | --- | --- |
 | `--command "..."` | 以 flag 形式传入 shell 命令，等价于在 sandbox 中执行 `bash -lc "..."`。 |
+| `--prompt "..."` | 在已有 sandbox 中执行一次 agent prompt，输出回复后退出；增加 `-i`（以及可选的 `-t`）进入多轮 attach 会话。 |
 | `--cwd <path>` | 指定 sandbox 内工作目录。 |
 | `--agent <agent>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
 | `--run <run-id>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
@@ -386,10 +387,10 @@ agent-compose exec <sandbox> --command "..."
 示例：
 
 ```bash
-agent-compose exec sandbox_123
-agent-compose exec sandbox_123 pwd
-agent-compose exec sandbox_123 bash -lc "task test"
+agent-compose exec sandbox_123 -- pwd
+agent-compose exec sandbox_123 -- bash -lc "task test"
 agent-compose exec sandbox_123 --command "git status --short"
+agent-compose exec sandbox_123 --prompt "总结当前 workspace"
 agent-compose exec sandbox_123 --cwd /workspace --command "pwd"
 ```
 


### PR DESCRIPTION
## Summary

  - allow `agent-compose exec <sandbox> --prompt <prompt>` to run a single agent turn without requiring `-i`
  - keep `-i` and `-it` prompt execution as multi-turn attached sessions
  - support direct argv execution with `agent-compose exec <sandbox> -- <command> [args...]`
  - keep `--command '<shell command>'` as the explicit `bash -lc` execution mode
  - reject conflicting prompt, shell-command, and positional-command inputs
  - return structured attach results for non-interactive prompt execution with `--json`
  - update the English and Chinese CLI manuals with the new command contract

  ## Testing

  - `go test ./cmd/agent-compose`
    - 577 tests passed
  - combined integration with `fix/exec-attach-eof-transcript`:
    - `go test ./cmd/agent-compose ./pkg/runs`
    - 632 tests passed

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.