### PR TITLE
feat(scheduler): add complete run lifecycle APIs

### DIFF
--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -39,7 +39,12 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "scheduler",
 			args: []string{"scheduler", "--help"},
-			want: []string{"Inspect and operate project schedulers, runs, logs, and triggers", "runs", "logs", "trigger", "inspect"},
+			want: []string{"Run, inspect, and operate project schedulers, runs, logs, and triggers", "run", "trigger", "runs", "logs", "stop", "inspect"},
+		},
+		{
+			name: "scheduler run",
+			args: []string{"scheduler", "run", "--help"},
+			want: []string{"Run a scheduler main function", "--payload", "--detach", "--prompt", "--sandbox"},
 		},
 		{
 			name: "scheduler trigger",

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -30,7 +30,7 @@ func TestE2ECLISchedulerPublicContractWorkflow(t *testing.T) {
 	TestIntegrationCLIUpAppliesInlineSchedulerScriptAndPSJSON(t)
 	TestIntegrationCLISchedulerList(t)
 	TestIntegrationCLISchedulerRunsLogsAndInspectResources(t)
-	TestIntegrationCLISchedulerTriggerUsesRunAgentTriggerID(t)
+	TestIntegrationCLISchedulerTriggerUsesSchedulerRunAPI(t)
 	TestIntegrationCLISchedulerInspectDeclarativeTriggerYAML(t)
 	TestIntegrationCLISchedulerInspectLoaderRegisteredTrigger(t)
 	TestIntegrationCLIInspectProjectAgentRunSandboxSessionJSON(t)

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -538,12 +538,22 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	schedulerLogsOptions := composeSchedulerLogsOptions{}
 	schedulerCmd := &cobra.Command{
 		Use:   "scheduler",
-		Short: "Inspect and operate project schedulers, runs, logs, and triggers",
+		Short: "Run, inspect, and operate project schedulers, runs, logs, and triggers",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 	}
+	schedulerRunOptions := composeSchedulerTriggerOptions{}
+	schedulerRunCmd := &cobra.Command{
+		Use:   "run <agent>",
+		Short: "Run a scheduler main function",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runComposeSchedulerMainCommand(cmd, options, schedulerRunOptions, args[0])
+		},
+	}
+	addComposeSchedulerExecutionFlags(schedulerRunCmd, &schedulerRunOptions)
 	schedulerListOptions := composeSchedulerListOptions{}
 	schedulerLSCmd := &cobra.Command{
 		Use:   "ls [agent]",
@@ -562,15 +572,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 			return runComposeSchedulerTriggerCommand(cmd, options, schedulerTriggerOptions, args[0], args[1])
 		},
 	}
-	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.SandboxID, "sandbox", "", "Reuse an existing sandbox")
-	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.Driver, "driver", "", "Runtime driver override for a new sandbox")
-	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.Prompt, "prompt", "", "Prompt override for this manual trigger run")
-	schedulerTriggerCmd.Flags().StringVar(&schedulerTriggerOptions.PayloadJSON, "payload", "", "JSON payload passed to the scheduler trigger handler")
-	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.KeepRunning, "keep-running", false, "Keep the sandbox runtime running after completion")
-	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.Remove, "rm", false, "Remove the sandbox after a successful run")
-	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.Jupyter, "jupyter", false, "Enable Jupyter for this run")
-	schedulerTriggerCmd.Flags().BoolVar(&schedulerTriggerOptions.JupyterExpose, "jupyter-expose", false, "Mark the Jupyter proxy endpoint for this run as user-accessible")
-	schedulerTriggerCmd.Flags().BoolVarP(&schedulerTriggerOptions.Detach, "detach", "d", false, "Start the run in the daemon and return immediately")
+	addComposeSchedulerExecutionFlags(schedulerTriggerCmd, &schedulerTriggerOptions)
 	schedulerRunsCmd := &cobra.Command{
 		Use:   "runs [scheduler]",
 		Short: "List project scheduler runs",
@@ -595,6 +597,16 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	schedulerLogsCmd.Flags().StringVar(&schedulerLogsOptions.Trigger, "trigger", "", "Filter by trigger name or id")
 	schedulerLogsCmd.Flags().StringVar(&schedulerLogsOptions.RunID, "run", "", "Filter by scheduler run id")
 	schedulerLogsCmd.Flags().IntVarP(&schedulerLogsOptions.Tail, "tail", "n", -1, "Show the last N log events")
+	schedulerStopOptions := composeSchedulerStopOptions{}
+	schedulerStopCmd := &cobra.Command{
+		Use:   "stop <run>",
+		Short: "Stop an active scheduler run",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runComposeSchedulerStopCommand(cmd, options, schedulerStopOptions, args[0])
+		},
+	}
+	schedulerStopCmd.Flags().StringVar(&schedulerStopOptions.Reason, "reason", "", "Reason recorded for the canceled run")
 	schedulerInspectCmd := &cobra.Command{
 		Use:   "inspect <name-or-id> [trigger]",
 		Short: "Inspect a scheduler, trigger, or scheduler run",
@@ -603,7 +615,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 			return runComposeSchedulerInspectCommand(cmd, options, args)
 		},
 	}
-	schedulerCmd.AddCommand(schedulerLSCmd, schedulerRunsCmd, schedulerLogsCmd, schedulerTriggerCmd, schedulerInspectCmd)
+	schedulerCmd.AddCommand(schedulerLSCmd, schedulerRunCmd, schedulerTriggerCmd, schedulerRunsCmd, schedulerLogsCmd, schedulerStopCmd, schedulerInspectCmd)
 
 	logsOptions := composeLogsOptions{}
 	logsCmd := &cobra.Command{
@@ -2034,53 +2046,7 @@ func runComposeSchedulerListCommand(cmd *cobra.Command, cli cliOptions, options 
 }
 
 func runComposeSchedulerTriggerCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerTriggerOptions, agentName, triggerRef string) error {
-	options, err := normalizeComposeSchedulerTriggerOptions(options)
-	if err != nil {
-		return err
-	}
-	if cmd.Flags().Changed("prompt") && strings.TrimSpace(options.Prompt) == "" {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --prompt requires a non-empty prompt")}
-	}
-	_, normalized, projectID, err := resolveComposeProject(cli)
-	if err != nil {
-		return err
-	}
-	clients, err := newCLIServiceClients(cli)
-	if err != nil {
-		return err
-	}
-	trigger, err := resolveComposeSchedulerTrigger(cmd.Context(), clients, normalized, projectID, agentName, triggerRef)
-	if err != nil {
-		return err
-	}
-	cleanupPolicy := agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION
-	if options.KeepRunning {
-		cleanupPolicy = agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_KEEP_RUNNING
-	} else if options.Remove {
-		cleanupPolicy = agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION
-	}
-	var jupyter *agentcomposev2.RunJupyterSpec
-	if options.Jupyter || options.JupyterExpose {
-		jupyter = &agentcomposev2.RunJupyterSpec{
-			Enabled: options.Jupyter || options.JupyterExpose,
-			Expose:  options.JupyterExpose,
-		}
-	}
-	runReq := &agentcomposev2.RunAgentRequest{
-		ProjectId:       projectID,
-		AgentName:       trigger.AgentName,
-		Source:          agentcomposev2.RunSource_RUN_SOURCE_MANUAL,
-		Prompt:          options.Prompt,
-		SandboxId:       strings.TrimSpace(options.SandboxID),
-		Driver:          strings.TrimSpace(options.Driver),
-		SchedulerId:     firstNonEmptyString(trigger.RawSchedulerID, trigger.SchedulerID),
-		TriggerId:       firstNonEmptyString(trigger.RawTriggerID, trigger.TriggerID),
-		PayloadJson:     options.PayloadJSON,
-		CleanupPolicy:   cleanupPolicy,
-		ClientRequestId: manualRunClientRequestID(normalized.Name, trigger.AgentName, firstNonEmptyString(trigger.RawTriggerID, trigger.TriggerID)),
-		Jupyter:         jupyter,
-	}
-	return executeComposeRunRequest(cmd, cli, normalized.Name, projectID, clients.run, runReq, options.Detach)
+	return runComposeSchedulerTriggerV2Command(cmd, cli, options, agentName, triggerRef)
 }
 
 func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerRunsOptions, args []string) error {
@@ -2344,28 +2310,7 @@ func setSchedulerTriggerInspectOutput(output *composeSchedulerInspectOutput, tri
 }
 
 func normalizeComposeSchedulerTriggerOptions(options composeSchedulerTriggerOptions) (composeSchedulerTriggerOptions, error) {
-	options.SandboxID = strings.TrimSpace(options.SandboxID)
-	options.Driver = strings.TrimSpace(options.Driver)
-	options.Prompt = strings.TrimSpace(options.Prompt)
-	options.PayloadJSON = strings.TrimSpace(options.PayloadJSON)
-	if options.PayloadJSON != "" {
-		payloadJSON, err := domain.NormalizeJSONDocument(options.PayloadJSON)
-		if err != nil {
-			return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --payload: %w", err)}
-		}
-		options.PayloadJSON = payloadJSON
-	}
-	if options.Driver != "" {
-		driver, err := driverpkg.ResolveSandboxRuntimeDriver(options.Driver, "")
-		if err != nil {
-			return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --driver: %w", err)}
-		}
-		options.Driver = driver
-	}
-	if options.SandboxID != "" && options.Driver != "" {
-		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger --driver cannot be combined with --sandbox")}
-	}
-	return options, nil
+	return normalizeComposeSchedulerExecutionOptions("scheduler trigger", options)
 }
 
 func listComposeSchedulerTriggers(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, agentFilter string) ([]composeSchedulerTriggerItem, error) {
@@ -2445,7 +2390,7 @@ func listComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, no
 			Status:      runStatus,
 			Limit:       limit,
 		}))
-		if listErr != nil {
+		if listErr != nil && connect.CodeOf(listErr) != connect.CodeUnimplemented {
 			return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agent.Name, listErr))
 		}
 		var triggers []composeSchedulerTriggerItem
@@ -2455,7 +2400,11 @@ func listComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, no
 				return nil, listErr
 			}
 		}
-		for _, run := range runsResp.Msg.GetRuns() {
+		var projectRuns []*agentcomposev2.RunSummary
+		if runsResp != nil {
+			projectRuns = runsResp.Msg.GetRuns()
+		}
+		for _, run := range projectRuns {
 			if statusText != "" && strings.ToLower(runStatusText(run.GetStatus())) != statusText {
 				continue
 			}
@@ -2520,10 +2469,11 @@ func parseSchedulerRunStatusFilter(value string) (agentcomposev2.RunStatus, stri
 		"succeeded": agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
 		"failed":    agentcomposev2.RunStatus_RUN_STATUS_FAILED,
 		"canceled":  agentcomposev2.RunStatus_RUN_STATUS_CANCELED,
+		"skipped":   agentcomposev2.RunStatus_RUN_STATUS_UNSPECIFIED,
 	}
 	status, ok := statuses[value]
 	if !ok {
-		return agentcomposev2.RunStatus_RUN_STATUS_UNSPECIFIED, "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler runs --status must be pending, running, succeeded, failed, or canceled")}
+		return agentcomposev2.RunStatus_RUN_STATUS_UNSPECIFIED, "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler runs --status must be pending, running, succeeded, failed, canceled, or skipped")}
 	}
 	return status, value, nil
 }
@@ -2589,12 +2539,90 @@ func listSchedulerRunEvents(ctx context.Context, clients cliServiceClients, proj
 	return events, nil
 }
 
-func listSchedulerRuntimeRuns(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, eventLimit uint32) ([]composeSchedulerRunItem, error) {
+func listSchedulerRuntimeRuns(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, limit uint32) ([]composeSchedulerRunItem, error) {
+	runs, err := listSchedulerRunsFromAPI(ctx, client, projectID, agentName, schedulerID, loaderID, limit)
+	if err == nil {
+		legacy, legacyErr := listLegacySchedulerRuntimeRuns(ctx, client, projectID, agentName, schedulerID, loaderID, limit)
+		if legacyErr == nil {
+			return mergeSchedulerRuntimeRuns(runs, legacy), nil
+		}
+		return runs, nil
+	}
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agentName, err))
+	}
+	legacy, legacyErr := listLegacySchedulerRuntimeRuns(ctx, client, projectID, agentName, schedulerID, loaderID, limit)
+	if legacyErr != nil {
+		return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agentName, err))
+	}
+	return legacy, nil
+}
+
+func listSchedulerRunsFromAPI(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, limit uint32) ([]composeSchedulerRunItem, error) {
+	if limit == 0 || limit > 500 {
+		limit = 500
+	}
+	runs := make([]composeSchedulerRunItem, 0, limit)
+	cursor := ""
+	seenCursors := make(map[string]struct{})
+	for uint32(len(runs)) < limit {
+		pageLimit := uint32(100)
+		if remaining := limit - uint32(len(runs)); remaining < pageLimit {
+			pageLimit = remaining
+		}
+		resp, err := client.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
+			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, Limit: pageLimit, Cursor: cursor,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		for _, run := range resp.Msg.GetRuns() {
+			runs = append(runs, schedulerRuntimeRunItem(schedulerID, loaderID, run))
+			if uint32(len(runs)) == limit {
+				return runs, nil
+			}
+		}
+		next := strings.TrimSpace(resp.Msg.GetNextCursor())
+		if next == "" {
+			return runs, nil
+		}
+		if _, ok := seenCursors[next]; ok {
+			return nil, fmt.Errorf("daemon returned a repeated scheduler run cursor")
+		}
+		seenCursors[next] = struct{}{}
+		cursor = next
+	}
+	return runs, nil
+}
+
+func schedulerRuntimeRunItem(schedulerID, loaderID string, run *agentcomposev2.SchedulerRun) composeSchedulerRunItem {
+	return composeSchedulerRunItem{
+		RunID:            run.GetRunId(),
+		RunShortID:       shortOpaqueID(run.GetRunId()),
+		AgentName:        run.GetAgentName(),
+		SchedulerID:      firstNonEmptyString(run.GetSchedulerId(), schedulerID),
+		ManagedLoaderID:  loaderID,
+		TriggerID:        run.GetTriggerId(),
+		TriggerKind:      run.GetTriggerKind(),
+		TriggerSource:    run.GetTriggerSource(),
+		Status:           schedulerRunStatusText(run.GetStatus()),
+		StartedAt:        formatProtoTimestamp(run.GetStartedAt()),
+		CompletedAt:      formatProtoTimestamp(run.GetCompletedAt()),
+		DurationMs:       run.GetDurationMs(),
+		Error:            run.GetError(),
+		ResultJSON:       run.GetResultJson(),
+		PayloadJSON:      run.GetPayloadJson(),
+		ArtifactsDir:     run.GetArtifactsDir(),
+		schedulerRuntime: true,
+	}
+}
+
+func listLegacySchedulerRuntimeRuns(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, eventLimit uint32) ([]composeSchedulerRunItem, error) {
 	resp, err := client.ListSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
 		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, Limit: eventLimit,
 	}))
 	if err != nil {
-		return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler events for agent %s: %w", agentName, err))
+		return nil, err
 	}
 	byID := make(map[string]*composeSchedulerRunItem)
 	for _, event := range resp.Msg.GetEvents() {
@@ -2623,6 +2651,23 @@ func listSchedulerRuntimeRuns(ctx context.Context, client agentcomposev2connect.
 	return runs, nil
 }
 
+func mergeSchedulerRuntimeRuns(current, legacy []composeSchedulerRunItem) []composeSchedulerRunItem {
+	byID := make(map[string]int, len(current))
+	for index := range current {
+		byID[current[index].RunID] = index
+	}
+	for _, run := range legacy {
+		index, ok := byID[run.RunID]
+		if !ok {
+			byID[run.RunID] = len(current)
+			current = append(current, run)
+			continue
+		}
+		current[index].SandboxIDs = appendUniqueStrings(current[index].SandboxIDs, run.SandboxIDs...)
+	}
+	return current
+}
+
 func applySchedulerRuntimeEvent(run *composeSchedulerRunItem, event *agentcomposev2.SchedulerEvent) {
 	eventType := strings.TrimSpace(event.GetType())
 	createdAt := formatProtoTimestamp(event.GetCreatedAt())
@@ -2646,6 +2691,22 @@ func applySchedulerRuntimeEvent(run *composeSchedulerRunItem, event *agentcompos
 }
 
 func resolveSchedulerRuntimeRun(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, normalized *compose.NormalizedProjectSpec, projectID, ref string) (*composeSchedulerRunItem, error) {
+	ref = strings.TrimSpace(ref)
+	response, err := client.GetSchedulerRun(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRunRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, RunId: ref,
+	}))
+	if err == nil && response != nil && response.Msg.GetRun() != nil {
+		run := response.Msg.GetRun()
+		loaderID, idErr := domain.StableManagedLoaderID(projectID, run.GetAgentName(), "")
+		if idErr != nil {
+			return nil, idErr
+		}
+		item := schedulerRuntimeRunItem(run.GetSchedulerId(), loaderID, run)
+		return &item, nil
+	}
+	if err != nil && connect.CodeOf(err) != connect.CodeNotFound && connect.CodeOf(err) != connect.CodeUnimplemented {
+		return nil, commandExitErrorForConnect(fmt.Errorf("get scheduler run %s: %w", ref, err))
+	}
 	matches := make([]composeSchedulerRunItem, 0)
 	for _, agent := range normalized.Agents {
 		if agent.Scheduler == nil {
@@ -5262,15 +5323,10 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 		if target == "" {
 			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect run requires a run id")}
 		}
-		target, err = resolveComposeRunIDRef(cmd.Context(), clients.run, projectID, "", target)
+		output, err = inspectComposeRunOutput(cmd.Context(), clients, projectID, normalized.Name, target)
 		if err != nil {
 			return err
 		}
-		run, err := getRunDetail(cmd.Context(), clients.run, projectID, target)
-		if err != nil {
-			return commandExitErrorForConnect(fmt.Errorf("inspect run %s in project %s: %w", target, normalized.Name, err))
-		}
-		output = composeRunOutputFromDetail(run.Msg.GetRun())
 	case "sandbox":
 		if target == "" {
 			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect sandbox requires a sandbox")}

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -3122,20 +3122,19 @@ func TestComposeUpUsesDistinctStableTriggerIDs(t *testing.T) {
 
 func TestNormalizeComposeSchedulerTriggerOptionsPayload(t *testing.T) {
 	options, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{
-		Prompt:      " override prompt ",
 		PayloadJSON: " { \"topic\" : \"nightly\" } ",
 	})
 	if err != nil {
 		t.Fatalf("normalize payload returned error: %v", err)
-	}
-	if options.Prompt != "override prompt" {
-		t.Fatalf("prompt = %q", options.Prompt)
 	}
 	if options.PayloadJSON != `{"topic":"nightly"}` {
 		t.Fatalf("payload = %q", options.PayloadJSON)
 	}
 	if _, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{PayloadJSON: "{bad"}); err == nil {
 		t.Fatalf("invalid payload returned nil error")
+	}
+	if _, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{Prompt: "override"}); err == nil || !strings.Contains(err.Error(), "deprecated") {
+		t.Fatalf("deprecated prompt error = %v", err)
 	}
 }
 
@@ -3285,7 +3284,7 @@ agents:
 	}
 }
 
-func TestIntegrationCLISchedulerTriggerUsesRunAgentTriggerID(t *testing.T) {
+func TestIntegrationCLISchedulerTriggerUsesSchedulerRunAPI(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
 name: cli-scheduler-trigger
 agents:
@@ -3297,37 +3296,25 @@ agents:
           cron: "0 2 * * *"
           prompt: review nightly
 `)
-	var requestedSandboxIDs []string
 	var requestedPayloads []string
-	var requestedPrompts []string
+	var requestedTriggerIDs []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
-			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
-				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-scheduler-trigger", composePath)}), nil
-			},
-		},
-		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				requestedSandboxIDs = append(requestedSandboxIDs, req.Msg.GetSandboxId())
+			runScheduler: func(ctx context.Context, req *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error) {
 				requestedPayloads = append(requestedPayloads, req.Msg.GetPayloadJson())
-				requestedPrompts = append(requestedPrompts, req.Msg.GetPrompt())
-				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) || req.Msg.GetCommand() != "" || req.Msg.GetSource() != agentcomposev2.RunSource_RUN_SOURCE_MANUAL {
-					t.Fatalf("RunAgentStream scheduler trigger request = %#v", req.Msg)
+				requestedTriggerIDs = append(requestedTriggerIDs, req.Msg.GetTriggerId())
+				if req.Msg.GetAgentName() != "reviewer" || !identity.IsID(req.Msg.GetTriggerId()) {
+					t.Fatalf("RunScheduler request = %#v", req.Msg)
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
-					RunId:     "run-scheduler-trigger",
-					Run: &agentcomposev2.RunSummary{
-						RunId:     "run-scheduler-trigger",
-						ProjectId: req.Msg.GetProjectId(),
-						AgentName: "reviewer",
-						Status:    agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
-						SandboxId: "sandbox-scheduler-trigger",
-					},
-				})
-			},
-			getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
-				return connect.NewResponse(&agentcomposev2.GetRunResponse{Run: testRunDetail(req.Msg.GetProjectId(), "run-scheduler-trigger", "reviewer", "sandbox-scheduler-trigger", agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, 0, "")}), nil
+				return connect.NewResponse(&agentcomposev2.RunSchedulerResponse{Run: &agentcomposev2.SchedulerRun{
+					RunId:       "scheduler-run-1",
+					ProjectId:   req.Msg.GetProject().GetProjectId(),
+					AgentName:   req.Msg.GetAgentName(),
+					TriggerId:   req.Msg.GetTriggerId(),
+					Status:      agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+					ResultJson:  `{"ok":true}`,
+					PayloadJson: req.Msg.GetPayloadJson(),
+				}}), nil
 			},
 		},
 	})
@@ -3337,33 +3324,28 @@ agents:
 		name      string
 		extraArgs []string
 	}{
-		{name: "creates sandbox"},
-		{name: "reuses sandbox", extraArgs: []string{"--sandbox", "sandbox-existing"}},
+		{name: "runs trigger"},
 		{name: "passes payload", extraArgs: []string{"--payload", `{"topic":"nightly"}`}},
-		{name: "passes prompt", extraArgs: []string{"--prompt", "review override"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			args := []string{"scheduler", "trigger", "--host", server.URL, "--file", composePath}
 			args = append(args, tc.extraArgs...)
 			args = append(args, "reviewer", "nightly")
 			stdout, stderr, _, exitCode := executeCLICommand(args...)
-			if exitCode != 0 || stdout != "" || stderr != "" {
+			if exitCode != 0 || !strings.Contains(stdout, "Status: succeeded") || !strings.Contains(stdout, `Result: {"ok":true}`) || stderr != "" {
 				t.Fatalf("scheduler trigger code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 			}
 		})
 	}
-	if !reflect.DeepEqual(requestedSandboxIDs, []string{"", "sandbox-existing", "", ""}) {
-		t.Fatalf("scheduler trigger sandbox IDs = %#v", requestedSandboxIDs)
-	}
-	if !reflect.DeepEqual(requestedPayloads, []string{"", "", `{"topic":"nightly"}`, ""}) {
+	if !reflect.DeepEqual(requestedPayloads, []string{"", `{"topic":"nightly"}`}) {
 		t.Fatalf("scheduler trigger payloads = %#v", requestedPayloads)
 	}
-	if !reflect.DeepEqual(requestedPrompts, []string{"", "", "", "review override"}) {
-		t.Fatalf("scheduler trigger prompts = %#v", requestedPrompts)
+	if len(requestedTriggerIDs) != 2 || requestedTriggerIDs[0] != requestedTriggerIDs[1] {
+		t.Fatalf("scheduler trigger IDs = %#v", requestedTriggerIDs)
 	}
 }
 
-func TestRunComposeSchedulerTriggerPromptRequiresValue(t *testing.T) {
+func TestRunComposeSchedulerTriggerRejectsDeprecatedPrompt(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().String("prompt", "", "")
 	if err := cmd.Flags().Set("prompt", " "); err != nil {
@@ -3371,7 +3353,7 @@ func TestRunComposeSchedulerTriggerPromptRequiresValue(t *testing.T) {
 	}
 	err := runComposeSchedulerTriggerCommand(cmd, cliOptions{}, composeSchedulerTriggerOptions{Prompt: " "}, "reviewer", "nightly")
 	var exitErr commandExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != exitCodeUsage || !strings.Contains(err.Error(), "--prompt requires a non-empty prompt") {
+	if !errors.As(err, &exitErr) || exitErr.Code != exitCodeUsage || !strings.Contains(err.Error(), "--prompt is deprecated") {
 		t.Fatalf("prompt error = %#v", err)
 	}
 }
@@ -8821,6 +8803,9 @@ agents:
 				getProject: func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
 					return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project missing"))
 				},
+				getSchedulerRun: func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error) {
+					return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("run missing"))
+				},
 			},
 			run: runServiceStub{
 				getRun: func(context.Context, *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
@@ -9679,6 +9664,11 @@ type projectServiceStub struct {
 	removeProject       func(context.Context, *connect.Request[agentcomposev2.RemoveProjectRequest]) (*connect.Response[agentcomposev2.RemoveProjectResponse], error)
 	getScheduler        func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error)
 	listSchedulerEvents func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error)
+	runScheduler        func(context.Context, *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error)
+	startSchedulerRun   func(context.Context, *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error)
+	getSchedulerRun     func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error)
+	listSchedulerRuns   func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error)
+	stopSchedulerRun    func(context.Context, *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error)
 
 	agentcomposev2connect.UnimplementedProjectServiceHandler
 }
@@ -9702,6 +9692,41 @@ func (s projectServiceStub) GetScheduler(ctx context.Context, req *connect.Reque
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("GetScheduler stub is not configured"))
 	}
 	return s.getScheduler(ctx, req)
+}
+
+func (s projectServiceStub) RunScheduler(ctx context.Context, req *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error) {
+	if s.runScheduler == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("RunScheduler stub is not configured"))
+	}
+	return s.runScheduler(ctx, req)
+}
+
+func (s projectServiceStub) StartSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error) {
+	if s.startSchedulerRun == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StartSchedulerRun stub is not configured"))
+	}
+	return s.startSchedulerRun(ctx, req)
+}
+
+func (s projectServiceStub) GetSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error) {
+	if s.getSchedulerRun == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("GetSchedulerRun stub is not configured"))
+	}
+	return s.getSchedulerRun(ctx, req)
+}
+
+func (s projectServiceStub) ListSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+	if s.listSchedulerRuns == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ListSchedulerRuns stub is not configured"))
+	}
+	return s.listSchedulerRuns(ctx, req)
+}
+
+func (s projectServiceStub) StopSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error) {
+	if s.stopSchedulerRun == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StopSchedulerRun stub is not configured"))
+	}
+	return s.stopSchedulerRun(ctx, req)
 }
 
 func (s projectServiceStub) GetProject(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
@@ -10080,7 +10105,7 @@ func sandboxStubWithSessionCompatibility(sandbox sandboxServiceStub, session ses
 func newComposeServiceStubServer(t *testing.T, stubs composeServiceStubs) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil {
+	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil {
 		path, handler := agentcomposev2connect.NewProjectServiceHandler(stubs.project)
 		mux.Handle(path, handler)
 	}

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -3133,8 +3133,8 @@ func TestNormalizeComposeSchedulerTriggerOptionsPayload(t *testing.T) {
 	if _, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{PayloadJSON: "{bad"}); err == nil {
 		t.Fatalf("invalid payload returned nil error")
 	}
-	if _, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{Prompt: "override"}); err == nil || !strings.Contains(err.Error(), "deprecated") {
-		t.Fatalf("deprecated prompt error = %v", err)
+	if _, err := normalizeComposeSchedulerTriggerOptions(composeSchedulerTriggerOptions{Prompt: "override"}); err == nil || !strings.Contains(err.Error(), "unsupported for complete scheduler runs") {
+		t.Fatalf("unsupported prompt error = %v", err)
 	}
 }
 
@@ -3345,7 +3345,7 @@ agents:
 	}
 }
 
-func TestRunComposeSchedulerTriggerRejectsDeprecatedPrompt(t *testing.T) {
+func TestRunComposeSchedulerTriggerRejectsUnsupportedPrompt(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().String("prompt", "", "")
 	if err := cmd.Flags().Set("prompt", " "); err != nil {
@@ -3353,7 +3353,7 @@ func TestRunComposeSchedulerTriggerRejectsDeprecatedPrompt(t *testing.T) {
 	}
 	err := runComposeSchedulerTriggerCommand(cmd, cliOptions{}, composeSchedulerTriggerOptions{Prompt: " "}, "reviewer", "nightly")
 	var exitErr commandExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != exitCodeUsage || !strings.Contains(err.Error(), "--prompt is deprecated") {
+	if !errors.As(err, &exitErr) || exitErr.Code != exitCodeUsage || !strings.Contains(err.Error(), "--prompt is unsupported for complete scheduler runs") {
 		t.Fatalf("prompt error = %#v", err)
 	}
 }

--- a/cmd/agent-compose/scheduler_runs.go
+++ b/cmd/agent-compose/scheduler_runs.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+type composeSchedulerStopOptions struct {
+	Reason string
+}
+
+type composeSchedulerRunOutput struct {
+	ID                 string `json:"id"`
+	ShortID            string `json:"short_id"`
+	ProjectID          string `json:"project_id"`
+	ProjectName        string `json:"project_name,omitempty"`
+	AgentName          string `json:"agent_name"`
+	SchedulerID        string `json:"scheduler_id"`
+	SchedulerShortID   string `json:"scheduler_short_id,omitempty"`
+	TriggerID          string `json:"trigger_id,omitempty"`
+	TriggerShortID     string `json:"trigger_short_id,omitempty"`
+	TriggerKind        string `json:"trigger_kind,omitempty"`
+	TriggerSource      string `json:"trigger_source,omitempty"`
+	Status             string `json:"status"`
+	StartedAt          string `json:"started_at,omitempty"`
+	CompletedAt        string `json:"completed_at,omitempty"`
+	DurationMs         int64  `json:"duration_ms,omitempty"`
+	Error              string `json:"error,omitempty"`
+	ResultJSON         string `json:"result_json,omitempty"`
+	PayloadJSON        string `json:"payload_json,omitempty"`
+	SourceScriptSHA256 string `json:"source_script_sha256,omitempty"`
+	ArtifactsDir       string `json:"artifacts_dir,omitempty"`
+	InspectCommand     string `json:"inspect_command,omitempty"`
+	StopCommand        string `json:"stop_command,omitempty"`
+}
+
+type composeSchedulerStopOutput struct {
+	Run           composeSchedulerRunOutput `json:"run"`
+	StopRequested bool                      `json:"stop_requested"`
+}
+
+func addComposeSchedulerExecutionFlags(cmd *cobra.Command, options *composeSchedulerTriggerOptions) {
+	cmd.Flags().StringVar(&options.SandboxID, "sandbox", "", "Deprecated: unsupported for complete scheduler runs")
+	cmd.Flags().StringVar(&options.Driver, "driver", "", "Deprecated: unsupported for complete scheduler runs")
+	cmd.Flags().StringVar(&options.Prompt, "prompt", "", "Deprecated: scheduler scripts own their agent prompts")
+	cmd.Flags().StringVar(&options.PayloadJSON, "payload", "", "JSON payload passed to main or the trigger callback")
+	cmd.Flags().BoolVar(&options.KeepRunning, "keep-running", false, "Deprecated: unsupported for complete scheduler runs")
+	cmd.Flags().BoolVar(&options.Remove, "rm", false, "Deprecated: unsupported for complete scheduler runs")
+	cmd.Flags().BoolVar(&options.Jupyter, "jupyter", false, "Deprecated: unsupported for complete scheduler runs")
+	cmd.Flags().BoolVar(&options.JupyterExpose, "jupyter-expose", false, "Deprecated: unsupported for complete scheduler runs")
+	cmd.Flags().BoolVarP(&options.Detach, "detach", "d", false, "Start the scheduler run and return immediately")
+}
+
+func runComposeSchedulerMainCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerTriggerOptions, agentRef string) error {
+	options, err := prepareComposeSchedulerExecutionOptions(cmd, "scheduler run", options)
+	if err != nil {
+		return err
+	}
+	_, normalized, projectID, err := resolveComposeProject(cli)
+	if err != nil {
+		return err
+	}
+	agentName, err := resolveComposeAgentNameFromSpec(normalized, projectID, agentRef)
+	if err != nil {
+		return err
+	}
+	agent, ok := composeRunAgentSpec(normalized, agentName)
+	if !ok || agent.Scheduler == nil {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("agent %q does not define a scheduler", agentName)}
+	}
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	return executeComposeSchedulerRun(cmd, cli, normalized.Name, projectID, agentName, "", options, clients.project)
+}
+
+func runComposeSchedulerTriggerV2Command(cmd *cobra.Command, cli cliOptions, options composeSchedulerTriggerOptions, agentRef, triggerRef string) error {
+	options, err := prepareComposeSchedulerExecutionOptions(cmd, "scheduler trigger", options)
+	if err != nil {
+		return err
+	}
+	_, normalized, projectID, err := resolveComposeProject(cli)
+	if err != nil {
+		return err
+	}
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	trigger, err := resolveComposeSchedulerTrigger(cmd.Context(), clients, normalized, projectID, agentRef, triggerRef)
+	if err != nil {
+		return err
+	}
+	triggerID := firstNonEmptyString(trigger.RawTriggerID, trigger.TriggerID)
+	return executeComposeSchedulerRun(cmd, cli, normalized.Name, projectID, trigger.AgentName, triggerID, options, clients.project)
+}
+
+func executeComposeSchedulerRun(cmd *cobra.Command, cli cliOptions, projectName, projectID, agentName, triggerID string, options composeSchedulerTriggerOptions, client agentcomposev2connect.ProjectServiceClient) error {
+	project := &agentcomposev2.ProjectRef{ProjectId: projectID}
+	var run *agentcomposev2.SchedulerRun
+	if options.Detach {
+		response, err := client.StartSchedulerRun(cmd.Context(), connect.NewRequest(&agentcomposev2.StartSchedulerRunRequest{
+			Project: project, AgentName: agentName, TriggerId: triggerID, PayloadJson: options.PayloadJSON,
+		}))
+		if err != nil {
+			return commandExitErrorForConnect(fmt.Errorf("start scheduler run for project %s agent %s: %w", projectName, agentName, err))
+		}
+		run = response.Msg.GetRun()
+	} else {
+		response, err := client.RunScheduler(cmd.Context(), connect.NewRequest(&agentcomposev2.RunSchedulerRequest{
+			Project: project, AgentName: agentName, TriggerId: triggerID, PayloadJson: options.PayloadJSON,
+		}))
+		if err != nil {
+			return commandExitErrorForConnect(fmt.Errorf("run scheduler for project %s agent %s: %w", projectName, agentName, err))
+		}
+		run = response.Msg.GetRun()
+	}
+	if run == nil {
+		return fmt.Errorf("scheduler run for project %s agent %s: response did not include a run", projectName, agentName)
+	}
+	output := composeSchedulerRunOutputFromProto(run, projectName)
+	if options.Detach {
+		output.InspectCommand = schedulerRunCLICommand(cli, "inspect", "run", run.GetRunId())
+		output.StopCommand = schedulerRunCLICommand(cli, "scheduler", "stop", run.GetRunId())
+	}
+	if err := writeComposeSchedulerRunOutput(cmd.OutOrStdout(), output, cli.JSON, options.Detach); err != nil {
+		return err
+	}
+	if options.Detach {
+		return nil
+	}
+	return composeSchedulerRunCompletionError(projectName, output)
+}
+
+func runComposeSchedulerStopCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerStopOptions, runID string) error {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler stop requires a run id")}
+	}
+	_, normalized, projectID, err := resolveComposeProject(cli)
+	if err != nil {
+		return err
+	}
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	response, err := clients.project.StopSchedulerRun(cmd.Context(), connect.NewRequest(&agentcomposev2.StopSchedulerRunRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, RunId: runID, Reason: strings.TrimSpace(options.Reason),
+	}))
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("stop scheduler run %s in project %s: %w", runID, normalized.Name, err))
+	}
+	run := response.Msg.GetRun()
+	if run == nil {
+		return fmt.Errorf("stop scheduler run %s in project %s: response did not include a run", runID, normalized.Name)
+	}
+	output := composeSchedulerStopOutput{Run: composeSchedulerRunOutputFromProto(run, normalized.Name), StopRequested: response.Msg.GetStopRequested()}
+	if cli.JSON {
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
+	}
+	if err := writeSchedulerRunText(cmd.OutOrStdout(), output.Run); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Stop requested: %t\n", output.StopRequested)
+	return err
+}
+
+func inspectComposeRunOutput(ctx context.Context, clients cliServiceClients, projectID, projectName, target string) (any, error) {
+	runID, err := resolveComposeRunIDRef(ctx, clients.run, projectID, "", target)
+	if err != nil {
+		return nil, err
+	}
+	run, err := getRunDetail(ctx, clients.run, projectID, runID)
+	if err == nil {
+		return composeRunOutputFromDetail(run.Msg.GetRun()), nil
+	}
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		return nil, commandExitErrorForConnect(fmt.Errorf("inspect run %s in project %s: %w", runID, projectName, err))
+	}
+	schedulerRun, schedulerErr := clients.project.GetSchedulerRun(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRunRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, RunId: runID,
+	}))
+	if schedulerErr != nil {
+		return nil, commandExitErrorForConnect(fmt.Errorf("inspect run %s in project %s: %w", runID, projectName, schedulerErr))
+	}
+	if schedulerRun.Msg.GetRun() == nil {
+		return nil, fmt.Errorf("inspect scheduler run %s in project %s: response did not include a run", runID, projectName)
+	}
+	return composeSchedulerRunOutputFromProto(schedulerRun.Msg.GetRun(), projectName), nil
+}
+
+func prepareComposeSchedulerExecutionOptions(cmd *cobra.Command, command string, options composeSchedulerTriggerOptions) (composeSchedulerTriggerOptions, error) {
+	if err := rejectChangedSchedulerExecutionFlags(cmd, command); err != nil {
+		return options, err
+	}
+	return normalizeComposeSchedulerExecutionOptions(command, options)
+}
+
+func rejectChangedSchedulerExecutionFlags(cmd *cobra.Command, command string) error {
+	for _, flagName := range []string{"prompt", "sandbox", "driver", "keep-running", "rm", "jupyter", "jupyter-expose"} {
+		flag := cmd.Flags().Lookup(flagName)
+		if flag == nil || !flag.Changed {
+			continue
+		}
+		return deprecatedSchedulerExecutionFlagError(command, flagName)
+	}
+	return nil
+}
+
+func normalizeComposeSchedulerExecutionOptions(command string, options composeSchedulerTriggerOptions) (composeSchedulerTriggerOptions, error) {
+	options.SandboxID = strings.TrimSpace(options.SandboxID)
+	options.Driver = strings.TrimSpace(options.Driver)
+	options.Prompt = strings.TrimSpace(options.Prompt)
+	options.PayloadJSON = strings.TrimSpace(options.PayloadJSON)
+	for _, deprecated := range []struct {
+		name string
+		used bool
+	}{
+		{name: "prompt", used: options.Prompt != ""},
+		{name: "sandbox", used: options.SandboxID != ""},
+		{name: "driver", used: options.Driver != ""},
+		{name: "keep-running", used: options.KeepRunning},
+		{name: "rm", used: options.Remove},
+		{name: "jupyter", used: options.Jupyter},
+		{name: "jupyter-expose", used: options.JupyterExpose},
+	} {
+		if deprecated.used {
+			return options, deprecatedSchedulerExecutionFlagError(command, deprecated.name)
+		}
+	}
+	if options.PayloadJSON != "" {
+		payloadJSON, err := domain.NormalizeJSONDocument(options.PayloadJSON)
+		if err != nil {
+			return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("%s --payload: %w", command, err)}
+		}
+		options.PayloadJSON = payloadJSON
+	}
+	return options, nil
+}
+
+func deprecatedSchedulerExecutionFlagError(command, flagName string) error {
+	return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("%s --%s is deprecated and unsupported by complete scheduler runs", command, flagName)}
+}
+
+func composeSchedulerRunOutputFromProto(run *agentcomposev2.SchedulerRun, projectName string) composeSchedulerRunOutput {
+	return composeSchedulerRunOutput{
+		ID:                 displayOpaqueID(run.GetRunId()),
+		ShortID:            shortOpaqueID(run.GetRunId()),
+		ProjectID:          displayOpaqueID(run.GetProjectId()),
+		ProjectName:        projectName,
+		AgentName:          run.GetAgentName(),
+		SchedulerID:        displayOpaqueID(run.GetSchedulerId()),
+		SchedulerShortID:   shortOpaqueID(run.GetSchedulerId()),
+		TriggerID:          displayOpaqueID(run.GetTriggerId()),
+		TriggerShortID:     shortOpaqueID(run.GetTriggerId()),
+		TriggerKind:        run.GetTriggerKind(),
+		TriggerSource:      run.GetTriggerSource(),
+		Status:             schedulerRunStatusText(run.GetStatus()),
+		StartedAt:          formatProtoTimestamp(run.GetStartedAt()),
+		CompletedAt:        formatProtoTimestamp(run.GetCompletedAt()),
+		DurationMs:         run.GetDurationMs(),
+		Error:              run.GetError(),
+		ResultJSON:         run.GetResultJson(),
+		PayloadJSON:        run.GetPayloadJson(),
+		SourceScriptSHA256: run.GetSourceScriptSha256(),
+		ArtifactsDir:       run.GetArtifactsDir(),
+	}
+}
+
+func writeComposeSchedulerRunOutput(out io.Writer, output composeSchedulerRunOutput, asJSON, detached bool) error {
+	if asJSON {
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeCommandOutput(out, append(data, '\n'))
+	}
+	if detached {
+		return writeDetachedSchedulerRunText(out, output)
+	}
+	return writeSchedulerRunText(out, output)
+}
+
+func writeSchedulerRunText(out io.Writer, run composeSchedulerRunOutput) error {
+	trigger := firstNonEmptyString(run.TriggerID, "main")
+	if _, err := fmt.Fprintf(out, "Run: %s\nAgent: %s\nTrigger: %s\nStatus: %s\n", run.ID, run.AgentName, trigger, run.Status); err != nil {
+		return err
+	}
+	if run.ResultJSON != "" {
+		if _, err := fmt.Fprintf(out, "Result: %s\n", run.ResultJSON); err != nil {
+			return err
+		}
+	}
+	if run.Error != "" {
+		if _, err := fmt.Fprintf(out, "Error: %s\n", run.Error); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeDetachedSchedulerRunText(out io.Writer, run composeSchedulerRunOutput) error {
+	_, err := fmt.Fprintf(out, "Run: %s\nStatus: %s\nInspect: %s\nStop: %s\n", run.ID, run.Status, run.InspectCommand, run.StopCommand)
+	return err
+}
+
+func composeSchedulerRunCompletionError(projectName string, run composeSchedulerRunOutput) error {
+	if run.Status == "succeeded" {
+		return nil
+	}
+	message := firstNonEmptyString(run.Error, run.Status)
+	return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("scheduler run %s for project %s agent %s %s: %s", run.ID, projectName, run.AgentName, run.Status, message)}
+}
+
+func schedulerRunStatusText(status agentcomposev2.SchedulerRunStatus) string {
+	switch status {
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING:
+		return "running"
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED:
+		return "succeeded"
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED:
+		return "failed"
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED:
+		return "canceled"
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED:
+		return "skipped"
+	default:
+		return "unspecified"
+	}
+}
+
+func schedulerRunCLICommand(cli cliOptions, args ...string) string {
+	parts := []string{"agent-compose"}
+	if value := strings.TrimSpace(cli.Host); value != "" {
+		parts = append(parts, "--host", value)
+	}
+	if value := strings.TrimSpace(cli.ComposeFile); value != "" {
+		parts = append(parts, "--file", value)
+	}
+	if value := strings.TrimSpace(cli.ProjectName); value != "" {
+		parts = append(parts, "--project-name", value)
+	}
+	parts = append(parts, args...)
+	for index, part := range parts {
+		parts[index] = shellQuoteCLIArg(part)
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/agent-compose/scheduler_runs.go
+++ b/cmd/agent-compose/scheduler_runs.go
@@ -50,14 +50,14 @@ type composeSchedulerStopOutput struct {
 }
 
 func addComposeSchedulerExecutionFlags(cmd *cobra.Command, options *composeSchedulerTriggerOptions) {
-	cmd.Flags().StringVar(&options.SandboxID, "sandbox", "", "Deprecated: unsupported for complete scheduler runs")
-	cmd.Flags().StringVar(&options.Driver, "driver", "", "Deprecated: unsupported for complete scheduler runs")
-	cmd.Flags().StringVar(&options.Prompt, "prompt", "", "Deprecated: scheduler scripts own their agent prompts")
+	cmd.Flags().StringVar(&options.SandboxID, "sandbox", "", "Unsupported for complete scheduler runs")
+	cmd.Flags().StringVar(&options.Driver, "driver", "", "Unsupported for complete scheduler runs")
+	cmd.Flags().StringVar(&options.Prompt, "prompt", "", "Unsupported for complete scheduler runs; scheduler scripts own their agent prompts")
 	cmd.Flags().StringVar(&options.PayloadJSON, "payload", "", "JSON payload passed to main or the trigger callback")
-	cmd.Flags().BoolVar(&options.KeepRunning, "keep-running", false, "Deprecated: unsupported for complete scheduler runs")
-	cmd.Flags().BoolVar(&options.Remove, "rm", false, "Deprecated: unsupported for complete scheduler runs")
-	cmd.Flags().BoolVar(&options.Jupyter, "jupyter", false, "Deprecated: unsupported for complete scheduler runs")
-	cmd.Flags().BoolVar(&options.JupyterExpose, "jupyter-expose", false, "Deprecated: unsupported for complete scheduler runs")
+	cmd.Flags().BoolVar(&options.KeepRunning, "keep-running", false, "Unsupported for complete scheduler runs")
+	cmd.Flags().BoolVar(&options.Remove, "rm", false, "Unsupported for complete scheduler runs")
+	cmd.Flags().BoolVar(&options.Jupyter, "jupyter", false, "Unsupported for complete scheduler runs")
+	cmd.Flags().BoolVar(&options.JupyterExpose, "jupyter-expose", false, "Unsupported for complete scheduler runs")
 	cmd.Flags().BoolVarP(&options.Detach, "detach", "d", false, "Start the scheduler run and return immediately")
 }
 
@@ -218,7 +218,7 @@ func rejectChangedSchedulerExecutionFlags(cmd *cobra.Command, command string) er
 		if flag == nil || !flag.Changed {
 			continue
 		}
-		return deprecatedSchedulerExecutionFlagError(command, flagName)
+		return unsupportedSchedulerExecutionFlagError(command, flagName)
 	}
 	return nil
 }
@@ -228,7 +228,7 @@ func normalizeComposeSchedulerExecutionOptions(command string, options composeSc
 	options.Driver = strings.TrimSpace(options.Driver)
 	options.Prompt = strings.TrimSpace(options.Prompt)
 	options.PayloadJSON = strings.TrimSpace(options.PayloadJSON)
-	for _, deprecated := range []struct {
+	for _, unsupported := range []struct {
 		name string
 		used bool
 	}{
@@ -240,8 +240,8 @@ func normalizeComposeSchedulerExecutionOptions(command string, options composeSc
 		{name: "jupyter", used: options.Jupyter},
 		{name: "jupyter-expose", used: options.JupyterExpose},
 	} {
-		if deprecated.used {
-			return options, deprecatedSchedulerExecutionFlagError(command, deprecated.name)
+		if unsupported.used {
+			return options, unsupportedSchedulerExecutionFlagError(command, unsupported.name)
 		}
 	}
 	if options.PayloadJSON != "" {
@@ -254,8 +254,8 @@ func normalizeComposeSchedulerExecutionOptions(command string, options composeSc
 	return options, nil
 }
 
-func deprecatedSchedulerExecutionFlagError(command, flagName string) error {
-	return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("%s --%s is deprecated and unsupported by complete scheduler runs", command, flagName)}
+func unsupportedSchedulerExecutionFlagError(command, flagName string) error {
+	return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("%s --%s is unsupported for complete scheduler runs", command, flagName)}
 }
 
 func composeSchedulerRunOutputFromProto(run *agentcomposev2.SchedulerRun, projectName string) composeSchedulerRunOutput {

--- a/cmd/agent-compose/scheduler_runs_test.go
+++ b/cmd/agent-compose/scheduler_runs_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestIntegrationCLISchedulerRunMainAndDetach(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-scheduler-main
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      enabled: true
+      script: |
+        function main(payload) { return payload; }
+`)
+	var runRequests []*agentcomposev2.RunSchedulerRequest
+	var startRequests []*agentcomposev2.StartSchedulerRunRequest
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		runScheduler: func(_ context.Context, req *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error) {
+			runRequests = append(runRequests, req.Msg)
+			return connect.NewResponse(&agentcomposev2.RunSchedulerResponse{Run: &agentcomposev2.SchedulerRun{
+				RunId:       "scheduler-run-main",
+				ProjectId:   req.Msg.GetProject().GetProjectId(),
+				AgentName:   req.Msg.GetAgentName(),
+				Status:      agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+				ResultJson:  `{"main":true}`,
+				PayloadJson: req.Msg.GetPayloadJson(),
+			}}), nil
+		},
+		startSchedulerRun: func(_ context.Context, req *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error) {
+			startRequests = append(startRequests, req.Msg)
+			return connect.NewResponse(&agentcomposev2.StartSchedulerRunResponse{Run: &agentcomposev2.SchedulerRun{
+				RunId:     "scheduler-run-detached",
+				ProjectId: req.Msg.GetProject().GetProjectId(),
+				AgentName: req.Msg.GetAgentName(),
+				Status:    agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING,
+			}}), nil
+		},
+	}})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "run", "--host", server.URL, "--file", composePath, "--payload", ` { "main" : true } `, "reviewer")
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, "Trigger: main") || !strings.Contains(stdout, `Result: {"main":true}`) {
+		t.Fatalf("scheduler run code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+	if len(runRequests) != 1 || runRequests[0].GetTriggerId() != "" || runRequests[0].GetPayloadJson() != `{"main":true}` {
+		t.Fatalf("RunScheduler requests = %#v", runRequests)
+	}
+
+	detachedOut, detachedErr, _, detachedCode := executeCLICommand("scheduler", "run", "--host", server.URL, "--file", composePath, "--detach", "reviewer")
+	if detachedCode != 0 || detachedErr != "" || !strings.Contains(detachedOut, "Run: scheduler-run-detached") || !strings.Contains(detachedOut, "Inspect: ") || !strings.Contains(detachedOut, "inspect run scheduler-run-detached") || !strings.Contains(detachedOut, "scheduler stop scheduler-run-detached") {
+		t.Fatalf("scheduler run --detach code/stdout/stderr = %d / %q / %q", detachedCode, detachedOut, detachedErr)
+	}
+	if len(startRequests) != 1 || startRequests[0].GetTriggerId() != "" {
+		t.Fatalf("StartSchedulerRun requests = %#v", startRequests)
+	}
+}
+
+func TestCLISchedulerExecutionRejectsDeprecatedFlags(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-scheduler-deprecated
+agents:
+  reviewer:
+    scheduler:
+      triggers:
+        - name: nightly
+          cron: "0 2 * * *"
+          prompt: review
+`)
+	tests := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "prompt", args: []string{"--prompt", "override"}, flag: "--prompt"},
+		{name: "sandbox", args: []string{"--sandbox", "sandbox-1"}, flag: "--sandbox"},
+		{name: "driver", args: []string{"--driver", "docker"}, flag: "--driver"},
+		{name: "keep running", args: []string{"--keep-running"}, flag: "--keep-running"},
+		{name: "remove false", args: []string{"--rm=false"}, flag: "--rm"},
+		{name: "jupyter", args: []string{"--jupyter"}, flag: "--jupyter"},
+		{name: "jupyter expose", args: []string{"--jupyter-expose"}, flag: "--jupyter-expose"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"scheduler", "trigger", "--file", composePath}
+			args = append(args, test.args...)
+			args = append(args, "reviewer", "nightly")
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, test.flag+" is deprecated") {
+				t.Fatalf("deprecated flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+			}
+		})
+	}
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "run", "--file", composePath, "--prompt", "override", "reviewer")
+	if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "scheduler run --prompt is deprecated") {
+		t.Fatalf("scheduler run deprecated flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+}
+
+func TestIntegrationCLISchedulerRunsPaginatesAndFiltersAgent(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-scheduler-runs
+agents:
+  reviewer:
+    scheduler:
+      enabled: true
+      script: function main() {}
+`)
+	var requests []*agentcomposev2.ListSchedulerRunsRequest
+	newRunID := "11111111-1111-4111-8111-111111111111"
+	oldRunID := "22222222-2222-4222-8222-222222222222"
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+			requests = append(requests, req.Msg)
+			if req.Msg.GetCursor() == "" {
+				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{
+					Runs:       []*agentcomposev2.SchedulerRun{{RunId: newRunID, AgentName: "reviewer", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED}},
+					NextCursor: "page-2",
+				}), nil
+			}
+			return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{
+				Runs: []*agentcomposev2.SchedulerRun{{RunId: oldRunID, AgentName: "reviewer", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED}},
+			}), nil
+		},
+	}})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "runs", "--host", server.URL, "--file", composePath, "reviewer")
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, shortOpaqueID(newRunID)) || !strings.Contains(stdout, shortOpaqueID(oldRunID)) || !strings.Contains(stdout, "skipped") {
+		t.Fatalf("scheduler runs code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+	if len(requests) != 2 || requests[0].GetAgentName() != "reviewer" || requests[0].GetCursor() != "" || requests[1].GetCursor() != "page-2" {
+		t.Fatalf("ListSchedulerRuns requests = %#v", requests)
+	}
+
+	requests = nil
+	filteredOut, filteredErr, _, filteredCode := executeCLICommand("scheduler", "runs", "--host", server.URL, "--file", composePath, "--status", "skipped", "reviewer")
+	if filteredCode != 0 || filteredErr != "" || !strings.Contains(filteredOut, shortOpaqueID(oldRunID)) || strings.Contains(filteredOut, shortOpaqueID(newRunID)) {
+		t.Fatalf("scheduler runs --status skipped code/stdout/stderr = %d / %q / %q", filteredCode, filteredOut, filteredErr)
+	}
+	if len(requests) != 2 || requests[0].GetCursor() != "" || requests[1].GetCursor() != "page-2" {
+		t.Fatalf("filtered ListSchedulerRuns requests = %#v", requests)
+	}
+}
+
+func TestIntegrationCLISchedulerStop(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-scheduler-stop
+agents:
+  reviewer:
+    scheduler:
+      enabled: true
+      script: function main() {}
+`)
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		stopSchedulerRun: func(_ context.Context, req *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error) {
+			if req.Msg.GetRunId() != "scheduler-run-active" || req.Msg.GetReason() != "manual stop" {
+				t.Fatalf("StopSchedulerRun request = %#v", req.Msg)
+			}
+			return connect.NewResponse(&agentcomposev2.StopSchedulerRunResponse{
+				Run:           &agentcomposev2.SchedulerRun{RunId: req.Msg.GetRunId(), AgentName: "reviewer", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED, Error: req.Msg.GetReason()},
+				StopRequested: true,
+			}), nil
+		},
+	}})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "stop", "--host", server.URL, "--file", composePath, "--reason", "manual stop", "scheduler-run-active")
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, "Status: canceled") || !strings.Contains(stdout, "Stop requested: true") {
+		t.Fatalf("scheduler stop code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+}
+
+func TestIntegrationCLIInspectRunFallsBackToSchedulerRun(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-scheduler-inspect-run
+agents:
+  reviewer:
+    scheduler:
+      enabled: true
+      script: function main() {}
+`)
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			getSchedulerRun: func(_ context.Context, req *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error) {
+				return connect.NewResponse(&agentcomposev2.GetSchedulerRunResponse{Run: &agentcomposev2.SchedulerRun{
+					RunId: req.Msg.GetRunId(), ProjectId: req.Msg.GetProject().GetProjectId(), AgentName: "reviewer",
+					Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED, ResultJson: `{"inspected":true}`,
+				}}), nil
+			},
+		},
+		run: runServiceStub{
+			getRun: func(context.Context, *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
+				return nil, connect.NewError(connect.CodeNotFound, context.Canceled)
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("inspect", "run", "scheduler-run-inspect", "--host", server.URL, "--file", composePath, "--json")
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("inspect scheduler run code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+	var output composeSchedulerRunOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil || output.ID != "scheduler-run-inspect" || output.Status != "succeeded" || output.ResultJSON != `{"inspected":true}` {
+		t.Fatalf("inspect scheduler run output=%#v err=%v", output, err)
+	}
+}

--- a/cmd/agent-compose/scheduler_runs_test.go
+++ b/cmd/agent-compose/scheduler_runs_test.go
@@ -65,9 +65,9 @@ agents:
 	}
 }
 
-func TestCLISchedulerExecutionRejectsDeprecatedFlags(t *testing.T) {
+func TestCLISchedulerExecutionRejectsUnsupportedFlags(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
-name: cli-scheduler-deprecated
+name: cli-scheduler-unsupported
 agents:
   reviewer:
     scheduler:
@@ -95,14 +95,14 @@ agents:
 			args = append(args, test.args...)
 			args = append(args, "reviewer", "nightly")
 			stdout, stderr, _, exitCode := executeCLICommand(args...)
-			if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, test.flag+" is deprecated") {
-				t.Fatalf("deprecated flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+			if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, test.flag+" is unsupported for complete scheduler runs") {
+				t.Fatalf("unsupported flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 			}
 		})
 	}
 	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "run", "--file", composePath, "--prompt", "override", "reviewer")
-	if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "scheduler run --prompt is deprecated") {
-		t.Fatalf("scheduler run deprecated flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "scheduler run --prompt is unsupported for complete scheduler runs") {
+		t.Fatalf("scheduler run unsupported flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 }
 

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -61,10 +61,12 @@ type ProjectHandler struct {
 	delegate      ProjectDelegate
 	store         ProjectStore
 	loaderRuntime ProjectLoaderRuntime
+	schedulerRuns ProjectSchedulerRunRuntime
 }
 
 func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, loaderRuntime ProjectLoaderRuntime) *ProjectHandler {
-	return &ProjectHandler{delegate: delegate, store: store, loaderRuntime: loaderRuntime}
+	schedulerRuns, _ := loaderRuntime.(ProjectSchedulerRunRuntime)
+	return &ProjectHandler{delegate: delegate, store: store, loaderRuntime: loaderRuntime, schedulerRuns: schedulerRuns}
 }
 
 func (h *ProjectHandler) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {

--- a/pkg/agentcompose/api/project_scheduler_run_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+type ProjectSchedulerRunRuntime interface {
+	RunScheduler(context.Context, loaders.SchedulerRunRequest) (domain.LoaderRunSummary, error)
+	StartSchedulerRun(context.Context, loaders.SchedulerRunRequest) (domain.LoaderRunSummary, error)
+	GetSchedulerRun(context.Context, string, string) (domain.LoaderRunSummary, error)
+	StopSchedulerRun(context.Context, string, string, string) (domain.LoaderRunSummary, bool, error)
+}
+
+type ProjectSchedulerRunStore interface {
+	GetLoaderRunForLoaders(context.Context, []string, string) (domain.LoaderRunSummary, error)
+	ListLoaderRunsPage(context.Context, loaders.LoaderRunPageFilter) ([]domain.LoaderRunSummary, error)
+}
+
+func (h *ProjectHandler) RunScheduler(ctx context.Context, req *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error) {
+	_, scheduler, err := h.resolveProjectScheduler(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	payloadJSON, err := normalizeSchedulerRunPayload(req.Msg.GetPayloadJson())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	runtime, err := h.schedulerRunRuntime()
+	if err != nil {
+		return nil, err
+	}
+	run, err := runtime.RunScheduler(ctx, loaders.SchedulerRunRequest{
+		LoaderID:    scheduler.ManagedLoaderID,
+		TriggerID:   req.Msg.GetTriggerId(),
+		PayloadJSON: payloadJSON,
+	})
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.RunSchedulerResponse{Run: schedulerRunToProto(run, scheduler)}), nil
+}
+
+func (h *ProjectHandler) StartSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error) {
+	_, scheduler, err := h.resolveProjectScheduler(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	payloadJSON, err := normalizeSchedulerRunPayload(req.Msg.GetPayloadJson())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	runtime, err := h.schedulerRunRuntime()
+	if err != nil {
+		return nil, err
+	}
+	run, err := runtime.StartSchedulerRun(ctx, loaders.SchedulerRunRequest{
+		LoaderID:    scheduler.ManagedLoaderID,
+		TriggerID:   req.Msg.GetTriggerId(),
+		PayloadJSON: payloadJSON,
+	})
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.StartSchedulerRunResponse{Run: schedulerRunToProto(run, scheduler)}), nil
+}
+
+func (h *ProjectHandler) GetSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error) {
+	_, scheduler, _, err := h.resolveProjectSchedulerRun(ctx, req.Msg.GetProject(), req.Msg.GetRunId())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	runtime, err := h.schedulerRunRuntime()
+	if err != nil {
+		return nil, err
+	}
+	run, err := runtime.GetSchedulerRun(ctx, scheduler.ManagedLoaderID, req.Msg.GetRunId())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.GetSchedulerRunResponse{Run: schedulerRunToProto(run, scheduler)}), nil
+}
+
+func (h *ProjectHandler) ListSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+	project, schedulers, err := h.resolveProjectSchedulerRunTargets(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	limit, err := schedulerRunPageLimit(req.Msg.GetLimit())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	cursor, err := decodeSchedulerRunCursor(req.Msg.GetCursor(), project.ID, req.Msg.GetAgentName())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	loaderIDs := make([]string, 0, len(schedulers))
+	byLoaderID := make(map[string]domain.ProjectSchedulerRecord, len(schedulers))
+	for _, scheduler := range schedulers {
+		loaderID := strings.TrimSpace(scheduler.ManagedLoaderID)
+		if loaderID == "" {
+			continue
+		}
+		loaderIDs = append(loaderIDs, loaderID)
+		byLoaderID[loaderID] = scheduler
+	}
+	store, err := h.schedulerRunStore()
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	runs, err := store.ListLoaderRunsPage(ctx, loaders.LoaderRunPageFilter{
+		LoaderIDs:       loaderIDs,
+		BeforeStartedAt: cursor.StartedAt,
+		BeforeLoaderID:  cursor.LoaderID,
+		BeforeRunID:     cursor.RunID,
+		Limit:           limit + 1,
+	})
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	end := min(limit, len(runs))
+	response := &agentcomposev2.ListSchedulerRunsResponse{Runs: make([]*agentcomposev2.SchedulerRun, 0, end)}
+	for _, run := range runs[:end] {
+		scheduler, ok := byLoaderID[run.LoaderID]
+		if !ok {
+			continue
+		}
+		response.Runs = append(response.Runs, schedulerRunToProto(run, scheduler))
+	}
+	if len(runs) > limit {
+		response.NextCursor = encodeSchedulerRunCursor(project.ID, req.Msg.GetAgentName(), runs[limit-1])
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (h *ProjectHandler) StopSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error) {
+	_, scheduler, _, err := h.resolveProjectSchedulerRun(ctx, req.Msg.GetProject(), req.Msg.GetRunId())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	runtime, err := h.schedulerRunRuntime()
+	if err != nil {
+		return nil, err
+	}
+	run, requested, err := runtime.StopSchedulerRun(ctx, scheduler.ManagedLoaderID, req.Msg.GetRunId(), req.Msg.GetReason())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.StopSchedulerRunResponse{Run: schedulerRunToProto(run, scheduler), StopRequested: requested}), nil
+}
+
+func (h *ProjectHandler) resolveProjectSchedulerRun(ctx context.Context, ref *agentcomposev2.ProjectRef, rawRunID string) (domain.ProjectRecord, domain.ProjectSchedulerRecord, domain.LoaderRunSummary, error) {
+	project, err := h.resolveProjectRef(ctx, ref)
+	if err != nil {
+		return domain.ProjectRecord{}, domain.ProjectSchedulerRecord{}, domain.LoaderRunSummary{}, err
+	}
+	runID := strings.TrimSpace(rawRunID)
+	if runID == "" {
+		return domain.ProjectRecord{}, domain.ProjectSchedulerRecord{}, domain.LoaderRunSummary{}, domain.ClassifyError(domain.ErrRequired, "scheduler run id is required", nil)
+	}
+	schedulers, err := h.currentProjectSchedulers(ctx, project)
+	if err != nil {
+		return domain.ProjectRecord{}, domain.ProjectSchedulerRecord{}, domain.LoaderRunSummary{}, err
+	}
+	loaderIDs := make([]string, 0, len(schedulers))
+	for _, scheduler := range schedulers {
+		if strings.TrimSpace(scheduler.ManagedLoaderID) != "" {
+			loaderIDs = append(loaderIDs, scheduler.ManagedLoaderID)
+		}
+	}
+	store, err := h.schedulerRunStore()
+	if err != nil {
+		return domain.ProjectRecord{}, domain.ProjectSchedulerRecord{}, domain.LoaderRunSummary{}, err
+	}
+	run, err := store.GetLoaderRunForLoaders(ctx, loaderIDs, runID)
+	if err != nil {
+		return domain.ProjectRecord{}, domain.ProjectSchedulerRecord{}, domain.LoaderRunSummary{}, err
+	}
+	for _, scheduler := range schedulers {
+		if scheduler.ManagedLoaderID == run.LoaderID {
+			return project, scheduler, run, nil
+		}
+	}
+	return domain.ProjectRecord{}, domain.ProjectSchedulerRecord{}, domain.LoaderRunSummary{}, domain.ResourceError(domain.ErrNotFound, "scheduler run", runID, fmt.Sprintf("scheduler run %s not found", runID), nil)
+}
+
+func (h *ProjectHandler) resolveProjectSchedulerRunTargets(ctx context.Context, ref *agentcomposev2.ProjectRef, rawAgentName string) (domain.ProjectRecord, []domain.ProjectSchedulerRecord, error) {
+	agentName := strings.TrimSpace(rawAgentName)
+	if agentName != "" {
+		project, scheduler, err := h.resolveProjectScheduler(ctx, ref, agentName)
+		if err != nil {
+			return domain.ProjectRecord{}, nil, err
+		}
+		return project, []domain.ProjectSchedulerRecord{scheduler}, nil
+	}
+	project, err := h.resolveProjectRef(ctx, ref)
+	if err != nil {
+		return domain.ProjectRecord{}, nil, err
+	}
+	schedulers, err := h.currentProjectSchedulers(ctx, project)
+	return project, schedulers, err
+}
+
+func (h *ProjectHandler) currentProjectSchedulers(ctx context.Context, project domain.ProjectRecord) ([]domain.ProjectSchedulerRecord, error) {
+	schedulers, err := h.store.ListProjectSchedulers(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	current := make([]domain.ProjectSchedulerRecord, 0, len(schedulers))
+	for _, scheduler := range schedulers {
+		if project.CurrentRevision > 0 && scheduler.Revision != project.CurrentRevision {
+			continue
+		}
+		current = append(current, scheduler)
+	}
+	return current, nil
+}
+
+func (h *ProjectHandler) schedulerRunRuntime() (ProjectSchedulerRunRuntime, error) {
+	if h.schedulerRuns == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler run controller is required"))
+	}
+	return h.schedulerRuns, nil
+}
+
+func (h *ProjectHandler) schedulerRunStore() (ProjectSchedulerRunStore, error) {
+	store, ok := h.store.(ProjectSchedulerRunStore)
+	if !ok {
+		return nil, fmt.Errorf("scheduler run store is required")
+	}
+	return store, nil
+}
+
+func normalizeSchedulerRunPayload(raw string) (string, error) {
+	payloadJSON, err := domain.NormalizeJSONDocument(raw)
+	if err != nil {
+		return "", domain.ClassifyError(domain.ErrInvalidArgument, "payload_json must contain valid JSON", err)
+	}
+	return payloadJSON, nil
+}
+
+func schedulerRunPageLimit(raw uint32) (int, error) {
+	if raw == 0 {
+		return 100, nil
+	}
+	if raw > 500 {
+		return 0, domain.ClassifyError(domain.ErrInvalidArgument, "limit must be between 1 and 500", nil)
+	}
+	return int(raw), nil
+}

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -1,0 +1,282 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestProjectHandlerRunSchedulerSupportsMainAndTerminalStatuses(t *testing.T) {
+	store, runtime, handler := newSchedulerRunHandlerFixture()
+	if store.scheduler.Enabled {
+		t.Fatal("fixture scheduler must be disabled to exercise manual execution")
+	}
+	tests := []struct {
+		name       string
+		triggerID  string
+		status     string
+		wantStatus agentcomposev2.SchedulerRunStatus
+	}{
+		{name: "main", status: domain.LoaderRunStatusSucceeded, wantStatus: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED},
+		{name: "canceled", triggerID: "trigger-1", status: domain.LoaderRunStatusCanceled, wantStatus: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED},
+		{name: "skipped", triggerID: "trigger-1", status: domain.LoaderRunStatusSkipped, wantStatus: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtime.runResult = domain.LoaderRunSummary{
+				ID:          "run-" + test.name,
+				LoaderID:    store.scheduler.ManagedLoaderID,
+				TriggerID:   test.triggerID,
+				Status:      test.status,
+				StartedAt:   time.Unix(100, 0).UTC(),
+				PayloadJSON: `{"value":true}`,
+			}
+			response, err := handler.RunScheduler(context.Background(), connect.NewRequest(&agentcomposev2.RunSchedulerRequest{
+				Project:     &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+				AgentName:   store.scheduler.AgentName,
+				TriggerId:   test.triggerID,
+				PayloadJson: ` { "value" : true } `,
+			}))
+			if err != nil {
+				t.Fatalf("RunScheduler returned error: %v", err)
+			}
+			if response.Msg.GetRun().GetStatus() != test.wantStatus || response.Msg.GetRun().GetProjectId() != store.project.ID || response.Msg.GetRun().GetAgentName() != store.scheduler.AgentName {
+				t.Fatalf("response run = %#v", response.Msg.GetRun())
+			}
+			if runtime.lastRequest.LoaderID != store.scheduler.ManagedLoaderID || runtime.lastRequest.TriggerID != test.triggerID || runtime.lastRequest.PayloadJSON != `{"value":true}` {
+				t.Fatalf("runtime request = %#v", runtime.lastRequest)
+			}
+		})
+	}
+}
+
+func TestProjectHandlerRunSchedulerValidatesPayloadAndMissingTrigger(t *testing.T) {
+	store, runtime, handler := newSchedulerRunHandlerFixture()
+	request := &agentcomposev2.RunSchedulerRequest{
+		Project:   &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		AgentName: store.scheduler.AgentName,
+	}
+	request.PayloadJson = `{bad`
+	if _, err := handler.RunScheduler(context.Background(), connect.NewRequest(request)); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("invalid payload code=%v err=%v", connect.CodeOf(err), err)
+	}
+	if runtime.runCalls != 0 {
+		t.Fatalf("runtime calls after invalid payload = %d", runtime.runCalls)
+	}
+
+	request.PayloadJson = `{}`
+	request.TriggerId = "missing"
+	runtime.runErr = domain.ResourceError(domain.ErrNotFound, "loader trigger", "missing", "loader trigger missing not found", nil)
+	if _, err := handler.RunScheduler(context.Background(), connect.NewRequest(request)); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("missing trigger code=%v err=%v", connect.CodeOf(err), err)
+	}
+}
+
+func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
+	store, runtime, handler := newSchedulerRunHandlerFixture()
+	startedAt := time.Unix(200, 0).UTC()
+	runtime.startResult = domain.LoaderRunSummary{ID: "run-start", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusRunning, StartedAt: startedAt}
+	started, err := handler.StartSchedulerRun(context.Background(), connect.NewRequest(&agentcomposev2.StartSchedulerRunRequest{
+		Project:     &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		AgentName:   store.scheduler.AgentName,
+		TriggerId:   "trigger-1",
+		PayloadJson: `{"start":true}`,
+	}))
+	if err != nil || started.Msg.GetRun().GetStatus() != agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING {
+		t.Fatalf("StartSchedulerRun response=%#v err=%v", started, err)
+	}
+
+	getRun := domain.LoaderRunSummary{ID: "run-get", LoaderID: store.scheduler.ManagedLoaderID, Status: domain.LoaderRunStatusCanceled, Error: "user stop", StartedAt: startedAt}
+	store.runs = []domain.LoaderRunSummary{getRun}
+	runtime.getResult = getRun
+	got, err := handler.GetSchedulerRun(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRunRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		RunId:   getRun.ID,
+	}))
+	if err != nil || got.Msg.GetRun().GetStatus() != agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED || got.Msg.GetRun().GetError() != "user stop" {
+		t.Fatalf("GetSchedulerRun response=%#v err=%v", got, err)
+	}
+
+	newer := domain.LoaderRunSummary{ID: "run-new", LoaderID: store.scheduler.ManagedLoaderID, Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(time.Second)}
+	older := domain.LoaderRunSummary{ID: "run-old", LoaderID: store.scheduler.ManagedLoaderID, Status: domain.LoaderRunStatusSkipped, StartedAt: startedAt}
+	store.runs = []domain.LoaderRunSummary{newer, older}
+	first, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Limit:   1,
+	}))
+	if err != nil || len(first.Msg.GetRuns()) != 1 || first.Msg.GetRuns()[0].GetRunId() != newer.ID || first.Msg.GetNextCursor() == "" {
+		t.Fatalf("ListSchedulerRuns first=%#v err=%v", first, err)
+	}
+	second, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Limit:   1,
+		Cursor:  first.Msg.GetNextCursor(),
+	}))
+	if err != nil || len(second.Msg.GetRuns()) != 1 || second.Msg.GetRuns()[0].GetRunId() != older.ID || second.Msg.GetNextCursor() != "" {
+		t.Fatalf("ListSchedulerRuns second=%#v err=%v", second, err)
+	}
+
+	store.runs = []domain.LoaderRunSummary{getRun}
+	runtime.stopResult = getRun
+	runtime.stopRequested = true
+	stopped, err := handler.StopSchedulerRun(context.Background(), connect.NewRequest(&agentcomposev2.StopSchedulerRunRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		RunId:   getRun.ID,
+		Reason:  "user stop",
+	}))
+	if err != nil || !stopped.Msg.GetStopRequested() || runtime.stopReason != "user stop" {
+		t.Fatalf("StopSchedulerRun response=%#v reason=%q err=%v", stopped, runtime.stopReason, err)
+	}
+}
+
+func TestSchedulerRunCursorIsScopedToProjectAndAgent(t *testing.T) {
+	run := domain.LoaderRunSummary{ID: "run-1", LoaderID: "loader-1", StartedAt: time.Unix(300, 0).UTC()}
+	token := encodeSchedulerRunCursor("project-1", "agent-1", run)
+	cursor, err := decodeSchedulerRunCursor(token, "project-1", "agent-1")
+	if err != nil || cursor.RunID != run.ID || cursor.LoaderID != run.LoaderID || !cursor.StartedAt.Equal(run.StartedAt) {
+		t.Fatalf("decode cursor=%#v err=%v", cursor, err)
+	}
+	if _, err := decodeSchedulerRunCursor(token, "project-2", "agent-1"); err == nil {
+		t.Fatal("cursor accepted a different project")
+	}
+	if _, err := decodeSchedulerRunCursor(token, "project-1", "agent-2"); err == nil {
+		t.Fatal("cursor accepted a different agent")
+	}
+	if _, err := decodeSchedulerRunCursor("not-base64!", "project-1", "agent-1"); err == nil {
+		t.Fatal("invalid cursor returned nil error")
+	}
+}
+
+func TestSchedulerRunStatusToProto(t *testing.T) {
+	tests := map[string]agentcomposev2.SchedulerRunStatus{
+		domain.LoaderRunStatusRunning:   agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING,
+		domain.LoaderRunStatusSucceeded: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+		domain.LoaderRunStatusFailed:    agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED,
+		domain.LoaderRunStatusCanceled:  agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED,
+		domain.LoaderRunStatusSkipped:   agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED,
+		"unknown":                       agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED,
+	}
+	for status, want := range tests {
+		if got := schedulerRunStatusToProto(status); got != want {
+			t.Fatalf("schedulerRunStatusToProto(%q)=%v, want %v", status, got, want)
+		}
+	}
+}
+
+func newSchedulerRunHandlerFixture() (*schedulerRunProjectStoreFake, *schedulerRunRuntimeFake, *ProjectHandler) {
+	store := &schedulerRunProjectStoreFake{
+		project: domain.ProjectRecord{ID: "project-1", Name: "Project", CurrentRevision: 1},
+		scheduler: domain.ProjectSchedulerRecord{
+			ProjectID:       "project-1",
+			AgentName:       "agent-1",
+			SchedulerID:     "scheduler-1",
+			ManagedLoaderID: "loader-1",
+			Revision:        1,
+			Enabled:         false,
+		},
+	}
+	runtime := &schedulerRunRuntimeFake{}
+	return store, runtime, NewProjectHandler(nil, store, runtime)
+}
+
+type schedulerRunProjectStoreFake struct {
+	project   domain.ProjectRecord
+	scheduler domain.ProjectSchedulerRecord
+	runs      []domain.LoaderRunSummary
+}
+
+func (s *schedulerRunProjectStoreFake) GetProject(context.Context, string) (domain.ProjectRecord, error) {
+	return s.project, nil
+}
+
+func (s *schedulerRunProjectStoreFake) ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error) {
+	return domain.ProjectListResult{Projects: []domain.ProjectRecord{s.project}}, nil
+}
+
+func (s *schedulerRunProjectStoreFake) ListProjectAgents(context.Context, string) ([]domain.ProjectAgentRecord, error) {
+	return nil, nil
+}
+
+func (s *schedulerRunProjectStoreFake) ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error) {
+	return []domain.ProjectSchedulerRecord{s.scheduler}, nil
+}
+
+func (s *schedulerRunProjectStoreFake) GetProjectRevision(context.Context, string, int64) (domain.ProjectRevisionRecord, error) {
+	return domain.ProjectRevisionRecord{}, nil
+}
+
+func (s *schedulerRunProjectStoreFake) GetLoaderRunForLoaders(_ context.Context, loaderIDs []string, runID string) (domain.LoaderRunSummary, error) {
+	for _, run := range s.runs {
+		if run.ID != runID {
+			continue
+		}
+		for _, loaderID := range loaderIDs {
+			if run.LoaderID == loaderID {
+				return run, nil
+			}
+		}
+	}
+	return domain.LoaderRunSummary{}, domain.ResourceError(domain.ErrNotFound, "loader run", runID, fmt.Sprintf("loader run %s not found", runID), nil)
+}
+
+func (s *schedulerRunProjectStoreFake) ListLoaderRunsPage(_ context.Context, filter loaders.LoaderRunPageFilter) ([]domain.LoaderRunSummary, error) {
+	start := 0
+	if filter.BeforeRunID != "" {
+		start = len(s.runs)
+		for index, run := range s.runs {
+			if run.ID == filter.BeforeRunID {
+				start = index + 1
+				break
+			}
+		}
+	}
+	end := min(start+filter.Limit, len(s.runs))
+	return append([]domain.LoaderRunSummary(nil), s.runs[start:end]...), nil
+}
+
+type schedulerRunRuntimeFake struct {
+	runResult     domain.LoaderRunSummary
+	startResult   domain.LoaderRunSummary
+	getResult     domain.LoaderRunSummary
+	stopResult    domain.LoaderRunSummary
+	runErr        error
+	stopRequested bool
+	runCalls      int
+	lastRequest   loaders.SchedulerRunRequest
+	stopReason    string
+}
+
+func (f *schedulerRunRuntimeFake) SetLoaderEnabled(context.Context, string, bool) (domain.Loader, error) {
+	return domain.Loader{}, nil
+}
+
+func (f *schedulerRunRuntimeFake) SetLoaderTriggerEnabled(context.Context, string, string, bool) (domain.Loader, error) {
+	return domain.Loader{}, nil
+}
+
+func (f *schedulerRunRuntimeFake) RunScheduler(_ context.Context, request loaders.SchedulerRunRequest) (domain.LoaderRunSummary, error) {
+	f.runCalls++
+	f.lastRequest = request
+	return f.runResult, f.runErr
+}
+
+func (f *schedulerRunRuntimeFake) StartSchedulerRun(_ context.Context, request loaders.SchedulerRunRequest) (domain.LoaderRunSummary, error) {
+	f.lastRequest = request
+	return f.startResult, nil
+}
+
+func (f *schedulerRunRuntimeFake) GetSchedulerRun(context.Context, string, string) (domain.LoaderRunSummary, error) {
+	return f.getResult, nil
+}
+
+func (f *schedulerRunRuntimeFake) StopSchedulerRun(_ context.Context, _, _, reason string) (domain.LoaderRunSummary, bool, error) {
+	f.stopReason = reason
+	return f.stopResult, f.stopRequested, nil
+}

--- a/pkg/agentcompose/api/scheduler_run.go
+++ b/pkg/agentcompose/api/scheduler_run.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"strings"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func schedulerRunToProto(run domain.LoaderRunSummary, scheduler domain.ProjectSchedulerRecord) *agentcomposev2.SchedulerRun {
+	return &agentcomposev2.SchedulerRun{
+		RunId:              run.ID,
+		ProjectId:          scheduler.ProjectID,
+		AgentName:          scheduler.AgentName,
+		SchedulerId:        scheduler.SchedulerID,
+		TriggerId:          run.TriggerID,
+		TriggerKind:        run.TriggerKind,
+		TriggerSource:      run.TriggerSource,
+		Status:             schedulerRunStatusToProto(run.Status),
+		StartedAt:          projectTimestamp(run.StartedAt),
+		CompletedAt:        projectTimestamp(run.CompletedAt),
+		DurationMs:         run.DurationMs,
+		Error:              run.Error,
+		ResultJson:         run.ResultJSON,
+		PayloadJson:        run.PayloadJSON,
+		SourceScriptSha256: run.SourceScriptHash,
+		ArtifactsDir:       run.ArtifactsDir,
+	}
+}
+
+func schedulerRunStatusToProto(status string) agentcomposev2.SchedulerRunStatus {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case domain.LoaderRunStatusRunning:
+		return agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING
+	case domain.LoaderRunStatusSucceeded:
+		return agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED
+	case domain.LoaderRunStatusFailed:
+		return agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED
+	case domain.LoaderRunStatusCanceled:
+		return agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED
+	case domain.LoaderRunStatusSkipped:
+		return agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED
+	default:
+		return agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED
+	}
+}

--- a/pkg/agentcompose/api/scheduler_run_cursor.go
+++ b/pkg/agentcompose/api/scheduler_run_cursor.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+type schedulerRunPageCursor struct {
+	ProjectID string    `json:"project_id"`
+	AgentName string    `json:"agent_name,omitempty"`
+	StartedAt time.Time `json:"started_at"`
+	LoaderID  string    `json:"loader_id"`
+	RunID     string    `json:"run_id"`
+}
+
+func encodeSchedulerRunCursor(projectID, agentName string, run domain.LoaderRunSummary) string {
+	payload, _ := json.Marshal(schedulerRunPageCursor{
+		ProjectID: strings.TrimSpace(projectID),
+		AgentName: strings.TrimSpace(agentName),
+		StartedAt: run.StartedAt.UTC(),
+		LoaderID:  strings.TrimSpace(run.LoaderID),
+		RunID:     strings.TrimSpace(run.ID),
+	})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func decodeSchedulerRunCursor(token, projectID, agentName string) (schedulerRunPageCursor, error) {
+	projectID = strings.TrimSpace(projectID)
+	agentName = strings.TrimSpace(agentName)
+	if strings.TrimSpace(token) == "" {
+		return schedulerRunPageCursor{ProjectID: projectID, AgentName: agentName}, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return schedulerRunPageCursor{}, fmt.Errorf("invalid cursor")
+	}
+	var cursor schedulerRunPageCursor
+	if json.Unmarshal(payload, &cursor) != nil ||
+		cursor.ProjectID != projectID || cursor.AgentName != agentName ||
+		cursor.StartedAt.IsZero() || strings.TrimSpace(cursor.LoaderID) == "" || strings.TrimSpace(cursor.RunID) == "" {
+		return schedulerRunPageCursor{}, fmt.Errorf("invalid cursor")
+	}
+	return cursor, nil
+}

--- a/pkg/loaders/controller.go
+++ b/pkg/loaders/controller.go
@@ -91,6 +91,7 @@ type Controller struct {
 	loaders         map[string]domain.Loader
 	running         map[string]int
 	runExecutor     *RunExecutor
+	schedulerRuns   *schedulerRunSupervisor
 	scheduler       *Scheduler
 	eventDispatcher *EventDispatcher
 }
@@ -139,6 +140,17 @@ func (c *Controller) init() {
 			UpdateTriggerEventDelivery: c.UpdateTriggerEventDelivery,
 			Notify:                     c.notify,
 			Refresh:                    c.Refresh,
+		})
+	}
+	if c.schedulerRuns == nil {
+		runStore, _ := c.deps.Store.(schedulerRunStore)
+		c.schedulerRuns = newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+			RootCtx:          c.deps.RootCtx,
+			Store:            runStore,
+			LoadLoaderForRun: c.LoadLoaderForRun,
+			Prepare:          c.Prepare,
+			Execute:          c.Execute,
+			RunTimeout:       c.runTimeout,
 		})
 	}
 	if c.scheduler == nil {
@@ -436,6 +448,9 @@ func (c *Controller) UpdateTriggerEventDelivery(ctx context.Context, run domain.
 	case domain.LoaderRunStatusSucceeded:
 		status = domain.EventDeliveryStatusRunSucceeded
 	case domain.LoaderRunStatusFailed:
+		status = domain.EventDeliveryStatusRunFailed
+		errText = run.Error
+	case domain.LoaderRunStatusCanceled:
 		status = domain.EventDeliveryStatusRunFailed
 		errText = run.Error
 	case domain.LoaderRunStatusSkipped:

--- a/pkg/loaders/controller_coverage_test.go
+++ b/pkg/loaders/controller_coverage_test.go
@@ -63,7 +63,7 @@ func TestControllerCoverageWorkflow(t *testing.T) {
 	if _, _, err := controller.LoadLoaderForRun(ctx, created.Summary.ID, "missing"); err == nil {
 		t.Fatalf("expected missing trigger error")
 	}
-	manualRun, err := controller.RunNow(ctx, created.Summary.ID, "trigger-1", `{"manual":true}`, time.Millisecond)
+	manualRun, err := controller.RunNow(ctx, created.Summary.ID, "trigger-1", `{"manual":true}`, time.Second)
 	if err != nil || manualRun.Status != domain.LoaderRunStatusSucceeded || manualRun.ResultJSON == "" {
 		t.Fatalf("RunNow run=%#v err=%v", manualRun, err)
 	}

--- a/pkg/loaders/controller_scheduler_runs.go
+++ b/pkg/loaders/controller_scheduler_runs.go
@@ -1,0 +1,27 @@
+package loaders
+
+import (
+	"context"
+
+	domain "agent-compose/pkg/model"
+)
+
+func (c *Controller) RunScheduler(ctx context.Context, request SchedulerRunRequest) (domain.LoaderRunSummary, error) {
+	return c.schedulerRuns.Run(ctx, request)
+}
+
+func (c *Controller) StartSchedulerRun(ctx context.Context, request SchedulerRunRequest) (domain.LoaderRunSummary, error) {
+	return c.schedulerRuns.Start(ctx, request)
+}
+
+func (c *Controller) GetSchedulerRun(ctx context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {
+	return c.schedulerRuns.Get(ctx, loaderID, runID)
+}
+
+func (c *Controller) ListSchedulerRuns(ctx context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error) {
+	return c.schedulerRuns.List(ctx, loaderID, limit)
+}
+
+func (c *Controller) StopSchedulerRun(ctx context.Context, loaderID, runID, reason string) (domain.LoaderRunSummary, bool, error) {
+	return c.schedulerRuns.Stop(ctx, loaderID, runID, reason)
+}

--- a/pkg/loaders/run_host.go
+++ b/pkg/loaders/run_host.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"agent-compose/pkg/execution"
 	domain "agent-compose/pkg/model"
-
-	"github.com/google/uuid"
 )
 
 type HostStore interface {
@@ -55,23 +54,6 @@ type HostCommandExecutor interface {
 	ExecuteLoaderCommand(ctx context.Context, session *domain.Sandbox, request domain.LoaderCommandRequest) (domain.LoaderCommandResult, error)
 }
 
-type HostProjectAgentRequest struct {
-	LoaderID         string
-	ProjectID        string
-	AgentName        string
-	Prompt           string
-	SchedulerID      string
-	TriggerID        string
-	OutputSchemaJSON string
-	ClientRequestID  string
-	Volumes          []domain.VolumeMountSpec
-	SandboxPolicy    string
-}
-
-type HostProjectAgentRunner interface {
-	RunProjectAgent(ctx context.Context, request HostProjectAgentRequest) (domain.ProjectRunRecord, error, error)
-}
-
 type HostLLMRunner interface {
 	Generate(ctx context.Context, prompt, model, outputSchema string) (domain.LoaderLLMResult, error)
 }
@@ -105,9 +87,10 @@ type RuntimeHost struct {
 	run          *domain.LoaderRunSummary
 	triggerEvent TriggerEventMetadata
 
-	commandSessionIDs      map[string]struct{}
-	commandSessionIDOrder  []string
-	commandReusableSession *domain.Sandbox
+	commandSessionIDs       map[string]struct{}
+	commandSessionIDOrder   []string
+	commandReusableSession  *domain.Sandbox
+	projectAgentRunSequence atomic.Uint64
 }
 
 func NewRuntimeHost(deps RunHostDependencies, loader domain.Loader, run *domain.LoaderRunSummary, triggerEvent TriggerEventMetadata) *RuntimeHost {
@@ -258,48 +241,6 @@ func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.L
 	return result, nil
 }
 
-func (h *RuntimeHost) ProjectAgent(ctx context.Context, prompt string, request domain.LoaderAgentRequest) (domain.LoaderAgentResult, error) {
-	sandboxPolicy := domain.LoaderSandboxPolicyNew
-	if strings.TrimSpace(h.loader.Summary.SandboxPolicy) != "" {
-		sandboxPolicy = domain.NormalizeLoaderSandboxPolicy(h.loader.Summary.SandboxPolicy)
-	}
-	if strings.TrimSpace(domain.LoaderAgentSandboxPolicy(request)) != "" {
-		sandboxPolicy = domain.NormalizeLoaderSandboxPolicy(domain.LoaderAgentSandboxPolicy(request))
-	}
-	run, execErr, err := h.deps.ProjectAgentRunner.RunProjectAgent(ctx, HostProjectAgentRequest{
-		LoaderID:         h.loader.Summary.ID,
-		ProjectID:        h.loader.Summary.ManagedProjectID,
-		AgentName:        h.loader.Summary.ManagedAgentName,
-		Prompt:           prompt,
-		SchedulerID:      h.loader.Summary.ManagedSchedulerID,
-		TriggerID:        h.run.TriggerID,
-		OutputSchemaJSON: request.OutputSchema,
-		ClientRequestID:  firstHostNonEmpty(h.run.ID, uuid.NewString()),
-		Volumes:          request.Volumes,
-		SandboxPolicy:    sandboxPolicy,
-	})
-	if err != nil {
-		return domain.LoaderAgentResult{}, err
-	}
-	result, jsonErr := AgentResultFromProjectRun(run, request.OutputSchema)
-	if jsonErr != nil && execErr == nil {
-		execErr = jsonErr
-	}
-	level := "info"
-	eventName := "loader.agent.completed"
-	if execErr != nil || run.Status != domain.ProjectRunStatusSucceeded {
-		level = "error"
-		eventName = "loader.agent.failed"
-		result.Text = firstHostNonEmpty(result.Text, run.Error, execErrString(execErr))
-	}
-	_ = h.addLinkedLoaderEvent(ctx, eventName, level, firstHostNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SandboxID, result.CellID, result.AgentThreadID)
-	h.publishAgentCompleted(result, &run)
-	if execErr != nil {
-		return result, execErr
-	}
-	return result, nil
-}
-
 func (h *RuntimeHost) Command(ctx context.Context, request domain.LoaderCommandRequest) (domain.LoaderCommandResult, error) {
 	cleanupSession := h.commandRequiresCleanup(request)
 	agentRequest := domain.LoaderAgentRequest{
@@ -362,16 +303,6 @@ func (h *RuntimeHost) CleanupCommandSessions(ctx context.Context) {
 		}
 		_ = h.addLinkedLoaderEvent(ctx, "loader.sandbox.stopped", "info", "loader command sandbox stopped after run", map[string]any{"sandboxId": sessionID}, sessionID, "", "")
 	}
-}
-
-func (h *RuntimeHost) useProjectManagedAgentRun(request domain.LoaderAgentRequest) bool {
-	if strings.TrimSpace(h.loader.Summary.ManagedProjectID) == "" || strings.TrimSpace(h.loader.Summary.ManagedAgentName) == "" {
-		return false
-	}
-	if strings.TrimSpace(request.Agent) != "" || request.Timeout > 0 {
-		return false
-	}
-	return !AgentRequestOverridesSession(request, true)
 }
 
 func (h *RuntimeHost) ensureCommandSession(ctx context.Context, request domain.LoaderAgentRequest, cleanupSession bool) (*domain.Sandbox, string, error) {

--- a/pkg/loaders/run_host_project_agent.go
+++ b/pkg/loaders/run_host_project_agent.go
@@ -1,0 +1,85 @@
+package loaders
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+
+	"github.com/google/uuid"
+)
+
+type HostProjectAgentRequest struct {
+	LoaderID         string
+	ProjectID        string
+	AgentName        string
+	Prompt           string
+	SchedulerID      string
+	TriggerID        string
+	OutputSchemaJSON string
+	ClientRequestID  string
+	Volumes          []domain.VolumeMountSpec
+	SandboxPolicy    string
+}
+
+type HostProjectAgentRunner interface {
+	RunProjectAgent(ctx context.Context, request HostProjectAgentRequest) (domain.ProjectRunRecord, error, error)
+}
+
+func (h *RuntimeHost) ProjectAgent(ctx context.Context, prompt string, request domain.LoaderAgentRequest) (domain.LoaderAgentResult, error) {
+	sandboxPolicy := domain.LoaderSandboxPolicyNew
+	if strings.TrimSpace(h.loader.Summary.SandboxPolicy) != "" {
+		sandboxPolicy = domain.NormalizeLoaderSandboxPolicy(h.loader.Summary.SandboxPolicy)
+	}
+	if strings.TrimSpace(domain.LoaderAgentSandboxPolicy(request)) != "" {
+		sandboxPolicy = domain.NormalizeLoaderSandboxPolicy(domain.LoaderAgentSandboxPolicy(request))
+	}
+	run, execErr, err := h.deps.ProjectAgentRunner.RunProjectAgent(ctx, HostProjectAgentRequest{
+		LoaderID:         h.loader.Summary.ID,
+		ProjectID:        h.loader.Summary.ManagedProjectID,
+		AgentName:        h.loader.Summary.ManagedAgentName,
+		Prompt:           prompt,
+		SchedulerID:      h.loader.Summary.ManagedSchedulerID,
+		TriggerID:        h.run.TriggerID,
+		OutputSchemaJSON: request.OutputSchema,
+		ClientRequestID:  h.nextProjectAgentRunID(),
+		Volumes:          request.Volumes,
+		SandboxPolicy:    sandboxPolicy,
+	})
+	if err != nil {
+		return domain.LoaderAgentResult{}, err
+	}
+	result, jsonErr := AgentResultFromProjectRun(run, request.OutputSchema)
+	if jsonErr != nil && execErr == nil {
+		execErr = jsonErr
+	}
+	level := "info"
+	eventName := "loader.agent.completed"
+	if execErr != nil || run.Status != domain.ProjectRunStatusSucceeded {
+		level = "error"
+		eventName = "loader.agent.failed"
+		result.Text = firstHostNonEmpty(result.Text, run.Error, execErrString(execErr))
+	}
+	_ = h.addLinkedLoaderEvent(ctx, eventName, level, firstHostNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SandboxID, result.CellID, result.AgentThreadID)
+	h.publishAgentCompleted(result, &run)
+	if execErr != nil {
+		return result, execErr
+	}
+	return result, nil
+}
+
+func (h *RuntimeHost) nextProjectAgentRunID() string {
+	baseID := firstHostNonEmpty(h.run.ID, uuid.NewString())
+	return fmt.Sprintf("%s:agent:%d", baseID, h.projectAgentRunSequence.Add(1))
+}
+
+func (h *RuntimeHost) useProjectManagedAgentRun(request domain.LoaderAgentRequest) bool {
+	if strings.TrimSpace(h.loader.Summary.ManagedProjectID) == "" || strings.TrimSpace(h.loader.Summary.ManagedAgentName) == "" {
+		return false
+	}
+	if strings.TrimSpace(request.Agent) != "" || request.Timeout > 0 {
+		return false
+	}
+	return !AgentRequestOverridesSession(request, true)
+}

--- a/pkg/loaders/run_host_test.go
+++ b/pkg/loaders/run_host_test.go
@@ -148,11 +148,39 @@ func TestRuntimeHostProjectAgentPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project Agent returned error: %v", err)
 	}
-	if result.Text != "project output" || projectRunner.request.ProjectID != "project-1" || projectRunner.request.ClientRequestID != run.ID {
+	if result.Text != "project output" || projectRunner.request.ProjectID != "project-1" || projectRunner.request.ClientRequestID != run.ID+":agent:1" {
 		t.Fatalf("project result/request = %#v/%#v", result, projectRunner.request)
 	}
 	if !events.contains("loader.agent.completed") || len(publisher.events) != 1 || publisher.events[0].payload["projectRunId"] != "project-run" {
 		t.Fatalf("events/publisher = %#v/%#v", events.types(), publisher.events)
+	}
+}
+
+func TestRuntimeHostProjectAgentUsesUniqueRequestIDs(t *testing.T) {
+	loader := domain.Loader{Summary: domain.LoaderSummary{
+		ID:               "loader-project",
+		ManagedProjectID: "project-1",
+		ManagedAgentName: "reviewer",
+	}}
+	run := &domain.LoaderRunSummary{ID: "run-project", LoaderID: loader.Summary.ID, TriggerID: "trigger-1"}
+	projectRunner := &hostProjectAgentRunnerFake{run: domain.ProjectRunRecord{
+		RunID:     "project-run",
+		ProjectID: "project-1",
+		AgentName: "reviewer",
+		Status:    domain.ProjectRunStatusSucceeded,
+	}}
+	host := loaders.NewRuntimeHost(loaders.RunHostDependencies{
+		ProjectAgentRunner: projectRunner,
+	}, loader, run, loaders.TriggerEventMetadata{})
+
+	for range 2 {
+		if _, err := host.Agent(context.Background(), "review", domain.LoaderAgentRequest{}); err != nil {
+			t.Fatalf("Project Agent returned error: %v", err)
+		}
+	}
+
+	if len(projectRunner.requests) != 2 || projectRunner.requests[0].ClientRequestID != run.ID+":agent:1" || projectRunner.requests[1].ClientRequestID != run.ID+":agent:2" {
+		t.Fatalf("project request IDs = %#v", projectRunner.requests)
 	}
 }
 
@@ -482,14 +510,16 @@ func (e *hostCommandExecutorFake) ExecuteLoaderCommand(context.Context, *domain.
 }
 
 type hostProjectAgentRunnerFake struct {
-	request loaders.HostProjectAgentRequest
-	run     domain.ProjectRunRecord
-	execErr error
-	err     error
+	request  loaders.HostProjectAgentRequest
+	requests []loaders.HostProjectAgentRequest
+	run      domain.ProjectRunRecord
+	execErr  error
+	err      error
 }
 
 func (r *hostProjectAgentRunnerFake) RunProjectAgent(_ context.Context, request loaders.HostProjectAgentRequest) (domain.ProjectRunRecord, error, error) {
 	r.request = request
+	r.requests = append(r.requests, request)
 	return r.run, r.execErr, r.err
 }
 

--- a/pkg/loaders/run_lifecycle.go
+++ b/pkg/loaders/run_lifecycle.go
@@ -164,7 +164,13 @@ func (e *RunExecutor) Execute(ctx context.Context, prepared PreparedRun) (domain
 	completedAt := time.Now().UTC()
 	run.CompletedAt = completedAt
 	run.DurationMs = completedAt.Sub(run.StartedAt).Milliseconds()
-	if execErr != nil {
+	if cancelCause := context.Cause(ctx); cancelCause != nil {
+		run.Status = domain.LoaderRunStatusCanceled
+		run.Error = cancelCause.Error()
+		_ = e.writeArtifact(run.ArtifactsDir, "error.txt", run.Error)
+		_ = e.deps.Store.UpdateLoaderLastError(writeCtx, prepared.Loader.Summary.ID, run.Error)
+		_ = e.addLoaderEvent(writeCtx, prepared.Loader.Summary.ID, run.ID, run.TriggerID, "loader.run.canceled", "warn", run.Error, nil, "", "", "")
+	} else if execErr != nil {
 		run.Status = domain.LoaderRunStatusFailed
 		run.Error = execErr.Error()
 		_ = e.writeArtifact(run.ArtifactsDir, "error.txt", run.Error)

--- a/pkg/loaders/run_query.go
+++ b/pkg/loaders/run_query.go
@@ -1,0 +1,11 @@
+package loaders
+
+import "time"
+
+type LoaderRunPageFilter struct {
+	LoaderIDs       []string
+	BeforeStartedAt time.Time
+	BeforeLoaderID  string
+	BeforeRunID     string
+	Limit           int
+}

--- a/pkg/loaders/scheduler_run_supervisor.go
+++ b/pkg/loaders/scheduler_run_supervisor.go
@@ -1,0 +1,207 @@
+package loaders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+var errSchedulerRunTimedOut = errors.New("scheduler run timed out")
+
+type SchedulerRunRequest struct {
+	LoaderID    string
+	TriggerID   string
+	PayloadJSON string
+	Timeout     time.Duration
+}
+
+type schedulerRunStore interface {
+	GetLoaderRun(ctx context.Context, loaderID, runID string) (domain.LoaderRunSummary, error)
+	ListLoaderRuns(ctx context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error)
+}
+
+type schedulerRunSupervisorDependencies struct {
+	RootCtx          context.Context
+	Store            schedulerRunStore
+	LoadLoaderForRun func(ctx context.Context, loaderID, triggerID string) (domain.Loader, *domain.LoaderTrigger, error)
+	Prepare          func(ctx context.Context, loader domain.Loader, trigger *domain.LoaderTrigger, payloadJSON, source string, options RunOptions) (PreparedRun, error)
+	Execute          func(ctx context.Context, prepared PreparedRun) (domain.LoaderRunSummary, error)
+	RunTimeout       func(override time.Duration) time.Duration
+}
+
+type schedulerRunSupervisor struct {
+	deps schedulerRunSupervisorDependencies
+
+	mu     sync.Mutex
+	active map[string]*activeSchedulerRun
+}
+
+type activeSchedulerRun struct {
+	loaderID string
+	cancel   context.CancelCauseFunc
+	done     chan struct{}
+	result   domain.LoaderRunSummary
+	err      error
+}
+
+func newSchedulerRunSupervisor(deps schedulerRunSupervisorDependencies) *schedulerRunSupervisor {
+	if deps.RootCtx == nil {
+		deps.RootCtx = context.Background()
+	}
+	return &schedulerRunSupervisor{
+		deps:   deps,
+		active: map[string]*activeSchedulerRun{},
+	}
+}
+
+func (s *schedulerRunSupervisor) Run(ctx context.Context, request SchedulerRunRequest) (domain.LoaderRunSummary, error) {
+	started, active, err := s.start(ctx, request)
+	if err != nil || active == nil {
+		return started, err
+	}
+	select {
+	case <-active.done:
+		return active.result, active.err
+	case <-ctx.Done():
+		active.cancel(context.Cause(ctx))
+		return domain.LoaderRunSummary{}, ctx.Err()
+	}
+}
+
+func (s *schedulerRunSupervisor) Start(ctx context.Context, request SchedulerRunRequest) (domain.LoaderRunSummary, error) {
+	started, _, err := s.start(ctx, request)
+	return started, err
+}
+
+func (s *schedulerRunSupervisor) start(ctx context.Context, request SchedulerRunRequest) (domain.LoaderRunSummary, *activeSchedulerRun, error) {
+	request.LoaderID = strings.TrimSpace(request.LoaderID)
+	request.TriggerID = strings.TrimSpace(request.TriggerID)
+	if request.LoaderID == "" {
+		return domain.LoaderRunSummary{}, nil, domain.ClassifyError(domain.ErrRequired, "scheduler loader id is required", nil)
+	}
+	if err := context.Cause(s.deps.RootCtx); err != nil {
+		return domain.LoaderRunSummary{}, nil, err
+	}
+	loader, trigger, err := s.deps.LoadLoaderForRun(ctx, request.LoaderID, request.TriggerID)
+	if err != nil {
+		return domain.LoaderRunSummary{}, nil, err
+	}
+	prepared, err := s.deps.Prepare(ctx, loader, trigger, request.PayloadJSON, "manual", RunOptions{})
+	if err != nil {
+		return domain.LoaderRunSummary{}, nil, err
+	}
+	if SchedulerRunStatusIsTerminal(prepared.Run.Status) {
+		return prepared.Run, nil, nil
+	}
+
+	runCtx, cancel := context.WithCancelCause(s.deps.RootCtx)
+	cleanup := func() { cancel(context.Canceled) }
+	if timeout := s.runTimeout(request.Timeout); timeout > 0 {
+		var timeoutCancel context.CancelFunc
+		runCtx, timeoutCancel = context.WithTimeoutCause(runCtx, timeout, errSchedulerRunTimedOut)
+		cleanup = func() {
+			timeoutCancel()
+			cancel(context.Canceled)
+		}
+	}
+	active := &activeSchedulerRun{
+		loaderID: request.LoaderID,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+	}
+	s.register(prepared.Run.ID, active)
+	go s.execute(runCtx, cleanup, prepared, active)
+	return prepared.Run, active, nil
+}
+
+func (s *schedulerRunSupervisor) execute(ctx context.Context, cleanup func(), prepared PreparedRun, active *activeSchedulerRun) {
+	defer cleanup()
+	active.result, active.err = s.deps.Execute(ctx, prepared)
+	close(active.done)
+	s.unregister(prepared.Run.ID, active)
+}
+
+func (s *schedulerRunSupervisor) Get(ctx context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {
+	if s.deps.Store == nil {
+		return domain.LoaderRunSummary{}, fmt.Errorf("scheduler run store is unavailable")
+	}
+	return s.deps.Store.GetLoaderRun(ctx, strings.TrimSpace(loaderID), strings.TrimSpace(runID))
+}
+
+func (s *schedulerRunSupervisor) List(ctx context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error) {
+	if s.deps.Store == nil {
+		return nil, fmt.Errorf("scheduler run store is unavailable")
+	}
+	return s.deps.Store.ListLoaderRuns(ctx, strings.TrimSpace(loaderID), limit)
+}
+
+func (s *schedulerRunSupervisor) Stop(ctx context.Context, loaderID, runID, reason string) (domain.LoaderRunSummary, bool, error) {
+	loaderID = strings.TrimSpace(loaderID)
+	runID = strings.TrimSpace(runID)
+	active := s.lookup(loaderID, runID)
+	if active == nil {
+		current, err := s.Get(ctx, loaderID, runID)
+		if err != nil || SchedulerRunStatusIsTerminal(current.Status) {
+			return current, false, err
+		}
+		id := loaderID + "/" + runID
+		return current, false, domain.ResourceError(domain.ErrFailedPrecondition, "scheduler run", id, fmt.Sprintf("scheduler run %s is not active in this process", id), nil)
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "stop requested"
+	}
+	active.cancel(errors.New(reason))
+	select {
+	case <-active.done:
+		return active.result, true, active.err
+	case <-ctx.Done():
+		return domain.LoaderRunSummary{}, true, ctx.Err()
+	}
+}
+
+func (s *schedulerRunSupervisor) register(runID string, active *activeSchedulerRun) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active[strings.TrimSpace(runID)] = active
+}
+
+func (s *schedulerRunSupervisor) unregister(runID string, active *activeSchedulerRun) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	runID = strings.TrimSpace(runID)
+	if s.active[runID] == active {
+		delete(s.active, runID)
+	}
+}
+
+func (s *schedulerRunSupervisor) lookup(loaderID, runID string) *activeSchedulerRun {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	active := s.active[runID]
+	if active == nil || active.loaderID != loaderID {
+		return nil
+	}
+	return active
+}
+
+func (s *schedulerRunSupervisor) runTimeout(override time.Duration) time.Duration {
+	if s.deps.RunTimeout == nil {
+		return override
+	}
+	return s.deps.RunTimeout(override)
+}
+
+func SchedulerRunStatusIsTerminal(status string) bool {
+	switch domain.NormalizeLoaderRunStatus(status) {
+	case domain.LoaderRunStatusSucceeded, domain.LoaderRunStatusFailed, domain.LoaderRunStatusCanceled, domain.LoaderRunStatusSkipped:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/loaders/scheduler_run_supervisor_test.go
+++ b/pkg/loaders/scheduler_run_supervisor_test.go
@@ -1,0 +1,272 @@
+package loaders
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestRunExecutorCancellationWritesCanceledTerminalState(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	store := &cancelRunStore{}
+	engine := &cancelRunEngine{started: make(chan struct{})}
+	var events []string
+	artifactsDir := t.TempDir()
+	executor := NewRunExecutor(RunExecutorDependencies{
+		Store:       store,
+		Engine:      engine,
+		HostFactory: func(domain.Loader, *domain.LoaderRunSummary, TriggerEventMetadata) RunHost { return nil },
+		ArtifactsDir: func(loaderID, runID string) string {
+			return filepath.Join(artifactsDir, loaderID, runID)
+		},
+		WriteArtifact: func(string, string, string) error { return nil },
+		AddLoaderEvent: func(_ context.Context, _, _, _, eventType, _, _ string, _ any, _, _, _ string) error {
+			events = append(events, eventType)
+			return nil
+		},
+	})
+	result := make(chan domain.LoaderRunSummary, 1)
+	errResult := make(chan error, 1)
+	go func() {
+		run, err := executor.Run(ctx, domain.Loader{
+			Summary: domain.LoaderSummary{ID: "loader-1", Runtime: domain.LoaderRuntimeScheduler},
+			Script:  "function main() {}",
+		}, nil, `{}`, "manual", RunOptions{})
+		result <- run
+		errResult <- err
+	}()
+
+	<-engine.started
+	cancel(errors.New("user stop"))
+	run := <-result
+	if err := <-errResult; err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if run.Status != domain.LoaderRunStatusCanceled || run.Error != "user stop" {
+		t.Fatalf("run = %#v", run)
+	}
+	if len(store.updated) != 1 || store.updated[0].Status != domain.LoaderRunStatusCanceled {
+		t.Fatalf("updated runs = %#v", store.updated)
+	}
+	if !slices.Contains(events, "loader.run.canceled") || slices.Contains(events, "loader.run.failed") {
+		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestSchedulerRunSupervisorRunReturnsFinalResult(t *testing.T) {
+	store := newSupervisorRunStore()
+	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+		RootCtx: context.Background(),
+		Store:   store,
+		LoadLoaderForRun: func(context.Context, string, string) (domain.Loader, *domain.LoaderTrigger, error) {
+			return domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1"}}, nil, nil
+		},
+		Prepare: func(_ context.Context, loader domain.Loader, _ *domain.LoaderTrigger, _, _ string, _ RunOptions) (PreparedRun, error) {
+			return PreparedRun{Loader: loader, Run: domain.LoaderRunSummary{ID: "run-success", LoaderID: loader.Summary.ID, Status: domain.LoaderRunStatusRunning}}, nil
+		},
+		Execute: func(_ context.Context, prepared PreparedRun) (domain.LoaderRunSummary, error) {
+			run := prepared.Run
+			run.Status = domain.LoaderRunStatusSucceeded
+			run.ResultJSON = `{"ok":true}`
+			store.set(run)
+			return run, nil
+		},
+	})
+
+	run, err := supervisor.Run(context.Background(), SchedulerRunRequest{LoaderID: "loader-1"})
+	if err != nil || run.Status != domain.LoaderRunStatusSucceeded || run.ResultJSON != `{"ok":true}` {
+		t.Fatalf("Run run=%#v err=%v", run, err)
+	}
+}
+
+func TestSchedulerRunSupervisorTimeoutCancelsExecution(t *testing.T) {
+	store := newSupervisorRunStore()
+	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+		RootCtx: context.Background(),
+		Store:   store,
+		LoadLoaderForRun: func(context.Context, string, string) (domain.Loader, *domain.LoaderTrigger, error) {
+			return domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1"}}, nil, nil
+		},
+		Prepare: func(_ context.Context, loader domain.Loader, _ *domain.LoaderTrigger, _, _ string, _ RunOptions) (PreparedRun, error) {
+			return PreparedRun{Loader: loader, Run: domain.LoaderRunSummary{ID: "run-timeout", LoaderID: loader.Summary.ID, Status: domain.LoaderRunStatusRunning}}, nil
+		},
+		Execute: func(ctx context.Context, prepared PreparedRun) (domain.LoaderRunSummary, error) {
+			<-ctx.Done()
+			run := prepared.Run
+			run.Status = domain.LoaderRunStatusCanceled
+			run.Error = context.Cause(ctx).Error()
+			store.set(run)
+			return run, nil
+		},
+	})
+
+	run, err := supervisor.Run(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", Timeout: 10 * time.Millisecond})
+	if err != nil || run.Status != domain.LoaderRunStatusCanceled || run.Error != errSchedulerRunTimedOut.Error() {
+		t.Fatalf("Run run=%#v err=%v", run, err)
+	}
+}
+
+func TestSchedulerRunSupervisorStopWaitsForExecutorTerminalState(t *testing.T) {
+	store := newSupervisorRunStore()
+	started := make(chan struct{})
+	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+		RootCtx: context.Background(),
+		Store:   store,
+		LoadLoaderForRun: func(context.Context, string, string) (domain.Loader, *domain.LoaderTrigger, error) {
+			return domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1"}}, nil, nil
+		},
+		Prepare: func(_ context.Context, loader domain.Loader, _ *domain.LoaderTrigger, payloadJSON, source string, _ RunOptions) (PreparedRun, error) {
+			run := domain.LoaderRunSummary{ID: "run-1", LoaderID: loader.Summary.ID, Status: domain.LoaderRunStatusRunning, PayloadJSON: payloadJSON, TriggerSource: source}
+			store.set(run)
+			return PreparedRun{Loader: loader, Run: run, PayloadJSON: payloadJSON}, nil
+		},
+		Execute: func(ctx context.Context, prepared PreparedRun) (domain.LoaderRunSummary, error) {
+			close(started)
+			<-ctx.Done()
+			run := prepared.Run
+			run.Status = domain.LoaderRunStatusCanceled
+			run.Error = context.Cause(ctx).Error()
+			store.set(run)
+			return run, nil
+		},
+	})
+
+	created, err := supervisor.Start(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", PayloadJSON: `{"key":true}`})
+	if err != nil || created.Status != domain.LoaderRunStatusRunning {
+		t.Fatalf("Start run=%#v err=%v", created, err)
+	}
+	<-started
+	stopped, requested, err := supervisor.Stop(context.Background(), "loader-1", created.ID, "user stop")
+	if err != nil || !requested || stopped.Status != domain.LoaderRunStatusCanceled || stopped.Error != "user stop" {
+		t.Fatalf("Stop run=%#v requested=%v err=%v", stopped, requested, err)
+	}
+	current, requested, err := supervisor.Stop(context.Background(), "loader-1", created.ID, "stop again")
+	if err != nil || requested || current.Status != domain.LoaderRunStatusCanceled || current.Error != "user stop" {
+		t.Fatalf("second Stop run=%#v requested=%v err=%v", current, requested, err)
+	}
+	runs, err := supervisor.List(context.Background(), "loader-1", 10)
+	if err != nil || len(runs) != 1 || runs[0].ID != created.ID {
+		t.Fatalf("List runs=%#v err=%v", runs, err)
+	}
+}
+
+func TestSchedulerRunSupervisorRootContextStopsBackgroundRun(t *testing.T) {
+	root, cancelRoot := context.WithCancel(context.Background())
+	store := newSupervisorRunStore()
+	started := make(chan struct{})
+	completed := make(chan struct{})
+	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+		RootCtx: root,
+		Store:   store,
+		LoadLoaderForRun: func(context.Context, string, string) (domain.Loader, *domain.LoaderTrigger, error) {
+			return domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1"}}, nil, nil
+		},
+		Prepare: func(_ context.Context, loader domain.Loader, _ *domain.LoaderTrigger, _, _ string, _ RunOptions) (PreparedRun, error) {
+			run := domain.LoaderRunSummary{ID: "run-root", LoaderID: loader.Summary.ID, Status: domain.LoaderRunStatusRunning}
+			store.set(run)
+			return PreparedRun{Loader: loader, Run: run}, nil
+		},
+		Execute: func(ctx context.Context, prepared PreparedRun) (domain.LoaderRunSummary, error) {
+			close(started)
+			<-ctx.Done()
+			run := prepared.Run
+			run.Status = domain.LoaderRunStatusCanceled
+			run.Error = context.Cause(ctx).Error()
+			store.set(run)
+			close(completed)
+			return run, nil
+		},
+	})
+
+	if _, err := supervisor.Start(context.Background(), SchedulerRunRequest{LoaderID: "loader-1"}); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	<-started
+	cancelRoot()
+	<-completed
+	run, err := supervisor.Get(context.Background(), "loader-1", "run-root")
+	if err != nil || run.Status != domain.LoaderRunStatusCanceled || run.Error != context.Canceled.Error() {
+		t.Fatalf("Get run=%#v err=%v", run, err)
+	}
+}
+
+type cancelRunEngine struct {
+	started chan struct{}
+}
+
+func (e *cancelRunEngine) Validate(context.Context, string, string) (LoaderValidationResult, error) {
+	return LoaderValidationResult{}, nil
+}
+
+func (e *cancelRunEngine) Execute(ctx context.Context, _ LoaderExecutionRequest, _ LoaderHost) (LoaderExecutionResult, error) {
+	close(e.started)
+	<-ctx.Done()
+	return LoaderExecutionResult{}, ctx.Err()
+}
+
+type cancelRunStore struct {
+	created   []domain.LoaderRunSummary
+	updated   []domain.LoaderRunSummary
+	lastError string
+}
+
+func (s *cancelRunStore) CreateLoaderRun(_ context.Context, run domain.LoaderRunSummary) error {
+	s.created = append(s.created, run)
+	return nil
+}
+
+func (s *cancelRunStore) UpdateLoaderRun(_ context.Context, run domain.LoaderRunSummary) error {
+	s.updated = append(s.updated, run)
+	return nil
+}
+
+func (s *cancelRunStore) UpdateLoaderLastError(_ context.Context, _ string, lastError string) error {
+	s.lastError = lastError
+	return nil
+}
+
+type supervisorRunStore struct {
+	mu   sync.Mutex
+	runs map[string]domain.LoaderRunSummary
+}
+
+func newSupervisorRunStore() *supervisorRunStore {
+	return &supervisorRunStore{runs: map[string]domain.LoaderRunSummary{}}
+}
+
+func (s *supervisorRunStore) set(run domain.LoaderRunSummary) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runs[run.LoaderID+"/"+run.ID] = run
+}
+
+func (s *supervisorRunStore) GetLoaderRun(_ context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.runs[loaderID+"/"+runID]
+	if !ok {
+		return domain.LoaderRunSummary{}, domain.ResourceError(domain.ErrNotFound, "scheduler run", loaderID+"/"+runID, "scheduler run not found", nil)
+	}
+	return run, nil
+}
+
+func (s *supervisorRunStore) ListLoaderRuns(_ context.Context, loaderID string, limit int) ([]domain.LoaderRunSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	runs := make([]domain.LoaderRunSummary, 0, len(s.runs))
+	for _, run := range s.runs {
+		if run.LoaderID == loaderID {
+			runs = append(runs, run)
+		}
+	}
+	if limit > 0 && len(runs) > limit {
+		runs = runs[:limit]
+	}
+	return runs, nil
+}

--- a/pkg/model/coverage_shape_workflows_test.go
+++ b/pkg/model/coverage_shape_workflows_test.go
@@ -112,7 +112,7 @@ func testModelBranchCoverageWorkflows(t *testing.T) {
 	if domain.NormalizeLoaderConcurrencyPolicy("allow") != domain.LoaderConcurrencyPolicyParallel || domain.NormalizeLoaderConcurrencyPolicy("bad") != domain.LoaderConcurrencyPolicySkip {
 		t.Fatalf("NormalizeLoaderConcurrencyPolicy returned unexpected values")
 	}
-	for _, status := range []string{domain.LoaderRunStatusRunning, domain.LoaderRunStatusSucceeded, domain.LoaderRunStatusFailed, domain.LoaderRunStatusSkipped} {
+	for _, status := range []string{domain.LoaderRunStatusRunning, domain.LoaderRunStatusSucceeded, domain.LoaderRunStatusFailed, domain.LoaderRunStatusCanceled, domain.LoaderRunStatusSkipped} {
 		if domain.NormalizeLoaderRunStatus(status) != status {
 			t.Fatalf("NormalizeLoaderRunStatus(%q) changed", status)
 		}

--- a/pkg/model/loader_model.go
+++ b/pkg/model/loader_model.go
@@ -27,6 +27,7 @@ const (
 	LoaderRunStatusRunning   = "running"
 	LoaderRunStatusSucceeded = "succeeded"
 	LoaderRunStatusFailed    = "failed"
+	LoaderRunStatusCanceled  = "canceled"
 	LoaderRunStatusSkipped   = "skipped"
 )
 
@@ -297,6 +298,8 @@ func NormalizeLoaderRunStatus(status string) string {
 		return LoaderRunStatusSucceeded
 	case LoaderRunStatusFailed:
 		return LoaderRunStatusFailed
+	case LoaderRunStatusCanceled:
+		return LoaderRunStatusCanceled
 	case LoaderRunStatusSkipped:
 		return LoaderRunStatusSkipped
 	default:

--- a/pkg/storage/configstore/loader_run_page.go
+++ b/pkg/storage/configstore/loader_run_page.go
@@ -1,0 +1,99 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+func (s *loaderStore) GetLoaderRunForLoaders(ctx context.Context, loaderIDs []string, runID string) (domain.LoaderRunSummary, error) {
+	loaderIDs = normalizedLoaderRunPageIDs(loaderIDs)
+	runID = strings.TrimSpace(runID)
+	if len(loaderIDs) == 0 {
+		return domain.LoaderRunSummary{}, loaderRunPageNotFound(runID, nil)
+	}
+	placeholders := make([]string, len(loaderIDs))
+	args := make([]any, 0, len(loaderIDs)+1)
+	args = append(args, runID)
+	for index, loaderID := range loaderIDs {
+		placeholders[index] = "?"
+		args = append(args, loaderID)
+	}
+	row := s.db.QueryRowContext(ctx, loaders.SelectLoaderRunSQL()+` WHERE run_id = ? AND loader_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY loader_id ASC LIMIT 1`, args...)
+	item, err := loaders.ScanLoaderRun(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.LoaderRunSummary{}, loaderRunPageNotFound(runID, err)
+		}
+		return domain.LoaderRunSummary{}, err
+	}
+	return item, nil
+}
+
+func loaderRunPageNotFound(runID string, cause error) error {
+	return domain.ResourceError(domain.ErrNotFound, "loader run", runID, fmt.Sprintf("loader run %s not found", runID), cause)
+}
+
+func (s *loaderStore) ListLoaderRunsPage(ctx context.Context, filter loaders.LoaderRunPageFilter) ([]domain.LoaderRunSummary, error) {
+	loaderIDs := normalizedLoaderRunPageIDs(filter.LoaderIDs)
+	if len(loaderIDs) == 0 {
+		return []domain.LoaderRunSummary{}, nil
+	}
+	if filter.Limit <= 0 {
+		filter.Limit = 50
+	}
+	placeholders := make([]string, len(loaderIDs))
+	args := make([]any, 0, len(loaderIDs)+7)
+	for index, loaderID := range loaderIDs {
+		placeholders[index] = "?"
+		args = append(args, loaderID)
+	}
+	query := loaders.SelectLoaderRunSQL() + ` WHERE loader_id IN (` + strings.Join(placeholders, ",") + `)`
+	if !filter.BeforeStartedAt.IsZero() {
+		query += ` AND (started_at < ? OR (started_at = ? AND (loader_id < ? OR (loader_id = ? AND run_id < ?))))`
+		beforeMillis := filter.BeforeStartedAt.UTC().UnixMilli()
+		args = append(args, beforeMillis, beforeMillis, strings.TrimSpace(filter.BeforeLoaderID), strings.TrimSpace(filter.BeforeLoaderID), strings.TrimSpace(filter.BeforeRunID))
+	}
+	query += ` ORDER BY started_at DESC, loader_id DESC, run_id DESC LIMIT ?`
+	args = append(args, filter.Limit)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query loader run page: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	items := make([]domain.LoaderRunSummary, 0)
+	for rows.Next() {
+		item, err := loaders.ScanLoaderRun(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate loader run page: %w", err)
+	}
+	return items, nil
+}
+
+func normalizedLoaderRunPageIDs(loaderIDs []string) []string {
+	seen := make(map[string]struct{}, len(loaderIDs))
+	result := make([]string, 0, len(loaderIDs))
+	for _, loaderID := range loaderIDs {
+		loaderID = strings.TrimSpace(loaderID)
+		if loaderID == "" {
+			continue
+		}
+		if _, ok := seen[loaderID]; ok {
+			continue
+		}
+		seen[loaderID] = struct{}{}
+		result = append(result, loaderID)
+	}
+	return result
+}

--- a/pkg/storage/configstore/loader_run_page_test.go
+++ b/pkg/storage/configstore/loader_run_page_test.go
@@ -1,0 +1,77 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+func TestLoaderRunPageUsesStableCrossLoaderCursor(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	for _, loaderID := range []string{"loader-a", "loader-b"} {
+		if _, err := store.UpsertManagedLoader(ctx, domain.Loader{
+			Summary: domain.LoaderSummary{
+				ID:                 loaderID,
+				Name:               loaderID,
+				Runtime:            domain.LoaderRuntimeScheduler,
+				ManagedProjectID:   "project-1",
+				ManagedAgentName:   loaderID,
+				ManagedSchedulerID: "scheduler-" + loaderID,
+			},
+			Script: "function main() {}",
+		}); err != nil {
+			t.Fatalf("upsert loader %s: %v", loaderID, err)
+		}
+	}
+	newer := time.UnixMilli(1_720_000_000_500).UTC()
+	older := newer.Add(-time.Second)
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: "run-a", LoaderID: "loader-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
+		{ID: "run-b1", LoaderID: "loader-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
+		{ID: "run-b2", LoaderID: "loader-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
+		{ID: "run-old", LoaderID: "loader-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: older},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run %s: %v", run.ID, err)
+		}
+	}
+
+	first, err := store.ListLoaderRunsPage(ctx, loaders.LoaderRunPageFilter{
+		LoaderIDs: []string{" loader-a ", "loader-b", "loader-a"},
+		Limit:     2,
+	})
+	if err != nil || len(first) != 2 || first[0].ID != "run-b2" || first[1].ID != "run-b1" {
+		t.Fatalf("first page=%#v err=%v", first, err)
+	}
+	second, err := store.ListLoaderRunsPage(ctx, loaders.LoaderRunPageFilter{
+		LoaderIDs:       []string{"loader-a", "loader-b"},
+		BeforeStartedAt: first[1].StartedAt,
+		BeforeLoaderID:  first[1].LoaderID,
+		BeforeRunID:     first[1].ID,
+		Limit:           2,
+	})
+	if err != nil || len(second) != 2 || second[0].ID != "run-a" || second[1].ID != "run-old" {
+		t.Fatalf("second page=%#v err=%v", second, err)
+	}
+	filtered, err := store.ListLoaderRunsPage(ctx, loaders.LoaderRunPageFilter{LoaderIDs: []string{"loader-a"}, Limit: 10})
+	if err != nil || len(filtered) != 1 || filtered[0].ID != "run-a" {
+		t.Fatalf("filtered page=%#v err=%v", filtered, err)
+	}
+	byID, err := store.GetLoaderRunForLoaders(ctx, []string{"loader-b"}, "run-old")
+	if err != nil || byID.LoaderID != "loader-b" {
+		t.Fatalf("GetLoaderRunForLoaders run=%#v err=%v", byID, err)
+	}
+	if _, err := store.GetLoaderRunForLoaders(ctx, []string{"loader-a"}, "run-old"); err == nil {
+		t.Fatal("GetLoaderRunForLoaders accepted a run from another loader")
+	}
+	if _, err := store.GetLoaderRunForLoaders(ctx, nil, "missing"); err == nil {
+		t.Fatal("GetLoaderRunForLoaders missing returned nil error")
+	}
+}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -288,6 +288,64 @@ func (RunSource) EnumDescriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{4}
 }
 
+type SchedulerRunStatus int32
+
+const (
+	SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED SchedulerRunStatus = 0
+	SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING     SchedulerRunStatus = 1
+	SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED   SchedulerRunStatus = 2
+	SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED      SchedulerRunStatus = 3
+	SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED    SchedulerRunStatus = 4
+	SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED     SchedulerRunStatus = 5
+)
+
+// Enum value maps for SchedulerRunStatus.
+var (
+	SchedulerRunStatus_name = map[int32]string{
+		0: "SCHEDULER_RUN_STATUS_UNSPECIFIED",
+		1: "SCHEDULER_RUN_STATUS_RUNNING",
+		2: "SCHEDULER_RUN_STATUS_SUCCEEDED",
+		3: "SCHEDULER_RUN_STATUS_FAILED",
+		4: "SCHEDULER_RUN_STATUS_CANCELED",
+		5: "SCHEDULER_RUN_STATUS_SKIPPED",
+	}
+	SchedulerRunStatus_value = map[string]int32{
+		"SCHEDULER_RUN_STATUS_UNSPECIFIED": 0,
+		"SCHEDULER_RUN_STATUS_RUNNING":     1,
+		"SCHEDULER_RUN_STATUS_SUCCEEDED":   2,
+		"SCHEDULER_RUN_STATUS_FAILED":      3,
+		"SCHEDULER_RUN_STATUS_CANCELED":    4,
+		"SCHEDULER_RUN_STATUS_SKIPPED":     5,
+	}
+)
+
+func (x SchedulerRunStatus) Enum() *SchedulerRunStatus {
+	p := new(SchedulerRunStatus)
+	*p = x
+	return p
+}
+
+func (x SchedulerRunStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SchedulerRunStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[5].Descriptor()
+}
+
+func (SchedulerRunStatus) Type() protoreflect.EnumType {
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[5]
+}
+
+func (x SchedulerRunStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SchedulerRunStatus.Descriptor instead.
+func (SchedulerRunStatus) EnumDescriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{5}
+}
+
 type AgentStatus int32
 
 const (
@@ -321,11 +379,11 @@ func (x AgentStatus) String() string {
 }
 
 func (AgentStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[5].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[6].Descriptor()
 }
 
 func (AgentStatus) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[5]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[6]
 }
 
 func (x AgentStatus) Number() protoreflect.EnumNumber {
@@ -334,7 +392,7 @@ func (x AgentStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AgentStatus.Descriptor instead.
 func (AgentStatus) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{5}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{6}
 }
 
 type ProjectAgentAvailability int32
@@ -373,11 +431,11 @@ func (x ProjectAgentAvailability) String() string {
 }
 
 func (ProjectAgentAvailability) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[6].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[7].Descriptor()
 }
 
 func (ProjectAgentAvailability) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[6]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[7]
 }
 
 func (x ProjectAgentAvailability) Number() protoreflect.EnumNumber {
@@ -386,7 +444,7 @@ func (x ProjectAgentAvailability) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ProjectAgentAvailability.Descriptor instead.
 func (ProjectAgentAvailability) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{6}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{7}
 }
 
 type ProjectAgentHealth int32
@@ -422,11 +480,11 @@ func (x ProjectAgentHealth) String() string {
 }
 
 func (ProjectAgentHealth) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[7].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[8].Descriptor()
 }
 
 func (ProjectAgentHealth) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[7]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[8]
 }
 
 func (x ProjectAgentHealth) Number() protoreflect.EnumNumber {
@@ -435,7 +493,7 @@ func (x ProjectAgentHealth) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ProjectAgentHealth.Descriptor instead.
 func (ProjectAgentHealth) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{7}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{8}
 }
 
 type RunEventKind int32
@@ -477,11 +535,11 @@ func (x RunEventKind) String() string {
 }
 
 func (RunEventKind) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[8].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[9].Descriptor()
 }
 
 func (RunEventKind) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[8]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[9]
 }
 
 func (x RunEventKind) Number() protoreflect.EnumNumber {
@@ -490,7 +548,7 @@ func (x RunEventKind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RunEventKind.Descriptor instead.
 func (RunEventKind) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{8}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{9}
 }
 
 type RunAgentStreamEventType int32
@@ -532,11 +590,11 @@ func (x RunAgentStreamEventType) String() string {
 }
 
 func (RunAgentStreamEventType) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[9].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[10].Descriptor()
 }
 
 func (RunAgentStreamEventType) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[9]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[10]
 }
 
 func (x RunAgentStreamEventType) Number() protoreflect.EnumNumber {
@@ -545,7 +603,7 @@ func (x RunAgentStreamEventType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RunAgentStreamEventType.Descriptor instead.
 func (RunAgentStreamEventType) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{9}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{10}
 }
 
 type RunSandboxCleanupPolicy int32
@@ -584,11 +642,11 @@ func (x RunSandboxCleanupPolicy) String() string {
 }
 
 func (RunSandboxCleanupPolicy) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[10].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[11].Descriptor()
 }
 
 func (RunSandboxCleanupPolicy) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[10]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[11]
 }
 
 func (x RunSandboxCleanupPolicy) Number() protoreflect.EnumNumber {
@@ -597,7 +655,7 @@ func (x RunSandboxCleanupPolicy) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RunSandboxCleanupPolicy.Descriptor instead.
 func (RunSandboxCleanupPolicy) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{10}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{11}
 }
 
 type ExecStreamEventType int32
@@ -636,11 +694,11 @@ func (x ExecStreamEventType) String() string {
 }
 
 func (ExecStreamEventType) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[11].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[12].Descriptor()
 }
 
 func (ExecStreamEventType) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[11]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[12]
 }
 
 func (x ExecStreamEventType) Number() protoreflect.EnumNumber {
@@ -649,7 +707,7 @@ func (x ExecStreamEventType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ExecStreamEventType.Descriptor instead.
 func (ExecStreamEventType) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{11}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{12}
 }
 
 type AttachRunMode int32
@@ -685,11 +743,11 @@ func (x AttachRunMode) String() string {
 }
 
 func (AttachRunMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[12].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[13].Descriptor()
 }
 
 func (AttachRunMode) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[12]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[13]
 }
 
 func (x AttachRunMode) Number() protoreflect.EnumNumber {
@@ -698,7 +756,7 @@ func (x AttachRunMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AttachRunMode.Descriptor instead.
 func (AttachRunMode) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{12}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{13}
 }
 
 type StdioStream int32
@@ -734,11 +792,11 @@ func (x StdioStream) String() string {
 }
 
 func (StdioStream) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[13].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[14].Descriptor()
 }
 
 func (StdioStream) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[13]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[14]
 }
 
 func (x StdioStream) Number() protoreflect.EnumNumber {
@@ -747,7 +805,7 @@ func (x StdioStream) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use StdioStream.Descriptor instead.
 func (StdioStream) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{13}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{14}
 }
 
 type ImageStoreKind int32
@@ -783,11 +841,11 @@ func (x ImageStoreKind) String() string {
 }
 
 func (ImageStoreKind) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[14].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[15].Descriptor()
 }
 
 func (ImageStoreKind) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[14]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[15]
 }
 
 func (x ImageStoreKind) Number() protoreflect.EnumNumber {
@@ -796,7 +854,7 @@ func (x ImageStoreKind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ImageStoreKind.Descriptor instead.
 func (ImageStoreKind) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{14}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{15}
 }
 
 type ImageAvailabilityStatus int32
@@ -835,11 +893,11 @@ func (x ImageAvailabilityStatus) String() string {
 }
 
 func (ImageAvailabilityStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[15].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[16].Descriptor()
 }
 
 func (ImageAvailabilityStatus) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[15]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[16]
 }
 
 func (x ImageAvailabilityStatus) Number() protoreflect.EnumNumber {
@@ -848,7 +906,7 @@ func (x ImageAvailabilityStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ImageAvailabilityStatus.Descriptor instead.
 func (ImageAvailabilityStatus) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{15}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{16}
 }
 
 type ImageOperationStatus int32
@@ -887,11 +945,11 @@ func (x ImageOperationStatus) String() string {
 }
 
 func (ImageOperationStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[16].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[17].Descriptor()
 }
 
 func (ImageOperationStatus) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[16]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[17]
 }
 
 func (x ImageOperationStatus) Number() protoreflect.EnumNumber {
@@ -900,7 +958,7 @@ func (x ImageOperationStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ImageOperationStatus.Descriptor instead.
 func (ImageOperationStatus) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{16}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{17}
 }
 
 type MetricStatus int32
@@ -939,11 +997,11 @@ func (x MetricStatus) String() string {
 }
 
 func (MetricStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[17].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[18].Descriptor()
 }
 
 func (MetricStatus) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[17]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[18]
 }
 
 func (x MetricStatus) Number() protoreflect.EnumNumber {
@@ -952,7 +1010,7 @@ func (x MetricStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MetricStatus.Descriptor instead.
 func (MetricStatus) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{17}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{18}
 }
 
 type CacheDomain int32
@@ -994,11 +1052,11 @@ func (x CacheDomain) String() string {
 }
 
 func (CacheDomain) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[18].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[19].Descriptor()
 }
 
 func (CacheDomain) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[18]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[19]
 }
 
 func (x CacheDomain) Number() protoreflect.EnumNumber {
@@ -1007,7 +1065,7 @@ func (x CacheDomain) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CacheDomain.Descriptor instead.
 func (CacheDomain) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{18}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{19}
 }
 
 type CacheReferencePolicy int32
@@ -1043,11 +1101,11 @@ func (x CacheReferencePolicy) String() string {
 }
 
 func (CacheReferencePolicy) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[19].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[20].Descriptor()
 }
 
 func (CacheReferencePolicy) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[19]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[20]
 }
 
 func (x CacheReferencePolicy) Number() protoreflect.EnumNumber {
@@ -1056,7 +1114,7 @@ func (x CacheReferencePolicy) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CacheReferencePolicy.Descriptor instead.
 func (CacheReferencePolicy) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{19}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{20}
 }
 
 type SandboxPruneCandidateKind int32
@@ -1092,11 +1150,11 @@ func (x SandboxPruneCandidateKind) String() string {
 }
 
 func (SandboxPruneCandidateKind) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[20].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[21].Descriptor()
 }
 
 func (SandboxPruneCandidateKind) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[20]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[21]
 }
 
 func (x SandboxPruneCandidateKind) Number() protoreflect.EnumNumber {
@@ -1105,7 +1163,7 @@ func (x SandboxPruneCandidateKind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SandboxPruneCandidateKind.Descriptor instead.
 func (SandboxPruneCandidateKind) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{20}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{21}
 }
 
 type CacheStatus int32
@@ -1153,11 +1211,11 @@ func (x CacheStatus) String() string {
 }
 
 func (CacheStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[21].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[22].Descriptor()
 }
 
 func (CacheStatus) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[21]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[22]
 }
 
 func (x CacheStatus) Number() protoreflect.EnumNumber {
@@ -1166,7 +1224,7 @@ func (x CacheStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CacheStatus.Descriptor instead.
 func (CacheStatus) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{21}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{22}
 }
 
 type ResourceKind int32
@@ -1214,11 +1272,11 @@ func (x ResourceKind) String() string {
 }
 
 func (ResourceKind) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[22].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[23].Descriptor()
 }
 
 func (ResourceKind) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[22]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[23]
 }
 
 func (x ResourceKind) Number() protoreflect.EnumNumber {
@@ -1227,7 +1285,7 @@ func (x ResourceKind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ResourceKind.Descriptor instead.
 func (ResourceKind) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{22}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{23}
 }
 
 type SandboxWatchEventType int32
@@ -1272,11 +1330,11 @@ func (x SandboxWatchEventType) String() string {
 }
 
 func (SandboxWatchEventType) Descriptor() protoreflect.EnumDescriptor {
-	return file_agentcompose_v2_agentcompose_proto_enumTypes[23].Descriptor()
+	return file_agentcompose_v2_agentcompose_proto_enumTypes[24].Descriptor()
 }
 
 func (SandboxWatchEventType) Type() protoreflect.EnumType {
-	return &file_agentcompose_v2_agentcompose_proto_enumTypes[23]
+	return &file_agentcompose_v2_agentcompose_proto_enumTypes[24]
 }
 
 func (x SandboxWatchEventType) Number() protoreflect.EnumNumber {
@@ -1285,7 +1343,7 @@ func (x SandboxWatchEventType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SandboxWatchEventType.Descriptor instead.
 func (SandboxWatchEventType) EnumDescriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{23}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{24}
 }
 
 type ValidateProjectRequest struct {
@@ -3432,6 +3490,722 @@ func (x *ListSchedulerEventsResponse) GetNextCursor() string {
 	return ""
 }
 
+type RunSchedulerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	TriggerId     string                 `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	PayloadJson   string                 `protobuf:"bytes,4,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunSchedulerRequest) Reset() {
+	*x = RunSchedulerRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunSchedulerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunSchedulerRequest) ProtoMessage() {}
+
+func (x *RunSchedulerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunSchedulerRequest.ProtoReflect.Descriptor instead.
+func (*RunSchedulerRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *RunSchedulerRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *RunSchedulerRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *RunSchedulerRequest) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *RunSchedulerRequest) GetPayloadJson() string {
+	if x != nil {
+		return x.PayloadJson
+	}
+	return ""
+}
+
+type RunSchedulerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *SchedulerRun          `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunSchedulerResponse) Reset() {
+	*x = RunSchedulerResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunSchedulerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunSchedulerResponse) ProtoMessage() {}
+
+func (x *RunSchedulerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunSchedulerResponse.ProtoReflect.Descriptor instead.
+func (*RunSchedulerResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *RunSchedulerResponse) GetRun() *SchedulerRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+type StartSchedulerRunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	TriggerId     string                 `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	PayloadJson   string                 `protobuf:"bytes,4,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartSchedulerRunRequest) Reset() {
+	*x = StartSchedulerRunRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartSchedulerRunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartSchedulerRunRequest) ProtoMessage() {}
+
+func (x *StartSchedulerRunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartSchedulerRunRequest.ProtoReflect.Descriptor instead.
+func (*StartSchedulerRunRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *StartSchedulerRunRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *StartSchedulerRunRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *StartSchedulerRunRequest) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *StartSchedulerRunRequest) GetPayloadJson() string {
+	if x != nil {
+		return x.PayloadJson
+	}
+	return ""
+}
+
+type StartSchedulerRunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *SchedulerRun          `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartSchedulerRunResponse) Reset() {
+	*x = StartSchedulerRunResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartSchedulerRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartSchedulerRunResponse) ProtoMessage() {}
+
+func (x *StartSchedulerRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartSchedulerRunResponse.ProtoReflect.Descriptor instead.
+func (*StartSchedulerRunResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *StartSchedulerRunResponse) GetRun() *SchedulerRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+type GetSchedulerRunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	RunId         string                 `protobuf:"bytes,2,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSchedulerRunRequest) Reset() {
+	*x = GetSchedulerRunRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSchedulerRunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSchedulerRunRequest) ProtoMessage() {}
+
+func (x *GetSchedulerRunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSchedulerRunRequest.ProtoReflect.Descriptor instead.
+func (*GetSchedulerRunRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *GetSchedulerRunRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *GetSchedulerRunRequest) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+type GetSchedulerRunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *SchedulerRun          `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSchedulerRunResponse) Reset() {
+	*x = GetSchedulerRunResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSchedulerRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSchedulerRunResponse) ProtoMessage() {}
+
+func (x *GetSchedulerRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSchedulerRunResponse.ProtoReflect.Descriptor instead.
+func (*GetSchedulerRunResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *GetSchedulerRunResponse) GetRun() *SchedulerRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+type ListSchedulerRunsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	Limit         uint32                 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
+	Cursor        string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSchedulerRunsRequest) Reset() {
+	*x = ListSchedulerRunsRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSchedulerRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSchedulerRunsRequest) ProtoMessage() {}
+
+func (x *ListSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSchedulerRunsRequest.ProtoReflect.Descriptor instead.
+func (*ListSchedulerRunsRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *ListSchedulerRunsRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *ListSchedulerRunsRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *ListSchedulerRunsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListSchedulerRunsRequest) GetCursor() string {
+	if x != nil {
+		return x.Cursor
+	}
+	return ""
+}
+
+type ListSchedulerRunsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Runs          []*SchedulerRun        `protobuf:"bytes,1,rep,name=runs,proto3" json:"runs,omitempty"`
+	NextCursor    string                 `protobuf:"bytes,2,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSchedulerRunsResponse) Reset() {
+	*x = ListSchedulerRunsResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSchedulerRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSchedulerRunsResponse) ProtoMessage() {}
+
+func (x *ListSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSchedulerRunsResponse.ProtoReflect.Descriptor instead.
+func (*ListSchedulerRunsResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *ListSchedulerRunsResponse) GetRuns() []*SchedulerRun {
+	if x != nil {
+		return x.Runs
+	}
+	return nil
+}
+
+func (x *ListSchedulerRunsResponse) GetNextCursor() string {
+	if x != nil {
+		return x.NextCursor
+	}
+	return ""
+}
+
+type StopSchedulerRunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	RunId         string                 `protobuf:"bytes,2,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	Reason        string                 `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopSchedulerRunRequest) Reset() {
+	*x = StopSchedulerRunRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopSchedulerRunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopSchedulerRunRequest) ProtoMessage() {}
+
+func (x *StopSchedulerRunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopSchedulerRunRequest.ProtoReflect.Descriptor instead.
+func (*StopSchedulerRunRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *StopSchedulerRunRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *StopSchedulerRunRequest) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *StopSchedulerRunRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type StopSchedulerRunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *SchedulerRun          `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	StopRequested bool                   `protobuf:"varint,2,opt,name=stop_requested,json=stopRequested,proto3" json:"stop_requested,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopSchedulerRunResponse) Reset() {
+	*x = StopSchedulerRunResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopSchedulerRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopSchedulerRunResponse) ProtoMessage() {}
+
+func (x *StopSchedulerRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopSchedulerRunResponse.ProtoReflect.Descriptor instead.
+func (*StopSchedulerRunResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *StopSchedulerRunResponse) GetRun() *SchedulerRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+func (x *StopSchedulerRunResponse) GetStopRequested() bool {
+	if x != nil {
+		return x.StopRequested
+	}
+	return false
+}
+
+type SchedulerRun struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	RunId              string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	ProjectId          string                 `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	AgentName          string                 `protobuf:"bytes,3,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	SchedulerId        string                 `protobuf:"bytes,4,opt,name=scheduler_id,json=schedulerId,proto3" json:"scheduler_id,omitempty"`
+	TriggerId          string                 `protobuf:"bytes,5,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	TriggerKind        string                 `protobuf:"bytes,6,opt,name=trigger_kind,json=triggerKind,proto3" json:"trigger_kind,omitempty"`
+	TriggerSource      string                 `protobuf:"bytes,7,opt,name=trigger_source,json=triggerSource,proto3" json:"trigger_source,omitempty"`
+	Status             SchedulerRunStatus     `protobuf:"varint,8,opt,name=status,proto3,enum=agentcompose.v2.SchedulerRunStatus" json:"status,omitempty"`
+	StartedAt          *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	CompletedAt        *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
+	DurationMs         int64                  `protobuf:"varint,11,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	Error              string                 `protobuf:"bytes,12,opt,name=error,proto3" json:"error,omitempty"`
+	ResultJson         string                 `protobuf:"bytes,13,opt,name=result_json,json=resultJson,proto3" json:"result_json,omitempty"`
+	PayloadJson        string                 `protobuf:"bytes,14,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
+	SourceScriptSha256 string                 `protobuf:"bytes,15,opt,name=source_script_sha256,json=sourceScriptSha256,proto3" json:"source_script_sha256,omitempty"`
+	ArtifactsDir       string                 `protobuf:"bytes,16,opt,name=artifacts_dir,json=artifactsDir,proto3" json:"artifacts_dir,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *SchedulerRun) Reset() {
+	*x = SchedulerRun{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SchedulerRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SchedulerRun) ProtoMessage() {}
+
+func (x *SchedulerRun) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SchedulerRun.ProtoReflect.Descriptor instead.
+func (*SchedulerRun) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *SchedulerRun) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetSchedulerId() string {
+	if x != nil {
+		return x.SchedulerId
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetTriggerKind() string {
+	if x != nil {
+		return x.TriggerKind
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetTriggerSource() string {
+	if x != nil {
+		return x.TriggerSource
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetStatus() SchedulerRunStatus {
+	if x != nil {
+		return x.Status
+	}
+	return SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED
+}
+
+func (x *SchedulerRun) GetStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartedAt
+	}
+	return nil
+}
+
+func (x *SchedulerRun) GetCompletedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CompletedAt
+	}
+	return nil
+}
+
+func (x *SchedulerRun) GetDurationMs() int64 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *SchedulerRun) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetResultJson() string {
+	if x != nil {
+		return x.ResultJson
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetPayloadJson() string {
+	if x != nil {
+		return x.PayloadJson
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetSourceScriptSha256() string {
+	if x != nil {
+		return x.SourceScriptSha256
+	}
+	return ""
+}
+
+func (x *SchedulerRun) GetArtifactsDir() string {
+	if x != nil {
+		return x.ArtifactsDir
+	}
+	return ""
+}
+
 type SetSchedulerEnabledRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
@@ -3443,7 +4217,7 @@ type SetSchedulerEnabledRequest struct {
 
 func (x *SetSchedulerEnabledRequest) Reset() {
 	*x = SetSchedulerEnabledRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3455,7 +4229,7 @@ func (x *SetSchedulerEnabledRequest) String() string {
 func (*SetSchedulerEnabledRequest) ProtoMessage() {}
 
 func (x *SetSchedulerEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3468,7 +4242,7 @@ func (x *SetSchedulerEnabledRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSchedulerEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetSchedulerEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{30}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *SetSchedulerEnabledRequest) GetProject() *ProjectRef {
@@ -3502,7 +4276,7 @@ type SetSchedulerEnabledResponse struct {
 
 func (x *SetSchedulerEnabledResponse) Reset() {
 	*x = SetSchedulerEnabledResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3514,7 +4288,7 @@ func (x *SetSchedulerEnabledResponse) String() string {
 func (*SetSchedulerEnabledResponse) ProtoMessage() {}
 
 func (x *SetSchedulerEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3527,7 +4301,7 @@ func (x *SetSchedulerEnabledResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSchedulerEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetSchedulerEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{31}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SetSchedulerEnabledResponse) GetScheduler() *ProjectScheduler {
@@ -3556,7 +4330,7 @@ type SetSchedulerTriggerEnabledRequest struct {
 
 func (x *SetSchedulerTriggerEnabledRequest) Reset() {
 	*x = SetSchedulerTriggerEnabledRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3568,7 +4342,7 @@ func (x *SetSchedulerTriggerEnabledRequest) String() string {
 func (*SetSchedulerTriggerEnabledRequest) ProtoMessage() {}
 
 func (x *SetSchedulerTriggerEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3581,7 +4355,7 @@ func (x *SetSchedulerTriggerEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetSchedulerTriggerEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetSchedulerTriggerEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{32}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *SetSchedulerTriggerEnabledRequest) GetProject() *ProjectRef {
@@ -3621,7 +4395,7 @@ type SetSchedulerTriggerEnabledResponse struct {
 
 func (x *SetSchedulerTriggerEnabledResponse) Reset() {
 	*x = SetSchedulerTriggerEnabledResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3633,7 +4407,7 @@ func (x *SetSchedulerTriggerEnabledResponse) String() string {
 func (*SetSchedulerTriggerEnabledResponse) ProtoMessage() {}
 
 func (x *SetSchedulerTriggerEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3646,7 +4420,7 @@ func (x *SetSchedulerTriggerEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetSchedulerTriggerEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetSchedulerTriggerEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{33}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SetSchedulerTriggerEnabledResponse) GetTrigger() *ResolvedTrigger {
@@ -3667,7 +4441,7 @@ type ProjectValidationIssue struct {
 
 func (x *ProjectValidationIssue) Reset() {
 	*x = ProjectValidationIssue{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3679,7 +4453,7 @@ func (x *ProjectValidationIssue) String() string {
 func (*ProjectValidationIssue) ProtoMessage() {}
 
 func (x *ProjectValidationIssue) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3692,7 +4466,7 @@ func (x *ProjectValidationIssue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectValidationIssue.ProtoReflect.Descriptor instead.
 func (*ProjectValidationIssue) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{34}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ProjectValidationIssue) GetSeverity() ProjectValidationSeverity {
@@ -3729,7 +4503,7 @@ type ProjectChange struct {
 
 func (x *ProjectChange) Reset() {
 	*x = ProjectChange{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3741,7 +4515,7 @@ func (x *ProjectChange) String() string {
 func (*ProjectChange) ProtoMessage() {}
 
 func (x *ProjectChange) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3754,7 +4528,7 @@ func (x *ProjectChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectChange.ProtoReflect.Descriptor instead.
 func (*ProjectChange) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{35}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ProjectChange) GetAction() ProjectChangeAction {
@@ -3807,7 +4581,7 @@ type ProjectSpec struct {
 
 func (x *ProjectSpec) Reset() {
 	*x = ProjectSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3819,7 +4593,7 @@ func (x *ProjectSpec) String() string {
 func (*ProjectSpec) ProtoMessage() {}
 
 func (x *ProjectSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3832,7 +4606,7 @@ func (x *ProjectSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectSpec.ProtoReflect.Descriptor instead.
 func (*ProjectSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{36}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ProjectSpec) GetName() string {
@@ -3894,7 +4668,7 @@ type NamedWorkspaceSpec struct {
 
 func (x *NamedWorkspaceSpec) Reset() {
 	*x = NamedWorkspaceSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3906,7 +4680,7 @@ func (x *NamedWorkspaceSpec) String() string {
 func (*NamedWorkspaceSpec) ProtoMessage() {}
 
 func (x *NamedWorkspaceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3919,7 +4693,7 @@ func (x *NamedWorkspaceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamedWorkspaceSpec.ProtoReflect.Descriptor instead.
 func (*NamedWorkspaceSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{37}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *NamedWorkspaceSpec) GetName() string {
@@ -3962,7 +4736,7 @@ type AgentSpec struct {
 
 func (x *AgentSpec) Reset() {
 	*x = AgentSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3974,7 +4748,7 @@ func (x *AgentSpec) String() string {
 func (*AgentSpec) ProtoMessage() {}
 
 func (x *AgentSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3987,7 +4761,7 @@ func (x *AgentSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentSpec.ProtoReflect.Descriptor instead.
 func (*AgentSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{38}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *AgentSpec) GetName() string {
@@ -4132,7 +4906,7 @@ type MCPServerSpec struct {
 
 func (x *MCPServerSpec) Reset() {
 	*x = MCPServerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4144,7 +4918,7 @@ func (x *MCPServerSpec) String() string {
 func (*MCPServerSpec) ProtoMessage() {}
 
 func (x *MCPServerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4157,7 +4931,7 @@ func (x *MCPServerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerSpec.ProtoReflect.Descriptor instead.
 func (*MCPServerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{39}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *MCPServerSpec) GetName() string {
@@ -4230,7 +5004,7 @@ type ProjectVolumeSpec struct {
 
 func (x *ProjectVolumeSpec) Reset() {
 	*x = ProjectVolumeSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4242,7 +5016,7 @@ func (x *ProjectVolumeSpec) String() string {
 func (*ProjectVolumeSpec) ProtoMessage() {}
 
 func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4255,7 +5029,7 @@ func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectVolumeSpec.ProtoReflect.Descriptor instead.
 func (*ProjectVolumeSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{40}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ProjectVolumeSpec) GetKey() string {
@@ -4312,7 +5086,7 @@ type VolumeMountSpec struct {
 
 func (x *VolumeMountSpec) Reset() {
 	*x = VolumeMountSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4324,7 +5098,7 @@ func (x *VolumeMountSpec) String() string {
 func (*VolumeMountSpec) ProtoMessage() {}
 
 func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4337,7 +5111,7 @@ func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeMountSpec.ProtoReflect.Descriptor instead.
 func (*VolumeMountSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{41}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *VolumeMountSpec) GetType() string {
@@ -4384,7 +5158,7 @@ type BuildSpec struct {
 
 func (x *BuildSpec) Reset() {
 	*x = BuildSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4396,7 +5170,7 @@ func (x *BuildSpec) String() string {
 func (*BuildSpec) ProtoMessage() {}
 
 func (x *BuildSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4409,7 +5183,7 @@ func (x *BuildSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildSpec.ProtoReflect.Descriptor instead.
 func (*BuildSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *BuildSpec) GetContext() string {
@@ -4479,7 +5253,7 @@ type EnvVarSpec struct {
 
 func (x *EnvVarSpec) Reset() {
 	*x = EnvVarSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4491,7 +5265,7 @@ func (x *EnvVarSpec) String() string {
 func (*EnvVarSpec) ProtoMessage() {}
 
 func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4504,7 +5278,7 @@ func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVarSpec.ProtoReflect.Descriptor instead.
 func (*EnvVarSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *EnvVarSpec) GetName() string {
@@ -4539,7 +5313,7 @@ type EnvVarUpdateSpec struct {
 
 func (x *EnvVarUpdateSpec) Reset() {
 	*x = EnvVarUpdateSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4551,7 +5325,7 @@ func (x *EnvVarUpdateSpec) String() string {
 func (*EnvVarUpdateSpec) ProtoMessage() {}
 
 func (x *EnvVarUpdateSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4564,7 +5338,7 @@ func (x *EnvVarUpdateSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVarUpdateSpec.ProtoReflect.Descriptor instead.
 func (*EnvVarUpdateSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *EnvVarUpdateSpec) GetName() string {
@@ -4602,7 +5376,7 @@ type WorkspaceSpec struct {
 
 func (x *WorkspaceSpec) Reset() {
 	*x = WorkspaceSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4614,7 +5388,7 @@ func (x *WorkspaceSpec) String() string {
 func (*WorkspaceSpec) ProtoMessage() {}
 
 func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4627,7 +5401,7 @@ func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspaceSpec.ProtoReflect.Descriptor instead.
 func (*WorkspaceSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *WorkspaceSpec) GetProvider() string {
@@ -4681,7 +5455,7 @@ type NetworkSpec struct {
 
 func (x *NetworkSpec) Reset() {
 	*x = NetworkSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4693,7 +5467,7 @@ func (x *NetworkSpec) String() string {
 func (*NetworkSpec) ProtoMessage() {}
 
 func (x *NetworkSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4706,7 +5480,7 @@ func (x *NetworkSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkSpec.ProtoReflect.Descriptor instead.
 func (*NetworkSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *NetworkSpec) GetMode() string {
@@ -4730,7 +5504,7 @@ type SchedulerSpec struct {
 
 func (x *SchedulerSpec) Reset() {
 	*x = SchedulerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4742,7 +5516,7 @@ func (x *SchedulerSpec) String() string {
 func (*SchedulerSpec) ProtoMessage() {}
 
 func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4755,7 +5529,7 @@ func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerSpec.ProtoReflect.Descriptor instead.
 func (*SchedulerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *SchedulerSpec) GetEnabled() bool {
@@ -4816,7 +5590,7 @@ type TriggerSpec struct {
 
 func (x *TriggerSpec) Reset() {
 	*x = TriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4828,7 +5602,7 @@ func (x *TriggerSpec) String() string {
 func (*TriggerSpec) ProtoMessage() {}
 
 func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4841,7 +5615,7 @@ func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerSpec.ProtoReflect.Descriptor instead.
 func (*TriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *TriggerSpec) GetName() string {
@@ -4909,7 +5683,7 @@ type EventTriggerSpec struct {
 
 func (x *EventTriggerSpec) Reset() {
 	*x = EventTriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4921,7 +5695,7 @@ func (x *EventTriggerSpec) String() string {
 func (*EventTriggerSpec) ProtoMessage() {}
 
 func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4934,7 +5708,7 @@ func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventTriggerSpec.ProtoReflect.Descriptor instead.
 func (*EventTriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *EventTriggerSpec) GetTopic() string {
@@ -4956,7 +5730,7 @@ type DriverSpec struct {
 
 func (x *DriverSpec) Reset() {
 	*x = DriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4968,7 +5742,7 @@ func (x *DriverSpec) String() string {
 func (*DriverSpec) ProtoMessage() {}
 
 func (x *DriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4981,7 +5755,7 @@ func (x *DriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DriverSpec.ProtoReflect.Descriptor instead.
 func (*DriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *DriverSpec) GetName() string {
@@ -5022,7 +5796,7 @@ type BoxliteDriverSpec struct {
 
 func (x *BoxliteDriverSpec) Reset() {
 	*x = BoxliteDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5034,7 +5808,7 @@ func (x *BoxliteDriverSpec) String() string {
 func (*BoxliteDriverSpec) ProtoMessage() {}
 
 func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5047,7 +5821,7 @@ func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoxliteDriverSpec.ProtoReflect.Descriptor instead.
 func (*BoxliteDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *BoxliteDriverSpec) GetKernel() string {
@@ -5073,7 +5847,7 @@ type DockerDriverSpec struct {
 
 func (x *DockerDriverSpec) Reset() {
 	*x = DockerDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5085,7 +5859,7 @@ func (x *DockerDriverSpec) String() string {
 func (*DockerDriverSpec) ProtoMessage() {}
 
 func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5098,7 +5872,7 @@ func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerDriverSpec.ProtoReflect.Descriptor instead.
 func (*DockerDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *DockerDriverSpec) GetHost() string {
@@ -5117,7 +5891,7 @@ type MicrosandboxDriverSpec struct {
 
 func (x *MicrosandboxDriverSpec) Reset() {
 	*x = MicrosandboxDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5129,7 +5903,7 @@ func (x *MicrosandboxDriverSpec) String() string {
 func (*MicrosandboxDriverSpec) ProtoMessage() {}
 
 func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5142,7 +5916,7 @@ func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosandboxDriverSpec.ProtoReflect.Descriptor instead.
 func (*MicrosandboxDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *MicrosandboxDriverSpec) GetProfile() string {
@@ -5176,7 +5950,7 @@ type RunAgentRequest struct {
 
 func (x *RunAgentRequest) Reset() {
 	*x = RunAgentRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5188,7 +5962,7 @@ func (x *RunAgentRequest) String() string {
 func (*RunAgentRequest) ProtoMessage() {}
 
 func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5201,7 +5975,7 @@ func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentRequest.ProtoReflect.Descriptor instead.
 func (*RunAgentRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *RunAgentRequest) GetProjectId() string {
@@ -5326,7 +6100,7 @@ type RunAgentResponse struct {
 
 func (x *RunAgentResponse) Reset() {
 	*x = RunAgentResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5338,7 +6112,7 @@ func (x *RunAgentResponse) String() string {
 func (*RunAgentResponse) ProtoMessage() {}
 
 func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5351,7 +6125,7 @@ func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *RunAgentResponse) GetRun() *RunDetail {
@@ -5384,7 +6158,7 @@ type RunAgentStreamResponse struct {
 
 func (x *RunAgentStreamResponse) Reset() {
 	*x = RunAgentStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5396,7 +6170,7 @@ func (x *RunAgentStreamResponse) String() string {
 func (*RunAgentStreamResponse) ProtoMessage() {}
 
 func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5409,7 +6183,7 @@ func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentStreamResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *RunAgentStreamResponse) GetEventType() RunAgentStreamEventType {
@@ -5487,7 +6261,7 @@ type RunAttachRequest struct {
 
 func (x *RunAttachRequest) Reset() {
 	*x = RunAttachRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5499,7 +6273,7 @@ func (x *RunAttachRequest) String() string {
 func (*RunAttachRequest) ProtoMessage() {}
 
 func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5512,7 +6286,7 @@ func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachRequest.ProtoReflect.Descriptor instead.
 func (*RunAttachRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *RunAttachRequest) GetClientFrameId() string {
@@ -5657,7 +6431,7 @@ type RunAttachResponse struct {
 
 func (x *RunAttachResponse) Reset() {
 	*x = RunAttachResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5669,7 +6443,7 @@ func (x *RunAttachResponse) String() string {
 func (*RunAttachResponse) ProtoMessage() {}
 
 func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5682,7 +6456,7 @@ func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachResponse.ProtoReflect.Descriptor instead.
 func (*RunAttachResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *RunAttachResponse) GetServerFrameId() string {
@@ -5813,7 +6587,7 @@ type RunAttachStart struct {
 
 func (x *RunAttachStart) Reset() {
 	*x = RunAttachStart{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5825,7 +6599,7 @@ func (x *RunAttachStart) String() string {
 func (*RunAttachStart) ProtoMessage() {}
 
 func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5838,7 +6612,7 @@ func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachStart.ProtoReflect.Descriptor instead.
 func (*RunAttachStart) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *RunAttachStart) GetRequest() *RunAgentRequest {
@@ -5889,7 +6663,7 @@ type TranscriptEvent struct {
 
 func (x *TranscriptEvent) Reset() {
 	*x = TranscriptEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5901,7 +6675,7 @@ func (x *TranscriptEvent) String() string {
 func (*TranscriptEvent) ProtoMessage() {}
 
 func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5914,7 +6688,7 @@ func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TranscriptEvent.ProtoReflect.Descriptor instead.
 func (*TranscriptEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *TranscriptEvent) GetStream() StdioStream {
@@ -5962,7 +6736,7 @@ type GetRunRequest struct {
 
 func (x *GetRunRequest) Reset() {
 	*x = GetRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5974,7 +6748,7 @@ func (x *GetRunRequest) String() string {
 func (*GetRunRequest) ProtoMessage() {}
 
 func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5987,7 +6761,7 @@ func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunRequest.ProtoReflect.Descriptor instead.
 func (*GetRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *GetRunRequest) GetRunId() string {
@@ -6013,7 +6787,7 @@ type GetRunResponse struct {
 
 func (x *GetRunResponse) Reset() {
 	*x = GetRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6025,7 +6799,7 @@ func (x *GetRunResponse) String() string {
 func (*GetRunResponse) ProtoMessage() {}
 
 func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6038,7 +6812,7 @@ func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunResponse.ProtoReflect.Descriptor instead.
 func (*GetRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *GetRunResponse) GetRun() *RunDetail {
@@ -6066,7 +6840,7 @@ type ListRunsRequest struct {
 
 func (x *ListRunsRequest) Reset() {
 	*x = ListRunsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6078,7 +6852,7 @@ func (x *ListRunsRequest) String() string {
 func (*ListRunsRequest) ProtoMessage() {}
 
 func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6091,7 +6865,7 @@ func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListRunsRequest) GetProjectId() string {
@@ -6173,7 +6947,7 @@ type ListRunsResponse struct {
 
 func (x *ListRunsResponse) Reset() {
 	*x = ListRunsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6185,7 +6959,7 @@ func (x *ListRunsResponse) String() string {
 func (*ListRunsResponse) ProtoMessage() {}
 
 func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6198,7 +6972,7 @@ func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ListRunsResponse) GetRuns() []*RunSummary {
@@ -6221,7 +6995,7 @@ type FollowRunLogsRequest struct {
 
 func (x *FollowRunLogsRequest) Reset() {
 	*x = FollowRunLogsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6233,7 +7007,7 @@ func (x *FollowRunLogsRequest) String() string {
 func (*FollowRunLogsRequest) ProtoMessage() {}
 
 func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6246,7 +7020,7 @@ func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FollowRunLogsRequest.ProtoReflect.Descriptor instead.
 func (*FollowRunLogsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *FollowRunLogsRequest) GetProjectId() string {
@@ -6297,7 +7071,7 @@ type RunLogChunk struct {
 
 func (x *RunLogChunk) Reset() {
 	*x = RunLogChunk{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6309,7 +7083,7 @@ func (x *RunLogChunk) String() string {
 func (*RunLogChunk) ProtoMessage() {}
 
 func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6322,7 +7096,7 @@ func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunLogChunk.ProtoReflect.Descriptor instead.
 func (*RunLogChunk) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *RunLogChunk) GetData() string {
@@ -6370,7 +7144,7 @@ type StopRunRequest struct {
 
 func (x *StopRunRequest) Reset() {
 	*x = StopRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6382,7 +7156,7 @@ func (x *StopRunRequest) String() string {
 func (*StopRunRequest) ProtoMessage() {}
 
 func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6395,7 +7169,7 @@ func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunRequest.ProtoReflect.Descriptor instead.
 func (*StopRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *StopRunRequest) GetRunId() string {
@@ -6422,7 +7196,7 @@ type StopRunResponse struct {
 
 func (x *StopRunResponse) Reset() {
 	*x = StopRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6434,7 +7208,7 @@ func (x *StopRunResponse) String() string {
 func (*StopRunResponse) ProtoMessage() {}
 
 func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6447,7 +7221,7 @@ func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunResponse.ProtoReflect.Descriptor instead.
 func (*StopRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *StopRunResponse) GetRun() *RunDetail {
@@ -6475,7 +7249,7 @@ type ListRunEventsRequest struct {
 
 func (x *ListRunEventsRequest) Reset() {
 	*x = ListRunEventsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6487,7 +7261,7 @@ func (x *ListRunEventsRequest) String() string {
 func (*ListRunEventsRequest) ProtoMessage() {}
 
 func (x *ListRunEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6500,7 +7274,7 @@ func (x *ListRunEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunEventsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunEventsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ListRunEventsRequest) GetRunId() string {
@@ -6544,7 +7318,7 @@ type RunEvent struct {
 
 func (x *RunEvent) Reset() {
 	*x = RunEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6556,7 +7330,7 @@ func (x *RunEvent) String() string {
 func (*RunEvent) ProtoMessage() {}
 
 func (x *RunEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6569,7 +7343,7 @@ func (x *RunEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunEvent.ProtoReflect.Descriptor instead.
 func (*RunEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *RunEvent) GetId() string {
@@ -6667,7 +7441,7 @@ type ListRunEventsResponse struct {
 
 func (x *ListRunEventsResponse) Reset() {
 	*x = ListRunEventsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6679,7 +7453,7 @@ func (x *ListRunEventsResponse) String() string {
 func (*ListRunEventsResponse) ProtoMessage() {}
 
 func (x *ListRunEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6692,7 +7466,7 @@ func (x *ListRunEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunEventsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunEventsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ListRunEventsResponse) GetEvents() []*RunEvent {
@@ -6727,7 +7501,7 @@ type ListSandboxRunEventsRequest struct {
 
 func (x *ListSandboxRunEventsRequest) Reset() {
 	*x = ListSandboxRunEventsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6739,7 +7513,7 @@ func (x *ListSandboxRunEventsRequest) String() string {
 func (*ListSandboxRunEventsRequest) ProtoMessage() {}
 
 func (x *ListSandboxRunEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6752,7 +7526,7 @@ func (x *ListSandboxRunEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxRunEventsRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxRunEventsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ListSandboxRunEventsRequest) GetSandboxId() string {
@@ -6787,7 +7561,7 @@ type ListSandboxRunEventsResponse struct {
 
 func (x *ListSandboxRunEventsResponse) Reset() {
 	*x = ListSandboxRunEventsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6799,7 +7573,7 @@ func (x *ListSandboxRunEventsResponse) String() string {
 func (*ListSandboxRunEventsResponse) ProtoMessage() {}
 
 func (x *ListSandboxRunEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6812,7 +7586,7 @@ func (x *ListSandboxRunEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxRunEventsResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxRunEventsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *ListSandboxRunEventsResponse) GetEvents() []*RunEvent {
@@ -6846,7 +7620,7 @@ type RemoveSandboxRequest struct {
 
 func (x *RemoveSandboxRequest) Reset() {
 	*x = RemoveSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6858,7 +7632,7 @@ func (x *RemoveSandboxRequest) String() string {
 func (*RemoveSandboxRequest) ProtoMessage() {}
 
 func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6871,7 +7645,7 @@ func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *RemoveSandboxRequest) GetSandboxId() string {
@@ -6899,7 +7673,7 @@ type RemoveSandboxResponse struct {
 
 func (x *RemoveSandboxResponse) Reset() {
 	*x = RemoveSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6911,7 +7685,7 @@ func (x *RemoveSandboxResponse) String() string {
 func (*RemoveSandboxResponse) ProtoMessage() {}
 
 func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6924,7 +7698,7 @@ func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *RemoveSandboxResponse) GetSandboxId() string {
@@ -6963,7 +7737,7 @@ type PruneSandboxesRequest struct {
 
 func (x *PruneSandboxesRequest) Reset() {
 	*x = PruneSandboxesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6975,7 +7749,7 @@ func (x *PruneSandboxesRequest) String() string {
 func (*PruneSandboxesRequest) ProtoMessage() {}
 
 func (x *PruneSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6988,7 +7762,7 @@ func (x *PruneSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*PruneSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *PruneSandboxesRequest) GetProjectId() string {
@@ -7058,7 +7832,7 @@ type SandboxPruneCandidate struct {
 
 func (x *SandboxPruneCandidate) Reset() {
 	*x = SandboxPruneCandidate{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7070,7 +7844,7 @@ func (x *SandboxPruneCandidate) String() string {
 func (*SandboxPruneCandidate) ProtoMessage() {}
 
 func (x *SandboxPruneCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7083,7 +7857,7 @@ func (x *SandboxPruneCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPruneCandidate.ProtoReflect.Descriptor instead.
 func (*SandboxPruneCandidate) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *SandboxPruneCandidate) GetKind() SandboxPruneCandidateKind {
@@ -7169,7 +7943,7 @@ type PruneSandboxesResponse struct {
 
 func (x *PruneSandboxesResponse) Reset() {
 	*x = PruneSandboxesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7181,7 +7955,7 @@ func (x *PruneSandboxesResponse) String() string {
 func (*PruneSandboxesResponse) ProtoMessage() {}
 
 func (x *PruneSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7194,7 +7968,7 @@ func (x *PruneSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*PruneSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *PruneSandboxesResponse) GetDryRun() bool {
@@ -7241,7 +8015,7 @@ type GetSandboxStatsRequest struct {
 
 func (x *GetSandboxStatsRequest) Reset() {
 	*x = GetSandboxStatsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7253,7 +8027,7 @@ func (x *GetSandboxStatsRequest) String() string {
 func (*GetSandboxStatsRequest) ProtoMessage() {}
 
 func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7266,7 +8040,7 @@ func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *GetSandboxStatsRequest) GetSandboxId() string {
@@ -7285,7 +8059,7 @@ type GetSandboxStatsResponse struct {
 
 func (x *GetSandboxStatsResponse) Reset() {
 	*x = GetSandboxStatsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7297,7 +8071,7 @@ func (x *GetSandboxStatsResponse) String() string {
 func (*GetSandboxStatsResponse) ProtoMessage() {}
 
 func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7310,7 +8084,7 @@ func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *GetSandboxStatsResponse) GetStats() *SandboxStats {
@@ -7329,7 +8103,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7341,7 +8115,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7354,7 +8128,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -7388,7 +8162,7 @@ type Sandbox struct {
 
 func (x *Sandbox) Reset() {
 	*x = Sandbox{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7400,7 +8174,7 @@ func (x *Sandbox) String() string {
 func (*Sandbox) ProtoMessage() {}
 
 func (x *Sandbox) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7413,7 +8187,7 @@ func (x *Sandbox) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sandbox.ProtoReflect.Descriptor instead.
 func (*Sandbox) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *Sandbox) GetSandboxId() string {
@@ -7538,7 +8312,7 @@ type SandboxTag struct {
 
 func (x *SandboxTag) Reset() {
 	*x = SandboxTag{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7550,7 +8324,7 @@ func (x *SandboxTag) String() string {
 func (*SandboxTag) ProtoMessage() {}
 
 func (x *SandboxTag) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7563,7 +8337,7 @@ func (x *SandboxTag) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxTag.ProtoReflect.Descriptor instead.
 func (*SandboxTag) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *SandboxTag) GetName() string {
@@ -7590,7 +8364,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7602,7 +8376,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7615,7 +8389,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *ListSandboxesRequest) GetLimit() uint32 {
@@ -7642,7 +8416,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7654,7 +8428,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7667,7 +8441,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -7693,7 +8467,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7705,7 +8479,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7718,7 +8492,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -7737,7 +8511,7 @@ type StopSandboxRequest struct {
 
 func (x *StopSandboxRequest) Reset() {
 	*x = StopSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7749,7 +8523,7 @@ func (x *StopSandboxRequest) String() string {
 func (*StopSandboxRequest) ProtoMessage() {}
 
 func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7762,7 +8536,7 @@ func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSandboxRequest.ProtoReflect.Descriptor instead.
 func (*StopSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *StopSandboxRequest) GetSandboxId() string {
@@ -7781,7 +8555,7 @@ type StopSandboxResponse struct {
 
 func (x *StopSandboxResponse) Reset() {
 	*x = StopSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7793,7 +8567,7 @@ func (x *StopSandboxResponse) String() string {
 func (*StopSandboxResponse) ProtoMessage() {}
 
 func (x *StopSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7806,7 +8580,7 @@ func (x *StopSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSandboxResponse.ProtoReflect.Descriptor instead.
 func (*StopSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *StopSandboxResponse) GetSandbox() *Sandbox {
@@ -7825,7 +8599,7 @@ type ResumeSandboxRequest struct {
 
 func (x *ResumeSandboxRequest) Reset() {
 	*x = ResumeSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7837,7 +8611,7 @@ func (x *ResumeSandboxRequest) String() string {
 func (*ResumeSandboxRequest) ProtoMessage() {}
 
 func (x *ResumeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7850,7 +8624,7 @@ func (x *ResumeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*ResumeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ResumeSandboxRequest) GetSandboxId() string {
@@ -7869,7 +8643,7 @@ type ResumeSandboxResponse struct {
 
 func (x *ResumeSandboxResponse) Reset() {
 	*x = ResumeSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7881,7 +8655,7 @@ func (x *ResumeSandboxResponse) String() string {
 func (*ResumeSandboxResponse) ProtoMessage() {}
 
 func (x *ResumeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7894,7 +8668,7 @@ func (x *ResumeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*ResumeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ResumeSandboxResponse) GetSandbox() *Sandbox {
@@ -7916,7 +8690,7 @@ type MetricValue struct {
 
 func (x *MetricValue) Reset() {
 	*x = MetricValue{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7928,7 +8702,7 @@ func (x *MetricValue) String() string {
 func (*MetricValue) ProtoMessage() {}
 
 func (x *MetricValue) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7941,7 +8715,7 @@ func (x *MetricValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetricValue.ProtoReflect.Descriptor instead.
 func (*MetricValue) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *MetricValue) GetValue() float64 {
@@ -7992,7 +8766,7 @@ type SandboxStats struct {
 
 func (x *SandboxStats) Reset() {
 	*x = SandboxStats{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8004,7 +8778,7 @@ func (x *SandboxStats) String() string {
 func (*SandboxStats) ProtoMessage() {}
 
 func (x *SandboxStats) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8017,7 +8791,7 @@ func (x *SandboxStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStats.ProtoReflect.Descriptor instead.
 func (*SandboxStats) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *SandboxStats) GetSandboxId() string {
@@ -8133,7 +8907,7 @@ type RunSummary struct {
 
 func (x *RunSummary) Reset() {
 	*x = RunSummary{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8145,7 +8919,7 @@ func (x *RunSummary) String() string {
 func (*RunSummary) ProtoMessage() {}
 
 func (x *RunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8158,7 +8932,7 @@ func (x *RunSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSummary.ProtoReflect.Descriptor instead.
 func (*RunSummary) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *RunSummary) GetRunId() string {
@@ -8326,7 +9100,7 @@ type RunDetail struct {
 
 func (x *RunDetail) Reset() {
 	*x = RunDetail{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8338,7 +9112,7 @@ func (x *RunDetail) String() string {
 func (*RunDetail) ProtoMessage() {}
 
 func (x *RunDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8351,7 +9125,7 @@ func (x *RunDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunDetail.ProtoReflect.Descriptor instead.
 func (*RunDetail) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *RunDetail) GetSummary() *RunSummary {
@@ -8443,7 +9217,7 @@ type ExecRequest struct {
 
 func (x *ExecRequest) Reset() {
 	*x = ExecRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8455,7 +9229,7 @@ func (x *ExecRequest) String() string {
 func (*ExecRequest) ProtoMessage() {}
 
 func (x *ExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8468,7 +9242,7 @@ func (x *ExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecRequest.ProtoReflect.Descriptor instead.
 func (*ExecRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *ExecRequest) GetTarget() isExecRequest_Target {
@@ -8573,7 +9347,7 @@ type ExecSandboxSelector struct {
 
 func (x *ExecSandboxSelector) Reset() {
 	*x = ExecSandboxSelector{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8585,7 +9359,7 @@ func (x *ExecSandboxSelector) String() string {
 func (*ExecSandboxSelector) ProtoMessage() {}
 
 func (x *ExecSandboxSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8598,7 +9372,7 @@ func (x *ExecSandboxSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxSelector.ProtoReflect.Descriptor instead.
 func (*ExecSandboxSelector) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *ExecSandboxSelector) GetProjectId() string {
@@ -8632,7 +9406,7 @@ type ExecCommand struct {
 
 func (x *ExecCommand) Reset() {
 	*x = ExecCommand{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8644,7 +9418,7 @@ func (x *ExecCommand) String() string {
 func (*ExecCommand) ProtoMessage() {}
 
 func (x *ExecCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8657,7 +9431,7 @@ func (x *ExecCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecCommand.ProtoReflect.Descriptor instead.
 func (*ExecCommand) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *ExecCommand) GetCommand() string {
@@ -8683,7 +9457,7 @@ type ExecResponse struct {
 
 func (x *ExecResponse) Reset() {
 	*x = ExecResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8695,7 +9469,7 @@ func (x *ExecResponse) String() string {
 func (*ExecResponse) ProtoMessage() {}
 
 func (x *ExecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8708,7 +9482,7 @@ func (x *ExecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResponse.ProtoReflect.Descriptor instead.
 func (*ExecResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ExecResponse) GetResult() *ExecResult {
@@ -8734,7 +9508,7 @@ type ExecStreamResponse struct {
 
 func (x *ExecStreamResponse) Reset() {
 	*x = ExecStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8746,7 +9520,7 @@ func (x *ExecStreamResponse) String() string {
 func (*ExecStreamResponse) ProtoMessage() {}
 
 func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8759,7 +9533,7 @@ func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecStreamResponse.ProtoReflect.Descriptor instead.
 func (*ExecStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ExecStreamResponse) GetEventType() ExecStreamEventType {
@@ -8837,7 +9611,7 @@ type ExecAttachRequest struct {
 
 func (x *ExecAttachRequest) Reset() {
 	*x = ExecAttachRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8849,7 +9623,7 @@ func (x *ExecAttachRequest) String() string {
 func (*ExecAttachRequest) ProtoMessage() {}
 
 func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8862,7 +9636,7 @@ func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachRequest.ProtoReflect.Descriptor instead.
 func (*ExecAttachRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *ExecAttachRequest) GetClientFrameId() string {
@@ -9007,7 +9781,7 @@ type ExecAttachResponse struct {
 
 func (x *ExecAttachResponse) Reset() {
 	*x = ExecAttachResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9019,7 +9793,7 @@ func (x *ExecAttachResponse) String() string {
 func (*ExecAttachResponse) ProtoMessage() {}
 
 func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9032,7 +9806,7 @@ func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachResponse.ProtoReflect.Descriptor instead.
 func (*ExecAttachResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *ExecAttachResponse) GetServerFrameId() string {
@@ -9164,7 +9938,7 @@ type ExecAttachStart struct {
 
 func (x *ExecAttachStart) Reset() {
 	*x = ExecAttachStart{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9176,7 +9950,7 @@ func (x *ExecAttachStart) String() string {
 func (*ExecAttachStart) ProtoMessage() {}
 
 func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9189,7 +9963,7 @@ func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachStart.ProtoReflect.Descriptor instead.
 func (*ExecAttachStart) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *ExecAttachStart) GetRequest() *ExecRequest {
@@ -9244,7 +10018,7 @@ type AttachTerminalSize struct {
 
 func (x *AttachTerminalSize) Reset() {
 	*x = AttachTerminalSize{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9256,7 +10030,7 @@ func (x *AttachTerminalSize) String() string {
 func (*AttachTerminalSize) ProtoMessage() {}
 
 func (x *AttachTerminalSize) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9269,7 +10043,7 @@ func (x *AttachTerminalSize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachTerminalSize.ProtoReflect.Descriptor instead.
 func (*AttachTerminalSize) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *AttachTerminalSize) GetRows() uint32 {
@@ -9295,7 +10069,7 @@ type AttachStdin struct {
 
 func (x *AttachStdin) Reset() {
 	*x = AttachStdin{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9307,7 +10081,7 @@ func (x *AttachStdin) String() string {
 func (*AttachStdin) ProtoMessage() {}
 
 func (x *AttachStdin) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9320,7 +10094,7 @@ func (x *AttachStdin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStdin.ProtoReflect.Descriptor instead.
 func (*AttachStdin) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{104}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *AttachStdin) GetData() []byte {
@@ -9338,7 +10112,7 @@ type AttachStdinEOF struct {
 
 func (x *AttachStdinEOF) Reset() {
 	*x = AttachStdinEOF{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9350,7 +10124,7 @@ func (x *AttachStdinEOF) String() string {
 func (*AttachStdinEOF) ProtoMessage() {}
 
 func (x *AttachStdinEOF) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9363,7 +10137,7 @@ func (x *AttachStdinEOF) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStdinEOF.ProtoReflect.Descriptor instead.
 func (*AttachStdinEOF) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{105}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{116}
 }
 
 type AttachResize struct {
@@ -9375,7 +10149,7 @@ type AttachResize struct {
 
 func (x *AttachResize) Reset() {
 	*x = AttachResize{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9387,7 +10161,7 @@ func (x *AttachResize) String() string {
 func (*AttachResize) ProtoMessage() {}
 
 func (x *AttachResize) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9400,7 +10174,7 @@ func (x *AttachResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachResize.ProtoReflect.Descriptor instead.
 func (*AttachResize) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{106}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *AttachResize) GetTerminalSize() *AttachTerminalSize {
@@ -9419,7 +10193,7 @@ type AttachSignal struct {
 
 func (x *AttachSignal) Reset() {
 	*x = AttachSignal{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9431,7 +10205,7 @@ func (x *AttachSignal) String() string {
 func (*AttachSignal) ProtoMessage() {}
 
 func (x *AttachSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9444,7 +10218,7 @@ func (x *AttachSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachSignal.ProtoReflect.Descriptor instead.
 func (*AttachSignal) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{107}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *AttachSignal) GetSignal() string {
@@ -9464,7 +10238,7 @@ type AttachHumanMessage struct {
 
 func (x *AttachHumanMessage) Reset() {
 	*x = AttachHumanMessage{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9476,7 +10250,7 @@ func (x *AttachHumanMessage) String() string {
 func (*AttachHumanMessage) ProtoMessage() {}
 
 func (x *AttachHumanMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9489,7 +10263,7 @@ func (x *AttachHumanMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachHumanMessage.ProtoReflect.Descriptor instead.
 func (*AttachHumanMessage) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{108}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *AttachHumanMessage) GetText() string {
@@ -9515,7 +10289,7 @@ type AttachCancel struct {
 
 func (x *AttachCancel) Reset() {
 	*x = AttachCancel{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9527,7 +10301,7 @@ func (x *AttachCancel) String() string {
 func (*AttachCancel) ProtoMessage() {}
 
 func (x *AttachCancel) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9540,7 +10314,7 @@ func (x *AttachCancel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachCancel.ProtoReflect.Descriptor instead.
 func (*AttachCancel) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{109}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *AttachCancel) GetReason() string {
@@ -9564,7 +10338,7 @@ type AttachStarted struct {
 
 func (x *AttachStarted) Reset() {
 	*x = AttachStarted{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9576,7 +10350,7 @@ func (x *AttachStarted) String() string {
 func (*AttachStarted) ProtoMessage() {}
 
 func (x *AttachStarted) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9589,7 +10363,7 @@ func (x *AttachStarted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStarted.ProtoReflect.Descriptor instead.
 func (*AttachStarted) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{110}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *AttachStarted) GetOperationId() string {
@@ -9646,7 +10420,7 @@ type AttachOutput struct {
 
 func (x *AttachOutput) Reset() {
 	*x = AttachOutput{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9658,7 +10432,7 @@ func (x *AttachOutput) String() string {
 func (*AttachOutput) ProtoMessage() {}
 
 func (x *AttachOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9671,7 +10445,7 @@ func (x *AttachOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachOutput.ProtoReflect.Descriptor instead.
 func (*AttachOutput) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{111}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *AttachOutput) GetData() []byte {
@@ -9714,7 +10488,7 @@ type AttachAgentEvent struct {
 
 func (x *AttachAgentEvent) Reset() {
 	*x = AttachAgentEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9726,7 +10500,7 @@ func (x *AttachAgentEvent) String() string {
 func (*AttachAgentEvent) ProtoMessage() {}
 
 func (x *AttachAgentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9739,7 +10513,7 @@ func (x *AttachAgentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachAgentEvent.ProtoReflect.Descriptor instead.
 func (*AttachAgentEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{112}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *AttachAgentEvent) GetName() string {
@@ -9781,7 +10555,7 @@ type AttachAgentTurnCompleted struct {
 
 func (x *AttachAgentTurnCompleted) Reset() {
 	*x = AttachAgentTurnCompleted{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9793,7 +10567,7 @@ func (x *AttachAgentTurnCompleted) String() string {
 func (*AttachAgentTurnCompleted) ProtoMessage() {}
 
 func (x *AttachAgentTurnCompleted) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9806,7 +10580,7 @@ func (x *AttachAgentTurnCompleted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachAgentTurnCompleted.ProtoReflect.Descriptor instead.
 func (*AttachAgentTurnCompleted) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{113}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *AttachAgentTurnCompleted) GetRunId() string {
@@ -9845,7 +10619,7 @@ type AttachResult struct {
 
 func (x *AttachResult) Reset() {
 	*x = AttachResult{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9857,7 +10631,7 @@ func (x *AttachResult) String() string {
 func (*AttachResult) ProtoMessage() {}
 
 func (x *AttachResult) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9870,7 +10644,7 @@ func (x *AttachResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachResult.ProtoReflect.Descriptor instead.
 func (*AttachResult) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{114}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *AttachResult) GetExitCode() int32 {
@@ -9934,7 +10708,7 @@ type AttachError struct {
 
 func (x *AttachError) Reset() {
 	*x = AttachError{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9946,7 +10720,7 @@ func (x *AttachError) String() string {
 func (*AttachError) ProtoMessage() {}
 
 func (x *AttachError) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9959,7 +10733,7 @@ func (x *AttachError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachError.ProtoReflect.Descriptor instead.
 func (*AttachError) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{115}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *AttachError) GetCode() string {
@@ -10012,7 +10786,7 @@ type ExecResult struct {
 
 func (x *ExecResult) Reset() {
 	*x = ExecResult{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10024,7 +10798,7 @@ func (x *ExecResult) String() string {
 func (*ExecResult) ProtoMessage() {}
 
 func (x *ExecResult) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10037,7 +10811,7 @@ func (x *ExecResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResult.ProtoReflect.Descriptor instead.
 func (*ExecResult) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{116}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *ExecResult) GetExecId() string {
@@ -10152,7 +10926,7 @@ type ListImagesRequest struct {
 
 func (x *ListImagesRequest) Reset() {
 	*x = ListImagesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10164,7 +10938,7 @@ func (x *ListImagesRequest) String() string {
 func (*ListImagesRequest) ProtoMessage() {}
 
 func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10177,7 +10951,7 @@ func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesRequest.ProtoReflect.Descriptor instead.
 func (*ListImagesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{117}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *ListImagesRequest) GetStore() ImageStoreKind {
@@ -10235,7 +11009,7 @@ type ListImagesResponse struct {
 
 func (x *ListImagesResponse) Reset() {
 	*x = ListImagesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10247,7 +11021,7 @@ func (x *ListImagesResponse) String() string {
 func (*ListImagesResponse) ProtoMessage() {}
 
 func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10260,7 +11034,7 @@ func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesResponse.ProtoReflect.Descriptor instead.
 func (*ListImagesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{118}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *ListImagesResponse) GetImages() []*Image {
@@ -10309,7 +11083,7 @@ type PullImageRequest struct {
 
 func (x *PullImageRequest) Reset() {
 	*x = PullImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10321,7 +11095,7 @@ func (x *PullImageRequest) String() string {
 func (*PullImageRequest) ProtoMessage() {}
 
 func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10334,7 +11108,7 @@ func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageRequest.ProtoReflect.Descriptor instead.
 func (*PullImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{119}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *PullImageRequest) GetImageRef() string {
@@ -10371,7 +11145,7 @@ type PullImageResponse struct {
 
 func (x *PullImageResponse) Reset() {
 	*x = PullImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10383,7 +11157,7 @@ func (x *PullImageResponse) String() string {
 func (*PullImageResponse) ProtoMessage() {}
 
 func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10396,7 +11170,7 @@ func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageResponse.ProtoReflect.Descriptor instead.
 func (*PullImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{120}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *PullImageResponse) GetImage() *Image {
@@ -10445,7 +11219,7 @@ type InspectImageRequest struct {
 
 func (x *InspectImageRequest) Reset() {
 	*x = InspectImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10457,7 +11231,7 @@ func (x *InspectImageRequest) String() string {
 func (*InspectImageRequest) ProtoMessage() {}
 
 func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10470,7 +11244,7 @@ func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageRequest.ProtoReflect.Descriptor instead.
 func (*InspectImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{121}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *InspectImageRequest) GetImageRef() string {
@@ -10504,7 +11278,7 @@ type InspectImageResponse struct {
 
 func (x *InspectImageResponse) Reset() {
 	*x = InspectImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10516,7 +11290,7 @@ func (x *InspectImageResponse) String() string {
 func (*InspectImageResponse) ProtoMessage() {}
 
 func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10529,7 +11303,7 @@ func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageResponse.ProtoReflect.Descriptor instead.
 func (*InspectImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{122}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *InspectImageResponse) GetImage() *Image {
@@ -10558,7 +11332,7 @@ type RemoveImageRequest struct {
 
 func (x *RemoveImageRequest) Reset() {
 	*x = RemoveImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10570,7 +11344,7 @@ func (x *RemoveImageRequest) String() string {
 func (*RemoveImageRequest) ProtoMessage() {}
 
 func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10583,7 +11357,7 @@ func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageRequest.ProtoReflect.Descriptor instead.
 func (*RemoveImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{123}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *RemoveImageRequest) GetImageRef() string {
@@ -10626,7 +11400,7 @@ type RemoveImageResponse struct {
 
 func (x *RemoveImageResponse) Reset() {
 	*x = RemoveImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10638,7 +11412,7 @@ func (x *RemoveImageResponse) String() string {
 func (*RemoveImageResponse) ProtoMessage() {}
 
 func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10651,7 +11425,7 @@ func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageResponse.ProtoReflect.Descriptor instead.
 func (*RemoveImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{124}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *RemoveImageResponse) GetImageRef() string {
@@ -10699,7 +11473,7 @@ type BuildImageRequest struct {
 
 func (x *BuildImageRequest) Reset() {
 	*x = BuildImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10711,7 +11485,7 @@ func (x *BuildImageRequest) String() string {
 func (*BuildImageRequest) ProtoMessage() {}
 
 func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10724,7 +11498,7 @@ func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageRequest.ProtoReflect.Descriptor instead.
 func (*BuildImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{125}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *BuildImageRequest) GetContextDir() string {
@@ -10805,7 +11579,7 @@ type BuildImageEvent struct {
 
 func (x *BuildImageEvent) Reset() {
 	*x = BuildImageEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10817,7 +11591,7 @@ func (x *BuildImageEvent) String() string {
 func (*BuildImageEvent) ProtoMessage() {}
 
 func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10830,7 +11604,7 @@ func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageEvent.ProtoReflect.Descriptor instead.
 func (*BuildImageEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{126}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *BuildImageEvent) GetStatus() ImageOperationStatus {
@@ -10896,7 +11670,7 @@ type CacheFilter struct {
 
 func (x *CacheFilter) Reset() {
 	*x = CacheFilter{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10908,7 +11682,7 @@ func (x *CacheFilter) String() string {
 func (*CacheFilter) ProtoMessage() {}
 
 func (x *CacheFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10921,7 +11695,7 @@ func (x *CacheFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheFilter.ProtoReflect.Descriptor instead.
 func (*CacheFilter) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{127}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *CacheFilter) GetDriver() string {
@@ -10975,7 +11749,7 @@ type ListCachesRequest struct {
 
 func (x *ListCachesRequest) Reset() {
 	*x = ListCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10987,7 +11761,7 @@ func (x *ListCachesRequest) String() string {
 func (*ListCachesRequest) ProtoMessage() {}
 
 func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11000,7 +11774,7 @@ func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesRequest.ProtoReflect.Descriptor instead.
 func (*ListCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{128}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *ListCachesRequest) GetFilter() *CacheFilter {
@@ -11020,7 +11794,7 @@ type ListCachesResponse struct {
 
 func (x *ListCachesResponse) Reset() {
 	*x = ListCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11032,7 +11806,7 @@ func (x *ListCachesResponse) String() string {
 func (*ListCachesResponse) ProtoMessage() {}
 
 func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11045,7 +11819,7 @@ func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesResponse.ProtoReflect.Descriptor instead.
 func (*ListCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{129}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *ListCachesResponse) GetCaches() []*CacheItem {
@@ -11071,7 +11845,7 @@ type InspectCacheRequest struct {
 
 func (x *InspectCacheRequest) Reset() {
 	*x = InspectCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11083,7 +11857,7 @@ func (x *InspectCacheRequest) String() string {
 func (*InspectCacheRequest) ProtoMessage() {}
 
 func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11096,7 +11870,7 @@ func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheRequest.ProtoReflect.Descriptor instead.
 func (*InspectCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{130}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *InspectCacheRequest) GetCacheId() string {
@@ -11116,7 +11890,7 @@ type InspectCacheResponse struct {
 
 func (x *InspectCacheResponse) Reset() {
 	*x = InspectCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11128,7 +11902,7 @@ func (x *InspectCacheResponse) String() string {
 func (*InspectCacheResponse) ProtoMessage() {}
 
 func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11141,7 +11915,7 @@ func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheResponse.ProtoReflect.Descriptor instead.
 func (*InspectCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{131}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *InspectCacheResponse) GetCache() *CacheItem {
@@ -11168,7 +11942,7 @@ type PruneCachesRequest struct {
 
 func (x *PruneCachesRequest) Reset() {
 	*x = PruneCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11180,7 +11954,7 @@ func (x *PruneCachesRequest) String() string {
 func (*PruneCachesRequest) ProtoMessage() {}
 
 func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11193,7 +11967,7 @@ func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesRequest.ProtoReflect.Descriptor instead.
 func (*PruneCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{132}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *PruneCachesRequest) GetFilter() *CacheFilter {
@@ -11223,7 +11997,7 @@ type PruneCachesResponse struct {
 
 func (x *PruneCachesResponse) Reset() {
 	*x = PruneCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11235,7 +12009,7 @@ func (x *PruneCachesResponse) String() string {
 func (*PruneCachesResponse) ProtoMessage() {}
 
 func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11248,7 +12022,7 @@ func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesResponse.ProtoReflect.Descriptor instead.
 func (*PruneCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{133}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *PruneCachesResponse) GetDryRun() bool {
@@ -11296,7 +12070,7 @@ type RemoveCacheRequest struct {
 
 func (x *RemoveCacheRequest) Reset() {
 	*x = RemoveCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11308,7 +12082,7 @@ func (x *RemoveCacheRequest) String() string {
 func (*RemoveCacheRequest) ProtoMessage() {}
 
 func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11321,7 +12095,7 @@ func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{134}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *RemoveCacheRequest) GetCacheId() string {
@@ -11351,7 +12125,7 @@ type RemoveCacheResponse struct {
 
 func (x *RemoveCacheResponse) Reset() {
 	*x = RemoveCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11363,7 +12137,7 @@ func (x *RemoveCacheResponse) String() string {
 func (*RemoveCacheResponse) ProtoMessage() {}
 
 func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11376,7 +12150,7 @@ func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheResponse.ProtoReflect.Descriptor instead.
 func (*RemoveCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{135}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *RemoveCacheResponse) GetDryRun() bool {
@@ -11438,7 +12212,7 @@ type CacheItem struct {
 
 func (x *CacheItem) Reset() {
 	*x = CacheItem{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11450,7 +12224,7 @@ func (x *CacheItem) String() string {
 func (*CacheItem) ProtoMessage() {}
 
 func (x *CacheItem) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11463,7 +12237,7 @@ func (x *CacheItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheItem.ProtoReflect.Descriptor instead.
 func (*CacheItem) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{136}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *CacheItem) GetCacheId() string {
@@ -11593,7 +12367,7 @@ type CacheReference struct {
 
 func (x *CacheReference) Reset() {
 	*x = CacheReference{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11605,7 +12379,7 @@ func (x *CacheReference) String() string {
 func (*CacheReference) ProtoMessage() {}
 
 func (x *CacheReference) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11618,7 +12392,7 @@ func (x *CacheReference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheReference.ProtoReflect.Descriptor instead.
 func (*CacheReference) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{137}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *CacheReference) GetType() string {
@@ -11681,7 +12455,7 @@ type ListVolumesRequest struct {
 
 func (x *ListVolumesRequest) Reset() {
 	*x = ListVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11693,7 +12467,7 @@ func (x *ListVolumesRequest) String() string {
 func (*ListVolumesRequest) ProtoMessage() {}
 
 func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11706,7 +12480,7 @@ func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesRequest.ProtoReflect.Descriptor instead.
 func (*ListVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{138}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *ListVolumesRequest) GetQuery() string {
@@ -11739,7 +12513,7 @@ type ListVolumesResponse struct {
 
 func (x *ListVolumesResponse) Reset() {
 	*x = ListVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11751,7 +12525,7 @@ func (x *ListVolumesResponse) String() string {
 func (*ListVolumesResponse) ProtoMessage() {}
 
 func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11764,7 +12538,7 @@ func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesResponse.ProtoReflect.Descriptor instead.
 func (*ListVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{139}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *ListVolumesResponse) GetVolumes() []*Volume {
@@ -11786,7 +12560,7 @@ type CreateVolumeRequest struct {
 
 func (x *CreateVolumeRequest) Reset() {
 	*x = CreateVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11798,7 +12572,7 @@ func (x *CreateVolumeRequest) String() string {
 func (*CreateVolumeRequest) ProtoMessage() {}
 
 func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11811,7 +12585,7 @@ func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeRequest.ProtoReflect.Descriptor instead.
 func (*CreateVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{140}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *CreateVolumeRequest) GetName() string {
@@ -11852,7 +12626,7 @@ type CreateVolumeResponse struct {
 
 func (x *CreateVolumeResponse) Reset() {
 	*x = CreateVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11864,7 +12638,7 @@ func (x *CreateVolumeResponse) String() string {
 func (*CreateVolumeResponse) ProtoMessage() {}
 
 func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11877,7 +12651,7 @@ func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeResponse.ProtoReflect.Descriptor instead.
 func (*CreateVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{141}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *CreateVolumeResponse) GetVolume() *Volume {
@@ -11903,7 +12677,7 @@ type InspectVolumeRequest struct {
 
 func (x *InspectVolumeRequest) Reset() {
 	*x = InspectVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11915,7 +12689,7 @@ func (x *InspectVolumeRequest) String() string {
 func (*InspectVolumeRequest) ProtoMessage() {}
 
 func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11928,7 +12702,7 @@ func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeRequest.ProtoReflect.Descriptor instead.
 func (*InspectVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{142}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *InspectVolumeRequest) GetName() string {
@@ -11947,7 +12721,7 @@ type InspectVolumeResponse struct {
 
 func (x *InspectVolumeResponse) Reset() {
 	*x = InspectVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11959,7 +12733,7 @@ func (x *InspectVolumeResponse) String() string {
 func (*InspectVolumeResponse) ProtoMessage() {}
 
 func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11972,7 +12746,7 @@ func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeResponse.ProtoReflect.Descriptor instead.
 func (*InspectVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{143}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *InspectVolumeResponse) GetVolume() *Volume {
@@ -11992,7 +12766,7 @@ type RemoveVolumeRequest struct {
 
 func (x *RemoveVolumeRequest) Reset() {
 	*x = RemoveVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12004,7 +12778,7 @@ func (x *RemoveVolumeRequest) String() string {
 func (*RemoveVolumeRequest) ProtoMessage() {}
 
 func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12017,7 +12791,7 @@ func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{144}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *RemoveVolumeRequest) GetName() string {
@@ -12044,7 +12818,7 @@ type RemoveVolumeResponse struct {
 
 func (x *RemoveVolumeResponse) Reset() {
 	*x = RemoveVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12056,7 +12830,7 @@ func (x *RemoveVolumeResponse) String() string {
 func (*RemoveVolumeResponse) ProtoMessage() {}
 
 func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12069,7 +12843,7 @@ func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeResponse.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{145}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *RemoveVolumeResponse) GetName() string {
@@ -12098,7 +12872,7 @@ type PruneVolumesRequest struct {
 
 func (x *PruneVolumesRequest) Reset() {
 	*x = PruneVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12110,7 +12884,7 @@ func (x *PruneVolumesRequest) String() string {
 func (*PruneVolumesRequest) ProtoMessage() {}
 
 func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12123,7 +12897,7 @@ func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesRequest.ProtoReflect.Descriptor instead.
 func (*PruneVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{146}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *PruneVolumesRequest) GetQuery() string {
@@ -12166,7 +12940,7 @@ type PruneVolumesResponse struct {
 
 func (x *PruneVolumesResponse) Reset() {
 	*x = PruneVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12178,7 +12952,7 @@ func (x *PruneVolumesResponse) String() string {
 func (*PruneVolumesResponse) ProtoMessage() {}
 
 func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12191,7 +12965,7 @@ func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesResponse.ProtoReflect.Descriptor instead.
 func (*PruneVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{147}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *PruneVolumesResponse) GetDryRun() bool {
@@ -12238,7 +13012,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12250,7 +13024,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12263,7 +13037,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{148}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *Volume) GetName() string {
@@ -12347,7 +13121,7 @@ type Image struct {
 
 func (x *Image) Reset() {
 	*x = Image{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12359,7 +13133,7 @@ func (x *Image) String() string {
 func (*Image) ProtoMessage() {}
 
 func (x *Image) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12372,7 +13146,7 @@ func (x *Image) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Image.ProtoReflect.Descriptor instead.
 func (*Image) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{149}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *Image) GetImageId() string {
@@ -12506,7 +13280,7 @@ type ImagePlatform struct {
 
 func (x *ImagePlatform) Reset() {
 	*x = ImagePlatform{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12518,7 +13292,7 @@ func (x *ImagePlatform) String() string {
 func (*ImagePlatform) ProtoMessage() {}
 
 func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12531,7 +13305,7 @@ func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePlatform.ProtoReflect.Descriptor instead.
 func (*ImagePlatform) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{150}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *ImagePlatform) GetOs() string {
@@ -12574,7 +13348,7 @@ type ImageStoreStatus struct {
 
 func (x *ImageStoreStatus) Reset() {
 	*x = ImageStoreStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12586,7 +13360,7 @@ func (x *ImageStoreStatus) String() string {
 func (*ImageStoreStatus) ProtoMessage() {}
 
 func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12599,7 +13373,7 @@ func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageStoreStatus.ProtoReflect.Descriptor instead.
 func (*ImageStoreStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{151}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *ImageStoreStatus) GetStore() ImageStoreKind {
@@ -12641,7 +13415,7 @@ type DockerImageStatus struct {
 
 func (x *DockerImageStatus) Reset() {
 	*x = DockerImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12653,7 +13427,7 @@ func (x *DockerImageStatus) String() string {
 func (*DockerImageStatus) ProtoMessage() {}
 
 func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12666,7 +13440,7 @@ func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerImageStatus.ProtoReflect.Descriptor instead.
 func (*DockerImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{152}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *DockerImageStatus) GetLocal() bool {
@@ -12704,7 +13478,7 @@ type OCIImageStatus struct {
 
 func (x *OCIImageStatus) Reset() {
 	*x = OCIImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12716,7 +13490,7 @@ func (x *OCIImageStatus) String() string {
 func (*OCIImageStatus) ProtoMessage() {}
 
 func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12729,7 +13503,7 @@ func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OCIImageStatus.ProtoReflect.Descriptor instead.
 func (*OCIImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{153}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *OCIImageStatus) GetLayoutCached() bool {
@@ -12787,7 +13561,7 @@ type ImagePullProgress struct {
 
 func (x *ImagePullProgress) Reset() {
 	*x = ImagePullProgress{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12799,7 +13573,7 @@ func (x *ImagePullProgress) String() string {
 func (*ImagePullProgress) ProtoMessage() {}
 
 func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12812,7 +13586,7 @@ func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePullProgress.ProtoReflect.Descriptor instead.
 func (*ImagePullProgress) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{154}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *ImagePullProgress) GetId() string {
@@ -12860,7 +13634,7 @@ type JupyterSpec struct {
 
 func (x *JupyterSpec) Reset() {
 	*x = JupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12872,7 +13646,7 @@ func (x *JupyterSpec) String() string {
 func (*JupyterSpec) ProtoMessage() {}
 
 func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12885,7 +13659,7 @@ func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JupyterSpec.ProtoReflect.Descriptor instead.
 func (*JupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{155}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *JupyterSpec) GetEnabled() bool {
@@ -12913,7 +13687,7 @@ type RunJupyterSpec struct {
 
 func (x *RunJupyterSpec) Reset() {
 	*x = RunJupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12925,7 +13699,7 @@ func (x *RunJupyterSpec) String() string {
 func (*RunJupyterSpec) ProtoMessage() {}
 
 func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12938,7 +13712,7 @@ func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunJupyterSpec.ProtoReflect.Descriptor instead.
 func (*RunJupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{156}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *RunJupyterSpec) GetEnabled() bool {
@@ -12971,7 +13745,7 @@ type StartRunRequest struct {
 
 func (x *StartRunRequest) Reset() {
 	*x = StartRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12983,7 +13757,7 @@ func (x *StartRunRequest) String() string {
 func (*StartRunRequest) ProtoMessage() {}
 
 func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12996,7 +13770,7 @@ func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunRequest.ProtoReflect.Descriptor instead.
 func (*StartRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{157}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{168}
 }
 
 func (x *StartRunRequest) GetRun() *RunAgentRequest {
@@ -13017,7 +13791,7 @@ type StartRunResponse struct {
 
 func (x *StartRunResponse) Reset() {
 	*x = StartRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13029,7 +13803,7 @@ func (x *StartRunResponse) String() string {
 func (*StartRunResponse) ProtoMessage() {}
 
 func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13042,7 +13816,7 @@ func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunResponse.ProtoReflect.Descriptor instead.
 func (*StartRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{158}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{169}
 }
 
 func (x *StartRunResponse) GetRun() *RunSummary {
@@ -13082,7 +13856,7 @@ type SkillSpec struct {
 
 func (x *SkillSpec) Reset() {
 	*x = SkillSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13094,7 +13868,7 @@ func (x *SkillSpec) String() string {
 func (*SkillSpec) ProtoMessage() {}
 
 func (x *SkillSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13107,7 +13881,7 @@ func (x *SkillSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillSpec.ProtoReflect.Descriptor instead.
 func (*SkillSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{159}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{170}
 }
 
 func (x *SkillSpec) GetName() string {
@@ -13176,7 +13950,7 @@ type ResolveResourceIDRequest struct {
 
 func (x *ResolveResourceIDRequest) Reset() {
 	*x = ResolveResourceIDRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13188,7 +13962,7 @@ func (x *ResolveResourceIDRequest) String() string {
 func (*ResolveResourceIDRequest) ProtoMessage() {}
 
 func (x *ResolveResourceIDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13201,7 +13975,7 @@ func (x *ResolveResourceIDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveResourceIDRequest.ProtoReflect.Descriptor instead.
 func (*ResolveResourceIDRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{160}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{171}
 }
 
 func (x *ResolveResourceIDRequest) GetId() string {
@@ -13228,7 +14002,7 @@ type ResolveResourceIDResponse struct {
 
 func (x *ResolveResourceIDResponse) Reset() {
 	*x = ResolveResourceIDResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13240,7 +14014,7 @@ func (x *ResolveResourceIDResponse) String() string {
 func (*ResolveResourceIDResponse) ProtoMessage() {}
 
 func (x *ResolveResourceIDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13253,7 +14027,7 @@ func (x *ResolveResourceIDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveResourceIDResponse.ProtoReflect.Descriptor instead.
 func (*ResolveResourceIDResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{161}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{172}
 }
 
 func (x *ResolveResourceIDResponse) GetTargets() []*ResourceTarget {
@@ -13284,7 +14058,7 @@ type ResourceTarget struct {
 
 func (x *ResourceTarget) Reset() {
 	*x = ResourceTarget{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13296,7 +14070,7 @@ func (x *ResourceTarget) String() string {
 func (*ResourceTarget) ProtoMessage() {}
 
 func (x *ResourceTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13309,7 +14083,7 @@ func (x *ResourceTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceTarget.ProtoReflect.Descriptor instead.
 func (*ResourceTarget) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{162}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{173}
 }
 
 func (x *ResourceTarget) GetKind() ResourceKind {
@@ -13362,7 +14136,7 @@ type GetDashboardOverviewRequest struct {
 
 func (x *GetDashboardOverviewRequest) Reset() {
 	*x = GetDashboardOverviewRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13374,7 +14148,7 @@ func (x *GetDashboardOverviewRequest) String() string {
 func (*GetDashboardOverviewRequest) ProtoMessage() {}
 
 func (x *GetDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13387,7 +14161,7 @@ func (x *GetDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDashboardOverviewRequest.ProtoReflect.Descriptor instead.
 func (*GetDashboardOverviewRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{163}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{174}
 }
 
 type WatchDashboardOverviewRequest struct {
@@ -13398,7 +14172,7 @@ type WatchDashboardOverviewRequest struct {
 
 func (x *WatchDashboardOverviewRequest) Reset() {
 	*x = WatchDashboardOverviewRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13410,7 +14184,7 @@ func (x *WatchDashboardOverviewRequest) String() string {
 func (*WatchDashboardOverviewRequest) ProtoMessage() {}
 
 func (x *WatchDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13423,7 +14197,7 @@ func (x *WatchDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDashboardOverviewRequest.ProtoReflect.Descriptor instead.
 func (*WatchDashboardOverviewRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{164}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{175}
 }
 
 type RunOverview struct {
@@ -13437,7 +14211,7 @@ type RunOverview struct {
 
 func (x *RunOverview) Reset() {
 	*x = RunOverview{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13449,7 +14223,7 @@ func (x *RunOverview) String() string {
 func (*RunOverview) ProtoMessage() {}
 
 func (x *RunOverview) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13462,7 +14236,7 @@ func (x *RunOverview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunOverview.ProtoReflect.Descriptor instead.
 func (*RunOverview) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{165}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{176}
 }
 
 func (x *RunOverview) GetRunningCount() uint32 {
@@ -13496,7 +14270,7 @@ type DashboardOverview struct {
 
 func (x *DashboardOverview) Reset() {
 	*x = DashboardOverview{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13508,7 +14282,7 @@ func (x *DashboardOverview) String() string {
 func (*DashboardOverview) ProtoMessage() {}
 
 func (x *DashboardOverview) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13521,7 +14295,7 @@ func (x *DashboardOverview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DashboardOverview.ProtoReflect.Descriptor instead.
 func (*DashboardOverview) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{166}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{177}
 }
 
 func (x *DashboardOverview) GetRuns() *RunOverview {
@@ -13547,7 +14321,7 @@ type GetDashboardOverviewResponse struct {
 
 func (x *GetDashboardOverviewResponse) Reset() {
 	*x = GetDashboardOverviewResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13559,7 +14333,7 @@ func (x *GetDashboardOverviewResponse) String() string {
 func (*GetDashboardOverviewResponse) ProtoMessage() {}
 
 func (x *GetDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13572,7 +14346,7 @@ func (x *GetDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDashboardOverviewResponse.ProtoReflect.Descriptor instead.
 func (*GetDashboardOverviewResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{167}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{178}
 }
 
 func (x *GetDashboardOverviewResponse) GetOverview() *DashboardOverview {
@@ -13592,7 +14366,7 @@ type WatchDashboardOverviewResponse struct {
 
 func (x *WatchDashboardOverviewResponse) Reset() {
 	*x = WatchDashboardOverviewResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13604,7 +14378,7 @@ func (x *WatchDashboardOverviewResponse) String() string {
 func (*WatchDashboardOverviewResponse) ProtoMessage() {}
 
 func (x *WatchDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13617,7 +14391,7 @@ func (x *WatchDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDashboardOverviewResponse.ProtoReflect.Descriptor instead.
 func (*WatchDashboardOverviewResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{168}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{179}
 }
 
 func (x *WatchDashboardOverviewResponse) GetOverview() *DashboardOverview {
@@ -13642,7 +14416,7 @@ type GetGlobalEnvRequest struct {
 
 func (x *GetGlobalEnvRequest) Reset() {
 	*x = GetGlobalEnvRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13654,7 +14428,7 @@ func (x *GetGlobalEnvRequest) String() string {
 func (*GetGlobalEnvRequest) ProtoMessage() {}
 
 func (x *GetGlobalEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13667,7 +14441,7 @@ func (x *GetGlobalEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGlobalEnvRequest.ProtoReflect.Descriptor instead.
 func (*GetGlobalEnvRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{169}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{180}
 }
 
 type GetGlobalEnvResponse struct {
@@ -13679,7 +14453,7 @@ type GetGlobalEnvResponse struct {
 
 func (x *GetGlobalEnvResponse) Reset() {
 	*x = GetGlobalEnvResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13691,7 +14465,7 @@ func (x *GetGlobalEnvResponse) String() string {
 func (*GetGlobalEnvResponse) ProtoMessage() {}
 
 func (x *GetGlobalEnvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13704,7 +14478,7 @@ func (x *GetGlobalEnvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGlobalEnvResponse.ProtoReflect.Descriptor instead.
 func (*GetGlobalEnvResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{170}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{181}
 }
 
 func (x *GetGlobalEnvResponse) GetEnv() []*EnvVarSpec {
@@ -13723,7 +14497,7 @@ type UpdateGlobalEnvRequest struct {
 
 func (x *UpdateGlobalEnvRequest) Reset() {
 	*x = UpdateGlobalEnvRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13735,7 +14509,7 @@ func (x *UpdateGlobalEnvRequest) String() string {
 func (*UpdateGlobalEnvRequest) ProtoMessage() {}
 
 func (x *UpdateGlobalEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13748,7 +14522,7 @@ func (x *UpdateGlobalEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGlobalEnvRequest.ProtoReflect.Descriptor instead.
 func (*UpdateGlobalEnvRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{171}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{182}
 }
 
 func (x *UpdateGlobalEnvRequest) GetEnv() []*EnvVarUpdateSpec {
@@ -13767,7 +14541,7 @@ type UpdateGlobalEnvResponse struct {
 
 func (x *UpdateGlobalEnvResponse) Reset() {
 	*x = UpdateGlobalEnvResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13779,7 +14553,7 @@ func (x *UpdateGlobalEnvResponse) String() string {
 func (*UpdateGlobalEnvResponse) ProtoMessage() {}
 
 func (x *UpdateGlobalEnvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13792,7 +14566,7 @@ func (x *UpdateGlobalEnvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGlobalEnvResponse.ProtoReflect.Descriptor instead.
 func (*UpdateGlobalEnvResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{172}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{183}
 }
 
 func (x *UpdateGlobalEnvResponse) GetEnv() []*EnvVarSpec {
@@ -13810,7 +14584,7 @@ type GetCapabilityGatewayConfigRequest struct {
 
 func (x *GetCapabilityGatewayConfigRequest) Reset() {
 	*x = GetCapabilityGatewayConfigRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13822,7 +14596,7 @@ func (x *GetCapabilityGatewayConfigRequest) String() string {
 func (*GetCapabilityGatewayConfigRequest) ProtoMessage() {}
 
 func (x *GetCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13835,7 +14609,7 @@ func (x *GetCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetCapabilityGatewayConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityGatewayConfigRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{173}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{184}
 }
 
 type CapabilityGatewayConfig struct {
@@ -13848,7 +14622,7 @@ type CapabilityGatewayConfig struct {
 
 func (x *CapabilityGatewayConfig) Reset() {
 	*x = CapabilityGatewayConfig{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13860,7 +14634,7 @@ func (x *CapabilityGatewayConfig) String() string {
 func (*CapabilityGatewayConfig) ProtoMessage() {}
 
 func (x *CapabilityGatewayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13873,7 +14647,7 @@ func (x *CapabilityGatewayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityGatewayConfig.ProtoReflect.Descriptor instead.
 func (*CapabilityGatewayConfig) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{174}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{185}
 }
 
 func (x *CapabilityGatewayConfig) GetAddr() string {
@@ -13899,7 +14673,7 @@ type GetCapabilityGatewayConfigResponse struct {
 
 func (x *GetCapabilityGatewayConfigResponse) Reset() {
 	*x = GetCapabilityGatewayConfigResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13911,7 +14685,7 @@ func (x *GetCapabilityGatewayConfigResponse) String() string {
 func (*GetCapabilityGatewayConfigResponse) ProtoMessage() {}
 
 func (x *GetCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13924,7 +14698,7 @@ func (x *GetCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetCapabilityGatewayConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetCapabilityGatewayConfigResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{175}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{186}
 }
 
 func (x *GetCapabilityGatewayConfigResponse) GetConfig() *CapabilityGatewayConfig {
@@ -13944,7 +14718,7 @@ type UpdateCapabilityGatewayConfigRequest struct {
 
 func (x *UpdateCapabilityGatewayConfigRequest) Reset() {
 	*x = UpdateCapabilityGatewayConfigRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13956,7 +14730,7 @@ func (x *UpdateCapabilityGatewayConfigRequest) String() string {
 func (*UpdateCapabilityGatewayConfigRequest) ProtoMessage() {}
 
 func (x *UpdateCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13969,7 +14743,7 @@ func (x *UpdateCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateCapabilityGatewayConfigRequest.ProtoReflect.Descriptor instead.
 func (*UpdateCapabilityGatewayConfigRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{176}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{187}
 }
 
 func (x *UpdateCapabilityGatewayConfigRequest) GetAddr() string {
@@ -13995,7 +14769,7 @@ type UpdateCapabilityGatewayConfigResponse struct {
 
 func (x *UpdateCapabilityGatewayConfigResponse) Reset() {
 	*x = UpdateCapabilityGatewayConfigResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14007,7 +14781,7 @@ func (x *UpdateCapabilityGatewayConfigResponse) String() string {
 func (*UpdateCapabilityGatewayConfigResponse) ProtoMessage() {}
 
 func (x *UpdateCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14020,7 +14794,7 @@ func (x *UpdateCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use UpdateCapabilityGatewayConfigResponse.ProtoReflect.Descriptor instead.
 func (*UpdateCapabilityGatewayConfigResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{177}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{188}
 }
 
 func (x *UpdateCapabilityGatewayConfigResponse) GetConfig() *CapabilityGatewayConfig {
@@ -14045,7 +14819,7 @@ type WorkspacePreset struct {
 
 func (x *WorkspacePreset) Reset() {
 	*x = WorkspacePreset{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14057,7 +14831,7 @@ func (x *WorkspacePreset) String() string {
 func (*WorkspacePreset) ProtoMessage() {}
 
 func (x *WorkspacePreset) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14070,7 +14844,7 @@ func (x *WorkspacePreset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspacePreset.ProtoReflect.Descriptor instead.
 func (*WorkspacePreset) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{178}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{189}
 }
 
 func (x *WorkspacePreset) GetId() string {
@@ -14130,7 +14904,7 @@ type ListWorkspacePresetsRequest struct {
 
 func (x *ListWorkspacePresetsRequest) Reset() {
 	*x = ListWorkspacePresetsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14142,7 +14916,7 @@ func (x *ListWorkspacePresetsRequest) String() string {
 func (*ListWorkspacePresetsRequest) ProtoMessage() {}
 
 func (x *ListWorkspacePresetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14155,7 +14929,7 @@ func (x *ListWorkspacePresetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacePresetsRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspacePresetsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{179}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{190}
 }
 
 type ListWorkspacePresetsResponse struct {
@@ -14167,7 +14941,7 @@ type ListWorkspacePresetsResponse struct {
 
 func (x *ListWorkspacePresetsResponse) Reset() {
 	*x = ListWorkspacePresetsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14179,7 +14953,7 @@ func (x *ListWorkspacePresetsResponse) String() string {
 func (*ListWorkspacePresetsResponse) ProtoMessage() {}
 
 func (x *ListWorkspacePresetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14192,7 +14966,7 @@ func (x *ListWorkspacePresetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacePresetsResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspacePresetsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{180}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{191}
 }
 
 func (x *ListWorkspacePresetsResponse) GetPresets() []*WorkspacePreset {
@@ -14214,7 +14988,7 @@ type CreateWorkspacePresetRequest struct {
 
 func (x *CreateWorkspacePresetRequest) Reset() {
 	*x = CreateWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14226,7 +15000,7 @@ func (x *CreateWorkspacePresetRequest) String() string {
 func (*CreateWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *CreateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14239,7 +15013,7 @@ func (x *CreateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{181}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{192}
 }
 
 func (x *CreateWorkspacePresetRequest) GetName() string {
@@ -14283,7 +15057,7 @@ type UpdateWorkspacePresetRequest struct {
 
 func (x *UpdateWorkspacePresetRequest) Reset() {
 	*x = UpdateWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14295,7 +15069,7 @@ func (x *UpdateWorkspacePresetRequest) String() string {
 func (*UpdateWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *UpdateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14308,7 +15082,7 @@ func (x *UpdateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*UpdateWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{182}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{193}
 }
 
 func (x *UpdateWorkspacePresetRequest) GetPresetId() string {
@@ -14355,7 +15129,7 @@ type DeleteWorkspacePresetRequest struct {
 
 func (x *DeleteWorkspacePresetRequest) Reset() {
 	*x = DeleteWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14367,7 +15141,7 @@ func (x *DeleteWorkspacePresetRequest) String() string {
 func (*DeleteWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *DeleteWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14380,7 +15154,7 @@ func (x *DeleteWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{183}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{194}
 }
 
 func (x *DeleteWorkspacePresetRequest) GetPresetId() string {
@@ -14398,7 +15172,7 @@ type DeleteWorkspacePresetResponse struct {
 
 func (x *DeleteWorkspacePresetResponse) Reset() {
 	*x = DeleteWorkspacePresetResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14410,7 +15184,7 @@ func (x *DeleteWorkspacePresetResponse) String() string {
 func (*DeleteWorkspacePresetResponse) ProtoMessage() {}
 
 func (x *DeleteWorkspacePresetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14423,7 +15197,7 @@ func (x *DeleteWorkspacePresetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspacePresetResponse.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspacePresetResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{184}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{195}
 }
 
 type WorkspacePresetResponse struct {
@@ -14435,7 +15209,7 @@ type WorkspacePresetResponse struct {
 
 func (x *WorkspacePresetResponse) Reset() {
 	*x = WorkspacePresetResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14447,7 +15221,7 @@ func (x *WorkspacePresetResponse) String() string {
 func (*WorkspacePresetResponse) ProtoMessage() {}
 
 func (x *WorkspacePresetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14460,7 +15234,7 @@ func (x *WorkspacePresetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspacePresetResponse.ProtoReflect.Descriptor instead.
 func (*WorkspacePresetResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{185}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{196}
 }
 
 func (x *WorkspacePresetResponse) GetPreset() *WorkspacePreset {
@@ -14478,7 +15252,7 @@ type GetCapabilityStatusRequest struct {
 
 func (x *GetCapabilityStatusRequest) Reset() {
 	*x = GetCapabilityStatusRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14490,7 +15264,7 @@ func (x *GetCapabilityStatusRequest) String() string {
 func (*GetCapabilityStatusRequest) ProtoMessage() {}
 
 func (x *GetCapabilityStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14503,7 +15277,7 @@ func (x *GetCapabilityStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityStatusRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{186}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{197}
 }
 
 type CapabilityStatusResponse struct {
@@ -14522,7 +15296,7 @@ type CapabilityStatusResponse struct {
 
 func (x *CapabilityStatusResponse) Reset() {
 	*x = CapabilityStatusResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14534,7 +15308,7 @@ func (x *CapabilityStatusResponse) String() string {
 func (*CapabilityStatusResponse) ProtoMessage() {}
 
 func (x *CapabilityStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14547,7 +15321,7 @@ func (x *CapabilityStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityStatusResponse.ProtoReflect.Descriptor instead.
 func (*CapabilityStatusResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{187}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{198}
 }
 
 func (x *CapabilityStatusResponse) GetConfigured() bool {
@@ -14614,7 +15388,7 @@ type ListCapabilitySetsRequest struct {
 
 func (x *ListCapabilitySetsRequest) Reset() {
 	*x = ListCapabilitySetsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14626,7 +15400,7 @@ func (x *ListCapabilitySetsRequest) String() string {
 func (*ListCapabilitySetsRequest) ProtoMessage() {}
 
 func (x *ListCapabilitySetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14639,7 +15413,7 @@ func (x *ListCapabilitySetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCapabilitySetsRequest.ProtoReflect.Descriptor instead.
 func (*ListCapabilitySetsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{188}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{199}
 }
 
 type CapabilitySet struct {
@@ -14654,7 +15428,7 @@ type CapabilitySet struct {
 
 func (x *CapabilitySet) Reset() {
 	*x = CapabilitySet{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14666,7 +15440,7 @@ func (x *CapabilitySet) String() string {
 func (*CapabilitySet) ProtoMessage() {}
 
 func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14679,7 +15453,7 @@ func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilitySet.ProtoReflect.Descriptor instead.
 func (*CapabilitySet) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{189}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{200}
 }
 
 func (x *CapabilitySet) GetId() string {
@@ -14719,7 +15493,7 @@ type ListCapabilitySetsResponse struct {
 
 func (x *ListCapabilitySetsResponse) Reset() {
 	*x = ListCapabilitySetsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14731,7 +15505,7 @@ func (x *ListCapabilitySetsResponse) String() string {
 func (*ListCapabilitySetsResponse) ProtoMessage() {}
 
 func (x *ListCapabilitySetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14744,7 +15518,7 @@ func (x *ListCapabilitySetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCapabilitySetsResponse.ProtoReflect.Descriptor instead.
 func (*ListCapabilitySetsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{190}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{201}
 }
 
 func (x *ListCapabilitySetsResponse) GetCapsets() []*CapabilitySet {
@@ -14763,7 +15537,7 @@ type GetCapabilityCatalogRequest struct {
 
 func (x *GetCapabilityCatalogRequest) Reset() {
 	*x = GetCapabilityCatalogRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14775,7 +15549,7 @@ func (x *GetCapabilityCatalogRequest) String() string {
 func (*GetCapabilityCatalogRequest) ProtoMessage() {}
 
 func (x *GetCapabilityCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14788,7 +15562,7 @@ func (x *GetCapabilityCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityCatalogRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{191}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{202}
 }
 
 func (x *GetCapabilityCatalogRequest) GetCapsetId() string {
@@ -14814,7 +15588,7 @@ type CapabilityEndpoint struct {
 
 func (x *CapabilityEndpoint) Reset() {
 	*x = CapabilityEndpoint{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14826,7 +15600,7 @@ func (x *CapabilityEndpoint) String() string {
 func (*CapabilityEndpoint) ProtoMessage() {}
 
 func (x *CapabilityEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14839,7 +15613,7 @@ func (x *CapabilityEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityEndpoint.ProtoReflect.Descriptor instead.
 func (*CapabilityEndpoint) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{192}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{203}
 }
 
 func (x *CapabilityEndpoint) GetProtocol() string {
@@ -14914,7 +15688,7 @@ type CapabilityMethod struct {
 
 func (x *CapabilityMethod) Reset() {
 	*x = CapabilityMethod{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14926,7 +15700,7 @@ func (x *CapabilityMethod) String() string {
 func (*CapabilityMethod) ProtoMessage() {}
 
 func (x *CapabilityMethod) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14939,7 +15713,7 @@ func (x *CapabilityMethod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityMethod.ProtoReflect.Descriptor instead.
 func (*CapabilityMethod) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{193}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{204}
 }
 
 func (x *CapabilityMethod) GetServiceId() string {
@@ -15010,7 +15784,7 @@ type GetCapabilityCatalogResponse struct {
 
 func (x *GetCapabilityCatalogResponse) Reset() {
 	*x = GetCapabilityCatalogResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15022,7 +15796,7 @@ func (x *GetCapabilityCatalogResponse) String() string {
 func (*GetCapabilityCatalogResponse) ProtoMessage() {}
 
 func (x *GetCapabilityCatalogResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15035,7 +15809,7 @@ func (x *GetCapabilityCatalogResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityCatalogResponse.ProtoReflect.Descriptor instead.
 func (*GetCapabilityCatalogResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{194}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{205}
 }
 
 func (x *GetCapabilityCatalogResponse) GetCapsetId() string {
@@ -15075,7 +15849,7 @@ type ListSandboxHistoryRequest struct {
 
 func (x *ListSandboxHistoryRequest) Reset() {
 	*x = ListSandboxHistoryRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15087,7 +15861,7 @@ func (x *ListSandboxHistoryRequest) String() string {
 func (*ListSandboxHistoryRequest) ProtoMessage() {}
 
 func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15100,7 +15874,7 @@ func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{195}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{206}
 }
 
 func (x *ListSandboxHistoryRequest) GetSandboxId() string {
@@ -15131,7 +15905,7 @@ type SandboxHistoryCell struct {
 
 func (x *SandboxHistoryCell) Reset() {
 	*x = SandboxHistoryCell{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15143,7 +15917,7 @@ func (x *SandboxHistoryCell) String() string {
 func (*SandboxHistoryCell) ProtoMessage() {}
 
 func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15156,7 +15930,7 @@ func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryCell.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryCell) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{196}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{207}
 }
 
 func (x *SandboxHistoryCell) GetId() string {
@@ -15263,7 +16037,7 @@ type SandboxHistoryEvent struct {
 
 func (x *SandboxHistoryEvent) Reset() {
 	*x = SandboxHistoryEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15275,7 +16049,7 @@ func (x *SandboxHistoryEvent) String() string {
 func (*SandboxHistoryEvent) ProtoMessage() {}
 
 func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15288,7 +16062,7 @@ func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryEvent.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{197}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{208}
 }
 
 func (x *SandboxHistoryEvent) GetId() string {
@@ -15337,7 +16111,7 @@ type ListSandboxHistoryResponse struct {
 
 func (x *ListSandboxHistoryResponse) Reset() {
 	*x = ListSandboxHistoryResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15349,7 +16123,7 @@ func (x *ListSandboxHistoryResponse) String() string {
 func (*ListSandboxHistoryResponse) ProtoMessage() {}
 
 func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15362,7 +16136,7 @@ func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{198}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{209}
 }
 
 func (x *ListSandboxHistoryResponse) GetCells() []*SandboxHistoryCell {
@@ -15395,7 +16169,7 @@ type WatchSandboxRequest struct {
 
 func (x *WatchSandboxRequest) Reset() {
 	*x = WatchSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15407,7 +16181,7 @@ func (x *WatchSandboxRequest) String() string {
 func (*WatchSandboxRequest) ProtoMessage() {}
 
 func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15420,7 +16194,7 @@ func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxRequest.ProtoReflect.Descriptor instead.
 func (*WatchSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{199}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{210}
 }
 
 func (x *WatchSandboxRequest) GetSandboxId() string {
@@ -15445,7 +16219,7 @@ type WatchSandboxResponse struct {
 
 func (x *WatchSandboxResponse) Reset() {
 	*x = WatchSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15457,7 +16231,7 @@ func (x *WatchSandboxResponse) String() string {
 func (*WatchSandboxResponse) ProtoMessage() {}
 
 func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15470,7 +16244,7 @@ func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxResponse.ProtoReflect.Descriptor instead.
 func (*WatchSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{200}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{211}
 }
 
 func (x *WatchSandboxResponse) GetEventType() SandboxWatchEventType {
@@ -15533,7 +16307,7 @@ type GenerateLLMRequest struct {
 
 func (x *GenerateLLMRequest) Reset() {
 	*x = GenerateLLMRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15545,7 +16319,7 @@ func (x *GenerateLLMRequest) String() string {
 func (*GenerateLLMRequest) ProtoMessage() {}
 
 func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15558,7 +16332,7 @@ func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMRequest.ProtoReflect.Descriptor instead.
 func (*GenerateLLMRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{201}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{212}
 }
 
 func (x *GenerateLLMRequest) GetPrompt() string {
@@ -15595,7 +16369,7 @@ type GenerateLLMResponse struct {
 
 func (x *GenerateLLMResponse) Reset() {
 	*x = GenerateLLMResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15607,7 +16381,7 @@ func (x *GenerateLLMResponse) String() string {
 func (*GenerateLLMResponse) ProtoMessage() {}
 
 func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15620,7 +16394,7 @@ func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMResponse.ProtoReflect.Descriptor instead.
 func (*GenerateLLMResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{202}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{213}
 }
 
 func (x *GenerateLLMResponse) GetText() string {
@@ -15867,7 +16641,71 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x1bListSchedulerEventsResponse\x127\n" +
 	"\x06events\x18\x01 \x03(\v2\x1f.agentcompose.v2.SchedulerEventR\x06events\x12\x1f\n" +
 	"\vnext_cursor\x18\x02 \x01(\tR\n" +
-	"nextCursor\"\x8c\x01\n" +
+	"nextCursor\"\xad\x01\n" +
+	"\x13RunSchedulerRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x03 \x01(\tR\ttriggerId\x12!\n" +
+	"\fpayload_json\x18\x04 \x01(\tR\vpayloadJson\"G\n" +
+	"\x14RunSchedulerResponse\x12/\n" +
+	"\x03run\x18\x01 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\"\xb2\x01\n" +
+	"\x18StartSchedulerRunRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x03 \x01(\tR\ttriggerId\x12!\n" +
+	"\fpayload_json\x18\x04 \x01(\tR\vpayloadJson\"L\n" +
+	"\x19StartSchedulerRunResponse\x12/\n" +
+	"\x03run\x18\x01 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\"f\n" +
+	"\x16GetSchedulerRunRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x15\n" +
+	"\x06run_id\x18\x02 \x01(\tR\x05runId\"J\n" +
+	"\x17GetSchedulerRunResponse\x12/\n" +
+	"\x03run\x18\x01 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\"\x9e\x01\n" +
+	"\x18ListSchedulerRunsRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x14\n" +
+	"\x05limit\x18\x03 \x01(\rR\x05limit\x12\x16\n" +
+	"\x06cursor\x18\x04 \x01(\tR\x06cursor\"o\n" +
+	"\x19ListSchedulerRunsResponse\x121\n" +
+	"\x04runs\x18\x01 \x03(\v2\x1d.agentcompose.v2.SchedulerRunR\x04runs\x12\x1f\n" +
+	"\vnext_cursor\x18\x02 \x01(\tR\n" +
+	"nextCursor\"\x7f\n" +
+	"\x17StopSchedulerRunRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x15\n" +
+	"\x06run_id\x18\x02 \x01(\tR\x05runId\x12\x16\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\"r\n" +
+	"\x18StopSchedulerRunResponse\x12/\n" +
+	"\x03run\x18\x01 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\x12%\n" +
+	"\x0estop_requested\x18\x02 \x01(\bR\rstopRequested\"\xf8\x04\n" +
+	"\fSchedulerRun\x12\x15\n" +
+	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x02 \x01(\tR\tprojectId\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x03 \x01(\tR\tagentName\x12!\n" +
+	"\fscheduler_id\x18\x04 \x01(\tR\vschedulerId\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x05 \x01(\tR\ttriggerId\x12!\n" +
+	"\ftrigger_kind\x18\x06 \x01(\tR\vtriggerKind\x12%\n" +
+	"\x0etrigger_source\x18\a \x01(\tR\rtriggerSource\x12;\n" +
+	"\x06status\x18\b \x01(\x0e2#.agentcompose.v2.SchedulerRunStatusR\x06status\x129\n" +
+	"\n" +
+	"started_at\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12=\n" +
+	"\fcompleted_at\x18\n" +
+	" \x01(\v2\x1a.google.protobuf.TimestampR\vcompletedAt\x12\x1f\n" +
+	"\vduration_ms\x18\v \x01(\x03R\n" +
+	"durationMs\x12\x14\n" +
+	"\x05error\x18\f \x01(\tR\x05error\x12\x1f\n" +
+	"\vresult_json\x18\r \x01(\tR\n" +
+	"resultJson\x12!\n" +
+	"\fpayload_json\x18\x0e \x01(\tR\vpayloadJson\x120\n" +
+	"\x14source_script_sha256\x18\x0f \x01(\tR\x12sourceScriptSha256\x12#\n" +
+	"\rartifacts_dir\x18\x10 \x01(\tR\fartifactsDir\"\x8c\x01\n" +
 	"\x1aSetSchedulerEnabledRequest\x125\n" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
 	"\n" +
@@ -16984,7 +17822,14 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x16RUN_SOURCE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11RUN_SOURCE_MANUAL\x10\x01\x12\x18\n" +
 	"\x14RUN_SOURCE_SCHEDULER\x10\x02\x12\x12\n" +
-	"\x0eRUN_SOURCE_API\x10\x03*`\n" +
+	"\x0eRUN_SOURCE_API\x10\x03*\xe6\x01\n" +
+	"\x12SchedulerRunStatus\x12$\n" +
+	" SCHEDULER_RUN_STATUS_UNSPECIFIED\x10\x00\x12 \n" +
+	"\x1cSCHEDULER_RUN_STATUS_RUNNING\x10\x01\x12\"\n" +
+	"\x1eSCHEDULER_RUN_STATUS_SUCCEEDED\x10\x02\x12\x1f\n" +
+	"\x1bSCHEDULER_RUN_STATUS_FAILED\x10\x03\x12!\n" +
+	"\x1dSCHEDULER_RUN_STATUS_CANCELED\x10\x04\x12 \n" +
+	"\x1cSCHEDULER_RUN_STATUS_SKIPPED\x10\x05*`\n" +
 	"\vAgentStatus\x12\x1c\n" +
 	"\x18AGENT_STATUS_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14AGENT_STATUS_ENABLED\x10\x01\x12\x19\n" +
@@ -17083,7 +17928,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"%SANDBOX_WATCH_EVENT_TYPE_CELL_STARTED\x10\x02\x12(\n" +
 	"$SANDBOX_WATCH_EVENT_TYPE_CELL_OUTPUT\x10\x03\x12+\n" +
 	"'SANDBOX_WATCH_EVENT_TYPE_CELL_COMPLETED\x10\x04\x12(\n" +
-	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xf2\b\n" +
+	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xf6\f\n" +
 	"\x0eProjectService\x12d\n" +
 	"\x0fValidateProject\x12'.agentcompose.v2.ValidateProjectRequest\x1a(.agentcompose.v2.ValidateProjectResponse\x12[\n" +
 	"\fApplyProject\x12$.agentcompose.v2.ApplyProjectRequest\x1a%.agentcompose.v2.ApplyProjectResponse\x12U\n" +
@@ -17094,7 +17939,12 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\fWatchProject\x12$.agentcompose.v2.WatchProjectRequest\x1a%.agentcompose.v2.WatchProjectResponse0\x01\x12[\n" +
 	"\fGetScheduler\x12$.agentcompose.v2.GetSchedulerRequest\x1a%.agentcompose.v2.GetSchedulerResponse\x12a\n" +
 	"\x0eListSchedulers\x12&.agentcompose.v2.ListSchedulersRequest\x1a'.agentcompose.v2.ListSchedulersResponse\x12p\n" +
-	"\x13ListSchedulerEvents\x12+.agentcompose.v2.ListSchedulerEventsRequest\x1a,.agentcompose.v2.ListSchedulerEventsResponse\x12p\n" +
+	"\x13ListSchedulerEvents\x12+.agentcompose.v2.ListSchedulerEventsRequest\x1a,.agentcompose.v2.ListSchedulerEventsResponse\x12[\n" +
+	"\fRunScheduler\x12$.agentcompose.v2.RunSchedulerRequest\x1a%.agentcompose.v2.RunSchedulerResponse\x12j\n" +
+	"\x11StartSchedulerRun\x12).agentcompose.v2.StartSchedulerRunRequest\x1a*.agentcompose.v2.StartSchedulerRunResponse\x12d\n" +
+	"\x0fGetSchedulerRun\x12'.agentcompose.v2.GetSchedulerRunRequest\x1a(.agentcompose.v2.GetSchedulerRunResponse\x12j\n" +
+	"\x11ListSchedulerRuns\x12).agentcompose.v2.ListSchedulerRunsRequest\x1a*.agentcompose.v2.ListSchedulerRunsResponse\x12g\n" +
+	"\x10StopSchedulerRun\x12(.agentcompose.v2.StopSchedulerRunRequest\x1a).agentcompose.v2.StopSchedulerRunResponse\x12p\n" +
 	"\x13SetSchedulerEnabled\x12+.agentcompose.v2.SetSchedulerEnabledRequest\x1a,.agentcompose.v2.SetSchedulerEnabledResponse\x12\x85\x01\n" +
 	"\x1aSetSchedulerTriggerEnabled\x122.agentcompose.v2.SetSchedulerTriggerEnabledRequest\x1a3.agentcompose.v2.SetSchedulerTriggerEnabledResponse2\xfc\x06\n" +
 	"\n" +
@@ -17180,631 +18030,666 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 	return file_agentcompose_v2_agentcompose_proto_rawDescData
 }
 
-var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 24)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 215)
+var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 25)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 226)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),                // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),                      // 1: agentcompose.v2.ProjectChangeAction
 	(ProjectWatchEventType)(0),                    // 2: agentcompose.v2.ProjectWatchEventType
 	(RunStatus)(0),                                // 3: agentcompose.v2.RunStatus
 	(RunSource)(0),                                // 4: agentcompose.v2.RunSource
-	(AgentStatus)(0),                              // 5: agentcompose.v2.AgentStatus
-	(ProjectAgentAvailability)(0),                 // 6: agentcompose.v2.ProjectAgentAvailability
-	(ProjectAgentHealth)(0),                       // 7: agentcompose.v2.ProjectAgentHealth
-	(RunEventKind)(0),                             // 8: agentcompose.v2.RunEventKind
-	(RunAgentStreamEventType)(0),                  // 9: agentcompose.v2.RunAgentStreamEventType
-	(RunSandboxCleanupPolicy)(0),                  // 10: agentcompose.v2.RunSandboxCleanupPolicy
-	(ExecStreamEventType)(0),                      // 11: agentcompose.v2.ExecStreamEventType
-	(AttachRunMode)(0),                            // 12: agentcompose.v2.AttachRunMode
-	(StdioStream)(0),                              // 13: agentcompose.v2.StdioStream
-	(ImageStoreKind)(0),                           // 14: agentcompose.v2.ImageStoreKind
-	(ImageAvailabilityStatus)(0),                  // 15: agentcompose.v2.ImageAvailabilityStatus
-	(ImageOperationStatus)(0),                     // 16: agentcompose.v2.ImageOperationStatus
-	(MetricStatus)(0),                             // 17: agentcompose.v2.MetricStatus
-	(CacheDomain)(0),                              // 18: agentcompose.v2.CacheDomain
-	(CacheReferencePolicy)(0),                     // 19: agentcompose.v2.CacheReferencePolicy
-	(SandboxPruneCandidateKind)(0),                // 20: agentcompose.v2.SandboxPruneCandidateKind
-	(CacheStatus)(0),                              // 21: agentcompose.v2.CacheStatus
-	(ResourceKind)(0),                             // 22: agentcompose.v2.ResourceKind
-	(SandboxWatchEventType)(0),                    // 23: agentcompose.v2.SandboxWatchEventType
-	(*ValidateProjectRequest)(nil),                // 24: agentcompose.v2.ValidateProjectRequest
-	(*ValidateProjectResponse)(nil),               // 25: agentcompose.v2.ValidateProjectResponse
-	(*ApplyProjectRequest)(nil),                   // 26: agentcompose.v2.ApplyProjectRequest
-	(*ApplyProjectResponse)(nil),                  // 27: agentcompose.v2.ApplyProjectResponse
-	(*GetProjectRequest)(nil),                     // 28: agentcompose.v2.GetProjectRequest
-	(*GetProjectResponse)(nil),                    // 29: agentcompose.v2.GetProjectResponse
-	(*ListProjectsRequest)(nil),                   // 30: agentcompose.v2.ListProjectsRequest
-	(*ListProjectsResponse)(nil),                  // 31: agentcompose.v2.ListProjectsResponse
-	(*RemoveProjectRequest)(nil),                  // 32: agentcompose.v2.RemoveProjectRequest
-	(*RemoveProjectResponse)(nil),                 // 33: agentcompose.v2.RemoveProjectResponse
-	(*WatchProjectRequest)(nil),                   // 34: agentcompose.v2.WatchProjectRequest
-	(*WatchProjectResponse)(nil),                  // 35: agentcompose.v2.WatchProjectResponse
-	(*ProjectRef)(nil),                            // 36: agentcompose.v2.ProjectRef
-	(*ProjectSource)(nil),                         // 37: agentcompose.v2.ProjectSource
-	(*Project)(nil),                               // 38: agentcompose.v2.Project
-	(*ProjectSummary)(nil),                        // 39: agentcompose.v2.ProjectSummary
-	(*ProjectRevision)(nil),                       // 40: agentcompose.v2.ProjectRevision
-	(*ProjectAgent)(nil),                          // 41: agentcompose.v2.ProjectAgent
-	(*ProjectAgentCurrentRun)(nil),                // 42: agentcompose.v2.ProjectAgentCurrentRun
-	(*ProjectAgentLatestRun)(nil),                 // 43: agentcompose.v2.ProjectAgentLatestRun
-	(*ProjectScheduler)(nil),                      // 44: agentcompose.v2.ProjectScheduler
-	(*GetSchedulerRequest)(nil),                   // 45: agentcompose.v2.GetSchedulerRequest
-	(*GetSchedulerResponse)(nil),                  // 46: agentcompose.v2.GetSchedulerResponse
-	(*ResolvedTrigger)(nil),                       // 47: agentcompose.v2.ResolvedTrigger
-	(*ListSchedulersRequest)(nil),                 // 48: agentcompose.v2.ListSchedulersRequest
-	(*SchedulerSummary)(nil),                      // 49: agentcompose.v2.SchedulerSummary
-	(*ListSchedulersResponse)(nil),                // 50: agentcompose.v2.ListSchedulersResponse
-	(*ListSchedulerEventsRequest)(nil),            // 51: agentcompose.v2.ListSchedulerEventsRequest
-	(*SchedulerEvent)(nil),                        // 52: agentcompose.v2.SchedulerEvent
-	(*ListSchedulerEventsResponse)(nil),           // 53: agentcompose.v2.ListSchedulerEventsResponse
-	(*SetSchedulerEnabledRequest)(nil),            // 54: agentcompose.v2.SetSchedulerEnabledRequest
-	(*SetSchedulerEnabledResponse)(nil),           // 55: agentcompose.v2.SetSchedulerEnabledResponse
-	(*SetSchedulerTriggerEnabledRequest)(nil),     // 56: agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	(*SetSchedulerTriggerEnabledResponse)(nil),    // 57: agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	(*ProjectValidationIssue)(nil),                // 58: agentcompose.v2.ProjectValidationIssue
-	(*ProjectChange)(nil),                         // 59: agentcompose.v2.ProjectChange
-	(*ProjectSpec)(nil),                           // 60: agentcompose.v2.ProjectSpec
-	(*NamedWorkspaceSpec)(nil),                    // 61: agentcompose.v2.NamedWorkspaceSpec
-	(*AgentSpec)(nil),                             // 62: agentcompose.v2.AgentSpec
-	(*MCPServerSpec)(nil),                         // 63: agentcompose.v2.MCPServerSpec
-	(*ProjectVolumeSpec)(nil),                     // 64: agentcompose.v2.ProjectVolumeSpec
-	(*VolumeMountSpec)(nil),                       // 65: agentcompose.v2.VolumeMountSpec
-	(*BuildSpec)(nil),                             // 66: agentcompose.v2.BuildSpec
-	(*EnvVarSpec)(nil),                            // 67: agentcompose.v2.EnvVarSpec
-	(*EnvVarUpdateSpec)(nil),                      // 68: agentcompose.v2.EnvVarUpdateSpec
-	(*WorkspaceSpec)(nil),                         // 69: agentcompose.v2.WorkspaceSpec
-	(*NetworkSpec)(nil),                           // 70: agentcompose.v2.NetworkSpec
-	(*SchedulerSpec)(nil),                         // 71: agentcompose.v2.SchedulerSpec
-	(*TriggerSpec)(nil),                           // 72: agentcompose.v2.TriggerSpec
-	(*EventTriggerSpec)(nil),                      // 73: agentcompose.v2.EventTriggerSpec
-	(*DriverSpec)(nil),                            // 74: agentcompose.v2.DriverSpec
-	(*BoxliteDriverSpec)(nil),                     // 75: agentcompose.v2.BoxliteDriverSpec
-	(*DockerDriverSpec)(nil),                      // 76: agentcompose.v2.DockerDriverSpec
-	(*MicrosandboxDriverSpec)(nil),                // 77: agentcompose.v2.MicrosandboxDriverSpec
-	(*RunAgentRequest)(nil),                       // 78: agentcompose.v2.RunAgentRequest
-	(*RunAgentResponse)(nil),                      // 79: agentcompose.v2.RunAgentResponse
-	(*RunAgentStreamResponse)(nil),                // 80: agentcompose.v2.RunAgentStreamResponse
-	(*RunAttachRequest)(nil),                      // 81: agentcompose.v2.RunAttachRequest
-	(*RunAttachResponse)(nil),                     // 82: agentcompose.v2.RunAttachResponse
-	(*RunAttachStart)(nil),                        // 83: agentcompose.v2.RunAttachStart
-	(*TranscriptEvent)(nil),                       // 84: agentcompose.v2.TranscriptEvent
-	(*GetRunRequest)(nil),                         // 85: agentcompose.v2.GetRunRequest
-	(*GetRunResponse)(nil),                        // 86: agentcompose.v2.GetRunResponse
-	(*ListRunsRequest)(nil),                       // 87: agentcompose.v2.ListRunsRequest
-	(*ListRunsResponse)(nil),                      // 88: agentcompose.v2.ListRunsResponse
-	(*FollowRunLogsRequest)(nil),                  // 89: agentcompose.v2.FollowRunLogsRequest
-	(*RunLogChunk)(nil),                           // 90: agentcompose.v2.RunLogChunk
-	(*StopRunRequest)(nil),                        // 91: agentcompose.v2.StopRunRequest
-	(*StopRunResponse)(nil),                       // 92: agentcompose.v2.StopRunResponse
-	(*ListRunEventsRequest)(nil),                  // 93: agentcompose.v2.ListRunEventsRequest
-	(*RunEvent)(nil),                              // 94: agentcompose.v2.RunEvent
-	(*ListRunEventsResponse)(nil),                 // 95: agentcompose.v2.ListRunEventsResponse
-	(*ListSandboxRunEventsRequest)(nil),           // 96: agentcompose.v2.ListSandboxRunEventsRequest
-	(*ListSandboxRunEventsResponse)(nil),          // 97: agentcompose.v2.ListSandboxRunEventsResponse
-	(*RemoveSandboxRequest)(nil),                  // 98: agentcompose.v2.RemoveSandboxRequest
-	(*RemoveSandboxResponse)(nil),                 // 99: agentcompose.v2.RemoveSandboxResponse
-	(*PruneSandboxesRequest)(nil),                 // 100: agentcompose.v2.PruneSandboxesRequest
-	(*SandboxPruneCandidate)(nil),                 // 101: agentcompose.v2.SandboxPruneCandidate
-	(*PruneSandboxesResponse)(nil),                // 102: agentcompose.v2.PruneSandboxesResponse
-	(*GetSandboxStatsRequest)(nil),                // 103: agentcompose.v2.GetSandboxStatsRequest
-	(*GetSandboxStatsResponse)(nil),               // 104: agentcompose.v2.GetSandboxStatsResponse
-	(*GetSandboxRequest)(nil),                     // 105: agentcompose.v2.GetSandboxRequest
-	(*Sandbox)(nil),                               // 106: agentcompose.v2.Sandbox
-	(*SandboxTag)(nil),                            // 107: agentcompose.v2.SandboxTag
-	(*ListSandboxesRequest)(nil),                  // 108: agentcompose.v2.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),                 // 109: agentcompose.v2.ListSandboxesResponse
-	(*GetSandboxResponse)(nil),                    // 110: agentcompose.v2.GetSandboxResponse
-	(*StopSandboxRequest)(nil),                    // 111: agentcompose.v2.StopSandboxRequest
-	(*StopSandboxResponse)(nil),                   // 112: agentcompose.v2.StopSandboxResponse
-	(*ResumeSandboxRequest)(nil),                  // 113: agentcompose.v2.ResumeSandboxRequest
-	(*ResumeSandboxResponse)(nil),                 // 114: agentcompose.v2.ResumeSandboxResponse
-	(*MetricValue)(nil),                           // 115: agentcompose.v2.MetricValue
-	(*SandboxStats)(nil),                          // 116: agentcompose.v2.SandboxStats
-	(*RunSummary)(nil),                            // 117: agentcompose.v2.RunSummary
-	(*RunDetail)(nil),                             // 118: agentcompose.v2.RunDetail
-	(*ExecRequest)(nil),                           // 119: agentcompose.v2.ExecRequest
-	(*ExecSandboxSelector)(nil),                   // 120: agentcompose.v2.ExecSandboxSelector
-	(*ExecCommand)(nil),                           // 121: agentcompose.v2.ExecCommand
-	(*ExecResponse)(nil),                          // 122: agentcompose.v2.ExecResponse
-	(*ExecStreamResponse)(nil),                    // 123: agentcompose.v2.ExecStreamResponse
-	(*ExecAttachRequest)(nil),                     // 124: agentcompose.v2.ExecAttachRequest
-	(*ExecAttachResponse)(nil),                    // 125: agentcompose.v2.ExecAttachResponse
-	(*ExecAttachStart)(nil),                       // 126: agentcompose.v2.ExecAttachStart
-	(*AttachTerminalSize)(nil),                    // 127: agentcompose.v2.AttachTerminalSize
-	(*AttachStdin)(nil),                           // 128: agentcompose.v2.AttachStdin
-	(*AttachStdinEOF)(nil),                        // 129: agentcompose.v2.AttachStdinEOF
-	(*AttachResize)(nil),                          // 130: agentcompose.v2.AttachResize
-	(*AttachSignal)(nil),                          // 131: agentcompose.v2.AttachSignal
-	(*AttachHumanMessage)(nil),                    // 132: agentcompose.v2.AttachHumanMessage
-	(*AttachCancel)(nil),                          // 133: agentcompose.v2.AttachCancel
-	(*AttachStarted)(nil),                         // 134: agentcompose.v2.AttachStarted
-	(*AttachOutput)(nil),                          // 135: agentcompose.v2.AttachOutput
-	(*AttachAgentEvent)(nil),                      // 136: agentcompose.v2.AttachAgentEvent
-	(*AttachAgentTurnCompleted)(nil),              // 137: agentcompose.v2.AttachAgentTurnCompleted
-	(*AttachResult)(nil),                          // 138: agentcompose.v2.AttachResult
-	(*AttachError)(nil),                           // 139: agentcompose.v2.AttachError
-	(*ExecResult)(nil),                            // 140: agentcompose.v2.ExecResult
-	(*ListImagesRequest)(nil),                     // 141: agentcompose.v2.ListImagesRequest
-	(*ListImagesResponse)(nil),                    // 142: agentcompose.v2.ListImagesResponse
-	(*PullImageRequest)(nil),                      // 143: agentcompose.v2.PullImageRequest
-	(*PullImageResponse)(nil),                     // 144: agentcompose.v2.PullImageResponse
-	(*InspectImageRequest)(nil),                   // 145: agentcompose.v2.InspectImageRequest
-	(*InspectImageResponse)(nil),                  // 146: agentcompose.v2.InspectImageResponse
-	(*RemoveImageRequest)(nil),                    // 147: agentcompose.v2.RemoveImageRequest
-	(*RemoveImageResponse)(nil),                   // 148: agentcompose.v2.RemoveImageResponse
-	(*BuildImageRequest)(nil),                     // 149: agentcompose.v2.BuildImageRequest
-	(*BuildImageEvent)(nil),                       // 150: agentcompose.v2.BuildImageEvent
-	(*CacheFilter)(nil),                           // 151: agentcompose.v2.CacheFilter
-	(*ListCachesRequest)(nil),                     // 152: agentcompose.v2.ListCachesRequest
-	(*ListCachesResponse)(nil),                    // 153: agentcompose.v2.ListCachesResponse
-	(*InspectCacheRequest)(nil),                   // 154: agentcompose.v2.InspectCacheRequest
-	(*InspectCacheResponse)(nil),                  // 155: agentcompose.v2.InspectCacheResponse
-	(*PruneCachesRequest)(nil),                    // 156: agentcompose.v2.PruneCachesRequest
-	(*PruneCachesResponse)(nil),                   // 157: agentcompose.v2.PruneCachesResponse
-	(*RemoveCacheRequest)(nil),                    // 158: agentcompose.v2.RemoveCacheRequest
-	(*RemoveCacheResponse)(nil),                   // 159: agentcompose.v2.RemoveCacheResponse
-	(*CacheItem)(nil),                             // 160: agentcompose.v2.CacheItem
-	(*CacheReference)(nil),                        // 161: agentcompose.v2.CacheReference
-	(*ListVolumesRequest)(nil),                    // 162: agentcompose.v2.ListVolumesRequest
-	(*ListVolumesResponse)(nil),                   // 163: agentcompose.v2.ListVolumesResponse
-	(*CreateVolumeRequest)(nil),                   // 164: agentcompose.v2.CreateVolumeRequest
-	(*CreateVolumeResponse)(nil),                  // 165: agentcompose.v2.CreateVolumeResponse
-	(*InspectVolumeRequest)(nil),                  // 166: agentcompose.v2.InspectVolumeRequest
-	(*InspectVolumeResponse)(nil),                 // 167: agentcompose.v2.InspectVolumeResponse
-	(*RemoveVolumeRequest)(nil),                   // 168: agentcompose.v2.RemoveVolumeRequest
-	(*RemoveVolumeResponse)(nil),                  // 169: agentcompose.v2.RemoveVolumeResponse
-	(*PruneVolumesRequest)(nil),                   // 170: agentcompose.v2.PruneVolumesRequest
-	(*PruneVolumesResponse)(nil),                  // 171: agentcompose.v2.PruneVolumesResponse
-	(*Volume)(nil),                                // 172: agentcompose.v2.Volume
-	(*Image)(nil),                                 // 173: agentcompose.v2.Image
-	(*ImagePlatform)(nil),                         // 174: agentcompose.v2.ImagePlatform
-	(*ImageStoreStatus)(nil),                      // 175: agentcompose.v2.ImageStoreStatus
-	(*DockerImageStatus)(nil),                     // 176: agentcompose.v2.DockerImageStatus
-	(*OCIImageStatus)(nil),                        // 177: agentcompose.v2.OCIImageStatus
-	(*ImagePullProgress)(nil),                     // 178: agentcompose.v2.ImagePullProgress
-	(*JupyterSpec)(nil),                           // 179: agentcompose.v2.JupyterSpec
-	(*RunJupyterSpec)(nil),                        // 180: agentcompose.v2.RunJupyterSpec
-	(*StartRunRequest)(nil),                       // 181: agentcompose.v2.StartRunRequest
-	(*StartRunResponse)(nil),                      // 182: agentcompose.v2.StartRunResponse
-	(*SkillSpec)(nil),                             // 183: agentcompose.v2.SkillSpec
-	(*ResolveResourceIDRequest)(nil),              // 184: agentcompose.v2.ResolveResourceIDRequest
-	(*ResolveResourceIDResponse)(nil),             // 185: agentcompose.v2.ResolveResourceIDResponse
-	(*ResourceTarget)(nil),                        // 186: agentcompose.v2.ResourceTarget
-	(*GetDashboardOverviewRequest)(nil),           // 187: agentcompose.v2.GetDashboardOverviewRequest
-	(*WatchDashboardOverviewRequest)(nil),         // 188: agentcompose.v2.WatchDashboardOverviewRequest
-	(*RunOverview)(nil),                           // 189: agentcompose.v2.RunOverview
-	(*DashboardOverview)(nil),                     // 190: agentcompose.v2.DashboardOverview
-	(*GetDashboardOverviewResponse)(nil),          // 191: agentcompose.v2.GetDashboardOverviewResponse
-	(*WatchDashboardOverviewResponse)(nil),        // 192: agentcompose.v2.WatchDashboardOverviewResponse
-	(*GetGlobalEnvRequest)(nil),                   // 193: agentcompose.v2.GetGlobalEnvRequest
-	(*GetGlobalEnvResponse)(nil),                  // 194: agentcompose.v2.GetGlobalEnvResponse
-	(*UpdateGlobalEnvRequest)(nil),                // 195: agentcompose.v2.UpdateGlobalEnvRequest
-	(*UpdateGlobalEnvResponse)(nil),               // 196: agentcompose.v2.UpdateGlobalEnvResponse
-	(*GetCapabilityGatewayConfigRequest)(nil),     // 197: agentcompose.v2.GetCapabilityGatewayConfigRequest
-	(*CapabilityGatewayConfig)(nil),               // 198: agentcompose.v2.CapabilityGatewayConfig
-	(*GetCapabilityGatewayConfigResponse)(nil),    // 199: agentcompose.v2.GetCapabilityGatewayConfigResponse
-	(*UpdateCapabilityGatewayConfigRequest)(nil),  // 200: agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	(*UpdateCapabilityGatewayConfigResponse)(nil), // 201: agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	(*WorkspacePreset)(nil),                       // 202: agentcompose.v2.WorkspacePreset
-	(*ListWorkspacePresetsRequest)(nil),           // 203: agentcompose.v2.ListWorkspacePresetsRequest
-	(*ListWorkspacePresetsResponse)(nil),          // 204: agentcompose.v2.ListWorkspacePresetsResponse
-	(*CreateWorkspacePresetRequest)(nil),          // 205: agentcompose.v2.CreateWorkspacePresetRequest
-	(*UpdateWorkspacePresetRequest)(nil),          // 206: agentcompose.v2.UpdateWorkspacePresetRequest
-	(*DeleteWorkspacePresetRequest)(nil),          // 207: agentcompose.v2.DeleteWorkspacePresetRequest
-	(*DeleteWorkspacePresetResponse)(nil),         // 208: agentcompose.v2.DeleteWorkspacePresetResponse
-	(*WorkspacePresetResponse)(nil),               // 209: agentcompose.v2.WorkspacePresetResponse
-	(*GetCapabilityStatusRequest)(nil),            // 210: agentcompose.v2.GetCapabilityStatusRequest
-	(*CapabilityStatusResponse)(nil),              // 211: agentcompose.v2.CapabilityStatusResponse
-	(*ListCapabilitySetsRequest)(nil),             // 212: agentcompose.v2.ListCapabilitySetsRequest
-	(*CapabilitySet)(nil),                         // 213: agentcompose.v2.CapabilitySet
-	(*ListCapabilitySetsResponse)(nil),            // 214: agentcompose.v2.ListCapabilitySetsResponse
-	(*GetCapabilityCatalogRequest)(nil),           // 215: agentcompose.v2.GetCapabilityCatalogRequest
-	(*CapabilityEndpoint)(nil),                    // 216: agentcompose.v2.CapabilityEndpoint
-	(*CapabilityMethod)(nil),                      // 217: agentcompose.v2.CapabilityMethod
-	(*GetCapabilityCatalogResponse)(nil),          // 218: agentcompose.v2.GetCapabilityCatalogResponse
-	(*ListSandboxHistoryRequest)(nil),             // 219: agentcompose.v2.ListSandboxHistoryRequest
-	(*SandboxHistoryCell)(nil),                    // 220: agentcompose.v2.SandboxHistoryCell
-	(*SandboxHistoryEvent)(nil),                   // 221: agentcompose.v2.SandboxHistoryEvent
-	(*ListSandboxHistoryResponse)(nil),            // 222: agentcompose.v2.ListSandboxHistoryResponse
-	(*WatchSandboxRequest)(nil),                   // 223: agentcompose.v2.WatchSandboxRequest
-	(*WatchSandboxResponse)(nil),                  // 224: agentcompose.v2.WatchSandboxResponse
-	(*GenerateLLMRequest)(nil),                    // 225: agentcompose.v2.GenerateLLMRequest
-	(*GenerateLLMResponse)(nil),                   // 226: agentcompose.v2.GenerateLLMResponse
-	nil,                                           // 227: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                                           // 228: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                                           // 229: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                                           // 230: agentcompose.v2.AttachHumanMessage.MetadataEntry
-	nil,                                           // 231: agentcompose.v2.AttachError.DetailsEntry
-	nil,                                           // 232: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                                           // 233: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                                           // 234: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                                           // 235: agentcompose.v2.Volume.LabelsEntry
-	nil,                                           // 236: agentcompose.v2.Volume.OptionsEntry
-	nil,                                           // 237: agentcompose.v2.Image.LabelsEntry
-	nil,                                           // 238: agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	(*timestamppb.Timestamp)(nil),                 // 239: google.protobuf.Timestamp
+	(SchedulerRunStatus)(0),                       // 5: agentcompose.v2.SchedulerRunStatus
+	(AgentStatus)(0),                              // 6: agentcompose.v2.AgentStatus
+	(ProjectAgentAvailability)(0),                 // 7: agentcompose.v2.ProjectAgentAvailability
+	(ProjectAgentHealth)(0),                       // 8: agentcompose.v2.ProjectAgentHealth
+	(RunEventKind)(0),                             // 9: agentcompose.v2.RunEventKind
+	(RunAgentStreamEventType)(0),                  // 10: agentcompose.v2.RunAgentStreamEventType
+	(RunSandboxCleanupPolicy)(0),                  // 11: agentcompose.v2.RunSandboxCleanupPolicy
+	(ExecStreamEventType)(0),                      // 12: agentcompose.v2.ExecStreamEventType
+	(AttachRunMode)(0),                            // 13: agentcompose.v2.AttachRunMode
+	(StdioStream)(0),                              // 14: agentcompose.v2.StdioStream
+	(ImageStoreKind)(0),                           // 15: agentcompose.v2.ImageStoreKind
+	(ImageAvailabilityStatus)(0),                  // 16: agentcompose.v2.ImageAvailabilityStatus
+	(ImageOperationStatus)(0),                     // 17: agentcompose.v2.ImageOperationStatus
+	(MetricStatus)(0),                             // 18: agentcompose.v2.MetricStatus
+	(CacheDomain)(0),                              // 19: agentcompose.v2.CacheDomain
+	(CacheReferencePolicy)(0),                     // 20: agentcompose.v2.CacheReferencePolicy
+	(SandboxPruneCandidateKind)(0),                // 21: agentcompose.v2.SandboxPruneCandidateKind
+	(CacheStatus)(0),                              // 22: agentcompose.v2.CacheStatus
+	(ResourceKind)(0),                             // 23: agentcompose.v2.ResourceKind
+	(SandboxWatchEventType)(0),                    // 24: agentcompose.v2.SandboxWatchEventType
+	(*ValidateProjectRequest)(nil),                // 25: agentcompose.v2.ValidateProjectRequest
+	(*ValidateProjectResponse)(nil),               // 26: agentcompose.v2.ValidateProjectResponse
+	(*ApplyProjectRequest)(nil),                   // 27: agentcompose.v2.ApplyProjectRequest
+	(*ApplyProjectResponse)(nil),                  // 28: agentcompose.v2.ApplyProjectResponse
+	(*GetProjectRequest)(nil),                     // 29: agentcompose.v2.GetProjectRequest
+	(*GetProjectResponse)(nil),                    // 30: agentcompose.v2.GetProjectResponse
+	(*ListProjectsRequest)(nil),                   // 31: agentcompose.v2.ListProjectsRequest
+	(*ListProjectsResponse)(nil),                  // 32: agentcompose.v2.ListProjectsResponse
+	(*RemoveProjectRequest)(nil),                  // 33: agentcompose.v2.RemoveProjectRequest
+	(*RemoveProjectResponse)(nil),                 // 34: agentcompose.v2.RemoveProjectResponse
+	(*WatchProjectRequest)(nil),                   // 35: agentcompose.v2.WatchProjectRequest
+	(*WatchProjectResponse)(nil),                  // 36: agentcompose.v2.WatchProjectResponse
+	(*ProjectRef)(nil),                            // 37: agentcompose.v2.ProjectRef
+	(*ProjectSource)(nil),                         // 38: agentcompose.v2.ProjectSource
+	(*Project)(nil),                               // 39: agentcompose.v2.Project
+	(*ProjectSummary)(nil),                        // 40: agentcompose.v2.ProjectSummary
+	(*ProjectRevision)(nil),                       // 41: agentcompose.v2.ProjectRevision
+	(*ProjectAgent)(nil),                          // 42: agentcompose.v2.ProjectAgent
+	(*ProjectAgentCurrentRun)(nil),                // 43: agentcompose.v2.ProjectAgentCurrentRun
+	(*ProjectAgentLatestRun)(nil),                 // 44: agentcompose.v2.ProjectAgentLatestRun
+	(*ProjectScheduler)(nil),                      // 45: agentcompose.v2.ProjectScheduler
+	(*GetSchedulerRequest)(nil),                   // 46: agentcompose.v2.GetSchedulerRequest
+	(*GetSchedulerResponse)(nil),                  // 47: agentcompose.v2.GetSchedulerResponse
+	(*ResolvedTrigger)(nil),                       // 48: agentcompose.v2.ResolvedTrigger
+	(*ListSchedulersRequest)(nil),                 // 49: agentcompose.v2.ListSchedulersRequest
+	(*SchedulerSummary)(nil),                      // 50: agentcompose.v2.SchedulerSummary
+	(*ListSchedulersResponse)(nil),                // 51: agentcompose.v2.ListSchedulersResponse
+	(*ListSchedulerEventsRequest)(nil),            // 52: agentcompose.v2.ListSchedulerEventsRequest
+	(*SchedulerEvent)(nil),                        // 53: agentcompose.v2.SchedulerEvent
+	(*ListSchedulerEventsResponse)(nil),           // 54: agentcompose.v2.ListSchedulerEventsResponse
+	(*RunSchedulerRequest)(nil),                   // 55: agentcompose.v2.RunSchedulerRequest
+	(*RunSchedulerResponse)(nil),                  // 56: agentcompose.v2.RunSchedulerResponse
+	(*StartSchedulerRunRequest)(nil),              // 57: agentcompose.v2.StartSchedulerRunRequest
+	(*StartSchedulerRunResponse)(nil),             // 58: agentcompose.v2.StartSchedulerRunResponse
+	(*GetSchedulerRunRequest)(nil),                // 59: agentcompose.v2.GetSchedulerRunRequest
+	(*GetSchedulerRunResponse)(nil),               // 60: agentcompose.v2.GetSchedulerRunResponse
+	(*ListSchedulerRunsRequest)(nil),              // 61: agentcompose.v2.ListSchedulerRunsRequest
+	(*ListSchedulerRunsResponse)(nil),             // 62: agentcompose.v2.ListSchedulerRunsResponse
+	(*StopSchedulerRunRequest)(nil),               // 63: agentcompose.v2.StopSchedulerRunRequest
+	(*StopSchedulerRunResponse)(nil),              // 64: agentcompose.v2.StopSchedulerRunResponse
+	(*SchedulerRun)(nil),                          // 65: agentcompose.v2.SchedulerRun
+	(*SetSchedulerEnabledRequest)(nil),            // 66: agentcompose.v2.SetSchedulerEnabledRequest
+	(*SetSchedulerEnabledResponse)(nil),           // 67: agentcompose.v2.SetSchedulerEnabledResponse
+	(*SetSchedulerTriggerEnabledRequest)(nil),     // 68: agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	(*SetSchedulerTriggerEnabledResponse)(nil),    // 69: agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	(*ProjectValidationIssue)(nil),                // 70: agentcompose.v2.ProjectValidationIssue
+	(*ProjectChange)(nil),                         // 71: agentcompose.v2.ProjectChange
+	(*ProjectSpec)(nil),                           // 72: agentcompose.v2.ProjectSpec
+	(*NamedWorkspaceSpec)(nil),                    // 73: agentcompose.v2.NamedWorkspaceSpec
+	(*AgentSpec)(nil),                             // 74: agentcompose.v2.AgentSpec
+	(*MCPServerSpec)(nil),                         // 75: agentcompose.v2.MCPServerSpec
+	(*ProjectVolumeSpec)(nil),                     // 76: agentcompose.v2.ProjectVolumeSpec
+	(*VolumeMountSpec)(nil),                       // 77: agentcompose.v2.VolumeMountSpec
+	(*BuildSpec)(nil),                             // 78: agentcompose.v2.BuildSpec
+	(*EnvVarSpec)(nil),                            // 79: agentcompose.v2.EnvVarSpec
+	(*EnvVarUpdateSpec)(nil),                      // 80: agentcompose.v2.EnvVarUpdateSpec
+	(*WorkspaceSpec)(nil),                         // 81: agentcompose.v2.WorkspaceSpec
+	(*NetworkSpec)(nil),                           // 82: agentcompose.v2.NetworkSpec
+	(*SchedulerSpec)(nil),                         // 83: agentcompose.v2.SchedulerSpec
+	(*TriggerSpec)(nil),                           // 84: agentcompose.v2.TriggerSpec
+	(*EventTriggerSpec)(nil),                      // 85: agentcompose.v2.EventTriggerSpec
+	(*DriverSpec)(nil),                            // 86: agentcompose.v2.DriverSpec
+	(*BoxliteDriverSpec)(nil),                     // 87: agentcompose.v2.BoxliteDriverSpec
+	(*DockerDriverSpec)(nil),                      // 88: agentcompose.v2.DockerDriverSpec
+	(*MicrosandboxDriverSpec)(nil),                // 89: agentcompose.v2.MicrosandboxDriverSpec
+	(*RunAgentRequest)(nil),                       // 90: agentcompose.v2.RunAgentRequest
+	(*RunAgentResponse)(nil),                      // 91: agentcompose.v2.RunAgentResponse
+	(*RunAgentStreamResponse)(nil),                // 92: agentcompose.v2.RunAgentStreamResponse
+	(*RunAttachRequest)(nil),                      // 93: agentcompose.v2.RunAttachRequest
+	(*RunAttachResponse)(nil),                     // 94: agentcompose.v2.RunAttachResponse
+	(*RunAttachStart)(nil),                        // 95: agentcompose.v2.RunAttachStart
+	(*TranscriptEvent)(nil),                       // 96: agentcompose.v2.TranscriptEvent
+	(*GetRunRequest)(nil),                         // 97: agentcompose.v2.GetRunRequest
+	(*GetRunResponse)(nil),                        // 98: agentcompose.v2.GetRunResponse
+	(*ListRunsRequest)(nil),                       // 99: agentcompose.v2.ListRunsRequest
+	(*ListRunsResponse)(nil),                      // 100: agentcompose.v2.ListRunsResponse
+	(*FollowRunLogsRequest)(nil),                  // 101: agentcompose.v2.FollowRunLogsRequest
+	(*RunLogChunk)(nil),                           // 102: agentcompose.v2.RunLogChunk
+	(*StopRunRequest)(nil),                        // 103: agentcompose.v2.StopRunRequest
+	(*StopRunResponse)(nil),                       // 104: agentcompose.v2.StopRunResponse
+	(*ListRunEventsRequest)(nil),                  // 105: agentcompose.v2.ListRunEventsRequest
+	(*RunEvent)(nil),                              // 106: agentcompose.v2.RunEvent
+	(*ListRunEventsResponse)(nil),                 // 107: agentcompose.v2.ListRunEventsResponse
+	(*ListSandboxRunEventsRequest)(nil),           // 108: agentcompose.v2.ListSandboxRunEventsRequest
+	(*ListSandboxRunEventsResponse)(nil),          // 109: agentcompose.v2.ListSandboxRunEventsResponse
+	(*RemoveSandboxRequest)(nil),                  // 110: agentcompose.v2.RemoveSandboxRequest
+	(*RemoveSandboxResponse)(nil),                 // 111: agentcompose.v2.RemoveSandboxResponse
+	(*PruneSandboxesRequest)(nil),                 // 112: agentcompose.v2.PruneSandboxesRequest
+	(*SandboxPruneCandidate)(nil),                 // 113: agentcompose.v2.SandboxPruneCandidate
+	(*PruneSandboxesResponse)(nil),                // 114: agentcompose.v2.PruneSandboxesResponse
+	(*GetSandboxStatsRequest)(nil),                // 115: agentcompose.v2.GetSandboxStatsRequest
+	(*GetSandboxStatsResponse)(nil),               // 116: agentcompose.v2.GetSandboxStatsResponse
+	(*GetSandboxRequest)(nil),                     // 117: agentcompose.v2.GetSandboxRequest
+	(*Sandbox)(nil),                               // 118: agentcompose.v2.Sandbox
+	(*SandboxTag)(nil),                            // 119: agentcompose.v2.SandboxTag
+	(*ListSandboxesRequest)(nil),                  // 120: agentcompose.v2.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),                 // 121: agentcompose.v2.ListSandboxesResponse
+	(*GetSandboxResponse)(nil),                    // 122: agentcompose.v2.GetSandboxResponse
+	(*StopSandboxRequest)(nil),                    // 123: agentcompose.v2.StopSandboxRequest
+	(*StopSandboxResponse)(nil),                   // 124: agentcompose.v2.StopSandboxResponse
+	(*ResumeSandboxRequest)(nil),                  // 125: agentcompose.v2.ResumeSandboxRequest
+	(*ResumeSandboxResponse)(nil),                 // 126: agentcompose.v2.ResumeSandboxResponse
+	(*MetricValue)(nil),                           // 127: agentcompose.v2.MetricValue
+	(*SandboxStats)(nil),                          // 128: agentcompose.v2.SandboxStats
+	(*RunSummary)(nil),                            // 129: agentcompose.v2.RunSummary
+	(*RunDetail)(nil),                             // 130: agentcompose.v2.RunDetail
+	(*ExecRequest)(nil),                           // 131: agentcompose.v2.ExecRequest
+	(*ExecSandboxSelector)(nil),                   // 132: agentcompose.v2.ExecSandboxSelector
+	(*ExecCommand)(nil),                           // 133: agentcompose.v2.ExecCommand
+	(*ExecResponse)(nil),                          // 134: agentcompose.v2.ExecResponse
+	(*ExecStreamResponse)(nil),                    // 135: agentcompose.v2.ExecStreamResponse
+	(*ExecAttachRequest)(nil),                     // 136: agentcompose.v2.ExecAttachRequest
+	(*ExecAttachResponse)(nil),                    // 137: agentcompose.v2.ExecAttachResponse
+	(*ExecAttachStart)(nil),                       // 138: agentcompose.v2.ExecAttachStart
+	(*AttachTerminalSize)(nil),                    // 139: agentcompose.v2.AttachTerminalSize
+	(*AttachStdin)(nil),                           // 140: agentcompose.v2.AttachStdin
+	(*AttachStdinEOF)(nil),                        // 141: agentcompose.v2.AttachStdinEOF
+	(*AttachResize)(nil),                          // 142: agentcompose.v2.AttachResize
+	(*AttachSignal)(nil),                          // 143: agentcompose.v2.AttachSignal
+	(*AttachHumanMessage)(nil),                    // 144: agentcompose.v2.AttachHumanMessage
+	(*AttachCancel)(nil),                          // 145: agentcompose.v2.AttachCancel
+	(*AttachStarted)(nil),                         // 146: agentcompose.v2.AttachStarted
+	(*AttachOutput)(nil),                          // 147: agentcompose.v2.AttachOutput
+	(*AttachAgentEvent)(nil),                      // 148: agentcompose.v2.AttachAgentEvent
+	(*AttachAgentTurnCompleted)(nil),              // 149: agentcompose.v2.AttachAgentTurnCompleted
+	(*AttachResult)(nil),                          // 150: agentcompose.v2.AttachResult
+	(*AttachError)(nil),                           // 151: agentcompose.v2.AttachError
+	(*ExecResult)(nil),                            // 152: agentcompose.v2.ExecResult
+	(*ListImagesRequest)(nil),                     // 153: agentcompose.v2.ListImagesRequest
+	(*ListImagesResponse)(nil),                    // 154: agentcompose.v2.ListImagesResponse
+	(*PullImageRequest)(nil),                      // 155: agentcompose.v2.PullImageRequest
+	(*PullImageResponse)(nil),                     // 156: agentcompose.v2.PullImageResponse
+	(*InspectImageRequest)(nil),                   // 157: agentcompose.v2.InspectImageRequest
+	(*InspectImageResponse)(nil),                  // 158: agentcompose.v2.InspectImageResponse
+	(*RemoveImageRequest)(nil),                    // 159: agentcompose.v2.RemoveImageRequest
+	(*RemoveImageResponse)(nil),                   // 160: agentcompose.v2.RemoveImageResponse
+	(*BuildImageRequest)(nil),                     // 161: agentcompose.v2.BuildImageRequest
+	(*BuildImageEvent)(nil),                       // 162: agentcompose.v2.BuildImageEvent
+	(*CacheFilter)(nil),                           // 163: agentcompose.v2.CacheFilter
+	(*ListCachesRequest)(nil),                     // 164: agentcompose.v2.ListCachesRequest
+	(*ListCachesResponse)(nil),                    // 165: agentcompose.v2.ListCachesResponse
+	(*InspectCacheRequest)(nil),                   // 166: agentcompose.v2.InspectCacheRequest
+	(*InspectCacheResponse)(nil),                  // 167: agentcompose.v2.InspectCacheResponse
+	(*PruneCachesRequest)(nil),                    // 168: agentcompose.v2.PruneCachesRequest
+	(*PruneCachesResponse)(nil),                   // 169: agentcompose.v2.PruneCachesResponse
+	(*RemoveCacheRequest)(nil),                    // 170: agentcompose.v2.RemoveCacheRequest
+	(*RemoveCacheResponse)(nil),                   // 171: agentcompose.v2.RemoveCacheResponse
+	(*CacheItem)(nil),                             // 172: agentcompose.v2.CacheItem
+	(*CacheReference)(nil),                        // 173: agentcompose.v2.CacheReference
+	(*ListVolumesRequest)(nil),                    // 174: agentcompose.v2.ListVolumesRequest
+	(*ListVolumesResponse)(nil),                   // 175: agentcompose.v2.ListVolumesResponse
+	(*CreateVolumeRequest)(nil),                   // 176: agentcompose.v2.CreateVolumeRequest
+	(*CreateVolumeResponse)(nil),                  // 177: agentcompose.v2.CreateVolumeResponse
+	(*InspectVolumeRequest)(nil),                  // 178: agentcompose.v2.InspectVolumeRequest
+	(*InspectVolumeResponse)(nil),                 // 179: agentcompose.v2.InspectVolumeResponse
+	(*RemoveVolumeRequest)(nil),                   // 180: agentcompose.v2.RemoveVolumeRequest
+	(*RemoveVolumeResponse)(nil),                  // 181: agentcompose.v2.RemoveVolumeResponse
+	(*PruneVolumesRequest)(nil),                   // 182: agentcompose.v2.PruneVolumesRequest
+	(*PruneVolumesResponse)(nil),                  // 183: agentcompose.v2.PruneVolumesResponse
+	(*Volume)(nil),                                // 184: agentcompose.v2.Volume
+	(*Image)(nil),                                 // 185: agentcompose.v2.Image
+	(*ImagePlatform)(nil),                         // 186: agentcompose.v2.ImagePlatform
+	(*ImageStoreStatus)(nil),                      // 187: agentcompose.v2.ImageStoreStatus
+	(*DockerImageStatus)(nil),                     // 188: agentcompose.v2.DockerImageStatus
+	(*OCIImageStatus)(nil),                        // 189: agentcompose.v2.OCIImageStatus
+	(*ImagePullProgress)(nil),                     // 190: agentcompose.v2.ImagePullProgress
+	(*JupyterSpec)(nil),                           // 191: agentcompose.v2.JupyterSpec
+	(*RunJupyterSpec)(nil),                        // 192: agentcompose.v2.RunJupyterSpec
+	(*StartRunRequest)(nil),                       // 193: agentcompose.v2.StartRunRequest
+	(*StartRunResponse)(nil),                      // 194: agentcompose.v2.StartRunResponse
+	(*SkillSpec)(nil),                             // 195: agentcompose.v2.SkillSpec
+	(*ResolveResourceIDRequest)(nil),              // 196: agentcompose.v2.ResolveResourceIDRequest
+	(*ResolveResourceIDResponse)(nil),             // 197: agentcompose.v2.ResolveResourceIDResponse
+	(*ResourceTarget)(nil),                        // 198: agentcompose.v2.ResourceTarget
+	(*GetDashboardOverviewRequest)(nil),           // 199: agentcompose.v2.GetDashboardOverviewRequest
+	(*WatchDashboardOverviewRequest)(nil),         // 200: agentcompose.v2.WatchDashboardOverviewRequest
+	(*RunOverview)(nil),                           // 201: agentcompose.v2.RunOverview
+	(*DashboardOverview)(nil),                     // 202: agentcompose.v2.DashboardOverview
+	(*GetDashboardOverviewResponse)(nil),          // 203: agentcompose.v2.GetDashboardOverviewResponse
+	(*WatchDashboardOverviewResponse)(nil),        // 204: agentcompose.v2.WatchDashboardOverviewResponse
+	(*GetGlobalEnvRequest)(nil),                   // 205: agentcompose.v2.GetGlobalEnvRequest
+	(*GetGlobalEnvResponse)(nil),                  // 206: agentcompose.v2.GetGlobalEnvResponse
+	(*UpdateGlobalEnvRequest)(nil),                // 207: agentcompose.v2.UpdateGlobalEnvRequest
+	(*UpdateGlobalEnvResponse)(nil),               // 208: agentcompose.v2.UpdateGlobalEnvResponse
+	(*GetCapabilityGatewayConfigRequest)(nil),     // 209: agentcompose.v2.GetCapabilityGatewayConfigRequest
+	(*CapabilityGatewayConfig)(nil),               // 210: agentcompose.v2.CapabilityGatewayConfig
+	(*GetCapabilityGatewayConfigResponse)(nil),    // 211: agentcompose.v2.GetCapabilityGatewayConfigResponse
+	(*UpdateCapabilityGatewayConfigRequest)(nil),  // 212: agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	(*UpdateCapabilityGatewayConfigResponse)(nil), // 213: agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	(*WorkspacePreset)(nil),                       // 214: agentcompose.v2.WorkspacePreset
+	(*ListWorkspacePresetsRequest)(nil),           // 215: agentcompose.v2.ListWorkspacePresetsRequest
+	(*ListWorkspacePresetsResponse)(nil),          // 216: agentcompose.v2.ListWorkspacePresetsResponse
+	(*CreateWorkspacePresetRequest)(nil),          // 217: agentcompose.v2.CreateWorkspacePresetRequest
+	(*UpdateWorkspacePresetRequest)(nil),          // 218: agentcompose.v2.UpdateWorkspacePresetRequest
+	(*DeleteWorkspacePresetRequest)(nil),          // 219: agentcompose.v2.DeleteWorkspacePresetRequest
+	(*DeleteWorkspacePresetResponse)(nil),         // 220: agentcompose.v2.DeleteWorkspacePresetResponse
+	(*WorkspacePresetResponse)(nil),               // 221: agentcompose.v2.WorkspacePresetResponse
+	(*GetCapabilityStatusRequest)(nil),            // 222: agentcompose.v2.GetCapabilityStatusRequest
+	(*CapabilityStatusResponse)(nil),              // 223: agentcompose.v2.CapabilityStatusResponse
+	(*ListCapabilitySetsRequest)(nil),             // 224: agentcompose.v2.ListCapabilitySetsRequest
+	(*CapabilitySet)(nil),                         // 225: agentcompose.v2.CapabilitySet
+	(*ListCapabilitySetsResponse)(nil),            // 226: agentcompose.v2.ListCapabilitySetsResponse
+	(*GetCapabilityCatalogRequest)(nil),           // 227: agentcompose.v2.GetCapabilityCatalogRequest
+	(*CapabilityEndpoint)(nil),                    // 228: agentcompose.v2.CapabilityEndpoint
+	(*CapabilityMethod)(nil),                      // 229: agentcompose.v2.CapabilityMethod
+	(*GetCapabilityCatalogResponse)(nil),          // 230: agentcompose.v2.GetCapabilityCatalogResponse
+	(*ListSandboxHistoryRequest)(nil),             // 231: agentcompose.v2.ListSandboxHistoryRequest
+	(*SandboxHistoryCell)(nil),                    // 232: agentcompose.v2.SandboxHistoryCell
+	(*SandboxHistoryEvent)(nil),                   // 233: agentcompose.v2.SandboxHistoryEvent
+	(*ListSandboxHistoryResponse)(nil),            // 234: agentcompose.v2.ListSandboxHistoryResponse
+	(*WatchSandboxRequest)(nil),                   // 235: agentcompose.v2.WatchSandboxRequest
+	(*WatchSandboxResponse)(nil),                  // 236: agentcompose.v2.WatchSandboxResponse
+	(*GenerateLLMRequest)(nil),                    // 237: agentcompose.v2.GenerateLLMRequest
+	(*GenerateLLMResponse)(nil),                   // 238: agentcompose.v2.GenerateLLMResponse
+	nil,                                           // 239: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                                           // 240: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                                           // 241: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                                           // 242: agentcompose.v2.AttachHumanMessage.MetadataEntry
+	nil,                                           // 243: agentcompose.v2.AttachError.DetailsEntry
+	nil,                                           // 244: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                                           // 245: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                                           // 246: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                                           // 247: agentcompose.v2.Volume.LabelsEntry
+	nil,                                           // 248: agentcompose.v2.Volume.OptionsEntry
+	nil,                                           // 249: agentcompose.v2.Image.LabelsEntry
+	nil,                                           // 250: agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	(*timestamppb.Timestamp)(nil),                 // 251: google.protobuf.Timestamp
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
-	60,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
-	37,  // 1: agentcompose.v2.ValidateProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
-	58,  // 2: agentcompose.v2.ValidateProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
-	60,  // 3: agentcompose.v2.ApplyProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
-	37,  // 4: agentcompose.v2.ApplyProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
-	38,  // 5: agentcompose.v2.ApplyProjectResponse.project:type_name -> agentcompose.v2.Project
-	40,  // 6: agentcompose.v2.ApplyProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
-	59,  // 7: agentcompose.v2.ApplyProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
-	58,  // 8: agentcompose.v2.ApplyProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
-	36,  // 9: agentcompose.v2.GetProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
-	38,  // 10: agentcompose.v2.GetProjectResponse.project:type_name -> agentcompose.v2.Project
-	39,  // 11: agentcompose.v2.ListProjectsResponse.projects:type_name -> agentcompose.v2.ProjectSummary
-	36,  // 12: agentcompose.v2.RemoveProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
-	38,  // 13: agentcompose.v2.RemoveProjectResponse.project:type_name -> agentcompose.v2.Project
-	59,  // 14: agentcompose.v2.RemoveProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
-	36,  // 15: agentcompose.v2.WatchProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
+	72,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
+	38,  // 1: agentcompose.v2.ValidateProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
+	70,  // 2: agentcompose.v2.ValidateProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
+	72,  // 3: agentcompose.v2.ApplyProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
+	38,  // 4: agentcompose.v2.ApplyProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
+	39,  // 5: agentcompose.v2.ApplyProjectResponse.project:type_name -> agentcompose.v2.Project
+	41,  // 6: agentcompose.v2.ApplyProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
+	71,  // 7: agentcompose.v2.ApplyProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	70,  // 8: agentcompose.v2.ApplyProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
+	37,  // 9: agentcompose.v2.GetProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
+	39,  // 10: agentcompose.v2.GetProjectResponse.project:type_name -> agentcompose.v2.Project
+	40,  // 11: agentcompose.v2.ListProjectsResponse.projects:type_name -> agentcompose.v2.ProjectSummary
+	37,  // 12: agentcompose.v2.RemoveProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
+	39,  // 13: agentcompose.v2.RemoveProjectResponse.project:type_name -> agentcompose.v2.Project
+	71,  // 14: agentcompose.v2.RemoveProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	37,  // 15: agentcompose.v2.WatchProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
 	2,   // 16: agentcompose.v2.WatchProjectResponse.type:type_name -> agentcompose.v2.ProjectWatchEventType
-	38,  // 17: agentcompose.v2.WatchProjectResponse.project:type_name -> agentcompose.v2.Project
-	40,  // 18: agentcompose.v2.WatchProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
-	59,  // 19: agentcompose.v2.WatchProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
-	39,  // 20: agentcompose.v2.Project.summary:type_name -> agentcompose.v2.ProjectSummary
-	60,  // 21: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
-	41,  // 22: agentcompose.v2.Project.agents:type_name -> agentcompose.v2.ProjectAgent
-	44,  // 23: agentcompose.v2.Project.schedulers:type_name -> agentcompose.v2.ProjectScheduler
-	60,  // 24: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
-	6,   // 25: agentcompose.v2.ProjectAgent.availability:type_name -> agentcompose.v2.ProjectAgentAvailability
-	7,   // 26: agentcompose.v2.ProjectAgent.health:type_name -> agentcompose.v2.ProjectAgentHealth
-	42,  // 27: agentcompose.v2.ProjectAgent.current_run:type_name -> agentcompose.v2.ProjectAgentCurrentRun
-	43,  // 28: agentcompose.v2.ProjectAgent.latest_run:type_name -> agentcompose.v2.ProjectAgentLatestRun
+	39,  // 17: agentcompose.v2.WatchProjectResponse.project:type_name -> agentcompose.v2.Project
+	41,  // 18: agentcompose.v2.WatchProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
+	71,  // 19: agentcompose.v2.WatchProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	40,  // 20: agentcompose.v2.Project.summary:type_name -> agentcompose.v2.ProjectSummary
+	72,  // 21: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
+	42,  // 22: agentcompose.v2.Project.agents:type_name -> agentcompose.v2.ProjectAgent
+	45,  // 23: agentcompose.v2.Project.schedulers:type_name -> agentcompose.v2.ProjectScheduler
+	72,  // 24: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
+	7,   // 25: agentcompose.v2.ProjectAgent.availability:type_name -> agentcompose.v2.ProjectAgentAvailability
+	8,   // 26: agentcompose.v2.ProjectAgent.health:type_name -> agentcompose.v2.ProjectAgentHealth
+	43,  // 27: agentcompose.v2.ProjectAgent.current_run:type_name -> agentcompose.v2.ProjectAgentCurrentRun
+	44,  // 28: agentcompose.v2.ProjectAgent.latest_run:type_name -> agentcompose.v2.ProjectAgentLatestRun
 	3,   // 29: agentcompose.v2.ProjectAgentLatestRun.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 30: agentcompose.v2.ProjectAgentLatestRun.source:type_name -> agentcompose.v2.RunSource
-	239, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
-	36,  // 32: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
-	44,  // 33: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
-	71,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
-	47,  // 35: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
-	72,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
-	239, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
-	239, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
-	239, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
-	49,  // 40: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
-	36,  // 41: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	239, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
-	52,  // 43: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
-	36,  // 44: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
-	44,  // 45: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
-	36,  // 46: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
-	47,  // 47: agentcompose.v2.SetSchedulerTriggerEnabledResponse.trigger:type_name -> agentcompose.v2.ResolvedTrigger
-	0,   // 48: agentcompose.v2.ProjectValidationIssue.severity:type_name -> agentcompose.v2.ProjectValidationSeverity
-	1,   // 49: agentcompose.v2.ProjectChange.action:type_name -> agentcompose.v2.ProjectChangeAction
-	67,  // 50: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
-	62,  // 51: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
-	70,  // 52: agentcompose.v2.ProjectSpec.network:type_name -> agentcompose.v2.NetworkSpec
-	64,  // 53: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
-	61,  // 54: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
-	63,  // 55: agentcompose.v2.ProjectSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
-	69,  // 56: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	74,  // 57: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
-	67,  // 58: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
-	69,  // 59: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	71,  // 60: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
-	179, // 61: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
-	66,  // 62: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
-	65,  // 63: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	63,  // 64: agentcompose.v2.AgentSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
-	183, // 65: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
-	5,   // 66: agentcompose.v2.AgentSpec.status:type_name -> agentcompose.v2.AgentStatus
-	67,  // 67: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
-	67,  // 68: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
-	227, // 69: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	228, // 70: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	229, // 71: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
-	72,  // 72: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
-	73,  // 73: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
-	75,  // 74: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
-	76,  // 75: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
-	77,  // 76: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
-	4,   // 77: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
-	67,  // 78: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	10,  // 79: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
-	180, // 80: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
-	65,  // 81: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	118, // 82: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
-	9,   // 83: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
-	117, // 84: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 85: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	84,  // 86: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	83,  // 87: agentcompose.v2.RunAttachRequest.start:type_name -> agentcompose.v2.RunAttachStart
-	128, // 88: agentcompose.v2.RunAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	129, // 89: agentcompose.v2.RunAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	130, // 90: agentcompose.v2.RunAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	131, // 91: agentcompose.v2.RunAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	132, // 92: agentcompose.v2.RunAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	133, // 93: agentcompose.v2.RunAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	134, // 94: agentcompose.v2.RunAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	135, // 95: agentcompose.v2.RunAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	136, // 96: agentcompose.v2.RunAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	137, // 97: agentcompose.v2.RunAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	138, // 98: agentcompose.v2.RunAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	139, // 99: agentcompose.v2.RunAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	78,  // 100: agentcompose.v2.RunAttachStart.request:type_name -> agentcompose.v2.RunAgentRequest
-	12,  // 101: agentcompose.v2.RunAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	127, // 102: agentcompose.v2.RunAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	13,  // 103: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
-	118, // 104: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	3,   // 105: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
-	4,   // 106: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
-	117, // 107: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
-	3,   // 108: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
-	118, // 109: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	8,   // 110: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
-	239, // 111: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
-	94,  // 112: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	94,  // 113: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	20,  // 114: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
-	239, // 115: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
-	101, // 116: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
-	101, // 117: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
-	116, // 118: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
-	239, // 119: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	239, // 120: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	107, // 121: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
-	106, // 122: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
-	106, // 123: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	106, // 124: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	106, // 125: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	17,  // 126: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	115, // 127: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
-	115, // 128: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
-	115, // 129: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
-	115, // 130: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
-	115, // 131: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
-	115, // 132: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
-	115, // 133: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
-	115, // 134: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
-	115, // 135: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
-	4,   // 136: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
-	3,   // 137: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	117, // 138: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	120, // 139: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
-	121, // 140: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
-	67,  // 141: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	140, // 142: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
-	11,  // 143: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
-	13,  // 144: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	140, // 145: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
-	84,  // 146: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	126, // 147: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
-	128, // 148: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	129, // 149: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	130, // 150: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	131, // 151: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	133, // 152: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	132, // 153: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	134, // 154: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	135, // 155: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	138, // 156: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	139, // 157: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	136, // 158: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	137, // 159: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	119, // 160: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
-	127, // 161: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	12,  // 162: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	127, // 163: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	230, // 164: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
-	117, // 165: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 166: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
-	84,  // 167: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	140, // 168: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
-	117, // 169: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	231, // 170: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
-	121, // 171: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
-	14,  // 172: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	173, // 173: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
-	175, // 174: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 175: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	174, // 176: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	173, // 177: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
-	16,  // 178: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
-	178, // 179: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
-	14,  // 180: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	173, // 181: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
-	175, // 182: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 183: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	232, // 184: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	14,  // 185: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	174, // 186: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	16,  // 187: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
-	173, // 188: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
-	18,  // 189: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 190: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
-	151, // 191: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	160, // 192: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
-	160, // 193: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
-	151, // 194: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	160, // 195: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
-	160, // 196: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	160, // 197: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
-	160, // 198: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	18,  // 199: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 200: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	161, // 201: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
-	19,  // 202: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
-	172, // 203: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	233, // 204: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	234, // 205: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	172, // 206: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	172, // 207: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	172, // 208: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
-	172, // 209: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
-	172, // 210: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	235, // 211: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	236, // 212: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	14,  // 213: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
-	15,  // 214: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
-	174, // 215: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	176, // 216: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
-	177, // 217: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	237, // 218: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
-	14,  // 219: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
-	78,  // 220: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
-	117, // 221: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
-	22,  // 222: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
-	186, // 223: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
-	22,  // 224: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
-	189, // 225: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	239, // 226: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
-	190, // 227: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	190, // 228: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	67,  // 229: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	68,  // 230: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
-	67,  // 231: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	198, // 232: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	198, // 233: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	239, // 234: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	239, // 235: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
-	202, // 236: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
-	202, // 237: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
-	213, // 238: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	238, // 239: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	216, // 240: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
-	217, // 241: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	239, // 242: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	239, // 243: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
-	220, // 244: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
-	221, // 245: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
-	23,  // 246: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
-	106, // 247: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	220, // 248: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
-	221, // 249: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
-	13,  // 250: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
-	24,  // 251: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	26,  // 252: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	28,  // 253: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	30,  // 254: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	32,  // 255: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	34,  // 256: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	45,  // 257: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
-	48,  // 258: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
-	51,  // 259: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
-	54,  // 260: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
-	56,  // 261: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	78,  // 262: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	181, // 263: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	78,  // 264: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	81,  // 265: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
-	85,  // 266: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	87,  // 267: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	89,  // 268: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	91,  // 269: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	93,  // 270: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
-	96,  // 271: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
-	119, // 272: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	119, // 273: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	124, // 274: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
-	141, // 275: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	143, // 276: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	145, // 277: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	147, // 278: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	149, // 279: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	152, // 280: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	154, // 281: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	156, // 282: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	158, // 283: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	162, // 284: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	164, // 285: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	166, // 286: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	168, // 287: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	170, // 288: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	98,  // 289: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	100, // 290: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
-	103, // 291: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	105, // 292: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
-	111, // 293: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
-	113, // 294: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
-	108, // 295: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	219, // 296: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	223, // 297: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
-	187, // 298: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
-	188, // 299: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
-	193, // 300: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
-	195, // 301: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
-	197, // 302: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
-	200, // 303: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	203, // 304: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
-	205, // 305: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
-	206, // 306: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
-	207, // 307: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
-	210, // 308: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
-	212, // 309: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
-	215, // 310: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	225, // 311: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	184, // 312: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	25,  // 313: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	27,  // 314: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	29,  // 315: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	31,  // 316: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	33,  // 317: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	35,  // 318: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	46,  // 319: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	50,  // 320: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	53,  // 321: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	55,  // 322: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	57,  // 323: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	79,  // 324: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	182, // 325: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	80,  // 326: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	82,  // 327: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
-	86,  // 328: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	88,  // 329: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	90,  // 330: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	92,  // 331: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	95,  // 332: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	97,  // 333: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	122, // 334: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	123, // 335: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	125, // 336: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
-	142, // 337: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	144, // 338: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	146, // 339: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	148, // 340: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	150, // 341: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	153, // 342: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	155, // 343: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	157, // 344: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	159, // 345: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	163, // 346: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	165, // 347: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	167, // 348: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	169, // 349: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	171, // 350: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	99,  // 351: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	102, // 352: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	104, // 353: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	110, // 354: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	112, // 355: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	114, // 356: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	109, // 357: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	222, // 358: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	224, // 359: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	191, // 360: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	192, // 361: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	194, // 362: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	196, // 363: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	199, // 364: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	201, // 365: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	204, // 366: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	209, // 367: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	209, // 368: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	208, // 369: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	211, // 370: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	214, // 371: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	218, // 372: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	226, // 373: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	185, // 374: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	313, // [313:375] is the sub-list for method output_type
-	251, // [251:313] is the sub-list for method input_type
-	251, // [251:251] is the sub-list for extension type_name
-	251, // [251:251] is the sub-list for extension extendee
-	0,   // [0:251] is the sub-list for field type_name
+	251, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
+	37,  // 32: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
+	45,  // 33: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
+	83,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
+	48,  // 35: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
+	84,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
+	251, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
+	251, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
+	251, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
+	50,  // 40: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
+	37,  // 41: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	251, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
+	53,  // 43: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
+	37,  // 44: agentcompose.v2.RunSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
+	65,  // 45: agentcompose.v2.RunSchedulerResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	37,  // 46: agentcompose.v2.StartSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
+	65,  // 47: agentcompose.v2.StartSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	37,  // 48: agentcompose.v2.GetSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
+	65,  // 49: agentcompose.v2.GetSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	37,  // 50: agentcompose.v2.ListSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	65,  // 51: agentcompose.v2.ListSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
+	37,  // 52: agentcompose.v2.StopSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
+	65,  // 53: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	5,   // 54: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
+	251, // 55: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
+	251, // 56: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
+	37,  // 57: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
+	45,  // 58: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
+	37,  // 59: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
+	48,  // 60: agentcompose.v2.SetSchedulerTriggerEnabledResponse.trigger:type_name -> agentcompose.v2.ResolvedTrigger
+	0,   // 61: agentcompose.v2.ProjectValidationIssue.severity:type_name -> agentcompose.v2.ProjectValidationSeverity
+	1,   // 62: agentcompose.v2.ProjectChange.action:type_name -> agentcompose.v2.ProjectChangeAction
+	79,  // 63: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
+	74,  // 64: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
+	82,  // 65: agentcompose.v2.ProjectSpec.network:type_name -> agentcompose.v2.NetworkSpec
+	76,  // 66: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
+	73,  // 67: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
+	75,  // 68: agentcompose.v2.ProjectSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
+	81,  // 69: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	86,  // 70: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
+	79,  // 71: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
+	81,  // 72: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	83,  // 73: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
+	191, // 74: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
+	78,  // 75: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
+	77,  // 76: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	75,  // 77: agentcompose.v2.AgentSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
+	195, // 78: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
+	6,   // 79: agentcompose.v2.AgentSpec.status:type_name -> agentcompose.v2.AgentStatus
+	79,  // 80: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
+	79,  // 81: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
+	239, // 82: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	240, // 83: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	241, // 84: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	84,  // 85: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
+	85,  // 86: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
+	87,  // 87: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
+	88,  // 88: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
+	89,  // 89: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
+	4,   // 90: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
+	79,  // 91: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	11,  // 92: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
+	192, // 93: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
+	77,  // 94: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	130, // 95: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
+	10,  // 96: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
+	129, // 97: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
+	14,  // 98: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	96,  // 99: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	95,  // 100: agentcompose.v2.RunAttachRequest.start:type_name -> agentcompose.v2.RunAttachStart
+	140, // 101: agentcompose.v2.RunAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	141, // 102: agentcompose.v2.RunAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	142, // 103: agentcompose.v2.RunAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	143, // 104: agentcompose.v2.RunAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	144, // 105: agentcompose.v2.RunAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	145, // 106: agentcompose.v2.RunAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	146, // 107: agentcompose.v2.RunAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	147, // 108: agentcompose.v2.RunAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	148, // 109: agentcompose.v2.RunAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	149, // 110: agentcompose.v2.RunAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	150, // 111: agentcompose.v2.RunAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	151, // 112: agentcompose.v2.RunAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	90,  // 113: agentcompose.v2.RunAttachStart.request:type_name -> agentcompose.v2.RunAgentRequest
+	13,  // 114: agentcompose.v2.RunAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	139, // 115: agentcompose.v2.RunAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	14,  // 116: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
+	130, // 117: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	3,   // 118: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
+	4,   // 119: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
+	129, // 120: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
+	3,   // 121: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
+	130, // 122: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	9,   // 123: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
+	251, // 124: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
+	106, // 125: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	106, // 126: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	21,  // 127: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
+	251, // 128: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	113, // 129: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
+	113, // 130: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
+	128, // 131: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
+	251, // 132: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	251, // 133: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	119, // 134: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
+	118, // 135: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
+	118, // 136: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	118, // 137: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	118, // 138: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	18,  // 139: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
+	127, // 140: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
+	127, // 141: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 142: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 143: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
+	127, // 144: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 145: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 146: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 147: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 148: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
+	4,   // 149: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
+	3,   // 150: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
+	129, // 151: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
+	132, // 152: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
+	133, // 153: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
+	79,  // 154: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	152, // 155: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
+	12,  // 156: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
+	14,  // 157: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	152, // 158: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
+	96,  // 159: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	138, // 160: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
+	140, // 161: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	141, // 162: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	142, // 163: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	143, // 164: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	145, // 165: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	144, // 166: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	146, // 167: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	147, // 168: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	150, // 169: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	151, // 170: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	148, // 171: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	149, // 172: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	131, // 173: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
+	139, // 174: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	13,  // 175: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	139, // 176: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	242, // 177: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	129, // 178: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
+	14,  // 179: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
+	96,  // 180: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	152, // 181: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
+	129, // 182: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
+	243, // 183: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	133, // 184: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
+	15,  // 185: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	185, // 186: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
+	187, // 187: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	15,  // 188: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	186, // 189: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	185, // 190: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
+	17,  // 191: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
+	190, // 192: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
+	15,  // 193: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	185, // 194: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
+	187, // 195: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	15,  // 196: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	244, // 197: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	15,  // 198: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	186, // 199: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	17,  // 200: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
+	185, // 201: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
+	19,  // 202: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
+	22,  // 203: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
+	163, // 204: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	172, // 205: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
+	172, // 206: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
+	163, // 207: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	172, // 208: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
+	172, // 209: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	172, // 210: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
+	172, // 211: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	19,  // 212: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
+	22,  // 213: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
+	173, // 214: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
+	20,  // 215: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
+	184, // 216: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
+	245, // 217: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	246, // 218: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	184, // 219: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	184, // 220: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	184, // 221: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
+	184, // 222: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
+	184, // 223: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
+	247, // 224: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	248, // 225: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	15,  // 226: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
+	16,  // 227: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
+	186, // 228: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
+	188, // 229: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
+	189, // 230: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
+	249, // 231: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	15,  // 232: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
+	90,  // 233: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
+	129, // 234: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	23,  // 235: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
+	198, // 236: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
+	23,  // 237: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
+	201, // 238: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
+	251, // 239: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	202, // 240: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	202, // 241: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	79,  // 242: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	80,  // 243: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
+	79,  // 244: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	210, // 245: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	210, // 246: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	251, // 247: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	251, // 248: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	214, // 249: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
+	214, // 250: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
+	225, // 251: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
+	250, // 252: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	228, // 253: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
+	229, // 254: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
+	251, // 255: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	251, // 256: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	232, // 257: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
+	233, // 258: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
+	24,  // 259: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
+	118, // 260: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	232, // 261: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
+	233, // 262: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
+	14,  // 263: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
+	25,  // 264: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	27,  // 265: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	29,  // 266: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	31,  // 267: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	33,  // 268: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	35,  // 269: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	46,  // 270: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
+	49,  // 271: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
+	52,  // 272: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
+	55,  // 273: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
+	57,  // 274: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
+	59,  // 275: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
+	61,  // 276: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
+	63,  // 277: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
+	66,  // 278: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
+	68,  // 279: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	90,  // 280: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	193, // 281: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
+	90,  // 282: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
+	93,  // 283: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
+	97,  // 284: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	99,  // 285: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	101, // 286: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	103, // 287: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	105, // 288: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
+	108, // 289: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
+	131, // 290: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	131, // 291: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
+	136, // 292: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
+	153, // 293: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	155, // 294: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	157, // 295: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	159, // 296: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	161, // 297: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	164, // 298: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	166, // 299: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	168, // 300: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	170, // 301: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	174, // 302: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	176, // 303: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	178, // 304: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	180, // 305: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	182, // 306: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	110, // 307: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	112, // 308: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
+	115, // 309: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	117, // 310: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
+	123, // 311: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
+	125, // 312: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
+	120, // 313: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
+	231, // 314: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	235, // 315: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	199, // 316: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
+	200, // 317: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
+	205, // 318: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
+	207, // 319: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
+	209, // 320: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
+	212, // 321: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	215, // 322: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
+	217, // 323: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
+	218, // 324: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
+	219, // 325: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
+	222, // 326: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
+	224, // 327: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
+	227, // 328: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
+	237, // 329: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	196, // 330: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	26,  // 331: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	28,  // 332: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	30,  // 333: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	32,  // 334: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	34,  // 335: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	36,  // 336: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	47,  // 337: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	51,  // 338: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	54,  // 339: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	56,  // 340: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	58,  // 341: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	60,  // 342: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	62,  // 343: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	64,  // 344: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	67,  // 345: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	69,  // 346: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	91,  // 347: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	194, // 348: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
+	92,  // 349: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
+	94,  // 350: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
+	98,  // 351: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	100, // 352: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	102, // 353: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	104, // 354: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	107, // 355: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	109, // 356: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	134, // 357: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	135, // 358: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
+	137, // 359: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
+	154, // 360: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	156, // 361: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	158, // 362: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	160, // 363: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	162, // 364: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	165, // 365: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	167, // 366: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	169, // 367: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	171, // 368: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	175, // 369: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	177, // 370: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	179, // 371: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	181, // 372: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	183, // 373: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	111, // 374: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	114, // 375: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	116, // 376: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	122, // 377: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	124, // 378: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	126, // 379: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	121, // 380: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	234, // 381: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	236, // 382: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	203, // 383: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	204, // 384: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	206, // 385: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	208, // 386: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	211, // 387: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	213, // 388: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	216, // 389: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	221, // 390: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	221, // 391: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	220, // 392: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	223, // 393: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	226, // 394: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	230, // 395: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	238, // 396: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	197, // 397: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	331, // [331:398] is the sub-list for method output_type
+	264, // [264:331] is the sub-list for method input_type
+	264, // [264:264] is the sub-list for extension type_name
+	264, // [264:264] is the sub-list for extension extendee
+	0,   // [0:264] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }
@@ -17812,8 +18697,8 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 	if File_agentcompose_v2_agentcompose_proto != nil {
 		return
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[44].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[57].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[55].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[68].OneofWrappers = []any{
 		(*RunAttachRequest_Start)(nil),
 		(*RunAttachRequest_Stdin)(nil),
 		(*RunAttachRequest_StdinEof)(nil),
@@ -17822,7 +18707,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*RunAttachRequest_HumanMessage)(nil),
 		(*RunAttachRequest_Cancel)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[58].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[69].OneofWrappers = []any{
 		(*RunAttachResponse_Started)(nil),
 		(*RunAttachResponse_Output)(nil),
 		(*RunAttachResponse_AgentEvent)(nil),
@@ -17830,13 +18715,13 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*RunAttachResponse_Result)(nil),
 		(*RunAttachResponse_Error)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[91].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[95].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[102].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[106].OneofWrappers = []any{
 		(*ExecRequest_SandboxId)(nil),
 		(*ExecRequest_RunId)(nil),
 		(*ExecRequest_Selector)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[100].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[111].OneofWrappers = []any{
 		(*ExecAttachRequest_Start)(nil),
 		(*ExecAttachRequest_Stdin)(nil),
 		(*ExecAttachRequest_StdinEof)(nil),
@@ -17845,7 +18730,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecAttachRequest_Cancel)(nil),
 		(*ExecAttachRequest_HumanMessage)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[101].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[112].OneofWrappers = []any{
 		(*ExecAttachResponse_Started)(nil),
 		(*ExecAttachResponse_Output)(nil),
 		(*ExecAttachResponse_Result)(nil),
@@ -17853,14 +18738,14 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecAttachResponse_AgentEvent)(nil),
 		(*ExecAttachResponse_AgentTurnCompleted)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[176].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[187].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
-			NumEnums:      24,
-			NumMessages:   215,
+			NumEnums:      25,
+			NumMessages:   226,
 			NumExtensions: 0,
 			NumServices:   12,
 		},

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -16,6 +16,11 @@ service ProjectService {
   rpc GetScheduler(GetSchedulerRequest) returns (GetSchedulerResponse);
   rpc ListSchedulers(ListSchedulersRequest) returns (ListSchedulersResponse);
   rpc ListSchedulerEvents(ListSchedulerEventsRequest) returns (ListSchedulerEventsResponse);
+  rpc RunScheduler(RunSchedulerRequest) returns (RunSchedulerResponse);
+  rpc StartSchedulerRun(StartSchedulerRunRequest) returns (StartSchedulerRunResponse);
+  rpc GetSchedulerRun(GetSchedulerRunRequest) returns (GetSchedulerRunResponse);
+  rpc ListSchedulerRuns(ListSchedulerRunsRequest) returns (ListSchedulerRunsResponse);
+  rpc StopSchedulerRun(StopSchedulerRunRequest) returns (StopSchedulerRunResponse);
   rpc SetSchedulerEnabled(SetSchedulerEnabledRequest) returns (SetSchedulerEnabledResponse);
   rpc SetSchedulerTriggerEnabled(SetSchedulerTriggerEnabledRequest) returns (SetSchedulerTriggerEnabledResponse);
 }
@@ -145,6 +150,15 @@ enum RunSource {
   RUN_SOURCE_MANUAL = 1;
   RUN_SOURCE_SCHEDULER = 2;
   RUN_SOURCE_API = 3;
+}
+
+enum SchedulerRunStatus {
+  SCHEDULER_RUN_STATUS_UNSPECIFIED = 0;
+  SCHEDULER_RUN_STATUS_RUNNING = 1;
+  SCHEDULER_RUN_STATUS_SUCCEEDED = 2;
+  SCHEDULER_RUN_STATUS_FAILED = 3;
+  SCHEDULER_RUN_STATUS_CANCELED = 4;
+  SCHEDULER_RUN_STATUS_SKIPPED = 5;
 }
 
 enum AgentStatus {
@@ -509,6 +523,79 @@ message SchedulerEvent {
 message ListSchedulerEventsResponse {
   repeated SchedulerEvent events = 1;
   string next_cursor = 2;
+}
+
+message RunSchedulerRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  string trigger_id = 3;
+  string payload_json = 4;
+}
+
+message RunSchedulerResponse {
+  SchedulerRun run = 1;
+}
+
+message StartSchedulerRunRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  string trigger_id = 3;
+  string payload_json = 4;
+}
+
+message StartSchedulerRunResponse {
+  SchedulerRun run = 1;
+}
+
+message GetSchedulerRunRequest {
+  ProjectRef project = 1;
+  string run_id = 2;
+}
+
+message GetSchedulerRunResponse {
+  SchedulerRun run = 1;
+}
+
+message ListSchedulerRunsRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  uint32 limit = 3;
+  string cursor = 4;
+}
+
+message ListSchedulerRunsResponse {
+  repeated SchedulerRun runs = 1;
+  string next_cursor = 2;
+}
+
+message StopSchedulerRunRequest {
+  ProjectRef project = 1;
+  string run_id = 2;
+  string reason = 3;
+}
+
+message StopSchedulerRunResponse {
+  SchedulerRun run = 1;
+  bool stop_requested = 2;
+}
+
+message SchedulerRun {
+  string run_id = 1;
+  string project_id = 2;
+  string agent_name = 3;
+  string scheduler_id = 4;
+  string trigger_id = 5;
+  string trigger_kind = 6;
+  string trigger_source = 7;
+  SchedulerRunStatus status = 8;
+  google.protobuf.Timestamp started_at = 9;
+  google.protobuf.Timestamp completed_at = 10;
+  int64 duration_ms = 11;
+  string error = 12;
+  string result_json = 13;
+  string payload_json = 14;
+  string source_script_sha256 = 15;
+  string artifacts_dir = 16;
 }
 
 message SetSchedulerEnabledRequest {

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -82,6 +82,21 @@ const (
 	// ProjectServiceListSchedulerEventsProcedure is the fully-qualified name of the ProjectService's
 	// ListSchedulerEvents RPC.
 	ProjectServiceListSchedulerEventsProcedure = "/agentcompose.v2.ProjectService/ListSchedulerEvents"
+	// ProjectServiceRunSchedulerProcedure is the fully-qualified name of the ProjectService's
+	// RunScheduler RPC.
+	ProjectServiceRunSchedulerProcedure = "/agentcompose.v2.ProjectService/RunScheduler"
+	// ProjectServiceStartSchedulerRunProcedure is the fully-qualified name of the ProjectService's
+	// StartSchedulerRun RPC.
+	ProjectServiceStartSchedulerRunProcedure = "/agentcompose.v2.ProjectService/StartSchedulerRun"
+	// ProjectServiceGetSchedulerRunProcedure is the fully-qualified name of the ProjectService's
+	// GetSchedulerRun RPC.
+	ProjectServiceGetSchedulerRunProcedure = "/agentcompose.v2.ProjectService/GetSchedulerRun"
+	// ProjectServiceListSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
+	// ListSchedulerRuns RPC.
+	ProjectServiceListSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/ListSchedulerRuns"
+	// ProjectServiceStopSchedulerRunProcedure is the fully-qualified name of the ProjectService's
+	// StopSchedulerRun RPC.
+	ProjectServiceStopSchedulerRunProcedure = "/agentcompose.v2.ProjectService/StopSchedulerRun"
 	// ProjectServiceSetSchedulerEnabledProcedure is the fully-qualified name of the ProjectService's
 	// SetSchedulerEnabled RPC.
 	ProjectServiceSetSchedulerEnabledProcedure = "/agentcompose.v2.ProjectService/SetSchedulerEnabled"
@@ -240,6 +255,11 @@ type ProjectServiceClient interface {
 	GetScheduler(context.Context, *connect.Request[v2.GetSchedulerRequest]) (*connect.Response[v2.GetSchedulerResponse], error)
 	ListSchedulers(context.Context, *connect.Request[v2.ListSchedulersRequest]) (*connect.Response[v2.ListSchedulersResponse], error)
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
+	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
+	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
+	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
+	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
 	SetSchedulerEnabled(context.Context, *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error)
 	SetSchedulerTriggerEnabled(context.Context, *connect.Request[v2.SetSchedulerTriggerEnabledRequest]) (*connect.Response[v2.SetSchedulerTriggerEnabledResponse], error)
 }
@@ -309,6 +329,36 @@ func NewProjectServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(projectServiceMethods.ByName("ListSchedulerEvents")),
 			connect.WithClientOptions(opts...),
 		),
+		runScheduler: connect.NewClient[v2.RunSchedulerRequest, v2.RunSchedulerResponse](
+			httpClient,
+			baseURL+ProjectServiceRunSchedulerProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("RunScheduler")),
+			connect.WithClientOptions(opts...),
+		),
+		startSchedulerRun: connect.NewClient[v2.StartSchedulerRunRequest, v2.StartSchedulerRunResponse](
+			httpClient,
+			baseURL+ProjectServiceStartSchedulerRunProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("StartSchedulerRun")),
+			connect.WithClientOptions(opts...),
+		),
+		getSchedulerRun: connect.NewClient[v2.GetSchedulerRunRequest, v2.GetSchedulerRunResponse](
+			httpClient,
+			baseURL+ProjectServiceGetSchedulerRunProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("GetSchedulerRun")),
+			connect.WithClientOptions(opts...),
+		),
+		listSchedulerRuns: connect.NewClient[v2.ListSchedulerRunsRequest, v2.ListSchedulerRunsResponse](
+			httpClient,
+			baseURL+ProjectServiceListSchedulerRunsProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
+			connect.WithClientOptions(opts...),
+		),
+		stopSchedulerRun: connect.NewClient[v2.StopSchedulerRunRequest, v2.StopSchedulerRunResponse](
+			httpClient,
+			baseURL+ProjectServiceStopSchedulerRunProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("StopSchedulerRun")),
+			connect.WithClientOptions(opts...),
+		),
 		setSchedulerEnabled: connect.NewClient[v2.SetSchedulerEnabledRequest, v2.SetSchedulerEnabledResponse](
 			httpClient,
 			baseURL+ProjectServiceSetSchedulerEnabledProcedure,
@@ -335,6 +385,11 @@ type projectServiceClient struct {
 	getScheduler               *connect.Client[v2.GetSchedulerRequest, v2.GetSchedulerResponse]
 	listSchedulers             *connect.Client[v2.ListSchedulersRequest, v2.ListSchedulersResponse]
 	listSchedulerEvents        *connect.Client[v2.ListSchedulerEventsRequest, v2.ListSchedulerEventsResponse]
+	runScheduler               *connect.Client[v2.RunSchedulerRequest, v2.RunSchedulerResponse]
+	startSchedulerRun          *connect.Client[v2.StartSchedulerRunRequest, v2.StartSchedulerRunResponse]
+	getSchedulerRun            *connect.Client[v2.GetSchedulerRunRequest, v2.GetSchedulerRunResponse]
+	listSchedulerRuns          *connect.Client[v2.ListSchedulerRunsRequest, v2.ListSchedulerRunsResponse]
+	stopSchedulerRun           *connect.Client[v2.StopSchedulerRunRequest, v2.StopSchedulerRunResponse]
 	setSchedulerEnabled        *connect.Client[v2.SetSchedulerEnabledRequest, v2.SetSchedulerEnabledResponse]
 	setSchedulerTriggerEnabled *connect.Client[v2.SetSchedulerTriggerEnabledRequest, v2.SetSchedulerTriggerEnabledResponse]
 }
@@ -384,6 +439,31 @@ func (c *projectServiceClient) ListSchedulerEvents(ctx context.Context, req *con
 	return c.listSchedulerEvents.CallUnary(ctx, req)
 }
 
+// RunScheduler calls agentcompose.v2.ProjectService.RunScheduler.
+func (c *projectServiceClient) RunScheduler(ctx context.Context, req *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error) {
+	return c.runScheduler.CallUnary(ctx, req)
+}
+
+// StartSchedulerRun calls agentcompose.v2.ProjectService.StartSchedulerRun.
+func (c *projectServiceClient) StartSchedulerRun(ctx context.Context, req *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error) {
+	return c.startSchedulerRun.CallUnary(ctx, req)
+}
+
+// GetSchedulerRun calls agentcompose.v2.ProjectService.GetSchedulerRun.
+func (c *projectServiceClient) GetSchedulerRun(ctx context.Context, req *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error) {
+	return c.getSchedulerRun.CallUnary(ctx, req)
+}
+
+// ListSchedulerRuns calls agentcompose.v2.ProjectService.ListSchedulerRuns.
+func (c *projectServiceClient) ListSchedulerRuns(ctx context.Context, req *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error) {
+	return c.listSchedulerRuns.CallUnary(ctx, req)
+}
+
+// StopSchedulerRun calls agentcompose.v2.ProjectService.StopSchedulerRun.
+func (c *projectServiceClient) StopSchedulerRun(ctx context.Context, req *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error) {
+	return c.stopSchedulerRun.CallUnary(ctx, req)
+}
+
 // SetSchedulerEnabled calls agentcompose.v2.ProjectService.SetSchedulerEnabled.
 func (c *projectServiceClient) SetSchedulerEnabled(ctx context.Context, req *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error) {
 	return c.setSchedulerEnabled.CallUnary(ctx, req)
@@ -405,6 +485,11 @@ type ProjectServiceHandler interface {
 	GetScheduler(context.Context, *connect.Request[v2.GetSchedulerRequest]) (*connect.Response[v2.GetSchedulerResponse], error)
 	ListSchedulers(context.Context, *connect.Request[v2.ListSchedulersRequest]) (*connect.Response[v2.ListSchedulersResponse], error)
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
+	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
+	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
+	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
+	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
 	SetSchedulerEnabled(context.Context, *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error)
 	SetSchedulerTriggerEnabled(context.Context, *connect.Request[v2.SetSchedulerTriggerEnabledRequest]) (*connect.Response[v2.SetSchedulerTriggerEnabledResponse], error)
 }
@@ -470,6 +555,36 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 		connect.WithSchema(projectServiceMethods.ByName("ListSchedulerEvents")),
 		connect.WithHandlerOptions(opts...),
 	)
+	projectServiceRunSchedulerHandler := connect.NewUnaryHandler(
+		ProjectServiceRunSchedulerProcedure,
+		svc.RunScheduler,
+		connect.WithSchema(projectServiceMethods.ByName("RunScheduler")),
+		connect.WithHandlerOptions(opts...),
+	)
+	projectServiceStartSchedulerRunHandler := connect.NewUnaryHandler(
+		ProjectServiceStartSchedulerRunProcedure,
+		svc.StartSchedulerRun,
+		connect.WithSchema(projectServiceMethods.ByName("StartSchedulerRun")),
+		connect.WithHandlerOptions(opts...),
+	)
+	projectServiceGetSchedulerRunHandler := connect.NewUnaryHandler(
+		ProjectServiceGetSchedulerRunProcedure,
+		svc.GetSchedulerRun,
+		connect.WithSchema(projectServiceMethods.ByName("GetSchedulerRun")),
+		connect.WithHandlerOptions(opts...),
+	)
+	projectServiceListSchedulerRunsHandler := connect.NewUnaryHandler(
+		ProjectServiceListSchedulerRunsProcedure,
+		svc.ListSchedulerRuns,
+		connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
+		connect.WithHandlerOptions(opts...),
+	)
+	projectServiceStopSchedulerRunHandler := connect.NewUnaryHandler(
+		ProjectServiceStopSchedulerRunProcedure,
+		svc.StopSchedulerRun,
+		connect.WithSchema(projectServiceMethods.ByName("StopSchedulerRun")),
+		connect.WithHandlerOptions(opts...),
+	)
 	projectServiceSetSchedulerEnabledHandler := connect.NewUnaryHandler(
 		ProjectServiceSetSchedulerEnabledProcedure,
 		svc.SetSchedulerEnabled,
@@ -502,6 +617,16 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 			projectServiceListSchedulersHandler.ServeHTTP(w, r)
 		case ProjectServiceListSchedulerEventsProcedure:
 			projectServiceListSchedulerEventsHandler.ServeHTTP(w, r)
+		case ProjectServiceRunSchedulerProcedure:
+			projectServiceRunSchedulerHandler.ServeHTTP(w, r)
+		case ProjectServiceStartSchedulerRunProcedure:
+			projectServiceStartSchedulerRunHandler.ServeHTTP(w, r)
+		case ProjectServiceGetSchedulerRunProcedure:
+			projectServiceGetSchedulerRunHandler.ServeHTTP(w, r)
+		case ProjectServiceListSchedulerRunsProcedure:
+			projectServiceListSchedulerRunsHandler.ServeHTTP(w, r)
+		case ProjectServiceStopSchedulerRunProcedure:
+			projectServiceStopSchedulerRunHandler.ServeHTTP(w, r)
 		case ProjectServiceSetSchedulerEnabledProcedure:
 			projectServiceSetSchedulerEnabledHandler.ServeHTTP(w, r)
 		case ProjectServiceSetSchedulerTriggerEnabledProcedure:
@@ -549,6 +674,26 @@ func (UnimplementedProjectServiceHandler) ListSchedulers(context.Context, *conne
 
 func (UnimplementedProjectServiceHandler) ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListSchedulerEvents is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.RunScheduler is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.StartSchedulerRun is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.GetSchedulerRun is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListSchedulerRuns is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.StopSchedulerRun is not implemented"))
 }
 
 func (UnimplementedProjectServiceHandler) SetSchedulerEnabled(context.Context, *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error) {


### PR DESCRIPTION
## Summary

- give each `scheduler.agent()` invocation an independent project run identity
- supervise complete Scheduler run lifecycles, including detached execution, cancellation, skipped runs, and terminal states
- expose run, start, get, list, and stop Scheduler operations through the v2 Project API
- migrate Scheduler CLI execution and inspection to the v2 run APIs while retaining existing observability commands
- retain legacy Scheduler execution flags for CLI compatibility and report them as unsupported by complete Scheduler runs without declaring them deprecated

## Validation

- `go test -count=1 ./cmd/agent-compose ./pkg/agentcompose/api ./pkg/storage/configstore`
- `go test -race -count=1 ./pkg/loaders`
- `go test -count=1 ./cmd/agent-compose -run 'TestCLISchedulerExecutionRejectsUnsupportedFlags|TestRunComposeSchedulerTriggerRejectsUnsupportedPrompt|TestNormalizeComposeSchedulerTriggerOptionsPayload|TestE2ECLIHelpCoversUserWorkflowCommands'`
- `go build ./cmd/agent-compose`
- rebase range-diff confirms the original four Scheduler patches are unchanged from the previously validated branch