### PR TITLE
fix(llms): isolate sandbox provider environments

### DIFF
--- a/pkg/agentcompose/adapters/loader_command_executor.go
+++ b/pkg/agentcompose/adapters/loader_command_executor.go
@@ -266,15 +266,12 @@ func (e *LoaderCommandExecutor) prepareLoaderCommandLLMFacadeEnv(ctx context.Con
 	execSession.EnvItems = append([]domain.SandboxEnvVar(nil), session.EnvItems...)
 	execSession.RuntimeEnvItems = append([]domain.SandboxEnvVar(nil), session.RuntimeEnvItems...)
 	execSession.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), session.ProviderEnvItems...)
-	if len(execSession.ProviderEnvItems) == 0 {
-		globalEnv, err := e.ConfigDB.ListGlobalEnv(ctx)
-		if err != nil {
-			return nil, "", err
-		}
-		providerEnv := domain.MergeEnvItems(globalEnv, session.EnvItems)
-		providerEnv = domain.MergeEnvItems(providerEnv, domain.LoaderCommandSandboxEnv(request))
-		execSession.ProviderEnvItems = providerEnv
+	if len(execSession.ProviderEnvItems) == 0 && session.ProviderEnvOverrideNames == nil {
+		// Metadata without provider provenance cannot identify the original source,
+		// so its persisted environment snapshot remains the compatible fallback.
+		execSession.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), session.EnvItems...)
 	}
+	execSession.ProviderEnvItems = domain.MergeEnvItems(execSession.ProviderEnvItems, domain.LoaderCommandSandboxEnv(request))
 
 	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, e.Config, facadeStoreFor(e.ConfigDB), &execSession, agent, model, runtimefacade.TokenSourceLoaderCommand, runID)
 	if err != nil {

--- a/pkg/agentcompose/adapters/loader_session_runner.go
+++ b/pkg/agentcompose/adapters/loader_session_runner.go
@@ -102,12 +102,13 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	}
 	hasOverrides := loaders.AgentRequestOverridesSession(request, titleOverridesSession)
 	forceNew := effectivePolicy == domain.LoaderSandboxPolicyNew || hasOverrides
-	envItems, err := r.ConfigDB.ListGlobalEnv(ctx)
+	globalEnvItems, err := r.ConfigDB.ListGlobalEnv(ctx)
 	if err != nil {
 		return nil, "", err
 	}
+	var providerEnvItems []domain.SandboxEnvVar
 	if agentDefinition != nil {
-		envItems = domain.MergeEnvItems(envItems, agentDefinition.EnvItems)
+		providerEnvItems = domain.MergeEnvItems(providerEnvItems, agentDefinition.EnvItems)
 	}
 	agentConfig := execution.AgentConfig{Provider: domain.NormalizeAgentKind(request.Agent)}
 	if agentDefinition != nil {
@@ -122,9 +123,9 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	if agentConfig.Provider == "" {
 		agentConfig.Provider = domain.DefaultAgentProvider
 	}
-	envItems = domain.MergeEnvItems(envItems, loader.EnvItems)
-	envItems = domain.MergeEnvItems(envItems, domain.LoaderAgentSandboxEnv(request))
-	providerEnvItems := envItems
+	providerEnvItems = domain.MergeEnvItems(providerEnvItems, loader.EnvItems)
+	providerEnvItems = domain.MergeEnvItems(providerEnvItems, domain.LoaderAgentSandboxEnv(request))
+	envItems := domain.MergeEnvItems(globalEnvItems, providerEnvItems)
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	workspaceID := r.workspaceID(loader, request, agentDefinition)
 	workspaceSnapshot, err := r.workspaceSnapshot(ctx, workspaceID)
@@ -199,7 +200,7 @@ func (r *LoaderSandboxRunner) Ensure(ctx context.Context, loader domain.Loader, 
 	if err != nil {
 		return nil, "", err
 	}
-	session.ProviderEnvItems = providerEnvItems
+	llms.SetSandboxProviderEnvItems(session, providerEnvItems)
 	if request.PullPolicy != "" {
 		session.Summary.PullPolicy = request.PullPolicy
 		if err := r.Store.UpdateSandbox(ctx, session); err != nil {

--- a/pkg/agentcompose/adapters/loader_session_runner_env_test.go
+++ b/pkg/agentcompose/adapters/loader_session_runner_env_test.go
@@ -61,7 +61,7 @@ func TestLoaderSandboxRunnerEnvironmentPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure loader sandbox: %v", err)
 	}
-	got := loaderRunnerEnvItemsByName(sandbox.ProviderEnvItems)
+	got := loaderRunnerEnvItemsByName(domain.MergeEnvItems(sandbox.EnvItems, sandbox.ProviderEnvItems))
 	for name, want := range map[string]domain.SandboxEnvVar{
 		"GLOBAL_ONLY":       {Name: "GLOBAL_ONLY", Value: "global"},
 		"AGENT_ONLY":        {Name: "AGENT_ONLY", Value: "agent"},
@@ -74,6 +74,9 @@ func TestLoaderSandboxRunnerEnvironmentPrecedence(t *testing.T) {
 		if got[name] != want {
 			t.Fatalf("effective env %s = %#v, want %#v", name, got[name], want)
 		}
+	}
+	if _, ok := loaderRunnerEnvItemsByName(sandbox.ProviderEnvItems)["GLOBAL_ONLY"]; ok {
+		t.Fatal("global-only env was recorded as a sandbox provider override")
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge.go
@@ -183,22 +183,20 @@ func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandb
 	}
 	tags := sandboxTagsWithoutAgentIdentity(req.Tags)
 	tags = append(tags, domain.SandboxTag{Name: domain.AgentSandboxTagProvider, Value: agentConfig.Provider})
-	envItems := append([]domain.SandboxEnvVar(nil), req.EnvItems...)
+	providerEnvItems := append([]domain.SandboxEnvVar(nil), req.EnvItems...)
 	globalEnvItems, err := b.configDB.ListGlobalEnv(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if agentDefinition != nil {
-		envItems = domain.MergeEnvItems(domain.MergeEnvItems(globalEnvItems, agentDefinition.EnvItems), envItems)
+		providerEnvItems = domain.MergeEnvItems(agentDefinition.EnvItems, providerEnvItems)
 		tags = append(tags,
 			domain.SandboxTag{Name: domain.AgentSandboxTagSource, Value: domain.AgentSandboxTagSourceVal},
 			domain.SandboxTag{Name: domain.AgentSandboxTagID, Value: agentDefinition.ID},
 			domain.SandboxTag{Name: domain.AgentSandboxTagName, Value: agentDefinition.Name},
 		)
-	} else {
-		envItems = domain.MergeEnvItems(globalEnvItems, envItems)
 	}
-	providerEnvItems := envItems
+	envItems := domain.MergeEnvItems(globalEnvItems, providerEnvItems)
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	capabilityVars, capabilityTags := capabilities.BuildGatewaySandboxVars(capabilities.ProxyTarget(b.cap), req.CapsetIDs)
 	envItems = domain.MergeEnvItems(envItems, capabilityVars)
@@ -226,7 +224,7 @@ func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandb
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	session.ProviderEnvItems = providerEnvItems
+	llms.SetSandboxProviderEnvItems(session, providerEnvItems)
 	if err := b.workspaceEnsurer.Ensure(ctx, session); err != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = b.store.UpdateSandbox(ctx, session)

--- a/pkg/agentcompose/adapters/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_test.go
@@ -183,6 +183,7 @@ func TestSandboxRPCBridgeCallJSONSupportsSessionRPCs(t *testing.T) {
 func TestSandboxRPCBridgeCreateSandboxInheritsSchedulerAgentEnvironment(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
+	bridge.config.RuntimeBaseURL = "http://agent-compose.test:7410"
 	definition, err := bridge.configDB.CreateAgentDefinition(ctx, domain.AgentDefinition{
 		ID:           "agent-scheduler",
 		Name:         "scheduler-agent",

--- a/pkg/agentcompose/proxy/runtime_llm_chat_integration_test.go
+++ b/pkg/agentcompose/proxy/runtime_llm_chat_integration_test.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestIntegrationRuntimeLLMFacadeUsesChatOnlyUpstream(t *testing.T) {
+	tests := []struct {
+		name       string
+		wireAPI    string
+		facadePath string
+		body       string
+	}{
+		{
+			name:       "Codex and OpenCode responses ingress",
+			wireAPI:    llms.APIProtocolResponses,
+			facadePath: "/api/runtime/sandboxes/sandbox-1/llm/openai/v1/responses",
+			body:       `{"model":"gpt","input":"hi"}`,
+		},
+		{
+			name:       "OpenCode compatible chat ingress",
+			wireAPI:    llms.APIProtocolChatCompletions,
+			facadePath: "/api/runtime/sandboxes/sandbox-1/llm/openai/v1/chat/completions",
+			body:       `{"model":"gpt","messages":[{"role":"user","content":"hi"}]}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream, upstreamPaths := newChatOnlyUpstream(t)
+
+			e := echo.New()
+			RegisterRuntimeLLMFacadeRoutes(e, RuntimeLLMOptions{
+				Tokens: fakeRuntimeLLMTokens{token: llms.FacadeToken{
+					SandboxID:  "sandbox-1",
+					Model:      "gpt",
+					ProviderID: "provider-1",
+					WireAPI:    tc.wireAPI,
+					ExpiresAt:  time.Now().Add(time.Hour),
+				}},
+				Sandboxes: fakeRuntimeLLMSessions{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", VMStatus: domain.VMStatusRunning}}},
+				ResolveTarget: func(context.Context, string, string) (llms.ResolvedTarget, error) {
+					return llms.ResolvedTarget{
+						Provider: llms.Provider{ID: "provider-1", ProviderType: llms.ProviderFamilyOpenAI, BaseURL: upstream.URL + "/v1"},
+						Model:    llms.Model{Name: "gpt"},
+						WireAPI:  llms.APIProtocolChatCompletions,
+					}, nil
+				},
+				Client: upstream.Client(),
+			})
+			req := httptest.NewRequest(http.MethodPost, tc.facadePath, strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer facade-token")
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("facade status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+			if upstreamPath := <-upstreamPaths; upstreamPath != "/v1/chat/completions" {
+				t.Fatalf("upstream path = %q", upstreamPath)
+			}
+		})
+	}
+}
+
+func newChatOnlyUpstream(t *testing.T) (*httptest.Server, <-chan string) {
+	t.Helper()
+	paths := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths <- r.URL.Path
+		if r.URL.Path != "/v1/chat/completions" {
+			http.Error(w, "chat completions only", http.StatusNotFound)
+			return
+		}
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream request: %v", err)
+			http.Error(w, "read request", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(string(requestBody), `"messages"`) {
+			t.Errorf("upstream request is not Chat Completions: %s", requestBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, `{"id":"chatcmpl-only","object":"chat.completion","created":0,"model":"gpt","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`); err != nil {
+			t.Errorf("write upstream response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, paths
+}

--- a/pkg/execution/agent_config.go
+++ b/pkg/execution/agent_config.go
@@ -35,7 +35,7 @@ func ApplyAgentProviderEnv(session *domain.Sandbox, agentEnv []domain.SandboxEnv
 		return
 	}
 	providerEnv := session.ProviderEnvItems
-	if len(providerEnv) == 0 {
+	if len(providerEnv) == 0 && session.ProviderEnvOverrideNames == nil {
 		providerEnv = session.EnvItems
 	}
 	session.ProviderEnvItems = domain.MergeEnvItems(agentEnv, providerEnv)

--- a/pkg/llms/anthropic_credential.go
+++ b/pkg/llms/anthropic_credential.go
@@ -1,0 +1,66 @@
+package llms
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+type anthropicCredential struct {
+	apiKey     string
+	authHeader string
+	authScheme string
+}
+
+// layeredAnthropicCredential selects the credential value and its wire
+// authentication semantics from one winning source layer. A generic key in a
+// higher layer must not be paired with, or displaced by, a family-specific
+// credential from a lower layer.
+func layeredAnthropicCredential(ctx context.Context, config *appconfig.Config, store GlobalEnvStore, sandboxItems []domain.SandboxEnvVar) anthropicCredential {
+	if credential, ok := anthropicCredentialFromItems(sandboxItems); ok {
+		return credential
+	}
+	if store != nil {
+		globalItems, err := store.ListGlobalEnv(ctx)
+		if err == nil {
+			if credential, ok := anthropicCredentialFromItems(globalItems); ok {
+				return credential
+			}
+		}
+	}
+	if credential, ok := anthropicCredentialFromValues(
+		os.Getenv("ANTHROPIC_API_KEY"),
+		os.Getenv("ANTHROPIC_AUTH_TOKEN"),
+		os.Getenv("LLM_API_KEY"),
+	); ok {
+		return credential
+	}
+	if credential, ok := anthropicCredentialFromValues("", "", configLLMEnvValue(config, "LLM_API_KEY")); ok {
+		return credential
+	}
+	return anthropicCredential{authHeader: "x-api-key"}
+}
+
+func anthropicCredentialFromItems(items []domain.SandboxEnvVar) (anthropicCredential, bool) {
+	return anthropicCredentialFromValues(
+		EnvItemValue(items, "ANTHROPIC_API_KEY"),
+		EnvItemValue(items, "ANTHROPIC_AUTH_TOKEN"),
+		EnvItemValue(items, "LLM_API_KEY"),
+	)
+}
+
+func anthropicCredentialFromValues(apiKey, authToken, genericKey string) (anthropicCredential, bool) {
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		return anthropicCredential{apiKey: apiKey, authHeader: "x-api-key"}, true
+	}
+	if authToken = strings.TrimSpace(authToken); authToken != "" {
+		return anthropicCredential{apiKey: authToken, authHeader: "Authorization", authScheme: "Bearer"}, true
+	}
+	if genericKey = strings.TrimSpace(genericKey); genericKey != "" {
+		return anthropicCredential{apiKey: genericKey, authHeader: "x-api-key"}, true
+	}
+	return anthropicCredential{}, false
+}

--- a/pkg/llms/codex_facade.go
+++ b/pkg/llms/codex_facade.go
@@ -1,0 +1,58 @@
+package llms
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+// CodexFacadeStore is the persistence surface needed to resolve a Codex model
+// and issue its run-scoped runtime facade token.
+type CodexFacadeStore interface {
+	LLMResolverStore
+	SaveLLMFacadeToken(context.Context, FacadeToken) error
+}
+
+// EnsureCodexFacadeConfig resolves the managed Codex provider and model,
+// requires a sandbox-reachable facade, and returns its managed environment.
+// A missing managed provider remains a no-op so Codex can use its own login.
+func EnsureCodexFacadeConfig(ctx context.Context, config *appconfig.Config, store CodexFacadeStore, sandbox *domain.Sandbox, model, source, runID string) (map[string]string, error) {
+	providerEnv, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, ProviderFamilyOpenAI, model, "", providerEnv)
+	if err != nil {
+		if errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	baseURL, err := RequireGuestRuntimeBaseURL(config, sandbox)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenValue, token, err := NewFacadeToken(sandbox.Summary.ID, target.Model.Name, target.Provider.ID, APIProtocolResponses, source, runID)
+	if err != nil {
+		return nil, err
+	}
+	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, err
+	}
+	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/openai/v1"
+	if err := WriteCodexRuntimeConfig(sandbox, target.Model.Name, openAIBaseURL, APIProtocolResponses, CodexRuntimePolicyFromConfig(config)); err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"AGENT_COMPOSE_SANDBOX_TOKEN": tokenValue,
+		"LLM_API_ENDPOINT":            openAIBaseURL,
+		"LLM_API_KEY":                 tokenValue,
+		"LLM_API_PROTOCOL":            APIProtocolResponses,
+		"OPENAI_API_KEY":              tokenValue,
+		"OPENAI_BASE_URL":             openAIBaseURL,
+	}, nil
+}

--- a/pkg/llms/config_helpers_coverage_test.go
+++ b/pkg/llms/config_helpers_coverage_test.go
@@ -17,11 +17,15 @@ import (
 func TestRuntimeConfigAndEnvHelperWorkflows(t *testing.T) {
 	root := t.TempDir()
 	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: filepath.Join(root, "workspace")}}
-	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolChatCompletions, CodexRuntimePolicyFromConfig(nil)); err != nil {
+	policy := CodexRuntimePolicyFromConfig(nil)
+	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolChatCompletions, policy); err == nil {
+		t.Fatal("WriteCodexRuntimeConfig accepted unsupported Chat Completions")
+	}
+	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolResponses, policy); err != nil {
 		t.Fatalf("WriteCodexRuntimeConfig returned error: %v", err)
 	}
 	codexConfig, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml"))
-	if err != nil || !strings.Contains(string(codexConfig), `wire_api = "chat_completions"`) || !strings.Contains(string(codexConfig), `AGENT_COMPOSE_SANDBOX_TOKEN`) {
+	if err != nil || !strings.Contains(string(codexConfig), `wire_api = "responses"`) || !strings.Contains(string(codexConfig), `AGENT_COMPOSE_SANDBOX_TOKEN`) {
 		t.Fatalf("codex config=%q err=%v", string(codexConfig), err)
 	}
 	if err := WriteOpenCodeRuntimeConfig(session, "custom", "gpt-custom", "http://runtime/openai/v1/"); err != nil {

--- a/pkg/llms/custom_openai_facade_target.go
+++ b/pkg/llms/custom_openai_facade_target.go
@@ -9,7 +9,10 @@ import (
 )
 
 func resolveCustomOpenAIFacadeTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sandbox *domain.Sandbox, providerID, model string) (ResolvedTarget, error) {
-	envItems := sandboxProviderEnvItems(sandbox)
+	envItems, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyOpenAI)
+	if err != nil {
+		return ResolvedTarget{}, err
+	}
 	sandboxID := ""
 	if sandbox != nil {
 		sandboxID = sandbox.Summary.ID
@@ -18,7 +21,7 @@ func resolveCustomOpenAIFacadeTarget(ctx context.Context, config *appconfig.Conf
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, ProviderFamilyOpenAI, model, providerID, envItems)
 	}
 	if sandboxID != "" && HasOpenAIEnvProviderInput(envItems) {
-		sessionProviderID, err := EnsureSessionOpenAIEnvProvider(ctx, store, sandboxID, model, envItems)
+		sessionProviderID, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sandboxID, model, envItems)
 		if err != nil {
 			return ResolvedTarget{}, err
 		}
@@ -30,14 +33,4 @@ func resolveCustomOpenAIFacadeTarget(ctx context.Context, config *appconfig.Conf
 		return ResolvedTarget{}, err
 	}
 	return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, ProviderFamilyOpenAI, model, providerID, envItems)
-}
-
-func sandboxProviderEnvItems(sandbox *domain.Sandbox) []domain.SandboxEnvVar {
-	if sandbox == nil {
-		return nil
-	}
-	if len(sandbox.ProviderEnvItems) > 0 {
-		return sandbox.ProviderEnvItems
-	}
-	return sandbox.EnvItems
 }

--- a/pkg/llms/env_provider.go
+++ b/pkg/llms/env_provider.go
@@ -1,7 +1,6 @@
 package llms
 
 import (
-	"net/url"
 	"strings"
 
 	domain "agent-compose/pkg/model"
@@ -18,18 +17,6 @@ func EnvItemValue(items []domain.SandboxEnvVar, key string) string {
 		}
 	}
 	return ""
-}
-
-func LooksLikeAnthropicMessagesEndpoint(endpoint string) bool {
-	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
-	if endpoint == "" {
-		return false
-	}
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return strings.HasSuffix(endpoint, "/messages")
-	}
-	return strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), "/messages")
 }
 
 func EnvHasProviderKeyForFamily(envItems []domain.SandboxEnvVar, providerFamily string) bool {
@@ -51,24 +38,63 @@ func EnvHasProviderKeyForFamily(envItems []domain.SandboxEnvVar, providerFamily 
 }
 
 func HasOpenAIEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
-	endpoint := EnvItemValue(envItems, "LLM_API_ENDPOINT")
-	if LooksLikeAnthropicMessagesEndpoint(endpoint) {
-		return false
-	}
-	return strings.TrimSpace(firstNonEmpty(
-		endpoint,
-		EnvItemValue(envItems, "LLM_API_KEY"),
-		EnvItemValue(envItems, "OPENAI_API_KEY"),
-	)) != ""
+	return hasOpenAIEnvProviderInput(envItems) ||
+		hasGenericLLMEnvProviderInput(envItems) && genericLLMEnvProviderFamily(envItems) == ProviderFamilyOpenAI
 }
 
 func HasAnthropicEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
+	return hasAnthropicEnvProviderInput(envItems) ||
+		hasGenericLLMEnvProviderInput(envItems) && genericLLMEnvProviderFamily(envItems) == ProviderFamilyAnthropic
+}
+
+// hasEnvProviderInputForFamily treats generic LLM_* values as belonging to an
+// explicitly selected provider family. Callers without an explicit family must
+// use HasOpenAIEnvProviderInput or HasAnthropicEnvProviderInput, which resolve
+// generic values through LLM_API_PROTOCOL instead of inspecting the endpoint.
+func hasEnvProviderInputForFamily(envItems []domain.SandboxEnvVar, providerFamily string) bool {
+	switch NormalizeProviderType(providerFamily) {
+	case ProviderFamilyOpenAI:
+		return hasOpenAIEnvProviderInput(envItems) || hasGenericLLMEnvProviderInput(envItems)
+	case ProviderFamilyAnthropic:
+		return hasAnthropicEnvProviderInput(envItems) || hasGenericLLMEnvProviderInput(envItems)
+	default:
+		return false
+	}
+}
+
+func hasOpenAIEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
+	return strings.TrimSpace(EnvItemValue(envItems, "OPENAI_API_KEY")) != ""
+}
+
+func hasAnthropicEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
 	return strings.TrimSpace(firstNonEmpty(
 		EnvItemValue(envItems, "ANTHROPIC_BASE_URL"),
 		EnvItemValue(envItems, "ANTHROPIC_API_ENDPOINT"),
 		EnvItemValue(envItems, "ANTHROPIC_API_KEY"),
 		EnvItemValue(envItems, "ANTHROPIC_AUTH_TOKEN"),
-	)) != "" || LooksLikeAnthropicMessagesEndpoint(EnvItemValue(envItems, "LLM_API_ENDPOINT"))
+	)) != ""
+}
+
+func hasGenericLLMEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
+	return strings.TrimSpace(firstNonEmpty(
+		EnvItemValue(envItems, "LLM_API_ENDPOINT"),
+		EnvItemValue(envItems, "LLM_API_KEY"),
+	)) != ""
+}
+
+func genericLLMEnvProviderFamily(envItems []domain.SandboxEnvVar) string {
+	hasOpenAI := hasOpenAIEnvProviderInput(envItems)
+	hasAnthropic := hasAnthropicEnvProviderInput(envItems)
+	switch {
+	case hasAnthropic && !hasOpenAI:
+		return ProviderFamilyAnthropic
+	case hasOpenAI && !hasAnthropic:
+		return ProviderFamilyOpenAI
+	case NormalizeWireAPI(EnvItemValue(envItems, "LLM_API_PROTOCOL")) == APIProtocolMessages:
+		return ProviderFamilyAnthropic
+	default:
+		return ProviderFamilyOpenAI
+	}
 }
 
 func HasSessionEnvProviderInput(envItems []domain.SandboxEnvVar) bool {

--- a/pkg/llms/env_provider.go
+++ b/pkg/llms/env_provider.go
@@ -47,21 +47,6 @@ func HasAnthropicEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
 		hasGenericLLMEnvProviderInput(envItems) && genericLLMEnvProviderFamily(envItems) == ProviderFamilyAnthropic
 }
 
-// hasEnvProviderInputForFamily treats generic LLM_* values as belonging to an
-// explicitly selected provider family. Callers without an explicit family must
-// use HasOpenAIEnvProviderInput or HasAnthropicEnvProviderInput, which resolve
-// generic values through LLM_API_PROTOCOL instead of inspecting the endpoint.
-func hasEnvProviderInputForFamily(envItems []domain.SandboxEnvVar, providerFamily string) bool {
-	switch NormalizeProviderType(providerFamily) {
-	case ProviderFamilyOpenAI:
-		return hasOpenAIEnvProviderInput(envItems) || hasGenericLLMEnvProviderInput(envItems)
-	case ProviderFamilyAnthropic:
-		return hasAnthropicEnvProviderInput(envItems) || hasGenericLLMEnvProviderInput(envItems)
-	default:
-		return false
-	}
-}
-
 func hasOpenAIEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
 	return strings.TrimSpace(EnvItemValue(envItems, "OPENAI_API_KEY")) != ""
 }
@@ -83,6 +68,9 @@ func hasGenericLLMEnvProviderInput(envItems []domain.SandboxEnvVar) bool {
 }
 
 func genericLLMEnvProviderFamily(envItems []domain.SandboxEnvVar) string {
+	if !hasGenericLLMEnvProviderInput(envItems) {
+		return ""
+	}
 	hasOpenAI := hasOpenAIEnvProviderInput(envItems)
 	hasAnthropic := hasAnthropicEnvProviderInput(envItems)
 	switch {

--- a/pkg/llms/env_provider_test.go
+++ b/pkg/llms/env_provider_test.go
@@ -1,0 +1,79 @@
+package llms
+
+import (
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestEnvProviderFamilySelectionUsesExplicitSignals(t *testing.T) {
+	tests := []struct {
+		name          string
+		items         []domain.SandboxEnvVar
+		wantOpenAI    bool
+		wantAnthropic bool
+	}{
+		{
+			name: "responses protocol remains OpenAI when path ends in messages",
+			items: []domain.SandboxEnvVar{
+				{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/custom/messages"},
+				{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+				{Name: "LLM_API_KEY", Value: "generic-key"},
+			},
+			wantOpenAI: true,
+		},
+		{
+			name: "messages protocol selects Anthropic for a base URL",
+			items: []domain.SandboxEnvVar{
+				{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/api/anthropic"},
+				{Name: "LLM_API_PROTOCOL", Value: APIProtocolMessages},
+				{Name: "LLM_API_KEY", Value: "generic-key"},
+			},
+			wantAnthropic: true,
+		},
+		{
+			name: "Anthropic variables select Anthropic regardless of generic protocol",
+			items: []domain.SandboxEnvVar{
+				{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/base"},
+				{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+				{Name: "ANTHROPIC_API_KEY", Value: "anthropic-key"},
+			},
+			wantAnthropic: true,
+		},
+		{
+			name: "OpenAI variables select OpenAI regardless of generic protocol",
+			items: []domain.SandboxEnvVar{
+				{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/base"},
+				{Name: "LLM_API_PROTOCOL", Value: APIProtocolMessages},
+				{Name: "OPENAI_API_KEY", Value: "openai-key"},
+			},
+			wantOpenAI: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasOpenAIEnvProviderInput(tt.items); got != tt.wantOpenAI {
+				t.Fatalf("HasOpenAIEnvProviderInput() = %t, want %t", got, tt.wantOpenAI)
+			}
+			if got := HasAnthropicEnvProviderInput(tt.items); got != tt.wantAnthropic {
+				t.Fatalf("HasAnthropicEnvProviderInput() = %t, want %t", got, tt.wantAnthropic)
+			}
+		})
+	}
+}
+
+func TestExplicitProviderFamilyOwnsGenericLLMInput(t *testing.T) {
+	items := []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/base"},
+		{Name: "LLM_API_KEY", Value: "generic-key"},
+	}
+	for _, family := range []string{ProviderFamilyOpenAI, ProviderFamilyAnthropic} {
+		if !hasEnvProviderInputForFamily(items, family) {
+			t.Fatalf("generic LLM input was not assigned to explicit family %q", family)
+		}
+		if !EnvHasProviderKeyForFamily(items, family) {
+			t.Fatalf("generic LLM key was not assigned to explicit family %q", family)
+		}
+	}
+}

--- a/pkg/llms/env_provider_test.go
+++ b/pkg/llms/env_provider_test.go
@@ -62,18 +62,3 @@ func TestEnvProviderFamilySelectionUsesExplicitSignals(t *testing.T) {
 		})
 	}
 }
-
-func TestExplicitProviderFamilyOwnsGenericLLMInput(t *testing.T) {
-	items := []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/base"},
-		{Name: "LLM_API_KEY", Value: "generic-key"},
-	}
-	for _, family := range []string{ProviderFamilyOpenAI, ProviderFamilyAnthropic} {
-		if !hasEnvProviderInputForFamily(items, family) {
-			t.Fatalf("generic LLM input was not assigned to explicit family %q", family)
-		}
-		if !EnvHasProviderKeyForFamily(items, family) {
-			t.Fatalf("generic LLM key was not assigned to explicit family %q", family)
-		}
-	}
-}

--- a/pkg/llms/opencode_facade.go
+++ b/pkg/llms/opencode_facade.go
@@ -39,7 +39,11 @@ func EnsureOpenCodeFacadeConfig(ctx context.Context, config *appconfig.Config, s
 }
 
 func ensureOpenCodeAnthropicFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, ProviderFamilyAnthropic, model, "", sandboxProviderEnvItems(sandbox))
+	providerEnv, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyAnthropic)
+	if err != nil {
+		return nil, err
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, ProviderFamilyAnthropic, model, "", providerEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +72,11 @@ func ensureOpenCodeAnthropicFacadeConfig(ctx context.Context, config *appconfig.
 }
 
 func ensureOpenCodeOpenAIFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, ProviderFamilyOpenAI, model, "", sandboxProviderEnvItems(sandbox))
+	providerEnv, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, ProviderFamilyOpenAI, model, "", providerEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/llms/pi_facade.go
+++ b/pkg/llms/pi_facade.go
@@ -74,15 +74,26 @@ func EnsurePiFacadeConfig(ctx context.Context, config *appconfig.Config, store P
 }
 
 func resolvePiFacadeTarget(ctx context.Context, config *appconfig.Config, store PiFacadeStore, sandbox *domain.Sandbox, providerID, model string) (ResolvedTarget, error) {
-	envItems := sandboxProviderEnvItems(sandbox)
 	sandboxID := sandbox.Summary.ID
 	if HasEnabledLLMProviderID(ctx, store, providerID) {
+		envItems, err := SandboxProviderEnvItems(ctx, store, sandbox, "")
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, "", model, providerID, envItems)
 	}
 	switch providerID {
 	case ProviderFamilyAnthropic:
+		envItems, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyAnthropic)
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, ProviderFamilyAnthropic, model, "", envItems)
 	case ProviderFamilyOpenAI, ProviderIDDefaultOpenAI:
+		envItems, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyOpenAI)
+		if err != nil {
+			return ResolvedTarget{}, err
+		}
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, ProviderFamilyOpenAI, model, "", envItems)
 	default:
 		return resolveCustomOpenAIFacadeTarget(ctx, config, store, sandbox, providerID, model)
@@ -92,7 +103,10 @@ func resolvePiFacadeTarget(ctx context.Context, config *appconfig.Config, store 
 func piFacadeProtocol(target ResolvedTarget, runtimeBaseURL, sandboxID string) (piAPI, facadeProtocol, facadeBaseURL string, err error) {
 	runtimeBaseURL = strings.TrimRight(runtimeBaseURL, "/")
 	if target.Provider.ProviderType == ProviderFamilyAnthropic {
-		return "anthropic-messages", APIProtocolMessages, runtimeBaseURL + "/api/runtime/sandboxes/" + sandboxID + "/llm/anthropic/v1", nil
+		// Pi's Anthropic SDK appends /v1/messages to the configured base URL.
+		// Keep the facade base at the family root so the version segment appears
+		// exactly once in the resulting request path.
+		return "anthropic-messages", APIProtocolMessages, runtimeBaseURL + "/api/runtime/sandboxes/" + sandboxID + "/llm/anthropic", nil
 	}
 	if target.Provider.ProviderType != ProviderFamilyOpenAI {
 		return "", "", "", fmt.Errorf("unsupported pi llm provider family %q", target.Provider.ProviderType)

--- a/pkg/llms/pi_runtime_config_test.go
+++ b/pkg/llms/pi_runtime_config_test.go
@@ -70,7 +70,7 @@ func TestPiFacadeProtocol(t *testing.T) {
 	}{
 		{name: "responses", target: ResolvedTarget{Provider: Provider{ProviderType: ProviderFamilyOpenAI}, WireAPI: APIProtocolResponses}, wantAPI: "openai-responses", wantWire: APIProtocolResponses, wantSuffix: "/llm/openai/v1"},
 		{name: "chat completions", target: ResolvedTarget{Provider: Provider{ProviderType: ProviderFamilyOpenAI}, WireAPI: APIProtocolChatCompletions}, wantAPI: "openai-completions", wantWire: APIProtocolChatCompletions, wantSuffix: "/llm/openai/v1"},
-		{name: "messages", target: ResolvedTarget{Provider: Provider{ProviderType: ProviderFamilyAnthropic}, WireAPI: APIProtocolMessages}, wantAPI: "anthropic-messages", wantWire: APIProtocolMessages, wantSuffix: "/llm/anthropic/v1"},
+		{name: "messages", target: ResolvedTarget{Provider: Provider{ProviderType: ProviderFamilyAnthropic}, WireAPI: APIProtocolMessages}, wantAPI: "anthropic-messages", wantWire: APIProtocolMessages, wantSuffix: "/llm/anthropic"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/llms/provider_bootstrap.go
+++ b/pkg/llms/provider_bootstrap.go
@@ -96,20 +96,17 @@ func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, look
 	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
 }
 
-func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, authHeader, authScheme, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+func ensureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, credential anthropicCredential, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
 	anthropicEndpoint := lookup("ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT")
 	genericEndpoint := lookup("LLM_API_ENDPOINT")
-	anthropicKey := lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
 	anthropicModel := lookup("ANTHROPIC_MODEL", "CLAUDE_MODEL")
 	genericModel := lookup("LLM_MODEL")
-	genericKey := lookup("LLM_API_KEY")
-	if anthropicEndpoint == "" && strings.TrimSpace(anthropicKey) == "" && strings.TrimSpace(anthropicModel) == "" && genericEndpoint == "" && strings.TrimSpace(genericKey) == "" && strings.TrimSpace(genericModel) == "" {
+	if anthropicEndpoint == "" && strings.TrimSpace(credential.apiKey) == "" && strings.TrimSpace(anthropicModel) == "" && genericEndpoint == "" && strings.TrimSpace(genericModel) == "" {
 		return "", nil
 	}
 	anthropicEndpoint = firstNonEmpty(anthropicEndpoint, genericEndpoint)
 	anthropicModel = firstNonEmpty(anthropicModel, genericModel)
 	endpoint := firstNonEmpty(anthropicEndpoint, "https://api.anthropic.com")
-	apiKey := firstNonEmpty(anthropicKey, genericKey)
 	model := strings.TrimSpace(firstNonEmpty(requestedModel, anthropicModel))
 	if providerID == "" || model == "" {
 		return "", nil
@@ -120,9 +117,9 @@ func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, l
 		ProviderType:   ProviderFamilyAnthropic,
 		DefaultWireAPI: APIProtocolMessages,
 		BaseURL:        endpoint,
-		APIKey:         apiKey,
-		AuthHeader:     authHeader,
-		AuthScheme:     authScheme,
+		APIKey:         credential.apiKey,
+		AuthHeader:     credential.authHeader,
+		AuthScheme:     credential.authScheme,
 		HeadersJSON:    `{"anthropic-version":"2023-06-01"}`,
 		Weight:         10,
 		Enabled:        true,
@@ -130,6 +127,23 @@ func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, l
 	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
 }
 
+// EnsureAnthropicEnvProvider persists an environment-backed Anthropic
+// provider using caller-selected authentication semantics. Resolver paths use
+// layeredAnthropicCredential so the key and semantics share a source layer.
+func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, authHeader, authScheme, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+	credential := anthropicCredential{
+		apiKey: firstNonEmpty(
+			lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
+			lookup("LLM_API_KEY"),
+		),
+		authHeader: authHeader,
+		authScheme: authScheme,
+	}
+	return ensureAnthropicEnvProvider(ctx, store, lookup, credential, providerID, name, scope, requestedModel, defaultModel)
+}
+
+// AnthropicProviderAuthFromLookup derives Anthropic authentication semantics
+// from a lookup whose values belong to one already-selected source layer.
 func AnthropicProviderAuthFromLookup(lookup EnvProviderLookup) (string, string) {
 	if strings.TrimSpace(lookup("ANTHROPIC_API_KEY")) != "" {
 		return "x-api-key", ""

--- a/pkg/llms/provider_bootstrap.go
+++ b/pkg/llms/provider_bootstrap.go
@@ -15,6 +15,24 @@ type ProviderListStore interface {
 	ListEnabledLLMProviders(ctx context.Context) ([]Provider, error)
 }
 
+func hasDefaultAnthropicEnvProviderInput(lookup EnvProviderLookup) bool {
+	if strings.TrimSpace(firstNonEmpty(
+		lookup("ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT"),
+		lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
+		lookup("ANTHROPIC_MODEL", "CLAUDE_MODEL"),
+	)) != "" {
+		return true
+	}
+	if NormalizeWireAPI(lookup("LLM_API_PROTOCOL")) != APIProtocolMessages {
+		return false
+	}
+	return strings.TrimSpace(firstNonEmpty(
+		lookup("LLM_API_ENDPOINT"),
+		lookup("LLM_API_KEY"),
+		lookup("LLM_MODEL"),
+	)) != ""
+}
+
 func HasEnabledProviderID(ctx context.Context, store ProviderListStore, providerID string) bool {
 	providerID = strings.TrimSpace(providerID)
 	if store == nil || providerID == "" {
@@ -53,10 +71,10 @@ func HasConfiguredProviderForFamily(ctx context.Context, store ProviderListStore
 
 func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
 	endpoint := firstNonEmpty(lookup("LLM_API_ENDPOINT"), "https://api.openai.com")
-	if LooksLikeAnthropicMessagesEndpoint(endpoint) {
+	protocol := NormalizeWireAPI(lookup("LLM_API_PROTOCOL"))
+	if protocol == APIProtocolMessages {
 		return "", nil
 	}
-	protocol := NormalizeWireAPI(lookup("LLM_API_PROTOCOL"))
 	apiKey := lookup("LLM_API_KEY", "OPENAI_API_KEY")
 	model := strings.TrimSpace(firstNonEmpty(requestedModel, lookup("LLM_MODEL")))
 	if providerID == "" || model == "" {
@@ -84,18 +102,14 @@ func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, l
 	anthropicKey := lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
 	anthropicModel := lookup("ANTHROPIC_MODEL", "CLAUDE_MODEL")
 	genericModel := lookup("LLM_MODEL")
-	useGenericEndpoint := anthropicEndpoint == "" && LooksLikeAnthropicMessagesEndpoint(genericEndpoint)
-	if useGenericEndpoint {
-		anthropicEndpoint = genericEndpoint
-	}
-	if genericModel != "" && (useGenericEndpoint || anthropicEndpoint != "" || anthropicKey != "" || anthropicModel != "") {
-		anthropicModel = firstNonEmpty(anthropicModel, genericModel)
-	}
-	if anthropicEndpoint == "" && strings.TrimSpace(anthropicKey) == "" && strings.TrimSpace(anthropicModel) == "" {
+	genericKey := lookup("LLM_API_KEY")
+	if anthropicEndpoint == "" && strings.TrimSpace(anthropicKey) == "" && strings.TrimSpace(anthropicModel) == "" && genericEndpoint == "" && strings.TrimSpace(genericKey) == "" && strings.TrimSpace(genericModel) == "" {
 		return "", nil
 	}
+	anthropicEndpoint = firstNonEmpty(anthropicEndpoint, genericEndpoint)
+	anthropicModel = firstNonEmpty(anthropicModel, genericModel)
 	endpoint := firstNonEmpty(anthropicEndpoint, "https://api.anthropic.com")
-	apiKey := firstNonEmpty(anthropicKey, lookup("LLM_API_KEY"))
+	apiKey := firstNonEmpty(anthropicKey, genericKey)
 	model := strings.TrimSpace(firstNonEmpty(requestedModel, anthropicModel))
 	if providerID == "" || model == "" {
 		return "", nil

--- a/pkg/llms/provider_bootstrap_test.go
+++ b/pkg/llms/provider_bootstrap_test.go
@@ -1,0 +1,118 @@
+package llms
+
+import (
+	"context"
+	"testing"
+)
+
+func TestOpenAIEnvProviderUsesProtocolInsteadOfEndpointShape(t *testing.T) {
+	tests := []struct {
+		name         string
+		protocol     string
+		wantProvider bool
+	}{
+		{name: "responses path ending in messages remains OpenAI", protocol: APIProtocolResponses, wantProvider: true},
+		{name: "messages protocol is not OpenAI", protocol: APIProtocolMessages, wantProvider: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newResolverCoverageStore()
+			values := map[string]string{
+				"LLM_API_ENDPOINT": "https://gateway.example/custom/messages",
+				"LLM_API_PROTOCOL": tt.protocol,
+				"LLM_API_KEY":      "generic-key",
+				"LLM_MODEL":        "test-model",
+			}
+			id, err := EnsureOpenAIEnvProvider(context.Background(), store, mapLookup(values), "openai-env", "openai-env", ProviderScopeSessionEnv, "", false)
+			if err != nil {
+				t.Fatalf("EnsureOpenAIEnvProvider() error = %v", err)
+			}
+			if got := id != ""; got != tt.wantProvider {
+				t.Fatalf("provider created = %t, want %t", got, tt.wantProvider)
+			}
+			if !tt.wantProvider {
+				return
+			}
+			if len(store.providers) != 1 || store.providers[0].ProviderType != ProviderFamilyOpenAI || store.providers[0].BaseURL != values["LLM_API_ENDPOINT"] {
+				t.Fatalf("OpenAI provider = %#v", store.providers)
+			}
+		})
+	}
+}
+
+func TestAnthropicEnvProviderUsesGenericBaseURLForExplicitFamily(t *testing.T) {
+	store := newResolverCoverageStore()
+	values := map[string]string{
+		"LLM_API_ENDPOINT": "https://gateway.example/api/anthropic",
+		"LLM_API_KEY":      "generic-key",
+		"LLM_MODEL":        "test-model",
+	}
+	id, err := EnsureAnthropicEnvProvider(context.Background(), store, mapLookup(values), "x-api-key", "", "anthropic-env", "anthropic-env", ProviderScopeSessionEnv, "", false)
+	if err != nil {
+		t.Fatalf("EnsureAnthropicEnvProvider() error = %v", err)
+	}
+	if id == "" || len(store.providers) != 1 {
+		t.Fatalf("provider id = %q, providers = %#v", id, store.providers)
+	}
+	provider := store.providers[0]
+	if provider.ProviderType != ProviderFamilyAnthropic || provider.DefaultWireAPI != APIProtocolMessages || provider.BaseURL != values["LLM_API_ENDPOINT"] || provider.APIKey != values["LLM_API_KEY"] {
+		t.Fatalf("Anthropic provider = %#v", provider)
+	}
+	if got := EndpointForProvider(provider, APIProtocolMessages); got != "https://gateway.example/api/anthropic/messages" {
+		t.Fatalf("Anthropic endpoint = %q", got)
+	}
+}
+
+func TestDefaultAnthropicEnvProviderInputRequiresExplicitSignal(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   bool
+	}{
+		{
+			name: "generic OpenAI configuration",
+			values: map[string]string{
+				"LLM_API_ENDPOINT": "https://gateway.example/openai",
+				"LLM_API_PROTOCOL": APIProtocolResponses,
+				"LLM_API_KEY":      "generic-key",
+			},
+		},
+		{
+			name: "generic messages configuration",
+			values: map[string]string{
+				"LLM_API_ENDPOINT": "https://gateway.example/anthropic",
+				"LLM_API_PROTOCOL": APIProtocolMessages,
+				"LLM_API_KEY":      "generic-key",
+			},
+			want: true,
+		},
+		{
+			name: "Anthropic-specific configuration",
+			values: map[string]string{
+				"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic",
+				"ANTHROPIC_API_KEY":  "anthropic-key",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasDefaultAnthropicEnvProviderInput(mapLookup(tt.values)); got != tt.want {
+				t.Fatalf("hasDefaultAnthropicEnvProviderInput() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func mapLookup(values map[string]string) EnvProviderLookup {
+	return func(keys ...string) string {
+		for _, key := range keys {
+			if value := values[key]; value != "" {
+				return value
+			}
+		}
+		return ""
+	}
+}

--- a/pkg/llms/provider_environment.go
+++ b/pkg/llms/provider_environment.go
@@ -60,7 +60,7 @@ func SandboxProviderEnvItems(ctx context.Context, store ProviderListStore, sandb
 	}
 
 	persisted := make([]domain.SandboxEnvVar, 0, len(sandbox.ProviderEnvOverrideNames))
-	missingProviderKey := false
+	missingProviderKeys := make([]string, 0, 1)
 	for _, name := range sandbox.ProviderEnvOverrideNames {
 		name = strings.ToUpper(strings.TrimSpace(name))
 		if name == "" || !providerEnvNameForFamily(name, providerFamily) {
@@ -70,23 +70,25 @@ func SandboxProviderEnvItems(ctx context.Context, store ProviderListStore, sandb
 			persisted = append(persisted, item)
 			continue
 		}
+		if item, ok := envItemByName(sandbox.ProviderEnvItems, name); ok && strings.TrimSpace(item.Value) != "" {
+			continue
+		}
 		if providerKeyOverrideName(name, providerFamily) {
-			missingProviderKey = true
+			missingProviderKeys = append(missingProviderKeys, name)
 		}
 	}
 
-	if missingProviderKey && store != nil {
+	if len(missingProviderKeys) > 0 && store != nil {
 		providers, err := store.ListEnabledLLMProviders(ctx)
 		if err != nil {
 			return nil, err
 		}
-		providerKey := sessionProviderAPIKey(sandbox.Summary.ID, providerFamily, providers)
-		if providerKey != "" {
-			for _, name := range sandbox.ProviderEnvOverrideNames {
-				name = strings.ToUpper(strings.TrimSpace(name))
-				if providerKeyOverrideName(name, providerFamily) {
-					persisted = append(persisted, domain.SandboxEnvVar{Name: name, Value: providerKey, Secret: true})
-				}
+		providerItems := domain.MergeEnvItems(persisted, sandbox.ProviderEnvItems)
+		for _, name := range missingProviderKeys {
+			ownerFamily := providerKeyOwnerFamily(name, providerFamily, providerItems)
+			providerKey := sessionProviderAPIKey(sandbox.Summary.ID, ownerFamily, providers)
+			if providerKey != "" {
+				persisted = append(persisted, domain.SandboxEnvVar{Name: name, Value: providerKey, Secret: true})
 			}
 		}
 	}
@@ -159,5 +161,22 @@ func providerKeyOverrideName(name, providerFamily string) bool {
 		return name == "LLM_API_KEY" || name == "ANTHROPIC_API_KEY" || name == "ANTHROPIC_AUTH_TOKEN"
 	default:
 		return false
+	}
+}
+
+func providerKeyOwnerFamily(name, requestedFamily string, envItems []domain.SandboxEnvVar) string {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	switch name {
+	case "LLM_API_KEY":
+		if family := genericLLMEnvProviderFamily(envItems); family != "" {
+			return family
+		}
+		return NormalizeOptionalProviderType(requestedFamily)
+	case "OPENAI_API_KEY":
+		return ProviderFamilyOpenAI
+	case "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN":
+		return ProviderFamilyAnthropic
+	default:
+		return ""
 	}
 }

--- a/pkg/llms/provider_environment.go
+++ b/pkg/llms/provider_environment.go
@@ -111,7 +111,7 @@ func filterProviderEnvItems(items []domain.SandboxEnvVar, providerFamily string)
 func providerEnvNameForFamily(name, providerFamily string) bool {
 	name = strings.ToUpper(strings.TrimSpace(name))
 	switch {
-	case strings.HasPrefix(name, "ANTHROPIC_"):
+	case strings.HasPrefix(name, "ANTHROPIC_"), name == "CLAUDE_MODEL":
 		return providerFamily == "" || providerFamily == ProviderFamilyAnthropic
 	case strings.HasPrefix(name, "OPENAI_"), strings.HasPrefix(name, "AZURE_OPENAI_"), strings.HasPrefix(name, "OPENROUTER_"):
 		return providerFamily == "" || providerFamily == ProviderFamilyOpenAI
@@ -127,7 +127,8 @@ func providerEnvName(name string) bool {
 		strings.HasPrefix(name, "OPENAI_") ||
 		strings.HasPrefix(name, "ANTHROPIC_") ||
 		strings.HasPrefix(name, "AZURE_OPENAI_") ||
-		strings.HasPrefix(name, "OPENROUTER_")
+		strings.HasPrefix(name, "OPENROUTER_") ||
+		name == "CLAUDE_MODEL"
 }
 
 func envItemByName(items []domain.SandboxEnvVar, name string) (domain.SandboxEnvVar, bool) {

--- a/pkg/llms/provider_environment.go
+++ b/pkg/llms/provider_environment.go
@@ -1,0 +1,162 @@
+package llms
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+// SetSandboxProviderEnvItems assigns the transient sandbox-owned provider
+// environment and records only its non-empty names for restart recovery.
+// Provider values must never be persisted in sandbox metadata.
+func SetSandboxProviderEnvItems(sandbox *domain.Sandbox, items []domain.SandboxEnvVar) {
+	if sandbox == nil {
+		return
+	}
+	sandbox.ProviderEnvItems = append([]domain.SandboxEnvVar(nil), domain.NormalizeEnvItems(items)...)
+	sandbox.ProviderEnvOverrideNames = providerEnvOverrideNames(items)
+}
+
+func providerEnvOverrideNames(items []domain.SandboxEnvVar) []string {
+	names := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range domain.NormalizeEnvItems(items) {
+		name := strings.ToUpper(strings.TrimSpace(item.Name))
+		if !providerEnvName(name) || strings.TrimSpace(item.Value) == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	// Preserve a non-nil empty slice. JSON [] distinguishes a sandbox with no
+	// overrides from metadata without provenance, where the field is absent/null.
+	return names
+}
+
+// SandboxProviderEnvItems returns the sandbox-owned provider layer for one LLM
+// family. For current executions, transient values win. After restart, values
+// are reconstructed from recorded names, persisted non-secret env, and the
+// family-scoped session provider row that owns the credential.
+func SandboxProviderEnvItems(ctx context.Context, store ProviderListStore, sandbox *domain.Sandbox, providerFamily string) ([]domain.SandboxEnvVar, error) {
+	if sandbox == nil {
+		return nil, nil
+	}
+	providerFamily = NormalizeOptionalProviderType(providerFamily)
+	if sandbox.ProviderEnvOverrideNames == nil {
+		// Metadata written before provenance tracking has no source information.
+		// Preserve its environment snapshot while removing names owned by the
+		// opposite provider family.
+		items := sandbox.ProviderEnvItems
+		if len(items) == 0 {
+			items = sandbox.EnvItems
+		}
+		return filterProviderEnvItems(items, providerFamily), nil
+	}
+
+	persisted := make([]domain.SandboxEnvVar, 0, len(sandbox.ProviderEnvOverrideNames))
+	missingProviderKey := false
+	for _, name := range sandbox.ProviderEnvOverrideNames {
+		name = strings.ToUpper(strings.TrimSpace(name))
+		if name == "" || !providerEnvNameForFamily(name, providerFamily) {
+			continue
+		}
+		if item, ok := envItemByName(sandbox.EnvItems, name); ok && strings.TrimSpace(item.Value) != "" {
+			persisted = append(persisted, item)
+			continue
+		}
+		if providerKeyOverrideName(name, providerFamily) {
+			missingProviderKey = true
+		}
+	}
+
+	if missingProviderKey && store != nil {
+		providers, err := store.ListEnabledLLMProviders(ctx)
+		if err != nil {
+			return nil, err
+		}
+		providerKey := sessionProviderAPIKey(sandbox.Summary.ID, providerFamily, providers)
+		if providerKey != "" {
+			for _, name := range sandbox.ProviderEnvOverrideNames {
+				name = strings.ToUpper(strings.TrimSpace(name))
+				if providerKeyOverrideName(name, providerFamily) {
+					persisted = append(persisted, domain.SandboxEnvVar{Name: name, Value: providerKey, Secret: true})
+				}
+			}
+		}
+	}
+
+	return filterProviderEnvItems(domain.MergeEnvItems(persisted, sandbox.ProviderEnvItems), providerFamily), nil
+}
+
+func filterProviderEnvItems(items []domain.SandboxEnvVar, providerFamily string) []domain.SandboxEnvVar {
+	providerFamily = NormalizeOptionalProviderType(providerFamily)
+	filtered := make([]domain.SandboxEnvVar, 0, len(items))
+	for _, item := range domain.NormalizeEnvItems(items) {
+		if providerEnvNameForFamily(item.Name, providerFamily) {
+			filtered = append(filtered, item)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
+func providerEnvNameForFamily(name, providerFamily string) bool {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	switch {
+	case strings.HasPrefix(name, "ANTHROPIC_"):
+		return providerFamily == "" || providerFamily == ProviderFamilyAnthropic
+	case strings.HasPrefix(name, "OPENAI_"), strings.HasPrefix(name, "AZURE_OPENAI_"), strings.HasPrefix(name, "OPENROUTER_"):
+		return providerFamily == "" || providerFamily == ProviderFamilyOpenAI
+	default:
+		// LLM_* is intentionally generic and remains visible to both families.
+		return strings.HasPrefix(name, "LLM_")
+	}
+}
+
+func providerEnvName(name string) bool {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	return strings.HasPrefix(name, "LLM_") ||
+		strings.HasPrefix(name, "OPENAI_") ||
+		strings.HasPrefix(name, "ANTHROPIC_") ||
+		strings.HasPrefix(name, "AZURE_OPENAI_") ||
+		strings.HasPrefix(name, "OPENROUTER_")
+}
+
+func envItemByName(items []domain.SandboxEnvVar, name string) (domain.SandboxEnvVar, bool) {
+	for _, item := range domain.NormalizeEnvItems(items) {
+		if strings.EqualFold(strings.TrimSpace(item.Name), strings.TrimSpace(name)) {
+			return item, true
+		}
+	}
+	return domain.SandboxEnvVar{}, false
+}
+
+func sessionProviderAPIKey(sessionID, providerFamily string, providers []Provider) string {
+	providerID := SessionEnvProviderID(sessionID, providerFamily)
+	for _, provider := range providers {
+		if provider.ID == providerID {
+			return strings.TrimSpace(provider.APIKey)
+		}
+	}
+	return ""
+}
+
+func providerKeyOverrideName(name, providerFamily string) bool {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	switch NormalizeOptionalProviderType(providerFamily) {
+	case ProviderFamilyOpenAI:
+		return name == "LLM_API_KEY" || name == "OPENAI_API_KEY"
+	case ProviderFamilyAnthropic:
+		return name == "LLM_API_KEY" || name == "ANTHROPIC_API_KEY" || name == "ANTHROPIC_AUTH_TOKEN"
+	default:
+		return false
+	}
+}

--- a/pkg/llms/provider_environment_test.go
+++ b/pkg/llms/provider_environment_test.go
@@ -218,22 +218,91 @@ func TestRuntimeTargetUsesSharedDefaultInsteadOfGlobalSessionSnapshot(t *testing
 	}
 }
 
-func TestRuntimeTargetKeepsAnthropicAuthTypeFromWinningLayer(t *testing.T) {
-	isolateLLMEnv(t)
-	t.Setenv("ANTHROPIC_API_KEY", "process-api-key")
-	store := newResolverCoverageStore()
-	store.global = []domain.SandboxEnvVar{
-		{Name: "ANTHROPIC_API_KEY", Value: "global-api-key"},
-		{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
+func TestRuntimeTargetKeepsAnthropicCredentialFromWinningLayer(t *testing.T) {
+	tests := []struct {
+		name             string
+		sandboxItems     []domain.SandboxEnvVar
+		globalItems      []domain.SandboxEnvVar
+		processAPIKey    string
+		processAuthToken string
+		configKey        string
+		wantKey          string
+		wantHeader       string
+		wantScheme       string
+	}{
+		{
+			name:         "sandbox auth token beats Global Env api key",
+			sandboxItems: []domain.SandboxEnvVar{{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"}},
+			globalItems:  []domain.SandboxEnvVar{{Name: "ANTHROPIC_API_KEY", Value: "global-api-key"}},
+			wantKey:      "sandbox-auth-token",
+			wantHeader:   "Authorization",
+			wantScheme:   "Bearer",
+		},
+		{
+			name:         "sandbox generic key beats Global Env auth token",
+			sandboxItems: []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "sandbox-generic-key"}},
+			globalItems:  []domain.SandboxEnvVar{{Name: "ANTHROPIC_AUTH_TOKEN", Value: "global-auth-token"}},
+			wantKey:      "sandbox-generic-key",
+			wantHeader:   "x-api-key",
+		},
+		{
+			name: "family-specific token beats generic key within sandbox",
+			sandboxItems: []domain.SandboxEnvVar{
+				{Name: "LLM_API_KEY", Value: "sandbox-generic-key"},
+				{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"},
+			},
+			wantKey:    "sandbox-auth-token",
+			wantHeader: "Authorization",
+			wantScheme: "Bearer",
+		},
+		{
+			name:             "Global Env generic key beats process auth token",
+			globalItems:      []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "global-generic-key"}},
+			processAuthToken: "process-auth-token",
+			wantKey:          "global-generic-key",
+			wantHeader:       "x-api-key",
+		},
+		{
+			name:             "process auth token beats daemon config key",
+			processAuthToken: "process-auth-token",
+			configKey:        "config-generic-key",
+			wantKey:          "process-auth-token",
+			wantHeader:       "Authorization",
+			wantScheme:       "Bearer",
+		},
+		{
+			name:          "process api key beats daemon config key",
+			processAPIKey: "process-api-key",
+			configKey:     "config-generic-key",
+			wantKey:       "process-api-key",
+			wantHeader:    "x-api-key",
+		},
+		{
+			name:       "daemon config generic key is x-api-key",
+			configKey:  "config-generic-key",
+			wantKey:    "config-generic-key",
+			wantHeader: "x-api-key",
+		},
 	}
-	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-auth", ProviderFamilyAnthropic, "", "", []domain.SandboxEnvVar{
-		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"},
-	})
-	if err != nil {
-		t.Fatalf("resolve layered Anthropic target: %v", err)
-	}
-	if target.Provider.APIKey != "sandbox-auth-token" || target.Provider.AuthHeader != "Authorization" || target.Provider.AuthScheme != "Bearer" {
-		t.Fatalf("layered Anthropic target = %#v", target)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateLLMEnv(t)
+			t.Setenv("ANTHROPIC_API_KEY", tt.processAPIKey)
+			t.Setenv("ANTHROPIC_AUTH_TOKEN", tt.processAuthToken)
+			store := newResolverCoverageStore()
+			store.global = append([]domain.SandboxEnvVar{
+				{Name: "ANTHROPIC_BASE_URL", Value: "https://global.anthropic.example"},
+				{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
+			}, tt.globalItems...)
+			target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{LLMAPIKey: tt.configKey}, store, "sandbox-anthropic-auth", ProviderFamilyAnthropic, "", "", tt.sandboxItems)
+			if err != nil {
+				t.Fatalf("resolve layered Anthropic target: %v", err)
+			}
+			if target.Provider.APIKey != tt.wantKey || target.Provider.AuthHeader != tt.wantHeader || target.Provider.AuthScheme != tt.wantScheme {
+				t.Fatalf("layered Anthropic credential = key %q header %q scheme %q", target.Provider.APIKey, target.Provider.AuthHeader, target.Provider.AuthScheme)
+			}
+		})
 	}
 }
 

--- a/pkg/llms/provider_environment_test.go
+++ b/pkg/llms/provider_environment_test.go
@@ -132,6 +132,45 @@ func TestSandboxProviderEnvItemsReconstructsRestartedOverrides(t *testing.T) {
 	}
 }
 
+func TestSandboxProviderEnvItemsReconstructsGenericKeyFromProtocolFamily(t *testing.T) {
+	const sandboxID = "sandbox-generic-restart"
+	store := newResolverCoverageStore()
+	store.providers = []Provider{
+		{ID: SessionEnvProviderID(sandboxID, ProviderFamilyOpenAI), ProviderType: ProviderFamilyOpenAI, APIKey: "persisted-openai-key", Enabled: true},
+		{ID: SessionEnvProviderID(sandboxID, ProviderFamilyAnthropic), ProviderType: ProviderFamilyAnthropic, APIKey: "persisted-anthropic-key", Enabled: true},
+	}
+	tests := []struct {
+		name            string
+		protocol        string
+		requestedFamily string
+		wantKey         string
+	}{
+		{name: "responses key remains OpenAI for Claude", protocol: APIProtocolResponses, requestedFamily: ProviderFamilyAnthropic, wantKey: "persisted-openai-key"},
+		{name: "messages key remains Anthropic for Codex", protocol: APIProtocolMessages, requestedFamily: ProviderFamilyOpenAI, wantKey: "persisted-anthropic-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := &domain.Sandbox{
+				Summary: domain.SandboxSummary{ID: sandboxID},
+				EnvItems: []domain.SandboxEnvVar{
+					{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/base"},
+					{Name: "LLM_API_PROTOCOL", Value: tt.protocol},
+					{Name: "LLM_MODEL", Value: "generic-model"},
+				},
+				ProviderEnvOverrideNames: []string{"LLM_API_ENDPOINT", "LLM_API_KEY", "LLM_API_PROTOCOL", "LLM_MODEL"},
+			}
+			items, err := SandboxProviderEnvItems(context.Background(), store, sandbox, tt.requestedFamily)
+			if err != nil {
+				t.Fatalf("reconstruct generic provider env: %v", err)
+			}
+			if got := EnvItemValue(items, "LLM_API_KEY"); got != tt.wantKey {
+				t.Fatalf("reconstructed generic key = %q, want protocol-family key %q", got, tt.wantKey)
+			}
+		})
+	}
+}
+
 func TestSandboxProviderEnvItemsSeparatesRecordedEmptyFromMissingProvenance(t *testing.T) {
 	recorded := &domain.Sandbox{
 		EnvItems:                 []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "global-snapshot"}},
@@ -244,11 +283,14 @@ func TestRuntimeTargetKeepsAnthropicCredentialFromWinningLayer(t *testing.T) {
 			wantScheme:   "Bearer",
 		},
 		{
-			name:         "sandbox generic key beats Global Env auth token",
-			sandboxItems: []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "sandbox-generic-key"}},
-			globalItems:  []domain.SandboxEnvVar{{Name: "ANTHROPIC_AUTH_TOKEN", Value: "global-auth-token"}},
-			wantKey:      "sandbox-generic-key",
-			wantHeader:   "x-api-key",
+			name: "sandbox generic Messages key beats Global Env auth token",
+			sandboxItems: []domain.SandboxEnvVar{
+				{Name: "LLM_API_PROTOCOL", Value: APIProtocolMessages},
+				{Name: "LLM_API_KEY", Value: "sandbox-generic-key"},
+			},
+			globalItems: []domain.SandboxEnvVar{{Name: "ANTHROPIC_AUTH_TOKEN", Value: "global-auth-token"}},
+			wantKey:     "sandbox-generic-key",
+			wantHeader:  "x-api-key",
 		},
 		{
 			name: "family-specific token beats generic key within sandbox",
@@ -311,26 +353,24 @@ func TestRuntimeTargetKeepsAnthropicCredentialFromWinningLayer(t *testing.T) {
 	}
 }
 
-func TestRuntimeTargetUsesGenericEnvironmentForExplicitAnthropicFamily(t *testing.T) {
+func TestRuntimeTargetKeepsGenericResponsesProviderForClaudeFacade(t *testing.T) {
 	isolateLLMEnv(t)
 	store := newResolverCoverageStore()
 	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-generic-anthropic", ProviderFamilyAnthropic, "", "", []domain.SandboxEnvVar{
-		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/api/anthropic"},
+		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/base"},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
 		{Name: "LLM_API_KEY", Value: "generic-key"},
-		{Name: "LLM_MODEL", Value: "generic-claude"},
+		{Name: "LLM_MODEL", Value: "generic-model"},
 	})
 	if err != nil {
-		t.Fatalf("resolve generic Anthropic target: %v", err)
+		t.Fatalf("resolve generic Responses target for Claude: %v", err)
 	}
-	if target.Provider.ProviderType != ProviderFamilyAnthropic || target.Provider.BaseURL != "https://gateway.example/api/anthropic" || target.Provider.APIKey != "generic-key" || target.Model.ID != "generic-claude" {
-		t.Fatalf("generic Anthropic target = %#v", target)
-	}
-	if target.Endpoint != "https://gateway.example/api/anthropic/messages" {
-		t.Fatalf("generic Anthropic endpoint = %q", target.Endpoint)
+	if target.Provider.ProviderType != ProviderFamilyOpenAI || target.WireAPI != APIProtocolResponses || target.Provider.APIKey != "generic-key" || target.Model.ID != "generic-model" {
+		t.Fatalf("generic Responses target for Claude = %#v", target)
 	}
 	for _, provider := range store.providers {
-		if provider.ProviderType == ProviderFamilyOpenAI {
-			t.Fatalf("explicit Anthropic resolution bootstrapped OpenAI provider: %#v", store.providers)
+		if provider.ProviderType == ProviderFamilyAnthropic {
+			t.Fatalf("Claude selection reclassified generic Responses provider: %#v", store.providers)
 		}
 	}
 }

--- a/pkg/llms/provider_environment_test.go
+++ b/pkg/llms/provider_environment_test.go
@@ -18,6 +18,8 @@ func TestSandboxProviderEnvItemsFiltersProviderFamilies(t *testing.T) {
 		{Name: "OPENAI_BASE_URL", Value: "https://openai.example/v1"},
 		{Name: "ANTHROPIC_API_KEY", Value: "anthropic-key", Secret: true},
 		{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example"},
+		{Name: "CLAUDE_MODEL", Value: "claude-session"},
+		{Name: "CLAUDE_CODE_PATH", Value: "/custom/claude"},
 	})
 
 	openAI, err := SandboxProviderEnvItems(context.Background(), nil, sandbox, ProviderFamilyOpenAI)
@@ -27,7 +29,7 @@ func TestSandboxProviderEnvItemsFiltersProviderFamilies(t *testing.T) {
 	if EnvItemValue(openAI, "OPENAI_API_KEY") != "openai-key" || EnvItemValue(openAI, "LLM_API_KEY") != "generic-key" {
 		t.Fatalf("OpenAI provider env = %#v", openAI)
 	}
-	if EnvItemValue(openAI, "ANTHROPIC_API_KEY") != "" || EnvItemValue(openAI, "ANTHROPIC_BASE_URL") != "" {
+	if EnvItemValue(openAI, "ANTHROPIC_API_KEY") != "" || EnvItemValue(openAI, "ANTHROPIC_BASE_URL") != "" || EnvItemValue(openAI, "CLAUDE_MODEL") != "" {
 		t.Fatalf("OpenAI provider env contains Anthropic values: %#v", openAI)
 	}
 
@@ -35,10 +37,10 @@ func TestSandboxProviderEnvItemsFiltersProviderFamilies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SandboxProviderEnvItems Anthropic returned error: %v", err)
 	}
-	if EnvItemValue(anthropic, "ANTHROPIC_API_KEY") != "anthropic-key" || EnvItemValue(anthropic, "LLM_API_KEY") != "generic-key" {
+	if EnvItemValue(anthropic, "ANTHROPIC_API_KEY") != "anthropic-key" || EnvItemValue(anthropic, "LLM_API_KEY") != "generic-key" || EnvItemValue(anthropic, "CLAUDE_MODEL") != "claude-session" {
 		t.Fatalf("Anthropic provider env = %#v", anthropic)
 	}
-	if EnvItemValue(anthropic, "OPENAI_API_KEY") != "" || EnvItemValue(anthropic, "OPENAI_BASE_URL") != "" {
+	if EnvItemValue(anthropic, "OPENAI_API_KEY") != "" || EnvItemValue(anthropic, "OPENAI_BASE_URL") != "" || EnvItemValue(anthropic, "CLAUDE_CODE_PATH") != "" {
 		t.Fatalf("Anthropic provider env contains OpenAI values: %#v", anthropic)
 	}
 }
@@ -48,6 +50,8 @@ func TestSandboxProviderEnvProvenanceDoesNotPersistSecrets(t *testing.T) {
 	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{
 		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
 		{Name: "OPENAI_API_KEY", Value: "sandbox-secret", Secret: true},
+		{Name: "CLAUDE_MODEL", Value: "claude-session"},
+		{Name: "CLAUDE_CODE_PATH", Value: "/custom/claude"},
 		{Name: "EMPTY", Value: ""},
 	})
 
@@ -58,7 +62,7 @@ func TestSandboxProviderEnvProvenanceDoesNotPersistSecrets(t *testing.T) {
 	if strings.Contains(string(data), "sandbox-secret") {
 		t.Fatalf("sandbox metadata contains provider secret: %s", data)
 	}
-	if !strings.Contains(string(data), `"provider_env_override_names":["LLM_API_ENDPOINT","OPENAI_API_KEY"]`) {
+	if !strings.Contains(string(data), `"provider_env_override_names":["CLAUDE_MODEL","LLM_API_ENDPOINT","OPENAI_API_KEY"]`) {
 		t.Fatalf("sandbox metadata has unexpected provenance: %s", data)
 	}
 
@@ -103,8 +107,9 @@ func TestSandboxProviderEnvItemsReconstructsRestartedOverrides(t *testing.T) {
 		EnvItems: []domain.SandboxEnvVar{
 			{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
 			{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example"},
+			{Name: "CLAUDE_MODEL", Value: "claude-session"},
 		},
-		ProviderEnvOverrideNames: []string{"LLM_API_ENDPOINT", "OPENAI_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"},
+		ProviderEnvOverrideNames: []string{"LLM_API_ENDPOINT", "OPENAI_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_MODEL"},
 	}
 
 	openAI, err := SandboxProviderEnvItems(context.Background(), store, sandbox, ProviderFamilyOpenAI)
@@ -114,7 +119,7 @@ func TestSandboxProviderEnvItemsReconstructsRestartedOverrides(t *testing.T) {
 	if EnvItemValue(openAI, "OPENAI_API_KEY") != "persisted-openai-key" || EnvItemValue(openAI, "LLM_API_ENDPOINT") == "" {
 		t.Fatalf("reconstructed OpenAI env = %#v", openAI)
 	}
-	if EnvItemValue(openAI, "ANTHROPIC_BASE_URL") != "" {
+	if EnvItemValue(openAI, "ANTHROPIC_BASE_URL") != "" || EnvItemValue(openAI, "CLAUDE_MODEL") != "" {
 		t.Fatalf("reconstructed OpenAI env contains Anthropic value: %#v", openAI)
 	}
 
@@ -122,7 +127,7 @@ func TestSandboxProviderEnvItemsReconstructsRestartedOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconstruct Anthropic provider env: %v", err)
 	}
-	if EnvItemValue(anthropic, "ANTHROPIC_AUTH_TOKEN") != "persisted-anthropic-key" || EnvItemValue(anthropic, "ANTHROPIC_BASE_URL") == "" {
+	if EnvItemValue(anthropic, "ANTHROPIC_AUTH_TOKEN") != "persisted-anthropic-key" || EnvItemValue(anthropic, "ANTHROPIC_BASE_URL") == "" || EnvItemValue(anthropic, "CLAUDE_MODEL") != "claude-session" {
 		t.Fatalf("reconstructed Anthropic env = %#v", anthropic)
 	}
 }

--- a/pkg/llms/provider_environment_test.go
+++ b/pkg/llms/provider_environment_test.go
@@ -1,0 +1,284 @@
+package llms
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+func TestSandboxProviderEnvItemsFiltersProviderFamilies(t *testing.T) {
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-family"}}
+	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{
+		{Name: "LLM_API_KEY", Value: "generic-key", Secret: true},
+		{Name: "OPENAI_API_KEY", Value: "openai-key", Secret: true},
+		{Name: "OPENAI_BASE_URL", Value: "https://openai.example/v1"},
+		{Name: "ANTHROPIC_API_KEY", Value: "anthropic-key", Secret: true},
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example"},
+	})
+
+	openAI, err := SandboxProviderEnvItems(context.Background(), nil, sandbox, ProviderFamilyOpenAI)
+	if err != nil {
+		t.Fatalf("SandboxProviderEnvItems OpenAI returned error: %v", err)
+	}
+	if EnvItemValue(openAI, "OPENAI_API_KEY") != "openai-key" || EnvItemValue(openAI, "LLM_API_KEY") != "generic-key" {
+		t.Fatalf("OpenAI provider env = %#v", openAI)
+	}
+	if EnvItemValue(openAI, "ANTHROPIC_API_KEY") != "" || EnvItemValue(openAI, "ANTHROPIC_BASE_URL") != "" {
+		t.Fatalf("OpenAI provider env contains Anthropic values: %#v", openAI)
+	}
+
+	anthropic, err := SandboxProviderEnvItems(context.Background(), nil, sandbox, ProviderFamilyAnthropic)
+	if err != nil {
+		t.Fatalf("SandboxProviderEnvItems Anthropic returned error: %v", err)
+	}
+	if EnvItemValue(anthropic, "ANTHROPIC_API_KEY") != "anthropic-key" || EnvItemValue(anthropic, "LLM_API_KEY") != "generic-key" {
+		t.Fatalf("Anthropic provider env = %#v", anthropic)
+	}
+	if EnvItemValue(anthropic, "OPENAI_API_KEY") != "" || EnvItemValue(anthropic, "OPENAI_BASE_URL") != "" {
+		t.Fatalf("Anthropic provider env contains OpenAI values: %#v", anthropic)
+	}
+}
+
+func TestSandboxProviderEnvProvenanceDoesNotPersistSecrets(t *testing.T) {
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-provenance"}}
+	SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+		{Name: "OPENAI_API_KEY", Value: "sandbox-secret", Secret: true},
+		{Name: "EMPTY", Value: ""},
+	})
+
+	data, err := json.Marshal(sandbox)
+	if err != nil {
+		t.Fatalf("marshal sandbox: %v", err)
+	}
+	if strings.Contains(string(data), "sandbox-secret") {
+		t.Fatalf("sandbox metadata contains provider secret: %s", data)
+	}
+	if !strings.Contains(string(data), `"provider_env_override_names":["LLM_API_ENDPOINT","OPENAI_API_KEY"]`) {
+		t.Fatalf("sandbox metadata has unexpected provenance: %s", data)
+	}
+
+	var persisted domain.Sandbox
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("unmarshal sandbox: %v", err)
+	}
+	if persisted.ProviderEnvOverrideNames == nil || len(persisted.ProviderEnvItems) != 0 {
+		t.Fatalf("persisted sandbox = %#v", persisted)
+	}
+
+	empty := &domain.Sandbox{}
+	SetSandboxProviderEnvItems(empty, nil)
+	emptyData, err := json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("marshal empty provenance: %v", err)
+	}
+	var emptyRoundTrip domain.Sandbox
+	if err := json.Unmarshal(emptyData, &emptyRoundTrip); err != nil {
+		t.Fatalf("unmarshal empty provenance: %v", err)
+	}
+	if emptyRoundTrip.ProviderEnvOverrideNames == nil {
+		t.Fatalf("recorded empty provenance became indistinguishable from missing provenance: %s", emptyData)
+	}
+	var withoutProvenance domain.Sandbox
+	if err := json.Unmarshal([]byte(`{"summary":{}}`), &withoutProvenance); err != nil {
+		t.Fatalf("unmarshal sandbox without provenance: %v", err)
+	}
+	if withoutProvenance.ProviderEnvOverrideNames != nil {
+		t.Fatalf("missing provenance = %#v, want nil", withoutProvenance.ProviderEnvOverrideNames)
+	}
+}
+
+func TestSandboxProviderEnvItemsReconstructsRestartedOverrides(t *testing.T) {
+	store := newResolverCoverageStore()
+	store.providers = []Provider{
+		{ID: SessionEnvProviderID("sandbox-restart", ProviderFamilyOpenAI), ProviderType: ProviderFamilyOpenAI, APIKey: "persisted-openai-key", Enabled: true},
+		{ID: SessionEnvProviderID("sandbox-restart", ProviderFamilyAnthropic), ProviderType: ProviderFamilyAnthropic, APIKey: "persisted-anthropic-key", Enabled: true},
+	}
+	sandbox := &domain.Sandbox{
+		Summary: domain.SandboxSummary{ID: "sandbox-restart"},
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+			{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example"},
+		},
+		ProviderEnvOverrideNames: []string{"LLM_API_ENDPOINT", "OPENAI_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"},
+	}
+
+	openAI, err := SandboxProviderEnvItems(context.Background(), store, sandbox, ProviderFamilyOpenAI)
+	if err != nil {
+		t.Fatalf("reconstruct OpenAI provider env: %v", err)
+	}
+	if EnvItemValue(openAI, "OPENAI_API_KEY") != "persisted-openai-key" || EnvItemValue(openAI, "LLM_API_ENDPOINT") == "" {
+		t.Fatalf("reconstructed OpenAI env = %#v", openAI)
+	}
+	if EnvItemValue(openAI, "ANTHROPIC_BASE_URL") != "" {
+		t.Fatalf("reconstructed OpenAI env contains Anthropic value: %#v", openAI)
+	}
+
+	anthropic, err := SandboxProviderEnvItems(context.Background(), store, sandbox, ProviderFamilyAnthropic)
+	if err != nil {
+		t.Fatalf("reconstruct Anthropic provider env: %v", err)
+	}
+	if EnvItemValue(anthropic, "ANTHROPIC_AUTH_TOKEN") != "persisted-anthropic-key" || EnvItemValue(anthropic, "ANTHROPIC_BASE_URL") == "" {
+		t.Fatalf("reconstructed Anthropic env = %#v", anthropic)
+	}
+}
+
+func TestSandboxProviderEnvItemsSeparatesRecordedEmptyFromMissingProvenance(t *testing.T) {
+	recorded := &domain.Sandbox{
+		EnvItems:                 []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "global-snapshot"}},
+		ProviderEnvOverrideNames: []string{},
+	}
+	items, err := SandboxProviderEnvItems(context.Background(), nil, recorded, ProviderFamilyOpenAI)
+	if err != nil {
+		t.Fatalf("recorded provider env: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("recorded empty provenance used Global Env snapshot: %#v", items)
+	}
+
+	withoutProvenance := &domain.Sandbox{EnvItems: []domain.SandboxEnvVar{
+		{Name: "LLM_API_KEY", Value: "snapshot-key"},
+		{Name: "ANTHROPIC_API_KEY", Value: "snapshot-anthropic-key"},
+	}}
+	items, err = SandboxProviderEnvItems(context.Background(), nil, withoutProvenance, ProviderFamilyOpenAI)
+	if err != nil {
+		t.Fatalf("provider env without provenance: %v", err)
+	}
+	if EnvItemValue(items, "LLM_API_KEY") != "snapshot-key" || EnvItemValue(items, "ANTHROPIC_API_KEY") != "" {
+		t.Fatalf("family-filtered fallback without provenance = %#v", items)
+	}
+}
+
+func TestRestoreSandboxTransientFieldsPreservesPendingProviderProvenance(t *testing.T) {
+	source := &domain.Sandbox{}
+	SetSandboxProviderEnvItems(source, nil)
+	destination := &domain.Sandbox{}
+	domain.RestoreSandboxTransientFields(destination, source)
+	if destination.ProviderEnvOverrideNames == nil {
+		t.Fatal("recorded empty provenance was lost during sandbox reload")
+	}
+
+	SetSandboxProviderEnvItems(source, []domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "secret", Secret: true}})
+	domain.RestoreSandboxTransientFields(destination, source)
+	if len(destination.ProviderEnvOverrideNames) != 1 || destination.ProviderEnvOverrideNames[0] != "OPENAI_API_KEY" {
+		t.Fatalf("restored provenance = %#v", destination.ProviderEnvOverrideNames)
+	}
+	if EnvItemValue(destination.ProviderEnvItems, "OPENAI_API_KEY") != "secret" {
+		t.Fatalf("restored transient provider env = %#v", destination.ProviderEnvItems)
+	}
+}
+
+func TestRuntimeTargetUsesLayeredProviderEnvironmentForRequestedFamily(t *testing.T) {
+	isolateLLMEnv(t)
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolResponses},
+		{Name: "LLM_API_KEY", Value: "global-key"},
+		{Name: "LLM_MODEL", Value: "global-model"},
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://global.anthropic.example"},
+		{Name: "ANTHROPIC_API_KEY", Value: "global-anthropic-key"},
+		{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
+	}
+
+	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-layered", ProviderFamilyOpenAI, "", "", []domain.SandboxEnvVar{
+		{Name: "OPENAI_API_KEY", Value: "sandbox-key"},
+	})
+	if err != nil {
+		t.Fatalf("resolve layered OpenAI target: %v", err)
+	}
+	if target.Provider.ID != SessionEnvProviderID("sandbox-layered", ProviderFamilyOpenAI) || target.Provider.APIKey != "sandbox-key" || target.Provider.BaseURL != "https://global.example/v1" || target.Model.ID != "global-model" {
+		t.Fatalf("layered OpenAI target = %#v", target)
+	}
+	for _, provider := range store.providers {
+		if provider.ProviderType == ProviderFamilyAnthropic {
+			t.Fatalf("OpenAI resolution bootstrapped Anthropic provider: %#v", store.providers)
+		}
+	}
+}
+
+func TestRuntimeTargetUsesSharedDefaultInsteadOfGlobalSessionSnapshot(t *testing.T) {
+	isolateLLMEnv(t)
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://global.example/v1"},
+		{Name: "LLM_API_KEY", Value: "global-key"},
+		{Name: "LLM_MODEL", Value: "global-model"},
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-global-only", ProviderFamilyOpenAI, "", "", nil)
+	if err != nil {
+		t.Fatalf("resolve default OpenAI target: %v", err)
+	}
+	if target.Provider.ID != ProviderIDDefaultOpenAI || target.Provider.Scope != ProviderScopeEnvDefault {
+		t.Fatalf("global-only target = %#v", target)
+	}
+}
+
+func TestRuntimeTargetKeepsAnthropicAuthTypeFromWinningLayer(t *testing.T) {
+	isolateLLMEnv(t)
+	t.Setenv("ANTHROPIC_API_KEY", "process-api-key")
+	store := newResolverCoverageStore()
+	store.global = []domain.SandboxEnvVar{
+		{Name: "ANTHROPIC_API_KEY", Value: "global-api-key"},
+		{Name: "ANTHROPIC_MODEL", Value: "global-claude"},
+	}
+	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-anthropic-auth", ProviderFamilyAnthropic, "", "", []domain.SandboxEnvVar{
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "sandbox-auth-token"},
+	})
+	if err != nil {
+		t.Fatalf("resolve layered Anthropic target: %v", err)
+	}
+	if target.Provider.APIKey != "sandbox-auth-token" || target.Provider.AuthHeader != "Authorization" || target.Provider.AuthScheme != "Bearer" {
+		t.Fatalf("layered Anthropic target = %#v", target)
+	}
+}
+
+func TestRuntimeTargetUsesGenericEnvironmentForExplicitAnthropicFamily(t *testing.T) {
+	isolateLLMEnv(t)
+	store := newResolverCoverageStore()
+	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-generic-anthropic", ProviderFamilyAnthropic, "", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/api/anthropic"},
+		{Name: "LLM_API_KEY", Value: "generic-key"},
+		{Name: "LLM_MODEL", Value: "generic-claude"},
+	})
+	if err != nil {
+		t.Fatalf("resolve generic Anthropic target: %v", err)
+	}
+	if target.Provider.ProviderType != ProviderFamilyAnthropic || target.Provider.BaseURL != "https://gateway.example/api/anthropic" || target.Provider.APIKey != "generic-key" || target.Model.ID != "generic-claude" {
+		t.Fatalf("generic Anthropic target = %#v", target)
+	}
+	if target.Endpoint != "https://gateway.example/api/anthropic/messages" {
+		t.Fatalf("generic Anthropic endpoint = %q", target.Endpoint)
+	}
+	for _, provider := range store.providers {
+		if provider.ProviderType == ProviderFamilyOpenAI {
+			t.Fatalf("explicit Anthropic resolution bootstrapped OpenAI provider: %#v", store.providers)
+		}
+	}
+}
+
+func TestRuntimeTargetUsesMessagesProtocolWhenProviderFamilyIsUnspecified(t *testing.T) {
+	isolateLLMEnv(t)
+	store := newResolverCoverageStore()
+	target, err := ResolveRuntimeLLMTargetWithEnv(context.Background(), &appconfig.Config{}, store, "sandbox-protocol-anthropic", "", "", "", []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://gateway.example/api/anthropic"},
+		{Name: "LLM_API_PROTOCOL", Value: APIProtocolMessages},
+		{Name: "LLM_API_KEY", Value: "generic-key"},
+		{Name: "LLM_MODEL", Value: "generic-claude"},
+	})
+	if err != nil {
+		t.Fatalf("resolve protocol-selected Anthropic target: %v", err)
+	}
+	if target.Provider.ProviderType != ProviderFamilyAnthropic || target.WireAPI != APIProtocolMessages {
+		t.Fatalf("protocol-selected target = %#v", target)
+	}
+	for _, provider := range store.providers {
+		if provider.ProviderType == ProviderFamilyOpenAI {
+			t.Fatalf("messages protocol bootstrapped OpenAI provider: %#v", store.providers)
+		}
+	}
+}

--- a/pkg/llms/resolver.go
+++ b/pkg/llms/resolver.go
@@ -92,6 +92,20 @@ func sessionLLMEnvProviderLookup(envItems []domain.SandboxEnvVar) EnvProviderLoo
 	}
 }
 
+// layeredLLMEnvProviderLookup resolves the sandbox-owned layer before the
+// default Global Env/process/config layers. Candidate aliases are exhausted
+// within a layer before falling through, preserving source-major precedence.
+func layeredLLMEnvProviderLookup(ctx context.Context, config *appconfig.Config, store LLMResolverStore, envItems []domain.SandboxEnvVar) EnvProviderLookup {
+	sessionLookup := sessionLLMEnvProviderLookup(envItems)
+	defaultLookup := defaultLLMEnvProviderLookup(ctx, config, store)
+	return func(keys ...string) string {
+		if value := sessionLookup(keys...); strings.TrimSpace(value) != "" {
+			return value
+		}
+		return defaultLookup(keys...)
+	}
+}
+
 func configLLMEnvValue(config *appconfig.Config, key string) string {
 	if config == nil {
 		return ""
@@ -149,6 +163,9 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	requestedModel = strings.TrimSpace(requestedModel)
 	providerID = strings.TrimSpace(providerID)
 	hasSessionEnvProvider := sessionID != "" && HasSessionEnvProviderInput(envItems)
+	if sessionID != "" && preferredProviderFamily != "" {
+		hasSessionEnvProvider = hasEnvProviderInputForFamily(envItems, preferredProviderFamily)
+	}
 	sessionProviderID := ""
 	// Reuse an already-persisted session-env provider when this session can no
 	// longer supply a key from env. The raw key env (Session.ProviderEnvItems) is
@@ -168,29 +185,39 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	// provider id from the token scope, so this avoids a redundant pair of
 	// idempotent provider upserts on every LLM request.
 	bootstrapProviders := (providerID == "" || !IsSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
-	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyOpenAI) {
+	bootstrapOpenAI := preferredProviderFamily == "" || preferredProviderFamily == ProviderFamilyOpenAI
+	if bootstrapProviders && bootstrapOpenAI && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyOpenAI) {
 		openAIModel := firstNonEmptyTrimmed(requestedModel, EnvItemValue(envItems, "LLM_MODEL"))
-		if sessionID != "" && HasOpenAIEnvProviderInput(envItems) {
-			id, err := ensureSessionOpenAIEnvProvider(ctx, store, sessionID, openAIModel, envItems)
+		hasOpenAIEnvProvider := HasOpenAIEnvProviderInput(envItems)
+		if preferredProviderFamily == ProviderFamilyOpenAI {
+			hasOpenAIEnvProvider = hasEnvProviderInputForFamily(envItems, ProviderFamilyOpenAI)
+		}
+		if sessionID != "" && hasOpenAIEnvProvider {
+			id, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sessionID, openAIModel, envItems)
 			if err != nil {
 				return ResolvedTarget{}, err
 			}
 			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyOpenAI, preferredProviderFamily)
-		} else if !hasSessionEnvProvider {
+		} else if preferredProviderFamily == ProviderFamilyOpenAI || !hasSessionEnvProvider {
 			if err := ensureDefaultOpenAIEnvProvider(ctx, config, store, openAIModel); err != nil {
 				return ResolvedTarget{}, err
 			}
 		}
 	}
-	if bootstrapProviders && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyAnthropic) {
+	bootstrapAnthropic := preferredProviderFamily == "" || preferredProviderFamily == ProviderFamilyAnthropic
+	if bootstrapProviders && bootstrapAnthropic && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyAnthropic) {
 		anthropicModel := firstNonEmptyTrimmed(requestedModel, SessionAnthropicEnvModel(envItems))
-		if sessionID != "" && HasAnthropicEnvProviderInput(envItems) {
-			id, err := ensureSessionAnthropicEnvProvider(ctx, store, sessionID, anthropicModel, envItems)
+		hasAnthropicEnvProvider := HasAnthropicEnvProviderInput(envItems)
+		if preferredProviderFamily == ProviderFamilyAnthropic {
+			hasAnthropicEnvProvider = hasEnvProviderInputForFamily(envItems, ProviderFamilyAnthropic)
+		}
+		if sessionID != "" && hasAnthropicEnvProvider {
+			id, err := ensureSessionAnthropicEnvProviderWithConfig(ctx, config, store, sessionID, anthropicModel, envItems)
 			if err != nil {
 				return ResolvedTarget{}, err
 			}
 			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyAnthropic, preferredProviderFamily)
-		} else if !hasSessionEnvProvider {
+		} else if preferredProviderFamily == ProviderFamilyAnthropic || !hasSessionEnvProvider {
 			if err := ensureDefaultAnthropicEnvProvider(ctx, config, store, anthropicModel); err != nil {
 				return ResolvedTarget{}, err
 			}
@@ -252,14 +279,21 @@ func BootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, 
 
 func ensureDefaultAnthropicEnvProvider(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
 	lookup := defaultLLMEnvProviderLookup(ctx, config, store)
-	authHeader, authScheme := AnthropicProviderAuthFromLookup(lookup)
+	if !hasDefaultAnthropicEnvProviderInput(lookup) {
+		return nil
+	}
+	authHeader, authScheme := layeredAnthropicProviderAuth(ctx, store, nil)
 	_, err := EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, ProviderIDDefaultAnthropic, "anthropic", ProviderScopeEnvDefault, requestedModel, false)
 	return err
 }
 
 func ensureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
+	return ensureSessionOpenAIEnvProviderWithConfig(ctx, nil, store, sessionID, requestedModel, envItems)
+}
+
+func ensureSessionOpenAIEnvProviderWithConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
 	providerID := SessionEnvProviderID(sessionID, ProviderFamilyOpenAI)
-	return EnsureOpenAIEnvProvider(ctx, store, sessionLLMEnvProviderLookup(envItems), providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+	return EnsureOpenAIEnvProvider(ctx, store, layeredLLMEnvProviderLookup(ctx, config, store, envItems), providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
 }
 
 func EnsureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
@@ -267,10 +301,45 @@ func EnsureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore,
 }
 
 func ensureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
+	return ensureSessionAnthropicEnvProviderWithConfig(ctx, nil, store, sessionID, requestedModel, envItems)
+}
+
+func ensureSessionAnthropicEnvProviderWithConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
 	providerID := SessionEnvProviderID(sessionID, ProviderFamilyAnthropic)
-	lookup := sessionLLMEnvProviderLookup(envItems)
-	authHeader, authScheme := AnthropicProviderAuthFromLookup(lookup)
+	lookup := layeredLLMEnvProviderLookup(ctx, config, store, envItems)
+	authHeader, authScheme := layeredAnthropicProviderAuth(ctx, store, envItems)
 	return EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+}
+
+func layeredAnthropicProviderAuth(ctx context.Context, store LLMResolverStore, sandboxItems []domain.SandboxEnvVar) (string, string) {
+	if header, scheme, ok := anthropicProviderAuthFromItems(sandboxItems); ok {
+		return header, scheme
+	}
+	if store != nil {
+		globalItems, err := store.ListGlobalEnv(ctx)
+		if err == nil {
+			if header, scheme, ok := anthropicProviderAuthFromItems(globalItems); ok {
+				return header, scheme
+			}
+		}
+	}
+	if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) != "" {
+		return "x-api-key", ""
+	}
+	if strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN")) != "" {
+		return "Authorization", "Bearer"
+	}
+	return "x-api-key", ""
+}
+
+func anthropicProviderAuthFromItems(items []domain.SandboxEnvVar) (string, string, bool) {
+	if strings.TrimSpace(EnvItemValue(items, "ANTHROPIC_API_KEY")) != "" {
+		return "x-api-key", "", true
+	}
+	if strings.TrimSpace(EnvItemValue(items, "ANTHROPIC_AUTH_TOKEN")) != "" {
+		return "Authorization", "Bearer", true
+	}
+	return "", "", false
 }
 
 func EnsureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
@@ -347,12 +416,7 @@ func lookupEnvValue(ctx context.Context, store LLMResolverStore, key string) str
 	if err != nil {
 		return ""
 	}
-	for _, item := range items {
-		if item.Name == key {
-			return item.Value
-		}
-	}
-	return ""
+	return EnvItemValue(items, key)
 }
 
 func LookupEnvValue(ctx context.Context, store LLMResolverStore, key string) string {

--- a/pkg/llms/resolver.go
+++ b/pkg/llms/resolver.go
@@ -282,8 +282,8 @@ func ensureDefaultAnthropicEnvProvider(ctx context.Context, config *appconfig.Co
 	if !hasDefaultAnthropicEnvProviderInput(lookup) {
 		return nil
 	}
-	authHeader, authScheme := layeredAnthropicProviderAuth(ctx, store, nil)
-	_, err := EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, ProviderIDDefaultAnthropic, "anthropic", ProviderScopeEnvDefault, requestedModel, false)
+	credential := layeredAnthropicCredential(ctx, config, store, nil)
+	_, err := ensureAnthropicEnvProvider(ctx, store, lookup, credential, ProviderIDDefaultAnthropic, "anthropic", ProviderScopeEnvDefault, requestedModel, false)
 	return err
 }
 
@@ -307,39 +307,8 @@ func ensureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverSto
 func ensureSessionAnthropicEnvProviderWithConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
 	providerID := SessionEnvProviderID(sessionID, ProviderFamilyAnthropic)
 	lookup := layeredLLMEnvProviderLookup(ctx, config, store, envItems)
-	authHeader, authScheme := layeredAnthropicProviderAuth(ctx, store, envItems)
-	return EnsureAnthropicEnvProvider(ctx, store, lookup, authHeader, authScheme, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
-}
-
-func layeredAnthropicProviderAuth(ctx context.Context, store LLMResolverStore, sandboxItems []domain.SandboxEnvVar) (string, string) {
-	if header, scheme, ok := anthropicProviderAuthFromItems(sandboxItems); ok {
-		return header, scheme
-	}
-	if store != nil {
-		globalItems, err := store.ListGlobalEnv(ctx)
-		if err == nil {
-			if header, scheme, ok := anthropicProviderAuthFromItems(globalItems); ok {
-				return header, scheme
-			}
-		}
-	}
-	if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) != "" {
-		return "x-api-key", ""
-	}
-	if strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN")) != "" {
-		return "Authorization", "Bearer"
-	}
-	return "x-api-key", ""
-}
-
-func anthropicProviderAuthFromItems(items []domain.SandboxEnvVar) (string, string, bool) {
-	if strings.TrimSpace(EnvItemValue(items, "ANTHROPIC_API_KEY")) != "" {
-		return "x-api-key", "", true
-	}
-	if strings.TrimSpace(EnvItemValue(items, "ANTHROPIC_AUTH_TOKEN")) != "" {
-		return "Authorization", "Bearer", true
-	}
-	return "", "", false
+	credential := layeredAnthropicCredential(ctx, config, store, envItems)
+	return ensureAnthropicEnvProvider(ctx, store, lookup, credential, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
 }
 
 func EnsureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {

--- a/pkg/llms/resolver.go
+++ b/pkg/llms/resolver.go
@@ -163,8 +163,9 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	requestedModel = strings.TrimSpace(requestedModel)
 	providerID = strings.TrimSpace(providerID)
 	hasSessionEnvProvider := sessionID != "" && HasSessionEnvProviderInput(envItems)
-	if sessionID != "" && preferredProviderFamily != "" {
-		hasSessionEnvProvider = hasEnvProviderInputForFamily(envItems, preferredProviderFamily)
+	genericSessionProviderFamily := ""
+	if sessionID != "" {
+		genericSessionProviderFamily = genericLLMEnvProviderFamily(envItems)
 	}
 	sessionProviderID := ""
 	// Reuse an already-persisted session-env provider when this session can no
@@ -185,13 +186,12 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	// provider id from the token scope, so this avoids a redundant pair of
 	// idempotent provider upserts on every LLM request.
 	bootstrapProviders := (providerID == "" || !IsSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
-	bootstrapOpenAI := preferredProviderFamily == "" || preferredProviderFamily == ProviderFamilyOpenAI
+	bootstrapOpenAI := preferredProviderFamily == "" ||
+		preferredProviderFamily == ProviderFamilyOpenAI ||
+		genericSessionProviderFamily == ProviderFamilyOpenAI
 	if bootstrapProviders && bootstrapOpenAI && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyOpenAI) {
 		openAIModel := firstNonEmptyTrimmed(requestedModel, EnvItemValue(envItems, "LLM_MODEL"))
 		hasOpenAIEnvProvider := HasOpenAIEnvProviderInput(envItems)
-		if preferredProviderFamily == ProviderFamilyOpenAI {
-			hasOpenAIEnvProvider = hasEnvProviderInputForFamily(envItems, ProviderFamilyOpenAI)
-		}
 		if sessionID != "" && hasOpenAIEnvProvider {
 			id, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sessionID, openAIModel, envItems)
 			if err != nil {
@@ -204,13 +204,12 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 			}
 		}
 	}
-	bootstrapAnthropic := preferredProviderFamily == "" || preferredProviderFamily == ProviderFamilyAnthropic
+	bootstrapAnthropic := preferredProviderFamily == "" ||
+		preferredProviderFamily == ProviderFamilyAnthropic ||
+		genericSessionProviderFamily == ProviderFamilyAnthropic
 	if bootstrapProviders && bootstrapAnthropic && !hasConfiguredLLMProviderForFamily(ctx, store, ProviderFamilyAnthropic) {
 		anthropicModel := firstNonEmptyTrimmed(requestedModel, SessionAnthropicEnvModel(envItems))
 		hasAnthropicEnvProvider := HasAnthropicEnvProviderInput(envItems)
-		if preferredProviderFamily == ProviderFamilyAnthropic {
-			hasAnthropicEnvProvider = hasEnvProviderInputForFamily(envItems, ProviderFamilyAnthropic)
-		}
 		if sessionID != "" && hasAnthropicEnvProvider {
 			id, err := ensureSessionAnthropicEnvProviderWithConfig(ctx, config, store, sessionID, anthropicModel, envItems)
 			if err != nil {

--- a/pkg/llms/runtime_config.go
+++ b/pkg/llms/runtime_config.go
@@ -66,6 +66,10 @@ func WriteCodexRuntimeConfig(session *domain.Sandbox, model, baseURL, wireAPI st
 	if model == "" || baseURL == "" {
 		return nil
 	}
+	wireAPI = NormalizeWireAPI(wireAPI)
+	if wireAPI != APIProtocolResponses {
+		return fmt.Errorf("codex model-provider wire API %q is unsupported; expected %q", wireAPI, APIProtocolResponses)
+	}
 	policy = normalizeCodexRuntimePolicy(policy)
 	path := filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -104,7 +108,7 @@ ignore_default_excludes = false
 
 [history]
 persistence = "save-all"
-`, model, baseURL, NormalizeWireAPI(wireAPI), policy.RequestMaxRetries, policy.StreamMaxRetries, policy.StreamIdleTimeout.Milliseconds())
+`, model, baseURL, wireAPI, policy.RequestMaxRetries, policy.StreamMaxRetries, policy.StreamIdleTimeout.Milliseconds())
 	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
 		return fmt.Errorf("write codex config: %w", err)
 	}

--- a/pkg/llms/runtime_config.go
+++ b/pkg/llms/runtime_config.go
@@ -382,6 +382,20 @@ func GuestRuntimeBaseURL(config *appconfig.Config, session *domain.Sandbox) stri
 	return "http://" + host + ":" + port
 }
 
+// RequireGuestRuntimeBaseURL resolves the daemon URL used by sandbox runtime
+// clients and rejects topologies that do not provide a sandbox-reachable URL.
+func RequireGuestRuntimeBaseURL(config *appconfig.Config, session *domain.Sandbox) (string, error) {
+	baseURL := GuestRuntimeBaseURL(config, session)
+	if baseURL != "" {
+		return baseURL, nil
+	}
+	return "", domain.ClassifyError(
+		domain.ErrFailedPrecondition,
+		fmt.Sprintf("runtime LLM facade requires a daemon URL reachable from the sandbox; configure %s", RuntimeBaseURLEnvName),
+		nil,
+	)
+}
+
 func LookupRuntimeBaseURLEnv(session *domain.Sandbox) string {
 	if session == nil {
 		return ""

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -47,7 +47,7 @@ func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Conf
 	}
 	switch domain.NormalizeAgentKind(agent) {
 	case "codex":
-		env, err := ensureSessionCodexConfig(ctx, config, store, session, model, source, runID)
+		env, err := llms.EnsureCodexFacadeConfig(ctx, config, store, session, model, source, runID)
 		return AgentRuntimeConfig{Env: env}, err
 	case "claude":
 		env, err := ensureSessionClaudeConfig(ctx, config, store, session, model, source, runID)
@@ -61,44 +61,6 @@ func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Conf
 	default:
 		return AgentRuntimeConfig{}, nil
 	}
-}
-
-func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	providerEnv, err := llms.SandboxProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
-	if err != nil {
-		return nil, err
-	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", providerEnv)
-	if err != nil {
-		if isOptionalConfigError(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	baseURL := llms.GuestRuntimeBaseURL(config, session)
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, nil
-	}
-	facadeWireAPI := llms.APIProtocolResponses
-	tokenValue, token, err := llms.NewFacadeToken(session.Summary.ID, target.Model.Name, target.Provider.ID, facadeWireAPI, source, runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
-	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + session.Summary.ID + "/llm/openai/v1"
-	if err := llms.WriteCodexRuntimeConfig(session, target.Model.Name, openAIBaseURL, facadeWireAPI, llms.CodexRuntimePolicyFromConfig(config)); err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		"AGENT_COMPOSE_SANDBOX_TOKEN": tokenValue,
-		"LLM_API_ENDPOINT":            openAIBaseURL,
-		"LLM_API_KEY":                 tokenValue,
-		"LLM_API_PROTOCOL":            facadeWireAPI,
-		"OPENAI_API_KEY":              tokenValue,
-		"OPENAI_BASE_URL":             openAIBaseURL,
-	}, nil
 }
 
 func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -64,7 +64,11 @@ func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Conf
 }
 
 func ensureSessionCodexConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", sessionProviderEnvItems(session))
+	providerEnv, err := llms.SandboxProviderEnvItems(ctx, store, session, llms.ProviderFamilyOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyOpenAI, model, "", providerEnv)
 	if err != nil {
 		if isOptionalConfigError(err) {
 			return nil, nil
@@ -102,7 +106,10 @@ func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, st
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	providerEnv := sessionProviderEnvItems(session)
+	providerEnv, err := llms.SandboxProviderEnvItems(ctx, store, session, llms.ProviderFamilyAnthropic)
+	if err != nil {
+		return nil, err
+	}
 	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, session.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
 	tokenModel := ""
 	tokenProvider := ""
@@ -167,16 +174,6 @@ func HasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, stor
 		os.Getenv("LLM_API_KEY"),
 		configKey,
 	)) != ""
-}
-
-func sessionProviderEnvItems(session *domain.Sandbox) []domain.SandboxEnvVar {
-	if session == nil {
-		return nil
-	}
-	if len(session.ProviderEnvItems) > 0 {
-		return session.ProviderEnvItems
-	}
-	return session.EnvItems
 }
 
 func firstNonEmpty(values ...string) string {

--- a/pkg/llms/runtimefacade/config_protocol_test.go
+++ b/pkg/llms/runtimefacade/config_protocol_test.go
@@ -1,0 +1,68 @@
+package runtimefacade
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/samber/do/v2"
+
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/internal/testutil"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestEnsureSessionOpenCodeKeepsResponsesIngressForChatUpstream(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		DbAddr:         filepath.Join(root, "data.db"),
+		RuntimeBaseURL: "http://agent-compose.test:7410",
+		GuestHomePath:  "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{
+		ID:            "sandbox-opencode-chat-upstream",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-opencode-chat-upstream", "workspace"),
+	}}
+	llms.SetSandboxProviderEnvItems(session, []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://chat.example.test/v1"},
+		{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolChatCompletions},
+		{Name: "LLM_API_KEY", Value: "chat-key", Secret: true},
+		{Name: "LLM_MODEL", Value: "gpt-chat"},
+	})
+
+	env, err := EnsureSessionLLMFacadeConfig(ctx, config, store, session, "opencode", "openai/gpt-chat", TokenSourceAgent, "run-chat")
+	if err != nil {
+		t.Fatalf("EnsureSessionLLMFacadeConfig returned error: %v", err)
+	}
+	if env["LLM_API_PROTOCOL"] != llms.APIProtocolResponses {
+		t.Fatalf("OpenCode ingress protocol = %q, want responses", env["LLM_API_PROTOCOL"])
+	}
+	token, err := store.GetLLMFacadeToken(ctx, env["AGENT_COMPOSE_SANDBOX_TOKEN"])
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
+	}
+	if token.WireAPI != llms.APIProtocolResponses {
+		t.Fatalf("facade token wire API = %q, want responses", token.WireAPI)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledLLMProviders returned error: %v", err)
+	}
+	if len(providers) != 1 || providers[0].DefaultWireAPI != llms.APIProtocolChatCompletions {
+		t.Fatalf("upstream providers = %#v", providers)
+	}
+}

--- a/pkg/llms/runtimefacade/config_test.go
+++ b/pkg/llms/runtimefacade/config_test.go
@@ -281,7 +281,10 @@ func TestEnsureSessionAgentRuntimeConfigClaudePreservesProviderlessCompatibility
 	config := &appconfig.Config{
 		DataRoot:       root,
 		DbAddr:         filepath.Join(root, "data.db"),
+		LLMAPIEndpoint: "https://openai.example.test/base",
+		LLMAPIProtocol: llms.APIProtocolResponses,
 		LLMAPIKey:      "generic-provider-key",
+		LLMModel:       "generic-model",
 		RuntimeBaseURL: "http://agent-compose.test:7410",
 	}
 	di := do.New()
@@ -307,6 +310,13 @@ func TestEnsureSessionAgentRuntimeConfigClaudePreservesProviderlessCompatibility
 	}
 	if token.ProviderID != "" || token.Model != "" {
 		t.Fatalf("compatibility token = %#v", token)
+	}
+	target, err := llms.ResolveRuntimeLLMTarget(ctx, config, store, config.LLMModel, token.ProviderID)
+	if err != nil {
+		t.Fatalf("resolve providerless compatibility target: %v", err)
+	}
+	if target.Provider.ProviderType != llms.ProviderFamilyOpenAI || target.WireAPI != llms.APIProtocolResponses || target.Provider.APIKey == "" {
+		t.Fatalf("providerless compatibility target = family %q, wire API %q", target.Provider.ProviderType, target.WireAPI)
 	}
 }
 

--- a/pkg/llms/runtimefacade/config_test.go
+++ b/pkg/llms/runtimefacade/config_test.go
@@ -2,6 +2,7 @@ package runtimefacade
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,6 +83,72 @@ func TestEnsureSessionLLMFacadeConfigCreatesCodexEnvAndToken(t *testing.T) {
 		if !strings.Contains(string(codexConfig), want) {
 			t.Fatalf("Codex runtime config %q does not contain %q", string(codexConfig), want)
 		}
+	}
+}
+
+func TestEnsureSessionLLMFacadeConfigRejectsManagedCodexWithoutReachableFacade(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		DbAddr:         filepath.Join(root, "data.db"),
+		LLMAPIEndpoint: "https://llm.example.test/v1",
+		LLMAPIKey:      "test-key",
+		LLMModel:       "gpt-test",
+		LLMAPIProtocol: llms.APIProtocolResponses,
+		HttpListen:     "127.0.0.1:7410",
+		GuestHomePath:  "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{
+		ID:            "sandbox-runtimefacade-unreachable",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-runtimefacade-unreachable", "workspace"),
+	}}
+
+	env, err := EnsureSessionLLMFacadeConfig(ctx, config, store, session, "codex", "", "test", "run-1")
+	if !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("EnsureSessionLLMFacadeConfig error = %v, want failed precondition", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("EnsureSessionLLMFacadeConfig env = %#v, want empty", env)
+	}
+	if !strings.Contains(err.Error(), llms.RuntimeBaseURLEnvName) {
+		t.Fatalf("EnsureSessionLLMFacadeConfig error = %q, want actionable runtime base URL configuration", err)
+	}
+}
+
+func TestEnsureSessionLLMFacadeConfigAllowsUnmanagedCodexWithoutFacade(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:      root,
+		DbAddr:        filepath.Join(root, "data.db"),
+		HttpListen:    "127.0.0.1:7410",
+		GuestHomePath: "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-runtimefacade-unmanaged", Driver: driverpkg.RuntimeDriverDocker}}
+
+	env, err := EnsureSessionLLMFacadeConfig(ctx, config, store, session, "codex", "", "test", "run-1")
+	if err != nil || len(env) != 0 {
+		t.Fatalf("EnsureSessionLLMFacadeConfig env = %#v, error = %v; want unmanaged no-op", env, err)
 	}
 }
 

--- a/pkg/llms/runtimefacade/provider_environment_e2e_test.go
+++ b/pkg/llms/runtimefacade/provider_environment_e2e_test.go
@@ -1,0 +1,121 @@
+package runtimefacade
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/internal/testutil"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestE2EClaudeModelProviderOverrideSurvivesSandboxReload(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:             root,
+		SandboxRoot:          filepath.Join(root, "sandboxes"),
+		DbAddr:               filepath.Join(root, "data.db"),
+		RuntimeDriver:        driverpkg.RuntimeDriverDocker,
+		DefaultImage:         "guest:latest",
+		RuntimeBaseURL:       "http://agent-compose.test:7410",
+		GuestHomePath:        "/root",
+		JupyterProxyBasePath: "/jupyter",
+	}
+	configStore, sandboxStore, err := testutil.OpenStores(t, config)
+	if err != nil {
+		t.Fatalf("open stores: %v", err)
+	}
+
+	const model = "claude-e2e-model"
+	providerEnv := []domain.SandboxEnvVar{
+		{Name: "ANTHROPIC_API_KEY", Value: "fixture-key", Secret: true},
+		{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.example.test"},
+		{Name: "CLAUDE_MODEL", Value: model},
+		{Name: "CLAUDE_CODE_PATH", Value: "/opt/claude"},
+	}
+	sandbox, err := sandboxStore.CreateSandbox(
+		ctx,
+		"Claude provider override",
+		"",
+		driverpkg.RuntimeDriverDocker,
+		"guest:latest",
+		"",
+		domain.SandboxTypeManual,
+		nil,
+		llms.FilterPersistedRuntimeEnv(providerEnv),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+	llms.SetSandboxProviderEnvItems(sandbox, providerEnv)
+	if len(sandbox.ProviderEnvOverrideNames) != 3 ||
+		!slices.Contains(sandbox.ProviderEnvOverrideNames, "CLAUDE_MODEL") ||
+		slices.Contains(sandbox.ProviderEnvOverrideNames, "CLAUDE_CODE_PATH") {
+		t.Fatalf("provider provenance names = %#v", sandbox.ProviderEnvOverrideNames)
+	}
+	requireClaudeFacadeModel(t, ctx, config, configStore, sandbox, "run-before-reload", model)
+	if err := sandboxStore.UpdateSandbox(ctx, sandbox); err != nil {
+		t.Fatalf("persist sandbox: %v", err)
+	}
+
+	reloaded, err := sandboxStore.GetSandbox(ctx, sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("reload sandbox: %v", err)
+	}
+	if len(reloaded.ProviderEnvItems) != 0 || llms.EnvItemValue(reloaded.EnvItems, "ANTHROPIC_API_KEY") != "" {
+		t.Fatal("reloaded sandbox retained transient provider credentials")
+	}
+	if llms.EnvItemValue(reloaded.EnvItems, "CLAUDE_CODE_PATH") != "/opt/claude" ||
+		slices.Contains(reloaded.ProviderEnvOverrideNames, "CLAUDE_CODE_PATH") {
+		t.Fatalf("ordinary Claude runtime environment was reclassified: %#v", reloaded.ProviderEnvOverrideNames)
+	}
+	anthropicEnv, err := llms.SandboxProviderEnvItems(ctx, configStore, reloaded, llms.ProviderFamilyAnthropic)
+	if err != nil {
+		t.Fatalf("restore Anthropic provider environment: %v", err)
+	}
+	if llms.EnvItemValue(anthropicEnv, "CLAUDE_MODEL") != model ||
+		llms.EnvItemValue(anthropicEnv, "ANTHROPIC_API_KEY") == "" ||
+		llms.EnvItemValue(anthropicEnv, "CLAUDE_CODE_PATH") != "" {
+		t.Fatal("restored Anthropic provider environment is incomplete or contains ordinary runtime values")
+	}
+	openAIEnv, err := llms.SandboxProviderEnvItems(ctx, configStore, reloaded, llms.ProviderFamilyOpenAI)
+	if err != nil {
+		t.Fatalf("restore OpenAI provider environment: %v", err)
+	}
+	if llms.EnvItemValue(openAIEnv, "CLAUDE_MODEL") != "" {
+		t.Fatal("OpenAI provider environment contains CLAUDE_MODEL")
+	}
+
+	rawToken := requireClaudeFacadeModel(t, ctx, config, configStore, reloaded, "run-after-reload", model)
+	token, err := configStore.GetLLMFacadeToken(ctx, rawToken)
+	if err != nil {
+		t.Fatalf("load facade token: %v", err)
+	}
+	if token.Model != model || token.ProviderID != llms.SessionEnvProviderID(sandbox.Summary.ID, llms.ProviderFamilyAnthropic) {
+		t.Fatalf("reloaded facade token scope = model %q, provider %q", token.Model, token.ProviderID)
+	}
+}
+
+func requireClaudeFacadeModel(t *testing.T, ctx context.Context, config *appconfig.Config, store FacadeStore, sandbox *domain.Sandbox, runID, wantModel string) string {
+	t.Helper()
+	runtimeConfig, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, sandbox, "claude", "", TokenSourceAgent, runID)
+	if err != nil {
+		t.Fatalf("configure Claude facade: %v", err)
+	}
+	if runtimeConfig.Env["CLAUDE_MODEL"] != wantModel || runtimeConfig.Env["ANTHROPIC_MODEL"] != wantModel {
+		t.Fatalf("Claude facade model = %q/%q, want %q", runtimeConfig.Env["CLAUDE_MODEL"], runtimeConfig.Env["ANTHROPIC_MODEL"], wantModel)
+	}
+	rawToken := runtimeConfig.Env["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	if rawToken == "" {
+		t.Fatal("Claude facade token is empty")
+	}
+	return rawToken
+}

--- a/pkg/llms/runtimefacade/provider_environment_e2e_test.go
+++ b/pkg/llms/runtimefacade/provider_environment_e2e_test.go
@@ -18,16 +18,7 @@ func TestE2EClaudeModelProviderOverrideSurvivesSandboxReload(t *testing.T) {
 
 	ctx := context.Background()
 	root := t.TempDir()
-	config := &appconfig.Config{
-		DataRoot:             root,
-		SandboxRoot:          filepath.Join(root, "sandboxes"),
-		DbAddr:               filepath.Join(root, "data.db"),
-		RuntimeDriver:        driverpkg.RuntimeDriverDocker,
-		DefaultImage:         "guest:latest",
-		RuntimeBaseURL:       "http://agent-compose.test:7410",
-		GuestHomePath:        "/root",
-		JupyterProxyBasePath: "/jupyter",
-	}
+	config := e2eRuntimeFacadeConfig(root)
 	configStore, sandboxStore, err := testutil.OpenStores(t, config)
 	if err != nil {
 		t.Fatalf("open stores: %v", err)
@@ -101,6 +92,98 @@ func TestE2EClaudeModelProviderOverrideSurvivesSandboxReload(t *testing.T) {
 	}
 	if token.Model != model || token.ProviderID != llms.SessionEnvProviderID(sandbox.Summary.ID, llms.ProviderFamilyAnthropic) {
 		t.Fatalf("reloaded facade token scope = model %q, provider %q", token.Model, token.ProviderID)
+	}
+}
+
+func TestE2EClaudeKeepsGenericResponsesProviderAcrossSandboxReload(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := e2eRuntimeFacadeConfig(root)
+	configStore, sandboxStore, err := testutil.OpenStores(t, config)
+	if err != nil {
+		t.Fatalf("open stores: %v", err)
+	}
+
+	const model = "generic-e2e-model"
+	providerEnv := []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://openai.example.test/base"},
+		{Name: "LLM_API_PROTOCOL", Value: llms.APIProtocolResponses},
+		{Name: "LLM_API_KEY", Value: "fixture-key", Secret: true},
+		{Name: "LLM_MODEL", Value: model},
+	}
+	sandbox, err := sandboxStore.CreateSandbox(
+		ctx,
+		"Claude generic provider compatibility",
+		"",
+		driverpkg.RuntimeDriverDocker,
+		"guest:latest",
+		"",
+		domain.SandboxTypeManual,
+		nil,
+		llms.FilterPersistedRuntimeEnv(providerEnv),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+	llms.SetSandboxProviderEnvItems(sandbox, providerEnv)
+	providerID := llms.SessionEnvProviderID(sandbox.Summary.ID, llms.ProviderFamilyOpenAI)
+	requireTokenScope := func(rawToken string) {
+		t.Helper()
+		token, err := configStore.GetLLMFacadeToken(ctx, rawToken)
+		if err != nil {
+			t.Fatalf("load facade token: %v", err)
+		}
+		if token.Model != model || token.ProviderID != providerID || token.WireAPI != llms.APIProtocolMessages {
+			t.Fatalf("Claude compatibility token scope = model %q, provider %q, wire API %q", token.Model, token.ProviderID, token.WireAPI)
+		}
+		target, err := llms.ResolveRuntimeLLMTarget(ctx, config, configStore, model, token.ProviderID)
+		if err != nil {
+			t.Fatalf("resolve facade compatibility target: %v", err)
+		}
+		if target.Provider.ProviderType != llms.ProviderFamilyOpenAI || target.WireAPI != llms.APIProtocolResponses {
+			t.Fatalf("facade compatibility target = family %q, wire API %q", target.Provider.ProviderType, target.WireAPI)
+		}
+		providers, err := configStore.ListEnabledLLMProviders(ctx)
+		if err != nil {
+			t.Fatalf("list providers: %v", err)
+		}
+		for _, provider := range providers {
+			if provider.ID == providerID && provider.ProviderType == llms.ProviderFamilyOpenAI && provider.APIKey != "" {
+				return
+			}
+		}
+		t.Fatal("generic OpenAI session provider or its credential is missing")
+	}
+
+	rawToken := requireClaudeFacadeModel(t, ctx, config, configStore, sandbox, "run-generic-before-reload", model)
+	requireTokenScope(rawToken)
+	if err := sandboxStore.UpdateSandbox(ctx, sandbox); err != nil {
+		t.Fatalf("persist sandbox: %v", err)
+	}
+	reloaded, err := sandboxStore.GetSandbox(ctx, sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("reload sandbox: %v", err)
+	}
+	if len(reloaded.ProviderEnvItems) != 0 || llms.EnvItemValue(reloaded.EnvItems, "LLM_API_KEY") != "" {
+		t.Fatal("reloaded sandbox retained transient generic provider credentials")
+	}
+	rawToken = requireClaudeFacadeModel(t, ctx, config, configStore, reloaded, "run-generic-after-reload", model)
+	requireTokenScope(rawToken)
+}
+
+func e2eRuntimeFacadeConfig(root string) *appconfig.Config {
+	return &appconfig.Config{
+		DataRoot:             root,
+		SandboxRoot:          filepath.Join(root, "sandboxes"),
+		DbAddr:               filepath.Join(root, "data.db"),
+		RuntimeDriver:        driverpkg.RuntimeDriverDocker,
+		DefaultImage:         "guest:latest",
+		RuntimeBaseURL:       "http://agent-compose.test:7410",
+		GuestHomePath:        "/root",
+		JupyterProxyBasePath: "/jupyter",
 	}
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -184,9 +184,15 @@ type Sandbox struct {
 	WorkspaceProvisioning *SandboxWorkspaceProvisioning `json:"workspace_provisioning,omitempty"`
 	WorkspaceReclamation  *SandboxWorkspaceReclamation  `json:"workspace_reclamation,omitempty"`
 	EnvItems              []SandboxEnvVar               `json:"env_items,omitempty"`
-	VolumeMounts          []SandboxVolumeMount          `json:"volume_mounts,omitempty"`
-	RuntimeEnvItems       []SandboxEnvVar               `json:"-"`
-	ProviderEnvItems      []SandboxEnvVar               `json:"-"`
+	// ProviderEnvOverrideNames records which provider environment names were
+	// explicitly supplied by the sandbox. A nil slice means the metadata has no
+	// provenance; an empty, non-nil slice means provenance was recorded and the
+	// sandbox has no provider overrides. Values remain transient in ProviderEnvItems
+	// or in session-scoped LLM provider rows.
+	ProviderEnvOverrideNames []string             `json:"provider_env_override_names"`
+	VolumeMounts             []SandboxVolumeMount `json:"volume_mounts,omitempty"`
+	RuntimeEnvItems          []SandboxEnvVar      `json:"-"`
+	ProviderEnvItems         []SandboxEnvVar      `json:"-"`
 }
 
 func SandboxWorkspaceReclaimed(sandbox *Sandbox) bool {
@@ -271,6 +277,9 @@ func validSandboxWorkspaceProvisioningStatus(status string) bool {
 func RestoreSandboxTransientFields(dst, src *Sandbox) {
 	if dst == nil || src == nil {
 		return
+	}
+	if src.ProviderEnvOverrideNames != nil {
+		dst.ProviderEnvOverrideNames = append([]string{}, src.ProviderEnvOverrideNames...)
 	}
 	if len(src.RuntimeEnvItems) > 0 {
 		dst.RuntimeEnvItems = append([]SandboxEnvVar(nil), src.RuntimeEnvItems...)

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1072,7 +1072,11 @@ func (c *Controller) ensurePromptAttachLLMFacadeEnv(ctx context.Context, sandbox
 	if domain.NormalizeAgentKind(agent.Provider) != "codex" {
 		return nil, nil
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, store, sandbox.Summary.ID, llms.ProviderFamilyOpenAI, agent.Model, "", promptAttachSandboxProviderEnvItems(sandbox))
+	providerEnv, err := llms.SandboxProviderEnvItems(ctx, store, sandbox, llms.ProviderFamilyOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, store, sandbox.Summary.ID, llms.ProviderFamilyOpenAI, agent.Model, "", providerEnv)
 	if err != nil {
 		if errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition) {
 			return nil, nil
@@ -1110,16 +1114,6 @@ func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token
 		return
 	}
 	_ = store.DeleteLLMFacadeToken(ctx, token)
-}
-
-func promptAttachSandboxProviderEnvItems(sandbox *domain.Sandbox) []domain.SandboxEnvVar {
-	if sandbox == nil {
-		return nil
-	}
-	if len(sandbox.ProviderEnvItems) > 0 {
-		return sandbox.ProviderEnvItems
-	}
-	return sandbox.EnvItems
 }
 
 func projectRunAgentExecutionStream(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, sink *StreamSink, hub *RunLogHub) execution.AgentExecutionStream {
@@ -2128,7 +2122,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 	if err != nil {
 		return SandboxResult{}, err
 	}
-	sandbox.ProviderEnvItems = prepared.ProviderEnvItems
+	llms.SetSandboxProviderEnvItems(sandbox, prepared.ProviderEnvItems)
 	if err := c.ensureProjectRunSandboxWorkspace(ctx, sandbox); err != nil {
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
 	}

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1060,52 +1060,18 @@ func (c *Controller) ensurePromptAttachLLMFacadeEnv(ctx context.Context, sandbox
 	if !ok || c.config == nil || sandbox == nil {
 		return nil, nil
 	}
-	if domain.NormalizeAgentKind(agent.Provider) == "claude" {
+	switch domain.NormalizeAgentKind(agent.Provider) {
+	case "claude":
 		return ensurePromptAttachClaudeLLMFacadeEnv(ctx, c.config, store, sandbox, agent.Model, runID)
-	}
-	if domain.NormalizeAgentKind(agent.Provider) == "opencode" {
+	case "opencode":
 		return llms.EnsureOpenCodeFacadeConfig(ctx, c.config, store, sandbox, agent.Model, "agent", runID)
-	}
-	if domain.NormalizeAgentKind(agent.Provider) == "pi" {
+	case "pi":
 		return llms.EnsurePiFacadeConfig(ctx, c.config, store, sandbox, agent.Model, "agent", runID)
-	}
-	if domain.NormalizeAgentKind(agent.Provider) != "codex" {
+	case "codex":
+		return llms.EnsureCodexFacadeConfig(ctx, c.config, store, sandbox, agent.Model, "agent", runID)
+	default:
 		return nil, nil
 	}
-	providerEnv, err := llms.SandboxProviderEnvItems(ctx, store, sandbox, llms.ProviderFamilyOpenAI)
-	if err != nil {
-		return nil, err
-	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, store, sandbox.Summary.ID, llms.ProviderFamilyOpenAI, agent.Model, "", providerEnv)
-	if err != nil {
-		if errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	baseURL := llms.GuestRuntimeBaseURL(c.config, sandbox)
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, nil
-	}
-	tokenValue, token, err := llms.NewFacadeToken(sandbox.Summary.ID, target.Model.Name, target.Provider.ID, llms.APIProtocolResponses, "agent", runID)
-	if err != nil {
-		return nil, err
-	}
-	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
-		return nil, err
-	}
-	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/openai/v1"
-	if err := llms.WriteCodexRuntimeConfig(sandbox, target.Model.Name, openAIBaseURL, llms.APIProtocolResponses, llms.CodexRuntimePolicyFromConfig(c.config)); err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		"AGENT_COMPOSE_SANDBOX_TOKEN": tokenValue,
-		"LLM_API_ENDPOINT":            openAIBaseURL,
-		"LLM_API_KEY":                 tokenValue,
-		"LLM_API_PROTOCOL":            llms.APIProtocolResponses,
-		"OPENAI_API_KEY":              tokenValue,
-		"OPENAI_BASE_URL":             openAIBaseURL,
-	}, nil
 }
 
 func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token string) {

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -69,13 +69,12 @@ func PrepareProjectRun(ctx context.Context, store PreparationStore, resolver Wor
 	if err != nil {
 		return Preparation{}, fmt.Errorf("list global env: %w", err)
 	}
-	envItems := MergeEnvItems(
-		globalEnv,
+	providerEnvItems := MergeEnvItems(
 		EnvItemsFromV2(spec.GetVariables()),
 		agent.EnvItems,
 		EnvItemsFromV2(requestEnv),
 	)
-	providerEnvItems := envItems
+	envItems := domain.MergeEnvItems(globalEnv, providerEnvItems)
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	prepared := Preparation{
 		EnvItems:         envItems,

--- a/pkg/runs/preparation_provider_env_test.go
+++ b/pkg/runs/preparation_provider_env_test.go
@@ -1,0 +1,54 @@
+package runs
+
+import (
+	"context"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestPrepareProjectRunKeepsGlobalEnvOutOfSandboxProviderOverrides(t *testing.T) {
+	store := &fakePreparationStore{
+		project: domain.ProjectRecord{ID: "project-1", Name: "project"},
+		revision: domain.ProjectRevisionRecord{
+			ProjectID: "project-1",
+			Revision:  1,
+			SpecJSON:  `{"variables":[{"name":"PROJECT_VALUE","value":"project"}],"agents":[{"name":"worker"}]}`,
+		},
+		agent: domain.AgentDefinition{
+			ID:       "agent-1",
+			EnvItems: []domain.SandboxEnvVar{{Name: "AGENT_VALUE", Value: "agent"}},
+		},
+		global: []domain.SandboxEnvVar{
+			{Name: "GLOBAL_VALUE", Value: "global"},
+			{Name: "LLM_API_KEY", Value: "global-key", Secret: true},
+		},
+	}
+	prepared, err := PrepareProjectRun(context.Background(), store, nil, domain.ProjectRunRecord{
+		ProjectID:       "project-1",
+		ProjectRevision: 1,
+		AgentName:       "worker",
+		ManagedAgentID:  "agent-1",
+	}, []*agentcomposev2.EnvVarSpec{{Name: "REQUEST_VALUE", Value: "request"}})
+	if err != nil {
+		t.Fatalf("PrepareProjectRun returned error: %v", err)
+	}
+	runtimeEnv := domain.SandboxEnvMap(prepared.EnvItems)
+	if runtimeEnv["GLOBAL_VALUE"] != "global" || runtimeEnv["LLM_API_KEY"] != "" {
+		t.Fatalf("runtime env = %#v", runtimeEnv)
+	}
+	providerEnv := domain.SandboxEnvMap(prepared.ProviderEnvItems)
+	if providerEnv["GLOBAL_VALUE"] != "" || providerEnv["LLM_API_KEY"] != "" {
+		t.Fatalf("provider overrides contain Global Env: %#v", providerEnv)
+	}
+	for name, want := range map[string]string{
+		"PROJECT_VALUE": "project",
+		"AGENT_VALUE":   "agent",
+		"REQUEST_VALUE": "request",
+	} {
+		if providerEnv[name] != want {
+			t.Fatalf("provider env %s = %q, want %q", name, providerEnv[name], want)
+		}
+	}
+}

--- a/pkg/runs/prompt_attach_facade.go
+++ b/pkg/runs/prompt_attach_facade.go
@@ -16,7 +16,11 @@ func ensurePromptAttachClaudeLLMFacadeEnv(ctx context.Context, config *appconfig
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, llms.ProviderFamilyAnthropic, model, "", promptAttachSandboxProviderEnvItems(sandbox))
+	providerEnv, err := llms.SandboxProviderEnvItems(ctx, store, sandbox, llms.ProviderFamilyAnthropic)
+	if err != nil {
+		return nil, err
+	}
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, llms.ProviderFamilyAnthropic, model, "", providerEnv)
 	tokenModel := strings.TrimSpace(model)
 	tokenProvider := ""
 	if err != nil {

--- a/pkg/runs/prompt_attach_facade_test.go
+++ b/pkg/runs/prompt_attach_facade_test.go
@@ -2,6 +2,7 @@ package runs
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,6 +91,38 @@ func TestEnsurePromptAttachLLMFacadeEnvClaudeUsesControllerStore(t *testing.T) {
 	token := store.tokens[0]
 	if token.SandboxID != sandbox.Summary.ID || token.Model != "claude-test" || token.Source != "agent" || token.RunID != "run-claude-attach" {
 		t.Fatalf("stored token = %#v", token)
+	}
+}
+
+func TestEnsurePromptAttachLLMFacadeEnvRejectsManagedCodexWithoutReachableFacade(t *testing.T) {
+	store := &promptAttachFacadeStore{
+		providers: []llms.Provider{{
+			ID:             "openai-test",
+			ProviderType:   llms.ProviderFamilyOpenAI,
+			DefaultWireAPI: llms.APIProtocolResponses,
+			BaseURL:        "https://openai.example.test/v1",
+			APIKey:         "openai-key",
+			Enabled:        true,
+		}},
+		models: []llms.Model{{ID: "gpt-test", Name: "gpt-test", DefaultModel: true, Enabled: true}},
+	}
+	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-codex-no-facade", Driver: driver.RuntimeDriverDocker}}
+	controller := &Controller{
+		config:   &appconfig.Config{HttpListen: "127.0.0.1:7410", GuestHomePath: "/root"},
+		configDB: store,
+	}
+
+	env, err := controller.ensurePromptAttachLLMFacadeEnv(
+		context.Background(),
+		sandbox,
+		execution.AgentConfig{Provider: "codex", Model: "gpt-test"},
+		"run-codex-no-facade",
+	)
+	if !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("ensurePromptAttachLLMFacadeEnv error = %v, want failed precondition", err)
+	}
+	if len(env) != 0 || len(store.tokens) != 0 {
+		t.Fatalf("facade env = %#v, tokens = %#v; want no partial configuration", env, store.tokens)
 	}
 }
 

--- a/pkg/storage/sessionstore/provider_env_persistence_test.go
+++ b/pkg/storage/sessionstore/provider_env_persistence_test.go
@@ -1,0 +1,48 @@
+package sessionstore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestSandboxProviderEnvPersistsOnlyProvenance(t *testing.T) {
+	store := newCoverageStore(t)
+	sandbox, err := store.CreateSandbox(context.Background(), "provider env", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	llms.SetSandboxProviderEnvItems(sandbox, []domain.SandboxEnvVar{
+		{Name: "LLM_API_ENDPOINT", Value: "https://sandbox.example/v1"},
+		{Name: "LLM_API_KEY", Value: "sandbox-key", Secret: true},
+		{Name: "ORDINARY", Value: "ordinary"},
+	})
+	if err := store.UpdateSandbox(context.Background(), sandbox); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+
+	loaded, err := store.GetSandbox(context.Background(), sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if len(loaded.ProviderEnvItems) != 0 {
+		t.Fatalf("transient ProviderEnvItems were persisted: %#v", loaded.ProviderEnvItems)
+	}
+	if len(loaded.ProviderEnvOverrideNames) != 2 || loaded.ProviderEnvOverrideNames[0] != "LLM_API_ENDPOINT" || loaded.ProviderEnvOverrideNames[1] != "LLM_API_KEY" {
+		t.Fatalf("persisted provider provenance = %#v", loaded.ProviderEnvOverrideNames)
+	}
+
+	metadata, err := os.ReadFile(filepath.Join(store.SandboxDir(sandbox.Summary.ID), "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	if strings.Contains(string(metadata), "sandbox-key") || strings.Contains(string(metadata), "ordinary") {
+		t.Fatalf("metadata contains transient provider values: %s", metadata)
+	}
+}


### PR DESCRIPTION
## Summary

- Isolate sandbox-owned provider environment from Global Env and persist only override provenance.
- Keep generic `LLM_*` family resolution protocol-based, with credentials and authentication semantics selected from the same source layer.
- Treat Claude and Codex as facade ingress choices rather than upstream-family signals, preserving cross-family protocol conversion.
- Enforce managed facade ingress protocols and fail managed Codex setup when no sandbox-reachable facade is available.
- Treat only `CLAUDE_MODEL` as an Anthropic provider override; unrelated `CLAUDE_*` runtime variables remain ordinary environment.

## Issue resolution

Fixes #305.

- Codex and OpenCode keep the Responses facade ingress; when the resolved OpenAI-compatible upstream uses Chat Completions, the runtime facade performs the protocol conversion.
- Global provider settings are no longer recorded as sandbox-owned overrides.
- Explicit sandbox overrides survive reload through provenance while credential values remain transient.
- Current and reloaded sandboxes apply the same provider-family filtering.
- Claude with generic Responses configuration keeps its OpenAI upstream before and after sandbox reload while continuing to use the Messages facade.

## Testing

Passed:

- `task lint`
- `task build`
- `go test ./pkg/llms/... ./pkg/agentcompose/proxy/... ./pkg/agentcompose/adapters/... ./pkg/runs/... -count=1`
- `go test -race ./pkg/llms/... -count=1`
- `task test`

Coverage from the final `task test` run: unit 75.02%, integration 60.80%, E2E 60.59%, combined 79.11%.

Anthropic-compatible Messages regression: non-streaming, streaming, and runtime facade pass-through completed successfully. No endpoint, model, credential, response body, or request identifier was recorded.

## Checklist

- [x] Documentation updated where shared behavior changed.
- [x] Regression and E2E coverage added for changed behavior.
- [x] No secrets, private endpoints, certificates, or local runtime state included.