### PR TITLE
fix(driver): preserve UTF-8 across output chunks

### DIFF
--- a/pkg/driver/boxlite_cache_gc_test.go
+++ b/pkg/driver/boxlite_cache_gc_test.go
@@ -57,7 +57,7 @@ func TestResolveRootfsPathDoesNotPruneMaterializedCache(t *testing.T) {
 		CacheTTL:      time.Nanosecond,
 	}}
 
-	rootfsPath, err := runtime.resolveRootfsPath(context.Background(), "guest:latest", "", defaultImagePullTimeout)
+	rootfsPath, _, err := runtime.resolveRootfsPath(context.Background(), "guest:latest", "", defaultImagePullTimeout)
 	if err != nil {
 		t.Fatalf("resolveRootfsPath: %v", err)
 	}

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -166,11 +166,13 @@ type cgoBoxInfo struct {
 }
 
 type cgoExecCollector struct {
-	stream ExecStreamWriter
-	filter *execOutputFilter
-	stdout bytes.Buffer
-	stderr bytes.Buffer
-	output bytes.Buffer
+	stream        ExecStreamWriter
+	filter        *execOutputFilter
+	stdoutDecoder utf8StreamDecoder
+	stderrDecoder utf8StreamDecoder
+	stdout        bytes.Buffer
+	stderr        bytes.Buffer
+	output        bytes.Buffer
 }
 
 type boxliteHandleResult struct {
@@ -264,6 +266,9 @@ func lookupExecAwaiter(handle uintptr) (*boxliteExecAwaiter, bool) {
 }
 
 func (c *cgoExecCollector) writeChunk(chunk ExecChunk) {
+	if chunk.Text == "" {
+		return
+	}
 	if c.filter == nil {
 		c.appendChunk(chunk)
 		return
@@ -272,10 +277,20 @@ func (c *cgoExecCollector) writeChunk(chunk ExecChunk) {
 }
 
 func (c *cgoExecCollector) finish() {
+	c.writeChunk(ExecChunk{Text: c.stdoutDecoder.Finish(), Stream: StdioStdout})
+	c.writeChunk(ExecChunk{Text: c.stderrDecoder.Finish(), Stream: StdioStderr})
 	if c.filter == nil {
 		return
 	}
 	c.filter.Finish(c.appendChunk)
+}
+
+func (c *cgoExecCollector) writeBytes(data []byte, stream StdioStream) {
+	decoder := &c.stdoutDecoder
+	if NormalizeStdioStream(stream) == StdioStderr {
+		decoder = &c.stderrDecoder
+	}
+	c.writeChunk(ExecChunk{Text: decoder.Write(data), Stream: stream})
 }
 
 func (c *cgoExecCollector) appendChunk(chunk ExecChunk) {
@@ -320,7 +335,7 @@ func agentcomposeBoxliteExecStdoutCallback(data *C.uint8_t, length C.size_t, han
 	if !ok || awaiter.collector == nil || data == nil || length == 0 {
 		return
 	}
-	awaiter.collector.writeChunk(ExecChunk{Text: string(C.GoBytes(unsafe.Pointer(data), C.int(length)))})
+	awaiter.collector.writeBytes(C.GoBytes(unsafe.Pointer(data), C.int(length)), StdioStdout)
 	notifyBoxliteExecOutput(awaiter)
 }
 
@@ -330,7 +345,7 @@ func agentcomposeBoxliteExecStderrCallback(data *C.uint8_t, length C.size_t, han
 	if !ok || awaiter.collector == nil || data == nil || length == 0 {
 		return
 	}
-	awaiter.collector.writeChunk(ExecChunk{Text: string(C.GoBytes(unsafe.Pointer(data), C.int(length))), Stream: StdioStderr})
+	awaiter.collector.writeBytes(C.GoBytes(unsafe.Pointer(data), C.int(length)), StdioStderr)
 	notifyBoxliteExecOutput(awaiter)
 }
 

--- a/pkg/driver/boxlite_cgo_test.go
+++ b/pkg/driver/boxlite_cgo_test.go
@@ -4,6 +4,7 @@ package driver
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -55,6 +56,30 @@ func TestBoxliteExecCollectorMapsStdioStreams(t *testing.T) {
 		if streamed[i] != want[i] {
 			t.Fatalf("streamed[%d] = %#v, want %#v", i, streamed[i], want[i])
 		}
+	}
+}
+
+func TestBoxliteExecCollectorPreservesSplitUTF8(t *testing.T) {
+	var streamed []ExecChunk
+	collector := &cgoExecCollector{stream: func(chunk ExecChunk) {
+		streamed = append(streamed, chunk)
+	}}
+	runeBytes := []byte("中")
+
+	collector.writeBytes(runeBytes[:1], StdioStdout)
+	if len(streamed) != 0 {
+		t.Fatalf("first fragment emitted invalid UTF-8 chunk: %#v", streamed)
+	}
+	collector.writeBytes(runeBytes[1:], StdioStdout)
+	collector.writeBytes([]byte{0xff}, StdioStderr)
+	collector.finish()
+
+	want := []ExecChunk{
+		{Text: "中", Stream: StdioStdout},
+		{Text: "\uFFFD", Stream: StdioStderr},
+	}
+	if !reflect.DeepEqual(streamed, want) {
+		t.Fatalf("streamed chunks = %#v, want %#v", streamed, want)
 	}
 }
 

--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -48,11 +48,13 @@ type dockerDaemonTopology struct {
 }
 
 type dockerExecCollector struct {
-	stream ExecStreamWriter
-	filter *execOutputFilter
-	stdout bytes.Buffer
-	stderr bytes.Buffer
-	output bytes.Buffer
+	stream        ExecStreamWriter
+	filter        *execOutputFilter
+	stdoutDecoder utf8StreamDecoder
+	stderrDecoder utf8StreamDecoder
+	stdout        bytes.Buffer
+	stderr        bytes.Buffer
+	output        bytes.Buffer
 }
 
 type dockerExecWriter struct {
@@ -85,6 +87,7 @@ type dockerInteractionWriter struct {
 	interaction *dockerCommandInteraction
 	stream      StdioStream
 	filter      *execOutputFilter
+	decoder     utf8StreamDecoder
 }
 
 func newDockerRuntime(config *appconfig.Config) (SandboxRuntime, error) {
@@ -92,6 +95,9 @@ func newDockerRuntime(config *appconfig.Config) (SandboxRuntime, error) {
 }
 
 func (c *dockerExecCollector) writeChunk(chunk ExecChunk) {
+	if chunk.Text == "" {
+		return
+	}
 	if c.filter == nil {
 		c.appendChunk(chunk)
 		return
@@ -100,16 +106,23 @@ func (c *dockerExecCollector) writeChunk(chunk ExecChunk) {
 }
 
 func (c *dockerExecCollector) finish() {
+	c.writeChunk(ExecChunk{Text: c.stdoutDecoder.Finish(), Stream: StdioStdout})
+	c.writeChunk(ExecChunk{Text: c.stderrDecoder.Finish(), Stream: StdioStderr})
 	if c.filter == nil {
 		return
 	}
 	c.filter.Finish(c.appendChunk)
 }
 
-func (c *dockerExecCollector) appendChunk(chunk ExecChunk) {
-	if chunk.Text == "" {
-		return
+func (c *dockerExecCollector) writeBytes(data []byte, stream StdioStream) {
+	decoder := &c.stdoutDecoder
+	if NormalizeStdioStream(stream) == StdioStderr {
+		decoder = &c.stderrDecoder
 	}
+	c.writeChunk(ExecChunk{Text: decoder.Write(data), Stream: stream})
+}
+
+func (c *dockerExecCollector) appendChunk(chunk ExecChunk) {
 	c.output.WriteString(chunk.Text)
 	if c.stream != nil {
 		c.stream(chunk)
@@ -125,7 +138,7 @@ func (w *dockerExecWriter) Write(p []byte) (int, error) {
 	if w == nil || w.collector == nil {
 		return len(p), nil
 	}
-	w.collector.writeChunk(ExecChunk{Text: string(p), Stream: w.stream})
+	w.collector.writeBytes(p, w.stream)
 	return len(p), nil
 }
 
@@ -560,19 +573,23 @@ func (i *dockerCommandInteraction) run() {
 
 func (i *dockerCommandInteraction) copyOutput() error {
 	if i.tty {
-		_, err := io.Copy(&dockerInteractionWriter{interaction: i, stream: StdioStdout}, i.attachResp.Reader)
+		writer := &dockerInteractionWriter{interaction: i, stream: StdioStdout}
+		_, err := io.Copy(writer, i.attachResp.Reader)
+		writer.finish()
 		return err
 	}
+	stdoutWriter := &dockerInteractionWriter{interaction: i, stream: StdioStdout}
 	stderrWriter := &dockerInteractionWriter{
 		interaction: i,
 		stream:      StdioStderr,
 		filter:      newExecOutputFilter(),
 	}
 	_, err := stdcopy.StdCopy(
-		&dockerInteractionWriter{interaction: i, stream: StdioStdout},
+		stdoutWriter,
 		stderrWriter,
 		i.attachResp.Reader,
 	)
+	stdoutWriter.finish()
 	stderrWriter.finish()
 	return err
 }
@@ -588,17 +605,28 @@ func (w *dockerInteractionWriter) Write(p []byte) (int, error) {
 	if len(p) == 0 || w == nil || w.interaction == nil {
 		return len(p), nil
 	}
-	chunk := ExecChunk{Text: string(p), Stream: w.stream}
-	if w.filter != nil {
-		w.filter.Write(chunk, w.emitChunk)
-		return len(p), nil
-	}
-	w.emitChunk(chunk)
+	w.writeText(w.decoder.Write(p))
 	return len(p), nil
 }
 
+func (w *dockerInteractionWriter) writeText(text string) {
+	if text == "" {
+		return
+	}
+	chunk := ExecChunk{Text: text, Stream: w.stream}
+	if w.filter != nil {
+		w.filter.Write(chunk, w.emitChunk)
+		return
+	}
+	w.emitChunk(chunk)
+}
+
 func (w *dockerInteractionWriter) finish() {
-	if w != nil && w.filter != nil {
+	if w == nil {
+		return
+	}
+	w.writeText(w.decoder.Finish())
+	if w.filter != nil {
 		w.filter.Finish(w.emitChunk)
 	}
 }

--- a/pkg/driver/docker_runtime_test.go
+++ b/pkg/driver/docker_runtime_test.go
@@ -68,6 +68,31 @@ func TestDockerExecCollectorMapsStdioStreams(t *testing.T) {
 	}
 }
 
+func TestDockerExecWriterPreservesSplitUTF8(t *testing.T) {
+	var streamed []ExecChunk
+	collector := &dockerExecCollector{stream: func(chunk ExecChunk) {
+		streamed = append(streamed, chunk)
+	}}
+	writer := &dockerExecWriter{collector: collector, stream: StdioStdout}
+	runeBytes := []byte("中")
+
+	if _, err := writer.Write(runeBytes[:1]); err != nil {
+		t.Fatalf("Write() first fragment error = %v", err)
+	}
+	if len(streamed) != 0 {
+		t.Fatalf("first fragment emitted invalid UTF-8 chunk: %#v", streamed)
+	}
+	if _, err := writer.Write(runeBytes[1:]); err != nil {
+		t.Fatalf("Write() second fragment error = %v", err)
+	}
+	collector.finish()
+
+	want := []ExecChunk{{Text: "中", Stream: StdioStdout}}
+	if !reflect.DeepEqual(streamed, want) {
+		t.Fatalf("streamed chunks = %#v, want %#v", streamed, want)
+	}
+}
+
 func TestDockerRuntimeInteractionCapabilities(t *testing.T) {
 	runtime := &dockerRuntime{}
 	caps := runtime.InteractionCapabilities()
@@ -189,6 +214,35 @@ func TestDockerInteractionWriterProjectsFramesAndFiltersStderr(t *testing.T) {
 	case frame := <-interaction.output:
 		t.Fatalf("unexpected extra frame = %#v", frame)
 	default:
+	}
+}
+
+func TestDockerInteractionWriterPreservesSplitUTF8(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	interaction := &dockerCommandInteraction{
+		ctx:    ctx,
+		output: make(chan RuntimeOutputFrame, 2),
+	}
+	writer := &dockerInteractionWriter{interaction: interaction, stream: StdioStdout}
+	runeBytes := []byte("中")
+
+	if _, err := writer.Write(runeBytes[:1]); err != nil {
+		t.Fatalf("Write() first fragment error = %v", err)
+	}
+	select {
+	case frame := <-interaction.output:
+		t.Fatalf("first fragment emitted invalid UTF-8 frame: %#v", frame)
+	default:
+	}
+	if _, err := writer.Write(runeBytes[1:]); err != nil {
+		t.Fatalf("Write() second fragment error = %v", err)
+	}
+	writer.finish()
+
+	frame := mustRecvDockerInteractionFrame(t, interaction)
+	if frame.Type != RuntimeOutputStdout || string(frame.Data) != "中" {
+		t.Fatalf("stdout frame = %#v", frame)
 	}
 }
 

--- a/pkg/driver/interaction.go
+++ b/pkg/driver/interaction.go
@@ -115,12 +115,14 @@ type RuntimeError struct {
 }
 
 type RuntimeOutputFrame struct {
-	Type      RuntimeOutputFrameType `json:"type"`
-	Data      []byte                 `json:"data,omitempty"`
-	Event     *RuntimeAgentEvent     `json:"event,omitempty"`
-	Result    *RuntimeResult         `json:"result,omitempty"`
-	Error     *RuntimeError          `json:"error,omitempty"`
-	StartedAt time.Time              `json:"started_at,omitempty"`
+	Type RuntimeOutputFrameType `json:"type"`
+	// Data in stdout and stderr frames is valid UTF-8 text. Runtime byte
+	// streams must complete or replace invalid rune fragments before emitting.
+	Data      []byte             `json:"data,omitempty"`
+	Event     *RuntimeAgentEvent `json:"event,omitempty"`
+	Result    *RuntimeResult     `json:"result,omitempty"`
+	Error     *RuntimeError      `json:"error,omitempty"`
+	StartedAt time.Time          `json:"started_at,omitempty"`
 }
 
 type RuntimeResult struct {

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -38,11 +38,13 @@ type microsandboxRuntime struct {
 }
 
 type microsandboxExecCollector struct {
-	stream ExecStreamWriter
-	filter *execOutputFilter
-	stdout bytes.Buffer
-	stderr bytes.Buffer
-	output bytes.Buffer
+	stream        ExecStreamWriter
+	filter        *execOutputFilter
+	stdoutDecoder utf8StreamDecoder
+	stderrDecoder utf8StreamDecoder
+	stdout        bytes.Buffer
+	stderr        bytes.Buffer
+	output        bytes.Buffer
 }
 
 const microsandboxExecExitIdleGracePeriod = 2 * time.Second
@@ -198,14 +200,14 @@ func consumeMicrosandboxExecStream(
 					resetWaitTimer(silenceInterval)
 				}
 			case microsandbox.ExecEventStdout:
-				collector.writeChunk(ExecChunk{Text: string(event.Data)})
+				collector.writeBytes(event.Data, StdioStdout)
 				if sawExit {
 					resetWaitTimer(idleGrace)
 				} else if probeAlive != nil && silenceInterval > 0 && pid != 0 {
 					resetWaitTimer(silenceInterval)
 				}
 			case microsandbox.ExecEventStderr:
-				collector.writeChunk(ExecChunk{Text: string(event.Data), Stream: StdioStderr})
+				collector.writeBytes(event.Data, StdioStderr)
 				if sawExit {
 					resetWaitTimer(idleGrace)
 				} else if probeAlive != nil && silenceInterval > 0 && pid != 0 {
@@ -305,6 +307,9 @@ func newMicrosandboxRuntime(config *appconfig.Config) (SandboxRuntime, error) {
 }
 
 func (c *microsandboxExecCollector) writeChunk(chunk ExecChunk) {
+	if chunk.Text == "" {
+		return
+	}
 	if c.filter == nil {
 		c.appendChunk(chunk)
 		return
@@ -313,10 +318,20 @@ func (c *microsandboxExecCollector) writeChunk(chunk ExecChunk) {
 }
 
 func (c *microsandboxExecCollector) finish() {
+	c.writeChunk(ExecChunk{Text: c.stdoutDecoder.Finish(), Stream: StdioStdout})
+	c.writeChunk(ExecChunk{Text: c.stderrDecoder.Finish(), Stream: StdioStderr})
 	if c.filter == nil {
 		return
 	}
 	c.filter.Finish(c.appendChunk)
+}
+
+func (c *microsandboxExecCollector) writeBytes(data []byte, stream StdioStream) {
+	decoder := &c.stdoutDecoder
+	if NormalizeStdioStream(stream) == StdioStderr {
+		decoder = &c.stderrDecoder
+	}
+	c.writeChunk(ExecChunk{Text: decoder.Write(data), Stream: stream})
 }
 
 func (c *microsandboxExecCollector) appendChunk(chunk ExecChunk) {

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -44,6 +45,50 @@ func TestMicrosandboxExecCollectorMapsStdioStreams(t *testing.T) {
 		if streamed[i] != want[i] {
 			t.Fatalf("streamed[%d] = %#v, want %#v", i, streamed[i], want[i])
 		}
+	}
+}
+
+func TestMicrosandboxExecStreamPreservesSplitUTF8(t *testing.T) {
+	runeBytes := []byte("中")
+	events := []*microsandbox.ExecEvent{
+		{Kind: microsandbox.ExecEventStarted},
+		{Kind: microsandbox.ExecEventStdout, Data: runeBytes[:1]},
+		{Kind: microsandbox.ExecEventStdout, Data: runeBytes[1:]},
+		{Kind: microsandbox.ExecEventStderr, Data: []byte{0xff}},
+		{Kind: microsandbox.ExecEventExited},
+		{Kind: microsandbox.ExecEventDone},
+	}
+	recv := func(context.Context) (*microsandbox.ExecEvent, error) {
+		event := events[0]
+		events = events[1:]
+		return event, nil
+	}
+	var streamed []ExecChunk
+	collector := &microsandboxExecCollector{stream: func(chunk ExecChunk) {
+		streamed = append(streamed, chunk)
+	}}
+
+	result, err := consumeMicrosandboxExecStream(
+		context.Background(),
+		recv,
+		func() error { return nil },
+		collector,
+		25*time.Millisecond,
+		nil,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("consumeMicrosandboxExecStream() error = %v", err)
+	}
+	if result.Stdout != "中" || result.Stderr != "\uFFFD" || result.Output != "中\uFFFD" {
+		t.Fatalf("result = %#v", result)
+	}
+	want := []ExecChunk{
+		{Text: "中", Stream: StdioStdout},
+		{Text: "\uFFFD", Stream: StdioStderr},
+	}
+	if !reflect.DeepEqual(streamed, want) {
+		t.Fatalf("streamed chunks = %#v, want %#v", streamed, want)
 	}
 }
 

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -83,6 +83,8 @@ func NormalizeStdioStream(stream StdioStream) StdioStream {
 }
 
 type ExecChunk struct {
+	// Text is valid UTF-8. Runtime byte streams must buffer incomplete rune
+	// suffixes and replace irrecoverably invalid input before emitting a chunk.
 	Text   string
 	Stream StdioStream
 }

--- a/pkg/driver/utf8_stream.go
+++ b/pkg/driver/utf8_stream.go
@@ -1,0 +1,51 @@
+package driver
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const invalidUTF8Replacement = "\uFFFD"
+
+// utf8StreamDecoder turns arbitrarily split byte fragments into valid UTF-8
+// text. A suffix that can still become a valid rune is held until the next
+// fragment; bytes that can no longer form valid UTF-8 are replaced.
+type utf8StreamDecoder struct {
+	pending []byte
+}
+
+func (d *utf8StreamDecoder) Write(fragment []byte) string {
+	if len(fragment) == 0 {
+		return ""
+	}
+
+	data := fragment
+	if len(d.pending) > 0 {
+		data = make([]byte, 0, len(d.pending)+len(fragment))
+		data = append(data, d.pending...)
+		data = append(data, fragment...)
+		d.pending = d.pending[:0]
+	}
+
+	completeEnd := len(data)
+	for offset := 0; offset < len(data); {
+		r, size := utf8.DecodeRune(data[offset:])
+		if r == utf8.RuneError && size == 1 && !utf8.FullRune(data[offset:]) {
+			completeEnd = offset
+			d.pending = append(d.pending, data[offset:]...)
+			break
+		}
+		offset += size
+	}
+
+	return strings.ToValidUTF8(string(data[:completeEnd]), invalidUTF8Replacement)
+}
+
+func (d *utf8StreamDecoder) Finish() string {
+	if len(d.pending) == 0 {
+		return ""
+	}
+	text := strings.ToValidUTF8(string(d.pending), invalidUTF8Replacement)
+	d.pending = nil
+	return text
+}

--- a/pkg/driver/utf8_stream_test.go
+++ b/pkg/driver/utf8_stream_test.go
@@ -1,0 +1,47 @@
+package driver
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestUTF8StreamDecoderPreservesSplitRunes(t *testing.T) {
+	decoder := &utf8StreamDecoder{}
+	data := []byte("A中🙂B")
+	fragments := [][]byte{
+		data[:2],
+		data[2:4],
+		data[4:7],
+		data[7:],
+	}
+
+	var got string
+	for _, fragment := range fragments {
+		chunk := decoder.Write(fragment)
+		if !utf8.ValidString(chunk) {
+			t.Fatalf("Write(%x) returned invalid UTF-8 %q", fragment, chunk)
+		}
+		got += chunk
+	}
+	got += decoder.Finish()
+	if got != "A中🙂B" {
+		t.Fatalf("decoded text = %q, want %q", got, "A中🙂B")
+	}
+}
+
+func TestUTF8StreamDecoderReplacesInvalidAndIncompleteInput(t *testing.T) {
+	decoder := &utf8StreamDecoder{}
+
+	if got := decoder.Write([]byte{'o', 'k', 0xff}); got != "ok\uFFFD" {
+		t.Fatalf("invalid byte decoded as %q, want %q", got, "ok\uFFFD")
+	}
+	if got := decoder.Write([]byte{0xe4, 0xb8}); got != "" {
+		t.Fatalf("incomplete rune decoded before Finish as %q", got)
+	}
+	if got := decoder.Finish(); got != "\uFFFD" {
+		t.Fatalf("incomplete rune Finish() = %q, want %q", got, "\uFFFD")
+	}
+	if got := decoder.Finish(); got != "" {
+		t.Fatalf("second Finish() = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

- buffer incomplete UTF-8 rune suffixes across runtime output fragments instead of converting each byte fragment directly to a Go string
- apply the shared decoder to Docker exec and native interaction output, BoxLite callbacks, and Microsandbox exec events, with independent stdout/stderr state
- replace irrecoverably invalid bytes and incomplete EOF suffixes with `U+FFFD`, guaranteeing protobuf-facing text is valid UTF-8
- add regression coverage for split multibyte output and document the UTF-8 contract for driver chunks and interaction frames

Closes #303

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.65%
  - Integration: 61.47%
  - E2E: 61.33%
  - Combined: 78.96%
- `GOFLAGS=-buildvcs=false go test -race ./pkg/driver -run 'TestUTF8StreamDecoder|TestDocker(ExecWriter|InteractionWriter)PreservesSplitUTF8' -count=1`
- `GOFLAGS=-buildvcs=false go test -tags boxlitecgo ./pkg/driver -count=1`
- `GOFLAGS=-buildvcs=false go test -tags microsandboxcgo ./pkg/driver -run 'TestMicrosandboxExec(StreamPreservesSplitUTF8|CollectorMapsStdioStreams)' -count=1 -v`
- `GOFLAGS=-buildvcs=false go test -tags microsandboxcgo ./pkg/driver -count=1 -v`
  - passed in a Debian trixie container with glibc 2.41, Go 1.26.5, QEMU 10.0.11, writable `/dev/kvm`, the Docker socket, and Microsandbox 0.6.4 available
  - environment-gated `TestSmokeMicrosandbox*` cases skipped as designed; real VM lifecycle smoke is outside this UTF-8 fix's scope

## Checklist

- [x] Documentation updated when behavior or configuration changed (driver text contracts are documented in code; no configuration changed).
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
