### PR TITLE
feat: pass payload to scheduler trigger runs

### DIFF
--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -39,7 +39,7 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "scheduler trigger",
 			args: []string{"scheduler", "trigger", "--help"},
-			want: []string{"Manually run a scheduler trigger", "--sandbox", "--driver", "--keep-running", "--rm", "--jupyter", "--jupyter-expose", "--detach"},
+			want: []string{"Manually run a scheduler trigger", "--sandbox", "--driver", "--prompt", "--payload", "--keep-running", "--rm", "--jupyter", "--jupyter-expose", "--detach"},
 		},
 		{
 			name: "logs",

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -556,6 +556,8 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	}
 	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.SandboxID, "sandbox", "", "Reuse an existing sandbox")
 	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.Driver, "driver", "", "Runtime driver override for a new sandbox")
+	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.Prompt, "prompt", "", "Prompt override for this manual trigger run")
+	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.PayloadJSON, "payload", "", "JSON payload passed to the scheduler trigger handler")
 	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.KeepRunning, "keep-running", false, "Keep the sandbox runtime running after completion")
 	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.Remove, "rm", false, "Remove the sandbox after a successful run")
 	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.Jupyter, "jupyter", false, "Enable Jupyter for this run")
@@ -999,6 +1001,8 @@ type composeRunOptions struct {
 type composeSchedulerTriggerOptions struct {
 	SandboxID     string
 	Driver        string
+	Prompt        string
+	PayloadJSON   string
 	KeepRunning   bool
 	Remove        bool
 	Jupyter       bool
@@ -1919,6 +1923,9 @@ func runComposeSchedulerTriggerCommand(cmd *cobra.Command, cli cliOptions, optio
 	if err != nil {
 		return err
 	}
+	if cmd.Flags().Changed("prompt") && strings.TrimSpace(options.Prompt) == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --prompt requires a non-empty prompt")}
+	}
 	_, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
@@ -1948,10 +1955,12 @@ func runComposeSchedulerTriggerCommand(cmd *cobra.Command, cli cliOptions, optio
 		ProjectId:       projectID,
 		AgentName:       trigger.AgentName,
 		Source:          agentcomposev2.RunSource_RUN_SOURCE_MANUAL,
+		Prompt:          options.Prompt,
 		SandboxId:       strings.TrimSpace(options.SandboxID),
 		Driver:          strings.TrimSpace(options.Driver),
 		SchedulerId:     firstNonEmptyString(trigger.RawSchedulerID, trigger.SchedulerID),
 		TriggerId:       firstNonEmptyString(trigger.RawTriggerID, trigger.TriggerID),
+		PayloadJson:     options.PayloadJSON,
 		CleanupPolicy:   cleanupPolicy,
 		ClientRequestId: manualRunClientRequestID(normalized.Name, trigger.AgentName, firstNonEmptyString(trigger.RawTriggerID, trigger.TriggerID)),
 		Jupyter:         jupyter,
@@ -1996,6 +2005,15 @@ func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, agent
 func normalizeComposeSchedulerTriggerOptions(options composeSchedulerTriggerOptions) (composeSchedulerTriggerOptions, error) {
 	options.SandboxID = strings.TrimSpace(options.SandboxID)
 	options.Driver = strings.TrimSpace(options.Driver)
+	options.Prompt = strings.TrimSpace(options.Prompt)
+	options.PayloadJSON = strings.TrimSpace(options.PayloadJSON)
+	if options.PayloadJSON != "" {
+		payloadJSON, err := domain.NormalizeJSONDocument(options.PayloadJSON)
+		if err != nil {
+			return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --payload: %w", err)}
+		}
+		options.PayloadJSON = payloadJSON
+	}
 	if options.Driver != "" {
 		driver, err := driverpkg.ResolveSandboxRuntimeDriver(options.Driver, "")
 		if err != nil {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -2580,6 +2580,25 @@ func TestComposeUpUsesDistinctStableTriggerIDs(t *testing.T) {
 	}
 }
 
+func TestNormalizeComposeSchedulerTriggerOptionsPayload(t *testing.T) {
+	options, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{
+		Prompt:      " override prompt ",
+		PayloadJSON: " { \"topic\" : \"nightly\" } ",
+	})
+	if err != nil {
+		t.Fatalf("normalize payload returned error: %v", err)
+	}
+	if options.Prompt != "override prompt" {
+		t.Fatalf("prompt = %q", options.Prompt)
+	}
+	if options.PayloadJSON != `{"topic":"nightly"}` {
+		t.Fatalf("payload = %q", options.PayloadJSON)
+	}
+	if _, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{PayloadJSON: "{bad"}); err == nil {
+		t.Fatalf("invalid payload returned nil error")
+	}
+}
+
 func TestIntegrationCLISchedulerTriggerUsesRunAgentTriggerID(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
 name: cli-scheduler-trigger
@@ -2593,6 +2612,8 @@ agents:
           prompt: review nightly
 `)
 	var requestedSandboxIDs []string
+	var requestedPayloads []string
+	var requestedPrompts []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
@@ -2602,7 +2623,9 @@ agents:
 		run: runServiceStub{
 			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
 				requestedSandboxIDs = append(requestedSandboxIDs, req.Msg.GetSandboxId())
-				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) || req.Msg.GetPrompt() != "" || req.Msg.GetCommand() != "" {
+				requestedPayloads = append(requestedPayloads, req.Msg.GetPayloadJson())
+				requestedPrompts = append(requestedPrompts, req.Msg.GetPrompt())
+				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) || req.Msg.GetCommand() != "" {
 					t.Fatalf("RunAgentStream scheduler trigger request = %#v", req.Msg)
 				}
 				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
@@ -2630,6 +2653,8 @@ agents:
 	}{
 		{name: "creates sandbox"},
 		{name: "reuses sandbox", extraArgs: []string{"--sandbox", "sandbox-existing"}},
+		{name: "passes payload", extraArgs: []string{"--payload", `{"topic":"nightly"}`}},
+		{name: "passes prompt", extraArgs: []string{"--prompt", "review override"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			args := []string{"scheduler", "trigger", "--host", server.URL, "--file", composePath}
@@ -2641,8 +2666,27 @@ agents:
 			}
 		})
 	}
-	if !reflect.DeepEqual(requestedSandboxIDs, []string{"", "sandbox-existing"}) {
+	if !reflect.DeepEqual(requestedSandboxIDs, []string{"", "sandbox-existing", "", ""}) {
 		t.Fatalf("scheduler trigger sandbox IDs = %#v", requestedSandboxIDs)
+	}
+	if !reflect.DeepEqual(requestedPayloads, []string{"", "", `{"topic":"nightly"}`, ""}) {
+		t.Fatalf("scheduler trigger payloads = %#v", requestedPayloads)
+	}
+	if !reflect.DeepEqual(requestedPrompts, []string{"", "", "", "review override"}) {
+		t.Fatalf("scheduler trigger prompts = %#v", requestedPrompts)
+	}
+}
+
+func TestRunComposeSchedulerTriggerPromptRequiresValue(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("prompt", "", "")
+	if err := cmd.Flags().Set("prompt", " "); err != nil {
+		t.Fatalf("set prompt flag: %v", err)
+	}
+	err := runComposeSchedulerTriggerCommand(cmd, cliOptions{}, composeSchedulerTriggerOptions{Prompt: " "}, "reviewer", "nightly")
+	var exitErr commandExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != exitCodeUsage || !strings.Contains(err.Error(), "--prompt requires a non-empty prompt") {
+		t.Fatalf("prompt error = %#v", err)
 	}
 }
 

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -199,6 +199,8 @@ agent-compose scheduler inspect <agent> <trigger>
 
 - `scheduler ls` lists triggers from declarative scheduler config and triggers registered by scheduler scripts.
 - `scheduler trigger` manually runs the selected trigger through the existing project run flow.
+- `scheduler trigger --prompt "..."` overrides the trigger's agent prompt for this manual run.
+- `scheduler trigger --payload '{"key":"value"}'` passes a JSON payload to the scheduler trigger handler.
 - `scheduler inspect` prints the YAML trigger definition for declarative triggers, or the registered loader trigger fields for scheduler-script triggers.
 
 ## `ps`: List Sandboxes

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -204,6 +204,8 @@ agent-compose scheduler inspect <agent> <trigger>
 
 - `scheduler ls` 同时列出声明式 scheduler 配置的 trigger 和 scheduler script 注册到系统中的 trigger。
 - `scheduler trigger` 通过现有 project run 流程手动执行指定 trigger。
+- `scheduler trigger --prompt "..."` 覆盖本次手动运行使用的 agent prompt。
+- `scheduler trigger --payload '{"key":"value"}'` 将 JSON payload 传给 scheduler trigger handler。
 - `scheduler inspect` 对声明式 trigger 输出 YAML 中对应 trigger 定义；对 scheduler script trigger 输出系统中注册到 loader trigger 的字段。
 
 ## `ps`：查看 sandbox

--- a/pkg/agentcompose/app/app_test.go
+++ b/pkg/agentcompose/app/app_test.go
@@ -213,16 +213,17 @@ func TestCacheServiceRouteUsesRuntimeCacheController(t *testing.T) {
 
 func TestRunAgentRequestFromProtoPreservesCommand(t *testing.T) {
 	req := runAgentRequestFromProto(&agentcomposev2.RunAgentRequest{
-		ProjectId: "project-1",
-		AgentName: "worker",
-		Prompt:    "prompt",
-		Command:   "echo hi",
-		TriggerId: "trigger-1",
-		Driver:    "microsandbox",
-		Jupyter:   &agentcomposev2.RunJupyterSpec{Enabled: true, Expose: true},
-		Volumes:   []*agentcomposev2.VolumeMountSpec{{Type: "bind", Source: "./fixtures", Target: "/fixtures", ReadOnly: true}},
+		ProjectId:   "project-1",
+		AgentName:   "worker",
+		Prompt:      "prompt",
+		Command:     "echo hi",
+		TriggerId:   "trigger-1",
+		PayloadJson: `{"input":true}`,
+		Driver:      "microsandbox",
+		Jupyter:     &agentcomposev2.RunJupyterSpec{Enabled: true, Expose: true},
+		Volumes:     []*agentcomposev2.VolumeMountSpec{{Type: "bind", Source: "./fixtures", Target: "/fixtures", ReadOnly: true}},
 	})
-	if req.ProjectID != "project-1" || req.AgentName != "worker" || req.Prompt != "prompt" || req.Command != "echo hi" || req.TriggerID != "trigger-1" || req.Driver != "microsandbox" {
+	if req.ProjectID != "project-1" || req.AgentName != "worker" || req.Prompt != "prompt" || req.Command != "echo hi" || req.TriggerID != "trigger-1" || req.PayloadJSON != `{"input":true}` || req.Driver != "microsandbox" {
 		t.Fatalf("mapped request = %#v", req)
 	}
 	if req.Jupyter == nil || !req.Jupyter.GetEnabled() || !req.Jupyter.GetExpose() {

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -178,6 +178,7 @@ func runAgentRequestFromProto(msg *agentcomposev2.RunAgentRequest) runs.RunAgent
 		Source:           api.ProjectRunSourceFromProto(msg.GetSource()),
 		SchedulerID:      msg.GetSchedulerId(),
 		TriggerID:        msg.GetTriggerId(),
+		PayloadJSON:      msg.GetPayloadJson(),
 		ClientRequestID:  msg.GetClientRequestId(),
 		Env:              msg.GetEnv(),
 		SandboxID:        msg.GetSandboxId(),

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -180,6 +180,7 @@ type RunAgentRequest struct {
 	Source                 string
 	SchedulerID            string
 	TriggerID              string
+	PayloadJSON            string
 	ClientRequestID        string
 	Env                    []*agentcomposev2.EnvVarSpec
 	SandboxID              string
@@ -1163,6 +1164,7 @@ func runAgentRequestFromAttachStart(start *agentcomposev2.RunAttachStart) RunAge
 		Source:           projectRunSourceFromAttachProto(msg.GetSource()),
 		SchedulerID:      msg.GetSchedulerId(),
 		TriggerID:        msg.GetTriggerId(),
+		PayloadJSON:      msg.GetPayloadJson(),
 		ClientRequestID:  msg.GetClientRequestId(),
 		Env:              msg.GetEnv(),
 		SandboxID:        msg.GetSandboxId(),

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -1294,6 +1294,110 @@ func TestRunsControllerRunProjectAgentManualTriggerResolution(t *testing.T) {
 	}
 }
 
+func TestRunsControllerRunProjectAgentManualTriggerPayload(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	trigger := domain.LoaderTrigger{
+		LoaderID:   "loader-1",
+		ID:         "trigger-1",
+		Kind:       domain.LoaderTriggerKindInterval,
+		IntervalMs: 1000,
+		Enabled:    true,
+		SpecJSON:   `{"kind":"interval","intervalMs":1000}`,
+	}
+	fixture.configDB.schedulers = []domain.ProjectSchedulerRecord{{
+		ProjectID:       "project-1",
+		SchedulerID:     "scheduler-1",
+		AgentName:       "worker",
+		ManagedLoaderID: "loader-1",
+		Enabled:         true,
+		TriggerCount:    1,
+	}}
+	fixture.configDB.loaders = map[string]domain.Loader{
+		"loader-1": {
+			Summary: domain.LoaderSummary{
+				ID:                 "loader-1",
+				Enabled:            true,
+				Runtime:            domain.LoaderRuntimeScheduler,
+				ManagedProjectID:   "project-1",
+				ManagedAgentName:   "worker",
+				ManagedSchedulerID: "scheduler-1",
+			},
+			Script:   `scheduler.interval("trigger-1", async function(payload) { return scheduler.agent("review " + payload.topic, { sandboxEnv: [{ name: "TRIGGER_TOPIC", value: payload.topic }] }); }, 1000);`,
+			Triggers: []domain.LoaderTrigger{trigger},
+		},
+	}
+	run, execErr, err := fixture.controller.RunProjectAgent(fixture.ctx, RunAgentRequest{
+		ProjectID:       "project-1",
+		AgentName:       "worker",
+		Source:          domain.ProjectRunSourceManual,
+		TriggerID:       "trigger-1",
+		PayloadJSON:     `{"topic":"nightly"}`,
+		ClientRequestID: "manual-trigger-payload",
+	}, nil)
+	if err != nil || execErr != nil {
+		t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
+	}
+	session, err := fixture.store.GetSandbox(fixture.ctx, run.SandboxID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if run.Prompt != "review nightly" || fixture.executor.request.Message != "review nightly" || envItemValue(session.EnvItems, "TRIGGER_TOPIC") != "nightly" {
+		t.Fatalf("run=%#v executor=%#v env=%#v", run, fixture.executor.request, session.EnvItems)
+	}
+}
+
+func TestRunsControllerRunProjectAgentManualTriggerPromptOverride(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	trigger := domain.LoaderTrigger{
+		LoaderID:   "loader-1",
+		ID:         "trigger-1",
+		Kind:       domain.LoaderTriggerKindInterval,
+		IntervalMs: 1000,
+		Enabled:    true,
+		SpecJSON:   `{"kind":"interval","intervalMs":1000}`,
+	}
+	fixture.configDB.schedulers = []domain.ProjectSchedulerRecord{{
+		ProjectID:       "project-1",
+		SchedulerID:     "scheduler-1",
+		AgentName:       "worker",
+		ManagedLoaderID: "loader-1",
+		Enabled:         true,
+		TriggerCount:    1,
+	}}
+	fixture.configDB.loaders = map[string]domain.Loader{
+		"loader-1": {
+			Summary: domain.LoaderSummary{
+				ID:                 "loader-1",
+				Enabled:            true,
+				Runtime:            domain.LoaderRuntimeScheduler,
+				ManagedProjectID:   "project-1",
+				ManagedAgentName:   "worker",
+				ManagedSchedulerID: "scheduler-1",
+			},
+			Script:   `scheduler.interval("trigger-1", async function() { return scheduler.agent("captured prompt", { sandboxEnv: [{ name: "TRIGGER_ENV", value: "yes" }] }); }, 1000);`,
+			Triggers: []domain.LoaderTrigger{trigger},
+		},
+	}
+	run, execErr, err := fixture.controller.RunProjectAgent(fixture.ctx, RunAgentRequest{
+		ProjectID:       "project-1",
+		AgentName:       "worker",
+		Prompt:          "override prompt",
+		Source:          domain.ProjectRunSourceManual,
+		TriggerID:       "trigger-1",
+		ClientRequestID: "manual-trigger-prompt",
+	}, nil)
+	if err != nil || execErr != nil {
+		t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
+	}
+	session, err := fixture.store.GetSandbox(fixture.ctx, run.SandboxID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if run.Prompt != "override prompt" || fixture.executor.request.Message != "override prompt" || envItemValue(session.EnvItems, "TRIGGER_ENV") != "yes" {
+		t.Fatalf("run=%#v executor=%#v env=%#v", run, fixture.executor.request, session.EnvItems)
+	}
+}
+
 func TestRunsControllerRunProjectAgentManualTriggerMissingDoesNotCreateRun(t *testing.T) {
 	fixture := newControllerRunFixture(t)
 	fixture.configDB.schedulers = []domain.ProjectSchedulerRecord{{

--- a/pkg/runs/trigger.go
+++ b/pkg/runs/trigger.go
@@ -21,8 +21,8 @@ func (c *Controller) resolveTriggerForManualRun(ctx context.Context, req RunAgen
 	if triggerID == "" || NormalizeSource(req.Source) != domain.ProjectRunSourceManual {
 		return result, nil
 	}
-	if strings.TrimSpace(req.Prompt) != "" || strings.TrimSpace(req.Command) != "" {
-		return result, fmt.Errorf("%w: scheduler trigger cannot be combined with prompt or command", ErrInvalidRequest)
+	if strings.TrimSpace(req.Command) != "" {
+		return result, fmt.Errorf("%w: scheduler trigger cannot be combined with command", ErrInvalidRequest)
 	}
 	if c.configDB == nil {
 		return result, fmt.Errorf("config store is required")
@@ -38,11 +38,15 @@ func (c *Controller) resolveTriggerForManualRun(ctx context.Context, req RunAgen
 	if !trigger.Enabled {
 		warnings = append(warnings, fmt.Sprintf("trigger %s is disabled; running because it was requested manually", trigger.ID))
 	}
-	captured, err := c.captureManualTriggerAgentRequest(ctx, loader, trigger)
+	captured, err := c.captureManualTriggerAgentRequest(ctx, loader, trigger, req.PayloadJSON)
 	if err != nil {
 		return result, err
 	}
-	result.Request.Prompt = captured.prompt
+	if prompt := strings.TrimSpace(req.Prompt); prompt != "" {
+		result.Request.Prompt = prompt
+	} else {
+		result.Request.Prompt = captured.prompt
+	}
 	if strings.TrimSpace(result.Request.SchedulerID) == "" {
 		result.Request.SchedulerID = scheduler.SchedulerID
 	}
@@ -109,16 +113,20 @@ type capturedManualTriggerAgentRequest struct {
 	request domain.LoaderAgentRequest
 }
 
-func (c *Controller) captureManualTriggerAgentRequest(ctx context.Context, loader domain.Loader, trigger *domain.LoaderTrigger) (capturedManualTriggerAgentRequest, error) {
+func (c *Controller) captureManualTriggerAgentRequest(ctx context.Context, loader domain.Loader, trigger *domain.LoaderTrigger, payloadJSON string) (capturedManualTriggerAgentRequest, error) {
 	if c.loaderEngine == nil {
 		return capturedManualTriggerAgentRequest{}, fmt.Errorf("loader engine is required")
+	}
+	payloadJSON = strings.TrimSpace(payloadJSON)
+	if payloadJSON == "" {
+		payloadJSON = `{}`
 	}
 	host := &manualTriggerCaptureHost{}
 	_, err := c.loaderEngine.Execute(ctx, loaders.LoaderExecutionRequest{
 		Runtime:     loader.Summary.Runtime,
 		Script:      loader.Script,
 		Trigger:     trigger,
-		PayloadJSON: `{}`,
+		PayloadJSON: payloadJSON,
 	}, host)
 	if err != nil {
 		return capturedManualTriggerAgentRequest{}, fmt.Errorf("%w: resolve trigger %s prompt: %v", domain.ErrInvalidArgument, trigger.ID, err)

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -3570,6 +3570,7 @@ type RunAgentRequest struct {
 	Driver           string                  `protobuf:"bytes,14,opt,name=driver,proto3" json:"driver,omitempty"`
 	SandboxId        string                  `protobuf:"bytes,15,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
 	Volumes          []*VolumeMountSpec      `protobuf:"bytes,16,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	PayloadJson      string                  `protobuf:"bytes,17,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -3707,6 +3708,13 @@ func (x *RunAgentRequest) GetVolumes() []*VolumeMountSpec {
 		return x.Volumes
 	}
 	return nil
+}
+
+func (x *RunAgentRequest) GetPayloadJson() string {
+	if x != nil {
+		return x.PayloadJson
+	}
+	return ""
 }
 
 type RunAgentResponse struct {
@@ -10573,7 +10581,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x10DockerDriverSpec\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\"2\n" +
 	"\x16MicrosandboxDriverSpec\x12\x18\n" +
-	"\aprofile\x18\x01 \x01(\tR\aprofile\"\x91\x05\n" +
+	"\aprofile\x18\x01 \x01(\tR\aprofile\"\xb4\x05\n" +
 	"\x0fRunAgentRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1d\n" +
@@ -10594,7 +10602,8 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x06driver\x18\x0e \x01(\tR\x06driver\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x0f \x01(\tR\tsandboxId\x12:\n" +
-	"\avolumes\x18\x10 \x03(\v2 .agentcompose.v2.VolumeMountSpecR\avolumesJ\x04\b\x05\x10\x06R\n" +
+	"\avolumes\x18\x10 \x03(\v2 .agentcompose.v2.VolumeMountSpecR\avolumes\x12!\n" +
+	"\fpayload_json\x18\x11 \x01(\tR\vpayloadJsonJ\x04\b\x05\x10\x06R\n" +
 	"session_id\"\\\n" +
 	"\x10RunAgentResponse\x12,\n" +
 	"\x03run\x18\x01 \x01(\v2\x1a.agentcompose.v2.RunDetailR\x03run\x12\x1a\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -489,6 +489,7 @@ message RunAgentRequest {
   string driver = 14;
   string sandbox_id = 15;
   repeated VolumeMountSpec volumes = 16;
+  string payload_json = 17;
 }
 
 message RunAgentResponse {


### PR DESCRIPTION
## Summary
- add `--payload` support for `agent-compose scheduler trigger`
- pass v2 `RunAgentRequest.payload_json` through manual scheduler trigger resolution
- document payload usage and cover CLI / run-controller behavior in tests

## Validation
- `go test ./cmd/agent-compose ./pkg/runs ./pkg/agentcompose/app`
- `task lint`
- `task build`
- `cd proto-client && npm run gen && npm run build`
- local daemon smoke test: `scheduler trigger reviewer nightly --payload '{"topic":"nightly"}' -d` then `inspect run` confirmed prompt `review nightly`\n\n## Notes\n- v1 API/files intentionally unchanged\n