### PR TITLE
docs: rewrite README as a lean, community-facing landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,496 +2,305 @@
 
 [![CI](https://github.com/chaitin/agent-compose/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/chaitin/agent-compose/actions/workflows/ci.yml)
 [![Images & Release](https://github.com/chaitin/agent-compose/actions/workflows/images.yml/badge.svg?branch=main)](https://github.com/chaitin/agent-compose/actions/workflows/images.yml)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE.txt)
 
-agent-compose is an experimental control plane for running isolated agent
-sandboxes. It provides a daemon, CLI, Connect APIs, runtime drivers, workspace
-provisioning, scheduler automation, event history, and a Jupyter proxy for
-notebook-style guest runtimes.
+**agent-compose is a daemon + CLI control plane that runs AI coding agents in isolated sandboxes.** You describe your agents in an `agent-compose.yml` file, and a long-lived daemon builds, runs, schedules, and proxies an isolated runtime for each one.
 
-agent-compose is a public preview project: APIs, runtime packaging, deployment
-defaults, and operational guidance may still change.
+> Public preview. APIs, runtime packaging, and deployment defaults may still change. It is suitable for experimentation, local development, and preview deployments — not yet a stable production platform.
 
-Chinese documentation is available at [docs/zh-CN/README.md](docs/zh-CN/README.md).
+📖 中文文档：[docs/zh-CN/README.md](docs/zh-CN/README.md)
 
-## What It Does
+## What is agent-compose?
 
-- Runs a long-lived daemon that owns state, scheduler execution, runtime
-  lifecycle, Connect APIs, and Jupyter proxying.
-- Provides a CLI for `up`, `run`, `logs`, `ps`, `down`, and image operations.
-- Supports project definitions in `agent-compose.yml`.
-- Starts isolated guest runtimes with Docker, BoxLite, or Microsandbox.
-- Provisions workspaces from local directories or Git repositories.
-- Exposes v1 compatibility session APIs and v2 project/run/sandbox/image APIs.
-- Includes JavaScript runtime components under `runtime/`.
+If you know Docker Compose, the mental model is familiar: instead of declaring
+containers, you declare **agents**. Each agent picks a provider CLI — `codex`,
+`claude` (Claude Code), `gemini`, or `opencode` — and the daemon gives it its own
+isolated sandbox with a workspace, then runs it on a prompt, a shell command, a
+schedule, or an event. Provider API keys stay on the daemon and are never exposed
+inside the guest.
 
-The web UI lives in a separate repository,
-[agent-compose-ui](https://github.com/chaitin/agent-compose-ui).
+You manage the whole lifecycle with a Compose-style CLI (`up`, `run`, `ps`,
+`logs`, `down`), and everything is driven by one declarative file.
 
-## Maturity
+Concretely, agent-compose provides:
 
-agent-compose is currently suitable for experimentation, local development, and
-preview deployments. It is not yet a stable production platform.
+- A **declarative compose model** (`agent-compose.yml`) with `${ENV}` interpolation.
+- **Multi-provider guest agents**: Codex, Claude Code, Gemini, and OpenCode CLIs.
+- **Three runtime drivers**: `docker` (default), `boxlite` (microVM), and `microsandbox`.
+- A **scheduler** with `cron`, `interval`, `timeout`, and `event` triggers — or full inline JavaScript scheduler scripts.
+- **Event triggers and webhooks** for event-driven agent runs.
+- **Workspaces** provisioned from a local directory or a Git repository.
+- A **Runtime LLM Facade** that brokers LLM credentials so provider keys never enter guest containers.
+- **MCP servers, reusable skills, and named volumes** per agent.
+- A **Jupyter proxy** for notebook-style guest runtimes.
+- **v1/v2 Connect APIs** and a generated TypeScript client.
 
-Before using it with untrusted workloads, review the runtime driver behavior,
-network access, authentication settings, workspace upload limits, and Jupyter
-proxy assumptions.
+## How it works
 
-## Repository Layout
+The **daemon** is the single source of truth: it owns persistence, scheduler
+execution, runtime lifecycle, the Connect/HTTP APIs, and Jupyter proxying. The
+**CLI** is a thin client — it reads your local `agent-compose.yml`, validates it,
+and calls the daemon. The compose file describes *projects and agents*, not
+already-running sandboxes. The **web UI** is a separate service
+([agent-compose-ui](https://github.com/chaitin/agent-compose-ui)) and is not
+hosted by the daemon.
 
-```text
-cmd/agent-compose/             daemon and CLI entrypoint
-pkg/agentcompose/app/          service graph, route registration, background managers
-pkg/agentcompose/api/          Connect handlers and API/protobuf conversion helpers
-pkg/agentcompose/adapters/     daemon runtime/sandbox/loader/capability adapters
-pkg/agentcompose/proxy/        Jupyter, workspace, and runtime LLM HTTP proxy routes
-pkg/model/                     domain records, validation, stable IDs, JSON helpers
-pkg/storage/                   sandbox and config persistence helpers
-pkg/loaders/                   loader engine, scheduling, command, and payload helpers
-pkg/projects/                  project normalization and managed-resource builders
-pkg/runs/                      project run coordinator and run/sandbox helpers
-pkg/sessions/                  v1-compatible stream broker and sandbox state helpers
-pkg/execution/                 cell, agent execution, artifact, and driver conversion helpers
-pkg/llms/                      daemon LLM client and runtime facade helpers
-pkg/events/                    event/webhook helpers
-pkg/images/                    daemon image store service helpers
-pkg/driver/                    Docker, BoxLite, and Microsandbox runtime drivers
-pkg/config/                    environment configuration
-pkg/imagecache/                OCI image cache helpers
-proto/                         Connect API definitions and generated Go code
-proto-client/                  npm package config for the generated TypeScript client
-runtime/                       guest runtime SDKs and JavaScript scheduler runtime
-guest-images/                  guest image Dockerfiles
-examples/scheduler-script/      scheduler script examples and API notes
-docs/design/                   design notes
-```
+For the full architecture, see [docs/design/agent-compose_design.md](docs/design/agent-compose_design.md).
 
-## Requirements
+## Quick start
 
-- Go toolchain compatible with the version declared in `go.mod`
-- Node.js and npm
-- Task, for the documented `task ...` commands
-- Docker, when using Docker runtime or building Docker images
-- Runtime-specific dependencies for BoxLite or Microsandbox when using those
-  drivers directly
+### Option A — Run a server (recommended)
 
-## Quick Start
-
-Build the CLI and daemon:
+The one-line installer sets up agent-compose with Docker Compose (including the
+web UI) on Linux amd64/arm64:
 
 ```bash
-task build
+curl -fsSL https://github.com/chaitin/agent-compose/releases/latest/download/install.sh | bash
 ```
 
-Start the daemon:
+On first run it generates an `admin` password and prints it once, then you work
+through the web UI at the printed URL. See [deploy/README.md](deploy/README.md)
+for options such as `--dir`, `--port`, `--upgrade`, and pulling from a
+mirror/private registry.
+
+### Option B — Build from source (for the CLI workflow)
 
 ```bash
+task build                       # builds ./build/agent-compose
+export PATH="$PWD/build:$PATH"   # so `agent-compose` is on your PATH
 agent-compose daemon
 ```
 
-By default, the daemon listens on a local Unix socket. To expose an HTTP endpoint
-for local development:
+The daemon listens on a local Unix socket by default. To expose a local HTTP
+endpoint instead:
 
 ```bash
 HTTP_LISTEN=127.0.0.1:7410 agent-compose daemon
-```
-
-Check daemon status:
-
-```bash
-agent-compose status
 agent-compose --host http://127.0.0.1:7410 status
 ```
 
-Create an `agent-compose.yml`:
+### Run your first agent
+
+With a local daemon running (Option B), create an `agent-compose.yml`:
 
 ```yaml
 name: demo
+
 agents:
   reviewer:
     provider: codex
-    model: gpt-test
-    image: debian:bookworm-slim
-    scheduler:
-      sandbox_policy: sticky
-      triggers:
-        - name: hourly
-          cron: "0 * * * *"
-          prompt: "Review the current workspace state."
-        - name: clean-review
-          cron: "0 0 * * *"
-          prompt: "Review in a fresh sandbox."
-          sandbox_policy: new
+    image: ghcr.io/chaitin/agent-compose-guest:latest
+    driver:
+      docker: {}
 ```
 
-Apply and run it:
+Then drive the lifecycle:
 
 ```bash
-agent-compose up
-agent-compose ps
+agent-compose up                                  # apply the project to the daemon
+agent-compose ps                                  # list project sandboxes
 agent-compose run reviewer --prompt "Review this change"
 agent-compose logs --agent reviewer
-agent-compose down
+agent-compose down                                # stop sandboxes, disable schedulers
 ```
 
-## CLI
+More runnable examples (cron, timeout, scheduler scripts) live in
+[examples/agent-compose/](examples/agent-compose/).
 
-The main commands are:
+## The compose file
 
-- `agent-compose daemon`: start the HTTP/Connect daemon.
-- `agent-compose up`: read `agent-compose.yml` and apply the project to the daemon.
-- `agent-compose run <agent> --prompt "..."` / `--command "..."`: run prompt or shell command work.
-- `agent-compose scheduler ls|trigger|inspect`: list, run, or inspect project scheduler triggers.
-- `agent-compose logs`: inspect project run logs.
-- `agent-compose ps`: list project agents, recent runs, and active sandboxes.
-- `agent-compose sandbox ls|stop|resume|rm|prune`: manage project sandboxes; `sandbox prune` cleans stopped/failed sandbox records and is dry-run unless `--force` is set.
-- `agent-compose down`: disable managed schedulers and stop running sandboxes.
-- `agent-compose images`, `pull`, `rmi`, `image inspect`: manage daemon-side images.
-- `agent-compose cache ls|inspect|prune|rm`: inspect and explicitly clean daemon runtime caches. `prune` and `rm` are dry-run unless `--force` is set; `sandbox prune` does not delete runtime cache files.
+**Top-level fields:** `name`, `variables`, `agents`, `mcps`, `volumes`, `network`.
 
-Useful flags and environment variables:
+**Common agent fields:** `provider`, `model`, `system_prompt`, `image`,
+`driver`, `env` (scalars or `{ value, secret }`), `workspace`, `scheduler`,
+`mcps`, `skills`, and `volumes`.
 
-- `--file, -f`: choose a compose file.
-- `--project-name`: override the compose project name.
-- `--json`: emit stable JSON for scripts.
-- `--host` or `AGENT_COMPOSE_HOST`: connect to a TCP daemon.
-- `AGENT_COMPOSE_SOCKET`: choose the local Unix socket path.
-
-## Compose File
-
-Top-level fields:
-
-- `name`: project name. If omitted, the compose file directory name is used.
-- `variables`: project variables with `${ENV_NAME}` interpolation.
-- `workspace`: default project workspace.
-- `agents`: agent definitions keyed by agent name.
-- `network.mode`: currently supports `default`.
-
-Common agent fields:
-
-- `provider`, `model`, `system_prompt`: guest agent settings (`provider` selects
-  the guest CLI runner; `model` is passed to provider runtimes that support
-  explicit model selection). Supported guest providers are `codex`, `claude`,
-  `gemini`, and `opencode`. Daemon-side LLM calls
-  (`LLMService`, `scheduler.llm`) use `LLM_MODEL` instead.
-- `image`: guest image reference.
-- `driver`: runtime driver override. Supported drivers are `boxlite`, `docker`,
-  and `microsandbox`.
-- `env`: agent environment variables. Values may be scalars or
-  `{ value, secret }` objects.
-- `workspace`: agent workspace override.
-- `scheduler.enabled`: defaults to `true`.
-- `scheduler.triggers`: supports `cron`, `interval`, `timeout`, and `event`
-  triggers.
-- `scheduler.script`: inline JavaScript scheduler runtime code. Use either
-  `scheduler.script` or `scheduler.triggers`, not both in the same scheduler.
-
-Workspace providers:
+Provision an agent's workspace from a local path (`provider: local`) or a Git
+repository (`provider: git`):
 
 ```yaml
-workspace:
-  provider: git
-  url: https://github.com/example/repo.git
-  branch: main
-
 agents:
   reviewer:
     workspace:
-      provider: local
-      path: .
+      provider: git
+      url: https://github.com/example/repo.git
+      branch: main
 ```
 
-## Runtime Drivers
+Add scheduled or event-driven runs. Use either `scheduler.triggers` **or** an
+inline `scheduler.script`, not both in the same scheduler:
 
-agent-compose supports three runtime drivers:
+```yaml
+agents:
+  reviewer:
+    scheduler:
+      enabled: true
+      triggers:
+        - name: hourly-review
+          cron: "0 * * * *"
+          prompt: "Review the current project state and summarize changes."
+```
 
-- `docker`: the default driver. It uses Docker containers and requires a
-  working Docker daemon.
-- `boxlite`: uses BoxLite runtime artifacts and guest images prepared by this
-  repository.
-- `microsandbox`: uses Microsandbox runtime artifacts.
+See the [command line manual](docs/command-line-manual.md) for the full field reference.
 
-Image handling is selected by `IMAGE_STORE_MODE`:
+## CLI overview
 
-- `auto`: use Docker image store when Docker is available, otherwise use the OCI
-  cache.
-- `docker`: require Docker image store.
-- `oci`: use daemonless OCI image cache.
+| Command | Purpose |
+| --- | --- |
+| `agent-compose daemon` | Start the HTTP/Connect daemon. |
+| `agent-compose up` | Read `agent-compose.yml` and apply the project. |
+| `agent-compose run <agent> --prompt/--command` | Run a prompt or shell command as an agent. |
+| `agent-compose exec <sandbox>` | Execute a command or prompt in a running sandbox. |
+| `agent-compose ps` / `stats` | List project sandboxes / show sandbox resource stats. |
+| `agent-compose logs` | Print project run logs. |
+| `agent-compose scheduler ls\|trigger\|inspect` | List, run, or inspect scheduler triggers. |
+| `agent-compose sandbox ls\|stop\|resume\|rm\|prune` | Manage project sandboxes. |
+| `agent-compose images\|pull\|build\|rmi\|inspect` | Manage daemon images and build agent images. |
+| `agent-compose volume ls\|create\|inspect\|rm\|prune` | Manage daemon volumes. |
+| `agent-compose cache ls\|inspect\|prune\|rm` | Inspect and clean daemon runtime caches. |
+| `agent-compose down` | Disable managed schedulers and stop sandboxes. |
+| `agent-compose status` | Check daemon status. |
 
-The default guest image is `debian:bookworm-slim` unless overridden by
-`DEFAULT_IMAGE`, `DOCKER_DEFAULT_IMAGE`, or `MICROSANDBOX_DEFAULT_IMAGE`.
+Useful global flags: `--file, -f` (choose a compose file), `--project-name`,
+`--json` (stable JSON for scripts), `--host` / `AGENT_COMPOSE_HOST` (connect to a
+TCP daemon), and `AGENT_COMPOSE_SOCKET` (Unix socket path). Full reference:
+[docs/command-line-manual.md](docs/command-line-manual.md).
 
-## Frontend
+## Runtime drivers
 
-The web UI lives in a separate repository,
-[agent-compose-ui](https://github.com/chaitin/agent-compose-ui). It consumes the
-generated API client from the published
-[`@chaitin-ai/agent-compose-client`](https://www.npmjs.com/package/@chaitin-ai/agent-compose-client)
-package, which is built from this repository's `proto/` via `proto-client/`.
+- **`docker`** (default): runs guests in Docker containers; requires a working Docker daemon.
+- **`boxlite`**: runs guests as microVMs using BoxLite runtime artifacts.
+- **`microsandbox`**: runs guests using the Microsandbox VM runtime.
 
-The daemon does not host the Web UI or browser login flows. The frontend
-repository builds an image (`ghcr.io/chaitin/agent-compose-ui`) that runs nginx
-in front of the agent-compose-ui server: nginx serves the built UI, and the UI
-server handles browser auth/OAuth before proxying API and Jupyter routes to the
-daemon. The root
-`docker-compose.yml` references that published image and is the default
-deployment entrypoint.
+Image handling is selected by `IMAGE_STORE_MODE` (`auto` / `docker` / `oci`,
+where `oci` uses a daemonless image cache). New sandboxes use the image set by
+`DEFAULT_IMAGE`; the bundled `.env.example` and installer set this to
+`ghcr.io/chaitin/agent-compose-guest:latest`, which ships the agent runtime and
+provider CLIs.
 
-For a server deployment that uses published container images:
+## Agent providers
+
+Each agent sets a `provider`, which selects the CLI it runs inside the sandbox:
+
+| Provider | Runs |
+| --- | --- |
+| `codex` | Codex CLI |
+| `claude` | Claude Code CLI |
+| `gemini` | Gemini CLI |
+| `opencode` | OpenCode CLI |
+
+You configure LLM credentials once, on the daemon (in `.env`) — not per guest.
+For Codex, Claude, and OpenCode, the daemon's **Runtime LLM Facade** hands each
+sandbox a scoped token instead of your real API key, so provider keys never enter
+the guest.
+
+Set the variables for the backend family your agents use. **OpenAI-family**
+(Codex, plus the daemon's own `LLMService` and scheduler LLM calls):
+
+```env
+LLM_API_ENDPOINT=https://api.openai.com
+LLM_API_PROTOCOL=responses    # or chat_completions for DeepSeek / vLLM / Ollama
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-...
+```
+
+**Anthropic-family** (Claude):
+
+```env
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_MODEL=claude-...
+```
+
+Set `LLM_API_PROTOCOL=chat_completions` to target any OpenAI-compatible endpoint
+(DeepSeek, vLLM, Ollama).
+
+**Per-provider notes.** OpenCode picks its upstream family from the agent's
+`model` (`provider/model`, e.g. `anthropic/…` or `openai/…`) and gets a facade
+token for it; only OpenCode's own native provider uses OpenCode's login instead.
+**Gemini is the exception** — it is never handed an LLM key (`GEMINI_API_KEY` /
+`GOOGLE_API_KEY` are filtered out of the guest) and authenticates through the
+Gemini CLI's own login, persisted under the sandbox home (`~/.gemini`).
+
+See [`.env.example`](.env.example) for the full list (timeouts, endpoint aliases,
+`OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) and the
+[Runtime LLM Facade design](docs/zh-CN/design/agent-compose-runtime-llm-facade.md)
+for how brokering works.
+
+## Deployment & configuration
+
+For a server deployment with published images:
 
 ```bash
 cp .env.example .env
-openssl rand -base64 24 # use this value for AUTH_PASSWORD
-openssl rand -hex 32    # use this value for AUTH_SECRET
-docker compose pull
-docker compose up -d
-# To also pull and start the web UI:
-docker compose --profile with-ui pull
-docker compose --profile with-ui up -d
+openssl rand -base64 24   # use for AUTH_PASSWORD
+openssl rand -hex 32      # use for AUTH_SECRET
+docker compose pull && docker compose up -d
+docker compose --profile with-ui up -d   # also start the web UI
 ```
 
-Edit `.env` before the first start. At minimum, replace `AUTH_PASSWORD` and
-`AUTH_SECRET`; enable the `with-ui` profile when you want the web UI, and set
-`AGENT_COMPOSE_HTTP_PORT` if port `80` is not suitable. Override
-`AGENT_COMPOSE_IMAGE`, `AGENT_COMPOSE_FRONTEND_IMAGE`, or `DEFAULT_IMAGE` to
-pin release tags or use a mirror/private registry. The frontend is released
-independently by `agent-compose-ui`; `AGENT_COMPOSE_FRONTEND_IMAGE` is used only
-when the `with-ui` profile is enabled.
+**[`.env.example`](.env.example) is the authoritative, fully commented
+configuration reference.** At minimum, review these before exposing a deployment:
 
-For local development, Docker Compose automatically loads
-`docker-compose.override.yml`, which builds the backend image from the local
-Dockerfile while keeping the same service topology. Use
-`docker compose up -d --build` when you want to rebuild the local backend image,
-or `docker compose --profile with-ui up -d --build` when you also want the web
-UI.
+- `AUTH_PASSWORD`, `AUTH_SECRET` — UI server login secrets (replace the examples).
+- `AGENT_COMPOSE_HTTP_PORT` — host port for the web UI / reverse proxy (`with-ui`).
+- `AGENT_COMPOSE_RUNTIME_BASE_URL` — guest-reachable daemon URL used for the LLM facade.
+- `RUNTIME_DRIVER` — default runtime driver.
 
-Upgrade notes for the UI server split:
+## Web UI
 
-- Upgrade `agent-compose` and `agent-compose-ui` together. The daemon no longer
-  serves browser auth/OAuth routes; the UI image now includes the Go UI server
-  that owns those routes and proxies daemon API/Jupyter traffic.
-- Move browser login settings (`AUTH_USERNAME`, `AUTH_PASSWORD`,
-  `AUTH_SECRET`, `AUTH_SESSION_TTL`, `OAUTH_*`) to the UI service environment.
-  Docker Compose already passes `.env` to `agent-compose-frontend` when the
-  `with-ui` profile is enabled.
-- Do not expose the daemon TCP API as the browser entrypoint. Browser
-  cookie/OAuth settings are not consumed by the daemon anymore; direct daemon
-  TCP access is for trusted networks or machine clients and should be protected
-  separately if enabled.
-- After changing runtime-reachable URLs or capability proxy settings such as
-  `AGENT_COMPOSE_RUNTIME_BASE_URL`, `CAP_GRPC_LISTEN`, or `CAP_GRPC_TARGET`,
-  restart the daemon and create new sandboxes so guest containers receive
-  the updated facade and capability environment.
+The web UI lives in a separate repository,
+[agent-compose-ui](https://github.com/chaitin/agent-compose-ui). It consumes the
+generated API client published as
+[`@chaitin-ai/agent-compose-client`](https://www.npmjs.com/package/@chaitin-ai/agent-compose-client),
+built from this repository's `proto/`. The daemon does not host the UI or browser
+login flows; the UI image runs nginx in front of a Go UI server that owns
+auth/OAuth and proxies API and Jupyter routes to the daemon.
 
-## Configuration
+## Security
 
-Copy `.env.example` to `.env`, edit the values for your environment, then run
-`docker compose up -d`. Add `--profile with-ui` to also start the web UI.
+The default configuration targets local development. Harden it before exposing a
+deployment to a network:
 
-Important variables include:
-
-- `AUTH_USERNAME`, `AUTH_PASSWORD`, `AUTH_SECRET`, `AUTH_SESSION_TTL`: UI server
-  password login settings. Replace the example password and secret before
-  exposing a deployment.
-- `AGENT_COMPOSE_HTTP_PORT`: host port for the web UI and reverse proxy when
-  the `with-ui` profile is enabled.
-- `AGENT_COMPOSE_IMAGE`, `AGENT_COMPOSE_FRONTEND_IMAGE`: Docker Compose service
-  images; the frontend image is used only with the `with-ui` profile.
-- `DEFAULT_IMAGE`, `DOCKER_DEFAULT_IMAGE`, `MICROSANDBOX_DEFAULT_IMAGE`: guest
-  image defaults.
-- `RUNTIME_DRIVER`: default runtime driver.
-- `OAUTH_*`: UI server OAuth login settings.
-- `LLM_API_ENDPOINT`, `LLM_API_PROTOCOL`, `LLM_API_KEY`, `OPENAI_API_KEY`,
-  `LLM_MODEL`, `LLM_TIMEOUT`: daemon-side OpenAI-family LLM settings for
-  `LLMService`, `scheduler.llm`, and runtime agent LLM facade bootstrap. These
-  values are not injected as provider keys into guest agent runtimes. Set
-  `LLM_API_PROTOCOL=chat_completions` for OpenAI-compatible chat completions
-  backends (aliases: `chat`, `chat_completion`).
-- `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_ENDPOINT`, `ANTHROPIC_API_KEY`,
-  `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`, `CLAUDE_MODEL`: daemon-side
-  Anthropic-family LLM facade bootstrap settings.
-- `AGENT_COMPOSE_RUNTIME_BASE_URL`: optional guest-reachable daemon base URL
-  used when generating runtime LLM facade configuration. Docker Compose
-  defaults this to `http://agent-compose:7410`; host-based Docker setups should
-  set it to a concrete host IP/name and port.
-- `SANDBOX_ROOT`: container path for sandbox metadata, state, workspaces, and
-  runtime files. The published image defaults this to `/data/sandboxes`.
-- `DOCKER_HOST_SANDBOX_ROOT`: host path for sandbox data bind-mounted into guest
-  containers. Docker Compose defaults this to `${PWD}/data/sandboxes`.
-- `CAP_GRPC_LISTEN`, `CAP_GRPC_TARGET`: required only when agents need to call
-  OctoBus gRPC capabilities. `CAP_GRPC_LISTEN` starts the agent-compose
-  capability proxy; `CAP_GRPC_TARGET` is the guest-reachable address injected
-  into new sandboxes. After changing either value, restart the daemon and create
-  a new sandbox.
-- `IMAGE_STORE_MODE`, `IMAGE_CACHE_ROOT`, `IMAGE_REGISTRY`,
-  `IMAGE_INSECURE_REGISTRIES`: image store and OCI cache settings.
-- `BOXLITE_HOME`, `BOXLITE_RUNTIME_DIR`, `BOX_ROOTFS_PATH`, `BOX_CACHE_TTL`:
-  BoxLite settings. `BOX_CACHE_TTL` no longer runs hidden startup GC; use
-  explicit `agent-compose cache prune --older-than ... --force` for cache
-  cleanup.
-- `BOX_DISK_SIZE_GB`: shared guest disk size for VM-type drivers (the boxlite
-  box disk and the microsandbox docker disk). It also defaults the microsandbox
-  bind mount quota. Default 6 GiB.
-- `DOCKER_HOME`: Docker runtime state directory.
-- `MICROSANDBOX_HOME`, `MICROSANDBOX_MSB_PATH`, `MICROSANDBOX_LIB_PATH`,
-  `MICROSANDBOX_BIND_QUOTA_GB`, `MICROSANDBOX_INSECURE_REGISTRIES`:
-  Microsandbox settings.
-- `GUEST_WORKSPACE`, `GUEST_STATE_ROOT`, `GUEST_RUNTIME_ROOT`,
-  `GUEST_LOG_ROOT`, `JUPYTER_GUEST_PORT`: guest paths and Jupyter port.
-- `WEBHOOK_BODY_LIMIT_BYTES`, `WORKSPACE_UPLOAD_LIMIT_BYTES`: request limits.
-
-### Agent providers
-
-Guest agent sandboxes run provider CLIs through the `agent-compose-runtime` CLI,
-provided by the `@chaitin-ai/agent-compose-runtime` npm package. Codex and Claude calls use the Runtime LLM Facade:
-provider keys stay in the daemon-side LLM provider configuration, while guest
-runtimes receive sandbox-scoped facade tokens and facade base URLs. LLM provider
-key names such as `LLM_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
-`ANTHROPIC_AUTH_TOKEN`, `GOOGLE_API_KEY`, and `GEMINI_API_KEY` are filtered from
-user-supplied runtime environment variables. Compatibility aliases such as
-`LLM_API_KEY` and `LLM_API_ENDPOINT` may still appear in the runtime, but they
-are daemon-managed facade values, not upstream provider credentials. Gemini and
-OpenCode still use their provider CLIs directly; OpenCode credentials depend on
-the selected OpenCode model provider.
-
-| Provider | Typical env vars | Notes |
-| --- | --- | --- |
-| `codex` | daemon LLM provider config; runtime receives `AGENT_COMPOSE_SANDBOX_TOKEN`, `LLM_API_KEY`, `LLM_API_ENDPOINT`, `OPENAI_BASE_URL`, and facade-token API key aliases | Uses Codex CLI/SDK in the guest image |
-| `claude` | daemon Anthropic-family provider config; runtime receives `AGENT_COMPOSE_SANDBOX_TOKEN`, `LLM_API_KEY`, `LLM_API_ENDPOINT`, `ANTHROPIC_BASE_URL`, and facade-token API key aliases | Uses Claude Code CLI in the guest image |
-| `gemini` | not yet routed through the LLM facade | Uses Gemini CLI in the guest image |
-| `opencode` | Provider-specific keys for the selected OpenCode model, for example `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` | Uses OpenCode CLI in the guest image |
-
-After changing guest runtime code or provider support, rebuild the guest image:
-
-```bash
-task image:agent-compose-guest
-```
-
-Create a new sandbox (or resume one) so the updated image and environment
-variables are picked up.
-
-> **Upgrade note (breaking for some Docker setups):** Because provider keys are
-> no longer passed through to guest runtimes, Codex/Claude now reach their LLM
-> upstream through the daemon facade and need a guest-reachable daemon URL. The
-> bundled `docker-compose.yml` sets
-> `AGENT_COMPOSE_RUNTIME_BASE_URL=http://agent-compose:7410` for you. If you run
-> the daemon directly on a host with the Docker driver and an
-> `HTTP_LISTEN=127.0.0.1:...` bind, the container cannot reach that loopback
-> address, so facade config is skipped and agent runs will have no working LLM
-> credentials. Set `AGENT_COMPOSE_RUNTIME_BASE_URL` to a concrete
-> host-reachable IP/name and port (for example `http://host.docker.internal:7410`).
-
-The Runtime LLM Facade design is documented in
-[`docs/zh-CN/design/agent-compose-runtime-llm-facade.md`](docs/zh-CN/design/agent-compose-runtime-llm-facade.md).
-
-### Chat Completions LLM Protocol
-
-Set `LLM_API_PROTOCOL=chat_completions` to use an OpenAI-compatible Chat
-Completions backend for daemon-side unary text generation. This path is used by
-`LLMService.Generate` and loader `scheduler.llm` calls.
-
-```env
-LLM_API_PROTOCOL=chat_completions
-LLM_API_ENDPOINT=https://api.example.com
-LLM_API_KEY=...
-LLM_MODEL=your-model
-```
-
-Compatible backends include DeepSeek, local OpenAI-compatible proxies
-(vLLM/Ollama), and similar Chat Completions endpoints.
-
-This does not create a workspace-capable agent sandbox and does not grant file,
-command, or MCP tool access.
-
-With `outputSchema`, `chat_completions` uses prompt guidance and
-`response_format: json_object` (not Responses API strict JSON Schema).
-
-## Security Notes
-
-The default configuration is designed for local development. Review and harden
-settings before exposing the deployment to a network.
-
-- Expose browser access through the agent-compose-ui server, not directly
-  through the daemon.
-- Set a stable, high-entropy `AUTH_SECRET` when enabling UI server
-  authentication.
-- Use HTTPS termination in production deployments.
-- `HTTP_LISTEN=0.0.0.0:7410` is an internal daemon API. Startup emits a warning
-  for non-loopback listeners; keep it behind container networking, reverse
-  proxies, VPNs, or equivalent controls.
-- Jupyter runs inside guest runtimes and is expected to be reached through the
-  agent-compose proxy. Do not expose guest Jupyter ports directly.
-- Runtime drivers may allow network access from guest workloads. Check driver
-  behavior before running untrusted code.
-- Treat Git credentials, uploaded workspaces, environment variables, and LLM API
-  keys as secrets.
+- Expose browser access through the agent-compose-ui server, not the daemon directly.
+- Set a stable, high-entropy `AUTH_SECRET`, and terminate HTTPS in production.
+- Keep the daemon TCP API (`HTTP_LISTEN`) behind container networking, a reverse proxy, or a VPN.
+- Do not expose guest Jupyter ports directly — reach them through the agent-compose proxy.
+- Treat Git credentials, uploaded workspaces, environment variables, and LLM API keys as secrets.
 
 See [SECURITY.md](SECURITY.md) for vulnerability reporting and hardening notes.
 
-## Build And Test
+## Build & test
 
 ```bash
 task lint
 task build
-task test
+task test          # or: task test:unit / task test:integration / task test:e2e
 ```
 
-Useful subcommands:
+Build guest and daemon images with `task image:agent-compose-guest` and
+`task image:agent-compose`. A BoxLite-enabled binary
+(`task build:agent-compose:boxlite`) is optional and requires BoxLite runtime
+artifacts. The JavaScript runtime components live under `runtime/`.
 
-```bash
-task test:unit
-task test:integration
-task test:e2e
-task image:agent-compose-guest
-task image:agent-compose
-```
-
-Runtime SDK:
-
-```bash
-cd runtime/agent-compose-runtime-sdk
-npm ci
-npm test
-```
-
-BoxLite-enabled binary builds are optional and require BoxLite runtime artifacts:
-
-```bash
-task build:agent-compose:boxlite
-```
-
-Scheduler runtime:
-
-```bash
-cd runtime/javascript
-npm ci
-npm run test:unit
-```
-
-## API Compatibility
-
-The daemon exposes both v1 and v2 Connect APIs.
-
-- v1 is the compatibility API for existing UI and clients and retains its
-  session-oriented wire shape.
-- v2 is the preferred path for newer CLI and project/run/sandbox/image
-  workflows.
-
-Protocol definitions live under `proto/`.
-
-## Related Documentation
+## Documentation
 
 - [Documentation index](docs/README.md)
-- [Chinese documentation](docs/zh-CN/README.md)
+- [Command line manual](docs/command-line-manual.md)
+- [Chinese documentation (中文文档)](docs/zh-CN/README.md)
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
 agent-compose is licensed under the [GNU Affero General Public License v3.0](LICENSE.txt).
+
 ## Community and Support
-Join the community to discuss Agent-compose usage, deployment, and development with other developers.
+
+Join the community to discuss agent-compose usage, deployment, and development with other developers.
+
 <table>
   <tr>
     <td align="center"><img src="https://github.com/user-attachments/assets/fcdbb42b-2e06-409e-b116-60544461fbc1" width="160" /><br/>WeChat Group</td>

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,232 +1,252 @@
 # agent-compose 中文文档
 
-agent-compose 是一个 daemon + CLI 形态的 agent/sandbox 控制面。daemon 负责持久化状态、scheduler、runtime 生命周期、Connect API 和 Jupyter 代理；CLI 负责读取本地 `agent-compose.yml`，连接 daemon，并执行 `up`、`run`、`logs`、`ps`、`down`、`image` 等操作。
+**agent-compose 是一个 daemon + CLI 形态的控制面，用于在隔离 sandbox 中运行 AI coding agent。** 你在 `agent-compose.yml` 里声明 agent，一个常驻 daemon 负责为每个 agent 构建、运行、调度并代理一个隔离的 runtime。
 
-当前项目正在准备首次公开发布，建议按 preview/experimental 项目使用。API、运行时打包、部署默认值和生产环境建议后续仍可能调整。
+> 公开预览阶段。API、运行时打包和部署默认值仍可能调整。适合实验、本地开发和预览部署，尚未达到稳定生产平台。
 
-英文首页见 [README.md](../../README.md)。
+英文首页见 [../../README.md](../../README.md)。
+
+## agent-compose 是什么？
+
+如果你了解 Docker Compose，这里的心智模型很类似：你声明的不是容器，而是 **agent**。每个 agent 选择一个 provider CLI —— `codex`、`claude`（Claude Code）、`gemini` 或 `opencode` —— daemon 给它一个带 workspace 的隔离 sandbox，然后按 prompt、shell 命令、定时或事件来运行它。真实的 provider API key 留在 daemon 上，不会进入 guest。
+
+你用 Compose 风格的 CLI（`up`、`run`、`ps`、`logs`、`down`）管理整个生命周期，一切由一个声明式文件驱动。
+
+具体能力：
+
+- **声明式 compose 模型**（`agent-compose.yml`），支持 `${ENV}` 插值。
+- **多 provider guest agent**：Codex、Claude Code、Gemini、OpenCode CLI。
+- **三种 runtime driver**：`docker`（默认）、`boxlite`（microVM）、`microsandbox`。
+- **scheduler**：`cron`、`interval`、`timeout`、`event` 四种 trigger，或内联 JavaScript scheduler 脚本。
+- **事件触发与 webhook**，支持事件驱动的 agent run。
+- **workspace** 从本地目录或 Git 仓库拉取。
+- **Runtime LLM Facade**，托管 LLM 凭据，使 provider key 不进入 guest 容器。
+- 每个 agent 可配 **MCP server、可复用 skill、具名 volume**。
+- **Jupyter 代理**，支持 notebook 风格的 guest runtime。
+- **v1/v2 Connect API** 与生成的 TypeScript client。
+
+## 工作原理
+
+**daemon** 是唯一的状态权威：负责持久化、scheduler 执行、runtime 生命周期、Connect/HTTP API 和 Jupyter 代理。**CLI** 是一个轻客户端 —— 读取本地 `agent-compose.yml`，做本地校验，再调用 daemon。compose 文件描述的是 *project 和 agent*，不是已经在跑的 sandbox。**Web UI** 是独立服务（[agent-compose-ui](https://github.com/chaitin/agent-compose-ui)），不由 daemon 托管。
+
+完整架构见 [design/agent-compose_design.md](design/agent-compose_design.md)。
 
 ## 快速开始
 
-完整 CLI 说明见 [agent-compose 命令行使用手册](command-line-manual.md)。
+### 方式 A —— 部署服务器（推荐）
 
-构建：
+一行安装脚本会用 Docker Compose 部署 agent-compose（含 Web UI），支持 Linux amd64/arm64：
 
 ```bash
-task build
+curl -fsSL https://github.com/chaitin/agent-compose/releases/latest/download/install.sh | bash
 ```
 
-启动 daemon：
+首次运行会生成 `admin` 密码并打印一次，之后通过打印出的 URL 使用 Web UI。安装选项（`--dir`、`--port`、`--upgrade`、使用镜像/私有 registry 等）见 [../../deploy/README.md](../../deploy/README.md)。
+
+### 方式 B —— 从源码构建（用于 CLI 工作流）
 
 ```bash
+task build                       # 产物在 ./build/agent-compose
+export PATH="$PWD/build:$PATH"   # 让 `agent-compose` 进入 PATH
 agent-compose daemon
 ```
 
-daemon 默认使用本地 Unix socket。需要本地 TCP 访问时可以设置：
+daemon 默认监听本地 Unix socket。需要本地 HTTP endpoint 时：
 
 ```bash
 HTTP_LISTEN=127.0.0.1:7410 agent-compose daemon
-```
-
-检查状态：
-
-```bash
-agent-compose status
 agent-compose --host http://127.0.0.1:7410 status
 ```
 
-准备 `agent-compose.yml`：
+### 运行第一个 agent
+
+在本地 daemon 运行的前提下（方式 B），创建 `agent-compose.yml`：
 
 ```yaml
 name: demo
+
 agents:
   reviewer:
     provider: codex
-    model: gpt-test
-    image: debian:bookworm-slim
-    scheduler:
-      triggers:
-        - name: hourly
-          cron: "0 * * * *"
-          prompt: "Review the current workspace state."
+    image: ghcr.io/chaitin/agent-compose-guest:latest
+    driver:
+      docker: {}
 ```
 
-应用并运行：
+然后驱动生命周期：
 
 ```bash
-agent-compose up
-agent-compose ps
+agent-compose up                                  # 把 project 应用到 daemon
+agent-compose ps                                  # 列出 project sandbox
 agent-compose run reviewer --prompt "Review this change"
 agent-compose logs --agent reviewer
-agent-compose down
+agent-compose down                                # 停止 sandbox、禁用 scheduler
 ```
 
-## 当前入口
-
-- `agent-compose daemon`：启动长期运行的 HTTP/Connect daemon。
-- `agent-compose up`：读取本地 `agent-compose.yml`，把 project 定义和 scheduler 应用到 daemon。
-- `agent-compose run <agent> --prompt "..."` / `--command "..."`：手动执行 prompt 或 shell command。
-- `agent-compose scheduler ls|trigger|inspect`：查看、执行或检查 project scheduler trigger。
-- `agent-compose logs`：查看 project run 日志。
-- `agent-compose ps`：查看 project agent、latest run 和 running sandbox 状态。
-- `agent-compose down`：禁用 daemon 管理的 scheduler，并停止该 project 的 running sandboxes。
-- `agent-compose images|pull|rmi|image inspect`：管理 daemon 侧 image store。
-- `agent-compose cache ls|inspect|prune|rm`：查看并显式清理 daemon runtime cache；`prune` 和 `rm` 默认 dry-run，只有传 `--force` 才会删除。
+更多可运行示例（cron、timeout、scheduler 脚本）见 [../../examples/agent-compose/](../../examples/agent-compose/)。
 
 ## Compose 配置
 
-顶层字段：
+**顶层字段：** `name`、`variables`、`agents`、`mcps`、`volumes`、`network`。
 
-- `name`：project 名称；未设置时使用 compose 文件所在目录名。
-- `variables`：project 级变量，支持 `${ENV_NAME}` 环境变量插值。
-- `workspace`：project 默认 workspace，当前支持 `local` 和 `git` provider。
-- `agents`：agent 定义 map，key 是 agent 名称。
-- `network.mode`：当前只支持 `default`。
+**agent 常用字段：** `provider`、`model`、`system_prompt`、`image`、`driver`、
+`env`（scalar 或 `{ value, secret }`）、`workspace`、`scheduler`、`mcps`、`skills`、`volumes`。
 
-agent 常用字段：
+为 agent 从本地路径（`provider: local`）或 Git 仓库（`provider: git`）配置 workspace：
 
-- `provider` / `model` / `system_prompt`：guest agent 配置（`provider` 选择 guest CLI runner；`model` 会传给支持显式模型选择的 provider runtime）。非空 `system_prompt` 在运行时生效，并作为 Agent Identity 层注入 provider system/developer 指令。目前支持 `codex`、`claude`、`gemini`、`opencode`。daemon 侧 LLM 调用（`LLMService`、`scheduler.llm`）使用 `LLM_MODEL`，不是 compose 里的 agent `model`。
-- `image`：guest 镜像引用；为空时使用 driver 对应默认镜像。
-- `driver`：每个 agent 可选择一个 runtime，支持 `boxlite`、`docker`、`microsandbox`。
-- `env`：agent 级环境变量，支持 scalar 或 `{ value, secret }` 形状。
-- `workspace`：覆盖 project 默认 workspace。
-- `scheduler.enabled`：默认 `true`。
-- `scheduler.triggers`：支持 `cron`、`interval`、`timeout`、`event` 四种 trigger。
-- `scheduler.script`：内联 JavaScript scheduler 脚本。`scheduler.script` 和 `scheduler.triggers` 二选一。
+```yaml
+agents:
+  reviewer:
+    workspace:
+      provider: git
+      url: https://github.com/example/repo.git
+      branch: main
+```
+
+添加定时或事件驱动的 run。`scheduler.triggers` 与内联 `scheduler.script` 在同一 scheduler 中二选一：
+
+```yaml
+agents:
+  reviewer:
+    scheduler:
+      enabled: true
+      triggers:
+        - name: hourly-review
+          cron: "0 * * * *"
+          prompt: "Review the current project state and summarize changes."
+```
+
+完整字段说明见[命令行使用手册](command-line-manual.md)。
+
+## CLI 概览
+
+| 命令 | 用途 |
+| --- | --- |
+| `agent-compose daemon` | 启动 HTTP/Connect daemon。 |
+| `agent-compose up` | 读取 `agent-compose.yml` 并应用 project。 |
+| `agent-compose run <agent> --prompt/--command` | 以 agent 身份执行 prompt 或 shell 命令。 |
+| `agent-compose exec <sandbox>` | 在运行中的 sandbox 内执行命令或 prompt。 |
+| `agent-compose ps` / `stats` | 列出 project sandbox / 查看 sandbox 资源统计。 |
+| `agent-compose logs` | 查看 project run 日志。 |
+| `agent-compose scheduler ls\|trigger\|inspect` | 查看、执行或检查 scheduler trigger。 |
+| `agent-compose sandbox ls\|stop\|resume\|rm\|prune` | 管理 project sandbox。 |
+| `agent-compose images\|pull\|build\|rmi\|inspect` | 管理 daemon 镜像并构建 agent 镜像。 |
+| `agent-compose volume ls\|create\|inspect\|rm\|prune` | 管理 daemon volume。 |
+| `agent-compose cache ls\|inspect\|prune\|rm` | 查看并清理 daemon runtime cache。 |
+| `agent-compose down` | 禁用受管 scheduler 并停止 sandbox。 |
+| `agent-compose status` | 查看 daemon 状态。 |
+
+常用全局参数：`--file, -f`（指定 compose 文件）、`--project-name`、`--json`
+（脚本用的稳定 JSON 输出）、`--host` / `AGENT_COMPOSE_HOST`（连接 TCP daemon）、
+`AGENT_COMPOSE_SOCKET`（Unix socket 路径）。完整参考见[命令行使用手册](command-line-manual.md)。
 
 ## Runtime Driver
 
-支持的 runtime driver：
+- **`docker`**（默认）：使用 Docker 容器运行 guest，需要可用的 Docker daemon。
+- **`boxlite`**：使用 BoxLite runtime artifact 以 microVM 运行 guest。
+- **`microsandbox`**：使用 Microsandbox VM runtime 运行 guest。
 
-- `docker`：默认 driver，使用 Docker daemon。
-- `boxlite`：使用本仓库准备的 BoxLite runtime artifact 和 guest image。
-- `microsandbox`：使用 Microsandbox runtime。
+镜像处理由 `IMAGE_STORE_MODE` 选择（`auto` / `docker` / `oci`，其中 `oci` 使用无 daemon 的镜像缓存）。新 sandbox 使用 `DEFAULT_IMAGE` 指定的镜像；自带的 `.env.example` 和安装脚本将其设为 `ghcr.io/chaitin/agent-compose-guest:latest`，该镜像内置 agent runtime 和各 provider CLI。
 
-默认镜像为 `debian:bookworm-slim`，可通过 `DEFAULT_IMAGE`、`DOCKER_DEFAULT_IMAGE`、`MICROSANDBOX_DEFAULT_IMAGE` 覆盖。
+## Agent Provider
 
-## 前端
+每个 agent 设置一个 `provider`，决定 sandbox 内运行的 CLI：
 
-Web UI 在独立仓库 [agent-compose-ui](https://github.com/chaitin/agent-compose-ui)。它通过已发布的 [`@chaitin-ai/agent-compose-client`](https://www.npmjs.com/package/@chaitin-ai/agent-compose-client) 包消费 API 客户端——该包由本仓库的 `proto/` 经 `proto-client/` 生成发布。
+| Provider | 运行 |
+| --- | --- |
+| `codex` | Codex CLI |
+| `claude` | Claude Code CLI |
+| `gemini` | Gemini CLI |
+| `opencode` | OpenCode CLI |
 
-daemon 不托管 Web UI 或浏览器登录流程。前端仓库构建一个镜像（`ghcr.io/chaitin/agent-compose-ui`），在 nginx 前置后运行 agent-compose-ui server：nginx 托管构建后的前端，UI server 处理浏览器认证/OAuth，并把 API、Jupyter proxy 路由反向代理到 daemon。仓库根目录的 `docker-compose.yml` 直接引用该已发布镜像，并作为默认部署入口。
+LLM 凭据只在 daemon（`.env`）配置一次，而不是每个 guest 各配。对 Codex、Claude 和 OpenCode，daemon 的 **Runtime LLM Facade** 给每个 sandbox 一个受限的 scoped token，而不是你的真实 API key，因此 provider key 不会进入 guest。
 
-使用已发布容器镜像部署到服务器：
+按你的 agent 使用的后端家族设置变量。**OpenAI 家族**（Codex，以及 daemon 自身的 `LLMService` 和 scheduler LLM 调用）：
+
+```env
+LLM_API_ENDPOINT=https://api.openai.com
+LLM_API_PROTOCOL=responses    # DeepSeek / vLLM / Ollama 用 chat_completions
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-...
+```
+
+**Anthropic 家族**（Claude）：
+
+```env
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_MODEL=claude-...
+```
+
+设置 `LLM_API_PROTOCOL=chat_completions` 可对接任意 OpenAI 兼容 endpoint（DeepSeek、vLLM、Ollama）。
+
+**各 provider 说明。** OpenCode 从 agent 的 `model`（`provider/model`，如 `anthropic/…` 或 `openai/…`）选择上游家族并获得对应的 facade token；只有 OpenCode 自带的原生 provider 才走 OpenCode 自身登录。**Gemini 是例外** —— 它不会拿到任何 LLM key（`GEMINI_API_KEY` / `GOOGLE_API_KEY` 会从 guest 中过滤），而是通过 Gemini CLI 自身登录，凭据持久化在 sandbox home（`~/.gemini`）。
+
+完整变量（超时、endpoint 别名、`OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN` 等）见 [../../.env.example](../../.env.example)；facade 的托管机制见 [design/agent-compose-runtime-llm-facade.md](design/agent-compose-runtime-llm-facade.md)。
+
+## 部署与配置
+
+使用已发布镜像部署到服务器：
 
 ```bash
 cp .env.example .env
-openssl rand -base64 24 # 将输出写入 AUTH_PASSWORD
-openssl rand -hex 32    # 将输出写入 AUTH_SECRET
-docker compose pull
-docker compose up -d
-# 如需同时拉取并启动 Web UI：
-docker compose --profile with-ui pull
-docker compose --profile with-ui up -d
+openssl rand -base64 24   # 用于 AUTH_PASSWORD
+openssl rand -hex 32      # 用于 AUTH_SECRET
+docker compose pull && docker compose up -d
+docker compose --profile with-ui up -d   # 同时启动 Web UI
 ```
 
-首次启动前编辑 `.env`。至少替换 `AUTH_PASSWORD` 和 `AUTH_SECRET`；需要 Web UI 时启用 `with-ui` profile，如果不能使用宿主机 `80` 端口，修改 `AGENT_COMPOSE_HTTP_PORT`。本地开发时，Docker Compose 会自动加载 `docker-compose.override.yml`，使用本地 Dockerfile 构建后端镜像；需要重建时执行 `docker compose up -d --build`，需要同时启动 Web UI 时执行 `docker compose --profile with-ui up -d --build`。
+**[../../.env.example](../../.env.example) 是权威的、带完整注释的配置参考。** 对外部署前至少检查这些：
 
-本次 UI server 拆分的升级注意事项：
+- `AUTH_PASSWORD`、`AUTH_SECRET` —— UI server 登录 secret（务必替换示例值）。
+- `AGENT_COMPOSE_HTTP_PORT` —— 启用 `with-ui` 时 Web UI / 反向代理的宿主机端口。
+- `AGENT_COMPOSE_RUNTIME_BASE_URL` —— guest 可达的 daemon URL，用于 LLM facade。
+- `RUNTIME_DRIVER` —— 默认 runtime driver。
 
-- `agent-compose` 和 `agent-compose-ui` 需要一起升级。daemon 不再提供浏览器 auth/OAuth 路由；新的 UI 镜像内置 Go UI server，由它处理这些路由，并代理 daemon API/Jupyter 流量。
-- 浏览器登录配置（`AUTH_USERNAME`、`AUTH_PASSWORD`、`AUTH_SECRET`、`AUTH_SESSION_TTL`、`OAUTH_*`）归属 UI service 环境。启用 `with-ui` profile 时，Docker Compose 已经把 `.env` 传给 `agent-compose-frontend`。
-- 不要把 daemon TCP API 当作浏览器入口直接暴露。浏览器 cookie/OAuth 配置不再被 daemon 消费；直接访问 daemon TCP 只适用于可信网络或机器客户端，启用时应独立做好访问保护。
-- 修改 runtime 内可访问地址或 capability proxy 配置后，例如 `AGENT_COMPOSE_RUNTIME_BASE_URL`、`CAP_GRPC_LISTEN`、`CAP_GRPC_TARGET`，需要重启 daemon 并新建 agent sandbox，让 guest 容器拿到更新后的 facade/capability 环境。
+## Web UI
 
-## 配置
-
-复制 `.env.example` 为 `.env`，按部署环境修改后执行 `docker compose up -d`。如需同时启动 Web UI，添加 `--profile with-ui`。
-
-常用环境变量：
-
-- `AUTH_USERNAME`、`AUTH_PASSWORD`、`AUTH_SECRET`、`AUTH_SESSION_TTL`：UI server 密码登录设置。对外部署前应替换示例密码和 secret。
-- `AGENT_COMPOSE_HTTP_PORT`：启用 `with-ui` profile 时，Web UI 和反向代理发布到宿主机的端口。
-- `AGENT_COMPOSE_IMAGE`、`AGENT_COMPOSE_FRONTEND_IMAGE`：Docker Compose 服务镜像；前端镜像仅在启用 `with-ui` profile 时使用。
-- `DEFAULT_IMAGE`、`DOCKER_DEFAULT_IMAGE`、`MICROSANDBOX_DEFAULT_IMAGE`：guest 镜像默认值。
-- `RUNTIME_DRIVER`：默认 runtime driver。
-- `OAUTH_*`：UI server OAuth 登录设置。
-- `LLM_API_ENDPOINT`、`LLM_API_PROTOCOL`、`LLM_API_KEY`、`OPENAI_API_KEY`、`LLM_MODEL`、`LLM_TIMEOUT`：daemon 侧 OpenAI family LLM 配置，供 `LLMService`、`scheduler.llm` 和 runtime agent LLM facade bootstrap 使用。这些值不会作为 provider key 注入 guest agent runtime。对接 OpenAI 兼容 Chat Completions 后端时设置 `LLM_API_PROTOCOL=chat_completions`。
-- `ANTHROPIC_BASE_URL`、`ANTHROPIC_API_ENDPOINT`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_MODEL`、`CLAUDE_MODEL`：daemon 侧 Anthropic family LLM facade bootstrap 配置。
-- `AGENT_COMPOSE_RUNTIME_BASE_URL`：可选的 runtime 内可访问 daemon base URL，用于生成 Runtime LLM Facade 配置。Docker Compose 默认使用 `http://agent-compose:7410`；宿主机 Docker 场景应配置具体的宿主机 IP/名称和端口。
-- `SANDBOX_ROOT`：容器内 sandbox metadata、state、workspace 和 runtime 文件路径。发布镜像默认使用 `/data/sandboxes`。
-- `DOCKER_HOST_SANDBOX_ROOT`：guest 容器 bind mount 使用的宿主机 sandbox 数据路径。Docker Compose 默认使用 `${PWD}/data/sandboxes`。
-- `CAP_GRPC_LISTEN`、`CAP_GRPC_TARGET`：仅在 Agent 需要调用 OctoBus gRPC capability 时必须配置。`CAP_GRPC_LISTEN` 启动 agent-compose capability proxy；`CAP_GRPC_TARGET` 是注入新 sandbox 的 guest 可达地址。修改后需要重启 daemon 并新建 sandbox。
-
-### Agent Provider
-
-Guest agent sandbox 在 guest 容器内通过 `agent-compose-runtime` CLI 运行 provider CLI；该 CLI 由 `@chaitin-ai/agent-compose-runtime` npm 包提供。Codex 和 Claude 通过 Runtime LLM Facade 调用：真实 provider key 保存在 daemon 侧 LLM provider 配置中，runtime 只拿 sandbox-scoped facade token 和 facade base URL。`LLM_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、`GOOGLE_API_KEY`、`GEMINI_API_KEY` 等 provider key 名称会从用户提供的 runtime env 中过滤。兼容别名 `LLM_API_KEY`、`LLM_API_ENDPOINT` 仍可能出现在 runtime 中，但它们是 daemon 写入的 facade 值，不是上游 provider 凭据。Gemini 和 OpenCode 仍直接使用各自 provider CLI；OpenCode 凭据取决于所选 OpenCode model provider。
-
-| Provider | 典型环境变量 | 说明 |
-| --- | --- | --- |
-| `codex` | daemon LLM provider 配置；runtime 获取 `AGENT_COMPOSE_SANDBOX_TOKEN`、`LLM_API_KEY`、`LLM_API_ENDPOINT`、`OPENAI_BASE_URL` 和 facade-token API key aliases | 使用 guest 镜像中的 Codex CLI/SDK |
-| `claude` | daemon Anthropic family provider 配置；runtime 获取 `AGENT_COMPOSE_SANDBOX_TOKEN`、`LLM_API_KEY`、`LLM_API_ENDPOINT`、`ANTHROPIC_BASE_URL` 和 facade-token API key aliases | 使用 guest 镜像中的 Claude Code CLI |
-| `gemini` | 暂未接入 LLM facade | 使用 guest 镜像中的 Gemini CLI |
-| `opencode` | 取决于所选 OpenCode model provider，例如 `ANTHROPIC_API_KEY` 或 `OPENAI_API_KEY` | 使用 guest 镜像中的 OpenCode CLI |
-
-修改 guest runtime 代码或 provider 支持后，需重建 guest 镜像：
-
-```bash
-task image:agent-compose-guest
-```
-
-创建新 sandbox（或 resume 已有 sandbox）以加载更新后的镜像和环境变量。
-
-> **升级注意（部分 Docker 部署存在破坏性变更）：** provider key 不再透传进 guest runtime，Codex/Claude 改为通过 daemon facade 访问上游 LLM，需要一个 runtime 内可达的 daemon URL。自带的 `docker-compose.yml` 已默认设置 `AGENT_COMPOSE_RUNTIME_BASE_URL=http://agent-compose:7410`。如果你在宿主机上直接运行 daemon（Docker driver）且 `HTTP_LISTEN=127.0.0.1:...`，容器无法访问该 loopback 地址，facade 配置会被跳过，agent run 将没有可用的 LLM 凭据。此时需要把 `AGENT_COMPOSE_RUNTIME_BASE_URL` 设为宿主机可达的具体 IP/名称和端口（例如 `http://host.docker.internal:7410`）。
-
-Runtime LLM Facade 设计见 [design/agent-compose-runtime-llm-facade.md](design/agent-compose-runtime-llm-facade.md)。
-
-### Chat Completions LLM 协议
-
-设置 `LLM_API_PROTOCOL=chat_completions`（别名 `chat`、`chat_completion`）后，daemon 侧单次文本生成（`LLMService.Generate`、`scheduler.llm`）可走 OpenAI 兼容 Chat Completions 后端：
-
-```env
-LLM_API_PROTOCOL=chat_completions
-LLM_API_ENDPOINT=https://api.example.com
-LLM_API_KEY=...
-LLM_MODEL=your-model
-```
-
-兼容后端包括 DeepSeek、本地 OpenAI 兼容代理（vLLM/Ollama）等 Chat Completions endpoint。
-
-该路径不会创建具备 workspace 能力的 agent sandbox，也不提供文件、命令或 MCP 工具访问。
-
-使用 `outputSchema` 时，`chat_completions` 通过 prompt 引导并设置 `response_format: json_object`，不等价于 Responses API 的 strict JSON Schema。
+Web UI 在独立仓库 [agent-compose-ui](https://github.com/chaitin/agent-compose-ui)。它消费已发布的 API client [`@chaitin-ai/agent-compose-client`](https://www.npmjs.com/package/@chaitin-ai/agent-compose-client)（由本仓库 `proto/` 生成）。daemon 不托管 UI 或浏览器登录流程；UI 镜像用 nginx 前置一个 Go UI server，由后者处理 auth/OAuth 并把 API、Jupyter 路由代理到 daemon。
 
 ## 安全提醒
 
-默认配置面向本地开发。公开部署前需要审查并加固：
+默认配置面向本地开发。对外部署前请加固：
 
-- 浏览器入口应通过启用 `with-ui` profile 后的 agent-compose-ui server 暴露。
-- 启用 UI 登录时设置稳定、高熵的 `AUTH_SECRET`。
-- 生产环境建议使用 HTTPS 终止。
-- `HTTP_LISTEN=0.0.0.0:7410` 是 daemon 内部 TCP API；监听非 loopback 地址时会输出强警告，应依赖容器网络、反向代理或其他网络控制避免公网直连。
-- Jupyter 访问应通过 agent-compose proxy，不应直接暴露 guest Jupyter 端口。
-- 对不可信 workload，需要额外审查 runtime driver 的隔离和网络访问行为。
+- 浏览器入口通过 agent-compose-ui server 暴露，不要直连 daemon。
+- 设置稳定、高熵的 `AUTH_SECRET`；生产环境使用 HTTPS 终止。
+- daemon TCP API（`HTTP_LISTEN`）应置于容器网络、反向代理或 VPN 之后。
+- 不要直接暴露 guest Jupyter 端口 —— 通过 agent-compose proxy 访问。
+- 把 Git 凭据、上传的 workspace、环境变量和 LLM API key 都当作 secret。
 
-更多说明见 [SECURITY.md](../../SECURITY.md)。
+更多说明见 [../../SECURITY.md](../../SECURITY.md)。
 
-## 构建和测试
+## 构建与测试
 
 ```bash
 task lint
 task build
-task test
+task test          # 或：task test:unit / task test:integration / task test:e2e
 ```
 
-相关文档：
+用 `task image:agent-compose-guest` 和 `task image:agent-compose` 构建 guest 和 daemon 镜像。启用 BoxLite 的二进制（`task build:agent-compose:boxlite`）为可选，需要 BoxLite runtime artifact。JavaScript runtime 组件在 `runtime/` 下。
+
+## 文档
 
 - [英文文档索引](../README.md)
 - [命令行使用手册](command-line-manual.md)
 - [架构说明](design/agent-compose_design.md)
-- [CLI 当前设计](design/agent-compose-cli-improvement-plan.md)
-- [Agent system prompt（Phase 1）](design/agent_system_prompt_design.md)
-- [Runtime contract](design/agent-compose-runtime_contract.md)
-- [OpenCode CLI Provider 支持](design/opencode_cli_support.md)
-- [Webhook design](design/webhook_design.md)
-- [Webhook queue design](design/webhook_queue_design.md)
-- [Loader script API](../../examples/scheduler-script/README.md)
 
-##  社区与支持
-欢迎加入技术社区，与更多开发者交流 Agent-copose 的使用、部署和开发经验。
+## 贡献
+
+欢迎贡献 —— 见 [../../CONTRIBUTING.md](../../CONTRIBUTING.md)。
+
+## 许可
+
+agent-compose 使用 [GNU Affero General Public License v3.0](../../LICENSE.txt) 授权。
+
+## 社区与支持
+
+欢迎加入技术社区，与更多开发者交流 agent-compose 的使用、部署和开发经验。
+
 <table>
   <tr>
     <td align="center"><img src="https://github.com/user-attachments/assets/fcdbb42b-2e06-409e-b116-60544461fbc1" width="160" /><br/>微信交流群</td>


### PR DESCRIPTION
## What

Rewrites the English `README.md` and syncs `docs/zh-CN/README.md` into a shorter, newcomer-oriented landing page. The goal was a doc that answers **what agent-compose is** and **how to use it** up front, and moves exhaustive reference material (full env-var list, driver internals, UI-split upgrade notes) out to `.env.example` and the design docs.

- ~500-line reference-manual README → lean landing page (~310 lines).
- Uses the "Docker Compose for AI agents" analogy as explanation, not marketing.
- Text only (no images/diagrams), English primary with the Chinese README kept in sync.

## Fact-check against current code

Every factual claim was verified against source; corrected drift includes:

- **Compose schema**: dropped stale singular top-level `workspace`; `driver` shown as a nested object (`driver: { docker: {} }`); added `mcps`/`skills`/`volumes` agent fields.
- **CLI**: removed the now-deprecated `image` subcommand; table now uses `images|pull|build|rmi|inspect` and adds `exec`, `stats`, `volume`, `build`.
- **Default image**: the shipped `.env.example`/installer set `DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest` (the previously-documented `debian:bookworm-slim` is only the code fallback when unset).
- **LLM providers**: the Runtime LLM Facade now covers **codex, claude, and opencode**; **gemini** is the exception — its API keys are filtered out and it authenticates via the Gemini CLI's own persisted login. Added concrete daemon-side LLM env-var configuration.
- **Quick start**: the installer is browser-driven; the CLI loop is the from-source path (`task build` outputs to `./build/agent-compose`).

All relative links in both READMEs verified to resolve.

## Notes

- Docs-only change; no code touched.
- `docs/zh-CN/README.md` mirrors the new English structure and the same corrected facts.