### PR TITLE
fix(runs): preserve prompt transcript boundaries

### DIFF
--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -961,14 +961,11 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 				promptTransition = nextTransition
 			}
 		case driverpkg.RuntimeOutputStderr:
-			chunk := domain.ExecChunk{Text: string(frame.Data), Stream: domain.StdioStderr}
-			offset, err := appendProjectRunLogChunk(logsPath, chunk)
-			if err != nil {
+			if err := projector.AppendStderr(string(frame.Data)); err != nil {
 				transition.ExitCode = 1
 				transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 				return transition, err
 			}
-			c.publishRunLogChunk(run.RunID, chunk, offset)
 			if err := send(runAttachOutputResponse(frame.Data, agentcomposev2.StdioStream_STDIO_STREAM_STDERR, false)); err != nil {
 				transition.ExitCode = 1
 				transition.Error = fmt.Sprintf("agent execution failed: %v", err)
@@ -1380,14 +1377,16 @@ func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInp
 }
 
 type promptAttachProjector struct {
-	run        domain.ProjectRunRecord
-	sandbox    *domain.Sandbox
-	logsPath   string
-	runLogs    *RunLogHub
-	mu         sync.Mutex
-	buffer     []byte
-	itemTexts  map[string]string
-	loggedText string
+	run                domain.ProjectRunRecord
+	sandbox            *domain.Sandbox
+	logsPath           string
+	runLogs            *RunLogHub
+	mu                 sync.Mutex
+	buffer             []byte
+	itemTexts          map[string]string
+	loggedText         string
+	hasLoggedText      bool
+	logEndsWithNewline bool
 }
 
 func newPromptAttachProjector(run domain.ProjectRunRecord, sandbox *domain.Sandbox, logsPath string, hub *RunLogHub) *promptAttachProjector {
@@ -1524,7 +1523,7 @@ func (p *promptAttachProjector) appendLogText(text string) error {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if err := p.appendLogChunkLocked(text); err != nil {
+	if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text}); err != nil {
 		return err
 	}
 	p.loggedText += text
@@ -1542,14 +1541,14 @@ func (p *promptAttachProjector) appendLogFinalText(finalText string) error {
 		if text == "" {
 			return nil
 		}
-		if err := p.appendLogChunkLocked(text); err != nil {
+		if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text}); err != nil {
 			return err
 		}
 		p.loggedText += text
 		return nil
 	}
 	if p.loggedText == "" {
-		if err := p.appendLogChunkLocked(finalText); err != nil {
+		if err := p.appendLogChunkLocked(domain.ExecChunk{Text: finalText}); err != nil {
 			return err
 		}
 		p.loggedText = finalText
@@ -1559,27 +1558,43 @@ func (p *promptAttachProjector) appendLogFinalText(finalText string) error {
 
 func (p *promptAttachProjector) AppendHumanMessage(message string) error {
 	text := promptAttachHumanLogText(message)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if text != "" {
+		if p.hasLoggedText && !p.logEndsWithNewline {
+			text = "\n" + text
+		}
+		if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *promptAttachProjector) AppendStderr(text string) error {
 	if text == "" {
 		return nil
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.appendLogChunkLocked(text)
+	return p.appendLogChunkLocked(domain.ExecChunk{Text: text, Stream: domain.StdioStderr})
 }
 
-func (p *promptAttachProjector) appendLogChunkLocked(text string) error {
-	chunk := domain.ExecChunk{Text: text}
+func (p *promptAttachProjector) appendLogChunkLocked(chunk domain.ExecChunk) error {
 	offset, err := appendProjectRunLogChunk(p.logsPath, chunk)
 	if err != nil {
 		return err
+	}
+	if chunk.Text != "" {
+		p.hasLoggedText = true
+		p.logEndsWithNewline = strings.HasSuffix(chunk.Text, "\n")
 	}
 	publishRunLogChunk(p.runLogs, p.run.RunID, chunk, offset)
 	return nil
 }
 
 func promptAttachHumanLogText(message string) string {
-	message = strings.TrimSpace(message)
-	if message == "" {
+	if strings.TrimSpace(message) == "" {
 		return ""
 	}
 	if strings.HasSuffix(message, "\n") {

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -866,6 +866,74 @@ func TestPromptAttachProjectorLogsTurnFinalTextWithoutAgentEventText(t *testing.
 	}
 }
 
+func TestPromptAttachProjectorSeparatesHumanMessageAfterUnterminatedAgentText(t *testing.T) {
+	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+	projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-boundary"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-boundary"}}, logsPath, nil)
+	if _, _, err := projector.Project([]byte(`{"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"first answer"}}}` + "\n")); err != nil {
+		t.Fatalf("project agent text: %v", err)
+	}
+	if err := projector.AppendHumanMessage("next question"); err != nil {
+		t.Fatalf("append human message: %v", err)
+	}
+	transcript, err := os.ReadFile(logsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if string(transcript) != "first answer\nnext question\n" {
+		t.Fatalf("transcript = %q", string(transcript))
+	}
+}
+
+func TestPromptAttachProjectorDoesNotDuplicateSeparatorsBetweenQueuedHumanMessages(t *testing.T) {
+	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+	projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-human-tail"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-human-tail"}}, logsPath, nil)
+	if _, _, err := projector.Project([]byte(`{"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"agent"}}}` + "\n")); err != nil {
+		t.Fatalf("project agent text: %v", err)
+	}
+	if err := projector.AppendHumanMessage("human-2"); err != nil {
+		t.Fatalf("append first human message: %v", err)
+	}
+	if err := projector.AppendHumanMessage("  human-3  "); err != nil {
+		t.Fatalf("append second human message: %v", err)
+	}
+	transcript, err := os.ReadFile(logsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if string(transcript) != "agent\nhuman-2\n  human-3  \n" {
+		t.Fatalf("transcript = %q", string(transcript))
+	}
+}
+
+func TestPromptAttachProjectorSeparatesHumanMessageFromStderrTail(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+	}{
+		{name: "terminated", stderr: "warning\n"},
+		{name: "unterminated", stderr: "warning"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+			projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-stderr-tail"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-stderr-tail"}}, logsPath, nil)
+			if err := projector.AppendStderr(test.stderr); err != nil {
+				t.Fatalf("append stderr: %v", err)
+			}
+			if err := projector.AppendHumanMessage("next"); err != nil {
+				t.Fatalf("append human message: %v", err)
+			}
+			transcript, err := os.ReadFile(logsPath)
+			if err != nil {
+				t.Fatalf("read transcript: %v", err)
+			}
+			if string(transcript) != "warning\nnext\n" {
+				t.Fatalf("transcript = %q", string(transcript))
+			}
+		})
+	}
+}
+
 func receiveProjectorRunLogEvent(t *testing.T, sub *RunLogSubscription) RunLogEvent {
 	t.Helper()
 	select {


### PR DESCRIPTION
## Summary

  Preserve readable boundaries in stored prompt transcripts.

  The prompt transcript projector now:

  - inserts a newline before a human message when the preceding log output has no trailing newline;
  - preserves the original whitespace in non-empty human messages;
  - routes stderr through the projector so transcript tail state and published stderr chunks remain consistent;
  - tracks the actual tail of persisted log chunks instead of relying only on accumulated agent text.

  The change is independent of prompt turn scheduling and remains compatible with the existing attach flow.

  ## Testing

  - `go test ./pkg/runs`
    - 82 tests passed
  - `task lint`
    - 0 issues
  - `git diff --check origin/main..HEAD`

  Existing prompt projector tests cover human-message and final-text transcript behavior and caught an ordering dependency during branch extraction. The
  implementation was narrowed so it remains valid independently on `origin/main`.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No documentation update is required because this corrects persisted transcript formatting
  without changing configuration or public APIs.
  - [x] Tests added or updated for user-visible behavior. Existing focused projector tests exercise the changed transcript behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.