### PR TITLE
fix(microsandbox): isolate guest etc state

### DIFF
--- a/pkg/driver/microsandbox_etc.go
+++ b/pkg/driver/microsandbox_etc.go
@@ -1,0 +1,113 @@
+package driver
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const microsandboxEtcStatePath = "microsandbox-rootfs/etc"
+
+// prepareMicrosandboxEtc copies the image's /etc into sandbox-owned state.
+// Microsandbox bind rootfs directories are shared by every sandbox using the
+// same materialized image. Its guest init writes instance-specific hosts and
+// resolver configuration under /etc, so /etc must not remain in that shared
+// directory.
+func prepareMicrosandboxEtc(rootfsPath, sandboxStateDir string) (string, error) {
+	source := filepath.Join(rootfsPath, "etc")
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("stat microsandbox image /etc: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("microsandbox image /etc is not a directory")
+	}
+
+	target := filepath.Join(sandboxStateDir, filepath.FromSlash(microsandboxEtcStatePath))
+	if _, err := os.Stat(target); err == nil {
+		return target, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat sandbox-owned microsandbox /etc: %w", err)
+	}
+
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", fmt.Errorf("create sandbox-owned microsandbox rootfs state: %w", err)
+	}
+	temporary, err := os.MkdirTemp(parent, ".etc-")
+	if err != nil {
+		return "", fmt.Errorf("create temporary sandbox-owned microsandbox /etc: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(temporary) }()
+
+	if err := copyMicrosandboxEtc(source, temporary); err != nil {
+		return "", err
+	}
+	if err := os.Rename(temporary, target); err != nil {
+		if _, statErr := os.Stat(target); statErr == nil {
+			return target, nil
+		}
+		return "", fmt.Errorf("publish sandbox-owned microsandbox /etc: %w", err)
+	}
+	return target, nil
+}
+
+func copyMicrosandboxEtc(source, target string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		if relative == "." {
+			return nil
+		}
+
+		destination := filepath.Join(target, relative)
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case entry.IsDir():
+			if err := os.Mkdir(destination, info.Mode().Perm()); err != nil && !os.IsExist(err) {
+				return err
+			}
+			return nil
+		case info.Mode()&os.ModeSymlink != 0:
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(linkTarget, destination)
+		case info.Mode().IsRegular():
+			return copyMicrosandboxEtcFile(path, destination, info.Mode().Perm())
+		default:
+			return fmt.Errorf("copy microsandbox image /etc: unsupported entry %s (%s)", path, info.Mode().Type())
+		}
+	})
+}
+
+func copyMicrosandboxEtcFile(source, target string, mode fs.FileMode) (err error) {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = input.Close() }()
+
+	output, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := output.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+	_, err = io.Copy(output, input)
+	return err
+}

--- a/pkg/driver/microsandbox_etc_test.go
+++ b/pkg/driver/microsandbox_etc_test.go
@@ -1,0 +1,89 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrepareMicrosandboxEtcIsolatesSandboxesFromSharedRootfs(t *testing.T) {
+	root := t.TempDir()
+	rootfs := filepath.Join(root, "image", "rootfs")
+	mustWriteMicrosandboxEtcTestFile(t, filepath.Join(rootfs, "etc", "hosts"), "image-hosts\n", 0o644)
+	mustWriteMicrosandboxEtcTestFile(t, filepath.Join(rootfs, "etc", "resolv.conf"), "nameserver image\n", 0o644)
+	if err := os.Symlink("../run/resolv.conf", filepath.Join(rootfs, "etc", "resolv-link")); err != nil {
+		t.Fatalf("create image /etc symlink: %v", err)
+	}
+
+	first, err := prepareMicrosandboxEtc(rootfs, filepath.Join(root, "sandbox-a", "state"))
+	if err != nil {
+		t.Fatalf("prepare first sandbox /etc: %v", err)
+	}
+	second, err := prepareMicrosandboxEtc(rootfs, filepath.Join(root, "sandbox-b", "state"))
+	if err != nil {
+		t.Fatalf("prepare second sandbox /etc: %v", err)
+	}
+	if first == second {
+		t.Fatalf("sandbox /etc paths alias: %q", first)
+	}
+
+	mustWriteMicrosandboxEtcTestFile(t, filepath.Join(first, "hosts"), "sandbox-a\n", 0o644)
+	assertMicrosandboxEtcTestFile(t, filepath.Join(second, "hosts"), "image-hosts\n")
+	assertMicrosandboxEtcTestFile(t, filepath.Join(rootfs, "etc", "hosts"), "image-hosts\n")
+	linkTarget, err := os.Readlink(filepath.Join(first, "resolv-link"))
+	if err != nil {
+		t.Fatalf("read copied /etc symlink: %v", err)
+	}
+	if linkTarget != "../run/resolv.conf" {
+		t.Fatalf("copied /etc symlink target = %q", linkTarget)
+	}
+}
+
+func TestPrepareMicrosandboxEtcReusesSandboxState(t *testing.T) {
+	root := t.TempDir()
+	rootfs := filepath.Join(root, "image", "rootfs")
+	mustWriteMicrosandboxEtcTestFile(t, filepath.Join(rootfs, "etc", "hosts"), "image-hosts\n", 0o644)
+	state := filepath.Join(root, "sandbox", "state")
+
+	first, err := prepareMicrosandboxEtc(rootfs, state)
+	if err != nil {
+		t.Fatalf("prepare sandbox /etc: %v", err)
+	}
+	mustWriteMicrosandboxEtcTestFile(t, filepath.Join(first, "hosts"), "runtime-hosts\n", 0o644)
+	second, err := prepareMicrosandboxEtc(rootfs, state)
+	if err != nil {
+		t.Fatalf("reuse sandbox /etc: %v", err)
+	}
+	if second != first {
+		t.Fatalf("reused sandbox /etc = %q, want %q", second, first)
+	}
+	assertMicrosandboxEtcTestFile(t, filepath.Join(second, "hosts"), "runtime-hosts\n")
+}
+
+func TestPrepareMicrosandboxEtcRejectsMissingImageEtc(t *testing.T) {
+	_, err := prepareMicrosandboxEtc(filepath.Join(t.TempDir(), "rootfs"), t.TempDir())
+	if err == nil {
+		t.Fatal("prepare sandbox /etc returned nil error")
+	}
+}
+
+func mustWriteMicrosandboxEtcTestFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create test file parent: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+}
+
+func assertMicrosandboxEtcTestFile(t *testing.T, path, want string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(content) != want {
+		t.Fatalf("%s = %q, want %q", path, content, want)
+	}
+}

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -985,6 +985,15 @@ func (r *microsandboxRuntime) createSandbox(ctx context.Context, session *Sandbo
 		imageRef = resolvedRef
 		imageEnv = envList
 	}
+	if filepath.IsAbs(imageRef) {
+		isolatedEtc, err := prepareMicrosandboxEtc(imageRef, filepath.Join(hostSandboxDir(session), "state"))
+		if err != nil {
+			return nil, fmt.Errorf("prepare sandbox-owned microsandbox /etc: %w", err)
+		}
+		// The isolated directory is already below the quota-managed sandbox
+		// directory. Do not assign a second, overlapping project quota here.
+		mounts["/etc"] = microsandbox.Mount.Bind(isolatedEtc, microsandbox.MountOptions{})
+	}
 	env := sandboxEnvMap(session.EnvItems, session.RuntimeEnvItems)
 	if env == nil {
 		env = map[string]string{}


### PR DESCRIPTION
## Summary

- copy the materialized image `/etc` into sandbox-owned state before creating a Microsandbox
- mount the sandbox-owned copy at `/etc` so concurrent guests cannot overwrite each other's hostname and resolver configuration through the shared bind rootfs
- preserve the isolated state across stop/resume and publish it atomically

## Testing

- `go test ./pkg/driver`
- `go test -race ./pkg/driver`
- `task test:unit`
- `task build`
- `git diff --check`
- `task lint` was attempted but the installed golangci-lint was built with Go 1.25, below the repository target Go 1.26.2
- `task test` was attempted; deterministic script checks passed, then the deployment installer test failed on macOS because BSD `realpath` does not support `-m`

## Checklist

- [x] Documentation updated when behavior or configuration changed. No public behavior or configuration documentation is affected.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.