### PR TITLE
fix(cli): batch scheduler run lookup for ps

### DIFF
--- a/cmd/agent-compose/cli_project.go
+++ b/cmd/agent-compose/cli_project.go
@@ -473,7 +473,7 @@ func composePSOutputFromProject(ctx context.Context, clients cliServiceClients, 
 	if err != nil {
 		return composePSOutput{}, err
 	}
-	schedulerRunBySandbox, err := latestSchedulerRunsBySandbox(ctx, clients.project, project, sessions)
+	schedulerRunBySandbox, err := latestSchedulerRunsBySandbox(ctx, clients, project, sessions)
 	if err != nil {
 		return composePSOutput{}, err
 	}

--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -570,22 +570,23 @@ func assertComposeUpChange(t *testing.T, changes []composeUpChangeOutput, action
 }
 
 type projectServiceStub struct {
-	applyProject               func(context.Context, *connect.Request[agentcomposev2.ApplyProjectRequest]) (*connect.Response[agentcomposev2.ApplyProjectResponse], error)
-	getProject                 func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error)
-	listProjects               func(context.Context, *connect.Request[agentcomposev2.ListProjectsRequest]) (*connect.Response[agentcomposev2.ListProjectsResponse], error)
-	removeProject              func(context.Context, *connect.Request[agentcomposev2.RemoveProjectRequest]) (*connect.Response[agentcomposev2.RemoveProjectResponse], error)
-	getScheduler               func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error)
-	listSchedulerEvents        func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error)
-	listProjectSchedulerEvents func(context.Context, *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error)
-	streamSchedulerEvents      func(context.Context, *connect.Request[agentcomposev2.StreamProjectSchedulerEventsRequest], *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]) error
-	invokeScheduler            func(context.Context, *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error)
-	runScheduler               func(context.Context, *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error)
-	startSchedulerRun          func(context.Context, *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error)
-	getSchedulerRun            func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error)
-	listSchedulerRuns          func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error)
-	streamSchedulerRuns        func(context.Context, *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error
-	stopSchedulerRun           func(context.Context, *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error)
-	pruneSchedulerRuns         func(context.Context, *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error)
+	applyProject                func(context.Context, *connect.Request[agentcomposev2.ApplyProjectRequest]) (*connect.Response[agentcomposev2.ApplyProjectResponse], error)
+	getProject                  func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error)
+	listProjects                func(context.Context, *connect.Request[agentcomposev2.ListProjectsRequest]) (*connect.Response[agentcomposev2.ListProjectsResponse], error)
+	removeProject               func(context.Context, *connect.Request[agentcomposev2.RemoveProjectRequest]) (*connect.Response[agentcomposev2.RemoveProjectResponse], error)
+	getScheduler                func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error)
+	listSchedulerEvents         func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error)
+	listProjectSchedulerEvents  func(context.Context, *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error)
+	streamSchedulerEvents       func(context.Context, *connect.Request[agentcomposev2.StreamProjectSchedulerEventsRequest], *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]) error
+	invokeScheduler             func(context.Context, *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error)
+	runScheduler                func(context.Context, *connect.Request[agentcomposev2.RunSchedulerRequest]) (*connect.Response[agentcomposev2.RunSchedulerResponse], error)
+	startSchedulerRun           func(context.Context, *connect.Request[agentcomposev2.StartSchedulerRunRequest]) (*connect.Response[agentcomposev2.StartSchedulerRunResponse], error)
+	getSchedulerRun             func(context.Context, *connect.Request[agentcomposev2.GetSchedulerRunRequest]) (*connect.Response[agentcomposev2.GetSchedulerRunResponse], error)
+	listSchedulerRuns           func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error)
+	batchGetLatestSchedulerRuns func(context.Context, *connect.Request[agentcomposev2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[agentcomposev2.BatchGetLatestSchedulerRunsResponse], error)
+	streamSchedulerRuns         func(context.Context, *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error
+	stopSchedulerRun            func(context.Context, *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error)
+	pruneSchedulerRuns          func(context.Context, *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error)
 
 	agentcomposev2connect.UnimplementedProjectServiceHandler
 }

--- a/cmd/agent-compose/cli_ps_run_association.go
+++ b/cmd/agent-compose/cli_ps_run_association.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -10,131 +9,57 @@ import (
 
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
-	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 )
+
+const schedulerRunLookupBatchSize = 500
 
 func latestSchedulerRunsBySandbox(ctx context.Context, clients cliServiceClients, project *agentcomposev2.Project, sessions []*agentcomposev2.Sandbox) (map[string]composeSchedulerRunItem, error) {
 	projectID := strings.TrimSpace(project.GetSummary().GetProjectId())
-	schedulerAgents := make(map[string]bool)
-	targetSandboxIDs := make(map[string]struct{}, len(sessions))
+	targetSandboxIDs := make([]string, 0, len(sessions))
 	for _, session := range sessions {
-		if sandboxID := strings.TrimSpace(session.GetSandboxId()); sandboxID != "" {
-			targetSandboxIDs[sandboxID] = struct{}{}
-		}
 		tags := sessionTagsMap(session.GetTags())
 		if tags["origin"] == "scheduler" && tags["project_id"] == projectID && tags["agent"] != "" {
-			schedulerAgents[tags["agent"]] = true
+			targetSandboxIDs = appendSchedulerSandboxID(targetSandboxIDs, session.GetSandboxId())
 			continue
 		}
-		if agentName := legacySchedulerAgentForProject(tags, project); agentName != "" {
-			schedulerAgents[agentName] = true
+		if legacySchedulerAgentForProject(tags, project) != "" {
+			targetSandboxIDs = appendSchedulerSandboxID(targetSandboxIDs, session.GetSandboxId())
 		}
 	}
 	result := make(map[string]composeSchedulerRunItem)
-	for _, scheduler := range project.GetSchedulers() {
-		agentName := strings.TrimSpace(scheduler.GetAgentName())
-		if !schedulerAgents[agentName] {
-			continue
-		}
-		err := visitSchedulerRuntimeRuns(ctx, clients, projectID, agentName, func(run *agentcomposev2.SchedulerRun) error {
-			var item composeSchedulerRunItem
-			mapped := false
-			for _, sandboxID := range run.GetSandboxIds() {
-				if _, ok := targetSandboxIDs[sandboxID]; !ok {
-					continue
-				}
-				if !mapped {
-					item = schedulerRunAssociationItem(run)
-					mapped = true
-				}
-				current, ok := result[sandboxID]
-				if !ok || runTimestampAfter(schedulerRunSortTime(item), schedulerRunSortTime(current)) {
-					result[sandboxID] = item
-				}
-			}
-			return nil
-		})
+	for start := 0; start < len(targetSandboxIDs); start += schedulerRunLookupBatchSize {
+		end := min(start+schedulerRunLookupBatchSize, len(targetSandboxIDs))
+		response, err := clients.project.BatchGetLatestSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.BatchGetLatestSchedulerRunsRequest{
+			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, SandboxIds: targetSandboxIDs[start:end],
+		}))
 		if err != nil {
-			return nil, err
+			return nil, commandExitErrorForConnect(err)
+		}
+		for _, lookup := range response.Msg.GetResults() {
+			sandboxID := strings.TrimSpace(lookup.GetSandboxId())
+			run := lookup.GetRun()
+			if sandboxID == "" || run == nil {
+				continue
+			}
+			result[sandboxID] = schedulerRunPSItem(run)
 		}
 	}
 	return result, nil
 }
 
-const maxSchedulerQueryRuns = uint64(maxSchedulerQueryPages) * uint64(schedulerQueryPageSize)
+func appendSchedulerSandboxID(values []string, sandboxID string) []string {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return values
+	}
+	return append(values, sandboxID)
+}
 
-func schedulerRunAssociationItem(run *agentcomposev2.SchedulerRun) composeSchedulerRunItem {
+func schedulerRunPSItem(run *agentcomposev2.SchedulerRun) composeSchedulerRunItem {
 	return composeSchedulerRunItem{
 		RunID: run.GetRunId(), AgentName: run.GetAgentName(),
 		StartedAt: formatProtoTimestamp(run.GetStartedAt()), CompletedAt: formatProtoTimestamp(run.GetCompletedAt()),
 	}
-}
-
-func visitSchedulerRuntimeRuns(ctx context.Context, clients cliServiceClients, projectID, agentName string, visit func(*agentcomposev2.SchedulerRun) error) error {
-	if clients.projectStream == nil {
-		return visitSchedulerRuntimeRunsFallback(ctx, clients.project, projectID, agentName, visit)
-	}
-	stream, err := clients.projectStream.StreamSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName,
-		BatchSize: schedulerCLIBatchSize, Limit: uint32(maxSchedulerQueryRuns),
-	}))
-	if err != nil {
-		if connect.CodeOf(err) == connect.CodeUnimplemented {
-			return visitSchedulerRuntimeRunsFallback(ctx, clients.project, projectID, agentName, visit)
-		}
-		return commandExitErrorForConnect(fmt.Errorf("stream scheduler runs for agent %s: %w", agentName, err))
-	}
-	received := false
-	completed := false
-	truncated := false
-	var receivedRuns uint64
-	for stream.Receive() {
-		received = true
-		if completed {
-			return fmt.Errorf("daemon sent scheduler run frames after stream completion")
-		}
-		frame := stream.Msg()
-		if uint64(len(frame.GetRuns())) > maxSchedulerQueryRuns-receivedRuns {
-			return fmt.Errorf("daemon returned more than %d scheduler runs for agent %s", maxSchedulerQueryRuns, agentName)
-		}
-		receivedRuns += uint64(len(frame.GetRuns()))
-		for _, run := range frame.GetRuns() {
-			if strings.TrimSpace(run.GetTriggerId()) == "" {
-				continue
-			}
-			if err := visit(run); err != nil {
-				return err
-			}
-		}
-		if frame.GetComplete() {
-			completed = true
-			truncated = frame.GetTruncated()
-		}
-	}
-	if err := stream.Err(); err != nil {
-		if !received && connect.CodeOf(err) == connect.CodeUnimplemented {
-			return visitSchedulerRuntimeRunsFallback(ctx, clients.project, projectID, agentName, visit)
-		}
-		return commandExitErrorForConnect(fmt.Errorf("stream scheduler runs for agent %s: %w", agentName, err))
-	}
-	if !completed {
-		return fmt.Errorf("stream scheduler runs for agent %s: daemon closed the stream before completion", agentName)
-	}
-	if truncated {
-		return fmt.Errorf("daemon returned more than %d scheduler runs for agent %s", maxSchedulerQueryRuns, agentName)
-	}
-	return nil
-}
-
-func visitSchedulerRuntimeRunsFallback(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName string, visit func(*agentcomposev2.SchedulerRun) error) error {
-	err := visitSchedulerRunsFromAPI(ctx, client, projectID, agentName, visit)
-	if err != nil && connect.CodeOf(err) == connect.CodeUnimplemented {
-		return commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support scheduler run queries; upgrade the daemon")}
-	}
-	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agentName, err))
-	}
-	return nil
 }
 
 func legacySchedulerSandboxBelongsToProject(tags map[string]string, project *agentcomposev2.Project) bool {

--- a/cmd/agent-compose/cli_ps_run_association.go
+++ b/cmd/agent-compose/cli_ps_run_association.go
@@ -2,18 +2,25 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
+
+	"connectrpc.com/connect"
 
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 )
 
-func latestSchedulerRunsBySandbox(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, project *agentcomposev2.Project, sessions []*agentcomposev2.Sandbox) (map[string]composeSchedulerRunItem, error) {
+func latestSchedulerRunsBySandbox(ctx context.Context, clients cliServiceClients, project *agentcomposev2.Project, sessions []*agentcomposev2.Sandbox) (map[string]composeSchedulerRunItem, error) {
 	projectID := strings.TrimSpace(project.GetSummary().GetProjectId())
 	schedulerAgents := make(map[string]bool)
+	targetSandboxIDs := make(map[string]struct{}, len(sessions))
 	for _, session := range sessions {
+		if sandboxID := strings.TrimSpace(session.GetSandboxId()); sandboxID != "" {
+			targetSandboxIDs[sandboxID] = struct{}{}
+		}
 		tags := sessionTagsMap(session.GetTags())
 		if tags["origin"] == "scheduler" && tags["project_id"] == projectID && tags["agent"] != "" {
 			schedulerAgents[tags["agent"]] = true
@@ -29,24 +36,105 @@ func latestSchedulerRunsBySandbox(ctx context.Context, client agentcomposev2conn
 		if !schedulerAgents[agentName] {
 			continue
 		}
-		loaderID, err := domain.StableManagedLoaderID(projectID, agentName, "")
-		if err != nil {
-			return nil, err
-		}
-		runs, err := listSchedulerRuntimeRuns(ctx, client, projectID, agentName, scheduler.GetSchedulerId(), loaderID, 500)
-		if err != nil {
-			return nil, err
-		}
-		for _, run := range runs {
-			for _, sandboxID := range run.SandboxIDs {
+		err := visitSchedulerRuntimeRuns(ctx, clients, projectID, agentName, func(run *agentcomposev2.SchedulerRun) error {
+			var item composeSchedulerRunItem
+			mapped := false
+			for _, sandboxID := range run.GetSandboxIds() {
+				if _, ok := targetSandboxIDs[sandboxID]; !ok {
+					continue
+				}
+				if !mapped {
+					item = schedulerRunAssociationItem(run)
+					mapped = true
+				}
 				current, ok := result[sandboxID]
-				if !ok || runTimestampAfter(schedulerRunSortTime(run), schedulerRunSortTime(current)) {
-					result[sandboxID] = run
+				if !ok || runTimestampAfter(schedulerRunSortTime(item), schedulerRunSortTime(current)) {
+					result[sandboxID] = item
 				}
 			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
 	}
 	return result, nil
+}
+
+const maxSchedulerQueryRuns = uint64(maxSchedulerQueryPages) * uint64(schedulerQueryPageSize)
+
+func schedulerRunAssociationItem(run *agentcomposev2.SchedulerRun) composeSchedulerRunItem {
+	return composeSchedulerRunItem{
+		RunID: run.GetRunId(), AgentName: run.GetAgentName(),
+		StartedAt: formatProtoTimestamp(run.GetStartedAt()), CompletedAt: formatProtoTimestamp(run.GetCompletedAt()),
+	}
+}
+
+func visitSchedulerRuntimeRuns(ctx context.Context, clients cliServiceClients, projectID, agentName string, visit func(*agentcomposev2.SchedulerRun) error) error {
+	if clients.projectStream == nil {
+		return visitSchedulerRuntimeRunsFallback(ctx, clients.project, projectID, agentName, visit)
+	}
+	stream, err := clients.projectStream.StreamSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName,
+		BatchSize: schedulerCLIBatchSize, Limit: uint32(maxSchedulerQueryRuns),
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeUnimplemented {
+			return visitSchedulerRuntimeRunsFallback(ctx, clients.project, projectID, agentName, visit)
+		}
+		return commandExitErrorForConnect(fmt.Errorf("stream scheduler runs for agent %s: %w", agentName, err))
+	}
+	received := false
+	completed := false
+	truncated := false
+	var receivedRuns uint64
+	for stream.Receive() {
+		received = true
+		if completed {
+			return fmt.Errorf("daemon sent scheduler run frames after stream completion")
+		}
+		frame := stream.Msg()
+		if uint64(len(frame.GetRuns())) > maxSchedulerQueryRuns-receivedRuns {
+			return fmt.Errorf("daemon returned more than %d scheduler runs for agent %s", maxSchedulerQueryRuns, agentName)
+		}
+		receivedRuns += uint64(len(frame.GetRuns()))
+		for _, run := range frame.GetRuns() {
+			if strings.TrimSpace(run.GetTriggerId()) == "" {
+				continue
+			}
+			if err := visit(run); err != nil {
+				return err
+			}
+		}
+		if frame.GetComplete() {
+			completed = true
+			truncated = frame.GetTruncated()
+		}
+	}
+	if err := stream.Err(); err != nil {
+		if !received && connect.CodeOf(err) == connect.CodeUnimplemented {
+			return visitSchedulerRuntimeRunsFallback(ctx, clients.project, projectID, agentName, visit)
+		}
+		return commandExitErrorForConnect(fmt.Errorf("stream scheduler runs for agent %s: %w", agentName, err))
+	}
+	if !completed {
+		return fmt.Errorf("stream scheduler runs for agent %s: daemon closed the stream before completion", agentName)
+	}
+	if truncated {
+		return fmt.Errorf("daemon returned more than %d scheduler runs for agent %s", maxSchedulerQueryRuns, agentName)
+	}
+	return nil
+}
+
+func visitSchedulerRuntimeRunsFallback(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName string, visit func(*agentcomposev2.SchedulerRun) error) error {
+	err := visitSchedulerRunsFromAPI(ctx, client, projectID, agentName, visit)
+	if err != nil && connect.CodeOf(err) == connect.CodeUnimplemented {
+		return commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support scheduler run queries; upgrade the daemon")}
+	}
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agentName, err))
+	}
+	return nil
 }
 
 func legacySchedulerSandboxBelongsToProject(tags map[string]string, project *agentcomposev2.Project) bool {

--- a/cmd/agent-compose/cli_ps_run_association_test.go
+++ b/cmd/agent-compose/cli_ps_run_association_test.go
@@ -101,13 +101,14 @@ agents:
 				projectID = req.Msg.GetProject().GetProjectId()
 				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(projectID, "cli-ps-scheduler-run", composePath)}), nil
 			},
-			listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
-				if req.Msg.GetAgentName() != "reviewer" {
-					t.Fatalf("ListSchedulerRuns agent = %q, want reviewer", req.Msg.GetAgentName())
+			batchGetLatestSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[agentcomposev2.BatchGetLatestSchedulerRunsResponse], error) {
+				if req.Msg.GetProject().GetProjectId() != projectID || len(req.Msg.GetSandboxIds()) != 1 || req.Msg.GetSandboxIds()[0] != sandboxID {
+					t.Fatalf("BatchGetLatestSchedulerRuns request = %#v", req.Msg)
 				}
-				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
-					RunId: schedulerRunID, AgentName: "reviewer", TriggerId: "nightly", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
-					SandboxIds: []string{sandboxID}, CompletedAt: timestamppb.New(time.Date(2026, 7, 15, 12, 1, 0, 0, time.UTC)),
+				return connect.NewResponse(&agentcomposev2.BatchGetLatestSchedulerRunsResponse{Results: []*agentcomposev2.SandboxSchedulerRun{{
+					SandboxId: sandboxID,
+					Run: &agentcomposev2.SchedulerRun{RunId: schedulerRunID, AgentName: "reviewer", TriggerId: "nightly", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED,
+						CompletedAt: timestamppb.New(time.Date(2026, 7, 15, 12, 1, 0, 0, time.UTC))},
 				}}}), nil
 			},
 		},
@@ -140,229 +141,45 @@ agents:
 	}
 }
 
-func TestLatestSchedulerRunsBySandboxReadsPastFiveHundredRuns(t *testing.T) {
+func TestLatestSchedulerRunsBySandboxBatchesSandboxIDs(t *testing.T) {
 	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
-	const sandboxID = "sandbox-from-older-page"
+	sessions := make([]*agentcomposev2.Sandbox, schedulerRunLookupBatchSize+1)
+	for index := range sessions {
+		sessions[index] = &agentcomposev2.Sandbox{
+			SandboxId: fmt.Sprintf("sandbox-%03d", index),
+			Tags: []*agentcomposev2.SandboxTag{
+				{Name: "origin", Value: "scheduler"},
+				{Name: "project_id", Value: "project-1"},
+				{Name: "agent", Value: "reviewer"},
+			},
+		}
+	}
 	requests := 0
 	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+		batchGetLatestSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[agentcomposev2.BatchGetLatestSchedulerRunsResponse], error) {
 			requests++
-			if req.Msg.GetLimit() != schedulerQueryPageSize {
-				t.Fatalf("ListSchedulerRuns limit = %d, want %d", req.Msg.GetLimit(), schedulerQueryPageSize)
+			wantSize := schedulerRunLookupBatchSize
+			if requests == 2 {
+				wantSize = 1
 			}
-			switch req.Msg.GetCursor() {
-			case "":
-				runs := make([]*agentcomposev2.SchedulerRun, 500)
-				for i := range runs {
-					runs[i] = &agentcomposev2.SchedulerRun{RunId: fmt.Sprintf("recent-%03d", i), TriggerId: "nightly"}
-				}
-				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: runs, NextCursor: "older"}), nil
-			case "older":
-				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
-					RunId: "older-associated-run", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{sandboxID},
-				}}}), nil
-			default:
-				t.Fatalf("unexpected cursor %q", req.Msg.GetCursor())
-				return nil, nil
+			if len(req.Msg.GetSandboxIds()) != wantSize {
+				t.Fatalf("batch request %d sandbox count=%d, want %d", requests, len(req.Msg.GetSandboxIds()), wantSize)
 			}
+			sandboxID := req.Msg.GetSandboxIds()[0]
+			return connect.NewResponse(&agentcomposev2.BatchGetLatestSchedulerRunsResponse{Results: []*agentcomposev2.SandboxSchedulerRun{{
+				SandboxId: sandboxID,
+				Run:       &agentcomposev2.SchedulerRun{RunId: fmt.Sprintf("run-%d", requests), AgentName: "reviewer", TriggerId: "nightly"},
+			}}}), nil
 		},
 	}})
 	t.Cleanup(server.Close)
 	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-	clients := cliServiceClients{project: client, projectStream: client}
 
-	got, err := latestSchedulerRunsBySandbox(t.Context(), clients, project, []*agentcomposev2.Sandbox{{
-		SandboxId: sandboxID,
-		Tags: []*agentcomposev2.SandboxTag{
-			{Name: "origin", Value: "scheduler"},
-			{Name: "project_id", Value: "project-1"},
-			{Name: "agent", Value: "reviewer"},
-		},
-	}})
+	got, err := latestSchedulerRunsBySandbox(t.Context(), cliServiceClients{project: client}, project, sessions)
 	if err != nil {
-		t.Fatalf("latest scheduler runs: %v", err)
+		t.Fatalf("latest scheduler runs by sandbox: %v", err)
 	}
-	if requests != 2 || got[sandboxID].RunID != "older-associated-run" {
-		t.Fatalf("requests/result = %d / %#v, want two pages and older-associated-run", requests, got[sandboxID])
-	}
-}
-
-func TestVisitSchedulerRunsFromAPIRejectsRepeatedCursor(t *testing.T) {
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
-			return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{NextCursor: "repeat"}), nil
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	err := visitSchedulerRunsFromAPI(t.Context(), client, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error { return nil })
-	if err == nil || !strings.Contains(err.Error(), "repeated scheduler run cursor") {
-		t.Fatalf("list all scheduler runs error = %v", err)
-	}
-}
-
-func TestVisitSchedulerRunsFromAPIRejectsExcessivePages(t *testing.T) {
-	requests := 0
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		listSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
-			requests++
-			return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{NextCursor: fmt.Sprintf("page-%d", requests)}), nil
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	err := visitSchedulerRunsFromAPI(t.Context(), client, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error { return nil })
-	if err == nil || !strings.Contains(err.Error(), "more than 1000 scheduler run pages") {
-		t.Fatalf("list excessive scheduler run pages error = %v", err)
-	}
-	if requests != maxSchedulerQueryPages {
-		t.Fatalf("scheduler run page requests = %d, want %d", requests, maxSchedulerQueryPages)
-	}
-}
-
-func TestLatestSchedulerRunsBySandboxStreamsAndRetainsOnlyTargets(t *testing.T) {
-	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
-	const sandboxID = "current-sandbox"
-	streamRequests := 0
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		streamSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
-			streamRequests++
-			if req.Msg.GetAgentName() != "reviewer" || req.Msg.GetBatchSize() != schedulerCLIBatchSize || req.Msg.GetLimit() != uint32(maxSchedulerQueryRuns) {
-				t.Fatalf("stream scheduler runs request = %#v", req.Msg)
-			}
-			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{
-				{RunId: "newest-target", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{sandboxID}, CompletedAt: timestamppb.New(time.Unix(200, 0)), ResultJson: strings.Repeat("x", 1024)},
-				{RunId: "irrelevant", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{"historical-sandbox"}, ResultJson: strings.Repeat("x", 1024)},
-			}}); err != nil {
-				return err
-			}
-			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
-				RunId: "older-target", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{sandboxID}, CompletedAt: timestamppb.New(time.Unix(100, 0)),
-			}}}); err != nil {
-				return err
-			}
-			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true})
-		},
-		listSchedulerRuns: func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
-			t.Fatal("stream-capable daemon unexpectedly used unary scheduler run fallback")
-			return nil, nil
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	got, err := latestSchedulerRunsBySandbox(t.Context(), cliServiceClients{project: client, projectStream: client}, project, []*agentcomposev2.Sandbox{{
-		SandboxId: sandboxID,
-		Tags: []*agentcomposev2.SandboxTag{
-			{Name: "origin", Value: "scheduler"},
-			{Name: "project_id", Value: "project-1"},
-			{Name: "agent", Value: "reviewer"},
-		},
-	}})
-	if err != nil {
-		t.Fatalf("latest streamed scheduler runs: %v", err)
-	}
-	if streamRequests != 1 || len(got) != 1 || got[sandboxID].RunID != "newest-target" || got[sandboxID].ResultJSON != "" {
-		t.Fatalf("stream requests/result = %d / %#v, want one target association", streamRequests, got)
-	}
-}
-
-func TestVisitSchedulerRuntimeRunsAcceptsSparseFrames(t *testing.T) {
-	const sparseFrames = int(maxSchedulerQueryRuns)/schedulerCLIBatchSize + 2
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		streamSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
-			for i := range sparseFrames {
-				if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
-					RunId: fmt.Sprintf("run-%d", i), TriggerId: "nightly",
-				}}}); err != nil {
-					return err
-				}
-			}
-			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true})
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	visited := 0
-	err := visitSchedulerRuntimeRuns(t.Context(), cliServiceClients{project: client, projectStream: client}, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error {
-		visited++
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("visit sparse scheduler run stream: %v", err)
-	}
-	if visited != sparseFrames {
-		t.Fatalf("visited scheduler runs = %d, want %d", visited, sparseFrames)
-	}
-}
-
-func TestVisitSchedulerRuntimeRunsRejectsFramesAfterCompletion(t *testing.T) {
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		streamSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
-			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
-				RunId: "before-completion", TriggerId: "nightly",
-			}}}); err != nil {
-				return err
-			}
-			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true}); err != nil {
-				return err
-			}
-			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
-				RunId: "after-completion", TriggerId: "nightly",
-			}}})
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	visited := 0
-	err := visitSchedulerRuntimeRuns(t.Context(), cliServiceClients{project: client, projectStream: client}, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error {
-		visited++
-		return nil
-	})
-	if err == nil || !strings.Contains(err.Error(), "after stream completion") {
-		t.Fatalf("frames after scheduler run completion error = %v", err)
-	}
-	if visited != 1 {
-		t.Fatalf("visited scheduler runs = %d, want 1", visited)
-	}
-}
-
-func TestLatestSchedulerRunsBySandboxRejectsIncompleteStream(t *testing.T) {
-	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		streamSchedulerRuns: func(context.Context, *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
-			return nil
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	_, err := latestSchedulerRunsBySandbox(t.Context(), cliServiceClients{project: client, projectStream: client}, project, []*agentcomposev2.Sandbox{{
-		SandboxId: "current-sandbox", Tags: []*agentcomposev2.SandboxTag{{Name: "origin", Value: "scheduler"}, {Name: "project_id", Value: "project-1"}, {Name: "agent", Value: "reviewer"}},
-	}})
-	if err == nil || !strings.Contains(err.Error(), "before completion") {
-		t.Fatalf("incomplete scheduler run stream error = %v", err)
-	}
-}
-
-func TestLatestSchedulerRunsBySandboxRejectsTruncatedStream(t *testing.T) {
-	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		streamSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
-			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true, Truncated: true})
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	_, err := latestSchedulerRunsBySandbox(t.Context(), cliServiceClients{project: client, projectStream: client}, project, []*agentcomposev2.Sandbox{{
-		SandboxId: "current-sandbox", Tags: []*agentcomposev2.SandboxTag{{Name: "origin", Value: "scheduler"}, {Name: "project_id", Value: "project-1"}, {Name: "agent", Value: "reviewer"}},
-	}})
-	if err == nil || !strings.Contains(err.Error(), "more than 500000 scheduler runs") {
-		t.Fatalf("truncated scheduler run stream error = %v", err)
+	if requests != 2 || len(got) != 2 || got["sandbox-000"].RunID != "run-1" || got["sandbox-500"].RunID != "run-2" {
+		t.Fatalf("requests/results=%d/%#v", requests, got)
 	}
 }

--- a/cmd/agent-compose/cli_ps_run_association_test.go
+++ b/cmd/agent-compose/cli_ps_run_association_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 )
 
 func TestSchedulerRunIsNewer(t *testing.T) {
@@ -135,5 +137,232 @@ agents:
 	}
 	if !strings.Contains(stdout, schedulerRunID[:12]) || strings.Contains(stdout, projectRunID[:12]) || strings.Contains(stdout, staleTagRunID[:12]) {
 		t.Fatalf("ps output = %q, want latest scheduler run %s", stdout, schedulerRunID[:12])
+	}
+}
+
+func TestLatestSchedulerRunsBySandboxReadsPastFiveHundredRuns(t *testing.T) {
+	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
+	const sandboxID = "sandbox-from-older-page"
+	requests := 0
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+			requests++
+			if req.Msg.GetLimit() != schedulerQueryPageSize {
+				t.Fatalf("ListSchedulerRuns limit = %d, want %d", req.Msg.GetLimit(), schedulerQueryPageSize)
+			}
+			switch req.Msg.GetCursor() {
+			case "":
+				runs := make([]*agentcomposev2.SchedulerRun, 500)
+				for i := range runs {
+					runs[i] = &agentcomposev2.SchedulerRun{RunId: fmt.Sprintf("recent-%03d", i), TriggerId: "nightly"}
+				}
+				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: runs, NextCursor: "older"}), nil
+			case "older":
+				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+					RunId: "older-associated-run", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{sandboxID},
+				}}}), nil
+			default:
+				t.Fatalf("unexpected cursor %q", req.Msg.GetCursor())
+				return nil, nil
+			}
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+	clients := cliServiceClients{project: client, projectStream: client}
+
+	got, err := latestSchedulerRunsBySandbox(t.Context(), clients, project, []*agentcomposev2.Sandbox{{
+		SandboxId: sandboxID,
+		Tags: []*agentcomposev2.SandboxTag{
+			{Name: "origin", Value: "scheduler"},
+			{Name: "project_id", Value: "project-1"},
+			{Name: "agent", Value: "reviewer"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("latest scheduler runs: %v", err)
+	}
+	if requests != 2 || got[sandboxID].RunID != "older-associated-run" {
+		t.Fatalf("requests/result = %d / %#v, want two pages and older-associated-run", requests, got[sandboxID])
+	}
+}
+
+func TestVisitSchedulerRunsFromAPIRejectsRepeatedCursor(t *testing.T) {
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+			return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{NextCursor: "repeat"}), nil
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	err := visitSchedulerRunsFromAPI(t.Context(), client, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "repeated scheduler run cursor") {
+		t.Fatalf("list all scheduler runs error = %v", err)
+	}
+}
+
+func TestVisitSchedulerRunsFromAPIRejectsExcessivePages(t *testing.T) {
+	requests := 0
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+			requests++
+			return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{NextCursor: fmt.Sprintf("page-%d", requests)}), nil
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	err := visitSchedulerRunsFromAPI(t.Context(), client, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "more than 1000 scheduler run pages") {
+		t.Fatalf("list excessive scheduler run pages error = %v", err)
+	}
+	if requests != maxSchedulerQueryPages {
+		t.Fatalf("scheduler run page requests = %d, want %d", requests, maxSchedulerQueryPages)
+	}
+}
+
+func TestLatestSchedulerRunsBySandboxStreamsAndRetainsOnlyTargets(t *testing.T) {
+	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
+	const sandboxID = "current-sandbox"
+	streamRequests := 0
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		streamSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+			streamRequests++
+			if req.Msg.GetAgentName() != "reviewer" || req.Msg.GetBatchSize() != schedulerCLIBatchSize || req.Msg.GetLimit() != uint32(maxSchedulerQueryRuns) {
+				t.Fatalf("stream scheduler runs request = %#v", req.Msg)
+			}
+			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{
+				{RunId: "newest-target", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{sandboxID}, CompletedAt: timestamppb.New(time.Unix(200, 0)), ResultJson: strings.Repeat("x", 1024)},
+				{RunId: "irrelevant", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{"historical-sandbox"}, ResultJson: strings.Repeat("x", 1024)},
+			}}); err != nil {
+				return err
+			}
+			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+				RunId: "older-target", AgentName: "reviewer", TriggerId: "nightly", SandboxIds: []string{sandboxID}, CompletedAt: timestamppb.New(time.Unix(100, 0)),
+			}}}); err != nil {
+				return err
+			}
+			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true})
+		},
+		listSchedulerRuns: func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
+			t.Fatal("stream-capable daemon unexpectedly used unary scheduler run fallback")
+			return nil, nil
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	got, err := latestSchedulerRunsBySandbox(t.Context(), cliServiceClients{project: client, projectStream: client}, project, []*agentcomposev2.Sandbox{{
+		SandboxId: sandboxID,
+		Tags: []*agentcomposev2.SandboxTag{
+			{Name: "origin", Value: "scheduler"},
+			{Name: "project_id", Value: "project-1"},
+			{Name: "agent", Value: "reviewer"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("latest streamed scheduler runs: %v", err)
+	}
+	if streamRequests != 1 || len(got) != 1 || got[sandboxID].RunID != "newest-target" || got[sandboxID].ResultJSON != "" {
+		t.Fatalf("stream requests/result = %d / %#v, want one target association", streamRequests, got)
+	}
+}
+
+func TestVisitSchedulerRuntimeRunsAcceptsSparseFrames(t *testing.T) {
+	const sparseFrames = int(maxSchedulerQueryRuns)/schedulerCLIBatchSize + 2
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		streamSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+			for i := range sparseFrames {
+				if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+					RunId: fmt.Sprintf("run-%d", i), TriggerId: "nightly",
+				}}}); err != nil {
+					return err
+				}
+			}
+			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true})
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	visited := 0
+	err := visitSchedulerRuntimeRuns(t.Context(), cliServiceClients{project: client, projectStream: client}, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error {
+		visited++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("visit sparse scheduler run stream: %v", err)
+	}
+	if visited != sparseFrames {
+		t.Fatalf("visited scheduler runs = %d, want %d", visited, sparseFrames)
+	}
+}
+
+func TestVisitSchedulerRuntimeRunsRejectsFramesAfterCompletion(t *testing.T) {
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		streamSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+				RunId: "before-completion", TriggerId: "nightly",
+			}}}); err != nil {
+				return err
+			}
+			if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true}); err != nil {
+				return err
+			}
+			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
+				RunId: "after-completion", TriggerId: "nightly",
+			}}})
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	visited := 0
+	err := visitSchedulerRuntimeRuns(t.Context(), cliServiceClients{project: client, projectStream: client}, "project-1", "reviewer", func(*agentcomposev2.SchedulerRun) error {
+		visited++
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "after stream completion") {
+		t.Fatalf("frames after scheduler run completion error = %v", err)
+	}
+	if visited != 1 {
+		t.Fatalf("visited scheduler runs = %d, want 1", visited)
+	}
+}
+
+func TestLatestSchedulerRunsBySandboxRejectsIncompleteStream(t *testing.T) {
+	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		streamSchedulerRuns: func(context.Context, *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+			return nil
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	_, err := latestSchedulerRunsBySandbox(t.Context(), cliServiceClients{project: client, projectStream: client}, project, []*agentcomposev2.Sandbox{{
+		SandboxId: "current-sandbox", Tags: []*agentcomposev2.SandboxTag{{Name: "origin", Value: "scheduler"}, {Name: "project_id", Value: "project-1"}, {Name: "agent", Value: "reviewer"}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "before completion") {
+		t.Fatalf("incomplete scheduler run stream error = %v", err)
+	}
+}
+
+func TestLatestSchedulerRunsBySandboxRejectsTruncatedStream(t *testing.T) {
+	project := testCLIProject("project-1", "project-one", "/work/agent-compose.yml")
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		streamSchedulerRuns: func(_ context.Context, _ *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {
+			return stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Complete: true, Truncated: true})
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	_, err := latestSchedulerRunsBySandbox(t.Context(), cliServiceClients{project: client, projectStream: client}, project, []*agentcomposev2.Sandbox{{
+		SandboxId: "current-sandbox", Tags: []*agentcomposev2.SandboxTag{{Name: "origin", Value: "scheduler"}, {Name: "project_id", Value: "project-1"}, {Name: "agent", Value: "reviewer"}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "more than 500000 scheduler runs") {
+		t.Fatalf("truncated scheduler run stream error = %v", err)
 	}
 }

--- a/cmd/agent-compose/cli_scheduler_query.go
+++ b/cmd/agent-compose/cli_scheduler_query.go
@@ -267,45 +267,6 @@ func parseSchedulerRunStatusFilter(value string) (agentcomposev2.SchedulerRunSta
 	return status, value, nil
 }
 
-const (
-	schedulerQueryPageSize = uint32(500)
-	maxSchedulerQueryPages = 1000
-)
-
-func visitSchedulerRunsFromAPI(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName string, visit func(*agentcomposev2.SchedulerRun) error) error {
-	cursor := ""
-	seenCursors := make(map[string]struct{})
-	for range maxSchedulerQueryPages {
-		resp, err := client.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
-			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, Limit: schedulerQueryPageSize, Cursor: cursor,
-		}))
-		if err != nil {
-			return err
-		}
-		for _, run := range resp.Msg.GetRuns() {
-			if strings.TrimSpace(run.GetTriggerId()) == "" {
-				continue
-			}
-			if err := visit(run); err != nil {
-				return err
-			}
-		}
-		next := strings.TrimSpace(resp.Msg.GetNextCursor())
-		if next == "" {
-			return nil
-		}
-		if next == cursor {
-			return fmt.Errorf("daemon returned a repeated scheduler run cursor")
-		}
-		if _, ok := seenCursors[next]; ok {
-			return fmt.Errorf("daemon returned a repeated scheduler run cursor")
-		}
-		seenCursors[next] = struct{}{}
-		cursor = next
-	}
-	return fmt.Errorf("daemon returned more than %d scheduler run pages", maxSchedulerQueryPages)
-}
-
 func schedulerRuntimeRunItem(schedulerID, loaderID string, run *agentcomposev2.SchedulerRun) composeSchedulerRunItem {
 	return composeSchedulerRunItem{
 		RunID:           run.GetRunId(),
@@ -356,14 +317,12 @@ func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2con
 	}
 	cursor := ""
 	seenCursors := make(map[string]struct{})
-	completed := false
-	for range maxSchedulerQueryPages {
-		pageLimit := schedulerQueryPageSize
+	for {
+		pageLimit := uint32(500)
 		if tail > 0 && tail-len(events) < int(pageLimit) {
 			pageLimit = uint32(tail - len(events))
 		}
 		if pageLimit == 0 {
-			completed = true
 			break
 		}
 		resp, err := client.ListProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
@@ -386,12 +345,10 @@ func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2con
 			}
 		}
 		if tail > 0 && len(events) >= tail {
-			completed = true
 			break
 		}
 		next := strings.TrimSpace(resp.Msg.GetNextCursor())
 		if next == "" {
-			completed = true
 			break
 		}
 		if next == cursor {
@@ -402,9 +359,6 @@ func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2con
 		}
 		seenCursors[next] = struct{}{}
 		cursor = next
-	}
-	if !completed {
-		return nil, fmt.Errorf("daemon returned more than %d scheduler event pages", maxSchedulerQueryPages)
 	}
 	for left, right := 0, len(events)-1; left < right; left, right = left+1, right-1 {
 		events[left], events[right] = events[right], events[left]

--- a/cmd/agent-compose/cli_scheduler_query.go
+++ b/cmd/agent-compose/cli_scheduler_query.go
@@ -267,55 +267,43 @@ func parseSchedulerRunStatusFilter(value string) (agentcomposev2.SchedulerRunSta
 	return status, value, nil
 }
 
-func listSchedulerRuntimeRuns(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, limit uint32) ([]composeSchedulerRunItem, error) {
-	runs, err := listSchedulerRunsFromAPI(ctx, client, projectID, agentName, schedulerID, loaderID, limit)
-	if err != nil {
-		if connect.CodeOf(err) == connect.CodeUnimplemented {
-			return nil, commandExitError{Code: exitCodeUnsupported, Err: fmt.Errorf("daemon does not support scheduler run queries; upgrade the daemon")}
-		}
-		return nil, commandExitErrorForConnect(fmt.Errorf("list scheduler runs for agent %s: %w", agentName, err))
-	}
-	return runs, nil
-}
+const (
+	schedulerQueryPageSize = uint32(500)
+	maxSchedulerQueryPages = 1000
+)
 
-func listSchedulerRunsFromAPI(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName, schedulerID, loaderID string, limit uint32) ([]composeSchedulerRunItem, error) {
-	if limit == 0 || limit > 500 {
-		limit = 500
-	}
-	runs := make([]composeSchedulerRunItem, 0, limit)
+func visitSchedulerRunsFromAPI(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, projectID, agentName string, visit func(*agentcomposev2.SchedulerRun) error) error {
 	cursor := ""
 	seenCursors := make(map[string]struct{})
-	for uint32(len(runs)) < limit {
-		pageLimit := uint32(100)
-		if remaining := limit - uint32(len(runs)); remaining < pageLimit {
-			pageLimit = remaining
-		}
+	for range maxSchedulerQueryPages {
 		resp, err := client.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
-			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, Limit: pageLimit, Cursor: cursor,
+			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, Limit: schedulerQueryPageSize, Cursor: cursor,
 		}))
 		if err != nil {
-			return nil, err
+			return err
 		}
 		for _, run := range resp.Msg.GetRuns() {
 			if strings.TrimSpace(run.GetTriggerId()) == "" {
 				continue
 			}
-			runs = append(runs, schedulerRuntimeRunItem(schedulerID, loaderID, run))
-			if uint32(len(runs)) == limit {
-				return runs, nil
+			if err := visit(run); err != nil {
+				return err
 			}
 		}
 		next := strings.TrimSpace(resp.Msg.GetNextCursor())
 		if next == "" {
-			return runs, nil
+			return nil
+		}
+		if next == cursor {
+			return fmt.Errorf("daemon returned a repeated scheduler run cursor")
 		}
 		if _, ok := seenCursors[next]; ok {
-			return nil, fmt.Errorf("daemon returned a repeated scheduler run cursor")
+			return fmt.Errorf("daemon returned a repeated scheduler run cursor")
 		}
 		seenCursors[next] = struct{}{}
 		cursor = next
 	}
-	return runs, nil
+	return fmt.Errorf("daemon returned more than %d scheduler run pages", maxSchedulerQueryPages)
 }
 
 func schedulerRuntimeRunItem(schedulerID, loaderID string, run *agentcomposev2.SchedulerRun) composeSchedulerRunItem {
@@ -368,12 +356,14 @@ func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2con
 	}
 	cursor := ""
 	seenCursors := make(map[string]struct{})
-	for {
-		pageLimit := uint32(500)
+	completed := false
+	for range maxSchedulerQueryPages {
+		pageLimit := schedulerQueryPageSize
 		if tail > 0 && tail-len(events) < int(pageLimit) {
 			pageLimit = uint32(tail - len(events))
 		}
 		if pageLimit == 0 {
+			completed = true
 			break
 		}
 		resp, err := client.ListProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
@@ -396,10 +386,12 @@ func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2con
 			}
 		}
 		if tail > 0 && len(events) >= tail {
+			completed = true
 			break
 		}
 		next := strings.TrimSpace(resp.Msg.GetNextCursor())
 		if next == "" {
+			completed = true
 			break
 		}
 		if next == cursor {
@@ -410,6 +402,9 @@ func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2con
 		}
 		seenCursors[next] = struct{}{}
 		cursor = next
+	}
+	if !completed {
+		return nil, fmt.Errorf("daemon returned more than %d scheduler event pages", maxSchedulerQueryPages)
 	}
 	for left, right := 0, len(events)-1; left < right; left, right = left+1, right-1 {
 		events[left], events[right] = events[right], events[left]

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -5,7 +5,6 @@ import (
 	"agent-compose/pkg/identity"
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
-	agentcomposev2connect "agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,26 +23,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-func TestListProjectSchedulerLogEventsRejectsExcessivePages(t *testing.T) {
-	requests := 0
-	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
-		listProjectSchedulerEvents: func(_ context.Context, _ *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
-			requests++
-			return connect.NewResponse(&agentcomposev2.ListProjectSchedulerEventsResponse{NextCursor: fmt.Sprintf("page-%d", requests)}), nil
-		},
-	}})
-	t.Cleanup(server.Close)
-	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-
-	_, err := listProjectSchedulerLogEvents(t.Context(), client, "project-1", "reviewer", "", "", -1)
-	if err == nil || !strings.Contains(err.Error(), "more than 1000 scheduler event pages") {
-		t.Fatalf("list excessive scheduler event pages error = %v", err)
-	}
-	if requests != maxSchedulerQueryPages {
-		t.Fatalf("scheduler event page requests = %d, want %d", requests, maxSchedulerQueryPages)
-	}
-}
 
 func TestConfigCommandExpandsSchedulerScriptURLs(t *testing.T) {
 	const script = `scheduler.interval("from-url", "1h");`
@@ -855,6 +834,13 @@ func (s projectServiceStub) ListSchedulerRuns(ctx context.Context, req *connect.
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ListSchedulerRuns stub is not configured"))
 	}
 	return s.listSchedulerRuns(ctx, req)
+}
+
+func (s projectServiceStub) BatchGetLatestSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[agentcomposev2.BatchGetLatestSchedulerRunsResponse], error) {
+	if s.batchGetLatestSchedulerRuns == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("BatchGetLatestSchedulerRuns stub is not configured"))
+	}
+	return s.batchGetLatestSchedulerRuns(ctx, req)
 }
 
 func (s projectServiceStub) StreamSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.StreamSchedulerRunsRequest], stream *connect.ServerStream[agentcomposev2.StreamSchedulerRunsResponse]) error {

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -5,6 +5,7 @@ import (
 	"agent-compose/pkg/identity"
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	agentcomposev2connect "agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"context"
 	"encoding/json"
 	"errors"
@@ -23,6 +24,26 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestListProjectSchedulerLogEventsRejectsExcessivePages(t *testing.T) {
+	requests := 0
+	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		listProjectSchedulerEvents: func(_ context.Context, _ *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
+			requests++
+			return connect.NewResponse(&agentcomposev2.ListProjectSchedulerEventsResponse{NextCursor: fmt.Sprintf("page-%d", requests)}), nil
+		},
+	}})
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+
+	_, err := listProjectSchedulerLogEvents(t.Context(), client, "project-1", "reviewer", "", "", -1)
+	if err == nil || !strings.Contains(err.Error(), "more than 1000 scheduler event pages") {
+		t.Fatalf("list excessive scheduler event pages error = %v", err)
+	}
+	if requests != maxSchedulerQueryPages {
+		t.Fatalf("scheduler event page requests = %d, want %d", requests, maxSchedulerQueryPages)
+	}
+}
 
 func TestConfigCommandExpandsSchedulerScriptURLs(t *testing.T) {
 	const script = `scheduler.interval("from-url", "1h");`

--- a/cmd/agent-compose/cli_stub_server_test.go
+++ b/cmd/agent-compose/cli_stub_server_test.go
@@ -32,7 +32,7 @@ type resourceServiceStub struct {
 func newComposeServiceStubServer(t *testing.T, stubs composeServiceStubs) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.listProjectSchedulerEvents != nil || stubs.project.streamSchedulerEvents != nil || stubs.project.invokeScheduler != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.streamSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil || stubs.project.pruneSchedulerRuns != nil {
+	if stubs.project.applyProject != nil || stubs.project.getProject != nil || stubs.project.listProjects != nil || stubs.project.removeProject != nil || stubs.project.getScheduler != nil || stubs.project.listSchedulerEvents != nil || stubs.project.listProjectSchedulerEvents != nil || stubs.project.streamSchedulerEvents != nil || stubs.project.invokeScheduler != nil || stubs.project.runScheduler != nil || stubs.project.startSchedulerRun != nil || stubs.project.getSchedulerRun != nil || stubs.project.listSchedulerRuns != nil || stubs.project.batchGetLatestSchedulerRuns != nil || stubs.project.streamSchedulerRuns != nil || stubs.project.stopSchedulerRun != nil || stubs.project.pruneSchedulerRuns != nil {
 		path, handler := agentcomposev2connect.NewProjectServiceHandler(stubs.project)
 		mux.Handle(path, handler)
 	}

--- a/pkg/agentcompose/api/project_scheduler_run_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler.go
@@ -29,6 +29,12 @@ type ProjectSchedulerRunSandboxStore interface {
 	ListLoaderRunSandboxIDs(context.Context, []loaders.LoaderRunKey) (map[loaders.LoaderRunKey][]string, error)
 }
 
+type ProjectSchedulerRunSandboxLookupStore interface {
+	BatchGetLatestLoaderRunsBySandboxIDs(context.Context, []string, []string) (map[string]domain.LoaderRunSummary, error)
+}
+
+const maxSchedulerRunBatchSandboxIDs = 500
+
 func (h *ProjectHandler) InvokeScheduler(ctx context.Context, req *connect.Request[agentcomposev2.InvokeSchedulerRequest]) (*connect.Response[agentcomposev2.InvokeSchedulerResponse], error) {
 	_, scheduler, err := h.resolveProjectScheduler(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
 	if err != nil {
@@ -188,6 +194,60 @@ func (h *ProjectHandler) ListSchedulerRuns(ctx context.Context, req *connect.Req
 		response.NextCursor = encodeSchedulerRunCursor(project.ID, project.CurrentRevision, req.Msg.GetAgentName(), triggerID, status, runs[limit-1])
 	}
 	return connect.NewResponse(response), nil
+}
+
+func (h *ProjectHandler) BatchGetLatestSchedulerRuns(ctx context.Context, req *connect.Request[agentcomposev2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[agentcomposev2.BatchGetLatestSchedulerRunsResponse], error) {
+	if len(req.Msg.GetSandboxIds()) > maxSchedulerRunBatchSandboxIDs {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("at most %d sandbox ids may be queried", maxSchedulerRunBatchSandboxIDs))
+	}
+	_, schedulers, err := h.resolveProjectSchedulerRunTargets(ctx, req.Msg.GetProject(), "")
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	sandboxIDs := normalizeSchedulerRunBatchSandboxIDs(req.Msg.GetSandboxIds())
+	response := &agentcomposev2.BatchGetLatestSchedulerRunsResponse{Results: make([]*agentcomposev2.SandboxSchedulerRun, 0, len(sandboxIDs))}
+	if len(sandboxIDs) == 0 {
+		return connect.NewResponse(response), nil
+	}
+	store, ok := h.store.(ProjectSchedulerRunSandboxLookupStore)
+	if !ok {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler run sandbox lookup store is required"))
+	}
+	loaderIDs, schedulersByLoaderID := schedulerLoaderIndex(schedulers)
+	runsBySandboxID, err := store.BatchGetLatestLoaderRunsBySandboxIDs(ctx, loaderIDs, sandboxIDs)
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	for _, sandboxID := range sandboxIDs {
+		run, found := runsBySandboxID[sandboxID]
+		if !found {
+			response.Results = append(response.Results, &agentcomposev2.SandboxSchedulerRun{SandboxId: sandboxID})
+			continue
+		}
+		scheduler, found := schedulersByLoaderID[run.LoaderID]
+		if !found {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("scheduler run sandbox lookup references an unknown project scheduler"))
+		}
+		response.Results = append(response.Results, &agentcomposev2.SandboxSchedulerRun{SandboxId: sandboxID, Run: schedulerRunToProto(run, scheduler)})
+	}
+	return connect.NewResponse(response), nil
+}
+
+func normalizeSchedulerRunBatchSandboxIDs(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func (h *ProjectHandler) StopSchedulerRun(ctx context.Context, req *connect.Request[agentcomposev2.StopSchedulerRunRequest]) (*connect.Response[agentcomposev2.StopSchedulerRunResponse], error) {

--- a/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/samber/do/v2"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/internal/testutil"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestIntegrationBatchGetLatestSchedulerRunsFindsRunBeyondFirstPage(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:  root,
+		DbAddr:    filepath.Join(root, "data.db"),
+		DbTimeout: 5 * time.Second,
+	}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("open migrated config store: %v", err)
+	}
+
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{
+		ID:         "project-regression",
+		Name:       "Scheduler run regression",
+		SourcePath: "/tmp/scheduler-run-regression",
+		SourceJSON: `{"kind":"local"}`,
+	})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	revision, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{
+		ProjectID: project.ID,
+		SpecHash:  "regression-spec",
+		SpecJSON:  `{"agents":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("create project revision: %v", err)
+	}
+	const (
+		loaderID    = "loader-regression"
+		schedulerID = "scheduler-regression"
+		agentName   = "reviewer"
+		targetRunID = "run-target-beyond-500"
+		targetID    = "sandbox-target"
+		missingID   = "sandbox-missing"
+	)
+	if _, err := store.UpsertProjectAgent(ctx, domain.ProjectAgentRecord{
+		ProjectID:        project.ID,
+		AgentName:        agentName,
+		Revision:         revision.Revision,
+		SchedulerEnabled: true,
+		SpecJSON:         `{"name":"reviewer"}`,
+	}); err != nil {
+		t.Fatalf("create project agent: %v", err)
+	}
+	if _, err := store.UpsertManagedLoader(ctx, domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:                 loaderID,
+			Name:               "Regression scheduler",
+			Runtime:            domain.LoaderRuntimeScheduler,
+			ManagedProjectID:   project.ID,
+			ManagedRevision:    revision.Revision,
+			ManagedAgentName:   agentName,
+			ManagedSchedulerID: schedulerID,
+		},
+		Script: "function main() {}",
+	}); err != nil {
+		t.Fatalf("create managed loader: %v", err)
+	}
+	if _, err := store.UpsertProjectScheduler(ctx, domain.ProjectSchedulerRecord{
+		ProjectID:       project.ID,
+		SchedulerID:     schedulerID,
+		AgentName:       agentName,
+		ManagedLoaderID: loaderID,
+		Revision:        revision.Revision,
+		Enabled:         true,
+		TriggerCount:    1,
+		SpecJSON:        `{"id":"scheduler-regression"}`,
+	}); err != nil {
+		t.Fatalf("create project scheduler: %v", err)
+	}
+
+	startedAt := time.UnixMilli(1_720_000_000_000).UTC()
+	if err := store.CreateLoaderRun(ctx, domain.LoaderRunSummary{
+		ID: targetRunID, LoaderID: loaderID, TriggerID: "trigger-regression",
+		Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt,
+	}); err != nil {
+		t.Fatalf("create target scheduler run: %v", err)
+	}
+	if err := store.AddLoaderEvent(ctx, domain.LoaderEvent{
+		ID: "event-target", LoaderID: loaderID, RunID: targetRunID,
+		TriggerID: "trigger-regression", Type: "loader.agent.completed",
+		LinkedSandboxID: targetID, CreatedAt: startedAt,
+	}); err != nil {
+		t.Fatalf("link target scheduler run to sandbox: %v", err)
+	}
+	for index := 0; index < 501; index++ {
+		runID := fmt.Sprintf("run-newer-%03d", index)
+		if err := store.CreateLoaderRun(ctx, domain.LoaderRunSummary{
+			ID: runID, LoaderID: loaderID, TriggerID: "trigger-regression",
+			Status: domain.LoaderRunStatusSucceeded, StartedAt: startedAt.Add(time.Duration(index+1) * time.Second),
+		}); err != nil {
+			t.Fatalf("create newer scheduler run %s: %v", runID, err)
+		}
+	}
+
+	handler := NewProjectHandler(nil, store, nil)
+	mux := http.NewServeMux()
+	path, connectHandler := agentcomposev2connect.NewProjectServiceHandler(handler)
+	mux.Handle(path, connectHandler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
+	projectRef := &agentcomposev2.ProjectRef{ProjectId: project.ID}
+
+	page, err := client.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
+		Project: projectRef,
+		Limit:   500,
+	}))
+	if err != nil {
+		t.Fatalf("list first 500 scheduler runs: %v", err)
+	}
+	if len(page.Msg.GetRuns()) != 500 || page.Msg.GetNextCursor() == "" {
+		t.Fatalf("first page has %d runs and cursor %q, want 500 runs and a next cursor", len(page.Msg.GetRuns()), page.Msg.GetNextCursor())
+	}
+	for _, run := range page.Msg.GetRuns() {
+		if run.GetRunId() == targetRunID {
+			t.Fatalf("target run %q unexpectedly appeared in first 500 runs", targetRunID)
+		}
+	}
+
+	batch, err := client.BatchGetLatestSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.BatchGetLatestSchedulerRunsRequest{
+		Project:    projectRef,
+		SandboxIds: []string{missingID, targetID, targetID},
+	}))
+	if err != nil {
+		t.Fatalf("batch get latest scheduler runs: %v", err)
+	}
+	results := batch.Msg.GetResults()
+	if len(results) != 2 {
+		t.Fatalf("batch results count = %d, want 2 distinct sandbox results", len(results))
+	}
+	if results[0].GetSandboxId() != missingID || results[0].GetRun() != nil {
+		t.Fatalf("first batch result = %#v, want ordered missing sandbox result", results[0])
+	}
+	target := results[1]
+	if target.GetSandboxId() != targetID || target.GetRun().GetRunId() != targetRunID {
+		t.Fatalf("target batch result = %#v, want sandbox %q run %q", target, targetID, targetRunID)
+	}
+	if target.GetRun().GetProjectId() != project.ID || target.GetRun().GetSchedulerId() != schedulerID || target.GetRun().GetAgentName() != agentName {
+		t.Fatalf("target scheduler identity = %#v", target.GetRun())
+	}
+}

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -165,6 +165,45 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	}
 }
 
+func TestProjectHandlerBatchGetsLatestSchedulerRuns(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	run := domain.LoaderRunSummary{
+		ID: "run-associated", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1",
+		Status: domain.LoaderRunStatusSucceeded, StartedAt: time.Unix(200, 0).UTC(),
+	}
+	store.batchRunsBySandbox = map[string]domain.LoaderRunSummary{"sandbox-a": run}
+	response, err := handler.BatchGetLatestSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.BatchGetLatestSchedulerRunsRequest{
+		Project:    &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		SandboxIds: []string{" sandbox-a ", "sandbox-missing", "sandbox-a", ""},
+	}))
+	if err != nil {
+		t.Fatalf("BatchGetLatestSchedulerRuns returned error: %v", err)
+	}
+	if !slices.Equal(store.lastBatchLoaderIDs, []string{store.scheduler.ManagedLoaderID}) ||
+		!slices.Equal(store.lastBatchSandboxIDs, []string{"sandbox-a", "sandbox-missing"}) {
+		t.Fatalf("batch filters=%#v/%#v", store.lastBatchLoaderIDs, store.lastBatchSandboxIDs)
+	}
+	results := response.Msg.GetResults()
+	if len(results) != 2 || results[0].GetSandboxId() != "sandbox-a" || results[0].GetRun().GetRunId() != run.ID ||
+		results[0].GetRun().GetProjectId() != store.project.ID || results[1].GetSandboxId() != "sandbox-missing" || results[1].GetRun() != nil {
+		t.Fatalf("batch results=%#v", results)
+	}
+}
+
+func TestProjectHandlerRejectsExcessiveSchedulerRunBatch(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	sandboxIDs := make([]string, maxSchedulerRunBatchSandboxIDs+1)
+	for index := range sandboxIDs {
+		sandboxIDs[index] = fmt.Sprintf("sandbox-%d", index)
+	}
+	_, err := handler.BatchGetLatestSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.BatchGetLatestSchedulerRunsRequest{
+		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, SandboxIds: sandboxIDs,
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("excessive batch query code=%v err=%v", connect.CodeOf(err), err)
+	}
+}
+
 func TestProjectHandlerListsProjectSchedulerEventsWithIdentityAndCursor(t *testing.T) {
 	store, _, handler := newSchedulerRunHandlerFixture()
 	createdAt := time.Unix(300, 0).UTC()
@@ -271,13 +310,16 @@ func newSchedulerRunHandlerFixture() (*schedulerRunProjectStoreFake, *schedulerR
 }
 
 type schedulerRunProjectStoreFake struct {
-	project       domain.ProjectRecord
-	scheduler     domain.ProjectSchedulerRecord
-	schedulers    []domain.ProjectSchedulerRecord
-	runs          []domain.LoaderRunSummary
-	events        []domain.LoaderEvent
-	sandboxIDs    map[loaders.LoaderRunKey][]string
-	lastRunFilter loaders.LoaderRunPageFilter
+	project             domain.ProjectRecord
+	scheduler           domain.ProjectSchedulerRecord
+	schedulers          []domain.ProjectSchedulerRecord
+	runs                []domain.LoaderRunSummary
+	events              []domain.LoaderEvent
+	sandboxIDs          map[loaders.LoaderRunKey][]string
+	lastRunFilter       loaders.LoaderRunPageFilter
+	batchRunsBySandbox  map[string]domain.LoaderRunSummary
+	lastBatchLoaderIDs  []string
+	lastBatchSandboxIDs []string
 }
 
 func (s *schedulerRunProjectStoreFake) ListLoaderEventsPage(_ context.Context, filter loaders.LoaderEventPageFilter) ([]domain.LoaderEvent, error) {
@@ -381,6 +423,12 @@ func (s *schedulerRunProjectStoreFake) ListLoaderRunsPage(_ context.Context, fil
 
 func (s *schedulerRunProjectStoreFake) ListLoaderRunSandboxIDs(_ context.Context, _ []loaders.LoaderRunKey) (map[loaders.LoaderRunKey][]string, error) {
 	return s.sandboxIDs, nil
+}
+
+func (s *schedulerRunProjectStoreFake) BatchGetLatestLoaderRunsBySandboxIDs(_ context.Context, loaderIDs, sandboxIDs []string) (map[string]domain.LoaderRunSummary, error) {
+	s.lastBatchLoaderIDs = append([]string(nil), loaderIDs...)
+	s.lastBatchSandboxIDs = append([]string(nil), sandboxIDs...)
+	return s.batchRunsBySandbox, nil
 }
 
 type schedulerRunRuntimeFake struct {

--- a/pkg/storage/configstore/loader_run_page.go
+++ b/pkg/storage/configstore/loader_run_page.go
@@ -158,6 +158,68 @@ func (s *loaderStore) ListLoaderRunSandboxIDs(ctx context.Context, keys []loader
 	return result, nil
 }
 
+func (s *loaderStore) BatchGetLatestLoaderRunsBySandboxIDs(ctx context.Context, loaderIDs, sandboxIDs []string) (map[string]domain.LoaderRunSummary, error) {
+	loaderIDs = normalizedLoaderRunPageIDs(loaderIDs)
+	sandboxIDs = normalizedLoaderRunPageIDs(sandboxIDs)
+	result := make(map[string]domain.LoaderRunSummary)
+	if len(loaderIDs) == 0 || len(sandboxIDs) == 0 {
+		return result, nil
+	}
+
+	args := make([]any, 0, len(loaderIDs)+len(sandboxIDs))
+	for _, sandboxID := range sandboxIDs {
+		args = append(args, sandboxID)
+	}
+	for _, loaderID := range loaderIDs {
+		args = append(args, loaderID)
+	}
+	query := `WITH associations AS (
+		SELECT DISTINCT linked_sandbox_id AS sandbox_id, loader_id, run_id
+		FROM loader_event
+		WHERE linked_sandbox_id <> ''
+			AND linked_sandbox_id IN (` + placeholders(len(sandboxIDs)) + `)
+			AND loader_id IN (` + placeholders(len(loaderIDs)) + `)
+	), ranked AS (
+		SELECT a.sandbox_id,
+			r.loader_id, r.run_id, r.trigger_id, r.trigger_kind, r.trigger_source, r.status,
+			r.started_at, r.completed_at, r.duration_ms, r.error, r.result_json, r.payload_json,
+			r.source_script_sha256, r.artifacts_dir,
+			ROW_NUMBER() OVER (
+				PARTITION BY a.sandbox_id
+				ORDER BY CASE WHEN r.completed_at > 0 THEN r.completed_at ELSE r.started_at END DESC,
+					r.started_at DESC, r.loader_id DESC, r.run_id DESC
+			) AS association_rank
+		FROM associations a
+		JOIN loader_run r ON r.loader_id = a.loader_id AND r.run_id = a.run_id
+		WHERE r.trigger_id <> ''
+	)
+	SELECT sandbox_id, loader_id, run_id, trigger_id, trigger_kind, trigger_source, status,
+		started_at, completed_at, duration_ms, error, result_json, payload_json,
+		source_script_sha256, artifacts_dir
+	FROM ranked
+	WHERE association_rank = 1
+	ORDER BY sandbox_id ASC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query latest loader runs by sandbox ids: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var sandboxID string
+		run, scanErr := loaders.ScanLoaderRun(func(dest ...any) error {
+			return rows.Scan(append([]any{&sandboxID}, dest...)...)
+		})
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		result[sandboxID] = run
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate latest loader runs by sandbox ids: %w", err)
+	}
+	return result, nil
+}
+
 func normalizedLoaderRunPageIDs(loaderIDs []string) []string {
 	seen := make(map[string]struct{}, len(loaderIDs))
 	result := make([]string, 0, len(loaderIDs))

--- a/pkg/storage/configstore/loader_run_page_test.go
+++ b/pkg/storage/configstore/loader_run_page_test.go
@@ -151,4 +151,50 @@ func TestLoaderRunPageFiltersTriggerRunsBeforeLimitAndBatchesSandboxes(t *testin
 	if err != nil || !reflect.DeepEqual(sandboxes[loaders.LoaderRunKey{LoaderID: "loader-a", RunID: "run-success"}], []string{"sandbox-a", "sandbox-b"}) {
 		t.Fatalf("sandbox ids=%#v err=%v", sandboxes, err)
 	}
+
+	latest, err := store.BatchGetLatestLoaderRunsBySandboxIDs(ctx, []string{"loader-a"}, []string{"sandbox-a", "sandbox-b", "sandbox-missing"})
+	if err != nil {
+		t.Fatalf("list latest runs by sandbox ids: %v", err)
+	}
+	if len(latest) != 2 || latest["sandbox-a"].ID != "run-success" || latest["sandbox-b"].ID != "run-success" {
+		t.Fatalf("latest runs by sandbox ids=%#v", latest)
+	}
+}
+
+func TestBatchGetLatestLoaderRunsBySandboxIDsSelectsLatestTriggerRun(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	for _, loader := range []domain.Loader{
+		{Summary: domain.LoaderSummary{ID: "loader-a", Runtime: domain.LoaderRuntimeScheduler, ManagedProjectID: "project-1", ManagedAgentName: "agent-a", ManagedSchedulerID: "scheduler-a"}, Script: "function main() {}"},
+		{Summary: domain.LoaderSummary{ID: "loader-other", Runtime: domain.LoaderRuntimeScheduler, ManagedProjectID: "project-2", ManagedAgentName: "agent-other", ManagedSchedulerID: "scheduler-other"}, Script: "function main() {}"},
+	} {
+		if _, err := store.UpsertManagedLoader(ctx, loader); err != nil {
+			t.Fatalf("upsert loader %s: %v", loader.Summary.ID, err)
+		}
+	}
+	startedAt := time.UnixMilli(1_720_000_000_000).UTC()
+	for _, run := range []domain.LoaderRunSummary{
+		{ID: "run-older", LoaderID: "loader-a", TriggerID: "trigger-a", StartedAt: startedAt},
+		{ID: "invoke-newer", LoaderID: "loader-a", StartedAt: startedAt.Add(time.Second)},
+		{ID: "run-newest", LoaderID: "loader-a", TriggerID: "trigger-a", StartedAt: startedAt.Add(2 * time.Second)},
+		{ID: "run-other-project", LoaderID: "loader-other", TriggerID: "trigger-a", StartedAt: startedAt.Add(3 * time.Second)},
+	} {
+		if err := store.CreateLoaderRun(ctx, run); err != nil {
+			t.Fatalf("create run %s: %v", run.ID, err)
+		}
+		if err := store.AddLoaderEvent(ctx, domain.LoaderEvent{LoaderID: run.LoaderID, ID: "event-" + run.ID, RunID: run.ID, TriggerID: run.TriggerID, Type: "loader.test", LinkedSandboxID: "sandbox-a", CreatedAt: run.StartedAt}); err != nil {
+			t.Fatalf("add event for run %s: %v", run.ID, err)
+		}
+	}
+
+	latest, err := store.BatchGetLatestLoaderRunsBySandboxIDs(ctx, []string{"loader-a"}, []string{"sandbox-a", "sandbox-a", ""})
+	if err != nil {
+		t.Fatalf("list latest runs by sandbox ids: %v", err)
+	}
+	if len(latest) != 1 || latest["sandbox-a"].ID != "run-newest" {
+		t.Fatalf("latest runs by sandbox ids=%#v, want run-newest", latest)
+	}
 }

--- a/pkg/storage/sqlite/migrations/000003_loader_event_sandbox_run.sql
+++ b/pkg/storage/sqlite/migrations/000003_loader_event_sandbox_run.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_loader_event_sandbox_run
+    ON loader_event(linked_sandbox_id, loader_id, run_id)
+    WHERE linked_sandbox_id <> '';

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -66,7 +66,7 @@ func TestMigrationBaseline(t *testing.T) {
 		"idx_event_dispatch", "idx_event_dispatch_attempt", "idx_event_idempotency", "idx_event_parent",
 		"idx_event_sandbox_link_loader_run", "idx_event_sandbox_link_run", "idx_event_sandbox_link_sandbox",
 		"idx_event_topic_sequence", "idx_llm_facade_token_sandbox", "idx_loader_event_created",
-		"idx_loader_event_run_created", "idx_loader_managed_project", "idx_loader_run_prune",
+		"idx_loader_event_run_created", "idx_loader_event_sandbox_run", "idx_loader_managed_project", "idx_loader_run_prune",
 		"idx_loader_run_started", "idx_loader_run_status_started", "idx_loader_run_trigger_started",
 		"idx_loader_trigger_schedule", "idx_project_agent_id", "idx_project_agent_managed_agent",
 		"idx_project_name", "idx_project_revision_hash", "idx_project_run_agent",
@@ -235,6 +235,7 @@ func TestBaselineIncludesPreviouslyOmittedSchema(t *testing.T) {
 		{name: "idx_loader_run_status_started", columns: []string{"loader_id", "status", "started_at", "run_id"}, descending: []bool{false, false, true, true}},
 		{name: "idx_loader_run_prune", columns: []string{"loader_id", "status", "completed_at", "started_at", "run_id"}, descending: []bool{false, false, false, false, false}},
 		{name: "idx_loader_event_run_created", columns: []string{"loader_id", "run_id", "created_at", "event_id"}, descending: []bool{false, false, true, true}},
+		{name: "idx_loader_event_sandbox_run", columns: []string{"linked_sandbox_id", "loader_id", "run_id"}, descending: []bool{false, false, false}},
 		{name: "idx_event_sandbox_link_loader_run", columns: []string{"loader_id", "run_id"}, descending: []bool{false, false}},
 		{name: "idx_event_delivery_loader_run", columns: []string{"loader_id", "run_id"}, descending: []bool{false, false}},
 	}
@@ -540,7 +541,7 @@ func TestMigratesEveryLegacyAddedColumn(t *testing.T) {
 		"idx_project_short_id", "idx_project_agent_id", "idx_project_scheduler_id",
 		"idx_project_run_sandbox", "idx_event_dispatch_attempt", "idx_event_parent",
 		"idx_loader_run_trigger_started", "idx_loader_run_status_started", "idx_loader_run_prune",
-		"idx_loader_event_run_created", "idx_event_sandbox_link_loader_run", "idx_event_delivery_loader_run",
+		"idx_loader_event_run_created", "idx_loader_event_sandbox_run", "idx_event_sandbox_link_loader_run", "idx_event_delivery_loader_run",
 		"idx_sandboxes_updated", "idx_sandboxes_vm_status_updated", "idx_sandboxes_project_updated", "idx_sandboxes_type_updated",
 	} {
 		assertSQLiteIndexExists(t, db, index)

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -17409,6 +17409,160 @@ func (x *StreamSchedulerRunsResponse) GetTruncated() bool {
 	return false
 }
 
+// BatchGetLatestSchedulerRunsRequest selects scheduler runs by sandbox. A
+// request accepts at most 500 sandbox IDs.
+type BatchGetLatestSchedulerRunsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	SandboxIds    []string               `protobuf:"bytes,2,rep,name=sandbox_ids,json=sandboxIds,proto3" json:"sandbox_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGetLatestSchedulerRunsRequest) Reset() {
+	*x = BatchGetLatestSchedulerRunsRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[225]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGetLatestSchedulerRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGetLatestSchedulerRunsRequest) ProtoMessage() {}
+
+func (x *BatchGetLatestSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[225]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGetLatestSchedulerRunsRequest.ProtoReflect.Descriptor instead.
+func (*BatchGetLatestSchedulerRunsRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{225}
+}
+
+func (x *BatchGetLatestSchedulerRunsRequest) GetProject() *ProjectRef {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *BatchGetLatestSchedulerRunsRequest) GetSandboxIds() []string {
+	if x != nil {
+		return x.SandboxIds
+	}
+	return nil
+}
+
+// SandboxSchedulerRun is the latest scheduler run linked to one sandbox. Run
+// is absent when the sandbox has no scheduler run in the selected project.
+type SandboxSchedulerRun struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	Run           *SchedulerRun          `protobuf:"bytes,2,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SandboxSchedulerRun) Reset() {
+	*x = SandboxSchedulerRun{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[226]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SandboxSchedulerRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SandboxSchedulerRun) ProtoMessage() {}
+
+func (x *SandboxSchedulerRun) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[226]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SandboxSchedulerRun.ProtoReflect.Descriptor instead.
+func (*SandboxSchedulerRun) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{226}
+}
+
+func (x *SandboxSchedulerRun) GetSandboxId() string {
+	if x != nil {
+		return x.SandboxId
+	}
+	return ""
+}
+
+func (x *SandboxSchedulerRun) GetRun() *SchedulerRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+// BatchGetLatestSchedulerRunsResponse contains one result for each distinct,
+// non-empty requested sandbox ID, ordered by its first request occurrence.
+type BatchGetLatestSchedulerRunsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Results       []*SandboxSchedulerRun `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGetLatestSchedulerRunsResponse) Reset() {
+	*x = BatchGetLatestSchedulerRunsResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[227]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGetLatestSchedulerRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGetLatestSchedulerRunsResponse) ProtoMessage() {}
+
+func (x *BatchGetLatestSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[227]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGetLatestSchedulerRunsResponse.ProtoReflect.Descriptor instead.
+func (*BatchGetLatestSchedulerRunsResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{227}
+}
+
+func (x *BatchGetLatestSchedulerRunsResponse) GetResults() []*SandboxSchedulerRun {
+	if x != nil {
+		return x.Results
+	}
+	return nil
+}
+
 var File_agentcompose_v2_agentcompose_proto protoreflect.FileDescriptor
 
 const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
@@ -18887,7 +19041,17 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"checkpoint\x12\x1a\n" +
 	"\bcomplete\x18\x03 \x01(\bR\bcomplete\x12#\n" +
 	"\remitted_count\x18\x04 \x01(\x04R\femittedCount\x12\x1c\n" +
-	"\ttruncated\x18\x05 \x01(\bR\ttruncated*\x98\x01\n" +
+	"\ttruncated\x18\x05 \x01(\bR\ttruncated\"|\n" +
+	"\"BatchGetLatestSchedulerRunsRequest\x125\n" +
+	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1f\n" +
+	"\vsandbox_ids\x18\x02 \x03(\tR\n" +
+	"sandboxIds\"e\n" +
+	"\x13SandboxSchedulerRun\x12\x1d\n" +
+	"\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12/\n" +
+	"\x03run\x18\x02 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\"e\n" +
+	"#BatchGetLatestSchedulerRunsResponse\x12>\n" +
+	"\aresults\x18\x01 \x03(\v2$.agentcompose.v2.SandboxSchedulerRunR\aresults*\x98\x01\n" +
 	"\x19ProjectValidationSeverity\x12+\n" +
 	"'PROJECT_VALIDATION_SEVERITY_UNSPECIFIED\x10\x00\x12'\n" +
 	"#PROJECT_VALIDATION_SEVERITY_WARNING\x10\x01\x12%\n" +
@@ -19016,7 +19180,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"%SANDBOX_WATCH_EVENT_TYPE_CELL_STARTED\x10\x02\x12(\n" +
 	"$SANDBOX_WATCH_EVENT_TYPE_CELL_OUTPUT\x10\x03\x12+\n" +
 	"'SANDBOX_WATCH_EVENT_TYPE_CELL_COMPLETED\x10\x04\x12(\n" +
-	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xd7\x11\n" +
+	"$SANDBOX_WATCH_EVENT_TYPE_EVENT_ADDED\x10\x052\xe2\x12\n" +
 	"\x0eProjectService\x12d\n" +
 	"\x0fValidateProject\x12'.agentcompose.v2.ValidateProjectRequest\x1a(.agentcompose.v2.ValidateProjectResponse\x12[\n" +
 	"\fApplyProject\x12$.agentcompose.v2.ApplyProjectRequest\x1a%.agentcompose.v2.ApplyProjectResponse\x12U\n" +
@@ -19034,7 +19198,8 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\fRunScheduler\x12$.agentcompose.v2.RunSchedulerRequest\x1a%.agentcompose.v2.RunSchedulerResponse\x12j\n" +
 	"\x11StartSchedulerRun\x12).agentcompose.v2.StartSchedulerRunRequest\x1a*.agentcompose.v2.StartSchedulerRunResponse\x12d\n" +
 	"\x0fGetSchedulerRun\x12'.agentcompose.v2.GetSchedulerRunRequest\x1a(.agentcompose.v2.GetSchedulerRunResponse\x12j\n" +
-	"\x11ListSchedulerRuns\x12).agentcompose.v2.ListSchedulerRunsRequest\x1a*.agentcompose.v2.ListSchedulerRunsResponse\x12r\n" +
+	"\x11ListSchedulerRuns\x12).agentcompose.v2.ListSchedulerRunsRequest\x1a*.agentcompose.v2.ListSchedulerRunsResponse\x12\x88\x01\n" +
+	"\x1bBatchGetLatestSchedulerRuns\x123.agentcompose.v2.BatchGetLatestSchedulerRunsRequest\x1a4.agentcompose.v2.BatchGetLatestSchedulerRunsResponse\x12r\n" +
 	"\x13StreamSchedulerRuns\x12+.agentcompose.v2.StreamSchedulerRunsRequest\x1a,.agentcompose.v2.StreamSchedulerRunsResponse0\x01\x12m\n" +
 	"\x12PruneSchedulerRuns\x12*.agentcompose.v2.PruneSchedulerRunsRequest\x1a+.agentcompose.v2.PruneSchedulerRunsResponse\x12g\n" +
 	"\x10StopSchedulerRun\x12(.agentcompose.v2.StopSchedulerRunRequest\x1a).agentcompose.v2.StopSchedulerRunResponse\x12p\n" +
@@ -19124,7 +19289,7 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 }
 
 var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 24)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 237)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 240)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),                // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),                      // 1: agentcompose.v2.ProjectChangeAction
@@ -19375,19 +19540,22 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*StreamProjectSchedulerEventsResponse)(nil),  // 246: agentcompose.v2.StreamProjectSchedulerEventsResponse
 	(*StreamSchedulerRunsRequest)(nil),            // 247: agentcompose.v2.StreamSchedulerRunsRequest
 	(*StreamSchedulerRunsResponse)(nil),           // 248: agentcompose.v2.StreamSchedulerRunsResponse
-	nil,                                           // 249: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                                           // 250: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                                           // 251: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                                           // 252: agentcompose.v2.AttachHumanMessage.MetadataEntry
-	nil,                                           // 253: agentcompose.v2.AttachError.DetailsEntry
-	nil,                                           // 254: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                                           // 255: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                                           // 256: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                                           // 257: agentcompose.v2.Volume.LabelsEntry
-	nil,                                           // 258: agentcompose.v2.Volume.OptionsEntry
-	nil,                                           // 259: agentcompose.v2.Image.LabelsEntry
-	nil,                                           // 260: agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	(*timestamppb.Timestamp)(nil),                 // 261: google.protobuf.Timestamp
+	(*BatchGetLatestSchedulerRunsRequest)(nil),    // 249: agentcompose.v2.BatchGetLatestSchedulerRunsRequest
+	(*SandboxSchedulerRun)(nil),                   // 250: agentcompose.v2.SandboxSchedulerRun
+	(*BatchGetLatestSchedulerRunsResponse)(nil),   // 251: agentcompose.v2.BatchGetLatestSchedulerRunsResponse
+	nil,                           // 252: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                           // 253: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                           // 254: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                           // 255: agentcompose.v2.AttachHumanMessage.MetadataEntry
+	nil,                           // 256: agentcompose.v2.AttachError.DetailsEntry
+	nil,                           // 257: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                           // 258: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                           // 259: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                           // 260: agentcompose.v2.Volume.LabelsEntry
+	nil,                           // 261: agentcompose.v2.Volume.OptionsEntry
+	nil,                           // 262: agentcompose.v2.Image.LabelsEntry
+	nil,                           // 263: agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	(*timestamppb.Timestamp)(nil), // 264: google.protobuf.Timestamp
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	79,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
@@ -19421,18 +19589,18 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	43,  // 28: agentcompose.v2.ProjectAgent.latest_run:type_name -> agentcompose.v2.ProjectAgentLatestRun
 	3,   // 29: agentcompose.v2.ProjectAgentLatestRun.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 30: agentcompose.v2.ProjectAgentLatestRun.source:type_name -> agentcompose.v2.RunSource
-	261, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
+	264, // 31: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
 	36,  // 32: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
 	44,  // 33: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	89,  // 34: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
 	47,  // 35: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
 	90,  // 36: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
-	261, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
-	261, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
-	261, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
+	264, // 37: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
+	264, // 38: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
+	264, // 39: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
 	49,  // 40: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
 	36,  // 41: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	261, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
+	264, // 42: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
 	52,  // 43: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
 	36,  // 44: agentcompose.v2.ListProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	52,  // 45: agentcompose.v2.ListProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
@@ -19454,8 +19622,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	36,  // 61: agentcompose.v2.StopSchedulerRunRequest.project:type_name -> agentcompose.v2.ProjectRef
 	72,  // 62: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
 	5,   // 63: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
-	261, // 64: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
-	261, // 65: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
+	264, // 64: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
+	264, // 65: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
 	36,  // 66: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
 	44,  // 67: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	36,  // 68: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
@@ -19479,9 +19647,9 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	201, // 86: agentcompose.v2.AgentSpec.skills:type_name -> agentcompose.v2.SkillSpec
 	86,  // 87: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
 	86,  // 88: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
-	249, // 89: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	250, // 90: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	251, // 91: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	252, // 89: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	253, // 90: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	254, // 91: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
 	90,  // 92: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
 	91,  // 93: agentcompose.v2.TriggerSpec.event:type_name -> agentcompose.v2.EventTriggerSpec
 	93,  // 94: agentcompose.v2.DriverSpec.boxlite:type_name -> agentcompose.v2.BoxliteDriverSpec
@@ -19522,19 +19690,19 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	135, // 129: agentcompose.v2.RunLogChunk.run:type_name -> agentcompose.v2.RunSummary
 	136, // 130: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
 	8,   // 131: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
-	261, // 132: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
+	264, // 132: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
 	112, // 133: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
 	112, // 134: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
 	20,  // 135: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
-	261, // 136: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	264, // 136: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
 	119, // 137: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
 	119, // 138: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
 	134, // 139: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
-	261, // 140: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	261, // 141: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	264, // 140: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	264, // 141: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
 	125, // 142: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
-	261, // 143: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
-	261, // 144: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
+	264, // 143: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
+	264, // 144: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
 	124, // 145: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
 	124, // 146: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
 	124, // 147: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
@@ -19577,13 +19745,13 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	145, // 184: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
 	12,  // 185: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
 	145, // 186: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	252, // 187: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	255, // 187: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
 	135, // 188: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
 	13,  // 189: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
 	102, // 190: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
 	158, // 191: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
 	135, // 192: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	253, // 193: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	256, // 193: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
 	139, // 194: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
 	14,  // 195: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
 	191, // 196: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
@@ -19597,7 +19765,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	191, // 204: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
 	193, // 205: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
 	14,  // 206: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	254, // 207: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	257, // 207: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
 	14,  // 208: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
 	192, // 209: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
 	16,  // 210: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
@@ -19617,21 +19785,21 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	179, // 224: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
 	19,  // 225: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
 	190, // 226: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	255, // 227: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	256, // 228: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	258, // 227: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	259, // 228: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
 	190, // 229: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
 	190, // 230: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
 	190, // 231: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
 	190, // 232: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
 	190, // 233: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	257, // 234: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	258, // 235: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	260, // 234: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	261, // 235: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
 	14,  // 236: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
 	15,  // 237: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
 	192, // 238: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
 	194, // 239: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
 	195, // 240: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	259, // 241: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	262, // 241: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
 	14,  // 242: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
 	96,  // 243: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
 	135, // 244: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
@@ -19639,7 +19807,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	204, // 246: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
 	22,  // 247: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
 	207, // 248: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	261, // 249: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	264, // 249: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
 	208, // 250: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
 	208, // 251: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
 	86,  // 252: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
@@ -19647,16 +19815,16 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	86,  // 254: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
 	216, // 255: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
 	216, // 256: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	261, // 257: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	261, // 258: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	264, // 257: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	264, // 258: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
 	220, // 259: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
 	220, // 260: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
 	231, // 261: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	260, // 262: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	263, // 262: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
 	234, // 263: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
 	235, // 264: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	261, // 265: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	261, // 266: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	264, // 265: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	264, // 266: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
 	238, // 267: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
 	239, // 268: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
 	23,  // 269: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
@@ -19669,155 +19837,160 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	36,  // 276: agentcompose.v2.StreamSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	5,   // 277: agentcompose.v2.StreamSchedulerRunsRequest.status:type_name -> agentcompose.v2.SchedulerRunStatus
 	72,  // 278: agentcompose.v2.StreamSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
-	24,  // 279: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	26,  // 280: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	28,  // 281: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	30,  // 282: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	32,  // 283: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	34,  // 284: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	45,  // 285: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
-	48,  // 286: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
-	51,  // 287: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
-	54,  // 288: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
-	245, // 289: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:input_type -> agentcompose.v2.StreamProjectSchedulerEventsRequest
-	56,  // 290: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
-	58,  // 291: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
-	60,  // 292: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
-	62,  // 293: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
-	64,  // 294: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
-	247, // 295: agentcompose.v2.ProjectService.StreamSchedulerRuns:input_type -> agentcompose.v2.StreamSchedulerRunsRequest
-	66,  // 296: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
-	70,  // 297: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
-	73,  // 298: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
-	75,  // 299: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	96,  // 300: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	199, // 301: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	96,  // 302: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	99,  // 303: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
-	103, // 304: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	105, // 305: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	107, // 306: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	109, // 307: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	111, // 308: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
-	114, // 309: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
-	137, // 310: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	137, // 311: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	142, // 312: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
-	159, // 313: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	161, // 314: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	163, // 315: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	165, // 316: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	167, // 317: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	170, // 318: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	172, // 319: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	174, // 320: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	176, // 321: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	180, // 322: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	182, // 323: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	184, // 324: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	186, // 325: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	188, // 326: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	116, // 327: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	118, // 328: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
-	121, // 329: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	123, // 330: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
-	129, // 331: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
-	131, // 332: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
-	126, // 333: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	237, // 334: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	241, // 335: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
-	205, // 336: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
-	206, // 337: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
-	211, // 338: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
-	213, // 339: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
-	215, // 340: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
-	218, // 341: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	221, // 342: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
-	223, // 343: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
-	224, // 344: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
-	225, // 345: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
-	228, // 346: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
-	230, // 347: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
-	233, // 348: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	243, // 349: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	202, // 350: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	25,  // 351: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	27,  // 352: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	29,  // 353: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	31,  // 354: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	33,  // 355: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	35,  // 356: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	46,  // 357: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	50,  // 358: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	53,  // 359: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	55,  // 360: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
-	246, // 361: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:output_type -> agentcompose.v2.StreamProjectSchedulerEventsResponse
-	57,  // 362: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
-	59,  // 363: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
-	61,  // 364: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
-	63,  // 365: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
-	65,  // 366: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
-	248, // 367: agentcompose.v2.ProjectService.StreamSchedulerRuns:output_type -> agentcompose.v2.StreamSchedulerRunsResponse
-	69,  // 368: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
-	71,  // 369: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
-	74,  // 370: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	76,  // 371: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	97,  // 372: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	200, // 373: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	98,  // 374: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	100, // 375: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
-	104, // 376: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	106, // 377: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	108, // 378: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	110, // 379: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	113, // 380: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	115, // 381: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	140, // 382: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	141, // 383: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	143, // 384: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
-	160, // 385: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	162, // 386: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	164, // 387: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	166, // 388: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	168, // 389: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	171, // 390: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	173, // 391: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	175, // 392: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	177, // 393: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	181, // 394: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	183, // 395: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	185, // 396: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	187, // 397: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	189, // 398: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	117, // 399: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	120, // 400: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	122, // 401: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	128, // 402: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	130, // 403: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	132, // 404: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	127, // 405: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	240, // 406: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	242, // 407: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	209, // 408: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	210, // 409: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	212, // 410: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	214, // 411: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	217, // 412: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	219, // 413: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	222, // 414: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	227, // 415: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	227, // 416: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	226, // 417: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	229, // 418: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	232, // 419: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	236, // 420: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	244, // 421: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	203, // 422: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	351, // [351:423] is the sub-list for method output_type
-	279, // [279:351] is the sub-list for method input_type
-	279, // [279:279] is the sub-list for extension type_name
-	279, // [279:279] is the sub-list for extension extendee
-	0,   // [0:279] is the sub-list for field type_name
+	36,  // 279: agentcompose.v2.BatchGetLatestSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
+	72,  // 280: agentcompose.v2.SandboxSchedulerRun.run:type_name -> agentcompose.v2.SchedulerRun
+	250, // 281: agentcompose.v2.BatchGetLatestSchedulerRunsResponse.results:type_name -> agentcompose.v2.SandboxSchedulerRun
+	24,  // 282: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	26,  // 283: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	28,  // 284: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	30,  // 285: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	32,  // 286: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	34,  // 287: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	45,  // 288: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
+	48,  // 289: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
+	51,  // 290: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
+	54,  // 291: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
+	245, // 292: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:input_type -> agentcompose.v2.StreamProjectSchedulerEventsRequest
+	56,  // 293: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
+	58,  // 294: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
+	60,  // 295: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
+	62,  // 296: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
+	64,  // 297: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
+	249, // 298: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:input_type -> agentcompose.v2.BatchGetLatestSchedulerRunsRequest
+	247, // 299: agentcompose.v2.ProjectService.StreamSchedulerRuns:input_type -> agentcompose.v2.StreamSchedulerRunsRequest
+	66,  // 300: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
+	70,  // 301: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
+	73,  // 302: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
+	75,  // 303: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	96,  // 304: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	199, // 305: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
+	96,  // 306: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
+	99,  // 307: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
+	103, // 308: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	105, // 309: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	107, // 310: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	109, // 311: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	111, // 312: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
+	114, // 313: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
+	137, // 314: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	137, // 315: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
+	142, // 316: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
+	159, // 317: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	161, // 318: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	163, // 319: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	165, // 320: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	167, // 321: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	170, // 322: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	172, // 323: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	174, // 324: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	176, // 325: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	180, // 326: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	182, // 327: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	184, // 328: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	186, // 329: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	188, // 330: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	116, // 331: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	118, // 332: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
+	121, // 333: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	123, // 334: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
+	129, // 335: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
+	131, // 336: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
+	126, // 337: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
+	237, // 338: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	241, // 339: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	205, // 340: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
+	206, // 341: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
+	211, // 342: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
+	213, // 343: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
+	215, // 344: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
+	218, // 345: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	221, // 346: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
+	223, // 347: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
+	224, // 348: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
+	225, // 349: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
+	228, // 350: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
+	230, // 351: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
+	233, // 352: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
+	243, // 353: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	202, // 354: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	25,  // 355: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	27,  // 356: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	29,  // 357: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	31,  // 358: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	33,  // 359: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	35,  // 360: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	46,  // 361: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	50,  // 362: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	53,  // 363: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	55,  // 364: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
+	246, // 365: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:output_type -> agentcompose.v2.StreamProjectSchedulerEventsResponse
+	57,  // 366: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
+	59,  // 367: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	61,  // 368: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	63,  // 369: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	65,  // 370: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	251, // 371: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:output_type -> agentcompose.v2.BatchGetLatestSchedulerRunsResponse
+	248, // 372: agentcompose.v2.ProjectService.StreamSchedulerRuns:output_type -> agentcompose.v2.StreamSchedulerRunsResponse
+	69,  // 373: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
+	71,  // 374: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	74,  // 375: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	76,  // 376: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	97,  // 377: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	200, // 378: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
+	98,  // 379: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
+	100, // 380: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
+	104, // 381: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	106, // 382: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	108, // 383: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	110, // 384: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	113, // 385: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	115, // 386: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	140, // 387: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	141, // 388: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
+	143, // 389: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
+	160, // 390: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	162, // 391: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	164, // 392: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	166, // 393: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	168, // 394: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	171, // 395: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	173, // 396: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	175, // 397: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	177, // 398: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	181, // 399: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	183, // 400: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	185, // 401: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	187, // 402: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	189, // 403: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	117, // 404: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	120, // 405: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	122, // 406: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	128, // 407: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	130, // 408: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	132, // 409: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	127, // 410: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	240, // 411: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	242, // 412: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	209, // 413: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	210, // 414: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	212, // 415: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	214, // 416: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	217, // 417: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	219, // 418: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	222, // 419: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	227, // 420: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	227, // 421: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	226, // 422: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	229, // 423: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	232, // 424: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	236, // 425: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	244, // 426: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	203, // 427: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	355, // [355:428] is the sub-list for method output_type
+	282, // [282:355] is the sub-list for method input_type
+	282, // [282:282] is the sub-list for extension type_name
+	282, // [282:282] is the sub-list for extension extendee
+	0,   // [0:282] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }
@@ -19874,7 +20047,7 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
 			NumEnums:      24,
-			NumMessages:   237,
+			NumMessages:   240,
 			NumExtensions: 0,
 			NumServices:   12,
 		},

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -23,6 +23,7 @@ service ProjectService {
   rpc StartSchedulerRun(StartSchedulerRunRequest) returns (StartSchedulerRunResponse);
   rpc GetSchedulerRun(GetSchedulerRunRequest) returns (GetSchedulerRunResponse);
   rpc ListSchedulerRuns(ListSchedulerRunsRequest) returns (ListSchedulerRunsResponse);
+  rpc BatchGetLatestSchedulerRuns(BatchGetLatestSchedulerRunsRequest) returns (BatchGetLatestSchedulerRunsResponse);
   rpc StreamSchedulerRuns(StreamSchedulerRunsRequest) returns (stream StreamSchedulerRunsResponse);
   rpc PruneSchedulerRuns(PruneSchedulerRunsRequest) returns (PruneSchedulerRunsResponse);
   rpc StopSchedulerRun(StopSchedulerRunRequest) returns (StopSchedulerRunResponse);
@@ -1934,4 +1935,24 @@ message StreamSchedulerRunsResponse {
   bool complete = 3;
   uint64 emitted_count = 4;
   bool truncated = 5;
+}
+
+// BatchGetLatestSchedulerRunsRequest selects scheduler runs by sandbox. A
+// request accepts at most 500 sandbox IDs.
+message BatchGetLatestSchedulerRunsRequest {
+  ProjectRef project = 1;
+  repeated string sandbox_ids = 2;
+}
+
+// SandboxSchedulerRun is the latest scheduler run linked to one sandbox. Run
+// is absent when the sandbox has no scheduler run in the selected project.
+message SandboxSchedulerRun {
+  string sandbox_id = 1;
+  SchedulerRun run = 2;
+}
+
+// BatchGetLatestSchedulerRunsResponse contains one result for each distinct,
+// non-empty requested sandbox ID, ordered by its first request occurrence.
+message BatchGetLatestSchedulerRunsResponse {
+  repeated SandboxSchedulerRun results = 1;
 }

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -103,6 +103,9 @@ const (
 	// ProjectServiceListSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
 	// ListSchedulerRuns RPC.
 	ProjectServiceListSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/ListSchedulerRuns"
+	// ProjectServiceBatchGetLatestSchedulerRunsProcedure is the fully-qualified name of the
+	// ProjectService's BatchGetLatestSchedulerRuns RPC.
+	ProjectServiceBatchGetLatestSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/BatchGetLatestSchedulerRuns"
 	// ProjectServiceStreamSchedulerRunsProcedure is the fully-qualified name of the ProjectService's
 	// StreamSchedulerRuns RPC.
 	ProjectServiceStreamSchedulerRunsProcedure = "/agentcompose.v2.ProjectService/StreamSchedulerRuns"
@@ -277,6 +280,7 @@ type ProjectServiceClient interface {
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	BatchGetLatestSchedulerRuns(context.Context, *connect.Request[v2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[v2.BatchGetLatestSchedulerRunsResponse], error)
 	StreamSchedulerRuns(context.Context, *connect.Request[v2.StreamSchedulerRunsRequest]) (*connect.ServerStreamForClient[v2.StreamSchedulerRunsResponse], error)
 	PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error)
 	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
@@ -391,6 +395,12 @@ func NewProjectServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
 			connect.WithClientOptions(opts...),
 		),
+		batchGetLatestSchedulerRuns: connect.NewClient[v2.BatchGetLatestSchedulerRunsRequest, v2.BatchGetLatestSchedulerRunsResponse](
+			httpClient,
+			baseURL+ProjectServiceBatchGetLatestSchedulerRunsProcedure,
+			connect.WithSchema(projectServiceMethods.ByName("BatchGetLatestSchedulerRuns")),
+			connect.WithClientOptions(opts...),
+		),
 		streamSchedulerRuns: connect.NewClient[v2.StreamSchedulerRunsRequest, v2.StreamSchedulerRunsResponse](
 			httpClient,
 			baseURL+ProjectServiceStreamSchedulerRunsProcedure,
@@ -442,6 +452,7 @@ type projectServiceClient struct {
 	startSchedulerRun            *connect.Client[v2.StartSchedulerRunRequest, v2.StartSchedulerRunResponse]
 	getSchedulerRun              *connect.Client[v2.GetSchedulerRunRequest, v2.GetSchedulerRunResponse]
 	listSchedulerRuns            *connect.Client[v2.ListSchedulerRunsRequest, v2.ListSchedulerRunsResponse]
+	batchGetLatestSchedulerRuns  *connect.Client[v2.BatchGetLatestSchedulerRunsRequest, v2.BatchGetLatestSchedulerRunsResponse]
 	streamSchedulerRuns          *connect.Client[v2.StreamSchedulerRunsRequest, v2.StreamSchedulerRunsResponse]
 	pruneSchedulerRuns           *connect.Client[v2.PruneSchedulerRunsRequest, v2.PruneSchedulerRunsResponse]
 	stopSchedulerRun             *connect.Client[v2.StopSchedulerRunRequest, v2.StopSchedulerRunResponse]
@@ -529,6 +540,11 @@ func (c *projectServiceClient) ListSchedulerRuns(ctx context.Context, req *conne
 	return c.listSchedulerRuns.CallUnary(ctx, req)
 }
 
+// BatchGetLatestSchedulerRuns calls agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns.
+func (c *projectServiceClient) BatchGetLatestSchedulerRuns(ctx context.Context, req *connect.Request[v2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[v2.BatchGetLatestSchedulerRunsResponse], error) {
+	return c.batchGetLatestSchedulerRuns.CallUnary(ctx, req)
+}
+
 // StreamSchedulerRuns calls agentcompose.v2.ProjectService.StreamSchedulerRuns.
 func (c *projectServiceClient) StreamSchedulerRuns(ctx context.Context, req *connect.Request[v2.StreamSchedulerRunsRequest]) (*connect.ServerStreamForClient[v2.StreamSchedulerRunsResponse], error) {
 	return c.streamSchedulerRuns.CallServerStream(ctx, req)
@@ -572,6 +588,7 @@ type ProjectServiceHandler interface {
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
+	BatchGetLatestSchedulerRuns(context.Context, *connect.Request[v2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[v2.BatchGetLatestSchedulerRunsResponse], error)
 	StreamSchedulerRuns(context.Context, *connect.Request[v2.StreamSchedulerRunsRequest], *connect.ServerStream[v2.StreamSchedulerRunsResponse]) error
 	PruneSchedulerRuns(context.Context, *connect.Request[v2.PruneSchedulerRunsRequest]) (*connect.Response[v2.PruneSchedulerRunsResponse], error)
 	StopSchedulerRun(context.Context, *connect.Request[v2.StopSchedulerRunRequest]) (*connect.Response[v2.StopSchedulerRunResponse], error)
@@ -682,6 +699,12 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 		connect.WithSchema(projectServiceMethods.ByName("ListSchedulerRuns")),
 		connect.WithHandlerOptions(opts...),
 	)
+	projectServiceBatchGetLatestSchedulerRunsHandler := connect.NewUnaryHandler(
+		ProjectServiceBatchGetLatestSchedulerRunsProcedure,
+		svc.BatchGetLatestSchedulerRuns,
+		connect.WithSchema(projectServiceMethods.ByName("BatchGetLatestSchedulerRuns")),
+		connect.WithHandlerOptions(opts...),
+	)
 	projectServiceStreamSchedulerRunsHandler := connect.NewServerStreamHandler(
 		ProjectServiceStreamSchedulerRunsProcedure,
 		svc.StreamSchedulerRuns,
@@ -746,6 +769,8 @@ func NewProjectServiceHandler(svc ProjectServiceHandler, opts ...connect.Handler
 			projectServiceGetSchedulerRunHandler.ServeHTTP(w, r)
 		case ProjectServiceListSchedulerRunsProcedure:
 			projectServiceListSchedulerRunsHandler.ServeHTTP(w, r)
+		case ProjectServiceBatchGetLatestSchedulerRunsProcedure:
+			projectServiceBatchGetLatestSchedulerRunsHandler.ServeHTTP(w, r)
 		case ProjectServiceStreamSchedulerRunsProcedure:
 			projectServiceStreamSchedulerRunsHandler.ServeHTTP(w, r)
 		case ProjectServicePruneSchedulerRunsProcedure:
@@ -827,6 +852,10 @@ func (UnimplementedProjectServiceHandler) GetSchedulerRun(context.Context, *conn
 
 func (UnimplementedProjectServiceHandler) ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.ListSchedulerRuns is not implemented"))
+}
+
+func (UnimplementedProjectServiceHandler) BatchGetLatestSchedulerRuns(context.Context, *connect.Request[v2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[v2.BatchGetLatestSchedulerRunsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns is not implemented"))
 }
 
 func (UnimplementedProjectServiceHandler) StreamSchedulerRuns(context.Context, *connect.Request[v2.StreamSchedulerRunsRequest], *connect.ServerStream[v2.StreamSchedulerRunsResponse]) error {


### PR DESCRIPTION
## Summary

Fixes scheduler-run attribution in `ps` without scanning scheduler-run history.

Closes #368.

## Solution

`ps` already knows the scheduler sandbox IDs it needs to display. This change moves the reverse lookup to the daemon instead of making the CLI page through unrelated runs:

- adds `BatchGetLatestSchedulerRuns`, accepting up to 500 sandbox IDs per request;
- returns one ordered `SandboxSchedulerRun` result for each distinct non-empty requested ID, including an empty `run` for misses;
- restricts lookups to the current project's managed scheduler loaders;
- queries `loader_event` by `linked_sandbox_id` and selects the latest trigger run per sandbox in one database query;
- adds the partial covering index `loader_event(linked_sandbox_id, loader_id, run_id)` for this reverse lookup;
- batches larger `ps` sandbox sets in the CLI;
- removes the old 500-run history scan and does not retain a streaming or pagination fallback, because the CLI and daemon are the same binary.

The previous proposal to scan up to 500,000 runs and the unrelated scheduler-event pagination changes have been removed.

## Testing

Passed on Go 1.26.2 after rebasing onto the latest `main`:

- `go test ./... -count=1`
- `go build ./cmd/agent-compose`
- repository Go lint scope (`golangci-lint fmt` and `golangci-lint run`)
- standalone installer lint scope

Focused coverage includes storage selection and project isolation, response ordering and missing results, the 500-ID request bound, CLI batching, and end-to-end `ps` attribution.