### PR TITLE
fix(llms): define facade environment contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,9 +131,14 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 # ---------------------------------------------------------------------------
 # LLM (optional). Configure if loaders or agents call an LLM.
 # ---------------------------------------------------------------------------
+# These values configure the daemon's real upstream. Global Env managed through
+# the control plane overrides this process/.env layer. Endpoint, protocol, key,
+# and model resolve independently, so a higher layer may override only one.
+# Empty values continue to the next layer.
 # LLM_API_ENDPOINT=https://api.openai.com
 # LLM_API_PROTOCOL=responses
 # LLM_API_KEY=
+# Alias for LLM_API_KEY; the canonical name wins when both are set here.
 # OPENAI_API_KEY=
 # LLM_MODEL=
 # LLM_TIMEOUT=60s
@@ -150,12 +155,21 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 
 # Anthropic-family facade bootstrap.
 # --------------------------------------
+# Provider family comes from these names, never from an endpoint suffix. The
+# generic LLM_API_ENDPOINT/KEY and LLM_MODEL do not bootstrap Anthropic.
 # ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Alias for ANTHROPIC_BASE_URL.
 # ANTHROPIC_API_ENDPOINT=
 # ANTHROPIC_API_KEY=
+# Alias for ANTHROPIC_API_KEY.
 # ANTHROPIC_AUTH_TOKEN=
 # ANTHROPIC_MODEL=
+# Alias for ANTHROPIC_MODEL.
 # CLAUDE_MODEL=
+
+# When the runtime facade is active, similarly named variables inside a guest
+# point to the facade and contain only a scoped facade token. Real provider keys
+# remain in the daemon and are never projected into the guest.
 
 # ---------------------------------------------------------------------------
 # OAuth (optional)

--- a/README.md
+++ b/README.md
@@ -252,14 +252,32 @@ Each agent sets a `provider`, which selects the CLI it runs inside the sandbox:
 | `gemini` | Gemini CLI |
 | `opencode` | OpenCode CLI |
 
-You configure LLM credentials once, on the daemon (in `.env`) — not per guest.
-For Codex, Claude, and OpenCode, the daemon's **Runtime LLM Facade** hands each
-sandbox a scoped token instead of your real API key, so provider keys never enter
-the guest. When that token pins an upstream provider, the model in each runtime
-request is forwarded to that provider and does not need to be listed in
-agent-compose first; an unsupported model returns the upstream provider's error.
-Compatibility tokens without a provider keep the existing configured
-model/provider resolution behavior.
+You configure LLM credentials once through daemon-side configuration (`.env` or
+Global Env), not per guest. For Codex, Claude, and OpenCode, the daemon's
+**Runtime LLM Facade** hands each sandbox a scoped token instead of your real
+API key, so provider keys never enter the guest. When that token pins an
+upstream provider, the model in each runtime request is forwarded to that
+provider and does not need to be listed in agent-compose first; an unsupported
+model returns the upstream provider's error.
+
+Provider selection and environment-field resolution are separate rules. An
+explicit provider wins first, then a configured system provider, then an
+environment-bootstrapped provider. For that env bootstrap, the applicable
+endpoint, protocol, key, and model fields resolve independently in this order:
+sandbox provider-specific overrides (**Provider Env**), control-plane **Global
+Env**, daemon process/`.env`, then defaults. A non-empty higher-layer alias
+still beats a lower-layer canonical name; within one layer, canonical names
+win, and empty values continue to the next layer. Global Env is an explicit
+control-plane override, so troubleshooting must inspect it as well as the
+deployment `.env`.
+
+Sandbox Provider Env is daemon-owned state and is never copied into the guest.
+Each facade token captures the sandbox plus execution-specific override layer,
+so concurrent executions cannot overwrite each other's endpoint, protocol, or
+key. Fields inherited from Global Env or the daemon are resolved again for each
+facade request, allowing rotations to take effect without changing explicit
+token-scoped overrides. A token bound to a configured system provider bypasses
+Provider Env resolution entirely.
 
 Set the variables for the backend family your agents use. **OpenAI-family**
 (Codex, plus the daemon's own `LLMService` and scheduler LLM calls):
@@ -279,15 +297,32 @@ ANTHROPIC_API_KEY=sk-ant-...
 ANTHROPIC_MODEL=claude-...
 ```
 
+The variable namespace, not the endpoint path, selects the provider family.
+Use `ANTHROPIC_BASE_URL` or its `ANTHROPIC_API_ENDPOINT` alias for an Anthropic
+Messages endpoint; `LLM_API_ENDPOINT` remains OpenAI-family even when its path
+ends in `/messages`. `LLM_API_KEY` and `LLM_MODEL` likewise do not bootstrap an
+Anthropic provider; use the Anthropic-specific names shown above.
+
 Set `LLM_API_PROTOCOL=chat_completions` to target any OpenAI-compatible endpoint
 (DeepSeek, vLLM, Ollama).
 
 **Per-provider notes.** OpenCode picks its upstream family from the agent's
 `model` (`provider/model`, e.g. `anthropic/…` or `openai/…`) and gets a facade
-token for it; only OpenCode's own native provider uses OpenCode's login instead.
+token for it. Codex and OpenCode `openai/*` speak Responses to the facade; when
+the resolved upstream is Chat Completions, the facade bridges the request and
+response and sends only `/chat/completions` upstream. Codex keeps Responses
+ingress because current Codex CLI model-provider configuration accepts only
+that wire API. OpenCode custom providers speak Chat Completions, while
+Anthropic-family agents speak Messages. Only OpenCode's own native provider
+uses OpenCode's login instead.
 **Gemini is the exception** — it is never handed an LLM key (`GEMINI_API_KEY` /
 `GOOGLE_API_KEY` are filtered out of the guest) and authenticates through the
 Gemini CLI's own login, persisted under the sandbox home (`~/.gemini`).
+
+The daemon-side `LLM_API_*` values always describe the real upstream. Inside a
+facade-managed guest, the same names are compatibility projections: endpoint is
+the local facade URL, key is a sandbox-scoped token, and protocol is the guest
+ingress protocol. The real provider credential never enters the guest.
 
 See [`.env.example`](.env.example) for the full list (timeouts, endpoint aliases,
 `OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) and the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -218,7 +218,11 @@ Bearer Token 不会加密网络流量。跨机器连接时，请使用 HTTPS、S
 | `gemini` | Gemini CLI |
 | `opencode` | OpenCode CLI |
 
-LLM 凭据只在 daemon（`.env`）配置一次，而不是每个 guest 各配。对 Codex、Claude 和 OpenCode，daemon 的 **Runtime LLM Facade** 给每个 sandbox 一个受限的 scoped token，而不是你的真实 API key，因此 provider key 不会进入 guest。当 token 已固定上游 provider 时，runtime 每次请求中的模型会透传给该 provider，无需预先登记到 agent-compose；provider 不支持模型时返回其上游错误。未绑定 provider 的兼容 token 保持既有的已配置 model/provider 解析行为。
+LLM 凭据只通过 daemon 侧配置（`.env` 或 Global Env）设置一次，而不是每个 guest 各配。对 Codex、Claude 和 OpenCode，daemon 的 **Runtime LLM Facade** 给每个 sandbox 一个受限的 scoped token，而不是你的真实 API key，因此 provider key 不会进入 guest。当 token 已固定上游 provider 时，runtime 每次请求中的模型会透传给该 provider，无需预先登记到 agent-compose；provider 不支持模型时返回其上游错误。
+
+Provider 选择和环境字段解析是两条独立规则。选择顺序是：显式 provider、已配置的 system provider、最后才是 env bootstrap。对 env bootstrap，适用的 endpoint、protocol、key 和 model 字段分别按以下顺序解析：sandbox 的 provider-specific override（**Provider Env**）、控制面的 **Global Env**、daemon process/`.env`、默认值。高层非空 alias 仍高于低层 canonical；同一层 canonical 优先，空值继续回退。Global Env 是显式控制面覆盖层，因此排障时必须同时检查 Global Env 和部署 `.env`。
+
+Sandbox Provider Env 由 daemon 持有，绝不会复制进 guest。每个 facade token 都会捕获 sandbox 与本次 execution 的显式覆盖层，因此并发 execution 不会互相覆盖 endpoint、protocol 或 key。继承自 Global Env 或 daemon 的字段会在每次 facade 请求时重新解析，使轮换立即生效，同时保持 token 内的显式覆盖不变。若 token 绑定的是已配置 system provider，则完全绕过 Provider Env 解析。
 
 按你的 agent 使用的后端家族设置变量。**OpenAI 家族**（Codex，以及 daemon 自身的 `LLMService` 和 scheduler LLM 调用）：
 
@@ -237,9 +241,17 @@ ANTHROPIC_API_KEY=sk-ant-...
 ANTHROPIC_MODEL=claude-...
 ```
 
+Provider family 由变量命名空间明确选择，而不是根据 endpoint 路径推断。
+Anthropic Messages endpoint 必须使用 `ANTHROPIC_BASE_URL` 或其 alias
+`ANTHROPIC_API_ENDPOINT`；即使路径以 `/messages` 结尾，`LLM_API_ENDPOINT`
+仍属于 OpenAI family。`LLM_API_KEY` 和 `LLM_MODEL` 同样不会 bootstrap
+Anthropic provider；请使用上面的 Anthropic 专用变量名。
+
 设置 `LLM_API_PROTOCOL=chat_completions` 可对接任意 OpenAI 兼容 endpoint（DeepSeek、vLLM、Ollama）。
 
-**各 provider 说明。** OpenCode 从 agent 的 `model`（`provider/model`，如 `anthropic/…` 或 `openai/…`）选择上游家族并获得对应的 facade token；只有 OpenCode 自带的原生 provider 才走 OpenCode 自身登录。**Gemini 是例外** —— 它不会拿到任何 LLM key（`GEMINI_API_KEY` / `GOOGLE_API_KEY` 会从 guest 中过滤），而是通过 Gemini CLI 自身登录，凭据持久化在 sandbox home（`~/.gemini`）。
+**各 provider 说明。** OpenCode 从 agent 的 `model`（`provider/model`，如 `anthropic/…` 或 `openai/…`）选择上游家族并获得对应的 facade token。Codex 和 OpenCode `openai/*` 都以 Responses 访问 facade；当上游解析为 Chat Completions 时，facade 转换请求与响应，上游只会收到 `/chat/completions`。Codex 保持 Responses 入站，因为当前 Codex CLI 的 model-provider 配置只接受这一 wire API。OpenCode 自定义 provider 使用 Chat Completions 入站，Anthropic 家族使用 Messages 入站。只有 OpenCode 自带的原生 provider 才走 OpenCode 自身登录。**Gemini 是例外** —— 它不会拿到任何 LLM key（`GEMINI_API_KEY` / `GOOGLE_API_KEY` 会从 guest 中过滤），而是通过 Gemini CLI 自身登录，凭据持久化在 sandbox home（`~/.gemini`）。
+
+Daemon 侧的 `LLM_API_*` 始终描述真实上游。在 facade 托管的 guest 内，同名变量只是兼容投影：endpoint 指向本地 facade，key 是 sandbox-scoped token，protocol 是 guest 入站协议；真实 provider credential 不会进入 guest。
 
 完整变量（超时、endpoint 别名、`OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN` 等）见 [`.env.example`](.env.example)；facade 的托管机制见 [docs/design/agent-compose_design.md#daemon-llm-client](docs/design/agent-compose_design.md#daemon-llm-client)。
 

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -944,15 +944,72 @@ locally. Passing plain JSON Schema performs JSON parsing.
   `chat_completions` (OpenAI-compatible Chat Completions; aliases: `chat`,
   `chat_completion`)
 
-Global env from the UI/database overrides process environment for these keys.
+Provider selection and environment-field resolution are independent. Selection
+uses an explicit provider first, then a configured system provider, then an env
+bootstrap provider. Env bootstrap resolves each field separately:
+
+1. valid sandbox provider-specific overrides (Provider Env);
+2. control-plane Global Env from the UI/database;
+3. daemon process environment / loaded `.env`;
+4. the field default.
+
+A higher source overrides only non-empty fields, so endpoint-only,
+protocol-only, key-only, and model-only sandbox configuration inherits the
+other fields. Within one source, canonical names precede aliases. A higher
+source alias still precedes a lower source canonical name, and an empty value
+falls through. Supported aliases remain `OPENAI_API_KEY` for `LLM_API_KEY`,
+`ANTHROPIC_API_ENDPOINT` for `ANTHROPIC_BASE_URL`,
+`ANTHROPIC_AUTH_TOKEN` for `ANTHROPIC_API_KEY`, and `CLAUDE_MODEL` for
+`ANTHROPIC_MODEL`. Global Env is an explicit control-plane override of the
+deployment `.env`; diagnostics must inspect both.
+
+The layers have distinct owners and lifetimes. The sandbox-owned Provider Env
+layer is persisted as daemon-only sandbox metadata and is excluded from every
+driver and guest environment projection. An agent or loader execution may add
+a transient execution overlay above it. When env bootstrap wins provider
+selection, token issuance snapshots those explicit layers into a token-unique
+facade grant. The facade request path never reconstructs a target from mutable
+sandbox state and never updates a shared session provider. Instead it combines
+the token grant with the current Global Env and daemon layers, so inherited
+field rotations are visible while concurrent or consecutive executions remain
+isolated. When a configured system provider wins, the token binds that provider
+ID and no Provider Env grant is created. Deleting a run token deletes its grant;
+sandbox removal revokes its tokens and removes their grants, while stop keeps
+them available for resume.
+
+Provider family is explicit in the variable namespace and requested agent
+family; it is never inferred from an endpoint suffix. `LLM_API_ENDPOINT` is an
+OpenAI-family field even when its path ends in `/messages`. Anthropic Messages
+configuration must establish that family with `ANTHROPIC_BASE_URL` or
+`ANTHROPIC_API_ENDPOINT` (or another Anthropic-specific key/model field), and
+Anthropic bootstrap does not inherit `LLM_API_KEY` or `LLM_MODEL`.
+
 The `chat_completions` protocol is for unary text generation only. It does not
 create workspace-capable agent sandboxes or grant file, command, or MCP tool
 access. With `outputSchema`, it uses prompt guidance and `json_object` instead
 of Responses API strict JSON Schema.
 
-Guest agent providers (`codex`, `claude`, `gemini`, `opencode`) remain separate CLI runners
-inside guest containers with their own API keys and provider-native session
-state.
+The daemon-side `LLM_API_*` values describe the real upstream. The same names
+inside a facade-managed guest are a compatibility projection: endpoint is the
+facade URL, key is a sandbox-scoped token, and protocol is the guest ingress
+wire API. Real provider keys never enter the guest.
+
+Facade ingress and upstream protocols have separate ownership:
+
+- Codex, including prompt attach, uses Responses ingress because current Codex
+  CLI model-provider configuration accepts only that wire API. The facade
+  bridges to Chat Completions when the resolved upstream requires it.
+- OpenCode `openai/*` also uses Responses ingress and the same upstream bridge.
+- OpenCode custom providers use Chat Completions ingress.
+- Anthropic-family agents use Messages ingress.
+- A facade token's `WireAPI` authorizes only guest ingress. A
+  `ResolvedTarget.WireAPI` describes only the upstream protocol. Mismatched
+  guest requests remain forbidden.
+
+Guest agent providers (`codex`, `claude`, `gemini`, `opencode`) remain separate
+CLI runners with provider-native session state. Codex, Claude, and managed
+OpenCode executions receive facade tokens rather than real upstream keys;
+Gemini continues to use its own CLI login.
 
 The loader's primary sandbox lifecycle API is:
 

--- a/docs/design/opencode_cli_support.md
+++ b/docs/design/opencode_cli_support.md
@@ -159,9 +159,9 @@ Agent execution should:
    - `frontend/src/pages/AgentsPage.svelte` and `frontend/src/api/agents.ts`
      accept `opencode`.
    - `README.md`, SDK docs, and runtime contract docs list the new provider.
-   - OpenCode environment-variable guidance notes that the exact provider key depends
-     on the selected OpenCode model provider, so document common cases rather
-     than a single universal key.
+   - OpenCode environment-variable guidance explains that provider-family key
+     and endpoint names are facade compatibility projections containing a
+     scoped token and facade URL, not real upstream credentials.
 
 7. Tests.
 
@@ -212,9 +212,9 @@ the current state files and command paths.
 
 - Confirm the exact JSON event shapes emitted by the installed `opencode-ai`
   version in the guest image against a real model backend.
-- Confirm whether OpenCode honors common provider API keys directly from the
-  environment, or whether a default config file should be mounted under
-  `/root/.opencode`.
+- Confirm the installed OpenCode version honors the facade-projected
+  provider-family environment and generated provider config for each supported
+  model family.
 - Decide separately whether existing Codex/Claude/Gemini runners should consume
   forwarded `model` / `system_prompt` or leave them as OpenCode-only runtime
   options.

--- a/docs/pages/guest-image-abi.md
+++ b/docs/pages/guest-image-abi.md
@@ -186,6 +186,25 @@ The daemon passes explicit workspace, state, and home paths. It also injects:
 | `VERSION` | Current daemon version |
 | `AGENT_COMPOSE_RUNTIME_BASE_URL` | Set when the runtime facade is configured |
 
+When the runtime LLM facade manages an agent execution, the daemon also
+projects compatibility variables such as `LLM_API_ENDPOINT`, `LLM_API_KEY`,
+`LLM_API_PROTOCOL`, provider-specific key/base URL names, and a provider model
+name when needed. In the guest these values describe the facade ingress, not
+the real upstream: the endpoint is a sandbox-scoped facade URL and every key
+value is a scoped facade token. A guest image **MUST NOT** assume that guest
+`LLM_API_*` values have the same meaning as daemon process/`.env` values, and
+real provider credentials **MUST NOT** be baked into or copied into the image.
+Sandbox and execution Provider Env remain daemon-side; only the facade URL and
+the execution's scoped token cross the guest boundary.
+
+The ingress protocol depends on the selected guest CLI. Codex, including
+prompt attach, uses Responses because current Codex CLI model-provider
+configuration accepts only that wire API. OpenCode `openai/*` also uses
+Responses ingress even when the facade bridges to a Chat Completions upstream;
+OpenCode custom providers use Chat Completions. Anthropic-family agents use
+Messages. A scoped token authorizes only its guest ingress protocol; the
+facade's resolved upstream protocol is a separate value.
+
 The `prompt` and `exec` stdout payloads, stream separation, artifact files, and
 interactive NDJSON frames are protocol, not just CLI presentation. A custom
 replacement runtime **MUST** implement the matching release protocol. Reusing
@@ -207,8 +226,9 @@ guest Dockerfile unless a combination has been independently tested.
 | Gemini | A `gemini` executable in `PATH` |
 | OpenCode | An `opencode` executable in `PATH` |
 
-Provider credentials and endpoint variables are injected at execution time.
-They **MUST NOT** be embedded in the image.
+When the facade manages an execution, facade endpoint variables and scoped
+tokens are injected at execution time. Real provider credentials remain
+daemon-side and **MUST NOT** be embedded in or passed through the image.
 
 ### 5.2 Jupyter
 

--- a/docs/pages/zh-CN/guest-image-abi.md
+++ b/docs/pages/zh-CN/guest-image-abi.md
@@ -132,6 +132,12 @@ daemon 会显式传递 workspace、state 和 home 路径，并注入：
 | `VERSION` | 当前 daemon version |
 | `AGENT_COMPOSE_RUNTIME_BASE_URL` | 配置 runtime facade 时设置 |
 
+当 runtime LLM facade 托管一次 agent 执行时，daemon 还会按需投影 `LLM_API_ENDPOINT`、`LLM_API_KEY`、`LLM_API_PROTOCOL`、provider-specific key/base URL 名称和 provider model。Guest 内这些值描述的是 facade 入站，不是真实上游：endpoint 是 sandbox-scoped facade URL，所有 key 值都是 scoped facade token。Guest image **不得**假定 guest 中 `LLM_API_*` 与 daemon process/`.env` 中同名变量语义相同，也**不得**把真实 provider credential 写入或复制进镜像。
+
+Sandbox 与 execution Provider Env 始终留在 daemon 侧；跨越 guest 边界的只有 facade URL 和本次 execution 的 scoped token。
+
+入站协议由所选 guest CLI 决定。Codex（包括 prompt attach）使用 Responses，因为当前 Codex CLI 的 model-provider 配置只接受这一 wire API。OpenCode `openai/*` 同样使用 Responses，即使 facade 桥接到 Chat Completions 上游；OpenCode 自定义 provider 使用 Chat Completions。Anthropic 家族使用 Messages。Scoped token 只授权 guest 入站协议；facade 解析出的上游协议是另一个独立值。
+
 `prompt` 和 `exec` 的 stdout payload、stream 分离、artifact 文件以及交互式 NDJSON frame 都属于协议，而不仅是 CLI 展示。自行替换 runtime 时，必须实现对应 release 的完整协议。强烈建议直接复用仓库 runtime，协议详见 [agent-compose 与 runtime 调用约定](https://github.com/chaitin/agent-compose/blob/main/docs/design/agent-compose-runtime_contract.md)。
 
 ## 5. 可选能力要求
@@ -147,7 +153,7 @@ daemon 会显式传递 workspace、state 和 home 路径，并注入：
 | Gemini | `PATH` 中的 `gemini` 可执行文件 |
 | OpenCode | `PATH` 中的 `opencode` 可执行文件 |
 
-Provider credential 和 endpoint variable 会在执行时注入，**不得**写入镜像。
+当 facade 托管一次执行时，facade endpoint variable 和 scoped token 会在执行时注入。真实 provider credential 保留在 daemon 侧，**不得**写入镜像或传入 guest。
 
 ### 5.2 Jupyter
 

--- a/docs/spec/core-e2e-test-strategy-spec.md
+++ b/docs/spec/core-e2e-test-strategy-spec.md
@@ -397,7 +397,7 @@ BoxLite、Microsandbox 的 runtime path、library path 和 image registry 继续
 | `AGT-002` | system prompt、capability guide 和 per-turn prompt 按 runtime contract 分层注入 | 三 driver |
 | `LLM-001` | `LLMService.Generate` 与 scheduler LLM 支持 Responses 和 Chat Completions | 控制面一次 |
 | `LLM-002` | structured output 成功、schema 不匹配、非法 JSON、upstream timeout/error 语义稳定 | 控制面一次 |
-| `LLM-003` | runtime facade 支持 OpenAI responses/chat 和 Anthropic messages；provider-bound token 可透传请求模型和上游模型错误，providerless 兼容 token 保持原解析行为，provider 与入口 wire scope 仍受 token 约束 | 三 driver |
+| `LLM-003` | runtime facade 支持 OpenAI responses/chat 和 Anthropic messages；provider-bound token 可透传请求模型和上游模型错误，provider 与入口 wire scope 仍受 token 约束 | 三 driver |
 | `LLM-004` | facade token 不能跨 sandbox 使用，并在 stop/remove 后撤销 | 三 driver |
 | `CAP-001` | capability catalog/status、sandbox guide 和 capability proxy 使用本地 mock 正确工作 | 三 driver |
 

--- a/pkg/agentcompose/adapters/agent_executor.go
+++ b/pkg/agentcompose/adapters/agent_executor.go
@@ -269,6 +269,7 @@ func cloneSessionForAgentExecution(session *domain.Sandbox, providerEnvItems []d
 	execSession.EnvItems = append([]domain.SandboxEnvVar(nil), session.EnvItems...)
 	execSession.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), session.RuntimeEnvItems...)
 	execSession.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), session.ProviderEnvItems...)
+	execSession.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), session.ExecutionProviderEnvItems...)
 	execution.ApplyAgentProviderEnv(&execSession, providerEnvItems)
 	return &execSession
 }

--- a/pkg/agentcompose/adapters/agent_runner.go
+++ b/pkg/agentcompose/adapters/agent_runner.go
@@ -82,6 +82,7 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 		if effectiveModel == "" {
 			effectiveModel = strings.TrimSpace(agentDef.Model)
 		}
+		execution.ApplyAgentProviderEnv(session, agentDef.EnvItems)
 	}
 	if err := execution.WriteAgentSystemPromptFile(session, systemPrompt); err != nil {
 		return domain.ExecResult{}, domain.AgentRunResult{}, err

--- a/pkg/agentcompose/adapters/loader_command_executor.go
+++ b/pkg/agentcompose/adapters/loader_command_executor.go
@@ -71,13 +71,15 @@ func (e *LoaderCommandExecutor) ExecuteLoaderCommand(ctx context.Context, sessio
 		CreatedAt: startedAt,
 		Running:   true,
 	}
-	execSession, facadeToken, err := e.prepareLoaderCommandLLMFacadeEnv(ctx, session, request, cellID)
+	execSession, managedEnv, err := e.prepareLoaderCommandLLMFacadeEnv(ctx, session, request, cellID)
 	if err != nil {
 		return domain.LoaderCommandResult{}, err
 	}
+	facadeToken := managedEnv["AGENT_COMPOSE_SANDBOX_TOKEN"]
 	if e.ConfigDB != nil && facadeToken != "" {
 		defer func() { _ = e.ConfigDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), facadeToken) }()
 	}
+	request.Env = llms.MergeManagedExecEnv(request.Env, managedEnv)
 	if err := e.Store.AddCell(ctx, session, cell); err != nil {
 		return domain.LoaderCommandResult{}, err
 	}
@@ -246,35 +248,28 @@ func (e *LoaderCommandExecutor) ExecuteLoaderCommand(ctx context.Context, sessio
 	}, nil
 }
 
-func (e *LoaderCommandExecutor) prepareLoaderCommandLLMFacadeEnv(ctx context.Context, session *domain.Sandbox, request domain.LoaderCommandRequest, runID string) (*domain.Sandbox, string, error) {
+func (e *LoaderCommandExecutor) prepareLoaderCommandLLMFacadeEnv(ctx context.Context, session *domain.Sandbox, request domain.LoaderCommandRequest, runID string) (*domain.Sandbox, map[string]string, error) {
 	if e == nil || e.Config == nil || e.ConfigDB == nil || session == nil {
-		return session, "", nil
+		return session, nil, nil
 	}
 	agent, model := llms.LoaderCommandFacadeAgentModel(request.Env)
 	if agent == "" {
-		return session, "", nil
+		return session, nil, nil
 	}
 
 	execSession := *session
 	execSession.EnvItems = append([]domain.SandboxEnvVar(nil), session.EnvItems...)
 	execSession.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), session.RuntimeEnvItems...)
 	execSession.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), session.ProviderEnvItems...)
-	if len(execSession.ProviderEnvItems) == 0 {
-		globalEnv, err := e.ConfigDB.ListGlobalEnv(ctx)
-		if err != nil {
-			return nil, "", err
-		}
-		providerEnv := domain.MergeEnvItems(globalEnv, session.EnvItems)
-		providerEnv = domain.MergeEnvItems(providerEnv, domain.LoaderCommandSandboxEnv(request))
-		execSession.ProviderEnvItems = providerEnv
-	}
+	execSession.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), session.ExecutionProviderEnvItems...)
+	execSession.ExecutionProviderEnvItems = domain.MergeEnvItems(execSession.ExecutionProviderEnvItems, domain.LoaderCommandSandboxEnv(request))
 
 	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, e.Config, facadeStoreFor(e.ConfigDB), &execSession, agent, model, runtimefacade.TokenSourceLoaderCommand, runID)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 	if len(managedEnv) > 0 {
 		execSession.RuntimeEnvItems = domain.MergeEnvItems(execSession.RuntimeEnvItems, llms.EnvItemsFromMap(managedEnv, false))
 	}
-	return &execSession, managedEnv["AGENT_COMPOSE_SANDBOX_TOKEN"], nil
+	return &execSession, managedEnv, nil
 }

--- a/pkg/agentcompose/adapters/loader_command_executor_test.go
+++ b/pkg/agentcompose/adapters/loader_command_executor_test.go
@@ -3,20 +3,28 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/samber/do/v2"
 
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/sessions"
+	"agent-compose/pkg/storage/configstore"
 	"agent-compose/pkg/storage/sessionstore"
 )
 
-type fakeLoaderCommandRuntime struct{}
+type fakeLoaderCommandRuntime struct {
+	capturedSpec    *domain.ExecSpec
+	capturedSession **domain.Sandbox
+}
 
 func (r fakeLoaderCommandRuntime) EnsureSandbox(context.Context, *domain.Sandbox, domain.VMState, domain.ProxyState) (domain.SandboxVMInfo, error) {
 	return domain.SandboxVMInfo{}, nil
@@ -34,7 +42,13 @@ func (r fakeLoaderCommandRuntime) Exec(context.Context, *domain.Sandbox, domain.
 	return domain.ExecResult{}, nil
 }
 
-func (r fakeLoaderCommandRuntime) ExecStream(_ context.Context, _ *domain.Sandbox, _ domain.VMState, _ domain.ExecSpec, stream domain.ExecStreamWriter) (domain.ExecResult, error) {
+func (r fakeLoaderCommandRuntime) ExecStream(_ context.Context, session *domain.Sandbox, _ domain.VMState, spec domain.ExecSpec, stream domain.ExecStreamWriter) (domain.ExecResult, error) {
+	if r.capturedSpec != nil {
+		*r.capturedSpec = spec
+	}
+	if r.capturedSession != nil {
+		*r.capturedSession = session
+	}
 	commandResult := domain.RuntimeCommandResult{
 		Stdout:   "loader stdout\n",
 		Stderr:   "loader stderr\n",
@@ -56,6 +70,89 @@ func (r fakeLoaderCommandRuntime) ExecStream(_ context.Context, _ *domain.Sandbo
 		ExitCode: 0,
 		Success:  true,
 	}, nil
+}
+
+func TestLoaderCommandExecutorProjectsOnlyFacadeCredentials(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:            root,
+		DbAddr:              filepath.Join(root, "config.db"),
+		SandboxRoot:         filepath.Join(root, "sandboxes"),
+		RuntimeDriver:       driverpkg.RuntimeDriverDocker,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		GuestStateRoot:      "/data/state",
+		GuestHomePath:       "/root",
+		RuntimeBaseURL:      "http://facade.internal:7410",
+		SandboxStartTimeout: 2 * time.Second,
+	}
+	store, err := sessionstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	configDB, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "loader command sandbox", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeScript, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	session.Summary.VMStatus = domain.VMStatusRunning
+	if err := store.UpdateSandbox(ctx, session); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+
+	const upstreamKey = "upstream-secret-must-not-enter-guest"
+	var capturedSpec domain.ExecSpec
+	var capturedSession *domain.Sandbox
+	runtime := fakeLoaderCommandRuntime{capturedSpec: &capturedSpec, capturedSession: &capturedSession}
+	executor := NewLoaderCommandExecutor(config, store, configDB, fakeRuntimeProvider{runtime: runtime}, sessions.NewStreamBrokerForTest())
+	result, err := executor.ExecuteLoaderCommand(ctx, session, domain.LoaderCommandRequest{
+		Mode:   "shell",
+		Script: "echo loader",
+		Env: map[string]string{
+			"AGENT_PROVIDER": "codex",
+			"CODEX_MODEL":    "test-model",
+			"LLM_API_KEY":    upstreamKey,
+		},
+		SandboxEnv: []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://upstream.example/v1"},
+			{Name: "LLM_API_PROTOCOL", Value: "chat_completions"},
+			{Name: "LLM_API_KEY", Value: upstreamKey, Secret: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteLoaderCommand returned error: %v", err)
+	}
+
+	requestBytes, err := os.ReadFile(result.Artifacts["request"])
+	if err != nil {
+		t.Fatalf("read command request artifact: %v", err)
+	}
+	if strings.Contains(string(requestBytes), upstreamKey) {
+		t.Fatal("command request artifact contains the upstream LLM key")
+	}
+	var request execution.RuntimeCommandRequest
+	if err := json.Unmarshal(requestBytes, &request); err != nil {
+		t.Fatalf("decode command request artifact: %v", err)
+	}
+	token := request.Env["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	if token == "" || request.Env["LLM_API_KEY"] != token || request.Env["OPENAI_API_KEY"] != token {
+		t.Fatalf("managed request credentials were not projected consistently: %#v", request.Env)
+	}
+	if request.Env["LLM_API_ENDPOINT"] != "http://facade.internal:7410/api/runtime/sandboxes/"+session.Summary.ID+"/llm/openai/v1" {
+		t.Fatalf("request facade endpoint = %q", request.Env["LLM_API_ENDPOINT"])
+	}
+	if strings.Contains(fmt.Sprint(capturedSpec.Env), upstreamKey) {
+		t.Fatal("child exec environment contains the upstream LLM key")
+	}
+	if capturedSpec.Env["LLM_API_KEY"] != token || capturedSession == nil {
+		t.Fatalf("child exec did not receive the managed facade token: env=%#v session=%#v", capturedSpec.Env, capturedSession)
+	}
 }
 
 func TestLoaderCommandExecutorFiltersCommandPayloadFromStreamingCellOutput(t *testing.T) {

--- a/pkg/agentcompose/adapters/loader_session_runner.go
+++ b/pkg/agentcompose/adapters/loader_session_runner.go
@@ -113,16 +113,17 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 		}
 	}
 
-	envItems, err := r.ConfigDB.ListGlobalEnv(ctx)
+	globalEnvItems, err := r.ConfigDB.ListGlobalEnv(ctx)
 	if err != nil {
 		return nil, "", err
 	}
+	var providerEnvItems []domain.SandboxEnvVar
 	if agentDefinition != nil {
-		envItems = domain.MergeEnvItems(envItems, agentDefinition.EnvItems)
+		providerEnvItems = domain.MergeEnvItems(providerEnvItems, agentDefinition.EnvItems)
 	}
-	envItems = domain.MergeEnvItems(envItems, loader.EnvItems)
-	envItems = domain.MergeEnvItems(envItems, domain.LoaderAgentSandboxEnv(request))
-	providerEnvItems := envItems
+	providerEnvItems = domain.MergeEnvItems(providerEnvItems, loader.EnvItems)
+	providerEnvItems = domain.MergeEnvItems(providerEnvItems, domain.LoaderAgentSandboxEnv(request))
+	envItems := domain.MergeEnvItems(globalEnvItems, providerEnvItems)
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	capabilityVars, capabilityTags := capabilities.BuildGatewaySandboxVars(capabilities.ProxyTarget(r.Cap), loader.Summary.CapsetIDs)
 	envItems = domain.MergeEnvItems(envItems, capabilityVars)
@@ -174,12 +175,12 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	if err != nil {
 		return nil, "", err
 	}
-	session.ProviderEnvItems = providerEnvItems
+	llms.SetSandboxProviderEnvItems(session, providerEnvItems)
 	if request.PullPolicy != "" {
 		session.Summary.PullPolicy = request.PullPolicy
-		if err := r.Store.UpdateSandbox(ctx, session); err != nil {
-			return nil, "", fmt.Errorf("persist sandbox pull policy: %w", err)
-		}
+	}
+	if err := r.Store.UpdateSandbox(ctx, session); err != nil {
+		return nil, "", fmt.Errorf("persist sandbox creation metadata: %w", err)
 	}
 	r.recordVolumeWarnings(ctx, session.Summary.ID, volumeWarnings)
 	if err := r.workspaceEnsurer.Ensure(ctx, session); err != nil {

--- a/pkg/agentcompose/adapters/loader_session_runner_workspace_ensurer_test.go
+++ b/pkg/agentcompose/adapters/loader_session_runner_workspace_ensurer_test.go
@@ -63,6 +63,13 @@ func TestLoaderSandboxRunnerEnsureUsesWorkspaceEnsurerBeforeGuideAndDriver(t *te
 		if len(driver.startCalls) != 0 {
 			t.Fatalf("driver starts before workspace ready = %#v", driver.startCalls)
 		}
+		persisted, err := bridge.store.GetSandbox(ctx, sandbox.Summary.ID)
+		if err != nil {
+			return err
+		}
+		if got := domain.SandboxEnvMap(persisted.ProviderEnvItems)["LLM_API_ENDPOINT"]; got != "https://loader.example/v1" {
+			t.Fatalf("provider env before workspace Ensure = %q", got)
+		}
 		if err := domain.TransitionSandboxWorkspaceProvisioning(sandbox, domain.SandboxWorkspaceProvisioningStatusReady); err != nil {
 			return err
 		}
@@ -90,7 +97,7 @@ func TestLoaderSandboxRunnerEnsureUsesWorkspaceEnsurerBeforeGuideAndDriver(t *te
 		Driver:        driverpkg.RuntimeDriverDocker,
 		SandboxPolicy: domain.LoaderSandboxPolicySticky,
 		CapsetIDs:     []string{"dev"},
-	}}
+	}, EnvItems: []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://loader.example/v1"}}}
 
 	sandbox, eventType, err := runner.Ensure(ctx, loader, domain.LoaderAgentRequest{BindingTriggerID: "trigger-create"}, false)
 	if err != nil {

--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -152,6 +152,11 @@ func (d *SandboxDriver) RemoveSandboxVM(ctx context.Context, session *domain.San
 			_ = d.Store.SaveVMState(session.Summary.ID, vmState)
 			return err
 		}
+		if err := d.ConfigDB.DeleteSandboxLLMResources(ctx, session.Summary.ID); err != nil {
+			vmState.LastError = err.Error()
+			_ = d.Store.SaveVMState(session.Summary.ID, vmState)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -261,6 +261,17 @@ func TestSandboxDriverStopPreservesFacadeTokensUntilRemove(t *testing.T) {
 	if err := configDB.SaveLLMFacadeToken(ctx, token); err != nil {
 		t.Fatalf("SaveLLMFacadeToken returned error: %v", err)
 	}
+	sessionProviderID := llms.SessionEnvProviderID(session.Summary.ID, llms.ProviderFamilyOpenAI)
+	if err := configDB.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:             sessionProviderID,
+		ProviderType:   llms.ProviderFamilyOpenAI,
+		DefaultWireAPI: llms.APIProtocolResponses,
+		BaseURL:        "https://provider.example/v1",
+		APIKey:         "provider-key",
+		Scope:          llms.ProviderScopeSessionEnv,
+	}, llms.Model{ID: "model-1", Name: "model-1", Scope: llms.ProviderScopeSessionEnv}); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
 	removed := false
 	runtime := fakeSessionRuntime{removeHook: func(removedSession *domain.Sandbox) {
 		removed = removedSession != nil && removedSession.Summary.ID == session.Summary.ID
@@ -277,6 +288,10 @@ func TestSandboxDriverStopPreservesFacadeTokensUntilRemove(t *testing.T) {
 	if !storedToken.RevokedAt.IsZero() {
 		t.Fatalf("facade token revoked during resumable stop: %+v", storedToken)
 	}
+	providers, err := configDB.ListEnabledLLMProviders(ctx)
+	if err != nil || len(providers) != 1 || providers[0].ID != sessionProviderID {
+		t.Fatalf("session provider changed during resumable stop: providers=%#v err=%v", providers, err)
+	}
 
 	if err := driver.RemoveSandboxVM(ctx, session); err != nil {
 		t.Fatalf("RemoveSandboxVM returned error: %v", err)
@@ -290,6 +305,13 @@ func TestSandboxDriverStopPreservesFacadeTokensUntilRemove(t *testing.T) {
 	}
 	if storedToken.RevokedAt.IsZero() {
 		t.Fatalf("facade token remains active after remove: %+v", storedToken)
+	}
+	providers, err = configDB.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders after remove returned error: %v", err)
+	}
+	if len(providers) != 0 {
+		t.Fatalf("session provider remains after remove: %#v", providers)
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge.go
@@ -159,13 +159,12 @@ func (b *SandboxRPCBridge) publishLoaderTopic(topic string, payload map[string]a
 
 func (b *SandboxRPCBridge) createSandbox(ctx context.Context, req sandboxRPCCreateRequest, source string) (*domain.Sandbox, error) {
 	tags := append([]domain.SandboxTag(nil), req.Tags...)
-	envItems := append([]domain.SandboxEnvVar(nil), req.EnvItems...)
+	providerEnvItems := append([]domain.SandboxEnvVar(nil), req.EnvItems...)
 	globalEnvItems, err := b.configDB.ListGlobalEnv(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	envItems = domain.MergeEnvItems(globalEnvItems, envItems)
-	providerEnvItems := envItems
+	envItems := domain.MergeEnvItems(globalEnvItems, providerEnvItems)
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	capabilityVars, capabilityTags := capabilities.BuildGatewaySandboxVars(capabilities.ProxyTarget(b.cap), req.CapsetIDs)
 	envItems = domain.MergeEnvItems(envItems, capabilityVars)
@@ -193,7 +192,10 @@ func (b *SandboxRPCBridge) createSandbox(ctx context.Context, req sandboxRPCCrea
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	session.ProviderEnvItems = providerEnvItems
+	llms.SetSandboxProviderEnvItems(session, providerEnvItems)
+	if err := b.store.UpdateSandbox(ctx, session); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("persist sandbox provider environment provenance: %w", err))
+	}
 	if err := b.workspaceEnsurer.Ensure(ctx, session); err != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = b.store.UpdateSandbox(ctx, session)

--- a/pkg/agentcompose/adapters/session_rpc_bridge_workspace_ensurer_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_workspace_ensurer_test.go
@@ -64,6 +64,14 @@ func TestSandboxRPCBridgeCreateSessionUsesWorkspaceEnsurer(t *testing.T) {
 	ensurer := &recordingBridgeWorkspaceEnsurer{}
 	ensurer.ensure = func(ctx context.Context, sandbox *domain.Sandbox) error {
 		order = append(order, "ensure")
+		persisted, err := bridge.store.GetSandbox(ctx, sandbox.Summary.ID)
+		if err != nil {
+			return err
+		}
+		providerEnv := domain.SandboxEnvMap(persisted.ProviderEnvItems)
+		if providerEnv["LLM_API_ENDPOINT"] != "https://sandbox.example/v1" || providerEnv["LLM_API_PROTOCOL"] != "chat_completions" {
+			t.Fatalf("provider env before workspace Ensure = %#v", providerEnv)
+		}
 		if err := domain.TransitionSandboxWorkspaceProvisioning(sandbox, domain.SandboxWorkspaceProvisioningStatusReady); err != nil {
 			return err
 		}
@@ -82,6 +90,10 @@ func TestSandboxRPCBridgeCreateSessionUsesWorkspaceEnsurer(t *testing.T) {
 		Title:       "workspace ensurer",
 		WorkspaceID: workspace.ID,
 		CapsetIDs:   []string{"dev"},
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+			{Name: "LLM_API_PROTOCOL", Value: "chat_completions"},
+		},
 	}, domain.SandboxTypeManual)
 	if err != nil {
 		t.Fatalf("CreateSession returned error: %v", err)

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -514,7 +514,7 @@ func registerRuntimeLLMFacadeRoutes(app *echo.Echo, di do.Injector) {
 		Tokens:    configDB,
 		Sandboxes: do.MustInvoke[*sessionstore.Store](di),
 		ResolveTarget: func(ctx context.Context, requestedModel, providerID string) (llms.ResolvedTarget, error) {
-			return llms.ResolveRuntimeLLMTarget(ctx, config, configDB, requestedModel, providerID)
+			return llms.ResolveFacadeRuntimeTarget(ctx, config, configDB, requestedModel, providerID)
 		},
 		Client: &http.Client{Timeout: config.LLMTimeout},
 	})

--- a/pkg/agentcompose/proxy/runtime_llm_chat_integration_test.go
+++ b/pkg/agentcompose/proxy/runtime_llm_chat_integration_test.go
@@ -1,0 +1,102 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestIntegrationRuntimeLLMFacadeUsesChatOnlyUpstream(t *testing.T) {
+	tests := []struct {
+		name       string
+		wireAPI    string
+		facadePath string
+		body       string
+	}{
+		{
+			name:       "Codex and OpenCode responses ingress",
+			wireAPI:    llms.APIProtocolResponses,
+			facadePath: "/api/runtime/sandboxes/sandbox-1/llm/openai/v1/responses",
+			body:       `{"model":"gpt","input":"hi"}`,
+		},
+		{
+			name:       "OpenCode custom chat ingress",
+			wireAPI:    llms.APIProtocolChatCompletions,
+			facadePath: "/api/runtime/sandboxes/sandbox-1/llm/openai/v1/chat/completions",
+			body:       `{"model":"gpt","messages":[{"role":"user","content":"hi"}]}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream, upstreamPaths := newChatOnlyUpstream(t)
+
+			e := echo.New()
+			RegisterRuntimeLLMFacadeRoutes(e, RuntimeLLMOptions{
+				Tokens: fakeRuntimeLLMTokens{token: llms.FacadeToken{
+					SandboxID:  "sandbox-1",
+					Model:      "gpt",
+					ProviderID: "provider-1",
+					WireAPI:    tc.wireAPI,
+					ExpiresAt:  time.Now().Add(time.Hour),
+				}},
+				Sandboxes: fakeRuntimeLLMSessions{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", VMStatus: domain.VMStatusRunning}}},
+				ResolveTarget: func(context.Context, string, string) (llms.ResolvedTarget, error) {
+					return llms.ResolvedTarget{
+						Provider: llms.Provider{ID: "provider-1", ProviderType: llms.ProviderFamilyOpenAI, BaseURL: upstream.URL + "/v1"},
+						Model:    llms.Model{Name: "gpt"},
+						WireAPI:  llms.APIProtocolChatCompletions,
+					}, nil
+				},
+				Client: upstream.Client(),
+			})
+			req := httptest.NewRequest(http.MethodPost, tc.facadePath, strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer facade-token")
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("facade status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+			upstreamPath := <-upstreamPaths
+			if upstreamPath != "/v1/chat/completions" {
+				t.Fatalf("upstream path = %q", upstreamPath)
+			}
+		})
+	}
+}
+
+func newChatOnlyUpstream(t *testing.T) (*httptest.Server, <-chan string) {
+	t.Helper()
+	paths := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths <- r.URL.Path
+		if r.URL.Path != "/v1/chat/completions" {
+			http.Error(w, "chat completions only", http.StatusNotFound)
+			return
+		}
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream request: %v", err)
+			http.Error(w, "read request", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(string(requestBody), `"messages"`) {
+			t.Errorf("upstream request is not Chat Completions: %s", requestBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, `{"id":"chatcmpl-only","object":"chat.completion","created":0,"model":"gpt","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`); err != nil {
+			t.Errorf("write upstream response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, paths
+}

--- a/pkg/agentcompose/proxy/runtime_llm_grant_integration_test.go
+++ b/pkg/agentcompose/proxy/runtime_llm_grant_integration_test.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/samber/do/v2"
+
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/llms"
+	"agent-compose/pkg/llms/runtimefacade"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/configstore"
+)
+
+func TestRuntimeLLMFacadeUsesExecutionGrantAfterSandboxReload(t *testing.T) {
+	for _, key := range []string{"LLM_API_ENDPOINT", "LLM_API_PROTOCOL", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_MODEL"} {
+		t.Setenv(key, "")
+	}
+	var upstreamPath string
+	var upstreamAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPath = r.URL.Path
+		upstreamAuthorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"gpt-test","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		DbAddr:         filepath.Join(root, "data.db"),
+		RuntimeBaseURL: "http://facade.example.test:7410",
+		GuestHomePath:  "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	executionSandbox := &domain.Sandbox{
+		Summary: domain.SandboxSummary{
+			ID:            "sandbox-execution-grant",
+			Driver:        driverpkg.RuntimeDriverDocker,
+			WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-execution-grant", "workspace"),
+		},
+		ExecutionProviderEnvItems: []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: upstream.URL + "/v1"},
+			{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolChatCompletions},
+			{Name: "LLM_API_KEY", Value: "execution-key", Secret: true},
+		},
+	}
+	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(context.Background(), config, store, executionSandbox, "codex", "gpt-test", runtimefacade.TokenSourceAgent, "run-execution")
+	if err != nil {
+		t.Fatalf("EnsureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	rawToken := managedEnv["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	if rawToken == "" {
+		t.Fatal("facade token is empty")
+	}
+
+	// The request handler sees the authoritative persisted sandbox, not the
+	// execution clone that supplied the Provider Env overlay.
+	reloadedSandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: executionSandbox.Summary.ID, VMStatus: domain.VMStatusRunning}}
+	e := echo.New()
+	RegisterRuntimeLLMFacadeRoutes(e, RuntimeLLMOptions{
+		Tokens:    store,
+		Sandboxes: runtimeLLMGrantSandboxStore{sandbox: reloadedSandbox},
+		ResolveTarget: func(ctx context.Context, model, providerID string) (llms.ResolvedTarget, error) {
+			return llms.ResolveFacadeRuntimeTarget(ctx, config, store, model, providerID)
+		},
+		Client: upstream.Client(),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/runtime/sandboxes/"+executionSandbox.Summary.ID+"/llm/openai/v1/responses", strings.NewReader(`{"model":"gpt-test","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("facade status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamPath != "/v1/chat/completions" {
+		t.Fatalf("upstream path = %q", upstreamPath)
+	}
+	if upstreamAuthorization != "Bearer execution-key" {
+		t.Fatalf("upstream authorization was not sourced from the execution grant")
+	}
+}
+
+type runtimeLLMGrantSandboxStore struct {
+	sandbox *domain.Sandbox
+}
+
+func (s runtimeLLMGrantSandboxStore) GetSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return s.sandbox, nil
+}

--- a/pkg/execution/agent_config.go
+++ b/pkg/execution/agent_config.go
@@ -34,11 +34,9 @@ func ApplyAgentProviderEnv(session *domain.Sandbox, agentEnv []domain.SandboxEnv
 	if session == nil || len(agentEnv) == 0 {
 		return
 	}
-	providerEnv := session.ProviderEnvItems
-	if len(providerEnv) == 0 {
-		providerEnv = session.EnvItems
-	}
-	session.ProviderEnvItems = domain.MergeEnvItems(agentEnv, providerEnv)
+	// A caller-supplied execution overlay already on the sandbox wins over the
+	// agent definition. Both are above the persisted sandbox provider layer.
+	session.ExecutionProviderEnvItems = domain.MergeEnvItems(agentEnv, session.ExecutionProviderEnvItems)
 }
 
 func SessionTagValue(tags []domain.SandboxTag, name string) string {

--- a/pkg/execution/artifacts_coverage_test.go
+++ b/pkg/execution/artifacts_coverage_test.go
@@ -50,13 +50,13 @@ func TestCellArtifactsAndAgentFilesWorkflows(t *testing.T) {
 	ApplyAgentProviderEnv(nil, []domain.SandboxEnvVar{{Name: "A", Value: "1"}})
 	sessionEnvTarget := &domain.Sandbox{EnvItems: []domain.SandboxEnvVar{{Name: "A", Value: "session"}}}
 	ApplyAgentProviderEnv(sessionEnvTarget, []domain.SandboxEnvVar{{Name: "A", Value: "agent"}, {Name: "B", Value: "agent"}})
-	if env := domain.SandboxEnvMap(sessionEnvTarget.ProviderEnvItems); env["A"] != "session" || env["B"] != "agent" {
-		t.Fatalf("ApplyAgentProviderEnv session env = %#v", sessionEnvTarget.ProviderEnvItems)
+	if env := domain.SandboxEnvMap(sessionEnvTarget.ExecutionProviderEnvItems); env["A"] != "agent" || env["B"] != "agent" {
+		t.Fatalf("ApplyAgentProviderEnv session env = %#v", sessionEnvTarget.ExecutionProviderEnvItems)
 	}
-	providerEnvTarget := &domain.Sandbox{EnvItems: []domain.SandboxEnvVar{{Name: "A", Value: "session"}}, ProviderEnvItems: []domain.SandboxEnvVar{{Name: "A", Value: "provider"}}}
+	providerEnvTarget := &domain.Sandbox{EnvItems: []domain.SandboxEnvVar{{Name: "A", Value: "session"}}, ExecutionProviderEnvItems: []domain.SandboxEnvVar{{Name: "A", Value: "provider"}}}
 	ApplyAgentProviderEnv(providerEnvTarget, []domain.SandboxEnvVar{{Name: "A", Value: "agent"}})
-	if env := domain.SandboxEnvMap(providerEnvTarget.ProviderEnvItems); env["A"] != "provider" {
-		t.Fatalf("ApplyAgentProviderEnv provider env = %#v", providerEnvTarget.ProviderEnvItems)
+	if env := domain.SandboxEnvMap(providerEnvTarget.ExecutionProviderEnvItems); env["A"] != "provider" {
+		t.Fatalf("ApplyAgentProviderEnv provider env = %#v", providerEnvTarget.ExecutionProviderEnvItems)
 	}
 	if SessionTagValue([]domain.SandboxTag{{Name: " agent ", Value: " codex "}}, " agent ") != "" || SessionTagValue([]domain.SandboxTag{{Name: "agent", Value: " codex "}}, "agent") != "codex" {
 		t.Fatalf("SessionTagValue returned unexpected value")

--- a/pkg/execution/driver_coverage_test.go
+++ b/pkg/execution/driver_coverage_test.go
@@ -79,6 +79,8 @@ func TestDriverConversionWorkflows(t *testing.T) {
 	}
 	session.EnvItems = []domain.SandboxEnvVar{{Name: "USER_VAR", Value: "ok"}, {Name: "LLM_API_KEY", Value: "secret"}}
 	session.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "MANAGED", Value: "yes"}}
+	session.ProviderEnvItems = []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "sandbox-provider-key", Secret: true}}
+	session.ExecutionProviderEnvItems = []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "execution-provider-key", Secret: true}}
 	env := BuildSandboxExecEnv(config, session, "/home/agent")
 	if env["USER_VAR"] != "ok" || env["LLM_API_KEY"] != "" || env["MANAGED"] != "yes" || env["SANDBOX_ID"] != "sandbox-1" {
 		t.Fatalf("sandbox exec env = %#v", env)

--- a/pkg/llms/config_helpers.go
+++ b/pkg/llms/config_helpers.go
@@ -92,7 +92,9 @@ func parseStoredUnixTimeAuto(value int64) time.Time {
 	return time.Unix(value, 0).UTC()
 }
 
-func NormalizeDefaultConfig(provider Provider, model Model) (Provider, Model, bool) {
+// NormalizeProviderConfig applies the persisted defaults and URL normalization
+// shared by provider creation and provider-only refreshes.
+func NormalizeProviderConfig(provider Provider) Provider {
 	provider.ID = firstNonEmpty(strings.TrimSpace(provider.ID), ProviderIDDefaultOpenAI)
 	provider.Name = firstNonEmpty(strings.TrimSpace(provider.Name), "default")
 	provider.ProviderType = NormalizeProviderType(provider.ProviderType)
@@ -112,6 +114,11 @@ func NormalizeDefaultConfig(provider Provider, model Model) (Provider, Model, bo
 		provider.Weight = 10
 	}
 	provider.Scope = firstNonEmpty(strings.TrimSpace(provider.Scope), ProviderScopeSystem)
+	return provider
+}
+
+func NormalizeDefaultConfig(provider Provider, model Model) (Provider, Model, bool) {
+	provider = NormalizeProviderConfig(provider)
 
 	model.ID = firstNonEmpty(strings.TrimSpace(model.ID), strings.TrimSpace(model.Name))
 	model.Name = firstNonEmpty(strings.TrimSpace(model.Name), model.ID)
@@ -253,7 +260,7 @@ func EndpointForProvider(provider Provider, wireAPI string) string {
 
 func ProviderScopeIsConfigured(scope string) bool {
 	switch strings.TrimSpace(scope) {
-	case ProviderScopeEnvDefault, ProviderScopeSessionEnv:
+	case ProviderScopeEnvDefault, ProviderScopeSessionEnv, ProviderScopeFacadeEnv:
 		return false
 	default:
 		return true

--- a/pkg/llms/config_helpers_coverage_test.go
+++ b/pkg/llms/config_helpers_coverage_test.go
@@ -17,11 +17,15 @@ import (
 func TestRuntimeConfigAndEnvHelperWorkflows(t *testing.T) {
 	root := t.TempDir()
 	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: filepath.Join(root, "workspace")}}
-	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolChatCompletions, CodexRuntimePolicyFromConfig(nil)); err != nil {
+	policy := CodexRuntimePolicyFromConfig(nil)
+	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolChatCompletions, policy); err == nil {
+		t.Fatal("WriteCodexRuntimeConfig accepted unsupported Chat Completions")
+	}
+	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolResponses, policy); err != nil {
 		t.Fatalf("WriteCodexRuntimeConfig returned error: %v", err)
 	}
 	codexConfig, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml"))
-	if err != nil || !strings.Contains(string(codexConfig), `wire_api = "chat_completions"`) || !strings.Contains(string(codexConfig), `AGENT_COMPOSE_SANDBOX_TOKEN`) {
+	if err != nil || !strings.Contains(string(codexConfig), `wire_api = "responses"`) || !strings.Contains(string(codexConfig), `AGENT_COMPOSE_SANDBOX_TOKEN`) {
 		t.Fatalf("codex config=%q err=%v", string(codexConfig), err)
 	}
 	if err := WriteOpenCodeRuntimeConfig(session, "custom", "gpt-custom", "http://runtime/openai/v1/"); err != nil {

--- a/pkg/llms/env_provider.go
+++ b/pkg/llms/env_provider.go
@@ -1,7 +1,6 @@
 package llms
 
 import (
-	"net/url"
 	"strings"
 
 	domain "agent-compose/pkg/model"
@@ -20,45 +19,13 @@ func EnvItemValue(items []domain.SandboxEnvVar, key string) string {
 	return ""
 }
 
-func LooksLikeAnthropicMessagesEndpoint(endpoint string) bool {
-	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
-	if endpoint == "" {
-		return false
-	}
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return strings.HasSuffix(endpoint, "/messages")
-	}
-	return strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), "/messages")
-}
-
-func EnvHasProviderKeyForFamily(envItems []domain.SandboxEnvVar, providerFamily string) bool {
-	switch NormalizeProviderType(providerFamily) {
-	case ProviderFamilyAnthropic:
-		return strings.TrimSpace(firstNonEmpty(
-			EnvItemValue(envItems, "ANTHROPIC_API_KEY"),
-			EnvItemValue(envItems, "ANTHROPIC_AUTH_TOKEN"),
-			EnvItemValue(envItems, "LLM_API_KEY"),
-		)) != ""
-	case ProviderFamilyOpenAI:
-		return strings.TrimSpace(firstNonEmpty(
-			EnvItemValue(envItems, "LLM_API_KEY"),
-			EnvItemValue(envItems, "OPENAI_API_KEY"),
-		)) != ""
-	default:
-		return false
-	}
-}
-
 func HasOpenAIEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
-	endpoint := EnvItemValue(envItems, "LLM_API_ENDPOINT")
-	if LooksLikeAnthropicMessagesEndpoint(endpoint) {
-		return false
-	}
 	return strings.TrimSpace(firstNonEmpty(
-		endpoint,
+		EnvItemValue(envItems, "LLM_API_ENDPOINT"),
+		EnvItemValue(envItems, "LLM_API_PROTOCOL"),
 		EnvItemValue(envItems, "LLM_API_KEY"),
 		EnvItemValue(envItems, "OPENAI_API_KEY"),
+		EnvItemValue(envItems, "LLM_MODEL"),
 	)) != ""
 }
 
@@ -68,19 +35,26 @@ func HasAnthropicEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
 		EnvItemValue(envItems, "ANTHROPIC_API_ENDPOINT"),
 		EnvItemValue(envItems, "ANTHROPIC_API_KEY"),
 		EnvItemValue(envItems, "ANTHROPIC_AUTH_TOKEN"),
-	)) != "" || LooksLikeAnthropicMessagesEndpoint(EnvItemValue(envItems, "LLM_API_ENDPOINT"))
+		EnvItemValue(envItems, "ANTHROPIC_MODEL"),
+		EnvItemValue(envItems, "CLAUDE_MODEL"),
+	)) != ""
 }
 
-func HasSessionEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
-	return HasOpenAIEnvProviderInput(envItems) || HasAnthropicEnvProviderInput(envItems)
+func HasProviderEnvInputForFamily(envItems []domain.SandboxEnvVar, providerFamily string) bool {
+	switch NormalizeOptionalProviderType(providerFamily) {
+	case ProviderFamilyAnthropic:
+		return HasAnthropicEnvProviderInput(envItems)
+	case ProviderFamilyOpenAI:
+		return HasOpenAIEnvProviderInput(envItems)
+	default:
+		return false
+	}
 }
 
 func SessionAnthropicEnvModel(envItems []domain.SandboxEnvVar) string {
-	genericModel := EnvItemValue(envItems, "LLM_MODEL")
 	return firstNonEmpty(
 		EnvItemValue(envItems, "ANTHROPIC_MODEL"),
 		EnvItemValue(envItems, "CLAUDE_MODEL"),
-		genericModel,
 	)
 }
 
@@ -102,11 +76,14 @@ func ChooseSessionEnvProviderID(current, next, nextFamily, preferredFamily strin
 	if next == "" {
 		return current
 	}
-	if strings.TrimSpace(current) == "" {
-		return next
-	}
 	preferredFamily = NormalizeOptionalProviderType(preferredFamily)
-	if preferredFamily != "" && NormalizeProviderType(nextFamily) == preferredFamily {
+	if preferredFamily != "" {
+		if NormalizeProviderType(nextFamily) == preferredFamily {
+			return next
+		}
+		return current
+	}
+	if strings.TrimSpace(current) == "" {
 		return next
 	}
 	return current

--- a/pkg/llms/facade_target_resolver.go
+++ b/pkg/llms/facade_target_resolver.go
@@ -1,0 +1,303 @@
+package llms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+// FacadeEnvironmentStore resolves token-owned Provider Env layers. The layer is
+// stored independently from selectable providers so concurrent executions can
+// never overwrite one another.
+type FacadeEnvironmentStore interface {
+	LLMResolverStore
+	GetLLMFacadeEnvironment(ctx context.Context, providerID string) (FacadeEnvironment, bool, error)
+}
+
+// ResolveFacadeTargetWithEnv applies provider selection before environment
+// resolution: an explicit configured provider, then a configured system
+// provider, then env bootstrap. Environment fields are resolved independently.
+func ResolveFacadeTargetWithEnv(ctx context.Context, config *appconfig.Config, store LLMResolverStore, providerFamily, requestedModel, explicitProviderID string, envItems []domain.SandboxEnvVar) (FacadeTarget, error) {
+	var err error
+	providerFamily, err = normalizeFacadeProviderFamily(providerFamily)
+	if err != nil {
+		return FacadeTarget{}, err
+	}
+	requestedModel = strings.TrimSpace(requestedModel)
+	explicitProviderID = strings.TrimSpace(explicitProviderID)
+
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return FacadeTarget{}, fmt.Errorf("list llm providers for facade target: %w", err)
+	}
+	if explicitProviderID != "" {
+		if provider, ok := configuredProviderByID(providers, explicitProviderID); ok {
+			target, err := resolveExplicitFacadeProviderTarget(ctx, store, provider, requestedModel)
+			return FacadeTarget{Target: target}, err
+		}
+	}
+
+	configured := configuredProvidersForFamily(providers, providerFamily)
+	if len(configured) > 0 {
+		target, err := resolveConfiguredFacadeProviderTarget(ctx, store, configured, providerFamily, requestedModel)
+		return FacadeTarget{Target: target}, err
+	}
+
+	sources, normalizedItems, err := layeredProviderEnvSources(ctx, config, store, envItems)
+	if err != nil {
+		return FacadeTarget{}, err
+	}
+	target, err := resolveFacadeEnvironmentTarget(providerFamily, firstNonEmptyTrimmed(explicitProviderID, facadeEnvironmentDefaultProviderID(providerFamily)), requestedModel, sources)
+	if err != nil {
+		return FacadeTarget{}, err
+	}
+	return FacadeTarget{
+		Target:      target,
+		Environment: facadeEnvironmentOverrides(providerFamily, normalizedItems),
+	}, nil
+}
+
+// ResolveFacadeRuntimeTarget resolves a provider-bound request without reading
+// mutable sandbox configuration. A token-owned env layer is combined with the
+// current Global Env and daemon layer; configured providers are resolved by ID.
+func ResolveFacadeRuntimeTarget(ctx context.Context, config *appconfig.Config, store FacadeEnvironmentStore, requestedModel, providerID string) (ResolvedTarget, error) {
+	requestedModel = strings.TrimSpace(requestedModel)
+	providerID = strings.TrimSpace(providerID)
+	if IsFacadeEnvironmentProviderID(providerID) {
+		environment, ok, err := store.GetLLMFacadeEnvironment(ctx, providerID)
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
+		if !ok {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm facade environment is unavailable", nil)
+		}
+		environment.ProviderType, err = normalizeFacadeProviderFamily(environment.ProviderType)
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
+		lowerSources, err := defaultProviderEnvSources(ctx, config, store)
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
+		sources := append(providerEnvSources{facadeEnvironmentSource(environment)}, lowerSources...)
+		return resolveFacadeEnvironmentTarget(environment.ProviderType, providerID, requestedModel, sources)
+	}
+	if providerID != "" {
+		target, ok, err := resolveRuntimeLLMProviderTarget(ctx, store, requestedModel, providerID)
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
+		if !ok {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm provider %q is unavailable", providerID), nil)
+		}
+		return target, nil
+	}
+	return resolveRuntimeLLMTarget(ctx, config, store, requestedModel, "")
+}
+
+// NewFacadeGrant creates a token and binds env-bootstrap selections to a unique
+// token-owned provider identity. The raw token is never stored in the grant.
+func NewFacadeGrant(sandboxID string, target FacadeTarget, ingressWireAPI, source, runID string) (string, FacadeGrant, error) {
+	rawToken, token, err := NewFacadeToken(sandboxID, target.Target.Model.Name, target.Target.Provider.ID, ingressWireAPI, source, runID)
+	if err != nil {
+		return "", FacadeGrant{}, err
+	}
+	grant := FacadeGrant{Token: token}
+	if target.Environment == nil {
+		return rawToken, grant, nil
+	}
+	environment := *target.Environment
+	environment.ProviderType, err = normalizeFacadeProviderFamily(environment.ProviderType)
+	if err != nil {
+		return "", FacadeGrant{}, err
+	}
+	environment.ProviderID = FacadeEnvironmentProviderID(token.TokenHash, environment.ProviderType)
+	grant.Token.ProviderID = environment.ProviderID
+	grant.Environment = &environment
+	return rawToken, grant, nil
+}
+
+// FacadeEnvironmentProviderID returns the private provider identity owned by a
+// single facade token.
+func FacadeEnvironmentProviderID(tokenHash, providerFamily string) string {
+	tokenHash = strings.TrimSpace(tokenHash)
+	providerFamily = NormalizeOptionalProviderType(providerFamily)
+	if tokenHash == "" || providerFamily == "" {
+		return ""
+	}
+	return "facade-env:" + tokenHash + ":" + providerFamily
+}
+
+// IsFacadeEnvironmentProviderID reports whether an ID belongs to a token-owned
+// facade environment grant.
+func IsFacadeEnvironmentProviderID(providerID string) bool {
+	return strings.HasPrefix(strings.TrimSpace(providerID), "facade-env:")
+}
+
+func configuredProviderByID(providers []Provider, providerID string) (Provider, bool) {
+	for _, provider := range providers {
+		if provider.ID == providerID && ProviderScopeIsConfigured(provider.Scope) {
+			return provider, true
+		}
+	}
+	return Provider{}, false
+}
+
+func configuredProvidersForFamily(providers []Provider, providerFamily string) []Provider {
+	configured := make([]Provider, 0, len(providers))
+	for _, provider := range providers {
+		if NormalizeProviderType(provider.ProviderType) != providerFamily || !ProviderScopeIsConfigured(provider.Scope) {
+			continue
+		}
+		configured = append(configured, provider)
+	}
+	return configured
+}
+
+func resolveExplicitFacadeProviderTarget(ctx context.Context, store LLMResolverStore, provider Provider, requestedModel string) (ResolvedTarget, error) {
+	if requestedModel != "" {
+		target, ok, err := resolveRuntimeLLMProviderTarget(ctx, store, requestedModel, provider.ID)
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
+		if ok {
+			return target, nil
+		}
+	}
+	return resolveConfiguredFacadeProviderTarget(ctx, store, []Provider{provider}, NormalizeProviderType(provider.ProviderType), requestedModel)
+}
+
+func resolveConfiguredFacadeProviderTarget(ctx context.Context, store LLMResolverStore, providers []Provider, providerFamily, requestedModel string) (ResolvedTarget, error) {
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		return ResolvedTarget{}, fmt.Errorf("list llm models for facade target: %w", err)
+	}
+	if len(models) == 0 {
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrRequired, "llm model is required", nil)
+	}
+	model, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, store, models, providers, requestedModel, providerFamily, "")
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	if !ok {
+		if requestedModel != "" {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm model %q is not configured for provider family %q", requestedModel, providerFamily), nil)
+		}
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm provider is not configured for provider family %q", providerFamily), nil)
+	}
+	return resolvedTarget(provider, model, wireAPI)
+}
+
+func resolveFacadeEnvironmentTarget(providerFamily, providerID, requestedModel string, sources providerEnvSources) (ResolvedTarget, error) {
+	var err error
+	providerFamily, err = normalizeFacadeProviderFamily(providerFamily)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	providerID = strings.TrimSpace(providerID)
+	var environment providerEnvironment
+	var provider Provider
+	switch providerFamily {
+	case ProviderFamilyAnthropic:
+		environment = sources.anthropicEnvironment()
+		if !environment.configured {
+			return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "anthropic environment is not configured", nil)
+		}
+		provider = applyAnthropicProviderEnvironment(Provider{ID: providerID, Name: providerID, Scope: ProviderScopeFacadeEnv}, environment)
+	case ProviderFamilyOpenAI:
+		environment = sources.openAIEnvironment()
+		provider = applyOpenAIProviderEnvironment(Provider{ID: providerID, Name: providerID, Scope: ProviderScopeFacadeEnv}, environment)
+	}
+	modelName := firstNonEmptyTrimmed(requestedModel, environment.model)
+	if modelName == "" {
+		return ResolvedTarget{}, domain.ClassifyError(domain.ErrRequired, "llm model is required", nil)
+	}
+	provider = NormalizeProviderConfig(provider)
+	return resolvedTarget(provider, Model{ID: modelName, Name: modelName, Enabled: true, Scope: ProviderScopeFacadeEnv}, provider.DefaultWireAPI)
+}
+
+func normalizeFacadeProviderFamily(providerFamily string) (string, error) {
+	providerFamily = NormalizeProviderType(providerFamily)
+	switch providerFamily {
+	case ProviderFamilyOpenAI, ProviderFamilyAnthropic:
+		return providerFamily, nil
+	default:
+		return "", fmt.Errorf("unsupported llm provider family %q", providerFamily)
+	}
+}
+
+func resolvedTarget(provider Provider, model Model, wireAPI string) (ResolvedTarget, error) {
+	wireAPI = NormalizeWireAPI(wireAPI)
+	headers, err := ProviderForwardHeaders(provider)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
+	return ResolvedTarget{
+		Provider: provider,
+		Model:    model,
+		WireAPI:  wireAPI,
+		Endpoint: EndpointForProvider(provider, wireAPI),
+		Headers:  headers,
+	}, nil
+}
+
+func facadeEnvironmentDefaultProviderID(providerFamily string) string {
+	if NormalizeProviderType(providerFamily) == ProviderFamilyAnthropic {
+		return ProviderIDDefaultAnthropic
+	}
+	return ProviderIDDefaultOpenAI
+}
+
+func facadeEnvironmentOverrides(providerFamily string, items []domain.SandboxEnvVar) *FacadeEnvironment {
+	sources := providerEnvSources{envItemsSource(items)}
+	providerFamily = NormalizeProviderType(providerFamily)
+	overrides := &FacadeEnvironment{ProviderType: providerFamily}
+	if providerFamily == ProviderFamilyAnthropic {
+		environment := sources.anthropicEnvironment()
+		overrides.Endpoint = environment.endpoint
+		overrides.APIKey = environment.apiKey
+		if environment.apiKey != "" {
+			overrides.AuthHeader = environment.authHeader
+			overrides.AuthScheme = environment.authScheme
+		}
+		return overrides
+	}
+	environment := sources.openAIEnvironment()
+	overrides.Endpoint = environment.endpoint
+	overrides.Protocol = environment.protocol
+	overrides.APIKey = environment.apiKey
+	return overrides
+}
+
+func facadeEnvironmentSource(environment FacadeEnvironment) providerEnvSource {
+	return func(key string) string {
+		switch NormalizeProviderType(environment.ProviderType) {
+		case ProviderFamilyAnthropic:
+			switch strings.ToUpper(strings.TrimSpace(key)) {
+			case "ANTHROPIC_BASE_URL":
+				return environment.Endpoint
+			case "ANTHROPIC_API_KEY":
+				if !strings.EqualFold(environment.AuthHeader, "Authorization") {
+					return environment.APIKey
+				}
+			case "ANTHROPIC_AUTH_TOKEN":
+				if strings.EqualFold(environment.AuthHeader, "Authorization") {
+					return environment.APIKey
+				}
+			}
+		default:
+			switch strings.ToUpper(strings.TrimSpace(key)) {
+			case "LLM_API_ENDPOINT":
+				return environment.Endpoint
+			case "LLM_API_PROTOCOL":
+				return environment.Protocol
+			case "LLM_API_KEY":
+				return environment.APIKey
+			}
+		}
+		return ""
+	}
+}

--- a/pkg/llms/model.go
+++ b/pkg/llms/model.go
@@ -12,6 +12,7 @@ const (
 	ProviderScopeSystem     = "system"
 	ProviderScopeEnvDefault = "env_default"
 	ProviderScopeSessionEnv = "session_env"
+	ProviderScopeFacadeEnv  = "facade_env"
 
 	ProviderIDDefaultOpenAI    = "default"
 	ProviderIDDefaultAnthropic = "anthropic"
@@ -58,6 +59,25 @@ type ResolvedTarget struct {
 	Headers  http.Header
 }
 
+// FacadeEnvironment is a sparse, token-owned Provider Env layer. Empty fields
+// inherit from the current Global Env and daemon configuration at request time.
+type FacadeEnvironment struct {
+	ProviderID   string
+	ProviderType string
+	Endpoint     string
+	Protocol     string
+	APIKey       string
+	AuthHeader   string
+	AuthScheme   string
+}
+
+// FacadeTarget is the upstream selected while preparing one guest execution.
+// Environment is non-nil only when provider selection reached env bootstrap.
+type FacadeTarget struct {
+	Target      ResolvedTarget
+	Environment *FacadeEnvironment
+}
+
 type FacadeToken struct {
 	SandboxID        string
 	TokenHash        string
@@ -70,4 +90,11 @@ type FacadeToken struct {
 	IssuedAt         time.Time
 	ExpiresAt        time.Time
 	RevokedAt        time.Time
+}
+
+// FacadeGrant persists a scoped token and its optional token-owned Provider Env
+// layer atomically. System-provider grants have no Environment.
+type FacadeGrant struct {
+	Token       FacadeToken
+	Environment *FacadeEnvironment
 }

--- a/pkg/llms/provider_bootstrap.go
+++ b/pkg/llms/provider_bootstrap.go
@@ -8,6 +8,8 @@ import (
 type EnvProviderLookup func(keys ...string) string
 
 type DefaultConfigStore interface {
+	// UpsertDefaultLLMConfig persists a provider/model binding. A session-scoped
+	// model must not replace metadata owned by an existing non-session model.
 	UpsertDefaultLLMConfig(ctx context.Context, provider Provider, model Model) error
 }
 
@@ -52,13 +54,19 @@ func HasConfiguredProviderForFamily(ctx context.Context, store ProviderListStore
 }
 
 func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
-	endpoint := firstNonEmpty(lookup("LLM_API_ENDPOINT"), "https://api.openai.com")
-	if LooksLikeAnthropicMessagesEndpoint(endpoint) {
-		return "", nil
+	environment := providerEnvironment{
+		endpoint: lookup("LLM_API_ENDPOINT"),
+		protocol: lookup("LLM_API_PROTOCOL"),
+		apiKey:   lookup("LLM_API_KEY", "OPENAI_API_KEY"),
+		model:    lookup("LLM_MODEL"),
 	}
-	protocol := NormalizeWireAPI(lookup("LLM_API_PROTOCOL"))
-	apiKey := lookup("LLM_API_KEY", "OPENAI_API_KEY")
-	model := strings.TrimSpace(firstNonEmpty(requestedModel, lookup("LLM_MODEL")))
+	return ensureOpenAIProviderEnvironment(ctx, store, environment, providerID, name, scope, requestedModel, defaultModel)
+}
+
+func ensureOpenAIProviderEnvironment(ctx context.Context, store DefaultConfigStore, environment providerEnvironment, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+	endpoint := firstNonEmpty(environment.endpoint, "https://api.openai.com")
+	protocol := NormalizeWireAPI(environment.protocol)
+	model := strings.TrimSpace(firstNonEmpty(requestedModel, environment.model))
 	if providerID == "" || model == "" {
 		return "", nil
 	}
@@ -68,7 +76,7 @@ func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, look
 		ProviderType:   ProviderFamilyOpenAI,
 		DefaultWireAPI: protocol,
 		BaseURL:        endpoint,
-		APIKey:         apiKey,
+		APIKey:         environment.apiKey,
 		AuthHeader:     "Authorization",
 		AuthScheme:     "Bearer",
 		HeadersJSON:    "{}",
@@ -78,25 +86,12 @@ func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, look
 	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
 }
 
-func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, authHeader, authScheme, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
-	anthropicEndpoint := lookup("ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT")
-	genericEndpoint := lookup("LLM_API_ENDPOINT")
-	anthropicKey := lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
-	anthropicModel := lookup("ANTHROPIC_MODEL", "CLAUDE_MODEL")
-	genericModel := lookup("LLM_MODEL")
-	useGenericEndpoint := anthropicEndpoint == "" && LooksLikeAnthropicMessagesEndpoint(genericEndpoint)
-	if useGenericEndpoint {
-		anthropicEndpoint = genericEndpoint
-	}
-	if genericModel != "" && (useGenericEndpoint || anthropicEndpoint != "" || anthropicKey != "" || anthropicModel != "") {
-		anthropicModel = firstNonEmpty(anthropicModel, genericModel)
-	}
-	if anthropicEndpoint == "" && strings.TrimSpace(anthropicKey) == "" && strings.TrimSpace(anthropicModel) == "" {
+func ensureAnthropicProviderEnvironment(ctx context.Context, store DefaultConfigStore, environment providerEnvironment, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+	if !environment.configured {
 		return "", nil
 	}
-	endpoint := firstNonEmpty(anthropicEndpoint, "https://api.anthropic.com")
-	apiKey := firstNonEmpty(anthropicKey, lookup("LLM_API_KEY"))
-	model := strings.TrimSpace(firstNonEmpty(requestedModel, anthropicModel))
+	endpoint := firstNonEmpty(environment.endpoint, "https://api.anthropic.com")
+	model := strings.TrimSpace(firstNonEmpty(requestedModel, environment.model))
 	if providerID == "" || model == "" {
 		return "", nil
 	}
@@ -106,22 +101,12 @@ func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, l
 		ProviderType:   ProviderFamilyAnthropic,
 		DefaultWireAPI: APIProtocolMessages,
 		BaseURL:        endpoint,
-		APIKey:         apiKey,
-		AuthHeader:     authHeader,
-		AuthScheme:     authScheme,
+		APIKey:         environment.apiKey,
+		AuthHeader:     environment.authHeader,
+		AuthScheme:     environment.authScheme,
 		HeadersJSON:    `{"anthropic-version":"2023-06-01"}`,
 		Weight:         10,
 		Enabled:        true,
 		Scope:          scope,
 	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
-}
-
-func AnthropicProviderAuthFromLookup(lookup EnvProviderLookup) (string, string) {
-	if strings.TrimSpace(lookup("ANTHROPIC_API_KEY")) != "" {
-		return "x-api-key", ""
-	}
-	if strings.TrimSpace(lookup("ANTHROPIC_AUTH_TOKEN")) != "" {
-		return "Authorization", "Bearer"
-	}
-	return "x-api-key", ""
 }

--- a/pkg/llms/provider_bootstrap.go
+++ b/pkg/llms/provider_bootstrap.go
@@ -64,49 +64,52 @@ func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, look
 }
 
 func ensureOpenAIProviderEnvironment(ctx context.Context, store DefaultConfigStore, environment providerEnvironment, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
-	endpoint := firstNonEmpty(environment.endpoint, "https://api.openai.com")
-	protocol := NormalizeWireAPI(environment.protocol)
 	model := strings.TrimSpace(firstNonEmpty(requestedModel, environment.model))
 	if providerID == "" || model == "" {
 		return "", nil
 	}
-	return providerID, store.UpsertDefaultLLMConfig(ctx, Provider{
-		ID:             providerID,
-		Name:           name,
-		ProviderType:   ProviderFamilyOpenAI,
-		DefaultWireAPI: protocol,
-		BaseURL:        endpoint,
-		APIKey:         environment.apiKey,
-		AuthHeader:     "Authorization",
-		AuthScheme:     "Bearer",
-		HeadersJSON:    "{}",
-		Weight:         10,
-		Enabled:        true,
-		Scope:          scope,
-	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
+	provider := applyOpenAIProviderEnvironment(Provider{ID: providerID, Name: name, Scope: scope}, environment)
+	return providerID, store.UpsertDefaultLLMConfig(ctx, provider, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
 }
 
 func ensureAnthropicProviderEnvironment(ctx context.Context, store DefaultConfigStore, environment providerEnvironment, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
 	if !environment.configured {
 		return "", nil
 	}
-	endpoint := firstNonEmpty(environment.endpoint, "https://api.anthropic.com")
 	model := strings.TrimSpace(firstNonEmpty(requestedModel, environment.model))
 	if providerID == "" || model == "" {
 		return "", nil
 	}
-	return providerID, store.UpsertDefaultLLMConfig(ctx, Provider{
-		ID:             providerID,
-		Name:           name,
-		ProviderType:   ProviderFamilyAnthropic,
-		DefaultWireAPI: APIProtocolMessages,
-		BaseURL:        endpoint,
-		APIKey:         environment.apiKey,
-		AuthHeader:     environment.authHeader,
-		AuthScheme:     environment.authScheme,
-		HeadersJSON:    `{"anthropic-version":"2023-06-01"}`,
-		Weight:         10,
-		Enabled:        true,
-		Scope:          scope,
-	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
+	provider := applyAnthropicProviderEnvironment(Provider{ID: providerID, Name: name, Scope: scope}, environment)
+	return providerID, store.UpsertDefaultLLMConfig(ctx, provider, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
+}
+
+func applyOpenAIProviderEnvironment(provider Provider, environment providerEnvironment) Provider {
+	provider.ProviderType = ProviderFamilyOpenAI
+	provider.DefaultWireAPI = NormalizeWireAPI(environment.protocol)
+	provider.BaseURL = firstNonEmpty(environment.endpoint, "https://api.openai.com")
+	provider.APIKey = environment.apiKey
+	provider.AuthHeader = "Authorization"
+	provider.AuthScheme = "Bearer"
+	provider.HeadersJSON = firstNonEmpty(provider.HeadersJSON, "{}")
+	if provider.Weight == 0 {
+		provider.Weight = 10
+	}
+	provider.Enabled = true
+	return provider
+}
+
+func applyAnthropicProviderEnvironment(provider Provider, environment providerEnvironment) Provider {
+	provider.ProviderType = ProviderFamilyAnthropic
+	provider.DefaultWireAPI = APIProtocolMessages
+	provider.BaseURL = firstNonEmpty(environment.endpoint, "https://api.anthropic.com")
+	provider.APIKey = environment.apiKey
+	provider.AuthHeader = environment.authHeader
+	provider.AuthScheme = environment.authScheme
+	provider.HeadersJSON = firstNonEmpty(provider.HeadersJSON, `{"anthropic-version":"2023-06-01"}`)
+	if provider.Weight == 0 {
+		provider.Weight = 10
+	}
+	provider.Enabled = true
+	return provider
 }

--- a/pkg/llms/provider_environment.go
+++ b/pkg/llms/provider_environment.go
@@ -1,0 +1,246 @@
+package llms
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+type providerEnvironment struct {
+	endpoint   string
+	protocol   string
+	apiKey     string
+	model      string
+	authHeader string
+	authScheme string
+	configured bool
+}
+
+type providerEnvValue struct {
+	name  string
+	value string
+}
+
+type providerEnvSource func(string) string
+
+type providerEnvSources []providerEnvSource
+
+func (sources providerEnvSources) lookup(keys ...string) providerEnvValue {
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		for _, key := range keys {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			if value := strings.TrimSpace(source(key)); value != "" {
+				return providerEnvValue{name: key, value: value}
+			}
+		}
+	}
+	return providerEnvValue{}
+}
+
+func (sources providerEnvSources) openAIEnvironment() providerEnvironment {
+	environment := providerEnvironment{
+		endpoint: sources.lookup("LLM_API_ENDPOINT").value,
+		protocol: sources.lookup("LLM_API_PROTOCOL").value,
+		apiKey:   sources.lookup("LLM_API_KEY", "OPENAI_API_KEY").value,
+		model:    sources.lookup("LLM_MODEL").value,
+	}
+	environment.configured = environment.endpoint != "" || environment.protocol != "" || environment.apiKey != "" || environment.model != ""
+	return environment
+}
+
+func (sources providerEnvSources) anthropicEnvironment() providerEnvironment {
+	key := sources.lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+	model := sources.lookup("ANTHROPIC_MODEL", "CLAUDE_MODEL")
+	authHeader, authScheme := "x-api-key", ""
+	if strings.EqualFold(key.name, "ANTHROPIC_AUTH_TOKEN") {
+		authHeader, authScheme = "Authorization", "Bearer"
+	}
+	environment := providerEnvironment{
+		endpoint:   sources.lookup("ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT").value,
+		apiKey:     key.value,
+		model:      model.value,
+		authHeader: authHeader,
+		authScheme: authScheme,
+	}
+	environment.configured = environment.endpoint != "" || environment.apiKey != "" || environment.model != ""
+	return environment
+}
+
+func defaultProviderEnvSources(ctx context.Context, config *appconfig.Config, store GlobalEnvStore) (providerEnvSources, error) {
+	globalItems, err := listGlobalEnvItems(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+	return providerEnvSources{
+		envItemsSource(globalItems),
+		daemonProviderEnvSource(config),
+	}, nil
+}
+
+func layeredProviderEnvSources(ctx context.Context, config *appconfig.Config, store GlobalEnvStore, sandboxItems []domain.SandboxEnvVar) (providerEnvSources, []domain.SandboxEnvVar, error) {
+	globalItems, err := listGlobalEnvItems(ctx, store)
+	if err != nil {
+		return nil, nil, err
+	}
+	sandboxItems = domain.NormalizeEnvItems(sandboxItems)
+	return providerEnvSources{
+		envItemsSource(sandboxItems),
+		envItemsSource(globalItems),
+		daemonProviderEnvSource(config),
+	}, sandboxItems, nil
+}
+
+func listGlobalEnvItems(ctx context.Context, store GlobalEnvStore) ([]domain.SandboxEnvVar, error) {
+	if store == nil {
+		return nil, nil
+	}
+	items, err := store.ListGlobalEnv(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list global provider environment: %w", err)
+	}
+	return domain.NormalizeEnvItems(items), nil
+}
+
+func envItemsSource(items []domain.SandboxEnvVar) providerEnvSource {
+	if len(items) == 0 {
+		return nil
+	}
+	return func(key string) string {
+		return EnvItemValue(items, key)
+	}
+}
+
+func daemonProviderEnvSource(config *appconfig.Config) providerEnvSource {
+	return func(key string) string {
+		if value := strings.TrimSpace(os.Getenv(strings.TrimSpace(key))); value != "" {
+			return value
+		}
+		return strings.TrimSpace(configLLMEnvValue(config, key))
+	}
+}
+
+// SetSandboxProviderEnvItems keeps provider values transient while persisting
+// the names of non-empty sandbox overrides. Names are sufficient to distinguish
+// explicit values from the Global Env values merged into Sandbox.EnvItems.
+func SetSandboxProviderEnvItems(sandbox *domain.Sandbox, items []domain.SandboxEnvVar) {
+	if sandbox == nil {
+		return
+	}
+	sandbox.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), items...)
+	sandbox.ProviderEnvOverrideNames = providerEnvOverrideNames(items)
+}
+
+func providerEnvOverrideNames(items []domain.SandboxEnvVar) []string {
+	names := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range domain.NormalizeEnvItems(items) {
+		name := strings.ToUpper(strings.TrimSpace(item.Name))
+		if name == "" || strings.TrimSpace(item.Value) == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+// SandboxProviderEnvItems reconstructs only the sandbox-owned provider layer.
+// Persisted EnvItems also contain the Global Env snapshot from sandbox creation,
+// so values are selected by recorded name provenance rather than equality with
+// today's mutable Global Env. Explicit provider keys are recovered from the
+// session provider row because their values are deliberately absent from
+// sandbox metadata.
+func SandboxProviderEnvItems(sandbox *domain.Sandbox, providerFamily string, providers []Provider) []domain.SandboxEnvVar {
+	if sandbox == nil {
+		return nil
+	}
+	providerFamily = NormalizeOptionalProviderType(providerFamily)
+	persisted := make([]domain.SandboxEnvVar, 0, len(sandbox.ProviderEnvOverrideNames))
+	providerKey := sessionProviderAPIKey(sandbox.Summary.ID, providerFamily, providers)
+	for _, name := range sandbox.ProviderEnvOverrideNames {
+		name = strings.ToUpper(strings.TrimSpace(name))
+		if name == "" {
+			continue
+		}
+		if item, ok := envItemByName(sandbox.EnvItems, name); ok && strings.TrimSpace(item.Value) != "" {
+			persisted = append(persisted, item)
+			continue
+		}
+		if providerKey != "" && providerKeyOverrideName(name, providerFamily) {
+			persisted = append(persisted, domain.SandboxEnvVar{Name: name, Value: providerKey, Secret: true})
+		}
+	}
+	return domain.MergeEnvItems(persisted, sandbox.ProviderEnvItems)
+}
+
+func envItemByName(items []domain.SandboxEnvVar, name string) (domain.SandboxEnvVar, bool) {
+	for _, item := range domain.NormalizeEnvItems(items) {
+		if strings.EqualFold(strings.TrimSpace(item.Name), strings.TrimSpace(name)) {
+			return item, true
+		}
+	}
+	return domain.SandboxEnvVar{}, false
+}
+
+func sessionProviderAPIKey(sessionID, providerFamily string, providers []Provider) string {
+	providerID := SessionEnvProviderID(sessionID, providerFamily)
+	for _, provider := range providers {
+		if provider.ID == providerID {
+			return strings.TrimSpace(provider.APIKey)
+		}
+	}
+	return ""
+}
+
+func providerKeyOverrideName(name, providerFamily string) bool {
+	switch NormalizeOptionalProviderType(providerFamily) {
+	case ProviderFamilyOpenAI:
+		return name == "LLM_API_KEY" || name == "OPENAI_API_KEY"
+	case ProviderFamilyAnthropic:
+		return name == "ANTHROPIC_API_KEY" || name == "ANTHROPIC_AUTH_TOKEN"
+	default:
+		return false
+	}
+}
+
+func providerEnvironmentLookup(sources providerEnvSources) EnvProviderLookup {
+	return func(keys ...string) string {
+		return sources.lookup(keys...).value
+	}
+}
+
+func configLLMEnvValue(config *appconfig.Config, key string) string {
+	if config == nil {
+		return ""
+	}
+	switch strings.ToUpper(strings.TrimSpace(key)) {
+	case "LLM_API_ENDPOINT":
+		return config.LLMAPIEndpoint
+	case "LLM_API_PROTOCOL":
+		return config.LLMAPIProtocol
+	case "LLM_API_KEY":
+		return config.LLMAPIKey
+	case "LLM_MODEL":
+		return config.LLMModel
+	default:
+		return ""
+	}
+}

--- a/pkg/llms/provider_environment.go
+++ b/pkg/llms/provider_environment.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
@@ -130,95 +129,76 @@ func daemonProviderEnvSource(config *appconfig.Config) providerEnvSource {
 	}
 }
 
-// SetSandboxProviderEnvItems keeps provider values transient while persisting
-// the names of non-empty sandbox overrides. Names are sufficient to distinguish
-// explicit values from the Global Env values merged into Sandbox.EnvItems.
+// SetSandboxProviderEnvItems stores only daemon-side LLM provider controls on
+// the sandbox. The driver boundary never projects this field into a guest.
 func SetSandboxProviderEnvItems(sandbox *domain.Sandbox, items []domain.SandboxEnvVar) {
 	if sandbox == nil {
 		return
 	}
-	sandbox.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), items...)
-	sandbox.ProviderEnvOverrideNames = providerEnvOverrideNames(items)
+	sandbox.ProviderEnvItems = filterSandboxProviderEnvItems(items)
 }
 
-func providerEnvOverrideNames(items []domain.SandboxEnvVar) []string {
-	names := make([]string, 0, len(items))
-	seen := make(map[string]struct{}, len(items))
+func filterSandboxProviderEnvItems(items []domain.SandboxEnvVar) []domain.SandboxEnvVar {
+	filtered := make([]domain.SandboxEnvVar, 0, len(items))
 	for _, item := range domain.NormalizeEnvItems(items) {
-		name := strings.ToUpper(strings.TrimSpace(item.Name))
-		if name == "" || strings.TrimSpace(item.Value) == "" {
+		if !sandboxProviderEnvName(item.Name) || strings.TrimSpace(item.Value) == "" {
 			continue
 		}
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		names = append(names, name)
+		filtered = append(filtered, item)
 	}
-	slices.Sort(names)
-	if len(names) == 0 {
+	if len(filtered) == 0 {
 		return nil
 	}
-	return names
+	return filtered
 }
 
-// SandboxProviderEnvItems reconstructs only the sandbox-owned provider layer.
-// Persisted EnvItems also contain the Global Env snapshot from sandbox creation,
-// so values are selected by recorded name provenance rather than equality with
-// today's mutable Global Env. Explicit provider keys are recovered from the
-// session provider row because their values are deliberately absent from
-// sandbox metadata.
-func SandboxProviderEnvItems(sandbox *domain.Sandbox, providerFamily string, providers []Provider) []domain.SandboxEnvVar {
+func sandboxProviderEnvName(name string) bool {
+	switch strings.ToUpper(strings.TrimSpace(name)) {
+	case "LLM_API_ENDPOINT", "LLM_API_PROTOCOL", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_MODEL",
+		"ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL", "CLAUDE_MODEL",
+		RuntimeBaseURLEnvName:
+		return true
+	default:
+		return false
+	}
+}
+
+// SandboxProviderEnvItems returns the effective explicit provider layer for one
+// execution. Execution values override the persisted sandbox layer; Global Env
+// and daemon configuration are deliberately not included here.
+func SandboxProviderEnvItems(sandbox *domain.Sandbox, providerFamily string) []domain.SandboxEnvVar {
 	if sandbox == nil {
 		return nil
 	}
 	providerFamily = NormalizeOptionalProviderType(providerFamily)
-	persisted := make([]domain.SandboxEnvVar, 0, len(sandbox.ProviderEnvOverrideNames))
-	providerKey := sessionProviderAPIKey(sandbox.Summary.ID, providerFamily, providers)
-	for _, name := range sandbox.ProviderEnvOverrideNames {
-		name = strings.ToUpper(strings.TrimSpace(name))
-		if name == "" {
-			continue
-		}
-		if item, ok := envItemByName(sandbox.EnvItems, name); ok && strings.TrimSpace(item.Value) != "" {
-			persisted = append(persisted, item)
-			continue
-		}
-		if providerKey != "" && providerKeyOverrideName(name, providerFamily) {
-			persisted = append(persisted, domain.SandboxEnvVar{Name: name, Value: providerKey, Secret: true})
-		}
-	}
-	return domain.MergeEnvItems(persisted, sandbox.ProviderEnvItems)
-}
-
-func envItemByName(items []domain.SandboxEnvVar, name string) (domain.SandboxEnvVar, bool) {
+	items := domain.MergeEnvItems(sandbox.ProviderEnvItems, sandbox.ExecutionProviderEnvItems)
+	filtered := make([]domain.SandboxEnvVar, 0, len(items))
 	for _, item := range domain.NormalizeEnvItems(items) {
-		if strings.EqualFold(strings.TrimSpace(item.Name), strings.TrimSpace(name)) {
-			return item, true
+		if providerEnvNameForFamily(item.Name, providerFamily) && strings.TrimSpace(item.Value) != "" {
+			filtered = append(filtered, item)
 		}
 	}
-	return domain.SandboxEnvVar{}, false
-}
-
-func sessionProviderAPIKey(sessionID, providerFamily string, providers []Provider) string {
-	providerID := SessionEnvProviderID(sessionID, providerFamily)
-	for _, provider := range providers {
-		if provider.ID == providerID {
-			return strings.TrimSpace(provider.APIKey)
-		}
+	if len(filtered) == 0 {
+		return nil
 	}
-	return ""
+	return filtered
 }
 
-func providerKeyOverrideName(name, providerFamily string) bool {
+func providerEnvNameForFamily(name, providerFamily string) bool {
+	name = strings.ToUpper(strings.TrimSpace(name))
 	switch NormalizeOptionalProviderType(providerFamily) {
 	case ProviderFamilyOpenAI:
-		return name == "LLM_API_KEY" || name == "OPENAI_API_KEY"
+		switch name {
+		case "LLM_API_ENDPOINT", "LLM_API_PROTOCOL", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_MODEL":
+			return true
+		}
 	case ProviderFamilyAnthropic:
-		return name == "ANTHROPIC_API_KEY" || name == "ANTHROPIC_AUTH_TOKEN"
-	default:
-		return false
+		switch name {
+		case "ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL", "CLAUDE_MODEL":
+			return true
+		}
 	}
+	return false
 }
 
 func providerEnvironmentLookup(sources providerEnvSources) EnvProviderLookup {

--- a/pkg/llms/provider_environment_test.go
+++ b/pkg/llms/provider_environment_test.go
@@ -1,0 +1,610 @@
+package llms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+func TestProviderEnvironmentUsesSourceMajorPrecedence(t *testing.T) {
+	isolateLLMEnv(t)
+	t.Setenv("LLM_API_ENDPOINT", "https://daemon.example/v1")
+	t.Setenv("LLM_API_PROTOCOL", APIProtocolResponses)
+	t.Setenv("LLM_API_KEY", "daemon-canonical-key")
+	t.Setenv("OPENAI_API_KEY", "daemon-alias-key")
+	t.Setenv("LLM_MODEL", "daemon-model")
+
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
+		{Name: "LLM_API_KEY", Value: "global-canonical-key"},
+		{Name: "OPENAI_API_KEY", Value: "global-alias-key"},
+		{Name: "LLM_MODEL", Value: "global-model"},
+	}
+	sources, sandboxItems := mustLayeredProviderEnvSources(t, &appconfig.Config{}, store, []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: ""},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions},
+		{Name: "OPENAI_API_KEY", Value: "sandbox-alias-key"},
+	})
+	environment := sources.openAIEnvironment()
+	if environment.endpoint != "https://global.example/v1" {
+		t.Fatalf("endpoint = %q, want Global Env value", environment.endpoint)
+	}
+	if environment.protocol != APIProtocolChatCompletions {
+		t.Fatalf("protocol = %q, want sandbox value", environment.protocol)
+	}
+	if environment.apiKey != "sandbox-alias-key" {
+		t.Fatalf("api key = %q, want higher-layer alias", environment.apiKey)
+	}
+	if environment.model != "global-model" {
+		t.Fatalf("model = %q, want Global Env value", environment.model)
+	}
+	if EnvItemValue(sandboxItems, "LLM_API_ENDPOINT") != "" {
+		t.Fatalf("empty sandbox endpoint did not remain an empty fallback: %#v", sandboxItems)
+	}
+
+	sameCanonicalSources, _ := mustLayeredProviderEnvSources(t, &appconfig.Config{}, store, []domain.SandboxEnvVar{
+		{Name: "LLM_API_KEY", Value: "global-canonical-key"},
+		{Name: "OPENAI_API_KEY", Value: "sandbox-alias-key"},
+	})
+	if got := sameCanonicalSources.openAIEnvironment().apiKey; got != "global-canonical-key" {
+		t.Fatalf("same-value sandbox canonical key = %q, want canonical to beat same-layer alias", got)
+	}
+	defaultEnvironment := mustDefaultProviderEnvSources(t, &appconfig.Config{}, store).openAIEnvironment()
+	if defaultEnvironment.apiKey != "global-canonical-key" {
+		t.Fatalf("default api key = %q, want canonical name within Global Env", defaultEnvironment.apiKey)
+	}
+
+	store.global = []domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "global-alias-key"}}
+	defaultEnvironment = mustDefaultProviderEnvSources(t, &appconfig.Config{}, store).openAIEnvironment()
+	if defaultEnvironment.apiKey != "global-alias-key" {
+		t.Fatalf("default api key = %q, want Global Env alias above daemon canonical", defaultEnvironment.apiKey)
+	}
+
+	store.global = []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: ""}}
+	defaultEnvironment = mustDefaultProviderEnvSources(t, &appconfig.Config{}, store).openAIEnvironment()
+	if defaultEnvironment.apiKey != "daemon-canonical-key" {
+		t.Fatalf("default api key = %q, want empty Global Env to fall through", defaultEnvironment.apiKey)
+	}
+}
+
+func TestProviderFamilyDoesNotDependOnEndpointPath(t *testing.T) {
+	isolateLLMEnv(t)
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/v1/messages"},
+		{Name: "LLM_API_KEY", Value: "openai-key"},
+		{Name: "LLM_MODEL", Value: "openai-model"},
+	}
+	sources := mustDefaultProviderEnvSources(t, &appconfig.Config{}, store)
+	environment := sources.openAIEnvironment()
+	if environment.endpoint != "https://gateway.example/v1/messages" {
+		t.Fatalf("OpenAI environment endpoint = %q", environment.endpoint)
+	}
+	providerID, err := ensureOpenAIProviderEnvironment(context.Background(), store, environment, ProviderIDDefaultOpenAI, "default", ProviderScopeEnvDefault, "", true)
+	if err != nil {
+		t.Fatalf("ensureOpenAIProviderEnvironment returned error: %v", err)
+	}
+	if providerID != ProviderIDDefaultOpenAI || len(store.providers) != 1 {
+		t.Fatalf("OpenAI bootstrap provider %q: %#v", providerID, store.providers)
+	}
+	provider := store.providers[0]
+	if provider.ProviderType != ProviderFamilyOpenAI || provider.BaseURL != "https://gateway.example/v1/messages" || provider.APIKey != "openai-key" {
+		t.Fatalf("OpenAI provider = %#v", provider)
+	}
+
+	anthropicEnvironment := sources.anthropicEnvironment()
+	if anthropicEnvironment.configured || anthropicEnvironment.endpoint != "" || anthropicEnvironment.apiKey != "" || anthropicEnvironment.model != "" {
+		t.Fatalf("generic OpenAI names configured Anthropic environment: %#v", anthropicEnvironment)
+	}
+}
+
+func TestSessionProviderSelectionDoesNotCrossPreferredFamily(t *testing.T) {
+	if got := ChooseSessionEnvProviderID("", "anthropic-session", ProviderFamilyAnthropic, ProviderFamilyOpenAI); got != "" {
+		t.Fatalf("non-preferred session provider = %q", got)
+	}
+	if got := ChooseSessionEnvProviderID("", "openai-session", ProviderFamilyOpenAI, ProviderFamilyOpenAI); got != "openai-session" {
+		t.Fatalf("preferred session provider = %q", got)
+	}
+}
+
+func TestRuntimeTargetBootstrapsOnlyRequestedProviderFamily(t *testing.T) {
+	t.Run("generic names are OpenAI even when endpoint ends in messages", func(t *testing.T) {
+		isolateLLMEnv(t)
+		store := newResolverCoverageStore()
+		target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-openai-generic", ProviderFamilyOpenAI, "openai-model", "", []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/v1/messages"},
+			{Name: "LLM_API_KEY", Value: "openai-key"},
+			{Name: "LLM_MODEL", Value: "openai-model"},
+		})
+		if err != nil {
+			t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+		}
+		if target.Provider.ProviderType != ProviderFamilyOpenAI || target.Provider.BaseURL != "https://gateway.example/v1/messages" || target.Provider.APIKey != "openai-key" {
+			t.Fatalf("OpenAI target = %#v", target)
+		}
+	})
+
+	t.Run("generic OpenAI names do not bootstrap Anthropic", func(t *testing.T) {
+		isolateLLMEnv(t)
+		store := newResolverCoverageStore()
+		_, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-generic", ProviderFamilyAnthropic, "claude-model", "", []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/v1/messages"},
+			{Name: "LLM_API_KEY", Value: "openai-key"},
+			{Name: "LLM_MODEL", Value: "claude-model"},
+		})
+		if err == nil {
+			t.Fatal("generic OpenAI names resolved as Anthropic")
+		}
+		if len(store.providers) != 0 {
+			t.Fatalf("generic OpenAI names created providers: %#v", store.providers)
+		}
+	})
+
+	t.Run("explicit Anthropic names bootstrap Anthropic without path inference", func(t *testing.T) {
+		isolateLLMEnv(t)
+		store := newResolverCoverageStore()
+		target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-explicit", ProviderFamilyAnthropic, "claude-model", "", []domain.SandboxEnvVar{
+			{Name: "ANTHROPIC_API_ENDPOINT", Value: "https://gateway.example/anthropic"},
+			{Name: "ANTHROPIC_AUTH_TOKEN", Value: "anthropic-key"},
+			{Name: "CLAUDE_MODEL", Value: "claude-model"},
+		})
+		if err != nil {
+			t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+		}
+		if target.Provider.ProviderType != ProviderFamilyAnthropic || target.Provider.BaseURL != "https://gateway.example/anthropic" || target.Provider.APIKey != "anthropic-key" {
+			t.Fatalf("Anthropic target = %#v", target)
+		}
+	})
+}
+
+func TestSandboxProviderEnvProvenanceDoesNotPersistSecrets(t *testing.T) {
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-provenance"}}
+	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+		{Name: "OPENAI_API_KEY", Value: "sandbox-secret", Secret: true},
+		{Name: "EMPTY_VALUE", Value: ""},
+	})
+	data, err := json.Marshal(sandbox)
+	if err != nil {
+		t.Fatalf("marshal sandbox: %v", err)
+	}
+	if strings.Contains(string(data), "sandbox-secret") {
+		t.Fatalf("sandbox metadata contains provider credential: %s", data)
+	}
+	for _, name := range []string{"LLM_API_ENDPOINT", "OPENAI_API_KEY"} {
+		if !strings.Contains(string(data), name) {
+			t.Fatalf("sandbox metadata does not contain override provenance %q: %s", name, data)
+		}
+	}
+	if strings.Contains(string(data), "EMPTY_VALUE") {
+		t.Fatalf("empty fallthrough value was recorded as an override: %s", data)
+	}
+}
+
+func TestSandboxProviderEnvRestoresExplicitKeyFromSessionProvider(t *testing.T) {
+	sandbox := &domain.Sandbox{
+		Summary:                  domain.SandboxSummary{ID: "sandbox-explicit-key"},
+		ProviderEnvOverrideNames: []string{"OPENAI_API_KEY"},
+	}
+	providers := []Provider{{
+		ID:           SessionEnvProviderID(sandbox.Summary.ID, ProviderFamilyOpenAI),
+		ProviderType: ProviderFamilyOpenAI,
+		APIKey:       "persisted-explicit-key",
+	}}
+	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
+	if got := EnvItemValue(overrides, "OPENAI_API_KEY"); got != "persisted-explicit-key" {
+		t.Fatalf("restored explicit key = %q", got)
+	}
+}
+
+func TestPersistedSandboxDoesNotPromoteInheritedGlobalEnvToOverride(t *testing.T) {
+	isolateLLMEnv(t)
+	ctx := context.Background()
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
+		{Name: "LLM_API_KEY", Value: "global-a-key"},
+		{Name: "LLM_MODEL", Value: "shared-model"},
+	}
+	if _, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-global", ProviderFamilyOpenAI, "shared-model", "", nil); err != nil {
+		t.Fatalf("initial ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	sandbox := &domain.Sandbox{
+		Summary: domain.SandboxSummary{ID: "sandbox-global"},
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
+			{Name: "LLM_MODEL", Value: "shared-model"},
+		},
+	}
+	SetSandboxProviderEnvItems(sandbox, nil)
+
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global-b.example/v1"},
+		{Name: "LLM_API_KEY", Value: "global-b-key"},
+		{Name: "LLM_MODEL", Value: "shared-model"},
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
+	if len(overrides) != 0 {
+		t.Fatalf("inherited sandbox snapshot became overrides: %#v", overrides)
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", overrides)
+	if err != nil {
+		t.Fatalf("refreshed ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if target.Provider.ID != ProviderIDDefaultOpenAI || target.Provider.BaseURL != "https://global-b.example/v1" || target.Provider.APIKey != "global-b-key" {
+		t.Fatalf("refreshed target = %#v", target)
+	}
+}
+
+func TestPersistedProtocolOverrideFollowsRotatedGlobalEndpointAndKey(t *testing.T) {
+	isolateLLMEnv(t)
+	ctx := context.Background()
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
+		{Name: "LLM_API_KEY", Value: "global-a-key"},
+		{Name: "LLM_MODEL", Value: "shared-model"},
+	}
+	sandbox := &domain.Sandbox{
+		Summary: domain.SandboxSummary{ID: "sandbox-protocol"},
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
+			{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions},
+			{Name: "LLM_MODEL", Value: "shared-model"},
+		},
+	}
+	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions}})
+	if _, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", sandbox.ProviderEnvItems); err != nil {
+		t.Fatalf("initial ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+
+	sandbox.ProviderEnvItems = nil
+	store.global[0].Value = "https://global-b.example/v1"
+	store.global[1].Value = "global-b-key"
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
+	if EnvItemValue(overrides, "LLM_API_ENDPOINT") != "" || EnvItemValue(overrides, "LLM_API_PROTOCOL") != APIProtocolChatCompletions {
+		t.Fatalf("restored overrides = %#v", overrides)
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", overrides)
+	if err != nil {
+		t.Fatalf("refreshed ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if target.Provider.Scope != ProviderScopeSessionEnv || target.Provider.BaseURL != "https://global-b.example/v1" || target.Provider.APIKey != "global-b-key" || target.WireAPI != APIProtocolChatCompletions {
+		t.Fatalf("refreshed target = %#v", target)
+	}
+}
+
+func TestSessionProviderRefreshesInheritedKey(t *testing.T) {
+	isolateLLMEnv(t)
+	ctx := context.Background()
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+		{Name: "LLM_API_KEY", Value: "old-global-key"},
+		{Name: "LLM_MODEL", Value: "shared-model"},
+	}
+	sandbox := &domain.Sandbox{
+		Summary: domain.SandboxSummary{ID: "sandbox-key-rotation"},
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+			{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+			{Name: "LLM_MODEL", Value: "shared-model"},
+		},
+	}
+	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"}})
+	initial, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", sandbox.ProviderEnvItems)
+	if err != nil {
+		t.Fatalf("initial ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if initial.Provider.APIKey != "old-global-key" {
+		t.Fatalf("initial provider key = %q", initial.Provider.APIKey)
+	}
+
+	// Simulate loading the sandbox after ProviderEnvItems has been discarded.
+	sandbox.ProviderEnvItems = nil
+	store.global[2].Value = "rotated-global-key"
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
+	refreshed, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", overrides)
+	if err != nil {
+		t.Fatalf("refreshed ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if refreshed.Provider.BaseURL != "https://sandbox.example/v1" || refreshed.Provider.APIKey != "rotated-global-key" {
+		t.Fatalf("refreshed provider = %#v", refreshed.Provider)
+	}
+}
+
+func TestTransientSessionProviderDoesNotOverrideLaterGlobalEnvironment(t *testing.T) {
+	isolateLLMEnv(t)
+	ctx := context.Background()
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+		{Name: "LLM_API_KEY", Value: "global-key"},
+		{Name: "LLM_MODEL", Value: "shared-model"},
+	}
+
+	transient, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-transient", ProviderFamilyOpenAI, "shared-model", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://transient.example/v1"},
+		{Name: "LLM_API_KEY", Value: "transient-key"},
+	})
+	if err != nil {
+		t.Fatalf("transient ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if transient.Provider.Scope != ProviderScopeSessionEnv || transient.Provider.BaseURL != "https://transient.example/v1" || transient.Provider.APIKey != "transient-key" {
+		t.Fatalf("transient target = %#v", transient)
+	}
+
+	inherited, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-transient", ProviderFamilyOpenAI, "shared-model", "", nil)
+	if err != nil {
+		t.Fatalf("inherited ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if inherited.Provider.ID != ProviderIDDefaultOpenAI || inherited.Provider.BaseURL != "https://global.example/v1" || inherited.Provider.APIKey != "global-key" {
+		t.Fatalf("inherited target = %#v", inherited)
+	}
+}
+
+func TestRuntimeTargetFailsClosedWhenGlobalEnvironmentCannotBeRead(t *testing.T) {
+	isolateLLMEnv(t)
+	globalErr := errors.New("global environment unavailable")
+	store := newResolverCoverageStore()
+	store.globalErr = globalErr
+
+	_, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{
+		LLMAPIKey: "daemon-key",
+		LLMModel:  "daemon-model",
+	}, store, "sandbox-global-error", ProviderFamilyOpenAI, "", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+	})
+	if !errors.Is(err, globalErr) {
+		t.Fatalf("ResolveRuntimeLLMTargetWithEnv error = %v, want %v", err, globalErr)
+	}
+	if len(store.providers) != 0 || len(store.models) != 0 {
+		t.Fatalf("failed resolution persisted providers=%#v models=%#v", store.providers, store.models)
+	}
+}
+
+func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		sandboxEnv   []domain.SandboxEnvVar
+		wantEndpoint string
+		wantProtocol string
+		wantKey      string
+		wantModel    string
+	}{
+		{
+			name:         "endpoint only",
+			sandboxEnv:   []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"}},
+			wantEndpoint: "https://sandbox.example/v1",
+			wantProtocol: APIProtocolResponses,
+			wantKey:      "global-key",
+			wantModel:    "global-model",
+		},
+		{
+			name:         "protocol only",
+			sandboxEnv:   []domain.SandboxEnvVar{{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions}},
+			wantEndpoint: "https://global.example/v1",
+			wantProtocol: APIProtocolChatCompletions,
+			wantKey:      "global-key",
+			wantModel:    "global-model",
+		},
+		{
+			name:         "key alias only",
+			sandboxEnv:   []domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "sandbox-key"}},
+			wantEndpoint: "https://global.example/v1",
+			wantProtocol: APIProtocolResponses,
+			wantKey:      "sandbox-key",
+			wantModel:    "global-model",
+		},
+		{
+			name:         "model only",
+			sandboxEnv:   []domain.SandboxEnvVar{{Name: "LLM_MODEL", Value: "sandbox-model"}},
+			wantEndpoint: "https://global.example/v1",
+			wantProtocol: APIProtocolResponses,
+			wantKey:      "global-key",
+			wantModel:    "sandbox-model",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateLLMEnv(t)
+			store := newResolverCoverageStore()
+			store.global = []domain.SandboxEnvVar{
+				{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
+				{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+				{Name: "LLM_API_KEY", Value: "global-key"},
+				{Name: "LLM_MODEL", Value: "global-model"},
+			}
+			target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-layered", ProviderFamilyOpenAI, "", "", tc.sandboxEnv)
+			if err != nil {
+				t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+			}
+			if target.Provider.Scope != ProviderScopeSessionEnv {
+				t.Fatalf("provider scope = %q, want session env", target.Provider.Scope)
+			}
+			if target.Provider.BaseURL != tc.wantEndpoint || target.Provider.APIKey != tc.wantKey || target.WireAPI != tc.wantProtocol || target.Model.ID != tc.wantModel {
+				t.Fatalf("target = %#v, want endpoint=%q protocol=%q key=%q model=%q", target, tc.wantEndpoint, tc.wantProtocol, tc.wantKey, tc.wantModel)
+			}
+			wantPath := "/responses"
+			if tc.wantProtocol == APIProtocolChatCompletions {
+				wantPath = "/chat/completions"
+			}
+			if !strings.HasSuffix(target.Endpoint, wantPath) {
+				t.Fatalf("upstream endpoint = %q, want suffix %q", target.Endpoint, wantPath)
+			}
+		})
+	}
+}
+
+func TestRuntimeTargetSessionAnthropicFieldsUseLayeredAliases(t *testing.T) {
+	isolateLLMEnv(t)
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://global.anthropic.example"},
+		{Name: "ANTHROPIC_API_KEY", Value: "global-anthropic-key"},
+		{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic", ProviderFamilyAnthropic, "", "", []domain.SandboxEnvVar{
+		{Name: "ANTHROPIC_API_ENDPOINT", Value: "https://sandbox.anthropic.example"},
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"},
+		{Name: "CLAUDE_MODEL", Value: "sandbox-claude"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if target.Provider.BaseURL != "https://sandbox.anthropic.example" || target.Provider.APIKey != "sandbox-auth-token" || target.Provider.AuthHeader != "Authorization" || target.Provider.AuthScheme != "Bearer" || target.Model.ID != "sandbox-claude" {
+		t.Fatalf("target = %#v", target)
+	}
+}
+
+func TestRuntimeTargetSessionProviderInheritsUnsetAnthropicFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		sandboxEnv     []domain.SandboxEnvVar
+		wantEndpoint   string
+		wantKey        string
+		wantModel      string
+		wantAuthHeader string
+		wantAuthScheme string
+	}{
+		{
+			name:           "endpoint alias only",
+			sandboxEnv:     []domain.SandboxEnvVar{{Name: "ANTHROPIC_API_ENDPOINT", Value: "https://sandbox.anthropic.example"}},
+			wantEndpoint:   "https://sandbox.anthropic.example",
+			wantKey:        "global-anthropic-key",
+			wantModel:      "global-claude",
+			wantAuthHeader: "x-api-key",
+		},
+		{
+			name:           "auth token alias only",
+			sandboxEnv:     []domain.SandboxEnvVar{{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"}},
+			wantEndpoint:   "https://global.anthropic.example",
+			wantKey:        "sandbox-auth-token",
+			wantModel:      "global-claude",
+			wantAuthHeader: "Authorization",
+			wantAuthScheme: "Bearer",
+		},
+		{
+			name:           "model alias only",
+			sandboxEnv:     []domain.SandboxEnvVar{{Name: "CLAUDE_MODEL", Value: "sandbox-claude"}},
+			wantEndpoint:   "https://global.anthropic.example",
+			wantKey:        "global-anthropic-key",
+			wantModel:      "sandbox-claude",
+			wantAuthHeader: "x-api-key",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateLLMEnv(t)
+			store := newResolverCoverageStore()
+			store.global = []domain.SandboxEnvVar{
+				{Name: "ANTHROPIC_BASE_URL", Value: "https://global.anthropic.example"},
+				{Name: "ANTHROPIC_API_KEY", Value: "global-anthropic-key"},
+				{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
+			}
+			target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-layered", ProviderFamilyAnthropic, "", "", tc.sandboxEnv)
+			if err != nil {
+				t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+			}
+			if target.Provider.Scope != ProviderScopeSessionEnv {
+				t.Fatalf("provider scope = %q, want session env", target.Provider.Scope)
+			}
+			if target.Provider.BaseURL != tc.wantEndpoint || target.Provider.APIKey != tc.wantKey || target.Model.ID != tc.wantModel || target.Provider.AuthHeader != tc.wantAuthHeader || target.Provider.AuthScheme != tc.wantAuthScheme {
+				t.Fatalf("target = %#v, want endpoint=%q key=%q model=%q auth header=%q scheme=%q", target, tc.wantEndpoint, tc.wantKey, tc.wantModel, tc.wantAuthHeader, tc.wantAuthScheme)
+			}
+			if !strings.HasSuffix(target.Endpoint, "/messages") {
+				t.Fatalf("upstream endpoint = %q, want messages path", target.Endpoint)
+			}
+		})
+	}
+}
+
+func TestRuntimeTargetConfiguredProviderPrecedesEnvironmentBootstrap(t *testing.T) {
+	isolateLLMEnv(t)
+	store := newResolverCoverageStore()
+	store.providers = []Provider{{
+		ID:             "system-provider",
+		ProviderType:   ProviderFamilyOpenAI,
+		DefaultWireAPI: APIProtocolResponses,
+		BaseURL:        "https://system.example/v1",
+		APIKey:         "system-key",
+		Enabled:        true,
+		Scope:          ProviderScopeSystem,
+	}}
+	store.models = []Model{{ID: "system-model", Name: "system-model", Enabled: true, Scope: ProviderScopeSystem}}
+	store.wire["system-provider\x00system-model"] = APIProtocolResponses
+
+	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{
+		LLMAPIEndpoint: "https://daemon.example/v1",
+		LLMAPIKey:      "daemon-key",
+	}, store, "sandbox-system", ProviderFamilyOpenAI, "system-model", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions},
+		{Name: "LLM_API_KEY", Value: "sandbox-key"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if target.Provider.ID != "system-provider" || target.Provider.BaseURL != "https://system.example/v1" || target.WireAPI != APIProtocolResponses {
+		t.Fatalf("target = %#v, want configured system provider", target)
+	}
+	if len(store.providers) != 1 {
+		t.Fatalf("providers = %#v, environment bootstrap should not add a provider", store.providers)
+	}
+
+	store.providers = append(store.providers, Provider{
+		ID:             "explicit-provider",
+		ProviderType:   ProviderFamilyOpenAI,
+		DefaultWireAPI: APIProtocolChatCompletions,
+		BaseURL:        "https://explicit.example/v1",
+		APIKey:         "explicit-key",
+		Enabled:        true,
+		Scope:          ProviderScopeEnvDefault,
+	})
+	store.wire["explicit-provider\x00system-model"] = APIProtocolChatCompletions
+	explicitTarget, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-system", ProviderFamilyOpenAI, "system-model", "explicit-provider", nil)
+	if err != nil {
+		t.Fatalf("ResolveRuntimeLLMTargetWithEnv explicit provider returned error: %v", err)
+	}
+	if explicitTarget.Provider.ID != "explicit-provider" || explicitTarget.WireAPI != APIProtocolChatCompletions {
+		t.Fatalf("explicit target = %#v", explicitTarget)
+	}
+}
+
+func mustDefaultProviderEnvSources(t *testing.T, config *appconfig.Config, store GlobalEnvStore) providerEnvSources {
+	t.Helper()
+	sources, err := defaultProviderEnvSources(context.Background(), config, store)
+	if err != nil {
+		t.Fatalf("defaultProviderEnvSources returned error: %v", err)
+	}
+	return sources
+}
+
+func mustLayeredProviderEnvSources(t *testing.T, config *appconfig.Config, store GlobalEnvStore, items []domain.SandboxEnvVar) (providerEnvSources, []domain.SandboxEnvVar) {
+	t.Helper()
+	sources, normalized, err := layeredProviderEnvSources(context.Background(), config, store, items)
+	if err != nil {
+		t.Fatalf("layeredProviderEnvSources returned error: %v", err)
+	}
+	return sources, normalized
+}

--- a/pkg/llms/provider_environment_test.go
+++ b/pkg/llms/provider_environment_test.go
@@ -32,361 +32,98 @@ func TestProviderEnvironmentUsesSourceMajorPrecedence(t *testing.T) {
 		{Name: "OPENAI_API_KEY", Value: "sandbox-alias-key"},
 	})
 	environment := sources.openAIEnvironment()
-	if environment.endpoint != "https://global.example/v1" {
-		t.Fatalf("endpoint = %q, want Global Env value", environment.endpoint)
+	if environment.endpoint != "https://global.example/v1" || environment.protocol != APIProtocolChatCompletions {
+		t.Fatalf("resolved endpoint/protocol = %q/%q", environment.endpoint, environment.protocol)
 	}
-	if environment.protocol != APIProtocolChatCompletions {
-		t.Fatalf("protocol = %q, want sandbox value", environment.protocol)
-	}
-	if environment.apiKey != "sandbox-alias-key" {
-		t.Fatalf("api key = %q, want higher-layer alias", environment.apiKey)
-	}
-	if environment.model != "global-model" {
-		t.Fatalf("model = %q, want Global Env value", environment.model)
+	if environment.apiKey != "sandbox-alias-key" || environment.model != "global-model" {
+		t.Fatalf("resolved key/model = %q/%q", environment.apiKey, environment.model)
 	}
 	if EnvItemValue(sandboxItems, "LLM_API_ENDPOINT") != "" {
-		t.Fatalf("empty sandbox endpoint did not remain an empty fallback: %#v", sandboxItems)
+		t.Fatalf("empty sandbox endpoint unexpectedly became a value: %#v", sandboxItems)
 	}
 
-	sameCanonicalSources, _ := mustLayeredProviderEnvSources(t, &appconfig.Config{}, store, []domain.SandboxEnvVar{
-		{Name: "LLM_API_KEY", Value: "global-canonical-key"},
-		{Name: "OPENAI_API_KEY", Value: "sandbox-alias-key"},
-	})
-	if got := sameCanonicalSources.openAIEnvironment().apiKey; got != "global-canonical-key" {
-		t.Fatalf("same-value sandbox canonical key = %q, want canonical to beat same-layer alias", got)
-	}
-	defaultEnvironment := mustDefaultProviderEnvSources(t, &appconfig.Config{}, store).openAIEnvironment()
-	if defaultEnvironment.apiKey != "global-canonical-key" {
-		t.Fatalf("default api key = %q, want canonical name within Global Env", defaultEnvironment.apiKey)
-	}
-
-	store.global = []domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "global-alias-key"}}
-	defaultEnvironment = mustDefaultProviderEnvSources(t, &appconfig.Config{}, store).openAIEnvironment()
-	if defaultEnvironment.apiKey != "global-alias-key" {
-		t.Fatalf("default api key = %q, want Global Env alias above daemon canonical", defaultEnvironment.apiKey)
-	}
-
-	store.global = []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: ""}}
-	defaultEnvironment = mustDefaultProviderEnvSources(t, &appconfig.Config{}, store).openAIEnvironment()
-	if defaultEnvironment.apiKey != "daemon-canonical-key" {
-		t.Fatalf("default api key = %q, want empty Global Env to fall through", defaultEnvironment.apiKey)
+	canonical := providerEnvSources{envItemsSource([]domain.SandboxEnvVar{
+		{Name: "LLM_API_KEY", Value: "canonical"},
+		{Name: "OPENAI_API_KEY", Value: "alias"},
+	})}.openAIEnvironment()
+	if canonical.apiKey != "canonical" {
+		t.Fatalf("same-layer canonical key lost to alias")
 	}
 }
 
 func TestProviderFamilyDoesNotDependOnEndpointPath(t *testing.T) {
 	isolateLLMEnv(t)
-	store := newResolverCoverageStore()
-	store.global = []domain.SandboxEnvVar{
+	sources := providerEnvSources{envItemsSource([]domain.SandboxEnvVar{
 		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/v1/messages"},
 		{Name: "LLM_API_KEY", Value: "openai-key"},
 		{Name: "LLM_MODEL", Value: "openai-model"},
+	})}
+	if got := sources.openAIEnvironment(); !got.configured || got.endpoint == "" || got.apiKey == "" {
+		t.Fatalf("generic variables did not configure OpenAI family: %#v", got)
 	}
-	sources := mustDefaultProviderEnvSources(t, &appconfig.Config{}, store)
-	environment := sources.openAIEnvironment()
-	if environment.endpoint != "https://gateway.example/v1/messages" {
-		t.Fatalf("OpenAI environment endpoint = %q", environment.endpoint)
+	if got := sources.anthropicEnvironment(); got.configured || got.endpoint != "" || got.apiKey != "" {
+		t.Fatalf("generic endpoint leaked into Anthropic family: %#v", got)
 	}
-	providerID, err := ensureOpenAIProviderEnvironment(context.Background(), store, environment, ProviderIDDefaultOpenAI, "default", ProviderScopeEnvDefault, "", true)
+
+	store := newResolverCoverageStore()
+	target, err := ResolveFacadeTargetWithEnv(context.Background(), &appconfig.Config{}, store, ProviderFamilyOpenAI, "openai-model", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/v1/messages"},
+		{Name: "LLM_API_KEY", Value: "openai-key"},
+	})
 	if err != nil {
-		t.Fatalf("ensureOpenAIProviderEnvironment returned error: %v", err)
+		t.Fatalf("ResolveFacadeTargetWithEnv returned error: %v", err)
 	}
-	if providerID != ProviderIDDefaultOpenAI || len(store.providers) != 1 {
-		t.Fatalf("OpenAI bootstrap provider %q: %#v", providerID, store.providers)
-	}
-	provider := store.providers[0]
-	if provider.ProviderType != ProviderFamilyOpenAI || provider.BaseURL != "https://gateway.example/v1/messages" || provider.APIKey != "openai-key" {
-		t.Fatalf("OpenAI provider = %#v", provider)
-	}
-
-	anthropicEnvironment := sources.anthropicEnvironment()
-	if anthropicEnvironment.configured || anthropicEnvironment.endpoint != "" || anthropicEnvironment.apiKey != "" || anthropicEnvironment.model != "" {
-		t.Fatalf("generic OpenAI names configured Anthropic environment: %#v", anthropicEnvironment)
+	if target.Target.Provider.ProviderType != ProviderFamilyOpenAI {
+		t.Fatalf("provider family = %q", target.Target.Provider.ProviderType)
 	}
 }
 
-func TestSessionProviderSelectionDoesNotCrossPreferredFamily(t *testing.T) {
-	if got := ChooseSessionEnvProviderID("", "anthropic-session", ProviderFamilyAnthropic, ProviderFamilyOpenAI); got != "" {
-		t.Fatalf("non-preferred session provider = %q", got)
-	}
-	if got := ChooseSessionEnvProviderID("", "openai-session", ProviderFamilyOpenAI, ProviderFamilyOpenAI); got != "openai-session" {
-		t.Fatalf("preferred session provider = %q", got)
-	}
-}
-
-func TestRuntimeTargetBootstrapsOnlyRequestedProviderFamily(t *testing.T) {
-	t.Run("generic names are OpenAI even when endpoint ends in messages", func(t *testing.T) {
-		isolateLLMEnv(t)
-		store := newResolverCoverageStore()
-		target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-openai-generic", ProviderFamilyOpenAI, "openai-model", "", []domain.SandboxEnvVar{
-			{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/v1/messages"},
-			{Name: "LLM_API_KEY", Value: "openai-key"},
-			{Name: "LLM_MODEL", Value: "openai-model"},
-		})
-		if err != nil {
-			t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-		}
-		if target.Provider.ProviderType != ProviderFamilyOpenAI || target.Provider.BaseURL != "https://gateway.example/v1/messages" || target.Provider.APIKey != "openai-key" {
-			t.Fatalf("OpenAI target = %#v", target)
-		}
-	})
-
-	t.Run("generic OpenAI names do not bootstrap Anthropic", func(t *testing.T) {
-		isolateLLMEnv(t)
-		store := newResolverCoverageStore()
-		_, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-generic", ProviderFamilyAnthropic, "claude-model", "", []domain.SandboxEnvVar{
-			{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/v1/messages"},
-			{Name: "LLM_API_KEY", Value: "openai-key"},
-			{Name: "LLM_MODEL", Value: "claude-model"},
-		})
-		if err == nil {
-			t.Fatal("generic OpenAI names resolved as Anthropic")
-		}
-		if len(store.providers) != 0 {
-			t.Fatalf("generic OpenAI names created providers: %#v", store.providers)
-		}
-	})
-
-	t.Run("explicit Anthropic names bootstrap Anthropic without path inference", func(t *testing.T) {
-		isolateLLMEnv(t)
-		store := newResolverCoverageStore()
-		target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-explicit", ProviderFamilyAnthropic, "claude-model", "", []domain.SandboxEnvVar{
-			{Name: "ANTHROPIC_API_ENDPOINT", Value: "https://gateway.example/anthropic"},
-			{Name: "ANTHROPIC_AUTH_TOKEN", Value: "anthropic-key"},
-			{Name: "CLAUDE_MODEL", Value: "claude-model"},
-		})
-		if err != nil {
-			t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-		}
-		if target.Provider.ProviderType != ProviderFamilyAnthropic || target.Provider.BaseURL != "https://gateway.example/anthropic" || target.Provider.APIKey != "anthropic-key" {
-			t.Fatalf("Anthropic target = %#v", target)
-		}
-	})
-}
-
-func TestSandboxProviderEnvProvenanceDoesNotPersistSecrets(t *testing.T) {
-	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-provenance"}}
+func TestSandboxProviderEnvironmentHasSeparatePersistentAndExecutionLayers(t *testing.T) {
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-layered"}}
 	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{
 		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
-		{Name: "OPENAI_API_KEY", Value: "sandbox-secret", Secret: true},
-		{Name: "EMPTY_VALUE", Value: ""},
+		{Name: "LLM_API_KEY", Value: "sandbox-key", Secret: true},
+		{Name: "ANTHROPIC_MODEL", Value: "claude-sandbox"},
+		{Name: "ORDINARY", Value: "not-provider-env"},
 	})
+	sandbox.ExecutionProviderEnvItems = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://execution.example/v1"},
+		{Name: "OPENAI_API_KEY", Value: "execution-key", Secret: true},
+	}
+
+	openAI := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI)
+	if EnvItemValue(openAI, "LLM_API_ENDPOINT") != "https://execution.example/v1" || EnvItemValue(openAI, "OPENAI_API_KEY") != "execution-key" {
+		t.Fatalf("effective execution layer = %#v", openAI)
+	}
+	if EnvItemValue(openAI, "ANTHROPIC_MODEL") != "" || EnvItemValue(sandbox.ProviderEnvItems, "ORDINARY") != "" {
+		t.Fatalf("provider family filtering failed: sandbox=%#v effective=%#v", sandbox.ProviderEnvItems, openAI)
+	}
+
 	data, err := json.Marshal(sandbox)
 	if err != nil {
 		t.Fatalf("marshal sandbox: %v", err)
 	}
-	if strings.Contains(string(data), "sandbox-secret") {
-		t.Fatalf("sandbox metadata contains provider credential: %s", data)
+	var persisted domain.Sandbox
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("unmarshal sandbox: %v", err)
 	}
-	for _, name := range []string{"LLM_API_ENDPOINT", "OPENAI_API_KEY"} {
-		if !strings.Contains(string(data), name) {
-			t.Fatalf("sandbox metadata does not contain override provenance %q: %s", name, data)
-		}
+	if EnvItemValue(persisted.ProviderEnvItems, "LLM_API_KEY") != "sandbox-key" {
+		t.Fatalf("persisted sandbox provider layer = %#v", persisted.ProviderEnvItems)
 	}
-	if strings.Contains(string(data), "EMPTY_VALUE") {
-		t.Fatalf("empty fallthrough value was recorded as an override: %s", data)
+	if len(persisted.ExecutionProviderEnvItems) != 0 {
+		t.Fatalf("execution layer was persisted: %#v", persisted.ExecutionProviderEnvItems)
+	}
+
+	envOnly := &domain.Sandbox{EnvItems: []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://ordinary.example/v1"}}}
+	if got := SandboxProviderEnvItems(envOnly, ProviderFamilyOpenAI); len(got) != 0 {
+		t.Fatalf("ordinary EnvItems were inferred as Provider Env: %#v", got)
 	}
 }
 
-func TestSandboxProviderEnvRestoresExplicitKeyFromSessionProvider(t *testing.T) {
-	sandbox := &domain.Sandbox{
-		Summary:                  domain.SandboxSummary{ID: "sandbox-explicit-key"},
-		ProviderEnvOverrideNames: []string{"OPENAI_API_KEY"},
-	}
-	providers := []Provider{{
-		ID:           SessionEnvProviderID(sandbox.Summary.ID, ProviderFamilyOpenAI),
-		ProviderType: ProviderFamilyOpenAI,
-		APIKey:       "persisted-explicit-key",
-	}}
-	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
-	if got := EnvItemValue(overrides, "OPENAI_API_KEY"); got != "persisted-explicit-key" {
-		t.Fatalf("restored explicit key = %q", got)
-	}
-}
-
-func TestPersistedSandboxDoesNotPromoteInheritedGlobalEnvToOverride(t *testing.T) {
-	isolateLLMEnv(t)
-	ctx := context.Background()
-	store := newResolverCoverageStore()
-	store.global = []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
-		{Name: "LLM_API_KEY", Value: "global-a-key"},
-		{Name: "LLM_MODEL", Value: "shared-model"},
-	}
-	if _, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-global", ProviderFamilyOpenAI, "shared-model", "", nil); err != nil {
-		t.Fatalf("initial ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	sandbox := &domain.Sandbox{
-		Summary: domain.SandboxSummary{ID: "sandbox-global"},
-		EnvItems: []domain.SandboxEnvVar{
-			{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
-			{Name: "LLM_MODEL", Value: "shared-model"},
-		},
-	}
-	SetSandboxProviderEnvItems(sandbox, nil)
-
-	store.global = []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://global-b.example/v1"},
-		{Name: "LLM_API_KEY", Value: "global-b-key"},
-		{Name: "LLM_MODEL", Value: "shared-model"},
-	}
-	providers, err := store.ListEnabledLLMProviders(ctx)
-	if err != nil {
-		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
-	}
-	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
-	if len(overrides) != 0 {
-		t.Fatalf("inherited sandbox snapshot became overrides: %#v", overrides)
-	}
-	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", overrides)
-	if err != nil {
-		t.Fatalf("refreshed ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if target.Provider.ID != ProviderIDDefaultOpenAI || target.Provider.BaseURL != "https://global-b.example/v1" || target.Provider.APIKey != "global-b-key" {
-		t.Fatalf("refreshed target = %#v", target)
-	}
-}
-
-func TestPersistedProtocolOverrideFollowsRotatedGlobalEndpointAndKey(t *testing.T) {
-	isolateLLMEnv(t)
-	ctx := context.Background()
-	store := newResolverCoverageStore()
-	store.global = []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
-		{Name: "LLM_API_KEY", Value: "global-a-key"},
-		{Name: "LLM_MODEL", Value: "shared-model"},
-	}
-	sandbox := &domain.Sandbox{
-		Summary: domain.SandboxSummary{ID: "sandbox-protocol"},
-		EnvItems: []domain.SandboxEnvVar{
-			{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
-			{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions},
-			{Name: "LLM_MODEL", Value: "shared-model"},
-		},
-	}
-	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions}})
-	if _, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", sandbox.ProviderEnvItems); err != nil {
-		t.Fatalf("initial ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-
-	sandbox.ProviderEnvItems = nil
-	store.global[0].Value = "https://global-b.example/v1"
-	store.global[1].Value = "global-b-key"
-	providers, err := store.ListEnabledLLMProviders(ctx)
-	if err != nil {
-		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
-	}
-	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
-	if EnvItemValue(overrides, "LLM_API_ENDPOINT") != "" || EnvItemValue(overrides, "LLM_API_PROTOCOL") != APIProtocolChatCompletions {
-		t.Fatalf("restored overrides = %#v", overrides)
-	}
-	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", overrides)
-	if err != nil {
-		t.Fatalf("refreshed ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if target.Provider.Scope != ProviderScopeSessionEnv || target.Provider.BaseURL != "https://global-b.example/v1" || target.Provider.APIKey != "global-b-key" || target.WireAPI != APIProtocolChatCompletions {
-		t.Fatalf("refreshed target = %#v", target)
-	}
-}
-
-func TestSessionProviderRefreshesInheritedKey(t *testing.T) {
-	isolateLLMEnv(t)
-	ctx := context.Background()
-	store := newResolverCoverageStore()
-	store.global = []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
-		{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
-		{Name: "LLM_API_KEY", Value: "old-global-key"},
-		{Name: "LLM_MODEL", Value: "shared-model"},
-	}
-	sandbox := &domain.Sandbox{
-		Summary: domain.SandboxSummary{ID: "sandbox-key-rotation"},
-		EnvItems: []domain.SandboxEnvVar{
-			{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
-			{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
-			{Name: "LLM_MODEL", Value: "shared-model"},
-		},
-	}
-	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"}})
-	initial, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", sandbox.ProviderEnvItems)
-	if err != nil {
-		t.Fatalf("initial ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if initial.Provider.APIKey != "old-global-key" {
-		t.Fatalf("initial provider key = %q", initial.Provider.APIKey)
-	}
-
-	// Simulate loading the sandbox after ProviderEnvItems has been discarded.
-	sandbox.ProviderEnvItems = nil
-	store.global[2].Value = "rotated-global-key"
-	providers, err := store.ListEnabledLLMProviders(ctx)
-	if err != nil {
-		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
-	}
-	overrides := SandboxProviderEnvItems(sandbox, ProviderFamilyOpenAI, providers)
-	refreshed, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, sandbox.Summary.ID, ProviderFamilyOpenAI, "shared-model", "", overrides)
-	if err != nil {
-		t.Fatalf("refreshed ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if refreshed.Provider.BaseURL != "https://sandbox.example/v1" || refreshed.Provider.APIKey != "rotated-global-key" {
-		t.Fatalf("refreshed provider = %#v", refreshed.Provider)
-	}
-}
-
-func TestTransientSessionProviderDoesNotOverrideLaterGlobalEnvironment(t *testing.T) {
-	isolateLLMEnv(t)
-	ctx := context.Background()
-	store := newResolverCoverageStore()
-	store.global = []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
-		{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
-		{Name: "LLM_API_KEY", Value: "global-key"},
-		{Name: "LLM_MODEL", Value: "shared-model"},
-	}
-
-	transient, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-transient", ProviderFamilyOpenAI, "shared-model", "", []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://transient.example/v1"},
-		{Name: "LLM_API_KEY", Value: "transient-key"},
-	})
-	if err != nil {
-		t.Fatalf("transient ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if transient.Provider.Scope != ProviderScopeSessionEnv || transient.Provider.BaseURL != "https://transient.example/v1" || transient.Provider.APIKey != "transient-key" {
-		t.Fatalf("transient target = %#v", transient)
-	}
-
-	inherited, err := ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-transient", ProviderFamilyOpenAI, "shared-model", "", nil)
-	if err != nil {
-		t.Fatalf("inherited ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if inherited.Provider.ID != ProviderIDDefaultOpenAI || inherited.Provider.BaseURL != "https://global.example/v1" || inherited.Provider.APIKey != "global-key" {
-		t.Fatalf("inherited target = %#v", inherited)
-	}
-}
-
-func TestRuntimeTargetFailsClosedWhenGlobalEnvironmentCannotBeRead(t *testing.T) {
-	isolateLLMEnv(t)
-	globalErr := errors.New("global environment unavailable")
-	store := newResolverCoverageStore()
-	store.globalErr = globalErr
-
-	_, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{
-		LLMAPIKey: "daemon-key",
-		LLMModel:  "daemon-model",
-	}, store, "sandbox-global-error", ProviderFamilyOpenAI, "", "", []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
-	})
-	if !errors.Is(err, globalErr) {
-		t.Fatalf("ResolveRuntimeLLMTargetWithEnv error = %v, want %v", err, globalErr)
-	}
-	if len(store.providers) != 0 || len(store.models) != 0 {
-		t.Fatalf("failed resolution persisted providers=%#v models=%#v", store.providers, store.models)
-	}
-}
-
-func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
+func TestFacadeEnvironmentTargetInheritsFieldsIndependently(t *testing.T) {
 	tests := []struct {
 		name         string
-		sandboxEnv   []domain.SandboxEnvVar
+		overrides    []domain.SandboxEnvVar
 		wantEndpoint string
 		wantProtocol string
 		wantKey      string
@@ -394,7 +131,7 @@ func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
 	}{
 		{
 			name:         "endpoint only",
-			sandboxEnv:   []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"}},
+			overrides:    []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"}},
 			wantEndpoint: "https://sandbox.example/v1",
 			wantProtocol: APIProtocolResponses,
 			wantKey:      "global-key",
@@ -402,7 +139,7 @@ func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
 		},
 		{
 			name:         "protocol only",
-			sandboxEnv:   []domain.SandboxEnvVar{{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions}},
+			overrides:    []domain.SandboxEnvVar{{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions}},
 			wantEndpoint: "https://global.example/v1",
 			wantProtocol: APIProtocolChatCompletions,
 			wantKey:      "global-key",
@@ -410,7 +147,7 @@ func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
 		},
 		{
 			name:         "key alias only",
-			sandboxEnv:   []domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "sandbox-key"}},
+			overrides:    []domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "sandbox-key"}},
 			wantEndpoint: "https://global.example/v1",
 			wantProtocol: APIProtocolResponses,
 			wantKey:      "sandbox-key",
@@ -418,7 +155,7 @@ func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
 		},
 		{
 			name:         "model only",
-			sandboxEnv:   []domain.SandboxEnvVar{{Name: "LLM_MODEL", Value: "sandbox-model"}},
+			overrides:    []domain.SandboxEnvVar{{Name: "LLM_MODEL", Value: "sandbox-model"}},
 			wantEndpoint: "https://global.example/v1",
 			wantProtocol: APIProtocolResponses,
 			wantKey:      "global-key",
@@ -435,15 +172,13 @@ func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
 				{Name: "LLM_API_KEY", Value: "global-key"},
 				{Name: "LLM_MODEL", Value: "global-model"},
 			}
-			target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-layered", ProviderFamilyOpenAI, "", "", tc.sandboxEnv)
+			selection, err := ResolveFacadeTargetWithEnv(context.Background(), &appconfig.Config{}, store, ProviderFamilyOpenAI, "", "", tc.overrides)
 			if err != nil {
-				t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+				t.Fatalf("ResolveFacadeTargetWithEnv returned error: %v", err)
 			}
-			if target.Provider.Scope != ProviderScopeSessionEnv {
-				t.Fatalf("provider scope = %q, want session env", target.Provider.Scope)
-			}
+			target := selection.Target
 			if target.Provider.BaseURL != tc.wantEndpoint || target.Provider.APIKey != tc.wantKey || target.WireAPI != tc.wantProtocol || target.Model.ID != tc.wantModel {
-				t.Fatalf("target = %#v, want endpoint=%q protocol=%q key=%q model=%q", target, tc.wantEndpoint, tc.wantProtocol, tc.wantKey, tc.wantModel)
+				t.Fatalf("target = %#v", target)
 			}
 			wantPath := "/responses"
 			if tc.wantProtocol == APIProtocolChatCompletions {
@@ -456,7 +191,7 @@ func TestRuntimeTargetSessionProviderInheritsUnsetOpenAIFields(t *testing.T) {
 	}
 }
 
-func TestRuntimeTargetSessionAnthropicFieldsUseLayeredAliases(t *testing.T) {
+func TestFacadeEnvironmentTargetUsesAnthropicAliases(t *testing.T) {
 	isolateLLMEnv(t)
 	store := newResolverCoverageStore()
 	store.global = []domain.SandboxEnvVar{
@@ -464,83 +199,129 @@ func TestRuntimeTargetSessionAnthropicFieldsUseLayeredAliases(t *testing.T) {
 		{Name: "ANTHROPIC_API_KEY", Value: "global-anthropic-key"},
 		{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
 	}
-	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic", ProviderFamilyAnthropic, "", "", []domain.SandboxEnvVar{
+	selection, err := ResolveFacadeTargetWithEnv(context.Background(), &appconfig.Config{}, store, ProviderFamilyAnthropic, "", "", []domain.SandboxEnvVar{
 		{Name: "ANTHROPIC_API_ENDPOINT", Value: "https://sandbox.anthropic.example"},
 		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"},
 		{Name: "CLAUDE_MODEL", Value: "sandbox-claude"},
 	})
 	if err != nil {
-		t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+		t.Fatalf("ResolveFacadeTargetWithEnv returned error: %v", err)
 	}
-	if target.Provider.BaseURL != "https://sandbox.anthropic.example" || target.Provider.APIKey != "sandbox-auth-token" || target.Provider.AuthHeader != "Authorization" || target.Provider.AuthScheme != "Bearer" || target.Model.ID != "sandbox-claude" {
+	target := selection.Target
+	if target.Provider.BaseURL != "https://sandbox.anthropic.example/v1" || target.Provider.AuthHeader != "Authorization" || target.Provider.AuthScheme != "Bearer" || target.Model.ID != "sandbox-claude" {
 		t.Fatalf("target = %#v", target)
 	}
-}
-
-func TestRuntimeTargetSessionProviderInheritsUnsetAnthropicFields(t *testing.T) {
-	tests := []struct {
-		name           string
-		sandboxEnv     []domain.SandboxEnvVar
-		wantEndpoint   string
-		wantKey        string
-		wantModel      string
-		wantAuthHeader string
-		wantAuthScheme string
-	}{
-		{
-			name:           "endpoint alias only",
-			sandboxEnv:     []domain.SandboxEnvVar{{Name: "ANTHROPIC_API_ENDPOINT", Value: "https://sandbox.anthropic.example"}},
-			wantEndpoint:   "https://sandbox.anthropic.example",
-			wantKey:        "global-anthropic-key",
-			wantModel:      "global-claude",
-			wantAuthHeader: "x-api-key",
-		},
-		{
-			name:           "auth token alias only",
-			sandboxEnv:     []domain.SandboxEnvVar{{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"}},
-			wantEndpoint:   "https://global.anthropic.example",
-			wantKey:        "sandbox-auth-token",
-			wantModel:      "global-claude",
-			wantAuthHeader: "Authorization",
-			wantAuthScheme: "Bearer",
-		},
-		{
-			name:           "model alias only",
-			sandboxEnv:     []domain.SandboxEnvVar{{Name: "CLAUDE_MODEL", Value: "sandbox-claude"}},
-			wantEndpoint:   "https://global.anthropic.example",
-			wantKey:        "global-anthropic-key",
-			wantModel:      "sandbox-claude",
-			wantAuthHeader: "x-api-key",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			isolateLLMEnv(t)
-			store := newResolverCoverageStore()
-			store.global = []domain.SandboxEnvVar{
-				{Name: "ANTHROPIC_BASE_URL", Value: "https://global.anthropic.example"},
-				{Name: "ANTHROPIC_API_KEY", Value: "global-anthropic-key"},
-				{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
-			}
-			target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-layered", ProviderFamilyAnthropic, "", "", tc.sandboxEnv)
-			if err != nil {
-				t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-			}
-			if target.Provider.Scope != ProviderScopeSessionEnv {
-				t.Fatalf("provider scope = %q, want session env", target.Provider.Scope)
-			}
-			if target.Provider.BaseURL != tc.wantEndpoint || target.Provider.APIKey != tc.wantKey || target.Model.ID != tc.wantModel || target.Provider.AuthHeader != tc.wantAuthHeader || target.Provider.AuthScheme != tc.wantAuthScheme {
-				t.Fatalf("target = %#v, want endpoint=%q key=%q model=%q auth header=%q scheme=%q", target, tc.wantEndpoint, tc.wantKey, tc.wantModel, tc.wantAuthHeader, tc.wantAuthScheme)
-			}
-			if !strings.HasSuffix(target.Endpoint, "/messages") {
-				t.Fatalf("upstream endpoint = %q, want messages path", target.Endpoint)
-			}
-		})
+	if !strings.HasSuffix(target.Endpoint, "/messages") {
+		t.Fatalf("upstream endpoint = %q", target.Endpoint)
 	}
 }
 
-func TestRuntimeTargetConfiguredProviderPrecedesEnvironmentBootstrap(t *testing.T) {
+func TestFacadeProviderSelectionPrecedesEnvironmentResolution(t *testing.T) {
 	isolateLLMEnv(t)
+	store := configuredFacadeProviderStore()
+	store.globalErr = errors.New("global environment must not be read")
+
+	selection, err := ResolveFacadeTargetWithEnv(context.Background(), &appconfig.Config{}, store, ProviderFamilyOpenAI, "system-model", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_KEY", Value: "unused-sandbox-key"},
+	})
+	if err != nil {
+		t.Fatalf("system provider resolution returned error: %v", err)
+	}
+	if selection.Environment != nil || selection.Target.Provider.ID != "system-provider" {
+		t.Fatalf("system provider selection = %#v", selection)
+	}
+
+	store.providers = append(store.providers, Provider{
+		ID:             "explicit-provider",
+		ProviderType:   ProviderFamilyOpenAI,
+		DefaultWireAPI: APIProtocolChatCompletions,
+		BaseURL:        "https://explicit.example/v1",
+		Enabled:        true,
+		Scope:          ProviderScopeSystem,
+	})
+	explicit, err := ResolveFacadeTargetWithEnv(context.Background(), &appconfig.Config{}, store, ProviderFamilyOpenAI, "any-model", "explicit-provider", nil)
+	if err != nil {
+		t.Fatalf("explicit provider resolution returned error: %v", err)
+	}
+	if explicit.Target.Provider.ID != "explicit-provider" || explicit.Target.WireAPI != APIProtocolChatCompletions {
+		t.Fatalf("explicit provider selection = %#v", explicit)
+	}
+}
+
+func TestFacadeEnvironmentResolutionFailsClosedWhenGlobalEnvCannotBeRead(t *testing.T) {
+	isolateLLMEnv(t)
+	wantErr := errors.New("global environment unavailable")
+	store := newResolverCoverageStore()
+	store.globalErr = wantErr
+	_, err := ResolveFacadeTargetWithEnv(context.Background(), &appconfig.Config{LLMModel: "daemon-model"}, store, ProviderFamilyOpenAI, "", "", nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ResolveFacadeTargetWithEnv error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestFacadeTokenEnvironmentsAreIsolatedAndRefreshInheritedFields(t *testing.T) {
+	isolateLLMEnv(t)
+	ctx := context.Background()
+	store := newResolverCoverageStore()
+	store.facadeEnvironments = map[string]FacadeEnvironment{}
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global-a.example/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+		{Name: "LLM_API_KEY", Value: "global-a-key"},
+		{Name: "LLM_MODEL", Value: "global-model"},
+	}
+
+	firstTarget, err := ResolveFacadeTargetWithEnv(ctx, &appconfig.Config{}, store, ProviderFamilyOpenAI, "model-a", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://execution-a.example/v1"},
+	})
+	if err != nil {
+		t.Fatalf("resolve first target: %v", err)
+	}
+	_, firstGrant, err := NewFacadeGrant("sandbox-1", firstTarget, APIProtocolResponses, "agent", "run-a")
+	if err != nil {
+		t.Fatalf("create first grant: %v", err)
+	}
+	store.facadeEnvironments[firstGrant.Environment.ProviderID] = *firstGrant.Environment
+
+	secondTarget, err := ResolveFacadeTargetWithEnv(ctx, &appconfig.Config{}, store, ProviderFamilyOpenAI, "model-b", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://execution-b.example/v1"},
+		{Name: "LLM_API_KEY", Value: "execution-b-key"},
+	})
+	if err != nil {
+		t.Fatalf("resolve second target: %v", err)
+	}
+	_, secondGrant, err := NewFacadeGrant("sandbox-1", secondTarget, APIProtocolResponses, "agent", "run-b")
+	if err != nil {
+		t.Fatalf("create second grant: %v", err)
+	}
+	store.facadeEnvironments[secondGrant.Environment.ProviderID] = *secondGrant.Environment
+	if firstGrant.Token.ProviderID == secondGrant.Token.ProviderID {
+		t.Fatal("independent executions shared a facade provider id")
+	}
+
+	store.global[1].Value = APIProtocolChatCompletions
+	store.global[2].Value = "global-b-key"
+	first, err := ResolveFacadeRuntimeTarget(ctx, &appconfig.Config{}, store, "runtime-model", firstGrant.Token.ProviderID)
+	if err != nil {
+		t.Fatalf("resolve first runtime target: %v", err)
+	}
+	second, err := ResolveFacadeRuntimeTarget(ctx, &appconfig.Config{}, store, "runtime-model", secondGrant.Token.ProviderID)
+	if err != nil {
+		t.Fatalf("resolve second runtime target: %v", err)
+	}
+	if first.Provider.BaseURL != "https://execution-a.example/v1" || first.Provider.APIKey != "global-b-key" || first.WireAPI != APIProtocolChatCompletions {
+		t.Fatalf("first runtime target = %#v", first)
+	}
+	if second.Provider.BaseURL != "https://execution-b.example/v1" || second.Provider.APIKey != "execution-b-key" || second.WireAPI != APIProtocolChatCompletions {
+		t.Fatalf("second runtime target = %#v", second)
+	}
+
+	if _, err := ResolveFacadeRuntimeTarget(ctx, &appconfig.Config{}, store, "runtime-model", FacadeEnvironmentProviderID("missing", ProviderFamilyOpenAI)); err == nil {
+		t.Fatal("missing token environment did not fail closed")
+	}
+}
+
+func configuredFacadeProviderStore() *resolverCoverageStore {
 	store := newResolverCoverageStore()
 	store.providers = []Provider{{
 		ID:             "system-provider",
@@ -553,51 +334,7 @@ func TestRuntimeTargetConfiguredProviderPrecedesEnvironmentBootstrap(t *testing.
 	}}
 	store.models = []Model{{ID: "system-model", Name: "system-model", Enabled: true, Scope: ProviderScopeSystem}}
 	store.wire["system-provider\x00system-model"] = APIProtocolResponses
-
-	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{
-		LLMAPIEndpoint: "https://daemon.example/v1",
-		LLMAPIKey:      "daemon-key",
-	}, store, "sandbox-system", ProviderFamilyOpenAI, "system-model", "", []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
-		{Name: "LLM_API_PROTOCOL", Value: APIProtocolChatCompletions},
-		{Name: "LLM_API_KEY", Value: "sandbox-key"},
-	})
-	if err != nil {
-		t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if target.Provider.ID != "system-provider" || target.Provider.BaseURL != "https://system.example/v1" || target.WireAPI != APIProtocolResponses {
-		t.Fatalf("target = %#v, want configured system provider", target)
-	}
-	if len(store.providers) != 1 {
-		t.Fatalf("providers = %#v, environment bootstrap should not add a provider", store.providers)
-	}
-
-	store.providers = append(store.providers, Provider{
-		ID:             "explicit-provider",
-		ProviderType:   ProviderFamilyOpenAI,
-		DefaultWireAPI: APIProtocolChatCompletions,
-		BaseURL:        "https://explicit.example/v1",
-		APIKey:         "explicit-key",
-		Enabled:        true,
-		Scope:          ProviderScopeEnvDefault,
-	})
-	store.wire["explicit-provider\x00system-model"] = APIProtocolChatCompletions
-	explicitTarget, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-system", ProviderFamilyOpenAI, "system-model", "explicit-provider", nil)
-	if err != nil {
-		t.Fatalf("ResolveRuntimeLLMTargetWithEnv explicit provider returned error: %v", err)
-	}
-	if explicitTarget.Provider.ID != "explicit-provider" || explicitTarget.WireAPI != APIProtocolChatCompletions {
-		t.Fatalf("explicit target = %#v", explicitTarget)
-	}
-}
-
-func mustDefaultProviderEnvSources(t *testing.T, config *appconfig.Config, store GlobalEnvStore) providerEnvSources {
-	t.Helper()
-	sources, err := defaultProviderEnvSources(context.Background(), config, store)
-	if err != nil {
-		t.Fatalf("defaultProviderEnvSources returned error: %v", err)
-	}
-	return sources
+	return store
 }
 
 func mustLayeredProviderEnvSources(t *testing.T, config *appconfig.Config, store GlobalEnvStore, items []domain.SandboxEnvVar) (providerEnvSources, []domain.SandboxEnvVar) {

--- a/pkg/llms/resolver.go
+++ b/pkg/llms/resolver.go
@@ -3,7 +3,6 @@ package llms
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
@@ -47,71 +46,25 @@ func BootstrapDefaultLLMConfig(ctx context.Context, config *appconfig.Config, st
 	return bootstrapDefaultLLMConfig(ctx, config, store, requestedModel)
 }
 
-// EnvProviderLookup resolves an environment value for LLM provider bootstrap.
-// It accepts candidate keys and returns the first non-empty value scanning
-// sources in priority order (source-major): an earlier source wins across all
-// candidate keys before a later source is consulted. This preserves the exact
-// precedence the bootstrap paths relied on when they used nested firstNonEmpty.
-// defaultLLMEnvProviderLookup reads from global env, then the process env, then
-// daemon config. Used by the env_default bootstrap providers.
-func defaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store LLMResolverStore) EnvProviderLookup {
-	return func(keys ...string) string {
-		for _, key := range keys {
-			if v := lookupEnvValue(ctx, store, key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		for _, key := range keys {
-			if v := os.Getenv(key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		for _, key := range keys {
-			if v := configLLMEnvValue(config, key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		return ""
+func defaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store LLMResolverStore) (EnvProviderLookup, error) {
+	sources, err := defaultProviderEnvSources(ctx, config, store)
+	if err != nil {
+		return nil, err
 	}
+	return providerEnvironmentLookup(sources), nil
 }
 
-func DefaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store LLMResolverStore) EnvProviderLookup {
+func DefaultLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store LLMResolverStore) (EnvProviderLookup, error) {
 	return defaultLLMEnvProviderLookup(ctx, config, store)
 }
 
-// sessionLLMEnvProviderLookup reads only from per-session env items. Used by the
-// session_env bootstrap providers.
-func sessionLLMEnvProviderLookup(envItems []domain.SandboxEnvVar) EnvProviderLookup {
-	return func(keys ...string) string {
-		for _, key := range keys {
-			if v := EnvItemValue(envItems, key); strings.TrimSpace(v) != "" {
-				return v
-			}
-		}
-		return ""
-	}
-}
-
-func configLLMEnvValue(config *appconfig.Config, key string) string {
-	if config == nil {
-		return ""
-	}
-	switch strings.ToUpper(strings.TrimSpace(key)) {
-	case "LLM_API_ENDPOINT":
-		return config.LLMAPIEndpoint
-	case "LLM_API_PROTOCOL":
-		return config.LLMAPIProtocol
-	case "LLM_API_KEY":
-		return config.LLMAPIKey
-	case "LLM_MODEL":
-		return config.LLMModel
-	default:
-		return ""
-	}
-}
-
 func ensureDefaultOpenAIEnvProvider(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
-	_, err := EnsureOpenAIEnvProvider(ctx, store, defaultLLMEnvProviderLookup(ctx, config, store), ProviderIDDefaultOpenAI, "default", ProviderScopeEnvDefault, requestedModel, true)
+	sources, err := defaultProviderEnvSources(ctx, config, store)
+	if err != nil {
+		return err
+	}
+	environment := sources.openAIEnvironment()
+	_, err = ensureOpenAIProviderEnvironment(ctx, store, environment, ProviderIDDefaultOpenAI, "default", ProviderScopeEnvDefault, requestedModel, true)
 	return err
 }
 
@@ -148,49 +101,41 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	preferredProviderFamily = NormalizeOptionalProviderType(preferredProviderFamily)
 	requestedModel = strings.TrimSpace(requestedModel)
 	providerID = strings.TrimSpace(providerID)
-	hasSessionEnvProvider := sessionID != "" && HasSessionEnvProviderInput(envItems)
-	sessionProviderID := ""
-	// Reuse an already-persisted session-env provider when this session can no
-	// longer supply a key from env. The raw key env (Session.ProviderEnvItems) is
-	// intentionally not persisted, so after a stop/resume the only durable home
-	// for a session-scoped credential is the llm_provider row written at creation.
-	// Pin its provider id here so resolution selects it (session-env providers are
-	// otherwise skipped without an explicit id) and does not clobber its key with
-	// the now-empty env. Only when the env still has no key for the family — an env
-	// that carries a (possibly rotated) key must keep re-bootstrapping it.
-	if providerID == "" && sessionID != "" && preferredProviderFamily != "" && !EnvHasProviderKeyForFamily(envItems, preferredProviderFamily) {
-		if candidate := SessionEnvProviderID(sessionID, preferredProviderFamily); hasEnabledLLMProviderID(ctx, store, candidate) {
-			providerID = candidate
-		}
+	providerEnvSources, sandboxEnvItems, err := layeredProviderEnvSources(ctx, config, store, envItems)
+	if err != nil {
+		return ResolvedTarget{}, err
 	}
+	sessionProviderID := ""
 	// Skip the env/default bootstrap entirely when the request already names a
 	// provider that exists. The facade hot path always passes a concrete
 	// provider id from the token scope, so this avoids a redundant pair of
 	// idempotent provider upserts on every LLM request.
 	bootstrapProviders := (providerID == "" || !IsSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
-	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyOpenAI) {
-		openAIModel := firstNonEmptyTrimmed(requestedModel, EnvItemValue(envItems, "LLM_MODEL"))
-		if sessionID != "" && HasOpenAIEnvProviderInput(envItems) {
-			id, err := ensureSessionOpenAIEnvProvider(ctx, store, sessionID, openAIModel, envItems)
+	bootstrapOpenAI := preferredProviderFamily == "" || preferredProviderFamily == ProviderFamilyOpenAI
+	if bootstrapProviders && bootstrapOpenAI && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyOpenAI) {
+		openAIModel := firstNonEmptyTrimmed(requestedModel, EnvItemValue(sandboxEnvItems, "LLM_MODEL"))
+		if sessionID != "" && HasOpenAIEnvProviderInput(sandboxEnvItems) {
+			id, err := ensureSessionOpenAIProviderEnvironment(ctx, store, sessionID, openAIModel, providerEnvSources.openAIEnvironment())
 			if err != nil {
 				return ResolvedTarget{}, err
 			}
 			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyOpenAI, preferredProviderFamily)
-		} else if !hasSessionEnvProvider {
+		} else {
 			if err := ensureDefaultOpenAIEnvProvider(ctx, config, store, openAIModel); err != nil {
 				return ResolvedTarget{}, err
 			}
 		}
 	}
-	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyAnthropic) {
-		anthropicModel := firstNonEmptyTrimmed(requestedModel, SessionAnthropicEnvModel(envItems))
-		if sessionID != "" && HasAnthropicEnvProviderInput(envItems) {
-			id, err := ensureSessionAnthropicEnvProvider(ctx, store, sessionID, anthropicModel, envItems)
+	bootstrapAnthropic := preferredProviderFamily == "" || preferredProviderFamily == ProviderFamilyAnthropic
+	if bootstrapProviders && bootstrapAnthropic && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyAnthropic) {
+		anthropicModel := firstNonEmptyTrimmed(requestedModel, SessionAnthropicEnvModel(sandboxEnvItems))
+		if sessionID != "" && HasAnthropicEnvProviderInput(sandboxEnvItems) {
+			id, err := ensureSessionAnthropicProviderEnvironment(ctx, store, sessionID, anthropicModel, providerEnvSources.anthropicEnvironment())
 			if err != nil {
 				return ResolvedTarget{}, err
 			}
 			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyAnthropic, preferredProviderFamily)
-		} else if !hasSessionEnvProvider {
+		} else {
 			if err := ensureDefaultAnthropicEnvProvider(ctx, config, store, anthropicModel); err != nil {
 				return ResolvedTarget{}, err
 			}
@@ -251,30 +196,41 @@ func BootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, 
 }
 
 func ensureDefaultAnthropicEnvProvider(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
-	lookup := defaultLLMEnvProviderLookup(ctx, config, store)
-	authHeader, authScheme := AnthropicProviderAuthFromLookup(lookup)
-	_, err := EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, ProviderIDDefaultAnthropic, "anthropic", ProviderScopeEnvDefault, requestedModel, false)
+	sources, err := defaultProviderEnvSources(ctx, config, store)
+	if err != nil {
+		return err
+	}
+	environment := sources.anthropicEnvironment()
+	_, err = ensureAnthropicProviderEnvironment(ctx, store, environment, ProviderIDDefaultAnthropic, "anthropic", ProviderScopeEnvDefault, requestedModel, false)
 	return err
 }
 
-func ensureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
+func ensureSessionOpenAIProviderEnvironment(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, environment providerEnvironment) (string, error) {
 	providerID := SessionEnvProviderID(sessionID, ProviderFamilyOpenAI)
-	return EnsureOpenAIEnvProvider(ctx, store, sessionLLMEnvProviderLookup(envItems), providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+	return ensureOpenAIProviderEnvironment(ctx, store, environment, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
 }
 
-func EnsureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
-	return ensureSessionOpenAIEnvProvider(ctx, store, sessionID, requestedModel, envItems)
+// EnsureSessionOpenAIEnvProviderWithConfig resolves each session provider field
+// from sandbox Provider Env, Global Env, then daemon process/config values.
+func EnsureSessionOpenAIEnvProviderWithConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
+	sources, _, err := layeredProviderEnvSources(ctx, config, store, envItems)
+	if err != nil {
+		return "", err
+	}
+	return ensureSessionOpenAIProviderEnvironment(ctx, store, sessionID, requestedModel, sources.openAIEnvironment())
 }
 
-func ensureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
+func ensureSessionAnthropicProviderEnvironment(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, environment providerEnvironment) (string, error) {
 	providerID := SessionEnvProviderID(sessionID, ProviderFamilyAnthropic)
-	lookup := sessionLLMEnvProviderLookup(envItems)
-	authHeader, authScheme := AnthropicProviderAuthFromLookup(lookup)
-	return EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+	return ensureAnthropicProviderEnvironment(ctx, store, environment, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
 }
 
 func EnsureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
-	return ensureSessionAnthropicEnvProvider(ctx, store, sessionID, requestedModel, envItems)
+	sources, _, err := layeredProviderEnvSources(ctx, nil, store, envItems)
+	if err != nil {
+		return "", err
+	}
+	return ensureSessionAnthropicProviderEnvironment(ctx, store, sessionID, requestedModel, sources.anthropicEnvironment())
 }
 
 func hasEnabledLLMProviderID(ctx context.Context, store LLMResolverStore, providerID string) bool {
@@ -337,24 +293,4 @@ func resolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Co
 
 func ResolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store LLMResolverStore, providerFamily, requestedModel string) (ResolvedTarget, error) {
 	return resolveLLMTargetForProviderFamily(ctx, config, store, providerFamily, requestedModel)
-}
-
-func lookupEnvValue(ctx context.Context, store LLMResolverStore, key string) string {
-	if store == nil {
-		return ""
-	}
-	items, err := store.ListGlobalEnv(ctx)
-	if err != nil {
-		return ""
-	}
-	for _, item := range items {
-		if item.Name == key {
-			return item.Value
-		}
-	}
-	return ""
-}
-
-func LookupEnvValue(ctx context.Context, store LLMResolverStore, key string) string {
-	return lookupEnvValue(ctx, store, key)
 }

--- a/pkg/llms/resolver_coverage_test.go
+++ b/pkg/llms/resolver_coverage_test.go
@@ -32,11 +32,12 @@ func TestResolverBootstrapAndRuntimeTargetWorkflows(t *testing.T) {
 	if len(store.providers) != 1 {
 		t.Fatalf("default bootstrap did not skip configured provider: %#v", store.providers)
 	}
-	if value := DefaultLLMEnvProviderLookup(ctx, config, store)("LLM_API_KEY"); value != "openai-key" {
-		t.Fatalf("default lookup config value = %q", value)
+	lookup, err := DefaultLLMEnvProviderLookup(ctx, config, store)
+	if err != nil {
+		t.Fatalf("DefaultLLMEnvProviderLookup returned error: %v", err)
 	}
-	if value := LookupEnvValue(ctx, store, "missing"); value != "" {
-		t.Fatalf("missing env lookup = %q", value)
+	if value := lookup("LLM_API_KEY"); value != "openai-key" {
+		t.Fatalf("default lookup config value = %q", value)
 	}
 
 	target, err := ResolveLLMTarget(ctx, config, store, "")
@@ -120,6 +121,7 @@ type resolverCoverageStore struct {
 	models    []Model
 	wire      map[string]string
 	global    []domain.SandboxEnvVar
+	globalErr error
 }
 
 func newResolverCoverageStore() *resolverCoverageStore {
@@ -142,7 +144,9 @@ func (s *resolverCoverageStore) UpsertDefaultLLMConfig(_ context.Context, provid
 	replacedModel := false
 	for i := range s.models {
 		if s.models[i].ID == model.ID {
-			s.models[i] = model
+			if model.Scope != ProviderScopeSessionEnv || s.models[i].Scope == ProviderScopeSessionEnv {
+				s.models[i] = model
+			}
 			replacedModel = true
 		}
 	}
@@ -179,5 +183,5 @@ func (s *resolverCoverageStore) LLMProviderModelWireAPI(_ context.Context, provi
 }
 
 func (s *resolverCoverageStore) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
-	return s.global, nil
+	return s.global, s.globalErr
 }

--- a/pkg/llms/resolver_coverage_test.go
+++ b/pkg/llms/resolver_coverage_test.go
@@ -117,11 +117,12 @@ func isolateLLMEnv(t *testing.T) {
 }
 
 type resolverCoverageStore struct {
-	providers []Provider
-	models    []Model
-	wire      map[string]string
-	global    []domain.SandboxEnvVar
-	globalErr error
+	providers          []Provider
+	models             []Model
+	wire               map[string]string
+	global             []domain.SandboxEnvVar
+	globalErr          error
+	facadeEnvironments map[string]FacadeEnvironment
 }
 
 func newResolverCoverageStore() *resolverCoverageStore {
@@ -184,4 +185,9 @@ func (s *resolverCoverageStore) LLMProviderModelWireAPI(_ context.Context, provi
 
 func (s *resolverCoverageStore) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
 	return s.global, s.globalErr
+}
+
+func (s *resolverCoverageStore) GetLLMFacadeEnvironment(_ context.Context, providerID string) (FacadeEnvironment, bool, error) {
+	environment, ok := s.facadeEnvironments[providerID]
+	return environment, ok, nil
 }

--- a/pkg/llms/runtime_config.go
+++ b/pkg/llms/runtime_config.go
@@ -382,7 +382,7 @@ func LookupRuntimeBaseURLEnv(session *domain.Sandbox) string {
 	if session == nil {
 		return ""
 	}
-	for _, items := range [][]domain.SandboxEnvVar{session.ProviderEnvItems, session.RuntimeEnvItems, session.EnvItems} {
+	for _, items := range [][]domain.SandboxEnvVar{session.ExecutionProviderEnvItems, session.ProviderEnvItems, session.RuntimeEnvItems, session.EnvItems} {
 		if value := EnvItemValue(items, RuntimeBaseURLEnvName); strings.TrimSpace(value) != "" {
 			return value
 		}

--- a/pkg/llms/runtime_config.go
+++ b/pkg/llms/runtime_config.go
@@ -66,6 +66,10 @@ func WriteCodexRuntimeConfig(session *domain.Sandbox, model, baseURL, wireAPI st
 	if model == "" || baseURL == "" {
 		return nil
 	}
+	wireAPI = NormalizeWireAPI(wireAPI)
+	if wireAPI != APIProtocolResponses {
+		return fmt.Errorf("codex model-provider wire API %q is unsupported; expected %q", wireAPI, APIProtocolResponses)
+	}
 	policy = normalizeCodexRuntimePolicy(policy)
 	path := filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -104,7 +108,7 @@ ignore_default_excludes = false
 
 [history]
 persistence = "save-all"
-`, model, baseURL, NormalizeWireAPI(wireAPI), policy.RequestMaxRetries, policy.StreamMaxRetries, policy.StreamIdleTimeout.Milliseconds())
+`, model, baseURL, wireAPI, policy.RequestMaxRetries, policy.StreamMaxRetries, policy.StreamIdleTimeout.Milliseconds())
 	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
 		return fmt.Errorf("write codex config: %w", err)
 	}

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -3,6 +3,7 @@ package runtimefacade
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
@@ -20,7 +21,7 @@ import (
 // nil pointer in the interface would bypass the `store == nil` guards here.
 type FacadeStore interface {
 	llms.LLMResolverStore
-	SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error
+	SaveLLMFacadeGrant(ctx context.Context, grant llms.FacadeGrant) error
 }
 
 const (
@@ -60,33 +61,31 @@ func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Conf
 }
 
 func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
-	if err != nil {
-		return nil, err
-	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", providerEnv)
+	providerEnv := sessionProviderEnvItems(session, llms.ProviderFamilyOpenAI)
+	selection, err := llms.ResolveFacadeTargetWithEnv(ctx, config, store, llms.ProviderFamilyOpenAI, model, "", providerEnv)
 	if err != nil {
 		if isOptionalConfigError(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	baseURL := llms.GuestRuntimeBaseURL(config, session)
+	target := selection.Target
+	baseURL, err := runtimeFacadeBaseURL(ctx, config, store, session)
+	if err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
 	// Codex 0.144.x accepts only Responses as a model-provider wire API. Keep
 	// guest ingress on Responses and let the facade bridge to target.WireAPI.
 	facadeWireAPI := llms.APIProtocolResponses
-	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, facadeWireAPI, source, runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
 	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + session.Summary.ID + "/llm/openai/v1"
 	if err := llms.WriteCodexRuntimeConfig(session, target.Model.Name, openAIBaseURL, facadeWireAPI, llms.CodexRuntimePolicyFromConfig(config)); err != nil {
+		return nil, err
+	}
+	tokenValue, err := saveFacadeGrant(ctx, store, session.Summary.ID, selection, facadeWireAPI, source, runID)
+	if err != nil {
 		return nil, err
 	}
 	return map[string]string{
@@ -100,23 +99,21 @@ func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, sto
 }
 
 func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	baseURL := llms.GuestRuntimeBaseURL(config, session)
+	baseURL, err := runtimeFacadeBaseURL(ctx, config, store, session)
+	if err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyAnthropic)
+	providerEnv := sessionProviderEnvItems(session, llms.ProviderFamilyAnthropic)
+	selection, err := llms.ResolveFacadeTargetWithEnv(ctx, config, store, llms.ProviderFamilyAnthropic, model, "", providerEnv)
 	if err != nil {
 		return nil, err
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
+	target := selection.Target
+	tokenValue, err := saveFacadeGrant(ctx, store, session.Summary.ID, selection, llms.APIProtocolMessages, source, runID)
 	if err != nil {
-		return nil, err
-	}
-	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolMessages, source, runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
 		return nil, err
 	}
 	anthropicBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + session.Summary.ID + "/llm/anthropic"
@@ -139,44 +136,39 @@ func ensureSessionOpenCodeConfig(ctx context.Context, config *appconfig.Config, 
 	if err != nil {
 		return nil, err
 	}
-	baseURL := llms.GuestRuntimeBaseURL(config, session)
+	if providerID == "opencode" {
+		return nil, nil
+	}
+	baseURL, err := runtimeFacadeBaseURL(ctx, config, store, session)
+	if err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
 	switch providerID {
-	case "opencode":
-		return nil, nil
 	case "anthropic":
-		return ensureOpenCodeAnthropicConfig(ctx, config, store, session, modelName, source, runID)
+		return ensureOpenCodeAnthropicConfig(ctx, config, store, session, baseURL, modelName, source, runID)
 	case "openai":
-		return ensureOpenCodeOpenAIConfig(ctx, config, store, session, modelName, source, runID)
+		return ensureOpenCodeOpenAIConfig(ctx, config, store, session, baseURL, modelName, source, runID)
 	default:
-		return ensureOpenCodeCustomProviderConfig(ctx, config, store, session, providerID, modelName, source, runID)
+		return ensureOpenCodeCustomProviderConfig(ctx, config, store, session, baseURL, providerID, modelName, source, runID)
 	}
 }
 
-func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	baseURL := llms.GuestRuntimeBaseURL(config, session)
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, nil
-	}
-	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyAnthropic)
+func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, baseURL, model, source, runID string) (map[string]string, error) {
+	providerEnv := sessionProviderEnvItems(session, llms.ProviderFamilyAnthropic)
+	selection, err := llms.ResolveFacadeTargetWithEnv(ctx, config, store, llms.ProviderFamilyAnthropic, model, "", providerEnv)
 	if err != nil {
 		return nil, err
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
-	if err != nil {
-		return nil, err
-	}
-	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolMessages, source, runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
+	target := selection.Target
 	anthropicBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + session.Summary.ID + "/llm/anthropic"
 	if err := llms.WriteOpenCodeAnthropicRuntimeConfig(session, target.Model.Name, anthropicBaseURL+"/v1"); err != nil {
+		return nil, err
+	}
+	tokenValue, err := saveFacadeGrant(ctx, store, session.Summary.ID, selection, llms.APIProtocolMessages, source, runID)
+	if err != nil {
 		return nil, err
 	}
 	return map[string]string{
@@ -191,28 +183,19 @@ func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config
 	}, nil
 }
 
-func ensureOpenCodeOpenAIConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
+func ensureOpenCodeOpenAIConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, baseURL, model, source, runID string) (map[string]string, error) {
+	providerEnv := sessionProviderEnvItems(session, llms.ProviderFamilyOpenAI)
+	selection, err := llms.ResolveFacadeTargetWithEnv(ctx, config, store, llms.ProviderFamilyOpenAI, model, "", providerEnv)
 	if err != nil {
 		return nil, err
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", providerEnv)
-	if err != nil {
-		return nil, err
-	}
-	baseURL := llms.GuestRuntimeBaseURL(config, session)
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, nil
-	}
-	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolResponses, source, runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
+	target := selection.Target
 	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + session.Summary.ID + "/llm/openai/v1"
 	if err := llms.WriteOpenCodeRuntimeConfig(session, "openai", target.Model.Name, openAIBaseURL); err != nil {
+		return nil, err
+	}
+	tokenValue, err := saveFacadeGrant(ctx, store, session.Summary.ID, selection, llms.APIProtocolResponses, source, runID)
+	if err != nil {
 		return nil, err
 	}
 	return map[string]string{
@@ -226,24 +209,18 @@ func ensureOpenCodeOpenAIConfig(ctx context.Context, config *appconfig.Config, s
 	}, nil
 }
 
-func ensureOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, providerID, model, source, runID string) (map[string]string, error) {
-	target, err := resolveOpenCodeCustomProviderTarget(ctx, config, store, session, providerID, model)
+func ensureOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, baseURL, providerID, model, source, runID string) (map[string]string, error) {
+	selection, err := resolveOpenCodeCustomProviderTarget(ctx, config, store, session, providerID, model)
 	if err != nil {
 		return nil, err
 	}
-	baseURL := llms.GuestRuntimeBaseURL(config, session)
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, nil
-	}
-	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolChatCompletions, source, runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
+	target := selection.Target
 	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + session.Summary.ID + "/llm/openai/v1"
 	if err := llms.WriteOpenCodeRuntimeConfig(session, providerID, target.Model.Name, openAIBaseURL); err != nil {
+		return nil, err
+	}
+	tokenValue, err := saveFacadeGrant(ctx, store, session.Summary.ID, selection, llms.APIProtocolChatCompletions, source, runID)
+	if err != nil {
 		return nil, err
 	}
 	return map[string]string{
@@ -257,35 +234,9 @@ func ensureOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.C
 	}, nil
 }
 
-func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, providerID, model string) (llms.ResolvedTarget, error) {
-	envItems, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	sessionID := ""
-	if session != nil {
-		sessionID = session.Summary.ID
-	}
-	if llms.HasEnabledLLMProviderID(ctx, store, providerID) {
-		return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
-	}
-	if sessionID != "" && llms.HasOpenAIEnvProviderInput(envItems) {
-		sessionProviderID, err := llms.EnsureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sessionID, model, envItems)
-		if err != nil {
-			return llms.ResolvedTarget{}, err
-		}
-		if strings.TrimSpace(sessionProviderID) != "" {
-			return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, sessionProviderID, envItems)
-		}
-	}
-	lookup, err := llms.DefaultLLMEnvProviderLookup(ctx, config, store)
-	if err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	if _, err := llms.EnsureOpenAIEnvProvider(ctx, store, lookup, providerID, providerID, llms.ProviderScopeEnvDefault, model, false); err != nil {
-		return llms.ResolvedTarget{}, err
-	}
-	return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
+func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, providerID, model string) (llms.FacadeTarget, error) {
+	envItems := sessionProviderEnvItems(session, llms.ProviderFamilyOpenAI)
+	return llms.ResolveFacadeTargetWithEnv(ctx, config, store, llms.ProviderFamilyOpenAI, model, providerID, envItems)
 }
 
 func isOptionalConfigError(err error) bool {
@@ -299,13 +250,37 @@ func IsOptionalConfigError(err error) bool {
 	return isOptionalConfigError(err)
 }
 
-func sessionProviderEnvItems(ctx context.Context, store FacadeStore, session *domain.Sandbox, providerFamily string) ([]domain.SandboxEnvVar, error) {
-	if session == nil {
-		return nil, nil
-	}
-	providers, err := store.ListEnabledLLMProviders(ctx)
+func saveFacadeGrant(ctx context.Context, store FacadeStore, sandboxID string, target llms.FacadeTarget, ingressWireAPI, source, runID string) (string, error) {
+	tokenValue, grant, err := llms.NewFacadeGrant(sandboxID, target, ingressWireAPI, source, runID)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return llms.SandboxProviderEnvItems(session, providerFamily, providers), nil
+	if err := store.SaveLLMFacadeGrant(ctx, grant); err != nil {
+		return "", err
+	}
+	return tokenValue, nil
+}
+
+func sessionProviderEnvItems(session *domain.Sandbox, providerFamily string) []domain.SandboxEnvVar {
+	return llms.SandboxProviderEnvItems(session, providerFamily)
+}
+
+func runtimeFacadeBaseURL(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox) (string, error) {
+	if config == nil {
+		return "", nil
+	}
+	if baseURL := strings.TrimRight(strings.TrimSpace(config.RuntimeBaseURL), "/"); baseURL != "" {
+		return baseURL, nil
+	}
+	if baseURL := strings.TrimRight(strings.TrimSpace(llms.LookupRuntimeBaseURLEnv(session)), "/"); baseURL != "" {
+		return baseURL, nil
+	}
+	globalEnv, err := store.ListGlobalEnv(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list global runtime environment: %w", err)
+	}
+	if baseURL := strings.TrimRight(strings.TrimSpace(llms.EnvItemValue(globalEnv, llms.RuntimeBaseURLEnvName)), "/"); baseURL != "" {
+		return baseURL, nil
+	}
+	return llms.GuestRuntimeBaseURL(config, session), nil
 }

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -3,7 +3,6 @@ package runtimefacade
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 
 	appconfig "agent-compose/pkg/config"
@@ -61,7 +60,11 @@ func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Conf
 }
 
 func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", sessionProviderEnvItems(session))
+	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", providerEnv)
 	if err != nil {
 		if isOptionalConfigError(err) {
 			return nil, nil
@@ -72,6 +75,8 @@ func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, sto
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
+	// Codex 0.144.x accepts only Responses as a model-provider wire API. Keep
+	// guest ingress on Responses and let the facade bridge to target.WireAPI.
 	facadeWireAPI := llms.APIProtocolResponses
 	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, facadeWireAPI, source, runID)
 	if err != nil {
@@ -99,19 +104,15 @@ func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, st
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	providerEnv := sessionProviderEnvItems(session)
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
-	tokenModel := ""
-	tokenProvider := ""
+	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyAnthropic)
 	if err != nil {
-		if !isOptionalConfigError(err) || !HasAnthropicProviderKey(ctx, config, store) {
-			return nil, err
-		}
-	} else {
-		tokenModel = target.Model.Name
-		tokenProvider = target.Provider.ID
+		return nil, err
 	}
-	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, tokenModel, tokenProvider, llms.APIProtocolMessages, source, runID)
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
+	if err != nil {
+		return nil, err
+	}
+	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolMessages, source, runID)
 	if err != nil {
 		return nil, err
 	}
@@ -128,10 +129,8 @@ func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, st
 		"ANTHROPIC_AUTH_TOKEN":        tokenValue,
 		"ANTHROPIC_BASE_URL":          anthropicBaseURL,
 	}
-	if tokenModel != "" {
-		env["ANTHROPIC_MODEL"] = tokenModel
-		env["CLAUDE_MODEL"] = tokenModel
-	}
+	env["ANTHROPIC_MODEL"] = target.Model.Name
+	env["CLAUDE_MODEL"] = target.Model.Name
 	return env, nil
 }
 
@@ -161,7 +160,11 @@ func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", sessionProviderEnvItems(session))
+	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyAnthropic)
+	if err != nil {
+		return nil, err
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +192,11 @@ func ensureOpenCodeAnthropicConfig(ctx context.Context, config *appconfig.Config
 }
 
 func ensureOpenCodeOpenAIConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", sessionProviderEnvItems(session))
+	providerEnv, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", providerEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +258,10 @@ func ensureOpenCodeCustomProviderConfig(ctx context.Context, config *appconfig.C
 }
 
 func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, providerID, model string) (llms.ResolvedTarget, error) {
-	envItems := sessionProviderEnvItems(session)
+	envItems, err := sessionProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
+	if err != nil {
+		return llms.ResolvedTarget{}, err
+	}
 	sessionID := ""
 	if session != nil {
 		sessionID = session.Summary.ID
@@ -260,7 +270,7 @@ func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.
 		return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
 	}
 	if sessionID != "" && llms.HasOpenAIEnvProviderInput(envItems) {
-		sessionProviderID, err := llms.EnsureSessionOpenAIEnvProvider(ctx, store, sessionID, model, envItems)
+		sessionProviderID, err := llms.EnsureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sessionID, model, envItems)
 		if err != nil {
 			return llms.ResolvedTarget{}, err
 		}
@@ -268,7 +278,11 @@ func resolveOpenCodeCustomProviderTarget(ctx context.Context, config *appconfig.
 			return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, sessionProviderID, envItems)
 		}
 	}
-	if _, err := llms.EnsureOpenAIEnvProvider(ctx, store, llms.DefaultLLMEnvProviderLookup(ctx, config, store), providerID, providerID, llms.ProviderScopeEnvDefault, model, false); err != nil {
+	lookup, err := llms.DefaultLLMEnvProviderLookup(ctx, config, store)
+	if err != nil {
+		return llms.ResolvedTarget{}, err
+	}
+	if _, err := llms.EnsureOpenAIEnvProvider(ctx, store, lookup, providerID, providerID, llms.ProviderScopeEnvDefault, model, false); err != nil {
 		return llms.ResolvedTarget{}, err
 	}
 	return llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, llms.ProviderFamilyOpenAI, model, providerID, envItems)
@@ -285,37 +299,13 @@ func IsOptionalConfigError(err error) bool {
 	return isOptionalConfigError(err)
 }
 
-func HasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, store FacadeStore) bool {
-	configKey := ""
-	if config != nil {
-		configKey = config.LLMAPIKey
-	}
-	return strings.TrimSpace(firstNonEmpty(
-		llms.LookupEnvValue(ctx, store, "ANTHROPIC_API_KEY"),
-		llms.LookupEnvValue(ctx, store, "ANTHROPIC_AUTH_TOKEN"),
-		llms.LookupEnvValue(ctx, store, "LLM_API_KEY"),
-		os.Getenv("ANTHROPIC_API_KEY"),
-		os.Getenv("ANTHROPIC_AUTH_TOKEN"),
-		os.Getenv("LLM_API_KEY"),
-		configKey,
-	)) != ""
-}
-
-func sessionProviderEnvItems(session *domain.Sandbox) []domain.SandboxEnvVar {
+func sessionProviderEnvItems(ctx context.Context, store FacadeStore, session *domain.Sandbox, providerFamily string) ([]domain.SandboxEnvVar, error) {
 	if session == nil {
-		return nil
+		return nil, nil
 	}
-	if len(session.ProviderEnvItems) > 0 {
-		return session.ProviderEnvItems
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return session.EnvItems
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return llms.SandboxProviderEnvItems(session, providerFamily, providers), nil
 }

--- a/pkg/llms/runtimefacade/config_test.go
+++ b/pkg/llms/runtimefacade/config_test.go
@@ -85,6 +85,61 @@ func TestEnsureSessionLLMFacadeConfigCreatesCodexEnvAndToken(t *testing.T) {
 	}
 }
 
+func TestEnsureSessionLLMFacadeConfigUsesGlobalRuntimeBaseURL(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:      root,
+		DbAddr:        filepath.Join(root, "data.db"),
+		HttpListen:    "daemon.example.test:7410",
+		GuestHomePath: "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{
+		{Name: llms.RuntimeBaseURLEnvName, Value: "http://global-runtime.example.test:7410/"},
+		{Name: "LLM_API_ENDPOINT", Value: "https://global-provider.example.test/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolChatCompletions},
+		{Name: "LLM_API_KEY", Value: "global-provider-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "global-model"},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+	session := &domain.Sandbox{
+		Summary: domain.SandboxSummary{
+			ID:            "sandbox-global-runtime-url",
+			Driver:        driverpkg.RuntimeDriverDocker,
+			WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-global-runtime-url", "workspace"),
+		},
+	}
+
+	env, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, config, store, session, "codex", "", "test", "run-global-runtime-url")
+	if err != nil {
+		t.Fatalf("EnsureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	wantBaseURL := "http://global-runtime.example.test:7410/api/runtime/sandboxes/sandbox-global-runtime-url/llm/openai/v1"
+	if env["LLM_API_ENDPOINT"] != wantBaseURL || env["OPENAI_BASE_URL"] != wantBaseURL {
+		t.Fatalf("facade URLs = LLM_API_ENDPOINT %q, OPENAI_BASE_URL %q; want %q", env["LLM_API_ENDPOINT"], env["OPENAI_BASE_URL"], wantBaseURL)
+	}
+	tokenValue := env["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	if tokenValue == "" {
+		t.Fatal("AGENT_COMPOSE_SANDBOX_TOKEN is empty")
+	}
+	token, err := store.GetLLMFacadeToken(ctx, tokenValue)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.SandboxID != session.Summary.ID || token.Model != "global-model" || token.WireAPI != llms.APIProtocolResponses {
+		t.Fatalf("stored token = %#v", token)
+	}
+}
+
 func TestEnsureSessionCodexConfigBridgesResponsesIngressToChatUpstream(t *testing.T) {
 	isolateLLMEnv(t)
 
@@ -128,9 +183,9 @@ func TestEnsureSessionCodexConfigBridgesResponsesIngressToChatUpstream(t *testin
 	if token.WireAPI != llms.APIProtocolResponses || token.ProviderID == "" || token.Model != "chat-model" {
 		t.Fatalf("stored token = %#v", token)
 	}
-	target, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "chat-model", token.ProviderID)
+	target, err := llms.ResolveFacadeRuntimeTarget(ctx, config, store, "chat-model", token.ProviderID)
 	if err != nil {
-		t.Fatalf("ResolveRuntimeLLMTarget returned error: %v", err)
+		t.Fatalf("ResolveFacadeRuntimeTarget returned error: %v", err)
 	}
 	if target.WireAPI != llms.APIProtocolChatCompletions {
 		t.Fatalf("upstream wire API = %q, want chat_completions", target.WireAPI)
@@ -206,9 +261,9 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 	if err != nil {
 		t.Fatalf("GetLLMFacadeToken opencode openai returned error: %v", err)
 	}
-	openAITarget, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "gpt-test", openAIToken.ProviderID)
+	openAITarget, err := llms.ResolveFacadeRuntimeTarget(ctx, config, store, "gpt-test", openAIToken.ProviderID)
 	if err != nil {
-		t.Fatalf("ResolveRuntimeLLMTarget opencode openai returned error: %v", err)
+		t.Fatalf("ResolveFacadeRuntimeTarget opencode openai returned error: %v", err)
 	}
 	if openAIToken.WireAPI != llms.APIProtocolResponses || openAITarget.WireAPI != llms.APIProtocolChatCompletions {
 		t.Fatalf("opencode token wire api = %q, upstream wire api = %q", openAIToken.WireAPI, openAITarget.WireAPI)
@@ -317,9 +372,9 @@ func TestEnsureSessionOpenCodeCustomProviderInheritsDaemonConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
 	}
-	target, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "custom-model", token.ProviderID)
+	target, err := llms.ResolveFacadeRuntimeTarget(ctx, config, store, "custom-model", token.ProviderID)
 	if err != nil {
-		t.Fatalf("ResolveRuntimeLLMTarget returned error: %v", err)
+		t.Fatalf("ResolveFacadeRuntimeTarget returned error: %v", err)
 	}
 	if target.Provider.BaseURL != "https://sandbox.example.test/v1" || target.Provider.APIKey != "daemon-key" || target.WireAPI != llms.APIProtocolChatCompletions {
 		t.Fatalf("custom provider target = %#v", target)

--- a/pkg/llms/runtimefacade/config_test.go
+++ b/pkg/llms/runtimefacade/config_test.go
@@ -1,4 +1,4 @@
-package runtimefacade
+package runtimefacade_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
 	"agent-compose/pkg/llms"
+	"agent-compose/pkg/llms/runtimefacade"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/storage/configstore"
 )
@@ -50,7 +51,7 @@ func TestEnsureSessionLLMFacadeConfigCreatesCodexEnvAndToken(t *testing.T) {
 		},
 	}
 
-	env, err := EnsureSessionLLMFacadeConfig(ctx, config, store, session, "codex", "", "test", "run-1")
+	env, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, config, store, session, "codex", "", "test", "run-1")
 	if err != nil {
 		t.Fatalf("EnsureSessionLLMFacadeConfig returned error: %v", err)
 	}
@@ -84,6 +85,65 @@ func TestEnsureSessionLLMFacadeConfigCreatesCodexEnvAndToken(t *testing.T) {
 	}
 }
 
+func TestEnsureSessionCodexConfigBridgesResponsesIngressToChatUpstream(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		DbAddr:         filepath.Join(root, "data.db"),
+		LLMAPIEndpoint: "https://chat.example.test/v1",
+		LLMAPIProtocol: llms.APIProtocolChatCompletions,
+		LLMAPIKey:      "chat-key",
+		LLMModel:       "chat-model",
+		RuntimeBaseURL: "http://agent-compose.test:7410",
+		GuestHomePath:  "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session := &domain.Sandbox{
+		Summary: domain.SandboxSummary{
+			ID:            "sandbox-codex-chat",
+			Driver:        driverpkg.RuntimeDriverDocker,
+			WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-codex-chat", "workspace"),
+		},
+	}
+
+	env, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, config, store, session, "codex", "", runtimefacade.TokenSourceAgent, "run-chat")
+	if err != nil {
+		t.Fatalf("EnsureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["LLM_API_PROTOCOL"] != llms.APIProtocolResponses {
+		t.Fatalf("LLM_API_PROTOCOL = %q, want responses", env["LLM_API_PROTOCOL"])
+	}
+	token, err := store.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SANDBOX_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.WireAPI != llms.APIProtocolResponses || token.ProviderID == "" || token.Model != "chat-model" {
+		t.Fatalf("stored token = %#v", token)
+	}
+	target, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "chat-model", token.ProviderID)
+	if err != nil {
+		t.Fatalf("ResolveRuntimeLLMTarget returned error: %v", err)
+	}
+	if target.WireAPI != llms.APIProtocolChatCompletions {
+		t.Fatalf("upstream wire API = %q, want chat_completions", target.WireAPI)
+	}
+	configBytes, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read Codex config: %v", err)
+	}
+	if !strings.Contains(string(configBytes), `wire_api = "responses"`) {
+		t.Fatalf("Codex config = %s", configBytes)
+	}
+}
+
 func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T) {
 	isolateLLMEnv(t)
 
@@ -113,11 +173,12 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 			{Name: "ANTHROPIC_API_KEY", Value: "anthropic-key"},
 			{Name: "ANTHROPIC_MODEL", Value: "claude-test"},
 			{Name: "LLM_API_ENDPOINT", Value: "https://openai.example.test/v1"},
+			{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolChatCompletions},
 			{Name: "LLM_API_KEY", Value: "openai-key"},
 			{Name: "LLM_MODEL", Value: "gpt-test"},
 		},
 	}
-	claude, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "claude", "", "agent", "run-claude")
+	claude, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "claude", "", "agent", "run-claude")
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig claude returned error: %v", err)
 	}
@@ -134,15 +195,26 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 		t.Fatalf("claude emitted deprecated session token env")
 	}
 
-	openAI, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "openai/gpt-test", TokenSourceAgent, "run-openai")
+	openAI, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "openai/gpt-test", runtimefacade.TokenSourceAgent, "run-openai")
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig opencode openai returned error: %v", err)
 	}
 	if openAI.Env["LLM_API_PROTOCOL"] != llms.APIProtocolResponses || openAI.Env["OPENCODE_CONFIG"] == "" {
 		t.Fatalf("opencode openai env = %#v", openAI.Env)
 	}
+	openAIToken, err := store.GetLLMFacadeToken(ctx, openAI.Env["AGENT_COMPOSE_SANDBOX_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken opencode openai returned error: %v", err)
+	}
+	openAITarget, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "gpt-test", openAIToken.ProviderID)
+	if err != nil {
+		t.Fatalf("ResolveRuntimeLLMTarget opencode openai returned error: %v", err)
+	}
+	if openAIToken.WireAPI != llms.APIProtocolResponses || openAITarget.WireAPI != llms.APIProtocolChatCompletions {
+		t.Fatalf("opencode token wire api = %q, upstream wire api = %q", openAIToken.WireAPI, openAITarget.WireAPI)
+	}
 
-	anthropic, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "anthropic/claude-test", TokenSourceAgent, "run-anthropic")
+	anthropic, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "anthropic/claude-test", runtimefacade.TokenSourceAgent, "run-anthropic")
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig opencode anthropic returned error: %v", err)
 	}
@@ -150,7 +222,7 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 		t.Fatalf("opencode anthropic env = %#v", anthropic.Env)
 	}
 
-	custom, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "custom/gpt-custom", TokenSourceLoaderCommand, "run-custom")
+	custom, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "custom/gpt-custom", runtimefacade.TokenSourceLoaderCommand, "run-custom")
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig opencode custom returned error: %v", err)
 	}
@@ -158,28 +230,22 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 		t.Fatalf("opencode custom env = %#v", custom.Env)
 	}
 
-	noop, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "opencode/local", "", "")
+	noop, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "opencode/local", "", "")
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig opencode local returned error: %v", err)
 	}
 	if len(noop.Env) != 0 {
 		t.Fatalf("opencode local env = %#v", noop.Env)
 	}
-	if _, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "bad-model", "", ""); err == nil {
+	if _, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "bad-model", "", ""); err == nil {
 		t.Fatalf("expected invalid opencode model error")
 	}
-	if env, err := EnsureSessionLLMFacadeConfig(ctx, nil, store, session, "codex", "", "", ""); err != nil || env != nil {
+	if env, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, nil, store, session, "codex", "", "", ""); err != nil || env != nil {
 		t.Fatalf("nil config env=%#v err=%v", env, err)
-	}
-	if !HasAnthropicProviderKey(ctx, config, store) {
-		t.Fatalf("expected anthropic provider key")
-	}
-	if got := firstNonEmpty(" \t", "value"); got != "value" {
-		t.Fatalf("firstNonEmpty = %q, want value", got)
 	}
 }
 
-func TestEnsureSessionAgentRuntimeConfigClaudePreservesProviderlessCompatibilityToken(t *testing.T) {
+func TestEnsureSessionAgentRuntimeConfigClaudeRejectsGenericOpenAIConfig(t *testing.T) {
 	isolateLLMEnv(t)
 
 	ctx := context.Background()
@@ -198,20 +264,68 @@ func TestEnsureSessionAgentRuntimeConfigClaudePreservesProviderlessCompatibility
 	}
 	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-claude-compat", Driver: driverpkg.RuntimeDriverDocker}}
 
-	runtimeConfig, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "claude", "", "test", "run-compat")
+	runtimeConfig, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "claude", "", "test", "run-compat")
+	if err == nil {
+		t.Fatal("EnsureSessionAgentRuntimeConfig returned nil error for generic OpenAI config")
+	}
+	if len(runtimeConfig.Env) != 0 {
+		t.Fatalf("runtime config = %#v, want no facade environment", runtimeConfig)
+	}
+	providers, listErr := store.ListEnabledLLMProviders(ctx)
+	if listErr != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", listErr)
+	}
+	if len(providers) != 0 {
+		t.Fatalf("generic OpenAI config created Anthropic providers: %#v", providers)
+	}
+}
+
+func TestEnsureSessionOpenCodeCustomProviderInheritsDaemonConfig(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		DbAddr:         filepath.Join(root, "data.db"),
+		LLMAPIEndpoint: "https://daemon.example.test/v1",
+		LLMAPIProtocol: llms.APIProtocolChatCompletions,
+		LLMAPIKey:      "daemon-key",
+		RuntimeBaseURL: "http://agent-compose.test:7410",
+		GuestHomePath:  "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, config)
+	store, err := configstore.NewConfigStore(di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session := &domain.Sandbox{
+		Summary: domain.SandboxSummary{
+			ID:            "sandbox-custom-layered",
+			Driver:        driverpkg.RuntimeDriverDocker,
+			WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-custom-layered", "workspace"),
+		},
+		ProviderEnvItems: []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example.test/v1"}},
+	}
+
+	runtimeConfig, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, session, "opencode", "custom/custom-model", runtimefacade.TokenSourceAgent, "run-custom-layered")
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig returned error: %v", err)
 	}
-	rawToken := runtimeConfig.Env["AGENT_COMPOSE_SANDBOX_TOKEN"]
-	if rawToken == "" {
-		t.Fatal("AGENT_COMPOSE_SANDBOX_TOKEN is empty")
-	}
-	token, err := store.GetLLMFacadeToken(ctx, rawToken)
+	token, err := store.GetLLMFacadeToken(ctx, runtimeConfig.Env["AGENT_COMPOSE_SANDBOX_TOKEN"])
 	if err != nil {
 		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
 	}
-	if token.ProviderID != "" || token.Model != "" {
-		t.Fatalf("compatibility token = %#v", token)
+	target, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "custom-model", token.ProviderID)
+	if err != nil {
+		t.Fatalf("ResolveRuntimeLLMTarget returned error: %v", err)
+	}
+	if target.Provider.BaseURL != "https://sandbox.example.test/v1" || target.Provider.APIKey != "daemon-key" || target.WireAPI != llms.APIProtocolChatCompletions {
+		t.Fatalf("custom provider target = %#v", target)
+	}
+	if token.WireAPI != llms.APIProtocolChatCompletions || runtimeConfig.Env["LLM_API_PROTOCOL"] != llms.APIProtocolChatCompletions {
+		t.Fatalf("custom ingress token=%q env=%q", token.WireAPI, runtimeConfig.Env["LLM_API_PROTOCOL"])
 	}
 }
 

--- a/pkg/llms/runtimefacade/coverage_shape_workflows_test.go
+++ b/pkg/llms/runtimefacade/coverage_shape_workflows_test.go
@@ -1,4 +1,4 @@
-package runtimefacade
+package runtimefacade_test
 
 import "testing"
 

--- a/pkg/llms/selection.go
+++ b/pkg/llms/selection.go
@@ -74,7 +74,7 @@ func SelectProviderForModel(ctx context.Context, store ProviderModelWireAPIStore
 		if providerID != "" && provider.ID != providerID {
 			continue
 		}
-		if providerID == "" && strings.TrimSpace(provider.Scope) == ProviderScopeSessionEnv {
+		if providerID == "" && (strings.TrimSpace(provider.Scope) == ProviderScopeSessionEnv || strings.TrimSpace(provider.Scope) == ProviderScopeFacadeEnv) {
 			continue
 		}
 		wireAPI, ok, err := store.LLMProviderModelWireAPI(ctx, provider.ID, modelID)
@@ -103,6 +103,8 @@ func SelectProviderForModel(ctx context.Context, store ProviderModelWireAPIStore
 
 func ProviderSelectionPriority(scope string) int {
 	switch strings.TrimSpace(scope) {
+	case ProviderScopeFacadeEnv:
+		return 3
 	case ProviderScopeSessionEnv:
 		return 2
 	case ProviderScopeEnvDefault:

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -182,9 +182,13 @@ type Sandbox struct {
 	WorkspaceProvisioning *SandboxWorkspaceProvisioning `json:"workspace_provisioning,omitempty"`
 	WorkspaceReclamation  *SandboxWorkspaceReclamation  `json:"workspace_reclamation,omitempty"`
 	EnvItems              []SandboxEnvVar               `json:"env_items,omitempty"`
-	VolumeMounts          []SandboxVolumeMount          `json:"volume_mounts,omitempty"`
-	RuntimeEnvItems       []SandboxEnvVar               `json:"-"`
-	ProviderEnvItems      []SandboxEnvVar               `json:"-"`
+	// ProviderEnvOverrideNames records source provenance without persisting
+	// provider credentials. Values remain transient in ProviderEnvItems or in
+	// the session-scoped provider row created by the LLM resolver.
+	ProviderEnvOverrideNames []string             `json:"provider_env_override_names,omitempty"`
+	VolumeMounts             []SandboxVolumeMount `json:"volume_mounts,omitempty"`
+	RuntimeEnvItems          []SandboxEnvVar      `json:"-"`
+	ProviderEnvItems         []SandboxEnvVar      `json:"-"`
 }
 
 func SandboxWorkspaceReclaimed(sandbox *Sandbox) bool {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -182,13 +182,14 @@ type Sandbox struct {
 	WorkspaceProvisioning *SandboxWorkspaceProvisioning `json:"workspace_provisioning,omitempty"`
 	WorkspaceReclamation  *SandboxWorkspaceReclamation  `json:"workspace_reclamation,omitempty"`
 	EnvItems              []SandboxEnvVar               `json:"env_items,omitempty"`
-	// ProviderEnvOverrideNames records source provenance without persisting
-	// provider credentials. Values remain transient in ProviderEnvItems or in
-	// the session-scoped provider row created by the LLM resolver.
-	ProviderEnvOverrideNames []string             `json:"provider_env_override_names,omitempty"`
-	VolumeMounts             []SandboxVolumeMount `json:"volume_mounts,omitempty"`
-	RuntimeEnvItems          []SandboxEnvVar      `json:"-"`
-	ProviderEnvItems         []SandboxEnvVar      `json:"-"`
+	// ProviderEnvItems is the daemon-only, sandbox-owned LLM provider layer. It
+	// is persisted separately from EnvItems and is never projected to a guest.
+	ProviderEnvItems []SandboxEnvVar      `json:"provider_env_items,omitempty"`
+	VolumeMounts     []SandboxVolumeMount `json:"volume_mounts,omitempty"`
+	RuntimeEnvItems  []SandboxEnvVar      `json:"-"`
+	// ExecutionProviderEnvItems is a transient overlay owned by one execution.
+	// It must never be persisted back to the sandbox or shared between runs.
+	ExecutionProviderEnvItems []SandboxEnvVar `json:"-"`
 }
 
 func SandboxWorkspaceReclaimed(sandbox *Sandbox) bool {
@@ -277,8 +278,8 @@ func RestoreSandboxTransientFields(dst, src *Sandbox) {
 	if len(src.RuntimeEnvItems) > 0 {
 		dst.RuntimeEnvItems = append([]SandboxEnvVar(nil), src.RuntimeEnvItems...)
 	}
-	if len(src.ProviderEnvItems) > 0 {
-		dst.ProviderEnvItems = append([]SandboxEnvVar(nil), src.ProviderEnvItems...)
+	if len(src.ExecutionProviderEnvItems) > 0 {
+		dst.ExecutionProviderEnvItems = append([]SandboxEnvVar(nil), src.ExecutionProviderEnvItems...)
 	}
 }
 

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -22,6 +22,7 @@ import (
 	"agent-compose/pkg/execution"
 	"agent-compose/pkg/images"
 	"agent-compose/pkg/llms"
+	"agent-compose/pkg/llms/runtimefacade"
 	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/sessions"
@@ -135,7 +136,7 @@ type llmFacadeTokenDeleter interface {
 
 type llmFacadeStore interface {
 	llms.LLMResolverStore
-	SaveLLMFacadeToken(context.Context, llms.FacadeToken) error
+	SaveLLMFacadeGrant(context.Context, llms.FacadeGrant) error
 }
 
 type ControllerDependencies struct {
@@ -1052,36 +1053,8 @@ func (c *Controller) ensurePromptAttachLLMFacadeEnv(ctx context.Context, sandbox
 	if !ok || c.config == nil || sandbox == nil || domain.NormalizeAgentKind(agent.Provider) != "codex" {
 		return nil, nil
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, store, sandbox.Summary.ID, llms.ProviderFamilyOpenAI, agent.Model, "", promptAttachSandboxProviderEnvItems(sandbox))
-	if err != nil {
-		if errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	baseURL := llms.GuestRuntimeBaseURL(c.config, sandbox)
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, nil
-	}
-	tokenValue, token, err := llms.NewFacadeToken(sandbox.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolResponses, "agent", runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
-	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/openai/v1"
-	if err := llms.WriteCodexRuntimeConfig(sandbox, target.Model.Name, openAIBaseURL, llms.APIProtocolResponses, llms.CodexRuntimePolicyFromConfig(c.config)); err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		"AGENT_COMPOSE_SANDBOX_TOKEN": tokenValue,
-		"LLM_API_ENDPOINT":            openAIBaseURL,
-		"LLM_API_KEY":                 tokenValue,
-		"LLM_API_PROTOCOL":            llms.APIProtocolResponses,
-		"OPENAI_API_KEY":              tokenValue,
-		"OPENAI_BASE_URL":             openAIBaseURL,
-	}, nil
+	runtimeConfig, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, c.config, store, sandbox, agent.Provider, agent.Model, runtimefacade.TokenSourceAgent, runID)
+	return runtimeConfig.Env, err
 }
 
 func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token string) {
@@ -1090,16 +1063,6 @@ func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token
 		return
 	}
 	_ = store.DeleteLLMFacadeToken(ctx, token)
-}
-
-func promptAttachSandboxProviderEnvItems(sandbox *domain.Sandbox) []domain.SandboxEnvVar {
-	if sandbox == nil {
-		return nil
-	}
-	if len(sandbox.ProviderEnvItems) > 0 {
-		return sandbox.ProviderEnvItems
-	}
-	return sandbox.EnvItems
 }
 
 func projectRunAgentExecutionStream(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, sink *StreamSink, hub *RunLogHub) execution.AgentExecutionStream {
@@ -2035,7 +1998,10 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 	if err != nil {
 		return SandboxResult{}, err
 	}
-	sandbox.ProviderEnvItems = prepared.ProviderEnvItems
+	llms.SetSandboxProviderEnvItems(sandbox, prepared.ProviderEnvItems)
+	if err := c.store.UpdateSandbox(ctx, sandbox); err != nil {
+		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, fmt.Errorf("persist sandbox provider environment provenance: %w", err)
+	}
 	if err := c.startProjectRunSandbox(ctx, sandbox, "sandbox.created", "sandbox started for project run"); err != nil {
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
 	}

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -68,13 +68,12 @@ func PrepareProjectRun(ctx context.Context, store PreparationStore, resolver Wor
 	if err != nil {
 		return Preparation{}, fmt.Errorf("list global env: %w", err)
 	}
-	envItems := MergeEnvItems(
-		globalEnv,
+	providerEnvItems := MergeEnvItems(
 		EnvItemsFromV2(spec.GetVariables()),
 		agent.EnvItems,
 		EnvItemsFromV2(requestEnv),
 	)
-	providerEnvItems := envItems
+	envItems := domain.MergeEnvItems(globalEnv, providerEnvItems)
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	prepared := Preparation{
 		EnvItems:         envItems,

--- a/pkg/runs/preparation_provider_env_test.go
+++ b/pkg/runs/preparation_provider_env_test.go
@@ -1,0 +1,54 @@
+package runs
+
+import (
+	"context"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestPrepareProjectRunKeepsGlobalEnvOutOfSandboxProviderOverrides(t *testing.T) {
+	store := &fakePreparationStore{
+		project: domain.ProjectRecord{ID: "project-1", Name: "project"},
+		revision: domain.ProjectRevisionRecord{
+			ProjectID: "project-1",
+			Revision:  1,
+			SpecJSON:  `{"variables":[{"name":"PROJECT_VALUE","value":"project"}],"agents":[{"name":"worker"}]}`,
+		},
+		agent: domain.AgentDefinition{
+			ID:       "agent-1",
+			EnvItems: []domain.SandboxEnvVar{{Name: "AGENT_VALUE", Value: "agent"}},
+		},
+		global: []domain.SandboxEnvVar{
+			{Name: "GLOBAL_VALUE", Value: "global"},
+			{Name: "LLM_API_KEY", Value: "global-key", Secret: true},
+		},
+	}
+	prepared, err := PrepareProjectRun(context.Background(), store, nil, domain.ProjectRunRecord{
+		ProjectID:       "project-1",
+		ProjectRevision: 1,
+		AgentName:       "worker",
+		ManagedAgentID:  "agent-1",
+	}, []*agentcomposev2.EnvVarSpec{{Name: "REQUEST_VALUE", Value: "request"}})
+	if err != nil {
+		t.Fatalf("PrepareProjectRun returned error: %v", err)
+	}
+	runtimeEnv := domain.SandboxEnvMap(prepared.EnvItems)
+	if runtimeEnv["GLOBAL_VALUE"] != "global" || runtimeEnv["LLM_API_KEY"] != "" {
+		t.Fatalf("runtime env = %#v", runtimeEnv)
+	}
+	providerEnv := domain.SandboxEnvMap(prepared.ProviderEnvItems)
+	if providerEnv["GLOBAL_VALUE"] != "" || providerEnv["LLM_API_KEY"] != "" {
+		t.Fatalf("provider overrides contain Global Env: %#v", providerEnv)
+	}
+	for name, want := range map[string]string{
+		"PROJECT_VALUE": "project",
+		"AGENT_VALUE":   "agent",
+		"REQUEST_VALUE": "request",
+	} {
+		if providerEnv[name] != want {
+			t.Fatalf("provider env %s = %q, want %q", name, providerEnv[name], want)
+		}
+	}
+}

--- a/pkg/runs/project_run_workspace_ensurer_test.go
+++ b/pkg/runs/project_run_workspace_ensurer_test.go
@@ -45,8 +45,21 @@ func TestRunsControllerProjectRunWorkspaceEnsurerPaths(t *testing.T) {
 	t.Run("new sandbox", func(t *testing.T) {
 		fixture := newControllerRunFixture(t)
 		ensurer := projectRunEnsurerBeforeDriver(t, fixture)
+		ensurer.beforeEnsure = func(sandbox *domain.Sandbox) {
+			if fixture.driver.started {
+				t.Fatal("driver started before workspace Ensurer")
+			}
+			persisted, err := fixture.store.GetSandbox(fixture.ctx, sandbox.Summary.ID)
+			if err != nil {
+				t.Fatalf("GetSandbox before workspace Ensure: %v", err)
+			}
+			if got := domain.SandboxEnvMap(persisted.ProviderEnvItems)["LLM_API_ENDPOINT"]; got != "https://project.example/v1" {
+				t.Fatalf("provider env before workspace Ensure = %q", got)
+			}
+		}
 		fixture.controller.workspaceEnsurer = ensurer
-		prepared := Preparation{Workspace: projectRunWorkspaceSnapshot("prepared")}
+		providerEnv := []domain.SandboxEnvVar{{Name: "LLM_API_ENDPOINT", Value: "https://project.example/v1"}}
+		prepared := Preparation{EnvItems: providerEnv, ProviderEnvItems: providerEnv, Workspace: projectRunWorkspaceSnapshot("prepared")}
 
 		result, err := fixture.controller.ensureProjectRunSandbox(
 			fixture.ctx,

--- a/pkg/runs/prompt_attach_llm_facade_test.go
+++ b/pkg/runs/prompt_attach_llm_facade_test.go
@@ -1,0 +1,159 @@
+package runs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
+	"agent-compose/pkg/llms"
+	"agent-compose/pkg/llms/runtimefacade"
+	domain "agent-compose/pkg/model"
+)
+
+func TestPromptAttachLLMFacadeMatchesOrdinaryCodexResponsesIngress(t *testing.T) {
+	for _, key := range []string{"LLM_API_ENDPOINT", "LLM_API_PROTOCOL", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_MODEL"} {
+		t.Setenv(key, "")
+	}
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		LLMAPIEndpoint: "https://chat.example.test/v1",
+		LLMAPIProtocol: llms.APIProtocolChatCompletions,
+		LLMAPIKey:      "provider-key",
+		LLMModel:       "chat-model",
+		RuntimeBaseURL: "http://agent-compose.test:7410",
+	}
+	store := newPromptAttachLLMStore()
+	controller := &Controller{config: config, configDB: store}
+	promptSession := promptAttachLLMTestSandbox(root, "prompt-attach")
+	ordinarySession := promptAttachLLMTestSandbox(root, "ordinary")
+
+	promptEnv, err := controller.ensurePromptAttachLLMFacadeEnv(ctx, promptSession, execution.AgentConfig{Provider: "codex"}, "run-prompt")
+	if err != nil {
+		t.Fatalf("ensurePromptAttachLLMFacadeEnv returned error: %v", err)
+	}
+	ordinaryConfig, err := runtimefacade.EnsureSessionAgentRuntimeConfig(ctx, config, store, ordinarySession, "codex", "", runtimefacade.TokenSourceAgent, "run-ordinary")
+	if err != nil {
+		t.Fatalf("EnsureSessionAgentRuntimeConfig returned error: %v", err)
+	}
+
+	assertCodexResponsesFacadeConfig(t, store, promptSession, promptEnv, "run-prompt")
+	assertCodexResponsesFacadeConfig(t, store, ordinarySession, ordinaryConfig.Env, "run-ordinary")
+	if strings.ReplaceAll(promptEnv["LLM_API_ENDPOINT"], promptSession.Summary.ID, "sandbox") != strings.ReplaceAll(ordinaryConfig.Env["LLM_API_ENDPOINT"], ordinarySession.Summary.ID, "sandbox") {
+		t.Fatalf("prompt endpoint %q does not match ordinary endpoint %q", promptEnv["LLM_API_ENDPOINT"], ordinaryConfig.Env["LLM_API_ENDPOINT"])
+	}
+}
+
+func promptAttachLLMTestSandbox(root, id string) *domain.Sandbox {
+	return &domain.Sandbox{Summary: domain.SandboxSummary{
+		ID:            id,
+		Driver:        driverpkg.RuntimeDriverDocker,
+		WorkspacePath: filepath.Join(root, "sandboxes", id, "workspace"),
+	}}
+}
+
+func assertCodexResponsesFacadeConfig(t *testing.T, store *promptAttachLLMStore, session *domain.Sandbox, env map[string]string, runID string) {
+	t.Helper()
+	if env["LLM_API_PROTOCOL"] != llms.APIProtocolResponses || env["AGENT_COMPOSE_SANDBOX_TOKEN"] == "" {
+		t.Fatalf("facade env = %#v", env)
+	}
+	token, ok := store.facadeToken(env["AGENT_COMPOSE_SANDBOX_TOKEN"])
+	if !ok {
+		t.Fatalf("facade token was not saved")
+	}
+	if token.WireAPI != llms.APIProtocolResponses || token.Source != runtimefacade.TokenSourceAgent || token.RunID != runID {
+		t.Fatalf("facade token = %#v", token)
+	}
+	data, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read Codex config: %v", err)
+	}
+	if !strings.Contains(string(data), `wire_api = "responses"`) {
+		t.Fatalf("Codex config = %s", data)
+	}
+}
+
+type promptAttachLLMStore struct {
+	ControllerStore
+	providers []llms.Provider
+	models    []llms.Model
+	wireAPI   map[string]string
+	tokens    map[string]llms.FacadeToken
+}
+
+func newPromptAttachLLMStore() *promptAttachLLMStore {
+	return &promptAttachLLMStore{
+		wireAPI: make(map[string]string),
+		tokens:  make(map[string]llms.FacadeToken),
+	}
+}
+
+func (s *promptAttachLLMStore) UpsertDefaultLLMConfig(_ context.Context, provider llms.Provider, model llms.Model) error {
+	provider.Enabled = true
+	model.Enabled = true
+	s.providers = replacePromptAttachProvider(s.providers, provider)
+	s.models = replacePromptAttachModel(s.models, model)
+	s.wireAPI[provider.ID+"\x00"+model.ID] = llms.NormalizeWireAPI(provider.DefaultWireAPI)
+	return nil
+}
+
+func (s *promptAttachLLMStore) ListEnabledLLMProviders(context.Context) ([]llms.Provider, error) {
+	return append([]llms.Provider(nil), s.providers...), nil
+}
+
+func (s *promptAttachLLMStore) ListEnabledLLMModels(context.Context) ([]llms.Model, error) {
+	return append([]llms.Model(nil), s.models...), nil
+}
+
+func (s *promptAttachLLMStore) LLMProviderModelWireAPI(_ context.Context, providerID, modelID string) (string, bool, error) {
+	wireAPI, ok := s.wireAPI[providerID+"\x00"+modelID]
+	return wireAPI, ok, nil
+}
+
+func (s *promptAttachLLMStore) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
+	return nil, nil
+}
+
+func (s *promptAttachLLMStore) SaveLLMFacadeToken(_ context.Context, token llms.FacadeToken) error {
+	s.tokens[token.TokenHash] = token
+	return nil
+}
+
+func (s *promptAttachLLMStore) SaveLLMFacadeGrant(_ context.Context, grant llms.FacadeGrant) error {
+	s.tokens[grant.Token.TokenHash] = grant.Token
+	return nil
+}
+
+func (s *promptAttachLLMStore) facadeToken(raw string) (llms.FacadeToken, bool) {
+	hash, _ := llms.HashFacadeToken(raw)
+	token, ok := s.tokens[hash]
+	return token, ok
+}
+
+func replacePromptAttachProvider(providers []llms.Provider, replacement llms.Provider) []llms.Provider {
+	for index := range providers {
+		if providers[index].ID == replacement.ID {
+			providers[index] = replacement
+			return providers
+		}
+	}
+	return append(providers, replacement)
+}
+
+func replacePromptAttachModel(models []llms.Model, replacement llms.Model) []llms.Model {
+	for index := range models {
+		if models[index].ID == replacement.ID {
+			if replacement.Scope != llms.ProviderScopeSessionEnv || models[index].Scope == llms.ProviderScopeSessionEnv {
+				models[index] = replacement
+			}
+			return models
+		}
+	}
+	return append(models, replacement)
+}

--- a/pkg/storage/configstore/llm_config.go
+++ b/pkg/storage/configstore/llm_config.go
@@ -2,7 +2,6 @@ package configstore
 
 import (
 	"agent-compose/pkg/llms"
-	domain "agent-compose/pkg/model"
 	"context"
 	"database/sql"
 	"errors"
@@ -79,7 +78,7 @@ func (s *llmStore) ensureLLMSchema(ctx context.Context) error {
 
 func (s *llmStore) HasLLMProviders(ctx context.Context) (bool, error) {
 	var count int
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM llm_provider`).Scan(&count); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM llm_provider WHERE scope != ?`, llms.ProviderScopeFacadeEnv).Scan(&count); err != nil {
 		return false, fmt.Errorf("count llm providers: %w", err)
 	}
 	return count > 0, nil
@@ -119,6 +118,75 @@ func (s *llmStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.Pro
 		return fmt.Errorf("insert default llm provider model: %w", err)
 	}
 	return tx.Commit()
+}
+
+// DeleteSandboxLLMResources removes session-scoped providers and bindings, then
+// prunes session models that became unreferenced.
+func (s *llmStore) DeleteSandboxLLMResources(ctx context.Context, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return fmt.Errorf("delete sandbox llm resources: sandbox id is required")
+	}
+	providerIDs := []string{
+		llms.SessionEnvProviderID(sandboxID, llms.ProviderFamilyOpenAI),
+		llms.SessionEnvProviderID(sandboxID, llms.ProviderFamilyAnthropic),
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sandbox llm resource cleanup: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT pm.model_id
+		FROM llm_provider_model pm
+		JOIN llm_provider p ON p.id = pm.provider_id
+		WHERE p.scope = ? AND (p.id = ? OR p.id = ?)`, llms.ProviderScopeSessionEnv, providerIDs[0], providerIDs[1])
+	if err != nil {
+		return fmt.Errorf("list sandbox llm models: %w", err)
+	}
+	var modelIDs []string
+	var scanErr error
+	for rows.Next() {
+		var modelID string
+		if err := rows.Scan(&modelID); err != nil {
+			scanErr = err
+			break
+		}
+		modelIDs = append(modelIDs, modelID)
+	}
+	iterateErr := rows.Err()
+	closeErr := rows.Close()
+	if scanErr != nil {
+		return fmt.Errorf("scan sandbox llm model: %w", scanErr)
+	}
+	if iterateErr != nil {
+		return fmt.Errorf("iterate sandbox llm models: %w", iterateErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close sandbox llm models: %w", closeErr)
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM llm_provider_model
+		WHERE provider_id IN (
+			SELECT id FROM llm_provider WHERE scope = ? AND (id = ? OR id = ?)
+		)`, llms.ProviderScopeSessionEnv, providerIDs[0], providerIDs[1]); err != nil {
+		return fmt.Errorf("delete sandbox llm provider bindings: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM llm_provider
+		WHERE scope = ? AND (id = ? OR id = ?)`, llms.ProviderScopeSessionEnv, providerIDs[0], providerIDs[1]); err != nil {
+		return fmt.Errorf("delete sandbox llm providers: %w", err)
+	}
+	for _, modelID := range modelIDs {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM llm_model
+			WHERE id = ? AND scope = ?
+			AND NOT EXISTS (SELECT 1 FROM llm_provider_model WHERE model_id = llm_model.id)`, modelID, llms.ProviderScopeSessionEnv); err != nil {
+			return fmt.Errorf("delete orphaned sandbox llm model %q: %w", modelID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sandbox llm resource cleanup: %w", err)
+	}
+	return nil
 }
 
 func (s *llmStore) ListEnabledLLMProviders(ctx context.Context) ([]llms.Provider, error) {
@@ -175,78 +243,4 @@ func (s *llmStore) LLMProviderModelWireAPI(ctx context.Context, providerID, mode
 		return "", true, nil
 	}
 	return llms.NormalizeWireAPI(wireAPI), true, nil
-}
-
-func (s *llmStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error {
-	if strings.TrimSpace(token.TokenHash) == "" || strings.TrimSpace(token.SandboxID) == "" {
-		return fmt.Errorf("llm facade token hash and sandbox id are required")
-	}
-	if token.IssuedAt.IsZero() {
-		token.IssuedAt = time.Now().UTC()
-	}
-	revokedAt := int64(0)
-	if !token.RevokedAt.IsZero() {
-		revokedAt = token.RevokedAt.Unix()
-	}
-	expiresAt := int64(0)
-	if !token.ExpiresAt.IsZero() {
-		expiresAt = token.ExpiresAt.Unix()
-	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO llm_facade_token(token_hash, sandbox_id, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(token_hash) DO UPDATE SET sandbox_id = excluded.sandbox_id, token_fingerprint = excluded.token_fingerprint, model = excluded.model, provider_id = excluded.provider_id, wire_api = excluded.wire_api, source = excluded.source, run_id = excluded.run_id, issued_at = excluded.issued_at, expires_at = excluded.expires_at, revoked_at = excluded.revoked_at`,
-		token.TokenHash, token.SandboxID, token.TokenFingerprint, token.Model, token.ProviderID, token.WireAPI, token.Source, token.RunID, token.IssuedAt.Unix(), expiresAt, revokedAt)
-	if err != nil {
-		return fmt.Errorf("save llm facade token: %w", err)
-	}
-	return nil
-}
-
-// DeleteLLMFacadeToken removes a single facade token by its raw value. It is used
-// to retire a per-run agent token as soon as that run completes, so live tokens
-// never accumulate over the lifetime of a long-running session.
-func (s *llmStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) error {
-	if strings.TrimSpace(rawToken) == "" {
-		return nil
-	}
-	hash, _ := llms.HashFacadeToken(rawToken)
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE token_hash = ?`, hash); err != nil {
-		return fmt.Errorf("delete llm facade token: %w", err)
-	}
-	return nil
-}
-
-func (s *llmStore) GetLLMFacadeToken(ctx context.Context, rawToken string) (llms.FacadeToken, error) {
-	hash, fingerprint := llms.HashFacadeToken(rawToken)
-	row := s.db.QueryRowContext(ctx, `SELECT sandbox_id, token_hash, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at FROM llm_facade_token WHERE token_hash = ?`, hash)
-	token, err := llms.ScanFacadeToken(row.Scan)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return llms.FacadeToken{}, domain.ResourceError(domain.ErrNotFound, "llm facade token", fingerprint, fmt.Sprintf("llm facade token %s not found", fingerprint), err)
-		}
-		return llms.FacadeToken{}, err
-	}
-	return token, nil
-}
-
-// llmFacadeTokenRetention is how long a revoked facade token row is kept before
-// it is physically pruned. The grace window keeps recently-revoked tokens around
-// for debugging while bounding table growth from completed sessions.
-const llmFacadeTokenRetention = time.Hour
-
-const LLMFacadeTokenRetention = llmFacadeTokenRetention
-
-func (s *llmStore) RevokeLLMFacadeTokensForSandbox(ctx context.Context, sandboxID string) error {
-	now := time.Now().UTC()
-	if _, err := s.db.ExecContext(ctx, `UPDATE llm_facade_token SET revoked_at = ? WHERE sandbox_id = ? AND revoked_at = 0`, now.Unix(), strings.TrimSpace(sandboxID)); err != nil {
-		return fmt.Errorf("revoke llm facade tokens for sandbox: %w", err)
-	}
-	// Opportunistically prune long-dead rows (revoked beyond the retention grace,
-	// or expired) so the table stays bounded across sessions. Both states already
-	// fail closed at the handler, so deleting them changes nothing observable.
-	cutoff := now.Add(-llmFacadeTokenRetention).Unix()
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE (revoked_at != 0 AND revoked_at < ?) OR (expires_at != 0 AND expires_at < ?)`, cutoff, now.Unix()); err != nil {
-		return fmt.Errorf("prune llm facade tokens: %w", err)
-	}
-	return nil
 }

--- a/pkg/storage/configstore/llm_config.go
+++ b/pkg/storage/configstore/llm_config.go
@@ -102,14 +102,15 @@ func (s *llmStore) UpsertDefaultLLMConfig(ctx context.Context, provider llms.Pro
 		ON CONFLICT(id) DO UPDATE SET name = excluded.name, provider_type = excluded.provider_type, default_wire_api = excluded.default_wire_api, base_url = excluded.base_url, api_key = excluded.api_key, auth_header = excluded.auth_header, auth_scheme = excluded.auth_scheme, headers_json = excluded.headers_json, use_generic_responses_text_parts = excluded.use_generic_responses_text_parts, weight = excluded.weight, enabled = excluded.enabled, scope = excluded.scope, updated_at = excluded.updated_at`, provider.ID, provider.Name, provider.ProviderType, provider.DefaultWireAPI, provider.BaseURL, provider.APIKey, provider.AuthHeader, provider.AuthScheme, provider.HeadersJSON, BoolToInt(provider.UseGenericResponsesTextParts), provider.Weight, provider.Scope, now, now); err != nil {
 		return fmt.Errorf("insert default llm provider: %w", err)
 	}
-	if model.DefaultModel {
+	if model.DefaultModel && model.Scope != llms.ProviderScopeSessionEnv {
 		if _, err := tx.ExecContext(ctx, `UPDATE llm_model SET default_model = 0 WHERE default_model != 0`); err != nil {
 			return fmt.Errorf("reset default llm models: %w", err)
 		}
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_model(id, name, description, default_model, enabled, scope, created_at, updated_at)
 		VALUES(?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET name = excluded.name, description = excluded.description, default_model = excluded.default_model, enabled = excluded.enabled, scope = excluded.scope, updated_at = excluded.updated_at`, model.ID, model.Name, model.Description, BoolToInt(model.DefaultModel), BoolToInt(model.Enabled), model.Scope, now, now); err != nil {
+		ON CONFLICT(id) DO UPDATE SET name = excluded.name, description = excluded.description, default_model = excluded.default_model, enabled = excluded.enabled, scope = excluded.scope, updated_at = excluded.updated_at
+		WHERE excluded.scope != ? OR llm_model.scope = ?`, model.ID, model.Name, model.Description, BoolToInt(model.DefaultModel), BoolToInt(model.Enabled), model.Scope, now, now, llms.ProviderScopeSessionEnv, llms.ProviderScopeSessionEnv); err != nil {
 		return fmt.Errorf("insert default llm model: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO llm_provider_model(provider_id, model_id, wire_api, weight)

--- a/pkg/storage/configstore/llm_config_test.go
+++ b/pkg/storage/configstore/llm_config_test.go
@@ -1,0 +1,55 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestSessionProtocolOverridePreservesSharedModelMetadata(t *testing.T) {
+	for _, key := range []string{"LLM_API_ENDPOINT", "LLM_API_PROTOCOL", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_MODEL"} {
+		t.Setenv(key, "")
+	}
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("initSchema returned error: %v", err)
+	}
+	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolResponses},
+		{Name: "LLM_API_KEY", Value: "global-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "shared-model"},
+	}); err != nil {
+		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
+	}
+
+	initial, err := llms.ResolveLLMTarget(ctx, &appconfig.Config{}, store, "")
+	if err != nil {
+		t.Fatalf("ResolveLLMTarget returned error: %v", err)
+	}
+	if !initial.Model.DefaultModel || initial.Model.Scope != llms.ProviderScopeEnvDefault {
+		t.Fatalf("initial shared model = %#v", initial.Model)
+	}
+
+	session, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-protocol", llms.ProviderFamilyOpenAI, "", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolChatCompletions},
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
+	}
+	if session.Provider.Scope != llms.ProviderScopeSessionEnv || session.WireAPI != llms.APIProtocolChatCompletions {
+		t.Fatalf("session target = %#v", session)
+	}
+
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMModels returned error: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "shared-model" || !models[0].DefaultModel || models[0].Scope != llms.ProviderScopeEnvDefault {
+		t.Fatalf("shared model metadata after session binding = %#v", models)
+	}
+}

--- a/pkg/storage/configstore/llm_config_test.go
+++ b/pkg/storage/configstore/llm_config_test.go
@@ -2,54 +2,138 @@ package configstore
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
-	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
 )
 
-func TestSessionProtocolOverridePreservesSharedModelMetadata(t *testing.T) {
-	for _, key := range []string{"LLM_API_ENDPOINT", "LLM_API_PROTOCOL", "LLM_API_KEY", "OPENAI_API_KEY", "LLM_MODEL"} {
-		t.Setenv(key, "")
-	}
+func TestFacadeGrantPersistsSparseEnvironmentOutsideSelectableProviders(t *testing.T) {
 	ctx := context.Background()
 	store := FromDB(newMemoryDB(t))
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("initSchema returned error: %v", err)
 	}
-	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
-		{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolResponses},
-		{Name: "LLM_API_KEY", Value: "global-key", Secret: true},
-		{Name: "LLM_MODEL", Value: "shared-model"},
-	}); err != nil {
-		t.Fatalf("ReplaceGlobalEnv returned error: %v", err)
-	}
-
-	initial, err := llms.ResolveLLMTarget(ctx, &appconfig.Config{}, store, "")
-	if err != nil {
-		t.Fatalf("ResolveLLMTarget returned error: %v", err)
-	}
-	if !initial.Model.DefaultModel || initial.Model.Scope != llms.ProviderScopeEnvDefault {
-		t.Fatalf("initial shared model = %#v", initial.Model)
-	}
-
-	session, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, &appconfig.Config{}, store, "sandbox-protocol", llms.ProviderFamilyOpenAI, "", "", []domain.SandboxEnvVar{
-		{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolChatCompletions},
+	rawToken, grant := testFacadeEnvironmentGrant(t, "sandbox-a", "run-a", llms.FacadeEnvironment{
+		ProviderType: llms.ProviderFamilyOpenAI,
+		Endpoint:     "https://execution.example/v1",
 	})
-	if err != nil {
-		t.Fatalf("ResolveRuntimeLLMTargetWithEnv returned error: %v", err)
-	}
-	if session.Provider.Scope != llms.ProviderScopeSessionEnv || session.WireAPI != llms.APIProtocolChatCompletions {
-		t.Fatalf("session target = %#v", session)
+	if err := store.SaveLLMFacadeGrant(ctx, grant); err != nil {
+		t.Fatalf("SaveLLMFacadeGrant returned error: %v", err)
 	}
 
-	models, err := store.ListEnabledLLMModels(ctx)
+	storedToken, err := store.GetLLMFacadeToken(ctx, rawToken)
 	if err != nil {
-		t.Fatalf("ListEnabledLLMModels returned error: %v", err)
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
 	}
-	if len(models) != 1 || models[0].ID != "shared-model" || !models[0].DefaultModel || models[0].Scope != llms.ProviderScopeEnvDefault {
-		t.Fatalf("shared model metadata after session binding = %#v", models)
+	if storedToken.ProviderID != grant.Token.ProviderID {
+		t.Fatalf("stored token provider = %q", storedToken.ProviderID)
 	}
+	environment, ok, err := store.GetLLMFacadeEnvironment(ctx, storedToken.ProviderID)
+	if err != nil || !ok {
+		t.Fatalf("GetLLMFacadeEnvironment ok=%v err=%v", ok, err)
+	}
+	if environment.Endpoint != "https://execution.example/v1" || environment.APIKey != "" || environment.Protocol != "" {
+		t.Fatalf("stored sparse environment = %#v", environment)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 0 {
+		t.Fatalf("token environment became selectable: %#v", providers)
+	}
+
+	if err := store.DeleteLLMFacadeToken(ctx, rawToken); err != nil {
+		t.Fatalf("DeleteLLMFacadeToken returned error: %v", err)
+	}
+	if _, ok, err := store.GetLLMFacadeEnvironment(ctx, storedToken.ProviderID); err != nil || ok {
+		t.Fatalf("deleted token environment ok=%v err=%v", ok, err)
+	}
+	if _, err := store.GetLLMFacadeToken(ctx, rawToken); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("deleted token lookup error = %v", err)
+	}
+}
+
+func TestRevokeSandboxFacadeTokensDeletesOnlyOwnedEnvironments(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("initSchema returned error: %v", err)
+	}
+	_, first := testFacadeEnvironmentGrant(t, "sandbox-a", "run-a", llms.FacadeEnvironment{
+		ProviderType: llms.ProviderFamilyOpenAI,
+		APIKey:       "sandbox-a-key",
+	})
+	secondRaw, second := testFacadeEnvironmentGrant(t, "sandbox-b", "run-b", llms.FacadeEnvironment{
+		ProviderType: llms.ProviderFamilyOpenAI,
+		APIKey:       "sandbox-b-key",
+	})
+	for _, grant := range []llms.FacadeGrant{first, second} {
+		if err := store.SaveLLMFacadeGrant(ctx, grant); err != nil {
+			t.Fatalf("SaveLLMFacadeGrant returned error: %v", err)
+		}
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx,
+		llms.Provider{ID: "system-provider", ProviderType: llms.ProviderFamilyOpenAI, BaseURL: "https://system.example/v1", Scope: llms.ProviderScopeSystem},
+		llms.Model{ID: "system-model", Name: "system-model", DefaultModel: true, Scope: llms.ProviderScopeSystem},
+	); err != nil {
+		t.Fatalf("UpsertDefaultLLMConfig returned error: %v", err)
+	}
+
+	if err := store.RevokeLLMFacadeTokensForSandbox(ctx, "sandbox-a"); err != nil {
+		t.Fatalf("RevokeLLMFacadeTokensForSandbox returned error: %v", err)
+	}
+	if _, ok, err := store.GetLLMFacadeEnvironment(ctx, first.Token.ProviderID); err != nil || ok {
+		t.Fatalf("sandbox A environment remains ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := store.GetLLMFacadeEnvironment(ctx, second.Token.ProviderID); err != nil || !ok {
+		t.Fatalf("sandbox B environment missing ok=%v err=%v", ok, err)
+	}
+	if token, err := store.GetLLMFacadeToken(ctx, secondRaw); err != nil || !token.RevokedAt.IsZero() {
+		t.Fatalf("sandbox B token = %#v err=%v", token, err)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil || len(providers) != 1 || providers[0].ID != "system-provider" {
+		t.Fatalf("configured providers = %#v err=%v", providers, err)
+	}
+}
+
+func TestFacadeGrantRejectsMissingEnvironmentAtomically(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("initSchema returned error: %v", err)
+	}
+	rawToken, token, err := llms.NewFacadeToken("sandbox-a", "model-a", "", llms.APIProtocolResponses, "agent", "run-a")
+	if err != nil {
+		t.Fatalf("NewFacadeToken returned error: %v", err)
+	}
+	token.ProviderID = llms.FacadeEnvironmentProviderID(token.TokenHash, llms.ProviderFamilyOpenAI)
+	if err := store.SaveLLMFacadeGrant(ctx, llms.FacadeGrant{Token: token}); err == nil {
+		t.Fatal("SaveLLMFacadeGrant accepted a missing environment")
+	}
+	if _, err := store.GetLLMFacadeToken(ctx, rawToken); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("invalid grant persisted token: %v", err)
+	}
+}
+
+func testFacadeEnvironmentGrant(t *testing.T, sandboxID, runID string, environment llms.FacadeEnvironment) (string, llms.FacadeGrant) {
+	t.Helper()
+	target := llms.FacadeTarget{
+		Target: llms.ResolvedTarget{
+			Provider: llms.Provider{ID: "environment", ProviderType: environment.ProviderType},
+			Model:    llms.Model{ID: "model-a", Name: "model-a"},
+			WireAPI:  llms.APIProtocolResponses,
+		},
+		Environment: &environment,
+	}
+	rawToken, grant, err := llms.NewFacadeGrant(sandboxID, target, llms.APIProtocolResponses, "agent", runID)
+	if err != nil {
+		t.Fatalf("NewFacadeGrant returned error: %v", err)
+	}
+	grant.Token.ExpiresAt = time.Now().UTC().Add(time.Hour)
+	return rawToken, grant
 }

--- a/pkg/storage/configstore/llm_facade_grant.go
+++ b/pkg/storage/configstore/llm_facade_grant.go
@@ -1,0 +1,229 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func (s *llmStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error {
+	return s.SaveLLMFacadeGrant(ctx, llms.FacadeGrant{Token: token})
+}
+
+// SaveLLMFacadeGrant atomically persists a token and its token-owned sparse
+// Provider Env layer, when env bootstrap selected the upstream.
+func (s *llmStore) SaveLLMFacadeGrant(ctx context.Context, grant llms.FacadeGrant) error {
+	token := grant.Token
+	if strings.TrimSpace(token.TokenHash) == "" || strings.TrimSpace(token.SandboxID) == "" {
+		return fmt.Errorf("llm facade token hash and sandbox id are required")
+	}
+	if grant.Environment == nil && llms.IsFacadeEnvironmentProviderID(token.ProviderID) {
+		return fmt.Errorf("llm facade environment is required")
+	}
+	if grant.Environment != nil {
+		expectedID := llms.FacadeEnvironmentProviderID(token.TokenHash, grant.Environment.ProviderType)
+		if expectedID == "" || token.ProviderID != expectedID || grant.Environment.ProviderID != expectedID {
+			return fmt.Errorf("llm facade environment provider id is invalid")
+		}
+	}
+	if token.IssuedAt.IsZero() {
+		token.IssuedAt = time.Now().UTC()
+	}
+	revokedAt := int64(0)
+	if !token.RevokedAt.IsZero() {
+		revokedAt = token.RevokedAt.Unix()
+	}
+	expiresAt := int64(0)
+	if !token.ExpiresAt.IsZero() {
+		expiresAt = token.ExpiresAt.Unix()
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin llm facade grant tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var previousProviderID string
+	if err := tx.QueryRowContext(ctx, `SELECT provider_id FROM llm_facade_token WHERE token_hash = ?`, token.TokenHash).Scan(&previousProviderID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("resolve previous llm facade grant: %w", err)
+	}
+	if grant.Environment != nil {
+		if err := saveLLMFacadeEnvironment(ctx, tx, token, *grant.Environment); err != nil {
+			return err
+		}
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO llm_facade_token(token_hash, sandbox_id, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(token_hash) DO UPDATE SET sandbox_id = excluded.sandbox_id, token_fingerprint = excluded.token_fingerprint, model = excluded.model, provider_id = excluded.provider_id, wire_api = excluded.wire_api, source = excluded.source, run_id = excluded.run_id, issued_at = excluded.issued_at, expires_at = excluded.expires_at, revoked_at = excluded.revoked_at`,
+		token.TokenHash, token.SandboxID, token.TokenFingerprint, token.Model, token.ProviderID, token.WireAPI, token.Source, token.RunID, token.IssuedAt.Unix(), expiresAt, revokedAt)
+	if err != nil {
+		return fmt.Errorf("save llm facade token: %w", err)
+	}
+	if previousProviderID != "" && previousProviderID != token.ProviderID {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM llm_provider WHERE id = ? AND scope = ?`, previousProviderID, llms.ProviderScopeFacadeEnv); err != nil {
+			return fmt.Errorf("delete replaced llm facade environment: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit llm facade grant: %w", err)
+	}
+	return nil
+}
+
+func saveLLMFacadeEnvironment(ctx context.Context, tx *sql.Tx, token llms.FacadeToken, environment llms.FacadeEnvironment) error {
+	protocol := strings.TrimSpace(environment.Protocol)
+	if protocol != "" {
+		protocol = llms.NormalizeWireAPI(protocol)
+	}
+	now := token.IssuedAt.Unix()
+	result, err := tx.ExecContext(ctx, `INSERT INTO llm_provider(id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, use_generic_responses_text_parts, weight, enabled, scope, created_at, updated_at)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, '{}', 0, 10, 0, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET name = excluded.name, provider_type = excluded.provider_type, default_wire_api = excluded.default_wire_api, base_url = excluded.base_url, api_key = excluded.api_key, auth_header = excluded.auth_header, auth_scheme = excluded.auth_scheme, headers_json = excluded.headers_json, use_generic_responses_text_parts = excluded.use_generic_responses_text_parts, weight = excluded.weight, enabled = excluded.enabled, updated_at = excluded.updated_at
+		WHERE llm_provider.scope = excluded.scope`,
+		environment.ProviderID,
+		"facade-env:"+token.TokenFingerprint,
+		llms.NormalizeProviderType(environment.ProviderType),
+		protocol,
+		strings.TrimSpace(environment.Endpoint),
+		strings.TrimSpace(environment.APIKey),
+		strings.TrimSpace(environment.AuthHeader),
+		strings.TrimSpace(environment.AuthScheme),
+		llms.ProviderScopeFacadeEnv,
+		now,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("save llm facade environment: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count saved llm facade environment: %w", err)
+	}
+	if updated != 1 {
+		return fmt.Errorf("save llm facade environment: provider id is already owned")
+	}
+	return nil
+}
+
+// GetLLMFacadeEnvironment loads only token-owned Provider Env rows. These rows
+// are disabled and never participate in configured provider selection.
+func (s *llmStore) GetLLMFacadeEnvironment(ctx context.Context, providerID string) (llms.FacadeEnvironment, bool, error) {
+	providerID = strings.TrimSpace(providerID)
+	if providerID == "" {
+		return llms.FacadeEnvironment{}, false, nil
+	}
+	var environment llms.FacadeEnvironment
+	err := s.db.QueryRowContext(ctx, `SELECT id, provider_type, base_url, default_wire_api, api_key, auth_header, auth_scheme
+		FROM llm_provider WHERE id = ? AND scope = ?`, providerID, llms.ProviderScopeFacadeEnv).Scan(
+		&environment.ProviderID,
+		&environment.ProviderType,
+		&environment.Endpoint,
+		&environment.Protocol,
+		&environment.APIKey,
+		&environment.AuthHeader,
+		&environment.AuthScheme,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return llms.FacadeEnvironment{}, false, nil
+	}
+	if err != nil {
+		return llms.FacadeEnvironment{}, false, fmt.Errorf("get llm facade environment: %w", err)
+	}
+	environment.ProviderType = llms.NormalizeProviderType(environment.ProviderType)
+	if strings.TrimSpace(environment.Protocol) != "" {
+		environment.Protocol = llms.NormalizeWireAPI(environment.Protocol)
+	}
+	return environment, true, nil
+}
+
+// DeleteLLMFacadeToken removes a single facade token by its raw value. It is used
+// to retire a per-run agent token as soon as that run completes, so live tokens
+// never accumulate over the lifetime of a long-running session.
+func (s *llmStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) error {
+	if strings.TrimSpace(rawToken) == "" {
+		return nil
+	}
+	hash, _ := llms.HashFacadeToken(rawToken)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin delete llm facade token tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var providerID string
+	err = tx.QueryRowContext(ctx, `SELECT provider_id FROM llm_facade_token WHERE token_hash = ?`, hash).Scan(&providerID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("resolve llm facade token provider: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE token_hash = ?`, hash); err != nil {
+		return fmt.Errorf("delete llm facade token: %w", err)
+	}
+	if providerID != "" {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM llm_provider WHERE id = ? AND scope = ?`, providerID, llms.ProviderScopeFacadeEnv); err != nil {
+			return fmt.Errorf("delete llm facade environment: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit delete llm facade token: %w", err)
+	}
+	return nil
+}
+
+func (s *llmStore) GetLLMFacadeToken(ctx context.Context, rawToken string) (llms.FacadeToken, error) {
+	hash, fingerprint := llms.HashFacadeToken(rawToken)
+	row := s.db.QueryRowContext(ctx, `SELECT sandbox_id, token_hash, token_fingerprint, model, provider_id, wire_api, source, run_id, issued_at, expires_at, revoked_at FROM llm_facade_token WHERE token_hash = ?`, hash)
+	token, err := llms.ScanFacadeToken(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return llms.FacadeToken{}, domain.ResourceError(domain.ErrNotFound, "llm facade token", fingerprint, fmt.Sprintf("llm facade token %s not found", fingerprint), err)
+		}
+		return llms.FacadeToken{}, err
+	}
+	return token, nil
+}
+
+// llmFacadeTokenRetention is how long a revoked facade token row is kept before
+// it is physically pruned. The grace window keeps recently-revoked tokens around
+// for debugging while bounding table growth from completed sessions.
+const llmFacadeTokenRetention = time.Hour
+
+const LLMFacadeTokenRetention = llmFacadeTokenRetention
+
+func (s *llmStore) RevokeLLMFacadeTokensForSandbox(ctx context.Context, sandboxID string) error {
+	now := time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin revoke llm facade tokens tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	sandboxID = strings.TrimSpace(sandboxID)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM llm_provider
+		WHERE scope = ? AND id IN (SELECT provider_id FROM llm_facade_token WHERE sandbox_id = ?)`, llms.ProviderScopeFacadeEnv, sandboxID); err != nil {
+		return fmt.Errorf("delete revoked llm facade environments: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_facade_token SET revoked_at = ? WHERE sandbox_id = ? AND revoked_at = 0`, now.Unix(), sandboxID); err != nil {
+		return fmt.Errorf("revoke llm facade tokens for sandbox: %w", err)
+	}
+	// Opportunistically prune long-dead rows (revoked beyond the retention grace,
+	// or expired) so the table stays bounded across sessions. Both states already
+	// fail closed at the handler, so deleting them changes nothing observable.
+	cutoff := now.Add(-llmFacadeTokenRetention).Unix()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM llm_provider
+		WHERE scope = ? AND id IN (
+			SELECT provider_id FROM llm_facade_token
+			WHERE (revoked_at != 0 AND revoked_at < ?) OR (expires_at != 0 AND expires_at < ?)
+		)`, llms.ProviderScopeFacadeEnv, cutoff, now.Unix()); err != nil {
+		return fmt.Errorf("prune llm facade environments: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE (revoked_at != 0 AND revoked_at < ?) OR (expires_at != 0 AND expires_at < ?)`, cutoff, now.Unix()); err != nil {
+		return fmt.Errorf("prune llm facade tokens: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit revoke llm facade tokens: %w", err)
+	}
+	return nil
+}

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -901,7 +901,11 @@ func testConfigStoreLLMBootstrapResolveCoverage(t *testing.T, ctx context.Contex
 		t.Fatalf("initSchema for LLM bootstrap returned error: %v", err)
 	}
 	config := &appconfig.Config{LLMAPIEndpoint: "https://config.example/v1", LLMAPIProtocol: "chat_completions", LLMAPIKey: "config-key", LLMModel: "config-model"}
-	if lookup := llms.DefaultLLMEnvProviderLookup(ctx, config, store); lookup("LLM_API_ENDPOINT") != "https://config.example/v1" {
+	lookup, err := llms.DefaultLLMEnvProviderLookup(ctx, config, store)
+	if err != nil {
+		t.Fatalf("DefaultLLMEnvProviderLookup returned error: %v", err)
+	}
+	if lookup("LLM_API_ENDPOINT") != "https://config.example/v1" {
 		t.Fatalf("config LLM lookup failed")
 	}
 	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{
@@ -927,15 +931,18 @@ func testConfigStoreLLMBootstrapResolveCoverage(t *testing.T, ctx context.Contex
 	if err != nil {
 		t.Fatalf("ResolveRuntimeLLMTargetWithEnv OpenAI returned error: %v", err)
 	}
-	if runtimeTarget.Provider.ID == target.Provider.ID || runtimeTarget.Provider.Scope != llms.ProviderScopeSessionEnv || runtimeTarget.Model.ID != "session-model" {
+	if runtimeTarget.Provider.ID == target.Provider.ID || runtimeTarget.Provider.Scope != llms.ProviderScopeSessionEnv || runtimeTarget.Model.ID != "session-model" || runtimeTarget.Provider.APIKey != "session-key" || runtimeTarget.WireAPI != llms.APIProtocolChatCompletions {
 		t.Fatalf("session OpenAI target = %#v", runtimeTarget)
 	}
 	if llms.HasEnabledLLMProviderID(ctx, store, runtimeTarget.Provider.ID) != true {
 		t.Fatalf("expected session provider to be enabled")
 	}
-	reusedRuntimeTarget, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, "sandbox-1", llms.ProviderFamilyOpenAI, "session-model", "", nil)
-	if err != nil || reusedRuntimeTarget.Provider.ID != runtimeTarget.Provider.ID {
-		t.Fatalf("reused session OpenAI target=%#v err=%v", reusedRuntimeTarget, err)
+	inheritedRuntimeTarget, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, "sandbox-1", llms.ProviderFamilyOpenAI, "global-model", "", nil)
+	if err != nil {
+		t.Fatalf("inherited session OpenAI target error: %v", err)
+	}
+	if inheritedRuntimeTarget.Provider.ID != llms.ProviderIDDefaultOpenAI || inheritedRuntimeTarget.Provider.BaseURL != "https://global.example/v1" || inheritedRuntimeTarget.Provider.APIKey != "global-key" {
+		t.Fatalf("inherited session OpenAI target=%#v", inheritedRuntimeTarget)
 	}
 	if _, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, "missing-model", "missing-provider"); err == nil {
 		t.Fatalf("expected missing runtime LLM target error")

--- a/pkg/storage/sessionstore/provider_env_persistence_test.go
+++ b/pkg/storage/sessionstore/provider_env_persistence_test.go
@@ -1,0 +1,46 @@
+package sessionstore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestSandboxProviderEnvPersistsWithoutExecutionOverlay(t *testing.T) {
+	store := newCoverageStore(t)
+	sandbox, err := store.CreateSandbox(context.Background(), "provider env", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	llms.SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+		{Name: "LLM_API_KEY", Value: "sandbox-key", Secret: true},
+	})
+	sandbox.ExecutionProviderEnvItems = []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "execution-key", Secret: true}}
+	if err := store.UpdateSandbox(context.Background(), sandbox); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+
+	loaded, err := store.GetSandbox(context.Background(), sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if llms.EnvItemValue(loaded.ProviderEnvItems, "LLM_API_KEY") != "sandbox-key" {
+		t.Fatalf("persisted Provider Env = %#v", loaded.ProviderEnvItems)
+	}
+	if len(loaded.ExecutionProviderEnvItems) != 0 {
+		t.Fatalf("execution Provider Env was persisted: %#v", loaded.ExecutionProviderEnvItems)
+	}
+	info, err := os.Stat(filepath.Join(store.SandboxDir(sandbox.Summary.ID), "metadata.json"))
+	if err != nil {
+		t.Fatalf("stat metadata: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("metadata mode = %o, want 600", got)
+	}
+}

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -595,7 +595,7 @@ func (s *Store) saveSandbox(session *Sandbox) error {
 	if err := writeFileAtomically(
 		filepath.Join(s.sandboxDir(session.Summary.ID), "metadata.json"),
 		append(data, '\n'),
-		0o644,
+		0o600,
 	); err != nil {
 		return fmt.Errorf("write session metadata: %w", err)
 	}

--- a/pkg/workspaces/provisioner_concurrency_test.go
+++ b/pkg/workspaces/provisioner_concurrency_test.go
@@ -37,7 +37,7 @@ func TestProvisionerConcurrentEnsureSameSandboxSingleMaterialization(t *testing.
 			t.Fatalf("load caller %d: %v", index, err)
 		}
 		caller.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "RUNTIME_CALLER", Value: fmt.Sprintf("%d", index)}}
-		caller.ProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_CALLER", Value: fmt.Sprintf("%d", index)}}
+		caller.ExecutionProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_CALLER", Value: fmt.Sprintf("%d", index)}}
 		callers[index] = caller
 
 		go func(index int, sandbox *domain.Sandbox) {
@@ -358,6 +358,7 @@ func cloneConcurrentProvisionerSandbox(src *domain.Sandbox) *domain.Sandbox {
 	dst.VolumeMounts = append([]domain.SandboxVolumeMount(nil), src.VolumeMounts...)
 	dst.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), src.RuntimeEnvItems...)
 	dst.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), src.ProviderEnvItems...)
+	dst.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), src.ExecutionProviderEnvItems...)
 	return &dst
 }
 
@@ -379,8 +380,8 @@ func assertConcurrentProvisionerCallerReady(t *testing.T, sandbox *domain.Sandbo
 	if len(sandbox.RuntimeEnvItems) != 1 || sandbox.RuntimeEnvItems[0].Name != "RUNTIME_CALLER" || sandbox.RuntimeEnvItems[0].Value != wantValue {
 		t.Errorf("caller %d runtime env = %#v, want its transient value", callerIndex, sandbox.RuntimeEnvItems)
 	}
-	if len(sandbox.ProviderEnvItems) != 1 || sandbox.ProviderEnvItems[0].Name != "PROVIDER_CALLER" || sandbox.ProviderEnvItems[0].Value != wantValue {
-		t.Errorf("caller %d provider env = %#v, want its transient value", callerIndex, sandbox.ProviderEnvItems)
+	if len(sandbox.ExecutionProviderEnvItems) != 1 || sandbox.ExecutionProviderEnvItems[0].Name != "PROVIDER_CALLER" || sandbox.ExecutionProviderEnvItems[0].Value != wantValue {
+		t.Errorf("caller %d provider env = %#v, want its transient value", callerIndex, sandbox.ExecutionProviderEnvItems)
 	}
 }
 

--- a/pkg/workspaces/provisioner_failure_test.go
+++ b/pkg/workspaces/provisioner_failure_test.go
@@ -309,7 +309,7 @@ func (s *provisionerFailureStore) UpdateSandbox(_ context.Context, sandbox *doma
 	}
 	s.sandboxValue = cloneProvisionerFailureSandbox(sandbox)
 	s.sandboxValue.RuntimeEnvItems = nil
-	s.sandboxValue.ProviderEnvItems = nil
+	s.sandboxValue.ExecutionProviderEnvItems = nil
 	return nil
 }
 
@@ -450,6 +450,7 @@ func cloneProvisionerFailureSandbox(sandbox *domain.Sandbox) *domain.Sandbox {
 	clone.VolumeMounts = append([]domain.SandboxVolumeMount(nil), sandbox.VolumeMounts...)
 	clone.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.RuntimeEnvItems...)
 	clone.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ProviderEnvItems...)
+	clone.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ExecutionProviderEnvItems...)
 	return &clone
 }
 

--- a/pkg/workspaces/provisioner_file_state_test.go
+++ b/pkg/workspaces/provisioner_file_state_test.go
@@ -380,5 +380,6 @@ func cloneProvisionerFileStateSandbox(sandbox *domain.Sandbox) *domain.Sandbox {
 	clone.VolumeMounts = append([]domain.SandboxVolumeMount(nil), sandbox.VolumeMounts...)
 	clone.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.RuntimeEnvItems...)
 	clone.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ProviderEnvItems...)
+	clone.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ExecutionProviderEnvItems...)
 	return &clone
 }

--- a/pkg/workspaces/provisioner_git_state_test.go
+++ b/pkg/workspaces/provisioner_git_state_test.go
@@ -314,6 +314,7 @@ func cloneProvisionerGitStateSandbox(sandbox *domain.Sandbox) *domain.Sandbox {
 	clone.VolumeMounts = append([]domain.SandboxVolumeMount(nil), sandbox.VolumeMounts...)
 	clone.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.RuntimeEnvItems...)
 	clone.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ProviderEnvItems...)
+	clone.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ExecutionProviderEnvItems...)
 	return &clone
 }
 

--- a/pkg/workspaces/provisioner_staging.go
+++ b/pkg/workspaces/provisioner_staging.go
@@ -248,5 +248,6 @@ func cloneSandboxForProvisioning(sandbox *domain.Sandbox) *domain.Sandbox {
 	clone.VolumeMounts = append([]domain.SandboxVolumeMount(nil), sandbox.VolumeMounts...)
 	clone.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.RuntimeEnvItems...)
 	clone.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ProviderEnvItems...)
+	clone.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ExecutionProviderEnvItems...)
 	return &clone
 }

--- a/pkg/workspaces/provisioner_staging_test.go
+++ b/pkg/workspaces/provisioner_staging_test.go
@@ -465,6 +465,7 @@ func cloneProvisionerStagingSandbox(sandbox *domain.Sandbox) *domain.Sandbox {
 	clone.VolumeMounts = append([]domain.SandboxVolumeMount(nil), sandbox.VolumeMounts...)
 	clone.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.RuntimeEnvItems...)
 	clone.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ProviderEnvItems...)
+	clone.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ExecutionProviderEnvItems...)
 	return &clone
 }
 

--- a/pkg/workspaces/provisioner_state_test.go
+++ b/pkg/workspaces/provisioner_state_test.go
@@ -132,7 +132,7 @@ func TestProvisionerReadyReloadsMetadataWithoutSideEffects(t *testing.T) {
 	caller.Summary.Title = "stale caller title"
 	caller.Summary.WorkspacePath = ""
 	caller.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "RUNTIME_ONLY", Value: "runtime"}}
-	caller.ProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_ONLY", Value: "provider", Secret: true}}
+	caller.ExecutionProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_ONLY", Value: "provider", Secret: true}}
 	if err := provisioner.Ensure(context.Background(), caller); err != nil {
 		t.Fatalf("Ensure returned error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestProvisionerPendingAndFailedMaterializeToReady(t *testing.T) {
 
 			caller := cloneProvisionerStateSandbox(stored)
 			caller.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "RUNTIME_ONLY", Value: "runtime"}}
-			caller.ProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_ONLY", Value: "provider", Secret: true}}
+			caller.ExecutionProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_ONLY", Value: "provider", Secret: true}}
 			if err := provisioner.Ensure(context.Background(), caller); err != nil {
 				t.Fatalf("Ensure returned error: %v", err)
 			}
@@ -286,7 +286,7 @@ func TestProvisionerMaterializerErrorStillReloadsCaller(t *testing.T) {
 	caller := cloneProvisionerStateSandbox(stored)
 	caller.Summary.Title = "stale caller"
 	caller.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "RUNTIME_ONLY", Value: "runtime"}}
-	caller.ProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_ONLY", Value: "provider", Secret: true}}
+	caller.ExecutionProviderEnvItems = []domain.SandboxEnvVar{{Name: "PROVIDER_ONLY", Value: "provider", Secret: true}}
 	err := provisioner.Ensure(context.Background(), caller)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Ensure error = %v, want %v", err, wantErr)
@@ -411,7 +411,7 @@ func (s *provisionerStateStore) UpdateSandbox(_ context.Context, sandbox *domain
 		persisted.Summary.Title = s.persistedTitleOnUpdate
 	}
 	persisted.RuntimeEnvItems = nil
-	persisted.ProviderEnvItems = nil
+	persisted.ExecutionProviderEnvItems = nil
 	s.sandboxes[sandbox.Summary.ID] = persisted
 	return nil
 }
@@ -511,6 +511,7 @@ func cloneProvisionerStateSandbox(sandbox *domain.Sandbox) *domain.Sandbox {
 	clone.VolumeMounts = append([]domain.SandboxVolumeMount(nil), sandbox.VolumeMounts...)
 	clone.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.RuntimeEnvItems...)
 	clone.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ProviderEnvItems...)
+	clone.ExecutionProviderEnvItems = append([]domain.SandboxEnvVar(nil), sandbox.ExecutionProviderEnvItems...)
 	return &clone
 }
 
@@ -545,7 +546,7 @@ func assertProvisionerTransientEnv(t *testing.T, sandbox *domain.Sandbox) {
 	if !reflect.DeepEqual(sandbox.RuntimeEnvItems, wantRuntime) {
 		t.Errorf("RuntimeEnvItems = %#v, want %#v", sandbox.RuntimeEnvItems, wantRuntime)
 	}
-	if !reflect.DeepEqual(sandbox.ProviderEnvItems, wantProvider) {
-		t.Errorf("ProviderEnvItems = %#v, want %#v", sandbox.ProviderEnvItems, wantProvider)
+	if !reflect.DeepEqual(sandbox.ExecutionProviderEnvItems, wantProvider) {
+		t.Errorf("ExecutionProviderEnvItems = %#v, want %#v", sandbox.ExecutionProviderEnvItems, wantProvider)
 	}
 }


### PR DESCRIPTION
## Summary

- resolve Provider Env fields independently across execution, sandbox, Global Env, and daemon layers
- bind env-bootstrap facade targets to token-owned sparse grants so concurrent executions cannot overwrite each other
- keep configured system providers separate from env bootstrap and refresh inherited Global/daemon fields at request time
- align Codex, OpenCode, Anthropic, and prompt-attach ingress protocol behavior
- keep upstream LLM credentials daemon-side while projecting only facade tokens into guest execution
- document the environment precedence and facade contracts in English and Chinese

## Compatibility

- no Compose, protobuf, HTTP/Connect, or database schema changes
- existing environment variable names and aliases remain supported
- legacy sandbox Provider Env metadata is intentionally not migrated; affected sandboxes must be recreated

## Verification

- `task lint`
- `task test`
- `task docs:build`
- focused Go tests for LLM resolution, facade proxying, adapters, runs, sessions, storage, workspaces, and execution
- Docker-only Linux Go build (`CGO_ENABLED=0`) plus protobuf and runtime SDK builds
- `git diff --check`

The full Linux `task build` was not used because it prepares BoxLite and Microsandbox artifacts; this change was verified with the Docker-only build path instead.

Refs #305