### PR TITLE
fix(cli): show scheduler first in list output

### DIFF
--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -2846,9 +2846,9 @@ func schedulerTriggerItemFromResolved(agentName, schedulerID string, schedulerEn
 
 func writeSchedulerListText(out io.Writer, output composeSchedulerListOutput, verbose bool) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	header := "AGENT\tTRIGGER\tKIND\tSOURCE\tSCHEDULER\tENABLED"
+	header := "SCHEDULER\tAGENT\tTRIGGER\tKIND\tSOURCE\tENABLED"
 	if verbose {
-		header = "AGENT\tTRIGGER\tTRIGGER ID\tKIND\tSOURCE\tSCHEDULER\tENABLED"
+		header = "SCHEDULER\tAGENT\tTRIGGER\tTRIGGER ID\tKIND\tSOURCE\tENABLED"
 	}
 	if _, err := fmt.Fprintln(tw, header); err != nil {
 		return err
@@ -2859,19 +2859,19 @@ func writeSchedulerListText(out io.Writer, output composeSchedulerListOutput, ve
 		if verbose {
 			schedulerID = firstNonEmptyString(trigger.SchedulerID, "-")
 			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%t\n",
-				trigger.AgentName, name, firstNonEmptyString(trigger.TriggerID, "-"), trigger.Kind,
-				trigger.Source, schedulerID, trigger.TriggerEnabled,
+				schedulerID, trigger.AgentName, name, firstNonEmptyString(trigger.TriggerID, "-"),
+				trigger.Kind, trigger.Source, trigger.TriggerEnabled,
 			); err != nil {
 				return err
 			}
 			continue
 		}
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%t\n",
+			schedulerID,
 			trigger.AgentName,
 			name,
 			trigger.Kind,
 			trigger.Source,
-			schedulerID,
 			trigger.TriggerEnabled,
 		); err != nil {
 			return err

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -3065,9 +3065,17 @@ agents:
 	if !strings.Contains(stdout, shortOpaqueID(schedulerID)) || strings.Contains(stdout, displayOpaqueID(schedulerID)) {
 		t.Fatalf("scheduler ls should show only short scheduler id %q, stdout = %q", shortOpaqueID(schedulerID), stdout)
 	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if !strings.HasPrefix(lines[0], "SCHEDULER") || !strings.HasPrefix(strings.TrimSpace(lines[1]), shortOpaqueID(schedulerID)) {
+		t.Fatalf("scheduler ls should show scheduler as first column, stdout = %q", stdout)
+	}
 	verboseOut, verboseErr, _, verboseCode := executeCLICommand("scheduler", "ls", "--verbose", "--host", server.URL, "--file", composePath)
 	if verboseCode != 0 || verboseErr != "" || !strings.Contains(verboseOut, displayOpaqueID(schedulerID)) || !strings.Contains(verboseOut, "TRIGGER ID") {
 		t.Fatalf("scheduler ls --verbose code/stdout/stderr = %d / %q / %q", verboseCode, verboseOut, verboseErr)
+	}
+	verboseLines := strings.Split(strings.TrimSpace(verboseOut), "\n")
+	if !strings.HasPrefix(verboseLines[0], "SCHEDULER") || !strings.HasPrefix(strings.TrimSpace(verboseLines[1]), displayOpaqueID(schedulerID)) {
+		t.Fatalf("scheduler ls --verbose should show scheduler as first column, stdout = %q", verboseOut)
 	}
 	jsonOut, jsonErr, _, jsonCode := executeCLICommand("scheduler", "ls", identity.ShortID(agentID), "--json", "--host", server.URL, "--file", composePath)
 	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, `"agent_name": "reviewer"`) || !strings.Contains(jsonOut, `"source": "declarative"`) ||


### PR DESCRIPTION
  ## Summary

  - Move the `SCHEDULER` column to the first position in `scheduler ls` text output.
  - Keep the same column order for both default and `--verbose` views.
  - Add regression coverage for the header and row ordering in both views.

  ## Testing

  - `go test ./cmd/agent-compose -run '^TestIntegrationCLISchedulerList$'`
  - `go test ./cmd/agent-compose`
  - `task lint`
  - `task build`
  - `task test`

  ## Checklist

  - [ ] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.