### PR TITLE
修复 system_prompt 导致重复 up 误报更新

### DIFF
--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1335,6 +1335,8 @@ agents:
   reviewer:
     provider: codex
     model: gpt-initial
+    system_prompt: |
+      Review the proposed changes carefully.
     image: guest:v1
     driver:
       boxlite: {}
@@ -1381,6 +1383,7 @@ agents:
 	}
 	assertComposeUpChange(t, repeated.Changes, "unchanged", "project", "cli-up-demo")
 	assertComposeUpChange(t, repeated.Changes, "unchanged", "project_agent", "reviewer")
+	assertComposeUpChange(t, repeated.Changes, "unchanged", "agent_definition", "reviewer")
 	assertComposeUpChange(t, repeated.Changes, "unchanged", "project_scheduler", "reviewer")
 
 	if err := os.WriteFile(composePath, []byte(`
@@ -1393,6 +1396,8 @@ agents:
   reviewer:
     provider: codex
     model: gpt-updated
+    system_prompt: |
+      Review the proposed changes carefully.
     image: guest:v1
     driver:
       boxlite: {}

--- a/pkg/projects/reconcile.go
+++ b/pkg/projects/reconcile.go
@@ -67,7 +67,7 @@ func ReconcileManagedAgentDefinitions(ctx context.Context, store ReconcileAgentD
 		if err != nil {
 			return nil, false, fmt.Errorf("upsert managed agent definition %s: %w", agent.ID, err)
 		}
-		action := ManagedAgentDefinitionChangeAction(existing, found, agent)
+		action := ManagedAgentDefinitionChangeAction(existing, found, saved)
 		if action != ChangeActionUnchanged {
 			unchanged = false
 		}


### PR DESCRIPTION
## 变更说明

- 修复 YAML 块标量产生的末尾换行导致重复执行 up 时 agent 始终显示 updated 的问题。
- 变更判断改用 UpsertManagedAgentDefinition 返回的规范化持久化结果，确保比较结果与数据库实际状态一致。
- 补充包含 system_prompt: | 的 CLI 回归测试，验证重复 up 返回 unchanged，真实配置变化仍返回 updated。

## 测试

- go test ./cmd/agent-compose -run ^TestIntegrationCLIUpAppliesProjectFirstRepeatedModifiedAndJSON$ -count=1
- go test ./pkg/projects/... ./pkg/storage/configstore/...
- golangci-lint fmt --no-config --diff ./cmd/... ./pkg/...
- golangci-lint run --no-config --allow-parallel-runners ./cmd/agent-compose ./pkg/projects ./pkg/storage/configstore

## 检查清单

- [x] 本次行为修复无需额外用户文档。
- [x] 已为用户可见行为增加或更新测试。
- [x] 未包含密钥、私有端点、内部证书或本地运行状态。