### PR TITLE
fix: 延迟创建 pending workspace 正式目录以修复全新 data root 下 Docker sandbox 启动

### DIFF
--- a/docs/design/runtime_mount_manifest_design.md
+++ b/docs/design/runtime_mount_manifest_design.md
@@ -43,6 +43,13 @@ The host sandbox directory created by `Store.CreateSandbox` includes:
   state/events.jsonl
 ```
 
+For a sandbox with pending workspace provisioning, `Store.CreateSandbox` does
+not create `<sandbox>/workspace` yet. The provisioner materializes the source in
+`<sandbox>/state/workspace-provisioning/attempt-*` and atomically renames the
+completed attempt to `<sandbox>/workspace` before marking provisioning ready.
+Sandboxes without a workspace source still receive an empty workspace directory
+at creation time.
+
 Guest/runtime actually uses:
 
 | Host path | Guest path | Purpose |
@@ -109,6 +116,9 @@ Constraints:
 - `type` currently supports only `bind`.
 - `hostPath` and `guestPath` must both be absolute paths.
 - All required host sources are created before the manifest is generated.
+- Runtime start runs the workspace ensurer before manifest generation, so a
+  pending workspace may be absent at sandbox creation but must exist before it
+  becomes a mount source.
 - Runtime consumers validate the manifest against the expected driver to avoid
   accidentally reusing an old manifest.
 

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -324,17 +324,20 @@ func (s *Store) createSandboxWithOptions(title, baseWorkspace, driver, guestImag
 		}
 	}
 
-	for _, dir := range []string{
+	dirs := []string{
 		sandboxDir,
 		filepath.Join(sandboxDir, "context"),
 		filepath.Join(sandboxDir, "home"),
 		filepath.Join(sandboxDir, "runtime"),
-		filepath.Join(sandboxDir, "workspace"),
 		filepath.Join(sandboxDir, "state"),
 		filepath.Join(sandboxDir, "logs"),
 		filepath.Join(sandboxDir, "vm"),
 		filepath.Join(sandboxDir, "proxy"),
-	} {
+	}
+	if workspaceProvisioning == nil {
+		dirs = append(dirs, workspaceDir)
+	}
+	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return nil, fmt.Errorf("create sandbox dir %s: %w", dir, err)
 		}

--- a/pkg/storage/sessionstore/store_workspace_provisioning_create_test.go
+++ b/pkg/storage/sessionstore/store_workspace_provisioning_create_test.go
@@ -3,6 +3,8 @@ package sessionstore
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,8 +59,10 @@ func TestStoreCreateSandboxInitializesWorkspaceProvisioning(t *testing.T) {
 			)
 
 			assertPendingWorkspaceProvisioning(t, "created sandbox", created.WorkspaceProvisioning)
+			assertWorkspacePathState(t, store, created, false)
 			persisted, rawMetadata := readProvisioningTestMetadata(t, store, created.Summary.ID)
 			assertPendingWorkspaceProvisioning(t, "persisted sandbox", persisted.WorkspaceProvisioning)
+			assertWorkspacePathState(t, store, persisted, false)
 			if _, ok := rawMetadata["workspace_provisioning"]; !ok {
 				t.Fatal("metadata.json has no workspace_provisioning field")
 			}
@@ -72,13 +76,36 @@ func TestStoreCreateSandboxWithoutWorkspaceOmitsWorkspaceProvisioning(t *testing
 	if created.WorkspaceProvisioning != nil {
 		t.Fatalf("created sandbox workspace provisioning = %#v, want nil", created.WorkspaceProvisioning)
 	}
+	assertWorkspacePathState(t, store, created, true)
 
 	persisted, rawMetadata := readProvisioningTestMetadata(t, store, created.Summary.ID)
 	if persisted.WorkspaceProvisioning != nil {
 		t.Fatalf("persisted sandbox workspace provisioning = %#v, want nil", persisted.WorkspaceProvisioning)
 	}
+	assertWorkspacePathState(t, store, persisted, true)
 	if _, ok := rawMetadata["workspace_provisioning"]; ok {
 		t.Fatalf("metadata.json contains workspace_provisioning: %s", rawMetadata["workspace_provisioning"])
+	}
+}
+
+func assertWorkspacePathState(t *testing.T, store *Store, sandbox *Sandbox, wantExists bool) {
+	t.Helper()
+	wantPath := filepath.Join(store.SandboxDir(sandbox.Summary.ID), "workspace")
+	if sandbox.Summary.WorkspacePath != wantPath {
+		t.Fatalf("workspace path = %q, want %q", sandbox.Summary.WorkspacePath, wantPath)
+	}
+	info, err := os.Stat(sandbox.Summary.WorkspacePath)
+	if wantExists {
+		if err != nil {
+			t.Fatalf("stat workspace path: %v", err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("workspace path %q is not a directory", sandbox.Summary.WorkspacePath)
+		}
+		return
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("workspace path stat error = %v, want not exist", err)
 	}
 }
 
@@ -159,6 +186,7 @@ func assertPendingWorkspaceProvisioning(
 	t.Helper()
 	if provisioning == nil {
 		t.Fatalf("%s workspace provisioning = nil, want pending", label)
+		return
 	}
 	if provisioning.Version != domain.SandboxWorkspaceProvisioningVersion {
 		t.Errorf(

--- a/pkg/workspaces/provisioner_failure_test.go
+++ b/pkg/workspaces/provisioner_failure_test.go
@@ -59,6 +59,9 @@ func TestProvisionerMaterializerFailurePersistsFailed(t *testing.T) {
 	}
 	assertProvisionerFailureStatus(t, caller, domain.SandboxWorkspaceProvisioningStatusFailed)
 	assertProvisionerFailureStatus(t, store.sandbox(t), domain.SandboxWorkspaceProvisioningStatusFailed)
+	if _, err := os.Stat(caller.Summary.WorkspacePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("formal workspace stat after materializer failure = %v, want not exist", err)
+	}
 	if got, want := store.updateStatuses(), []string{domain.SandboxWorkspaceProvisioningStatusFailed}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("UpdateSandbox statuses = %v, want %v", got, want)
 	}

--- a/pkg/workspaces/provisioner_staging_test.go
+++ b/pkg/workspaces/provisioner_staging_test.go
@@ -106,6 +106,31 @@ func TestProvisionerStagingPromotionReplacesPendingWorkspace(t *testing.T) {
 	}
 }
 
+func TestProvisionerStagingPromotionCreatesWorkspaceAtMissingTarget(t *testing.T) {
+	t.Parallel()
+
+	sandboxRoot := t.TempDir()
+	workspacePath := filepath.Join(sandboxRoot, "workspace")
+	stored := newProvisionerStagingSandbox("missing-workspace-target", workspacePath, domain.SandboxWorkspaceProvisioningStatusPending)
+	store := newProvisionerStagingStore(stored)
+	materializer := &provisionerStagingMaterializer{materialize: func(sandbox *domain.Sandbox) error {
+		return os.WriteFile(filepath.Join(sandbox.Summary.WorkspacePath, "materialized.txt"), []byte("ready\n"), 0o644)
+	}}
+	provisioner := NewProvisionerWithMaterializer(store, materializer)
+	caller := cloneProvisionerStagingSandbox(stored)
+
+	if _, err := os.Stat(workspacePath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("workspace target stat before Ensure = %v, want not exist", err)
+	}
+	if err := provisioner.Ensure(context.Background(), caller); err != nil {
+		t.Fatalf("Ensure returned error: %v", err)
+	}
+
+	assertProvisionerStagingFile(t, filepath.Join(workspacePath, "materialized.txt"), "ready\n")
+	assertProvisionerStagingReady(t, caller)
+	assertProvisionerStagingReady(t, store.sandbox(t, caller.Summary.ID))
+}
+
 func TestProvisionerStagingRejectsStateSymlinkWithoutTouchingTarget(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 关联 Issue

Refs: chaitin/agent-compose#359

本次 PR 先解决 Issue #359 中全新 data root 下 Docker sandbox 启动失败的部分；`RunAttach` 早失败终态补齐（CLI 兜底报 `completed without result`）将另行提交，不在本 PR 范围。

## 摘要

在 macOS Docker Desktop 全新 data root 路径下，创建带 workspace source 的 Docker sandbox 时会因 `/host_mnt/.../workspace` 不存在而启动失败，需手动执行一次父级 `docker run -v <data>:/mnt` 刷新路径可见性才能恢复。

根因：`sessionstore.Store.CreateSandbox` 会先创建正式 `<sandbox>/workspace` 占位目录，`workspaces.Provisioner` 随后在 staging 目录物化 workspace，再删除占位目录并把 staging rename 为正式 workspace。这一“建了又删再 rename”的 inode 替换在全新共享根路径下会让 Docker Linux VM 看到被替换前的目录状态。

修复：pending workspace 不再预建随后立即替换的正式目录。存在 workspace provisioning 时，创建 sandbox 只建立 sandbox、state、staging 等控制目录，不预建正式 `workspace`；物化成功后由 provisioner 一次 rename 到此前不存在的正式路径，消除 mountpoint inode 替换。没有 workspace source 的 sandbox 仍立即创建空 `workspace`，保持原有行为。

staging promotion 保持 attempt 完整物化后原子 rename 的既有边界，legacy 已存在正式 workspace 的 retry 仍兼容。

## 设计文档

- 更新 `docs/design/runtime_mount_manifest_design.md`：
  - 补充 pending workspace provisioning 时 `Store.CreateSandbox` 不创建正式 `<sandbox>/workspace`，由 provisioner 物化 attempt 后原子 rename；
  - 补充约束：runtime start 在生成 mount manifest 前先跑 workspace ensurer，pending workspace 可在创建时不存在但成为 mount source 前必须存在。

## 验证

开发阶段使用项目本地缓存目录（不使用 `GOMODCACHE`/`GOCACHE`）：

- [x] `go test ./pkg/storage/sessionstore/... ./pkg/workspaces/...` — 通过
- [x] `go test -race ./pkg/workspaces/...` — 通过
- [x] `gofmt -l` 受影响文件 — 无输出
- [x] `go vet ./pkg/storage/sessionstore/... ./pkg/workspaces/...` — 无告警
- [ ] `task lint` / `task build` / `task test` — 未在本机全量执行（聚焦包验证已覆盖改动）
- [ ] 真实 Docker 回归 `task test:e2e:docker-workspace-resume` — 既有 E2E（`docker_workspace_resume_host_daemon_test.go`）已覆盖全新 data root 首次启动路径，建议 CI/合并前在 macOS Docker Desktop 环境复核

## 风险

- **pending workspace 路径暂时不存在**：部分未识别调用方若假设 `CreateSandbox` 返回后 `WorkspacePath` 立即存在会受影响。已确认 runtime、guide writer 等均在 `WorkspaceEnsurer.Ensure` 之后访问 workspace；无 workspace source 的路径仍立即创建。
- **staging 原子性**：未改用逐文件复制，保留 attempt 完整物化 + 目录 rename，不引入部分发布。
- **driver 兼容**：所有 driver 均在 workspace provisioning 后生成 mount manifest，ready 后目录布局不变；`prepareRuntimeMountManifest` 的 source 校验仍是最后一道保护。

## 回滚

直接 revert 本 PR 即可，无数据库迁移、配置项或 proto 变更。revert 后恢复“创建即预建正式 workspace 占位目录”的原有行为。

## 破坏性变更分析

- 删除/重命名/默认行为变更：无。pending sandbox 目录布局变化是内部行为，对外路径格式与 metadata shape 不变。
- API/配置/schema/迁移：无变更。
- 手动升级或发布协调：无。

## 既有逻辑影响

- 受影响模块：`pkg/storage/sessionstore`（sandbox 目录初始化）、`pkg/workspaces`（staging promotion 兼容目标路径不存在）、`pkg/driver`（无代码改动，manifest source 校验不变）。
- 兼容性：legacy 已存在正式 workspace 的 pending/failed sandbox retry 仍走原有清理后 promotion 路径。
- 回归风险：低。改动集中在创建期目录布局，provisioning 成功后的 ready 状态与目录内容与原先一致。

## 评审重点

- `pkg/storage/sessionstore/store.go`：`createSandboxWithOptions` 按 `workspaceProvisioning` 是否为 nil 决定是否预建正式 workspace。
- `pkg/workspaces/provisioner_staging_test.go`：新增 `TestProvisionerStagingPromotionCreatesWorkspaceAtMissingTarget` 覆盖目标路径初始不存在的 promotion。
- `pkg/workspaces/provisioner_failure_test.go`：新增物化失败后正式 workspace 不存在的断言。
