### PR TITLE
fix(storage): 修复相对 DATA_ROOT 启动时 SQLite 打开失败

### DIFF
--- a/pkg/storage/sqlite/database.go
+++ b/pkg/storage/sqlite/database.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -82,7 +83,8 @@ func sqliteDSN(path string, busyTimeout time.Duration) string {
 		if path == ":memory:" {
 			uri = &url.URL{Scheme: "file", Opaque: ":memory:"}
 		} else {
-			uri = &url.URL{Scheme: "file", Path: path}
+			// 相对路径必须省略 host 分隔符，否则首段会被 SQLite 解释为 URI authority。
+			uri = &url.URL{Scheme: "file", Path: path, OmitHost: !filepath.IsAbs(path)}
 		}
 	}
 	query := uri.Query()

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -438,6 +439,33 @@ func TestSQLiteDSNConfiguresProductionConnection(t *testing.T) {
 	}
 	if foreignKeys != 1 || busyTimeout != 5000 {
 		t.Fatalf("connection PRAGMAs = (foreign_keys=%d, busy_timeout=%d), want (1, 5000)", foreignKeys, busyTimeout)
+	}
+}
+
+func TestOpenSupportsRelativePath(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	if err := os.Mkdir("data", 0o755); err != nil {
+		t.Fatalf("create data directory: %v", err)
+	}
+
+	database, err := Open(filepath.Join("data", "data.db"), time.Second)
+	if err != nil {
+		t.Fatalf("Open relative path: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	dbPath := filepath.Join(workDir, "data", "data.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("stat database file %q: %v", dbPath, err)
+	}
+
+	var migrationCount int
+	if err := database.DB().QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&migrationCount); err != nil {
+		t.Fatalf("query migration history: %v", err)
+	}
+	if migrationCount == 0 {
+		t.Fatal("migration history is empty")
 	}
 }
 


### PR DESCRIPTION
## 问题

Upstream issue: chaitin/agent-compose#374

在 `.env` 配置 `DATA_ROOT=./data` 后执行 `ac daemon`，daemon 在打开 SQLite 数据库时 panic：

```
panic: ping SQLite database: SQL logic error: invalid uri authority: data (1)
```

## 原因

`pkg/config.NewConfig` 由 `DATA_ROOT=./data` 生成相对数据库路径 `data/data.db`。`pkg/storage/sqlite.sqliteDSN` 使用 `url.URL{Scheme: "file", Path: path}` 构造 DSN，标准库把相对路径序列化为 `file://data/data.db?...`，SQLite 将 `data` 识别为 URI authority。SQLite file URI 只接受空 authority 或 `localhost`，因此首次建立连接的 `PingContext` 失败，依赖注入层随后 panic。

## 方案

在共享 SQLite DSN 构造边界正确表达相对文件路径：相对路径设置 `url.URL.OmitHost` 生成 `file:data/data.db?...`，不产生 authority。

- 绝对路径：`IsAbs=true` -> `OmitHost=false` -> `file:///abs/path`，行为不变
- 相对路径：`IsAbs=false` -> `OmitHost=true` -> `file:relative/path`，修复
- `:memory:` 与 `file:` 开头 URI 分支未触动，行为不变
- 继续用 `net/url` 序列化，路径特殊字符（空格、`#` 等）仍正确转义

修复点选在共享 `sqliteDSN` 而非 `pkg/config`，`sessionstore.NewWithConfig` 等其他相对路径调用方自动受益。

## 回归风险评估

- 默认部署（绝对路径）走未改动分支，零行为变化。
- 相对路径分支从「必崩」变为「正确」，多段 `data/data.db`、单段 `data.db`、`./data.db` 前缀实测均能打开并完成迁移。
- 三个生产调用方均经 `config.DbAddr` 或 `filepath.Join(SandboxRoot, "data.db")` 构造路径，形态一致；`DbAddr` 无 env 直接覆盖入口，不会有意外的 `file:`/`:memory:` 路径。

## 测试

- 新增 `TestOpenSupportsRelativePath`（并入既有 `migrations_test.go`）：通过相对路径调用 `Open`，断言数据库文件落在进程工作目录、迁移表非空。该测试在修复前稳定失败。
- 既有 `TestSQLiteDSNConfiguresProductionConnection`（绝对路径 + PRAGMA）继续通过，证明绝对路径、WAL、外键、busy_timeout 未回归。

```
go vet ./pkg/storage/sqlite
go test ./pkg/storage/sqlite -count=1
```

未运行 `task lint`/`task build`/`task test`（本地环境限制），CI 将覆盖。

Fixes chaitin/agent-compose#374