### PR TITLE
fix(projects): migrate legacy agents into v2 projects

### DIFF
--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -718,7 +718,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 		},
 		runEvents: []domain.ProjectRunEventRecord{{ID: "event-1", RunID: "run-1", Sequence: 1, Kind: domain.ProjectRunEventKindUserMessage, Text: "hello", CreatedAt: time.Unix(1, 0)}},
 	}
-	projectHandler := NewProjectHandler(nil, store)
+	projectHandler := NewProjectHandler(nil, store, nil)
 	projectResp, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Name: "Project"}, IncludeSpec: true}))
 	if err != nil {
 		t.Fatalf("GetProject returned error: %v", err)

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -701,7 +701,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 			{ProjectID: "project-1", AgentName: "worker-2", ManagedAgentID: "agent-2", Revision: 1, Driver: "boxlite", Image: "guest:latest"},
 		},
 		schedulers: []domain.ProjectSchedulerRecord{
-			{ProjectID: "project-1", SchedulerID: "scheduler-1", AgentName: "worker", ManagedLoaderID: "loader-1", Revision: 1, Enabled: true, SpecJSON: `{"enabled":true,"script":"run()"}`, RunCount: 3, LatestRunAt: time.Unix(10, 0), LastError: "failed"},
+			{ProjectID: "project-1", SchedulerID: "scheduler-1", AgentName: "worker", ManagedLoaderID: "loader-1", Revision: 1, Enabled: true, SpecJSON: `{"enabled":true,"display_name":"每日巡检","description":"每天汇总巡检结果","script":"run()"}`, RunCount: 3, LatestRunAt: time.Unix(10, 0), LastError: "failed"},
 			{ProjectID: "project-1", SchedulerID: "scheduler-2", AgentName: "worker-2", ManagedLoaderID: "loader-2", Revision: 1, Enabled: true, SpecJSON: `{"enabled":true,"script":"run()"}`},
 		},
 		loaders: map[string]domain.Loader{
@@ -738,14 +738,14 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 		t.Fatalf("ListProjects summary counts = agents %d schedulers %d", summary.GetAgentCount(), summary.GetSchedulerCount())
 	}
 	scheduler, err := projectHandler.GetScheduler(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRequest{Project: &agentcomposev2.ProjectRef{ProjectId: "project-1"}, AgentName: "worker"}))
-	if err != nil || scheduler.Msg.GetScheduler().GetSchedulerId() != "scheduler-1" || scheduler.Msg.GetSpec().GetScript() != "run()" {
+	if err != nil || scheduler.Msg.GetScheduler().GetSchedulerId() != "scheduler-1" || scheduler.Msg.GetScheduler().GetDisplayName() != "每日巡检" || scheduler.Msg.GetSpec().GetScript() != "run()" || scheduler.Msg.GetSpec().GetDescription() != "每天汇总巡检结果" {
 		t.Fatalf("GetScheduler resp=%#v err=%v", scheduler, err)
 	}
 	firstSchedulers, err := projectHandler.ListSchedulers(ctx, connect.NewRequest(&agentcomposev2.ListSchedulersRequest{Limit: 1}))
 	if err != nil || len(firstSchedulers.Msg.GetSchedulers()) != 1 || firstSchedulers.Msg.GetNextCursor() == "" {
 		t.Fatalf("ListSchedulers first page=%#v err=%v", firstSchedulers, err)
 	}
-	if summary := firstSchedulers.Msg.GetSchedulers()[0]; summary.GetEnabled() || summary.GetRunCount() != 3 || !summary.GetLatestRunAt().AsTime().Equal(time.Unix(10, 0)) || summary.GetLastError() != "failed" {
+	if summary := firstSchedulers.Msg.GetSchedulers()[0]; summary.GetEnabled() || summary.GetRunCount() != 3 || !summary.GetLatestRunAt().AsTime().Equal(time.Unix(10, 0)) || summary.GetLastError() != "failed" || summary.GetDisplayName() != "每日巡检" || summary.GetDescription() != "每天汇总巡检结果" {
 		t.Fatalf("ListSchedulers summary=%#v", summary)
 	}
 	secondSchedulers, err := projectHandler.ListSchedulers(ctx, connect.NewRequest(&agentcomposev2.ListSchedulersRequest{Limit: 1, Cursor: firstSchedulers.Msg.GetNextCursor()}))

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -436,6 +436,7 @@ func WorkspaceSpecToProto(workspace *compose.WorkspaceSpec) *agentcomposev2.Work
 		Provider: workspace.Provider,
 		Url:      workspace.URL,
 		Branch:   workspace.Branch,
+		Commit:   workspace.Commit,
 		Path:     workspace.Path,
 	}
 }
@@ -984,6 +985,9 @@ func WorkspaceYAMLShape(workspace *agentcomposev2.WorkspaceSpec) map[string]any 
 	}
 	if strings.TrimSpace(workspace.GetBranch()) != "" {
 		raw["branch"] = workspace.GetBranch()
+	}
+	if strings.TrimSpace(workspace.GetCommit()) != "" {
+		raw["commit"] = workspace.GetCommit()
 	}
 	if strings.TrimSpace(workspace.GetPath()) != "" {
 		raw["path"] = workspace.GetPath()

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -82,7 +82,7 @@ func ProjectRevisionToProto(revision domain.ProjectRevisionRecord, spec *agentco
 func ProjectAgentsToProto(agents []domain.ProjectAgentRecord) []*agentcomposev2.ProjectAgent {
 	items := make([]*agentcomposev2.ProjectAgent, 0, len(agents))
 	for _, agent := range agents {
-		status, specErr := projectAgentSpecStatus(agent.SpecJSON)
+		status, displayName, description, specErr := projectAgentSpecMetadata(agent.SpecJSON)
 		enabled := status != agentcomposev2.AgentStatus_AGENT_STATUS_DISABLED
 		availability := agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_AVAILABLE
 		health := agentcomposev2.ProjectAgentHealth_PROJECT_AGENT_HEALTH_HEALTHY
@@ -95,6 +95,8 @@ func ProjectAgentsToProto(agents []domain.ProjectAgentRecord) []*agentcomposev2.
 		items = append(items, &agentcomposev2.ProjectAgent{
 			ProjectId:        agent.ProjectID,
 			AgentName:        agent.AgentName,
+			DisplayName:      displayName,
+			Description:      description,
 			ManagedAgentId:   agent.ManagedAgentID,
 			Provider:         agent.Provider,
 			Model:            agent.Model,
@@ -107,46 +109,64 @@ func ProjectAgentsToProto(agents []domain.ProjectAgentRecord) []*agentcomposev2.
 	return items
 }
 
-func projectAgentSpecStatus(specJSON string) (agentcomposev2.AgentStatus, error) {
+func projectAgentSpecMetadata(specJSON string) (agentcomposev2.AgentStatus, string, string, error) {
 	var raw struct {
-		Status json.RawMessage `json:"status"`
+		Status      json.RawMessage `json:"status"`
+		DisplayName string          `json:"display_name"`
+		Description string          `json:"description"`
 	}
 	if err := json.Unmarshal([]byte(specJSON), &raw); err != nil {
-		return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, err
+		return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, "", "", err
 	}
+	displayName := strings.TrimSpace(raw.DisplayName)
+	description := strings.TrimSpace(raw.Description)
 	if len(raw.Status) == 0 || string(raw.Status) == "null" {
-		return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, nil
+		return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, displayName, description, nil
 	}
 	var status string
 	if err := json.Unmarshal(raw.Status, &status); err == nil {
 		switch strings.ToLower(strings.TrimSpace(status)) {
 		case "", "enabled":
-			return agentcomposev2.AgentStatus_AGENT_STATUS_ENABLED, nil
+			return agentcomposev2.AgentStatus_AGENT_STATUS_ENABLED, displayName, description, nil
 		case "disabled":
-			return agentcomposev2.AgentStatus_AGENT_STATUS_DISABLED, nil
+			return agentcomposev2.AgentStatus_AGENT_STATUS_DISABLED, displayName, description, nil
 		default:
-			return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, fmt.Errorf("decode project agent spec: unknown agent status %q", status)
+			return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, displayName, description, fmt.Errorf("decode project agent spec: unknown agent status %q", status)
 		}
 	}
 	var spec agentcomposev2.AgentSpec
 	if err := json.Unmarshal([]byte(specJSON), &spec); err != nil {
-		return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, err
+		return agentcomposev2.AgentStatus_AGENT_STATUS_UNSPECIFIED, displayName, description, err
 	}
-	return spec.GetStatus(), nil
+	return spec.GetStatus(), displayName, description, nil
 }
 
 func ProjectSchedulersToProto(schedulers []domain.ProjectSchedulerRecord) []*agentcomposev2.ProjectScheduler {
 	items := make([]*agentcomposev2.ProjectScheduler, 0, len(schedulers))
 	for _, scheduler := range schedulers {
+		displayName, description := projectSchedulerPresentation(scheduler.SpecJSON)
 		items = append(items, &agentcomposev2.ProjectScheduler{
 			ProjectId:    scheduler.ProjectID,
 			AgentName:    scheduler.AgentName,
 			SchedulerId:  scheduler.SchedulerID,
 			Enabled:      scheduler.Enabled,
 			TriggerCount: uint32(scheduler.TriggerCount),
+			DisplayName:  displayName,
+			Description:  description,
 		})
 	}
 	return items
+}
+
+func projectSchedulerPresentation(specJSON string) (string, string) {
+	var presentation struct {
+		DisplayName string `json:"display_name"`
+		Description string `json:"description"`
+	}
+	if json.Unmarshal([]byte(specJSON), &presentation) != nil {
+		return "", ""
+	}
+	return strings.TrimSpace(presentation.DisplayName), strings.TrimSpace(presentation.Description)
 }
 
 func ProjectApplyChanges(project domain.ProjectRecord, existing domain.ProjectRecord, found bool, revision domain.ProjectRevisionRecord, revisionCreated bool) []*agentcomposev2.ProjectChange {
@@ -260,6 +280,8 @@ func AgentSpecsToProto(agents []compose.NormalizedAgentSpec) []*agentcomposev2.A
 	for _, agent := range agents {
 		items = append(items, &agentcomposev2.AgentSpec{
 			Name:         agent.Name,
+			DisplayName:  agent.DisplayName,
+			Description:  agent.Description,
 			Provider:     agent.Provider,
 			Model:        agent.Model,
 			SystemPrompt: agent.SystemPrompt,
@@ -467,6 +489,8 @@ func SchedulerSpecToProto(scheduler *compose.NormalizedSchedulerSpec) *agentcomp
 		Triggers:      triggers,
 		Script:        scheduler.Script,
 		SandboxPolicy: scheduler.SandboxPolicy,
+		DisplayName:   scheduler.DisplayName,
+		Description:   scheduler.Description,
 	}
 }
 
@@ -587,6 +611,12 @@ func AgentYAMLMap(agents []*agentcomposev2.AgentSpec) (map[string]any, []*agentc
 			return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(fmt.Sprintf("agents[%d].name", i), fmt.Sprintf("duplicate agent %q", name))}
 		}
 		raw := map[string]any{}
+		if strings.TrimSpace(agent.GetDisplayName()) != "" {
+			raw["display_name"] = agent.GetDisplayName()
+		}
+		if strings.TrimSpace(agent.GetDescription()) != "" {
+			raw["description"] = agent.GetDescription()
+		}
 		switch agent.GetStatus() {
 		case agentcomposev2.AgentStatus_AGENT_STATUS_ENABLED:
 			raw["status"] = "enabled"
@@ -878,6 +908,12 @@ func SchedulerYAMLShape(scheduler *agentcomposev2.SchedulerSpec) map[string]any 
 		return nil
 	}
 	raw := map[string]any{"enabled": scheduler.GetEnabled()}
+	if strings.TrimSpace(scheduler.GetDisplayName()) != "" {
+		raw["display_name"] = scheduler.GetDisplayName()
+	}
+	if strings.TrimSpace(scheduler.GetDescription()) != "" {
+		raw["description"] = scheduler.GetDescription()
+	}
 	if scheduler.GetSandboxPolicy() != "" {
 		raw["sandbox_policy"] = scheduler.GetSandboxPolicy()
 	}

--- a/pkg/agentcompose/api/project_agent_status_test.go
+++ b/pkg/agentcompose/api/project_agent_status_test.go
@@ -35,3 +35,28 @@ func TestIntegrationProjectAgentAvailabilityReflectsCanonicalDisabledStatus(t *t
 		t.Fatalf("disabled agent status = %#v", items[0])
 	}
 }
+
+func TestProjectAgentIncludesPresentationMetadataFromCanonicalSpec(t *testing.T) {
+	items := ProjectAgentsToProto([]domain.ProjectAgentRecord{{
+		ProjectID:      "p",
+		AgentName:      "legacy-agent-bfe5286dc77f",
+		ManagedAgentID: "managed-agent",
+		Provider:       "codex",
+		SpecJSON:       `{"name":"legacy-agent-bfe5286dc77f","display_name":"通用助手","description":"处理日常通用任务","status":"enabled"}`,
+	}})
+	if len(items) != 1 || items[0].GetDisplayName() != "通用助手" || items[0].GetDescription() != "处理日常通用任务" {
+		t.Fatalf("project agent metadata = %#v", items)
+	}
+}
+
+func TestProjectSchedulerIncludesPresentationMetadataFromCanonicalSpec(t *testing.T) {
+	items := ProjectSchedulersToProto([]domain.ProjectSchedulerRecord{{
+		ProjectID:   "p",
+		AgentName:   "legacy-agent-bfe5286dc77f",
+		SchedulerID: "scheduler",
+		SpecJSON:    `{"enabled":true,"display_name":"每日巡检","description":"每天汇总巡检结果"}`,
+	}})
+	if len(items) != 1 || items[0].GetDisplayName() != "每日巡检" || items[0].GetDescription() != "每天汇总巡检结果" {
+		t.Fatalf("project scheduler metadata = %#v", items)
+	}
+}

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -37,9 +37,12 @@ type ProjectStore interface {
 
 type ProjectLoaderStore interface {
 	GetLoader(context.Context, string) (domain.Loader, error)
-	SetLoaderEnabled(context.Context, string, bool) error
-	SetLoaderTriggerEnabled(context.Context, string, string, bool) error
 	ListLoaderEvents(context.Context, string, int) ([]domain.LoaderEvent, error)
+}
+
+type ProjectLoaderRuntime interface {
+	SetLoaderEnabled(context.Context, string, bool) (domain.Loader, error)
+	SetLoaderTriggerEnabled(context.Context, string, string, bool) (domain.Loader, error)
 }
 
 type ProjectLoaderEventCursorStore interface {
@@ -55,12 +58,13 @@ type ProjectSchedulerPageStore interface {
 
 type ProjectHandler struct {
 	agentcomposev2connect.UnimplementedProjectServiceHandler
-	delegate ProjectDelegate
-	store    ProjectStore
+	delegate      ProjectDelegate
+	store         ProjectStore
+	loaderRuntime ProjectLoaderRuntime
 }
 
-func NewProjectHandler(delegate ProjectDelegate, store ProjectStore) *ProjectHandler {
-	return &ProjectHandler{delegate: delegate, store: store}
+func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, loaderRuntime ProjectLoaderRuntime) *ProjectHandler {
+	return &ProjectHandler{delegate: delegate, store: store, loaderRuntime: loaderRuntime}
 }
 
 func (h *ProjectHandler) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {
@@ -255,14 +259,14 @@ func (h *ProjectHandler) SetSchedulerEnabled(ctx context.Context, req *connect.R
 	if err != nil {
 		return nil, projectConnectError(err)
 	}
-	store, ok := h.store.(ProjectLoaderStore)
-	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler runtime store is required"))
+	if h.loaderRuntime == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler runtime controller is required"))
 	}
-	if err := store.SetLoaderEnabled(ctx, scheduler.ManagedLoaderID, req.Msg.GetEnabled()); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+	loader, err := h.loaderRuntime.SetLoaderEnabled(ctx, scheduler.ManagedLoaderID, req.Msg.GetEnabled())
+	if err != nil {
+		return nil, projectConnectError(err)
 	}
-	scheduler.Enabled = req.Msg.GetEnabled()
+	scheduler.Enabled = loader.Summary.Enabled
 	return connect.NewResponse(&agentcomposev2.SetSchedulerEnabledResponse{Scheduler: ProjectSchedulersToProto([]domain.ProjectSchedulerRecord{scheduler})[0], Overridden: true}), nil
 }
 
@@ -271,20 +275,16 @@ func (h *ProjectHandler) SetSchedulerTriggerEnabled(ctx context.Context, req *co
 	if err != nil {
 		return nil, projectConnectError(err)
 	}
-	store, ok := h.store.(ProjectLoaderStore)
-	if !ok {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler runtime store is required"))
+	if h.loaderRuntime == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler runtime controller is required"))
 	}
 	triggerID := strings.TrimSpace(req.Msg.GetTriggerId())
 	if triggerID == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("trigger id is required"))
 	}
-	if err := store.SetLoaderTriggerEnabled(ctx, scheduler.ManagedLoaderID, triggerID, req.Msg.GetEnabled()); err != nil {
-		return nil, projectConnectError(err)
-	}
-	loader, err := store.GetLoader(ctx, scheduler.ManagedLoaderID)
+	loader, err := h.loaderRuntime.SetLoaderTriggerEnabled(ctx, scheduler.ManagedLoaderID, triggerID, req.Msg.GetEnabled())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, projectConnectError(err)
 	}
 	for _, trigger := range loader.Triggers {
 		if trigger.ID == triggerID {

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -119,7 +119,16 @@ func (h *ProjectHandler) ListSchedulers(ctx context.Context, req *connect.Reques
 		if err != nil {
 			return nil, err
 		}
-		summary := &agentcomposev2.SchedulerSummary{ProjectId: scheduler.ProjectID, AgentName: scheduler.AgentName, SchedulerId: scheduler.SchedulerID, Enabled: enabled, TriggerCount: uint32(scheduler.TriggerCount)}
+		displayName, description := projectSchedulerPresentation(scheduler.SpecJSON)
+		summary := &agentcomposev2.SchedulerSummary{
+			ProjectId:    scheduler.ProjectID,
+			AgentName:    scheduler.AgentName,
+			SchedulerId:  scheduler.SchedulerID,
+			Enabled:      enabled,
+			TriggerCount: uint32(scheduler.TriggerCount),
+			DisplayName:  displayName,
+			Description:  description,
+		}
 		summary.RunCount = uint32(scheduler.RunCount)
 		summary.LatestRunAt = projectTimestamp(scheduler.LatestRunAt)
 		summary.LastError = scheduler.LastError

--- a/pkg/agentcompose/api/project_handler_scheduler_runtime_test.go
+++ b/pkg/agentcompose/api/project_handler_scheduler_runtime_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestProjectHandlerSchedulerUpdatesUseLoaderRuntime(t *testing.T) {
+	const (
+		projectID = "project-1"
+		agentName = "中文智能体"
+		loaderID  = "loader-1"
+		triggerID = "中文心跳"
+	)
+	store := schedulerRuntimeProjectStore{
+		project: domain.ProjectRecord{ID: projectID, Name: "migration"},
+		scheduler: domain.ProjectSchedulerRecord{
+			ProjectID:       projectID,
+			AgentName:       agentName,
+			SchedulerID:     "scheduler-1",
+			ManagedLoaderID: loaderID,
+		},
+	}
+	runtime := &schedulerRuntimeFake{loader: domain.Loader{
+		Summary:  domain.LoaderSummary{ID: loaderID},
+		Triggers: []domain.LoaderTrigger{{ID: triggerID, Kind: domain.LoaderTriggerKindInterval, IntervalMs: 3000}},
+	}}
+	handler := NewProjectHandler(nil, store, runtime)
+
+	enabled, err := handler.SetSchedulerEnabled(context.Background(), connect.NewRequest(&agentcomposev2.SetSchedulerEnabledRequest{
+		Project:   &agentcomposev2.ProjectRef{ProjectId: projectID},
+		AgentName: agentName,
+		Enabled:   true,
+	}))
+	if err != nil {
+		t.Fatalf("SetSchedulerEnabled returned error: %v", err)
+	}
+	if runtime.enabledCalls != 1 || runtime.loaderID != loaderID || !enabled.Msg.GetScheduler().GetEnabled() {
+		t.Fatalf("scheduler update calls=%d loader=%q response=%#v", runtime.enabledCalls, runtime.loaderID, enabled.Msg.GetScheduler())
+	}
+
+	trigger, err := handler.SetSchedulerTriggerEnabled(context.Background(), connect.NewRequest(&agentcomposev2.SetSchedulerTriggerEnabledRequest{
+		Project:   &agentcomposev2.ProjectRef{ProjectId: projectID},
+		AgentName: agentName,
+		TriggerId: triggerID,
+		Enabled:   true,
+	}))
+	if err != nil {
+		t.Fatalf("SetSchedulerTriggerEnabled returned error: %v", err)
+	}
+	if runtime.triggerCalls != 1 || runtime.triggerID != triggerID || !trigger.Msg.GetTrigger().GetEnabled() {
+		t.Fatalf("trigger update calls=%d trigger=%q response=%#v", runtime.triggerCalls, runtime.triggerID, trigger.Msg.GetTrigger())
+	}
+}
+
+type schedulerRuntimeProjectStore struct {
+	project   domain.ProjectRecord
+	scheduler domain.ProjectSchedulerRecord
+}
+
+func (s schedulerRuntimeProjectStore) GetProject(context.Context, string) (domain.ProjectRecord, error) {
+	return s.project, nil
+}
+
+func (s schedulerRuntimeProjectStore) ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error) {
+	return domain.ProjectListResult{Projects: []domain.ProjectRecord{s.project}}, nil
+}
+
+func (s schedulerRuntimeProjectStore) ListProjectAgents(context.Context, string) ([]domain.ProjectAgentRecord, error) {
+	return nil, nil
+}
+
+func (s schedulerRuntimeProjectStore) ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error) {
+	return []domain.ProjectSchedulerRecord{s.scheduler}, nil
+}
+
+func (s schedulerRuntimeProjectStore) GetProjectRevision(context.Context, string, int64) (domain.ProjectRevisionRecord, error) {
+	return domain.ProjectRevisionRecord{}, nil
+}
+
+type schedulerRuntimeFake struct {
+	loader       domain.Loader
+	loaderID     string
+	triggerID    string
+	enabledCalls int
+	triggerCalls int
+}
+
+func (f *schedulerRuntimeFake) SetLoaderEnabled(_ context.Context, loaderID string, enabled bool) (domain.Loader, error) {
+	f.enabledCalls++
+	f.loaderID = loaderID
+	f.loader.Summary.Enabled = enabled
+	return f.loader, nil
+}
+
+func (f *schedulerRuntimeFake) SetLoaderTriggerEnabled(_ context.Context, loaderID, triggerID string, enabled bool) (domain.Loader, error) {
+	f.triggerCalls++
+	f.loaderID = loaderID
+	f.triggerID = triggerID
+	f.loader.Triggers[0].Enabled = enabled
+	return f.loader, nil
+}

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -198,7 +198,7 @@ func TestIntegrationProjectSpecToProtoIncludesWorkspaceRegistry(t *testing.T) {
 	spec := &compose.NormalizedProjectSpec{
 		Name: "workspace-registry",
 		Workspaces: map[string]compose.WorkspaceSpec{
-			"docs": {Name: "docs", Provider: "git", URL: "https://example.test/docs.git", Path: "docs"},
+			"docs": {Name: "docs", Provider: "git", URL: "https://example.test/docs.git", Branch: "main", Commit: "abc123", Path: "docs"},
 			"repo": {Name: "repo", Provider: "local", Path: "."},
 		},
 		Agents: []compose.NormalizedAgentSpec{{
@@ -212,7 +212,7 @@ func TestIntegrationProjectSpecToProtoIncludesWorkspaceRegistry(t *testing.T) {
 	if response == nil || len(response.GetWorkspaces()) != 2 {
 		t.Fatalf("ProjectSpecToProto workspaces = %#v", response)
 	}
-	if response.GetWorkspaces()[0].GetName() != "docs" || response.GetWorkspaces()[0].GetWorkspace().GetProvider() != "git" {
+	if response.GetWorkspaces()[0].GetName() != "docs" || response.GetWorkspaces()[0].GetWorkspace().GetProvider() != "git" || response.GetWorkspaces()[0].GetWorkspace().GetBranch() != "main" || response.GetWorkspaces()[0].GetWorkspace().GetCommit() != "abc123" {
 		t.Fatalf("first workspace = %#v", response.GetWorkspaces()[0])
 	}
 	if response.GetWorkspaces()[1].GetName() != "repo" || response.GetWorkspaces()[1].GetWorkspace().GetName() != "" {
@@ -225,7 +225,7 @@ func TestIntegrationProjectSpecYAMLShapeIncludesWorkspaceRegistry(t *testing.T) 
 		Name: "workspace-shape",
 		Workspaces: []*agentcomposev2.NamedWorkspaceSpec{{
 			Name:      "repo",
-			Workspace: &agentcomposev2.WorkspaceSpec{Provider: "local", Path: "."},
+			Workspace: &agentcomposev2.WorkspaceSpec{Provider: "git", Url: "https://example.test/repo.git", Branch: "main", Commit: "abc123", Path: "."},
 		}},
 		Agents: []*agentcomposev2.AgentSpec{{
 			Name:      "reviewer",
@@ -238,6 +238,10 @@ func TestIntegrationProjectSpecYAMLShapeIncludesWorkspaceRegistry(t *testing.T) 
 	workspaces, ok := shape["workspaces"].(map[string]any)
 	if !ok || len(workspaces) != 1 {
 		t.Fatalf("workspaces shape = %#v", shape["workspaces"])
+	}
+	repo, ok := workspaces["repo"].(map[string]any)
+	if !ok || repo["branch"] != "main" || repo["commit"] != "abc123" {
+		t.Fatalf("repo workspace shape = %#v", workspaces["repo"])
 	}
 	agents, ok := shape["agents"].(map[string]any)
 	if !ok {

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -9,6 +9,7 @@ import (
 	"agent-compose/pkg/compose"
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestProjectToProtoOnlyIncludesCurrentRevisionArtifacts(t *testing.T) {
@@ -104,6 +105,8 @@ func TestProjectSpecToProtoIncludesSchedulerScript(t *testing.T) {
 			Scheduler: &compose.NormalizedSchedulerSpec{
 				Enabled:       true,
 				SandboxPolicy: "sticky",
+				DisplayName:   "Hourly review",
+				Description:   "Reviews pending changes every hour",
 				Script:        script,
 			},
 		}},
@@ -120,8 +123,11 @@ func TestProjectSpecToProtoIncludesSchedulerScript(t *testing.T) {
 	if scheduler.GetSandboxPolicy() != "sticky" {
 		t.Fatalf("scheduler sandbox policy = %q, want sticky", scheduler.GetSandboxPolicy())
 	}
+	if scheduler.GetDisplayName() != "Hourly review" || scheduler.GetDescription() != "Reviews pending changes every hour" {
+		t.Fatalf("scheduler presentation = %#v", scheduler)
+	}
 	shape := SchedulerYAMLShape(scheduler)
-	if shape["sandbox_policy"] != "sticky" {
+	if shape["sandbox_policy"] != "sticky" || shape["display_name"] != "Hourly review" || shape["description"] != "Reviews pending changes every hour" {
 		t.Fatalf("scheduler YAML shape = %#v", shape)
 	}
 	if got := len(scheduler.GetTriggers()); got != 0 {
@@ -150,6 +156,41 @@ func TestProjectSpecToProtoIncludesJupyter(t *testing.T) {
 	jupyter := response.GetAgents()[0].GetJupyter()
 	if !jupyter.GetEnabled() || jupyter.GetGuestPort() != 8888 {
 		t.Fatalf("jupyter = %#v, want enabled guest port 8888", jupyter)
+	}
+}
+
+func TestIntegrationAgentPresentationMetadataRoundTripsThroughProtoAndCompose(t *testing.T) {
+	shape, issues := ProjectSpecYAMLShape(&agentcomposev2.ProjectSpec{
+		Name: "presentation",
+		Agents: []*agentcomposev2.AgentSpec{{
+			Name:        "legacy-agent-bfe5286dc77f",
+			DisplayName: "通用助手",
+			Description: "处理日常通用任务",
+			Provider:    "codex",
+		}},
+	})
+	if len(issues) != 0 {
+		t.Fatalf("ProjectSpecYAMLShape issues = %#v", issues)
+	}
+	data, err := yaml.Marshal(shape)
+	if err != nil {
+		t.Fatalf("marshal project shape: %v", err)
+	}
+	parsed, err := compose.Parse(data)
+	if err != nil {
+		t.Fatalf("parse project shape: %v", err)
+	}
+	normalized, err := compose.Normalize(parsed, compose.NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("normalize project shape: %v", err)
+	}
+	response := ProjectSpecToProto(normalized)
+	if response == nil || len(response.GetAgents()) != 1 {
+		t.Fatalf("ProjectSpecToProto response = %#v", response)
+	}
+	agent := response.GetAgents()[0]
+	if agent.GetName() != "legacy-agent-bfe5286dc77f" || agent.GetDisplayName() != "通用助手" || agent.GetDescription() != "处理日常通用任务" {
+		t.Fatalf("round-tripped agent = %#v", agent)
 	}
 }
 

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -90,7 +90,11 @@ func RegisterDependencies(di do.Injector) {
 func RegisterRoutes(di do.Injector) {
 	app := do.MustInvoke[*echo.Echo](di)
 
-	projectHandler := api.NewProjectHandler(projectControllerDelegate{controller: do.MustInvoke[*projects.Controller](di)}, do.MustInvoke[*configstore.ConfigStore](di))
+	projectHandler := api.NewProjectHandler(
+		projectControllerDelegate{controller: do.MustInvoke[*projects.Controller](di)},
+		do.MustInvoke[*configstore.ConfigStore](di),
+		do.MustInvoke[*loaders.Controller](di),
+	)
 	path, handler := agentcomposev2connect.NewProjectServiceHandler(projectHandler)
 	app.Any(path+"*", echo.WrapHandler(handler))
 	runDelegate := runControllerDelegate{

--- a/pkg/compose/helper_coverage_test.go
+++ b/pkg/compose/helper_coverage_test.go
@@ -17,8 +17,8 @@ func TestComposePrivateHelperCoverage(t *testing.T) {
 		t.Fatalf("cloneStringMap aliased input: %#v", values)
 	}
 
-	workspace := cloneWorkspaceSpec(&WorkspaceSpec{Provider: " git ", URL: " https://example.test/repo.git ", Branch: " main ", Path: " app "})
-	if workspace.Provider != "git" || workspace.URL != "https://example.test/repo.git" || workspace.Branch != "main" || workspace.Path != "app" {
+	workspace := cloneWorkspaceSpec(&WorkspaceSpec{Provider: " git ", URL: " https://example.test/repo.git ", Branch: " main ", Commit: " abc123 ", Path: " app "})
+	if workspace.Provider != "git" || workspace.URL != "https://example.test/repo.git" || workspace.Branch != "main" || workspace.Commit != "abc123" || workspace.Path != "app" {
 		t.Fatalf("cloneWorkspaceSpec = %#v", workspace)
 	}
 	if cloneWorkspaceSpec(nil) != nil {

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -364,7 +364,7 @@ func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]
 	}
 	trimmed := cloneWorkspaceSpec(spec)
 	hasName := trimmed.Name != ""
-	hasInline := trimmed.Provider != "" || trimmed.URL != "" || trimmed.Branch != "" || trimmed.Path != ""
+	hasInline := trimmed.Provider != "" || trimmed.URL != "" || trimmed.Branch != "" || trimmed.Commit != "" || trimmed.Path != ""
 	switch {
 	case hasName && !hasInline:
 		workspace, ok := globals[trimmed.Name]
@@ -401,6 +401,9 @@ func normalizeInlineWorkspaceSpec(path string, spec *WorkspaceSpec, defaultName 
 		if strings.TrimSpace(workspace.Branch) != "" {
 			return nil, &ValidationError{Path: path + ".branch", Message: "local workspace does not support branch"}
 		}
+		if strings.TrimSpace(workspace.Commit) != "" {
+			return nil, &ValidationError{Path: path + ".commit", Message: "local workspace does not support commit"}
+		}
 		if _, err := cleanComposeLocalWorkspacePath(workspace.Path); err != nil {
 			return nil, &ValidationError{Path: path + ".path", Message: err.Error()}
 		}
@@ -418,6 +421,8 @@ func normalizeInlineWorkspaceSpec(path string, spec *WorkspaceSpec, defaultName 
 			workspace.Path = "."
 		}
 		workspace.URL = strings.TrimSpace(workspace.URL)
+		workspace.Branch = strings.TrimSpace(workspace.Branch)
+		workspace.Commit = strings.TrimSpace(workspace.Commit)
 	default:
 		return nil, &ValidationError{Path: path + ".provider", Message: fmt.Sprintf("unsupported workspace provider %q", workspace.Provider)}
 	}
@@ -1325,6 +1330,7 @@ func cloneWorkspaceSpec(value *WorkspaceSpec) *WorkspaceSpec {
 	cloned.Provider = strings.TrimSpace(cloned.Provider)
 	cloned.URL = strings.TrimSpace(cloned.URL)
 	cloned.Branch = strings.TrimSpace(cloned.Branch)
+	cloned.Commit = strings.TrimSpace(cloned.Commit)
 	cloned.Path = strings.TrimSpace(cloned.Path)
 	return &cloned
 }

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -49,6 +49,8 @@ type NormalizedProjectSpec struct {
 type NormalizedAgentSpec struct {
 	Name         string                             `yaml:"name" json:"name"`
 	Status       string                             `yaml:"status,omitempty" json:"status,omitempty"`
+	DisplayName  string                             `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description  string                             `yaml:"description,omitempty" json:"description,omitempty"`
 	Provider     string                             `yaml:"provider,omitempty" json:"provider,omitempty"`
 	Model        string                             `yaml:"model,omitempty" json:"model,omitempty"`
 	SystemPrompt string                             `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
@@ -122,6 +124,8 @@ type NormalizedDriverSpec struct {
 type NormalizedSchedulerSpec struct {
 	Enabled       bool                    `yaml:"enabled" json:"enabled"`
 	SandboxPolicy string                  `yaml:"sandbox_policy" json:"sandbox_policy"`
+	DisplayName   string                  `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description   string                  `yaml:"description,omitempty" json:"description,omitempty"`
 	Script        string                  `yaml:"script,omitempty" json:"script,omitempty"`
 	Triggers      []NormalizedTriggerSpec `yaml:"triggers,omitempty" json:"triggers,omitempty"`
 
@@ -284,6 +288,8 @@ func normalizeAgent(name string, agent AgentSpec, options NormalizeOptions, proj
 	return NormalizedAgentSpec{
 		Name:         name,
 		Status:       status,
+		DisplayName:  strings.TrimSpace(agent.DisplayName),
+		Description:  strings.TrimSpace(agent.Description),
 		Provider:     strings.TrimSpace(agent.Provider),
 		Model:        model,
 		SystemPrompt: agent.SystemPrompt,
@@ -1084,7 +1090,13 @@ func normalizeSchedulerSpec(path string, scheduler *SchedulerSpec, options Norma
 	if err != nil {
 		return nil, err
 	}
-	normalized := &NormalizedSchedulerSpec{Enabled: enabled, SandboxPolicy: sandboxPolicy, Script: script}
+	normalized := &NormalizedSchedulerSpec{
+		Enabled:       enabled,
+		SandboxPolicy: sandboxPolicy,
+		DisplayName:   strings.TrimSpace(scheduler.DisplayName),
+		Description:   strings.TrimSpace(scheduler.Description),
+		Script:        script,
+	}
 	if scriptURL != "" {
 		if !options.ResolveScriptURLs {
 			normalized.scriptURL = scriptURL

--- a/pkg/compose/output.go
+++ b/pkg/compose/output.go
@@ -33,6 +33,7 @@ type orderedNamedWorkspace struct {
 	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
 	URL      string `yaml:"url,omitempty" json:"url,omitempty"`
 	Branch   string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	Commit   string `yaml:"commit,omitempty" json:"commit,omitempty"`
 	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
@@ -219,6 +220,7 @@ func orderedWorkspaces(values map[string]WorkspaceSpec) []orderedNamedWorkspace 
 			Provider: value.Provider,
 			URL:      value.URL,
 			Branch:   value.Branch,
+			Commit:   value.Commit,
 			Path:     value.Path,
 		})
 	}
@@ -236,6 +238,7 @@ func workspaceMapFromOrdered(values []orderedNamedWorkspace) map[string]Workspac
 			Provider: value.Provider,
 			URL:      value.URL,
 			Branch:   value.Branch,
+			Commit:   value.Commit,
 			Path:     value.Path,
 		}
 	}

--- a/pkg/compose/output.go
+++ b/pkg/compose/output.go
@@ -39,6 +39,8 @@ type orderedNamedWorkspace struct {
 type orderedAgentSpec struct {
 	Name         string                      `yaml:"name" json:"name"`
 	Status       string                      `yaml:"status,omitempty" json:"status,omitempty"`
+	DisplayName  string                      `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description  string                      `yaml:"description,omitempty" json:"description,omitempty"`
 	Provider     string                      `yaml:"provider,omitempty" json:"provider,omitempty"`
 	Model        string                      `yaml:"model,omitempty" json:"model,omitempty"`
 	SystemPrompt string                      `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
@@ -132,6 +134,8 @@ func (s *NormalizedProjectSpec) ordered(redactSecrets bool) orderedProjectSpec {
 		agents = append(agents, orderedAgentSpec{
 			Name:         agent.Name,
 			Status:       agent.Status,
+			DisplayName:  agent.DisplayName,
+			Description:  agent.Description,
 			Provider:     agent.Provider,
 			Model:        agent.Model,
 			SystemPrompt: agent.SystemPrompt,
@@ -176,6 +180,8 @@ func (s *NormalizedProjectSpec) clone(redactSecrets bool) *NormalizedProjectSpec
 		cloned.Agents = append(cloned.Agents, NormalizedAgentSpec{
 			Name:         agent.Name,
 			Status:       agent.Status,
+			DisplayName:  agent.DisplayName,
+			Description:  agent.Description,
 			Provider:     agent.Provider,
 			Model:        agent.Model,
 			SystemPrompt: agent.SystemPrompt,
@@ -418,6 +424,8 @@ func cloneNormalizedSchedulerSpec(value *NormalizedSchedulerSpec) *NormalizedSch
 	cloned := &NormalizedSchedulerSpec{
 		Enabled:       value.Enabled,
 		SandboxPolicy: value.SandboxPolicy,
+		DisplayName:   value.DisplayName,
+		Description:   value.Description,
 		Script:        value.Script,
 		scriptURL:     value.scriptURL,
 	}

--- a/pkg/compose/output_test.go
+++ b/pkg/compose/output_test.go
@@ -49,6 +49,59 @@ agents:
 	}
 }
 
+func TestAgentPresentationMetadataSurvivesNormalizationAndCanonicalOutput(t *testing.T) {
+	normalized := mustNormalizeCompose(t, `
+name: presentation
+agents:
+  legacy-agent-bfe5286dc77f:
+    display_name: "  通用助手  "
+    description: "  处理日常通用任务  "
+    provider: codex
+    scheduler:
+      display_name: "  每日巡检  "
+      description: "  每天汇总巡检结果  "
+      enabled: false
+`, nil)
+
+	agent := normalized.Agents[0]
+	if agent.Name != "legacy-agent-bfe5286dc77f" || agent.DisplayName != "通用助手" || agent.Description != "处理日常通用任务" {
+		t.Fatalf("normalized agent metadata = %#v", agent)
+	}
+	if agent.Scheduler == nil || agent.Scheduler.DisplayName != "每日巡检" || agent.Scheduler.Description != "每天汇总巡检结果" {
+		t.Fatalf("normalized scheduler metadata = %#v", agent.Scheduler)
+	}
+	jsonData, err := normalized.MarshalCanonicalJSON(false)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON returned error: %v", err)
+	}
+	for _, want := range []string{`"display_name":"通用助手"`, `"description":"处理日常通用任务"`, `"display_name":"每日巡检"`, `"description":"每天汇总巡检结果"`} {
+		if !bytes.Contains(jsonData, []byte(want)) {
+			t.Fatalf("canonical JSON = %s, want %s", jsonData, want)
+		}
+	}
+	redacted := normalized.Redacted()
+	if redacted.Agents[0].DisplayName != agent.DisplayName || redacted.Agents[0].Description != agent.Description {
+		t.Fatalf("redacted agent metadata = %#v", redacted.Agents[0])
+	}
+	if redacted.Agents[0].Scheduler == agent.Scheduler || redacted.Agents[0].Scheduler.DisplayName != agent.Scheduler.DisplayName || redacted.Agents[0].Scheduler.Description != agent.Scheduler.Description {
+		t.Fatalf("redacted scheduler metadata = %#v", redacted.Agents[0].Scheduler)
+	}
+}
+
+func TestAgentDisplayNameDoesNotRelaxStableAgentNameValidation(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: presentation
+agents:
+  通用助手:
+    display_name: 通用助手
+    provider: codex
+`)
+
+	if _, err := Normalize(spec, NormalizeOptions{}); err == nil || !strings.Contains(err.Error(), "agents.通用助手") {
+		t.Fatalf("Normalize error = %v, want agent name validation", err)
+	}
+}
+
 func TestNormalizeInterpolationMissingEnvIncludesFieldPath(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -205,6 +205,7 @@ type WorkspaceSpec struct {
 	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
 	URL      string `yaml:"url,omitempty" json:"url,omitempty"`
 	Branch   string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	Commit   string `yaml:"commit,omitempty" json:"commit,omitempty"`
 	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
@@ -765,6 +766,7 @@ func validateWorkspace(node *yaml.Node, path string) error {
 		"provider": validateScalar,
 		"url":      validateScalar,
 		"branch":   validateScalar,
+		"commit":   validateScalar,
 		"path":     validateScalar,
 	})
 }

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -45,6 +45,8 @@ func (s *EnvFileSpec) UnmarshalYAML(value *yaml.Node) error {
 
 type AgentSpec struct {
 	Status       string                `yaml:"status,omitempty" json:"status,omitempty"`
+	DisplayName  string                `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description  string                `yaml:"description,omitempty" json:"description,omitempty"`
 	Provider     string                `yaml:"provider,omitempty" json:"provider,omitempty"`
 	Model        string                `yaml:"model,omitempty" json:"model,omitempty"`
 	SystemPrompt string                `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
@@ -130,6 +132,8 @@ type SkillSpec struct {
 type SchedulerSpec struct {
 	Enabled       *bool         `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	SandboxPolicy *string       `yaml:"sandbox_policy,omitempty" json:"sandbox_policy,omitempty"`
+	DisplayName   string        `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description   string        `yaml:"description,omitempty" json:"description,omitempty"`
 	Triggers      []TriggerSpec `yaml:"triggers,omitempty" json:"triggers,omitempty"`
 	Script        ScriptSource  `yaml:"script,omitempty" json:"script,omitempty"`
 }
@@ -494,6 +498,8 @@ func validateAgentMap(node *yaml.Node, path string) error {
 func validateAgent(node *yaml.Node, path string) error {
 	return validateMapping(node, path, map[string]nodeValidator{
 		"status":        validateScalar,
+		"display_name":  validateScalar,
+		"description":   validateScalar,
 		"provider":      validateScalar,
 		"model":         validateScalar,
 		"system_prompt": validateScalar,
@@ -685,6 +691,8 @@ func validateScheduler(node *yaml.Node, path string) error {
 	return validateMapping(node, path, map[string]nodeValidator{
 		"enabled":        validateBool,
 		"sandbox_policy": validateScalar,
+		"display_name":   validateScalar,
+		"description":    validateScalar,
 		"triggers":       validateTriggerList,
 		"script":         validateScriptSource,
 	})

--- a/pkg/compose/workspace_commit_test.go
+++ b/pkg/compose/workspace_commit_test.go
@@ -1,0 +1,71 @@
+package compose
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeGitWorkspacePreservesBranchAndCommit(t *testing.T) {
+	normalized, err := Normalize(&ProjectSpec{
+		Name: "project",
+		Agents: map[string]AgentSpec{
+			"worker": {
+				Provider: "codex",
+				Workspace: &WorkspaceSpec{
+					Provider: " git ",
+					URL:      " https://example.test/repo.git ",
+					Branch:   " main ",
+					Commit:   " abc123 ",
+				},
+			},
+		},
+	}, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	workspace := normalized.Agents[0].Workspace
+	if workspace == nil || workspace.Branch != "main" || workspace.Commit != "abc123" {
+		t.Fatalf("normalized workspace = %#v", workspace)
+	}
+
+	data, err := normalized.MarshalCanonicalJSON(false)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON returned error: %v", err)
+	}
+	if !strings.Contains(string(data), `"branch":"main"`) || !strings.Contains(string(data), `"commit":"abc123"`) {
+		t.Fatalf("canonical JSON lost git revision fields: %s", data)
+	}
+}
+
+func TestParseGitWorkspaceAcceptsCommit(t *testing.T) {
+	spec, err := Parse([]byte(`
+name: project
+agents:
+  worker:
+    provider: codex
+    workspace:
+      provider: git
+      url: https://example.test/repo.git
+      branch: main
+      commit: abc123
+`))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	workspace := spec.Agents["worker"].Workspace
+	if workspace == nil || workspace.Branch != "main" || workspace.Commit != "abc123" {
+		t.Fatalf("parsed workspace = %#v", workspace)
+	}
+}
+
+func TestNormalizeLocalWorkspaceRejectsCommit(t *testing.T) {
+	_, err := Normalize(&ProjectSpec{
+		Name: "project",
+		Agents: map[string]AgentSpec{
+			"worker": {Provider: "codex", Workspace: &WorkspaceSpec{Provider: "local", Path: ".", Commit: "abc123"}},
+		},
+	}, NormalizeOptions{})
+	if err == nil || !strings.Contains(err.Error(), "local workspace does not support commit") {
+		t.Fatalf("Normalize error = %v", err)
+	}
+}

--- a/pkg/projects/compare.go
+++ b/pkg/projects/compare.go
@@ -89,6 +89,7 @@ func NormalizeComparableLoaderTriggers(items []domain.LoaderTrigger) []domain.Lo
 func ManagedAgentDefinitionUnchanged(existing, current domain.AgentDefinition) bool {
 	return existing.Name == current.Name &&
 		existing.Description == current.Description &&
+		existing.Enabled == current.Enabled &&
 		existing.Provider == current.Provider &&
 		existing.Model == current.Model &&
 		existing.SystemPrompt == current.SystemPrompt &&

--- a/pkg/projects/compare_test.go
+++ b/pkg/projects/compare_test.go
@@ -1,0 +1,32 @@
+package projects
+
+import (
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestManagedAgentDefinitionChangeActionComparesEnabledState(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing bool
+		current  bool
+		want     string
+	}{
+		{name: "enabled remains enabled", existing: true, current: true, want: ChangeActionUnchanged},
+		{name: "disabled remains disabled", existing: false, current: false, want: ChangeActionUnchanged},
+		{name: "enabled becomes disabled", existing: true, current: false, want: ChangeActionUpdated},
+		{name: "disabled becomes enabled", existing: false, current: true, want: ChangeActionUpdated},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := domain.AgentDefinition{ID: "agent-1", Name: "worker", Enabled: tt.existing}
+			current := existing
+			current.Enabled = tt.current
+			if got := ManagedAgentDefinitionChangeAction(existing, true, current); got != tt.want {
+				t.Fatalf("ManagedAgentDefinitionChangeAction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -10,7 +10,6 @@ import (
 	"agent-compose/pkg/compose"
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
-	"agent-compose/pkg/identity"
 	"agent-compose/pkg/images"
 	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
@@ -36,10 +35,6 @@ type NormalizedProject struct {
 	// projection. It lets that boundary adopt an existing loader ID so runs,
 	// events, trigger state, and enablement survive the project migration.
 	managedLoaderOverrides map[string]domain.Loader
-
-	// legacyProjectID keeps the synthetic legacy project identity independent
-	// from the data-root source path used by migrated file workspaces.
-	legacyProjectID string
 }
 
 type ProjectRef struct {
@@ -169,10 +164,6 @@ func (c *Controller) ApplyProject(ctx context.Context, req ApplyRequest) (ApplyR
 	project, err := NewRecordFromSpec(normalized.Spec, normalized.SourcePath)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project: %w", ErrInvalidRequest, err)
-	}
-	if legacyProjectID := strings.TrimSpace(normalized.legacyProjectID); legacyProjectID != "" {
-		project.ID = legacyProjectID
-		project.ShortID = identity.ShortID(legacyProjectID)
 	}
 	if issues := c.validateManagedAgentDefinitions(normalized); len(issues) > 0 {
 		return ApplyResult{Issues: issues, RevisionSpec: normalized.Spec}, nil
@@ -446,6 +437,9 @@ func (c *Controller) projectArtifacts(ctx context.Context, project domain.Projec
 	}
 	agentDefinitions, err := NewAgentDefinitionsFromSpec(project, revision, spec)
 	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if err := c.bindLegacyFileWorkspaces(ctx, project, spec, agentDefinitions); err != nil {
 		return nil, nil, nil, nil, err
 	}
 	schedulerRecords, managedLoaders, err := c.projectManagedSchedulersFromSpec(ctx, project, revision, spec)

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -165,6 +165,10 @@ func (c *Controller) ApplyProject(ctx context.Context, req ApplyRequest) (ApplyR
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project: %w", ErrInvalidRequest, err)
 	}
+	normalized, err = c.preserveLegacyManagedLoaderIdentities(ctx, project, normalized)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("apply project %s: preserve legacy scheduler identities: %w", normalized.Spec.Name, err)
+	}
 	if issues := c.validateManagedAgentDefinitions(normalized); len(issues) > 0 {
 		return ApplyResult{Issues: issues, RevisionSpec: normalized.Spec}, nil
 	}

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -10,6 +10,7 @@ import (
 	"agent-compose/pkg/compose"
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/identity"
 	"agent-compose/pkg/images"
 	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
@@ -35,6 +36,10 @@ type NormalizedProject struct {
 	// projection. It lets that boundary adopt an existing loader ID so runs,
 	// events, trigger state, and enablement survive the project migration.
 	managedLoaderOverrides map[string]domain.Loader
+
+	// legacyProjectID keeps the synthetic legacy project identity independent
+	// from the data-root source path used by migrated file workspaces.
+	legacyProjectID string
 }
 
 type ProjectRef struct {
@@ -164,6 +169,10 @@ func (c *Controller) ApplyProject(ctx context.Context, req ApplyRequest) (ApplyR
 	project, err := NewRecordFromSpec(normalized.Spec, normalized.SourcePath)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project: %w", ErrInvalidRequest, err)
+	}
+	if legacyProjectID := strings.TrimSpace(normalized.legacyProjectID); legacyProjectID != "" {
+		project.ID = legacyProjectID
+		project.ShortID = identity.ShortID(legacyProjectID)
 	}
 	if issues := c.validateManagedAgentDefinitions(normalized); len(issues) > 0 {
 		return ApplyResult{Issues: issues, RevisionSpec: normalized.Spec}, nil

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -114,7 +114,11 @@ func legacyDefaultNormalizedProject(agents []domain.AgentDefinition, legacyLoade
 }
 
 func legacyDefaultNormalizedProjectWithWorkspaces(agents []domain.AgentDefinition, legacyLoaders []domain.Loader, workspaceProjection legacyWorkspaceProjection) (NormalizedProject, error) {
-	spec := &compose.NormalizedProjectSpec{Name: LegacyDefaultProjectName, Workspaces: workspaceProjection.workspaces}
+	spec := &compose.NormalizedProjectSpec{
+		Name:       LegacyDefaultProjectName,
+		Workspaces: workspaceProjection.workspaces,
+		Network:    &compose.NetworkSpec{Mode: "default"},
+	}
 	agents = append([]domain.AgentDefinition(nil), agents...)
 	sort.Slice(agents, func(i, j int) bool {
 		if agents[i].Name == agents[j].Name {
@@ -299,6 +303,9 @@ func projectLegacyLoaderWorkspace(spec *compose.NormalizedProjectSpec, loader do
 		return targetIndex, nil
 	}
 
+	// A loader-specific workspace cannot be assigned to a workspace-less source
+	// agent without changing that agent's manual-run behavior. Preserve both v1
+	// meanings by creating a dedicated compatibility scheduler agent.
 	source := spec.Agents[targetIndex]
 	name := reserveLegacyStableName(source.Name+"-loader", identity.ResourceLoader, loader.Summary.ID, loader.Summary.Name, usedNames)
 	targetIndex = appendLegacyLoaderAgent(spec, loader, name, targetIndex, true, true)
@@ -314,7 +321,7 @@ func appendLegacyLoaderAgent(spec *compose.NormalizedProjectSpec, loader domain.
 		agent.Scheduler = nil
 	} else {
 		status := "disabled"
-		if associated {
+		if associated && loader.Summary.Enabled {
 			status = "enabled"
 		}
 		agent = compose.NormalizedAgentSpec{
@@ -430,7 +437,16 @@ func legacyDriver(name string) *compose.NormalizedDriverSpec {
 	if name == "" {
 		return nil
 	}
-	return &compose.NormalizedDriverSpec{Name: name}
+	driver := &compose.NormalizedDriverSpec{Name: name}
+	switch name {
+	case compose.DriverDocker:
+		driver.Docker = &compose.DockerDriverSpec{}
+	case compose.DriverBoxlite:
+		driver.Boxlite = &compose.BoxliteDriverSpec{}
+	case compose.DriverMicrosandbox:
+		driver.Microsandbox = &compose.MicrosandboxDriverSpec{}
+	}
+	return driver
 }
 
 func legacyEnv(items []domain.SandboxEnvVar) map[string]compose.EnvVarSpec {

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -46,13 +46,9 @@ func (c *Controller) SyncLegacyDefaultProject(ctx context.Context) (ApplyResult,
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	normalized.SourcePath = workspaceProjection.sourcePath
-	if normalized.SourcePath != "" {
-		normalized.legacyProjectID, err = domain.StableProjectID(LegacyDefaultProjectName, "")
-		if err != nil {
-			return ApplyResult{}, fmt.Errorf("resolve legacy default project id: %w", err)
-		}
-	}
+	// Uploaded v1 file presets are stored snapshots, not project source trees.
+	// Keep the synthetic source empty so project identity and relative bind
+	// resolution retain their v1 behavior; project artifacts carry preset IDs.
 	return c.ApplyProject(ctx, ApplyRequest{Normalized: normalized})
 }
 
@@ -294,11 +290,11 @@ func projectLegacyLoaderWorkspace(spec *compose.NormalizedProjectSpec, loader do
 	if err != nil {
 		return -1, fmt.Errorf("map legacy loader %s workspace: %w", loader.Summary.ID, err)
 	}
+	existing := spec.Agents[targetIndex].Workspace
 	if workspace == nil {
 		return targetIndex, nil
 	}
-	existing := spec.Agents[targetIndex].Workspace
-	if targetCreated || existing == nil || existing.Name == workspace.Name {
+	if targetCreated || existing != nil && existing.Name == workspace.Name {
 		spec.Agents[targetIndex].Workspace = workspace
 		return targetIndex, nil
 	}

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -38,9 +38,20 @@ func (c *Controller) SyncLegacyDefaultProject(ctx context.Context) (ApplyResult,
 	if len(agents) == 0 && len(legacyLoaders) == 0 {
 		return ApplyResult{}, nil
 	}
-	normalized, err := legacyDefaultNormalizedProject(agents, legacyLoaders)
+	workspaceProjection, err := c.loadLegacyWorkspaceProjection(ctx, agents, legacyLoaders)
 	if err != nil {
 		return ApplyResult{}, err
+	}
+	normalized, err := legacyDefaultNormalizedProjectWithWorkspaces(agents, legacyLoaders, workspaceProjection)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	normalized.SourcePath = workspaceProjection.sourcePath
+	if normalized.SourcePath != "" {
+		normalized.legacyProjectID, err = domain.StableProjectID(LegacyDefaultProjectName, "")
+		if err != nil {
+			return ApplyResult{}, fmt.Errorf("resolve legacy default project id: %w", err)
+		}
 	}
 	return c.ApplyProject(ctx, ApplyRequest{Normalized: normalized})
 }
@@ -103,7 +114,11 @@ func (c *Controller) listLegacyDefaultLoaders(ctx context.Context) ([]domain.Loa
 }
 
 func legacyDefaultNormalizedProject(agents []domain.AgentDefinition, legacyLoaders []domain.Loader) (NormalizedProject, error) {
-	spec := &compose.NormalizedProjectSpec{Name: LegacyDefaultProjectName}
+	return legacyDefaultNormalizedProjectWithWorkspaces(agents, legacyLoaders, legacyWorkspaceProjection{})
+}
+
+func legacyDefaultNormalizedProjectWithWorkspaces(agents []domain.AgentDefinition, legacyLoaders []domain.Loader, workspaceProjection legacyWorkspaceProjection) (NormalizedProject, error) {
+	spec := &compose.NormalizedProjectSpec{Name: LegacyDefaultProjectName, Workspaces: workspaceProjection.workspaces}
 	agents = append([]domain.AgentDefinition(nil), agents...)
 	sort.Slice(agents, func(i, j int) bool {
 		if agents[i].Name == agents[j].Name {
@@ -122,6 +137,10 @@ func legacyDefaultNormalizedProject(agents []domain.AgentDefinition, legacyLoade
 		}
 		agent.Name = names[index]
 		agent.DisplayName = distinctLegacyDisplayName(agent.DisplayName, agent.Name)
+		agent.Workspace, err = workspaceProjection.reference(definition.WorkspaceID)
+		if err != nil {
+			return NormalizedProject{}, fmt.Errorf("map legacy agent %s workspace: %w", definition.ID, err)
+		}
 		if legacyID := strings.TrimSpace(definition.ID); legacyID != "" {
 			agentByLegacyID[legacyID] = len(spec.Agents)
 		}
@@ -130,7 +149,11 @@ func legacyDefaultNormalizedProject(agents []domain.AgentDefinition, legacyLoade
 		spec.Agents = append(spec.Agents, agent)
 	}
 
-	overrides := projectLegacyLoaders(spec, legacyLoaders, agentByLegacyID, agentByName, usedNames)
+	overrides, err := projectLegacyLoaders(spec, legacyLoaders, agentByLegacyID, agentByName, usedNames, workspaceProjection)
+	if err != nil {
+		return NormalizedProject{}, err
+	}
+	removeImplicitLegacyWorkspaceDefault(spec)
 	sort.Slice(spec.Agents, func(i, j int) bool { return spec.Agents[i].Name < spec.Agents[j].Name })
 	hash, err := spec.Hash()
 	if err != nil {
@@ -180,7 +203,7 @@ func legacyProjectAgentNames(agents []domain.AgentDefinition) []string {
 	return names
 }
 
-func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []domain.Loader, agentByLegacyID, agentByName map[string]int, usedNames map[string]struct{}) map[string]domain.Loader {
+func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []domain.Loader, agentByLegacyID, agentByName map[string]int, usedNames map[string]struct{}, workspaceProjection legacyWorkspaceProjection) (map[string]domain.Loader, error) {
 	legacyLoaders = append([]domain.Loader(nil), legacyLoaders...)
 	sort.Slice(legacyLoaders, func(i, j int) bool {
 		iManaged := strings.TrimSpace(legacyLoaders[i].Summary.ManagedAgentName) != ""
@@ -201,6 +224,7 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 		managedName := legacyCanonicalAgentName(loader.Summary.ManagedAgentName)
 		trustedManagedBinding := managedName != ""
 		targetIndex := -1
+		targetCreated := false
 
 		if managedName != "" {
 			if index, exists := agentByName[managedName]; exists {
@@ -209,6 +233,7 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 				}
 			} else {
 				targetIndex = appendLegacyLoaderAgent(spec, loader, managedName, sourceIndex, sourceFound, true)
+				targetCreated = true
 				agentByName[managedName] = targetIndex
 				usedNames[managedName] = struct{}{}
 			}
@@ -227,7 +252,13 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 			}
 			targetName := reserveLegacyStableName(prefix, identity.ResourceLoader, loader.Summary.ID, loader.Summary.Name, usedNames)
 			targetIndex = appendLegacyLoaderAgent(spec, loader, targetName, sourceIndex, sourceFound, associated)
+			targetCreated = true
 			agentByName[targetName] = targetIndex
+		}
+		var err error
+		targetIndex, err = projectLegacyLoaderWorkspace(spec, loader, targetIndex, targetCreated, agentByName, usedNames, workspaceProjection)
+		if err != nil {
+			return nil, err
 		}
 
 		targetName := spec.Agents[targetIndex].Name
@@ -253,9 +284,31 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 		overrides[targetName] = projected
 	}
 	if len(overrides) == 0 {
-		return nil
+		return nil, nil
 	}
-	return overrides
+	return overrides, nil
+}
+
+func projectLegacyLoaderWorkspace(spec *compose.NormalizedProjectSpec, loader domain.Loader, targetIndex int, targetCreated bool, agentByName map[string]int, usedNames map[string]struct{}, workspaceProjection legacyWorkspaceProjection) (int, error) {
+	workspace, err := workspaceProjection.reference(loader.Summary.WorkspaceID)
+	if err != nil {
+		return -1, fmt.Errorf("map legacy loader %s workspace: %w", loader.Summary.ID, err)
+	}
+	if workspace == nil {
+		return targetIndex, nil
+	}
+	existing := spec.Agents[targetIndex].Workspace
+	if targetCreated || existing == nil || existing.Name == workspace.Name {
+		spec.Agents[targetIndex].Workspace = workspace
+		return targetIndex, nil
+	}
+
+	source := spec.Agents[targetIndex]
+	name := reserveLegacyStableName(source.Name+"-loader", identity.ResourceLoader, loader.Summary.ID, loader.Summary.Name, usedNames)
+	targetIndex = appendLegacyLoaderAgent(spec, loader, name, targetIndex, true, true)
+	spec.Agents[targetIndex].Workspace = workspace
+	agentByName[name] = targetIndex
+	return targetIndex, nil
 }
 
 func appendLegacyLoaderAgent(spec *compose.NormalizedProjectSpec, loader domain.Loader, name string, sourceIndex int, sourceFound, associated bool) int {
@@ -327,9 +380,6 @@ func reserveLegacyStableName(prefix string, kind identity.ResourceKind, id, fall
 }
 
 func normalizedAgentFromLegacy(definition domain.AgentDefinition) (compose.NormalizedAgentSpec, error) {
-	if strings.TrimSpace(definition.WorkspaceID) != "" {
-		return compose.NormalizedAgentSpec{}, fmt.Errorf("legacy agent %s uses workspace preset %s, which cannot be projected losslessly", definition.ID, definition.WorkspaceID)
-	}
 	config, err := decodeLegacyAgentConfig(definition.ConfigJSON)
 	if err != nil {
 		return compose.NormalizedAgentSpec{}, fmt.Errorf("decode legacy agent %s config: %w", definition.ID, err)

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -121,6 +121,7 @@ func legacyDefaultNormalizedProject(agents []domain.AgentDefinition, legacyLoade
 			return NormalizedProject{}, err
 		}
 		agent.Name = names[index]
+		agent.DisplayName = distinctLegacyDisplayName(agent.DisplayName, agent.Name)
 		if legacyID := strings.TrimSpace(definition.ID); legacyID != "" {
 			agentByLegacyID[legacyID] = len(spec.Agents)
 		}
@@ -244,6 +245,8 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 		spec.Agents[targetIndex].Scheduler = &compose.NormalizedSchedulerSpec{
 			Enabled:       projected.Summary.Enabled,
 			SandboxPolicy: domain.NormalizeLoaderSandboxPolicy(projected.Summary.SandboxPolicy),
+			DisplayName:   strings.TrimSpace(projected.Summary.Name),
+			Description:   strings.TrimSpace(projected.Summary.Description),
 			Script:        projected.Script,
 		}
 		scheduledAgents[targetName] = struct{}{}
@@ -276,6 +279,14 @@ func appendLegacyLoaderAgent(spec *compose.NormalizedProjectSpec, loader domain.
 		}
 	}
 	agent.Name = name
+	displayName := strings.TrimSpace(loader.Summary.Name)
+	if displayName == "" && sourceFound {
+		displayName = projectAgentDisplayName(spec.Agents[sourceIndex])
+	}
+	agent.DisplayName = distinctLegacyDisplayName(displayName, name)
+	if description := strings.TrimSpace(loader.Summary.Description); description != "" {
+		agent.Description = description
+	}
 	spec.Agents = append(spec.Agents, agent)
 	return len(spec.Agents) - 1
 }
@@ -325,6 +336,8 @@ func normalizedAgentFromLegacy(definition domain.AgentDefinition) (compose.Norma
 	}
 	agent := compose.NormalizedAgentSpec{
 		Name:         strings.TrimSpace(definition.Name),
+		DisplayName:  strings.TrimSpace(definition.Name),
+		Description:  strings.TrimSpace(definition.Description),
 		Status:       map[bool]string{true: "enabled", false: "disabled"}[definition.Enabled],
 		Provider:     strings.TrimSpace(definition.Provider),
 		Model:        strings.TrimSpace(definition.Model),
@@ -339,6 +352,14 @@ func normalizedAgentFromLegacy(definition domain.AgentDefinition) (compose.Norma
 		MCPServers:   config.MCPServers,
 	}
 	return agent, nil
+}
+
+func distinctLegacyDisplayName(displayName, stableName string) string {
+	displayName = strings.TrimSpace(displayName)
+	if displayName == strings.TrimSpace(stableName) {
+		return ""
+	}
+	return displayName
 }
 
 type legacyAgentConfig struct {

--- a/pkg/projects/legacy_default_project_e2e_test.go
+++ b/pkg/projects/legacy_default_project_e2e_test.go
@@ -1,0 +1,8 @@
+package projects_test
+
+import "testing"
+
+func TestE2ELegacyDefaultProjectMigrationWorkflows(t *testing.T) {
+	t.Run("legacy resources migrate into the v2 default project", TestIntegrationLegacyDefaultProjectAdoptsLoaderHistoryAtCurrentRevision)
+	t.Run("loader file workspaces preserve source and scheduler bindings", TestIntegrationLegacyLoaderFileWorkspacePreservesSourceAndSchedulerBindings)
+}

--- a/pkg/projects/legacy_default_project_integration_test.go
+++ b/pkg/projects/legacy_default_project_integration_test.go
@@ -127,7 +127,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if len(result.Agents) != 1 || !strings.HasPrefix(result.Agents[0].AgentName, "legacy-agent-") {
 		t.Fatalf("projected Chinese agents = %#v", result.Agents)
 	}
-	if result.Project.SourcePath != filepath.Clean(root) || result.RevisionSpec == nil || len(result.RevisionSpec.Workspaces) != 1 || len(result.RevisionSpec.Agents) != 1 {
+	if result.Project.SourcePath != "" || result.RevisionSpec == nil || len(result.RevisionSpec.Workspaces) != 1 || len(result.RevisionSpec.Agents) != 1 {
 		t.Fatalf("projected file workspace project = %#v, spec = %#v", result.Project, result.RevisionSpec)
 	}
 	projectedAgent := result.RevisionSpec.Agents[0]
@@ -156,6 +156,14 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	project, err := store.GetProject(ctx, projectID)
 	if err != nil {
 		t.Fatalf("load legacy project: %v", err)
+	}
+	resolved, err := controller.ResolveProjectRef(ctx, projects.ProjectRef{Name: result.Project.Name, SourcePath: result.Project.SourcePath})
+	if err != nil || resolved.ID != project.ID {
+		t.Fatalf("resolve returned legacy project ref = %#v, err = %v", resolved, err)
+	}
+	managedAgent, err := store.GetAgentDefinition(ctx, result.Agents[0].ManagedAgentID)
+	if err != nil || managedAgent.WorkspaceID != workspace.ID {
+		t.Fatalf("managed legacy agent workspace = %#v, err = %v", managedAgent, err)
 	}
 	page, err := store.ListProjectSchedulersPage(ctx, "", "", 10)
 	if err != nil {
@@ -202,7 +210,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if err != nil || len(page) != 1 || page[0].Revision != project.CurrentRevision || page[0].ManagedLoaderID != loader.Summary.ID || page[0].RunCount != 1 || !strings.Contains(page[0].SpecJSON, `"display_name":"资讯推送任务"`) {
 		t.Fatalf("scheduler page after presentation upgrade = %#v, err = %v", page, err)
 	}
-	managedAgent, err := store.GetAgentDefinition(ctx, result.Agents[0].ManagedAgentID)
+	managedAgent, err = store.GetAgentDefinition(ctx, result.Agents[0].ManagedAgentID)
 	if err != nil || managedAgent.Name != result.Agents[0].AgentName || managedAgent.ManagedAgentName != result.Agents[0].AgentName || managedAgent.Description != "每日推送最新的 AI 资讯" {
 		t.Fatalf("managed agent after presentation upgrade = %#v, err = %v", managedAgent, err)
 	}

--- a/pkg/projects/legacy_default_project_integration_test.go
+++ b/pkg/projects/legacy_default_project_integration_test.go
@@ -218,6 +218,28 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if err != nil || !repeated.Applied || repeated.Revision.Revision != project.CurrentRevision {
 		t.Fatalf("repeated upgraded sync = %#v, err = %v", repeated, err)
 	}
+
+	editedSpec := *repeated.RevisionSpec
+	editedSpec.Agents = append([]compose.NormalizedAgentSpec(nil), repeated.RevisionSpec.Agents...)
+	editedScheduler := *editedSpec.Agents[0].Scheduler
+	editedScheduler.Description = "Edited through v2 project apply"
+	editedSpec.Agents[0].Scheduler = &editedScheduler
+	editedHash, err := editedSpec.Hash()
+	if err != nil {
+		t.Fatalf("hash edited synthetic project: %v", err)
+	}
+	edited, err := controller.ApplyProject(ctx, projects.ApplyRequest{Normalized: projects.NormalizedProject{Spec: &editedSpec, SpecHash: editedHash}})
+	if err != nil || !edited.Applied {
+		t.Fatalf("apply edited synthetic project = %#v, err = %v", edited, err)
+	}
+	page, err = store.ListProjectSchedulersPage(ctx, "", "", 10)
+	if err != nil || len(page) != 1 || page[0].ManagedLoaderID != loader.Summary.ID {
+		t.Fatalf("edited scheduler lost adopted loader identity: %#v, err = %v", page, err)
+	}
+	editedLoader, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil || editedLoader.Summary.Description != editedScheduler.Description {
+		t.Fatalf("edited adopted loader = %#v, err = %v", editedLoader.Summary, err)
+	}
 }
 
 func emulateLegacyRevisionWithoutPresentation(t *testing.T, ctx context.Context, store *configstore.ConfigStore, project domain.ProjectRecord, spec *compose.NormalizedProjectSpec, agent domain.ProjectAgentRecord) {

--- a/pkg/projects/legacy_default_project_integration_test.go
+++ b/pkg/projects/legacy_default_project_integration_test.go
@@ -17,6 +17,7 @@ import (
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/projects"
 	"agent-compose/pkg/storage/configstore"
+	"agent-compose/pkg/workspaces"
 )
 
 func TestIntegrationLegacyDefaultProjectAdoptsLoaderHistoryAtCurrentRevision(t *testing.T) {
@@ -40,6 +41,15 @@ func TestIntegrationLegacyDefaultProjectAdoptsLoaderHistoryAtCurrentRevision(t *
 		}
 	})
 
+	workspace, err := store.CreateWorkspaceConfig(ctx, domain.WorkspaceConfig{
+		ID:         "legacy-file-workspace",
+		Name:       "news-source",
+		Type:       "file",
+		ConfigJSON: workspaces.DefaultFileConfigJSON(config, "legacy-file-workspace"),
+	})
+	if err != nil {
+		t.Fatalf("create legacy workspace: %v", err)
+	}
 	agent, err := store.CreateAgentDefinition(ctx, domain.AgentDefinition{
 		ID:          "legacy-agent-source",
 		Name:        "ai资讯推送",
@@ -48,6 +58,7 @@ func TestIntegrationLegacyDefaultProjectAdoptsLoaderHistoryAtCurrentRevision(t *
 		Provider:    "codex",
 		Driver:      driverpkg.RuntimeDriverDocker,
 		GuestImage:  "guest:latest",
+		WorkspaceID: workspace.ID,
 	})
 	if err != nil {
 		t.Fatalf("create legacy agent: %v", err)
@@ -64,6 +75,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 			Enabled:       false,
 			Runtime:       domain.LoaderRuntimeScheduler,
 			AgentID:       agent.ID,
+			WorkspaceID:   workspace.ID,
 			Driver:        driverpkg.RuntimeDriverDocker,
 			GuestImage:    "guest:latest",
 			DefaultAgent:  "codex",
@@ -115,6 +127,9 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if len(result.Agents) != 1 || !strings.HasPrefix(result.Agents[0].AgentName, "legacy-agent-") {
 		t.Fatalf("projected Chinese agents = %#v", result.Agents)
 	}
+	if result.Project.SourcePath != filepath.Clean(root) || result.RevisionSpec == nil || len(result.RevisionSpec.Workspaces) != 1 || len(result.RevisionSpec.Agents) != 1 {
+		t.Fatalf("projected file workspace project = %#v, spec = %#v", result.Project, result.RevisionSpec)
+	}
 	projectedAgent := result.RevisionSpec.Agents[0]
 	if projectedAgent.DisplayName != "ai资讯推送" || projectedAgent.Description != "每日推送最新的 AI 资讯" {
 		t.Fatalf("projected agent metadata = %#v", projectedAgent)
@@ -124,6 +139,14 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	}
 	if !strings.Contains(result.Agents[0].SpecJSON, `"display_name":"ai资讯推送"`) || !strings.Contains(result.Agents[0].SpecJSON, `"description":"每日推送最新的 AI 资讯"`) {
 		t.Fatalf("persisted project agent spec = %s", result.Agents[0].SpecJSON)
+	}
+	if projectedAgent.Workspace == nil || projectedAgent.Workspace.Name != "news-source" {
+		t.Fatalf("projected agent workspace = %#v", projectedAgent.Workspace)
+	}
+	projectedWorkspace := result.RevisionSpec.Workspaces["news-source"]
+	wantWorkspacePath := filepath.ToSlash(filepath.Join("workspaces", workspace.ID, workspaces.FileWorkspaceContentDirName))
+	if projectedWorkspace.Provider != "local" || projectedWorkspace.Path != wantWorkspacePath {
+		t.Fatalf("projected workspace = %#v, want path %q", projectedWorkspace, wantWorkspacePath)
 	}
 
 	projectID, err := domain.StableProjectID(projects.LegacyDefaultProjectName, "")
@@ -146,7 +169,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if err != nil {
 		t.Fatalf("load adopted loader: %v", err)
 	}
-	if adopted.Summary.ManagedProjectID != project.ID || adopted.Summary.ManagedRevision != project.CurrentRevision || adopted.Summary.ManagedAgentName != page[0].AgentName || adopted.Summary.Enabled || adopted.Summary.Name != "资讯推送任务" || adopted.Summary.Description != "每小时检查并推送资讯" {
+	if adopted.Summary.ManagedProjectID != project.ID || adopted.Summary.ManagedRevision != project.CurrentRevision || adopted.Summary.ManagedAgentName != page[0].AgentName || adopted.Summary.Enabled || adopted.Summary.WorkspaceID != workspace.ID || adopted.Summary.Name != "资讯推送任务" || adopted.Summary.Description != "每小时检查并推送资讯" {
 		t.Fatalf("adopted loader = %#v", adopted.Summary)
 	}
 	triggerEnabled := make(map[string]bool, len(adopted.Triggers))

--- a/pkg/projects/legacy_default_project_integration_test.go
+++ b/pkg/projects/legacy_default_project_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/samber/do/v2"
 
+	"agent-compose/pkg/compose"
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/images"
@@ -40,12 +41,13 @@ func TestIntegrationLegacyDefaultProjectAdoptsLoaderHistoryAtCurrentRevision(t *
 	})
 
 	agent, err := store.CreateAgentDefinition(ctx, domain.AgentDefinition{
-		ID:         "legacy-agent-source",
-		Name:       "ai资讯推送",
-		Enabled:    true,
-		Provider:   "codex",
-		Driver:     driverpkg.RuntimeDriverDocker,
-		GuestImage: "guest:latest",
+		ID:          "legacy-agent-source",
+		Name:        "ai资讯推送",
+		Description: "每日推送最新的 AI 资讯",
+		Enabled:     true,
+		Provider:    "codex",
+		Driver:      driverpkg.RuntimeDriverDocker,
+		GuestImage:  "guest:latest",
 	})
 	if err != nil {
 		t.Fatalf("create legacy agent: %v", err)
@@ -58,6 +60,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 		Summary: domain.LoaderSummary{
 			ID:            "legacy-loader-source",
 			Name:          "资讯推送任务",
+			Description:   "每小时检查并推送资讯",
 			Enabled:       false,
 			Runtime:       domain.LoaderRuntimeScheduler,
 			AgentID:       agent.ID,
@@ -112,6 +115,16 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if len(result.Agents) != 1 || !strings.HasPrefix(result.Agents[0].AgentName, "legacy-agent-") {
 		t.Fatalf("projected Chinese agents = %#v", result.Agents)
 	}
+	projectedAgent := result.RevisionSpec.Agents[0]
+	if projectedAgent.DisplayName != "ai资讯推送" || projectedAgent.Description != "每日推送最新的 AI 资讯" {
+		t.Fatalf("projected agent metadata = %#v", projectedAgent)
+	}
+	if projectedAgent.Scheduler == nil || projectedAgent.Scheduler.DisplayName != "资讯推送任务" || projectedAgent.Scheduler.Description != "每小时检查并推送资讯" {
+		t.Fatalf("projected scheduler metadata = %#v", projectedAgent.Scheduler)
+	}
+	if !strings.Contains(result.Agents[0].SpecJSON, `"display_name":"ai资讯推送"`) || !strings.Contains(result.Agents[0].SpecJSON, `"description":"每日推送最新的 AI 资讯"`) {
+		t.Fatalf("persisted project agent spec = %s", result.Agents[0].SpecJSON)
+	}
 
 	projectID, err := domain.StableProjectID(projects.LegacyDefaultProjectName, "")
 	if err != nil {
@@ -125,7 +138,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if err != nil {
 		t.Fatalf("list project schedulers page: %v", err)
 	}
-	if len(page) != 1 || page[0].Revision != project.CurrentRevision || page[0].ManagedLoaderID != loader.Summary.ID || page[0].Enabled || page[0].RunCount != 1 {
+	if len(page) != 1 || page[0].Revision != project.CurrentRevision || page[0].ManagedLoaderID != loader.Summary.ID || page[0].Enabled || page[0].RunCount != 1 || !strings.Contains(page[0].SpecJSON, `"display_name":"资讯推送任务"`) || !strings.Contains(page[0].SpecJSON, `"description":"每小时检查并推送资讯"`) {
 		t.Fatalf("project scheduler page = %#v, project = %#v", page, project)
 	}
 
@@ -133,7 +146,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if err != nil {
 		t.Fatalf("load adopted loader: %v", err)
 	}
-	if adopted.Summary.ManagedProjectID != project.ID || adopted.Summary.ManagedRevision != project.CurrentRevision || adopted.Summary.ManagedAgentName != page[0].AgentName || adopted.Summary.Enabled {
+	if adopted.Summary.ManagedProjectID != project.ID || adopted.Summary.ManagedRevision != project.CurrentRevision || adopted.Summary.ManagedAgentName != page[0].AgentName || adopted.Summary.Enabled || adopted.Summary.Name != "资讯推送任务" || adopted.Summary.Description != "每小时检查并推送资讯" {
 		t.Fatalf("adopted loader = %#v", adopted.Summary)
 	}
 	triggerEnabled := make(map[string]bool, len(adopted.Triggers))
@@ -150,13 +163,85 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 		t.Fatalf("adopted loader events = %#v, err = %v", events, err)
 	}
 
-	repeated, err := controller.SyncLegacyDefaultProject(ctx)
-	if err != nil || !repeated.Applied || repeated.Revision.Revision != project.CurrentRevision {
-		t.Fatalf("repeated sync = %#v, err = %v", repeated, err)
+	emulateLegacyRevisionWithoutPresentation(t, ctx, store, project, result.RevisionSpec, result.Agents[0])
+	upgraded, err := controller.SyncLegacyDefaultProject(ctx)
+	if err != nil || !upgraded.Applied || upgraded.Revision.Revision != project.CurrentRevision+1 {
+		t.Fatalf("presentation metadata upgrade = %#v, err = %v", upgraded, err)
+	}
+	if len(upgraded.RevisionSpec.Agents) != 1 || upgraded.RevisionSpec.Agents[0].DisplayName != "ai资讯推送" || upgraded.RevisionSpec.Agents[0].Description != "每日推送最新的 AI 资讯" || upgraded.RevisionSpec.Agents[0].Scheduler == nil || upgraded.RevisionSpec.Agents[0].Scheduler.DisplayName != "资讯推送任务" || upgraded.RevisionSpec.Agents[0].Scheduler.Description != "每小时检查并推送资讯" {
+		t.Fatalf("upgraded presentation metadata = %#v", upgraded.RevisionSpec.Agents)
+	}
+	project, err = store.GetProject(ctx, projectID)
+	if err != nil {
+		t.Fatalf("load upgraded legacy project: %v", err)
 	}
 	page, err = store.ListProjectSchedulersPage(ctx, "", "", 10)
-	if err != nil || len(page) != 1 || page[0].ManagedLoaderID != loader.Summary.ID || page[0].RunCount != 1 {
-		t.Fatalf("scheduler page after repeated sync = %#v, err = %v", page, err)
+	if err != nil || len(page) != 1 || page[0].Revision != project.CurrentRevision || page[0].ManagedLoaderID != loader.Summary.ID || page[0].RunCount != 1 || !strings.Contains(page[0].SpecJSON, `"display_name":"资讯推送任务"`) {
+		t.Fatalf("scheduler page after presentation upgrade = %#v, err = %v", page, err)
+	}
+	managedAgent, err := store.GetAgentDefinition(ctx, result.Agents[0].ManagedAgentID)
+	if err != nil || managedAgent.Name != result.Agents[0].AgentName || managedAgent.ManagedAgentName != result.Agents[0].AgentName || managedAgent.Description != "每日推送最新的 AI 资讯" {
+		t.Fatalf("managed agent after presentation upgrade = %#v, err = %v", managedAgent, err)
+	}
+	repeated, err := controller.SyncLegacyDefaultProject(ctx)
+	if err != nil || !repeated.Applied || repeated.Revision.Revision != project.CurrentRevision {
+		t.Fatalf("repeated upgraded sync = %#v, err = %v", repeated, err)
+	}
+}
+
+func emulateLegacyRevisionWithoutPresentation(t *testing.T, ctx context.Context, store *configstore.ConfigStore, project domain.ProjectRecord, spec *compose.NormalizedProjectSpec, agent domain.ProjectAgentRecord) {
+	t.Helper()
+	legacySpec := *spec
+	legacySpec.Agents = append([]compose.NormalizedAgentSpec(nil), spec.Agents...)
+	for index := range legacySpec.Agents {
+		legacySpec.Agents[index].DisplayName = ""
+		legacySpec.Agents[index].Description = ""
+		if legacySpec.Agents[index].Scheduler != nil {
+			scheduler := *legacySpec.Agents[index].Scheduler
+			scheduler.DisplayName = ""
+			scheduler.Description = ""
+			legacySpec.Agents[index].Scheduler = &scheduler
+		}
+	}
+	legacyHash, err := legacySpec.Hash()
+	if err != nil {
+		t.Fatalf("hash legacy presentation-free spec: %v", err)
+	}
+	legacyJSON, err := legacySpec.MarshalCanonicalJSON(false)
+	if err != nil {
+		t.Fatalf("marshal legacy presentation-free spec: %v", err)
+	}
+	legacyAgent, err := projects.NewAgentRecordFromSpec(project.ID, project.CurrentRevision, legacySpec.Agents[0])
+	if err != nil {
+		t.Fatalf("build legacy presentation-free agent: %v", err)
+	}
+	legacyScheduler, ok, err := projects.NewSchedulerRecordFromSpec(project.ID, project.CurrentRevision, legacySpec.Agents[0])
+	if err != nil || !ok {
+		t.Fatalf("build legacy presentation-free scheduler: %#v/%v/%v", legacyScheduler, ok, err)
+	}
+
+	tx, err := store.DB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin legacy presentation downgrade: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `UPDATE project SET spec_hash = ? WHERE id = ?`, legacyHash, project.ID); err != nil {
+		t.Fatalf("downgrade project hash: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE project_revision SET spec_hash = ?, spec_json = ? WHERE project_id = ? AND revision = ?`, legacyHash, string(legacyJSON), project.ID, project.CurrentRevision); err != nil {
+		t.Fatalf("downgrade project revision: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE project_agent SET spec_json = ? WHERE project_id = ? AND agent_name = ?`, legacyAgent.SpecJSON, project.ID, agent.AgentName); err != nil {
+		t.Fatalf("downgrade project agent spec: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE project_scheduler SET spec_json = ? WHERE project_id = ? AND agent_name = ?`, legacyScheduler.SpecJSON, project.ID, agent.AgentName); err != nil {
+		t.Fatalf("downgrade project scheduler spec: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE agent_definition SET name = ?, description = '' WHERE id = ?`, agent.AgentName, agent.ManagedAgentID); err != nil {
+		t.Fatalf("downgrade managed agent presentation: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit legacy presentation downgrade: %v", err)
 	}
 }
 

--- a/pkg/projects/legacy_default_project_test.go
+++ b/pkg/projects/legacy_default_project_test.go
@@ -246,6 +246,16 @@ func TestLegacyDefaultNormalizedProjectKeepsUnboundLoaderVisibleButDisabled(t *t
 	if adopted := project.managedLoaderOverrides[agent.Name]; adopted.Summary.ID != loader.Summary.ID || adopted.Summary.Enabled {
 		t.Fatalf("unbound loader override = %#v", adopted)
 	}
+
+	loader.Summary.Enabled = false
+	loader.Summary.ManagedAgentName = agent.Name
+	reprojected, err := legacyDefaultNormalizedProject(nil, []domain.Loader{loader})
+	if err != nil {
+		t.Fatalf("reproject adopted unbound loader: %v", err)
+	}
+	if len(reprojected.Spec.Agents) != 1 || reprojected.Spec.Agents[0].Status != "disabled" || reprojected.Spec.Agents[0].Scheduler.Enabled {
+		t.Fatalf("reprojected unbound compatibility agent = %#v", reprojected.Spec.Agents)
+	}
 }
 
 func findLegacyProjectAgent(t *testing.T, project NormalizedProject, name string) compose.NormalizedAgentSpec {

--- a/pkg/projects/legacy_default_project_test.go
+++ b/pkg/projects/legacy_default_project_test.go
@@ -54,10 +54,10 @@ func TestLegacyDefaultNormalizedProjectPreservesAgentConfiguration(t *testing.T)
 	}
 }
 
-func TestLegacyDefaultNormalizedProjectRejectsLossyMappings(t *testing.T) {
+func TestLegacyDefaultNormalizedProjectRequiresLoadedWorkspacePreset(t *testing.T) {
 	_, err := legacyDefaultNormalizedProject([]domain.AgentDefinition{{ID: "agent-1", Name: "worker", Enabled: true, Provider: "codex", WorkspaceID: "workspace-1"}}, nil)
-	if err == nil {
-		t.Fatal("expected workspace preset compatibility error")
+	if err == nil || !strings.Contains(err.Error(), "was not loaded") {
+		t.Fatalf("legacyDefaultNormalizedProject error = %v", err)
 	}
 }
 

--- a/pkg/projects/legacy_default_project_test.go
+++ b/pkg/projects/legacy_default_project_test.go
@@ -63,7 +63,7 @@ func TestLegacyDefaultNormalizedProjectRejectsLossyMappings(t *testing.T) {
 
 func TestLegacyDefaultNormalizedProjectUsesStableCompatibilityNames(t *testing.T) {
 	agents := []domain.AgentDefinition{
-		{ID: "agent-chinese", Name: "ai资讯推送", Enabled: true, Provider: "codex"},
+		{ID: "agent-chinese", Name: "ai资讯推送", Description: "每天汇总 AI 资讯", Enabled: true, Provider: "codex"},
 		{ID: "agent-duplicate-b", Name: "worker", Enabled: true, Provider: "codex"},
 		{ID: "agent-duplicate-a", Name: "worker", Enabled: true, Provider: "codex"},
 		{ID: "agent-valid", Name: "Reviewer-Z", Enabled: true, Provider: "codex"},
@@ -78,6 +78,7 @@ func TestLegacyDefaultNormalizedProjectUsesStableCompatibilityNames(t *testing.T
 	}
 	names := make(map[string]struct{}, len(project.Spec.Agents))
 	var compatibilityName string
+	var compatibilityAgent compose.NormalizedAgentSpec
 	duplicateCount := 0
 	for _, agent := range project.Spec.Agents {
 		if !domain.IsProjectStableIdentifier(agent.Name) {
@@ -89,6 +90,7 @@ func TestLegacyDefaultNormalizedProjectUsesStableCompatibilityNames(t *testing.T
 		names[agent.Name] = struct{}{}
 		if strings.HasPrefix(agent.Name, "legacy-agent-") {
 			compatibilityName = agent.Name
+			compatibilityAgent = agent
 		}
 		if strings.HasPrefix(agent.Name, "worker-") {
 			duplicateCount++
@@ -96,6 +98,9 @@ func TestLegacyDefaultNormalizedProjectUsesStableCompatibilityNames(t *testing.T
 	}
 	if compatibilityName == "" || duplicateCount != 2 {
 		t.Fatalf("compatibility names = %#v", names)
+	}
+	if compatibilityAgent.DisplayName != "ai资讯推送" || compatibilityAgent.Description != "每天汇总 AI 资讯" {
+		t.Fatalf("compatibility agent metadata = %#v", compatibilityAgent)
 	}
 	if _, exists := names["reviewer-z"]; !exists {
 		t.Fatalf("valid normalized name missing from %#v", names)
@@ -136,6 +141,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 			Summary: domain.LoaderSummary{
 				ID:                "loader-b",
 				Name:              "Second task",
+				Description:       "Second task description",
 				Enabled:           true,
 				Runtime:           domain.LoaderRuntimeScheduler,
 				AgentID:           "agent-1",
@@ -152,6 +158,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 			Summary: domain.LoaderSummary{
 				ID:            "loader-a",
 				Name:          "First task",
+				Description:   "First task description",
 				Enabled:       false,
 				Runtime:       domain.LoaderRuntimeScheduler,
 				AgentID:       "agent-1",
@@ -173,7 +180,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 		t.Fatalf("project agents/overrides = %#v/%#v", project.Spec.Agents, project.managedLoaderOverrides)
 	}
 	worker := findLegacyProjectAgent(t, project, "worker")
-	if worker.Scheduler == nil || worker.Scheduler.Enabled || worker.Scheduler.Script != loaders[1].Script {
+	if worker.Scheduler == nil || worker.Scheduler.Enabled || worker.Scheduler.Script != loaders[1].Script || worker.Scheduler.DisplayName != "First task" || worker.Scheduler.Description != "First task description" {
 		t.Fatalf("worker scheduler = %#v", worker.Scheduler)
 	}
 	workerLoader := project.managedLoaderOverrides["worker"]
@@ -185,7 +192,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 	for _, agent := range project.Spec.Agents {
 		if strings.HasPrefix(agent.Name, "worker-loader-") {
 			clonedName = agent.Name
-			if agent.Scheduler == nil || !agent.Scheduler.Enabled || agent.Scheduler.Script != loaders[0].Script {
+			if agent.Scheduler == nil || !agent.Scheduler.Enabled || agent.Scheduler.Script != loaders[0].Script || agent.Scheduler.DisplayName != "Second task" || agent.Scheduler.Description != "Second task description" {
 				t.Fatalf("cloned scheduler = %#v", agent.Scheduler)
 			}
 		}
@@ -207,7 +214,8 @@ func TestLegacyDefaultNormalizedProjectKeepsUnboundLoaderVisibleButDisabled(t *t
 	loader := domain.Loader{
 		Summary: domain.LoaderSummary{
 			ID:           "loader-unbound",
-			Name:         "Unbound task",
+			Name:         "未绑定任务",
+			Description:  "迁移后保持可见但禁用",
 			Enabled:      true,
 			Runtime:      domain.LoaderRuntimeScheduler,
 			DefaultAgent: "codex",
@@ -228,6 +236,12 @@ func TestLegacyDefaultNormalizedProjectKeepsUnboundLoaderVisibleButDisabled(t *t
 	agent := project.Spec.Agents[0]
 	if agent.Status != "disabled" || agent.Scheduler == nil || agent.Scheduler.Enabled {
 		t.Fatalf("unbound compatibility agent = %#v", agent)
+	}
+	if agent.DisplayName != "未绑定任务" || agent.Description != "迁移后保持可见但禁用" {
+		t.Fatalf("unbound compatibility agent metadata = %#v", agent)
+	}
+	if agent.Scheduler.DisplayName != "未绑定任务" || agent.Scheduler.Description != "迁移后保持可见但禁用" {
+		t.Fatalf("unbound scheduler metadata = %#v", agent.Scheduler)
 	}
 	if adopted := project.managedLoaderOverrides[agent.Name]; adopted.Summary.ID != loader.Summary.ID || adopted.Summary.Enabled {
 		t.Fatalf("unbound loader override = %#v", adopted)

--- a/pkg/projects/legacy_loader_workspace_integration_test.go
+++ b/pkg/projects/legacy_loader_workspace_integration_test.go
@@ -1,0 +1,158 @@
+package projects_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/samber/do/v2"
+
+	"agent-compose/pkg/compose"
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+	"agent-compose/pkg/runs"
+	"agent-compose/pkg/storage/configstore"
+	"agent-compose/pkg/workspaces"
+)
+
+func TestIntegrationLegacyLoaderFileWorkspacePreservesSourceAndSchedulerBindings(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:           root,
+		DbAddr:             filepath.Join(root, "data.db"),
+		RuntimeDriver:      driverpkg.RuntimeDriverDocker,
+		DockerDefaultImage: "guest:latest",
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("create config store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.DB().Close(); err != nil {
+			t.Errorf("close config store: %v", err)
+		}
+	})
+
+	workspace, err := store.CreateWorkspaceConfig(ctx, domain.WorkspaceConfig{
+		ID:         "loader-upload",
+		Name:       "Loader upload",
+		Type:       "file",
+		ConfigJSON: workspaces.DefaultFileConfigJSON(config, "loader-upload"),
+	})
+	if err != nil {
+		t.Fatalf("create legacy workspace: %v", err)
+	}
+	content, err := workspaces.OpenFileWorkspaceContent(config, workspace)
+	if err != nil {
+		t.Fatalf("open legacy workspace content: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(content.AbsRoot, "migration.txt"), []byte("preserved\n"), 0o600); err != nil {
+		if closeErr := content.Root.Close(); closeErr != nil {
+			t.Errorf("close legacy workspace content after write failure: %v", closeErr)
+		}
+		t.Fatalf("write legacy workspace content: %v", err)
+	}
+	if err := content.Root.Close(); err != nil {
+		t.Fatalf("close legacy workspace content: %v", err)
+	}
+
+	source, err := store.CreateAgentDefinition(ctx, domain.AgentDefinition{
+		ID: "workspace-less-source", Name: "worker", Enabled: true, Provider: "codex",
+		Driver: driverpkg.RuntimeDriverDocker, GuestImage: "guest:latest",
+	})
+	if err != nil {
+		t.Fatalf("create source agent: %v", err)
+	}
+	loader, err := store.CreateLoader(ctx, domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID: "loader-with-upload", Name: "uploaded task", Enabled: true,
+			Runtime: domain.LoaderRuntimeScheduler, AgentID: source.ID, WorkspaceID: workspace.ID,
+			Driver: driverpkg.RuntimeDriverDocker, GuestImage: "guest:latest", DefaultAgent: "codex",
+		},
+		Script: `scheduler.interval("uploaded", function uploaded() {}, 60000);`,
+	})
+	if err != nil {
+		t.Fatalf("create loader: %v", err)
+	}
+	engine := &loaders.QJSLoaderEngine{}
+	validation, err := engine.Validate(ctx, loader.Summary.Runtime, loader.Script)
+	if err != nil {
+		t.Fatalf("validate loader: %v", err)
+	}
+	if _, err := store.ReplaceLoaderTriggers(ctx, loader.Summary.ID, validation.Triggers); err != nil {
+		t.Fatalf("persist loader triggers: %v", err)
+	}
+
+	controller := projects.NewController(projects.ControllerDependencies{
+		Config: config, Store: store, Images: legacyProjectImageBackend{},
+		Loaders: legacyProjectLoaderValidator{engine: engine}, Volumes: legacyProjectVolumeManager{},
+	})
+	result, err := controller.SyncLegacyDefaultProject(ctx)
+	if err != nil {
+		t.Fatalf("SyncLegacyDefaultProject returned error: %v", err)
+	}
+	if !result.Applied || len(result.Agents) != 2 || len(result.Schedulers) != 1 {
+		t.Fatalf("migration result = %#v", result)
+	}
+
+	var sourceSpec, schedulerSpec *compose.NormalizedAgentSpec
+	for index := range result.RevisionSpec.Agents {
+		agent := &result.RevisionSpec.Agents[index]
+		if agent.Scheduler == nil {
+			sourceSpec = agent
+		} else {
+			schedulerSpec = agent
+		}
+	}
+	if sourceSpec == nil || sourceSpec.Workspace != nil {
+		t.Fatalf("workspace-less source changed: %#v", sourceSpec)
+	}
+	if schedulerSpec == nil || schedulerSpec.Workspace == nil {
+		t.Fatalf("compatibility scheduler workspace = %#v", schedulerSpec)
+	}
+
+	var schedulerAgent domain.ProjectAgentRecord
+	for _, agent := range result.Agents {
+		if agent.AgentName == schedulerSpec.Name {
+			schedulerAgent = agent
+		}
+	}
+	if schedulerAgent.ManagedAgentID == "" {
+		t.Fatalf("scheduler agent record not found: %#v", result.Agents)
+	}
+	definition, err := store.GetAgentDefinition(ctx, schedulerAgent.ManagedAgentID)
+	if err != nil {
+		t.Fatalf("load compatibility scheduler agent: %v", err)
+	}
+	if definition.WorkspaceID != workspace.ID {
+		t.Fatalf("scheduler workspace ID = %q, want %q", definition.WorkspaceID, workspace.ID)
+	}
+
+	prepared, err := runs.PrepareProjectRun(ctx, store, rejectingWorkspaceResolver{}, domain.ProjectRunRecord{
+		RunID: "migration-run", ProjectID: result.Project.ID, ProjectRevision: result.Revision.Revision,
+		AgentName: schedulerAgent.AgentName, ManagedAgentID: schedulerAgent.ManagedAgentID,
+	}, nil)
+	if err != nil {
+		t.Fatalf("PrepareProjectRun returned error: %v", err)
+	}
+	if prepared.WorkspaceConfig == nil || prepared.WorkspaceConfig.ID != workspace.ID || prepared.Workspace == nil || prepared.Workspace.ID != workspace.ID {
+		t.Fatalf("prepared original uploaded workspace = %#v / %#v", prepared.WorkspaceConfig, prepared.Workspace)
+	}
+	if data, err := os.ReadFile(filepath.Join(content.AbsRoot, "migration.txt")); err != nil || string(data) != "preserved\n" {
+		t.Fatalf("uploaded workspace content = %q, err = %v", data, err)
+	}
+}
+
+type rejectingWorkspaceResolver struct{}
+
+func (rejectingWorkspaceResolver) ResolveProjectRunWorkspace(context.Context, domain.ProjectRunRecord, domain.ProjectRecord, *compose.WorkspaceSpec, *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SandboxWorkspace, error) {
+	return nil, nil, fmt.Errorf("ordinary workspace resolver must not handle migrated file preset")
+}

--- a/pkg/projects/legacy_managed_loader_reapply.go
+++ b/pkg/projects/legacy_managed_loader_reapply.go
@@ -1,0 +1,56 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+// preserveLegacyManagedLoaderIdentities keeps adopted v1 loader IDs attached
+// when the synthetic project is edited through the ordinary v2 ApplyProject
+// API. The initial migration already carries explicit overrides.
+func (c *Controller) preserveLegacyManagedLoaderIdentities(ctx context.Context, project domain.ProjectRecord, normalized NormalizedProject) (NormalizedProject, error) {
+	if len(normalized.managedLoaderOverrides) != 0 || !IsLegacyDefaultProject(project) || normalized.Spec == nil {
+		return normalized, nil
+	}
+	store, ok := c.store.(ReconcileSchedulerStore)
+	if !ok {
+		return NormalizedProject{}, fmt.Errorf("scheduler store is required")
+	}
+	schedulers, err := store.ListProjectSchedulers(ctx, project.ID)
+	if err != nil {
+		return NormalizedProject{}, fmt.Errorf("list existing schedulers: %w", err)
+	}
+	declared := make(map[string]struct{}, len(normalized.Spec.Agents))
+	for _, agent := range normalized.Spec.Agents {
+		if agent.Scheduler != nil {
+			declared[agent.Name] = struct{}{}
+		}
+	}
+	overrides := make(map[string]domain.Loader, len(schedulers))
+	for _, scheduler := range schedulers {
+		if _, ok := declared[scheduler.AgentName]; !ok || strings.TrimSpace(scheduler.ManagedLoaderID) == "" {
+			continue
+		}
+		loader, found, err := store.GetLoaderIfExists(ctx, scheduler.ManagedLoaderID)
+		if err != nil {
+			return NormalizedProject{}, fmt.Errorf("load scheduler %s loader %s: %w", scheduler.SchedulerID, scheduler.ManagedLoaderID, err)
+		}
+		if !found || !managedLoaderMatchesProjectScheduler(loader, project.ID, scheduler) {
+			continue
+		}
+		overrides[scheduler.AgentName] = loader
+	}
+	if len(overrides) != 0 {
+		normalized.managedLoaderOverrides = overrides
+	}
+	return normalized, nil
+}
+
+func managedLoaderMatchesProjectScheduler(loader domain.Loader, projectID string, scheduler domain.ProjectSchedulerRecord) bool {
+	return strings.TrimSpace(loader.Summary.ManagedProjectID) == strings.TrimSpace(projectID) &&
+		strings.TrimSpace(loader.Summary.ManagedAgentName) == strings.TrimSpace(scheduler.AgentName) &&
+		strings.TrimSpace(loader.Summary.ManagedSchedulerID) == strings.TrimSpace(scheduler.SchedulerID)
+}

--- a/pkg/projects/legacy_workspace_binding.go
+++ b/pkg/projects/legacy_workspace_binding.go
@@ -1,0 +1,128 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"agent-compose/pkg/compose"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/workspaces"
+)
+
+// bindLegacyFileWorkspaces restores the v1 preset binding carried by the
+// synthetic project's canonical local-workspace path. Ordinary v2 projects
+// continue to materialize local workspaces from their project source.
+func (c *Controller) bindLegacyFileWorkspaces(ctx context.Context, project domain.ProjectRecord, spec *compose.NormalizedProjectSpec, definitions []domain.AgentDefinition) error {
+	if !IsLegacyDefaultProject(project) || spec == nil || len(definitions) == 0 {
+		return nil
+	}
+	agents := make(map[string]compose.NormalizedAgentSpec, len(spec.Agents))
+	for _, agent := range spec.Agents {
+		agents[agent.Name] = agent
+	}
+	type binding struct {
+		definitionIndex int
+		agentName       string
+		workspaceID     string
+	}
+	bindings := make([]binding, 0, len(definitions))
+	for index := range definitions {
+		agent, ok := agents[definitions[index].ManagedAgentName]
+		if !ok {
+			continue
+		}
+		workspaceID, ok := legacyFileWorkspaceID(spec, agent)
+		if !ok {
+			continue
+		}
+		bindings = append(bindings, binding{definitionIndex: index, agentName: agent.Name, workspaceID: workspaceID})
+	}
+	if len(bindings) == 0 {
+		return nil
+	}
+	if c == nil || c.config == nil {
+		return fmt.Errorf("bind legacy file workspaces: config is required")
+	}
+	store, ok := c.store.(legacyWorkspaceConfigStore)
+	if !ok {
+		return fmt.Errorf("bind legacy file workspaces: workspace config store is required")
+	}
+	loaded := make(map[string]domain.WorkspaceConfig, len(bindings))
+	for _, binding := range bindings {
+		workspaceID := binding.workspaceID
+		workspace, found := loaded[workspaceID]
+		if !found {
+			var err error
+			workspace, err = store.GetWorkspaceConfig(ctx, workspaceID)
+			if err != nil {
+				return fmt.Errorf("bind legacy agent %s workspace %s: %w", binding.agentName, workspaceID, err)
+			}
+			if strings.ToLower(strings.TrimSpace(workspace.Type)) != "file" {
+				return fmt.Errorf("bind legacy agent %s workspace %s: workspace type is %q, want file", binding.agentName, workspaceID, workspace.Type)
+			}
+			if _, err := workspaces.FileWorkspaceContentRoot(c.config, workspace); err != nil {
+				return fmt.Errorf("bind legacy agent %s workspace %s: %w", binding.agentName, workspaceID, err)
+			}
+			loaded[workspaceID] = workspace
+		}
+		definitions[binding.definitionIndex].WorkspaceID = workspace.ID
+	}
+	return nil
+}
+
+// IsLegacyDefaultProject reports whether project is the canonical synthetic
+// project created by the v1 compatibility migration.
+func IsLegacyDefaultProject(project domain.ProjectRecord) bool {
+	if strings.TrimSpace(project.Name) != LegacyDefaultProjectName || strings.TrimSpace(project.SourcePath) != "" {
+		return false
+	}
+	projectID, err := domain.StableProjectID(LegacyDefaultProjectName, "")
+	return err == nil && strings.TrimSpace(project.ID) == projectID
+}
+
+func legacyFileWorkspaceID(spec *compose.NormalizedProjectSpec, agent compose.NormalizedAgentSpec) (string, bool) {
+	workspace := resolvedLegacyWorkspace(spec, agent.Workspace)
+	return LegacyFileWorkspacePresetID(workspace)
+}
+
+// LegacyFileWorkspacePresetID returns the original v1 file-workspace preset ID
+// encoded by the canonical migration-only local workspace path.
+func LegacyFileWorkspacePresetID(workspace *compose.WorkspaceSpec) (string, bool) {
+	if workspace == nil || strings.ToLower(strings.TrimSpace(workspace.Provider)) != "local" {
+		return "", false
+	}
+	path := filepath.ToSlash(filepath.Clean(strings.TrimSpace(workspace.Path)))
+	prefix := "workspaces/"
+	suffix := "/" + workspaces.FileWorkspaceContentDirName
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", false
+	}
+	workspaceID := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	expected, err := workspaces.FileWorkspaceContentRelRoot(workspaceID)
+	if err != nil || filepath.ToSlash(filepath.Clean(expected)) != path {
+		return "", false
+	}
+	return workspaceID, true
+}
+
+func resolvedLegacyWorkspace(spec *compose.NormalizedProjectSpec, reference *compose.WorkspaceSpec) *compose.WorkspaceSpec {
+	if reference == nil {
+		if len(spec.Workspaces) != 1 {
+			return nil
+		}
+		for _, workspace := range spec.Workspaces {
+			resolved := workspace
+			return &resolved
+		}
+	}
+	if strings.TrimSpace(reference.Provider) != "" || strings.TrimSpace(reference.URL) != "" || strings.TrimSpace(reference.Branch) != "" || strings.TrimSpace(reference.Path) != "" {
+		return reference
+	}
+	workspace, ok := spec.Workspaces[strings.TrimSpace(reference.Name)]
+	if !ok {
+		return nil
+	}
+	return &workspace
+}

--- a/pkg/projects/legacy_workspace_binding.go
+++ b/pkg/projects/legacy_workspace_binding.go
@@ -117,7 +117,7 @@ func resolvedLegacyWorkspace(spec *compose.NormalizedProjectSpec, reference *com
 			return &resolved
 		}
 	}
-	if strings.TrimSpace(reference.Provider) != "" || strings.TrimSpace(reference.URL) != "" || strings.TrimSpace(reference.Branch) != "" || strings.TrimSpace(reference.Path) != "" {
+	if strings.TrimSpace(reference.Provider) != "" || strings.TrimSpace(reference.URL) != "" || strings.TrimSpace(reference.Branch) != "" || strings.TrimSpace(reference.Commit) != "" || strings.TrimSpace(reference.Path) != "" {
 		return reference
 	}
 	workspace, ok := spec.Workspaces[strings.TrimSpace(reference.Name)]

--- a/pkg/projects/legacy_workspace_binding_test.go
+++ b/pkg/projects/legacy_workspace_binding_test.go
@@ -1,0 +1,52 @@
+package projects
+
+import (
+	"testing"
+
+	"agent-compose/pkg/compose"
+	domain "agent-compose/pkg/model"
+)
+
+func TestLegacyFileWorkspaceIDSupportsNamedAndReappliedInlineSpecs(t *testing.T) {
+	spec := &compose.NormalizedProjectSpec{
+		Workspaces: map[string]compose.WorkspaceSpec{
+			"uploads": {Provider: "local", Path: "workspaces/legacy-file/content"},
+		},
+	}
+
+	workspaceID, ok := legacyFileWorkspaceID(spec, compose.NormalizedAgentSpec{
+		Workspace: &compose.WorkspaceSpec{Name: "uploads"},
+	})
+	if !ok || workspaceID != "legacy-file" {
+		t.Fatalf("named legacy workspace = %q, %v", workspaceID, ok)
+	}
+
+	workspaceID, ok = legacyFileWorkspaceID(spec, compose.NormalizedAgentSpec{
+		Workspace: &compose.WorkspaceSpec{Provider: "local", Path: "workspaces/legacy-file/content"},
+	})
+	if !ok || workspaceID != "legacy-file" {
+		t.Fatalf("inline legacy workspace = %q, %v", workspaceID, ok)
+	}
+
+	if workspaceID, ok := legacyFileWorkspaceID(spec, compose.NormalizedAgentSpec{
+		Workspace: &compose.WorkspaceSpec{Provider: "local", Path: "source"},
+	}); ok || workspaceID != "" {
+		t.Fatalf("ordinary local workspace was treated as legacy = %q, %v", workspaceID, ok)
+	}
+}
+
+func TestLegacyFileWorkspaceBindingIsLimitedToSyntheticProjectIdentity(t *testing.T) {
+	projectID, err := domain.StableProjectID(LegacyDefaultProjectName, "")
+	if err != nil {
+		t.Fatalf("StableProjectID returned error: %v", err)
+	}
+	if !IsLegacyDefaultProject(domain.ProjectRecord{ID: projectID, Name: LegacyDefaultProjectName}) {
+		t.Fatal("synthetic legacy project was not recognized")
+	}
+	if IsLegacyDefaultProject(domain.ProjectRecord{ID: projectID, Name: LegacyDefaultProjectName, SourcePath: "/repo"}) {
+		t.Fatal("sourced project was treated as the synthetic legacy project")
+	}
+	if IsLegacyDefaultProject(domain.ProjectRecord{ID: "other", Name: LegacyDefaultProjectName}) {
+		t.Fatal("different project identity was treated as the synthetic legacy project")
+	}
+}

--- a/pkg/projects/legacy_workspace_migration.go
+++ b/pkg/projects/legacy_workspace_migration.go
@@ -126,9 +126,6 @@ func mapLegacyWorkspaceConfig(config *appconfig.Config, workspace domain.Workspa
 		if err := json.Unmarshal([]byte(workspace.ConfigJSON), &legacy); err != nil {
 			return compose.WorkspaceSpec{}, fmt.Errorf("decode legacy git workspace preset %s: %w", workspace.ID, err)
 		}
-		if strings.TrimSpace(legacy.Commit) != "" {
-			return compose.WorkspaceSpec{}, fmt.Errorf("legacy git workspace preset %s pins commit %s, which cannot be mapped to a v2 workspace branch", workspace.ID, legacy.Commit)
-		}
 		cloneTarget, err := workspaces.NormalizeGitCloneTarget(workspace.ID, legacy.CloneTarget)
 		if err != nil {
 			return compose.WorkspaceSpec{}, err
@@ -141,6 +138,7 @@ func mapLegacyWorkspaceConfig(config *appconfig.Config, workspace domain.Workspa
 			Provider: "git",
 			URL:      cloneURL,
 			Branch:   strings.TrimSpace(legacy.Branch),
+			Commit:   strings.TrimSpace(legacy.Commit),
 			Path:     cloneTarget,
 		}, nil
 	case "file":

--- a/pkg/projects/legacy_workspace_migration.go
+++ b/pkg/projects/legacy_workspace_migration.go
@@ -22,7 +22,6 @@ type legacyWorkspaceConfigStore interface {
 type legacyWorkspaceProjection struct {
 	workspaces map[string]compose.WorkspaceSpec
 	nameByID   map[string]string
-	sourcePath string
 }
 
 func (c *Controller) loadLegacyWorkspaceProjection(ctx context.Context, agents []domain.AgentDefinition, loaders []domain.Loader) (legacyWorkspaceProjection, error) {
@@ -49,28 +48,14 @@ func (c *Controller) loadLegacyWorkspaceProjection(ctx context.Context, agents [
 
 	nameByID := legacyProjectWorkspaceNames(configs)
 	projectWorkspaces := make(map[string]compose.WorkspaceSpec, len(configs))
-	usesLocalWorkspace := false
 	for _, config := range configs {
-		workspace, local, err := mapLegacyWorkspaceConfig(c.config, config)
+		workspace, err := mapLegacyWorkspaceConfig(c.config, config)
 		if err != nil {
 			return legacyWorkspaceProjection{}, err
 		}
 		projectWorkspaces[nameByID[config.ID]] = workspace
-		usesLocalWorkspace = usesLocalWorkspace || local
 	}
-
-	projection := legacyWorkspaceProjection{workspaces: projectWorkspaces, nameByID: nameByID}
-	if usesLocalWorkspace {
-		if c.config == nil || strings.TrimSpace(c.config.DataRoot) == "" {
-			return legacyWorkspaceProjection{}, fmt.Errorf("map legacy file workspace presets: data root is required")
-		}
-		root, err := filepath.Abs(c.config.DataRoot)
-		if err != nil {
-			return legacyWorkspaceProjection{}, fmt.Errorf("resolve legacy workspace source root: %w", err)
-		}
-		projection.sourcePath = filepath.Clean(root)
-	}
-	return projection, nil
+	return legacyWorkspaceProjection{workspaces: projectWorkspaces, nameByID: nameByID}, nil
 }
 
 func legacyReferencedWorkspaceIDs(agents []domain.AgentDefinition, loaders []domain.Loader) []string {
@@ -134,52 +119,55 @@ func legacyProjectWorkspaceNames(configs []domain.WorkspaceConfig) map[string]st
 	return names
 }
 
-func mapLegacyWorkspaceConfig(config *appconfig.Config, workspace domain.WorkspaceConfig) (compose.WorkspaceSpec, bool, error) {
+func mapLegacyWorkspaceConfig(config *appconfig.Config, workspace domain.WorkspaceConfig) (compose.WorkspaceSpec, error) {
 	switch strings.ToLower(strings.TrimSpace(workspace.Type)) {
 	case "git":
 		var legacy workspaces.GitWorkspaceConfig
 		if err := json.Unmarshal([]byte(workspace.ConfigJSON), &legacy); err != nil {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("decode legacy git workspace preset %s: %w", workspace.ID, err)
+			return compose.WorkspaceSpec{}, fmt.Errorf("decode legacy git workspace preset %s: %w", workspace.ID, err)
 		}
 		if strings.TrimSpace(legacy.Commit) != "" {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy git workspace preset %s pins commit %s, which cannot be mapped to a v2 workspace branch", workspace.ID, legacy.Commit)
+			return compose.WorkspaceSpec{}, fmt.Errorf("legacy git workspace preset %s pins commit %s, which cannot be mapped to a v2 workspace branch", workspace.ID, legacy.Commit)
 		}
 		cloneTarget, err := workspaces.NormalizeGitCloneTarget(workspace.ID, legacy.CloneTarget)
 		if err != nil {
-			return compose.WorkspaceSpec{}, false, err
+			return compose.WorkspaceSpec{}, err
 		}
 		cloneURL := workspaces.ApplyGitCredentials(legacy.URL, legacy)
 		if strings.TrimSpace(cloneURL) == "" {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy git workspace preset %s has no url", workspace.ID)
+			return compose.WorkspaceSpec{}, fmt.Errorf("legacy git workspace preset %s has no url", workspace.ID)
 		}
 		return compose.WorkspaceSpec{
 			Provider: "git",
 			URL:      cloneURL,
 			Branch:   strings.TrimSpace(legacy.Branch),
 			Path:     cloneTarget,
-		}, false, nil
+		}, nil
 	case "file":
+		// Keep a valid v2 shape in the returned spec. The synthetic-project
+		// artifact boundary recognizes this canonical storage path and restores
+		// the original preset ID instead of treating DATA_ROOT as project source.
 		if config == nil || strings.TrimSpace(config.DataRoot) == "" {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("map legacy file workspace preset %s: data root is required", workspace.ID)
+			return compose.WorkspaceSpec{}, fmt.Errorf("map legacy file workspace preset %s: data root is required", workspace.ID)
 		}
 		root, err := workspaces.FileWorkspaceContentRoot(config, workspace)
 		if err != nil {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("map legacy file workspace preset %s: %w", workspace.ID, err)
+			return compose.WorkspaceSpec{}, fmt.Errorf("map legacy file workspace preset %s: %w", workspace.ID, err)
 		}
 		dataRoot, err := filepath.Abs(config.DataRoot)
 		if err != nil {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("resolve data root for legacy file workspace preset %s: %w", workspace.ID, err)
+			return compose.WorkspaceSpec{}, fmt.Errorf("resolve data root for legacy file workspace preset %s: %w", workspace.ID, err)
 		}
 		relative, err := filepath.Rel(filepath.Clean(dataRoot), filepath.Clean(root))
 		if err != nil {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("map legacy file workspace preset %s path: %w", workspace.ID, err)
+			return compose.WorkspaceSpec{}, fmt.Errorf("map legacy file workspace preset %s path: %w", workspace.ID, err)
 		}
 		if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-			return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy file workspace preset %s content is outside the data root", workspace.ID)
+			return compose.WorkspaceSpec{}, fmt.Errorf("legacy file workspace preset %s content is outside the data root", workspace.ID)
 		}
-		return compose.WorkspaceSpec{Provider: "local", Path: filepath.ToSlash(relative)}, true, nil
+		return compose.WorkspaceSpec{Provider: "local", Path: filepath.ToSlash(relative)}, nil
 	default:
-		return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy workspace preset %s has unsupported type %q", workspace.ID, workspace.Type)
+		return compose.WorkspaceSpec{}, fmt.Errorf("legacy workspace preset %s has unsupported type %q", workspace.ID, workspace.Type)
 	}
 }
 
@@ -196,7 +184,7 @@ func (p legacyWorkspaceProjection) reference(workspaceID string) (*compose.Works
 }
 
 func removeImplicitLegacyWorkspaceDefault(spec *compose.NormalizedProjectSpec) {
-	if spec == nil || len(spec.Workspaces) != 1 {
+	if spec == nil || len(spec.Workspaces) == 0 {
 		return
 	}
 	hasWorkspaceLessAgent := false

--- a/pkg/projects/legacy_workspace_migration.go
+++ b/pkg/projects/legacy_workspace_migration.go
@@ -1,0 +1,225 @@
+package projects
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"agent-compose/pkg/compose"
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/identity"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/workspaces"
+)
+
+type legacyWorkspaceConfigStore interface {
+	GetWorkspaceConfig(context.Context, string) (domain.WorkspaceConfig, error)
+}
+
+type legacyWorkspaceProjection struct {
+	workspaces map[string]compose.WorkspaceSpec
+	nameByID   map[string]string
+	sourcePath string
+}
+
+func (c *Controller) loadLegacyWorkspaceProjection(ctx context.Context, agents []domain.AgentDefinition, loaders []domain.Loader) (legacyWorkspaceProjection, error) {
+	workspaceIDs := legacyReferencedWorkspaceIDs(agents, loaders)
+	if len(workspaceIDs) == 0 {
+		return legacyWorkspaceProjection{}, nil
+	}
+	if c == nil || c.store == nil {
+		return legacyWorkspaceProjection{}, fmt.Errorf("sync legacy default project: config store is required")
+	}
+	store, ok := c.store.(legacyWorkspaceConfigStore)
+	if !ok {
+		return legacyWorkspaceProjection{}, fmt.Errorf("sync legacy default project: workspace config store is required")
+	}
+
+	configs := make([]domain.WorkspaceConfig, 0, len(workspaceIDs))
+	for _, workspaceID := range workspaceIDs {
+		config, err := store.GetWorkspaceConfig(ctx, workspaceID)
+		if err != nil {
+			return legacyWorkspaceProjection{}, fmt.Errorf("load legacy workspace preset %s: %w", workspaceID, err)
+		}
+		configs = append(configs, config)
+	}
+
+	nameByID := legacyProjectWorkspaceNames(configs)
+	projectWorkspaces := make(map[string]compose.WorkspaceSpec, len(configs))
+	usesLocalWorkspace := false
+	for _, config := range configs {
+		workspace, local, err := mapLegacyWorkspaceConfig(c.config, config)
+		if err != nil {
+			return legacyWorkspaceProjection{}, err
+		}
+		projectWorkspaces[nameByID[config.ID]] = workspace
+		usesLocalWorkspace = usesLocalWorkspace || local
+	}
+
+	projection := legacyWorkspaceProjection{workspaces: projectWorkspaces, nameByID: nameByID}
+	if usesLocalWorkspace {
+		if c.config == nil || strings.TrimSpace(c.config.DataRoot) == "" {
+			return legacyWorkspaceProjection{}, fmt.Errorf("map legacy file workspace presets: data root is required")
+		}
+		root, err := filepath.Abs(c.config.DataRoot)
+		if err != nil {
+			return legacyWorkspaceProjection{}, fmt.Errorf("resolve legacy workspace source root: %w", err)
+		}
+		projection.sourcePath = filepath.Clean(root)
+	}
+	return projection, nil
+}
+
+func legacyReferencedWorkspaceIDs(agents []domain.AgentDefinition, loaders []domain.Loader) []string {
+	seen := make(map[string]struct{}, len(agents)+len(loaders))
+	for _, agent := range agents {
+		if workspaceID := strings.TrimSpace(agent.WorkspaceID); workspaceID != "" {
+			seen[workspaceID] = struct{}{}
+		}
+	}
+	for _, loader := range loaders {
+		if workspaceID := strings.TrimSpace(loader.Summary.WorkspaceID); workspaceID != "" {
+			seen[workspaceID] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(seen))
+	for workspaceID := range seen {
+		ids = append(ids, workspaceID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func legacyProjectWorkspaceNames(configs []domain.WorkspaceConfig) map[string]string {
+	configs = append([]domain.WorkspaceConfig(nil), configs...)
+	sort.Slice(configs, func(i, j int) bool {
+		if configs[i].Name == configs[j].Name {
+			return configs[i].ID < configs[j].ID
+		}
+		return configs[i].Name < configs[j].Name
+	})
+
+	bases := make(map[string]string, len(configs))
+	counts := make(map[string]int, len(configs))
+	for _, config := range configs {
+		base := legacyCanonicalAgentName(config.Name)
+		bases[config.ID] = base
+		if base != "" {
+			counts[base]++
+		}
+	}
+
+	names := make(map[string]string, len(configs))
+	used := make(map[string]struct{}, len(configs))
+	for _, config := range configs {
+		base := bases[config.ID]
+		if base != "" && counts[base] == 1 {
+			names[config.ID] = base
+			used[base] = struct{}{}
+		}
+	}
+	for _, config := range configs {
+		if names[config.ID] != "" {
+			continue
+		}
+		prefix := bases[config.ID]
+		if prefix == "" {
+			prefix = "legacy-workspace"
+		}
+		names[config.ID] = reserveLegacyStableName(prefix, identity.ResourceWorkspace, config.ID, config.Name, used)
+	}
+	return names
+}
+
+func mapLegacyWorkspaceConfig(config *appconfig.Config, workspace domain.WorkspaceConfig) (compose.WorkspaceSpec, bool, error) {
+	switch strings.ToLower(strings.TrimSpace(workspace.Type)) {
+	case "git":
+		var legacy workspaces.GitWorkspaceConfig
+		if err := json.Unmarshal([]byte(workspace.ConfigJSON), &legacy); err != nil {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("decode legacy git workspace preset %s: %w", workspace.ID, err)
+		}
+		if strings.TrimSpace(legacy.Commit) != "" {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy git workspace preset %s pins commit %s, which cannot be mapped to a v2 workspace branch", workspace.ID, legacy.Commit)
+		}
+		cloneTarget, err := workspaces.NormalizeGitCloneTarget(workspace.ID, legacy.CloneTarget)
+		if err != nil {
+			return compose.WorkspaceSpec{}, false, err
+		}
+		cloneURL := workspaces.ApplyGitCredentials(legacy.URL, legacy)
+		if strings.TrimSpace(cloneURL) == "" {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy git workspace preset %s has no url", workspace.ID)
+		}
+		return compose.WorkspaceSpec{
+			Provider: "git",
+			URL:      cloneURL,
+			Branch:   strings.TrimSpace(legacy.Branch),
+			Path:     cloneTarget,
+		}, false, nil
+	case "file":
+		if config == nil || strings.TrimSpace(config.DataRoot) == "" {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("map legacy file workspace preset %s: data root is required", workspace.ID)
+		}
+		root, err := workspaces.FileWorkspaceContentRoot(config, workspace)
+		if err != nil {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("map legacy file workspace preset %s: %w", workspace.ID, err)
+		}
+		dataRoot, err := filepath.Abs(config.DataRoot)
+		if err != nil {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("resolve data root for legacy file workspace preset %s: %w", workspace.ID, err)
+		}
+		relative, err := filepath.Rel(filepath.Clean(dataRoot), filepath.Clean(root))
+		if err != nil {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("map legacy file workspace preset %s path: %w", workspace.ID, err)
+		}
+		if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy file workspace preset %s content is outside the data root", workspace.ID)
+		}
+		return compose.WorkspaceSpec{Provider: "local", Path: filepath.ToSlash(relative)}, true, nil
+	default:
+		return compose.WorkspaceSpec{}, false, fmt.Errorf("legacy workspace preset %s has unsupported type %q", workspace.ID, workspace.Type)
+	}
+}
+
+func (p legacyWorkspaceProjection) reference(workspaceID string) (*compose.WorkspaceSpec, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return nil, nil
+	}
+	name := strings.TrimSpace(p.nameByID[workspaceID])
+	if name == "" {
+		return nil, fmt.Errorf("legacy workspace preset %s was not loaded for project migration", workspaceID)
+	}
+	return &compose.WorkspaceSpec{Name: name}, nil
+}
+
+func removeImplicitLegacyWorkspaceDefault(spec *compose.NormalizedProjectSpec) {
+	if spec == nil || len(spec.Workspaces) != 1 {
+		return
+	}
+	hasWorkspaceLessAgent := false
+	for _, agent := range spec.Agents {
+		if agent.Workspace == nil {
+			hasWorkspaceLessAgent = true
+			break
+		}
+	}
+	if !hasWorkspaceLessAgent {
+		return
+	}
+	for index := range spec.Agents {
+		workspace := spec.Agents[index].Workspace
+		if workspace == nil {
+			continue
+		}
+		mapped, ok := spec.Workspaces[strings.TrimSpace(workspace.Name)]
+		if !ok {
+			continue
+		}
+		mapped.Name = ""
+		spec.Agents[index].Workspace = &mapped
+	}
+	spec.Workspaces = nil
+}

--- a/pkg/projects/legacy_workspace_migration_test.go
+++ b/pkg/projects/legacy_workspace_migration_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
 	t.Run("git", func(t *testing.T) {
-		workspace, local, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
+		workspace, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
 			ID:   "git-workspace",
 			Type: "git",
 			ConfigJSON: `{
@@ -26,8 +26,8 @@ func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("mapLegacyWorkspaceConfig returned error: %v", err)
 		}
-		if local || workspace.Provider != "git" || workspace.URL != "https://user:token@example.test/team/repo.git" || workspace.Branch != "main" || workspace.Path != "source" {
-			t.Fatalf("mapped git workspace = %#v, local = %v", workspace, local)
+		if workspace.Provider != "git" || workspace.URL != "https://user:token@example.test/team/repo.git" || workspace.Branch != "main" || workspace.Path != "source" {
+			t.Fatalf("mapped git workspace = %#v", workspace)
 		}
 	})
 
@@ -35,7 +35,7 @@ func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
 		root := t.TempDir()
 		config := &appconfig.Config{DataRoot: root}
 		workspaceID := "file-workspace"
-		workspace, local, err := mapLegacyWorkspaceConfig(config, domain.WorkspaceConfig{
+		workspace, err := mapLegacyWorkspaceConfig(config, domain.WorkspaceConfig{
 			ID:         workspaceID,
 			Type:       "file",
 			ConfigJSON: workspaces.DefaultFileConfigJSON(config, workspaceID),
@@ -44,14 +44,14 @@ func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
 			t.Fatalf("mapLegacyWorkspaceConfig returned error: %v", err)
 		}
 		wantPath := filepath.ToSlash(filepath.Join("workspaces", workspaceID, workspaces.FileWorkspaceContentDirName))
-		if !local || workspace.Provider != "local" || workspace.Path != wantPath {
-			t.Fatalf("mapped file workspace = %#v, local = %v, want path %q", workspace, local, wantPath)
+		if workspace.Provider != "local" || workspace.Path != wantPath {
+			t.Fatalf("mapped file workspace = %#v, want path %q", workspace, wantPath)
 		}
 	})
 }
 
 func TestMapLegacyWorkspaceConfigRejectsUnrepresentableCommit(t *testing.T) {
-	_, _, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
+	_, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
 		ID:         "git-workspace",
 		Type:       "git",
 		ConfigJSON: `{"url":"https://example.test/repo.git","commit":"abc123"}`,
@@ -167,5 +167,90 @@ func TestLegacySingleWorkspaceDoesNotBecomeDefaultForUnassignedAgents(t *testing
 	withoutWorkspace := findLegacyProjectAgent(t, project, "without-workspace")
 	if withWorkspace.Workspace == nil || withWorkspace.Workspace.Provider != "git" || withoutWorkspace.Workspace != nil {
 		t.Fatalf("projected workspaces = with %#v, without %#v", withWorkspace.Workspace, withoutWorkspace.Workspace)
+	}
+}
+
+func TestLegacyMultipleWorkspacesRemainReapplicableWithUnassignedAgent(t *testing.T) {
+	projection := legacyWorkspaceProjection{
+		workspaces: map[string]compose.WorkspaceSpec{
+			"source": {Provider: "git", URL: "https://example.test/source.git", Path: "."},
+			"tasks":  {Provider: "git", URL: "https://example.test/tasks.git", Path: "."},
+		},
+		nameByID: map[string]string{
+			"workspace-source": "source",
+			"workspace-tasks":  "tasks",
+		},
+	}
+	agents := []domain.AgentDefinition{
+		{ID: "agent-source", Name: "source-agent", Enabled: true, Provider: "codex", WorkspaceID: "workspace-source"},
+		{ID: "agent-tasks", Name: "tasks-agent", Enabled: true, Provider: "codex", WorkspaceID: "workspace-tasks"},
+		{ID: "agent-empty", Name: "empty-agent", Enabled: true, Provider: "codex"},
+	}
+
+	project, err := legacyDefaultNormalizedProjectWithWorkspaces(agents, nil, projection)
+	if err != nil {
+		t.Fatalf("legacyDefaultNormalizedProjectWithWorkspaces returned error: %v", err)
+	}
+	if len(project.Spec.Workspaces) != 0 {
+		t.Fatalf("project workspaces must be inlined when an agent has no workspace: %#v", project.Spec.Workspaces)
+	}
+	if findLegacyProjectAgent(t, project, "empty-agent").Workspace != nil {
+		t.Fatalf("workspace-less agent gained a workspace")
+	}
+	for _, name := range []string{"source-agent", "tasks-agent"} {
+		workspace := findLegacyProjectAgent(t, project, name).Workspace
+		if workspace == nil || workspace.Provider != "git" || workspace.Name != "" {
+			t.Fatalf("agent %s workspace was not inlined: %#v", name, workspace)
+		}
+	}
+
+	reapplied := &compose.ProjectSpec{
+		Name:       project.Spec.Name,
+		Workspaces: project.Spec.Workspaces,
+		Agents:     make(map[string]compose.AgentSpec, len(project.Spec.Agents)),
+	}
+	for _, agent := range project.Spec.Agents {
+		reapplied.Agents[agent.Name] = compose.AgentSpec{Provider: agent.Provider, Workspace: agent.Workspace}
+	}
+	if _, err := compose.Normalize(reapplied, compose.NormalizeOptions{}); err != nil {
+		t.Fatalf("reapply migrated spec: %v", err)
+	}
+}
+
+func TestLegacyLoaderWorkspaceDoesNotOverwriteWorkspaceLessSourceAgent(t *testing.T) {
+	projection := legacyWorkspaceProjection{
+		workspaces: map[string]compose.WorkspaceSpec{
+			"tasks": {Provider: "git", URL: "https://example.test/tasks.git", Path: "."},
+		},
+		nameByID: map[string]string{"workspace-tasks": "tasks"},
+	}
+	agents := []domain.AgentDefinition{{ID: "agent-1", Name: "worker", Enabled: true, Provider: "codex"}}
+	loaders := []domain.Loader{{
+		Summary: domain.LoaderSummary{
+			ID: "loader-1", Name: "task", Enabled: true, Runtime: domain.LoaderRuntimeScheduler,
+			AgentID: "agent-1", WorkspaceID: "workspace-tasks",
+		},
+		Script: "scheduler.interval('task', function task() {}, 60000);",
+	}}
+
+	project, err := legacyDefaultNormalizedProjectWithWorkspaces(agents, loaders, projection)
+	if err != nil {
+		t.Fatalf("legacyDefaultNormalizedProjectWithWorkspaces returned error: %v", err)
+	}
+	source := findLegacyProjectAgent(t, project, "worker")
+	if source.Workspace != nil || source.Scheduler != nil {
+		t.Fatalf("source agent changed by loader workspace: %#v", source)
+	}
+	if len(project.Spec.Agents) != 2 {
+		t.Fatalf("project agents = %#v, want source and compatibility loader agent", project.Spec.Agents)
+	}
+	var scheduled compose.NormalizedAgentSpec
+	for _, agent := range project.Spec.Agents {
+		if agent.Scheduler != nil {
+			scheduled = agent
+		}
+	}
+	if scheduled.Workspace == nil || scheduled.Workspace.Provider != "git" || scheduled.Workspace.Path != "." {
+		t.Fatalf("compatibility loader agent workspace = %#v", scheduled.Workspace)
 	}
 }

--- a/pkg/projects/legacy_workspace_migration_test.go
+++ b/pkg/projects/legacy_workspace_migration_test.go
@@ -2,7 +2,6 @@ package projects
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"agent-compose/pkg/compose"
@@ -19,6 +18,7 @@ func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
 			ConfigJSON: `{
 				"url":"https://example.test/team/repo.git",
 				"branch":"main",
+				"commit":"abc123",
 				"credential":"user:token",
 				"path":"source"
 			}`,
@@ -26,7 +26,7 @@ func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("mapLegacyWorkspaceConfig returned error: %v", err)
 		}
-		if workspace.Provider != "git" || workspace.URL != "https://user:token@example.test/team/repo.git" || workspace.Branch != "main" || workspace.Path != "source" {
+		if workspace.Provider != "git" || workspace.URL != "https://user:token@example.test/team/repo.git" || workspace.Branch != "main" || workspace.Commit != "abc123" || workspace.Path != "source" {
 			t.Fatalf("mapped git workspace = %#v", workspace)
 		}
 	})
@@ -50,14 +50,17 @@ func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
 	})
 }
 
-func TestMapLegacyWorkspaceConfigRejectsUnrepresentableCommit(t *testing.T) {
-	_, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
+func TestMapLegacyWorkspaceConfigPreservesCommitPin(t *testing.T) {
+	workspace, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
 		ID:         "git-workspace",
 		Type:       "git",
 		ConfigJSON: `{"url":"https://example.test/repo.git","commit":"abc123"}`,
 	})
-	if err == nil || !strings.Contains(err.Error(), "pins commit") {
-		t.Fatalf("mapLegacyWorkspaceConfig error = %v", err)
+	if err != nil {
+		t.Fatalf("mapLegacyWorkspaceConfig returned error: %v", err)
+	}
+	if workspace.Commit != "abc123" {
+		t.Fatalf("mapped commit = %q, want abc123", workspace.Commit)
 	}
 }
 

--- a/pkg/projects/legacy_workspace_migration_test.go
+++ b/pkg/projects/legacy_workspace_migration_test.go
@@ -1,0 +1,171 @@
+package projects
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"agent-compose/pkg/compose"
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/workspaces"
+)
+
+func TestMapLegacyWorkspaceConfigToExistingV2Shapes(t *testing.T) {
+	t.Run("git", func(t *testing.T) {
+		workspace, local, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
+			ID:   "git-workspace",
+			Type: "git",
+			ConfigJSON: `{
+				"url":"https://example.test/team/repo.git",
+				"branch":"main",
+				"credential":"user:token",
+				"path":"source"
+			}`,
+		})
+		if err != nil {
+			t.Fatalf("mapLegacyWorkspaceConfig returned error: %v", err)
+		}
+		if local || workspace.Provider != "git" || workspace.URL != "https://user:token@example.test/team/repo.git" || workspace.Branch != "main" || workspace.Path != "source" {
+			t.Fatalf("mapped git workspace = %#v, local = %v", workspace, local)
+		}
+	})
+
+	t.Run("file", func(t *testing.T) {
+		root := t.TempDir()
+		config := &appconfig.Config{DataRoot: root}
+		workspaceID := "file-workspace"
+		workspace, local, err := mapLegacyWorkspaceConfig(config, domain.WorkspaceConfig{
+			ID:         workspaceID,
+			Type:       "file",
+			ConfigJSON: workspaces.DefaultFileConfigJSON(config, workspaceID),
+		})
+		if err != nil {
+			t.Fatalf("mapLegacyWorkspaceConfig returned error: %v", err)
+		}
+		wantPath := filepath.ToSlash(filepath.Join("workspaces", workspaceID, workspaces.FileWorkspaceContentDirName))
+		if !local || workspace.Provider != "local" || workspace.Path != wantPath {
+			t.Fatalf("mapped file workspace = %#v, local = %v, want path %q", workspace, local, wantPath)
+		}
+	})
+}
+
+func TestMapLegacyWorkspaceConfigRejectsUnrepresentableCommit(t *testing.T) {
+	_, _, err := mapLegacyWorkspaceConfig(nil, domain.WorkspaceConfig{
+		ID:         "git-workspace",
+		Type:       "git",
+		ConfigJSON: `{"url":"https://example.test/repo.git","commit":"abc123"}`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "pins commit") {
+		t.Fatalf("mapLegacyWorkspaceConfig error = %v", err)
+	}
+}
+
+func TestLegacyDefaultNormalizedProjectMapsNamedWorkspaces(t *testing.T) {
+	projection := legacyWorkspaceProjection{
+		workspaces: map[string]compose.WorkspaceSpec{
+			"source": {Provider: "git", URL: "https://example.test/source.git", Path: "."},
+			"tasks":  {Provider: "git", URL: "https://example.test/tasks.git", Path: "."},
+		},
+		nameByID: map[string]string{
+			"workspace-source": "source",
+			"workspace-tasks":  "tasks",
+		},
+	}
+	agents := []domain.AgentDefinition{{
+		ID:          "agent-1",
+		Name:        "worker",
+		Enabled:     true,
+		Provider:    "codex",
+		WorkspaceID: "workspace-source",
+	}}
+	loaders := []domain.Loader{{
+		Summary: domain.LoaderSummary{
+			ID:          "loader-1",
+			Name:        "task",
+			Enabled:     false,
+			Runtime:     domain.LoaderRuntimeScheduler,
+			AgentID:     "agent-1",
+			WorkspaceID: "workspace-tasks",
+		},
+		Script: "scheduler.interval('task', function task() {}, 60000);",
+	}}
+
+	project, err := legacyDefaultNormalizedProjectWithWorkspaces(agents, loaders, projection)
+	if err != nil {
+		t.Fatalf("legacyDefaultNormalizedProjectWithWorkspaces returned error: %v", err)
+	}
+	if len(project.Spec.Workspaces) != 2 || len(project.Spec.Agents) != 2 {
+		t.Fatalf("project workspaces/agents = %#v/%#v", project.Spec.Workspaces, project.Spec.Agents)
+	}
+	source := findLegacyProjectAgent(t, project, "worker")
+	if source.Workspace == nil || source.Workspace.Name != "source" || source.Scheduler != nil {
+		t.Fatalf("source agent = %#v", source)
+	}
+	var taskAgent compose.NormalizedAgentSpec
+	for _, agent := range project.Spec.Agents {
+		if agent.Scheduler != nil {
+			taskAgent = agent
+		}
+	}
+	if taskAgent.Workspace == nil || taskAgent.Workspace.Name != "tasks" || project.managedLoaderOverrides[taskAgent.Name].Summary.ID != "loader-1" {
+		t.Fatalf("task agent/override = %#v/%#v", taskAgent, project.managedLoaderOverrides)
+	}
+}
+
+func TestLegacyProjectWorkspaceNamesAreStableAndValid(t *testing.T) {
+	configs := []domain.WorkspaceConfig{
+		{ID: "workspace-z", Name: "共享空间"},
+		{ID: "workspace-b", Name: "source"},
+		{ID: "workspace-a", Name: "source"},
+		{ID: "workspace-valid", Name: "review-repo"},
+	}
+	names := legacyProjectWorkspaceNames(configs)
+	if names["workspace-valid"] != "review-repo" {
+		t.Fatalf("valid workspace name = %q", names["workspace-valid"])
+	}
+	seen := make(map[string]struct{}, len(names))
+	for id, name := range names {
+		if !domain.IsProjectStableIdentifier(name) {
+			t.Fatalf("workspace %s mapped to invalid name %q", id, name)
+		}
+		if _, exists := seen[name]; exists {
+			t.Fatalf("duplicate mapped workspace name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+
+	reversed := []domain.WorkspaceConfig{configs[3], configs[2], configs[1], configs[0]}
+	reversedNames := legacyProjectWorkspaceNames(reversed)
+	for id, name := range names {
+		if reversedNames[id] != name {
+			t.Fatalf("workspace %s name depends on input order: %q != %q", id, reversedNames[id], name)
+		}
+	}
+}
+
+func TestLegacySingleWorkspaceDoesNotBecomeDefaultForUnassignedAgents(t *testing.T) {
+	projection := legacyWorkspaceProjection{
+		workspaces: map[string]compose.WorkspaceSpec{
+			"source": {Provider: "git", URL: "https://example.test/source.git", Path: "."},
+		},
+		nameByID: map[string]string{"workspace-source": "source"},
+	}
+	agents := []domain.AgentDefinition{
+		{ID: "agent-with", Name: "with-workspace", Enabled: true, Provider: "codex", WorkspaceID: "workspace-source"},
+		{ID: "agent-without", Name: "without-workspace", Enabled: true, Provider: "codex"},
+	}
+
+	project, err := legacyDefaultNormalizedProjectWithWorkspaces(agents, nil, projection)
+	if err != nil {
+		t.Fatalf("legacyDefaultNormalizedProjectWithWorkspaces returned error: %v", err)
+	}
+	if len(project.Spec.Workspaces) != 0 {
+		t.Fatalf("single global workspace would become an implicit default: %#v", project.Spec.Workspaces)
+	}
+	withWorkspace := findLegacyProjectAgent(t, project, "with-workspace")
+	withoutWorkspace := findLegacyProjectAgent(t, project, "without-workspace")
+	if withWorkspace.Workspace == nil || withWorkspace.Workspace.Provider != "git" || withoutWorkspace.Workspace != nil {
+		t.Fatalf("projected workspaces = with %#v, without %#v", withWorkspace.Workspace, withoutWorkspace.Workspace)
+	}
+}

--- a/pkg/projects/managed_loader_overrides.go
+++ b/pkg/projects/managed_loader_overrides.go
@@ -24,9 +24,7 @@ func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int
 			return nil, fmt.Errorf("legacy loader for agent %s has no id", builds[index].Scheduler.AgentName)
 		}
 
-		loader := loaders.CloneLoader(override)
-		loader.Volumes = append([]domain.VolumeMountSpec(nil), override.Volumes...)
-		loader.Summary.CapsetIDs = append([]string(nil), override.Summary.CapsetIDs...)
+		loader := mergeManagedLoaderOverride(builds[index].Loader, override)
 		loader.Summary.ManagedProjectID = project.ID
 		loader.Summary.ManagedRevision = revision
 		loader.Summary.ManagedAgentName = builds[index].Scheduler.AgentName
@@ -39,6 +37,38 @@ func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int
 		builds[index].ValidationTriggers = append([]domain.LoaderTrigger(nil), loader.Triggers...)
 	}
 	return builds, nil
+}
+
+func mergeManagedLoaderOverride(current, override domain.Loader) domain.Loader {
+	loader := loaders.CloneLoader(current)
+	loader.Summary.ID = override.Summary.ID
+	loader.Summary.AgentID = override.Summary.AgentID
+	loader.Summary.WorkspaceID = override.Summary.WorkspaceID
+	loader.Summary.ConcurrencyPolicy = override.Summary.ConcurrencyPolicy
+	loader.Summary.CreatedAt = override.Summary.CreatedAt
+	loader.Summary.UpdatedAt = override.Summary.UpdatedAt
+	loader.Summary.LastError = override.Summary.LastError
+	loader.Summary.RunCount = override.Summary.RunCount
+	loader.Summary.EventCount = override.Summary.EventCount
+	loader.Summary.LatestRunAt = override.Summary.LatestRunAt
+	loader.Summary.CapsetIDs = append([]string(nil), current.Summary.CapsetIDs...)
+	loader.Volumes = append([]domain.VolumeMountSpec(nil), current.Volumes...)
+
+	previousTriggers := make(map[string]domain.LoaderTrigger, len(override.Triggers))
+	for _, trigger := range override.Triggers {
+		previousTriggers[trigger.ID] = trigger
+	}
+	for index := range loader.Triggers {
+		loader.Triggers[index].LoaderID = loader.Summary.ID
+		previous, ok := previousTriggers[loader.Triggers[index].ID]
+		if !ok {
+			continue
+		}
+		loader.Triggers[index].Enabled = previous.Enabled
+		loader.Triggers[index].NextFireAt = previous.NextFireAt
+		loader.Triggers[index].LastFiredAt = previous.LastFiredAt
+	}
+	return loader
 }
 
 func applyManagedLoaderOverrides(project domain.ProjectRecord, revision int64, schedulers []domain.ProjectSchedulerRecord, managedLoaders []domain.Loader, overrides map[string]domain.Loader) ([]domain.ProjectSchedulerRecord, []domain.Loader, error) {

--- a/pkg/projects/reconcile.go
+++ b/pkg/projects/reconcile.go
@@ -250,7 +250,7 @@ func ManagedAgentDefinitionChangeAction(existing domain.AgentDefinition, found b
 	if !found {
 		return ChangeActionCreated
 	}
-	if !existing.DeletedAt.IsZero() || !existing.Enabled {
+	if !existing.DeletedAt.IsZero() {
 		return ChangeActionUpdated
 	}
 	if ManagedAgentDefinitionUnchanged(existing, current) {

--- a/pkg/projects/records.go
+++ b/pkg/projects/records.go
@@ -109,6 +109,7 @@ func NewAgentDefinitionFromSpec(project domain.ProjectRecord, revision int64, ag
 	return domain.AgentDefinition{
 		ID:                     managedAgentID,
 		Name:                   agent.Name,
+		Description:            agent.Description,
 		Enabled:                agentEnabled(agent),
 		Provider:               agent.Provider,
 		Model:                  agent.Model,
@@ -124,6 +125,13 @@ func NewAgentDefinitionFromSpec(project domain.ProjectRecord, revision int64, ag
 		ManagedProjectRevision: revision,
 		ManagedAgentName:       agent.Name,
 	}, nil
+}
+
+func projectAgentDisplayName(agent compose.NormalizedAgentSpec) string {
+	if displayName := strings.TrimSpace(agent.DisplayName); displayName != "" {
+		return displayName
+	}
+	return strings.TrimSpace(agent.Name)
 }
 
 func agentEnabled(agent compose.NormalizedAgentSpec) bool {
@@ -188,7 +196,8 @@ func NewManagedLoaderFromScheduler(project domain.ProjectRecord, scheduler domai
 	return domain.Loader{
 		Summary: domain.LoaderSummary{
 			ID:                 scheduler.ManagedLoaderID,
-			Name:               fmt.Sprintf("%s/%s scheduler", project.Name, agent.Name),
+			Name:               managedSchedulerDisplayName(project.Name, agent),
+			Description:        strings.TrimSpace(agent.Scheduler.Description),
 			Enabled:            scheduler.Enabled,
 			Runtime:            domain.LoaderRuntimeScheduler,
 			AgentID:            managedAgentID,
@@ -208,6 +217,13 @@ func NewManagedLoaderFromScheduler(project domain.ProjectRecord, scheduler domai
 		EnvItems: SandboxEnvItemsFromCompose(agent.Env),
 		Volumes:  VolumeMountSpecsFromCompose(agent.Volumes),
 	}, nil
+}
+
+func managedSchedulerDisplayName(projectName string, agent compose.NormalizedAgentSpec) string {
+	if displayName := strings.TrimSpace(agent.Scheduler.DisplayName); displayName != "" {
+		return displayName
+	}
+	return fmt.Sprintf("%s/%s scheduler", projectName, agent.Name)
 }
 
 func VolumeMountSpecsFromCompose(values []compose.NormalizedVolumeMountSpec) []domain.VolumeMountSpec {

--- a/pkg/projects/records_test.go
+++ b/pkg/projects/records_test.go
@@ -44,6 +44,24 @@ func TestNewAgentDefinitionFromSpecKeepsEmptyConfigWithoutJupyter(t *testing.T) 
 	}
 }
 
+func TestNewAgentDefinitionFromSpecKeepsStableNameWithPresentationMetadata(t *testing.T) {
+	project := domain.ProjectRecord{ID: "project-1", Name: "project"}
+	agent := compose.NormalizedAgentSpec{
+		Name:        "legacy-agent-bfe5286dc77f",
+		DisplayName: "通用助手",
+		Description: "处理日常通用任务",
+		Provider:    "codex",
+	}
+
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil)
+	if err != nil {
+		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
+	}
+	if definition.Name != agent.Name || definition.Description != "处理日常通用任务" || definition.ManagedAgentName != agent.Name {
+		t.Fatalf("managed agent definition = %#v", definition)
+	}
+}
+
 func TestProjectRecordsCarryVolumeMountSpecs(t *testing.T) {
 	project := domain.ProjectRecord{ID: "project-1", Name: "project"}
 	agent := compose.NormalizedAgentSpec{
@@ -54,7 +72,7 @@ func TestProjectRecordsCarryVolumeMountSpecs(t *testing.T) {
 			{Type: "volume", Source: "cache", Target: "/cache"},
 			{Type: "bind", Source: "./fixtures", Target: "/fixtures", ReadOnly: true},
 		},
-		Scheduler: &compose.NormalizedSchedulerSpec{Enabled: true, Script: "scheduler.agent('hi')"},
+		Scheduler: &compose.NormalizedSchedulerSpec{Enabled: true, DisplayName: "缓存巡检", Description: "检查缓存状态", Script: "scheduler.agent('hi')"},
 	}
 	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil)
 	if err != nil {
@@ -73,6 +91,9 @@ func TestProjectRecordsCarryVolumeMountSpecs(t *testing.T) {
 	}
 	if len(loader.Volumes) != 2 || loader.Volumes[0].Source != "cache" {
 		t.Fatalf("loader volumes = %#v", loader.Volumes)
+	}
+	if loader.Summary.Name != "缓存巡检" || loader.Summary.Description != "检查缓存状态" {
+		t.Fatalf("loader presentation = %#v", loader.Summary)
 	}
 }
 

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -187,8 +187,12 @@ func TestRunsPreparationWorkspaceAndStatusWorkflows(t *testing.T) {
 	if path, err := ResolveLocalProjectWorkspacePath(store.project, "."); err != nil || path == "" {
 		t.Fatalf("ResolveLocalProjectWorkspacePath path=%q err=%v", path, err)
 	}
-	if _, err := projectRunGitWorkspaceConfig(run, &compose.WorkspaceSpec{Provider: "git", URL: "https://example.test/repo.git", Branch: "main", Path: "."}); err != nil {
+	gitConfig, err := projectRunGitWorkspaceConfig(run, &compose.WorkspaceSpec{Provider: "git", URL: "https://example.test/repo.git", Branch: "main", Commit: "abc123", Path: "."})
+	if err != nil {
 		t.Fatalf("projectRunGitWorkspaceConfig returned error: %v", err)
+	}
+	if !strings.Contains(gitConfig.ConfigJSON, `"branch":"main"`) || !strings.Contains(gitConfig.ConfigJSON, `"commit":"abc123"`) {
+		t.Fatalf("git workspace config lost revision fields: %s", gitConfig.ConfigJSON)
 	}
 	if _, err := projectRunGitWorkspaceConfig(run, &compose.WorkspaceSpec{Provider: "git"}); err == nil {
 		t.Fatalf("expected git workspace url error")

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -89,6 +89,15 @@ func PrepareProjectRun(ctx context.Context, store PreparationStore, resolver Wor
 		return Preparation{}, fmt.Errorf("list project volumes %s: %w", project.ID, err)
 	}
 	prepared.ProjectVolumes = projectVolumes
+	legacyWorkspaceConfig, legacyWorkspace, bound, err := prepareLegacyFileWorkspace(ctx, store, project, spec, agentSpec, agent)
+	if err != nil {
+		return Preparation{}, err
+	}
+	if bound {
+		prepared.WorkspaceConfig = legacyWorkspaceConfig
+		prepared.Workspace = legacyWorkspace
+		return prepared, nil
+	}
 	if resolver == nil {
 		return prepared, nil
 	}

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -193,6 +193,7 @@ type canonicalRevisionWorkspace struct {
 	Provider  string                        `json:"provider"`
 	URL       string                        `json:"url"`
 	Branch    string                        `json:"branch"`
+	Commit    string                        `json:"commit"`
 	Path      string                        `json:"path"`
 	Workspace *agentcomposev2.WorkspaceSpec `json:"workspace"`
 }
@@ -220,6 +221,7 @@ func restoreCanonicalProjectWorkspaces(data []byte, spec *agentcomposev2.Project
 		if strings.TrimSpace(workspace.Provider) == "" &&
 			strings.TrimSpace(workspace.URL) == "" &&
 			strings.TrimSpace(workspace.Branch) == "" &&
+			strings.TrimSpace(workspace.Commit) == "" &&
 			strings.TrimSpace(workspace.Path) == "" {
 			continue
 		}
@@ -232,6 +234,7 @@ func restoreCanonicalProjectWorkspaces(data []byte, spec *agentcomposev2.Project
 			Provider: workspace.Provider,
 			Url:      workspace.URL,
 			Branch:   workspace.Branch,
+			Commit:   workspace.Commit,
 			Path:     workspace.Path,
 		}
 	}
@@ -275,6 +278,7 @@ func ComposeWorkspaceSpecFromV2(workspace *agentcomposev2.WorkspaceSpec) *compos
 		Provider: workspace.GetProvider(),
 		URL:      workspace.GetUrl(),
 		Branch:   workspace.GetBranch(),
+		Commit:   workspace.GetCommit(),
 		Path:     workspace.GetPath(),
 	}
 }
@@ -300,7 +304,7 @@ func ProjectRunWorkspaceSpecsFromV2(projectWorkspaces []*agentcomposev2.NamedWor
 	agent := ComposeWorkspaceSpecFromV2(agentWorkspace)
 	if agent != nil {
 		hasName := strings.TrimSpace(agent.Name) != ""
-		hasInline := strings.TrimSpace(agent.Provider) != "" || strings.TrimSpace(agent.URL) != "" || strings.TrimSpace(agent.Branch) != "" || strings.TrimSpace(agent.Path) != ""
+		hasInline := strings.TrimSpace(agent.Provider) != "" || strings.TrimSpace(agent.URL) != "" || strings.TrimSpace(agent.Branch) != "" || strings.TrimSpace(agent.Commit) != "" || strings.TrimSpace(agent.Path) != ""
 		switch {
 		case hasInline:
 			return nil, agent, nil

--- a/pkg/runs/preparation_legacy_workspace.go
+++ b/pkg/runs/preparation_legacy_workspace.go
@@ -1,0 +1,52 @@
+package runs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+type legacyWorkspacePreparationStore interface {
+	GetWorkspaceConfig(context.Context, string) (domain.WorkspaceConfig, error)
+}
+
+// prepareLegacyFileWorkspace restores the v1 uploaded-snapshot binding only
+// for the canonical synthetic project. Git and ordinary v2 workspaces remain
+// on the project workspace resolver path.
+func prepareLegacyFileWorkspace(ctx context.Context, store PreparationStore, project domain.ProjectRecord, spec *agentcomposev2.ProjectSpec, agentSpec *agentcomposev2.AgentSpec, agent domain.AgentDefinition) (*domain.WorkspaceConfig, *domain.SandboxWorkspace, bool, error) {
+	workspaceID := strings.TrimSpace(agent.WorkspaceID)
+	if workspaceID == "" || !projects.IsLegacyDefaultProject(project) {
+		return nil, nil, false, nil
+	}
+	projectWorkspace, agentWorkspace, err := ProjectRunWorkspaceSpecsFromV2(spec.GetWorkspaces(), agentSpec.GetWorkspace())
+	if err != nil {
+		return nil, nil, false, err
+	}
+	effectiveWorkspace := projectWorkspace
+	if agentWorkspace != nil {
+		effectiveWorkspace = agentWorkspace
+	}
+	presetID, ok := projects.LegacyFileWorkspacePresetID(effectiveWorkspace)
+	if !ok {
+		return nil, nil, false, nil
+	}
+	if presetID != workspaceID {
+		return nil, nil, false, fmt.Errorf("legacy file workspace binding mismatch: agent has %s, project spec has %s", workspaceID, presetID)
+	}
+	workspaceStore, ok := store.(legacyWorkspacePreparationStore)
+	if !ok {
+		return nil, nil, false, fmt.Errorf("legacy file workspace config store is required")
+	}
+	workspace, err := workspaceStore.GetWorkspaceConfig(ctx, workspaceID)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("resolve managed legacy file workspace %s: %w", workspaceID, err)
+	}
+	if strings.ToLower(strings.TrimSpace(workspace.Type)) != "file" {
+		return nil, nil, false, fmt.Errorf("managed legacy workspace %s type is %q, want file", workspaceID, workspace.Type)
+	}
+	return &workspace, toSandboxWorkspaceSnapshot(workspace), true, nil
+}

--- a/pkg/runs/preparation_legacy_workspace_test.go
+++ b/pkg/runs/preparation_legacy_workspace_test.go
@@ -1,0 +1,163 @@
+package runs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"agent-compose/pkg/compose"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+)
+
+func TestPrepareProjectRunReusesManagedAgentWorkspacePreset(t *testing.T) {
+	projectID, err := domain.StableProjectID(projects.LegacyDefaultProjectName, "")
+	if err != nil {
+		t.Fatalf("StableProjectID returned error: %v", err)
+	}
+	workspace := domain.WorkspaceConfig{
+		ID:         "legacy-file",
+		Name:       "Uploaded files",
+		Type:       "file",
+		ConfigJSON: `{"root":"/data/workspaces/legacy-file/content"}`,
+	}
+	store := &legacyWorkspacePreparationStoreStub{
+		project: domain.ProjectRecord{ID: projectID, Name: projects.LegacyDefaultProjectName},
+		revision: domain.ProjectRevisionRecord{
+			ProjectID: projectID,
+			Revision:  1,
+			SpecJSON:  `{"name":"legacy-v1-default","agents":[{"name":"worker","workspace":{"provider":"local","path":"workspaces/legacy-file/content"}}]}`,
+		},
+		agent:     domain.AgentDefinition{ID: "managed-agent", WorkspaceID: workspace.ID},
+		workspace: workspace,
+	}
+	resolver := &recordingPreparationWorkspaceResolver{}
+	prepared, err := PrepareProjectRun(context.Background(), store, resolver, domain.ProjectRunRecord{
+		RunID:           "run-1",
+		ProjectID:       store.project.ID,
+		ProjectRevision: store.revision.Revision,
+		AgentName:       "worker",
+		ManagedAgentID:  store.agent.ID,
+	}, nil)
+	if err != nil {
+		t.Fatalf("PrepareProjectRun returned error: %v", err)
+	}
+	if resolver.called {
+		t.Fatal("v2 workspace resolver was called for a persisted legacy preset binding")
+	}
+	if store.workspaceCalls != 1 {
+		t.Fatalf("workspace config calls = %d, want 1", store.workspaceCalls)
+	}
+	if prepared.WorkspaceConfig == nil || prepared.WorkspaceConfig.ID != workspace.ID {
+		t.Fatalf("prepared workspace config = %#v", prepared.WorkspaceConfig)
+	}
+	if prepared.Workspace == nil || prepared.Workspace.ID != workspace.ID || prepared.Workspace.ConfigJSON != workspace.ConfigJSON {
+		t.Fatalf("prepared workspace snapshot = %#v", prepared.Workspace)
+	}
+}
+
+func TestPrepareProjectRunKeepsGitAndOrdinaryV2OnWorkspaceResolver(t *testing.T) {
+	legacyProjectID, err := domain.StableProjectID(projects.LegacyDefaultProjectName, "")
+	if err != nil {
+		t.Fatalf("StableProjectID returned error: %v", err)
+	}
+	tests := []struct {
+		name      string
+		project   domain.ProjectRecord
+		specJSON  string
+		workspace domain.WorkspaceConfig
+	}{
+		{
+			name:      "legacy git workspace",
+			project:   domain.ProjectRecord{ID: legacyProjectID, Name: projects.LegacyDefaultProjectName},
+			specJSON:  `{"name":"legacy-v1-default","agents":[{"name":"worker","workspace":{"provider":"git","url":"https://example.test/repo.git","branch":"main","path":"."}}]}`,
+			workspace: domain.WorkspaceConfig{ID: "legacy-git", Type: "git", ConfigJSON: `{"url":"https://example.test/repo.git"}`},
+		},
+		{
+			name:      "ordinary v2 local workspace",
+			project:   domain.ProjectRecord{ID: "project-1", Name: "project", SourcePath: "/project/source"},
+			specJSON:  `{"name":"project","agents":[{"name":"worker","workspace":{"provider":"local","path":"workspaces/legacy-file/content"}}]}`,
+			workspace: domain.WorkspaceConfig{ID: "legacy-file", Type: "file", ConfigJSON: `{}`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &legacyWorkspacePreparationStoreStub{
+				project: tt.project,
+				revision: domain.ProjectRevisionRecord{
+					ProjectID: tt.project.ID,
+					Revision:  1,
+					SpecJSON:  tt.specJSON,
+				},
+				agent:     domain.AgentDefinition{ID: "managed-agent", WorkspaceID: tt.workspace.ID},
+				workspace: tt.workspace,
+			}
+			resolver := &recordingPreparationWorkspaceResolver{}
+			_, err := PrepareProjectRun(context.Background(), store, resolver, domain.ProjectRunRecord{
+				RunID:           "run-1",
+				ProjectID:       tt.project.ID,
+				ProjectRevision: 1,
+				AgentName:       "worker",
+				ManagedAgentID:  store.agent.ID,
+			}, nil)
+			if err != nil {
+				t.Fatalf("PrepareProjectRun returned error: %v", err)
+			}
+			if !resolver.called {
+				t.Fatal("v2 workspace resolver was not called")
+			}
+			if store.workspaceCalls != 0 {
+				t.Fatalf("legacy workspace config calls = %d, want 0", store.workspaceCalls)
+			}
+		})
+	}
+}
+
+type legacyWorkspacePreparationStoreStub struct {
+	project        domain.ProjectRecord
+	revision       domain.ProjectRevisionRecord
+	agent          domain.AgentDefinition
+	workspace      domain.WorkspaceConfig
+	workspaceCalls int
+}
+
+func (s *legacyWorkspacePreparationStoreStub) GetProject(context.Context, string) (domain.ProjectRecord, error) {
+	return s.project, nil
+}
+
+func (s *legacyWorkspacePreparationStoreStub) GetProjectRevision(context.Context, string, int64) (domain.ProjectRevisionRecord, error) {
+	return s.revision, nil
+}
+
+func (s *legacyWorkspacePreparationStoreStub) GetAgentDefinition(context.Context, string) (domain.AgentDefinition, error) {
+	return s.agent, nil
+}
+
+func (s *legacyWorkspacePreparationStoreStub) GetWorkspaceConfig(_ context.Context, id string) (domain.WorkspaceConfig, error) {
+	s.workspaceCalls++
+	if id != s.workspace.ID {
+		return domain.WorkspaceConfig{}, fmt.Errorf("workspace %s not found", id)
+	}
+	return s.workspace, nil
+}
+
+func (s *legacyWorkspacePreparationStoreStub) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
+	return nil, nil
+}
+
+func (s *legacyWorkspacePreparationStoreStub) ListProjectVolumes(context.Context, string) (map[string]domain.VolumeRecord, error) {
+	return nil, nil
+}
+
+type recordingPreparationWorkspaceResolver struct {
+	called bool
+}
+
+func (r *recordingPreparationWorkspaceResolver) ResolveProjectRunWorkspace(context.Context, domain.ProjectRunRecord, domain.ProjectRecord, *compose.WorkspaceSpec, *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SandboxWorkspace, error) {
+	r.called = true
+	return nil, nil, nil
+}
+
+var _ WorkspaceResolver = (*recordingPreparationWorkspaceResolver)(nil)
+var _ PreparationStore = (*legacyWorkspacePreparationStoreStub)(nil)
+var _ legacyWorkspacePreparationStore = (*legacyWorkspacePreparationStoreStub)(nil)

--- a/pkg/runs/preparation_workspace_compat_test.go
+++ b/pkg/runs/preparation_workspace_compat_test.go
@@ -29,19 +29,41 @@ func TestDecodeRevisionSpecSupportsCanonicalWorkspaceShape(t *testing.T) {
 	}
 }
 
+func TestDecodeRevisionSpecSupportsCanonicalGitCommitShape(t *testing.T) {
+	decoded, err := DecodeRevisionSpec(`{
+		"name":"workspace-project",
+		"workspaces":[{
+			"key":"repo-root",
+			"provider":"git",
+			"url":"https://example.test/repo.git",
+			"branch":"main",
+			"commit":"abc123",
+			"path":"."
+		}],
+		"agents":[{"name":"reviewer"}]
+	}`)
+	if err != nil {
+		t.Fatalf("DecodeRevisionSpec returned error: %v", err)
+	}
+	workspace := decoded.GetWorkspaces()[0].GetWorkspace()
+	if workspace.GetBranch() != "main" || workspace.GetCommit() != "abc123" {
+		t.Fatalf("canonical git workspace = %#v", workspace)
+	}
+}
+
 func TestDecodeRevisionSpecPreservesNestedWorkspaceShape(t *testing.T) {
 	decoded, err := DecodeRevisionSpec(`{
 		"name":"workspace-project",
 		"workspaces":[{
 			"name":"repo-root",
-			"workspace":{"provider":"git","url":"https://example.test/repo.git","branch":"main"}
+			"workspace":{"provider":"git","url":"https://example.test/repo.git","branch":"main","commit":"abc123"}
 		}]
 	}`)
 	if err != nil {
 		t.Fatalf("DecodeRevisionSpec returned error: %v", err)
 	}
 	workspace := decoded.GetWorkspaces()[0]
-	if workspace.GetName() != "repo-root" || workspace.GetWorkspace().GetProvider() != "git" || workspace.GetWorkspace().GetUrl() != "https://example.test/repo.git" || workspace.GetWorkspace().GetBranch() != "main" {
+	if workspace.GetName() != "repo-root" || workspace.GetWorkspace().GetProvider() != "git" || workspace.GetWorkspace().GetUrl() != "https://example.test/repo.git" || workspace.GetWorkspace().GetBranch() != "main" || workspace.GetWorkspace().GetCommit() != "abc123" {
 		t.Fatalf("workspace = %#v", workspace)
 	}
 }

--- a/pkg/runs/workspace.go
+++ b/pkg/runs/workspace.go
@@ -106,6 +106,7 @@ func projectRunGitWorkspaceConfig(run domain.ProjectRunRecord, workspace *compos
 	payload, err := json.Marshal(workspaces.GitWorkspaceConfig{
 		URL:         strings.TrimSpace(workspace.URL),
 		Branch:      strings.TrimSpace(workspace.Branch),
+		Commit:      strings.TrimSpace(workspace.Commit),
 		CloneTarget: strings.TrimSpace(workspace.Path),
 	})
 	if err != nil {

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -4595,6 +4595,7 @@ type WorkspaceSpec struct {
 	Branch        string                 `protobuf:"bytes,3,opt,name=branch,proto3" json:"branch,omitempty"`
 	Path          string                 `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`
 	Name          string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	Commit        string                 `protobuf:"bytes,6,opt,name=commit,proto3" json:"commit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4660,6 +4661,13 @@ func (x *WorkspaceSpec) GetPath() string {
 func (x *WorkspaceSpec) GetName() string {
 	if x != nil {
 		return x.Name
+	}
+	return ""
+}
+
+func (x *WorkspaceSpec) GetCommit() string {
+	if x != nil {
+		return x.Commit
 	}
 	return ""
 }
@@ -15976,13 +15984,14 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x19\n" +
 	"\x05value\x18\x02 \x01(\tH\x00R\x05value\x88\x01\x01\x12\x16\n" +
 	"\x06secret\x18\x03 \x01(\bR\x06secretB\b\n" +
-	"\x06_value\"}\n" +
+	"\x06_value\"\x95\x01\n" +
 	"\rWorkspaceSpec\x12\x1a\n" +
 	"\bprovider\x18\x01 \x01(\tR\bprovider\x12\x10\n" +
 	"\x03url\x18\x02 \x01(\tR\x03url\x12\x16\n" +
 	"\x06branch\x18\x03 \x01(\tR\x06branch\x12\x12\n" +
 	"\x04path\x18\x04 \x01(\tR\x04path\x12\x12\n" +
-	"\x04name\x18\x05 \x01(\tR\x04name\"!\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\x12\x16\n" +
+	"\x06commit\x18\x06 \x01(\tR\x06commit\"!\n" +
 	"\vNetworkSpec\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\"\xe7\x01\n" +
 	"\rSchedulerSpec\x12\x18\n" +

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -2419,6 +2419,8 @@ type ProjectAgent struct {
 	Health           ProjectAgentHealth       `protobuf:"varint,11,opt,name=health,proto3,enum=agentcompose.v2.ProjectAgentHealth" json:"health,omitempty"`
 	CurrentRun       *ProjectAgentCurrentRun  `protobuf:"bytes,12,opt,name=current_run,json=currentRun,proto3" json:"current_run,omitempty"`
 	LatestRun        *ProjectAgentLatestRun   `protobuf:"bytes,13,opt,name=latest_run,json=latestRun,proto3" json:"latest_run,omitempty"`
+	DisplayName      string                   `protobuf:"bytes,14,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description      string                   `protobuf:"bytes,15,opt,name=description,proto3" json:"description,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -2542,6 +2544,20 @@ func (x *ProjectAgent) GetLatestRun() *ProjectAgentLatestRun {
 		return x.LatestRun
 	}
 	return nil
+}
+
+func (x *ProjectAgent) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *ProjectAgent) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
 }
 
 type ProjectAgentCurrentRun struct {
@@ -2679,6 +2695,8 @@ type ProjectScheduler struct {
 	SchedulerId   string                 `protobuf:"bytes,3,opt,name=scheduler_id,json=schedulerId,proto3" json:"scheduler_id,omitempty"`
 	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	TriggerCount  uint32                 `protobuf:"varint,6,opt,name=trigger_count,json=triggerCount,proto3" json:"trigger_count,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,7,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description   string                 `protobuf:"bytes,8,opt,name=description,proto3" json:"description,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2746,6 +2764,20 @@ func (x *ProjectScheduler) GetTriggerCount() uint32 {
 		return x.TriggerCount
 	}
 	return 0
+}
+
+func (x *ProjectScheduler) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *ProjectScheduler) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
 }
 
 type GetSchedulerRequest struct {
@@ -3022,6 +3054,8 @@ type SchedulerSummary struct {
 	RunCount      uint32                 `protobuf:"varint,6,opt,name=run_count,json=runCount,proto3" json:"run_count,omitempty"`
 	LatestRunAt   *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=latest_run_at,json=latestRunAt,proto3" json:"latest_run_at,omitempty"`
 	LastError     string                 `protobuf:"bytes,8,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,9,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description   string                 `protobuf:"bytes,10,opt,name=description,proto3" json:"description,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3108,6 +3142,20 @@ func (x *SchedulerSummary) GetLatestRunAt() *timestamppb.Timestamp {
 func (x *SchedulerSummary) GetLastError() string {
 	if x != nil {
 		return x.LastError
+	}
+	return ""
+}
+
+func (x *SchedulerSummary) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *SchedulerSummary) GetDescription() string {
+	if x != nil {
+		return x.Description
 	}
 	return ""
 }
@@ -3906,6 +3954,8 @@ type AgentSpec struct {
 	McpServers    []*MCPServerSpec       `protobuf:"bytes,14,rep,name=mcp_servers,json=mcpServers,proto3" json:"mcp_servers,omitempty"`
 	Skills        []*SkillSpec           `protobuf:"bytes,15,rep,name=skills,proto3" json:"skills,omitempty"`
 	Status        AgentStatus            `protobuf:"varint,16,opt,name=status,proto3,enum=agentcompose.v2.AgentStatus" json:"status,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,17,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description   string                 `protobuf:"bytes,18,opt,name=description,proto3" json:"description,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4050,6 +4100,20 @@ func (x *AgentSpec) GetStatus() AgentStatus {
 		return x.Status
 	}
 	return AgentStatus_AGENT_STATUS_UNSPECIFIED
+}
+
+func (x *AgentSpec) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *AgentSpec) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
 }
 
 type MCPServerSpec struct {
@@ -4650,6 +4714,8 @@ type SchedulerSpec struct {
 	Triggers      []*TriggerSpec         `protobuf:"bytes,2,rep,name=triggers,proto3" json:"triggers,omitempty"`
 	Script        string                 `protobuf:"bytes,3,opt,name=script,proto3" json:"script,omitempty"`
 	SandboxPolicy string                 `protobuf:"bytes,4,opt,name=sandbox_policy,json=sandboxPolicy,proto3" json:"sandbox_policy,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,5,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description   string                 `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4708,6 +4774,20 @@ func (x *SchedulerSpec) GetScript() string {
 func (x *SchedulerSpec) GetSandboxPolicy() string {
 	if x != nil {
 		return x.SandboxPolicy
+	}
+	return ""
+}
+
+func (x *SchedulerSpec) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *SchedulerSpec) GetDescription() string {
+	if x != nil {
+		return x.Description
 	}
 	return ""
 }
@@ -15671,7 +15751,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\tspec_hash\x18\x03 \x01(\tR\bspecHash\x120\n" +
 	"\x04spec\x18\x04 \x01(\v2\x1c.agentcompose.v2.ProjectSpecR\x04spec\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\x05 \x01(\tR\tcreatedAt\"\xba\x04\n" +
+	"created_at\x18\x05 \x01(\tR\tcreatedAt\"\xff\x04\n" +
 	"\fProjectAgent\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1d\n" +
@@ -15690,7 +15770,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\vcurrent_run\x18\f \x01(\v2'.agentcompose.v2.ProjectAgentCurrentRunR\n" +
 	"currentRun\x12E\n" +
 	"\n" +
-	"latest_run\x18\r \x01(\v2&.agentcompose.v2.ProjectAgentLatestRunR\tlatestRun\"\x97\x01\n" +
+	"latest_run\x18\r \x01(\v2&.agentcompose.v2.ProjectAgentLatestRunR\tlatestRun\x12!\n" +
+	"\fdisplay_name\x18\x0e \x01(\tR\vdisplayName\x12 \n" +
+	"\vdescription\x18\x0f \x01(\tR\vdescription\"\x97\x01\n" +
 	"\x16ProjectAgentCurrentRun\x12\x12\n" +
 	"\x04text\x18\x01 \x01(\tR\x04text\x12*\n" +
 	"\x11running_run_count\x18\x02 \x01(\rR\x0frunningRunCount\x12=\n" +
@@ -15699,7 +15781,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x122\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x1a.agentcompose.v2.RunStatusR\x06status\x122\n" +
 	"\x06source\x18\x03 \x01(\x0e2\x1a.agentcompose.v2.RunSourceR\x06source\x12*\n" +
-	"\x02at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x02at\"\xcb\x01\n" +
+	"\x02at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x02at\"\x90\x02\n" +
 	"\x10ProjectScheduler\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1d\n" +
@@ -15707,7 +15789,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"agent_name\x18\x02 \x01(\tR\tagentName\x12!\n" +
 	"\fscheduler_id\x18\x03 \x01(\tR\vschedulerId\x12\x18\n" +
 	"\aenabled\x18\x05 \x01(\bR\aenabled\x12#\n" +
-	"\rtrigger_count\x18\x06 \x01(\rR\ftriggerCountJ\x04\b\x04\x10\x05R\x11managed_loader_id\"k\n" +
+	"\rtrigger_count\x18\x06 \x01(\rR\ftriggerCount\x12!\n" +
+	"\fdisplay_name\x18\a \x01(\tR\vdisplayName\x12 \n" +
+	"\vdescription\x18\b \x01(\tR\vdescriptionJ\x04\b\x04\x10\x05R\x11managed_loader_id\"k\n" +
 	"\x13GetSchedulerRequest\x125\n" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
 	"\n" +
@@ -15733,7 +15817,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x15ListSchedulersRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\rR\x05limit\x12\x16\n" +
-	"\x06cursor\x18\x03 \x01(\tR\x06cursor\"\xae\x02\n" +
+	"\x06cursor\x18\x03 \x01(\tR\x06cursor\"\xf3\x02\n" +
 	"\x10SchedulerSummary\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x1d\n" +
@@ -15745,7 +15829,10 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\trun_count\x18\x06 \x01(\rR\brunCount\x12>\n" +
 	"\rlatest_run_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\vlatestRunAt\x12\x1d\n" +
 	"\n" +
-	"last_error\x18\b \x01(\tR\tlastError\"|\n" +
+	"last_error\x18\b \x01(\tR\tlastError\x12!\n" +
+	"\fdisplay_name\x18\t \x01(\tR\vdisplayName\x12 \n" +
+	"\vdescription\x18\n" +
+	" \x01(\tR\vdescription\"|\n" +
 	"\x16ListSchedulersResponse\x12A\n" +
 	"\n" +
 	"schedulers\x18\x01 \x03(\v2!.agentcompose.v2.SchedulerSummaryR\n" +
@@ -15816,7 +15903,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"mcpServersJ\x04\b\x03\x10\x04R\tworkspace\"f\n" +
 	"\x12NamedWorkspaceSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12<\n" +
-	"\tworkspace\x18\x02 \x01(\v2\x1e.agentcompose.v2.WorkspaceSpecR\tworkspace\"\xdc\x05\n" +
+	"\tworkspace\x18\x02 \x01(\v2\x1e.agentcompose.v2.WorkspaceSpecR\tworkspace\"\xa1\x06\n" +
 	"\tAgentSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\bprovider\x18\x02 \x01(\tR\bprovider\x12\x14\n" +
@@ -15836,7 +15923,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\vmcp_servers\x18\x0e \x03(\v2\x1e.agentcompose.v2.MCPServerSpecR\n" +
 	"mcpServers\x122\n" +
 	"\x06skills\x18\x0f \x03(\v2\x1a.agentcompose.v2.SkillSpecR\x06skills\x124\n" +
-	"\x06status\x18\x10 \x01(\x0e2\x1c.agentcompose.v2.AgentStatusR\x06status\"\xfb\x01\n" +
+	"\x06status\x18\x10 \x01(\x0e2\x1c.agentcompose.v2.AgentStatusR\x06status\x12!\n" +
+	"\fdisplay_name\x18\x11 \x01(\tR\vdisplayName\x12 \n" +
+	"\vdescription\x18\x12 \x01(\tR\vdescription\"\xfb\x01\n" +
 	"\rMCPServerSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1c\n" +
@@ -15895,12 +15984,14 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x04path\x18\x04 \x01(\tR\x04path\x12\x12\n" +
 	"\x04name\x18\x05 \x01(\tR\x04name\"!\n" +
 	"\vNetworkSpec\x12\x12\n" +
-	"\x04mode\x18\x01 \x01(\tR\x04mode\"\xa2\x01\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04mode\"\xe7\x01\n" +
 	"\rSchedulerSpec\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x128\n" +
 	"\btriggers\x18\x02 \x03(\v2\x1c.agentcompose.v2.TriggerSpecR\btriggers\x12\x16\n" +
 	"\x06script\x18\x03 \x01(\tR\x06script\x12%\n" +
-	"\x0esandbox_policy\x18\x04 \x01(\tR\rsandboxPolicy\"\xf7\x01\n" +
+	"\x0esandbox_policy\x18\x04 \x01(\tR\rsandboxPolicy\x12!\n" +
+	"\fdisplay_name\x18\x05 \x01(\tR\vdisplayName\x12 \n" +
+	"\vdescription\x18\x06 \x01(\tR\vdescription\"\xf7\x01\n" +
 	"\vTriggerSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x12\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -641,6 +641,7 @@ message WorkspaceSpec {
   string branch = 3;
   string path = 4;
   string name = 5;
+  string commit = 6;
 }
 
 message NetworkSpec {

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -413,6 +413,8 @@ message ProjectAgent {
   ProjectAgentHealth health = 11;
   ProjectAgentCurrentRun current_run = 12;
   ProjectAgentLatestRun latest_run = 13;
+  string display_name = 14;
+  string description = 15;
 }
 
 message ProjectAgentCurrentRun {
@@ -437,6 +439,8 @@ message ProjectScheduler {
   string scheduler_id = 3;
   bool enabled = 5;
   uint32 trigger_count = 6;
+  string display_name = 7;
+  string description = 8;
 }
 
 message GetSchedulerRequest {
@@ -475,6 +479,8 @@ message SchedulerSummary {
   uint32 run_count = 6;
   google.protobuf.Timestamp latest_run_at = 7;
   string last_error = 8;
+  string display_name = 9;
+  string description = 10;
 }
 
 message ListSchedulersResponse {
@@ -575,6 +581,8 @@ message AgentSpec {
   repeated MCPServerSpec mcp_servers = 14;
   repeated SkillSpec skills = 15;
   AgentStatus status = 16;
+  string display_name = 17;
+  string description = 18;
 }
 
 message MCPServerSpec {
@@ -644,6 +652,8 @@ message SchedulerSpec {
   repeated TriggerSpec triggers = 2;
   string script = 3;
   string sandbox_policy = 4;
+  string display_name = 5;
+  string description = 6;
 }
 
 message TriggerSpec {


### PR DESCRIPTION
## Summary

- expose agent and scheduler display names and descriptions through the v2 project API and compose schema
- preserve stable agent names while migrating legacy presentation metadata
- project legacy file and Git workspace presets into v2 workspaces without changing the legacy default project identity

## Testing

- go test -count=1 ./pkg/compose ./pkg/agentcompose/api
- go test -count=1 ./pkg/projects

## Checklist

- [ ] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.