### PR TITLE
fix: preserve legacy data across upgrades

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ AGENT_COMPOSE_FRONTEND_IMAGE=ghcr.io/chaitin/agent-compose-ui:latest
 # Host port published by the web UI and reverse proxy when the with-ui profile
 # is enabled.
 AGENT_COMPOSE_HTTP_PORT=80
+# Host directory bind-mounted at /data. The installer persists the legacy
+# ./data/agent-compose layout when upgrading an installation that uses it.
+AGENT_COMPOSE_DATA_DIR=./data
 
 # ---------------------------------------------------------------------------
 # Authentication

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,6 +118,7 @@ tasks:
     dir: '{{.TASKFILE_DIR}}'
     cmds:
       - ./deploy/install_test.sh
+      - ./deploy/install_upgrade_test.sh
       - ./scripts/test-compose-kvm-config.sh
       - ./scripts/test-installer-assets.sh
 

--- a/cmd/agent-compose/compose_env_e2e_test.go
+++ b/cmd/agent-compose/compose_env_e2e_test.go
@@ -49,7 +49,7 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 			t.Fatalf("compose service still exposes legacy session root env %q", key)
 		}
 	}
-	for _, volume := range []string{"/var/run/docker.sock:/var/run/docker.sock", "./data:/data", "./.env:/data/work/.env:ro"} {
+	for _, volume := range []string{"/var/run/docker.sock:/var/run/docker.sock", "${AGENT_COMPOSE_DATA_DIR:-./data}:/data", "./.env:/data/work/.env:ro"} {
 		if !stringSliceContains(service.Volumes, volume) {
 			t.Fatalf("agent-compose volumes = %#v, want %q", service.Volumes, volume)
 		}
@@ -59,6 +59,7 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		"AGENT_COMPOSE_DATA_DIR=./data",
 		"# SANDBOX_ROOT=/data/sandboxes",
 		"# DOCKER_HOST_SANDBOX_ROOT=/absolute/host/path/to/data/sandboxes",
 		"SESSION_ROOT, DOCKER_HOST_SESSION_ROOT, SESSION_START_TIMEOUT, and",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,7 +67,8 @@ once. Its summary includes the URL to use after the UI profile is enabled:
 ./install.sh --dir /opt/agent-compose --port 8080
 ./install.sh --version v1.2.3         # specific release (remote mode)
 ./install.sh --image-prefix registry.example.com/agent-compose   # mirror / private registry
-./install.sh --upgrade                # update an existing install to this release
+./install.sh --upgrade                # update an existing install to the latest release
+./install.sh --upgrade --version v1.2.3  # update to a specific release
 ./install.sh --no-start               # write files but don't pull images or start
 ./install.sh --yes                    # skip the confirmation prompt
 ```
@@ -132,10 +133,11 @@ Configuration lives in `<install-dir>/.env`; edit and re-run
 before exposing the daemon beyond a trusted network.
 
 Re-running the installer refreshes the Compose files and fills missing secrets
-or image refs. `--upgrade` updates image refs only when they still match values
+or image refs. `--upgrade` downloads the latest release bundle by default, even
+when invoked from an older extracted bundle. Add `--version vX.Y.Z` to select a
+specific release. Upgrade updates image refs only when they still match values
 recorded as installer-managed; custom or otherwise user-managed refs in `.env`
-remain unchanged. Use `--upgrade` with a newer installer to update an existing
-installation to that release and restart the stack.
+remain unchanged.
 
 The host data mount is persisted as `AGENT_COMPOSE_DATA_DIR` in the installed
 `.env`. New installations use `./data`. When upgrading an installation whose

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -137,6 +137,14 @@ recorded as installer-managed; custom or otherwise user-managed refs in `.env`
 remain unchanged. Use `--upgrade` with a newer installer to update an existing
 installation to that release and restart the stack.
 
+The host data mount is persisted as `AGENT_COMPOSE_DATA_DIR` in the installed
+`.env`. New installations use `./data`. When upgrading an installation whose
+database exists only under the earlier `./data/agent-compose` layout, the
+installer preserves that path instead of moving data. If databases exist in
+both locations, the installer stops before changing files; set
+`AGENT_COMPOSE_DATA_DIR=./data` or `./data/agent-compose` after identifying the
+authoritative database, then retry the upgrade.
+
 Before changing the installation directory, the installer prints a deployment
 plan and asks for confirmation. Use `--yes` or `AGENT_COMPOSE_YES=1` for
 non-interactive automation.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -41,10 +41,10 @@ Usage: install.sh [options]
 Options:
   --dir <path>           Install directory (default: ./agent-compose)
   --port <port>          Host port for the web UI (default: 80)
-  --version <vX.Y.Z>     Release version to install in remote mode (default: latest)
+  --version <vX.Y.Z>     Release version to install (default: latest)
   --image-prefix <ref>   Pull images from this prefix (mirror / private registry)
                          instead of the default registry
-  --upgrade              Update installer-managed image refs to this version
+  --upgrade              Update an existing install to the latest release
   --no-start             Lay down files but do not pull images or start
   -y, --yes              Run without the interactive confirmation prompt
   -h, --help             Show this help
@@ -346,8 +346,15 @@ trap cleanup EXIT
 
 # images/manifest.env only exists in a real installer bundle, so it
 # disambiguates from a source checkout that also has a docker-compose.yml.
+# An ordinary install uses that adjacent bundle. Upgrade always downloads the
+# selected release so an old extracted installer cannot silently reinstall
+# itself.
+ADJACENT_BUNDLE=0
 if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/docker-compose.yml" ] \
    && [ -f "$SCRIPT_DIR/images/manifest.env" ]; then
+  ADJACENT_BUNDLE=1
+fi
+if [ "$ADJACENT_BUNDLE" -eq 1 ] && [ "$UPGRADE" -eq 0 ]; then
   BUNDLE_SRC="$SCRIPT_DIR"
   log "Running from extracted bundle: $BUNDLE_SRC"
 else

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -165,6 +165,33 @@ truthy() {
   esac
 }
 
+select_data_dir() {
+  local configured current_db legacy_db
+  current_db="$INSTALL_DIR/data/data.db"
+  legacy_db="$INSTALL_DIR/data/agent-compose/data.db"
+
+  if has_active_env "$EXISTING_ENV_FILE" AGENT_COMPOSE_DATA_DIR; then
+    configured="$(get_env "$EXISTING_ENV_FILE" AGENT_COMPOSE_DATA_DIR)"
+    case "$configured" in
+      ./data|data) DATA_DIR_REL=./data ;;
+      ./data/agent-compose|data/agent-compose) DATA_DIR_REL=./data/agent-compose ;;
+      *)
+        die "AGENT_COMPOSE_DATA_DIR must be ./data or ./data/agent-compose when using the installer"
+        ;;
+    esac
+  elif [ -f "$current_db" ] && [ -f "$legacy_db" ]; then
+    die "both current and legacy data stores exist; set AGENT_COMPOSE_DATA_DIR to ./data or ./data/agent-compose in $EXISTING_ENV_FILE before retrying"
+  elif [ -f "$legacy_db" ]; then
+    DATA_DIR_REL=./data/agent-compose
+    warn "legacy data detected at $INSTALL_DIR/data/agent-compose; preserving its mount path"
+  else
+    DATA_DIR_REL=./data
+  fi
+
+  DATA_DIR_PATH="$INSTALL_DIR/${DATA_DIR_REL#./}"
+  [ ! -d "$DATA_DIR_PATH" ] || DATA_DIR_EXISTED=1
+}
+
 apply_image_refs() { # $1=file $2=mode(install|set-missing|upgrade) $3=managed-state
   local file="$1" mode="$2" state_file="$3" key value pair current managed
   if [ -n "$IMAGE_PREFIX" ]; then
@@ -223,6 +250,8 @@ INSTALL_SUCCEEDED=0
 INSTALL_DIR_EXISTED=0
 INSTALL_DIR_CREATED=0
 INSTALL_DIR_CREATED_PATH=""
+DATA_DIR_REL=""
+DATA_DIR_PATH=""
 DATA_DIR_EXISTED=0
 PREVIOUS_INSTALL=0
 UP_ATTEMPTED=0
@@ -262,8 +291,10 @@ restore_installation() {
     if [ -L "$INSTALL_DIR_ABS/data" ] || [ -L "$INSTALL_DIR_ABS/data/agent-compose" ]; then
       restore_status=1
     else
-      rm -rf "$INSTALL_DIR_ABS/data/agent-compose" || restore_status=1
-      rmdir "$INSTALL_DIR_ABS/data" 2>/dev/null || true
+      rm -rf "$DATA_DIR_PATH" || restore_status=1
+      if [ "$DATA_DIR_REL" = "./data/agent-compose" ]; then
+        rmdir "$INSTALL_DIR_ABS/data" 2>/dev/null || true
+      fi
     fi
   fi
   if [ "$INSTALL_DIR_EXISTED" -eq 0 ]; then
@@ -390,7 +421,6 @@ if [ -e "$INSTALL_DIR" ] && [ ! -d "$INSTALL_DIR" ]; then
 fi
 [ -d "$INSTALL_DIR" ] && INSTALL_DIR_EXISTED=1
 validate_data_paths
-[ -d "$INSTALL_DIR/data/agent-compose" ] && DATA_DIR_EXISTED=1
 for name in "${managed_files[@]}"; do
   target="$INSTALL_DIR/$name"
   if [ -L "$target" ] || { [ -e "$target" ] && [ ! -f "$target" ]; }; then
@@ -406,6 +436,7 @@ if [ -f "$BUNDLE_SRC/docker-compose.kvm.yml" ] || [ -f "$INSTALL_DIR/docker-comp
 fi
 
 EXISTING_ENV_FILE="$INSTALL_DIR/.env"
+select_data_dir
 COMPOSE_SELECTION_EXPLICIT=0
 if has_active_env "$EXISTING_ENV_FILE" COMPOSE_FILE; then
   COMPOSE_SELECTION_EXPLICIT=1
@@ -462,7 +493,7 @@ cat <<EOF
 agent-compose deployment plan
   Source:       $BUNDLE_SRC
   Target dir:   $INSTALL_DIR
-  Data dir:     $INSTALL_DIR/data/agent-compose
+  Data dir:     $DATA_DIR_PATH
   Config:       $ENV_STATE
   Compose:      $COMPOSE_STATE
   Images:       $IMAGE_STATE
@@ -544,6 +575,8 @@ else
   [ -n "$PORT" ] && set_env "$CANDIDATE_ENV" AGENT_COMPOSE_HTTP_PORT "$PORT"
 fi
 
+set_env "$CANDIDATE_ENV" AGENT_COMPOSE_DATA_DIR "$DATA_DIR_REL"
+
 if [ "$COMPOSE_SELECTION_EXPLICIT" -eq 0 ]; then
   if [ "$KVM_AVAILABLE" -eq 1 ]; then
     set_env "$CANDIDATE_ENV" COMPOSE_FILE "docker-compose.yml:docker-compose.kvm.yml"
@@ -584,6 +617,7 @@ INSTALL_DIR_ABS="$(cd -P -- "$INSTALL_DIR" && pwd)"
   || die "refusing install path changed during creation: $INSTALL_DIR"
 INSTALL_DIR="$INSTALL_DIR_ABS"
 ENV_FILE="$INSTALL_DIR/.env"
+DATA_DIR_PATH="$INSTALL_DIR/${DATA_DIR_REL#./}"
 for name in "${managed_files[@]}"; do
   target="$INSTALL_DIR/$name"
   if [ -f "$target" ]; then
@@ -606,7 +640,7 @@ fi
 atomic_install_file "$CANDIDATE_ENV" "$ENV_FILE" 600 1
 atomic_install_file "$CANDIDATE_STATE" "$INSTALL_DIR/.installer-state.env" 600 1
 validate_data_paths
-mkdir -p "$INSTALL_DIR/data/agent-compose"
+mkdir -p "$DATA_DIR_PATH"
 if [ ! -f "$ROLLBACK_DIR/.env.present" ]; then
   log "Created $ENV_FILE"
 fi

--- a/deploy/install_test.sh
+++ b/deploy/install_test.sh
@@ -90,7 +90,35 @@ FAKE_DOCKER_LOG="$TMP_ROOT/fake-docker.log"
 FAKE_DOCKER_COUNTER="$TMP_ROOT/fake-docker.counter"
 FAKE_DOCKER_STATE="$TMP_ROOT/fake-docker.state"
 REAL_MKTEMP=$(command -v mktemp)
+FAKE_REMOTE_DIR="$TMP_ROOT/fake-release"
 mkdir -p "$FAKE_BIN"
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=''
+url=''
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -o)
+      output=${2:?missing curl output}
+      shift 2
+      ;;
+    -*) shift ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+case $url in
+  */agent-compose-installer.tar.gz) cp "$FAKE_REMOTE_ARCHIVE" "$output" ;;
+  */SHASUMS256.txt) cp "$FAKE_REMOTE_SHASUMS" "$output" ;;
+  *) exit 22 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/curl"
+
 cat >"$FAKE_BIN/docker" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -220,6 +248,14 @@ FAKE_MKTEMP_FAIL_RESTORE=0
 run_installer() { # $1=bundle $2=install-dir $3=kvm-path, remaining=args
   local bundle=$1 install_dir=$2 kvm_path=$3
   shift 3
+  rm -rf "$FAKE_REMOTE_DIR"
+  mkdir -p "$FAKE_REMOTE_DIR"
+  tar -czf "$FAKE_REMOTE_DIR/agent-compose-installer.tar.gz" \
+    -C "$(dirname "$bundle")" "$(basename "$bundle")"
+  (
+    cd "$FAKE_REMOTE_DIR"
+    sha256sum agent-compose-installer.tar.gz >SHASUMS256.txt
+  )
   : >"$RUN_STDOUT"
   : >"$RUN_STDERR"
   : >"$FAKE_DOCKER_LOG"
@@ -236,6 +272,8 @@ run_installer() { # $1=bundle $2=install-dir $3=kvm-path, remaining=args
     FAKE_DOCKER_VERSION_SYMLINK_VICTIM="$FAKE_DOCKER_VERSION_SYMLINK_VICTIM" \
     FAKE_MKTEMP_FAIL_RESTORE="$FAKE_MKTEMP_FAIL_RESTORE" \
     REAL_MKTEMP="$REAL_MKTEMP" \
+    FAKE_REMOTE_ARCHIVE="$FAKE_REMOTE_DIR/agent-compose-installer.tar.gz" \
+    FAKE_REMOTE_SHASUMS="$FAKE_REMOTE_DIR/SHASUMS256.txt" \
     AGENT_COMPOSE_KVM_DETECT_PATH="$kvm_path" \
     AGENT_COMPOSE_YES=1 \
     COMPOSE_FILE=hostile-parent.yml \

--- a/deploy/install_test.sh
+++ b/deploy/install_test.sh
@@ -105,6 +105,11 @@ if [[ -f .env ]]; then
   fi
 fi
 process_selection=${COMPOSE_FILE-<unset>}
+data_dir=./data
+if [[ -f .env ]]; then
+  value=$(grep -E '^(export[[:space:]]+)?AGENT_COMPOSE_DATA_DIR=' .env 2>/dev/null | tail -n1 || true)
+  [[ -z $value ]] || data_dir=${value#*=}
+fi
 {
   printf 'cwd=%s|process=%s|file=%s|args=' "$PWD" "$process_selection" "$selection"
   printf '%s ' "$@"
@@ -138,19 +143,19 @@ case ${2:-} in
       count=$(cat "$FAKE_DOCKER_COUNTER" 2>/dev/null || printf '0')
       if [[ $count -eq 0 ]]; then
         printf '1\n' >"$FAKE_DOCKER_COUNTER"
-        mkdir -p data/agent-compose
-        printf 'partial\n' >data/agent-compose/fake-partial
+        mkdir -p "$data_dir"
+        printf 'partial\n' >"$data_dir/fake-partial"
         exit 43
       fi
     fi
-    rm -f data/agent-compose/fake-partial
+    rm -f ./data/fake-partial ./data/agent-compose/fake-partial
     printf 'running\n' >"$FAKE_DOCKER_STATE"
     exit 0
     ;;
   down)
     [[ ${3:-} == --remove-orphans ]] || exit 96
     [[ ${FAKE_DOCKER_FAIL_COMMAND:-} == up-once-down-fails ]] && exit 45
-    rm -f data/agent-compose/fake-partial "$FAKE_DOCKER_STATE"
+    rm -f ./data/fake-partial ./data/agent-compose/fake-partial "$FAKE_DOCKER_STATE"
     exit 0
     ;;
   *)
@@ -263,6 +268,7 @@ base_install="$TMP_ROOT/install base"
 run_installer "$BUNDLE" "$base_install" "$MISSING_KVM" --no-start
 assert_success
 assert_env "$base_install/.env" COMPOSE_FILE docker-compose.yml
+assert_env "$base_install/.env" AGENT_COMPOSE_DATA_DIR ./data
 assert_mode "$base_install/.env" 600
 assert_mode "$base_install/.installer-state.env" 600
 assert_mode "$base_install/docker-compose.yml" 644
@@ -278,8 +284,56 @@ assert_contains "$FAKE_DOCKER_LOG" "cwd=$base_install|process=<unset>|file=docke
 assert_not_contains "$FAKE_DOCKER_LOG" 'args=compose pull '
 assert_not_contains "$FAKE_DOCKER_LOG" 'args=compose up -d '
 assert_installed_sequence "$base_install" 'compose config --quiet'
+[[ -d $base_install/data ]] || fail 'new install did not create the current data directory'
+[[ ! -e $base_install/data/agent-compose ]] || fail 'new install unexpectedly created the legacy data directory'
 base_json=$(real_compose_json "$base_install")
 jq -e '.services["agent-compose"].privileged != true and ((.services["agent-compose"].devices // []) | length == 0)' >/dev/null <<<"$base_json"
+jq -e --arg source "$base_install/data" 'any(.services["agent-compose"].volumes[]; .source == $source and .target == "/data")' >/dev/null <<<"$base_json"
+
+# Upgrades preserve the only populated layout and persist it so later Compose
+# runs cannot silently switch databases. Ambiguous dual-database installs stop
+# before mutation until the operator selects the authoritative store.
+make_bundle data-layout 1
+legacy_data_install="$TMP_ROOT/legacy-data-layout"
+mkdir -p "$legacy_data_install/data/agent-compose"
+printf 'legacy-db\n' >"$legacy_data_install/data/agent-compose/data.db"
+write_user_env "$legacy_data_install/.env"
+printf '%s\n' 'COMPOSE_FILE=docker-compose.yml' >>"$legacy_data_install/.env"
+run_installer "$BUNDLE" "$legacy_data_install" "$MISSING_KVM" --upgrade --no-start
+assert_success
+assert_env "$legacy_data_install/.env" AGENT_COMPOSE_DATA_DIR ./data/agent-compose
+assert_contains "$RUN_STDERR" 'legacy data detected'
+assert_contains "$RUN_STDOUT" "Data dir:     $legacy_data_install/data/agent-compose"
+assert_contains "$legacy_data_install/data/agent-compose/data.db" legacy-db
+legacy_data_json=$(real_compose_json "$legacy_data_install")
+jq -e --arg source "$legacy_data_install/data/agent-compose" 'any(.services["agent-compose"].volumes[]; .source == $source and .target == "/data")' >/dev/null <<<"$legacy_data_json"
+
+current_data_install="$TMP_ROOT/current-data-layout"
+mkdir -p "$current_data_install/data"
+printf 'current-db\n' >"$current_data_install/data/data.db"
+write_user_env "$current_data_install/.env"
+printf '%s\n' 'COMPOSE_FILE=docker-compose.yml' >>"$current_data_install/.env"
+run_installer "$BUNDLE" "$current_data_install" "$MISSING_KVM" --upgrade --no-start
+assert_success
+assert_env "$current_data_install/.env" AGENT_COMPOSE_DATA_DIR ./data
+assert_contains "$current_data_install/data/data.db" current-db
+
+ambiguous_data_install="$TMP_ROOT/ambiguous-data-layout"
+mkdir -p "$ambiguous_data_install/data/agent-compose"
+printf 'current-db\n' >"$ambiguous_data_install/data/data.db"
+printf 'legacy-db\n' >"$ambiguous_data_install/data/agent-compose/data.db"
+write_user_env "$ambiguous_data_install/.env"
+printf '%s\n' 'COMPOSE_FILE=docker-compose.yml' >>"$ambiguous_data_install/.env"
+ambiguous_env_before=$(sha256sum "$ambiguous_data_install/.env")
+run_installer "$BUNDLE" "$ambiguous_data_install" "$MISSING_KVM" --upgrade --no-start
+assert_failure
+assert_contains "$RUN_STDERR" 'both current and legacy data stores exist'
+[[ $(sha256sum "$ambiguous_data_install/.env") == "$ambiguous_env_before" ]] || fail 'ambiguous data preflight changed .env'
+[[ ! -e $ambiguous_data_install/docker-compose.yml ]] || fail 'ambiguous data preflight installed Compose files'
+printf '%s\n' 'AGENT_COMPOSE_DATA_DIR=./data/agent-compose' >>"$ambiguous_data_install/.env"
+run_installer "$BUNDLE" "$ambiguous_data_install" "$MISSING_KVM" --upgrade --no-start
+assert_success
+assert_env "$ambiguous_data_install/.env" AGENT_COMPOSE_DATA_DIR ./data/agent-compose
 
 # New KVM install uses the dual persisted selection for config, pull, and up.
 make_bundle new-kvm 1
@@ -546,6 +600,7 @@ assert_contains "$RUN_STDERR" 'restored managed files'
 make_bundle rollback 1
 rollback_install="$TMP_ROOT/rollback"
 mkdir -p "$rollback_install/data/agent-compose"
+printf 'legacy-db\n' >"$rollback_install/data/agent-compose/data.db"
 cp "$ROOT_DIR/docker-compose.yml" "$rollback_install/docker-compose.yml"
 printf '%s\n' '# old installer' >"$rollback_install/install.sh"
 chmod 700 "$rollback_install/install.sh"
@@ -576,6 +631,7 @@ fi
 # out-of-tree backup instead of deleting the only recovery copy.
 incomplete_install="$TMP_ROOT/incomplete-rollback"
 mkdir -p "$incomplete_install/data/agent-compose"
+printf 'legacy-db\n' >"$incomplete_install/data/agent-compose/data.db"
 cp "$ROOT_DIR/docker-compose.yml" "$incomplete_install/docker-compose.yml"
 printf '%s\n' '# recovery source installer' >"$incomplete_install/install.sh"
 write_user_env "$incomplete_install/.env"
@@ -615,6 +671,7 @@ assert_installed_sequence "$rollback_install" $'compose config --quiet\ncompose 
 # managed-file restoration itself is incomplete.
 restore_failure_install="$TMP_ROOT/restore-failure"
 mkdir -p "$restore_failure_install/data/agent-compose"
+printf 'legacy-db\n' >"$restore_failure_install/data/agent-compose/data.db"
 cp "$ROOT_DIR/docker-compose.yml" "$restore_failure_install/docker-compose.yml"
 printf '%s\n' '# old restore-failure installer' >"$restore_failure_install/install.sh"
 write_user_env "$restore_failure_install/.env"
@@ -655,7 +712,7 @@ assert_contains "$RUN_STDERR" 'recovery was incomplete'
 assert_installed_sequence "$new_down_failure" $'compose config --quiet\ncompose pull\ncompose up -d\ncompose down --remove-orphans'
 assert_env "$new_down_failure/.env" COMPOSE_FILE 'docker-compose.yml:docker-compose.kvm.yml'
 [[ -f $new_down_failure/docker-compose.yml && -f $new_down_failure/docker-compose.kvm.yml ]] || fail 'failed cleanup removed candidate Compose files'
-[[ -e $new_down_failure/data/agent-compose/fake-partial ]] || fail 'failed cleanup repro did not retain partial runtime marker'
+[[ -e $new_down_failure/data/fake-partial ]] || fail 'failed cleanup repro did not retain partial runtime marker'
 preserved_backup=$(sed -n 's/^.*backups retained at //p' "$RUN_STDERR" | tail -n1)
 [[ -n $preserved_backup && -d $preserved_backup/recovery-install ]] || fail 'failed cleanup recovery snapshot was not retained'
 PRESERVED_BACKUPS+=("$preserved_backup")

--- a/deploy/install_upgrade_test.sh
+++ b/deploy/install_upgrade_test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_INSTALLER="$ROOT_DIR/deploy/install.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+  printf 'install_upgrade_test: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_env() { # $1=file $2=key $3=value
+  local actual
+  actual="$(sed -n "s/^$2=//p" "$1" | tail -n1)"
+  [[ $actual == "$3" ]] || fail "$2=$actual, want $3"
+}
+
+FAKE_BIN="$TMP_ROOT/bin"
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=''
+url=''
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -o)
+      output=${2:?missing curl output}
+      shift 2
+      ;;
+    -*) shift ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+printf '%s\n' "$url" >>"$FAKE_CURL_LOG"
+case $url in
+  */agent-compose-installer.tar.gz) cp "$FAKE_REMOTE_ARCHIVE" "$output" ;;
+  */SHASUMS256.txt) cp "$FAKE_REMOTE_SHASUMS" "$output" ;;
+  *) exit 22 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/curl"
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ ${1:-} == compose && ${2:-} == version ]]; then
+  exit 0
+fi
+if [[ ${1:-} == compose && ${2:-} == config && ${3:-} == --quiet ]]; then
+  exit 0
+fi
+exit 91
+EOF
+chmod +x "$FAKE_BIN/docker"
+
+make_bundle() { # $1=directory $2=version $3=compose-marker $4=installer-marker
+  local bundle=$1 version=$2 compose_marker=$3 installer_marker=$4
+  mkdir -p "$bundle/images"
+  cp "$SOURCE_INSTALLER" "$bundle/install.sh"
+  cp "$ROOT_DIR/docker-compose.yml" "$bundle/docker-compose.yml"
+  printf '\n# %s\n' "$compose_marker" >>"$bundle/docker-compose.yml"
+  cp "$ROOT_DIR/.env.example" "$bundle/.env.example"
+  printf '%s\n' "$installer_marker" >>"$bundle/install.sh"
+  chmod +x "$bundle/install.sh"
+  cat >"$bundle/images/manifest.env" <<EOF
+AGENT_COMPOSE_IMAGE=registry.example/agent-compose:$version
+AGENT_COMPOSE_FRONTEND_VERSION=$version-ui
+AGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:$version-ui
+DEFAULT_IMAGE=registry.example/agent-compose-guest:$version
+EOF
+}
+
+make_existing_install() { # $1=directory
+  local target=$1
+  mkdir -p "$target/data"
+  printf 'existing-db\n' >"$target/data/data.db"
+  cp "$ROOT_DIR/docker-compose.yml" "$target/docker-compose.yml"
+  cat >"$target/.env" <<'EOF'
+AUTH_USERNAME=operator
+AUTH_PASSWORD=keep-password
+AUTH_SECRET=keep-secret
+AGENT_COMPOSE_IMAGE=registry.example/agent-compose:v-old
+AGENT_COMPOSE_FRONTEND_VERSION=v-old-ui
+AGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:v-old-ui
+DEFAULT_IMAGE=registry.example/agent-compose-guest:v-old
+AGENT_COMPOSE_DATA_DIR=./data
+COMPOSE_FILE=docker-compose.yml
+EOF
+  cat >"$target/.installer-state.env" <<'EOF'
+AGENT_COMPOSE_IMAGE=registry.example/agent-compose:v-old
+AGENT_COMPOSE_FRONTEND_VERSION=v-old-ui
+AGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:v-old-ui
+DEFAULT_IMAGE=registry.example/agent-compose-guest:v-old
+EOF
+}
+
+OLD_BUNDLE="$TMP_ROOT/local-old"
+REMOTE_PAYLOAD_ROOT="$TMP_ROOT/remote-payload"
+REMOTE_BUNDLE="$REMOTE_PAYLOAD_ROOT/agent-compose-installer"
+make_bundle "$OLD_BUNDLE" v-old local-old-bundle '# local-old-installer'
+make_bundle "$REMOTE_BUNDLE" v-latest remote-latest-bundle '# remote-latest-installer'
+
+REMOTE_ARCHIVE="$TMP_ROOT/agent-compose-installer.tar.gz"
+tar -czf "$REMOTE_ARCHIVE" -C "$REMOTE_PAYLOAD_ROOT" agent-compose-installer
+REMOTE_SHASUMS="$TMP_ROOT/SHASUMS256.txt"
+(
+  cd "$TMP_ROOT"
+  sha256sum agent-compose-installer.tar.gz >SHASUMS256.txt
+)
+
+run_upgrade() { # $1=target, remaining installer args
+  local target=$1
+  shift
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    FAKE_CURL_LOG="$FAKE_CURL_LOG" \
+    FAKE_REMOTE_ARCHIVE="$REMOTE_ARCHIVE" \
+    FAKE_REMOTE_SHASUMS="$REMOTE_SHASUMS" \
+    AGENT_COMPOSE_REPO=example/agent-compose \
+    AGENT_COMPOSE_KVM_DETECT_PATH="$TMP_ROOT/missing-kvm" \
+    AGENT_COMPOSE_YES=1 \
+    bash "$OLD_BUNDLE/install.sh" --dir "$target" --yes --no-start "$@"
+}
+
+# The regression: an installer extracted from v-old must fetch latest instead
+# of silently reinstalling its adjacent v-old manifest.
+FAKE_CURL_LOG="$TMP_ROOT/latest-curl.log"
+: >"$FAKE_CURL_LOG"
+latest_target="$TMP_ROOT/latest-target"
+make_existing_install "$latest_target"
+run_upgrade "$latest_target" --upgrade
+grep -Fxq 'https://github.com/example/agent-compose/releases/latest/download/agent-compose-installer.tar.gz' "$FAKE_CURL_LOG" \
+  || fail 'default upgrade did not download the latest release bundle'
+assert_env "$latest_target/.env" AGENT_COMPOSE_IMAGE registry.example/agent-compose:v-latest
+assert_env "$latest_target/.env" AGENT_COMPOSE_FRONTEND_IMAGE registry.example/agent-compose-ui:v-latest-ui
+grep -Fq '# remote-latest-bundle' "$latest_target/docker-compose.yml" \
+  || fail 'default upgrade did not install remote Compose files'
+grep -Fq '# remote-latest-installer' "$latest_target/install.sh" \
+  || fail 'default upgrade did not install the remote installer'
+
+# --version selects an exact release URL while still avoiding the stale local
+# bundle.
+FAKE_CURL_LOG="$TMP_ROOT/version-curl.log"
+: >"$FAKE_CURL_LOG"
+version_target="$TMP_ROOT/version-target"
+make_existing_install "$version_target"
+run_upgrade "$version_target" --upgrade --version v-target
+grep -Fxq 'https://github.com/example/agent-compose/releases/download/v-target/agent-compose-installer.tar.gz' "$FAKE_CURL_LOG" \
+  || fail 'versioned upgrade did not download the selected release bundle'
+
+printf 'install_upgrade_test: ok\n'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       AGENT_COMPOSE_RUNTIME_BASE_URL: ${AGENT_COMPOSE_RUNTIME_BASE_URL:-http://agent-compose:7410}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./data:/data
+      - ${AGENT_COMPOSE_DATA_DIR:-./data}:/data
       - ./.env:/data/work/.env:ro
     working_dir: /data/work
     ports:

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -30,6 +30,11 @@ type NormalizedProject struct {
 	Spec       *compose.NormalizedProjectSpec
 	SpecHash   string
 	SourcePath string
+
+	// managedLoaderOverrides is populated only by the legacy-v1 compatibility
+	// projection. It lets that boundary adopt an existing loader ID so runs,
+	// events, trigger state, and enablement survive the project migration.
+	managedLoaderOverrides map[string]domain.Loader
 }
 
 type ProjectRef struct {
@@ -166,7 +171,7 @@ func (c *Controller) ApplyProject(ctx context.Context, req ApplyRequest) (ApplyR
 	if issues := c.validateManagedSchedulers(ctx, normalized); len(issues) > 0 {
 		return ApplyResult{Issues: issues, RevisionSpec: normalized.Spec}, nil
 	}
-	agentRecords, agentDefinitions, schedulerRecords, managedLoaders, err := c.projectArtifacts(ctx, project, 0, normalized.Spec)
+	agentRecords, agentDefinitions, schedulerRecords, managedLoaders, err := c.projectArtifacts(ctx, project, 0, normalized)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project %s: %w", ErrInvalidRequest, normalized.Spec.Name, err)
 	}
@@ -213,7 +218,7 @@ func (c *Controller) ApplyProject(ctx context.Context, req ApplyRequest) (ApplyR
 		return ApplyResult{}, fmt.Errorf("apply project %s: reload project: %w", normalized.Spec.Name, err)
 	}
 
-	agentRecords, agentDefinitions, schedulerRecords, managedLoaders, err = c.projectArtifacts(ctx, project, revision.Revision, normalized.Spec)
+	agentRecords, agentDefinitions, schedulerRecords, managedLoaders, err = c.projectArtifacts(ctx, project, revision.Revision, normalized)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project %s: %w", ErrInvalidRequest, normalized.Spec.Name, err)
 	}
@@ -424,7 +429,8 @@ func (c *Controller) resolveProjectRef(ctx context.Context, ref ProjectRef, incl
 	return matches[0], nil
 }
 
-func (c *Controller) projectArtifacts(ctx context.Context, project domain.ProjectRecord, revision int64, spec *compose.NormalizedProjectSpec) ([]domain.ProjectAgentRecord, []domain.AgentDefinition, []domain.ProjectSchedulerRecord, []domain.Loader, error) {
+func (c *Controller) projectArtifacts(ctx context.Context, project domain.ProjectRecord, revision int64, normalized NormalizedProject) ([]domain.ProjectAgentRecord, []domain.AgentDefinition, []domain.ProjectSchedulerRecord, []domain.Loader, error) {
+	spec := normalized.Spec
 	agentRecords, err := NewAgentRecordsFromSpec(project.ID, revision, spec)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -437,6 +443,11 @@ func (c *Controller) projectArtifacts(ctx context.Context, project domain.Projec
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	schedulerRecords, managedLoaders, err = applyManagedLoaderOverrides(project, revision, schedulerRecords, managedLoaders, normalized.managedLoaderOverrides)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	syncProjectAgentSchedulerState(agentRecords, schedulerRecords)
 	return agentRecords, agentDefinitions, schedulerRecords, managedLoaders, nil
 }
 
@@ -486,6 +497,10 @@ func (c *Controller) validateManagedSchedulers(ctx context.Context, normalized N
 	builds, err := c.projectManagedSchedulerBuildsFromSpec(ctx, project, 0, normalized.Spec)
 	if err != nil {
 		return []ValidationIssue{managedSchedulerBuildIssue(err)}
+	}
+	builds, err = applyManagedLoaderOverrideBuilds(project, 0, builds, normalized.managedLoaderOverrides)
+	if err != nil {
+		return []ValidationIssue{{Path: "schedulers", Message: err.Error()}}
 	}
 	loaderRecords := SchedulerLoaders(builds)
 	for _, loader := range loaderRecords {

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -4,33 +4,41 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
 	"agent-compose/pkg/compose"
+	"agent-compose/pkg/identity"
 	domain "agent-compose/pkg/model"
 )
 
 const LegacyDefaultProjectName = "legacy-v1-default"
 
-var legacyAgentNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
-
 type legacyAgentDefinitionStore interface {
 	ListAgentDefinitions(context.Context, domain.AgentDefinitionListOptions) (domain.AgentDefinitionListResult, error)
 }
 
-// SyncLegacyDefaultProject projects active standalone v1 agents into one
-// deterministic v2 project without changing the source AgentDefinitions.
+type legacyLoaderStore interface {
+	ListLoaders(context.Context) ([]domain.Loader, error)
+}
+
+// SyncLegacyDefaultProject projects active standalone v1 agents and loaders
+// into one deterministic v2 project. Source AgentDefinitions remain unchanged;
+// legacy loaders are adopted in place so their history and trigger state stay
+// attached to the task shown by the project APIs.
 func (c *Controller) SyncLegacyDefaultProject(ctx context.Context) (ApplyResult, error) {
 	agents, err := c.listStandaloneAgents(ctx)
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	if len(agents) == 0 {
+	legacyLoaders, err := c.listLegacyDefaultLoaders(ctx)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if len(agents) == 0 && len(legacyLoaders) == 0 {
 		return ApplyResult{}, nil
 	}
-	normalized, err := legacyDefaultNormalizedProject(agents)
+	normalized, err := legacyDefaultNormalizedProject(agents, legacyLoaders)
 	if err != nil {
 		return ApplyResult{}, err
 	}
@@ -68,7 +76,33 @@ func (c *Controller) listStandaloneAgents(ctx context.Context) ([]domain.AgentDe
 	return standalone, nil
 }
 
-func legacyDefaultNormalizedProject(agents []domain.AgentDefinition) (NormalizedProject, error) {
+func (c *Controller) listLegacyDefaultLoaders(ctx context.Context) ([]domain.Loader, error) {
+	if c == nil || c.store == nil {
+		return nil, fmt.Errorf("sync legacy default project: config store is required")
+	}
+	store, ok := c.store.(legacyLoaderStore)
+	if !ok {
+		return nil, fmt.Errorf("sync legacy default project: loader store is required")
+	}
+	projectID, err := domain.StableProjectID(LegacyDefaultProjectName, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve legacy default project id: %w", err)
+	}
+	items, err := store.ListLoaders(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list legacy loaders: %w", err)
+	}
+	legacy := make([]domain.Loader, 0, len(items))
+	for _, loader := range items {
+		managedProjectID := strings.TrimSpace(loader.Summary.ManagedProjectID)
+		if managedProjectID == "" || managedProjectID == projectID {
+			legacy = append(legacy, loader)
+		}
+	}
+	return legacy, nil
+}
+
+func legacyDefaultNormalizedProject(agents []domain.AgentDefinition, legacyLoaders []domain.Loader) (NormalizedProject, error) {
 	spec := &compose.NormalizedProjectSpec{Name: LegacyDefaultProjectName}
 	agents = append([]domain.AgentDefinition(nil), agents...)
 	sort.Slice(agents, func(i, j int) bool {
@@ -77,42 +111,208 @@ func legacyDefaultNormalizedProject(agents []domain.AgentDefinition) (Normalized
 		}
 		return agents[i].Name < agents[j].Name
 	})
-	seen := make(map[string]string, len(agents))
-	for _, definition := range agents {
-		name, err := legacyProjectAgentName(definition.Name)
-		if err != nil {
-			return NormalizedProject{}, fmt.Errorf("legacy agent %s: %w", definition.ID, err)
-		}
-		if name == "" {
-			return NormalizedProject{}, fmt.Errorf("legacy agent %s has no name", definition.ID)
-		}
-		if existingID, exists := seen[name]; exists {
-			return NormalizedProject{}, fmt.Errorf("legacy agents %s and %s share name %q", existingID, definition.ID, name)
-		}
-		seen[name] = definition.ID
+	names := legacyProjectAgentNames(agents)
+	agentByLegacyID := make(map[string]int, len(agents))
+	agentByName := make(map[string]int, len(agents)+len(legacyLoaders))
+	usedNames := make(map[string]struct{}, len(agents)+len(legacyLoaders))
+	for index, definition := range agents {
 		agent, err := normalizedAgentFromLegacy(definition)
 		if err != nil {
 			return NormalizedProject{}, err
 		}
-		agent.Name = name
+		agent.Name = names[index]
+		if legacyID := strings.TrimSpace(definition.ID); legacyID != "" {
+			agentByLegacyID[legacyID] = len(spec.Agents)
+		}
+		agentByName[agent.Name] = len(spec.Agents)
+		usedNames[agent.Name] = struct{}{}
 		spec.Agents = append(spec.Agents, agent)
 	}
+
+	overrides := projectLegacyLoaders(spec, legacyLoaders, agentByLegacyID, agentByName, usedNames)
+	sort.Slice(spec.Agents, func(i, j int) bool { return spec.Agents[i].Name < spec.Agents[j].Name })
 	hash, err := spec.Hash()
 	if err != nil {
 		return NormalizedProject{}, fmt.Errorf("hash legacy default project: %w", err)
 	}
-	return NormalizedProject{Spec: spec, SpecHash: hash}, nil
+	return NormalizedProject{Spec: spec, SpecHash: hash, managedLoaderOverrides: overrides}, nil
 }
 
-func legacyProjectAgentName(name string) (string, error) {
+func legacyCanonicalAgentName(name string) string {
 	name = strings.ToLower(strings.TrimSpace(name))
-	if name == "" {
-		return "", nil
+	if !domain.IsProjectStableIdentifier(name) {
+		return ""
 	}
-	if !legacyAgentNamePattern.MatchString(name) {
-		return "", fmt.Errorf("legacy agent name %q cannot be converted to a stable v2 identifier", name)
+	return name
+}
+
+func legacyProjectAgentNames(agents []domain.AgentDefinition) []string {
+	bases := make([]string, len(agents))
+	counts := make(map[string]int, len(agents))
+	for index, agent := range agents {
+		bases[index] = legacyCanonicalAgentName(agent.Name)
+		if bases[index] != "" {
+			counts[bases[index]]++
+		}
 	}
-	return name, nil
+
+	names := make([]string, len(agents))
+	used := make(map[string]struct{}, len(agents))
+	// Reserve unique, already-valid names first. A generated compatibility name
+	// must never force a valid legacy name to change.
+	for index, base := range bases {
+		if base != "" && counts[base] == 1 {
+			names[index] = base
+			used[base] = struct{}{}
+		}
+	}
+	for index, agent := range agents {
+		if names[index] != "" {
+			continue
+		}
+		prefix := bases[index]
+		if prefix == "" {
+			prefix = "legacy-agent"
+		}
+		names[index] = reserveLegacyStableName(prefix, identity.ResourceAgent, agent.ID, agent.Name, used)
+	}
+	return names
+}
+
+func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []domain.Loader, agentByLegacyID, agentByName map[string]int, usedNames map[string]struct{}) map[string]domain.Loader {
+	legacyLoaders = append([]domain.Loader(nil), legacyLoaders...)
+	sort.Slice(legacyLoaders, func(i, j int) bool {
+		iManaged := strings.TrimSpace(legacyLoaders[i].Summary.ManagedAgentName) != ""
+		jManaged := strings.TrimSpace(legacyLoaders[j].Summary.ManagedAgentName) != ""
+		if iManaged != jManaged {
+			return iManaged
+		}
+		if legacyLoaders[i].Summary.ID != legacyLoaders[j].Summary.ID {
+			return legacyLoaders[i].Summary.ID < legacyLoaders[j].Summary.ID
+		}
+		return legacyLoaders[i].Summary.Name < legacyLoaders[j].Summary.Name
+	})
+
+	scheduledAgents := make(map[string]struct{}, len(legacyLoaders))
+	overrides := make(map[string]domain.Loader, len(legacyLoaders))
+	for _, loader := range legacyLoaders {
+		sourceIndex, sourceFound := agentByLegacyID[strings.TrimSpace(loader.Summary.AgentID)]
+		managedName := legacyCanonicalAgentName(loader.Summary.ManagedAgentName)
+		trustedManagedBinding := managedName != ""
+		targetIndex := -1
+
+		if managedName != "" {
+			if index, exists := agentByName[managedName]; exists {
+				if _, scheduled := scheduledAgents[managedName]; !scheduled {
+					targetIndex = index
+				}
+			} else {
+				targetIndex = appendLegacyLoaderAgent(spec, loader, managedName, sourceIndex, sourceFound, true)
+				agentByName[managedName] = targetIndex
+				usedNames[managedName] = struct{}{}
+			}
+		}
+		if targetIndex < 0 && sourceFound {
+			sourceName := spec.Agents[sourceIndex].Name
+			if _, scheduled := scheduledAgents[sourceName]; !scheduled {
+				targetIndex = sourceIndex
+			}
+		}
+		associated := sourceFound || trustedManagedBinding
+		if targetIndex < 0 {
+			prefix := "legacy-loader"
+			if sourceFound {
+				prefix = spec.Agents[sourceIndex].Name + "-loader"
+			}
+			targetName := reserveLegacyStableName(prefix, identity.ResourceLoader, loader.Summary.ID, loader.Summary.Name, usedNames)
+			targetIndex = appendLegacyLoaderAgent(spec, loader, targetName, sourceIndex, sourceFound, associated)
+			agentByName[targetName] = targetIndex
+		}
+
+		targetName := spec.Agents[targetIndex].Name
+		projected := loader
+		projected.Triggers = append([]domain.LoaderTrigger(nil), loader.Triggers...)
+		projected.EnvItems = append([]domain.SandboxEnvVar(nil), loader.EnvItems...)
+		projected.Volumes = append([]domain.VolumeMountSpec(nil), loader.Volumes...)
+		projected.Summary.CapsetIDs = append([]string(nil), loader.Summary.CapsetIDs...)
+		projected.Script = strings.ReplaceAll(loader.Script, "\r\n", "\n")
+		if !associated {
+			// An unbound global loader has no lossless project-agent target. Keep it
+			// visible, but do not let migration unexpectedly execute it.
+			projected.Summary.Enabled = false
+		}
+		spec.Agents[targetIndex].Scheduler = &compose.NormalizedSchedulerSpec{
+			Enabled:       projected.Summary.Enabled,
+			SandboxPolicy: domain.NormalizeLoaderSandboxPolicy(projected.Summary.SandboxPolicy),
+			Script:        projected.Script,
+		}
+		scheduledAgents[targetName] = struct{}{}
+		overrides[targetName] = projected
+	}
+	if len(overrides) == 0 {
+		return nil
+	}
+	return overrides
+}
+
+func appendLegacyLoaderAgent(spec *compose.NormalizedProjectSpec, loader domain.Loader, name string, sourceIndex int, sourceFound, associated bool) int {
+	var agent compose.NormalizedAgentSpec
+	if sourceFound {
+		agent = spec.Agents[sourceIndex]
+		agent.Scheduler = nil
+	} else {
+		status := "disabled"
+		if associated {
+			status = "enabled"
+		}
+		agent = compose.NormalizedAgentSpec{
+			Status:    status,
+			Provider:  legacyLoaderProvider(loader.Summary.DefaultAgent),
+			Image:     strings.TrimSpace(loader.Summary.GuestImage),
+			Driver:    legacyDriver(loader.Summary.Driver),
+			Env:       legacyEnv(loader.EnvItems),
+			CapsetIDs: append([]string(nil), loader.Summary.CapsetIDs...),
+			Volumes:   legacyVolumes(loader.Volumes),
+		}
+	}
+	agent.Name = name
+	spec.Agents = append(spec.Agents, agent)
+	return len(spec.Agents) - 1
+}
+
+func legacyLoaderProvider(provider string) string {
+	provider = domain.NormalizeAgentKind(provider)
+	switch provider {
+	case "codex", "claude", "gemini", "opencode":
+		return provider
+	default:
+		return domain.DefaultAgentProvider
+	}
+}
+
+func reserveLegacyStableName(prefix string, kind identity.ResourceKind, id, fallback string, used map[string]struct{}) string {
+	seed := strings.TrimSpace(id)
+	if seed == "" {
+		seed = strings.TrimSpace(fallback)
+	}
+	digest := identity.NewID(kind, LegacyDefaultProjectName, seed)
+	for length := 12; length <= len(digest); length += 4 {
+		if length > len(digest) {
+			length = len(digest)
+		}
+		candidate := prefix + "-" + digest[:length]
+		if _, exists := used[candidate]; !exists {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
+	for sequence := 2; ; sequence++ {
+		candidate := fmt.Sprintf("%s-%s-%d", prefix, digest, sequence)
+		if _, exists := used[candidate]; !exists {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
 }
 
 func normalizedAgentFromLegacy(definition domain.AgentDefinition) (compose.NormalizedAgentSpec, error) {

--- a/pkg/projects/legacy_default_project_integration_test.go
+++ b/pkg/projects/legacy_default_project_integration_test.go
@@ -1,0 +1,205 @@
+package projects_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/do/v2"
+
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/images"
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+	"agent-compose/pkg/storage/configstore"
+)
+
+func TestIntegrationLegacyDefaultProjectAdoptsLoaderHistoryAtCurrentRevision(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:           root,
+		DbAddr:             filepath.Join(root, "data.db"),
+		RuntimeDriver:      driverpkg.RuntimeDriverDocker,
+		DockerDefaultImage: "guest:latest",
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("create config store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.DB().Close(); err != nil {
+			t.Errorf("close config store: %v", err)
+		}
+	})
+
+	agent, err := store.CreateAgentDefinition(ctx, domain.AgentDefinition{
+		ID:         "legacy-agent-source",
+		Name:       "ai资讯推送",
+		Enabled:    true,
+		Provider:   "codex",
+		Driver:     driverpkg.RuntimeDriverDocker,
+		GuestImage: "guest:latest",
+	})
+	if err != nil {
+		t.Fatalf("create legacy agent: %v", err)
+	}
+	const script = `
+scheduler.interval("hourly", function hourly() {}, 3600000);
+scheduler.on("news.ready", "on-news", function onNews() {});
+`
+	loader, err := store.CreateLoader(ctx, domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:            "legacy-loader-source",
+			Name:          "资讯推送任务",
+			Enabled:       false,
+			Runtime:       domain.LoaderRuntimeScheduler,
+			AgentID:       agent.ID,
+			Driver:        driverpkg.RuntimeDriverDocker,
+			GuestImage:    "guest:latest",
+			DefaultAgent:  "codex",
+			SandboxPolicy: domain.LoaderSandboxPolicySticky,
+		},
+		Script: script,
+	})
+	if err != nil {
+		t.Fatalf("create legacy loader: %v", err)
+	}
+	engine := &loaders.QJSLoaderEngine{}
+	validation, err := engine.Validate(ctx, loader.Summary.Runtime, loader.Script)
+	if err != nil {
+		t.Fatalf("validate legacy loader: %v", err)
+	}
+	if _, err := store.ReplaceLoaderTriggers(ctx, loader.Summary.ID, validation.Triggers); err != nil {
+		t.Fatalf("create legacy triggers: %v", err)
+	}
+	if err := store.SetLoaderTriggerEnabled(ctx, loader.Summary.ID, "on-news", false); err != nil {
+		t.Fatalf("disable legacy trigger: %v", err)
+	}
+	startedAt := time.Now().UTC().Add(-time.Hour)
+	if err := store.CreateLoaderRun(ctx, domain.LoaderRunSummary{
+		ID: "legacy-run", LoaderID: loader.Summary.ID, TriggerID: "hourly", TriggerKind: domain.LoaderTriggerKindInterval,
+		Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt, CompletedAt: startedAt.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("create legacy run: %v", err)
+	}
+	if err := store.AddLoaderEvent(ctx, domain.LoaderEvent{
+		ID: "legacy-event", LoaderID: loader.Summary.ID, RunID: "legacy-run", Type: "loader.completed", CreatedAt: startedAt.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("create legacy event: %v", err)
+	}
+
+	controller := projects.NewController(projects.ControllerDependencies{
+		Config:  config,
+		Store:   store,
+		Images:  legacyProjectImageBackend{},
+		Loaders: legacyProjectLoaderValidator{engine: engine},
+		Volumes: legacyProjectVolumeManager{},
+	})
+	result, err := controller.SyncLegacyDefaultProject(ctx)
+	if err != nil {
+		t.Fatalf("SyncLegacyDefaultProject returned error: %v", err)
+	}
+	if !result.Applied || len(result.Issues) != 0 {
+		t.Fatalf("sync result = %#v", result)
+	}
+	if len(result.Agents) != 1 || !strings.HasPrefix(result.Agents[0].AgentName, "legacy-agent-") {
+		t.Fatalf("projected Chinese agents = %#v", result.Agents)
+	}
+
+	projectID, err := domain.StableProjectID(projects.LegacyDefaultProjectName, "")
+	if err != nil {
+		t.Fatalf("stable project id: %v", err)
+	}
+	project, err := store.GetProject(ctx, projectID)
+	if err != nil {
+		t.Fatalf("load legacy project: %v", err)
+	}
+	page, err := store.ListProjectSchedulersPage(ctx, "", "", 10)
+	if err != nil {
+		t.Fatalf("list project schedulers page: %v", err)
+	}
+	if len(page) != 1 || page[0].Revision != project.CurrentRevision || page[0].ManagedLoaderID != loader.Summary.ID || page[0].Enabled || page[0].RunCount != 1 {
+		t.Fatalf("project scheduler page = %#v, project = %#v", page, project)
+	}
+
+	adopted, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil {
+		t.Fatalf("load adopted loader: %v", err)
+	}
+	if adopted.Summary.ManagedProjectID != project.ID || adopted.Summary.ManagedRevision != project.CurrentRevision || adopted.Summary.ManagedAgentName != page[0].AgentName || adopted.Summary.Enabled {
+		t.Fatalf("adopted loader = %#v", adopted.Summary)
+	}
+	triggerEnabled := make(map[string]bool, len(adopted.Triggers))
+	for _, trigger := range adopted.Triggers {
+		triggerEnabled[trigger.ID] = trigger.Enabled
+	}
+	if len(triggerEnabled) != 2 || !triggerEnabled["hourly"] || triggerEnabled["on-news"] {
+		t.Fatalf("adopted trigger states = %#v", triggerEnabled)
+	}
+	if runs, err := store.ListLoaderRuns(ctx, loader.Summary.ID, 10); err != nil || len(runs) != 1 || runs[0].ID != "legacy-run" {
+		t.Fatalf("adopted loader runs = %#v, err = %v", runs, err)
+	}
+	if events, err := store.ListLoaderEvents(ctx, loader.Summary.ID, 10); err != nil || len(events) != 1 || events[0].ID != "legacy-event" {
+		t.Fatalf("adopted loader events = %#v, err = %v", events, err)
+	}
+
+	repeated, err := controller.SyncLegacyDefaultProject(ctx)
+	if err != nil || !repeated.Applied || repeated.Revision.Revision != project.CurrentRevision {
+		t.Fatalf("repeated sync = %#v, err = %v", repeated, err)
+	}
+	page, err = store.ListProjectSchedulersPage(ctx, "", "", 10)
+	if err != nil || len(page) != 1 || page[0].ManagedLoaderID != loader.Summary.ID || page[0].RunCount != 1 {
+		t.Fatalf("scheduler page after repeated sync = %#v, err = %v", page, err)
+	}
+}
+
+type legacyProjectLoaderValidator struct {
+	engine *loaders.QJSLoaderEngine
+}
+
+func (v legacyProjectLoaderValidator) Validate(ctx context.Context, runtime, script string) (loaders.LoaderValidationResult, error) {
+	return v.engine.Validate(ctx, runtime, script)
+}
+
+func (legacyProjectLoaderValidator) Refresh(context.Context) error { return nil }
+
+type legacyProjectImageBackend struct{}
+
+func (legacyProjectImageBackend) ListImages(context.Context, images.ListRequest) (images.ListResult, error) {
+	return images.ListResult{}, nil
+}
+
+func (legacyProjectImageBackend) PullImage(context.Context, images.PullRequest) (images.PullResult, error) {
+	return images.PullResult{}, nil
+}
+
+func (legacyProjectImageBackend) InspectImage(context.Context, images.InspectRequest) (images.InspectResult, error) {
+	return images.InspectResult{}, nil
+}
+
+func (legacyProjectImageBackend) RemoveImage(context.Context, images.RemoveRequest) (images.RemoveResult, error) {
+	return images.RemoveResult{}, nil
+}
+
+type legacyProjectVolumeManager struct{}
+
+func (legacyProjectVolumeManager) Ensure(context.Context, domain.VolumeRecord) (domain.VolumeRecord, bool, error) {
+	return domain.VolumeRecord{}, false, nil
+}
+
+func (legacyProjectVolumeManager) Inspect(context.Context, string) (domain.VolumeRecord, error) {
+	return domain.VolumeRecord{}, nil
+}
+
+func (legacyProjectVolumeManager) ReplaceProjectVolumes(context.Context, string, map[string]domain.ProjectVolumeLink) error {
+	return nil
+}
+
+func (legacyProjectVolumeManager) RemoveProjectVolumes(context.Context, string) error { return nil }

--- a/pkg/projects/legacy_default_project_test.go
+++ b/pkg/projects/legacy_default_project_test.go
@@ -1,8 +1,10 @@
 package projects
 
 import (
+	"strings"
 	"testing"
 
+	"agent-compose/pkg/compose"
 	domain "agent-compose/pkg/model"
 )
 
@@ -25,7 +27,7 @@ func TestLegacyDefaultNormalizedProjectPreservesAgentConfiguration(t *testing.T)
 		{ID: "agent-a", Name: "worker-a-Z", Enabled: true, Provider: "codex", ConfigJSON: "{}"},
 	}
 
-	project, err := legacyDefaultNormalizedProject(agents)
+	project, err := legacyDefaultNormalizedProject(agents, nil)
 	if err != nil {
 		t.Fatalf("legacyDefaultNormalizedProject returned error: %v", err)
 	}
@@ -43,7 +45,7 @@ func TestLegacyDefaultNormalizedProjectPreservesAgentConfiguration(t *testing.T)
 		t.Fatalf("worker configuration = %#v", worker)
 	}
 
-	reversed, err := legacyDefaultNormalizedProject([]domain.AgentDefinition{agents[1], agents[0]})
+	reversed, err := legacyDefaultNormalizedProject([]domain.AgentDefinition{agents[1], agents[0]}, nil)
 	if err != nil {
 		t.Fatalf("reversed project returned error: %v", err)
 	}
@@ -53,13 +55,192 @@ func TestLegacyDefaultNormalizedProjectPreservesAgentConfiguration(t *testing.T)
 }
 
 func TestLegacyDefaultNormalizedProjectRejectsLossyMappings(t *testing.T) {
-	_, err := legacyDefaultNormalizedProject([]domain.AgentDefinition{{ID: "agent-1", Name: "worker", Enabled: true, Provider: "codex", WorkspaceID: "workspace-1"}})
+	_, err := legacyDefaultNormalizedProject([]domain.AgentDefinition{{ID: "agent-1", Name: "worker", Enabled: true, Provider: "codex", WorkspaceID: "workspace-1"}}, nil)
 	if err == nil {
 		t.Fatal("expected workspace preset compatibility error")
 	}
+}
 
-	_, err = legacyDefaultNormalizedProject([]domain.AgentDefinition{{ID: "agent-1", Name: "worker", Enabled: true}, {ID: "agent-2", Name: "worker", Enabled: true}})
-	if err == nil {
-		t.Fatal("expected duplicate agent name error")
+func TestLegacyDefaultNormalizedProjectUsesStableCompatibilityNames(t *testing.T) {
+	agents := []domain.AgentDefinition{
+		{ID: "agent-chinese", Name: "ai资讯推送", Enabled: true, Provider: "codex"},
+		{ID: "agent-duplicate-b", Name: "worker", Enabled: true, Provider: "codex"},
+		{ID: "agent-duplicate-a", Name: "worker", Enabled: true, Provider: "codex"},
+		{ID: "agent-valid", Name: "Reviewer-Z", Enabled: true, Provider: "codex"},
 	}
+
+	project, err := legacyDefaultNormalizedProject(agents, nil)
+	if err != nil {
+		t.Fatalf("legacyDefaultNormalizedProject returned error: %v", err)
+	}
+	if len(project.Spec.Agents) != len(agents) {
+		t.Fatalf("project agents = %#v", project.Spec.Agents)
+	}
+	names := make(map[string]struct{}, len(project.Spec.Agents))
+	var compatibilityName string
+	duplicateCount := 0
+	for _, agent := range project.Spec.Agents {
+		if !domain.IsProjectStableIdentifier(agent.Name) {
+			t.Fatalf("projected agent name %q is not a stable identifier", agent.Name)
+		}
+		if _, exists := names[agent.Name]; exists {
+			t.Fatalf("duplicate projected agent name %q", agent.Name)
+		}
+		names[agent.Name] = struct{}{}
+		if strings.HasPrefix(agent.Name, "legacy-agent-") {
+			compatibilityName = agent.Name
+		}
+		if strings.HasPrefix(agent.Name, "worker-") {
+			duplicateCount++
+		}
+	}
+	if compatibilityName == "" || duplicateCount != 2 {
+		t.Fatalf("compatibility names = %#v", names)
+	}
+	if _, exists := names["reviewer-z"]; !exists {
+		t.Fatalf("valid normalized name missing from %#v", names)
+	}
+
+	reversed := append([]domain.AgentDefinition(nil), agents...)
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+	reversedProject, err := legacyDefaultNormalizedProject(reversed, nil)
+	if err != nil {
+		t.Fatalf("reversed project returned error: %v", err)
+	}
+	if reversedProject.SpecHash != project.SpecHash {
+		t.Fatalf("hash depends on input order: %s != %s", reversedProject.SpecHash, project.SpecHash)
+	}
+
+	renamed, err := legacyDefaultNormalizedProject([]domain.AgentDefinition{{ID: "agent-chinese", Name: "另一个中文名", Enabled: true, Provider: "codex"}}, nil)
+	if err != nil {
+		t.Fatalf("renamed invalid agent returned error: %v", err)
+	}
+	if renamed.Spec.Agents[0].Name != compatibilityName {
+		t.Fatalf("compatibility name changed after display-name edit: %q != %q", renamed.Spec.Agents[0].Name, compatibilityName)
+	}
+}
+
+func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
+	agents := []domain.AgentDefinition{{
+		ID:         "agent-1",
+		Name:       "worker",
+		Enabled:    true,
+		Provider:   "codex",
+		Driver:     "docker",
+		GuestImage: "guest:latest",
+	}}
+	loaders := []domain.Loader{
+		{
+			Summary: domain.LoaderSummary{
+				ID:                "loader-b",
+				Name:              "Second task",
+				Enabled:           true,
+				Runtime:           domain.LoaderRuntimeScheduler,
+				AgentID:           "agent-1",
+				DefaultAgent:      "codex",
+				SandboxPolicy:     domain.LoaderSandboxPolicyNew,
+				ConcurrencyPolicy: domain.LoaderConcurrencyPolicyParallel,
+			},
+			Script: "scheduler.on('topic.b', 'event-b', function eventB() {});",
+			Triggers: []domain.LoaderTrigger{{
+				ID: "event-b", Kind: domain.LoaderTriggerKindEvent, Topic: "topic.b", Enabled: true,
+			}},
+		},
+		{
+			Summary: domain.LoaderSummary{
+				ID:            "loader-a",
+				Name:          "First task",
+				Enabled:       false,
+				Runtime:       domain.LoaderRuntimeScheduler,
+				AgentID:       "agent-1",
+				DefaultAgent:  "codex",
+				SandboxPolicy: domain.LoaderSandboxPolicySticky,
+			},
+			Script: "scheduler.interval('interval-a', function intervalA() {}, 60000);",
+			Triggers: []domain.LoaderTrigger{{
+				ID: "interval-a", Kind: domain.LoaderTriggerKindInterval, IntervalMs: 60000, Enabled: false,
+			}},
+		},
+	}
+
+	project, err := legacyDefaultNormalizedProject(agents, loaders)
+	if err != nil {
+		t.Fatalf("legacyDefaultNormalizedProject returned error: %v", err)
+	}
+	if len(project.Spec.Agents) != 2 || len(project.managedLoaderOverrides) != 2 {
+		t.Fatalf("project agents/overrides = %#v/%#v", project.Spec.Agents, project.managedLoaderOverrides)
+	}
+	worker := findLegacyProjectAgent(t, project, "worker")
+	if worker.Scheduler == nil || worker.Scheduler.Enabled || worker.Scheduler.Script != loaders[1].Script {
+		t.Fatalf("worker scheduler = %#v", worker.Scheduler)
+	}
+	workerLoader := project.managedLoaderOverrides["worker"]
+	if workerLoader.Summary.ID != "loader-a" || workerLoader.Summary.Enabled || len(workerLoader.Triggers) != 1 || workerLoader.Triggers[0].Enabled {
+		t.Fatalf("worker loader override = %#v", workerLoader)
+	}
+
+	var clonedName string
+	for _, agent := range project.Spec.Agents {
+		if strings.HasPrefix(agent.Name, "worker-loader-") {
+			clonedName = agent.Name
+			if agent.Scheduler == nil || !agent.Scheduler.Enabled || agent.Scheduler.Script != loaders[0].Script {
+				t.Fatalf("cloned scheduler = %#v", agent.Scheduler)
+			}
+		}
+	}
+	if clonedName == "" || project.managedLoaderOverrides[clonedName].Summary.ID != "loader-b" {
+		t.Fatalf("second loader was not projected: name=%q overrides=%#v", clonedName, project.managedLoaderOverrides)
+	}
+
+	reversedProject, err := legacyDefaultNormalizedProject(agents, []domain.Loader{loaders[1], loaders[0]})
+	if err != nil {
+		t.Fatalf("reversed loaders returned error: %v", err)
+	}
+	if reversedProject.SpecHash != project.SpecHash {
+		t.Fatalf("loader projection hash depends on input order: %s != %s", reversedProject.SpecHash, project.SpecHash)
+	}
+}
+
+func TestLegacyDefaultNormalizedProjectKeepsUnboundLoaderVisibleButDisabled(t *testing.T) {
+	loader := domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:           "loader-unbound",
+			Name:         "Unbound task",
+			Enabled:      true,
+			Runtime:      domain.LoaderRuntimeScheduler,
+			DefaultAgent: "codex",
+		},
+		Script: "scheduler.on('topic', 'event', function event() {});",
+		Triggers: []domain.LoaderTrigger{{
+			ID: "event", Kind: domain.LoaderTriggerKindEvent, Topic: "topic", Enabled: true,
+		}},
+	}
+
+	project, err := legacyDefaultNormalizedProject(nil, []domain.Loader{loader})
+	if err != nil {
+		t.Fatalf("legacyDefaultNormalizedProject returned error: %v", err)
+	}
+	if len(project.Spec.Agents) != 1 || !strings.HasPrefix(project.Spec.Agents[0].Name, "legacy-loader-") {
+		t.Fatalf("compatibility agent = %#v", project.Spec.Agents)
+	}
+	agent := project.Spec.Agents[0]
+	if agent.Status != "disabled" || agent.Scheduler == nil || agent.Scheduler.Enabled {
+		t.Fatalf("unbound compatibility agent = %#v", agent)
+	}
+	if adopted := project.managedLoaderOverrides[agent.Name]; adopted.Summary.ID != loader.Summary.ID || adopted.Summary.Enabled {
+		t.Fatalf("unbound loader override = %#v", adopted)
+	}
+}
+
+func findLegacyProjectAgent(t *testing.T, project NormalizedProject, name string) compose.NormalizedAgentSpec {
+	t.Helper()
+	for _, agent := range project.Spec.Agents {
+		if agent.Name == name {
+			return agent
+		}
+	}
+	t.Fatalf("agent %q not found in %#v", name, project.Spec.Agents)
+	return compose.NormalizedAgentSpec{}
 }

--- a/pkg/projects/managed_loader_overrides.go
+++ b/pkg/projects/managed_loader_overrides.go
@@ -1,0 +1,72 @@
+package projects
+
+import (
+	"fmt"
+	"strings"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+// applyManagedLoaderOverrideBuilds adopts legacy loader identities at the
+// project artifact boundary. Ordinary project specs never populate overrides.
+func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int64, builds []SchedulerBuild, overrides map[string]domain.Loader) ([]SchedulerBuild, error) {
+	if len(overrides) == 0 {
+		return builds, nil
+	}
+	for index := range builds {
+		override, ok := overrides[builds[index].Scheduler.AgentName]
+		if !ok {
+			continue
+		}
+		loaderID := strings.TrimSpace(override.Summary.ID)
+		if loaderID == "" {
+			return nil, fmt.Errorf("legacy loader for agent %s has no id", builds[index].Scheduler.AgentName)
+		}
+
+		loader := loaders.CloneLoader(override)
+		loader.Volumes = append([]domain.VolumeMountSpec(nil), override.Volumes...)
+		loader.Summary.CapsetIDs = append([]string(nil), override.Summary.CapsetIDs...)
+		loader.Summary.ManagedProjectID = project.ID
+		loader.Summary.ManagedRevision = revision
+		loader.Summary.ManagedAgentName = builds[index].Scheduler.AgentName
+		loader.Summary.ManagedSchedulerID = builds[index].Scheduler.SchedulerID
+
+		builds[index].Scheduler.ManagedLoaderID = loaderID
+		builds[index].Scheduler.Enabled = loader.Summary.Enabled
+		builds[index].Scheduler.TriggerCount = len(loader.Triggers)
+		builds[index].Loader = loader
+		builds[index].ValidationTriggers = append([]domain.LoaderTrigger(nil), loader.Triggers...)
+	}
+	return builds, nil
+}
+
+func applyManagedLoaderOverrides(project domain.ProjectRecord, revision int64, schedulers []domain.ProjectSchedulerRecord, managedLoaders []domain.Loader, overrides map[string]domain.Loader) ([]domain.ProjectSchedulerRecord, []domain.Loader, error) {
+	if len(overrides) == 0 {
+		return schedulers, managedLoaders, nil
+	}
+	if len(schedulers) != len(managedLoaders) {
+		return nil, nil, fmt.Errorf("project scheduler and managed loader counts differ")
+	}
+	builds := make([]SchedulerBuild, 0, len(schedulers))
+	for index := range schedulers {
+		builds = append(builds, SchedulerBuild{Scheduler: schedulers[index], Loader: managedLoaders[index]})
+	}
+	builds, err := applyManagedLoaderOverrideBuilds(project, revision, builds, overrides)
+	if err != nil {
+		return nil, nil, err
+	}
+	return SchedulerRecords(builds), SchedulerLoaders(builds), nil
+}
+
+func syncProjectAgentSchedulerState(agents []domain.ProjectAgentRecord, schedulers []domain.ProjectSchedulerRecord) {
+	enabledByAgent := make(map[string]bool, len(schedulers))
+	for _, scheduler := range schedulers {
+		enabledByAgent[scheduler.AgentName] = scheduler.Enabled
+	}
+	for index := range agents {
+		if enabled, ok := enabledByAgent[agents[index].AgentName]; ok {
+			agents[index].SchedulerEnabled = enabled
+		}
+	}
+}

--- a/scripts/test-compose-kvm-config.sh
+++ b/scripts/test-compose-kvm-config.sh
@@ -19,6 +19,7 @@ compose_config() {
     -u AGENT_COMPOSE_IMAGE \
     -u AGENT_COMPOSE_FRONTEND_IMAGE \
     -u AGENT_COMPOSE_RUNTIME_BASE_URL \
+    -u AGENT_COMPOSE_DATA_DIR \
     docker compose \
       --project-directory "$ROOT_DIR" \
       --env-file "$ROOT_DIR/.env.example" \
@@ -30,13 +31,13 @@ base_json=$(compose_config -f "$ROOT_DIR/docker-compose.yml")
 kvm_json=$(compose_config -f "$ROOT_DIR/docker-compose.yml" -f "$ROOT_DIR/docker-compose.kvm.yml")
 local_json=$(compose_config -f "$ROOT_DIR/docker-compose.yml" -f "$ROOT_DIR/docker-compose.override.yml.example")
 
-jq -e '
+jq -e --arg data_source "$ROOT_DIR/data" '
   .services["agent-compose"] as $service |
   $service.privileged != true and
   (($service.devices // []) | length == 0) and
   $service.build == null and
   any($service.volumes[]; .source == "/var/run/docker.sock" and .target == "/var/run/docker.sock") and
-  any($service.volumes[]; .target == "/data") and
+  any($service.volumes[]; .source == $data_source and .target == "/data") and
   any($service.volumes[]; .target == "/data/work/.env" and .read_only == true) and
   any($service.ports[]; .host_ip == "127.0.0.1" and .target == 7410 and .published == "7410")
 ' >/dev/null <<<"$base_json"


### PR DESCRIPTION
## Summary

- Project standalone legacy agents and loaders into legacy-v1-default while preserving loader IDs, run and event history, triggers, and enablement state.
- Generate stable compatibility names for invalid or duplicate legacy agent names, and keep unbound loaders visible but disabled.
- Persist AGENT_COMPOSE_DATA_DIR so upgrades retain either the current data layout or the legacy data/agent-compose layout, and stop before mutation when both databases exist.
- Make install.sh --upgrade fetch the latest release bundle, with --version selecting an exact release, while an ordinary bundle install continues to use the extracted bundle.

## Validation

- go test ./pkg/projects/...
- pkg/projects lint
- task build
- bash -n deploy/install.sh deploy/install_test.sh deploy/install_upgrade_test.sh
- deploy/install_test.sh in a non-root Linux container
- deploy/install_upgrade_test.sh in a Debian Linux container
- scripts/test-compose-kvm-config.sh in Linux
- scripts/test-installer-assets.sh in Linux
- git diff --check

## Notes

- The installer does not move or rewrite an existing database. It only persists the authoritative host data directory used for the /data mount.
- The complete host task test command was not rerun as one command because the macOS environment lacks the GNU realpath, stat, find, and tar behavior required by the deployment tests. All four test:deploy child commands passed in a prepared Linux environment.
