### PR TITLE
feat(scheduler): expose project concurrency policy

### DIFF
--- a/cmd/agent-compose/cli_runtime_project.go
+++ b/cmd/agent-compose/cli_runtime_project.go
@@ -156,12 +156,13 @@ func normalizedRuntimeAgentSpec(agent *agentcomposev2.AgentSpec) compose.Normali
 	}
 	if scheduler := agent.GetScheduler(); scheduler != nil {
 		result.Scheduler = &compose.NormalizedSchedulerSpec{
-			Enabled:       scheduler.GetEnabled(),
-			SandboxPolicy: scheduler.GetSandboxPolicy(),
-			DisplayName:   scheduler.GetDisplayName(),
-			Description:   scheduler.GetDescription(),
-			Script:        scheduler.GetScript(),
-			Triggers:      make([]compose.NormalizedTriggerSpec, 0, len(scheduler.GetTriggers())),
+			Enabled:           scheduler.GetEnabled(),
+			SandboxPolicy:     scheduler.GetSandboxPolicy(),
+			ConcurrencyPolicy: scheduler.GetConcurrencyPolicy(),
+			DisplayName:       scheduler.GetDisplayName(),
+			Description:       scheduler.GetDescription(),
+			Script:            scheduler.GetScript(),
+			Triggers:          make([]compose.NormalizedTriggerSpec, 0, len(scheduler.GetTriggers())),
 		}
 		for _, trigger := range scheduler.GetTriggers() {
 			item := compose.NormalizedTriggerSpec{

--- a/cmd/agent-compose/cli_runtime_project_test.go
+++ b/cmd/agent-compose/cli_runtime_project_test.go
@@ -9,6 +9,23 @@ import (
 	"connectrpc.com/connect"
 )
 
+func TestNormalizedRuntimeAgentSpecPreservesSchedulerConcurrencyPolicy(t *testing.T) {
+	enabled := true
+	agent := normalizedRuntimeAgentSpec(&agentcomposev2.AgentSpec{
+		Name:     "worker",
+		Provider: "codex",
+		Enabled:  &enabled,
+		Scheduler: &agentcomposev2.SchedulerSpec{
+			Enabled:           true,
+			ConcurrencyPolicy: "parallel",
+		},
+	})
+
+	if agent.Scheduler == nil || agent.Scheduler.ConcurrencyPolicy != "parallel" {
+		t.Fatalf("scheduler = %#v, want concurrency policy parallel", agent.Scheduler)
+	}
+}
+
 func TestIntegrationCLIRuntimeCommandsSelectStoredProjectByName(t *testing.T) {
 	withWorkingDir(t, t.TempDir())
 	enabled := true
@@ -16,7 +33,7 @@ func TestIntegrationCLIRuntimeCommandsSelectStoredProjectByName(t *testing.T) {
 		Summary: &agentcomposev2.ProjectSummary{ProjectId: "project-stored", Name: "stored-project"},
 		Spec: &agentcomposev2.ProjectSpec{Name: "stored-project", Agents: []*agentcomposev2.AgentSpec{{
 			Name: "worker", Provider: "codex", Enabled: &enabled,
-			Scheduler: &agentcomposev2.SchedulerSpec{Enabled: true, Triggers: []*agentcomposev2.TriggerSpec{{Name: "manual", Kind: "manual"}}},
+			Scheduler: &agentcomposev2.SchedulerSpec{Enabled: true, ConcurrencyPolicy: "parallel", Triggers: []*agentcomposev2.TriggerSpec{{Name: "manual", Kind: "manual"}}},
 		}}},
 		Agents:     []*agentcomposev2.ProjectAgent{{ProjectId: "project-stored", AgentName: "worker", ManagedAgentId: "agent-stored", Provider: "codex", Enabled: true}},
 		Schedulers: []*agentcomposev2.ProjectScheduler{{ProjectId: "project-stored", AgentName: "worker", SchedulerId: "scheduler-stored", Enabled: true, TriggerCount: 1}},

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -688,10 +688,13 @@ A scheduler uses either declarative `triggers` or JavaScript `script`; the two f
 | --- | --- | --- | --- |
 | `enabled` | bool | `true` | Enables this agent's scheduler. Disabling the Agent also prevents its scheduler from being enabled. |
 | `sandbox_policy` | string | `new` | Scheduler default sandbox policy: `new` or `sticky`. |
+| `concurrency_policy` | string | `skip` | Overlapping run policy for the entire agent scheduler: `skip` or `parallel`. |
 | `triggers` | list | Empty | Declarative triggers. |
 | `script` | string/object | Empty | Inline JavaScript or a flat `file`/`http`/`git` source mapping. Cannot coexist with `triggers`. |
 
 `new` creates a new sandbox for scheduler calls. `sticky` allows the scheduler to bind and reuse a sandbox. A trigger-level `sandbox_policy` controls the generated agent call for that trigger.
+
+`concurrency_policy` applies to the whole agent scheduler, including all declarative or script-registered triggers and manual scheduler invocations. With `skip`, a run that overlaps another run from the same scheduler is recorded as `skipped` and is not queued. With `parallel`, overlapping runs may execute concurrently. It is not a per-trigger policy.
 
 #### Declarative triggers
 
@@ -701,6 +704,7 @@ Each trigger must set exactly one kind field: `cron`, `interval`, `timeout`, or 
 scheduler:
   enabled: true
   sandbox_policy: sticky
+  concurrency_policy: parallel
   triggers:
     - name: nightly
       cron: "0 2 * * *"

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -693,10 +693,13 @@ Scheduler 可以使用声明式 `triggers`，也可以使用 JavaScript `script`
 | --- | --- | --- | --- |
 | `enabled` | bool | `true` | 是否启用该 Agent 的 Scheduler。禁用 Agent 也会使其 Scheduler 无效。 |
 | `sandbox_policy` | string | `new` | Scheduler 默认 sandbox 策略：`new` 或 `sticky`。 |
+| `concurrency_policy` | string | `skip` | 整个 Agent Scheduler 的重叠运行策略：`skip` 或 `parallel`。 |
 | `triggers` | list | 空 | 声明式触发器。 |
 | `script` | string/object | 空 | 内联 JavaScript，或扁平的 `file`/`http`/`git` 来源配置。不能和 `triggers` 同时使用。 |
 
 `new` 为每次调用创建新 sandbox；`sticky` 允许 Scheduler 绑定并复用 sandbox。单个 Trigger 的 `sandbox_policy` 可覆盖执行 Agent 时的策略。
+
+`concurrency_policy` 作用于整个 Agent Scheduler，包括全部声明式或脚本注册的 Trigger，以及手动 Scheduler 调用。`skip` 会把与同一 Scheduler 既有运行重叠的新 run 记录为 `skipped`，且不会排队补跑；`parallel` 允许重叠 run 并行执行。它不是 Trigger 级策略。
 
 #### 声明式 Trigger
 
@@ -706,6 +709,7 @@ Scheduler 可以使用声明式 `triggers`，也可以使用 JavaScript `script`
 scheduler:
   enabled: true
   sandbox_policy: sticky
+  concurrency_policy: parallel
   triggers:
     - name: nightly
       cron: "0 2 * * *"

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -456,12 +456,13 @@ func SchedulerSpecToProto(scheduler *compose.NormalizedSchedulerSpec) *agentcomp
 		triggers = append(triggers, TriggerSpecToProto(trigger))
 	}
 	return &agentcomposev2.SchedulerSpec{
-		Enabled:       scheduler.Enabled,
-		Triggers:      triggers,
-		Script:        scheduler.Script,
-		SandboxPolicy: scheduler.SandboxPolicy,
-		DisplayName:   scheduler.DisplayName,
-		Description:   scheduler.Description,
+		Enabled:           scheduler.Enabled,
+		Triggers:          triggers,
+		Script:            scheduler.Script,
+		SandboxPolicy:     scheduler.SandboxPolicy,
+		DisplayName:       scheduler.DisplayName,
+		Description:       scheduler.Description,
+		ConcurrencyPolicy: scheduler.ConcurrencyPolicy,
 	}
 }
 
@@ -881,6 +882,9 @@ func SchedulerYAMLShape(scheduler *agentcomposev2.SchedulerSpec) map[string]any 
 	}
 	if scheduler.GetSandboxPolicy() != "" {
 		raw["sandbox_policy"] = scheduler.GetSandboxPolicy()
+	}
+	if scheduler.GetConcurrencyPolicy() != "" {
+		raw["concurrency_policy"] = scheduler.GetConcurrencyPolicy()
 	}
 	triggers := make([]map[string]any, 0, len(scheduler.GetTriggers()))
 	for _, trigger := range scheduler.GetTriggers() {

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -103,11 +104,12 @@ func TestProjectSpecToProtoIncludesSchedulerScript(t *testing.T) {
 				Boxlite: &compose.BoxliteDriverSpec{},
 			},
 			Scheduler: &compose.NormalizedSchedulerSpec{
-				Enabled:       true,
-				SandboxPolicy: "sticky",
-				DisplayName:   "Hourly review",
-				Description:   "Reviews pending changes every hour",
-				Script:        script,
+				Enabled:           true,
+				SandboxPolicy:     "sticky",
+				ConcurrencyPolicy: "parallel",
+				DisplayName:       "Hourly review",
+				Description:       "Reviews pending changes every hour",
+				Script:            script,
 			},
 		}},
 	}
@@ -123,11 +125,14 @@ func TestProjectSpecToProtoIncludesSchedulerScript(t *testing.T) {
 	if scheduler.GetSandboxPolicy() != "sticky" {
 		t.Fatalf("scheduler sandbox policy = %q, want sticky", scheduler.GetSandboxPolicy())
 	}
+	if scheduler.GetConcurrencyPolicy() != "parallel" {
+		t.Fatalf("scheduler concurrency policy = %q, want parallel", scheduler.GetConcurrencyPolicy())
+	}
 	if scheduler.GetDisplayName() != "Hourly review" || scheduler.GetDescription() != "Reviews pending changes every hour" {
 		t.Fatalf("scheduler presentation = %#v", scheduler)
 	}
 	shape := SchedulerYAMLShape(scheduler)
-	if shape["sandbox_policy"] != "sticky" || shape["display_name"] != "Hourly review" || shape["description"] != "Reviews pending changes every hour" {
+	if shape["sandbox_policy"] != "sticky" || shape["concurrency_policy"] != "parallel" || shape["display_name"] != "Hourly review" || shape["description"] != "Reviews pending changes every hour" {
 		t.Fatalf("scheduler YAML shape = %#v", shape)
 	}
 	if got := len(scheduler.GetTriggers()); got != 0 {
@@ -251,6 +256,259 @@ func TestIntegrationAgentPresentationMetadataRoundTripsThroughProtoAndCompose(t 
 	agent := response.GetAgents()[0]
 	if agent.GetName() != "legacy-agent-bfe5286dc77f" || agent.GetDisplayName() != "通用助手" || agent.GetDescription() != "处理日常通用任务" {
 		t.Fatalf("round-tripped agent = %#v", agent)
+	}
+}
+
+func TestIntegrationSchedulerConcurrencyPolicyRoundTripsThroughProtoAndCompose(t *testing.T) {
+	raw, err := compose.Parse([]byte(`
+name: scheduler-policy-round-trip
+agents:
+  reviewer:
+    provider: codex
+    driver:
+      docker: {}
+    scheduler:
+      enabled: true
+      display_name: Review queue
+      description: Processes every pending review
+      sandbox_policy: sticky
+      concurrency_policy: parallel
+      triggers:
+        - name: hourly
+          cron: "0 * * * *"
+          prompt: Review hourly changes
+        - name: frequent
+          interval: 5m
+          prompt: Review recent changes
+        - name: later
+          timeout: 30s
+          prompt: Review after delay
+        - name: requested
+          event:
+            topic: review.requested
+          prompt: Review requested change
+`))
+	if err != nil {
+		t.Fatalf("parse authoring YAML: %v", err)
+	}
+	normalized, err := compose.Normalize(raw, compose.NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("normalize authoring YAML: %v", err)
+	}
+	if len(normalized.Agents) != 1 || normalized.Agents[0].Scheduler == nil || normalized.Agents[0].Scheduler.ConcurrencyPolicy != domain.LoaderConcurrencyPolicyParallel {
+		t.Fatalf("normalized scheduler = %#v", normalized.Agents)
+	}
+
+	wireSpec, err := ProjectSpecToProtoChecked(normalized)
+	if err != nil {
+		t.Fatalf("convert normalized project to protobuf: %v", err)
+	}
+	if got := wireSpec.GetAgents()[0].GetScheduler().GetConcurrencyPolicy(); got != domain.LoaderConcurrencyPolicyParallel {
+		t.Fatalf("protobuf concurrency policy = %q, want parallel", got)
+	}
+	shape, issues := ProjectSpecYAMLShape(wireSpec)
+	if len(issues) != 0 {
+		t.Fatalf("convert protobuf project to YAML shape: %#v", issues)
+	}
+	data, err := yaml.Marshal(shape)
+	if err != nil {
+		t.Fatalf("marshal reconstructed YAML: %v", err)
+	}
+	if !strings.Contains(string(data), "concurrency_policy: parallel") {
+		t.Fatalf("reconstructed YAML lost concurrency policy:\n%s", data)
+	}
+
+	reparsed, err := compose.Parse(data)
+	if err != nil {
+		t.Fatalf("parse reconstructed YAML: %v", err)
+	}
+	roundTripped, err := compose.Normalize(reparsed, compose.NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("normalize reconstructed YAML: %v", err)
+	}
+	if len(roundTripped.Agents) != 1 || roundTripped.Agents[0].Scheduler == nil {
+		t.Fatalf("round-tripped agents = %#v", roundTripped.Agents)
+	}
+	scheduler := roundTripped.Agents[0].Scheduler
+	if scheduler.ConcurrencyPolicy != domain.LoaderConcurrencyPolicyParallel || scheduler.SandboxPolicy != domain.LoaderSandboxPolicySticky || len(scheduler.Triggers) != 4 {
+		t.Fatalf("round-tripped scheduler = %#v", scheduler)
+	}
+	for index, kind := range []string{"cron", "interval", "timeout", "event"} {
+		if scheduler.Triggers[index].Kind != kind {
+			t.Fatalf("round-tripped trigger %d = %#v, want kind %q", index, scheduler.Triggers[index], kind)
+		}
+	}
+}
+
+func TestIntegrationProjectSpecRichConfigurationRoundTripsThroughServiceShape(t *testing.T) {
+	raw, err := compose.Parse([]byte(`
+name: rich-service-round-trip
+variables:
+  API_TOKEN:
+    value: ${API_TOKEN}
+    secret: true
+mcp_servers:
+  local-tools:
+    type: local
+    command: npx
+    args: ["-y", "@example/mcp-server"]
+    env:
+      TOOL_MODE: strict
+  issue-tracker:
+    type: remote
+    transport: http
+    url: https://issues.example.test/mcp
+    headers:
+      Authorization: Bearer ${ISSUE_TOKEN}
+volumes:
+  cache:
+    name: shared-review-cache
+    driver: local
+    external: true
+    labels:
+      purpose: review
+    options:
+      device: /var/cache/reviews
+agents:
+  reviewer:
+    enabled: true
+    display_name: Release reviewer
+    description: Reviews release candidates
+    provider: codex
+    model: gpt-test
+    system_prompt: Review every release carefully.
+    image: reviewer:test
+    build:
+      context: ./guest
+      dockerfile: Dockerfile.review
+      target: runtime
+      args:
+        CHANNEL: stable
+      platforms: [linux/amd64]
+      tags: [reviewer:latest]
+      no_cache: true
+      pull: true
+    driver:
+      docker:
+        host: unix:///var/run/docker.sock
+    env:
+      LOG_LEVEL: debug
+      SERVICE_TOKEN:
+        value: ${SERVICE_TOKEN}
+        secret: true
+    capset_ids: [engineering, audit]
+    skills:
+      - name: release-check
+        provider: git
+        url: https://example.test/skills.git
+        path: skills/release-check
+        ref: main
+        username: ${SKILL_USER}
+        password: ${SKILL_PASSWORD}
+        token: ${SKILL_TOKEN}
+    mcp_servers:
+      - local-tools
+      - name: audit-api
+        type: remote
+        transport: sse
+        url: https://audit.example.test/sse
+        headers:
+          Authorization: Bearer ${AUDIT_TOKEN}
+    volumes:
+      - type: volume
+        source: cache
+        target: /cache
+        read_only: true
+      - type: bind
+        source: ./reports
+        target: /workspace/reports
+    scheduler:
+      enabled: true
+      sandbox_policy: sticky
+      concurrency_policy: parallel
+      triggers:
+        - name: hourly-review
+          cron: "0 * * * *"
+          prompt: Review current release state
+    jupyter:
+      enabled: true
+      guest_port: 8888
+`))
+	if err != nil {
+		t.Fatalf("parse rich project: %v", err)
+	}
+	composePath := filepath.Join(t.TempDir(), "agent-compose.yaml")
+	normalizeOptions := compose.NormalizeOptions{
+		ComposePath: composePath,
+		Env: map[string]string{
+			"API_TOKEN":      "${API_TOKEN}",
+			"ISSUE_TOKEN":    "${ISSUE_TOKEN}",
+			"SERVICE_TOKEN":  "${SERVICE_TOKEN}",
+			"SKILL_USER":     "${SKILL_USER}",
+			"SKILL_PASSWORD": "${SKILL_PASSWORD}",
+			"SKILL_TOKEN":    "${SKILL_TOKEN}",
+			"AUDIT_TOKEN":    "${AUDIT_TOKEN}",
+		},
+	}
+	normalized, err := compose.Normalize(raw, normalizeOptions)
+	if err != nil {
+		t.Fatalf("normalize rich project: %v", err)
+	}
+	wireSpec, err := ProjectSpecToProtoChecked(normalized)
+	if err != nil {
+		t.Fatalf("convert rich project to protobuf: %v", err)
+	}
+	shape, issues := ProjectSpecYAMLShape(wireSpec)
+	if len(issues) != 0 {
+		t.Fatalf("convert rich project to YAML shape: %#v", issues)
+	}
+	data, err := yaml.Marshal(shape)
+	if err != nil {
+		t.Fatalf("marshal rich service shape: %v", err)
+	}
+	reparsed, err := compose.Parse(data)
+	if err != nil {
+		t.Fatalf("parse rich service shape: %v\n%s", err, data)
+	}
+	roundTripped, err := compose.Normalize(reparsed, normalizeOptions)
+	if err != nil {
+		t.Fatalf("normalize rich service shape: %v\n%s", err, data)
+	}
+
+	if token := roundTripped.Variables["API_TOKEN"]; token.Value != "${API_TOKEN}" || !token.Secret {
+		t.Fatalf("round-tripped project variable = %#v", token)
+	}
+	volume := roundTripped.Volumes["cache"]
+	if volume.Name != "shared-review-cache" || !volume.External || volume.Labels["purpose"] != "review" || volume.Options["device"] != "/var/cache/reviews" {
+		t.Fatalf("round-tripped project volume = %#v", volume)
+	}
+	if len(roundTripped.MCPServers) != 2 || roundTripped.MCPServers["local-tools"].Command != "npx" || roundTripped.MCPServers["issue-tracker"].Transport != "http" {
+		t.Fatalf("round-tripped project MCP servers = %#v", roundTripped.MCPServers)
+	}
+	if len(roundTripped.Agents) != 1 {
+		t.Fatalf("round-tripped agents = %#v", roundTripped.Agents)
+	}
+	agent := roundTripped.Agents[0]
+	if agent.Build == nil || agent.Build.Dockerfile != "Dockerfile.review" || !agent.Build.NoCache || !agent.Build.Pull || len(agent.Build.Args) != 1 {
+		t.Fatalf("round-tripped build = %#v", agent.Build)
+	}
+	if agent.Driver == nil || agent.Driver.Docker == nil || agent.Driver.Docker.Host != "unix:///var/run/docker.sock" {
+		t.Fatalf("round-tripped driver = %#v", agent.Driver)
+	}
+	if len(agent.Skills) != 1 || agent.Skills[0].Name != "release-check" || agent.Skills[0].Token != "${SKILL_TOKEN}" {
+		t.Fatalf("round-tripped skills = %#v", agent.Skills)
+	}
+	if len(agent.MCPServers) != 2 || agent.MCPServers["audit-api"].Transport != "sse" {
+		t.Fatalf("round-tripped agent MCP servers = %#v", agent.MCPServers)
+	}
+	if len(agent.Volumes) != 2 || !agent.Volumes[0].ReadOnly || agent.Volumes[1].Type != "bind" {
+		t.Fatalf("round-tripped mounts = %#v", agent.Volumes)
+	}
+	if agent.Jupyter == nil || !agent.Jupyter.Enabled || agent.Jupyter.GuestPort != 8888 {
+		t.Fatalf("round-tripped jupyter = %#v", agent.Jupyter)
+	}
+	if agent.Scheduler == nil || agent.Scheduler.ConcurrencyPolicy != domain.LoaderConcurrencyPolicyParallel {
+		t.Fatalf("round-tripped scheduler = %#v", agent.Scheduler)
 	}
 }
 

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -124,12 +124,13 @@ type NormalizedDriverSpec struct {
 }
 
 type NormalizedSchedulerSpec struct {
-	Enabled       bool                    `yaml:"enabled" json:"enabled"`
-	SandboxPolicy string                  `yaml:"sandbox_policy" json:"sandbox_policy"`
-	DisplayName   string                  `yaml:"display_name,omitempty" json:"display_name,omitempty"`
-	Description   string                  `yaml:"description,omitempty" json:"description,omitempty"`
-	Script        string                  `yaml:"script,omitempty" json:"script,omitempty"`
-	Triggers      []NormalizedTriggerSpec `yaml:"triggers,omitempty" json:"triggers,omitempty"`
+	Enabled           bool                    `yaml:"enabled" json:"enabled"`
+	SandboxPolicy     string                  `yaml:"sandbox_policy" json:"sandbox_policy"`
+	ConcurrencyPolicy string                  `yaml:"concurrency_policy" json:"concurrency_policy"`
+	DisplayName       string                  `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description       string                  `yaml:"description,omitempty" json:"description,omitempty"`
+	Script            string                  `yaml:"script,omitempty" json:"script,omitempty"`
+	Triggers          []NormalizedTriggerSpec `yaml:"triggers,omitempty" json:"triggers,omitempty"`
 
 	scriptSource *sources.Source
 }
@@ -1076,12 +1077,17 @@ func normalizeSchedulerSpec(path string, scheduler *SchedulerSpec, options Norma
 	if err != nil {
 		return nil, err
 	}
+	concurrencyPolicy, err := normalizeSchedulerConcurrencyPolicy(path+".concurrency_policy", scheduler.ConcurrencyPolicy)
+	if err != nil {
+		return nil, err
+	}
 	normalized := &NormalizedSchedulerSpec{
-		Enabled:       enabled,
-		SandboxPolicy: sandboxPolicy,
-		DisplayName:   strings.TrimSpace(scheduler.DisplayName),
-		Description:   strings.TrimSpace(scheduler.Description),
-		Script:        script,
+		Enabled:           enabled,
+		SandboxPolicy:     sandboxPolicy,
+		ConcurrencyPolicy: concurrencyPolicy,
+		DisplayName:       strings.TrimSpace(scheduler.DisplayName),
+		Description:       strings.TrimSpace(scheduler.Description),
+		Script:            script,
 	}
 	if scriptSource.HasContent() {
 		if !options.ResolveScriptURLs {
@@ -1251,6 +1257,19 @@ func normalizeSandboxPolicy(path string, value *string, fallback string) (string
 		return policy, nil
 	default:
 		return "", &ValidationError{Path: path, Message: fmt.Sprintf("sandbox_policy must be sticky or new, got %q", policy)}
+	}
+}
+
+func normalizeSchedulerConcurrencyPolicy(path string, value *string) (string, error) {
+	if value == nil {
+		return "skip", nil
+	}
+	policy := strings.ToLower(strings.TrimSpace(*value))
+	switch policy {
+	case "skip", "parallel":
+		return policy, nil
+	default:
+		return "", &ValidationError{Path: path, Message: fmt.Sprintf("concurrency_policy must be skip or parallel, got %q", policy)}
 	}
 }
 

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -111,7 +111,7 @@ agents:
 	}
 }
 
-func TestNormalizeSchedulerSandboxPolicies(t *testing.T) {
+func TestNormalizeSchedulerPolicies(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: policy-project
 agents:
@@ -119,6 +119,7 @@ agents:
     provider: codex
     scheduler:
       sandbox_policy: sticky
+      concurrency_policy: parallel
       triggers:
         - name: inherited
           interval: 1m
@@ -131,7 +132,7 @@ agents:
 		t.Fatalf("Normalize returned error: %v", err)
 	}
 	scheduler := normalized.Agents[0].Scheduler
-	if scheduler.SandboxPolicy != "sticky" || scheduler.Triggers[0].SandboxPolicy != "" || scheduler.Triggers[1].SandboxPolicy != "new" {
+	if scheduler.SandboxPolicy != "sticky" || scheduler.ConcurrencyPolicy != "parallel" || scheduler.Triggers[0].SandboxPolicy != "" || scheduler.Triggers[1].SandboxPolicy != "new" {
 		t.Fatalf("scheduler policies = %#v", scheduler)
 	}
 
@@ -150,6 +151,9 @@ agents:
 	if got := defaultNormalized.Agents[0].Scheduler.SandboxPolicy; got != "new" {
 		t.Fatalf("default sandbox policy = %q, want new", got)
 	}
+	if got := defaultNormalized.Agents[0].Scheduler.ConcurrencyPolicy; got != "skip" {
+		t.Fatalf("default concurrency policy = %q, want skip", got)
+	}
 
 	for _, input := range []string{
 		"sandbox_policy: reuse\n      triggers:\n        - interval: 1m",
@@ -158,6 +162,13 @@ agents:
 		invalid := mustParseCompose(t, "name: invalid-policy\nagents:\n  reviewer:\n    scheduler:\n      "+input+"\n")
 		if _, err := Normalize(invalid, NormalizeOptions{}); err == nil || !strings.Contains(err.Error(), "sandbox_policy") {
 			t.Fatalf("Normalize invalid policy error = %v", err)
+		}
+	}
+
+	for _, policy := range []string{"", "allow", "serial"} {
+		invalid := mustParseCompose(t, "name: invalid-concurrency-policy\nagents:\n  reviewer:\n    scheduler:\n      concurrency_policy: '"+policy+"'\n      triggers:\n        - interval: 1m\n")
+		if _, err := Normalize(invalid, NormalizeOptions{}); err == nil || !strings.Contains(err.Error(), "concurrency_policy") {
+			t.Fatalf("Normalize invalid concurrency policy %q error = %v", policy, err)
 		}
 	}
 }

--- a/pkg/compose/output.go
+++ b/pkg/compose/output.go
@@ -436,12 +436,13 @@ func cloneNormalizedSchedulerSpec(value *NormalizedSchedulerSpec) *NormalizedSch
 		return nil
 	}
 	cloned := &NormalizedSchedulerSpec{
-		Enabled:       value.Enabled,
-		SandboxPolicy: value.SandboxPolicy,
-		DisplayName:   value.DisplayName,
-		Description:   value.Description,
-		Script:        value.Script,
-		scriptSource:  cloneSourcePointer(value.scriptSource),
+		Enabled:           value.Enabled,
+		SandboxPolicy:     value.SandboxPolicy,
+		ConcurrencyPolicy: value.ConcurrencyPolicy,
+		DisplayName:       value.DisplayName,
+		Description:       value.Description,
+		Script:            value.Script,
+		scriptSource:      cloneSourcePointer(value.scriptSource),
 	}
 	for _, trigger := range value.Triggers {
 		cloned.Triggers = append(cloned.Triggers, cloneNormalizedTriggerSpec(trigger))

--- a/pkg/compose/output_test.go
+++ b/pkg/compose/output_test.go
@@ -90,6 +90,36 @@ agents:
 	}
 }
 
+func TestSchedulerConcurrencyPolicySurvivesCanonicalOutput(t *testing.T) {
+	normalized := mustNormalizeCompose(t, `
+name: scheduler-concurrency
+agents:
+  reviewer:
+    scheduler:
+      concurrency_policy: parallel
+      triggers:
+        - interval: 1m
+`, nil)
+
+	jsonData, err := normalized.MarshalCanonicalJSON(false)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON returned error: %v", err)
+	}
+	yamlData, err := normalized.MarshalCanonicalYAML(false)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalYAML returned error: %v", err)
+	}
+	if !bytes.Contains(jsonData, []byte(`"concurrency_policy":"parallel"`)) {
+		t.Fatalf("canonical JSON = %s, want concurrency policy", jsonData)
+	}
+	if !bytes.Contains(yamlData, []byte("concurrency_policy: parallel")) {
+		t.Fatalf("canonical YAML = %s, want concurrency policy", yamlData)
+	}
+	if got := normalized.Redacted().Agents[0].Scheduler.ConcurrencyPolicy; got != "parallel" {
+		t.Fatalf("redacted concurrency policy = %q, want parallel", got)
+	}
+}
+
 func TestAgentEnablementUsesCanonicalBooleanOutput(t *testing.T) {
 	normalized := mustNormalizeCompose(t, `
 name: enablement

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -132,12 +132,13 @@ type SkillSpec struct {
 }
 
 type SchedulerSpec struct {
-	Enabled       *bool         `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	SandboxPolicy *string       `yaml:"sandbox_policy,omitempty" json:"sandbox_policy,omitempty"`
-	DisplayName   string        `yaml:"display_name,omitempty" json:"display_name,omitempty"`
-	Description   string        `yaml:"description,omitempty" json:"description,omitempty"`
-	Triggers      []TriggerSpec `yaml:"triggers,omitempty" json:"triggers,omitempty"`
-	Script        ScriptSource  `yaml:"script,omitempty" json:"script,omitempty"`
+	Enabled           *bool         `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	SandboxPolicy     *string       `yaml:"sandbox_policy,omitempty" json:"sandbox_policy,omitempty"`
+	ConcurrencyPolicy *string       `yaml:"concurrency_policy,omitempty" json:"concurrency_policy,omitempty"`
+	DisplayName       string        `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description       string        `yaml:"description,omitempty" json:"description,omitempty"`
+	Triggers          []TriggerSpec `yaml:"triggers,omitempty" json:"triggers,omitempty"`
+	Script            ScriptSource  `yaml:"script,omitempty" json:"script,omitempty"`
 }
 
 // ScriptSource is the authoring shape accepted by scheduler.script. Inline is
@@ -666,12 +667,13 @@ func validateStringList(node *yaml.Node, path string) error {
 
 func validateScheduler(node *yaml.Node, path string) error {
 	return validateMapping(node, path, map[string]nodeValidator{
-		"enabled":        validateBool,
-		"sandbox_policy": validateScalar,
-		"display_name":   validateScalar,
-		"description":    validateScalar,
-		"triggers":       validateTriggerList,
-		"script":         validateScriptSource,
+		"enabled":            validateBool,
+		"sandbox_policy":     validateScalar,
+		"concurrency_policy": validateScalar,
+		"display_name":       validateScalar,
+		"description":        validateScalar,
+		"triggers":           validateTriggerList,
+		"script":             validateScriptSource,
 	})
 }
 

--- a/pkg/compose/spec_test.go
+++ b/pkg/compose/spec_test.go
@@ -122,6 +122,7 @@ agents:
       guest_port: 8888
     scheduler:
       enabled: true
+      concurrency_policy: parallel
       triggers:
         - cron: "0 * * * *"
           prompt: "Review the latest workspace state."
@@ -150,6 +151,9 @@ agents:
 	}
 	if agent.Scheduler == nil || agent.Scheduler.Enabled == nil || !*agent.Scheduler.Enabled {
 		t.Fatalf("scheduler enabled = %#v", agent.Scheduler)
+	}
+	if agent.Scheduler.ConcurrencyPolicy == nil || *agent.Scheduler.ConcurrencyPolicy != "parallel" {
+		t.Fatalf("scheduler concurrency policy = %#v", agent.Scheduler.ConcurrencyPolicy)
 	}
 	if got := len(agent.Scheduler.Triggers); got != 2 {
 		t.Fatalf("trigger count = %d, want 2", got)

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -273,11 +273,12 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 			projected.Summary.Enabled = false
 		}
 		spec.Agents[targetIndex].Scheduler = &compose.NormalizedSchedulerSpec{
-			Enabled:       projected.Summary.Enabled,
-			SandboxPolicy: domain.NormalizeLoaderSandboxPolicy(projected.Summary.SandboxPolicy),
-			DisplayName:   strings.TrimSpace(projected.Summary.Name),
-			Description:   strings.TrimSpace(projected.Summary.Description),
-			Script:        projected.Script,
+			Enabled:           projected.Summary.Enabled,
+			SandboxPolicy:     domain.NormalizeLoaderSandboxPolicy(projected.Summary.SandboxPolicy),
+			ConcurrencyPolicy: domain.NormalizeLoaderConcurrencyPolicy(projected.Summary.ConcurrencyPolicy),
+			DisplayName:       strings.TrimSpace(projected.Summary.Name),
+			Description:       strings.TrimSpace(projected.Summary.Description),
+			Script:            projected.Script,
 		}
 		scheduledAgents[targetName] = struct{}{}
 		overrides[targetName] = projected

--- a/pkg/projects/legacy_default_project_integration_test.go
+++ b/pkg/projects/legacy_default_project_integration_test.go
@@ -71,17 +71,18 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 `
 	loader, err := store.CreateLoader(ctx, domain.Loader{
 		Summary: domain.LoaderSummary{
-			ID:            "legacy-loader-source",
-			Name:          "资讯推送任务",
-			Description:   "每小时检查并推送资讯",
-			Enabled:       false,
-			Runtime:       domain.LoaderRuntimeScheduler,
-			AgentID:       agent.ID,
-			WorkspaceID:   workspace.ID,
-			Driver:        driverpkg.RuntimeDriverDocker,
-			GuestImage:    "guest:latest",
-			DefaultAgent:  "codex",
-			SandboxPolicy: domain.LoaderSandboxPolicySticky,
+			ID:                "legacy-loader-source",
+			Name:              "资讯推送任务",
+			Description:       "每小时检查并推送资讯",
+			Enabled:           false,
+			Runtime:           domain.LoaderRuntimeScheduler,
+			AgentID:           agent.ID,
+			WorkspaceID:       workspace.ID,
+			Driver:            driverpkg.RuntimeDriverDocker,
+			GuestImage:        "guest:latest",
+			DefaultAgent:      "codex",
+			SandboxPolicy:     domain.LoaderSandboxPolicySticky,
+			ConcurrencyPolicy: domain.LoaderConcurrencyPolicySkip,
 		},
 		Script: script,
 	})
@@ -225,6 +226,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	editedSpec.Agents = append([]compose.NormalizedAgentSpec(nil), repeated.RevisionSpec.Agents...)
 	editedScheduler := *editedSpec.Agents[0].Scheduler
 	editedScheduler.Description = "Edited through v2 project apply"
+	editedScheduler.ConcurrencyPolicy = domain.LoaderConcurrencyPolicyParallel
 	editedSpec.Agents[0].Scheduler = &editedScheduler
 	editedHash, err := editedSpec.Hash()
 	if err != nil {
@@ -239,8 +241,73 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 		t.Fatalf("edited scheduler lost adopted loader identity: %#v, err = %v", page, err)
 	}
 	editedLoader, err := store.GetLoader(ctx, loader.Summary.ID)
-	if err != nil || editedLoader.Summary.Description != editedScheduler.Description {
+	if err != nil || editedLoader.Summary.Description != editedScheduler.Description || editedLoader.Summary.ConcurrencyPolicy != domain.LoaderConcurrencyPolicyParallel {
 		t.Fatalf("edited adopted loader = %#v, err = %v", editedLoader.Summary, err)
+	}
+	if runs, err := store.ListLoaderRuns(ctx, loader.Summary.ID, 10); err != nil || len(runs) != 1 || runs[0].ID != "legacy-run" {
+		t.Fatalf("adopted loader runs after edit = %#v, err = %v", runs, err)
+	}
+	if events, err := store.ListLoaderEvents(ctx, loader.Summary.ID, 10); err != nil || len(events) != 1 || events[0].ID != "legacy-event" {
+		t.Fatalf("adopted loader events after edit = %#v, err = %v", events, err)
+	}
+
+	parallelProject, err := store.GetProject(ctx, projectID)
+	if err != nil {
+		t.Fatalf("load project after parallel edit: %v", err)
+	}
+	revertedSpec := editedSpec
+	revertedSpec.Agents = append([]compose.NormalizedAgentSpec(nil), editedSpec.Agents...)
+	revertedScheduler := *revertedSpec.Agents[0].Scheduler
+	revertedScheduler.ConcurrencyPolicy = domain.LoaderConcurrencyPolicySkip
+	revertedSpec.Agents[0].Scheduler = &revertedScheduler
+	revertedHash, err := revertedSpec.Hash()
+	if err != nil {
+		t.Fatalf("hash reverted synthetic project: %v", err)
+	}
+	revertedProject := projects.NormalizedProject{Spec: &revertedSpec, SpecHash: revertedHash}
+
+	dryRun, err := controller.ApplyProject(ctx, projects.ApplyRequest{Normalized: revertedProject, DryRun: true})
+	if err != nil || dryRun.Applied || len(dryRun.Issues) != 0 || len(dryRun.Schedulers) != 1 {
+		t.Fatalf("dry-run reverted synthetic project = %#v, err = %v", dryRun, err)
+	}
+	if dryRun.Schedulers[0].ManagedLoaderID != loader.Summary.ID || !strings.Contains(dryRun.Schedulers[0].SpecJSON, `"concurrency_policy":"skip"`) {
+		t.Fatalf("dry-run reverted scheduler = %#v", dryRun.Schedulers[0])
+	}
+	projectAfterDryRun, err := store.GetProject(ctx, projectID)
+	if err != nil || projectAfterDryRun.CurrentRevision != parallelProject.CurrentRevision {
+		t.Fatalf("project changed during dry-run = %#v, err = %v", projectAfterDryRun, err)
+	}
+	loaderAfterDryRun, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil || loaderAfterDryRun.Summary.ConcurrencyPolicy != domain.LoaderConcurrencyPolicyParallel {
+		t.Fatalf("loader changed during dry-run = %#v, err = %v", loaderAfterDryRun.Summary, err)
+	}
+
+	reverted, err := controller.ApplyProject(ctx, projects.ApplyRequest{Normalized: revertedProject})
+	if err != nil || !reverted.Applied || reverted.Unchanged || reverted.Revision.Revision != parallelProject.CurrentRevision+1 {
+		t.Fatalf("apply reverted synthetic project = %#v, err = %v", reverted, err)
+	}
+	revertedLoader, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil || revertedLoader.Summary.ConcurrencyPolicy != domain.LoaderConcurrencyPolicySkip {
+		t.Fatalf("reverted adopted loader = %#v, err = %v", revertedLoader.Summary, err)
+	}
+
+	idempotent, err := controller.ApplyProject(ctx, projects.ApplyRequest{Normalized: revertedProject})
+	if err != nil || !idempotent.Applied || !idempotent.Unchanged || idempotent.Revision.Revision != reverted.Revision.Revision {
+		t.Fatalf("repeated reverted project apply = %#v, err = %v", idempotent, err)
+	}
+	finalProject, err := store.GetProject(ctx, projectID)
+	if err != nil || finalProject.CurrentRevision != reverted.Revision.Revision {
+		t.Fatalf("repeated apply changed project revision = %#v, err = %v", finalProject, err)
+	}
+	finalPage, err := store.ListProjectSchedulersPage(ctx, "", "", 10)
+	if err != nil || len(finalPage) != 1 || finalPage[0].ManagedLoaderID != loader.Summary.ID || finalPage[0].Revision != reverted.Revision.Revision {
+		t.Fatalf("scheduler identity after repeated apply = %#v, err = %v", finalPage, err)
+	}
+	if runs, err := store.ListLoaderRuns(ctx, loader.Summary.ID, 10); err != nil || len(runs) != 1 || runs[0].ID != "legacy-run" {
+		t.Fatalf("adopted loader runs after policy round trip = %#v, err = %v", runs, err)
+	}
+	if events, err := store.ListLoaderEvents(ctx, loader.Summary.ID, 10); err != nil || len(events) != 1 || events[0].ID != "legacy-event" {
+		t.Fatalf("adopted loader events after policy round trip = %#v, err = %v", events, err)
 	}
 }
 

--- a/pkg/projects/legacy_default_project_test.go
+++ b/pkg/projects/legacy_default_project_test.go
@@ -180,7 +180,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 		t.Fatalf("project agents/overrides = %#v/%#v", project.Spec.Agents, project.managedLoaderOverrides)
 	}
 	worker := findLegacyProjectAgent(t, project, "worker")
-	if worker.Scheduler == nil || worker.Scheduler.Enabled || worker.Scheduler.Script != loaders[1].Script || worker.Scheduler.DisplayName != "First task" || worker.Scheduler.Description != "First task description" {
+	if worker.Scheduler == nil || worker.Scheduler.Enabled || worker.Scheduler.Script != loaders[1].Script || worker.Scheduler.DisplayName != "First task" || worker.Scheduler.Description != "First task description" || worker.Scheduler.ConcurrencyPolicy != domain.LoaderConcurrencyPolicySkip {
 		t.Fatalf("worker scheduler = %#v", worker.Scheduler)
 	}
 	workerLoader := project.managedLoaderOverrides["worker"]
@@ -192,7 +192,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 	for _, agent := range project.Spec.Agents {
 		if strings.HasPrefix(agent.Name, "worker-loader-") {
 			clonedName = agent.Name
-			if agent.Scheduler == nil || !agent.Scheduler.Enabled || agent.Scheduler.Script != loaders[0].Script || agent.Scheduler.DisplayName != "Second task" || agent.Scheduler.Description != "Second task description" {
+			if agent.Scheduler == nil || !agent.Scheduler.Enabled || agent.Scheduler.Script != loaders[0].Script || agent.Scheduler.DisplayName != "Second task" || agent.Scheduler.Description != "Second task description" || agent.Scheduler.ConcurrencyPolicy != domain.LoaderConcurrencyPolicyParallel {
 				t.Fatalf("cloned scheduler = %#v", agent.Scheduler)
 			}
 		}

--- a/pkg/projects/managed_loader_overrides.go
+++ b/pkg/projects/managed_loader_overrides.go
@@ -44,7 +44,6 @@ func mergeManagedLoaderOverride(current, override domain.Loader) domain.Loader {
 	loader.Summary.ID = override.Summary.ID
 	loader.Summary.AgentID = override.Summary.AgentID
 	loader.Summary.WorkspaceID = override.Summary.WorkspaceID
-	loader.Summary.ConcurrencyPolicy = override.Summary.ConcurrencyPolicy
 	loader.Summary.CreatedAt = override.Summary.CreatedAt
 	loader.Summary.UpdatedAt = override.Summary.UpdatedAt
 	loader.Summary.LastError = override.Summary.LastError

--- a/pkg/projects/records.go
+++ b/pkg/projects/records.go
@@ -201,7 +201,7 @@ func NewManagedLoaderFromScheduler(project domain.ProjectRecord, scheduler domai
 			GuestImage:         agent.Image,
 			DefaultAgent:       agent.Provider,
 			SandboxPolicy:      agent.Scheduler.SandboxPolicy,
-			ConcurrencyPolicy:  domain.LoaderConcurrencyPolicySkip,
+			ConcurrencyPolicy:  domain.NormalizeLoaderConcurrencyPolicy(agent.Scheduler.ConcurrencyPolicy),
 			CapsetIDs:          capabilities.NormalizeCapsetIDs(agent.CapsetIDs),
 			ManagedProjectID:   project.ID,
 			ManagedRevision:    scheduler.Revision,

--- a/pkg/projects/records_test.go
+++ b/pkg/projects/records_test.go
@@ -100,6 +100,46 @@ func TestProjectRecordsCarryVolumeMountSpecs(t *testing.T) {
 	}
 }
 
+func TestSchedulerConcurrencyPolicyFlowsIntoManagedLoader(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "default skip",
+			raw:  "name: default-policy\nagents:\n  reviewer:\n    scheduler:\n      triggers:\n        - interval: 1m\n",
+			want: domain.LoaderConcurrencyPolicySkip,
+		},
+		{
+			name: "parallel",
+			raw:  "name: parallel-policy\nagents:\n  reviewer:\n    scheduler:\n      concurrency_policy: parallel\n      triggers:\n        - interval: 1m\n",
+			want: domain.LoaderConcurrencyPolicyParallel,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			spec, err := compose.Parse([]byte(test.raw))
+			if err != nil {
+				t.Fatalf("Parse returned error: %v", err)
+			}
+			normalized, err := compose.Normalize(spec, compose.NormalizeOptions{})
+			if err != nil {
+				t.Fatalf("Normalize returned error: %v", err)
+			}
+			builds, err := NewSchedulerBuildsFromSpec(domain.ProjectRecord{ID: "project-1", Name: normalized.Name}, 1, normalized)
+			if err != nil {
+				t.Fatalf("NewSchedulerBuildsFromSpec returned error: %v", err)
+			}
+			if len(builds) != 1 {
+				t.Fatalf("scheduler builds = %d, want 1", len(builds))
+			}
+			if got := builds[0].Loader.Summary.ConcurrencyPolicy; got != test.want {
+				t.Fatalf("loader concurrency policy = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestDisabledAgentDisablesManagedAgentAndSchedulerRecords(t *testing.T) {
 	project := domain.ProjectRecord{ID: "project-1", Name: "project"}
 	agent := compose.NormalizedAgentSpec{

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -6062,15 +6062,16 @@ func (x *WorkspaceSpec) GetToken() string {
 }
 
 type SchedulerSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	Triggers      []*TriggerSpec         `protobuf:"bytes,2,rep,name=triggers,proto3" json:"triggers,omitempty"`
-	Script        string                 `protobuf:"bytes,3,opt,name=script,proto3" json:"script,omitempty"`
-	SandboxPolicy string                 `protobuf:"bytes,4,opt,name=sandbox_policy,json=sandboxPolicy,proto3" json:"sandbox_policy,omitempty"`
-	DisplayName   string                 `protobuf:"bytes,5,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	Description   string                 `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Enabled           bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Triggers          []*TriggerSpec         `protobuf:"bytes,2,rep,name=triggers,proto3" json:"triggers,omitempty"`
+	Script            string                 `protobuf:"bytes,3,opt,name=script,proto3" json:"script,omitempty"`
+	SandboxPolicy     string                 `protobuf:"bytes,4,opt,name=sandbox_policy,json=sandboxPolicy,proto3" json:"sandbox_policy,omitempty"`
+	DisplayName       string                 `protobuf:"bytes,5,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description       string                 `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
+	ConcurrencyPolicy string                 `protobuf:"bytes,7,opt,name=concurrency_policy,json=concurrencyPolicy,proto3" json:"concurrency_policy,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SchedulerSpec) Reset() {
@@ -6141,6 +6142,13 @@ func (x *SchedulerSpec) GetDisplayName() string {
 func (x *SchedulerSpec) GetDescription() string {
 	if x != nil {
 		return x.Description
+	}
+	return ""
+}
+
+func (x *SchedulerSpec) GetConcurrencyPolicy() string {
+	if x != nil {
+		return x.ConcurrencyPolicy
 	}
 	return ""
 }
@@ -17876,14 +17884,15 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\busername\x18\b \x01(\tR\busername\x12\x1a\n" +
 	"\bpassword\x18\t \x01(\tR\bpassword\x12\x14\n" +
 	"\x05token\x18\n" +
-	" \x01(\tR\x05token\"\xe7\x01\n" +
+	" \x01(\tR\x05token\"\x96\x02\n" +
 	"\rSchedulerSpec\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x128\n" +
 	"\btriggers\x18\x02 \x03(\v2\x1c.agentcompose.v2.TriggerSpecR\btriggers\x12\x16\n" +
 	"\x06script\x18\x03 \x01(\tR\x06script\x12%\n" +
 	"\x0esandbox_policy\x18\x04 \x01(\tR\rsandboxPolicy\x12!\n" +
 	"\fdisplay_name\x18\x05 \x01(\tR\vdisplayName\x12 \n" +
-	"\vdescription\x18\x06 \x01(\tR\vdescription\"\xf7\x01\n" +
+	"\vdescription\x18\x06 \x01(\tR\vdescription\x12-\n" +
+	"\x12concurrency_policy\x18\a \x01(\tR\x11concurrencyPolicy\"\xf7\x01\n" +
 	"\vTriggerSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x12\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -810,6 +810,7 @@ message SchedulerSpec {
   string sandbox_policy = 4;
   string display_name = 5;
   string description = 6;
+  string concurrency_policy = 7;
 }
 
 message TriggerSpec {


### PR DESCRIPTION
## Summary

- expose scheduler-level `concurrency_policy` in project YAML with `skip` as the compatibility default and `parallel` as the opt-in concurrent mode
- carry the policy through normalization, canonical output, managed loader creation, ProjectService protobuf mapping, and CLI remote project reconstruction
- keep migrated legacy loader identity, trigger runtime state, runs, and events while allowing later v2 project edits to change the declarative concurrency policy
- document the scheduler-wide scope in English and Chinese and add regression, integration, and black-box scheduler coverage

Example:

```yaml
scheduler:
  concurrency_policy: parallel
  triggers:
    - name: task-a
      cron: "0 4,10 * * *"
    - name: task-b
      cron: "0 4,10 * * *"
```

The policy is scheduler-wide because the underlying loader owns concurrency. `skip` records an overlapping run as skipped; `parallel` permits overlapping runs to execute concurrently.

Closes #378

## Testing

- `GOFLAGS=-buildvcs=false go test ./pkg/projects ./pkg/agentcompose/api -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.52%
  - Integration: 61.07%
  - E2E: 61.44%
  - Combined: 78.93%
- local `suit-scheduler` black-box suite: 78/78 passed, including default `skip` behavior and two simultaneously running callbacks under `parallel`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
