### PR TITLE
fix(llms): disable codex plugin marketplace fetch on startup

### DIFF
--- a/assets/.codex/config.toml
+++ b/assets/.codex/config.toml
@@ -1,3 +1,14 @@
+check_for_update_on_startup = false
+
+# Codex otherwise clones the official curated plugin marketplace on startup, and
+# a fresh container has no ~/.codex/plugins cache to hit. Keep in sync with the
+# payload in pkg/llms/runtime_config.go, which overwrites this file for agent runs.
+[features]
+plugins = false
+plugin_hooks = false
+remote_plugin = false
+plugin_sharing = false
+
 [sandbox_workspace_write]
 exclude_tmpdir_env_var = false
 exclude_slash_tmp = false

--- a/pkg/llms/runtime_config.go
+++ b/pkg/llms/runtime_config.go
@@ -34,6 +34,7 @@ func WriteCodexRuntimeConfig(session *domain.Sandbox, model, baseURL, wireAPI st
 	}
 	payload := fmt.Sprintf(`model_provider = "agent_compose"
 model = %q
+check_for_update_on_startup = false
 
 [model_providers.agent_compose]
 name = "agent-compose"
@@ -43,6 +44,15 @@ wire_api = %q
 request_max_retries = 30
 stream_max_retries = 50
 stream_idle_timeout_ms = 120000
+
+# Codex otherwise clones the official curated plugin marketplace on startup, and
+# a fresh sandbox has no ~/.codex/plugins cache to hit. Keep in sync with
+# assets/.codex/config.toml, which seeds the same defaults for devbox images.
+[features]
+plugins = false
+plugin_hooks = false
+remote_plugin = false
+plugin_sharing = false
 
 [sandbox_workspace_write]
 exclude_tmpdir_env_var = false


### PR DESCRIPTION
## 问题

Codex 默认把「官方 curated plugin marketplace」纳入考虑，每次沙箱启动都会走网络去 clone 它 —— 而新容器的 `~/.codex/plugins` 缓存是空的，所以**每个容器首启都要重新下载一遍**。

这不是我们的代码触发的，是 codex 自身的行为（`codex_core_plugins::marketplace`）。我们的配置恰好把闸门都开到最大（`danger-full-access` + `networkAccessEnabled` + `approvalPolicy: never`），所以这个动作静默发生、无人察觉。

## 改动

两个文件，因为 codex 的 config 有两个来源：

- **`pkg/llms/runtime_config.go`** — `WriteCodexRuntimeConfig` 渲染的 payload，会用 `os.WriteFile` **整个覆盖** `~/.codex/config.toml`。这是 agent 运行路径真正读到的内容，也是本次修复实际生效的地方。
- **`assets/.codex/config.toml`** — 只在 devbox 镜像、以及 `model`/`baseURL` 为空导致上面那个函数早返回时才生效的 fallback。

两边各留了一行注释指向对方，避免后续有人只改 asset 而被静默覆盖。

## 验证

在**与生产同版本**的 codex `0.144.1` 上实测（本地跑，未接触任何部署环境）：

默认行为（复现问题）：
- `WARN codex_core_plugins::manager: failed to warm featured plugin ids cache ... https://chatgpt.com/backend-api/plugins/featured ... 401 Unauthorized`
- feature 列表含 `Plugins, RemotePlugin, PluginSharing`
- 磁盘落下 `.tmp/plugins.sync.lock` 和 `.tmp/plugins-clone-*`

修复后（把 Go **实际渲染出的** config.toml 喂给真二进制）：
- 无告警、无 plugin 拉取请求
- feature 列表中 plugin 相关项归零
- 磁盘无任何 plugin 残留

键名都做了对照验证：故意写错的键会触发 `WARN unknown feature key in config`，而这四个键不会。`plugins = false` 单独即可止住下载，但 `RemotePlugin` / `PluginSharing` 仍会保持激活，故一并关闭。

`go build ./...` 通过；`pkg/llms` 与 `pkg/llms/runtimefacade` 测试全绿。

## Reviewer 请注意

- **`check_for_update_on_startup` 在 agent 路径上是无效配置。** 更新检查位于 `codex_tui::update_prompt`（TUI 专属），而我们经 SDK 走 exec 模式；实测 `codex exec` 对 `api.github.com` 零请求。它只对 devbox 里手动起 TUI 有意义。另外 codex 对顶层未知键是**静默忽略**的（不像 `[features]` 会告警），所以这个键名的确信度弱于其余四个。
- **Go payload 与 asset 是手工同步的两份重复配置**，本身就是个隐患。注释只是缓解。是否值得让 asset 成为唯一来源、Go 侧读 embed 后再 append provider 段？可另开单子。