### PR TITLE
fix(runs): sync project sandbox capability tokens

### DIFF
--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -2148,6 +2148,9 @@ func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain
 	}
 	domain.RestoreSandboxTransientFields(loaded, sandbox)
 	*sandbox = *loaded
+	if c.capTokens != nil {
+		c.capTokens.IndexSandbox(loaded)
+	}
 	return nil
 }
 
@@ -2207,7 +2210,10 @@ func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandb
 	sandbox := sandboxResult.Sandbox
 	if CleanupPolicyRemovesSandbox(policy) && sandboxResult.Created {
 		if c.removal != nil {
-			_, err := c.removal.Remove(ctx, sandbox.Summary.ID, true)
+			result, err := c.removal.Remove(ctx, sandbox.Summary.ID, true)
+			if err == nil && result.Removed && c.capTokens != nil {
+				c.capTokens.RevokeSandbox(sandbox.Summary.ID)
+			}
 			return err
 		}
 		if err := c.stopProjectRunSandbox(ctx, sandbox); err != nil {
@@ -2224,6 +2230,9 @@ func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandb
 		}
 		if err := c.store.RemoveSandbox(ctx, sandbox.Summary.ID); err != nil {
 			return err
+		}
+		if c.capTokens != nil {
+			c.capTokens.RevokeSandbox(sandbox.Summary.ID)
 		}
 		if c.dashboard != nil {
 			c.dashboard.Notify("sandbox_removed")
@@ -2242,6 +2251,9 @@ func (c *Controller) stopProjectRunSandbox(ctx context.Context, sandbox *domain.
 		return err
 	}
 	if loaded.Summary.VMStatus != domain.VMStatusRunning {
+		if c.capTokens != nil {
+			c.capTokens.RevokeSandbox(loaded.Summary.ID)
+		}
 		return nil
 	}
 	if c.driver == nil {
@@ -2253,6 +2265,9 @@ func (c *Controller) stopProjectRunSandbox(ctx context.Context, sandbox *domain.
 	loaded.Summary.VMStatus = domain.VMStatusStopped
 	if err := c.store.UpdateSandbox(ctx, loaded); err != nil {
 		return err
+	}
+	if c.capTokens != nil {
+		c.capTokens.RevokeSandbox(loaded.Summary.ID)
 	}
 	event := domain.SandboxEvent{ID: uuid.NewString(), Type: "sandbox.stopped", Level: "info", Message: "sandbox stopped", CreatedAt: time.Now().UTC()}
 	_ = c.store.AddEvent(ctx, loaded.Summary.ID, event)

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -2231,9 +2231,6 @@ func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandb
 		if err := c.store.RemoveSandbox(ctx, sandbox.Summary.ID); err != nil {
 			return err
 		}
-		if c.capTokens != nil {
-			c.capTokens.RevokeSandbox(sandbox.Summary.ID)
-		}
 		if c.dashboard != nil {
 			c.dashboard.Notify("sandbox_removed")
 		}

--- a/pkg/runs/project_run_capability_token_test.go
+++ b/pkg/runs/project_run_capability_token_test.go
@@ -1,0 +1,152 @@
+package runs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"agent-compose/pkg/capabilities"
+	driverpkg "agent-compose/pkg/driver"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sessions"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+type recordingCapabilitySandboxIndexer struct {
+	indexed []*domain.Sandbox
+	revoked []string
+}
+
+func (i *recordingCapabilitySandboxIndexer) IndexSandbox(sandbox *domain.Sandbox) {
+	i.indexed = append(i.indexed, sandbox)
+}
+
+func (i *recordingCapabilitySandboxIndexer) RevokeSandbox(sandboxID string) {
+	i.revoked = append(i.revoked, sandboxID)
+}
+
+type projectRunRemovalStub struct {
+	result sessions.RemovalResult
+	err    error
+}
+
+func (s projectRunRemovalStub) Remove(context.Context, string, bool) (sessions.RemovalResult, error) {
+	return s.result, s.err
+}
+
+func TestProjectRunCapabilityTokenLifecycle(t *testing.T) {
+	t.Run("start and resume index only after running state reload", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusStopped)
+
+		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed"); err != nil {
+			t.Fatalf("startProjectRunSandbox: %v", err)
+		}
+		if len(indexer.indexed) != 1 {
+			t.Fatalf("indexed count = %d, want 1", len(indexer.indexed))
+		}
+		indexed := indexer.indexed[0]
+		if indexed.Summary.VMStatus != domain.VMStatusRunning || capabilities.SandboxToken(indexed) == "" {
+			t.Fatalf("indexed sandbox = %#v", indexed)
+		}
+		reloaded, err := fixture.store.GetSandbox(fixture.ctx, sandbox.Summary.ID)
+		if err != nil {
+			t.Fatalf("reload sandbox: %v", err)
+		}
+		if indexed.Summary.UpdatedAt != reloaded.Summary.UpdatedAt {
+			t.Fatalf("indexed UpdatedAt = %v, reloaded = %v", indexed.Summary.UpdatedAt, reloaded.Summary.UpdatedAt)
+		}
+	})
+
+	t.Run("start failure does not index", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+		fixture.driver.startErr = errors.New("start failed")
+		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusStopped)
+
+		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed"); !errors.Is(err, fixture.driver.startErr) {
+			t.Fatalf("startProjectRunSandbox error = %v", err)
+		}
+		if len(indexer.indexed) != 0 || len(indexer.revoked) != 0 {
+			t.Fatalf("index changes = indexed %d revoked %v", len(indexer.indexed), indexer.revoked)
+		}
+	})
+
+	t.Run("stop success and already stopped revoke", func(t *testing.T) {
+		for _, status := range []string{domain.VMStatusRunning, domain.VMStatusStopped} {
+			t.Run(status, func(t *testing.T) {
+				fixture := newControllerRunFixture(t)
+				indexer := &recordingCapabilitySandboxIndexer{}
+				fixture.controller.capTokens = indexer
+				sandbox := newProjectRunCapabilitySandbox(t, fixture, status)
+
+				if err := fixture.controller.stopProjectRunSandbox(fixture.ctx, sandbox); err != nil {
+					t.Fatalf("stopProjectRunSandbox: %v", err)
+				}
+				if len(indexer.revoked) != 1 || indexer.revoked[0] != sandbox.Summary.ID {
+					t.Fatalf("revoked = %v", indexer.revoked)
+				}
+			})
+		}
+	})
+
+	t.Run("stop failure preserves index", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+		fixture.driver.stopErr = errors.New("stop failed")
+		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusRunning)
+
+		if err := fixture.controller.stopProjectRunSandbox(fixture.ctx, sandbox); !errors.Is(err, fixture.driver.stopErr) {
+			t.Fatalf("stopProjectRunSandbox error = %v", err)
+		}
+		if len(indexer.revoked) != 0 {
+			t.Fatalf("revoked = %v", indexer.revoked)
+		}
+	})
+
+	t.Run("remove revokes only after confirmed removal", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			result  sessions.RemovalResult
+			err     error
+			wantRev bool
+		}{
+			{name: "success", result: sessions.RemovalResult{Removed: true}, wantRev: true},
+			{name: "incomplete", result: sessions.RemovalResult{}},
+			{name: "failure", err: errors.New("remove failed")},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				indexer := &recordingCapabilitySandboxIndexer{}
+				controller := NewController(ControllerDependencies{CapTokens: indexer, Removal: projectRunRemovalStub{result: tc.result, err: tc.err}})
+				sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}}
+				err := controller.cleanupProjectRunSandboxByPolicy(context.Background(), SandboxResult{Sandbox: sandbox, Created: true}, agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION)
+				if !errors.Is(err, tc.err) {
+					t.Fatalf("cleanup error = %v, want %v", err, tc.err)
+				}
+				if got := len(indexer.revoked) == 1; got != tc.wantRev {
+					t.Fatalf("revoked = %v, wantRev = %v", indexer.revoked, tc.wantRev)
+				}
+			})
+		}
+	})
+}
+
+func newProjectRunCapabilitySandbox(t *testing.T, fixture *controllerRunFixture, status string) *domain.Sandbox {
+	t.Helper()
+	sandbox, err := fixture.store.CreateSandbox(fixture.ctx, "project run", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeManual, nil,
+		[]domain.SandboxEnvVar{{Name: capabilities.SandboxTokenEnvName, Value: "token-1", Secret: true}},
+		[]domain.SandboxTag{{Name: capabilities.CapsetTagName, Value: "capset-1"}},
+	)
+	if err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+	sandbox.Summary.VMStatus = status
+	if err := fixture.store.UpdateSandbox(fixture.ctx, sandbox); err != nil {
+		t.Fatalf("UpdateSandbox: %v", err)
+	}
+	return sandbox
+}

--- a/pkg/runs/project_run_capability_token_test.go
+++ b/pkg/runs/project_run_capability_token_test.go
@@ -133,6 +133,28 @@ func TestProjectRunCapabilityTokenLifecycle(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("fallback remove revokes exactly once", func(t *testing.T) {
+		fixture := newControllerRunFixture(t)
+		indexer := &recordingCapabilitySandboxIndexer{}
+		fixture.controller.capTokens = indexer
+		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusRunning)
+
+		err := fixture.controller.cleanupProjectRunSandboxByPolicy(
+			fixture.ctx,
+			SandboxResult{Sandbox: sandbox, Created: true},
+			agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION,
+		)
+		if err != nil {
+			t.Fatalf("cleanupProjectRunSandboxByPolicy: %v", err)
+		}
+		if len(indexer.revoked) != 1 || indexer.revoked[0] != sandbox.Summary.ID {
+			t.Fatalf("revoked = %v, want [%s]", indexer.revoked, sandbox.Summary.ID)
+		}
+		if _, err := fixture.store.GetSandbox(fixture.ctx, sandbox.Summary.ID); err == nil {
+			t.Fatal("removed sandbox is still present")
+		}
+	})
 }
 
 func newProjectRunCapabilitySandbox(t *testing.T, fixture *controllerRunFixture, status string) *domain.Sandbox {


### PR DESCRIPTION
## Summary
<img width="552" height="747" alt="image" src="https://github.com/user-attachments/assets/391b7269-d728-48be-a0e3-8e9a76aac328" />

Fix project-run sandboxes failing to authenticate with the local capability proxy.

Project runs already received `CAP_TOKEN` and `CAP_GRPC_TARGET`, but their capability tokens were not synchronized with the proxy's in-memory sandbox index. As a result, valid gRPC requests failed with:

```text
rpc error: code = Unauthenticated desc = capability sandbox token not found
```

This change:

- Indexes the capability token after a project-run sandbox successfully reaches and persists the `RUNNING` state.
- Revokes the token after the sandbox stops or is successfully removed.
- Clears stale token bindings for sandboxes already outside the running state.
- Preserves valid bindings when stop or removal fails.
- Adds regression coverage for start, resume, stop, removal, and failure paths.

The fix was also verified against a running Docker deployment. A newly created project-run sandbox successfully used `grpcurl` through the local capability proxy to resolve the CISA KEV service via gRPC reflection.

## Testing

```bash
go test ./pkg/runs ./pkg/agentcompose/adapters ./pkg/capproxy
go test ./pkg/runs -run 'ProjectRunCapability' -count=1 -v
```

The focused and related package tests pass.

`go test ./...` was also run. It encountered an unrelated existing macOS path-normalization failure in `pkg/volumes`, where `/private/var/...` was compared with `/var/...`.

Manual Docker verification:

- Built a Linux AMD64 binary from this branch.
- Replaced the binary in the running `agent-compose` container.
- Created and ran a project sandbox with a capability set.
- Confirmed gRPC reflection through `agent-compose:9100`.
- Confirmed the previous `capability sandbox token not found` error no longer occurs.

## Checklist

- [x] Documentation updated when behavior or configuration changed.  
  No documentation update was required; this restores the documented capability-token lifecycle.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

