### PR TITLE
fix(cli): handle piped exec prompt input

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3401,11 +3401,13 @@ func runComposeExecAttachCommand(cmd *cobra.Command, projectName string, client 
 	return nil
 }
 
-func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, client execAttachClient, req *agentcomposev2.ExecRequest, options composeExecOptions) error {
+func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, client execAttachClient, req *agentcomposev2.ExecRequest, options composeExecOptions) (retErr error) {
 	stdin := cmd.InOrStdin()
 	stdout := cmd.OutOrStdout()
 	stderr := cmd.ErrOrStderr()
-	stream := client.ExecAttach(cmd.Context())
+	attachCtx, cancelAttach := context.WithCancel(cmd.Context())
+	defer cancelAttach()
+	stream := client.ExecAttach(attachCtx)
 	var sendMu sync.Mutex
 	send := func(frame *agentcomposev2.ExecAttachRequest) error {
 		sendMu.Lock()
@@ -3430,6 +3432,26 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 	}
 	scanner := bufio.NewScanner(stdin)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	stdinIsTerminal := false
+	if fd, ok := terminalFileDescriptor(stdin); ok {
+		stdinIsTerminal = isTerminalFD(fd)
+	}
+	var inputErr <-chan error
+	if !stdinIsTerminal {
+		ch := make(chan error, 1)
+		inputErr = ch
+		go func() { ch <- pumpExecPromptMessages(scanner, send, closeRequest) }()
+		defer func() {
+			cancelAttach()
+			select {
+			case err := <-inputErr:
+				if retErr == nil && err != nil {
+					retErr = err
+				}
+			default:
+			}
+		}()
+	}
 	lastOutputEndedWithNewline := true
 	inputPrompt := promptAttachInputPrompt{
 		SandboxID: req.GetSandboxId(),
@@ -3498,14 +3520,26 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 				lastOutputEndedWithNewline = strings.HasSuffix(text, "\n")
 			}
 		case *agentcomposev2.ExecAttachResponse_AgentTurnCompleted:
-			if err := promptForInput(); err != nil {
-				return err
+			if stdinIsTerminal {
+				if err := promptForInput(); err != nil {
+					return err
+				}
 			}
 		case *agentcomposev2.ExecAttachResponse_Result:
 			result = frame.Result
 			inputPrompt.UpdateFromRun(result.GetRun())
 		case *agentcomposev2.ExecAttachResponse_Error:
 			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("exec project %s prompt attach failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
+		}
+	}
+	if inputErr != nil {
+		select {
+		case err := <-inputErr:
+			inputErr = nil
+			if err != nil {
+				return err
+			}
+		default:
 		}
 	}
 	if err := output.Finish(); err != nil {
@@ -3522,6 +3556,26 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 		return commandExitError{Code: attachResultExitCode(result), Err: fmt.Errorf("run %s in project %s failed: %s", firstNonEmptyString(runID, "attach"), projectName, firstNonEmptyString(result.GetError(), result.GetOutput(), "prompt failed"))}
 	}
 	return nil
+}
+
+func pumpExecPromptMessages(scanner *bufio.Scanner, send func(*agentcomposev2.ExecAttachRequest) error, closeRequest func() error) (err error) {
+	defer func() { err = errors.Join(err, closeRequest()) }()
+	for scanner.Scan() {
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		if text == "/exit" {
+			break
+		}
+		if err := send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}}}); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}})
 }
 
 func pumpExecAttachStdin(stdin io.Reader, send func(*agentcomposev2.ExecAttachRequest) error, closeRequest func() error) (err error) {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -5290,6 +5290,86 @@ func TestCLIExecPromptAttachUsesExecAttachClient(t *testing.T) {
 	}
 }
 
+func TestCLIExecPromptAttachDoesNotWaitForOpenStdin(t *testing.T) {
+	stream := newFakeExecAttachStream(nil)
+	stream.recvErr = io.EOF
+	stdin, stdinWriter := io.Pipe()
+	defer func() { _ = stdin.Close() }()
+	defer func() { _ = stdinWriter.Close() }()
+
+	cmd := &cobra.Command{Use: "exec"}
+	cmd.SetContext(context.Background())
+	cmd.SetIn(stdin)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runComposeExecPromptAttachCommand(cmd, "cli-exec-prompt", &fakeExecAttachClient{stream: stream}, &agentcomposev2.ExecRequest{
+			Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
+		}, composeExecOptions{Interactive: true, Prompt: "hi"})
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "completed without result") {
+			t.Fatalf("exec prompt attach error = %v, want missing result", err)
+		}
+		if err := stdinWriter.Close(); err != nil {
+			t.Fatalf("close caller-owned stdin writer: %v", err)
+		}
+		select {
+		case <-stream.closedCh:
+		case <-time.After(time.Second):
+			t.Fatal("prompt input pump did not close the request stream after stdin ended")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("exec prompt attach waited for stdin after the response stream completed")
+	}
+}
+
+func TestCLIExecPromptAttachReceiveErrorDoesNotCloseCallerStdin(t *testing.T) {
+	receiveErr := connect.NewError(connect.CodeUnavailable, errors.New("stream lost"))
+	stream := newFakeExecAttachStream(nil)
+	stream.recvErr = receiveErr
+	stdin, stdinWriter := io.Pipe()
+	defer func() { _ = stdin.Close() }()
+	defer func() { _ = stdinWriter.Close() }()
+
+	cmd := &cobra.Command{Use: "exec"}
+	cmd.SetContext(context.Background())
+	cmd.SetIn(stdin)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runComposeExecPromptAttachCommand(cmd, "cli-exec-prompt", &fakeExecAttachClient{stream: stream}, &agentcomposev2.ExecRequest{
+			Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
+		}, composeExecOptions{Interactive: true, Prompt: "hi"})
+	}()
+
+	select {
+	case err := <-done:
+		if connect.CodeOf(err) != connect.CodeUnavailable {
+			t.Fatalf("exec prompt attach error = %v, want unavailable", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("exec prompt attach waited for stdin after receive failed")
+	}
+	if _, err := stdinWriter.Write([]byte("caller still owns stdin\n")); err != nil {
+		t.Fatalf("write caller-owned stdin after command returned: %v", err)
+	}
+	if err := stdinWriter.Close(); err != nil {
+		t.Fatalf("close caller-owned stdin writer: %v", err)
+	}
+	select {
+	case <-stream.closedCh:
+	case <-time.After(time.Second):
+		t.Fatal("prompt input pump did not close the request stream after stdin ended")
+	}
+}
+
 func TestCLIExecInteractiveUnsupportedUsesUnsupportedExitCode(t *testing.T) {
 	client := &fakeExecAttachClient{stream: &fakeExecAttachStream{
 		closedCh: make(chan struct{}),


### PR DESCRIPTION
  ## Summary

  Improve piped stdin handling for interactive `exec --prompt` sessions.

  Non-terminal input is now pumped independently from response processing so queued messages and EOF can be forwarded without waiting for each agent turn.
  Terminal input retains the existing turn-by-turn prompt behavior.

  The attach stream now uses a child context that is canceled on every command exit path. Input handling does not close caller-owned stdin or wait indefinitely
  for an arbitrary `io.Reader`, preventing open pipes from blocking command completion and avoiding side effects in embedded or test callers.

  Input-side errors are collected without overriding a more important response, output, or server error. Request-side `Send` and `CloseRequest` operations
  remain serialized to keep bidirectional stream access safe.

  Tests cover:

  - response completion while piped stdin remains open;
  - receive failures while piped stdin remains open;
  - caller ownership of stdin after command completion;
  - eventual request-stream closure after the caller ends stdin;
  - existing human-message, EOF, and request-close behavior.

  ## Testing

  - `go test ./cmd/agent-compose`
    - 601 tests passed
  - `go test -race ./cmd/agent-compose`
    - 601 tests passed
  - `task lint`
    - 0 issues
  - `git diff --check origin/main..HEAD`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No documentation update is required because this fixes internal stdin and stream lifecycle
  handling without changing CLI flags, configuration, or public protocols.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.