### PR TITLE
fix(compose): rename MCP server config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ More runnable examples (cron, timeout, scheduler scripts) live in
 
 ## The compose file
 
-**Top-level fields:** `name`, `variables`, `agents`, `mcps`, `volumes`, `network`.
+**Top-level fields:** `name`, `variables`, `agents`, `mcp_servers`, `volumes`, `network`.
 
 **Common agent fields:** `provider`, `model`, `system_prompt`, `image`,
 `driver`, `env` (scalars or `{ value, secret }`), `workspace`, `scheduler`,
-`mcps`, `skills`, and `volumes`.
+`mcp_servers`, `skills`, and `volumes`.
 
 Provision an agent's workspace from a local path (`provider: local`) or a Git
 repository (`provider: git`):

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -98,10 +98,10 @@ agent-compose down                                # 停止 sandbox、禁用 sche
 
 ## Compose 配置
 
-**顶层字段：** `name`、`variables`、`agents`、`mcps`、`volumes`、`network`。
+**顶层字段：** `name`、`variables`、`agents`、`mcp_servers`、`volumes`、`network`。
 
 **agent 常用字段：** `provider`、`model`、`system_prompt`、`image`、`driver`、
-`env`（scalar 或 `{ value, secret }`）、`workspace`、`scheduler`、`mcps`、`skills`、`volumes`。
+`env`（scalar 或 `{ value, secret }`）、`workspace`、`scheduler`、`mcp_servers`、`skills`、`volumes`。
 
 为 agent 从本地路径（`provider: local`）或 Git 仓库（`provider: git`）配置 workspace：
 

--- a/pkg/agentcompose/adapters/agent_runner_test.go
+++ b/pkg/agentcompose/adapters/agent_runner_test.go
@@ -271,7 +271,7 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		root := t.TempDir()
 		session := &domain.Sandbox{Summary: domain.SandboxSummary{WorkspacePath: filepath.Join(root, "workspace")}}
 		payload, err := json.Marshal(map[string]any{
-			"mcps": map[string]any{
+			"mcp_servers": map[string]any{
 				"filesystem": map[string]any{"type": "local", "command": "npx", "args": []string{"-y", "server"}},
 				"docs":       map[string]any{"type": "remote", "transport": "http", "url": "https://docs.example/mcp"},
 			},
@@ -297,7 +297,7 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		root := t.TempDir()
 		session := &domain.Sandbox{Summary: domain.SandboxSummary{WorkspacePath: filepath.Join(root, "workspace")}}
 		payload, err := json.Marshal(map[string]any{
-			"mcps": map[string]any{
+			"mcp_servers": map[string]any{
 				"filesystem": map[string]any{"type": "local", "command": "npx", "args": []string{"-y", "server"}, "env": map[string]any{"TOKEN": map[string]any{"value": "secret"}}},
 			},
 		})
@@ -318,7 +318,7 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		root := t.TempDir()
 		session := &domain.Sandbox{Summary: domain.SandboxSummary{WorkspacePath: filepath.Join(root, "workspace")}}
 		payload, err := json.Marshal(map[string]any{
-			"mcps": map[string]any{
+			"mcp_servers": map[string]any{
 				"docs": map[string]any{"type": "remote", "transport": "sse", "url": "https://docs.example/sse"},
 			},
 		})
@@ -343,7 +343,7 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		if err := os.MkdirAll(filepath.Join(execution.HostSandboxHome(session), ".codex"), 0o755); err != nil {
 			t.Fatalf("MkdirAll returned error: %v", err)
 		}
-		_ = os.WriteFile(execution.HostAgentMCPConfigPath(session), []byte(`{"mcps":{"old":{}}}`), 0o644)
+		_ = os.WriteFile(execution.HostAgentMCPConfigPath(session), []byte(`{"mcp_servers":{"old":{}}}`), 0o644)
 		if err := os.WriteFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml"), []byte("# agent-compose managed mcp start\n[mcp_servers.old]\ncommand = \"old\"\n# agent-compose managed mcp end\n"), 0o644); err != nil {
 			t.Fatalf("WriteFile returned error: %v", err)
 		}

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -233,7 +233,7 @@ func ProjectSpecToProtoChecked(spec *compose.NormalizedProjectSpec) (*agentcompo
 		Agents:     AgentSpecsToProto(spec.Agents),
 		Network:    NetworkSpecToProto(spec.Network),
 		Volumes:    ProjectVolumeSpecsToProto(spec.Volumes),
-		Mcps:       MCPServerSpecsToProto(spec.MCPs),
+		McpServers: MCPServerSpecsToProto(spec.MCPServers),
 	}, nil
 }
 
@@ -273,7 +273,7 @@ func AgentSpecsToProto(agents []compose.NormalizedAgentSpec) []*agentcomposev2.A
 			Scheduler:    SchedulerSpecToProto(agent.Scheduler),
 			Jupyter:      JupyterSpecToProto(agent.Jupyter),
 			Volumes:      VolumeMountSpecsToProto(agent.Volumes),
-			Mcps:         MCPServerSpecsToProto(agent.MCPs),
+			McpServers:   MCPServerSpecsToProto(agent.MCPServers),
 			Status:       agentStatusToProto(agent.Status),
 		})
 	}
@@ -518,10 +518,10 @@ func ProjectSpecYAMLShape(spec *agentcomposev2.ProjectSpec) (map[string]any, []*
 	} else if len(volumes) > 0 {
 		root["volumes"] = volumes
 	}
-	if mcps, issues := MCPServerYAMLMap("mcps", spec.GetMcps()); len(issues) > 0 {
+	if mcps, issues := MCPServerYAMLMap("mcp_servers", spec.GetMcpServers()); len(issues) > 0 {
 		return nil, issues
 	} else if len(mcps) > 0 {
-		root["mcps"] = mcps
+		root["mcp_servers"] = mcps
 	}
 	if network := NetworkYAMLShape(spec.GetNetwork()); len(network) > 0 {
 		root["network"] = network
@@ -641,10 +641,10 @@ func AgentYAMLMap(agents []*agentcomposev2.AgentSpec) (map[string]any, []*agentc
 		if volumes := VolumeMountYAMLList(agent.GetVolumes()); len(volumes) > 0 {
 			raw["volumes"] = volumes
 		}
-		if mcps, issues := AgentMCPYAMLList(fmt.Sprintf("agents[%d].mcps", i), agent.GetMcps()); len(issues) > 0 {
+		if mcps, issues := AgentMCPYAMLList(fmt.Sprintf("agents[%d].mcp_servers", i), agent.GetMcpServers()); len(issues) > 0 {
 			return nil, issues
 		} else if len(mcps) > 0 {
-			raw["mcps"] = mcps
+			raw["mcp_servers"] = mcps
 		}
 		values[name] = raw
 	}

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -212,10 +212,10 @@ func TestIntegrationProjectSpecYAMLShapeIncludesWorkspaceRegistry(t *testing.T) 
 	}
 }
 
-func TestProjectSpecToProtoIncludesMCPs(t *testing.T) {
+func TestProjectSpecToProtoIncludesMCPServers(t *testing.T) {
 	spec := &compose.NormalizedProjectSpec{
 		Name: "mcp",
-		MCPs: map[string]compose.NormalizedMCPServerSpec{
+		MCPServers: map[string]compose.NormalizedMCPServerSpec{
 			"docs": {Type: "remote", Transport: "http", URL: "https://docs.example.com/mcp"},
 		},
 		Agents: []compose.NormalizedAgentSpec{{
@@ -225,28 +225,28 @@ func TestProjectSpecToProtoIncludesMCPs(t *testing.T) {
 				Name:   compose.DriverDocker,
 				Docker: &compose.DockerDriverSpec{},
 			},
-			MCPs: map[string]compose.NormalizedMCPServerSpec{
+			MCPServers: map[string]compose.NormalizedMCPServerSpec{
 				"docs": {Type: "remote", Transport: "http", URL: "https://docs.example.com/mcp"},
 			},
 		}},
 	}
 
 	response := ProjectSpecToProto(spec)
-	if response == nil || len(response.GetMcps()) != 1 {
-		t.Fatalf("project mcps missing: %#v", response)
+	if response == nil || len(response.GetMcpServers()) != 1 {
+		t.Fatalf("project mcp servers missing: %#v", response)
 	}
-	if response.GetMcps()[0].GetName() != "docs" || response.GetMcps()[0].GetUrl() != "https://docs.example.com/mcp" {
-		t.Fatalf("project mcps = %#v", response.GetMcps())
+	if response.GetMcpServers()[0].GetName() != "docs" || response.GetMcpServers()[0].GetUrl() != "https://docs.example.com/mcp" {
+		t.Fatalf("project mcp servers = %#v", response.GetMcpServers())
 	}
-	if len(response.GetAgents()) != 1 || len(response.GetAgents()[0].GetMcps()) != 1 {
-		t.Fatalf("agent mcps missing: %#v", response.GetAgents())
+	if len(response.GetAgents()) != 1 || len(response.GetAgents()[0].GetMcpServers()) != 1 {
+		t.Fatalf("agent mcp servers missing: %#v", response.GetAgents())
 	}
 }
 
-func TestProjectSpecYAMLShapeIncludesMCPs(t *testing.T) {
+func TestProjectSpecYAMLShapeIncludesMCPServers(t *testing.T) {
 	raw, issues := ProjectSpecYAMLShape(ProjectSpecToProto(&compose.NormalizedProjectSpec{
 		Name: "mcp",
-		MCPs: map[string]compose.NormalizedMCPServerSpec{
+		MCPServers: map[string]compose.NormalizedMCPServerSpec{
 			"filesystem": {Type: "local", Command: "npx", Args: []string{"server"}},
 		},
 		Agents: []compose.NormalizedAgentSpec{{
@@ -256,7 +256,7 @@ func TestProjectSpecYAMLShapeIncludesMCPs(t *testing.T) {
 				Name:   compose.DriverDocker,
 				Docker: &compose.DockerDriverSpec{},
 			},
-			MCPs: map[string]compose.NormalizedMCPServerSpec{
+			MCPServers: map[string]compose.NormalizedMCPServerSpec{
 				"filesystem": {Type: "local", Command: "npx", Args: []string{"server"}},
 			},
 		}},
@@ -264,9 +264,9 @@ func TestProjectSpecYAMLShapeIncludesMCPs(t *testing.T) {
 	if len(issues) > 0 {
 		t.Fatalf("issues = %#v", issues)
 	}
-	projectMCPs, ok := raw["mcps"].(map[string]any)
-	if !ok || len(projectMCPs) != 1 {
-		t.Fatalf("project mcps = %#v", raw["mcps"])
+	projectMCPServers, ok := raw["mcp_servers"].(map[string]any)
+	if !ok || len(projectMCPServers) != 1 {
+		t.Fatalf("project mcp servers = %#v", raw["mcp_servers"])
 	}
 	agents, ok := raw["agents"].(map[string]any)
 	if !ok {
@@ -276,8 +276,8 @@ func TestProjectSpecYAMLShapeIncludesMCPs(t *testing.T) {
 	if !ok {
 		t.Fatalf("reviewer = %#v", agents["reviewer"])
 	}
-	agentMCPs, ok := reviewer["mcps"].([]map[string]any)
-	if !ok || len(agentMCPs) != 1 || agentMCPs[0]["name"] != "filesystem" {
-		t.Fatalf("agent mcps = %#v", reviewer["mcps"])
+	agentMCPServers, ok := reviewer["mcp_servers"].([]map[string]any)
+	if !ok || len(agentMCPServers) != 1 || agentMCPServers[0]["name"] != "filesystem" {
+		t.Fatalf("agent mcp servers = %#v", reviewer["mcp_servers"])
 	}
 }

--- a/pkg/compose/mcp_test.go
+++ b/pkg/compose/mcp_test.go
@@ -8,7 +8,7 @@ import (
 func TestParseMCPConfig(t *testing.T) {
 	spec, err := Parse([]byte(`
 name: mcp-demo
-mcps:
+mcp_servers:
   filesystem:
     type: local
     command: npx
@@ -28,10 +28,10 @@ mcps:
 agents:
   reviewer:
     provider: codex
-    mcps: [filesystem, docs]
+    mcp_servers: [filesystem, docs]
   writer:
     provider: claude
-    mcps:
+    mcp_servers:
       - filesystem
       - name: notes
         type: local
@@ -41,17 +41,60 @@ agents:
 	if err != nil {
 		t.Fatalf("Parse returned error: %v", err)
 	}
-	if len(spec.MCPs) != 2 {
-		t.Fatalf("mcps = %#v", spec.MCPs)
+	if len(spec.MCPServers) != 2 {
+		t.Fatalf("mcp servers = %#v", spec.MCPServers)
 	}
-	if got := spec.MCPs["filesystem"].Command; got != "npx" {
+	if got := spec.MCPServers["filesystem"].Command; got != "npx" {
 		t.Fatalf("filesystem command = %q", got)
 	}
-	if got := spec.Agents["reviewer"].MCPs; len(got) != 2 || got[0].Ref != "filesystem" || got[1].Ref != "docs" {
-		t.Fatalf("reviewer mcps = %#v", got)
+	if got := spec.Agents["reviewer"].MCPServers; len(got) != 2 || got[0].Ref != "filesystem" || got[1].Ref != "docs" {
+		t.Fatalf("reviewer mcp servers = %#v", got)
 	}
-	if got := spec.Agents["writer"].MCPs; len(got) != 2 || got[0].Ref != "filesystem" || got[1].Name != "notes" || got[1].Command != "uvx" {
-		t.Fatalf("writer mcps = %#v", got)
+	if got := spec.Agents["writer"].MCPServers; len(got) != 2 || got[0].Ref != "filesystem" || got[1].Name != "notes" || got[1].Command != "uvx" {
+		t.Fatalf("writer mcp servers = %#v", got)
+	}
+}
+
+func TestParseRejectsLegacyMCPKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantField string
+	}{
+		{
+			name: "project",
+			raw: `
+name: legacy-project-mcp
+mcps:
+  filesystem:
+    type: local
+    command: npx
+`,
+			wantField: "mcps",
+		},
+		{
+			name: "agent",
+			raw: `
+name: legacy-agent-mcp
+agents:
+  reviewer:
+    provider: codex
+    mcps: [filesystem]
+`,
+			wantField: "agents.reviewer.mcps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.raw))
+			if err == nil {
+				t.Fatalf("expected Parse to reject legacy mcps field")
+			}
+			if got := err.Error(); !strings.Contains(got, tt.wantField) || !strings.Contains(got, "unknown field") {
+				t.Fatalf("error = %q, want unknown field %s", got, tt.wantField)
+			}
+		})
 	}
 }
 
@@ -61,7 +104,7 @@ name: invalid-mcp-ref
 agents:
   reviewer:
     provider: codex
-    mcps:
+    mcp_servers:
       name: docs
 `))
 	if err != nil {
@@ -71,7 +114,7 @@ agents:
 	if err == nil {
 		t.Fatalf("expected Normalize to fail")
 	}
-	if got := err.Error(); !strings.Contains(got, "agents.reviewer.mcps[0].type") {
+	if got := err.Error(); !strings.Contains(got, "agents.reviewer.mcp_servers[0].type") {
 		t.Fatalf("error = %q, want mcp path", got)
 	}
 }
@@ -79,7 +122,7 @@ agents:
 func TestNormalizeMCPConfig(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: mcp-demo
-mcps:
+mcp_servers:
   filesystem:
     type: local
     command: npx
@@ -99,7 +142,7 @@ mcps:
 agents:
   reviewer:
     provider: codex
-    mcps:
+    mcp_servers:
       - filesystem
       - docs
       - filesystem
@@ -117,28 +160,28 @@ agents:
 	if err != nil {
 		t.Fatalf("Normalize returned error: %v", err)
 	}
-	if got := normalized.MCPs["filesystem"].Env["TOKEN"]; got.Value != "mcp-secret" || !got.Secret {
+	if got := normalized.MCPServers["filesystem"].Env["TOKEN"]; got.Value != "mcp-secret" || !got.Secret {
 		t.Fatalf("filesystem env = %#v", got)
 	}
-	if got := normalized.MCPs["docs"].URL; got != "https://docs.example.com/mcp" {
+	if got := normalized.MCPServers["docs"].URL; got != "https://docs.example.com/mcp" {
 		t.Fatalf("docs url = %q", got)
 	}
-	if got := normalized.Agents[0].MCPs; len(got) != 3 || got["filesystem"].Command != "npx" || got["notes"].Command != "uvx" {
-		t.Fatalf("agent mcps = %#v", got)
+	if got := normalized.Agents[0].MCPServers; len(got) != 3 || got["filesystem"].Command != "npx" || got["notes"].Command != "uvx" {
+		t.Fatalf("agent mcp servers = %#v", got)
 	}
 }
 
 func TestNormalizeRejectsUndefinedMCPRef(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: undefined-mcp
-mcps:
+mcp_servers:
   filesystem:
     type: local
     command: npx
 agents:
   reviewer:
     provider: codex
-    mcps: [filesystem, missing]
+    mcp_servers: [filesystem, missing]
 `)
 
 	_, err := Normalize(spec, NormalizeOptions{})
@@ -160,20 +203,20 @@ func TestNormalizeRejectsInvalidMCPShape(t *testing.T) {
 			name: "local requires command",
 			raw: `
 name: bad-local
-mcps:
+mcp_servers:
   filesystem:
     type: local
 agents:
   reviewer:
     provider: codex
 `,
-			wantField: "mcps.filesystem.command",
+			wantField: "mcp_servers.filesystem.command",
 		},
 		{
 			name: "remote requires transport",
 			raw: `
 name: bad-remote
-mcps:
+mcp_servers:
   docs:
     type: remote
     url: https://docs.example.com/mcp
@@ -181,13 +224,13 @@ agents:
   reviewer:
     provider: codex
 `,
-			wantField: "mcps.docs.transport",
+			wantField: "mcp_servers.docs.transport",
 		},
 		{
 			name: "remote forbids env",
 			raw: `
 name: bad-remote-env
-mcps:
+mcp_servers:
   docs:
     type: remote
     transport: http
@@ -198,7 +241,7 @@ agents:
   reviewer:
     provider: codex
 `,
-			wantField: "mcps.docs.env",
+			wantField: "mcp_servers.docs.env",
 		},
 	}
 
@@ -219,7 +262,7 @@ agents:
 func TestRedactedOutputDoesNotLeakMCPSecrets(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: redacted-mcp
-mcps:
+mcp_servers:
   docs:
     type: remote
     transport: http
@@ -231,7 +274,7 @@ mcps:
 agents:
   reviewer:
     provider: codex
-    mcps: docs
+    mcp_servers: docs
 `)
 	normalized, err := Normalize(spec, NormalizeOptions{Env: map[string]string{"DOCS_TOKEN": "super-secret"}})
 	if err != nil {
@@ -245,7 +288,33 @@ agents:
 	if strings.Contains(text, "super-secret") {
 		t.Fatalf("redacted yaml leaked secret: %s", text)
 	}
-	if !strings.Contains(text, redactedEnvValue) || !strings.Contains(text, "mcps:") {
+	if !strings.Contains(text, redactedEnvValue) || !strings.Contains(text, "mcp_servers:") {
 		t.Fatalf("redacted yaml = %s", text)
+	}
+}
+
+func TestCanonicalMCPJSONUsesMCPServersKey(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: canonical-mcp
+mcp_servers:
+  filesystem:
+    type: local
+    command: npx
+agents:
+  reviewer:
+    provider: codex
+    mcp_servers: filesystem
+`)
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	data, err := normalized.MarshalCanonicalJSON(false)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON returned error: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"mcp_servers"`) || strings.Contains(text, `"mcps"`) {
+		t.Fatalf("canonical json = %s", text)
 	}
 }

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -40,7 +40,7 @@ type NormalizedProjectSpec struct {
 	Name       string                             `yaml:"name" json:"name"`
 	Variables  map[string]EnvVarSpec              `yaml:"variables,omitempty" json:"variables,omitempty"`
 	Workspaces map[string]WorkspaceSpec           `yaml:"workspaces,omitempty" json:"workspaces,omitempty"`
-	MCPs       map[string]NormalizedMCPServerSpec `yaml:"mcps,omitempty" json:"mcps,omitempty"`
+	MCPServers map[string]NormalizedMCPServerSpec `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	Volumes    map[string]NormalizedVolumeSpec    `yaml:"volumes,omitempty" json:"volumes,omitempty"`
 	Agents     []NormalizedAgentSpec              `yaml:"agents,omitempty" json:"agents,omitempty"`
 	Network    *NetworkSpec                       `yaml:"network,omitempty" json:"network,omitempty"`
@@ -56,7 +56,7 @@ type NormalizedAgentSpec struct {
 	Build        *NormalizedBuildSpec               `yaml:"build,omitempty" json:"build,omitempty"`
 	Driver       *NormalizedDriverSpec              `yaml:"driver" json:"driver"`
 	Env          map[string]EnvVarSpec              `yaml:"env,omitempty" json:"env,omitempty"`
-	MCPs         map[string]NormalizedMCPServerSpec `yaml:"mcps,omitempty" json:"mcps,omitempty"`
+	MCPServers   map[string]NormalizedMCPServerSpec `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	CapsetIDs    []string                           `yaml:"capset_ids,omitempty" json:"capset_ids,omitempty"`
 	Skills       []NormalizedSkillSpec              `yaml:"skills,omitempty" json:"skills,omitempty"`
 	Volumes      []NormalizedVolumeMountSpec        `yaml:"volumes,omitempty" json:"volumes,omitempty"`
@@ -189,11 +189,11 @@ func Normalize(spec *ProjectSpec, options NormalizeOptions) (*NormalizedProjectS
 		return nil, err
 	}
 	normalized.Workspaces = workspaces
-	mcps, err := normalizeMCPMap("mcps", spec.MCPs, options)
+	mcps, err := normalizeMCPMap("mcp_servers", spec.MCPServers, options)
 	if err != nil {
 		return nil, err
 	}
-	normalized.MCPs = mcps
+	normalized.MCPServers = mcps
 	if err := validateNetworkSpec(normalized.Network); err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func Normalize(spec *ProjectSpec, options NormalizeOptions) (*NormalizedProjectS
 			return nil, err
 		}
 		agent := spec.Agents[agentName]
-		normalizedAgent, err := normalizeAgent(agentName, agent, options, normalized.Volumes, normalized.Workspaces, normalized.MCPs)
+		normalizedAgent, err := normalizeAgent(agentName, agent, options, normalized.Volumes, normalized.Workspaces, normalized.MCPServers)
 		if err != nil {
 			return nil, err
 		}
@@ -236,7 +236,7 @@ func NormalizeFile(path string) (*NormalizedProjectSpec, error) {
 	return normalized, nil
 }
 
-func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, projectVolumes map[string]NormalizedVolumeSpec, projectWorkspaces map[string]WorkspaceSpec, projectMCPs map[string]NormalizedMCPServerSpec) (NormalizedAgentSpec, error) {
+func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, projectVolumes map[string]NormalizedVolumeSpec, projectWorkspaces map[string]WorkspaceSpec, projectMCPServers map[string]NormalizedMCPServerSpec) (NormalizedAgentSpec, error) {
 	status := strings.ToLower(strings.TrimSpace(agent.Status))
 	if status != "" && status != "enabled" && status != "disabled" {
 		return NormalizedAgentSpec{}, fmt.Errorf("%s.status must be enabled or disabled", joinPath("agents", name))
@@ -257,7 +257,7 @@ func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, proj
 	if err != nil {
 		return NormalizedAgentSpec{}, err
 	}
-	agentMCPs, err := normalizeAgentMCPEntries(joinPath("agents", name), agent.MCPs, projectMCPs, options)
+	agentMCPServers, err := normalizeAgentMCPEntries(joinPath("agents", name), agent.MCPServers, projectMCPServers, options)
 	if err != nil {
 		return NormalizedAgentSpec{}, err
 	}
@@ -291,7 +291,7 @@ func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, proj
 		Build:        build,
 		Driver:       driver,
 		Env:          env,
-		MCPs:         agentMCPs,
+		MCPServers:   agentMCPServers,
 		CapsetIDs:    normalizeStringList(agent.CapsetIDs),
 		Skills:       skills,
 		Volumes:      volumes,
@@ -498,16 +498,16 @@ func normalizeMCPServer(path string, server MCPServerSpec, options NormalizeOpti
 	}
 }
 
-func normalizeAgentMCPEntries(path string, entries AgentMCPEntriesSpec, projectMCPs map[string]NormalizedMCPServerSpec, options NormalizeOptions) (map[string]NormalizedMCPServerSpec, error) {
+func normalizeAgentMCPEntries(path string, entries AgentMCPEntriesSpec, projectMCPServers map[string]NormalizedMCPServerSpec, options NormalizeOptions) (map[string]NormalizedMCPServerSpec, error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
 	result := make(map[string]NormalizedMCPServerSpec, len(entries))
 	seenNames := make(map[string]string, len(entries))
 	for index, entry := range entries {
-		itemPath := fmt.Sprintf("%s.mcps[%d]", path, index)
+		itemPath := fmt.Sprintf("%s.mcp_servers[%d]", path, index)
 		if ref := strings.TrimSpace(entry.Ref); ref != "" {
-			server, ok := projectMCPs[ref]
+			server, ok := projectMCPServers[ref]
 			if !ok {
 				return nil, &ValidationError{Path: itemPath, Message: fmt.Sprintf("mcp %q is not defined", ref)}
 			}

--- a/pkg/compose/output.go
+++ b/pkg/compose/output.go
@@ -21,7 +21,7 @@ type orderedProjectSpec struct {
 	Name       string                  `yaml:"name" json:"name"`
 	Variables  []orderedEnvVarSpec     `yaml:"variables,omitempty" json:"variables,omitempty"`
 	Workspaces []orderedNamedWorkspace `yaml:"workspaces,omitempty" json:"workspaces,omitempty"`
-	MCPs       []orderedMCPServerSpec  `yaml:"mcps,omitempty" json:"mcps,omitempty"`
+	MCPServers []orderedMCPServerSpec  `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	Volumes    []orderedVolumeSpec     `yaml:"volumes,omitempty" json:"volumes,omitempty"`
 	Agents     []orderedAgentSpec      `yaml:"agents,omitempty" json:"agents,omitempty"`
 	Network    *NetworkSpec            `yaml:"network,omitempty" json:"network,omitempty"`
@@ -46,7 +46,7 @@ type orderedAgentSpec struct {
 	Build        *NormalizedBuildSpec        `yaml:"build,omitempty" json:"build,omitempty"`
 	Driver       *NormalizedDriverSpec       `yaml:"driver" json:"driver"`
 	Env          []orderedEnvVarSpec         `yaml:"env,omitempty" json:"env,omitempty"`
-	MCPs         []orderedMCPServerSpec      `yaml:"mcps,omitempty" json:"mcps,omitempty"`
+	MCPServers   []orderedMCPServerSpec      `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	CapsetIDs    []string                    `yaml:"capset_ids,omitempty" json:"capset_ids,omitempty"`
 	Skills       []NormalizedSkillSpec       `yaml:"skills,omitempty" json:"skills,omitempty"`
 	Volumes      []NormalizedVolumeMountSpec `yaml:"volumes,omitempty" json:"volumes,omitempty"`
@@ -126,7 +126,7 @@ func (s *NormalizedProjectSpec) ordered(redactSecrets bool) orderedProjectSpec {
 	if s == nil {
 		return orderedProjectSpec{}
 	}
-	mcps := orderedMCPServers(s.MCPs, redactSecrets)
+	mcps := orderedMCPServers(s.MCPServers, redactSecrets)
 	agents := make([]orderedAgentSpec, 0, len(s.Agents))
 	for _, agent := range s.Agents {
 		agents = append(agents, orderedAgentSpec{
@@ -139,7 +139,7 @@ func (s *NormalizedProjectSpec) ordered(redactSecrets bool) orderedProjectSpec {
 			Build:        cloneNormalizedBuildSpec(agent.Build),
 			Driver:       cloneNormalizedDriverSpec(agent.Driver),
 			Env:          orderedEnvVars(agent.Env, redactSecrets),
-			MCPs:         orderedMCPServers(agent.MCPs, redactSecrets),
+			MCPServers:   orderedMCPServers(agent.MCPServers, redactSecrets),
 			CapsetIDs:    slices.Clone(agent.CapsetIDs),
 			Skills:       cloneNormalizedSkillSpecs(agent.Skills),
 			Volumes:      cloneNormalizedVolumeMountSpecs(agent.Volumes),
@@ -155,7 +155,7 @@ func (s *NormalizedProjectSpec) ordered(redactSecrets bool) orderedProjectSpec {
 		Name:       s.Name,
 		Variables:  orderedEnvVars(s.Variables, redactSecrets),
 		Workspaces: orderedWorkspaces(s.Workspaces),
-		MCPs:       mcps,
+		MCPServers: mcps,
 		Volumes:    orderedVolumes(s.Volumes),
 		Agents:     agents,
 		Network:    cloneNetworkSpecForOutput(s.Network),
@@ -168,7 +168,7 @@ func (s *NormalizedProjectSpec) clone(redactSecrets bool) *NormalizedProjectSpec
 		Name:       ordered.Name,
 		Variables:  envVarMapFromOrdered(ordered.Variables),
 		Workspaces: workspaceMapFromOrdered(ordered.Workspaces),
-		MCPs:       mcpMapFromOrdered(ordered.MCPs),
+		MCPServers: mcpMapFromOrdered(ordered.MCPServers),
 		Volumes:    volumeMapFromOrdered(ordered.Volumes),
 		Network:    ordered.Network,
 	}
@@ -183,7 +183,7 @@ func (s *NormalizedProjectSpec) clone(redactSecrets bool) *NormalizedProjectSpec
 			Build:        agent.Build,
 			Driver:       agent.Driver,
 			Env:          envVarMapFromOrdered(agent.Env),
-			MCPs:         mcpMapFromOrdered(agent.MCPs),
+			MCPServers:   mcpMapFromOrdered(agent.MCPServers),
 			CapsetIDs:    slices.Clone(agent.CapsetIDs),
 			Skills:       cloneNormalizedSkillSpecs(agent.Skills),
 			Volumes:      cloneNormalizedVolumeMountSpecs(agent.Volumes),

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -13,7 +13,7 @@ type ProjectSpec struct {
 	EnvFiles   EnvFileSpec              `yaml:"env_file,omitempty" json:"env_file,omitempty"`
 	Variables  map[string]EnvVarSpec    `yaml:"variables,omitempty" json:"variables,omitempty"`
 	Workspaces map[string]WorkspaceSpec `yaml:"workspaces,omitempty" json:"workspaces,omitempty"`
-	MCPs       map[string]MCPServerSpec `yaml:"mcps,omitempty" json:"mcps,omitempty"`
+	MCPServers map[string]MCPServerSpec `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	Volumes    map[string]VolumeSpec    `yaml:"volumes,omitempty" json:"volumes,omitempty"`
 	Agents     map[string]AgentSpec     `yaml:"agents,omitempty" json:"agents,omitempty"`
 	Network    *NetworkSpec             `yaml:"network,omitempty" json:"network,omitempty"`
@@ -52,7 +52,7 @@ type AgentSpec struct {
 	Build        *BuildSpec            `yaml:"build,omitempty" json:"build,omitempty"`
 	Driver       *DriverSpec           `yaml:"driver,omitempty" json:"driver,omitempty"`
 	Env          map[string]EnvVarSpec `yaml:"env,omitempty" json:"env,omitempty"`
-	MCPs         AgentMCPEntriesSpec   `yaml:"mcps,omitempty" json:"mcps,omitempty"`
+	MCPServers   AgentMCPEntriesSpec   `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 	CapsetIDs    []string              `yaml:"capset_ids,omitempty" json:"capset_ids,omitempty"`
 	Skills       []SkillSpec           `yaml:"skills,omitempty" json:"skills,omitempty"`
 	Volumes      []VolumeMountSpec     `yaml:"volumes,omitempty" json:"volumes,omitempty"`
@@ -465,14 +465,14 @@ type nodeValidator func(node *yaml.Node, path string) error
 
 func validateProjectNode(node *yaml.Node) error {
 	return validateMapping(node, "", map[string]nodeValidator{
-		"name":       validateScalar,
-		"env_file":   validateScalarOrStringList,
-		"variables":  validateEnvVarMap,
-		"workspaces": validateWorkspaceMap,
-		"mcps":       validateMCPMap,
-		"volumes":    validateVolumeMap,
-		"agents":     validateAgentMap,
-		"network":    validateNetwork,
+		"name":        validateScalar,
+		"env_file":    validateScalarOrStringList,
+		"variables":   validateEnvVarMap,
+		"workspaces":  validateWorkspaceMap,
+		"mcp_servers": validateMCPMap,
+		"volumes":     validateVolumeMap,
+		"agents":      validateAgentMap,
+		"network":     validateNetwork,
 	})
 }
 
@@ -501,7 +501,7 @@ func validateAgent(node *yaml.Node, path string) error {
 		"build":         validateBuild,
 		"driver":        validateDriver,
 		"env":           validateEnvVarMap,
-		"mcps":          validateAgentMCPEntries,
+		"mcp_servers":   validateAgentMCPEntries,
 		"capset_ids":    validateStringList,
 		"skills":        validateSkillList,
 		"volumes":       validateVolumeMountList,

--- a/pkg/execution/mcp_config.go
+++ b/pkg/execution/mcp_config.go
@@ -11,7 +11,7 @@ import (
 )
 
 type AgentMCPConfigPayload struct {
-	MCPs map[string]compose.NormalizedMCPServerSpec `json:"mcps,omitempty"`
+	MCPServers map[string]compose.NormalizedMCPServerSpec `json:"mcp_servers,omitempty"`
 }
 
 func HostAgentMCPConfigPath(session *domain.Sandbox) string {
@@ -38,7 +38,7 @@ func WriteAgentMCPConfigFile(session *domain.Sandbox, mcps map[string]compose.No
 	if err := os.MkdirAll(filepath.Dir(hostPath), 0o755); err != nil {
 		return fmt.Errorf("create agent mcp config dir: %w", err)
 	}
-	if err := WriteJSONArtifact(hostPath, AgentMCPConfigPayload{MCPs: mcps}); err != nil {
+	if err := WriteJSONArtifact(hostPath, AgentMCPConfigPayload{MCPServers: mcps}); err != nil {
 		return fmt.Errorf("write agent mcp config file: %w", err)
 	}
 	return nil

--- a/pkg/execution/mcp_config_test.go
+++ b/pkg/execution/mcp_config_test.go
@@ -24,7 +24,7 @@ func TestWriteAgentMCPConfigFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile returned error: %v", err)
 	}
-	if !strings.Contains(string(data), `"mcps"`) || !strings.Contains(string(data), `"filesystem"`) {
+	if !strings.Contains(string(data), `"mcp_servers"`) || !strings.Contains(string(data), `"filesystem"`) {
 		t.Fatalf("config = %q", string(data))
 	}
 	if err := WriteAgentMCPConfigFile(session, nil); err != nil {

--- a/pkg/llms/mcp_config.go
+++ b/pkg/llms/mcp_config.go
@@ -9,8 +9,8 @@ import (
 )
 
 type AgentConfigPayload struct {
-	Jupyter *compose.JupyterSpec                       `json:"jupyter,omitempty"`
-	MCPs    map[string]compose.NormalizedMCPServerSpec `json:"mcps,omitempty"`
+	Jupyter    *compose.JupyterSpec                       `json:"jupyter,omitempty"`
+	MCPServers map[string]compose.NormalizedMCPServerSpec `json:"mcp_servers,omitempty"`
 }
 
 func AgentMCPConfig(definition domain.AgentDefinition) map[string]compose.NormalizedMCPServerSpec {
@@ -22,8 +22,8 @@ func AgentMCPConfig(definition domain.AgentDefinition) map[string]compose.Normal
 	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
 		return nil
 	}
-	if len(payload.MCPs) == 0 {
+	if len(payload.MCPServers) == 0 {
 		return nil
 	}
-	return payload.MCPs
+	return payload.MCPServers
 }

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -136,14 +136,14 @@ func normalizedAgentFromLegacy(definition domain.AgentDefinition) (compose.Norma
 		Skills:       legacySkills(definition.Skills),
 		Volumes:      legacyVolumes(definition.Volumes),
 		Jupyter:      config.Jupyter,
-		MCPs:         config.MCPs,
+		MCPServers:   config.MCPServers,
 	}
 	return agent, nil
 }
 
 type legacyAgentConfig struct {
-	Jupyter *compose.JupyterSpec                       `json:"jupyter,omitempty"`
-	MCPs    map[string]compose.NormalizedMCPServerSpec `json:"mcps,omitempty"`
+	Jupyter    *compose.JupyterSpec                       `json:"jupyter,omitempty"`
+	MCPServers map[string]compose.NormalizedMCPServerSpec `json:"mcp_servers,omitempty"`
 }
 
 func decodeLegacyAgentConfig(raw string) (legacyAgentConfig, error) {

--- a/pkg/projects/records.go
+++ b/pkg/projects/records.go
@@ -84,7 +84,7 @@ func NewAgentRecordsFromSpec(projectID string, revision int64, spec *compose.Nor
 func NewAgentDefinitionsFromSpec(project domain.ProjectRecord, revision int64, spec *compose.NormalizedProjectSpec) ([]domain.AgentDefinition, error) {
 	agents := make([]domain.AgentDefinition, 0, len(spec.Agents))
 	for _, agent := range spec.Agents {
-		record, err := NewAgentDefinitionFromSpec(project, revision, agent, spec.MCPs)
+		record, err := NewAgentDefinitionFromSpec(project, revision, agent, spec.MCPServers)
 		if err != nil {
 			return nil, err
 		}
@@ -93,12 +93,12 @@ func NewAgentDefinitionsFromSpec(project domain.ProjectRecord, revision int64, s
 	return agents, nil
 }
 
-func NewAgentDefinitionFromSpec(project domain.ProjectRecord, revision int64, agent compose.NormalizedAgentSpec, projectMCPs map[string]compose.NormalizedMCPServerSpec) (domain.AgentDefinition, error) {
+func NewAgentDefinitionFromSpec(project domain.ProjectRecord, revision int64, agent compose.NormalizedAgentSpec, projectMCPServers map[string]compose.NormalizedMCPServerSpec) (domain.AgentDefinition, error) {
 	managedAgentID, err := domain.StableManagedAgentID(project.ID, agent.Name)
 	if err != nil {
 		return domain.AgentDefinition{}, err
 	}
-	configJSON, err := agentDefinitionConfigJSON(agent, projectMCPs)
+	configJSON, err := agentDefinitionConfigJSON(agent, projectMCPServers)
 	if err != nil {
 		return domain.AgentDefinition{}, fmt.Errorf("marshal managed agent %s config: %w", agent.Name, err)
 	}
@@ -131,24 +131,24 @@ func agentEnabled(agent compose.NormalizedAgentSpec) bool {
 }
 
 type agentDefinitionConfigPayload struct {
-	Jupyter *compose.JupyterSpec                       `json:"jupyter,omitempty"`
-	MCPs    map[string]compose.NormalizedMCPServerSpec `json:"mcps,omitempty"`
+	Jupyter    *compose.JupyterSpec                       `json:"jupyter,omitempty"`
+	MCPServers map[string]compose.NormalizedMCPServerSpec `json:"mcp_servers,omitempty"`
 }
 
-func agentDefinitionConfigJSON(agent compose.NormalizedAgentSpec, projectMCPs map[string]compose.NormalizedMCPServerSpec) (string, error) {
+func agentDefinitionConfigJSON(agent compose.NormalizedAgentSpec, projectMCPServers map[string]compose.NormalizedMCPServerSpec) (string, error) {
 	payload := agentDefinitionConfigPayload{
-		Jupyter: agent.Jupyter,
-		MCPs:    selectedAgentMCPs(agent, projectMCPs),
+		Jupyter:    agent.Jupyter,
+		MCPServers: selectedAgentMCPServers(agent, projectMCPServers),
 	}
-	if payload.Jupyter == nil && len(payload.MCPs) == 0 {
+	if payload.Jupyter == nil && len(payload.MCPServers) == 0 {
 		return "{}", nil
 	}
 	data, err := MarshalCanonicalJSON(struct {
-		Jupyter *compose.JupyterSpec                       `json:"jupyter,omitempty"`
-		MCPs    map[string]compose.NormalizedMCPServerSpec `json:"mcps,omitempty"`
+		Jupyter    *compose.JupyterSpec                       `json:"jupyter,omitempty"`
+		MCPServers map[string]compose.NormalizedMCPServerSpec `json:"mcp_servers,omitempty"`
 	}{
-		Jupyter: payload.Jupyter,
-		MCPs:    payload.MCPs,
+		Jupyter:    payload.Jupyter,
+		MCPServers: payload.MCPServers,
 	})
 	if err != nil {
 		return "", err
@@ -156,10 +156,10 @@ func agentDefinitionConfigJSON(agent compose.NormalizedAgentSpec, projectMCPs ma
 	return string(data), nil
 }
 
-func selectedAgentMCPs(agent compose.NormalizedAgentSpec, projectMCPs map[string]compose.NormalizedMCPServerSpec) map[string]compose.NormalizedMCPServerSpec {
-	if len(agent.MCPs) > 0 {
-		result := make(map[string]compose.NormalizedMCPServerSpec, len(agent.MCPs))
-		for name, server := range agent.MCPs {
+func selectedAgentMCPServers(agent compose.NormalizedAgentSpec, projectMCPServers map[string]compose.NormalizedMCPServerSpec) map[string]compose.NormalizedMCPServerSpec {
+	if len(agent.MCPServers) > 0 {
+		result := make(map[string]compose.NormalizedMCPServerSpec, len(agent.MCPServers))
+		for name, server := range agent.MCPServers {
 			result[name] = server
 		}
 		return result

--- a/pkg/projects/records_test.go
+++ b/pkg/projects/records_test.go
@@ -119,7 +119,7 @@ func TestNewAgentDefinitionFromSpecPreservesMCPConfig(t *testing.T) {
 	agent := compose.NormalizedAgentSpec{
 		Name:     "reviewer",
 		Provider: "codex",
-		MCPs: map[string]compose.NormalizedMCPServerSpec{
+		MCPServers: map[string]compose.NormalizedMCPServerSpec{
 			"filesystem": {
 				Type:    "local",
 				Command: "npx",
@@ -135,20 +135,20 @@ func TestNewAgentDefinitionFromSpecPreservesMCPConfig(t *testing.T) {
 			},
 		},
 	}
-	projectMCPs := map[string]compose.NormalizedMCPServerSpec{}
+	projectMCPServers := map[string]compose.NormalizedMCPServerSpec{}
 
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, projectMCPs)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, projectMCPServers)
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
 	var config struct {
-		MCPs map[string]compose.NormalizedMCPServerSpec `json:"mcps"`
+		MCPServers map[string]compose.NormalizedMCPServerSpec `json:"mcp_servers"`
 	}
 	if err := json.Unmarshal([]byte(definition.ConfigJSON), &config); err != nil {
 		t.Fatalf("unmarshal config json: %v", err)
 	}
-	if len(config.MCPs) != 2 || config.MCPs["filesystem"].Command != "npx" || config.MCPs["docs"].Transport != "http" {
-		t.Fatalf("config json = %s, want mcps preserved", definition.ConfigJSON)
+	if len(config.MCPServers) != 2 || config.MCPServers["filesystem"].Command != "npx" || config.MCPServers["docs"].Transport != "http" {
+		t.Fatalf("config json = %s, want mcp_servers preserved", definition.ConfigJSON)
 	}
 }
 

--- a/pkg/runs/preparation_mcp_test.go
+++ b/pkg/runs/preparation_mcp_test.go
@@ -1,0 +1,20 @@
+package runs
+
+import "testing"
+
+func TestDecodeRevisionSpecSupportsMCPServers(t *testing.T) {
+	decoded, err := DecodeRevisionSpec(`{
+		"name":"mcp-project",
+		"mcp_servers":[{"name":"docs","type":"remote","transport":"http","url":"https://docs.example.com/mcp"}],
+		"agents":[{"name":"reviewer","mcp_servers":[{"name":"docs","type":"remote","transport":"http","url":"https://docs.example.com/mcp"}]}]
+	}`)
+	if err != nil {
+		t.Fatalf("DecodeRevisionSpec returned error: %v", err)
+	}
+	if len(decoded.GetMcpServers()) != 1 || decoded.GetMcpServers()[0].GetName() != "docs" {
+		t.Fatalf("project mcp servers = %#v", decoded.GetMcpServers())
+	}
+	if len(decoded.GetAgents()) != 1 || len(decoded.GetAgents()[0].GetMcpServers()) != 1 {
+		t.Fatalf("agent mcp servers = %#v", decoded.GetAgents())
+	}
+}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -3752,7 +3752,7 @@ type ProjectSpec struct {
 	Network       *NetworkSpec           `protobuf:"bytes,5,opt,name=network,proto3" json:"network,omitempty"`
 	Volumes       []*ProjectVolumeSpec   `protobuf:"bytes,6,rep,name=volumes,proto3" json:"volumes,omitempty"`
 	Workspaces    []*NamedWorkspaceSpec  `protobuf:"bytes,7,rep,name=workspaces,proto3" json:"workspaces,omitempty"`
-	Mcps          []*MCPServerSpec       `protobuf:"bytes,8,rep,name=mcps,proto3" json:"mcps,omitempty"`
+	McpServers    []*MCPServerSpec       `protobuf:"bytes,8,rep,name=mcp_servers,json=mcpServers,proto3" json:"mcp_servers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3829,9 +3829,9 @@ func (x *ProjectSpec) GetWorkspaces() []*NamedWorkspaceSpec {
 	return nil
 }
 
-func (x *ProjectSpec) GetMcps() []*MCPServerSpec {
+func (x *ProjectSpec) GetMcpServers() []*MCPServerSpec {
 	if x != nil {
-		return x.Mcps
+		return x.McpServers
 	}
 	return nil
 }
@@ -3903,7 +3903,7 @@ type AgentSpec struct {
 	Jupyter       *JupyterSpec           `protobuf:"bytes,11,opt,name=jupyter,proto3" json:"jupyter,omitempty"`
 	Build         *BuildSpec             `protobuf:"bytes,12,opt,name=build,proto3" json:"build,omitempty"`
 	Volumes       []*VolumeMountSpec     `protobuf:"bytes,13,rep,name=volumes,proto3" json:"volumes,omitempty"`
-	Mcps          []*MCPServerSpec       `protobuf:"bytes,14,rep,name=mcps,proto3" json:"mcps,omitempty"`
+	McpServers    []*MCPServerSpec       `protobuf:"bytes,14,rep,name=mcp_servers,json=mcpServers,proto3" json:"mcp_servers,omitempty"`
 	Skills        []*SkillSpec           `protobuf:"bytes,15,rep,name=skills,proto3" json:"skills,omitempty"`
 	Status        AgentStatus            `protobuf:"varint,16,opt,name=status,proto3,enum=agentcompose.v2.AgentStatus" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -4031,9 +4031,9 @@ func (x *AgentSpec) GetVolumes() []*VolumeMountSpec {
 	return nil
 }
 
-func (x *AgentSpec) GetMcps() []*MCPServerSpec {
+func (x *AgentSpec) GetMcpServers() []*MCPServerSpec {
 	if x != nil {
-		return x.Mcps
+		return x.McpServers
 	}
 	return nil
 }
@@ -15802,7 +15802,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\vresource_id\x18\x03 \x01(\tR\n" +
 	"resourceId\x12\x12\n" +
 	"\x04name\x18\x04 \x01(\tR\x04name\x12\x18\n" +
-	"\amessage\x18\x05 \x01(\tR\amessage\"\x90\x03\n" +
+	"\amessage\x18\x05 \x01(\tR\amessage\"\x9d\x03\n" +
 	"\vProjectSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
 	"\tvariables\x18\x02 \x03(\v2\x1b.agentcompose.v2.EnvVarSpecR\tvariables\x122\n" +
@@ -15811,11 +15811,12 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\avolumes\x18\x06 \x03(\v2\".agentcompose.v2.ProjectVolumeSpecR\avolumes\x12C\n" +
 	"\n" +
 	"workspaces\x18\a \x03(\v2#.agentcompose.v2.NamedWorkspaceSpecR\n" +
-	"workspaces\x122\n" +
-	"\x04mcps\x18\b \x03(\v2\x1e.agentcompose.v2.MCPServerSpecR\x04mcpsJ\x04\b\x03\x10\x04R\tworkspace\"f\n" +
+	"workspaces\x12?\n" +
+	"\vmcp_servers\x18\b \x03(\v2\x1e.agentcompose.v2.MCPServerSpecR\n" +
+	"mcpServersJ\x04\b\x03\x10\x04R\tworkspace\"f\n" +
 	"\x12NamedWorkspaceSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12<\n" +
-	"\tworkspace\x18\x02 \x01(\v2\x1e.agentcompose.v2.WorkspaceSpecR\tworkspace\"\xcf\x05\n" +
+	"\tworkspace\x18\x02 \x01(\v2\x1e.agentcompose.v2.WorkspaceSpecR\tworkspace\"\xdc\x05\n" +
 	"\tAgentSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\bprovider\x18\x02 \x01(\tR\bprovider\x12\x14\n" +
@@ -15831,8 +15832,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	" \x03(\tR\tcapsetIds\x126\n" +
 	"\ajupyter\x18\v \x01(\v2\x1c.agentcompose.v2.JupyterSpecR\ajupyter\x120\n" +
 	"\x05build\x18\f \x01(\v2\x1a.agentcompose.v2.BuildSpecR\x05build\x12:\n" +
-	"\avolumes\x18\r \x03(\v2 .agentcompose.v2.VolumeMountSpecR\avolumes\x122\n" +
-	"\x04mcps\x18\x0e \x03(\v2\x1e.agentcompose.v2.MCPServerSpecR\x04mcps\x122\n" +
+	"\avolumes\x18\r \x03(\v2 .agentcompose.v2.VolumeMountSpecR\avolumes\x12?\n" +
+	"\vmcp_servers\x18\x0e \x03(\v2\x1e.agentcompose.v2.MCPServerSpecR\n" +
+	"mcpServers\x122\n" +
 	"\x06skills\x18\x0f \x03(\v2\x1a.agentcompose.v2.SkillSpecR\x06skills\x124\n" +
 	"\x06status\x18\x10 \x01(\x0e2\x1c.agentcompose.v2.AgentStatusR\x06status\"\xfb\x01\n" +
 	"\rMCPServerSpec\x12\x12\n" +
@@ -17378,7 +17380,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	70,  // 52: agentcompose.v2.ProjectSpec.network:type_name -> agentcompose.v2.NetworkSpec
 	64,  // 53: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
 	61,  // 54: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
-	63,  // 55: agentcompose.v2.ProjectSpec.mcps:type_name -> agentcompose.v2.MCPServerSpec
+	63,  // 55: agentcompose.v2.ProjectSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
 	69,  // 56: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
 	74,  // 57: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
 	67,  // 58: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
@@ -17387,7 +17389,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	179, // 61: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
 	66,  // 62: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
 	65,  // 63: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	63,  // 64: agentcompose.v2.AgentSpec.mcps:type_name -> agentcompose.v2.MCPServerSpec
+	63,  // 64: agentcompose.v2.AgentSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
 	183, // 65: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
 	5,   // 66: agentcompose.v2.AgentSpec.status:type_name -> agentcompose.v2.AgentStatus
 	67,  // 67: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -550,7 +550,7 @@ message ProjectSpec {
   NetworkSpec network = 5;
   repeated ProjectVolumeSpec volumes = 6;
   repeated NamedWorkspaceSpec workspaces = 7;
-  repeated MCPServerSpec mcps = 8;
+  repeated MCPServerSpec mcp_servers = 8;
 }
 
 message NamedWorkspaceSpec {
@@ -572,7 +572,7 @@ message AgentSpec {
   JupyterSpec jupyter = 11;
   BuildSpec build = 12;
   repeated VolumeMountSpec volumes = 13;
-  repeated MCPServerSpec mcps = 14;
+  repeated MCPServerSpec mcp_servers = 14;
   repeated SkillSpec skills = 15;
   AgentStatus status = 16;
 }

--- a/runtime/javascript/src/mcp-config.ts
+++ b/runtime/javascript/src/mcp-config.ts
@@ -17,7 +17,7 @@ export type RuntimeMCPServer = {
 };
 
 export type RuntimeMCPConfig = {
-  mcps?: Record<string, RuntimeMCPServer>;
+  mcp_servers?: Record<string, RuntimeMCPServer>;
 };
 
 const mcpConfigRelativePath = path.join("agents", "mcp", "config.json");

--- a/runtime/javascript/src/prompt.ts
+++ b/runtime/javascript/src/prompt.ts
@@ -48,7 +48,7 @@ export async function buildPromptRuntimeOptions(commandOptions: Omit<PromptComma
     systemContext: provider === "gemini" || provider === "codex"
       ? await appendSkillCatalogContext(baseSystemContext, home, skills)
       : baseSystemContext,
-    mcpConfig: mcpConfig.mcps,
+    mcpConfig: mcpConfig.mcp_servers,
     skills,
     outputSchema,
   };

--- a/runtime/javascript/test/runtime.e2e.test.ts
+++ b/runtime/javascript/test/runtime.e2e.test.ts
@@ -302,7 +302,7 @@ describe("runtime JavaScript E2E", () => {
       await fs.writeFile(messageFile, "gemini prompt", "utf8");
       await fs.mkdir(path.join(stateRoot, "agents", "mcp"), { recursive: true });
       await fs.writeFile(path.join(stateRoot, "agents", "mcp", "config.json"), JSON.stringify({
-		mcps: {
+		mcp_servers: {
 			docs: {
 				type: "remote",
 				transport: "http",
@@ -356,7 +356,7 @@ describe("runtime JavaScript E2E", () => {
       }), "utf8");
       await fs.mkdir(path.join(stateRoot, "agents", "mcp"), { recursive: true });
       await fs.writeFile(path.join(stateRoot, "agents", "mcp", "config.json"), JSON.stringify({
-		mcps: {
+		mcp_servers: {
 			filesystem: { type: "local", command: "npx", args: ["-y", "server"] },
 			docs: {
 				type: "remote",
@@ -416,7 +416,7 @@ describe("runtime JavaScript E2E", () => {
 			await fs.writeFile(messageFile, "opencode prompt", "utf8");
 			await fs.mkdir(path.join(stateRoot, "agents", "mcp"), { recursive: true });
 			await fs.writeFile(path.join(stateRoot, "agents", "mcp", "config.json"), JSON.stringify({
-				mcps: {
+				mcp_servers: {
 					filesystem: {
 						type: "local",
 						command: "npx",


### PR DESCRIPTION
## Summary

- rename the project and agent MCP configuration key from `mcps` to `mcp_servers`
- propagate the new key through canonical JSON, persisted/runtime payloads, and protobuf while preserving field numbers
- reject the legacy YAML key and update documentation and regression coverage

## Testing

- `GOFLAGS=-buildvcs=false task lint`
- `GOFLAGS=-buildvcs=false npm_config_cache=$PWD/.cache/npm task build`
- `GOFLAGS=-buildvcs=false ./scripts/test-coverage.sh`
- `buf lint`
- focused Go tests and runtime JavaScript typecheck/E2E tests