### PR TITLE
fix(sandboxes): filter lists by project and status

### DIFF
--- a/cmd/agent-compose/cli_project.go
+++ b/cmd/agent-compose/cli_project.go
@@ -469,7 +469,7 @@ func composePSOutputFromProject(ctx context.Context, clients cliServiceClients, 
 		return composePSOutput{}, err
 	}
 	runBySandbox := latestRunsBySandbox(runs)
-	sessions, err := listAllSandboxes(ctx, clients.sandbox)
+	sessions, err := listFilteredSandboxes(ctx, clients.sandbox, projectID, composePSStatusValues(statusFilter))
 	if err != nil {
 		return composePSOutput{}, err
 	}

--- a/cmd/agent-compose/cli_project_display.go
+++ b/cmd/agent-compose/cli_project_display.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 )
@@ -63,6 +64,18 @@ func composePSStatusFilter(options composePSOptions) (map[string]bool, error) {
 		return nil, nil
 	}
 	return map[string]bool{"running": true}, nil
+}
+
+func composePSStatusValues(filter map[string]bool) []string {
+	if filter == nil {
+		return nil
+	}
+	values := make([]string, 0, len(filter))
+	for value := range filter {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
 }
 
 func writePSText(out io.Writer, output composePSOutput, verbose bool) error {

--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -9,10 +9,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestConfigCommandUsesGlobalFileProjectNameAndJSON(t *testing.T) {
@@ -637,11 +639,13 @@ func (s projectServiceStub) RemoveProject(ctx context.Context, req *connect.Requ
 
 func TestComposePSAllIncludesEveryStatusOnlyForCurrentProject(t *testing.T) {
 	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
+	var sandboxRequests []*agentcomposev2.ListSandboxesRequest
 	stubs := composeServiceStubs{
 		run: runServiceStub{listRuns: func(context.Context, *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
 			return connect.NewResponse(&agentcomposev2.ListRunsResponse{}), nil
 		}},
-		sandbox: sandboxServiceStub{listSandboxes: func(context.Context, *connect.Request[agentcomposev2.ListSandboxesRequest]) (*connect.Response[agentcomposev2.ListSandboxesResponse], error) {
+		sandbox: sandboxServiceStub{listSandboxes: func(_ context.Context, req *connect.Request[agentcomposev2.ListSandboxesRequest]) (*connect.Response[agentcomposev2.ListSandboxesResponse], error) {
+			sandboxRequests = append(sandboxRequests, proto.Clone(req.Msg).(*agentcomposev2.ListSandboxesRequest))
 			return connect.NewResponse(&agentcomposev2.ListSandboxesResponse{Sandboxes: []*agentcomposev2.Sandbox{
 				{SandboxId: "sandbox-project-running", Status: "running", Tags: []*agentcomposev2.SandboxTag{{Name: "project_id", Value: "project-1"}}},
 				{SandboxId: "sandbox-project-stopped", Status: "stopped", Tags: []*agentcomposev2.SandboxTag{{Name: "project_id", Value: "project-1"}}},
@@ -670,6 +674,23 @@ func TestComposePSAllIncludesEveryStatusOnlyForCurrentProject(t *testing.T) {
 	}
 	if len(allOutput.Sandboxes) != 2 || allOutput.Sandboxes[0].RawID != "sandbox-project-running" || allOutput.Sandboxes[1].RawID != "sandbox-project-stopped" {
 		t.Fatalf("ps --all sandboxes = %#v, want all statuses from current project only", allOutput.Sandboxes)
+	}
+
+	filteredOutput, err := composePSOutputFromProject(t.Context(), clients, project, composePSOptions{Status: "stopped,running"})
+	if err != nil || len(filteredOutput.Sandboxes) != 2 {
+		t.Fatalf("build multi-status ps output = %#v, err=%v", filteredOutput, err)
+	}
+	if len(sandboxRequests) != 3 {
+		t.Fatalf("sandbox requests = %d, want 3", len(sandboxRequests))
+	}
+	if sandboxRequests[0].GetProjectId() != "project-1" || !slices.Equal(sandboxRequests[0].GetStatus(), []string{"running"}) {
+		t.Fatalf("default sandbox request = %#v", sandboxRequests[0])
+	}
+	if sandboxRequests[1].GetProjectId() != "project-1" || len(sandboxRequests[1].GetStatus()) != 0 {
+		t.Fatalf("all sandbox request = %#v", sandboxRequests[1])
+	}
+	if !slices.Equal(sandboxRequests[2].GetStatus(), []string{"running", "stopped"}) {
+		t.Fatalf("multi-status sandbox request = %#v", sandboxRequests[2])
 	}
 }
 

--- a/cmd/agent-compose/cli_sandbox_lifecycle.go
+++ b/cmd/agent-compose/cli_sandbox_lifecycle.go
@@ -157,13 +157,19 @@ type composeSandboxOutput struct {
 }
 
 func listAllSandboxes(ctx context.Context, client agentcomposev2connect.SandboxServiceClient) ([]*agentcomposev2.Sandbox, error) {
+	return listFilteredSandboxes(ctx, client, "", nil)
+}
+
+func listFilteredSandboxes(ctx context.Context, client agentcomposev2connect.SandboxServiceClient, projectID string, statuses []string) ([]*agentcomposev2.Sandbox, error) {
 	var result []*agentcomposev2.Sandbox
 	var cursor string
 	const limit uint32 = 100
 	for {
 		resp, err := client.ListSandboxes(ctx, connect.NewRequest(&agentcomposev2.ListSandboxesRequest{
-			Cursor: cursor,
-			Limit:  limit,
+			Cursor:    cursor,
+			Limit:     limit,
+			ProjectId: strings.TrimSpace(projectID),
+			Status:    append([]string(nil), statuses...),
 		}))
 		if err != nil {
 			return nil, err

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -171,7 +171,13 @@ func (h *SandboxHandler) ListSandboxes(ctx context.Context, req *connect.Request
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("sandbox list store is required"))
 	}
-	result, err := store.ListSandboxes(ctx, domain.SandboxListOptions{Limit: limit, BeforeUpdatedAt: cursor.UpdatedAt, BeforeID: cursor.SandboxID})
+	result, err := store.ListSandboxes(ctx, domain.SandboxListOptions{
+		ProjectID:       strings.TrimSpace(req.Msg.GetProjectId()),
+		VMStatuses:      append([]string(nil), req.Msg.GetStatus()...),
+		Limit:           limit,
+		BeforeUpdatedAt: cursor.UpdatedAt,
+		BeforeID:        cursor.SandboxID,
+	})
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
 	}

--- a/pkg/agentcompose/api/sandbox_characterization_test.go
+++ b/pkg/agentcompose/api/sandbox_characterization_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -207,6 +208,25 @@ func TestV2ListSandboxesUsesOpaquePagination(t *testing.T) {
 	}
 	if _, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{Cursor: "invalid"})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("invalid token code=%v err=%v", connect.CodeOf(err), err)
+	}
+}
+
+func TestV2ListSandboxesPassesProjectAndStatusFiltersToStore(t *testing.T) {
+	store := &characterizationSandboxStore{}
+	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+
+	_, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{
+		ProjectId: " project-a ", Status: []string{"running", "stopped"},
+	}))
+	if err != nil {
+		t.Fatalf("ListSandboxes() error = %v", err)
+	}
+	if len(store.listOptions) != 1 {
+		t.Fatalf("list options count = %d, want 1", len(store.listOptions))
+	}
+	options := store.listOptions[0]
+	if options.ProjectID != "project-a" || !slices.Equal(options.VMStatuses, []string{"running", "stopped"}) {
+		t.Fatalf("list options = %#v", options)
 	}
 }
 

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -444,7 +444,24 @@ func NewConfigStore(di do.Injector) (*configstore.ConfigStore, error) {
 func NewSandboxStore(di do.Injector) (*sessionstore.Store, error) {
 	config := do.MustInvoke[*appconfig.Config](di)
 	database := do.MustInvoke[*storagesqlite.Database](di)
-	return sessionstore.NewWithDatabase(config, database.DB())
+	resolver := sandboxProjectProjectionResolver{resolver: do.MustInvoke[*runs.SandboxRunTargetResolver](di)}
+	return sessionstore.NewWithDatabase(config, database.DB(), resolver)
+}
+
+type sandboxProjectProjectionResolver struct {
+	resolver *runs.SandboxRunTargetResolver
+}
+
+func (r sandboxProjectProjectionResolver) ResolveSandboxProjectIDs(ctx context.Context, sandboxes []*domain.Sandbox) (map[string]string, error) {
+	resolved, err := r.resolver.ResolveBatch(ctx, sandboxes)
+	if err != nil {
+		return nil, err
+	}
+	projectIDs := make(map[string]string, len(resolved))
+	for sandboxID, target := range resolved {
+		projectIDs[sandboxID] = target.ProjectID
+	}
+	return projectIDs, nil
 }
 
 func NewWorkspaceProvisioner(di do.Injector) (*workspaces.Provisioner, error) {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -132,11 +132,13 @@ type SandboxSummary struct {
 
 type SandboxListOptions struct {
 	SandboxType        string
+	ProjectID          string
 	TriggerSourceQuery string
 	TitleQuery         string
 	WorkspaceQuery     string
 	Driver             string
 	VMStatus           string
+	VMStatuses         []string
 	CreatedFrom        time.Time
 	CreatedTo          time.Time
 	UpdatedFrom        time.Time

--- a/pkg/model/session_list.go
+++ b/pkg/model/session_list.go
@@ -110,6 +110,25 @@ func SandboxMatchesListOptions(session *Sandbox, options SandboxListOptions) boo
 			return false
 		}
 	}
+	if len(options.VMStatuses) > 0 {
+		status := strings.ToUpper(strings.TrimSpace(summary.VMStatus))
+		matched := false
+		required := false
+		for _, value := range options.VMStatuses {
+			value = strings.ToUpper(strings.TrimSpace(value))
+			if value == "" {
+				continue
+			}
+			required = true
+			if status == value {
+				matched = true
+				break
+			}
+		}
+		if required && !matched {
+			return false
+		}
+	}
 	if !MatchesTimeRange(summary.CreatedAt, options.CreatedFrom, options.CreatedTo) {
 		return false
 	}

--- a/pkg/storage/sessionstore/sandbox_cache.go
+++ b/pkg/storage/sessionstore/sandbox_cache.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -34,39 +33,18 @@ func openSandboxCacheDB(ctx context.Context, db *sql.DB) (*sandboxCache, bool, e
 		return nil, false, err
 	}
 	var version int
-	if _, err := db.ExecContext(ctx, sandboxCacheMetaSchema); err != nil {
-		slog.Warn("sandbox projection metadata unreadable; rebuilding cache tables", "error", err)
-		if resetErr := resetSandboxCacheSchema(ctx, db); resetErr != nil {
-			return nil, false, errors.Join(fmt.Errorf("create sandbox projection metadata: %w", err), resetErr)
-		}
-		return idx, true, nil
-	}
 	if err := db.QueryRowContext(ctx, `SELECT COALESCE((SELECT version FROM sandbox_projection_meta WHERE id = 1), 0)`).Scan(&version); err != nil {
-		slog.Warn("sandbox projection metadata unreadable; rebuilding cache tables", "error", err)
-		if resetErr := resetSandboxCacheSchema(ctx, db); resetErr != nil {
-			return nil, false, errors.Join(fmt.Errorf("read sandbox listing cache version: %w", err), resetErr)
-		}
-		return idx, true, nil
+		return nil, false, sandboxCacheError("read schema version", err)
+	}
+	if err := idx.validateSchema(ctx); err != nil {
+		return nil, false, err
 	}
 
 	needsRebuild := version != sandboxCacheVersion
 	if needsRebuild {
-		if err := resetSandboxCacheSchema(ctx, db); err != nil {
+		if err := idx.invalidate(ctx); err != nil {
 			return nil, false, err
 		}
-	} else if _, err := db.ExecContext(ctx, sandboxCacheSchema); err != nil {
-		slog.Warn("sandbox projection schema unreadable; dropping and rebuilding cache table", "error", err)
-		if resetErr := resetSandboxCacheSchema(ctx, db); resetErr != nil {
-			return nil, false, errors.Join(fmt.Errorf("create sandbox projection schema: %w", err), resetErr)
-		}
-		needsRebuild = true
-	}
-	if err := idx.validateSchema(ctx); err != nil {
-		slog.Warn("sandboxes projection table unreadable; dropping and rebuilding cache table", "error", err)
-		if resetErr := resetSandboxCacheSchema(ctx, db); resetErr != nil {
-			return nil, false, errors.Join(err, resetErr)
-		}
-		needsRebuild = true
 	}
 	// The schema version is intentionally NOT stamped here. It is stamped by
 	// markComplete only after a full rebuild finishes, so an interrupted rebuild
@@ -75,15 +53,24 @@ func openSandboxCacheDB(ctx context.Context, db *sql.DB) (*sandboxCache, bool, e
 	return idx, needsRebuild, nil
 }
 
-func resetSandboxCacheSchema(ctx context.Context, db *sql.DB) error {
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS sandboxes; DROP TABLE IF EXISTS sandbox_projection_meta;`); err != nil {
-		return fmt.Errorf("drop stale sandboxes projection tables: %w", err)
+func (x *sandboxCache) invalidate(ctx context.Context) (operationErr error) {
+	tx, err := x.db.BeginTx(ctx, nil)
+	if err != nil {
+		return sandboxCacheError("begin invalidation", err)
 	}
-	if _, err := db.ExecContext(ctx, sandboxCacheMetaSchema); err != nil {
-		return fmt.Errorf("create sandbox projection metadata: %w", err)
+	defer func() {
+		if operationErr != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM sandboxes`); err != nil {
+		return sandboxCacheError("clear projection", err)
 	}
-	if _, err := db.ExecContext(ctx, sandboxCacheSchema); err != nil {
-		return fmt.Errorf("create sandbox projection schema: %w", err)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM sandbox_projection_meta`); err != nil {
+		return sandboxCacheError("clear schema version", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return sandboxCacheError("commit invalidation", err)
 	}
 	return nil
 }
@@ -229,42 +216,3 @@ const sandboxCacheValidationCols = `id, short_id, title, trigger_source, driver,
 	workspace_path, workspace_id, nested_workspace_id, workspace_name, workspace_type, created_at, updated_at,
 	sandbox_type, title_search, trigger_source_search, driver_search, vm_status_search, project_id_search,
 	workspace_path_search, workspace_id_search, nested_workspace_id_search, workspace_name_search, workspace_type_search`
-
-const sandboxCacheMetaSchema = `CREATE TABLE IF NOT EXISTS sandbox_projection_meta (
-	id INTEGER PRIMARY KEY CHECK (id = 1),
-	version INTEGER NOT NULL
-);`
-
-const sandboxCacheSchema = `
-CREATE TABLE IF NOT EXISTS sandboxes (
-	id             TEXT PRIMARY KEY,
-	short_id       TEXT NOT NULL DEFAULT '',
-	title          TEXT NOT NULL DEFAULT '',
-	trigger_source TEXT NOT NULL DEFAULT '',
-	driver         TEXT NOT NULL DEFAULT '',
-	vm_status      TEXT NOT NULL DEFAULT '',
-	project_id     TEXT NOT NULL DEFAULT '',
-	workspace_path      TEXT NOT NULL DEFAULT '',
-	workspace_id        TEXT NOT NULL DEFAULT '',
-	nested_workspace_id TEXT NOT NULL DEFAULT '',
-	workspace_name      TEXT NOT NULL DEFAULT '',
-	workspace_type      TEXT NOT NULL DEFAULT '',
-	created_at          INTEGER NOT NULL DEFAULT 0,
-	updated_at          INTEGER NOT NULL DEFAULT 0,
-	sandbox_type               TEXT NOT NULL DEFAULT '',
-	title_search               TEXT NOT NULL DEFAULT '',
-	trigger_source_search      TEXT NOT NULL DEFAULT '',
-	driver_search              TEXT NOT NULL DEFAULT '',
-	vm_status_search           TEXT NOT NULL DEFAULT '',
-	project_id_search          TEXT NOT NULL DEFAULT '',
-	workspace_path_search      TEXT NOT NULL DEFAULT '',
-	workspace_id_search        TEXT NOT NULL DEFAULT '',
-	nested_workspace_id_search TEXT NOT NULL DEFAULT '',
-	workspace_name_search      TEXT NOT NULL DEFAULT '',
-	workspace_type_search      TEXT NOT NULL DEFAULT ''
-);
-CREATE INDEX IF NOT EXISTS idx_sandboxes_updated ON sandboxes(updated_at DESC, id DESC);
-CREATE INDEX IF NOT EXISTS idx_sandboxes_vm_status_updated ON sandboxes(vm_status_search, updated_at DESC, id DESC);
-CREATE INDEX IF NOT EXISTS idx_sandboxes_project_updated ON sandboxes(project_id_search, updated_at DESC, id DESC);
-CREATE INDEX IF NOT EXISTS idx_sandboxes_type_updated ON sandboxes(sandbox_type, updated_at DESC, id DESC);
-`

--- a/pkg/storage/sessionstore/sandbox_cache.go
+++ b/pkg/storage/sessionstore/sandbox_cache.go
@@ -12,7 +12,7 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
-const sandboxCacheVersion = 1
+const sandboxCacheVersion = 2
 
 var errSandboxCache = errors.New("sandbox listing cache failure")
 
@@ -130,17 +130,17 @@ func sandboxCacheError(operation string, err error) error {
 
 // Upsert records the latest sandbox metadata committed by the store. Callers
 // serialize metadata commits, so even an older timestamp is authoritative.
-func (x *sandboxCache) Upsert(ctx context.Context, sb *domain.Sandbox) error {
-	return x.upsert(ctx, sb)
+func (x *sandboxCache) Upsert(ctx context.Context, sb *domain.Sandbox, projectID string) error {
+	return x.upsert(ctx, sb, strings.TrimSpace(projectID))
 }
 
 // Reconcile replaces an index row with authoritative filesystem state even if
 // an earlier failed write left a newer, never-persisted timestamp in the index.
-func (x *sandboxCache) Reconcile(ctx context.Context, sb *domain.Sandbox) error {
-	return x.upsert(ctx, sb)
+func (x *sandboxCache) Reconcile(ctx context.Context, sb *domain.Sandbox, projectID string) error {
+	return x.upsert(ctx, sb, strings.TrimSpace(projectID))
 }
 
-func (x *sandboxCache) upsert(ctx context.Context, sb *domain.Sandbox) error {
+func (x *sandboxCache) upsert(ctx context.Context, sb *domain.Sandbox, projectID string) error {
 	if sb == nil || sb.Summary.ID == "" {
 		return fmt.Errorf("sandbox id is required")
 	}
@@ -156,30 +156,30 @@ func (x *sandboxCache) upsert(ctx context.Context, sb *domain.Sandbox) error {
 	// preserves SandboxMatchesListOptions semantics; SQLite's LOWER only folds
 	// ASCII characters.
 	query := `
-INSERT INTO sandboxes (id, short_id, title, trigger_source, driver, vm_status,
+INSERT INTO sandboxes (id, short_id, title, trigger_source, driver, vm_status, project_id,
 	workspace_path, workspace_id, nested_workspace_id, workspace_name, workspace_type, created_at, updated_at,
-	sandbox_type, title_search, trigger_source_search, driver_search, vm_status_search,
+	sandbox_type, title_search, trigger_source_search, driver_search, vm_status_search, project_id_search,
 	workspace_path_search, workspace_id_search, nested_workspace_id_search, workspace_name_search, workspace_type_search)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
 	short_id=excluded.short_id, title=excluded.title, trigger_source=excluded.trigger_source,
-	driver=excluded.driver, vm_status=excluded.vm_status, workspace_path=excluded.workspace_path,
+	driver=excluded.driver, vm_status=excluded.vm_status, project_id=excluded.project_id, workspace_path=excluded.workspace_path,
 	workspace_id=excluded.workspace_id, nested_workspace_id=excluded.nested_workspace_id,
 	workspace_name=excluded.workspace_name,
 	workspace_type=excluded.workspace_type, created_at=excluded.created_at, updated_at=excluded.updated_at,
 	sandbox_type=excluded.sandbox_type, title_search=excluded.title_search,
 	trigger_source_search=excluded.trigger_source_search, driver_search=excluded.driver_search,
-	vm_status_search=excluded.vm_status_search, workspace_path_search=excluded.workspace_path_search,
+	vm_status_search=excluded.vm_status_search, project_id_search=excluded.project_id_search, workspace_path_search=excluded.workspace_path_search,
 	workspace_id_search=excluded.workspace_id_search,
 	nested_workspace_id_search=excluded.nested_workspace_id_search,
 	workspace_name_search=excluded.workspace_name_search, workspace_type_search=excluded.workspace_type_search
 `
 	_, err := x.db.ExecContext(ctx, query,
-		s.ID, s.ShortID, s.Title, s.TriggerSource, s.Driver, s.VMStatus,
+		s.ID, s.ShortID, s.Title, s.TriggerSource, s.Driver, s.VMStatus, projectID,
 		s.WorkspacePath, wsID, nestedWSID, wsName, wsType,
 		sandboxCacheUnixNano(s.CreatedAt), sandboxCacheUnixNano(s.UpdatedAt),
 		domain.SandboxTypeFromTriggerSource(s.TriggerSource), strings.ToLower(s.Title), strings.ToLower(s.TriggerSource),
-		strings.ToLower(strings.TrimSpace(s.Driver)), strings.ToUpper(strings.TrimSpace(s.VMStatus)),
+		strings.ToLower(strings.TrimSpace(s.Driver)), strings.ToUpper(strings.TrimSpace(s.VMStatus)), strings.ToLower(projectID),
 		strings.ToLower(strings.TrimSpace(s.WorkspacePath)), strings.ToLower(strings.TrimSpace(wsID)),
 		strings.ToLower(strings.TrimSpace(nestedWSID)), strings.ToLower(strings.TrimSpace(wsName)),
 		strings.ToLower(strings.TrimSpace(wsType)))
@@ -225,9 +225,9 @@ func (x *sandboxCache) markComplete(ctx context.Context) error {
 	return nil
 }
 
-const sandboxCacheValidationCols = `id, short_id, title, trigger_source, driver, vm_status,
+const sandboxCacheValidationCols = `id, short_id, title, trigger_source, driver, vm_status, project_id,
 	workspace_path, workspace_id, nested_workspace_id, workspace_name, workspace_type, created_at, updated_at,
-	sandbox_type, title_search, trigger_source_search, driver_search, vm_status_search,
+	sandbox_type, title_search, trigger_source_search, driver_search, vm_status_search, project_id_search,
 	workspace_path_search, workspace_id_search, nested_workspace_id_search, workspace_name_search, workspace_type_search`
 
 const sandboxCacheMetaSchema = `CREATE TABLE IF NOT EXISTS sandbox_projection_meta (
@@ -243,6 +243,7 @@ CREATE TABLE IF NOT EXISTS sandboxes (
 	trigger_source TEXT NOT NULL DEFAULT '',
 	driver         TEXT NOT NULL DEFAULT '',
 	vm_status      TEXT NOT NULL DEFAULT '',
+	project_id     TEXT NOT NULL DEFAULT '',
 	workspace_path      TEXT NOT NULL DEFAULT '',
 	workspace_id        TEXT NOT NULL DEFAULT '',
 	nested_workspace_id TEXT NOT NULL DEFAULT '',
@@ -255,6 +256,7 @@ CREATE TABLE IF NOT EXISTS sandboxes (
 	trigger_source_search      TEXT NOT NULL DEFAULT '',
 	driver_search              TEXT NOT NULL DEFAULT '',
 	vm_status_search           TEXT NOT NULL DEFAULT '',
+	project_id_search          TEXT NOT NULL DEFAULT '',
 	workspace_path_search      TEXT NOT NULL DEFAULT '',
 	workspace_id_search        TEXT NOT NULL DEFAULT '',
 	nested_workspace_id_search TEXT NOT NULL DEFAULT '',
@@ -263,5 +265,6 @@ CREATE TABLE IF NOT EXISTS sandboxes (
 );
 CREATE INDEX IF NOT EXISTS idx_sandboxes_updated ON sandboxes(updated_at DESC, id DESC);
 CREATE INDEX IF NOT EXISTS idx_sandboxes_vm_status_updated ON sandboxes(vm_status_search, updated_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS idx_sandboxes_project_updated ON sandboxes(project_id_search, updated_at DESC, id DESC);
 CREATE INDEX IF NOT EXISTS idx_sandboxes_type_updated ON sandboxes(sandbox_type, updated_at DESC, id DESC);
 `

--- a/pkg/storage/sessionstore/sandbox_cache_sync_test.go
+++ b/pkg/storage/sessionstore/sandbox_cache_sync_test.go
@@ -11,6 +11,7 @@ import (
 
 	appconfig "agent-compose/pkg/config"
 	domain "agent-compose/pkg/model"
+	storagesqlite "agent-compose/pkg/storage/sqlite"
 )
 
 func cleanupSandboxStore(t *testing.T, store *Store) {
@@ -84,6 +85,9 @@ func TestNewWithDatabaseDoesNotCloseSharedDatabase(t *testing.T) {
 			t.Errorf("close shared database: %v", err)
 		}
 	})
+	if err := storagesqlite.Migrate(t.Context(), db); err != nil {
+		t.Fatalf("migrate shared database: %v", err)
+	}
 	store, err := NewWithDatabase(&appconfig.Config{SandboxRoot: filepath.Join(root, "sandboxes")}, db)
 	if err != nil {
 		t.Fatalf("NewWithDatabase: %v", err)
@@ -116,6 +120,9 @@ func TestNewWithDatabaseRebuildsProjectProjectionFromResolver(t *testing.T) {
 		t.Fatalf("open shared database: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
+	if err := storagesqlite.Migrate(t.Context(), db); err != nil {
+		t.Fatalf("migrate shared database: %v", err)
+	}
 
 	store, err := NewWithDatabase(&appconfig.Config{SandboxRoot: sandboxRoot}, db, staticSandboxProjectResolver{
 		"legacy-project-a": "project-a",
@@ -139,7 +146,7 @@ func TestNewWithDatabaseRebuildsProjectProjectionFromResolver(t *testing.T) {
 	}
 }
 
-func TestNewWithConfigRecoversFromCurrentVersionIndexWithMissingColumns(t *testing.T) {
+func TestNewWithConfigFallsBackFromCurrentVersionIndexWithMissingColumns(t *testing.T) {
 	root := t.TempDir()
 	persisted := writePersistedSandboxForIndexRecovery(t, root, "missing-columns")
 	path := filepath.Join(root, "data.db")
@@ -169,13 +176,13 @@ INSERT INTO sandbox_projection_meta(id, version) VALUES(1, 4)
 		t.Fatalf("NewWithConfig: %v", err)
 	}
 	cleanupSandboxStore(t, store)
-	if store.index == nil {
-		t.Fatal("store degraded instead of rebuilding malformed sandboxes projection table")
+	if store.index != nil {
+		t.Fatal("store retained malformed sandboxes projection instead of using filesystem fallback")
 	}
 	assertSandboxListed(t, store, persisted.Summary.ID)
 }
 
-func TestNewWithConfigRecoversWhenReconciliationHitsIndexFailure(t *testing.T) {
+func TestNewWithConfigFallsBackWhenReconciliationHitsIndexFailure(t *testing.T) {
 	root := t.TempDir()
 	persisted := writePersistedSandboxForIndexRecovery(t, root, "reconcile-failure")
 	path := filepath.Join(root, "data.db")
@@ -204,13 +211,16 @@ END;
 		t.Fatalf("NewWithConfig: %v", err)
 	}
 	cleanupSandboxStore(t, store)
+	if store.index != nil {
+		t.Fatal("store retained failing sandbox projection instead of using filesystem fallback")
+	}
 	assertSandboxListed(t, store, persisted.Summary.ID)
 	var triggerCount int
-	if err := store.index.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = 'fail_sandbox_reconcile'`).Scan(&triggerCount); err != nil {
-		t.Fatalf("query recovered index trigger: %v", err)
+	if err := store.database.DB().QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = 'fail_sandbox_reconcile'`).Scan(&triggerCount); err != nil {
+		t.Fatalf("query failing index trigger: %v", err)
 	}
-	if triggerCount != 0 {
-		t.Fatalf("recovered index retained failing trigger")
+	if triggerCount != 1 {
+		t.Fatalf("store changed migration-owned schema while falling back: trigger count = %d", triggerCount)
 	}
 }
 

--- a/pkg/storage/sessionstore/sandbox_cache_sync_test.go
+++ b/pkg/storage/sessionstore/sandbox_cache_sync_test.go
@@ -96,6 +96,49 @@ func TestNewWithDatabaseDoesNotCloseSharedDatabase(t *testing.T) {
 	}
 }
 
+type staticSandboxProjectResolver map[string]string
+
+func (r staticSandboxProjectResolver) ResolveSandboxProjectIDs(_ context.Context, sandboxes []*domain.Sandbox) (map[string]string, error) {
+	resolved := make(map[string]string, len(sandboxes))
+	for _, sandbox := range sandboxes {
+		resolved[sandbox.Summary.ID] = r[sandbox.Summary.ID]
+	}
+	return resolved, nil
+}
+
+func TestNewWithDatabaseRebuildsProjectProjectionFromResolver(t *testing.T) {
+	root := t.TempDir()
+	sandboxRoot := filepath.Join(root, "sandboxes")
+	first := writePersistedSandboxForIndexRecovery(t, sandboxRoot, "legacy-project-a")
+	writePersistedSandboxForIndexRecovery(t, sandboxRoot, "project-b")
+	db, err := sql.Open("sqlite", filepath.Join(root, "data.db"))
+	if err != nil {
+		t.Fatalf("open shared database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store, err := NewWithDatabase(&appconfig.Config{SandboxRoot: sandboxRoot}, db, staticSandboxProjectResolver{
+		"legacy-project-a": "project-a",
+		"project-b":        "project-b",
+	})
+	if err != nil {
+		t.Fatalf("NewWithDatabase: %v", err)
+	}
+	cleanupSandboxStore(t, store)
+
+	result, err := store.ListSandboxes(context.Background(), domain.SandboxListOptions{ProjectID: "PROJECT-A"})
+	if err != nil {
+		t.Fatalf("list project sandboxes: %v", err)
+	}
+	if got := ids(result.Sandboxes); len(got) != 1 || got[0] != first.Summary.ID {
+		t.Fatalf("project sandboxes = %v, want [%s]", got, first.Summary.ID)
+	}
+	var projected string
+	if err := db.QueryRow(`SELECT project_id FROM sandboxes WHERE id = ?`, first.Summary.ID).Scan(&projected); err != nil || projected != "project-a" {
+		t.Fatalf("project projection = %q, err=%v", projected, err)
+	}
+}
+
 func TestNewWithConfigRecoversFromCurrentVersionIndexWithMissingColumns(t *testing.T) {
 	root := t.TempDir()
 	persisted := writePersistedSandboxForIndexRecovery(t, root, "missing-columns")
@@ -207,7 +250,7 @@ func TestNewWithConfigReconcilesCurrentIndexWithFilesystem(t *testing.T) {
 	}
 	persisted := seedSandboxDir(t, store, "persisted", time.Unix(100, 0).UTC())
 	missing := seedSandboxDir(t, store, "missing", time.Unix(99, 0).UTC())
-	if err := store.index.Upsert(context.Background(), persisted); err != nil {
+	if err := store.index.Upsert(context.Background(), persisted, ""); err != nil {
 		t.Fatalf("seed index: %v", err)
 	}
 	if err := store.index.Delete(context.Background(), persisted.Summary.ID); err != nil {
@@ -217,7 +260,7 @@ func TestNewWithConfigReconcilesCurrentIndexWithFilesystem(t *testing.T) {
 	stale.Summary = persisted.Summary
 	stale.Summary.Driver = "stale-index-driver"
 	stale.Summary.UpdatedAt = persisted.Summary.UpdatedAt.Add(time.Hour)
-	if err := store.index.Upsert(context.Background(), &stale); err != nil {
+	if err := store.index.Upsert(context.Background(), &stale, ""); err != nil {
 		t.Fatalf("seed inconsistent index row: %v", err)
 	}
 	if err := store.Close(); err != nil {
@@ -470,7 +513,7 @@ func TestListSandboxesRefillsPageAfterPruningGhosts(t *testing.T) {
 
 	valid := seedSandboxDir(t, store, "valid", time.Unix(100, 0).UTC())
 	store.recordIndex(valid)
-	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(101, 0).UTC())); err != nil {
+	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(101, 0).UTC()), ""); err != nil {
 		t.Fatalf("seed ghost: %v", err)
 	}
 
@@ -493,7 +536,7 @@ func TestListSandboxesIgnoresGhostsBeforeOffset(t *testing.T) {
 	older := seedSandboxDir(t, store, "older", time.Unix(100, 0).UTC())
 	store.recordIndex(newer)
 	store.recordIndex(older)
-	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(102, 0).UTC())); err != nil {
+	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(102, 0).UTC()), ""); err != nil {
 		t.Fatalf("seed ghost: %v", err)
 	}
 
@@ -758,7 +801,7 @@ func TestRebuildIndexBackfillsAndPrunesOrphans(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed an orphan index row whose directory does not exist.
-	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(1, 0).UTC())); err != nil {
+	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(1, 0).UTC()), ""); err != nil {
 		t.Fatalf("seed ghost: %v", err)
 	}
 	// Create two real sandbox dirs with metadata.json.

--- a/pkg/storage/sessionstore/sandbox_cache_test.go
+++ b/pkg/storage/sessionstore/sandbox_cache_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	domain "agent-compose/pkg/model"
+	storagesqlite "agent-compose/pkg/storage/sqlite"
 )
 
 func newTestIndex(t *testing.T) *sandboxCache {
@@ -333,10 +334,13 @@ func TestSandboxCacheSharesDataDatabaseForJoinsAndIsolatedRebuilds(t *testing.T)
 		}
 	})
 	ctx := context.Background()
+	if err := storagesqlite.Migrate(ctx, db); err != nil {
+		t.Fatalf("migrate shared data database: %v", err)
+	}
 	if _, err := db.ExecContext(ctx, `
-		CREATE TABLE project_run (run_id TEXT PRIMARY KEY, sandbox_id TEXT NOT NULL, project_id TEXT NOT NULL);
+		CREATE TABLE sandbox_owner (sandbox_id TEXT PRIMARY KEY, project_id TEXT NOT NULL);
 		CREATE TABLE unrelated_state (id TEXT PRIMARY KEY, value TEXT NOT NULL);
-		INSERT INTO project_run(run_id, sandbox_id, project_id) VALUES('run-1', 'sandbox-1', 'project-1');
+		INSERT INTO sandbox_owner(sandbox_id, project_id) VALUES('sandbox-1', 'project-1');
 		INSERT INTO unrelated_state(id, value) VALUES('keep', 'authoritative');
 	`); err != nil {
 		t.Fatalf("seed shared data database: %v", err)
@@ -352,7 +356,7 @@ func TestSandboxCacheSharesDataDatabaseForJoinsAndIsolatedRebuilds(t *testing.T)
 		t.Fatalf("mark sandbox listing cache complete: %v", err)
 	}
 	var projectID string
-	if err := db.QueryRowContext(ctx, `SELECT pr.project_id FROM sandboxes si JOIN project_run pr ON pr.sandbox_id = si.id WHERE si.id = ?`, "sandbox-1").Scan(&projectID); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT owner.project_id FROM sandboxes si JOIN sandbox_owner owner ON owner.sandbox_id = si.id WHERE si.id = ?`, "sandbox-1").Scan(&projectID); err != nil {
 		t.Fatalf("join sandbox listing cache with project run: %v", err)
 	}
 	if projectID != "project-1" {
@@ -378,10 +382,8 @@ func TestSandboxCacheSharesDataDatabaseForJoinsAndIsolatedRebuilds(t *testing.T)
 	if _, err := db.ExecContext(ctx, `DROP TABLE sandbox_projection_meta; CREATE TABLE sandbox_projection_meta (broken TEXT)`); err != nil {
 		t.Fatalf("malform sandbox projection metadata: %v", err)
 	}
-	if _, needsRebuild, err := openSandboxCacheDB(ctx, db); err != nil {
-		t.Fatalf("recover malformed sandbox projection metadata: %v", err)
-	} else if !needsRebuild {
-		t.Fatal("malformed sandbox projection metadata did not request rebuild")
+	if _, _, err := openSandboxCacheDB(ctx, db); err == nil {
+		t.Fatal("malformed migration-owned sandbox projection metadata returned no error")
 	}
 	if err := db.QueryRowContext(ctx, `SELECT value FROM unrelated_state WHERE id = 'keep'`).Scan(&value); err != nil {
 		t.Fatalf("query unrelated state after metadata recovery: %v", err)

--- a/pkg/storage/sessionstore/sandbox_cache_test.go
+++ b/pkg/storage/sessionstore/sandbox_cache_test.go
@@ -200,7 +200,7 @@ func TestSandboxCacheListFiltersOrderKeysetOffset(t *testing.T) {
 	c := sb("c", base.Add(3*time.Second))
 	b.Summary.Driver = "boxlite"
 	for _, s := range []*domain.Sandbox{a, b, c} {
-		if err := idx.Upsert(ctx, s); err != nil {
+		if err := idx.Upsert(ctx, s, ""); err != nil {
 			t.Fatalf("upsert: %v", err)
 		}
 	}
@@ -254,19 +254,51 @@ func TestSandboxCacheListFiltersOrderKeysetOffset(t *testing.T) {
 	}
 }
 
+func TestSandboxCacheListFiltersProjectAndStatuses(t *testing.T) {
+	idx := newTestIndex(t)
+	ctx := context.Background()
+	dir := func(id string) string { return "/root/" + id }
+	base := time.Unix(10_000, 0).UTC()
+
+	running := sb("project-running", base.Add(2*time.Second))
+	stopped := sb("project-stopped", base.Add(time.Second))
+	stopped.Summary.VMStatus = "STOPPED"
+	other := sb("other-running", base)
+	if err := idx.Upsert(ctx, running, "project-a"); err != nil {
+		t.Fatalf("upsert running: %v", err)
+	}
+	if err := idx.Upsert(ctx, stopped, "project-a"); err != nil {
+		t.Fatalf("upsert stopped: %v", err)
+	}
+	if err := idx.Upsert(ctx, other, "project-b"); err != nil {
+		t.Fatalf("upsert other: %v", err)
+	}
+
+	page, total, err := idx.list(ctx, domain.SandboxListOptions{
+		ProjectID: "PROJECT-A", VMStatuses: []string{"running", "stopped"}, Limit: 10,
+	}, dir)
+	if err != nil {
+		t.Fatalf("list by project and statuses: %v", err)
+	}
+	got := ids(page)
+	if total != 2 || len(got) != 2 || got[0] != "project-running" || got[1] != "project-stopped" {
+		t.Fatalf("project/status result total=%d ids=%v", total, got)
+	}
+}
+
 func TestSandboxCacheUpsertAcceptsAuthoritativeOlderTimestamp(t *testing.T) {
 	idx := newTestIndex(t)
 	ctx := context.Background()
 	t0 := time.Unix(1000, 0).UTC()
 	t1 := time.Unix(2000, 0).UTC()
 
-	if err := idx.Upsert(ctx, sb("x", t1)); err != nil {
+	if err := idx.Upsert(ctx, sb("x", t1), ""); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	// A successfully committed older timestamp remains authoritative.
 	stale := sb("x", t0)
 	stale.Summary.Driver = "STALE"
-	if err := idx.Upsert(ctx, stale); err != nil {
+	if err := idx.Upsert(ctx, stale, ""); err != nil {
 		t.Fatalf("stale upsert: %v", err)
 	}
 	var driver string
@@ -313,7 +345,7 @@ func TestSandboxCacheSharesDataDatabaseForJoinsAndIsolatedRebuilds(t *testing.T)
 	if err != nil {
 		t.Fatalf("open sandbox listing cache on shared database: %v", err)
 	}
-	if err := idx.Upsert(ctx, sb("sandbox-1", time.Unix(100, 0).UTC())); err != nil {
+	if err := idx.Upsert(ctx, sb("sandbox-1", time.Unix(100, 0).UTC()), ""); err != nil {
 		t.Fatalf("upsert sandbox listing cache: %v", err)
 	}
 	if err := idx.markComplete(ctx); err != nil {

--- a/pkg/storage/sessionstore/sandbox_cache_test_support_test.go
+++ b/pkg/storage/sessionstore/sandbox_cache_test_support_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	storagesqlite "agent-compose/pkg/storage/sqlite"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -15,6 +17,9 @@ func openSandboxCache(path string) (*sandboxCache, bool, error) {
 	}
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
+	if err := storagesqlite.Migrate(context.Background(), db); err != nil {
+		return nil, false, closeSandboxCacheDB(db, fmt.Errorf("migrate data database for sandbox listing cache: %w", err))
+	}
 	idx, needsRebuild, err := openSandboxCacheDB(context.Background(), db)
 	if err != nil {
 		return nil, false, closeSandboxCacheDB(db, err)

--- a/pkg/storage/sessionstore/sandbox_filesystem_list.go
+++ b/pkg/storage/sessionstore/sandbox_filesystem_list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	domain "agent-compose/pkg/model"
 )
@@ -34,6 +35,19 @@ func (s *Store) listSandboxesFromFilesystem(ctx context.Context, options Sandbox
 			continue
 		}
 		sandboxes = append(sandboxes, sandbox)
+	}
+	if projectID := strings.TrimSpace(options.ProjectID); projectID != "" {
+		projectIDs, err := s.resolveSandboxProjectIDs(ctx, sandboxes)
+		if err != nil {
+			return SandboxListResult{}, fmt.Errorf("resolve sandbox project filter: %w", err)
+		}
+		filtered := sandboxes[:0]
+		for _, sandbox := range sandboxes {
+			if strings.EqualFold(projectIDs[sandbox.Summary.ID], projectID) {
+				filtered = append(filtered, sandbox)
+			}
+		}
+		sandboxes = filtered
 	}
 	sort.Slice(sandboxes, func(i, j int) bool {
 		if sandboxes[i].Summary.UpdatedAt.Equal(sandboxes[j].Summary.UpdatedAt) {

--- a/pkg/storage/sessionstore/sandbox_list_contract_test.go
+++ b/pkg/storage/sessionstore/sandbox_list_contract_test.go
@@ -126,7 +126,7 @@ func TestListSandboxesClampsOffsetBeyondEndAfterGhostPruning(t *testing.T) {
 		sandbox := seedSandboxDir(t, store, id, time.Unix(int64(100+index), 0).UTC())
 		store.recordIndex(sandbox)
 	}
-	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(102, 0).UTC())); err != nil {
+	if err := store.index.Upsert(ctx, sb("ghost", time.Unix(102, 0).UTC()), ""); err != nil {
 		t.Fatalf("seed ghost: %v", err)
 	}
 

--- a/pkg/storage/sessionstore/sandbox_project_projection.go
+++ b/pkg/storage/sessionstore/sandbox_project_projection.go
@@ -1,0 +1,28 @@
+package sessionstore
+
+import (
+	"context"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+// SandboxProjectResolver supplies the domain-owned sandbox-to-project
+// association used by the rebuildable listing projection.
+type SandboxProjectResolver interface {
+	ResolveSandboxProjectIDs(context.Context, []*domain.Sandbox) (map[string]string, error)
+}
+
+func (s *Store) resolveSandboxProjectIDs(ctx context.Context, sandboxes []*domain.Sandbox) (map[string]string, error) {
+	if s.projectResolver == nil || len(sandboxes) == 0 {
+		return map[string]string{}, nil
+	}
+	resolved, err := s.projectResolver.ResolveSandboxProjectIDs(ctx, sandboxes)
+	if err != nil {
+		return nil, err
+	}
+	for id, projectID := range resolved {
+		resolved[id] = strings.TrimSpace(projectID)
+	}
+	return resolved, nil
+}

--- a/pkg/storage/sessionstore/sandbox_query.go
+++ b/pkg/storage/sessionstore/sandbox_query.go
@@ -26,6 +26,10 @@ func sandboxWhere(o domain.SandboxListOptions) (string, []any) {
 		conds = append(conds, "sandbox_type = ?")
 		args = append(args, strings.ToLower(v))
 	}
+	if v := strings.TrimSpace(o.ProjectID); v != "" {
+		conds = append(conds, "project_id_search = ?")
+		args = append(args, strings.ToLower(v))
+	}
 	if v := strings.TrimSpace(o.TriggerSourceQuery); v != "" {
 		contains("trigger_source_search", v)
 	}
@@ -44,6 +48,21 @@ func sandboxWhere(o domain.SandboxListOptions) (string, []any) {
 	if v := strings.TrimSpace(o.VMStatus); v != "" {
 		conds = append(conds, "vm_status_search = ?")
 		args = append(args, strings.ToUpper(v))
+	}
+	if len(o.VMStatuses) > 0 {
+		statuses := make([]string, 0, len(o.VMStatuses))
+		for _, status := range o.VMStatuses {
+			status = strings.ToUpper(strings.TrimSpace(status))
+			if status != "" {
+				statuses = append(statuses, status)
+			}
+		}
+		if len(statuses) > 0 {
+			conds = append(conds, "vm_status_search IN ("+strings.TrimSuffix(strings.Repeat("?,", len(statuses)), ",")+")")
+			for _, status := range statuses {
+				args = append(args, status)
+			}
+		}
 	}
 	if !o.CreatedFrom.IsZero() {
 		conds = append(conds, "created_at >= ?")

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -138,8 +138,9 @@ func newStoreWithIndex(config *appconfig.Config, index *sandboxCache, dbPath str
 			}
 			return nil, fmt.Errorf("reconcile sandbox listing cache: %w", err)
 		}
-		if err := store.recreateSandboxCache(context.Background(), err); err != nil {
+		if err := store.retrySandboxCacheRebuild(context.Background(), err); err != nil {
 			slog.Warn("sandbox listing cache recovery failed; using filesystem listing", "database", dbPath, "error", err)
+			store.index = nil
 			return store, nil
 		}
 	}
@@ -156,17 +157,17 @@ func closeSandboxCacheAfterStoreInitFailure(index *sandboxCache, operationErr er
 	return operationErr
 }
 
-func (s *Store) recreateSandboxCache(ctx context.Context, cause error) error {
-	slog.Warn("sandbox listing cache reconciliation failed; rebuilding cache table", "error", cause)
+func (s *Store) retrySandboxCacheRebuild(ctx context.Context, cause error) error {
+	slog.Warn("sandbox listing cache reconciliation failed; clearing projection before retry", "error", cause)
 	index := s.index
 	if index == nil || index.db == nil {
-		return fmt.Errorf("recreate sandbox listing cache: database is unavailable")
+		return fmt.Errorf("retry sandbox listing cache rebuild: database is unavailable")
 	}
-	if err := resetSandboxCacheSchema(ctx, index.db); err != nil {
+	if err := index.invalidate(ctx); err != nil {
 		return err
 	}
 	if err := s.completeIndexRebuild(ctx); err != nil {
-		return fmt.Errorf("reconcile recreated sandbox listing cache: %w", err)
+		return fmt.Errorf("retry sandbox listing cache rebuild: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -105,7 +105,9 @@ func NewWithConfig(config *appconfig.Config) (*Store, error) {
 
 // NewWithDatabase constructs a Store using the application's shared data.db
 // connection. The caller owns db; closing the Store only releases index-owned
-// resources and never closes the shared database.
+// resources and never closes the shared database. The database must have been
+// opened with storage/sqlite.Open or successfully passed through
+// storage/sqlite.Migrate before this function is called.
 func NewWithDatabase(config *appconfig.Config, db *sql.DB, projectResolvers ...SandboxProjectResolver) (*Store, error) {
 	index, _, err := openSandboxCacheDB(context.Background(), db)
 	var projectResolver SandboxProjectResolver

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -66,6 +66,7 @@ type Store struct {
 	index                 *sandboxCache
 	indexRepairMu         sync.Mutex
 	indexDirty            atomic.Bool
+	projectResolver       SandboxProjectResolver
 }
 
 type CacheDependencyLocker interface {
@@ -85,10 +86,10 @@ func NewWithConfig(config *appconfig.Config) (*Store, error) {
 	}
 	database, err := storagesqlite.Open(dbPath, config.DbTimeout)
 	if err != nil {
-		return newStoreWithIndex(config, nil, dbPath, err)
+		return newStoreWithIndex(config, nil, dbPath, err, nil)
 	}
 	index, _, indexErr := openSandboxCacheDB(context.Background(), database.DB())
-	store, err := newStoreWithIndex(config, index, dbPath, indexErr)
+	store, err := newStoreWithIndex(config, index, dbPath, indexErr, nil)
 	if err != nil {
 		return nil, errors.Join(err, database.Close())
 	}
@@ -105,16 +106,20 @@ func NewWithConfig(config *appconfig.Config) (*Store, error) {
 // NewWithDatabase constructs a Store using the application's shared data.db
 // connection. The caller owns db; closing the Store only releases index-owned
 // resources and never closes the shared database.
-func NewWithDatabase(config *appconfig.Config, db *sql.DB) (*Store, error) {
+func NewWithDatabase(config *appconfig.Config, db *sql.DB, projectResolvers ...SandboxProjectResolver) (*Store, error) {
 	index, _, err := openSandboxCacheDB(context.Background(), db)
-	return newStoreWithIndex(config, index, config.DbAddr, err)
+	var projectResolver SandboxProjectResolver
+	if len(projectResolvers) > 0 {
+		projectResolver = projectResolvers[0]
+	}
+	return newStoreWithIndex(config, index, config.DbAddr, err, projectResolver)
 }
 
-func newStoreWithIndex(config *appconfig.Config, index *sandboxCache, dbPath string, indexErr error) (*Store, error) {
+func newStoreWithIndex(config *appconfig.Config, index *sandboxCache, dbPath string, indexErr error, projectResolver SandboxProjectResolver) (*Store, error) {
 	if err := os.MkdirAll(config.SandboxRoot, 0o755); err != nil {
 		return nil, closeSandboxCacheAfterStoreInitFailure(index, fmt.Errorf("create sandbox root: %w", err))
 	}
-	store := &Store{config: config}
+	store := &Store{config: config, projectResolver: projectResolver}
 	if err := store.backfillOwnershipRecords(); err != nil {
 		return nil, closeSandboxCacheAfterStoreInitFailure(index, err)
 	}
@@ -236,6 +241,7 @@ func (s *Store) runIndexRebuild(ctx context.Context) error {
 		return fmt.Errorf("read sandbox root: %w", err)
 	}
 	validIDs := make(map[string]struct{}, len(entries))
+	var sandboxes []*Sandbox
 	for _, entry := range entries {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -248,10 +254,17 @@ func (s *Store) runIndexRebuild(ctx context.Context) error {
 			// Not a loadable sandbox (corrupt/foreign dir): skip, not a failure.
 			continue
 		}
-		if upsertErr := s.index.Reconcile(ctx, sandbox); upsertErr != nil {
+		sandboxes = append(sandboxes, sandbox)
+		validIDs[sandbox.Summary.ID] = struct{}{}
+	}
+	projectIDs, err := s.resolveSandboxProjectIDs(ctx, sandboxes)
+	if err != nil {
+		return fmt.Errorf("resolve sandbox project projection: %w", err)
+	}
+	for _, sandbox := range sandboxes {
+		if upsertErr := s.index.Reconcile(ctx, sandbox, projectIDs[sandbox.Summary.ID]); upsertErr != nil {
 			return fmt.Errorf("upsert %s: %w", sandbox.Summary.ID, upsertErr)
 		}
-		validIDs[sandbox.Summary.ID] = struct{}{}
 	}
 
 	// Rows are retained only for metadata that was successfully loaded. A
@@ -476,11 +489,17 @@ func (s *Store) recordIndex(session *Sandbox) {
 		slog.Warn("load committed sandbox for index failed", "sandbox_id", session.Summary.ID, "error", err)
 		return
 	}
-	s.indexRepairMu.Lock()
-	defer s.indexRepairMu.Unlock()
 	indexCtx, cancel := context.WithTimeout(context.Background(), sandboxCacheWriteTimeout)
 	defer cancel()
-	if err := s.index.Upsert(indexCtx, indexed); err != nil {
+	projectIDs, err := s.resolveSandboxProjectIDs(indexCtx, []*Sandbox{indexed})
+	if err != nil {
+		s.indexDirty.Store(true)
+		slog.Warn("resolve committed sandbox project for index failed", "sandbox_id", session.Summary.ID, "error", err)
+		return
+	}
+	s.indexRepairMu.Lock()
+	defer s.indexRepairMu.Unlock()
+	if err := s.index.Upsert(indexCtx, indexed, projectIDs[indexed.Summary.ID]); err != nil {
 		s.indexDirty.Store(true)
 		slog.Warn("sandbox listing cache upsert failed", "sandbox_id", session.Summary.ID, "error", err)
 	}

--- a/pkg/storage/sqlite/migrations/000002_sandbox_project_projection.sql
+++ b/pkg/storage/sqlite/migrations/000002_sandbox_project_projection.sql
@@ -1,0 +1,47 @@
+-- The sandbox table is a rebuildable projection of filesystem metadata. Drop
+-- the previous projection so the session store repopulates project ownership
+-- from the authoritative run records before serving indexed queries.
+DROP TABLE IF EXISTS sandboxes;
+DROP TABLE IF EXISTS sandbox_projection_meta;
+
+CREATE TABLE sandbox_projection_meta (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE sandboxes (
+    id                         TEXT PRIMARY KEY,
+    short_id                   TEXT NOT NULL DEFAULT '',
+    title                      TEXT NOT NULL DEFAULT '',
+    trigger_source             TEXT NOT NULL DEFAULT '',
+    driver                     TEXT NOT NULL DEFAULT '',
+    vm_status                  TEXT NOT NULL DEFAULT '',
+    project_id                 TEXT NOT NULL DEFAULT '',
+    workspace_path             TEXT NOT NULL DEFAULT '',
+    workspace_id               TEXT NOT NULL DEFAULT '',
+    nested_workspace_id        TEXT NOT NULL DEFAULT '',
+    workspace_name             TEXT NOT NULL DEFAULT '',
+    workspace_type             TEXT NOT NULL DEFAULT '',
+    created_at                 INTEGER NOT NULL DEFAULT 0,
+    updated_at                 INTEGER NOT NULL DEFAULT 0,
+    sandbox_type               TEXT NOT NULL DEFAULT '',
+    title_search               TEXT NOT NULL DEFAULT '',
+    trigger_source_search      TEXT NOT NULL DEFAULT '',
+    driver_search              TEXT NOT NULL DEFAULT '',
+    vm_status_search           TEXT NOT NULL DEFAULT '',
+    project_id_search          TEXT NOT NULL DEFAULT '',
+    workspace_path_search      TEXT NOT NULL DEFAULT '',
+    workspace_id_search        TEXT NOT NULL DEFAULT '',
+    nested_workspace_id_search TEXT NOT NULL DEFAULT '',
+    workspace_name_search      TEXT NOT NULL DEFAULT '',
+    workspace_type_search      TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX idx_sandboxes_updated
+    ON sandboxes(updated_at DESC, id DESC);
+CREATE INDEX idx_sandboxes_vm_status_updated
+    ON sandboxes(vm_status_search, updated_at DESC, id DESC);
+CREATE INDEX idx_sandboxes_project_updated
+    ON sandboxes(project_id_search, updated_at DESC, id DESC);
+CREATE INDEX idx_sandboxes_type_updated
+    ON sandboxes(sandbox_type, updated_at DESC, id DESC);

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -72,7 +72,7 @@ func TestMigrationBaseline(t *testing.T) {
 		"idx_project_run_event_sequence", "idx_project_run_project_status", "idx_project_run_sandbox",
 		"idx_project_run_scheduler", "idx_project_scheduler_agent", "idx_project_scheduler_id",
 		"idx_project_scheduler_managed_loader", "idx_project_short_id", "idx_project_source_path",
-		"idx_project_volumes_volume", "idx_sandboxes_type_updated", "idx_sandboxes_updated",
+		"idx_project_volumes_volume", "idx_sandboxes_project_updated", "idx_sandboxes_type_updated", "idx_sandboxes_updated",
 		"idx_sandboxes_vm_status_updated", "idx_volumes_driver", "idx_volumes_project",
 		"idx_webhook_source_enabled_topic",
 	} {
@@ -169,6 +169,51 @@ func TestMigrationBaseline(t *testing.T) {
 	}
 }
 
+func TestSandboxProjectProjectionMigrationInvalidatesCache(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	available, err := loadMigrations(embeddedMigrations)
+	if err != nil {
+		t.Fatalf("load migrations: %v", err)
+	}
+	if len(available) < 2 {
+		t.Fatalf("migration count = %d, want at least 2", len(available))
+	}
+	if err := applyMigrationSet(ctx, db, available[:1]); err != nil {
+		t.Fatalf("apply baseline migration: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO sandboxes(id, updated_at) VALUES('stale-sandbox', 123);
+		INSERT INTO sandbox_projection_meta(id, version) VALUES(1, 1);
+	`); err != nil {
+		t.Fatalf("seed previous sandbox projection: %v", err)
+	}
+
+	if err := applyMigrationSet(ctx, db, available); err != nil {
+		t.Fatalf("apply sandbox project projection migration: %v", err)
+	}
+	var sandboxCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sandboxes`).Scan(&sandboxCount); err != nil {
+		t.Fatalf("count migrated sandbox projection: %v", err)
+	}
+	if sandboxCount != 0 {
+		t.Fatalf("migrated sandbox projection retained %d stale rows", sandboxCount)
+	}
+	var versionCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sandbox_projection_meta`).Scan(&versionCount); err != nil {
+		t.Fatalf("count migrated sandbox projection versions: %v", err)
+	}
+	if versionCount != 0 {
+		t.Fatalf("migrated sandbox projection version rows = %d, want 0 to force rebuild", versionCount)
+	}
+	if rows, err := db.QueryContext(ctx, `SELECT project_id, project_id_search FROM sandboxes LIMIT 0`); err != nil {
+		t.Fatalf("query migrated sandbox project columns: %v", err)
+	} else if err := rows.Close(); err != nil {
+		t.Fatalf("close migrated sandbox project column query: %v", err)
+	}
+	assertSQLiteIndexColumns(t, db, "idx_sandboxes_project_updated", []string{"project_id_search", "updated_at", "id"}, []bool{false, true, true})
+}
+
 func TestBaselineIncludesPreviouslyOmittedSchema(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
@@ -183,6 +228,7 @@ func TestBaselineIncludesPreviouslyOmittedSchema(t *testing.T) {
 	}{
 		{name: "idx_sandboxes_updated", columns: []string{"updated_at", "id"}, descending: []bool{true, true}},
 		{name: "idx_sandboxes_vm_status_updated", columns: []string{"vm_status_search", "updated_at", "id"}, descending: []bool{false, true, true}},
+		{name: "idx_sandboxes_project_updated", columns: []string{"project_id_search", "updated_at", "id"}, descending: []bool{false, true, true}},
 		{name: "idx_sandboxes_type_updated", columns: []string{"sandbox_type", "updated_at", "id"}, descending: []bool{false, true, true}},
 		{name: "idx_loader_run_trigger_started", columns: []string{"loader_id", "trigger_id", "started_at", "run_id"}, descending: []bool{false, false, true, true}},
 		{name: "idx_loader_run_status_started", columns: []string{"loader_id", "status", "started_at", "run_id"}, descending: []bool{false, false, true, true}},
@@ -467,7 +513,7 @@ func TestMigratesEveryLegacyAddedColumn(t *testing.T) {
 		"idx_project_run_sandbox", "idx_event_dispatch_attempt", "idx_event_parent",
 		"idx_loader_run_trigger_started", "idx_loader_run_status_started", "idx_loader_run_prune",
 		"idx_loader_event_run_created", "idx_event_sandbox_link_loader_run", "idx_event_delivery_loader_run",
-		"idx_sandboxes_updated", "idx_sandboxes_vm_status_updated", "idx_sandboxes_type_updated",
+		"idx_sandboxes_updated", "idx_sandboxes_vm_status_updated", "idx_sandboxes_project_updated", "idx_sandboxes_type_updated",
 	} {
 		assertSQLiteIndexExists(t, db, index)
 	}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -8961,6 +8961,8 @@ type ListSandboxesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Limit         uint32                 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
 	Cursor        string                 `protobuf:"bytes,2,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	ProjectId     string                 `protobuf:"bytes,3,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	Status        []string               `protobuf:"bytes,4,rep,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -9007,6 +9009,20 @@ func (x *ListSandboxesRequest) GetCursor() string {
 		return x.Cursor
 	}
 	return ""
+}
+
+func (x *ListSandboxesRequest) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *ListSandboxesRequest) GetStatus() []string {
+	if x != nil {
+		return x.Status
+	}
+	return nil
 }
 
 type ListSandboxesResponse struct {
@@ -17781,10 +17797,13 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"SandboxTag\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"D\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"{\n" +
 	"\x14ListSandboxesRequest\x12\x14\n" +
 	"\x05limit\x18\x01 \x01(\rR\x05limit\x12\x16\n" +
-	"\x06cursor\x18\x02 \x01(\tR\x06cursor\"p\n" +
+	"\x06cursor\x18\x02 \x01(\tR\x06cursor\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x03 \x01(\tR\tprojectId\x12\x16\n" +
+	"\x06status\x18\x04 \x03(\tR\x06status\"p\n" +
 	"\x15ListSandboxesResponse\x126\n" +
 	"\tsandboxes\x18\x01 \x03(\v2\x18.agentcompose.v2.SandboxR\tsandboxes\x12\x1f\n" +
 	"\vnext_cursor\x18\x02 \x01(\tR\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -1106,6 +1106,8 @@ message SandboxTag {
 message ListSandboxesRequest {
   uint32 limit = 1;
   string cursor = 2;
+  string project_id = 3;
+  repeated string status = 4;
 }
 
 message ListSandboxesResponse {


### PR DESCRIPTION
## Summary

Adds server-side project and status filtering to ListSandboxes, so ps and sandbox ls no longer need to transfer every sandbox from the daemon before filtering.

Closes #367.

## Root cause and solution

ListSandboxesRequest only exposed pagination, even though status filtering was already supported by the sessionstore index. Project ownership was resolved only while mapping response rows, after pagination.

This change:

- adds project_id and repeated status filters to the v2 request and regenerates protobuf code;
- pushes both filters through the API/domain boundary into the indexed sessionstore query;
- adds a versioned project_id projection and a project/update-time index;
- populates project ownership through the existing SandboxRunTargetResolver, including legacy associations, instead of duplicating CLI fallback rules in storage;
- rebuilds the disposable projection when upgrading from the previous schema version;
- sends project/status filters from ps, while retaining final client-side filtering so a new CLI remains correct when an older daemon ignores unknown fields;
- supports multiple status values and preserves --all as an unfiltered status query.

## Compatibility

The protobuf change only appends fields. Existing clients continue sending no filters. New clients talking to an older daemon still receive unfiltered pages and apply the existing local project/status checks, so they do not expose rows from another project.

## Testing

Passed locally:

- task generate:proto
- go test for model, sessionstore, API, app, and CLI packages
- focused project/status projection, API propagation, and CLI compatibility tests
- task lint
- task test
  - Unit: 74.75%
  - Integration: 60.55%
  - E2E: 61.51%
  - Combined: 78.56%

task build was not rerun in this worktree because the same host-wide build attempt was blocked fetching docker.io/library/golang:1-alpine for the BoxLite/Microsandbox development artifacts. Go packages, generated protobuf packages, runtime SDK coverage builds, and all test shapes compiled successfully under task test.

## Checklist

- [x] Documentation updated when behavior or configuration changed, or no public manual change was required.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
