### PR TITLE
fix(execution): preserve UTF-8 in failure summaries

### DIFF
--- a/pkg/execution/parse.go
+++ b/pkg/execution/parse.go
@@ -81,8 +81,9 @@ func SummarizeAgentExecFailure(result domain.ExecResult) string {
 		return ""
 	}
 	detail = strings.Join(strings.Fields(detail), " ")
-	if len(detail) > 240 {
-		detail = detail[:240] + "..."
+	runes := []rune(detail)
+	if len(runes) > 240 {
+		detail = string(runes[:240]) + "..."
 	}
 	return detail
 }

--- a/pkg/execution/parse_coverage_test.go
+++ b/pkg/execution/parse_coverage_test.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	domain "agent-compose/pkg/model"
 )
@@ -50,6 +51,19 @@ func TestParseAgentAndCommandExecResultWorkflows(t *testing.T) {
 	}
 	if _, err := ParseCommandExecResult(domain.ExecResult{Stdout: "noise"}); err == nil {
 		t.Fatalf("expected missing command payload error")
+	}
+}
+
+func TestSummarizeAgentExecFailurePreservesUTF8(t *testing.T) {
+	detail := SummarizeAgentExecFailure(domain.ExecResult{Stderr: strings.Repeat("界", 241)})
+	if !strings.HasSuffix(detail, "...") {
+		t.Fatalf("summary should be truncated: %q", detail)
+	}
+	if !utf8.ValidString(detail) {
+		t.Fatalf("summary is not valid UTF-8: %q", detail)
+	}
+	if got := len([]rune(strings.TrimSuffix(detail, "..."))); got != 240 {
+		t.Fatalf("summary has %d content runes, want 240", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Truncates failure summaries by Unicode code points instead of raw bytes, preventing invalid UTF-8 when a multibyte character crosses the 240-character boundary.

Closes #338

## Testing

- gofmt check passed
- go test ./pkg/execution passed
- Added a regression test that verifies both the rune limit and UTF-8 validity

## Checklist

- [x] Documentation is not required for this internal correctness fix
- [x] Tests added for user-visible failure text
- [x] No secrets, private endpoints, certificates, or runtime state included