### PR TITLE
feat(cli): add project and agent command groups

### DIFF
--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -23,8 +23,13 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		},
 		{
 			name: "list projects",
-			args: []string{"ls", "--help"},
+			args: []string{"project", "ls", "--help"},
 			want: []string{"List daemon projects", "--verbose", "--limit", "--offset"},
+		},
+		{
+			name: "list agents",
+			args: []string{"agent", "ls", "--help"},
+			want: []string{"List current project agents"},
 		},
 		{
 			name: "run",

--- a/cmd/agent-compose/cli_project_agent_commands.go
+++ b/cmd/agent-compose/cli_project_agent_commands.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func newCLIProjectCommand(options *cliOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Manage projects",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newCLIProjectListCommand(options), newCLIProjectUpCommand(options), newCLIProjectDownCommand(options))
+	return cmd
+}
+
+func newCLIProjectListCommand(options *cliOptions) *cobra.Command {
+	listOptions := composeListProjectsOptions{}
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List daemon projects",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runComposeListProjectsCommand(cmd, *options, listOptions)
+		},
+	}
+	cmd.Flags().BoolVar(&listOptions.Verbose, "verbose", false, "Show more project details")
+	cmd.Flags().Uint32Var(&listOptions.Limit, "limit", 0, "Maximum number of projects to return")
+	cmd.Flags().Uint32Var(&listOptions.Offset, "offset", 0, "Project list offset")
+	return cmd
+}
+
+func newCLIProjectUpCommand(options *cliOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "up",
+		Short: "Apply the current compose project to the daemon",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runComposeUpCommand(cmd, *options)
+		},
+	}
+}
+
+func newCLIProjectDownCommand(options *cliOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "down",
+		Short: "Stop project schedulers and running sandboxes",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runComposeDownCommand(cmd, *options)
+		},
+	}
+}
+
+func newCLIAgentCommand(options *cliOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Manage project agents",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newCLIAgentListCommand(options))
+	return cmd
+}
+
+func newCLIAgentListCommand(options *cliOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "ls",
+		Short: "List current project agents",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runComposeListAgentsCommand(cmd, *options)
+		},
+	}
+}
+
+type composeAgentListOutput struct {
+	Project composeUpProjectOutput      `json:"project"`
+	Agents  []composeProjectAgentOutput `json:"agents"`
+}
+
+func runComposeListAgentsCommand(cmd *cobra.Command, options cliOptions) error {
+	composePath, normalized, projectID, err := resolveComposeProject(options)
+	if err != nil {
+		return err
+	}
+	clients, err := newCLIServiceClients(options)
+	if err != nil {
+		return err
+	}
+	resp, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
+	}))
+	if err != nil {
+		return commandExitErrorForComposeProject(fmt.Errorf("get project %s: %w", normalized.Name, err), "agent ls", normalized.Name, composePath)
+	}
+	project := resp.Msg.GetProject()
+	output := composeAgentListOutput{
+		Project: composeProjectSummaryOutput(project.GetSummary()),
+		Agents:  make([]composeProjectAgentOutput, 0, len(project.GetAgents())),
+	}
+	for _, agent := range project.GetAgents() {
+		output.Agents = append(output.Agents, composeProjectAgentOutputFromProto(agent))
+	}
+	if options.JSON {
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal agent list output: %w", err)
+		}
+		return writeCommandOutput(cmd.OutOrStdout(), data)
+	}
+	return writeAgentListText(cmd.OutOrStdout(), output.Agents)
+}
+
+func writeAgentListText(out io.Writer, agents []composeProjectAgentOutput) error {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "AGENT\tPROVIDER\tMODEL\tIMAGE\tDRIVER\tSCHEDULER"); err != nil {
+		return err
+	}
+	for _, agent := range agents {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%t\n", agent.Name, agent.Provider, agent.Model, agent.Image, agent.Driver, agent.SchedulerEnabled); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}

--- a/cmd/agent-compose/cli_project_agent_commands_test.go
+++ b/cmd/agent-compose/cli_project_agent_commands_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestCLIProjectAndAgentCommandLayout(t *testing.T) {
+	root := newRootCommand(nil, nil, func(context.Context) error { return nil })
+	for _, args := range [][]string{
+		{"project", "ls"},
+		{"project", "up"},
+		{"project", "down"},
+		{"agent", "ls"},
+		{"ls"},
+		{"up"},
+		{"down"},
+	} {
+		cmd, remaining, err := root.Find(args)
+		if err != nil {
+			t.Fatalf("find %q: %v", strings.Join(args, " "), err)
+		}
+		if len(remaining) != 0 {
+			t.Fatalf("find %q remaining args = %q", strings.Join(args, " "), remaining)
+		}
+		if got := cmd.CommandPath(); got != "agent-compose "+strings.Join(args, " ") {
+			t.Fatalf("command path = %q, want %q", got, "agent-compose "+strings.Join(args, " "))
+		}
+	}
+}
+
+func TestCLIAgentListAndTopLevelAlias(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "agent-list")
+	composePath := writeComposeFile(t, dir, `
+name: agent-list
+agents:
+  reviewer:
+    provider: codex
+`)
+	project := testCLIProject("project-test", "agent-list", composePath)
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		getProject: func(_ context.Context, _ *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+			return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
+		},
+	}})
+	defer server.Close()
+
+	for _, args := range [][]string{{"agent", "ls"}, {"ls"}} {
+		stdout, stderr, _, code := executeCLICommand(append(args, "--file", composePath, "--host", server.URL)...)
+		if code != 0 || stderr != "" {
+			t.Fatalf("%s code/stderr = %d / %q", strings.Join(args, " "), code, stderr)
+		}
+		for _, want := range []string{"AGENT", "reviewer", "worker", "gpt-test", "boxlite"} {
+			if !strings.Contains(stdout, want) {
+				t.Fatalf("%s stdout = %q, want %q", strings.Join(args, " "), stdout, want)
+			}
+		}
+	}
+
+	stdout, stderr, _, code := executeCLICommand("agent", "ls", "--file", composePath, "--host", server.URL, "--json")
+	if code != 0 || stderr != "" {
+		t.Fatalf("agent ls --json code/stderr = %d / %q", code, stderr)
+	}
+	var output composeAgentListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode agent list JSON: %v; stdout=%q", err, stdout)
+	}
+	if output.Project.Name != "agent-list" || len(output.Agents) != 2 {
+		t.Fatalf("agent list JSON = %#v", output)
+	}
+}
+
+func TestCLIProjectListUsesFormerTopLevelListBehavior(t *testing.T) {
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listProjects: func(_ context.Context, req *connect.Request[agentcomposev2.ListProjectsRequest]) (*connect.Response[agentcomposev2.ListProjectsResponse], error) {
+			if req.Msg.GetLimit() != 1 || req.Msg.GetOffset() != 2 {
+				t.Fatalf("project ls pagination = limit %d offset %d", req.Msg.GetLimit(), req.Msg.GetOffset())
+			}
+			return connect.NewResponse(&agentcomposev2.ListProjectsResponse{Projects: []*agentcomposev2.ProjectSummary{{Name: "listed-project"}}}), nil
+		},
+	}})
+	defer server.Close()
+
+	stdout, stderr, _, code := executeCLICommand("project", "ls", "--limit", "1", "--offset", "2", "--host", server.URL)
+	if code != 0 || stderr != "" {
+		t.Fatalf("project ls code/stderr = %d / %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "listed-project") {
+		t.Fatalf("project ls stdout = %q", stdout)
+	}
+}

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -503,36 +503,11 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	}
 	configCmd.Flags().BoolVar(&configOptions.Quiet, "quiet", false, "Only validate config")
 
-	listOptions := composeListProjectsOptions{}
-	listCmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List daemon projects",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComposeListProjectsCommand(cmd, options, listOptions)
-		},
-	}
-	listCmd.Flags().BoolVar(&listOptions.Verbose, "verbose", false, "Show more project details")
-	listCmd.Flags().Uint32Var(&listOptions.Limit, "limit", 0, "Maximum number of projects to return")
-	listCmd.Flags().Uint32Var(&listOptions.Offset, "offset", 0, "Project list offset")
-
-	upCmd := &cobra.Command{
-		Use:   "up",
-		Short: "Apply the current compose project to the daemon",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComposeUpCommand(cmd, options)
-		},
-	}
-
-	downCmd := &cobra.Command{
-		Use:   "down",
-		Short: "Stop project schedulers and running sandboxes",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComposeDownCommand(cmd, options)
-		},
-	}
+	projectCmd := newCLIProjectCommand(&options)
+	agentCmd := newCLIAgentCommand(&options)
+	listCmd := newCLIAgentListCommand(&options)
+	upCmd := newCLIProjectUpCommand(&options)
+	downCmd := newCLIProjectDownCommand(&options)
 
 	runOptions := composeRunOptions{}
 	runCmd := &cobra.Command{
@@ -1021,7 +996,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	}
 
 	authCmd := newCLIAuthCommand(&options)
-	root.AddCommand(daemonCmd, versionCmd, statusCmd, authCmd, configCmd, listCmd, upCmd, downCmd, runCmd, schedulerCmd, logsCmd, psCmd, statsCmd, sandboxCmd, stopCmd, resumeCmd, rmCmd, execCmd, imagesCmd, cacheCmd, volumeCmd, imageCmd, pullCmd, buildCmd, rmiCmd, inspectCmd)
+	root.AddCommand(daemonCmd, versionCmd, statusCmd, authCmd, configCmd, projectCmd, agentCmd, listCmd, upCmd, downCmd, runCmd, schedulerCmd, logsCmd, psCmd, statsCmd, sandboxCmd, stopCmd, resumeCmd, rmCmd, execCmd, imagesCmd, cacheCmd, volumeCmd, imageCmd, pullCmd, buildCmd, rmiCmd, inspectCmd)
 	return root
 }
 

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -1211,7 +1211,7 @@ func TestIntegrationCLIListProjectsClassifiesNotFoundAndUnsupported(t *testing.T
 			})
 			defer server.Close()
 
-			stdout, stderr, _, exitCode := executeCLICommand("ls", "--host", server.URL)
+			stdout, stderr, _, exitCode := executeCLICommand("project", "ls", "--host", server.URL)
 			if exitCode != tc.exit {
 				t.Fatalf("ls %s exit code = %d, want %d; stderr=%q", tc.name, exitCode, tc.exit, stderr)
 			}
@@ -8928,7 +8928,7 @@ func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("ls", "--host", server.URL)
+	stdout, stderr, _, exitCode := executeCLICommand("project", "ls", "--host", server.URL)
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("ls code/stderr = %d / %q", exitCode, stderr)
 	}
@@ -8938,7 +8938,7 @@ func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 		}
 	}
 
-	verboseOut, verboseErr, _, verboseCode := executeCLICommand("ls", "--host", server.URL, "--verbose")
+	verboseOut, verboseErr, _, verboseCode := executeCLICommand("project", "ls", "--host", server.URL, "--verbose")
 	if verboseCode != 0 || verboseErr != "" {
 		t.Fatalf("ls --verbose code/stderr = %d / %q", verboseCode, verboseErr)
 	}
@@ -8948,7 +8948,7 @@ func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 		}
 	}
 
-	jsonOut, jsonErr, _, jsonCode := executeCLICommand("ls", "--host", server.URL, "--json")
+	jsonOut, jsonErr, _, jsonCode := executeCLICommand("project", "ls", "--host", server.URL, "--json")
 	if jsonCode != 0 || jsonErr != "" {
 		t.Fatalf("ls --json code/stderr = %d / %q", jsonCode, jsonErr)
 	}
@@ -8992,7 +8992,7 @@ func TestIntegrationCLIListProjectsPaginationFlags(t *testing.T) {
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("ls", "--host", server.URL, "--limit", "10", "--offset", "20", "--json")
+	stdout, stderr, _, exitCode := executeCLICommand("project", "ls", "--host", server.URL, "--limit", "10", "--offset", "20", "--json")
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("ls pagination code/stderr = %d / %q", exitCode, stderr)
 	}

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -111,20 +111,20 @@ agent-compose -f /path/to/project/agent-compose.yml logs --follow
 Remote daemon:
 
 ```bash
-agent-compose --host http://10.0.0.12:7410 ls
+agent-compose --host http://10.0.0.12:7410 project ls
 agent-compose --host http://10.0.0.12:7410 -f /path/to/project/agent-compose.yml up
 agent-compose --host http://10.0.0.12:7410 -f /path/to/project/agent-compose.yml logs --follow
 ```
 
-## `ls`: List Projects
+## `project ls`: List Projects
 
 List projects known to the selected daemon.
 
 ```bash
-agent-compose ls
-agent-compose ls --limit 20 --offset 40
-agent-compose ls --verbose
-agent-compose ls --json
+agent-compose project ls
+agent-compose project ls --limit 20 --offset 40
+agent-compose project ls --verbose
+agent-compose project ls --json
 ```
 
 Default columns:
@@ -145,25 +145,41 @@ Default columns:
 | `--offset <n>` | Start from an offset. Usually used together with `--limit`. |
 | `--verbose` | Show additional columns. |
 
-## `up`: Apply a Project
+## `agent ls`: List Current Project Agents
+
+List the agents in the current applied project. The top-level `ls` command is an alias for `agent ls`.
+
+```bash
+agent-compose agent ls
+agent-compose ls
+agent-compose agent ls --json
+```
+
+## `project up`: Apply a Project
 
 Read the config file and apply the project to the daemon. This starts or updates project schedulers and daemon-managed state.
 
 ```bash
 agent-compose up
+agent-compose project up
 agent-compose -f /path/to/project/agent-compose.yml up
 ```
 
 Current `up` semantics are daemon-style: the command applies the project and returns. It does not attach project logs and does not support `-d/--detach`.
 
-## `down`: Stop a Project
+The top-level `up` command is an alias for `project up`.
+
+## `project down`: Stop a Project
 
 Stop the current project, including schedulers, services, and running sandboxes.
 
 ```bash
 agent-compose down
+agent-compose project down
 agent-compose -f /path/to/project/agent-compose.yml down
 ```
+
+The top-level `down` command is an alias for `project down`.
 
 Notes:
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -107,20 +107,20 @@ agent-compose -f /path/to/project/agent-compose.yml logs --follow
 远程 daemon：
 
 ```bash
-agent-compose --host http://10.0.0.12:7410 ls
+agent-compose --host http://10.0.0.12:7410 project ls
 agent-compose --host http://10.0.0.12:7410 -f /path/to/project/agent-compose.yml up
 agent-compose --host http://10.0.0.12:7410 -f /path/to/project/agent-compose.yml logs --follow
 ```
 
-## `ls`：查看 project
+## `project ls`：查看 project
 
 查看当前 daemon 管理的所有 project。
 
 ```bash
-agent-compose ls
-agent-compose ls --limit 20 --offset 40
-agent-compose ls --verbose
-agent-compose ls --json
+agent-compose project ls
+agent-compose project ls --limit 20 --offset 40
+agent-compose project ls --verbose
+agent-compose project ls --json
 ```
 
 默认输出字段：
@@ -143,25 +143,41 @@ agent-compose ls --json
 | `--offset <n>` | 从指定 offset 开始读取 project。通常与 `--limit` 一起用于分页。 |
 | `--verbose` | 显示更多列。 |
 
-## `up`：启动或更新 project
+## `agent ls`：查看当前 project 的 agents
+
+查看当前已应用 project 下的所有 agents。顶级 `ls` 是 `agent ls` 的别名。
+
+```bash
+agent-compose agent ls
+agent-compose ls
+agent-compose agent ls --json
+```
+
+## `project up`：启动或更新 project
 
 读取配置文件，将 project 应用到 daemon，并启动或更新 project 中的 scheduler 和服务。
 
 ```bash
 agent-compose up
+agent-compose project up
 agent-compose -f /path/to/project/agent-compose.yml up
 ```
 
 当前 `up` 的行为是将 project 应用到 daemon 后返回，project 后续由 daemon 管理。它不会 attach project 日志，也不提供 `-d/--detach` 参数。
 
-## `down`：关闭 project
+顶级 `up` 是 `project up` 的别名。
+
+## `project down`：关闭 project
 
 关闭当前 project，停止 scheduler、服务和运行中的 sandbox。
 
 ```bash
 agent-compose down
+agent-compose project down
 agent-compose -f /path/to/project/agent-compose.yml down
 ```
+
+顶级 `down` 是 `project down` 的别名。
 
 注意事项：
 

--- a/docs/spec/core-e2e-test-strategy-spec.md
+++ b/docs/spec/core-e2e-test-strategy-spec.md
@@ -314,7 +314,7 @@ BoxLite、Microsandbox 的 runtime path、library path 和 image registry 继续
 | `PRJ-001` | `config` 和 `ValidateProject` 对合法 compose 给出一致规范化结果 | 控制面一次 |
 | `PRJ-002` | 非法变量、driver、workspace、scheduler 配置返回稳定问题路径且不产生持久化副作用 | 控制面一次 |
 | `PRJ-003` | 首次 `up` 创建 project/agent/scheduler，重复 `up` 幂等，spec 修改产生新 revision | 控制面一次 |
-| `PRJ-004` | `ls`、`inspect project/agent` 与 API 状态一致；`down` 停止相关 sandbox 并禁用 scheduler | 三 driver |
+| `PRJ-004` | `project ls`、`agent ls`、`inspect project/agent` 与 API 状态一致；`project down` 停止相关 sandbox 并禁用 scheduler | 三 driver |
 | `PRJ-005` | global/project/agent/run env 按优先级合并，secret 不出现在 CLI、日志或持久化明文视图 | 三 driver |
 
 ### Run、Exec 和日志


### PR DESCRIPTION
  ## Summary

  - Add a `project` command group:
    - Move the project-listing behavior from top-level `ls` to `project ls`.
    - Add `project up` and `project down`.
    - Keep top-level `up` and `down` as equivalent aliases.
  - Add an `agent` command group:
    - Add `agent ls` to list all agents in the current applied project.
    - Change top-level `ls` to an equivalent alias for `agent ls`.
    - Support both table and JSON output.
  - Update the English and Chinese CLI manuals and E2E contract documentation.
  - Update existing project-list tests and add coverage for the new command layout and aliases.

  ## Testing

  - `go test ./cmd/agent-compose`
  - `task lint`
  - `task build`
  - `task test`
  - `task docs:build`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.