### PR TITLE
fix(images): 固定 Docker ensure 使用的镜像存储

### DIFF
--- a/pkg/images/ensure.go
+++ b/pkg/images/ensure.go
@@ -53,6 +53,12 @@ func EnsureDriverImage(ctx context.Context, config *appconfig.Config, backend Ba
 	if backend == nil {
 		return fmt.Errorf("ensure image for project %s agent %s: driver %s image %s: image backend is required", req.ProjectName, req.AgentName, driver, imageRef)
 	}
+	if autoBackend, ok := backend.(*AutoBackend); ok {
+		if autoBackend == nil || autoBackend.docker == nil {
+			return fmt.Errorf("ensure image for project %s agent %s: driver %s image %s: docker image backend is required", req.ProjectName, req.AgentName, driver, imageRef)
+		}
+		backend = autoBackend.docker
+	}
 	if _, err := backend.InspectImage(ctx, InspectRequest{ImageRef: imageRef}); err == nil {
 		return nil
 	} else if !IsNotFound(err) {

--- a/pkg/images/ensure_test.go
+++ b/pkg/images/ensure_test.go
@@ -1,0 +1,71 @@
+package images
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/imagecache"
+)
+
+func TestEnsureDriverImageUsesDockerBackendFromAutoBackend(t *testing.T) {
+	docker := &ensureBackend{pullErr: errors.New("registry unavailable")}
+	oci := &ensureBackend{inspectErr: OpError{
+		Op:       "inspect image",
+		ImageRef: "guest:latest",
+		Err:      imagecache.NewError(imagecache.ErrorKindNotFound, "inspect", "guest:latest", errors.New("missing")),
+	}}
+	pingCalls := 0
+	backend := NewAutoBackend(appconfig.ImageStoreModeAuto, docker, oci, WithDockerPing(func(context.Context) error {
+		pingCalls++
+		if pingCalls == 1 {
+			return errors.New("docker unavailable")
+		}
+		return nil
+	}))
+
+	err := EnsureDriverImage(context.Background(), &appconfig.Config{}, backend, EnsureRequest{
+		Driver:      "docker",
+		ImageRef:    "guest:latest",
+		ProjectName: "project",
+		AgentName:   "agent",
+	})
+	if err != nil {
+		t.Fatalf("EnsureDriverImage() error = %v", err)
+	}
+	if docker.inspectCalls != 1 || docker.pullCalls != 0 {
+		t.Fatalf("docker calls inspect=%d pull=%d, want inspect=1 pull=0", docker.inspectCalls, docker.pullCalls)
+	}
+	if oci.inspectCalls != 0 || oci.pullCalls != 0 {
+		t.Fatalf("OCI calls inspect=%d pull=%d, want inspect=0 pull=0", oci.inspectCalls, oci.pullCalls)
+	}
+	if pingCalls != 0 {
+		t.Fatalf("docker ping calls = %d, want 0", pingCalls)
+	}
+}
+
+type ensureBackend struct {
+	inspectErr   error
+	pullErr      error
+	inspectCalls int
+	pullCalls    int
+}
+
+func (*ensureBackend) ListImages(context.Context, ListRequest) (ListResult, error) {
+	return ListResult{}, nil
+}
+
+func (b *ensureBackend) PullImage(context.Context, PullRequest) (PullResult, error) {
+	b.pullCalls++
+	return PullResult{}, b.pullErr
+}
+
+func (b *ensureBackend) InspectImage(context.Context, InspectRequest) (InspectResult, error) {
+	b.inspectCalls++
+	return InspectResult{}, b.inspectErr
+}
+
+func (*ensureBackend) RemoveImage(context.Context, RemoveRequest) (RemoveResult, error) {
+	return RemoveResult{}, nil
+}


### PR DESCRIPTION
## Summary

- 修复 `IMAGE_STORE_MODE=auto` 下，同一次 Docker 镜像 ensure 因重复探测 daemon 而在 OCI cache 与 Docker store 之间切换的问题。
- `EnsureDriverImage` 确认 driver 为 Docker 后，直接复用 `AutoBackend` 已组装的 Docker backend 完成 inspect 与必要的 pull，避免本地已有镜像仍访问 registry。
- **这里固定 Docker 是 driver 专属约束，不是修改通用 auto 选择规则：非 Docker driver 会在固定 backend 之前直接返回；BoxLite、Microsandbox 原有的 Docker-first / OCI fallback 路径不变，ImageService 的 `auto|docker|oci` 行为也不变。**
- 新增确定性回归测试，验证 Docker inspect 命中时不会调用 ping、pull 或 OCI backend。

## Testing

- `go test ./pkg/images -count=1`：通过。
- `task build`：通过。
- `task lint`：被未改动代码 `pkg/driver/boxlite_volume_bridge.go:188` 的既有 unused 问题阻断；本次新增代码无 lint 报错。
- `task test`：被 installer 测试对 macOS `/var` 系统符号链接的路径校验阻断。
- `go test ./... -count=1`：2821 个测试通过；`pkg/volumes` 5 个测试因 macOS `/var` 与 `/private/var` 路径差异失败。

## Checklist

- [x] 无需更新公开文档：本次恢复既有 Docker runtime store 合同，不新增配置或 API。
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.