### PR TITLE
fix(runs): serialize prompt attach turns

### DIFF
--- a/pkg/runs/attach_input_test.go
+++ b/pkg/runs/attach_input_test.go
@@ -2,7 +2,10 @@ package runs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -38,32 +41,162 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 	})
 }
 
-func TestForwardPromptHumanMessageWaitsForTurnCompletion(t *testing.T) {
-	interaction := &closingRuntimeInteraction{}
+func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t *testing.T) {
+	requests := make(chan *agentcomposev2.RunAttachRequest, 2)
+	received := make(chan struct{}, 2)
+	interaction := newObservedRuntimeInteraction()
 	input := &promptWrapperInput{interaction: interaction}
 	turnReady := make(chan struct{}, 1)
-	done := make(chan bool, 1)
+	done := make(chan struct{})
+
 	go func() {
-		done <- forwardPromptHumanMessage(context.Background(), input, turnReady, "next", nil)
+		defer close(done)
+		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.RunAttachRequest, error) {
+			req, ok := <-requests
+			if !ok {
+				return nil, io.EOF
+			}
+			received <- struct{}{}
+			return req, nil
+		}, input, turnReady, nil)
 	}()
+
+	requests <- humanMessageAttachRequest("human-2")
+	requests <- humanMessageAttachRequest("human-3")
+	close(requests)
+	<-received
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	turnReady <- struct{}{}
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-2")
+	<-received
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	turnReady <- struct{}{}
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-3")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "eof", "")
 
 	select {
 	case <-done:
-		t.Fatal("human message was forwarded before the previous turn completed")
+	case <-time.After(time.Second):
+		t.Fatal("prompt input pump did not exit after EOF")
+	}
+	if interaction.closeCallCount() != 1 {
+		t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCallCount())
+	}
+}
+
+func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	requests := make(chan *agentcomposev2.RunAttachRequest, 1)
+	received := make(chan struct{}, 1)
+	interaction := newObservedRuntimeInteraction()
+	input := &promptWrapperInput{interaction: interaction}
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		pumpRunPromptAttachInput(ctx, func() (*agentcomposev2.RunAttachRequest, error) {
+			req := <-requests
+			received <- struct{}{}
+			return req, nil
+		}, input, make(chan struct{}, 1), nil)
+	}()
+
+	requests <- humanMessageAttachRequest("queued")
+	<-received
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("prompt input pump did not exit after cancellation")
+	}
+	assertNoRuntimeInputFrame(t, interaction.sent)
+	if interaction.closeCallCount() != 1 {
+		t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCallCount())
+	}
+}
+
+func humanMessageAttachRequest(message string) *agentcomposev2.RunAttachRequest {
+	return &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_HumanMessage{
+		HumanMessage: &agentcomposev2.AttachHumanMessage{Text: message},
+	}}
+}
+
+func receiveRuntimeInputFrame(t *testing.T, frames <-chan driverpkg.RuntimeInputFrame) driverpkg.RuntimeInputFrame {
+	t.Helper()
+	select {
+	case frame := <-frames:
+		return frame
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runtime input frame")
+	}
+	return driverpkg.RuntimeInputFrame{}
+}
+
+func assertNoRuntimeInputFrame(t *testing.T, frames <-chan driverpkg.RuntimeInputFrame) {
+	t.Helper()
+	select {
+	case frame := <-frames:
+		t.Fatalf("unexpected runtime input frame: %s", frame.Data)
 	default:
 	}
-	releasePromptTurn(turnReady)
-	select {
-	case ok := <-done:
-		if !ok {
-			t.Fatal("human message was not forwarded")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("human message remained blocked after turn completion")
+}
+
+func assertPromptRuntimeFrame(t *testing.T, frame driverpkg.RuntimeInputFrame, frameType, message string) {
+	t.Helper()
+	var payload struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
 	}
-	if len(interaction.sent) != 1 || string(interaction.sent[0].Data) != "{\"message\":\"next\",\"seq\":0,\"type\":\"human_message\",\"v\":1}\n" {
-		t.Fatalf("sent frames = %#v", interaction.sent)
+	if err := json.Unmarshal(frame.Data, &payload); err != nil {
+		t.Fatalf("decode runtime input frame: %v", err)
 	}
+	if payload.Type != frameType || payload.Message != message {
+		t.Fatalf("runtime input frame = %#v, want type=%q message=%q", payload, frameType, message)
+	}
+}
+
+type observedRuntimeInteraction struct {
+	sent       chan driverpkg.RuntimeInputFrame
+	closed     chan struct{}
+	closeOnce  sync.Once
+	mu         sync.Mutex
+	closeCalls int
+}
+
+func newObservedRuntimeInteraction() *observedRuntimeInteraction {
+	return &observedRuntimeInteraction{
+		sent:   make(chan driverpkg.RuntimeInputFrame, 4),
+		closed: make(chan struct{}),
+	}
+}
+
+func (i *observedRuntimeInteraction) Send(frame driverpkg.RuntimeInputFrame) error {
+	i.sent <- frame
+	return nil
+}
+
+func (i *observedRuntimeInteraction) CloseSend() error {
+	i.mu.Lock()
+	i.closeCalls++
+	i.mu.Unlock()
+	i.closeOnce.Do(func() { close(i.closed) })
+	return nil
+}
+
+func (*observedRuntimeInteraction) Recv() (driverpkg.RuntimeOutputFrame, error) {
+	return driverpkg.RuntimeOutputFrame{}, errors.New("unused")
+}
+
+func (*observedRuntimeInteraction) Wait() (driverpkg.RuntimeResult, error) {
+	return driverpkg.RuntimeResult{}, errors.New("unused")
+}
+
+func (i *observedRuntimeInteraction) closeCallCount() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.closeCalls
 }
 
 type closingRuntimeInteraction struct {

--- a/pkg/runs/attach_input_test.go
+++ b/pkg/runs/attach_input_test.go
@@ -1,8 +1,10 @@
 package runs
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	driverpkg "agent-compose/pkg/driver"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
@@ -24,9 +26,9 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 	t.Run("prompt", func(t *testing.T) {
 		interaction := &closingRuntimeInteraction{}
 		input := &promptWrapperInput{interaction: interaction}
-		pumpRunPromptAttachInput(func() (*agentcomposev2.RunAttachRequest, error) {
+		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.RunAttachRequest, error) {
 			return nil, receiveErr
-		}, input, nil)
+		}, input, nil, nil)
 		if interaction.closeCalls != 1 {
 			t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
 		}
@@ -34,6 +36,34 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 			t.Fatalf("sent frames = %#v, want prompt EOF", interaction.sent)
 		}
 	})
+}
+
+func TestForwardPromptHumanMessageWaitsForTurnCompletion(t *testing.T) {
+	interaction := &closingRuntimeInteraction{}
+	input := &promptWrapperInput{interaction: interaction}
+	turnReady := make(chan struct{}, 1)
+	done := make(chan bool, 1)
+	go func() {
+		done <- forwardPromptHumanMessage(context.Background(), input, turnReady, "next", nil)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("human message was forwarded before the previous turn completed")
+	default:
+	}
+	releasePromptTurn(turnReady)
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("human message was not forwarded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("human message remained blocked after turn completion")
+	}
+	if len(interaction.sent) != 1 || string(interaction.sent[0].Data) != "{\"message\":\"next\",\"seq\":0,\"type\":\"human_message\",\"v\":1}\n" {
+		t.Fatalf("sent frames = %#v", interaction.sent)
+	}
 }
 
 type closingRuntimeInteraction struct {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -898,14 +898,19 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 		transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 		return transition, err
 	}
+	inputCtx, cancelInput := context.WithCancel(ctx)
+	defer cancelInput()
+	turnReady := make(chan struct{}, 1)
 	if prompt := strings.TrimSpace(req.Prompt); prompt != "" {
 		if err := input.HumanMessage(prompt); err != nil {
 			transition.ExitCode = 1
 			transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 			return transition, err
 		}
+	} else {
+		releasePromptTurn(turnReady)
 	}
-	go pumpRunPromptAttachInput(receive, input, projector.AppendHumanMessage)
+	go pumpRunPromptAttachInput(inputCtx, receive, input, turnReady, projector.AppendHumanMessage)
 	var promptTransition *TransitionRequest
 	for {
 		frame, err := interaction.Recv()
@@ -955,6 +960,9 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 					transition.ExitCode = 1
 					transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 					return transition, err
+				}
+				if resp.GetAgentTurnCompleted() != nil {
+					releasePromptTurn(turnReady)
 				}
 			}
 			if nextTransition != nil {
@@ -1337,7 +1345,7 @@ func (w *promptWrapperInput) send(frame map[string]any) error {
 	return w.interaction.Send(driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: data})
 }
 
-func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInput, onHumanMessage func(string) error) {
+func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, input *promptWrapperInput, turnReady <-chan struct{}, onHumanMessage func(string) error) {
 	defer func() { _ = input.interaction.CloseSend() }()
 	for {
 		req, err := receive()
@@ -1348,23 +1356,13 @@ func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInp
 		switch frame := req.GetFrame().(type) {
 		case *agentcomposev2.RunAttachRequest_HumanMessage:
 			text := frame.HumanMessage.GetText()
-			if err := input.HumanMessage(text); err != nil {
+			if !forwardPromptHumanMessage(ctx, input, turnReady, text, onHumanMessage) {
 				return
-			}
-			if onHumanMessage != nil {
-				if err := onHumanMessage(text); err != nil {
-					return
-				}
 			}
 		case *agentcomposev2.RunAttachRequest_Stdin:
 			text := string(frame.Stdin.GetData())
-			if err := input.HumanMessage(text); err != nil {
+			if !forwardPromptHumanMessage(ctx, input, turnReady, text, onHumanMessage) {
 				return
-			}
-			if onHumanMessage != nil {
-				if err := onHumanMessage(text); err != nil {
-					return
-				}
 			}
 		case *agentcomposev2.RunAttachRequest_StdinEof:
 			_ = input.EOF()
@@ -1376,6 +1374,29 @@ func pumpRunPromptAttachInput(receive RunAttachReceiver, input *promptWrapperInp
 			_ = input.Cancel("invalid run prompt attach frame")
 			return
 		}
+	}
+}
+
+func forwardPromptHumanMessage(ctx context.Context, input *promptWrapperInput, turnReady <-chan struct{}, text string, onHumanMessage func(string) error) bool {
+	if turnReady != nil {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-turnReady:
+		}
+	}
+	if onHumanMessage != nil {
+		if err := onHumanMessage(text); err != nil {
+			return false
+		}
+	}
+	return input.HumanMessage(text) == nil
+}
+
+func releasePromptTurn(turnReady chan<- struct{}) {
+	select {
+	case turnReady <- struct{}{}:
+	default:
 	}
 }
 

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -801,6 +802,94 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	if string(transcript) != "hello agent\n" {
 		t.Fatalf("prompt attach transcript = %q", string(transcript))
 	}
+}
+
+func TestRunsControllerRunProjectPromptAttachGatesQueuedTurnsAndOrdersTranscript(t *testing.T) {
+	ctx := context.Background()
+	controller, configDB, runtime := newTestRunAttachController(t, nil)
+	interaction := newScriptedRunAttachInteraction()
+	runtime.interactionOverride = interaction
+
+	requests := make(chan *agentcomposev2.RunAttachRequest, 4)
+	requests <- &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+		Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "human-1"},
+		Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
+	}}}
+	requests <- humanMessageAttachRequest("human-2")
+	requests <- humanMessageAttachRequest("human-3")
+	requests <- &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}}
+	close(requests)
+
+	var responses []*agentcomposev2.RunAttachResponse
+	done := make(chan error, 1)
+	go func() {
+		done <- controller.RunProjectCommandAttach(ctx, func() (*agentcomposev2.RunAttachRequest, error) {
+			req, ok := <-requests
+			if !ok {
+				return nil, io.EOF
+			}
+			return req, nil
+		}, func(resp *agentcomposev2.RunAttachResponse) error {
+			responses = append(responses, resp)
+			return nil
+		})
+	}()
+
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "start", "")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-1")
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	interaction.frames <- driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputStarted}
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":0,"type":"started","provider":"codex","sessionId":"thread-1"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":1,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"agent-1\n"}}}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-1\n"}`)
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-2")
+	assertNoRuntimeInputFrame(t, interaction.sent)
+
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":3,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m2","type":"agent_message","text":"agent-2\n"}}}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":4,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-2\n"}`)
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-3")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "eof", "")
+
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":5,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m3","type":"agent_message","text":"agent-3\n"}}}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":6,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-3\n"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":7,"type":"result","provider":"codex","sessionId":"thread-1","stopReason":"eof","finalText":"agent-3\n","transcript":"agent-1\nagent-2\nagent-3\n"}`)
+	interaction.frames <- driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", Success: true}}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunProjectCommandAttach returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunProjectCommandAttach did not finish")
+	}
+
+	var result *agentcomposev2.AttachResult
+	for _, response := range responses {
+		if response.GetResult() != nil {
+			result = response.GetResult()
+		}
+	}
+	if result == nil || result.GetRun() == nil {
+		t.Fatalf("prompt attach responses have no result: %#v", responses)
+	}
+	stored, err := configDB.GetProjectRun(ctx, result.GetRun().GetRunId())
+	if err != nil {
+		t.Fatalf("get stored run: %v", err)
+	}
+	transcript, err := os.ReadFile(stored.LogsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	const expected = "agent-1\nhuman-2\nagent-2\nhuman-3\nagent-3\n"
+	if string(transcript) != expected {
+		t.Fatalf("transcript = %q, want %q", string(transcript), expected)
+	}
+}
+
+func promptRuntimeStdoutFrame(line string) driverpkg.RuntimeOutputFrame {
+	return driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputStdout, Data: []byte(line + "\n")}
 }
 
 func TestPromptAttachProjectorLogsResultFinalTextWithoutAgentEventText(t *testing.T) {
@@ -2103,15 +2192,56 @@ func newTestRunAttachController(t *testing.T, frames []driverpkg.RuntimeOutputFr
 
 type fakeRunAttachRuntime struct {
 	fakeControllerRuntime
-	spec        driverpkg.RuntimeStartSpec
-	frames      []driverpkg.RuntimeOutputFrame
-	interaction *fakeRunAttachInteraction
+	spec                driverpkg.RuntimeStartSpec
+	frames              []driverpkg.RuntimeOutputFrame
+	interaction         *fakeRunAttachInteraction
+	interactionOverride driverpkg.RuntimeInteraction
 }
 
 func (r *fakeRunAttachRuntime) OpenInteraction(_ context.Context, _ *domain.Sandbox, _ domain.VMState, spec driverpkg.RuntimeStartSpec) (driverpkg.RuntimeInteraction, error) {
 	r.spec = spec
+	if r.interactionOverride != nil {
+		return r.interactionOverride, nil
+	}
 	r.interaction = &fakeRunAttachInteraction{frames: append([]driverpkg.RuntimeOutputFrame(nil), r.frames...)}
 	return r.interaction, nil
+}
+
+type scriptedRunAttachInteraction struct {
+	frames    chan driverpkg.RuntimeOutputFrame
+	sent      chan driverpkg.RuntimeInputFrame
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newScriptedRunAttachInteraction() *scriptedRunAttachInteraction {
+	return &scriptedRunAttachInteraction{
+		frames: make(chan driverpkg.RuntimeOutputFrame, 16),
+		sent:   make(chan driverpkg.RuntimeInputFrame, 8),
+		closed: make(chan struct{}),
+	}
+}
+
+func (i *scriptedRunAttachInteraction) Send(frame driverpkg.RuntimeInputFrame) error {
+	i.sent <- frame
+	return nil
+}
+
+func (i *scriptedRunAttachInteraction) CloseSend() error {
+	i.closeOnce.Do(func() { close(i.closed) })
+	return nil
+}
+
+func (i *scriptedRunAttachInteraction) Recv() (driverpkg.RuntimeOutputFrame, error) {
+	frame, ok := <-i.frames
+	if !ok {
+		return driverpkg.RuntimeOutputFrame{}, io.EOF
+	}
+	return frame, nil
+}
+
+func (*scriptedRunAttachInteraction) Wait() (driverpkg.RuntimeResult, error) {
+	return driverpkg.RuntimeResult{Success: true}, nil
 }
 
 type fakeRunAttachInteraction struct {


### PR DESCRIPTION
## Summary

  Serialize queued prompt-attach human messages across agent turns.

  Prompt attach now uses a single turn-ready token:

  - an initial request prompt occupies the first turn;
  - an attach without an initial prompt allows the first human message immediately;
  - each `agent_turn_completed` frame releases exactly one queued human message;
  - cancellation unblocks a message waiting for the previous turn;
  - human messages are projected when they are actually forwarded, preserving execution and transcript order.

  This prevents multiple queued messages from being sent into the runtime during the same active agent turn.

  ## Testing

  - `go test ./pkg/runs`
    - 83 tests passed
  - `task lint`
    - 0 issues
  - `git diff --check origin/main..HEAD`

  Added a focused test verifying that a queued human message remains blocked until the previous turn completes.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No documentation update is required because the existing prompt-attach protocol is
  unchanged; this fixes its turn-ordering semantics.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.