### PR TITLE
runtime: bump packages to 0.6.0

### DIFF
--- a/runtime/agent-compose-runtime-sdk/package-lock.json
+++ b/runtime/agent-compose-runtime-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime-sdk",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "license": "LGPL-3.0-only",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/runtime/agent-compose-runtime-sdk/package.json
+++ b/runtime/agent-compose-runtime-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Node.js SDK for scripts running inside an agent-compose guest runtime.",
   "license": "LGPL-3.0-only",
   "type": "module",

--- a/runtime/javascript/package-lock.json
+++ b/runtime/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.141",

--- a/runtime/javascript/package.json
+++ b/runtime/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Guest-side runtime CLI for agent-compose agent sessions.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## What

Bumps both runtime npm packages from `0.4.0` to `0.6.0`:

- `runtime/javascript` → `@chaitin-ai/agent-compose-runtime`
- `runtime/agent-compose-runtime-sdk` → `@chaitin-ai/agent-compose-runtime-sdk`

Both `package.json` and `package-lock.json` are updated for each. The two package versions are kept identical, which `.github/workflows/publish-runtime.yml` requires (it fails the release if they diverge).

## Release step (after merge)

This PR only lands the version bump. To actually publish to npm, tag the merged commit:

```bash
git tag runtime-v0.6.0
git push origin runtime-v0.6.0
```

The `publish-runtime` workflow then verifies `tag version == package version`, builds/tests, and publishes both packages with provenance.

## Notes

- No code changes — version metadata only.