### PR TITLE
feat(microsandbox): inherit Docker image ENV as baseline env vars in guest VM

### DIFF
--- a/pkg/driver/local_docker_oci.go
+++ b/pkg/driver/local_docker_oci.go
@@ -28,6 +28,7 @@ type localDockerImageRootfs struct {
 	ImageID     string
 	ResolvedRef string
 	RootfsPath  string
+	Env         []string
 }
 
 type localDockerImageLayout struct {
@@ -76,6 +77,8 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 		return localDockerImageRootfs{}, false, nil
 	}
 
+	imageEnv := inspectEnv(inspect)
+
 	imageID := strings.TrimPrefix(inspect.ID, "sha256:")
 	if imageID == "" {
 		imageID = sanitizeRuntimeName(resolvedRef)
@@ -85,7 +88,8 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 	readyFlag := filepath.Join(cacheDir, ".rootfs.ready")
 	if _, err := os.Stat(readyFlag); err == nil {
 		if info, statErr := os.Stat(rootfsDir); statErr == nil && info.IsDir() {
-			return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+			env := loadImageEnvCache(cacheDir, imageEnv)
+			return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: env}, true, nil
 		}
 	}
 	_ = os.Remove(readyFlag)
@@ -114,7 +118,8 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 
 	if _, err := os.Stat(readyFlag); err == nil {
 		if info, statErr := os.Stat(rootfsDir); statErr == nil && info.IsDir() {
-			return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+			env := loadImageEnvCache(cacheDir, imageEnv)
+			return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: env}, true, nil
 		}
 	}
 	_ = os.Remove(readyFlag)
@@ -156,7 +161,10 @@ func materializeLocalDockerImageRootfsWithClient(ctx context.Context, dataRoot s
 	if err := os.WriteFile(readyFlag, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
 		return localDockerImageRootfs{}, false, fmt.Errorf("write image cache ready flag: %w", err)
 	}
-	return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+	if err := writeImageEnvCache(cacheDir, imageEnv); err != nil {
+		return localDockerImageRootfs{}, false, fmt.Errorf("write image env cache: %w", err)
+	}
+	return localDockerImageRootfs{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: imageEnv}, true, nil
 }
 
 func materializeRootfsFromReadyLayout(cacheDir, rootfsDir, readyFlag string, layout localDockerImageLayout, resolvedRef string) (localDockerImageRootfs, bool, error) {
@@ -176,7 +184,8 @@ func materializeRootfsFromReadyLayout(cacheDir, rootfsDir, readyFlag string, lay
 
 	if _, err := os.Stat(readyFlag); err == nil {
 		if info, statErr := os.Stat(rootfsDir); statErr == nil && info.IsDir() {
-			return localDockerImageRootfs{ImageID: layout.ImageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+			env := loadImageEnvCache(cacheDir, nil)
+			return localDockerImageRootfs{ImageID: layout.ImageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: env}, true, nil
 		}
 	}
 	_ = os.Remove(readyFlag)
@@ -204,7 +213,8 @@ func materializeRootfsFromReadyLayout(cacheDir, rootfsDir, readyFlag string, lay
 	if err := os.WriteFile(readyFlag, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
 		return localDockerImageRootfs{}, false, fmt.Errorf("write image cache ready flag: %w", err)
 	}
-	return localDockerImageRootfs{ImageID: layout.ImageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+	env := loadImageEnvCache(cacheDir, nil)
+	return localDockerImageRootfs{ImageID: layout.ImageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: env}, true, nil
 }
 
 func materializeLocalDockerImageLayout(ctx context.Context, dataRoot, imageRef string) (localDockerImageLayout, bool, error) {
@@ -870,4 +880,51 @@ func sanitizeRuntimeName(value string) string {
 		return "image"
 	}
 	return result
+}
+
+// imageEnvCacheFileName is the basename of the file that stores the image's ENV
+// list alongside the rootfs cache.
+const imageEnvCacheFileName = ".env.json"
+
+func inspectEnv(inspect typesimage.InspectResponse) []string {
+	if inspect.Config == nil || len(inspect.Config.Env) == 0 {
+		return nil
+	}
+	env := make([]string, len(inspect.Config.Env))
+	copy(env, inspect.Config.Env)
+	return env
+}
+
+// writeImageEnvCache writes the image environment variables to cacheDir.
+func writeImageEnvCache(cacheDir string, env []string) error {
+	if len(env) == 0 {
+		return nil
+	}
+	path := filepath.Join(cacheDir, imageEnvCacheFileName)
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("encode env cache: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// loadImageEnvCache reads the cached image environment variables from cacheDir.
+// When fresh is non-nil and the cache file does not exist, it writes fresh first.
+func loadImageEnvCache(cacheDir string, fresh []string) []string {
+	path := filepath.Join(cacheDir, imageEnvCacheFileName)
+	if fresh != nil {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			_ = writeImageEnvCache(cacheDir, fresh)
+			return fresh
+		}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var env []string
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil
+	}
+	return env
 }

--- a/pkg/driver/local_docker_oci.go
+++ b/pkg/driver/local_docker_oci.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -920,10 +921,12 @@ func loadImageEnvCache(cacheDir string, fresh []string) []string {
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
+		slog.Warn("agent-compose failed to read cached image env; image ENV will not be passed to guest", "cache_dir", cacheDir, "error", err)
 		return nil
 	}
 	var env []string
 	if err := json.Unmarshal(data, &env); err != nil {
+		slog.Warn("agent-compose failed to decode cached image env; image ENV will not be passed to guest", "cache_dir", cacheDir, "error", err)
 		return nil
 	}
 	return env

--- a/pkg/driver/microsandbox_image_resolver.go
+++ b/pkg/driver/microsandbox_image_resolver.go
@@ -15,6 +15,7 @@ type microsandboxRootFSResult struct {
 	ImageID     string
 	ResolvedRef string
 	RootFSPath  string
+	Env         []string
 }
 
 type microsandboxImageResolverOps struct {
@@ -78,7 +79,7 @@ func materializeMicrosandboxOCIRootFS(ctx context.Context, config *appconfig.Con
 		if _, pullErr := cache.Pull(pullCtx, imagecache.PullRequest{Reference: imageRef}); pullErr != nil {
 			result, matErr := cache.MaterializeRootFS(ctx, imageRef)
 			if matErr == nil {
-				return microsandboxRootFSResult{ImageID: result.ImageID, ResolvedRef: result.ResolvedRef, RootFSPath: result.RootFSPath}, true, nil
+				return microsandboxRootFSResult{ImageID: result.ImageID, ResolvedRef: result.ResolvedRef, RootFSPath: result.RootFSPath, Env: result.Env}, true, nil
 			}
 			return microsandboxRootFSResult{}, false, fmt.Errorf("guest image %s: pull failed (%w) and not found locally", imageRef, pullErr)
 		}
@@ -86,7 +87,7 @@ func materializeMicrosandboxOCIRootFS(ctx context.Context, config *appconfig.Con
 		if matErr != nil {
 			return microsandboxRootFSResult{}, false, matErr
 		}
-		return microsandboxRootFSResult{ImageID: result.ImageID, ResolvedRef: result.ResolvedRef, RootFSPath: result.RootFSPath}, true, nil
+		return microsandboxRootFSResult{ImageID: result.ImageID, ResolvedRef: result.ResolvedRef, RootFSPath: result.RootFSPath, Env: result.Env}, true, nil
 	}
 
 	result, err := cache.MaterializeRootFS(ctx, imageRef)
@@ -108,5 +109,6 @@ func materializeMicrosandboxOCIRootFS(ctx context.Context, config *appconfig.Con
 		ImageID:     result.ImageID,
 		ResolvedRef: result.ResolvedRef,
 		RootFSPath:  result.RootFSPath,
+		Env:         result.Env,
 	}, true, nil
 }

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -981,14 +981,25 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sandbo
 	if imagePullTimeout <= 0 {
 		imagePullTimeout = defaultImagePullTimeout
 	}
-	if resolvedRef, ok, err := r.resolveMicrosandboxImageRef(ctx, imageRef, session.Summary.PullPolicy, imagePullTimeout); err != nil {
+	var imageEnv []string
+	if resolvedRef, envList, ok, err := r.resolveMicrosandboxImageRef(ctx, imageRef, session.Summary.PullPolicy, imagePullTimeout); err != nil {
 		return nil, err
 	} else if ok {
 		imageRef = resolvedRef
+		imageEnv = envList
 	}
 	env := sandboxEnvMap(session.EnvItems, session.RuntimeEnvItems)
 	if env == nil {
 		env = map[string]string{}
+	}
+	// Merge image ENV as baseline — user/session env vars and agent-compose
+	// defaults override image-defined values (matching Docker daemon behavior).
+	for _, e := range imageEnv {
+		if key, value, ok := parseEnvEntry(e); ok && !LLMProviderKeyName(key) {
+			if _, exists := env[key]; !exists {
+				env[key] = value
+			}
+		}
 	}
 	env["GOPATH"] = "/usr/local/go"
 	env["PATH"] = "/root/.local/bin:/usr/local/go/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -1047,7 +1058,7 @@ func (r *microsandboxRuntime) microsandboxBindQuotaGB() int {
 	return r.config.BoxDiskSizeGB
 }
 
-func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, imageRef, pullPolicy string, pullTimeout time.Duration) (string, bool, error) {
+func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, imageRef, pullPolicy string, pullTimeout time.Duration) (string, []string, bool, error) {
 	rootfs, ok, err := resolveMicrosandboxRootFS(ctx, imageRef, microsandboxImageResolverOps{
 		dockerAvailable: dockerDaemonAvailable,
 		applyDockerPullPolicy: func(ctx context.Context, imageRef string) error {
@@ -1058,20 +1069,20 @@ func (r *microsandboxRuntime) resolveMicrosandboxImageRef(ctx context.Context, i
 			if err != nil || !ok {
 				return microsandboxRootFSResult{}, ok, err
 			}
-			return microsandboxRootFSResult{ImageID: rootfs.ImageID, ResolvedRef: rootfs.ResolvedRef, RootFSPath: rootfs.RootfsPath}, true, nil
+			return microsandboxRootFSResult{ImageID: rootfs.ImageID, ResolvedRef: rootfs.ResolvedRef, RootFSPath: rootfs.RootfsPath, Env: rootfs.Env}, true, nil
 		},
 		ociMaterialize: func(ctx context.Context, imageRef string) (microsandboxRootFSResult, bool, error) {
 			return materializeMicrosandboxOCIRootFS(ctx, r.config, imageRef, pullPolicy)
 		},
 	})
 	if err != nil {
-		return "", false, err
+		return "", nil, false, err
 	}
 	if ok {
 		slog.Info("agent-compose microsandbox using materialized image rootfs", "image", imageRef, "resolved_ref", rootfs.ResolvedRef, "rootfs_path", rootfs.RootFSPath)
-		return rootfs.RootFSPath, true, nil
+		return rootfs.RootFSPath, rootfs.Env, true, nil
 	}
-	return "", false, nil
+	return "", nil, false, nil
 }
 
 func microsandboxPullPolicyForImageRef(imageRef string, perCallPolicy string) microsandbox.PullPolicy {

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -186,6 +186,20 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+// parseEnvEntry splits a "KEY=VALUE" environment entry. Returns false when the
+// entry is malformed (no "=") or the key is empty after trimming.
+func parseEnvEntry(entry string) (string, string, bool) {
+	idx := strings.Index(entry, "=")
+	if idx < 0 {
+		return "", "", false
+	}
+	key := strings.TrimSpace(entry[:idx])
+	if key == "" {
+		return "", "", false
+	}
+	return key, entry[idx+1:], true
+}
+
 func hostSandboxDir(session *Sandbox) string {
 	if session == nil {
 		return ""

--- a/pkg/driver/types_test.go
+++ b/pkg/driver/types_test.go
@@ -2,6 +2,30 @@ package driver
 
 import "testing"
 
+func TestParseEnvEntry(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantKey   string
+		wantValue string
+		wantOK    bool
+	}{
+		{"KEY=VALUE", "KEY", "VALUE", true},
+		{"KEY=VAL=UE", "KEY", "VAL=UE", true},
+		{"KEY=", "KEY", "", true},
+		{"=VALUE", "", "", false},
+		{"NODELIM", "", "", false},
+		{"  KEY  =  VALUE  ", "KEY", "  VALUE  ", true},
+		{"", "", "", false},
+	}
+	for _, tt := range tests {
+		key, value, ok := parseEnvEntry(tt.input)
+		if ok != tt.wantOK || key != tt.wantKey || value != tt.wantValue {
+			t.Errorf("parseEnvEntry(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tt.input, key, value, ok, tt.wantKey, tt.wantValue, tt.wantOK)
+		}
+	}
+}
+
 func TestSandboxEnvMapKeepsNonLLMSecretEnv(t *testing.T) {
 	env := sandboxEnvMap([]SandboxEnvVar{
 		{Name: "DATABASE_PASSWORD", Value: "db-secret", Secret: true},

--- a/pkg/imagecache/materialize.go
+++ b/pkg/imagecache/materialize.go
@@ -48,6 +48,7 @@ func (c *Cache) MaterializeOCILayout(ctx context.Context, ref string) (Materiali
 		ImageID:     imageID,
 		ResolvedRef: resolvedRef,
 		LayoutPath:  layoutPath,
+		Env:         image.Env,
 	}
 	if ReadyFlagExists(readyFlag) && isValidOCILayoutPath(layoutPath) {
 		return result, nil

--- a/pkg/imagecache/materialize_test.go
+++ b/pkg/imagecache/materialize_test.go
@@ -68,7 +68,7 @@ func TestMaterializeOCILayoutReadyCacheHitDoesNotOverwrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second MaterializeOCILayout returned error: %v", err)
 	}
-	if second != first {
+	if second.ImageID != first.ImageID || second.ResolvedRef != first.ResolvedRef || second.LayoutPath != first.LayoutPath || second.RootFSPath != first.RootFSPath {
 		t.Fatalf("second result = %#v, want %#v", second, first)
 	}
 	if _, err := os.Stat(sentinelPath); err != nil {

--- a/pkg/imagecache/pull.go
+++ b/pkg/imagecache/pull.go
@@ -101,6 +101,7 @@ func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 		Platform:        metadataPlatform,
 		MediaType:       string(mediaType),
 		Labels:          configFile.Config.Labels,
+		Env:             configFile.Config.Env,
 		SizeBytes:       sizeBytes,
 		CreatedAt:       configFile.Created.Time,
 		PulledAt:        time.Now().UTC(),

--- a/pkg/imagecache/reference.go
+++ b/pkg/imagecache/reference.go
@@ -22,6 +22,7 @@ type MetadataInput struct {
 	Platform          Platform
 	MediaType         string
 	Labels            map[string]string
+	Env               []string
 	SizeBytes         int64
 	CreatedAt         time.Time
 	PulledAt          time.Time
@@ -85,6 +86,7 @@ func NewImageMetadata(input MetadataInput) (ImageMetadata, error) {
 		Platform:        input.Platform,
 		MediaType:       input.MediaType,
 		Labels:          cloneStringMap(input.Labels),
+		Env:             cloneStringSlice(input.Env),
 		SizeBytes:       input.SizeBytes,
 		CreatedAt:       input.CreatedAt,
 		PulledAt:        pulledAt,
@@ -121,6 +123,15 @@ func cloneStringMap(values map[string]string) map[string]string {
 	for key, value := range values {
 		clone[key] = value
 	}
+	return clone
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	clone := make([]string, len(values))
+	copy(clone, values)
 	return clone
 }
 

--- a/pkg/imagecache/rootfs.go
+++ b/pkg/imagecache/rootfs.go
@@ -50,6 +50,7 @@ func (c *Cache) MaterializeRootFS(ctx context.Context, ref string) (Materializat
 		ResolvedRef: firstImageRef(image.RepoDigests, image.NormalizedRef, image.ManifestDigest, image.CacheKey),
 		LayoutPath:  c.MaterializedOCILayoutPath(imageID),
 		RootFSPath:  rootfsPath,
+		Env:         image.Env,
 	}
 	if ReadyFlagExists(readyFlag) && isUsableRootFS(rootfsPath) {
 		return result, nil

--- a/pkg/imagecache/rootfs_test.go
+++ b/pkg/imagecache/rootfs_test.go
@@ -94,7 +94,7 @@ func TestMaterializeRootFSHandlesSymlinkHardlinkAndReadyHit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second MaterializeRootFS returned error: %v", err)
 	}
-	if second != first {
+	if second.ImageID != first.ImageID || second.ResolvedRef != first.ResolvedRef || second.LayoutPath != first.LayoutPath || second.RootFSPath != first.RootFSPath {
 		t.Fatalf("second result = %#v, want %#v", second, first)
 	}
 	assertFileContent(t, sentinelPath, "keep\n")

--- a/pkg/imagecache/types.go
+++ b/pkg/imagecache/types.go
@@ -42,6 +42,7 @@ type ImageMetadata struct {
 	Platform        Platform          `json:"platform,omitempty"`
 	MediaType       string            `json:"media_type,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty"`
+	Env             []string          `json:"env,omitempty"`
 	SizeBytes       int64             `json:"size_bytes,omitempty"`
 	CreatedAt       time.Time         `json:"created_at,omitempty"`
 	PulledAt        time.Time         `json:"pulled_at,omitempty"`
@@ -100,4 +101,5 @@ type MaterializationResult struct {
 	ResolvedRef string
 	LayoutPath  string
 	RootFSPath  string
+	Env         []string
 }


### PR DESCRIPTION
## Summary

When a Docker image defines `ENV` directives (e.g. `ENV DEBIAN_FRONTEND=noninteractive`), those variables were silently discarded when starting a microsandbox guest. The `createSandbox` path only used user-provided `EnvItems` and hardcoded agent-compose defaults. Docker native runtime inherits image ENV automatically through the daemon, but microsandbox boots from a raw rootfs and must explicitly pass them.

## Changes

- **imagecache**: store `Env []string` in `ImageMetadata`, `MetadataInput`, `MaterializationResult`; extract from `configFile.Config.Env` during pull
- **local_docker_oci**: persist image ENV alongside rootfs cache (`.env.json`) and thread it through `localDockerImageRootfs.Env`
- **microsandbox_image_resolver**: add `Env` to `microsandboxRootFSResult`, propagate from both Docker-daemon and OCI-pull paths
- **microsandbox_runtime**: read image ENV as baseline in `createSandbox`; user `EnvItems` / `RuntimeEnvItems` / agent-compose defaults override (matching Docker daemon behavior)
- **types**: add `parseEnvEntry` helper for `KEY=VALUE` parsing with unit test

## Merge priority

image ENV (baseline) < user EnvItems/RuntimeEnvItems < agent-compose hardcoded defaults

LLM provider keys (`OPENAI_API_KEY`, etc.) are still filtered from image ENV.

## Files changed

12 files, +139 / -15 lines.