### PR TITLE
fix(llms): preserve long-lived facade streams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,8 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 # LLM_API_KEY=
 # OPENAI_API_KEY=
 # LLM_MODEL=
+# Bounds direct LLM calls and the facade's wait for upstream response headers.
+# Established streaming responses do not have a total duration limit.
 # LLM_TIMEOUT=60s
 # Codex retries 5xx and transport failures separately from reconnecting a
 # dropped stream. Set either retry limit to 0 to disable that retry layer.

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
@@ -522,7 +521,7 @@ func registerRuntimeLLMFacadeRoutes(app *echo.Echo, di do.Injector) {
 		ResolveTarget: func(ctx context.Context, requestedModel, providerID string) (llms.ResolvedTarget, error) {
 			return llms.ResolveRuntimeLLMTarget(ctx, config, configDB, requestedModel, providerID)
 		},
-		Client: &http.Client{Timeout: config.LLMTimeout},
+		Client: proxy.NewRuntimeLLMHTTPClient(config.LLMTimeout),
 	})
 }
 

--- a/pkg/agentcompose/proxy/runtime_llm_client.go
+++ b/pkg/agentcompose/proxy/runtime_llm_client.go
@@ -1,0 +1,14 @@
+package proxy
+
+import (
+	"net/http"
+	"time"
+)
+
+// NewRuntimeLLMHTTPClient creates an upstream client that bounds the wait for
+// response headers without imposing a total deadline on streaming responses.
+func NewRuntimeLLMHTTPClient(responseHeaderTimeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	return &http.Client{Transport: transport}
+}

--- a/pkg/agentcompose/proxy/runtime_llm_client_test.go
+++ b/pkg/agentcompose/proxy/runtime_llm_client_test.go
@@ -1,0 +1,23 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewRuntimeLLMHTTPClientDoesNotLimitStreamingResponseDuration(t *testing.T) {
+	timeout := 45 * time.Second
+	client := NewRuntimeLLMHTTPClient(timeout)
+
+	if client.Timeout != 0 {
+		t.Fatalf("client timeout = %s, want no total request timeout", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("client transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != timeout {
+		t.Fatalf("response header timeout = %s, want %s", transport.ResponseHeaderTimeout, timeout)
+	}
+}


### PR DESCRIPTION
## Summary

- stop applying `LLM_TIMEOUT` as a total deadline to runtime LLM facade streaming responses
- retain the configured timeout as the upstream response-header wait limit
- document the streaming timeout behavior and add a regression test for the HTTP client configuration

## Testing

- `GOTOOLCHAIN=go1.26.2 go test ./pkg/agentcompose/proxy ./pkg/agentcompose/app` (passed)
- `task lint` (not completed: installed golangci-lint v1.49.0 does not support the repository's `fmt --diff` invocation)
- `task build` (not completed: Linux full-driver link fails on existing BoxLite `aio_*`, `timer_*`, and `mq_*` unresolved symbols)
- `task test` (changed packages passed; full gate fails because installed Git 2.25.1 does not support `git init -b` used by existing compose/workspace tests)

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
