### PR TITLE
fix(cli): list stored projects without compose file

### DIFF
--- a/cmd/agent-compose/cli_project.go
+++ b/cmd/agent-compose/cli_project.go
@@ -587,6 +587,12 @@ func composeProjectAgentOutputFromProto(agent *agentcomposev2.ProjectAgent) comp
 
 func commandExitErrorForComposeProject(err error, command, projectName, composePath string) error {
 	if connect.CodeOf(err) == connect.CodeNotFound {
+		if strings.TrimSpace(composePath) == "" {
+			return commandExitError{
+				Code: exitCodeUsage,
+				Err:  fmt.Errorf("project %q was not found on this daemon", projectName),
+			}
+		}
 		return commandExitError{
 			Code: exitCodeUsage,
 			Err: fmt.Errorf(

--- a/cmd/agent-compose/cli_ps_project.go
+++ b/cmd/agent-compose/cli_ps_project.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+type composePSProjectSelection struct {
+	composePath string
+	projectName string
+	projectRef  *agentcomposev2.ProjectRef
+}
+
+// resolveComposePSProject selects an already-applied project by name only when
+// no default compose file exists. Explicit files and discovered compose files
+// retain the ordinary compose project identity rules.
+func resolveComposePSProject(cli cliOptions) (composePSProjectSelection, error) {
+	projectName := strings.TrimSpace(cli.ProjectName)
+	if strings.TrimSpace(cli.ComposeFile) == "" && projectName != "" {
+		composePath, err := resolveComposePath("")
+		if err != nil {
+			return composePSProjectSelection{}, err
+		}
+		exists, err := fileExists(composePath)
+		if err != nil {
+			return composePSProjectSelection{}, err
+		}
+		if !exists {
+			return composePSProjectSelection{
+				projectName: projectName,
+				projectRef:  &agentcomposev2.ProjectRef{Name: projectName},
+			}, nil
+		}
+	}
+
+	composePath, normalized, projectID, err := resolveComposeProject(cli)
+	if err != nil {
+		return composePSProjectSelection{}, err
+	}
+	return composePSProjectSelection{
+		composePath: composePath,
+		projectName: normalized.Name,
+		projectRef:  &agentcomposev2.ProjectRef{ProjectId: projectID},
+	}, nil
+}

--- a/cmd/agent-compose/cli_ps_project_test.go
+++ b/cmd/agent-compose/cli_ps_project_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestIntegrationCLIPSSelectsStoredProjectByNameWithoutComposeFile(t *testing.T) {
+	for _, command := range [][]string{{"ps"}, {"sandbox", "ls"}} {
+		t.Run(strings.Join(command, " "), func(t *testing.T) {
+			withWorkingDir(t, t.TempDir())
+			server := newComposeServiceStubServer(t, composeServiceStubs{
+				project: projectServiceStub{getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+					if req.Msg.GetProject().GetName() != "legacy-v1-default" || req.Msg.GetProject().GetProjectId() != "" {
+						t.Fatalf("project ref = %#v, want name-only legacy-v1-default", req.Msg.GetProject())
+					}
+					return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject("legacy-project-id", "legacy-v1-default", "")}), nil
+				}},
+				run: runServiceStub{listRuns: func(context.Context, *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
+					return connect.NewResponse(&agentcomposev2.ListRunsResponse{}), nil
+				}},
+				sandbox: sandboxServiceStub{listSandboxes: func(context.Context, *connect.Request[agentcomposev2.ListSandboxesRequest]) (*connect.Response[agentcomposev2.ListSandboxesResponse], error) {
+					return connect.NewResponse(&agentcomposev2.ListSandboxesResponse{}), nil
+				}},
+			})
+			t.Cleanup(server.Close)
+
+			args := append(append([]string(nil), command...), "--project-name", "legacy-v1-default", "--host", server.URL)
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != 0 || stderr != "" {
+				t.Fatalf("%s code/stdout/stderr = %d / %q / %q", strings.Join(command, " "), exitCode, stdout, stderr)
+			}
+			if !strings.Contains(stdout, "SANDBOX ID") {
+				t.Fatalf("%s output = %q, want sandbox table", strings.Join(command, " "), stdout)
+			}
+		})
+	}
+}
+
+func TestResolveComposePSProjectKeepsComposeAndExplicitFileSemantics(t *testing.T) {
+	t.Run("existing default compose keeps derived id", func(t *testing.T) {
+		dir := t.TempDir()
+		writeComposeFile(t, dir, "name: original\nagents: {}\n")
+		withWorkingDir(t, dir)
+
+		selection, err := resolveComposePSProject(cliOptions{ProjectName: "override"})
+		if err != nil {
+			t.Fatalf("resolve compose ps project: %v", err)
+		}
+		if selection.projectRef.GetProjectId() == "" || selection.projectRef.GetName() != "" || selection.projectName != "override" || selection.composePath == "" {
+			t.Fatalf("selection = %#v, ref=%#v", selection, selection.projectRef)
+		}
+	})
+
+	t.Run("explicit missing file does not fall back", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing.yml")
+		_, err := resolveComposePSProject(cliOptions{ComposeFile: missing, ProjectName: "stored-project"})
+		if err == nil || !strings.Contains(err.Error(), "no such file") {
+			t.Fatalf("resolve explicit missing file error = %v", err)
+		}
+	})
+}
+
+func TestIntegrationCLIPSNameSelectionClassifiesLookupErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		code connect.Code
+		want string
+	}{
+		{name: "not found", code: connect.CodeNotFound, want: `project "missing" was not found on this daemon`},
+		{name: "ambiguous", code: connect.CodeInvalidArgument, want: "ambiguous"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withWorkingDir(t, t.TempDir())
+			server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{getProject: func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				return nil, connect.NewError(tt.code, errors.New(tt.want))
+			}}})
+			t.Cleanup(server.Close)
+
+			_, stderr, _, exitCode := executeCLICommand("ps", "--project-name", "missing", "--host", server.URL)
+			if exitCode != exitCodeUsage || !strings.Contains(stderr, tt.want) {
+				t.Fatalf("ps code/stderr = %d / %q, want usage containing %q", exitCode, stderr, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -470,7 +470,7 @@ func normalizeOptionalRunModeValue(value string) string {
 }
 
 func runComposePSCommand(cmd *cobra.Command, cli cliOptions, options composePSOptions) error {
-	composePath, normalized, projectID, err := resolveComposeProject(cli)
+	selection, err := resolveComposePSProject(cli)
 	if err != nil {
 		return err
 	}
@@ -479,14 +479,14 @@ func runComposePSCommand(cmd *cobra.Command, cli cliOptions, options composePSOp
 		return err
 	}
 	project, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project: selection.projectRef,
 	}))
 	if err != nil {
-		return commandExitErrorForComposeProject(fmt.Errorf("get project %s: %w", normalized.Name, err), "ps", normalized.Name, composePath)
+		return commandExitErrorForComposeProject(fmt.Errorf("get project %s: %w", selection.projectName, err), "ps", selection.projectName, selection.composePath)
 	}
 	output, err := composePSOutputFromProject(cmd.Context(), clients, project.Msg.GetProject(), options)
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("build ps for project %s: %w", normalized.Name, err))
+		return commandExitErrorForConnect(fmt.Errorf("build ps for project %s: %w", selection.projectName, err))
 	}
 	if cli.JSON {
 		data, err := json.MarshalIndent(output, "", "  ")

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -21,7 +21,7 @@ Global options are placed between `agent-compose` and the subcommand, and apply 
 | --- | --- |
 | `-f, --file <path>` | Path to the project config file. Both `agent-compose.yml` and `agent-compose.yaml` are supported. When this option is used, the project root is the config file directory, so you do not need to `cd` into it. |
 | `--host <endpoint>` | Daemon HTTP endpoint. This can target a local daemon or a remote daemon. |
-| `--project-name <name>` | Override the project name from the config file. Useful when running the same config under different environment names. |
+| `--project-name <name>` | Override the project name from the config file. For `ps` and `sandbox ls`, it also selects an existing daemon project when the current directory has no default compose file. |
 | `--json` | Print machine-readable JSON for scripts, AI agents, and automation. |
 
 Examples:
@@ -273,6 +273,7 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 
 List sandboxes in the current project. By default, only running sandboxes are shown. With `--all`, the command includes all statuses while remaining scoped to the current project.
 The project must already exist on the daemon; after `agent-compose down`, run `agent-compose up` again before using `ps`.
+When no default compose file is available, use `--project-name <name>` to select an existing daemon project. An explicit missing `--file` remains an error.
 
 ```bash
 agent-compose ps

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -21,7 +21,7 @@ agent-compose [global options] <command> [command options] [arguments]
 | --- | --- |
 | `-f, --file <path>` | 指定 project 配置文件。支持 `agent-compose.yml` 和 `agent-compose.yaml`。使用该参数后，可以在任意目录操作该 project，project root 为配置文件所在目录。 |
 | `--host <endpoint>` | 指定 daemon 地址。可以连接本机 daemon，也可以连接远程 daemon。 |
-| `--project-name <name>` | 覆盖配置文件中的 project 名称。适用于同一份配置在不同环境中以不同 project 名称运行的场景。 |
+| `--project-name <name>` | 覆盖配置文件中的 project 名称。对于 `ps` 和 `sandbox ls`，当前目录没有默认 compose 文件时，也可用它选择 daemon 中已有的 project。 |
 | `--json` | 使用 JSON 输出，供脚本、AI 和自动化系统解析。 |
 
 示例：
@@ -273,6 +273,7 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 
 查看当前 project 下的 sandbox。默认只显示运行中的 sandbox。使用 `--all` 时仍限定当前 project，但会包含所有状态。
 该 project 必须已经存在于 daemon 中；执行 `agent-compose down` 后，需要先重新执行 `agent-compose up`，再使用 `ps`。
+当前目录没有默认 compose 文件时，可用 `--project-name <name>` 选择 daemon 中已有的 project；显式指定但不存在的 `--file` 仍会报错。
 
 ```bash
 agent-compose ps


### PR DESCRIPTION
## Summary

Fixes ps and sandbox ls for daemon projects whose persisted source_path is empty, including migrated legacy-v1-default projects.

The read-only list path now selects a stored project with a name-only ProjectRef when --project-name is provided and neither default compose file exists. Existing compose-file override semantics remain unchanged, and an explicitly missing --file still fails instead of hiding a typo.

The English and Chinese CLI manuals document the new fallback.

Closes #366.

## Root cause and solution

runComposePSCommand always called resolveComposeProject before contacting the daemon, so it could not reach the server's existing name-only project resolver unless a local compose file could first be parsed and converted into a stable project ID.

A dedicated read-only selector now:

- keeps compose-derived IDs when a compose file exists;
- sends a name-only ProjectRef only when no default compose file exists;
- preserves server-side not-found and ambiguous-name classification;
- returns a direct not-found message when no local compose path is available.

## Testing

Passed locally:

- go test ./cmd/agent-compose with the new selector and integration regression tests
- task docs:build
- task lint
- task test
  - Unit: 74.78%
  - Integration: 60.54%
  - E2E: 61.55%
  - Combined: 78.62%

task build was attempted but did not complete because Docker timed out fetching docker.io/library/golang:1-alpine while preparing the BoxLite/Microsandbox Linux development artifacts. The failure occurred at the external image fetch boundary, before a source build failure.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
