### PR TITLE
feat(sandboxes): prepare agent environment before first start

### DIFF
--- a/pkg/agentcompose/adapters/agent_executor.go
+++ b/pkg/agentcompose/adapters/agent_executor.go
@@ -29,6 +29,20 @@ func NewAgentExecutor(config *appconfig.Config, store *sessionstore.Store, strea
 	return &AgentExecutor{config: config, store: store, streams: streams, runner: runner}
 }
 
+func (e *AgentExecutor) PrepareSandboxAgentEnvironment(ctx context.Context, session *domain.Sandbox, agent execution.AgentConfig, definition *domain.AgentDefinition) error {
+	if e == nil || e.runner == nil {
+		return fmt.Errorf("agent runner is required")
+	}
+	return e.runner.PrepareSandboxAgentEnvironment(ctx, session, agent, definition)
+}
+
+func (e *AgentExecutor) PrepareSandboxAgentEnvironmentFromTags(ctx context.Context, session *domain.Sandbox) error {
+	if e == nil || e.runner == nil {
+		return fmt.Errorf("agent runner is required")
+	}
+	return e.runner.PrepareSandboxAgentEnvironmentFromTags(ctx, session)
+}
+
 func (e *AgentExecutor) ExecuteAgentRequest(ctx context.Context, session *domain.Sandbox, request execution.ExecuteAgentRequest) (domain.NotebookCell, domain.SandboxEvent, domain.SandboxEvent, error) {
 	agent := domain.NormalizeAgentKind(request.Agent)
 	if agent == "" {

--- a/pkg/agentcompose/adapters/agent_runner.go
+++ b/pkg/agentcompose/adapters/agent_runner.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"agent-compose/pkg/compose"
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/execution"
 	"agent-compose/pkg/llms"
@@ -76,33 +77,19 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 		slog.Warn("resolve agent definition failed", "agent_id", strings.TrimSpace(agentDefinitionID), "error", err)
 		agentDef = nil
 	}
-	systemPrompt := ""
 	effectiveModel := strings.TrimSpace(model)
 	if agentDef != nil {
-		systemPrompt = strings.TrimSpace(agentDef.SystemPrompt)
 		if effectiveModel == "" {
 			effectiveModel = strings.TrimSpace(agentDef.Model)
 		}
 	}
-	if err := execution.WriteAgentSystemPromptFile(session, systemPrompt); err != nil {
+	skillNames, err := r.prepareAgentFiles(ctx, session, execution.AgentConfig{
+		Provider:          agent,
+		AgentDefinitionID: agentDefinitionID,
+		Model:             effectiveModel,
+	}, agentDef)
+	if err != nil {
 		return domain.ExecResult{}, domain.AgentRunResult{}, err
-	}
-	var skillNames []string
-	if agentDef != nil && len(agentDef.Skills) > 0 {
-		resolver := skills.NewResolver(r.config)
-		resolver.Env = agentSkillEnv(agentDef.EnvItems)
-		resolvedSkills, err := resolver.Resolve(ctx, agentDef.Skills)
-		if err != nil {
-			return domain.ExecResult{}, domain.AgentRunResult{}, err
-		}
-		skillNames, err = execution.WriteAgentSkills(session, resolver.Projected(resolvedSkills))
-		if err != nil {
-			return domain.ExecResult{}, domain.AgentRunResult{}, err
-		}
-	} else {
-		if _, err := execution.WriteAgentSkills(session, nil); err != nil {
-			return domain.ExecResult{}, domain.AgentRunResult{}, err
-		}
 	}
 	spec := BuildAgentExecSpec(r.config, session, agent, effectiveModel, promptPath, schemaPath, skillNames)
 	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, r.config, facadeStoreFor(r.configDB), session, agent, effectiveModel, runtimefacade.TokenSourceAgent, runID)
@@ -122,7 +109,7 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 			}
 		}
 	}
-	if err := r.prepareAgentMCPConfig(ctx, session, agentDefinitionID, agent); err != nil {
+	if err := prepareAgentMCPConfig(session, agent, agentDef); err != nil {
 		return domain.ExecResult{}, domain.AgentRunResult{}, err
 	}
 	result, err := runtime.ExecStream(ctx, session, vmState, spec, stream)
@@ -137,6 +124,111 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 	return execution.SanitizeAgentExecResult(result), parsed, nil
 }
 
+func (r *AgentRunner) PrepareSandboxAgentEnvironment(ctx context.Context, session *domain.Sandbox, agent execution.AgentConfig, definition *domain.AgentDefinition) error {
+	if session == nil {
+		return fmt.Errorf("sandbox is required")
+	}
+	appconfig.ApplyDefaultGuestPaths(r.config)
+	agent.Provider = domain.NormalizeAgentKind(agent.Provider)
+	if agent.Provider == "" {
+		agent.Provider = domain.DefaultAgentProvider
+	}
+	if definition != nil {
+		if agent.AgentDefinitionID == "" {
+			agent.AgentDefinitionID = strings.TrimSpace(definition.ID)
+		}
+		if agent.Model == "" {
+			agent.Model = strings.TrimSpace(definition.Model)
+		}
+	}
+	if r.configDB != nil {
+		if err := r.configDB.RevokeLLMFacadeTokensForSandbox(ctx, session.Summary.ID); err != nil {
+			return err
+		}
+	}
+	if _, err := r.prepareAgentFiles(ctx, session, agent, definition); err != nil {
+		return err
+	}
+	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, r.config, facadeStoreFor(r.configDB), session, agent.Provider, agent.Model, "session", "")
+	if err != nil {
+		if r.configDB != nil {
+			_ = r.configDB.RevokeLLMFacadeTokensForSandbox(context.WithoutCancel(ctx), session.Summary.ID)
+		}
+		return err
+	}
+	if err := prepareAgentMCPConfig(session, agent.Provider, definition); err != nil {
+		if r.configDB != nil {
+			_ = r.configDB.RevokeLLMFacadeTokensForSandbox(context.WithoutCancel(ctx), session.Summary.ID)
+		}
+		return err
+	}
+	if len(managedEnv) > 0 {
+		session.RuntimeEnvItems = domain.MergeEnvItems(session.RuntimeEnvItems, llms.EnvItemsFromMap(managedEnv, false))
+	}
+	return nil
+}
+
+func (r *AgentRunner) PrepareSandboxAgentEnvironmentFromTags(ctx context.Context, session *domain.Sandbox) error {
+	if r == nil {
+		return fmt.Errorf("agent runner is required")
+	}
+	if session == nil {
+		return fmt.Errorf("sandbox is required")
+	}
+	providerTag := domain.NormalizeAgentKind(execution.SessionTagValue(session.Summary.Tags, domain.AgentSandboxTagProvider))
+	provider := providerTag
+	if provider == "" {
+		provider = domain.DefaultAgentProvider
+	}
+	agent := execution.AgentConfig{Provider: provider}
+	var definition *domain.AgentDefinition
+	taggedAgentID := execution.SessionTagValue(session.Summary.Tags, domain.AgentSandboxTagID)
+	if taggedAgentID != "" && (domain.SandboxHasAgentTag(session, taggedAgentID) || execution.SessionTagValue(session.Summary.Tags, domain.AgentSandboxTagProvider) != "") {
+		if r.agents == nil {
+			return fmt.Errorf("agent definition store is required")
+		}
+		resolved, err := r.agents.GetAgentDefinition(ctx, taggedAgentID)
+		if err != nil {
+			return fmt.Errorf("resolve sandbox agent definition %s: %w", taggedAgentID, err)
+		}
+		if !resolved.Enabled {
+			return fmt.Errorf("sandbox agent definition %s is disabled", taggedAgentID)
+		}
+		definition = &resolved
+		agent = execution.AgentConfigFromDefinition(resolved, domain.DefaultAgentProvider)
+		if providerTag != "" {
+			agent.Provider = providerTag
+		}
+	}
+	return r.PrepareSandboxAgentEnvironment(ctx, session, agent, definition)
+}
+
+func (r *AgentRunner) prepareAgentFiles(ctx context.Context, session *domain.Sandbox, agent execution.AgentConfig, definition *domain.AgentDefinition) ([]string, error) {
+	systemPrompt := ""
+	if definition != nil {
+		systemPrompt = strings.TrimSpace(definition.SystemPrompt)
+	}
+	if err := execution.WriteAgentSystemPromptFile(session, systemPrompt); err != nil {
+		return nil, err
+	}
+	var skillNames []string
+	if definition != nil && len(definition.Skills) > 0 {
+		resolver := skills.NewResolver(r.config)
+		resolver.Env = agentSkillEnv(definition.EnvItems)
+		resolvedSkills, err := resolver.Resolve(ctx, definition.Skills)
+		if err != nil {
+			return nil, err
+		}
+		skillNames, err = execution.WriteAgentSkills(session, resolver.Projected(resolvedSkills))
+		if err != nil {
+			return nil, err
+		}
+	} else if _, err := execution.WriteAgentSkills(session, nil); err != nil {
+		return nil, err
+	}
+	return skillNames, nil
+}
+
 func agentSkillEnv(items []domain.SandboxEnvVar) map[string]string {
 	env := domain.SandboxEnvMap(items)
 	if env == nil {
@@ -145,40 +237,15 @@ func agentSkillEnv(items []domain.SandboxEnvVar) map[string]string {
 	return env
 }
 
-func (r *AgentRunner) prepareAgentMCPConfig(ctx context.Context, session *domain.Sandbox, agentDefinitionID, agent string) error {
-	if session == nil {
-		return nil
+func prepareAgentMCPConfig(session *domain.Sandbox, agent string, definition *domain.AgentDefinition) error {
+	var mcps map[string]compose.NormalizedMCPServerSpec
+	if definition != nil {
+		mcps = llms.AgentMCPConfig(*definition)
 	}
-	provider := domain.NormalizeAgentKind(agent)
-	clearProvider := func() error {
-		if err := execution.WriteAgentMCPConfigFile(session, nil); err != nil {
-			return err
-		}
-		switch provider {
-		case "codex":
-			return llms.WriteCodexMCPConfig(session, nil)
-		case "opencode":
-			return llms.WriteOpenCodeMCPConfig(session, nil)
-		default:
-			return nil
-		}
-	}
-	if r == nil || r.agents == nil {
-		return clearProvider()
-	}
-	agentID := strings.TrimSpace(agentDefinitionID)
-	if agentID == "" {
-		return clearProvider()
-	}
-	definition, err := r.agents.GetAgentDefinition(ctx, agentID)
-	if err != nil {
-		return clearProvider()
-	}
-	mcps := llms.AgentMCPConfig(definition)
 	if err := execution.WriteAgentMCPConfigFile(session, mcps); err != nil {
 		return err
 	}
-	switch provider {
+	switch domain.NormalizeAgentKind(agent) {
 	case "codex":
 		return llms.WriteCodexMCPConfig(session, mcps)
 	case "opencode":

--- a/pkg/agentcompose/adapters/agent_runner_test.go
+++ b/pkg/agentcompose/adapters/agent_runner_test.go
@@ -37,6 +37,108 @@ type fakeAgentRuntime struct {
 	err          error
 }
 
+func TestAgentRunnerPrepareSandboxAgentEnvironmentUsesOnlyCurrentAgent(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:             root,
+		DbAddr:               filepath.Join(root, "data.db"),
+		SandboxRoot:          filepath.Join(root, "sandboxes"),
+		RuntimeDriver:        driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:         "guest:latest",
+		GuestWorkspacePath:   "/workspace",
+		GuestStateRoot:       "/state",
+		GuestHomePath:        "/root",
+		RuntimeBaseURL:       "http://agent-compose.test:7410",
+		LLMAPIEndpoint:       "https://llm.example.test/v1",
+		LLMAPIKey:            "provider-key",
+		LLMModel:             "gpt-default",
+		LLMAPIProtocol:       "responses",
+		SandboxStartTimeout:  2 * time.Second,
+		JupyterProxyBasePath: "/agent-compose/session",
+	}
+	configDB, store, err := testutil.OpenStores(t, config)
+	if err != nil {
+		t.Fatalf("OpenStores returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "agent environment", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, []domain.SandboxTag{
+		{Name: domain.AgentSandboxTagSource, Value: domain.AgentSandboxTagSourceVal},
+		{Name: domain.AgentSandboxTagID, Value: "agent-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"mcp_servers": map[string]any{
+			"filesystem": map[string]any{"type": "local", "command": "npx", "args": []string{"server"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	definition := &domain.AgentDefinition{
+		ID:           "agent-1",
+		Enabled:      true,
+		Provider:     "codex",
+		Model:        "gpt-agent",
+		SystemPrompt: "Use the configured agent identity",
+		ConfigJSON:   string(payload),
+	}
+	runner := NewAgentRunner(config, store, configDB, fakeAgentDefinitionStore{agent: *definition}, nil)
+	if err := runner.PrepareSandboxAgentEnvironmentFromTags(ctx, session); err != nil {
+		t.Fatalf("PrepareSandboxAgentEnvironmentFromTags returned error: %v", err)
+	}
+
+	env := domain.SandboxEnvMap(session.RuntimeEnvItems)
+	if env["OPENAI_API_KEY"] == "" || env["OPENAI_BASE_URL"] == "" {
+		t.Fatalf("missing current Codex environment: %#v", env)
+	}
+	if env["ANTHROPIC_API_KEY"] != "" || env["ANTHROPIC_BASE_URL"] != "" {
+		t.Fatalf("unexpected Claude environment: %#v", env)
+	}
+	if data, err := os.ReadFile(execution.HostAgentSystemPromptPath(session)); err != nil || string(data) != definition.SystemPrompt {
+		t.Fatalf("system prompt = %q err=%v", string(data), err)
+	}
+	if data, err := os.ReadFile(execution.HostAgentMCPConfigPath(session)); err != nil || !strings.Contains(string(data), `"filesystem"`) {
+		t.Fatalf("generic MCP config = %q err=%v", string(data), err)
+	}
+	if data, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml")); err != nil || !strings.Contains(string(data), "[mcp_servers.filesystem]") {
+		t.Fatalf("Codex config = %q err=%v", string(data), err)
+	}
+	token, err := configDB.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SANDBOX_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.Model != "gpt-agent" || token.Source != "session" || token.RunID != "" {
+		t.Fatalf("sandbox token = %#v", token)
+	}
+}
+
+func TestAgentRunnerPrepareSandboxAgentEnvironmentFromTagsRejectsInvalidDefinition(t *testing.T) {
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{Tags: []domain.SandboxTag{
+		{Name: domain.AgentSandboxTagSource, Value: domain.AgentSandboxTagSourceVal},
+		{Name: domain.AgentSandboxTagID, Value: "agent-1"},
+		{Name: domain.AgentSandboxTagProvider, Value: "opencode"},
+	}}}
+
+	t.Run("definition lookup failure", func(t *testing.T) {
+		lookupErr := errors.New("definition unavailable")
+		runner := NewAgentRunner(nil, nil, nil, fakeAgentDefinitionStore{err: lookupErr}, nil)
+		err := runner.PrepareSandboxAgentEnvironmentFromTags(context.Background(), session)
+		if !errors.Is(err, lookupErr) {
+			t.Fatalf("PrepareSandboxAgentEnvironmentFromTags error = %v, want %v", err, lookupErr)
+		}
+	})
+
+	t.Run("disabled definition", func(t *testing.T) {
+		runner := NewAgentRunner(nil, nil, nil, fakeAgentDefinitionStore{agent: domain.AgentDefinition{ID: "agent-1", Enabled: false}}, nil)
+		err := runner.PrepareSandboxAgentEnvironmentFromTags(context.Background(), session)
+		if err == nil || !strings.Contains(err.Error(), "is disabled") {
+			t.Fatalf("PrepareSandboxAgentEnvironmentFromTags error = %v, want disabled definition", err)
+		}
+	})
+}
+
 func (r *fakeAgentRuntime) EnsureSandbox(context.Context, *domain.Sandbox, domain.VMState, domain.ProxyState) (domain.SandboxVMInfo, error) {
 	return domain.SandboxVMInfo{}, nil
 }
@@ -349,8 +451,8 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Marshal returned error: %v", err)
 		}
-		runner := &AgentRunner{agents: fakeAgentDefinitionStore{agent: domain.AgentDefinition{ConfigJSON: string(payload)}}}
-		if err := runner.prepareAgentMCPConfig(context.Background(), session, "agent-1", "codex"); err != nil {
+		definition := &domain.AgentDefinition{ConfigJSON: string(payload)}
+		if err := prepareAgentMCPConfig(session, "codex", definition); err != nil {
 			t.Fatalf("prepareAgentMCPConfig returned error: %v", err)
 		}
 		stateConfig, err := os.ReadFile(execution.HostAgentMCPConfigPath(session))
@@ -374,8 +476,8 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Marshal returned error: %v", err)
 		}
-		runner := &AgentRunner{agents: fakeAgentDefinitionStore{agent: domain.AgentDefinition{ConfigJSON: string(payload)}}}
-		if err := runner.prepareAgentMCPConfig(context.Background(), session, "agent-1", "opencode"); err != nil {
+		definition := &domain.AgentDefinition{ConfigJSON: string(payload)}
+		if err := prepareAgentMCPConfig(session, "opencode", definition); err != nil {
 			t.Fatalf("prepareAgentMCPConfig returned error: %v", err)
 		}
 		openCodeConfig, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(session), ".config", "opencode", "opencode.json"))
@@ -395,8 +497,8 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Marshal returned error: %v", err)
 		}
-		runner := &AgentRunner{agents: fakeAgentDefinitionStore{agent: domain.AgentDefinition{ConfigJSON: string(payload)}}}
-		if err := runner.prepareAgentMCPConfig(context.Background(), session, "agent-1", "claude"); err != nil {
+		definition := &domain.AgentDefinition{ConfigJSON: string(payload)}
+		if err := prepareAgentMCPConfig(session, "claude", definition); err != nil {
 			t.Fatalf("prepareAgentMCPConfig returned error: %v", err)
 		}
 		if _, err := os.Stat(execution.HostAgentMCPConfigPath(session)); err != nil {
@@ -417,8 +519,7 @@ func TestAgentRunnerPrepareManagedMCPConfigForProviders(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml"), []byte("# agent-compose managed mcp start\n[mcp_servers.old]\ncommand = \"old\"\n# agent-compose managed mcp end\n"), 0o644); err != nil {
 			t.Fatalf("WriteFile returned error: %v", err)
 		}
-		runner := &AgentRunner{agents: fakeAgentDefinitionStore{err: errors.New("boom")}}
-		if err := runner.prepareAgentMCPConfig(context.Background(), session, "agent-1", "codex"); err != nil {
+		if err := prepareAgentMCPConfig(session, "codex", nil); err != nil {
 			t.Fatalf("prepareAgentMCPConfig returned error: %v", err)
 		}
 		if _, err := os.Stat(execution.HostAgentMCPConfigPath(session)); !os.IsNotExist(err) {

--- a/pkg/agentcompose/adapters/loader_session_runner.go
+++ b/pkg/agentcompose/adapters/loader_session_runner.go
@@ -14,6 +14,7 @@ import (
 	"agent-compose/pkg/capabilities"
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
 	"agent-compose/pkg/llms"
 	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
@@ -39,11 +40,12 @@ type LoaderSandboxRunner struct {
 	Streams          *sessions.StreamBroker
 	Publisher        loaders.ControllerPublisher
 	CapTokens        *CapabilitySandboxResolver
+	AgentExecutor    *AgentExecutor
 	LifecycleLocks   *sessions.LifecycleLocks
 }
 
-func NewLoaderSandboxRunner(config *appconfig.Config, store *sessionstore.Store, configDB *configstore.ConfigStore, workspaceEnsurer workspaces.WorkspaceEnsurer, driver sessions.SandboxDriver, cap capabilities.Provider, volumeResolver LoaderVolumeResolver, streams *sessions.StreamBroker, publisher loaders.ControllerPublisher, capTokens *CapabilitySandboxResolver, locks ...*sessions.LifecycleLocks) *LoaderSandboxRunner {
-	runner := &LoaderSandboxRunner{Config: config, Store: store, ConfigDB: configDB, workspaceEnsurer: workspaceEnsurer, Driver: driver, Cap: cap, Volumes: volumeResolver, Streams: streams, Publisher: publisher, CapTokens: capTokens}
+func NewLoaderSandboxRunner(config *appconfig.Config, store *sessionstore.Store, configDB *configstore.ConfigStore, workspaceEnsurer workspaces.WorkspaceEnsurer, driver sessions.SandboxDriver, cap capabilities.Provider, volumeResolver LoaderVolumeResolver, streams *sessions.StreamBroker, publisher loaders.ControllerPublisher, capTokens *CapabilitySandboxResolver, agentExecutor *AgentExecutor, locks ...*sessions.LifecycleLocks) *LoaderSandboxRunner {
+	runner := &LoaderSandboxRunner{Config: config, Store: store, ConfigDB: configDB, workspaceEnsurer: workspaceEnsurer, Driver: driver, Cap: cap, Volumes: volumeResolver, Streams: streams, Publisher: publisher, CapTokens: capTokens, AgentExecutor: agentExecutor}
 	if len(locks) > 0 {
 		runner.LifecycleLocks = locks[0]
 	}
@@ -107,6 +109,19 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	if agentDefinition != nil {
 		envItems = domain.MergeEnvItems(envItems, agentDefinition.EnvItems)
 	}
+	agentConfig := execution.AgentConfig{Provider: domain.NormalizeAgentKind(request.Agent)}
+	if agentDefinition != nil {
+		agentConfig = execution.AgentConfigFromDefinition(*agentDefinition, domain.DefaultAgentProvider)
+		if requestedProvider := domain.NormalizeAgentKind(request.Agent); requestedProvider != "" {
+			agentConfig.Provider = requestedProvider
+		}
+	}
+	if agentConfig.Provider == "" {
+		agentConfig.Provider = domain.NormalizeAgentKind(loader.Summary.DefaultAgent)
+	}
+	if agentConfig.Provider == "" {
+		agentConfig.Provider = domain.DefaultAgentProvider
+	}
 	envItems = domain.MergeEnvItems(envItems, loader.EnvItems)
 	envItems = domain.MergeEnvItems(envItems, domain.LoaderAgentSandboxEnv(request))
 	providerEnvItems := envItems
@@ -153,7 +168,12 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	if strings.TrimSpace(loader.Summary.ManagedProjectID) != "" {
 		origin = "scheduler"
 	}
-	tags := []domain.SandboxTag{{Name: "origin", Value: origin}, {Name: "loader_id", Value: loader.Summary.ID}, {Name: "loader_name", Value: loader.Summary.Name}}
+	tags := []domain.SandboxTag{
+		{Name: "origin", Value: origin},
+		{Name: "loader_id", Value: loader.Summary.ID},
+		{Name: "loader_name", Value: loader.Summary.Name},
+		{Name: domain.AgentSandboxTagProvider, Value: agentConfig.Provider},
+	}
 	if origin == "scheduler" {
 		projectID := strings.TrimSpace(loader.Summary.ManagedProjectID)
 		tags = append(tags,
@@ -193,6 +213,16 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 		return nil, "", err
 	}
 	writeCapabilityGuide(ctx, r.Cap, r.Store, r.Streams, session, loader.Summary.CapsetIDs)
+	if r.AgentExecutor == nil {
+		session.Summary.VMStatus = domain.VMStatusFailed
+		_ = r.Store.UpdateSandbox(ctx, session)
+		return nil, "", fmt.Errorf("agent executor is required")
+	}
+	if err := r.AgentExecutor.PrepareSandboxAgentEnvironment(ctx, session, agentConfig, agentDefinition); err != nil {
+		session.Summary.VMStatus = domain.VMStatusFailed
+		_ = r.Store.UpdateSandbox(ctx, session)
+		return nil, "", err
+	}
 	if err := r.Driver.StartSandboxVM(ctx, session); err != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = r.Store.UpdateSandbox(ctx, session)
@@ -275,6 +305,15 @@ func (r *LoaderSandboxRunner) loadOrResumeLocked(ctx context.Context, sessionID 
 	}
 	if err := r.workspaceEnsurer.Ensure(ctx, session); err != nil {
 		return nil, "", err
+	}
+	vmState, err := r.Store.GetVMState(session.Summary.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	if vmState.StartedAt.IsZero() {
+		if err := r.AgentExecutor.PrepareSandboxAgentEnvironmentFromTags(ctx, session); err != nil {
+			return nil, "", err
+		}
 	}
 	writeCapabilityGuide(ctx, r.Cap, r.Store, r.Streams, session, capabilities.SandboxCapsets(session))
 	if err := r.Driver.StartSandboxVM(ctx, session); err != nil {

--- a/pkg/agentcompose/adapters/loader_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/loader_session_runner_coverage_test.go
@@ -17,8 +17,13 @@ import (
 func TestLoaderSandboxRunnerLoadResumeAndShutdownCoverage(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
+	bridge.config.RuntimeBaseURL = "http://agent-compose.test:7410"
+	bridge.config.LLMAPIEndpoint = "https://llm.example.test/v1"
+	bridge.config.LLMAPIKey = "provider-key"
+	bridge.config.LLMModel = "gpt-loader-retry"
+	bridge.config.LLMAPIProtocol = "responses"
 	publisher := &loaderSessionPublisherFake{}
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, publisher, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
 
 	running, err := bridge.store.CreateSandbox(ctx, "running", "", driverpkg.RuntimeDriverBoxlite, "", "", "loader", nil, nil, nil)
 	if err != nil {
@@ -49,6 +54,9 @@ func TestLoaderSandboxRunnerLoadResumeAndShutdownCoverage(t *testing.T) {
 	resumed, eventType, err = runner.LoadOrResume(ctx, stopped.Summary.ID)
 	if err != nil || resumed.Summary.VMStatus != domain.VMStatusRunning || eventType != "loader.sandbox.resumed" || len(driver.startCalls) != 1 {
 		t.Fatalf("LoadOrResume stopped resumed=%#v event=%q err=%v starts=%#v", resumed, eventType, err, driver.startCalls)
+	}
+	if token := domain.SandboxEnvMap(driver.startSessions[0].RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]; token == "" {
+		t.Fatal("fresh loader retry started without an agent token")
 	}
 	if len(publisher.events) != 1 || publisher.events[0].Topic != "agent-compose.session.resumed" {
 		t.Fatalf("resume publisher events=%#v", publisher.events)
@@ -91,7 +99,7 @@ func TestLoaderSandboxRunnerLoadResumeAndShutdownCoverage(t *testing.T) {
 func TestLoaderSandboxRunnerRejectsUnsupportedStickyResumeBeforeSideEffects(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, nil, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
 	session, err := bridge.store.CreateSandbox(ctx, "historical sticky", "", driverpkg.RuntimeDriverMicrosandbox, "", "", "loader", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
@@ -133,7 +141,7 @@ func TestLoaderSandboxRunnerRejectsUncompiledDriverBeforePersistence(t *testing.
 			ctx := context.Background()
 			bridge, sandboxDriver := newTestSandboxRPCBridge(t)
 			publisher := &loaderSessionPublisherFake{}
-			runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, sandboxDriver, nil, nil, bridge.streams, publisher, nil)
+			runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, sandboxDriver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
 			loader := domain.Loader{Summary: domain.LoaderSummary{
 				ID:            "loader-uncompiled-" + runtimeDriver,
 				Name:          "Uncompiled " + runtimeDriver,
@@ -213,7 +221,7 @@ func TestLoaderSandboxRunnerResolvesVolumeMounts(t *testing.T) {
 		}},
 		warnings: []string{"volume target /cache overlaps test path"},
 	}
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, resolver, bridge.streams, nil, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, resolver, bridge.streams, nil, nil, bridge.agentExecutor)
 	projectRoot := t.TempDir()
 	projectPath := filepath.Join(projectRoot, "agent-compose.yml")
 	if _, err := bridge.configDB.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "Project", SourcePath: projectPath}); err != nil {

--- a/pkg/agentcompose/adapters/loader_session_runner_workspace_ensurer_test.go
+++ b/pkg/agentcompose/adapters/loader_session_runner_workspace_ensurer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"agent-compose/pkg/capabilities"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/workspaces"
 )
@@ -83,7 +84,7 @@ func TestLoaderSandboxRunnerEnsureUsesWorkspaceEnsurerBeforeGuideAndDriver(t *te
 		}
 	}
 	publisher := &loaderSessionPublisherFake{}
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, bridge.cap, nil, bridge.streams, publisher, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, bridge.cap, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
 	loader := domain.Loader{Summary: domain.LoaderSummary{
 		ID:            "loader-create",
 		Name:          "Loader Create",
@@ -119,6 +120,9 @@ func TestLoaderSandboxRunnerEnsureUsesWorkspaceEnsurerBeforeGuideAndDriver(t *te
 	if sandbox.Summary.VMStatus != domain.VMStatusRunning || sandbox.WorkspaceProvisioning == nil || sandbox.WorkspaceProvisioning.Status != domain.SandboxWorkspaceProvisioningStatusReady {
 		t.Fatalf("created sandbox state = vm:%q provisioning:%#v", sandbox.Summary.VMStatus, sandbox.WorkspaceProvisioning)
 	}
+	if execution.SessionTagValue(sandbox.Summary.Tags, domain.AgentSandboxTagProvider) != domain.DefaultAgentProvider {
+		t.Fatalf("sandbox provider tag = %#v", sandbox.Summary.Tags)
+	}
 	binding, ok, err := bridge.configDB.GetLoaderBinding(ctx, loader.Summary.ID, "trigger-create")
 	if err != nil || !ok || binding.SandboxID != sandbox.Summary.ID {
 		t.Fatalf("loader binding = %#v ok=%v err=%v, want sandbox %q", binding, ok, err, sandbox.Summary.ID)
@@ -137,7 +141,7 @@ func TestLoaderSandboxRunnerEnsureWorkspaceEnsurerErrorShortCircuitsDriver(t *te
 		return []byte("unexpected guide"), nil
 	}}
 	publisher := &loaderSessionPublisherFake{}
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
 	loader := domain.Loader{Summary: domain.LoaderSummary{
 		ID:            "loader-ensure-error",
 		Name:          "Loader Ensure Error",
@@ -192,7 +196,7 @@ func TestLoaderSandboxRunnerEnsureRuntimeFailurePreservesReadyProvisioning(t *te
 	}}
 	startErr := errors.New("loader runtime start failed")
 	driver.startErr = startErr
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, nil, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
 	loader := domain.Loader{Summary: domain.LoaderSummary{
 		ID:            "loader-runtime-error",
 		Name:          "Loader Runtime Error",
@@ -275,7 +279,7 @@ func TestLoaderSandboxRunnerLoadOrResumeUsesWorkspaceEnsurer(t *testing.T) {
 			}
 		}
 		publisher := &loaderSessionPublisherFake{}
-		runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil)
+		runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
 
 		resumed, eventType, err := runner.LoadOrResume(ctx, stopped.Summary.ID)
 		if err != nil {
@@ -328,7 +332,7 @@ func TestLoaderSandboxRunnerLoadOrResumeUsesWorkspaceEnsurer(t *testing.T) {
 			return nil, nil
 		}}
 		publisher := &loaderSessionPublisherFake{}
-		runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil)
+		runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
 
 		_, _, err = runner.LoadOrResume(ctx, stopped.Summary.ID)
 		if err != ensureErr {
@@ -366,7 +370,7 @@ func TestLoaderSandboxRunnerLoadOrResumeUsesWorkspaceEnsurer(t *testing.T) {
 		}}
 		startErr := errors.New("resume runtime start failed")
 		driver.startErr = startErr
-		runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, nil, nil)
+		runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
 
 		_, _, err = runner.LoadOrResume(ctx, stopped.Summary.ID)
 		if err != startErr {
@@ -419,7 +423,7 @@ func TestLoaderSandboxRunnerStickyRunningMatchingConfigSkipsEnsurerAndPreservesW
 	request := domain.LoaderAgentRequest{Agent: "codex", BindingTriggerID: "sticky-trigger"}
 	ensurer := &recordingLoaderWorkspaceEnsurer{err: errors.New("running sticky path must not ensure workspace")}
 	publisher := &loaderSessionPublisherFake{}
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
 	baseConfigHash, err := loaderSandboxConfigHash(loader)
 	if err != nil {
 		t.Fatalf("loaderSandboxConfigHash returned error: %v", err)
@@ -476,7 +480,7 @@ func TestLoaderSandboxRunnerAdoptsLegacyStickyBindingWithoutStoppingSandbox(t *t
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			bridge, driver := newTestSandboxRPCBridge(t)
-			runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, nil, nil)
+			runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
 			loader := domain.Loader{Summary: domain.LoaderSummary{ID: "legacy-loader", SandboxPolicy: domain.LoaderSandboxPolicySticky}}
 			const triggerID = "legacy-trigger"
 			const configHash = "sha256:current"
@@ -513,7 +517,7 @@ func TestLoaderSandboxRunnerAdoptsLegacyStickyBindingWithoutStoppingSandbox(t *t
 func TestLoaderSandboxRunnerConcurrentStickyClaimReusesWinner(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, nil, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
 	loader := domain.Loader{Summary: domain.LoaderSummary{
 		ID:                "loader-concurrent-sticky",
 		Name:              "Concurrent Sticky",
@@ -586,7 +590,7 @@ func TestLoaderSandboxRunnerStickyWorkspaceConfigChangeCreatesReplacement(t *tes
 	if err != nil {
 		t.Fatalf("CreateWorkspaceConfig returned error: %v", err)
 	}
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, &loaderSessionPublisherFake{}, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, &loaderSessionPublisherFake{}, nil, bridge.agentExecutor)
 	loader := domain.Loader{Summary: domain.LoaderSummary{
 		ID:            "loader-sticky-workspace-update",
 		Name:          "Loader Sticky Workspace Update",
@@ -636,6 +640,7 @@ func TestLoaderSandboxRunnerStickyRunningConfigChangeCreatesReplacement(t *testi
 		bridge.streams,
 		&loaderSessionPublisherFake{},
 		capTokens,
+		bridge.agentExecutor,
 	)
 	loader := domain.Loader{
 		Summary: domain.LoaderSummary{
@@ -715,7 +720,7 @@ func TestLoaderSandboxRunnerStickyRunningConfigChangeCreatesReplacement(t *testi
 func TestLoaderSandboxRunnerStickyStoppedConfigChangeDoesNotResume(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
-	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, &loaderSessionPublisherFake{}, nil)
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingLoaderWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, &loaderSessionPublisherFake{}, nil, bridge.agentExecutor)
 	loader := domain.Loader{
 		Summary: domain.LoaderSummary{
 			ID:            "loader-sticky-stopped-update",

--- a/pkg/agentcompose/adapters/loader_session_runner_workspace_resume_integration_test.go
+++ b/pkg/agentcompose/adapters/loader_session_runner_workspace_resume_integration_test.go
@@ -68,6 +68,7 @@ func TestIntegrationLoaderStickyResumePreservesReadyFileWorkspace(t *testing.T) 
 		bridge.streams,
 		publisher,
 		nil,
+		bridge.agentExecutor,
 	)
 
 	created, eventType, err := runner.Ensure(ctx, loader, request, false)

--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -2,14 +2,12 @@ package adapters
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"time"
 
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
-	"agent-compose/pkg/llms"
-	"agent-compose/pkg/llms/runtimefacade"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/sessions"
 	"agent-compose/pkg/storage/configstore"
@@ -22,8 +20,6 @@ type SandboxDriver struct {
 	ConfigDB *configstore.ConfigStore
 	Runtimes RuntimeProvider
 }
-
-var ensureSandboxLLMFacadeConfig = runtimefacade.EnsureSessionLLMFacadeConfig
 
 func NewSandboxDriver(config *appconfig.Config, store *sessionstore.Store, configDB *configstore.ConfigStore, runtimes RuntimeProvider) *SandboxDriver {
 	return &SandboxDriver{Config: config, Store: store, ConfigDB: configDB, Runtimes: runtimes}
@@ -46,7 +42,7 @@ func (d *SandboxDriver) ValidateSandboxRuntime(session *domain.Sandbox) error {
 	return err
 }
 
-func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sandbox) error {
+func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sandbox) (resultErr error) {
 	if session == nil || session.Summary.VMStatus == domain.VMStatusDeleting {
 		return domain.ClassifyError(domain.ErrConflict, "sandbox is being deleted", nil)
 	}
@@ -62,6 +58,17 @@ func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sand
 	if err != nil {
 		return err
 	}
+	runtimeStarted := false
+	if vmState.StartedAt.IsZero() && d.ConfigDB != nil {
+		defer func() {
+			if resultErr == nil || runtimeStarted {
+				return
+			}
+			if err := d.ConfigDB.RevokeLLMFacadeTokensForSandbox(context.WithoutCancel(ctx), session.Summary.ID); err != nil {
+				resultErr = errors.Join(resultErr, err)
+			}
+		}()
+	}
 	proxyState, err := d.Store.GetProxyState(session.Summary.ID)
 	if err != nil {
 		return err
@@ -70,8 +77,7 @@ func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sand
 	vmState.Mode = driver
 	vmState.BoxName = firstNonEmpty(vmState.BoxName, session.Summary.RuntimeRef)
 	vmState.RuntimeHome = firstNonEmpty(vmState.RuntimeHome, driverpkg.RuntimeHomeForDriver(d.Config, driver))
-	resuming := !vmState.StoppedAt.IsZero()
-	if err := d.prepareSandboxStart(ctx, driver, session, &vmState, !resuming); err != nil {
+	if err := d.prepareSandboxStart(ctx, driver, session, &vmState); err != nil {
 		vmState.LastError = err.Error()
 		_ = d.Store.SaveVMState(session.Summary.ID, vmState)
 		return err
@@ -91,6 +97,7 @@ func (d *SandboxDriver) StartSandboxVM(ctx context.Context, session *domain.Sand
 		_ = d.Store.SaveVMState(session.Summary.ID, vmState)
 		return err
 	}
+	runtimeStarted = true
 
 	return d.saveSandboxStartInfo(session, vmState, proxyState, info)
 }
@@ -156,49 +163,11 @@ func (d *SandboxDriver) RemoveSandboxVM(ctx context.Context, session *domain.San
 	return nil
 }
 
-func (d *SandboxDriver) prepareSandboxStart(ctx context.Context, driver string, session *domain.Sandbox, vmState *domain.VMState, refreshRuntimeEnv bool) error {
+func (d *SandboxDriver) prepareSandboxStart(ctx context.Context, driver string, session *domain.Sandbox, vmState *domain.VMState) error {
 	prepared, err := driverpkg.PrepareSandboxStart(ctx, d.Config, driver, execution.ToDriverSandbox(session), execution.ToDriverVMState(*vmState))
 	if err != nil {
 		return err
 	}
 	*vmState = execution.FromDriverVMState(prepared)
-	if !refreshRuntimeEnv {
-		return nil
-	}
-	managedEnv := map[string]string{}
-	for _, agent := range []string{"codex", "claude"} {
-		agentEnv, err := ensureSandboxLLMFacadeConfig(ctx, d.Config, facadeStoreFor(d.ConfigDB), session, agent, "", "session", "")
-		if err != nil {
-			if agent == "claude" && runtimefacade.IsOptionalConfigError(err) {
-				continue
-			}
-			return err
-		}
-		for key, value := range startupFacadeEnv(agent, agentEnv) {
-			managedEnv[key] = value
-		}
-	}
-	if len(managedEnv) > 0 {
-		session.RuntimeEnvItems = llms.EnvItemsFromMap(managedEnv, false)
-	}
 	return nil
-}
-
-func startupFacadeEnv(agent string, env map[string]string) map[string]string {
-	if len(env) == 0 {
-		return nil
-	}
-	if strings.EqualFold(strings.TrimSpace(agent), "claude") {
-		filtered := make(map[string]string, len(env))
-		for _, key := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL", "CLAUDE_MODEL"} {
-			if value := strings.TrimSpace(env[key]); value != "" {
-				filtered[key] = value
-			}
-		}
-		if len(filtered) == 0 {
-			return nil
-		}
-		return filtered
-	}
-	return env
 }

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -3,15 +3,16 @@ package adapters
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
 	"agent-compose/pkg/internal/testutil"
 	"agent-compose/pkg/llms"
-	"agent-compose/pkg/llms/runtimefacade"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/storage/sessionstore"
 
@@ -186,6 +187,183 @@ func TestSandboxDriverStartSandboxVMSavesRuntimeState(t *testing.T) {
 	}
 }
 
+func TestSandboxDriverFreshStartFailureRevokesPreparedAgentToken(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:            root,
+		DbAddr:              filepath.Join(root, "data.db"),
+		SandboxRoot:         filepath.Join(root, "sandboxes"),
+		RuntimeDriver:       driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		GuestStateRoot:      "/state",
+		GuestHomePath:       "/root",
+		RuntimeBaseURL:      "http://agent-compose.test:7410",
+		LLMAPIEndpoint:      "https://llm.example.test/v1",
+		LLMAPIKey:           "provider-key",
+		LLMModel:            "gpt-test",
+		LLMAPIProtocol:      "responses",
+		SandboxStartTimeout: 2 * time.Second,
+	}
+	configDB, store, err := testutil.OpenStores(t, config)
+	if err != nil {
+		t.Fatalf("OpenStores returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "failed start", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	runner := NewAgentRunner(config, store, configDB, configDB, nil)
+	if err := runner.PrepareSandboxAgentEnvironment(ctx, session, execution.AgentConfig{Provider: "codex", Model: "gpt-test"}, nil); err != nil {
+		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
+	}
+	rawToken := domain.SandboxEnvMap(session.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	if rawToken == "" {
+		t.Fatal("prepared sandbox token is empty")
+	}
+	startErr := errors.New("runtime start failed")
+	driver := NewSandboxDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{ensureErr: startErr}})
+	if err := driver.StartSandboxVM(ctx, session); !errors.Is(err, startErr) {
+		t.Fatalf("StartSandboxVM error = %v, want %v", err, startErr)
+	}
+	token, err := configDB.GetLLMFacadeToken(ctx, rawToken)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.RevokedAt.IsZero() {
+		t.Fatalf("failed fresh start token remains active: %#v", token)
+	}
+}
+
+func TestSandboxDriverFailedRunningSandboxCheckKeepsPreparedAgentToken(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:            root,
+		DbAddr:              filepath.Join(root, "data.db"),
+		SandboxRoot:         filepath.Join(root, "sandboxes"),
+		RuntimeDriver:       driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		GuestStateRoot:      "/state",
+		GuestHomePath:       "/root",
+		RuntimeBaseURL:      "http://agent-compose.test:7410",
+		LLMAPIEndpoint:      "https://llm.example.test/v1",
+		LLMAPIKey:           "provider-key",
+		LLMModel:            "gpt-test",
+		LLMAPIProtocol:      "responses",
+		SandboxStartTimeout: 2 * time.Second,
+	}
+	configDB, store, err := testutil.OpenStores(t, config)
+	if err != nil {
+		t.Fatalf("OpenStores returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "running sandbox", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	runner := NewAgentRunner(config, store, configDB, configDB, nil)
+	if err := runner.PrepareSandboxAgentEnvironment(ctx, session, execution.AgentConfig{Provider: "codex", Model: "gpt-test"}, nil); err != nil {
+		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
+	}
+	rawToken := domain.SandboxEnvMap(session.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	if rawToken == "" {
+		t.Fatal("prepared sandbox token is empty")
+	}
+	if err := store.SaveVMState(session.Summary.ID, domain.VMState{
+		Driver:    driverpkg.RuntimeDriverBoxlite,
+		BoxID:     "container-1",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveVMState returned error: %v", err)
+	}
+
+	startErr := errors.New("runtime check failed")
+	driver := NewSandboxDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{ensureErr: startErr}})
+	if err := driver.StartSandboxVM(ctx, session); !errors.Is(err, startErr) {
+		t.Fatalf("StartSandboxVM error = %v, want %v", err, startErr)
+	}
+	token, err := configDB.GetLLMFacadeToken(ctx, rawToken)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if !token.RevokedAt.IsZero() {
+		t.Fatalf("running sandbox token was revoked: %#v", token)
+	}
+}
+
+func TestSandboxDriverPostStartPersistenceFailureKeepsPreparedAgentToken(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:            root,
+		DbAddr:              filepath.Join(root, "data.db"),
+		SandboxRoot:         filepath.Join(root, "sandboxes"),
+		RuntimeDriver:       driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		GuestStateRoot:      "/state",
+		GuestHomePath:       "/root",
+		RuntimeBaseURL:      "http://agent-compose.test:7410",
+		LLMAPIEndpoint:      "https://llm.example.test/v1",
+		LLMAPIKey:           "provider-key",
+		LLMModel:            "gpt-test",
+		LLMAPIProtocol:      "responses",
+		SandboxStartTimeout: 2 * time.Second,
+	}
+	configDB, store, err := testutil.OpenStores(t, config)
+	if err != nil {
+		t.Fatalf("OpenStores returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "post-start persistence failure", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	runner := NewAgentRunner(config, store, configDB, configDB, nil)
+	if err := runner.PrepareSandboxAgentEnvironment(ctx, session, execution.AgentConfig{Provider: "codex", Model: "gpt-test"}, nil); err != nil {
+		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
+	}
+	rawToken := domain.SandboxEnvMap(session.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	if rawToken == "" {
+		t.Fatal("prepared sandbox token is empty")
+	}
+
+	driver := NewSandboxDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{
+		info: domain.SandboxVMInfo{BoxID: "container-1"},
+		ensureHook: func(*domain.Sandbox) {
+			proxyDir := filepath.Dir(store.ProxyStatePath(session.Summary.ID))
+			if err := os.Remove(store.ProxyStatePath(session.Summary.ID)); err != nil {
+				t.Fatalf("remove proxy state: %v", err)
+			}
+			if err := os.Remove(proxyDir); err != nil {
+				t.Fatalf("remove proxy directory: %v", err)
+			}
+			if err := os.WriteFile(proxyDir, []byte("block proxy state persistence"), 0o644); err != nil {
+				t.Fatalf("replace proxy directory: %v", err)
+			}
+		},
+	}})
+	if err := driver.StartSandboxVM(ctx, session); err == nil {
+		t.Fatal("StartSandboxVM succeeded despite proxy state persistence failure")
+	}
+
+	vmState, err := store.GetVMState(session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetVMState returned error: %v", err)
+	}
+	if vmState.StartedAt.IsZero() || vmState.BoxID != "container-1" {
+		t.Fatalf("runtime start was not persisted before proxy failure: %#v", vmState)
+	}
+	token, err := configDB.GetLLMFacadeToken(ctx, rawToken)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if !token.RevokedAt.IsZero() {
+		t.Fatalf("running sandbox token was revoked after proxy persistence failure: %#v", token)
+	}
+}
+
 func TestSandboxDriverStopSandboxVMAddsDockerStopContextMargin(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -296,13 +474,6 @@ func TestSandboxDriverStopPreservesFacadeTokensUntilRemove(t *testing.T) {
 
 func TestSandboxDriverResumeReusesRuntimeWithoutRefreshingStartupEnv(t *testing.T) {
 	ctx := context.Background()
-	originalEnsure := ensureSandboxLLMFacadeConfig
-	defer func() { ensureSandboxLLMFacadeConfig = originalEnsure }()
-	ensureCalls := 0
-	ensureSandboxLLMFacadeConfig = func(context.Context, *appconfig.Config, runtimefacade.FacadeStore, *domain.Sandbox, string, string, string, string) (map[string]string, error) {
-		ensureCalls++
-		return map[string]string{"OPENAI_API_KEY": "new-token"}, nil
-	}
 	root := t.TempDir()
 	config := &appconfig.Config{
 		DataRoot:            root,
@@ -321,6 +492,7 @@ func TestSandboxDriverResumeReusesRuntimeWithoutRefreshingStartupEnv(t *testing.
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
+	session.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "existing-token"}}
 	if err := store.SaveVMState(session.Summary.ID, domain.VMState{
 		Driver:    driverpkg.RuntimeDriverBoxlite,
 		BoxID:     "container-1",
@@ -331,8 +503,8 @@ func TestSandboxDriverResumeReusesRuntimeWithoutRefreshingStartupEnv(t *testing.
 	runtime := fakeSessionRuntime{
 		info: domain.SandboxVMInfo{BoxID: "container-1"},
 		ensureHook: func(resumed *domain.Sandbox) {
-			if len(resumed.RuntimeEnvItems) != 0 {
-				t.Fatalf("resume injected replacement startup env: %#v", resumed.RuntimeEnvItems)
+			if got := domain.SandboxEnvMap(resumed.RuntimeEnvItems)["OPENAI_API_KEY"]; got != "existing-token" {
+				t.Fatalf("resume runtime env = %#v", resumed.RuntimeEnvItems)
 			}
 		},
 	}
@@ -340,9 +512,6 @@ func TestSandboxDriverResumeReusesRuntimeWithoutRefreshingStartupEnv(t *testing.
 
 	if err := driver.StartSandboxVM(ctx, session); err != nil {
 		t.Fatalf("StartSandboxVM returned error: %v", err)
-	}
-	if ensureCalls != 0 {
-		t.Fatalf("startup facade refresh calls during resume = %d, want 0", ensureCalls)
 	}
 	vmState, err := store.GetVMState(session.Summary.ID)
 	if err != nil {
@@ -396,173 +565,44 @@ func TestSandboxDriverResumeRecordsAttemptBeforeRuntimeFailure(t *testing.T) {
 	}
 }
 
-func TestSandboxDriverStartSandboxVMInjectsOpenAIAndAnthropicFacadeEnv(t *testing.T) {
+func TestSandboxDriverStartSandboxVMUsesPreparedAgentEnvironmentWithoutAddingProviders(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	config := &appconfig.Config{
-		DataRoot:             root,
-		DbAddr:               filepath.Join(root, "data.db"),
-		SandboxRoot:          filepath.Join(root, "sandboxes"),
-		RuntimeDriver:        driverpkg.RuntimeDriverMicrosandbox,
-		MicrosandboxHome:     filepath.Join(root, "microsandbox"),
-		DefaultImage:         "guest:latest",
-		GuestWorkspacePath:   "/workspace",
-		JupyterGuestPort:     8888,
-		JupyterProxyBasePath: "/agent-compose/session",
-		SandboxStartTimeout:  2 * time.Second,
-		RuntimeBaseURL:       "http://agent-compose.test:7410",
+		DataRoot:            root,
+		SandboxRoot:         filepath.Join(root, "sandboxes"),
+		RuntimeDriver:       driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:        "guest:latest",
+		GuestWorkspacePath:  "/workspace",
+		SandboxStartTimeout: 2 * time.Second,
 	}
 	store, err := sessionstore.NewWithConfig(config)
 	if err != nil {
 		t.Fatalf("NewWithConfig returned error: %v", err)
 	}
-	di := do.New()
-	do.ProvideValue(di, ctx)
-	do.ProvideValue(di, config)
-	configDB, err := testutil.OpenConfigStore(t, di)
+	session, err := store.CreateSandbox(ctx, "adapter session", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
 	if err != nil {
-		t.Fatalf("NewConfigStore returned error: %v", err)
+		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
-	session, err := store.CreateSandbox(ctx, "adapter session", "", driverpkg.RuntimeDriverMicrosandbox, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
-	if err != nil {
-		t.Fatalf("CreateSession returned error: %v", err)
-	}
-	session.ProviderEnvItems = []domain.SandboxEnvVar{
-		{Name: "LLM_MODEL", Value: "gpt-test"},
-		{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example.test"},
-		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "anthropic-secret"},
-		{Name: "ANTHROPIC_MODEL", Value: "claude-test"},
-	}
-	updatedProxyState := domain.ProxyState{
-		ProxyPath:  session.Summary.ProxyPath,
-		GuestHost:  "agent-compose-sandbox-1",
-		HostPort:   39000,
-		GuestPort:  8888,
-		JupyterURL: "http://127.0.0.1:39000/lab?token=secret",
-		Token:      "secret",
+	session.RuntimeEnvItems = []domain.SandboxEnvVar{
+		{Name: "OPENAI_API_KEY", Value: "prepared-token"},
+		{Name: "OPENAI_BASE_URL", Value: "http://prepared.example/v1"},
 	}
 	var runtimeEnv map[string]string
-	driver := NewSandboxDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{
-		info: domain.SandboxVMInfo{BoxID: "container-1", JupyterURL: updatedProxyState.JupyterURL, ProxyState: &updatedProxyState},
-		ensureHook: func(session *domain.Sandbox) {
-			runtimeEnv = map[string]string{}
-			for _, item := range session.RuntimeEnvItems {
-				runtimeEnv[item.Name] = item.Value
-			}
+	driver := NewSandboxDriver(config, store, nil, fakeRuntimeProvider{runtime: fakeSessionRuntime{
+		info: domain.SandboxVMInfo{BoxID: "container-1"},
+		ensureHook: func(started *domain.Sandbox) {
+			runtimeEnv = domain.SandboxEnvMap(started.RuntimeEnvItems)
 		},
 	}})
 
 	if err := driver.StartSandboxVM(ctx, session); err != nil {
 		t.Fatalf("StartSandboxVM returned error: %v", err)
 	}
-	if runtimeEnv["OPENAI_BASE_URL"] != "http://agent-compose.test:7410/api/runtime/sandboxes/"+session.Summary.ID+"/llm/openai/v1" {
-		t.Fatalf("OPENAI_BASE_URL = %q", runtimeEnv["OPENAI_BASE_URL"])
+	if runtimeEnv["OPENAI_API_KEY"] != "prepared-token" || runtimeEnv["OPENAI_BASE_URL"] != "http://prepared.example/v1" {
+		t.Fatalf("prepared runtime env = %#v", runtimeEnv)
 	}
-	if runtimeEnv["ANTHROPIC_BASE_URL"] != "http://agent-compose.test:7410/api/runtime/sandboxes/"+session.Summary.ID+"/llm/anthropic" {
-		t.Fatalf("ANTHROPIC_BASE_URL = %q", runtimeEnv["ANTHROPIC_BASE_URL"])
-	}
-	if runtimeEnv["OPENAI_API_KEY"] == "" {
-		t.Fatalf("OPENAI_API_KEY is empty")
-	}
-	if runtimeEnv["LLM_API_PROTOCOL"] != "responses" {
-		t.Fatalf("LLM_API_PROTOCOL = %q", runtimeEnv["LLM_API_PROTOCOL"])
-	}
-	if runtimeEnv["LLM_API_ENDPOINT"] != runtimeEnv["OPENAI_BASE_URL"] {
-		t.Fatalf("LLM_API_ENDPOINT = %q, want openai base %q", runtimeEnv["LLM_API_ENDPOINT"], runtimeEnv["OPENAI_BASE_URL"])
-	}
-	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] == "" {
-		t.Fatalf("ANTHROPIC_AUTH_TOKEN is empty")
-	}
-	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] != runtimeEnv["ANTHROPIC_API_KEY"] {
-		t.Fatalf("anthropic token mismatch auth=%q api=%q", runtimeEnv["ANTHROPIC_AUTH_TOKEN"], runtimeEnv["ANTHROPIC_API_KEY"])
-	}
-	if runtimeEnv["ANTHROPIC_AUTH_TOKEN"] == "anthropic-secret" {
-		t.Fatalf("expected managed anthropic facade token, got raw provider token")
-	}
-	if runtimeEnv["AGENT_COMPOSE_SANDBOX_TOKEN"] == runtimeEnv["ANTHROPIC_AUTH_TOKEN"] {
-		t.Fatalf("expected generic sandbox token to remain openai facade token")
-	}
-	if runtimeEnv["AGENT_COMPOSE_SESSION_TOKEN"] != "" {
-		t.Fatalf("AGENT_COMPOSE_SESSION_TOKEN should not be injected")
-	}
-}
-
-func TestSandboxDriverStartSandboxVMIgnoresOptionalClaudeConfigError(t *testing.T) {
-	ctx := context.Background()
-	originalEnsure := ensureSandboxLLMFacadeConfig
-	defer func() { ensureSandboxLLMFacadeConfig = originalEnsure }()
-	ensureSandboxLLMFacadeConfig = func(ctx context.Context, config *appconfig.Config, store runtimefacade.FacadeStore, session *domain.Sandbox, agent, model, source, runID string) (map[string]string, error) {
-		switch agent {
-		case "codex":
-			return map[string]string{
-				"AGENT_COMPOSE_SANDBOX_TOKEN": "openai-token",
-				"LLM_API_ENDPOINT":            "http://agent-compose.test:7410/api/runtime/sandboxes/" + session.Summary.ID + "/llm/openai/v1",
-				"LLM_API_KEY":                 "openai-token",
-				"LLM_API_PROTOCOL":            "responses",
-				"OPENAI_API_KEY":              "openai-token",
-				"OPENAI_BASE_URL":             "http://agent-compose.test:7410/api/runtime/sandboxes/" + session.Summary.ID + "/llm/openai/v1",
-			}, nil
-		case "claude":
-			return nil, domain.ClassifyError(domain.ErrRequired, "anthropic provider is required", nil)
-		default:
-			return nil, errors.New("unexpected agent")
-		}
-	}
-	root := t.TempDir()
-	config := &appconfig.Config{
-		DataRoot:             root,
-		DbAddr:               filepath.Join(root, "data.db"),
-		SandboxRoot:          filepath.Join(root, "sandboxes"),
-		RuntimeDriver:        driverpkg.RuntimeDriverMicrosandbox,
-		MicrosandboxHome:     filepath.Join(root, "microsandbox"),
-		DefaultImage:         "guest:latest",
-		GuestWorkspacePath:   "/workspace",
-		JupyterGuestPort:     8888,
-		JupyterProxyBasePath: "/agent-compose/session",
-		SandboxStartTimeout:  2 * time.Second,
-		RuntimeBaseURL:       "http://agent-compose.test:7410",
-	}
-	store, err := sessionstore.NewWithConfig(config)
-	if err != nil {
-		t.Fatalf("NewWithConfig returned error: %v", err)
-	}
-	di := do.New()
-	do.ProvideValue(di, ctx)
-	do.ProvideValue(di, config)
-	configDB, err := testutil.OpenConfigStore(t, di)
-	if err != nil {
-		t.Fatalf("NewConfigStore returned error: %v", err)
-	}
-	session, err := store.CreateSandbox(ctx, "adapter session", "", driverpkg.RuntimeDriverMicrosandbox, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
-	if err != nil {
-		t.Fatalf("CreateSession returned error: %v", err)
-	}
-	updatedProxyState := domain.ProxyState{
-		ProxyPath:  session.Summary.ProxyPath,
-		GuestHost:  "agent-compose-sandbox-1",
-		HostPort:   39000,
-		GuestPort:  8888,
-		JupyterURL: "http://127.0.0.1:39000/lab?token=secret",
-		Token:      "secret",
-	}
-	var runtimeEnv map[string]string
-	driver := NewSandboxDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{
-		info: domain.SandboxVMInfo{BoxID: "container-1", JupyterURL: updatedProxyState.JupyterURL, ProxyState: &updatedProxyState},
-		ensureHook: func(session *domain.Sandbox) {
-			runtimeEnv = map[string]string{}
-			for _, item := range session.RuntimeEnvItems {
-				runtimeEnv[item.Name] = item.Value
-			}
-		},
-	}})
-
-	if err := driver.StartSandboxVM(ctx, session); err != nil {
-		t.Fatalf("StartSandboxVM returned error: %v", err)
-	}
-	if runtimeEnv["OPENAI_BASE_URL"] == "" || runtimeEnv["OPENAI_API_KEY"] == "" {
-		t.Fatalf("missing openai facade env: %#v", runtimeEnv)
-	}
-	if runtimeEnv["ANTHROPIC_BASE_URL"] != "" || runtimeEnv["ANTHROPIC_AUTH_TOKEN"] != "" || runtimeEnv["ANTHROPIC_API_KEY"] != "" {
-		t.Fatalf("expected optional claude env to be skipped, got %#v", runtimeEnv)
+	if runtimeEnv["ANTHROPIC_API_KEY"] != "" || runtimeEnv["ANTHROPIC_BASE_URL"] != "" {
+		t.Fatalf("driver added an unrelated provider environment: %#v", runtimeEnv)
 	}
 }

--- a/pkg/agentcompose/adapters/session_rpc_bridge.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge.go
@@ -18,6 +18,7 @@ import (
 	appconfig "agent-compose/pkg/config"
 	"agent-compose/pkg/dashboard"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
 	"agent-compose/pkg/llms"
 	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
@@ -39,10 +40,11 @@ type SandboxRPCBridge struct {
 	cap              capabilities.Provider
 	capTokens        *CapabilitySandboxResolver
 	dashboard        *dashboard.Hub
+	agentExecutor    *AgentExecutor
 	lifecycleLocks   *sessions.LifecycleLocks
 }
 
-func NewSandboxRPCBridge(config *appconfig.Config, store *sessionstore.Store, configDB *configstore.ConfigStore, workspaceEnsurer workspaces.WorkspaceEnsurer, driver sessions.SandboxDriver, runtimes RuntimeProvider, bus *loaders.Bus, streams *sessions.StreamBroker, cap capabilities.Provider, capTokens *CapabilitySandboxResolver, dashboard *dashboard.Hub, locks ...*sessions.LifecycleLocks) *SandboxRPCBridge {
+func NewSandboxRPCBridge(config *appconfig.Config, store *sessionstore.Store, configDB *configstore.ConfigStore, workspaceEnsurer workspaces.WorkspaceEnsurer, driver sessions.SandboxDriver, runtimes RuntimeProvider, bus *loaders.Bus, streams *sessions.StreamBroker, cap capabilities.Provider, capTokens *CapabilitySandboxResolver, dashboard *dashboard.Hub, agentExecutor *AgentExecutor, locks ...*sessions.LifecycleLocks) *SandboxRPCBridge {
 	bridge := &SandboxRPCBridge{
 		config:           config,
 		store:            store,
@@ -55,6 +57,7 @@ func NewSandboxRPCBridge(config *appconfig.Config, store *sessionstore.Store, co
 		cap:              cap,
 		capTokens:        capTokens,
 		dashboard:        dashboard,
+		agentExecutor:    agentExecutor,
 	}
 	if len(locks) > 0 {
 		bridge.lifecycleLocks = locks[0]
@@ -78,7 +81,7 @@ func (b *SandboxRPCBridge) CallJSONWithSource(ctx context.Context, method, reque
 		if err := decodeSandboxRPCJSON(requestJSON, &request); err != nil {
 			return "", err
 		}
-		loaded, err := b.createSandbox(ctx, request, source)
+		loaded, err := b.createSandboxWithAgent(ctx, request, source, loaders.SandboxCreationContextFromContext(ctx))
 		if err != nil {
 			return "", err
 		}
@@ -158,13 +161,43 @@ func (b *SandboxRPCBridge) publishLoaderTopic(topic string, payload map[string]a
 }
 
 func (b *SandboxRPCBridge) createSandbox(ctx context.Context, req sandboxRPCCreateRequest, source string) (*domain.Sandbox, error) {
-	tags := append([]domain.SandboxTag(nil), req.Tags...)
+	return b.createSandboxWithAgent(ctx, req, source, loaders.SandboxCreationContext{})
+}
+
+func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandboxRPCCreateRequest, source string, creation loaders.SandboxCreationContext) (*domain.Sandbox, error) {
+	agentConfig := execution.AgentConfig{Provider: domain.NormalizeAgentKind(creation.Provider)}
+	var agentDefinition *domain.AgentDefinition
+	if agentID := strings.TrimSpace(creation.AgentDefinitionID); agentID != "" {
+		definition, err := b.configDB.GetAgentDefinition(ctx, agentID)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("resolve sandbox agent definition %s: %w", agentID, err))
+		}
+		if !definition.Enabled {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sandbox agent definition %s is disabled", agentID))
+		}
+		agentDefinition = &definition
+		agentConfig = execution.AgentConfigFromDefinition(definition, domain.DefaultAgentProvider)
+	}
+	if agentConfig.Provider == "" {
+		agentConfig.Provider = domain.DefaultAgentProvider
+	}
+	tags := sandboxTagsWithoutAgentIdentity(req.Tags)
+	tags = append(tags, domain.SandboxTag{Name: domain.AgentSandboxTagProvider, Value: agentConfig.Provider})
 	envItems := append([]domain.SandboxEnvVar(nil), req.EnvItems...)
 	globalEnvItems, err := b.configDB.ListGlobalEnv(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	envItems = domain.MergeEnvItems(globalEnvItems, envItems)
+	if agentDefinition != nil {
+		envItems = domain.MergeEnvItems(domain.MergeEnvItems(globalEnvItems, agentDefinition.EnvItems), envItems)
+		tags = append(tags,
+			domain.SandboxTag{Name: domain.AgentSandboxTagSource, Value: domain.AgentSandboxTagSourceVal},
+			domain.SandboxTag{Name: domain.AgentSandboxTagID, Value: agentDefinition.ID},
+			domain.SandboxTag{Name: domain.AgentSandboxTagName, Value: agentDefinition.Name},
+		)
+	} else {
+		envItems = domain.MergeEnvItems(globalEnvItems, envItems)
+	}
 	providerEnvItems := envItems
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	capabilityVars, capabilityTags := capabilities.BuildGatewaySandboxVars(capabilities.ProxyTarget(b.cap), req.CapsetIDs)
@@ -200,6 +233,16 @@ func (b *SandboxRPCBridge) createSandbox(ctx context.Context, req sandboxRPCCrea
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	writeCapabilityGuide(ctx, b.cap, b.store, b.streams, session, req.CapsetIDs)
+	if b.agentExecutor == nil {
+		session.Summary.VMStatus = domain.VMStatusFailed
+		_ = b.store.UpdateSandbox(ctx, session)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("agent executor is required"))
+	}
+	if err := b.agentExecutor.PrepareSandboxAgentEnvironment(ctx, session, agentConfig, agentDefinition); err != nil {
+		session.Summary.VMStatus = domain.VMStatusFailed
+		_ = b.store.UpdateSandbox(ctx, session)
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
 	if err := b.driver.StartSandboxVM(ctx, session); err != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = b.store.UpdateSandbox(ctx, session)
@@ -230,6 +273,19 @@ func (b *SandboxRPCBridge) createSandbox(ctx context.Context, req sandboxRPCCrea
 	b.indexCapabilitySandbox(loaded)
 	b.publishLoaderTopic("agent-compose.session.created", loaders.SessionTopicPayload(loaded, source))
 	return loaded, nil
+}
+
+func sandboxTagsWithoutAgentIdentity(tags []domain.SandboxTag) []domain.SandboxTag {
+	filtered := make([]domain.SandboxTag, 0, len(tags))
+	for _, tag := range tags {
+		switch strings.TrimSpace(tag.Name) {
+		case domain.AgentSandboxTagID, domain.AgentSandboxTagName, domain.AgentSandboxTagProvider:
+			continue
+		default:
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
 }
 
 func (b *SandboxRPCBridge) ResumeSandbox(ctx context.Context, sandboxID string) (*domain.Sandbox, error) {
@@ -367,7 +423,8 @@ func (b *SandboxRPCBridge) sessionLifecycle() sessions.Lifecycle {
 		GuideWriter: func(ctx context.Context, session *domain.Sandbox, capsetIDs []string) {
 			writeCapabilityGuide(ctx, b.cap, b.store, b.streams, session, capsetIDs)
 		},
-		Locks: b.lifecycleLocks,
+		PrepareAgentEnvironment: b.agentExecutor.PrepareSandboxAgentEnvironmentFromTags,
+		Locks:                   b.lifecycleLocks,
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_test.go
@@ -18,7 +18,9 @@ import (
 	"agent-compose/pkg/capability"
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
 	"agent-compose/pkg/internal/testutil"
+	"agent-compose/pkg/loaders"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/sessions"
 	"agent-compose/pkg/workspaces"
@@ -166,6 +168,79 @@ func TestSandboxRPCBridgeCallJSONSupportsSessionRPCs(t *testing.T) {
 	}
 	if _, err := bridge.CallJSON(ctx, "GetSession", `{bad json`); err == nil || !strings.Contains(err.Error(), "decode session rpc request") {
 		t.Fatalf("bad json error = %v", err)
+	}
+}
+
+func TestSandboxRPCBridgeCreateSandboxInheritsSchedulerAgentEnvironment(t *testing.T) {
+	ctx := context.Background()
+	bridge, driver := newTestSandboxRPCBridge(t)
+	definition, err := bridge.configDB.CreateAgentDefinition(ctx, domain.AgentDefinition{
+		ID:           "agent-scheduler",
+		Name:         "scheduler-agent",
+		Enabled:      true,
+		Provider:     "codex",
+		Model:        "gpt-scheduler",
+		SystemPrompt: "Scheduler inherited prompt",
+		EnvItems:     []domain.SandboxEnvVar{{Name: "AGENT_ENV", Value: "from-agent"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentDefinition returned error: %v", err)
+	}
+	ctx = loaders.WithSandboxCreationContext(ctx, loaders.SandboxCreationContext{
+		AgentDefinitionID: definition.ID,
+		Provider:          "claude",
+	})
+	responseJSON, err := bridge.CallJSONWithSource(ctx, "CreateSession", `{"title":"scheduler child","envItems":[{"name":"REQUEST_ENV","value":"from-script"}]}`, domain.SandboxTypeScript+":loader-1")
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	var response sandboxRPCResponse
+	if err := json.Unmarshal([]byte(responseJSON), &response); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+	loaded, err := bridge.store.GetSandbox(ctx, response.Session.Summary.SessionID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	env := domain.SandboxEnvMap(loaded.EnvItems)
+	if env["AGENT_ENV"] != "from-agent" || env["REQUEST_ENV"] != "from-script" {
+		t.Fatalf("sandbox env = %#v", env)
+	}
+	if execution.SessionTagValue(loaded.Summary.Tags, domain.AgentSandboxTagID) != definition.ID {
+		t.Fatalf("sandbox tags = %#v", loaded.Summary.Tags)
+	}
+	if execution.SessionTagValue(loaded.Summary.Tags, domain.AgentSandboxTagProvider) != definition.Provider {
+		t.Fatalf("sandbox provider tag = %#v", loaded.Summary.Tags)
+	}
+	if data, err := os.ReadFile(execution.HostAgentSystemPromptPath(loaded)); err != nil || string(data) != definition.SystemPrompt {
+		t.Fatalf("system prompt = %q err=%v", string(data), err)
+	}
+	if len(driver.startSessions) != 1 {
+		t.Fatalf("driver start sessions = %d", len(driver.startSessions))
+	}
+}
+
+func TestSandboxRPCBridgeCreateIgnoresRequestedAgentIdentityTags(t *testing.T) {
+	ctx := context.Background()
+	bridge, _ := newTestSandboxRPCBridge(t)
+
+	loaded, err := bridge.createSandbox(ctx, sandboxRPCCreateRequest{
+		Title: "untrusted agent tags",
+		Tags: []domain.SandboxTag{
+			{Name: domain.AgentSandboxTagID, Value: "forged-agent"},
+			{Name: domain.AgentSandboxTagName, Value: "forged-name"},
+			{Name: domain.AgentSandboxTagProvider, Value: "claude"},
+			{Name: "custom", Value: "preserved"},
+		},
+	}, domain.SandboxTypeManual)
+	if err != nil {
+		t.Fatalf("createSandbox returned error: %v", err)
+	}
+	if execution.SessionTagValue(loaded.Summary.Tags, domain.AgentSandboxTagID) != "" || execution.SessionTagValue(loaded.Summary.Tags, domain.AgentSandboxTagName) != "" {
+		t.Fatalf("sandbox retained requested agent identity: %#v", loaded.Summary.Tags)
+	}
+	if execution.SessionTagValue(loaded.Summary.Tags, domain.AgentSandboxTagProvider) != domain.DefaultAgentProvider || execution.SessionTagValue(loaded.Summary.Tags, "custom") != "preserved" {
+		t.Fatalf("sandbox tags = %#v", loaded.Summary.Tags)
 	}
 }
 
@@ -378,6 +453,8 @@ func newTestSandboxRPCBridge(t *testing.T) (*SandboxRPCBridge, *fakeRPCSandboxDr
 		t.Fatalf("open test storage: %v", err)
 	}
 	driver := &fakeRPCSandboxDriver{}
+	streams := sessions.NewStreamBrokerForTest()
+	agentExecutor := NewAgentExecutor(config, store, streams, NewAgentRunner(config, store, configDB, configDB, nil))
 	return NewSandboxRPCBridge(
 		config,
 		store,
@@ -386,10 +463,11 @@ func newTestSandboxRPCBridge(t *testing.T) (*SandboxRPCBridge, *fakeRPCSandboxDr
 		driver,
 		nil,
 		nil,
-		sessions.NewStreamBrokerForTest(),
+		streams,
 		testCapabilityProvider{},
 		nil,
 		nil,
+		agentExecutor,
 	), driver
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge_workspace_failure_retry_integration_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_workspace_failure_retry_integration_test.go
@@ -168,6 +168,11 @@ func TestIntegrationSandboxRPCBridgeGitWorkspaceProvisioningFailureRetry(t *test
 func TestIntegrationSandboxRPCBridgeRuntimeStartFailureRetryPreservesReadyWorkspace(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
+	bridge.config.RuntimeBaseURL = "http://agent-compose.test:7410"
+	bridge.config.LLMAPIEndpoint = "https://llm.example.test/v1"
+	bridge.config.LLMAPIKey = "provider-key"
+	bridge.config.LLMModel = "gpt-retry"
+	bridge.config.LLMAPIProtocol = "responses"
 	recordingStore := installIntegrationRecordingProvisioner(bridge)
 
 	const workspaceID = "runtime-failure-ready-retry"
@@ -192,8 +197,10 @@ func TestIntegrationSandboxRPCBridgeRuntimeStartFailureRetryPreservesReadyWorksp
 	runtimeErr := errors.New("injected runtime start failure")
 	driver.startErr = runtimeErr
 	var firstStartSandboxID string
+	var firstStartToken string
 	driver.onStart = func(sandbox *domain.Sandbox) {
 		firstStartSandboxID = sandbox.Summary.ID
+		firstStartToken = domain.SandboxEnvMap(sandbox.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]
 		integrationAssertPersistedReady(t, ctx, bridge, sandbox.Summary.ID, nil)
 	}
 	_, err = bridge.createSandbox(ctx, sandboxRPCCreateRequest{
@@ -205,6 +212,9 @@ func TestIntegrationSandboxRPCBridgeRuntimeStartFailureRetryPreservesReadyWorksp
 	}
 	if firstStartSandboxID == "" {
 		t.Fatal("runtime driver was not called after workspace became ready")
+	}
+	if firstStartToken == "" {
+		t.Fatal("first runtime start did not receive an agent token")
 	}
 	failed, err := bridge.store.GetSandbox(ctx, firstStartSandboxID)
 	if err != nil {
@@ -234,7 +244,7 @@ func TestIntegrationSandboxRPCBridgeRuntimeStartFailureRetryPreservesReadyWorksp
 		t.Fatalf("replace file workspace source with hostile file: %v", err)
 	}
 	driver.startErr = nil
-	driver.onStart = integrationPersistedReadyStartCheck(t, ctx, bridge, failed.Summary.ID, func(persisted *domain.Sandbox) {
+	persistedReadyCheck := integrationPersistedReadyStartCheck(t, ctx, bridge, failed.Summary.ID, func(persisted *domain.Sandbox) {
 		if !persisted.WorkspaceProvisioning.UpdatedAt.Equal(readyUpdatedAt) {
 			t.Errorf("ready timestamp at runtime retry start = %s, want %s", persisted.WorkspaceProvisioning.UpdatedAt, readyUpdatedAt)
 		}
@@ -250,6 +260,11 @@ func TestIntegrationSandboxRPCBridgeRuntimeStartFailureRetryPreservesReadyWorksp
 			t.Errorf("ready workspace changed before runtime retry start:\n got: %#v\nwant: %#v", atStart, beforeRetry)
 		}
 	})
+	var retryToken string
+	driver.onStart = func(sandbox *domain.Sandbox) {
+		persistedReadyCheck(sandbox)
+		retryToken = domain.SandboxEnvMap(sandbox.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	}
 
 	if _, err := bridge.ResumeSandbox(ctx, failed.Summary.ID); err != nil {
 		t.Fatalf("ResumeSession after runtime start failure returned error: %v", err)
@@ -274,6 +289,9 @@ func TestIntegrationSandboxRPCBridgeRuntimeStartFailureRetryPreservesReadyWorksp
 	}
 	if got := len(driver.startCalls); got != 2 {
 		t.Fatalf("driver start count across runtime failure/retry = %d, want 2 attempts", got)
+	}
+	if retryToken == "" || retryToken == firstStartToken {
+		t.Fatalf("runtime retry token = %q, want a newly prepared token distinct from first start", retryToken)
 	}
 	if got, want := recordingStore.statusHistory(resumed.Summary.ID), []string{domain.SandboxWorkspaceProvisioningStatusReady}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Provisioner writes across runtime-only retry = %#v, want unchanged %#v", got, want)

--- a/pkg/agentcompose/adapters/workspace_ensurer_injection_test.go
+++ b/pkg/agentcompose/adapters/workspace_ensurer_injection_test.go
@@ -20,8 +20,8 @@ func TestWorkspaceEnsurerConstructorDependencies(t *testing.T) {
 	t.Parallel()
 
 	ensurer := &constructorWorkspaceEnsurer{}
-	bridge := NewSandboxRPCBridge(nil, nil, nil, ensurer, nil, nil, nil, nil, nil, nil, nil)
-	runner := NewLoaderSandboxRunner(nil, nil, nil, ensurer, nil, nil, nil, nil, nil, nil)
+	bridge := NewSandboxRPCBridge(nil, nil, nil, ensurer, nil, nil, nil, nil, nil, nil, nil, nil)
+	runner := NewLoaderSandboxRunner(nil, nil, nil, ensurer, nil, nil, nil, nil, nil, nil, nil)
 
 	if bridge.workspaceEnsurer != ensurer {
 		t.Fatalf("SandboxRPCBridge workspace ensurer = %p, want %p", bridge.workspaceEnsurer, ensurer)

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -406,6 +406,7 @@ func NewLoaderSandboxRunner(di do.Injector) (*adapters.LoaderSandboxRunner, erro
 		do.MustInvoke[*sessions.StreamBroker](di),
 		do.MustInvoke[*loaders.Bus](di),
 		do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
+		do.MustInvoke[*adapters.AgentExecutor](di),
 		do.MustInvoke[*sessions.LifecycleLocks](di),
 	), nil
 }
@@ -424,6 +425,7 @@ func NewSandboxRPCBridge(di do.Injector) (*adapters.SandboxRPCBridge, error) {
 		do.MustInvoke[capabilities.Provider](di),
 		do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
 		dashboard,
+		do.MustInvoke[*adapters.AgentExecutor](di),
 		do.MustInvoke[*sessions.LifecycleLocks](di),
 	), nil
 }

--- a/pkg/loaders/run_host.go
+++ b/pkg/loaders/run_host.go
@@ -62,6 +62,22 @@ type HostSessionRPC interface {
 	CallJSONWithSource(ctx context.Context, method, requestJSON, source string) (string, error)
 }
 
+type SandboxCreationContext struct {
+	AgentDefinitionID string
+	Provider          string
+}
+
+type sandboxCreationContextKey struct{}
+
+func WithSandboxCreationContext(ctx context.Context, value SandboxCreationContext) context.Context {
+	return context.WithValue(ctx, sandboxCreationContextKey{}, value)
+}
+
+func SandboxCreationContextFromContext(ctx context.Context) SandboxCreationContext {
+	value, _ := ctx.Value(sandboxCreationContextKey{}).(SandboxCreationContext)
+	return value
+}
+
 type HostPublisher interface {
 	Publish(topic string, payload map[string]any)
 }
@@ -150,6 +166,10 @@ func (h *RuntimeHost) CallSessionRPC(ctx context.Context, method, requestJSON st
 	}
 	method = strings.TrimSpace(method)
 	requestJSON = strings.TrimSpace(requestJSON)
+	ctx = WithSandboxCreationContext(ctx, SandboxCreationContext{
+		AgentDefinitionID: strings.TrimSpace(h.loader.Summary.AgentID),
+		Provider:          domain.NormalizeAgentKind(h.loader.Summary.DefaultAgent),
+	})
 	responseJSON, err := h.deps.SessionRPC.CallJSONWithSource(ctx, method, requestJSON, domain.SandboxTypeScript+":"+h.loader.Summary.ID)
 	linkedSandboxID := h.linkedSandboxID(method, requestJSON, responseJSON)
 	if err != nil {

--- a/pkg/loaders/run_host_test.go
+++ b/pkg/loaders/run_host_test.go
@@ -112,6 +112,9 @@ func TestRuntimeHostAgentCommandLLMAndSessionRPC(t *testing.T) {
 	if responseJSON != rpc.response || rpc.source != domain.SandboxTypeScript+":"+loader.Summary.ID {
 		t.Fatalf("rpc response/source = %q/%q", responseJSON, rpc.source)
 	}
+	if rpc.creation.Provider != "gemini" || rpc.creation.AgentDefinitionID != "" {
+		t.Fatalf("rpc sandbox creation context = %#v", rpc.creation)
+	}
 	if !store.containsLink("sandbox-rpc", "sandbox_rpc_completed") {
 		t.Fatalf("sandbox links = %#v", store.links)
 	}
@@ -576,11 +579,13 @@ func (l *hostLLMFake) Generate(_ context.Context, prompt, _, _ string) (domain.L
 type hostRPCFake struct {
 	response string
 	source   string
+	creation loaders.SandboxCreationContext
 	err      error
 }
 
-func (r *hostRPCFake) CallJSONWithSource(_ context.Context, _, _, source string) (string, error) {
+func (r *hostRPCFake) CallJSONWithSource(ctx context.Context, _, _, source string) (string, error) {
 	r.source = source
+	r.creation = loaders.SandboxCreationContextFromContext(ctx)
 	return r.response, r.err
 }
 

--- a/pkg/model/agent_model.go
+++ b/pkg/model/agent_model.go
@@ -16,6 +16,7 @@ const (
 	AgentSandboxTagSourceVal = "agent"
 	AgentSandboxTagID        = "agent_id"
 	AgentSandboxTagName      = "agent_name"
+	AgentSandboxTagProvider  = "agent_provider"
 )
 
 type AgentDefinition struct {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -38,6 +38,8 @@ var (
 )
 
 type AgentExecutor interface {
+	PrepareSandboxAgentEnvironment(context.Context, *domain.Sandbox, execution.AgentConfig, *domain.AgentDefinition) error
+	PrepareSandboxAgentEnvironmentFromTags(context.Context, *domain.Sandbox) error
 	ExecuteAgentRequest(context.Context, *domain.Sandbox, execution.ExecuteAgentRequest) (domain.NotebookCell, domain.SandboxEvent, domain.SandboxEvent, error)
 }
 
@@ -1980,6 +1982,15 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 		return SandboxResult{}, fmt.Errorf("hash sticky project sandbox configuration: %w", err)
 	}
 	tags := SandboxTags(run)
+	agentConfig := execution.AgentConfig{Provider: domain.DefaultAgentProvider}
+	if prepared.AgentDefinition != nil {
+		agentConfig = execution.AgentConfigFromDefinition(*prepared.AgentDefinition, domain.DefaultAgentProvider)
+		tags = append(tags,
+			domain.SandboxTag{Name: domain.AgentSandboxTagID, Value: prepared.AgentDefinition.ID},
+			domain.SandboxTag{Name: domain.AgentSandboxTagName, Value: prepared.AgentDefinition.Name},
+		)
+	}
+	tags = append(tags, domain.SandboxTag{Name: domain.AgentSandboxTagProvider, Value: agentConfig.Provider})
 	capabilityVars, capabilityTags := capabilities.BuildGatewaySandboxVars(capabilities.ProxyTarget(c.cap), prepared.CapsetIDs)
 	tags = append(tags, capabilityTags...)
 	bindingStore, hasBindingStore := c.configDB.(stickyBindingStore)
@@ -2118,7 +2129,20 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 		return SandboxResult{}, err
 	}
 	sandbox.ProviderEnvItems = prepared.ProviderEnvItems
-	if err := c.startProjectRunSandbox(ctx, sandbox, "sandbox.created", "sandbox started for project run"); err != nil {
+	if err := c.ensureProjectRunSandboxWorkspace(ctx, sandbox); err != nil {
+		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
+	}
+	if c.executor == nil {
+		sandbox.Summary.VMStatus = domain.VMStatusFailed
+		_ = c.store.UpdateSandbox(ctx, sandbox)
+		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, fmt.Errorf("agent executor is required")
+	}
+	if err := c.executor.PrepareSandboxAgentEnvironment(ctx, sandbox, agentConfig, prepared.AgentDefinition); err != nil {
+		sandbox.Summary.VMStatus = domain.VMStatusFailed
+		_ = c.store.UpdateSandbox(ctx, sandbox)
+		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
+	}
+	if err := c.startProjectRunSandboxRuntime(ctx, sandbox, "sandbox.created", "sandbox started for project run"); err != nil {
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
 	}
 	if stickyLoaderID != "" {
@@ -2234,11 +2258,44 @@ func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain
 	if sandbox.Summary.VMStatus == domain.VMStatusDeleting {
 		return fmt.Errorf("sandbox %s is being deleted", sandbox.Summary.ID)
 	}
+	if err := c.ensureProjectRunSandboxWorkspace(ctx, sandbox); err != nil {
+		return err
+	}
+	if err := c.prepareFreshStartAgentEnvironment(ctx, sandbox); err != nil {
+		sandbox.Summary.VMStatus = domain.VMStatusFailed
+		_ = c.store.UpdateSandbox(ctx, sandbox)
+		return err
+	}
+	return c.startProjectRunSandboxRuntime(ctx, sandbox, eventType, eventMessage)
+}
+
+func (c *Controller) ensureProjectRunSandboxWorkspace(ctx context.Context, sandbox *domain.Sandbox) error {
 	if err := c.workspaceEnsurer.Ensure(ctx, sandbox); err != nil {
 		sandbox.Summary.VMStatus = domain.VMStatusFailed
 		_ = c.store.UpdateSandbox(ctx, sandbox)
 		return err
 	}
+	return nil
+}
+
+func (c *Controller) prepareFreshStartAgentEnvironment(ctx context.Context, sandbox *domain.Sandbox) error {
+	if sandbox.Summary.VMStatus == domain.VMStatusRunning {
+		return nil
+	}
+	vmState, err := c.store.GetVMState(sandbox.Summary.ID)
+	if err != nil {
+		return err
+	}
+	if !vmState.StartedAt.IsZero() {
+		return nil
+	}
+	if c.executor == nil {
+		return fmt.Errorf("agent executor is required")
+	}
+	return c.executor.PrepareSandboxAgentEnvironmentFromTags(ctx, sandbox)
+}
+
+func (c *Controller) startProjectRunSandboxRuntime(ctx context.Context, sandbox *domain.Sandbox, eventType, eventMessage string) error {
 	writeCapabilityGuide(ctx, c.cap, c.store, c.streams, sandbox, capabilities.SandboxCapsets(sandbox))
 	if sandbox.Summary.VMStatus != domain.VMStatusRunning {
 		if err := c.driver.StartSandboxVM(ctx, sandbox); err != nil {

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -545,12 +545,14 @@ func TestRunsControllerRunProjectAgentCommandWorkflow(t *testing.T) {
 		runs:     map[string]domain.ProjectRunRecord{},
 	}
 	runtime := &fakeControllerRuntime{}
+	executor := &fakeControllerExecutor{}
 	controller := NewController(ControllerDependencies{
 		Config:           config,
 		Store:            store,
 		ConfigDB:         configDB,
 		WorkspaceEnsurer: &controllerWorkspaceEnsurer{},
 		Driver:           &fakeControllerDriver{store: store},
+		Executor:         executor,
 		Runtime: func(*domain.Sandbox) (Runtime, error) {
 			return runtime, nil
 		},
@@ -576,6 +578,16 @@ func TestRunsControllerRunProjectAgentCommandWorkflow(t *testing.T) {
 	})
 	if err != nil || execErr != nil {
 		t.Fatalf("RunProjectAgent command err=%v execErr=%v run=%#v", err, execErr, run)
+	}
+	if executor.prepareCalls != 1 || executor.preparedAgent.Provider != "codex" || executor.preparedDefinition == nil || executor.preparedDefinition.ID != "agent-1" {
+		t.Fatalf("sandbox agent preparation = calls:%d agent:%#v definition:%#v", executor.prepareCalls, executor.preparedAgent, executor.preparedDefinition)
+	}
+	sandbox, err := store.GetSandbox(ctx, run.SandboxID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if execution.SessionTagValue(sandbox.Summary.Tags, domain.AgentSandboxTagID) != "agent-1" || execution.SessionTagValue(sandbox.Summary.Tags, domain.AgentSandboxTagProvider) != "codex" {
+		t.Fatalf("sandbox agent tags = %#v", sandbox.Summary.Tags)
 	}
 	if run.Status != domain.ProjectRunStatusSucceeded || run.Output != "command output\n" || run.ArtifactsDir == "" || run.LogsPath == "" {
 		t.Fatalf("command run = %#v", run)
@@ -629,6 +641,57 @@ func TestRunsControllerRunProjectAgentCommandWorkflow(t *testing.T) {
 	}
 }
 
+func TestRunsControllerExistingSandboxDoesNotRepeatAgentEnvironmentPreparation(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	sandbox, err := fixture.store.CreateSandbox(fixture.ctx, "existing", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandbox.Summary.VMStatus = domain.VMStatusRunning
+	if err := fixture.store.UpdateSandbox(fixture.ctx, sandbox); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, domain.ProjectRunRecord{
+		RunID: "run-existing", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", Driver: driverpkg.RuntimeDriverDocker, ImageRef: "guest:latest",
+	}, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
+	if err != nil {
+		t.Fatalf("ensureProjectRunSandbox returned error: %v", err)
+	}
+	if result.Created || result.Sandbox == nil || result.Sandbox.Summary.ID != sandbox.Summary.ID {
+		t.Fatalf("existing sandbox result = %#v", result)
+	}
+	if fixture.executor.prepareCalls != 0 || fixture.executor.prepareFromTagsCalls != 0 {
+		t.Fatalf("existing sandbox preparation calls = direct:%d tags:%d", fixture.executor.prepareCalls, fixture.executor.prepareFromTagsCalls)
+	}
+}
+
+func TestRunsControllerFailedFreshSandboxRetryPreparesAgentEnvironment(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	sandbox, err := fixture.store.CreateSandbox(fixture.ctx, "failed fresh start", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeManual, nil, nil, []domain.SandboxTag{
+		{Name: domain.AgentSandboxTagProvider, Value: "codex"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandbox.Summary.VMStatus = domain.VMStatusFailed
+	if err := fixture.store.UpdateSandbox(fixture.ctx, sandbox); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+
+	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, domain.ProjectRunRecord{
+		RunID: "run-retry", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", Driver: driverpkg.RuntimeDriverDocker, ImageRef: "guest:latest",
+	}, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
+	if err != nil {
+		t.Fatalf("ensureProjectRunSandbox returned error: %v", err)
+	}
+	if result.Sandbox == nil || result.Sandbox.Summary.VMStatus != domain.VMStatusRunning {
+		t.Fatalf("retried sandbox = %#v", result.Sandbox)
+	}
+	if fixture.executor.prepareFromTagsCalls != 1 {
+		t.Fatalf("tag-based agent preparation calls = %d, want 1", fixture.executor.prepareFromTagsCalls)
+	}
+}
+
 func TestRunsControllerRunProjectAgentCommandNonZeroExitPreservesOutput(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -668,6 +731,7 @@ func TestRunsControllerRunProjectAgentCommandNonZeroExitPreservesOutput(t *testi
 		ConfigDB:         configDB,
 		WorkspaceEnsurer: &controllerWorkspaceEnsurer{},
 		Driver:           &fakeControllerDriver{store: store},
+		Executor:         &fakeControllerExecutor{},
 		Runtime: func(*domain.Sandbox) (Runtime, error) {
 			return runtime, nil
 		},
@@ -1385,6 +1449,7 @@ func newControllerRunFixture(t *testing.T) *controllerRunFixture {
 		Images:           fakeControllerImages{},
 		LoaderEngine:     &loaders.QJSLoaderEngine{},
 		Dashboard:        dashboard,
+		LifecycleLocks:   sessions.NewLifecycleLocks(),
 	})
 	return &controllerRunFixture{
 		ctx:        ctx,
@@ -2582,9 +2647,26 @@ func (d *fakeControllerDriver) RemoveSandboxVM(context.Context, *domain.Sandbox)
 }
 
 type fakeControllerExecutor struct {
-	request execution.ExecuteAgentRequest
-	cell    domain.NotebookCell
-	execErr error
+	request              execution.ExecuteAgentRequest
+	cell                 domain.NotebookCell
+	execErr              error
+	prepareCalls         int
+	prepareFromTagsCalls int
+	preparedAgent        execution.AgentConfig
+	preparedDefinition   *domain.AgentDefinition
+	prepareErr           error
+}
+
+func (e *fakeControllerExecutor) PrepareSandboxAgentEnvironment(_ context.Context, _ *domain.Sandbox, agent execution.AgentConfig, definition *domain.AgentDefinition) error {
+	e.prepareCalls++
+	e.preparedAgent = agent
+	e.preparedDefinition = definition
+	return e.prepareErr
+}
+
+func (e *fakeControllerExecutor) PrepareSandboxAgentEnvironmentFromTags(_ context.Context, _ *domain.Sandbox) error {
+	e.prepareFromTagsCalls++
+	return e.prepareErr
 }
 
 func (e *fakeControllerExecutor) ExecuteAgentRequest(_ context.Context, _ *domain.Sandbox, req execution.ExecuteAgentRequest) (domain.NotebookCell, domain.SandboxEvent, domain.SandboxEvent, error) {
@@ -2676,6 +2758,7 @@ func newTestRunAttachController(t *testing.T, frames []driverpkg.RuntimeOutputFr
 		ConfigDB:         configDB,
 		WorkspaceEnsurer: &controllerWorkspaceEnsurer{},
 		Driver:           &fakeControllerDriver{store: store},
+		Executor:         &fakeControllerExecutor{},
 		Runtime: func(*domain.Sandbox) (Runtime, error) {
 			return runtime, nil
 		},

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -31,6 +31,7 @@ type WorkspaceResolver interface {
 type Preparation struct {
 	EnvItems         []domain.SandboxEnvVar
 	ProviderEnvItems []domain.SandboxEnvVar
+	AgentDefinition  *domain.AgentDefinition
 	CapsetIDs        []string
 	WorkspaceConfig  *domain.WorkspaceConfig
 	Workspace        *domain.SandboxWorkspace
@@ -79,6 +80,7 @@ func PrepareProjectRun(ctx context.Context, store PreparationStore, resolver Wor
 	prepared := Preparation{
 		EnvItems:         envItems,
 		ProviderEnvItems: providerEnvItems,
+		AgentDefinition:  &agent,
 		CapsetIDs:        capabilities.NormalizeCapsetIDs(agent.CapsetIDs),
 		Volumes:          agent.Volumes,
 		ProjectRoot:      ProjectRoot(project),

--- a/pkg/runs/project_workspace_resume_integration_test.go
+++ b/pkg/runs/project_workspace_resume_integration_test.go
@@ -307,6 +307,14 @@ func upsertProjectWorkspaceAgent(t *testing.T, ctx context.Context, store *confi
 
 type projectWorkspaceExecutor struct{}
 
+func (projectWorkspaceExecutor) PrepareSandboxAgentEnvironment(_ context.Context, session *domain.Sandbox, _ execution.AgentConfig, _ *domain.AgentDefinition) error {
+	return nil
+}
+
+func (projectWorkspaceExecutor) PrepareSandboxAgentEnvironmentFromTags(context.Context, *domain.Sandbox) error {
+	return nil
+}
+
 type projectWorkspaceImages struct{}
 
 func (projectWorkspaceImages) ListImages(context.Context, images.ListRequest) (images.ListResult, error) {

--- a/pkg/sessions/lifecycle.go
+++ b/pkg/sessions/lifecycle.go
@@ -49,16 +49,17 @@ type LifecycleNotifier interface {
 type CapabilityGuideWriter func(context.Context, *domain.Sandbox, []string)
 
 type Lifecycle struct {
-	Config           *appconfig.Config
-	Store            LifecycleStore
-	Workspace        workspaces.Store
-	WorkspaceEnsurer workspaces.WorkspaceEnsurer
-	Driver           SandboxDriver
-	Liveness         RuntimeLivenessProvider
-	TokenRevoker     FacadeTokenRevoker
-	Notifier         LifecycleNotifier
-	GuideWriter      CapabilityGuideWriter
-	Locks            *LifecycleLocks
+	Config                  *appconfig.Config
+	Store                   LifecycleStore
+	Workspace               workspaces.Store
+	WorkspaceEnsurer        workspaces.WorkspaceEnsurer
+	Driver                  SandboxDriver
+	Liveness                RuntimeLivenessProvider
+	TokenRevoker            FacadeTokenRevoker
+	Notifier                LifecycleNotifier
+	GuideWriter             CapabilityGuideWriter
+	PrepareAgentEnvironment func(context.Context, *domain.Sandbox) error
+	Locks                   *LifecycleLocks
 }
 
 func (l Lifecycle) validateSandboxRuntime(session *domain.Sandbox) error {
@@ -160,6 +161,11 @@ func (l Lifecycle) EnsureProxyReady(ctx context.Context, sessionID string) (*dom
 		_ = l.Store.UpdateSandbox(ctx, session)
 		return nil, domain.ProxyState{}, err
 	}
+	if err := l.prepareFreshStartAgentEnvironment(startCtx, session); err != nil {
+		session.Summary.VMStatus = domain.VMStatusFailed
+		_ = l.Store.UpdateSandbox(ctx, session)
+		return nil, domain.ProxyState{}, err
+	}
 	if err := l.Driver.StartSandboxVM(startCtx, session); err != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = l.Store.UpdateSandbox(ctx, session)
@@ -203,6 +209,11 @@ func (l Lifecycle) ResumeLoaded(ctx context.Context, session *domain.Sandbox, ca
 	if err := l.ensureWorkspace(ctx, session); err != nil {
 		return nil, err
 	}
+	if err := l.prepareFreshStartAgentEnvironment(ctx, session); err != nil {
+		session.Summary.VMStatus = domain.VMStatusFailed
+		_ = l.Store.UpdateSandbox(ctx, session)
+		return nil, err
+	}
 	if l.GuideWriter != nil {
 		l.GuideWriter(ctx, session, capsetIDs)
 	}
@@ -239,6 +250,20 @@ func (l Lifecycle) ensureWorkspace(ctx context.Context, session *domain.Sandbox)
 		return fmt.Errorf("workspace ensurer is not configured")
 	}
 	return l.WorkspaceEnsurer.Ensure(ctx, session)
+}
+
+func (l Lifecycle) prepareFreshStartAgentEnvironment(ctx context.Context, session *domain.Sandbox) error {
+	if l.PrepareAgentEnvironment == nil {
+		return nil
+	}
+	vmState, err := l.Store.GetVMState(session.Summary.ID)
+	if err != nil {
+		return err
+	}
+	if !vmState.StartedAt.IsZero() {
+		return nil
+	}
+	return l.PrepareAgentEnvironment(ctx, session)
 }
 
 func (l Lifecycle) StopLoaded(ctx context.Context, session *domain.Sandbox) (*domain.Sandbox, bool, error) {

--- a/pkg/sessions/lifecycle_coverage_test.go
+++ b/pkg/sessions/lifecycle_coverage_test.go
@@ -185,19 +185,56 @@ func TestLifecycleEnsureProxyReadyBranches(t *testing.T) {
 		session := lifecycleTestSession("session-start", driverpkg.RuntimeDriverDocker, domain.VMStatusStopped)
 		proxyState := domain.ProxyState{Enabled: true, HostPort: unusedTCPPort(t), GuestPort: 8888, ProxyPath: "/lab"}
 		store := &fakeLifecycleStore{session: session, proxyState: proxyState}
-		driver := &recordingSandboxDriver{}
+		driver := &recordingSandboxDriver{onStart: func(started *domain.Sandbox) {
+			if got := domain.SandboxEnvMap(started.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]; got != "retry-token" {
+				t.Fatalf("runtime token = %q, want retry-token", got)
+			}
+		}}
+		prepareCalls := 0
 		lifecycle := Lifecycle{
 			Config:           &appconfig.Config{SandboxStartTimeout: time.Second},
 			Store:            store,
 			WorkspaceEnsurer: &recordingWorkspaceEnsurer{},
 			Driver:           driver,
+			PrepareAgentEnvironment: func(_ context.Context, sandbox *domain.Sandbox) error {
+				prepareCalls++
+				sandbox.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "AGENT_COMPOSE_SANDBOX_TOKEN", Value: "retry-token"}}
+				return nil
+			},
 		}
 		loaded, loadedProxy, err := lifecycle.EnsureProxyReady(context.Background(), session.Summary.ID)
 		if err != nil {
 			t.Fatalf("EnsureProxyReady returned error: %v", err)
 		}
-		if !driver.started || loaded.Summary.VMStatus != domain.VMStatusRunning || loadedProxy.ProxyPath != "/lab" {
+		if prepareCalls != 1 || !driver.started || loaded.Summary.VMStatus != domain.VMStatusRunning || loadedProxy.ProxyPath != "/lab" {
 			t.Fatalf("driver/loaded/proxy = %v/%#v/%#v", driver.started, loaded, loadedProxy)
+		}
+	})
+
+	t.Run("previously started sandbox skips agent preparation", func(t *testing.T) {
+		session := lifecycleTestSession("session-running-unreachable", driverpkg.RuntimeDriverDocker, domain.VMStatusRunning)
+		store := &fakeLifecycleStore{
+			session:    session,
+			vmState:    domain.VMState{StartedAt: time.Now().UTC()},
+			proxyState: domain.ProxyState{Enabled: true, HostPort: unusedTCPPort(t), GuestPort: 8888},
+		}
+		prepareCalls := 0
+		lifecycle := Lifecycle{
+			Config:           &appconfig.Config{SandboxStartTimeout: time.Second},
+			Store:            store,
+			WorkspaceEnsurer: &recordingWorkspaceEnsurer{},
+			Driver:           &recordingSandboxDriver{},
+			PrepareAgentEnvironment: func(context.Context, *domain.Sandbox) error {
+				prepareCalls++
+				return nil
+			},
+		}
+
+		if _, _, err := lifecycle.EnsureProxyReady(context.Background(), session.Summary.ID); err != nil {
+			t.Fatalf("EnsureProxyReady returned error: %v", err)
+		}
+		if prepareCalls != 0 {
+			t.Fatalf("agent preparation calls = %d, want 0", prepareCalls)
 		}
 	})
 }
@@ -376,6 +413,11 @@ func TestLifecycleResumeLoadedWorkspaceEnsurerOrdering(t *testing.T) {
 		WorkspaceEnsurer: ensurer,
 		Driver:           driver,
 		Notifier:         notifier,
+		PrepareAgentEnvironment: func(_ context.Context, sandbox *domain.Sandbox) error {
+			order = append(order, "agent.prepare")
+			sandbox.RuntimeEnvItems = []domain.SandboxEnvVar{{Name: "AGENT_COMPOSE_SANDBOX_TOKEN", Value: "retry-token"}}
+			return nil
+		},
 		GuideWriter: func(context.Context, *domain.Sandbox, []string) {
 			order = append(order, "guide")
 		},
@@ -391,7 +433,7 @@ func TestLifecycleResumeLoadedWorkspaceEnsurerOrdering(t *testing.T) {
 	if ensurer.calls != 1 || driver.calls != 1 {
 		t.Fatalf("ensure/start calls = %d/%d, want 1/1", ensurer.calls, driver.calls)
 	}
-	wantOrder := "ensure,guide,driver.start,store.update,notify.updated,notify.dashboard,event.persist,notify.event"
+	wantOrder := "ensure,agent.prepare,guide,driver.start,store.update,notify.updated,notify.dashboard,event.persist,notify.event"
 	if got := strings.Join(order, ","); got != wantOrder {
 		t.Fatalf("call order = %q, want %q", got, wantOrder)
 	}
@@ -641,14 +683,18 @@ type recordingSandboxDriver struct {
 	started  bool
 	calls    int
 	order    *[]string
+	onStart  func(*domain.Sandbox)
 	startErr error
 }
 
-func (d *recordingSandboxDriver) StartSandboxVM(context.Context, *domain.Sandbox) error {
+func (d *recordingSandboxDriver) StartSandboxVM(_ context.Context, sandbox *domain.Sandbox) error {
 	d.started = true
 	d.calls++
 	if d.order != nil {
 		*d.order = append(*d.order, "driver.start")
+	}
+	if d.onStart != nil {
+		d.onStart(sandbox)
 	}
 	return d.startErr
 }


### PR DESCRIPTION
## Summary

- Prepare a fresh sandbox with the selected agent's system prompt, skills, unified and provider-native MCP configuration, and LLM facade environment before its first VM start.
- Apply the same initialization to project runs, loader sandboxes, and scheduler-created child sandboxes.
- Persist the selected agent metadata so failed fresh-start retries can rebuild transient runtime environment, while normal stop/resume continues to reuse the existing sandbox environment.
- Keep sandbox-scoped facade credentials valid for a running VM and revoke them only when a fresh start fails before the runtime is established or when the sandbox is removed.

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `task test GO_BUILD_CACHE_DIR="$GOCACHE"` (with `GOFLAGS=-buildvcs=false` exported in an isolated shell and product configuration variables cleared as documented)
- Coverage: Unit 74.49%, Integration 61.11%, E2E 61.43%, Combined 78.88%

## Checklist

- [x] Documentation reviewed; no configuration, schema, or CLI syntax changes require updates.
- [x] Tests added or updated for the new sandbox initialization and retry behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
