### PR TITLE
fix(runs): 完善 Claude 交互式 Prompt Attach 支持

### DIFF
--- a/cmd/agent-compose/cli_resource_reference.go
+++ b/cmd/agent-compose/cli_resource_reference.go
@@ -67,12 +67,12 @@ func validateInteractivePromptProvider(project *compose.NormalizedProjectSpec, a
 		}
 	}
 	switch provider {
-	case "codex":
+	case "codex", "claude":
 		return nil
 	default:
 		return commandExitError{
 			Code: exitCodeUnsupported,
-			Err:  fmt.Errorf("run --prompt -it is unsupported for provider %s; supported providers: codex", provider),
+			Err:  fmt.Errorf("run --prompt -it is unsupported for provider %s; supported providers: codex, claude", provider),
 		}
 	}
 }

--- a/cmd/agent-compose/cli_run_stream_test.go
+++ b/cmd/agent-compose/cli_run_stream_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCLIRunInteractivePromptProviderUnsupported(t *testing.T) {
-	for _, provider := range []string{"claude", "gemini", "opencode"} {
+	for _, provider := range []string{"gemini", "opencode"} {
 		t.Run(provider, func(t *testing.T) {
 			composePath := writeComposeFile(t, t.TempDir(), fmt.Sprintf(`
 name: cli-run-interactive-%s
@@ -23,7 +23,7 @@ agents:
 			if exitCode != exitCodeUnsupported {
 				t.Fatalf("run --prompt -it %s exit code = %d, want %d; stderr=%q", provider, exitCode, exitCodeUnsupported, stderr)
 			}
-			if stdout != "" || !strings.Contains(stderr, "run --prompt -it is unsupported for provider "+provider) || !strings.Contains(stderr, "supported providers: codex") {
+			if stdout != "" || !strings.Contains(stderr, "run --prompt -it is unsupported for provider "+provider) || !strings.Contains(stderr, "supported providers: codex, claude") {
 				t.Fatalf("run --prompt -it %s stdout/stderr = %q / %q", provider, stdout, stderr)
 			}
 		})

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -616,8 +616,8 @@ func testComposeRunExecAndLogsEdgeHelpers(t *testing.T) {
 	if err := validateInteractivePromptProvider(project, "reviewer", false); err != nil {
 		t.Fatalf("validateInteractivePromptProvider claude-code legacy returned error: %v", err)
 	}
-	if err := validateInteractivePromptProvider(project, "reviewer", true); commandExitCode(err) != exitCodeUnsupported {
-		t.Fatalf("validateInteractivePromptProvider claude-code attach err=%v code=%d", err, commandExitCode(err))
+	if err := validateInteractivePromptProvider(project, "reviewer", true); err != nil {
+		t.Fatalf("validateInteractivePromptProvider claude-code attach returned error: %v", err)
 	}
 	project.Agents[0].Provider = "codex"
 	if err := validateInteractivePromptProvider(project, "reviewer", true); err != nil {

--- a/pkg/runs/prompt_attach_facade.go
+++ b/pkg/runs/prompt_attach_facade.go
@@ -17,7 +17,7 @@ func ensurePromptAttachClaudeLLMFacadeEnv(ctx context.Context, config *appconfig
 		return nil, nil
 	}
 	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, llms.ProviderFamilyAnthropic, model, "", promptAttachSandboxProviderEnvItems(sandbox))
-	tokenModel := ""
+	tokenModel := strings.TrimSpace(model)
 	tokenProvider := ""
 	if err != nil {
 		optional := errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition)

--- a/pkg/runs/prompt_attach_facade_test.go
+++ b/pkg/runs/prompt_attach_facade_test.go
@@ -86,3 +86,29 @@ func TestEnsurePromptAttachLLMFacadeEnvClaudeUsesControllerStore(t *testing.T) {
 		t.Fatalf("stored token = %#v", token)
 	}
 }
+
+func TestEnsurePromptAttachClaudeLLMFacadeEnvPreservesRequestedModelWithoutConfiguredProvider(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("LLM_API_KEY", "")
+
+	store := &promptAttachFacadeStore{}
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-claude-attach"}}
+	env, err := ensurePromptAttachClaudeLLMFacadeEnv(
+		context.Background(),
+		&appconfig.Config{RuntimeBaseURL: "http://agent-compose.test:7410"},
+		store,
+		sandbox,
+		" claude-sonnet-4-20250514 ",
+		"run-claude-attach",
+	)
+	if err != nil {
+		t.Fatalf("ensurePromptAttachClaudeLLMFacadeEnv returned error: %v", err)
+	}
+	if env["ANTHROPIC_MODEL"] != "claude-sonnet-4-20250514" || env["CLAUDE_MODEL"] != "claude-sonnet-4-20250514" {
+		t.Fatalf("Claude model env = %#v", env)
+	}
+	if len(store.tokens) != 1 || store.tokens[0].Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("saved tokens = %#v", store.tokens)
+	}
+}


### PR DESCRIPTION
## 变更说明

- 允许 `claude` 和兼容名称 `claude-code` 使用交互式 Prompt Attach 模式。
- 使用环境变量认证且未配置 Anthropic Provider 时，保留用户指定的 Claude 模型。
- 补充 CLI Provider 校验及模型传递的回归测试。

这是 #345 的后续修复，替代 rebase 后关闭的 #348。

## 测试

- `go test ./cmd/agent-compose ./pkg/runs`

## 检查项

- [x] 已为变更行为补充或更新测试。
- [x] 本次变更无需更新文档。
- [x] 未包含密钥或本地运行数据。