### PR TITLE
feat(runs): support Claude prompt attach

### DIFF
--- a/cmd/agent-compose/cli_resource_reference.go
+++ b/cmd/agent-compose/cli_resource_reference.go
@@ -67,12 +67,12 @@ func validateInteractivePromptProvider(project *compose.NormalizedProjectSpec, a
 		}
 	}
 	switch provider {
-	case "codex":
+	case "codex", "claude":
 		return nil
 	default:
 		return commandExitError{
 			Code: exitCodeUnsupported,
-			Err:  fmt.Errorf("run --prompt -it is unsupported for provider %s; supported providers: codex", provider),
+			Err:  fmt.Errorf("run --prompt -it is unsupported for provider %s; supported providers: codex, claude", provider),
 		}
 	}
 }

--- a/cmd/agent-compose/cli_run_stream_test.go
+++ b/cmd/agent-compose/cli_run_stream_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCLIRunInteractivePromptProviderUnsupported(t *testing.T) {
-	for _, provider := range []string{"claude", "gemini", "opencode"} {
+	for _, provider := range []string{"gemini", "opencode"} {
 		t.Run(provider, func(t *testing.T) {
 			composePath := writeComposeFile(t, t.TempDir(), fmt.Sprintf(`
 name: cli-run-interactive-%s
@@ -23,7 +23,7 @@ agents:
 			if exitCode != exitCodeUnsupported {
 				t.Fatalf("run --prompt -it %s exit code = %d, want %d; stderr=%q", provider, exitCode, exitCodeUnsupported, stderr)
 			}
-			if stdout != "" || !strings.Contains(stderr, "run --prompt -it is unsupported for provider "+provider) || !strings.Contains(stderr, "supported providers: codex") {
+			if stdout != "" || !strings.Contains(stderr, "run --prompt -it is unsupported for provider "+provider) || !strings.Contains(stderr, "supported providers: codex, claude") {
 				t.Fatalf("run --prompt -it %s stdout/stderr = %q / %q", provider, stdout, stderr)
 			}
 		})

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -616,8 +616,8 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 	if err := validateInteractivePromptProvider(project, "reviewer", false); err != nil {
 		t.Fatalf("validateInteractivePromptProvider claude-code legacy returned error: %v", err)
 	}
-	if err := validateInteractivePromptProvider(project, "reviewer", true); commandExitCode(err) != exitCodeUnsupported {
-		t.Fatalf("validateInteractivePromptProvider claude-code attach err=%v code=%d", err, commandExitCode(err))
+	if err := validateInteractivePromptProvider(project, "reviewer", true); err != nil {
+		t.Fatalf("validateInteractivePromptProvider claude-code attach returned error: %v", err)
 	}
 	project.Agents[0].Provider = "codex"
 	if err := validateInteractivePromptProvider(project, "reviewer", true); err != nil {

--- a/docs/pages/guest-image-abi.md
+++ b/docs/pages/guest-image-abi.md
@@ -174,6 +174,9 @@ An image supporting these capabilities **MUST** provide:
 - the `prompt` and `exec` subcommands used by normal runs; and
 - the `stream` subcommand when interactive prompt attach is required.
 
+Prompt-mode `stream` sessions support the `codex` and `claude` providers.
+Other providers are rejected before the guest runtime interaction is opened.
+
 The daemon passes explicit workspace, state, and home paths. It also injects:
 
 | Variable | Default/value |

--- a/docs/pages/zh-CN/guest-image-abi.md
+++ b/docs/pages/zh-CN/guest-image-abi.md
@@ -120,6 +120,8 @@ Agent prompt 和受管 scheduler command 不会由 daemon 直接调用 provider 
 - 普通 run 使用的 `prompt` 和 `exec` 子命令；
 - 需要交互式 prompt attach 时使用的 `stream` 子命令。
 
+Prompt mode 的 `stream` session 支持 `codex` 和 `claude` provider。其他 provider 会在 guest runtime interaction 打开前被拒绝。
+
 daemon 会显式传递 workspace、state 和 home 路径，并注入：
 
 | 变量 | 默认值/内容 |

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -14,6 +14,8 @@ import (
 	"agent-compose/pkg/capabilities"
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/dashboard"
+	"agent-compose/pkg/execution"
+	"agent-compose/pkg/llms/runtimefacade"
 	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/runs"
@@ -32,15 +34,20 @@ func NewRunController(di do.Injector) (*runs.Controller, error) {
 	}
 	imageBackends := do.MustInvoke[*adapters.ImageBackends](di)
 	runtimeProvider := do.MustInvoke[adapters.RuntimeProvider](di)
+	config := do.MustInvoke[*appconfig.Config](di)
+	configDB := do.MustInvoke[*configstore.ConfigStore](di)
 	return runs.NewController(runs.ControllerDependencies{
-		Config:           do.MustInvoke[*appconfig.Config](di),
+		Config:           config,
 		Store:            do.MustInvoke[*sessionstore.Store](di),
-		ConfigDB:         do.MustInvoke[*configstore.ConfigStore](di),
+		ConfigDB:         configDB,
 		WorkspaceEnsurer: do.MustInvoke[workspaces.WorkspaceEnsurer](di),
 		Driver:           do.MustInvoke[*adapters.SandboxDriver](di),
 		Executor:         do.MustInvoke[*adapters.AgentExecutor](di),
 		Runtime: func(session *domain.Sandbox) (runs.Runtime, error) {
 			return runtimeProvider.ForSession(session)
+		},
+		PromptAttachEnv: func(ctx context.Context, session *domain.Sandbox, agent execution.AgentConfig, runID string) (map[string]string, error) {
+			return runtimefacade.EnsureSessionLLMFacadeConfig(ctx, config, configDB, session, agent.Provider, agent.Model, runtimefacade.TokenSourceAgent, runID)
 		},
 		Images:         imageBackends.Auto,
 		LoaderEngine:   do.MustInvoke[loaders.LoaderEngine](di),

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -14,8 +14,6 @@ import (
 	"agent-compose/pkg/capabilities"
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/dashboard"
-	"agent-compose/pkg/execution"
-	"agent-compose/pkg/llms/runtimefacade"
 	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/runs"
@@ -34,20 +32,15 @@ func NewRunController(di do.Injector) (*runs.Controller, error) {
 	}
 	imageBackends := do.MustInvoke[*adapters.ImageBackends](di)
 	runtimeProvider := do.MustInvoke[adapters.RuntimeProvider](di)
-	config := do.MustInvoke[*appconfig.Config](di)
-	configDB := do.MustInvoke[*configstore.ConfigStore](di)
 	return runs.NewController(runs.ControllerDependencies{
-		Config:           config,
+		Config:           do.MustInvoke[*appconfig.Config](di),
 		Store:            do.MustInvoke[*sessionstore.Store](di),
-		ConfigDB:         configDB,
+		ConfigDB:         do.MustInvoke[*configstore.ConfigStore](di),
 		WorkspaceEnsurer: do.MustInvoke[workspaces.WorkspaceEnsurer](di),
 		Driver:           do.MustInvoke[*adapters.SandboxDriver](di),
 		Executor:         do.MustInvoke[*adapters.AgentExecutor](di),
 		Runtime: func(session *domain.Sandbox) (runs.Runtime, error) {
 			return runtimeProvider.ForSession(session)
-		},
-		PromptAttachEnv: func(ctx context.Context, session *domain.Sandbox, agent execution.AgentConfig, runID string) (map[string]string, error) {
-			return runtimefacade.EnsureSessionLLMFacadeConfig(ctx, config, configDB, session, agent.Provider, agent.Model, runtimefacade.TokenSourceAgent, runID)
 		},
 		Images:         imageBackends.Auto,
 		LoaderEngine:   do.MustInvoke[loaders.LoaderEngine](di),

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -50,6 +50,9 @@ type InteractionRuntime interface {
 
 type RuntimeProvider func(*domain.Sandbox) (Runtime, error)
 
+// PromptAttachEnvEnsurer prepares provider-specific managed environment variables for an attached prompt run.
+type PromptAttachEnvEnsurer func(context.Context, *domain.Sandbox, execution.AgentConfig, string) (map[string]string, error)
+
 type SandboxDriver interface {
 	StartSandboxVM(context.Context, *domain.Sandbox) error
 	StopSandboxVM(context.Context, *domain.Sandbox) error
@@ -127,15 +130,11 @@ type Controller struct {
 	runLogs          *RunLogHub
 	lifecycleLocks   *sessions.LifecycleLocks
 	removal          SandboxRemoval
+	promptAttachEnv  PromptAttachEnvEnsurer
 }
 
 type llmFacadeTokenDeleter interface {
 	DeleteLLMFacadeToken(context.Context, string) error
-}
-
-type llmFacadeStore interface {
-	llms.LLMResolverStore
-	SaveLLMFacadeToken(context.Context, llms.FacadeToken) error
 }
 
 type ControllerDependencies struct {
@@ -157,6 +156,7 @@ type ControllerDependencies struct {
 	RunLogs          *RunLogHub
 	LifecycleLocks   *sessions.LifecycleLocks
 	Removal          SandboxRemoval
+	PromptAttachEnv  PromptAttachEnvEnsurer
 }
 
 type SandboxRemoval interface {
@@ -183,6 +183,7 @@ func NewController(deps ControllerDependencies) *Controller {
 		runLogs:          deps.RunLogs,
 		lifecycleLocks:   deps.LifecycleLocks,
 		removal:          deps.Removal,
+		promptAttachEnv:  deps.PromptAttachEnv,
 	}
 }
 
@@ -839,8 +840,8 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 		transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 		return transition, err
 	}
-	if agentConfig.Provider != "codex" {
-		err := fmt.Errorf("%w: prompt attach currently supports codex provider only", domain.ErrUnsupported)
+	if agentConfig.Provider != "codex" && agentConfig.Provider != "claude" {
+		err := fmt.Errorf("%w: prompt attach currently supports codex and claude providers only", domain.ErrUnsupported)
 		transition.ExitCode = 1
 		transition.Error = err.Error()
 		return transition, err
@@ -1048,40 +1049,10 @@ func (c *Controller) projectRunAgentSystemPrompt(ctx context.Context, run domain
 }
 
 func (c *Controller) ensurePromptAttachLLMFacadeEnv(ctx context.Context, sandbox *domain.Sandbox, agent execution.AgentConfig, runID string) (map[string]string, error) {
-	store, ok := c.configDB.(llmFacadeStore)
-	if !ok || c.config == nil || sandbox == nil || domain.NormalizeAgentKind(agent.Provider) != "codex" {
+	if c.promptAttachEnv == nil {
 		return nil, nil
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, store, sandbox.Summary.ID, llms.ProviderFamilyOpenAI, agent.Model, "", promptAttachSandboxProviderEnvItems(sandbox))
-	if err != nil {
-		if errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	baseURL := llms.GuestRuntimeBaseURL(c.config, sandbox)
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, nil
-	}
-	tokenValue, token, err := llms.NewFacadeToken(sandbox.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolResponses, "agent", runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
-	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/openai/v1"
-	if err := llms.WriteCodexRuntimeConfig(sandbox, target.Model.Name, openAIBaseURL, llms.APIProtocolResponses); err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		"AGENT_COMPOSE_SANDBOX_TOKEN": tokenValue,
-		"LLM_API_ENDPOINT":            openAIBaseURL,
-		"LLM_API_KEY":                 tokenValue,
-		"LLM_API_PROTOCOL":            llms.APIProtocolResponses,
-		"OPENAI_API_KEY":              tokenValue,
-		"OPENAI_BASE_URL":             openAIBaseURL,
-	}, nil
+	return c.promptAttachEnv(ctx, sandbox, agent, runID)
 }
 
 func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token string) {
@@ -1090,16 +1061,6 @@ func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token
 		return
 	}
 	_ = store.DeleteLLMFacadeToken(ctx, token)
-}
-
-func promptAttachSandboxProviderEnvItems(sandbox *domain.Sandbox) []domain.SandboxEnvVar {
-	if sandbox == nil {
-		return nil
-	}
-	if len(sandbox.ProviderEnvItems) > 0 {
-		return sandbox.ProviderEnvItems
-	}
-	return sandbox.EnvItems
 }
 
 func projectRunAgentExecutionStream(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, sink *StreamSink, hub *RunLogHub) execution.AgentExecutionStream {
@@ -1524,6 +1485,7 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunA
 func (p *promptAttachProjector) agentEventText(raw json.RawMessage) (string, string) {
 	var event struct {
 		Type string `json:"type"`
+		Text string `json:"text"`
 		Item *struct {
 			ID               string `json:"id"`
 			Type             string `json:"type"`
@@ -1536,6 +1498,9 @@ func (p *promptAttachProjector) agentEventText(raw json.RawMessage) (string, str
 		return "agent_event", ""
 	}
 	name := firstNonEmpty(event.Type, "agent_event")
+	if event.Text != "" {
+		return name, event.Text
+	}
 	if event.Item == nil {
 		return name, ""
 	}

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -50,9 +50,6 @@ type InteractionRuntime interface {
 
 type RuntimeProvider func(*domain.Sandbox) (Runtime, error)
 
-// PromptAttachEnvEnsurer prepares provider-specific managed environment variables for an attached prompt run.
-type PromptAttachEnvEnsurer func(context.Context, *domain.Sandbox, execution.AgentConfig, string) (map[string]string, error)
-
 type SandboxDriver interface {
 	StartSandboxVM(context.Context, *domain.Sandbox) error
 	StopSandboxVM(context.Context, *domain.Sandbox) error
@@ -130,11 +127,15 @@ type Controller struct {
 	runLogs          *RunLogHub
 	lifecycleLocks   *sessions.LifecycleLocks
 	removal          SandboxRemoval
-	promptAttachEnv  PromptAttachEnvEnsurer
 }
 
 type llmFacadeTokenDeleter interface {
 	DeleteLLMFacadeToken(context.Context, string) error
+}
+
+type llmFacadeStore interface {
+	llms.LLMResolverStore
+	SaveLLMFacadeToken(context.Context, llms.FacadeToken) error
 }
 
 type ControllerDependencies struct {
@@ -156,7 +157,6 @@ type ControllerDependencies struct {
 	RunLogs          *RunLogHub
 	LifecycleLocks   *sessions.LifecycleLocks
 	Removal          SandboxRemoval
-	PromptAttachEnv  PromptAttachEnvEnsurer
 }
 
 type SandboxRemoval interface {
@@ -183,7 +183,6 @@ func NewController(deps ControllerDependencies) *Controller {
 		runLogs:          deps.RunLogs,
 		lifecycleLocks:   deps.LifecycleLocks,
 		removal:          deps.Removal,
-		promptAttachEnv:  deps.PromptAttachEnv,
 	}
 }
 
@@ -1049,10 +1048,46 @@ func (c *Controller) projectRunAgentSystemPrompt(ctx context.Context, run domain
 }
 
 func (c *Controller) ensurePromptAttachLLMFacadeEnv(ctx context.Context, sandbox *domain.Sandbox, agent execution.AgentConfig, runID string) (map[string]string, error) {
-	if c.promptAttachEnv == nil {
+	store, ok := c.configDB.(llmFacadeStore)
+	if !ok || c.config == nil || sandbox == nil {
 		return nil, nil
 	}
-	return c.promptAttachEnv(ctx, sandbox, agent, runID)
+	if domain.NormalizeAgentKind(agent.Provider) == "claude" {
+		return ensurePromptAttachClaudeLLMFacadeEnv(ctx, c.config, store, sandbox, agent.Model, runID)
+	}
+	if domain.NormalizeAgentKind(agent.Provider) != "codex" {
+		return nil, nil
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, store, sandbox.Summary.ID, llms.ProviderFamilyOpenAI, agent.Model, "", promptAttachSandboxProviderEnvItems(sandbox))
+	if err != nil {
+		if errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	baseURL := llms.GuestRuntimeBaseURL(c.config, sandbox)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	tokenValue, token, err := llms.NewFacadeToken(sandbox.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolResponses, "agent", runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/openai/v1"
+	if err := llms.WriteCodexRuntimeConfig(sandbox, target.Model.Name, openAIBaseURL, llms.APIProtocolResponses); err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"AGENT_COMPOSE_SANDBOX_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            openAIBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            llms.APIProtocolResponses,
+		"OPENAI_API_KEY":              tokenValue,
+		"OPENAI_BASE_URL":             openAIBaseURL,
+	}, nil
 }
 
 func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token string) {
@@ -1061,6 +1096,16 @@ func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token
 		return
 	}
 	_ = store.DeleteLLMFacadeToken(ctx, token)
+}
+
+func promptAttachSandboxProviderEnvItems(sandbox *domain.Sandbox) []domain.SandboxEnvVar {
+	if sandbox == nil {
+		return nil
+	}
+	if len(sandbox.ProviderEnvItems) > 0 {
+		return sandbox.ProviderEnvItems
+	}
+	return sandbox.EnvItems
 }
 
 func projectRunAgentExecutionStream(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, sink *StreamSink, hub *RunLogHub) execution.AgentExecutionStream {

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -780,12 +780,19 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	ctx := context.Background()
 	controller, configDB, runtime := newTestRunAttachController(t, []driverpkg.RuntimeOutputFrame{
 		{Type: driverpkg.RuntimeOutputStarted},
-		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":0,"type":"started","provider":"codex","sessionId":"thread-1"}` + "\n")},
-		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":1,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"hello agent\n"}}}` + "\n")},
-		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"hello agent\n"}` + "\n")},
-		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":3,"type":"result","provider":"codex","sessionId":"thread-1","stopReason":"eof","finalText":"hello agent\n","transcript":"hello agent\n"}` + "\n")},
+		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":0,"type":"started","provider":"claude","sessionId":"thread-1"}` + "\n")},
+		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":1,"type":"agent_event","event":{"type":"output","provider":"claude","text":"hello agent\n"}}` + "\n")},
+		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"claude","sessionId":"thread-1","finalText":"hello agent\n"}` + "\n")},
+		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":3,"type":"result","provider":"claude","sessionId":"thread-1","stopReason":"eof","finalText":"hello agent\n","transcript":"hello agent\n"}` + "\n")},
 		{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", ExitCode: 0, Success: true}},
 	})
+	configDB.agent.Provider = "claude"
+	controller.promptAttachEnv = func(_ context.Context, _ *domain.Sandbox, agent execution.AgentConfig, _ string) (map[string]string, error) {
+		if agent.Provider != "claude" {
+			t.Fatalf("prompt attach env provider = %q, want claude", agent.Provider)
+		}
+		return map[string]string{"CLAUDE_ATTACH_TEST": "managed"}, nil
+	}
 	requests := []*agentcomposev2.RunAttachRequest{{
 		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
 			Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "hello"},
@@ -818,6 +825,9 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	if runtime.spec.Command == nil || runtime.spec.Command.Command != "sh" || !strings.Contains(strings.Join(runtime.spec.Command.Args, " "), "agent-compose-runtime stream") || runtime.spec.TTY {
 		t.Fatalf("runtime spec = %#v", runtime.spec)
 	}
+	if runtime.spec.Env["CLAUDE_ATTACH_TEST"] != "managed" {
+		t.Fatalf("runtime env = %#v", runtime.spec.Env)
+	}
 	if runtime.interaction == nil || len(runtime.interaction.sent) < 2 {
 		t.Fatalf("runtime sent frames = %#v", runtime.interaction)
 	}
@@ -825,7 +835,7 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	if err := json.Unmarshal(runtime.interaction.sent[0].Data, &startFrame); err != nil {
 		t.Fatalf("start frame json: %v", err)
 	}
-	if startFrame["type"] != "start" || startFrame["provider"] != "codex" {
+	if startFrame["type"] != "start" || startFrame["provider"] != "claude" {
 		t.Fatalf("start frame = %#v", startFrame)
 	}
 	var humanFrame map[string]any
@@ -1184,7 +1194,7 @@ func receiveProjectorRunLogEvent(t *testing.T, sub *RunLogSubscription) RunLogEv
 }
 
 func TestRunsControllerRunProjectPromptAttachUnsupportedProvidersDoNotOpenRuntime(t *testing.T) {
-	for _, provider := range []string{"claude", "gemini", "opencode"} {
+	for _, provider := range []string{"gemini", "opencode"} {
 		t.Run(provider, func(t *testing.T) {
 			ctx := context.Background()
 			controller, configDB, runtime := newTestRunAttachController(t, nil)
@@ -1209,7 +1219,7 @@ func TestRunsControllerRunProjectPromptAttachUnsupportedProvidersDoNotOpenRuntim
 			if len(responses) != 1 || responses[0].GetResult() == nil || responses[0].GetResult().GetSuccess() {
 				t.Fatalf("prompt attach unsupported provider responses = %#v", responses)
 			}
-			if got := responses[0].GetResult().GetError(); !strings.Contains(got, "prompt attach currently supports codex provider only") {
+			if got := responses[0].GetResult().GetError(); !strings.Contains(got, "prompt attach currently supports codex and claude providers only") {
 				t.Fatalf("prompt attach unsupported provider error = %q", got)
 			}
 			run := responses[0].GetResult().GetRun()

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -787,12 +787,6 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 		{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", ExitCode: 0, Success: true}},
 	})
 	configDB.agent.Provider = "claude"
-	controller.promptAttachEnv = func(_ context.Context, _ *domain.Sandbox, agent execution.AgentConfig, _ string) (map[string]string, error) {
-		if agent.Provider != "claude" {
-			t.Fatalf("prompt attach env provider = %q, want claude", agent.Provider)
-		}
-		return map[string]string{"CLAUDE_ATTACH_TEST": "managed"}, nil
-	}
 	requests := []*agentcomposev2.RunAttachRequest{{
 		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
 			Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "hello"},
@@ -824,9 +818,6 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	}
 	if runtime.spec.Command == nil || runtime.spec.Command.Command != "sh" || !strings.Contains(strings.Join(runtime.spec.Command.Args, " "), "agent-compose-runtime stream") || runtime.spec.TTY {
 		t.Fatalf("runtime spec = %#v", runtime.spec)
-	}
-	if runtime.spec.Env["CLAUDE_ATTACH_TEST"] != "managed" {
-		t.Fatalf("runtime env = %#v", runtime.spec.Env)
 	}
 	if runtime.interaction == nil || len(runtime.interaction.sent) < 2 {
 		t.Fatalf("runtime sent frames = %#v", runtime.interaction)

--- a/pkg/runs/prompt_attach_facade.go
+++ b/pkg/runs/prompt_attach_facade.go
@@ -1,0 +1,74 @@
+package runs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func ensurePromptAttachClaudeLLMFacadeEnv(ctx context.Context, config *appconfig.Config, store llmFacadeStore, sandbox *domain.Sandbox, model, runID string) (map[string]string, error) {
+	baseURL := llms.GuestRuntimeBaseURL(config, sandbox)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, llms.ProviderFamilyAnthropic, model, "", promptAttachSandboxProviderEnvItems(sandbox))
+	tokenModel := ""
+	tokenProvider := ""
+	if err != nil {
+		optional := errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition)
+		if !optional || !promptAttachHasAnthropicProviderKey(ctx, config, store) {
+			return nil, err
+		}
+	} else {
+		tokenModel = target.Model.Name
+		tokenProvider = target.Provider.ID
+	}
+	tokenValue, token, err := llms.NewFacadeToken(sandbox.Summary.ID, tokenModel, tokenProvider, llms.APIProtocolMessages, "agent", runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	anthropicBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/anthropic"
+	env := map[string]string{
+		"AGENT_COMPOSE_SANDBOX_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            anthropicBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            llms.APIProtocolMessages,
+		"ANTHROPIC_API_KEY":           tokenValue,
+		"ANTHROPIC_AUTH_TOKEN":        tokenValue,
+		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
+	}
+	if tokenModel != "" {
+		env["ANTHROPIC_MODEL"] = tokenModel
+		env["CLAUDE_MODEL"] = tokenModel
+	}
+	return env, nil
+}
+
+func promptAttachHasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, store llmFacadeStore) bool {
+	configKey := ""
+	if config != nil {
+		configKey = config.LLMAPIKey
+	}
+	for _, value := range []string{
+		llms.LookupEnvValue(ctx, store, "ANTHROPIC_API_KEY"),
+		llms.LookupEnvValue(ctx, store, "ANTHROPIC_AUTH_TOKEN"),
+		llms.LookupEnvValue(ctx, store, "LLM_API_KEY"),
+		os.Getenv("ANTHROPIC_API_KEY"),
+		os.Getenv("ANTHROPIC_AUTH_TOKEN"),
+		os.Getenv("LLM_API_KEY"),
+		configKey,
+	} {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/runs/prompt_attach_facade.go
+++ b/pkg/runs/prompt_attach_facade.go
@@ -17,7 +17,7 @@ func ensurePromptAttachClaudeLLMFacadeEnv(ctx context.Context, config *appconfig
 		return nil, nil
 	}
 	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, llms.ProviderFamilyAnthropic, model, "", promptAttachSandboxProviderEnvItems(sandbox))
-	tokenModel := ""
+	tokenModel := strings.TrimSpace(model)
 	tokenProvider := ""
 	if err != nil {
 		optional := errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition)

--- a/pkg/runs/prompt_attach_facade_test.go
+++ b/pkg/runs/prompt_attach_facade_test.go
@@ -1,0 +1,88 @@
+package runs
+
+import (
+	"context"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+type promptAttachFacadeStore struct {
+	ControllerStore
+	providers []llms.Provider
+	models    []llms.Model
+	tokens    []llms.FacadeToken
+}
+
+func (s *promptAttachFacadeStore) UpsertDefaultLLMConfig(context.Context, llms.Provider, llms.Model) error {
+	return nil
+}
+
+func (s *promptAttachFacadeStore) ListEnabledLLMProviders(context.Context) ([]llms.Provider, error) {
+	return s.providers, nil
+}
+
+func (s *promptAttachFacadeStore) ListEnabledLLMModels(context.Context) ([]llms.Model, error) {
+	return s.models, nil
+}
+
+func (s *promptAttachFacadeStore) LLMProviderModelWireAPI(context.Context, string, string) (string, bool, error) {
+	return llms.APIProtocolMessages, true, nil
+}
+
+func (s *promptAttachFacadeStore) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
+	return nil, nil
+}
+
+func (s *promptAttachFacadeStore) SaveLLMFacadeToken(_ context.Context, token llms.FacadeToken) error {
+	s.tokens = append(s.tokens, token)
+	return nil
+}
+
+func TestEnsurePromptAttachLLMFacadeEnvClaudeUsesControllerStore(t *testing.T) {
+	ctx := context.Background()
+	config := &appconfig.Config{
+		RuntimeBaseURL: "http://agent-compose.test:7410",
+		GuestHomePath:  "/root",
+	}
+	store := &promptAttachFacadeStore{
+		providers: []llms.Provider{{
+			ID:             "anthropic-test",
+			ProviderType:   llms.ProviderFamilyAnthropic,
+			DefaultWireAPI: llms.APIProtocolMessages,
+			BaseURL:        "https://anthropic.example.test",
+			APIKey:         "anthropic-key",
+			Enabled:        true,
+		}},
+		models: []llms.Model{{ID: "claude-test", Name: "claude-test", DefaultModel: true, Enabled: true}},
+	}
+	sandbox := &domain.Sandbox{
+		Summary: domain.SandboxSummary{
+			ID:     "sandbox-claude-attach",
+			Driver: driver.RuntimeDriverDocker,
+		},
+	}
+	controller := &Controller{config: config, configDB: store}
+
+	env, err := controller.ensurePromptAttachLLMFacadeEnv(ctx, sandbox, execution.AgentConfig{Provider: "claude"}, "run-claude-attach")
+	if err != nil {
+		t.Fatalf("ensurePromptAttachLLMFacadeEnv returned error: %v", err)
+	}
+	if env["LLM_API_PROTOCOL"] != llms.APIProtocolMessages || env["ANTHROPIC_MODEL"] != "claude-test" {
+		t.Fatalf("Claude facade env = %#v", env)
+	}
+	if env["ANTHROPIC_BASE_URL"] != "http://agent-compose.test:7410/api/runtime/sandboxes/sandbox-claude-attach/llm/anthropic" {
+		t.Fatalf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
+	}
+	if env["AGENT_COMPOSE_SANDBOX_TOKEN"] == "" || len(store.tokens) != 1 {
+		t.Fatalf("Claude facade token env = %q, saved tokens = %#v", env["AGENT_COMPOSE_SANDBOX_TOKEN"], store.tokens)
+	}
+	token := store.tokens[0]
+	if token.SandboxID != sandbox.Summary.ID || token.Model != "claude-test" || token.Source != "agent" || token.RunID != "run-claude-attach" {
+		t.Fatalf("stored token = %#v", token)
+	}
+}

--- a/pkg/runs/prompt_attach_facade_test.go
+++ b/pkg/runs/prompt_attach_facade_test.go
@@ -86,3 +86,29 @@ func TestEnsurePromptAttachLLMFacadeEnvClaudeUsesControllerStore(t *testing.T) {
 		t.Fatalf("stored token = %#v", token)
 	}
 }
+
+func TestEnsurePromptAttachClaudeLLMFacadeEnvPreservesRequestedModelWithoutConfiguredProvider(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("LLM_API_KEY", "")
+
+	store := &promptAttachFacadeStore{}
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-claude-attach"}}
+	env, err := ensurePromptAttachClaudeLLMFacadeEnv(
+		context.Background(),
+		&appconfig.Config{RuntimeBaseURL: "http://agent-compose.test:7410"},
+		store,
+		sandbox,
+		" claude-sonnet-4-20250514 ",
+		"run-claude-attach",
+	)
+	if err != nil {
+		t.Fatalf("ensurePromptAttachClaudeLLMFacadeEnv returned error: %v", err)
+	}
+	if env["ANTHROPIC_MODEL"] != "claude-sonnet-4-20250514" || env["CLAUDE_MODEL"] != "claude-sonnet-4-20250514" {
+		t.Fatalf("Claude model env = %#v", env)
+	}
+	if len(store.tokens) != 1 || store.tokens[0].Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("saved tokens = %#v", store.tokens)
+	}
+}

--- a/runtime/javascript/src/interactive.ts
+++ b/runtime/javascript/src/interactive.ts
@@ -1,9 +1,10 @@
 import { resolveCodexPath } from "./codex-path.js";
 import { stringEnv } from "./env.js";
 import { buildPromptRuntimeOptions } from "./prompt.js";
+import { ClaudeRunner } from "./runners/claude.js";
 import { CodexRunner } from "./runners/codex.js";
 import { readStoredThread, writeStoredThread } from "./session-state.js";
-import type { TextWriter } from "./transcript.js";
+import type { TextWriter, TranscriptTextWriter } from "./transcript.js";
 import type { AgentResult, Provider, RunnerOptions } from "./types.js";
 
 export interface InteractiveStartOptions {
@@ -17,6 +18,12 @@ export interface InteractiveStartOptions {
 
 export type EmitInteractiveFrame = (type: string, fields?: object) => void;
 
+export interface InteractiveSession {
+  start(): Promise<void>;
+  runHumanMessage(message: string): Promise<void>;
+  finish(stopReason: string): Promise<AgentResult>;
+}
+
 export class UnsupportedProviderError extends Error {
   readonly code = "unsupported_provider";
 
@@ -26,7 +33,7 @@ export class UnsupportedProviderError extends Error {
   }
 }
 
-export class CodexInteractiveSession {
+export class CodexInteractiveSession implements InteractiveSession {
   private readonly runner: CodexRunner;
   private readonly writer: BufferedTextWriter;
   private readonly result: AgentResult;
@@ -117,6 +124,74 @@ export class CodexInteractiveSession {
   }
 }
 
+interface PromptTurnRunner {
+  runPrompt(message: string): Promise<AgentResult>;
+}
+
+class PromptRunnerInteractiveSession implements InteractiveSession {
+  private readonly writer: InteractiveTextWriter;
+  private readonly runner: PromptTurnRunner;
+  private readonly result: AgentResult;
+  private started = false;
+  private turnCount = 0;
+
+  constructor(
+    private readonly provider: Provider,
+    private readonly options: RunnerOptions,
+    private readonly emit: EmitInteractiveFrame,
+    createRunner: (writer: TranscriptTextWriter) => PromptTurnRunner,
+  ) {
+    this.writer = new InteractiveTextWriter(provider, emit);
+    this.runner = createRunner(this.writer);
+    this.result = {
+      provider,
+      threadId: "",
+      stopReason: "completed",
+      finalText: "",
+      transcript: "",
+      stderr: "",
+    };
+  }
+
+  async start(): Promise<void> {
+    const stored = await readStoredThread(this.options.stateRoot, this.provider);
+    this.result.threadId = stored?.threadId || "";
+    this.started = true;
+    this.emit("started", {
+      provider: this.provider,
+      threadId: this.result.threadId,
+    });
+  }
+
+  async runHumanMessage(message: string): Promise<void> {
+    if (!this.started) {
+      throw new Error("stream has not been started");
+    }
+    if (this.turnCount > 0) {
+      this.writer.beginTurn();
+    }
+    this.turnCount++;
+    const turnResult = await this.runner.runPrompt(message);
+    this.result.threadId = turnResult.threadId || this.result.threadId;
+    this.result.stopReason = turnResult.stopReason;
+    this.result.finalText = turnResult.finalText;
+    this.result.transcript = turnResult.transcript;
+    this.result.stderr = turnResult.stderr;
+    this.emit("agent_turn_completed", {
+      provider: this.provider,
+      threadId: this.result.threadId,
+      finalText: this.result.finalText,
+      stopReason: this.result.stopReason,
+    });
+  }
+
+  async finish(stopReason: string): Promise<AgentResult> {
+    this.result.stopReason = stopReason;
+    this.result.transcript = this.writer.transcript();
+    return { ...this.result };
+  }
+}
+
 class BufferedTextWriter implements TextWriter {
   private readonly chunks: string[] = [];
 
@@ -145,15 +220,50 @@ class BufferedTextWriter implements TextWriter {
   }
 }
 
+class InteractiveTextWriter extends BufferedTextWriter implements TranscriptTextWriter {
+  constructor(
+    private readonly provider: Provider,
+    private readonly emit: EmitInteractiveFrame,
+  ) {
+    super();
+  }
+
+  override write(text: string): void {
+    if (!text) {
+      return;
+    }
+    super.write(text);
+    this.emit("agent_event", {
+      event: {
+        type: "output",
+        provider: this.provider,
+        text,
+      },
+    });
+  }
+}
+
 export async function createInteractiveSession(
   startOptions: InteractiveStartOptions,
   emit: EmitInteractiveFrame,
-): Promise<CodexInteractiveSession> {
+): Promise<InteractiveSession> {
   const options = await buildPromptRuntimeOptions(startOptions);
-  if (options.provider !== "codex") {
-    throw new UnsupportedProviderError(options.provider);
+  let session: InteractiveSession;
+  switch (options.provider) {
+    case "codex":
+      session = new CodexInteractiveSession(options, emit);
+      break;
+    case "claude":
+      session = new PromptRunnerInteractiveSession(
+        "claude",
+        options,
+        emit,
+        (writer) => new ClaudeRunner(options, writer),
+      );
+      break;
+    default:
+      throw new UnsupportedProviderError(options.provider);
   }
-  const session = new CodexInteractiveSession(options, emit);
   await session.start();
   return session;
 }

--- a/runtime/javascript/src/runners/claude.ts
+++ b/runtime/javascript/src/runners/claude.ts
@@ -3,7 +3,7 @@ import { flattenEnvMap } from "../mcp-config.js";
 import { uniqueDirectories } from "../paths.js";
 import { readStoredThread, writeStoredThread } from "../session-state.js";
 import { jsonString } from "../text.js";
-import { TranscriptWriter } from "../transcript.js";
+import { TranscriptWriter, type TranscriptTextWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions, StoredThread } from "../types.js";
 
 type PendingToolUse = {
@@ -75,10 +75,12 @@ function toClaudeMCPConfig(config: Record<string, unknown> | undefined): Record<
 }
 
 export class ClaudeRunner {
-  private readonly writer = new TranscriptWriter();
   private readonly pendingToolUses = new Map<string, PendingToolUse>();
 
-  constructor(private readonly options: RunnerOptions) {}
+  constructor(
+    private readonly options: RunnerOptions,
+    private readonly writer: TranscriptTextWriter = new TranscriptWriter(),
+  ) {}
 
   queryOptions(stored: StoredThread | null): Record<string, unknown> {
     const executable = claudeExecutable();

--- a/runtime/javascript/src/stream.ts
+++ b/runtime/javascript/src/stream.ts
@@ -2,7 +2,7 @@ import { createInterface } from "node:readline/promises";
 import type { Readable, Writable } from "node:stream";
 import { runRuntimeCommand, type RuntimeCommandRequest } from "./command.js";
 import { decodeFrame, encodeFrame, FRAME_VERSION, type StreamFrame } from "./frame.js";
-import { createInteractiveSession, UnsupportedProviderError, type CodexInteractiveSession } from "./interactive.js";
+import { createInteractiveSession, UnsupportedProviderError, type InteractiveSession } from "./interactive.js";
 
 export interface RunStreamOptions {
   stdin?: Readable;
@@ -15,7 +15,7 @@ export async function runStreamCommand(options: RunStreamOptions = {}): Promise<
   const stdout = options.stdout || process.stdout;
   const stderr = options.stderr || process.stderr;
   let outputSeq = 0;
-  let session: CodexInteractiveSession | undefined;
+  let session: InteractiveSession | undefined;
   let finished = false;
 
   const emit = (type: string, fields: object = {}) => {

--- a/runtime/javascript/src/transcript.ts
+++ b/runtime/javascript/src/transcript.ts
@@ -6,6 +6,10 @@ export interface TextWriter {
   line(text?: string): void;
 }
 
+export interface TranscriptTextWriter extends TextWriter {
+  transcript(): string;
+}
+
 export function appendDelta(
   writer: TextWriter,
   cache: Map<string, string>,
@@ -26,7 +30,7 @@ export function appendDelta(
   }
 }
 
-export class TranscriptWriter implements TextWriter {
+export class TranscriptWriter implements TranscriptTextWriter {
   private readonly chunks: string[] = [];
 
   write(text: string): void {

--- a/runtime/javascript/test/stream.test.ts
+++ b/runtime/javascript/test/stream.test.ts
@@ -23,6 +23,10 @@ const thread = {
 const startThread = vi.fn(() => thread);
 const resumeThread = vi.fn(() => thread);
 
+const claudeState = vi.hoisted(() => ({
+  queryCalls: [] as Array<Record<string, unknown>>,
+}));
+
 vi.mock("@openai/codex-sdk", () => ({
   Codex: vi.fn(function CodexMock(this: object) {
     Object.assign(this, {
@@ -32,10 +36,38 @@ vi.mock("@openai/codex-sdk", () => ({
   }),
 }));
 
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn((request: Record<string, unknown>) => {
+    claudeState.queryCalls.push(request);
+    const turn = claudeState.queryCalls.length;
+    return {
+      close: vi.fn(),
+      [Symbol.asyncIterator]: async function* iterator() {
+        yield {
+          type: "stream_event",
+          session_id: "claude-session-1",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: `claude answer ${turn}` },
+          },
+        };
+        yield {
+          type: "result",
+          subtype: "success",
+          session_id: "claude-session-1",
+          stop_reason: "end_turn",
+          result: `claude answer ${turn}`,
+        };
+      },
+    };
+  }),
+}));
+
 afterEach(() => {
   runInputs.length = 0;
   startThread.mockClear();
   resumeThread.mockClear();
+  claudeState.queryCalls = [];
   vi.restoreAllMocks();
 });
 
@@ -110,13 +142,58 @@ describe("runStreamCommand", () => {
     });
   });
 
+  it("runs multiple Claude human messages by resuming the stored provider session", async () => {
+    await withTempSession(async (root) => {
+      const stdout = new MemoryWritable();
+      const stderr = new MemoryWritable();
+
+      await runStreamCommand({
+        stdin: Readable.from([
+          frame({ seq: 0, type: "start", provider: "claude", stateRoot: `${root}/state`, workspace: `${root}/workspace`, home: `${root}/home` }),
+          frame({ seq: 1, type: "human_message", message: "first" }),
+          frame({ seq: 2, type: "human_message", message: "second" }),
+          frame({ seq: 3, type: "eof" }),
+        ]),
+        stdout,
+        stderr,
+      });
+
+      const frames = parseOutput(stdout.text);
+      expect(frames.map((entry) => entry.type)).toEqual([
+        "started",
+        "agent_event",
+        "agent_turn_completed",
+        "agent_event",
+        "agent_turn_completed",
+        "result",
+      ]);
+      expect(frames.every((entry, index) => entry.seq === index)).toBe(true);
+      expect(frames.filter((entry) => entry.type === "agent_event")).toEqual([
+        expect.objectContaining({ event: expect.objectContaining({ provider: "claude", text: "claude answer 1" }) }),
+        expect.objectContaining({ event: expect.objectContaining({ provider: "claude", text: "claude answer 2" }) }),
+      ]);
+      expect(claudeState.queryCalls.map((call) => call.prompt)).toEqual(["first", "second"]);
+      expect(claudeState.queryCalls[0]?.options).not.toMatchObject({ resume: expect.anything() });
+      expect(claudeState.queryCalls[1]?.options).toMatchObject({ resume: "claude-session-1" });
+      expect(frames.at(-1)).toMatchObject({
+        type: "result",
+        provider: "claude",
+        threadId: "claude-session-1",
+        stopReason: "eof",
+        finalText: "claude answer 2",
+        transcript: "claude answer 1\nclaude answer 2",
+      });
+      expect(stderr.text).toBe("");
+    });
+  });
+
   it("emits a structured error for unsupported interactive providers", async () => {
     await withTempSession(async (root) => {
       const stdout = new MemoryWritable();
 
       await runStreamCommand({
         stdin: Readable.from([
-          frame({ seq: 0, type: "start", provider: "claude", stateRoot: `${root}/state` }),
+          frame({ seq: 0, type: "start", provider: "opencode", stateRoot: `${root}/state` }),
         ]),
         stdout,
       });
@@ -127,9 +204,9 @@ describe("runStreamCommand", () => {
           seq: 0,
           type: "error",
           code: "unsupported_provider",
-          message: "interactive stream is not supported for provider claude",
+          message: "interactive stream is not supported for provider opencode",
           inputSeq: 0,
-          provider: "claude",
+          provider: "opencode",
         },
       ]);
     });


### PR DESCRIPTION
  ## Summary

  - Add Claude support to prompt-mode bidirectional `RunAttach` streams.
  - Introduce a provider-neutral interactive session boundary while preserving the existing Codex behavior.
  - Resume Claude sessions between turns using the existing persisted provider session ID.
  - Normalize Claude runner output into stream agent events and preserve transcript turn boundaries.
  - Reuse the shared runtime LLM facade configuration through dependency injection, keeping the path ready for future OpenCode support.
  - Document Codex and Claude prompt-attach support in the English and Chinese guest image ABI manuals.

  ## Testing

  - `npm run typecheck` in `runtime/javascript`
  - `npm run test:unit` in `runtime/javascript` — 145 tests passed
  - Focused Go prompt-attach tests in `pkg/runs`
  - `GOOS=linux GOTOOLCHAIN=auto task lint` — 0 issues
  - `GOTOOLCHAIN=auto task build`
  - `GOTOOLCHAIN=auto task test`
  - `GOTOOLCHAIN=auto task docs:build`

  The full test suite was run on macOS with a non-symlink temporary directory and temporary GNU-compatible command shims for the Linux-oriented deployment
  tests.

  Native Darwin `task lint` still reports the pre-existing `boxliteVolumeBridgeIsMountPoint` unused warning because its only caller is Linux-specific; the
  complete Linux-target lint passes.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.