### PR TITLE
fix(cli): make project name a deployed project filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ See the [command line manual](docs/pages/command-line-manual.md) for the full fi
 | `agent-compose down` | Disable managed schedulers and stop sandboxes. |
 | `agent-compose status` | Check daemon status. |
 
-Useful global flags: `--file, -f` (choose a compose file), `--project-name`,
+Useful global flags: `--file, -f` (choose a compose file), `--project-name` (select a deployed project by name),
 `--json` (stable JSON for scripts), `--host` / `AGENT_COMPOSE_HOST` (connect to a
 TCP daemon), and `AGENT_COMPOSE_SOCKET` (Unix socket path). Full reference:
 [docs/pages/command-line-manual.md](docs/pages/command-line-manual.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,7 +167,7 @@ agents:
 | `agent-compose down` | 禁用受管 scheduler 并停止 sandbox。 |
 | `agent-compose status` | 查看 daemon 状态。 |
 
-常用全局参数：`--file, -f`（指定 compose 文件）、`--project-name`、`--json`
+常用全局参数：`--file, -f`（指定 compose 文件）、`--project-name`（按名称选择已部署项目）、`--json`
 （脚本用的稳定 JSON 输出）、`--host` / `AGENT_COMPOSE_HOST`（连接 TCP daemon）、
 `AGENT_COMPOSE_SOCKET`（Unix socket 路径）。完整参考见[命令行使用手册](docs/pages/zh-CN/command-line-manual.md)。
 

--- a/cmd/agent-compose/cli_compose_config.go
+++ b/cmd/agent-compose/cli_compose_config.go
@@ -27,9 +27,6 @@ func loadNormalizedComposeWithOptions(ctx context.Context, cli cliOptions, resol
 	if err != nil {
 		return "", nil, commandExitError{Code: exitCodeUsage, Err: err}
 	}
-	if projectName := strings.TrimSpace(cli.ProjectName); projectName != "" {
-		spec.Name = projectName
-	}
 	projectEnv, err := resolveCLIProjectEnv(spec, composePath)
 	if err != nil {
 		return "", nil, commandExitError{Code: exitCodeUsage, Err: err}

--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestConfigCommandUsesGlobalFileProjectNameAndJSON(t *testing.T) {
+func TestConfigCommandProjectNameDoesNotOverrideComposeName(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "file-project")
 	composePath := writeComposeFile(t, dir, `
 name: original-project
@@ -45,8 +45,8 @@ agents:
 	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
 		t.Fatalf("config global JSON output is not JSON: %v\n%s", err, stdout)
 	}
-	if decoded.Name != "override-project" {
-		t.Fatalf("config project name = %q, want override-project", decoded.Name)
+	if decoded.Name != "original-project" {
+		t.Fatalf("config project name = %q, want original-project", decoded.Name)
 	}
 }
 

--- a/cmd/agent-compose/cli_ps_project_test.go
+++ b/cmd/agent-compose/cli_ps_project_test.go
@@ -60,21 +60,24 @@ func TestResolveComposeRuntimeProjectRefMatchesComposeSelectionSemantics(t *test
 		}
 	})
 
-	t.Run("explicit missing file does not fall back", func(t *testing.T) {
+	t.Run("project name bypasses explicit missing file", func(t *testing.T) {
 		missing := filepath.Join(t.TempDir(), "missing.yml")
-		_, _, _, err := resolveComposeRuntimeProjectRef(cliOptions{ComposeFile: missing, ProjectName: "stored-project"})
-		if err == nil || !strings.Contains(err.Error(), "no such file") {
-			t.Fatalf("resolve explicit missing file error = %v", err)
+		composePath, projectName, ref, err := resolveComposeRuntimeProjectRef(cliOptions{ComposeFile: missing, ProjectName: "stored-project"})
+		if err != nil {
+			t.Fatalf("resolve runtime project ref: %v", err)
+		}
+		if composePath != "" || projectName != "stored-project" || ref.GetProjectId() != "" || ref.GetName() != "stored-project" {
+			t.Fatalf("compose path/name/ref = %q / %q / %#v", composePath, projectName, ref)
 		}
 	})
 
-	t.Run("explicit file and project name derive exact id", func(t *testing.T) {
+	t.Run("project name filters instead of overriding explicit file", func(t *testing.T) {
 		composePath := writeComposeFile(t, t.TempDir(), "name: original\nagents: {}\n")
 		resolvedPath, projectName, ref, err := resolveComposeRuntimeProjectRef(cliOptions{ComposeFile: composePath, ProjectName: "override"})
 		if err != nil {
 			t.Fatalf("resolve runtime project ref: %v", err)
 		}
-		if resolvedPath != composePath || projectName != "override" || ref.GetProjectId() == "" || ref.GetName() != "" {
+		if resolvedPath != "" || projectName != "override" || ref.GetProjectId() != "" || ref.GetName() != "override" {
 			t.Fatalf("compose path/name/ref = %q / %q / %#v", resolvedPath, projectName, ref)
 		}
 	})

--- a/cmd/agent-compose/cli_root.go
+++ b/cmd/agent-compose/cli_root.go
@@ -53,7 +53,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 
 	root.PersistentFlags().StringVar(&options.Host, "host", "", "Daemon HTTP endpoint")
 	root.PersistentFlags().StringVarP(&options.ComposeFile, "file", "f", "", "Path to agent-compose.yml")
-	root.PersistentFlags().StringVar(&options.ProjectName, "project-name", "", "Set compose project name or select a deployed project")
+	root.PersistentFlags().StringVar(&options.ProjectName, "project-name", "", "Select a deployed project by name")
 	root.PersistentFlags().BoolVar(&options.JSON, "json", false, "Print machine-readable JSON")
 
 	commands := []*cobra.Command{

--- a/cmd/agent-compose/cli_runtime_project.go
+++ b/cmd/agent-compose/cli_runtime_project.go
@@ -39,10 +39,9 @@ func (p composeRuntimeProject) name() string {
 	return strings.TrimSpace(p.project.GetSummary().GetName())
 }
 
-// resolveComposeRuntimeProject follows Docker Compose's project-or-name
-// behavior: an explicit project name selects an already-applied project unless
-// an explicit compose file was also supplied. Without either flag, the default
-// compose file continues to identify the project.
+// resolveComposeRuntimeProject resolves an explicit project name as an
+// already-applied project filter. Without one, the compose file identifies the
+// project.
 func resolveComposeRuntimeProject(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, cli cliOptions, command string, loadMode composeRuntimeProjectLoadMode) (composeRuntimeProject, error) {
 	selection, err := resolveComposeRuntimeProjectSelectionForCLI(cli)
 	if err != nil {
@@ -87,7 +86,7 @@ func resolveComposeRuntimeProjectRef(cli cliOptions) (string, string, *agentcomp
 
 func resolveComposeRuntimeProjectSelectionForCLI(cli cliOptions) (composeRuntimeProjectSelection, error) {
 	projectName := strings.TrimSpace(cli.ProjectName)
-	if strings.TrimSpace(cli.ComposeFile) == "" && projectName != "" {
+	if projectName != "" {
 		return composeRuntimeProjectSelection{requestedName: projectName, ref: &agentcomposev2.ProjectRef{Name: projectName}}, nil
 	}
 	composePath, normalized, projectID, err := resolveComposeProject(cli)

--- a/cmd/agent-compose/cli_runtime_project_test.go
+++ b/cmd/agent-compose/cli_runtime_project_test.go
@@ -70,7 +70,7 @@ func TestIntegrationCLIRuntimeCommandsSelectStoredProjectByName(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "down", args: []string{"down"}, want: "stored-project"},
+		{name: "down with ignored compose file", args: []string{"down", "--file", "missing.yml"}, want: "stored-project"},
 		{name: "run", args: []string{"run", "-d", "worker", "--command", "true"}, want: "run-stored"},
 		{name: "scheduler list", args: []string{"scheduler", "ls"}, want: "manual"},
 		{name: "logs", args: []string{"logs"}},

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -137,7 +137,7 @@ func testCLIConfigAndOutputWorkflow(t *testing.T) {
 	TestConfigCommandQuietOnlyValidates(t)
 	TestConfigCommandQuietRejectsRemovedNetworkField(t)
 	TestConfigCommandMissingComposeFileWritesStderrAndExitCode(t)
-	TestConfigCommandUsesGlobalFileProjectNameAndJSON(t)
+	TestConfigCommandProjectNameDoesNotOverrideComposeName(t)
 	TestCLIClientConfigPriority(t)
 	TestCLIClientConfigRejectsInvalidHost(t)
 	TestStatusCommandUsesHostFlagBeforeEnvironment(t)

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -186,7 +186,7 @@ SECRET_VALUE:
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
-| `name` | string | Conditionally | Project identifier. If omitted, the compose directory name is used; the final value must be a stable identifier. CLI `--project-name` overrides it. |
+| `name` | string | Conditionally | Project identifier. If omitted, the compose directory name is used; the final value must be a stable identifier. |
 | `env_file` | string or string[] | No | Dotenv files used for interpolation. Relative paths are resolved from the compose directory. |
 | `variables` | map | No | Project-level named values and secret metadata stored in the normalized project specification. |
 | `workspaces` | map | No | Reusable project workspace definitions. Only the plural top-level form is valid. |

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -21,7 +21,7 @@ Global options are placed between `agent-compose` and the subcommand, and apply 
 | --- | --- |
 | `-f, --file <path>` | Path to the project config file. Both `agent-compose.yml` and `agent-compose.yaml` are supported. When this option is used, the project root is the config file directory, so you do not need to `cd` into it. |
 | `--host <endpoint>` | Daemon HTTP endpoint. This can target a local daemon or a remote daemon. |
-| `--project-name <name>` | Set the compose project name. Without `--file`, deployed-project commands use it to select an existing daemon project without reading a config file. With `--file`, it overrides the name declared by that file. |
+| `--project-name <name>` | Select an existing daemon project by name. It never changes the project name declared by a compose file. |
 | `--json` | Print machine-readable JSON for scripts, AI agents, and automation. |
 
 Examples:
@@ -35,8 +35,8 @@ agent-compose --host http://10.0.0.12:7410 ls --json
 Rules:
 
 - Without `-f` or `--project-name`, project-scoped commands look for `agent-compose.yml` or `agent-compose.yaml` in the current directory.
-- With `--project-name` and no `-f`, deployed-project commands select that daemon project directly and do not read default compose files from the current directory.
-- With both `-f` and `--project-name`, the file supplies the project definition and source path while `--project-name` overrides its declared name.
+- With `--project-name`, deployed-project commands select that daemon project directly and do not read a compose file, even when `-f` is also present.
+- Local authoring commands such as `config` and `up` always use the project name declared by the compose file (or derived from its directory); `--project-name` never overrides it.
 - With `-f`, the CLI can operate on a project from any working directory.
 - `--host` only selects the daemon. Sandboxes run in the daemon environment.
 - Automation should use `--json` and avoid parsing human-readable tables.
@@ -275,7 +275,7 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 
 List sandboxes in the current project. By default, only running sandboxes are shown. With `--all`, the command includes all statuses while remaining scoped to the current project.
 The project must already exist on the daemon; after `agent-compose down`, run `agent-compose up` again before using `ps`.
-Use `--project-name <name>` without `--file` to select an existing daemon project. Default compose files in the current directory are not read in this mode. An explicit missing `--file` remains an error.
+Use `--project-name <name>` to select an existing daemon project. Compose files are not read for deployed-project selection, including when `--file` is also present. Local authoring commands still require a compose file and never use `--project-name` to change its project name.
 
 ```bash
 agent-compose ps

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -185,7 +185,7 @@ SECRET_VALUE:
 
 | 字段 | 类型 | 必填 | 作用 |
 | --- | --- | --- | --- |
-| `name` | string | 条件必填 | 项目标识。省略时尝试使用配置文件所在目录名；最终必须符合稳定标识符格式。也可由 CLI `--project-name` 覆盖。 |
+| `name` | string | 条件必填 | 项目标识。省略时尝试使用配置文件所在目录名；最终必须符合稳定标识符格式。 |
 | `env_file` | string 或 string[] | 否 | 指定插值使用的 dotenv 文件。相对路径以配置文件目录为基准。 |
 | `variables` | map | 否 | 项目级命名变量及 secret 元数据，写入规范化项目配置。它们不会自动继承到 Agent 的 `env`，也不会成为其他 `${NAME}` 的变量来源。 |
 | `workspaces` | map | 否 | 可复用的项目级 Workspace 定义。只能使用复数形式。 |

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -21,7 +21,7 @@ agent-compose [global options] <command> [command options] [arguments]
 | --- | --- |
 | `-f, --file <path>` | 指定 project 配置文件。支持 `agent-compose.yml` 和 `agent-compose.yaml`。使用该参数后，可以在任意目录操作该 project，project root 为配置文件所在目录。 |
 | `--host <endpoint>` | 指定 daemon 地址。可以连接本机 daemon，也可以连接远程 daemon。 |
-| `--project-name <name>` | 设置 compose project 名称。未指定 `--file` 时，已部署项目命令用它直接选择 daemon 中的 project，不读取配置文件；与 `--file` 同时使用时，它覆盖文件中声明的名称。 |
+| `--project-name <name>` | 按名称选择 daemon 中已部署的 project；它不会修改 compose 文件声明的项目名称。 |
 | `--json` | 使用 JSON 输出，供脚本、AI 和自动化系统解析。 |
 
 示例：
@@ -35,8 +35,8 @@ agent-compose --host http://10.0.0.12:7410 ls --json
 使用规则：
 
 - 未指定 `-f` 和 `--project-name` 时，project 范围的命令在当前目录查找 `agent-compose.yml` 或 `agent-compose.yaml`。
-- 指定 `--project-name` 且未指定 `-f` 时，已部署项目命令直接选择 daemon project，不读取当前目录的默认 compose 文件。
-- 同时指定 `-f` 和 `--project-name` 时，文件提供 project 定义和 source path，`--project-name` 覆盖文件中声明的名称。
+- 指定 `--project-name` 时，已部署项目命令直接选择 daemon project，不读取 compose 文件；即使同时指定 `-f` 也是如此。
+- `config`、`up` 等本地编排命令始终使用 compose 文件声明的项目名称（或根据其目录推导），`--project-name` 不会覆盖该名称。
 - 使用 `-f` 时，不需要切换到 project root。
 - `--host` 只决定 CLI 连接哪个 daemon；sandbox 实际运行在 daemon 所在环境中。
 - daemon 不再消费浏览器登录用的 `AUTH_*` / `OAUTH_*` 配置；UI 浏览器认证由 agent-compose-ui server 处理。
@@ -275,7 +275,7 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 
 查看当前 project 下的 sandbox。默认只显示运行中的 sandbox。使用 `--all` 时仍限定当前 project，但会包含所有状态。
 该 project 必须已经存在于 daemon 中；执行 `agent-compose down` 后，需要先重新执行 `agent-compose up`，再使用 `ps`。
-不带 `--file` 使用 `--project-name <name>` 时，会直接选择 daemon 中已有的 project，且不会读取当前目录的默认 compose 文件；显式指定但不存在的 `--file` 仍会报错。
+使用 `--project-name <name>` 时，会直接选择 daemon 中已有的 project；即使同时指定 `--file`，已部署项目选择也不会读取 compose 文件。本地编排命令仍要求 compose 文件，且绝不会用 `--project-name` 修改其中的项目名称。
 
 ```bash
 agent-compose ps


### PR DESCRIPTION
Closes #405  
## Summary

  - Remove the behavior where `--project-name` overrides the project name declared in a local compose file.
  - Use `--project-name` exclusively to select an already deployed daemon project by name.
  - Make deployed-project commands prefer `--project-name` selection even when `--file` is also provided.
  - Update CLI help, English and Chinese documentation, and regression tests for the clarified semantics.

  ## Testing

  - `go test ./cmd/agent-compose`
  - `task docs:build`
  - `task lint`
  - `task build`
  - `task test`
  - `git diff --check`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.