### PR TITLE
fix(llms): preserve Responses assistant output text

### DIFF
--- a/pkg/llms/facade_bridge.go
+++ b/pkg/llms/facade_bridge.go
@@ -53,13 +53,8 @@ func normalizeRuntimeRawResponsesInput(payload map[string]json.RawMessage, gener
 		return false
 	}
 	var changed bool
-	defaultTextType := "input_text"
-	if genericTextParts {
-		defaultTextType = "text"
-	}
-	textTypeJSON, _ := json.Marshal(defaultTextType)
 	for _, item := range items {
-		if normalizeRuntimeRawResponsesContent(item, textTypeJSON) {
+		if normalizeRuntimeRawResponsesContent(item, genericTextParts) {
 			changed = true
 		}
 	}
@@ -74,7 +69,7 @@ func normalizeRuntimeRawResponsesInput(payload map[string]json.RawMessage, gener
 	return true
 }
 
-func normalizeRuntimeRawResponsesContent(item map[string]json.RawMessage, textType []byte) bool {
+func normalizeRuntimeRawResponsesContent(item map[string]json.RawMessage, genericTextParts bool) bool {
 	raw := item["content"]
 	if len(raw) == 0 || string(raw) == "null" {
 		return false
@@ -83,18 +78,30 @@ func normalizeRuntimeRawResponsesContent(item map[string]json.RawMessage, textTy
 	if err := json.Unmarshal(raw, &parts); err != nil {
 		return false
 	}
+	textType := "input_text"
+	if genericTextParts {
+		textType = "text"
+	} else {
+		var role string
+		if err := json.Unmarshal(item["role"], &role); err == nil && role == string(protocolbridge.RoleAssistant) {
+			textType = "output_text"
+		}
+	}
+	textTypeJSON, _ := json.Marshal(textType)
 	var changed bool
 	for _, part := range parts {
 		if len(part["text"]) == 0 || string(part["text"]) == "null" {
 			continue
 		}
 		if len(part["type"]) == 0 || string(part["type"]) == "null" {
-			part["type"] = textType
+			part["type"] = textTypeJSON
 			changed = true
 			continue
 		}
-		if string(part["type"]) == `"output_text"` || (string(textType) == `"text"` && string(part["type"]) == `"input_text"`) {
-			part["type"] = textType
+		var partType string
+		if err := json.Unmarshal(part["type"], &partType); err == nil &&
+			(partType == "input_text" || partType == "output_text") && partType != textType {
+			part["type"] = textTypeJSON
 			changed = true
 		}
 	}

--- a/pkg/llms/facade_bridge_test.go
+++ b/pkg/llms/facade_bridge_test.go
@@ -7,13 +7,13 @@ import (
 	protocolbridge "github.com/chaitin/ai-api-protocol-bridge"
 )
 
-func TestRewriteRuntimeRequestForUpstreamNormalizesResumedAssistantText(t *testing.T) {
+func TestRewriteRuntimeRequestForUpstreamPreservesAssistantTextAfterToolCall(t *testing.T) {
 	body := []byte(`{
-		"model":"old",
 		"input":[
-			{"role":"user","content":[{"type":"input_text","text":"remember kiwi"}]},
-			{"role":"assistant","content":[{"type":"output_text","text":"I will remember kiwi"}]},
-			{"role":"user","content":[{"type":"input_text","text":"what did I ask you to remember?"}]}
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Call the demo tool."}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I'll call the demo tool."}]},
+			{"type":"function_call","name":"search_demo","arguments":"{\"query\":\"demo\"}","call_id":"call_1"},
+			{"type":"function_call_output","call_id":"call_1","output":"mcp-tool-ok"}
 		]
 	}`)
 
@@ -24,6 +24,8 @@ func TestRewriteRuntimeRequestForUpstreamNormalizesResumedAssistantText(t *testi
 
 	var payload struct {
 		Input []struct {
+			Type    string `json:"type"`
+			Role    string `json:"role"`
 			Content []struct {
 				Type string `json:"type"`
 			} `json:"content"`
@@ -32,10 +34,69 @@ func TestRewriteRuntimeRequestForUpstreamNormalizesResumedAssistantText(t *testi
 	if err := json.Unmarshal(rewritten, &payload); err != nil {
 		t.Fatalf("unmarshal rewritten request: %v", err)
 	}
-	if got := payload.Input[1].Content[0].Type; got != "input_text" {
-		t.Fatalf("resumed assistant text type = %q, want input_text", got)
+	if got := payload.Input[1].Content[0].Type; got != "output_text" {
+		t.Fatalf("assistant preamble text type = %q, want output_text", got)
 	}
 	if got := payload.Input[0].Content[0].Type; got != "input_text" {
-		t.Fatalf("existing user text type = %q, want input_text", got)
+		t.Fatalf("user text type = %q, want input_text", got)
+	}
+	if got := payload.Input[2].Type; got != "function_call" {
+		t.Fatalf("tool call item type = %q, want function_call", got)
+	}
+	if got := payload.Input[3].Type; got != "function_call_output" {
+		t.Fatalf("tool output item type = %q, want function_call_output", got)
+	}
+}
+
+func TestRewriteRuntimeRequestForUpstreamNormalizesResponsesTextTypesByRole(t *testing.T) {
+	tests := []struct {
+		name   string
+		target ResolvedTarget
+		want   []string
+	}{
+		{
+			name: "standard responses",
+			want: []string{"input_text", "input_text", "output_text"},
+		},
+		{
+			name: "generic provider",
+			target: ResolvedTarget{Provider: Provider{
+				UseGenericResponsesTextParts: true,
+			}},
+			want: []string{"text", "text", "text"},
+		},
+	}
+
+	body := []byte(`{
+		"input":[
+			{"role":"developer","content":[{"text":"Follow the instructions."}]},
+			{"role":"user","content":[{"type":"output_text","text":"Question"}]},
+			{"role":"assistant","content":[{"type":"input_text","text":"Answer"}]}
+		]
+	}`)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rewritten, err := RewriteRuntimeRequestForUpstream(body, tt.target, protocolbridge.ProtocolOpenAIResponses)
+			if err != nil {
+				t.Fatalf("RewriteRuntimeRequestForUpstream() error = %v", err)
+			}
+
+			var payload struct {
+				Input []struct {
+					Content []struct {
+						Type string `json:"type"`
+					} `json:"content"`
+				} `json:"input"`
+			}
+			if err := json.Unmarshal(rewritten, &payload); err != nil {
+				t.Fatalf("unmarshal rewritten request: %v", err)
+			}
+			for i, want := range tt.want {
+				if got := payload.Input[i].Content[0].Type; got != want {
+					t.Errorf("input[%d] text type = %q, want %q", i, got, want)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- make OpenAI Responses request normalization role-aware so assistant history keeps `output_text` while user and developer input uses `input_text`
- preserve provider-specific generic `text` normalization only for providers that explicitly require it
- add regression coverage for an assistant preamble followed by a function call and tool output, plus standard and generic provider text-type normalization

Fixes #415.

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.53%
  - Integration: 61.02%
  - E2E: 61.45%
  - Combined: 78.94%
- `GOFLAGS=-buildvcs=false go test ./pkg/llms -count=1`
- `GOFLAGS=-buildvcs=false go test ./pkg/agentcompose/proxy -count=1`
- `data/ai_analyse/ai-test-suit/suit-mcp` case 14 (`real_codex_issue_323_exact.sh`)
  - run exited successfully
  - MCP `tools/call` and runtime MCP event observed
  - deterministic tool result returned
  - `--rm` removed the sandbox

## Checklist

- [x] Documentation updated when behavior or configuration changed (not required; this fixes protocol normalization without changing public configuration).
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
