### PR TITLE
fix(driver): make directory bootstrap symlinks race-safe

### DIFF
--- a/pkg/driver/boxlite_guest_test.go
+++ b/pkg/driver/boxlite_guest_test.go
@@ -87,7 +87,7 @@ func TestBoxLiteBootstrapExecSpecRunsFromRoot(t *testing.T) {
 	if strings.Contains(spec.Args[1], "ln -s '/data/home' '/root'") {
 		t.Fatalf("bootstrap script unexpectedly contains whole-root symlink: %s", spec.Args[1])
 	}
-	if !strings.Contains(spec.Args[1], "ln -s '/data/home/.codex' '/root/.codex'") {
+	if !strings.Contains(spec.Args[1], "ln -sfn '/data/home/.codex' '/root/.codex'") {
 		t.Fatalf("bootstrap script missing codex home symlink: %s", spec.Args[1])
 	}
 	if spec.Cwd != "/" {
@@ -133,7 +133,7 @@ func TestMicrosandboxBootstrapExecSpecRunsFromRoot(t *testing.T) {
 	if strings.Contains(spec.Args[1], "ln -s '/data/home' '/root'") {
 		t.Fatalf("bootstrap script unexpectedly contains whole-root symlink: %s", spec.Args[1])
 	}
-	if !strings.Contains(spec.Args[1], "ln -s '/data/home/.gitconfig' '/root/.gitconfig'") {
+	if !strings.Contains(spec.Args[1], "ln -sfn '/data/home/.gitconfig' '/root/.gitconfig'") {
 		t.Fatalf("bootstrap script missing gitconfig home symlink: %s", spec.Args[1])
 	}
 	if spec.Cwd != "/" {

--- a/pkg/driver/directory_only_guest_bootstrap.go
+++ b/pkg/driver/directory_only_guest_bootstrap.go
@@ -67,7 +67,16 @@ func directoryOnlySymlinkCommand(source, target string, isFile bool, replaceExis
 	}
 	prepareTarget := "mkdir -p " + targetParentQuote + "; "
 	if replaceExisting {
-		prepareTarget += "rm -rf " + targetQuote + "; ln -s " + sourceQuote + " " + targetQuote + "; "
+		// Multiple Exec calls can bootstrap the same guest concurrently. Keep an
+		// already-correct link stable and make competing replacements converge;
+		// unconditional rm+ln lets one bootstrap delete another's fresh link.
+		prepareTarget += "directory_only_symlink_attempt=0; " +
+			"while [ \"$(readlink " + targetQuote + " 2>/dev/null)\" != " + sourceQuote + " ]; do " +
+			"directory_only_symlink_attempt=$((directory_only_symlink_attempt + 1)); " +
+			"if [ \"$directory_only_symlink_attempt\" -gt 10 ]; then echo \"directory-only symlink target does not converge to " + source + "\" >&2; exit 1; fi; " +
+			"if [ -d " + targetQuote + " ] && [ ! -L " + targetQuote + " ]; then rm -rf " + targetQuote + "; fi; " +
+			"ln -sfn " + sourceQuote + " " + targetQuote + " || { echo \"failed to replace directory-only symlink target " + target + "\" >&2; exit 1; }; " +
+			"done; "
 		return prepareSource + "; " + prepareTarget +
 			"test \"$(readlink " + targetQuote + ")\" = " + sourceQuote + " || { echo \"directory-only symlink target does not match " + source + "\" >&2; exit 1; }"
 	}

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -505,24 +505,25 @@ func TestDirectoryOnlyGuestSandboxBootstrapUsesDataMountRoot(t *testing.T) {
 	for _, required := range []string{
 		"test -d '/data/workspace'",
 		"test -d '/data/home'",
-		"ln -s '/data/workspace' '/workspace'",
+		"while [ \"$(readlink '/workspace' 2>/dev/null)\" != '/data/workspace' ]; do",
+		"ln -sfn '/data/workspace' '/workspace'",
 		"if mountpoint -q '/root'; then echo \"refusing to replace mounted home target /root\" >&2; exit 1; fi",
 		"if [ -L '/root' ]; then rm -f '/root'; mkdir -p '/root';",
 		"if [ ! -d '/root' ]; then echo \"refusing to replace non-directory /root\" >&2; exit 1; fi;",
 		"test -d '/root' || { echo \"directory-only home target is not a directory /root\" >&2; exit 1; }",
-		"rm -rf '/root/.codex'; ln -s '/data/home/.codex' '/root/.codex'",
-		"ln -s '/data/home/.codex' '/root/.codex'",
-		"ln -s '/data/home/.agents' '/root/.agents'",
-		"ln -s '/data/home/.claude' '/root/.claude'",
-		"ln -s '/data/home/.opencode' '/root/.opencode'",
-		"ln -s '/data/home/.claude.json' '/root/.claude.json'",
-		"ln -s '/data/home/.gitconfig' '/root/.gitconfig'",
-		"ln -s '/data/home/.gemini' '/root/.gemini'",
-		"ln -s '/data/home/.config/claude' '/root/.config/claude'",
-		"ln -s '/data/home/.config/Claude' '/root/.config/Claude'",
-		"ln -s '/data/home/.config/gemini' '/root/.config/gemini'",
-		"ln -s '/data/home/.config/opencode' '/root/.config/opencode'",
-		"ln -s '/data/home/.local/share/gemini' '/root/.local/share/gemini'",
+		"while [ \"$(readlink '/root/.codex' 2>/dev/null)\" != '/data/home/.codex' ]; do",
+		"ln -sfn '/data/home/.codex' '/root/.codex'",
+		"ln -sfn '/data/home/.agents' '/root/.agents'",
+		"ln -sfn '/data/home/.claude' '/root/.claude'",
+		"ln -sfn '/data/home/.opencode' '/root/.opencode'",
+		"ln -sfn '/data/home/.claude.json' '/root/.claude.json'",
+		"ln -sfn '/data/home/.gitconfig' '/root/.gitconfig'",
+		"ln -sfn '/data/home/.gemini' '/root/.gemini'",
+		"ln -sfn '/data/home/.config/claude' '/root/.config/claude'",
+		"ln -sfn '/data/home/.config/Claude' '/root/.config/Claude'",
+		"ln -sfn '/data/home/.config/gemini' '/root/.config/gemini'",
+		"ln -sfn '/data/home/.config/opencode' '/root/.config/opencode'",
+		"ln -sfn '/data/home/.local/share/gemini' '/root/.local/share/gemini'",
 		"test \"$(readlink '/root/.gitconfig')\" = '/data/home/.gitconfig'",
 		"test \"$(readlink '/root/.codex')\" = '/data/home/.codex'",
 	} {
@@ -543,8 +544,8 @@ func TestDirectoryOnlyGuestSandboxBootstrapUsesDataMountRoot(t *testing.T) {
 		}
 	}
 	assertSubstringOrder(t, command, "test -d '/data/home'", "rm -f '/root'")
-	assertSubstringOrder(t, command, "test -d '/data/home'", "ln -s '/data/home/.codex' '/root/.codex'")
-	assertSubstringOrder(t, command, "test -d '/root' ||", "ln -s '/data/home/.codex' '/root/.codex'")
+	assertSubstringOrder(t, command, "test -d '/data/home'", "ln -sfn '/data/home/.codex' '/root/.codex'")
+	assertSubstringOrder(t, command, "test -d '/root' ||", "ln -sfn '/data/home/.codex' '/root/.codex'")
 }
 
 func TestBoxliteDirectoryOnlyGuestSandboxBootstrapIncludesVolumeSymlinks(t *testing.T) {
@@ -559,7 +560,7 @@ func TestBoxliteDirectoryOnlyGuestSandboxBootstrapIncludesVolumeSymlinks(t *test
 	}}
 	command := directoryOnlyGuestSandboxBootstrapCommandForSandbox(testRuntimeMountConfig(), session)
 	for _, required := range []string{
-		"ln -s '/data/volumes/mount-a8f37c92e51b4d10' '/cache'",
+		"ln -sfn '/data/volumes/mount-a8f37c92e51b4d10' '/cache'",
 		"test \"$(readlink '/cache')\" = '/data/volumes/mount-a8f37c92e51b4d10'",
 	} {
 		if !strings.Contains(command, required) {
@@ -630,7 +631,7 @@ func TestJupyterLaunchCommandDoesNotRunDirectoryOnlyBootstrapByDefault(t *testin
 	if strings.Contains(directoryOnlyCommand, "mount --bind '/data/home' '/root'") {
 		t.Fatalf("directory-only jupyter command unexpectedly contains bind mount: %s", directoryOnlyCommand)
 	}
-	if !strings.Contains(directoryOnlyCommand, "ln -s '/data/home/.codex' '/root/.codex'") {
+	if !strings.Contains(directoryOnlyCommand, "ln -sfn '/data/home/.codex' '/root/.codex'") {
 		t.Fatalf("directory-only jupyter command missing home symlink bootstrap: %s", directoryOnlyCommand)
 	}
 }

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -571,18 +571,30 @@ func TestBoxliteDirectoryOnlyGuestSandboxBootstrapIncludesVolumeSymlinks(t *test
 	}
 }
 
-func TestDirectoryOnlyGuestSandboxBootstrapReplacesImageHomeTargets(t *testing.T) {
+func TestDirectoryOnlyGuestSandboxBootstrapConvergesImageHomeTargets(t *testing.T) {
 	command := directoryOnlyGuestSandboxBootstrapCommand(testRuntimeMountConfig())
-	for _, required := range []string{
-		"rm -rf '/root/.codex'; ln -s '/data/home/.codex' '/root/.codex'",
-		"rm -rf '/root/.agents'; ln -s '/data/home/.agents' '/root/.agents'",
-		"rm -rf '/root/.claude'; ln -s '/data/home/.claude' '/root/.claude'",
-		"rm -rf '/root/.opencode'; ln -s '/data/home/.opencode' '/root/.opencode'",
-		"rm -rf '/root/.claude.json'; ln -s '/data/home/.claude.json' '/root/.claude.json'",
-		"rm -rf '/root/.gitconfig'; ln -s '/data/home/.gitconfig' '/root/.gitconfig'",
+	for _, target := range []struct {
+		source string
+		target string
+	}{
+		{source: "/data/home/.codex", target: "/root/.codex"},
+		{source: "/data/home/.agents", target: "/root/.agents"},
+		{source: "/data/home/.claude", target: "/root/.claude"},
+		{source: "/data/home/.opencode", target: "/root/.opencode"},
+		{source: "/data/home/.claude.json", target: "/root/.claude.json"},
+		{source: "/data/home/.gitconfig", target: "/root/.gitconfig"},
 	} {
-		if !strings.Contains(command, required) {
-			t.Fatalf("bootstrap command should replace image target with sandbox symlink %q: %s", required, command)
+		guard := "while [ \"$(readlink '" + target.target + "' 2>/dev/null)\" != '" + target.source + "' ]; do"
+		if !strings.Contains(command, guard) {
+			t.Fatalf("bootstrap command should preserve an already-correct symlink with guard %q: %s", guard, command)
+		}
+		replace := "ln -sfn '" + target.source + "' '" + target.target + "'"
+		if !strings.Contains(command, replace) {
+			t.Fatalf("bootstrap command should converge image target with no-dereference replacement %q: %s", replace, command)
+		}
+		unsafeReplace := "rm -rf '" + target.target + "'; ln -s '" + target.source + "' '" + target.target + "'"
+		if strings.Contains(command, unsafeReplace) {
+			t.Fatalf("bootstrap command still has race-prone unconditional replacement %q: %s", unsafeReplace, command)
 		}
 	}
 	if strings.Contains(command, "refusing to replace existing directory-only symlink target /root/.codex") {


### PR DESCRIPTION
## Summary

Concurrent Exec calls could run the directory-only guest bootstrap at the same time. The unconditional `rm + ln` sequence let one bootstrap delete another bootstrap's fresh link, and `ln` could follow an existing directory symlink and create nested links such as `/root/.agents/.agents`.

This change leaves already-correct links untouched and makes replacements converge: no-dereference `ln -sfn` semantics plus a bounded retry loop that exits once the link points at the expected source.

## Testing

- targeted `pkg/driver` tests pass
- live microsandbox host, 24 concurrent Execs against one guest — before fix: 21/24 failed bootstrap
- same probe after fix: 24/24 passed

## Checklist

- [x] Documentation updated when behavior or configuration changed. (no documented behavior or configuration surface changed — internal driver bootstrap fix)
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
