### PR TITLE
fix(runs): index capability tokens for project sandboxes

### DIFF
--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -2148,7 +2148,14 @@ func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain
 	}
 	domain.RestoreSandboxTransientFields(loaded, sandbox)
 	*sandbox = *loaded
+	c.indexCapabilitySandbox(sandbox)
 	return nil
+}
+
+func (c *Controller) indexCapabilitySandbox(sandbox *domain.Sandbox) {
+	if c != nil && c.capTokens != nil {
+		c.capTokens.IndexSandbox(sandbox)
+	}
 }
 
 func (c *Controller) publishProjectRunSandboxStarted(ctx context.Context, sandbox *domain.Sandbox, eventType, message string) {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -2158,6 +2158,12 @@ func (c *Controller) indexCapabilitySandbox(sandbox *domain.Sandbox) {
 	}
 }
 
+func (c *Controller) revokeCapabilitySandbox(sandboxID string) {
+	if c != nil && c.capTokens != nil {
+		c.capTokens.RevokeSandbox(sandboxID)
+	}
+}
+
 func (c *Controller) publishProjectRunSandboxStarted(ctx context.Context, sandbox *domain.Sandbox, eventType, message string) {
 	if c.streams != nil {
 		c.streams.PublishSandboxUpdated(&sandbox.Summary)
@@ -2214,8 +2220,11 @@ func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandb
 	sandbox := sandboxResult.Sandbox
 	if CleanupPolicyRemovesSandbox(policy) && sandboxResult.Created {
 		if c.removal != nil {
-			_, err := c.removal.Remove(ctx, sandbox.Summary.ID, true)
-			return err
+			if _, err := c.removal.Remove(ctx, sandbox.Summary.ID, true); err != nil {
+				return err
+			}
+			c.revokeCapabilitySandbox(sandbox.Summary.ID)
+			return nil
 		}
 		if err := c.stopProjectRunSandbox(ctx, sandbox); err != nil {
 			return err
@@ -2232,6 +2241,7 @@ func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandb
 		if err := c.store.RemoveSandbox(ctx, sandbox.Summary.ID); err != nil {
 			return err
 		}
+		c.revokeCapabilitySandbox(sandbox.Summary.ID)
 		if c.dashboard != nil {
 			c.dashboard.Notify("sandbox_removed")
 		}
@@ -2249,6 +2259,7 @@ func (c *Controller) stopProjectRunSandbox(ctx context.Context, sandbox *domain.
 		return err
 	}
 	if loaded.Summary.VMStatus != domain.VMStatusRunning {
+		c.revokeCapabilitySandbox(loaded.Summary.ID)
 		return nil
 	}
 	if c.driver == nil {
@@ -2261,6 +2272,7 @@ func (c *Controller) stopProjectRunSandbox(ctx context.Context, sandbox *domain.
 	if err := c.store.UpdateSandbox(ctx, loaded); err != nil {
 		return err
 	}
+	c.revokeCapabilitySandbox(loaded.Summary.ID)
 	event := domain.SandboxEvent{ID: uuid.NewString(), Type: "sandbox.stopped", Level: "info", Message: "sandbox stopped", CreatedAt: time.Now().UTC()}
 	_ = c.store.AddEvent(ctx, loaded.Summary.ID, event)
 	if c.streams != nil {

--- a/pkg/runs/project_run_workspace_ensurer_test.go
+++ b/pkg/runs/project_run_workspace_ensurer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sessions"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
@@ -23,6 +24,13 @@ type recordingCapabilitySandboxIndexer struct {
 	revoked []string
 }
 
+type recordingSandboxRemoval struct {
+	calls  []string
+	forces []bool
+	err    error
+	remove func(context.Context, string) error
+}
+
 func (i *recordingCapabilitySandboxIndexer) IndexSandbox(sandbox *domain.Sandbox) {
 	if sandbox == nil {
 		i.indexed = append(i.indexed, "")
@@ -33,6 +41,20 @@ func (i *recordingCapabilitySandboxIndexer) IndexSandbox(sandbox *domain.Sandbox
 
 func (i *recordingCapabilitySandboxIndexer) RevokeSandbox(sandboxID string) {
 	i.revoked = append(i.revoked, sandboxID)
+}
+
+func (r *recordingSandboxRemoval) Remove(ctx context.Context, sandboxID string, force bool) (sessions.RemovalResult, error) {
+	r.calls = append(r.calls, sandboxID)
+	r.forces = append(r.forces, force)
+	if r.err != nil {
+		return sessions.RemovalResult{}, r.err
+	}
+	if r.remove != nil {
+		if err := r.remove(ctx, sandboxID); err != nil {
+			return sessions.RemovalResult{}, err
+		}
+	}
+	return sessions.RemovalResult{SandboxID: sandboxID, Stopped: true, Removed: true}, nil
 }
 
 func (e *recordingProjectRunWorkspaceEnsurer) Ensure(_ context.Context, sandbox *domain.Sandbox) error {
@@ -217,6 +239,96 @@ func TestRunsControllerProjectRunIndexesCapabilitySandbox(t *testing.T) {
 			t.Fatalf("sandbox result = %#v, want reused sandbox %q", result, sandbox.Summary.ID)
 		}
 		assertIndexedCapabilitySandbox(t, indexer, sandbox.Summary.ID)
+	})
+}
+
+func TestRunsControllerProjectRunRevokesCapabilitySandbox(t *testing.T) {
+	t.Run("stop cleanup", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+
+		run, execErr, err := fixture.controller.RunProjectAgent(fixture.ctx, RunAgentRequest{
+			ProjectID:       "project-1",
+			AgentName:       "worker",
+			Prompt:          "do work",
+			Source:          domain.ProjectRunSourceAPI,
+			ClientRequestID: "capability-stop-cleanup",
+			CleanupPolicy:   agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION,
+		}, nil)
+		if err != nil || execErr != nil {
+			t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
+		}
+		if run.Status != domain.ProjectRunStatusSucceeded || run.SandboxID == "" {
+			t.Fatalf("run = %#v", run)
+		}
+		assertCapabilitySandboxTokenCalls(t, indexer, []string{run.SandboxID}, []string{run.SandboxID})
+		persisted, err := fixture.store.GetSandbox(fixture.ctx, run.SandboxID)
+		if err != nil {
+			t.Fatalf("GetSandbox returned error: %v", err)
+		}
+		if persisted.Summary.VMStatus != domain.VMStatusStopped {
+			t.Fatalf("sandbox VM status = %q, want stopped", persisted.Summary.VMStatus)
+		}
+	})
+
+	t.Run("remove cleanup fallback", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+
+		run, execErr, err := fixture.controller.RunProjectAgent(fixture.ctx, RunAgentRequest{
+			ProjectID:       "project-1",
+			AgentName:       "worker",
+			Prompt:          "do work",
+			Source:          domain.ProjectRunSourceAPI,
+			ClientRequestID: "capability-remove-cleanup-fallback",
+			CleanupPolicy:   agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION,
+		}, nil)
+		if err != nil || execErr != nil {
+			t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
+		}
+		if run.Status != domain.ProjectRunStatusSucceeded || run.SandboxID == "" {
+			t.Fatalf("run = %#v", run)
+		}
+		assertCapabilitySandboxTokenCalls(t, indexer, []string{run.SandboxID}, []string{run.SandboxID, run.SandboxID})
+		if _, loadErr := fixture.store.GetSandbox(fixture.ctx, run.SandboxID); loadErr == nil {
+			t.Fatalf("created sandbox %q was not removed", run.SandboxID)
+		}
+	})
+
+	t.Run("remove cleanup coordinator", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+		removal := &recordingSandboxRemoval{
+			remove: func(ctx context.Context, sandboxID string) error {
+				return fixture.store.RemoveSandbox(ctx, sandboxID)
+			},
+		}
+		fixture.controller.removal = removal
+
+		run, execErr, err := fixture.controller.RunProjectAgent(fixture.ctx, RunAgentRequest{
+			ProjectID:       "project-1",
+			AgentName:       "worker",
+			Prompt:          "do work",
+			Source:          domain.ProjectRunSourceAPI,
+			ClientRequestID: "capability-remove-cleanup-coordinator",
+			CleanupPolicy:   agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION,
+		}, nil)
+		if err != nil || execErr != nil {
+			t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
+		}
+		if run.Status != domain.ProjectRunStatusSucceeded || run.SandboxID == "" {
+			t.Fatalf("run = %#v", run)
+		}
+		assertCapabilitySandboxTokenCalls(t, indexer, []string{run.SandboxID}, []string{run.SandboxID})
+		if len(removal.calls) != 1 || removal.calls[0] != run.SandboxID || len(removal.forces) != 1 || !removal.forces[0] {
+			t.Fatalf("removal calls=%#v forces=%#v, want forced removal for %q", removal.calls, removal.forces, run.SandboxID)
+		}
+		if _, loadErr := fixture.store.GetSandbox(fixture.ctx, run.SandboxID); loadErr == nil {
+			t.Fatalf("created sandbox %q was not removed", run.SandboxID)
+		}
 	})
 }
 
@@ -432,10 +544,27 @@ func assertProjectRunReadyUnchanged(t *testing.T, label string, sandbox *domain.
 
 func assertIndexedCapabilitySandbox(t *testing.T, indexer *recordingCapabilitySandboxIndexer, sandboxID string) {
 	t.Helper()
-	if len(indexer.indexed) != 1 || indexer.indexed[0] != sandboxID {
-		t.Fatalf("indexed capability sandboxes = %#v, want [%q]", indexer.indexed, sandboxID)
+	assertCapabilitySandboxTokenCalls(t, indexer, []string{sandboxID}, nil)
+}
+
+func assertCapabilitySandboxTokenCalls(t *testing.T, indexer *recordingCapabilitySandboxIndexer, indexed, revoked []string) {
+	t.Helper()
+	if !stringSlicesEqual(indexer.indexed, indexed) {
+		t.Fatalf("indexed capability sandboxes = %#v, want %#v", indexer.indexed, indexed)
 	}
-	if len(indexer.revoked) != 0 {
-		t.Fatalf("revoked capability sandboxes = %#v, want none", indexer.revoked)
+	if !stringSlicesEqual(indexer.revoked, revoked) {
+		t.Fatalf("revoked capability sandboxes = %#v, want %#v", indexer.revoked, revoked)
 	}
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/runs/project_run_workspace_ensurer_test.go
+++ b/pkg/runs/project_run_workspace_ensurer_test.go
@@ -18,6 +18,23 @@ type recordingProjectRunWorkspaceEnsurer struct {
 	workspaceCopies []*domain.SandboxWorkspace
 }
 
+type recordingCapabilitySandboxIndexer struct {
+	indexed []string
+	revoked []string
+}
+
+func (i *recordingCapabilitySandboxIndexer) IndexSandbox(sandbox *domain.Sandbox) {
+	if sandbox == nil {
+		i.indexed = append(i.indexed, "")
+		return
+	}
+	i.indexed = append(i.indexed, sandbox.Summary.ID)
+}
+
+func (i *recordingCapabilitySandboxIndexer) RevokeSandbox(sandboxID string) {
+	i.revoked = append(i.revoked, sandboxID)
+}
+
 func (e *recordingProjectRunWorkspaceEnsurer) Ensure(_ context.Context, sandbox *domain.Sandbox) error {
 	if e.beforeEnsure != nil {
 		e.beforeEnsure(sandbox)
@@ -157,6 +174,49 @@ func TestRunsControllerProjectRunWorkspaceEnsurerPaths(t *testing.T) {
 		assertProjectRunEnsurerCall(t, ensurer, sandbox.Summary.ID, original)
 		assertProjectRunWorkspaceSnapshot(t, "running sandbox", result.Sandbox.Workspace, original)
 		assertProjectRunReadyUnchanged(t, "running sandbox", result.Sandbox, readyAt)
+	})
+}
+
+func TestRunsControllerProjectRunIndexesCapabilitySandbox(t *testing.T) {
+	t.Run("created sandbox", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+
+		result, err := fixture.controller.ensureProjectRunSandbox(
+			fixture.ctx,
+			projectRunEnsurerRecord("run-created-capability"),
+			Preparation{},
+			RunAgentRequest{},
+		)
+		if err != nil {
+			t.Fatalf("ensureProjectRunSandbox returned error: %v", err)
+		}
+		if result.Sandbox == nil || result.Sandbox.Summary.ID == "" {
+			t.Fatalf("sandbox result = %#v", result)
+		}
+		assertIndexedCapabilitySandbox(t, indexer, result.Sandbox.Summary.ID)
+	})
+
+	t.Run("reused sandbox", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+		sandbox := createProjectRunWorkspaceSandbox(t, fixture, projectRunWorkspaceSnapshot("existing-capability"))
+
+		result, err := fixture.controller.ensureProjectRunSandbox(
+			fixture.ctx,
+			projectRunEnsurerRecord("run-reused-capability"),
+			Preparation{},
+			RunAgentRequest{SandboxID: sandbox.Summary.ID},
+		)
+		if err != nil {
+			t.Fatalf("ensureProjectRunSandbox returned error: %v", err)
+		}
+		if result.Sandbox == nil || result.Sandbox.Summary.ID != sandbox.Summary.ID {
+			t.Fatalf("sandbox result = %#v, want reused sandbox %q", result, sandbox.Summary.ID)
+		}
+		assertIndexedCapabilitySandbox(t, indexer, sandbox.Summary.ID)
 	})
 }
 
@@ -367,5 +427,15 @@ func assertProjectRunReadyUnchanged(t *testing.T, label string, sandbox *domain.
 	}
 	if !sandbox.WorkspaceProvisioning.UpdatedAt.Equal(readyAt) {
 		t.Fatalf("%s workspace ready timestamp = %v, want unchanged %v", label, sandbox.WorkspaceProvisioning.UpdatedAt, readyAt)
+	}
+}
+
+func assertIndexedCapabilitySandbox(t *testing.T, indexer *recordingCapabilitySandboxIndexer, sandboxID string) {
+	t.Helper()
+	if len(indexer.indexed) != 1 || indexer.indexed[0] != sandboxID {
+		t.Fatalf("indexed capability sandboxes = %#v, want [%q]", indexer.indexed, sandboxID)
+	}
+	if len(indexer.revoked) != 0 {
+		t.Fatalf("revoked capability sandboxes = %#v, want none", indexer.revoked)
 	}
 }


### PR DESCRIPTION
## Summary
- index project-run sandboxes with the capability token resolver after the sandbox is running and reloaded
- add regression coverage for both created and reused project-run sandboxes

## Why
Project runs currently receive CAP_TOKEN/CAP_GRPC_TARGET, but the capability proxy cannot resolve the sandbox token because this run path never indexes the sandbox. Capability calls then fail with `Unauthenticated desc = capability sandbox token not found`.

## Testing
- go test ./pkg/runs
- verified against a patched v2607.6.6 daemon that project-run grpcurl can list a configured capset service successfully