### PR TITLE
fix(microsandbox): stop waiting on an exit that will never arrive

### DIFF
--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -47,6 +47,22 @@ type microsandboxExecCollector struct {
 
 const microsandboxExecExitIdleGracePeriod = 2 * time.Second
 
+// microsandboxExecSilenceProbeInterval is how long a stream may produce nothing
+// at all before the guest is asked whether the process is still there.
+//
+// The guest agent reports a process exit only after both of its output pipes
+// reach EOF, and a pipe reaches EOF only once every process that inherited it
+// has exited. A command that leaves a background helper running therefore ends
+// without the stream ever saying so, and waiting on the next event is a wait
+// that never returns. Silence alone proves nothing -- a build can be quiet for
+// a long time -- so it only triggers the question, and the answer decides.
+const microsandboxExecSilenceProbeInterval = 2 * time.Minute
+
+// microsandboxExecLivenessProbeTimeout bounds the liveness question itself, so
+// a guest agent that has stopped answering cannot turn the probe into a second
+// place to hang.
+const microsandboxExecLivenessProbeTimeout = 30 * time.Second
+
 const (
 	microsandboxManagedLabel   = "agent-compose.managed"
 	microsandboxSandboxIDLabel = "agent-compose.sandbox_id"
@@ -55,15 +71,23 @@ const (
 type microsandboxExecEventReceiver func(context.Context) (*microsandbox.ExecEvent, error)
 type microsandboxExecHandleCloser func() error
 
+// microsandboxExecLivenessProbe reports whether the guest process is still
+// present. A nil probe, or a probe that cannot answer, leaves the stream
+// waiting: only a definite "the process is gone" is allowed to end it.
+type microsandboxExecLivenessProbe func(ctx context.Context, pid uint32) (bool, error)
+
 func consumeMicrosandboxExecStream(
 	ctx context.Context,
 	recv microsandboxExecEventReceiver,
 	closeHandle microsandboxExecHandleCloser,
 	collector *microsandboxExecCollector,
 	idleGrace time.Duration,
+	probeAlive microsandboxExecLivenessProbe,
+	silenceInterval time.Duration,
 ) (ExecResult, error) {
 	exitCode := 0
 	sawExit := false
+	var pid uint32
 	var idleDeadline time.Time
 
 	closeAfterDrainTimeout := func() {
@@ -77,6 +101,8 @@ func consumeMicrosandboxExecStream(
 		}
 	}
 
+	silenceProbeArmed := probeAlive != nil && silenceInterval > 0
+
 	for {
 		recvCtx := ctx
 		var recvCancel context.CancelFunc
@@ -87,6 +113,8 @@ func consumeMicrosandboxExecStream(
 				break
 			}
 			recvCtx, recvCancel = context.WithTimeout(ctx, remaining)
+		} else if silenceProbeArmed && pid != 0 {
+			recvCtx, recvCancel = context.WithTimeout(ctx, silenceInterval)
 		}
 
 		event, err := recv(recvCtx)
@@ -94,9 +122,29 @@ func consumeMicrosandboxExecStream(
 			recvCancel()
 		}
 		if err != nil {
-			if sawExit && errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
-				closeAfterDrainTimeout()
-				break
+			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+				if sawExit {
+					closeAfterDrainTimeout()
+					break
+				}
+				gone, probeErr := microsandboxExecProcessGone(ctx, probeAlive, pid)
+				if probeErr != nil {
+					slog.Warn("failed to probe microsandbox exec process liveness; continuing to wait", "pid", pid, "error", probeErr)
+					continue
+				}
+				if !gone {
+					continue
+				}
+				slog.Warn(
+					"microsandbox exec process is gone but the stream never reported its exit; closing handle",
+					"pid", pid,
+					"silence_window", silenceInterval,
+				)
+				if closeErr := closeHandle(); closeErr != nil {
+					slog.Warn("failed to close microsandbox exec handle after a lost exit", "error", closeErr)
+				}
+				collector.finish()
+				return microsandboxExecResult(collector, -1, false), fmt.Errorf("microsandbox exec process %d exited without reporting its status; a process it started is still holding the output pipes open", pid)
 			}
 			collector.finish()
 			return ExecResult{}, err
@@ -106,6 +154,8 @@ func consumeMicrosandboxExecStream(
 		}
 
 		switch event.Kind {
+		case microsandbox.ExecEventStarted:
+			pid = event.PID
 		case microsandbox.ExecEventStdout:
 			collector.writeChunk(ExecChunk{Text: string(event.Data)})
 			if sawExit {
@@ -130,17 +180,56 @@ func consumeMicrosandboxExecStream(
 
 	collector.finish()
 	if !sawExit {
-		exitCode = 0
+		// The stream ended without ever carrying an exit status. Reporting exit
+		// code 0 here would turn a lost status into a success whose output is
+		// silently short, which reads downstream as a command that ran fine but
+		// printed no result.
+		return microsandboxExecResult(collector, -1, false), fmt.Errorf("microsandbox exec stream ended without reporting a process exit status")
 	}
 
-	result := ExecResult{
+	return microsandboxExecResult(collector, exitCode, exitCode == 0), nil
+}
+
+func microsandboxExecResult(collector *microsandboxExecCollector, exitCode int, success bool) ExecResult {
+	return ExecResult{
 		ExitCode: exitCode,
+		Success:  success,
 		Stdout:   collector.stdout.String(),
 		Stderr:   collector.stderr.String(),
 		Output:   collector.output.String(),
 	}
-	result.Success = result.ExitCode == 0
-	return result, nil
+}
+
+// microsandboxExecLivenessProbeFor asks the guest about a pid over a separate
+// exec session, which is unaffected by the pipes the original session is still
+// waiting on.
+func microsandboxExecLivenessProbeFor(sandbox *microsandbox.Sandbox) microsandboxExecLivenessProbe {
+	if sandbox == nil {
+		return nil
+	}
+	return func(ctx context.Context, pid uint32) (bool, error) {
+		output, err := sandbox.Exec(ctx, "sh", []string{"-c", fmt.Sprintf("kill -0 %d 2>/dev/null", pid)})
+		if err != nil {
+			return false, err
+		}
+		return output.ExitCode() == 0, nil
+	}
+}
+
+// microsandboxExecProcessGone answers only when it is sure. A probe that fails
+// leaves the caller waiting, because "the guest could not be asked" and "the
+// process is gone" must not lead to the same decision.
+func microsandboxExecProcessGone(ctx context.Context, probeAlive microsandboxExecLivenessProbe, pid uint32) (bool, error) {
+	if probeAlive == nil || pid == 0 {
+		return false, nil
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, microsandboxExecLivenessProbeTimeout)
+	defer cancel()
+	alive, err := probeAlive(probeCtx, pid)
+	if err != nil {
+		return false, err
+	}
+	return !alive, nil
 }
 
 func newMicrosandboxRuntime(config *appconfig.Config) (SandboxRuntime, error) {
@@ -361,7 +450,15 @@ func (r *microsandboxRuntime) ExecStream(ctx context.Context, session *Sandbox, 
 			}()
 
 			collector := &microsandboxExecCollector{stream: stream, filter: newExecOutputFilter()}
-			return consumeMicrosandboxExecStream(ctx, handle.Recv, closeHandle, collector, microsandboxExecExitIdleGracePeriod)
+			return consumeMicrosandboxExecStream(
+				ctx,
+				handle.Recv,
+				closeHandle,
+				collector,
+				microsandboxExecExitIdleGracePeriod,
+				microsandboxExecLivenessProbeFor(sandbox),
+				microsandboxExecSilenceProbeInterval,
+			)
 		},
 	)
 }

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -4,6 +4,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,7 +71,7 @@ func TestMicrosandboxExecStreamReturnsAfterExitWithoutDone(t *testing.T) {
 	grace := 25 * time.Millisecond
 	startedAt := time.Now()
 
-	result, err := consumeMicrosandboxExecStream(ctx, recv, closeHandle, collector, grace)
+	result, err := consumeMicrosandboxExecStream(ctx, recv, closeHandle, collector, grace, nil, 0)
 	if err != nil {
 		t.Fatalf("consumeMicrosandboxExecStream returned error: %v", err)
 	}
@@ -85,6 +86,164 @@ func TestMicrosandboxExecStreamReturnsAfterExitWithoutDone(t *testing.T) {
 	}
 	if elapsed := time.Since(startedAt); elapsed < grace {
 		t.Fatalf("returned before drain grace period: %s", elapsed)
+	}
+}
+
+// A command that leaves a background process holding the output pipes never
+// produces an exit event. Waiting for one is a wait that never ends, so the
+// silence is used to ask the guest whether the process is even still there.
+func TestMicrosandboxExecStreamStopsWhenProcessIsGoneWithoutExit(t *testing.T) {
+	events := []*microsandbox.ExecEvent{
+		{Kind: microsandbox.ExecEventStarted, PID: 4242},
+		{Kind: microsandbox.ExecEventStdout, Data: []byte("done\n")},
+	}
+	recv := func(ctx context.Context) (*microsandbox.ExecEvent, error) {
+		if len(events) > 0 {
+			event := events[0]
+			events = events[1:]
+			return event, nil
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	var closeCalls int
+	closeHandle := func() error {
+		closeCalls++
+		return nil
+	}
+	var probedPID uint32
+	probe := func(context.Context, uint32) (bool, error) {
+		return false, nil
+	}
+	probeRecorder := func(ctx context.Context, pid uint32) (bool, error) {
+		probedPID = pid
+		return probe(ctx, pid)
+	}
+	collector := &microsandboxExecCollector{filter: newExecOutputFilter()}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := consumeMicrosandboxExecStream(ctx, recv, closeHandle, collector, 25*time.Millisecond, probeRecorder, 20*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "without reporting its status") {
+		t.Fatalf("error = %v, want a lost-exit failure", err)
+	}
+	if probedPID != 4242 {
+		t.Fatalf("probed pid = %d, want the pid from the started event", probedPID)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("close calls = %d, want 1", closeCalls)
+	}
+	// The output collected before the stream went quiet is still reported, so
+	// callers can see how far the command got.
+	if result.Output != "done\n" || result.Success || result.ExitCode != -1 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+// scriptedExecStream hands out queued events once each and then blocks, which
+// is how a real stream behaves. A receiver that keeps re-delivering the same
+// event instead would hold the drain window open forever.
+type scriptedExecStream struct {
+	pending []*microsandbox.ExecEvent
+}
+
+func (s *scriptedExecStream) push(event *microsandbox.ExecEvent) {
+	s.pending = append(s.pending, event)
+}
+
+func (s *scriptedExecStream) recv(ctx context.Context) (*microsandbox.ExecEvent, error) {
+	if len(s.pending) > 0 {
+		event := s.pending[0]
+		s.pending = s.pending[1:]
+		return event, nil
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// Silence on its own means nothing: a command can be quiet for a long time.
+func TestMicrosandboxExecStreamKeepsWaitingWhileProcessLives(t *testing.T) {
+	stream := &scriptedExecStream{pending: []*microsandbox.ExecEvent{
+		// The pid has to be known before silence can be interpreted at all.
+		{Kind: microsandbox.ExecEventStarted, PID: 11},
+	}}
+	var probeCalls int
+	probe := func(context.Context, uint32) (bool, error) {
+		probeCalls++
+		if probeCalls == 3 {
+			stream.push(&microsandbox.ExecEvent{Kind: microsandbox.ExecEventExited, ExitCode: 0})
+		}
+		return true, nil
+	}
+	collector := &microsandboxExecCollector{filter: newExecOutputFilter()}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := consumeMicrosandboxExecStream(ctx, stream.recv, func() error { return nil }, collector, 10*time.Millisecond, probe, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("consumeMicrosandboxExecStream returned error: %v", err)
+	}
+	if probeCalls < 3 {
+		t.Fatalf("probe calls = %d, want the stream to keep waiting while the process lives", probeCalls)
+	}
+	if !result.Success || result.ExitCode != 0 {
+		t.Fatalf("result = %#v, want the reported exit to win", result)
+	}
+}
+
+// A probe that cannot answer must not be read as "the process is gone".
+func TestMicrosandboxExecStreamKeepsWaitingWhenProbeFails(t *testing.T) {
+	stream := &scriptedExecStream{pending: []*microsandbox.ExecEvent{
+		{Kind: microsandbox.ExecEventStarted, PID: 9},
+	}}
+	var probeCalls int
+	probe := func(context.Context, uint32) (bool, error) {
+		probeCalls++
+		if probeCalls == 2 {
+			stream.push(&microsandbox.ExecEvent{Kind: microsandbox.ExecEventExited, ExitCode: 3})
+		}
+		return false, errors.New("guest agent did not answer")
+	}
+	collector := &microsandboxExecCollector{filter: newExecOutputFilter()}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := consumeMicrosandboxExecStream(ctx, stream.recv, func() error { return nil }, collector, 10*time.Millisecond, probe, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("consumeMicrosandboxExecStream returned error: %v", err)
+	}
+	if probeCalls < 2 {
+		t.Fatalf("probe calls = %d, want the stream to keep waiting after a failed probe", probeCalls)
+	}
+	if result.ExitCode != 3 || result.Success {
+		t.Fatalf("result = %#v, want the eventual exit status", result)
+	}
+}
+
+// A stream that ends without an exit status used to be reported as exit code 0,
+// which turns a lost status into a success whose output is quietly short.
+func TestMicrosandboxExecStreamRejectsDoneWithoutExit(t *testing.T) {
+	events := []*microsandbox.ExecEvent{
+		{Kind: microsandbox.ExecEventStarted, PID: 5},
+		{Kind: microsandbox.ExecEventStdout, Data: []byte("partial")},
+		{Kind: microsandbox.ExecEventDone},
+	}
+	recv := func(context.Context) (*microsandbox.ExecEvent, error) {
+		event := events[0]
+		events = events[1:]
+		return event, nil
+	}
+	collector := &microsandboxExecCollector{filter: newExecOutputFilter()}
+
+	result, err := consumeMicrosandboxExecStream(context.Background(), recv, func() error { return nil }, collector, 25*time.Millisecond, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), "without reporting a process exit status") {
+		t.Fatalf("error = %v, want a missing-exit failure", err)
+	}
+	if result.Success || result.ExitCode != -1 {
+		t.Fatalf("result = %#v, want a non-success result", result)
+	}
+	if result.Output != "partial" {
+		t.Fatalf("output = %q", result.Output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- probe guest process liveness after two minutes of stream silence, and end the exec only when the process is definitely gone
- report a stream that ended without an exit status as a failure instead of exit code 0

## Why

A Microsandbox exec can end without ever reporting that it ended. The guest agent sends `ExecExited` only after both output pipes reach EOF (`crates/agentd/lib/session.rs`, pipe reader task: `while !stdout_eof || !stderr_eof { … }` and only then `child.wait()`), and a pipe reaches EOF only once *every* process that inherited it has exited. A command that leaves a background helper running therefore finishes while its stream stays open forever.

The driver had two guards and neither covered this:

- the guest-side `WithExecTimeout` is derived from the Go context deadline, which for a loader command is the whole run budget (`LOADER_RUN_TIMEOUT`, 8h in the affected deployment)
- the host-side drain window (`microsandboxExecExitIdleGracePeriod`) only arms **after** an exit event is seen, so the one path that never sees an exit is the one path with no deadline at all

Observed in production on a devboard task: the agent finished and published its MR at 09:55:49Z, the guest exited 0, and the run still sat in `running` two hours later holding 8 vCPU / 16 GB. Nothing was wrong with the task; a `ai-trs` proxy the entrypoint had started in the background was still holding the exec's stdout and stderr. The docker driver is unaffected because its exit code comes from the daemon API rather than from the stream, which is why the same loader script had worked for months.

## Approach

Silence alone proves nothing — a build can print nothing for an hour — so silence only triggers a question. After `microsandboxExecSilenceProbeInterval` with no events, ask the guest whether the pid from the `Started` event still exists, over a **separate** exec session that the stuck pipes cannot block. A live process means keep waiting. A probe that cannot answer also means keep waiting: "could not ask" and "it is gone" must not lead to the same decision. Only a definite answer ends the stream, as a failure that names the cause.

The second change is smaller and independent: `!sawExit` used to fall through to `exitCode = 0`, turning a lost status into a success whose output is quietly short. That is what surfaced downstream as `decode command result: no result payload found` — the result payload is printed last, so a truncated stream loses exactly it.

This is the runtime half of the problem. The loader-side half (the entrypoint leaking inherited descriptors) is fixed separately in agentkit; the two are independent, and this change also protects sandboxes agent-compose does not control the entrypoint of.

## Testing

- `go build`, `go vet`, `gofmt -l`, and `go test ./pkg/cache ./pkg/agentcompose/...` on darwin
- `go test -tags microsandboxcgo ./pkg/driver -run TestMicrosandbox -count=1` on linux/amd64 with cgo, all green
- `go test -tags microsandboxcgo ./pkg/driver -run TestMicrosandboxExecStream -count=1 -v` to confirm each new case runs rather than skips:
  - `TestMicrosandboxExecStreamStopsWhenProcessIsGoneWithoutExit`
  - `TestMicrosandboxExecStreamKeepsWaitingWhileProcessLives`
  - `TestMicrosandboxExecStreamKeepsWaitingWhenProbeFails`
  - `TestMicrosandboxExecStreamRejectsDoneWithoutExit`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
