### PR TITLE
fix(cli): keep image command tree supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See the [command line manual](docs/pages/command-line-manual.md) for the full fi
 | `agent-compose logs` | Print project run logs; a project, agent, run, or sandbox ID can be passed without its resource type. |
 | `agent-compose scheduler ls\|runs\|logs\|trigger\|inspect` | List triggers and runs, read scheduler logs, manually run triggers, or inspect scheduler resources. |
 | `agent-compose sandbox ls\|stop\|resume\|rm\|prune` | Manage project sandboxes. |
-| `agent-compose images\|pull\|build\|rmi\|inspect` | Manage daemon images and build agent images. |
+| `agent-compose image ls\|pull\|build\|rm\|inspect` | Manage daemon images and build agent images; top-level shortcuts remain available. |
 | `agent-compose volume ls\|create\|inspect\|rm\|prune` | Manage daemon volumes. |
 | `agent-compose cache ls\|inspect\|prune\|rm` | Inspect and clean daemon runtime caches. |
 | `agent-compose down` | Disable managed schedulers and stop sandboxes. |

--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -107,9 +107,14 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 			want: []string{"Remove an image", "--force", "--prune-children"},
 		},
 		{
-			name: "deprecated image command",
+			name: "image command",
 			args: []string{"image", "--help"},
-			want: []string{"Deprecated: use images, pull, rmi, or inspect image", "pull", "build", "inspect"},
+			want: []string{"Manage daemon images", "ls", "pull", "build", "rm", "inspect"},
+		},
+		{
+			name: "image pull",
+			args: []string{"image", "pull", "--help"},
+			want: []string{"Pull an image or all project images", "pull [image]", "--platform"},
 		},
 		{
 			name: "inspect",
@@ -127,8 +132,8 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 			if runCount != 0 {
 				t.Fatalf("%v started daemon %d time(s)", tc.args, runCount)
 			}
-			if stderr != "" && !strings.Contains(stderr, "deprecated") {
-				t.Fatalf("%v stderr = %q, want empty or deprecation warning", tc.args, stderr)
+			if stderr != "" {
+				t.Fatalf("%v stderr = %q, want empty", tc.args, stderr)
 			}
 			for _, want := range tc.want {
 				if !strings.Contains(stdout, want) {

--- a/cmd/agent-compose/main.go
+++ b/cmd/agent-compose/main.go
@@ -885,13 +885,9 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 
 	imageCmd := &cobra.Command{
 		Use:   "image",
-		Short: "Deprecated: use images, pull, rmi, or inspect image",
+		Short: "Manage daemon images",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Deprecated: use top-level image commands instead.
-			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose image", "agent-compose images, agent-compose pull, agent-compose rmi, or agent-compose inspect image"); err != nil {
-				return err
-			}
 			return cmd.Help()
 		},
 	}
@@ -901,10 +897,6 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		Short: "List daemon images",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Deprecated: use `agent-compose images` instead.
-			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose image ls", "agent-compose images"); err != nil {
-				return err
-			}
 			return runComposeImageListCommand(cmd, options, imageLSOptions)
 		},
 	}
@@ -922,15 +914,11 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	addImagePullFlags(pullCmd, &pullOptions)
 	imagePullOptions := composeImagePullOptions{}
 	imagePullCmd := &cobra.Command{
-		Use:   "pull <image>",
-		Short: "Pull an image",
-		Args:  cobra.ExactArgs(1),
+		Use:   "pull [image]",
+		Short: "Pull an image or all project images",
+		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Deprecated: use `agent-compose pull <image>` instead.
-			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose image pull", "agent-compose pull"); err != nil {
-				return err
-			}
-			return runComposeImagePullCommand(cmd, options, imagePullOptions, args[0])
+			return runComposePullCommand(cmd, options, imagePullOptions, args)
 		},
 	}
 	addImagePullFlags(imagePullCmd, &imagePullOptions)
@@ -951,9 +939,6 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		Short: "Build project agent images",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose image build", "agent-compose build"); err != nil {
-				return err
-			}
 			return runComposeBuildCommand(cmd, options, imageBuildOptions, args)
 		},
 	}
@@ -975,10 +960,6 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		Short: "Remove an image",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Deprecated: use `agent-compose rmi <image>` instead.
-			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose image rm", "agent-compose rmi"); err != nil {
-				return err
-			}
 			return runComposeImageRemoveCommand(cmd, options, imageRemoveOptions, args[0])
 		},
 	}
@@ -989,10 +970,6 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		Short: "Inspect an image",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Deprecated: use `agent-compose inspect image <image>` instead.
-			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose image inspect", "agent-compose inspect image"); err != nil {
-				return err
-			}
 			return runComposeImageInspectCommand(cmd, options, args[0])
 		},
 	}

--- a/cmd/agent-compose/main_integration_test.go
+++ b/cmd/agent-compose/main_integration_test.go
@@ -82,5 +82,5 @@ func testDaemonListenConfigWorkflow(t *testing.T) {
 	t.Run("cli image inspect json", TestIntegrationCLIImageInspectJSON)
 	t.Run("cli images json accepts OCI store status", TestIntegrationCLIImagesJSONAcceptsOCIStoreStatus)
 	t.Run("cli image Docker error is clear", TestIntegrationCLIImageDockerErrorIsClear)
-	t.Run("cli image root command warns deprecated", TestCLIImageRootCommandWarnsDeprecated)
+	t.Run("cli image root command shows help", TestCLIImageRootCommandShowsHelp)
 }

--- a/cmd/agent-compose/main_test.go
+++ b/cmd/agent-compose/main_test.go
@@ -6254,10 +6254,9 @@ func TestIntegrationCLIImagesAliasesAndJSON(t *testing.T) {
 	}
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "ls", "--host", server.URL)
-	if textCode != 0 {
+	if textCode != 0 || textErr != "" {
 		t.Fatalf("image ls code/stderr = %d / %q", textCode, textErr)
 	}
-	assertDeprecatedWarning(t, textErr, "agent-compose images")
 	for _, want := range []string{"IMAGE ID", "REF", "DISK USAGE", "abc123456789", "agent:latest", "1.0KB"} {
 		if !strings.Contains(textOut, want) {
 			t.Fatalf("image ls output %q does not contain %q", textOut, want)
@@ -7308,10 +7307,9 @@ func TestIntegrationCLIImagePullAliasesAndJSON(t *testing.T) {
 	}
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "pull", "--host", server.URL, "agent:latest")
-	if textCode != 0 {
+	if textCode != 0 || textErr != "" {
 		t.Fatalf("image pull code/stderr = %d / %q", textCode, textErr)
 	}
-	assertDeprecatedWarning(t, textErr, "agent-compose pull")
 	if !strings.Contains(textOut, "Pulled agent:latest") || !strings.Contains(textOut, "agent@sha256:def") {
 		t.Fatalf("image pull output = %q", textOut)
 	}
@@ -7389,16 +7387,29 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("pull", "--host", server.URL, "--file", composePath, "--platform", "linux/amd64")
-	if exitCode != 0 || stderr != "" {
-		t.Fatalf("pull project code/stderr = %d / %q", exitCode, stderr)
+	commands := []struct {
+		name string
+		args []string
+	}{
+		{name: "top-level alias", args: []string{"pull"}},
+		{name: "image command", args: []string{"image", "pull"}},
 	}
-	for _, want := range []string{"Pulled agent:v2", "agent:v2@sha256:def", "Pulled agent:v1", "agent:v1@sha256:def"} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("pull project stdout %q does not contain %q", stdout, want)
-		}
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			args := append([]string{}, command.args...)
+			args = append(args, "--host", server.URL, "--file", composePath, "--platform", "linux/amd64")
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != 0 || stderr != "" {
+				t.Fatalf("pull project code/stderr = %d / %q", exitCode, stderr)
+			}
+			for _, want := range []string{"Pulled agent:v2", "agent:v2@sha256:def", "Pulled agent:v1", "agent:v1@sha256:def"} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("pull project stdout %q does not contain %q", stdout, want)
+				}
+			}
+		})
 	}
-	if len(pulled) != 2 || pulled[0] != "agent:v2" || pulled[1] != "agent:v1" {
+	if len(pulled) != 4 || pulled[0] != "agent:v2" || pulled[1] != "agent:v1" || pulled[2] != "agent:v2" || pulled[3] != "agent:v1" {
 		t.Fatalf("pulled images = %#v", pulled)
 	}
 }
@@ -7512,10 +7523,9 @@ agents:
 	defer server.Close()
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "build", "--host", server.URL, "--file", composePath, "-t", "reviewer:ci", "--dockerfile", "Dockerfile.agent", "--target", "runtime", "--build-arg", "NODE_ENV=development", "--platform", "linux/amd64", "--no-cache", "--pull", "reviewer")
-	if textCode != 0 {
+	if textCode != 0 || textErr != "" {
 		t.Fatalf("image build code/stderr = %d / %q", textCode, textErr)
 	}
-	assertDeprecatedWarning(t, textErr, "agent-compose build")
 	if !strings.Contains(textOut, "build step") || !strings.Contains(textOut, "Built reviewer:dev") {
 		t.Fatalf("image build output = %q", textOut)
 	}
@@ -7641,10 +7651,9 @@ func TestIntegrationCLIImageRemoveAliasesAndJSON(t *testing.T) {
 	}
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "rm", "--host", server.URL, "--prune-children", "agent:old")
-	if textCode != 0 {
+	if textCode != 0 || textErr != "" {
 		t.Fatalf("image rm code/stderr = %d / %q", textCode, textErr)
 	}
-	assertDeprecatedWarning(t, textErr, "agent-compose rmi")
 	if !strings.Contains(textOut, "Untagged: agent:old") || !strings.Contains(textOut, "Deleted: old") {
 		t.Fatalf("image rm output = %q", textOut)
 	}
@@ -7712,17 +7721,16 @@ func TestIntegrationCLIImageInspectJSON(t *testing.T) {
 		t.Fatalf("inspect image JSON = %#v", decoded)
 	}
 
-	legacyOut, legacyErr, _, legacyCode := executeCLICommand("image", "inspect", "--host", server.URL, "agent:latest")
-	if legacyCode != 0 {
-		t.Fatalf("legacy image inspect code = %d; stderr=%q", legacyCode, legacyErr)
+	imageOut, imageErr, _, imageCode := executeCLICommand("image", "inspect", "--host", server.URL, "agent:latest")
+	if imageCode != 0 || imageErr != "" {
+		t.Fatalf("image inspect code/stderr = %d / %q", imageCode, imageErr)
 	}
-	assertDeprecatedWarning(t, legacyErr, "agent-compose inspect image")
-	var legacyDecoded composeImageInspectOutput
-	if err := json.Unmarshal([]byte(legacyOut), &legacyDecoded); err != nil {
-		t.Fatalf("legacy image inspect JSON decode failed: %v\n%s", err, legacyOut)
+	var imageDecoded composeImageInspectOutput
+	if err := json.Unmarshal([]byte(imageOut), &imageDecoded); err != nil {
+		t.Fatalf("image inspect JSON decode failed: %v\n%s", err, imageOut)
 	}
-	if legacyDecoded.Image.ImageRef != "agent:latest" || legacyDecoded.StoreStatus.Endpoint == "" {
-		t.Fatalf("legacy image inspect JSON = %#v", legacyDecoded)
+	if imageDecoded.Image.ImageRef != "agent:latest" || imageDecoded.StoreStatus.Endpoint == "" {
+		t.Fatalf("image inspect JSON = %#v", imageDecoded)
 	}
 	if calls != 2 {
 		t.Fatalf("InspectImage calls = %d, want 2", calls)
@@ -8998,13 +9006,17 @@ func TestIntegrationCLIListProjectsPaginationFlags(t *testing.T) {
 	}
 }
 
-func TestCLIImageRootCommandWarnsDeprecated(t *testing.T) {
+func TestCLIImageRootCommandShowsHelp(t *testing.T) {
 	stdout, stderr, _, exitCode := executeCLICommand("image")
-	if exitCode != 0 {
-		t.Fatalf("image root exit code = %d, stderr=%q", exitCode, stderr)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("image root code/stderr = %d / %q", exitCode, stderr)
 	}
-	assertDeprecatedWarning(t, stderr, "agent-compose images")
-	if !strings.Contains(stdout, "Deprecated") {
+	for _, want := range []string{"Manage daemon images", "build", "inspect", "pull"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("image root help output %q does not contain %q", stdout, want)
+		}
+	}
+	if strings.Contains(strings.ToLower(stdout), "deprecated") {
 		t.Fatalf("image root help output = %q", stdout)
 	}
 }
@@ -9474,13 +9486,6 @@ func freeTCPListenAddress(t *testing.T) string {
 		t.Fatalf("close free tcp port: %v", err)
 	}
 	return addr
-}
-
-func assertDeprecatedWarning(t *testing.T, stderr string, replacement string) {
-	t.Helper()
-	if !strings.Contains(stderr, "deprecated") || !strings.Contains(stderr, replacement) {
-		t.Fatalf("deprecated warning stderr = %q, want replacement %q", stderr, replacement)
-	}
 }
 
 func writeComposeFile(t *testing.T, dir string, content string) string {

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -519,30 +519,49 @@ Details:
 Manage images known to the daemon or referenced by the current project.
 
 ```bash
-agent-compose images
-agent-compose pull
-agent-compose pull <image>
-agent-compose rmi <image>
-agent-compose inspect image <image>
+agent-compose image ls
+agent-compose image pull
+agent-compose image pull <image>
+agent-compose image build [agent...]
+agent-compose image rm <image>
+agent-compose image inspect <image>
 ```
 
 Commands:
 
-- `images`: list images.
-- `pull`: pull all agent images referenced by the current project.
-- `pull <image>`: pull a specific image. If the local OCI image backend/store already has the image, the command succeeds directly with a skipped/already exists warning and does not pull again.
-- `rmi <image>`: remove an image metadata/store entry. For OCI storage this removes the logical metadata reference only; physical manifests/blobs are reclaimed explicitly by CacheService once unreferenced. It does not delete materialized or runtime-derived cache.
-- `inspect image <image>`: inspect an image.
+- `image ls`: list images.
+- `image pull`: pull all agent images referenced by the current project.
+- `image pull <image>`: pull a specific image. If the local OCI image backend/store already has the image, the command succeeds directly with a skipped/already exists warning and does not pull again.
+- `image build [agent...]`: build images configured for all project agents, or only the named agents when names are provided.
+- `image rm <image>`: remove an image metadata/store entry. For OCI storage this removes the logical metadata reference only; physical manifests/blobs are reclaimed explicitly by CacheService once unreferenced. It does not delete materialized or runtime-derived cache.
+- `image inspect <image>`: inspect an image.
+
+The following top-level commands are shortcuts for the corresponding `image` subcommands:
+
+| Top-level shortcut | Image command |
+| --- | --- |
+| `images` | `image ls` |
+| `pull [image]` | `image pull [image]` |
+| `build [agent...]` | `image build [agent...]` |
+| `rmi <image>` | `image rm <image>` |
+| `inspect image <image>` | `image inspect <image>` |
 
 Common options:
 
 | Command | Option | Description |
 | --- | --- | --- |
-| `images` | `-a, --all` | Show all images. |
-| `images` | `--query <text>` | Filter by image reference. |
-| `pull` | `--platform <os/arch[/variant]>` | Pull for a specific platform. |
-| `rmi` | `--force` | Force image removal. |
-| `rmi` | `--prune-children` | Request child-image pruning from the image backend. OCI cache currently returns a warning and does not remove blobs or runtime/materialized cache. |
+| `image ls` | `-a, --all` | Show all images. |
+| `image ls` | `--query <text>` | Filter by image reference. |
+| `image pull` | `--platform <os/arch[/variant]>` | Pull for a specific platform. |
+| `image build` | `-t, --tag <name[:tag]>` | Add an output image tag. |
+| `image build` | `--dockerfile <path>` | Override the configured Dockerfile. |
+| `image build` | `--target <stage>` | Select a Dockerfile target stage. |
+| `image build` | `--build-arg <key=value>` | Set a build-time variable; may be repeated. |
+| `image build` | `--platform <os/arch[/variant]>` | Build for a specific platform. |
+| `image build` | `--no-cache` | Disable the build cache. |
+| `image build` | `--pull` | Always attempt to pull newer base images. |
+| `image rm` | `--force` | Force image removal. |
+| `image rm` | `--prune-children` | Request child-image pruning from the image backend. OCI cache currently returns a warning and does not remove blobs or runtime/materialized cache. |
 
 ## Cache Commands
 
@@ -595,14 +614,6 @@ agent-compose cache rm <cache-id> --force
 
 `CACHE_TTL` defaults to `168h`; `0` disables expiration classification. TTL never triggers background/startup deletion. Use `cache prune --expired --force` explicitly. `--older-than` remains an independent filter. `cache prune` and `cache rm` default to dry-run; `--force` authorizes execution but never bypasses `active`, `referenced`, or `unknown` protection. BoxLite v0.9.7 runtime image inventory is read-only because its ABI has no safe image remove/prune operation; Microsandbox shared images use the SDK inventory/remove APIs. `sandbox prune` does not delete cache artifacts.
 
-Compatibility:
-
-- `agent-compose image ls` is deprecated; use `agent-compose images`.
-- `agent-compose image pull <image>` is deprecated; use `agent-compose pull <image>`.
-- `agent-compose image rm <image>` is deprecated; use `agent-compose rmi <image>`.
-- `agent-compose image inspect <image>` is deprecated; use `agent-compose inspect image <image>`.
-- The old `image` command tree still works and prints warnings to stderr, but it may be removed in a future release.
-
 ## `status`: Query Daemon Status
 
 Check the selected daemon status and version.
@@ -641,7 +652,6 @@ agent-compose config --quiet
 
 The following commands or capabilities are not published as stable CLI features yet:
 
-- `build`: project image build is deferred.
 - `push`: image push is deferred.
 - `up -d/--detach`: current `up` already applies the project and returns; no detach flag is provided.
 - Foreground `up` attach and Ctrl+C project shutdown are deferred.

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -527,30 +527,49 @@ agent-compose inspect cache <cache-id>
 管理 daemon 或当前 project 相关的镜像。
 
 ```bash
-agent-compose images
-agent-compose pull
-agent-compose pull <image>
-agent-compose rmi <image>
-agent-compose inspect image <image>
+agent-compose image ls
+agent-compose image pull
+agent-compose image pull <image>
+agent-compose image build [agent...]
+agent-compose image rm <image>
+agent-compose image inspect <image>
 ```
 
 命令说明：
 
-- `images`：列出镜像。
-- `pull`：拉取当前 project 中所有 agent 引用的镜像。
-- `pull <image>`：拉取指定镜像；如果本地 OCI image backend/store 已存在该镜像，会直接成功并输出 skipped/already exists warning，不会再次 pull。
-- `rmi <image>`：删除镜像 metadata/store entry。OCI 模式下只删除逻辑 metadata ref；无引用的物理 manifest/blob 由 CacheService 显式回收。该命令不删除 materialized 或 runtime-derived cache。
-- `inspect image <image>`：查看镜像详情。
+- `image ls`：列出镜像。
+- `image pull`：拉取当前 project 中所有 agent 引用的镜像。
+- `image pull <image>`：拉取指定镜像；如果本地 OCI image backend/store 已存在该镜像，会直接成功并输出 skipped/already exists warning，不会再次 pull。
+- `image build [agent...]`：构建所有 project agent 配置的镜像；提供 agent 名称时只构建指定 agent 的镜像。
+- `image rm <image>`：删除镜像 metadata/store entry。OCI 模式下只删除逻辑 metadata ref；无引用的物理 manifest/blob 由 CacheService 显式回收。该命令不删除 materialized 或 runtime-derived cache。
+- `image inspect <image>`：查看镜像详情。
+
+以下顶层命令是对应 `image` 子命令的快捷别名：
+
+| 顶层快捷别名 | Image 命令 |
+| --- | --- |
+| `images` | `image ls` |
+| `pull [image]` | `image pull [image]` |
+| `build [agent...]` | `image build [agent...]` |
+| `rmi <image>` | `image rm <image>` |
+| `inspect image <image>` | `image inspect <image>` |
 
 常用选项：
 
 | 命令 | 参数 | 说明 |
 | --- | --- | --- |
-| `images` | `-a, --all` | 显示全部镜像。 |
-| `images` | `--query <text>` | 按镜像引用过滤。 |
-| `pull` | `--platform <os/arch[/variant]>` | 指定拉取平台。 |
-| `rmi` | `--force` | 强制删除镜像。 |
-| `rmi` | `--prune-children` | 请求 image backend 清理 child images。OCI cache 当前会返回 warning，不删除 blobs，也不删除 runtime/materialized cache。 |
+| `image ls` | `-a, --all` | 显示全部镜像。 |
+| `image ls` | `--query <text>` | 按镜像引用过滤。 |
+| `image pull` | `--platform <os/arch[/variant]>` | 指定拉取平台。 |
+| `image build` | `-t, --tag <name[:tag]>` | 添加输出镜像 tag。 |
+| `image build` | `--dockerfile <path>` | 覆盖配置中的 Dockerfile。 |
+| `image build` | `--target <stage>` | 指定 Dockerfile target stage。 |
+| `image build` | `--build-arg <key=value>` | 设置构建变量，可重复提供。 |
+| `image build` | `--platform <os/arch[/variant]>` | 指定构建平台。 |
+| `image build` | `--no-cache` | 禁用构建缓存。 |
+| `image build` | `--pull` | 始终尝试拉取更新的基础镜像。 |
+| `image rm` | `--force` | 强制删除镜像。 |
+| `image rm` | `--prune-children` | 请求 image backend 清理 child images。OCI cache 当前会返回 warning，不删除 blobs，也不删除 runtime/materialized cache。 |
 
 ## Cache 命令
 
@@ -603,14 +622,6 @@ agent-compose cache rm <cache-id> --force
 
 `CACHE_TTL` 默认 `168h`，设为 `0` 会禁用 expired 判定；TTL 不会触发后台或启动时删除，必须显式执行 `cache prune --expired --force`。`--older-than` 仍是独立过滤条件。`cache prune` 和 `cache rm` 默认 dry-run；`--force` 只授权执行，不能绕过 `active`、`referenced` 或 `unknown` 保护。BoxLite v0.9.7 ABI 不提供安全 image remove/prune，因此 runtime image inventory 只读；Microsandbox 共享 image 使用 SDK inventory/remove API。`sandbox prune` 不删除 cache artifact。
 
-兼容说明：
-
-- `agent-compose image ls` 已废弃，请使用 `agent-compose images`。
-- `agent-compose image pull <image>` 已废弃，请使用 `agent-compose pull <image>`。
-- `agent-compose image rm <image>` 已废弃，请使用 `agent-compose rmi <image>`。
-- `agent-compose image inspect <image>` 已废弃，请使用 `agent-compose inspect image <image>`。
-- 旧 `image` 命令树仍可用，但会在 stderr 输出 deprecated warning，后续版本会评估删除。
-
 ## `status`：检查 daemon 状态
 
 检查当前选择的 daemon 状态和版本。
@@ -649,7 +660,6 @@ agent-compose config --quiet
 
 以下命令或能力尚未作为稳定 CLI 发布：
 
-- `build`：project image build 暂缓。
 - `push`：image push 暂缓。
 - `up -d/--detach`：当前 `up` 本身就是 apply project 后返回，不提供 detach 参数。
 - `up` 前台 attach 和 Ctrl+C 停止整个 project：暂缓。


### PR DESCRIPTION
## Summary

- keep `agent-compose image` and its `ls`, `pull`, `build`, `rm`, and `inspect` subcommands as supported CLI commands without deprecation warnings
- make `agent-compose image pull [image]` match the top-level `pull [image]` shortcut, including the no-argument project image workflow
- update CLI regression coverage, README, and the English and Chinese command-line manuals to document the `image` command tree and its top-level shortcuts

## Testing

- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -run 'TestCLIImageRootCommandShowsHelp|TestIntegrationCLIImagesAliasesAndJSON|TestIntegrationCLIImagePullAliasesAndJSON|TestIntegrationCLIPullProjectImages|TestIntegrationCLIProjectBuildImages|TestIntegrationCLIImageRemoveAliasesAndJSON|TestIntegrationCLIImageInspectJSON|TestE2ECLIHelpCommands' -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.17%
  - Integration: 62.53%
  - E2E: 61.75%
  - Combined: 78.08%
- `task docs:build` currently fails because the existing English `agent-compose-yaml-manual.md` does not reference the `commit`, `description`, and `display_name` schema fields; this PR does not modify that manual or those schema fields

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
