### PR TITLE
fix(installer): drop --progress flag and make cancellation reach compose

### DIFF
--- a/cmd/installer/internal/core/command.go
+++ b/cmd/installer/internal/core/command.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -32,12 +31,11 @@ func (r ExecRunner) Run(ctx context.Context, dir, name string, args ...string) e
 	// `docker` runs `compose` as a plugin in a separate process that inherits
 	// this output pipe. CommandContext only signals the direct child, so the
 	// plugin would keep running and holding the pipe open, and Wait would block
-	// on it forever. Giving the child its own process group lets cancellation
-	// reach the whole tree.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }
-	// Backstop for anything that ignores the signal: abandon its output rather
-	// than hang the installer. Go escalates to SIGKILL once this elapses.
+	// on it forever.
+	cancelProcessTree(cmd)
+	// Backstop for anything the cancellation does not reach: abandon its output
+	// rather than hang the installer. Go escalates to SIGKILL once this elapses
+	// and closes the pipes, so Wait always returns.
 	cmd.WaitDelay = commandCancelGrace
 	runErr := cmd.Run()
 	if flusher, ok := r.Output.(interface{ Flush() }); ok {

--- a/cmd/installer/internal/core/command.go
+++ b/cmd/installer/internal/core/command.go
@@ -7,7 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
+	"time"
 )
+
+// commandCancelGrace bounds how long a cancelled command may keep the
+// installer waiting on its output before it is abandoned.
+const commandCancelGrace = 5 * time.Second
 
 type CommandRunner interface {
 	Run(context.Context, string, string, ...string) error
@@ -23,6 +29,16 @@ func (r ExecRunner) Run(ctx context.Context, dir, name string, args ...string) e
 	cmd.Stdout = r.Output
 	cmd.Stderr = r.Output
 	cmd.Env = filteredComposeEnvironment(os.Environ())
+	// `docker` runs `compose` as a plugin in a separate process that inherits
+	// this output pipe. CommandContext only signals the direct child, so the
+	// plugin would keep running and holding the pipe open, and Wait would block
+	// on it forever. Giving the child its own process group lets cancellation
+	// reach the whole tree.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }
+	// Backstop for anything that ignores the signal: abandon its output rather
+	// than hang the installer. Go escalates to SIGKILL once this elapses.
+	cmd.WaitDelay = commandCancelGrace
 	runErr := cmd.Run()
 	if flusher, ok := r.Output.(interface{ Flush() }); ok {
 		flusher.Flush()

--- a/cmd/installer/internal/core/command_cancel_test.go
+++ b/cmd/installer/internal/core/command_cancel_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package core
 
 import (

--- a/cmd/installer/internal/core/command_cancel_test.go
+++ b/cmd/installer/internal/core/command_cancel_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+// `docker` runs the compose plugin as a grandchild that inherits the output
+// pipe. Cancelling must reach it too: killing only the direct child leaves the
+// pipe open and Wait blocks until the grandchild exits on its own.
+func TestExecRunnerCancelStopsGrandchildHoldingOutput(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runner := ExecRunner{Output: io.Discard}
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	started := time.Now()
+	go func() {
+		// The backgrounded sleep inherits stdout and outlives its parent shell.
+		done <- runner.Run(ctx, "", "sh", "-c", "sleep 60 & sleep 60")
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled command reported success")
+		}
+		if elapsed := time.Since(started); elapsed > commandCancelGrace {
+			t.Fatalf("cancellation took %s, want well under %s", elapsed, commandCancelGrace)
+		}
+	case <-time.After(commandCancelGrace + 3*time.Second):
+		t.Fatal("cancelled command never returned; output pipe is still held open")
+	}
+}

--- a/cmd/installer/internal/core/command_other.go
+++ b/cmd/installer/internal/core/command_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package core
+
+import "os/exec"
+
+// cancelProcessTree has no portable equivalent outside unix, so cancellation
+// keeps the default behaviour of signalling only the process that was started.
+// A descendant holding the output pipe therefore delays Wait until WaitDelay
+// elapses instead of being stopped outright. The installer only ships unix
+// binaries; this exists so the package still builds elsewhere.
+func cancelProcessTree(*exec.Cmd) {}

--- a/cmd/installer/internal/core/command_unix.go
+++ b/cmd/installer/internal/core/command_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package core
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// cancelProcessTree makes cancellation reach the descendants that inherited the
+// command's output pipe, not just the process that was started. Running the
+// child in its own process group turns the negated pid into a group signal.
+func cancelProcessTree(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) }
+}

--- a/cmd/installer/internal/core/installer_e2e_test.go
+++ b/cmd/installer/internal/core/installer_e2e_test.go
@@ -42,8 +42,8 @@ func TestE2EInstallerLifecycle(t *testing.T) {
 		"|docker version --format {{.Server.Version}}",
 		"|docker compose version --short",
 		installDir + "|docker compose config --quiet",
-		installDir + "|docker compose --progress plain pull",
-		installDir + "|docker compose --progress plain up -d",
+		installDir + "|docker compose pull",
+		installDir + "|docker compose up -d",
 	}, "\n") {
 		t.Fatalf("install calls:\n%s", strings.Join(runner.calls, "\n"))
 	}

--- a/cmd/installer/internal/core/service.go
+++ b/cmd/installer/internal/core/service.go
@@ -170,12 +170,12 @@ func (s Service) installOrUpgrade(ctx context.Context, operation Operation, opti
 	return result, nil
 }
 
+// compose deliberately passes no --progress flag. Forcing plain output kept the
+// TUI from having to cope with docker's cursor-driven redraws, but the flag
+// only exists on newer Compose plugins: on older ones every install and upgrade
+// failed outright at the pull step with "unknown flag: --progress".
 func (s Service) compose(ctx context.Context, dir string, args ...string) error {
-	command := []string{"compose"}
-	if len(args) > 0 && (args[0] == "pull" || args[0] == "up") {
-		command = append(command, "--progress", "plain")
-	}
-	return s.runner().Run(ctx, dir, "docker", append(command, args...)...)
+	return s.runner().Run(ctx, dir, "docker", append([]string{"compose"}, args...)...)
 }
 
 type installPlan struct {

--- a/cmd/installer/internal/core/service_integration_test.go
+++ b/cmd/installer/internal/core/service_integration_test.go
@@ -134,7 +134,7 @@ func TestIntegrationInstallRollbackRestoresManagedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner := &fakeRunner{failOn: "docker compose --progress plain pull"}
+	runner := &fakeRunner{failOn: "docker compose pull"}
 	options := DefaultOptions()
 	options.InstallDir = installDir
 	options.BundleDir = makeTestBundle(t, "v2")
@@ -163,7 +163,7 @@ func TestIntegrationFailedInitialStartRetainsFilesWhenCleanupFails(t *testing.T)
 	root := t.TempDir()
 	installDir := filepath.Join(root, "install")
 	runner := &fakeRunner{failures: []string{
-		"docker compose --progress plain up -d",
+		"docker compose up -d",
 		"docker compose down --remove-orphans",
 	}}
 	options := DefaultOptions()
@@ -188,7 +188,7 @@ func TestIntegrationFailedInitialStartRetainsFilesWhenCleanupFails(t *testing.T)
 func TestIntegrationFailedInitialStartRollsBackAfterCleanup(t *testing.T) {
 	root := t.TempDir()
 	installDir := filepath.Join(root, "install")
-	runner := &fakeRunner{failOn: "docker compose --progress plain up -d"}
+	runner := &fakeRunner{failOn: "docker compose up -d"}
 	options := DefaultOptions()
 	options.InstallDir = installDir
 	options.BundleDir = makeTestBundle(t, "v1")

--- a/cmd/installer/internal/tui/model.go
+++ b/cmd/installer/internal/tui/model.go
@@ -53,6 +53,7 @@ type model struct {
 	inputs        []textinput.Model
 	focus         int
 	spinner       spinner.Model
+	cancelling    bool
 	events        []string
 	result        core.Result
 	err           error
@@ -134,7 +135,12 @@ func (m *model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" && m.screen == screenRunning {
-			m.appendEvent(m.text("正在取消并回滚...", "Cancelling and rolling back..."))
+			// Repeated presses must not stack identical lines; cancellation is
+			// already under way and the log is the only feedback available.
+			if !m.cancelling {
+				m.cancelling = true
+				m.appendEvent(m.text("正在取消并回滚...", "Cancelling and rolling back..."))
+			}
 			m.cancel()
 			return m, nil
 		}

--- a/cmd/installer/internal/tui/model_test.go
+++ b/cmd/installer/internal/tui/model_test.go
@@ -132,6 +132,14 @@ func TestModelCancelsRunningOperationBeforeExit(t *testing.T) {
 	if !strings.Contains(m.View(), "回滚") {
 		t.Fatalf("cancellation state missing from view:\n%s", m.View())
 	}
+
+	// Cancellation is not instant, so impatient repeats must not stack lines.
+	for range 5 {
+		m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	}
+	if count := strings.Count(m.View(), "正在取消并回滚"); count != 1 {
+		t.Fatalf("cancellation notice rendered %d times:\n%s", count, m.View())
+	}
 }
 
 func TestModelIgnoresKeysWhileOperationIsRunning(t *testing.T) {


### PR DESCRIPTION
Two installer failures that only occur on error paths, so neither was covered by existing tests. Both affect current users and are independent of any feature work.

## 1. `--progress plain` breaks pull on older Compose

`Service.compose` unconditionally appended `--progress plain` to `pull` and `up`. That flag only exists on newer Compose plugins. On older ones every install and upgrade dies at the pull step:

```
run docker compose --progress plain pull: exit status 1
unknown flag: --progress
```

Because pull happens inside the install transaction, this then triggers a full rollback — the user sees `pull deployment images: exit status 1` and an installation that reverted itself. Reproduced on Compose **v2.10.2** (Docker Desktop, Server 20.10.17).

`checkCompose` only verifies `docker compose version --short` succeeds, i.e. that Compose v2 exists at all — it never established a version floor, so the incompatibility slipped past the preflight check and surfaced mid-transaction.

The flag is now dropped rather than version-gated: it existed to keep the TUI from dealing with docker's cursor-driven redraws, which is a display concern better solved in the TUI than by constraining which Compose versions the installer supports.

## 2. Cancellation never reaches the process doing the work

`ExecRunner.Run` relied on `exec.CommandContext`, which signals **only the direct child**. The real process tree is three deep:

```
installer
 └─ docker                 ← the only process CommandContext signals
     └─ com.docker.cli
         └─ docker-compose ← actually performing the pull
```

The grandchildren survive and, critically, **inherit the stdout/stderr pipe**. `cmd.Run()` must wait for its output-copying goroutine, which only ends at EOF — and EOF never arrives while a descendant holds the write end. So Ctrl+C in the TUI printed "正在取消并回滚..." and then hung indefinitely.

Fix: run the child in its own process group and signal the whole group on cancel, plus a `WaitDelay` backstop so a process that ignores the signal costs a bounded wait instead of a hang.

Repeated Ctrl+C also appended a duplicate notice per press; it is now recorded once.

## Tests

`TestExecRunnerCancelStopsGrandchildHoldingOutput` reproduces the hang with a shell that backgrounds a child inheriting stdout. Verified to fail before the fix (hit the 8s timeout) and pass after (**0.2s**).

The Compose change is covered by the existing exact-command assertions in `TestE2EInstallerLifecycle`, updated to expect no `--progress`.

Full suite passes, `go vet` clean, `gofmt` clean.

> Note for reviewers on macOS: `internal/core` integration tests fail under the default `TMPDIR` because `/var` is a symlink and `validateInstallPath` rejects symlinked components. This is pre-existing and reproduces on an unmodified tree. Run with `TMPDIR` set to a non-symlinked path; Linux CI is unaffected.