### PR TITLE
feat(daemon): add automatic retention cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,12 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 # classification. Cache deletion is always explicit through cache prune/rm.
 # CACHE_TTL=168h
 
+# Automatic retention cleanup. Each TTL is also its feature switch: 0 keeps
+# data indefinitely. Cleanup is time-based and does not use disk watermarks.
+# CLEANUP_INTERVAL=1h
+# WORKSPACE_CLEANUP_TTL=0
+# IMAGE_CACHE_CLEANUP_TTL=0
+
 # BoxLite runtime storage.
 # --------------------------------------
 # BOXLITE_HOME=/data/boxlite

--- a/TESTING.md
+++ b/TESTING.md
@@ -87,6 +87,20 @@ daemon logs when it fails.
 This focused task is intentionally absent from `task test` and GitHub Actions
 because GitHub-hosted CI does not provide its prebuilt guest-image prerequisite.
 
+The daemon retention cleanup has a separate opt-in real Docker E2E:
+
+```bash
+task image:agent-compose-guest
+task test:e2e:docker-retention
+```
+
+Set `AGENT_COMPOSE_E2E_RETENTION_IMAGE` to use another compatible local guest
+image. The test starts the built host daemon with short cleanup intervals,
+removes an expired materialization from an isolated `IMAGE_CACHE_ROOT`, creates
+and stops a real Docker sandbox, waits for automatic workspace reclamation,
+then verifies that sandbox metadata remains available and resume is rejected.
+All daemon data and Docker resources are fixture-scoped and cleaned afterward.
+
 The real Docker scheduler script E2E is also opt-in because it starts a Docker
 sandbox and waits for a scheduler trigger. Run it with:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -210,6 +210,22 @@ tasks:
           GOCACHE={{.GO_BUILD_CACHE_DIR}} \
           {{.GO_TOOLCHAIN_ENV}} go test ./test/e2e -run '^TestE2EDockerFileWorkspaceResumePreservesState$' -count=1 -v
 
+  test:e2e:docker-retention:
+    desc: Run the opt-in host-daemon Docker retention cleanup E2E test
+    dir: '{{.TASKFILE_DIR}}'
+    deps: ['build:agent-compose']
+    cmds:
+      - |
+        image="${AGENT_COMPOSE_E2E_RETENTION_IMAGE:-agent-compose-guest:latest}"
+        if ! docker image inspect "$image" >/dev/null 2>&1; then
+          echo "Docker retention image $image is unavailable; run 'task image:agent-compose-guest' or set AGENT_COMPOSE_E2E_RETENTION_IMAGE" >&2
+          exit 1
+        fi
+        AGENT_COMPOSE_E2E_BINARY="$PWD/build/agent-compose" \
+          AGENT_COMPOSE_E2E_RETENTION_IMAGE="$image" \
+          GOCACHE={{.GO_BUILD_CACHE_DIR}} \
+          {{.GO_TOOLCHAIN_ENV}} go test ./test/e2e -run '^TestE2EDockerDaemonRetentionCleanup$' -count=1 -v
+
   test:e2e:docker-scheduler:
     desc: Run the opt-in Docker scheduler script E2E test
     dir: '{{.TASKFILE_DIR}}'

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -5809,20 +5809,28 @@ type composeAgentInspectOutput struct {
 }
 
 type composeSandboxOutput struct {
-	SandboxID      string            `json:"sandbox_id"`
-	SandboxShortID string            `json:"sandbox_short_id,omitempty"`
-	Title          string            `json:"title,omitempty"`
-	Driver         string            `json:"driver,omitempty"`
-	VMStatus       string            `json:"vm_status,omitempty"`
-	WorkspacePath  string            `json:"workspace_path,omitempty"`
-	ProxyPath      string            `json:"proxy_path,omitempty"`
-	GuestImage     string            `json:"guest_image,omitempty"`
-	TriggerSource  string            `json:"trigger_source,omitempty"`
-	CreatedAt      string            `json:"created_at,omitempty"`
-	UpdatedAt      string            `json:"updated_at,omitempty"`
-	CellCount      uint32            `json:"cell_count"`
-	EventCount     uint32            `json:"event_count"`
-	Tags           map[string]string `json:"tags,omitempty"`
+	SandboxID            string                             `json:"sandbox_id"`
+	SandboxShortID       string                             `json:"sandbox_short_id,omitempty"`
+	Title                string                             `json:"title,omitempty"`
+	Driver               string                             `json:"driver,omitempty"`
+	VMStatus             string                             `json:"vm_status,omitempty"`
+	WorkspacePath        string                             `json:"workspace_path,omitempty"`
+	ProxyPath            string                             `json:"proxy_path,omitempty"`
+	GuestImage           string                             `json:"guest_image,omitempty"`
+	TriggerSource        string                             `json:"trigger_source,omitempty"`
+	CreatedAt            string                             `json:"created_at,omitempty"`
+	UpdatedAt            string                             `json:"updated_at,omitempty"`
+	CellCount            uint32                             `json:"cell_count"`
+	EventCount           uint32                             `json:"event_count"`
+	Tags                 map[string]string                  `json:"tags,omitempty"`
+	WorkspaceReclamation *composeWorkspaceReclamationOutput `json:"workspace_reclamation,omitempty"`
+}
+
+type composeWorkspaceReclamationOutput struct {
+	State       string `json:"state"`
+	StartedAt   string `json:"started_at,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+	LastError   string `json:"last_error,omitempty"`
 }
 
 type composeExecOutput struct {
@@ -7764,7 +7772,7 @@ func composeSandboxOutputFromSummary(summary *agentcomposev2.Sandbox) composeSan
 	if len(tags) == 0 {
 		tags = nil
 	}
-	return composeSandboxOutput{
+	result := composeSandboxOutput{
 		SandboxID:      displayOpaqueID(summary.GetSandboxId()),
 		SandboxShortID: identity.ShortID(summary.GetSandboxId()),
 		Title:          summary.GetTitle(),
@@ -7780,6 +7788,13 @@ func composeSandboxOutputFromSummary(summary *agentcomposev2.Sandbox) composeSan
 		EventCount:     summary.GetEventCount(),
 		Tags:           tags,
 	}
+	if summary.GetWorkspaceReclamationState() != "" {
+		result.WorkspaceReclamation = &composeWorkspaceReclamationOutput{
+			State: summary.GetWorkspaceReclamationState(), StartedAt: formatProtoTimestamp(summary.GetWorkspaceReclamationStartedAt()),
+			CompletedAt: formatProtoTimestamp(summary.GetWorkspaceReclamationCompletedAt()), LastError: summary.GetWorkspaceReclamationLastError(),
+		}
+	}
+	return result
 }
 
 func formatProtoTimestamp(value interface{ AsTime() time.Time }) string {

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -87,6 +87,7 @@ type DaemonOptions struct {
 	LoadDotEnv      bool
 	SetRlimit       bool
 	StartBackground func(do.Injector) error
+	StopBackground  func(context.Context, do.Injector) error
 }
 
 type DaemonApp struct {
@@ -95,8 +96,10 @@ type DaemonApp struct {
 	Logger          *slog.Logger
 	Config          *config.Config
 	startBackground func(do.Injector) error
+	stopBackground  func(context.Context, do.Injector) error
 	startOnce       sync.Once
 	startErr        error
+	shutdownTimeout time.Duration
 }
 
 type daemonServer struct {
@@ -181,8 +184,14 @@ func NewDaemonApp(ctx context.Context, opts DaemonOptions) (*DaemonApp, error) {
 	installDaemonMiddleware(app, conf)
 
 	startBackground := opts.StartBackground
+	stopBackground := opts.StopBackground
 	if startBackground == nil {
 		startBackground = agentcomposeapp.StartBackground
+		if stopBackground == nil {
+			stopBackground = agentcomposeapp.StopBackground
+		}
+	} else if stopBackground == nil {
+		stopBackground = func(context.Context, do.Injector) error { return nil }
 	}
 	return &DaemonApp{
 		DI:              di,
@@ -190,6 +199,8 @@ func NewDaemonApp(ctx context.Context, opts DaemonOptions) (*DaemonApp, error) {
 		Logger:          logger,
 		Config:          conf,
 		startBackground: startBackground,
+		stopBackground:  stopBackground,
+		shutdownTimeout: 10 * time.Second,
 	}, nil
 }
 
@@ -206,6 +217,13 @@ func (a *DaemonApp) StartBackground() error {
 	return a.startErr
 }
 
+func (a *DaemonApp) StopBackground(ctx context.Context) error {
+	if a == nil || a.stopBackground == nil {
+		return nil
+	}
+	return a.stopBackground(ctx, a.DI)
+}
+
 func (a *DaemonApp) Run(ctx context.Context) error {
 	servers, err := a.listen()
 	if err != nil {
@@ -213,9 +231,7 @@ func (a *DaemonApp) Run(ctx context.Context) error {
 	}
 
 	if err := a.StartBackground(); err != nil {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if shutdownErr := servers.shutdown(shutdownCtx); shutdownErr != nil {
+		if shutdownErr := a.shutdown(servers); shutdownErr != nil {
 			err = errors.Join(err, shutdownErr)
 		}
 		return err
@@ -226,9 +242,7 @@ func (a *DaemonApp) Run(ctx context.Context) error {
 	case err := <-serverErrCh:
 		if err != nil {
 			a.Logger.Error("agent-compose server failed", "error", err)
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			if shutdownErr := servers.shutdown(shutdownCtx); shutdownErr != nil {
+			if shutdownErr := a.shutdown(servers); shutdownErr != nil {
 				err = errors.Join(err, shutdownErr)
 			}
 			return err
@@ -237,13 +251,34 @@ func (a *DaemonApp) Run(ctx context.Context) error {
 		a.Logger.Info("shutdown requested", "error", ctx.Err())
 	}
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := servers.shutdown(shutdownCtx); err != nil {
+	if err := a.shutdown(servers); err != nil {
 		a.Logger.Error("failed to shutdown agent-compose server", "error", err)
 		return err
 	}
 	return nil
+}
+
+func (a *DaemonApp) shutdown(servers *daemonServers) error {
+	var joined error
+	serverCtx, cancelServers := context.WithTimeout(context.Background(), a.effectiveShutdownTimeout())
+	if err := servers.shutdown(serverCtx); err != nil {
+		joined = errors.Join(joined, err)
+	}
+	cancelServers()
+
+	backgroundCtx, cancelBackground := context.WithTimeout(context.Background(), a.effectiveShutdownTimeout())
+	if err := a.StopBackground(backgroundCtx); err != nil {
+		joined = errors.Join(joined, fmt.Errorf("stop background managers: %w", err))
+	}
+	cancelBackground()
+	return joined
+}
+
+func (a *DaemonApp) effectiveShutdownTimeout() time.Duration {
+	if a != nil && a.shutdownTimeout > 0 {
+		return a.shutdownTimeout
+	}
+	return 10 * time.Second
 }
 
 func (a *DaemonApp) listen() (*daemonServers, error) {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -9203,6 +9203,106 @@ func TestDaemonAppStartsBackgroundOnce(t *testing.T) {
 	testDaemonAppStartsBackgroundOnce(t)
 }
 
+func TestDaemonAppWaitsForBackgroundShutdown(t *testing.T) {
+	app, cancelApp := newTestDaemonAppWithSocketAndTCP(t, shortUnixSocketPath(t), "127.0.0.1:0", func(do.Injector) error { return nil })
+	defer cancelApp()
+	stopEntered := make(chan struct{})
+	stopRelease := make(chan struct{})
+	app.stopBackground = func(context.Context, do.Injector) error {
+		close(stopEntered)
+		<-stopRelease
+		return nil
+	}
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	runDone := runDaemonAppAsync(app, runCtx)
+	cancelRun()
+	select {
+	case <-stopEntered:
+	case err := <-runDone:
+		t.Fatalf("Run returned before stopping background managers: %v", err)
+	}
+	select {
+	case err := <-runDone:
+		t.Fatalf("Run returned before background shutdown completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(stopRelease)
+	if err := <-runDone; err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestDaemonAppGivesBackgroundShutdownAnIndependentDeadline(t *testing.T) {
+	requestEntered := make(chan struct{})
+	requestRelease := make(chan struct{})
+	releaseRequest := sync.OnceFunc(func() { close(requestRelease) })
+	defer releaseRequest()
+	server := &http.Server{Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(requestEntered)
+		<-requestRelease
+	})}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() {
+		if err := server.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("close server: %v", err)
+		}
+	}()
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- server.Serve(listener)
+	}()
+
+	requestDone := make(chan error, 1)
+	go func() {
+		response, requestErr := http.Get("http://" + listener.Addr().String())
+		if requestErr == nil {
+			requestErr = response.Body.Close()
+		}
+		requestDone <- requestErr
+	}()
+	select {
+	case <-requestEntered:
+	case <-time.After(time.Second):
+		t.Fatal("request did not enter blocking handler")
+	}
+
+	backgroundContextErr := make(chan error, 1)
+	app := &DaemonApp{
+		shutdownTimeout: 50 * time.Millisecond,
+		stopBackground: func(ctx context.Context, _ do.Injector) error {
+			backgroundContextErr <- ctx.Err()
+			return nil
+		},
+	}
+	servers := &daemonServers{items: []*daemonServer{{
+		name: "test", value: listener.Addr().String(), listener: listener, server: server,
+	}}}
+	shutdownErr := app.shutdown(servers)
+	if shutdownErr == nil {
+		t.Fatal("shutdown returned nil error while an active request exceeded the server deadline")
+	}
+	if err := <-backgroundContextErr; err != nil {
+		t.Fatalf("background shutdown received expired context: %v", err)
+	}
+
+	releaseRequest()
+	select {
+	case requestErr := <-requestDone:
+		if requestErr != nil {
+			t.Errorf("request returned error: %v", requestErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request did not finish after handler release")
+	}
+	if err := <-serveDone; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+}
+
 func testDaemonAppStartsBackgroundOnce(t *testing.T) {
 	t.Helper()
 	starts := 0

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -595,6 +595,8 @@ agent-compose cache rm <cache-id> --force
 
 `CACHE_TTL` defaults to `168h`; `0` disables expiration classification. TTL never triggers background/startup deletion. Use `cache prune --expired --force` explicitly. `--older-than` remains an independent filter. `cache prune` and `cache rm` default to dry-run; `--force` authorizes execution but never bypasses `active`, `referenced`, or `unknown` protection. BoxLite v0.9.7 runtime image inventory is read-only because its ABI has no safe image remove/prune operation; Microsandbox shared images use the SDK inventory/remove APIs. `sandbox prune` does not delete cache artifacts.
 
+The daemon can optionally run time-based retention cleanup. `WORKSPACE_CLEANUP_TTL` reclaims only the workspace directory of eligible stopped sandboxes, while preserving metadata, logs, and state for audit; a reclaimed sandbox cannot be resumed. `IMAGE_CACHE_CLEANUP_TTL` removes unreferenced OCI and materialized data owned by `IMAGE_CACHE_ROOT`, using last-used time when available and pull time or filesystem modification time as a fallback. Both default to `0`, which disables that cleaner. `CLEANUP_INTERVAL` defaults to `1h`. Automatic cleanup does not touch workspace sources, Docker daemon images, BoxLite home, or Microsandbox SDK caches, and it does not implement a disk-space watermark.
+
 Compatibility:
 
 - `agent-compose image ls` is deprecated; use `agent-compose images`.

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -603,6 +603,8 @@ agent-compose cache rm <cache-id> --force
 
 `CACHE_TTL` 默认 `168h`，设为 `0` 会禁用 expired 判定；TTL 不会触发后台或启动时删除，必须显式执行 `cache prune --expired --force`。`--older-than` 仍是独立过滤条件。`cache prune` 和 `cache rm` 默认 dry-run；`--force` 只授权执行，不能绕过 `active`、`referenced` 或 `unknown` 保护。BoxLite v0.9.7 ABI 不提供安全 image remove/prune，因此 runtime image inventory 只读；Microsandbox 共享 image 使用 SDK inventory/remove API。`sandbox prune` 不删除 cache artifact。
 
+daemon 可以选择启用基于时间的保留清理。`WORKSPACE_CLEANUP_TTL` 只回收符合条件的 stopped sandbox 的 workspace 目录，metadata、logs 和 state 会保留用于审计；workspace 被回收后 sandbox 不能再 resume。`IMAGE_CACHE_CLEANUP_TTL` 清理 `IMAGE_CACHE_ROOT` 自有且未被引用的 OCI 与 materialized 数据，优先使用最后使用时间，没有时回退到拉取时间或文件修改时间。两项默认都是 `0`，即关闭对应 cleaner；`CLEANUP_INTERVAL` 默认 `1h`。自动清理不会处理 workspace source、Docker daemon 镜像、BoxLite home 或 Microsandbox SDK cache，也不实现磁盘空间水位策略。
+
 兼容说明：
 
 - `agent-compose image ls` 已废弃，请使用 `agent-compose images`。

--- a/pkg/agentcompose/adapters/image_cache_cleanup.go
+++ b/pkg/agentcompose/adapters/image_cache_cleanup.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -54,8 +55,14 @@ func (c *ImageCacheCleaner) protectedIdentities(ctx context.Context) ([]string, 
 		}
 	}
 	for _, record := range records {
-		if sandbox := byID[record.SandboxID]; sandbox != nil && domain.SandboxWorkspaceReclaimed(sandbox) {
+		if sandbox := byID[record.SandboxID]; sandbox != nil {
+			if domain.SandboxWorkspaceReclaimed(sandbox) {
+				continue
+			}
+		} else if _, err := os.Lstat(record.SandboxPath); os.IsNotExist(err) {
 			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("inspect sandbox ownership path %s: %w", record.SandboxID, err)
 		}
 		for _, dependency := range record.CacheDependencies {
 			if dependency.Domain == "runtime-image" && dependency.Identity != "" {

--- a/pkg/agentcompose/adapters/image_cache_cleanup.go
+++ b/pkg/agentcompose/adapters/image_cache_cleanup.go
@@ -1,0 +1,67 @@
+package adapters
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"agent-compose/pkg/cleanup"
+	"agent-compose/pkg/imagecache"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sessions"
+)
+
+type cleanupSandboxStore interface {
+	ListSandboxes(context.Context, domain.SandboxListOptions) (domain.SandboxListResult, error)
+}
+
+type ImageCacheCleaner struct {
+	Cache       *imagecache.Cache
+	Sandboxes   cleanupSandboxStore
+	SandboxRoot string
+}
+
+func (c *ImageCacheCleaner) Name() string { return "image-cache" }
+
+func (c *ImageCacheCleaner) Clean(ctx context.Context, cutoff time.Time) (cleanup.Result, error) {
+	result, err := c.Cache.PruneBeforeWithProtection(ctx, cutoff, c.protectedIdentities)
+	return cleanup.Result{
+		Matched: result.Matched,
+		Removed: result.Removed,
+		Skipped: result.Skipped,
+		Failed:  result.Failed,
+	}, err
+}
+
+func (c *ImageCacheCleaner) protectedIdentities(ctx context.Context) ([]string, error) {
+	listed, err := c.Sandboxes.ListSandboxes(ctx, domain.SandboxListOptions{Limit: 1 << 30})
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]*domain.Sandbox, len(listed.Sandboxes))
+	for _, sandbox := range listed.Sandboxes {
+		byID[sandbox.Summary.ID] = sandbox
+	}
+	records, warnings := sessions.ListOwnershipRecords(c.SandboxRoot)
+	if len(warnings) > 0 {
+		return nil, fmt.Errorf("sandbox ownership inventory is incomplete: %s", strings.Join(warnings, "; "))
+	}
+	protected := make([]string, 0, len(records))
+	for _, sandbox := range listed.Sandboxes {
+		if !domain.SandboxWorkspaceReclaimed(sandbox) && sandbox.Summary.GuestImage != "" {
+			protected = append(protected, sandbox.Summary.GuestImage)
+		}
+	}
+	for _, record := range records {
+		if sandbox := byID[record.SandboxID]; sandbox != nil && domain.SandboxWorkspaceReclaimed(sandbox) {
+			continue
+		}
+		for _, dependency := range record.CacheDependencies {
+			if dependency.Domain == "runtime-image" && dependency.Identity != "" {
+				protected = append(protected, dependency.Identity)
+			}
+		}
+	}
+	return protected, nil
+}

--- a/pkg/agentcompose/adapters/image_cache_cleanup.go
+++ b/pkg/agentcompose/adapters/image_cache_cleanup.go
@@ -59,10 +59,14 @@ func (c *ImageCacheCleaner) protectedIdentities(ctx context.Context) ([]string, 
 			if domain.SandboxWorkspaceReclaimed(sandbox) {
 				continue
 			}
-		} else if _, err := os.Lstat(record.SandboxPath); os.IsNotExist(err) {
-			continue
-		} else if err != nil {
-			return nil, fmt.Errorf("inspect sandbox ownership path %s: %w", record.SandboxID, err)
+		} else {
+			present, err := ownershipPathPresent(record.SandboxPath, os.Lstat)
+			if err != nil {
+				return nil, err
+			}
+			if !present {
+				continue
+			}
 		}
 		for _, dependency := range record.CacheDependencies {
 			if dependency.Domain == "runtime-image" && dependency.Identity != "" {
@@ -71,4 +75,15 @@ func (c *ImageCacheCleaner) protectedIdentities(ctx context.Context) ([]string, 
 		}
 	}
 	return protected, nil
+}
+
+func ownershipPathPresent(path string, lstat func(string) (os.FileInfo, error)) (bool, error) {
+	_, err := lstat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("inspect sandbox ownership path %s: %w", path, err)
 }

--- a/pkg/agentcompose/adapters/image_cache_cleanup_test.go
+++ b/pkg/agentcompose/adapters/image_cache_cleanup_test.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -19,6 +20,9 @@ import (
 func TestImageCacheCleanerProtectsResumableSandboxAndReleasesReclaimedSandbox(t *testing.T) {
 	root := t.TempDir()
 	sandboxID := "sandbox-1"
+	if err := os.MkdirAll(filepath.Join(root, sandboxID), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := sessions.WriteOwnershipRecord(root, sessions.OwnershipRecord{
 		SandboxID: sandboxID, SandboxPath: filepath.Join(root, sandboxID), LifecycleState: "active",
 		CacheDependencies: []sessions.CacheDependency{{Domain: "runtime-image", Identity: "sha256:guest"}},
@@ -44,6 +48,30 @@ func TestImageCacheCleanerProtectsResumableSandboxAndReleasesReclaimedSandbox(t 
 	}
 	if len(protected) != 0 {
 		t.Fatalf("reclaimed sandbox protected identities = %v", protected)
+	}
+}
+
+func TestImageCacheCleanerSkipsOnlyConfirmedOrphanOwnership(t *testing.T) {
+	root := t.TempDir()
+	for _, sandboxID := range []string{"orphan", "unreadable"} {
+		if err := sessions.WriteOwnershipRecord(root, sessions.OwnershipRecord{
+			SandboxID: sandboxID, SandboxPath: filepath.Join(root, sandboxID), LifecycleState: "active",
+			CacheDependencies: []sessions.CacheDependency{{Domain: "runtime-image", Identity: sandboxID + ":latest"}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, "unreadable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaner := &ImageCacheCleaner{Sandboxes: cleanupSandboxStoreFake{}, SandboxRoot: root}
+	protected, err := cleaner.protectedIdentities(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(protected, "orphan:latest") || !slices.Contains(protected, "unreadable:latest") {
+		t.Fatalf("protected identities = %v, want only existing unreadable sandbox dependency", protected)
 	}
 }
 

--- a/pkg/agentcompose/adapters/image_cache_cleanup_test.go
+++ b/pkg/agentcompose/adapters/image_cache_cleanup_test.go
@@ -1,0 +1,144 @@
+package adapters
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"agent-compose/pkg/cleanup"
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/imagecache"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sessions"
+	"agent-compose/pkg/storage/sessionstore"
+)
+
+func TestImageCacheCleanerProtectsResumableSandboxAndReleasesReclaimedSandbox(t *testing.T) {
+	root := t.TempDir()
+	sandboxID := "sandbox-1"
+	if err := sessions.WriteOwnershipRecord(root, sessions.OwnershipRecord{
+		SandboxID: sandboxID, SandboxPath: filepath.Join(root, sandboxID), LifecycleState: "active",
+		CacheDependencies: []sessions.CacheDependency{{Domain: "runtime-image", Identity: "sha256:guest"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, GuestImage: "guest:latest"}}
+	cleaner := &ImageCacheCleaner{Sandboxes: cleanupSandboxStoreFake{sandboxes: []*domain.Sandbox{sandbox}}, SandboxRoot: root}
+	protected, err := cleaner.protectedIdentities(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(protected, "guest:latest") || !slices.Contains(protected, "sha256:guest") {
+		t.Fatalf("protected identities = %v", protected)
+	}
+
+	sandbox.WorkspaceReclamation = &domain.SandboxWorkspaceReclamation{
+		State: domain.SandboxWorkspaceReclamationStateReclaimed, CompletedAt: time.Now(),
+	}
+	protected, err = cleaner.protectedIdentities(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(protected) != 0 {
+		t.Fatalf("reclaimed sandbox protected identities = %v", protected)
+	}
+}
+
+func TestImageCacheCleanerSerializesProtectionSnapshotWithSandboxRegistration(t *testing.T) {
+	root := t.TempDir()
+	cache, err := imagecache.New(imagecache.Config{Root: filepath.Join(root, "images")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	if err := cache.SaveMetadata(imagecache.MetadataFile{Images: []imagecache.ImageMetadata{{
+		RequestedRef: "guest:latest", NormalizedRef: "index.docker.io/library/guest:latest",
+		ConfigDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		PulledAt:     now.Add(-30 * 24 * time.Hour), LastUsedAt: now.Add(-20 * 24 * time.Hour),
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	config := &appconfig.Config{
+		DataRoot: root, SandboxRoot: filepath.Join(root, "sandboxes"), RuntimeDriver: "docker",
+		DefaultImage: "guest:latest", DockerDefaultImage: "guest:latest", JupyterProxyBasePath: "/jupyter",
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration := &blockingCacheRegistration{
+		cache: cache, acquired: make(chan struct{}), release: make(chan struct{}),
+	}
+	releaseRegistration := sync.OnceFunc(func() { close(registration.release) })
+	defer releaseRegistration()
+	store.SetCacheDependencyLocker(registration)
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, createErr := store.CreateSandbox(context.Background(), "race", "", "docker", "guest:latest", "", "test", nil, nil, nil)
+		createDone <- createErr
+	}()
+	<-registration.acquired
+
+	cleaner := &ImageCacheCleaner{Cache: cache, Sandboxes: store, SandboxRoot: config.SandboxRoot}
+	cleanDone := make(chan struct {
+		result cleanup.Result
+		err    error
+	}, 1)
+	cleanStarted := make(chan struct{})
+	go func() {
+		close(cleanStarted)
+		result, cleanErr := cleaner.Clean(context.Background(), now.Add(-7*24*time.Hour))
+		cleanDone <- struct {
+			result cleanup.Result
+			err    error
+		}{result: result, err: cleanErr}
+	}()
+	<-cleanStarted
+	select {
+	case outcome := <-cleanDone:
+		t.Fatalf("cleanup bypassed sandbox registration lock: %#v, %v", outcome.result, outcome.err)
+	case <-time.After(250 * time.Millisecond):
+	}
+	releaseRegistration()
+	if err := <-createDone; err != nil {
+		t.Fatal(err)
+	}
+	outcome := <-cleanDone
+	if outcome.err != nil {
+		t.Fatal(outcome.err)
+	}
+	if outcome.result.Matched != 1 || outcome.result.Skipped != 1 || outcome.result.Removed != 0 {
+		t.Fatalf("cleanup result after registration = %#v", outcome.result)
+	}
+}
+
+type cleanupSandboxStoreFake struct {
+	sandboxes []*domain.Sandbox
+}
+
+type blockingCacheRegistration struct {
+	cache    *imagecache.Cache
+	acquired chan struct{}
+	release  chan struct{}
+	once     sync.Once
+}
+
+func (l *blockingCacheRegistration) WithLockContext(ctx context.Context, fn func() error) error {
+	return l.cache.WithLockContext(ctx, func() error {
+		l.once.Do(func() { close(l.acquired) })
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-l.release:
+			return fn()
+		}
+	})
+}
+
+func (f cleanupSandboxStoreFake) ListSandboxes(context.Context, domain.SandboxListOptions) (domain.SandboxListResult, error) {
+	return domain.SandboxListResult{Sandboxes: f.sandboxes}, nil
+}

--- a/pkg/agentcompose/adapters/image_cache_cleanup_test.go
+++ b/pkg/agentcompose/adapters/image_cache_cleanup_test.go
@@ -2,9 +2,11 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -72,6 +74,20 @@ func TestImageCacheCleanerSkipsOnlyConfirmedOrphanOwnership(t *testing.T) {
 	}
 	if slices.Contains(protected, "orphan:latest") || !slices.Contains(protected, "unreadable:latest") {
 		t.Fatalf("protected identities = %v, want only existing unreadable sandbox dependency", protected)
+	}
+}
+
+func TestOwnershipPathPresentReportsInspectedPath(t *testing.T) {
+	path := "/sandboxes/unreadable"
+	inspectErr := errors.New("permission denied")
+	_, err := ownershipPathPresent(path, func(got string) (os.FileInfo, error) {
+		if got != path {
+			t.Fatalf("inspected path = %q, want %q", got, path)
+		}
+		return nil, inspectErr
+	})
+	if err == nil || !errors.Is(err, inspectErr) || !strings.Contains(err.Error(), path) {
+		t.Fatalf("ownership path error = %v, want wrapped error containing %q", err, path)
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -76,6 +76,14 @@ func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sand
 		_ = d.Store.SaveVMState(session.Summary.ID, vmState)
 		return err
 	}
+	// Persist a start-attempt fence before asking the runtime to start. Runtime
+	// creation can partially succeed before returning an error; retaining the
+	// stop timestamp preserves resume semantics, while the newer attempt time
+	// prevents destructive cleanup until another stop is confirmed.
+	vmState.StartAttemptedAt = time.Now().UTC()
+	if err := d.Store.SaveVMState(session.Summary.ID, vmState); err != nil {
+		return err
+	}
 
 	info, err := runtime.EnsureSandbox(ctx, session, vmState, proxyState)
 	if err != nil {

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -19,17 +19,22 @@ import (
 )
 
 type fakeSessionRuntime struct {
-	info       domain.SandboxVMInfo
-	ensureHook func(*domain.Sandbox)
-	removeHook func(*domain.Sandbox)
-	removeErr  error
+	info            domain.SandboxVMInfo
+	ensureHook      func(*domain.Sandbox)
+	ensureStateHook func(domain.VMState)
+	ensureErr       error
+	removeHook      func(*domain.Sandbox)
+	removeErr       error
 }
 
-func (r fakeSessionRuntime) EnsureSandbox(_ context.Context, session *domain.Sandbox, _ domain.VMState, _ domain.ProxyState) (domain.SandboxVMInfo, error) {
+func (r fakeSessionRuntime) EnsureSandbox(_ context.Context, session *domain.Sandbox, vmState domain.VMState, _ domain.ProxyState) (domain.SandboxVMInfo, error) {
 	if r.ensureHook != nil {
 		r.ensureHook(session)
 	}
-	return r.info, nil
+	if r.ensureStateHook != nil {
+		r.ensureStateHook(vmState)
+	}
+	return r.info, r.ensureErr
 }
 
 func (r fakeSessionRuntime) StopSandbox(context.Context, *domain.Sandbox, domain.VMState) (bool, error) {
@@ -344,6 +349,49 @@ func TestSandboxDriverResumeReusesRuntimeWithoutRefreshingStartupEnv(t *testing.
 	}
 	if vmState.BoxID != "container-1" || !vmState.StoppedAt.IsZero() {
 		t.Fatalf("vm state after resume = %+v", vmState)
+	}
+}
+
+func TestSandboxDriverResumeRecordsAttemptBeforeRuntimeFailure(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot: root, SandboxRoot: filepath.Join(root, "sandboxes"),
+		RuntimeDriver: driverpkg.RuntimeDriverBoxlite, BoxliteHome: filepath.Join(root, "boxlite"), DefaultImage: "guest:latest",
+		GuestWorkspacePath: "/workspace", SandboxStartTimeout: 2 * time.Second,
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := store.CreateSandbox(ctx, "resume failure", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stoppedAt := time.Now().UTC().Add(-48 * time.Hour)
+	if err := store.SaveVMState(session.Summary.ID, domain.VMState{
+		Driver: driverpkg.RuntimeDriverBoxlite, BoxID: "container-1", StoppedAt: stoppedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	startErr := errors.New("runtime partially started")
+	var runtimeState domain.VMState
+	driver := NewSandboxDriver(config, store, nil, fakeRuntimeProvider{runtime: fakeSessionRuntime{
+		ensureErr: startErr, ensureStateHook: func(state domain.VMState) { runtimeState = state },
+	}})
+
+	if err := driver.StartSandboxVM(ctx, session); !errors.Is(err, startErr) {
+		t.Fatalf("StartSandboxVM error = %v, want %v", err, startErr)
+	}
+	vmState, err := store.GetVMState(session.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vmState.StoppedAt.Equal(stoppedAt) || !runtimeState.StoppedAt.Equal(stoppedAt) {
+		t.Fatalf("failed resume lost stopped state: persisted=%#v runtime=%#v", vmState, runtimeState)
+	}
+	if !vmState.StartAttemptedAt.After(stoppedAt) || !runtimeState.StartAttemptedAt.Equal(vmState.StartAttemptedAt) || vmState.LastError != startErr.Error() {
+		t.Fatalf("vm state after failed resume = %#v, runtime state = %#v", vmState, runtimeState)
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge.go
@@ -272,10 +272,6 @@ func (b *SandboxRPCBridge) stopSandbox(ctx context.Context, sandboxID, source st
 	} else {
 		session = reconciled
 	}
-	if session.Summary.VMStatus != domain.VMStatusRunning {
-		b.revokeCapabilitySandbox(session.Summary.ID)
-		return session, nil
-	}
 	loaded, stopped, err := b.sessionLifecycle().StopLoaded(ctx, session)
 	if err != nil {
 		return nil, api.ConnectErrorForDomain(err)

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -342,6 +342,9 @@ func (h *SandboxHandler) ResumeSandbox(ctx context.Context, req *connect.Request
 	if sandbox.Summary.VMStatus != domain.VMStatusStopped {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sandbox %s cannot be resumed from state %s", sandbox.Summary.ID, sandbox.Summary.VMStatus))
 	}
+	if domain.SandboxWorkspaceUnavailable(sandbox) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sandbox %s workspace was reclaimed and cannot be resumed", sandbox.Summary.ID))
+	}
 	resumed, err := h.delegate.ResumeSandbox(ctx, sandbox.Summary.ID)
 	if err != nil {
 		return nil, err
@@ -394,6 +397,12 @@ func sandboxToV2WithTarget(sandbox *domain.Sandbox, target runs.SandboxRunTarget
 	}
 	for _, tag := range sandbox.Summary.Tags {
 		result.Tags = append(result.Tags, &agentcomposev2.SandboxTag{Name: tag.Name, Value: tag.Value})
+	}
+	if reclamation := sandbox.WorkspaceReclamation; reclamation != nil {
+		result.WorkspaceReclamationState = reclamation.State
+		result.WorkspaceReclamationStartedAt = sandboxHistoryTimestamp(reclamation.StartedAt)
+		result.WorkspaceReclamationCompletedAt = sandboxHistoryTimestamp(reclamation.CompletedAt)
+		result.WorkspaceReclamationLastError = reclamation.LastError
 	}
 	return result
 }

--- a/pkg/agentcompose/api/sandbox_reclamation_test.go
+++ b/pkg/agentcompose/api/sandbox_reclamation_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestSandboxToV2IncludesWorkspaceReclamation(t *testing.T) {
+	started := time.Date(2026, 7, 17, 1, 2, 3, 0, time.UTC)
+	completed := started.Add(time.Minute)
+	got := sandboxToV2(&domain.Sandbox{
+		Summary: domain.SandboxSummary{ID: "sandbox-1"},
+		WorkspaceReclamation: &domain.SandboxWorkspaceReclamation{
+			State: domain.SandboxWorkspaceReclamationStateReclaimed, StartedAt: started, CompletedAt: completed,
+		},
+	})
+	if got.GetWorkspaceReclamationState() != domain.SandboxWorkspaceReclamationStateReclaimed ||
+		!got.GetWorkspaceReclamationStartedAt().AsTime().Equal(started) ||
+		!got.GetWorkspaceReclamationCompletedAt().AsTime().Equal(completed) {
+		t.Fatalf("workspace reclamation = %#v", got)
+	}
+}

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -18,6 +18,7 @@ import (
 	"agent-compose/pkg/cache"
 	"agent-compose/pkg/capabilities"
 	"agent-compose/pkg/capproxy"
+	"agent-compose/pkg/cleanup"
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/dashboard"
 	"agent-compose/pkg/driver"
@@ -83,6 +84,7 @@ func RegisterDependencies(di do.Injector) {
 	do.Provide(di, NewRunController)
 	do.Provide(di, NewSandboxRunTargetResolver)
 	do.Provide(di, NewSandboxRemovalCoordinator)
+	do.Provide(di, NewCleanupRunner)
 	do.Provide(di, NewRunSupervisor)
 	do.Provide(di, NewProjectController)
 }
@@ -195,15 +197,40 @@ func NewSandboxRemovalCoordinator(di do.Injector) (*sessions.RemovalCoordinator,
 	}, nil
 }
 
+func NewCleanupRunner(di do.Injector) (*cleanup.Runner, error) {
+	config := do.MustInvoke[*appconfig.Config](di)
+	store := do.MustInvoke[*sessionstore.Store](di)
+	imageCache, err := imagecache.New(imagecache.Config{
+		Root: config.ImageCacheRoot, DefaultRegistry: config.ImageRegistry,
+		InsecureRegistries: config.ImageInsecureRegistries,
+	})
+	if err != nil {
+		return nil, err
+	}
+	store.SetCacheDependencyLocker(imageCache)
+	return &cleanup.Runner{
+		Interval: config.CleanupInterval,
+		Policies: []cleanup.Policy{
+			{TTL: config.WorkspaceCleanupTTL, Cleaner: &sessions.WorkspaceCleaner{Store: store, Locks: do.MustInvoke[*sessions.LifecycleLocks](di)}},
+			{TTL: config.ImageCacheCleanupTTL, Cleaner: &adapters.ImageCacheCleaner{Cache: imageCache, Sandboxes: store, SandboxRoot: config.SandboxRoot}},
+		},
+	}, nil
+}
+
 func StartBackground(di do.Injector) error {
+	// Constructing the cleanup runner installs the cache-dependency lock on the
+	// sandbox store. Do this before resolving or starting any component that can
+	// create a sandbox, so the initial cleanup pass cannot race registration.
+	runner := do.MustInvoke[*cleanup.Runner](di)
 	for _, warning := range do.MustInvoke[*sessions.RemovalCoordinator](di).Recover(do.MustInvoke[context.Context](di)) {
 		slog.Warn("failed to recover sandbox deletion", "warning", warning)
 	}
 	if err := syncLegacyDefaultProject(do.MustInvoke[context.Context](di), do.MustInvoke[*projects.Controller](di)); err != nil {
 		slog.Warn("failed to sync legacy v1 agents into the default project", "error", err)
 	}
-	return startBackgroundManagers(
-		do.MustInvoke[context.Context](di),
+	ctx := do.MustInvoke[context.Context](di)
+	if err := startBackgroundManagers(
+		ctx,
 		do.MustInvoke[*sessionstore.Store](di),
 		do.MustInvoke[*configstore.ConfigStore](di),
 		do.MustInvoke[*adapters.SandboxRPCBridge](di),
@@ -211,7 +238,19 @@ func StartBackground(di do.Injector) error {
 		do.MustInvoke[*events.Dispatcher](di),
 		do.MustInvoke[*capproxy.Server](di),
 		do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
-	)
+	); err != nil {
+		return err
+	}
+	runner.Start(ctx)
+	return nil
+}
+
+func StopBackground(ctx context.Context, di do.Injector) error {
+	runner, err := do.Invoke[*cleanup.Runner](di)
+	if err != nil {
+		return err
+	}
+	return runner.Shutdown(ctx)
 }
 
 func NewCapProxyServer(di do.Injector) (*capproxy.Server, error) {

--- a/pkg/agentcompose/app/app_test.go
+++ b/pkg/agentcompose/app/app_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/samber/do/v2"
 
 	"agent-compose/pkg/agentcompose/adapters"
+	"agent-compose/pkg/cleanup"
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/projects"
 	"agent-compose/pkg/runs"
@@ -79,6 +81,41 @@ func TestSetupRegistersServiceGraph(t *testing.T) {
 	app.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("proxy route status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+}
+
+func TestStartBackgroundConstructsCleanupBeforeLoader(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DATA_ROOT", root)
+	t.Setenv("SANDBOX_ROOT", filepath.Join(root, "sandboxes"))
+	t.Setenv("IMAGE_CACHE_ROOT", filepath.Join(root, "images"))
+	t.Setenv("RUNTIME_DRIVER", driverpkg.RuntimeDriverDocker)
+	t.Setenv("DOCKER_IMAGE", "guest:latest")
+	t.Setenv("LLM_API_ENDPOINT", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	di := do.New()
+	appconfig.Setup(di)
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, slog.Default())
+	RegisterDependencies(di)
+
+	var constructionOrder []string
+	do.Override(di, func(di do.Injector) (*cleanup.Runner, error) {
+		constructionOrder = append(constructionOrder, "cleanup")
+		return NewCleanupRunner(di)
+	})
+	do.Override(di, func(di do.Injector) (*loaders.Controller, error) {
+		constructionOrder = append(constructionOrder, "loader")
+		return NewLoaderController(di)
+	})
+
+	if err := StartBackground(di); err != nil {
+		t.Fatalf("StartBackground returned error: %v", err)
+	}
+	if len(constructionOrder) < 2 || constructionOrder[0] != "cleanup" || constructionOrder[1] != "loader" {
+		t.Fatalf("background construction order = %v, want cleanup before loader", constructionOrder)
 	}
 }
 

--- a/pkg/cleanup/runner.go
+++ b/pkg/cleanup/runner.go
@@ -1,0 +1,97 @@
+package cleanup
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+type Result struct {
+	Matched int
+	Removed int
+	Skipped int
+	Failed  int
+}
+
+type Cleaner interface {
+	Name() string
+	Clean(context.Context, time.Time) (Result, error)
+}
+
+type Policy struct {
+	TTL     time.Duration
+	Cleaner Cleaner
+}
+
+type Runner struct {
+	Interval time.Duration
+	Policies []Policy
+	Now      func() time.Time
+	Logger   *slog.Logger
+}
+
+func (r *Runner) Enabled() bool {
+	if r == nil || r.Interval <= 0 {
+		return false
+	}
+	for _, policy := range r.Policies {
+		if policy.TTL > 0 && policy.Cleaner != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Runner) Start(ctx context.Context) {
+	if !r.Enabled() {
+		return
+	}
+	go r.run(ctx)
+}
+
+func (r *Runner) run(ctx context.Context) {
+	r.runOnce(ctx)
+	ticker := time.NewTicker(r.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.runOnce(ctx)
+		}
+	}
+}
+
+func (r *Runner) runOnce(ctx context.Context) {
+	now := r.now()
+	for _, policy := range r.Policies {
+		if policy.TTL <= 0 || policy.Cleaner == nil || ctx.Err() != nil {
+			continue
+		}
+		cutoff := now.Add(-policy.TTL)
+		result, err := policy.Cleaner.Clean(ctx, cutoff)
+		logger := r.Logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		attrs := []any{
+			"cleaner", policy.Cleaner.Name(), "cutoff", cutoff,
+			"matched", result.Matched, "removed", result.Removed,
+			"skipped", result.Skipped, "failed", result.Failed,
+		}
+		if err != nil {
+			attrs = append(attrs, "error", err)
+			logger.Warn("automatic cleanup completed with errors", attrs...)
+			continue
+		}
+		logger.Info("automatic cleanup completed", attrs...)
+	}
+}
+
+func (r *Runner) now() time.Time {
+	if r != nil && r.Now != nil {
+		return r.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/pkg/cleanup/runner.go
+++ b/pkg/cleanup/runner.go
@@ -3,6 +3,7 @@ package cleanup
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -28,6 +29,10 @@ type Runner struct {
 	Policies []Policy
 	Now      func() time.Time
 	Logger   *slog.Logger
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 func (r *Runner) Enabled() bool {
@@ -46,7 +51,40 @@ func (r *Runner) Start(ctx context.Context) {
 	if !r.Enabled() {
 		return
 	}
-	go r.run(ctx)
+	r.mu.Lock()
+	if r.done != nil {
+		r.mu.Unlock()
+		return
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	r.done = make(chan struct{})
+	done := r.done
+	r.mu.Unlock()
+	go func() {
+		defer close(done)
+		r.run(runCtx)
+	}()
+}
+
+func (r *Runner) Shutdown(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	cancel := r.cancel
+	done := r.done
+	r.mu.Unlock()
+	if cancel == nil || done == nil {
+		return nil
+	}
+	cancel()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (r *Runner) run(ctx context.Context) {

--- a/pkg/cleanup/runner_test.go
+++ b/pkg/cleanup/runner_test.go
@@ -1,0 +1,50 @@
+package cleanup
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestRunnerRunOnceUsesIndependentPolicyCutoffs(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	first := &recordingCleaner{name: "workspace"}
+	second := &recordingCleaner{name: "image", err: errors.New("failed")}
+	runner := &Runner{
+		Interval: time.Hour,
+		Now:      func() time.Time { return now },
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Policies: []Policy{{TTL: 24 * time.Hour, Cleaner: first}, {TTL: 48 * time.Hour, Cleaner: second}, {TTL: 0, Cleaner: &recordingCleaner{name: "disabled"}}},
+	}
+	runner.runOnce(context.Background())
+	if len(first.cutoffs) != 1 || !first.cutoffs[0].Equal(now.Add(-24*time.Hour)) {
+		t.Fatalf("workspace cutoffs = %v", first.cutoffs)
+	}
+	if len(second.cutoffs) != 1 || !second.cutoffs[0].Equal(now.Add(-48*time.Hour)) {
+		t.Fatalf("image cutoffs = %v", second.cutoffs)
+	}
+}
+
+func TestRunnerDisabledWithoutPositivePolicy(t *testing.T) {
+	if (&Runner{Interval: time.Hour, Policies: []Policy{{TTL: 0, Cleaner: &recordingCleaner{}}}}).Enabled() {
+		t.Fatal("runner with zero TTL is enabled")
+	}
+	if (&Runner{Interval: 0, Policies: []Policy{{TTL: time.Hour, Cleaner: &recordingCleaner{}}}}).Enabled() {
+		t.Fatal("runner with zero interval is enabled")
+	}
+}
+
+type recordingCleaner struct {
+	name    string
+	err     error
+	cutoffs []time.Time
+}
+
+func (c *recordingCleaner) Name() string { return c.name }
+func (c *recordingCleaner) Clean(_ context.Context, cutoff time.Time) (Result, error) {
+	c.cutoffs = append(c.cutoffs, cutoff)
+	return Result{Matched: 1}, c.err
+}

--- a/pkg/cleanup/runner_test.go
+++ b/pkg/cleanup/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 )
@@ -37,10 +38,42 @@ func TestRunnerDisabledWithoutPositivePolicy(t *testing.T) {
 	}
 }
 
+func TestRunnerShutdownWaitsForActiveCleaner(t *testing.T) {
+	cleaner := &blockingCleaner{entered: make(chan struct{}), release: make(chan struct{})}
+	runner := &Runner{Interval: time.Hour, Policies: []Policy{{TTL: time.Hour, Cleaner: cleaner}}}
+	runner.Start(context.Background())
+	<-cleaner.entered
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- runner.Shutdown(context.Background()) }()
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("Shutdown returned before cleaner completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(cleaner.release)
+	if err := <-shutdownDone; err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+}
+
 type recordingCleaner struct {
 	name    string
 	err     error
 	cutoffs []time.Time
+}
+
+type blockingCleaner struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (*blockingCleaner) Name() string { return "blocking" }
+func (c *blockingCleaner) Clean(context.Context, time.Time) (Result, error) {
+	c.once.Do(func() { close(c.entered) })
+	<-c.release
+	return Result{}, nil
 }
 
 func (c *recordingCleaner) Name() string { return c.name }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,9 @@ type Config struct {
 	ImageInsecureRegistries    []string
 	BoxDiskSizeGB              int
 	CacheTTL                   time.Duration
+	CleanupInterval            time.Duration
+	WorkspaceCleanupTTL        time.Duration
+	ImageCacheCleanupTTL       time.Duration
 	ImagePullTimeout           time.Duration
 	GuestWorkspacePath         string
 	GuestHomePath              string
@@ -305,6 +308,22 @@ func NewConfig(di do.Injector) (*Config, error) {
 		cacheTTL = parsed
 	}
 
+	cleanupInterval, err := cleanupDurationEnv("CLEANUP_INTERVAL", time.Hour)
+	if err != nil {
+		return nil, err
+	}
+	workspaceCleanupTTL, err := cleanupDurationEnv("WORKSPACE_CLEANUP_TTL", 0)
+	if err != nil {
+		return nil, err
+	}
+	imageCacheCleanupTTL, err := cleanupDurationEnv("IMAGE_CACHE_CLEANUP_TTL", 0)
+	if err != nil {
+		return nil, err
+	}
+	if (workspaceCleanupTTL > 0 || imageCacheCleanupTTL > 0) && cleanupInterval <= 0 {
+		return nil, fmt.Errorf("CLEANUP_INTERVAL must be positive when automatic cleanup is enabled")
+	}
+
 	guestPaths := &Config{
 		GuestWorkspacePath: os.Getenv("GUEST_WORKSPACE"),
 		GuestStateRoot:     os.Getenv("GUEST_STATE_ROOT"),
@@ -473,6 +492,9 @@ func NewConfig(di do.Injector) (*Config, error) {
 		ImageInsecureRegistries:    imageInsecureRegistries,
 		BoxDiskSizeGB:              boxDiskSizeGB,
 		CacheTTL:                   cacheTTL,
+		CleanupInterval:            cleanupInterval,
+		WorkspaceCleanupTTL:        workspaceCleanupTTL,
+		ImageCacheCleanupTTL:       imageCacheCleanupTTL,
 		ImagePullTimeout:           imagePullTimeout,
 		GuestWorkspacePath:         guestPaths.GuestWorkspacePath,
 		GuestHomePath:              guestPaths.GuestHomePath,
@@ -488,6 +510,21 @@ func NewConfig(di do.Injector) (*Config, error) {
 		CapGRPCTarget:              strings.TrimSpace(os.Getenv("CAP_GRPC_TARGET")),
 		Version:                    BuildVersion,
 	}, nil
+}
+
+func cleanupDurationEnv(name string, defaultValue time.Duration) (time.Duration, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return defaultValue, nil
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s %q: %w", name, raw, err)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("%s must not be negative", name)
+	}
+	return parsed, nil
 }
 
 func Setup(di do.Injector) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -86,6 +86,31 @@ func TestNewConfigNormalizesJupyterProxyBase(t *testing.T) {
 	}
 }
 
+func TestNewConfigRejectsInvalidCleanupDurations(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		interval  string
+		workspace string
+		image     string
+	}{
+		{name: "negative workspace TTL", workspace: "-1h"},
+		{name: "invalid image TTL", image: "tomorrow"},
+		{name: "zero interval while enabled", interval: "0", workspace: "1h"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("DATA_ROOT", filepath.Join(t.TempDir(), "data"))
+			t.Setenv("CLEANUP_INTERVAL", test.interval)
+			t.Setenv("WORKSPACE_CLEANUP_TTL", test.workspace)
+			t.Setenv("IMAGE_CACHE_CLEANUP_TTL", test.image)
+			di := do.New()
+			do.ProvideValue(di, slog.Default())
+			if _, err := NewConfig(di); err == nil {
+				t.Fatal("NewConfig returned nil error")
+			}
+		})
+	}
+}
+
 func testNewConfigParsesEnvironment(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("DATA_ROOT", filepath.Join(root, "data"))
@@ -108,6 +133,9 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	t.Setenv("IMAGE_INSECURE_REGISTRIES", "oci-one.example; oci-two.example\noci-three.example")
 	t.Setenv("BOX_DISK_SIZE_GB", "11")
 	t.Setenv("CACHE_TTL", "2h")
+	t.Setenv("CLEANUP_INTERVAL", "30m")
+	t.Setenv("WORKSPACE_CLEANUP_TTL", "24h")
+	t.Setenv("IMAGE_CACHE_CLEANUP_TTL", "48h")
 	t.Setenv("GUEST_WORKSPACE", "/workspace")
 	t.Setenv("GUEST_HOME", "/home/test")
 	t.Setenv("GUEST_STATE_ROOT", "/state")
@@ -147,6 +175,9 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	}
 	if config.BoxDiskSizeGB != 11 || config.CacheTTL != 2*time.Hour {
 		t.Fatalf("box disk/cache = %d/%s", config.BoxDiskSizeGB, config.CacheTTL)
+	}
+	if config.CleanupInterval != 30*time.Minute || config.WorkspaceCleanupTTL != 24*time.Hour || config.ImageCacheCleanupTTL != 48*time.Hour {
+		t.Fatalf("cleanup config = %s/%s/%s", config.CleanupInterval, config.WorkspaceCleanupTTL, config.ImageCacheCleanupTTL)
 	}
 	if config.DefaultImage != "box:latest" || config.DockerDefaultImage != "docker:latest" || config.MicrosandboxDefaultImage != "box:latest" {
 		t.Fatalf("image config = %#v", config)

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -43,17 +43,18 @@ type SandboxVolumeMount struct {
 }
 
 type VMState struct {
-	Driver       string    `json:"driver"`
-	Mode         string    `json:"mode,omitempty"`
-	BoxName      string    `json:"box_name,omitempty"`
-	BoxID        string    `json:"box_id,omitempty"`
-	Image        string    `json:"image,omitempty"`
-	Registry     string    `json:"registry,omitempty"`
-	RuntimeHome  string    `json:"runtime_home,omitempty"`
-	StartedAt    time.Time `json:"started_at,omitempty"`
-	StoppedAt    time.Time `json:"stopped_at,omitempty"`
-	LastError    string    `json:"last_error,omitempty"`
-	BootstrapRef string    `json:"bootstrap_ref,omitempty"`
+	Driver           string    `json:"driver"`
+	Mode             string    `json:"mode,omitempty"`
+	BoxName          string    `json:"box_name,omitempty"`
+	BoxID            string    `json:"box_id,omitempty"`
+	Image            string    `json:"image,omitempty"`
+	Registry         string    `json:"registry,omitempty"`
+	RuntimeHome      string    `json:"runtime_home,omitempty"`
+	StartedAt        time.Time `json:"started_at,omitempty"`
+	StartAttemptedAt time.Time `json:"start_attempted_at,omitempty"`
+	StoppedAt        time.Time `json:"stopped_at,omitempty"`
+	LastError        string    `json:"last_error,omitempty"`
+	BootstrapRef     string    `json:"bootstrap_ref,omitempty"`
 }
 
 type ProxyState struct {

--- a/pkg/execution/driver.go
+++ b/pkg/execution/driver.go
@@ -49,33 +49,35 @@ func ToDriverSandbox(session *domain.Sandbox) *driverpkg.Sandbox {
 
 func ToDriverVMState(state domain.VMState) driverpkg.VMState {
 	return driverpkg.VMState{
-		Driver:       state.Driver,
-		Mode:         state.Mode,
-		BoxName:      state.BoxName,
-		BoxID:        state.BoxID,
-		Image:        state.Image,
-		Registry:     state.Registry,
-		RuntimeHome:  state.RuntimeHome,
-		StartedAt:    state.StartedAt,
-		StoppedAt:    state.StoppedAt,
-		LastError:    state.LastError,
-		BootstrapRef: state.BootstrapRef,
+		Driver:           state.Driver,
+		Mode:             state.Mode,
+		BoxName:          state.BoxName,
+		BoxID:            state.BoxID,
+		Image:            state.Image,
+		Registry:         state.Registry,
+		RuntimeHome:      state.RuntimeHome,
+		StartedAt:        state.StartedAt,
+		StartAttemptedAt: state.StartAttemptedAt,
+		StoppedAt:        state.StoppedAt,
+		LastError:        state.LastError,
+		BootstrapRef:     state.BootstrapRef,
 	}
 }
 
 func FromDriverVMState(state driverpkg.VMState) domain.VMState {
 	return domain.VMState{
-		Driver:       state.Driver,
-		Mode:         state.Mode,
-		BoxName:      state.BoxName,
-		BoxID:        state.BoxID,
-		Image:        state.Image,
-		Registry:     state.Registry,
-		RuntimeHome:  state.RuntimeHome,
-		StartedAt:    state.StartedAt,
-		StoppedAt:    state.StoppedAt,
-		LastError:    state.LastError,
-		BootstrapRef: state.BootstrapRef,
+		Driver:           state.Driver,
+		Mode:             state.Mode,
+		BoxName:          state.BoxName,
+		BoxID:            state.BoxID,
+		Image:            state.Image,
+		Registry:         state.Registry,
+		RuntimeHome:      state.RuntimeHome,
+		StartedAt:        state.StartedAt,
+		StartAttemptedAt: state.StartAttemptedAt,
+		StoppedAt:        state.StoppedAt,
+		LastError:        state.LastError,
+		BootstrapRef:     state.BootstrapRef,
 	}
 }
 

--- a/pkg/execution/driver_coverage_test.go
+++ b/pkg/execution/driver_coverage_test.go
@@ -29,7 +29,7 @@ func TestDriverConversionWorkflows(t *testing.T) {
 	if driverSession.Summary.ID != "sandbox-1" || len(driverSession.EnvItems) != 1 || !driverSession.EnvItems[0].Secret || len(driverSession.RuntimeEnvItems) != 1 {
 		t.Fatalf("driver sandbox = %#v", driverSession)
 	}
-	vmState := domain.VMState{Driver: "docker", Mode: "runtime", BoxName: "box", BoxID: "box-id", Image: "image", Registry: "registry", RuntimeHome: "/root", StartedAt: now, StoppedAt: now, LastError: "none", BootstrapRef: "boot"}
+	vmState := domain.VMState{Driver: "docker", Mode: "runtime", BoxName: "box", BoxID: "box-id", Image: "image", Registry: "registry", RuntimeHome: "/root", StartedAt: now, StartAttemptedAt: now, StoppedAt: now, LastError: "none", BootstrapRef: "boot"}
 	driverVMState := ToDriverVMState(vmState)
 	if got := FromDriverVMState(driverVMState); got != vmState {
 		t.Fatalf("vm state round trip = %#v", got)

--- a/pkg/imagecache/cache_test.go
+++ b/pkg/imagecache/cache_test.go
@@ -1,6 +1,7 @@
 package imagecache
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -111,6 +112,29 @@ func TestCacheLockTempDirAndReadyFlag(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Fatalf("WithLock returned error: %v", err)
+	}
+}
+
+func TestLockContextStopsWaitingWhenCanceled(t *testing.T) {
+	cache := newTestCache(t)
+	unlock, err := cache.Lock()
+	if err != nil {
+		t.Fatalf("Lock returned error: %v", err)
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			t.Errorf("unlock cache: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = cache.LockContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("LockContext error = %v, want context.Canceled", err)
+	}
+	if !IsKind(err, ErrorKindUnavailable) {
+		t.Fatalf("LockContext error kind = %q, want %q", Kind(err), ErrorKindUnavailable)
 	}
 }
 

--- a/pkg/imagecache/lock.go
+++ b/pkg/imagecache/lock.go
@@ -1,6 +1,8 @@
 package imagecache
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +13,13 @@ import (
 type UnlockFunc func() error
 
 func (c *Cache) Lock() (UnlockFunc, error) {
+	return c.LockContext(context.Background())
+}
+
+func (c *Cache) LockContext(ctx context.Context) (UnlockFunc, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, NewError(ErrorKindUnavailable, "lock", c.config.Root, err)
+	}
 	if err := c.Ensure(); err != nil {
 		return nil, err
 	}
@@ -19,9 +28,21 @@ func (c *Cache) Lock() (UnlockFunc, error) {
 	if err != nil {
 		return nil, NewError(ErrorKindInternal, "lock", lockPath, err)
 	}
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-		_ = lockFile.Close()
-		return nil, NewError(ErrorKindInternal, "lock", lockPath, err)
+	for {
+		err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			_ = lockFile.Close()
+			return nil, NewError(ErrorKindInternal, "lock", lockPath, err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = lockFile.Close()
+			return nil, NewError(ErrorKindUnavailable, "lock", lockPath, ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 	return func() error {
 		unlockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
@@ -33,13 +54,21 @@ func (c *Cache) Lock() (UnlockFunc, error) {
 	}, nil
 }
 
-func (c *Cache) WithLock(fn func() error) error {
-	unlock, err := c.Lock()
+func (c *Cache) WithLockContext(ctx context.Context, fn func() error) (returnErr error) {
+	unlock, err := c.LockContext(ctx)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = unlock() }()
+	defer func() {
+		if err := unlock(); err != nil {
+			returnErr = errors.Join(returnErr, err)
+		}
+	}()
 	return fn()
+}
+
+func (c *Cache) WithLock(fn func() error) error {
+	return c.WithLockContext(context.Background(), fn)
 }
 
 func (c *Cache) TempDir(name string) (string, error) {

--- a/pkg/imagecache/materialize.go
+++ b/pkg/imagecache/materialize.go
@@ -50,6 +50,9 @@ func (c *Cache) MaterializeOCILayout(ctx context.Context, ref string) (Materiali
 		LayoutPath:  layoutPath,
 	}
 	if ReadyFlagExists(readyFlag) && isValidOCILayoutPath(layoutPath) {
+		if err := c.touchMetadataImage(&metadata, image); err != nil {
+			return MaterializationResult{}, err
+		}
 		return result, nil
 	}
 	_ = os.Remove(readyFlag)
@@ -75,6 +78,9 @@ func (c *Cache) MaterializeOCILayout(ctx context.Context, ref string) (Materiali
 	}
 	_ = os.RemoveAll(tmpDir)
 	if err := WriteReadyFlag(readyFlag); err != nil {
+		return MaterializationResult{}, err
+	}
+	if err := c.touchMetadataImage(&metadata, image); err != nil {
 		return MaterializationResult{}, err
 	}
 	return result, nil

--- a/pkg/imagecache/prune.go
+++ b/pkg/imagecache/prune.go
@@ -1,0 +1,308 @@
+package imagecache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/match"
+)
+
+type PruneResult struct {
+	Matched int
+	Removed int
+	Skipped int
+	Failed  int
+}
+
+func (c *Cache) PruneBefore(ctx context.Context, cutoff time.Time, protectedIdentities []string) (PruneResult, error) {
+	return c.PruneBeforeWithProtection(ctx, cutoff, func(context.Context) ([]string, error) {
+		return protectedIdentities, nil
+	})
+}
+
+func (c *Cache) PruneBeforeWithProtection(ctx context.Context, cutoff time.Time, protection func(context.Context) ([]string, error)) (result PruneResult, returnErr error) {
+	if err := ctx.Err(); err != nil {
+		return PruneResult{}, err
+	}
+	if protection == nil {
+		return PruneResult{}, fmt.Errorf("image cache protection provider is required")
+	}
+	unlock, err := c.LockContext(ctx)
+	if err != nil {
+		return PruneResult{}, err
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			returnErr = errors.Join(returnErr, err)
+		}
+	}()
+	protectedIdentities, err := protection(ctx)
+	if err != nil {
+		return PruneResult{}, err
+	}
+	protected := make(map[string]struct{}, len(protectedIdentities))
+	for _, identity := range protectedIdentities {
+		if value := normalizeLookupValue(identity); value != "" {
+			protected[value] = struct{}{}
+		}
+	}
+	metadata, err := c.LoadMetadata()
+	if err != nil {
+		return PruneResult{}, err
+	}
+	retainUntrackedMaterializations := requiresConservativeMaterializationRetention(metadata.Images, protected)
+	result = PruneResult{}
+	remaining := make([]ImageMetadata, 0, len(metadata.Images))
+	removed := make([]ImageMetadata, 0)
+	for _, image := range metadata.Images {
+		usedAt := c.imageUsedAt(image)
+		if !usedAt.IsZero() && !usedAt.After(cutoff) {
+			result.Matched++
+			if imageIsProtected(image, protected) {
+				result.Skipped++
+				remaining = append(remaining, image)
+				continue
+			}
+			removed = append(removed, image)
+			continue
+		}
+		remaining = append(remaining, image)
+	}
+	if len(removed) > 0 {
+		metadata.Images = remaining
+		if err := c.SaveMetadata(metadata); err != nil {
+			return result, err
+		}
+	}
+	var joined error
+	retainedMaterializations := c.materializationPaths(remaining)
+	for _, image := range removed {
+		if err := ctx.Err(); err != nil {
+			return result, errors.Join(joined, err)
+		}
+		materializedPath := c.materializedImagePath(image)
+		if _, retained := retainedMaterializations[materializedPath]; retained {
+			result.Removed++
+			continue
+		}
+		if err := c.removeMaterializedImage(materializedPath); err != nil {
+			result.Failed++
+			joined = errors.Join(joined, err)
+			continue
+		}
+		result.Removed++
+	}
+	if err := c.removeUnreferencedManifests(remaining, removed, cutoff); err != nil {
+		joined = errors.Join(joined, err)
+	}
+	if orphanResult, err := c.pruneOldUntrackedPaths(ctx, cutoff, remaining, retainUntrackedMaterializations); err != nil {
+		joined = errors.Join(joined, err)
+		result.Matched += orphanResult.Matched
+		result.Removed += orphanResult.Removed
+		result.Failed += orphanResult.Failed
+	} else {
+		result.Matched += orphanResult.Matched
+		result.Removed += orphanResult.Removed
+	}
+	return result, joined
+}
+
+func (c *Cache) imageUsedAt(image ImageMetadata) time.Time {
+	if !image.LastUsedAt.IsZero() {
+		return image.LastUsedAt.UTC()
+	}
+	if !image.PulledAt.IsZero() {
+		return image.PulledAt.UTC()
+	}
+	var latest time.Time
+	paths := []string{image.RootFSCachePath, image.LayoutCachePath}
+	if digest := strings.TrimSpace(image.ManifestDigest); strings.HasPrefix(digest, "sha256:") {
+		paths = append(paths, filepath.Join(c.OCILayoutPath(), "blobs", "sha256", strings.TrimPrefix(digest, "sha256:")))
+	}
+	for _, path := range paths {
+		if info, err := os.Stat(strings.TrimSpace(path)); err == nil && info.ModTime().After(latest) {
+			latest = info.ModTime().UTC()
+		}
+	}
+	return latest
+}
+
+func imageIsProtected(image ImageMetadata, protected map[string]struct{}) bool {
+	for _, value := range imageLookupValues(image) {
+		if _, ok := protected[normalizeLookupValue(value)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func requiresConservativeMaterializationRetention(images []ImageMetadata, protected map[string]struct{}) bool {
+	for identity := range protected {
+		if !isImmutableImageIdentity(identity) {
+			return true
+		}
+		resolved := false
+		for _, image := range images {
+			if imageMatchesLookup(image, identity) {
+				resolved = true
+				break
+			}
+		}
+		if !resolved {
+			return true
+		}
+	}
+	return false
+}
+
+func isImmutableImageIdentity(identity string) bool {
+	identity = normalizeLookupValue(identity)
+	return strings.HasPrefix(identity, "sha256:") || strings.Contains(identity, "@sha256:")
+}
+
+func (c *Cache) materializedImagePath(image ImageMetadata) string {
+	imageID := firstNonEmpty(image.ConfigDigest, image.CacheKey, image.ManifestDigest, image.NormalizedRef)
+	if strings.TrimSpace(imageID) == "" {
+		return ""
+	}
+	return filepath.Clean(c.MaterializedImageDir(imageID))
+}
+
+func (c *Cache) materializationPaths(images []ImageMetadata) map[string]struct{} {
+	paths := make(map[string]struct{}, len(images))
+	for _, image := range images {
+		if path := c.materializedImagePath(image); path != "" {
+			paths[path] = struct{}{}
+		}
+	}
+	return paths
+}
+
+func (c *Cache) removeMaterializedImage(target string) error {
+	if target == "" {
+		return nil
+	}
+	root, err := filepath.Abs(c.MaterializationRoot())
+	if err != nil {
+		return err
+	}
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+	if filepath.Dir(abs) != root {
+		return fmt.Errorf("materialized image path %q is outside cache root", abs)
+	}
+	return os.RemoveAll(abs)
+}
+
+func (c *Cache) removeUnreferencedManifests(images, removed []ImageMetadata, cutoff time.Time) error {
+	if _, err := os.Stat(filepath.Join(c.OCILayoutPath(), "index.json")); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	keep := make(map[string]struct{}, len(images))
+	for _, image := range images {
+		if digest := strings.TrimSpace(image.ManifestDigest); digest != "" {
+			keep[digest] = struct{}{}
+		}
+	}
+	expired := make(map[string]struct{}, len(removed))
+	for _, image := range removed {
+		if digest := strings.TrimSpace(image.ManifestDigest); digest != "" {
+			expired[digest] = struct{}{}
+		}
+	}
+	path := layout.Path(c.OCILayoutPath())
+	index, err := path.ImageIndex()
+	if err != nil {
+		return err
+	}
+	manifest, err := index.IndexManifest()
+	if err != nil {
+		return err
+	}
+	for _, descriptor := range manifest.Manifests {
+		if _, ok := keep[descriptor.Digest.String()]; ok {
+			continue
+		}
+		if _, explicitlyExpired := expired[descriptor.Digest.String()]; !explicitlyExpired {
+			info, statErr := os.Stat(filepath.Join(c.OCILayoutPath(), "blobs", descriptor.Digest.Algorithm, descriptor.Digest.Hex))
+			if statErr != nil || info.ModTime().After(cutoff) {
+				continue
+			}
+		}
+		digest, err := v1.NewHash(descriptor.Digest.String())
+		if err != nil {
+			return err
+		}
+		if err := path.RemoveDescriptors(match.Digests(digest)); err != nil {
+			return err
+		}
+	}
+	orphans, err := path.GarbageCollect()
+	if err != nil {
+		return err
+	}
+	for _, orphan := range orphans {
+		if err := path.RemoveBlob(orphan); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Cache) pruneOldUntrackedPaths(ctx context.Context, cutoff time.Time, images []ImageMetadata, retainUntrackedMaterializations bool) (PruneResult, error) {
+	tracked := make(map[string]struct{}, len(images))
+	for _, image := range images {
+		imageID := firstNonEmpty(image.ConfigDigest, image.CacheKey, image.ManifestDigest, image.NormalizedRef)
+		if imageID != "" {
+			tracked[filepath.Base(c.MaterializedImageDir(imageID))] = struct{}{}
+		}
+	}
+	result := PruneResult{}
+	var joined error
+	for _, root := range []string{filepath.Join(c.Root(), "tmp"), c.MaterializationRoot()} {
+		if root == c.MaterializationRoot() && retainUntrackedMaterializations {
+			continue
+		}
+		entries, err := os.ReadDir(root)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			joined = errors.Join(joined, err)
+			continue
+		}
+		for _, entry := range entries {
+			if err := ctx.Err(); err != nil {
+				return result, errors.Join(joined, err)
+			}
+			if root == c.MaterializationRoot() {
+				if _, ok := tracked[entry.Name()]; ok {
+					continue
+				}
+			}
+			info, err := entry.Info()
+			if err != nil || info.ModTime().After(cutoff) {
+				continue
+			}
+			result.Matched++
+			if err := os.RemoveAll(filepath.Join(root, entry.Name())); err != nil {
+				result.Failed++
+				joined = errors.Join(joined, err)
+				continue
+			}
+			result.Removed++
+		}
+	}
+	return result, joined
+}

--- a/pkg/imagecache/prune_test.go
+++ b/pkg/imagecache/prune_test.go
@@ -1,0 +1,157 @@
+package imagecache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPruneBeforeUsesLastUsedAndProtectsReferencedImage(t *testing.T) {
+	cache := newTestCache(t)
+	old := writeMaterializeTestImage(t, cache, "team/old:latest")
+	metadata, err := cache.LoadMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	for index := range metadata.Images {
+		metadata.Images[index].PulledAt = now.Add(-30 * 24 * time.Hour)
+		metadata.Images[index].LastUsedAt = now.Add(-20 * 24 * time.Hour)
+	}
+	if err := cache.SaveMetadata(metadata); err != nil {
+		t.Fatal(err)
+	}
+
+	protected, err := cache.PruneBefore(context.Background(), now.Add(-7*24*time.Hour), []string{old.RequestedRef})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if protected.Matched != 1 || protected.Skipped != 1 || protected.Removed != 0 {
+		t.Fatalf("protected result = %#v", protected)
+	}
+
+	removed, err := cache.PruneBefore(context.Background(), now.Add(-7*24*time.Hour), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed.Matched != 1 || removed.Removed != 1 {
+		t.Fatalf("removed result = %#v", removed)
+	}
+	got, err := cache.LoadMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Images) != 0 {
+		t.Fatalf("remaining metadata = %#v", got.Images)
+	}
+}
+
+func TestImageUsedAtPrefersLastUsedAndFallsBackToPulled(t *testing.T) {
+	cache := newTestCache(t)
+	pulled := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	used := pulled.Add(24 * time.Hour)
+	if got := cache.imageUsedAt(ImageMetadata{PulledAt: pulled, LastUsedAt: used}); !got.Equal(used) {
+		t.Fatalf("imageUsedAt with usage = %s", got)
+	}
+	if got := cache.imageUsedAt(ImageMetadata{PulledAt: pulled}); !got.Equal(pulled) {
+		t.Fatalf("imageUsedAt fallback = %s", got)
+	}
+}
+
+func TestPruneBeforeRemovesOldUntrackedMaterialization(t *testing.T) {
+	cache := newTestCache(t)
+	path := cache.MaterializedImageDir("orphan")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	result, err := cache.PruneBefore(context.Background(), time.Now().Add(-24*time.Hour), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 1 || result.Removed != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("orphan materialization still exists: %v", err)
+	}
+}
+
+func TestPruneBeforePreservesMaterializationUsedByRetainedAlias(t *testing.T) {
+	cache := newTestCache(t)
+	old := writeMaterializeTestImage(t, cache, "team/app:old")
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	old.PulledAt = now.Add(-30 * 24 * time.Hour)
+	old.LastUsedAt = now.Add(-20 * 24 * time.Hour)
+	recent := old
+	recent.RequestedRef = "team/app:recent"
+	recent.NormalizedRef = "index.docker.io/team/app:recent"
+	recent.RepoTags = []string{"team/app:recent"}
+	recent.LastUsedAt = now.Add(-time.Hour)
+	if err := cache.SaveMetadata(MetadataFile{Images: []ImageMetadata{old, recent}}); err != nil {
+		t.Fatal(err)
+	}
+	materializedPath := cache.MaterializedImageDir(old.ConfigDigest)
+	if err := os.MkdirAll(materializedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(materializedPath, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("retained"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := cache.PruneBefore(context.Background(), now.Add(-7*24*time.Hour), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 1 || result.Removed != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("retained alias materialization was removed: %v", err)
+	}
+	metadata, err := cache.LoadMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metadata.Images) != 1 || metadata.Images[0].RequestedRef != recent.RequestedRef {
+		t.Fatalf("remaining metadata = %#v", metadata.Images)
+	}
+}
+
+func TestPruneBeforePreservesUntrackedMaterializationForMutableSandboxRef(t *testing.T) {
+	cache := newTestCache(t)
+	old := writeMaterializeTestImage(t, cache, "team/app:latest")
+	current := writeMaterializeTestImage(t, cache, "team/app:latest")
+	if old.ConfigDigest == current.ConfigDigest {
+		t.Fatal("test images unexpectedly share a config digest")
+	}
+	oldPath := cache.MaterializedImageDir(old.ConfigDigest)
+	if err := os.MkdirAll(oldPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(oldPath, "sandbox-rootfs")
+	if err := os.WriteFile(sentinel, []byte("in use"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := cache.PruneBefore(context.Background(), time.Now().Add(-24*time.Hour), []string{"team/app:latest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed != 0 {
+		t.Fatalf("cleanup removed protected untracked materialization: %#v", result)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("protected untracked materialization was removed: %v", err)
+	}
+}

--- a/pkg/imagecache/pull.go
+++ b/pkg/imagecache/pull.go
@@ -94,6 +94,7 @@ func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 		return PullResult{Progress: progress}, NewError(ErrorKindInternal, "pull", req.Reference, err)
 	}
 
+	now := time.Now().UTC()
 	image, err := NewImageMetadata(MetadataInput{
 		RequestedRef:    req.Reference,
 		ManifestDigest:  manifestDigest.String(),
@@ -103,7 +104,7 @@ func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 		Labels:          configFile.Config.Labels,
 		SizeBytes:       sizeBytes,
 		CreatedAt:       configFile.Created.Time,
-		PulledAt:        time.Now().UTC(),
+		PulledAt:        now,
 		LayoutCachePath: c.OCILayoutPath(),
 		DefaultRegistry: c.config.DefaultRegistry,
 	})
@@ -111,6 +112,7 @@ func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 		progress := finishProgress(progressCh, progressDone)
 		return PullResult{Progress: progress}, err
 	}
+	image.LastUsedAt = now
 
 	metadata, err := c.LoadMetadata()
 	if err != nil {

--- a/pkg/imagecache/rootfs.go
+++ b/pkg/imagecache/rootfs.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
@@ -52,6 +53,9 @@ func (c *Cache) MaterializeRootFS(ctx context.Context, ref string) (Materializat
 		RootFSPath:  rootfsPath,
 	}
 	if ReadyFlagExists(readyFlag) && isUsableRootFS(rootfsPath) {
+		if err := c.touchMetadataImage(&metadata, image); err != nil {
+			return MaterializationResult{}, err
+		}
 		return result, nil
 	}
 	_ = os.Remove(readyFlag)
@@ -80,11 +84,21 @@ func (c *Cache) MaterializeRootFS(ctx context.Context, ref string) (Materializat
 	}
 	if idx := indexOfImage(metadata.Images, image); idx >= 0 {
 		metadata.Images[idx].RootFSCachePath = rootfsPath
+		metadata.Images[idx].LastUsedAt = time.Now().UTC()
 		if err := c.SaveMetadata(metadata); err != nil {
 			return MaterializationResult{}, err
 		}
 	}
 	return result, nil
+}
+
+func (c *Cache) touchMetadataImage(metadata *MetadataFile, image ImageMetadata) error {
+	idx := indexOfImage(metadata.Images, image)
+	if idx < 0 {
+		return nil
+	}
+	metadata.Images[idx].LastUsedAt = time.Now().UTC()
+	return c.SaveMetadata(*metadata)
 }
 
 func extractRootFSFromOCILayout(ctx context.Context, layoutPath, manifestDigest, dstDir string) error {

--- a/pkg/imagecache/types.go
+++ b/pkg/imagecache/types.go
@@ -45,6 +45,7 @@ type ImageMetadata struct {
 	SizeBytes       int64             `json:"size_bytes,omitempty"`
 	CreatedAt       time.Time         `json:"created_at,omitempty"`
 	PulledAt        time.Time         `json:"pulled_at,omitempty"`
+	LastUsedAt      time.Time         `json:"last_used_at,omitempty"`
 	LayoutCachePath string            `json:"layout_cache_path,omitempty"`
 	RootFSCachePath string            `json:"rootfs_cache_path,omitempty"`
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -22,6 +22,9 @@ const (
 	SandboxWorkspaceProvisioningStatusPending = "pending"
 	SandboxWorkspaceProvisioningStatusReady   = "ready"
 	SandboxWorkspaceProvisioningStatusFailed  = "failed"
+
+	SandboxWorkspaceReclamationStateReclaiming = "reclaiming"
+	SandboxWorkspaceReclamationStateReclaimed  = "reclaimed"
 )
 
 type SandboxTag struct {
@@ -164,16 +167,35 @@ type SandboxWorkspaceProvisioning struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+type SandboxWorkspaceReclamation struct {
+	State       string    `json:"state"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+	LastError   string    `json:"last_error,omitempty"`
+}
+
 type Sandbox struct {
 	Summary               SandboxSummary                `json:"summary"`
 	BaseWorkspace         string                        `json:"base_workspace,omitempty"`
 	WorkspaceID           string                        `json:"workspace_id,omitempty"`
 	Workspace             *SandboxWorkspace             `json:"workspace,omitempty"`
 	WorkspaceProvisioning *SandboxWorkspaceProvisioning `json:"workspace_provisioning,omitempty"`
+	WorkspaceReclamation  *SandboxWorkspaceReclamation  `json:"workspace_reclamation,omitempty"`
 	EnvItems              []SandboxEnvVar               `json:"env_items,omitempty"`
 	VolumeMounts          []SandboxVolumeMount          `json:"volume_mounts,omitempty"`
 	RuntimeEnvItems       []SandboxEnvVar               `json:"-"`
 	ProviderEnvItems      []SandboxEnvVar               `json:"-"`
+}
+
+func SandboxWorkspaceReclaimed(sandbox *Sandbox) bool {
+	if sandbox == nil || sandbox.WorkspaceReclamation == nil {
+		return false
+	}
+	return sandbox.WorkspaceReclamation.State == SandboxWorkspaceReclamationStateReclaimed
+}
+
+func SandboxWorkspaceUnavailable(sandbox *Sandbox) bool {
+	return sandbox != nil && sandbox.WorkspaceReclamation != nil
 }
 
 func ValidateSandboxWorkspaceProvisioning(provisioning *SandboxWorkspaceProvisioning) error {
@@ -451,17 +473,18 @@ type RuntimeCommandResult struct {
 type ExecStreamWriter func(ExecChunk)
 
 type VMState struct {
-	Driver       string    `json:"driver"`
-	Mode         string    `json:"mode,omitempty"`
-	BoxName      string    `json:"box_name,omitempty"`
-	BoxID        string    `json:"box_id,omitempty"`
-	Image        string    `json:"image,omitempty"`
-	Registry     string    `json:"registry,omitempty"`
-	RuntimeHome  string    `json:"runtime_home,omitempty"`
-	StartedAt    time.Time `json:"started_at,omitempty"`
-	StoppedAt    time.Time `json:"stopped_at,omitempty"`
-	LastError    string    `json:"last_error,omitempty"`
-	BootstrapRef string    `json:"bootstrap_ref,omitempty"`
+	Driver           string    `json:"driver"`
+	Mode             string    `json:"mode,omitempty"`
+	BoxName          string    `json:"box_name,omitempty"`
+	BoxID            string    `json:"box_id,omitempty"`
+	Image            string    `json:"image,omitempty"`
+	Registry         string    `json:"registry,omitempty"`
+	RuntimeHome      string    `json:"runtime_home,omitempty"`
+	StartedAt        time.Time `json:"started_at,omitempty"`
+	StartAttemptedAt time.Time `json:"start_attempted_at,omitempty"`
+	StoppedAt        time.Time `json:"stopped_at,omitempty"`
+	LastError        string    `json:"last_error,omitempty"`
+	BootstrapRef     string    `json:"bootstrap_ref,omitempty"`
 }
 
 type ProxyState struct {

--- a/pkg/sessions/lifecycle.go
+++ b/pkg/sessions/lifecycle.go
@@ -232,6 +232,9 @@ func (l Lifecycle) ResumeLoaded(ctx context.Context, session *domain.Sandbox, ca
 }
 
 func (l Lifecycle) ensureWorkspace(ctx context.Context, session *domain.Sandbox) error {
+	if domain.SandboxWorkspaceUnavailable(session) {
+		return domain.ClassifyError(domain.ErrFailedPrecondition, "sandbox workspace was reclaimed and cannot be resumed", nil)
+	}
 	if l.WorkspaceEnsurer == nil {
 		return fmt.Errorf("workspace ensurer is not configured")
 	}

--- a/pkg/sessions/lifecycle.go
+++ b/pkg/sessions/lifecycle.go
@@ -258,7 +258,11 @@ func (l Lifecycle) StopLoaded(ctx context.Context, session *domain.Sandbox) (*do
 	if session.Summary.VMStatus == domain.VMStatusDeleting {
 		return nil, false, fmt.Errorf("sandbox is being deleted")
 	}
-	if session.Summary.VMStatus != domain.VMStatusRunning {
+	stopRequired, err := l.stopRequired(session)
+	if err != nil {
+		return nil, false, err
+	}
+	if !stopRequired {
 		return session, false, nil
 	}
 	if err := l.Driver.StopSandboxVM(ctx, session); err != nil {
@@ -283,6 +287,18 @@ func (l Lifecycle) StopLoaded(ctx context.Context, session *domain.Sandbox) (*do
 		return nil, false, err
 	}
 	return loaded, true, nil
+}
+
+func (l Lifecycle) stopRequired(session *domain.Sandbox) (bool, error) {
+	if session.Summary.VMStatus == domain.VMStatusRunning {
+		return true, nil
+	}
+	vmState, err := l.Store.GetVMState(session.Summary.ID)
+	if err != nil {
+		return false, err
+	}
+	latestStartRecorded := !vmState.StartedAt.IsZero() || !vmState.StartAttemptedAt.IsZero()
+	return latestStartRecorded && !vmStopIsCurrent(vmState), nil
 }
 
 func (l Lifecycle) publishSandboxUpdated(summary *domain.SandboxSummary) {

--- a/pkg/sessions/lifecycle_coverage_test.go
+++ b/pkg/sessions/lifecycle_coverage_test.go
@@ -78,6 +78,42 @@ func TestLifecycleReconcileRuntimeStateEarlyReturns(t *testing.T) {
 	}
 }
 
+func TestLifecycleStopLoadedConfirmsUnresolvedStartAttempt(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	session := lifecycleTestSession("session-start-attempt", driverpkg.RuntimeDriverDocker, domain.VMStatusStopped)
+	store := &fakeLifecycleStore{session: session, vmState: domain.VMState{
+		StoppedAt: now.Add(-2 * time.Hour), StartAttemptedAt: now.Add(-time.Hour),
+	}}
+	driver := &fakeSandboxDriver{}
+	lifecycle := Lifecycle{Store: store, Driver: driver, Locks: NewLifecycleLocks()}
+
+	loaded, stopped, err := lifecycle.StopLoaded(context.Background(), session)
+	if err != nil {
+		t.Fatalf("StopLoaded returned error: %v", err)
+	}
+	if !stopped || !driver.stopped || loaded.Summary.VMStatus != domain.VMStatusStopped {
+		t.Fatalf("stopped/driver/loaded = %v/%v/%#v", stopped, driver.stopped, loaded)
+	}
+	if store.updated != 1 || store.events != 1 {
+		t.Fatalf("updates/events = %d/%d, want 1/1", store.updated, store.events)
+	}
+}
+
+func TestLifecycleStopLoadedSkipsConfirmedStoppedSandbox(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	session := lifecycleTestSession("session-confirmed-stop", driverpkg.RuntimeDriverDocker, domain.VMStatusStopped)
+	store := &fakeLifecycleStore{session: session, vmState: domain.VMState{
+		StartAttemptedAt: now.Add(-2 * time.Hour), StoppedAt: now.Add(-time.Hour),
+	}}
+	driver := &fakeSandboxDriver{}
+	lifecycle := Lifecycle{Store: store, Driver: driver, Locks: NewLifecycleLocks()}
+
+	loaded, stopped, err := lifecycle.StopLoaded(context.Background(), session)
+	if err != nil || stopped || driver.stopped || loaded != session {
+		t.Fatalf("StopLoaded confirmed stop = %#v/%v/%v, driver stopped=%v", loaded, stopped, err, driver.stopped)
+	}
+}
+
 func TestLifecycleEnsureProxyReadyBranches(t *testing.T) {
 	t.Run("running reachable fast path skips workspace ensure", func(t *testing.T) {
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -584,6 +620,7 @@ type fakeSandboxDriver struct {
 	startErr    error
 	stopErr     error
 	started     bool
+	stopped     bool
 }
 
 func (d *fakeSandboxDriver) ValidateSandboxRuntime(*domain.Sandbox) error {
@@ -596,6 +633,7 @@ func (d *fakeSandboxDriver) StartSandboxVM(context.Context, *domain.Sandbox) err
 }
 
 func (d *fakeSandboxDriver) StopSandboxVM(context.Context, *domain.Sandbox) error {
+	d.stopped = true
 	return d.stopErr
 }
 

--- a/pkg/sessions/workspace_cleanup.go
+++ b/pkg/sessions/workspace_cleanup.go
@@ -1,0 +1,183 @@
+package sessions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"agent-compose/pkg/cleanup"
+	domain "agent-compose/pkg/model"
+)
+
+type WorkspaceCleanupStore interface {
+	ListSandboxes(context.Context, domain.SandboxListOptions) (domain.SandboxListResult, error)
+	GetSandbox(context.Context, string) (*domain.Sandbox, error)
+	GetVMState(string) (domain.VMState, error)
+	UpdateSandbox(context.Context, *domain.Sandbox) error
+	AddEvent(context.Context, string, domain.SandboxEvent) error
+	SandboxDir(string) string
+}
+
+type WorkspaceCleaner struct {
+	Store WorkspaceCleanupStore
+	Locks *LifecycleLocks
+	Now   func() time.Time
+}
+
+func (c *WorkspaceCleaner) Name() string { return "sandbox-workspace" }
+
+func (c *WorkspaceCleaner) Clean(ctx context.Context, cutoff time.Time) (cleanup.Result, error) {
+	if c == nil || c.Store == nil {
+		return cleanup.Result{}, fmt.Errorf("workspace cleaner store is not configured")
+	}
+	listed, err := c.Store.ListSandboxes(ctx, domain.SandboxListOptions{Limit: 1 << 30})
+	if err != nil {
+		return cleanup.Result{}, err
+	}
+	result := cleanup.Result{}
+	var joined error
+	for _, sandbox := range listed.Sandboxes {
+		if err := ctx.Err(); err != nil {
+			return result, errors.Join(joined, err)
+		}
+		matched, removed, err := c.cleanSandbox(ctx, sandbox.Summary.ID, cutoff)
+		if err != nil {
+			if matched {
+				result.Matched++
+			}
+			result.Failed++
+			joined = errors.Join(joined, fmt.Errorf("reclaim workspace for sandbox %s: %w", sandbox.Summary.ID, err))
+			continue
+		}
+		if !matched {
+			result.Skipped++
+			continue
+		}
+		result.Matched++
+		if removed {
+			result.Removed++
+		}
+	}
+	return result, joined
+}
+
+func (c *WorkspaceCleaner) cleanSandbox(ctx context.Context, sandboxID string, cutoff time.Time) (bool, bool, error) {
+	unlock := c.Locks.Lock(sandboxID)
+	defer unlock()
+
+	sandbox, err := c.Store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return false, false, err
+	}
+	if sandbox.WorkspaceReclamation != nil && sandbox.WorkspaceReclamation.State == domain.SandboxWorkspaceReclamationStateReclaimed {
+		return false, false, nil
+	}
+	retrying := sandbox.WorkspaceReclamation != nil && sandbox.WorkspaceReclamation.State == domain.SandboxWorkspaceReclamationStateReclaiming
+	if sandbox.WorkspaceReclamation != nil && !retrying {
+		return false, false, fmt.Errorf("unknown workspace reclamation state %q", sandbox.WorkspaceReclamation.State)
+	}
+	if !retrying {
+		eligibleAt, ok, err := c.workspaceEligibleAt(sandbox)
+		if err != nil || !ok || eligibleAt.After(cutoff) {
+			return false, false, err
+		}
+		if _, err := c.safeWorkspacePath(sandbox); err != nil {
+			return true, false, err
+		}
+		now := c.now()
+		sandbox.WorkspaceReclamation = &domain.SandboxWorkspaceReclamation{
+			State: domain.SandboxWorkspaceReclamationStateReclaiming, StartedAt: now,
+		}
+		if err := c.Store.UpdateSandbox(ctx, sandbox); err != nil {
+			return true, false, fmt.Errorf("persist reclamation intent: %w", err)
+		}
+	}
+
+	// Validate again after persisting intent so an external path replacement
+	// cannot turn the destructive operation into an unsafe deletion.
+	workspacePath, err := c.safeWorkspacePath(sandbox)
+	if err == nil {
+		err = os.RemoveAll(workspacePath)
+	}
+	if err != nil {
+		sandbox.WorkspaceReclamation.LastError = err.Error()
+		// The persisted reclaiming intent remains the recovery boundary even if
+		// recording the latest retry error also fails.
+		_ = c.Store.UpdateSandbox(ctx, sandbox)
+		return true, false, err
+	}
+	sandbox.WorkspaceReclamation.State = domain.SandboxWorkspaceReclamationStateReclaimed
+	sandbox.WorkspaceReclamation.CompletedAt = c.now()
+	sandbox.WorkspaceReclamation.LastError = ""
+	if err := c.Store.UpdateSandbox(ctx, sandbox); err != nil {
+		return true, false, fmt.Errorf("persist reclaimed workspace: %w", err)
+	}
+	// Reclamation state is the durable audit record; an event append failure
+	// must not make a completed, irreversible deletion retry as available.
+	_ = c.Store.AddEvent(ctx, sandboxID, domain.SandboxEvent{
+		ID: uuid.NewString(), Type: "sandbox.workspace_reclaimed", Level: "info",
+		Message: "sandbox workspace was reclaimed by retention policy", CreatedAt: c.now(),
+	})
+	return true, true, nil
+}
+
+func (c *WorkspaceCleaner) workspaceEligibleAt(sandbox *domain.Sandbox) (time.Time, bool, error) {
+	if sandbox == nil {
+		return time.Time{}, false, nil
+	}
+	if sandbox.Summary.VMStatus != domain.VMStatusStopped {
+		return time.Time{}, false, nil
+	}
+	vmState, err := c.Store.GetVMState(sandbox.Summary.ID)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if vmState.StoppedAt.IsZero() {
+		return time.Time{}, false, nil
+	}
+	if !vmState.StartedAt.IsZero() && vmState.StoppedAt.Before(vmState.StartedAt) {
+		return time.Time{}, false, nil
+	}
+	if !vmState.StartAttemptedAt.IsZero() && vmState.StoppedAt.Before(vmState.StartAttemptedAt) {
+		return time.Time{}, false, nil
+	}
+	return vmState.StoppedAt.UTC(), true, nil
+}
+
+func (c *WorkspaceCleaner) safeWorkspacePath(sandbox *domain.Sandbox) (string, error) {
+	expected, err := filepath.Abs(filepath.Join(c.Store.SandboxDir(sandbox.Summary.ID), "workspace"))
+	if err != nil {
+		return "", err
+	}
+	actual, err := filepath.Abs(strings.TrimSpace(sandbox.Summary.WorkspacePath))
+	if err != nil {
+		return "", err
+	}
+	if actual != expected {
+		return "", fmt.Errorf("workspace path %q is outside its authoritative sandbox", actual)
+	}
+	info, err := os.Lstat(actual)
+	if os.IsNotExist(err) {
+		return actual, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", fmt.Errorf("workspace path %q is not a safe directory", actual)
+	}
+	return actual, nil
+}
+
+func (c *WorkspaceCleaner) now() time.Time {
+	if c.Now != nil {
+		return c.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/pkg/sessions/workspace_cleanup.go
+++ b/pkg/sessions/workspace_cleanup.go
@@ -141,13 +141,18 @@ func (c *WorkspaceCleaner) workspaceEligibleAt(sandbox *domain.Sandbox) (time.Ti
 	if vmState.StoppedAt.IsZero() {
 		return time.Time{}, false, nil
 	}
-	if !vmState.StartedAt.IsZero() && vmState.StoppedAt.Before(vmState.StartedAt) {
-		return time.Time{}, false, nil
-	}
-	if !vmState.StartAttemptedAt.IsZero() && vmState.StoppedAt.Before(vmState.StartAttemptedAt) {
+	if !vmStopIsCurrent(vmState) {
 		return time.Time{}, false, nil
 	}
 	return vmState.StoppedAt.UTC(), true, nil
+}
+
+func vmStopIsCurrent(vmState domain.VMState) bool {
+	if vmState.StoppedAt.IsZero() {
+		return false
+	}
+	return (vmState.StartedAt.IsZero() || !vmState.StoppedAt.Before(vmState.StartedAt)) &&
+		(vmState.StartAttemptedAt.IsZero() || !vmState.StoppedAt.Before(vmState.StartAttemptedAt))
 }
 
 func (c *WorkspaceCleaner) safeWorkspacePath(sandbox *domain.Sandbox) (string, error) {

--- a/pkg/sessions/workspace_cleanup_test.go
+++ b/pkg/sessions/workspace_cleanup_test.go
@@ -1,0 +1,214 @@
+package sessions_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sessions"
+	"agent-compose/pkg/storage/sessionstore"
+	"agent-compose/pkg/workspaces"
+)
+
+func TestWorkspaceCleanerReclaimsStoppedSandboxAndBlocksProvisioning(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	store, sandbox := newWorkspaceCleanupSandbox(t, now.Add(-48*time.Hour))
+	workspaceFile := filepath.Join(sandbox.Summary.WorkspacePath, "result.txt")
+	if err := os.WriteFile(workspaceFile, []byte("result"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaner := &sessions.WorkspaceCleaner{Store: store, Locks: sessions.NewLifecycleLocks(), Now: func() time.Time { return now }}
+	result, err := cleaner.Clean(ctx, now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 1 || result.Removed != 1 || result.Failed != 0 {
+		t.Fatalf("cleanup result = %#v", result)
+	}
+	if _, err := os.Stat(sandbox.Summary.WorkspacePath); !os.IsNotExist(err) {
+		t.Fatalf("workspace still exists: %v", err)
+	}
+	reclaimed, err := store.GetSandbox(ctx, sandbox.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reclaimed.WorkspaceReclamation == nil || reclaimed.WorkspaceReclamation.State != domain.SandboxWorkspaceReclamationStateReclaimed || reclaimed.WorkspaceReclamation.CompletedAt.IsZero() {
+		t.Fatalf("workspace reclamation = %#v", reclaimed.WorkspaceReclamation)
+	}
+	provisioner := workspaces.NewProvisionerWithMaterializer(store, noopWorkspaceMaterializer{})
+	if err := provisioner.Ensure(ctx, reclaimed); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("Ensure error = %v, want failed precondition", err)
+	}
+	if err := store.RemoveSandbox(ctx, sandbox.Summary.ID); err != nil {
+		t.Fatalf("RemoveSandbox after reclamation: %v", err)
+	}
+}
+
+func TestWorkspaceCleanerRejectsSymlinkWorkspace(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	store, sandbox := newWorkspaceCleanupSandbox(t, now.Add(-48*time.Hour))
+	external := t.TempDir()
+	if err := os.RemoveAll(sandbox.Summary.WorkspacePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, sandbox.Summary.WorkspacePath); err != nil {
+		t.Fatal(err)
+	}
+	cleaner := &sessions.WorkspaceCleaner{Store: store, Locks: sessions.NewLifecycleLocks(), Now: func() time.Time { return now }}
+	result, err := cleaner.Clean(context.Background(), now.Add(-24*time.Hour))
+	if err == nil || result.Failed != 1 {
+		t.Fatalf("result/error = %#v/%v", result, err)
+	}
+	loaded, loadErr := store.GetSandbox(context.Background(), sandbox.Summary.ID)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if loaded.WorkspaceReclamation != nil || domain.SandboxWorkspaceUnavailable(loaded) {
+		t.Fatalf("unsafe path committed reclamation intent: %#v", loaded.WorkspaceReclamation)
+	}
+	if _, err := os.Stat(external); err != nil {
+		t.Fatalf("external target was affected: %v", err)
+	}
+}
+
+func TestWorkspaceCleanerRequiresRecordedStop(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	store, sandbox := newWorkspaceCleanupSandbox(t, time.Time{})
+	cleaner := &sessions.WorkspaceCleaner{Store: store, Locks: sessions.NewLifecycleLocks(), Now: func() time.Time { return now }}
+	result, err := cleaner.Clean(context.Background(), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 0 || result.Removed != 0 {
+		t.Fatalf("cleanup without recorded stop = %#v", result)
+	}
+	if _, err := os.Stat(sandbox.Summary.WorkspacePath); err != nil {
+		t.Fatalf("workspace without recorded stop was removed: %v", err)
+	}
+	loaded, err := store.GetSandbox(context.Background(), sandbox.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.WorkspaceReclamation != nil {
+		t.Fatalf("cleanup without recorded stop persisted intent: %#v", loaded.WorkspaceReclamation)
+	}
+}
+
+func TestWorkspaceCleanerDoesNotReclaimFailedSandboxWithStaleStop(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	store, sandbox := newWorkspaceCleanupSandbox(t, now.Add(-48*time.Hour))
+	sandbox.Summary.VMStatus = domain.VMStatusFailed
+	if err := store.UpdateSandbox(context.Background(), sandbox); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaner := &sessions.WorkspaceCleaner{Store: store, Locks: sessions.NewLifecycleLocks(), Now: func() time.Time { return now }}
+	result, err := cleaner.Clean(context.Background(), now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 0 || result.Removed != 0 {
+		t.Fatalf("cleanup failed sandbox with stale stop = %#v", result)
+	}
+	if _, err := os.Stat(sandbox.Summary.WorkspacePath); err != nil {
+		t.Fatalf("failed sandbox workspace was removed: %v", err)
+	}
+	loaded, err := store.GetSandbox(context.Background(), sandbox.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.WorkspaceReclamation != nil {
+		t.Fatalf("failed sandbox persisted reclamation intent: %#v", loaded.WorkspaceReclamation)
+	}
+}
+
+func TestWorkspaceCleanerRequiresStopAfterLatestStart(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	store, sandbox := newWorkspaceCleanupSandbox(t, now.Add(-48*time.Hour))
+	vmState, err := store.GetVMState(sandbox.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vmState.StartedAt = now.Add(-time.Hour)
+	if err := store.SaveVMState(sandbox.Summary.ID, vmState); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaner := &sessions.WorkspaceCleaner{Store: store, Locks: sessions.NewLifecycleLocks(), Now: func() time.Time { return now }}
+	result, err := cleaner.Clean(context.Background(), now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 0 || result.Removed != 0 {
+		t.Fatalf("cleanup stale stop before latest start = %#v", result)
+	}
+	if _, err := os.Stat(sandbox.Summary.WorkspacePath); err != nil {
+		t.Fatalf("workspace with stale stop marker was removed: %v", err)
+	}
+}
+
+func TestWorkspaceCleanerRequiresStopAfterLatestStartAttempt(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	store, sandbox := newWorkspaceCleanupSandbox(t, now.Add(-48*time.Hour))
+	vmState, err := store.GetVMState(sandbox.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vmState.StartAttemptedAt = now.Add(-time.Hour)
+	if err := store.SaveVMState(sandbox.Summary.ID, vmState); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaner := &sessions.WorkspaceCleaner{Store: store, Locks: sessions.NewLifecycleLocks(), Now: func() time.Time { return now }}
+	result, err := cleaner.Clean(context.Background(), now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 0 || result.Removed != 0 {
+		t.Fatalf("cleanup stop before latest start attempt = %#v", result)
+	}
+	if _, err := os.Stat(sandbox.Summary.WorkspacePath); err != nil {
+		t.Fatalf("workspace with newer start attempt was removed: %v", err)
+	}
+}
+
+func newWorkspaceCleanupSandbox(t *testing.T, stoppedAt time.Time) (*sessionstore.Store, *domain.Sandbox) {
+	t.Helper()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot: root, SandboxRoot: filepath.Join(root, "sandboxes"), RuntimeDriver: "docker",
+		DefaultImage: "guest:latest", DockerDefaultImage: "guest:latest", JupyterProxyBasePath: "/jupyter",
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sandbox, err := store.CreateSandbox(context.Background(), "cleanup", "", "docker", "guest:latest", "", "test", nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sandbox.Summary.VMStatus = domain.VMStatusStopped
+	if err := store.UpdateSandbox(context.Background(), sandbox); err != nil {
+		t.Fatal(err)
+	}
+	vmState, err := store.GetVMState(sandbox.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vmState.StoppedAt = stoppedAt
+	if err := store.SaveVMState(sandbox.Summary.ID, vmState); err != nil {
+		t.Fatal(err)
+	}
+	return store, sandbox
+}
+
+type noopWorkspaceMaterializer struct{}
+
+func (noopWorkspaceMaterializer) Materialize(context.Context, *domain.Sandbox) error { return nil }

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -53,8 +53,14 @@ type (
 )
 
 type Store struct {
-	config       *appconfig.Config
-	sandboxLocks sync.Map
+	config                *appconfig.Config
+	sandboxLocks          sync.Map
+	cacheDependencyMu     sync.RWMutex
+	cacheDependencyLocker CacheDependencyLocker
+}
+
+type CacheDependencyLocker interface {
+	WithLockContext(context.Context, func() error) error
 }
 
 func NewStore(di do.Injector) (*Store, error) {
@@ -96,7 +102,27 @@ func (s *Store) CreateSandbox(ctx context.Context, title, baseWorkspace, driver,
 	return s.CreateSandboxWithOptions(ctx, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, CreateSandboxOptions{})
 }
 
-func (s *Store) CreateSandboxWithOptions(_ context.Context, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *SandboxWorkspace, envItems []SandboxEnvVar, tags []SandboxTag, options CreateSandboxOptions) (*Sandbox, error) {
+func (s *Store) CreateSandboxWithOptions(ctx context.Context, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *SandboxWorkspace, envItems []SandboxEnvVar, tags []SandboxTag, options CreateSandboxOptions) (*Sandbox, error) {
+	return s.createSandboxWithCacheDependencyLock(ctx, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, options)
+}
+
+func (s *Store) createSandboxWithCacheDependencyLock(ctx context.Context, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *SandboxWorkspace, envItems []SandboxEnvVar, tags []SandboxTag, options CreateSandboxOptions) (*Sandbox, error) {
+	s.cacheDependencyMu.RLock()
+	locker := s.cacheDependencyLocker
+	s.cacheDependencyMu.RUnlock()
+	if locker == nil {
+		return s.createSandboxWithOptions(title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, options)
+	}
+	var sandbox *Sandbox
+	err := locker.WithLockContext(ctx, func() error {
+		var err error
+		sandbox, err = s.createSandboxWithOptions(title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, options)
+		return err
+	})
+	return sandbox, err
+}
+
+func (s *Store) createSandboxWithOptions(title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *SandboxWorkspace, envItems []SandboxEnvVar, tags []SandboxTag, options CreateSandboxOptions) (*Sandbox, error) {
 	now := time.Now().UTC()
 	workspaceID = strings.TrimSpace(workspaceID)
 	id := identity.NewRandomID(identity.ResourceSandbox)
@@ -226,6 +252,12 @@ func (s *Store) CreateSandboxWithOptions(_ context.Context, title, baseWorkspace
 	}
 
 	return session, nil
+}
+
+func (s *Store) SetCacheDependencyLocker(locker CacheDependencyLocker) {
+	s.cacheDependencyMu.Lock()
+	defer s.cacheDependencyMu.Unlock()
+	s.cacheDependencyLocker = locker
 }
 
 func (s *Store) GetSandbox(_ context.Context, id string) (*Sandbox, error) {

--- a/pkg/workspaces/provisioner.go
+++ b/pkg/workspaces/provisioner.go
@@ -106,6 +106,9 @@ func (p *Provisioner) Ensure(ctx context.Context, sandbox *domain.Sandbox) error
 }
 
 func (p *Provisioner) ensureLoaded(ctx context.Context, sandbox *domain.Sandbox) error {
+	if domain.SandboxWorkspaceUnavailable(sandbox) {
+		return domain.ClassifyError(domain.ErrFailedPrecondition, "sandbox workspace was reclaimed and cannot be provisioned", nil)
+	}
 	if !sandboxHasWorkspace(sandbox) {
 		return nil
 	}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -8139,25 +8139,29 @@ func (x *GetSandboxRequest) GetSandboxId() string {
 }
 
 type Sandbox struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
-	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
-	Driver        string                 `protobuf:"bytes,3,opt,name=driver,proto3" json:"driver,omitempty"`
-	ProjectId     string                 `protobuf:"bytes,4,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
-	AgentName     string                 `protobuf:"bytes,5,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
-	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	Image         string                 `protobuf:"bytes,8,opt,name=image,proto3" json:"image,omitempty"`
-	WorkspacePath string                 `protobuf:"bytes,9,opt,name=workspace_path,json=workspacePath,proto3" json:"workspace_path,omitempty"`
-	Tags          []*SandboxTag          `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty"`
-	Title         string                 `protobuf:"bytes,11,opt,name=title,proto3" json:"title,omitempty"`
-	ProxyPath     string                 `protobuf:"bytes,12,opt,name=proxy_path,json=proxyPath,proto3" json:"proxy_path,omitempty"`
-	TriggerSource string                 `protobuf:"bytes,13,opt,name=trigger_source,json=triggerSource,proto3" json:"trigger_source,omitempty"`
-	CellCount     uint32                 `protobuf:"varint,14,opt,name=cell_count,json=cellCount,proto3" json:"cell_count,omitempty"`
-	EventCount    uint32                 `protobuf:"varint,15,opt,name=event_count,json=eventCount,proto3" json:"event_count,omitempty"`
-	NotebookUrl   string                 `protobuf:"bytes,16,opt,name=notebook_url,json=notebookUrl,proto3" json:"notebook_url,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                           protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId                       string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	Status                          string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	Driver                          string                 `protobuf:"bytes,3,opt,name=driver,proto3" json:"driver,omitempty"`
+	ProjectId                       string                 `protobuf:"bytes,4,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	AgentName                       string                 `protobuf:"bytes,5,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	CreatedAt                       *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt                       *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	Image                           string                 `protobuf:"bytes,8,opt,name=image,proto3" json:"image,omitempty"`
+	WorkspacePath                   string                 `protobuf:"bytes,9,opt,name=workspace_path,json=workspacePath,proto3" json:"workspace_path,omitempty"`
+	Tags                            []*SandboxTag          `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty"`
+	Title                           string                 `protobuf:"bytes,11,opt,name=title,proto3" json:"title,omitempty"`
+	ProxyPath                       string                 `protobuf:"bytes,12,opt,name=proxy_path,json=proxyPath,proto3" json:"proxy_path,omitempty"`
+	TriggerSource                   string                 `protobuf:"bytes,13,opt,name=trigger_source,json=triggerSource,proto3" json:"trigger_source,omitempty"`
+	CellCount                       uint32                 `protobuf:"varint,14,opt,name=cell_count,json=cellCount,proto3" json:"cell_count,omitempty"`
+	EventCount                      uint32                 `protobuf:"varint,15,opt,name=event_count,json=eventCount,proto3" json:"event_count,omitempty"`
+	NotebookUrl                     string                 `protobuf:"bytes,16,opt,name=notebook_url,json=notebookUrl,proto3" json:"notebook_url,omitempty"`
+	WorkspaceReclamationState       string                 `protobuf:"bytes,17,opt,name=workspace_reclamation_state,json=workspaceReclamationState,proto3" json:"workspace_reclamation_state,omitempty"`
+	WorkspaceReclamationStartedAt   *timestamppb.Timestamp `protobuf:"bytes,18,opt,name=workspace_reclamation_started_at,json=workspaceReclamationStartedAt,proto3" json:"workspace_reclamation_started_at,omitempty"`
+	WorkspaceReclamationCompletedAt *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=workspace_reclamation_completed_at,json=workspaceReclamationCompletedAt,proto3" json:"workspace_reclamation_completed_at,omitempty"`
+	WorkspaceReclamationLastError   string                 `protobuf:"bytes,20,opt,name=workspace_reclamation_last_error,json=workspaceReclamationLastError,proto3" json:"workspace_reclamation_last_error,omitempty"`
+	unknownFields                   protoimpl.UnknownFields
+	sizeCache                       protoimpl.SizeCache
 }
 
 func (x *Sandbox) Reset() {
@@ -8298,6 +8302,34 @@ func (x *Sandbox) GetEventCount() uint32 {
 func (x *Sandbox) GetNotebookUrl() string {
 	if x != nil {
 		return x.NotebookUrl
+	}
+	return ""
+}
+
+func (x *Sandbox) GetWorkspaceReclamationState() string {
+	if x != nil {
+		return x.WorkspaceReclamationState
+	}
+	return ""
+}
+
+func (x *Sandbox) GetWorkspaceReclamationStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.WorkspaceReclamationStartedAt
+	}
+	return nil
+}
+
+func (x *Sandbox) GetWorkspaceReclamationCompletedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.WorkspaceReclamationCompletedAt
+	}
+	return nil
+}
+
+func (x *Sandbox) GetWorkspaceReclamationLastError() string {
+	if x != nil {
+		return x.WorkspaceReclamationLastError
 	}
 	return ""
 }
@@ -17068,7 +17100,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x05stats\x18\x01 \x01(\v2\x1d.agentcompose.v2.SandboxStatsR\x05stats\"2\n" +
 	"\x11GetSandboxRequest\x12\x1d\n" +
 	"\n" +
-	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"\xb9\x04\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"\x90\a\n" +
 	"\aSandbox\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x16\n" +
@@ -17094,7 +17126,11 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"cell_count\x18\x0e \x01(\rR\tcellCount\x12\x1f\n" +
 	"\vevent_count\x18\x0f \x01(\rR\n" +
 	"eventCount\x12!\n" +
-	"\fnotebook_url\x18\x10 \x01(\tR\vnotebookUrl\"6\n" +
+	"\fnotebook_url\x18\x10 \x01(\tR\vnotebookUrl\x12>\n" +
+	"\x1bworkspace_reclamation_state\x18\x11 \x01(\tR\x19workspaceReclamationState\x12c\n" +
+	" workspace_reclamation_started_at\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\x1dworkspaceReclamationStartedAt\x12g\n" +
+	"\"workspace_reclamation_completed_at\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\x1fworkspaceReclamationCompletedAt\x12G\n" +
+	" workspace_reclamation_last_error\x18\x14 \x01(\tR\x1dworkspaceReclamationLastError\"6\n" +
 	"\n" +
 	"SandboxTag\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
@@ -18422,274 +18458,276 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	251, // 132: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
 	251, // 133: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
 	119, // 134: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
-	118, // 135: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
-	118, // 136: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	118, // 137: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	118, // 138: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	18,  // 139: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	127, // 140: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
-	127, // 141: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
-	127, // 142: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
-	127, // 143: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
-	127, // 144: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
-	127, // 145: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
-	127, // 146: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
-	127, // 147: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
-	127, // 148: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
-	4,   // 149: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
-	3,   // 150: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	129, // 151: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	132, // 152: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
-	133, // 153: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
-	79,  // 154: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	152, // 155: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
-	12,  // 156: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
-	14,  // 157: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	152, // 158: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
-	96,  // 159: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	138, // 160: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
-	140, // 161: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	141, // 162: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	142, // 163: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	143, // 164: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	145, // 165: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	144, // 166: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	146, // 167: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	147, // 168: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	150, // 169: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	151, // 170: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	148, // 171: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	149, // 172: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	131, // 173: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
-	139, // 174: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	13,  // 175: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	139, // 176: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	242, // 177: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
-	129, // 178: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
-	14,  // 179: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
-	96,  // 180: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	152, // 181: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
-	129, // 182: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	243, // 183: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
-	133, // 184: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
-	15,  // 185: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	185, // 186: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
-	187, // 187: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	15,  // 188: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	186, // 189: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	185, // 190: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
-	17,  // 191: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
-	190, // 192: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
-	15,  // 193: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	185, // 194: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
-	187, // 195: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	15,  // 196: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	244, // 197: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	15,  // 198: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	186, // 199: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	17,  // 200: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
-	185, // 201: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
-	19,  // 202: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
-	22,  // 203: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
-	163, // 204: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	172, // 205: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
-	172, // 206: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
-	163, // 207: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	172, // 208: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
-	172, // 209: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	172, // 210: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
-	172, // 211: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	19,  // 212: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
-	22,  // 213: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	173, // 214: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
-	20,  // 215: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
-	184, // 216: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	245, // 217: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	246, // 218: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	184, // 219: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	184, // 220: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	184, // 221: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
-	184, // 222: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
-	184, // 223: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	247, // 224: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	248, // 225: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	15,  // 226: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
-	16,  // 227: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
-	186, // 228: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	188, // 229: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
-	189, // 230: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	249, // 231: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
-	15,  // 232: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
-	90,  // 233: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
-	129, // 234: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
-	23,  // 235: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
-	198, // 236: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
-	23,  // 237: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
-	201, // 238: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	251, // 239: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
-	202, // 240: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	202, // 241: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	79,  // 242: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	80,  // 243: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
-	79,  // 244: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	210, // 245: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	210, // 246: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	251, // 247: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	251, // 248: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
-	214, // 249: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
-	214, // 250: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
-	225, // 251: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	250, // 252: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	228, // 253: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
-	229, // 254: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	251, // 255: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	251, // 256: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
-	232, // 257: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
-	233, // 258: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
-	24,  // 259: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
-	118, // 260: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	232, // 261: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
-	233, // 262: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
-	14,  // 263: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
-	25,  // 264: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	27,  // 265: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	29,  // 266: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	31,  // 267: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	33,  // 268: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	35,  // 269: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	46,  // 270: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
-	49,  // 271: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
-	52,  // 272: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
-	55,  // 273: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
-	57,  // 274: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
-	59,  // 275: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
-	61,  // 276: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
-	63,  // 277: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
-	66,  // 278: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
-	68,  // 279: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	90,  // 280: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	193, // 281: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	90,  // 282: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	93,  // 283: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
-	97,  // 284: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	99,  // 285: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	101, // 286: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	103, // 287: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	105, // 288: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
-	108, // 289: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
-	131, // 290: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	131, // 291: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	136, // 292: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
-	153, // 293: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	155, // 294: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	157, // 295: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	159, // 296: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	161, // 297: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	164, // 298: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	166, // 299: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	168, // 300: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	170, // 301: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	174, // 302: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	176, // 303: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	178, // 304: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	180, // 305: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	182, // 306: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	110, // 307: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	112, // 308: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
-	115, // 309: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	117, // 310: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
-	123, // 311: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
-	125, // 312: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
-	120, // 313: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	231, // 314: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	235, // 315: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
-	199, // 316: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
-	200, // 317: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
-	205, // 318: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
-	207, // 319: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
-	209, // 320: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
-	212, // 321: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	215, // 322: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
-	217, // 323: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
-	218, // 324: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
-	219, // 325: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
-	222, // 326: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
-	224, // 327: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
-	227, // 328: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	237, // 329: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	196, // 330: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	26,  // 331: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	28,  // 332: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	30,  // 333: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	32,  // 334: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	34,  // 335: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	36,  // 336: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	47,  // 337: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	51,  // 338: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	54,  // 339: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	56,  // 340: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
-	58,  // 341: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
-	60,  // 342: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
-	62,  // 343: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
-	64,  // 344: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
-	67,  // 345: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	69,  // 346: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	91,  // 347: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	194, // 348: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	92,  // 349: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	94,  // 350: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
-	98,  // 351: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	100, // 352: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	102, // 353: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	104, // 354: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	107, // 355: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	109, // 356: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	134, // 357: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	135, // 358: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	137, // 359: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
-	154, // 360: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	156, // 361: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	158, // 362: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	160, // 363: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	162, // 364: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	165, // 365: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	167, // 366: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	169, // 367: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	171, // 368: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	175, // 369: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	177, // 370: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	179, // 371: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	181, // 372: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	183, // 373: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	111, // 374: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	114, // 375: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	116, // 376: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	122, // 377: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	124, // 378: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	126, // 379: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	121, // 380: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	234, // 381: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	236, // 382: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	203, // 383: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	204, // 384: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	206, // 385: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	208, // 386: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	211, // 387: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	213, // 388: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	216, // 389: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	221, // 390: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	221, // 391: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	220, // 392: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	223, // 393: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	226, // 394: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	230, // 395: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	238, // 396: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	197, // 397: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	331, // [331:398] is the sub-list for method output_type
-	264, // [264:331] is the sub-list for method input_type
-	264, // [264:264] is the sub-list for extension type_name
-	264, // [264:264] is the sub-list for extension extendee
-	0,   // [0:264] is the sub-list for field type_name
+	251, // 135: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
+	251, // 136: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
+	118, // 137: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
+	118, // 138: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	118, // 139: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	118, // 140: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	18,  // 141: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
+	127, // 142: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
+	127, // 143: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 144: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 145: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
+	127, // 146: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 147: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 148: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 149: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
+	127, // 150: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
+	4,   // 151: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
+	3,   // 152: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
+	129, // 153: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
+	132, // 154: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
+	133, // 155: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
+	79,  // 156: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	152, // 157: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
+	12,  // 158: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
+	14,  // 159: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	152, // 160: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
+	96,  // 161: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	138, // 162: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
+	140, // 163: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	141, // 164: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	142, // 165: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	143, // 166: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	145, // 167: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	144, // 168: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	146, // 169: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	147, // 170: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	150, // 171: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	151, // 172: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	148, // 173: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	149, // 174: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	131, // 175: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
+	139, // 176: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	13,  // 177: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	139, // 178: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	242, // 179: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	129, // 180: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
+	14,  // 181: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
+	96,  // 182: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	152, // 183: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
+	129, // 184: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
+	243, // 185: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	133, // 186: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
+	15,  // 187: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	185, // 188: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
+	187, // 189: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	15,  // 190: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	186, // 191: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	185, // 192: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
+	17,  // 193: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
+	190, // 194: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
+	15,  // 195: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	185, // 196: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
+	187, // 197: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	15,  // 198: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	244, // 199: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	15,  // 200: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	186, // 201: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	17,  // 202: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
+	185, // 203: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
+	19,  // 204: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
+	22,  // 205: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
+	163, // 206: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	172, // 207: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
+	172, // 208: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
+	163, // 209: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	172, // 210: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
+	172, // 211: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	172, // 212: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
+	172, // 213: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	19,  // 214: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
+	22,  // 215: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
+	173, // 216: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
+	20,  // 217: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
+	184, // 218: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
+	245, // 219: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	246, // 220: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	184, // 221: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	184, // 222: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	184, // 223: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
+	184, // 224: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
+	184, // 225: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
+	247, // 226: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	248, // 227: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	15,  // 228: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
+	16,  // 229: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
+	186, // 230: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
+	188, // 231: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
+	189, // 232: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
+	249, // 233: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	15,  // 234: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
+	90,  // 235: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
+	129, // 236: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	23,  // 237: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
+	198, // 238: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
+	23,  // 239: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
+	201, // 240: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
+	251, // 241: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	202, // 242: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	202, // 243: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	79,  // 244: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	80,  // 245: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
+	79,  // 246: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	210, // 247: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	210, // 248: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	251, // 249: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	251, // 250: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	214, // 251: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
+	214, // 252: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
+	225, // 253: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
+	250, // 254: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	228, // 255: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
+	229, // 256: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
+	251, // 257: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	251, // 258: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	232, // 259: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
+	233, // 260: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
+	24,  // 261: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
+	118, // 262: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	232, // 263: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
+	233, // 264: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
+	14,  // 265: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
+	25,  // 266: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	27,  // 267: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	29,  // 268: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	31,  // 269: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	33,  // 270: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	35,  // 271: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	46,  // 272: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
+	49,  // 273: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
+	52,  // 274: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
+	55,  // 275: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
+	57,  // 276: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
+	59,  // 277: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
+	61,  // 278: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
+	63,  // 279: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
+	66,  // 280: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
+	68,  // 281: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	90,  // 282: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	193, // 283: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
+	90,  // 284: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
+	93,  // 285: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
+	97,  // 286: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	99,  // 287: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	101, // 288: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	103, // 289: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	105, // 290: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
+	108, // 291: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
+	131, // 292: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	131, // 293: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
+	136, // 294: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
+	153, // 295: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	155, // 296: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	157, // 297: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	159, // 298: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	161, // 299: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	164, // 300: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	166, // 301: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	168, // 302: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	170, // 303: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	174, // 304: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	176, // 305: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	178, // 306: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	180, // 307: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	182, // 308: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	110, // 309: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	112, // 310: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
+	115, // 311: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	117, // 312: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
+	123, // 313: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
+	125, // 314: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
+	120, // 315: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
+	231, // 316: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	235, // 317: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	199, // 318: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
+	200, // 319: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
+	205, // 320: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
+	207, // 321: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
+	209, // 322: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
+	212, // 323: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	215, // 324: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
+	217, // 325: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
+	218, // 326: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
+	219, // 327: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
+	222, // 328: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
+	224, // 329: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
+	227, // 330: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
+	237, // 331: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	196, // 332: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	26,  // 333: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	28,  // 334: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	30,  // 335: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	32,  // 336: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	34,  // 337: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	36,  // 338: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	47,  // 339: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	51,  // 340: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	54,  // 341: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	56,  // 342: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	58,  // 343: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	60,  // 344: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	62,  // 345: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	64,  // 346: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	67,  // 347: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	69,  // 348: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	91,  // 349: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	194, // 350: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
+	92,  // 351: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
+	94,  // 352: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
+	98,  // 353: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	100, // 354: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	102, // 355: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	104, // 356: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	107, // 357: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	109, // 358: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	134, // 359: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	135, // 360: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
+	137, // 361: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
+	154, // 362: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	156, // 363: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	158, // 364: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	160, // 365: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	162, // 366: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	165, // 367: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	167, // 368: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	169, // 369: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	171, // 370: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	175, // 371: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	177, // 372: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	179, // 373: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	181, // 374: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	183, // 375: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	111, // 376: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	114, // 377: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	116, // 378: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	122, // 379: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	124, // 380: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	126, // 381: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	121, // 382: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	234, // 383: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	236, // 384: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	203, // 385: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	204, // 386: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	206, // 387: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	208, // 388: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	211, // 389: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	213, // 390: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	216, // 391: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	221, // 392: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	221, // 393: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	220, // 394: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	223, // 395: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	226, // 396: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	230, // 397: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	238, // 398: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	197, // 399: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	333, // [333:400] is the sub-list for method output_type
+	266, // [266:333] is the sub-list for method input_type
+	266, // [266:266] is the sub-list for extension type_name
+	266, // [266:266] is the sub-list for extension extendee
+	0,   // [0:266] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -1026,6 +1026,10 @@ message Sandbox {
   uint32 cell_count = 14;
   uint32 event_count = 15;
   string notebook_url = 16;
+  string workspace_reclamation_state = 17;
+  google.protobuf.Timestamp workspace_reclamation_started_at = 18;
+  google.protobuf.Timestamp workspace_reclamation_completed_at = 19;
+  string workspace_reclamation_last_error = 20;
 }
 
 message SandboxTag {

--- a/scripts/tests/test-coverage-contract.sh
+++ b/scripts/tests/test-coverage-contract.sh
@@ -139,7 +139,7 @@ fi
 
 listed_e2e_tests="$(go test -list '^Test' ./test/e2e | awk '/^Test/ { print }')"
 listed_e2e_count="$(printf '%s\n' "$listed_e2e_tests" | awk 'NF { count++ } END { print count + 0 }')"
-assert_equal 6 "$listed_e2e_count" "unexpected test/e2e package test count"
+assert_equal 7 "$listed_e2e_count" "unexpected test/e2e package test count"
 
 e2e_output="$(go test -run '^Test' -v ./test/e2e)"
 while IFS= read -r test_name; do

--- a/test/e2e/host_daemon_helpers_test.go
+++ b/test/e2e/host_daemon_helpers_test.go
@@ -44,11 +44,15 @@ type e2eDaemonProcess struct {
 }
 
 func startE2EDaemon(t *testing.T, binary, repoRoot, testRoot, listenAddress, image string) *e2eDaemonProcess {
+	return startE2EDaemonWithEnv(t, binary, repoRoot, testRoot, listenAddress, image, nil)
+}
+
+func startE2EDaemonWithEnv(t *testing.T, binary, repoRoot, testRoot, listenAddress, image string, extraEnv map[string]string) *e2eDaemonProcess {
 	t.Helper()
 	process := &e2eDaemonProcess{done: make(chan error, 1)}
 	process.cmd = exec.Command(binary, "daemon")
 	process.cmd.Dir = repoRoot
-	process.cmd.Env = overrideE2EEnv(os.Environ(), map[string]string{
+	env := map[string]string{
 		"AGENT_COMPOSE_SOCKET":     filepath.Join(testRoot, "agent-compose.sock"),
 		"AUTH_PASSWORD":            "",
 		"AUTH_USERNAME":            "",
@@ -66,7 +70,11 @@ func startE2EDaemon(t *testing.T, binary, repoRoot, testRoot, listenAddress, ima
 		"RUNTIME_DRIVER":           "docker",
 		"SANDBOX_ROOT":             filepath.Join(testRoot, "sandboxes"),
 		"SANDBOX_START_TIMEOUT":    "3m",
-	})
+	}
+	for name, value := range extraEnv {
+		env[name] = value
+	}
+	process.cmd.Env = overrideE2EEnv(os.Environ(), env)
 	process.cmd.Stdout = &process.logs
 	process.cmd.Stderr = &process.logs
 	if err := process.cmd.Start(); err != nil {

--- a/test/e2e/retention_host_daemon_test.go
+++ b/test/e2e/retention_host_daemon_test.go
@@ -1,0 +1,155 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/imagecache"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+const dockerRetentionE2EImageEnv = "AGENT_COMPOSE_E2E_RETENTION_IMAGE"
+
+func TestE2EDockerDaemonRetentionCleanup(t *testing.T) {
+	image := strings.TrimSpace(os.Getenv(dockerRetentionE2EImageEnv))
+	if image == "" {
+		t.Skipf("set %s to a local Docker guest image", dockerRetentionE2EImageEnv)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	repoRoot := e2eRepoRoot(t)
+	testRoot, err := os.MkdirTemp(repoRoot, ".docker-retention-e2e-")
+	if err != nil {
+		t.Fatalf("create Docker-visible retention root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(testRoot) })
+	dockerClient := newE2EDockerClient(t, ctx, image)
+	binary := e2eDaemonBinary(t, ctx, repoRoot, testRoot)
+
+	cacheRoot := filepath.Join(testRoot, "images")
+	cache, materializedPath := prepareExpiredE2EImageCache(t, cacheRoot)
+	listenAddress := unusedLoopbackAddress(t)
+	baseURL := "http://" + listenAddress
+	daemon := startE2EDaemonWithEnv(t, binary, repoRoot, testRoot, listenAddress, image, map[string]string{
+		"CLEANUP_INTERVAL":        "100ms",
+		"IMAGE_CACHE_CLEANUP_TTL": "1h",
+		"IMAGE_CACHE_ROOT":        cacheRoot,
+		"WORKSPACE_CLEANUP_TTL":   "500ms",
+	})
+	waitForE2EDaemon(t, ctx, daemon, baseURL)
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("retention daemon log:\n%s", daemon.logs.String())
+		}
+	})
+
+	waitForE2ECondition(t, 10*time.Second, func() bool {
+		metadata, loadErr := cache.LoadMetadata()
+		_, statErr := os.Stat(materializedPath)
+		return loadErr == nil && len(metadata.Images) == 0 && os.IsNotExist(statErr)
+	}, "expired image cache was not removed")
+
+	httpClient := newE2EHTTPClient()
+	defer httpClient.CloseIdleConnections()
+	projectClient := agentcomposev2connect.NewProjectServiceClient(httpClient, baseURL)
+	runClient := agentcomposev2connect.NewRunServiceClient(httpClient, baseURL)
+	sandboxClient := agentcomposev2connect.NewSandboxServiceClient(httpClient, baseURL)
+	projectID := applyE2ERetentionProject(t, ctx, projectClient, testRoot, image)
+	sandbox := runE2EWorkspaceSandbox(t, ctx, runClient, sandboxClient, projectID, "retention-workspace")
+	sandboxID := sandbox.GetSandboxId()
+	removed := false
+	t.Cleanup(func() {
+		cleanupE2EWorkspaceSandbox(t, dockerClient, sandboxClient, sandboxID, removed)
+	})
+	workspacePath := sandbox.GetWorkspacePath()
+
+	stopResp, err := sandboxClient.StopSandbox(ctx, connect.NewRequest(&agentcomposev2.StopSandboxRequest{SandboxId: sandboxID}))
+	if err != nil || stopResp.Msg.GetSandbox().GetStatus() != domain.VMStatusStopped {
+		t.Fatalf("StopSandbox = %#v, error %v", stopResp, err)
+	}
+	waitForE2ECondition(t, 15*time.Second, func() bool {
+		response, getErr := sandboxClient.GetSandbox(ctx, connect.NewRequest(&agentcomposev2.GetSandboxRequest{SandboxId: sandboxID}))
+		return getErr == nil && response.Msg.GetSandbox().GetWorkspaceReclamationState() == domain.SandboxWorkspaceReclamationStateReclaimed
+	}, "stopped sandbox workspace was not reclaimed")
+	if _, err := os.Stat(workspacePath); !os.IsNotExist(err) {
+		t.Fatalf("reclaimed workspace still exists: %v", err)
+	}
+	if _, err := sandboxClient.ResumeSandbox(ctx, connect.NewRequest(&agentcomposev2.ResumeSandboxRequest{SandboxId: sandboxID})); err == nil {
+		t.Fatal("ResumeSandbox succeeded after workspace reclamation")
+	}
+
+	removeResp, err := sandboxClient.RemoveSandbox(ctx, connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID, Force: true}))
+	if err != nil || removeResp.Msg.GetSandboxId() != sandboxID || !removeResp.Msg.GetRemoved() {
+		t.Fatalf("RemoveSandbox reclaimed sandbox = %#v, error %v", removeResp, err)
+	}
+	removed = true
+	removeE2EDockerSandboxFallback(t, ctx, dockerClient, sandboxID)
+	assertE2EDockerSandboxContainerCount(t, ctx, dockerClient, sandboxID, 0)
+	if _, err := projectClient.RemoveProject(ctx, connect.NewRequest(&agentcomposev2.RemoveProjectRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
+	})); err != nil {
+		t.Fatalf("RemoveProject returned error: %v", err)
+	}
+	daemon.stop(t)
+	assertE2EDaemonReleased(t, daemon, filepath.Join(testRoot, "agent-compose.sock"), listenAddress)
+}
+
+func prepareExpiredE2EImageCache(t *testing.T, root string) (*imagecache.Cache, string) {
+	t.Helper()
+	cache, err := imagecache.New(imagecache.Config{Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	materializedPath := cache.MaterializedImageDir(digest)
+	if err := os.MkdirAll(filepath.Join(materializedPath, "rootfs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	if err := cache.SaveMetadata(imagecache.MetadataFile{Images: []imagecache.ImageMetadata{{
+		RequestedRef: "retention.invalid/expired:latest", NormalizedRef: "retention.invalid/expired:latest",
+		ConfigDigest: digest, PulledAt: old, LastUsedAt: old,
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	return cache, materializedPath
+}
+
+func applyE2ERetentionProject(t *testing.T, ctx context.Context, client agentcomposev2connect.ProjectServiceClient, root, image string) string {
+	t.Helper()
+	response, err := client.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec: &agentcomposev2.ProjectSpec{
+			Name: "docker-retention-e2e",
+			Agents: []*agentcomposev2.AgentSpec{{
+				Name: "worker", Provider: "codex", Image: image,
+				Driver: &agentcomposev2.DriverSpec{Name: "docker", Docker: &agentcomposev2.DockerDriverSpec{}},
+			}},
+		},
+		Source: &agentcomposev2.ProjectSource{ComposePath: filepath.Join(root, "agent-compose.yml"), ProjectDir: root},
+	}))
+	if err != nil {
+		t.Fatalf("ApplyProject returned error: %v", err)
+	}
+	return response.Msg.GetProject().GetSummary().GetProjectId()
+}
+
+func waitForE2ECondition(t *testing.T, timeout time.Duration, condition func() bool, failure string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal(failure)
+}


### PR DESCRIPTION
## Summary

- add configurable daemon retention cleanup for sandbox workspaces and `IMAGE_CACHE_ROOT`
- use `WORKSPACE_CLEANUP_TTL=0` and `IMAGE_CACHE_CLEANUP_TTL=0` as per-cleaner disable switches, with `CLEANUP_INTERVAL=1h` by default
- reclaim only confirmed stopped workspaces while preserving sandbox metadata, logs, state, and audit information
- track image cache last-use time and prune expired unreferenced OCI, materialized, temporary, and orphaned data
- coordinate sandbox registration with cache pruning and wait for cleanup during daemon shutdown
- add an opt-in real Docker E2E for workspace and image-cache retention

## Testing

- `task lint`
- `task test`
- `go test -race ./pkg/execution ./pkg/sessions ./pkg/agentcompose/adapters`
- real Docker host-daemon workspace restart/resume regression
- real Docker host-daemon retention cleanup regression

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.