### PR TITLE
feat(cli): load project environment files

### DIFF
--- a/cmd/agent-compose/cli_project_env.go
+++ b/cmd/agent-compose/cli_project_env.go
@@ -12,7 +12,15 @@ import (
 )
 
 func resolveCLIProjectEnv(spec *compose.ProjectSpec, composePath string) (map[string]string, error) {
-	envFiles, err := resolveCLIProjectEnvFiles(spec.EnvFiles, composePath)
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current directory for project env: %w", err)
+	}
+	return resolveCLIProjectEnvFromDir(spec, composePath, workingDir)
+}
+
+func resolveCLIProjectEnvFromDir(spec *compose.ProjectSpec, composePath, workingDir string) (map[string]string, error) {
+	envFiles, err := resolveCLIProjectEnvFiles(spec.EnvFiles, composePath, workingDir)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +44,7 @@ func resolveCLIProjectEnv(spec *compose.ProjectSpec, composePath string) (map[st
 	return values, nil
 }
 
-func resolveCLIProjectEnvFiles(configured compose.EnvFileSpec, composePath string) ([]string, error) {
+func resolveCLIProjectEnvFiles(configured compose.EnvFileSpec, composePath, workingDir string) ([]string, error) {
 	projectDir := filepath.Dir(composePath)
 	if configured != nil {
 		paths := make([]string, 0, len(configured))
@@ -62,10 +70,6 @@ func resolveCLIProjectEnvFiles(configured compose.EnvFileSpec, composePath strin
 		return []string{projectEnv}, nil
 	}
 
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("resolve current directory for project env: %w", err)
-	}
 	workingEnv := filepath.Join(workingDir, ".env")
 	if filepath.Clean(workingEnv) == filepath.Clean(projectEnv) {
 		return nil, nil

--- a/cmd/agent-compose/cli_project_env.go
+++ b/cmd/agent-compose/cli_project_env.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"agent-compose/pkg/compose"
+
+	"github.com/joho/godotenv"
+)
+
+func resolveCLIProjectEnv(spec *compose.ProjectSpec, composePath string) (map[string]string, error) {
+	envFiles, err := resolveCLIProjectEnvFiles(spec.EnvFiles, composePath)
+	if err != nil {
+		return nil, err
+	}
+
+	values := make(map[string]string)
+	for _, path := range envFiles {
+		fileValues, err := godotenv.Read(path)
+		if err != nil {
+			return nil, fmt.Errorf("load project env file %s: %w", path, err)
+		}
+		for key, value := range fileValues {
+			values[key] = value
+		}
+	}
+	for _, item := range os.Environ() {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	return values, nil
+}
+
+func resolveCLIProjectEnvFiles(configured compose.EnvFileSpec, composePath string) ([]string, error) {
+	projectDir := filepath.Dir(composePath)
+	if configured != nil {
+		paths := make([]string, 0, len(configured))
+		for _, rawPath := range configured {
+			path := strings.TrimSpace(rawPath)
+			if path == "" {
+				return nil, fmt.Errorf("%s: env_file path is empty", composePath)
+			}
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(projectDir, path)
+			}
+			paths = append(paths, filepath.Clean(path))
+		}
+		return paths, nil
+	}
+
+	projectEnv := filepath.Join(projectDir, ".env")
+	exists, err := fileExists(projectEnv)
+	if err != nil {
+		return nil, fmt.Errorf("inspect project env file %s: %w", projectEnv, err)
+	}
+	if exists {
+		return []string{projectEnv}, nil
+	}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current directory for project env: %w", err)
+	}
+	workingEnv := filepath.Join(workingDir, ".env")
+	if filepath.Clean(workingEnv) == filepath.Clean(projectEnv) {
+		return nil, nil
+	}
+	exists, err = fileExists(workingEnv)
+	if err != nil {
+		return nil, fmt.Errorf("inspect current directory env file %s: %w", workingEnv, err)
+	}
+	if exists {
+		return []string{workingEnv}, nil
+	}
+	return nil, nil
+}

--- a/cmd/agent-compose/cli_project_env_test.go
+++ b/cmd/agent-compose/cli_project_env_test.go
@@ -52,20 +52,7 @@ func TestResolveCLIProjectEnvAutoDiscovery(t *testing.T) {
 	composePath := filepath.Join(projectDir, "agent-compose.yml")
 	writeTestFile(t, filepath.Join(workingDir, ".env"), "SOURCE=working\n")
 
-	previousWorkingDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd returned error: %v", err)
-	}
-	if err := os.Chdir(workingDir); err != nil {
-		t.Fatalf("Chdir returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(previousWorkingDir); err != nil {
-			t.Errorf("restore working directory: %v", err)
-		}
-	})
-
-	values, err := resolveCLIProjectEnv(&compose.ProjectSpec{}, composePath)
+	values, err := resolveCLIProjectEnvFromDir(&compose.ProjectSpec{}, composePath, workingDir)
 	if err != nil {
 		t.Fatalf("resolve cwd env returned error: %v", err)
 	}
@@ -74,7 +61,7 @@ func TestResolveCLIProjectEnvAutoDiscovery(t *testing.T) {
 	}
 
 	writeTestFile(t, filepath.Join(projectDir, ".env"), "SOURCE=project\n")
-	values, err = resolveCLIProjectEnv(&compose.ProjectSpec{}, composePath)
+	values, err = resolveCLIProjectEnvFromDir(&compose.ProjectSpec{}, composePath, workingDir)
 	if err != nil {
 		t.Fatalf("resolve project env returned error: %v", err)
 	}

--- a/cmd/agent-compose/cli_project_env_test.go
+++ b/cmd/agent-compose/cli_project_env_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"agent-compose/pkg/compose"
+)
+
+func TestResolveCLIProjectEnvPrecedence(t *testing.T) {
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "agent-compose.yml")
+	writeTestFile(t, filepath.Join(projectDir, ".env.base"), "FROM_BASE=base\nSHARED=base\n")
+	writeTestFile(t, filepath.Join(projectDir, ".env.local"), "FROM_LOCAL=local\nSHARED=local\n")
+	t.Setenv("SHARED", "process")
+
+	values, err := resolveCLIProjectEnv(&compose.ProjectSpec{EnvFiles: compose.EnvFileSpec{".env.base", ".env.local"}}, composePath)
+	if err != nil {
+		t.Fatalf("resolveCLIProjectEnv returned error: %v", err)
+	}
+	for key, want := range map[string]string{
+		"FROM_BASE":  "base",
+		"FROM_LOCAL": "local",
+		"SHARED":     "process",
+	} {
+		if got := values[key]; got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestResolveCLIProjectEnvProcessEmptyValueOverridesFile(t *testing.T) {
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "agent-compose.yml")
+	writeTestFile(t, filepath.Join(projectDir, ".env"), "CLI_PROJECT_EMPTY_OVERRIDE=file-value\n")
+	t.Setenv("CLI_PROJECT_EMPTY_OVERRIDE", "")
+
+	values, err := resolveCLIProjectEnv(&compose.ProjectSpec{}, composePath)
+	if err != nil {
+		t.Fatalf("resolveCLIProjectEnv returned error: %v", err)
+	}
+	value, ok := values["CLI_PROJECT_EMPTY_OVERRIDE"]
+	if !ok || value != "" {
+		t.Fatalf("CLI_PROJECT_EMPTY_OVERRIDE = %q, %v; want present empty value", value, ok)
+	}
+}
+
+func TestResolveCLIProjectEnvAutoDiscovery(t *testing.T) {
+	workingDir := t.TempDir()
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "agent-compose.yml")
+	writeTestFile(t, filepath.Join(workingDir, ".env"), "SOURCE=working\n")
+
+	previousWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd returned error: %v", err)
+	}
+	if err := os.Chdir(workingDir); err != nil {
+		t.Fatalf("Chdir returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previousWorkingDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
+
+	values, err := resolveCLIProjectEnv(&compose.ProjectSpec{}, composePath)
+	if err != nil {
+		t.Fatalf("resolve cwd env returned error: %v", err)
+	}
+	if got := values["SOURCE"]; got != "working" {
+		t.Fatalf("SOURCE = %q, want working", got)
+	}
+
+	writeTestFile(t, filepath.Join(projectDir, ".env"), "SOURCE=project\n")
+	values, err = resolveCLIProjectEnv(&compose.ProjectSpec{}, composePath)
+	if err != nil {
+		t.Fatalf("resolve project env returned error: %v", err)
+	}
+	if got := values["SOURCE"]; got != "project" {
+		t.Fatalf("SOURCE = %q, want project", got)
+	}
+}
+
+func TestResolveCLIProjectEnvExplicitFileDisablesAutoDiscovery(t *testing.T) {
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "agent-compose.yml")
+	writeTestFile(t, filepath.Join(projectDir, ".env"), "AUTO=unexpected\n")
+	writeTestFile(t, filepath.Join(projectDir, "custom.env"), "EXPLICIT=expected\n")
+
+	values, err := resolveCLIProjectEnv(&compose.ProjectSpec{EnvFiles: compose.EnvFileSpec{"custom.env"}}, composePath)
+	if err != nil {
+		t.Fatalf("resolveCLIProjectEnv returned error: %v", err)
+	}
+	if got := values["EXPLICIT"]; got != "expected" {
+		t.Fatalf("EXPLICIT = %q, want expected", got)
+	}
+	if _, ok := values["AUTO"]; ok {
+		t.Fatalf("AUTO should not be loaded from project .env")
+	}
+}
+
+func TestResolveCLIProjectEnvEmptyFileListDisablesAutoDiscovery(t *testing.T) {
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "agent-compose.yml")
+	writeTestFile(t, filepath.Join(projectDir, ".env"), "AUTO_EMPTY_LIST=unexpected\n")
+
+	values, err := resolveCLIProjectEnv(&compose.ProjectSpec{EnvFiles: compose.EnvFileSpec{}}, composePath)
+	if err != nil {
+		t.Fatalf("resolveCLIProjectEnv returned error: %v", err)
+	}
+	if _, ok := values["AUTO_EMPTY_LIST"]; ok {
+		t.Fatal("AUTO_EMPTY_LIST should not be loaded when env_file is an empty list")
+	}
+}
+
+func TestLoadNormalizedComposeUsesProjectEnv(t *testing.T) {
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "agent-compose.yml")
+	writeTestFile(t, composePath, "name: env-project\nagents:\n  reviewer:\n    provider: codex\n    model: ${PROJECT_MODEL}\n")
+	writeTestFile(t, filepath.Join(projectDir, ".env"), "PROJECT_MODEL=gpt-from-project\n")
+
+	_, normalized, err := loadNormalizedCompose(cliOptions{ComposeFile: composePath})
+	if err != nil {
+		t.Fatalf("loadNormalizedCompose returned error: %v", err)
+	}
+	if got := normalized.Agents[0].Model; got != "gpt-from-project" {
+		t.Fatalf("model = %q, want gpt-from-project", got)
+	}
+}
+
+func TestResolveCLIProjectEnvMissingExplicitFileFails(t *testing.T) {
+	composePath := filepath.Join(t.TempDir(), "agent-compose.yml")
+	_, err := resolveCLIProjectEnv(&compose.ProjectSpec{EnvFiles: compose.EnvFileSpec{"missing.env"}}, composePath)
+	if err == nil {
+		t.Fatal("resolveCLIProjectEnv returned nil error")
+	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -4655,8 +4655,13 @@ func loadNormalizedComposeWithOptions(ctx context.Context, cli cliOptions, resol
 	if projectName := strings.TrimSpace(cli.ProjectName); projectName != "" {
 		spec.Name = projectName
 	}
+	projectEnv, err := resolveCLIProjectEnv(spec, composePath)
+	if err != nil {
+		return "", nil, commandExitError{Code: exitCodeUsage, Err: err}
+	}
 	normalized, err := compose.Normalize(spec, compose.NormalizeOptions{
 		ComposePath:       composePath,
+		Env:               projectEnv,
 		ResolveScriptURLs: resolveScriptURLs,
 		Context:           ctx,
 	})

--- a/docs/command-line-manual.md
+++ b/docs/command-line-manual.md
@@ -48,6 +48,20 @@ Rules:
 - When connecting to an HTTP(S) daemon through `--host` or `AGENT_COMPOSE_HOST`, the CLI reads Basic Auth credentials from local `AUTH_USERNAME` and `AUTH_PASSWORD`; local Unix socket connections do not use this authentication path.
 - Automation should use `--json` and avoid parsing human-readable tables.
 
+### Project environment files
+
+A project can explicitly load one or more dotenv files. Relative paths are resolved from the directory containing the project config file:
+
+```yaml
+env_file:
+  - .env
+  - .env.local
+```
+
+Without `env_file`, the CLI first looks for `.env` in the project directory, then falls back to `.env` in the current working directory. An explicit `env_file` disables both automatic locations.
+
+Later files override earlier files, and the environment inherited by the CLI overrides every env file. Project env files are only used to render `agent-compose.yml`; they do not change CLI connection settings such as `--host` or authentication.
+
 ## Common Workflows
 
 Local development:

--- a/docs/zh-CN/command-line-manual.md
+++ b/docs/zh-CN/command-line-manual.md
@@ -49,6 +49,20 @@ agent-compose --host http://10.0.0.12:7410 ls
 - daemon 不再消费浏览器登录用的 `AUTH_*` / `OAUTH_*` 配置；UI 浏览器认证由 agent-compose-ui server 处理。
 - 自动化场景应使用 `--json`，不要解析人类可读表格。
 
+### Project 环境文件
+
+配置可以显式指定一个或多个 dotenv 文件；相对路径以 project 配置文件所在目录为基准：
+
+```yaml
+env_file:
+  - .env
+  - .env.local
+```
+
+未声明 `env_file` 时，CLI 优先自动加载 project 目录下的 `.env`；该文件不存在时，再尝试当前工作目录的 `.env`。显式声明 `env_file` 后不再自动加载这两个文件。
+
+变量冲突时，后声明的 env 文件覆盖先声明的文件，启动 CLI 时已有的进程环境覆盖所有 env 文件。Project 环境文件只参与 `agent-compose.yml` 渲染，不会改变 `--host`、认证等 CLI 连接配置。
+
 ## 常见工作流
 
 本地开发：

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -10,12 +10,37 @@ import (
 
 type ProjectSpec struct {
 	Name       string                   `yaml:"name,omitempty" json:"name,omitempty"`
+	EnvFiles   EnvFileSpec              `yaml:"env_file,omitempty" json:"env_file,omitempty"`
 	Variables  map[string]EnvVarSpec    `yaml:"variables,omitempty" json:"variables,omitempty"`
 	Workspaces map[string]WorkspaceSpec `yaml:"workspaces,omitempty" json:"workspaces,omitempty"`
 	MCPs       map[string]MCPServerSpec `yaml:"mcps,omitempty" json:"mcps,omitempty"`
 	Volumes    map[string]VolumeSpec    `yaml:"volumes,omitempty" json:"volumes,omitempty"`
 	Agents     map[string]AgentSpec     `yaml:"agents,omitempty" json:"agents,omitempty"`
 	Network    *NetworkSpec             `yaml:"network,omitempty" json:"network,omitempty"`
+}
+
+// EnvFileSpec lists dotenv files used while loading a project configuration.
+// The scalar form is shorthand for a single-item list.
+type EnvFileSpec []string
+
+func (s *EnvFileSpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		var path string
+		if err := value.Decode(&path); err != nil {
+			return err
+		}
+		*s = EnvFileSpec{path}
+		return nil
+	}
+	if value.Kind != yaml.SequenceNode {
+		return fmt.Errorf("env_file must be a string or list of strings")
+	}
+	var paths []string
+	if err := value.Decode(&paths); err != nil {
+		return err
+	}
+	*s = paths
+	return nil
 }
 
 type AgentSpec struct {
@@ -441,6 +466,7 @@ type nodeValidator func(node *yaml.Node, path string) error
 func validateProjectNode(node *yaml.Node) error {
 	return validateMapping(node, "", map[string]nodeValidator{
 		"name":       validateScalar,
+		"env_file":   validateScalarOrStringList,
 		"variables":  validateEnvVarMap,
 		"workspaces": validateWorkspaceMap,
 		"mcps":       validateMCPMap,
@@ -448,6 +474,13 @@ func validateProjectNode(node *yaml.Node) error {
 		"agents":     validateAgentMap,
 		"network":    validateNetwork,
 	})
+}
+
+func validateScalarOrStringList(node *yaml.Node, path string) error {
+	if node.Kind == yaml.ScalarNode {
+		return validateScalar(node, path)
+	}
+	return validateStringList(node, path)
 }
 
 func validateWorkspaceMap(node *yaml.Node, path string) error {

--- a/pkg/compose/spec_test.go
+++ b/pkg/compose/spec_test.go
@@ -29,6 +29,40 @@ agents:
 	}
 }
 
+func TestParseEnvFileScalarAndList(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{name: "scalar", yaml: "env_file: .env.local\nagents: {}\n", want: []string{".env.local"}},
+		{name: "list", yaml: "env_file:\n  - .env\n  - .env.local\nagents: {}\n", want: []string{".env", ".env.local"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := Parse([]byte(tt.yaml))
+			if err != nil {
+				t.Fatalf("Parse returned error: %v", err)
+			}
+			if len(spec.EnvFiles) != len(tt.want) {
+				t.Fatalf("EnvFiles = %#v, want %#v", spec.EnvFiles, tt.want)
+			}
+			for index := range tt.want {
+				if spec.EnvFiles[index] != tt.want[index] {
+					t.Fatalf("EnvFiles = %#v, want %#v", spec.EnvFiles, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseRejectsInvalidEnvFile(t *testing.T) {
+	_, err := Parse([]byte("env_file:\n  path: .env\nagents: {}\n"))
+	if err == nil || !strings.Contains(err.Error(), "env_file") {
+		t.Fatalf("Parse error = %v, want env_file validation error", err)
+	}
+}
+
 func TestParseAgentStatus(t *testing.T) {
 	spec, err := Parse([]byte("name: status\nagents:\n  worker:\n    status: disabled\n    provider: codex\n"))
 	if err != nil {


### PR DESCRIPTION
  ## Summary

  - Add top-level `env_file` support with scalar and list forms.
  - Resolve relative env file paths from the project configuration directory.
  - Automatically load the project `.env`, falling back to the current working directory `.env` when no `env_file` is configured.
  - Apply deterministic precedence: CLI process environment > later env files > earlier env files.
  - Keep project environment loading isolated from CLI connection and authentication settings.
  - Update the English and Chinese CLI documentation.

  ## Testing

  - `go test ./pkg/compose ./cmd/agent-compose` — passed, 1030 tests.
  - `task lint` — passed with 0 issues.
  - `task build` — passed.
  - Go coverage test phase in `./scripts/test-coverage.sh` — passed.
  - `task test` could not complete because `deploy/install_test.sh` failed in the `incomplete-rollback` scenario: expected `recovery was incomplete`, but the
  installer output did not contain it. Re-running `task test:deploy` produced the same result.
  - The JavaScript coverage phase could not run because `runtime/javascript` did not have `vitest` installed in the new worktree.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.