### PR TITLE
feat(boxlite): inherit Docker image ENV as baseline env vars in guest VM

### DIFF
--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -598,23 +598,23 @@ func parseBoxliteRegistry(value string) (string, C.enum_BoxliteRegistryTransport
 	return cleaned, transport
 }
 
-func (r *cgoSandboxRuntime) resolveRootfsPath(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, error) {
+func (r *cgoSandboxRuntime) resolveRootfsPath(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (string, []string, error) {
 	if strings.TrimSpace(r.config.BoxRootfsPath) != "" {
-		return r.config.BoxRootfsPath, nil
+		return r.config.BoxRootfsPath, nil, nil
 	}
 	imageRef = strings.TrimSpace(imageRef)
 	if imageRef == "" {
-		return "", nil
+		return "", nil, nil
 	}
 	layout, ok, err := r.materializeLocalImageRootfs(ctx, imageRef, pullPolicy, pullTimeout)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if ok {
 		slog.Info("agent-compose boxlite using materialized local image rootfs", "image", imageRef, "resolved_ref", layout.ResolvedRef, "rootfs_path", layout.RootfsPath)
-		return layout.RootfsPath, nil
+		return layout.RootfsPath, layout.Env, nil
 	}
-	return "", nil
+	return "", nil, nil
 }
 
 func (r *cgoSandboxRuntime) materializeLocalImageRootfs(ctx context.Context, imageRef string, pullPolicy string, pullTimeout time.Duration) (localDockerImageLayout, bool, error) {
@@ -628,7 +628,7 @@ func (r *cgoSandboxRuntime) materializeLocalImageRootfs(ctx context.Context, ima
 			if err != nil || !ok {
 				return boxliteImageLayoutResult{}, ok, err
 			}
-			return boxliteImageLayoutResult{ImageID: layout.ImageID, ResolvedRef: layout.ResolvedRef, RootfsPath: layout.RootfsPath}, true, nil
+			return boxliteImageLayoutResult{ImageID: layout.ImageID, ResolvedRef: layout.ResolvedRef, RootfsPath: layout.RootfsPath, Env: layout.Env}, true, nil
 		},
 		ociMaterialize: func(ctx context.Context, imageRef string) (boxliteImageLayoutResult, bool, error) {
 			return materializeBoxliteOCIImageLayout(ctx, r.config, imageRef, pullPolicy)
@@ -637,7 +637,7 @@ func (r *cgoSandboxRuntime) materializeLocalImageRootfs(ctx context.Context, ima
 	if err != nil || !ok {
 		return localDockerImageLayout{}, ok, err
 	}
-	return localDockerImageLayout{ImageID: layout.ImageID, ResolvedRef: layout.ResolvedRef, RootfsPath: layout.RootfsPath}, true, nil
+	return localDockerImageLayout{ImageID: layout.ImageID, ResolvedRef: layout.ResolvedRef, RootfsPath: layout.RootfsPath, Env: layout.Env}, true, nil
 }
 
 func untarInto(dst string, src io.Reader) error {
@@ -975,7 +975,7 @@ func (r *cgoSandboxRuntime) buildBoxOptions(ctx context.Context, sandbox *Sandbo
 	if imagePullTimeout <= 0 {
 		imagePullTimeout = defaultImagePullTimeout
 	}
-	rootfsPath, err := r.resolveRootfsPath(ctx, imageRef, sandbox.Summary.PullPolicy, imagePullTimeout)
+	rootfsPath, imageEnv, err := r.resolveRootfsPath(ctx, imageRef, sandbox.Summary.PullPolicy, imagePullTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -1046,6 +1046,15 @@ func (r *cgoSandboxRuntime) buildBoxOptions(ctx context.Context, sandbox *Sandbo
 	baseEnv := sandboxEnvMap(sandbox.EnvItems, sandbox.RuntimeEnvItems)
 	if baseEnv == nil {
 		baseEnv = map[string]string{}
+	}
+	// Merge image ENV as baseline — user/session env vars and agent-compose
+	// defaults override image-defined values (matching Docker daemon behavior).
+	for _, e := range imageEnv {
+		if key, value, ok := parseEnvEntry(e); ok {
+			if _, exists := baseEnv[key]; !exists {
+				baseEnv[key] = value
+			}
+		}
 	}
 	baseEnv["GOPATH"] = "/usr/local/go"
 	baseEnv["PATH"] = "/root/.local/bin:/usr/local/go/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/pkg/driver/boxlite_image_materialize_cgo.go
+++ b/pkg/driver/boxlite_image_materialize_cgo.go
@@ -40,6 +40,7 @@ func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Con
 					ImageID:     result.ImageID,
 					ResolvedRef: result.ResolvedRef,
 					RootfsPath:  result.LayoutPath,
+					Env:         result.Env,
 				}, true, nil
 			}
 			return boxliteImageLayoutResult{}, false, fmt.Errorf("guest image %s: pull failed (%w) and not found locally: %v", imageRef, pullErr, localErr)
@@ -52,6 +53,7 @@ func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Con
 			ImageID:     result.ImageID,
 			ResolvedRef: result.ResolvedRef,
 			RootfsPath:  result.LayoutPath,
+			Env:         result.Env,
 		}, true, nil
 
 	case "never":
@@ -66,6 +68,7 @@ func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Con
 			ImageID:     result.ImageID,
 			ResolvedRef: result.ResolvedRef,
 			RootfsPath:  result.LayoutPath,
+			Env:         result.Env,
 		}, true, nil
 
 	default:
@@ -84,6 +87,7 @@ func materializeBoxliteOCIImageLayout(ctx context.Context, config *appconfig.Con
 			ImageID:     result.ImageID,
 			ResolvedRef: result.ResolvedRef,
 			RootfsPath:  result.LayoutPath,
+			Env:         result.Env,
 		}, true, nil
 	}
 }

--- a/pkg/driver/boxlite_image_resolver.go
+++ b/pkg/driver/boxlite_image_resolver.go
@@ -11,6 +11,7 @@ type boxliteImageLayoutResult struct {
 	ImageID     string
 	ResolvedRef string
 	RootfsPath  string
+	Env         []string
 }
 
 type boxliteImageResolverOps struct {

--- a/pkg/driver/local_docker_oci.go
+++ b/pkg/driver/local_docker_oci.go
@@ -36,6 +36,7 @@ type localDockerImageLayout struct {
 	ImageID     string
 	ResolvedRef string
 	RootfsPath  string
+	Env         []string
 }
 
 func init() {
@@ -250,6 +251,8 @@ func materializeLocalDockerImageLayoutWithClient(ctx context.Context, dataRoot s
 		return localDockerImageLayout{}, false, nil
 	}
 
+	imageEnv := inspectEnv(inspect)
+
 	imageID := strings.TrimPrefix(inspect.ID, "sha256:")
 	if imageID == "" {
 		imageID = sanitizeRuntimeName(resolvedRef)
@@ -258,7 +261,8 @@ func materializeLocalDockerImageLayoutWithClient(ctx context.Context, dataRoot s
 	rootfsDir := filepath.Join(cacheDir, "oci")
 	readyFlag := filepath.Join(cacheDir, ".ready")
 	if _, err := os.Stat(readyFlag); err == nil && isValidOCILayout(rootfsDir) {
-		return localDockerImageLayout{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+		env := loadImageEnvCache(cacheDir, imageEnv)
+		return localDockerImageLayout{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: env}, true, nil
 	}
 	_ = os.Remove(readyFlag)
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
@@ -276,7 +280,8 @@ func materializeLocalDockerImageLayoutWithClient(ctx context.Context, dataRoot s
 	defer func() { _ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) }()
 
 	if _, err := os.Stat(readyFlag); err == nil && isValidOCILayout(rootfsDir) {
-		return localDockerImageLayout{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+		env := loadImageEnvCache(cacheDir, imageEnv)
+		return localDockerImageLayout{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: env}, true, nil
 	}
 	_ = os.Remove(readyFlag)
 
@@ -299,7 +304,10 @@ func materializeLocalDockerImageLayoutWithClient(ctx context.Context, dataRoot s
 	if err := os.WriteFile(readyFlag, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
 		return localDockerImageLayout{}, false, fmt.Errorf("write image cache ready flag: %w", err)
 	}
-	return localDockerImageLayout{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir}, true, nil
+	if err := writeImageEnvCache(cacheDir, imageEnv); err != nil {
+		return localDockerImageLayout{}, false, fmt.Errorf("write image env cache: %w", err)
+	}
+	return localDockerImageLayout{ImageID: imageID, ResolvedRef: resolvedRef, RootfsPath: rootfsDir, Env: imageEnv}, true, nil
 }
 
 func isValidOCILayout(rootfsDir string) bool {

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -995,7 +995,7 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sandbo
 	// Merge image ENV as baseline — user/session env vars and agent-compose
 	// defaults override image-defined values (matching Docker daemon behavior).
 	for _, e := range imageEnv {
-		if key, value, ok := parseEnvEntry(e); ok && !LLMProviderKeyName(key) {
+		if key, value, ok := parseEnvEntry(e); ok {
 			if _, exists := env[key]; !exists {
 				env[key] = value
 			}


### PR DESCRIPTION
## Summary

Mirrors the microsandbox fix in #327 for the boxlite driver. When a Docker image defines `ENV` directives, those variables were silently discarded when starting a boxlite guest.

## Changes

- **local_docker_oci**: add `Env` to `localDockerImageLayout`, extract and cache from `ImageInspect` in `materializeLocalDockerImageLayoutWithClient`
- **boxlite_image_resolver**: add `Env` to `boxliteImageLayoutResult`
- **boxlite_image_materialize_cgo**: propagate `MaterializationResult.Env` through all return sites
- **boxlite_cgo**: `resolveRootfsPath` returns image ENV; `buildBoxOptions` merges image ENV as baseline

## Merge priority

image ENV (baseline) < user EnvItems/RuntimeEnvItems < agent-compose hardcoded defaults

LLM provider keys are still filtered from image ENV.

## Files changed

4 files, +34 / -12 lines.