### PR TITLE
fix(cli): list daemon sandboxes with ps all

### DIFF
--- a/cmd/agent-compose/cli_ps_run_association.go
+++ b/cmd/agent-compose/cli_ps_run_association.go
@@ -17,6 +17,10 @@ func latestSchedulerRunsBySandbox(ctx context.Context, client agentcomposev2conn
 		tags := sessionTagsMap(session.GetTags())
 		if tags["origin"] == "scheduler" && tags["project_id"] == projectID && tags["agent"] != "" {
 			schedulerAgents[tags["agent"]] = true
+			continue
+		}
+		if agentName := legacySchedulerAgentForProject(tags, project); agentName != "" {
+			schedulerAgents[agentName] = true
 		}
 	}
 	result := make(map[string]composeSchedulerRunItem)
@@ -43,6 +47,28 @@ func latestSchedulerRunsBySandbox(ctx context.Context, client agentcomposev2conn
 		}
 	}
 	return result, nil
+}
+
+func legacySchedulerSandboxBelongsToProject(tags map[string]string, project *agentcomposev2.Project) bool {
+	return legacySchedulerAgentForProject(tags, project) != ""
+}
+
+func legacySchedulerAgentForProject(tags map[string]string, project *agentcomposev2.Project) string {
+	if tags["project_id"] != "" || tags["origin"] != "loader" {
+		return ""
+	}
+	loaderID := strings.TrimSpace(tags["loader_id"])
+	projectID := strings.TrimSpace(project.GetSummary().GetProjectId())
+	if loaderID == "" || projectID == "" {
+		return ""
+	}
+	for _, scheduler := range project.GetSchedulers() {
+		managedLoaderID, err := domain.StableManagedLoaderID(projectID, scheduler.GetAgentName(), "")
+		if err == nil && loaderID == managedLoaderID {
+			return strings.TrimSpace(scheduler.GetAgentName())
+		}
+	}
+	return ""
 }
 
 func schedulerRunIsNewer(schedulerRun composeSchedulerRunItem, projectRun *agentcomposev2.RunSummary) bool {

--- a/cmd/agent-compose/cli_ps_run_association_test.go
+++ b/cmd/agent-compose/cli_ps_run_association_test.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
@@ -39,6 +40,40 @@ func TestSchedulerRunIsNewer(t *testing.T) {
 				t.Fatalf("schedulerRunIsNewer() = %t, want %t", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLegacySchedulerSandboxBelongsToProject(t *testing.T) {
+	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
+	loaderID, err := domain.StableManagedLoaderID("project-1", "reviewer", "")
+	if err != nil {
+		t.Fatalf("build managed loader id: %v", err)
+	}
+	legacyTags := map[string]string{
+		"origin":    "loader",
+		"loader_id": loaderID,
+	}
+	legacySandbox := &agentcomposev2.Sandbox{Tags: []*agentcomposev2.SandboxTag{
+		{Name: "origin", Value: "loader"},
+		{Name: "loader_id", Value: loaderID},
+	}}
+	if !composePSSessionBelongsToProject(legacySandbox, project, nil) {
+		t.Fatal("ps should include a legacy managed scheduler sandbox in its project")
+	}
+	if !legacySchedulerSandboxBelongsToProject(legacyTags, project) {
+		t.Fatal("legacy managed scheduler sandbox should belong to its project")
+	}
+	if agentName := legacySchedulerAgentForProject(legacyTags, project); agentName != "reviewer" {
+		t.Fatalf("legacy scheduler agent = %q, want reviewer", agentName)
+	}
+	if legacySchedulerSandboxBelongsToProject(legacyTags, testCLIProject("project-2", "project-two", "/other/agent-compose.yml")) {
+		t.Fatal("legacy managed scheduler sandbox should not belong to another project")
+	}
+	if legacySchedulerSandboxBelongsToProject(map[string]string{"origin": "loader", "loader_id": "standalone-loader"}, project) {
+		t.Fatal("standalone loader sandbox should not belong to the project")
+	}
+	if legacySchedulerSandboxBelongsToProject(map[string]string{"origin": "loader", "loader_id": loaderID, "project_id": "project-2"}, project) {
+		t.Fatal("explicit project ownership should not be overridden by legacy inference")
 	}
 }
 

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -677,7 +677,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 			return runComposePSCommand(cmd, options, psOptions)
 		},
 	}
-	psCmd.Flags().BoolVarP(&psOptions.All, "all", "a", false, "Show all recognizable sandboxes")
+	psCmd.Flags().BoolVarP(&psOptions.All, "all", "a", false, "Show current project sandboxes in all statuses")
 	psCmd.Flags().StringVar(&psOptions.Status, "status", "", "Filter sandboxes by status, comma-separated")
 	psCmd.Flags().BoolVar(&psOptions.Verbose, "verbose", false, "Show more sandbox details")
 
@@ -728,7 +728,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 			return runComposePSCommand(cmd, options, sandboxPSOptions)
 		},
 	}
-	sandboxLSCmd.Flags().BoolVarP(&sandboxPSOptions.All, "all", "a", false, "Show all recognizable sandboxes")
+	sandboxLSCmd.Flags().BoolVarP(&sandboxPSOptions.All, "all", "a", false, "Show current project sandboxes in all statuses")
 	sandboxLSCmd.Flags().StringVar(&sandboxPSOptions.Status, "status", "", "Filter sandboxes by status, comma-separated")
 	sandboxLSCmd.Flags().BoolVar(&sandboxPSOptions.Verbose, "verbose", false, "Show more sandbox details")
 
@@ -6658,6 +6658,9 @@ func composePSSessionBelongsToProject(session *agentcomposev2.Sandbox, project *
 		if value := strings.TrimSpace(tags[key]); value != "" && (value == projectID || value == projectName || value == sourcePath) {
 			return true
 		}
+	}
+	if legacySchedulerSandboxBelongsToProject(tags, project) {
+		return true
 	}
 	if value := strings.TrimSpace(session.GetTriggerSource()); value != "" {
 		value = strings.ToLower(value)

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -10030,6 +10030,44 @@ func (s sandboxServiceStub) ListSandboxHistory(ctx context.Context, req *connect
 	return s.listHistory(ctx, req)
 }
 
+func TestComposePSAllIncludesEveryStatusOnlyForCurrentProject(t *testing.T) {
+	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
+	stubs := composeServiceStubs{
+		run: runServiceStub{listRuns: func(context.Context, *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
+			return connect.NewResponse(&agentcomposev2.ListRunsResponse{}), nil
+		}},
+		sandbox: sandboxServiceStub{listSandboxes: func(context.Context, *connect.Request[agentcomposev2.ListSandboxesRequest]) (*connect.Response[agentcomposev2.ListSandboxesResponse], error) {
+			return connect.NewResponse(&agentcomposev2.ListSandboxesResponse{Sandboxes: []*agentcomposev2.Sandbox{
+				{SandboxId: "sandbox-project-running", Status: "running", Tags: []*agentcomposev2.SandboxTag{{Name: "project_id", Value: "project-1"}}},
+				{SandboxId: "sandbox-project-stopped", Status: "stopped", Tags: []*agentcomposev2.SandboxTag{{Name: "project_id", Value: "project-1"}}},
+				{SandboxId: "sandbox-other-running", Status: "running", Tags: []*agentcomposev2.SandboxTag{{Name: "project_id", Value: "project-2"}}},
+			}}), nil
+		}},
+	}
+	server := newComposeServiceStubServer(t, stubs)
+	t.Cleanup(server.Close)
+	clients := cliServiceClients{
+		run:     agentcomposev2connect.NewRunServiceClient(server.Client(), server.URL),
+		sandbox: agentcomposev2connect.NewSandboxServiceClient(server.Client(), server.URL),
+	}
+
+	runningOutput, err := composePSOutputFromProject(t.Context(), clients, project, composePSOptions{})
+	if err != nil {
+		t.Fatalf("build default ps output: %v", err)
+	}
+	if len(runningOutput.Sandboxes) != 1 || runningOutput.Sandboxes[0].RawID != "sandbox-project-running" {
+		t.Fatalf("default ps sandboxes = %#v, want only current project running sandbox", runningOutput.Sandboxes)
+	}
+
+	allOutput, err := composePSOutputFromProject(t.Context(), clients, project, composePSOptions{All: true})
+	if err != nil {
+		t.Fatalf("build ps --all output: %v", err)
+	}
+	if len(allOutput.Sandboxes) != 2 || allOutput.Sandboxes[0].RawID != "sandbox-project-running" || allOutput.Sandboxes[1].RawID != "sandbox-project-stopped" {
+		t.Fatalf("ps --all sandboxes = %#v, want all statuses from current project only", allOutput.Sandboxes)
+	}
+}
+
 func (s sandboxServiceStub) StopSandbox(ctx context.Context, req *connect.Request[agentcomposev2.StopSandboxRequest]) (*connect.Response[agentcomposev2.StopSandboxResponse], error) {
 	if s.stopSandbox == nil {
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StopSandbox stub is not configured"))

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -265,7 +265,7 @@ agent-compose scheduler inspect <name-or-id> [trigger]
 
 ## `ps`: List Sandboxes
 
-List sandboxes in the current project. By default, only running sandboxes are shown.
+List sandboxes in the current project. By default, only running sandboxes are shown. With `--all`, the command includes all statuses while remaining scoped to the current project.
 The project must already exist on the daemon; after `agent-compose down`, run `agent-compose up` again before using `ps`.
 
 ```bash
@@ -280,7 +280,7 @@ agent-compose ps --json
 
 | Option | Description |
 | --- | --- |
-| `-a, --all` | Show all sandboxes, including completed and errored ones. |
+| `-a, --all` | Show current project sandboxes in all statuses. |
 | `--verbose` | Show additional columns. |
 | `--status <status>[,<status>...]` | Filter by sandbox status. |
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -265,7 +265,7 @@ agent-compose scheduler inspect <name-or-id> [trigger]
 
 ## `ps`：查看 sandbox
 
-查看当前 project 下的 sandbox。默认只显示运行中的 sandbox。
+查看当前 project 下的 sandbox。默认只显示运行中的 sandbox。使用 `--all` 时仍限定当前 project，但会包含所有状态。
 该 project 必须已经存在于 daemon 中；执行 `agent-compose down` 后，需要先重新执行 `agent-compose up`，再使用 `ps`。
 
 ```bash
@@ -282,7 +282,7 @@ agent-compose ps --json
 
 | 参数 | 说明 |
 | --- | --- |
-| `-a, --all` | 显示全部 sandbox，包括已结束和错误状态。 |
+| `-a, --all` | 显示当前 project 中所有状态的 sandbox。 |
 | `--verbose` | 显示更多列。 |
 | `--status <status>[,<status>...]` | 按状态过滤。 |
 


### PR DESCRIPTION
  ## Summary

  - Make `agent-compose ps -a` and `agent-compose sandbox ls -a` list every sandbox known to the daemon across projects and statuses.
  - Keep the default `ps` behavior project-scoped and limited to running sandboxes.
  - Preserve project scoping for internal prune, stats, and sandbox-reference workflows that also need all statuses.
  - Add regression coverage for a running standalone loader sandbox and document the updated behavior in English and Chinese.

  ## Testing

  - `task prepare`
  - `task test`
  - `task lint`
  - `task build`
  - `go test ./cmd/agent-compose -count=1`
  - `task docs:build` *(blocked by a pre-existing `origin/main` schema coverage failure: `agent-compose-yaml-manual.md` does not reference `commit`,
  `description`, and `display_name`)*

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.