### PR TITLE
fix(scheduler): associate sandbox logs with projects

### DIFF
--- a/cmd/agent-compose/cli_logs_locator.go
+++ b/cmd/agent-compose/cli_logs_locator.go
@@ -53,5 +53,5 @@ func runComposeLogsForResourceID(cmd *cobra.Command, cli cliOptions, options com
 		}
 		return writeLogsForRun(cmd.OutOrStdout(), run.Msg.GetRun(), cli.JSON, options)
 	}
-	return followOrPrintProjectLogs(cmd, cli, clients.run, projectID, projectName, options)
+	return followOrPrintProjectLogs(cmd, cli, clients, projectID, projectName, options)
 }

--- a/cmd/agent-compose/cli_sandbox_logs.go
+++ b/cmd/agent-compose/cli_sandbox_logs.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+type composeSandboxLogsOutput struct {
+	SandboxID string                                `json:"sandbox_id"`
+	Output    string                                `json:"output"`
+	Events    []*agentcomposev2.SandboxHistoryEvent `json:"events,omitempty"`
+}
+
+func resolveProjectSandboxIDRef(ctx context.Context, client agentcomposev2connect.SandboxServiceClient, projectID, ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("sandbox id is required")}
+	}
+	sandboxes, err := listAllSandboxes(ctx, client)
+	if err != nil {
+		return "", commandExitErrorForConnect(fmt.Errorf("resolve sandbox %s: %w", ref, err))
+	}
+	matches := make([]string, 0, 1)
+	for _, sandbox := range sandboxes {
+		if !protoSandboxBelongsToProject(sandbox, projectID) || !resourceIDMatchesRef(sandbox.GetSandboxId(), shortOpaqueID(sandbox.GetSandboxId()), ref) {
+			continue
+		}
+		matches = append(matches, sandbox.GetSandboxId())
+	}
+	if len(matches) == 0 {
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("sandbox %q not found in current project", ref)}
+	}
+	if len(matches) > 1 {
+		shortIDs := make([]string, 0, len(matches))
+		for _, id := range matches {
+			shortIDs = append(shortIDs, shortOpaqueID(id))
+		}
+		sort.Strings(shortIDs)
+		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("sandbox ref %q is ambiguous in current project; matches: %s", ref, strings.Join(shortIDs, ", "))}
+	}
+	return matches[0], nil
+}
+
+func protoSandboxBelongsToProject(sandbox *agentcomposev2.Sandbox, projectID string) bool {
+	projectID = strings.TrimSpace(projectID)
+	tags := sessionTagsMap(sandbox.GetTags())
+	if canonical := strings.TrimSpace(tags["project"]); canonical != "" {
+		return canonical == projectID
+	}
+	return strings.TrimSpace(tags["project_id"]) == projectID
+}
+
+func writeSandboxHistoryLogs(cmd *cobra.Command, cli cliOptions, client agentcomposev2connect.SandboxServiceClient, projectID string, options composeLogsOptions) error {
+	if options.Follow {
+		return commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("logs --follow is not yet supported for scheduler command sandbox history")}
+	}
+	sandboxID, err := resolveProjectSandboxIDRef(cmd.Context(), client, projectID, options.SandboxID)
+	if err != nil {
+		return err
+	}
+	resp, err := client.ListSandboxHistory(cmd.Context(), connect.NewRequest(&agentcomposev2.ListSandboxHistoryRequest{SandboxId: sandboxID}))
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("list sandbox %s history for project %s: %w", sandboxID, projectID, err))
+	}
+	output := tailLogOutput(sandboxHistoryOutput(resp.Msg.GetCells()), options.TailLines)
+	if cli.JSON {
+		data, err := json.MarshalIndent(composeSandboxLogsOutput{SandboxID: sandboxID, Output: output, Events: resp.Msg.GetEvents()}, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
+	}
+	if output != "" {
+		if _, err := fmt.Fprint(cmd.OutOrStdout(), output); err != nil {
+			return err
+		}
+		if !strings.HasSuffix(output, "\n") {
+			if _, err := fmt.Fprintln(cmd.OutOrStdout()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func sandboxHistoryOutput(cells []*agentcomposev2.SandboxHistoryCell) string {
+	var output strings.Builder
+	for _, cell := range cells {
+		text := firstNonEmptyString(cell.GetOutput(), cell.GetStdout(), cell.GetStderr())
+		if text == "" {
+			continue
+		}
+		output.WriteString(text)
+		if !strings.HasSuffix(text, "\n") {
+			output.WriteByte('\n')
+		}
+	}
+	return output.String()
+}

--- a/cmd/agent-compose/cli_sandbox_logs_test.go
+++ b/cmd/agent-compose/cli_sandbox_logs_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestResolveProjectSandboxIDRefSupportsSchedulerProjectTag(t *testing.T) {
+	const projectID = "project-1"
+	sandboxID := strings.Repeat("a", 64)
+	server := newComposeServiceStubServer(t, composeServiceStubs{sandbox: sandboxServiceStub{
+		listSandboxes: func(context.Context, *connect.Request[agentcomposev2.ListSandboxesRequest]) (*connect.Response[agentcomposev2.ListSandboxesResponse], error) {
+			return connect.NewResponse(&agentcomposev2.ListSandboxesResponse{Sandboxes: []*agentcomposev2.Sandbox{
+				{SandboxId: sandboxID, Tags: []*agentcomposev2.SandboxTag{{Name: "project_id", Value: projectID}, {Name: "agent", Value: "worker"}}},
+			}}), nil
+		},
+	}})
+	defer server.Close()
+
+	client := agentcomposev2connect.NewSandboxServiceClient(server.Client(), server.URL)
+	got, err := resolveProjectSandboxIDRef(context.Background(), client, projectID, sandboxID[:12])
+	if err != nil {
+		t.Fatalf("resolveProjectSandboxIDRef returned error: %v", err)
+	}
+	if got != sandboxID {
+		t.Fatalf("sandbox id = %q, want %q", got, sandboxID)
+	}
+}
+
+func TestWriteSandboxHistoryLogsPrintsSchedulerCommandOutput(t *testing.T) {
+	const projectID = "project-1"
+	sandboxID := strings.Repeat("b", 64)
+	server := newComposeServiceStubServer(t, composeServiceStubs{sandbox: sandboxServiceStub{
+		listSandboxes: func(context.Context, *connect.Request[agentcomposev2.ListSandboxesRequest]) (*connect.Response[agentcomposev2.ListSandboxesResponse], error) {
+			return connect.NewResponse(&agentcomposev2.ListSandboxesResponse{Sandboxes: []*agentcomposev2.Sandbox{
+				{SandboxId: sandboxID, Tags: []*agentcomposev2.SandboxTag{{Name: "project", Value: projectID}}},
+			}}), nil
+		},
+		listHistory: func(_ context.Context, req *connect.Request[agentcomposev2.ListSandboxHistoryRequest]) (*connect.Response[agentcomposev2.ListSandboxHistoryResponse], error) {
+			if req.Msg.GetSandboxId() != sandboxID {
+				t.Fatalf("sandbox id = %q, want %q", req.Msg.GetSandboxId(), sandboxID)
+			}
+			return connect.NewResponse(&agentcomposev2.ListSandboxHistoryResponse{Cells: []*agentcomposev2.SandboxHistoryCell{{Id: "cell-1", Output: "scheduler command output\n", Success: true}}}), nil
+		},
+	}})
+	defer server.Close()
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	client := agentcomposev2connect.NewSandboxServiceClient(server.Client(), server.URL)
+	err := writeSandboxHistoryLogs(cmd, cliOptions{}, client, projectID, composeLogsOptions{SandboxID: sandboxID, TailLines: -1})
+	if err != nil {
+		t.Fatalf("writeSandboxHistoryLogs returned error: %v", err)
+	}
+	if got := out.String(); got != "scheduler command output\n" {
+		t.Fatalf("output = %q", got)
+	}
+}

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -3505,26 +3505,25 @@ func runComposeLogsCommand(cmd *cobra.Command, cli cliOptions, options composeLo
 	if err != nil {
 		return err
 	}
-	clientConfig, err := resolveCLIClientConfig(cli.Host)
+	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
 	}
-	client := agentcomposev2connect.NewRunServiceClient(newDaemonHTTPClient(clientConfig), clientConfig.BaseURL)
-	normalizedOptions, err = resolveComposeLogRefs(cmd.Context(), client, normalized, projectID, normalizedOptions)
+	normalizedOptions, err = resolveComposeLogRefs(cmd.Context(), clients.run, clients.sandbox, normalized, projectID, normalizedOptions)
 	if err != nil {
 		return err
 	}
 	if strings.TrimSpace(normalizedOptions.RunID) != "" {
-		run, err := getRunDetail(cmd.Context(), client, projectID, normalizedOptions.RunID)
+		run, err := getRunDetail(cmd.Context(), clients.run, projectID, normalizedOptions.RunID)
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", strings.TrimSpace(normalizedOptions.RunID), normalized.Name, err))
 		}
 		if normalizedOptions.Follow {
-			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), client, projectID, run.Msg.GetRun().GetSummary(), normalizedOptions)
+			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.run, projectID, run.Msg.GetRun().GetSummary(), normalizedOptions)
 		}
 		return writeLogsForRun(cmd.OutOrStdout(), run.Msg.GetRun(), cli.JSON, normalizedOptions)
 	}
-	return followOrPrintProjectLogs(cmd, cli, client, projectID, normalized.Name, normalizedOptions)
+	return followOrPrintProjectLogs(cmd, cli, clients, projectID, normalized.Name, normalizedOptions)
 }
 
 func normalizeComposeLogsOptions(cmd *cobra.Command, options composeLogsOptions, args []string) (composeLogsOptions, error) {
@@ -3544,7 +3543,7 @@ func normalizeComposeLogsOptions(cmd *cobra.Command, options composeLogsOptions,
 	return options, nil
 }
 
-func resolveComposeLogRefs(ctx context.Context, client agentcomposev2connect.RunServiceClient, normalized *compose.NormalizedProjectSpec, projectID string, options composeLogsOptions) (composeLogsOptions, error) {
+func resolveComposeLogRefs(ctx context.Context, runClient agentcomposev2connect.RunServiceClient, sandboxClient agentcomposev2connect.SandboxServiceClient, normalized *compose.NormalizedProjectSpec, projectID string, options composeLogsOptions) (composeLogsOptions, error) {
 	if strings.TrimSpace(options.AgentName) != "" {
 		agentName, err := resolveComposeAgentNameFromSpec(normalized, projectID, options.AgentName)
 		if err != nil {
@@ -3553,16 +3552,20 @@ func resolveComposeLogRefs(ctx context.Context, client agentcomposev2connect.Run
 		options.AgentName = agentName
 	}
 	if shouldResolveComposeLogResourceRef(options.RunID) {
-		runID, err := resolveComposeRunIDRef(ctx, client, projectID, options.AgentName, options.RunID)
+		runID, err := resolveComposeRunIDRef(ctx, runClient, projectID, options.AgentName, options.RunID)
 		if err != nil {
 			return options, err
 		}
 		options.RunID = runID
 	}
 	if shouldResolveComposeLogResourceRef(options.SandboxID) {
-		sandboxID, err := resolveComposeSandboxIDRefFromRuns(ctx, client, projectID, options.AgentName, options.SandboxID)
-		if err != nil {
-			return options, err
+		sandboxID, runErr := resolveComposeSandboxIDRefFromRuns(ctx, runClient, projectID, options.AgentName, options.SandboxID)
+		if runErr != nil {
+			var err error
+			sandboxID, err = resolveProjectSandboxIDRef(ctx, sandboxClient, projectID, options.SandboxID)
+			if err != nil {
+				return options, err
+			}
 		}
 		options.SandboxID = sandboxID
 	}
@@ -7793,11 +7796,15 @@ func formatProtoTimestamp(value interface{ AsTime() time.Time }) string {
 	return parsed.UTC().Format(time.RFC3339Nano)
 }
 
-func followOrPrintProjectLogs(cmd *cobra.Command, cli cliOptions, client agentcomposev2connect.RunServiceClient, projectID, projectName string, options composeLogsOptions) error {
+func followOrPrintProjectLogs(cmd *cobra.Command, cli cliOptions, clients cliServiceClients, projectID, projectName string, options composeLogsOptions) error {
+	client := clients.run
 	if options.Follow && !cli.JSON {
 		runs, err := listLogRuns(cmd.Context(), client, projectID, options)
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("list logs for project %s: %w", projectName, err))
+		}
+		if len(runs) == 0 && options.SandboxID != "" {
+			return writeSandboxHistoryLogs(cmd, cli, clients.sandbox, projectID, options)
 		}
 		for _, summary := range runs {
 			if err := followRunLogStream(cmd.Context(), cmd.OutOrStdout(), client, projectID, summary, options); err != nil {
@@ -7813,6 +7820,9 @@ func followOrPrintProjectLogs(cmd *cobra.Command, cli cliOptions, client agentco
 			return commandExitErrorForConnect(fmt.Errorf("list logs for project %s: %w", projectName, err))
 		}
 		if len(runs) == 0 {
+			if options.SandboxID != "" {
+				return writeSandboxHistoryLogs(cmd, cli, clients.sandbox, projectID, options)
+			}
 			if cli.JSON {
 				data, err := json.MarshalIndent(composeLogsOutput{}, "", "  ")
 				if err != nil {

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -9911,10 +9911,18 @@ type sandboxServiceStub struct {
 	getStats      func(context.Context, *connect.Request[agentcomposev2.GetSandboxStatsRequest]) (*connect.Response[agentcomposev2.GetSandboxStatsResponse], error)
 	getSandbox    func(context.Context, *connect.Request[agentcomposev2.GetSandboxRequest]) (*connect.Response[agentcomposev2.GetSandboxResponse], error)
 	listSandboxes func(context.Context, *connect.Request[agentcomposev2.ListSandboxesRequest]) (*connect.Response[agentcomposev2.ListSandboxesResponse], error)
+	listHistory   func(context.Context, *connect.Request[agentcomposev2.ListSandboxHistoryRequest]) (*connect.Response[agentcomposev2.ListSandboxHistoryResponse], error)
 	stopSandbox   func(context.Context, *connect.Request[agentcomposev2.StopSandboxRequest]) (*connect.Response[agentcomposev2.StopSandboxResponse], error)
 	resumeSandbox func(context.Context, *connect.Request[agentcomposev2.ResumeSandboxRequest]) (*connect.Response[agentcomposev2.ResumeSandboxResponse], error)
 
 	agentcomposev2connect.UnimplementedSandboxServiceHandler
+}
+
+func (s sandboxServiceStub) ListSandboxHistory(ctx context.Context, req *connect.Request[agentcomposev2.ListSandboxHistoryRequest]) (*connect.Response[agentcomposev2.ListSandboxHistoryResponse], error) {
+	if s.listHistory == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ListSandboxHistory stub is not configured"))
+	}
+	return s.listHistory(ctx, req)
 }
 
 func (s sandboxServiceStub) StopSandbox(ctx context.Context, req *connect.Request[agentcomposev2.StopSandboxRequest]) (*connect.Response[agentcomposev2.StopSandboxResponse], error) {

--- a/pkg/agentcompose/adapters/loader_session_runner.go
+++ b/pkg/agentcompose/adapters/loader_session_runner.go
@@ -132,8 +132,10 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	}
 	tags := []domain.SandboxTag{{Name: "origin", Value: origin}, {Name: "loader_id", Value: loader.Summary.ID}, {Name: "loader_name", Value: loader.Summary.Name}}
 	if origin == "scheduler" {
+		projectID := strings.TrimSpace(loader.Summary.ManagedProjectID)
 		tags = append(tags,
-			domain.SandboxTag{Name: "project_id", Value: loader.Summary.ManagedProjectID},
+			domain.SandboxTag{Name: "project", Value: projectID},
+			domain.SandboxTag{Name: "project_id", Value: projectID},
 			domain.SandboxTag{Name: "agent", Value: loader.Summary.ManagedAgentName},
 			domain.SandboxTag{Name: "scheduler_id", Value: loader.Summary.ManagedSchedulerID},
 		)

--- a/pkg/agentcompose/adapters/loader_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/loader_session_runner_coverage_test.go
@@ -265,7 +265,7 @@ func TestLoaderSandboxRunnerResolvesVolumeMounts(t *testing.T) {
 	for _, tag := range session.Summary.Tags {
 		tags[tag.Name] = tag.Value
 	}
-	if tags["origin"] != "scheduler" || tags["project_id"] != "project-1" || tags["agent"] != "reviewer" || tags["scheduler_id"] != "scheduler-1" {
+	if tags["origin"] != "scheduler" || tags["project"] != "project-1" || tags["project_id"] != "project-1" || tags["agent"] != "reviewer" || tags["scheduler_id"] != "scheduler-1" {
 		t.Fatalf("managed scheduler sandbox tags = %#v", tags)
 	}
 	events, err := bridge.store.ListEvents(ctx, session.Summary.ID)

--- a/pkg/projects/controller_coverage_test.go
+++ b/pkg/projects/controller_coverage_test.go
@@ -173,6 +173,8 @@ func TestDownProjectSandboxAndSchedulerWorkflows(t *testing.T) {
 		{Summary: domain.SandboxSummary{ID: "other", Title: "Other", Tags: []domain.SandboxTag{{Name: "project", Value: "other"}}}},
 		{Summary: domain.SandboxSummary{ID: "session-fail", Title: "Fail", Tags: []domain.SandboxTag{{Name: " project ", Value: " project-1 "}}}},
 		{Summary: domain.SandboxSummary{ID: "session-ok", Title: "OK", Tags: []domain.SandboxTag{{Name: "project", Value: "project-1"}}}},
+		{Summary: domain.SandboxSummary{ID: "session-legacy", Title: "Legacy", Tags: []domain.SandboxTag{{Name: "project_id", Value: "project-1"}}}},
+		{Summary: domain.SandboxSummary{ID: "session-conflict", Title: "Conflict", Tags: []domain.SandboxTag{{Name: "project", Value: "other"}, {Name: "project_id", Value: "project-1"}}}},
 	}}
 	stopped := make([]string, 0)
 	refreshed := false
@@ -200,13 +202,14 @@ func TestDownProjectSandboxAndSchedulerWorkflows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DownProject returned error: %v", err)
 	}
-	if !refreshed || len(stopped) != 2 {
+	if !refreshed || len(stopped) != 3 {
 		t.Fatalf("refreshed/stopped = %v/%#v", refreshed, stopped)
 	}
 	assertDownChange(t, changes, DownChangeUpdated, "project_scheduler", "scheduler-1")
 	assertDownChange(t, changes, DownChangeUpdated, "loader", "loader-1")
 	assertDownChange(t, changes, DownChangeUnchanged, "sandbox", "session-fail")
 	assertDownChange(t, changes, DownChangeUpdated, "sandbox", "session-ok")
+	assertDownChange(t, changes, DownChangeUpdated, "sandbox", "session-legacy")
 	if SandboxHasTag(nil, "project", project.ID) || !SandboxHasTag(sessionStore.sessions[2], "project", project.ID) {
 		t.Fatalf("SandboxHasTag returned unexpected values")
 	}

--- a/pkg/projects/down.go
+++ b/pkg/projects/down.go
@@ -110,7 +110,7 @@ func StopProjectRunningSandboxes(ctx context.Context, project domain.ProjectReco
 	}
 	var changes []DownChange
 	for _, sandbox := range result.Sandboxes {
-		if !SandboxHasTag(sandbox, "project", project.ID) {
+		if !SandboxBelongsToProject(sandbox, project.ID) {
 			continue
 		}
 		if options.StopSandbox == nil {
@@ -135,6 +135,28 @@ func StopProjectRunningSandboxes(ctx context.Context, project domain.ProjectReco
 		})
 	}
 	return changes, nil
+}
+
+func SandboxBelongsToProject(sandbox *domain.Sandbox, projectID string) bool {
+	if sandbox == nil {
+		return false
+	}
+	if canonical := sandboxTagValue(sandbox, "project"); canonical != "" {
+		return canonical == strings.TrimSpace(projectID)
+	}
+	return sandboxTagValue(sandbox, "project_id") == strings.TrimSpace(projectID)
+}
+
+func sandboxTagValue(sandbox *domain.Sandbox, name string) string {
+	if sandbox == nil {
+		return ""
+	}
+	for _, tag := range sandbox.Summary.Tags {
+		if strings.TrimSpace(tag.Name) == strings.TrimSpace(name) {
+			return strings.TrimSpace(tag.Value)
+		}
+	}
+	return ""
 }
 
 func SandboxHasTag(sandbox *domain.Sandbox, name, value string) bool {

--- a/pkg/runs/sandbox_target.go
+++ b/pkg/runs/sandbox_target.go
@@ -76,7 +76,11 @@ func (r *SandboxRunTargetResolver) ResolveBatch(ctx context.Context, sandboxes [
 			result[id] = SandboxRunTarget{ProjectID: run.ProjectID, AgentName: run.AgentName}
 			continue
 		}
-		if projectID, agentName := sandboxTagValue(sandbox, "project"), sandboxTagValue(sandbox, "agent"); projectID != "" && agentName != "" {
+		projectID := sandboxTagValue(sandbox, "project")
+		if projectID == "" {
+			projectID = sandboxTagValue(sandbox, "project_id")
+		}
+		if agentName := sandboxTagValue(sandbox, "agent"); projectID != "" && agentName != "" {
 			result[id] = SandboxRunTarget{ProjectID: projectID, AgentName: agentName}
 			continue
 		}

--- a/pkg/runs/sandbox_target_test.go
+++ b/pkg/runs/sandbox_target_test.go
@@ -33,6 +33,7 @@ func TestSandboxRunTargetResolverResolveBatch(t *testing.T) {
 	sandboxes := []*domain.Sandbox{
 		sandboxWithTags("run-sandbox", domain.SandboxTag{Name: "project", Value: "ignored-project"}),
 		sandboxWithTags("tag-sandbox", domain.SandboxTag{Name: "project", Value: "tag-project"}, domain.SandboxTag{Name: "agent", Value: "tag-agent"}),
+		sandboxWithTags("legacy-tag-sandbox", domain.SandboxTag{Name: "project_id", Value: "legacy-tag-project"}, domain.SandboxTag{Name: "agent", Value: "legacy-tag-agent"}),
 		sandboxWithTags("managed-sandbox", domain.SandboxTag{Name: domain.AgentSandboxTagID, Value: "managed-id"}),
 		sandboxWithTags("legacy-sandbox", domain.SandboxTag{Name: domain.AgentSandboxTagID, Value: "old-uuid"}, domain.SandboxTag{Name: domain.AgentSandboxTagName, Value: "Legacy-Agent"}),
 		sandboxWithTags("unknown-sandbox", domain.SandboxTag{Name: domain.AgentSandboxTagID, Value: "unknown"}),
@@ -43,10 +44,11 @@ func TestSandboxRunTargetResolverResolveBatch(t *testing.T) {
 		t.Fatalf("ResolveBatch returned error: %v", err)
 	}
 	wants := map[string]SandboxRunTarget{
-		"run-sandbox":     {ProjectID: "run-project", AgentName: "run-agent"},
-		"tag-sandbox":     {ProjectID: "tag-project", AgentName: "tag-agent"},
-		"managed-sandbox": {ProjectID: "managed-project", AgentName: "managed-agent"},
-		"legacy-sandbox":  {ProjectID: legacyProjectID, AgentName: "legacy-agent"},
+		"run-sandbox":        {ProjectID: "run-project", AgentName: "run-agent"},
+		"tag-sandbox":        {ProjectID: "tag-project", AgentName: "tag-agent"},
+		"legacy-tag-sandbox": {ProjectID: "legacy-tag-project", AgentName: "legacy-tag-agent"},
+		"managed-sandbox":    {ProjectID: "managed-project", AgentName: "managed-agent"},
+		"legacy-sandbox":     {ProjectID: legacyProjectID, AgentName: "legacy-agent"},
 	}
 	for sandboxID, want := range wants {
 		if got := targets[sandboxID]; got != want {


### PR DESCRIPTION
  ## Summary

  - Associate scheduler-created sandboxes with their owning project using the canonical `project` tag while retaining `project_id` compatibility.
  - Resolve legacy scheduler sandboxes through `project_id` for project shutdown, pruning, and sandbox target lookup.
  - Fall back to sandbox cell history for `logs --sandbox` when a scheduler `exec`, `shell`, or direct-agent sandbox has no corresponding project run.
  - Preserve existing project-run logs and scheduler trigger logs behavior.

  This fixes scheduler sandboxes appearing in `scheduler runs` and `ps -a` while their logs could not be queried by either short or full sandbox ID.

  ## Testing

  - `go test ./pkg/agentcompose/adapters ./pkg/projects ./pkg/runs ./cmd/agent-compose`
  - `go test -race ./pkg/agentcompose/adapters ./pkg/projects ./pkg/runs ./cmd/agent-compose`
  - `task lint`
  - `task build`
  - `task test`
  - Manually started a daemon on an isolated Unix socket and applied the `docker-scheduler-exec-logs` sample.
  - Manually verified both `scheduler run` and `scheduler trigger` workflows:
    - scheduler runs include the created sandbox;
    - scheduler logs include run, command, and sandbox lifecycle events;
    - `ps -a` and `inspect` resolve the sandbox under the correct project;
    - `logs --sandbox` works with short and full sandbox IDs;
    - sandbox pruning resolves the scheduler sandbox through its project ownership;
    - loader run/events, sandbox cell history, and project ownership records remain consistent.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.