### PR TITLE
ci: notify multiple DingTalk targets

### DIFF
--- a/.github/workflows/notify-dingtalk-release.yml
+++ b/.github/workflows/notify-dingtalk-release.yml
@@ -1,5 +1,7 @@
 name: Notify DingTalk release
 
+# Configure DINGTALK_TARGETS_JSON as a GitHub Actions secret containing a
+# non-empty array of {"webhook":"...","secret":"..."} objects.
 on:
   workflow_run:
     workflows:
@@ -29,13 +31,12 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Translate release notes and send notification
+      - name: Translate release notes and send notifications
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_RUN_TAG: ${{ github.event.workflow_run.head_branch }}
           MANUAL_RELEASE_TAG: ${{ inputs.release_tag }}
-          DINGTALK_WEBHOOK: ${{ secrets.DINGTALK_WEBHOOK }}
-          DINGTALK_SECRET: ${{ secrets.DINGTALK_SECRET }}
+          DINGTALK_TARGETS_JSON: ${{ secrets.DINGTALK_TARGETS_JSON }}
           RELEASE_LLM_API_URL: ${{ secrets.RELEASE_LLM_API_URL }}
           RELEASE_LLM_API_KEY: ${{ secrets.RELEASE_LLM_API_KEY }}
           RELEASE_LLM_MODEL: ${{ secrets.RELEASE_LLM_MODEL }}
@@ -43,8 +44,7 @@ jobs:
           set -euo pipefail
 
           for variable in \
-            DINGTALK_WEBHOOK \
-            DINGTALK_SECRET \
+            DINGTALK_TARGETS_JSON \
             RELEASE_LLM_API_URL \
             RELEASE_LLM_API_KEY \
             RELEASE_LLM_MODEL
@@ -54,6 +54,20 @@ jobs:
               exit 1
             fi
           done
+
+          if ! jq -e '
+            type == "array" and
+            length > 0 and
+            all(.[];
+              type == "object" and
+              (.webhook | type == "string" and length > 0) and
+              (.secret | type == "string" and length > 0)
+            )
+          ' <<<"$DINGTALK_TARGETS_JSON" >/dev/null 2>&1
+          then
+            echo '::error::DINGTALK_TARGETS_JSON must be a non-empty array of objects with non-empty webhook and secret strings'
+            exit 1
+          fi
 
           release_tag="${WORKFLOW_RUN_TAG:-}"
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
@@ -126,37 +140,70 @@ jobs:
             --arg text "$dingtalk_text" \
             '{msgtype: "markdown", markdown: {title: $title, text: $text}}')"
 
-          timestamp="$(date +%s)000"
-          string_to_sign="${timestamp}
-          ${DINGTALK_SECRET}"
-          sign="$(printf '%s' "$string_to_sign" \
-            | openssl dgst -sha256 -hmac "$DINGTALK_SECRET" -binary \
-            | base64 \
-            | tr -d '\r\n')"
-          encoded_sign="$(jq -rn --arg sign "$sign" '$sign | @uri')"
+          target_count="$(jq -r 'length' <<<"$DINGTALK_TARGETS_JSON")"
+          failed_count=0
+          for ((index = 0; index < target_count; index++)); do
+            target_number=$((index + 1))
+            webhook="$(jq -er ".[$index].webhook" <<<"$DINGTALK_TARGETS_JSON")"
+            signing_secret="$(jq -er ".[$index].secret" <<<"$DINGTALK_TARGETS_JSON")"
+            echo "::add-mask::$webhook"
+            echo "::add-mask::$signing_secret"
 
-          separator='?'
-          if [[ "$DINGTALK_WEBHOOK" == *\?* ]]; then
-            separator='&'
-          fi
-          signed_webhook="${DINGTALK_WEBHOOK}${separator}timestamp=${timestamp}&sign=${encoded_sign}"
+            timestamp="$(date +%s)000"
+            string_to_sign="$(printf '%s\n%s' "$timestamp" "$signing_secret")"
+            sign="$(printf '%s' "$string_to_sign" \
+              | openssl dgst -sha256 -hmac "$signing_secret" -binary \
+              | base64 \
+              | tr -d '\r\n')"
+            encoded_sign="$(jq -rn --arg sign "$sign" '$sign | @uri')"
+            echo "::add-mask::$encoded_sign"
 
-          if ! dingtalk_response="$(curl -fsS \
-            --retry 3 \
-            --connect-timeout 10 \
-            --max-time 30 \
-            -X POST \
-            -H 'Content-Type: application/json' \
-            --data "$dingtalk_payload" \
-            "$signed_webhook")"
-          then
-            echo "::error::DingTalk HTTP request failed; check DINGTALK_WEBHOOK and DINGTALK_SECRET"
-            exit 1
-          fi
+            separator='?'
+            if [[ "$webhook" == *\?* ]]; then
+              separator='&'
+            fi
+            signed_webhook="${webhook}${separator}timestamp=${timestamp}&sign=${encoded_sign}"
+            echo "::add-mask::$signed_webhook"
 
-          dingtalk_error="$(jq -r 'if (.errcode // 0) == 0 then empty else (.errmsg // "unknown error") end' <<<"$dingtalk_response")"
-          if [[ -n "$dingtalk_error" ]]; then
-            echo "::error::DingTalk notification failed: $dingtalk_error"
+            if ! dingtalk_response="$(curl -fsS \
+              --retry 3 \
+              --connect-timeout 10 \
+              --max-time 30 \
+              -X POST \
+              -H 'Content-Type: application/json' \
+              --data "$dingtalk_payload" \
+              "$signed_webhook")"
+            then
+              echo "::error::DingTalk HTTP request failed for target #${target_number}"
+              failed_count=$((failed_count + 1))
+              continue
+            fi
+
+            if ! dingtalk_error="$(jq -er '
+              if type != "object" then
+                error("response is not an object")
+              elif (.errcode // 0) == 0 then
+                ""
+              else
+                (.errmsg // "unknown error")
+              end
+            ' <<<"$dingtalk_response" 2>/dev/null)"
+            then
+              echo "::error::DingTalk returned an invalid response for target #${target_number}"
+              failed_count=$((failed_count + 1))
+              continue
+            fi
+            if [[ -n "$dingtalk_error" ]]; then
+              echo "::error::DingTalk notification failed for target #${target_number}: $dingtalk_error"
+              failed_count=$((failed_count + 1))
+              continue
+            fi
+
+            echo "DingTalk notification sent to target #${target_number}."
+          done
+
+          if ((failed_count > 0)); then
+            echo "::error::DingTalk notification failed for ${failed_count} of ${target_count} targets"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Replace the single DingTalk webhook and signing-secret pair with the required `DINGTALK_TARGETS_JSON` secret containing paired `{webhook, secret}` objects.
- Translate release notes once, notify every configured target, and report aggregate failures after all targets are attempted.
- Mask extracted credentials, generated signatures, and signed webhook URLs in Actions logs.
- Remove compatibility with the legacy `DINGTALK_WEBHOOK` and `DINGTALK_SECRET` secrets.

## Testing

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/notify-dingtalk-release.yml`
- `yq eval . .github/workflows/notify-dingtalk-release.yml`
- Valid and invalid `DINGTALK_TARGETS_JSON` schema checks with `jq`
- DingTalk success and error response parsing checks with `jq`
- `task lint`
- `task build`
- `task test` — blocked in the existing macOS installer test because BSD `realpath` does not support `-m`; the cleanup path then reports an unbound array.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [ ] Tests added or updated for user-visible behavior; this workflow-only change was validated statically and with focused command checks.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.