### PR TITLE
fix(runtime): terminate guest execs when runs are canceled

### DIFF
--- a/pkg/agentcompose/adapters/agent_runner.go
+++ b/pkg/agentcompose/adapters/agent_runner.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -108,11 +109,16 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 	if err != nil {
 		return domain.ExecResult{}, domain.AgentRunResult{}, err
 	}
+	retainFacadeToken := false
 	if len(managedEnv) > 0 {
 		spec.Env = llms.MergeManagedExecEnv(spec.Env, managedEnv)
 		if r.configDB != nil {
 			if token := managedEnv["AGENT_COMPOSE_SANDBOX_TOKEN"]; token != "" {
-				defer func() { _ = r.configDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), token) }()
+				defer func() {
+					if !retainFacadeToken {
+						_ = r.configDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), token)
+					}
+				}()
 			}
 		}
 	}
@@ -121,6 +127,7 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 	}
 	result, err := runtime.ExecStream(ctx, session, vmState, spec, stream)
 	if err != nil {
+		retainFacadeToken = errors.Is(err, domain.ErrExecTerminationUnconfirmed)
 		return execution.SanitizeAgentExecResult(result), domain.AgentRunResult{}, err
 	}
 	parsed, err := execution.ParseAgentExecResult(agent, result)

--- a/pkg/agentcompose/adapters/agent_runner_test.go
+++ b/pkg/agentcompose/adapters/agent_runner_test.go
@@ -13,6 +13,7 @@ import (
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
+	"agent-compose/pkg/internal/testutil"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/storage/sessionstore"
 )
@@ -33,6 +34,7 @@ type fakeAgentRuntime struct {
 	specs        []domain.ExecSpec
 	streamChunks []domain.ExecChunk
 	result       domain.ExecResult
+	err          error
 }
 
 func (r *fakeAgentRuntime) EnsureSandbox(context.Context, *domain.Sandbox, domain.VMState, domain.ProxyState) (domain.SandboxVMInfo, error) {
@@ -58,11 +60,79 @@ func (r *fakeAgentRuntime) ExecStream(_ context.Context, _ *domain.Sandbox, _ do
 			stream(chunk)
 		}
 	}
+	if r.err != nil {
+		return domain.ExecResult{}, r.err
+	}
 	if r.result.Stdout != "" || r.result.Stderr != "" || r.result.Output != "" || r.result.ExitCode != 0 || r.result.Success {
 		return r.result, nil
 	}
 	payload := execution.AgentResultPrefix + `{"provider":"codex","threadId":"agent-thread-1","finalText":"done","transcript":"trace","stopReason":"completed"}`
 	return domain.ExecResult{Stdout: payload, Output: payload, ExitCode: 0, Success: true}, nil
+}
+
+func TestAgentRunnerRetainsFacadeTokenOnlyWhenExecTerminationIsUnconfirmed(t *testing.T) {
+	tests := []struct {
+		name         string
+		runtimeErr   error
+		wantRetained bool
+	}{
+		{name: "confirmed cancellation", runtimeErr: context.Canceled},
+		{name: "unconfirmed termination", runtimeErr: domain.ErrExecTerminationUnconfirmed, wantRetained: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			config := &appconfig.Config{
+				DataRoot:            root,
+				DbAddr:              filepath.Join(root, "data.db"),
+				SandboxRoot:         filepath.Join(root, "sandboxes"),
+				RuntimeDriver:       driverpkg.RuntimeDriverDocker,
+				DefaultImage:        "guest:latest",
+				GuestWorkspacePath:  "/workspace",
+				GuestStateRoot:      "/data/state",
+				GuestRuntimeRoot:    "/data/runtime",
+				GuestHomePath:       "/root",
+				RuntimeBaseURL:      "http://agent-compose.test:7410",
+				LLMAPIKey:           "provider-key",
+				SandboxStartTimeout: 2 * time.Second,
+			}
+			configDB, store, err := testutil.OpenStores(t, config)
+			if err != nil {
+				t.Fatalf("OpenStores returned error: %v", err)
+			}
+			session, err := store.CreateSandbox(context.Background(), "token lifecycle", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+			if err != nil {
+				t.Fatalf("CreateSandbox returned error: %v", err)
+			}
+			session.Summary.VMStatus = domain.VMStatusRunning
+			if err := store.UpdateSandbox(context.Background(), session); err != nil {
+				t.Fatalf("UpdateSandbox returned error: %v", err)
+			}
+			if err := store.SaveVMState(session.Summary.ID, domain.VMState{Driver: driverpkg.RuntimeDriverDocker, BoxID: "container-1"}); err != nil {
+				t.Fatalf("SaveVMState returned error: %v", err)
+			}
+			runtime := &fakeAgentRuntime{err: tt.runtimeErr}
+			runner := NewAgentRunner(config, store, configDB, nil, fakeRuntimeProvider{runtime: runtime})
+			_, _, err = runner.ExecuteAgentRun(context.Background(), session, "claude", "", "", "run-1", "wait", "", nil)
+			if !errors.Is(err, tt.runtimeErr) {
+				t.Fatalf("ExecuteAgentRun error = %v, want %v", err, tt.runtimeErr)
+			}
+			if len(runtime.specs) != 1 {
+				t.Fatalf("runtime specs = %#v", runtime.specs)
+			}
+			token := runtime.specs[0].Env["AGENT_COMPOSE_SANDBOX_TOKEN"]
+			if token == "" {
+				t.Fatal("runtime spec missing facade token")
+			}
+			_, tokenErr := configDB.GetLLMFacadeToken(context.Background(), token)
+			if tt.wantRetained && tokenErr != nil {
+				t.Fatalf("facade token was removed after unconfirmed termination: %v", tokenErr)
+			}
+			if !tt.wantRetained && !errors.Is(tokenErr, domain.ErrNotFound) {
+				t.Fatalf("facade token after confirmed termination error = %v, want not found", tokenErr)
+			}
+		})
+	}
 }
 
 func TestAgentRunnerExecuteAgentRunWritesSystemPromptAndParsesResult(t *testing.T) {

--- a/pkg/agentcompose/adapters/loader_command_executor.go
+++ b/pkg/agentcompose/adapters/loader_command_executor.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,8 +76,13 @@ func (e *LoaderCommandExecutor) ExecuteLoaderCommand(ctx context.Context, sessio
 	if err != nil {
 		return domain.LoaderCommandResult{}, err
 	}
+	retainFacadeToken := false
 	if e.ConfigDB != nil && facadeToken != "" {
-		defer func() { _ = e.ConfigDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), facadeToken) }()
+		defer func() {
+			if !retainFacadeToken {
+				_ = e.ConfigDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), facadeToken)
+			}
+		}()
 	}
 	if err := e.Store.AddCell(ctx, session, cell); err != nil {
 		return domain.LoaderCommandResult{}, err
@@ -185,6 +191,7 @@ func (e *LoaderCommandExecutor) ExecuteLoaderCommand(ctx context.Context, sessio
 	}
 	commandHome := e.Config.GuestHomePath
 	execResult, err := runtime.ExecStream(execCtx, execSession, vmState, execution.BuildLoaderCommandExecSpec(e.Config, execSession, filepath.Join(guestCellDir, "command-request.json"), commandHome), streamWriter)
+	retainFacadeToken = errors.Is(err, domain.ErrExecTerminationUnconfirmed)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()

--- a/pkg/agentcompose/adapters/runtime_provider.go
+++ b/pkg/agentcompose/adapters/runtime_provider.go
@@ -118,7 +118,7 @@ func (r driverRuntimeAdapter) RemoveSandbox(ctx context.Context, session *domain
 
 func (r driverRuntimeAdapter) Exec(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, spec domain.ExecSpec) (domain.ExecResult, error) {
 	result, err := r.runtime.Exec(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), execution.ToDriverExecSpec(spec))
-	return execution.FromDriverExecResult(result), err
+	return execution.FromDriverExecResult(result), classifyExecTerminationError(err)
 }
 
 func (r driverRuntimeAdapter) ExecStream(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, spec domain.ExecSpec, stream domain.ExecStreamWriter) (domain.ExecResult, error) {
@@ -128,7 +128,14 @@ func (r driverRuntimeAdapter) ExecStream(ctx context.Context, session *domain.Sa
 		}
 	}
 	result, err := r.runtime.ExecStream(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), execution.ToDriverExecSpec(spec), driverStream)
-	return execution.FromDriverExecResult(result), err
+	return execution.FromDriverExecResult(result), classifyExecTerminationError(err)
+}
+
+func classifyExecTerminationError(err error) error {
+	if errors.Is(err, driverpkg.ErrExecTerminationUnconfirmed) {
+		return domain.ClassifyError(domain.ErrExecTerminationUnconfirmed, "", err)
+	}
+	return err
 }
 
 func (r driverRuntimeAdapter) OpenInteraction(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, spec driverpkg.RuntimeStartSpec) (driverpkg.RuntimeInteraction, error) {

--- a/pkg/agentcompose/adapters/runtime_provider_test.go
+++ b/pkg/agentcompose/adapters/runtime_provider_test.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -170,5 +171,16 @@ func TestDomainStreamFromDriver(t *testing.T) {
 				t.Fatalf("domainStreamFromDriver(%q) = %q, want %q", tt.stream, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClassifyExecTerminationErrorMapsDriverSentinelToDomain(t *testing.T) {
+	driverErr := fmt.Errorf("cancel exec: %w", driverpkg.ErrExecTerminationUnconfirmed)
+	err := classifyExecTerminationError(driverErr)
+	if !errors.Is(err, domain.ErrExecTerminationUnconfirmed) {
+		t.Fatalf("classified error = %v, want domain termination sentinel", err)
+	}
+	if !errors.Is(err, driverpkg.ErrExecTerminationUnconfirmed) {
+		t.Fatalf("classified error lost driver cause: %v", err)
 	}
 }

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -124,6 +124,15 @@ static enum BoxliteErrorCode agentcompose_boxlite_execution_on_exit(
 	void *user_data = (void *)user_handle;
 	return boxlite_execution_on_exit(execution, agentcomposeBoxliteExecExitCallbackBridge, user_data, out_error);
 }
+
+static enum BoxliteErrorCode agentcompose_boxlite_execution_kill(
+	CExecutionHandle *execution,
+	uintptr_t user_handle,
+	CBoxliteError *out_error
+) {
+	void *user_data = (void *)user_handle;
+	return boxlite_execution_kill(execution, agentcomposeBoxliteVoidCallbackBridge, user_data, out_error);
+}
 */
 import "C"
 
@@ -919,6 +928,21 @@ func (r *cgoSandboxRuntime) waitForExecCompletion(ctx context.Context, runtimeHa
 	})
 }
 
+func (r *cgoSandboxRuntime) killExecution(ctx context.Context, runtimeHandle *C.CBoxliteRuntime, execution *C.CExecutionHandle) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), execTerminationTimeout)
+	defer cancel()
+
+	awaiter := &boxliteVoidAwaiter{ch: make(chan error, 1)}
+	awaiterHandle := globalBoxliteAwaiters.register(awaiter)
+	defer globalBoxliteAwaiters.delete(awaiterHandle)
+	var ffiErr C.CBoxliteError
+	code := C.agentcompose_boxlite_execution_kill(execution, C.uintptr_t(awaiterHandle), &ffiErr)
+	if err := boxliteStatusError(code, &ffiErr, "kill box command"); err != nil {
+		return err
+	}
+	return r.waitForVoidResult(cleanupCtx, runtimeHandle, awaiter.ch)
+}
+
 func waitForExecCompletion(ctx context.Context, awaiter *boxliteExecAwaiter, exitIdleGrace time.Duration, drain func(time.Duration) error) (int, error) {
 	exited := false
 	exitCode := 0
@@ -1277,6 +1301,12 @@ func (r *cgoSandboxRuntime) executeBox(ctx context.Context, box *cgoBoxHandle, s
 		return ExecResult{}, err
 	}
 	exitCode, err := r.waitForExecCompletion(ctx, runtimeHandle, awaiter)
+	if err != nil && ctx.Err() != nil {
+		terminationErr := r.killExecution(ctx, runtimeHandle, execution)
+		r.flushRuntimeCallbacks(runtimeHandle)
+		collector.finish()
+		return ExecResult{}, execTerminationResultError(RuntimeDriverBoxlite, fmt.Sprintf("%d", awaiterHandle), ctx.Err(), terminationErr)
+	}
 	r.flushRuntimeCallbacks(runtimeHandle)
 	collector.finish()
 	if err != nil {

--- a/pkg/driver/docker_exec_lifecycle.go
+++ b/pkg/driver/docker_exec_lifecycle.go
@@ -1,0 +1,119 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	dockertypes "github.com/docker/docker/api/types"
+	containerapi "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/google/uuid"
+)
+
+const (
+	dockerExecMarkerEnv = "AGENT_COMPOSE_INTERNAL_EXECUTION_ID"
+)
+
+// Docker has no kill-exec API. Every exec therefore carries a driver-owned
+// marker inherited by its descendants. A separate control exec can terminate
+// exactly that process tree without stopping a KEEP_RUNNING sandbox.
+const dockerTerminateMarkedExecScript = `
+marker=$1
+expected=` + dockerExecMarkerEnv + `=$marker
+
+matching_pids() {
+  for path in /proc/[0-9]*/environ; do
+    [ -r "$path" ] || continue
+    if tr '\000' '\n' <"$path" 2>/dev/null | grep -Fqx "$expected"; then
+      pid=${path#/proc/}
+      printf '%s\n' "${pid%/environ}"
+    fi
+  done
+}
+
+signal_until_gone() {
+  signal=$1
+  attempts=$2
+  attempt=0
+  while [ "$attempt" -lt "$attempts" ]; do
+    pids=$(matching_pids)
+    [ -z "$pids" ] && return 0
+    for pid in $pids; do
+      kill "-$signal" "$pid" 2>/dev/null || true
+    done
+    attempt=$((attempt + 1))
+    sleep 0.1
+  done
+  [ -z "$(matching_pids)" ]
+}
+
+signal_until_gone TERM 20 || signal_until_gone KILL 30
+`
+
+func newDockerExecMarker() string {
+	return uuid.NewString()
+}
+
+func dockerExecEnvWithMarker(env []string, marker string) []string {
+	prefix := dockerExecMarkerEnv + "="
+	marked := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		if !strings.HasPrefix(item, prefix) {
+			marked = append(marked, item)
+		}
+	}
+	marked = append(marked, prefix+marker)
+	sort.Strings(marked)
+	return marked
+}
+
+func (r *dockerRuntime) terminateDockerExec(ctx context.Context, dockerClient *client.Client, containerID, execID, marker string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), execTerminationTimeout)
+	defer cancel()
+
+	control, err := dockerClient.ContainerExecCreate(cleanupCtx, containerID, containerapi.ExecOptions{
+		AttachStdout: true,
+		AttachStderr: true,
+		Cmd:          []string{"sh", "-c", dockerTerminateMarkedExecScript, "agent-compose-exec-cleanup", marker},
+		User:         "0",
+		WorkingDir:   "/",
+	})
+	if err != nil {
+		return fmt.Errorf("create docker exec termination control: %w", err)
+	}
+	attach, err := dockerClient.ContainerExecAttach(cleanupCtx, control.ID, containerapi.ExecAttachOptions{})
+	if err != nil {
+		return fmt.Errorf("start docker exec termination control %s: %w", control.ID, err)
+	}
+	if err := drainDockerControlExec(attach); err != nil {
+		return fmt.Errorf("read docker exec termination control %s: %w", control.ID, err)
+	}
+	controlInfo, err := r.waitForExecExit(cleanupCtx, dockerClient, control.ID)
+	if err != nil {
+		return err
+	}
+	if controlInfo.ExitCode != 0 {
+		return fmt.Errorf("docker exec termination control %s exited with code %d", control.ID, controlInfo.ExitCode)
+	}
+	execInfo, err := r.waitForExecExit(cleanupCtx, dockerClient, execID)
+	if err != nil {
+		return err
+	}
+	if execInfo.Running {
+		return fmt.Errorf("docker exec %s is still running after termination", execID)
+	}
+	return nil
+}
+
+func drainDockerControlExec(attach dockertypes.HijackedResponse) error {
+	defer attach.Close()
+	_, err := stdcopy.StdCopy(io.Discard, io.Discard, attach.Reader)
+	if err != nil && !isDockerStreamClosed(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -67,6 +67,8 @@ type dockerCommandInteraction struct {
 	dockerClient *client.Client
 	attachResp   dockertypes.HijackedResponse
 	execID       string
+	containerID  string
+	execMarker   string
 	operationID  string
 	tty          bool
 	attachStdin  bool
@@ -317,6 +319,8 @@ func (r *dockerRuntime) OpenInteraction(ctx context.Context, sandbox *Sandbox, v
 		cancel()
 		return nil, err
 	}
+	execMarker := newDockerExecMarker()
+	execOptions.Env = dockerExecEnvWithMarker(execOptions.Env, execMarker)
 	execResp, err := dockerClient.ContainerExecCreate(childCtx, containerInfo.ID, execOptions)
 	if err != nil {
 		cancel()
@@ -327,8 +331,10 @@ func (r *dockerRuntime) OpenInteraction(ctx context.Context, sandbox *Sandbox, v
 		ConsoleSize: dockerConsoleSize(spec.Rows, spec.Cols),
 	})
 	if err != nil {
+		terminationErr := r.terminateDockerExec(childCtx, dockerClient, containerInfo.ID, execResp.ID, execMarker)
 		cancel()
-		return nil, fmt.Errorf("attach docker exec for sandbox %s: %w", sandbox.Summary.ID, err)
+		attachErr := fmt.Errorf("attach docker exec for sandbox %s: %w", sandbox.Summary.ID, err)
+		return nil, execTerminationResultError(RuntimeDriverDocker, execResp.ID, attachErr, terminationErr)
 	}
 
 	closeClient = false
@@ -339,6 +345,8 @@ func (r *dockerRuntime) OpenInteraction(ctx context.Context, sandbox *Sandbox, v
 		dockerClient: dockerClient,
 		attachResp:   attachResp,
 		execID:       execResp.ID,
+		containerID:  containerInfo.ID,
+		execMarker:   execMarker,
 		operationID:  spec.OperationID,
 		tty:          spec.TTY,
 		attachStdin:  spec.AttachStdin,
@@ -398,11 +406,12 @@ func (r *dockerRuntime) execWithStream(ctx context.Context, sandbox *Sandbox, vm
 		return ExecResult{}, fmt.Errorf("docker container for sandbox %s is not running", sandbox.Summary.ID)
 	}
 
+	execMarker := newDockerExecMarker()
 	execResp, err := dockerClient.ContainerExecCreate(ctx, containerInfo.ID, containerapi.ExecOptions{
 		AttachStdout: true,
 		AttachStderr: true,
 		Cmd:          append([]string{command}, spec.Args...),
-		Env:          dockerEnvList(spec.Env),
+		Env:          dockerExecEnvWithMarker(dockerEnvList(spec.Env), execMarker),
 		WorkingDir:   firstNonEmpty(spec.Cwd, r.config.GuestWorkspacePath),
 	})
 	if err != nil {
@@ -410,7 +419,12 @@ func (r *dockerRuntime) execWithStream(ctx context.Context, sandbox *Sandbox, vm
 	}
 	attachResp, err := dockerClient.ContainerExecAttach(ctx, execResp.ID, containerapi.ExecAttachOptions{})
 	if err != nil {
-		return ExecResult{}, fmt.Errorf("attach docker exec for sandbox %s: %w", sandbox.Summary.ID, err)
+		terminationErr := r.terminateDockerExec(ctx, dockerClient, containerInfo.ID, execResp.ID, execMarker)
+		attachErr := fmt.Errorf("attach docker exec for sandbox %s: %w", sandbox.Summary.ID, err)
+		if ctx.Err() != nil {
+			attachErr = ctx.Err()
+		}
+		return ExecResult{}, execTerminationResultError(RuntimeDriverDocker, execResp.ID, attachErr, terminationErr)
 	}
 	defer attachResp.Close()
 
@@ -427,16 +441,22 @@ func (r *dockerRuntime) execWithStream(ctx context.Context, sandbox *Sandbox, vm
 	collector := &dockerExecCollector{stream: stream, filter: newExecOutputFilter()}
 	_, copyErr := stdcopy.StdCopy(&dockerExecWriter{collector: collector, stream: StdioStdout}, &dockerExecWriter{collector: collector, stream: StdioStderr}, attachResp.Reader)
 	collector.finish()
-	if copyErr != nil && ctx.Err() != nil {
-		return ExecResult{}, ctx.Err()
+	if ctx.Err() != nil {
+		attachResp.Close()
+		terminationErr := r.terminateDockerExec(ctx, dockerClient, containerInfo.ID, execResp.ID, execMarker)
+		return ExecResult{}, execTerminationResultError(RuntimeDriverDocker, execResp.ID, ctx.Err(), terminationErr)
 	}
 	if copyErr != nil && !isDockerStreamClosed(copyErr) {
-		return ExecResult{}, copyErr
+		attachResp.Close()
+		terminationErr := r.terminateDockerExec(ctx, dockerClient, containerInfo.ID, execResp.ID, execMarker)
+		return ExecResult{}, execTerminationResultError(RuntimeDriverDocker, execResp.ID, copyErr, terminationErr)
 	}
 
 	execInfo, err := r.waitForExecExit(ctx, dockerClient, execResp.ID)
 	if err != nil {
-		return ExecResult{}, err
+		attachResp.Close()
+		terminationErr := r.terminateDockerExec(ctx, dockerClient, containerInfo.ID, execResp.ID, execMarker)
+		return ExecResult{}, execTerminationResultError(RuntimeDriverDocker, execResp.ID, err, terminationErr)
 	}
 	result := ExecResult{
 		ExitCode: execInfo.ExitCode,
@@ -540,6 +560,11 @@ func (i *dockerCommandInteraction) run() {
 		} else {
 			exitCode = execInfo.ExitCode
 		}
+	}
+	if runErr != nil {
+		i.attachResp.Close()
+		terminationErr := i.docker.terminateDockerExec(i.ctx, i.dockerClient, i.containerID, i.execID, i.execMarker)
+		runErr = execTerminationResultError(RuntimeDriverDocker, i.execID, runErr, terminationErr)
 	}
 
 	completedAt := time.Now()

--- a/pkg/driver/docker_runtime_test.go
+++ b/pkg/driver/docker_runtime_test.go
@@ -152,6 +152,20 @@ func TestDockerCommandExecOptionsNonTTYAttachesStderr(t *testing.T) {
 	}
 }
 
+func TestDockerExecEnvMarkerIsDriverOwnedAndIsolatesExecutions(t *testing.T) {
+	first := dockerExecEnvWithMarker([]string{"B=2", dockerExecMarkerEnv + "=caller", "A=1"}, "exec-1")
+	second := dockerExecEnvWithMarker([]string{"A=1"}, "exec-2")
+	if !reflect.DeepEqual(first, []string{"A=1", dockerExecMarkerEnv + "=exec-1", "B=2"}) {
+		t.Fatalf("first marked env = %#v", first)
+	}
+	if !reflect.DeepEqual(second, []string{"A=1", dockerExecMarkerEnv + "=exec-2"}) {
+		t.Fatalf("second marked env = %#v", second)
+	}
+	if reflect.DeepEqual(first, second) {
+		t.Fatalf("separate executions received the same marker: %#v", first)
+	}
+}
+
 func TestDockerInteractionWriterProjectsFramesAndFiltersStderr(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/driver/exec_termination.go
+++ b/pkg/driver/exec_termination.go
@@ -1,0 +1,46 @@
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrExecTerminationUnconfirmed means a runtime driver returned without being
+// able to prove that the guest execution it started has stopped.
+var ErrExecTerminationUnconfirmed = errors.New("guest execution termination unconfirmed")
+
+const execTerminationTimeout = 15 * time.Second
+
+type execTerminationUnconfirmedError struct {
+	driver      string
+	executionID string
+	cause       error
+}
+
+func (e *execTerminationUnconfirmedError) Error() string {
+	return fmt.Sprintf("%s runtime could not confirm termination of guest execution %s: %v", e.driver, e.executionID, e.cause)
+}
+
+func (e *execTerminationUnconfirmedError) Unwrap() error {
+	return e.cause
+}
+
+func (e *execTerminationUnconfirmedError) Is(target error) bool {
+	return target == ErrExecTerminationUnconfirmed
+}
+
+func execTerminationResultError(driver, executionID string, primary, terminationErr error) error {
+	if terminationErr == nil {
+		return primary
+	}
+	unconfirmed := &execTerminationUnconfirmedError{
+		driver:      driver,
+		executionID: executionID,
+		cause:       terminationErr,
+	}
+	if primary == nil {
+		return unconfirmed
+	}
+	return errors.Join(primary, unconfirmed)
+}

--- a/pkg/driver/exec_termination_test.go
+++ b/pkg/driver/exec_termination_test.go
@@ -1,0 +1,28 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestExecTerminationResultErrorPreservesPrimaryAndClassifiesUnconfirmedCleanup(t *testing.T) {
+	primary := context.Canceled
+	cleanup := errors.New("kill failed")
+	err := execTerminationResultError(RuntimeDriverDocker, "exec-1", primary, cleanup)
+	if !errors.Is(err, primary) {
+		t.Fatalf("error = %v, want primary cancellation", err)
+	}
+	if !errors.Is(err, cleanup) {
+		t.Fatalf("error = %v, want cleanup cause", err)
+	}
+	if !errors.Is(err, ErrExecTerminationUnconfirmed) {
+		t.Fatalf("error = %v, want ErrExecTerminationUnconfirmed", err)
+	}
+}
+
+func TestExecTerminationResultErrorReturnsPrimaryAfterConfirmedCleanup(t *testing.T) {
+	if err := execTerminationResultError(RuntimeDriverDocker, "exec-1", context.Canceled, nil); !errors.Is(err, context.Canceled) || errors.Is(err, ErrExecTerminationUnconfirmed) {
+		t.Fatalf("error = %v, want only context cancellation", err)
+	}
+}

--- a/pkg/driver/microsandbox_runtime.go
+++ b/pkg/driver/microsandbox_runtime.go
@@ -70,10 +70,27 @@ const (
 
 type microsandboxExecEventReceiver func(context.Context) (*microsandbox.ExecEvent, error)
 type microsandboxExecHandleCloser func() error
+type microsandboxExecTerminator func(context.Context) error
+
+type microsandboxExecTerminationHandle interface {
+	Kill(context.Context) error
+	Wait(context.Context) (int, error)
+}
 
 type microsandboxExecReceiveResult struct {
 	event *microsandbox.ExecEvent
 	err   error
+}
+
+func terminateMicrosandboxExec(ctx context.Context, handle microsandboxExecTerminationHandle) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), execTerminationTimeout)
+	defer cancel()
+	killErr := handle.Kill(cleanupCtx)
+	_, waitErr := handle.Wait(cleanupCtx)
+	if waitErr == nil {
+		return nil
+	}
+	return errors.Join(killErr, waitErr)
 }
 
 // microsandboxExecLivenessProbe reports whether the guest process is still
@@ -85,6 +102,7 @@ func consumeMicrosandboxExecStream(
 	ctx context.Context,
 	recv microsandboxExecEventReceiver,
 	closeHandle microsandboxExecHandleCloser,
+	terminate microsandboxExecTerminator,
 	collector *microsandboxExecCollector,
 	idleGrace time.Duration,
 	probeAlive microsandboxExecLivenessProbe,
@@ -141,8 +159,13 @@ func consumeMicrosandboxExecStream(
 	for {
 		select {
 		case <-ctx.Done():
+			stopReceiving()
+			var terminationErr error
+			if terminate != nil {
+				terminationErr = terminate(context.WithoutCancel(ctx))
+			}
 			collector.finish()
-			return ExecResult{}, ctx.Err()
+			return ExecResult{}, execTerminationResultError(RuntimeDriverMicrosandbox, strconv.FormatUint(uint64(pid), 10), ctx.Err(), terminationErr)
 		case <-wait:
 			if sawExit {
 				stopReceiving()
@@ -522,6 +545,7 @@ func (r *microsandboxRuntime) ExecStream(ctx context.Context, session *Sandbox, 
 				ctx,
 				handle.Recv,
 				closeHandle,
+				func(cleanupCtx context.Context) error { return terminateMicrosandboxExec(cleanupCtx, handle) },
 				collector,
 				microsandboxExecExitIdleGracePeriod,
 				microsandboxExecLivenessProbeFor(sandbox),

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -73,7 +73,7 @@ func TestMicrosandboxExecStreamReturnsAfterExitWithoutDone(t *testing.T) {
 	grace := 25 * time.Millisecond
 	startedAt := time.Now()
 
-	result, err := consumeMicrosandboxExecStream(ctx, recv, closeHandle, collector, grace, nil, 0)
+	result, err := consumeMicrosandboxExecStream(ctx, recv, closeHandle, nil, collector, grace, nil, 0)
 	if err != nil {
 		t.Fatalf("consumeMicrosandboxExecStream returned error: %v", err)
 	}
@@ -88,6 +88,118 @@ func TestMicrosandboxExecStreamReturnsAfterExitWithoutDone(t *testing.T) {
 	}
 	if elapsed := time.Since(startedAt); elapsed < grace {
 		t.Fatalf("returned before drain grace period: %s", elapsed)
+	}
+}
+
+func TestMicrosandboxExecStreamCancellationWaitsForTermination(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	terminationStarted := make(chan struct{})
+	allowTermination := make(chan struct{})
+	result := make(chan error, 1)
+	recv := func(ctx context.Context) (*microsandbox.ExecEvent, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	terminate := func(cleanupCtx context.Context) error {
+		if cleanupCtx.Err() != nil {
+			return cleanupCtx.Err()
+		}
+		close(terminationStarted)
+		<-allowTermination
+		return nil
+	}
+	go func() {
+		_, err := consumeMicrosandboxExecStream(
+			ctx,
+			recv,
+			func() error { return nil },
+			terminate,
+			&microsandboxExecCollector{},
+			time.Second,
+			nil,
+			0,
+		)
+		result <- err
+	}()
+
+	cancel()
+	select {
+	case <-terminationStarted:
+	case <-time.After(time.Second):
+		t.Fatal("termination did not start after cancellation")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("ExecStream returned before termination completed: %v", err)
+	default:
+	}
+	close(allowTermination)
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ExecStream error = %v, want context canceled", err)
+		}
+		if errors.Is(err, ErrExecTerminationUnconfirmed) {
+			t.Fatalf("successful termination was reported as unconfirmed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ExecStream did not return after termination completed")
+	}
+}
+
+type recordingMicrosandboxTerminationHandle struct {
+	calls   []string
+	killErr error
+	waitErr error
+}
+
+func (h *recordingMicrosandboxTerminationHandle) Kill(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	h.calls = append(h.calls, "kill")
+	return h.killErr
+}
+
+func (h *recordingMicrosandboxTerminationHandle) Wait(ctx context.Context) (int, error) {
+	if ctx.Err() != nil {
+		return -1, ctx.Err()
+	}
+	h.calls = append(h.calls, "wait")
+	return -1, h.waitErr
+}
+
+func TestTerminateMicrosandboxExecKillsThenWaitsWithFreshContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	handle := &recordingMicrosandboxTerminationHandle{}
+	if err := terminateMicrosandboxExec(ctx, handle); err != nil {
+		t.Fatalf("terminateMicrosandboxExec returned error: %v", err)
+	}
+	if got := strings.Join(handle.calls, ","); got != "kill,wait" {
+		t.Fatalf("termination calls = %q, want kill,wait", got)
+	}
+}
+
+func TestMicrosandboxExecStreamCancellationReportsUnconfirmedTermination(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	wantErr := errors.New("kill failed")
+	_, err := consumeMicrosandboxExecStream(
+		ctx,
+		func(ctx context.Context) (*microsandbox.ExecEvent, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		func() error { return nil },
+		func(context.Context) error { return wantErr },
+		&microsandboxExecCollector{},
+		time.Second,
+		nil,
+		0,
+	)
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, wantErr) || !errors.Is(err, ErrExecTerminationUnconfirmed) {
+		t.Fatalf("ExecStream error = %v, want cancellation and unconfirmed termination", err)
 	}
 }
 
@@ -125,7 +237,7 @@ func TestMicrosandboxExecStreamStopsWhenProcessIsGoneWithoutExit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := consumeMicrosandboxExecStream(ctx, recv, closeHandle, collector, 25*time.Millisecond, probeRecorder, 20*time.Millisecond)
+	result, err := consumeMicrosandboxExecStream(ctx, recv, closeHandle, nil, collector, 25*time.Millisecond, probeRecorder, 20*time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "without reporting its status") {
 		t.Fatalf("error = %v, want a lost-exit failure", err)
 	}
@@ -234,7 +346,7 @@ func TestMicrosandboxExecStreamKeepsWaitingWhileProcessLives(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := consumeMicrosandboxExecStream(ctx, stream.recv, func() error { return nil }, collector, 10*time.Millisecond, probe, 10*time.Millisecond)
+	result, err := consumeMicrosandboxExecStream(ctx, stream.recv, func() error { return nil }, nil, collector, 10*time.Millisecond, probe, 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("consumeMicrosandboxExecStream returned error: %v", err)
 	}
@@ -269,7 +381,7 @@ func TestMicrosandboxExecStreamKeepsWaitingWhenProbeFails(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := consumeMicrosandboxExecStream(ctx, stream.recv, func() error { return nil }, collector, 10*time.Millisecond, probe, 10*time.Millisecond)
+	result, err := consumeMicrosandboxExecStream(ctx, stream.recv, func() error { return nil }, nil, collector, 10*time.Millisecond, probe, 10*time.Millisecond)
 	if err != nil {
 		t.Fatalf("consumeMicrosandboxExecStream returned error: %v", err)
 	}
@@ -296,7 +408,7 @@ func TestMicrosandboxExecStreamRejectsDoneWithoutExit(t *testing.T) {
 	}
 	collector := &microsandboxExecCollector{filter: newExecOutputFilter()}
 
-	result, err := consumeMicrosandboxExecStream(context.Background(), recv, func() error { return nil }, collector, 25*time.Millisecond, nil, 0)
+	result, err := consumeMicrosandboxExecStream(context.Background(), recv, func() error { return nil }, nil, collector, 25*time.Millisecond, nil, 0)
 	if err == nil || !strings.Contains(err.Error(), "without reporting a process exit status") {
 		t.Fatalf("error = %v, want a missing-exit failure", err)
 	}

--- a/pkg/model/errors.go
+++ b/pkg/model/errors.go
@@ -7,16 +7,17 @@ import (
 )
 
 var (
-	ErrNotFound           = errors.New("not found")
-	ErrInvalidArgument    = errors.New("invalid argument")
-	ErrUnsupported        = errors.New("unsupported")
-	ErrRequired           = errors.New("required")
-	ErrAmbiguous          = errors.New("ambiguous")
-	ErrConflict           = errors.New("conflict")
-	ErrAlreadyExists      = errors.New("already exists")
-	ErrReferenced         = errors.New("referenced")
-	ErrFailedPrecondition = errors.New("failed precondition")
-	ErrBodyTooLarge       = errors.New("body too large")
+	ErrNotFound                   = errors.New("not found")
+	ErrInvalidArgument            = errors.New("invalid argument")
+	ErrUnsupported                = errors.New("unsupported")
+	ErrRequired                   = errors.New("required")
+	ErrAmbiguous                  = errors.New("ambiguous")
+	ErrConflict                   = errors.New("conflict")
+	ErrAlreadyExists              = errors.New("already exists")
+	ErrReferenced                 = errors.New("referenced")
+	ErrFailedPrecondition         = errors.New("failed precondition")
+	ErrBodyTooLarge               = errors.New("body too large")
+	ErrExecTerminationUnconfirmed = errors.New("guest execution termination unconfirmed")
 )
 
 type ClassifiedError struct {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -792,7 +792,7 @@ func markProjectRunInteractionArtifacts(ctx context.Context, coordinator *Coordi
 	})
 }
 
-func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, start *agentcomposev2.RunAttachStart, receive RunAttachReceiver, send RunAttachSender) (TransitionRequest, error) {
+func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, start *agentcomposev2.RunAttachStart, receive RunAttachReceiver, send RunAttachSender) (transitionResult TransitionRequest, returnErr error) {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	logsPath := filepath.Join(artifactsDir, "transcript.txt")
 	transition := TransitionRequest{RunID: run.RunID, SandboxID: sandbox.Summary.ID, LogsPath: logsPath}
@@ -872,7 +872,11 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 	if len(managedEnv) > 0 {
 		env = llms.MergeManagedExecEnv(env, managedEnv)
 		if token := managedEnv["AGENT_COMPOSE_SANDBOX_TOKEN"]; token != "" {
-			defer c.deletePromptAttachLLMFacadeToken(context.WithoutCancel(ctx), token)
+			defer func() {
+				if !errors.Is(returnErr, domain.ErrExecTerminationUnconfirmed) && !errors.Is(returnErr, driverpkg.ErrExecTerminationUnconfirmed) {
+					c.deletePromptAttachLLMFacadeToken(context.WithoutCancel(ctx), token)
+				}
+			}()
 		}
 	}
 	command := strings.Join([]string{


### PR DESCRIPTION
## Summary

- Make runtime cancellation a strong execution-lifecycle contract: a driver does not return from a canceled exec until the Guest execution has been terminated or termination is explicitly reported as unconfirmed.
- Use native execution handles for BoxLite (`boxlite_execution_kill`) and Microsandbox (`ExecHandle.Kill` followed by `Wait`).
- Add Docker execution-scoped markers because Docker Engine has no kill-exec API. A driver-owned control exec sends TERM/KILL only to the marked process tree, then confirms both marker disappearance and the original Docker exec exit. The sandbox and unrelated execs remain running.
- Apply the same Docker behavior to `ExecStream` and `OpenInteraction`, and retain temporary LLM facade tokens when a driver cannot confirm termination.

Closes #358.

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.62%
  - Integration: 61.42%
  - E2E: 61.28%
  - Combined: 78.93%
- `GOFLAGS=-buildvcs=false go test -race -count=1 ./pkg/driver ./pkg/agentcompose/adapters ./pkg/runs`
- `LD_LIBRARY_PATH=$PWD/build/microsandbox/lib GOFLAGS=-buildvcs=false go test -race -tags microsandboxcgo -count=1 -run '^TestMicrosandboxExecStreamCancellation' ./pkg/driver`
- `LD_LIBRARY_PATH=$PWD/build/microsandbox/lib GOFLAGS=-buildvcs=false go test -tags microsandboxcgo -count=1 ./pkg/driver`
- `GOFLAGS=-buildvcs=false go build -tags boxlitecgo ./pkg/driver`
- Real Docker E2E from `data/ai_analyse/ai-test-suit/suit-run-cancellation`:
  - canceled `AgentRunner` exec exited;
  - canceled Docker command interaction exited;
  - unrelated parallel Guest exec and container remained running;
  - facade token remained valid during termination and was deleted after confirmation.

The host has no `/dev/kvm`, so real BoxLite/Microsandbox VM smoke tests were not run; their native production paths were compiled and the Microsandbox lifecycle tests were run with native tags.

## Checklist

- [x] Documentation updated when behavior or configuration changed (no public API or configuration change; local E2E instructions are kept outside the repository under the shared `data/` suite).
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
