### PR TITLE
feat(cli): stream scheduler history and run logs

### DIFF
--- a/cmd/agent-compose/cli_client.go
+++ b/cmd/agent-compose/cli_client.go
@@ -16,14 +16,18 @@ type cliClientConfig struct {
 }
 
 type cliServiceClients struct {
-	project  agentcomposev2connect.ProjectServiceClient
-	run      agentcomposev2connect.RunServiceClient
-	exec     agentcomposev2connect.ExecServiceClient
-	resource agentcomposev2connect.ResourceServiceClient
-	image    agentcomposev2connect.ImageServiceClient
-	cache    agentcomposev2connect.CacheServiceClient
-	volume   agentcomposev2connect.VolumeServiceClient
-	sandbox  agentcomposev2connect.SandboxServiceClient
+	project       agentcomposev2connect.ProjectServiceClient
+	projectStream agentcomposev2connect.ProjectServiceClient
+	run           agentcomposev2connect.RunServiceClient
+	runStream     agentcomposev2connect.RunServiceClient
+	exec          agentcomposev2connect.ExecServiceClient
+	execStream    agentcomposev2connect.ExecServiceClient
+	resource      agentcomposev2connect.ResourceServiceClient
+	image         agentcomposev2connect.ImageServiceClient
+	imageStream   agentcomposev2connect.ImageServiceClient
+	cache         agentcomposev2connect.CacheServiceClient
+	volume        agentcomposev2connect.VolumeServiceClient
+	sandbox       agentcomposev2connect.SandboxServiceClient
 }
 
 func newCLIServiceClients(cli cliOptions) (cliServiceClients, error) {
@@ -32,15 +36,20 @@ func newCLIServiceClients(cli cliOptions) (cliServiceClients, error) {
 		return cliServiceClients{}, err
 	}
 	httpClient := newDaemonHTTPClient(clientConfig)
+	streamingHTTPClient := newDaemonStreamingHTTPClient(clientConfig)
 	return cliServiceClients{
-		project:  agentcomposev2connect.NewProjectServiceClient(httpClient, clientConfig.BaseURL),
-		run:      agentcomposev2connect.NewRunServiceClient(httpClient, clientConfig.BaseURL),
-		exec:     agentcomposev2connect.NewExecServiceClient(httpClient, clientConfig.BaseURL),
-		resource: agentcomposev2connect.NewResourceServiceClient(httpClient, clientConfig.BaseURL),
-		image:    agentcomposev2connect.NewImageServiceClient(httpClient, clientConfig.BaseURL),
-		cache:    agentcomposev2connect.NewCacheServiceClient(httpClient, clientConfig.BaseURL),
-		volume:   agentcomposev2connect.NewVolumeServiceClient(httpClient, clientConfig.BaseURL),
-		sandbox:  agentcomposev2connect.NewSandboxServiceClient(httpClient, clientConfig.BaseURL),
+		project:       agentcomposev2connect.NewProjectServiceClient(httpClient, clientConfig.BaseURL),
+		projectStream: agentcomposev2connect.NewProjectServiceClient(streamingHTTPClient, clientConfig.BaseURL),
+		run:           agentcomposev2connect.NewRunServiceClient(httpClient, clientConfig.BaseURL),
+		runStream:     agentcomposev2connect.NewRunServiceClient(streamingHTTPClient, clientConfig.BaseURL),
+		exec:          agentcomposev2connect.NewExecServiceClient(httpClient, clientConfig.BaseURL),
+		execStream:    agentcomposev2connect.NewExecServiceClient(streamingHTTPClient, clientConfig.BaseURL),
+		resource:      agentcomposev2connect.NewResourceServiceClient(httpClient, clientConfig.BaseURL),
+		image:         agentcomposev2connect.NewImageServiceClient(httpClient, clientConfig.BaseURL),
+		imageStream:   agentcomposev2connect.NewImageServiceClient(streamingHTTPClient, clientConfig.BaseURL),
+		cache:         agentcomposev2connect.NewCacheServiceClient(httpClient, clientConfig.BaseURL),
+		volume:        agentcomposev2connect.NewVolumeServiceClient(httpClient, clientConfig.BaseURL),
+		sandbox:       agentcomposev2connect.NewSandboxServiceClient(httpClient, clientConfig.BaseURL),
 	}, nil
 }
 

--- a/cmd/agent-compose/cli_daemon.go
+++ b/cmd/agent-compose/cli_daemon.go
@@ -486,6 +486,10 @@ func newDaemonAttachHTTPClient(clientConfig cliClientConfig) *http.Client {
 	return newDaemonHTTPClientWithTimeout(clientConfig, 0)
 }
 
+func newDaemonStreamingHTTPClient(clientConfig cliClientConfig) *http.Client {
+	return newDaemonHTTPClientWithTimeout(clientConfig, 0)
+}
+
 func newDaemonHTTPClientWithTimeout(clientConfig cliClientConfig, timeout time.Duration) *http.Client {
 	roundTripper := http.RoundTripper(newDaemonBaseRoundTripper(clientConfig))
 	if !clientConfig.UseUnixSocket && clientConfig.AuthToken != "" {

--- a/cmd/agent-compose/cli_daemon_http_test.go
+++ b/cmd/agent-compose/cli_daemon_http_test.go
@@ -184,7 +184,7 @@ func TestDaemonHTTPClientRunAttachBidiUsesH2C(t *testing.T) {
 	}
 }
 
-func TestDaemonAttachHTTPClientHasNoRequestTimeout(t *testing.T) {
+func TestDaemonStreamingAndAttachHTTPClientsHaveNoRequestTimeout(t *testing.T) {
 	regular := newDaemonHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410"})
 	if regular.Timeout != 10*time.Minute {
 		t.Fatalf("regular daemon client timeout = %v, want 10m", regular.Timeout)
@@ -192,6 +192,10 @@ func TestDaemonAttachHTTPClientHasNoRequestTimeout(t *testing.T) {
 	attach := newDaemonAttachHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410"})
 	if attach.Timeout != 0 {
 		t.Fatalf("attach daemon client timeout = %v, want none", attach.Timeout)
+	}
+	streaming := newDaemonStreamingHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410"})
+	if streaming.Timeout != 0 {
+		t.Fatalf("streaming daemon client timeout = %v, want none", streaming.Timeout)
 	}
 }
 

--- a/cmd/agent-compose/cli_exec_command.go
+++ b/cmd/agent-compose/cli_exec_command.go
@@ -119,7 +119,7 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 		}
 		return runComposeExecPromptOnceCommand(cmd, normalized.Name, connectExecAttachClient{client: attachClient}, req, options, cli.JSON)
 	}
-	stream, err := clients.exec.ExecStream(cmd.Context(), connect.NewRequest(req))
+	stream, err := clients.execStream.ExecStream(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("exec project %s: %w", normalized.Name, err))
 	}

--- a/cmd/agent-compose/cli_image_command.go
+++ b/cmd/agent-compose/cli_image_command.go
@@ -212,7 +212,7 @@ func runComposeProjectBuildCommand(cmd *cobra.Command, cli cliOptions, options c
 	}
 	output := composeProjectImageBuildOutput{Images: make([]composeImageBuildOutput, 0, len(plans))}
 	for _, plan := range plans {
-		item, err := buildImage(cmd.Context(), cmd.OutOrStdout(), cli.JSON, clients.image, plan)
+		item, err := buildImage(cmd.Context(), cmd.OutOrStdout(), cli.JSON, clients.imageStream, plan)
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("build image %s: %w", firstNonEmptyString(plan.GetTags()...), err))
 		}

--- a/cmd/agent-compose/cli_logs.go
+++ b/cmd/agent-compose/cli_logs.go
@@ -54,12 +54,12 @@ func runComposeLogsCommand(cmd *cobra.Command, cli cliOptions, options composeLo
 		return err
 	}
 	if strings.TrimSpace(normalizedOptions.RunID) != "" {
+		if !cli.JSON {
+			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.runStream, projectID, &agentcomposev2.RunSummary{RunId: normalizedOptions.RunID}, normalizedOptions)
+		}
 		run, err := getRunDetail(cmd.Context(), clients.run, projectID, normalizedOptions.RunID)
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", strings.TrimSpace(normalizedOptions.RunID), normalized.Name, err))
-		}
-		if normalizedOptions.Follow {
-			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.run, projectID, run.Msg.GetRun().GetSummary(), normalizedOptions)
 		}
 		return writeLogsForRun(cmd.OutOrStdout(), run.Msg.GetRun(), cli.JSON, normalizedOptions)
 	}
@@ -132,7 +132,7 @@ type composeLogRunOutput struct {
 
 func followOrPrintProjectLogs(cmd *cobra.Command, cli cliOptions, clients cliServiceClients, projectID, projectName string, options composeLogsOptions) error {
 	client := clients.run
-	if options.Follow && !cli.JSON {
+	if !cli.JSON {
 		runs, err := listLogRuns(cmd.Context(), client, projectID, options)
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("list logs for project %s: %w", projectName, err))
@@ -140,8 +140,21 @@ func followOrPrintProjectLogs(cmd *cobra.Command, cli cliOptions, clients cliSer
 		if len(runs) == 0 && options.SandboxID != "" {
 			return writeSandboxHistoryLogs(cmd, cli, clients.sandbox, projectID, options)
 		}
+		for index, summary := range runs {
+			if _, ok := parseComposeLogSortTimestamp(runLogSortTimestamp(summary)); ok {
+				continue
+			}
+			detail, detailErr := getRunDetail(cmd.Context(), client, projectID, summary.GetRunId())
+			if detailErr != nil {
+				return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", summary.GetRunId(), projectName, detailErr))
+			}
+			if detailSummary := detail.Msg.GetRun().GetSummary(); detailSummary != nil {
+				runs[index] = detailSummary
+			}
+		}
+		sort.SliceStable(runs, func(i, j int) bool { return logRunSummaryLess(runs[i], runs[j]) })
 		for _, summary := range runs {
-			if err := followRunLogStream(cmd.Context(), cmd.OutOrStdout(), client, projectID, summary, options); err != nil {
+			if err := followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.runStream, projectID, summary, options); err != nil {
 				return err
 			}
 		}
@@ -239,30 +252,26 @@ func followRunLogStream(ctx context.Context, out io.Writer, client agentcomposev
 	if summary == nil {
 		return nil
 	}
-	detailResp, err := getRunDetail(ctx, client, projectID, summary.GetRunId())
-	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", summary.GetRunId(), projectID, err))
-	}
-	detailRun := detailResp.Msg.GetRun()
 	displaySummary := summary
-	if detailSummary := detailRun.GetSummary(); detailSummary != nil {
-		displaySummary = detailSummary
-	}
-	prompt := runLogPrompt(detailRun)
+	var detailRun *agentcomposev2.RunDetail
+	prompt := ""
+	metadataReceived := false
 	promptPrinted := false
 	refreshPrompt := func() error {
-		if promptPrinted || prompt != "" {
+		if promptPrinted || prompt != "" || metadataReceived {
 			return nil
 		}
-		detailResp, err := getRunDetail(ctx, client, projectID, summary.GetRunId())
-		if err != nil {
-			return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", summary.GetRunId(), projectID, err))
+		for attempts := 0; attempts < 2 && prompt == ""; attempts++ {
+			detailResp, err := getRunDetail(ctx, client, projectID, summary.GetRunId())
+			if err != nil {
+				return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", summary.GetRunId(), projectID, err))
+			}
+			detailRun = detailResp.Msg.GetRun()
+			if detailSummary := detailRun.GetSummary(); detailSummary != nil {
+				displaySummary = detailSummary
+			}
+			prompt = runLogPrompt(detailRun)
 		}
-		detailRun = detailResp.Msg.GetRun()
-		if detailSummary := detailRun.GetSummary(); detailSummary != nil {
-			displaySummary = detailSummary
-		}
-		prompt = runLogPrompt(detailRun)
 		return nil
 	}
 	printPrompt := func() error {
@@ -283,18 +292,39 @@ func followRunLogStream(ctx context.Context, out io.Writer, client agentcomposev
 		tailLines = uint32(options.TailLines)
 	}
 	stream, err := client.FollowRunLogs(ctx, connect.NewRequest(&agentcomposev2.FollowRunLogsRequest{
-		ProjectId: strings.TrimSpace(projectID),
-		RunId:     summary.GetRunId(),
-		TailLines: tailLines,
-		Follow:    true,
+		ProjectId:       strings.TrimSpace(projectID),
+		RunId:           summary.GetRunId(),
+		TailLines:       tailLines,
+		Follow:          options.Follow,
+		IncludeMetadata: true,
+		TailSet:         options.TailLines >= 0,
 	}))
 	if err != nil {
+		if !options.Follow && connect.CodeOf(err) == connect.CodeUnimplemented {
+			return writeLegacyRunLogs(ctx, out, client, projectID, summary.GetRunId(), options)
+		}
 		return commandExitErrorForConnect(fmt.Errorf("follow run %s logs: %w", summary.GetRunId(), err))
 	}
 	assistantStarted := false
+	received := false
+	dataWriter := newPrefixedRunOutputStreamWriter(out, options.Timestamp)
+	suppressData := options.TailLines == 0 && !options.Follow
 	for stream.Receive() {
+		received = true
 		chunk := stream.Msg()
-		if chunk.GetData() != "" {
+		if chunk.GetRun() != nil {
+			displaySummary = chunk.GetRun()
+			metadataReceived = true
+		}
+		if chunk.GetPrompt() != "" {
+			prompt = chunk.GetPrompt()
+		}
+		if metadataReceived {
+			if err := printPrompt(); err != nil {
+				return err
+			}
+		}
+		if chunk.GetData() != "" && !suppressData {
 			if !assistantStarted && !promptPrinted && prompt == "" {
 				if err := refreshPrompt(); err != nil {
 					return err
@@ -309,7 +339,7 @@ func followRunLogStream(ctx context.Context, out io.Writer, client agentcomposev
 				}
 				assistantStarted = true
 			}
-			if err := writePrefixedRunOutput(out, displaySummary, chunk.GetData(), options.Timestamp); err != nil {
+			if err := dataWriter.Write(displaySummary, chunk.GetData(), runLogTimestamp(displaySummary)); err != nil {
 				return err
 			}
 		}
@@ -322,13 +352,27 @@ func followRunLogStream(ctx context.Context, out io.Writer, client agentcomposev
 					return err
 				}
 			}
-			return nil
+			return dataWriter.Finish()
 		}
 	}
-	if err := stream.Err(); err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("follow run %s logs: %w", summary.GetRunId(), err))
+	if err := dataWriter.Finish(); err != nil {
+		return err
 	}
-	return nil
+	if err := stream.Err(); err != nil {
+		if !received && !options.Follow && connect.CodeOf(err) == connect.CodeUnimplemented {
+			return writeLegacyRunLogs(ctx, out, client, projectID, summary.GetRunId(), options)
+		}
+		return commandExitErrorForConnect(fmt.Errorf("stream run %s logs: %w", summary.GetRunId(), err))
+	}
+	return fmt.Errorf("stream run %s logs: daemon closed the stream before completion", summary.GetRunId())
+}
+
+func writeLegacyRunLogs(ctx context.Context, out io.Writer, client agentcomposev2connect.RunServiceClient, projectID, runID string, options composeLogsOptions) error {
+	run, err := getRunDetail(ctx, client, projectID, runID)
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("get run %s for project %s: %w", runID, projectID, err))
+	}
+	return writeLogsForRun(out, run.Msg.GetRun(), false, options)
 }
 
 func writeLogsForRun(out io.Writer, run *agentcomposev2.RunDetail, asJSON bool, options composeLogsOptions) error {

--- a/cmd/agent-compose/cli_logs_locator.go
+++ b/cmd/agent-compose/cli_logs_locator.go
@@ -44,12 +44,12 @@ func runComposeLogsForResourceID(cmd *cobra.Command, cli cliOptions, options com
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("resource id cannot be used with logs")}
 	}
 	if options.RunID != "" {
+		if !cli.JSON {
+			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.runStream, projectID, &agentcomposev2.RunSummary{RunId: options.RunID}, options)
+		}
 		run, err := getRunDetail(cmd.Context(), clients.run, projectID, options.RunID)
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("get run %s: %w", options.RunID, err))
-		}
-		if options.Follow {
-			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.run, projectID, run.Msg.GetRun().GetSummary(), options)
 		}
 		return writeLogsForRun(cmd.OutOrStdout(), run.Msg.GetRun(), cli.JSON, options)
 	}

--- a/cmd/agent-compose/cli_logs_test.go
+++ b/cmd/agent-compose/cli_logs_test.go
@@ -44,7 +44,7 @@ agents:
 			followRunLogs: func(ctx context.Context, req *connect.Request[agentcomposev2.FollowRunLogsRequest], stream *connect.ServerStream[agentcomposev2.RunLogChunk]) error {
 				sawFollow = true
 				followRequests = append(followRequests, req.Msg)
-				if req.Msg.GetRunId() != "run-detached-logs" || !req.Msg.GetFollow() || req.Msg.GetTailLines() != 3 {
+				if req.Msg.GetRunId() != "run-detached-logs" || !req.Msg.GetFollow() || req.Msg.GetTailLines() != 3 || !req.Msg.GetTailSet() {
 					t.Fatalf("FollowRunLogs request = %#v", req.Msg)
 				}
 				if err := stream.Send(&agentcomposev2.RunLogChunk{
@@ -335,7 +335,7 @@ agents:
 		},
 		followRunLogs: func(ctx context.Context, req *connect.Request[agentcomposev2.FollowRunLogsRequest], stream *connect.ServerStream[agentcomposev2.RunLogChunk]) error {
 			followCalls++
-			if req.Msg.GetRunId() != "run-follow" || !req.Msg.GetFollow() || req.Msg.GetTailLines() != 2 {
+			if req.Msg.GetRunId() != "run-follow" || !req.Msg.GetFollow() || req.Msg.GetTailLines() != 2 || !req.Msg.GetTailSet() {
 				t.Fatalf("FollowRunLogs request = %#v", req.Msg)
 			}
 			if err := stream.Send(&agentcomposev2.RunLogChunk{Data: "first\n", Offset: 6, RunStatus: agentcomposev2.RunStatus_RUN_STATUS_RUNNING, CreatedAt: "2026-07-06T08:01:36.372Z"}); err != nil {

--- a/cmd/agent-compose/cli_output_test.go
+++ b/cmd/agent-compose/cli_output_test.go
@@ -7,6 +7,26 @@ import (
 	"testing"
 )
 
+func TestPrefixedRunOutputStreamWriterPreservesLinesAcrossChunks(t *testing.T) {
+	summary := &agentcomposev2.RunSummary{RunId: "run-stream-boundary", AgentName: "reviewer"}
+	var out bytes.Buffer
+	writer := newPrefixedRunOutputStreamWriter(&out, false)
+	if err := writer.Write(summary, "first line\npartial", ""); err != nil {
+		t.Fatalf("write first chunk: %v", err)
+	}
+	if err := writer.Write(summary, " line\nlast", ""); err != nil {
+		t.Fatalf("write second chunk: %v", err)
+	}
+	if err := writer.Finish(); err != nil {
+		t.Fatalf("finish stream: %v", err)
+	}
+	prefix := runLogPrefix(summary) + " | "
+	want := prefix + "first line\n" + prefix + "partial line\n" + prefix + "last\n"
+	if out.String() != want {
+		t.Fatalf("streamed prefixed output = %q, want %q", out.String(), want)
+	}
+}
+
 func TestCLIOutputHelpersCoverEdgeBranches(t *testing.T) {
 	project := &agentcomposev2.Project{
 		Summary: &agentcomposev2.ProjectSummary{

--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -575,11 +575,13 @@ type projectServiceStub struct {
 	getScheduler               func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error)
 	listSchedulerEvents        func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error)
 	listProjectSchedulerEvents func(context.Context, *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error)
+	streamSchedulerEvents      func(context.Context, *connect.Request[agentcomposev2.StreamProjectSchedulerEventsRequest], *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]) error
 	invokeScheduler            func(context.Context, *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error)
 	runScheduler               func(context.Context, *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error)
 	startSchedulerRun          func(context.Context, *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error)
 	getSchedulerRun            func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error)
 	listSchedulerRuns          func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error)
+	streamSchedulerRuns        func(context.Context, *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error
 	stopSchedulerRun           func(context.Context, *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error)
 	pruneSchedulerRuns         func(context.Context, *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error)
 
@@ -598,6 +600,13 @@ func (s projectServiceStub) ListProjectSchedulerEvents(ctx context.Context, req 
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ListProjectSchedulerEvents stub is not configured"))
 	}
 	return s.listProjectSchedulerEvents(ctx, req)
+}
+
+func (s projectServiceStub) StreamProjectSchedulerEvents(ctx context.Context, req *connect.Request[agentcomposev2.StreamProjectSchedulerEventsRequest], stream *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]) error {
+	if s.streamSchedulerEvents == nil {
+		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StreamProjectSchedulerEvents stub is not configured"))
+	}
+	return s.streamSchedulerEvents(ctx, req, stream)
 }
 
 func (s projectServiceStub) InvokeScheduler(ctx context.Context, req *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error) {

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -349,6 +349,7 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 	if normalizedOptions.Detach {
 		return startDetachedRun(cmd, cli, normalized.Name, client, runReq)
 	}
+	client = clients.runStream
 	if normalizedOptions.Interactive {
 		if normalizedOptions.TTY {
 			attachClient, err := newCLIRunAttachServiceClient(cli)

--- a/cmd/agent-compose/cli_run_output.go
+++ b/cmd/agent-compose/cli_run_output.go
@@ -171,39 +171,64 @@ func writePrefixedRunOutput(out io.Writer, summary *agentcomposev2.RunSummary, o
 }
 
 func writePrefixedRunOutputWithTimestamp(out io.Writer, summary *agentcomposev2.RunSummary, output string, timestamp bool, timestampValue string) error {
-	if output == "" {
-		return nil
+	writer := newPrefixedRunOutputStreamWriter(out, timestamp)
+	if err := writer.Write(summary, output, timestampValue); err != nil {
+		return err
 	}
-	prefix := runLogPrefix(summary)
-	runTime := ""
-	if timestamp {
-		runTime = formatComposeLogTimestamp(timestampValue)
-	}
+	return writer.Finish()
+}
+
+type prefixedRunOutputStreamWriter struct {
+	out       io.Writer
+	timestamp bool
+	lineOpen  bool
+}
+
+func newPrefixedRunOutputStreamWriter(out io.Writer, timestamp bool) *prefixedRunOutputStreamWriter {
+	return &prefixedRunOutputStreamWriter{out: out, timestamp: timestamp}
+}
+
+func (w *prefixedRunOutputStreamWriter) Write(summary *agentcomposev2.RunSummary, output, timestampValue string) error {
 	for len(output) > 0 {
-		line := output
+		if !w.lineOpen {
+			if err := w.writePrefix(summary, timestampValue); err != nil {
+				return err
+			}
+		}
+		chunk := output
 		rest := ""
 		if idx := strings.IndexByte(output, '\n'); idx >= 0 {
-			line = output[:idx+1]
+			chunk = output[:idx+1]
 			rest = output[idx+1:]
 		}
-		if runTime != "" {
-			if _, err := fmt.Fprintf(out, "%s [%s]| ", prefix, runTime); err != nil {
-				return err
-			}
-		} else if _, err := fmt.Fprintf(out, "%s | ", prefix); err != nil {
+		if _, err := io.WriteString(w.out, chunk); err != nil {
 			return err
 		}
-		if err := writeCommandOutput(out, []byte(line)); err != nil {
-			return err
-		}
-		if !strings.HasSuffix(line, "\n") {
-			if _, err := fmt.Fprintln(out); err != nil {
-				return err
-			}
-		}
+		w.lineOpen = !strings.HasSuffix(chunk, "\n")
 		output = rest
 	}
 	return nil
+}
+
+func (w *prefixedRunOutputStreamWriter) Finish() error {
+	if !w.lineOpen {
+		return nil
+	}
+	w.lineOpen = false
+	_, err := fmt.Fprintln(w.out)
+	return err
+}
+
+func (w *prefixedRunOutputStreamWriter) writePrefix(summary *agentcomposev2.RunSummary, timestampValue string) error {
+	prefix := runLogPrefix(summary)
+	if w.timestamp {
+		if runTime := formatComposeLogTimestamp(timestampValue); runTime != "" {
+			_, err := fmt.Fprintf(w.out, "%s [%s]| ", prefix, runTime)
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(w.out, "%s | ", prefix)
+	return err
 }
 
 func runSummaryExitCode(run *agentcomposev2.RunSummary) int {

--- a/cmd/agent-compose/cli_scheduler_command.go
+++ b/cmd/agent-compose/cli_scheduler_command.go
@@ -70,22 +70,22 @@ func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options 
 		}
 		agentRef = args[0]
 	}
-	runs, err := listComposeSchedulerRuns(cmd.Context(), clients, normalized, projectID, agentRef, options.Trigger, options.Status, options.Limit)
-	if err != nil {
-		return err
-	}
-	output := composeSchedulerRunsOutput{
-		Project: composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: normalized.Name},
-		Runs:    runs,
-	}
+	project := composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: normalized.Name}
 	if cli.JSON {
-		data, err := json.MarshalIndent(output, "", "  ")
+		writer, err := newSchedulerJSONStreamWriter[composeSchedulerRunItem](cmd.OutOrStdout(), schedulerRunsJSONPrefix{Project: project}, "runs")
 		if err != nil {
 			return err
 		}
-		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
+		if err := streamComposeSchedulerRuns(cmd.Context(), clients, normalized, projectID, agentRef, options.Trigger, options.Status, options.Limit, writer.Write); err != nil {
+			return err
+		}
+		return writer.Finish()
 	}
-	return writeSchedulerRunsText(cmd.OutOrStdout(), output)
+	writer := newSchedulerRunsTextStreamWriter(cmd.OutOrStdout())
+	if err := streamComposeSchedulerRuns(cmd.Context(), clients, normalized, projectID, agentRef, options.Trigger, options.Status, options.Limit, writer.Write); err != nil {
+		return err
+	}
+	return writer.Finish()
 }
 
 func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerLogsOptions, args []string) error {
@@ -151,23 +151,23 @@ func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options 
 		}
 		triggerID = resolvedTriggerID
 	}
-	events, err := listProjectSchedulerLogEvents(cmd.Context(), clients.project, projectID, agentName, triggerID, runRef, options.Tail)
-	if err != nil {
-		return err
-	}
-	output := composeSchedulerLogsOutput{
-		Project: composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: normalized.Name},
-		Run:     selected,
-		Events:  events,
-	}
+	project := composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: normalized.Name}
 	if cli.JSON {
-		data, err := json.MarshalIndent(output, "", "  ")
+		writer, err := newSchedulerJSONStreamWriter[composeSchedulerLogEvent](cmd.OutOrStdout(), schedulerLogsJSONPrefix{Project: project, Run: selected}, "events")
 		if err != nil {
 			return err
 		}
-		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
+		if err := streamProjectSchedulerLogEvents(cmd.Context(), clients, projectID, agentName, triggerID, runRef, options.Tail, writer.Write); err != nil {
+			return err
+		}
+		return writer.Finish()
 	}
-	return writeSchedulerLogsText(cmd.OutOrStdout(), output)
+	if err := streamProjectSchedulerLogEvents(cmd.Context(), clients, projectID, agentName, triggerID, runRef, options.Tail, func(events []composeSchedulerLogEvent) error {
+		return writeSchedulerLogsText(cmd.OutOrStdout(), composeSchedulerLogsOutput{Events: events})
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func writeDeprecatedSchedulerAgentFlagWarning(cmd *cobra.Command, guidance string) error {

--- a/cmd/agent-compose/cli_scheduler_output.go
+++ b/cmd/agent-compose/cli_scheduler_output.go
@@ -91,35 +91,6 @@ func writeSchedulerInspectText(out io.Writer, output composeSchedulerInspectOutp
 	return writeCommandOutput(out, data)
 }
 
-func writeSchedulerRunsText(out io.Writer, output composeSchedulerRunsOutput) error {
-	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "RUN ID\tAGENT\tTRIGGER\tSTATUS\tSANDBOXES\tSTARTED\tDURATION"); err != nil {
-		return err
-	}
-	for _, run := range output.Runs {
-		sandboxes := "-"
-		if len(run.SandboxIDs) > 0 {
-			shortIDs := make([]string, 0, len(run.SandboxIDs))
-			for _, sandboxID := range run.SandboxIDs {
-				shortIDs = append(shortIDs, shortOpaqueID(sandboxID))
-			}
-			sandboxes = strings.Join(shortIDs, ",")
-		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			run.RunShortID,
-			run.AgentName,
-			firstNonEmptyString(run.TriggerID, "-"),
-			run.Status,
-			sandboxes,
-			firstNonEmptyString(run.StartedAt, "-"),
-			formatDurationMs(run.DurationMs),
-		); err != nil {
-			return err
-		}
-	}
-	return tw.Flush()
-}
-
 func writeSchedulerLogsText(out io.Writer, output composeSchedulerLogsOutput) error {
 	for _, event := range output.Events {
 		line := fmt.Sprintf("%s %s %s", event.CreatedAt, strings.ToUpper(firstNonEmptyString(event.Level, "info")), event.Type)

--- a/cmd/agent-compose/cli_scheduler_query.go
+++ b/cmd/agent-compose/cli_scheduler_query.go
@@ -102,32 +102,9 @@ func listComposeSchedulerTriggers(ctx context.Context, clients cliServiceClients
 }
 
 func listComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, agentRef, triggerRef, status string, limit uint32) ([]composeSchedulerRunItem, error) {
-	agentFilter := ""
-	if strings.TrimSpace(agentRef) != "" {
-		scheduler, resolveErr := resolveComposeScheduler(normalized, projectID, agentRef)
-		if resolveErr != nil {
-			return nil, resolveErr
-		}
-		agentFilter = scheduler.AgentName
-	}
-	runStatus, statusText, statusErr := parseSchedulerRunStatusFilter(status)
-	if statusErr != nil {
-		return nil, statusErr
-	}
-	triggerRef = strings.TrimSpace(triggerRef)
-	triggerID := ""
-	if triggerRef != "" {
-		resolvedTriggerID, resolveErr := resolveSchedulerTriggerIDForQuery(ctx, clients, normalized, projectID, agentFilter, triggerRef)
-		if resolveErr != nil {
-			if errors.Is(resolveErr, domain.ErrAmbiguous) && agentFilter == "" {
-				resolveErr = fmt.Errorf("%w; specify a scheduler argument to disambiguate", resolveErr)
-			}
-			if isSchedulerResourceNotFound(resolveErr) || errors.Is(resolveErr, domain.ErrAmbiguous) {
-				return nil, commandExitError{Code: exitCodeUsage, Err: resolveErr}
-			}
-			return nil, resolveErr
-		}
-		triggerID = resolvedTriggerID
+	agentFilter, triggerID, runStatus, statusText, err := resolveComposeSchedulerRunQuery(ctx, clients, normalized, projectID, agentRef, triggerRef, status)
+	if err != nil {
+		return nil, err
 	}
 	items := make([]composeSchedulerRunItem, 0)
 	cursor := ""
@@ -176,6 +153,37 @@ func listComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, no
 		seenCursors[next] = struct{}{}
 		cursor = next
 	}
+}
+
+func resolveComposeSchedulerRunQuery(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, agentRef, triggerRef, status string) (string, string, agentcomposev2.SchedulerRunStatus, string, error) {
+	agentFilter := ""
+	if strings.TrimSpace(agentRef) != "" {
+		scheduler, resolveErr := resolveComposeScheduler(normalized, projectID, agentRef)
+		if resolveErr != nil {
+			return "", "", agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED, "", resolveErr
+		}
+		agentFilter = scheduler.AgentName
+	}
+	runStatus, statusText, statusErr := parseSchedulerRunStatusFilter(status)
+	if statusErr != nil {
+		return "", "", agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED, "", statusErr
+	}
+	triggerRef = strings.TrimSpace(triggerRef)
+	triggerID := ""
+	if triggerRef != "" {
+		resolvedTriggerID, resolveErr := resolveSchedulerTriggerIDForQuery(ctx, clients, normalized, projectID, agentFilter, triggerRef)
+		if resolveErr != nil {
+			if errors.Is(resolveErr, domain.ErrAmbiguous) && agentFilter == "" {
+				resolveErr = fmt.Errorf("%w; specify a scheduler argument to disambiguate", resolveErr)
+			}
+			if isSchedulerResourceNotFound(resolveErr) || errors.Is(resolveErr, domain.ErrAmbiguous) {
+				return "", "", agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED, "", commandExitError{Code: exitCodeUsage, Err: resolveErr}
+			}
+			return "", "", agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED, "", resolveErr
+		}
+		triggerID = resolvedTriggerID
+	}
+	return agentFilter, triggerID, runStatus, statusText, nil
 }
 
 func resolveSchedulerTriggerIDForQuery(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, agentFilter, triggerRef string) (string, error) {

--- a/cmd/agent-compose/cli_scheduler_stream.go
+++ b/cmd/agent-compose/cli_scheduler_stream.go
@@ -209,6 +209,9 @@ func newSchedulerJSONStreamWriter[T any](out io.Writer, prefix any, fieldName st
 	if err != nil {
 		return nil, err
 	}
+	if len(data) < 2 || data[0] != '{' || data[len(data)-1] != '}' {
+		return nil, fmt.Errorf("scheduler JSON stream prefix must encode a JSON object")
+	}
 	return &schedulerJSONStreamWriter[T]{out: out, prefix: data, fieldName: fieldName}, nil
 }
 

--- a/cmd/agent-compose/cli_scheduler_stream.go
+++ b/cmd/agent-compose/cli_scheduler_stream.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"text/tabwriter"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/compose"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+const schedulerCLIBatchSize = 100
+
+func streamComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, agentRef, triggerRef, status string, limit uint32, writeBatch func([]composeSchedulerRunItem) error) error {
+	agentFilter, triggerID, runStatus, statusText, err := resolveComposeSchedulerRunQuery(ctx, clients, normalized, projectID, agentRef, triggerRef, status)
+	if err != nil {
+		return err
+	}
+	stream, err := clients.projectStream.StreamSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentFilter, TriggerId: triggerID,
+		Status: runStatus, BatchSize: schedulerCLIBatchSize, Limit: limit,
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeUnimplemented {
+			return fallbackComposeSchedulerRuns(ctx, clients, normalized, projectID, agentRef, triggerRef, status, limit, writeBatch)
+		}
+		return commandExitErrorForConnect(fmt.Errorf("stream scheduler runs: %w", err))
+	}
+	received := false
+	completed := false
+	for stream.Receive() {
+		received = true
+		frame := stream.Msg()
+		items := make([]composeSchedulerRunItem, 0, len(frame.GetRuns()))
+		for _, run := range frame.GetRuns() {
+			if strings.TrimSpace(run.GetTriggerId()) == "" || (agentFilter != "" && run.GetAgentName() != agentFilter) ||
+				(triggerID != "" && run.GetTriggerId() != triggerID) || (statusText != "" && schedulerRunStatusText(run.GetStatus()) != statusText) {
+				continue
+			}
+			scheduler, resolveErr := resolveComposeScheduler(normalized, projectID, run.GetAgentName())
+			if resolveErr == nil {
+				items = append(items, schedulerRuntimeRunItem(scheduler.SchedulerID, scheduler.ManagedLoaderID, run))
+			}
+		}
+		if len(items) > 0 {
+			if err := writeBatch(items); err != nil {
+				return err
+			}
+		}
+		if frame.GetComplete() {
+			completed = true
+		}
+	}
+	if err := stream.Err(); err != nil {
+		if !received && connect.CodeOf(err) == connect.CodeUnimplemented {
+			return fallbackComposeSchedulerRuns(ctx, clients, normalized, projectID, agentRef, triggerRef, status, limit, writeBatch)
+		}
+		return commandExitErrorForConnect(fmt.Errorf("stream scheduler runs: %w", err))
+	}
+	if !completed {
+		return fmt.Errorf("stream scheduler runs: daemon closed the stream before completion")
+	}
+	return nil
+}
+
+func fallbackComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, normalized *compose.NormalizedProjectSpec, projectID, agentRef, triggerRef, status string, limit uint32, writeBatch func([]composeSchedulerRunItem) error) error {
+	runs, err := listComposeSchedulerRuns(ctx, clients, normalized, projectID, agentRef, triggerRef, status, limit)
+	if err != nil {
+		return err
+	}
+	if len(runs) == 0 {
+		return nil
+	}
+	return writeBatch(runs)
+}
+
+func streamProjectSchedulerLogEvents(ctx context.Context, clients cliServiceClients, projectID, agentName, triggerID, runID string, tail int, writeBatch func([]composeSchedulerLogEvent) error) error {
+	if tail == 0 {
+		return nil
+	}
+	if tail > math.MaxUint32 {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs --tail must be at most %d", uint64(math.MaxUint32))}
+	}
+	streamTail := uint32(0)
+	if tail > 0 {
+		streamTail = uint32(tail)
+	}
+	stream, err := clients.projectStream.StreamProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, TriggerId: triggerID, RunId: runID,
+		BatchSize: schedulerCLIBatchSize, Tail: streamTail,
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeUnimplemented {
+			return fallbackProjectSchedulerLogEvents(ctx, clients, projectID, agentName, triggerID, runID, tail, writeBatch)
+		}
+		return commandExitErrorForConnect(fmt.Errorf("stream scheduler logs: %w", err))
+	}
+	received := false
+	completed := false
+	for stream.Receive() {
+		received = true
+		frame := stream.Msg()
+		items := make([]composeSchedulerLogEvent, 0, len(frame.GetEvents()))
+		for _, event := range frame.GetEvents() {
+			items = append(items, schedulerLogEventFromProto(event))
+		}
+		if len(items) > 0 {
+			if err := writeBatch(items); err != nil {
+				return err
+			}
+		}
+		if frame.GetComplete() {
+			completed = true
+		}
+	}
+	if err := stream.Err(); err != nil {
+		if !received && connect.CodeOf(err) == connect.CodeUnimplemented {
+			return fallbackProjectSchedulerLogEvents(ctx, clients, projectID, agentName, triggerID, runID, tail, writeBatch)
+		}
+		return commandExitErrorForConnect(fmt.Errorf("stream scheduler logs: %w", err))
+	}
+	if !completed {
+		return fmt.Errorf("stream scheduler logs: daemon closed the stream before completion")
+	}
+	return nil
+}
+
+func fallbackProjectSchedulerLogEvents(ctx context.Context, clients cliServiceClients, projectID, agentName, triggerID, runID string, tail int, writeBatch func([]composeSchedulerLogEvent) error) error {
+	events, err := listProjectSchedulerLogEvents(ctx, clients.project, projectID, agentName, triggerID, runID, tail)
+	if err != nil {
+		return err
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	return writeBatch(events)
+}
+
+func schedulerLogEventFromProto(event *agentcomposev2.SchedulerEvent) composeSchedulerLogEvent {
+	return composeSchedulerLogEvent{
+		ID: event.GetId(), RunID: event.GetRunId(), AgentName: event.GetAgentName(), SchedulerID: event.GetSchedulerId(), TriggerID: event.GetTriggerId(),
+		Type: schedulerDisplayEventType(event.GetType()), Level: event.GetLevel(), Message: event.GetMessage(), PayloadJSON: event.GetPayloadJson(),
+		SandboxID: event.GetLinkedSandboxId(), CellID: event.GetLinkedCellId(), AgentThreadID: event.GetLinkedAgentThreadId(), CreatedAt: formatProtoTimestamp(event.GetCreatedAt()),
+	}
+}
+
+type schedulerRunsTextStreamWriter struct {
+	writer  *tabwriter.Writer
+	started bool
+}
+
+func newSchedulerRunsTextStreamWriter(out io.Writer) *schedulerRunsTextStreamWriter {
+	return &schedulerRunsTextStreamWriter{writer: tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)}
+}
+
+func (w *schedulerRunsTextStreamWriter) Write(items []composeSchedulerRunItem) error {
+	if err := w.start(); err != nil {
+		return err
+	}
+	for _, run := range items {
+		sandboxes := "-"
+		if len(run.SandboxIDs) > 0 {
+			shortIDs := make([]string, 0, len(run.SandboxIDs))
+			for _, sandboxID := range run.SandboxIDs {
+				shortIDs = append(shortIDs, shortOpaqueID(sandboxID))
+			}
+			sandboxes = strings.Join(shortIDs, ",")
+		}
+		if _, err := fmt.Fprintf(w.writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", run.RunShortID, run.AgentName,
+			firstNonEmptyString(run.TriggerID, "-"), run.Status, sandboxes, firstNonEmptyString(run.StartedAt, "-"), formatDurationMs(run.DurationMs)); err != nil {
+			return err
+		}
+	}
+	return w.writer.Flush()
+}
+
+func (w *schedulerRunsTextStreamWriter) Finish() error {
+	if err := w.start(); err != nil {
+		return err
+	}
+	return w.writer.Flush()
+}
+
+func (w *schedulerRunsTextStreamWriter) start() error {
+	if w.started {
+		return nil
+	}
+	w.started = true
+	_, err := fmt.Fprintln(w.writer, "RUN ID\tAGENT\tTRIGGER\tSTATUS\tSANDBOXES\tSTARTED\tDURATION")
+	return err
+}
+
+type schedulerJSONStreamWriter[T any] struct {
+	out       io.Writer
+	prefix    []byte
+	fieldName string
+	started   bool
+	written   bool
+}
+
+func newSchedulerJSONStreamWriter[T any](out io.Writer, prefix any, fieldName string) (*schedulerJSONStreamWriter[T], error) {
+	data, err := json.Marshal(prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &schedulerJSONStreamWriter[T]{out: out, prefix: data, fieldName: fieldName}, nil
+}
+
+func (w *schedulerJSONStreamWriter[T]) Write(items []T) error {
+	if err := w.start(); err != nil {
+		return err
+	}
+	for _, item := range items {
+		data, err := json.MarshalIndent(item, "", "  ")
+		if err != nil {
+			return err
+		}
+		if w.written {
+			if _, err := io.WriteString(w.out, ","); err != nil {
+				return err
+			}
+		}
+		if _, err := w.out.Write(data); err != nil {
+			return err
+		}
+		w.written = true
+	}
+	return nil
+}
+
+func (w *schedulerJSONStreamWriter[T]) Finish() error {
+	if err := w.start(); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w.out, "]}\n")
+	return err
+}
+
+func (w *schedulerJSONStreamWriter[T]) start() error {
+	if w.started {
+		return nil
+	}
+	w.started = true
+	if _, err := w.out.Write(w.prefix[:len(w.prefix)-1]); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w.out, ",%q: [", w.fieldName)
+	return err
+}
+
+type schedulerRunsJSONPrefix struct {
+	Project composeUpProjectOutput `json:"project"`
+}
+
+type schedulerLogsJSONPrefix struct {
+	Project composeUpProjectOutput   `json:"project"`
+	Run     *composeSchedulerRunItem `json:"run,omitempty"`
+}

--- a/cmd/agent-compose/cli_scheduler_stream_test.go
+++ b/cmd/agent-compose/cli_scheduler_stream_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestIntegrationSchedulerStreamsOutputBeforeCompletion(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: scheduler-stream-output
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      triggers:
+        - name: nightly
+          cron: "0 2 * * *"
+          prompt: review
+`)
+	tests := []struct {
+		name   string
+		args   []string
+		marker string
+		stub   projectServiceStub
+	}{
+		{
+			name:   "runs",
+			args:   []string{"scheduler", "runs"},
+			marker: "run-stream",
+			stub: projectServiceStub{streamSchedulerRuns: func(ctx context.Context, _ *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+				if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{RunId: "run-stream-first", AgentName: "reviewer", TriggerId: "nightly", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING}}}); err != nil {
+					return err
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			}},
+		},
+		{
+			name:   "logs",
+			args:   []string{"scheduler", "logs"},
+			marker: "first-stream-event",
+			stub: projectServiceStub{streamSchedulerEvents: func(ctx context.Context, _ *connect.Request[agentcomposev2.StreamProjectSchedulerEventsRequest], stream *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]) error {
+				if err := stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Events: []*agentcomposev2.SchedulerEvent{{Id: "event-first", AgentName: "reviewer", TriggerId: "nightly", Type: "loader.log", Message: "first-stream-event"}}}); err != nil {
+					return err
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			stub := test.stub
+			stub.getProject = func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "scheduler-stream-output", composePath)}), nil
+			}
+			server := newComposeServiceStubServer(t, composeServiceStubs{project: stub})
+			defer server.Close()
+			out := newMarkerWriter(test.marker)
+			var stderr bytes.Buffer
+			done := make(chan int, 1)
+			args := append(append([]string(nil), test.args...), "--host", server.URL, "--file", composePath)
+			go func() { done <- executeCLI(ctx, out, &stderr, args, nil) }()
+			select {
+			case <-out.seen:
+			case code := <-done:
+				t.Fatalf("command completed before streaming the first item: code=%d stderr=%q", code, stderr.String())
+			case <-ctx.Done():
+				t.Fatalf("timed out waiting for streamed output: %v", ctx.Err())
+			}
+			select {
+			case code := <-done:
+				t.Fatalf("command completed before the server stream ended: code=%d stderr=%q", code, stderr.String())
+			default:
+			}
+			cancel()
+			<-done
+		})
+	}
+}
+
+type markerWriter struct {
+	mu     sync.Mutex
+	marker string
+	data   strings.Builder
+	seen   chan struct{}
+	once   sync.Once
+}
+
+func newMarkerWriter(marker string) *markerWriter {
+	return &markerWriter{marker: marker, seen: make(chan struct{})}
+}
+
+func (w *markerWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.data.Write(data)
+	if strings.Contains(w.data.String(), w.marker) {
+		w.once.Do(func() { close(w.seen) })
+	}
+	return n, err
+}
+
+var _ io.Writer = (*markerWriter)(nil)

--- a/cmd/agent-compose/cli_scheduler_stream_test.go
+++ b/cmd/agent-compose/cli_scheduler_stream_test.go
@@ -90,6 +90,20 @@ agents:
 	}
 }
 
+func TestSchedulerJSONStreamWriterRejectsNonObjectPrefix(t *testing.T) {
+	for name, prefix := range map[string]any{
+		"nil":    nil,
+		"string": "prefix",
+		"slice":  []string{"prefix"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := newSchedulerJSONStreamWriter[string](io.Discard, prefix, "items"); err == nil || !strings.Contains(err.Error(), "must encode a JSON object") {
+				t.Fatalf("newSchedulerJSONStreamWriter error = %v", err)
+			}
+		})
+	}
+}
+
 type markerWriter struct {
 	mu     sync.Mutex
 	marker string

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -836,6 +836,13 @@ func (s projectServiceStub) ListSchedulerRuns(ctx context.Context, req *connect.
 	return s.listSchedulerRuns(ctx, req)
 }
 
+func (s projectServiceStub) StreamSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+	if s.streamSchedulerRuns == nil {
+		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StreamSchedulerRuns stub is not configured"))
+	}
+	return s.streamSchedulerRuns(ctx, req, stream)
+}
+
 func (s projectServiceStub) StopSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error) {
 	if s.stopSchedulerRun == nil {
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StopSchedulerRun stub is not configured"))

--- a/cmd/agent-compose/cli_stub_server_test.go
+++ b/cmd/agent-compose/cli_stub_server_test.go
@@ -32,7 +32,7 @@ type resourceServiceStub struct {
 func newComposeServiceStubServer(t *testing.T, stubs composeServiceStubs) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.listProjectSchedulerEvents != nil || stubs.project.invokeScheduler != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil || stubs.project.pruneSchedulerRuns != nil {
+	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.listProjectSchedulerEvents != nil || stubs.project.streamSchedulerEvents != nil || stubs.project.invokeScheduler != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.streamSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil || stubs.project.pruneSchedulerRuns != nil {
 		path, handler := agentcomposev2connect.NewProjectServiceHandler(stubs.project)
 		mux.Handle(path, handler)
 	}

--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -86,6 +86,7 @@ func (h *ExecHandler) Exec(ctx context.Context, req *connect.Request[agentcompos
 }
 
 func (h *ExecHandler) ExecStream(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+	PrepareStreamingHeaders(stream.ResponseHeader())
 	execID := uuid.NewString()
 	result, err := h.executeProjectCommand(ctx, req.Msg, execID, func(resp *agentcomposev2.ExecStreamResponse) error {
 		return stream.Send(resp)

--- a/pkg/agentcompose/api/image.go
+++ b/pkg/agentcompose/api/image.go
@@ -141,6 +141,7 @@ func (h *ImageHandler) BuildImage(ctx context.Context, req *connect.Request[agen
 	if len(tags) == 0 {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("at least one tag is required"))
 	}
+	PrepareStreamingHeaders(stream.ResponseHeader())
 	backend, err := h.backends.ImageBackendForStore(req.Msg.GetStore())
 	if err != nil {
 		return err

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -278,18 +281,49 @@ type schedulerRunProjectStoreFake struct {
 }
 
 func (s *schedulerRunProjectStoreFake) ListLoaderEventsPage(_ context.Context, filter loaders.LoaderEventPageFilter) ([]domain.LoaderEvent, error) {
-	start := 0
-	if filter.BeforeEventID != "" {
-		start = len(s.events)
-		for index, event := range s.events {
-			if event.ID == filter.BeforeEventID {
-				start = index + 1
-				break
-			}
+	items := make([]domain.LoaderEvent, 0, len(s.events))
+	for _, event := range s.events {
+		if !slices.Contains(filter.LoaderIDs, event.LoaderID) || (filter.RequireTrigger && event.TriggerID == "") ||
+			(strings.TrimSpace(filter.TriggerID) != "" && event.TriggerID != filter.TriggerID) || (strings.TrimSpace(filter.RunID) != "" && event.RunID != filter.RunID) {
+			continue
 		}
+		if !filter.BeforeCreatedAt.IsZero() && compareLoaderEventKey(event, filter.BeforeCreatedAt, filter.BeforeLoaderID, filter.BeforeEventID) >= 0 {
+			continue
+		}
+		if !filter.AfterCreatedAt.IsZero() && compareLoaderEventKey(event, filter.AfterCreatedAt, filter.AfterLoaderID, filter.AfterEventID) <= 0 {
+			continue
+		}
+		if !filter.FromCreatedAt.IsZero() && compareLoaderEventKey(event, filter.FromCreatedAt, filter.FromLoaderID, filter.FromEventID) < 0 {
+			continue
+		}
+		if !filter.ThroughCreatedAt.IsZero() && compareLoaderEventKey(event, filter.ThroughCreatedAt, filter.ThroughLoaderID, filter.ThroughEventID) > 0 {
+			continue
+		}
+		items = append(items, event)
 	}
-	end := min(start+filter.Limit, len(s.events))
-	return append([]domain.LoaderEvent(nil), s.events[start:end]...), nil
+	sort.Slice(items, func(i, j int) bool {
+		comparison := compareLoaderEventKey(items[i], items[j].CreatedAt, items[j].LoaderID, items[j].ID)
+		if filter.Ascending {
+			return comparison < 0
+		}
+		return comparison > 0
+	})
+	start := min(max(filter.Offset, 0), len(items))
+	end := min(start+filter.Limit, len(items))
+	return append([]domain.LoaderEvent(nil), items[start:end]...), nil
+}
+
+func compareLoaderEventKey(event domain.LoaderEvent, createdAt time.Time, loaderID, eventID string) int {
+	if !event.CreatedAt.Equal(createdAt) {
+		if event.CreatedAt.Before(createdAt) {
+			return -1
+		}
+		return 1
+	}
+	if comparison := strings.Compare(event.LoaderID, loaderID); comparison != 0 {
+		return comparison
+	}
+	return strings.Compare(event.ID, eventID)
 }
 
 func (s *schedulerRunProjectStoreFake) GetProject(context.Context, string) (domain.ProjectRecord, error) {

--- a/pkg/agentcompose/api/project_scheduler_stream_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_stream_handler.go
@@ -1,0 +1,280 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+const defaultSchedulerStreamBatchSize = 100
+
+type schedulerEventStreamSelection struct {
+	project    domain.ProjectRecord
+	schedulers map[string]domain.ProjectSchedulerRecord
+	loaderIDs  []string
+	agentName  string
+	triggerID  string
+	runID      string
+	store      ProjectSchedulerEventStore
+}
+
+// StreamProjectSchedulerEvents sends a finite scheduler-event scan in display
+// order. Database rows are fully scanned and released before each network send.
+func (h *ProjectHandler) StreamProjectSchedulerEvents(ctx context.Context, req *connect.Request[agentcomposev2.StreamProjectSchedulerEventsRequest], stream *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]) error {
+	selection, err := h.schedulerEventStreamSelection(ctx, req.Msg)
+	if err != nil {
+		return err
+	}
+	batchSize, err := schedulerStreamBatchSize(req.Msg.GetBatchSize())
+	if err != nil {
+		return ConnectErrorForDomain(err)
+	}
+	PrepareStreamingHeaders(stream.ResponseHeader())
+	baseFilter := loaders.LoaderEventPageFilter{
+		LoaderIDs:      selection.loaderIDs,
+		RequireTrigger: true,
+		TriggerID:      selection.triggerID,
+		RunID:          selection.runID,
+	}
+	upper, err := selection.store.ListLoaderEventsPage(ctx, loaderEventPage(baseFilter, 1, 0, false))
+	if err != nil {
+		return ConnectErrorForDomain(err)
+	}
+	if len(upper) == 0 {
+		return stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Complete: true})
+	}
+	var lower *domain.LoaderEvent
+	if tail := req.Msg.GetTail(); tail > 0 {
+		boundary, queryErr := selection.store.ListLoaderEventsPage(ctx, loaderEventPage(baseFilter, 1, int(tail-1), false))
+		if queryErr != nil {
+			return ConnectErrorForDomain(queryErr)
+		}
+		if len(boundary) > 0 {
+			lower = &boundary[0]
+		}
+	}
+	return h.sendSchedulerEventPages(ctx, stream, selection, baseFilter, lower, upper[0], batchSize)
+}
+
+func (h *ProjectHandler) sendSchedulerEventPages(ctx context.Context, stream *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse], selection schedulerEventStreamSelection, base loaders.LoaderEventPageFilter, lower *domain.LoaderEvent, upper domain.LoaderEvent, batchSize int) error {
+	var after *domain.LoaderEvent
+	var emitted uint64
+	checkpoint := ""
+	for {
+		filter := loaderEventPage(base, batchSize, 0, true)
+		filter.ThroughCreatedAt, filter.ThroughLoaderID, filter.ThroughEventID = upper.CreatedAt, upper.LoaderID, upper.ID
+		if lower != nil {
+			filter.FromCreatedAt, filter.FromLoaderID, filter.FromEventID = lower.CreatedAt, lower.LoaderID, lower.ID
+		}
+		if after != nil {
+			filter.AfterCreatedAt, filter.AfterLoaderID, filter.AfterEventID = after.CreatedAt, after.LoaderID, after.ID
+		}
+		events, err := selection.store.ListLoaderEventsPage(ctx, filter)
+		if err != nil {
+			return ConnectErrorForDomain(err)
+		}
+		if len(events) == 0 {
+			break
+		}
+		items := make([]*agentcomposev2.SchedulerEvent, 0, len(events))
+		for _, event := range events {
+			scheduler, ok := selection.schedulers[event.LoaderID]
+			if ok {
+				items = append(items, schedulerEventToProto(event, scheduler))
+			}
+		}
+		last := events[len(events)-1]
+		after = &last
+		emitted += uint64(len(items))
+		checkpoint = encodeProjectSchedulerEventCursor(selection.project.ID, selection.project.CurrentRevision, selection.agentName, selection.triggerID, selection.runID, last)
+		if err := stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Events: items, Checkpoint: checkpoint, EmittedCount: emitted}); err != nil {
+			return err
+		}
+		if len(events) < batchSize || sameLoaderEventKey(last, upper) {
+			break
+		}
+	}
+	return stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Complete: true, Checkpoint: checkpoint, EmittedCount: emitted})
+}
+
+func (h *ProjectHandler) schedulerEventStreamSelection(ctx context.Context, req *agentcomposev2.StreamProjectSchedulerEventsRequest) (schedulerEventStreamSelection, error) {
+	project, schedulers, err := h.resolveProjectSchedulerRunTargets(ctx, req.GetProject(), req.GetAgentName())
+	if err != nil {
+		return schedulerEventStreamSelection{}, ConnectErrorForDomain(err)
+	}
+	agentName := strings.TrimSpace(req.GetAgentName())
+	triggerID := strings.TrimSpace(req.GetTriggerId())
+	runID := strings.TrimSpace(req.GetRunId())
+	if runID != "" {
+		_, runScheduler, run, resolveErr := h.resolveProjectSchedulerRun(ctx, req.GetProject(), runID)
+		if resolveErr != nil {
+			return schedulerEventStreamSelection{}, ConnectErrorForDomain(resolveErr)
+		}
+		if agentName != "" && agentName != runScheduler.AgentName {
+			return schedulerEventStreamSelection{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scheduler run does not belong to scheduler %q", agentName))
+		}
+		if triggerID != "" && triggerID != run.TriggerID {
+			return schedulerEventStreamSelection{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("scheduler run does not belong to trigger %q", triggerID))
+		}
+		agentName, triggerID, runID = runScheduler.AgentName, run.TriggerID, run.ID
+		schedulers = []domain.ProjectSchedulerRecord{runScheduler}
+	}
+	loaderIDs, byLoaderID := schedulerLoaderIndex(schedulers)
+	store, ok := h.store.(ProjectSchedulerEventStore)
+	if !ok {
+		return schedulerEventStreamSelection{}, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler event store is required"))
+	}
+	return schedulerEventStreamSelection{project: project, schedulers: byLoaderID, loaderIDs: loaderIDs, agentName: agentName, triggerID: triggerID, runID: runID, store: store}, nil
+}
+
+// StreamSchedulerRuns sends bounded run batches until the finite scan or the
+// caller's final result limit is reached.
+func (h *ProjectHandler) StreamSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+	project, schedulers, err := h.resolveProjectSchedulerRunTargets(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	if err != nil {
+		return ConnectErrorForDomain(err)
+	}
+	status, err := schedulerRunStatusFilter(req.Msg.GetStatus())
+	if err != nil {
+		return ConnectErrorForDomain(err)
+	}
+	batchSize, err := schedulerStreamBatchSize(req.Msg.GetBatchSize())
+	if err != nil {
+		return ConnectErrorForDomain(err)
+	}
+	store, err := h.schedulerRunStore()
+	if err != nil {
+		return ConnectErrorForDomain(err)
+	}
+	loaderIDs, byLoaderID := schedulerLoaderIndex(schedulers)
+	PrepareStreamingHeaders(stream.ResponseHeader())
+	return h.sendSchedulerRunPages(ctx, stream, schedulerRunStreamSelection{
+		project: project, schedulers: byLoaderID, loaderIDs: loaderIDs, agentName: strings.TrimSpace(req.Msg.GetAgentName()),
+		triggerID: strings.TrimSpace(req.Msg.GetTriggerId()), status: status, store: store, limit: req.Msg.GetLimit(), batchSize: batchSize,
+	})
+}
+
+type schedulerRunStreamSelection struct {
+	project    domain.ProjectRecord
+	schedulers map[string]domain.ProjectSchedulerRecord
+	loaderIDs  []string
+	agentName  string
+	triggerID  string
+	status     string
+	store      ProjectSchedulerRunStore
+	limit      uint32
+	batchSize  int
+}
+
+func (h *ProjectHandler) sendSchedulerRunPages(ctx context.Context, stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse], selection schedulerRunStreamSelection) error {
+	var before *domain.LoaderRunSummary
+	var emitted uint64
+	checkpoint := ""
+	for {
+		pageSize := selection.batchSize
+		if selection.limit > 0 && uint64(pageSize) > uint64(selection.limit)-emitted {
+			pageSize = int(uint64(selection.limit) - emitted)
+		}
+		if pageSize == 0 {
+			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true, Checkpoint: checkpoint, EmittedCount: emitted, Truncated: true})
+		}
+		filter := loaders.LoaderRunPageFilter{LoaderIDs: selection.loaderIDs, RequireTrigger: true, TriggerID: selection.triggerID, Status: selection.status, Limit: pageSize + 1}
+		if before != nil {
+			filter.BeforeStartedAt, filter.BeforeLoaderID, filter.BeforeRunID = before.StartedAt, before.LoaderID, before.ID
+		}
+		runs, err := selection.store.ListLoaderRunsPage(ctx, filter)
+		if err != nil {
+			return ConnectErrorForDomain(err)
+		}
+		if len(runs) == 0 {
+			break
+		}
+		end := min(pageSize, len(runs))
+		page := runs[:end]
+		items, err := h.schedulerRunStreamItems(ctx, selection.schedulers, page)
+		if err != nil {
+			return err
+		}
+		last := page[len(page)-1]
+		before = &last
+		emitted += uint64(len(items))
+		checkpoint = encodeSchedulerRunCursor(selection.project.ID, selection.project.CurrentRevision, selection.agentName, selection.triggerID, selection.status, last)
+		if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: items, Checkpoint: checkpoint, EmittedCount: emitted}); err != nil {
+			return err
+		}
+		if len(runs) <= end {
+			break
+		}
+		if selection.limit > 0 && emitted >= uint64(selection.limit) {
+			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true, Checkpoint: checkpoint, EmittedCount: emitted, Truncated: true})
+		}
+	}
+	return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true, Checkpoint: checkpoint, EmittedCount: emitted})
+}
+
+func (h *ProjectHandler) schedulerRunStreamItems(ctx context.Context, schedulers map[string]domain.ProjectSchedulerRecord, runs []domain.LoaderRunSummary) ([]*agentcomposev2.SchedulerRun, error) {
+	keys := make([]loaders.LoaderRunKey, 0, len(runs))
+	for _, run := range runs {
+		keys = append(keys, loaders.LoaderRunKey{LoaderID: run.LoaderID, RunID: run.ID})
+	}
+	sandboxIDs := make(map[loaders.LoaderRunKey][]string)
+	if sandboxStore, ok := h.store.(ProjectSchedulerRunSandboxStore); ok {
+		var err error
+		sandboxIDs, err = sandboxStore.ListLoaderRunSandboxIDs(ctx, keys)
+		if err != nil {
+			return nil, ConnectErrorForDomain(err)
+		}
+	}
+	items := make([]*agentcomposev2.SchedulerRun, 0, len(runs))
+	for _, run := range runs {
+		scheduler, ok := schedulers[run.LoaderID]
+		if !ok {
+			continue
+		}
+		item := schedulerRunToProto(run, scheduler)
+		item.SandboxIds = sandboxIDs[loaders.LoaderRunKey{LoaderID: run.LoaderID, RunID: run.ID}]
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func schedulerLoaderIndex(schedulers []domain.ProjectSchedulerRecord) ([]string, map[string]domain.ProjectSchedulerRecord) {
+	loaderIDs := make([]string, 0, len(schedulers))
+	byLoaderID := make(map[string]domain.ProjectSchedulerRecord, len(schedulers))
+	for _, scheduler := range schedulers {
+		loaderID := strings.TrimSpace(scheduler.ManagedLoaderID)
+		if loaderID == "" {
+			continue
+		}
+		loaderIDs = append(loaderIDs, loaderID)
+		byLoaderID[loaderID] = scheduler
+	}
+	return loaderIDs, byLoaderID
+}
+
+func schedulerStreamBatchSize(value uint32) (int, error) {
+	if value == 0 {
+		return defaultSchedulerStreamBatchSize, nil
+	}
+	if value > 500 {
+		return 0, domain.ClassifyError(domain.ErrInvalidArgument, "scheduler stream batch size must be at most 500", nil)
+	}
+	return int(value), nil
+}
+
+func loaderEventPage(base loaders.LoaderEventPageFilter, limit, offset int, ascending bool) loaders.LoaderEventPageFilter {
+	base.Limit = limit
+	base.Offset = offset
+	base.Ascending = ascending
+	return base
+}
+
+func sameLoaderEventKey(left, right domain.LoaderEvent) bool {
+	return left.LoaderID == right.LoaderID && left.ID == right.ID && left.CreatedAt.Equal(right.CreatedAt)
+}

--- a/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestStreamSchedulerRunsBatchesAndCompletes(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	startedAt := time.Unix(500, 0).UTC()
+	store.runs = []domain.LoaderRunSummary{
+		{ID: "run-3", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(2 * time.Second)},
+		{ID: "run-2", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(time.Second)},
+		{ID: "run-1", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt},
+	}
+	client, closeServer := schedulerStreamTestClient(t, handler)
+	defer closeServer()
+	stream, err := client.StreamSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, BatchSize: 1, Limit: 2,
+	}))
+	if err != nil {
+		t.Fatalf("StreamSchedulerRuns returned error: %v", err)
+	}
+	var frames []*agentcomposev2.StreamSchedulerRunsResponse
+	for stream.Receive() {
+		frames = append(frames, stream.Msg())
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamSchedulerRuns receive error: %v", err)
+	}
+	if len(frames) != 3 || frames[0].GetRuns()[0].GetRunId() != "run-3" || frames[1].GetRuns()[0].GetRunId() != "run-2" ||
+		!frames[2].GetComplete() || !frames[2].GetTruncated() || frames[2].GetEmittedCount() != 2 || frames[2].GetCheckpoint() == "" {
+		t.Fatalf("stream frames = %#v", frames)
+	}
+	assertSchedulerStreamHeaders(t, stream.ResponseHeader())
+}
+
+func TestStreamProjectSchedulerEventsTailsInDisplayOrder(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	createdAt := time.Unix(600, 0).UTC()
+	store.events = []domain.LoaderEvent{
+		{ID: "event-3", LoaderID: store.scheduler.ManagedLoaderID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "event-2", LoaderID: store.scheduler.ManagedLoaderID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", CreatedAt: createdAt.Add(time.Second)},
+		{ID: "event-1", LoaderID: store.scheduler.ManagedLoaderID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", CreatedAt: createdAt},
+	}
+	client, closeServer := schedulerStreamTestClient(t, handler)
+	defer closeServer()
+	stream, err := client.StreamProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, BatchSize: 1, Tail: 2,
+	}))
+	if err != nil {
+		t.Fatalf("StreamProjectSchedulerEvents returned error: %v", err)
+	}
+	var eventIDs []string
+	var completed *agentcomposev2.StreamProjectSchedulerEventsResponse
+	for stream.Receive() {
+		frame := stream.Msg()
+		for _, event := range frame.GetEvents() {
+			eventIDs = append(eventIDs, event.GetId())
+		}
+		if frame.GetComplete() {
+			completed = frame
+		}
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamProjectSchedulerEvents receive error: %v", err)
+	}
+	if len(eventIDs) != 2 || eventIDs[0] != "event-2" || eventIDs[1] != "event-3" || completed == nil || completed.GetEmittedCount() != 2 {
+		t.Fatalf("event ids/completion = %#v / %#v", eventIDs, completed)
+	}
+	assertSchedulerStreamHeaders(t, stream.ResponseHeader())
+}
+
+func schedulerStreamTestClient(t *testing.T, handler *ProjectHandler) (agentcomposev2connect.ProjectServiceClient, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, connectHandler := agentcomposev2connect.NewProjectServiceHandler(handler)
+	mux.Handle(path, connectHandler)
+	server := httptest.NewServer(mux)
+	return agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL), server.Close
+}
+
+func assertSchedulerStreamHeaders(t *testing.T, headers http.Header) {
+	t.Helper()
+	if headers.Get("Cache-Control") != "no-cache, no-transform" || headers.Get("X-Accel-Buffering") != "no" {
+		t.Fatalf("stream headers = %#v", headers)
+	}
+}

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 
@@ -80,6 +81,7 @@ func (h *RunHandler) StartRun(ctx context.Context, req *connect.Request[agentcom
 }
 
 func (h *RunHandler) RunAgentStream(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+	PrepareStreamingHeaders(stream.ResponseHeader())
 	return h.delegate.RunAgentStream(ctx, req, stream)
 }
 
@@ -299,13 +301,22 @@ func (h *RunHandler) FollowRunLogs(ctx context.Context, req *connect.Request[age
 	if runID == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("run id is required"))
 	}
+	PrepareStreamingHeaders(stream.ResponseHeader())
 	run, err := h.projectRunForLogRequest(ctx, req.Msg.GetProjectId(), runID)
 	if err != nil {
 		return err
 	}
-	offset, err := initialRunLogOffset(run.LogsPath, int(req.Msg.GetTailLines()), req.Msg.GetStartOffset(), req.Msg.GetFollow())
+	offset, err := initialRunLogOffset(run.LogsPath, int(req.Msg.GetTailLines()), req.Msg.GetStartOffset(), req.Msg.GetTailSet() || req.Msg.GetTailLines() > 0)
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, err)
+	}
+	if req.Msg.GetIncludeMetadata() {
+		if err := stream.Send(&agentcomposev2.RunLogChunk{
+			Offset: offset, RunStatus: ProjectRunStatusToProto(run.Status), CreatedAt: FormatProjectTime(time.Now().UTC()),
+			Run: ProjectRunSummaryToProto(run), Prompt: run.Prompt,
+		}); err != nil {
+			return err
+		}
 	}
 	if req.Msg.GetFollow() && h.runLogs != nil {
 		return h.followRunLogsWithHub(ctx, req.Msg.GetProjectId(), run, offset, stream)
@@ -323,7 +334,7 @@ func (h *RunHandler) followRunLogsByPolling(ctx context.Context, req *connect.Re
 		if err != nil {
 			return err
 		}
-		if err := sendRunLogFileChunk(stream, run, &offset, time.Now().UTC()); err != nil {
+		if err := sendRunLogFileChunks(stream, run, &offset, time.Now().UTC()); err != nil {
 			return err
 		}
 		if !req.Msg.GetFollow() || runs.StatusIsTerminal(run.Status) {
@@ -343,7 +354,7 @@ func (h *RunHandler) followRunLogsWithHub(ctx context.Context, projectID string,
 		return h.followRunLogsByPolling(ctx, connect.NewRequest(&agentcomposev2.FollowRunLogsRequest{ProjectId: projectID, RunId: run.RunID, Follow: true}), run, offset, stream)
 	}
 	defer sub.Close()
-	if err := sendRunLogFileChunk(stream, run, &offset, time.Now().UTC()); err != nil {
+	if err := sendRunLogFileChunks(stream, run, &offset, time.Now().UTC()); err != nil {
 		return err
 	}
 	if runs.StatusIsTerminal(run.Status) {
@@ -366,7 +377,7 @@ func (h *RunHandler) followRunLogsWithHub(ctx context.Context, projectID string,
 			if err != nil {
 				return err
 			}
-			if err := sendRunLogFileChunk(stream, current, &offset, event.CreatedAt); err != nil {
+			if err := sendRunLogFileChunks(stream, current, &offset, event.CreatedAt); err != nil {
 				return err
 			}
 		case <-ticker.C:
@@ -374,7 +385,7 @@ func (h *RunHandler) followRunLogsWithHub(ctx context.Context, projectID string,
 			if err != nil {
 				return err
 			}
-			if err := sendRunLogFileChunk(stream, current, &offset, time.Now().UTC()); err != nil {
+			if err := sendRunLogFileChunks(stream, current, &offset, time.Now().UTC()); err != nil {
 				return err
 			}
 			if runs.StatusIsTerminal(current.Status) {
@@ -384,27 +395,33 @@ func (h *RunHandler) followRunLogsWithHub(ctx context.Context, projectID string,
 	}
 }
 
-func sendRunLogFileChunk(stream *connect.ServerStream[agentcomposev2.RunLogChunk], run domain.ProjectRunRecord, offset *uint64, createdAt time.Time) error {
-	data, nextOffset, err := readRunLogFromOffset(run.LogsPath, *offset)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return connect.NewError(connect.CodeInternal, err)
+func sendRunLogFileChunks(stream *connect.ServerStream[agentcomposev2.RunLogChunk], run domain.ProjectRunRecord, offset *uint64, createdAt time.Time) error {
+	for {
+		data, nextOffset, atEnd, err := readRunLogChunkFromOffset(run.LogsPath, *offset)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return connect.NewError(connect.CodeInternal, err)
+		}
+		*offset = nextOffset
+		if data != "" {
+			if createdAt.IsZero() {
+				createdAt = time.Now().UTC()
+			}
+			if err := stream.Send(&agentcomposev2.RunLogChunk{
+				Data:      data,
+				Offset:    *offset,
+				RunStatus: ProjectRunStatusToProto(run.Status),
+				CreatedAt: FormatProjectTime(createdAt),
+			}); err != nil {
+				return connect.NewError(connect.CodeUnknown, err)
+			}
+		}
+		if atEnd {
+			return nil
+		}
 	}
-	if data == "" {
-		return nil
-	}
-	*offset = nextOffset
-	if createdAt.IsZero() {
-		createdAt = time.Now().UTC()
-	}
-	if err := stream.Send(&agentcomposev2.RunLogChunk{
-		Data:      data,
-		Offset:    *offset,
-		RunStatus: ProjectRunStatusToProto(run.Status),
-		CreatedAt: FormatProjectTime(createdAt),
-	}); err != nil {
-		return connect.NewError(connect.CodeUnknown, err)
-	}
-	return nil
 }
 
 func sendRunLogFinal(stream *connect.ServerStream[agentcomposev2.RunLogChunk], run domain.ProjectRunRecord, offset uint64) error {
@@ -413,6 +430,7 @@ func sendRunLogFinal(stream *connect.ServerStream[agentcomposev2.RunLogChunk], r
 		IsFinal:   true,
 		RunStatus: ProjectRunStatusToProto(run.Status),
 		CreatedAt: FormatProjectTime(time.Now().UTC()),
+		Run:       ProjectRunSummaryToProto(run),
 	})
 }
 
@@ -430,8 +448,8 @@ func (h *RunHandler) projectRunForLogRequest(ctx context.Context, projectID, run
 	return run, nil
 }
 
-func initialRunLogOffset(path string, tailLines int, startOffset uint64, _ bool) (uint64, error) {
-	if tailLines > 0 {
+func initialRunLogOffset(path string, tailLines int, startOffset uint64, tailSet bool) (uint64, error) {
+	if tailSet {
 		return tailRunLogOffset(path, tailLines)
 	}
 	if startOffset > 0 {
@@ -440,45 +458,78 @@ func initialRunLogOffset(path string, tailLines int, startOffset uint64, _ bool)
 	return 0, nil
 }
 
-func readRunLogFromOffset(path string, offset uint64) (string, uint64, error) {
+const runLogFileChunkBytes = 64 * 1024
+
+func readRunLogChunkFromOffset(path string, offset uint64) (string, uint64, bool, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return "", offset, err
+		return "", offset, false, err
 	}
 	defer func() { _ = file.Close() }()
-	if _, err := file.Seek(int64(offset), io.SeekStart); err != nil {
-		return "", offset, err
-	}
-	data, err := io.ReadAll(file)
+	info, err := file.Stat()
 	if err != nil {
-		return "", offset, err
+		return "", offset, false, err
 	}
-	return string(data), offset + uint64(len(data)), nil
+	if offset > uint64(info.Size()) {
+		offset = 0
+	}
+	if _, err := file.Seek(int64(offset), io.SeekStart); err != nil {
+		return "", offset, false, err
+	}
+	data := make([]byte, runLogFileChunkBytes)
+	n, err := io.ReadFull(file, data)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return "", offset, false, err
+	}
+	nextOffset := offset + uint64(n)
+	if nextOffset < uint64(info.Size()) && !utf8.Valid(data[:n]) {
+		for trim := 1; trim < utf8.UTFMax && trim < n; trim++ {
+			if utf8.Valid(data[:n-trim]) {
+				n -= trim
+				nextOffset = offset + uint64(n)
+				break
+			}
+		}
+	}
+	return string(data[:n]), nextOffset, nextOffset >= uint64(info.Size()), nil
 }
 
 func tailRunLogOffset(path string, lines int) (uint64, error) {
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0, nil
 		}
 		return 0, err
 	}
-	if lines <= 0 || len(data) == 0 {
-		return uint64(len(data)), nil
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	size := info.Size()
+	if lines <= 0 || size == 0 {
+		return uint64(size), nil
 	}
 	seen := 0
-	for index := len(data) - 1; index >= 0; index-- {
-		if data[index] != '\n' {
-			continue
+	buffer := make([]byte, runLogFileChunkBytes)
+	for end := size; end > 0; {
+		start := max(int64(0), end-int64(len(buffer)))
+		chunk := buffer[:end-start]
+		if _, err := file.ReadAt(chunk, start); err != nil && !errors.Is(err, io.EOF) {
+			return 0, err
 		}
-		if index == len(data)-1 {
-			continue
+		for index := len(chunk) - 1; index >= 0; index-- {
+			position := start + int64(index)
+			if chunk[index] != '\n' || position == size-1 {
+				continue
+			}
+			seen++
+			if seen == lines {
+				return uint64(position + 1), nil
+			}
 		}
-		seen++
-		if seen == lines {
-			return uint64(index + 1), nil
-		}
+		end = start
 	}
 	return 0, nil
 }

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -482,16 +482,33 @@ func readRunLogChunkFromOffset(path string, offset uint64) (string, uint64, bool
 		return "", offset, false, err
 	}
 	nextOffset := offset + uint64(n)
-	if nextOffset < uint64(info.Size()) && !utf8.Valid(data[:n]) {
-		for trim := 1; trim < utf8.UTFMax && trim < n; trim++ {
-			if utf8.Valid(data[:n-trim]) {
-				n -= trim
-				nextOffset = offset + uint64(n)
-				break
-			}
+	atSnapshotEnd := nextOffset >= uint64(info.Size())
+	if !utf8.Valid(data[:n]) {
+		prefixLength, incomplete := incompleteUTF8SuffixStart(data[:n])
+		if !incomplete {
+			return "", offset, false, fmt.Errorf("run log contains invalid UTF-8 at or after byte offset %d", offset)
+		}
+		n = prefixLength
+		nextOffset = offset + uint64(n)
+		if atSnapshotEnd {
+			return string(data[:n]), nextOffset, true, nil
 		}
 	}
 	return string(data[:n]), nextOffset, nextOffset >= uint64(info.Size()), nil
+}
+
+func incompleteUTF8SuffixStart(data []byte) (int, bool) {
+	if len(data) == 0 || utf8.Valid(data) {
+		return len(data), false
+	}
+	start := len(data) - 1
+	for start > 0 && !utf8.RuneStart(data[start]) {
+		start--
+	}
+	if !utf8.RuneStart(data[start]) || utf8.FullRune(data[start:]) || !utf8.Valid(data[:start]) {
+		return 0, false
+	}
+	return start, true
 }
 
 func tailRunLogOffset(path string, lines int) (uint64, error) {

--- a/pkg/agentcompose/api/run_log_file_test.go
+++ b/pkg/agentcompose/api/run_log_file_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 
@@ -60,6 +61,50 @@ func TestReadRunLogChunkFromOffsetKeepsUTF8CodePointsIntact(t *testing.T) {
 	}
 	if !atEnd || first+second != want {
 		t.Fatalf("reassembled UTF-8 log end/length = %t/%d, want true/%d", atEnd, len(first+second), len(want))
+	}
+}
+
+func TestReadRunLogChunkFromOffsetDefersIncompleteUTF8AtEOF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.log")
+	runeBytes := []byte("界")
+	initial := append([]byte("ready "), runeBytes[:2]...)
+	if err := os.WriteFile(path, initial, 0o600); err != nil {
+		t.Fatalf("write partial log: %v", err)
+	}
+	first, offset, atEnd, err := readRunLogChunkFromOffset(path, 0)
+	if err != nil {
+		t.Fatalf("read partial log: %v", err)
+	}
+	if first != "ready " || offset != uint64(len("ready ")) || !atEnd || !utf8.ValidString(first) {
+		t.Fatalf("partial chunk/data offset/end/valid = %q/%d/%t/%t", first, offset, atEnd, utf8.ValidString(first))
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open partial log for append: %v", err)
+	}
+	if _, err := file.Write(runeBytes[2:]); err != nil {
+		_ = file.Close()
+		t.Fatalf("complete log rune: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close completed log: %v", err)
+	}
+	second, next, atEnd, err := readRunLogChunkFromOffset(path, offset)
+	if err != nil {
+		t.Fatalf("read completed rune: %v", err)
+	}
+	if second != "界" || next != uint64(len(initial)+1) || !atEnd || !utf8.ValidString(second) {
+		t.Fatalf("completed chunk/data offset/end/valid = %q/%d/%t/%t", second, next, atEnd, utf8.ValidString(second))
+	}
+}
+
+func TestReadRunLogChunkFromOffsetRejectsInvalidUTF8(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.log")
+	if err := os.WriteFile(path, []byte{'o', 'k', 0xff}, 0o600); err != nil {
+		t.Fatalf("write invalid log: %v", err)
+	}
+	if _, _, _, err := readRunLogChunkFromOffset(path, 0); err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
+		t.Fatalf("read invalid log error = %v", err)
 	}
 }
 

--- a/pkg/agentcompose/api/run_log_file_test.go
+++ b/pkg/agentcompose/api/run_log_file_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestReadRunLogChunkFromOffsetKeepsFramesBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.log")
+	want := strings.Repeat("a", runLogFileChunkBytes*2+137)
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	var got strings.Builder
+	var offset uint64
+	for {
+		chunk, next, atEnd, err := readRunLogChunkFromOffset(path, offset)
+		if err != nil {
+			t.Fatalf("read chunk at %d: %v", offset, err)
+		}
+		if len(chunk) > runLogFileChunkBytes || next < offset {
+			t.Fatalf("chunk length/next = %d/%d at %d", len(chunk), next, offset)
+		}
+		got.WriteString(chunk)
+		offset = next
+		if atEnd {
+			break
+		}
+	}
+	if got.String() != want {
+		t.Fatalf("reassembled log length = %d, want %d", got.Len(), len(want))
+	}
+}
+
+func TestReadRunLogChunkFromOffsetKeepsUTF8CodePointsIntact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.log")
+	want := strings.Repeat("a", runLogFileChunkBytes-1) + "界" + strings.Repeat("b", 32)
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	first, offset, atEnd, err := readRunLogChunkFromOffset(path, 0)
+	if err != nil {
+		t.Fatalf("read first chunk: %v", err)
+	}
+	if atEnd || !strings.HasSuffix(first, "a") || len(first) != runLogFileChunkBytes-1 {
+		t.Fatalf("first chunk end/length = %t/%d", atEnd, len(first))
+	}
+	second, _, atEnd, err := readRunLogChunkFromOffset(path, offset)
+	if err != nil {
+		t.Fatalf("read second chunk: %v", err)
+	}
+	if !atEnd || first+second != want {
+		t.Fatalf("reassembled UTF-8 log end/length = %t/%d, want true/%d", atEnd, len(first+second), len(want))
+	}
+}
+
+func TestTailRunLogOffsetScansBackwardsInBoundedChunks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.log")
+	prefix := strings.Repeat("x", runLogFileChunkBytes+17)
+	data := prefix + "\nlast-one\nlast-two\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	offset, err := tailRunLogOffset(path, 2)
+	if err != nil {
+		t.Fatalf("tail offset: %v", err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.Seek(int64(offset), io.SeekStart); err != nil {
+		t.Fatalf("seek tail: %v", err)
+	}
+	tail, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("read tail: %v", err)
+	}
+	if string(tail) != "last-one\nlast-two\n" {
+		t.Fatalf("tail = %q", tail)
+	}
+}
+
+func TestFollowRunLogsStreamsMetadataAndBoundedFrames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.log")
+	want := strings.Repeat("log-line\n", runLogFileChunkBytes/4)
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	store := &apiProjectRunStore{runs: map[string]domain.ProjectRunRecord{
+		"run-large": {RunID: "run-large", ProjectID: "project-1", AgentName: "reviewer", Prompt: "inspect the repository", Status: domain.ProjectRunStatusSucceeded, LogsPath: path},
+	}}
+	client, closeServer := newRunHandlerTestClient(t, NewRunHandler(nil, store))
+	defer closeServer()
+	stream, err := client.FollowRunLogs(context.Background(), connect.NewRequest(&agentcomposev2.FollowRunLogsRequest{
+		ProjectId: "project-1", RunId: "run-large", IncludeMetadata: true,
+	}))
+	if err != nil {
+		t.Fatalf("FollowRunLogs returned error: %v", err)
+	}
+	var data strings.Builder
+	var metadata, final bool
+	for stream.Receive() {
+		chunk := stream.Msg()
+		if chunk.GetRun() != nil && chunk.GetPrompt() == "inspect the repository" {
+			metadata = true
+		}
+		if len(chunk.GetData()) > runLogFileChunkBytes {
+			t.Fatalf("streamed chunk length = %d", len(chunk.GetData()))
+		}
+		data.WriteString(chunk.GetData())
+		final = final || chunk.GetIsFinal()
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("FollowRunLogs receive error: %v", err)
+	}
+	if !metadata || !final || data.String() != want {
+		t.Fatalf("metadata/final/data length = %t/%t/%d, want true/true/%d", metadata, final, data.Len(), len(want))
+	}
+	assertSchedulerStreamHeaders(t, stream.ResponseHeader())
+}
+
+func TestFollowRunLogsExplicitZeroTailSkipsExistingOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.log")
+	if err := os.WriteFile(path, []byte("existing output\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	store := &apiProjectRunStore{runs: map[string]domain.ProjectRunRecord{
+		"run-tail-zero": {RunID: "run-tail-zero", ProjectID: "project-1", AgentName: "reviewer", Prompt: "prompt", Status: domain.ProjectRunStatusSucceeded, LogsPath: path},
+	}}
+	client, closeServer := newRunHandlerTestClient(t, NewRunHandler(nil, store))
+	defer closeServer()
+	stream, err := client.FollowRunLogs(context.Background(), connect.NewRequest(&agentcomposev2.FollowRunLogsRequest{
+		ProjectId: "project-1", RunId: "run-tail-zero", TailSet: true, IncludeMetadata: true,
+	}))
+	if err != nil {
+		t.Fatalf("FollowRunLogs returned error: %v", err)
+	}
+	var data strings.Builder
+	var metadata, final bool
+	for stream.Receive() {
+		chunk := stream.Msg()
+		data.WriteString(chunk.GetData())
+		metadata = metadata || chunk.GetRun() != nil
+		final = final || chunk.GetIsFinal()
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("FollowRunLogs receive error: %v", err)
+	}
+	if data.Len() != 0 || !metadata || !final {
+		t.Fatalf("zero-tail data/metadata/final = %q/%t/%t", data.String(), metadata, final)
+	}
+}

--- a/pkg/loaders/run_query.go
+++ b/pkg/loaders/run_query.go
@@ -19,12 +19,23 @@ type LoaderRunKey struct {
 }
 
 type LoaderEventPageFilter struct {
-	LoaderIDs       []string
-	RequireTrigger  bool
-	TriggerID       string
-	RunID           string
-	BeforeCreatedAt time.Time
-	BeforeLoaderID  string
-	BeforeEventID   string
-	Limit           int
+	LoaderIDs        []string
+	RequireTrigger   bool
+	TriggerID        string
+	RunID            string
+	BeforeCreatedAt  time.Time
+	BeforeLoaderID   string
+	BeforeEventID    string
+	AfterCreatedAt   time.Time
+	AfterLoaderID    string
+	AfterEventID     string
+	FromCreatedAt    time.Time
+	FromLoaderID     string
+	FromEventID      string
+	ThroughCreatedAt time.Time
+	ThroughLoaderID  string
+	ThroughEventID   string
+	Ascending        bool
+	Offset           int
+	Limit            int
 }

--- a/pkg/storage/configstore/loader_event_page.go
+++ b/pkg/storage/configstore/loader_event_page.go
@@ -42,8 +42,32 @@ func (s *loaderStore) ListLoaderEventsPage(ctx context.Context, filter loaders.L
 		beforeMillis := filter.BeforeCreatedAt.UTC().UnixMilli()
 		args = append(args, beforeMillis, beforeMillis, strings.TrimSpace(filter.BeforeLoaderID), strings.TrimSpace(filter.BeforeLoaderID), strings.TrimSpace(filter.BeforeEventID))
 	}
-	query += ` ORDER BY e.created_at DESC, e.loader_id DESC, e.event_id DESC LIMIT ?`
+	if !filter.AfterCreatedAt.IsZero() {
+		query += ` AND (e.created_at > ? OR (e.created_at = ? AND (e.loader_id > ? OR (e.loader_id = ? AND e.event_id > ?))))`
+		afterMillis := filter.AfterCreatedAt.UTC().UnixMilli()
+		args = append(args, afterMillis, afterMillis, strings.TrimSpace(filter.AfterLoaderID), strings.TrimSpace(filter.AfterLoaderID), strings.TrimSpace(filter.AfterEventID))
+	}
+	if !filter.FromCreatedAt.IsZero() {
+		query += ` AND (e.created_at > ? OR (e.created_at = ? AND (e.loader_id > ? OR (e.loader_id = ? AND e.event_id >= ?))))`
+		fromMillis := filter.FromCreatedAt.UTC().UnixMilli()
+		args = append(args, fromMillis, fromMillis, strings.TrimSpace(filter.FromLoaderID), strings.TrimSpace(filter.FromLoaderID), strings.TrimSpace(filter.FromEventID))
+	}
+	if !filter.ThroughCreatedAt.IsZero() {
+		query += ` AND (e.created_at < ? OR (e.created_at = ? AND (e.loader_id < ? OR (e.loader_id = ? AND e.event_id <= ?))))`
+		throughMillis := filter.ThroughCreatedAt.UTC().UnixMilli()
+		args = append(args, throughMillis, throughMillis, strings.TrimSpace(filter.ThroughLoaderID), strings.TrimSpace(filter.ThroughLoaderID), strings.TrimSpace(filter.ThroughEventID))
+	}
+	if filter.Ascending {
+		query += ` ORDER BY e.created_at ASC, e.loader_id ASC, e.event_id ASC`
+	} else {
+		query += ` ORDER BY e.created_at DESC, e.loader_id DESC, e.event_id DESC`
+	}
+	query += ` LIMIT ?`
 	args = append(args, filter.Limit)
+	if filter.Offset > 0 {
+		query += ` OFFSET ?`
+		args = append(args, filter.Offset)
+	}
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query loader event page: %w", err)

--- a/pkg/storage/configstore/loader_event_page_test.go
+++ b/pkg/storage/configstore/loader_event_page_test.go
@@ -55,3 +55,35 @@ func TestLoaderEventPageOnlyReturnsEventsJoinedToTriggerRuns(t *testing.T) {
 		t.Fatalf("run filter=%#v err=%v", byRun, err)
 	}
 }
+
+func TestLoaderEventPageSupportsTailBoundaryAndAscendingRange(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertManagedLoader(ctx, domain.Loader{Summary: domain.LoaderSummary{ID: "loader-a", Runtime: domain.LoaderRuntimeScheduler, ManagedProjectID: "project-1", ManagedAgentName: "agent-1", ManagedSchedulerID: "scheduler-1"}, Script: "function main() {}"}); err != nil {
+		t.Fatalf("upsert loader: %v", err)
+	}
+	startedAt := time.UnixMilli(1_730_000_000_000).UTC()
+	if err := store.CreateLoaderRun(ctx, domain.LoaderRunSummary{ID: "run-a", LoaderID: "loader-a", TriggerID: "trigger-a", Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	for index, id := range []string{"event-1", "event-2", "event-3", "event-4"} {
+		if err := store.AddLoaderEvent(ctx, domain.LoaderEvent{LoaderID: "loader-a", ID: id, RunID: "run-a", TriggerID: "trigger-a", Type: "loader.log", CreatedAt: startedAt.Add(time.Duration(index) * time.Second)}); err != nil {
+			t.Fatalf("add event %s: %v", id, err)
+		}
+	}
+	boundary, err := store.ListLoaderEventsPage(ctx, loaders.LoaderEventPageFilter{LoaderIDs: []string{"loader-a"}, RequireTrigger: true, Limit: 1, Offset: 1})
+	if err != nil || len(boundary) != 1 || boundary[0].ID != "event-3" {
+		t.Fatalf("tail boundary = %#v, err=%v", boundary, err)
+	}
+	page, err := store.ListLoaderEventsPage(ctx, loaders.LoaderEventPageFilter{
+		LoaderIDs: []string{"loader-a"}, RequireTrigger: true, Ascending: true, Limit: 10,
+		AfterCreatedAt: boundary[0].CreatedAt, AfterLoaderID: boundary[0].LoaderID, AfterEventID: boundary[0].ID,
+		ThroughCreatedAt: startedAt.Add(3 * time.Second), ThroughLoaderID: "loader-a", ThroughEventID: "event-4",
+	})
+	if err != nil || len(page) != 1 || page[0].ID != "event-4" {
+		t.Fatalf("ascending bounded page = %#v, err=%v", page, err)
+	}
+}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -7554,12 +7554,15 @@ func (x *ListRunsResponse) GetRuns() []*RunSummary {
 }
 
 type FollowRunLogsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ProjectId     string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
-	RunId         string                 `protobuf:"bytes,2,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
-	TailLines     uint32                 `protobuf:"varint,3,opt,name=tail_lines,json=tailLines,proto3" json:"tail_lines,omitempty"`
-	StartOffset   uint64                 `protobuf:"varint,4,opt,name=start_offset,json=startOffset,proto3" json:"start_offset,omitempty"`
-	Follow        bool                   `protobuf:"varint,5,opt,name=follow,proto3" json:"follow,omitempty"`
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ProjectId       string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	RunId           string                 `protobuf:"bytes,2,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	TailLines       uint32                 `protobuf:"varint,3,opt,name=tail_lines,json=tailLines,proto3" json:"tail_lines,omitempty"`
+	StartOffset     uint64                 `protobuf:"varint,4,opt,name=start_offset,json=startOffset,proto3" json:"start_offset,omitempty"`
+	Follow          bool                   `protobuf:"varint,5,opt,name=follow,proto3" json:"follow,omitempty"`
+	IncludeMetadata bool                   `protobuf:"varint,6,opt,name=include_metadata,json=includeMetadata,proto3" json:"include_metadata,omitempty"`
+	// Distinguishes an explicit zero-line tail from the default full history.
+	TailSet       bool `protobuf:"varint,7,opt,name=tail_set,json=tailSet,proto3" json:"tail_set,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7629,6 +7632,20 @@ func (x *FollowRunLogsRequest) GetFollow() bool {
 	return false
 }
 
+func (x *FollowRunLogsRequest) GetIncludeMetadata() bool {
+	if x != nil {
+		return x.IncludeMetadata
+	}
+	return false
+}
+
+func (x *FollowRunLogsRequest) GetTailSet() bool {
+	if x != nil {
+		return x.TailSet
+	}
+	return false
+}
+
 type RunLogChunk struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Data          string                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
@@ -7636,6 +7653,8 @@ type RunLogChunk struct {
 	IsFinal       bool                   `protobuf:"varint,3,opt,name=is_final,json=isFinal,proto3" json:"is_final,omitempty"`
 	RunStatus     RunStatus              `protobuf:"varint,4,opt,name=run_status,json=runStatus,proto3,enum=agentcompose.v2.RunStatus" json:"run_status,omitempty"`
 	CreatedAt     string                 `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	Run           *RunSummary            `protobuf:"bytes,6,opt,name=run,proto3" json:"run,omitempty"`
+	Prompt        string                 `protobuf:"bytes,7,opt,name=prompt,proto3" json:"prompt,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7701,6 +7720,20 @@ func (x *RunLogChunk) GetRunStatus() RunStatus {
 func (x *RunLogChunk) GetCreatedAt() string {
 	if x != nil {
 		return x.CreatedAt
+	}
+	return ""
+}
+
+func (x *RunLogChunk) GetRun() *RunSummary {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+func (x *RunLogChunk) GetPrompt() string {
+	if x != nil {
+		return x.Prompt
 	}
 	return ""
 }
@@ -17043,6 +17076,323 @@ func (x *GenerateLLMResponse) GetJson() string {
 	return ""
 }
 
+// StreamProjectSchedulerEventsRequest describes a finite scan of scheduler
+// trigger-run events. A zero tail returns the complete matching
+// history; callers that want no events should avoid starting the stream.
+type StreamProjectSchedulerEventsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	TriggerId     string                 `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	RunId         string                 `protobuf:"bytes,4,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	BatchSize     uint32                 `protobuf:"varint,5,opt,name=batch_size,json=batchSize,proto3" json:"batch_size,omitempty"`
+	Tail          uint32                 `protobuf:"varint,6,opt,name=tail,proto3" json:"tail,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamProjectSchedulerEventsRequest) Reset() {
+	*x = StreamProjectSchedulerEventsRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[221]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamProjectSchedulerEventsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamProjectSchedulerEventsRequest) ProtoMessage() {}
+
+func (x *StreamProjectSchedulerEventsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[221]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamProjectSchedulerEventsRequest.ProtoReflect.Descriptor instead.
+func (*StreamProjectSchedulerEventsRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{221}
+}
+
+func (x *StreamProjectSchedulerEventsRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *StreamProjectSchedulerEventsRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *StreamProjectSchedulerEventsRequest) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *StreamProjectSchedulerEventsRequest) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *StreamProjectSchedulerEventsRequest) GetBatchSize() uint32 {
+	if x != nil {
+		return x.BatchSize
+	}
+	return 0
+}
+
+func (x *StreamProjectSchedulerEventsRequest) GetTail() uint32 {
+	if x != nil {
+		return x.Tail
+	}
+	return 0
+}
+
+type StreamProjectSchedulerEventsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Events        []*SchedulerEvent      `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
+	Checkpoint    string                 `protobuf:"bytes,2,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
+	Complete      bool                   `protobuf:"varint,3,opt,name=complete,proto3" json:"complete,omitempty"`
+	EmittedCount  uint64                 `protobuf:"varint,4,opt,name=emitted_count,json=emittedCount,proto3" json:"emitted_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamProjectSchedulerEventsResponse) Reset() {
+	*x = StreamProjectSchedulerEventsResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[222]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamProjectSchedulerEventsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamProjectSchedulerEventsResponse) ProtoMessage() {}
+
+func (x *StreamProjectSchedulerEventsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[222]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamProjectSchedulerEventsResponse.ProtoReflect.Descriptor instead.
+func (*StreamProjectSchedulerEventsResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{222}
+}
+
+func (x *StreamProjectSchedulerEventsResponse) GetEvents() []*SchedulerEvent {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
+func (x *StreamProjectSchedulerEventsResponse) GetCheckpoint() string {
+	if x != nil {
+		return x.Checkpoint
+	}
+	return ""
+}
+
+func (x *StreamProjectSchedulerEventsResponse) GetComplete() bool {
+	if x != nil {
+		return x.Complete
+	}
+	return false
+}
+
+func (x *StreamProjectSchedulerEventsResponse) GetEmittedCount() uint64 {
+	if x != nil {
+		return x.EmittedCount
+	}
+	return 0
+}
+
+// StreamSchedulerRunsRequest describes a finite scan of scheduler trigger runs.
+// limit is the final result limit; zero means all.
+type StreamSchedulerRunsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	TriggerId     string                 `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	Status        SchedulerRunStatus     `protobuf:"varint,4,opt,name=status,proto3,enum=agentcompose.v2.SchedulerRunStatus" json:"status,omitempty"`
+	BatchSize     uint32                 `protobuf:"varint,5,opt,name=batch_size,json=batchSize,proto3" json:"batch_size,omitempty"`
+	Limit         uint32                 `protobuf:"varint,6,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamSchedulerRunsRequest) Reset() {
+	*x = StreamSchedulerRunsRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[223]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamSchedulerRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamSchedulerRunsRequest) ProtoMessage() {}
+
+func (x *StreamSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[223]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamSchedulerRunsRequest.ProtoReflect.Descriptor instead.
+func (*StreamSchedulerRunsRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{223}
+}
+
+func (x *StreamSchedulerRunsRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *StreamSchedulerRunsRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+func (x *StreamSchedulerRunsRequest) GetTriggerId() string {
+	if x != nil {
+		return x.TriggerId
+	}
+	return ""
+}
+
+func (x *StreamSchedulerRunsRequest) GetStatus() SchedulerRunStatus {
+	if x != nil {
+		return x.Status
+	}
+	return SchedulerRunStatus_SCHEDULER_RUN_STATUS_UNSPECIFIED
+}
+
+func (x *StreamSchedulerRunsRequest) GetBatchSize() uint32 {
+	if x != nil {
+		return x.BatchSize
+	}
+	return 0
+}
+
+func (x *StreamSchedulerRunsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type StreamSchedulerRunsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Runs          []*SchedulerRun        `protobuf:"bytes,1,rep,name=runs,proto3" json:"runs,omitempty"`
+	Checkpoint    string                 `protobuf:"bytes,2,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
+	Complete      bool                   `protobuf:"varint,3,opt,name=complete,proto3" json:"complete,omitempty"`
+	EmittedCount  uint64                 `protobuf:"varint,4,opt,name=emitted_count,json=emittedCount,proto3" json:"emitted_count,omitempty"`
+	Truncated     bool                   `protobuf:"varint,5,opt,name=truncated,proto3" json:"truncated,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamSchedulerRunsResponse) Reset() {
+	*x = StreamSchedulerRunsResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[224]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamSchedulerRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamSchedulerRunsResponse) ProtoMessage() {}
+
+func (x *StreamSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[224]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamSchedulerRunsResponse.ProtoReflect.Descriptor instead.
+func (*StreamSchedulerRunsResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{224}
+}
+
+func (x *StreamSchedulerRunsResponse) GetRuns() []*SchedulerRun {
+	if x != nil {
+		return x.Runs
+	}
+	return nil
+}
+
+func (x *StreamSchedulerRunsResponse) GetCheckpoint() string {
+	if x != nil {
+		return x.Checkpoint
+	}
+	return ""
+}
+
+func (x *StreamSchedulerRunsResponse) GetComplete() bool {
+	if x != nil {
+		return x.Complete
+	}
+	return false
+}
+
+func (x *StreamSchedulerRunsResponse) GetEmittedCount() uint64 {
+	if x != nil {
+		return x.EmittedCount
+	}
+	return 0
+}
+
+func (x *StreamSchedulerRunsResponse) GetTruncated() bool {
+	if x != nil {
+		return x.Truncated
+	}
+	return false
+}
+
 var File_agentcompose_v2_agentcompose_proto protoreflect.FileDescriptor
 
 const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
@@ -17640,7 +17990,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"sandbox_id\x18\v \x01(\tR\tsandboxIdJ\x04\b\x03\x10\x04R\n" +
 	"session_id\"C\n" +
 	"\x10ListRunsResponse\x12/\n" +
-	"\x04runs\x18\x01 \x03(\v2\x1b.agentcompose.v2.RunSummaryR\x04runs\"\xa6\x01\n" +
+	"\x04runs\x18\x01 \x03(\v2\x1b.agentcompose.v2.RunSummaryR\x04runs\"\xec\x01\n" +
 	"\x14FollowRunLogsRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x15\n" +
@@ -17648,7 +17998,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"tail_lines\x18\x03 \x01(\rR\ttailLines\x12!\n" +
 	"\fstart_offset\x18\x04 \x01(\x04R\vstartOffset\x12\x16\n" +
-	"\x06follow\x18\x05 \x01(\bR\x06follow\"\xae\x01\n" +
+	"\x06follow\x18\x05 \x01(\bR\x06follow\x12)\n" +
+	"\x10include_metadata\x18\x06 \x01(\bR\x0fincludeMetadata\x12\x19\n" +
+	"\btail_set\x18\a \x01(\bR\atailSet\"\xf5\x01\n" +
 	"\vRunLogChunk\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\tR\x04data\x12\x16\n" +
 	"\x06offset\x18\x02 \x01(\x04R\x06offset\x12\x19\n" +
@@ -17656,7 +18008,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"run_status\x18\x04 \x01(\x0e2\x1a.agentcompose.v2.RunStatusR\trunStatus\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\x05 \x01(\tR\tcreatedAt\"?\n" +
+	"created_at\x18\x05 \x01(\tR\tcreatedAt\x12-\n" +
+	"\x03run\x18\x06 \x01(\v2\x1b.agentcompose.v2.RunSummaryR\x03run\x12\x16\n" +
+	"\x06prompt\x18\a \x01(\tR\x06prompt\"?\n" +
 	"\x0eStopRunRequest\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\"f\n" +
@@ -18479,7 +18833,42 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\vresponse_id\x18\x03 \x01(\tR\n" +
 	"responseId\x12#\n" +
 	"\rfinish_reason\x18\x04 \x01(\tR\ffinishReason\x12\x12\n" +
-	"\x04json\x18\x05 \x01(\tR\x04json*\x98\x01\n" +
+	"\x04json\x18\x05 \x01(\tR\x04json\"\xe4\x01\n" +
+	"#StreamProjectSchedulerEventsRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x03 \x01(\tR\ttriggerId\x12\x15\n" +
+	"\x06run_id\x18\x04 \x01(\tR\x05runId\x12\x1d\n" +
+	"\n" +
+	"batch_size\x18\x05 \x01(\rR\tbatchSize\x12\x12\n" +
+	"\x04tail\x18\x06 \x01(\rR\x04tail\"\xc0\x01\n" +
+	"$StreamProjectSchedulerEventsResponse\x127\n" +
+	"\x06events\x18\x01 \x03(\v2\x1f.agentcompose.v2.SchedulerEventR\x06events\x12\x1e\n" +
+	"\n" +
+	"checkpoint\x18\x02 \x01(\tR\n" +
+	"checkpoint\x12\x1a\n" +
+	"\bcomplete\x18\x03 \x01(\bR\bcomplete\x12#\n" +
+	"\remitted_count\x18\x04 \x01(\x04R\femittedCount\"\x83\x02\n" +
+	"\x1aStreamSchedulerRunsRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12\x1d\n" +
+	"\n" +
+	"trigger_id\x18\x03 \x01(\tR\ttriggerId\x12;\n" +
+	"\x06status\x18\x04 \x01(\x0e2#.agentcompose.v2.SchedulerRunStatusR\x06status\x12\x1d\n" +
+	"\n" +
+	"batch_size\x18\x05 \x01(\rR\tbatchSize\x12\x14\n" +
+	"\x05limit\x18\x06 \x01(\rR\x05limit\"\xcf\x01\n" +
+	"\x1bStreamSchedulerRunsResponse\x121\n" +
+	"\x04runs\x18\x01 \x03(\v2\x1d.agentcompose.v2.SchedulerRunR\x04runs\x12\x1e\n" +
+	"\n" +
+	"checkpoint\x18\x02 \x01(\tR\n" +
+	"checkpoint\x12\x1a\n" +
+	"\bcomplete\x18\x03 \x01(\bR\bcomplete\x12#\n" +
+	"\remitted_count\x18\x04 \x01(\x04R\femittedCount\x12\x1c\n" +
+	"\ttruncated\x18\x05 \x01(\bR\ttruncated*\x98\x01\n" +
 	"\x19ProjectValidationSeverity\x12+\n" +
 	"'PROJECT_VALIDATION_SEVERITY_UNSPECIFIED\x10\x00\x12'\n" +
 	"#PROJECT_VALIDATION_SEVERITY_WARNING\x10\x01\x12%\n" +
@@ -18608,7 +18997,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"%SANDBOX_WATCH_EVENT_TYPE_CELL_STARTED\x10\x02\x12(\n" +
 	"$SANDBOX_WATCH_EVENT_TYPE_CELL_OUTPUT\x10\x03\x12+\n" +
 	"'SANDBOX_WATCH_EVENT_TYPE_CELL_COMPLETED\x10\x04\x12(\n" +
-	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xd3\x0f\n" +
+	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xd7\x11\n" +
 	"\x0eProjectService\x12d\n" +
 	"\x0fValidateProject\x12'.agentcompose.v2.ValidateProjectRequest\x1a(.agentcompose.v2.ValidateProjectResponse\x12[\n" +
 	"\fApplyProject\x12$.agentcompose.v2.ApplyProjectRequest\x1a%.agentcompose.v2.ApplyProjectResponse\x12U\n" +
@@ -18620,12 +19009,14 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\fGetScheduler\x12$.agentcompose.v2.GetSchedulerRequest\x1a%.agentcompose.v2.GetSchedulerResponse\x12a\n" +
 	"\x0eListSchedulers\x12&.agentcompose.v2.ListSchedulersRequest\x1a'.agentcompose.v2.ListSchedulersResponse\x12p\n" +
 	"\x13ListSchedulerEvents\x12+.agentcompose.v2.ListSchedulerEventsRequest\x1a,.agentcompose.v2.ListSchedulerEventsResponse\x12\x85\x01\n" +
-	"\x1aListProjectSchedulerEvents\x122.agentcompose.v2.ListProjectSchedulerEventsRequest\x1a3.agentcompose.v2.ListProjectSchedulerEventsResponse\x12d\n" +
+	"\x1aListProjectSchedulerEvents\x122.agentcompose.v2.ListProjectSchedulerEventsRequest\x1a3.agentcompose.v2.ListProjectSchedulerEventsResponse\x12\x8d\x01\n" +
+	"\x1cStreamProjectSchedulerEvents\x124.agentcompose.v2.StreamProjectSchedulerEventsRequest\x1a5.agentcompose.v2.StreamProjectSchedulerEventsResponse0\x01\x12d\n" +
 	"\x0fInvokeScheduler\x12'.agentcompose.v2.InvokeSchedulerRequest\x1a(.agentcompose.v2.InvokeSchedulerResponse\x12[\n" +
 	"\fRunScheduler\x12$.agentcompose.v2.RunSchedulerRequest\x1a%.agentcompose.v2.RunSchedulerResponse\x12j\n" +
 	"\x11StartSchedulerRun\x12).agentcompose.v2.StartSchedulerRunRequest\x1a*.agentcompose.v2.StartSchedulerRunResponse\x12d\n" +
 	"\x0fGetSchedulerRun\x12'.agentcompose.v2.GetSchedulerRunRequest\x1a(.agentcompose.v2.GetSchedulerRunResponse\x12j\n" +
-	"\x11ListSchedulerRuns\x12).agentcompose.v2.ListSchedulerRunsRequest\x1a*.agentcompose.v2.ListSchedulerRunsResponse\x12m\n" +
+	"\x11ListSchedulerRuns\x12).agentcompose.v2.ListSchedulerRunsRequest\x1a*.agentcompose.v2.ListSchedulerRunsResponse\x12r\n" +
+	"\x13StreamSchedulerRuns\x12+.agentcompose.v2.StreamSchedulerRunsRequest\x1a,.agentcompose.v2.StreamSchedulerRunsResponse0\x01\x12m\n" +
 	"\x12PruneSchedulerRuns\x12*.agentcompose.v2.PruneSchedulerRunsRequest\x1a+.agentcompose.v2.PruneSchedulerRunsResponse\x12g\n" +
 	"\x10StopSchedulerRun\x12(.agentcompose.v2.StopSchedulerRunRequest\x1a).agentcompose.v2.StopSchedulerRunResponse\x12p\n" +
 	"\x13SetSchedulerEnabled\x12+.agentcompose.v2.SetSchedulerEnabledRequest\x1a,.agentcompose.v2.SetSchedulerEnabledResponse\x12\x85\x01\n" +
@@ -18714,7 +19105,7 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 }
 
 var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 24)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 233)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 237)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),                // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),                      // 1: agentcompose.v2.ProjectChangeAction
@@ -18961,19 +19352,23 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*WatchSandboxResponse)(nil),                  // 242: agentcompose.v2.WatchSandboxResponse
 	(*GenerateLLMRequest)(nil),                    // 243: agentcompose.v2.GenerateLLMRequest
 	(*GenerateLLMResponse)(nil),                   // 244: agentcompose.v2.GenerateLLMResponse
-	nil,                                           // 245: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                                           // 246: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                                           // 247: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                                           // 248: agentcompose.v2.AttachHumanMessage.MetadataEntry
-	nil,                                           // 249: agentcompose.v2.AttachError.DetailsEntry
-	nil,                                           // 250: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                                           // 251: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                                           // 252: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                                           // 253: agentcompose.v2.Volume.LabelsEntry
-	nil,                                           // 254: agentcompose.v2.Volume.OptionsEntry
-	nil,                                           // 255: agentcompose.v2.Image.LabelsEntry
-	nil,                                           // 256: agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	(*timestamppb.Timestamp)(nil),                 // 257: google.protobuf.Timestamp
+	(*StreamProjectSchedulerEventsRequest)(nil),   // 245: agentcompose.v2.StreamProjectSchedulerEventsRequest
+	(*StreamProjectSchedulerEventsResponse)(nil),  // 246: agentcompose.v2.StreamProjectSchedulerEventsResponse
+	(*StreamSchedulerRunsRequest)(nil),            // 247: agentcompose.v2.StreamSchedulerRunsRequest
+	(*StreamSchedulerRunsResponse)(nil),           // 248: agentcompose.v2.StreamSchedulerRunsResponse
+	nil,                                           // 249: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                                           // 250: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                                           // 251: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                                           // 252: agentcompose.v2.AttachHumanMessage.MetadataEntry
+	nil,                                           // 253: agentcompose.v2.AttachError.DetailsEntry
+	nil,                                           // 254: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                                           // 255: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                                           // 256: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                                           // 257: agentcompose.v2.Volume.LabelsEntry
+	nil,                                           // 258: agentcompose.v2.Volume.OptionsEntry
+	nil,                                           // 259: agentcompose.v2.Image.LabelsEntry
+	nil,                                           // 260: agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	(*timestamppb.Timestamp)(nil),                 // 261: google.protobuf.Timestamp
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	79,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
@@ -19007,18 +19402,18 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	43,  // 28: agentcompose.v2.ProjectAgent.latest_run:type_name -> agentcompose.v2.ProjectAgentLatestRun
 	3,   // 29: agentcompose.v2.ProjectAgentLatestRun.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 30: agentcompose.v2.ProjectAgentLatestRun.source:type_name -> agentcompose.v2.RunSource
-	257, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
+	261, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
 	36,  // 32: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
 	44,  // 33: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	89,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
 	47,  // 35: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
 	90,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
-	257, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
-	257, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
-	257, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
+	261, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
+	261, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
+	261, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
 	49,  // 40: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
 	36,  // 41: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	257, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
+	261, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
 	52,  // 43: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
 	36,  // 44: agentcompose.v2.ListProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	52,  // 45: agentcompose.v2.ListProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
@@ -19040,8 +19435,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	36,  // 61: agentcompose.v2.StopSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
 	72,  // 62: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
 	5,   // 63: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
-	257, // 64: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
-	257, // 65: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
+	261, // 64: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
+	261, // 65: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
 	36,  // 66: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
 	44,  // 67: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	36,  // 68: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
@@ -19065,9 +19460,9 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	201, // 86: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
 	86,  // 87: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
 	86,  // 88: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
-	245, // 89: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	246, // 90: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	247, // 91: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	249, // 89: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	250, // 90: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	251, // 91: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
 	90,  // 92: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
 	91,  // 93: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
 	93,  // 94: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
@@ -19105,295 +19500,305 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	4,   // 126: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
 	135, // 127: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
 	3,   // 128: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
-	136, // 129: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
-	8,   // 130: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
-	257, // 131: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
-	112, // 132: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	112, // 133: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
-	20,  // 134: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
-	257, // 135: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
-	119, // 136: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
-	119, // 137: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
-	134, // 138: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
-	257, // 139: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	257, // 140: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
-	125, // 141: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
-	257, // 142: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
-	257, // 143: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
-	124, // 144: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
-	124, // 145: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	124, // 146: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	124, // 147: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	17,  // 148: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	133, // 149: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
-	133, // 150: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
-	133, // 151: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
-	133, // 152: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
-	133, // 153: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
-	133, // 154: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
-	133, // 155: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
-	133, // 156: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
-	133, // 157: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
-	4,   // 158: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
-	3,   // 159: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	135, // 160: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	138, // 161: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
-	139, // 162: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
-	86,  // 163: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
-	158, // 164: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
-	11,  // 165: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
-	13,  // 166: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	158, // 167: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
-	102, // 168: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	144, // 169: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
-	146, // 170: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	147, // 171: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	148, // 172: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	149, // 173: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	151, // 174: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	150, // 175: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	152, // 176: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	153, // 177: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	156, // 178: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	157, // 179: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	154, // 180: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	155, // 181: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	137, // 182: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
-	145, // 183: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	12,  // 184: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	145, // 185: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	248, // 186: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
-	135, // 187: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 188: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
-	102, // 189: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	158, // 190: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
-	135, // 191: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	249, // 192: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
-	139, // 193: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
-	14,  // 194: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	191, // 195: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
-	193, // 196: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 197: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	192, // 198: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	191, // 199: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
-	16,  // 200: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
-	196, // 201: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
-	14,  // 202: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	191, // 203: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
-	193, // 204: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
-	14,  // 205: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	250, // 206: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	14,  // 207: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	192, // 208: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
-	16,  // 209: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
-	191, // 210: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
-	18,  // 211: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 212: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
-	169, // 213: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	178, // 214: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
-	178, // 215: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
-	169, // 216: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
-	178, // 217: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
-	178, // 218: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	178, // 219: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
-	178, // 220: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
-	18,  // 221: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
-	21,  // 222: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	179, // 223: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
-	19,  // 224: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
-	190, // 225: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	251, // 226: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	252, // 227: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	190, // 228: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	190, // 229: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
-	190, // 230: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
-	190, // 231: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
-	190, // 232: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	253, // 233: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	254, // 234: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	14,  // 235: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
-	15,  // 236: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
-	192, // 237: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	194, // 238: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
-	195, // 239: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	255, // 240: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
-	14,  // 241: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
-	96,  // 242: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
-	135, // 243: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
-	22,  // 244: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
-	204, // 245: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
-	22,  // 246: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
-	207, // 247: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	257, // 248: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
-	208, // 249: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	208, // 250: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
-	86,  // 251: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	87,  // 252: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
-	86,  // 253: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
-	216, // 254: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	216, // 255: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	257, // 256: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	257, // 257: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
-	220, // 258: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
-	220, // 259: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
-	231, // 260: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	256, // 261: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	234, // 262: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
-	235, // 263: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	257, // 264: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	257, // 265: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
-	238, // 266: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
-	239, // 267: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
-	23,  // 268: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
-	124, // 269: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	238, // 270: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
-	239, // 271: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
-	13,  // 272: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
-	24,  // 273: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	26,  // 274: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	28,  // 275: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	30,  // 276: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	32,  // 277: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	34,  // 278: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	45,  // 279: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
-	48,  // 280: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
-	51,  // 281: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
-	54,  // 282: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
-	56,  // 283: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
-	58,  // 284: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
-	60,  // 285: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
-	62,  // 286: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
-	64,  // 287: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
-	66,  // 288: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
-	70,  // 289: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
-	73,  // 290: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
-	75,  // 291: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	96,  // 292: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	199, // 293: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	96,  // 294: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	99,  // 295: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
-	103, // 296: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	105, // 297: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	107, // 298: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	109, // 299: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	111, // 300: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
-	114, // 301: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
-	137, // 302: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	137, // 303: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	142, // 304: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
-	159, // 305: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	161, // 306: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	163, // 307: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	165, // 308: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	167, // 309: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	170, // 310: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	172, // 311: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	174, // 312: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	176, // 313: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	180, // 314: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	182, // 315: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	184, // 316: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	186, // 317: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	188, // 318: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	116, // 319: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	118, // 320: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
-	121, // 321: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	123, // 322: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
-	129, // 323: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
-	131, // 324: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
-	126, // 325: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	237, // 326: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	241, // 327: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
-	205, // 328: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
-	206, // 329: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
-	211, // 330: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
-	213, // 331: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
-	215, // 332: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
-	218, // 333: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	221, // 334: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
-	223, // 335: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
-	224, // 336: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
-	225, // 337: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
-	228, // 338: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
-	230, // 339: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
-	233, // 340: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	243, // 341: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	202, // 342: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	25,  // 343: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	27,  // 344: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	29,  // 345: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	31,  // 346: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	33,  // 347: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	35,  // 348: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	46,  // 349: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	50,  // 350: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	53,  // 351: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	55,  // 352: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
-	57,  // 353: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
-	59,  // 354: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
-	61,  // 355: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
-	63,  // 356: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
-	65,  // 357: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
-	69,  // 358: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
-	71,  // 359: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
-	74,  // 360: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	76,  // 361: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	97,  // 362: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	200, // 363: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	98,  // 364: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	100, // 365: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
-	104, // 366: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	106, // 367: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	108, // 368: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	110, // 369: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	113, // 370: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	115, // 371: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	140, // 372: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	141, // 373: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	143, // 374: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
-	160, // 375: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	162, // 376: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	164, // 377: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	166, // 378: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	168, // 379: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	171, // 380: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	173, // 381: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	175, // 382: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	177, // 383: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	181, // 384: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	183, // 385: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	185, // 386: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	187, // 387: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	189, // 388: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	117, // 389: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	120, // 390: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	122, // 391: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	128, // 392: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	130, // 393: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	132, // 394: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	127, // 395: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	240, // 396: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	242, // 397: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	209, // 398: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	210, // 399: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	212, // 400: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	214, // 401: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	217, // 402: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	219, // 403: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	222, // 404: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	227, // 405: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	227, // 406: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	226, // 407: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	229, // 408: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	232, // 409: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	236, // 410: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	244, // 411: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	203, // 412: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	343, // [343:413] is the sub-list for method output_type
-	273, // [273:343] is the sub-list for method input_type
-	273, // [273:273] is the sub-list for extension type_name
-	273, // [273:273] is the sub-list for extension extendee
-	0,   // [0:273] is the sub-list for field type_name
+	135, // 129: agentcompose.v2.RunLogChunk.run:type_name -> agentcompose.v2.RunSummary
+	136, // 130: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
+	8,   // 131: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
+	261, // 132: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
+	112, // 133: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	112, // 134: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
+	20,  // 135: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
+	261, // 136: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	119, // 137: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
+	119, // 138: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
+	134, // 139: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
+	261, // 140: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	261, // 141: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	125, // 142: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
+	261, // 143: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
+	261, // 144: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
+	124, // 145: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
+	124, // 146: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	124, // 147: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	124, // 148: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	17,  // 149: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
+	133, // 150: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
+	133, // 151: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 152: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 153: agentcompose.v2.SandboxStats.memory_percent:type_name -> agentcompose.v2.MetricValue
+	133, // 154: agentcompose.v2.SandboxStats.network_rx_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 155: agentcompose.v2.SandboxStats.network_tx_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 156: agentcompose.v2.SandboxStats.block_read_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 157: agentcompose.v2.SandboxStats.block_write_bytes:type_name -> agentcompose.v2.MetricValue
+	133, // 158: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
+	4,   // 159: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
+	3,   // 160: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
+	135, // 161: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
+	138, // 162: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
+	139, // 163: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
+	86,  // 164: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
+	158, // 165: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
+	11,  // 166: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
+	13,  // 167: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
+	158, // 168: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
+	102, // 169: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	144, // 170: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
+	146, // 171: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	147, // 172: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	148, // 173: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
+	149, // 174: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	151, // 175: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	150, // 176: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	152, // 177: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
+	153, // 178: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
+	156, // 179: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
+	157, // 180: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
+	154, // 181: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	155, // 182: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	137, // 183: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
+	145, // 184: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	12,  // 185: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	145, // 186: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	252, // 187: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	135, // 188: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
+	13,  // 189: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
+	102, // 190: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	158, // 191: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
+	135, // 192: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
+	253, // 193: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	139, // 194: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
+	14,  // 195: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	191, // 196: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
+	193, // 197: agentcompose.v2.ListImagesResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	14,  // 198: agentcompose.v2.PullImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	192, // 199: agentcompose.v2.PullImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	191, // 200: agentcompose.v2.PullImageResponse.image:type_name -> agentcompose.v2.Image
+	16,  // 201: agentcompose.v2.PullImageResponse.status:type_name -> agentcompose.v2.ImageOperationStatus
+	196, // 202: agentcompose.v2.PullImageResponse.progress:type_name -> agentcompose.v2.ImagePullProgress
+	14,  // 203: agentcompose.v2.InspectImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	191, // 204: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
+	193, // 205: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
+	14,  // 206: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	254, // 207: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	14,  // 208: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
+	192, // 209: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
+	16,  // 210: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
+	191, // 211: agentcompose.v2.BuildImageEvent.image:type_name -> agentcompose.v2.Image
+	18,  // 212: agentcompose.v2.CacheFilter.domain:type_name -> agentcompose.v2.CacheDomain
+	21,  // 213: agentcompose.v2.CacheFilter.status:type_name -> agentcompose.v2.CacheStatus
+	169, // 214: agentcompose.v2.ListCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	178, // 215: agentcompose.v2.ListCachesResponse.caches:type_name -> agentcompose.v2.CacheItem
+	178, // 216: agentcompose.v2.InspectCacheResponse.cache:type_name -> agentcompose.v2.CacheItem
+	169, // 217: agentcompose.v2.PruneCachesRequest.filter:type_name -> agentcompose.v2.CacheFilter
+	178, // 218: agentcompose.v2.PruneCachesResponse.matched:type_name -> agentcompose.v2.CacheItem
+	178, // 219: agentcompose.v2.PruneCachesResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	178, // 220: agentcompose.v2.RemoveCacheResponse.matched:type_name -> agentcompose.v2.CacheItem
+	178, // 221: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
+	18,  // 222: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
+	21,  // 223: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
+	179, // 224: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
+	19,  // 225: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
+	190, // 226: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
+	255, // 227: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	256, // 228: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	190, // 229: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	190, // 230: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
+	190, // 231: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
+	190, // 232: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
+	190, // 233: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
+	257, // 234: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	258, // 235: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	14,  // 236: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
+	15,  // 237: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
+	192, // 238: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
+	194, // 239: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
+	195, // 240: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
+	259, // 241: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	14,  // 242: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
+	96,  // 243: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
+	135, // 244: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	22,  // 245: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
+	204, // 246: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
+	22,  // 247: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
+	207, // 248: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
+	261, // 249: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	208, // 250: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	208, // 251: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
+	86,  // 252: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	87,  // 253: agentcompose.v2.UpdateGlobalEnvRequest.env:type_name -> agentcompose.v2.EnvVarUpdateSpec
+	86,  // 254: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
+	216, // 255: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	216, // 256: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
+	261, // 257: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	261, // 258: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	220, // 259: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
+	220, // 260: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
+	231, // 261: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
+	260, // 262: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	234, // 263: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
+	235, // 264: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
+	261, // 265: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	261, // 266: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	238, // 267: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
+	239, // 268: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
+	23,  // 269: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
+	124, // 270: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
+	238, // 271: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
+	239, // 272: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
+	13,  // 273: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
+	36,  // 274: agentcompose.v2.StreamProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	52,  // 275: agentcompose.v2.StreamProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
+	36,  // 276: agentcompose.v2.StreamSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	5,   // 277: agentcompose.v2.StreamSchedulerRunsRequest.status:type_name -> agentcompose.v2.SchedulerRunStatus
+	72,  // 278: agentcompose.v2.StreamSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
+	24,  // 279: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	26,  // 280: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	28,  // 281: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	30,  // 282: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	32,  // 283: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	34,  // 284: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	45,  // 285: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
+	48,  // 286: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
+	51,  // 287: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
+	54,  // 288: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
+	245, // 289: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:input_type -> agentcompose.v2.StreamProjectSchedulerEventsRequest
+	56,  // 290: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
+	58,  // 291: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
+	60,  // 292: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
+	62,  // 293: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
+	64,  // 294: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
+	247, // 295: agentcompose.v2.ProjectService.StreamSchedulerRuns:input_type -> agentcompose.v2.StreamSchedulerRunsRequest
+	66,  // 296: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
+	70,  // 297: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
+	73,  // 298: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
+	75,  // 299: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	96,  // 300: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	199, // 301: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
+	96,  // 302: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
+	99,  // 303: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
+	103, // 304: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	105, // 305: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	107, // 306: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	109, // 307: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	111, // 308: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
+	114, // 309: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
+	137, // 310: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	137, // 311: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
+	142, // 312: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
+	159, // 313: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	161, // 314: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	163, // 315: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	165, // 316: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	167, // 317: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	170, // 318: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	172, // 319: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	174, // 320: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	176, // 321: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	180, // 322: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	182, // 323: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	184, // 324: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	186, // 325: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	188, // 326: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	116, // 327: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	118, // 328: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
+	121, // 329: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	123, // 330: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
+	129, // 331: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
+	131, // 332: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
+	126, // 333: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
+	237, // 334: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	241, // 335: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	205, // 336: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
+	206, // 337: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
+	211, // 338: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
+	213, // 339: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
+	215, // 340: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
+	218, // 341: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	221, // 342: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
+	223, // 343: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
+	224, // 344: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
+	225, // 345: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
+	228, // 346: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
+	230, // 347: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
+	233, // 348: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
+	243, // 349: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	202, // 350: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	25,  // 351: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	27,  // 352: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	29,  // 353: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	31,  // 354: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	33,  // 355: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	35,  // 356: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	46,  // 357: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	50,  // 358: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	53,  // 359: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	55,  // 360: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
+	246, // 361: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:output_type -> agentcompose.v2.StreamProjectSchedulerEventsResponse
+	57,  // 362: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
+	59,  // 363: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	61,  // 364: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	63,  // 365: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	65,  // 366: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	248, // 367: agentcompose.v2.ProjectService.StreamSchedulerRuns:output_type -> agentcompose.v2.StreamSchedulerRunsResponse
+	69,  // 368: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
+	71,  // 369: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	74,  // 370: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	76,  // 371: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	97,  // 372: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	200, // 373: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
+	98,  // 374: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
+	100, // 375: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
+	104, // 376: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	106, // 377: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	108, // 378: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	110, // 379: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	113, // 380: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	115, // 381: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	140, // 382: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	141, // 383: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
+	143, // 384: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
+	160, // 385: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	162, // 386: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	164, // 387: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	166, // 388: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	168, // 389: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	171, // 390: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	173, // 391: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	175, // 392: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	177, // 393: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	181, // 394: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	183, // 395: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	185, // 396: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	187, // 397: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	189, // 398: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	117, // 399: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	120, // 400: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	122, // 401: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	128, // 402: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	130, // 403: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	132, // 404: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	127, // 405: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	240, // 406: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	242, // 407: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	209, // 408: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	210, // 409: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	212, // 410: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	214, // 411: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	217, // 412: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	219, // 413: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	222, // 414: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	227, // 415: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	227, // 416: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	226, // 417: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	229, // 418: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	232, // 419: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	236, // 420: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	244, // 421: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	203, // 422: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	351, // [351:423] is the sub-list for method output_type
+	279, // [279:351] is the sub-list for method input_type
+	279, // [279:279] is the sub-list for extension type_name
+	279, // [279:279] is the sub-list for extension extendee
+	0,   // [0:279] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }
@@ -19450,7 +19855,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
 			NumEnums:      24,
-			NumMessages:   233,
+			NumMessages:   237,
 			NumExtensions: 0,
 			NumServices:   12,
 		},

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -17,11 +17,13 @@ service ProjectService {
   rpc ListSchedulers(ListSchedulersRequest) returns (ListSchedulersResponse);
   rpc ListSchedulerEvents(ListSchedulerEventsRequest) returns (ListSchedulerEventsResponse);
   rpc ListProjectSchedulerEvents(ListProjectSchedulerEventsRequest) returns (ListProjectSchedulerEventsResponse);
+  rpc StreamProjectSchedulerEvents(StreamProjectSchedulerEventsRequest) returns (stream StreamProjectSchedulerEventsResponse);
   rpc InvokeScheduler(InvokeSchedulerRequest) returns (InvokeSchedulerResponse);
   rpc RunScheduler(RunSchedulerRequest) returns (RunSchedulerResponse);
   rpc StartSchedulerRun(StartSchedulerRunRequest) returns (StartSchedulerRunResponse);
   rpc GetSchedulerRun(GetSchedulerRunRequest) returns (GetSchedulerRunResponse);
   rpc ListSchedulerRuns(ListSchedulerRunsRequest) returns (ListSchedulerRunsResponse);
+  rpc StreamSchedulerRuns(StreamSchedulerRunsRequest) returns (stream StreamSchedulerRunsResponse);
   rpc PruneSchedulerRuns(PruneSchedulerRunsRequest) returns (PruneSchedulerRunsResponse);
   rpc StopSchedulerRun(StopSchedulerRunRequest) returns (StopSchedulerRunResponse);
   rpc SetSchedulerEnabled(SetSchedulerEnabledRequest) returns (SetSchedulerEnabledResponse);
@@ -962,6 +964,9 @@ message FollowRunLogsRequest {
   uint32 tail_lines = 3;
   uint64 start_offset = 4;
   bool follow = 5;
+  bool include_metadata = 6;
+  // Distinguishes an explicit zero-line tail from the default full history.
+  bool tail_set = 7;
 }
 
 message RunLogChunk {
@@ -970,6 +975,8 @@ message RunLogChunk {
   bool is_final = 3;
   RunStatus run_status = 4;
   string created_at = 5;
+  RunSummary run = 6;
+  string prompt = 7;
 }
 
 message StopRunRequest {
@@ -1887,4 +1894,42 @@ message GenerateLLMResponse {
   string response_id = 3;
   string finish_reason = 4;
   string json = 5;
+}
+
+// StreamProjectSchedulerEventsRequest describes a finite scan of scheduler
+// trigger-run events. A zero tail returns the complete matching
+// history; callers that want no events should avoid starting the stream.
+message StreamProjectSchedulerEventsRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  string trigger_id = 3;
+  string run_id = 4;
+  uint32 batch_size = 5;
+  uint32 tail = 6;
+}
+
+message StreamProjectSchedulerEventsResponse {
+  repeated SchedulerEvent events = 1;
+  string checkpoint = 2;
+  bool complete = 3;
+  uint64 emitted_count = 4;
+}
+
+// StreamSchedulerRunsRequest describes a finite scan of scheduler trigger runs.
+// limit is the final result limit; zero means all.
+message StreamSchedulerRunsRequest {
+  ProjectRef project = 1;
+  string agent_name = 2;
+  string trigger_id = 3;
+  SchedulerRunStatus status = 4;
+  uint32 batch_size = 5;
+  uint32 limit = 6;
+}
+
+message StreamSchedulerRunsResponse {
+  repeated SchedulerRun runs = 1;
+  string checkpoint = 2;
+  bool complete = 3;
+  uint64 emitted_count = 4;
+  bool truncated = 5;
 }

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -85,6 +85,9 @@ const (
 	// ProjectServiceListProjectSchedulerEventsProcedure is the fully-qualified name of the
 	// ProjectService's ListProjectSchedulerEvents RPC.
 	ProjectServiceListProjectSchedulerEventsProcedure = "/agentcompose.v2.ProjectService/ListProjectSchedulerEvents"
+	// ProjectServiceStreamProjectSchedulerEventsProcedure is the fully-qualified name of the
+	// ProjectService's StreamProjectSchedulerEvents RPC.
+	ProjectServiceStreamProjectSchedulerEventsProcedure = "/agentcompose.v2.ProjectService/StreamProjectSchedulerEvents"
 	// ProjectServiceInvokeSchedulerProcedure is the fully-qualified name of the ProjectService's
 	// InvokeScheduler RPC.
 	ProjectServiceInvokeSchedulerProcedure = "/agentcompose.v2.ProjectService/InvokeScheduler"
@@ -100,6 +103,9 @@ const (
 	// ProjectServiceListSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
 	// ListSchedulerRuns RPC.
 	ProjectServiceListSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/ListSchedulerRuns"
+	// ProjectServiceStreamSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
+	// StreamSchedulerRuns RPC.
+	ProjectServiceStreamSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/StreamSchedulerRuns"
 	// ProjectServicePruneSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
 	// PruneSchedulerRuns RPC.
 	ProjectServicePruneSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/PruneSchedulerRuns"
@@ -265,11 +271,13 @@ type ProjectServiceClient interface {
 	ListSchedulers(context.Context, *connect.Request[v2.ListSchedulersRequest]) (*connect.Response[v2.ListSchedulersResponse], error)
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
 	ListProjectSchedulerEvents(context.Context, *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error)
+	StreamProjectSchedulerEvents(context.Context, *connect.Request[v2.StreamProjectSchedulerEventsRequest]) (*connect.ServerStreamForClient[v2.StreamProjectSchedulerEventsResponse], error)
 	InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error)
 	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	StreamSchedulerRuns(context.Context, *connect.Request[v2.StreamSchedulerRunsRequest]) (*connect.ServerStreamForClient[v2.StreamSchedulerRunsResponse], error)
 	PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error)
 	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
 	SetSchedulerEnabled(context.Context, *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error)
@@ -347,6 +355,12 @@ func NewProjectServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(projectServiceMethods.ByName("ListProjectSchedulerEvents")),
 			connect.WithClientOptions(opts...),
 		),
+		streamProjectSchedulerEvents: connect.NewClient[v2.StreamProjectSchedulerEventsRequest, v2.StreamProjectSchedulerEventsResponse](
+			httpClient,
+			baseURL+ProjectServiceStreamProjectSchedulerEventsProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("StreamProjectSchedulerEvents")),
+			connect.WithClientOptions(opts...),
+		),
 		invokeScheduler: connect.NewClient[v2.InvokeSchedulerRequest, v2.InvokeSchedulerResponse](
 			httpClient,
 			baseURL+ProjectServiceInvokeSchedulerProcedure,
@@ -375,6 +389,12 @@ func NewProjectServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			httpClient,
 			baseURL+ProjectServiceListSchedulerRunsProcedure,
 			connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
+			connect.WithClientOptions(opts...),
+		),
+		streamSchedulerRuns: connect.NewClient[v2.StreamSchedulerRunsRequest, v2.StreamSchedulerRunsResponse](
+			httpClient,
+			baseURL+ProjectServiceStreamSchedulerRunsProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("StreamSchedulerRuns")),
 			connect.WithClientOptions(opts...),
 		),
 		pruneSchedulerRuns: connect.NewClient[v2.PruneSchedulerRunsRequest, v2.PruneSchedulerRunsResponse](
@@ -406,25 +426,27 @@ func NewProjectServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 
 // projectServiceClient implements ProjectServiceClient.
 type projectServiceClient struct {
-	validateProject            *connect.Client[v2.ValidateProjectRequest, v2.ValidateProjectResponse]
-	applyProject               *connect.Client[v2.ApplyProjectRequest, v2.ApplyProjectResponse]
-	getProject                 *connect.Client[v2.GetProjectRequest, v2.GetProjectResponse]
-	listProjects               *connect.Client[v2.ListProjectsRequest, v2.ListProjectsResponse]
-	removeProject              *connect.Client[v2.RemoveProjectRequest, v2.RemoveProjectResponse]
-	watchProject               *connect.Client[v2.WatchProjectRequest, v2.WatchProjectResponse]
-	getScheduler               *connect.Client[v2.GetSchedulerRequest, v2.GetSchedulerResponse]
-	listSchedulers             *connect.Client[v2.ListSchedulersRequest, v2.ListSchedulersResponse]
-	listSchedulerEvents        *connect.Client[v2.ListSchedulerEventsRequest, v2.ListSchedulerEventsResponse]
-	listProjectSchedulerEvents *connect.Client[v2.ListProjectSchedulerEventsRequest, v2.ListProjectSchedulerEventsResponse]
-	invokeScheduler            *connect.Client[v2.InvokeSchedulerRequest, v2.InvokeSchedulerResponse]
-	runScheduler               *connect.Client[v2.RunSchedulerRequest, v2.RunSchedulerResponse]
-	startSchedulerRun          *connect.Client[v2.StartSchedulerRunRequest, v2.StartSchedulerRunResponse]
-	getSchedulerRun            *connect.Client[v2.GetSchedulerRunRequest, v2.GetSchedulerRunResponse]
-	listSchedulerRuns          *connect.Client[v2.ListSchedulerRunsRequest, v2.ListSchedulerRunsResponse]
-	pruneSchedulerRuns         *connect.Client[v2.PruneSchedulerRunsRequest, v2.PruneSchedulerRunsResponse]
-	stopSchedulerRun           *connect.Client[v2.StopSchedulerRunRequest, v2.StopSchedulerRunResponse]
-	setSchedulerEnabled        *connect.Client[v2.SetSchedulerEnabledRequest, v2.SetSchedulerEnabledResponse]
-	setSchedulerTriggerEnabled *connect.Client[v2.SetSchedulerTriggerEnabledRequest, v2.SetSchedulerTriggerEnabledResponse]
+	validateProject              *connect.Client[v2.ValidateProjectRequest, v2.ValidateProjectResponse]
+	applyProject                 *connect.Client[v2.ApplyProjectRequest, v2.ApplyProjectResponse]
+	getProject                   *connect.Client[v2.GetProjectRequest, v2.GetProjectResponse]
+	listProjects                 *connect.Client[v2.ListProjectsRequest, v2.ListProjectsResponse]
+	removeProject                *connect.Client[v2.RemoveProjectRequest, v2.RemoveProjectResponse]
+	watchProject                 *connect.Client[v2.WatchProjectRequest, v2.WatchProjectResponse]
+	getScheduler                 *connect.Client[v2.GetSchedulerRequest, v2.GetSchedulerResponse]
+	listSchedulers               *connect.Client[v2.ListSchedulersRequest, v2.ListSchedulersResponse]
+	listSchedulerEvents          *connect.Client[v2.ListSchedulerEventsRequest, v2.ListSchedulerEventsResponse]
+	listProjectSchedulerEvents   *connect.Client[v2.ListProjectSchedulerEventsRequest, v2.ListProjectSchedulerEventsResponse]
+	streamProjectSchedulerEvents *connect.Client[v2.StreamProjectSchedulerEventsRequest, v2.StreamProjectSchedulerEventsResponse]
+	invokeScheduler              *connect.Client[v2.InvokeSchedulerRequest, v2.InvokeSchedulerResponse]
+	runScheduler                 *connect.Client[v2.RunSchedulerRequest, v2.RunSchedulerResponse]
+	startSchedulerRun            *connect.Client[v2.StartSchedulerRunRequest, v2.StartSchedulerRunResponse]
+	getSchedulerRun              *connect.Client[v2.GetSchedulerRunRequest, v2.GetSchedulerRunResponse]
+	listSchedulerRuns            *connect.Client[v2.ListSchedulerRunsRequest, v2.ListSchedulerRunsResponse]
+	streamSchedulerRuns          *connect.Client[v2.StreamSchedulerRunsRequest, v2.StreamSchedulerRunsResponse]
+	pruneSchedulerRuns           *connect.Client[v2.PruneSchedulerRunsRequest, v2.PruneSchedulerRunsResponse]
+	stopSchedulerRun             *connect.Client[v2.StopSchedulerRunRequest, v2.StopSchedulerRunResponse]
+	setSchedulerEnabled          *connect.Client[v2.SetSchedulerEnabledRequest, v2.SetSchedulerEnabledResponse]
+	setSchedulerTriggerEnabled   *connect.Client[v2.SetSchedulerTriggerEnabledRequest, v2.SetSchedulerTriggerEnabledResponse]
 }
 
 // ValidateProject calls agentcompose.v2.ProjectService.ValidateProject.
@@ -477,6 +499,11 @@ func (c *projectServiceClient) ListProjectSchedulerEvents(ctx context.Context, r
 	return c.listProjectSchedulerEvents.CallUnary(ctx, req)
 }
 
+// StreamProjectSchedulerEvents calls agentcompose.v2.ProjectService.StreamProjectSchedulerEvents.
+func (c *projectServiceClient) StreamProjectSchedulerEvents(ctx context.Context, req *connect.Request[v2.StreamProjectSchedulerEventsRequest]) (*connect.ServerStreamForClient[v2.StreamProjectSchedulerEventsResponse], error) {
+	return c.streamProjectSchedulerEvents.CallServerStream(ctx, req)
+}
+
 // InvokeScheduler calls agentcompose.v2.ProjectService.InvokeScheduler.
 func (c *projectServiceClient) InvokeScheduler(ctx context.Context, req *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error) {
 	return c.invokeScheduler.CallUnary(ctx, req)
@@ -500,6 +527,11 @@ func (c *projectServiceClient) GetSchedulerRun(ctx context.Context, req *connect
 // ListSchedulerRuns calls agentcompose.v2.ProjectService.ListSchedulerRuns.
 func (c *projectServiceClient) ListSchedulerRuns(ctx context.Context, req *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error) {
 	return c.listSchedulerRuns.CallUnary(ctx, req)
+}
+
+// StreamSchedulerRuns calls agentcompose.v2.ProjectService.StreamSchedulerRuns.
+func (c *projectServiceClient) StreamSchedulerRuns(ctx context.Context, req *connect.Request[v2.StreamSchedulerRunsRequest]) (*connect.ServerStreamForClient[v2.StreamSchedulerRunsResponse], error) {
+	return c.streamSchedulerRuns.CallServerStream(ctx, req)
 }
 
 // PruneSchedulerRuns calls agentcompose.v2.ProjectService.PruneSchedulerRuns.
@@ -534,11 +566,13 @@ type ProjectServiceHandler interface {
 	ListSchedulers(context.Context, *connect.Request[v2.ListSchedulersRequest]) (*connect.Response[v2.ListSchedulersResponse], error)
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
 	ListProjectSchedulerEvents(context.Context, *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error)
+	StreamProjectSchedulerEvents(context.Context, *connect.Request[v2.StreamProjectSchedulerEventsRequest], *connect.ServerStream[v2.StreamProjectSchedulerEventsResponse]) error
 	InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error)
 	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	StreamSchedulerRuns(context.Context, *connect.Request[v2.StreamSchedulerRunsRequest], *connect.ServerStream[v2.StreamSchedulerRunsResponse]) error
 	PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error)
 	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
 	SetSchedulerEnabled(context.Context, *connect.Request[v2.SetSchedulerEnabledRequest]) (*connect.Response[v2.SetSchedulerEnabledResponse], error)
@@ -612,6 +646,12 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 		connect.WithSchema(projectServiceMethods.ByName("ListProjectSchedulerEvents")),
 		connect.WithHandlerOptions(opts...),
 	)
+	projectServiceStreamProjectSchedulerEventsHandler := connect.NewServerStreamHandler(
+		ProjectServiceStreamProjectSchedulerEventsProcedure,
+		svc.StreamProjectSchedulerEvents,
+		connect.WithSchema(projectServiceMethods.ByName("StreamProjectSchedulerEvents")),
+		connect.WithHandlerOptions(opts...),
+	)
 	projectServiceInvokeSchedulerHandler := connect.NewUnaryHandler(
 		ProjectServiceInvokeSchedulerProcedure,
 		svc.InvokeScheduler,
@@ -640,6 +680,12 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 		ProjectServiceListSchedulerRunsProcedure,
 		svc.ListSchedulerRuns,
 		connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
+		connect.WithHandlerOptions(opts...),
+	)
+	projectServiceStreamSchedulerRunsHandler := connect.NewServerStreamHandler(
+		ProjectServiceStreamSchedulerRunsProcedure,
+		svc.StreamSchedulerRuns,
+		connect.WithSchema(projectServiceMethods.ByName("StreamSchedulerRuns")),
 		connect.WithHandlerOptions(opts...),
 	)
 	projectServicePruneSchedulerRunsHandler := connect.NewUnaryHandler(
@@ -688,6 +734,8 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 			projectServiceListSchedulerEventsHandler.ServeHTTP(w, r)
 		case ProjectServiceListProjectSchedulerEventsProcedure:
 			projectServiceListProjectSchedulerEventsHandler.ServeHTTP(w, r)
+		case ProjectServiceStreamProjectSchedulerEventsProcedure:
+			projectServiceStreamProjectSchedulerEventsHandler.ServeHTTP(w, r)
 		case ProjectServiceInvokeSchedulerProcedure:
 			projectServiceInvokeSchedulerHandler.ServeHTTP(w, r)
 		case ProjectServiceRunSchedulerProcedure:
@@ -698,6 +746,8 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 			projectServiceGetSchedulerRunHandler.ServeHTTP(w, r)
 		case ProjectServiceListSchedulerRunsProcedure:
 			projectServiceListSchedulerRunsHandler.ServeHTTP(w, r)
+		case ProjectServiceStreamSchedulerRunsProcedure:
+			projectServiceStreamSchedulerRunsHandler.ServeHTTP(w, r)
 		case ProjectServicePruneSchedulerRunsProcedure:
 			projectServicePruneSchedulerRunsHandler.ServeHTTP(w, r)
 		case ProjectServiceStopSchedulerRunProcedure:
@@ -755,6 +805,10 @@ func (UnimplementedProjectServiceHandler) ListProjectSchedulerEvents(context.Con
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListProjectSchedulerEvents is not implemented"))
 }
 
+func (UnimplementedProjectServiceHandler) StreamProjectSchedulerEvents(context.Context, *connect.Request[v2.StreamProjectSchedulerEventsRequest], *connect.ServerStream[v2.StreamProjectSchedulerEventsResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.StreamProjectSchedulerEvents is not implemented"))
+}
+
 func (UnimplementedProjectServiceHandler) InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.InvokeScheduler is not implemented"))
 }
@@ -773,6 +827,10 @@ func (UnimplementedProjectServiceHandler) GetSchedulerRun(context.Context, *conn
 
 func (UnimplementedProjectServiceHandler) ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListSchedulerRuns is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) StreamSchedulerRuns(context.Context, *connect.Request[v2.StreamSchedulerRunsRequest], *connect.ServerStream[v2.StreamSchedulerRunsResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.StreamSchedulerRuns is not implemented"))
 }
 
 func (UnimplementedProjectServiceHandler) PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error) {


### PR DESCRIPTION
## Summary

- add finite server streams for `scheduler runs` and `scheduler logs`, including bounded batches, stable scan boundaries, completion frames, checkpoints, and incremental text/JSON rendering
- stream text-mode run logs without loading complete log files or `RunDetail.output`; read files in UTF-8-safe 64 KiB chunks, preserve line formatting across transport frames, and keep `--tail` semantics including explicit `--tail 0`
- use no-total-timeout HTTP clients and no-buffer/no-transform response headers for streaming `run`, `exec`, `image build`, run logs, and scheduler history paths
- retain zero-frame `Unimplemented` fallback for older daemons while avoiding replay after partial output

This phase intentionally leaves operation streams such as `image pull` and foreground `scheduler trigger`, inventory streams, prune streams, sandbox history streams, and project-wide multi-run multiplexing to follow-up PRs.

## Testing

- `go test ./cmd/agent-compose ./pkg/agentcompose/api ./pkg/storage/configstore -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
- local workspace `suit-stream`: 7/7 cases passed, including gated proof that stdout arrives before stream completion for scheduler runs/logs and run logs, exact record/line counts, valid incremental JSON, bounded frames, headers, and cancellation propagation

## Checklist

- [x] Documentation updated when behavior or configuration changed (proto/API semantics are documented; no CLI flags were added)
- [x] Tests added or updated for user-visible behavior
- [x] No secrets, private endpoints, internal certificates, or local runtime state included
