### PR TITLE
fix(microsandbox): recover exec streams after lost exits

### DIFF
--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -71,6 +71,11 @@ const (
 type microsandboxExecEventReceiver func(context.Context) (*microsandbox.ExecEvent, error)
 type microsandboxExecHandleCloser func() error
 
+type microsandboxExecReceiveResult struct {
+	event *microsandbox.ExecEvent
+	err   error
+}
+
 // microsandboxExecLivenessProbe reports whether the guest process is still
 // present. A nil probe, or a probe that cannot answer, leaves the stream
 // waiting: only a definite "the process is gone" is allowed to end it.
@@ -88,7 +93,39 @@ func consumeMicrosandboxExecStream(
 	exitCode := 0
 	sawExit := false
 	var pid uint32
-	var idleDeadline time.Time
+	receiveCtx, cancelReceive := context.WithCancel(ctx)
+	received := receiveMicrosandboxExecEvents(receiveCtx, recv)
+	stopReceiving := func() {
+		cancelReceive()
+		for range received {
+		}
+	}
+	defer stopReceiving()
+
+	var waitTimer *time.Timer
+	var wait <-chan time.Time
+	stopWaitTimer := func() {
+		if waitTimer == nil {
+			return
+		}
+		if !waitTimer.Stop() {
+			select {
+			case <-waitTimer.C:
+			default:
+			}
+		}
+		wait = nil
+	}
+	defer stopWaitTimer()
+	resetWaitTimer := func(duration time.Duration) {
+		stopWaitTimer()
+		if waitTimer == nil {
+			waitTimer = time.NewTimer(duration)
+		} else {
+			waitTimer.Reset(duration)
+		}
+		wait = waitTimer.C
+	}
 
 	closeAfterDrainTimeout := func() {
 		slog.Warn(
@@ -101,93 +138,115 @@ func consumeMicrosandboxExecStream(
 		}
 	}
 
-	silenceProbeArmed := probeAlive != nil && silenceInterval > 0
-
 	for {
-		recvCtx := ctx
-		var recvCancel context.CancelFunc
-		if sawExit {
-			remaining := time.Until(idleDeadline)
-			if remaining <= 0 {
+		select {
+		case <-ctx.Done():
+			collector.finish()
+			return ExecResult{}, ctx.Err()
+		case <-wait:
+			if sawExit {
+				stopReceiving()
 				closeAfterDrainTimeout()
-				break
+				return microsandboxExecResult(collector, exitCode, exitCode == 0), nil
 			}
-			recvCtx, recvCancel = context.WithTimeout(ctx, remaining)
-		} else if silenceProbeArmed && pid != 0 {
-			recvCtx, recvCancel = context.WithTimeout(ctx, silenceInterval)
-		}
-
-		event, err := recv(recvCtx)
-		if recvCancel != nil {
-			recvCancel()
-		}
-		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
-				if sawExit {
-					closeAfterDrainTimeout()
-					break
-				}
-				gone, probeErr := microsandboxExecProcessGone(ctx, probeAlive, pid)
-				if probeErr != nil {
-					slog.Warn("failed to probe microsandbox exec process liveness; continuing to wait", "pid", pid, "error", probeErr)
-					continue
-				}
-				if !gone {
-					continue
-				}
-				slog.Warn(
-					"microsandbox exec process is gone but the stream never reported its exit; closing handle",
-					"pid", pid,
-					"silence_window", silenceInterval,
-				)
-				if closeErr := closeHandle(); closeErr != nil {
-					slog.Warn("failed to close microsandbox exec handle after a lost exit", "error", closeErr)
-				}
+			gone, probeErr := microsandboxExecProcessGone(ctx, probeAlive, pid)
+			if probeErr != nil {
+				slog.Warn("failed to probe microsandbox exec process liveness; continuing to wait", "pid", pid, "error", probeErr)
+				resetWaitTimer(silenceInterval)
+				continue
+			}
+			if !gone {
+				resetWaitTimer(silenceInterval)
+				continue
+			}
+			slog.Warn(
+				"microsandbox exec process is gone but the stream never reported its exit; closing handle",
+				"pid", pid,
+				"silence_window", silenceInterval,
+			)
+			stopReceiving()
+			if closeErr := closeHandle(); closeErr != nil {
+				slog.Warn("failed to close microsandbox exec handle after a lost exit", "error", closeErr)
+			}
+			collector.finish()
+			return microsandboxExecResult(collector, -1, false), fmt.Errorf("microsandbox exec process %d exited without reporting its status; a process it started is still holding the output pipes open", pid)
+		case result, ok := <-received:
+			if !ok {
 				collector.finish()
-				return microsandboxExecResult(collector, -1, false), fmt.Errorf("microsandbox exec process %d exited without reporting its status; a process it started is still holding the output pipes open", pid)
+				if !sawExit {
+					return microsandboxExecResult(collector, -1, false), fmt.Errorf("microsandbox exec stream ended without reporting a process exit status")
+				}
+				return microsandboxExecResult(collector, exitCode, exitCode == 0), nil
 			}
-			collector.finish()
-			return ExecResult{}, err
-		}
-		if event == nil || event.Kind == microsandbox.ExecEventDone {
-			break
-		}
+			if result.err != nil {
+				collector.finish()
+				return ExecResult{}, result.err
+			}
+			event := result.event
+			if event == nil || event.Kind == microsandbox.ExecEventDone {
+				collector.finish()
+				if !sawExit {
+					return microsandboxExecResult(collector, -1, false), fmt.Errorf("microsandbox exec stream ended without reporting a process exit status")
+				}
+				return microsandboxExecResult(collector, exitCode, exitCode == 0), nil
+			}
 
-		switch event.Kind {
-		case microsandbox.ExecEventStarted:
-			pid = event.PID
-		case microsandbox.ExecEventStdout:
-			collector.writeChunk(ExecChunk{Text: string(event.Data)})
-			if sawExit {
-				idleDeadline = time.Now().Add(idleGrace)
+			switch event.Kind {
+			case microsandbox.ExecEventStarted:
+				pid = event.PID
+				if probeAlive != nil && silenceInterval > 0 && pid != 0 {
+					resetWaitTimer(silenceInterval)
+				}
+			case microsandbox.ExecEventStdout:
+				collector.writeChunk(ExecChunk{Text: string(event.Data)})
+				if sawExit {
+					resetWaitTimer(idleGrace)
+				} else if probeAlive != nil && silenceInterval > 0 && pid != 0 {
+					resetWaitTimer(silenceInterval)
+				}
+			case microsandbox.ExecEventStderr:
+				collector.writeChunk(ExecChunk{Text: string(event.Data), Stream: StdioStderr})
+				if sawExit {
+					resetWaitTimer(idleGrace)
+				} else if probeAlive != nil && silenceInterval > 0 && pid != 0 {
+					resetWaitTimer(silenceInterval)
+				}
+			case microsandbox.ExecEventExited:
+				exitCode = event.ExitCode
+				sawExit = true
+				resetWaitTimer(idleGrace)
+			case microsandbox.ExecEventFailed:
+				collector.finish()
+				return ExecResult{}, formatMicrosandboxExecFailure(event.Failure)
+			case microsandbox.ExecEventStdinError:
+				collector.writeChunk(ExecChunk{Text: formatMicrosandboxExecFailure(event.Failure).Error() + "\n", Stream: StdioStderr})
 			}
-		case microsandbox.ExecEventStderr:
-			collector.writeChunk(ExecChunk{Text: string(event.Data), Stream: StdioStderr})
-			if sawExit {
-				idleDeadline = time.Now().Add(idleGrace)
-			}
-		case microsandbox.ExecEventExited:
-			exitCode = event.ExitCode
-			sawExit = true
-			idleDeadline = time.Now().Add(idleGrace)
-		case microsandbox.ExecEventFailed:
-			collector.finish()
-			return ExecResult{}, formatMicrosandboxExecFailure(event.Failure)
-		case microsandbox.ExecEventStdinError:
-			collector.writeChunk(ExecChunk{Text: formatMicrosandboxExecFailure(event.Failure).Error() + "\n", Stream: StdioStderr})
 		}
 	}
+}
 
-	collector.finish()
-	if !sawExit {
-		// The stream ended without ever carrying an exit status. Reporting exit
-		// code 0 here would turn a lost status into a success whose output is
-		// silently short, which reads downstream as a command that ran fine but
-		// printed no result.
-		return microsandboxExecResult(collector, -1, false), fmt.Errorf("microsandbox exec stream ended without reporting a process exit status")
-	}
-
-	return microsandboxExecResult(collector, exitCode, exitCode == 0), nil
+func receiveMicrosandboxExecEvents(ctx context.Context, recv microsandboxExecEventReceiver) <-chan microsandboxExecReceiveResult {
+	received := make(chan microsandboxExecReceiveResult, 1)
+	go func() {
+		defer close(received)
+		for {
+			// ExecHandle is not safe for concurrent use. More importantly, the
+			// SDK documents that canceling Recv only releases the Go caller while
+			// the Rust receive continues in the background. Keep exactly one Recv
+			// loop for the lifetime of the stream; silence timers must never use
+			// Recv cancellation as their clock.
+			event, err := recv(ctx)
+			select {
+			case received <- microsandboxExecReceiveResult{event: event, err: err}:
+			case <-ctx.Done():
+				return
+			}
+			if err != nil || event == nil || event.Kind == microsandbox.ExecEventDone {
+				return
+			}
+		}
+	}()
+	return received
 }
 
 func microsandboxExecResult(collector *microsandboxExecCollector, exitCode int, success bool) ExecResult {
@@ -208,12 +267,21 @@ func microsandboxExecLivenessProbeFor(sandbox *microsandbox.Sandbox) microsandbo
 		return nil
 	}
 	return func(ctx context.Context, pid uint32) (bool, error) {
-		output, err := sandbox.Exec(ctx, "sh", []string{"-c", fmt.Sprintf("kill -0 %d 2>/dev/null", pid)})
+		output, err := sandbox.Exec(ctx, "sh", []string{"-c", microsandboxExecLivenessProbeCommand(pid)})
 		if err != nil {
 			return false, err
 		}
 		return output.ExitCode() == 0, nil
 	}
+}
+
+func microsandboxExecLivenessProbeCommand(pid uint32) string {
+	return fmt.Sprintf(
+		"kill -0 %[1]d 2>/dev/null || exit 1; "+
+			"stat=$(cat /proc/%[1]d/stat 2>/dev/null) || exit 0; "+
+			"rest=${stat##*) }; state=${rest%%%% *}; [ \"$state\" != Z ]",
+		pid,
+	)
 }
 
 // microsandboxExecProcessGone answers only when it is sure. A probe that fails

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -144,21 +146,74 @@ func TestMicrosandboxExecStreamStopsWhenProcessIsGoneWithoutExit(t *testing.T) {
 // is how a real stream behaves. A receiver that keeps re-delivering the same
 // event instead would hold the drain window open forever.
 type scriptedExecStream struct {
-	pending []*microsandbox.ExecEvent
+	mu       sync.Mutex
+	pending  []*microsandbox.ExecEvent
+	ready    chan struct{}
+	active   int
+	max      int
+	canceled int
 }
 
 func (s *scriptedExecStream) push(event *microsandbox.ExecEvent) {
+	s.mu.Lock()
 	s.pending = append(s.pending, event)
+	if s.ready == nil {
+		s.ready = make(chan struct{}, 1)
+	}
+	s.mu.Unlock()
+	select {
+	case s.ready <- struct{}{}:
+	default:
+	}
 }
 
 func (s *scriptedExecStream) recv(ctx context.Context) (*microsandbox.ExecEvent, error) {
-	if len(s.pending) > 0 {
-		event := s.pending[0]
-		s.pending = s.pending[1:]
-		return event, nil
+	s.mu.Lock()
+	if s.ready == nil {
+		s.ready = make(chan struct{}, 1)
 	}
-	<-ctx.Done()
-	return nil, ctx.Err()
+	s.active++
+	if s.active > s.max {
+		s.max = s.active
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.active--
+		s.mu.Unlock()
+	}()
+
+	for {
+		s.mu.Lock()
+		if len(s.pending) > 0 {
+			event := s.pending[0]
+			s.pending = s.pending[1:]
+			s.mu.Unlock()
+			return event, nil
+		}
+		ready := s.ready
+		s.mu.Unlock()
+		select {
+		case <-ready:
+		case <-ctx.Done():
+			s.mu.Lock()
+			s.canceled++
+			s.mu.Unlock()
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (s *scriptedExecStream) maxConcurrentReceivers() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.max
+}
+
+func (s *scriptedExecStream) canceledReceivers() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.canceled
 }
 
 // Silence on its own means nothing: a command can be quiet for a long time.
@@ -188,6 +243,12 @@ func TestMicrosandboxExecStreamKeepsWaitingWhileProcessLives(t *testing.T) {
 	}
 	if !result.Success || result.ExitCode != 0 {
 		t.Fatalf("result = %#v, want the reported exit to win", result)
+	}
+	if got := stream.maxConcurrentReceivers(); got != 1 {
+		t.Fatalf("concurrent receivers = %d, want exactly one", got)
+	}
+	if got := stream.canceledReceivers(); got != 1 {
+		t.Fatalf("canceled receivers = %d, want only the terminal drain cancellation", got)
 	}
 }
 
@@ -244,6 +305,32 @@ func TestMicrosandboxExecStreamRejectsDoneWithoutExit(t *testing.T) {
 	}
 	if result.Output != "partial" {
 		t.Fatalf("output = %q", result.Output)
+	}
+}
+
+func TestMicrosandboxExecLivenessProbeTreatsZombieAsGone(t *testing.T) {
+	if err := exec.Command("sh", "-c", microsandboxExecLivenessProbeCommand(uint32(os.Getpid()))).Run(); err != nil {
+		t.Fatalf("probe reported current process gone: %v", err)
+	}
+	if err := exec.Command("sh", "-c", microsandboxExecLivenessProbeCommand(^uint32(0))).Run(); err == nil {
+		t.Fatal("probe reported nonexistent process alive")
+	}
+
+	child := exec.Command("sh", "-c", "exit 0")
+	if err := child.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	t.Cleanup(func() { _ = child.Wait() })
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err := exec.Command("sh", "-c", microsandboxExecLivenessProbeCommand(uint32(child.Process.Pid))).Run()
+		if err != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("probe still reported exited child %d alive", child.Process.Pid)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/pkg/driver/runtime_mount_manifest_microsandbox_smoke_test.go
+++ b/pkg/driver/runtime_mount_manifest_microsandbox_smoke_test.go
@@ -4,11 +4,47 @@ package driver
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
 )
+
+func TestSmokeMicrosandboxExecStreamRecoversLostExitAfterLiveSilenceProbe(t *testing.T) {
+	runtimeSmokeEnabled(t, RuntimeDriverMicrosandbox)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	config := newRuntimeSmokeConfig(t, RuntimeDriverMicrosandbox)
+	session, vmState, proxyState := newRuntimeSmokeSandbox(t, ctx, config, RuntimeDriverMicrosandbox)
+	runtime := &microsandboxRuntime{config: config, lifecycleHandles: map[string]*microsandbox.Sandbox{}}
+	info, err := runtime.EnsureSandbox(ctx, session, vmState, proxyState)
+	if err != nil {
+		t.Fatalf("EnsureSandbox returned error: %v", err)
+	}
+	vmState.BoxID = info.BoxID
+	cleanupRuntimeSmokeSandbox(t, config, runtime, session, vmState)
+
+	execCtx, execCancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer execCancel()
+	startedAt := time.Now()
+	result, err := runtime.ExecStream(execCtx, session, vmState, ExecSpec{
+		Command: "sh",
+		Args:    []string{"-lc", "sleep 125; echo foreground-done; sleep 600 & exit 7"},
+		Cwd:     "/",
+	}, func(ExecChunk) {})
+	elapsed := time.Since(startedAt)
+	if err == nil || !strings.Contains(err.Error(), "exited without reporting its status") {
+		t.Fatalf("ExecStream result=%#v error=%v elapsed=%s, want a bounded lost-exit error", result, err, elapsed)
+	}
+	if !strings.Contains(result.Stdout, "foreground-done") {
+		t.Fatalf("ExecStream stdout=%q, want foreground output preserved", result.Stdout)
+	}
+	if elapsed < 4*time.Minute || elapsed >= 6*time.Minute {
+		t.Fatalf("ExecStream elapsed=%s, want recovery after the live and gone silence probes", elapsed)
+	}
+}
 
 func TestSmokeMicrosandboxStopResumePreservesWritableLayer(t *testing.T) {
 	runtimeSmokeEnabled(t, RuntimeDriverMicrosandbox)


### PR DESCRIPTION
## Summary

- keep exactly one Microsandbox exec receiver active while silence probes run, matching the SDK cancellation and concurrency contract
- stop and drain the receiver before closing an exec handle on terminal paths
- classify zombie guest processes as exited while preserving conservative behavior when process state cannot be read
- add regression coverage for receiver lifecycle, zombie detection, and the real lost-exit sequence

The failure required two conditions. A silence timeout previously canceled `Recv`, although the SDK documents that the underlying receive may continue in the background; a later `Recv` could then race for the exit event. Separately, `kill -0` reports a zombie PID as present, so a process that had exited but had not been reaped was treated as alive indefinitely.

## Testing

- `go test ./pkg/driver -count=1`
- `go test -race ./pkg/driver -count=1`
- `go vet ./pkg/driver`
- `task lint`
- `task build`
- `task test`
- Linux/amd64 race run with the `microsandboxcgo` build tag covering the exec-stream and zombie-probe tests
- Real KVM Microsandbox smoke regression:
  - kept the foreground command silent for 125 seconds so the first two-minute probe observed a live PID
  - then exited the foreground shell while a background process retained its output pipes
  - verified the second probe classified the unreaped zombie as exited and closed the stream with a bounded lost-exit error
  - completed successfully in 392.91 seconds including first-time base-disk preparation; the exec recovery itself completed after the expected two probe windows

## Checklist

- [x] Documentation is not required because no public API or configuration changed.
- [x] Tests added for receiver lifecycle, zombie detection, and real KVM behavior.
- [x] No secrets, private endpoints, certificates, or local runtime state included.