### PR TITLE
fix(runtime): preserve sandbox writable layer across stop and resume

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,13 +128,13 @@ tasks:
           SMOKE_RUNTIME_DRIVERS=boxlite \
             LD_LIBRARY_PATH="$PWD/build/boxlite/lib:${LD_LIBRARY_PATH:-}" \
             GOCACHE={{.GO_BUILD_CACHE_DIR}} \
-            {{.GO_TOOLCHAIN_ENV}} go test -tags boxlitecgo ./pkg/driver -run '^TestSmokeBoxLite(RuntimeMountManifestDirectoryOnlyStarts|UsesGoContainerRegistryOCIImage)$' -count=1 -v
+            {{.GO_TOOLCHAIN_ENV}} go test -tags boxlitecgo ./pkg/driver -run '^TestSmokeBoxLite(RuntimeMountManifestDirectoryOnlyStarts|UsesGoContainerRegistryOCIImage|StopResumePreservesWritableLayer)$' -count=1 -v
         fi
         if [[ ",$drivers," == *",all,"* || ",$drivers," == *",microsandbox,"* ]]; then
           SMOKE_RUNTIME_DRIVERS=microsandbox \
             LD_LIBRARY_PATH="$PWD/build/microsandbox/lib:${LD_LIBRARY_PATH:-}" \
             GOCACHE={{.GO_BUILD_CACHE_DIR}} \
-            {{.GO_TOOLCHAIN_ENV}} go test ./pkg/driver -run '^TestSmokeMicrosandbox(RuntimeMountManifestDirectoryOnlyStarts|UsesGoContainerRegistryOCIImage)$' -count=1 -v
+            {{.GO_TOOLCHAIN_ENV}} go test ./pkg/driver -run '^TestSmokeMicrosandbox(RuntimeMountManifestDirectoryOnlyStarts|UsesGoContainerRegistryOCIImage|StopResumePreservesWritableLayer)$' -count=1 -v
         fi
 
   test:boxlite-mount-repro:

--- a/pkg/agentcompose/adapters/adapter_helpers_coverage_test.go
+++ b/pkg/agentcompose/adapters/adapter_helpers_coverage_test.go
@@ -135,6 +135,10 @@ func (r *fakeDriverAdapterRuntime) StopSandbox(context.Context, *driverpkg.Sandb
 	return false, nil
 }
 
+func (r *fakeDriverAdapterRuntime) RemoveSandbox(context.Context, *driverpkg.Sandbox, driverpkg.VMState) error {
+	return nil
+}
+
 func (r *fakeDriverAdapterRuntime) Exec(_ context.Context, _ *driverpkg.Sandbox, _ driverpkg.VMState, spec driverpkg.ExecSpec) (driverpkg.ExecResult, error) {
 	r.execSpec = spec
 	return r.execResult, nil
@@ -160,6 +164,10 @@ func (fakeDriverNoStatsRuntime) EnsureSandbox(context.Context, *driverpkg.Sandbo
 
 func (fakeDriverNoStatsRuntime) StopSandbox(context.Context, *driverpkg.Sandbox, driverpkg.VMState) (bool, error) {
 	return false, nil
+}
+
+func (fakeDriverNoStatsRuntime) RemoveSandbox(context.Context, *driverpkg.Sandbox, driverpkg.VMState) error {
+	return nil
 }
 
 func (fakeDriverNoStatsRuntime) Exec(context.Context, *driverpkg.Sandbox, driverpkg.VMState, driverpkg.ExecSpec) (driverpkg.ExecResult, error) {

--- a/pkg/agentcompose/adapters/agent_runner_test.go
+++ b/pkg/agentcompose/adapters/agent_runner_test.go
@@ -43,6 +43,10 @@ func (r *fakeAgentRuntime) StopSandbox(context.Context, *domain.Sandbox, domain.
 	return false, nil
 }
 
+func (r *fakeAgentRuntime) RemoveSandbox(context.Context, *domain.Sandbox, domain.VMState) error {
+	return nil
+}
+
 func (r *fakeAgentRuntime) Exec(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec) (domain.ExecResult, error) {
 	return domain.ExecResult{}, nil
 }

--- a/pkg/agentcompose/adapters/cell_executor_test.go
+++ b/pkg/agentcompose/adapters/cell_executor_test.go
@@ -26,6 +26,10 @@ func (r fakeCellRuntime) StopSandbox(context.Context, *domain.Sandbox, domain.VM
 	return false, nil
 }
 
+func (r fakeCellRuntime) RemoveSandbox(context.Context, *domain.Sandbox, domain.VMState) error {
+	return nil
+}
+
 func (r fakeCellRuntime) Exec(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec) (domain.ExecResult, error) {
 	return r.result, nil
 }

--- a/pkg/agentcompose/adapters/coverage_shape_workflows_test.go
+++ b/pkg/agentcompose/adapters/coverage_shape_workflows_test.go
@@ -9,6 +9,8 @@ func TestIntegrationAdapterRuntimeWorkflows(t *testing.T) {
 	t.Run("agent runner mcp", TestAgentRunnerPrepareManagedMCPConfigForProviders)
 	t.Run("cell executor", TestCellExecutorExecuteCellPersistsCellAndEvent)
 	t.Run("sandbox driver", TestSandboxDriverStartSandboxVMSavesRuntimeState)
+	t.Run("sandbox stop and remove lifecycle", TestSandboxDriverStopPreservesFacadeTokensUntilRemove)
+	t.Run("sandbox resume reuses runtime", TestSandboxDriverResumeReusesRuntimeWithoutRefreshingStartupEnv)
 	t.Run("sandbox rpc", TestSandboxRPCBridgeCallJSONSupportsSessionRPCs)
 	t.Run("capability guide lifecycle", TestSandboxRPCBridgeCapabilityGuideLifecycle)
 	t.Run("capability guide best effort", TestSandboxRPCBridgeCapabilityGuideIsBestEffort)

--- a/pkg/agentcompose/adapters/loader_command_executor_test.go
+++ b/pkg/agentcompose/adapters/loader_command_executor_test.go
@@ -26,6 +26,10 @@ func (r fakeLoaderCommandRuntime) StopSandbox(context.Context, *domain.Sandbox, 
 	return false, nil
 }
 
+func (r fakeLoaderCommandRuntime) RemoveSandbox(context.Context, *domain.Sandbox, domain.VMState) error {
+	return nil
+}
+
 func (r fakeLoaderCommandRuntime) Exec(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec) (domain.ExecResult, error) {
 	return domain.ExecResult{}, nil
 }

--- a/pkg/agentcompose/adapters/runtime_provider.go
+++ b/pkg/agentcompose/adapters/runtime_provider.go
@@ -13,6 +13,7 @@ import (
 type SandboxRuntime interface {
 	EnsureSandbox(context.Context, *domain.Sandbox, domain.VMState, domain.ProxyState) (domain.SandboxVMInfo, error)
 	StopSandbox(context.Context, *domain.Sandbox, domain.VMState) (bool, error)
+	RemoveSandbox(context.Context, *domain.Sandbox, domain.VMState) error
 	Exec(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec) (domain.ExecResult, error)
 	ExecStream(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec, domain.ExecStreamWriter) (domain.ExecResult, error)
 }
@@ -91,6 +92,10 @@ func (r driverRuntimeAdapter) EnsureSandbox(ctx context.Context, session *domain
 
 func (r driverRuntimeAdapter) StopSandbox(ctx context.Context, session *domain.Sandbox, vmState domain.VMState) (bool, error) {
 	return r.runtime.StopSandbox(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState))
+}
+
+func (r driverRuntimeAdapter) RemoveSandbox(ctx context.Context, session *domain.Sandbox, vmState domain.VMState) error {
+	return r.runtime.RemoveSandbox(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState))
 }
 
 func (r driverRuntimeAdapter) Exec(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, spec domain.ExecSpec) (domain.ExecResult, error) {

--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -54,7 +54,8 @@ func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sand
 	vmState.Mode = driver
 	vmState.BoxName = firstNonEmpty(vmState.BoxName, session.Summary.RuntimeRef)
 	vmState.RuntimeHome = firstNonEmpty(vmState.RuntimeHome, driverpkg.RuntimeHomeForDriver(d.Config, driver))
-	if err := d.prepareSandboxStart(ctx, driver, session, &vmState); err != nil {
+	resuming := !vmState.StoppedAt.IsZero()
+	if err := d.prepareSandboxStart(ctx, driver, session, &vmState, !resuming); err != nil {
 		vmState.LastError = err.Error()
 		_ = d.Store.SaveVMState(session.Summary.ID, vmState)
 		return err
@@ -63,7 +64,6 @@ func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sand
 	info, err := runtime.EnsureSandbox(ctx, session, vmState, proxyState)
 	if err != nil {
 		vmState.LastError = err.Error()
-		vmState.StoppedAt = time.Time{}
 		_ = d.Store.SaveVMState(session.Summary.ID, vmState)
 		return err
 	}
@@ -108,18 +108,48 @@ func (d *SandboxDriver) StopSandboxVM(ctx context.Context, session *domain.Sandb
 	if missing {
 		vmState.BoxID = ""
 	}
-	if d.ConfigDB != nil {
-		if err := d.ConfigDB.RevokeLLMFacadeTokensForSandbox(ctx, session.Summary.ID); err != nil {
-			return err
-		}
-	}
 	return d.Store.SaveVMState(session.Summary.ID, vmState)
 }
 
-func (d *SandboxDriver) prepareSandboxStart(ctx context.Context, driver string, session *domain.Sandbox, vmState *domain.VMState) error {
+func (d *SandboxDriver) RemoveSandboxVM(ctx context.Context, session *domain.Sandbox) error {
+	driver, err := driverpkg.ResolveSandboxRuntimeDriver(session.Summary.Driver, d.Config.RuntimeDriver)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, driverpkg.SandboxStopContextTimeout(driver, d.Config.SandboxStopTimeout))
+	defer cancel()
+
+	runtime, err := d.Runtimes.ForDriver(driver)
+	if err != nil {
+		return err
+	}
+	vmState, err := d.Store.GetVMState(session.Summary.ID)
+	if err != nil {
+		return err
+	}
+	if err := runtime.RemoveSandbox(ctx, session, vmState); err != nil {
+		vmState.LastError = err.Error()
+		_ = d.Store.SaveVMState(session.Summary.ID, vmState)
+		return err
+	}
+	if d.ConfigDB != nil {
+		if err := d.ConfigDB.RevokeLLMFacadeTokensForSandbox(ctx, session.Summary.ID); err != nil {
+			vmState.LastError = err.Error()
+			_ = d.Store.SaveVMState(session.Summary.ID, vmState)
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *SandboxDriver) prepareSandboxStart(ctx context.Context, driver string, session *domain.Sandbox, vmState *domain.VMState, refreshRuntimeEnv bool) error {
 	prepared, err := driverpkg.PrepareSandboxStart(ctx, d.Config, driver, execution.ToDriverSandbox(session), execution.ToDriverVMState(*vmState))
 	if err != nil {
 		return err
+	}
+	*vmState = execution.FromDriverVMState(prepared)
+	if !refreshRuntimeEnv {
+		return nil
 	}
 	managedEnv := map[string]string{}
 	for _, agent := range []string{"codex", "claude"} {
@@ -137,7 +167,6 @@ func (d *SandboxDriver) prepareSandboxStart(ctx context.Context, driver string, 
 	if len(managedEnv) > 0 {
 		session.RuntimeEnvItems = llms.EnvItemsFromMap(managedEnv, false)
 	}
-	*vmState = execution.FromDriverVMState(prepared)
 	return nil
 }
 

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -9,6 +9,7 @@ import (
 
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/llms"
 	"agent-compose/pkg/llms/runtimefacade"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/storage/configstore"
@@ -20,6 +21,8 @@ import (
 type fakeSessionRuntime struct {
 	info       domain.SandboxVMInfo
 	ensureHook func(*domain.Sandbox)
+	removeHook func(*domain.Sandbox)
+	removeErr  error
 }
 
 func (r fakeSessionRuntime) EnsureSandbox(_ context.Context, session *domain.Sandbox, _ domain.VMState, _ domain.ProxyState) (domain.SandboxVMInfo, error) {
@@ -31,6 +34,13 @@ func (r fakeSessionRuntime) EnsureSandbox(_ context.Context, session *domain.San
 
 func (r fakeSessionRuntime) StopSandbox(context.Context, *domain.Sandbox, domain.VMState) (bool, error) {
 	return false, nil
+}
+
+func (r fakeSessionRuntime) RemoveSandbox(_ context.Context, session *domain.Sandbox, _ domain.VMState) error {
+	if r.removeHook != nil {
+		r.removeHook(session)
+	}
+	return r.removeErr
 }
 
 func (r fakeSessionRuntime) Exec(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec) (domain.ExecResult, error) {
@@ -57,6 +67,10 @@ func (r *fakeStopDeadlineRuntime) StopSandbox(ctx context.Context, _ *domain.San
 	return false, nil
 }
 
+func (r *fakeStopDeadlineRuntime) RemoveSandbox(context.Context, *domain.Sandbox, domain.VMState) error {
+	return nil
+}
+
 func (r *fakeStopDeadlineRuntime) Exec(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec) (domain.ExecResult, error) {
 	return domain.ExecResult{}, nil
 }
@@ -75,6 +89,10 @@ func (r fakeDriverRuntime) EnsureSandbox(context.Context, *driverpkg.Sandbox, dr
 
 func (r fakeDriverRuntime) StopSandbox(context.Context, *driverpkg.Sandbox, driverpkg.VMState) (bool, error) {
 	return false, nil
+}
+
+func (r fakeDriverRuntime) RemoveSandbox(context.Context, *driverpkg.Sandbox, driverpkg.VMState) error {
+	return nil
 }
 
 func (r fakeDriverRuntime) Exec(context.Context, *driverpkg.Sandbox, driverpkg.VMState, driverpkg.ExecSpec) (driverpkg.ExecResult, error) {
@@ -191,6 +209,134 @@ func TestSandboxDriverStopSandboxVMAddsDockerStopContextMargin(t *testing.T) {
 	}
 	if vmState.StoppedAt.IsZero() || vmState.LastError != "" {
 		t.Fatalf("vm state after stop = %+v", vmState)
+	}
+}
+
+func TestSandboxDriverStopPreservesFacadeTokensUntilRemove(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:            root,
+		DbAddr:              filepath.Join(root, "data.db"),
+		SandboxRoot:         filepath.Join(root, "sandboxes"),
+		RuntimeDriver:       driverpkg.RuntimeDriverDocker,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		SandboxStartTimeout: 2 * time.Second,
+		SandboxStopTimeout:  2 * time.Second,
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	configDB, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "adapter session", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if err := store.SaveVMState(session.Summary.ID, domain.VMState{Driver: driverpkg.RuntimeDriverDocker, BoxID: "container-1"}); err != nil {
+		t.Fatalf("SaveVMState returned error: %v", err)
+	}
+	rawToken, token, err := llms.NewFacadeToken(session.Summary.ID, "model-1", "provider-1", llms.APIProtocolResponses, "test", "")
+	if err != nil {
+		t.Fatalf("NewFacadeToken returned error: %v", err)
+	}
+	if err := configDB.SaveLLMFacadeToken(ctx, token); err != nil {
+		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
+	}
+	removed := false
+	runtime := fakeSessionRuntime{removeHook: func(removedSession *domain.Sandbox) {
+		removed = removedSession != nil && removedSession.Summary.ID == session.Summary.ID
+	}}
+	driver := NewSandboxDriver(config, store, configDB, fakeRuntimeProvider{runtime: runtime})
+
+	if err := driver.StopSandboxVM(ctx, session); err != nil {
+		t.Fatalf("StopSandboxVM returned error: %v", err)
+	}
+	storedToken, err := configDB.GetLLMFacadeToken(ctx, rawToken)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken after stop returned error: %v", err)
+	}
+	if !storedToken.RevokedAt.IsZero() {
+		t.Fatalf("facade token revoked during resumable stop: %+v", storedToken)
+	}
+
+	if err := driver.RemoveSandboxVM(ctx, session); err != nil {
+		t.Fatalf("RemoveSandboxVM returned error: %v", err)
+	}
+	if !removed {
+		t.Fatal("runtime RemoveSandbox was not called")
+	}
+	storedToken, err = configDB.GetLLMFacadeToken(ctx, rawToken)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken after remove returned error: %v", err)
+	}
+	if storedToken.RevokedAt.IsZero() {
+		t.Fatalf("facade token remains active after remove: %+v", storedToken)
+	}
+}
+
+func TestSandboxDriverResumeReusesRuntimeWithoutRefreshingStartupEnv(t *testing.T) {
+	ctx := context.Background()
+	originalEnsure := ensureSandboxLLMFacadeConfig
+	defer func() { ensureSandboxLLMFacadeConfig = originalEnsure }()
+	ensureCalls := 0
+	ensureSandboxLLMFacadeConfig = func(context.Context, *appconfig.Config, runtimefacade.FacadeStore, *domain.Sandbox, string, string, string, string) (map[string]string, error) {
+		ensureCalls++
+		return map[string]string{"OPENAI_API_KEY": "new-token"}, nil
+	}
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:            root,
+		SandboxRoot:         filepath.Join(root, "sandboxes"),
+		RuntimeDriver:       driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		SandboxStartTimeout: 2 * time.Second,
+		SandboxStopTimeout:  2 * time.Second,
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "adapter session", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if err := store.SaveVMState(session.Summary.ID, domain.VMState{
+		Driver:    driverpkg.RuntimeDriverBoxlite,
+		BoxID:     "container-1",
+		StoppedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveVMState returned error: %v", err)
+	}
+	runtime := fakeSessionRuntime{
+		info: domain.SandboxVMInfo{BoxID: "container-1"},
+		ensureHook: func(resumed *domain.Sandbox) {
+			if len(resumed.RuntimeEnvItems) != 0 {
+				t.Fatalf("resume injected replacement startup env: %#v", resumed.RuntimeEnvItems)
+			}
+		},
+	}
+	driver := NewSandboxDriver(config, store, nil, fakeRuntimeProvider{runtime: runtime})
+
+	if err := driver.StartSandboxVM(ctx, session); err != nil {
+		t.Fatalf("StartSandboxVM returned error: %v", err)
+	}
+	if ensureCalls != 0 {
+		t.Fatalf("startup facade refresh calls during resume = %d, want 0", ensureCalls)
+	}
+	vmState, err := store.GetVMState(session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetVMState returned error: %v", err)
+	}
+	if vmState.BoxID != "container-1" || !vmState.StoppedAt.IsZero() {
+		t.Fatalf("vm state after resume = %+v", vmState)
 	}
 }
 

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -65,6 +65,10 @@ func TestPrepareStreamingHeadersPreservesNoTransform(t *testing.T) {
 func TestIntegrationAPIHandlerRuntimeWorkflows(t *testing.T) {
 	t.Run("streaming headers", TestPrepareStreamingHeadersPreservesNoTransform)
 	t.Run("sandbox remove race", TestRemoveSandboxRemoveRaceRemainsInternal)
+	t.Run("sandbox remove lifecycle", TestV2SandboxRemoveUsesSandboxIDAndSessionCompatibilityDelegate)
+	t.Run("sandbox remove running guard", TestV2SandboxRemoveRejectsRunningWithoutForce)
+	t.Run("sandbox remove preserves metadata on runtime failure", TestV2SandboxRemoveKeepsMetadataWhenRuntimeRemovalFails)
+	t.Run("sandbox remove validation and storage failures", TestV2SandboxRemoveValidationAndStoreErrors)
 	t.Run("sandbox stats runtime metrics", TestGetSandboxStatsReturnsRuntimeMetrics)
 	t.Run("sandbox stats stopped sandbox", TestGetSandboxStatsRejectsStoppedSandbox)
 	t.Run("sandbox stats unsupported runtime", TestGetSandboxStatsUnsupportedRuntimeIsUnimplemented)
@@ -91,7 +95,7 @@ func TestRemoveSandboxRemoveRaceRemainsInternal(t *testing.T) {
 		session:   &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}},
 		removeErr: os.ErrNotExist,
 	}
-	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, nil)
+	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
 	_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeInternal {
 		t.Fatalf("RemoveSandbox error code = %v, want %v; err=%v", connect.CodeOf(err), connect.CodeInternal, err)
@@ -115,7 +119,7 @@ func TestGetSandboxStatsReturnsRuntimeMetrics(t *testing.T) {
 		CPUPercent:       domain.MetricValue{Value: &value, Unit: "percent", Status: domain.MetricStatusOK},
 		MemoryUsageBytes: domain.MetricValue{Unit: "bytes", Status: domain.MetricStatusUnknown},
 	}}
-	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, nil, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
+	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, nil, nil, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
 		return runtime, nil
 	})
 	resp, err := handler.GetSandboxStats(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
@@ -138,7 +142,7 @@ func TestGetSandboxStatsRejectsStoppedSandbox(t *testing.T) {
 	store := &apiSandboxStore{
 		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}},
 	}
-	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, nil, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
+	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, nil, nil, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
 		return &apiStatsRuntime{}, nil
 	})
 	_, err := handler.GetSandboxStats(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
@@ -152,7 +156,7 @@ func TestGetSandboxStatsUnsupportedRuntimeIsUnimplemented(t *testing.T) {
 	store := &apiSandboxStore{
 		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusRunning}},
 	}
-	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, nil)
+	handler := NewSandboxHandler(&fakeSessionDelegate{}, store, nil, nil)
 	_, err := handler.GetSandboxStats(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeUnimplemented {
 		t.Fatalf("GetSandboxStats unsupported code = %v, err=%v", connect.CodeOf(err), err)

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -32,6 +32,10 @@ type SandboxStatsRuntime interface {
 
 type SandboxStatsRuntimeResolver func(*domain.Sandbox) (SandboxStatsRuntime, error)
 
+type SandboxRuntimeRemover interface {
+	RemoveSandboxVM(context.Context, *domain.Sandbox) error
+}
+
 type SandboxDashboardNotifier interface {
 	Notify(string)
 }
@@ -39,13 +43,14 @@ type SandboxDashboardNotifier interface {
 type SandboxHandler struct {
 	delegate   SessionDelegate
 	store      SandboxStore
+	remover    SandboxRuntimeRemover
 	reconciler SessionRuntimeReconciler
 	dashboard  SandboxDashboardNotifier
 	stats      SandboxStatsRuntimeResolver
 }
 
-func NewSandboxHandler(delegate SessionDelegate, store SandboxStore, dashboard SandboxDashboardNotifier, stats ...SandboxStatsRuntimeResolver) *SandboxHandler {
-	handler := &SandboxHandler{delegate: delegate, store: store, dashboard: dashboard}
+func NewSandboxHandler(delegate SessionDelegate, store SandboxStore, remover SandboxRuntimeRemover, dashboard SandboxDashboardNotifier, stats ...SandboxStatsRuntimeResolver) *SandboxHandler {
+	handler := &SandboxHandler{delegate: delegate, store: store, remover: remover, dashboard: dashboard}
 	if reconciler, ok := delegate.(SessionRuntimeReconciler); ok {
 		handler.reconciler = reconciler
 	}
@@ -81,6 +86,12 @@ func (h *SandboxHandler) RemoveSandbox(ctx context.Context, req *connect.Request
 			return nil, err
 		}
 		stopped = true
+	}
+	if h.remover == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("sandbox runtime remover is required"))
+	}
+	if err := h.remover.RemoveSandboxVM(ctx, session); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if err := h.store.RemoveSandbox(ctx, sandboxID); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)

--- a/pkg/agentcompose/api/sandbox_characterization_test.go
+++ b/pkg/agentcompose/api/sandbox_characterization_test.go
@@ -19,8 +19,9 @@ func TestV2SandboxRemoveUsesSandboxIDAndSessionCompatibilityDelegate(t *testing.
 	store := &characterizationSandboxStore{
 		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusRunning}},
 	}
+	remover := &characterizationSandboxRemover{}
 	dashboard := &characterizationDashboard{}
-	handler := NewSandboxHandler(delegate, store, dashboard)
+	handler := NewSandboxHandler(delegate, store, remover, dashboard)
 
 	resp, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{
 		SandboxId: " " + sandboxID + " ",
@@ -38,6 +39,9 @@ func TestV2SandboxRemoveUsesSandboxIDAndSessionCompatibilityDelegate(t *testing.
 	if len(delegate.stopSessionIDs) != 1 || delegate.stopSessionIDs[0] != sandboxID {
 		t.Fatalf("compatibility StopSession calls = %#v, want [%q]", delegate.stopSessionIDs, sandboxID)
 	}
+	if len(remover.sandboxIDs) != 1 || remover.sandboxIDs[0] != sandboxID {
+		t.Fatalf("runtime remove calls = %#v, want [%q]", remover.sandboxIDs, sandboxID)
+	}
 	if len(dashboard.events) != 1 || dashboard.events[0] != "sandbox_removed" {
 		t.Fatalf("dashboard events = %#v", dashboard.events)
 	}
@@ -48,7 +52,7 @@ func TestV2SandboxRemoveRejectsRunningWithoutForce(t *testing.T) {
 	store := &characterizationSandboxStore{
 		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusRunning}},
 	}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, nil)
+	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
 
 	_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
@@ -59,8 +63,29 @@ func TestV2SandboxRemoveRejectsRunningWithoutForce(t *testing.T) {
 	}
 }
 
+func TestV2SandboxRemoveKeepsMetadataWhenRuntimeRemovalFails(t *testing.T) {
+	sandboxID := identity.NewID(identity.ResourceSandbox, "characterization", "runtime-remove-error")
+	store := &characterizationSandboxStore{
+		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}},
+	}
+	removeErr := errors.New("runtime remove failed")
+	remover := &characterizationSandboxRemover{err: removeErr}
+	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, remover, nil)
+
+	_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
+	if connect.CodeOf(err) != connect.CodeInternal || !errors.Is(err, removeErr) {
+		t.Fatalf("RemoveSandbox runtime error = %v, code=%v", err, connect.CodeOf(err))
+	}
+	if len(remover.sandboxIDs) != 1 || remover.sandboxIDs[0] != sandboxID {
+		t.Fatalf("runtime remove calls = %#v, want [%q]", remover.sandboxIDs, sandboxID)
+	}
+	if store.removeID != "" {
+		t.Fatalf("metadata removed after runtime removal failed: %q", store.removeID)
+	}
+}
+
 func TestV2SandboxRemoveValidationAndStoreErrors(t *testing.T) {
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{}, nil)
+	handler := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{}, &characterizationSandboxRemover{}, nil)
 	for _, sandboxID := range []string{"", "not an id", "../bad"} {
 		_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 		if connect.CodeOf(err) != connect.CodeInvalidArgument {
@@ -69,7 +94,7 @@ func TestV2SandboxRemoveValidationAndStoreErrors(t *testing.T) {
 	}
 
 	missingID := identity.NewID(identity.ResourceSandbox, "characterization", "missing")
-	missing := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{getErr: errors.New("missing")}, nil)
+	missing := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{getErr: errors.New("missing")}, &characterizationSandboxRemover{}, nil)
 	if _, err := missing.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: missingID})); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("RemoveSandbox missing code = %v, want not found (err=%v)", connect.CodeOf(err), err)
 	}
@@ -79,7 +104,7 @@ func TestV2SandboxRemoveValidationAndStoreErrors(t *testing.T) {
 	failing := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{
 		session:   &domain.Sandbox{Summary: domain.SandboxSummary{ID: removeID, VMStatus: domain.VMStatusStopped}},
 		removeErr: removeErr,
-	}, nil)
+	}, &characterizationSandboxRemover{}, nil)
 	if _, err := failing.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: removeID})); connect.CodeOf(err) != connect.CodeInternal {
 		t.Fatalf("RemoveSandbox remove error code = %v, want internal (err=%v)", connect.CodeOf(err), err)
 	}
@@ -129,6 +154,16 @@ func (s *characterizationSandboxStore) RemoveSandbox(_ context.Context, id strin
 
 type characterizationDashboard struct {
 	events []string
+}
+
+type characterizationSandboxRemover struct {
+	sandboxIDs []string
+	err        error
+}
+
+func (r *characterizationSandboxRemover) RemoveSandboxVM(_ context.Context, sandbox *domain.Sandbox) error {
+	r.sandboxIDs = append(r.sandboxIDs, sandbox.Summary.ID)
+	return r.err
 }
 
 func (d *characterizationDashboard) Notify(event string) {

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -168,6 +168,7 @@ func RegisterRoutes(di do.Injector) {
 	sandboxHandler := api.NewSandboxHandler(
 		do.MustInvoke[*adapters.SandboxRPCBridge](di),
 		do.MustInvoke[*sessionstore.Store](di),
+		do.MustInvoke[*adapters.SandboxDriver](di),
 		do.MustInvoke[*dashboard.Hub](di),
 		func(session *domain.Sandbox) (api.SandboxStatsRuntime, error) {
 			runtime, err := do.MustInvoke[adapters.RuntimeProvider](di).ForSession(session)

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -450,15 +450,16 @@ func (r *cgoSandboxRuntime) StopSandbox(ctx context.Context, sandbox *Sandbox, v
 		return false, err
 	}
 	defer box.free()
-	if err := r.stopBox(ctx, box); err != nil && !isStoppedBox(err) && !isBoxNotFound(err) {
+	missing, err := classifyBoxliteStopError(r.stopBox(ctx, box))
+	if err != nil {
 		return false, err
 	}
 	if sandbox != nil {
 		if err := CleanupBoxliteVolumeBridgeMounts(hostSandboxDir(sandbox)); err != nil {
-			return false, err
+			return missing, err
 		}
 	}
-	return false, nil
+	return missing, nil
 }
 
 func (r *cgoSandboxRuntime) RemoveSandbox(ctx context.Context, sandbox *Sandbox, vmState VMState) error {
@@ -1332,16 +1333,32 @@ type boxliteCallError struct {
 	message string
 }
 
+const (
+	boxliteStatusNotFound = int(C.NotFound)
+	boxliteStatusStopped  = int(C.Stopped)
+)
+
 func (e *boxliteCallError) Error() string {
 	return e.message
 }
 
 func isBoxNotFound(err error) bool {
 	var callErr *boxliteCallError
-	return errors.As(err, &callErr) && callErr.code == int(C.NotFound)
+	return errors.As(err, &callErr) && callErr.code == boxliteStatusNotFound
 }
 
 func isStoppedBox(err error) bool {
 	var callErr *boxliteCallError
-	return errors.As(err, &callErr) && callErr.code == int(C.Stopped)
+	return errors.As(err, &callErr) && callErr.code == boxliteStatusStopped
+}
+
+func classifyBoxliteStopError(err error) (bool, error) {
+	switch {
+	case err == nil, isStoppedBox(err):
+		return false, nil
+	case isBoxNotFound(err):
+		return true, nil
+	default:
+		return false, err
+	}
 }

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -453,15 +453,30 @@ func (r *cgoSandboxRuntime) StopSandbox(ctx context.Context, sandbox *Sandbox, v
 	if err := r.stopBox(ctx, box); err != nil && !isStoppedBox(err) && !isBoxNotFound(err) {
 		return false, err
 	}
-	if err := r.removeBox(ctx, vmState.BoxID, true); err != nil && !isBoxNotFound(err) {
-		return false, err
-	}
 	if sandbox != nil {
 		if err := CleanupBoxliteVolumeBridgeMounts(hostSandboxDir(sandbox)); err != nil {
 			return false, err
 		}
 	}
-	return true, nil
+	return false, nil
+}
+
+func (r *cgoSandboxRuntime) RemoveSandbox(ctx context.Context, sandbox *Sandbox, vmState VMState) error {
+	lookup := firstNonEmpty(strings.TrimSpace(vmState.BoxID), strings.TrimSpace(vmState.BoxName))
+	if sandbox != nil {
+		lookup = firstNonEmpty(lookup, strings.TrimSpace(sandbox.Summary.RuntimeRef))
+	}
+	if lookup != "" {
+		if err := r.removeBox(ctx, lookup, true); err != nil && !isBoxNotFound(err) {
+			return err
+		}
+	}
+	if sandbox != nil {
+		if err := CleanupBoxliteVolumeBridgeMounts(hostSandboxDir(sandbox)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *cgoSandboxRuntime) Exec(ctx context.Context, sandbox *Sandbox, vmState VMState, spec ExecSpec) (ExecResult, error) {
@@ -707,6 +722,9 @@ func (r *cgoSandboxRuntime) getOrCreateBox(ctx context.Context, sandbox *Sandbox
 				status := normalizeBoxliteStatus(info.State.Status)
 				if shouldRecreateBoxForStatus(status) {
 					box.free()
+					if !vmState.StoppedAt.IsZero() {
+						return nil, false, fmt.Errorf("boxlite runtime state for stopped sandbox %s is not resumable from status %s", sandbox.Summary.ID, status)
+					}
 					if err := r.removeBox(ctx, existingID, true); err != nil && !isBoxNotFound(err) {
 						return nil, false, err
 					}
@@ -726,6 +744,9 @@ func (r *cgoSandboxRuntime) getOrCreateBox(ctx context.Context, sandbox *Sandbox
 		if !isBoxNotFound(err) {
 			return nil, false, err
 		}
+	}
+	if !vmState.StoppedAt.IsZero() {
+		return nil, false, fmt.Errorf("boxlite runtime state for stopped sandbox %s is missing; refusing to recreate it during resume", sandbox.Summary.ID)
 	}
 
 	box, err := r.createBox(ctx, sandbox, vmState, proxyState)
@@ -747,7 +768,7 @@ func normalizeBoxliteStatus(status string) string {
 
 func shouldRecreateBoxForStatus(status string) bool {
 	switch status {
-	case "stopped", "failed", "dead", "removed", "exited":
+	case "failed", "dead", "removed", "exited":
 		return true
 	default:
 		return false

--- a/pkg/driver/boxlite_stub.go
+++ b/pkg/driver/boxlite_stub.go
@@ -22,6 +22,10 @@ func (s *stubSandboxRuntime) StopSandbox(context.Context, *Sandbox, VMState) (bo
 	return false, fmt.Errorf("agent-compose was built without BoxLite cgo support; rebuild with -tags boxlitecgo after preparing libboxlite")
 }
 
+func (s *stubSandboxRuntime) RemoveSandbox(context.Context, *Sandbox, VMState) error {
+	return fmt.Errorf("agent-compose was built without BoxLite cgo support; rebuild with -tags boxlitecgo after preparing libboxlite")
+}
+
 func (s *stubSandboxRuntime) Exec(context.Context, *Sandbox, VMState, ExecSpec) (ExecResult, error) {
 	return ExecResult{}, fmt.Errorf("agent-compose was built without BoxLite cgo support; rebuild with -tags boxlitecgo after preparing libboxlite")
 }

--- a/pkg/driver/docker_interaction_smoke_test.go
+++ b/pkg/driver/docker_interaction_smoke_test.go
@@ -10,6 +10,17 @@ import (
 	"time"
 )
 
+func TestDockerStopResumePreservesWritableLayerSmoke(t *testing.T) {
+	runtimeSmokeEnabled(t, RuntimeDriverDocker)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	config := newRuntimeSmokeConfig(t, RuntimeDriverDocker)
+	runtime := &dockerRuntime{config: config}
+	session, vmState, proxyState := newRuntimeSmokeSandbox(t, ctx, config, RuntimeDriverDocker)
+	assertRuntimeStopResumePreservesWritableLayer(t, ctx, config, runtime, session, vmState, proxyState)
+}
+
 func TestDockerCommandInteractionSmokeCatStdinEOF(t *testing.T) {
 	runtimeSmokeEnabled(t, RuntimeDriverDocker)
 

--- a/pkg/driver/docker_interaction_smoke_test.go
+++ b/pkg/driver/docker_interaction_smoke_test.go
@@ -36,11 +36,7 @@ func TestDockerCommandInteractionSmokeCatStdinEOF(t *testing.T) {
 		t.Fatalf("EnsureSandbox() error = %v", err)
 	}
 	vmState.BoxID = info.BoxID
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), SandboxStopContextTimeout(RuntimeDriverDocker, config.SandboxStopTimeout))
-		defer stopCancel()
-		_, _ = runtime.StopSandbox(stopCtx, session, vmState)
-	})
+	cleanupRuntimeSmokeSandbox(t, config, runtime, session, vmState)
 
 	interaction, err := runtime.OpenInteraction(ctx, session, vmState, RuntimeStartSpec{
 		OperationID: "smoke-cat",

--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -181,7 +181,10 @@ func (r *dockerRuntime) StopSandbox(ctx context.Context, sandbox *Sandbox, vmSta
 		if timeoutSeconds < 0 {
 			timeoutSeconds = 0
 		}
-		if err := dockerClient.ContainerStop(ctx, containerInfo.ID, containerapi.StopOptions{Timeout: &timeoutSeconds}); err != nil && !isDockerNotFound(err) {
+		if err := dockerClient.ContainerStop(ctx, containerInfo.ID, containerapi.StopOptions{Timeout: &timeoutSeconds}); err != nil {
+			if isDockerNotFound(err) {
+				return true, nil
+			}
 			if stopped, inspectErr := r.containerStoppedAfterStopError(containerInfo.ID); inspectErr != nil {
 				return false, fmt.Errorf("stop docker container %s: %w; inspect after stop failure: %v", containerInfo.ID, err, inspectErr)
 			} else if !stopped {
@@ -189,12 +192,29 @@ func (r *dockerRuntime) StopSandbox(ctx context.Context, sandbox *Sandbox, vmSta
 			}
 		}
 	}
+	return false, nil
+}
+
+func (r *dockerRuntime) RemoveSandbox(ctx context.Context, sandbox *Sandbox, vmState VMState) error {
+	dockerClient, err := r.newClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dockerClient.Close() }()
+
+	containerInfo, ok, err := r.findContainer(ctx, dockerClient, sandbox, vmState)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
 	removeCtx, cancel := dockerFallbackContextIfDone(ctx)
 	defer cancel()
 	if err := dockerClient.ContainerRemove(removeCtx, containerInfo.ID, containerapi.RemoveOptions{Force: true}); err != nil && !isDockerNotFound(err) {
-		return false, fmt.Errorf("remove docker container %s: %w", containerInfo.ID, err)
+		return fmt.Errorf("remove docker container %s: %w", containerInfo.ID, err)
 	}
-	return false, nil
+	return nil
 }
 
 func (r *dockerRuntime) Exec(ctx context.Context, sandbox *Sandbox, vmState VMState, spec ExecSpec) (ExecResult, error) {
@@ -609,6 +629,9 @@ func (r *dockerRuntime) getOrCreateContainer(ctx context.Context, dockerClient *
 		return containerapi.InspectResponse{}, false, err
 	} else if ok {
 		return containerInfo, false, nil
+	}
+	if !vmState.StoppedAt.IsZero() {
+		return containerapi.InspectResponse{}, false, fmt.Errorf("docker runtime state for stopped sandbox %s is missing; refusing to recreate it during resume", sandbox.Summary.ID)
 	}
 
 	name := r.containerName(sandbox, vmState)

--- a/pkg/driver/interaction_test.go
+++ b/pkg/driver/interaction_test.go
@@ -159,6 +159,10 @@ func (fakeInteractionRuntime) StopSandbox(context.Context, *Sandbox, VMState) (b
 	return true, nil
 }
 
+func (fakeInteractionRuntime) RemoveSandbox(context.Context, *Sandbox, VMState) error {
+	return nil
+}
+
 func (fakeInteractionRuntime) Exec(context.Context, *Sandbox, VMState, ExecSpec) (ExecResult, error) {
 	return ExecResult{}, nil
 }

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -134,13 +134,7 @@ func (r *microsandboxRuntime) StopSandbox(ctx context.Context, session *Sandbox,
 		return false, err
 	}
 	if handle.Status() != microsandbox.SandboxStatusRunning && handle.Status() != microsandbox.SandboxStatusDraining {
-		// Already stopped, but the sandbox metadata still persists in the
-		// daemon. Destroy it (and its docker disk) so a restart rebuilds
-		// from scratch instead of remounting the deleted disk. See
-		// removeSandboxState.
 		r.discardLifecycleHandle(name)
-		r.removeDockerDisk(session.Summary.ID)
-		r.removeSandboxState(ctx, name)
 		return false, nil
 	}
 
@@ -152,15 +146,12 @@ func (r *microsandboxRuntime) StopSandbox(ctx context.Context, session *Sandbox,
 		}()
 		if err := sandbox.Stop(ctx); err != nil {
 			if microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound) {
-				r.removeDockerDisk(session.Summary.ID)
 				return true, nil
 			}
 			r.trackLifecycleHandle(name, sandbox)
 			sandbox = nil
 			return false, err
 		}
-		r.removeDockerDisk(session.Summary.ID)
-		r.removeSandboxState(ctx, name)
 		return false, nil
 	}
 
@@ -170,21 +161,32 @@ func (r *microsandboxRuntime) StopSandbox(ctx context.Context, session *Sandbox,
 	}
 	if stale || sandbox == nil {
 		r.discardLifecycleHandle(name)
-		r.removeDockerDisk(session.Summary.ID)
-		r.removeSandboxState(ctx, name)
 		return true, nil
 	}
 	defer r.releaseSandboxHandle(name, sandbox)
 	if err := sandbox.Stop(ctx); err != nil {
 		if microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound) {
-			r.removeDockerDisk(session.Summary.ID)
 			return true, nil
 		}
 		return false, err
 	}
-	r.removeDockerDisk(session.Summary.ID)
-	r.removeSandboxState(ctx, name)
 	return false, nil
+}
+
+func (r *microsandboxRuntime) RemoveSandbox(ctx context.Context, session *Sandbox, vmState VMState) error {
+	if _, err := r.StopSandbox(ctx, session, vmState); err != nil {
+		return err
+	}
+	name := r.sandboxName(session, vmState)
+	r.discardLifecycleHandle(name)
+	if err := microsandbox.RemoveSandbox(ctx, name); err != nil &&
+		!microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound) {
+		return fmt.Errorf("remove microsandbox %s: %w", name, err)
+	}
+	if err := r.removeDockerDiskFiles(session.Summary.ID); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *microsandboxRuntime) Exec(ctx context.Context, session *Sandbox, vmState VMState, spec ExecSpec) (ExecResult, error) {
@@ -666,32 +668,22 @@ func (r *microsandboxRuntime) ensureDockerDisk(sandboxID string) (string, error)
 }
 
 func (r *microsandboxRuntime) removeDockerDisk(sandboxID string) {
+	if err := r.removeDockerDiskFiles(sandboxID); err != nil {
+		slog.Warn("agent-compose microsandbox: failed to remove docker disk image", "sandbox_id", sandboxID, "error", err)
+	}
+}
+
+func (r *microsandboxRuntime) removeDockerDiskFiles(sandboxID string) error {
 	paths := []string{r.dockerDiskPath(sandboxID)}
 	if legacyPath := r.legacyDockerDiskPath(sandboxID); legacyPath != paths[0] {
 		paths = append(paths, legacyPath)
 	}
 	for _, path := range paths {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			slog.Warn("agent-compose microsandbox: failed to remove docker disk image", "path", path, "error", err)
+			return fmt.Errorf("remove microsandbox docker disk image %s: %w", path, err)
 		}
 	}
-}
-
-// removeSandboxState purges a stopped sandbox's persisted metadata from the
-// microsandbox daemon so a later GetSandbox(name) returns ErrSandboxNotFound.
-// This matches the docker driver, which fully removes the container on stop:
-// without it, a restart would take the getOrCreateSandbox handle.Start() path
-// and remount the per-sandbox docker disk that StopSandbox already deleted,
-// failing with "host path not found". Best-effort — a purge failure must not
-// mask the stop result; the daemon's gc reclaims any residue on restart.
-func (r *microsandboxRuntime) removeSandboxState(ctx context.Context, name string) {
-	if strings.TrimSpace(name) == "" {
-		return
-	}
-	if err := microsandbox.RemoveSandbox(ctx, name); err != nil &&
-		!microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound) {
-		slog.Warn("agent-compose microsandbox: failed to remove sandbox state", "name", name, "error", err)
-	}
+	return nil
 }
 
 func (r *microsandboxRuntime) sandboxAgentSockPath(name string) string {
@@ -783,6 +775,9 @@ func (r *microsandboxRuntime) getOrCreateSandbox(ctx context.Context, session *S
 	if err != nil {
 		if !microsandbox.IsKind(err, microsandbox.ErrSandboxNotFound) {
 			return nil, false, false, err
+		}
+		if !vmState.StoppedAt.IsZero() {
+			return nil, false, false, fmt.Errorf("microsandbox runtime state for stopped sandbox %s is missing; refusing to recreate it during resume", session.Summary.ID)
 		}
 		sandbox, err := r.createSandbox(ctx, session, vmState, proxyState, name)
 		if err == nil {

--- a/pkg/driver/microsandbox_runtime_stub.go
+++ b/pkg/driver/microsandbox_runtime_stub.go
@@ -22,6 +22,10 @@ func (r *microsandboxRuntime) StopSandbox(context.Context, *Sandbox, VMState) (b
 	return false, fmt.Errorf("agent-compose was built without cgo support; microsandbox runtime is unavailable")
 }
 
+func (r *microsandboxRuntime) RemoveSandbox(context.Context, *Sandbox, VMState) error {
+	return fmt.Errorf("agent-compose was built without cgo support; microsandbox runtime is unavailable")
+}
+
 func (r *microsandboxRuntime) Exec(context.Context, *Sandbox, VMState, ExecSpec) (ExecResult, error) {
 	return ExecResult{}, fmt.Errorf("agent-compose was built without cgo support; microsandbox runtime is unavailable")
 }

--- a/pkg/driver/runtime_mount_manifest_boxlite_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_boxlite_smoke_test.go
@@ -8,6 +8,27 @@ import (
 	"time"
 )
 
+func TestBoxLiteStoppedStatusIsResumable(t *testing.T) {
+	if shouldRecreateBoxForStatus("stopped") {
+		t.Fatal("stopped box should be restarted instead of recreated")
+	}
+	for _, status := range []string{"failed", "dead", "removed", "exited"} {
+		if !shouldRecreateBoxForStatus(status) {
+			t.Fatalf("box status %q should be recreated", status)
+		}
+	}
+}
+
+func TestSmokeBoxLiteStopResumePreservesWritableLayer(t *testing.T) {
+	runtimeSmokeEnabled(t, RuntimeDriverBoxlite)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	config := newRuntimeSmokeConfig(t, RuntimeDriverBoxlite)
+	session, vmState, proxyState := newRuntimeSmokeSandbox(t, ctx, config, RuntimeDriverBoxlite)
+	runtime := &cgoSandboxRuntime{config: config}
+	assertRuntimeStopResumePreservesWritableLayer(t, ctx, config, runtime, session, vmState, proxyState)
+}
+
 func TestSmokeBoxLiteRuntimeMountManifestDirectoryOnlyStarts(t *testing.T) {
 	runtimeSmokeEnabled(t, RuntimeDriverBoxlite)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/pkg/driver/runtime_mount_manifest_boxlite_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_boxlite_smoke_test.go
@@ -4,9 +4,33 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
+
+func TestClassifyBoxliteStopError(t *testing.T) {
+	otherErr := errors.New("stop failed")
+	tests := []struct {
+		name        string
+		err         error
+		wantMissing bool
+		wantErr     error
+	}{
+		{name: "success"},
+		{name: "already stopped", err: &boxliteCallError{code: boxliteStatusStopped}},
+		{name: "not found", err: &boxliteCallError{code: boxliteStatusNotFound}, wantMissing: true},
+		{name: "other error", err: otherErr, wantErr: otherErr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			missing, err := classifyBoxliteStopError(tt.err)
+			if missing != tt.wantMissing || !errors.Is(err, tt.wantErr) {
+				t.Fatalf("classifyBoxliteStopError() = (%v, %v), want (%v, %v)", missing, err, tt.wantMissing, tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestBoxLiteStoppedStatusIsResumable(t *testing.T) {
 	if shouldRecreateBoxForStatus("stopped") {

--- a/pkg/driver/runtime_mount_manifest_boxlite_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_boxlite_smoke_test.go
@@ -44,14 +44,7 @@ func TestSmokeBoxLiteRuntimeMountManifestDirectoryOnlyStarts(t *testing.T) {
 		t.Fatalf("EnsureSandbox returned error: %v", err)
 	}
 	vmState.BoxID = info.BoxID
-	t.Cleanup(func() {
-		if t.Failed() && runtimeSmokeKeepTmp() {
-			return
-		}
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), config.SandboxStopTimeout)
-		defer stopCancel()
-		_, _ = runtime.StopSandbox(stopCtx, session, vmState)
-	})
+	cleanupRuntimeSmokeSandbox(t, config, runtime, session, vmState)
 	assertBoxLiteRuntimeSmokeGuestPaths(t, ctx, runtime, vmState)
 	assertRuntimeSmokeHomeFiles(t, ctx, runtime, session, vmState)
 }
@@ -73,14 +66,7 @@ func TestSmokeBoxLiteUsesGoContainerRegistryOCIImage(t *testing.T) {
 		t.Fatalf("EnsureSandbox returned error: %v", err)
 	}
 	vmState.BoxID = info.BoxID
-	t.Cleanup(func() {
-		if t.Failed() && runtimeSmokeKeepTmp() {
-			return
-		}
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), config.SandboxStopTimeout)
-		defer stopCancel()
-		_, _ = runtime.StopSandbox(stopCtx, session, vmState)
-	})
+	cleanupRuntimeSmokeSandbox(t, config, runtime, session, vmState)
 	assertBoxLiteRuntimeSmokeGuestPaths(t, ctx, runtime, vmState)
 	assertRuntimeSmokeHomeFiles(t, ctx, runtime, session, vmState)
 }

--- a/pkg/driver/runtime_mount_manifest_microsandbox_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_microsandbox_smoke_test.go
@@ -10,6 +10,16 @@ import (
 	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
 )
 
+func TestSmokeMicrosandboxStopResumePreservesWritableLayer(t *testing.T) {
+	runtimeSmokeEnabled(t, RuntimeDriverMicrosandbox)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	config := newRuntimeSmokeConfig(t, RuntimeDriverMicrosandbox)
+	session, vmState, proxyState := newRuntimeSmokeSandbox(t, ctx, config, RuntimeDriverMicrosandbox)
+	runtime := &microsandboxRuntime{config: config, lifecycleHandles: map[string]*microsandbox.Sandbox{}}
+	assertRuntimeStopResumePreservesWritableLayer(t, ctx, config, runtime, session, vmState, proxyState)
+}
+
 func TestSmokeMicrosandboxRuntimeMountManifestDirectoryOnlyStarts(t *testing.T) {
 	runtimeSmokeEnabled(t, RuntimeDriverMicrosandbox)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/pkg/driver/runtime_mount_manifest_microsandbox_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_microsandbox_smoke_test.go
@@ -35,14 +35,7 @@ func TestSmokeMicrosandboxRuntimeMountManifestDirectoryOnlyStarts(t *testing.T) 
 		t.Fatalf("EnsureSandbox returned error: %v", err)
 	}
 	vmState.BoxID = info.BoxID
-	t.Cleanup(func() {
-		if t.Failed() && runtimeSmokeKeepTmp() {
-			return
-		}
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), config.SandboxStopTimeout)
-		defer stopCancel()
-		_, _ = runtime.StopSandbox(stopCtx, session, vmState)
-	})
+	cleanupRuntimeSmokeSandbox(t, config, runtime, session, vmState)
 	assertMicrosandboxRuntimeSmokeGuestPaths(t, ctx, runtime, session, vmState)
 	assertRuntimeSmokeHomeFiles(t, ctx, runtime, session, vmState)
 }
@@ -63,14 +56,7 @@ func TestSmokeMicrosandboxUsesGoContainerRegistryOCIImage(t *testing.T) {
 		t.Fatalf("EnsureSandbox returned error: %v", err)
 	}
 	vmState.BoxID = info.BoxID
-	t.Cleanup(func() {
-		if t.Failed() && runtimeSmokeKeepTmp() {
-			return
-		}
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), config.SandboxStopTimeout)
-		defer stopCancel()
-		_, _ = runtime.StopSandbox(stopCtx, session, vmState)
-	})
+	cleanupRuntimeSmokeSandbox(t, config, runtime, session, vmState)
 	assertMicrosandboxRuntimeSmokeGuestPaths(t, ctx, runtime, session, vmState)
 	assertRuntimeSmokeHomeFiles(t, ctx, runtime, session, vmState)
 }

--- a/pkg/driver/runtime_mount_manifest_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_smoke_test.go
@@ -203,6 +203,69 @@ func assertRuntimeSmokeHomeFiles(t *testing.T, ctx context.Context, runtime Sand
 	}
 }
 
+func assertRuntimeStopResumePreservesWritableLayer(t *testing.T, ctx context.Context, config *appconfig.Config, runtime SandboxRuntime, session *Sandbox, vmState VMState, proxyState ProxyState) {
+	t.Helper()
+	proxyState.Enabled = false
+	info, err := runtime.EnsureSandbox(ctx, session, vmState, proxyState)
+	if err != nil {
+		t.Fatalf("EnsureSandbox() error = %v", err)
+	}
+	vmState.BoxID = info.BoxID
+	originalBoxID := info.BoxID
+	statePath := "/tmp/regression-sandbox-state.txt"
+	if session.Summary.Driver != RuntimeDriverDocker {
+		// BoxLite mounts /tmp as tmpfs, so use a path on the guest root disk
+		// when checking writable-layer persistence across a VM power cycle.
+		statePath = "/var/tmp/regression-sandbox-state.txt"
+	}
+	t.Cleanup(func() {
+		removeCtx, removeCancel := context.WithTimeout(context.Background(), SandboxStopContextTimeout(session.Summary.Driver, config.SandboxStopTimeout))
+		defer removeCancel()
+		_ = runtime.RemoveSandbox(removeCtx, session, vmState)
+	})
+
+	writeResult, err := runtime.Exec(ctx, session, vmState, ExecSpec{
+		Command: "sh",
+		Args:    []string{"-lc", "printf %s sandbox-exec-before-stop-ok > " + statePath},
+		Cwd:     "/",
+	})
+	if err != nil || !writeResult.Success {
+		t.Fatalf("write state result = %#v, err=%v", writeResult, err)
+	}
+
+	for round := 1; round <= 2; round++ {
+		missing, err := runtime.StopSandbox(ctx, session, vmState)
+		if err != nil || missing {
+			t.Fatalf("round %d StopSandbox() missing=%v error=%v", round, missing, err)
+		}
+		vmState.StoppedAt = time.Now().UTC()
+		info, err := runtime.EnsureSandbox(ctx, session, vmState, proxyState)
+		if err != nil {
+			t.Fatalf("round %d EnsureSandbox() error = %v", round, err)
+		}
+		if info.BoxID != originalBoxID {
+			t.Fatalf("round %d resumed runtime = %q, want original %q", round, info.BoxID, originalBoxID)
+		}
+		vmState.StoppedAt = time.Time{}
+		readResult, err := runtime.Exec(ctx, session, vmState, ExecSpec{
+			Command: "cat",
+			Args:    []string{statePath},
+			Cwd:     "/",
+		})
+		if err != nil || !readResult.Success || strings.TrimSpace(readResult.Stdout) != "sandbox-exec-before-stop-ok" {
+			t.Fatalf("round %d read state result = %#v, err=%v", round, readResult, err)
+		}
+	}
+
+	if err := runtime.RemoveSandbox(ctx, session, vmState); err != nil {
+		t.Fatalf("RemoveSandbox() error = %v", err)
+	}
+	vmState.StoppedAt = time.Now().UTC()
+	if _, err := runtime.EnsureSandbox(ctx, session, vmState, proxyState); err == nil || !strings.Contains(err.Error(), "refusing to recreate") {
+		t.Fatalf("resume after runtime removal error = %v, want refusal to recreate", err)
+	}
+}
+
 func runtimeSmokeGuestPathAssertionScript() string {
 	return `
 set -eu

--- a/pkg/driver/runtime_mount_manifest_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_smoke_test.go
@@ -31,6 +31,48 @@ func runtimeSmokeKeepTmp() bool {
 	return strings.TrimSpace(os.Getenv("SMOKE_KEEP_TMP")) != ""
 }
 
+func cleanupRuntimeSmokeSandbox(t *testing.T, config *appconfig.Config, runtime SandboxRuntime, session *Sandbox, vmState VMState) {
+	t.Helper()
+	t.Cleanup(func() {
+		if t.Failed() && runtimeSmokeKeepTmp() {
+			return
+		}
+		removeCtx, removeCancel := context.WithTimeout(context.Background(), SandboxStopContextTimeout(session.Summary.Driver, config.SandboxStopTimeout))
+		defer removeCancel()
+		if err := runtime.RemoveSandbox(removeCtx, session, vmState); err != nil {
+			t.Errorf("RemoveSandbox cleanup error = %v", err)
+		}
+	})
+}
+
+func TestCleanupRuntimeSmokeSandboxRemovesRuntime(t *testing.T) {
+	runtime := &cleanupRuntimeSmokeRuntime{}
+	config := &appconfig.Config{SandboxStopTimeout: time.Second}
+	session := &Sandbox{Summary: SandboxSummary{ID: "smoke-cleanup", Driver: RuntimeDriverDocker}}
+	t.Run("cleanup", func(t *testing.T) {
+		cleanupRuntimeSmokeSandbox(t, config, runtime, session, VMState{BoxID: "container-1"})
+	})
+	if runtime.removeCalls != 1 || runtime.stopCalls != 0 {
+		t.Fatalf("cleanup calls: remove=%d stop=%d, want remove=1 stop=0", runtime.removeCalls, runtime.stopCalls)
+	}
+}
+
+type cleanupRuntimeSmokeRuntime struct {
+	fakeInteractionRuntime
+	removeCalls int
+	stopCalls   int
+}
+
+func (r *cleanupRuntimeSmokeRuntime) StopSandbox(context.Context, *Sandbox, VMState) (bool, error) {
+	r.stopCalls++
+	return false, nil
+}
+
+func (r *cleanupRuntimeSmokeRuntime) RemoveSandbox(context.Context, *Sandbox, VMState) error {
+	r.removeCalls++
+	return nil
+}
+
 func newRuntimeSmokeConfig(t *testing.T, driver string) *appconfig.Config {
 	t.Helper()
 	root, err := os.MkdirTemp("/tmp", "agent-compose-smoke-")
@@ -218,11 +260,7 @@ func assertRuntimeStopResumePreservesWritableLayer(t *testing.T, ctx context.Con
 		// when checking writable-layer persistence across a VM power cycle.
 		statePath = "/var/tmp/regression-sandbox-state.txt"
 	}
-	t.Cleanup(func() {
-		removeCtx, removeCancel := context.WithTimeout(context.Background(), SandboxStopContextTimeout(session.Summary.Driver, config.SandboxStopTimeout))
-		defer removeCancel()
-		_ = runtime.RemoveSandbox(removeCtx, session, vmState)
-	})
+	cleanupRuntimeSmokeSandbox(t, config, runtime, session, vmState)
 
 	writeResult, err := runtime.Exec(ctx, session, vmState, ExecSpec{
 		Command: "sh",

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -140,6 +140,7 @@ type SandboxVMInfo struct {
 type SandboxRuntime interface {
 	EnsureSandbox(context.Context, *Sandbox, VMState, ProxyState) (SandboxVMInfo, error)
 	StopSandbox(context.Context, *Sandbox, VMState) (bool, error)
+	RemoveSandbox(context.Context, *Sandbox, VMState) error
 	Exec(context.Context, *Sandbox, VMState, ExecSpec) (ExecResult, error)
 	ExecStream(context.Context, *Sandbox, VMState, ExecSpec, ExecStreamWriter) (ExecResult, error)
 }

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -53,6 +53,7 @@ type RuntimeProvider func(*domain.Sandbox) (Runtime, error)
 type SandboxDriver interface {
 	StartSandboxVM(context.Context, *domain.Sandbox) error
 	StopSandboxVM(context.Context, *domain.Sandbox) error
+	RemoveSandboxVM(context.Context, *domain.Sandbox) error
 }
 
 type TopicPublisher interface {
@@ -2081,6 +2082,12 @@ func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandb
 		}
 		if c.store == nil {
 			return fmt.Errorf("sandbox store is required")
+		}
+		if c.driver == nil {
+			return fmt.Errorf("sandbox driver is required")
+		}
+		if err := c.driver.RemoveSandboxVM(ctx, sandbox); err != nil {
+			return err
 		}
 		if err := c.store.RemoveSandbox(ctx, sandbox.Summary.ID); err != nil {
 			return err

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -1121,7 +1121,7 @@ func TestRunsControllerRunProjectAgentRemoveOnCompletionCleanup(t *testing.T) {
 		if _, statErr := os.Stat(fixture.store.SandboxDir(run.SandboxID)); !errors.Is(statErr, os.ErrNotExist) {
 			t.Fatalf("created sandbox dir still exists or stat error mismatch: %v", statErr)
 		}
-		if !fixture.driver.stopped || !containsString(fixture.dashboard.reasons, "sandbox_removed") {
+		if !fixture.driver.stopped || !fixture.driver.removed || !containsString(fixture.dashboard.reasons, "sandbox_removed") {
 			t.Fatalf("driver=%#v dashboard=%#v", fixture.driver, fixture.dashboard.reasons)
 		}
 	})
@@ -1207,6 +1207,21 @@ func TestRunsControllerRunProjectAgentCleanupErrorRecording(t *testing.T) {
 		}
 	})
 
+	t.Run("runtime remove failure keeps sandbox metadata", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		fixture.driver.removeErr = errors.New("runtime remove failed")
+		run, execErr, err := runAgentWithRemoveOnCompletion(t, fixture, nil)
+		if err != nil || execErr != nil {
+			t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
+		}
+		if !strings.Contains(run.CleanupError, "runtime remove failed") {
+			t.Fatalf("cleanup error = %q", run.CleanupError)
+		}
+		if _, statErr := os.Stat(fixture.store.SandboxDir(run.SandboxID)); statErr != nil {
+			t.Fatalf("sandbox dir should remain when runtime removal fails: %v", statErr)
+		}
+	})
+
 	t.Run("failed run keeps original error and records cleanup error", func(t *testing.T) {
 		fixture := newControllerRunFixture(t)
 		fixture.driver.stopErr = errors.New("stop failed")
@@ -1235,6 +1250,15 @@ func TestRunsControllerRunProjectAgentCleanupErrorRecording(t *testing.T) {
 			t.Fatalf("created sandbox dir still exists or stat error mismatch: %v", statErr)
 		}
 	})
+}
+
+func TestIntegrationRunsControllerRemoveOnCompletionWorkflows(t *testing.T) {
+	t.Run("cleanup", TestRunsControllerRunProjectAgentRemoveOnCompletionCleanup)
+	t.Run("cleanup error recording", TestRunsControllerRunProjectAgentCleanupErrorRecording)
+}
+
+func TestE2ERunsControllerRemoveOnCompletionWorkflows(t *testing.T) {
+	TestIntegrationRunsControllerRemoveOnCompletionWorkflows(t)
 }
 
 func TestRunsControllerRunProjectAgentManualTriggerResolution(t *testing.T) {
@@ -1820,11 +1844,13 @@ func (s *fakeControllerStore) UpsertLoaderBinding(_ context.Context, binding dom
 }
 
 type fakeControllerDriver struct {
-	started  bool
-	stopped  bool
-	startErr error
-	stopErr  error
-	store    *sessionstore.Store
+	started   bool
+	stopped   bool
+	removed   bool
+	startErr  error
+	stopErr   error
+	removeErr error
+	store     *sessionstore.Store
 }
 
 func (d *fakeControllerDriver) StartSandboxVM(_ context.Context, session *domain.Sandbox) error {
@@ -1844,6 +1870,11 @@ func (d *fakeControllerDriver) StopSandboxVM(context.Context, *domain.Sandbox) e
 		return d.stopErr
 	}
 	return nil
+}
+
+func (d *fakeControllerDriver) RemoveSandboxVM(context.Context, *domain.Sandbox) error {
+	d.removed = true
+	return d.removeErr
 }
 
 type fakeControllerExecutor struct {


### PR DESCRIPTION
## Summary

Fixes AC-SANDBOX-001, where stopping a sandbox destroyed its runtime and writable layer, so resume silently created an empty replacement.

- split runtime lifecycle semantics so `stop` preserves runtime state while `rm` performs destructive cleanup
- resume the original Docker container, BoxLite VM, or microsandbox instead of recreating it
- refuse silent recreation when a previously stopped runtime is unexpectedly missing
- keep runtime facade tokens active across resumable stops and revoke them on removal
- remove runtime resources before sandbox metadata in the API and project-run cleanup paths
- preserve metadata when runtime removal fails so cleanup can be retried safely
- add shared stop/resume writable-layer smoke coverage for all three runtime drivers

## Testing

Automated quality gates:

- `task lint`
- clean-environment `task test`
  - Unit: 76.78%
  - Integration: 64.64%
  - E2E: 61.60%
  - Combined: 79.53%
- `task build`

Real runtime verification:

- Docker: two stop/resume rounds reused the same container ID and preserved `/tmp/regression-sandbox-state.txt`; removal deleted the container
- BoxLite: two stop/resume rounds reused the same box and preserved `/var/tmp/regression-sandbox-state.txt` on the guest root disk (`/tmp` is tmpfs); removal deleted the sandbox
- microsandbox: two stop/resume rounds preserved `/var/tmp/regression-sandbox-state.txt`; removal deleted the sandbox metadata and per-sandbox `.raw` disk
- verified that resume after explicit runtime removal refuses to create a replacement runtime

## Checklist

- [x] Documentation reviewed; no update is required because this restores the existing stop/resume/rm contract and adds no configuration.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.