### PR TITLE
fix(runtime): preserve Codex transcript turn boundaries

### DIFF
--- a/runtime/javascript/src/interactive.ts
+++ b/runtime/javascript/src/interactive.ts
@@ -28,7 +28,9 @@ export class UnsupportedProviderError extends Error {
 
 export class CodexInteractiveSession {
   private readonly runner: CodexRunner;
+  private readonly writer: BufferedTextWriter;
   private readonly result: AgentResult;
+  private turnCount = 0;
   private thread?: {
     id?: string | null;
     runStreamed(input: string, options?: unknown): Promise<{ events: AsyncIterable<unknown> }>;
@@ -38,7 +40,8 @@ export class CodexInteractiveSession {
     private readonly options: RunnerOptions,
     private readonly emit: EmitInteractiveFrame,
   ) {
-    this.runner = new CodexRunner(options, new BufferedTextWriter());
+    this.writer = new BufferedTextWriter();
+    this.runner = new CodexRunner(options, this.writer);
     this.result = {
       provider: "codex",
       threadId: "",
@@ -74,6 +77,10 @@ export class CodexInteractiveSession {
     if (!this.thread) {
       throw new Error("stream has not been started");
     }
+    if (this.turnCount > 0) {
+      this.writer.beginTurn();
+    }
+    this.turnCount++;
     const { events } = await this.thread.runStreamed(
       message,
       this.options.outputSchema ? { outputSchema: this.options.outputSchema } : undefined,
@@ -121,6 +128,16 @@ class BufferedTextWriter implements TextWriter {
 
   line(text = ""): void {
     this.write(text.endsWith("\n") ? text : `${text}\n`);
+  }
+
+  beginTurn(): void {
+    if (this.chunks.length === 0) {
+      return;
+    }
+    const last = this.chunks[this.chunks.length - 1] || "";
+    if (!last.endsWith("\n")) {
+      this.chunks.push("\n");
+    }
   }
 
   transcript(): string {

--- a/runtime/javascript/test/runtime.e2e.test.ts
+++ b/runtime/javascript/test/runtime.e2e.test.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { EventEmitter } from "node:events";
-import { Readable } from "node:stream";
+import { Readable, Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { createProgram } from "../src/cli.js";
 import { runExecCommand } from "../src/command.js";
 import { COMMAND_RESULT_PREFIX, RESULT_PREFIX } from "../src/constants.js";
+import { runStreamCommand } from "../src/stream.js";
 import { captureStdio, withTempSession } from "./helpers.js";
 
 const codexMockState = vi.hoisted(() => ({
@@ -121,6 +122,38 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 describe("runtime JavaScript E2E", () => {
+  it("preserves turn boundaries across interactive Codex messages", async () => {
+    await withTempSession(async (root) => {
+      let output = "";
+      const stdout = new Writable({
+        write(chunk, _encoding, callback) {
+          output += chunk.toString();
+          callback();
+        },
+      });
+      const frame = (seq: number, type: string, fields: Record<string, unknown> = {}) =>
+        JSON.stringify({ v: 1, seq, type, ...fields }) + "\n";
+
+      await runStreamCommand({
+        stdin: Readable.from([
+          frame(0, "start", { provider: "codex", stateRoot: path.join(root, "state") }),
+          frame(1, "human_message", { message: "first" }),
+          frame(2, "human_message", { message: "second" }),
+          frame(3, "eof"),
+        ]),
+        stdout,
+      });
+
+      const frames = output.trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+      expect(frames.at(-1)).toMatchObject({
+        type: "result",
+        threadId: "e2e-codex-thread",
+        stopReason: "eof",
+        transcript: '{"input":"first"}\n{"input":"second"}',
+      });
+    });
+  });
+
   it("runs a production-like command workflow through request and artifact files", async () => {
     await withTempSession(async (root) => {
       const workspace = path.join(root, "workspace");

--- a/runtime/javascript/test/stream.test.ts
+++ b/runtime/javascript/test/stream.test.ts
@@ -104,6 +104,7 @@ describe("runStreamCommand", () => {
         threadId: "thread-1",
         stopReason: "eof",
         finalText: "answer 2",
+        transcript: "answer 1\nanswer 2",
       });
       expect(parseOutput(stdout.text)).toHaveLength(8);
     });


### PR DESCRIPTION
## Summary

  Preserve boundaries between consecutive Codex interactive turns in the runtime transcript.

  The interactive session now keeps its buffered text writer and inserts a newline before a subsequent turn when the previous output did not end with one. This
  prevents output from adjacent turns from being concatenated while avoiding redundant separators when a newline is already present.

  ## Testing

  - `npm test`
    - 16 test files passed
    - 143 tests passed
  - `npm run typecheck`
  - `git diff --check origin/main..HEAD`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No documentation update is required because this is an internal transcript formatting fix
  with no configuration or interface changes.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.