### PR TITLE
fix(proxy): bypass environment proxy for Jupyter

### DIFF
--- a/pkg/agentcompose/proxy/jupyter_coverage_test.go
+++ b/pkg/agentcompose/proxy/jupyter_coverage_test.go
@@ -68,6 +68,16 @@ func TestJupyterProxyRouteCoverage(t *testing.T) {
 	}
 }
 
+func TestNewJupyterProxyTransportDisablesProxyFromEnvironment(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+
+	transport := newJupyterProxyTransport()
+	if transport.Proxy != nil {
+		t.Fatalf("jupyter proxy transport should not use proxy environment")
+	}
+}
+
 type fakeJupyterStore struct {
 	state domain.ProxyState
 	err   error

--- a/pkg/agentcompose/proxy/proxy.go
+++ b/pkg/agentcompose/proxy/proxy.go
@@ -30,6 +30,7 @@ type JupyterOptions struct {
 
 func RegisterJupyterRoutes(app *echo.Echo, opts JupyterOptions) {
 	base := strings.TrimRight(opts.BasePath, "/")
+	transport := newJupyterProxyTransport()
 	app.GET(base+"/:sessionID", func(c echo.Context) error {
 		proxyState, err := opts.EnsureReady(c.Request().Context(), c.Param("sessionID"))
 		if err != nil {
@@ -63,6 +64,7 @@ func RegisterJupyterRoutes(app *echo.Echo, opts JupyterOptions) {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		proxy := &httputil.ReverseProxy{
+			Transport: transport,
 			Rewrite: func(req *httputil.ProxyRequest) {
 				req.SetURL(target)
 				req.SetXForwarded()
@@ -79,6 +81,12 @@ func RegisterJupyterRoutes(app *echo.Echo, opts JupyterOptions) {
 		proxy.ServeHTTP(c.Response(), c.Request())
 		return nil
 	})
+}
+
+func newJupyterProxyTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return transport
 }
 
 func JupyterTargetReachable(proxyState domain.ProxyState, timeout time.Duration) bool {


### PR DESCRIPTION
## Summary

- configure the Jupyter reverse proxy with a dedicated transport that does not read HTTP_PROXY or HTTPS_PROXY
- reuse the transport across Jupyter proxy requests
- add regression coverage for environment-proxy bypass

## Root cause

The Jupyter readiness check connected directly to the guest container, while httputil.ReverseProxy used the default Go transport. When the daemon inherited an HTTP proxy and the dynamic guest hostname was absent from NO_PROXY, Jupyter traffic was sent to the external proxy and returned 502 after a timeout.

## Validation

- task test
- task build
- go test ./pkg/agentcompose/...
- golangci-lint run --allow-parallel-runners ./pkg/agentcompose/proxy/...