### PR TITLE
fix(scheduler): correct command behavior and trigger history

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ See the [command line manual](docs/pages/command-line-manual.md) for the full fi
 | `agent-compose exec <sandbox>` | Execute a command or prompt in a running sandbox. |
 | `agent-compose ps` / `stats` | List project sandboxes / show sandbox resource stats. |
 | `agent-compose logs` | Print project run logs; a project, agent, run, or sandbox ID can be passed without its resource type. |
-| `agent-compose scheduler ls\|runs\|logs\|trigger\|inspect` | List triggers and runs, read scheduler logs, manually run triggers, or inspect scheduler resources. |
+| `agent-compose scheduler ls\|invoke\|runs\|logs\|trigger\|inspect\|prune` | Invoke schedulers, list triggers and runs, read logs, manually run triggers, inspect resources, or prune terminal trigger-run history. |
 | `agent-compose sandbox ls\|stop\|resume\|rm\|prune` | Manage project sandboxes. |
 | `agent-compose image ls\|pull\|build\|rm\|inspect` | Manage daemon images and build agent images; top-level shortcuts remain available. |
 | `agent-compose volume ls\|create\|inspect\|rm\|prune` | Manage daemon volumes. |

--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -39,17 +39,17 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "scheduler",
 			args: []string{"scheduler", "--help"},
-			want: []string{"Run, inspect, and operate project schedulers, runs, logs, and triggers", "run", "trigger", "runs", "logs", "stop", "inspect"},
+			want: []string{"Invoke, inspect, and operate project schedulers, trigger runs, logs, and triggers", "invoke", "trigger", "runs", "logs", "stop", "inspect"},
 		},
 		{
-			name: "scheduler run",
-			args: []string{"scheduler", "run", "--help"},
-			want: []string{"Run a scheduler main function", "--payload", "--detach", "--prompt", "--sandbox"},
+			name: "scheduler invoke",
+			args: []string{"scheduler", "invoke", "--help"},
+			want: []string{"Invoke a script-based scheduler in the foreground", "invoke <scheduler-ref>", "--payload"},
 		},
 		{
 			name: "scheduler trigger",
 			args: []string{"scheduler", "trigger", "--help"},
-			want: []string{"Manually run a scheduler trigger", "--sandbox", "--driver", "--prompt", "--payload", "--keep-running", "--rm", "--jupyter", "--jupyter-expose", "--detach"},
+			want: []string{"Manually run a scheduler trigger", "trigger <scheduler-ref> <trigger-ref>", "--payload", "--detach"},
 		},
 		{
 			name: "logs",

--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -568,19 +568,35 @@ func assertComposeUpChange(t *testing.T, changes []composeUpChangeOutput, action
 }
 
 type projectServiceStub struct {
-	applyProject        func(context.Context, *connect.Request[agentcomposev2.ApplyProjectRequest]) (*connect.Response[agentcomposev2.ApplyProjectResponse], error)
-	getProject          func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error)
-	listProjects        func(context.Context, *connect.Request[agentcomposev2.ListProjectsRequest]) (*connect.Response[agentcomposev2.ListProjectsResponse], error)
-	removeProject       func(context.Context, *connect.Request[agentcomposev2.RemoveProjectRequest]) (*connect.Response[agentcomposev2.RemoveProjectResponse], error)
-	getScheduler        func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error)
-	listSchedulerEvents func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error)
-	runScheduler        func(context.Context, *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error)
-	startSchedulerRun   func(context.Context, *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error)
-	getSchedulerRun     func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error)
-	listSchedulerRuns   func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error)
-	stopSchedulerRun    func(context.Context, *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error)
+	applyProject               func(context.Context, *connect.Request[agentcomposev2.ApplyProjectRequest]) (*connect.Response[agentcomposev2.ApplyProjectResponse], error)
+	getProject                 func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error)
+	listProjects               func(context.Context, *connect.Request[agentcomposev2.ListProjectsRequest]) (*connect.Response[agentcomposev2.ListProjectsResponse], error)
+	removeProject              func(context.Context, *connect.Request[agentcomposev2.RemoveProjectRequest]) (*connect.Response[agentcomposev2.RemoveProjectResponse], error)
+	getScheduler               func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error)
+	listSchedulerEvents        func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error)
+	listProjectSchedulerEvents func(context.Context, *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error)
+	invokeScheduler            func(context.Context, *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error)
+	runScheduler               func(context.Context, *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error)
+	startSchedulerRun          func(context.Context, *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error)
+	getSchedulerRun            func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error)
+	listSchedulerRuns          func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error)
+	stopSchedulerRun           func(context.Context, *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error)
 
 	agentcomposev2connect.UnimplementedProjectServiceHandler
+}
+
+func (s projectServiceStub) ListProjectSchedulerEvents(ctx context.Context, req *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
+	if s.listProjectSchedulerEvents == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ListProjectSchedulerEvents stub is not configured"))
+	}
+	return s.listProjectSchedulerEvents(ctx, req)
+}
+
+func (s projectServiceStub) InvokeScheduler(ctx context.Context, req *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error) {
+	if s.invokeScheduler == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("InvokeScheduler stub is not configured"))
+	}
+	return s.invokeScheduler(ctx, req)
 }
 
 func (s projectServiceStub) ApplyProject(ctx context.Context, req *connect.Request[agentcomposev2.ApplyProjectRequest]) (*connect.Response[agentcomposev2.ApplyProjectResponse], error) {

--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -581,8 +581,16 @@ type projectServiceStub struct {
 	getSchedulerRun            func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error)
 	listSchedulerRuns          func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error)
 	stopSchedulerRun           func(context.Context, *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error)
+	pruneSchedulerRuns         func(context.Context, *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error)
 
 	agentcomposev2connect.UnimplementedProjectServiceHandler
+}
+
+func (s projectServiceStub) PruneSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error) {
+	if s.pruneSchedulerRuns == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("PruneSchedulerRuns stub is not configured"))
+	}
+	return s.pruneSchedulerRuns(ctx, req)
 }
 
 func (s projectServiceStub) ListProjectSchedulerEvents(ctx context.Context, req *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {

--- a/cmd/agent-compose/cli_ps_run_association_test.go
+++ b/cmd/agent-compose/cli_ps_run_association_test.go
@@ -99,14 +99,14 @@ agents:
 				projectID = req.Msg.GetProject().GetProjectId()
 				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(projectID, "cli-ps-scheduler-run", composePath)}), nil
 			},
-			listSchedulerEvents: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error) {
+			listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
 				if req.Msg.GetAgentName() != "reviewer" {
-					t.Fatalf("ListSchedulerEvents agent = %q, want reviewer", req.Msg.GetAgentName())
+					t.Fatalf("ListSchedulerRuns agent = %q, want reviewer", req.Msg.GetAgentName())
 				}
-				return connect.NewResponse(&agentcomposev2.ListSchedulerEventsResponse{Events: []*agentcomposev2.SchedulerEvent{
-					{Id: "event-started", Type: "loader.run.started", RunId: schedulerRunID, CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC))},
-					{Id: "event-completed", Type: "loader.run.completed", RunId: schedulerRunID, PayloadJson: `{"sandboxId":"` + sandboxID + `"}`, CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 12, 1, 0, 0, time.UTC))},
-				}}), nil
+				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+					RunId: schedulerRunID, AgentName: "reviewer", TriggerId: "nightly", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+					SandboxIds: []string{sandboxID}, CompletedAt: timestamppb.New(time.Date(2026, 7, 15, 12, 1, 0, 0, time.UTC)),
+				}}}), nil
 			},
 		},
 		run: runServiceStub{listRuns: func(context.Context, *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {

--- a/cmd/agent-compose/cli_scheduler_command.go
+++ b/cmd/agent-compose/cli_scheduler_command.go
@@ -3,15 +3,12 @@ package main
 import (
 	"agent-compose/pkg/compose"
 	domain "agent-compose/pkg/model"
-	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"connectrpc.com/connect"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -34,11 +31,20 @@ type composeSchedulerRunsOptions struct {
 	Limit     uint32
 }
 
+type composeSchedulerInvokeOptions struct {
+	PayloadJSON string
+}
+
 type composeSchedulerLogsOptions struct {
-	AgentName string
-	Trigger   string
-	RunID     string
-	Tail      int
+	SchedulerRef string
+	AgentName    string
+	Trigger      string
+	RunID        string
+	Tail         int
+}
+
+type composeSchedulerInspectOptions struct {
+	SchedulerRef string
 }
 
 func runComposeSchedulerTriggerCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerTriggerOptions, agentName, triggerRef string) error {
@@ -46,6 +52,9 @@ func runComposeSchedulerTriggerCommand(cmd *cobra.Command, cli cliOptions, optio
 }
 
 func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerRunsOptions, args []string) error {
+	if err := writeDeprecatedSchedulerAgentFlagWarning(cmd, "use the scheduler positional argument instead"); err != nil {
+		return err
+	}
 	_, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
@@ -80,6 +89,9 @@ func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options 
 }
 
 func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerLogsOptions, args []string) error {
+	if err := writeDeprecatedSchedulerAgentFlagWarning(cmd, "use --scheduler instead"); err != nil {
+		return err
+	}
 	_, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
@@ -98,33 +110,50 @@ func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options 
 	if options.Tail < -1 {
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs --tail must be -1 or greater")}
 	}
-	if runRef != "" && (strings.TrimSpace(options.AgentName) != "" || strings.TrimSpace(options.Trigger) != "") {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs --agent and --trigger can only be used when selecting the latest run")}
+	schedulerRef := strings.TrimSpace(options.SchedulerRef)
+	if schedulerRef != "" && strings.TrimSpace(options.AgentName) != "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs accepts either --scheduler or deprecated --agent, not both")}
+	}
+	if schedulerRef == "" {
+		schedulerRef = strings.TrimSpace(options.AgentName)
+	}
+	if runRef != "" && (schedulerRef != "" || strings.TrimSpace(options.Trigger) != "") {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs run filters cannot be combined with --scheduler or --trigger")}
 	}
 	var selected *composeSchedulerRunItem
+	agentName := ""
+	triggerID := ""
 	if runRef != "" {
 		selected, err = getComposeSchedulerRun(cmd.Context(), clients, normalized, projectID, runRef)
 		if err != nil {
 			return err
 		}
-	} else {
-		runs, listErr := listComposeSchedulerRuns(cmd.Context(), clients, normalized, projectID, options.AgentName, options.Trigger, "", 1)
-		if listErr != nil {
-			return listErr
+		agentName = selected.AgentName
+		triggerID = selected.TriggerID
+		runRef = selected.RunID
+	} else if schedulerRef != "" {
+		scheduler, resolveErr := resolveComposeScheduler(normalized, projectID, schedulerRef)
+		if resolveErr != nil {
+			return resolveErr
 		}
-		if len(runs) > 0 {
-			selected = &runs[0]
+		agentName = scheduler.AgentName
+	}
+	if triggerRef := strings.TrimSpace(options.Trigger); triggerRef != "" {
+		resolvedTriggerID, resolveErr := resolveSchedulerTriggerIDForQuery(cmd.Context(), clients, normalized, projectID, agentName, triggerRef)
+		if resolveErr != nil {
+			if errors.Is(resolveErr, domain.ErrAmbiguous) && agentName == "" {
+				resolveErr = fmt.Errorf("%w; use --scheduler <scheduler-ref> to disambiguate", resolveErr)
+			}
+			if isSchedulerResourceNotFound(resolveErr) || errors.Is(resolveErr, domain.ErrAmbiguous) {
+				return commandExitError{Code: exitCodeUsage, Err: resolveErr}
+			}
+			return resolveErr
 		}
+		triggerID = resolvedTriggerID
 	}
-	if selected == nil {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("no scheduler runs found")}
-	}
-	events, err := listSchedulerRunEvents(cmd.Context(), clients, projectID, *selected)
+	events, err := listProjectSchedulerLogEvents(cmd.Context(), clients.project, projectID, agentName, triggerID, runRef, options.Tail)
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("list scheduler run %s logs: %w", selected.RunID, err))
-	}
-	if options.Tail >= 0 && len(events) > options.Tail {
-		events = events[len(events)-options.Tail:]
+		return err
 	}
 	output := composeSchedulerLogsOutput{
 		Project: composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: normalized.Name},
@@ -141,7 +170,15 @@ func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options 
 	return writeSchedulerLogsText(cmd.OutOrStdout(), output)
 }
 
-func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, args []string) error {
+func writeDeprecatedSchedulerAgentFlagWarning(cmd *cobra.Command, guidance string) error {
+	if !cmd.Flags().Changed("agent") {
+		return nil
+	}
+	_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Warning: --agent is deprecated; %s\n", guidance)
+	return err
+}
+
+func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerInspectOptions, rawRef string) error {
 	_, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
@@ -151,14 +188,14 @@ func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, args 
 		return err
 	}
 	output := composeSchedulerInspectOutput{Project: composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: normalized.Name}}
-	if len(args) == 2 {
-		trigger, err := resolveComposeSchedulerTrigger(cmd.Context(), clients, normalized, projectID, args[0], args[1])
+	ref := strings.TrimSpace(rawRef)
+	if schedulerRef := strings.TrimSpace(options.SchedulerRef); schedulerRef != "" {
+		trigger, err := resolveComposeSchedulerTrigger(cmd.Context(), clients, normalized, projectID, schedulerRef, ref)
 		if err != nil {
 			return err
 		}
 		setSchedulerTriggerInspectOutput(&output, trigger)
 	} else {
-		ref := strings.TrimSpace(args[0])
 		if shouldResolveSchedulerRunRef(ref) {
 			run, runErr := getComposeSchedulerRun(cmd.Context(), clients, normalized, projectID, ref)
 			if runErr == nil {
@@ -191,6 +228,9 @@ func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, args 
 			}
 			trigger, triggerErr := resolveSchedulerTriggerFromItems(triggers, ref)
 			if triggerErr != nil {
+				if errors.Is(triggerErr, domain.ErrAmbiguous) {
+					triggerErr = fmt.Errorf("%w; use --scheduler <scheduler-ref> to disambiguate", triggerErr)
+				}
 				return commandExitError{Code: exitCodeUsage, Err: triggerErr}
 			}
 			setSchedulerTriggerInspectOutput(&output, *trigger)
@@ -221,59 +261,11 @@ func isSchedulerResourceNotFound(err error) bool {
 }
 
 func getComposeSchedulerRun(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, runRef string) (*composeSchedulerRunItem, error) {
-	runID, err := resolveSchedulerRunID(ctx, clients.resource, projectID, runRef)
-	if err != nil {
-		if !isSchedulerResourceNotFound(err) {
-			return nil, err
-		}
-		return resolveSchedulerRuntimeRun(ctx, clients.project, normalized, projectID, runRef)
-	}
-	resp, err := clients.run.GetRun(ctx, connect.NewRequest(&agentcomposev2.GetRunRequest{ProjectId: projectID, RunId: runID}))
-	if err != nil {
-		if connect.CodeOf(err) == connect.CodeNotFound {
-			return resolveSchedulerRuntimeRun(ctx, clients.project, normalized, projectID, runRef)
-		}
-		return nil, commandExitErrorForConnect(fmt.Errorf("get scheduler run %s: %w", runRef, err))
-	}
-	summary := resp.Msg.GetRun().GetSummary()
-	if summary == nil || strings.TrimSpace(summary.GetSchedulerId()) == "" {
-		return resolveSchedulerRuntimeRun(ctx, clients.project, normalized, projectID, runRef)
-	}
-	loaderID, idErr := domain.StableManagedLoaderID(projectID, summary.GetAgentName(), "")
-	if idErr != nil {
-		return nil, idErr
-	}
-	item := schedulerRunItem(summary.GetAgentName(), summary.GetSchedulerId(), loaderID, summary)
-	item.ResultJSON = resp.Msg.GetRun().GetResultJson()
-	item.ArtifactsDir = resp.Msg.GetRun().GetArtifactsDir()
-	return &item, nil
-}
-
-func isLegacySchedulerRunID(runID string) bool {
-	runID = strings.TrimSpace(runID)
-	parsed, err := uuid.Parse(runID)
-	return err == nil && parsed.String() == runID
+	return resolveSchedulerRuntimeRun(ctx, clients.project, normalized, projectID, runRef)
 }
 
 func normalizeComposeSchedulerTriggerOptions(options composeSchedulerTriggerOptions) (composeSchedulerTriggerOptions, error) {
 	return normalizeComposeSchedulerExecutionOptions("scheduler trigger", options)
-}
-
-func mergeSchedulerRuntimeRuns(current, legacy []composeSchedulerRunItem) []composeSchedulerRunItem {
-	byID := make(map[string]int, len(current))
-	for index := range current {
-		byID[current[index].RunID] = index
-	}
-	for _, run := range legacy {
-		index, ok := byID[run.RunID]
-		if !ok {
-			byID[run.RunID] = len(current)
-			current = append(current, run)
-			continue
-		}
-		current[index].SandboxIDs = appendUniqueStrings(current[index].SandboxIDs, run.SandboxIDs...)
-	}
-	return current
 }
 
 func (b *composeDisplayChangeBuilder) addTriggerChanges(action, id, agentName, message string, spec *compose.NormalizedProjectSpec) {

--- a/cmd/agent-compose/cli_scheduler_definition.go
+++ b/cmd/agent-compose/cli_scheduler_definition.go
@@ -71,6 +71,26 @@ func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 	logsCmd.Flags().StringVar(&logsOptions.RunID, "run", "", "Filter by scheduler run id")
 	logsCmd.Flags().IntVarP(&logsOptions.Tail, "tail", "n", -1, "Show the last N log events")
 
+	pruneOptions := composeSchedulerPruneOptions{}
+	pruneCmd := &cobra.Command{
+		Use: "prune", Short: "Prune scheduler trigger-run history",
+		Long: "Prune terminal scheduler trigger runs and their outer events and artifacts. The command is a dry-run unless --force is specified.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return commandExitError{Code: exitCodeUsage, Err: err}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runComposeSchedulerPruneCommand(cmd, *cli, pruneOptions)
+		},
+	}
+	pruneCmd.Flags().StringVar(&pruneOptions.SchedulerRef, "scheduler", "", "Filter by scheduler name or ID")
+	pruneCmd.Flags().StringVar(&pruneOptions.TriggerRef, "trigger", "", "Filter by current trigger name or exact historical trigger ID")
+	pruneCmd.Flags().StringVar(&pruneOptions.Status, "status", "", "Filter by terminal run status, comma-separated")
+	pruneCmd.Flags().StringVar(&pruneOptions.OlderThan, "older-than", "", "Only match runs older than a duration such as 7d or 24h")
+	pruneCmd.Flags().BoolVar(&pruneOptions.Force, "force", false, "Actually remove matched scheduler trigger runs")
+
 	stopOptions := composeSchedulerStopOptions{}
 	stopCmd := &cobra.Command{
 		Use: "stop <run>", Short: "Stop an active scheduler run", Args: cobra.ExactArgs(1),
@@ -95,6 +115,6 @@ func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 		},
 	}
 	inspectCmd.Flags().StringVar(&inspectOptions.SchedulerRef, "scheduler", "", "Limit trigger lookup to a scheduler name or ID")
-	cmd.AddCommand(listCmd, invokeCmd, triggerCmd, runsCmd, logsCmd, stopCmd, inspectCmd)
+	cmd.AddCommand(listCmd, invokeCmd, triggerCmd, runsCmd, logsCmd, pruneCmd, stopCmd, inspectCmd)
 	return cmd
 }

--- a/cmd/agent-compose/cli_scheduler_definition.go
+++ b/cmd/agent-compose/cli_scheduler_definition.go
@@ -1,23 +1,28 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "scheduler",
-		Short: "Run, inspect, and operate project schedulers, runs, logs, and triggers",
+		Short: "Invoke, inspect, and operate project schedulers, trigger runs, logs, and triggers",
 		Args:  cobra.NoArgs,
 		RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 	}
 
-	runOptions := composeSchedulerTriggerOptions{}
-	runCmd := &cobra.Command{
-		Use: "run <agent>", Short: "Run a scheduler main function", Args: cobra.ExactArgs(1),
+	invokeOptions := composeSchedulerInvokeOptions{}
+	invokeCmd := &cobra.Command{
+		Use: "invoke <scheduler-ref>", Short: "Invoke a deployed scheduler script",
+		Long: "Invoke a script-based scheduler in the foreground and wait for its result. This does not execute a named trigger or create scheduler trigger-run history.", Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComposeSchedulerMainCommand(cmd, *cli, runOptions, args[0])
+			return runComposeSchedulerInvokeCommand(cmd, *cli, invokeOptions, args[0])
 		},
 	}
-	addComposeSchedulerExecutionFlags(runCmd, &runOptions)
+	invokeCmd.Flags().StringVar(&invokeOptions.PayloadJSON, "payload", "", "JSON payload passed to the scheduler script")
 
 	listOptions := composeSchedulerListOptions{}
 	listCmd := &cobra.Command{
@@ -30,7 +35,7 @@ func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 
 	triggerOptions := composeSchedulerTriggerOptions{}
 	triggerCmd := &cobra.Command{
-		Use: "trigger <agent> <trigger>", Short: "Manually run a scheduler trigger", Args: cobra.ExactArgs(2),
+		Use: "trigger <scheduler-ref> <trigger-ref>", Short: "Manually run a scheduler trigger", Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runComposeSchedulerTriggerCommand(cmd, *cli, triggerOptions, args[0], args[1])
 		},
@@ -39,24 +44,29 @@ func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 
 	runsOptions := composeSchedulerRunsOptions{}
 	runsCmd := &cobra.Command{
-		Use: "runs [scheduler]", Short: "List project scheduler runs", Args: cobra.RangeArgs(0, 1),
+		Use: "runs [scheduler-ref]", Short: "List scheduler trigger runs",
+		Long: "List outer trigger-run history for current project schedulers. Results are unbounded by default; use --limit to restrict the final count.", Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runComposeSchedulerRunsCommand(cmd, *cli, runsOptions, args)
 		},
 	}
-	runsCmd.Flags().StringVar(&runsOptions.AgentName, "agent", "", "Filter by agent name or id")
+	runsCmd.Flags().StringVar(&runsOptions.AgentName, "agent", "", "Filter by scheduler owner (deprecated)")
+	_ = runsCmd.Flags().MarkHidden("agent")
 	runsCmd.Flags().StringVar(&runsOptions.Trigger, "trigger", "", "Filter by trigger name or id")
 	runsCmd.Flags().StringVar(&runsOptions.Status, "status", "", "Filter by run status")
-	runsCmd.Flags().Uint32Var(&runsOptions.Limit, "limit", 20, "Maximum runs to show")
+	runsCmd.Flags().Uint32Var(&runsOptions.Limit, "limit", 0, "Maximum runs to show; 0 means all")
 
 	logsOptions := composeSchedulerLogsOptions{}
 	logsCmd := &cobra.Command{
-		Use: "logs [run]", Short: "Print scheduler run logs", Args: cobra.RangeArgs(0, 1),
+		Use: "logs [run-ref]", Short: "Print scheduler trigger-run logs",
+		Long: "Print outer structured events for all scheduler trigger runs by default. Use scheduler, trigger, or run filters to narrow the result. These logs do not include invocation logs or inner agent transcripts.", Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runComposeSchedulerLogsCommand(cmd, *cli, logsOptions, args)
 		},
 	}
-	logsCmd.Flags().StringVar(&logsOptions.AgentName, "agent", "", "Filter by agent name or id")
+	logsCmd.Flags().StringVar(&logsOptions.SchedulerRef, "scheduler", "", "Filter by scheduler name or ID")
+	logsCmd.Flags().StringVar(&logsOptions.AgentName, "agent", "", "Filter by scheduler owner (deprecated)")
+	_ = logsCmd.Flags().MarkHidden("agent")
 	logsCmd.Flags().StringVar(&logsOptions.Trigger, "trigger", "", "Filter by trigger name or id")
 	logsCmd.Flags().StringVar(&logsOptions.RunID, "run", "", "Filter by scheduler run id")
 	logsCmd.Flags().IntVarP(&logsOptions.Tail, "tail", "n", -1, "Show the last N log events")
@@ -70,12 +80,21 @@ func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 	}
 	stopCmd.Flags().StringVar(&stopOptions.Reason, "reason", "", "Reason recorded for the canceled run")
 
+	inspectOptions := composeSchedulerInspectOptions{}
 	inspectCmd := &cobra.Command{
-		Use: "inspect <name-or-id> [trigger]", Short: "Inspect a scheduler, trigger, or scheduler run", Args: cobra.RangeArgs(1, 2),
+		Use: "inspect <scheduler-or-trigger-or-run-ref>", Short: "Inspect a scheduler, trigger, or scheduler trigger run",
+		Long: "Inspect one scheduler, trigger, or outer scheduler trigger run. Use --scheduler to disambiguate trigger references shared by multiple schedulers.",
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler inspect accepts one resource reference; use --scheduler <scheduler-ref> to scope a trigger lookup")}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComposeSchedulerInspectCommand(cmd, *cli, args)
+			return runComposeSchedulerInspectCommand(cmd, *cli, inspectOptions, args[0])
 		},
 	}
-	cmd.AddCommand(listCmd, runCmd, triggerCmd, runsCmd, logsCmd, stopCmd, inspectCmd)
+	inspectCmd.Flags().StringVar(&inspectOptions.SchedulerRef, "scheduler", "", "Limit trigger lookup to a scheduler name or ID")
+	cmd.AddCommand(listCmd, invokeCmd, triggerCmd, runsCmd, logsCmd, stopCmd, inspectCmd)
 	return cmd
 }

--- a/cmd/agent-compose/cli_scheduler_output.go
+++ b/cmd/agent-compose/cli_scheduler_output.go
@@ -123,6 +123,9 @@ func writeSchedulerRunsText(out io.Writer, output composeSchedulerRunsOutput) er
 func writeSchedulerLogsText(out io.Writer, output composeSchedulerLogsOutput) error {
 	for _, event := range output.Events {
 		line := fmt.Sprintf("%s %s %s", event.CreatedAt, strings.ToUpper(firstNonEmptyString(event.Level, "info")), event.Type)
+		line += " scheduler=" + firstNonEmptyString(event.AgentName, shortOpaqueID(event.SchedulerID), "-")
+		line += " trigger=" + firstNonEmptyString(shortOpaqueID(event.TriggerID), "-")
+		line += " run=" + firstNonEmptyString(shortOpaqueID(event.RunID), "-")
 		if event.Message != "" {
 			line += " " + event.Message
 		}

--- a/cmd/agent-compose/cli_scheduler_prune.go
+++ b/cmd/agent-compose/cli_scheduler_prune.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+type composeSchedulerPruneOptions struct {
+	SchedulerRef string
+	TriggerRef   string
+	Status       string
+	OlderThan    string
+	Force        bool
+}
+
+type composeSchedulerPruneStats struct {
+	Runs              uint64 `json:"runs"`
+	LoaderEvents      uint64 `json:"loader_events"`
+	EventDeliveries   uint64 `json:"event_deliveries"`
+	EventSandboxLinks uint64 `json:"event_sandbox_links"`
+	ArtifactDirs      uint64 `json:"artifact_dirs"`
+	ArtifactBytes     uint64 `json:"artifact_bytes"`
+}
+
+type composeSchedulerPruneResidue struct {
+	LoaderID string `json:"loader_id"`
+	RunID    string `json:"run_id"`
+	Path     string `json:"path"`
+	Error    string `json:"error"`
+}
+
+type composeSchedulerPruneOutput struct {
+	RecordScope string                         `json:"record_scope"`
+	DryRun      bool                           `json:"dry_run"`
+	Project     composeUpProjectOutput         `json:"project"`
+	Scheduler   string                         `json:"scheduler,omitempty"`
+	TriggerID   string                         `json:"trigger_id,omitempty"`
+	Statuses    []string                       `json:"statuses,omitempty"`
+	OlderThan   string                         `json:"older_than,omitempty"`
+	Matched     composeSchedulerPruneStats     `json:"matched"`
+	Removed     composeSchedulerPruneStats     `json:"removed"`
+	SkippedRuns uint64                         `json:"skipped_runs"`
+	Residues    []composeSchedulerPruneResidue `json:"residues"`
+	Warnings    []string                       `json:"warnings"`
+}
+
+func runComposeSchedulerPruneCommand(cmd interface {
+	Context() context.Context
+	OutOrStdout() io.Writer
+}, cli cliOptions, options composeSchedulerPruneOptions) error {
+	_, normalized, projectID, err := resolveComposeProject(cli)
+	if err != nil {
+		return err
+	}
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	agentName := ""
+	if strings.TrimSpace(options.SchedulerRef) != "" {
+		scheduler, resolveErr := resolveComposeScheduler(normalized, projectID, options.SchedulerRef)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		agentName = scheduler.AgentName
+	}
+	triggerID := ""
+	if strings.TrimSpace(options.TriggerRef) != "" {
+		triggerID, err = resolveSchedulerTriggerIDForQuery(cmd.Context(), clients, normalized, projectID, agentName, options.TriggerRef)
+		if err != nil {
+			if isSchedulerResourceNotFound(err) || errors.Is(err, model.ErrAmbiguous) {
+				return commandExitError{Code: exitCodeUsage, Err: err}
+			}
+			return err
+		}
+	}
+	statuses, statusNames, err := parseSchedulerRunPruneStatuses(options.Status)
+	if err != nil {
+		return err
+	}
+	olderThanSeconds, err := parseOlderThanSeconds(options.OlderThan)
+	if err != nil {
+		return commandExitError{Code: exitCodeUsage, Err: err}
+	}
+	response, err := clients.project.PruneSchedulerRuns(cmd.Context(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
+		Project:          &agentcomposev2.ProjectRef{ProjectId: projectID},
+		AgentName:        agentName,
+		TriggerId:        triggerID,
+		Status:           statuses,
+		OlderThanSeconds: olderThanSeconds,
+		Force:            options.Force,
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeUnimplemented {
+			return commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support scheduler run pruning; upgrade the daemon")}
+		}
+		return commandExitErrorForConnect(fmt.Errorf("prune scheduler runs: %w", err))
+	}
+	output := composeSchedulerPruneOutputFromResponse(response.Msg)
+	output.Project = composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: normalized.Name}
+	output.Scheduler = agentName
+	output.TriggerID = triggerID
+	output.Statuses = statusNames
+	output.OlderThan = strings.TrimSpace(options.OlderThan)
+	if err := writeComposeSchedulerPruneOutput(cmd.OutOrStdout(), cli.JSON, output); err != nil {
+		return err
+	}
+	if options.Force && (output.SkippedRuns > 0 || len(output.Residues) > 0) {
+		return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("scheduler prune completed with %d skipped run(s) and %d artifact residue(s)", output.SkippedRuns, len(output.Residues))}
+	}
+	return nil
+}
+
+func parseSchedulerRunPruneStatuses(value string) ([]agentcomposev2.SchedulerRunStatus, []string, error) {
+	values := strings.Split(value, ",")
+	statuses := make([]agentcomposev2.SchedulerRunStatus, 0, len(values))
+	names := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		var status agentcomposev2.SchedulerRunStatus
+		switch name {
+		case model.LoaderRunStatusSucceeded:
+			status = agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED
+		case model.LoaderRunStatusFailed:
+			status = agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED
+		case model.LoaderRunStatusCanceled:
+			status = agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED
+		case model.LoaderRunStatusSkipped:
+			status = agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED
+		default:
+			return nil, nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler prune --status must contain only succeeded, failed, canceled, or skipped")}
+		}
+		seen[name] = struct{}{}
+		statuses = append(statuses, status)
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return statuses, names, nil
+}
+
+func composeSchedulerPruneOutputFromResponse(response *agentcomposev2.PruneSchedulerRunsResponse) composeSchedulerPruneOutput {
+	output := composeSchedulerPruneOutput{
+		RecordScope: "trigger_runs",
+		DryRun:      response.GetDryRun(),
+		Matched:     composeSchedulerPruneStatsFromProto(response.GetMatched()),
+		Removed:     composeSchedulerPruneStatsFromProto(response.GetRemoved()),
+		SkippedRuns: response.GetSkippedRuns(),
+		Residues:    make([]composeSchedulerPruneResidue, 0, len(response.GetResidues())),
+		Warnings:    append([]string(nil), response.GetWarnings()...),
+	}
+	for _, residue := range response.GetResidues() {
+		output.Residues = append(output.Residues, composeSchedulerPruneResidue{
+			LoaderID: displayOpaqueID(residue.GetLoaderId()),
+			RunID:    displayOpaqueID(residue.GetRunId()),
+			Path:     residue.GetPath(),
+			Error:    residue.GetError(),
+		})
+	}
+	return output
+}
+
+func composeSchedulerPruneStatsFromProto(stats *agentcomposev2.SchedulerRunPruneStats) composeSchedulerPruneStats {
+	if stats == nil {
+		return composeSchedulerPruneStats{}
+	}
+	return composeSchedulerPruneStats{
+		Runs:              stats.GetRuns(),
+		LoaderEvents:      stats.GetLoaderEvents(),
+		EventDeliveries:   stats.GetEventDeliveries(),
+		EventSandboxLinks: stats.GetEventSandboxLinks(),
+		ArtifactDirs:      stats.GetArtifactDirs(),
+		ArtifactBytes:     stats.GetArtifactBytes(),
+	}
+}
+
+func writeComposeSchedulerPruneOutput(out io.Writer, asJSON bool, output composeSchedulerPruneOutput) error {
+	if asJSON {
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeCommandOutput(out, append(data, '\n'))
+	}
+	removable := output.Matched.Runs - min(output.Matched.Runs, output.SkippedRuns)
+	if output.DryRun {
+		if _, err := fmt.Fprintf(out, "Dry-run: %d scheduler trigger run(s) matched; %d would be removed, %d skipped.\n", output.Matched.Runs, removable, output.SkippedRuns); err != nil {
+			return err
+		}
+	} else if _, err := fmt.Fprintf(out, "Removed %d scheduler trigger run(s); %d matched, %d skipped.\n", output.Removed.Runs, output.Matched.Runs, output.SkippedRuns); err != nil {
+		return err
+	}
+	related := output.Matched
+	label := "Matched related"
+	if !output.DryRun {
+		related = output.Removed
+		label = "Removed related"
+	}
+	if _, err := fmt.Fprintf(out, "%s: %d loader event(s), %d event delivery row(s), %d event sandbox link(s), %d artifact dir(s), %d artifact byte(s).\n",
+		label, related.LoaderEvents, related.EventDeliveries, related.EventSandboxLinks, related.ArtifactDirs, related.ArtifactBytes); err != nil {
+		return err
+	}
+	if output.DryRun && removable > 0 {
+		if _, err := fmt.Fprintln(out, "Use --force to remove matched scheduler trigger-run history."); err != nil {
+			return err
+		}
+	}
+	for _, residue := range output.Residues {
+		if _, err := fmt.Fprintf(out, "Residue: run=%s path=%s error=%s\n", residue.RunID, residue.Path, residue.Error); err != nil {
+			return err
+		}
+	}
+	return writeStringListSection(out, "Warnings", output.Warnings)
+}

--- a/cmd/agent-compose/cli_scheduler_prune_e2e_test.go
+++ b/cmd/agent-compose/cli_scheduler_prune_e2e_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/do/v2"
+
+	"agent-compose/pkg/identity"
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/configstore"
+)
+
+type schedulerPruneE2EFixture struct {
+	composePath string
+	host        string
+	store       *configstore.ConfigStore
+	scheduler   domain.ProjectSchedulerRecord
+	triggerID   string
+	runID       string
+	eventID     string
+	artifactDir string
+	artifactLen uint64
+}
+
+func TestE2ECLISchedulerPruneLifecycleWithInProcessDaemon(t *testing.T) {
+	fixture := newSchedulerPruneE2EFixture(t)
+	fixture.assertHistoryVisible(t)
+
+	dryRun := fixture.prune(t, false)
+	if !dryRun.DryRun || dryRun.Matched != fixture.wantStats() || dryRun.Removed != (composeSchedulerPruneStats{}) {
+		t.Fatalf("dry-run output=%#v, want matched %#v and no removals", dryRun, fixture.wantStats())
+	}
+	fixture.assertPersisted(t)
+
+	removed := fixture.prune(t, true)
+	if removed.DryRun || removed.Matched != fixture.wantStats() || removed.Removed != fixture.wantStats() || removed.SkippedRuns != 0 || len(removed.Residues) != 0 {
+		t.Fatalf("forced prune output=%#v, want matched and removed %#v", removed, fixture.wantStats())
+	}
+	fixture.assertHistoryRemoved(t)
+}
+
+func newSchedulerPruneE2EFixture(t *testing.T) schedulerPruneE2EFixture {
+	t.Helper()
+	useTestDockerImage(t, "guest:v1")
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: scheduler-prune-test
+agents:
+  reviewer:
+    provider: codex
+    image: guest:v1
+    driver:
+      docker: {}
+    scheduler:
+      triggers:
+        - name: nightly
+          cron: "0 2 * * *"
+          prompt: review nightly
+`)
+	app, cancel := newTestDaemonApp(t, "127.0.0.1:0", nil)
+	t.Cleanup(cancel)
+	server := httptestServer(t, app)
+
+	stdout, stderr, _, exitCode := executeCLICommand("up", "--host", server.URL, "--file", composePath, "--json")
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("up code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+
+	ctx := context.Background()
+	store := do.MustInvoke[*configstore.ConfigStore](app.DI)
+	projects, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "scheduler-prune-test", Limit: 10})
+	if err != nil || len(projects.Projects) != 1 {
+		t.Fatalf("list project result=%#v err=%v", projects, err)
+	}
+	project := projects.Projects[0]
+	schedulers, err := store.ListProjectSchedulers(ctx, project.ID)
+	if err != nil || len(schedulers) != 1 || schedulers[0].ManagedLoaderID == "" {
+		t.Fatalf("list project schedulers=%#v err=%v", schedulers, err)
+	}
+	triggerID, err := domain.StableManagedTriggerID(project.ID, "reviewer", "", "nightly", 0)
+	if err != nil {
+		t.Fatalf("stable trigger id: %v", err)
+	}
+	fixture := schedulerPruneE2EFixture{
+		composePath: composePath,
+		host:        server.URL,
+		store:       store,
+		scheduler:   schedulers[0],
+		triggerID:   triggerID,
+		runID:       identity.NewRandomID(identity.ResourceRun),
+		eventID:     "evt_scheduler_prune_e2e",
+	}
+	fixture.seedHistory(t, app.Config.DataRoot)
+	return fixture
+}
+
+func httptestServer(t *testing.T, app *DaemonApp) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(app.Echo)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func (f *schedulerPruneE2EFixture) seedHistory(t *testing.T, dataRoot string) {
+	t.Helper()
+	ctx := context.Background()
+	completedAt := time.Now().UTC().Add(-time.Hour)
+	f.artifactDir = filepath.Join(dataRoot, "loaders", f.scheduler.ManagedLoaderID, "runs", f.runID)
+	if err := f.store.CreateLoaderRun(ctx, domain.LoaderRunSummary{
+		ID: f.runID, LoaderID: f.scheduler.ManagedLoaderID, TriggerID: f.triggerID,
+		TriggerKind: domain.LoaderTriggerKindCron, TriggerSource: "manual", Status: domain.LoaderRunStatusSucceeded,
+		StartedAt: completedAt.Add(-time.Minute), CompletedAt: completedAt, DurationMs: 60_000,
+		ResultJSON: `{"ok":true}`, PayloadJSON: `{"source":"e2e"}`, ArtifactsDir: f.artifactDir,
+	}); err != nil {
+		t.Fatalf("create loader run: %v", err)
+	}
+	if err := f.store.AddLoaderEvent(ctx, domain.LoaderEvent{
+		ID: "loader-event-scheduler-prune-e2e", LoaderID: f.scheduler.ManagedLoaderID, RunID: f.runID, TriggerID: f.triggerID,
+		Type: "loader.run.completed", Level: "info", Message: "scheduler prune e2e completed", CreatedAt: completedAt,
+	}); err != nil {
+		t.Fatalf("add loader event: %v", err)
+	}
+	if _, err := f.store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: f.eventID, Topic: "scheduler.prune.e2e", Source: domain.TopicEventSourceSystem,
+		DispatchStatus: domain.TopicEventDispatchPublishedToBus, PayloadJSON: `{}`, CreatedAt: completedAt,
+	}); err != nil {
+		t.Fatalf("create topic event: %v", err)
+	}
+	if err := f.store.UpsertEventDelivery(ctx, domain.EventDelivery{
+		EventID: f.eventID, LoaderID: f.scheduler.ManagedLoaderID, TriggerID: f.triggerID, RunID: f.runID,
+		Status: domain.EventDeliveryStatusRunSucceeded, CreatedAt: completedAt, UpdatedAt: completedAt,
+	}); err != nil {
+		t.Fatalf("add event delivery: %v", err)
+	}
+	if err := f.store.AddEventSandboxLink(ctx, domain.EventSandboxLink{
+		EventID: f.eventID, SandboxID: identity.NewRandomID(identity.ResourceSandbox), Relation: "used",
+		LoaderID: f.scheduler.ManagedLoaderID, RunID: f.runID, TriggerID: f.triggerID, CreatedAt: completedAt,
+	}); err != nil {
+		t.Fatalf("add event sandbox link: %v", err)
+	}
+	artifact := []byte("{\"ok\":true}\n")
+	if err := os.MkdirAll(f.artifactDir, 0o700); err != nil {
+		t.Fatalf("create artifact dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(f.artifactDir, "payload.json"), artifact, 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	f.artifactLen = uint64(len(artifact))
+}
+
+func (f schedulerPruneE2EFixture) prune(t *testing.T, force bool) composeSchedulerPruneOutput {
+	t.Helper()
+	args := []string{"scheduler", "prune", "--scheduler", "reviewer", "--trigger", "nightly", "--json", "--host", f.host, "--file", f.composePath}
+	if force {
+		args = append(args, "--force")
+	}
+	stdout, stderr, _, exitCode := executeCLICommand(args...)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("scheduler prune force=%v code/stdout/stderr=%d/%q/%q", force, exitCode, stdout, stderr)
+	}
+	var output composeSchedulerPruneOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode scheduler prune output: %v\n%s", err, stdout)
+	}
+	return output
+}
+
+func (f schedulerPruneE2EFixture) wantStats() composeSchedulerPruneStats {
+	return composeSchedulerPruneStats{
+		Runs: 1, LoaderEvents: 1, EventDeliveries: 1, EventSandboxLinks: 1,
+		ArtifactDirs: 1, ArtifactBytes: f.artifactLen,
+	}
+}
+
+func (f schedulerPruneE2EFixture) assertHistoryVisible(t *testing.T) {
+	t.Helper()
+	runs := f.schedulerRuns(t)
+	if len(runs.Runs) != 1 || runs.Runs[0].RunID != f.runID || runs.Runs[0].TriggerID != f.triggerID || runs.Runs[0].Status != domain.LoaderRunStatusSucceeded {
+		t.Fatalf("scheduler runs=%#v", runs.Runs)
+	}
+	logs := f.schedulerLogs(t)
+	if len(logs.Events) != 1 || logs.Events[0].RunID != f.runID || logs.Events[0].Message != "scheduler prune e2e completed" {
+		t.Fatalf("scheduler logs=%#v", logs.Events)
+	}
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "inspect", f.runID, "--json", "--host", f.host, "--file", f.composePath)
+	var inspected composeSchedulerInspectOutput
+	if exitCode != 0 || stderr != "" || json.Unmarshal([]byte(stdout), &inspected) != nil || inspected.Resource != "run" || inspected.Run == nil || inspected.Run.RunID != f.runID {
+		t.Fatalf("scheduler inspect code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+}
+
+func (f schedulerPruneE2EFixture) assertPersisted(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := f.store.GetLoaderRun(ctx, f.scheduler.ManagedLoaderID, f.runID); err != nil {
+		t.Fatalf("loader run missing after dry-run: %v", err)
+	}
+	if _, err := os.Stat(f.artifactDir); err != nil {
+		t.Fatalf("artifact missing after dry-run: %v", err)
+	}
+	f.assertRelationCounts(t, 1)
+}
+
+func (f schedulerPruneE2EFixture) assertHistoryRemoved(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := f.store.GetLoaderRun(ctx, f.scheduler.ManagedLoaderID, f.runID); err == nil {
+		t.Fatal("loader run still exists after forced prune")
+	}
+	if _, err := os.Stat(f.artifactDir); !os.IsNotExist(err) {
+		t.Fatalf("artifact dir stat after forced prune=%v, want not exist", err)
+	}
+	f.assertRelationCounts(t, 0)
+	if _, err := f.store.GetEvent(ctx, f.eventID); err != nil {
+		t.Fatalf("topic event was removed with scheduler run history: %v", err)
+	}
+	if runs := f.schedulerRuns(t); len(runs.Runs) != 0 {
+		t.Fatalf("scheduler runs after prune=%#v, want empty", runs.Runs)
+	}
+	if logs := f.schedulerLogs(t); strings.Contains(mustJSON(t, logs), f.runID) {
+		t.Fatalf("scheduler logs still contain pruned run %s: %#v", f.runID, logs.Events)
+	}
+	for _, args := range [][]string{{"scheduler", "logs", f.runID}, {"scheduler", "inspect", f.runID}} {
+		stdout, stderr, _, exitCode := executeCLICommand(append(args, "--host", f.host, "--file", f.composePath)...)
+		if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "not found") {
+			t.Fatalf("pruned history command %v code/stdout/stderr=%d/%q/%q", args, exitCode, stdout, stderr)
+		}
+	}
+}
+
+func (f schedulerPruneE2EFixture) assertRelationCounts(t *testing.T, want int) {
+	t.Helper()
+	ctx := context.Background()
+	events, err := f.store.ListLoaderEventsPage(ctx, loaders.LoaderEventPageFilter{
+		LoaderIDs: []string{f.scheduler.ManagedLoaderID}, RunID: f.runID, Limit: 10,
+	})
+	if err != nil || len(events) != want {
+		t.Fatalf("loader events=%#v err=%v, want %d", events, err, want)
+	}
+	deliveries, err := f.store.ListEventDeliveries(ctx, []string{f.eventID})
+	if err != nil || len(deliveries) != want {
+		t.Fatalf("event deliveries=%#v err=%v, want %d", deliveries, err, want)
+	}
+	links, err := f.store.ListEventSandboxLinks(ctx, []string{f.eventID})
+	if err != nil || len(links) != want {
+		t.Fatalf("event sandbox links=%#v err=%v, want %d", links, err, want)
+	}
+}
+
+func (f schedulerPruneE2EFixture) schedulerRuns(t *testing.T) composeSchedulerRunsOutput {
+	t.Helper()
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "runs", "reviewer", "--json", "--host", f.host, "--file", f.composePath)
+	var output composeSchedulerRunsOutput
+	if exitCode != 0 || stderr != "" || json.Unmarshal([]byte(stdout), &output) != nil {
+		t.Fatalf("scheduler runs code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+	return output
+}
+
+func (f schedulerPruneE2EFixture) schedulerLogs(t *testing.T) composeSchedulerLogsOutput {
+	t.Helper()
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "logs", "--scheduler", "reviewer", "--trigger", "nightly", "--json", "--host", f.host, "--file", f.composePath)
+	var output composeSchedulerLogsOutput
+	if exitCode != 0 || stderr != "" || json.Unmarshal([]byte(stdout), &output) != nil {
+		t.Fatalf("scheduler logs code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+	return output
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal test value: %v", err)
+	}
+	return string(data)
+}

--- a/cmd/agent-compose/cli_scheduler_prune_test.go
+++ b/cmd/agent-compose/cli_scheduler_prune_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/pflag"
+
+	"agent-compose/pkg/identity"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestSchedulerPruneCommandFlags(t *testing.T) {
+	command, _, err := newCLISchedulerCommand(&cliOptions{}).Find([]string{"prune"})
+	if err != nil {
+		t.Fatalf("find scheduler prune: %v", err)
+	}
+	var flags []string
+	command.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) { flags = append(flags, flag.Name) })
+	if want := []string{"force", "older-than", "scheduler", "status", "trigger"}; !slices.Equal(flags, want) {
+		t.Fatalf("local prune flags=%#v, want %#v", flags, want)
+	}
+
+	stdout, stderr, runCount, exitCode := executeCLICommand("scheduler", "prune", "--help")
+	if exitCode != 0 || stderr != "" || runCount != 0 {
+		t.Fatalf("help code/stdout/stderr/run=%d/%q/%q/%d", exitCode, stdout, stderr, runCount)
+	}
+	for _, want := range []string{"--scheduler", "--trigger", "--status", "--older-than", "--force", "--json", "dry-run"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("help missing %q:\n%s", want, stdout)
+		}
+	}
+	for _, absent := range []string{"--all-runs", "--limit", "--keep-last"} {
+		if strings.Contains(stdout, absent) {
+			t.Fatalf("help contains unsupported %q:\n%s", absent, stdout)
+		}
+	}
+}
+
+func TestSchedulerPruneRejectsArgumentsAndInvalidFilters(t *testing.T) {
+	composePath := writeSchedulerPruneCompose(t)
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "position argument", args: []string{"extra"}, want: "unknown command"},
+		{name: "running status", args: []string{"--status", "running"}, want: "must contain only succeeded, failed, canceled, or skipped"},
+		{name: "pending status", args: []string{"--status", "pending"}, want: "must contain only succeeded, failed, canceled, or skipped"},
+		{name: "invalid older than", args: []string{"--older-than", "zero"}, want: "invalid --older-than"},
+		{name: "zero older than", args: []string{"--older-than", "0s"}, want: "duration must be positive"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := append([]string{"scheduler", "prune"}, test.args...)
+			args = append(args, "--file", composePath)
+			stdout, stderr, runCount, exitCode := executeCLICommand(args...)
+			if exitCode != exitCodeUsage || stdout != "" || runCount != 0 || !strings.Contains(stderr, test.want) {
+				t.Fatalf("code/stdout/stderr/run=%d/%q/%q/%d, want %q", exitCode, stdout, stderr, runCount, test.want)
+			}
+		})
+	}
+}
+
+func TestIntegrationCLISchedulerPruneMapsFiltersAndJSONStats(t *testing.T) {
+	composePath := writeSchedulerPruneCompose(t)
+	var captured *agentcomposev2.PruneSchedulerRunsRequest
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		pruneSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error) {
+			captured = req.Msg
+			return connect.NewResponse(&agentcomposev2.PruneSchedulerRunsResponse{
+				DryRun: true,
+				Matched: &agentcomposev2.SchedulerRunPruneStats{
+					Runs: 2, LoaderEvents: 5, EventDeliveries: 1, EventSandboxLinks: 1, ArtifactDirs: 2, ArtifactBytes: 19,
+				},
+			}), nil
+		},
+	}})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand(
+		"scheduler", "prune", "--scheduler", "reviewer", "--trigger", "nightly",
+		"--status", " failed,SUCCEEDED,failed ", "--older-than", "7d", "--json",
+		"--host", server.URL, "--file", composePath,
+	)
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("prune code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+	if captured == nil || captured.GetAgentName() != "reviewer" || captured.GetTriggerId() == "" ||
+		!slices.Equal(captured.GetStatus(), []agentcomposev2.SchedulerRunStatus{
+			agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED,
+			agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+		}) || captured.GetOlderThanSeconds() != 7*24*60*60 || captured.GetForce() {
+		t.Fatalf("request=%#v", captured)
+	}
+	var output composeSchedulerPruneOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if !output.DryRun || output.Matched.Runs != 2 || output.Matched.LoaderEvents != 5 || output.Matched.ArtifactBytes != 19 ||
+		output.Scheduler != "reviewer" || output.TriggerID != captured.GetTriggerId() || !slices.Equal(output.Statuses, []string{"failed", "succeeded"}) {
+		t.Fatalf("output=%#v", output)
+	}
+}
+
+func TestIntegrationCLISchedulerPruneSupportsHistoricalTriggerID(t *testing.T) {
+	composePath := writeSchedulerPruneCompose(t)
+	const historicalTriggerID = "removed-trigger"
+	probeRunID := identity.NewRandomID(identity.ResourceRun)
+	var pruneRequest *agentcomposev2.PruneSchedulerRunsRequest
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+			if req.Msg.GetAgentName() == "reviewer" && req.Msg.GetTriggerId() == historicalTriggerID {
+				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+					RunId: probeRunID, AgentName: "reviewer", TriggerId: historicalTriggerID,
+				}}}), nil
+			}
+			return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{}), nil
+		},
+		pruneSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error) {
+			pruneRequest = req.Msg
+			return connect.NewResponse(&agentcomposev2.PruneSchedulerRunsResponse{DryRun: true, Matched: &agentcomposev2.SchedulerRunPruneStats{Runs: 1}}), nil
+		},
+	}})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "prune", "--scheduler", "reviewer", "--trigger", historicalTriggerID, "--host", server.URL, "--file", composePath)
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, "1 scheduler trigger run(s) matched") {
+		t.Fatalf("historical prune code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+	if pruneRequest == nil || pruneRequest.GetAgentName() != "reviewer" || pruneRequest.GetTriggerId() != historicalTriggerID {
+		t.Fatalf("prune request=%#v", pruneRequest)
+	}
+}
+
+func TestIntegrationCLISchedulerPruneForcePartialResultIsNonZero(t *testing.T) {
+	composePath := writeSchedulerPruneCompose(t)
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		pruneSchedulerRuns: func(context.Context, *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error) {
+			return connect.NewResponse(&agentcomposev2.PruneSchedulerRunsResponse{
+				Matched:     &agentcomposev2.SchedulerRunPruneStats{Runs: 3, ArtifactDirs: 2},
+				Removed:     &agentcomposev2.SchedulerRunPruneStats{Runs: 2, ArtifactDirs: 1},
+				SkippedRuns: 1,
+				Residues:    []*agentcomposev2.SchedulerRunPruneResidue{{LoaderId: "loader-1", RunId: "run-1", Path: "/runs/run-1", Error: "permission denied"}},
+			}), nil
+		},
+	}})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "prune", "--force", "--json", "--host", server.URL, "--file", composePath)
+	if exitCode != exitCodeGeneral || !strings.Contains(stderr, "1 skipped run(s) and 1 artifact residue(s)") {
+		t.Fatalf("partial prune code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+	var output composeSchedulerPruneOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil || output.Removed.Runs != 2 || output.SkippedRuns != 1 || len(output.Residues) != 1 {
+		t.Fatalf("partial output=%#v err=%v", output, err)
+	}
+}
+
+func TestIntegrationCLISchedulerPruneUnimplementedDaemon(t *testing.T) {
+	composePath := writeSchedulerPruneCompose(t)
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{}})
+	defer server.Close()
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "prune", "--host", server.URL, "--file", composePath)
+	if exitCode != exitCodeUnsupported || stdout != "" || !strings.Contains(stderr, "daemon does not support scheduler run pruning") {
+		t.Fatalf("unimplemented code/stdout/stderr=%d/%q/%q", exitCode, stdout, stderr)
+	}
+}
+
+func writeSchedulerPruneCompose(t *testing.T) string {
+	t.Helper()
+	return writeComposeFile(t, t.TempDir(), `
+name: scheduler-prune-test
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      triggers:
+        - name: nightly
+          cron: "0 2 * * *"
+          prompt: review nightly
+`)
+}

--- a/cmd/agent-compose/cli_scheduler_query.go
+++ b/cmd/agent-compose/cli_scheduler_query.go
@@ -9,9 +9,8 @@ import (
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -55,39 +54,6 @@ func runComposeSchedulerListCommand(cmd *cobra.Command, cli cliOptions, options 
 		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
 	}
 	return writeSchedulerListText(cmd.OutOrStdout(), output, options.Verbose)
-}
-
-func resolveSchedulerRunID(ctx context.Context, client agentcomposev2connect.ResourceServiceClient, projectID, runRef string) (string, error) {
-	runRef = strings.TrimSpace(runRef)
-	if identity.IsID(runRef) || isLegacySchedulerRunID(runRef) {
-		return runRef, nil
-	}
-	if strings.Contains(runRef, "-") {
-		return "", schedulerResourceNotFoundError{kind: "run", ref: runRef}
-	}
-	resp, err := client.ResolveID(ctx, connect.NewRequest(&agentcomposev2.ResolveResourceIDRequest{
-		Id:    runRef,
-		Kinds: []agentcomposev2.ResourceKind{agentcomposev2.ResourceKind_RESOURCE_KIND_RUN},
-	}))
-	if err != nil {
-		if connect.CodeOf(err) == connect.CodeNotFound {
-			return "", schedulerResourceNotFoundError{kind: "run", ref: runRef}
-		}
-		return "", commandExitErrorForConnect(fmt.Errorf("resolve scheduler run %s: %w", runRef, err))
-	}
-	matches := make([]string, 0, len(resp.Msg.GetTargets()))
-	for _, target := range resp.Msg.GetTargets() {
-		if target.GetKind() == agentcomposev2.ResourceKind_RESOURCE_KIND_RUN && (target.GetProjectId() == "" || target.GetProjectId() == projectID) {
-			matches = append(matches, target.GetId())
-		}
-	}
-	if len(matches) == 0 {
-		return "", schedulerResourceNotFoundError{kind: "run", ref: runRef}
-	}
-	if len(matches) > 1 {
-		return "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler run reference %q is ambiguous", runRef)}
-	}
-	return matches[0], nil
 }
 
 func shouldResolveSchedulerRunRef(ref string) bool {
@@ -144,200 +110,162 @@ func listComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, no
 		}
 		agentFilter = scheduler.AgentName
 	}
-	if limit == 0 {
-		limit = 20
-	}
 	runStatus, statusText, statusErr := parseSchedulerRunStatusFilter(status)
 	if statusErr != nil {
 		return nil, statusErr
 	}
 	triggerRef = strings.TrimSpace(triggerRef)
+	triggerID := ""
+	if triggerRef != "" {
+		resolvedTriggerID, resolveErr := resolveSchedulerTriggerIDForQuery(ctx, clients, normalized, projectID, agentFilter, triggerRef)
+		if resolveErr != nil {
+			if errors.Is(resolveErr, domain.ErrAmbiguous) && agentFilter == "" {
+				resolveErr = fmt.Errorf("%w; specify a scheduler argument to disambiguate", resolveErr)
+			}
+			if isSchedulerResourceNotFound(resolveErr) || errors.Is(resolveErr, domain.ErrAmbiguous) {
+				return nil, commandExitError{Code: exitCodeUsage, Err: resolveErr}
+			}
+			return nil, resolveErr
+		}
+		triggerID = resolvedTriggerID
+	}
 	items := make([]composeSchedulerRunItem, 0)
+	cursor := ""
+	seenCursors := make(map[string]struct{})
+	for {
+		pageLimit := uint32(500)
+		if limit > 0 && limit-uint32(len(items)) < pageLimit {
+			pageLimit = limit - uint32(len(items))
+		}
+		if pageLimit == 0 {
+			return items, nil
+		}
+		resp, err := clients.project.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
+			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentFilter, TriggerId: triggerID, Status: runStatus, Limit: pageLimit, Cursor: cursor,
+		}))
+		if err != nil {
+			if connect.CodeOf(err) == connect.CodeUnimplemented {
+				return nil, commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support complete scheduler run queries; upgrade the daemon")}
+			}
+			return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs: %w", err))
+		}
+		for _, run := range resp.Msg.GetRuns() {
+			if strings.TrimSpace(run.GetTriggerId()) == "" || (agentFilter != "" && run.GetAgentName() != agentFilter) ||
+				(triggerID != "" && run.GetTriggerId() != triggerID) || (statusText != "" && schedulerRunStatusText(run.GetStatus()) != statusText) {
+				continue
+			}
+			scheduler, resolveErr := resolveComposeScheduler(normalized, projectID, run.GetAgentName())
+			if resolveErr != nil {
+				continue
+			}
+			items = append(items, schedulerRuntimeRunItem(scheduler.SchedulerID, scheduler.ManagedLoaderID, run))
+			if limit > 0 && uint32(len(items)) >= limit {
+				return items, nil
+			}
+		}
+		next := strings.TrimSpace(resp.Msg.GetNextCursor())
+		if next == "" {
+			return items, nil
+		}
+		if next == cursor {
+			return nil, fmt.Errorf("daemon returned a repeated scheduler run cursor")
+		}
+		if _, ok := seenCursors[next]; ok {
+			return nil, fmt.Errorf("daemon returned a repeated scheduler run cursor")
+		}
+		seenCursors[next] = struct{}{}
+		cursor = next
+	}
+}
+
+func resolveSchedulerTriggerIDForQuery(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, agentFilter, triggerRef string) (string, error) {
+	triggers, err := listComposeSchedulerTriggers(ctx, clients, normalized, projectID, agentFilter)
+	if err != nil {
+		return "", err
+	}
+	trigger, err := resolveSchedulerTriggerFromItems(triggers, triggerRef)
+	if err == nil {
+		return firstNonEmptyString(trigger.RawTriggerID, trigger.TriggerID), nil
+	}
+	if !isSchedulerResourceNotFound(err) {
+		return "", err
+	}
+
+	historicalID, found, historicalErr := resolveHistoricalSchedulerTriggerID(ctx, clients.project, normalized, projectID, agentFilter, triggerRef)
+	if historicalErr != nil {
+		return "", historicalErr
+	}
+	if !found {
+		return "", err
+	}
+	return historicalID, nil
+}
+
+func resolveHistoricalSchedulerTriggerID(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, normalized *compose.NormalizedProjectSpec, projectID, agentFilter, rawRef string) (string, bool, error) {
+	triggerID := strings.TrimSpace(rawRef)
+	if hash, err := identity.Hash(triggerID); err == nil {
+		triggerID = hash
+	}
+
+	matchedAgents := make([]string, 0, 1)
 	for _, agent := range normalized.Agents {
 		if agent.Scheduler == nil || (agentFilter != "" && agent.Name != agentFilter) {
 			continue
 		}
-		schedulerID, idErr := domain.StableProjectSchedulerID(projectID, agent.Name, "")
-		if idErr != nil {
-			return nil, idErr
-		}
-		loaderID, idErr := domain.StableManagedLoaderID(projectID, agent.Name, "")
-		if idErr != nil {
-			return nil, idErr
-		}
-		runsResp, listErr := clients.run.ListRuns(ctx, connect.NewRequest(&agentcomposev2.ListRunsRequest{
-			ProjectId:   projectID,
-			AgentName:   agent.Name,
-			SchedulerId: schedulerID,
-			Status:      runStatus,
-			Limit:       limit,
+		resp, err := client.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
+			Project:   &agentcomposev2.ProjectRef{ProjectId: projectID},
+			AgentName: agent.Name,
+			TriggerId: triggerID,
+			Limit:     1,
 		}))
-		if listErr != nil && connect.CodeOf(listErr) != connect.CodeUnimplemented {
-			return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agent.Name, listErr))
-		}
-		var triggers []composeSchedulerTriggerItem
-		if triggerRef != "" {
-			triggers, listErr = listComposeSchedulerTriggers(ctx, clients, normalized, projectID, agent.Name)
-			if listErr != nil {
-				return nil, listErr
+		if err != nil {
+			if connect.CodeOf(err) == connect.CodeUnimplemented {
+				return "", false, commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support complete scheduler run queries; upgrade the daemon")}
 			}
+			return "", false, commandExitErrorForConnect(fmt.Errorf("probe scheduler run history for trigger %s: %w", triggerID, err))
 		}
-		var projectRuns []*agentcomposev2.RunSummary
-		if runsResp != nil {
-			projectRuns = runsResp.Msg.GetRuns()
-		}
-		for _, run := range projectRuns {
-			if statusText != "" && strings.ToLower(runStatusText(run.GetStatus())) != statusText {
-				continue
+		for _, run := range resp.Msg.GetRuns() {
+			if run.GetAgentName() == agent.Name && run.GetTriggerId() == triggerID {
+				matchedAgents = append(matchedAgents, agent.Name)
+				break
 			}
-			if triggerRef != "" && !resourceRefMatches(triggerRef, run.GetTriggerId()) {
-				matched := false
-				for _, trigger := range triggers {
-					if resourceRefMatches(triggerRef, trigger.Name, trigger.TriggerID, trigger.RawTriggerID) && resourceRefMatches(run.GetTriggerId(), trigger.TriggerID, trigger.RawTriggerID) {
-						matched = true
-						break
-					}
-				}
-				if !matched {
-					continue
-				}
-			}
-			items = append(items, schedulerRunItem(agent.Name, schedulerID, loaderID, run))
-		}
-		runtimeRuns, runtimeErr := listSchedulerRuntimeRuns(ctx, clients.project, projectID, agent.Name, schedulerID, loaderID, 500)
-		if runtimeErr != nil {
-			return nil, runtimeErr
-		}
-		for _, run := range runtimeRuns {
-			if statusText != "" && run.Status != statusText {
-				continue
-			}
-			if triggerRef != "" && !schedulerRunTriggerMatches(run.TriggerID, triggerRef, triggers) {
-				continue
-			}
-			items = append(items, run)
 		}
 	}
-	sort.SliceStable(items, func(i, j int) bool {
-		if items[i].StartedAt == items[j].StartedAt {
-			return items[i].RunID > items[j].RunID
-		}
-		return items[i].StartedAt > items[j].StartedAt
-	})
-	if uint32(len(items)) > limit {
-		items = items[:limit]
+	if len(matchedAgents) == 0 {
+		return "", false, nil
 	}
-	return items, nil
+	if len(matchedAgents) > 1 {
+		return "", false, domain.ResourceError(domain.ErrAmbiguous, "historical scheduler trigger", rawRef, fmt.Sprintf("historical scheduler trigger ID %q is ambiguous", rawRef), nil)
+	}
+	return triggerID, true, nil
 }
 
-func schedulerRunTriggerMatches(runTriggerID, ref string, triggers []composeSchedulerTriggerItem) bool {
-	if resourceRefMatches(ref, runTriggerID) {
-		return true
-	}
-	for _, trigger := range triggers {
-		if resourceRefMatches(ref, trigger.Name, trigger.TriggerID, trigger.RawTriggerID) && resourceRefMatches(runTriggerID, trigger.TriggerID, trigger.RawTriggerID) {
-			return true
-		}
-	}
-	return false
-}
-
-func parseSchedulerRunStatusFilter(value string) (agentcomposev2.RunStatus, string, error) {
+func parseSchedulerRunStatusFilter(value string) (agentcomposev2.SchedulerRunStatus, string, error) {
 	value = strings.ToLower(strings.TrimSpace(value))
-	statuses := map[string]agentcomposev2.RunStatus{
-		"":          agentcomposev2.RunStatus_RUN_STATUS_UNSPECIFIED,
-		"pending":   agentcomposev2.RunStatus_RUN_STATUS_PENDING,
-		"running":   agentcomposev2.RunStatus_RUN_STATUS_RUNNING,
-		"succeeded": agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
-		"failed":    agentcomposev2.RunStatus_RUN_STATUS_FAILED,
-		"canceled":  agentcomposev2.RunStatus_RUN_STATUS_CANCELED,
-		"skipped":   agentcomposev2.RunStatus_RUN_STATUS_UNSPECIFIED,
+	statuses := map[string]agentcomposev2.SchedulerRunStatus{
+		"":          agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED,
+		"running":   agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING,
+		"succeeded": agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+		"failed":    agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED,
+		"canceled":  agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED,
+		"skipped":   agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED,
 	}
 	status, ok := statuses[value]
 	if !ok {
-		return agentcomposev2.RunStatus_RUN_STATUS_UNSPECIFIED, "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler runs --status must be pending, running, succeeded, failed, canceled, or skipped")}
+		return agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED, "", commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler runs --status must be running, succeeded, failed, canceled, or skipped")}
 	}
 	return status, value, nil
 }
 
-func schedulerRunItem(agentName, schedulerID, loaderID string, run *agentcomposev2.RunSummary) composeSchedulerRunItem {
-	sandboxIDs := []string(nil)
-	if strings.TrimSpace(run.GetSandboxId()) != "" {
-		sandboxIDs = []string{run.GetSandboxId()}
-	}
-	return composeSchedulerRunItem{
-		RunID:           run.GetRunId(),
-		RunShortID:      shortOpaqueID(run.GetRunId()),
-		AgentName:       agentName,
-		SchedulerID:     schedulerID,
-		ManagedLoaderID: loaderID,
-		TriggerID:       run.GetTriggerId(),
-		Status:          runStatusText(run.GetStatus()),
-		SandboxIDs:      sandboxIDs,
-		StartedAt:       run.GetStartedAt(),
-		CompletedAt:     run.GetCompletedAt(),
-		DurationMs:      run.GetDurationMs(),
-		Error:           run.GetError(),
-		rawRun:          run,
-	}
-}
-
-func listSchedulerRunEvents(ctx context.Context, clients cliServiceClients, projectID string, run composeSchedulerRunItem) ([]composeSchedulerLogEvent, error) {
-	if run.schedulerRuntime {
-		return listSchedulerRuntimeLogEvents(ctx, clients.project, projectID, run)
-	}
-	events := make([]composeSchedulerLogEvent, 0)
-	sandboxID := ""
-	if len(run.SandboxIDs) > 0 {
-		sandboxID = run.SandboxIDs[0]
-	}
-	cursor := ""
-	for {
-		resp, err := clients.run.ListRunEvents(ctx, connect.NewRequest(&agentcomposev2.ListRunEventsRequest{RunId: run.RunID, Limit: 500, Cursor: cursor}))
-		if err != nil {
-			return nil, err
-		}
-		for _, event := range resp.Msg.GetEvents() {
-			events = append(events, composeSchedulerLogEvent{
-				ID:          event.GetId(),
-				RunID:       event.GetRunId(),
-				AgentName:   run.AgentName,
-				TriggerID:   run.TriggerID,
-				Type:        schedulerRunEventType(event.GetKind()),
-				Level:       "info",
-				Message:     firstNonEmptyString(event.GetText(), event.GetName()),
-				PayloadJSON: event.GetPayloadJson(),
-				SandboxID:   sandboxID,
-				CreatedAt:   formatProtoTimestamp(event.GetCreatedAt()),
-			})
-		}
-		nextCursor := strings.TrimSpace(resp.Msg.GetNextCursor())
-		if nextCursor == "" || nextCursor == cursor {
-			break
-		}
-		cursor = nextCursor
-	}
-	sort.SliceStable(events, func(i, j int) bool { return events[i].CreatedAt < events[j].CreatedAt })
-	return events, nil
-}
-
 func listSchedulerRuntimeRuns(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, limit uint32) ([]composeSchedulerRunItem, error) {
 	runs, err := listSchedulerRunsFromAPI(ctx, client, projectID, agentName, schedulerID, loaderID, limit)
-	if err == nil {
-		legacy, legacyErr := listLegacySchedulerRuntimeRuns(ctx, client, projectID, agentName, schedulerID, loaderID, limit)
-		if legacyErr == nil {
-			return mergeSchedulerRuntimeRuns(runs, legacy), nil
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeUnimplemented {
+			return nil, commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support scheduler run queries; upgrade the daemon")}
 		}
-		return runs, nil
-	}
-	if connect.CodeOf(err) != connect.CodeUnimplemented {
 		return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agentName, err))
 	}
-	legacy, legacyErr := listLegacySchedulerRuntimeRuns(ctx, client, projectID, agentName, schedulerID, loaderID, limit)
-	if legacyErr != nil {
-		return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agentName, err))
-	}
-	return legacy, nil
+	return runs, nil
 }
 
 func listSchedulerRunsFromAPI(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, limit uint32) ([]composeSchedulerRunItem, error) {
@@ -359,6 +287,9 @@ func listSchedulerRunsFromAPI(ctx context.Context, client agentcomposev2connect.
 			return nil, err
 		}
 		for _, run := range resp.Msg.GetRuns() {
+			if strings.TrimSpace(run.GetTriggerId()) == "" {
+				continue
+			}
 			runs = append(runs, schedulerRuntimeRunItem(schedulerID, loaderID, run))
 			if uint32(len(runs)) == limit {
 				return runs, nil
@@ -379,79 +310,23 @@ func listSchedulerRunsFromAPI(ctx context.Context, client agentcomposev2connect.
 
 func schedulerRuntimeRunItem(schedulerID, loaderID string, run *agentcomposev2.SchedulerRun) composeSchedulerRunItem {
 	return composeSchedulerRunItem{
-		RunID:            run.GetRunId(),
-		RunShortID:       shortOpaqueID(run.GetRunId()),
-		AgentName:        run.GetAgentName(),
-		SchedulerID:      firstNonEmptyString(run.GetSchedulerId(), schedulerID),
-		ManagedLoaderID:  loaderID,
-		TriggerID:        run.GetTriggerId(),
-		TriggerKind:      run.GetTriggerKind(),
-		TriggerSource:    run.GetTriggerSource(),
-		Status:           schedulerRunStatusText(run.GetStatus()),
-		StartedAt:        formatProtoTimestamp(run.GetStartedAt()),
-		CompletedAt:      formatProtoTimestamp(run.GetCompletedAt()),
-		DurationMs:       run.GetDurationMs(),
-		Error:            run.GetError(),
-		ResultJSON:       run.GetResultJson(),
-		PayloadJSON:      run.GetPayloadJson(),
-		ArtifactsDir:     run.GetArtifactsDir(),
-		schedulerRuntime: true,
-	}
-}
-
-func listLegacySchedulerRuntimeRuns(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, eventLimit uint32) ([]composeSchedulerRunItem, error) {
-	resp, err := client.ListSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, Limit: eventLimit,
-	}))
-	if err != nil {
-		return nil, err
-	}
-	byID := make(map[string]*composeSchedulerRunItem)
-	for _, event := range resp.Msg.GetEvents() {
-		runID := strings.TrimSpace(event.GetRunId())
-		if runID == "" {
-			continue
-		}
-		run := byID[runID]
-		if run == nil {
-			run = &composeSchedulerRunItem{RunID: runID, RunShortID: shortOpaqueID(runID), AgentName: agentName, SchedulerID: schedulerID, ManagedLoaderID: loaderID, TriggerID: event.GetTriggerId(), Status: "running", schedulerRuntime: true}
-			byID[runID] = run
-		}
-		applySchedulerRuntimeEvent(run, event)
-	}
-	runs := make([]composeSchedulerRunItem, 0, len(byID))
-	for _, run := range byID {
-		if run.StartedAt != "" && run.CompletedAt != "" {
-			started, startErr := time.Parse(time.RFC3339Nano, run.StartedAt)
-			completed, completeErr := time.Parse(time.RFC3339Nano, run.CompletedAt)
-			if startErr == nil && completeErr == nil {
-				run.DurationMs = completed.Sub(started).Milliseconds()
-			}
-		}
-		runs = append(runs, *run)
-	}
-	return runs, nil
-}
-
-func applySchedulerRuntimeEvent(run *composeSchedulerRunItem, event *agentcomposev2.SchedulerEvent) {
-	eventType := strings.TrimSpace(event.GetType())
-	createdAt := formatProtoTimestamp(event.GetCreatedAt())
-	switch eventType {
-	case "loader.run.started":
-		run.StartedAt = createdAt
-	case "loader.run.completed":
-		run.Status, run.CompletedAt = "succeeded", createdAt
-	case "loader.run.failed":
-		run.Status, run.CompletedAt, run.Error = "failed", createdAt, event.GetMessage()
-	}
-	var payload map[string]any
-	if json.Unmarshal([]byte(event.GetPayloadJson()), &payload) == nil {
-		if sandboxID, ok := payload["sandboxId"].(string); ok && sandboxID != "" && !slices.Contains(run.SandboxIDs, sandboxID) {
-			run.SandboxIDs = append(run.SandboxIDs, sandboxID)
-		}
-		if result, ok := payload["resultJson"].(string); ok {
-			run.ResultJSON = result
-		}
+		RunID:           run.GetRunId(),
+		RunShortID:      shortOpaqueID(run.GetRunId()),
+		AgentName:       run.GetAgentName(),
+		SchedulerID:     firstNonEmptyString(run.GetSchedulerId(), schedulerID),
+		ManagedLoaderID: loaderID,
+		TriggerID:       run.GetTriggerId(),
+		TriggerKind:     run.GetTriggerKind(),
+		TriggerSource:   run.GetTriggerSource(),
+		Status:          schedulerRunStatusText(run.GetStatus()),
+		SandboxIDs:      append([]string(nil), run.GetSandboxIds()...),
+		StartedAt:       formatProtoTimestamp(run.GetStartedAt()),
+		CompletedAt:     formatProtoTimestamp(run.GetCompletedAt()),
+		DurationMs:      run.GetDurationMs(),
+		Error:           run.GetError(),
+		ResultJSON:      run.GetResultJson(),
+		PayloadJSON:     run.GetPayloadJson(),
+		ArtifactsDir:    run.GetArtifactsDir(),
 	}
 }
 
@@ -469,52 +344,67 @@ func resolveSchedulerRuntimeRun(ctx context.Context, client agentcomposev2connec
 		item := schedulerRuntimeRunItem(run.GetSchedulerId(), loaderID, run)
 		return &item, nil
 	}
-	if err != nil && connect.CodeOf(err) != connect.CodeNotFound && connect.CodeOf(err) != connect.CodeUnimplemented {
+	if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
 		return nil, commandExitErrorForConnect(fmt.Errorf("get scheduler run %s: %w", ref, err))
 	}
-	matches := make([]composeSchedulerRunItem, 0)
-	for _, agent := range normalized.Agents {
-		if agent.Scheduler == nil {
-			continue
-		}
-		schedulerID, _ := domain.StableProjectSchedulerID(projectID, agent.Name, "")
-		loaderID, _ := domain.StableManagedLoaderID(projectID, agent.Name, "")
-		runs, err := listSchedulerRuntimeRuns(ctx, client, projectID, agent.Name, schedulerID, loaderID, 500)
-		if err != nil {
-			return nil, err
-		}
-		for _, run := range runs {
-			if resourceRefMatches(ref, run.RunID, run.RunShortID) {
-				matches = append(matches, run)
-			}
-		}
-	}
-	if len(matches) == 1 {
-		return &matches[0], nil
-	}
-	if len(matches) > 1 {
-		return nil, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler run reference %q is ambiguous", ref)}
-	}
+	_ = normalized
 	return nil, schedulerResourceNotFoundError{kind: "run", ref: ref}
 }
 
-func listSchedulerRuntimeLogEvents(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID string, run composeSchedulerRunItem) ([]composeSchedulerLogEvent, error) {
-	resp, err := client.ListSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: run.AgentName, Limit: 500}))
-	if err != nil {
-		return nil, err
-	}
+func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, triggerID, runID string, tail int) ([]composeSchedulerLogEvent, error) {
 	events := make([]composeSchedulerLogEvent, 0)
-	for _, event := range resp.Msg.GetEvents() {
-		if event.GetRunId() == run.RunID {
-			events = append(events, composeSchedulerLogEvent{ID: event.GetId(), RunID: run.RunID, AgentName: run.AgentName, TriggerID: event.GetTriggerId(), Type: schedulerDisplayEventType(event.GetType()), Level: event.GetLevel(), Message: event.GetMessage(), PayloadJSON: event.GetPayloadJson(), CreatedAt: formatProtoTimestamp(event.GetCreatedAt())})
-		}
+	if tail == 0 {
+		return events, nil
 	}
-	sort.SliceStable(events, func(i, j int) bool { return events[i].CreatedAt < events[j].CreatedAt })
+	cursor := ""
+	seenCursors := make(map[string]struct{})
+	for {
+		pageLimit := uint32(500)
+		if tail > 0 && tail-len(events) < int(pageLimit) {
+			pageLimit = uint32(tail - len(events))
+		}
+		if pageLimit == 0 {
+			break
+		}
+		resp, err := client.ListProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
+			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, TriggerId: triggerID, RunId: runID, Limit: pageLimit, Cursor: cursor,
+		}))
+		if err != nil {
+			if connect.CodeOf(err) == connect.CodeUnimplemented {
+				return nil, commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support complete scheduler log queries; upgrade the daemon")}
+			}
+			return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler logs: %w", err))
+		}
+		for _, event := range resp.Msg.GetEvents() {
+			events = append(events, composeSchedulerLogEvent{
+				ID: event.GetId(), RunID: event.GetRunId(), AgentName: event.GetAgentName(), SchedulerID: event.GetSchedulerId(), TriggerID: event.GetTriggerId(),
+				Type: schedulerDisplayEventType(event.GetType()), Level: event.GetLevel(), Message: event.GetMessage(), PayloadJSON: event.GetPayloadJson(),
+				SandboxID: event.GetLinkedSandboxId(), CellID: event.GetLinkedCellId(), AgentThreadID: event.GetLinkedAgentThreadId(), CreatedAt: formatProtoTimestamp(event.GetCreatedAt()),
+			})
+			if tail > 0 && len(events) >= tail {
+				break
+			}
+		}
+		if tail > 0 && len(events) >= tail {
+			break
+		}
+		next := strings.TrimSpace(resp.Msg.GetNextCursor())
+		if next == "" {
+			break
+		}
+		if next == cursor {
+			return nil, fmt.Errorf("daemon returned a repeated scheduler event cursor")
+		}
+		if _, ok := seenCursors[next]; ok {
+			return nil, fmt.Errorf("daemon returned a repeated scheduler event cursor")
+		}
+		seenCursors[next] = struct{}{}
+		cursor = next
+	}
+	for left, right := 0, len(events)-1; left < right; left, right = left+1, right-1 {
+		events[left], events[right] = events[right], events[left]
+	}
 	return events, nil
-}
-
-func schedulerRunEventType(kind agentcomposev2.RunEventKind) string {
-	return "scheduler." + strings.ReplaceAll(strings.TrimPrefix(strings.ToLower(kind.String()), "run_event_kind_"), "_", ".")
 }
 
 func resolveComposeScheduler(normalized *compose.NormalizedProjectSpec, projectID, ref string) (*composeSchedulerItem, error) {
@@ -556,7 +446,7 @@ func resolveSchedulerTriggerFromItems(items []composeSchedulerTriggerItem, ref s
 		return &matches[0], nil
 	}
 	if len(matches) > 1 {
-		return nil, fmt.Errorf("scheduler trigger reference %q is ambiguous", ref)
+		return nil, domain.ResourceError(domain.ErrAmbiguous, "scheduler trigger", ref, fmt.Sprintf("scheduler trigger reference %q is ambiguous", ref), nil)
 	}
 	return nil, schedulerResourceNotFoundError{kind: "trigger", ref: ref}
 }
@@ -566,28 +456,23 @@ func resolveComposeSchedulerTrigger(ctx context.Context, clients cliServiceClien
 	if strings.TrimSpace(agentName) == "" || triggerRef == "" {
 		return composeSchedulerTriggerItem{}, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger requires non-empty agent and trigger")}
 	}
-	resolvedAgentName, err := resolveComposeAgentNameFromSpec(normalized, projectID, agentName)
+	scheduler, err := resolveComposeScheduler(normalized, projectID, agentName)
 	if err != nil {
 		return composeSchedulerTriggerItem{}, err
 	}
-	agentName = resolvedAgentName
+	agentName = scheduler.AgentName
 	items, err := listComposeSchedulerTriggers(ctx, clients, normalized, projectID, agentName)
 	if err != nil {
 		return composeSchedulerTriggerItem{}, err
 	}
-	var matches []composeSchedulerTriggerItem
-	for _, item := range items {
-		if item.TriggerID == triggerRef || item.RawTriggerID == triggerRef || (item.Name != "" && item.Name == triggerRef) {
-			matches = append(matches, item)
-		}
-	}
-	if len(matches) == 0 {
+	trigger, err := resolveSchedulerTriggerFromItems(items, triggerRef)
+	if isSchedulerResourceNotFound(err) {
 		return composeSchedulerTriggerItem{}, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger %q not found for agent %q", triggerRef, agentName)}
 	}
-	if len(matches) > 1 {
+	if err != nil {
 		return composeSchedulerTriggerItem{}, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler trigger %q for agent %q is ambiguous; use the trigger id", triggerRef, agentName)}
 	}
-	return matches[0], nil
+	return *trigger, nil
 }
 
 func schedulerTriggerItemFromDeclarative(agentName, schedulerID string, schedulerEnabled bool, triggerID string, trigger compose.NormalizedTriggerSpec) composeSchedulerTriggerItem {
@@ -636,31 +521,30 @@ type composeSchedulerItem struct {
 }
 
 type composeSchedulerRunItem struct {
-	RunID            string   `json:"run_id"`
-	RunShortID       string   `json:"run_short_id"`
-	AgentName        string   `json:"agent_name"`
-	SchedulerID      string   `json:"scheduler_id"`
-	ManagedLoaderID  string   `json:"managed_loader_id"`
-	TriggerID        string   `json:"trigger_id,omitempty"`
-	TriggerKind      string   `json:"trigger_kind,omitempty"`
-	TriggerSource    string   `json:"trigger_source,omitempty"`
-	Status           string   `json:"status"`
-	SandboxIDs       []string `json:"sandbox_ids,omitempty"`
-	StartedAt        string   `json:"started_at,omitempty"`
-	CompletedAt      string   `json:"completed_at,omitempty"`
-	DurationMs       int64    `json:"duration_ms,omitempty"`
-	Error            string   `json:"error,omitempty"`
-	ResultJSON       string   `json:"result_json,omitempty"`
-	PayloadJSON      string   `json:"payload_json,omitempty"`
-	ArtifactsDir     string   `json:"artifacts_dir,omitempty"`
-	rawRun           *agentcomposev2.RunSummary
-	schedulerRuntime bool
+	RunID           string   `json:"run_id"`
+	RunShortID      string   `json:"run_short_id"`
+	AgentName       string   `json:"agent_name"`
+	SchedulerID     string   `json:"scheduler_id"`
+	ManagedLoaderID string   `json:"managed_loader_id"`
+	TriggerID       string   `json:"trigger_id,omitempty"`
+	TriggerKind     string   `json:"trigger_kind,omitempty"`
+	TriggerSource   string   `json:"trigger_source,omitempty"`
+	Status          string   `json:"status"`
+	SandboxIDs      []string `json:"sandbox_ids,omitempty"`
+	StartedAt       string   `json:"started_at,omitempty"`
+	CompletedAt     string   `json:"completed_at,omitempty"`
+	DurationMs      int64    `json:"duration_ms,omitempty"`
+	Error           string   `json:"error,omitempty"`
+	ResultJSON      string   `json:"result_json,omitempty"`
+	PayloadJSON     string   `json:"payload_json,omitempty"`
+	ArtifactsDir    string   `json:"artifacts_dir,omitempty"`
 }
 
 type composeSchedulerLogEvent struct {
 	ID            string `json:"id"`
 	RunID         string `json:"run_id"`
 	AgentName     string `json:"agent_name"`
+	SchedulerID   string `json:"scheduler_id"`
 	TriggerID     string `json:"trigger_id,omitempty"`
 	Type          string `json:"type"`
 	Level         string `json:"level"`

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -406,27 +406,20 @@ func TestNormalizeComposeSchedulerTriggerOptionsPayload(t *testing.T) {
 	}
 }
 
-func TestLegacySchedulerRunIDValidation(t *testing.T) {
-	tests := []struct {
-		name  string
-		runID string
-		want  bool
-	}{
-		{name: "canonical UUID", runID: "550e8400-e29b-41d4-a716-446655440000", want: true},
-		{name: "uppercase UUID", runID: "550E8400-E29B-41D4-A716-446655440000"},
-		{name: "surrounding whitespace", runID: " 550e8400-e29b-41d4-a716-446655440000 ", want: true},
-		{name: "UUID without hyphens", runID: "550e8400e29b41d4a716446655440000"},
-		{name: "braced UUID", runID: "{550e8400-e29b-41d4-a716-446655440000}"},
-		{name: "SHA-256 resource ID", runID: identity.NewRandomID(identity.ResourceRun)},
-		{name: "invalid UUID", runID: "550e8400-e29b-41d4-a716-invalid"},
-		{name: "empty", runID: ""},
+func TestDeprecatedSchedulerAgentFlagWarningUsesStderr(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("agent", "", "")
+	if err := cmd.Flags().Set("agent", "reviewer"); err != nil {
+		t.Fatalf("Set agent flag returned error: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isLegacySchedulerRunID(tt.runID); got != tt.want {
-				t.Fatalf("isLegacySchedulerRunID(%q) = %t, want %t", tt.runID, got, tt.want)
-			}
-		})
+	var stdout, stderr strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := writeDeprecatedSchedulerAgentFlagWarning(cmd, "use --scheduler instead"); err != nil {
+		t.Fatalf("writeDeprecatedSchedulerAgentFlagWarning returned error: %v", err)
+	}
+	if stdout.String() != "" || !strings.Contains(stderr.String(), "--agent is deprecated") || !strings.Contains(stderr.String(), "use --scheduler instead") {
+		t.Fatalf("stdout/stderr = %q / %q", stdout.String(), stderr.String())
 	}
 }
 
@@ -446,52 +439,36 @@ agents:
 	legacyRunID := "550e8400-e29b-41d4-a716-446655440000"
 	errorRunID := identity.NewRandomID(identity.ResourceRun)
 	sandboxID := identity.NewRandomID(identity.ResourceSandbox)
-	getRunCalls := 0
+	getSchedulerRunCalls := 0
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
 				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-scheduler-observability", composePath)}), nil
 			},
-			listSchedulerEvents: func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error) {
-				return connect.NewResponse(&agentcomposev2.ListSchedulerEventsResponse{}), nil
+			listSchedulerRuns: func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+					RunId: runID, AgentName: "reviewer", SchedulerId: "scheduler-reviewer", TriggerId: "nightly",
+					Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED, SandboxIds: []string{sandboxID},
+					StartedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 0, 0, time.UTC)), CompletedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 2, 0, time.UTC)), DurationMs: 2000,
+				}}}), nil
 			},
-		},
-		resource: resourceServiceStub{
-			resolveID: func(_ context.Context, req *connect.Request[agentcomposev2.ResolveResourceIDRequest]) (*connect.Response[agentcomposev2.ResolveResourceIDResponse], error) {
-				if req.Msg.GetId() != runID[:12] {
-					return connect.NewResponse(&agentcomposev2.ResolveResourceIDResponse{}), nil
-				}
-				return connect.NewResponse(&agentcomposev2.ResolveResourceIDResponse{Targets: []*agentcomposev2.ResourceTarget{{Kind: agentcomposev2.ResourceKind_RESOURCE_KIND_RUN, Id: runID}}}), nil
-			},
-		},
-		run: runServiceStub{
-			getRun: func(_ context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
-				getRunCalls++
+			getSchedulerRun: func(_ context.Context, req *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error) {
+				getSchedulerRunCalls++
 				if req.Msg.GetRunId() == errorRunID {
 					return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("run store unavailable"))
 				}
-				if req.Msg.GetRunId() != runID && req.Msg.GetRunId() != legacyRunID {
+				if req.Msg.GetRunId() != runID[:12] && req.Msg.GetRunId() != legacyRunID {
 					return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("run not found"))
 				}
-				return connect.NewResponse(&agentcomposev2.GetRunResponse{Run: &agentcomposev2.RunDetail{Summary: &agentcomposev2.RunSummary{
-					RunId: req.Msg.GetRunId(), AgentName: "reviewer", Source: agentcomposev2.RunSource_RUN_SOURCE_SCHEDULER, SchedulerId: "scheduler-reviewer",
-					TriggerId: "nightly", Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, SandboxId: sandboxID,
-					StartedAt: "2026-07-15T01:00:00Z", CompletedAt: "2026-07-15T01:00:02Z", DurationMs: 2000,
-				}}}), nil
+				return connect.NewResponse(&agentcomposev2.GetSchedulerRunResponse{Run: &agentcomposev2.SchedulerRun{
+					RunId: firstNonEmptyString(map[bool]string{true: legacyRunID}[req.Msg.GetRunId() == legacyRunID], runID), AgentName: "reviewer", SchedulerId: "scheduler-reviewer", TriggerId: "nightly",
+					Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED, SandboxIds: []string{sandboxID},
+				}}), nil
 			},
-			listRuns: func(context.Context, *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
-				return connect.NewResponse(&agentcomposev2.ListRunsResponse{Runs: []*agentcomposev2.RunSummary{{
-					RunId: runID, TriggerId: "nightly", Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, SandboxId: sandboxID,
-					StartedAt: "2026-07-15T01:00:00Z", CompletedAt: "2026-07-15T01:00:02Z", DurationMs: 2000,
-				}}}), nil
-			},
-			listRunEvents: func(_ context.Context, req *connect.Request[agentcomposev2.ListRunEventsRequest]) (*connect.Response[agentcomposev2.ListRunEventsResponse], error) {
-				if req.Msg.GetLimit() != 500 {
-					t.Fatalf("ListRunEvents limit = %d, want 500", req.Msg.GetLimit())
-				}
-				return connect.NewResponse(&agentcomposev2.ListRunEventsResponse{Events: []*agentcomposev2.RunEvent{
-					{Id: "event-2", RunId: runID, Kind: agentcomposev2.RunEventKind_RUN_EVENT_KIND_AGENT_ACTIVITY, Text: "done", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 2, 0, time.UTC))},
-					{Id: "event-1", RunId: runID, Kind: agentcomposev2.RunEventKind_RUN_EVENT_KIND_STATUS, Text: "started", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 0, 0, time.UTC))},
+			listProjectSchedulerEvents: func(context.Context, *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
+				return connect.NewResponse(&agentcomposev2.ListProjectSchedulerEventsResponse{Events: []*agentcomposev2.SchedulerEvent{
+					{Id: "event-2", RunId: runID, AgentName: "reviewer", TriggerId: "nightly", Type: "loader.agent.activity", Level: "info", Message: "done", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 2, 0, time.UTC))},
+					{Id: "event-1", RunId: runID, AgentName: "reviewer", TriggerId: "nightly", Type: "loader.status", Level: "info", Message: "started", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 0, 0, time.UTC))},
 				}}), nil
 			},
 		},
@@ -527,8 +504,8 @@ agents:
 	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, `"resource": "scheduler"`) || !strings.Contains(jsonOut, `"agent_name": "reviewer"`) {
 		t.Fatalf("scheduler inspect scheduler code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
 	}
-	if getRunCalls != 3 {
-		t.Fatalf("GetRun calls = %d, want 3; scheduler name inspection must not probe runs", getRunCalls)
+	if getSchedulerRunCalls != 3 {
+		t.Fatalf("GetSchedulerRun calls = %d, want 3; scheduler name inspection must not probe runs", getSchedulerRunCalls)
 	}
 
 	_, stderr, _, exitCode = executeCLICommand("scheduler", "inspect", errorRunID, "--host", server.URL, "--file", composePath)
@@ -547,8 +524,104 @@ agents:
 	}
 
 	_, stderr, _, exitCode = executeCLICommand("scheduler", "logs", runID, "--agent", "reviewer", "--host", server.URL, "--file", composePath)
-	if exitCode != exitCodeUsage || !strings.Contains(stderr, "selecting the latest run") {
+	if exitCode != exitCodeUsage || !strings.Contains(stderr, "cannot be combined") {
 		t.Fatalf("scheduler logs explicit run filters code/stderr = %d / %q", exitCode, stderr)
+	}
+}
+
+func TestIntegrationCLISchedulerQueriesHistoricalTriggerIDs(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-scheduler-historical-triggers
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      triggers:
+        - name: current-shared
+          cron: "0 2 * * *"
+          prompt: review nightly
+  builder:
+    provider: codex
+    scheduler:
+      triggers:
+        - name: current-shared
+          cron: "0 3 * * *"
+          prompt: build nightly
+`)
+	const historicalTriggerID = "removed-reviewer-trigger"
+	historicalRunID := identity.NewRandomID(identity.ResourceRun)
+	legacyTriggerID := identity.NewRandomID(identity.ResourceTrigger)
+	legacyRunID := identity.NewRandomID(identity.ResourceRun)
+	probeRequests := make([]*agentcomposev2.ListSchedulerRunsRequest, 0)
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+				probeRequests = append(probeRequests, req.Msg)
+				var runID string
+				runAgent := req.Msg.GetAgentName()
+				switch {
+				case req.Msg.GetTriggerId() == historicalTriggerID && (req.Msg.GetAgentName() == "" || req.Msg.GetAgentName() == "reviewer"):
+					runID = historicalRunID
+					runAgent = "reviewer"
+				case req.Msg.GetTriggerId() == "removed-shared-trigger" && (req.Msg.GetAgentName() == "reviewer" || req.Msg.GetAgentName() == "builder"):
+					runID = identity.NewID(identity.ResourceRun, req.Msg.GetAgentName(), req.Msg.GetTriggerId())
+				case req.Msg.GetTriggerId() == legacyTriggerID && req.Msg.GetAgentName() == "reviewer":
+					runID = legacyRunID
+				default:
+					return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{}), nil
+				}
+				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+					RunId: runID, AgentName: runAgent, TriggerId: req.Msg.GetTriggerId(),
+					Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+				}}}), nil
+			},
+			listProjectSchedulerEvents: func(_ context.Context, req *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
+				if req.Msg.GetAgentName() != "" || req.Msg.GetTriggerId() != historicalTriggerID {
+					t.Fatalf("ListProjectSchedulerEvents filter = agent %q trigger %q", req.Msg.GetAgentName(), req.Msg.GetTriggerId())
+				}
+				return connect.NewResponse(&agentcomposev2.ListProjectSchedulerEventsResponse{Events: []*agentcomposev2.SchedulerEvent{{
+					Id: "historical-event", RunId: historicalRunID, AgentName: "reviewer", TriggerId: historicalTriggerID, Message: "historical log",
+				}}}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "runs", "--trigger", historicalTriggerID, "--json", "--host", server.URL, "--file", composePath)
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, historicalRunID) || !strings.Contains(stdout, `"trigger_id": "`+historicalTriggerID+`"`) {
+		t.Fatalf("historical scheduler runs code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+
+	stdout, stderr, _, exitCode = executeCLICommand("scheduler", "logs", "--trigger", historicalTriggerID, "--json", "--host", server.URL, "--file", composePath)
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, `"id": "historical-event"`) || !strings.Contains(stdout, `"message": "historical log"`) {
+		t.Fatalf("historical scheduler logs code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+
+	stdout, stderr, _, exitCode = executeCLICommand("scheduler", "runs", "reviewer", "--trigger", identity.Prefix+legacyTriggerID, "--json", "--host", server.URL, "--file", composePath)
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, legacyRunID) {
+		t.Fatalf("legacy historical trigger ID code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+	if len(probeRequests) == 0 || probeRequests[len(probeRequests)-2].GetTriggerId() != legacyTriggerID {
+		t.Fatalf("legacy historical trigger was not normalized in requests: %#v", probeRequests)
+	}
+
+	_, stderr, _, exitCode = executeCLICommand("scheduler", "runs", "reviewer", "--trigger", "typo-with-no-history", "--host", server.URL, "--file", composePath)
+	if exitCode != exitCodeUsage || !strings.Contains(stderr, `scheduler trigger "typo-with-no-history" not found`) {
+		t.Fatalf("missing historical trigger code/stderr = %d / %q", exitCode, stderr)
+	}
+
+	_, stderr, _, exitCode = executeCLICommand("scheduler", "runs", "--trigger", "removed-shared-trigger", "--host", server.URL, "--file", composePath)
+	if exitCode != exitCodeUsage || !strings.Contains(stderr, "ambiguous") || !strings.Contains(stderr, "specify a scheduler") {
+		t.Fatalf("ambiguous historical trigger code/stderr = %d / %q", exitCode, stderr)
+	}
+
+	requestsBeforeCurrentAmbiguity := len(probeRequests)
+	_, stderr, _, exitCode = executeCLICommand("scheduler", "logs", "--trigger", "current-shared", "--host", server.URL, "--file", composePath)
+	if exitCode != exitCodeUsage || !strings.Contains(stderr, "ambiguous") || !strings.Contains(stderr, "--scheduler") {
+		t.Fatalf("ambiguous current trigger code/stderr = %d / %q", exitCode, stderr)
+	}
+	if len(probeRequests) != requestsBeforeCurrentAmbiguity {
+		t.Fatalf("current trigger ambiguity performed historical probes: before=%d after=%d", requestsBeforeCurrentAmbiguity, len(probeRequests))
 	}
 }
 
@@ -647,12 +720,28 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "inspect", "--host", server.URL, "--file", composePath, "reviewer", "nightly")
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "inspect", "--host", server.URL, "--file", composePath, "--scheduler", "reviewer", "nightly")
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("scheduler inspect code/stderr = %d / %q", exitCode, stderr)
 	}
 	if !strings.Contains(stdout, "name: nightly") || !strings.Contains(stdout, "cron: 0 2 * * *") || !strings.Contains(stdout, "prompt: review nightly") {
 		t.Fatalf("scheduler inspect stdout = %q", stdout)
+	}
+	projectID, err := domain.StableProjectID("cli-scheduler-inspect", composePath)
+	if err != nil {
+		t.Fatalf("StableProjectID returned error: %v", err)
+	}
+	triggerID, err := domain.StableManagedTriggerID(projectID, "reviewer", "", "nightly", 0)
+	if err != nil {
+		t.Fatalf("StableManagedTriggerID returned error: %v", err)
+	}
+	shortOut, shortErr, _, shortCode := executeCLICommand("scheduler", "inspect", "--host", server.URL, "--file", composePath, "--scheduler", "reviewer", shortOpaqueID(triggerID))
+	if shortCode != 0 || shortErr != "" || !strings.Contains(shortOut, "name: nightly") {
+		t.Fatalf("scheduler inspect short trigger code/stdout/stderr = %d / %q / %q", shortCode, shortOut, shortErr)
+	}
+	_, legacyErr, _, legacyCode := executeCLICommand("scheduler", "inspect", "--host", server.URL, "--file", composePath, "reviewer", "nightly")
+	if legacyCode != exitCodeUsage || !strings.Contains(legacyErr, "use --scheduler <scheduler-ref>") {
+		t.Fatalf("legacy scheduler inspect code/stderr = %d / %q", legacyCode, legacyErr)
 	}
 }
 
@@ -681,7 +770,7 @@ agents:
 	})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "inspect", "--host", server.URL, "--file", composePath, "reviewer", "loader-every-minute")
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "inspect", "--host", server.URL, "--file", composePath, "--scheduler", "reviewer", "loader-every-minute")
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("scheduler inspect loader code/stderr = %d / %q", exitCode, stderr)
 	}

--- a/cmd/agent-compose/cli_stub_server_test.go
+++ b/cmd/agent-compose/cli_stub_server_test.go
@@ -32,7 +32,7 @@ type resourceServiceStub struct {
 func newComposeServiceStubServer(t *testing.T, stubs composeServiceStubs) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.listProjectSchedulerEvents != nil || stubs.project.invokeScheduler != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil {
+	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.listProjectSchedulerEvents != nil || stubs.project.invokeScheduler != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil || stubs.project.pruneSchedulerRuns != nil {
 		path, handler := agentcomposev2connect.NewProjectServiceHandler(stubs.project)
 		mux.Handle(path, handler)
 	}

--- a/cmd/agent-compose/cli_stub_server_test.go
+++ b/cmd/agent-compose/cli_stub_server_test.go
@@ -32,7 +32,7 @@ type resourceServiceStub struct {
 func newComposeServiceStubServer(t *testing.T, stubs composeServiceStubs) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil {
+	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.listProjectSchedulerEvents != nil || stubs.project.invokeScheduler != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil {
 		path, handler := agentcomposev2connect.NewProjectServiceHandler(stubs.project)
 		mux.Handle(path, handler)
 	}

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -33,6 +33,10 @@ func TestE2ECLISchedulerPublicContractWorkflow(t *testing.T) {
 	TestIntegrationCLISchedulerTriggerUsesSchedulerRunAPI(t)
 	TestIntegrationCLISchedulerInspectDeclarativeTriggerYAML(t)
 	TestIntegrationCLISchedulerInspectLoaderRegisteredTrigger(t)
+	TestIntegrationCLISchedulerPruneMapsFiltersAndJSONStats(t)
+	TestIntegrationCLISchedulerPruneSupportsHistoricalTriggerID(t)
+	TestIntegrationCLISchedulerPruneForcePartialResultIsNonZero(t)
+	TestIntegrationCLISchedulerPruneUnimplementedDaemon(t)
 	TestIntegrationCLIInspectProjectAgentRunSandboxSessionJSON(t)
 }
 

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -33,6 +33,8 @@ func TestE2ECLISchedulerPublicContractWorkflow(t *testing.T) {
 	TestIntegrationCLISchedulerTriggerUsesSchedulerRunAPI(t)
 	TestIntegrationCLISchedulerInspectDeclarativeTriggerYAML(t)
 	TestIntegrationCLISchedulerInspectLoaderRegisteredTrigger(t)
+	TestSchedulerPruneCommandFlags(t)
+	TestSchedulerPruneRejectsArgumentsAndInvalidFilters(t)
 	TestIntegrationCLISchedulerPruneMapsFiltersAndJSONStats(t)
 	TestIntegrationCLISchedulerPruneSupportsHistoricalTriggerID(t)
 	TestIntegrationCLISchedulerPruneForcePartialResultIsNonZero(t)

--- a/cmd/agent-compose/scheduler_runs.go
+++ b/cmd/agent-compose/scheduler_runs.go
@@ -49,40 +49,74 @@ type composeSchedulerStopOutput struct {
 	StopRequested bool                      `json:"stop_requested"`
 }
 
+type composeSchedulerInvocationOutput struct {
+	Scheduler  string   `json:"scheduler"`
+	Status     string   `json:"status"`
+	DurationMs int64    `json:"duration_ms"`
+	ResultJSON string   `json:"result_json,omitempty"`
+	Warnings   []string `json:"warnings,omitempty"`
+}
+
 func addComposeSchedulerExecutionFlags(cmd *cobra.Command, options *composeSchedulerTriggerOptions) {
-	cmd.Flags().StringVar(&options.SandboxID, "sandbox", "", "Unsupported for complete scheduler runs")
-	cmd.Flags().StringVar(&options.Driver, "driver", "", "Unsupported for complete scheduler runs")
-	cmd.Flags().StringVar(&options.Prompt, "prompt", "", "Unsupported for complete scheduler runs; scheduler scripts own their agent prompts")
-	cmd.Flags().StringVar(&options.PayloadJSON, "payload", "", "JSON payload passed to main or the trigger callback")
-	cmd.Flags().BoolVar(&options.KeepRunning, "keep-running", false, "Unsupported for complete scheduler runs")
-	cmd.Flags().BoolVar(&options.Remove, "rm", false, "Unsupported for complete scheduler runs")
-	cmd.Flags().BoolVar(&options.Jupyter, "jupyter", false, "Unsupported for complete scheduler runs")
-	cmd.Flags().BoolVar(&options.JupyterExpose, "jupyter-expose", false, "Unsupported for complete scheduler runs")
+	cmd.Flags().StringVar(&options.PayloadJSON, "payload", "", "JSON payload passed to the trigger callback")
 	cmd.Flags().BoolVarP(&options.Detach, "detach", "d", false, "Start the scheduler run and return immediately")
 }
 
-func runComposeSchedulerMainCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerTriggerOptions, agentRef string) error {
-	options, err := prepareComposeSchedulerExecutionOptions(cmd, "scheduler run", options)
-	if err != nil {
-		return err
-	}
+func runComposeSchedulerInvokeCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerInvokeOptions, schedulerRef string) error {
 	_, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
 		return err
 	}
-	agentName, err := resolveComposeAgentNameFromSpec(normalized, projectID, agentRef)
+	scheduler, err := resolveComposeScheduler(normalized, projectID, schedulerRef)
 	if err != nil {
 		return err
 	}
-	agent, ok := composeRunAgentSpec(normalized, agentName)
-	if !ok || agent.Scheduler == nil {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("agent %q does not define a scheduler", agentName)}
+	agent, ok := composeRunAgentSpec(normalized, scheduler.AgentName)
+	if !ok || agent.Scheduler == nil || !agent.Scheduler.HasScript() {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler %q does not define a script; use scheduler trigger to execute one of its triggers", scheduler.AgentName)}
+	}
+	payloadJSON := strings.TrimSpace(options.PayloadJSON)
+	if payloadJSON != "" {
+		payloadJSON, err = domain.NormalizeJSONDocument(payloadJSON)
+		if err != nil {
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler invoke --payload: %w", err)}
+		}
 	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
 	}
-	return executeComposeSchedulerRun(cmd, cli, normalized.Name, projectID, agentName, "", options, clients.project)
+	response, err := clients.project.InvokeScheduler(cmd.Context(), connect.NewRequest(&agentcomposev2.InvokeSchedulerRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: scheduler.AgentName, PayloadJson: payloadJSON,
+	}))
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("invoke scheduler %s in project %s: %w", scheduler.AgentName, normalized.Name, err))
+	}
+	output := composeSchedulerInvocationOutput{
+		Scheduler: scheduler.AgentName, Status: "succeeded", DurationMs: response.Msg.GetDurationMs(),
+		ResultJSON: response.Msg.GetResultJson(), Warnings: append([]string(nil), response.Msg.GetWarnings()...),
+	}
+	if cli.JSON {
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Scheduler: %s\nStatus: %s\nDuration: %s\n", output.Scheduler, output.Status, formatDurationMs(output.DurationMs)); err != nil {
+		return err
+	}
+	if output.ResultJSON != "" {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Result: %s\n", output.ResultJSON); err != nil {
+			return err
+		}
+	}
+	for _, warning := range output.Warnings {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", warning); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func runComposeSchedulerTriggerV2Command(cmd *cobra.Command, cli cliOptions, options composeSchedulerTriggerOptions, agentRef, triggerRef string) error {

--- a/cmd/agent-compose/scheduler_runs_test.go
+++ b/cmd/agent-compose/scheduler_runs_test.go
@@ -5,13 +5,15 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestIntegrationCLISchedulerRunMainAndDetach(t *testing.T) {
+func TestIntegrationCLISchedulerInvokeHasNoLegacyRunOrDetachCompatibility(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
 name: cli-scheduler-main
 agents:
@@ -22,46 +24,65 @@ agents:
       script: |
         function main(payload) { return payload; }
 `)
-	var runRequests []*agentcomposev2.RunSchedulerRequest
-	var startRequests []*agentcomposev2.StartSchedulerRunRequest
+	var invokeRequests []*agentcomposev2.InvokeSchedulerRequest
 	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		runScheduler: func(_ context.Context, req *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error) {
-			runRequests = append(runRequests, req.Msg)
-			return connect.NewResponse(&agentcomposev2.RunSchedulerResponse{Run: &agentcomposev2.SchedulerRun{
-				RunId:       "scheduler-run-main",
-				ProjectId:   req.Msg.GetProject().GetProjectId(),
-				AgentName:   req.Msg.GetAgentName(),
-				Status:      agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
-				ResultJson:  `{"main":true}`,
-				PayloadJson: req.Msg.GetPayloadJson(),
-			}}), nil
-		},
-		startSchedulerRun: func(_ context.Context, req *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error) {
-			startRequests = append(startRequests, req.Msg)
-			return connect.NewResponse(&agentcomposev2.StartSchedulerRunResponse{Run: &agentcomposev2.SchedulerRun{
-				RunId:     "scheduler-run-detached",
-				ProjectId: req.Msg.GetProject().GetProjectId(),
-				AgentName: req.Msg.GetAgentName(),
-				Status:    agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING,
-			}}), nil
+		invokeScheduler: func(_ context.Context, req *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error) {
+			invokeRequests = append(invokeRequests, req.Msg)
+			return connect.NewResponse(&agentcomposev2.InvokeSchedulerResponse{ResultJson: `{"main":true}`, DurationMs: 25}), nil
 		},
 	}})
 	defer server.Close()
 
-	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "run", "--host", server.URL, "--file", composePath, "--payload", ` { "main" : true } `, "reviewer")
-	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, "Trigger: main") || !strings.Contains(stdout, `Result: {"main":true}`) {
-		t.Fatalf("scheduler run code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "invoke", "--host", server.URL, "--file", composePath, "--payload", ` { "main" : true } `, "reviewer")
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, "Scheduler: reviewer") || !strings.Contains(stdout, `Result: {"main":true}`) {
+		t.Fatalf("scheduler invoke code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
-	if len(runRequests) != 1 || runRequests[0].GetTriggerId() != "" || runRequests[0].GetPayloadJson() != `{"main":true}` {
-		t.Fatalf("RunScheduler requests = %#v", runRequests)
+	if len(invokeRequests) != 1 || invokeRequests[0].GetAgentName() != "reviewer" || invokeRequests[0].GetPayloadJson() != `{"main":true}` {
+		t.Fatalf("InvokeScheduler requests = %#v", invokeRequests)
 	}
 
-	detachedOut, detachedErr, _, detachedCode := executeCLICommand("scheduler", "run", "--host", server.URL, "--file", composePath, "--detach", "reviewer")
-	if detachedCode != 0 || detachedErr != "" || !strings.Contains(detachedOut, "Run: scheduler-run-detached") || !strings.Contains(detachedOut, "Inspect: ") || !strings.Contains(detachedOut, "inspect run scheduler-run-detached") || !strings.Contains(detachedOut, "scheduler stop scheduler-run-detached") {
-		t.Fatalf("scheduler run --detach code/stdout/stderr = %d / %q / %q", detachedCode, detachedOut, detachedErr)
+	legacyOut, legacyErr, _, legacyCode := executeCLICommand("scheduler", "run", "--host", server.URL, "--file", composePath, "reviewer")
+	if legacyCode != exitCodeGeneral || legacyOut != "" || !strings.Contains(legacyErr, "unknown command") || len(invokeRequests) != 1 {
+		t.Fatalf("removed scheduler run code/stdout/stderr/requests = %d / %q / %q / %d", legacyCode, legacyOut, legacyErr, len(invokeRequests))
 	}
-	if len(startRequests) != 1 || startRequests[0].GetTriggerId() != "" {
-		t.Fatalf("StartSchedulerRun requests = %#v", startRequests)
+	detachOut, detachErr, _, detachCode := executeCLICommand("scheduler", "invoke", "--host", server.URL, "--file", composePath, "--detach", "reviewer")
+	if detachCode != exitCodeUsage || detachOut != "" || !strings.Contains(detachErr, "unknown flag: --detach") || len(invokeRequests) != 1 {
+		t.Fatalf("scheduler invoke removed --detach code/stdout/stderr/requests = %d / %q / %q / %d", detachCode, detachOut, detachErr, len(invokeRequests))
+	}
+}
+
+func TestIntegrationCLISchedulerLogsDefaultsToAllTriggerRunsAndAppliesGlobalTail(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-scheduler-logs
+agents:
+  reviewer:
+    scheduler:
+      script: function main() {}
+`)
+	var requests []*agentcomposev2.ListProjectSchedulerEventsRequest
+	events := []*agentcomposev2.SchedulerEvent{
+		{Id: "event-new", RunId: "run-new", AgentName: "reviewer", TriggerId: "trigger-new", Type: "loader.log", Level: "info", Message: "newest", CreatedAt: timestamppb.New(time.Unix(200, 0).UTC())},
+		{Id: "event-old", RunId: "run-old", AgentName: "reviewer", TriggerId: "trigger-old", Type: "loader.log", Level: "info", Message: "oldest", CreatedAt: timestamppb.New(time.Unix(100, 0).UTC())},
+	}
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listProjectSchedulerEvents: func(_ context.Context, req *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
+			requests = append(requests, req.Msg)
+			limit := min(int(req.Msg.GetLimit()), len(events))
+			return connect.NewResponse(&agentcomposev2.ListProjectSchedulerEventsResponse{Events: events[:limit]}), nil
+		},
+	}})
+	defer server.Close()
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "logs", "--host", server.URL, "--file", composePath)
+	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, "oldest") || !strings.Contains(stdout, "newest") || strings.Index(stdout, "oldest") > strings.Index(stdout, "newest") {
+		t.Fatalf("scheduler logs code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+	if len(requests) != 1 || requests[0].GetAgentName() != "" || requests[0].GetRunId() != "" || requests[0].GetLimit() != 500 {
+		t.Fatalf("default logs requests = %#v", requests)
+	}
+	requests = nil
+	tailOut, tailErr, _, tailCode := executeCLICommand("scheduler", "logs", "--host", server.URL, "--file", composePath, "--tail", "1")
+	if tailCode != 0 || tailErr != "" || !strings.Contains(tailOut, "newest") || strings.Contains(tailOut, "oldest") || len(requests) != 1 || requests[0].GetLimit() != 1 {
+		t.Fatalf("scheduler logs --tail 1 code/stdout/stderr/requests = %d / %q / %q / %#v", tailCode, tailOut, tailErr, requests)
 	}
 }
 
@@ -95,14 +116,14 @@ agents:
 			args = append(args, test.args...)
 			args = append(args, "reviewer", "nightly")
 			stdout, stderr, _, exitCode := executeCLICommand(args...)
-			if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, test.flag+" is unsupported for complete scheduler runs") {
+			if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "unknown flag: "+test.flag) {
 				t.Fatalf("unsupported flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 			}
 		})
 	}
-	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "run", "--file", composePath, "--prompt", "override", "reviewer")
-	if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "scheduler run --prompt is unsupported for complete scheduler runs") {
-		t.Fatalf("scheduler run unsupported flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	stdout, stderr, _, exitCode := executeCLICommand("scheduler", "invoke", "--file", composePath, "--prompt", "override", "reviewer")
+	if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, "unknown flag: --prompt") {
+		t.Fatalf("scheduler invoke unsupported flag code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 }
 
@@ -123,12 +144,12 @@ agents:
 			requests = append(requests, req.Msg)
 			if req.Msg.GetCursor() == "" {
 				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{
-					Runs:       []*agentcomposev2.SchedulerRun{{RunId: newRunID, AgentName: "reviewer", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED}},
+					Runs:       []*agentcomposev2.SchedulerRun{{RunId: newRunID, AgentName: "reviewer", TriggerId: "trigger-1", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED}},
 					NextCursor: "page-2",
 				}), nil
 			}
 			return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{
-				Runs: []*agentcomposev2.SchedulerRun{{RunId: oldRunID, AgentName: "reviewer", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED}},
+				Runs: []*agentcomposev2.SchedulerRun{{RunId: oldRunID, AgentName: "reviewer", TriggerId: "trigger-1", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED}},
 			}), nil
 		},
 	}})
@@ -149,6 +170,10 @@ agents:
 	}
 	if len(requests) != 2 || requests[0].GetCursor() != "" || requests[1].GetCursor() != "page-2" {
 		t.Fatalf("filtered ListSchedulerRuns requests = %#v", requests)
+	}
+	_, pendingErr, _, pendingCode := executeCLICommand("scheduler", "runs", "--host", server.URL, "--file", composePath, "--status", "pending")
+	if pendingCode != exitCodeUsage || !strings.Contains(pendingErr, "running, succeeded, failed, canceled, or skipped") {
+		t.Fatalf("scheduler runs --status pending code/stderr = %d / %q", pendingCode, pendingErr)
 	}
 }
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -245,23 +245,26 @@ Rules:
 - `run -i --prompt` supports providers with reusable provider conversations: Codex, Claude/cc, and OpenCode. Gemini currently returns unsupported.
 - `StopRun` requests cancellation for active in-daemon runs. Pending/running runs left behind after daemon restart are reconciled to failed with a `daemon interrupted` error.
 
-## `scheduler`: Inspect and Trigger Project Schedulers
+## `scheduler`: Invoke, Inspect, and Operate Project Schedulers
 
 ```bash
 agent-compose scheduler ls [agent]
-agent-compose scheduler runs [scheduler] [--agent <agent>] [--trigger <trigger>] [--status <status>] [--limit <n>]
-agent-compose scheduler logs [run] [--run <run>] [--agent <agent>] [--trigger <trigger>] [--tail <n>]
-agent-compose scheduler trigger <agent> <trigger>
-agent-compose scheduler inspect <name-or-id> [trigger]
+agent-compose scheduler invoke <scheduler-ref> [--payload <json>]
+agent-compose scheduler trigger <scheduler-ref> <trigger-ref> [--payload <json>] [--detach]
+agent-compose scheduler runs [scheduler-ref] [--trigger <trigger-ref>] [--status <status>] [--limit <n>]
+agent-compose scheduler logs [run-ref] [--run <run-ref>] [--scheduler <scheduler-ref>] [--trigger <trigger-ref>] [--tail <n>]
+agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <scheduler-ref>]
 ```
 
 - `scheduler ls` lists triggers from declarative scheduler config and triggers registered by scheduler scripts.
-- `scheduler runs` lists scheduler runs in the current project and the sandboxes linked to each run.
-- `scheduler logs` prints the structured event log for a scheduler run; without a run argument it selects the latest matching run.
-- `scheduler trigger` manually runs the selected trigger through the existing project run flow.
-- `scheduler trigger --prompt "..."` overrides the trigger's agent prompt for this manual run.
+- `scheduler invoke` calls the default entry point of an explicitly script-based scheduler in the foreground. It does not create trigger-run history, persisted outer logs, or artifacts. The former `scheduler run` command has been removed.
+- `scheduler trigger` manually executes a named trigger. `--detach` returns a persisted trigger run that can be inspected or stopped later.
 - `scheduler trigger --payload '{"key":"value"}'` passes a JSON payload to the scheduler trigger handler.
-- `scheduler inspect` accepts a scheduler name/ID, trigger name/ID, or scheduler run ID. The legacy `<agent> <trigger>` form remains supported.
+- `scheduler runs` lists only outer trigger runs; inner agent runs created by `scheduler.agent()` are managed by the ordinary run commands. The default is all matching runs, while `--limit` restricts the final count. Status is one of `running`, `succeeded`, `failed`, `canceled`, or `skipped`.
+- `scheduler logs` prints outer structured events for all current schedulers' trigger runs by default. `--tail N` selects the newest N matching events globally and prints them oldest-to-newest; `--tail -1` means all and `--tail 0` means none. Invocation logs and inner agent transcripts are not included.
+- For `scheduler runs/logs --trigger`, names and short IDs are resolved against the current definition first. An exact trigger ID that was removed or renamed remains queryable when persisted trigger-run history exists. If that historical ID belongs to multiple schedulers, add the scheduler positional argument for `runs` or `--scheduler` for `logs`.
+- `scheduler inspect` accepts one scheduler name/ID, trigger name/ID, or outer trigger-run ID. If a trigger reference exists in multiple schedulers, add `--scheduler <scheduler-ref>`; the old two-position-argument form is no longer supported.
+- `scheduler runs` and `scheduler logs` currently collect unary cursor pages and render once. Streaming and follow behavior are intentionally deferred to a separate change.
 
 ## `ps`: List Sandboxes
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -253,6 +253,7 @@ agent-compose scheduler invoke <scheduler-ref> [--payload <json>]
 agent-compose scheduler trigger <scheduler-ref> <trigger-ref> [--payload <json>] [--detach]
 agent-compose scheduler runs [scheduler-ref] [--trigger <trigger-ref>] [--status <status>] [--limit <n>]
 agent-compose scheduler logs [run-ref] [--run <run-ref>] [--scheduler <scheduler-ref>] [--trigger <trigger-ref>] [--tail <n>]
+agent-compose scheduler prune [--scheduler <scheduler-ref>] [--trigger <trigger-ref>] [--status <terminal-statuses>] [--older-than <duration>] [--force]
 agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <scheduler-ref>]
 ```
 
@@ -263,6 +264,8 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 - `scheduler runs` lists only outer trigger runs; inner agent runs created by `scheduler.agent()` are managed by the ordinary run commands. The default is all matching runs, while `--limit` restricts the final count. Status is one of `running`, `succeeded`, `failed`, `canceled`, or `skipped`.
 - `scheduler logs` prints outer structured events for all current schedulers' trigger runs by default. `--tail N` selects the newest N matching events globally and prints them oldest-to-newest; `--tail -1` means all and `--tail 0` means none. Invocation logs and inner agent transcripts are not included.
 - For `scheduler runs/logs --trigger`, names and short IDs are resolved against the current definition first. An exact trigger ID that was removed or renamed remains queryable when persisted trigger-run history exists. If that historical ID belongs to multiple schedulers, add the scheduler positional argument for `runs` or `--scheduler` for `logs`.
+- `scheduler prune` removes outer trigger-run history and its directly owned loader events, event delivery/link rows, and canonical run artifacts. It matches all terminal (`succeeded`, `failed`, `canceled`, or `skipped`) trigger runs in the current project by default. Use `--scheduler`, `--trigger`, `--status`, or `--older-than` to narrow the scope. The default is a dry-run; only `--force` deletes data. Running runs, invocations, inner agent runs, topic events, sandboxes, loader state, and sticky bindings are retained. Historical trigger IDs use the same current-definition-first resolution as `runs` and `logs`.
+- On daemon startup, an outer trigger run left in `running` by an interrupted daemon process is reconciled to `failed` with a daemon-interrupted loader event before it can later become eligible for pruning.
 - `scheduler inspect` accepts one scheduler name/ID, trigger name/ID, or outer trigger-run ID. If a trigger reference exists in multiple schedulers, add `--scheduler <scheduler-ref>`; the old two-position-argument form is no longer supported.
 - `scheduler runs` and `scheduler logs` currently collect unary cursor pages and render once. Streaming and follow behavior are intentionally deferred to a separate change.
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -253,6 +253,7 @@ agent-compose scheduler invoke <scheduler-ref> [--payload <json>]
 agent-compose scheduler trigger <scheduler-ref> <trigger-ref> [--payload <json>] [--detach]
 agent-compose scheduler runs [scheduler-ref] [--trigger <trigger-ref>] [--status <status>] [--limit <n>]
 agent-compose scheduler logs [run-ref] [--run <run-ref>] [--scheduler <scheduler-ref>] [--trigger <trigger-ref>] [--tail <n>]
+agent-compose scheduler prune [--scheduler <scheduler-ref>] [--trigger <trigger-ref>] [--status <terminal-statuses>] [--older-than <duration>] [--force]
 agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <scheduler-ref>]
 ```
 
@@ -263,6 +264,8 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 - `scheduler runs` 只列出外层 trigger run；`scheduler.agent()` 创建的内层 agent run 仍由普通 run 命令管理。默认返回全部匹配记录，只有显式设置 `--limit` 才限制最终数量；status 可选 `running`、`succeeded`、`failed`、`canceled`、`skipped`。
 - `scheduler logs` 默认输出当前所有 scheduler 的全部 trigger run 外层结构化事件。`--tail N` 选择全局最新 N 条匹配事件并按从旧到新输出；`--tail -1` 表示全部，`--tail 0` 表示不输出。这里不包含 Invocation 日志或内层 agent transcript。
 - `scheduler runs/logs --trigger` 会优先按当前定义解析名称和短 ID。Trigger 被删除或改名后，只要仍有持久化的 trigger run 历史，就可以继续用其精确 ID 查询；同一历史 ID 属于多个 Scheduler 时，`runs` 需要增加 Scheduler 位置参数，`logs` 需要增加 `--scheduler`。
+- `scheduler prune` 清理外层 trigger run 历史及其直属 loader event、event delivery/link 和规范 run artifacts。默认匹配当前 project 中全部 `succeeded`、`failed`、`canceled`、`skipped` 终态 trigger run；可用 `--scheduler`、`--trigger`、`--status`、`--older-than` 缩小范围。命令默认只 dry-run，只有 `--force` 才真正删除。running run、Invocation、内层 agent run、topic event、sandbox、loader state 和 sticky binding 都会保留。历史 Trigger ID 与 `runs`/`logs` 使用相同的“当前定义优先”解析规则。
+- daemon 启动时会先把上一次进程中断后遗留的外层 `running` trigger run 收敛为 `failed`，并记录 daemon-interrupted loader event；之后它才能按普通终态历史参与 prune。
 - `scheduler inspect` 只接受一个 scheduler 名称/ID、trigger 名称/ID 或外层 trigger run ID。多个 scheduler 存在相同 trigger reference 时，使用 `--scheduler <scheduler-ref>` 消歧；旧双位置参数形式不再支持。
 - 当前 `scheduler runs` 和 `scheduler logs` 会收齐 unary cursor pages 后一次性渲染；streaming/follow 能力留到单独修改中实现。
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -245,23 +245,26 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 - `run -i --prompt` 仅支持可复用 provider conversation 的 Codex、Claude/cc 和 OpenCode；Gemini 当前会返回 unsupported。
 - `StopRun` 会请求 daemon 内当前活动 run 取消；daemon 重启后遗留的 running/pending run 会在启动 reconcile 中标记为 failed，并带 `daemon interrupted` 错误。
 
-## `scheduler`：查看和执行 project scheduler
+## `scheduler`：调用、查看和操作 project scheduler
 
 ```bash
 agent-compose scheduler ls [agent]
-agent-compose scheduler runs [scheduler] [--agent <agent>] [--trigger <trigger>] [--status <status>] [--limit <n>]
-agent-compose scheduler logs [run] [--run <run>] [--agent <agent>] [--trigger <trigger>] [--tail <n>]
-agent-compose scheduler trigger <agent> <trigger>
-agent-compose scheduler inspect <name-or-id> [trigger]
+agent-compose scheduler invoke <scheduler-ref> [--payload <json>]
+agent-compose scheduler trigger <scheduler-ref> <trigger-ref> [--payload <json>] [--detach]
+agent-compose scheduler runs [scheduler-ref] [--trigger <trigger-ref>] [--status <status>] [--limit <n>]
+agent-compose scheduler logs [run-ref] [--run <run-ref>] [--scheduler <scheduler-ref>] [--trigger <trigger-ref>] [--tail <n>]
+agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <scheduler-ref>]
 ```
 
 - `scheduler ls` 同时列出声明式 scheduler 配置的 trigger 和 scheduler script 注册到系统中的 trigger。
-- `scheduler runs` 列出当前 project 的 scheduler run，以及每次 run 关联的 sandbox。
-- `scheduler logs` 输出 scheduler run 的结构化事件日志；不指定 run 时选择最新的匹配 run。
-- `scheduler trigger` 通过现有 project run 流程手动执行指定 trigger。
-- `scheduler trigger --prompt "..."` 覆盖本次手动运行使用的 agent prompt。
+- `scheduler invoke` 在前台调用显式脚本型 scheduler 的默认执行入口；它不创建 trigger run 历史、持久化外层日志或 artifacts。原有 `scheduler run` 命令已直接移除。
+- `scheduler trigger` 手动执行指定 trigger；使用 `--detach` 时会返回一个可继续 inspect 或 stop 的持久化 trigger run。
 - `scheduler trigger --payload '{"key":"value"}'` 将 JSON payload 传给 scheduler trigger handler。
-- `scheduler inspect` 可接受 scheduler 名称/ID、trigger 名称/ID 或 scheduler run ID；原有 `<agent> <trigger>` 形式继续兼容。
+- `scheduler runs` 只列出外层 trigger run；`scheduler.agent()` 创建的内层 agent run 仍由普通 run 命令管理。默认返回全部匹配记录，只有显式设置 `--limit` 才限制最终数量；status 可选 `running`、`succeeded`、`failed`、`canceled`、`skipped`。
+- `scheduler logs` 默认输出当前所有 scheduler 的全部 trigger run 外层结构化事件。`--tail N` 选择全局最新 N 条匹配事件并按从旧到新输出；`--tail -1` 表示全部，`--tail 0` 表示不输出。这里不包含 Invocation 日志或内层 agent transcript。
+- `scheduler runs/logs --trigger` 会优先按当前定义解析名称和短 ID。Trigger 被删除或改名后，只要仍有持久化的 trigger run 历史，就可以继续用其精确 ID 查询；同一历史 ID 属于多个 Scheduler 时，`runs` 需要增加 Scheduler 位置参数，`logs` 需要增加 `--scheduler`。
+- `scheduler inspect` 只接受一个 scheduler 名称/ID、trigger 名称/ID 或外层 trigger run ID。多个 scheduler 存在相同 trigger reference 时，使用 `--scheduler <scheduler-ref>` 消歧；旧双位置参数形式不再支持。
+- 当前 `scheduler runs` 和 `scheduler logs` 会收齐 unary cursor pages 后一次性渲染；streaming/follow 能力留到单独修改中实现。
 
 ## `ps`：查看 sandbox
 

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"connectrpc.com/connect"
 
+	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/runs"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
@@ -45,6 +46,10 @@ type ProjectLoaderRuntime interface {
 	SetLoaderTriggerEnabled(context.Context, string, string, bool) (domain.Loader, error)
 }
 
+type ProjectSchedulerInvocationRuntime interface {
+	InvokeScheduler(context.Context, string, string) (loaders.InvocationResult, error)
+}
+
 type ProjectLoaderEventCursorStore interface {
 	ListLoaderEventsBefore(context.Context, string, time.Time, string, int) ([]domain.LoaderEvent, error)
 }
@@ -62,11 +67,13 @@ type ProjectHandler struct {
 	store         ProjectStore
 	loaderRuntime ProjectLoaderRuntime
 	schedulerRuns ProjectSchedulerRunRuntime
+	invocations   ProjectSchedulerInvocationRuntime
 }
 
 func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, loaderRuntime ProjectLoaderRuntime) *ProjectHandler {
 	schedulerRuns, _ := loaderRuntime.(ProjectSchedulerRunRuntime)
-	return &ProjectHandler{delegate: delegate, store: store, loaderRuntime: loaderRuntime, schedulerRuns: schedulerRuns}
+	invocations, _ := loaderRuntime.(ProjectSchedulerInvocationRuntime)
+	return &ProjectHandler{delegate: delegate, store: store, loaderRuntime: loaderRuntime, schedulerRuns: schedulerRuns, invocations: invocations}
 }
 
 func (h *ProjectHandler) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {
@@ -247,7 +254,7 @@ func (h *ProjectHandler) ListSchedulerEvents(ctx context.Context, req *connect.R
 	}
 	response := &agentcomposev2.ListSchedulerEventsResponse{}
 	for _, event := range events[:end] {
-		response.Events = append(response.Events, &agentcomposev2.SchedulerEvent{Id: event.ID, Type: event.Type, Level: event.Level, Message: event.Message, PayloadJson: event.PayloadJSON, RunId: event.RunID, TriggerId: event.TriggerID, CreatedAt: projectTimestamp(event.CreatedAt)})
+		response.Events = append(response.Events, schedulerEventToProto(event, scheduler))
 	}
 	if end < len(events) {
 		last := events[end-1]

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -50,6 +50,10 @@ type ProjectSchedulerInvocationRuntime interface {
 	InvokeScheduler(context.Context, string, string) (loaders.InvocationResult, error)
 }
 
+type ProjectSchedulerPruneRuntime interface {
+	PruneSchedulerRuns(context.Context, loaders.SchedulerRunPruneRequest) (loaders.SchedulerRunPruneResult, error)
+}
+
 type ProjectLoaderEventCursorStore interface {
 	ListLoaderEventsBefore(context.Context, string, time.Time, string, int) ([]domain.LoaderEvent, error)
 }
@@ -63,17 +67,19 @@ type ProjectSchedulerPageStore interface {
 
 type ProjectHandler struct {
 	agentcomposev2connect.UnimplementedProjectServiceHandler
-	delegate      ProjectDelegate
-	store         ProjectStore
-	loaderRuntime ProjectLoaderRuntime
-	schedulerRuns ProjectSchedulerRunRuntime
-	invocations   ProjectSchedulerInvocationRuntime
+	delegate       ProjectDelegate
+	store          ProjectStore
+	loaderRuntime  ProjectLoaderRuntime
+	schedulerRuns  ProjectSchedulerRunRuntime
+	invocations    ProjectSchedulerInvocationRuntime
+	schedulerPrune ProjectSchedulerPruneRuntime
 }
 
 func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, loaderRuntime ProjectLoaderRuntime) *ProjectHandler {
 	schedulerRuns, _ := loaderRuntime.(ProjectSchedulerRunRuntime)
 	invocations, _ := loaderRuntime.(ProjectSchedulerInvocationRuntime)
-	return &ProjectHandler{delegate: delegate, store: store, loaderRuntime: loaderRuntime, schedulerRuns: schedulerRuns, invocations: invocations}
+	schedulerPrune, _ := loaderRuntime.(ProjectSchedulerPruneRuntime)
+	return &ProjectHandler{delegate: delegate, store: store, loaderRuntime: loaderRuntime, schedulerRuns: schedulerRuns, invocations: invocations, schedulerPrune: schedulerPrune}
 }
 
 func (h *ProjectHandler) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {

--- a/pkg/agentcompose/api/project_scheduler_event_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_event_handler.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+type ProjectSchedulerEventStore interface {
+	ListLoaderEventsPage(context.Context, loaders.LoaderEventPageFilter) ([]domain.LoaderEvent, error)
+}
+
+func (h *ProjectHandler) ListProjectSchedulerEvents(ctx context.Context, req *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
+	project, schedulers, err := h.resolveProjectSchedulerRunTargets(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	agentName := strings.TrimSpace(req.Msg.GetAgentName())
+	triggerID := strings.TrimSpace(req.Msg.GetTriggerId())
+	runID := strings.TrimSpace(req.Msg.GetRunId())
+	if runID != "" {
+		_, runScheduler, run, resolveErr := h.resolveProjectSchedulerRun(ctx, req.Msg.GetProject(), runID)
+		if resolveErr != nil {
+			return nil, ConnectErrorForDomain(resolveErr)
+		}
+		if agentName != "" && agentName != runScheduler.AgentName {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scheduler run does not belong to scheduler %q", agentName))
+		}
+		if triggerID != "" && triggerID != run.TriggerID {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scheduler run does not belong to trigger %q", triggerID))
+		}
+		agentName = runScheduler.AgentName
+		triggerID = run.TriggerID
+		runID = run.ID
+		schedulers = []domain.ProjectSchedulerRecord{runScheduler}
+	}
+	limit, err := schedulerRunPageLimit(req.Msg.GetLimit())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	cursor, err := decodeProjectSchedulerEventCursor(req.Msg.GetCursor(), project.ID, project.CurrentRevision, agentName, triggerID, runID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	loaderIDs := make([]string, 0, len(schedulers))
+	byLoaderID := make(map[string]domain.ProjectSchedulerRecord, len(schedulers))
+	for _, scheduler := range schedulers {
+		loaderID := strings.TrimSpace(scheduler.ManagedLoaderID)
+		if loaderID == "" {
+			continue
+		}
+		loaderIDs = append(loaderIDs, loaderID)
+		byLoaderID[loaderID] = scheduler
+	}
+	store, ok := h.store.(ProjectSchedulerEventStore)
+	if !ok {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler event store is required"))
+	}
+	events, err := store.ListLoaderEventsPage(ctx, loaders.LoaderEventPageFilter{
+		LoaderIDs:       loaderIDs,
+		RequireTrigger:  true,
+		TriggerID:       triggerID,
+		RunID:           runID,
+		BeforeCreatedAt: cursor.CreatedAt,
+		BeforeLoaderID:  cursor.LoaderID,
+		BeforeEventID:   cursor.EventID,
+		Limit:           limit + 1,
+	})
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	end := min(limit, len(events))
+	response := &agentcomposev2.ListProjectSchedulerEventsResponse{Events: make([]*agentcomposev2.SchedulerEvent, 0, end)}
+	for _, event := range events[:end] {
+		scheduler, ok := byLoaderID[event.LoaderID]
+		if !ok {
+			continue
+		}
+		response.Events = append(response.Events, schedulerEventToProto(event, scheduler))
+	}
+	if len(events) > limit {
+		response.NextCursor = encodeProjectSchedulerEventCursor(project.ID, project.CurrentRevision, agentName, triggerID, runID, events[limit-1])
+	}
+	return connect.NewResponse(response), nil
+}
+
+func schedulerEventToProto(event domain.LoaderEvent, scheduler domain.ProjectSchedulerRecord) *agentcomposev2.SchedulerEvent {
+	return &agentcomposev2.SchedulerEvent{
+		Id:                  event.ID,
+		Type:                event.Type,
+		Level:               event.Level,
+		Message:             event.Message,
+		PayloadJson:         event.PayloadJSON,
+		RunId:               event.RunID,
+		TriggerId:           event.TriggerID,
+		CreatedAt:           projectTimestamp(event.CreatedAt),
+		AgentName:           scheduler.AgentName,
+		SchedulerId:         scheduler.SchedulerID,
+		LinkedSandboxId:     event.LinkedSandboxID,
+		LinkedCellId:        event.LinkedCellID,
+		LinkedAgentThreadId: event.LinkedAgentThreadID,
+	}
+}

--- a/pkg/agentcompose/api/project_scheduler_prune_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_prune_handler.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func (h *ProjectHandler) PruneSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error) {
+	if h.schedulerPrune == nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("scheduler run prune controller is unavailable"))
+	}
+	_, schedulers, err := h.resolveProjectSchedulerRunTargets(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	statuses, err := schedulerRunPruneStatuses(req.Msg.GetStatus())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	olderThan, err := RuntimeCacheOlderThanFromProto(req.Msg.GetOlderThanSeconds())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	loaderIDs := make([]string, 0, len(schedulers))
+	for _, scheduler := range schedulers {
+		if loaderID := strings.TrimSpace(scheduler.ManagedLoaderID); loaderID != "" {
+			loaderIDs = append(loaderIDs, loaderID)
+		}
+	}
+	result, err := h.schedulerPrune.PruneSchedulerRuns(ctx, loaders.SchedulerRunPruneRequest{
+		LoaderIDs: loaderIDs,
+		TriggerID: strings.TrimSpace(req.Msg.GetTriggerId()),
+		Statuses:  statuses,
+		OlderThan: olderThan,
+		Force:     req.Msg.GetForce(),
+	})
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(schedulerRunPruneResultToProto(result)), nil
+}
+
+func schedulerRunPruneStatuses(values []agentcomposev2.SchedulerRunStatus) ([]string, error) {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		switch value {
+		case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED:
+			result = append(result, domain.LoaderRunStatusSucceeded)
+		case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED:
+			result = append(result, domain.LoaderRunStatusFailed)
+		case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED:
+			result = append(result, domain.LoaderRunStatusCanceled)
+		case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED:
+			result = append(result, domain.LoaderRunStatusSkipped)
+		default:
+			return nil, fmt.Errorf("scheduler run prune only accepts terminal statuses")
+		}
+	}
+	return result, nil
+}
+
+func schedulerRunPruneResultToProto(result loaders.SchedulerRunPruneResult) *agentcomposev2.PruneSchedulerRunsResponse {
+	response := &agentcomposev2.PruneSchedulerRunsResponse{
+		DryRun:      result.DryRun,
+		Matched:     schedulerRunPruneStatsToProto(result.Matched),
+		Removed:     schedulerRunPruneStatsToProto(result.Removed),
+		SkippedRuns: result.SkippedRuns,
+		Warnings:    append([]string(nil), result.Warnings...),
+		Residues:    make([]*agentcomposev2.SchedulerRunPruneResidue, 0, len(result.Residues)),
+	}
+	for _, residue := range result.Residues {
+		response.Residues = append(response.Residues, &agentcomposev2.SchedulerRunPruneResidue{
+			LoaderId: residue.LoaderID,
+			RunId:    residue.RunID,
+			Path:     residue.Path,
+			Error:    residue.Error,
+		})
+	}
+	return response
+}
+
+func schedulerRunPruneStatsToProto(stats loaders.SchedulerRunPruneStats) *agentcomposev2.SchedulerRunPruneStats {
+	return &agentcomposev2.SchedulerRunPruneStats{
+		Runs:              stats.Runs,
+		LoaderEvents:      stats.LoaderEvents,
+		EventDeliveries:   stats.EventDeliveries,
+		EventSandboxLinks: stats.EventSandboxLinks,
+		ArtifactDirs:      stats.ArtifactDirs,
+		ArtifactBytes:     stats.ArtifactBytes,
+	}
+}

--- a/pkg/agentcompose/api/project_scheduler_prune_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_prune_handler_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"math"
+	"slices"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestProjectHandlerPruneSchedulerRunsMapsRequestAndResult(t *testing.T) {
+	store, runtime, handler := newSchedulerRunHandlerFixture()
+	runtime.pruneResult = loaders.SchedulerRunPruneResult{
+		DryRun: true,
+		Matched: loaders.SchedulerRunPruneStats{
+			Runs: 3, LoaderEvents: 4, EventDeliveries: 5, EventSandboxLinks: 6, ArtifactDirs: 2, ArtifactBytes: 17,
+		},
+		SkippedRuns: 1,
+		Residues:    []loaders.SchedulerRunPruneResidue{{LoaderID: "loader-1", RunID: "run-1", Path: "/runs/run-1", Error: "failed"}},
+		Warnings:    []string{"warning"},
+	}
+	response, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
+		Project:   &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		AgentName: store.scheduler.AgentName,
+		TriggerId: " trigger-history ",
+		Status: []agentcomposev2.SchedulerRunStatus{
+			agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+			agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED,
+		},
+		OlderThanSeconds: 7200,
+	}))
+	if err != nil {
+		t.Fatalf("PruneSchedulerRuns: %v", err)
+	}
+	if !slices.Equal(runtime.pruneRequest.LoaderIDs, []string{store.scheduler.ManagedLoaderID}) ||
+		runtime.pruneRequest.TriggerID != "trigger-history" ||
+		!slices.Equal(runtime.pruneRequest.Statuses, []string{domain.LoaderRunStatusSucceeded, domain.LoaderRunStatusFailed}) ||
+		runtime.pruneRequest.OlderThan != 2*time.Hour || runtime.pruneRequest.Force {
+		t.Fatalf("runtime request = %#v", runtime.pruneRequest)
+	}
+	if !response.Msg.GetDryRun() || response.Msg.GetMatched().GetRuns() != 3 || response.Msg.GetMatched().GetArtifactBytes() != 17 ||
+		response.Msg.GetSkippedRuns() != 1 || len(response.Msg.GetResidues()) != 1 || response.Msg.GetResidues()[0].GetRunId() != "run-1" ||
+		len(response.Msg.GetWarnings()) != 1 {
+		t.Fatalf("response = %#v", response.Msg)
+	}
+}
+
+func TestProjectHandlerPruneSchedulerRunsUsesCurrentProjectSchedulers(t *testing.T) {
+	store, runtime, handler := newSchedulerRunHandlerFixture()
+	currentSecond := store.scheduler
+	currentSecond.AgentName = "agent-2"
+	currentSecond.ManagedLoaderID = "loader-2"
+	stale := store.scheduler
+	stale.AgentName = "old-agent"
+	stale.ManagedLoaderID = "loader-old"
+	stale.Revision = store.project.CurrentRevision - 1
+	store.schedulers = []domain.ProjectSchedulerRecord{store.scheduler, stale, currentSecond}
+
+	_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Force: true,
+	}))
+	if err != nil {
+		t.Fatalf("PruneSchedulerRuns: %v", err)
+	}
+	if !slices.Equal(runtime.pruneRequest.LoaderIDs, []string{"loader-1", "loader-2"}) || !runtime.pruneRequest.Force {
+		t.Fatalf("runtime request = %#v", runtime.pruneRequest)
+	}
+}
+
+func TestProjectHandlerPruneSchedulerRunsRejectsInvalidStatusAndDuration(t *testing.T) {
+	store, runtime, handler := newSchedulerRunHandlerFixture()
+	for _, status := range []agentcomposev2.SchedulerRunStatus{
+		agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED,
+		agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING,
+	} {
+		_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
+			Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Status: []agentcomposev2.SchedulerRunStatus{status},
+		}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("status %v code=%v err=%v", status, connect.CodeOf(err), err)
+		}
+	}
+	_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, OlderThanSeconds: math.MaxUint64,
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("overflow duration code=%v err=%v", connect.CodeOf(err), err)
+	}
+	if runtime.pruneRequest.LoaderIDs != nil {
+		t.Fatalf("runtime called for invalid request: %#v", runtime.pruneRequest)
+	}
+}
+
+func TestProjectHandlerPruneSchedulerRunsRuntimeUnavailable(t *testing.T) {
+	store, _, _ := newSchedulerRunHandlerFixture()
+	handler := NewProjectHandler(nil, store, &schedulerRuntimeFake{})
+	_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+	}))
+	if connect.CodeOf(err) != connect.CodeUnavailable {
+		t.Fatalf("runtime unavailable code=%v err=%v", connect.CodeOf(err), err)
+	}
+}

--- a/pkg/agentcompose/api/project_scheduler_run_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -24,7 +25,40 @@ type ProjectSchedulerRunStore interface {
 	ListLoaderRunsPage(context.Context, loaders.LoaderRunPageFilter) ([]domain.LoaderRunSummary, error)
 }
 
+type ProjectSchedulerRunSandboxStore interface {
+	ListLoaderRunSandboxIDs(context.Context, []loaders.LoaderRunKey) (map[loaders.LoaderRunKey][]string, error)
+}
+
+func (h *ProjectHandler) InvokeScheduler(ctx context.Context, req *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error) {
+	_, scheduler, err := h.resolveProjectScheduler(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	var spec agentcomposev2.SchedulerSpec
+	if err := json.Unmarshal([]byte(scheduler.SpecJSON), &spec); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("decode scheduler spec: %w", err))
+	}
+	if strings.TrimSpace(spec.GetScript()) == "" {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("scheduler %q does not define a script; use scheduler trigger to execute one of its triggers", scheduler.AgentName))
+	}
+	payloadJSON, err := normalizeSchedulerRunPayload(req.Msg.GetPayloadJson())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	if h.invocations == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler invocation controller is required"))
+	}
+	result, err := h.invocations.InvokeScheduler(ctx, scheduler.ManagedLoaderID, payloadJSON)
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.InvokeSchedulerResponse{ResultJson: result.ResultJSON, DurationMs: result.DurationMs, Warnings: result.Warnings}), nil
+}
+
 func (h *ProjectHandler) RunScheduler(ctx context.Context, req *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error) {
+	if strings.TrimSpace(req.Msg.GetTriggerId()) == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scheduler trigger id is required"))
+	}
 	_, scheduler, err := h.resolveProjectScheduler(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
@@ -49,6 +83,9 @@ func (h *ProjectHandler) RunScheduler(ctx context.Context, req *connect.Request[
 }
 
 func (h *ProjectHandler) StartSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error) {
+	if strings.TrimSpace(req.Msg.GetTriggerId()) == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scheduler trigger id is required"))
+	}
 	_, scheduler, err := h.resolveProjectScheduler(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
@@ -73,15 +110,7 @@ func (h *ProjectHandler) StartSchedulerRun(ctx context.Context, req *connect.Req
 }
 
 func (h *ProjectHandler) GetSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error) {
-	_, scheduler, _, err := h.resolveProjectSchedulerRun(ctx, req.Msg.GetProject(), req.Msg.GetRunId())
-	if err != nil {
-		return nil, ConnectErrorForDomain(err)
-	}
-	runtime, err := h.schedulerRunRuntime()
-	if err != nil {
-		return nil, err
-	}
-	run, err := runtime.GetSchedulerRun(ctx, scheduler.ManagedLoaderID, req.Msg.GetRunId())
+	_, scheduler, run, err := h.resolveProjectSchedulerRun(ctx, req.Msg.GetProject(), req.Msg.GetRunId())
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
 	}
@@ -97,7 +126,12 @@ func (h *ProjectHandler) ListSchedulerRuns(ctx context.Context, req *connect.Req
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
 	}
-	cursor, err := decodeSchedulerRunCursor(req.Msg.GetCursor(), project.ID, req.Msg.GetAgentName())
+	status, err := schedulerRunStatusFilter(req.Msg.GetStatus())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	triggerID := strings.TrimSpace(req.Msg.GetTriggerId())
+	cursor, err := decodeSchedulerRunCursor(req.Msg.GetCursor(), project.ID, project.CurrentRevision, req.Msg.GetAgentName(), triggerID, status)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -117,6 +151,9 @@ func (h *ProjectHandler) ListSchedulerRuns(ctx context.Context, req *connect.Req
 	}
 	runs, err := store.ListLoaderRunsPage(ctx, loaders.LoaderRunPageFilter{
 		LoaderIDs:       loaderIDs,
+		RequireTrigger:  true,
+		TriggerID:       triggerID,
+		Status:          status,
 		BeforeStartedAt: cursor.StartedAt,
 		BeforeLoaderID:  cursor.LoaderID,
 		BeforeRunID:     cursor.RunID,
@@ -127,21 +164,34 @@ func (h *ProjectHandler) ListSchedulerRuns(ctx context.Context, req *connect.Req
 	}
 	end := min(limit, len(runs))
 	response := &agentcomposev2.ListSchedulerRunsResponse{Runs: make([]*agentcomposev2.SchedulerRun, 0, end)}
+	keys := make([]loaders.LoaderRunKey, 0, end)
+	for _, run := range runs[:end] {
+		keys = append(keys, loaders.LoaderRunKey{LoaderID: run.LoaderID, RunID: run.ID})
+	}
+	sandboxIDs := make(map[loaders.LoaderRunKey][]string)
+	if sandboxStore, ok := h.store.(ProjectSchedulerRunSandboxStore); ok {
+		sandboxIDs, err = sandboxStore.ListLoaderRunSandboxIDs(ctx, keys)
+		if err != nil {
+			return nil, ConnectErrorForDomain(err)
+		}
+	}
 	for _, run := range runs[:end] {
 		scheduler, ok := byLoaderID[run.LoaderID]
 		if !ok {
 			continue
 		}
-		response.Runs = append(response.Runs, schedulerRunToProto(run, scheduler))
+		item := schedulerRunToProto(run, scheduler)
+		item.SandboxIds = sandboxIDs[loaders.LoaderRunKey{LoaderID: run.LoaderID, RunID: run.ID}]
+		response.Runs = append(response.Runs, item)
 	}
 	if len(runs) > limit {
-		response.NextCursor = encodeSchedulerRunCursor(project.ID, req.Msg.GetAgentName(), runs[limit-1])
+		response.NextCursor = encodeSchedulerRunCursor(project.ID, project.CurrentRevision, req.Msg.GetAgentName(), triggerID, status, runs[limit-1])
 	}
 	return connect.NewResponse(response), nil
 }
 
 func (h *ProjectHandler) StopSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error) {
-	_, scheduler, _, err := h.resolveProjectSchedulerRun(ctx, req.Msg.GetProject(), req.Msg.GetRunId())
+	_, scheduler, resolved, err := h.resolveProjectSchedulerRun(ctx, req.Msg.GetProject(), req.Msg.GetRunId())
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
 	}
@@ -149,11 +199,30 @@ func (h *ProjectHandler) StopSchedulerRun(ctx context.Context, req *connect.Requ
 	if err != nil {
 		return nil, err
 	}
-	run, requested, err := runtime.StopSchedulerRun(ctx, scheduler.ManagedLoaderID, req.Msg.GetRunId(), req.Msg.GetReason())
+	run, requested, err := runtime.StopSchedulerRun(ctx, scheduler.ManagedLoaderID, resolved.ID, req.Msg.GetReason())
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
 	}
 	return connect.NewResponse(&agentcomposev2.StopSchedulerRunResponse{Run: schedulerRunToProto(run, scheduler), StopRequested: requested}), nil
+}
+
+func schedulerRunStatusFilter(status agentcomposev2.SchedulerRunStatus) (string, error) {
+	switch status {
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED:
+		return "", nil
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING:
+		return domain.LoaderRunStatusRunning, nil
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED:
+		return domain.LoaderRunStatusSucceeded, nil
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_FAILED:
+		return domain.LoaderRunStatusFailed, nil
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED:
+		return domain.LoaderRunStatusCanceled, nil
+	case agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED:
+		return domain.LoaderRunStatusSkipped, nil
+	default:
+		return "", domain.ClassifyError(domain.ErrInvalidArgument, "invalid scheduler run status", nil)
+	}
 }
 
 func (h *ProjectHandler) resolveProjectSchedulerRun(ctx context.Context, ref *agentcomposev2.ProjectRef, rawRunID string) (domain.ProjectRecord, domain.ProjectSchedulerRecord, domain.LoaderRunSummary, error) {

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -24,7 +24,7 @@ func TestProjectHandlerRunSchedulerSupportsMainAndTerminalStatuses(t *testing.T)
 		status     string
 		wantStatus agentcomposev2.SchedulerRunStatus
 	}{
-		{name: "main", status: domain.LoaderRunStatusSucceeded, wantStatus: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED},
+		{name: "succeeded", triggerID: "trigger-1", status: domain.LoaderRunStatusSucceeded, wantStatus: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED},
 		{name: "canceled", triggerID: "trigger-1", status: domain.LoaderRunStatusCanceled, wantStatus: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED},
 		{name: "skipped", triggerID: "trigger-1", status: domain.LoaderRunStatusSkipped, wantStatus: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED},
 	}
@@ -79,6 +79,26 @@ func TestProjectHandlerRunSchedulerValidatesPayloadAndMissingTrigger(t *testing.
 	}
 }
 
+func TestProjectHandlerInvokeSchedulerReturnsValueWithoutRunResource(t *testing.T) {
+	store, runtime, handler := newSchedulerRunHandlerFixture()
+	runtime.invokeResult = loaders.InvocationResult{ResultJSON: `{"ok":true}`, DurationMs: 42, Warnings: []string{"warning"}}
+	response, err := handler.InvokeScheduler(context.Background(), connect.NewRequest(&agentcomposev2.InvokeSchedulerRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, AgentName: store.scheduler.AgentName, PayloadJson: ` { "value" : true } `,
+	}))
+	if err != nil || response.Msg.GetResultJson() != `{"ok":true}` || response.Msg.GetDurationMs() != 42 || len(response.Msg.GetWarnings()) != 1 {
+		t.Fatalf("InvokeScheduler response=%#v err=%v", response, err)
+	}
+	if runtime.invokeLoaderID != store.scheduler.ManagedLoaderID || runtime.invokePayload != `{"value":true}` {
+		t.Fatalf("invocation loader/payload=%q/%q", runtime.invokeLoaderID, runtime.invokePayload)
+	}
+	store.scheduler.SpecJSON = `{"triggers":[{"name":"nightly"}]}`
+	if _, err := handler.InvokeScheduler(context.Background(), connect.NewRequest(&agentcomposev2.InvokeSchedulerRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, AgentName: store.scheduler.AgentName,
+	})); connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("declarative invoke code=%v err=%v", connect.CodeOf(err), err)
+	}
+}
+
 func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	store, runtime, handler := newSchedulerRunHandlerFixture()
 	startedAt := time.Unix(200, 0).UTC()
@@ -93,7 +113,7 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 		t.Fatalf("StartSchedulerRun response=%#v err=%v", started, err)
 	}
 
-	getRun := domain.LoaderRunSummary{ID: "run-get", LoaderID: store.scheduler.ManagedLoaderID, Status: domain.LoaderRunStatusCanceled, Error: "user stop", StartedAt: startedAt}
+	getRun := domain.LoaderRunSummary{ID: "run-get", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusCanceled, Error: "user stop", StartedAt: startedAt}
 	store.runs = []domain.LoaderRunSummary{getRun}
 	runtime.getResult = getRun
 	got, err := handler.GetSchedulerRun(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRunRequest{
@@ -104,14 +124,15 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 		t.Fatalf("GetSchedulerRun response=%#v err=%v", got, err)
 	}
 
-	newer := domain.LoaderRunSummary{ID: "run-new", LoaderID: store.scheduler.ManagedLoaderID, Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(time.Second)}
-	older := domain.LoaderRunSummary{ID: "run-old", LoaderID: store.scheduler.ManagedLoaderID, Status: domain.LoaderRunStatusSkipped, StartedAt: startedAt}
+	newer := domain.LoaderRunSummary{ID: "run-new", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(time.Second)}
+	older := domain.LoaderRunSummary{ID: "run-old", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusSkipped, StartedAt: startedAt}
 	store.runs = []domain.LoaderRunSummary{newer, older}
+	store.sandboxIDs = map[loaders.LoaderRunKey][]string{{LoaderID: newer.LoaderID, RunID: newer.ID}: {"sandbox-1"}}
 	first, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
 		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
 		Limit:   1,
 	}))
-	if err != nil || len(first.Msg.GetRuns()) != 1 || first.Msg.GetRuns()[0].GetRunId() != newer.ID || first.Msg.GetNextCursor() == "" {
+	if err != nil || len(first.Msg.GetRuns()) != 1 || first.Msg.GetRuns()[0].GetRunId() != newer.ID || len(first.Msg.GetRuns()[0].GetSandboxIds()) != 1 || first.Msg.GetNextCursor() == "" {
 		t.Fatalf("ListSchedulerRuns first=%#v err=%v", first, err)
 	}
 	second, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
@@ -121,6 +142,11 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	}))
 	if err != nil || len(second.Msg.GetRuns()) != 1 || second.Msg.GetRuns()[0].GetRunId() != older.ID || second.Msg.GetNextCursor() != "" {
 		t.Fatalf("ListSchedulerRuns second=%#v err=%v", second, err)
+	}
+	if _, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, TriggerId: "trigger-1", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED, Limit: 1,
+	})); err != nil || !store.lastRunFilter.RequireTrigger || store.lastRunFilter.TriggerID != "trigger-1" || store.lastRunFilter.Status != domain.LoaderRunStatusSkipped {
+		t.Fatalf("ListSchedulerRuns filter=%#v err=%v", store.lastRunFilter, err)
 	}
 
 	store.runs = []domain.LoaderRunSummary{getRun}
@@ -136,20 +162,74 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	}
 }
 
+func TestProjectHandlerListsProjectSchedulerEventsWithIdentityAndCursor(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	createdAt := time.Unix(300, 0).UTC()
+	store.events = []domain.LoaderEvent{
+		{ID: "event-2", LoaderID: store.scheduler.ManagedLoaderID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", LinkedSandboxID: "sandbox-1", CreatedAt: createdAt},
+		{ID: "event-1", LoaderID: store.scheduler.ManagedLoaderID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.run.started", CreatedAt: createdAt.Add(-time.Second)},
+	}
+	first, err := handler.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Limit: 1,
+	}))
+	if err != nil || len(first.Msg.GetEvents()) != 1 || first.Msg.GetEvents()[0].GetAgentName() != store.scheduler.AgentName ||
+		first.Msg.GetEvents()[0].GetSchedulerId() != store.scheduler.SchedulerID || first.Msg.GetEvents()[0].GetLinkedSandboxId() != "sandbox-1" || first.Msg.GetNextCursor() == "" {
+		t.Fatalf("first event page=%#v err=%v", first, err)
+	}
+	second, err := handler.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Limit: 1, Cursor: first.Msg.GetNextCursor(),
+	}))
+	if err != nil || len(second.Msg.GetEvents()) != 1 || second.Msg.GetEvents()[0].GetId() != "event-1" || second.Msg.GetNextCursor() != "" {
+		t.Fatalf("second event page=%#v err=%v", second, err)
+	}
+}
+
+func TestProjectSchedulerEventCursorBindsAllFilters(t *testing.T) {
+	event := domain.LoaderEvent{ID: "event-1", LoaderID: "loader-1", CreatedAt: time.Unix(400, 0).UTC()}
+	token := encodeProjectSchedulerEventCursor("project-1", 3, "agent-1", "trigger-1", "run-1", event)
+	if _, err := decodeProjectSchedulerEventCursor(token, "project-1", 3, "agent-1", "trigger-1", "run-1"); err != nil {
+		t.Fatalf("decode event cursor: %v", err)
+	}
+	for _, scope := range []struct {
+		project             string
+		revision            int64
+		agent, trigger, run string
+	}{
+		{project: "project-2", revision: 3, agent: "agent-1", trigger: "trigger-1", run: "run-1"},
+		{project: "project-1", revision: 4, agent: "agent-1", trigger: "trigger-1", run: "run-1"},
+		{project: "project-1", revision: 3, agent: "agent-2", trigger: "trigger-1", run: "run-1"},
+		{project: "project-1", revision: 3, agent: "agent-1", trigger: "trigger-2", run: "run-1"},
+		{project: "project-1", revision: 3, agent: "agent-1", trigger: "trigger-1", run: "run-2"},
+	} {
+		if _, err := decodeProjectSchedulerEventCursor(token, scope.project, scope.revision, scope.agent, scope.trigger, scope.run); err == nil {
+			t.Fatalf("cursor accepted scope %#v", scope)
+		}
+	}
+}
+
 func TestSchedulerRunCursorIsScopedToProjectAndAgent(t *testing.T) {
 	run := domain.LoaderRunSummary{ID: "run-1", LoaderID: "loader-1", StartedAt: time.Unix(300, 0).UTC()}
-	token := encodeSchedulerRunCursor("project-1", "agent-1", run)
-	cursor, err := decodeSchedulerRunCursor(token, "project-1", "agent-1")
+	token := encodeSchedulerRunCursor("project-1", 3, "agent-1", "trigger-1", "running", run)
+	cursor, err := decodeSchedulerRunCursor(token, "project-1", 3, "agent-1", "trigger-1", "running")
 	if err != nil || cursor.RunID != run.ID || cursor.LoaderID != run.LoaderID || !cursor.StartedAt.Equal(run.StartedAt) {
 		t.Fatalf("decode cursor=%#v err=%v", cursor, err)
 	}
-	if _, err := decodeSchedulerRunCursor(token, "project-2", "agent-1"); err == nil {
+	if _, err := decodeSchedulerRunCursor(token, "project-2", 3, "agent-1", "trigger-1", "running"); err == nil {
 		t.Fatal("cursor accepted a different project")
 	}
-	if _, err := decodeSchedulerRunCursor(token, "project-1", "agent-2"); err == nil {
+	if _, err := decodeSchedulerRunCursor(token, "project-1", 4, "agent-1", "trigger-1", "running"); err == nil {
+		t.Fatal("cursor accepted a different project revision")
+	}
+	if _, err := decodeSchedulerRunCursor(token, "project-1", 3, "agent-2", "trigger-1", "running"); err == nil {
 		t.Fatal("cursor accepted a different agent")
 	}
-	if _, err := decodeSchedulerRunCursor("not-base64!", "project-1", "agent-1"); err == nil {
+	if _, err := decodeSchedulerRunCursor(token, "project-1", 3, "agent-1", "trigger-2", "running"); err == nil {
+		t.Fatal("cursor accepted a different trigger")
+	}
+	if _, err := decodeSchedulerRunCursor(token, "project-1", 3, "agent-1", "trigger-1", "failed"); err == nil {
+		t.Fatal("cursor accepted a different status")
+	}
+	if _, err := decodeSchedulerRunCursor("not-base64!", "project-1", 3, "agent-1", "trigger-1", "running"); err == nil {
 		t.Fatal("invalid cursor returned nil error")
 	}
 }
@@ -180,6 +260,7 @@ func newSchedulerRunHandlerFixture() (*schedulerRunProjectStoreFake, *schedulerR
 			ManagedLoaderID: "loader-1",
 			Revision:        1,
 			Enabled:         false,
+			SpecJSON:        `{"script":"function main() {}"}`,
 		},
 	}
 	runtime := &schedulerRunRuntimeFake{}
@@ -187,9 +268,27 @@ func newSchedulerRunHandlerFixture() (*schedulerRunProjectStoreFake, *schedulerR
 }
 
 type schedulerRunProjectStoreFake struct {
-	project   domain.ProjectRecord
-	scheduler domain.ProjectSchedulerRecord
-	runs      []domain.LoaderRunSummary
+	project       domain.ProjectRecord
+	scheduler     domain.ProjectSchedulerRecord
+	runs          []domain.LoaderRunSummary
+	events        []domain.LoaderEvent
+	sandboxIDs    map[loaders.LoaderRunKey][]string
+	lastRunFilter loaders.LoaderRunPageFilter
+}
+
+func (s *schedulerRunProjectStoreFake) ListLoaderEventsPage(_ context.Context, filter loaders.LoaderEventPageFilter) ([]domain.LoaderEvent, error) {
+	start := 0
+	if filter.BeforeEventID != "" {
+		start = len(s.events)
+		for index, event := range s.events {
+			if event.ID == filter.BeforeEventID {
+				start = index + 1
+				break
+			}
+		}
+	}
+	end := min(start+filter.Limit, len(s.events))
+	return append([]domain.LoaderEvent(nil), s.events[start:end]...), nil
 }
 
 func (s *schedulerRunProjectStoreFake) GetProject(context.Context, string) (domain.ProjectRecord, error) {
@@ -227,6 +326,7 @@ func (s *schedulerRunProjectStoreFake) GetLoaderRunForLoaders(_ context.Context,
 }
 
 func (s *schedulerRunProjectStoreFake) ListLoaderRunsPage(_ context.Context, filter loaders.LoaderRunPageFilter) ([]domain.LoaderRunSummary, error) {
+	s.lastRunFilter = filter
 	start := 0
 	if filter.BeforeRunID != "" {
 		start = len(s.runs)
@@ -241,16 +341,29 @@ func (s *schedulerRunProjectStoreFake) ListLoaderRunsPage(_ context.Context, fil
 	return append([]domain.LoaderRunSummary(nil), s.runs[start:end]...), nil
 }
 
+func (s *schedulerRunProjectStoreFake) ListLoaderRunSandboxIDs(_ context.Context, _ []loaders.LoaderRunKey) (map[loaders.LoaderRunKey][]string, error) {
+	return s.sandboxIDs, nil
+}
+
 type schedulerRunRuntimeFake struct {
-	runResult     domain.LoaderRunSummary
-	startResult   domain.LoaderRunSummary
-	getResult     domain.LoaderRunSummary
-	stopResult    domain.LoaderRunSummary
-	runErr        error
-	stopRequested bool
-	runCalls      int
-	lastRequest   loaders.SchedulerRunRequest
-	stopReason    string
+	runResult      domain.LoaderRunSummary
+	startResult    domain.LoaderRunSummary
+	getResult      domain.LoaderRunSummary
+	stopResult     domain.LoaderRunSummary
+	runErr         error
+	stopRequested  bool
+	runCalls       int
+	lastRequest    loaders.SchedulerRunRequest
+	stopReason     string
+	invokeResult   loaders.InvocationResult
+	invokeLoaderID string
+	invokePayload  string
+}
+
+func (f *schedulerRunRuntimeFake) InvokeScheduler(_ context.Context, loaderID, payloadJSON string) (loaders.InvocationResult, error) {
+	f.invokeLoaderID = loaderID
+	f.invokePayload = payloadJSON
+	return f.invokeResult, nil
 }
 
 func (f *schedulerRunRuntimeFake) SetLoaderEnabled(context.Context, string, bool) (domain.Loader, error) {

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -270,6 +270,7 @@ func newSchedulerRunHandlerFixture() (*schedulerRunProjectStoreFake, *schedulerR
 type schedulerRunProjectStoreFake struct {
 	project       domain.ProjectRecord
 	scheduler     domain.ProjectSchedulerRecord
+	schedulers    []domain.ProjectSchedulerRecord
 	runs          []domain.LoaderRunSummary
 	events        []domain.LoaderEvent
 	sandboxIDs    map[loaders.LoaderRunKey][]string
@@ -304,6 +305,9 @@ func (s *schedulerRunProjectStoreFake) ListProjectAgents(context.Context, string
 }
 
 func (s *schedulerRunProjectStoreFake) ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error) {
+	if s.schedulers != nil {
+		return append([]domain.ProjectSchedulerRecord(nil), s.schedulers...), nil
+	}
 	return []domain.ProjectSchedulerRecord{s.scheduler}, nil
 }
 
@@ -358,6 +362,14 @@ type schedulerRunRuntimeFake struct {
 	invokeResult   loaders.InvocationResult
 	invokeLoaderID string
 	invokePayload  string
+	pruneRequest   loaders.SchedulerRunPruneRequest
+	pruneResult    loaders.SchedulerRunPruneResult
+	pruneErr       error
+}
+
+func (f *schedulerRunRuntimeFake) PruneSchedulerRuns(_ context.Context, request loaders.SchedulerRunPruneRequest) (loaders.SchedulerRunPruneResult, error) {
+	f.pruneRequest = request
+	return f.pruneResult, f.pruneErr
 }
 
 func (f *schedulerRunRuntimeFake) InvokeScheduler(_ context.Context, loaderID, payloadJSON string) (loaders.InvocationResult, error) {

--- a/pkg/agentcompose/api/scheduler_event_cursor.go
+++ b/pkg/agentcompose/api/scheduler_event_cursor.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+type projectSchedulerEventCursor struct {
+	ProjectID       string    `json:"project_id"`
+	ProjectRevision int64     `json:"project_revision"`
+	AgentName       string    `json:"agent_name,omitempty"`
+	TriggerID       string    `json:"trigger_id,omitempty"`
+	RunID           string    `json:"run_id,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	LoaderID        string    `json:"loader_id"`
+	EventID         string    `json:"event_id"`
+}
+
+func encodeProjectSchedulerEventCursor(projectID string, projectRevision int64, agentName, triggerID, runID string, event domain.LoaderEvent) string {
+	payload, _ := json.Marshal(projectSchedulerEventCursor{
+		ProjectID:       strings.TrimSpace(projectID),
+		ProjectRevision: projectRevision,
+		AgentName:       strings.TrimSpace(agentName),
+		TriggerID:       strings.TrimSpace(triggerID),
+		RunID:           strings.TrimSpace(runID),
+		CreatedAt:       event.CreatedAt.UTC(),
+		LoaderID:        strings.TrimSpace(event.LoaderID),
+		EventID:         strings.TrimSpace(event.ID),
+	})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func decodeProjectSchedulerEventCursor(token, projectID string, projectRevision int64, agentName, triggerID, runID string) (projectSchedulerEventCursor, error) {
+	expected := projectSchedulerEventCursor{
+		ProjectID:       strings.TrimSpace(projectID),
+		ProjectRevision: projectRevision,
+		AgentName:       strings.TrimSpace(agentName),
+		TriggerID:       strings.TrimSpace(triggerID),
+		RunID:           strings.TrimSpace(runID),
+	}
+	if strings.TrimSpace(token) == "" {
+		return expected, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return projectSchedulerEventCursor{}, fmt.Errorf("invalid cursor")
+	}
+	var cursor projectSchedulerEventCursor
+	if json.Unmarshal(payload, &cursor) != nil || cursor.ProjectID != expected.ProjectID || cursor.ProjectRevision != expected.ProjectRevision || cursor.AgentName != expected.AgentName ||
+		cursor.TriggerID != expected.TriggerID || cursor.RunID != expected.RunID || cursor.CreatedAt.IsZero() ||
+		strings.TrimSpace(cursor.LoaderID) == "" || strings.TrimSpace(cursor.EventID) == "" {
+		return projectSchedulerEventCursor{}, fmt.Errorf("invalid cursor")
+	}
+	return cursor, nil
+}

--- a/pkg/agentcompose/api/scheduler_run_cursor.go
+++ b/pkg/agentcompose/api/scheduler_run_cursor.go
@@ -11,29 +11,37 @@ import (
 )
 
 type schedulerRunPageCursor struct {
-	ProjectID string    `json:"project_id"`
-	AgentName string    `json:"agent_name,omitempty"`
-	StartedAt time.Time `json:"started_at"`
-	LoaderID  string    `json:"loader_id"`
-	RunID     string    `json:"run_id"`
+	ProjectID       string    `json:"project_id"`
+	ProjectRevision int64     `json:"project_revision"`
+	AgentName       string    `json:"agent_name,omitempty"`
+	TriggerID       string    `json:"trigger_id,omitempty"`
+	Status          string    `json:"status,omitempty"`
+	StartedAt       time.Time `json:"started_at"`
+	LoaderID        string    `json:"loader_id"`
+	RunID           string    `json:"run_id"`
 }
 
-func encodeSchedulerRunCursor(projectID, agentName string, run domain.LoaderRunSummary) string {
+func encodeSchedulerRunCursor(projectID string, projectRevision int64, agentName, triggerID, status string, run domain.LoaderRunSummary) string {
 	payload, _ := json.Marshal(schedulerRunPageCursor{
-		ProjectID: strings.TrimSpace(projectID),
-		AgentName: strings.TrimSpace(agentName),
-		StartedAt: run.StartedAt.UTC(),
-		LoaderID:  strings.TrimSpace(run.LoaderID),
-		RunID:     strings.TrimSpace(run.ID),
+		ProjectID:       strings.TrimSpace(projectID),
+		ProjectRevision: projectRevision,
+		AgentName:       strings.TrimSpace(agentName),
+		TriggerID:       strings.TrimSpace(triggerID),
+		Status:          strings.TrimSpace(status),
+		StartedAt:       run.StartedAt.UTC(),
+		LoaderID:        strings.TrimSpace(run.LoaderID),
+		RunID:           strings.TrimSpace(run.ID),
 	})
 	return base64.RawURLEncoding.EncodeToString(payload)
 }
 
-func decodeSchedulerRunCursor(token, projectID, agentName string) (schedulerRunPageCursor, error) {
+func decodeSchedulerRunCursor(token, projectID string, projectRevision int64, agentName, triggerID, status string) (schedulerRunPageCursor, error) {
 	projectID = strings.TrimSpace(projectID)
 	agentName = strings.TrimSpace(agentName)
+	triggerID = strings.TrimSpace(triggerID)
+	status = strings.TrimSpace(status)
 	if strings.TrimSpace(token) == "" {
-		return schedulerRunPageCursor{ProjectID: projectID, AgentName: agentName}, nil
+		return schedulerRunPageCursor{ProjectID: projectID, ProjectRevision: projectRevision, AgentName: agentName, TriggerID: triggerID, Status: status}, nil
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
@@ -41,7 +49,7 @@ func decodeSchedulerRunCursor(token, projectID, agentName string) (schedulerRunP
 	}
 	var cursor schedulerRunPageCursor
 	if json.Unmarshal(payload, &cursor) != nil ||
-		cursor.ProjectID != projectID || cursor.AgentName != agentName ||
+		cursor.ProjectID != projectID || cursor.ProjectRevision != projectRevision || cursor.AgentName != agentName || cursor.TriggerID != triggerID || cursor.Status != status ||
 		cursor.StartedAt.IsZero() || strings.TrimSpace(cursor.LoaderID) == "" || strings.TrimSpace(cursor.RunID) == "" {
 		return schedulerRunPageCursor{}, fmt.Errorf("invalid cursor")
 	}

--- a/pkg/agentcompose/app/background.go
+++ b/pkg/agentcompose/app/background.go
@@ -26,6 +26,7 @@ type runtimeReconciler interface {
 }
 
 type backgroundLoaderManager interface {
+	RecoverInterruptedRuns(context.Context, time.Time) error
 	Start()
 }
 
@@ -40,6 +41,9 @@ func startBackgroundManagers(ctx context.Context, sandboxes *sessionstore.Store,
 		if err := capTokens.Rebuild(reconcileCtx); err != nil {
 			slog.Warn("failed to rebuild capability sandbox token index on startup", "error", err)
 		}
+	}
+	if err := loaders.RecoverInterruptedRuns(reconcileCtx, startedAt); err != nil {
+		slog.Warn("failed to recover interrupted scheduler runs", "error", err)
 	}
 	loaders.Start()
 	events.Start()

--- a/pkg/agentcompose/app/loader_controller.go
+++ b/pkg/agentcompose/app/loader_controller.go
@@ -50,10 +50,14 @@ func NewLoaderController(di do.Injector) (*loaders.Controller, error) {
 		ReserveSlots: func(event domain.LoaderTopicEvent, count int) ([]*webhooks.Reservation, bool) {
 			return reserveLoaderEventQueueSlots(config, &queue, event, count)
 		},
-		HostFactory: func(loader domain.Loader, run *domain.LoaderRunSummary, triggerEvent loaders.TriggerEventMetadata) loaders.RunHost {
+		HostFactory: func(loader domain.Loader, execution loaders.RuntimeExecutionContext, triggerEvent loaders.TriggerEventMetadata) loaders.RunHost {
+			events := loaders.HostEventRecorder(nil)
+			if execution.Kind == loaders.ExecutionKindTrigger {
+				events = adapters.LoaderHostEvents{Controller: controller}
+			}
 			return loaders.NewRuntimeHost(loaders.RunHostDependencies{
 				Store:                   configDB,
-				Events:                  adapters.LoaderHostEvents{Controller: controller},
+				Events:                  events,
 				Sessions:                do.MustInvoke[*adapters.LoaderSandboxRunner](di),
 				AgentDefinitions:        do.MustInvoke[*adapters.LoaderSandboxRunner](di),
 				AgentExecutor:           adapters.LoaderHostAgentExecutor{Executor: do.MustInvoke[*adapters.AgentExecutor](di)},
@@ -64,7 +68,7 @@ func NewLoaderController(di do.Injector) (*loaders.Controller, error) {
 				Publisher:               controller,
 				CommandRequiresCleanup:  loaders.CommandRequestRequiresCleanup,
 				LinkedSandboxIDFromJSON: adapters.LoaderSandboxRPCLinkedSandboxID,
-			}, loader, run, triggerEvent)
+			}, loader, execution, triggerEvent)
 		},
 	})
 	return controller, nil

--- a/pkg/loaders/controller.go
+++ b/pkg/loaders/controller.go
@@ -91,6 +91,7 @@ type Controller struct {
 	loaders         map[string]domain.Loader
 	running         map[string]int
 	runExecutor     *RunExecutor
+	invocations     *InvocationExecutor
 	schedulerRuns   *schedulerRunSupervisor
 	scheduler       *Scheduler
 	eventDispatcher *EventDispatcher
@@ -140,6 +141,15 @@ func (c *Controller) init() {
 			UpdateTriggerEventDelivery: c.UpdateTriggerEventDelivery,
 			Notify:                     c.notify,
 			Refresh:                    c.Refresh,
+		})
+	}
+	if c.invocations == nil {
+		c.invocations = NewInvocationExecutor(InvocationExecutorDependencies{
+			Engine:      c.deps.Engine,
+			HostFactory: c.deps.HostFactory,
+			EnterRun:    c.EnterRun,
+			LeaveRun:    c.LeaveRun,
+			NewID:       c.deps.NewID,
 		})
 	}
 	if c.schedulerRuns == nil {

--- a/pkg/loaders/controller_coverage_test.go
+++ b/pkg/loaders/controller_coverage_test.go
@@ -21,7 +21,7 @@ func TestControllerCoverageWorkflow(t *testing.T) {
 	controller := NewController(ControllerDependencies{
 		Store:  store,
 		Engine: controllerTestEngine{},
-		HostFactory: func(domain.Loader, *domain.LoaderRunSummary, TriggerEventMetadata) RunHost {
+		HostFactory: func(domain.Loader, RuntimeExecutionContext, TriggerEventMetadata) RunHost {
 			return nil
 		},
 		Notifier:  notifier,
@@ -136,7 +136,7 @@ func TestControllerCoverageWorkflow(t *testing.T) {
 	bareController := NewController(ControllerDependencies{
 		Store:  store,
 		Engine: controllerTestEngine{},
-		HostFactory: func(domain.Loader, *domain.LoaderRunSummary, TriggerEventMetadata) RunHost {
+		HostFactory: func(domain.Loader, RuntimeExecutionContext, TriggerEventMetadata) RunHost {
 			return nil
 		},
 	})

--- a/pkg/loaders/controller_scheduler_runs.go
+++ b/pkg/loaders/controller_scheduler_runs.go
@@ -10,6 +10,14 @@ func (c *Controller) RunScheduler(ctx context.Context, request SchedulerRunReque
 	return c.schedulerRuns.Run(ctx, request)
 }
 
+func (c *Controller) InvokeScheduler(ctx context.Context, loaderID, payloadJSON string) (InvocationResult, error) {
+	loader, _, err := c.LoadLoaderForRun(ctx, loaderID, "")
+	if err != nil {
+		return InvocationResult{}, err
+	}
+	return c.invocations.Invoke(ctx, loader, payloadJSON)
+}
+
 func (c *Controller) StartSchedulerRun(ctx context.Context, request SchedulerRunRequest) (domain.LoaderRunSummary, error) {
 	return c.schedulerRuns.Start(ctx, request)
 }

--- a/pkg/loaders/engine.go
+++ b/pkg/loaders/engine.go
@@ -61,6 +61,7 @@ type loaderRegistration struct {
 type loaderExecutionState struct {
 	ctx           context.Context
 	host          LoaderHost
+	jsonEncoder   *jsValueEncoder
 	registrations []loaderRegistration
 	seenIDs       map[string]struct{}
 	warnings      []string
@@ -83,7 +84,7 @@ func (e *QJSLoaderEngine) Execute(ctx context.Context, request LoaderExecutionRe
 	return e.execute(ctx, request, host, false)
 }
 
-func (e *QJSLoaderEngine) execute(ctx context.Context, request LoaderExecutionRequest, host LoaderHost, validateOnly bool) (LoaderExecutionResult, error) {
+func (e *QJSLoaderEngine) executeRuntime(ctx context.Context, request LoaderExecutionRequest, host LoaderHost, validateOnly bool) (LoaderExecutionResult, error) {
 	runtimeName, err := domain.NormalizeLoaderRuntime(request.Runtime)
 	if err != nil {
 		return LoaderExecutionResult{}, err
@@ -96,19 +97,25 @@ func (e *QJSLoaderEngine) execute(ctx context.Context, request LoaderExecutionRe
 	}
 
 	rt, err := qjs.New(qjs.Option{
-		Context:          ctx,
-		MemoryLimit:      64 << 20,
-		MaxExecutionTime: loaderEngineMaxExecutionTime(ctx),
+		Context:            ctx,
+		CloseOnContextDone: true,
+		MemoryLimit:        64 << 20,
+		MaxExecutionTime:   loaderEngineMaxExecutionTime(ctx),
 	})
 	if err != nil {
 		return LoaderExecutionResult{}, fmt.Errorf("create qjs runtime: %w", err)
 	}
-	defer rt.Close()
+	defer closeQJSLoaderRuntime(ctx, rt)
 
 	jsctx := rt.Context()
+	jsonEncoder, err := newJSValueEncoder(jsctx)
+	if err != nil {
+		return LoaderExecutionResult{}, err
+	}
 	state := &loaderExecutionState{
 		ctx:           ctx,
 		host:          host,
+		jsonEncoder:   jsonEncoder,
 		registrations: make([]loaderRegistration, 0),
 		seenIDs:       make(map[string]struct{}),
 		warningSet:    make(map[string]struct{}),
@@ -174,7 +181,7 @@ func (e *QJSLoaderEngine) execute(ctx context.Context, request LoaderExecutionRe
 			}
 			executed = awaited
 		}
-		if jsonResult, ok, err := loaderResultJSON(executed); err != nil {
+		if jsonResult, ok, err := loaderResultJSON(state.jsonEncoder, executed); err != nil {
 			state.freeCallbacks()
 			return LoaderExecutionResult{}, err
 		} else if ok {
@@ -353,7 +360,7 @@ func (e *QJSLoaderEngine) installRuntime(jsctx *qjs.Context, state *loaderExecut
 			return nil, fmt.Errorf("scheduler.log requires a non-empty message")
 		}
 		var payload any
-		if len(args) > 1 {
+		if len(args) > 1 && args[1] != nil && !args[1].IsUndefined() && !args[1].IsNull() {
 			value, err := qjs.ToGoValue[any](args[1])
 			if err != nil {
 				return nil, fmt.Errorf("decode scheduler.log payload: %w", err)
@@ -383,7 +390,7 @@ func (e *QJSLoaderEngine) installRuntime(jsctx *qjs.Context, state *loaderExecut
 		if args[1].IsUndefined() || args[1].IsNull() || !args[1].IsObject() || args[1].IsArray() {
 			return nil, fmt.Errorf("scheduler.event.publish payload must be an object")
 		}
-		payloadJSON, err := jsValueToJSON(args[1])
+		payloadJSON, err := state.jsonEncoder.Encode(args[1])
 		if err != nil {
 			return nil, fmt.Errorf("encode scheduler.event.publish payload: %w", err)
 		}
@@ -422,7 +429,7 @@ func (e *QJSLoaderEngine) installRuntime(jsctx *qjs.Context, state *loaderExecut
 			return nil, err
 		}
 		var outputSchemaValue *qjs.Value
-		options.OutputSchema, outputSchemaValue, err = parseLoaderOutputSchema(jsctx, args, "scheduler.agent")
+		options.OutputSchema, outputSchemaValue, err = parseLoaderOutputSchema(jsctx, state.jsonEncoder, args, "scheduler.agent")
 		if err != nil {
 			return nil, err
 		}
@@ -498,12 +505,12 @@ func (e *QJSLoaderEngine) installRuntime(jsctx *qjs.Context, state *loaderExecut
 		if prompt == "" {
 			return nil, fmt.Errorf("scheduler.llm requires a non-empty prompt")
 		}
-		options, err := parseLoaderLLMRequest(args)
+		options, err := parseLoaderLLMRequest(args, state)
 		if err != nil {
 			return nil, err
 		}
 		var outputSchemaValue *qjs.Value
-		options.OutputSchema, outputSchemaValue, err = parseLoaderOutputSchema(jsctx, args, "scheduler.llm")
+		options.OutputSchema, outputSchemaValue, err = parseLoaderOutputSchema(jsctx, state.jsonEncoder, args, "scheduler.llm")
 		if err != nil {
 			return nil, err
 		}
@@ -579,7 +586,7 @@ func (e *QJSLoaderEngine) installRuntime(jsctx *qjs.Context, state *loaderExecut
 			}
 			return jsctx.NewUndefined(), nil
 		}
-		valueJSON, err := jsValueToJSON(args[1])
+		valueJSON, err := state.jsonEncoder.Encode(args[1])
 		if err != nil {
 			return nil, err
 		}
@@ -629,7 +636,7 @@ func (e *QJSLoaderEngine) installRuntime(jsctx *qjs.Context, state *loaderExecut
 			if state.host == nil {
 				return nil, fmt.Errorf("%s is unavailable during validation", apiNameCopy)
 			}
-			requestJSON, err := loaderRPCRequestJSON(call.Args(), apiNameCopy)
+			requestJSON, err := loaderRPCRequestJSON(state.jsonEncoder, call.Args(), apiNameCopy)
 			if err != nil {
 				return nil, err
 			}
@@ -669,7 +676,7 @@ func (e *QJSLoaderEngine) installRuntime(jsctx *qjs.Context, state *loaderExecut
 			if state.host == nil {
 				return nil, fmt.Errorf("%s is unavailable during validation", apiNameCopy)
 			}
-			requestJSON, err := loaderRPCRequestJSON(call.Args(), apiNameCopy)
+			requestJSON, err := loaderRPCRequestJSON(state.jsonEncoder, call.Args(), apiNameCopy)
 			if err != nil {
 				return nil, err
 			}
@@ -1072,7 +1079,7 @@ func parseLoaderAgentRequest(args []*qjs.Value, state *loaderExecutionState) (do
 	if len(args) < 2 || args[1] == nil || args[1].IsUndefined() || args[1].IsNull() {
 		return request, nil
 	}
-	options, err := loaderAgentOptionsWithoutSchema(args[1])
+	options, err := loaderAgentOptionsWithoutSchema(state.jsonEncoder, args[1])
 	if err != nil {
 		return domain.LoaderAgentRequest{}, fmt.Errorf("decode scheduler.agent options: %w", err)
 	}
@@ -1099,14 +1106,14 @@ func parseLoaderAgentRequest(args []*qjs.Value, state *loaderExecutionState) (do
 	return request, nil
 }
 
-func loaderAgentOptionsWithoutSchema(value *qjs.Value) (map[string]any, error) {
+func loaderAgentOptionsWithoutSchema(encoder *jsValueEncoder, value *qjs.Value) (map[string]any, error) {
 	if value == nil || value.IsUndefined() || value.IsNull() {
 		return map[string]any{}, nil
 	}
 	if !value.IsObject() || value.IsArray() {
 		return qjs.ToGoValue[map[string]any](value)
 	}
-	rawJSON, err := value.JSONStringify()
+	rawJSON, err := encoder.Encode(value)
 	if err != nil {
 		return nil, err
 	}
@@ -1119,7 +1126,7 @@ func loaderAgentOptionsWithoutSchema(value *qjs.Value) (map[string]any, error) {
 	return options, nil
 }
 
-func parseLoaderOutputSchema(jsctx *qjs.Context, args []*qjs.Value, apiName string) (string, *qjs.Value, error) {
+func parseLoaderOutputSchema(jsctx *qjs.Context, encoder *jsValueEncoder, args []*qjs.Value, apiName string) (string, *qjs.Value, error) {
 	if len(args) < 2 || args[1] == nil || args[1].IsUndefined() || args[1].IsNull() {
 		return "", nil, nil
 	}
@@ -1132,7 +1139,7 @@ func parseLoaderOutputSchema(jsctx *qjs.Context, args []*qjs.Value, apiName stri
 		if schemaValue == nil || schemaValue.IsUndefined() || schemaValue.IsNull() {
 			continue
 		}
-		schemaJSON, err := loaderOutputSchemaJSON(jsctx, schemaValue)
+		schemaJSON, err := loaderOutputSchemaJSON(jsctx, encoder, schemaValue)
 		if err != nil {
 			return "", nil, fmt.Errorf("decode %s %s: %w", apiName, key, err)
 		}
@@ -1141,7 +1148,7 @@ func parseLoaderOutputSchema(jsctx *qjs.Context, args []*qjs.Value, apiName stri
 	return "", nil, nil
 }
 
-func loaderOutputSchemaJSON(jsctx *qjs.Context, value *qjs.Value) (string, error) {
+func loaderOutputSchemaJSON(jsctx *qjs.Context, encoder *jsValueEncoder, value *qjs.Value) (string, error) {
 	if !value.IsObject() || value.IsArray() {
 		return "", fmt.Errorf("must be an object")
 	}
@@ -1154,9 +1161,9 @@ func loaderOutputSchemaJSON(jsctx *qjs.Context, value *qjs.Value) (string, error
 		if converted == nil || converted.IsUndefined() || converted.IsNull() || !converted.IsObject() || converted.IsArray() {
 			return "", fmt.Errorf("toJSONSchema must return an object")
 		}
-		return jsValueToJSON(converted)
+		return encoder.Encode(converted)
 	}
-	return jsValueToJSON(value)
+	return encoder.Encode(value)
 }
 
 func validateLoaderJSONWithSchema(jsctx *qjs.Context, schemaValue, responseValue *qjs.Value, apiName string) error {
@@ -1670,12 +1677,12 @@ func loaderSecretEnvName(name string) bool {
 	}
 }
 
-func parseLoaderLLMRequest(args []*qjs.Value) (domain.LoaderLLMRequest, error) {
+func parseLoaderLLMRequest(args []*qjs.Value, state *loaderExecutionState) (domain.LoaderLLMRequest, error) {
 	request := domain.LoaderLLMRequest{}
 	if len(args) < 2 || args[1] == nil || args[1].IsUndefined() || args[1].IsNull() {
 		return request, nil
 	}
-	options, err := loaderAgentOptionsWithoutSchema(args[1])
+	options, err := loaderAgentOptionsWithoutSchema(state.jsonEncoder, args[1])
 	if err != nil {
 		return domain.LoaderLLMRequest{}, fmt.Errorf("decode scheduler.llm options: %w", err)
 	}
@@ -1685,7 +1692,7 @@ func parseLoaderLLMRequest(args []*qjs.Value) (domain.LoaderLLMRequest, error) {
 	return request, nil
 }
 
-func loaderRPCRequestJSON(args []*qjs.Value, apiName string) (string, error) {
+func loaderRPCRequestJSON(encoder *jsValueEncoder, args []*qjs.Value, apiName string) (string, error) {
 	if len(args) == 0 {
 		return "", nil
 	}
@@ -1696,7 +1703,7 @@ func loaderRPCRequestJSON(args []*qjs.Value, apiName string) (string, error) {
 	if value == nil || value.IsNull() || value.IsUndefined() {
 		return "", nil
 	}
-	requestJSON, err := jsValueToJSON(value)
+	requestJSON, err := encoder.Encode(value)
 	if err != nil {
 		return "", fmt.Errorf("encode %s request: %w", apiName, err)
 	}
@@ -1793,63 +1800,6 @@ func payloadValueFromJSON(jsctx *qjs.Context, payloadJSON string) (*qjs.Value, e
 		return jsctx.NewUndefined(), nil
 	}
 	return jsctx.ParseJSON(payloadJSON), nil
-}
-
-func jsValueToJSON(value *qjs.Value) (string, error) {
-	if value == nil || value.IsUndefined() {
-		return "", nil
-	}
-	if value.IsNull() {
-		return "null", nil
-	}
-	if value.IsBool() {
-		if value.Bool() {
-			return "true", nil
-		}
-		return "false", nil
-	}
-	if value.IsString() || value.IsBigInt() {
-		data, err := json.Marshal(value.String())
-		if err != nil {
-			return "", fmt.Errorf("encode js string value: %w", err)
-		}
-		return string(data), nil
-	}
-	if value.IsNumber() {
-		raw := strings.TrimSpace(value.String())
-		if raw == "" {
-			return "", nil
-		}
-		if raw == "NaN" || raw == "Infinity" || raw == "-Infinity" {
-			data, err := json.Marshal(raw)
-			if err != nil {
-				return "", fmt.Errorf("encode js numeric sentinel: %w", err)
-			}
-			return string(data), nil
-		}
-		if json.Valid([]byte(raw)) {
-			return raw, nil
-		}
-	}
-	jsonValue, err := value.JSONStringify()
-	if err == nil && strings.TrimSpace(jsonValue) != "" && json.Valid([]byte(jsonValue)) {
-		return jsonValue, nil
-	}
-	return "", nil
-}
-
-func loaderResultJSON(value *qjs.Value) (string, bool, error) {
-	if value == nil || value.IsUndefined() {
-		return "", false, nil
-	}
-	jsonValue, err := jsValueToJSON(value)
-	if err != nil {
-		return "", false, err
-	}
-	if strings.TrimSpace(jsonValue) == "" {
-		return "", false, nil
-	}
-	return jsonValue, true, nil
 }
 
 func normalizeImagePullPolicy(policy string) string {

--- a/pkg/loaders/engine_execution_test.go
+++ b/pkg/loaders/engine_execution_test.go
@@ -1,0 +1,138 @@
+package loaders
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestQJSLoaderEnginePreservesCallbackObjectResult(t *testing.T) {
+	result, err := (&QJSLoaderEngine{}).Execute(context.Background(), LoaderExecutionRequest{
+		Runtime:     domain.LoaderRuntimeScheduler,
+		PayloadJSON: `{"request":"gamma-invoke"}`,
+		Script: `
+scheduler.interval("gamma-only", function gammaOnly(payload) {
+	  return { entry: "gamma-only-callback", payload: payload || null };
+}, 86400000);`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	const want = `{"entry":"gamma-only-callback","payload":{"request":"gamma-invoke"}}`
+	if result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestQJSLoaderEngineUsesCapturedJSONStringifier(t *testing.T) {
+	result, err := (&QJSLoaderEngine{}).Execute(context.Background(), LoaderExecutionRequest{
+		Runtime: domain.LoaderRuntimeScheduler,
+		Script: `
+JSON.stringify = function () { return "tampered"; };
+function main() { return { source: "engine" }; }`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != `{"source":"engine"}` {
+		t.Fatalf("ResultJSON = %q, want trusted JSON serialization", result.ResultJSON)
+	}
+}
+
+func TestQJSLoaderEngineReportsUnserializableResult(t *testing.T) {
+	_, err := (&QJSLoaderEngine{}).Execute(context.Background(), LoaderExecutionRequest{
+		Runtime: domain.LoaderRuntimeScheduler,
+		Script: `
+function main() {
+  const result = {};
+  result.self = result;
+  return result;
+}`,
+	}, &coverageEngineHost{})
+	if err == nil || !strings.Contains(err.Error(), "stringify js value") {
+		t.Fatalf("Execute error = %v, want JSON serialization error", err)
+	}
+}
+
+func TestQJSLoaderEngineAcceptsNullLogPayload(t *testing.T) {
+	host := &capturingLogHost{}
+	result, err := (&QJSLoaderEngine{}).Execute(context.Background(), LoaderExecutionRequest{
+		Runtime: domain.LoaderRuntimeScheduler,
+		Script: `function main() {
+  scheduler.log("null payload", null);
+  return { logged: true };
+}`,
+	}, host)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != `{"logged":true}` {
+		t.Fatalf("ResultJSON = %q", result.ResultJSON)
+	}
+	if host.message != "null payload" || host.payload != nil {
+		t.Fatalf("Log message/payload = %q / %#v", host.message, host.payload)
+	}
+}
+
+func TestQJSLoaderEngineCancellationInterruptsPendingPromise(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	host := &engineCancellationHost{started: make(chan struct{})}
+	result := make(chan error, 1)
+	go func() {
+		_, err := (&QJSLoaderEngine{}).Execute(ctx, LoaderExecutionRequest{
+			Runtime: domain.LoaderRuntimeScheduler,
+			Script: `
+scheduler.interval("pending", async function pending() {
+  scheduler.log("callback started");
+  await new Promise(function neverResolve() {});
+}, 86400000);`,
+			Trigger: &domain.LoaderTrigger{ID: "pending"},
+		}, host)
+		result <- err
+	}()
+
+	select {
+	case <-host.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler callback did not start")
+	}
+
+	stopCause := errors.New("stop requested")
+	cancel(stopCause)
+	select {
+	case err := <-result:
+		if !errors.Is(err, stopCause) {
+			t.Fatalf("Execute error = %v, want cancellation cause %v", err, stopCause)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Execute did not return after its context was canceled")
+	}
+}
+
+type engineCancellationHost struct {
+	coverageEngineHost
+	started chan struct{}
+	once    sync.Once
+}
+
+type capturingLogHost struct {
+	coverageEngineHost
+	message string
+	payload any
+}
+
+func (h *capturingLogHost) Log(_ context.Context, message string, payload any) error {
+	h.message = message
+	h.payload = payload
+	return nil
+}
+
+func (h *engineCancellationHost) Log(context.Context, string, any) error {
+	h.once.Do(func() { close(h.started) })
+	return nil
+}

--- a/pkg/loaders/engine_execution_test.go
+++ b/pkg/loaders/engine_execution_test.go
@@ -114,6 +114,23 @@ scheduler.interval("pending", async function pending() {
 	}
 }
 
+func TestQJSLoaderEnginePreservesSuccessfulResultWhenContextIsCanceledAfterExecution(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	stopCause := errors.New("late stop request")
+	want := LoaderExecutionResult{ResultJSON: `{"ok":true}`, Warnings: []string{"preserved"}}
+
+	result, err := executeWithQJSPanicRecovery(ctx, func() (LoaderExecutionResult, error) {
+		cancel(stopCause)
+		return want, nil
+	})
+	if err != nil {
+		t.Fatalf("executeWithQJSPanicRecovery returned error: %v", err)
+	}
+	if result.ResultJSON != want.ResultJSON || len(result.Warnings) != 1 || result.Warnings[0] != "preserved" {
+		t.Fatalf("result = %#v, want %#v", result, want)
+	}
+}
+
 type engineCancellationHost struct {
 	coverageEngineHost
 	started chan struct{}

--- a/pkg/loaders/engine_json.go
+++ b/pkg/loaders/engine_json.go
@@ -1,0 +1,104 @@
+package loaders
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fastschema/qjs"
+)
+
+type jsValueEncoder struct {
+	context    *qjs.Context
+	jsonObject *qjs.Value
+	stringify  *qjs.Value
+}
+
+func newJSValueEncoder(jsctx *qjs.Context) (*jsValueEncoder, error) {
+	jsonObject := jsctx.Global().GetPropertyStr("JSON")
+	if jsonObject == nil || !jsonObject.IsObject() {
+		return nil, fmt.Errorf("initialize js value encoder: JSON object is unavailable")
+	}
+	stringify := jsonObject.GetPropertyStr("stringify")
+	if stringify == nil || !stringify.IsFunction() {
+		return nil, fmt.Errorf("initialize js value encoder: JSON.stringify is unavailable")
+	}
+	// qjs v0.0.6's Value.JSONStringify wrapper frees the QuickJS C string before
+	// Go reads it. Keep the JS intrinsic itself and return a managed JS string
+	// across the WASM boundary instead. Capturing it before user code runs also
+	// prevents a script from changing the engine's serialization behavior.
+	return &jsValueEncoder{
+		context:    jsctx,
+		jsonObject: jsonObject,
+		stringify:  stringify,
+	}, nil
+}
+
+func (e *jsValueEncoder) Encode(value *qjs.Value) (string, error) {
+	if value == nil || value.IsUndefined() {
+		return "", nil
+	}
+	if value.IsNull() {
+		return "null", nil
+	}
+	if value.IsBool() {
+		if value.Bool() {
+			return "true", nil
+		}
+		return "false", nil
+	}
+	if value.IsString() || value.IsBigInt() {
+		data, err := json.Marshal(value.String())
+		if err != nil {
+			return "", fmt.Errorf("encode js string value: %w", err)
+		}
+		return string(data), nil
+	}
+	if value.IsNumber() {
+		raw := strings.TrimSpace(value.String())
+		if raw == "" {
+			return "", nil
+		}
+		if raw == "NaN" || raw == "Infinity" || raw == "-Infinity" {
+			data, err := json.Marshal(raw)
+			if err != nil {
+				return "", fmt.Errorf("encode js numeric sentinel: %w", err)
+			}
+			return string(data), nil
+		}
+		if json.Valid([]byte(raw)) {
+			return raw, nil
+		}
+	}
+
+	jsonValue, err := e.context.Invoke(e.stringify, e.jsonObject, value)
+	if err != nil {
+		return "", fmt.Errorf("stringify js value: %w", err)
+	}
+	defer jsonValue.Free()
+	if jsonValue.IsUndefined() {
+		return "", nil
+	}
+	if !jsonValue.IsString() {
+		return "", fmt.Errorf("stringify js value returned %s instead of a string", jsonValue.Type())
+	}
+	raw := strings.TrimSpace(jsonValue.String())
+	if raw == "" || !json.Valid([]byte(raw)) {
+		return "", fmt.Errorf("stringify js value returned invalid JSON")
+	}
+	return raw, nil
+}
+
+func loaderResultJSON(encoder *jsValueEncoder, value *qjs.Value) (string, bool, error) {
+	if value == nil || value.IsUndefined() {
+		return "", false, nil
+	}
+	jsonValue, err := encoder.Encode(value)
+	if err != nil {
+		return "", false, err
+	}
+	if strings.TrimSpace(jsonValue) == "" {
+		return "", false, nil
+	}
+	return jsonValue, true, nil
+}

--- a/pkg/loaders/engine_runtime.go
+++ b/pkg/loaders/engine_runtime.go
@@ -1,0 +1,43 @@
+package loaders
+
+import (
+	"context"
+
+	"github.com/fastschema/qjs"
+)
+
+func (e *QJSLoaderEngine) execute(
+	ctx context.Context,
+	request LoaderExecutionRequest,
+	host LoaderHost,
+	validateOnly bool,
+) (result LoaderExecutionResult, err error) {
+	defer func() {
+		recovered := recover()
+		// CloseOnContextDone terminates the wazero module, while qjs v0.0.6
+		// reports subsequent operations on that module as panics. Only translate
+		// panics accompanied by this execution's cancellation; unrelated runtime
+		// panics retain their existing fail-fast behavior.
+		if cause := context.Cause(ctx); cause != nil {
+			result = LoaderExecutionResult{}
+			err = cause
+			return
+		}
+		if recovered != nil {
+			panic(recovered)
+		}
+	}()
+
+	return e.executeRuntime(ctx, request, host, validateOnly)
+}
+
+func closeQJSLoaderRuntime(ctx context.Context, runtime *qjs.Runtime) {
+	defer func() {
+		// A canceled context may already have closed the module. qjs.Close then
+		// attempts to free the QuickJS runtime through that closed module.
+		if recovered := recover(); recovered != nil && context.Cause(ctx) == nil {
+			panic(recovered)
+		}
+	}()
+	runtime.Close()
+}

--- a/pkg/loaders/engine_runtime.go
+++ b/pkg/loaders/engine_runtime.go
@@ -12,8 +12,20 @@ func (e *QJSLoaderEngine) execute(
 	host LoaderHost,
 	validateOnly bool,
 ) (result LoaderExecutionResult, err error) {
+	return executeWithQJSPanicRecovery(ctx, func() (LoaderExecutionResult, error) {
+		return e.executeRuntime(ctx, request, host, validateOnly)
+	})
+}
+
+func executeWithQJSPanicRecovery(
+	ctx context.Context,
+	execute func() (LoaderExecutionResult, error),
+) (result LoaderExecutionResult, err error) {
 	defer func() {
 		recovered := recover()
+		if recovered == nil {
+			return
+		}
 		// CloseOnContextDone terminates the wazero module, while qjs v0.0.6
 		// reports subsequent operations on that module as panics. Only translate
 		// panics accompanied by this execution's cancellation; unrelated runtime
@@ -23,12 +35,10 @@ func (e *QJSLoaderEngine) execute(
 			err = cause
 			return
 		}
-		if recovered != nil {
-			panic(recovered)
-		}
+		panic(recovered)
 	}()
 
-	return e.executeRuntime(ctx, request, host, validateOnly)
+	return execute()
 }
 
 func closeQJSLoaderRuntime(ctx context.Context, runtime *qjs.Runtime) {

--- a/pkg/loaders/invocation.go
+++ b/pkg/loaders/invocation.go
@@ -1,0 +1,78 @@
+package loaders
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	domain "agent-compose/pkg/model"
+)
+
+type InvocationResult struct {
+	ResultJSON string
+	DurationMs int64
+	Warnings   []string
+}
+
+type InvocationExecutorDependencies struct {
+	Engine      LoaderEngine
+	HostFactory RunHostFactory
+	EnterRun    func(loader domain.Loader) bool
+	LeaveRun    func(loaderID string)
+	NewID       func() string
+}
+
+type InvocationExecutor struct {
+	deps InvocationExecutorDependencies
+}
+
+func NewInvocationExecutor(deps InvocationExecutorDependencies) *InvocationExecutor {
+	return &InvocationExecutor{deps: deps}
+}
+
+func (e *InvocationExecutor) Invoke(ctx context.Context, loader domain.Loader, payloadJSON string) (InvocationResult, error) {
+	payloadJSON, err := domain.NormalizeJSONDocument(payloadJSON)
+	if err != nil {
+		return InvocationResult{}, err
+	}
+	if e.deps.Engine == nil || e.deps.HostFactory == nil {
+		return InvocationResult{}, fmt.Errorf("scheduler invocation runtime is unavailable")
+	}
+	if e.deps.EnterRun != nil && !e.deps.EnterRun(loader) {
+		return InvocationResult{}, domain.ResourceError(domain.ErrFailedPrecondition, "scheduler", loader.Summary.ID, "scheduler is already running", nil)
+	}
+	if e.deps.LeaveRun != nil {
+		defer e.deps.LeaveRun(loader.Summary.ID)
+	}
+
+	correlationID := uuid.NewString()
+	if e.deps.NewID != nil {
+		if generatedID := strings.TrimSpace(e.deps.NewID()); generatedID != "" {
+			correlationID = generatedID
+		}
+	}
+	host := e.deps.HostFactory(loader, RuntimeExecutionContext{ID: correlationID, Kind: ExecutionKindInvocation}, TriggerEventMetadata{})
+	startedAt := time.Now().UTC()
+	execution, execErr := e.deps.Engine.Execute(ctx, LoaderExecutionRequest{
+		Runtime:     loader.Summary.Runtime,
+		Script:      loader.Script,
+		PayloadJSON: payloadJSON,
+	}, host)
+	if host != nil {
+		host.CleanupCommandSessions(context.WithoutCancel(ctx))
+	}
+	if execErr != nil {
+		return InvocationResult{}, execErr
+	}
+	if err := context.Cause(ctx); err != nil {
+		return InvocationResult{}, err
+	}
+	return InvocationResult{
+		ResultJSON: execution.ResultJSON,
+		DurationMs: time.Since(startedAt).Milliseconds(),
+		Warnings:   append([]string(nil), execution.Warnings...),
+	}, nil
+}

--- a/pkg/loaders/invocation.go
+++ b/pkg/loaders/invocation.go
@@ -67,9 +67,6 @@ func (e *InvocationExecutor) Invoke(ctx context.Context, loader domain.Loader, p
 	if execErr != nil {
 		return InvocationResult{}, execErr
 	}
-	if err := context.Cause(ctx); err != nil {
-		return InvocationResult{}, err
-	}
 	return InvocationResult{
 		ResultJSON: execution.ResultJSON,
 		DurationMs: time.Since(startedAt).Milliseconds(),

--- a/pkg/loaders/invocation_test.go
+++ b/pkg/loaders/invocation_test.go
@@ -1,0 +1,119 @@
+package loaders
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestInvocationExecutorUsesEphemeralContextAndSharedConcurrencyGate(t *testing.T) {
+	engine := &invocationEngineFake{result: LoaderExecutionResult{ResultJSON: `{"ok":true}`, Warnings: []string{"warning"}}}
+	host := &invocationHostFake{}
+	entered := 0
+	left := 0
+	var execution RuntimeExecutionContext
+	executor := NewInvocationExecutor(InvocationExecutorDependencies{
+		Engine: engine,
+		HostFactory: func(_ domain.Loader, current RuntimeExecutionContext, _ TriggerEventMetadata) RunHost {
+			execution = current
+			return host
+		},
+		EnterRun: func(domain.Loader) bool { entered++; return true },
+		LeaveRun: func(string) { left++ },
+		NewID:    func() string { return "invocation-correlation" },
+	})
+	loader := domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1", Runtime: domain.LoaderRuntimeScheduler}, Script: "function main() {}"}
+	result, err := executor.Invoke(context.Background(), loader, ` { "value" : true } `)
+	if err != nil || result.ResultJSON != `{"ok":true}` || len(result.Warnings) != 1 {
+		t.Fatalf("Invoke result=%#v err=%v", result, err)
+	}
+	if execution.ID != "invocation-correlation" || execution.TriggerID != "" || execution.Kind != ExecutionKindInvocation {
+		t.Fatalf("execution context=%#v", execution)
+	}
+	if engine.request.PayloadJSON != `{"value":true}` || entered != 1 || left != 1 || host.cleanupCalls != 1 {
+		t.Fatalf("request/gate/cleanup=%#v/%d/%d/%d", engine.request, entered, left, host.cleanupCalls)
+	}
+}
+
+func TestInvocationExecutorBusyAndFailureDoNotCreateRunLifecycle(t *testing.T) {
+	loader := domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1", Runtime: domain.LoaderRuntimeScheduler}, Script: "function main() {}"}
+	busy := NewInvocationExecutor(InvocationExecutorDependencies{
+		Engine: &invocationEngineFake{}, HostFactory: func(domain.Loader, RuntimeExecutionContext, TriggerEventMetadata) RunHost {
+			return &invocationHostFake{}
+		},
+		EnterRun: func(domain.Loader) bool { return false },
+	})
+	if _, err := busy.Invoke(context.Background(), loader, `{}`); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("busy error=%v", err)
+	}
+	host := &invocationHostFake{}
+	left := 0
+	failed := NewInvocationExecutor(InvocationExecutorDependencies{
+		Engine: &invocationEngineFake{err: errors.New("script failed")}, HostFactory: func(domain.Loader, RuntimeExecutionContext, TriggerEventMetadata) RunHost { return host },
+		EnterRun: func(domain.Loader) bool { return true }, LeaveRun: func(string) { left++ },
+	})
+	if _, err := failed.Invoke(context.Background(), loader, `{}`); err == nil || err.Error() != "script failed" || left != 1 || host.cleanupCalls != 1 {
+		t.Fatalf("failure err=%v left=%d cleanup=%d", err, left, host.cleanupCalls)
+	}
+}
+
+func TestInvocationExecutorFallsBackWhenIDGeneratorReturnsEmpty(t *testing.T) {
+	var execution RuntimeExecutionContext
+	executor := NewInvocationExecutor(InvocationExecutorDependencies{
+		Engine: &invocationEngineFake{},
+		HostFactory: func(_ domain.Loader, current RuntimeExecutionContext, _ TriggerEventMetadata) RunHost {
+			execution = current
+			return &invocationHostFake{}
+		},
+		NewID: func() string { return " " },
+	})
+	loader := domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1", Runtime: domain.LoaderRuntimeScheduler}, Script: "function main() {}"}
+	if _, err := executor.Invoke(context.Background(), loader, `{}`); err != nil {
+		t.Fatalf("Invoke returned error: %v", err)
+	}
+	if execution.ID == "" {
+		t.Fatal("invocation execution context has an empty correlation ID")
+	}
+}
+
+type invocationEngineFake struct {
+	request LoaderExecutionRequest
+	result  LoaderExecutionResult
+	err     error
+}
+
+func (e *invocationEngineFake) Validate(context.Context, string, string) (LoaderValidationResult, error) {
+	return LoaderValidationResult{}, nil
+}
+
+func (e *invocationEngineFake) Execute(_ context.Context, request LoaderExecutionRequest, _ LoaderHost) (LoaderExecutionResult, error) {
+	e.request = request
+	return e.result, e.err
+}
+
+type invocationHostFake struct{ cleanupCalls int }
+
+func (*invocationHostFake) Log(context.Context, string, any) error { return nil }
+func (*invocationHostFake) PublishEvent(context.Context, string, string) (domain.TopicEventRecord, error) {
+	return domain.TopicEventRecord{}, nil
+}
+func (*invocationHostFake) Agent(context.Context, string, domain.LoaderAgentRequest) (domain.LoaderAgentResult, error) {
+	return domain.LoaderAgentResult{}, nil
+}
+func (*invocationHostFake) Command(context.Context, domain.LoaderCommandRequest) (domain.LoaderCommandResult, error) {
+	return domain.LoaderCommandResult{}, nil
+}
+func (*invocationHostFake) LLM(context.Context, string, domain.LoaderLLMRequest) (domain.LoaderLLMResult, error) {
+	return domain.LoaderLLMResult{}, nil
+}
+func (*invocationHostFake) StateGet(context.Context, string) (string, bool, error) {
+	return "", false, nil
+}
+func (*invocationHostFake) StateSet(context.Context, string, string) error { return nil }
+func (*invocationHostFake) StateDelete(context.Context, string) error      { return nil }
+func (*invocationHostFake) CallSessionRPC(context.Context, string, string) (string, error) {
+	return "", nil
+}
+func (h *invocationHostFake) CleanupCommandSessions(context.Context) { h.cleanupCalls++ }

--- a/pkg/loaders/invocation_test.go
+++ b/pkg/loaders/invocation_test.go
@@ -78,10 +78,37 @@ func TestInvocationExecutorFallsBackWhenIDGeneratorReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestInvocationExecutorPreservesSuccessfulResultWhenContextIsCanceledAfterExecution(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	stopCause := errors.New("late stop request")
+	engine := &invocationEngineFake{
+		result: LoaderExecutionResult{ResultJSON: `{"ok":true}`, Warnings: []string{"preserved"}},
+		afterExecute: func() {
+			cancel(stopCause)
+		},
+	}
+	executor := NewInvocationExecutor(InvocationExecutorDependencies{
+		Engine: engine,
+		HostFactory: func(domain.Loader, RuntimeExecutionContext, TriggerEventMetadata) RunHost {
+			return &invocationHostFake{}
+		},
+	})
+	loader := domain.Loader{Summary: domain.LoaderSummary{ID: "loader-1", Runtime: domain.LoaderRuntimeScheduler}, Script: "function main() {}"}
+
+	result, err := executor.Invoke(ctx, loader, `{}`)
+	if err != nil {
+		t.Fatalf("Invoke returned error: %v", err)
+	}
+	if result.ResultJSON != `{"ok":true}` || len(result.Warnings) != 1 || result.Warnings[0] != "preserved" {
+		t.Fatalf("Invoke result = %#v", result)
+	}
+}
+
 type invocationEngineFake struct {
-	request LoaderExecutionRequest
-	result  LoaderExecutionResult
-	err     error
+	request      LoaderExecutionRequest
+	result       LoaderExecutionResult
+	err          error
+	afterExecute func()
 }
 
 func (e *invocationEngineFake) Validate(context.Context, string, string) (LoaderValidationResult, error) {
@@ -90,6 +117,9 @@ func (e *invocationEngineFake) Validate(context.Context, string, string) (Loader
 
 func (e *invocationEngineFake) Execute(_ context.Context, request LoaderExecutionRequest, _ LoaderHost) (LoaderExecutionResult, error) {
 	e.request = request
+	if e.afterExecute != nil {
+		e.afterExecute()
+	}
 	return e.result, e.err
 }
 

--- a/pkg/loaders/orchestration_test.go
+++ b/pkg/loaders/orchestration_test.go
@@ -27,7 +27,7 @@ func TestRunExecutorLifecycleWorkflows(t *testing.T) {
 	executor := loaders.NewRunExecutor(loaders.RunExecutorDependencies{
 		Store:  store,
 		Engine: engine,
-		HostFactory: func(domain.Loader, *domain.LoaderRunSummary, loaders.TriggerEventMetadata) loaders.RunHost {
+		HostFactory: func(domain.Loader, loaders.RuntimeExecutionContext, loaders.TriggerEventMetadata) loaders.RunHost {
 			return &runHostFake{}
 		},
 		ArtifactsDir: func(loaderID, runID string) string {
@@ -80,7 +80,7 @@ func TestRunExecutorLifecycleWorkflows(t *testing.T) {
 	busyExecutor := loaders.NewRunExecutor(loaders.RunExecutorDependencies{
 		Store:  busyStore,
 		Engine: engine,
-		HostFactory: func(domain.Loader, *domain.LoaderRunSummary, loaders.TriggerEventMetadata) loaders.RunHost {
+		HostFactory: func(domain.Loader, loaders.RuntimeExecutionContext, loaders.TriggerEventMetadata) loaders.RunHost {
 			return &runHostFake{}
 		},
 		ArtifactsDir:  func(loaderID, runID string) string { return filepath.Join(t.TempDir(), loaderID, runID) },

--- a/pkg/loaders/run_host.go
+++ b/pkg/loaders/run_host.go
@@ -84,7 +84,7 @@ type RunHostDependencies struct {
 type RuntimeHost struct {
 	deps         RunHostDependencies
 	loader       domain.Loader
-	run          *domain.LoaderRunSummary
+	execution    RuntimeExecutionContext
 	triggerEvent TriggerEventMetadata
 
 	commandSessionIDs       map[string]struct{}
@@ -93,8 +93,8 @@ type RuntimeHost struct {
 	projectAgentRunSequence atomic.Uint64
 }
 
-func NewRuntimeHost(deps RunHostDependencies, loader domain.Loader, run *domain.LoaderRunSummary, triggerEvent TriggerEventMetadata) *RuntimeHost {
-	return &RuntimeHost{deps: deps, loader: loader, run: run, triggerEvent: triggerEvent}
+func NewRuntimeHost(deps RunHostDependencies, loader domain.Loader, execution RuntimeExecutionContext, triggerEvent TriggerEventMetadata) *RuntimeHost {
+	return &RuntimeHost{deps: deps, loader: loader, execution: execution, triggerEvent: triggerEvent}
 }
 
 func (h *RuntimeHost) Log(ctx context.Context, message string, payload any) error {
@@ -105,7 +105,11 @@ func (h *RuntimeHost) PublishEvent(ctx context.Context, topic string, payloadJSO
 	if h.deps.Store == nil {
 		return domain.TopicEventRecord{}, fmt.Errorf("event store is unavailable")
 	}
-	published, err := NewPublishedTopicEvent(topic, payloadJSON, h.triggerEvent, h.loader.Summary.ID, h.run.ID)
+	publisherRunID := ""
+	if h.execution.Kind == ExecutionKindTrigger {
+		publisherRunID = h.execution.ID
+	}
+	published, err := NewPublishedTopicEvent(topic, payloadJSON, h.triggerEvent, h.loader.Summary.ID, publisherRunID)
 	if err != nil {
 		return domain.TopicEventRecord{}, err
 	}
@@ -159,7 +163,7 @@ func (h *RuntimeHost) CallSessionRPC(ctx context.Context, method, requestJSON st
 }
 
 func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.LoaderAgentRequest) (domain.LoaderAgentResult, error) {
-	request.BindingTriggerID = h.run.TriggerID
+	request.BindingTriggerID = h.execution.TriggerID
 	if h.useProjectManagedAgentRun(request) {
 		return h.ProjectAgent(ctx, prompt, request)
 	}
@@ -197,7 +201,7 @@ func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.L
 		Provider:          agentConfig.Provider,
 		AgentDefinitionID: agentDefinitionID,
 		Model:             agentConfig.Model,
-		RunID:             h.run.ID,
+		RunID:             h.execution.ID,
 		Prompt:            prompt,
 		Timeout:           request.Timeout,
 		OutputSchemaJSON:  request.OutputSchema,
@@ -253,7 +257,7 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.LoaderCommandR
 		JupyterEnabled:   request.JupyterEnabled,
 		SandboxEnv:       domain.LoaderCommandSandboxEnv(request),
 		Volumes:          request.Volumes,
-		BindingTriggerID: h.run.TriggerID,
+		BindingTriggerID: h.execution.TriggerID,
 	}
 	session, eventType, err := h.ensureCommandSession(ctx, agentRequest, cleanupSession)
 	if err != nil {
@@ -340,14 +344,14 @@ func (h *RuntimeHost) addLoaderEvent(ctx context.Context, eventType, level, mess
 	if h.deps.Events == nil {
 		return nil
 	}
-	return h.deps.Events.Add(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventType, level, message, payload, linkedSandboxID, linkedCellID, linkedAgentThreadID)
+	return h.deps.Events.Add(ctx, h.loader.Summary.ID, h.execution.ID, h.execution.TriggerID, eventType, level, message, payload, linkedSandboxID, linkedCellID, linkedAgentThreadID)
 }
 
 func (h *RuntimeHost) addLoaderEventRecord(ctx context.Context, eventType, level, message string, payload any, linkedSandboxID, linkedCellID, linkedAgentThreadID string) (domain.LoaderEvent, error) {
 	if h.deps.Events == nil {
 		return domain.LoaderEvent{}, nil
 	}
-	return h.deps.Events.AddRecord(ctx, h.loader.Summary.ID, h.run.ID, h.run.TriggerID, eventType, level, message, payload, linkedSandboxID, linkedCellID, linkedAgentThreadID)
+	return h.deps.Events.AddRecord(ctx, h.loader.Summary.ID, h.execution.ID, h.execution.TriggerID, eventType, level, message, payload, linkedSandboxID, linkedCellID, linkedAgentThreadID)
 }
 
 func (h *RuntimeHost) addLinkedLoaderEvent(ctx context.Context, eventType, level, message string, payload any, linkedSandboxID, linkedCellID, linkedAgentThreadID string) error {
@@ -368,12 +372,12 @@ func (h *RuntimeHost) addEventSandboxLink(ctx context.Context, event domain.Load
 		SandboxID:     sandboxID,
 		Relation:      relation,
 		LoaderID:      h.loader.Summary.ID,
-		RunID:         h.run.ID,
-		TriggerID:     h.run.TriggerID,
+		RunID:         h.execution.ID,
+		TriggerID:     h.execution.TriggerID,
 		LoaderEventID: event.ID,
 		CreatedAt:     event.CreatedAt,
 	}); err != nil {
-		slog.Warn("failed to add event sandbox link", "event_id", h.triggerEvent.EventID, "sandbox_id", sandboxID, "run_id", h.run.ID, "error", err)
+		slog.Warn("failed to add event sandbox link", "event_id", h.triggerEvent.EventID, "sandbox_id", sandboxID, "run_id", h.execution.ID, "error", err)
 	}
 }
 
@@ -392,7 +396,9 @@ func (h *RuntimeHost) publishAgentCompleted(result domain.LoaderAgentResult, pro
 		"loaderId":      h.loader.Summary.ID,
 	}
 	if projectRun != nil {
-		payload["loaderRunId"] = h.run.ID
+		if h.execution.Kind == ExecutionKindTrigger {
+			payload["loaderRunId"] = h.execution.ID
+		}
 		payload["projectId"] = projectRun.ProjectID
 		payload["projectRunId"] = projectRun.RunID
 	}

--- a/pkg/loaders/run_host_project_agent.go
+++ b/pkg/loaders/run_host_project_agent.go
@@ -41,7 +41,7 @@ func (h *RuntimeHost) ProjectAgent(ctx context.Context, prompt string, request d
 		AgentName:        h.loader.Summary.ManagedAgentName,
 		Prompt:           prompt,
 		SchedulerID:      h.loader.Summary.ManagedSchedulerID,
-		TriggerID:        h.run.TriggerID,
+		TriggerID:        h.execution.TriggerID,
 		OutputSchemaJSON: request.OutputSchema,
 		ClientRequestID:  h.nextProjectAgentRunID(),
 		Volumes:          request.Volumes,
@@ -70,7 +70,7 @@ func (h *RuntimeHost) ProjectAgent(ctx context.Context, prompt string, request d
 }
 
 func (h *RuntimeHost) nextProjectAgentRunID() string {
-	baseID := firstHostNonEmpty(h.run.ID, uuid.NewString())
+	baseID := firstHostNonEmpty(h.execution.ID, uuid.NewString())
 	return fmt.Sprintf("%s:agent:%d", baseID, h.projectAgentRunSequence.Add(1))
 }
 

--- a/pkg/loaders/run_host_test.go
+++ b/pkg/loaders/run_host_test.go
@@ -59,7 +59,7 @@ func TestRuntimeHostAgentCommandLLMAndSessionRPC(t *testing.T) {
 			}
 			return ""
 		},
-	}, loader, run, loaders.TriggerEventMetadata{EventID: "topic-event"})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{EventID: "topic-event"})
 
 	agentResult, err := host.Agent(ctx, "summarize", domain.LoaderAgentRequest{})
 	if err != nil {
@@ -142,7 +142,7 @@ func TestRuntimeHostProjectAgentPath(t *testing.T) {
 		Events:             events,
 		ProjectAgentRunner: projectRunner,
 		Publisher:          publisher,
-	}, loader, run, loaders.TriggerEventMetadata{EventID: "topic-event"})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{EventID: "topic-event"})
 
 	result, err := host.Agent(ctx, "review", domain.LoaderAgentRequest{})
 	if err != nil {
@@ -153,6 +153,23 @@ func TestRuntimeHostProjectAgentPath(t *testing.T) {
 	}
 	if !events.contains("loader.agent.completed") || len(publisher.events) != 1 || publisher.events[0].payload["projectRunId"] != "project-run" {
 		t.Fatalf("events/publisher = %#v/%#v", events.types(), publisher.events)
+	}
+	if publisher.events[0].payload["loaderRunId"] != run.ID {
+		t.Fatalf("trigger execution publisher payload = %#v", publisher.events[0].payload)
+	}
+	invocationPublisher := &hostPublisherFake{}
+	invocationHost := loaders.NewRuntimeHost(loaders.RunHostDependencies{
+		ProjectAgentRunner: projectRunner,
+		Publisher:          invocationPublisher,
+	}, loader, loaders.RuntimeExecutionContext{ID: "invocation-correlation", Kind: loaders.ExecutionKindInvocation}, loaders.TriggerEventMetadata{})
+	if _, err := invocationHost.Agent(ctx, "review", domain.LoaderAgentRequest{}); err != nil {
+		t.Fatalf("Invocation Project Agent returned error: %v", err)
+	}
+	if len(invocationPublisher.events) != 1 || invocationPublisher.events[0].payload["projectRunId"] != "project-run" {
+		t.Fatalf("invocation publisher = %#v", invocationPublisher.events)
+	}
+	if _, ok := invocationPublisher.events[0].payload["loaderRunId"]; ok {
+		t.Fatalf("invocation payload exposed correlation id as loader run: %#v", invocationPublisher.events[0].payload)
 	}
 }
 
@@ -171,7 +188,7 @@ func TestRuntimeHostProjectAgentUsesUniqueRequestIDs(t *testing.T) {
 	}}
 	host := loaders.NewRuntimeHost(loaders.RunHostDependencies{
 		ProjectAgentRunner: projectRunner,
-	}, loader, run, loaders.TriggerEventMetadata{})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{})
 
 	for range 2 {
 		if _, err := host.Agent(context.Background(), "review", domain.LoaderAgentRequest{}); err != nil {
@@ -204,7 +221,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 			err:  errors.New("agent failed"),
 		},
 		Publisher: &hostPublisherFake{},
-	}, loader, run, loaders.TriggerEventMetadata{EventID: "topic-event"})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{EventID: "topic-event"})
 	agentResult, err := host.Agent(ctx, "prompt", domain.LoaderAgentRequest{})
 	if err == nil || agentResult.Text != "agent stderr" || !events.contains("loader.agent.failed") || !events.contains("loader.sandbox.stop_failed") {
 		t.Fatalf("agent error result=%#v err=%v events=%#v", agentResult, err, events.types())
@@ -222,14 +239,14 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 			Error:     "project failed",
 		}},
 		Publisher: &hostPublisherFake{},
-	}, projectLoader, run, loaders.TriggerEventMetadata{})
+	}, projectLoader, triggerExecution(run), loaders.TriggerEventMetadata{})
 	projectResult, err := projectHost.Agent(ctx, "prompt", domain.LoaderAgentRequest{})
 	if err != nil || projectResult.Text != "project failed" || !projectEvents.contains("loader.agent.failed") {
 		t.Fatalf("project failed result=%#v err=%v events=%#v", projectResult, err, projectEvents.types())
 	}
 	projectHost = loaders.NewRuntimeHost(loaders.RunHostDependencies{
 		ProjectAgentRunner: &hostProjectAgentRunnerFake{err: errors.New("project unavailable")},
-	}, projectLoader, run, loaders.TriggerEventMetadata{})
+	}, projectLoader, triggerExecution(run), loaders.TriggerEventMetadata{})
 	if _, err := projectHost.Agent(ctx, "prompt", domain.LoaderAgentRequest{}); err == nil {
 		t.Fatalf("project runner error returned nil")
 	}
@@ -241,7 +258,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 			session:   &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-command", VMStatus: domain.VMStatusRunning}},
 			ensureErr: errors.New("ensure failed"),
 		},
-	}, loader, run, loaders.TriggerEventMetadata{})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{})
 	if _, err := commandHost.Command(ctx, domain.LoaderCommandRequest{Mode: "shell", Command: "echo"}); err == nil || !commandEvents.contains("loader.command.failed") {
 		t.Fatalf("command ensure err=%v events=%#v", err, commandEvents.types())
 	}
@@ -250,7 +267,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 		Events:          commandEvents,
 		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-command", VMStatus: domain.VMStatusRunning}}},
 		CommandExecutor: &hostCommandExecutorFake{err: errors.New("command failed"), result: domain.LoaderCommandResult{SandboxID: "session-command", CellID: "cell-command", Output: "partial"}},
-	}, loader, run, loaders.TriggerEventMetadata{})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{})
 	if result, err := commandHost.Command(ctx, domain.LoaderCommandRequest{Mode: "shell", Command: "false"}); err == nil || result.Output != "partial" || !commandEvents.contains("loader.command.failed") {
 		t.Fatalf("command executor result=%#v err=%v events=%#v", result, err, commandEvents.types())
 	}
@@ -259,24 +276,24 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 		Events:          commandEvents,
 		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-command", VMStatus: domain.VMStatusRunning}}},
 		CommandExecutor: &hostCommandExecutorFake{result: domain.LoaderCommandResult{Output: "bad", Success: false, SandboxID: "session-command"}},
-	}, loader, run, loaders.TriggerEventMetadata{})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{})
 	if result, err := commandHost.Command(ctx, domain.LoaderCommandRequest{Mode: "shell", Command: "false"}); err != nil || result.Success || !commandEvents.contains("loader.command.completed") {
 		t.Fatalf("command nonzero result=%#v err=%v events=%#v", result, err, commandEvents.types())
 	}
 
-	if _, err := loaders.NewRuntimeHost(loaders.RunHostDependencies{}, loader, run, loaders.TriggerEventMetadata{}).LLM(ctx, "prompt", domain.LoaderLLMRequest{}); err == nil {
+	if _, err := loaders.NewRuntimeHost(loaders.RunHostDependencies{}, loader, triggerExecution(run), loaders.TriggerEventMetadata{}).LLM(ctx, "prompt", domain.LoaderLLMRequest{}); err == nil {
 		t.Fatalf("nil LLM returned nil error")
 	}
 	llmEvents := &hostEventsFake{}
 	llmHost := loaders.NewRuntimeHost(loaders.RunHostDependencies{
 		Events: llmEvents,
 		LLM:    &hostLLMFake{err: errors.New("llm failed")},
-	}, loader, run, loaders.TriggerEventMetadata{})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{})
 	if _, err := llmHost.LLM(ctx, "prompt", domain.LoaderLLMRequest{Model: "model-a"}); err == nil || !llmEvents.contains("loader.llm.failed") {
 		t.Fatalf("llm err=%v events=%#v", err, llmEvents.types())
 	}
 
-	if _, err := loaders.NewRuntimeHost(loaders.RunHostDependencies{}, loader, run, loaders.TriggerEventMetadata{}).CallSessionRPC(ctx, "GetSession", `{}`); err == nil {
+	if _, err := loaders.NewRuntimeHost(loaders.RunHostDependencies{}, loader, triggerExecution(run), loaders.TriggerEventMetadata{}).CallSessionRPC(ctx, "GetSession", `{}`); err == nil {
 		t.Fatalf("nil session RPC returned nil error")
 	}
 	rpcEvents := &hostEventsFake{}
@@ -291,7 +308,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 			}
 			return ""
 		},
-	}, loader, run, loaders.TriggerEventMetadata{EventID: "topic-event"})
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{EventID: "topic-event"})
 	if _, err := rpcHost.CallSessionRPC(ctx, "GetSession", `{"sessionId":"sandbox-rpc"}`); err == nil || !rpcEvents.contains("loader.sandbox.rpc.failed") || !rpcStore.containsLink("sandbox-rpc", "sandbox_rpc_failed") {
 		t.Fatalf("rpc err=%v events=%#v links=%#v", err, rpcEvents.types(), rpcStore.links)
 	}
@@ -306,7 +323,7 @@ func TestRuntimeHostLogPublishEventAndState(t *testing.T) {
 	host := loaders.NewRuntimeHost(loaders.RunHostDependencies{
 		Store:  store,
 		Events: events,
-	}, loader, run, loaders.TriggerEventMetadata{
+	}, loader, triggerExecution(run), loaders.TriggerEventMetadata{
 		EventID:       "trigger-event",
 		CorrelationID: "correlation-1",
 	})
@@ -325,8 +342,22 @@ func TestRuntimeHostLogPublishEventAndState(t *testing.T) {
 	if created.Topic != "runtime.demo" || created.Sequence != 7 || created.PayloadJSON == `{"value":1}` {
 		t.Fatalf("created event = %#v", created)
 	}
+	if created.PublisherRunID != run.ID {
+		t.Fatalf("trigger publisher run ID = %q, want %q", created.PublisherRunID, run.ID)
+	}
 	if !events.contains("loader.event.published") {
 		t.Fatalf("events after PublishEvent = %#v", events.types())
+	}
+	invocationStore := &hostStoreFake{}
+	invocationHost := loaders.NewRuntimeHost(loaders.RunHostDependencies{Store: invocationStore}, loader, loaders.RuntimeExecutionContext{
+		ID: "invocation-correlation", Kind: loaders.ExecutionKindInvocation,
+	}, loaders.TriggerEventMetadata{})
+	invocationEvent, err := invocationHost.PublishEvent(ctx, "runtime.demo", `{"value":2}`)
+	if err != nil {
+		t.Fatalf("Invocation PublishEvent returned error: %v", err)
+	}
+	if invocationEvent.PublisherRunID != "" {
+		t.Fatalf("invocation correlation ID exposed as publisher run ID: %#v", invocationEvent)
 	}
 
 	if err := host.StateSet(ctx, "cursor", `{"offset":2}`); err != nil {
@@ -343,10 +374,14 @@ func TestRuntimeHostLogPublishEventAndState(t *testing.T) {
 		t.Fatalf("StateGet after delete ok=%v err=%v", ok, err)
 	}
 
-	missingStoreHost := loaders.NewRuntimeHost(loaders.RunHostDependencies{}, loader, run, loaders.TriggerEventMetadata{})
+	missingStoreHost := loaders.NewRuntimeHost(loaders.RunHostDependencies{}, loader, triggerExecution(run), loaders.TriggerEventMetadata{})
 	if _, err := missingStoreHost.PublishEvent(ctx, "runtime.demo", `{}`); err == nil || !strings.Contains(err.Error(), "event store is unavailable") {
 		t.Fatalf("PublishEvent missing store error = %v", err)
 	}
+}
+
+func triggerExecution(run *domain.LoaderRunSummary) loaders.RuntimeExecutionContext {
+	return loaders.RuntimeExecutionContext{ID: run.ID, TriggerID: run.TriggerID, Kind: loaders.ExecutionKindTrigger}
 }
 
 type hostStoreFake struct {

--- a/pkg/loaders/run_lifecycle.go
+++ b/pkg/loaders/run_lifecycle.go
@@ -24,7 +24,20 @@ type RunHost interface {
 	CleanupCommandSessions(ctx context.Context)
 }
 
-type RunHostFactory func(loader domain.Loader, run *domain.LoaderRunSummary, triggerEvent TriggerEventMetadata) RunHost
+type ExecutionKind string
+
+const (
+	ExecutionKindTrigger    ExecutionKind = "trigger"
+	ExecutionKindInvocation ExecutionKind = "invocation"
+)
+
+type RuntimeExecutionContext struct {
+	ID        string
+	TriggerID string
+	Kind      ExecutionKind
+}
+
+type RunHostFactory func(loader domain.Loader, execution RuntimeExecutionContext, triggerEvent TriggerEventMetadata) RunHost
 
 type RunOptions struct {
 	RetryWhenBusy  bool
@@ -145,7 +158,11 @@ func (e *RunExecutor) Execute(ctx context.Context, prepared PreparedRun) (domain
 	}
 	defer e.leaveRun(prepared.Loader.Summary.ID)
 	run := prepared.Run
-	host := e.deps.HostFactory(prepared.Loader, &run, ParseTriggerEventMetadata(prepared.PayloadJSON))
+	host := e.deps.HostFactory(prepared.Loader, RuntimeExecutionContext{
+		ID:        run.ID,
+		TriggerID: run.TriggerID,
+		Kind:      ExecutionKindTrigger,
+	}, ParseTriggerEventMetadata(prepared.PayloadJSON))
 	execution, execErr := e.deps.Engine.Execute(ctx, LoaderExecutionRequest{
 		Runtime:     prepared.Loader.Summary.Runtime,
 		Script:      prepared.Loader.Script,

--- a/pkg/loaders/run_query.go
+++ b/pkg/loaders/run_query.go
@@ -4,8 +4,27 @@ import "time"
 
 type LoaderRunPageFilter struct {
 	LoaderIDs       []string
+	RequireTrigger  bool
+	TriggerID       string
+	Status          string
 	BeforeStartedAt time.Time
 	BeforeLoaderID  string
 	BeforeRunID     string
+	Limit           int
+}
+
+type LoaderRunKey struct {
+	LoaderID string
+	RunID    string
+}
+
+type LoaderEventPageFilter struct {
+	LoaderIDs       []string
+	RequireTrigger  bool
+	TriggerID       string
+	RunID           string
+	BeforeCreatedAt time.Time
+	BeforeLoaderID  string
+	BeforeEventID   string
 	Limit           int
 }

--- a/pkg/loaders/scan.go
+++ b/pkg/loaders/scan.go
@@ -249,9 +249,9 @@ func SelectLoaderSummarySQL() string {
         l.created_at,
         l.updated_at,
         (SELECT COUNT(*) FROM loader_trigger t WHERE t.loader_id = l.id),
-        (SELECT COUNT(*) FROM loader_run r WHERE r.loader_id = l.id),
-        (SELECT COUNT(*) FROM loader_event e WHERE e.loader_id = l.id),
-        (SELECT MAX(r.started_at) FROM loader_run r WHERE r.loader_id = l.id)
+		(SELECT COUNT(*) FROM loader_run r WHERE r.loader_id = l.id AND r.trigger_id <> ''),
+		(SELECT COUNT(*) FROM loader_event e JOIN loader_run er ON er.loader_id = e.loader_id AND er.run_id = e.run_id WHERE e.loader_id = l.id AND er.trigger_id <> ''),
+		(SELECT MAX(r.started_at) FROM loader_run r WHERE r.loader_id = l.id AND r.trigger_id <> '')
         FROM loader l`
 }
 

--- a/pkg/loaders/scheduler_run_artifacts.go
+++ b/pkg/loaders/scheduler_run_artifacts.go
@@ -1,0 +1,128 @@
+package loaders
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"agent-compose/pkg/identity"
+)
+
+func (a FSArtifacts) InspectRunArtifacts(loaderID, runID, recordedDir string) (SchedulerRunArtifactInfo, error) {
+	target, err := a.safeRunArtifactsPath(loaderID, runID, recordedDir)
+	if err != nil {
+		return SchedulerRunArtifactInfo{}, err
+	}
+	info := SchedulerRunArtifactInfo{Path: target}
+	entry, err := os.Lstat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return info, nil
+		}
+		return SchedulerRunArtifactInfo{}, fmt.Errorf("inspect scheduler run artifacts: %w", err)
+	}
+	if entry.Mode()&os.ModeSymlink != 0 {
+		return SchedulerRunArtifactInfo{}, fmt.Errorf("scheduler run artifacts path must not be a symlink")
+	}
+	if !entry.IsDir() {
+		return SchedulerRunArtifactInfo{}, fmt.Errorf("scheduler run artifacts path is not a directory")
+	}
+	info.Exists = true
+	if err := filepath.WalkDir(target, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type().IsRegular() {
+			fileInfo, infoErr := entry.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			if fileInfo.Size() > 0 {
+				info.Bytes += uint64(fileInfo.Size())
+			}
+		}
+		return nil
+	}); err != nil {
+		return SchedulerRunArtifactInfo{}, fmt.Errorf("measure scheduler run artifacts: %w", err)
+	}
+	return info, nil
+}
+
+func (a FSArtifacts) RemoveRunArtifacts(loaderID, runID, recordedDir string) (SchedulerRunArtifactInfo, error) {
+	info, err := a.InspectRunArtifacts(loaderID, runID, recordedDir)
+	if err != nil || !info.Exists {
+		return info, err
+	}
+	if err := os.RemoveAll(info.Path); err != nil {
+		return info, fmt.Errorf("remove scheduler run artifacts: %w", err)
+	}
+	return info, nil
+}
+
+func (a FSArtifacts) safeRunArtifactsPath(loaderID, runID, recordedDir string) (string, error) {
+	loaderID = strings.TrimSpace(loaderID)
+	runID = strings.TrimSpace(runID)
+	if !identity.IsID(loaderID) || !identity.IsID(runID) {
+		return "", fmt.Errorf("loader and run ids must be complete resource ids")
+	}
+	if strings.TrimSpace(a.DataRoot) == "" {
+		return "", fmt.Errorf("scheduler run artifacts data root is empty")
+	}
+	dataRoot, err := filepath.Abs(a.DataRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve scheduler run artifacts data root: %w", err)
+	}
+	runsRoot := filepath.Join(dataRoot, "loaders", loaderID, "runs")
+	runsRoot, err = filepath.Abs(runsRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve scheduler run artifacts root: %w", err)
+	}
+	target, err := filepath.Abs(filepath.Join(runsRoot, runID))
+	if err != nil {
+		return "", fmt.Errorf("resolve scheduler run artifacts path: %w", err)
+	}
+	relative, err := filepath.Rel(runsRoot, target)
+	if err != nil || relative != runID || filepath.Base(target) != runID {
+		return "", fmt.Errorf("scheduler run artifacts path escapes the runs root")
+	}
+	if recordedDir = strings.TrimSpace(recordedDir); recordedDir != "" {
+		recorded, absErr := filepath.Abs(recordedDir)
+		if absErr != nil || filepath.Clean(recorded) != filepath.Clean(target) {
+			return "", fmt.Errorf("recorded artifacts directory does not match the canonical run path")
+		}
+	}
+	if err := rejectSymlinkPathBelowRoot(dataRoot, filepath.Dir(target)); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func rejectSymlinkPathBelowRoot(root, target string) error {
+	relative, err := filepath.Rel(root, target)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("scheduler run artifacts parent escapes the data root")
+	}
+	current := root
+	for _, part := range strings.Split(relative, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		entry, statErr := os.Lstat(current)
+		if os.IsNotExist(statErr) {
+			return nil
+		}
+		if statErr != nil {
+			return fmt.Errorf("inspect scheduler run artifacts parent: %w", statErr)
+		}
+		if entry.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("scheduler run artifacts parent must not contain symlinks")
+		}
+		if !entry.IsDir() {
+			return fmt.Errorf("scheduler run artifacts parent is not a directory")
+		}
+	}
+	return nil
+}

--- a/pkg/loaders/scheduler_run_artifacts_test.go
+++ b/pkg/loaders/scheduler_run_artifacts_test.go
@@ -1,0 +1,102 @@
+package loaders
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"agent-compose/pkg/identity"
+)
+
+func TestFSArtifactsInspectAndRemoveRunArtifacts(t *testing.T) {
+	root := t.TempDir()
+	loaderID := identity.NewID(identity.ResourceLoader, "loader")
+	runID := identity.NewID(identity.ResourceRun, "run")
+	artifacts := FSArtifacts{DataRoot: root}
+	dir := artifacts.RunDir(loaderID, runID)
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatalf("create artifact directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "payload.json"), []byte("12345"), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "nested", "result.json"), []byte("1234567"), 0o644); err != nil {
+		t.Fatalf("write result: %v", err)
+	}
+
+	info, err := artifacts.InspectRunArtifacts(loaderID, runID, dir)
+	if err != nil || !info.Exists || info.Path != dir || info.Bytes != 12 {
+		t.Fatalf("inspect info=%#v err=%v", info, err)
+	}
+	removed, err := artifacts.RemoveRunArtifacts(loaderID, runID, dir)
+	if err != nil || removed != info {
+		t.Fatalf("remove info=%#v err=%v, want %#v", removed, err, info)
+	}
+	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+		t.Fatalf("artifact directory still exists: %v", err)
+	}
+	missing, err := artifacts.InspectRunArtifacts(loaderID, runID, dir)
+	if err != nil || missing.Exists || missing.Path != dir {
+		t.Fatalf("missing info=%#v err=%v", missing, err)
+	}
+}
+
+func TestFSArtifactsRejectsUnsafeRunArtifactPaths(t *testing.T) {
+	root := t.TempDir()
+	loaderID := identity.NewID(identity.ResourceLoader, "loader")
+	runID := identity.NewID(identity.ResourceRun, "run")
+	artifacts := FSArtifacts{DataRoot: root}
+	dir := artifacts.RunDir(loaderID, runID)
+
+	tests := []struct {
+		name      string
+		loaderID  string
+		runID     string
+		recorded  string
+		wantError string
+	}{
+		{name: "invalid loader id", loaderID: "loader", runID: runID, wantError: "complete resource ids"},
+		{name: "invalid run id", loaderID: loaderID, runID: "run", wantError: "complete resource ids"},
+		{name: "recorded mismatch", loaderID: loaderID, runID: runID, recorded: filepath.Join(root, "elsewhere"), wantError: "does not match"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := artifacts.InspectRunArtifacts(test.loaderID, test.runID, test.recorded)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("error=%v, want %q", err, test.wantError)
+			}
+		})
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		t.Fatalf("create runs root: %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, dir); err != nil {
+		t.Fatalf("create run symlink: %v", err)
+	}
+	if _, err := artifacts.InspectRunArtifacts(loaderID, runID, dir); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("run symlink error=%v", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside directory changed: %v", err)
+	}
+}
+
+func TestFSArtifactsRejectsSymlinkedParentBelowDataRoot(t *testing.T) {
+	root := t.TempDir()
+	loaderID := identity.NewID(identity.ResourceLoader, "loader")
+	runID := identity.NewID(identity.ResourceRun, "run")
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "loaders"), 0o755); err != nil {
+		t.Fatalf("create loaders root: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "loaders", loaderID)); err != nil {
+		t.Fatalf("create loader symlink: %v", err)
+	}
+	artifacts := FSArtifacts{DataRoot: root}
+	if _, err := artifacts.InspectRunArtifacts(loaderID, runID, ""); err == nil || !strings.Contains(err.Error(), "parent must not contain symlinks") {
+		t.Fatalf("symlink parent error=%v", err)
+	}
+}

--- a/pkg/loaders/scheduler_run_prune.go
+++ b/pkg/loaders/scheduler_run_prune.go
@@ -1,0 +1,274 @@
+package loaders
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+type SchedulerRunPruneFilter struct {
+	LoaderIDs []string
+	TriggerID string
+	Statuses  []string
+	OlderThan time.Duration
+	Now       time.Time
+}
+
+type SchedulerRunPruneRequest struct {
+	LoaderIDs []string
+	TriggerID string
+	Statuses  []string
+	OlderThan time.Duration
+	Force     bool
+}
+
+type SchedulerRunPruneStats struct {
+	Runs              uint64
+	LoaderEvents      uint64
+	EventDeliveries   uint64
+	EventSandboxLinks uint64
+	ArtifactDirs      uint64
+	ArtifactBytes     uint64
+}
+
+type SchedulerRunPruneResidue struct {
+	LoaderID string
+	RunID    string
+	Path     string
+	Error    string
+}
+
+type SchedulerRunPruneResult struct {
+	DryRun      bool
+	Matched     SchedulerRunPruneStats
+	Removed     SchedulerRunPruneStats
+	SkippedRuns uint64
+	Residues    []SchedulerRunPruneResidue
+	Warnings    []string
+}
+
+type SchedulerRunPruneDatabaseStats struct {
+	LoaderEvents      uint64
+	EventDeliveries   uint64
+	EventSandboxLinks uint64
+	Runs              uint64
+}
+
+type SchedulerRunPruneDatabaseResult struct {
+	Stats       SchedulerRunPruneDatabaseStats
+	RemovedKeys []LoaderRunKey
+}
+
+type SchedulerRunPruneStore interface {
+	ListLoaderRunsForPrune(context.Context, SchedulerRunPruneFilter) ([]domain.LoaderRunSummary, error)
+	CountLoaderRunPruneData(context.Context, []LoaderRunKey) (SchedulerRunPruneDatabaseStats, error)
+	DeleteLoaderRunPruneData(context.Context, []LoaderRunKey) (SchedulerRunPruneDatabaseResult, error)
+}
+
+type SchedulerRunArtifactPruner interface {
+	InspectRunArtifacts(loaderID, runID, recordedDir string) (SchedulerRunArtifactInfo, error)
+	RemoveRunArtifacts(loaderID, runID, recordedDir string) (SchedulerRunArtifactInfo, error)
+}
+
+type SchedulerRunArtifactInfo struct {
+	Path   string
+	Exists bool
+	Bytes  uint64
+}
+
+type schedulerRunPruneCandidate struct {
+	run      domain.LoaderRunSummary
+	artifact SchedulerRunArtifactInfo
+}
+
+func (c *Controller) PruneSchedulerRuns(ctx context.Context, request SchedulerRunPruneRequest) (SchedulerRunPruneResult, error) {
+	store, ok := c.deps.Store.(SchedulerRunPruneStore)
+	if !ok || store == nil {
+		return SchedulerRunPruneResult{}, fmt.Errorf("scheduler run prune store is unavailable")
+	}
+	filter, err := normalizeSchedulerRunPruneFilter(request, c.now())
+	if err != nil {
+		return SchedulerRunPruneResult{}, err
+	}
+	runs, err := store.ListLoaderRunsForPrune(ctx, filter)
+	if err != nil {
+		return SchedulerRunPruneResult{}, err
+	}
+	result := SchedulerRunPruneResult{DryRun: !request.Force}
+	if filter.OlderThan > 0 {
+		missingCompletedAt := 0
+		for _, run := range runs {
+			if run.CompletedAt.IsZero() {
+				missingCompletedAt++
+			}
+		}
+		if missingCompletedAt > 0 {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("%d terminal run(s) have no completion timestamp; older-than used their start time", missingCompletedAt))
+		}
+	}
+	keys := schedulerRunKeys(runs)
+	databaseStats, err := store.CountLoaderRunPruneData(ctx, keys)
+	if err != nil {
+		return result, err
+	}
+	addSchedulerRunPruneDatabaseStats(&result.Matched, databaseStats)
+
+	artifactPruner, _ := c.deps.Artifacts.(SchedulerRunArtifactPruner)
+	if len(runs) > 0 && artifactPruner == nil {
+		return result, fmt.Errorf("scheduler run artifact pruner is unavailable")
+	}
+	candidates := make([]schedulerRunPruneCandidate, 0, len(runs))
+	busyLoaders := make(map[string]struct{})
+	invalidArtifacts := 0
+	for _, run := range runs {
+		if c.loaderBusy(run.LoaderID) {
+			result.SkippedRuns++
+			busyLoaders[run.LoaderID] = struct{}{}
+			continue
+		}
+		candidate := schedulerRunPruneCandidate{run: run}
+		candidate.artifact, err = artifactPruner.InspectRunArtifacts(run.LoaderID, run.ID, run.ArtifactsDir)
+		if err != nil {
+			result.SkippedRuns++
+			invalidArtifacts++
+			result.Warnings = append(result.Warnings, fmt.Sprintf("scheduler run %s/%s artifacts are unsafe to prune: %v", run.LoaderID, run.ID, err))
+			continue
+		}
+		if candidate.artifact.Exists {
+			result.Matched.ArtifactDirs++
+			result.Matched.ArtifactBytes += candidate.artifact.Bytes
+		}
+		candidates = append(candidates, candidate)
+	}
+	if len(busyLoaders) > 0 {
+		busyRuns := result.SkippedRuns - min(result.SkippedRuns, uint64(invalidArtifacts))
+		result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %d matching run(s) from %d busy scheduler(s)", busyRuns, len(busyLoaders)))
+	}
+	if result.DryRun || len(candidates) == 0 {
+		return result, nil
+	}
+
+	removedDatabase, err := store.DeleteLoaderRunPruneData(ctx, schedulerRunCandidateKeys(candidates))
+	if err != nil {
+		return result, err
+	}
+	addSchedulerRunPruneDatabaseStats(&result.Removed, removedDatabase.Stats)
+	removedKeys := make(map[LoaderRunKey]struct{}, len(removedDatabase.RemovedKeys))
+	for _, key := range removedDatabase.RemovedKeys {
+		removedKeys[key] = struct{}{}
+	}
+	for _, candidate := range candidates {
+		key := LoaderRunKey{LoaderID: candidate.run.LoaderID, RunID: candidate.run.ID}
+		if _, removed := removedKeys[key]; !removed {
+			result.SkippedRuns++
+			result.Warnings = append(result.Warnings, fmt.Sprintf("scheduler run %s/%s no longer matched during force recheck and was not removed", candidate.run.LoaderID, candidate.run.ID))
+			continue
+		}
+		if !candidate.artifact.Exists {
+			continue
+		}
+		removed, removeErr := artifactPruner.RemoveRunArtifacts(candidate.run.LoaderID, candidate.run.ID, candidate.run.ArtifactsDir)
+		if removeErr != nil {
+			result.Residues = append(result.Residues, SchedulerRunPruneResidue{
+				LoaderID: candidate.run.LoaderID,
+				RunID:    candidate.run.ID,
+				Path:     candidate.artifact.Path,
+				Error:    removeErr.Error(),
+			})
+			continue
+		}
+		if removed.Exists {
+			result.Removed.ArtifactDirs++
+			result.Removed.ArtifactBytes += removed.Bytes
+		}
+	}
+	return result, nil
+}
+
+func normalizeSchedulerRunPruneFilter(request SchedulerRunPruneRequest, now time.Time) (SchedulerRunPruneFilter, error) {
+	loaderIDs := normalizedStrings(request.LoaderIDs)
+	if request.OlderThan < 0 {
+		return SchedulerRunPruneFilter{}, domain.ClassifyError(domain.ErrInvalidArgument, "scheduler run prune older-than must not be negative", nil)
+	}
+	statuses := request.Statuses
+	if len(statuses) == 0 {
+		statuses = []string{
+			domain.LoaderRunStatusSucceeded,
+			domain.LoaderRunStatusFailed,
+			domain.LoaderRunStatusCanceled,
+			domain.LoaderRunStatusSkipped,
+		}
+	}
+	normalizedStatuses := make([]string, 0, len(statuses))
+	seenStatuses := make(map[string]struct{}, len(statuses))
+	for _, raw := range statuses {
+		status := strings.ToLower(strings.TrimSpace(raw))
+		if !SchedulerRunStatusIsTerminal(status) {
+			return SchedulerRunPruneFilter{}, domain.ClassifyError(domain.ErrInvalidArgument, fmt.Sprintf("scheduler run prune status %q is not terminal", raw), nil)
+		}
+		if _, exists := seenStatuses[status]; exists {
+			continue
+		}
+		seenStatuses[status] = struct{}{}
+		normalizedStatuses = append(normalizedStatuses, status)
+	}
+	sort.Strings(normalizedStatuses)
+	return SchedulerRunPruneFilter{
+		LoaderIDs: loaderIDs,
+		TriggerID: strings.TrimSpace(request.TriggerID),
+		Statuses:  normalizedStatuses,
+		OlderThan: request.OlderThan,
+		Now:       now.UTC(),
+	}, nil
+}
+
+func normalizedStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func schedulerRunKeys(runs []domain.LoaderRunSummary) []LoaderRunKey {
+	keys := make([]LoaderRunKey, 0, len(runs))
+	for _, run := range runs {
+		keys = append(keys, LoaderRunKey{LoaderID: run.LoaderID, RunID: run.ID})
+	}
+	return keys
+}
+
+func schedulerRunCandidateKeys(candidates []schedulerRunPruneCandidate) []LoaderRunKey {
+	keys := make([]LoaderRunKey, 0, len(candidates))
+	for _, candidate := range candidates {
+		keys = append(keys, LoaderRunKey{LoaderID: candidate.run.LoaderID, RunID: candidate.run.ID})
+	}
+	return keys
+}
+
+func addSchedulerRunPruneDatabaseStats(target *SchedulerRunPruneStats, source SchedulerRunPruneDatabaseStats) {
+	target.Runs += source.Runs
+	target.LoaderEvents += source.LoaderEvents
+	target.EventDeliveries += source.EventDeliveries
+	target.EventSandboxLinks += source.EventSandboxLinks
+}
+
+func (c *Controller) loaderBusy(loaderID string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.running[strings.TrimSpace(loaderID)] > 0
+}

--- a/pkg/loaders/scheduler_run_prune_test.go
+++ b/pkg/loaders/scheduler_run_prune_test.go
@@ -1,0 +1,281 @@
+package loaders
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestNormalizeSchedulerRunPruneFilter(t *testing.T) {
+	now := time.Date(2026, 7, 22, 10, 0, 0, 0, time.FixedZone("test", 8*60*60))
+	filter, err := normalizeSchedulerRunPruneFilter(SchedulerRunPruneRequest{
+		LoaderIDs: []string{" loader-b ", "loader-a", "loader-b"},
+		Statuses:  []string{" FAILED ", "succeeded", "failed"},
+		TriggerID: " trigger-a ",
+		OlderThan: 24 * time.Hour,
+	}, now)
+	if err != nil {
+		t.Fatalf("normalize filter: %v", err)
+	}
+	if strings.Join(filter.LoaderIDs, ",") != "loader-a,loader-b" || strings.Join(filter.Statuses, ",") != "failed,succeeded" {
+		t.Fatalf("normalized filter = %#v", filter)
+	}
+	if filter.TriggerID != "trigger-a" || filter.OlderThan != 24*time.Hour || !filter.Now.Equal(now.UTC()) {
+		t.Fatalf("normalized filter = %#v", filter)
+	}
+
+	defaults, err := normalizeSchedulerRunPruneFilter(SchedulerRunPruneRequest{}, now)
+	if err != nil {
+		t.Fatalf("normalize default filter: %v", err)
+	}
+	if strings.Join(defaults.Statuses, ",") != "canceled,failed,skipped,succeeded" {
+		t.Fatalf("default statuses = %#v", defaults.Statuses)
+	}
+	for _, request := range []SchedulerRunPruneRequest{
+		{Statuses: []string{domain.LoaderRunStatusRunning}},
+		{Statuses: []string{"pending"}},
+		{OlderThan: -time.Second},
+	} {
+		if _, err := normalizeSchedulerRunPruneFilter(request, now); !errors.Is(err, domain.ErrInvalidArgument) {
+			t.Fatalf("normalize %#v error = %v, want invalid argument", request, err)
+		}
+	}
+}
+
+func TestControllerPruneSchedulerRunsDryRunCountsWithoutDeleting(t *testing.T) {
+	store := &schedulerRunPruneStoreFake{
+		runs: []domain.LoaderRunSummary{
+			{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", ArtifactsDir: "/recorded/a"},
+			{ID: "run-b", LoaderID: "loader-b", TriggerID: "trigger-b", ArtifactsDir: "/recorded/b"},
+		},
+		counted: SchedulerRunPruneDatabaseStats{Runs: 2, LoaderEvents: 5, EventDeliveries: 1, EventSandboxLinks: 2},
+	}
+	artifacts := &schedulerRunArtifactPrunerFake{inspected: map[string]SchedulerRunArtifactInfo{
+		"loader-a/run-a": {Path: "/recorded/a", Exists: true, Bytes: 7},
+		"loader-b/run-b": {Path: "/recorded/b", Exists: true, Bytes: 11},
+	}}
+	controller := newSchedulerRunPruneController(store, artifacts, nil)
+	result, err := controller.PruneSchedulerRuns(context.Background(), SchedulerRunPruneRequest{LoaderIDs: []string{"loader-b", "loader-a"}})
+	if err != nil {
+		t.Fatalf("prune dry-run: %v", err)
+	}
+	if !result.DryRun || store.deleteCalls != 0 || len(artifacts.removed) != 0 {
+		t.Fatalf("dry-run result=%#v delete_calls=%d removed=%#v", result, store.deleteCalls, artifacts.removed)
+	}
+	want := SchedulerRunPruneStats{Runs: 2, LoaderEvents: 5, EventDeliveries: 1, EventSandboxLinks: 2, ArtifactDirs: 2, ArtifactBytes: 18}
+	if result.Matched != want {
+		t.Fatalf("matched=%#v, want %#v", result.Matched, want)
+	}
+	if strings.Join(store.filter.Statuses, ",") != "canceled,failed,skipped,succeeded" {
+		t.Fatalf("default statuses = %#v", store.filter.Statuses)
+	}
+}
+
+func TestControllerPruneSchedulerRunsForceRemovesDatabaseAndArtifacts(t *testing.T) {
+	store := &schedulerRunPruneStoreFake{
+		runs: []domain.LoaderRunSummary{
+			{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", ArtifactsDir: "/recorded/a"},
+			{ID: "run-b", LoaderID: "loader-a", TriggerID: "trigger-a", ArtifactsDir: "/recorded/b"},
+		},
+		counted: SchedulerRunPruneDatabaseStats{Runs: 2, LoaderEvents: 4},
+		deleted: SchedulerRunPruneDatabaseStats{Runs: 2, LoaderEvents: 4},
+	}
+	artifacts := &schedulerRunArtifactPrunerFake{
+		inspected: map[string]SchedulerRunArtifactInfo{
+			"loader-a/run-a": {Path: "/recorded/a", Exists: true, Bytes: 13},
+			"loader-a/run-b": {Path: "/recorded/b"},
+		},
+		removeResults: map[string]SchedulerRunArtifactInfo{
+			"loader-a/run-a": {Path: "/recorded/a", Exists: true, Bytes: 13},
+		},
+	}
+	controller := newSchedulerRunPruneController(store, artifacts, nil)
+	result, err := controller.PruneSchedulerRuns(context.Background(), SchedulerRunPruneRequest{LoaderIDs: []string{"loader-a"}, Force: true})
+	if err != nil {
+		t.Fatalf("force prune: %v", err)
+	}
+	if result.DryRun || store.deleteCalls != 1 || len(store.deletedKeys) != 2 {
+		t.Fatalf("force result=%#v store=%#v", result, store)
+	}
+	wantRemoved := SchedulerRunPruneStats{Runs: 2, LoaderEvents: 4, ArtifactDirs: 1, ArtifactBytes: 13}
+	if result.Removed != wantRemoved || len(artifacts.removed) != 1 {
+		t.Fatalf("removed=%#v artifacts=%#v, want %#v", result.Removed, artifacts.removed, wantRemoved)
+	}
+}
+
+func TestControllerPruneSchedulerRunsSkipsBusyAndUnsafeRuns(t *testing.T) {
+	store := &schedulerRunPruneStoreFake{
+		runs: []domain.LoaderRunSummary{
+			{ID: "run-busy", LoaderID: "loader-busy", TriggerID: "trigger-a"},
+			{ID: "run-unsafe", LoaderID: "loader-free", TriggerID: "trigger-a"},
+		},
+		counted: SchedulerRunPruneDatabaseStats{Runs: 2, LoaderEvents: 2},
+	}
+	artifacts := &schedulerRunArtifactPrunerFake{inspectErrors: map[string]error{
+		"loader-free/run-unsafe": errors.New("recorded path mismatch"),
+	}}
+	controller := newSchedulerRunPruneController(store, artifacts, map[string]int{"loader-busy": 1})
+	result, err := controller.PruneSchedulerRuns(context.Background(), SchedulerRunPruneRequest{LoaderIDs: []string{"loader-busy", "loader-free"}, Force: true})
+	if err != nil {
+		t.Fatalf("force prune: %v", err)
+	}
+	if result.SkippedRuns != 2 || store.deleteCalls != 0 || len(result.Warnings) != 2 {
+		t.Fatalf("result=%#v delete_calls=%d", result, store.deleteCalls)
+	}
+	if !strings.Contains(strings.Join(result.Warnings, "\n"), "skipped 1 matching run(s) from 1 busy scheduler(s)") {
+		t.Fatalf("warnings=%#v", result.Warnings)
+	}
+}
+
+func TestControllerPruneSchedulerRunsReportsArtifactResidue(t *testing.T) {
+	store := &schedulerRunPruneStoreFake{
+		runs:    []domain.LoaderRunSummary{{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", ArtifactsDir: "/recorded/a"}},
+		counted: SchedulerRunPruneDatabaseStats{Runs: 1},
+		deleted: SchedulerRunPruneDatabaseStats{Runs: 1},
+	}
+	artifacts := &schedulerRunArtifactPrunerFake{
+		inspected:    map[string]SchedulerRunArtifactInfo{"loader-a/run-a": {Path: "/recorded/a", Exists: true, Bytes: 9}},
+		removeErrors: map[string]error{"loader-a/run-a": errors.New("permission denied")},
+	}
+	controller := newSchedulerRunPruneController(store, artifacts, nil)
+	result, err := controller.PruneSchedulerRuns(context.Background(), SchedulerRunPruneRequest{LoaderIDs: []string{"loader-a"}, Force: true})
+	if err != nil {
+		t.Fatalf("force prune: %v", err)
+	}
+	if result.Removed.Runs != 1 || result.Removed.ArtifactDirs != 0 || len(result.Residues) != 1 {
+		t.Fatalf("result=%#v", result)
+	}
+	if result.Residues[0].LoaderID != "loader-a" || result.Residues[0].RunID != "run-a" || !strings.Contains(result.Residues[0].Error, "permission denied") {
+		t.Fatalf("residue=%#v", result.Residues[0])
+	}
+}
+
+func TestControllerPruneSchedulerRunsKeepsArtifactsForForceRecheckSkip(t *testing.T) {
+	store := &schedulerRunPruneStoreFake{
+		runs:        []domain.LoaderRunSummary{{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", ArtifactsDir: "/recorded/a"}},
+		counted:     SchedulerRunPruneDatabaseStats{Runs: 1},
+		removedKeys: []LoaderRunKey{},
+	}
+	artifacts := &schedulerRunArtifactPrunerFake{
+		inspected: map[string]SchedulerRunArtifactInfo{"loader-a/run-a": {Path: "/recorded/a", Exists: true, Bytes: 9}},
+	}
+	controller := newSchedulerRunPruneController(store, artifacts, nil)
+	result, err := controller.PruneSchedulerRuns(context.Background(), SchedulerRunPruneRequest{LoaderIDs: []string{"loader-a"}, Force: true})
+	if err != nil {
+		t.Fatalf("force prune: %v", err)
+	}
+	if result.Removed.Runs != 0 || result.SkippedRuns != 1 || len(artifacts.removed) != 0 || len(result.Warnings) != 1 {
+		t.Fatalf("result=%#v artifacts=%#v", result, artifacts.removed)
+	}
+}
+
+func TestControllerRecoverInterruptedRunsMarksFailedAndRecordsEvent(t *testing.T) {
+	startedAt := time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC)
+	store := &schedulerRunPruneStoreFake{interrupted: []domain.LoaderRunSummary{
+		{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusRunning, StartedAt: startedAt},
+		{ID: "run-b", LoaderID: "loader-b", TriggerID: "trigger-b", Status: domain.LoaderRunStatusRunning, StartedAt: startedAt.Add(10 * time.Minute)},
+	}}
+	controller := newSchedulerRunPruneController(store, nil, nil)
+	controller.deps.NewID = func() string { return "recovery-event" }
+	if err := controller.RecoverInterruptedRuns(context.Background(), startedAt.Add(time.Hour)); err != nil {
+		t.Fatalf("recover interrupted runs: %v", err)
+	}
+	if len(store.updatedRuns) != 2 || len(store.events) != 2 {
+		t.Fatalf("updated=%#v events=%#v", store.updatedRuns, store.events)
+	}
+	for index, run := range store.updatedRuns {
+		if run.Status != domain.LoaderRunStatusFailed || run.CompletedAt.IsZero() || run.DurationMs <= 0 || run.Error != interruptedSchedulerRunError {
+			t.Fatalf("updated run=%#v", run)
+		}
+		event := store.events[index]
+		if event.Type != "loader.run.failed" || event.Level != "error" || event.RunID != run.ID || event.TriggerID != run.TriggerID || !strings.Contains(event.PayloadJSON, "daemon_interrupted") {
+			t.Fatalf("recovery event=%#v", event)
+		}
+	}
+}
+
+type schedulerRunPruneStoreFake struct {
+	ControllerStore
+	runs        []domain.LoaderRunSummary
+	filter      SchedulerRunPruneFilter
+	counted     SchedulerRunPruneDatabaseStats
+	deleted     SchedulerRunPruneDatabaseStats
+	countErr    error
+	deleteErr   error
+	deleteCalls int
+	deletedKeys []LoaderRunKey
+	removedKeys []LoaderRunKey
+	interrupted []domain.LoaderRunSummary
+	updatedRuns []domain.LoaderRunSummary
+	events      []domain.LoaderEvent
+}
+
+func (s *schedulerRunPruneStoreFake) ListInterruptedLoaderRuns(context.Context, time.Time) ([]domain.LoaderRunSummary, error) {
+	return append([]domain.LoaderRunSummary(nil), s.interrupted...), nil
+}
+
+func (s *schedulerRunPruneStoreFake) UpdateLoaderRun(_ context.Context, run domain.LoaderRunSummary) error {
+	s.updatedRuns = append(s.updatedRuns, run)
+	return nil
+}
+
+func (s *schedulerRunPruneStoreFake) AddLoaderEvent(_ context.Context, event domain.LoaderEvent) error {
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *schedulerRunPruneStoreFake) ListLoaderRunsForPrune(_ context.Context, filter SchedulerRunPruneFilter) ([]domain.LoaderRunSummary, error) {
+	s.filter = filter
+	return append([]domain.LoaderRunSummary(nil), s.runs...), nil
+}
+
+func (s *schedulerRunPruneStoreFake) CountLoaderRunPruneData(context.Context, []LoaderRunKey) (SchedulerRunPruneDatabaseStats, error) {
+	return s.counted, s.countErr
+}
+
+func (s *schedulerRunPruneStoreFake) DeleteLoaderRunPruneData(_ context.Context, keys []LoaderRunKey) (SchedulerRunPruneDatabaseResult, error) {
+	s.deleteCalls++
+	s.deletedKeys = append([]LoaderRunKey(nil), keys...)
+	removedKeys := s.removedKeys
+	if removedKeys == nil {
+		removedKeys = keys
+	}
+	return SchedulerRunPruneDatabaseResult{Stats: s.deleted, RemovedKeys: append([]LoaderRunKey(nil), removedKeys...)}, s.deleteErr
+}
+
+type schedulerRunArtifactPrunerFake struct {
+	ControllerArtifacts
+	inspected     map[string]SchedulerRunArtifactInfo
+	inspectErrors map[string]error
+	removeResults map[string]SchedulerRunArtifactInfo
+	removeErrors  map[string]error
+	removed       []string
+}
+
+func (p *schedulerRunArtifactPrunerFake) InspectRunArtifacts(loaderID, runID, _ string) (SchedulerRunArtifactInfo, error) {
+	key := loaderID + "/" + runID
+	return p.inspected[key], p.inspectErrors[key]
+}
+
+func (p *schedulerRunArtifactPrunerFake) RemoveRunArtifacts(loaderID, runID, _ string) (SchedulerRunArtifactInfo, error) {
+	key := loaderID + "/" + runID
+	p.removed = append(p.removed, key)
+	return p.removeResults[key], p.removeErrors[key]
+}
+
+func newSchedulerRunPruneController(store ControllerStore, artifacts ControllerArtifacts, running map[string]int) *Controller {
+	if running == nil {
+		running = map[string]int{}
+	}
+	return &Controller{
+		deps: ControllerDependencies{
+			Store: store, Artifacts: artifacts,
+			Now: func() time.Time { return time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC) },
+		},
+		running: running,
+	}
+}

--- a/pkg/loaders/scheduler_run_recovery.go
+++ b/pkg/loaders/scheduler_run_recovery.go
@@ -1,0 +1,47 @@
+package loaders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+const interruptedSchedulerRunError = "daemon interrupted scheduler trigger run before reaching terminal state"
+
+type interruptedSchedulerRunStore interface {
+	ListInterruptedLoaderRuns(context.Context, time.Time) ([]domain.LoaderRunSummary, error)
+}
+
+func (c *Controller) RecoverInterruptedRuns(ctx context.Context, startedAt time.Time) error {
+	store, ok := c.deps.Store.(interruptedSchedulerRunStore)
+	if !ok || store == nil {
+		return fmt.Errorf("scheduler run recovery store is unavailable")
+	}
+	runs, err := store.ListInterruptedLoaderRuns(ctx, startedAt.UTC())
+	if err != nil {
+		return err
+	}
+	completedAt := c.now()
+	var recoveryErrors []error
+	for _, run := range runs {
+		run.Status = domain.LoaderRunStatusFailed
+		run.CompletedAt = completedAt
+		run.DurationMs = max(completedAt.Sub(run.StartedAt).Milliseconds(), 0)
+		run.Error = interruptedSchedulerRunError
+		if err := c.deps.Store.UpdateLoaderRun(ctx, run); err != nil {
+			recoveryErrors = append(recoveryErrors, fmt.Errorf("recover interrupted scheduler run %s/%s: %w", run.LoaderID, run.ID, err))
+			continue
+		}
+		if _, err := c.AddLoaderEventRecord(
+			ctx, run.LoaderID, run.ID, run.TriggerID,
+			"loader.run.failed", "error", interruptedSchedulerRunError,
+			map[string]any{"reason": "daemon_interrupted"}, "", "", "",
+		); err != nil {
+			recoveryErrors = append(recoveryErrors, fmt.Errorf("record interrupted scheduler run event %s/%s: %w", run.LoaderID, run.ID, err))
+		}
+	}
+	return errors.Join(recoveryErrors...)
+}

--- a/pkg/loaders/scheduler_run_supervisor.go
+++ b/pkg/loaders/scheduler_run_supervisor.go
@@ -84,6 +84,9 @@ func (s *schedulerRunSupervisor) start(ctx context.Context, request SchedulerRun
 	if request.LoaderID == "" {
 		return domain.LoaderRunSummary{}, nil, domain.ClassifyError(domain.ErrRequired, "scheduler loader id is required", nil)
 	}
+	if request.TriggerID == "" {
+		return domain.LoaderRunSummary{}, nil, domain.ClassifyError(domain.ErrRequired, "scheduler trigger id is required", nil)
+	}
 	if err := context.Cause(s.deps.RootCtx); err != nil {
 		return domain.LoaderRunSummary{}, nil, err
 	}

--- a/pkg/loaders/scheduler_run_supervisor_test.go
+++ b/pkg/loaders/scheduler_run_supervisor_test.go
@@ -21,7 +21,7 @@ func TestRunExecutorCancellationWritesCanceledTerminalState(t *testing.T) {
 	executor := NewRunExecutor(RunExecutorDependencies{
 		Store:       store,
 		Engine:      engine,
-		HostFactory: func(domain.Loader, *domain.LoaderRunSummary, TriggerEventMetadata) RunHost { return nil },
+		HostFactory: func(domain.Loader, RuntimeExecutionContext, TriggerEventMetadata) RunHost { return nil },
 		ArtifactsDir: func(loaderID, runID string) string {
 			return filepath.Join(artifactsDir, loaderID, runID)
 		},
@@ -79,9 +79,26 @@ func TestSchedulerRunSupervisorRunReturnsFinalResult(t *testing.T) {
 		},
 	})
 
-	run, err := supervisor.Run(context.Background(), SchedulerRunRequest{LoaderID: "loader-1"})
+	run, err := supervisor.Run(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", TriggerID: "trigger-1"})
 	if err != nil || run.Status != domain.LoaderRunStatusSucceeded || run.ResultJSON != `{"ok":true}` {
 		t.Fatalf("Run run=%#v err=%v", run, err)
+	}
+}
+
+func TestSchedulerRunSupervisorRejectsEmptyTriggerWithoutPreparingRun(t *testing.T) {
+	prepareCalls := 0
+	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+		LoadLoaderForRun: func(context.Context, string, string) (domain.Loader, *domain.LoaderTrigger, error) {
+			t.Fatal("empty trigger must be rejected before loading")
+			return domain.Loader{}, nil, nil
+		},
+		Prepare: func(context.Context, domain.Loader, *domain.LoaderTrigger, string, string, RunOptions) (PreparedRun, error) {
+			prepareCalls++
+			return PreparedRun{}, nil
+		},
+	})
+	if _, err := supervisor.Run(context.Background(), SchedulerRunRequest{LoaderID: "loader-1"}); !errors.Is(err, domain.ErrRequired) || prepareCalls != 0 {
+		t.Fatalf("empty trigger err=%v prepareCalls=%d", err, prepareCalls)
 	}
 }
 
@@ -106,7 +123,7 @@ func TestSchedulerRunSupervisorTimeoutCancelsExecution(t *testing.T) {
 		},
 	})
 
-	run, err := supervisor.Run(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", Timeout: 10 * time.Millisecond})
+	run, err := supervisor.Run(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", TriggerID: "trigger-1", Timeout: 10 * time.Millisecond})
 	if err != nil || run.Status != domain.LoaderRunStatusCanceled || run.Error != errSchedulerRunTimedOut.Error() {
 		t.Fatalf("Run run=%#v err=%v", run, err)
 	}
@@ -137,7 +154,7 @@ func TestSchedulerRunSupervisorStopWaitsForExecutorTerminalState(t *testing.T) {
 		},
 	})
 
-	created, err := supervisor.Start(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", PayloadJSON: `{"key":true}`})
+	created, err := supervisor.Start(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", TriggerID: "trigger-1", PayloadJSON: `{"key":true}`})
 	if err != nil || created.Status != domain.LoaderRunStatusRunning {
 		t.Fatalf("Start run=%#v err=%v", created, err)
 	}
@@ -153,6 +170,81 @@ func TestSchedulerRunSupervisorStopWaitsForExecutorTerminalState(t *testing.T) {
 	runs, err := supervisor.List(context.Background(), "loader-1", 10)
 	if err != nil || len(runs) != 1 || runs[0].ID != created.ID {
 		t.Fatalf("List runs=%#v err=%v", runs, err)
+	}
+}
+
+func TestSchedulerRunSupervisorStopsQJSPendingPromise(t *testing.T) {
+	store := newSupervisorRunStore()
+	host := &pendingPromiseRunHost{
+		engineCancellationHost: engineCancellationHost{started: make(chan struct{})},
+	}
+	var (
+		eventMu sync.Mutex
+		events  []string
+	)
+	artifactsDir := t.TempDir()
+	executor := NewRunExecutor(RunExecutorDependencies{
+		Store:  store,
+		Engine: &QJSLoaderEngine{},
+		HostFactory: func(domain.Loader, RuntimeExecutionContext, TriggerEventMetadata) RunHost {
+			return host
+		},
+		ArtifactsDir: func(loaderID, runID string) string {
+			return filepath.Join(artifactsDir, loaderID, runID)
+		},
+		WriteArtifact: func(string, string, string) error { return nil },
+		AddLoaderEvent: func(_ context.Context, _, _, _, eventType, _, _ string, _ any, _, _, _ string) error {
+			eventMu.Lock()
+			defer eventMu.Unlock()
+			events = append(events, eventType)
+			return nil
+		},
+	})
+	loader := domain.Loader{
+		Summary: domain.LoaderSummary{ID: "loader-qjs-pending", Runtime: domain.LoaderRuntimeScheduler},
+		Script: `
+scheduler.interval("pending", async function pending() {
+  scheduler.log("callback started");
+  await new Promise(function neverResolve() {});
+}, 86400000);`,
+	}
+	trigger := &domain.LoaderTrigger{ID: "pending", Kind: "interval"}
+	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+		RootCtx: context.Background(),
+		Store:   store,
+		LoadLoaderForRun: func(context.Context, string, string) (domain.Loader, *domain.LoaderTrigger, error) {
+			return loader, trigger, nil
+		},
+		Prepare: executor.Prepare,
+		Execute: executor.Execute,
+	})
+
+	created, err := supervisor.Start(context.Background(), SchedulerRunRequest{
+		LoaderID:  loader.Summary.ID,
+		TriggerID: trigger.ID,
+	})
+	if err != nil || created.Status != domain.LoaderRunStatusRunning {
+		t.Fatalf("Start run=%#v err=%v", created, err)
+	}
+	select {
+	case <-host.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler callback did not start")
+	}
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelStop()
+	stopped, requested, err := supervisor.Stop(stopCtx, loader.Summary.ID, created.ID, "operator stop")
+	if err != nil || !requested {
+		t.Fatalf("Stop run=%#v requested=%v err=%v", stopped, requested, err)
+	}
+	if stopped.Status != domain.LoaderRunStatusCanceled || stopped.Error != "operator stop" || stopped.CompletedAt.IsZero() {
+		t.Fatalf("stopped run = %#v", stopped)
+	}
+	eventMu.Lock()
+	defer eventMu.Unlock()
+	if !slices.Equal(events, []string{"loader.run.started", "loader.run.canceled"}) {
+		t.Fatalf("events = %#v", events)
 	}
 }
 
@@ -184,7 +276,7 @@ func TestSchedulerRunSupervisorRootContextStopsBackgroundRun(t *testing.T) {
 		},
 	})
 
-	if _, err := supervisor.Start(context.Background(), SchedulerRunRequest{LoaderID: "loader-1"}); err != nil {
+	if _, err := supervisor.Start(context.Background(), SchedulerRunRequest{LoaderID: "loader-1", TriggerID: "trigger-1"}); err != nil {
 		t.Fatalf("Start returned error: %v", err)
 	}
 	<-started
@@ -236,6 +328,12 @@ type supervisorRunStore struct {
 	runs map[string]domain.LoaderRunSummary
 }
 
+type pendingPromiseRunHost struct {
+	engineCancellationHost
+}
+
+func (*pendingPromiseRunHost) CleanupCommandSessions(context.Context) {}
+
 func newSupervisorRunStore() *supervisorRunStore {
 	return &supervisorRunStore{runs: map[string]domain.LoaderRunSummary{}}
 }
@@ -244,6 +342,20 @@ func (s *supervisorRunStore) set(run domain.LoaderRunSummary) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.runs[run.LoaderID+"/"+run.ID] = run
+}
+
+func (s *supervisorRunStore) CreateLoaderRun(_ context.Context, run domain.LoaderRunSummary) error {
+	s.set(run)
+	return nil
+}
+
+func (s *supervisorRunStore) UpdateLoaderRun(_ context.Context, run domain.LoaderRunSummary) error {
+	s.set(run)
+	return nil
+}
+
+func (*supervisorRunStore) UpdateLoaderLastError(context.Context, string, string) error {
+	return nil
 }
 
 func (s *supervisorRunStore) GetLoaderRun(_ context.Context, loaderID, runID string) (domain.LoaderRunSummary, error) {

--- a/pkg/projects/reconcile.go
+++ b/pkg/projects/reconcile.go
@@ -123,6 +123,28 @@ func ReconcileManagedSchedulers(ctx context.Context, store ReconcileSchedulerSto
 		if err != nil {
 			return changes, false, fmt.Errorf("load project scheduler %s/%s: %w", scheduler.ProjectID, scheduler.SchedulerID, err)
 		}
+		loader, ok := loadersByID[scheduler.ManagedLoaderID]
+		if !ok {
+			return changes, false, fmt.Errorf("managed loader %s for scheduler %s missing", scheduler.ManagedLoaderID, scheduler.SchedulerID)
+		}
+		existingLoader, loaderFound, err := store.GetLoaderIfExists(ctx, loader.Summary.ID)
+		if err != nil {
+			return changes, false, fmt.Errorf("load managed loader %s: %w", loader.Summary.ID, err)
+		}
+		if found && loaderFound && SchedulerRecordUnchanged(existing, scheduler) && ManagedLoaderUnchanged(existingLoader, loader) {
+			changes = append(changes, Change{
+				Action:       ChangeActionUnchanged,
+				ResourceType: "project_scheduler",
+				ResourceID:   scheduler.SchedulerID,
+				Name:         scheduler.AgentName,
+			}, Change{
+				Action:       ChangeActionUnchanged,
+				ResourceType: "loader",
+				ResourceID:   loader.Summary.ID,
+				Name:         loader.Summary.Name,
+			})
+			continue
+		}
 		stagedScheduler := scheduler
 		stagedScheduler.Enabled = false
 		saved, err := store.UpsertProjectScheduler(ctx, stagedScheduler)
@@ -130,14 +152,6 @@ func ReconcileManagedSchedulers(ctx context.Context, store ReconcileSchedulerSto
 			return changes, false, fmt.Errorf("stage project scheduler %s/%s disabled: %w", scheduler.ProjectID, scheduler.SchedulerID, err)
 		}
 
-		loader, ok := loadersByID[saved.ManagedLoaderID]
-		if !ok {
-			return changes, false, fmt.Errorf("managed loader %s for scheduler %s missing", saved.ManagedLoaderID, saved.SchedulerID)
-		}
-		existingLoader, loaderFound, err := store.GetLoaderIfExists(ctx, loader.Summary.ID)
-		if err != nil {
-			return changes, false, fmt.Errorf("load managed loader %s: %w", loader.Summary.ID, err)
-		}
 		stagedLoader := loader
 		stagedLoader.Summary.Enabled = false
 		savedLoader, err := store.UpsertManagedLoader(ctx, stagedLoader)

--- a/pkg/projects/reconcile_scheduler_test.go
+++ b/pkg/projects/reconcile_scheduler_test.go
@@ -1,0 +1,98 @@
+package projects
+
+import (
+	"context"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestReconcileManagedSchedulersSkipsWritesForUnchangedScheduler(t *testing.T) {
+	t.Parallel()
+
+	project := domain.ProjectRecord{ID: "project-1"}
+	trigger := domain.LoaderTrigger{
+		LoaderID:   "loader-1",
+		ID:         "daily",
+		Kind:       domain.LoaderTriggerKindInterval,
+		IntervalMs: 86_400_000,
+		Enabled:    true,
+	}
+	scheduler := domain.ProjectSchedulerRecord{
+		ProjectID:       project.ID,
+		SchedulerID:     "scheduler-1",
+		AgentName:       "worker",
+		ManagedLoaderID: "loader-1",
+		Revision:        3,
+		Enabled:         true,
+		TriggerCount:    1,
+		SpecJSON:        `{"enabled":true}`,
+	}
+	loader := domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID: "loader-1", Name: "worker scheduler", Enabled: true, Runtime: domain.LoaderRuntimeScheduler,
+			DefaultAgent: "codex", SandboxPolicy: domain.LoaderSandboxPolicySticky,
+			ManagedProjectID: project.ID, ManagedRevision: 3, ManagedAgentName: "worker", ManagedSchedulerID: scheduler.SchedulerID,
+		},
+		Script:   `scheduler.interval("daily", function daily() {}, 86400000);`,
+		Triggers: []domain.LoaderTrigger{trigger},
+	}
+	store := &unchangedSchedulerReconcileStore{scheduler: scheduler, loader: loader}
+
+	changes, unchanged, err := ReconcileManagedSchedulers(context.Background(), store, project, []domain.ProjectSchedulerRecord{scheduler}, []domain.Loader{loader}, ReconcileSchedulerOptions{})
+	if err != nil {
+		t.Fatalf("ReconcileManagedSchedulers returned error: %v", err)
+	}
+	if !unchanged {
+		t.Fatal("ReconcileManagedSchedulers reported an identical scheduler as changed")
+	}
+	if len(changes) != 2 || changes[0].Action != ChangeActionUnchanged || changes[0].ResourceType != "project_scheduler" || changes[1].Action != ChangeActionUnchanged || changes[1].ResourceType != "loader" {
+		t.Fatalf("changes = %#v", changes)
+	}
+	if len(store.writes) != 0 {
+		t.Fatalf("identical scheduler caused writes: %v", store.writes)
+	}
+}
+
+type unchangedSchedulerReconcileStore struct {
+	scheduler domain.ProjectSchedulerRecord
+	loader    domain.Loader
+	writes    []string
+}
+
+func (s *unchangedSchedulerReconcileStore) GetProjectScheduler(context.Context, string, string) (domain.ProjectSchedulerRecord, error) {
+	return s.scheduler, nil
+}
+
+func (s *unchangedSchedulerReconcileStore) UpsertProjectScheduler(_ context.Context, item domain.ProjectSchedulerRecord) (domain.ProjectSchedulerRecord, error) {
+	s.writes = append(s.writes, "upsert scheduler")
+	return item, nil
+}
+
+func (s *unchangedSchedulerReconcileStore) SetProjectSchedulerEnabled(_ context.Context, _, _ string, _ bool) (domain.ProjectSchedulerRecord, error) {
+	s.writes = append(s.writes, "set scheduler enabled")
+	return s.scheduler, nil
+}
+
+func (s *unchangedSchedulerReconcileStore) ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error) {
+	return []domain.ProjectSchedulerRecord{s.scheduler}, nil
+}
+
+func (s *unchangedSchedulerReconcileStore) GetLoaderIfExists(context.Context, string) (domain.Loader, bool, error) {
+	return s.loader, true, nil
+}
+
+func (s *unchangedSchedulerReconcileStore) UpsertManagedLoader(_ context.Context, item domain.Loader) (domain.Loader, error) {
+	s.writes = append(s.writes, "upsert loader")
+	return item, nil
+}
+
+func (s *unchangedSchedulerReconcileStore) ReplaceLoaderTriggers(_ context.Context, _ string, triggers []domain.LoaderTrigger) ([]domain.LoaderTrigger, error) {
+	s.writes = append(s.writes, "replace triggers")
+	return triggers, nil
+}
+
+func (s *unchangedSchedulerReconcileStore) SetLoaderEnabled(context.Context, string, bool) error {
+	s.writes = append(s.writes, "set loader enabled")
+	return nil
+}

--- a/pkg/storage/configstore/loader_event_page.go
+++ b/pkg/storage/configstore/loader_event_page.go
@@ -1,0 +1,64 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+func (s *loaderStore) ListLoaderEventsPage(ctx context.Context, filter loaders.LoaderEventPageFilter) ([]domain.LoaderEvent, error) {
+	loaderIDs := normalizedLoaderRunPageIDs(filter.LoaderIDs)
+	if len(loaderIDs) == 0 {
+		return []domain.LoaderEvent{}, nil
+	}
+	if filter.Limit <= 0 {
+		filter.Limit = 100
+	}
+	placeholders := make([]string, len(loaderIDs))
+	args := make([]any, 0, len(loaderIDs)+10)
+	for index, loaderID := range loaderIDs {
+		placeholders[index] = "?"
+		args = append(args, loaderID)
+	}
+	query := `SELECT e.loader_id, e.event_id, e.run_id, r.trigger_id, e.type, e.level, e.message, e.payload_json, e.linked_sandbox_id, e.linked_cell_id, e.linked_agent_thread_id, e.created_at
+		FROM loader_event e JOIN loader_run r ON r.loader_id = e.loader_id AND r.run_id = e.run_id
+		WHERE e.loader_id IN (` + strings.Join(placeholders, ",") + `)`
+	if filter.RequireTrigger {
+		query += ` AND r.trigger_id <> ''`
+	}
+	if triggerID := strings.TrimSpace(filter.TriggerID); triggerID != "" {
+		query += ` AND r.trigger_id = ?`
+		args = append(args, triggerID)
+	}
+	if runID := strings.TrimSpace(filter.RunID); runID != "" {
+		query += ` AND r.run_id = ?`
+		args = append(args, runID)
+	}
+	if !filter.BeforeCreatedAt.IsZero() {
+		query += ` AND (e.created_at < ? OR (e.created_at = ? AND (e.loader_id < ? OR (e.loader_id = ? AND e.event_id < ?))))`
+		beforeMillis := filter.BeforeCreatedAt.UTC().UnixMilli()
+		args = append(args, beforeMillis, beforeMillis, strings.TrimSpace(filter.BeforeLoaderID), strings.TrimSpace(filter.BeforeLoaderID), strings.TrimSpace(filter.BeforeEventID))
+	}
+	query += ` ORDER BY e.created_at DESC, e.loader_id DESC, e.event_id DESC LIMIT ?`
+	args = append(args, filter.Limit)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query loader event page: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	items := make([]domain.LoaderEvent, 0)
+	for rows.Next() {
+		item, err := loaders.ScanLoaderEvent(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate loader event page: %w", err)
+	}
+	return items, nil
+}

--- a/pkg/storage/configstore/loader_event_page_test.go
+++ b/pkg/storage/configstore/loader_event_page_test.go
@@ -1,0 +1,57 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+func TestLoaderEventPageOnlyReturnsEventsJoinedToTriggerRuns(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertManagedLoader(ctx, domain.Loader{Summary: domain.LoaderSummary{ID: "loader-a", Runtime: domain.LoaderRuntimeScheduler, ManagedProjectID: "project-1", ManagedAgentName: "agent-1", ManagedSchedulerID: "scheduler-1"}, Script: "function main() {}"}); err != nil {
+		t.Fatalf("upsert loader: %v", err)
+	}
+	startedAt := time.UnixMilli(1_720_000_000_000).UTC()
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt},
+		{ID: "run-b", LoaderID: "loader-a", TriggerID: "trigger-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt},
+		{ID: "invoke-old", LoaderID: "loader-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run: %v", err)
+		}
+	}
+	for _, event := range []domain.LoaderEvent{
+		{LoaderID: "loader-a", ID: "event-a2", RunID: "run-a", TriggerID: "wrong-event-trigger", Type: "loader.log", CreatedAt: startedAt.Add(2 * time.Second)},
+		{LoaderID: "loader-a", ID: "event-a1", RunID: "run-a", TriggerID: "trigger-a", Type: "loader.run.started", CreatedAt: startedAt.Add(time.Second)},
+		{LoaderID: "loader-a", ID: "event-b", RunID: "run-b", TriggerID: "trigger-b", Type: "loader.log", CreatedAt: startedAt},
+		{LoaderID: "loader-a", ID: "event-invoke", RunID: "invoke-old", Type: "loader.log", CreatedAt: startedAt.Add(3 * time.Second)},
+		{LoaderID: "loader-a", ID: "event-orphan", RunID: "missing", TriggerID: "trigger-a", Type: "loader.log", CreatedAt: startedAt.Add(4 * time.Second)},
+	} {
+		if err := store.AddLoaderEvent(ctx, event); err != nil {
+			t.Fatalf("add event %s: %v", event.ID, err)
+		}
+	}
+	first, err := store.ListLoaderEventsPage(ctx, loaders.LoaderEventPageFilter{LoaderIDs: []string{"loader-a"}, RequireTrigger: true, TriggerID: "trigger-a", Limit: 1})
+	if err != nil || len(first) != 1 || first[0].ID != "event-a2" || first[0].TriggerID != "trigger-a" {
+		t.Fatalf("first page=%#v err=%v", first, err)
+	}
+	second, err := store.ListLoaderEventsPage(ctx, loaders.LoaderEventPageFilter{
+		LoaderIDs: []string{"loader-a"}, RequireTrigger: true, TriggerID: "trigger-a", BeforeCreatedAt: first[0].CreatedAt,
+		BeforeLoaderID: first[0].LoaderID, BeforeEventID: first[0].ID, Limit: 10,
+	})
+	if err != nil || len(second) != 1 || second[0].ID != "event-a1" {
+		t.Fatalf("second page=%#v err=%v", second, err)
+	}
+	byRun, err := store.ListLoaderEventsPage(ctx, loaders.LoaderEventPageFilter{LoaderIDs: []string{"loader-a"}, RequireTrigger: true, RunID: "run-b", Limit: 10})
+	if err != nil || len(byRun) != 1 || byRun[0].ID != "event-b" {
+		t.Fatalf("run filter=%#v err=%v", byRun, err)
+	}
+}

--- a/pkg/storage/configstore/loader_run_page.go
+++ b/pkg/storage/configstore/loader_run_page.go
@@ -3,7 +3,6 @@ package configstore
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -17,26 +16,45 @@ func (s *loaderStore) GetLoaderRunForLoaders(ctx context.Context, loaderIDs []st
 	if len(loaderIDs) == 0 {
 		return domain.LoaderRunSummary{}, loaderRunPageNotFound(runID, nil)
 	}
+	refClause, refArgs, ok := resourceIDClause("run_id", runID)
+	if !ok {
+		refClause = `run_id = ?`
+		refArgs = []any{runID}
+	}
 	placeholders := make([]string, len(loaderIDs))
-	args := make([]any, 0, len(loaderIDs)+1)
-	args = append(args, runID)
+	args := make([]any, 0, len(loaderIDs)+len(refArgs))
+	args = append(args, refArgs...)
 	for index, loaderID := range loaderIDs {
 		placeholders[index] = "?"
 		args = append(args, loaderID)
 	}
-	row := s.db.QueryRowContext(ctx, loaders.SelectLoaderRunSQL()+` WHERE run_id = ? AND loader_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY loader_id ASC LIMIT 1`, args...)
-	item, err := loaders.ScanLoaderRun(row.Scan)
+	rows, err := s.db.QueryContext(ctx, loaders.SelectLoaderRunSQL()+` WHERE `+refClause+` AND loader_id IN (`+strings.Join(placeholders, ",")+`) AND trigger_id <> '' ORDER BY loader_id ASC, run_id ASC LIMIT 2`, args...)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return domain.LoaderRunSummary{}, loaderRunPageNotFound(runID, err)
-		}
 		return domain.LoaderRunSummary{}, err
 	}
-	return item, nil
+	defer func() { _ = rows.Close() }()
+	items := make([]domain.LoaderRunSummary, 0, 2)
+	for rows.Next() {
+		item, scanErr := loaders.ScanLoaderRun(rows.Scan)
+		if scanErr != nil {
+			return domain.LoaderRunSummary{}, scanErr
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return domain.LoaderRunSummary{}, err
+	}
+	if len(items) == 0 {
+		return domain.LoaderRunSummary{}, loaderRunPageNotFound(runID, sql.ErrNoRows)
+	}
+	if len(items) > 1 {
+		return domain.LoaderRunSummary{}, domain.ResourceError(domain.ErrAmbiguous, "scheduler run", runID, fmt.Sprintf("scheduler run reference %s is ambiguous", runID), nil)
+	}
+	return items[0], nil
 }
 
 func loaderRunPageNotFound(runID string, cause error) error {
-	return domain.ResourceError(domain.ErrNotFound, "loader run", runID, fmt.Sprintf("loader run %s not found", runID), cause)
+	return domain.ResourceError(domain.ErrNotFound, "scheduler run", runID, fmt.Sprintf("scheduler run %s not found", runID), cause)
 }
 
 func (s *loaderStore) ListLoaderRunsPage(ctx context.Context, filter loaders.LoaderRunPageFilter) ([]domain.LoaderRunSummary, error) {
@@ -54,6 +72,17 @@ func (s *loaderStore) ListLoaderRunsPage(ctx context.Context, filter loaders.Loa
 		args = append(args, loaderID)
 	}
 	query := loaders.SelectLoaderRunSQL() + ` WHERE loader_id IN (` + strings.Join(placeholders, ",") + `)`
+	if filter.RequireTrigger {
+		query += ` AND trigger_id <> ''`
+	}
+	if triggerID := strings.TrimSpace(filter.TriggerID); triggerID != "" {
+		query += ` AND trigger_id = ?`
+		args = append(args, triggerID)
+	}
+	if status := strings.TrimSpace(filter.Status); status != "" {
+		query += ` AND status = ?`
+		args = append(args, status)
+	}
 	if !filter.BeforeStartedAt.IsZero() {
 		query += ` AND (started_at < ? OR (started_at = ? AND (loader_id < ? OR (loader_id = ? AND run_id < ?))))`
 		beforeMillis := filter.BeforeStartedAt.UTC().UnixMilli()
@@ -79,6 +108,54 @@ func (s *loaderStore) ListLoaderRunsPage(ctx context.Context, filter loaders.Loa
 		return nil, fmt.Errorf("iterate loader run page: %w", err)
 	}
 	return items, nil
+}
+
+func (s *loaderStore) ListLoaderRunSandboxIDs(ctx context.Context, keys []loaders.LoaderRunKey) (map[loaders.LoaderRunKey][]string, error) {
+	result := make(map[loaders.LoaderRunKey][]string)
+	clauses := make([]string, 0, len(keys))
+	args := make([]any, 0, len(keys)*2)
+	seenKeys := make(map[loaders.LoaderRunKey]struct{}, len(keys))
+	for _, key := range keys {
+		key.LoaderID = strings.TrimSpace(key.LoaderID)
+		key.RunID = strings.TrimSpace(key.RunID)
+		if key.LoaderID == "" || key.RunID == "" {
+			continue
+		}
+		if _, ok := seenKeys[key]; ok {
+			continue
+		}
+		seenKeys[key] = struct{}{}
+		clauses = append(clauses, `(loader_id = ? AND run_id = ?)`)
+		args = append(args, key.LoaderID, key.RunID)
+	}
+	if len(clauses) == 0 {
+		return result, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT loader_id, run_id, linked_sandbox_id FROM loader_event WHERE linked_sandbox_id <> '' AND (`+strings.Join(clauses, ` OR `)+`) ORDER BY loader_id ASC, run_id ASC, linked_sandbox_id ASC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query loader run sandbox ids: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	seen := make(map[loaders.LoaderRunKey]map[string]struct{})
+	for rows.Next() {
+		var key loaders.LoaderRunKey
+		var sandboxID string
+		if err := rows.Scan(&key.LoaderID, &key.RunID, &sandboxID); err != nil {
+			return nil, fmt.Errorf("scan loader run sandbox id: %w", err)
+		}
+		if seen[key] == nil {
+			seen[key] = make(map[string]struct{})
+		}
+		if _, ok := seen[key][sandboxID]; ok {
+			continue
+		}
+		seen[key][sandboxID] = struct{}{}
+		result[key] = append(result[key], sandboxID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate loader run sandbox ids: %w", err)
+	}
+	return result, nil
 }
 
 func normalizedLoaderRunPageIDs(loaderIDs []string) []string {

--- a/pkg/storage/configstore/loader_run_page_test.go
+++ b/pkg/storage/configstore/loader_run_page_test.go
@@ -2,6 +2,10 @@ package configstore
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,10 +37,10 @@ func TestLoaderRunPageUsesStableCrossLoaderCursor(t *testing.T) {
 	newer := time.UnixMilli(1_720_000_000_500).UTC()
 	older := newer.Add(-time.Second)
 	for _, run := range []domain.LoaderRunSummary{
-		{ID: "run-a", LoaderID: "loader-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
-		{ID: "run-b1", LoaderID: "loader-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
-		{ID: "run-b2", LoaderID: "loader-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
-		{ID: "run-old", LoaderID: "loader-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: older},
+		{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
+		{ID: "run-b1", LoaderID: "loader-b", TriggerID: "trigger-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
+		{ID: "run-b2", LoaderID: "loader-b", TriggerID: "trigger-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: newer},
+		{ID: "run-old", LoaderID: "loader-b", TriggerID: "trigger-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: older},
 	} {
 		if err := store.CreateLoaderRun(ctx, run); err != nil {
 			t.Fatalf("create run %s: %v", run.ID, err)
@@ -73,5 +77,78 @@ func TestLoaderRunPageUsesStableCrossLoaderCursor(t *testing.T) {
 	}
 	if _, err := store.GetLoaderRunForLoaders(ctx, nil, "missing"); err == nil {
 		t.Fatal("GetLoaderRunForLoaders missing returned nil error")
+	}
+}
+
+func TestGetLoaderRunForLoadersResolvesTriggerRunShortIDs(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertManagedLoader(ctx, domain.Loader{Summary: domain.LoaderSummary{ID: "loader-a", Runtime: domain.LoaderRuntimeScheduler, ManagedProjectID: "project-1", ManagedAgentName: "agent-1", ManagedSchedulerID: "scheduler-1"}, Script: "function main() {}"}); err != nil {
+		t.Fatalf("upsert loader: %v", err)
+	}
+	prefix := "abcdef123456"
+	firstID := prefix + strings.Repeat("1", 52)
+	secondID := prefix + strings.Repeat("2", 52)
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: firstID, LoaderID: "loader-a", TriggerID: "trigger-1", Status: domain.LoaderRunStatusSucceeded, StartedAt: time.Now().UTC()},
+		{ID: secondID, LoaderID: "loader-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: time.Now().UTC()},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run: %v", err)
+		}
+	}
+	resolved, err := store.GetLoaderRunForLoaders(ctx, []string{"loader-a"}, prefix)
+	if err != nil || resolved.ID != firstID {
+		t.Fatalf("resolved run=%#v err=%v", resolved, err)
+	}
+	if err := store.CreateLoaderRun(ctx, domain.LoaderRunSummary{ID: secondID, LoaderID: "loader-a", TriggerID: "trigger-2", Status: domain.LoaderRunStatusSucceeded, StartedAt: time.Now().UTC()}); err == nil {
+		t.Fatal("expected duplicate run update setup to fail")
+	}
+	thirdID := prefix + strings.Repeat("3", 52)
+	if err := store.CreateLoaderRun(ctx, domain.LoaderRunSummary{ID: thirdID, LoaderID: "loader-a", TriggerID: "trigger-2", Status: domain.LoaderRunStatusSucceeded, StartedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create ambiguous run: %v", err)
+	}
+	if _, err := store.GetLoaderRunForLoaders(ctx, []string{"loader-a"}, prefix); !errors.Is(err, domain.ErrAmbiguous) {
+		t.Fatalf("ambiguous short id error=%v", err)
+	}
+}
+
+func TestLoaderRunPageFiltersTriggerRunsBeforeLimitAndBatchesSandboxes(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertManagedLoader(ctx, domain.Loader{Summary: domain.LoaderSummary{ID: "loader-a", Runtime: domain.LoaderRuntimeScheduler, ManagedProjectID: "project-1", ManagedAgentName: "agent-1", ManagedSchedulerID: "scheduler-1"}, Script: "function main() {}"}); err != nil {
+		t.Fatalf("upsert loader: %v", err)
+	}
+	startedAt := time.UnixMilli(1_720_000_000_000).UTC()
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: "invoke-newest", LoaderID: "loader-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(3 * time.Second)},
+		{ID: "run-failed", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusFailed, StartedAt: startedAt.Add(2 * time.Second)},
+		{ID: "run-success", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(time.Second)},
+		{ID: "run-other", LoaderID: "loader-a", TriggerID: "trigger-b", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run %s: %v", run.ID, err)
+		}
+	}
+	filtered, err := store.ListLoaderRunsPage(ctx, loaders.LoaderRunPageFilter{
+		LoaderIDs: []string{"loader-a"}, RequireTrigger: true, TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, Limit: 1,
+	})
+	if err != nil || len(filtered) != 1 || filtered[0].ID != "run-success" {
+		t.Fatalf("filtered runs=%#v err=%v", filtered, err)
+	}
+	for index, sandboxID := range []string{"sandbox-b", "sandbox-a", "sandbox-a"} {
+		if err := store.AddLoaderEvent(ctx, domain.LoaderEvent{LoaderID: "loader-a", ID: fmt.Sprintf("event-%d", index), RunID: "run-success", TriggerID: "trigger-a", Type: "loader.test", LinkedSandboxID: sandboxID, CreatedAt: startedAt}); err != nil {
+			t.Fatalf("add event: %v", err)
+		}
+	}
+	sandboxes, err := store.ListLoaderRunSandboxIDs(ctx, []loaders.LoaderRunKey{{LoaderID: "loader-a", RunID: "run-success"}, {LoaderID: "loader-a", RunID: "run-success"}})
+	if err != nil || !reflect.DeepEqual(sandboxes[loaders.LoaderRunKey{LoaderID: "loader-a", RunID: "run-success"}], []string{"sandbox-a", "sandbox-b"}) {
+		t.Fatalf("sandbox ids=%#v err=%v", sandboxes, err)
 	}
 }

--- a/pkg/storage/configstore/loader_run_prune.go
+++ b/pkg/storage/configstore/loader_run_prune.go
@@ -1,0 +1,192 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+func (s *loaderStore) ListLoaderRunsForPrune(ctx context.Context, filter loaders.SchedulerRunPruneFilter) ([]domain.LoaderRunSummary, error) {
+	loaderIDs := normalizedLoaderRunPageIDs(filter.LoaderIDs)
+	if len(loaderIDs) == 0 {
+		return []domain.LoaderRunSummary{}, nil
+	}
+	placeholders := make([]string, len(loaderIDs))
+	args := make([]any, 0, len(loaderIDs)+len(filter.Statuses)+4)
+	for index, loaderID := range loaderIDs {
+		placeholders[index] = "?"
+		args = append(args, loaderID)
+	}
+	query := loaders.SelectLoaderRunSQL() + ` WHERE loader_id IN (` + strings.Join(placeholders, ",") + `) AND trigger_id <> ''`
+	if triggerID := strings.TrimSpace(filter.TriggerID); triggerID != "" {
+		query += ` AND trigger_id = ?`
+		args = append(args, triggerID)
+	}
+	if len(filter.Statuses) > 0 {
+		statusPlaceholders := make([]string, len(filter.Statuses))
+		for index, status := range filter.Statuses {
+			statusPlaceholders[index] = "?"
+			args = append(args, strings.TrimSpace(status))
+		}
+		query += ` AND status IN (` + strings.Join(statusPlaceholders, ",") + `)`
+	}
+	if filter.OlderThan > 0 {
+		cutoff := filter.Now.Add(-filter.OlderThan).UnixMilli()
+		query += ` AND ((completed_at > 0 AND completed_at <= ?) OR (completed_at = 0 AND started_at <= ?))`
+		args = append(args, cutoff, cutoff)
+	}
+	query += ` ORDER BY started_at ASC, loader_id ASC, run_id ASC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query loader runs for prune: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]domain.LoaderRunSummary, 0)
+	for rows.Next() {
+		run, scanErr := loaders.ScanLoaderRun(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		result = append(result, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate loader runs for prune: %w", err)
+	}
+	return result, nil
+}
+
+func (s *loaderStore) CountLoaderRunPruneData(ctx context.Context, keys []loaders.LoaderRunKey) (loaders.SchedulerRunPruneDatabaseStats, error) {
+	keys = normalizedLoaderRunKeys(keys)
+	var stats loaders.SchedulerRunPruneDatabaseStats
+	for _, key := range keys {
+		eligible, err := schedulerRunPruneKeyIsEligible(ctx, s.db, key)
+		if err != nil {
+			return loaders.SchedulerRunPruneDatabaseStats{}, err
+		}
+		if !eligible {
+			continue
+		}
+		var loaderEvents, deliveries, sandboxLinks, runs int64
+		err = s.db.QueryRowContext(ctx, `SELECT
+			(SELECT COUNT(*) FROM loader_event WHERE loader_id = ? AND run_id = ?),
+			(SELECT COUNT(*) FROM event_delivery WHERE loader_id = ? AND run_id = ?),
+			(SELECT COUNT(*) FROM event_sandbox_link WHERE loader_id = ? AND run_id = ?),
+			(SELECT COUNT(*) FROM loader_run WHERE loader_id = ? AND run_id = ? AND trigger_id <> '')`,
+			key.LoaderID, key.RunID,
+			key.LoaderID, key.RunID,
+			key.LoaderID, key.RunID,
+			key.LoaderID, key.RunID,
+		).Scan(&loaderEvents, &deliveries, &sandboxLinks, &runs)
+		if err != nil {
+			return loaders.SchedulerRunPruneDatabaseStats{}, fmt.Errorf("count scheduler run prune data %s/%s: %w", key.LoaderID, key.RunID, err)
+		}
+		stats.LoaderEvents += uint64(loaderEvents)
+		stats.EventDeliveries += uint64(deliveries)
+		stats.EventSandboxLinks += uint64(sandboxLinks)
+		stats.Runs += uint64(runs)
+	}
+	return stats, nil
+}
+
+func (s *loaderStore) DeleteLoaderRunPruneData(ctx context.Context, keys []loaders.LoaderRunKey) (loaders.SchedulerRunPruneDatabaseResult, error) {
+	keys = normalizedLoaderRunKeys(keys)
+	if len(keys) == 0 {
+		return loaders.SchedulerRunPruneDatabaseResult{}, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return loaders.SchedulerRunPruneDatabaseResult{}, fmt.Errorf("begin scheduler run prune: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var result loaders.SchedulerRunPruneDatabaseResult
+	for _, key := range keys {
+		removed, err := deleteLoaderRunPruneRows(ctx, tx, key, &result.Stats)
+		if err != nil {
+			return loaders.SchedulerRunPruneDatabaseResult{}, err
+		}
+		if removed {
+			result.RemovedKeys = append(result.RemovedKeys, key)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return loaders.SchedulerRunPruneDatabaseResult{}, fmt.Errorf("commit scheduler run prune: %w", err)
+	}
+	return result, nil
+}
+
+func deleteLoaderRunPruneRows(ctx context.Context, tx *sql.Tx, key loaders.LoaderRunKey, stats *loaders.SchedulerRunPruneDatabaseStats) (bool, error) {
+	eligible, err := schedulerRunPruneKeyIsEligible(ctx, tx, key)
+	if err != nil {
+		return false, err
+	}
+	if !eligible {
+		return false, nil
+	}
+	steps := []struct {
+		name  string
+		query string
+		add   func(uint64)
+	}{
+		{name: "event sandbox links", query: `DELETE FROM event_sandbox_link WHERE loader_id = ? AND run_id = ?`, add: func(count uint64) { stats.EventSandboxLinks += count }},
+		{name: "event deliveries", query: `DELETE FROM event_delivery WHERE loader_id = ? AND run_id = ?`, add: func(count uint64) { stats.EventDeliveries += count }},
+		{name: "loader events", query: `DELETE FROM loader_event WHERE loader_id = ? AND run_id = ?`, add: func(count uint64) { stats.LoaderEvents += count }},
+		{name: "loader run", query: `DELETE FROM loader_run WHERE loader_id = ? AND run_id = ? AND trigger_id <> ''`, add: func(count uint64) { stats.Runs += count }},
+	}
+	for _, step := range steps {
+		result, err := tx.ExecContext(ctx, step.query, key.LoaderID, key.RunID)
+		if err != nil {
+			return false, fmt.Errorf("delete scheduler run %s %s/%s: %w", step.name, key.LoaderID, key.RunID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return false, fmt.Errorf("count deleted scheduler run %s %s/%s: %w", step.name, key.LoaderID, key.RunID, err)
+		}
+		step.add(uint64(rows))
+	}
+	return true, nil
+}
+
+type schedulerRunPruneQueryRower interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func schedulerRunPruneKeyIsEligible(ctx context.Context, queryer schedulerRunPruneQueryRower, key loaders.LoaderRunKey) (bool, error) {
+	var eligible int
+	err := queryer.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM loader_run
+		WHERE loader_id = ? AND run_id = ? AND trigger_id <> ''
+		AND status IN (?, ?, ?, ?)
+	)`,
+		key.LoaderID, key.RunID,
+		domain.LoaderRunStatusSucceeded,
+		domain.LoaderRunStatusFailed,
+		domain.LoaderRunStatusCanceled,
+		domain.LoaderRunStatusSkipped,
+	).Scan(&eligible)
+	if err != nil {
+		return false, fmt.Errorf("recheck scheduler run prune candidate %s/%s: %w", key.LoaderID, key.RunID, err)
+	}
+	return eligible != 0, nil
+}
+
+func normalizedLoaderRunKeys(keys []loaders.LoaderRunKey) []loaders.LoaderRunKey {
+	seen := make(map[loaders.LoaderRunKey]struct{}, len(keys))
+	result := make([]loaders.LoaderRunKey, 0, len(keys))
+	for _, key := range keys {
+		key.LoaderID = strings.TrimSpace(key.LoaderID)
+		key.RunID = strings.TrimSpace(key.RunID)
+		if key.LoaderID == "" || key.RunID == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, key)
+	}
+	return result
+}

--- a/pkg/storage/configstore/loader_run_prune_test.go
+++ b/pkg/storage/configstore/loader_run_prune_test.go
@@ -1,0 +1,178 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+func TestLoaderRunPruneFiltersAndDeletesDirectRunData(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	createPruneTestLoader(t, store, "loader-a")
+	createPruneTestLoader(t, store, "loader-b")
+	now := time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour)
+	newer := now.Add(-time.Hour)
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: "run-old-success", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: old, CompletedAt: old.Add(time.Minute)},
+		{ID: "run-new-failed", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusFailed, StartedAt: newer, CompletedAt: newer.Add(time.Minute)},
+		{ID: "run-old-other-trigger", LoaderID: "loader-a", TriggerID: "trigger-b", Status: domain.LoaderRunStatusFailed, StartedAt: old.Add(time.Minute), CompletedAt: old.Add(2 * time.Minute)},
+		{ID: "run-running", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusRunning, StartedAt: old},
+		{ID: "run-invocation", LoaderID: "loader-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: old, CompletedAt: old.Add(time.Minute)},
+		{ID: "run-other-loader", LoaderID: "loader-b", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: old, CompletedAt: old.Add(time.Minute)},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run %s: %v", run.ID, err)
+		}
+	}
+	addPruneTestRelations(t, store, "loader-a", "run-old-success", "trigger-a")
+	if _, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "topic-event", Topic: "topic.test", Source: domain.TopicEventSourceSystem,
+		CorrelationID: "correlation-test", PayloadJSON: `{}`, CreatedAt: old,
+	}); err != nil {
+		t.Fatalf("create topic event: %v", err)
+	}
+
+	filtered, err := store.ListLoaderRunsForPrune(ctx, loaders.SchedulerRunPruneFilter{
+		LoaderIDs: []string{"loader-a"}, TriggerID: "trigger-a",
+		Statuses:  []string{domain.LoaderRunStatusSucceeded, domain.LoaderRunStatusFailed},
+		OlderThan: 24 * time.Hour, Now: now,
+	})
+	if err != nil || len(filtered) != 1 || filtered[0].ID != "run-old-success" {
+		t.Fatalf("filtered runs=%#v err=%v", filtered, err)
+	}
+	keys := []loaders.LoaderRunKey{{LoaderID: "loader-a", RunID: "run-old-success"}}
+	counted, err := store.CountLoaderRunPruneData(ctx, keys)
+	if err != nil {
+		t.Fatalf("count prune data: %v", err)
+	}
+	if counted.Runs != 1 || counted.LoaderEvents != 1 || counted.EventDeliveries != 1 || counted.EventSandboxLinks != 1 {
+		t.Fatalf("counted prune data = %#v", counted)
+	}
+	removed, err := store.DeleteLoaderRunPruneData(ctx, keys)
+	if err != nil {
+		t.Fatalf("delete prune data: %v", err)
+	}
+	if removed.Stats != counted || len(removed.RemovedKeys) != 1 || removed.RemovedKeys[0] != keys[0] {
+		t.Fatalf("removed=%#v, want stats %#v and key %#v", removed, counted, keys[0])
+	}
+	if remaining, err := store.ListLoaderRunsForPrune(ctx, loaders.SchedulerRunPruneFilter{LoaderIDs: []string{"loader-a", "loader-b"}}); err != nil || len(remaining) != 4 {
+		t.Fatalf("remaining trigger runs=%#v err=%v", remaining, err)
+	}
+	for table, where := range map[string]string{
+		"loader_event":       "loader_id = 'loader-a' AND run_id = 'run-old-success'",
+		"event_delivery":     "loader_id = 'loader-a' AND run_id = 'run-old-success'",
+		"event_sandbox_link": "loader_id = 'loader-a' AND run_id = 'run-old-success'",
+	} {
+		assertPruneTestRowCount(t, store, table, where, 0)
+	}
+	assertPruneTestRowCount(t, store, "event", "id = 'topic-event'", 1)
+	assertPruneTestRowCount(t, store, "loader_run", "run_id = 'run-invocation'", 1)
+	assertPruneTestRowCount(t, store, "loader_run", "run_id = 'run-running'", 1)
+}
+
+func TestDeleteLoaderRunPruneDataRollsBackWholeTransaction(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	createPruneTestLoader(t, store, "loader-a")
+	now := time.Now().UTC()
+	for _, runID := range []string{"run-ok", "run-fail"} {
+		if err := store.CreateLoaderRun(ctx, domain.LoaderRunSummary{ID: runID, LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: now, CompletedAt: now}); err != nil {
+			t.Fatalf("create run %s: %v", runID, err)
+		}
+		addPruneTestRelations(t, store, "loader-a", runID, "trigger-a")
+	}
+	if _, err := store.db.ExecContext(ctx, `CREATE TRIGGER block_prune_event BEFORE DELETE ON loader_event
+		WHEN OLD.run_id = 'run-fail' BEGIN SELECT RAISE(ABORT, 'blocked prune'); END`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	keys := []loaders.LoaderRunKey{{LoaderID: "loader-a", RunID: "run-ok"}, {LoaderID: "loader-a", RunID: "run-fail"}}
+	if _, err := store.DeleteLoaderRunPruneData(ctx, keys); err == nil {
+		t.Fatal("DeleteLoaderRunPruneData returned nil error")
+	}
+	for _, runID := range []string{"run-ok", "run-fail"} {
+		assertPruneTestRowCount(t, store, "loader_run", "run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, "loader_event", "run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, "event_delivery", "run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, "event_sandbox_link", "run_id = '"+runID+"'", 1)
+	}
+}
+
+func TestDeleteLoaderRunPruneDataRechecksTerminalTriggerRun(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	createPruneTestLoader(t, store, "loader-a")
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: "run-running", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusRunning, StartedAt: time.Now().UTC()},
+		{ID: "run-empty-trigger", LoaderID: "loader-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC()},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run %s: %v", run.ID, err)
+		}
+		addPruneTestRelations(t, store, "loader-a", run.ID, run.TriggerID)
+	}
+	keys := []loaders.LoaderRunKey{{LoaderID: "loader-a", RunID: "run-running"}, {LoaderID: "loader-a", RunID: "run-empty-trigger"}}
+	if counted, err := store.CountLoaderRunPruneData(ctx, keys); err != nil || counted != (loaders.SchedulerRunPruneDatabaseStats{}) {
+		t.Fatalf("counted=%#v err=%v", counted, err)
+	}
+	if removed, err := store.DeleteLoaderRunPruneData(ctx, keys); err != nil || removed.Stats != (loaders.SchedulerRunPruneDatabaseStats{}) || len(removed.RemovedKeys) != 0 {
+		t.Fatalf("removed=%#v err=%v", removed, err)
+	}
+	for _, runID := range []string{"run-running", "run-empty-trigger"} {
+		assertPruneTestRowCount(t, store, "loader_run", "run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, "loader_event", "run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, "event_delivery", "run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, "event_sandbox_link", "run_id = '"+runID+"'", 1)
+	}
+}
+
+func createPruneTestLoader(t *testing.T, store *ConfigStore, loaderID string) {
+	t.Helper()
+	if _, err := store.UpsertManagedLoader(context.Background(), domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID: loaderID, Name: loaderID, Runtime: domain.LoaderRuntimeScheduler,
+			ManagedProjectID: "project-1", ManagedAgentName: loaderID, ManagedSchedulerID: "scheduler-" + loaderID,
+		},
+		Script: "function main() {}",
+	}); err != nil {
+		t.Fatalf("create loader %s: %v", loaderID, err)
+	}
+}
+
+func addPruneTestRelations(t *testing.T, store *ConfigStore, loaderID, runID, triggerID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.AddLoaderEvent(ctx, domain.LoaderEvent{ID: "loader-event-" + runID, LoaderID: loaderID, RunID: runID, TriggerID: triggerID, Type: "loader.run.completed", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("add loader event: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO event_delivery(event_id, loader_id, trigger_id, run_id, status, created_at, updated_at) VALUES(?, ?, ?, ?, 'run_succeeded', 1, 1)`, "event-"+runID, loaderID, triggerID, runID); err != nil {
+		t.Fatalf("add event delivery: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO event_sandbox_link(event_id, sandbox_id, relation, loader_id, run_id, trigger_id, created_at) VALUES(?, ?, 'used', ?, ?, ?, 1)`, "event-"+runID, "sandbox-"+runID, loaderID, runID, triggerID); err != nil {
+		t.Fatalf("add event sandbox link: %v", err)
+	}
+}
+
+func assertPruneTestRowCount(t *testing.T, store *ConfigStore, table, where string, want int) {
+	t.Helper()
+	var count int
+	if err := store.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM "+table+" WHERE "+where).Scan(&count); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	if count != want {
+		t.Fatalf("%s count=%d, want %d", table, count, want)
+	}
+}

--- a/pkg/storage/configstore/loader_run_recovery.go
+++ b/pkg/storage/configstore/loader_run_recovery.go
@@ -1,0 +1,34 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+)
+
+func (s *loaderStore) ListInterruptedLoaderRuns(ctx context.Context, startedBefore time.Time) ([]domain.LoaderRunSummary, error) {
+	rows, err := s.db.QueryContext(ctx, loaders.SelectLoaderRunSQL()+`
+		WHERE trigger_id <> '' AND status = ? AND started_at < ?
+		ORDER BY started_at ASC, loader_id ASC, run_id ASC`,
+		domain.LoaderRunStatusRunning, startedBefore.UTC().UnixMilli(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query interrupted scheduler runs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]domain.LoaderRunSummary, 0)
+	for rows.Next() {
+		run, scanErr := loaders.ScanLoaderRun(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		result = append(result, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate interrupted scheduler runs: %w", err)
+	}
+	return result, nil
+}

--- a/pkg/storage/configstore/loader_run_recovery_test.go
+++ b/pkg/storage/configstore/loader_run_recovery_test.go
@@ -1,0 +1,36 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestListInterruptedLoaderRunsOnlyReturnsOlderTriggerRuns(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	createPruneTestLoader(t, store, "loader-a")
+	startedAt := time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: "old-trigger", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusRunning, StartedAt: startedAt.Add(-time.Hour)},
+		{ID: "fresh-trigger", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusRunning, StartedAt: startedAt},
+		{ID: "old-terminal", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(-time.Hour), CompletedAt: startedAt.Add(-time.Minute)},
+		{ID: "old-empty-trigger", LoaderID: "loader-a", Status: domain.LoaderRunStatusRunning, StartedAt: startedAt.Add(-time.Hour)},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run %s: %v", run.ID, err)
+		}
+	}
+	runs, err := store.ListInterruptedLoaderRuns(ctx, startedAt)
+	if err != nil {
+		t.Fatalf("list interrupted runs: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != "old-trigger" {
+		t.Fatalf("interrupted runs=%#v", runs)
+	}
+}

--- a/pkg/storage/configstore/loader_store.go
+++ b/pkg/storage/configstore/loader_store.go
@@ -80,6 +80,7 @@ func (s *loaderStore) ensureLoaderSchema(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_loader_run_started ON loader_run(loader_id, started_at DESC);`,
 		`CREATE INDEX IF NOT EXISTS idx_loader_run_trigger_started ON loader_run(loader_id, trigger_id, started_at DESC, run_id DESC);`,
 		`CREATE INDEX IF NOT EXISTS idx_loader_run_status_started ON loader_run(loader_id, status, started_at DESC, run_id DESC);`,
+		`CREATE INDEX IF NOT EXISTS idx_loader_run_prune ON loader_run(loader_id, status, completed_at, started_at, run_id);`,
 		`CREATE TABLE IF NOT EXISTS loader_event (
             loader_id TEXT NOT NULL,
             event_id TEXT NOT NULL,

--- a/pkg/storage/configstore/loader_store.go
+++ b/pkg/storage/configstore/loader_store.go
@@ -78,6 +78,8 @@ func (s *loaderStore) ensureLoaderSchema(ctx context.Context) error {
             FOREIGN KEY(loader_id) REFERENCES loader(id) ON DELETE CASCADE
         );`,
 		`CREATE INDEX IF NOT EXISTS idx_loader_run_started ON loader_run(loader_id, started_at DESC);`,
+		`CREATE INDEX IF NOT EXISTS idx_loader_run_trigger_started ON loader_run(loader_id, trigger_id, started_at DESC, run_id DESC);`,
+		`CREATE INDEX IF NOT EXISTS idx_loader_run_status_started ON loader_run(loader_id, status, started_at DESC, run_id DESC);`,
 		`CREATE TABLE IF NOT EXISTS loader_event (
             loader_id TEXT NOT NULL,
             event_id TEXT NOT NULL,
@@ -95,6 +97,7 @@ func (s *loaderStore) ensureLoaderSchema(ctx context.Context) error {
             FOREIGN KEY(loader_id) REFERENCES loader(id) ON DELETE CASCADE
         );`,
 		`CREATE INDEX IF NOT EXISTS idx_loader_event_created ON loader_event(loader_id, created_at DESC);`,
+		`CREATE INDEX IF NOT EXISTS idx_loader_event_run_created ON loader_event(loader_id, run_id, created_at DESC, event_id DESC);`,
 		`CREATE TABLE IF NOT EXISTS loader_state (
             loader_id TEXT NOT NULL,
             key TEXT NOT NULL,
@@ -576,9 +579,9 @@ func (s *loaderStore) hydrateLoaderSummaryCounts(ctx context.Context, summary *d
 	}
 	row := s.db.QueryRowContext(ctx, `SELECT
         (SELECT COUNT(*) FROM loader_trigger WHERE loader_id = ?),
-        (SELECT COUNT(*) FROM loader_run WHERE loader_id = ?),
-        (SELECT COUNT(*) FROM loader_event WHERE loader_id = ?),
-        (SELECT MAX(started_at) FROM loader_run WHERE loader_id = ?)`, summary.ID, summary.ID, summary.ID, summary.ID)
+		(SELECT COUNT(*) FROM loader_run WHERE loader_id = ? AND trigger_id <> ''),
+		(SELECT COUNT(*) FROM loader_event e JOIN loader_run r ON r.loader_id = e.loader_id AND r.run_id = e.run_id WHERE e.loader_id = ? AND r.trigger_id <> ''),
+		(SELECT MAX(started_at) FROM loader_run WHERE loader_id = ? AND trigger_id <> '')`, summary.ID, summary.ID, summary.ID, summary.ID)
 	var triggerCount int
 	var runCount int
 	var eventCount int

--- a/pkg/storage/configstore/project_scheduler_page_test.go
+++ b/pkg/storage/configstore/project_scheduler_page_test.go
@@ -36,9 +36,12 @@ func TestProjectSchedulerPageUsesStableCursorAndProjectQuery(t *testing.T) {
 		t.Fatalf("insert loader: %v", err)
 	}
 	for index, startedAt := range []int64{1700000000, 1700000060} {
-		if _, err := store.db.ExecContext(ctx, `INSERT INTO loader_run(loader_id, run_id, started_at) VALUES(?, ?, ?)`, "loader-a", fmt.Sprintf("run-%d", index), startedAt); err != nil {
+		if _, err := store.db.ExecContext(ctx, `INSERT INTO loader_run(loader_id, run_id, trigger_id, started_at) VALUES(?, ?, ?, ?)`, "loader-a", fmt.Sprintf("run-%d", index), "trigger-1", startedAt); err != nil {
 			t.Fatalf("insert loader run: %v", err)
 		}
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO loader_run(loader_id, run_id, started_at) VALUES(?, ?, ?)`, "loader-a", "old-invocation", int64(1700000120)); err != nil {
+		t.Fatalf("insert old invocation: %v", err)
 	}
 
 	first, err := store.ListProjectSchedulersPage(ctx, "", "", 2)

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -441,8 +441,8 @@ func (s *projectStore) ListProjectSchedulersPage(ctx context.Context, query, aft
 		ORDER BY s.project_id ASC, s.agent_name ASC, s.scheduler_id ASC LIMIT ?
 	)
 	SELECT page.id, page.short_id, page.project_id, page.scheduler_id, page.agent_name, page.managed_loader_id, page.revision, page.enabled, page.trigger_count, page.spec_json, page.created_at, page.updated_at,
-		(SELECT COUNT(*) FROM loader_run lr WHERE lr.loader_id = page.managed_loader_id),
-		(SELECT MAX(started_at) FROM loader_run lr WHERE lr.loader_id = page.managed_loader_id),
+		(SELECT COUNT(*) FROM loader_run lr WHERE lr.loader_id = page.managed_loader_id AND lr.trigger_id <> ''),
+		(SELECT MAX(started_at) FROM loader_run lr WHERE lr.loader_id = page.managed_loader_id AND lr.trigger_id <> ''),
 		COALESCE(l.last_error, '')
 	FROM page LEFT JOIN loader l ON l.id = page.managed_loader_id
 	ORDER BY page.project_id ASC, page.agent_name ASC, page.scheduler_id ASC`, query, likeQuery, likeQuery, likeQuery, afterKey, limit)

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -72,6 +72,7 @@ func (s *eventStore) ensureEventSchema(ctx context.Context) error {
 			PRIMARY KEY(event_id, loader_id, trigger_id)
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_event_delivery_run ON event_delivery(run_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_event_delivery_loader_run ON event_delivery(loader_id, run_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_event_delivery_status ON event_delivery(status, updated_at);`,
 		`CREATE TABLE IF NOT EXISTS event_sandbox_link (
 			event_id TEXT NOT NULL,
@@ -86,6 +87,7 @@ func (s *eventStore) ensureEventSchema(ctx context.Context) error {
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_event_sandbox_link_sandbox ON event_sandbox_link(sandbox_id, created_at);`,
 		`CREATE INDEX IF NOT EXISTS idx_event_sandbox_link_run ON event_sandbox_link(run_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_event_sandbox_link_loader_run ON event_sandbox_link(loader_id, run_id);`,
 	}
 	for _, stmt := range statements {
 		if _, err := s.db.ExecContext(ctx, stmt); err != nil {

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -3290,17 +3290,22 @@ func (x *ListSchedulerEventsRequest) GetCursor() string {
 }
 
 type SchedulerEvent struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	Level         string                 `protobuf:"bytes,3,opt,name=level,proto3" json:"level,omitempty"`
-	Message       string                 `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
-	PayloadJson   string                 `protobuf:"bytes,5,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
-	RunId         string                 `protobuf:"bytes,6,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
-	TriggerId     string                 `protobuf:"bytes,7,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
-	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Id                  string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Type                string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Level               string                 `protobuf:"bytes,3,opt,name=level,proto3" json:"level,omitempty"`
+	Message             string                 `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	PayloadJson         string                 `protobuf:"bytes,5,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
+	RunId               string                 `protobuf:"bytes,6,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	TriggerId           string                 `protobuf:"bytes,7,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	CreatedAt           *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	AgentName           string                 `protobuf:"bytes,9,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	SchedulerId         string                 `protobuf:"bytes,10,opt,name=scheduler_id,json=schedulerId,proto3" json:"scheduler_id,omitempty"`
+	LinkedSandboxId     string                 `protobuf:"bytes,11,opt,name=linked_sandbox_id,json=linkedSandboxId,proto3" json:"linked_sandbox_id,omitempty"`
+	LinkedCellId        string                 `protobuf:"bytes,12,opt,name=linked_cell_id,json=linkedCellId,proto3" json:"linked_cell_id,omitempty"`
+	LinkedAgentThreadId string                 `protobuf:"bytes,13,opt,name=linked_agent_thread_id,json=linkedAgentThreadId,proto3" json:"linked_agent_thread_id,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *SchedulerEvent) Reset() {
@@ -3389,6 +3394,41 @@ func (x *SchedulerEvent) GetCreatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *SchedulerEvent) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *SchedulerEvent) GetSchedulerId() string {
+	if x != nil {
+		return x.SchedulerId
+	}
+	return ""
+}
+
+func (x *SchedulerEvent) GetLinkedSandboxId() string {
+	if x != nil {
+		return x.LinkedSandboxId
+	}
+	return ""
+}
+
+func (x *SchedulerEvent) GetLinkedCellId() string {
+	if x != nil {
+		return x.LinkedCellId
+	}
+	return ""
+}
+
+func (x *SchedulerEvent) GetLinkedAgentThreadId() string {
+	if x != nil {
+		return x.LinkedAgentThreadId
+	}
+	return ""
+}
+
 type ListSchedulerEventsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Events        []*SchedulerEvent      `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
@@ -3441,6 +3481,262 @@ func (x *ListSchedulerEventsResponse) GetNextCursor() string {
 	return ""
 }
 
+type ListProjectSchedulerEventsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	TriggerId     string                 `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	RunId         string                 `protobuf:"bytes,4,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	Limit         uint32                 `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`
+	Cursor        string                 `protobuf:"bytes,6,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListProjectSchedulerEventsRequest) Reset() {
+	*x = ListProjectSchedulerEventsRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListProjectSchedulerEventsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListProjectSchedulerEventsRequest) ProtoMessage() {}
+
+func (x *ListProjectSchedulerEventsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListProjectSchedulerEventsRequest.ProtoReflect.Descriptor instead.
+func (*ListProjectSchedulerEventsRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ListProjectSchedulerEventsRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *ListProjectSchedulerEventsRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *ListProjectSchedulerEventsRequest) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *ListProjectSchedulerEventsRequest) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *ListProjectSchedulerEventsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListProjectSchedulerEventsRequest) GetCursor() string {
+	if x != nil {
+		return x.Cursor
+	}
+	return ""
+}
+
+type ListProjectSchedulerEventsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Events        []*SchedulerEvent      `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
+	NextCursor    string                 `protobuf:"bytes,2,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListProjectSchedulerEventsResponse) Reset() {
+	*x = ListProjectSchedulerEventsResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListProjectSchedulerEventsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListProjectSchedulerEventsResponse) ProtoMessage() {}
+
+func (x *ListProjectSchedulerEventsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListProjectSchedulerEventsResponse.ProtoReflect.Descriptor instead.
+func (*ListProjectSchedulerEventsResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *ListProjectSchedulerEventsResponse) GetEvents() []*SchedulerEvent {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
+func (x *ListProjectSchedulerEventsResponse) GetNextCursor() string {
+	if x != nil {
+		return x.NextCursor
+	}
+	return ""
+}
+
+type InvokeSchedulerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	PayloadJson   string                 `protobuf:"bytes,3,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokeSchedulerRequest) Reset() {
+	*x = InvokeSchedulerRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokeSchedulerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokeSchedulerRequest) ProtoMessage() {}
+
+func (x *InvokeSchedulerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokeSchedulerRequest.ProtoReflect.Descriptor instead.
+func (*InvokeSchedulerRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *InvokeSchedulerRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *InvokeSchedulerRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *InvokeSchedulerRequest) GetPayloadJson() string {
+	if x != nil {
+		return x.PayloadJson
+	}
+	return ""
+}
+
+type InvokeSchedulerResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ResultJson    string                 `protobuf:"bytes,1,opt,name=result_json,json=resultJson,proto3" json:"result_json,omitempty"`
+	DurationMs    int64                  `protobuf:"varint,2,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	Warnings      []string               `protobuf:"bytes,3,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokeSchedulerResponse) Reset() {
+	*x = InvokeSchedulerResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokeSchedulerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokeSchedulerResponse) ProtoMessage() {}
+
+func (x *InvokeSchedulerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokeSchedulerResponse.ProtoReflect.Descriptor instead.
+func (*InvokeSchedulerResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *InvokeSchedulerResponse) GetResultJson() string {
+	if x != nil {
+		return x.ResultJson
+	}
+	return ""
+}
+
+func (x *InvokeSchedulerResponse) GetDurationMs() int64 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *InvokeSchedulerResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
+
 type RunSchedulerRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
@@ -3453,7 +3749,7 @@ type RunSchedulerRequest struct {
 
 func (x *RunSchedulerRequest) Reset() {
 	*x = RunSchedulerRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3465,7 +3761,7 @@ func (x *RunSchedulerRequest) String() string {
 func (*RunSchedulerRequest) ProtoMessage() {}
 
 func (x *RunSchedulerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[30]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3478,7 +3774,7 @@ func (x *RunSchedulerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSchedulerRequest.ProtoReflect.Descriptor instead.
 func (*RunSchedulerRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{30}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *RunSchedulerRequest) GetProject() *ProjectRef {
@@ -3518,7 +3814,7 @@ type RunSchedulerResponse struct {
 
 func (x *RunSchedulerResponse) Reset() {
 	*x = RunSchedulerResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3530,7 +3826,7 @@ func (x *RunSchedulerResponse) String() string {
 func (*RunSchedulerResponse) ProtoMessage() {}
 
 func (x *RunSchedulerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[31]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3543,7 +3839,7 @@ func (x *RunSchedulerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSchedulerResponse.ProtoReflect.Descriptor instead.
 func (*RunSchedulerResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{31}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RunSchedulerResponse) GetRun() *SchedulerRun {
@@ -3565,7 +3861,7 @@ type StartSchedulerRunRequest struct {
 
 func (x *StartSchedulerRunRequest) Reset() {
 	*x = StartSchedulerRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3577,7 +3873,7 @@ func (x *StartSchedulerRunRequest) String() string {
 func (*StartSchedulerRunRequest) ProtoMessage() {}
 
 func (x *StartSchedulerRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[32]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3590,7 +3886,7 @@ func (x *StartSchedulerRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartSchedulerRunRequest.ProtoReflect.Descriptor instead.
 func (*StartSchedulerRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{32}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *StartSchedulerRunRequest) GetProject() *ProjectRef {
@@ -3630,7 +3926,7 @@ type StartSchedulerRunResponse struct {
 
 func (x *StartSchedulerRunResponse) Reset() {
 	*x = StartSchedulerRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3642,7 +3938,7 @@ func (x *StartSchedulerRunResponse) String() string {
 func (*StartSchedulerRunResponse) ProtoMessage() {}
 
 func (x *StartSchedulerRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[33]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3655,7 +3951,7 @@ func (x *StartSchedulerRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartSchedulerRunResponse.ProtoReflect.Descriptor instead.
 func (*StartSchedulerRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{33}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *StartSchedulerRunResponse) GetRun() *SchedulerRun {
@@ -3675,7 +3971,7 @@ type GetSchedulerRunRequest struct {
 
 func (x *GetSchedulerRunRequest) Reset() {
 	*x = GetSchedulerRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3687,7 +3983,7 @@ func (x *GetSchedulerRunRequest) String() string {
 func (*GetSchedulerRunRequest) ProtoMessage() {}
 
 func (x *GetSchedulerRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[34]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3700,7 +3996,7 @@ func (x *GetSchedulerRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSchedulerRunRequest.ProtoReflect.Descriptor instead.
 func (*GetSchedulerRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{34}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetSchedulerRunRequest) GetProject() *ProjectRef {
@@ -3726,7 +4022,7 @@ type GetSchedulerRunResponse struct {
 
 func (x *GetSchedulerRunResponse) Reset() {
 	*x = GetSchedulerRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3738,7 +4034,7 @@ func (x *GetSchedulerRunResponse) String() string {
 func (*GetSchedulerRunResponse) ProtoMessage() {}
 
 func (x *GetSchedulerRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[35]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3751,7 +4047,7 @@ func (x *GetSchedulerRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSchedulerRunResponse.ProtoReflect.Descriptor instead.
 func (*GetSchedulerRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{35}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetSchedulerRunResponse) GetRun() *SchedulerRun {
@@ -3767,13 +4063,15 @@ type ListSchedulerRunsRequest struct {
 	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
 	Limit         uint32                 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 	Cursor        string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	TriggerId     string                 `protobuf:"bytes,5,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	Status        SchedulerRunStatus     `protobuf:"varint,6,opt,name=status,proto3,enum=agentcompose.v2.SchedulerRunStatus" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListSchedulerRunsRequest) Reset() {
 	*x = ListSchedulerRunsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3785,7 +4083,7 @@ func (x *ListSchedulerRunsRequest) String() string {
 func (*ListSchedulerRunsRequest) ProtoMessage() {}
 
 func (x *ListSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[36]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3798,7 +4096,7 @@ func (x *ListSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSchedulerRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListSchedulerRunsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{36}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ListSchedulerRunsRequest) GetProject() *ProjectRef {
@@ -3829,6 +4127,20 @@ func (x *ListSchedulerRunsRequest) GetCursor() string {
 	return ""
 }
 
+func (x *ListSchedulerRunsRequest) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *ListSchedulerRunsRequest) GetStatus() SchedulerRunStatus {
+	if x != nil {
+		return x.Status
+	}
+	return SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED
+}
+
 type ListSchedulerRunsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Runs          []*SchedulerRun        `protobuf:"bytes,1,rep,name=runs,proto3" json:"runs,omitempty"`
@@ -3839,7 +4151,7 @@ type ListSchedulerRunsResponse struct {
 
 func (x *ListSchedulerRunsResponse) Reset() {
 	*x = ListSchedulerRunsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3851,7 +4163,7 @@ func (x *ListSchedulerRunsResponse) String() string {
 func (*ListSchedulerRunsResponse) ProtoMessage() {}
 
 func (x *ListSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[37]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3864,7 +4176,7 @@ func (x *ListSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSchedulerRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListSchedulerRunsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{37}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListSchedulerRunsResponse) GetRuns() []*SchedulerRun {
@@ -3892,7 +4204,7 @@ type StopSchedulerRunRequest struct {
 
 func (x *StopSchedulerRunRequest) Reset() {
 	*x = StopSchedulerRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3904,7 +4216,7 @@ func (x *StopSchedulerRunRequest) String() string {
 func (*StopSchedulerRunRequest) ProtoMessage() {}
 
 func (x *StopSchedulerRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[38]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3917,7 +4229,7 @@ func (x *StopSchedulerRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSchedulerRunRequest.ProtoReflect.Descriptor instead.
 func (*StopSchedulerRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{38}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *StopSchedulerRunRequest) GetProject() *ProjectRef {
@@ -3951,7 +4263,7 @@ type StopSchedulerRunResponse struct {
 
 func (x *StopSchedulerRunResponse) Reset() {
 	*x = StopSchedulerRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3963,7 +4275,7 @@ func (x *StopSchedulerRunResponse) String() string {
 func (*StopSchedulerRunResponse) ProtoMessage() {}
 
 func (x *StopSchedulerRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[39]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3976,7 +4288,7 @@ func (x *StopSchedulerRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSchedulerRunResponse.ProtoReflect.Descriptor instead.
 func (*StopSchedulerRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{39}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *StopSchedulerRunResponse) GetRun() *SchedulerRun {
@@ -4011,13 +4323,14 @@ type SchedulerRun struct {
 	PayloadJson        string                 `protobuf:"bytes,14,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
 	SourceScriptSha256 string                 `protobuf:"bytes,15,opt,name=source_script_sha256,json=sourceScriptSha256,proto3" json:"source_script_sha256,omitempty"`
 	ArtifactsDir       string                 `protobuf:"bytes,16,opt,name=artifacts_dir,json=artifactsDir,proto3" json:"artifacts_dir,omitempty"`
+	SandboxIds         []string               `protobuf:"bytes,17,rep,name=sandbox_ids,json=sandboxIds,proto3" json:"sandbox_ids,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
 
 func (x *SchedulerRun) Reset() {
 	*x = SchedulerRun{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4029,7 +4342,7 @@ func (x *SchedulerRun) String() string {
 func (*SchedulerRun) ProtoMessage() {}
 
 func (x *SchedulerRun) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[40]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4042,7 +4355,7 @@ func (x *SchedulerRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerRun.ProtoReflect.Descriptor instead.
 func (*SchedulerRun) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{40}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SchedulerRun) GetRunId() string {
@@ -4157,6 +4470,13 @@ func (x *SchedulerRun) GetArtifactsDir() string {
 	return ""
 }
 
+func (x *SchedulerRun) GetSandboxIds() []string {
+	if x != nil {
+		return x.SandboxIds
+	}
+	return nil
+}
+
 type SetSchedulerEnabledRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
@@ -4168,7 +4488,7 @@ type SetSchedulerEnabledRequest struct {
 
 func (x *SetSchedulerEnabledRequest) Reset() {
 	*x = SetSchedulerEnabledRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4180,7 +4500,7 @@ func (x *SetSchedulerEnabledRequest) String() string {
 func (*SetSchedulerEnabledRequest) ProtoMessage() {}
 
 func (x *SetSchedulerEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[41]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4193,7 +4513,7 @@ func (x *SetSchedulerEnabledRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSchedulerEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetSchedulerEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{41}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *SetSchedulerEnabledRequest) GetProject() *ProjectRef {
@@ -4227,7 +4547,7 @@ type SetSchedulerEnabledResponse struct {
 
 func (x *SetSchedulerEnabledResponse) Reset() {
 	*x = SetSchedulerEnabledResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4239,7 +4559,7 @@ func (x *SetSchedulerEnabledResponse) String() string {
 func (*SetSchedulerEnabledResponse) ProtoMessage() {}
 
 func (x *SetSchedulerEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4252,7 +4572,7 @@ func (x *SetSchedulerEnabledResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSchedulerEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetSchedulerEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *SetSchedulerEnabledResponse) GetScheduler() *ProjectScheduler {
@@ -4281,7 +4601,7 @@ type SetSchedulerTriggerEnabledRequest struct {
 
 func (x *SetSchedulerTriggerEnabledRequest) Reset() {
 	*x = SetSchedulerTriggerEnabledRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4293,7 +4613,7 @@ func (x *SetSchedulerTriggerEnabledRequest) String() string {
 func (*SetSchedulerTriggerEnabledRequest) ProtoMessage() {}
 
 func (x *SetSchedulerTriggerEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4306,7 +4626,7 @@ func (x *SetSchedulerTriggerEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetSchedulerTriggerEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetSchedulerTriggerEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *SetSchedulerTriggerEnabledRequest) GetProject() *ProjectRef {
@@ -4346,7 +4666,7 @@ type SetSchedulerTriggerEnabledResponse struct {
 
 func (x *SetSchedulerTriggerEnabledResponse) Reset() {
 	*x = SetSchedulerTriggerEnabledResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4358,7 +4678,7 @@ func (x *SetSchedulerTriggerEnabledResponse) String() string {
 func (*SetSchedulerTriggerEnabledResponse) ProtoMessage() {}
 
 func (x *SetSchedulerTriggerEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4371,7 +4691,7 @@ func (x *SetSchedulerTriggerEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetSchedulerTriggerEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetSchedulerTriggerEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *SetSchedulerTriggerEnabledResponse) GetTrigger() *ResolvedTrigger {
@@ -4392,7 +4712,7 @@ type ProjectValidationIssue struct {
 
 func (x *ProjectValidationIssue) Reset() {
 	*x = ProjectValidationIssue{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4404,7 +4724,7 @@ func (x *ProjectValidationIssue) String() string {
 func (*ProjectValidationIssue) ProtoMessage() {}
 
 func (x *ProjectValidationIssue) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4417,7 +4737,7 @@ func (x *ProjectValidationIssue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectValidationIssue.ProtoReflect.Descriptor instead.
 func (*ProjectValidationIssue) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ProjectValidationIssue) GetSeverity() ProjectValidationSeverity {
@@ -4454,7 +4774,7 @@ type ProjectChange struct {
 
 func (x *ProjectChange) Reset() {
 	*x = ProjectChange{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4466,7 +4786,7 @@ func (x *ProjectChange) String() string {
 func (*ProjectChange) ProtoMessage() {}
 
 func (x *ProjectChange) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4479,7 +4799,7 @@ func (x *ProjectChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectChange.ProtoReflect.Descriptor instead.
 func (*ProjectChange) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ProjectChange) GetAction() ProjectChangeAction {
@@ -4531,7 +4851,7 @@ type ProjectSpec struct {
 
 func (x *ProjectSpec) Reset() {
 	*x = ProjectSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4543,7 +4863,7 @@ func (x *ProjectSpec) String() string {
 func (*ProjectSpec) ProtoMessage() {}
 
 func (x *ProjectSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4556,7 +4876,7 @@ func (x *ProjectSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectSpec.ProtoReflect.Descriptor instead.
 func (*ProjectSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ProjectSpec) GetName() string {
@@ -4611,7 +4931,7 @@ type NamedWorkspaceSpec struct {
 
 func (x *NamedWorkspaceSpec) Reset() {
 	*x = NamedWorkspaceSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4623,7 +4943,7 @@ func (x *NamedWorkspaceSpec) String() string {
 func (*NamedWorkspaceSpec) ProtoMessage() {}
 
 func (x *NamedWorkspaceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4636,7 +4956,7 @@ func (x *NamedWorkspaceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamedWorkspaceSpec.ProtoReflect.Descriptor instead.
 func (*NamedWorkspaceSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *NamedWorkspaceSpec) GetName() string {
@@ -4679,7 +4999,7 @@ type AgentSpec struct {
 
 func (x *AgentSpec) Reset() {
 	*x = AgentSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4691,7 +5011,7 @@ func (x *AgentSpec) String() string {
 func (*AgentSpec) ProtoMessage() {}
 
 func (x *AgentSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4704,7 +5024,7 @@ func (x *AgentSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentSpec.ProtoReflect.Descriptor instead.
 func (*AgentSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *AgentSpec) GetName() string {
@@ -4849,7 +5169,7 @@ type MCPServerSpec struct {
 
 func (x *MCPServerSpec) Reset() {
 	*x = MCPServerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4861,7 +5181,7 @@ func (x *MCPServerSpec) String() string {
 func (*MCPServerSpec) ProtoMessage() {}
 
 func (x *MCPServerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4874,7 +5194,7 @@ func (x *MCPServerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerSpec.ProtoReflect.Descriptor instead.
 func (*MCPServerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *MCPServerSpec) GetName() string {
@@ -4947,7 +5267,7 @@ type ProjectVolumeSpec struct {
 
 func (x *ProjectVolumeSpec) Reset() {
 	*x = ProjectVolumeSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4959,7 +5279,7 @@ func (x *ProjectVolumeSpec) String() string {
 func (*ProjectVolumeSpec) ProtoMessage() {}
 
 func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4972,7 +5292,7 @@ func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectVolumeSpec.ProtoReflect.Descriptor instead.
 func (*ProjectVolumeSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ProjectVolumeSpec) GetKey() string {
@@ -5029,7 +5349,7 @@ type VolumeMountSpec struct {
 
 func (x *VolumeMountSpec) Reset() {
 	*x = VolumeMountSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5041,7 +5361,7 @@ func (x *VolumeMountSpec) String() string {
 func (*VolumeMountSpec) ProtoMessage() {}
 
 func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5054,7 +5374,7 @@ func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeMountSpec.ProtoReflect.Descriptor instead.
 func (*VolumeMountSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *VolumeMountSpec) GetType() string {
@@ -5101,7 +5421,7 @@ type BuildSpec struct {
 
 func (x *BuildSpec) Reset() {
 	*x = BuildSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5113,7 +5433,7 @@ func (x *BuildSpec) String() string {
 func (*BuildSpec) ProtoMessage() {}
 
 func (x *BuildSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5126,7 +5446,7 @@ func (x *BuildSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildSpec.ProtoReflect.Descriptor instead.
 func (*BuildSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *BuildSpec) GetContext() string {
@@ -5196,7 +5516,7 @@ type EnvVarSpec struct {
 
 func (x *EnvVarSpec) Reset() {
 	*x = EnvVarSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5208,7 +5528,7 @@ func (x *EnvVarSpec) String() string {
 func (*EnvVarSpec) ProtoMessage() {}
 
 func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5221,7 +5541,7 @@ func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVarSpec.ProtoReflect.Descriptor instead.
 func (*EnvVarSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *EnvVarSpec) GetName() string {
@@ -5256,7 +5576,7 @@ type EnvVarUpdateSpec struct {
 
 func (x *EnvVarUpdateSpec) Reset() {
 	*x = EnvVarUpdateSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5268,7 +5588,7 @@ func (x *EnvVarUpdateSpec) String() string {
 func (*EnvVarUpdateSpec) ProtoMessage() {}
 
 func (x *EnvVarUpdateSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5281,7 +5601,7 @@ func (x *EnvVarUpdateSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVarUpdateSpec.ProtoReflect.Descriptor instead.
 func (*EnvVarUpdateSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *EnvVarUpdateSpec) GetName() string {
@@ -5323,7 +5643,7 @@ type WorkspaceSpec struct {
 
 func (x *WorkspaceSpec) Reset() {
 	*x = WorkspaceSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5335,7 +5655,7 @@ func (x *WorkspaceSpec) String() string {
 func (*WorkspaceSpec) ProtoMessage() {}
 
 func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5348,7 +5668,7 @@ func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspaceSpec.ProtoReflect.Descriptor instead.
 func (*WorkspaceSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *WorkspaceSpec) GetProvider() string {
@@ -5435,7 +5755,7 @@ type SchedulerSpec struct {
 
 func (x *SchedulerSpec) Reset() {
 	*x = SchedulerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5447,7 +5767,7 @@ func (x *SchedulerSpec) String() string {
 func (*SchedulerSpec) ProtoMessage() {}
 
 func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5460,7 +5780,7 @@ func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerSpec.ProtoReflect.Descriptor instead.
 func (*SchedulerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *SchedulerSpec) GetEnabled() bool {
@@ -5521,7 +5841,7 @@ type TriggerSpec struct {
 
 func (x *TriggerSpec) Reset() {
 	*x = TriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5533,7 +5853,7 @@ func (x *TriggerSpec) String() string {
 func (*TriggerSpec) ProtoMessage() {}
 
 func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5546,7 +5866,7 @@ func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerSpec.ProtoReflect.Descriptor instead.
 func (*TriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *TriggerSpec) GetName() string {
@@ -5614,7 +5934,7 @@ type EventTriggerSpec struct {
 
 func (x *EventTriggerSpec) Reset() {
 	*x = EventTriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5626,7 +5946,7 @@ func (x *EventTriggerSpec) String() string {
 func (*EventTriggerSpec) ProtoMessage() {}
 
 func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5639,7 +5959,7 @@ func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventTriggerSpec.ProtoReflect.Descriptor instead.
 func (*EventTriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *EventTriggerSpec) GetTopic() string {
@@ -5661,7 +5981,7 @@ type DriverSpec struct {
 
 func (x *DriverSpec) Reset() {
 	*x = DriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5673,7 +5993,7 @@ func (x *DriverSpec) String() string {
 func (*DriverSpec) ProtoMessage() {}
 
 func (x *DriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5686,7 +6006,7 @@ func (x *DriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DriverSpec.ProtoReflect.Descriptor instead.
 func (*DriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *DriverSpec) GetName() string {
@@ -5727,7 +6047,7 @@ type BoxliteDriverSpec struct {
 
 func (x *BoxliteDriverSpec) Reset() {
 	*x = BoxliteDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5739,7 +6059,7 @@ func (x *BoxliteDriverSpec) String() string {
 func (*BoxliteDriverSpec) ProtoMessage() {}
 
 func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5752,7 +6072,7 @@ func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoxliteDriverSpec.ProtoReflect.Descriptor instead.
 func (*BoxliteDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *BoxliteDriverSpec) GetKernel() string {
@@ -5778,7 +6098,7 @@ type DockerDriverSpec struct {
 
 func (x *DockerDriverSpec) Reset() {
 	*x = DockerDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5790,7 +6110,7 @@ func (x *DockerDriverSpec) String() string {
 func (*DockerDriverSpec) ProtoMessage() {}
 
 func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5803,7 +6123,7 @@ func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerDriverSpec.ProtoReflect.Descriptor instead.
 func (*DockerDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *DockerDriverSpec) GetHost() string {
@@ -5822,7 +6142,7 @@ type MicrosandboxDriverSpec struct {
 
 func (x *MicrosandboxDriverSpec) Reset() {
 	*x = MicrosandboxDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5834,7 +6154,7 @@ func (x *MicrosandboxDriverSpec) String() string {
 func (*MicrosandboxDriverSpec) ProtoMessage() {}
 
 func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5847,7 +6167,7 @@ func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosandboxDriverSpec.ProtoReflect.Descriptor instead.
 func (*MicrosandboxDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *MicrosandboxDriverSpec) GetProfile() string {
@@ -5881,7 +6201,7 @@ type RunAgentRequest struct {
 
 func (x *RunAgentRequest) Reset() {
 	*x = RunAgentRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5893,7 +6213,7 @@ func (x *RunAgentRequest) String() string {
 func (*RunAgentRequest) ProtoMessage() {}
 
 func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5906,7 +6226,7 @@ func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentRequest.ProtoReflect.Descriptor instead.
 func (*RunAgentRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *RunAgentRequest) GetProjectId() string {
@@ -6031,7 +6351,7 @@ type RunAgentResponse struct {
 
 func (x *RunAgentResponse) Reset() {
 	*x = RunAgentResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6043,7 +6363,7 @@ func (x *RunAgentResponse) String() string {
 func (*RunAgentResponse) ProtoMessage() {}
 
 func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6056,7 +6376,7 @@ func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *RunAgentResponse) GetRun() *RunDetail {
@@ -6089,7 +6409,7 @@ type RunAgentStreamResponse struct {
 
 func (x *RunAgentStreamResponse) Reset() {
 	*x = RunAgentStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6101,7 +6421,7 @@ func (x *RunAgentStreamResponse) String() string {
 func (*RunAgentStreamResponse) ProtoMessage() {}
 
 func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6114,7 +6434,7 @@ func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentStreamResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *RunAgentStreamResponse) GetEventType() RunAgentStreamEventType {
@@ -6192,7 +6512,7 @@ type RunAttachRequest struct {
 
 func (x *RunAttachRequest) Reset() {
 	*x = RunAttachRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6204,7 +6524,7 @@ func (x *RunAttachRequest) String() string {
 func (*RunAttachRequest) ProtoMessage() {}
 
 func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6217,7 +6537,7 @@ func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachRequest.ProtoReflect.Descriptor instead.
 func (*RunAttachRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *RunAttachRequest) GetClientFrameId() string {
@@ -6362,7 +6682,7 @@ type RunAttachResponse struct {
 
 func (x *RunAttachResponse) Reset() {
 	*x = RunAttachResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6374,7 +6694,7 @@ func (x *RunAttachResponse) String() string {
 func (*RunAttachResponse) ProtoMessage() {}
 
 func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6387,7 +6707,7 @@ func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachResponse.ProtoReflect.Descriptor instead.
 func (*RunAttachResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *RunAttachResponse) GetServerFrameId() string {
@@ -6518,7 +6838,7 @@ type RunAttachStart struct {
 
 func (x *RunAttachStart) Reset() {
 	*x = RunAttachStart{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6530,7 +6850,7 @@ func (x *RunAttachStart) String() string {
 func (*RunAttachStart) ProtoMessage() {}
 
 func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6543,7 +6863,7 @@ func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachStart.ProtoReflect.Descriptor instead.
 func (*RunAttachStart) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *RunAttachStart) GetRequest() *RunAgentRequest {
@@ -6594,7 +6914,7 @@ type TranscriptEvent struct {
 
 func (x *TranscriptEvent) Reset() {
 	*x = TranscriptEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6606,7 +6926,7 @@ func (x *TranscriptEvent) String() string {
 func (*TranscriptEvent) ProtoMessage() {}
 
 func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6619,7 +6939,7 @@ func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TranscriptEvent.ProtoReflect.Descriptor instead.
 func (*TranscriptEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *TranscriptEvent) GetStream() StdioStream {
@@ -6667,7 +6987,7 @@ type GetRunRequest struct {
 
 func (x *GetRunRequest) Reset() {
 	*x = GetRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6679,7 +6999,7 @@ func (x *GetRunRequest) String() string {
 func (*GetRunRequest) ProtoMessage() {}
 
 func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6692,7 +7012,7 @@ func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunRequest.ProtoReflect.Descriptor instead.
 func (*GetRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetRunRequest) GetRunId() string {
@@ -6718,7 +7038,7 @@ type GetRunResponse struct {
 
 func (x *GetRunResponse) Reset() {
 	*x = GetRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6730,7 +7050,7 @@ func (x *GetRunResponse) String() string {
 func (*GetRunResponse) ProtoMessage() {}
 
 func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6743,7 +7063,7 @@ func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunResponse.ProtoReflect.Descriptor instead.
 func (*GetRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GetRunResponse) GetRun() *RunDetail {
@@ -6771,7 +7091,7 @@ type ListRunsRequest struct {
 
 func (x *ListRunsRequest) Reset() {
 	*x = ListRunsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6783,7 +7103,7 @@ func (x *ListRunsRequest) String() string {
 func (*ListRunsRequest) ProtoMessage() {}
 
 func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6796,7 +7116,7 @@ func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *ListRunsRequest) GetProjectId() string {
@@ -6878,7 +7198,7 @@ type ListRunsResponse struct {
 
 func (x *ListRunsResponse) Reset() {
 	*x = ListRunsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6890,7 +7210,7 @@ func (x *ListRunsResponse) String() string {
 func (*ListRunsResponse) ProtoMessage() {}
 
 func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6903,7 +7223,7 @@ func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ListRunsResponse) GetRuns() []*RunSummary {
@@ -6926,7 +7246,7 @@ type FollowRunLogsRequest struct {
 
 func (x *FollowRunLogsRequest) Reset() {
 	*x = FollowRunLogsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6938,7 +7258,7 @@ func (x *FollowRunLogsRequest) String() string {
 func (*FollowRunLogsRequest) ProtoMessage() {}
 
 func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6951,7 +7271,7 @@ func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FollowRunLogsRequest.ProtoReflect.Descriptor instead.
 func (*FollowRunLogsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *FollowRunLogsRequest) GetProjectId() string {
@@ -7002,7 +7322,7 @@ type RunLogChunk struct {
 
 func (x *RunLogChunk) Reset() {
 	*x = RunLogChunk{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7014,7 +7334,7 @@ func (x *RunLogChunk) String() string {
 func (*RunLogChunk) ProtoMessage() {}
 
 func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7027,7 +7347,7 @@ func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunLogChunk.ProtoReflect.Descriptor instead.
 func (*RunLogChunk) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *RunLogChunk) GetData() string {
@@ -7075,7 +7395,7 @@ type StopRunRequest struct {
 
 func (x *StopRunRequest) Reset() {
 	*x = StopRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7087,7 +7407,7 @@ func (x *StopRunRequest) String() string {
 func (*StopRunRequest) ProtoMessage() {}
 
 func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7100,7 +7420,7 @@ func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunRequest.ProtoReflect.Descriptor instead.
 func (*StopRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *StopRunRequest) GetRunId() string {
@@ -7127,7 +7447,7 @@ type StopRunResponse struct {
 
 func (x *StopRunResponse) Reset() {
 	*x = StopRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7139,7 +7459,7 @@ func (x *StopRunResponse) String() string {
 func (*StopRunResponse) ProtoMessage() {}
 
 func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7152,7 +7472,7 @@ func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunResponse.ProtoReflect.Descriptor instead.
 func (*StopRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *StopRunResponse) GetRun() *RunDetail {
@@ -7180,7 +7500,7 @@ type ListRunEventsRequest struct {
 
 func (x *ListRunEventsRequest) Reset() {
 	*x = ListRunEventsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7192,7 +7512,7 @@ func (x *ListRunEventsRequest) String() string {
 func (*ListRunEventsRequest) ProtoMessage() {}
 
 func (x *ListRunEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7205,7 +7525,7 @@ func (x *ListRunEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunEventsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunEventsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ListRunEventsRequest) GetRunId() string {
@@ -7249,7 +7569,7 @@ type RunEvent struct {
 
 func (x *RunEvent) Reset() {
 	*x = RunEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7261,7 +7581,7 @@ func (x *RunEvent) String() string {
 func (*RunEvent) ProtoMessage() {}
 
 func (x *RunEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7274,7 +7594,7 @@ func (x *RunEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunEvent.ProtoReflect.Descriptor instead.
 func (*RunEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *RunEvent) GetId() string {
@@ -7372,7 +7692,7 @@ type ListRunEventsResponse struct {
 
 func (x *ListRunEventsResponse) Reset() {
 	*x = ListRunEventsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7384,7 +7704,7 @@ func (x *ListRunEventsResponse) String() string {
 func (*ListRunEventsResponse) ProtoMessage() {}
 
 func (x *ListRunEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7397,7 +7717,7 @@ func (x *ListRunEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunEventsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunEventsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ListRunEventsResponse) GetEvents() []*RunEvent {
@@ -7432,7 +7752,7 @@ type ListSandboxRunEventsRequest struct {
 
 func (x *ListSandboxRunEventsRequest) Reset() {
 	*x = ListSandboxRunEventsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7444,7 +7764,7 @@ func (x *ListSandboxRunEventsRequest) String() string {
 func (*ListSandboxRunEventsRequest) ProtoMessage() {}
 
 func (x *ListSandboxRunEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7457,7 +7777,7 @@ func (x *ListSandboxRunEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxRunEventsRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxRunEventsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ListSandboxRunEventsRequest) GetSandboxId() string {
@@ -7492,7 +7812,7 @@ type ListSandboxRunEventsResponse struct {
 
 func (x *ListSandboxRunEventsResponse) Reset() {
 	*x = ListSandboxRunEventsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7504,7 +7824,7 @@ func (x *ListSandboxRunEventsResponse) String() string {
 func (*ListSandboxRunEventsResponse) ProtoMessage() {}
 
 func (x *ListSandboxRunEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7517,7 +7837,7 @@ func (x *ListSandboxRunEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxRunEventsResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxRunEventsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *ListSandboxRunEventsResponse) GetEvents() []*RunEvent {
@@ -7551,7 +7871,7 @@ type RemoveSandboxRequest struct {
 
 func (x *RemoveSandboxRequest) Reset() {
 	*x = RemoveSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7563,7 +7883,7 @@ func (x *RemoveSandboxRequest) String() string {
 func (*RemoveSandboxRequest) ProtoMessage() {}
 
 func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7576,7 +7896,7 @@ func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *RemoveSandboxRequest) GetSandboxId() string {
@@ -7604,7 +7924,7 @@ type RemoveSandboxResponse struct {
 
 func (x *RemoveSandboxResponse) Reset() {
 	*x = RemoveSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7616,7 +7936,7 @@ func (x *RemoveSandboxResponse) String() string {
 func (*RemoveSandboxResponse) ProtoMessage() {}
 
 func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7629,7 +7949,7 @@ func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *RemoveSandboxResponse) GetSandboxId() string {
@@ -7668,7 +7988,7 @@ type PruneSandboxesRequest struct {
 
 func (x *PruneSandboxesRequest) Reset() {
 	*x = PruneSandboxesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7680,7 +8000,7 @@ func (x *PruneSandboxesRequest) String() string {
 func (*PruneSandboxesRequest) ProtoMessage() {}
 
 func (x *PruneSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7693,7 +8013,7 @@ func (x *PruneSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*PruneSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *PruneSandboxesRequest) GetProjectId() string {
@@ -7763,7 +8083,7 @@ type SandboxPruneCandidate struct {
 
 func (x *SandboxPruneCandidate) Reset() {
 	*x = SandboxPruneCandidate{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7775,7 +8095,7 @@ func (x *SandboxPruneCandidate) String() string {
 func (*SandboxPruneCandidate) ProtoMessage() {}
 
 func (x *SandboxPruneCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7788,7 +8108,7 @@ func (x *SandboxPruneCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPruneCandidate.ProtoReflect.Descriptor instead.
 func (*SandboxPruneCandidate) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *SandboxPruneCandidate) GetKind() SandboxPruneCandidateKind {
@@ -7874,7 +8194,7 @@ type PruneSandboxesResponse struct {
 
 func (x *PruneSandboxesResponse) Reset() {
 	*x = PruneSandboxesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7886,7 +8206,7 @@ func (x *PruneSandboxesResponse) String() string {
 func (*PruneSandboxesResponse) ProtoMessage() {}
 
 func (x *PruneSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7899,7 +8219,7 @@ func (x *PruneSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*PruneSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *PruneSandboxesResponse) GetDryRun() bool {
@@ -7946,7 +8266,7 @@ type GetSandboxStatsRequest struct {
 
 func (x *GetSandboxStatsRequest) Reset() {
 	*x = GetSandboxStatsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7958,7 +8278,7 @@ func (x *GetSandboxStatsRequest) String() string {
 func (*GetSandboxStatsRequest) ProtoMessage() {}
 
 func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7971,7 +8291,7 @@ func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *GetSandboxStatsRequest) GetSandboxId() string {
@@ -7990,7 +8310,7 @@ type GetSandboxStatsResponse struct {
 
 func (x *GetSandboxStatsResponse) Reset() {
 	*x = GetSandboxStatsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8002,7 +8322,7 @@ func (x *GetSandboxStatsResponse) String() string {
 func (*GetSandboxStatsResponse) ProtoMessage() {}
 
 func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8015,7 +8335,7 @@ func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *GetSandboxStatsResponse) GetStats() *SandboxStats {
@@ -8034,7 +8354,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8046,7 +8366,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8059,7 +8379,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -8097,7 +8417,7 @@ type Sandbox struct {
 
 func (x *Sandbox) Reset() {
 	*x = Sandbox{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8109,7 +8429,7 @@ func (x *Sandbox) String() string {
 func (*Sandbox) ProtoMessage() {}
 
 func (x *Sandbox) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8122,7 +8442,7 @@ func (x *Sandbox) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sandbox.ProtoReflect.Descriptor instead.
 func (*Sandbox) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *Sandbox) GetSandboxId() string {
@@ -8275,7 +8595,7 @@ type SandboxTag struct {
 
 func (x *SandboxTag) Reset() {
 	*x = SandboxTag{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8287,7 +8607,7 @@ func (x *SandboxTag) String() string {
 func (*SandboxTag) ProtoMessage() {}
 
 func (x *SandboxTag) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8300,7 +8620,7 @@ func (x *SandboxTag) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxTag.ProtoReflect.Descriptor instead.
 func (*SandboxTag) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *SandboxTag) GetName() string {
@@ -8327,7 +8647,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8339,7 +8659,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8352,7 +8672,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *ListSandboxesRequest) GetLimit() uint32 {
@@ -8379,7 +8699,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8391,7 +8711,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8404,7 +8724,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -8430,7 +8750,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8442,7 +8762,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8455,7 +8775,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -8474,7 +8794,7 @@ type StopSandboxRequest struct {
 
 func (x *StopSandboxRequest) Reset() {
 	*x = StopSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8486,7 +8806,7 @@ func (x *StopSandboxRequest) String() string {
 func (*StopSandboxRequest) ProtoMessage() {}
 
 func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8499,7 +8819,7 @@ func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSandboxRequest.ProtoReflect.Descriptor instead.
 func (*StopSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *StopSandboxRequest) GetSandboxId() string {
@@ -8518,7 +8838,7 @@ type StopSandboxResponse struct {
 
 func (x *StopSandboxResponse) Reset() {
 	*x = StopSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8530,7 +8850,7 @@ func (x *StopSandboxResponse) String() string {
 func (*StopSandboxResponse) ProtoMessage() {}
 
 func (x *StopSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8543,7 +8863,7 @@ func (x *StopSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSandboxResponse.ProtoReflect.Descriptor instead.
 func (*StopSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *StopSandboxResponse) GetSandbox() *Sandbox {
@@ -8562,7 +8882,7 @@ type ResumeSandboxRequest struct {
 
 func (x *ResumeSandboxRequest) Reset() {
 	*x = ResumeSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8574,7 +8894,7 @@ func (x *ResumeSandboxRequest) String() string {
 func (*ResumeSandboxRequest) ProtoMessage() {}
 
 func (x *ResumeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8587,7 +8907,7 @@ func (x *ResumeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*ResumeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *ResumeSandboxRequest) GetSandboxId() string {
@@ -8606,7 +8926,7 @@ type ResumeSandboxResponse struct {
 
 func (x *ResumeSandboxResponse) Reset() {
 	*x = ResumeSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8618,7 +8938,7 @@ func (x *ResumeSandboxResponse) String() string {
 func (*ResumeSandboxResponse) ProtoMessage() {}
 
 func (x *ResumeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8631,7 +8951,7 @@ func (x *ResumeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*ResumeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *ResumeSandboxResponse) GetSandbox() *Sandbox {
@@ -8653,7 +8973,7 @@ type MetricValue struct {
 
 func (x *MetricValue) Reset() {
 	*x = MetricValue{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8665,7 +8985,7 @@ func (x *MetricValue) String() string {
 func (*MetricValue) ProtoMessage() {}
 
 func (x *MetricValue) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8678,7 +8998,7 @@ func (x *MetricValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetricValue.ProtoReflect.Descriptor instead.
 func (*MetricValue) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *MetricValue) GetValue() float64 {
@@ -8729,7 +9049,7 @@ type SandboxStats struct {
 
 func (x *SandboxStats) Reset() {
 	*x = SandboxStats{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8741,7 +9061,7 @@ func (x *SandboxStats) String() string {
 func (*SandboxStats) ProtoMessage() {}
 
 func (x *SandboxStats) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8754,7 +9074,7 @@ func (x *SandboxStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStats.ProtoReflect.Descriptor instead.
 func (*SandboxStats) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *SandboxStats) GetSandboxId() string {
@@ -8870,7 +9190,7 @@ type RunSummary struct {
 
 func (x *RunSummary) Reset() {
 	*x = RunSummary{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8882,7 +9202,7 @@ func (x *RunSummary) String() string {
 func (*RunSummary) ProtoMessage() {}
 
 func (x *RunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8895,7 +9215,7 @@ func (x *RunSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSummary.ProtoReflect.Descriptor instead.
 func (*RunSummary) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *RunSummary) GetRunId() string {
@@ -9063,7 +9383,7 @@ type RunDetail struct {
 
 func (x *RunDetail) Reset() {
 	*x = RunDetail{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9075,7 +9395,7 @@ func (x *RunDetail) String() string {
 func (*RunDetail) ProtoMessage() {}
 
 func (x *RunDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9088,7 +9408,7 @@ func (x *RunDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunDetail.ProtoReflect.Descriptor instead.
 func (*RunDetail) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{104}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *RunDetail) GetSummary() *RunSummary {
@@ -9180,7 +9500,7 @@ type ExecRequest struct {
 
 func (x *ExecRequest) Reset() {
 	*x = ExecRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9192,7 +9512,7 @@ func (x *ExecRequest) String() string {
 func (*ExecRequest) ProtoMessage() {}
 
 func (x *ExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9205,7 +9525,7 @@ func (x *ExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecRequest.ProtoReflect.Descriptor instead.
 func (*ExecRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{105}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ExecRequest) GetTarget() isExecRequest_Target {
@@ -9310,7 +9630,7 @@ type ExecSandboxSelector struct {
 
 func (x *ExecSandboxSelector) Reset() {
 	*x = ExecSandboxSelector{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9322,7 +9642,7 @@ func (x *ExecSandboxSelector) String() string {
 func (*ExecSandboxSelector) ProtoMessage() {}
 
 func (x *ExecSandboxSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9335,7 +9655,7 @@ func (x *ExecSandboxSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxSelector.ProtoReflect.Descriptor instead.
 func (*ExecSandboxSelector) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{106}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ExecSandboxSelector) GetProjectId() string {
@@ -9369,7 +9689,7 @@ type ExecCommand struct {
 
 func (x *ExecCommand) Reset() {
 	*x = ExecCommand{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9381,7 +9701,7 @@ func (x *ExecCommand) String() string {
 func (*ExecCommand) ProtoMessage() {}
 
 func (x *ExecCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9394,7 +9714,7 @@ func (x *ExecCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecCommand.ProtoReflect.Descriptor instead.
 func (*ExecCommand) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{107}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *ExecCommand) GetCommand() string {
@@ -9420,7 +9740,7 @@ type ExecResponse struct {
 
 func (x *ExecResponse) Reset() {
 	*x = ExecResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9432,7 +9752,7 @@ func (x *ExecResponse) String() string {
 func (*ExecResponse) ProtoMessage() {}
 
 func (x *ExecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9445,7 +9765,7 @@ func (x *ExecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResponse.ProtoReflect.Descriptor instead.
 func (*ExecResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{108}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *ExecResponse) GetResult() *ExecResult {
@@ -9471,7 +9791,7 @@ type ExecStreamResponse struct {
 
 func (x *ExecStreamResponse) Reset() {
 	*x = ExecStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9483,7 +9803,7 @@ func (x *ExecStreamResponse) String() string {
 func (*ExecStreamResponse) ProtoMessage() {}
 
 func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9496,7 +9816,7 @@ func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecStreamResponse.ProtoReflect.Descriptor instead.
 func (*ExecStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{109}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *ExecStreamResponse) GetEventType() ExecStreamEventType {
@@ -9574,7 +9894,7 @@ type ExecAttachRequest struct {
 
 func (x *ExecAttachRequest) Reset() {
 	*x = ExecAttachRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9586,7 +9906,7 @@ func (x *ExecAttachRequest) String() string {
 func (*ExecAttachRequest) ProtoMessage() {}
 
 func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9599,7 +9919,7 @@ func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachRequest.ProtoReflect.Descriptor instead.
 func (*ExecAttachRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{110}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *ExecAttachRequest) GetClientFrameId() string {
@@ -9744,7 +10064,7 @@ type ExecAttachResponse struct {
 
 func (x *ExecAttachResponse) Reset() {
 	*x = ExecAttachResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9756,7 +10076,7 @@ func (x *ExecAttachResponse) String() string {
 func (*ExecAttachResponse) ProtoMessage() {}
 
 func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9769,7 +10089,7 @@ func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachResponse.ProtoReflect.Descriptor instead.
 func (*ExecAttachResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{111}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *ExecAttachResponse) GetServerFrameId() string {
@@ -9901,7 +10221,7 @@ type ExecAttachStart struct {
 
 func (x *ExecAttachStart) Reset() {
 	*x = ExecAttachStart{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9913,7 +10233,7 @@ func (x *ExecAttachStart) String() string {
 func (*ExecAttachStart) ProtoMessage() {}
 
 func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9926,7 +10246,7 @@ func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachStart.ProtoReflect.Descriptor instead.
 func (*ExecAttachStart) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{112}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *ExecAttachStart) GetRequest() *ExecRequest {
@@ -9981,7 +10301,7 @@ type AttachTerminalSize struct {
 
 func (x *AttachTerminalSize) Reset() {
 	*x = AttachTerminalSize{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9993,7 +10313,7 @@ func (x *AttachTerminalSize) String() string {
 func (*AttachTerminalSize) ProtoMessage() {}
 
 func (x *AttachTerminalSize) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10006,7 +10326,7 @@ func (x *AttachTerminalSize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachTerminalSize.ProtoReflect.Descriptor instead.
 func (*AttachTerminalSize) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{113}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *AttachTerminalSize) GetRows() uint32 {
@@ -10032,7 +10352,7 @@ type AttachStdin struct {
 
 func (x *AttachStdin) Reset() {
 	*x = AttachStdin{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10044,7 +10364,7 @@ func (x *AttachStdin) String() string {
 func (*AttachStdin) ProtoMessage() {}
 
 func (x *AttachStdin) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10057,7 +10377,7 @@ func (x *AttachStdin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStdin.ProtoReflect.Descriptor instead.
 func (*AttachStdin) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{114}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *AttachStdin) GetData() []byte {
@@ -10075,7 +10395,7 @@ type AttachStdinEOF struct {
 
 func (x *AttachStdinEOF) Reset() {
 	*x = AttachStdinEOF{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10087,7 +10407,7 @@ func (x *AttachStdinEOF) String() string {
 func (*AttachStdinEOF) ProtoMessage() {}
 
 func (x *AttachStdinEOF) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10100,7 +10420,7 @@ func (x *AttachStdinEOF) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStdinEOF.ProtoReflect.Descriptor instead.
 func (*AttachStdinEOF) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{115}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{119}
 }
 
 type AttachResize struct {
@@ -10112,7 +10432,7 @@ type AttachResize struct {
 
 func (x *AttachResize) Reset() {
 	*x = AttachResize{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10124,7 +10444,7 @@ func (x *AttachResize) String() string {
 func (*AttachResize) ProtoMessage() {}
 
 func (x *AttachResize) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10137,7 +10457,7 @@ func (x *AttachResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachResize.ProtoReflect.Descriptor instead.
 func (*AttachResize) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{116}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *AttachResize) GetTerminalSize() *AttachTerminalSize {
@@ -10156,7 +10476,7 @@ type AttachSignal struct {
 
 func (x *AttachSignal) Reset() {
 	*x = AttachSignal{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10168,7 +10488,7 @@ func (x *AttachSignal) String() string {
 func (*AttachSignal) ProtoMessage() {}
 
 func (x *AttachSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10181,7 +10501,7 @@ func (x *AttachSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachSignal.ProtoReflect.Descriptor instead.
 func (*AttachSignal) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{117}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *AttachSignal) GetSignal() string {
@@ -10201,7 +10521,7 @@ type AttachHumanMessage struct {
 
 func (x *AttachHumanMessage) Reset() {
 	*x = AttachHumanMessage{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10213,7 +10533,7 @@ func (x *AttachHumanMessage) String() string {
 func (*AttachHumanMessage) ProtoMessage() {}
 
 func (x *AttachHumanMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10226,7 +10546,7 @@ func (x *AttachHumanMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachHumanMessage.ProtoReflect.Descriptor instead.
 func (*AttachHumanMessage) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{118}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *AttachHumanMessage) GetText() string {
@@ -10252,7 +10572,7 @@ type AttachCancel struct {
 
 func (x *AttachCancel) Reset() {
 	*x = AttachCancel{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10264,7 +10584,7 @@ func (x *AttachCancel) String() string {
 func (*AttachCancel) ProtoMessage() {}
 
 func (x *AttachCancel) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10277,7 +10597,7 @@ func (x *AttachCancel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachCancel.ProtoReflect.Descriptor instead.
 func (*AttachCancel) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{119}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *AttachCancel) GetReason() string {
@@ -10301,7 +10621,7 @@ type AttachStarted struct {
 
 func (x *AttachStarted) Reset() {
 	*x = AttachStarted{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10313,7 +10633,7 @@ func (x *AttachStarted) String() string {
 func (*AttachStarted) ProtoMessage() {}
 
 func (x *AttachStarted) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10326,7 +10646,7 @@ func (x *AttachStarted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStarted.ProtoReflect.Descriptor instead.
 func (*AttachStarted) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{120}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *AttachStarted) GetOperationId() string {
@@ -10383,7 +10703,7 @@ type AttachOutput struct {
 
 func (x *AttachOutput) Reset() {
 	*x = AttachOutput{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10395,7 +10715,7 @@ func (x *AttachOutput) String() string {
 func (*AttachOutput) ProtoMessage() {}
 
 func (x *AttachOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10408,7 +10728,7 @@ func (x *AttachOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachOutput.ProtoReflect.Descriptor instead.
 func (*AttachOutput) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{121}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *AttachOutput) GetData() []byte {
@@ -10451,7 +10771,7 @@ type AttachAgentEvent struct {
 
 func (x *AttachAgentEvent) Reset() {
 	*x = AttachAgentEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10463,7 +10783,7 @@ func (x *AttachAgentEvent) String() string {
 func (*AttachAgentEvent) ProtoMessage() {}
 
 func (x *AttachAgentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10476,7 +10796,7 @@ func (x *AttachAgentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachAgentEvent.ProtoReflect.Descriptor instead.
 func (*AttachAgentEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{122}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *AttachAgentEvent) GetName() string {
@@ -10518,7 +10838,7 @@ type AttachAgentTurnCompleted struct {
 
 func (x *AttachAgentTurnCompleted) Reset() {
 	*x = AttachAgentTurnCompleted{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10530,7 +10850,7 @@ func (x *AttachAgentTurnCompleted) String() string {
 func (*AttachAgentTurnCompleted) ProtoMessage() {}
 
 func (x *AttachAgentTurnCompleted) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10543,7 +10863,7 @@ func (x *AttachAgentTurnCompleted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachAgentTurnCompleted.ProtoReflect.Descriptor instead.
 func (*AttachAgentTurnCompleted) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{123}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *AttachAgentTurnCompleted) GetRunId() string {
@@ -10582,7 +10902,7 @@ type AttachResult struct {
 
 func (x *AttachResult) Reset() {
 	*x = AttachResult{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10594,7 +10914,7 @@ func (x *AttachResult) String() string {
 func (*AttachResult) ProtoMessage() {}
 
 func (x *AttachResult) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10607,7 +10927,7 @@ func (x *AttachResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachResult.ProtoReflect.Descriptor instead.
 func (*AttachResult) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{124}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *AttachResult) GetExitCode() int32 {
@@ -10671,7 +10991,7 @@ type AttachError struct {
 
 func (x *AttachError) Reset() {
 	*x = AttachError{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10683,7 +11003,7 @@ func (x *AttachError) String() string {
 func (*AttachError) ProtoMessage() {}
 
 func (x *AttachError) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10696,7 +11016,7 @@ func (x *AttachError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachError.ProtoReflect.Descriptor instead.
 func (*AttachError) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{125}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *AttachError) GetCode() string {
@@ -10749,7 +11069,7 @@ type ExecResult struct {
 
 func (x *ExecResult) Reset() {
 	*x = ExecResult{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10761,7 +11081,7 @@ func (x *ExecResult) String() string {
 func (*ExecResult) ProtoMessage() {}
 
 func (x *ExecResult) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10774,7 +11094,7 @@ func (x *ExecResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResult.ProtoReflect.Descriptor instead.
 func (*ExecResult) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{126}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *ExecResult) GetExecId() string {
@@ -10889,7 +11209,7 @@ type ListImagesRequest struct {
 
 func (x *ListImagesRequest) Reset() {
 	*x = ListImagesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10901,7 +11221,7 @@ func (x *ListImagesRequest) String() string {
 func (*ListImagesRequest) ProtoMessage() {}
 
 func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10914,7 +11234,7 @@ func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesRequest.ProtoReflect.Descriptor instead.
 func (*ListImagesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{127}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *ListImagesRequest) GetStore() ImageStoreKind {
@@ -10972,7 +11292,7 @@ type ListImagesResponse struct {
 
 func (x *ListImagesResponse) Reset() {
 	*x = ListImagesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10984,7 +11304,7 @@ func (x *ListImagesResponse) String() string {
 func (*ListImagesResponse) ProtoMessage() {}
 
 func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10997,7 +11317,7 @@ func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesResponse.ProtoReflect.Descriptor instead.
 func (*ListImagesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{128}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *ListImagesResponse) GetImages() []*Image {
@@ -11046,7 +11366,7 @@ type PullImageRequest struct {
 
 func (x *PullImageRequest) Reset() {
 	*x = PullImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11058,7 +11378,7 @@ func (x *PullImageRequest) String() string {
 func (*PullImageRequest) ProtoMessage() {}
 
 func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11071,7 +11391,7 @@ func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageRequest.ProtoReflect.Descriptor instead.
 func (*PullImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{129}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *PullImageRequest) GetImageRef() string {
@@ -11108,7 +11428,7 @@ type PullImageResponse struct {
 
 func (x *PullImageResponse) Reset() {
 	*x = PullImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11120,7 +11440,7 @@ func (x *PullImageResponse) String() string {
 func (*PullImageResponse) ProtoMessage() {}
 
 func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11133,7 +11453,7 @@ func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageResponse.ProtoReflect.Descriptor instead.
 func (*PullImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{130}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *PullImageResponse) GetImage() *Image {
@@ -11182,7 +11502,7 @@ type InspectImageRequest struct {
 
 func (x *InspectImageRequest) Reset() {
 	*x = InspectImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11194,7 +11514,7 @@ func (x *InspectImageRequest) String() string {
 func (*InspectImageRequest) ProtoMessage() {}
 
 func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11207,7 +11527,7 @@ func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageRequest.ProtoReflect.Descriptor instead.
 func (*InspectImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{131}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *InspectImageRequest) GetImageRef() string {
@@ -11241,7 +11561,7 @@ type InspectImageResponse struct {
 
 func (x *InspectImageResponse) Reset() {
 	*x = InspectImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11253,7 +11573,7 @@ func (x *InspectImageResponse) String() string {
 func (*InspectImageResponse) ProtoMessage() {}
 
 func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11266,7 +11586,7 @@ func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageResponse.ProtoReflect.Descriptor instead.
 func (*InspectImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{132}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *InspectImageResponse) GetImage() *Image {
@@ -11295,7 +11615,7 @@ type RemoveImageRequest struct {
 
 func (x *RemoveImageRequest) Reset() {
 	*x = RemoveImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11307,7 +11627,7 @@ func (x *RemoveImageRequest) String() string {
 func (*RemoveImageRequest) ProtoMessage() {}
 
 func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11320,7 +11640,7 @@ func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageRequest.ProtoReflect.Descriptor instead.
 func (*RemoveImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{133}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *RemoveImageRequest) GetImageRef() string {
@@ -11363,7 +11683,7 @@ type RemoveImageResponse struct {
 
 func (x *RemoveImageResponse) Reset() {
 	*x = RemoveImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11375,7 +11695,7 @@ func (x *RemoveImageResponse) String() string {
 func (*RemoveImageResponse) ProtoMessage() {}
 
 func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11388,7 +11708,7 @@ func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageResponse.ProtoReflect.Descriptor instead.
 func (*RemoveImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{134}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *RemoveImageResponse) GetImageRef() string {
@@ -11436,7 +11756,7 @@ type BuildImageRequest struct {
 
 func (x *BuildImageRequest) Reset() {
 	*x = BuildImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11448,7 +11768,7 @@ func (x *BuildImageRequest) String() string {
 func (*BuildImageRequest) ProtoMessage() {}
 
 func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11461,7 +11781,7 @@ func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageRequest.ProtoReflect.Descriptor instead.
 func (*BuildImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{135}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *BuildImageRequest) GetContextDir() string {
@@ -11542,7 +11862,7 @@ type BuildImageEvent struct {
 
 func (x *BuildImageEvent) Reset() {
 	*x = BuildImageEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11554,7 +11874,7 @@ func (x *BuildImageEvent) String() string {
 func (*BuildImageEvent) ProtoMessage() {}
 
 func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11567,7 +11887,7 @@ func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageEvent.ProtoReflect.Descriptor instead.
 func (*BuildImageEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{136}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *BuildImageEvent) GetStatus() ImageOperationStatus {
@@ -11633,7 +11953,7 @@ type CacheFilter struct {
 
 func (x *CacheFilter) Reset() {
 	*x = CacheFilter{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11645,7 +11965,7 @@ func (x *CacheFilter) String() string {
 func (*CacheFilter) ProtoMessage() {}
 
 func (x *CacheFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11658,7 +11978,7 @@ func (x *CacheFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheFilter.ProtoReflect.Descriptor instead.
 func (*CacheFilter) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{137}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *CacheFilter) GetDriver() string {
@@ -11712,7 +12032,7 @@ type ListCachesRequest struct {
 
 func (x *ListCachesRequest) Reset() {
 	*x = ListCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11724,7 +12044,7 @@ func (x *ListCachesRequest) String() string {
 func (*ListCachesRequest) ProtoMessage() {}
 
 func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11737,7 +12057,7 @@ func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesRequest.ProtoReflect.Descriptor instead.
 func (*ListCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{138}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *ListCachesRequest) GetFilter() *CacheFilter {
@@ -11757,7 +12077,7 @@ type ListCachesResponse struct {
 
 func (x *ListCachesResponse) Reset() {
 	*x = ListCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11769,7 +12089,7 @@ func (x *ListCachesResponse) String() string {
 func (*ListCachesResponse) ProtoMessage() {}
 
 func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11782,7 +12102,7 @@ func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesResponse.ProtoReflect.Descriptor instead.
 func (*ListCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{139}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *ListCachesResponse) GetCaches() []*CacheItem {
@@ -11808,7 +12128,7 @@ type InspectCacheRequest struct {
 
 func (x *InspectCacheRequest) Reset() {
 	*x = InspectCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11820,7 +12140,7 @@ func (x *InspectCacheRequest) String() string {
 func (*InspectCacheRequest) ProtoMessage() {}
 
 func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11833,7 +12153,7 @@ func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheRequest.ProtoReflect.Descriptor instead.
 func (*InspectCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{140}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *InspectCacheRequest) GetCacheId() string {
@@ -11853,7 +12173,7 @@ type InspectCacheResponse struct {
 
 func (x *InspectCacheResponse) Reset() {
 	*x = InspectCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11865,7 +12185,7 @@ func (x *InspectCacheResponse) String() string {
 func (*InspectCacheResponse) ProtoMessage() {}
 
 func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11878,7 +12198,7 @@ func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheResponse.ProtoReflect.Descriptor instead.
 func (*InspectCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{141}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *InspectCacheResponse) GetCache() *CacheItem {
@@ -11905,7 +12225,7 @@ type PruneCachesRequest struct {
 
 func (x *PruneCachesRequest) Reset() {
 	*x = PruneCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11917,7 +12237,7 @@ func (x *PruneCachesRequest) String() string {
 func (*PruneCachesRequest) ProtoMessage() {}
 
 func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11930,7 +12250,7 @@ func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesRequest.ProtoReflect.Descriptor instead.
 func (*PruneCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{142}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *PruneCachesRequest) GetFilter() *CacheFilter {
@@ -11960,7 +12280,7 @@ type PruneCachesResponse struct {
 
 func (x *PruneCachesResponse) Reset() {
 	*x = PruneCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11972,7 +12292,7 @@ func (x *PruneCachesResponse) String() string {
 func (*PruneCachesResponse) ProtoMessage() {}
 
 func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11985,7 +12305,7 @@ func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesResponse.ProtoReflect.Descriptor instead.
 func (*PruneCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{143}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *PruneCachesResponse) GetDryRun() bool {
@@ -12033,7 +12353,7 @@ type RemoveCacheRequest struct {
 
 func (x *RemoveCacheRequest) Reset() {
 	*x = RemoveCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12045,7 +12365,7 @@ func (x *RemoveCacheRequest) String() string {
 func (*RemoveCacheRequest) ProtoMessage() {}
 
 func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12058,7 +12378,7 @@ func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{144}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *RemoveCacheRequest) GetCacheId() string {
@@ -12088,7 +12408,7 @@ type RemoveCacheResponse struct {
 
 func (x *RemoveCacheResponse) Reset() {
 	*x = RemoveCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12100,7 +12420,7 @@ func (x *RemoveCacheResponse) String() string {
 func (*RemoveCacheResponse) ProtoMessage() {}
 
 func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12113,7 +12433,7 @@ func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheResponse.ProtoReflect.Descriptor instead.
 func (*RemoveCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{145}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *RemoveCacheResponse) GetDryRun() bool {
@@ -12175,7 +12495,7 @@ type CacheItem struct {
 
 func (x *CacheItem) Reset() {
 	*x = CacheItem{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12187,7 +12507,7 @@ func (x *CacheItem) String() string {
 func (*CacheItem) ProtoMessage() {}
 
 func (x *CacheItem) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12200,7 +12520,7 @@ func (x *CacheItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheItem.ProtoReflect.Descriptor instead.
 func (*CacheItem) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{146}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *CacheItem) GetCacheId() string {
@@ -12330,7 +12650,7 @@ type CacheReference struct {
 
 func (x *CacheReference) Reset() {
 	*x = CacheReference{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12342,7 +12662,7 @@ func (x *CacheReference) String() string {
 func (*CacheReference) ProtoMessage() {}
 
 func (x *CacheReference) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12355,7 +12675,7 @@ func (x *CacheReference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheReference.ProtoReflect.Descriptor instead.
 func (*CacheReference) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{147}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *CacheReference) GetType() string {
@@ -12418,7 +12738,7 @@ type ListVolumesRequest struct {
 
 func (x *ListVolumesRequest) Reset() {
 	*x = ListVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12430,7 +12750,7 @@ func (x *ListVolumesRequest) String() string {
 func (*ListVolumesRequest) ProtoMessage() {}
 
 func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12443,7 +12763,7 @@ func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesRequest.ProtoReflect.Descriptor instead.
 func (*ListVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{148}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *ListVolumesRequest) GetQuery() string {
@@ -12476,7 +12796,7 @@ type ListVolumesResponse struct {
 
 func (x *ListVolumesResponse) Reset() {
 	*x = ListVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12488,7 +12808,7 @@ func (x *ListVolumesResponse) String() string {
 func (*ListVolumesResponse) ProtoMessage() {}
 
 func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12501,7 +12821,7 @@ func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesResponse.ProtoReflect.Descriptor instead.
 func (*ListVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{149}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *ListVolumesResponse) GetVolumes() []*Volume {
@@ -12523,7 +12843,7 @@ type CreateVolumeRequest struct {
 
 func (x *CreateVolumeRequest) Reset() {
 	*x = CreateVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12535,7 +12855,7 @@ func (x *CreateVolumeRequest) String() string {
 func (*CreateVolumeRequest) ProtoMessage() {}
 
 func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12548,7 +12868,7 @@ func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeRequest.ProtoReflect.Descriptor instead.
 func (*CreateVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{150}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *CreateVolumeRequest) GetName() string {
@@ -12589,7 +12909,7 @@ type CreateVolumeResponse struct {
 
 func (x *CreateVolumeResponse) Reset() {
 	*x = CreateVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12601,7 +12921,7 @@ func (x *CreateVolumeResponse) String() string {
 func (*CreateVolumeResponse) ProtoMessage() {}
 
 func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12614,7 +12934,7 @@ func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeResponse.ProtoReflect.Descriptor instead.
 func (*CreateVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{151}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *CreateVolumeResponse) GetVolume() *Volume {
@@ -12640,7 +12960,7 @@ type InspectVolumeRequest struct {
 
 func (x *InspectVolumeRequest) Reset() {
 	*x = InspectVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12652,7 +12972,7 @@ func (x *InspectVolumeRequest) String() string {
 func (*InspectVolumeRequest) ProtoMessage() {}
 
 func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12665,7 +12985,7 @@ func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeRequest.ProtoReflect.Descriptor instead.
 func (*InspectVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{152}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *InspectVolumeRequest) GetName() string {
@@ -12684,7 +13004,7 @@ type InspectVolumeResponse struct {
 
 func (x *InspectVolumeResponse) Reset() {
 	*x = InspectVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12696,7 +13016,7 @@ func (x *InspectVolumeResponse) String() string {
 func (*InspectVolumeResponse) ProtoMessage() {}
 
 func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12709,7 +13029,7 @@ func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeResponse.ProtoReflect.Descriptor instead.
 func (*InspectVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{153}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *InspectVolumeResponse) GetVolume() *Volume {
@@ -12729,7 +13049,7 @@ type RemoveVolumeRequest struct {
 
 func (x *RemoveVolumeRequest) Reset() {
 	*x = RemoveVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12741,7 +13061,7 @@ func (x *RemoveVolumeRequest) String() string {
 func (*RemoveVolumeRequest) ProtoMessage() {}
 
 func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12754,7 +13074,7 @@ func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{154}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *RemoveVolumeRequest) GetName() string {
@@ -12781,7 +13101,7 @@ type RemoveVolumeResponse struct {
 
 func (x *RemoveVolumeResponse) Reset() {
 	*x = RemoveVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12793,7 +13113,7 @@ func (x *RemoveVolumeResponse) String() string {
 func (*RemoveVolumeResponse) ProtoMessage() {}
 
 func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12806,7 +13126,7 @@ func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeResponse.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{155}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *RemoveVolumeResponse) GetName() string {
@@ -12835,7 +13155,7 @@ type PruneVolumesRequest struct {
 
 func (x *PruneVolumesRequest) Reset() {
 	*x = PruneVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12847,7 +13167,7 @@ func (x *PruneVolumesRequest) String() string {
 func (*PruneVolumesRequest) ProtoMessage() {}
 
 func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12860,7 +13180,7 @@ func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesRequest.ProtoReflect.Descriptor instead.
 func (*PruneVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{156}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *PruneVolumesRequest) GetQuery() string {
@@ -12903,7 +13223,7 @@ type PruneVolumesResponse struct {
 
 func (x *PruneVolumesResponse) Reset() {
 	*x = PruneVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12915,7 +13235,7 @@ func (x *PruneVolumesResponse) String() string {
 func (*PruneVolumesResponse) ProtoMessage() {}
 
 func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12928,7 +13248,7 @@ func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesResponse.ProtoReflect.Descriptor instead.
 func (*PruneVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{157}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *PruneVolumesResponse) GetDryRun() bool {
@@ -12975,7 +13295,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12987,7 +13307,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13000,7 +13320,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{158}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *Volume) GetName() string {
@@ -13084,7 +13404,7 @@ type Image struct {
 
 func (x *Image) Reset() {
 	*x = Image{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13096,7 +13416,7 @@ func (x *Image) String() string {
 func (*Image) ProtoMessage() {}
 
 func (x *Image) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13109,7 +13429,7 @@ func (x *Image) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Image.ProtoReflect.Descriptor instead.
 func (*Image) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{159}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *Image) GetImageId() string {
@@ -13243,7 +13563,7 @@ type ImagePlatform struct {
 
 func (x *ImagePlatform) Reset() {
 	*x = ImagePlatform{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13255,7 +13575,7 @@ func (x *ImagePlatform) String() string {
 func (*ImagePlatform) ProtoMessage() {}
 
 func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13268,7 +13588,7 @@ func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePlatform.ProtoReflect.Descriptor instead.
 func (*ImagePlatform) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{160}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *ImagePlatform) GetOs() string {
@@ -13311,7 +13631,7 @@ type ImageStoreStatus struct {
 
 func (x *ImageStoreStatus) Reset() {
 	*x = ImageStoreStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13323,7 +13643,7 @@ func (x *ImageStoreStatus) String() string {
 func (*ImageStoreStatus) ProtoMessage() {}
 
 func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13336,7 +13656,7 @@ func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageStoreStatus.ProtoReflect.Descriptor instead.
 func (*ImageStoreStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{161}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *ImageStoreStatus) GetStore() ImageStoreKind {
@@ -13378,7 +13698,7 @@ type DockerImageStatus struct {
 
 func (x *DockerImageStatus) Reset() {
 	*x = DockerImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13390,7 +13710,7 @@ func (x *DockerImageStatus) String() string {
 func (*DockerImageStatus) ProtoMessage() {}
 
 func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13403,7 +13723,7 @@ func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerImageStatus.ProtoReflect.Descriptor instead.
 func (*DockerImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{162}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *DockerImageStatus) GetLocal() bool {
@@ -13441,7 +13761,7 @@ type OCIImageStatus struct {
 
 func (x *OCIImageStatus) Reset() {
 	*x = OCIImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13453,7 +13773,7 @@ func (x *OCIImageStatus) String() string {
 func (*OCIImageStatus) ProtoMessage() {}
 
 func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13466,7 +13786,7 @@ func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OCIImageStatus.ProtoReflect.Descriptor instead.
 func (*OCIImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{163}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *OCIImageStatus) GetLayoutCached() bool {
@@ -13524,7 +13844,7 @@ type ImagePullProgress struct {
 
 func (x *ImagePullProgress) Reset() {
 	*x = ImagePullProgress{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13536,7 +13856,7 @@ func (x *ImagePullProgress) String() string {
 func (*ImagePullProgress) ProtoMessage() {}
 
 func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13549,7 +13869,7 @@ func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePullProgress.ProtoReflect.Descriptor instead.
 func (*ImagePullProgress) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{164}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{168}
 }
 
 func (x *ImagePullProgress) GetId() string {
@@ -13597,7 +13917,7 @@ type JupyterSpec struct {
 
 func (x *JupyterSpec) Reset() {
 	*x = JupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13609,7 +13929,7 @@ func (x *JupyterSpec) String() string {
 func (*JupyterSpec) ProtoMessage() {}
 
 func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13622,7 +13942,7 @@ func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JupyterSpec.ProtoReflect.Descriptor instead.
 func (*JupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{165}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{169}
 }
 
 func (x *JupyterSpec) GetEnabled() bool {
@@ -13650,7 +13970,7 @@ type RunJupyterSpec struct {
 
 func (x *RunJupyterSpec) Reset() {
 	*x = RunJupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13662,7 +13982,7 @@ func (x *RunJupyterSpec) String() string {
 func (*RunJupyterSpec) ProtoMessage() {}
 
 func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13675,7 +13995,7 @@ func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunJupyterSpec.ProtoReflect.Descriptor instead.
 func (*RunJupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{166}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{170}
 }
 
 func (x *RunJupyterSpec) GetEnabled() bool {
@@ -13708,7 +14028,7 @@ type StartRunRequest struct {
 
 func (x *StartRunRequest) Reset() {
 	*x = StartRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13720,7 +14040,7 @@ func (x *StartRunRequest) String() string {
 func (*StartRunRequest) ProtoMessage() {}
 
 func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13733,7 +14053,7 @@ func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunRequest.ProtoReflect.Descriptor instead.
 func (*StartRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{167}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{171}
 }
 
 func (x *StartRunRequest) GetRun() *RunAgentRequest {
@@ -13754,7 +14074,7 @@ type StartRunResponse struct {
 
 func (x *StartRunResponse) Reset() {
 	*x = StartRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13766,7 +14086,7 @@ func (x *StartRunResponse) String() string {
 func (*StartRunResponse) ProtoMessage() {}
 
 func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13779,7 +14099,7 @@ func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunResponse.ProtoReflect.Descriptor instead.
 func (*StartRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{168}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{172}
 }
 
 func (x *StartRunResponse) GetRun() *RunSummary {
@@ -13820,7 +14140,7 @@ type SkillSpec struct {
 
 func (x *SkillSpec) Reset() {
 	*x = SkillSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13832,7 +14152,7 @@ func (x *SkillSpec) String() string {
 func (*SkillSpec) ProtoMessage() {}
 
 func (x *SkillSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13845,7 +14165,7 @@ func (x *SkillSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillSpec.ProtoReflect.Descriptor instead.
 func (*SkillSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{169}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{173}
 }
 
 func (x *SkillSpec) GetName() string {
@@ -13921,7 +14241,7 @@ type ResolveResourceIDRequest struct {
 
 func (x *ResolveResourceIDRequest) Reset() {
 	*x = ResolveResourceIDRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13933,7 +14253,7 @@ func (x *ResolveResourceIDRequest) String() string {
 func (*ResolveResourceIDRequest) ProtoMessage() {}
 
 func (x *ResolveResourceIDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13946,7 +14266,7 @@ func (x *ResolveResourceIDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveResourceIDRequest.ProtoReflect.Descriptor instead.
 func (*ResolveResourceIDRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{170}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{174}
 }
 
 func (x *ResolveResourceIDRequest) GetId() string {
@@ -13973,7 +14293,7 @@ type ResolveResourceIDResponse struct {
 
 func (x *ResolveResourceIDResponse) Reset() {
 	*x = ResolveResourceIDResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13985,7 +14305,7 @@ func (x *ResolveResourceIDResponse) String() string {
 func (*ResolveResourceIDResponse) ProtoMessage() {}
 
 func (x *ResolveResourceIDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13998,7 +14318,7 @@ func (x *ResolveResourceIDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveResourceIDResponse.ProtoReflect.Descriptor instead.
 func (*ResolveResourceIDResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{171}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{175}
 }
 
 func (x *ResolveResourceIDResponse) GetTargets() []*ResourceTarget {
@@ -14029,7 +14349,7 @@ type ResourceTarget struct {
 
 func (x *ResourceTarget) Reset() {
 	*x = ResourceTarget{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14041,7 +14361,7 @@ func (x *ResourceTarget) String() string {
 func (*ResourceTarget) ProtoMessage() {}
 
 func (x *ResourceTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14054,7 +14374,7 @@ func (x *ResourceTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceTarget.ProtoReflect.Descriptor instead.
 func (*ResourceTarget) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{172}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{176}
 }
 
 func (x *ResourceTarget) GetKind() ResourceKind {
@@ -14107,7 +14427,7 @@ type GetDashboardOverviewRequest struct {
 
 func (x *GetDashboardOverviewRequest) Reset() {
 	*x = GetDashboardOverviewRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14119,7 +14439,7 @@ func (x *GetDashboardOverviewRequest) String() string {
 func (*GetDashboardOverviewRequest) ProtoMessage() {}
 
 func (x *GetDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14132,7 +14452,7 @@ func (x *GetDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDashboardOverviewRequest.ProtoReflect.Descriptor instead.
 func (*GetDashboardOverviewRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{173}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{177}
 }
 
 type WatchDashboardOverviewRequest struct {
@@ -14143,7 +14463,7 @@ type WatchDashboardOverviewRequest struct {
 
 func (x *WatchDashboardOverviewRequest) Reset() {
 	*x = WatchDashboardOverviewRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14155,7 +14475,7 @@ func (x *WatchDashboardOverviewRequest) String() string {
 func (*WatchDashboardOverviewRequest) ProtoMessage() {}
 
 func (x *WatchDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14168,7 +14488,7 @@ func (x *WatchDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDashboardOverviewRequest.ProtoReflect.Descriptor instead.
 func (*WatchDashboardOverviewRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{174}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{178}
 }
 
 type RunOverview struct {
@@ -14182,7 +14502,7 @@ type RunOverview struct {
 
 func (x *RunOverview) Reset() {
 	*x = RunOverview{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14194,7 +14514,7 @@ func (x *RunOverview) String() string {
 func (*RunOverview) ProtoMessage() {}
 
 func (x *RunOverview) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14207,7 +14527,7 @@ func (x *RunOverview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunOverview.ProtoReflect.Descriptor instead.
 func (*RunOverview) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{175}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{179}
 }
 
 func (x *RunOverview) GetRunningCount() uint32 {
@@ -14241,7 +14561,7 @@ type DashboardOverview struct {
 
 func (x *DashboardOverview) Reset() {
 	*x = DashboardOverview{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14253,7 +14573,7 @@ func (x *DashboardOverview) String() string {
 func (*DashboardOverview) ProtoMessage() {}
 
 func (x *DashboardOverview) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14266,7 +14586,7 @@ func (x *DashboardOverview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DashboardOverview.ProtoReflect.Descriptor instead.
 func (*DashboardOverview) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{176}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{180}
 }
 
 func (x *DashboardOverview) GetRuns() *RunOverview {
@@ -14292,7 +14612,7 @@ type GetDashboardOverviewResponse struct {
 
 func (x *GetDashboardOverviewResponse) Reset() {
 	*x = GetDashboardOverviewResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14304,7 +14624,7 @@ func (x *GetDashboardOverviewResponse) String() string {
 func (*GetDashboardOverviewResponse) ProtoMessage() {}
 
 func (x *GetDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14317,7 +14637,7 @@ func (x *GetDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDashboardOverviewResponse.ProtoReflect.Descriptor instead.
 func (*GetDashboardOverviewResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{177}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{181}
 }
 
 func (x *GetDashboardOverviewResponse) GetOverview() *DashboardOverview {
@@ -14337,7 +14657,7 @@ type WatchDashboardOverviewResponse struct {
 
 func (x *WatchDashboardOverviewResponse) Reset() {
 	*x = WatchDashboardOverviewResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14349,7 +14669,7 @@ func (x *WatchDashboardOverviewResponse) String() string {
 func (*WatchDashboardOverviewResponse) ProtoMessage() {}
 
 func (x *WatchDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14362,7 +14682,7 @@ func (x *WatchDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDashboardOverviewResponse.ProtoReflect.Descriptor instead.
 func (*WatchDashboardOverviewResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{178}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{182}
 }
 
 func (x *WatchDashboardOverviewResponse) GetOverview() *DashboardOverview {
@@ -14387,7 +14707,7 @@ type GetGlobalEnvRequest struct {
 
 func (x *GetGlobalEnvRequest) Reset() {
 	*x = GetGlobalEnvRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14399,7 +14719,7 @@ func (x *GetGlobalEnvRequest) String() string {
 func (*GetGlobalEnvRequest) ProtoMessage() {}
 
 func (x *GetGlobalEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14412,7 +14732,7 @@ func (x *GetGlobalEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGlobalEnvRequest.ProtoReflect.Descriptor instead.
 func (*GetGlobalEnvRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{179}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{183}
 }
 
 type GetGlobalEnvResponse struct {
@@ -14424,7 +14744,7 @@ type GetGlobalEnvResponse struct {
 
 func (x *GetGlobalEnvResponse) Reset() {
 	*x = GetGlobalEnvResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14436,7 +14756,7 @@ func (x *GetGlobalEnvResponse) String() string {
 func (*GetGlobalEnvResponse) ProtoMessage() {}
 
 func (x *GetGlobalEnvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14449,7 +14769,7 @@ func (x *GetGlobalEnvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGlobalEnvResponse.ProtoReflect.Descriptor instead.
 func (*GetGlobalEnvResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{180}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{184}
 }
 
 func (x *GetGlobalEnvResponse) GetEnv() []*EnvVarSpec {
@@ -14468,7 +14788,7 @@ type UpdateGlobalEnvRequest struct {
 
 func (x *UpdateGlobalEnvRequest) Reset() {
 	*x = UpdateGlobalEnvRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14480,7 +14800,7 @@ func (x *UpdateGlobalEnvRequest) String() string {
 func (*UpdateGlobalEnvRequest) ProtoMessage() {}
 
 func (x *UpdateGlobalEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14493,7 +14813,7 @@ func (x *UpdateGlobalEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGlobalEnvRequest.ProtoReflect.Descriptor instead.
 func (*UpdateGlobalEnvRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{181}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{185}
 }
 
 func (x *UpdateGlobalEnvRequest) GetEnv() []*EnvVarUpdateSpec {
@@ -14512,7 +14832,7 @@ type UpdateGlobalEnvResponse struct {
 
 func (x *UpdateGlobalEnvResponse) Reset() {
 	*x = UpdateGlobalEnvResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14524,7 +14844,7 @@ func (x *UpdateGlobalEnvResponse) String() string {
 func (*UpdateGlobalEnvResponse) ProtoMessage() {}
 
 func (x *UpdateGlobalEnvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14537,7 +14857,7 @@ func (x *UpdateGlobalEnvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGlobalEnvResponse.ProtoReflect.Descriptor instead.
 func (*UpdateGlobalEnvResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{182}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{186}
 }
 
 func (x *UpdateGlobalEnvResponse) GetEnv() []*EnvVarSpec {
@@ -14555,7 +14875,7 @@ type GetCapabilityGatewayConfigRequest struct {
 
 func (x *GetCapabilityGatewayConfigRequest) Reset() {
 	*x = GetCapabilityGatewayConfigRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14567,7 +14887,7 @@ func (x *GetCapabilityGatewayConfigRequest) String() string {
 func (*GetCapabilityGatewayConfigRequest) ProtoMessage() {}
 
 func (x *GetCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14580,7 +14900,7 @@ func (x *GetCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetCapabilityGatewayConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityGatewayConfigRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{183}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{187}
 }
 
 type CapabilityGatewayConfig struct {
@@ -14593,7 +14913,7 @@ type CapabilityGatewayConfig struct {
 
 func (x *CapabilityGatewayConfig) Reset() {
 	*x = CapabilityGatewayConfig{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14605,7 +14925,7 @@ func (x *CapabilityGatewayConfig) String() string {
 func (*CapabilityGatewayConfig) ProtoMessage() {}
 
 func (x *CapabilityGatewayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14618,7 +14938,7 @@ func (x *CapabilityGatewayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityGatewayConfig.ProtoReflect.Descriptor instead.
 func (*CapabilityGatewayConfig) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{184}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{188}
 }
 
 func (x *CapabilityGatewayConfig) GetAddr() string {
@@ -14644,7 +14964,7 @@ type GetCapabilityGatewayConfigResponse struct {
 
 func (x *GetCapabilityGatewayConfigResponse) Reset() {
 	*x = GetCapabilityGatewayConfigResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14656,7 +14976,7 @@ func (x *GetCapabilityGatewayConfigResponse) String() string {
 func (*GetCapabilityGatewayConfigResponse) ProtoMessage() {}
 
 func (x *GetCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14669,7 +14989,7 @@ func (x *GetCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetCapabilityGatewayConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetCapabilityGatewayConfigResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{185}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{189}
 }
 
 func (x *GetCapabilityGatewayConfigResponse) GetConfig() *CapabilityGatewayConfig {
@@ -14689,7 +15009,7 @@ type UpdateCapabilityGatewayConfigRequest struct {
 
 func (x *UpdateCapabilityGatewayConfigRequest) Reset() {
 	*x = UpdateCapabilityGatewayConfigRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14701,7 +15021,7 @@ func (x *UpdateCapabilityGatewayConfigRequest) String() string {
 func (*UpdateCapabilityGatewayConfigRequest) ProtoMessage() {}
 
 func (x *UpdateCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14714,7 +15034,7 @@ func (x *UpdateCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateCapabilityGatewayConfigRequest.ProtoReflect.Descriptor instead.
 func (*UpdateCapabilityGatewayConfigRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{186}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{190}
 }
 
 func (x *UpdateCapabilityGatewayConfigRequest) GetAddr() string {
@@ -14740,7 +15060,7 @@ type UpdateCapabilityGatewayConfigResponse struct {
 
 func (x *UpdateCapabilityGatewayConfigResponse) Reset() {
 	*x = UpdateCapabilityGatewayConfigResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14752,7 +15072,7 @@ func (x *UpdateCapabilityGatewayConfigResponse) String() string {
 func (*UpdateCapabilityGatewayConfigResponse) ProtoMessage() {}
 
 func (x *UpdateCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14765,7 +15085,7 @@ func (x *UpdateCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use UpdateCapabilityGatewayConfigResponse.ProtoReflect.Descriptor instead.
 func (*UpdateCapabilityGatewayConfigResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{187}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{191}
 }
 
 func (x *UpdateCapabilityGatewayConfigResponse) GetConfig() *CapabilityGatewayConfig {
@@ -14790,7 +15110,7 @@ type WorkspacePreset struct {
 
 func (x *WorkspacePreset) Reset() {
 	*x = WorkspacePreset{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14802,7 +15122,7 @@ func (x *WorkspacePreset) String() string {
 func (*WorkspacePreset) ProtoMessage() {}
 
 func (x *WorkspacePreset) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14815,7 +15135,7 @@ func (x *WorkspacePreset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspacePreset.ProtoReflect.Descriptor instead.
 func (*WorkspacePreset) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{188}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{192}
 }
 
 func (x *WorkspacePreset) GetId() string {
@@ -14875,7 +15195,7 @@ type ListWorkspacePresetsRequest struct {
 
 func (x *ListWorkspacePresetsRequest) Reset() {
 	*x = ListWorkspacePresetsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14887,7 +15207,7 @@ func (x *ListWorkspacePresetsRequest) String() string {
 func (*ListWorkspacePresetsRequest) ProtoMessage() {}
 
 func (x *ListWorkspacePresetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14900,7 +15220,7 @@ func (x *ListWorkspacePresetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacePresetsRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspacePresetsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{189}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{193}
 }
 
 type ListWorkspacePresetsResponse struct {
@@ -14912,7 +15232,7 @@ type ListWorkspacePresetsResponse struct {
 
 func (x *ListWorkspacePresetsResponse) Reset() {
 	*x = ListWorkspacePresetsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14924,7 +15244,7 @@ func (x *ListWorkspacePresetsResponse) String() string {
 func (*ListWorkspacePresetsResponse) ProtoMessage() {}
 
 func (x *ListWorkspacePresetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14937,7 +15257,7 @@ func (x *ListWorkspacePresetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacePresetsResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspacePresetsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{190}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{194}
 }
 
 func (x *ListWorkspacePresetsResponse) GetPresets() []*WorkspacePreset {
@@ -14959,7 +15279,7 @@ type CreateWorkspacePresetRequest struct {
 
 func (x *CreateWorkspacePresetRequest) Reset() {
 	*x = CreateWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14971,7 +15291,7 @@ func (x *CreateWorkspacePresetRequest) String() string {
 func (*CreateWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *CreateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14984,7 +15304,7 @@ func (x *CreateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{191}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{195}
 }
 
 func (x *CreateWorkspacePresetRequest) GetName() string {
@@ -15028,7 +15348,7 @@ type UpdateWorkspacePresetRequest struct {
 
 func (x *UpdateWorkspacePresetRequest) Reset() {
 	*x = UpdateWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15040,7 +15360,7 @@ func (x *UpdateWorkspacePresetRequest) String() string {
 func (*UpdateWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *UpdateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15053,7 +15373,7 @@ func (x *UpdateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*UpdateWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{192}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{196}
 }
 
 func (x *UpdateWorkspacePresetRequest) GetPresetId() string {
@@ -15100,7 +15420,7 @@ type DeleteWorkspacePresetRequest struct {
 
 func (x *DeleteWorkspacePresetRequest) Reset() {
 	*x = DeleteWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15112,7 +15432,7 @@ func (x *DeleteWorkspacePresetRequest) String() string {
 func (*DeleteWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *DeleteWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15125,7 +15445,7 @@ func (x *DeleteWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{193}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{197}
 }
 
 func (x *DeleteWorkspacePresetRequest) GetPresetId() string {
@@ -15143,7 +15463,7 @@ type DeleteWorkspacePresetResponse struct {
 
 func (x *DeleteWorkspacePresetResponse) Reset() {
 	*x = DeleteWorkspacePresetResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15155,7 +15475,7 @@ func (x *DeleteWorkspacePresetResponse) String() string {
 func (*DeleteWorkspacePresetResponse) ProtoMessage() {}
 
 func (x *DeleteWorkspacePresetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15168,7 +15488,7 @@ func (x *DeleteWorkspacePresetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspacePresetResponse.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspacePresetResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{194}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{198}
 }
 
 type WorkspacePresetResponse struct {
@@ -15180,7 +15500,7 @@ type WorkspacePresetResponse struct {
 
 func (x *WorkspacePresetResponse) Reset() {
 	*x = WorkspacePresetResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15192,7 +15512,7 @@ func (x *WorkspacePresetResponse) String() string {
 func (*WorkspacePresetResponse) ProtoMessage() {}
 
 func (x *WorkspacePresetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15205,7 +15525,7 @@ func (x *WorkspacePresetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspacePresetResponse.ProtoReflect.Descriptor instead.
 func (*WorkspacePresetResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{195}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{199}
 }
 
 func (x *WorkspacePresetResponse) GetPreset() *WorkspacePreset {
@@ -15223,7 +15543,7 @@ type GetCapabilityStatusRequest struct {
 
 func (x *GetCapabilityStatusRequest) Reset() {
 	*x = GetCapabilityStatusRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15235,7 +15555,7 @@ func (x *GetCapabilityStatusRequest) String() string {
 func (*GetCapabilityStatusRequest) ProtoMessage() {}
 
 func (x *GetCapabilityStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15248,7 +15568,7 @@ func (x *GetCapabilityStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityStatusRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{196}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{200}
 }
 
 type CapabilityStatusResponse struct {
@@ -15267,7 +15587,7 @@ type CapabilityStatusResponse struct {
 
 func (x *CapabilityStatusResponse) Reset() {
 	*x = CapabilityStatusResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15279,7 +15599,7 @@ func (x *CapabilityStatusResponse) String() string {
 func (*CapabilityStatusResponse) ProtoMessage() {}
 
 func (x *CapabilityStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15292,7 +15612,7 @@ func (x *CapabilityStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityStatusResponse.ProtoReflect.Descriptor instead.
 func (*CapabilityStatusResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{197}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{201}
 }
 
 func (x *CapabilityStatusResponse) GetConfigured() bool {
@@ -15359,7 +15679,7 @@ type ListCapabilitySetsRequest struct {
 
 func (x *ListCapabilitySetsRequest) Reset() {
 	*x = ListCapabilitySetsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15371,7 +15691,7 @@ func (x *ListCapabilitySetsRequest) String() string {
 func (*ListCapabilitySetsRequest) ProtoMessage() {}
 
 func (x *ListCapabilitySetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15384,7 +15704,7 @@ func (x *ListCapabilitySetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCapabilitySetsRequest.ProtoReflect.Descriptor instead.
 func (*ListCapabilitySetsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{198}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{202}
 }
 
 type CapabilitySet struct {
@@ -15399,7 +15719,7 @@ type CapabilitySet struct {
 
 func (x *CapabilitySet) Reset() {
 	*x = CapabilitySet{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15411,7 +15731,7 @@ func (x *CapabilitySet) String() string {
 func (*CapabilitySet) ProtoMessage() {}
 
 func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15424,7 +15744,7 @@ func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilitySet.ProtoReflect.Descriptor instead.
 func (*CapabilitySet) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{199}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{203}
 }
 
 func (x *CapabilitySet) GetId() string {
@@ -15464,7 +15784,7 @@ type ListCapabilitySetsResponse struct {
 
 func (x *ListCapabilitySetsResponse) Reset() {
 	*x = ListCapabilitySetsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15476,7 +15796,7 @@ func (x *ListCapabilitySetsResponse) String() string {
 func (*ListCapabilitySetsResponse) ProtoMessage() {}
 
 func (x *ListCapabilitySetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15489,7 +15809,7 @@ func (x *ListCapabilitySetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCapabilitySetsResponse.ProtoReflect.Descriptor instead.
 func (*ListCapabilitySetsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{200}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{204}
 }
 
 func (x *ListCapabilitySetsResponse) GetCapsets() []*CapabilitySet {
@@ -15508,7 +15828,7 @@ type GetCapabilityCatalogRequest struct {
 
 func (x *GetCapabilityCatalogRequest) Reset() {
 	*x = GetCapabilityCatalogRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15520,7 +15840,7 @@ func (x *GetCapabilityCatalogRequest) String() string {
 func (*GetCapabilityCatalogRequest) ProtoMessage() {}
 
 func (x *GetCapabilityCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15533,7 +15853,7 @@ func (x *GetCapabilityCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityCatalogRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{201}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{205}
 }
 
 func (x *GetCapabilityCatalogRequest) GetCapsetId() string {
@@ -15559,7 +15879,7 @@ type CapabilityEndpoint struct {
 
 func (x *CapabilityEndpoint) Reset() {
 	*x = CapabilityEndpoint{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15571,7 +15891,7 @@ func (x *CapabilityEndpoint) String() string {
 func (*CapabilityEndpoint) ProtoMessage() {}
 
 func (x *CapabilityEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15584,7 +15904,7 @@ func (x *CapabilityEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityEndpoint.ProtoReflect.Descriptor instead.
 func (*CapabilityEndpoint) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{202}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{206}
 }
 
 func (x *CapabilityEndpoint) GetProtocol() string {
@@ -15659,7 +15979,7 @@ type CapabilityMethod struct {
 
 func (x *CapabilityMethod) Reset() {
 	*x = CapabilityMethod{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15671,7 +15991,7 @@ func (x *CapabilityMethod) String() string {
 func (*CapabilityMethod) ProtoMessage() {}
 
 func (x *CapabilityMethod) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15684,7 +16004,7 @@ func (x *CapabilityMethod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityMethod.ProtoReflect.Descriptor instead.
 func (*CapabilityMethod) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{203}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{207}
 }
 
 func (x *CapabilityMethod) GetServiceId() string {
@@ -15755,7 +16075,7 @@ type GetCapabilityCatalogResponse struct {
 
 func (x *GetCapabilityCatalogResponse) Reset() {
 	*x = GetCapabilityCatalogResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15767,7 +16087,7 @@ func (x *GetCapabilityCatalogResponse) String() string {
 func (*GetCapabilityCatalogResponse) ProtoMessage() {}
 
 func (x *GetCapabilityCatalogResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15780,7 +16100,7 @@ func (x *GetCapabilityCatalogResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityCatalogResponse.ProtoReflect.Descriptor instead.
 func (*GetCapabilityCatalogResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{204}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{208}
 }
 
 func (x *GetCapabilityCatalogResponse) GetCapsetId() string {
@@ -15820,7 +16140,7 @@ type ListSandboxHistoryRequest struct {
 
 func (x *ListSandboxHistoryRequest) Reset() {
 	*x = ListSandboxHistoryRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15832,7 +16152,7 @@ func (x *ListSandboxHistoryRequest) String() string {
 func (*ListSandboxHistoryRequest) ProtoMessage() {}
 
 func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15845,7 +16165,7 @@ func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{205}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{209}
 }
 
 func (x *ListSandboxHistoryRequest) GetSandboxId() string {
@@ -15876,7 +16196,7 @@ type SandboxHistoryCell struct {
 
 func (x *SandboxHistoryCell) Reset() {
 	*x = SandboxHistoryCell{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15888,7 +16208,7 @@ func (x *SandboxHistoryCell) String() string {
 func (*SandboxHistoryCell) ProtoMessage() {}
 
 func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15901,7 +16221,7 @@ func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryCell.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryCell) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{206}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{210}
 }
 
 func (x *SandboxHistoryCell) GetId() string {
@@ -16008,7 +16328,7 @@ type SandboxHistoryEvent struct {
 
 func (x *SandboxHistoryEvent) Reset() {
 	*x = SandboxHistoryEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16020,7 +16340,7 @@ func (x *SandboxHistoryEvent) String() string {
 func (*SandboxHistoryEvent) ProtoMessage() {}
 
 func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16033,7 +16353,7 @@ func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryEvent.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{207}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{211}
 }
 
 func (x *SandboxHistoryEvent) GetId() string {
@@ -16082,7 +16402,7 @@ type ListSandboxHistoryResponse struct {
 
 func (x *ListSandboxHistoryResponse) Reset() {
 	*x = ListSandboxHistoryResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16094,7 +16414,7 @@ func (x *ListSandboxHistoryResponse) String() string {
 func (*ListSandboxHistoryResponse) ProtoMessage() {}
 
 func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16107,7 +16427,7 @@ func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{208}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{212}
 }
 
 func (x *ListSandboxHistoryResponse) GetCells() []*SandboxHistoryCell {
@@ -16140,7 +16460,7 @@ type WatchSandboxRequest struct {
 
 func (x *WatchSandboxRequest) Reset() {
 	*x = WatchSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16152,7 +16472,7 @@ func (x *WatchSandboxRequest) String() string {
 func (*WatchSandboxRequest) ProtoMessage() {}
 
 func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16165,7 +16485,7 @@ func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxRequest.ProtoReflect.Descriptor instead.
 func (*WatchSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{209}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{213}
 }
 
 func (x *WatchSandboxRequest) GetSandboxId() string {
@@ -16190,7 +16510,7 @@ type WatchSandboxResponse struct {
 
 func (x *WatchSandboxResponse) Reset() {
 	*x = WatchSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[214]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16202,7 +16522,7 @@ func (x *WatchSandboxResponse) String() string {
 func (*WatchSandboxResponse) ProtoMessage() {}
 
 func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[214]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16215,7 +16535,7 @@ func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxResponse.ProtoReflect.Descriptor instead.
 func (*WatchSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{210}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{214}
 }
 
 func (x *WatchSandboxResponse) GetEventType() SandboxWatchEventType {
@@ -16278,7 +16598,7 @@ type GenerateLLMRequest struct {
 
 func (x *GenerateLLMRequest) Reset() {
 	*x = GenerateLLMRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[215]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16290,7 +16610,7 @@ func (x *GenerateLLMRequest) String() string {
 func (*GenerateLLMRequest) ProtoMessage() {}
 
 func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[215]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16303,7 +16623,7 @@ func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMRequest.ProtoReflect.Descriptor instead.
 func (*GenerateLLMRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{211}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{215}
 }
 
 func (x *GenerateLLMRequest) GetPrompt() string {
@@ -16340,7 +16660,7 @@ type GenerateLLMResponse struct {
 
 func (x *GenerateLLMResponse) Reset() {
 	*x = GenerateLLMResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[216]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16352,7 +16672,7 @@ func (x *GenerateLLMResponse) String() string {
 func (*GenerateLLMResponse) ProtoMessage() {}
 
 func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[216]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16365,7 +16685,7 @@ func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMResponse.ProtoReflect.Descriptor instead.
 func (*GenerateLLMResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{212}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{216}
 }
 
 func (x *GenerateLLMResponse) GetText() string {
@@ -16597,7 +16917,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x14\n" +
 	"\x05limit\x18\x03 \x01(\rR\x05limit\x12\x16\n" +
-	"\x06cursor\x18\x04 \x01(\tR\x06cursor\"\xf8\x01\n" +
+	"\x06cursor\x18\x04 \x01(\tR\x06cursor\"\xc1\x03\n" +
 	"\x0eSchedulerEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x14\n" +
@@ -16608,11 +16928,42 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"trigger_id\x18\a \x01(\tR\ttriggerId\x129\n" +
 	"\n" +
-	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"w\n" +
+	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\t \x01(\tR\tagentName\x12!\n" +
+	"\fscheduler_id\x18\n" +
+	" \x01(\tR\vschedulerId\x12*\n" +
+	"\x11linked_sandbox_id\x18\v \x01(\tR\x0flinkedSandboxId\x12$\n" +
+	"\x0elinked_cell_id\x18\f \x01(\tR\flinkedCellId\x123\n" +
+	"\x16linked_agent_thread_id\x18\r \x01(\tR\x13linkedAgentThreadId\"w\n" +
 	"\x1bListSchedulerEventsResponse\x127\n" +
 	"\x06events\x18\x01 \x03(\v2\x1f.agentcompose.v2.SchedulerEventR\x06events\x12\x1f\n" +
 	"\vnext_cursor\x18\x02 \x01(\tR\n" +
-	"nextCursor\"\xad\x01\n" +
+	"nextCursor\"\xdd\x01\n" +
+	"!ListProjectSchedulerEventsRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x03 \x01(\tR\ttriggerId\x12\x15\n" +
+	"\x06run_id\x18\x04 \x01(\tR\x05runId\x12\x14\n" +
+	"\x05limit\x18\x05 \x01(\rR\x05limit\x12\x16\n" +
+	"\x06cursor\x18\x06 \x01(\tR\x06cursor\"~\n" +
+	"\"ListProjectSchedulerEventsResponse\x127\n" +
+	"\x06events\x18\x01 \x03(\v2\x1f.agentcompose.v2.SchedulerEventR\x06events\x12\x1f\n" +
+	"\vnext_cursor\x18\x02 \x01(\tR\n" +
+	"nextCursor\"\x91\x01\n" +
+	"\x16InvokeSchedulerRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12!\n" +
+	"\fpayload_json\x18\x03 \x01(\tR\vpayloadJson\"w\n" +
+	"\x17InvokeSchedulerResponse\x12\x1f\n" +
+	"\vresult_json\x18\x01 \x01(\tR\n" +
+	"resultJson\x12\x1f\n" +
+	"\vduration_ms\x18\x02 \x01(\x03R\n" +
+	"durationMs\x12\x1a\n" +
+	"\bwarnings\x18\x03 \x03(\tR\bwarnings\"\xad\x01\n" +
 	"\x13RunSchedulerRequest\x125\n" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
 	"\n" +
@@ -16635,13 +16986,16 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x15\n" +
 	"\x06run_id\x18\x02 \x01(\tR\x05runId\"J\n" +
 	"\x17GetSchedulerRunResponse\x12/\n" +
-	"\x03run\x18\x01 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\"\x9e\x01\n" +
+	"\x03run\x18\x01 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\"\xfa\x01\n" +
 	"\x18ListSchedulerRunsRequest\x125\n" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
 	"\n" +
 	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x14\n" +
 	"\x05limit\x18\x03 \x01(\rR\x05limit\x12\x16\n" +
-	"\x06cursor\x18\x04 \x01(\tR\x06cursor\"o\n" +
+	"\x06cursor\x18\x04 \x01(\tR\x06cursor\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x05 \x01(\tR\ttriggerId\x12;\n" +
+	"\x06status\x18\x06 \x01(\x0e2#.agentcompose.v2.SchedulerRunStatusR\x06status\"o\n" +
 	"\x19ListSchedulerRunsResponse\x121\n" +
 	"\x04runs\x18\x01 \x03(\v2\x1d.agentcompose.v2.SchedulerRunR\x04runs\x12\x1f\n" +
 	"\vnext_cursor\x18\x02 \x01(\tR\n" +
@@ -16652,7 +17006,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x06reason\x18\x03 \x01(\tR\x06reason\"r\n" +
 	"\x18StopSchedulerRunResponse\x12/\n" +
 	"\x03run\x18\x01 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\x12%\n" +
-	"\x0estop_requested\x18\x02 \x01(\bR\rstopRequested\"\xf8\x04\n" +
+	"\x0estop_requested\x18\x02 \x01(\bR\rstopRequested\"\x99\x05\n" +
 	"\fSchedulerRun\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x1d\n" +
 	"\n" +
@@ -16676,7 +17030,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"resultJson\x12!\n" +
 	"\fpayload_json\x18\x0e \x01(\tR\vpayloadJson\x120\n" +
 	"\x14source_script_sha256\x18\x0f \x01(\tR\x12sourceScriptSha256\x12#\n" +
-	"\rartifacts_dir\x18\x10 \x01(\tR\fartifactsDir\"\x8c\x01\n" +
+	"\rartifacts_dir\x18\x10 \x01(\tR\fartifactsDir\x12\x1f\n" +
+	"\vsandbox_ids\x18\x11 \x03(\tR\n" +
+	"sandboxIds\"\x8c\x01\n" +
 	"\x1aSetSchedulerEnabledRequest\x125\n" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
 	"\n" +
@@ -17904,7 +18260,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"%SANDBOX_WATCH_EVENT_TYPE_CELL_STARTED\x10\x02\x12(\n" +
 	"$SANDBOX_WATCH_EVENT_TYPE_CELL_OUTPUT\x10\x03\x12+\n" +
 	"'SANDBOX_WATCH_EVENT_TYPE_CELL_COMPLETED\x10\x04\x12(\n" +
-	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xf6\f\n" +
+	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xe4\x0e\n" +
 	"\x0eProjectService\x12d\n" +
 	"\x0fValidateProject\x12'.agentcompose.v2.ValidateProjectRequest\x1a(.agentcompose.v2.ValidateProjectResponse\x12[\n" +
 	"\fApplyProject\x12$.agentcompose.v2.ApplyProjectRequest\x1a%.agentcompose.v2.ApplyProjectResponse\x12U\n" +
@@ -17915,7 +18271,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\fWatchProject\x12$.agentcompose.v2.WatchProjectRequest\x1a%.agentcompose.v2.WatchProjectResponse0\x01\x12[\n" +
 	"\fGetScheduler\x12$.agentcompose.v2.GetSchedulerRequest\x1a%.agentcompose.v2.GetSchedulerResponse\x12a\n" +
 	"\x0eListSchedulers\x12&.agentcompose.v2.ListSchedulersRequest\x1a'.agentcompose.v2.ListSchedulersResponse\x12p\n" +
-	"\x13ListSchedulerEvents\x12+.agentcompose.v2.ListSchedulerEventsRequest\x1a,.agentcompose.v2.ListSchedulerEventsResponse\x12[\n" +
+	"\x13ListSchedulerEvents\x12+.agentcompose.v2.ListSchedulerEventsRequest\x1a,.agentcompose.v2.ListSchedulerEventsResponse\x12\x85\x01\n" +
+	"\x1aListProjectSchedulerEvents\x122.agentcompose.v2.ListProjectSchedulerEventsRequest\x1a3.agentcompose.v2.ListProjectSchedulerEventsResponse\x12d\n" +
+	"\x0fInvokeScheduler\x12'.agentcompose.v2.InvokeSchedulerRequest\x1a(.agentcompose.v2.InvokeSchedulerResponse\x12[\n" +
 	"\fRunScheduler\x12$.agentcompose.v2.RunSchedulerRequest\x1a%.agentcompose.v2.RunSchedulerResponse\x12j\n" +
 	"\x11StartSchedulerRun\x12).agentcompose.v2.StartSchedulerRunRequest\x1a*.agentcompose.v2.StartSchedulerRunResponse\x12d\n" +
 	"\x0fGetSchedulerRun\x12'.agentcompose.v2.GetSchedulerRunRequest\x1a(.agentcompose.v2.GetSchedulerRunResponse\x12j\n" +
@@ -18007,7 +18365,7 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 }
 
 var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 24)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 225)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 229)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),                // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),                      // 1: agentcompose.v2.ProjectChangeAction
@@ -18063,607 +18421,619 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*ListSchedulerEventsRequest)(nil),            // 51: agentcompose.v2.ListSchedulerEventsRequest
 	(*SchedulerEvent)(nil),                        // 52: agentcompose.v2.SchedulerEvent
 	(*ListSchedulerEventsResponse)(nil),           // 53: agentcompose.v2.ListSchedulerEventsResponse
-	(*RunSchedulerRequest)(nil),                   // 54: agentcompose.v2.RunSchedulerRequest
-	(*RunSchedulerResponse)(nil),                  // 55: agentcompose.v2.RunSchedulerResponse
-	(*StartSchedulerRunRequest)(nil),              // 56: agentcompose.v2.StartSchedulerRunRequest
-	(*StartSchedulerRunResponse)(nil),             // 57: agentcompose.v2.StartSchedulerRunResponse
-	(*GetSchedulerRunRequest)(nil),                // 58: agentcompose.v2.GetSchedulerRunRequest
-	(*GetSchedulerRunResponse)(nil),               // 59: agentcompose.v2.GetSchedulerRunResponse
-	(*ListSchedulerRunsRequest)(nil),              // 60: agentcompose.v2.ListSchedulerRunsRequest
-	(*ListSchedulerRunsResponse)(nil),             // 61: agentcompose.v2.ListSchedulerRunsResponse
-	(*StopSchedulerRunRequest)(nil),               // 62: agentcompose.v2.StopSchedulerRunRequest
-	(*StopSchedulerRunResponse)(nil),              // 63: agentcompose.v2.StopSchedulerRunResponse
-	(*SchedulerRun)(nil),                          // 64: agentcompose.v2.SchedulerRun
-	(*SetSchedulerEnabledRequest)(nil),            // 65: agentcompose.v2.SetSchedulerEnabledRequest
-	(*SetSchedulerEnabledResponse)(nil),           // 66: agentcompose.v2.SetSchedulerEnabledResponse
-	(*SetSchedulerTriggerEnabledRequest)(nil),     // 67: agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	(*SetSchedulerTriggerEnabledResponse)(nil),    // 68: agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	(*ProjectValidationIssue)(nil),                // 69: agentcompose.v2.ProjectValidationIssue
-	(*ProjectChange)(nil),                         // 70: agentcompose.v2.ProjectChange
-	(*ProjectSpec)(nil),                           // 71: agentcompose.v2.ProjectSpec
-	(*NamedWorkspaceSpec)(nil),                    // 72: agentcompose.v2.NamedWorkspaceSpec
-	(*AgentSpec)(nil),                             // 73: agentcompose.v2.AgentSpec
-	(*MCPServerSpec)(nil),                         // 74: agentcompose.v2.MCPServerSpec
-	(*ProjectVolumeSpec)(nil),                     // 75: agentcompose.v2.ProjectVolumeSpec
-	(*VolumeMountSpec)(nil),                       // 76: agentcompose.v2.VolumeMountSpec
-	(*BuildSpec)(nil),                             // 77: agentcompose.v2.BuildSpec
-	(*EnvVarSpec)(nil),                            // 78: agentcompose.v2.EnvVarSpec
-	(*EnvVarUpdateSpec)(nil),                      // 79: agentcompose.v2.EnvVarUpdateSpec
-	(*WorkspaceSpec)(nil),                         // 80: agentcompose.v2.WorkspaceSpec
-	(*SchedulerSpec)(nil),                         // 81: agentcompose.v2.SchedulerSpec
-	(*TriggerSpec)(nil),                           // 82: agentcompose.v2.TriggerSpec
-	(*EventTriggerSpec)(nil),                      // 83: agentcompose.v2.EventTriggerSpec
-	(*DriverSpec)(nil),                            // 84: agentcompose.v2.DriverSpec
-	(*BoxliteDriverSpec)(nil),                     // 85: agentcompose.v2.BoxliteDriverSpec
-	(*DockerDriverSpec)(nil),                      // 86: agentcompose.v2.DockerDriverSpec
-	(*MicrosandboxDriverSpec)(nil),                // 87: agentcompose.v2.MicrosandboxDriverSpec
-	(*RunAgentRequest)(nil),                       // 88: agentcompose.v2.RunAgentRequest
-	(*RunAgentResponse)(nil),                      // 89: agentcompose.v2.RunAgentResponse
-	(*RunAgentStreamResponse)(nil),                // 90: agentcompose.v2.RunAgentStreamResponse
-	(*RunAttachRequest)(nil),                      // 91: agentcompose.v2.RunAttachRequest
-	(*RunAttachResponse)(nil),                     // 92: agentcompose.v2.RunAttachResponse
-	(*RunAttachStart)(nil),                        // 93: agentcompose.v2.RunAttachStart
-	(*TranscriptEvent)(nil),                       // 94: agentcompose.v2.TranscriptEvent
-	(*GetRunRequest)(nil),                         // 95: agentcompose.v2.GetRunRequest
-	(*GetRunResponse)(nil),                        // 96: agentcompose.v2.GetRunResponse
-	(*ListRunsRequest)(nil),                       // 97: agentcompose.v2.ListRunsRequest
-	(*ListRunsResponse)(nil),                      // 98: agentcompose.v2.ListRunsResponse
-	(*FollowRunLogsRequest)(nil),                  // 99: agentcompose.v2.FollowRunLogsRequest
-	(*RunLogChunk)(nil),                           // 100: agentcompose.v2.RunLogChunk
-	(*StopRunRequest)(nil),                        // 101: agentcompose.v2.StopRunRequest
-	(*StopRunResponse)(nil),                       // 102: agentcompose.v2.StopRunResponse
-	(*ListRunEventsRequest)(nil),                  // 103: agentcompose.v2.ListRunEventsRequest
-	(*RunEvent)(nil),                              // 104: agentcompose.v2.RunEvent
-	(*ListRunEventsResponse)(nil),                 // 105: agentcompose.v2.ListRunEventsResponse
-	(*ListSandboxRunEventsRequest)(nil),           // 106: agentcompose.v2.ListSandboxRunEventsRequest
-	(*ListSandboxRunEventsResponse)(nil),          // 107: agentcompose.v2.ListSandboxRunEventsResponse
-	(*RemoveSandboxRequest)(nil),                  // 108: agentcompose.v2.RemoveSandboxRequest
-	(*RemoveSandboxResponse)(nil),                 // 109: agentcompose.v2.RemoveSandboxResponse
-	(*PruneSandboxesRequest)(nil),                 // 110: agentcompose.v2.PruneSandboxesRequest
-	(*SandboxPruneCandidate)(nil),                 // 111: agentcompose.v2.SandboxPruneCandidate
-	(*PruneSandboxesResponse)(nil),                // 112: agentcompose.v2.PruneSandboxesResponse
-	(*GetSandboxStatsRequest)(nil),                // 113: agentcompose.v2.GetSandboxStatsRequest
-	(*GetSandboxStatsResponse)(nil),               // 114: agentcompose.v2.GetSandboxStatsResponse
-	(*GetSandboxRequest)(nil),                     // 115: agentcompose.v2.GetSandboxRequest
-	(*Sandbox)(nil),                               // 116: agentcompose.v2.Sandbox
-	(*SandboxTag)(nil),                            // 117: agentcompose.v2.SandboxTag
-	(*ListSandboxesRequest)(nil),                  // 118: agentcompose.v2.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),                 // 119: agentcompose.v2.ListSandboxesResponse
-	(*GetSandboxResponse)(nil),                    // 120: agentcompose.v2.GetSandboxResponse
-	(*StopSandboxRequest)(nil),                    // 121: agentcompose.v2.StopSandboxRequest
-	(*StopSandboxResponse)(nil),                   // 122: agentcompose.v2.StopSandboxResponse
-	(*ResumeSandboxRequest)(nil),                  // 123: agentcompose.v2.ResumeSandboxRequest
-	(*ResumeSandboxResponse)(nil),                 // 124: agentcompose.v2.ResumeSandboxResponse
-	(*MetricValue)(nil),                           // 125: agentcompose.v2.MetricValue
-	(*SandboxStats)(nil),                          // 126: agentcompose.v2.SandboxStats
-	(*RunSummary)(nil),                            // 127: agentcompose.v2.RunSummary
-	(*RunDetail)(nil),                             // 128: agentcompose.v2.RunDetail
-	(*ExecRequest)(nil),                           // 129: agentcompose.v2.ExecRequest
-	(*ExecSandboxSelector)(nil),                   // 130: agentcompose.v2.ExecSandboxSelector
-	(*ExecCommand)(nil),                           // 131: agentcompose.v2.ExecCommand
-	(*ExecResponse)(nil),                          // 132: agentcompose.v2.ExecResponse
-	(*ExecStreamResponse)(nil),                    // 133: agentcompose.v2.ExecStreamResponse
-	(*ExecAttachRequest)(nil),                     // 134: agentcompose.v2.ExecAttachRequest
-	(*ExecAttachResponse)(nil),                    // 135: agentcompose.v2.ExecAttachResponse
-	(*ExecAttachStart)(nil),                       // 136: agentcompose.v2.ExecAttachStart
-	(*AttachTerminalSize)(nil),                    // 137: agentcompose.v2.AttachTerminalSize
-	(*AttachStdin)(nil),                           // 138: agentcompose.v2.AttachStdin
-	(*AttachStdinEOF)(nil),                        // 139: agentcompose.v2.AttachStdinEOF
-	(*AttachResize)(nil),                          // 140: agentcompose.v2.AttachResize
-	(*AttachSignal)(nil),                          // 141: agentcompose.v2.AttachSignal
-	(*AttachHumanMessage)(nil),                    // 142: agentcompose.v2.AttachHumanMessage
-	(*AttachCancel)(nil),                          // 143: agentcompose.v2.AttachCancel
-	(*AttachStarted)(nil),                         // 144: agentcompose.v2.AttachStarted
-	(*AttachOutput)(nil),                          // 145: agentcompose.v2.AttachOutput
-	(*AttachAgentEvent)(nil),                      // 146: agentcompose.v2.AttachAgentEvent
-	(*AttachAgentTurnCompleted)(nil),              // 147: agentcompose.v2.AttachAgentTurnCompleted
-	(*AttachResult)(nil),                          // 148: agentcompose.v2.AttachResult
-	(*AttachError)(nil),                           // 149: agentcompose.v2.AttachError
-	(*ExecResult)(nil),                            // 150: agentcompose.v2.ExecResult
-	(*ListImagesRequest)(nil),                     // 151: agentcompose.v2.ListImagesRequest
-	(*ListImagesResponse)(nil),                    // 152: agentcompose.v2.ListImagesResponse
-	(*PullImageRequest)(nil),                      // 153: agentcompose.v2.PullImageRequest
-	(*PullImageResponse)(nil),                     // 154: agentcompose.v2.PullImageResponse
-	(*InspectImageRequest)(nil),                   // 155: agentcompose.v2.InspectImageRequest
-	(*InspectImageResponse)(nil),                  // 156: agentcompose.v2.InspectImageResponse
-	(*RemoveImageRequest)(nil),                    // 157: agentcompose.v2.RemoveImageRequest
-	(*RemoveImageResponse)(nil),                   // 158: agentcompose.v2.RemoveImageResponse
-	(*BuildImageRequest)(nil),                     // 159: agentcompose.v2.BuildImageRequest
-	(*BuildImageEvent)(nil),                       // 160: agentcompose.v2.BuildImageEvent
-	(*CacheFilter)(nil),                           // 161: agentcompose.v2.CacheFilter
-	(*ListCachesRequest)(nil),                     // 162: agentcompose.v2.ListCachesRequest
-	(*ListCachesResponse)(nil),                    // 163: agentcompose.v2.ListCachesResponse
-	(*InspectCacheRequest)(nil),                   // 164: agentcompose.v2.InspectCacheRequest
-	(*InspectCacheResponse)(nil),                  // 165: agentcompose.v2.InspectCacheResponse
-	(*PruneCachesRequest)(nil),                    // 166: agentcompose.v2.PruneCachesRequest
-	(*PruneCachesResponse)(nil),                   // 167: agentcompose.v2.PruneCachesResponse
-	(*RemoveCacheRequest)(nil),                    // 168: agentcompose.v2.RemoveCacheRequest
-	(*RemoveCacheResponse)(nil),                   // 169: agentcompose.v2.RemoveCacheResponse
-	(*CacheItem)(nil),                             // 170: agentcompose.v2.CacheItem
-	(*CacheReference)(nil),                        // 171: agentcompose.v2.CacheReference
-	(*ListVolumesRequest)(nil),                    // 172: agentcompose.v2.ListVolumesRequest
-	(*ListVolumesResponse)(nil),                   // 173: agentcompose.v2.ListVolumesResponse
-	(*CreateVolumeRequest)(nil),                   // 174: agentcompose.v2.CreateVolumeRequest
-	(*CreateVolumeResponse)(nil),                  // 175: agentcompose.v2.CreateVolumeResponse
-	(*InspectVolumeRequest)(nil),                  // 176: agentcompose.v2.InspectVolumeRequest
-	(*InspectVolumeResponse)(nil),                 // 177: agentcompose.v2.InspectVolumeResponse
-	(*RemoveVolumeRequest)(nil),                   // 178: agentcompose.v2.RemoveVolumeRequest
-	(*RemoveVolumeResponse)(nil),                  // 179: agentcompose.v2.RemoveVolumeResponse
-	(*PruneVolumesRequest)(nil),                   // 180: agentcompose.v2.PruneVolumesRequest
-	(*PruneVolumesResponse)(nil),                  // 181: agentcompose.v2.PruneVolumesResponse
-	(*Volume)(nil),                                // 182: agentcompose.v2.Volume
-	(*Image)(nil),                                 // 183: agentcompose.v2.Image
-	(*ImagePlatform)(nil),                         // 184: agentcompose.v2.ImagePlatform
-	(*ImageStoreStatus)(nil),                      // 185: agentcompose.v2.ImageStoreStatus
-	(*DockerImageStatus)(nil),                     // 186: agentcompose.v2.DockerImageStatus
-	(*OCIImageStatus)(nil),                        // 187: agentcompose.v2.OCIImageStatus
-	(*ImagePullProgress)(nil),                     // 188: agentcompose.v2.ImagePullProgress
-	(*JupyterSpec)(nil),                           // 189: agentcompose.v2.JupyterSpec
-	(*RunJupyterSpec)(nil),                        // 190: agentcompose.v2.RunJupyterSpec
-	(*StartRunRequest)(nil),                       // 191: agentcompose.v2.StartRunRequest
-	(*StartRunResponse)(nil),                      // 192: agentcompose.v2.StartRunResponse
-	(*SkillSpec)(nil),                             // 193: agentcompose.v2.SkillSpec
-	(*ResolveResourceIDRequest)(nil),              // 194: agentcompose.v2.ResolveResourceIDRequest
-	(*ResolveResourceIDResponse)(nil),             // 195: agentcompose.v2.ResolveResourceIDResponse
-	(*ResourceTarget)(nil),                        // 196: agentcompose.v2.ResourceTarget
-	(*GetDashboardOverviewRequest)(nil),           // 197: agentcompose.v2.GetDashboardOverviewRequest
-	(*WatchDashboardOverviewRequest)(nil),         // 198: agentcompose.v2.WatchDashboardOverviewRequest
-	(*RunOverview)(nil),                           // 199: agentcompose.v2.RunOverview
-	(*DashboardOverview)(nil),                     // 200: agentcompose.v2.DashboardOverview
-	(*GetDashboardOverviewResponse)(nil),          // 201: agentcompose.v2.GetDashboardOverviewResponse
-	(*WatchDashboardOverviewResponse)(nil),        // 202: agentcompose.v2.WatchDashboardOverviewResponse
-	(*GetGlobalEnvRequest)(nil),                   // 203: agentcompose.v2.GetGlobalEnvRequest
-	(*GetGlobalEnvResponse)(nil),                  // 204: agentcompose.v2.GetGlobalEnvResponse
-	(*UpdateGlobalEnvRequest)(nil),                // 205: agentcompose.v2.UpdateGlobalEnvRequest
-	(*UpdateGlobalEnvResponse)(nil),               // 206: agentcompose.v2.UpdateGlobalEnvResponse
-	(*GetCapabilityGatewayConfigRequest)(nil),     // 207: agentcompose.v2.GetCapabilityGatewayConfigRequest
-	(*CapabilityGatewayConfig)(nil),               // 208: agentcompose.v2.CapabilityGatewayConfig
-	(*GetCapabilityGatewayConfigResponse)(nil),    // 209: agentcompose.v2.GetCapabilityGatewayConfigResponse
-	(*UpdateCapabilityGatewayConfigRequest)(nil),  // 210: agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	(*UpdateCapabilityGatewayConfigResponse)(nil), // 211: agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	(*WorkspacePreset)(nil),                       // 212: agentcompose.v2.WorkspacePreset
-	(*ListWorkspacePresetsRequest)(nil),           // 213: agentcompose.v2.ListWorkspacePresetsRequest
-	(*ListWorkspacePresetsResponse)(nil),          // 214: agentcompose.v2.ListWorkspacePresetsResponse
-	(*CreateWorkspacePresetRequest)(nil),          // 215: agentcompose.v2.CreateWorkspacePresetRequest
-	(*UpdateWorkspacePresetRequest)(nil),          // 216: agentcompose.v2.UpdateWorkspacePresetRequest
-	(*DeleteWorkspacePresetRequest)(nil),          // 217: agentcompose.v2.DeleteWorkspacePresetRequest
-	(*DeleteWorkspacePresetResponse)(nil),         // 218: agentcompose.v2.DeleteWorkspacePresetResponse
-	(*WorkspacePresetResponse)(nil),               // 219: agentcompose.v2.WorkspacePresetResponse
-	(*GetCapabilityStatusRequest)(nil),            // 220: agentcompose.v2.GetCapabilityStatusRequest
-	(*CapabilityStatusResponse)(nil),              // 221: agentcompose.v2.CapabilityStatusResponse
-	(*ListCapabilitySetsRequest)(nil),             // 222: agentcompose.v2.ListCapabilitySetsRequest
-	(*CapabilitySet)(nil),                         // 223: agentcompose.v2.CapabilitySet
-	(*ListCapabilitySetsResponse)(nil),            // 224: agentcompose.v2.ListCapabilitySetsResponse
-	(*GetCapabilityCatalogRequest)(nil),           // 225: agentcompose.v2.GetCapabilityCatalogRequest
-	(*CapabilityEndpoint)(nil),                    // 226: agentcompose.v2.CapabilityEndpoint
-	(*CapabilityMethod)(nil),                      // 227: agentcompose.v2.CapabilityMethod
-	(*GetCapabilityCatalogResponse)(nil),          // 228: agentcompose.v2.GetCapabilityCatalogResponse
-	(*ListSandboxHistoryRequest)(nil),             // 229: agentcompose.v2.ListSandboxHistoryRequest
-	(*SandboxHistoryCell)(nil),                    // 230: agentcompose.v2.SandboxHistoryCell
-	(*SandboxHistoryEvent)(nil),                   // 231: agentcompose.v2.SandboxHistoryEvent
-	(*ListSandboxHistoryResponse)(nil),            // 232: agentcompose.v2.ListSandboxHistoryResponse
-	(*WatchSandboxRequest)(nil),                   // 233: agentcompose.v2.WatchSandboxRequest
-	(*WatchSandboxResponse)(nil),                  // 234: agentcompose.v2.WatchSandboxResponse
-	(*GenerateLLMRequest)(nil),                    // 235: agentcompose.v2.GenerateLLMRequest
-	(*GenerateLLMResponse)(nil),                   // 236: agentcompose.v2.GenerateLLMResponse
-	nil,                                           // 237: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                                           // 238: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                                           // 239: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                                           // 240: agentcompose.v2.AttachHumanMessage.MetadataEntry
-	nil,                                           // 241: agentcompose.v2.AttachError.DetailsEntry
-	nil,                                           // 242: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                                           // 243: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                                           // 244: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                                           // 245: agentcompose.v2.Volume.LabelsEntry
-	nil,                                           // 246: agentcompose.v2.Volume.OptionsEntry
-	nil,                                           // 247: agentcompose.v2.Image.LabelsEntry
-	nil,                                           // 248: agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	(*timestamppb.Timestamp)(nil),                 // 249: google.protobuf.Timestamp
+	(*ListProjectSchedulerEventsRequest)(nil),     // 54: agentcompose.v2.ListProjectSchedulerEventsRequest
+	(*ListProjectSchedulerEventsResponse)(nil),    // 55: agentcompose.v2.ListProjectSchedulerEventsResponse
+	(*InvokeSchedulerRequest)(nil),                // 56: agentcompose.v2.InvokeSchedulerRequest
+	(*InvokeSchedulerResponse)(nil),               // 57: agentcompose.v2.InvokeSchedulerResponse
+	(*RunSchedulerRequest)(nil),                   // 58: agentcompose.v2.RunSchedulerRequest
+	(*RunSchedulerResponse)(nil),                  // 59: agentcompose.v2.RunSchedulerResponse
+	(*StartSchedulerRunRequest)(nil),              // 60: agentcompose.v2.StartSchedulerRunRequest
+	(*StartSchedulerRunResponse)(nil),             // 61: agentcompose.v2.StartSchedulerRunResponse
+	(*GetSchedulerRunRequest)(nil),                // 62: agentcompose.v2.GetSchedulerRunRequest
+	(*GetSchedulerRunResponse)(nil),               // 63: agentcompose.v2.GetSchedulerRunResponse
+	(*ListSchedulerRunsRequest)(nil),              // 64: agentcompose.v2.ListSchedulerRunsRequest
+	(*ListSchedulerRunsResponse)(nil),             // 65: agentcompose.v2.ListSchedulerRunsResponse
+	(*StopSchedulerRunRequest)(nil),               // 66: agentcompose.v2.StopSchedulerRunRequest
+	(*StopSchedulerRunResponse)(nil),              // 67: agentcompose.v2.StopSchedulerRunResponse
+	(*SchedulerRun)(nil),                          // 68: agentcompose.v2.SchedulerRun
+	(*SetSchedulerEnabledRequest)(nil),            // 69: agentcompose.v2.SetSchedulerEnabledRequest
+	(*SetSchedulerEnabledResponse)(nil),           // 70: agentcompose.v2.SetSchedulerEnabledResponse
+	(*SetSchedulerTriggerEnabledRequest)(nil),     // 71: agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	(*SetSchedulerTriggerEnabledResponse)(nil),    // 72: agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	(*ProjectValidationIssue)(nil),                // 73: agentcompose.v2.ProjectValidationIssue
+	(*ProjectChange)(nil),                         // 74: agentcompose.v2.ProjectChange
+	(*ProjectSpec)(nil),                           // 75: agentcompose.v2.ProjectSpec
+	(*NamedWorkspaceSpec)(nil),                    // 76: agentcompose.v2.NamedWorkspaceSpec
+	(*AgentSpec)(nil),                             // 77: agentcompose.v2.AgentSpec
+	(*MCPServerSpec)(nil),                         // 78: agentcompose.v2.MCPServerSpec
+	(*ProjectVolumeSpec)(nil),                     // 79: agentcompose.v2.ProjectVolumeSpec
+	(*VolumeMountSpec)(nil),                       // 80: agentcompose.v2.VolumeMountSpec
+	(*BuildSpec)(nil),                             // 81: agentcompose.v2.BuildSpec
+	(*EnvVarSpec)(nil),                            // 82: agentcompose.v2.EnvVarSpec
+	(*EnvVarUpdateSpec)(nil),                      // 83: agentcompose.v2.EnvVarUpdateSpec
+	(*WorkspaceSpec)(nil),                         // 84: agentcompose.v2.WorkspaceSpec
+	(*SchedulerSpec)(nil),                         // 85: agentcompose.v2.SchedulerSpec
+	(*TriggerSpec)(nil),                           // 86: agentcompose.v2.TriggerSpec
+	(*EventTriggerSpec)(nil),                      // 87: agentcompose.v2.EventTriggerSpec
+	(*DriverSpec)(nil),                            // 88: agentcompose.v2.DriverSpec
+	(*BoxliteDriverSpec)(nil),                     // 89: agentcompose.v2.BoxliteDriverSpec
+	(*DockerDriverSpec)(nil),                      // 90: agentcompose.v2.DockerDriverSpec
+	(*MicrosandboxDriverSpec)(nil),                // 91: agentcompose.v2.MicrosandboxDriverSpec
+	(*RunAgentRequest)(nil),                       // 92: agentcompose.v2.RunAgentRequest
+	(*RunAgentResponse)(nil),                      // 93: agentcompose.v2.RunAgentResponse
+	(*RunAgentStreamResponse)(nil),                // 94: agentcompose.v2.RunAgentStreamResponse
+	(*RunAttachRequest)(nil),                      // 95: agentcompose.v2.RunAttachRequest
+	(*RunAttachResponse)(nil),                     // 96: agentcompose.v2.RunAttachResponse
+	(*RunAttachStart)(nil),                        // 97: agentcompose.v2.RunAttachStart
+	(*TranscriptEvent)(nil),                       // 98: agentcompose.v2.TranscriptEvent
+	(*GetRunRequest)(nil),                         // 99: agentcompose.v2.GetRunRequest
+	(*GetRunResponse)(nil),                        // 100: agentcompose.v2.GetRunResponse
+	(*ListRunsRequest)(nil),                       // 101: agentcompose.v2.ListRunsRequest
+	(*ListRunsResponse)(nil),                      // 102: agentcompose.v2.ListRunsResponse
+	(*FollowRunLogsRequest)(nil),                  // 103: agentcompose.v2.FollowRunLogsRequest
+	(*RunLogChunk)(nil),                           // 104: agentcompose.v2.RunLogChunk
+	(*StopRunRequest)(nil),                        // 105: agentcompose.v2.StopRunRequest
+	(*StopRunResponse)(nil),                       // 106: agentcompose.v2.StopRunResponse
+	(*ListRunEventsRequest)(nil),                  // 107: agentcompose.v2.ListRunEventsRequest
+	(*RunEvent)(nil),                              // 108: agentcompose.v2.RunEvent
+	(*ListRunEventsResponse)(nil),                 // 109: agentcompose.v2.ListRunEventsResponse
+	(*ListSandboxRunEventsRequest)(nil),           // 110: agentcompose.v2.ListSandboxRunEventsRequest
+	(*ListSandboxRunEventsResponse)(nil),          // 111: agentcompose.v2.ListSandboxRunEventsResponse
+	(*RemoveSandboxRequest)(nil),                  // 112: agentcompose.v2.RemoveSandboxRequest
+	(*RemoveSandboxResponse)(nil),                 // 113: agentcompose.v2.RemoveSandboxResponse
+	(*PruneSandboxesRequest)(nil),                 // 114: agentcompose.v2.PruneSandboxesRequest
+	(*SandboxPruneCandidate)(nil),                 // 115: agentcompose.v2.SandboxPruneCandidate
+	(*PruneSandboxesResponse)(nil),                // 116: agentcompose.v2.PruneSandboxesResponse
+	(*GetSandboxStatsRequest)(nil),                // 117: agentcompose.v2.GetSandboxStatsRequest
+	(*GetSandboxStatsResponse)(nil),               // 118: agentcompose.v2.GetSandboxStatsResponse
+	(*GetSandboxRequest)(nil),                     // 119: agentcompose.v2.GetSandboxRequest
+	(*Sandbox)(nil),                               // 120: agentcompose.v2.Sandbox
+	(*SandboxTag)(nil),                            // 121: agentcompose.v2.SandboxTag
+	(*ListSandboxesRequest)(nil),                  // 122: agentcompose.v2.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),                 // 123: agentcompose.v2.ListSandboxesResponse
+	(*GetSandboxResponse)(nil),                    // 124: agentcompose.v2.GetSandboxResponse
+	(*StopSandboxRequest)(nil),                    // 125: agentcompose.v2.StopSandboxRequest
+	(*StopSandboxResponse)(nil),                   // 126: agentcompose.v2.StopSandboxResponse
+	(*ResumeSandboxRequest)(nil),                  // 127: agentcompose.v2.ResumeSandboxRequest
+	(*ResumeSandboxResponse)(nil),                 // 128: agentcompose.v2.ResumeSandboxResponse
+	(*MetricValue)(nil),                           // 129: agentcompose.v2.MetricValue
+	(*SandboxStats)(nil),                          // 130: agentcompose.v2.SandboxStats
+	(*RunSummary)(nil),                            // 131: agentcompose.v2.RunSummary
+	(*RunDetail)(nil),                             // 132: agentcompose.v2.RunDetail
+	(*ExecRequest)(nil),                           // 133: agentcompose.v2.ExecRequest
+	(*ExecSandboxSelector)(nil),                   // 134: agentcompose.v2.ExecSandboxSelector
+	(*ExecCommand)(nil),                           // 135: agentcompose.v2.ExecCommand
+	(*ExecResponse)(nil),                          // 136: agentcompose.v2.ExecResponse
+	(*ExecStreamResponse)(nil),                    // 137: agentcompose.v2.ExecStreamResponse
+	(*ExecAttachRequest)(nil),                     // 138: agentcompose.v2.ExecAttachRequest
+	(*ExecAttachResponse)(nil),                    // 139: agentcompose.v2.ExecAttachResponse
+	(*ExecAttachStart)(nil),                       // 140: agentcompose.v2.ExecAttachStart
+	(*AttachTerminalSize)(nil),                    // 141: agentcompose.v2.AttachTerminalSize
+	(*AttachStdin)(nil),                           // 142: agentcompose.v2.AttachStdin
+	(*AttachStdinEOF)(nil),                        // 143: agentcompose.v2.AttachStdinEOF
+	(*AttachResize)(nil),                          // 144: agentcompose.v2.AttachResize
+	(*AttachSignal)(nil),                          // 145: agentcompose.v2.AttachSignal
+	(*AttachHumanMessage)(nil),                    // 146: agentcompose.v2.AttachHumanMessage
+	(*AttachCancel)(nil),                          // 147: agentcompose.v2.AttachCancel
+	(*AttachStarted)(nil),                         // 148: agentcompose.v2.AttachStarted
+	(*AttachOutput)(nil),                          // 149: agentcompose.v2.AttachOutput
+	(*AttachAgentEvent)(nil),                      // 150: agentcompose.v2.AttachAgentEvent
+	(*AttachAgentTurnCompleted)(nil),              // 151: agentcompose.v2.AttachAgentTurnCompleted
+	(*AttachResult)(nil),                          // 152: agentcompose.v2.AttachResult
+	(*AttachError)(nil),                           // 153: agentcompose.v2.AttachError
+	(*ExecResult)(nil),                            // 154: agentcompose.v2.ExecResult
+	(*ListImagesRequest)(nil),                     // 155: agentcompose.v2.ListImagesRequest
+	(*ListImagesResponse)(nil),                    // 156: agentcompose.v2.ListImagesResponse
+	(*PullImageRequest)(nil),                      // 157: agentcompose.v2.PullImageRequest
+	(*PullImageResponse)(nil),                     // 158: agentcompose.v2.PullImageResponse
+	(*InspectImageRequest)(nil),                   // 159: agentcompose.v2.InspectImageRequest
+	(*InspectImageResponse)(nil),                  // 160: agentcompose.v2.InspectImageResponse
+	(*RemoveImageRequest)(nil),                    // 161: agentcompose.v2.RemoveImageRequest
+	(*RemoveImageResponse)(nil),                   // 162: agentcompose.v2.RemoveImageResponse
+	(*BuildImageRequest)(nil),                     // 163: agentcompose.v2.BuildImageRequest
+	(*BuildImageEvent)(nil),                       // 164: agentcompose.v2.BuildImageEvent
+	(*CacheFilter)(nil),                           // 165: agentcompose.v2.CacheFilter
+	(*ListCachesRequest)(nil),                     // 166: agentcompose.v2.ListCachesRequest
+	(*ListCachesResponse)(nil),                    // 167: agentcompose.v2.ListCachesResponse
+	(*InspectCacheRequest)(nil),                   // 168: agentcompose.v2.InspectCacheRequest
+	(*InspectCacheResponse)(nil),                  // 169: agentcompose.v2.InspectCacheResponse
+	(*PruneCachesRequest)(nil),                    // 170: agentcompose.v2.PruneCachesRequest
+	(*PruneCachesResponse)(nil),                   // 171: agentcompose.v2.PruneCachesResponse
+	(*RemoveCacheRequest)(nil),                    // 172: agentcompose.v2.RemoveCacheRequest
+	(*RemoveCacheResponse)(nil),                   // 173: agentcompose.v2.RemoveCacheResponse
+	(*CacheItem)(nil),                             // 174: agentcompose.v2.CacheItem
+	(*CacheReference)(nil),                        // 175: agentcompose.v2.CacheReference
+	(*ListVolumesRequest)(nil),                    // 176: agentcompose.v2.ListVolumesRequest
+	(*ListVolumesResponse)(nil),                   // 177: agentcompose.v2.ListVolumesResponse
+	(*CreateVolumeRequest)(nil),                   // 178: agentcompose.v2.CreateVolumeRequest
+	(*CreateVolumeResponse)(nil),                  // 179: agentcompose.v2.CreateVolumeResponse
+	(*InspectVolumeRequest)(nil),                  // 180: agentcompose.v2.InspectVolumeRequest
+	(*InspectVolumeResponse)(nil),                 // 181: agentcompose.v2.InspectVolumeResponse
+	(*RemoveVolumeRequest)(nil),                   // 182: agentcompose.v2.RemoveVolumeRequest
+	(*RemoveVolumeResponse)(nil),                  // 183: agentcompose.v2.RemoveVolumeResponse
+	(*PruneVolumesRequest)(nil),                   // 184: agentcompose.v2.PruneVolumesRequest
+	(*PruneVolumesResponse)(nil),                  // 185: agentcompose.v2.PruneVolumesResponse
+	(*Volume)(nil),                                // 186: agentcompose.v2.Volume
+	(*Image)(nil),                                 // 187: agentcompose.v2.Image
+	(*ImagePlatform)(nil),                         // 188: agentcompose.v2.ImagePlatform
+	(*ImageStoreStatus)(nil),                      // 189: agentcompose.v2.ImageStoreStatus
+	(*DockerImageStatus)(nil),                     // 190: agentcompose.v2.DockerImageStatus
+	(*OCIImageStatus)(nil),                        // 191: agentcompose.v2.OCIImageStatus
+	(*ImagePullProgress)(nil),                     // 192: agentcompose.v2.ImagePullProgress
+	(*JupyterSpec)(nil),                           // 193: agentcompose.v2.JupyterSpec
+	(*RunJupyterSpec)(nil),                        // 194: agentcompose.v2.RunJupyterSpec
+	(*StartRunRequest)(nil),                       // 195: agentcompose.v2.StartRunRequest
+	(*StartRunResponse)(nil),                      // 196: agentcompose.v2.StartRunResponse
+	(*SkillSpec)(nil),                             // 197: agentcompose.v2.SkillSpec
+	(*ResolveResourceIDRequest)(nil),              // 198: agentcompose.v2.ResolveResourceIDRequest
+	(*ResolveResourceIDResponse)(nil),             // 199: agentcompose.v2.ResolveResourceIDResponse
+	(*ResourceTarget)(nil),                        // 200: agentcompose.v2.ResourceTarget
+	(*GetDashboardOverviewRequest)(nil),           // 201: agentcompose.v2.GetDashboardOverviewRequest
+	(*WatchDashboardOverviewRequest)(nil),         // 202: agentcompose.v2.WatchDashboardOverviewRequest
+	(*RunOverview)(nil),                           // 203: agentcompose.v2.RunOverview
+	(*DashboardOverview)(nil),                     // 204: agentcompose.v2.DashboardOverview
+	(*GetDashboardOverviewResponse)(nil),          // 205: agentcompose.v2.GetDashboardOverviewResponse
+	(*WatchDashboardOverviewResponse)(nil),        // 206: agentcompose.v2.WatchDashboardOverviewResponse
+	(*GetGlobalEnvRequest)(nil),                   // 207: agentcompose.v2.GetGlobalEnvRequest
+	(*GetGlobalEnvResponse)(nil),                  // 208: agentcompose.v2.GetGlobalEnvResponse
+	(*UpdateGlobalEnvRequest)(nil),                // 209: agentcompose.v2.UpdateGlobalEnvRequest
+	(*UpdateGlobalEnvResponse)(nil),               // 210: agentcompose.v2.UpdateGlobalEnvResponse
+	(*GetCapabilityGatewayConfigRequest)(nil),     // 211: agentcompose.v2.GetCapabilityGatewayConfigRequest
+	(*CapabilityGatewayConfig)(nil),               // 212: agentcompose.v2.CapabilityGatewayConfig
+	(*GetCapabilityGatewayConfigResponse)(nil),    // 213: agentcompose.v2.GetCapabilityGatewayConfigResponse
+	(*UpdateCapabilityGatewayConfigRequest)(nil),  // 214: agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	(*UpdateCapabilityGatewayConfigResponse)(nil), // 215: agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	(*WorkspacePreset)(nil),                       // 216: agentcompose.v2.WorkspacePreset
+	(*ListWorkspacePresetsRequest)(nil),           // 217: agentcompose.v2.ListWorkspacePresetsRequest
+	(*ListWorkspacePresetsResponse)(nil),          // 218: agentcompose.v2.ListWorkspacePresetsResponse
+	(*CreateWorkspacePresetRequest)(nil),          // 219: agentcompose.v2.CreateWorkspacePresetRequest
+	(*UpdateWorkspacePresetRequest)(nil),          // 220: agentcompose.v2.UpdateWorkspacePresetRequest
+	(*DeleteWorkspacePresetRequest)(nil),          // 221: agentcompose.v2.DeleteWorkspacePresetRequest
+	(*DeleteWorkspacePresetResponse)(nil),         // 222: agentcompose.v2.DeleteWorkspacePresetResponse
+	(*WorkspacePresetResponse)(nil),               // 223: agentcompose.v2.WorkspacePresetResponse
+	(*GetCapabilityStatusRequest)(nil),            // 224: agentcompose.v2.GetCapabilityStatusRequest
+	(*CapabilityStatusResponse)(nil),              // 225: agentcompose.v2.CapabilityStatusResponse
+	(*ListCapabilitySetsRequest)(nil),             // 226: agentcompose.v2.ListCapabilitySetsRequest
+	(*CapabilitySet)(nil),                         // 227: agentcompose.v2.CapabilitySet
+	(*ListCapabilitySetsResponse)(nil),            // 228: agentcompose.v2.ListCapabilitySetsResponse
+	(*GetCapabilityCatalogRequest)(nil),           // 229: agentcompose.v2.GetCapabilityCatalogRequest
+	(*CapabilityEndpoint)(nil),                    // 230: agentcompose.v2.CapabilityEndpoint
+	(*CapabilityMethod)(nil),                      // 231: agentcompose.v2.CapabilityMethod
+	(*GetCapabilityCatalogResponse)(nil),          // 232: agentcompose.v2.GetCapabilityCatalogResponse
+	(*ListSandboxHistoryRequest)(nil),             // 233: agentcompose.v2.ListSandboxHistoryRequest
+	(*SandboxHistoryCell)(nil),                    // 234: agentcompose.v2.SandboxHistoryCell
+	(*SandboxHistoryEvent)(nil),                   // 235: agentcompose.v2.SandboxHistoryEvent
+	(*ListSandboxHistoryResponse)(nil),            // 236: agentcompose.v2.ListSandboxHistoryResponse
+	(*WatchSandboxRequest)(nil),                   // 237: agentcompose.v2.WatchSandboxRequest
+	(*WatchSandboxResponse)(nil),                  // 238: agentcompose.v2.WatchSandboxResponse
+	(*GenerateLLMRequest)(nil),                    // 239: agentcompose.v2.GenerateLLMRequest
+	(*GenerateLLMResponse)(nil),                   // 240: agentcompose.v2.GenerateLLMResponse
+	nil,                                           // 241: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                                           // 242: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                                           // 243: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                                           // 244: agentcompose.v2.AttachHumanMessage.MetadataEntry
+	nil,                                           // 245: agentcompose.v2.AttachError.DetailsEntry
+	nil,                                           // 246: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                                           // 247: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                                           // 248: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                                           // 249: agentcompose.v2.Volume.LabelsEntry
+	nil,                                           // 250: agentcompose.v2.Volume.OptionsEntry
+	nil,                                           // 251: agentcompose.v2.Image.LabelsEntry
+	nil,                                           // 252: agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	(*timestamppb.Timestamp)(nil),                 // 253: google.protobuf.Timestamp
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
-	71,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
+	75,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
 	37,  // 1: agentcompose.v2.ValidateProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
-	69,  // 2: agentcompose.v2.ValidateProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
-	71,  // 3: agentcompose.v2.ApplyProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
+	73,  // 2: agentcompose.v2.ValidateProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
+	75,  // 3: agentcompose.v2.ApplyProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
 	37,  // 4: agentcompose.v2.ApplyProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
 	38,  // 5: agentcompose.v2.ApplyProjectResponse.project:type_name -> agentcompose.v2.Project
 	40,  // 6: agentcompose.v2.ApplyProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
-	70,  // 7: agentcompose.v2.ApplyProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
-	69,  // 8: agentcompose.v2.ApplyProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
+	74,  // 7: agentcompose.v2.ApplyProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	73,  // 8: agentcompose.v2.ApplyProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
 	36,  // 9: agentcompose.v2.GetProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
 	38,  // 10: agentcompose.v2.GetProjectResponse.project:type_name -> agentcompose.v2.Project
 	39,  // 11: agentcompose.v2.ListProjectsResponse.projects:type_name -> agentcompose.v2.ProjectSummary
 	36,  // 12: agentcompose.v2.RemoveProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
 	38,  // 13: agentcompose.v2.RemoveProjectResponse.project:type_name -> agentcompose.v2.Project
-	70,  // 14: agentcompose.v2.RemoveProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	74,  // 14: agentcompose.v2.RemoveProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
 	36,  // 15: agentcompose.v2.WatchProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
 	2,   // 16: agentcompose.v2.WatchProjectResponse.type:type_name -> agentcompose.v2.ProjectWatchEventType
 	38,  // 17: agentcompose.v2.WatchProjectResponse.project:type_name -> agentcompose.v2.Project
 	40,  // 18: agentcompose.v2.WatchProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
-	70,  // 19: agentcompose.v2.WatchProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	74,  // 19: agentcompose.v2.WatchProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
 	39,  // 20: agentcompose.v2.Project.summary:type_name -> agentcompose.v2.ProjectSummary
-	71,  // 21: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
+	75,  // 21: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
 	41,  // 22: agentcompose.v2.Project.agents:type_name -> agentcompose.v2.ProjectAgent
 	44,  // 23: agentcompose.v2.Project.schedulers:type_name -> agentcompose.v2.ProjectScheduler
-	71,  // 24: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
+	75,  // 24: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
 	6,   // 25: agentcompose.v2.ProjectAgent.availability:type_name -> agentcompose.v2.ProjectAgentAvailability
 	7,   // 26: agentcompose.v2.ProjectAgent.health:type_name -> agentcompose.v2.ProjectAgentHealth
 	42,  // 27: agentcompose.v2.ProjectAgent.current_run:type_name -> agentcompose.v2.ProjectAgentCurrentRun
 	43,  // 28: agentcompose.v2.ProjectAgent.latest_run:type_name -> agentcompose.v2.ProjectAgentLatestRun
 	3,   // 29: agentcompose.v2.ProjectAgentLatestRun.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 30: agentcompose.v2.ProjectAgentLatestRun.source:type_name -> agentcompose.v2.RunSource
-	249, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
+	253, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
 	36,  // 32: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
 	44,  // 33: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
-	81,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
+	85,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
 	47,  // 35: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
-	82,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
-	249, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
-	249, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
-	249, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
+	86,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
+	253, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
+	253, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
+	253, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
 	49,  // 40: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
 	36,  // 41: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	249, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
+	253, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
 	52,  // 43: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
-	36,  // 44: agentcompose.v2.RunSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
-	64,  // 45: agentcompose.v2.RunSchedulerResponse.run:type_name -> agentcompose.v2.SchedulerRun
-	36,  // 46: agentcompose.v2.StartSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
-	64,  // 47: agentcompose.v2.StartSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
-	36,  // 48: agentcompose.v2.GetSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
-	64,  // 49: agentcompose.v2.GetSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
-	36,  // 50: agentcompose.v2.ListSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	64,  // 51: agentcompose.v2.ListSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
-	36,  // 52: agentcompose.v2.StopSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
-	64,  // 53: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
-	5,   // 54: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
-	249, // 55: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
-	249, // 56: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
-	36,  // 57: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
-	44,  // 58: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
-	36,  // 59: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
-	47,  // 60: agentcompose.v2.SetSchedulerTriggerEnabledResponse.trigger:type_name -> agentcompose.v2.ResolvedTrigger
-	0,   // 61: agentcompose.v2.ProjectValidationIssue.severity:type_name -> agentcompose.v2.ProjectValidationSeverity
-	1,   // 62: agentcompose.v2.ProjectChange.action:type_name -> agentcompose.v2.ProjectChangeAction
-	78,  // 63: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
-	73,  // 64: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
-	75,  // 65: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
-	72,  // 66: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
-	74,  // 67: agentcompose.v2.ProjectSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
-	80,  // 68: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	84,  // 69: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
-	78,  // 70: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
-	80,  // 71: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	81,  // 72: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
-	189, // 73: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
-	77,  // 74: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
-	76,  // 75: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	74,  // 76: agentcompose.v2.AgentSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
-	193, // 77: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
-	78,  // 78: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
-	78,  // 79: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
-	237, // 80: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	238, // 81: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	239, // 82: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
-	82,  // 83: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
-	83,  // 84: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
-	85,  // 85: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
-	86,  // 86: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
-	87,  // 87: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
-	4,   // 88: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
-	78,  // 89: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	10,  // 90: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
-	190, // 91: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
-	76,  // 92: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	128, // 93: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
-	9,   // 94: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
-	127, // 95: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 96: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	94,  // 97: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	93,  // 98: agentcompose.v2.RunAttachRequest.start:type_name -> agentcompose.v2.RunAttachStart
-	138, // 99: agentcompose.v2.RunAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	139, // 100: agentcompose.v2.RunAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	140, // 101: agentcompose.v2.RunAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	141, // 102: agentcompose.v2.RunAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	142, // 103: agentcompose.v2.RunAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	143, // 104: agentcompose.v2.RunAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	144, // 105: agentcompose.v2.RunAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	145, // 106: agentcompose.v2.RunAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	146, // 107: agentcompose.v2.RunAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	147, // 108: agentcompose.v2.RunAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	148, // 109: agentcompose.v2.RunAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	149, // 110: agentcompose.v2.RunAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	88,  // 111: agentcompose.v2.RunAttachStart.request:type_name -> agentcompose.v2.RunAgentRequest
-	12,  // 112: agentcompose.v2.RunAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	137, // 113: agentcompose.v2.RunAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	13,  // 114: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
-	128, // 115: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	3,   // 116: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
-	4,   // 117: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
-	127, // 118: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
-	3,   // 119: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
-	128, // 120: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	8,   // 121: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
-	249, // 122: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
-	104, // 123: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	104, // 124: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	20,  // 125: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
-	249, // 126: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
-	111, // 127: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
-	111, // 128: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
-	126, // 129: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
-	249, // 130: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	249, // 131: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	117, // 132: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
-	249, // 133: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
-	249, // 134: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
-	116, // 135: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
-	116, // 136: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	116, // 137: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	116, // 138: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	17,  // 139: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	125, // 140: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
-	125, // 141: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
-	125, // 142: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
-	125, // 143: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
-	125, // 144: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
-	125, // 145: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
-	125, // 146: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
-	125, // 147: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
-	125, // 148: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
-	4,   // 149: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
-	3,   // 150: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	127, // 151: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	130, // 152: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
-	131, // 153: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
-	78,  // 154: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	150, // 155: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
-	11,  // 156: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
-	13,  // 157: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	150, // 158: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
-	94,  // 159: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	136, // 160: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
-	138, // 161: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	139, // 162: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	140, // 163: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	141, // 164: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	143, // 165: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	142, // 166: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	144, // 167: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	145, // 168: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	148, // 169: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	149, // 170: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	146, // 171: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	147, // 172: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	129, // 173: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
-	137, // 174: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	12,  // 175: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	137, // 176: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	240, // 177: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
-	127, // 178: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 179: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
-	94,  // 180: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	150, // 181: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
-	127, // 182: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	241, // 183: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
-	131, // 184: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
-	14,  // 185: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	183, // 186: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
-	185, // 187: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 188: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	184, // 189: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	183, // 190: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
-	16,  // 191: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
-	188, // 192: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
-	14,  // 193: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	183, // 194: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
-	185, // 195: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 196: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	242, // 197: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	14,  // 198: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	184, // 199: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	16,  // 200: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
-	183, // 201: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
-	18,  // 202: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 203: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
-	161, // 204: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	170, // 205: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
-	170, // 206: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
-	161, // 207: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	170, // 208: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
-	170, // 209: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	170, // 210: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
-	170, // 211: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	18,  // 212: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 213: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	171, // 214: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
-	19,  // 215: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
-	182, // 216: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	243, // 217: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	244, // 218: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	182, // 219: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	182, // 220: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	182, // 221: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
-	182, // 222: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
-	182, // 223: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	245, // 224: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	246, // 225: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	14,  // 226: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
-	15,  // 227: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
-	184, // 228: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	186, // 229: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
-	187, // 230: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	247, // 231: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
-	14,  // 232: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
-	88,  // 233: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
-	127, // 234: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
-	22,  // 235: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
-	196, // 236: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
-	22,  // 237: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
-	199, // 238: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	249, // 239: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
-	200, // 240: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	200, // 241: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	78,  // 242: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	79,  // 243: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
-	78,  // 244: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	208, // 245: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	208, // 246: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	249, // 247: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	249, // 248: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
-	212, // 249: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
-	212, // 250: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
-	223, // 251: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	248, // 252: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	226, // 253: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
-	227, // 254: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	249, // 255: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	249, // 256: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
-	230, // 257: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
-	231, // 258: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
-	23,  // 259: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
-	116, // 260: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	230, // 261: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
-	231, // 262: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
-	13,  // 263: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
-	24,  // 264: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	26,  // 265: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	28,  // 266: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	30,  // 267: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	32,  // 268: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	34,  // 269: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	45,  // 270: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
-	48,  // 271: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
-	51,  // 272: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
-	54,  // 273: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
-	56,  // 274: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
-	58,  // 275: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
-	60,  // 276: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
-	62,  // 277: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
-	65,  // 278: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
-	67,  // 279: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	88,  // 280: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	191, // 281: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	88,  // 282: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	91,  // 283: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
-	95,  // 284: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	97,  // 285: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	99,  // 286: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	101, // 287: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	103, // 288: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
-	106, // 289: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
-	129, // 290: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	129, // 291: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	134, // 292: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
-	151, // 293: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	153, // 294: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	155, // 295: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	157, // 296: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	159, // 297: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	162, // 298: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	164, // 299: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	166, // 300: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	168, // 301: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	172, // 302: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	174, // 303: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	176, // 304: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	178, // 305: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	180, // 306: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	108, // 307: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	110, // 308: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
-	113, // 309: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	115, // 310: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
-	121, // 311: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
-	123, // 312: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
-	118, // 313: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	229, // 314: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	233, // 315: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
-	197, // 316: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
-	198, // 317: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
-	203, // 318: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
-	205, // 319: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
-	207, // 320: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
-	210, // 321: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	213, // 322: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
-	215, // 323: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
-	216, // 324: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
-	217, // 325: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
-	220, // 326: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
-	222, // 327: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
-	225, // 328: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	235, // 329: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	194, // 330: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	25,  // 331: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	27,  // 332: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	29,  // 333: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	31,  // 334: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	33,  // 335: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	35,  // 336: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	46,  // 337: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	50,  // 338: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	53,  // 339: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	55,  // 340: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
-	57,  // 341: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
-	59,  // 342: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
-	61,  // 343: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
-	63,  // 344: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
-	66,  // 345: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	68,  // 346: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	89,  // 347: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	192, // 348: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	90,  // 349: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	92,  // 350: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
-	96,  // 351: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	98,  // 352: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	100, // 353: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	102, // 354: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	105, // 355: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	107, // 356: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	132, // 357: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	133, // 358: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	135, // 359: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
-	152, // 360: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	154, // 361: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	156, // 362: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	158, // 363: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	160, // 364: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	163, // 365: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	165, // 366: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	167, // 367: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	169, // 368: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	173, // 369: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	175, // 370: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	177, // 371: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	179, // 372: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	181, // 373: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	109, // 374: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	112, // 375: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	114, // 376: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	120, // 377: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	122, // 378: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	124, // 379: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	119, // 380: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	232, // 381: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	234, // 382: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	201, // 383: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	202, // 384: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	204, // 385: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	206, // 386: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	209, // 387: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	211, // 388: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	214, // 389: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	219, // 390: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	219, // 391: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	218, // 392: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	221, // 393: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	224, // 394: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	228, // 395: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	236, // 396: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	195, // 397: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	331, // [331:398] is the sub-list for method output_type
-	264, // [264:331] is the sub-list for method input_type
-	264, // [264:264] is the sub-list for extension type_name
-	264, // [264:264] is the sub-list for extension extendee
-	0,   // [0:264] is the sub-list for field type_name
+	36,  // 44: agentcompose.v2.ListProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	52,  // 45: agentcompose.v2.ListProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
+	36,  // 46: agentcompose.v2.InvokeSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
+	36,  // 47: agentcompose.v2.RunSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
+	68,  // 48: agentcompose.v2.RunSchedulerResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	36,  // 49: agentcompose.v2.StartSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
+	68,  // 50: agentcompose.v2.StartSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	36,  // 51: agentcompose.v2.GetSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
+	68,  // 52: agentcompose.v2.GetSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	36,  // 53: agentcompose.v2.ListSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	5,   // 54: agentcompose.v2.ListSchedulerRunsRequest.status:type_name -> agentcompose.v2.SchedulerRunStatus
+	68,  // 55: agentcompose.v2.ListSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
+	36,  // 56: agentcompose.v2.StopSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
+	68,  // 57: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	5,   // 58: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
+	253, // 59: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
+	253, // 60: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
+	36,  // 61: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
+	44,  // 62: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
+	36,  // 63: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
+	47,  // 64: agentcompose.v2.SetSchedulerTriggerEnabledResponse.trigger:type_name -> agentcompose.v2.ResolvedTrigger
+	0,   // 65: agentcompose.v2.ProjectValidationIssue.severity:type_name -> agentcompose.v2.ProjectValidationSeverity
+	1,   // 66: agentcompose.v2.ProjectChange.action:type_name -> agentcompose.v2.ProjectChangeAction
+	82,  // 67: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
+	77,  // 68: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
+	79,  // 69: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
+	76,  // 70: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
+	78,  // 71: agentcompose.v2.ProjectSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
+	84,  // 72: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	88,  // 73: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
+	82,  // 74: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
+	84,  // 75: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	85,  // 76: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
+	193, // 77: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
+	81,  // 78: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
+	80,  // 79: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	78,  // 80: agentcompose.v2.AgentSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
+	197, // 81: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
+	82,  // 82: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
+	82,  // 83: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
+	241, // 84: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	242, // 85: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	243, // 86: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	86,  // 87: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
+	87,  // 88: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
+	89,  // 89: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
+	90,  // 90: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
+	91,  // 91: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
+	4,   // 92: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
+	82,  // 93: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	10,  // 94: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
+	194, // 95: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
+	80,  // 96: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	132, // 97: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
+	9,   // 98: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
+	131, // 99: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
+	13,  // 100: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	98,  // 101: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	97,  // 102: agentcompose.v2.RunAttachRequest.start:type_name -> agentcompose.v2.RunAttachStart
+	142, // 103: agentcompose.v2.RunAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	143, // 104: agentcompose.v2.RunAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	144, // 105: agentcompose.v2.RunAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	145, // 106: agentcompose.v2.RunAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	146, // 107: agentcompose.v2.RunAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	147, // 108: agentcompose.v2.RunAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	148, // 109: agentcompose.v2.RunAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	149, // 110: agentcompose.v2.RunAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	150, // 111: agentcompose.v2.RunAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	151, // 112: agentcompose.v2.RunAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	152, // 113: agentcompose.v2.RunAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	153, // 114: agentcompose.v2.RunAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	92,  // 115: agentcompose.v2.RunAttachStart.request:type_name -> agentcompose.v2.RunAgentRequest
+	12,  // 116: agentcompose.v2.RunAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	141, // 117: agentcompose.v2.RunAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	13,  // 118: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
+	132, // 119: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	3,   // 120: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
+	4,   // 121: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
+	131, // 122: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
+	3,   // 123: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
+	132, // 124: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	8,   // 125: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
+	253, // 126: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
+	108, // 127: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	108, // 128: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	20,  // 129: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
+	253, // 130: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	115, // 131: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
+	115, // 132: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
+	130, // 133: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
+	253, // 134: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	253, // 135: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	121, // 136: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
+	253, // 137: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
+	253, // 138: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
+	120, // 139: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
+	120, // 140: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	120, // 141: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	120, // 142: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	17,  // 143: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
+	129, // 144: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
+	129, // 145: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
+	129, // 146: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
+	129, // 147: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
+	129, // 148: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
+	129, // 149: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
+	129, // 150: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
+	129, // 151: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
+	129, // 152: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
+	4,   // 153: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
+	3,   // 154: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
+	131, // 155: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
+	134, // 156: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
+	135, // 157: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
+	82,  // 158: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	154, // 159: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
+	11,  // 160: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
+	13,  // 161: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	154, // 162: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
+	98,  // 163: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	140, // 164: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
+	142, // 165: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	143, // 166: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	144, // 167: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	145, // 168: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	147, // 169: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	146, // 170: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	148, // 171: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	149, // 172: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	152, // 173: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	153, // 174: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	150, // 175: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	151, // 176: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	133, // 177: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
+	141, // 178: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	12,  // 179: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	141, // 180: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	244, // 181: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	131, // 182: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
+	13,  // 183: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
+	98,  // 184: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	154, // 185: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
+	131, // 186: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
+	245, // 187: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	135, // 188: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
+	14,  // 189: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	187, // 190: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
+	189, // 191: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	14,  // 192: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	188, // 193: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	187, // 194: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
+	16,  // 195: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
+	192, // 196: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
+	14,  // 197: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	187, // 198: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
+	189, // 199: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	14,  // 200: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	246, // 201: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	14,  // 202: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	188, // 203: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	16,  // 204: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
+	187, // 205: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
+	18,  // 206: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
+	21,  // 207: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
+	165, // 208: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	174, // 209: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
+	174, // 210: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
+	165, // 211: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	174, // 212: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
+	174, // 213: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	174, // 214: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
+	174, // 215: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	18,  // 216: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
+	21,  // 217: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
+	175, // 218: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
+	19,  // 219: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
+	186, // 220: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
+	247, // 221: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	248, // 222: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	186, // 223: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	186, // 224: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	186, // 225: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
+	186, // 226: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
+	186, // 227: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
+	249, // 228: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	250, // 229: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	14,  // 230: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
+	15,  // 231: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
+	188, // 232: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
+	190, // 233: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
+	191, // 234: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
+	251, // 235: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	14,  // 236: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
+	92,  // 237: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
+	131, // 238: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	22,  // 239: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
+	200, // 240: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
+	22,  // 241: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
+	203, // 242: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
+	253, // 243: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	204, // 244: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	204, // 245: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	82,  // 246: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	83,  // 247: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
+	82,  // 248: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	212, // 249: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	212, // 250: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	253, // 251: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	253, // 252: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	216, // 253: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
+	216, // 254: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
+	227, // 255: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
+	252, // 256: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	230, // 257: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
+	231, // 258: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
+	253, // 259: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	253, // 260: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	234, // 261: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
+	235, // 262: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
+	23,  // 263: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
+	120, // 264: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	234, // 265: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
+	235, // 266: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
+	13,  // 267: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
+	24,  // 268: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	26,  // 269: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	28,  // 270: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	30,  // 271: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	32,  // 272: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	34,  // 273: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	45,  // 274: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
+	48,  // 275: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
+	51,  // 276: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
+	54,  // 277: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
+	56,  // 278: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
+	58,  // 279: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
+	60,  // 280: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
+	62,  // 281: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
+	64,  // 282: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
+	66,  // 283: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
+	69,  // 284: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
+	71,  // 285: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	92,  // 286: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	195, // 287: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
+	92,  // 288: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
+	95,  // 289: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
+	99,  // 290: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	101, // 291: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	103, // 292: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	105, // 293: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	107, // 294: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
+	110, // 295: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
+	133, // 296: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	133, // 297: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
+	138, // 298: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
+	155, // 299: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	157, // 300: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	159, // 301: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	161, // 302: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	163, // 303: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	166, // 304: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	168, // 305: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	170, // 306: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	172, // 307: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	176, // 308: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	178, // 309: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	180, // 310: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	182, // 311: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	184, // 312: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	112, // 313: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	114, // 314: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
+	117, // 315: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	119, // 316: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
+	125, // 317: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
+	127, // 318: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
+	122, // 319: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
+	233, // 320: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	237, // 321: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	201, // 322: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
+	202, // 323: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
+	207, // 324: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
+	209, // 325: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
+	211, // 326: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
+	214, // 327: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	217, // 328: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
+	219, // 329: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
+	220, // 330: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
+	221, // 331: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
+	224, // 332: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
+	226, // 333: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
+	229, // 334: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
+	239, // 335: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	198, // 336: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	25,  // 337: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	27,  // 338: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	29,  // 339: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	31,  // 340: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	33,  // 341: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	35,  // 342: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	46,  // 343: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	50,  // 344: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	53,  // 345: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	55,  // 346: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
+	57,  // 347: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
+	59,  // 348: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	61,  // 349: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	63,  // 350: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	65,  // 351: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	67,  // 352: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	70,  // 353: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	72,  // 354: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	93,  // 355: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	196, // 356: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
+	94,  // 357: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
+	96,  // 358: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
+	100, // 359: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	102, // 360: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	104, // 361: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	106, // 362: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	109, // 363: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	111, // 364: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	136, // 365: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	137, // 366: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
+	139, // 367: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
+	156, // 368: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	158, // 369: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	160, // 370: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	162, // 371: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	164, // 372: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	167, // 373: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	169, // 374: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	171, // 375: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	173, // 376: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	177, // 377: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	179, // 378: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	181, // 379: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	183, // 380: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	185, // 381: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	113, // 382: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	116, // 383: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	118, // 384: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	124, // 385: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	126, // 386: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	128, // 387: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	123, // 388: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	236, // 389: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	238, // 390: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	205, // 391: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	206, // 392: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	208, // 393: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	210, // 394: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	213, // 395: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	215, // 396: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	218, // 397: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	223, // 398: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	223, // 399: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	222, // 400: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	225, // 401: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	228, // 402: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	232, // 403: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	240, // 404: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	199, // 405: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	337, // [337:406] is the sub-list for method output_type
+	268, // [268:337] is the sub-list for method input_type
+	268, // [268:268] is the sub-list for extension type_name
+	268, // [268:268] is the sub-list for extension extendee
+	0,   // [0:268] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }
@@ -18671,9 +19041,9 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 	if File_agentcompose_v2_agentcompose_proto != nil {
 		return
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[49].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[55].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[67].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[53].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[59].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[71].OneofWrappers = []any{
 		(*RunAttachRequest_Start)(nil),
 		(*RunAttachRequest_Stdin)(nil),
 		(*RunAttachRequest_StdinEof)(nil),
@@ -18682,7 +19052,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*RunAttachRequest_HumanMessage)(nil),
 		(*RunAttachRequest_Cancel)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[68].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[72].OneofWrappers = []any{
 		(*RunAttachResponse_Started)(nil),
 		(*RunAttachResponse_Output)(nil),
 		(*RunAttachResponse_AgentEvent)(nil),
@@ -18690,13 +19060,13 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*RunAttachResponse_Result)(nil),
 		(*RunAttachResponse_Error)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[101].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[105].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[105].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[109].OneofWrappers = []any{
 		(*ExecRequest_SandboxId)(nil),
 		(*ExecRequest_RunId)(nil),
 		(*ExecRequest_Selector)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[110].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[114].OneofWrappers = []any{
 		(*ExecAttachRequest_Start)(nil),
 		(*ExecAttachRequest_Stdin)(nil),
 		(*ExecAttachRequest_StdinEof)(nil),
@@ -18705,7 +19075,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecAttachRequest_Cancel)(nil),
 		(*ExecAttachRequest_HumanMessage)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[111].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[115].OneofWrappers = []any{
 		(*ExecAttachResponse_Started)(nil),
 		(*ExecAttachResponse_Output)(nil),
 		(*ExecAttachResponse_Result)(nil),
@@ -18713,14 +19083,14 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecAttachResponse_AgentEvent)(nil),
 		(*ExecAttachResponse_AgentTurnCompleted)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[186].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[190].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
 			NumEnums:      24,
-			NumMessages:   225,
+			NumMessages:   229,
 			NumExtensions: 0,
 			NumServices:   12,
 		},

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -4193,6 +4193,326 @@ func (x *ListSchedulerRunsResponse) GetNextCursor() string {
 	return ""
 }
 
+type PruneSchedulerRunsRequest struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Project          *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName        string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	TriggerId        string                 `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	Status           []SchedulerRunStatus   `protobuf:"varint,4,rep,packed,name=status,proto3,enum=agentcompose.v2.SchedulerRunStatus" json:"status,omitempty"`
+	OlderThanSeconds uint64                 `protobuf:"varint,5,opt,name=older_than_seconds,json=olderThanSeconds,proto3" json:"older_than_seconds,omitempty"`
+	Force            bool                   `protobuf:"varint,6,opt,name=force,proto3" json:"force,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *PruneSchedulerRunsRequest) Reset() {
+	*x = PruneSchedulerRunsRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PruneSchedulerRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PruneSchedulerRunsRequest) ProtoMessage() {}
+
+func (x *PruneSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PruneSchedulerRunsRequest.ProtoReflect.Descriptor instead.
+func (*PruneSchedulerRunsRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *PruneSchedulerRunsRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *PruneSchedulerRunsRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *PruneSchedulerRunsRequest) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *PruneSchedulerRunsRequest) GetStatus() []SchedulerRunStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *PruneSchedulerRunsRequest) GetOlderThanSeconds() uint64 {
+	if x != nil {
+		return x.OlderThanSeconds
+	}
+	return 0
+}
+
+func (x *PruneSchedulerRunsRequest) GetForce() bool {
+	if x != nil {
+		return x.Force
+	}
+	return false
+}
+
+type SchedulerRunPruneStats struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Runs              uint64                 `protobuf:"varint,1,opt,name=runs,proto3" json:"runs,omitempty"`
+	LoaderEvents      uint64                 `protobuf:"varint,2,opt,name=loader_events,json=loaderEvents,proto3" json:"loader_events,omitempty"`
+	EventDeliveries   uint64                 `protobuf:"varint,3,opt,name=event_deliveries,json=eventDeliveries,proto3" json:"event_deliveries,omitempty"`
+	EventSandboxLinks uint64                 `protobuf:"varint,4,opt,name=event_sandbox_links,json=eventSandboxLinks,proto3" json:"event_sandbox_links,omitempty"`
+	ArtifactDirs      uint64                 `protobuf:"varint,5,opt,name=artifact_dirs,json=artifactDirs,proto3" json:"artifact_dirs,omitempty"`
+	ArtifactBytes     uint64                 `protobuf:"varint,6,opt,name=artifact_bytes,json=artifactBytes,proto3" json:"artifact_bytes,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *SchedulerRunPruneStats) Reset() {
+	*x = SchedulerRunPruneStats{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SchedulerRunPruneStats) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SchedulerRunPruneStats) ProtoMessage() {}
+
+func (x *SchedulerRunPruneStats) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SchedulerRunPruneStats.ProtoReflect.Descriptor instead.
+func (*SchedulerRunPruneStats) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *SchedulerRunPruneStats) GetRuns() uint64 {
+	if x != nil {
+		return x.Runs
+	}
+	return 0
+}
+
+func (x *SchedulerRunPruneStats) GetLoaderEvents() uint64 {
+	if x != nil {
+		return x.LoaderEvents
+	}
+	return 0
+}
+
+func (x *SchedulerRunPruneStats) GetEventDeliveries() uint64 {
+	if x != nil {
+		return x.EventDeliveries
+	}
+	return 0
+}
+
+func (x *SchedulerRunPruneStats) GetEventSandboxLinks() uint64 {
+	if x != nil {
+		return x.EventSandboxLinks
+	}
+	return 0
+}
+
+func (x *SchedulerRunPruneStats) GetArtifactDirs() uint64 {
+	if x != nil {
+		return x.ArtifactDirs
+	}
+	return 0
+}
+
+func (x *SchedulerRunPruneStats) GetArtifactBytes() uint64 {
+	if x != nil {
+		return x.ArtifactBytes
+	}
+	return 0
+}
+
+type SchedulerRunPruneResidue struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	LoaderId      string                 `protobuf:"bytes,1,opt,name=loader_id,json=loaderId,proto3" json:"loader_id,omitempty"`
+	RunId         string                 `protobuf:"bytes,2,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	Path          string                 `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
+	Error         string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SchedulerRunPruneResidue) Reset() {
+	*x = SchedulerRunPruneResidue{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SchedulerRunPruneResidue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SchedulerRunPruneResidue) ProtoMessage() {}
+
+func (x *SchedulerRunPruneResidue) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SchedulerRunPruneResidue.ProtoReflect.Descriptor instead.
+func (*SchedulerRunPruneResidue) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *SchedulerRunPruneResidue) GetLoaderId() string {
+	if x != nil {
+		return x.LoaderId
+	}
+	return ""
+}
+
+func (x *SchedulerRunPruneResidue) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *SchedulerRunPruneResidue) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *SchedulerRunPruneResidue) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+type PruneSchedulerRunsResponse struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	DryRun        bool                        `protobuf:"varint,1,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	Matched       *SchedulerRunPruneStats     `protobuf:"bytes,2,opt,name=matched,proto3" json:"matched,omitempty"`
+	Removed       *SchedulerRunPruneStats     `protobuf:"bytes,3,opt,name=removed,proto3" json:"removed,omitempty"`
+	SkippedRuns   uint64                      `protobuf:"varint,4,opt,name=skipped_runs,json=skippedRuns,proto3" json:"skipped_runs,omitempty"`
+	Residues      []*SchedulerRunPruneResidue `protobuf:"bytes,5,rep,name=residues,proto3" json:"residues,omitempty"`
+	Warnings      []string                    `protobuf:"bytes,6,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PruneSchedulerRunsResponse) Reset() {
+	*x = PruneSchedulerRunsResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PruneSchedulerRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PruneSchedulerRunsResponse) ProtoMessage() {}
+
+func (x *PruneSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PruneSchedulerRunsResponse.ProtoReflect.Descriptor instead.
+func (*PruneSchedulerRunsResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *PruneSchedulerRunsResponse) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+func (x *PruneSchedulerRunsResponse) GetMatched() *SchedulerRunPruneStats {
+	if x != nil {
+		return x.Matched
+	}
+	return nil
+}
+
+func (x *PruneSchedulerRunsResponse) GetRemoved() *SchedulerRunPruneStats {
+	if x != nil {
+		return x.Removed
+	}
+	return nil
+}
+
+func (x *PruneSchedulerRunsResponse) GetSkippedRuns() uint64 {
+	if x != nil {
+		return x.SkippedRuns
+	}
+	return 0
+}
+
+func (x *PruneSchedulerRunsResponse) GetResidues() []*SchedulerRunPruneResidue {
+	if x != nil {
+		return x.Residues
+	}
+	return nil
+}
+
+func (x *PruneSchedulerRunsResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
+
 type StopSchedulerRunRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
@@ -4204,7 +4524,7 @@ type StopSchedulerRunRequest struct {
 
 func (x *StopSchedulerRunRequest) Reset() {
 	*x = StopSchedulerRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4216,7 +4536,7 @@ func (x *StopSchedulerRunRequest) String() string {
 func (*StopSchedulerRunRequest) ProtoMessage() {}
 
 func (x *StopSchedulerRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[42]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4229,7 +4549,7 @@ func (x *StopSchedulerRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSchedulerRunRequest.ProtoReflect.Descriptor instead.
 func (*StopSchedulerRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{42}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *StopSchedulerRunRequest) GetProject() *ProjectRef {
@@ -4263,7 +4583,7 @@ type StopSchedulerRunResponse struct {
 
 func (x *StopSchedulerRunResponse) Reset() {
 	*x = StopSchedulerRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4275,7 +4595,7 @@ func (x *StopSchedulerRunResponse) String() string {
 func (*StopSchedulerRunResponse) ProtoMessage() {}
 
 func (x *StopSchedulerRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[43]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4288,7 +4608,7 @@ func (x *StopSchedulerRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSchedulerRunResponse.ProtoReflect.Descriptor instead.
 func (*StopSchedulerRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{43}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *StopSchedulerRunResponse) GetRun() *SchedulerRun {
@@ -4330,7 +4650,7 @@ type SchedulerRun struct {
 
 func (x *SchedulerRun) Reset() {
 	*x = SchedulerRun{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4342,7 +4662,7 @@ func (x *SchedulerRun) String() string {
 func (*SchedulerRun) ProtoMessage() {}
 
 func (x *SchedulerRun) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[44]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4355,7 +4675,7 @@ func (x *SchedulerRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerRun.ProtoReflect.Descriptor instead.
 func (*SchedulerRun) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{44}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *SchedulerRun) GetRunId() string {
@@ -4488,7 +4808,7 @@ type SetSchedulerEnabledRequest struct {
 
 func (x *SetSchedulerEnabledRequest) Reset() {
 	*x = SetSchedulerEnabledRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4500,7 +4820,7 @@ func (x *SetSchedulerEnabledRequest) String() string {
 func (*SetSchedulerEnabledRequest) ProtoMessage() {}
 
 func (x *SetSchedulerEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[45]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4513,7 +4833,7 @@ func (x *SetSchedulerEnabledRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSchedulerEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetSchedulerEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{45}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *SetSchedulerEnabledRequest) GetProject() *ProjectRef {
@@ -4547,7 +4867,7 @@ type SetSchedulerEnabledResponse struct {
 
 func (x *SetSchedulerEnabledResponse) Reset() {
 	*x = SetSchedulerEnabledResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4559,7 +4879,7 @@ func (x *SetSchedulerEnabledResponse) String() string {
 func (*SetSchedulerEnabledResponse) ProtoMessage() {}
 
 func (x *SetSchedulerEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[46]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4572,7 +4892,7 @@ func (x *SetSchedulerEnabledResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetSchedulerEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetSchedulerEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{46}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SetSchedulerEnabledResponse) GetScheduler() *ProjectScheduler {
@@ -4601,7 +4921,7 @@ type SetSchedulerTriggerEnabledRequest struct {
 
 func (x *SetSchedulerTriggerEnabledRequest) Reset() {
 	*x = SetSchedulerTriggerEnabledRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4613,7 +4933,7 @@ func (x *SetSchedulerTriggerEnabledRequest) String() string {
 func (*SetSchedulerTriggerEnabledRequest) ProtoMessage() {}
 
 func (x *SetSchedulerTriggerEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[47]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4626,7 +4946,7 @@ func (x *SetSchedulerTriggerEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetSchedulerTriggerEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetSchedulerTriggerEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{47}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *SetSchedulerTriggerEnabledRequest) GetProject() *ProjectRef {
@@ -4666,7 +4986,7 @@ type SetSchedulerTriggerEnabledResponse struct {
 
 func (x *SetSchedulerTriggerEnabledResponse) Reset() {
 	*x = SetSchedulerTriggerEnabledResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4678,7 +4998,7 @@ func (x *SetSchedulerTriggerEnabledResponse) String() string {
 func (*SetSchedulerTriggerEnabledResponse) ProtoMessage() {}
 
 func (x *SetSchedulerTriggerEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[48]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4691,7 +5011,7 @@ func (x *SetSchedulerTriggerEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetSchedulerTriggerEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetSchedulerTriggerEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{48}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *SetSchedulerTriggerEnabledResponse) GetTrigger() *ResolvedTrigger {
@@ -4712,7 +5032,7 @@ type ProjectValidationIssue struct {
 
 func (x *ProjectValidationIssue) Reset() {
 	*x = ProjectValidationIssue{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4724,7 +5044,7 @@ func (x *ProjectValidationIssue) String() string {
 func (*ProjectValidationIssue) ProtoMessage() {}
 
 func (x *ProjectValidationIssue) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[49]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4737,7 +5057,7 @@ func (x *ProjectValidationIssue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectValidationIssue.ProtoReflect.Descriptor instead.
 func (*ProjectValidationIssue) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{49}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ProjectValidationIssue) GetSeverity() ProjectValidationSeverity {
@@ -4774,7 +5094,7 @@ type ProjectChange struct {
 
 func (x *ProjectChange) Reset() {
 	*x = ProjectChange{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4786,7 +5106,7 @@ func (x *ProjectChange) String() string {
 func (*ProjectChange) ProtoMessage() {}
 
 func (x *ProjectChange) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[50]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4799,7 +5119,7 @@ func (x *ProjectChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectChange.ProtoReflect.Descriptor instead.
 func (*ProjectChange) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{50}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ProjectChange) GetAction() ProjectChangeAction {
@@ -4851,7 +5171,7 @@ type ProjectSpec struct {
 
 func (x *ProjectSpec) Reset() {
 	*x = ProjectSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4863,7 +5183,7 @@ func (x *ProjectSpec) String() string {
 func (*ProjectSpec) ProtoMessage() {}
 
 func (x *ProjectSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[51]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4876,7 +5196,7 @@ func (x *ProjectSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectSpec.ProtoReflect.Descriptor instead.
 func (*ProjectSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{51}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ProjectSpec) GetName() string {
@@ -4931,7 +5251,7 @@ type NamedWorkspaceSpec struct {
 
 func (x *NamedWorkspaceSpec) Reset() {
 	*x = NamedWorkspaceSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4943,7 +5263,7 @@ func (x *NamedWorkspaceSpec) String() string {
 func (*NamedWorkspaceSpec) ProtoMessage() {}
 
 func (x *NamedWorkspaceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[52]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4956,7 +5276,7 @@ func (x *NamedWorkspaceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamedWorkspaceSpec.ProtoReflect.Descriptor instead.
 func (*NamedWorkspaceSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{52}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *NamedWorkspaceSpec) GetName() string {
@@ -4999,7 +5319,7 @@ type AgentSpec struct {
 
 func (x *AgentSpec) Reset() {
 	*x = AgentSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5011,7 +5331,7 @@ func (x *AgentSpec) String() string {
 func (*AgentSpec) ProtoMessage() {}
 
 func (x *AgentSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[53]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5024,7 +5344,7 @@ func (x *AgentSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentSpec.ProtoReflect.Descriptor instead.
 func (*AgentSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{53}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *AgentSpec) GetName() string {
@@ -5169,7 +5489,7 @@ type MCPServerSpec struct {
 
 func (x *MCPServerSpec) Reset() {
 	*x = MCPServerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5181,7 +5501,7 @@ func (x *MCPServerSpec) String() string {
 func (*MCPServerSpec) ProtoMessage() {}
 
 func (x *MCPServerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[54]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5194,7 +5514,7 @@ func (x *MCPServerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MCPServerSpec.ProtoReflect.Descriptor instead.
 func (*MCPServerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{54}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *MCPServerSpec) GetName() string {
@@ -5267,7 +5587,7 @@ type ProjectVolumeSpec struct {
 
 func (x *ProjectVolumeSpec) Reset() {
 	*x = ProjectVolumeSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5279,7 +5599,7 @@ func (x *ProjectVolumeSpec) String() string {
 func (*ProjectVolumeSpec) ProtoMessage() {}
 
 func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[55]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5292,7 +5612,7 @@ func (x *ProjectVolumeSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectVolumeSpec.ProtoReflect.Descriptor instead.
 func (*ProjectVolumeSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{55}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ProjectVolumeSpec) GetKey() string {
@@ -5349,7 +5669,7 @@ type VolumeMountSpec struct {
 
 func (x *VolumeMountSpec) Reset() {
 	*x = VolumeMountSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5361,7 +5681,7 @@ func (x *VolumeMountSpec) String() string {
 func (*VolumeMountSpec) ProtoMessage() {}
 
 func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[56]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5374,7 +5694,7 @@ func (x *VolumeMountSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeMountSpec.ProtoReflect.Descriptor instead.
 func (*VolumeMountSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{56}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *VolumeMountSpec) GetType() string {
@@ -5421,7 +5741,7 @@ type BuildSpec struct {
 
 func (x *BuildSpec) Reset() {
 	*x = BuildSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5433,7 +5753,7 @@ func (x *BuildSpec) String() string {
 func (*BuildSpec) ProtoMessage() {}
 
 func (x *BuildSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[57]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5446,7 +5766,7 @@ func (x *BuildSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildSpec.ProtoReflect.Descriptor instead.
 func (*BuildSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{57}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *BuildSpec) GetContext() string {
@@ -5516,7 +5836,7 @@ type EnvVarSpec struct {
 
 func (x *EnvVarSpec) Reset() {
 	*x = EnvVarSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5528,7 +5848,7 @@ func (x *EnvVarSpec) String() string {
 func (*EnvVarSpec) ProtoMessage() {}
 
 func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[58]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5541,7 +5861,7 @@ func (x *EnvVarSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVarSpec.ProtoReflect.Descriptor instead.
 func (*EnvVarSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{58}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *EnvVarSpec) GetName() string {
@@ -5576,7 +5896,7 @@ type EnvVarUpdateSpec struct {
 
 func (x *EnvVarUpdateSpec) Reset() {
 	*x = EnvVarUpdateSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5588,7 +5908,7 @@ func (x *EnvVarUpdateSpec) String() string {
 func (*EnvVarUpdateSpec) ProtoMessage() {}
 
 func (x *EnvVarUpdateSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[59]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5601,7 +5921,7 @@ func (x *EnvVarUpdateSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvVarUpdateSpec.ProtoReflect.Descriptor instead.
 func (*EnvVarUpdateSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{59}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *EnvVarUpdateSpec) GetName() string {
@@ -5643,7 +5963,7 @@ type WorkspaceSpec struct {
 
 func (x *WorkspaceSpec) Reset() {
 	*x = WorkspaceSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5655,7 +5975,7 @@ func (x *WorkspaceSpec) String() string {
 func (*WorkspaceSpec) ProtoMessage() {}
 
 func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[60]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5668,7 +5988,7 @@ func (x *WorkspaceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspaceSpec.ProtoReflect.Descriptor instead.
 func (*WorkspaceSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{60}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *WorkspaceSpec) GetProvider() string {
@@ -5755,7 +6075,7 @@ type SchedulerSpec struct {
 
 func (x *SchedulerSpec) Reset() {
 	*x = SchedulerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5767,7 +6087,7 @@ func (x *SchedulerSpec) String() string {
 func (*SchedulerSpec) ProtoMessage() {}
 
 func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[61]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5780,7 +6100,7 @@ func (x *SchedulerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerSpec.ProtoReflect.Descriptor instead.
 func (*SchedulerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{61}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *SchedulerSpec) GetEnabled() bool {
@@ -5841,7 +6161,7 @@ type TriggerSpec struct {
 
 func (x *TriggerSpec) Reset() {
 	*x = TriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5853,7 +6173,7 @@ func (x *TriggerSpec) String() string {
 func (*TriggerSpec) ProtoMessage() {}
 
 func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[62]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5866,7 +6186,7 @@ func (x *TriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerSpec.ProtoReflect.Descriptor instead.
 func (*TriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{62}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *TriggerSpec) GetName() string {
@@ -5934,7 +6254,7 @@ type EventTriggerSpec struct {
 
 func (x *EventTriggerSpec) Reset() {
 	*x = EventTriggerSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5946,7 +6266,7 @@ func (x *EventTriggerSpec) String() string {
 func (*EventTriggerSpec) ProtoMessage() {}
 
 func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[63]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5959,7 +6279,7 @@ func (x *EventTriggerSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventTriggerSpec.ProtoReflect.Descriptor instead.
 func (*EventTriggerSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{63}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *EventTriggerSpec) GetTopic() string {
@@ -5981,7 +6301,7 @@ type DriverSpec struct {
 
 func (x *DriverSpec) Reset() {
 	*x = DriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5993,7 +6313,7 @@ func (x *DriverSpec) String() string {
 func (*DriverSpec) ProtoMessage() {}
 
 func (x *DriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[64]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6006,7 +6326,7 @@ func (x *DriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DriverSpec.ProtoReflect.Descriptor instead.
 func (*DriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{64}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *DriverSpec) GetName() string {
@@ -6047,7 +6367,7 @@ type BoxliteDriverSpec struct {
 
 func (x *BoxliteDriverSpec) Reset() {
 	*x = BoxliteDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6059,7 +6379,7 @@ func (x *BoxliteDriverSpec) String() string {
 func (*BoxliteDriverSpec) ProtoMessage() {}
 
 func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[65]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6072,7 +6392,7 @@ func (x *BoxliteDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoxliteDriverSpec.ProtoReflect.Descriptor instead.
 func (*BoxliteDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{65}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *BoxliteDriverSpec) GetKernel() string {
@@ -6098,7 +6418,7 @@ type DockerDriverSpec struct {
 
 func (x *DockerDriverSpec) Reset() {
 	*x = DockerDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6110,7 +6430,7 @@ func (x *DockerDriverSpec) String() string {
 func (*DockerDriverSpec) ProtoMessage() {}
 
 func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[66]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6123,7 +6443,7 @@ func (x *DockerDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerDriverSpec.ProtoReflect.Descriptor instead.
 func (*DockerDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{66}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *DockerDriverSpec) GetHost() string {
@@ -6142,7 +6462,7 @@ type MicrosandboxDriverSpec struct {
 
 func (x *MicrosandboxDriverSpec) Reset() {
 	*x = MicrosandboxDriverSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6154,7 +6474,7 @@ func (x *MicrosandboxDriverSpec) String() string {
 func (*MicrosandboxDriverSpec) ProtoMessage() {}
 
 func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[67]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6167,7 +6487,7 @@ func (x *MicrosandboxDriverSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosandboxDriverSpec.ProtoReflect.Descriptor instead.
 func (*MicrosandboxDriverSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{67}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *MicrosandboxDriverSpec) GetProfile() string {
@@ -6201,7 +6521,7 @@ type RunAgentRequest struct {
 
 func (x *RunAgentRequest) Reset() {
 	*x = RunAgentRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6213,7 +6533,7 @@ func (x *RunAgentRequest) String() string {
 func (*RunAgentRequest) ProtoMessage() {}
 
 func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[68]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6226,7 +6546,7 @@ func (x *RunAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentRequest.ProtoReflect.Descriptor instead.
 func (*RunAgentRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{68}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *RunAgentRequest) GetProjectId() string {
@@ -6351,7 +6671,7 @@ type RunAgentResponse struct {
 
 func (x *RunAgentResponse) Reset() {
 	*x = RunAgentResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6363,7 +6683,7 @@ func (x *RunAgentResponse) String() string {
 func (*RunAgentResponse) ProtoMessage() {}
 
 func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[69]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6376,7 +6696,7 @@ func (x *RunAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *RunAgentResponse) GetRun() *RunDetail {
@@ -6409,7 +6729,7 @@ type RunAgentStreamResponse struct {
 
 func (x *RunAgentStreamResponse) Reset() {
 	*x = RunAgentStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6421,7 +6741,7 @@ func (x *RunAgentStreamResponse) String() string {
 func (*RunAgentStreamResponse) ProtoMessage() {}
 
 func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[70]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6434,7 +6754,7 @@ func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAgentStreamResponse.ProtoReflect.Descriptor instead.
 func (*RunAgentStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{70}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *RunAgentStreamResponse) GetEventType() RunAgentStreamEventType {
@@ -6512,7 +6832,7 @@ type RunAttachRequest struct {
 
 func (x *RunAttachRequest) Reset() {
 	*x = RunAttachRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6524,7 +6844,7 @@ func (x *RunAttachRequest) String() string {
 func (*RunAttachRequest) ProtoMessage() {}
 
 func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[71]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6537,7 +6857,7 @@ func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachRequest.ProtoReflect.Descriptor instead.
 func (*RunAttachRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{71}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *RunAttachRequest) GetClientFrameId() string {
@@ -6682,7 +7002,7 @@ type RunAttachResponse struct {
 
 func (x *RunAttachResponse) Reset() {
 	*x = RunAttachResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6694,7 +7014,7 @@ func (x *RunAttachResponse) String() string {
 func (*RunAttachResponse) ProtoMessage() {}
 
 func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[72]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6707,7 +7027,7 @@ func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachResponse.ProtoReflect.Descriptor instead.
 func (*RunAttachResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{72}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *RunAttachResponse) GetServerFrameId() string {
@@ -6838,7 +7158,7 @@ type RunAttachStart struct {
 
 func (x *RunAttachStart) Reset() {
 	*x = RunAttachStart{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6850,7 +7170,7 @@ func (x *RunAttachStart) String() string {
 func (*RunAttachStart) ProtoMessage() {}
 
 func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[73]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6863,7 +7183,7 @@ func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunAttachStart.ProtoReflect.Descriptor instead.
 func (*RunAttachStart) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{73}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *RunAttachStart) GetRequest() *RunAgentRequest {
@@ -6914,7 +7234,7 @@ type TranscriptEvent struct {
 
 func (x *TranscriptEvent) Reset() {
 	*x = TranscriptEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6926,7 +7246,7 @@ func (x *TranscriptEvent) String() string {
 func (*TranscriptEvent) ProtoMessage() {}
 
 func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[74]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6939,7 +7259,7 @@ func (x *TranscriptEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TranscriptEvent.ProtoReflect.Descriptor instead.
 func (*TranscriptEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{74}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *TranscriptEvent) GetStream() StdioStream {
@@ -6987,7 +7307,7 @@ type GetRunRequest struct {
 
 func (x *GetRunRequest) Reset() {
 	*x = GetRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6999,7 +7319,7 @@ func (x *GetRunRequest) String() string {
 func (*GetRunRequest) ProtoMessage() {}
 
 func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7012,7 +7332,7 @@ func (x *GetRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunRequest.ProtoReflect.Descriptor instead.
 func (*GetRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *GetRunRequest) GetRunId() string {
@@ -7038,7 +7358,7 @@ type GetRunResponse struct {
 
 func (x *GetRunResponse) Reset() {
 	*x = GetRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7050,7 +7370,7 @@ func (x *GetRunResponse) String() string {
 func (*GetRunResponse) ProtoMessage() {}
 
 func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7063,7 +7383,7 @@ func (x *GetRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRunResponse.ProtoReflect.Descriptor instead.
 func (*GetRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *GetRunResponse) GetRun() *RunDetail {
@@ -7091,7 +7411,7 @@ type ListRunsRequest struct {
 
 func (x *ListRunsRequest) Reset() {
 	*x = ListRunsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7103,7 +7423,7 @@ func (x *ListRunsRequest) String() string {
 func (*ListRunsRequest) ProtoMessage() {}
 
 func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7116,7 +7436,7 @@ func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ListRunsRequest) GetProjectId() string {
@@ -7198,7 +7518,7 @@ type ListRunsResponse struct {
 
 func (x *ListRunsResponse) Reset() {
 	*x = ListRunsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7210,7 +7530,7 @@ func (x *ListRunsResponse) String() string {
 func (*ListRunsResponse) ProtoMessage() {}
 
 func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7223,7 +7543,7 @@ func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ListRunsResponse) GetRuns() []*RunSummary {
@@ -7246,7 +7566,7 @@ type FollowRunLogsRequest struct {
 
 func (x *FollowRunLogsRequest) Reset() {
 	*x = FollowRunLogsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7258,7 +7578,7 @@ func (x *FollowRunLogsRequest) String() string {
 func (*FollowRunLogsRequest) ProtoMessage() {}
 
 func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[79]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7271,7 +7591,7 @@ func (x *FollowRunLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FollowRunLogsRequest.ProtoReflect.Descriptor instead.
 func (*FollowRunLogsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{79}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *FollowRunLogsRequest) GetProjectId() string {
@@ -7322,7 +7642,7 @@ type RunLogChunk struct {
 
 func (x *RunLogChunk) Reset() {
 	*x = RunLogChunk{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7334,7 +7654,7 @@ func (x *RunLogChunk) String() string {
 func (*RunLogChunk) ProtoMessage() {}
 
 func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[80]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7347,7 +7667,7 @@ func (x *RunLogChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunLogChunk.ProtoReflect.Descriptor instead.
 func (*RunLogChunk) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{80}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *RunLogChunk) GetData() string {
@@ -7395,7 +7715,7 @@ type StopRunRequest struct {
 
 func (x *StopRunRequest) Reset() {
 	*x = StopRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7407,7 +7727,7 @@ func (x *StopRunRequest) String() string {
 func (*StopRunRequest) ProtoMessage() {}
 
 func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[81]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7420,7 +7740,7 @@ func (x *StopRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunRequest.ProtoReflect.Descriptor instead.
 func (*StopRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{81}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *StopRunRequest) GetRunId() string {
@@ -7447,7 +7767,7 @@ type StopRunResponse struct {
 
 func (x *StopRunResponse) Reset() {
 	*x = StopRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7459,7 +7779,7 @@ func (x *StopRunResponse) String() string {
 func (*StopRunResponse) ProtoMessage() {}
 
 func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[82]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7472,7 +7792,7 @@ func (x *StopRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRunResponse.ProtoReflect.Descriptor instead.
 func (*StopRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{82}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *StopRunResponse) GetRun() *RunDetail {
@@ -7500,7 +7820,7 @@ type ListRunEventsRequest struct {
 
 func (x *ListRunEventsRequest) Reset() {
 	*x = ListRunEventsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7512,7 +7832,7 @@ func (x *ListRunEventsRequest) String() string {
 func (*ListRunEventsRequest) ProtoMessage() {}
 
 func (x *ListRunEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[83]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7525,7 +7845,7 @@ func (x *ListRunEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunEventsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunEventsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{83}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *ListRunEventsRequest) GetRunId() string {
@@ -7569,7 +7889,7 @@ type RunEvent struct {
 
 func (x *RunEvent) Reset() {
 	*x = RunEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7581,7 +7901,7 @@ func (x *RunEvent) String() string {
 func (*RunEvent) ProtoMessage() {}
 
 func (x *RunEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[84]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7594,7 +7914,7 @@ func (x *RunEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunEvent.ProtoReflect.Descriptor instead.
 func (*RunEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{84}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *RunEvent) GetId() string {
@@ -7692,7 +8012,7 @@ type ListRunEventsResponse struct {
 
 func (x *ListRunEventsResponse) Reset() {
 	*x = ListRunEventsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7704,7 +8024,7 @@ func (x *ListRunEventsResponse) String() string {
 func (*ListRunEventsResponse) ProtoMessage() {}
 
 func (x *ListRunEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[85]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7717,7 +8037,7 @@ func (x *ListRunEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunEventsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunEventsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{85}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *ListRunEventsResponse) GetEvents() []*RunEvent {
@@ -7752,7 +8072,7 @@ type ListSandboxRunEventsRequest struct {
 
 func (x *ListSandboxRunEventsRequest) Reset() {
 	*x = ListSandboxRunEventsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7764,7 +8084,7 @@ func (x *ListSandboxRunEventsRequest) String() string {
 func (*ListSandboxRunEventsRequest) ProtoMessage() {}
 
 func (x *ListSandboxRunEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[86]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7777,7 +8097,7 @@ func (x *ListSandboxRunEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxRunEventsRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxRunEventsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{86}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ListSandboxRunEventsRequest) GetSandboxId() string {
@@ -7812,7 +8132,7 @@ type ListSandboxRunEventsResponse struct {
 
 func (x *ListSandboxRunEventsResponse) Reset() {
 	*x = ListSandboxRunEventsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7824,7 +8144,7 @@ func (x *ListSandboxRunEventsResponse) String() string {
 func (*ListSandboxRunEventsResponse) ProtoMessage() {}
 
 func (x *ListSandboxRunEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[87]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7837,7 +8157,7 @@ func (x *ListSandboxRunEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxRunEventsResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxRunEventsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{87}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *ListSandboxRunEventsResponse) GetEvents() []*RunEvent {
@@ -7871,7 +8191,7 @@ type RemoveSandboxRequest struct {
 
 func (x *RemoveSandboxRequest) Reset() {
 	*x = RemoveSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7883,7 +8203,7 @@ func (x *RemoveSandboxRequest) String() string {
 func (*RemoveSandboxRequest) ProtoMessage() {}
 
 func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[88]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7896,7 +8216,7 @@ func (x *RemoveSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{88}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *RemoveSandboxRequest) GetSandboxId() string {
@@ -7924,7 +8244,7 @@ type RemoveSandboxResponse struct {
 
 func (x *RemoveSandboxResponse) Reset() {
 	*x = RemoveSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7936,7 +8256,7 @@ func (x *RemoveSandboxResponse) String() string {
 func (*RemoveSandboxResponse) ProtoMessage() {}
 
 func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[89]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7949,7 +8269,7 @@ func (x *RemoveSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSandboxResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{89}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *RemoveSandboxResponse) GetSandboxId() string {
@@ -7988,7 +8308,7 @@ type PruneSandboxesRequest struct {
 
 func (x *PruneSandboxesRequest) Reset() {
 	*x = PruneSandboxesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8000,7 +8320,7 @@ func (x *PruneSandboxesRequest) String() string {
 func (*PruneSandboxesRequest) ProtoMessage() {}
 
 func (x *PruneSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[90]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8013,7 +8333,7 @@ func (x *PruneSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*PruneSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{90}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *PruneSandboxesRequest) GetProjectId() string {
@@ -8083,7 +8403,7 @@ type SandboxPruneCandidate struct {
 
 func (x *SandboxPruneCandidate) Reset() {
 	*x = SandboxPruneCandidate{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8095,7 +8415,7 @@ func (x *SandboxPruneCandidate) String() string {
 func (*SandboxPruneCandidate) ProtoMessage() {}
 
 func (x *SandboxPruneCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[91]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8108,7 +8428,7 @@ func (x *SandboxPruneCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxPruneCandidate.ProtoReflect.Descriptor instead.
 func (*SandboxPruneCandidate) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{91}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *SandboxPruneCandidate) GetKind() SandboxPruneCandidateKind {
@@ -8194,7 +8514,7 @@ type PruneSandboxesResponse struct {
 
 func (x *PruneSandboxesResponse) Reset() {
 	*x = PruneSandboxesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8206,7 +8526,7 @@ func (x *PruneSandboxesResponse) String() string {
 func (*PruneSandboxesResponse) ProtoMessage() {}
 
 func (x *PruneSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[92]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8219,7 +8539,7 @@ func (x *PruneSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*PruneSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{92}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *PruneSandboxesResponse) GetDryRun() bool {
@@ -8266,7 +8586,7 @@ type GetSandboxStatsRequest struct {
 
 func (x *GetSandboxStatsRequest) Reset() {
 	*x = GetSandboxStatsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8278,7 +8598,7 @@ func (x *GetSandboxStatsRequest) String() string {
 func (*GetSandboxStatsRequest) ProtoMessage() {}
 
 func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[93]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8291,7 +8611,7 @@ func (x *GetSandboxStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{93}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *GetSandboxStatsRequest) GetSandboxId() string {
@@ -8310,7 +8630,7 @@ type GetSandboxStatsResponse struct {
 
 func (x *GetSandboxStatsResponse) Reset() {
 	*x = GetSandboxStatsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8322,7 +8642,7 @@ func (x *GetSandboxStatsResponse) String() string {
 func (*GetSandboxStatsResponse) ProtoMessage() {}
 
 func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[94]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8335,7 +8655,7 @@ func (x *GetSandboxStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxStatsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{94}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *GetSandboxStatsResponse) GetStats() *SandboxStats {
@@ -8354,7 +8674,7 @@ type GetSandboxRequest struct {
 
 func (x *GetSandboxRequest) Reset() {
 	*x = GetSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8366,7 +8686,7 @@ func (x *GetSandboxRequest) String() string {
 func (*GetSandboxRequest) ProtoMessage() {}
 
 func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[95]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8379,7 +8699,7 @@ func (x *GetSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{95}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *GetSandboxRequest) GetSandboxId() string {
@@ -8417,7 +8737,7 @@ type Sandbox struct {
 
 func (x *Sandbox) Reset() {
 	*x = Sandbox{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8429,7 +8749,7 @@ func (x *Sandbox) String() string {
 func (*Sandbox) ProtoMessage() {}
 
 func (x *Sandbox) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[96]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8442,7 +8762,7 @@ func (x *Sandbox) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sandbox.ProtoReflect.Descriptor instead.
 func (*Sandbox) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{96}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *Sandbox) GetSandboxId() string {
@@ -8595,7 +8915,7 @@ type SandboxTag struct {
 
 func (x *SandboxTag) Reset() {
 	*x = SandboxTag{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8607,7 +8927,7 @@ func (x *SandboxTag) String() string {
 func (*SandboxTag) ProtoMessage() {}
 
 func (x *SandboxTag) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[97]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8620,7 +8940,7 @@ func (x *SandboxTag) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxTag.ProtoReflect.Descriptor instead.
 func (*SandboxTag) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{97}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *SandboxTag) GetName() string {
@@ -8647,7 +8967,7 @@ type ListSandboxesRequest struct {
 
 func (x *ListSandboxesRequest) Reset() {
 	*x = ListSandboxesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8659,7 +8979,7 @@ func (x *ListSandboxesRequest) String() string {
 func (*ListSandboxesRequest) ProtoMessage() {}
 
 func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[98]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8672,7 +8992,7 @@ func (x *ListSandboxesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{98}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *ListSandboxesRequest) GetLimit() uint32 {
@@ -8699,7 +9019,7 @@ type ListSandboxesResponse struct {
 
 func (x *ListSandboxesResponse) Reset() {
 	*x = ListSandboxesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8711,7 +9031,7 @@ func (x *ListSandboxesResponse) String() string {
 func (*ListSandboxesResponse) ProtoMessage() {}
 
 func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[99]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8724,7 +9044,7 @@ func (x *ListSandboxesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxesResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{99}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *ListSandboxesResponse) GetSandboxes() []*Sandbox {
@@ -8750,7 +9070,7 @@ type GetSandboxResponse struct {
 
 func (x *GetSandboxResponse) Reset() {
 	*x = GetSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8762,7 +9082,7 @@ func (x *GetSandboxResponse) String() string {
 func (*GetSandboxResponse) ProtoMessage() {}
 
 func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[100]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8775,7 +9095,7 @@ func (x *GetSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{100}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *GetSandboxResponse) GetSandbox() *Sandbox {
@@ -8794,7 +9114,7 @@ type StopSandboxRequest struct {
 
 func (x *StopSandboxRequest) Reset() {
 	*x = StopSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8806,7 +9126,7 @@ func (x *StopSandboxRequest) String() string {
 func (*StopSandboxRequest) ProtoMessage() {}
 
 func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[101]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8819,7 +9139,7 @@ func (x *StopSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSandboxRequest.ProtoReflect.Descriptor instead.
 func (*StopSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{101}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *StopSandboxRequest) GetSandboxId() string {
@@ -8838,7 +9158,7 @@ type StopSandboxResponse struct {
 
 func (x *StopSandboxResponse) Reset() {
 	*x = StopSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8850,7 +9170,7 @@ func (x *StopSandboxResponse) String() string {
 func (*StopSandboxResponse) ProtoMessage() {}
 
 func (x *StopSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[102]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8863,7 +9183,7 @@ func (x *StopSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopSandboxResponse.ProtoReflect.Descriptor instead.
 func (*StopSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{102}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *StopSandboxResponse) GetSandbox() *Sandbox {
@@ -8882,7 +9202,7 @@ type ResumeSandboxRequest struct {
 
 func (x *ResumeSandboxRequest) Reset() {
 	*x = ResumeSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8894,7 +9214,7 @@ func (x *ResumeSandboxRequest) String() string {
 func (*ResumeSandboxRequest) ProtoMessage() {}
 
 func (x *ResumeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[103]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8907,7 +9227,7 @@ func (x *ResumeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*ResumeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{103}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *ResumeSandboxRequest) GetSandboxId() string {
@@ -8926,7 +9246,7 @@ type ResumeSandboxResponse struct {
 
 func (x *ResumeSandboxResponse) Reset() {
 	*x = ResumeSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8938,7 +9258,7 @@ func (x *ResumeSandboxResponse) String() string {
 func (*ResumeSandboxResponse) ProtoMessage() {}
 
 func (x *ResumeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[104]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8951,7 +9271,7 @@ func (x *ResumeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*ResumeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{104}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *ResumeSandboxResponse) GetSandbox() *Sandbox {
@@ -8973,7 +9293,7 @@ type MetricValue struct {
 
 func (x *MetricValue) Reset() {
 	*x = MetricValue{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8985,7 +9305,7 @@ func (x *MetricValue) String() string {
 func (*MetricValue) ProtoMessage() {}
 
 func (x *MetricValue) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[105]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8998,7 +9318,7 @@ func (x *MetricValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetricValue.ProtoReflect.Descriptor instead.
 func (*MetricValue) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{105}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *MetricValue) GetValue() float64 {
@@ -9049,7 +9369,7 @@ type SandboxStats struct {
 
 func (x *SandboxStats) Reset() {
 	*x = SandboxStats{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9061,7 +9381,7 @@ func (x *SandboxStats) String() string {
 func (*SandboxStats) ProtoMessage() {}
 
 func (x *SandboxStats) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[106]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9074,7 +9394,7 @@ func (x *SandboxStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStats.ProtoReflect.Descriptor instead.
 func (*SandboxStats) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{106}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *SandboxStats) GetSandboxId() string {
@@ -9190,7 +9510,7 @@ type RunSummary struct {
 
 func (x *RunSummary) Reset() {
 	*x = RunSummary{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9202,7 +9522,7 @@ func (x *RunSummary) String() string {
 func (*RunSummary) ProtoMessage() {}
 
 func (x *RunSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[107]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9215,7 +9535,7 @@ func (x *RunSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSummary.ProtoReflect.Descriptor instead.
 func (*RunSummary) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{107}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *RunSummary) GetRunId() string {
@@ -9383,7 +9703,7 @@ type RunDetail struct {
 
 func (x *RunDetail) Reset() {
 	*x = RunDetail{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9395,7 +9715,7 @@ func (x *RunDetail) String() string {
 func (*RunDetail) ProtoMessage() {}
 
 func (x *RunDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[108]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9408,7 +9728,7 @@ func (x *RunDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunDetail.ProtoReflect.Descriptor instead.
 func (*RunDetail) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{108}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *RunDetail) GetSummary() *RunSummary {
@@ -9500,7 +9820,7 @@ type ExecRequest struct {
 
 func (x *ExecRequest) Reset() {
 	*x = ExecRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9512,7 +9832,7 @@ func (x *ExecRequest) String() string {
 func (*ExecRequest) ProtoMessage() {}
 
 func (x *ExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[109]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9525,7 +9845,7 @@ func (x *ExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecRequest.ProtoReflect.Descriptor instead.
 func (*ExecRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{109}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *ExecRequest) GetTarget() isExecRequest_Target {
@@ -9630,7 +9950,7 @@ type ExecSandboxSelector struct {
 
 func (x *ExecSandboxSelector) Reset() {
 	*x = ExecSandboxSelector{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9642,7 +9962,7 @@ func (x *ExecSandboxSelector) String() string {
 func (*ExecSandboxSelector) ProtoMessage() {}
 
 func (x *ExecSandboxSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[110]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9655,7 +9975,7 @@ func (x *ExecSandboxSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSandboxSelector.ProtoReflect.Descriptor instead.
 func (*ExecSandboxSelector) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{110}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *ExecSandboxSelector) GetProjectId() string {
@@ -9689,7 +10009,7 @@ type ExecCommand struct {
 
 func (x *ExecCommand) Reset() {
 	*x = ExecCommand{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9701,7 +10021,7 @@ func (x *ExecCommand) String() string {
 func (*ExecCommand) ProtoMessage() {}
 
 func (x *ExecCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[111]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9714,7 +10034,7 @@ func (x *ExecCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecCommand.ProtoReflect.Descriptor instead.
 func (*ExecCommand) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{111}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *ExecCommand) GetCommand() string {
@@ -9740,7 +10060,7 @@ type ExecResponse struct {
 
 func (x *ExecResponse) Reset() {
 	*x = ExecResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9752,7 +10072,7 @@ func (x *ExecResponse) String() string {
 func (*ExecResponse) ProtoMessage() {}
 
 func (x *ExecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[112]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9765,7 +10085,7 @@ func (x *ExecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResponse.ProtoReflect.Descriptor instead.
 func (*ExecResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{112}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *ExecResponse) GetResult() *ExecResult {
@@ -9791,7 +10111,7 @@ type ExecStreamResponse struct {
 
 func (x *ExecStreamResponse) Reset() {
 	*x = ExecStreamResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9803,7 +10123,7 @@ func (x *ExecStreamResponse) String() string {
 func (*ExecStreamResponse) ProtoMessage() {}
 
 func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[113]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9816,7 +10136,7 @@ func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecStreamResponse.ProtoReflect.Descriptor instead.
 func (*ExecStreamResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{113}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *ExecStreamResponse) GetEventType() ExecStreamEventType {
@@ -9894,7 +10214,7 @@ type ExecAttachRequest struct {
 
 func (x *ExecAttachRequest) Reset() {
 	*x = ExecAttachRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9906,7 +10226,7 @@ func (x *ExecAttachRequest) String() string {
 func (*ExecAttachRequest) ProtoMessage() {}
 
 func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[114]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9919,7 +10239,7 @@ func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachRequest.ProtoReflect.Descriptor instead.
 func (*ExecAttachRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{114}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *ExecAttachRequest) GetClientFrameId() string {
@@ -10064,7 +10384,7 @@ type ExecAttachResponse struct {
 
 func (x *ExecAttachResponse) Reset() {
 	*x = ExecAttachResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10076,7 +10396,7 @@ func (x *ExecAttachResponse) String() string {
 func (*ExecAttachResponse) ProtoMessage() {}
 
 func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[115]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10089,7 +10409,7 @@ func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachResponse.ProtoReflect.Descriptor instead.
 func (*ExecAttachResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{115}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *ExecAttachResponse) GetServerFrameId() string {
@@ -10221,7 +10541,7 @@ type ExecAttachStart struct {
 
 func (x *ExecAttachStart) Reset() {
 	*x = ExecAttachStart{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10233,7 +10553,7 @@ func (x *ExecAttachStart) String() string {
 func (*ExecAttachStart) ProtoMessage() {}
 
 func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[116]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10246,7 +10566,7 @@ func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecAttachStart.ProtoReflect.Descriptor instead.
 func (*ExecAttachStart) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{116}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *ExecAttachStart) GetRequest() *ExecRequest {
@@ -10301,7 +10621,7 @@ type AttachTerminalSize struct {
 
 func (x *AttachTerminalSize) Reset() {
 	*x = AttachTerminalSize{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10313,7 +10633,7 @@ func (x *AttachTerminalSize) String() string {
 func (*AttachTerminalSize) ProtoMessage() {}
 
 func (x *AttachTerminalSize) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[117]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10326,7 +10646,7 @@ func (x *AttachTerminalSize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachTerminalSize.ProtoReflect.Descriptor instead.
 func (*AttachTerminalSize) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{117}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *AttachTerminalSize) GetRows() uint32 {
@@ -10352,7 +10672,7 @@ type AttachStdin struct {
 
 func (x *AttachStdin) Reset() {
 	*x = AttachStdin{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10364,7 +10684,7 @@ func (x *AttachStdin) String() string {
 func (*AttachStdin) ProtoMessage() {}
 
 func (x *AttachStdin) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10377,7 +10697,7 @@ func (x *AttachStdin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStdin.ProtoReflect.Descriptor instead.
 func (*AttachStdin) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{118}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *AttachStdin) GetData() []byte {
@@ -10395,7 +10715,7 @@ type AttachStdinEOF struct {
 
 func (x *AttachStdinEOF) Reset() {
 	*x = AttachStdinEOF{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10407,7 +10727,7 @@ func (x *AttachStdinEOF) String() string {
 func (*AttachStdinEOF) ProtoMessage() {}
 
 func (x *AttachStdinEOF) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10420,7 +10740,7 @@ func (x *AttachStdinEOF) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStdinEOF.ProtoReflect.Descriptor instead.
 func (*AttachStdinEOF) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{119}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{123}
 }
 
 type AttachResize struct {
@@ -10432,7 +10752,7 @@ type AttachResize struct {
 
 func (x *AttachResize) Reset() {
 	*x = AttachResize{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10444,7 +10764,7 @@ func (x *AttachResize) String() string {
 func (*AttachResize) ProtoMessage() {}
 
 func (x *AttachResize) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10457,7 +10777,7 @@ func (x *AttachResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachResize.ProtoReflect.Descriptor instead.
 func (*AttachResize) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{120}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *AttachResize) GetTerminalSize() *AttachTerminalSize {
@@ -10476,7 +10796,7 @@ type AttachSignal struct {
 
 func (x *AttachSignal) Reset() {
 	*x = AttachSignal{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10488,7 +10808,7 @@ func (x *AttachSignal) String() string {
 func (*AttachSignal) ProtoMessage() {}
 
 func (x *AttachSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10501,7 +10821,7 @@ func (x *AttachSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachSignal.ProtoReflect.Descriptor instead.
 func (*AttachSignal) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{121}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *AttachSignal) GetSignal() string {
@@ -10521,7 +10841,7 @@ type AttachHumanMessage struct {
 
 func (x *AttachHumanMessage) Reset() {
 	*x = AttachHumanMessage{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10533,7 +10853,7 @@ func (x *AttachHumanMessage) String() string {
 func (*AttachHumanMessage) ProtoMessage() {}
 
 func (x *AttachHumanMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[122]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10546,7 +10866,7 @@ func (x *AttachHumanMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachHumanMessage.ProtoReflect.Descriptor instead.
 func (*AttachHumanMessage) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{122}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *AttachHumanMessage) GetText() string {
@@ -10572,7 +10892,7 @@ type AttachCancel struct {
 
 func (x *AttachCancel) Reset() {
 	*x = AttachCancel{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10584,7 +10904,7 @@ func (x *AttachCancel) String() string {
 func (*AttachCancel) ProtoMessage() {}
 
 func (x *AttachCancel) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[123]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10597,7 +10917,7 @@ func (x *AttachCancel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachCancel.ProtoReflect.Descriptor instead.
 func (*AttachCancel) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{123}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *AttachCancel) GetReason() string {
@@ -10621,7 +10941,7 @@ type AttachStarted struct {
 
 func (x *AttachStarted) Reset() {
 	*x = AttachStarted{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10633,7 +10953,7 @@ func (x *AttachStarted) String() string {
 func (*AttachStarted) ProtoMessage() {}
 
 func (x *AttachStarted) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[124]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10646,7 +10966,7 @@ func (x *AttachStarted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachStarted.ProtoReflect.Descriptor instead.
 func (*AttachStarted) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{124}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *AttachStarted) GetOperationId() string {
@@ -10703,7 +11023,7 @@ type AttachOutput struct {
 
 func (x *AttachOutput) Reset() {
 	*x = AttachOutput{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10715,7 +11035,7 @@ func (x *AttachOutput) String() string {
 func (*AttachOutput) ProtoMessage() {}
 
 func (x *AttachOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[125]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10728,7 +11048,7 @@ func (x *AttachOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachOutput.ProtoReflect.Descriptor instead.
 func (*AttachOutput) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{125}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *AttachOutput) GetData() []byte {
@@ -10771,7 +11091,7 @@ type AttachAgentEvent struct {
 
 func (x *AttachAgentEvent) Reset() {
 	*x = AttachAgentEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10783,7 +11103,7 @@ func (x *AttachAgentEvent) String() string {
 func (*AttachAgentEvent) ProtoMessage() {}
 
 func (x *AttachAgentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[126]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10796,7 +11116,7 @@ func (x *AttachAgentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachAgentEvent.ProtoReflect.Descriptor instead.
 func (*AttachAgentEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{126}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *AttachAgentEvent) GetName() string {
@@ -10838,7 +11158,7 @@ type AttachAgentTurnCompleted struct {
 
 func (x *AttachAgentTurnCompleted) Reset() {
 	*x = AttachAgentTurnCompleted{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10850,7 +11170,7 @@ func (x *AttachAgentTurnCompleted) String() string {
 func (*AttachAgentTurnCompleted) ProtoMessage() {}
 
 func (x *AttachAgentTurnCompleted) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[127]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10863,7 +11183,7 @@ func (x *AttachAgentTurnCompleted) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachAgentTurnCompleted.ProtoReflect.Descriptor instead.
 func (*AttachAgentTurnCompleted) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{127}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *AttachAgentTurnCompleted) GetRunId() string {
@@ -10902,7 +11222,7 @@ type AttachResult struct {
 
 func (x *AttachResult) Reset() {
 	*x = AttachResult{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10914,7 +11234,7 @@ func (x *AttachResult) String() string {
 func (*AttachResult) ProtoMessage() {}
 
 func (x *AttachResult) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[128]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10927,7 +11247,7 @@ func (x *AttachResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachResult.ProtoReflect.Descriptor instead.
 func (*AttachResult) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{128}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *AttachResult) GetExitCode() int32 {
@@ -10991,7 +11311,7 @@ type AttachError struct {
 
 func (x *AttachError) Reset() {
 	*x = AttachError{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11003,7 +11323,7 @@ func (x *AttachError) String() string {
 func (*AttachError) ProtoMessage() {}
 
 func (x *AttachError) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[129]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11016,7 +11336,7 @@ func (x *AttachError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachError.ProtoReflect.Descriptor instead.
 func (*AttachError) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{129}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *AttachError) GetCode() string {
@@ -11069,7 +11389,7 @@ type ExecResult struct {
 
 func (x *ExecResult) Reset() {
 	*x = ExecResult{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11081,7 +11401,7 @@ func (x *ExecResult) String() string {
 func (*ExecResult) ProtoMessage() {}
 
 func (x *ExecResult) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[130]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11094,7 +11414,7 @@ func (x *ExecResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResult.ProtoReflect.Descriptor instead.
 func (*ExecResult) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{130}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *ExecResult) GetExecId() string {
@@ -11209,7 +11529,7 @@ type ListImagesRequest struct {
 
 func (x *ListImagesRequest) Reset() {
 	*x = ListImagesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11221,7 +11541,7 @@ func (x *ListImagesRequest) String() string {
 func (*ListImagesRequest) ProtoMessage() {}
 
 func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[131]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11234,7 +11554,7 @@ func (x *ListImagesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesRequest.ProtoReflect.Descriptor instead.
 func (*ListImagesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{131}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *ListImagesRequest) GetStore() ImageStoreKind {
@@ -11292,7 +11612,7 @@ type ListImagesResponse struct {
 
 func (x *ListImagesResponse) Reset() {
 	*x = ListImagesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11304,7 +11624,7 @@ func (x *ListImagesResponse) String() string {
 func (*ListImagesResponse) ProtoMessage() {}
 
 func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[132]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11317,7 +11637,7 @@ func (x *ListImagesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListImagesResponse.ProtoReflect.Descriptor instead.
 func (*ListImagesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{132}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *ListImagesResponse) GetImages() []*Image {
@@ -11366,7 +11686,7 @@ type PullImageRequest struct {
 
 func (x *PullImageRequest) Reset() {
 	*x = PullImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11378,7 +11698,7 @@ func (x *PullImageRequest) String() string {
 func (*PullImageRequest) ProtoMessage() {}
 
 func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[133]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11391,7 +11711,7 @@ func (x *PullImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageRequest.ProtoReflect.Descriptor instead.
 func (*PullImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{133}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *PullImageRequest) GetImageRef() string {
@@ -11428,7 +11748,7 @@ type PullImageResponse struct {
 
 func (x *PullImageResponse) Reset() {
 	*x = PullImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11440,7 +11760,7 @@ func (x *PullImageResponse) String() string {
 func (*PullImageResponse) ProtoMessage() {}
 
 func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[134]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11453,7 +11773,7 @@ func (x *PullImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullImageResponse.ProtoReflect.Descriptor instead.
 func (*PullImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{134}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *PullImageResponse) GetImage() *Image {
@@ -11502,7 +11822,7 @@ type InspectImageRequest struct {
 
 func (x *InspectImageRequest) Reset() {
 	*x = InspectImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11514,7 +11834,7 @@ func (x *InspectImageRequest) String() string {
 func (*InspectImageRequest) ProtoMessage() {}
 
 func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[135]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11527,7 +11847,7 @@ func (x *InspectImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageRequest.ProtoReflect.Descriptor instead.
 func (*InspectImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{135}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *InspectImageRequest) GetImageRef() string {
@@ -11561,7 +11881,7 @@ type InspectImageResponse struct {
 
 func (x *InspectImageResponse) Reset() {
 	*x = InspectImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11573,7 +11893,7 @@ func (x *InspectImageResponse) String() string {
 func (*InspectImageResponse) ProtoMessage() {}
 
 func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[136]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11586,7 +11906,7 @@ func (x *InspectImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectImageResponse.ProtoReflect.Descriptor instead.
 func (*InspectImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{136}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *InspectImageResponse) GetImage() *Image {
@@ -11615,7 +11935,7 @@ type RemoveImageRequest struct {
 
 func (x *RemoveImageRequest) Reset() {
 	*x = RemoveImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11627,7 +11947,7 @@ func (x *RemoveImageRequest) String() string {
 func (*RemoveImageRequest) ProtoMessage() {}
 
 func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[137]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11640,7 +11960,7 @@ func (x *RemoveImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageRequest.ProtoReflect.Descriptor instead.
 func (*RemoveImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{137}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *RemoveImageRequest) GetImageRef() string {
@@ -11683,7 +12003,7 @@ type RemoveImageResponse struct {
 
 func (x *RemoveImageResponse) Reset() {
 	*x = RemoveImageResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11695,7 +12015,7 @@ func (x *RemoveImageResponse) String() string {
 func (*RemoveImageResponse) ProtoMessage() {}
 
 func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[138]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11708,7 +12028,7 @@ func (x *RemoveImageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveImageResponse.ProtoReflect.Descriptor instead.
 func (*RemoveImageResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{138}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *RemoveImageResponse) GetImageRef() string {
@@ -11756,7 +12076,7 @@ type BuildImageRequest struct {
 
 func (x *BuildImageRequest) Reset() {
 	*x = BuildImageRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11768,7 +12088,7 @@ func (x *BuildImageRequest) String() string {
 func (*BuildImageRequest) ProtoMessage() {}
 
 func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[139]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11781,7 +12101,7 @@ func (x *BuildImageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageRequest.ProtoReflect.Descriptor instead.
 func (*BuildImageRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{139}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *BuildImageRequest) GetContextDir() string {
@@ -11862,7 +12182,7 @@ type BuildImageEvent struct {
 
 func (x *BuildImageEvent) Reset() {
 	*x = BuildImageEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11874,7 +12194,7 @@ func (x *BuildImageEvent) String() string {
 func (*BuildImageEvent) ProtoMessage() {}
 
 func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[140]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11887,7 +12207,7 @@ func (x *BuildImageEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildImageEvent.ProtoReflect.Descriptor instead.
 func (*BuildImageEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{140}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *BuildImageEvent) GetStatus() ImageOperationStatus {
@@ -11953,7 +12273,7 @@ type CacheFilter struct {
 
 func (x *CacheFilter) Reset() {
 	*x = CacheFilter{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11965,7 +12285,7 @@ func (x *CacheFilter) String() string {
 func (*CacheFilter) ProtoMessage() {}
 
 func (x *CacheFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[141]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11978,7 +12298,7 @@ func (x *CacheFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheFilter.ProtoReflect.Descriptor instead.
 func (*CacheFilter) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{141}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *CacheFilter) GetDriver() string {
@@ -12032,7 +12352,7 @@ type ListCachesRequest struct {
 
 func (x *ListCachesRequest) Reset() {
 	*x = ListCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12044,7 +12364,7 @@ func (x *ListCachesRequest) String() string {
 func (*ListCachesRequest) ProtoMessage() {}
 
 func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[142]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12057,7 +12377,7 @@ func (x *ListCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesRequest.ProtoReflect.Descriptor instead.
 func (*ListCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{142}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *ListCachesRequest) GetFilter() *CacheFilter {
@@ -12077,7 +12397,7 @@ type ListCachesResponse struct {
 
 func (x *ListCachesResponse) Reset() {
 	*x = ListCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12089,7 +12409,7 @@ func (x *ListCachesResponse) String() string {
 func (*ListCachesResponse) ProtoMessage() {}
 
 func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[143]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12102,7 +12422,7 @@ func (x *ListCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCachesResponse.ProtoReflect.Descriptor instead.
 func (*ListCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{143}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *ListCachesResponse) GetCaches() []*CacheItem {
@@ -12128,7 +12448,7 @@ type InspectCacheRequest struct {
 
 func (x *InspectCacheRequest) Reset() {
 	*x = InspectCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12140,7 +12460,7 @@ func (x *InspectCacheRequest) String() string {
 func (*InspectCacheRequest) ProtoMessage() {}
 
 func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[144]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12153,7 +12473,7 @@ func (x *InspectCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheRequest.ProtoReflect.Descriptor instead.
 func (*InspectCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{144}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *InspectCacheRequest) GetCacheId() string {
@@ -12173,7 +12493,7 @@ type InspectCacheResponse struct {
 
 func (x *InspectCacheResponse) Reset() {
 	*x = InspectCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12185,7 +12505,7 @@ func (x *InspectCacheResponse) String() string {
 func (*InspectCacheResponse) ProtoMessage() {}
 
 func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[145]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12198,7 +12518,7 @@ func (x *InspectCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectCacheResponse.ProtoReflect.Descriptor instead.
 func (*InspectCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{145}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *InspectCacheResponse) GetCache() *CacheItem {
@@ -12225,7 +12545,7 @@ type PruneCachesRequest struct {
 
 func (x *PruneCachesRequest) Reset() {
 	*x = PruneCachesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12237,7 +12557,7 @@ func (x *PruneCachesRequest) String() string {
 func (*PruneCachesRequest) ProtoMessage() {}
 
 func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[146]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12250,7 +12570,7 @@ func (x *PruneCachesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesRequest.ProtoReflect.Descriptor instead.
 func (*PruneCachesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{146}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *PruneCachesRequest) GetFilter() *CacheFilter {
@@ -12280,7 +12600,7 @@ type PruneCachesResponse struct {
 
 func (x *PruneCachesResponse) Reset() {
 	*x = PruneCachesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12292,7 +12612,7 @@ func (x *PruneCachesResponse) String() string {
 func (*PruneCachesResponse) ProtoMessage() {}
 
 func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[147]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12305,7 +12625,7 @@ func (x *PruneCachesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneCachesResponse.ProtoReflect.Descriptor instead.
 func (*PruneCachesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{147}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *PruneCachesResponse) GetDryRun() bool {
@@ -12353,7 +12673,7 @@ type RemoveCacheRequest struct {
 
 func (x *RemoveCacheRequest) Reset() {
 	*x = RemoveCacheRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12365,7 +12685,7 @@ func (x *RemoveCacheRequest) String() string {
 func (*RemoveCacheRequest) ProtoMessage() {}
 
 func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[148]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12378,7 +12698,7 @@ func (x *RemoveCacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCacheRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{148}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *RemoveCacheRequest) GetCacheId() string {
@@ -12408,7 +12728,7 @@ type RemoveCacheResponse struct {
 
 func (x *RemoveCacheResponse) Reset() {
 	*x = RemoveCacheResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12420,7 +12740,7 @@ func (x *RemoveCacheResponse) String() string {
 func (*RemoveCacheResponse) ProtoMessage() {}
 
 func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[149]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12433,7 +12753,7 @@ func (x *RemoveCacheResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCacheResponse.ProtoReflect.Descriptor instead.
 func (*RemoveCacheResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{149}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *RemoveCacheResponse) GetDryRun() bool {
@@ -12495,7 +12815,7 @@ type CacheItem struct {
 
 func (x *CacheItem) Reset() {
 	*x = CacheItem{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12507,7 +12827,7 @@ func (x *CacheItem) String() string {
 func (*CacheItem) ProtoMessage() {}
 
 func (x *CacheItem) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[150]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12520,7 +12840,7 @@ func (x *CacheItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheItem.ProtoReflect.Descriptor instead.
 func (*CacheItem) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{150}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *CacheItem) GetCacheId() string {
@@ -12650,7 +12970,7 @@ type CacheReference struct {
 
 func (x *CacheReference) Reset() {
 	*x = CacheReference{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12662,7 +12982,7 @@ func (x *CacheReference) String() string {
 func (*CacheReference) ProtoMessage() {}
 
 func (x *CacheReference) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[151]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12675,7 +12995,7 @@ func (x *CacheReference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheReference.ProtoReflect.Descriptor instead.
 func (*CacheReference) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{151}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *CacheReference) GetType() string {
@@ -12738,7 +13058,7 @@ type ListVolumesRequest struct {
 
 func (x *ListVolumesRequest) Reset() {
 	*x = ListVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12750,7 +13070,7 @@ func (x *ListVolumesRequest) String() string {
 func (*ListVolumesRequest) ProtoMessage() {}
 
 func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[152]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12763,7 +13083,7 @@ func (x *ListVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesRequest.ProtoReflect.Descriptor instead.
 func (*ListVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{152}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *ListVolumesRequest) GetQuery() string {
@@ -12796,7 +13116,7 @@ type ListVolumesResponse struct {
 
 func (x *ListVolumesResponse) Reset() {
 	*x = ListVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12808,7 +13128,7 @@ func (x *ListVolumesResponse) String() string {
 func (*ListVolumesResponse) ProtoMessage() {}
 
 func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[153]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12821,7 +13141,7 @@ func (x *ListVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVolumesResponse.ProtoReflect.Descriptor instead.
 func (*ListVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{153}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *ListVolumesResponse) GetVolumes() []*Volume {
@@ -12843,7 +13163,7 @@ type CreateVolumeRequest struct {
 
 func (x *CreateVolumeRequest) Reset() {
 	*x = CreateVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12855,7 +13175,7 @@ func (x *CreateVolumeRequest) String() string {
 func (*CreateVolumeRequest) ProtoMessage() {}
 
 func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[154]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12868,7 +13188,7 @@ func (x *CreateVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeRequest.ProtoReflect.Descriptor instead.
 func (*CreateVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{154}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *CreateVolumeRequest) GetName() string {
@@ -12909,7 +13229,7 @@ type CreateVolumeResponse struct {
 
 func (x *CreateVolumeResponse) Reset() {
 	*x = CreateVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12921,7 +13241,7 @@ func (x *CreateVolumeResponse) String() string {
 func (*CreateVolumeResponse) ProtoMessage() {}
 
 func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[155]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12934,7 +13254,7 @@ func (x *CreateVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateVolumeResponse.ProtoReflect.Descriptor instead.
 func (*CreateVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{155}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *CreateVolumeResponse) GetVolume() *Volume {
@@ -12960,7 +13280,7 @@ type InspectVolumeRequest struct {
 
 func (x *InspectVolumeRequest) Reset() {
 	*x = InspectVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12972,7 +13292,7 @@ func (x *InspectVolumeRequest) String() string {
 func (*InspectVolumeRequest) ProtoMessage() {}
 
 func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[156]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12985,7 +13305,7 @@ func (x *InspectVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeRequest.ProtoReflect.Descriptor instead.
 func (*InspectVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{156}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *InspectVolumeRequest) GetName() string {
@@ -13004,7 +13324,7 @@ type InspectVolumeResponse struct {
 
 func (x *InspectVolumeResponse) Reset() {
 	*x = InspectVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13016,7 +13336,7 @@ func (x *InspectVolumeResponse) String() string {
 func (*InspectVolumeResponse) ProtoMessage() {}
 
 func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[157]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13029,7 +13349,7 @@ func (x *InspectVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectVolumeResponse.ProtoReflect.Descriptor instead.
 func (*InspectVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{157}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *InspectVolumeResponse) GetVolume() *Volume {
@@ -13049,7 +13369,7 @@ type RemoveVolumeRequest struct {
 
 func (x *RemoveVolumeRequest) Reset() {
 	*x = RemoveVolumeRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13061,7 +13381,7 @@ func (x *RemoveVolumeRequest) String() string {
 func (*RemoveVolumeRequest) ProtoMessage() {}
 
 func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[158]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13074,7 +13394,7 @@ func (x *RemoveVolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{158}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *RemoveVolumeRequest) GetName() string {
@@ -13101,7 +13421,7 @@ type RemoveVolumeResponse struct {
 
 func (x *RemoveVolumeResponse) Reset() {
 	*x = RemoveVolumeResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13113,7 +13433,7 @@ func (x *RemoveVolumeResponse) String() string {
 func (*RemoveVolumeResponse) ProtoMessage() {}
 
 func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[159]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13126,7 +13446,7 @@ func (x *RemoveVolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveVolumeResponse.ProtoReflect.Descriptor instead.
 func (*RemoveVolumeResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{159}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *RemoveVolumeResponse) GetName() string {
@@ -13155,7 +13475,7 @@ type PruneVolumesRequest struct {
 
 func (x *PruneVolumesRequest) Reset() {
 	*x = PruneVolumesRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13167,7 +13487,7 @@ func (x *PruneVolumesRequest) String() string {
 func (*PruneVolumesRequest) ProtoMessage() {}
 
 func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[160]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13180,7 +13500,7 @@ func (x *PruneVolumesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesRequest.ProtoReflect.Descriptor instead.
 func (*PruneVolumesRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{160}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *PruneVolumesRequest) GetQuery() string {
@@ -13223,7 +13543,7 @@ type PruneVolumesResponse struct {
 
 func (x *PruneVolumesResponse) Reset() {
 	*x = PruneVolumesResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13235,7 +13555,7 @@ func (x *PruneVolumesResponse) String() string {
 func (*PruneVolumesResponse) ProtoMessage() {}
 
 func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[161]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13248,7 +13568,7 @@ func (x *PruneVolumesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PruneVolumesResponse.ProtoReflect.Descriptor instead.
 func (*PruneVolumesResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{161}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *PruneVolumesResponse) GetDryRun() bool {
@@ -13295,7 +13615,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13307,7 +13627,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[162]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13320,7 +13640,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{162}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *Volume) GetName() string {
@@ -13404,7 +13724,7 @@ type Image struct {
 
 func (x *Image) Reset() {
 	*x = Image{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13416,7 +13736,7 @@ func (x *Image) String() string {
 func (*Image) ProtoMessage() {}
 
 func (x *Image) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[163]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13429,7 +13749,7 @@ func (x *Image) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Image.ProtoReflect.Descriptor instead.
 func (*Image) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{163}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *Image) GetImageId() string {
@@ -13563,7 +13883,7 @@ type ImagePlatform struct {
 
 func (x *ImagePlatform) Reset() {
 	*x = ImagePlatform{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13575,7 +13895,7 @@ func (x *ImagePlatform) String() string {
 func (*ImagePlatform) ProtoMessage() {}
 
 func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[164]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13588,7 +13908,7 @@ func (x *ImagePlatform) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePlatform.ProtoReflect.Descriptor instead.
 func (*ImagePlatform) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{164}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{168}
 }
 
 func (x *ImagePlatform) GetOs() string {
@@ -13631,7 +13951,7 @@ type ImageStoreStatus struct {
 
 func (x *ImageStoreStatus) Reset() {
 	*x = ImageStoreStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13643,7 +13963,7 @@ func (x *ImageStoreStatus) String() string {
 func (*ImageStoreStatus) ProtoMessage() {}
 
 func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[165]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13656,7 +13976,7 @@ func (x *ImageStoreStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageStoreStatus.ProtoReflect.Descriptor instead.
 func (*ImageStoreStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{165}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{169}
 }
 
 func (x *ImageStoreStatus) GetStore() ImageStoreKind {
@@ -13698,7 +14018,7 @@ type DockerImageStatus struct {
 
 func (x *DockerImageStatus) Reset() {
 	*x = DockerImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13710,7 +14030,7 @@ func (x *DockerImageStatus) String() string {
 func (*DockerImageStatus) ProtoMessage() {}
 
 func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[166]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13723,7 +14043,7 @@ func (x *DockerImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerImageStatus.ProtoReflect.Descriptor instead.
 func (*DockerImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{166}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{170}
 }
 
 func (x *DockerImageStatus) GetLocal() bool {
@@ -13761,7 +14081,7 @@ type OCIImageStatus struct {
 
 func (x *OCIImageStatus) Reset() {
 	*x = OCIImageStatus{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13773,7 +14093,7 @@ func (x *OCIImageStatus) String() string {
 func (*OCIImageStatus) ProtoMessage() {}
 
 func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[167]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13786,7 +14106,7 @@ func (x *OCIImageStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OCIImageStatus.ProtoReflect.Descriptor instead.
 func (*OCIImageStatus) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{167}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{171}
 }
 
 func (x *OCIImageStatus) GetLayoutCached() bool {
@@ -13844,7 +14164,7 @@ type ImagePullProgress struct {
 
 func (x *ImagePullProgress) Reset() {
 	*x = ImagePullProgress{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13856,7 +14176,7 @@ func (x *ImagePullProgress) String() string {
 func (*ImagePullProgress) ProtoMessage() {}
 
 func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[168]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13869,7 +14189,7 @@ func (x *ImagePullProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImagePullProgress.ProtoReflect.Descriptor instead.
 func (*ImagePullProgress) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{168}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{172}
 }
 
 func (x *ImagePullProgress) GetId() string {
@@ -13917,7 +14237,7 @@ type JupyterSpec struct {
 
 func (x *JupyterSpec) Reset() {
 	*x = JupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13929,7 +14249,7 @@ func (x *JupyterSpec) String() string {
 func (*JupyterSpec) ProtoMessage() {}
 
 func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[169]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13942,7 +14262,7 @@ func (x *JupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JupyterSpec.ProtoReflect.Descriptor instead.
 func (*JupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{169}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{173}
 }
 
 func (x *JupyterSpec) GetEnabled() bool {
@@ -13970,7 +14290,7 @@ type RunJupyterSpec struct {
 
 func (x *RunJupyterSpec) Reset() {
 	*x = RunJupyterSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13982,7 +14302,7 @@ func (x *RunJupyterSpec) String() string {
 func (*RunJupyterSpec) ProtoMessage() {}
 
 func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[170]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13995,7 +14315,7 @@ func (x *RunJupyterSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunJupyterSpec.ProtoReflect.Descriptor instead.
 func (*RunJupyterSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{170}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{174}
 }
 
 func (x *RunJupyterSpec) GetEnabled() bool {
@@ -14028,7 +14348,7 @@ type StartRunRequest struct {
 
 func (x *StartRunRequest) Reset() {
 	*x = StartRunRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14040,7 +14360,7 @@ func (x *StartRunRequest) String() string {
 func (*StartRunRequest) ProtoMessage() {}
 
 func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[171]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14053,7 +14373,7 @@ func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunRequest.ProtoReflect.Descriptor instead.
 func (*StartRunRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{171}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{175}
 }
 
 func (x *StartRunRequest) GetRun() *RunAgentRequest {
@@ -14074,7 +14394,7 @@ type StartRunResponse struct {
 
 func (x *StartRunResponse) Reset() {
 	*x = StartRunResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14086,7 +14406,7 @@ func (x *StartRunResponse) String() string {
 func (*StartRunResponse) ProtoMessage() {}
 
 func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[172]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14099,7 +14419,7 @@ func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRunResponse.ProtoReflect.Descriptor instead.
 func (*StartRunResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{172}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{176}
 }
 
 func (x *StartRunResponse) GetRun() *RunSummary {
@@ -14140,7 +14460,7 @@ type SkillSpec struct {
 
 func (x *SkillSpec) Reset() {
 	*x = SkillSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14152,7 +14472,7 @@ func (x *SkillSpec) String() string {
 func (*SkillSpec) ProtoMessage() {}
 
 func (x *SkillSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[173]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14165,7 +14485,7 @@ func (x *SkillSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkillSpec.ProtoReflect.Descriptor instead.
 func (*SkillSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{173}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{177}
 }
 
 func (x *SkillSpec) GetName() string {
@@ -14241,7 +14561,7 @@ type ResolveResourceIDRequest struct {
 
 func (x *ResolveResourceIDRequest) Reset() {
 	*x = ResolveResourceIDRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14253,7 +14573,7 @@ func (x *ResolveResourceIDRequest) String() string {
 func (*ResolveResourceIDRequest) ProtoMessage() {}
 
 func (x *ResolveResourceIDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[174]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14266,7 +14586,7 @@ func (x *ResolveResourceIDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveResourceIDRequest.ProtoReflect.Descriptor instead.
 func (*ResolveResourceIDRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{174}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{178}
 }
 
 func (x *ResolveResourceIDRequest) GetId() string {
@@ -14293,7 +14613,7 @@ type ResolveResourceIDResponse struct {
 
 func (x *ResolveResourceIDResponse) Reset() {
 	*x = ResolveResourceIDResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14305,7 +14625,7 @@ func (x *ResolveResourceIDResponse) String() string {
 func (*ResolveResourceIDResponse) ProtoMessage() {}
 
 func (x *ResolveResourceIDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[175]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14318,7 +14638,7 @@ func (x *ResolveResourceIDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveResourceIDResponse.ProtoReflect.Descriptor instead.
 func (*ResolveResourceIDResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{175}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{179}
 }
 
 func (x *ResolveResourceIDResponse) GetTargets() []*ResourceTarget {
@@ -14349,7 +14669,7 @@ type ResourceTarget struct {
 
 func (x *ResourceTarget) Reset() {
 	*x = ResourceTarget{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14361,7 +14681,7 @@ func (x *ResourceTarget) String() string {
 func (*ResourceTarget) ProtoMessage() {}
 
 func (x *ResourceTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14374,7 +14694,7 @@ func (x *ResourceTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceTarget.ProtoReflect.Descriptor instead.
 func (*ResourceTarget) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{176}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{180}
 }
 
 func (x *ResourceTarget) GetKind() ResourceKind {
@@ -14427,7 +14747,7 @@ type GetDashboardOverviewRequest struct {
 
 func (x *GetDashboardOverviewRequest) Reset() {
 	*x = GetDashboardOverviewRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14439,7 +14759,7 @@ func (x *GetDashboardOverviewRequest) String() string {
 func (*GetDashboardOverviewRequest) ProtoMessage() {}
 
 func (x *GetDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14452,7 +14772,7 @@ func (x *GetDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDashboardOverviewRequest.ProtoReflect.Descriptor instead.
 func (*GetDashboardOverviewRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{177}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{181}
 }
 
 type WatchDashboardOverviewRequest struct {
@@ -14463,7 +14783,7 @@ type WatchDashboardOverviewRequest struct {
 
 func (x *WatchDashboardOverviewRequest) Reset() {
 	*x = WatchDashboardOverviewRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14475,7 +14795,7 @@ func (x *WatchDashboardOverviewRequest) String() string {
 func (*WatchDashboardOverviewRequest) ProtoMessage() {}
 
 func (x *WatchDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[178]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14488,7 +14808,7 @@ func (x *WatchDashboardOverviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDashboardOverviewRequest.ProtoReflect.Descriptor instead.
 func (*WatchDashboardOverviewRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{178}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{182}
 }
 
 type RunOverview struct {
@@ -14502,7 +14822,7 @@ type RunOverview struct {
 
 func (x *RunOverview) Reset() {
 	*x = RunOverview{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14514,7 +14834,7 @@ func (x *RunOverview) String() string {
 func (*RunOverview) ProtoMessage() {}
 
 func (x *RunOverview) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[179]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14527,7 +14847,7 @@ func (x *RunOverview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunOverview.ProtoReflect.Descriptor instead.
 func (*RunOverview) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{179}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{183}
 }
 
 func (x *RunOverview) GetRunningCount() uint32 {
@@ -14561,7 +14881,7 @@ type DashboardOverview struct {
 
 func (x *DashboardOverview) Reset() {
 	*x = DashboardOverview{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14573,7 +14893,7 @@ func (x *DashboardOverview) String() string {
 func (*DashboardOverview) ProtoMessage() {}
 
 func (x *DashboardOverview) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[180]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14586,7 +14906,7 @@ func (x *DashboardOverview) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DashboardOverview.ProtoReflect.Descriptor instead.
 func (*DashboardOverview) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{180}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{184}
 }
 
 func (x *DashboardOverview) GetRuns() *RunOverview {
@@ -14612,7 +14932,7 @@ type GetDashboardOverviewResponse struct {
 
 func (x *GetDashboardOverviewResponse) Reset() {
 	*x = GetDashboardOverviewResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14624,7 +14944,7 @@ func (x *GetDashboardOverviewResponse) String() string {
 func (*GetDashboardOverviewResponse) ProtoMessage() {}
 
 func (x *GetDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[181]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14637,7 +14957,7 @@ func (x *GetDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDashboardOverviewResponse.ProtoReflect.Descriptor instead.
 func (*GetDashboardOverviewResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{181}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{185}
 }
 
 func (x *GetDashboardOverviewResponse) GetOverview() *DashboardOverview {
@@ -14657,7 +14977,7 @@ type WatchDashboardOverviewResponse struct {
 
 func (x *WatchDashboardOverviewResponse) Reset() {
 	*x = WatchDashboardOverviewResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14669,7 +14989,7 @@ func (x *WatchDashboardOverviewResponse) String() string {
 func (*WatchDashboardOverviewResponse) ProtoMessage() {}
 
 func (x *WatchDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[182]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14682,7 +15002,7 @@ func (x *WatchDashboardOverviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDashboardOverviewResponse.ProtoReflect.Descriptor instead.
 func (*WatchDashboardOverviewResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{182}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{186}
 }
 
 func (x *WatchDashboardOverviewResponse) GetOverview() *DashboardOverview {
@@ -14707,7 +15027,7 @@ type GetGlobalEnvRequest struct {
 
 func (x *GetGlobalEnvRequest) Reset() {
 	*x = GetGlobalEnvRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14719,7 +15039,7 @@ func (x *GetGlobalEnvRequest) String() string {
 func (*GetGlobalEnvRequest) ProtoMessage() {}
 
 func (x *GetGlobalEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[183]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14732,7 +15052,7 @@ func (x *GetGlobalEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGlobalEnvRequest.ProtoReflect.Descriptor instead.
 func (*GetGlobalEnvRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{183}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{187}
 }
 
 type GetGlobalEnvResponse struct {
@@ -14744,7 +15064,7 @@ type GetGlobalEnvResponse struct {
 
 func (x *GetGlobalEnvResponse) Reset() {
 	*x = GetGlobalEnvResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14756,7 +15076,7 @@ func (x *GetGlobalEnvResponse) String() string {
 func (*GetGlobalEnvResponse) ProtoMessage() {}
 
 func (x *GetGlobalEnvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[184]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14769,7 +15089,7 @@ func (x *GetGlobalEnvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGlobalEnvResponse.ProtoReflect.Descriptor instead.
 func (*GetGlobalEnvResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{184}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{188}
 }
 
 func (x *GetGlobalEnvResponse) GetEnv() []*EnvVarSpec {
@@ -14788,7 +15108,7 @@ type UpdateGlobalEnvRequest struct {
 
 func (x *UpdateGlobalEnvRequest) Reset() {
 	*x = UpdateGlobalEnvRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14800,7 +15120,7 @@ func (x *UpdateGlobalEnvRequest) String() string {
 func (*UpdateGlobalEnvRequest) ProtoMessage() {}
 
 func (x *UpdateGlobalEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[185]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14813,7 +15133,7 @@ func (x *UpdateGlobalEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGlobalEnvRequest.ProtoReflect.Descriptor instead.
 func (*UpdateGlobalEnvRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{185}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{189}
 }
 
 func (x *UpdateGlobalEnvRequest) GetEnv() []*EnvVarUpdateSpec {
@@ -14832,7 +15152,7 @@ type UpdateGlobalEnvResponse struct {
 
 func (x *UpdateGlobalEnvResponse) Reset() {
 	*x = UpdateGlobalEnvResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14844,7 +15164,7 @@ func (x *UpdateGlobalEnvResponse) String() string {
 func (*UpdateGlobalEnvResponse) ProtoMessage() {}
 
 func (x *UpdateGlobalEnvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[186]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14857,7 +15177,7 @@ func (x *UpdateGlobalEnvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGlobalEnvResponse.ProtoReflect.Descriptor instead.
 func (*UpdateGlobalEnvResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{186}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{190}
 }
 
 func (x *UpdateGlobalEnvResponse) GetEnv() []*EnvVarSpec {
@@ -14875,7 +15195,7 @@ type GetCapabilityGatewayConfigRequest struct {
 
 func (x *GetCapabilityGatewayConfigRequest) Reset() {
 	*x = GetCapabilityGatewayConfigRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14887,7 +15207,7 @@ func (x *GetCapabilityGatewayConfigRequest) String() string {
 func (*GetCapabilityGatewayConfigRequest) ProtoMessage() {}
 
 func (x *GetCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[187]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14900,7 +15220,7 @@ func (x *GetCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetCapabilityGatewayConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityGatewayConfigRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{187}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{191}
 }
 
 type CapabilityGatewayConfig struct {
@@ -14913,7 +15233,7 @@ type CapabilityGatewayConfig struct {
 
 func (x *CapabilityGatewayConfig) Reset() {
 	*x = CapabilityGatewayConfig{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14925,7 +15245,7 @@ func (x *CapabilityGatewayConfig) String() string {
 func (*CapabilityGatewayConfig) ProtoMessage() {}
 
 func (x *CapabilityGatewayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[188]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14938,7 +15258,7 @@ func (x *CapabilityGatewayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityGatewayConfig.ProtoReflect.Descriptor instead.
 func (*CapabilityGatewayConfig) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{188}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{192}
 }
 
 func (x *CapabilityGatewayConfig) GetAddr() string {
@@ -14964,7 +15284,7 @@ type GetCapabilityGatewayConfigResponse struct {
 
 func (x *GetCapabilityGatewayConfigResponse) Reset() {
 	*x = GetCapabilityGatewayConfigResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14976,7 +15296,7 @@ func (x *GetCapabilityGatewayConfigResponse) String() string {
 func (*GetCapabilityGatewayConfigResponse) ProtoMessage() {}
 
 func (x *GetCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[189]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14989,7 +15309,7 @@ func (x *GetCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetCapabilityGatewayConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetCapabilityGatewayConfigResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{189}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{193}
 }
 
 func (x *GetCapabilityGatewayConfigResponse) GetConfig() *CapabilityGatewayConfig {
@@ -15009,7 +15329,7 @@ type UpdateCapabilityGatewayConfigRequest struct {
 
 func (x *UpdateCapabilityGatewayConfigRequest) Reset() {
 	*x = UpdateCapabilityGatewayConfigRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15021,7 +15341,7 @@ func (x *UpdateCapabilityGatewayConfigRequest) String() string {
 func (*UpdateCapabilityGatewayConfigRequest) ProtoMessage() {}
 
 func (x *UpdateCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[190]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15034,7 +15354,7 @@ func (x *UpdateCapabilityGatewayConfigRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateCapabilityGatewayConfigRequest.ProtoReflect.Descriptor instead.
 func (*UpdateCapabilityGatewayConfigRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{190}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{194}
 }
 
 func (x *UpdateCapabilityGatewayConfigRequest) GetAddr() string {
@@ -15060,7 +15380,7 @@ type UpdateCapabilityGatewayConfigResponse struct {
 
 func (x *UpdateCapabilityGatewayConfigResponse) Reset() {
 	*x = UpdateCapabilityGatewayConfigResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15072,7 +15392,7 @@ func (x *UpdateCapabilityGatewayConfigResponse) String() string {
 func (*UpdateCapabilityGatewayConfigResponse) ProtoMessage() {}
 
 func (x *UpdateCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[191]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15085,7 +15405,7 @@ func (x *UpdateCapabilityGatewayConfigResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use UpdateCapabilityGatewayConfigResponse.ProtoReflect.Descriptor instead.
 func (*UpdateCapabilityGatewayConfigResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{191}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{195}
 }
 
 func (x *UpdateCapabilityGatewayConfigResponse) GetConfig() *CapabilityGatewayConfig {
@@ -15110,7 +15430,7 @@ type WorkspacePreset struct {
 
 func (x *WorkspacePreset) Reset() {
 	*x = WorkspacePreset{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15122,7 +15442,7 @@ func (x *WorkspacePreset) String() string {
 func (*WorkspacePreset) ProtoMessage() {}
 
 func (x *WorkspacePreset) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[192]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15135,7 +15455,7 @@ func (x *WorkspacePreset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspacePreset.ProtoReflect.Descriptor instead.
 func (*WorkspacePreset) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{192}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{196}
 }
 
 func (x *WorkspacePreset) GetId() string {
@@ -15195,7 +15515,7 @@ type ListWorkspacePresetsRequest struct {
 
 func (x *ListWorkspacePresetsRequest) Reset() {
 	*x = ListWorkspacePresetsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15207,7 +15527,7 @@ func (x *ListWorkspacePresetsRequest) String() string {
 func (*ListWorkspacePresetsRequest) ProtoMessage() {}
 
 func (x *ListWorkspacePresetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[193]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15220,7 +15540,7 @@ func (x *ListWorkspacePresetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacePresetsRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspacePresetsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{193}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{197}
 }
 
 type ListWorkspacePresetsResponse struct {
@@ -15232,7 +15552,7 @@ type ListWorkspacePresetsResponse struct {
 
 func (x *ListWorkspacePresetsResponse) Reset() {
 	*x = ListWorkspacePresetsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15244,7 +15564,7 @@ func (x *ListWorkspacePresetsResponse) String() string {
 func (*ListWorkspacePresetsResponse) ProtoMessage() {}
 
 func (x *ListWorkspacePresetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[194]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15257,7 +15577,7 @@ func (x *ListWorkspacePresetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacePresetsResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspacePresetsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{194}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{198}
 }
 
 func (x *ListWorkspacePresetsResponse) GetPresets() []*WorkspacePreset {
@@ -15279,7 +15599,7 @@ type CreateWorkspacePresetRequest struct {
 
 func (x *CreateWorkspacePresetRequest) Reset() {
 	*x = CreateWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15291,7 +15611,7 @@ func (x *CreateWorkspacePresetRequest) String() string {
 func (*CreateWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *CreateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[195]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15304,7 +15624,7 @@ func (x *CreateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*CreateWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{195}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{199}
 }
 
 func (x *CreateWorkspacePresetRequest) GetName() string {
@@ -15348,7 +15668,7 @@ type UpdateWorkspacePresetRequest struct {
 
 func (x *UpdateWorkspacePresetRequest) Reset() {
 	*x = UpdateWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15360,7 +15680,7 @@ func (x *UpdateWorkspacePresetRequest) String() string {
 func (*UpdateWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *UpdateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[196]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15373,7 +15693,7 @@ func (x *UpdateWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*UpdateWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{196}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{200}
 }
 
 func (x *UpdateWorkspacePresetRequest) GetPresetId() string {
@@ -15420,7 +15740,7 @@ type DeleteWorkspacePresetRequest struct {
 
 func (x *DeleteWorkspacePresetRequest) Reset() {
 	*x = DeleteWorkspacePresetRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15432,7 +15752,7 @@ func (x *DeleteWorkspacePresetRequest) String() string {
 func (*DeleteWorkspacePresetRequest) ProtoMessage() {}
 
 func (x *DeleteWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[197]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15445,7 +15765,7 @@ func (x *DeleteWorkspacePresetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspacePresetRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspacePresetRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{197}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{201}
 }
 
 func (x *DeleteWorkspacePresetRequest) GetPresetId() string {
@@ -15463,7 +15783,7 @@ type DeleteWorkspacePresetResponse struct {
 
 func (x *DeleteWorkspacePresetResponse) Reset() {
 	*x = DeleteWorkspacePresetResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15475,7 +15795,7 @@ func (x *DeleteWorkspacePresetResponse) String() string {
 func (*DeleteWorkspacePresetResponse) ProtoMessage() {}
 
 func (x *DeleteWorkspacePresetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[198]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15488,7 +15808,7 @@ func (x *DeleteWorkspacePresetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspacePresetResponse.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspacePresetResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{198}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{202}
 }
 
 type WorkspacePresetResponse struct {
@@ -15500,7 +15820,7 @@ type WorkspacePresetResponse struct {
 
 func (x *WorkspacePresetResponse) Reset() {
 	*x = WorkspacePresetResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15512,7 +15832,7 @@ func (x *WorkspacePresetResponse) String() string {
 func (*WorkspacePresetResponse) ProtoMessage() {}
 
 func (x *WorkspacePresetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[199]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15525,7 +15845,7 @@ func (x *WorkspacePresetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspacePresetResponse.ProtoReflect.Descriptor instead.
 func (*WorkspacePresetResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{199}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{203}
 }
 
 func (x *WorkspacePresetResponse) GetPreset() *WorkspacePreset {
@@ -15543,7 +15863,7 @@ type GetCapabilityStatusRequest struct {
 
 func (x *GetCapabilityStatusRequest) Reset() {
 	*x = GetCapabilityStatusRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15555,7 +15875,7 @@ func (x *GetCapabilityStatusRequest) String() string {
 func (*GetCapabilityStatusRequest) ProtoMessage() {}
 
 func (x *GetCapabilityStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[200]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15568,7 +15888,7 @@ func (x *GetCapabilityStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityStatusRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{200}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{204}
 }
 
 type CapabilityStatusResponse struct {
@@ -15587,7 +15907,7 @@ type CapabilityStatusResponse struct {
 
 func (x *CapabilityStatusResponse) Reset() {
 	*x = CapabilityStatusResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15599,7 +15919,7 @@ func (x *CapabilityStatusResponse) String() string {
 func (*CapabilityStatusResponse) ProtoMessage() {}
 
 func (x *CapabilityStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[201]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15612,7 +15932,7 @@ func (x *CapabilityStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityStatusResponse.ProtoReflect.Descriptor instead.
 func (*CapabilityStatusResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{201}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{205}
 }
 
 func (x *CapabilityStatusResponse) GetConfigured() bool {
@@ -15679,7 +15999,7 @@ type ListCapabilitySetsRequest struct {
 
 func (x *ListCapabilitySetsRequest) Reset() {
 	*x = ListCapabilitySetsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15691,7 +16011,7 @@ func (x *ListCapabilitySetsRequest) String() string {
 func (*ListCapabilitySetsRequest) ProtoMessage() {}
 
 func (x *ListCapabilitySetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[202]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15704,7 +16024,7 @@ func (x *ListCapabilitySetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCapabilitySetsRequest.ProtoReflect.Descriptor instead.
 func (*ListCapabilitySetsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{202}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{206}
 }
 
 type CapabilitySet struct {
@@ -15719,7 +16039,7 @@ type CapabilitySet struct {
 
 func (x *CapabilitySet) Reset() {
 	*x = CapabilitySet{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15731,7 +16051,7 @@ func (x *CapabilitySet) String() string {
 func (*CapabilitySet) ProtoMessage() {}
 
 func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[203]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15744,7 +16064,7 @@ func (x *CapabilitySet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilitySet.ProtoReflect.Descriptor instead.
 func (*CapabilitySet) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{203}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{207}
 }
 
 func (x *CapabilitySet) GetId() string {
@@ -15784,7 +16104,7 @@ type ListCapabilitySetsResponse struct {
 
 func (x *ListCapabilitySetsResponse) Reset() {
 	*x = ListCapabilitySetsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15796,7 +16116,7 @@ func (x *ListCapabilitySetsResponse) String() string {
 func (*ListCapabilitySetsResponse) ProtoMessage() {}
 
 func (x *ListCapabilitySetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[204]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15809,7 +16129,7 @@ func (x *ListCapabilitySetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCapabilitySetsResponse.ProtoReflect.Descriptor instead.
 func (*ListCapabilitySetsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{204}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{208}
 }
 
 func (x *ListCapabilitySetsResponse) GetCapsets() []*CapabilitySet {
@@ -15828,7 +16148,7 @@ type GetCapabilityCatalogRequest struct {
 
 func (x *GetCapabilityCatalogRequest) Reset() {
 	*x = GetCapabilityCatalogRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15840,7 +16160,7 @@ func (x *GetCapabilityCatalogRequest) String() string {
 func (*GetCapabilityCatalogRequest) ProtoMessage() {}
 
 func (x *GetCapabilityCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[205]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15853,7 +16173,7 @@ func (x *GetCapabilityCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityCatalogRequest.ProtoReflect.Descriptor instead.
 func (*GetCapabilityCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{205}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{209}
 }
 
 func (x *GetCapabilityCatalogRequest) GetCapsetId() string {
@@ -15879,7 +16199,7 @@ type CapabilityEndpoint struct {
 
 func (x *CapabilityEndpoint) Reset() {
 	*x = CapabilityEndpoint{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15891,7 +16211,7 @@ func (x *CapabilityEndpoint) String() string {
 func (*CapabilityEndpoint) ProtoMessage() {}
 
 func (x *CapabilityEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[206]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15904,7 +16224,7 @@ func (x *CapabilityEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityEndpoint.ProtoReflect.Descriptor instead.
 func (*CapabilityEndpoint) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{206}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{210}
 }
 
 func (x *CapabilityEndpoint) GetProtocol() string {
@@ -15979,7 +16299,7 @@ type CapabilityMethod struct {
 
 func (x *CapabilityMethod) Reset() {
 	*x = CapabilityMethod{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -15991,7 +16311,7 @@ func (x *CapabilityMethod) String() string {
 func (*CapabilityMethod) ProtoMessage() {}
 
 func (x *CapabilityMethod) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[207]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16004,7 +16324,7 @@ func (x *CapabilityMethod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapabilityMethod.ProtoReflect.Descriptor instead.
 func (*CapabilityMethod) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{207}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{211}
 }
 
 func (x *CapabilityMethod) GetServiceId() string {
@@ -16075,7 +16395,7 @@ type GetCapabilityCatalogResponse struct {
 
 func (x *GetCapabilityCatalogResponse) Reset() {
 	*x = GetCapabilityCatalogResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16087,7 +16407,7 @@ func (x *GetCapabilityCatalogResponse) String() string {
 func (*GetCapabilityCatalogResponse) ProtoMessage() {}
 
 func (x *GetCapabilityCatalogResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[208]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16100,7 +16420,7 @@ func (x *GetCapabilityCatalogResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapabilityCatalogResponse.ProtoReflect.Descriptor instead.
 func (*GetCapabilityCatalogResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{208}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{212}
 }
 
 func (x *GetCapabilityCatalogResponse) GetCapsetId() string {
@@ -16140,7 +16460,7 @@ type ListSandboxHistoryRequest struct {
 
 func (x *ListSandboxHistoryRequest) Reset() {
 	*x = ListSandboxHistoryRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16152,7 +16472,7 @@ func (x *ListSandboxHistoryRequest) String() string {
 func (*ListSandboxHistoryRequest) ProtoMessage() {}
 
 func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[209]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16165,7 +16485,7 @@ func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{209}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{213}
 }
 
 func (x *ListSandboxHistoryRequest) GetSandboxId() string {
@@ -16196,7 +16516,7 @@ type SandboxHistoryCell struct {
 
 func (x *SandboxHistoryCell) Reset() {
 	*x = SandboxHistoryCell{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[214]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16208,7 +16528,7 @@ func (x *SandboxHistoryCell) String() string {
 func (*SandboxHistoryCell) ProtoMessage() {}
 
 func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[210]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[214]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16221,7 +16541,7 @@ func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryCell.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryCell) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{210}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{214}
 }
 
 func (x *SandboxHistoryCell) GetId() string {
@@ -16328,7 +16648,7 @@ type SandboxHistoryEvent struct {
 
 func (x *SandboxHistoryEvent) Reset() {
 	*x = SandboxHistoryEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[215]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16340,7 +16660,7 @@ func (x *SandboxHistoryEvent) String() string {
 func (*SandboxHistoryEvent) ProtoMessage() {}
 
 func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[211]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[215]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16353,7 +16673,7 @@ func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryEvent.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{211}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{215}
 }
 
 func (x *SandboxHistoryEvent) GetId() string {
@@ -16402,7 +16722,7 @@ type ListSandboxHistoryResponse struct {
 
 func (x *ListSandboxHistoryResponse) Reset() {
 	*x = ListSandboxHistoryResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[216]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16414,7 +16734,7 @@ func (x *ListSandboxHistoryResponse) String() string {
 func (*ListSandboxHistoryResponse) ProtoMessage() {}
 
 func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[212]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[216]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16427,7 +16747,7 @@ func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{212}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{216}
 }
 
 func (x *ListSandboxHistoryResponse) GetCells() []*SandboxHistoryCell {
@@ -16460,7 +16780,7 @@ type WatchSandboxRequest struct {
 
 func (x *WatchSandboxRequest) Reset() {
 	*x = WatchSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[217]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16472,7 +16792,7 @@ func (x *WatchSandboxRequest) String() string {
 func (*WatchSandboxRequest) ProtoMessage() {}
 
 func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[213]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[217]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16485,7 +16805,7 @@ func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxRequest.ProtoReflect.Descriptor instead.
 func (*WatchSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{213}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{217}
 }
 
 func (x *WatchSandboxRequest) GetSandboxId() string {
@@ -16510,7 +16830,7 @@ type WatchSandboxResponse struct {
 
 func (x *WatchSandboxResponse) Reset() {
 	*x = WatchSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[214]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[218]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16522,7 +16842,7 @@ func (x *WatchSandboxResponse) String() string {
 func (*WatchSandboxResponse) ProtoMessage() {}
 
 func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[214]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[218]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16535,7 +16855,7 @@ func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxResponse.ProtoReflect.Descriptor instead.
 func (*WatchSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{214}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{218}
 }
 
 func (x *WatchSandboxResponse) GetEventType() SandboxWatchEventType {
@@ -16598,7 +16918,7 @@ type GenerateLLMRequest struct {
 
 func (x *GenerateLLMRequest) Reset() {
 	*x = GenerateLLMRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[215]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[219]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16610,7 +16930,7 @@ func (x *GenerateLLMRequest) String() string {
 func (*GenerateLLMRequest) ProtoMessage() {}
 
 func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[215]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[219]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16623,7 +16943,7 @@ func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMRequest.ProtoReflect.Descriptor instead.
 func (*GenerateLLMRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{215}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{219}
 }
 
 func (x *GenerateLLMRequest) GetPrompt() string {
@@ -16660,7 +16980,7 @@ type GenerateLLMResponse struct {
 
 func (x *GenerateLLMResponse) Reset() {
 	*x = GenerateLLMResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[216]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[220]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -16672,7 +16992,7 @@ func (x *GenerateLLMResponse) String() string {
 func (*GenerateLLMResponse) ProtoMessage() {}
 
 func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[216]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[220]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -16685,7 +17005,7 @@ func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMResponse.ProtoReflect.Descriptor instead.
 func (*GenerateLLMResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{216}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{220}
 }
 
 func (x *GenerateLLMResponse) GetText() string {
@@ -16999,7 +17319,35 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x19ListSchedulerRunsResponse\x121\n" +
 	"\x04runs\x18\x01 \x03(\v2\x1d.agentcompose.v2.SchedulerRunR\x04runs\x12\x1f\n" +
 	"\vnext_cursor\x18\x02 \x01(\tR\n" +
-	"nextCursor\"\x7f\n" +
+	"nextCursor\"\x91\x02\n" +
+	"\x19PruneSchedulerRunsRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x03 \x01(\tR\ttriggerId\x12;\n" +
+	"\x06status\x18\x04 \x03(\x0e2#.agentcompose.v2.SchedulerRunStatusR\x06status\x12,\n" +
+	"\x12older_than_seconds\x18\x05 \x01(\x04R\x10olderThanSeconds\x12\x14\n" +
+	"\x05force\x18\x06 \x01(\bR\x05force\"\xf8\x01\n" +
+	"\x16SchedulerRunPruneStats\x12\x12\n" +
+	"\x04runs\x18\x01 \x01(\x04R\x04runs\x12#\n" +
+	"\rloader_events\x18\x02 \x01(\x04R\floaderEvents\x12)\n" +
+	"\x10event_deliveries\x18\x03 \x01(\x04R\x0feventDeliveries\x12.\n" +
+	"\x13event_sandbox_links\x18\x04 \x01(\x04R\x11eventSandboxLinks\x12#\n" +
+	"\rartifact_dirs\x18\x05 \x01(\x04R\fartifactDirs\x12%\n" +
+	"\x0eartifact_bytes\x18\x06 \x01(\x04R\rartifactBytes\"x\n" +
+	"\x18SchedulerRunPruneResidue\x12\x1b\n" +
+	"\tloader_id\x18\x01 \x01(\tR\bloaderId\x12\x15\n" +
+	"\x06run_id\x18\x02 \x01(\tR\x05runId\x12\x12\n" +
+	"\x04path\x18\x03 \x01(\tR\x04path\x12\x14\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"\xc1\x02\n" +
+	"\x1aPruneSchedulerRunsResponse\x12\x17\n" +
+	"\adry_run\x18\x01 \x01(\bR\x06dryRun\x12A\n" +
+	"\amatched\x18\x02 \x01(\v2'.agentcompose.v2.SchedulerRunPruneStatsR\amatched\x12A\n" +
+	"\aremoved\x18\x03 \x01(\v2'.agentcompose.v2.SchedulerRunPruneStatsR\aremoved\x12!\n" +
+	"\fskipped_runs\x18\x04 \x01(\x04R\vskippedRuns\x12E\n" +
+	"\bresidues\x18\x05 \x03(\v2).agentcompose.v2.SchedulerRunPruneResidueR\bresidues\x12\x1a\n" +
+	"\bwarnings\x18\x06 \x03(\tR\bwarnings\"\x7f\n" +
 	"\x17StopSchedulerRunRequest\x125\n" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x15\n" +
 	"\x06run_id\x18\x02 \x01(\tR\x05runId\x12\x16\n" +
@@ -18260,7 +18608,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"%SANDBOX_WATCH_EVENT_TYPE_CELL_STARTED\x10\x02\x12(\n" +
 	"$SANDBOX_WATCH_EVENT_TYPE_CELL_OUTPUT\x10\x03\x12+\n" +
 	"'SANDBOX_WATCH_EVENT_TYPE_CELL_COMPLETED\x10\x04\x12(\n" +
-	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xe4\x0e\n" +
+	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xd3\x0f\n" +
 	"\x0eProjectService\x12d\n" +
 	"\x0fValidateProject\x12'.agentcompose.v2.ValidateProjectRequest\x1a(.agentcompose.v2.ValidateProjectResponse\x12[\n" +
 	"\fApplyProject\x12$.agentcompose.v2.ApplyProjectRequest\x1a%.agentcompose.v2.ApplyProjectResponse\x12U\n" +
@@ -18277,7 +18625,8 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\fRunScheduler\x12$.agentcompose.v2.RunSchedulerRequest\x1a%.agentcompose.v2.RunSchedulerResponse\x12j\n" +
 	"\x11StartSchedulerRun\x12).agentcompose.v2.StartSchedulerRunRequest\x1a*.agentcompose.v2.StartSchedulerRunResponse\x12d\n" +
 	"\x0fGetSchedulerRun\x12'.agentcompose.v2.GetSchedulerRunRequest\x1a(.agentcompose.v2.GetSchedulerRunResponse\x12j\n" +
-	"\x11ListSchedulerRuns\x12).agentcompose.v2.ListSchedulerRunsRequest\x1a*.agentcompose.v2.ListSchedulerRunsResponse\x12g\n" +
+	"\x11ListSchedulerRuns\x12).agentcompose.v2.ListSchedulerRunsRequest\x1a*.agentcompose.v2.ListSchedulerRunsResponse\x12m\n" +
+	"\x12PruneSchedulerRuns\x12*.agentcompose.v2.PruneSchedulerRunsRequest\x1a+.agentcompose.v2.PruneSchedulerRunsResponse\x12g\n" +
 	"\x10StopSchedulerRun\x12(.agentcompose.v2.StopSchedulerRunRequest\x1a).agentcompose.v2.StopSchedulerRunResponse\x12p\n" +
 	"\x13SetSchedulerEnabled\x12+.agentcompose.v2.SetSchedulerEnabledRequest\x1a,.agentcompose.v2.SetSchedulerEnabledResponse\x12\x85\x01\n" +
 	"\x1aSetSchedulerTriggerEnabled\x122.agentcompose.v2.SetSchedulerTriggerEnabledRequest\x1a3.agentcompose.v2.SetSchedulerTriggerEnabledResponse2\xfc\x06\n" +
@@ -18365,7 +18714,7 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 }
 
 var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 24)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 229)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 233)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),                // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),                      // 1: agentcompose.v2.ProjectChangeAction
@@ -18433,607 +18782,618 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*GetSchedulerRunResponse)(nil),               // 63: agentcompose.v2.GetSchedulerRunResponse
 	(*ListSchedulerRunsRequest)(nil),              // 64: agentcompose.v2.ListSchedulerRunsRequest
 	(*ListSchedulerRunsResponse)(nil),             // 65: agentcompose.v2.ListSchedulerRunsResponse
-	(*StopSchedulerRunRequest)(nil),               // 66: agentcompose.v2.StopSchedulerRunRequest
-	(*StopSchedulerRunResponse)(nil),              // 67: agentcompose.v2.StopSchedulerRunResponse
-	(*SchedulerRun)(nil),                          // 68: agentcompose.v2.SchedulerRun
-	(*SetSchedulerEnabledRequest)(nil),            // 69: agentcompose.v2.SetSchedulerEnabledRequest
-	(*SetSchedulerEnabledResponse)(nil),           // 70: agentcompose.v2.SetSchedulerEnabledResponse
-	(*SetSchedulerTriggerEnabledRequest)(nil),     // 71: agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	(*SetSchedulerTriggerEnabledResponse)(nil),    // 72: agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	(*ProjectValidationIssue)(nil),                // 73: agentcompose.v2.ProjectValidationIssue
-	(*ProjectChange)(nil),                         // 74: agentcompose.v2.ProjectChange
-	(*ProjectSpec)(nil),                           // 75: agentcompose.v2.ProjectSpec
-	(*NamedWorkspaceSpec)(nil),                    // 76: agentcompose.v2.NamedWorkspaceSpec
-	(*AgentSpec)(nil),                             // 77: agentcompose.v2.AgentSpec
-	(*MCPServerSpec)(nil),                         // 78: agentcompose.v2.MCPServerSpec
-	(*ProjectVolumeSpec)(nil),                     // 79: agentcompose.v2.ProjectVolumeSpec
-	(*VolumeMountSpec)(nil),                       // 80: agentcompose.v2.VolumeMountSpec
-	(*BuildSpec)(nil),                             // 81: agentcompose.v2.BuildSpec
-	(*EnvVarSpec)(nil),                            // 82: agentcompose.v2.EnvVarSpec
-	(*EnvVarUpdateSpec)(nil),                      // 83: agentcompose.v2.EnvVarUpdateSpec
-	(*WorkspaceSpec)(nil),                         // 84: agentcompose.v2.WorkspaceSpec
-	(*SchedulerSpec)(nil),                         // 85: agentcompose.v2.SchedulerSpec
-	(*TriggerSpec)(nil),                           // 86: agentcompose.v2.TriggerSpec
-	(*EventTriggerSpec)(nil),                      // 87: agentcompose.v2.EventTriggerSpec
-	(*DriverSpec)(nil),                            // 88: agentcompose.v2.DriverSpec
-	(*BoxliteDriverSpec)(nil),                     // 89: agentcompose.v2.BoxliteDriverSpec
-	(*DockerDriverSpec)(nil),                      // 90: agentcompose.v2.DockerDriverSpec
-	(*MicrosandboxDriverSpec)(nil),                // 91: agentcompose.v2.MicrosandboxDriverSpec
-	(*RunAgentRequest)(nil),                       // 92: agentcompose.v2.RunAgentRequest
-	(*RunAgentResponse)(nil),                      // 93: agentcompose.v2.RunAgentResponse
-	(*RunAgentStreamResponse)(nil),                // 94: agentcompose.v2.RunAgentStreamResponse
-	(*RunAttachRequest)(nil),                      // 95: agentcompose.v2.RunAttachRequest
-	(*RunAttachResponse)(nil),                     // 96: agentcompose.v2.RunAttachResponse
-	(*RunAttachStart)(nil),                        // 97: agentcompose.v2.RunAttachStart
-	(*TranscriptEvent)(nil),                       // 98: agentcompose.v2.TranscriptEvent
-	(*GetRunRequest)(nil),                         // 99: agentcompose.v2.GetRunRequest
-	(*GetRunResponse)(nil),                        // 100: agentcompose.v2.GetRunResponse
-	(*ListRunsRequest)(nil),                       // 101: agentcompose.v2.ListRunsRequest
-	(*ListRunsResponse)(nil),                      // 102: agentcompose.v2.ListRunsResponse
-	(*FollowRunLogsRequest)(nil),                  // 103: agentcompose.v2.FollowRunLogsRequest
-	(*RunLogChunk)(nil),                           // 104: agentcompose.v2.RunLogChunk
-	(*StopRunRequest)(nil),                        // 105: agentcompose.v2.StopRunRequest
-	(*StopRunResponse)(nil),                       // 106: agentcompose.v2.StopRunResponse
-	(*ListRunEventsRequest)(nil),                  // 107: agentcompose.v2.ListRunEventsRequest
-	(*RunEvent)(nil),                              // 108: agentcompose.v2.RunEvent
-	(*ListRunEventsResponse)(nil),                 // 109: agentcompose.v2.ListRunEventsResponse
-	(*ListSandboxRunEventsRequest)(nil),           // 110: agentcompose.v2.ListSandboxRunEventsRequest
-	(*ListSandboxRunEventsResponse)(nil),          // 111: agentcompose.v2.ListSandboxRunEventsResponse
-	(*RemoveSandboxRequest)(nil),                  // 112: agentcompose.v2.RemoveSandboxRequest
-	(*RemoveSandboxResponse)(nil),                 // 113: agentcompose.v2.RemoveSandboxResponse
-	(*PruneSandboxesRequest)(nil),                 // 114: agentcompose.v2.PruneSandboxesRequest
-	(*SandboxPruneCandidate)(nil),                 // 115: agentcompose.v2.SandboxPruneCandidate
-	(*PruneSandboxesResponse)(nil),                // 116: agentcompose.v2.PruneSandboxesResponse
-	(*GetSandboxStatsRequest)(nil),                // 117: agentcompose.v2.GetSandboxStatsRequest
-	(*GetSandboxStatsResponse)(nil),               // 118: agentcompose.v2.GetSandboxStatsResponse
-	(*GetSandboxRequest)(nil),                     // 119: agentcompose.v2.GetSandboxRequest
-	(*Sandbox)(nil),                               // 120: agentcompose.v2.Sandbox
-	(*SandboxTag)(nil),                            // 121: agentcompose.v2.SandboxTag
-	(*ListSandboxesRequest)(nil),                  // 122: agentcompose.v2.ListSandboxesRequest
-	(*ListSandboxesResponse)(nil),                 // 123: agentcompose.v2.ListSandboxesResponse
-	(*GetSandboxResponse)(nil),                    // 124: agentcompose.v2.GetSandboxResponse
-	(*StopSandboxRequest)(nil),                    // 125: agentcompose.v2.StopSandboxRequest
-	(*StopSandboxResponse)(nil),                   // 126: agentcompose.v2.StopSandboxResponse
-	(*ResumeSandboxRequest)(nil),                  // 127: agentcompose.v2.ResumeSandboxRequest
-	(*ResumeSandboxResponse)(nil),                 // 128: agentcompose.v2.ResumeSandboxResponse
-	(*MetricValue)(nil),                           // 129: agentcompose.v2.MetricValue
-	(*SandboxStats)(nil),                          // 130: agentcompose.v2.SandboxStats
-	(*RunSummary)(nil),                            // 131: agentcompose.v2.RunSummary
-	(*RunDetail)(nil),                             // 132: agentcompose.v2.RunDetail
-	(*ExecRequest)(nil),                           // 133: agentcompose.v2.ExecRequest
-	(*ExecSandboxSelector)(nil),                   // 134: agentcompose.v2.ExecSandboxSelector
-	(*ExecCommand)(nil),                           // 135: agentcompose.v2.ExecCommand
-	(*ExecResponse)(nil),                          // 136: agentcompose.v2.ExecResponse
-	(*ExecStreamResponse)(nil),                    // 137: agentcompose.v2.ExecStreamResponse
-	(*ExecAttachRequest)(nil),                     // 138: agentcompose.v2.ExecAttachRequest
-	(*ExecAttachResponse)(nil),                    // 139: agentcompose.v2.ExecAttachResponse
-	(*ExecAttachStart)(nil),                       // 140: agentcompose.v2.ExecAttachStart
-	(*AttachTerminalSize)(nil),                    // 141: agentcompose.v2.AttachTerminalSize
-	(*AttachStdin)(nil),                           // 142: agentcompose.v2.AttachStdin
-	(*AttachStdinEOF)(nil),                        // 143: agentcompose.v2.AttachStdinEOF
-	(*AttachResize)(nil),                          // 144: agentcompose.v2.AttachResize
-	(*AttachSignal)(nil),                          // 145: agentcompose.v2.AttachSignal
-	(*AttachHumanMessage)(nil),                    // 146: agentcompose.v2.AttachHumanMessage
-	(*AttachCancel)(nil),                          // 147: agentcompose.v2.AttachCancel
-	(*AttachStarted)(nil),                         // 148: agentcompose.v2.AttachStarted
-	(*AttachOutput)(nil),                          // 149: agentcompose.v2.AttachOutput
-	(*AttachAgentEvent)(nil),                      // 150: agentcompose.v2.AttachAgentEvent
-	(*AttachAgentTurnCompleted)(nil),              // 151: agentcompose.v2.AttachAgentTurnCompleted
-	(*AttachResult)(nil),                          // 152: agentcompose.v2.AttachResult
-	(*AttachError)(nil),                           // 153: agentcompose.v2.AttachError
-	(*ExecResult)(nil),                            // 154: agentcompose.v2.ExecResult
-	(*ListImagesRequest)(nil),                     // 155: agentcompose.v2.ListImagesRequest
-	(*ListImagesResponse)(nil),                    // 156: agentcompose.v2.ListImagesResponse
-	(*PullImageRequest)(nil),                      // 157: agentcompose.v2.PullImageRequest
-	(*PullImageResponse)(nil),                     // 158: agentcompose.v2.PullImageResponse
-	(*InspectImageRequest)(nil),                   // 159: agentcompose.v2.InspectImageRequest
-	(*InspectImageResponse)(nil),                  // 160: agentcompose.v2.InspectImageResponse
-	(*RemoveImageRequest)(nil),                    // 161: agentcompose.v2.RemoveImageRequest
-	(*RemoveImageResponse)(nil),                   // 162: agentcompose.v2.RemoveImageResponse
-	(*BuildImageRequest)(nil),                     // 163: agentcompose.v2.BuildImageRequest
-	(*BuildImageEvent)(nil),                       // 164: agentcompose.v2.BuildImageEvent
-	(*CacheFilter)(nil),                           // 165: agentcompose.v2.CacheFilter
-	(*ListCachesRequest)(nil),                     // 166: agentcompose.v2.ListCachesRequest
-	(*ListCachesResponse)(nil),                    // 167: agentcompose.v2.ListCachesResponse
-	(*InspectCacheRequest)(nil),                   // 168: agentcompose.v2.InspectCacheRequest
-	(*InspectCacheResponse)(nil),                  // 169: agentcompose.v2.InspectCacheResponse
-	(*PruneCachesRequest)(nil),                    // 170: agentcompose.v2.PruneCachesRequest
-	(*PruneCachesResponse)(nil),                   // 171: agentcompose.v2.PruneCachesResponse
-	(*RemoveCacheRequest)(nil),                    // 172: agentcompose.v2.RemoveCacheRequest
-	(*RemoveCacheResponse)(nil),                   // 173: agentcompose.v2.RemoveCacheResponse
-	(*CacheItem)(nil),                             // 174: agentcompose.v2.CacheItem
-	(*CacheReference)(nil),                        // 175: agentcompose.v2.CacheReference
-	(*ListVolumesRequest)(nil),                    // 176: agentcompose.v2.ListVolumesRequest
-	(*ListVolumesResponse)(nil),                   // 177: agentcompose.v2.ListVolumesResponse
-	(*CreateVolumeRequest)(nil),                   // 178: agentcompose.v2.CreateVolumeRequest
-	(*CreateVolumeResponse)(nil),                  // 179: agentcompose.v2.CreateVolumeResponse
-	(*InspectVolumeRequest)(nil),                  // 180: agentcompose.v2.InspectVolumeRequest
-	(*InspectVolumeResponse)(nil),                 // 181: agentcompose.v2.InspectVolumeResponse
-	(*RemoveVolumeRequest)(nil),                   // 182: agentcompose.v2.RemoveVolumeRequest
-	(*RemoveVolumeResponse)(nil),                  // 183: agentcompose.v2.RemoveVolumeResponse
-	(*PruneVolumesRequest)(nil),                   // 184: agentcompose.v2.PruneVolumesRequest
-	(*PruneVolumesResponse)(nil),                  // 185: agentcompose.v2.PruneVolumesResponse
-	(*Volume)(nil),                                // 186: agentcompose.v2.Volume
-	(*Image)(nil),                                 // 187: agentcompose.v2.Image
-	(*ImagePlatform)(nil),                         // 188: agentcompose.v2.ImagePlatform
-	(*ImageStoreStatus)(nil),                      // 189: agentcompose.v2.ImageStoreStatus
-	(*DockerImageStatus)(nil),                     // 190: agentcompose.v2.DockerImageStatus
-	(*OCIImageStatus)(nil),                        // 191: agentcompose.v2.OCIImageStatus
-	(*ImagePullProgress)(nil),                     // 192: agentcompose.v2.ImagePullProgress
-	(*JupyterSpec)(nil),                           // 193: agentcompose.v2.JupyterSpec
-	(*RunJupyterSpec)(nil),                        // 194: agentcompose.v2.RunJupyterSpec
-	(*StartRunRequest)(nil),                       // 195: agentcompose.v2.StartRunRequest
-	(*StartRunResponse)(nil),                      // 196: agentcompose.v2.StartRunResponse
-	(*SkillSpec)(nil),                             // 197: agentcompose.v2.SkillSpec
-	(*ResolveResourceIDRequest)(nil),              // 198: agentcompose.v2.ResolveResourceIDRequest
-	(*ResolveResourceIDResponse)(nil),             // 199: agentcompose.v2.ResolveResourceIDResponse
-	(*ResourceTarget)(nil),                        // 200: agentcompose.v2.ResourceTarget
-	(*GetDashboardOverviewRequest)(nil),           // 201: agentcompose.v2.GetDashboardOverviewRequest
-	(*WatchDashboardOverviewRequest)(nil),         // 202: agentcompose.v2.WatchDashboardOverviewRequest
-	(*RunOverview)(nil),                           // 203: agentcompose.v2.RunOverview
-	(*DashboardOverview)(nil),                     // 204: agentcompose.v2.DashboardOverview
-	(*GetDashboardOverviewResponse)(nil),          // 205: agentcompose.v2.GetDashboardOverviewResponse
-	(*WatchDashboardOverviewResponse)(nil),        // 206: agentcompose.v2.WatchDashboardOverviewResponse
-	(*GetGlobalEnvRequest)(nil),                   // 207: agentcompose.v2.GetGlobalEnvRequest
-	(*GetGlobalEnvResponse)(nil),                  // 208: agentcompose.v2.GetGlobalEnvResponse
-	(*UpdateGlobalEnvRequest)(nil),                // 209: agentcompose.v2.UpdateGlobalEnvRequest
-	(*UpdateGlobalEnvResponse)(nil),               // 210: agentcompose.v2.UpdateGlobalEnvResponse
-	(*GetCapabilityGatewayConfigRequest)(nil),     // 211: agentcompose.v2.GetCapabilityGatewayConfigRequest
-	(*CapabilityGatewayConfig)(nil),               // 212: agentcompose.v2.CapabilityGatewayConfig
-	(*GetCapabilityGatewayConfigResponse)(nil),    // 213: agentcompose.v2.GetCapabilityGatewayConfigResponse
-	(*UpdateCapabilityGatewayConfigRequest)(nil),  // 214: agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	(*UpdateCapabilityGatewayConfigResponse)(nil), // 215: agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	(*WorkspacePreset)(nil),                       // 216: agentcompose.v2.WorkspacePreset
-	(*ListWorkspacePresetsRequest)(nil),           // 217: agentcompose.v2.ListWorkspacePresetsRequest
-	(*ListWorkspacePresetsResponse)(nil),          // 218: agentcompose.v2.ListWorkspacePresetsResponse
-	(*CreateWorkspacePresetRequest)(nil),          // 219: agentcompose.v2.CreateWorkspacePresetRequest
-	(*UpdateWorkspacePresetRequest)(nil),          // 220: agentcompose.v2.UpdateWorkspacePresetRequest
-	(*DeleteWorkspacePresetRequest)(nil),          // 221: agentcompose.v2.DeleteWorkspacePresetRequest
-	(*DeleteWorkspacePresetResponse)(nil),         // 222: agentcompose.v2.DeleteWorkspacePresetResponse
-	(*WorkspacePresetResponse)(nil),               // 223: agentcompose.v2.WorkspacePresetResponse
-	(*GetCapabilityStatusRequest)(nil),            // 224: agentcompose.v2.GetCapabilityStatusRequest
-	(*CapabilityStatusResponse)(nil),              // 225: agentcompose.v2.CapabilityStatusResponse
-	(*ListCapabilitySetsRequest)(nil),             // 226: agentcompose.v2.ListCapabilitySetsRequest
-	(*CapabilitySet)(nil),                         // 227: agentcompose.v2.CapabilitySet
-	(*ListCapabilitySetsResponse)(nil),            // 228: agentcompose.v2.ListCapabilitySetsResponse
-	(*GetCapabilityCatalogRequest)(nil),           // 229: agentcompose.v2.GetCapabilityCatalogRequest
-	(*CapabilityEndpoint)(nil),                    // 230: agentcompose.v2.CapabilityEndpoint
-	(*CapabilityMethod)(nil),                      // 231: agentcompose.v2.CapabilityMethod
-	(*GetCapabilityCatalogResponse)(nil),          // 232: agentcompose.v2.GetCapabilityCatalogResponse
-	(*ListSandboxHistoryRequest)(nil),             // 233: agentcompose.v2.ListSandboxHistoryRequest
-	(*SandboxHistoryCell)(nil),                    // 234: agentcompose.v2.SandboxHistoryCell
-	(*SandboxHistoryEvent)(nil),                   // 235: agentcompose.v2.SandboxHistoryEvent
-	(*ListSandboxHistoryResponse)(nil),            // 236: agentcompose.v2.ListSandboxHistoryResponse
-	(*WatchSandboxRequest)(nil),                   // 237: agentcompose.v2.WatchSandboxRequest
-	(*WatchSandboxResponse)(nil),                  // 238: agentcompose.v2.WatchSandboxResponse
-	(*GenerateLLMRequest)(nil),                    // 239: agentcompose.v2.GenerateLLMRequest
-	(*GenerateLLMResponse)(nil),                   // 240: agentcompose.v2.GenerateLLMResponse
-	nil,                                           // 241: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                                           // 242: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                                           // 243: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                                           // 244: agentcompose.v2.AttachHumanMessage.MetadataEntry
-	nil,                                           // 245: agentcompose.v2.AttachError.DetailsEntry
-	nil,                                           // 246: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                                           // 247: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                                           // 248: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                                           // 249: agentcompose.v2.Volume.LabelsEntry
-	nil,                                           // 250: agentcompose.v2.Volume.OptionsEntry
-	nil,                                           // 251: agentcompose.v2.Image.LabelsEntry
-	nil,                                           // 252: agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	(*timestamppb.Timestamp)(nil),                 // 253: google.protobuf.Timestamp
+	(*PruneSchedulerRunsRequest)(nil),             // 66: agentcompose.v2.PruneSchedulerRunsRequest
+	(*SchedulerRunPruneStats)(nil),                // 67: agentcompose.v2.SchedulerRunPruneStats
+	(*SchedulerRunPruneResidue)(nil),              // 68: agentcompose.v2.SchedulerRunPruneResidue
+	(*PruneSchedulerRunsResponse)(nil),            // 69: agentcompose.v2.PruneSchedulerRunsResponse
+	(*StopSchedulerRunRequest)(nil),               // 70: agentcompose.v2.StopSchedulerRunRequest
+	(*StopSchedulerRunResponse)(nil),              // 71: agentcompose.v2.StopSchedulerRunResponse
+	(*SchedulerRun)(nil),                          // 72: agentcompose.v2.SchedulerRun
+	(*SetSchedulerEnabledRequest)(nil),            // 73: agentcompose.v2.SetSchedulerEnabledRequest
+	(*SetSchedulerEnabledResponse)(nil),           // 74: agentcompose.v2.SetSchedulerEnabledResponse
+	(*SetSchedulerTriggerEnabledRequest)(nil),     // 75: agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	(*SetSchedulerTriggerEnabledResponse)(nil),    // 76: agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	(*ProjectValidationIssue)(nil),                // 77: agentcompose.v2.ProjectValidationIssue
+	(*ProjectChange)(nil),                         // 78: agentcompose.v2.ProjectChange
+	(*ProjectSpec)(nil),                           // 79: agentcompose.v2.ProjectSpec
+	(*NamedWorkspaceSpec)(nil),                    // 80: agentcompose.v2.NamedWorkspaceSpec
+	(*AgentSpec)(nil),                             // 81: agentcompose.v2.AgentSpec
+	(*MCPServerSpec)(nil),                         // 82: agentcompose.v2.MCPServerSpec
+	(*ProjectVolumeSpec)(nil),                     // 83: agentcompose.v2.ProjectVolumeSpec
+	(*VolumeMountSpec)(nil),                       // 84: agentcompose.v2.VolumeMountSpec
+	(*BuildSpec)(nil),                             // 85: agentcompose.v2.BuildSpec
+	(*EnvVarSpec)(nil),                            // 86: agentcompose.v2.EnvVarSpec
+	(*EnvVarUpdateSpec)(nil),                      // 87: agentcompose.v2.EnvVarUpdateSpec
+	(*WorkspaceSpec)(nil),                         // 88: agentcompose.v2.WorkspaceSpec
+	(*SchedulerSpec)(nil),                         // 89: agentcompose.v2.SchedulerSpec
+	(*TriggerSpec)(nil),                           // 90: agentcompose.v2.TriggerSpec
+	(*EventTriggerSpec)(nil),                      // 91: agentcompose.v2.EventTriggerSpec
+	(*DriverSpec)(nil),                            // 92: agentcompose.v2.DriverSpec
+	(*BoxliteDriverSpec)(nil),                     // 93: agentcompose.v2.BoxliteDriverSpec
+	(*DockerDriverSpec)(nil),                      // 94: agentcompose.v2.DockerDriverSpec
+	(*MicrosandboxDriverSpec)(nil),                // 95: agentcompose.v2.MicrosandboxDriverSpec
+	(*RunAgentRequest)(nil),                       // 96: agentcompose.v2.RunAgentRequest
+	(*RunAgentResponse)(nil),                      // 97: agentcompose.v2.RunAgentResponse
+	(*RunAgentStreamResponse)(nil),                // 98: agentcompose.v2.RunAgentStreamResponse
+	(*RunAttachRequest)(nil),                      // 99: agentcompose.v2.RunAttachRequest
+	(*RunAttachResponse)(nil),                     // 100: agentcompose.v2.RunAttachResponse
+	(*RunAttachStart)(nil),                        // 101: agentcompose.v2.RunAttachStart
+	(*TranscriptEvent)(nil),                       // 102: agentcompose.v2.TranscriptEvent
+	(*GetRunRequest)(nil),                         // 103: agentcompose.v2.GetRunRequest
+	(*GetRunResponse)(nil),                        // 104: agentcompose.v2.GetRunResponse
+	(*ListRunsRequest)(nil),                       // 105: agentcompose.v2.ListRunsRequest
+	(*ListRunsResponse)(nil),                      // 106: agentcompose.v2.ListRunsResponse
+	(*FollowRunLogsRequest)(nil),                  // 107: agentcompose.v2.FollowRunLogsRequest
+	(*RunLogChunk)(nil),                           // 108: agentcompose.v2.RunLogChunk
+	(*StopRunRequest)(nil),                        // 109: agentcompose.v2.StopRunRequest
+	(*StopRunResponse)(nil),                       // 110: agentcompose.v2.StopRunResponse
+	(*ListRunEventsRequest)(nil),                  // 111: agentcompose.v2.ListRunEventsRequest
+	(*RunEvent)(nil),                              // 112: agentcompose.v2.RunEvent
+	(*ListRunEventsResponse)(nil),                 // 113: agentcompose.v2.ListRunEventsResponse
+	(*ListSandboxRunEventsRequest)(nil),           // 114: agentcompose.v2.ListSandboxRunEventsRequest
+	(*ListSandboxRunEventsResponse)(nil),          // 115: agentcompose.v2.ListSandboxRunEventsResponse
+	(*RemoveSandboxRequest)(nil),                  // 116: agentcompose.v2.RemoveSandboxRequest
+	(*RemoveSandboxResponse)(nil),                 // 117: agentcompose.v2.RemoveSandboxResponse
+	(*PruneSandboxesRequest)(nil),                 // 118: agentcompose.v2.PruneSandboxesRequest
+	(*SandboxPruneCandidate)(nil),                 // 119: agentcompose.v2.SandboxPruneCandidate
+	(*PruneSandboxesResponse)(nil),                // 120: agentcompose.v2.PruneSandboxesResponse
+	(*GetSandboxStatsRequest)(nil),                // 121: agentcompose.v2.GetSandboxStatsRequest
+	(*GetSandboxStatsResponse)(nil),               // 122: agentcompose.v2.GetSandboxStatsResponse
+	(*GetSandboxRequest)(nil),                     // 123: agentcompose.v2.GetSandboxRequest
+	(*Sandbox)(nil),                               // 124: agentcompose.v2.Sandbox
+	(*SandboxTag)(nil),                            // 125: agentcompose.v2.SandboxTag
+	(*ListSandboxesRequest)(nil),                  // 126: agentcompose.v2.ListSandboxesRequest
+	(*ListSandboxesResponse)(nil),                 // 127: agentcompose.v2.ListSandboxesResponse
+	(*GetSandboxResponse)(nil),                    // 128: agentcompose.v2.GetSandboxResponse
+	(*StopSandboxRequest)(nil),                    // 129: agentcompose.v2.StopSandboxRequest
+	(*StopSandboxResponse)(nil),                   // 130: agentcompose.v2.StopSandboxResponse
+	(*ResumeSandboxRequest)(nil),                  // 131: agentcompose.v2.ResumeSandboxRequest
+	(*ResumeSandboxResponse)(nil),                 // 132: agentcompose.v2.ResumeSandboxResponse
+	(*MetricValue)(nil),                           // 133: agentcompose.v2.MetricValue
+	(*SandboxStats)(nil),                          // 134: agentcompose.v2.SandboxStats
+	(*RunSummary)(nil),                            // 135: agentcompose.v2.RunSummary
+	(*RunDetail)(nil),                             // 136: agentcompose.v2.RunDetail
+	(*ExecRequest)(nil),                           // 137: agentcompose.v2.ExecRequest
+	(*ExecSandboxSelector)(nil),                   // 138: agentcompose.v2.ExecSandboxSelector
+	(*ExecCommand)(nil),                           // 139: agentcompose.v2.ExecCommand
+	(*ExecResponse)(nil),                          // 140: agentcompose.v2.ExecResponse
+	(*ExecStreamResponse)(nil),                    // 141: agentcompose.v2.ExecStreamResponse
+	(*ExecAttachRequest)(nil),                     // 142: agentcompose.v2.ExecAttachRequest
+	(*ExecAttachResponse)(nil),                    // 143: agentcompose.v2.ExecAttachResponse
+	(*ExecAttachStart)(nil),                       // 144: agentcompose.v2.ExecAttachStart
+	(*AttachTerminalSize)(nil),                    // 145: agentcompose.v2.AttachTerminalSize
+	(*AttachStdin)(nil),                           // 146: agentcompose.v2.AttachStdin
+	(*AttachStdinEOF)(nil),                        // 147: agentcompose.v2.AttachStdinEOF
+	(*AttachResize)(nil),                          // 148: agentcompose.v2.AttachResize
+	(*AttachSignal)(nil),                          // 149: agentcompose.v2.AttachSignal
+	(*AttachHumanMessage)(nil),                    // 150: agentcompose.v2.AttachHumanMessage
+	(*AttachCancel)(nil),                          // 151: agentcompose.v2.AttachCancel
+	(*AttachStarted)(nil),                         // 152: agentcompose.v2.AttachStarted
+	(*AttachOutput)(nil),                          // 153: agentcompose.v2.AttachOutput
+	(*AttachAgentEvent)(nil),                      // 154: agentcompose.v2.AttachAgentEvent
+	(*AttachAgentTurnCompleted)(nil),              // 155: agentcompose.v2.AttachAgentTurnCompleted
+	(*AttachResult)(nil),                          // 156: agentcompose.v2.AttachResult
+	(*AttachError)(nil),                           // 157: agentcompose.v2.AttachError
+	(*ExecResult)(nil),                            // 158: agentcompose.v2.ExecResult
+	(*ListImagesRequest)(nil),                     // 159: agentcompose.v2.ListImagesRequest
+	(*ListImagesResponse)(nil),                    // 160: agentcompose.v2.ListImagesResponse
+	(*PullImageRequest)(nil),                      // 161: agentcompose.v2.PullImageRequest
+	(*PullImageResponse)(nil),                     // 162: agentcompose.v2.PullImageResponse
+	(*InspectImageRequest)(nil),                   // 163: agentcompose.v2.InspectImageRequest
+	(*InspectImageResponse)(nil),                  // 164: agentcompose.v2.InspectImageResponse
+	(*RemoveImageRequest)(nil),                    // 165: agentcompose.v2.RemoveImageRequest
+	(*RemoveImageResponse)(nil),                   // 166: agentcompose.v2.RemoveImageResponse
+	(*BuildImageRequest)(nil),                     // 167: agentcompose.v2.BuildImageRequest
+	(*BuildImageEvent)(nil),                       // 168: agentcompose.v2.BuildImageEvent
+	(*CacheFilter)(nil),                           // 169: agentcompose.v2.CacheFilter
+	(*ListCachesRequest)(nil),                     // 170: agentcompose.v2.ListCachesRequest
+	(*ListCachesResponse)(nil),                    // 171: agentcompose.v2.ListCachesResponse
+	(*InspectCacheRequest)(nil),                   // 172: agentcompose.v2.InspectCacheRequest
+	(*InspectCacheResponse)(nil),                  // 173: agentcompose.v2.InspectCacheResponse
+	(*PruneCachesRequest)(nil),                    // 174: agentcompose.v2.PruneCachesRequest
+	(*PruneCachesResponse)(nil),                   // 175: agentcompose.v2.PruneCachesResponse
+	(*RemoveCacheRequest)(nil),                    // 176: agentcompose.v2.RemoveCacheRequest
+	(*RemoveCacheResponse)(nil),                   // 177: agentcompose.v2.RemoveCacheResponse
+	(*CacheItem)(nil),                             // 178: agentcompose.v2.CacheItem
+	(*CacheReference)(nil),                        // 179: agentcompose.v2.CacheReference
+	(*ListVolumesRequest)(nil),                    // 180: agentcompose.v2.ListVolumesRequest
+	(*ListVolumesResponse)(nil),                   // 181: agentcompose.v2.ListVolumesResponse
+	(*CreateVolumeRequest)(nil),                   // 182: agentcompose.v2.CreateVolumeRequest
+	(*CreateVolumeResponse)(nil),                  // 183: agentcompose.v2.CreateVolumeResponse
+	(*InspectVolumeRequest)(nil),                  // 184: agentcompose.v2.InspectVolumeRequest
+	(*InspectVolumeResponse)(nil),                 // 185: agentcompose.v2.InspectVolumeResponse
+	(*RemoveVolumeRequest)(nil),                   // 186: agentcompose.v2.RemoveVolumeRequest
+	(*RemoveVolumeResponse)(nil),                  // 187: agentcompose.v2.RemoveVolumeResponse
+	(*PruneVolumesRequest)(nil),                   // 188: agentcompose.v2.PruneVolumesRequest
+	(*PruneVolumesResponse)(nil),                  // 189: agentcompose.v2.PruneVolumesResponse
+	(*Volume)(nil),                                // 190: agentcompose.v2.Volume
+	(*Image)(nil),                                 // 191: agentcompose.v2.Image
+	(*ImagePlatform)(nil),                         // 192: agentcompose.v2.ImagePlatform
+	(*ImageStoreStatus)(nil),                      // 193: agentcompose.v2.ImageStoreStatus
+	(*DockerImageStatus)(nil),                     // 194: agentcompose.v2.DockerImageStatus
+	(*OCIImageStatus)(nil),                        // 195: agentcompose.v2.OCIImageStatus
+	(*ImagePullProgress)(nil),                     // 196: agentcompose.v2.ImagePullProgress
+	(*JupyterSpec)(nil),                           // 197: agentcompose.v2.JupyterSpec
+	(*RunJupyterSpec)(nil),                        // 198: agentcompose.v2.RunJupyterSpec
+	(*StartRunRequest)(nil),                       // 199: agentcompose.v2.StartRunRequest
+	(*StartRunResponse)(nil),                      // 200: agentcompose.v2.StartRunResponse
+	(*SkillSpec)(nil),                             // 201: agentcompose.v2.SkillSpec
+	(*ResolveResourceIDRequest)(nil),              // 202: agentcompose.v2.ResolveResourceIDRequest
+	(*ResolveResourceIDResponse)(nil),             // 203: agentcompose.v2.ResolveResourceIDResponse
+	(*ResourceTarget)(nil),                        // 204: agentcompose.v2.ResourceTarget
+	(*GetDashboardOverviewRequest)(nil),           // 205: agentcompose.v2.GetDashboardOverviewRequest
+	(*WatchDashboardOverviewRequest)(nil),         // 206: agentcompose.v2.WatchDashboardOverviewRequest
+	(*RunOverview)(nil),                           // 207: agentcompose.v2.RunOverview
+	(*DashboardOverview)(nil),                     // 208: agentcompose.v2.DashboardOverview
+	(*GetDashboardOverviewResponse)(nil),          // 209: agentcompose.v2.GetDashboardOverviewResponse
+	(*WatchDashboardOverviewResponse)(nil),        // 210: agentcompose.v2.WatchDashboardOverviewResponse
+	(*GetGlobalEnvRequest)(nil),                   // 211: agentcompose.v2.GetGlobalEnvRequest
+	(*GetGlobalEnvResponse)(nil),                  // 212: agentcompose.v2.GetGlobalEnvResponse
+	(*UpdateGlobalEnvRequest)(nil),                // 213: agentcompose.v2.UpdateGlobalEnvRequest
+	(*UpdateGlobalEnvResponse)(nil),               // 214: agentcompose.v2.UpdateGlobalEnvResponse
+	(*GetCapabilityGatewayConfigRequest)(nil),     // 215: agentcompose.v2.GetCapabilityGatewayConfigRequest
+	(*CapabilityGatewayConfig)(nil),               // 216: agentcompose.v2.CapabilityGatewayConfig
+	(*GetCapabilityGatewayConfigResponse)(nil),    // 217: agentcompose.v2.GetCapabilityGatewayConfigResponse
+	(*UpdateCapabilityGatewayConfigRequest)(nil),  // 218: agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	(*UpdateCapabilityGatewayConfigResponse)(nil), // 219: agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	(*WorkspacePreset)(nil),                       // 220: agentcompose.v2.WorkspacePreset
+	(*ListWorkspacePresetsRequest)(nil),           // 221: agentcompose.v2.ListWorkspacePresetsRequest
+	(*ListWorkspacePresetsResponse)(nil),          // 222: agentcompose.v2.ListWorkspacePresetsResponse
+	(*CreateWorkspacePresetRequest)(nil),          // 223: agentcompose.v2.CreateWorkspacePresetRequest
+	(*UpdateWorkspacePresetRequest)(nil),          // 224: agentcompose.v2.UpdateWorkspacePresetRequest
+	(*DeleteWorkspacePresetRequest)(nil),          // 225: agentcompose.v2.DeleteWorkspacePresetRequest
+	(*DeleteWorkspacePresetResponse)(nil),         // 226: agentcompose.v2.DeleteWorkspacePresetResponse
+	(*WorkspacePresetResponse)(nil),               // 227: agentcompose.v2.WorkspacePresetResponse
+	(*GetCapabilityStatusRequest)(nil),            // 228: agentcompose.v2.GetCapabilityStatusRequest
+	(*CapabilityStatusResponse)(nil),              // 229: agentcompose.v2.CapabilityStatusResponse
+	(*ListCapabilitySetsRequest)(nil),             // 230: agentcompose.v2.ListCapabilitySetsRequest
+	(*CapabilitySet)(nil),                         // 231: agentcompose.v2.CapabilitySet
+	(*ListCapabilitySetsResponse)(nil),            // 232: agentcompose.v2.ListCapabilitySetsResponse
+	(*GetCapabilityCatalogRequest)(nil),           // 233: agentcompose.v2.GetCapabilityCatalogRequest
+	(*CapabilityEndpoint)(nil),                    // 234: agentcompose.v2.CapabilityEndpoint
+	(*CapabilityMethod)(nil),                      // 235: agentcompose.v2.CapabilityMethod
+	(*GetCapabilityCatalogResponse)(nil),          // 236: agentcompose.v2.GetCapabilityCatalogResponse
+	(*ListSandboxHistoryRequest)(nil),             // 237: agentcompose.v2.ListSandboxHistoryRequest
+	(*SandboxHistoryCell)(nil),                    // 238: agentcompose.v2.SandboxHistoryCell
+	(*SandboxHistoryEvent)(nil),                   // 239: agentcompose.v2.SandboxHistoryEvent
+	(*ListSandboxHistoryResponse)(nil),            // 240: agentcompose.v2.ListSandboxHistoryResponse
+	(*WatchSandboxRequest)(nil),                   // 241: agentcompose.v2.WatchSandboxRequest
+	(*WatchSandboxResponse)(nil),                  // 242: agentcompose.v2.WatchSandboxResponse
+	(*GenerateLLMRequest)(nil),                    // 243: agentcompose.v2.GenerateLLMRequest
+	(*GenerateLLMResponse)(nil),                   // 244: agentcompose.v2.GenerateLLMResponse
+	nil,                                           // 245: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                                           // 246: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                                           // 247: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                                           // 248: agentcompose.v2.AttachHumanMessage.MetadataEntry
+	nil,                                           // 249: agentcompose.v2.AttachError.DetailsEntry
+	nil,                                           // 250: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                                           // 251: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                                           // 252: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                                           // 253: agentcompose.v2.Volume.LabelsEntry
+	nil,                                           // 254: agentcompose.v2.Volume.OptionsEntry
+	nil,                                           // 255: agentcompose.v2.Image.LabelsEntry
+	nil,                                           // 256: agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	(*timestamppb.Timestamp)(nil),                 // 257: google.protobuf.Timestamp
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
-	75,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
+	79,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
 	37,  // 1: agentcompose.v2.ValidateProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
-	73,  // 2: agentcompose.v2.ValidateProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
-	75,  // 3: agentcompose.v2.ApplyProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
+	77,  // 2: agentcompose.v2.ValidateProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
+	79,  // 3: agentcompose.v2.ApplyProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
 	37,  // 4: agentcompose.v2.ApplyProjectRequest.source:type_name -> agentcompose.v2.ProjectSource
 	38,  // 5: agentcompose.v2.ApplyProjectResponse.project:type_name -> agentcompose.v2.Project
 	40,  // 6: agentcompose.v2.ApplyProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
-	74,  // 7: agentcompose.v2.ApplyProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
-	73,  // 8: agentcompose.v2.ApplyProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
+	78,  // 7: agentcompose.v2.ApplyProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	77,  // 8: agentcompose.v2.ApplyProjectResponse.issues:type_name -> agentcompose.v2.ProjectValidationIssue
 	36,  // 9: agentcompose.v2.GetProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
 	38,  // 10: agentcompose.v2.GetProjectResponse.project:type_name -> agentcompose.v2.Project
 	39,  // 11: agentcompose.v2.ListProjectsResponse.projects:type_name -> agentcompose.v2.ProjectSummary
 	36,  // 12: agentcompose.v2.RemoveProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
 	38,  // 13: agentcompose.v2.RemoveProjectResponse.project:type_name -> agentcompose.v2.Project
-	74,  // 14: agentcompose.v2.RemoveProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	78,  // 14: agentcompose.v2.RemoveProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
 	36,  // 15: agentcompose.v2.WatchProjectRequest.project:type_name -> agentcompose.v2.ProjectRef
 	2,   // 16: agentcompose.v2.WatchProjectResponse.type:type_name -> agentcompose.v2.ProjectWatchEventType
 	38,  // 17: agentcompose.v2.WatchProjectResponse.project:type_name -> agentcompose.v2.Project
 	40,  // 18: agentcompose.v2.WatchProjectResponse.revision:type_name -> agentcompose.v2.ProjectRevision
-	74,  // 19: agentcompose.v2.WatchProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
+	78,  // 19: agentcompose.v2.WatchProjectResponse.changes:type_name -> agentcompose.v2.ProjectChange
 	39,  // 20: agentcompose.v2.Project.summary:type_name -> agentcompose.v2.ProjectSummary
-	75,  // 21: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
+	79,  // 21: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
 	41,  // 22: agentcompose.v2.Project.agents:type_name -> agentcompose.v2.ProjectAgent
 	44,  // 23: agentcompose.v2.Project.schedulers:type_name -> agentcompose.v2.ProjectScheduler
-	75,  // 24: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
+	79,  // 24: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
 	6,   // 25: agentcompose.v2.ProjectAgent.availability:type_name -> agentcompose.v2.ProjectAgentAvailability
 	7,   // 26: agentcompose.v2.ProjectAgent.health:type_name -> agentcompose.v2.ProjectAgentHealth
 	42,  // 27: agentcompose.v2.ProjectAgent.current_run:type_name -> agentcompose.v2.ProjectAgentCurrentRun
 	43,  // 28: agentcompose.v2.ProjectAgent.latest_run:type_name -> agentcompose.v2.ProjectAgentLatestRun
 	3,   // 29: agentcompose.v2.ProjectAgentLatestRun.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 30: agentcompose.v2.ProjectAgentLatestRun.source:type_name -> agentcompose.v2.RunSource
-	253, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
+	257, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
 	36,  // 32: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
 	44,  // 33: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
-	85,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
+	89,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
 	47,  // 35: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
-	86,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
-	253, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
-	253, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
-	253, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
+	90,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
+	257, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
+	257, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
+	257, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
 	49,  // 40: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
 	36,  // 41: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	253, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
+	257, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
 	52,  // 43: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
 	36,  // 44: agentcompose.v2.ListProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	52,  // 45: agentcompose.v2.ListProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
 	36,  // 46: agentcompose.v2.InvokeSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
 	36,  // 47: agentcompose.v2.RunSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
-	68,  // 48: agentcompose.v2.RunSchedulerResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	72,  // 48: agentcompose.v2.RunSchedulerResponse.run:type_name -> agentcompose.v2.SchedulerRun
 	36,  // 49: agentcompose.v2.StartSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
-	68,  // 50: agentcompose.v2.StartSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	72,  // 50: agentcompose.v2.StartSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
 	36,  // 51: agentcompose.v2.GetSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
-	68,  // 52: agentcompose.v2.GetSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	72,  // 52: agentcompose.v2.GetSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
 	36,  // 53: agentcompose.v2.ListSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	5,   // 54: agentcompose.v2.ListSchedulerRunsRequest.status:type_name -> agentcompose.v2.SchedulerRunStatus
-	68,  // 55: agentcompose.v2.ListSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
-	36,  // 56: agentcompose.v2.StopSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
-	68,  // 57: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
-	5,   // 58: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
-	253, // 59: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
-	253, // 60: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
-	36,  // 61: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
-	44,  // 62: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
-	36,  // 63: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
-	47,  // 64: agentcompose.v2.SetSchedulerTriggerEnabledResponse.trigger:type_name -> agentcompose.v2.ResolvedTrigger
-	0,   // 65: agentcompose.v2.ProjectValidationIssue.severity:type_name -> agentcompose.v2.ProjectValidationSeverity
-	1,   // 66: agentcompose.v2.ProjectChange.action:type_name -> agentcompose.v2.ProjectChangeAction
-	82,  // 67: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
-	77,  // 68: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
-	79,  // 69: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
-	76,  // 70: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
-	78,  // 71: agentcompose.v2.ProjectSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
-	84,  // 72: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	88,  // 73: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
-	82,  // 74: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
-	84,  // 75: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
-	85,  // 76: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
-	193, // 77: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
-	81,  // 78: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
-	80,  // 79: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	78,  // 80: agentcompose.v2.AgentSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
-	197, // 81: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
-	82,  // 82: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
-	82,  // 83: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
-	241, // 84: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	242, // 85: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	243, // 86: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
-	86,  // 87: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
-	87,  // 88: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
-	89,  // 89: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
-	90,  // 90: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
-	91,  // 91: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
-	4,   // 92: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
-	82,  // 93: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	10,  // 94: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
-	194, // 95: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
-	80,  // 96: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	132, // 97: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
-	9,   // 98: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
-	131, // 99: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 100: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	98,  // 101: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	97,  // 102: agentcompose.v2.RunAttachRequest.start:type_name -> agentcompose.v2.RunAttachStart
-	142, // 103: agentcompose.v2.RunAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	143, // 104: agentcompose.v2.RunAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	144, // 105: agentcompose.v2.RunAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	145, // 106: agentcompose.v2.RunAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	146, // 107: agentcompose.v2.RunAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	147, // 108: agentcompose.v2.RunAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	148, // 109: agentcompose.v2.RunAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	149, // 110: agentcompose.v2.RunAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	150, // 111: agentcompose.v2.RunAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	151, // 112: agentcompose.v2.RunAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	152, // 113: agentcompose.v2.RunAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	153, // 114: agentcompose.v2.RunAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	92,  // 115: agentcompose.v2.RunAttachStart.request:type_name -> agentcompose.v2.RunAgentRequest
-	12,  // 116: agentcompose.v2.RunAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	141, // 117: agentcompose.v2.RunAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	13,  // 118: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
-	132, // 119: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	3,   // 120: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
-	4,   // 121: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
-	131, // 122: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
-	3,   // 123: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
-	132, // 124: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	8,   // 125: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
-	253, // 126: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
-	108, // 127: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	108, // 128: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	20,  // 129: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
-	253, // 130: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
-	115, // 131: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
-	115, // 132: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
-	130, // 133: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
-	253, // 134: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	253, // 135: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	121, // 136: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
-	253, // 137: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
-	253, // 138: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
-	120, // 139: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
-	120, // 140: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	120, // 141: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	120, // 142: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	17,  // 143: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	129, // 144: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
-	129, // 145: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
-	129, // 146: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
-	129, // 147: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
-	129, // 148: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
-	129, // 149: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
-	129, // 150: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
-	129, // 151: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
-	129, // 152: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
-	4,   // 153: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
-	3,   // 154: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	131, // 155: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	134, // 156: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
-	135, // 157: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
-	82,  // 158: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	154, // 159: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
-	11,  // 160: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
-	13,  // 161: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	154, // 162: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
-	98,  // 163: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	140, // 164: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
-	142, // 165: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	143, // 166: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	144, // 167: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	145, // 168: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	147, // 169: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	146, // 170: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	148, // 171: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	149, // 172: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	152, // 173: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	153, // 174: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	150, // 175: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	151, // 176: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	133, // 177: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
-	141, // 178: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	12,  // 179: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	141, // 180: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	244, // 181: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
-	131, // 182: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 183: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
-	98,  // 184: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	154, // 185: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
-	131, // 186: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	245, // 187: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
-	135, // 188: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
-	14,  // 189: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	187, // 190: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
-	189, // 191: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 192: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	188, // 193: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	187, // 194: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
-	16,  // 195: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
-	192, // 196: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
-	14,  // 197: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	187, // 198: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
-	189, // 199: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 200: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	246, // 201: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	14,  // 202: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	188, // 203: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	16,  // 204: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
-	187, // 205: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
-	18,  // 206: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 207: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
-	165, // 208: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	174, // 209: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
-	174, // 210: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
-	165, // 211: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	174, // 212: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
-	174, // 213: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	174, // 214: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
-	174, // 215: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	18,  // 216: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 217: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	175, // 218: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
-	19,  // 219: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
-	186, // 220: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	247, // 221: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	248, // 222: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	186, // 223: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	186, // 224: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	186, // 225: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
-	186, // 226: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
-	186, // 227: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	249, // 228: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	250, // 229: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	14,  // 230: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
-	15,  // 231: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
-	188, // 232: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	190, // 233: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
-	191, // 234: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	251, // 235: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
-	14,  // 236: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
-	92,  // 237: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
-	131, // 238: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
-	22,  // 239: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
-	200, // 240: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
-	22,  // 241: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
-	203, // 242: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	253, // 243: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
-	204, // 244: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	204, // 245: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	82,  // 246: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	83,  // 247: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
-	82,  // 248: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	212, // 249: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	212, // 250: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	253, // 251: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	253, // 252: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
-	216, // 253: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
-	216, // 254: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
-	227, // 255: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	252, // 256: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	230, // 257: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
-	231, // 258: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	253, // 259: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	253, // 260: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
-	234, // 261: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
-	235, // 262: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
-	23,  // 263: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
-	120, // 264: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	234, // 265: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
-	235, // 266: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
-	13,  // 267: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
-	24,  // 268: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	26,  // 269: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	28,  // 270: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	30,  // 271: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	32,  // 272: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	34,  // 273: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	45,  // 274: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
-	48,  // 275: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
-	51,  // 276: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
-	54,  // 277: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
-	56,  // 278: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
-	58,  // 279: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
-	60,  // 280: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
-	62,  // 281: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
-	64,  // 282: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
-	66,  // 283: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
-	69,  // 284: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
-	71,  // 285: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	92,  // 286: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	195, // 287: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	92,  // 288: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	95,  // 289: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
-	99,  // 290: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	101, // 291: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	103, // 292: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	105, // 293: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	107, // 294: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
-	110, // 295: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
-	133, // 296: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	133, // 297: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	138, // 298: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
-	155, // 299: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	157, // 300: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	159, // 301: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	161, // 302: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	163, // 303: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	166, // 304: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	168, // 305: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	170, // 306: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	172, // 307: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	176, // 308: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	178, // 309: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	180, // 310: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	182, // 311: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	184, // 312: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	112, // 313: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	114, // 314: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
-	117, // 315: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	119, // 316: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
-	125, // 317: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
-	127, // 318: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
-	122, // 319: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	233, // 320: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	237, // 321: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
-	201, // 322: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
-	202, // 323: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
-	207, // 324: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
-	209, // 325: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
-	211, // 326: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
-	214, // 327: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	217, // 328: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
-	219, // 329: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
-	220, // 330: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
-	221, // 331: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
-	224, // 332: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
-	226, // 333: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
-	229, // 334: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	239, // 335: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	198, // 336: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	25,  // 337: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	27,  // 338: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	29,  // 339: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	31,  // 340: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	33,  // 341: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	35,  // 342: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	46,  // 343: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	50,  // 344: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	53,  // 345: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	55,  // 346: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
-	57,  // 347: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
-	59,  // 348: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
-	61,  // 349: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
-	63,  // 350: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
-	65,  // 351: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
-	67,  // 352: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
-	70,  // 353: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	72,  // 354: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	93,  // 355: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	196, // 356: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	94,  // 357: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	96,  // 358: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
-	100, // 359: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	102, // 360: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	104, // 361: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	106, // 362: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	109, // 363: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	111, // 364: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	136, // 365: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	137, // 366: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	139, // 367: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
-	156, // 368: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	158, // 369: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	160, // 370: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	162, // 371: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	164, // 372: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	167, // 373: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	169, // 374: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	171, // 375: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	173, // 376: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	177, // 377: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	179, // 378: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	181, // 379: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	183, // 380: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	185, // 381: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	113, // 382: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	116, // 383: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	118, // 384: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	124, // 385: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	126, // 386: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	128, // 387: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	123, // 388: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	236, // 389: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	238, // 390: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	205, // 391: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	206, // 392: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	208, // 393: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	210, // 394: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	213, // 395: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	215, // 396: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	218, // 397: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	223, // 398: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	223, // 399: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	222, // 400: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	225, // 401: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	228, // 402: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	232, // 403: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	240, // 404: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	199, // 405: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	337, // [337:406] is the sub-list for method output_type
-	268, // [268:337] is the sub-list for method input_type
-	268, // [268:268] is the sub-list for extension type_name
-	268, // [268:268] is the sub-list for extension extendee
-	0,   // [0:268] is the sub-list for field type_name
+	72,  // 55: agentcompose.v2.ListSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
+	36,  // 56: agentcompose.v2.PruneSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	5,   // 57: agentcompose.v2.PruneSchedulerRunsRequest.status:type_name -> agentcompose.v2.SchedulerRunStatus
+	67,  // 58: agentcompose.v2.PruneSchedulerRunsResponse.matched:type_name -> agentcompose.v2.SchedulerRunPruneStats
+	67,  // 59: agentcompose.v2.PruneSchedulerRunsResponse.removed:type_name -> agentcompose.v2.SchedulerRunPruneStats
+	68,  // 60: agentcompose.v2.PruneSchedulerRunsResponse.residues:type_name -> agentcompose.v2.SchedulerRunPruneResidue
+	36,  // 61: agentcompose.v2.StopSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
+	72,  // 62: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
+	5,   // 63: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
+	257, // 64: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
+	257, // 65: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
+	36,  // 66: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
+	44,  // 67: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
+	36,  // 68: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
+	47,  // 69: agentcompose.v2.SetSchedulerTriggerEnabledResponse.trigger:type_name -> agentcompose.v2.ResolvedTrigger
+	0,   // 70: agentcompose.v2.ProjectValidationIssue.severity:type_name -> agentcompose.v2.ProjectValidationSeverity
+	1,   // 71: agentcompose.v2.ProjectChange.action:type_name -> agentcompose.v2.ProjectChangeAction
+	86,  // 72: agentcompose.v2.ProjectSpec.variables:type_name -> agentcompose.v2.EnvVarSpec
+	81,  // 73: agentcompose.v2.ProjectSpec.agents:type_name -> agentcompose.v2.AgentSpec
+	83,  // 74: agentcompose.v2.ProjectSpec.volumes:type_name -> agentcompose.v2.ProjectVolumeSpec
+	80,  // 75: agentcompose.v2.ProjectSpec.workspaces:type_name -> agentcompose.v2.NamedWorkspaceSpec
+	82,  // 76: agentcompose.v2.ProjectSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
+	88,  // 77: agentcompose.v2.NamedWorkspaceSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	92,  // 78: agentcompose.v2.AgentSpec.driver:type_name -> agentcompose.v2.DriverSpec
+	86,  // 79: agentcompose.v2.AgentSpec.env:type_name -> agentcompose.v2.EnvVarSpec
+	88,  // 80: agentcompose.v2.AgentSpec.workspace:type_name -> agentcompose.v2.WorkspaceSpec
+	89,  // 81: agentcompose.v2.AgentSpec.scheduler:type_name -> agentcompose.v2.SchedulerSpec
+	197, // 82: agentcompose.v2.AgentSpec.jupyter:type_name -> agentcompose.v2.JupyterSpec
+	85,  // 83: agentcompose.v2.AgentSpec.build:type_name -> agentcompose.v2.BuildSpec
+	84,  // 84: agentcompose.v2.AgentSpec.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	82,  // 85: agentcompose.v2.AgentSpec.mcp_servers:type_name -> agentcompose.v2.MCPServerSpec
+	201, // 86: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
+	86,  // 87: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
+	86,  // 88: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
+	245, // 89: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	246, // 90: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	247, // 91: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	90,  // 92: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
+	91,  // 93: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
+	93,  // 94: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
+	94,  // 95: agentcompose.v2.DriverSpec.docker:type_name -> agentcompose.v2.DockerDriverSpec
+	95,  // 96: agentcompose.v2.DriverSpec.microsandbox:type_name -> agentcompose.v2.MicrosandboxDriverSpec
+	4,   // 97: agentcompose.v2.RunAgentRequest.source:type_name -> agentcompose.v2.RunSource
+	86,  // 98: agentcompose.v2.RunAgentRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	10,  // 99: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
+	198, // 100: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
+	84,  // 101: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
+	136, // 102: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
+	9,   // 103: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
+	135, // 104: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
+	13,  // 105: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	102, // 106: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	101, // 107: agentcompose.v2.RunAttachRequest.start:type_name -> agentcompose.v2.RunAttachStart
+	146, // 108: agentcompose.v2.RunAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	147, // 109: agentcompose.v2.RunAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	148, // 110: agentcompose.v2.RunAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	149, // 111: agentcompose.v2.RunAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	150, // 112: agentcompose.v2.RunAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	151, // 113: agentcompose.v2.RunAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	152, // 114: agentcompose.v2.RunAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	153, // 115: agentcompose.v2.RunAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	154, // 116: agentcompose.v2.RunAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	155, // 117: agentcompose.v2.RunAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	156, // 118: agentcompose.v2.RunAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	157, // 119: agentcompose.v2.RunAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	96,  // 120: agentcompose.v2.RunAttachStart.request:type_name -> agentcompose.v2.RunAgentRequest
+	12,  // 121: agentcompose.v2.RunAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	145, // 122: agentcompose.v2.RunAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	13,  // 123: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
+	136, // 124: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	3,   // 125: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
+	4,   // 126: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
+	135, // 127: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
+	3,   // 128: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
+	136, // 129: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	8,   // 130: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
+	257, // 131: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
+	112, // 132: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	112, // 133: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	20,  // 134: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
+	257, // 135: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	119, // 136: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
+	119, // 137: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
+	134, // 138: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
+	257, // 139: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	257, // 140: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	125, // 141: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
+	257, // 142: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
+	257, // 143: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
+	124, // 144: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
+	124, // 145: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	124, // 146: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	124, // 147: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	17,  // 148: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
+	133, // 149: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
+	133, // 150: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 151: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 152: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
+	133, // 153: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 154: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 155: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 156: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 157: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
+	4,   // 158: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
+	3,   // 159: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
+	135, // 160: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
+	138, // 161: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
+	139, // 162: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
+	86,  // 163: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	158, // 164: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
+	11,  // 165: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
+	13,  // 166: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	158, // 167: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
+	102, // 168: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	144, // 169: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
+	146, // 170: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	147, // 171: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	148, // 172: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	149, // 173: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	151, // 174: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	150, // 175: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	152, // 176: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	153, // 177: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	156, // 178: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	157, // 179: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	154, // 180: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	155, // 181: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	137, // 182: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
+	145, // 183: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	12,  // 184: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	145, // 185: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	248, // 186: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	135, // 187: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
+	13,  // 188: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
+	102, // 189: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	158, // 190: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
+	135, // 191: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
+	249, // 192: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	139, // 193: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
+	14,  // 194: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	191, // 195: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
+	193, // 196: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	14,  // 197: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	192, // 198: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	191, // 199: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
+	16,  // 200: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
+	196, // 201: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
+	14,  // 202: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	191, // 203: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
+	193, // 204: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	14,  // 205: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	250, // 206: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	14,  // 207: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	192, // 208: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	16,  // 209: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
+	191, // 210: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
+	18,  // 211: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
+	21,  // 212: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
+	169, // 213: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	178, // 214: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
+	178, // 215: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
+	169, // 216: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	178, // 217: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
+	178, // 218: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	178, // 219: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
+	178, // 220: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	18,  // 221: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
+	21,  // 222: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
+	179, // 223: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
+	19,  // 224: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
+	190, // 225: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
+	251, // 226: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	252, // 227: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	190, // 228: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	190, // 229: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	190, // 230: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
+	190, // 231: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
+	190, // 232: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
+	253, // 233: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	254, // 234: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	14,  // 235: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
+	15,  // 236: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
+	192, // 237: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
+	194, // 238: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
+	195, // 239: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
+	255, // 240: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	14,  // 241: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
+	96,  // 242: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
+	135, // 243: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	22,  // 244: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
+	204, // 245: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
+	22,  // 246: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
+	207, // 247: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
+	257, // 248: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	208, // 249: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	208, // 250: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	86,  // 251: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	87,  // 252: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
+	86,  // 253: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	216, // 254: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	216, // 255: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	257, // 256: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	257, // 257: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	220, // 258: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
+	220, // 259: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
+	231, // 260: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
+	256, // 261: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	234, // 262: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
+	235, // 263: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
+	257, // 264: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	257, // 265: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	238, // 266: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
+	239, // 267: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
+	23,  // 268: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
+	124, // 269: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	238, // 270: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
+	239, // 271: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
+	13,  // 272: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
+	24,  // 273: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	26,  // 274: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	28,  // 275: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	30,  // 276: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	32,  // 277: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	34,  // 278: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	45,  // 279: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
+	48,  // 280: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
+	51,  // 281: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
+	54,  // 282: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
+	56,  // 283: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
+	58,  // 284: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
+	60,  // 285: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
+	62,  // 286: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
+	64,  // 287: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
+	66,  // 288: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
+	70,  // 289: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
+	73,  // 290: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
+	75,  // 291: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	96,  // 292: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	199, // 293: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
+	96,  // 294: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
+	99,  // 295: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
+	103, // 296: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	105, // 297: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	107, // 298: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	109, // 299: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	111, // 300: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
+	114, // 301: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
+	137, // 302: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	137, // 303: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
+	142, // 304: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
+	159, // 305: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	161, // 306: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	163, // 307: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	165, // 308: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	167, // 309: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	170, // 310: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	172, // 311: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	174, // 312: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	176, // 313: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	180, // 314: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	182, // 315: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	184, // 316: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	186, // 317: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	188, // 318: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	116, // 319: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	118, // 320: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
+	121, // 321: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	123, // 322: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
+	129, // 323: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
+	131, // 324: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
+	126, // 325: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
+	237, // 326: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	241, // 327: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	205, // 328: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
+	206, // 329: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
+	211, // 330: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
+	213, // 331: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
+	215, // 332: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
+	218, // 333: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	221, // 334: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
+	223, // 335: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
+	224, // 336: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
+	225, // 337: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
+	228, // 338: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
+	230, // 339: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
+	233, // 340: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
+	243, // 341: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	202, // 342: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	25,  // 343: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	27,  // 344: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	29,  // 345: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	31,  // 346: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	33,  // 347: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	35,  // 348: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	46,  // 349: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	50,  // 350: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	53,  // 351: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	55,  // 352: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
+	57,  // 353: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
+	59,  // 354: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	61,  // 355: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	63,  // 356: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	65,  // 357: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	69,  // 358: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
+	71,  // 359: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	74,  // 360: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	76,  // 361: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	97,  // 362: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	200, // 363: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
+	98,  // 364: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
+	100, // 365: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
+	104, // 366: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	106, // 367: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	108, // 368: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	110, // 369: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	113, // 370: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	115, // 371: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	140, // 372: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	141, // 373: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
+	143, // 374: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
+	160, // 375: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	162, // 376: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	164, // 377: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	166, // 378: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	168, // 379: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	171, // 380: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	173, // 381: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	175, // 382: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	177, // 383: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	181, // 384: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	183, // 385: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	185, // 386: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	187, // 387: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	189, // 388: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	117, // 389: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	120, // 390: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	122, // 391: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	128, // 392: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	130, // 393: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	132, // 394: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	127, // 395: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	240, // 396: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	242, // 397: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	209, // 398: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	210, // 399: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	212, // 400: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	214, // 401: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	217, // 402: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	219, // 403: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	222, // 404: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	227, // 405: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	227, // 406: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	226, // 407: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	229, // 408: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	232, // 409: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	236, // 410: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	244, // 411: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	203, // 412: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	343, // [343:413] is the sub-list for method output_type
+	273, // [273:343] is the sub-list for method input_type
+	273, // [273:273] is the sub-list for extension type_name
+	273, // [273:273] is the sub-list for extension extendee
+	0,   // [0:273] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }
@@ -19041,9 +19401,9 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 	if File_agentcompose_v2_agentcompose_proto != nil {
 		return
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[53].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[59].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[71].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[57].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[63].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[75].OneofWrappers = []any{
 		(*RunAttachRequest_Start)(nil),
 		(*RunAttachRequest_Stdin)(nil),
 		(*RunAttachRequest_StdinEof)(nil),
@@ -19052,7 +19412,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*RunAttachRequest_HumanMessage)(nil),
 		(*RunAttachRequest_Cancel)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[72].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[76].OneofWrappers = []any{
 		(*RunAttachResponse_Started)(nil),
 		(*RunAttachResponse_Output)(nil),
 		(*RunAttachResponse_AgentEvent)(nil),
@@ -19060,13 +19420,13 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*RunAttachResponse_Result)(nil),
 		(*RunAttachResponse_Error)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[105].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[109].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[109].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[113].OneofWrappers = []any{
 		(*ExecRequest_SandboxId)(nil),
 		(*ExecRequest_RunId)(nil),
 		(*ExecRequest_Selector)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[114].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[118].OneofWrappers = []any{
 		(*ExecAttachRequest_Start)(nil),
 		(*ExecAttachRequest_Stdin)(nil),
 		(*ExecAttachRequest_StdinEof)(nil),
@@ -19075,7 +19435,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecAttachRequest_Cancel)(nil),
 		(*ExecAttachRequest_HumanMessage)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[115].OneofWrappers = []any{
+	file_agentcompose_v2_agentcompose_proto_msgTypes[119].OneofWrappers = []any{
 		(*ExecAttachResponse_Started)(nil),
 		(*ExecAttachResponse_Output)(nil),
 		(*ExecAttachResponse_Result)(nil),
@@ -19083,14 +19443,14 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecAttachResponse_AgentEvent)(nil),
 		(*ExecAttachResponse_AgentTurnCompleted)(nil),
 	}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[190].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[194].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
 			NumEnums:      24,
-			NumMessages:   229,
+			NumMessages:   233,
 			NumExtensions: 0,
 			NumServices:   12,
 		},

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -22,6 +22,7 @@ service ProjectService {
   rpc StartSchedulerRun(StartSchedulerRunRequest) returns (StartSchedulerRunResponse);
   rpc GetSchedulerRun(GetSchedulerRunRequest) returns (GetSchedulerRunResponse);
   rpc ListSchedulerRuns(ListSchedulerRunsRequest) returns (ListSchedulerRunsResponse);
+  rpc PruneSchedulerRuns(PruneSchedulerRunsRequest) returns (PruneSchedulerRunsResponse);
   rpc StopSchedulerRun(StopSchedulerRunRequest) returns (StopSchedulerRunResponse);
   rpc SetSchedulerEnabled(SetSchedulerEnabledRequest) returns (SetSchedulerEnabledResponse);
   rpc SetSchedulerTriggerEnabled(SetSchedulerTriggerEnabledRequest) returns (SetSchedulerTriggerEnabledResponse);
@@ -595,6 +596,40 @@ message ListSchedulerRunsRequest {
 message ListSchedulerRunsResponse {
   repeated SchedulerRun runs = 1;
   string next_cursor = 2;
+}
+
+message PruneSchedulerRunsRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  string trigger_id = 3;
+  repeated SchedulerRunStatus status = 4;
+  uint64 older_than_seconds = 5;
+  bool force = 6;
+}
+
+message SchedulerRunPruneStats {
+  uint64 runs = 1;
+  uint64 loader_events = 2;
+  uint64 event_deliveries = 3;
+  uint64 event_sandbox_links = 4;
+  uint64 artifact_dirs = 5;
+  uint64 artifact_bytes = 6;
+}
+
+message SchedulerRunPruneResidue {
+  string loader_id = 1;
+  string run_id = 2;
+  string path = 3;
+  string error = 4;
+}
+
+message PruneSchedulerRunsResponse {
+  bool dry_run = 1;
+  SchedulerRunPruneStats matched = 2;
+  SchedulerRunPruneStats removed = 3;
+  uint64 skipped_runs = 4;
+  repeated SchedulerRunPruneResidue residues = 5;
+  repeated string warnings = 6;
 }
 
 message StopSchedulerRunRequest {

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -16,6 +16,8 @@ service ProjectService {
   rpc GetScheduler(GetSchedulerRequest) returns (GetSchedulerResponse);
   rpc ListSchedulers(ListSchedulersRequest) returns (ListSchedulersResponse);
   rpc ListSchedulerEvents(ListSchedulerEventsRequest) returns (ListSchedulerEventsResponse);
+  rpc ListProjectSchedulerEvents(ListProjectSchedulerEventsRequest) returns (ListProjectSchedulerEventsResponse);
+  rpc InvokeScheduler(InvokeSchedulerRequest) returns (InvokeSchedulerResponse);
   rpc RunScheduler(RunSchedulerRequest) returns (RunSchedulerResponse);
   rpc StartSchedulerRun(StartSchedulerRunRequest) returns (StartSchedulerRunResponse);
   rpc GetSchedulerRun(GetSchedulerRunRequest) returns (GetSchedulerRunResponse);
@@ -512,11 +514,42 @@ message SchedulerEvent {
   string run_id = 6;
   string trigger_id = 7;
   google.protobuf.Timestamp created_at = 8;
+  string agent_name = 9;
+  string scheduler_id = 10;
+  string linked_sandbox_id = 11;
+  string linked_cell_id = 12;
+  string linked_agent_thread_id = 13;
 }
 
 message ListSchedulerEventsResponse {
   repeated SchedulerEvent events = 1;
   string next_cursor = 2;
+}
+
+message ListProjectSchedulerEventsRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  string trigger_id = 3;
+  string run_id = 4;
+  uint32 limit = 5;
+  string cursor = 6;
+}
+
+message ListProjectSchedulerEventsResponse {
+  repeated SchedulerEvent events = 1;
+  string next_cursor = 2;
+}
+
+message InvokeSchedulerRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  string payload_json = 3;
+}
+
+message InvokeSchedulerResponse {
+  string result_json = 1;
+  int64 duration_ms = 2;
+  repeated string warnings = 3;
 }
 
 message RunSchedulerRequest {
@@ -555,6 +588,8 @@ message ListSchedulerRunsRequest {
   string agent_name = 2;
   uint32 limit = 3;
   string cursor = 4;
+  string trigger_id = 5;
+  SchedulerRunStatus status = 6;
 }
 
 message ListSchedulerRunsResponse {
@@ -590,6 +625,7 @@ message SchedulerRun {
   string payload_json = 14;
   string source_script_sha256 = 15;
   string artifacts_dir = 16;
+  repeated string sandbox_ids = 17;
 }
 
 message SetSchedulerEnabledRequest {

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -100,6 +100,9 @@ const (
 	// ProjectServiceListSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
 	// ListSchedulerRuns RPC.
 	ProjectServiceListSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/ListSchedulerRuns"
+	// ProjectServicePruneSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
+	// PruneSchedulerRuns RPC.
+	ProjectServicePruneSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/PruneSchedulerRuns"
 	// ProjectServiceStopSchedulerRunProcedure is the fully-qualified name of the ProjectService's
 	// StopSchedulerRun RPC.
 	ProjectServiceStopSchedulerRunProcedure = "/agentcompose.v2.ProjectService/StopSchedulerRun"
@@ -267,6 +270,7 @@ type ProjectServiceClient interface {
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error)
 	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
 	SetSchedulerEnabled(context.Context, *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error)
 	SetSchedulerTriggerEnabled(context.Context, *connect.Request[v2.SetSchedulerTriggerEnabledRequest]) (*connect.Response[v2.SetSchedulerTriggerEnabledResponse], error)
@@ -373,6 +377,12 @@ func NewProjectServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
 			connect.WithClientOptions(opts...),
 		),
+		pruneSchedulerRuns: connect.NewClient[v2.PruneSchedulerRunsRequest, v2.PruneSchedulerRunsResponse](
+			httpClient,
+			baseURL+ProjectServicePruneSchedulerRunsProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("PruneSchedulerRuns")),
+			connect.WithClientOptions(opts...),
+		),
 		stopSchedulerRun: connect.NewClient[v2.StopSchedulerRunRequest, v2.StopSchedulerRunResponse](
 			httpClient,
 			baseURL+ProjectServiceStopSchedulerRunProcedure,
@@ -411,6 +421,7 @@ type projectServiceClient struct {
 	startSchedulerRun          *connect.Client[v2.StartSchedulerRunRequest, v2.StartSchedulerRunResponse]
 	getSchedulerRun            *connect.Client[v2.GetSchedulerRunRequest, v2.GetSchedulerRunResponse]
 	listSchedulerRuns          *connect.Client[v2.ListSchedulerRunsRequest, v2.ListSchedulerRunsResponse]
+	pruneSchedulerRuns         *connect.Client[v2.PruneSchedulerRunsRequest, v2.PruneSchedulerRunsResponse]
 	stopSchedulerRun           *connect.Client[v2.StopSchedulerRunRequest, v2.StopSchedulerRunResponse]
 	setSchedulerEnabled        *connect.Client[v2.SetSchedulerEnabledRequest, v2.SetSchedulerEnabledResponse]
 	setSchedulerTriggerEnabled *connect.Client[v2.SetSchedulerTriggerEnabledRequest, v2.SetSchedulerTriggerEnabledResponse]
@@ -491,6 +502,11 @@ func (c *projectServiceClient) ListSchedulerRuns(ctx context.Context, req *conne
 	return c.listSchedulerRuns.CallUnary(ctx, req)
 }
 
+// PruneSchedulerRuns calls agentcompose.v2.ProjectService.PruneSchedulerRuns.
+func (c *projectServiceClient) PruneSchedulerRuns(ctx context.Context, req *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error) {
+	return c.pruneSchedulerRuns.CallUnary(ctx, req)
+}
+
 // StopSchedulerRun calls agentcompose.v2.ProjectService.StopSchedulerRun.
 func (c *projectServiceClient) StopSchedulerRun(ctx context.Context, req *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error) {
 	return c.stopSchedulerRun.CallUnary(ctx, req)
@@ -523,6 +539,7 @@ type ProjectServiceHandler interface {
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error)
 	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
 	SetSchedulerEnabled(context.Context, *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error)
 	SetSchedulerTriggerEnabled(context.Context, *connect.Request[v2.SetSchedulerTriggerEnabledRequest]) (*connect.Response[v2.SetSchedulerTriggerEnabledResponse], error)
@@ -625,6 +642,12 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 		connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
 		connect.WithHandlerOptions(opts...),
 	)
+	projectServicePruneSchedulerRunsHandler := connect.NewUnaryHandler(
+		ProjectServicePruneSchedulerRunsProcedure,
+		svc.PruneSchedulerRuns,
+		connect.WithSchema(projectServiceMethods.ByName("PruneSchedulerRuns")),
+		connect.WithHandlerOptions(opts...),
+	)
 	projectServiceStopSchedulerRunHandler := connect.NewUnaryHandler(
 		ProjectServiceStopSchedulerRunProcedure,
 		svc.StopSchedulerRun,
@@ -675,6 +698,8 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 			projectServiceGetSchedulerRunHandler.ServeHTTP(w, r)
 		case ProjectServiceListSchedulerRunsProcedure:
 			projectServiceListSchedulerRunsHandler.ServeHTTP(w, r)
+		case ProjectServicePruneSchedulerRunsProcedure:
+			projectServicePruneSchedulerRunsHandler.ServeHTTP(w, r)
 		case ProjectServiceStopSchedulerRunProcedure:
 			projectServiceStopSchedulerRunHandler.ServeHTTP(w, r)
 		case ProjectServiceSetSchedulerEnabledProcedure:
@@ -748,6 +773,10 @@ func (UnimplementedProjectServiceHandler) GetSchedulerRun(context.Context, *conn
 
 func (UnimplementedProjectServiceHandler) ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListSchedulerRuns is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.PruneSchedulerRuns is not implemented"))
 }
 
 func (UnimplementedProjectServiceHandler) StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error) {

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -82,6 +82,12 @@ const (
 	// ProjectServiceListSchedulerEventsProcedure is the fully-qualified name of the ProjectService's
 	// ListSchedulerEvents RPC.
 	ProjectServiceListSchedulerEventsProcedure = "/agentcompose.v2.ProjectService/ListSchedulerEvents"
+	// ProjectServiceListProjectSchedulerEventsProcedure is the fully-qualified name of the
+	// ProjectService's ListProjectSchedulerEvents RPC.
+	ProjectServiceListProjectSchedulerEventsProcedure = "/agentcompose.v2.ProjectService/ListProjectSchedulerEvents"
+	// ProjectServiceInvokeSchedulerProcedure is the fully-qualified name of the ProjectService's
+	// InvokeScheduler RPC.
+	ProjectServiceInvokeSchedulerProcedure = "/agentcompose.v2.ProjectService/InvokeScheduler"
 	// ProjectServiceRunSchedulerProcedure is the fully-qualified name of the ProjectService's
 	// RunScheduler RPC.
 	ProjectServiceRunSchedulerProcedure = "/agentcompose.v2.ProjectService/RunScheduler"
@@ -255,6 +261,8 @@ type ProjectServiceClient interface {
 	GetScheduler(context.Context, *connect.Request[v2.GetSchedulerRequest]) (*connect.Response[v2.GetSchedulerResponse], error)
 	ListSchedulers(context.Context, *connect.Request[v2.ListSchedulersRequest]) (*connect.Response[v2.ListSchedulersResponse], error)
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
+	ListProjectSchedulerEvents(context.Context, *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error)
+	InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error)
 	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
@@ -329,6 +337,18 @@ func NewProjectServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(projectServiceMethods.ByName("ListSchedulerEvents")),
 			connect.WithClientOptions(opts...),
 		),
+		listProjectSchedulerEvents: connect.NewClient[v2.ListProjectSchedulerEventsRequest, v2.ListProjectSchedulerEventsResponse](
+			httpClient,
+			baseURL+ProjectServiceListProjectSchedulerEventsProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("ListProjectSchedulerEvents")),
+			connect.WithClientOptions(opts...),
+		),
+		invokeScheduler: connect.NewClient[v2.InvokeSchedulerRequest, v2.InvokeSchedulerResponse](
+			httpClient,
+			baseURL+ProjectServiceInvokeSchedulerProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("InvokeScheduler")),
+			connect.WithClientOptions(opts...),
+		),
 		runScheduler: connect.NewClient[v2.RunSchedulerRequest, v2.RunSchedulerResponse](
 			httpClient,
 			baseURL+ProjectServiceRunSchedulerProcedure,
@@ -385,6 +405,8 @@ type projectServiceClient struct {
 	getScheduler               *connect.Client[v2.GetSchedulerRequest, v2.GetSchedulerResponse]
 	listSchedulers             *connect.Client[v2.ListSchedulersRequest, v2.ListSchedulersResponse]
 	listSchedulerEvents        *connect.Client[v2.ListSchedulerEventsRequest, v2.ListSchedulerEventsResponse]
+	listProjectSchedulerEvents *connect.Client[v2.ListProjectSchedulerEventsRequest, v2.ListProjectSchedulerEventsResponse]
+	invokeScheduler            *connect.Client[v2.InvokeSchedulerRequest, v2.InvokeSchedulerResponse]
 	runScheduler               *connect.Client[v2.RunSchedulerRequest, v2.RunSchedulerResponse]
 	startSchedulerRun          *connect.Client[v2.StartSchedulerRunRequest, v2.StartSchedulerRunResponse]
 	getSchedulerRun            *connect.Client[v2.GetSchedulerRunRequest, v2.GetSchedulerRunResponse]
@@ -439,6 +461,16 @@ func (c *projectServiceClient) ListSchedulerEvents(ctx context.Context, req *con
 	return c.listSchedulerEvents.CallUnary(ctx, req)
 }
 
+// ListProjectSchedulerEvents calls agentcompose.v2.ProjectService.ListProjectSchedulerEvents.
+func (c *projectServiceClient) ListProjectSchedulerEvents(ctx context.Context, req *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error) {
+	return c.listProjectSchedulerEvents.CallUnary(ctx, req)
+}
+
+// InvokeScheduler calls agentcompose.v2.ProjectService.InvokeScheduler.
+func (c *projectServiceClient) InvokeScheduler(ctx context.Context, req *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error) {
+	return c.invokeScheduler.CallUnary(ctx, req)
+}
+
 // RunScheduler calls agentcompose.v2.ProjectService.RunScheduler.
 func (c *projectServiceClient) RunScheduler(ctx context.Context, req *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error) {
 	return c.runScheduler.CallUnary(ctx, req)
@@ -485,6 +517,8 @@ type ProjectServiceHandler interface {
 	GetScheduler(context.Context, *connect.Request[v2.GetSchedulerRequest]) (*connect.Response[v2.GetSchedulerResponse], error)
 	ListSchedulers(context.Context, *connect.Request[v2.ListSchedulersRequest]) (*connect.Response[v2.ListSchedulersResponse], error)
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
+	ListProjectSchedulerEvents(context.Context, *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error)
+	InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error)
 	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
@@ -555,6 +589,18 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 		connect.WithSchema(projectServiceMethods.ByName("ListSchedulerEvents")),
 		connect.WithHandlerOptions(opts...),
 	)
+	projectServiceListProjectSchedulerEventsHandler := connect.NewUnaryHandler(
+		ProjectServiceListProjectSchedulerEventsProcedure,
+		svc.ListProjectSchedulerEvents,
+		connect.WithSchema(projectServiceMethods.ByName("ListProjectSchedulerEvents")),
+		connect.WithHandlerOptions(opts...),
+	)
+	projectServiceInvokeSchedulerHandler := connect.NewUnaryHandler(
+		ProjectServiceInvokeSchedulerProcedure,
+		svc.InvokeScheduler,
+		connect.WithSchema(projectServiceMethods.ByName("InvokeScheduler")),
+		connect.WithHandlerOptions(opts...),
+	)
 	projectServiceRunSchedulerHandler := connect.NewUnaryHandler(
 		ProjectServiceRunSchedulerProcedure,
 		svc.RunScheduler,
@@ -617,6 +663,10 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 			projectServiceListSchedulersHandler.ServeHTTP(w, r)
 		case ProjectServiceListSchedulerEventsProcedure:
 			projectServiceListSchedulerEventsHandler.ServeHTTP(w, r)
+		case ProjectServiceListProjectSchedulerEventsProcedure:
+			projectServiceListProjectSchedulerEventsHandler.ServeHTTP(w, r)
+		case ProjectServiceInvokeSchedulerProcedure:
+			projectServiceInvokeSchedulerHandler.ServeHTTP(w, r)
 		case ProjectServiceRunSchedulerProcedure:
 			projectServiceRunSchedulerHandler.ServeHTTP(w, r)
 		case ProjectServiceStartSchedulerRunProcedure:
@@ -674,6 +724,14 @@ func (UnimplementedProjectServiceHandler) ListSchedulers(context.Context, *conne
 
 func (UnimplementedProjectServiceHandler) ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListSchedulerEvents is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) ListProjectSchedulerEvents(context.Context, *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListProjectSchedulerEvents is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.InvokeScheduler is not implemented"))
 }
 
 func (UnimplementedProjectServiceHandler) RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error) {


### PR DESCRIPTION
## Summary

- Replace the misleading `scheduler run` command with foreground-only `scheduler invoke` for explicitly scripted schedulers. Invocations no longer create outer trigger-run records, loader events, or invocation artifacts.
- Make Scheduler history authoritative and unambiguous: `scheduler runs` now returns only persisted outer trigger runs, defaults to all matching results with cursor pagination, and reports linked sandbox IDs without merging inner agent runs.
- Make `scheduler logs` query all outer trigger-run events in the project by default, with scheduler, trigger, run, and tail filters backed by project-wide cursor pagination.
- Tighten Scheduler reference and help behavior for inspect/trigger commands, preserve exact historical trigger-ID filtering after a trigger is renamed or removed, and report cross-scheduler historical ID conflicts as ambiguous.
- Add `scheduler prune` with dry-run by default and explicit `--force` deletion. It supports scheduler, current or historical trigger ID, terminal status, and age filters; it removes only terminal outer trigger runs and their directly owned events, delivery/link rows, and canonical artifacts.
- Preserve running runs, historical invocations, inner project runs/events, topic events, sandboxes, loader state, and sticky bindings. Recheck terminal trigger-run eligibility transactionally and report artifact residues as partial failures.
- Reconcile stale outer `running` trigger runs to failed daemon-interrupted history at daemon startup so interrupted records do not remain permanently active.
- Avoid rewriting unchanged managed schedulers during reconcile so identical `up` operations preserve interval/timeout fire state. Update API definitions, generated clients, tests, and English/Chinese command documentation.

Streaming output is intentionally out of scope for this PR; runs and logs still collect unary cursor pages before rendering, and `scheduler invoke` remains foreground-only without persistent invocation history.

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
  - 0 issues
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
  - `build all done`
- `task docs:build`
  - passed
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.68%
  - Integration: 60.53%
  - E2E: 61.49%
  - Combined: 78.55%
- `GOFLAGS=-buildvcs=false go test -race ./pkg/loaders ./pkg/storage/configstore ./pkg/agentcompose/api ./pkg/agentcompose/app -count=1`
  - passed
- In-process daemon Scheduler prune E2E
  - covers CLI -> Connect handler -> loader use case -> SQLite -> filesystem artifacts
  - verifies exact dry-run/force counts and runs/logs/inspect visibility before and after deletion
- Shared `suit-scheduler` black-box regression suite
  - 77/77 cases passed, including repeated force-prune idempotency
- `task generate:proto`
  - generated Go and Connect sources reproduced from the updated proto
- `git diff --check`
  - passed

`GOFLAGS=-buildvcs=false` is the documented local linked-worktree compatibility setting for Go VCS stamping.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
