### PR TITLE
feat(auth): improve login and site listing

### DIFF
--- a/cmd/agent-compose/cli_auth.go
+++ b/cmd/agent-compose/cli_auth.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -45,7 +46,7 @@ func newCLIAuthCommand(options *cliOptions) *cobra.Command {
 		},
 	}
 	listCmd := &cobra.Command{
-		Use:   "list",
+		Use:   "ls",
 		Short: "List authenticated daemon sites",
 		Args:  cobra.NoArgs,
 		RunE:  runCLIAuthList,
@@ -68,6 +69,10 @@ func runCLIAuthLogin(cmd *cobra.Command, hostFlag string, options cliAuthLoginOp
 	}
 	clientConfig.AuthToken = token
 	if _, err := fetchDaemonVersion(cmd.Context(), clientConfig); err != nil {
+		var statusErr daemonHTTPStatusError
+		if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusUnauthorized {
+			return fmt.Errorf("authentication failed for %s: token was rejected (HTTP %d)", clientConfig.BaseURL, statusErr.StatusCode)
+		}
 		return fmt.Errorf("authenticate daemon %s: %w", clientConfig.BaseURL, err)
 	}
 	path, err := clientconfig.DefaultPath()
@@ -113,8 +118,15 @@ func runCLIAuthList(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	if len(hosts) == 0 {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "No authenticated Agent-Compose sites.")
+		return err
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Authenticated Agent-Compose sites:"); err != nil {
+		return err
+	}
 	for _, host := range hosts {
-		if _, err := fmt.Fprintln(cmd.OutOrStdout(), host); err != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "- %s\n", host); err != nil {
 			return err
 		}
 	}

--- a/cmd/agent-compose/cli_auth_test.go
+++ b/cmd/agent-compose/cli_auth_test.go
@@ -39,8 +39,9 @@ func TestCLIAuthLoginPersistsAndReusesToken(t *testing.T) {
 		t.Fatalf("status stdout/stderr/code = %q / %q / %d", stdout, stderr, exitCode)
 	}
 
-	stdout, stderr, _, exitCode = executeCLICommand("auth", "list")
-	if exitCode != 0 || stderr != "" || strings.TrimSpace(stdout) != server.URL {
+	stdout, stderr, _, exitCode = executeCLICommand("auth", "ls")
+	wantList := "Authenticated Agent-Compose sites:\n- " + server.URL + "\n"
+	if exitCode != 0 || stderr != "" || stdout != wantList {
 		t.Fatalf("list stdout/stderr/code = %q / %q / %d", stdout, stderr, exitCode)
 	}
 
@@ -50,17 +51,32 @@ func TestCLIAuthLoginPersistsAndReusesToken(t *testing.T) {
 	}
 }
 
+func TestCLIAuthListReportsWhenNoSitesAreAuthenticated(t *testing.T) {
+	t.Setenv("AGENT_COMPOSE_CONFIG", filepath.Join(t.TempDir(), "config.yml"))
+
+	stdout, stderr, _, exitCode := executeCLICommand("auth", "ls")
+	want := "No authenticated Agent-Compose sites.\n"
+	if exitCode != 0 || stderr != "" || stdout != want {
+		t.Fatalf("list stdout/stderr/code = %q / %q / %d, want %q / empty / 0", stdout, stderr, exitCode, want)
+	}
+}
+
 func TestCLIAuthLoginFailureDoesNotPersistToken(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.yml")
 	t.Setenv("AGENT_COMPOSE_CONFIG", configPath)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"err":"Unknown","msg":"daemon authentication required, code=401, message=daemon authentication required"}`)
 	}))
 	defer server.Close()
 
-	_, _, _, exitCode := executeCLICommand("auth", "login", "--host", server.URL, "--token", "wrong")
+	_, stderr, _, exitCode := executeCLICommand("auth", "login", "--host", server.URL, "--token", "wrong")
 	if exitCode == 0 {
 		t.Fatal("login exit code = 0, want failure")
+	}
+	wantError := "authentication failed for " + server.URL + ": token was rejected (HTTP 401)\n"
+	if stderr != wantError {
+		t.Fatalf("login stderr = %q, want %q", stderr, wantError)
 	}
 	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
 		t.Fatalf("config stat error = %v, want not exist", err)

--- a/cmd/agent-compose/daemon_http_error.go
+++ b/cmd/agent-compose/daemon_http_error.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+type daemonHTTPStatusError struct {
+	Source      string
+	SourceValue string
+	StatusCode  int
+	Body        string
+}
+
+func (e daemonHTTPStatusError) Error() string {
+	return fmt.Sprintf("daemon via %s %q returned HTTP %d: %s", e.Source, e.SourceValue, e.StatusCode, e.Body)
+}

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -9114,7 +9114,12 @@ func fetchDaemonVersion(ctx context.Context, clientConfig cliClientConfig) ([]by
 		return nil, fmt.Errorf("read daemon response from %s %q: %w", clientConfig.Source, clientConfig.SourceValue, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("daemon via %s %q returned HTTP %d: %s", clientConfig.Source, clientConfig.SourceValue, resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, daemonHTTPStatusError{
+			Source:      clientConfig.Source,
+			SourceValue: clientConfig.SourceValue,
+			StatusCode:  resp.StatusCode,
+			Body:        strings.TrimSpace(string(body)),
+		}
 	}
 	return body, nil
 }

--- a/docs/design/daemon_bearer_auth.md
+++ b/docs/design/daemon_bearer_auth.md
@@ -57,7 +57,7 @@ agent-compose --host https://compose.example.com auth login --token '<token>'
 
 Login sends the supplied token to the protected `/api/version` endpoint. The
 credential is persisted only after a successful response. `auth logout`
-removes one site and `auth list` prints site names without tokens.
+removes one site and `auth ls` prints site names without tokens.
 
 The default store is the platform user configuration directory at
 `agent-compose/config.yml`. On standard Linux systems this is

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -57,7 +57,7 @@ The first command verifies the token against the daemon before saving it under
 `~/.config/agent-compose/config.yml` (or the platform user configuration
 directory). Later commands automatically load the token associated with the
 normalized `--host` or `AGENT_COMPOSE_HOST` value. The file is written with
-owner-only permissions. Use `agent-compose auth list` to list saved sites and
+owner-only permissions. Use `agent-compose auth ls` to list saved sites and
 `agent-compose --host <site> auth logout` to remove one.
 
 HTTP remains supported, including loopback container port mappings, but a

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -56,7 +56,7 @@ agent-compose --host https://compose.example.com status
 第一条命令会先向 daemon 验证 Token，成功后写入
 `~/.config/agent-compose/config.yml`（或当前平台的用户配置目录）。后续命令会
 根据规范化后的 `--host` 或 `AGENT_COMPOSE_HOST` 自动加载对应 Token。配置文件
-仅允许当前用户读写。可通过 `agent-compose auth list` 查看已保存的站点，通过
+仅允许当前用户读写。可通过 `agent-compose auth ls` 查看已保存的站点，通过
 `agent-compose --host <site> auth logout` 删除站点凭据。
 
 当前仍支持 HTTP，包括宿主机访问容器回环映射的场景；但明文 HTTP 中的 Bearer


### PR DESCRIPTION
  ## Summary

  - Improve `auth login` errors when a daemon rejects a token, replacing the raw HTTP response body with a concise authentication failure message.
  - Rename `auth list` to `auth ls`.
  - Present authenticated Agent-Compose sites as a labeled list and report an explicit message when no sites are configured.
  - Update the English and Chinese CLI manuals and authentication design documentation.

  ## Testing

  - `go test ./cmd/agent-compose -run 'TestCLIAuth(Login|List)'`
  - `task prepare`
  - `task lint`
  - `task build`
  - `task docs:build`
  - `task test`

  Coverage results:

  - Unit: 74.59%
  - Integration: 62.96%
  - E2E: 61.90%
  - Combined: 77.88%

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.