### PR TITLE
ci: generate release notes with git-cliff

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -200,8 +200,20 @@ jobs:
     permissions:
       actions: read
       contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: release-notes.md
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Build installer assets
         env:
           VERSION: ${{ github.ref_name }}
@@ -246,5 +258,5 @@ jobs:
             gh release create "${GITHUB_REF_NAME}" upload/* \
               --repo "${GITHUB_REPOSITORY}" \
               --title "agent-compose ${GITHUB_REF_NAME}" \
-              --notes "Release ${GITHUB_REF_NAME}."
+              --notes-file release-notes.md
           fi

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,23 @@
+[git]
+conventional_commits = true
+filter_unconventional = false
+protect_breaking_commits = true
+
+tag_pattern = '^v[0-9].*'
+
+commit_parsers = [
+  { message = '^[a-z]+(\([^)]*\))?!:', group = 'Breaking Changes' },
+  { message = '^feat', group = 'Features' },
+  { message = '^fix', group = 'Bug Fixes' },
+  { message = '^docs', group = 'Documentation' },
+  { message = '^refactor', group = 'Refactoring' },
+  { message = '^perf', group = 'Performance' },
+  { message = '^test', skip = true },
+  { message = '^chore', skip = true },
+  { message = '^Merge', skip = true },
+  { message = '.*', group = 'Other Changes' },
+]
+
+[remote.github]
+owner = 'chaitin'
+repo = 'agent-compose'


### PR DESCRIPTION
## Summary

- Generate Release Notes with git-cliff for v* tags.
- Keep runtime and historical client release lines out via tag_pattern.
- Replace the fixed Release body with the generated release-notes.md.

## Validation

- Local git-cliff 2.13.1 offline generation passed.
- Workflow YAML parsing passed.
- git diff --check passed.

## Notes

- Existing installer assets and idempotent upload behavior remain unchanged.
- The release job has pull-requests: read permission for PR metadata.