### PR TITLE
fix(compose): keep agent workspace selection explicit

### DIFF
--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1501,7 +1501,7 @@ func testCLIWorkspaceRegistryConfigAndApply(t *testing.T) {
 	t.Setenv("AGENT_COMPOSE_SOCKET", socketPath)
 	t.Setenv("AGENT_COMPOSE_HOST", "")
 
-	t.Run("single global workspace becomes default", func(t *testing.T) {
+	t.Run("single global workspace is not selected implicitly", func(t *testing.T) {
 		composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "workspace-default"), `
 name: workspace-default
 workspaces:
@@ -1528,7 +1528,7 @@ agents:
 			} `json:"workspaces"`
 			Agents []struct {
 				Name      string `json:"name"`
-				Workspace struct {
+				Workspace *struct {
 					Provider string `json:"provider"`
 					Path     string `json:"path"`
 				} `json:"workspace"`
@@ -1540,7 +1540,7 @@ agents:
 		if len(decoded.Workspaces) != 1 || decoded.Workspaces[0].Key != "repo-root" || decoded.Workspaces[0].Provider != "local" {
 			t.Fatalf("decoded workspaces = %#v", decoded.Workspaces)
 		}
-		if len(decoded.Agents) != 1 || decoded.Agents[0].Workspace.Provider != "local" || decoded.Agents[0].Workspace.Path != "." {
+		if len(decoded.Agents) != 1 || decoded.Agents[0].Workspace != nil {
 			t.Fatalf("decoded agents = %#v", decoded.Agents)
 		}
 
@@ -1611,7 +1611,7 @@ agents:
 		}
 	})
 
-	t.Run("multiple globals without agent workspace fails", func(t *testing.T) {
+	t.Run("multiple globals are not selected implicitly", func(t *testing.T) {
 		composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "workspace-ambiguous"), `
 name: workspace-ambiguous
 workspaces:
@@ -1624,14 +1624,42 @@ workspaces:
 agents:
   reviewer:
     provider: codex
+    image: guest:v1
+    driver:
+      docker: {}
 `)
 
-		_, stderr, _, exitCode := executeCLICommand("config", "--file", composePath, "--json")
-		if exitCode == 0 {
-			t.Fatalf("expected config to fail")
+		stdout, stderr, _, exitCode := executeCLICommand("config", "--file", composePath, "--json")
+		if exitCode != 0 || stderr != "" {
+			t.Fatalf("config code/stderr = %d / %q", exitCode, stderr)
 		}
-		if !strings.Contains(stderr, "project workspaces has multiple entries") {
-			t.Fatalf("stderr = %q", stderr)
+		var decoded struct {
+			Workspaces []struct {
+				Key string `json:"key"`
+			} `json:"workspaces"`
+			Agents []struct {
+				Workspace *struct {
+					Provider string `json:"provider"`
+				} `json:"workspace"`
+			} `json:"agents"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+			t.Fatalf("config json decode failed: %v\n%s", err, stdout)
+		}
+		if len(decoded.Workspaces) != 2 || decoded.Workspaces[0].Key != "docs-repo" || decoded.Workspaces[1].Key != "repo-root" {
+			t.Fatalf("decoded workspaces = %#v", decoded.Workspaces)
+		}
+		if len(decoded.Agents) != 1 || decoded.Agents[0].Workspace != nil {
+			t.Fatalf("decoded agents = %#v", decoded.Agents)
+		}
+
+		upOut, upErr, _, upCode := executeCLICommand("up", "--file", composePath, "--json")
+		if upCode != 0 || upErr != "" {
+			t.Fatalf("up code/stderr = %d / %q", upCode, upErr)
+		}
+		up := decodeComposeUpOutput(t, upOut)
+		if up.Project.Name != "workspace-ambiguous" || !up.Applied {
+			t.Fatalf("up output = %#v", up)
 		}
 	})
 

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -279,9 +279,10 @@ workspaces:
 
 Workspace selection follows these rules:
 
-- With no project workspace and no agent `workspace`, the run has no configured workspace.
-- With exactly one project workspace and no agent `workspace`, the agent automatically uses that entry.
-- With multiple project workspaces, each agent must select one with `workspace.name` or define an inline workspace.
+- Top-level `workspaces` entries are named definitions only; they are never assigned to an agent automatically.
+- When an agent omits `workspace`, the run has no configured workspace, regardless of how many project workspaces exist.
+- To use a project workspace, the agent must explicitly select it with `workspace.name`, or define an inline workspace.
+- An explicit empty `workspace: {}` is invalid; omit the key to configure no workspace.
 
 ## `mcp_servers`: project MCP servers
 
@@ -385,7 +386,7 @@ agents:
 | `capset_ids` | string[] | Empty | OctoBus capability set IDs allowed for this agent's sandboxes. |
 | `skills` | list | Empty | Skill sources projected into the agent runtime. |
 | `volumes` | list | Empty | Volume and bind mounts. |
-| `workspace` | object | Automatic/none | Selects a project `workspaces` entry or defines an inline workspace. |
+| `workspace` | object | None | Explicitly selects a project `workspaces` entry or defines an inline workspace. |
 | `scheduler` | object | None | Automatic trigger configuration. |
 | `jupyter` | object | Disabled | Default Jupyter behavior for agent runs. |
 
@@ -839,9 +840,9 @@ agents:
 
 To reuse deployment environment values, both locations may contain `${API_URL}`, supplied through `env_file` or the CLI process environment.
 
-### Defining multiple `workspaces` without selecting one
+### Expecting a project `workspace` to be selected automatically
 
-When the project contains multiple workspace entries, each agent must set `workspace.name` or define an inline workspace.
+Top-level `workspaces` are never selected automatically. An agent that omits `workspace` has no configured workspace, even when the project defines exactly one entry. Set `workspace.name` or define an inline workspace when the agent needs one. Use omission, not `workspace: {}`, to configure no workspace.
 
 ### Selecting an unavailable runtime driver
 

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -278,9 +278,10 @@ workspaces:
 
 Workspace 选择规则：
 
-- 没有顶层 Workspace 且 Agent 未写 `workspace`：不配置 Workspace。
-- 只有一个顶层 Workspace 且 Agent 未写 `workspace`：该 Agent 自动使用唯一条目。
-- 有多个顶层 Workspace：每个 Agent 必须通过 `workspace.name` 引用一个条目，或写内联 Workspace。
+- 顶层 `workspaces` 只是命名定义，不会自动分配给任何 Agent。
+- Agent 省略 `workspace` 时，无论顶层定义了多少个 Workspace，该次 run 都不配置 Workspace。
+- Agent 需要使用顶层 Workspace 时，必须通过 `workspace.name` 显式引用，或定义内联 Workspace。
+- 显式的空对象 `workspace: {}` 非法；不使用 Workspace 时应省略该 key。
 
 ## `mcp_servers`：项目级 MCP
 
@@ -386,7 +387,7 @@ agents:
 | `capset_ids` | string[] | 空 | 允许该 Agent sandbox 使用的 OctoBus capability set ID。 |
 | `skills` | list | 空 | 注入 Agent 的 Skill 来源。 |
 | `volumes` | list | 空 | Volume 或 bind mount 列表。 |
-| `workspace` | object | 自动/无 | 引用一个顶层 `workspaces` 条目，或定义 Agent 内联 Workspace。 |
+| `workspace` | object | 无 | 显式引用一个顶层 `workspaces` 条目，或定义 Agent 内联 Workspace。 |
 | `scheduler` | object | 无 | 自动触发 Agent 的 Scheduler。 |
 | `jupyter` | object | disabled | Agent run 的 Jupyter 默认配置。 |
 
@@ -844,9 +845,9 @@ agents:
 
 如果目标是复用部署环境值，可在两个位置都写 `${API_URL}`，并通过 `env_file` 或 CLI 进程环境提供。
 
-### 多个 `workspaces` 但 Agent 未选择
+### 以为项目 Workspace 会被自动选择
 
-顶层有多个条目时，每个 Agent 必须写 `workspace.name` 或内联 Workspace，否则校验失败。
+顶层 `workspaces` 不会被自动选择。Agent 省略 `workspace` 时，即使项目只定义了一个条目，也不会配置 Workspace。需要使用时应设置 `workspace.name` 或内联 Workspace；不使用时应省略该 key，而不是写 `workspace: {}`。
 
 ### 选择未编译或运行条件不满足的 driver
 

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -354,18 +354,7 @@ func normalizeMCPMap(path string, values map[string]MCPServerSpec, options Norma
 
 func resolveAgentWorkspace(path string, spec *WorkspaceSpec, globals map[string]WorkspaceSpec) (*WorkspaceSpec, error) {
 	if spec == nil {
-		switch len(globals) {
-		case 1:
-			for _, workspace := range globals {
-				resolved := cloneWorkspaceSpec(&workspace)
-				resolved.Name = ""
-				return resolved, nil
-			}
-		case 0:
-			return nil, nil
-		default:
-			return nil, &ValidationError{Path: path, Message: "workspace is required when project workspaces has multiple entries"}
-		}
+		return nil, nil
 	}
 	trimmed := cloneWorkspaceSpec(spec)
 	hasName := trimmed.Name != ""

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -1070,7 +1070,7 @@ agents:
 	}
 }
 
-func TestNormalizeUsesOnlyGlobalWorkspaceByDefault(t *testing.T) {
+func TestNormalizeDoesNotUseOnlyGlobalWorkspaceByDefault(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: default-workspace
 workspaces:
@@ -1086,8 +1086,8 @@ agents:
 	if err != nil {
 		t.Fatalf("Normalize returned error: %v", err)
 	}
-	if normalized.Agents[0].Workspace == nil || normalized.Agents[0].Workspace.Provider != "local" || normalized.Agents[0].Workspace.Path != "." || normalized.Agents[0].Workspace.Name != "" {
-		t.Fatalf("workspace = %#v", normalized.Agents[0].Workspace)
+	if normalized.Agents[0].Workspace != nil {
+		t.Fatalf("workspace = %#v, want nil", normalized.Agents[0].Workspace)
 	}
 }
 
@@ -1179,7 +1179,7 @@ agents:
 	}
 }
 
-func TestNormalizeRejectsAmbiguousDefaultWorkspace(t *testing.T) {
+func TestNormalizeAllowsOmittedAgentWorkspaceWithMultipleGlobals(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: ambiguous-workspace
 workspaces:
@@ -1194,12 +1194,12 @@ agents:
     provider: codex
 `)
 
-	_, err := Normalize(spec, NormalizeOptions{})
-	if err == nil {
-		t.Fatalf("expected Normalize to fail")
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
 	}
-	if got := err.Error(); !strings.Contains(got, "agents.reviewer.workspace") || !strings.Contains(got, "multiple") {
-		t.Fatalf("error = %q, want ambiguous default workspace error", got)
+	if normalized.Agents[0].Workspace != nil {
+		t.Fatalf("workspace = %#v, want nil", normalized.Agents[0].Workspace)
 	}
 }
 

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -272,7 +272,6 @@ func ComposeWorkspaceSpecFromV2(workspace *agentcomposev2.WorkspaceSpec) *compos
 
 func ProjectRunWorkspaceSpecsFromV2(projectWorkspaces []*agentcomposev2.NamedWorkspaceSpec, agentWorkspace *agentcomposev2.WorkspaceSpec) (*compose.WorkspaceSpec, *compose.WorkspaceSpec, error) {
 	globals := make(map[string]compose.WorkspaceSpec, len(projectWorkspaces))
-	keys := make([]string, 0, len(projectWorkspaces))
 	for i, item := range projectWorkspaces {
 		name := strings.TrimSpace(item.GetName())
 		if name == "" {
@@ -287,7 +286,6 @@ func ProjectRunWorkspaceSpecsFromV2(projectWorkspaces []*agentcomposev2.NamedWor
 		}
 		workspace.Name = ""
 		globals[name] = *workspace
-		keys = append(keys, name)
 	}
 
 	agent := ComposeWorkspaceSpecFromV2(agentWorkspace)
@@ -306,10 +304,6 @@ func ProjectRunWorkspaceSpecsFromV2(projectWorkspaces []*agentcomposev2.NamedWor
 		}
 	}
 
-	if len(globals) == 1 {
-		workspace := globals[keys[0]]
-		return &workspace, nil, nil
-	}
 	return nil, nil, nil
 }
 

--- a/pkg/runs/preparation_workspace_compat_test.go
+++ b/pkg/runs/preparation_workspace_compat_test.go
@@ -59,7 +59,7 @@ func TestDecodeRevisionSpecSupportsCanonicalAgentStatus(t *testing.T) {
 	}
 }
 
-func TestIntegrationProjectRevisionWorkspaceRoundTrip(t *testing.T) {
+func TestIntegrationProjectRevisionDoesNotSelectOmittedAgentWorkspace(t *testing.T) {
 	normalized, err := compose.Normalize(&compose.ProjectSpec{
 		Name: "workspace-project",
 		Workspaces: map[string]compose.WorkspaceSpec{
@@ -87,16 +87,15 @@ func TestIntegrationProjectRevisionWorkspaceRoundTrip(t *testing.T) {
 	if !ok {
 		t.Fatalf("reviewer missing from decoded revision: %#v", decoded.GetAgents())
 	}
+	if agent.GetWorkspace() != nil {
+		t.Fatalf("decoded agent workspace = %#v, want nil", agent.GetWorkspace())
+	}
 	projectWorkspace, agentWorkspace, err := ProjectRunWorkspaceSpecsFromV2(decoded.GetWorkspaces(), agent.GetWorkspace())
 	if err != nil {
 		t.Fatalf("ProjectRunWorkspaceSpecsFromV2 returned error: %v", err)
 	}
-	resolved := agentWorkspace
-	if resolved == nil {
-		resolved = projectWorkspace
-	}
-	if resolved == nil || resolved.Provider != "local" || resolved.Path != "workspaces/local-repo" {
-		t.Fatalf("resolved workspace = %#v", resolved)
+	if projectWorkspace != nil || agentWorkspace != nil {
+		t.Fatalf("resolved workspaces = (%#v, %#v), want nil, nil", projectWorkspace, agentWorkspace)
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat top-level `workspaces` as an explicit named registry instead of an implicit agent default
- keep an omitted `agent.workspace` unset for both single and multiple project workspace definitions, including project revision preparation
- preserve validation for `workspace: {}` and missing named references, with unit, CLI, and round-trip regression coverage
- update the English and Chinese YAML manuals to document explicit workspace selection

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `task test GO_BUILD_CACHE_DIR="$GOCACHE"` with inherited local agent-compose product configuration unset
  - Unit: 75.32%
  - Integration: 63.67%
  - E2E: 62.79%
  - Combined: 77.90%
- `task docs:build`
- local Docker YAML workspace suite: 33/33 scenarios passed, including single/multiple unselected workspaces and runtime non-materialization

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
