### PR TITLE
fix(runtime): reset Codex thread when system context changes

### DIFF
--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -498,14 +498,31 @@ Content:
 {
   "provider": "codex",
   "threadId": "<provider-thread-id>",
-  "updatedAt": "2026-01-01T00:00:00.000Z"
+  "updatedAt": "2026-01-01T00:00:00.000Z",
+  "systemContextHash": "<sha256-hex-of-systemContext>",
+  "systemContextHashVersion": 1
 }
 ```
 
-Codex and Claude read this file on the next call and resume:
+`systemContextHash` and `systemContextHashVersion` are written only for Codex.
+Other providers omit these fields.
 
-- Codex: `codex.resumeThread(threadId, ...)`
+Codex and Claude read this file on the next call:
+
+- Codex resumes with `codex.resumeThread(threadId, ...)` only when the stored
+  fingerprint version is supported and the stored SHA-256 hash exactly matches
+  the current composed `systemContext`. Otherwise it starts a new thread.
 - Claude: `resume: threadId`
+
+Codex state created before fingerprint support is intentionally treated as
+incompatible and starts a new thread on the first run after upgrade. This
+safety-first migration prevents a legacy thread from receiving stale
+developer instructions when the previous context cannot be established.
+
+When an existing Codex thread is rejected because its fingerprint is missing,
+unsupported, or different, the runtime writes a warning to stderr. A reset
+preserves instruction correctness but does not preserve the previous provider
+conversation history.
 
 Gemini currently does not write provider state.
 
@@ -608,6 +625,12 @@ If `/data/state/agents/system-prompts/system-prompt.txt` and/or
 `/data/runtime/mpi/catalog.md` exist and are readable, the JavaScript runtime
 composes Agent Identity + MPI into `systemContext` and injects it through Codex
 `config.developer_instructions`.
+
+Before selecting a Codex thread, the runtime hashes the complete composed
+`systemContext`, including the configured skill catalog when present. It resumes
+only when that fingerprint matches the value stored in
+`/data/state/agents/providers/codex.json`; context changes start a new thread so
+the first model turn cannot inherit stale developer instructions.
 
 Codex events are converted into a human-readable transcript, including agent
 messages, reasoning, command execution, file changes, MCP calls, web search, and

--- a/docs/design/agent_system_prompt_design.md
+++ b/docs/design/agent_system_prompt_design.md
@@ -269,8 +269,26 @@ new Codex({
 ```
 
 The `@openai/codex-sdk` reads `config` at constructor scope, not from
-`ThreadOptions`. That means both `startThread` and `resumeThread` receive the
-current combined context on each run, including after `system_prompt` edits.
+`ThreadOptions`. The SDK passes the current combined context to both start and
+resume commands, but upstream Codex resume behavior does not guarantee that a
+changed plain `developer_instructions` value is model-visible on the first
+resumed turn (see [openai/codex#19045](https://github.com/openai/codex/issues/19045)).
+
+The runtime therefore stores a versioned SHA-256 fingerprint of the complete
+`systemContext` in the Codex provider state. It resumes only when the stored
+fingerprint exactly matches the current context. A missing fingerprint, an
+unsupported fingerprint version, or a changed context starts a new Codex
+thread and emits a warning to stderr.
+
+State created before fingerprint support is reset once after upgrade rather
+than resumed and lazily migrated. This intentionally favors instruction
+correctness over conversation continuity because the context associated with a
+legacy thread cannot be verified.
+
+This downstream guard can be reconsidered after the upstream issue is fixed and
+the runtime's minimum Codex SDK/CLI version is known to contain that fix. Removal
+requires an integration test proving that changed developer instructions are
+model-visible on the first resumed turn.
 
 ### Claude
 
@@ -327,8 +345,9 @@ the system prompt wiring scope.
 - MPI-only path matches pre-change injection (no `## Agent Identity`)
 - `readSystemPromptFile` trim and missing-file behavior
 
-Runner tests (`runners.test.ts`, `runner-execution.test.ts`) were updated to use
-`systemContext` instead of `mpiContext`.
+Runner and resume-policy tests verify `systemContext` injection, fingerprint
+persistence, matching-context resume, and safe reset for legacy, incompatible,
+or changed context state.
 
 ## Security and Operations
 
@@ -361,20 +380,24 @@ Runner tests (`runners.test.ts`, `runner-execution.test.ts`) were updated to use
 | `pkg/agentcompose/adapters/agent_runner_test.go` | Host resolution, fixed-path write/remove tests |
 | `runtime/javascript/src/system-context.ts` | **new** — `agentSystemPromptPath`, composition, file read helpers |
 | `runtime/javascript/src/prompt.ts` | Convention-path read; compose `systemContext` before runner dispatch |
-| `runtime/javascript/src/types.ts` | `systemContext` on `RunnerOptions` |
-| `runtime/javascript/src/runners/codex.ts` | `developer_instructions` from `systemContext` |
+| `runtime/javascript/src/types.ts` | `systemContext` on `RunnerOptions`; optional Codex fingerprint fields on `StoredThread` |
+| `runtime/javascript/src/codex-thread-resume.ts` | Versioned system-context hashing and Codex resume decision policy |
+| `runtime/javascript/src/runners/codex.ts` | `developer_instructions` from `systemContext`; fingerprint-gated resume |
+| `runtime/javascript/src/session-state.ts` | Validated provider-state parsing and optional fingerprint persistence |
 | `runtime/javascript/src/runners/claude.ts` | `systemPrompt.append` from `systemContext` |
 | `runtime/javascript/src/runners/gemini.ts` | Prepend `systemContext` to `-p` |
 | `runtime/javascript/test/system-context.test.ts` | **new** — composition unit tests |
 | `runtime/javascript/test/runners.test.ts` | Updated for `systemContext` |
-| `runtime/javascript/test/runner-execution.test.ts` | Updated for `systemContext` |
+| `runtime/javascript/test/codex-thread-resume.test.ts` | Hash, version, reset-reason, and resume-policy coverage |
+| `runtime/javascript/test/runner-execution.test.ts` | Codex resume/reset execution and persistence coverage |
 | `docs/design/agent-compose-runtime_contract.md` | Document convention path and layering |
 
 ## Success Criteria (Phase 1, verified)
 
 1. Agent with `system_prompt: "Reply only in Chinese"` obeys after Codex/Claude chat run.
 2. Empty `system_prompt` → identical to pre-change MPI-only behavior.
-3. Codex provider thread resume after prompt edit uses new instructions.
+3. Codex provider state starts a new thread after prompt or skill-context edits,
+   guaranteeing that the first turn uses the new instructions.
 4. Loader bound to an agent definition inherits `system_prompt`.
 5. `task test`, runtime JS tests, and `task lint` pass on touched packages.
 

--- a/runtime/javascript/src/codex-thread-resume.ts
+++ b/runtime/javascript/src/codex-thread-resume.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+import type { StoredThread } from "./types.js";
+
+export const CODEX_SYSTEM_CONTEXT_HASH_VERSION = 1;
+
+export type CodexThreadStartReason =
+  | "no-stored-thread"
+  | "missing-system-context-hash"
+  | "unsupported-system-context-hash-version"
+  | "system-context-changed";
+
+export type CodexThreadResumeDecision =
+  | { action: "resume"; threadId: string }
+  | { action: "start"; reason: CodexThreadStartReason };
+
+export type CodexThreadStateMetadata = Required<
+  Pick<StoredThread, "systemContextHash" | "systemContextHashVersion">
+>;
+
+export function hashSystemContext(systemContext: string): string {
+  return createHash("sha256").update(systemContext, "utf8").digest("hex");
+}
+
+export function codexThreadStateMetadata(systemContextHash: string): CodexThreadStateMetadata {
+  return {
+    systemContextHash,
+    systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+  };
+}
+
+export function decideCodexThreadResume(
+  stored: StoredThread | null,
+  currentSystemContextHash: string,
+): CodexThreadResumeDecision {
+  if (!stored?.threadId) {
+    return { action: "start", reason: "no-stored-thread" };
+  }
+  if (!stored.systemContextHash) {
+    return { action: "start", reason: "missing-system-context-hash" };
+  }
+  if (stored.systemContextHashVersion !== CODEX_SYSTEM_CONTEXT_HASH_VERSION) {
+    return { action: "start", reason: "unsupported-system-context-hash-version" };
+  }
+  if (stored.systemContextHash !== currentSystemContextHash) {
+    return { action: "start", reason: "system-context-changed" };
+  }
+  return { action: "resume", threadId: stored.threadId };
+}
+
+export function codexThreadStartWarning(reason: CodexThreadStartReason): string | null {
+  switch (reason) {
+    case "no-stored-thread":
+      return null;
+    case "missing-system-context-hash":
+      return "stored Codex thread has no system context fingerprint; started a new thread";
+    case "unsupported-system-context-hash-version":
+      return "stored Codex thread has an unsupported system context fingerprint version; started a new thread";
+    case "system-context-changed":
+      return "system context changed; started a new Codex thread";
+  }
+}

--- a/runtime/javascript/src/interactive.ts
+++ b/runtime/javascript/src/interactive.ts
@@ -1,5 +1,12 @@
 import { resolveCodexPath } from "./codex-path.js";
+import {
+  codexThreadStateMetadata,
+  codexThreadStartWarning,
+  decideCodexThreadResume,
+  hashSystemContext,
+} from "./codex-thread-resume.js";
 import { stringEnv } from "./env.js";
+import { warn } from "./mpi.js";
 import { buildPromptRuntimeOptions } from "./prompt.js";
 import { ClaudeRunner } from "./runners/claude.js";
 import { CodexRunner } from "./runners/codex.js";
@@ -39,6 +46,7 @@ export class CodexInteractiveSession implements InteractiveSession {
   private readonly runner: CodexRunner;
   private readonly writer: BufferedTextWriter;
   private readonly result: AgentResult;
+  private readonly systemContextHash: string;
   private turnCount = 0;
   private thread?: {
     id?: string | null;
@@ -51,6 +59,7 @@ export class CodexInteractiveSession implements InteractiveSession {
   ) {
     this.writer = new BufferedTextWriter();
     this.runner = new CodexRunner(options, this.writer);
+    this.systemContextHash = hashSystemContext(options.systemContext);
     this.result = {
       provider: "codex",
       threadId: "",
@@ -72,11 +81,18 @@ export class CodexInteractiveSession implements InteractiveSession {
         ? { config: { developer_instructions: this.options.systemContext } }
         : {}),
     });
-    this.thread = stored?.threadId
-      ? codex.resumeThread(stored.threadId, this.runner.threadOptions())
+    const resumeDecision = decideCodexThreadResume(stored, this.systemContextHash);
+    this.thread = resumeDecision.action === "resume"
+      ? codex.resumeThread(resumeDecision.threadId, this.runner.threadOptions())
       : codex.startThread(this.runner.threadOptions());
+    if (resumeDecision.action === "start") {
+      const warning = codexThreadStartWarning(resumeDecision.reason);
+      if (warning) {
+        warn(warning);
+      }
+    }
     const thread = this.thread;
-    this.result.threadId = stored?.threadId || thread.id || "";
+    this.result.threadId = resumeDecision.action === "resume" ? resumeDecision.threadId : thread.id || "";
     this.emit("started", {
       provider: "codex",
       threadId: this.result.threadId,
@@ -108,7 +124,7 @@ export class CodexInteractiveSession implements InteractiveSession {
       this.result.finalText = this.result.transcript;
       this.result.finalTextSource = "transcript_fallback";
     }
-    await writeStoredThread(this.options.stateRoot, "codex", this.result.threadId);
+    await this.writeThreadState();
     this.emit("agent_turn_completed", {
       provider: "codex",
       threadId: this.result.threadId,
@@ -122,9 +138,19 @@ export class CodexInteractiveSession implements InteractiveSession {
     this.result.threadId = this.thread?.id || this.result.threadId;
     this.result.transcript = this.runner.transcript();
     if (this.result.threadId) {
-      await writeStoredThread(this.options.stateRoot, "codex", this.result.threadId);
+      await this.writeThreadState();
     }
     return { ...this.result };
+  }
+
+  private async writeThreadState(): Promise<void> {
+    await writeStoredThread(
+      this.options.stateRoot,
+      "codex",
+      this.result.threadId,
+      new Date(),
+      codexThreadStateMetadata(this.systemContextHash),
+    );
   }
 }
 

--- a/runtime/javascript/src/runners/codex.ts
+++ b/runtime/javascript/src/runners/codex.ts
@@ -1,5 +1,12 @@
 import { resolveCodexPath } from "../codex-path.js";
+import {
+  codexThreadStateMetadata,
+  codexThreadStartWarning,
+  decideCodexThreadResume,
+  hashSystemContext,
+} from "../codex-thread-resume.js";
 import { stringEnv } from "../env.js";
+import { warn } from "../mpi.js";
 import { uniqueDirectories } from "../paths.js";
 import { readStoredThread, writeStoredThread } from "../session-state.js";
 import { extractText, jsonString } from "../text.js";
@@ -195,19 +202,28 @@ export class CodexRunner {
       codexPathOverride: resolveCodexPath(),
       env: stringEnv(),
       // `config` (the `--config key=value` overrides) is a CodexOptions field on the
-      // constructor; it is NOT read from ThreadOptions/startThread. Injecting the combined
-      // Agent Identity + MPI system context here applies to both start and resume flows.
+      // constructor; it is NOT read from ThreadOptions/startThread. The resume decision below
+      // prevents a changed override from being combined with stale model-visible instructions.
       ...(this.options.systemContext
         ? { config: { developer_instructions: this.options.systemContext } }
         : {}),
     });
-    const thread = stored?.threadId
-      ? codex.resumeThread(stored.threadId, this.threadOptions())
+    const systemContextHash = hashSystemContext(this.options.systemContext);
+    const resumeDecision = decideCodexThreadResume(stored, systemContextHash);
+    const thread = resumeDecision.action === "resume"
+      ? codex.resumeThread(resumeDecision.threadId, this.threadOptions())
       : codex.startThread(this.threadOptions());
+
+    if (resumeDecision.action === "start") {
+      const warning = codexThreadStartWarning(resumeDecision.reason);
+      if (warning) {
+        warn(warning);
+      }
+    }
 
     const result: AgentResult = {
       provider: "codex",
-      threadId: stored?.threadId || "",
+      threadId: resumeDecision.action === "resume" ? resumeDecision.threadId : "",
       stopReason: "completed",
       finalText: "",
       finalTextSource: "none",
@@ -228,7 +244,13 @@ export class CodexRunner {
       result.finalText = result.transcript;
       result.finalTextSource = "transcript_fallback";
     }
-    await writeStoredThread(this.options.stateRoot, "codex", result.threadId);
+    await writeStoredThread(
+      this.options.stateRoot,
+      "codex",
+      result.threadId,
+      new Date(),
+      codexThreadStateMetadata(systemContextHash),
+    );
     return result;
   }
 }

--- a/runtime/javascript/src/session-state.ts
+++ b/runtime/javascript/src/session-state.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { ensureDir, readText } from "./fs.js";
 import type { Provider, StoredThread } from "./types.js";
 
+type StoredThreadMetadata = Required<Pick<StoredThread, "systemContextHash" | "systemContextHashVersion">>;
+
 export function providerStatePath(stateRoot: string, provider: Provider): string {
   return path.join(stateRoot, "agents", "providers", `${provider}.json`);
 }
@@ -10,14 +12,36 @@ export function providerStatePath(stateRoot: string, provider: Provider): string
 export async function readStoredThread(stateRoot: string, provider: Provider): Promise<StoredThread | null> {
   try {
     const raw = await readText(providerStatePath(stateRoot, provider));
-    const payload = JSON.parse(raw);
-    if (typeof payload?.threadId === "string") {
-      return payload;
+    const payload: unknown = JSON.parse(raw);
+    if (typeof payload !== "object" || payload === null) {
+      return null;
     }
-    if (typeof payload?.sessionId === "string") {
-      return { ...payload, threadId: payload.sessionId };
+    const record = payload as Record<string, unknown>;
+    const threadId = typeof record.threadId === "string"
+      ? record.threadId
+      : typeof record.sessionId === "string"
+        ? record.sessionId
+        : null;
+    if (threadId === null) {
+      return null;
     }
-    return null;
+    const stored: StoredThread = {
+      provider: typeof record.provider === "string" ? record.provider : provider,
+      threadId,
+    };
+    if (typeof record.sessionId === "string") {
+      stored.sessionId = record.sessionId;
+    }
+    if (typeof record.updatedAt === "string") {
+      stored.updatedAt = record.updatedAt;
+    }
+    if (typeof record.systemContextHash === "string") {
+      stored.systemContextHash = record.systemContextHash;
+    }
+    if (typeof record.systemContextHashVersion === "number" && Number.isInteger(record.systemContextHashVersion)) {
+      stored.systemContextHashVersion = record.systemContextHashVersion;
+    }
+    return stored;
   } catch {
     return null;
   }
@@ -28,16 +52,21 @@ export async function writeStoredThread(
   provider: Provider,
   threadId: string,
   now: Date = new Date(),
+  metadata?: StoredThreadMetadata,
 ): Promise<void> {
   if (!threadId) {
     return;
   }
   const target = providerStatePath(stateRoot, provider);
   await ensureDir(path.dirname(target));
-  const payload = {
+  const payload: StoredThread = {
     provider,
     threadId,
     updatedAt: now.toISOString(),
   };
+  if (metadata) {
+    payload.systemContextHash = metadata.systemContextHash;
+    payload.systemContextHashVersion = metadata.systemContextHashVersion;
+  }
   await fs.writeFile(target, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }

--- a/runtime/javascript/src/types.ts
+++ b/runtime/javascript/src/types.ts
@@ -28,5 +28,8 @@ export interface RunnerOptions {
 export interface StoredThread {
   provider: string;
   threadId: string;
+  sessionId?: string;
   updatedAt?: string;
+  systemContextHash?: string;
+  systemContextHashVersion?: number;
 }

--- a/runtime/javascript/test/codex-thread-resume.test.ts
+++ b/runtime/javascript/test/codex-thread-resume.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+  codexThreadStateMetadata,
+  codexThreadStartWarning,
+  decideCodexThreadResume,
+  hashSystemContext,
+} from "../src/codex-thread-resume.js";
+
+describe("Codex thread resume policy", () => {
+  it("hashes the exact system context deterministically", () => {
+    expect(hashSystemContext("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    expect(hashSystemContext("context")).toBe(hashSystemContext("context"));
+    expect(hashSystemContext("context")).not.toBe(hashSystemContext("context\n"));
+  });
+
+  it("builds versioned persistence metadata", () => {
+    const systemContextHash = hashSystemContext("context");
+    expect(codexThreadStateMetadata(systemContextHash)).toEqual({
+      systemContextHash,
+      systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+    });
+  });
+
+  it("starts when no stored thread exists", () => {
+    expect(decideCodexThreadResume(null, hashSystemContext("context"))).toEqual({
+      action: "start",
+      reason: "no-stored-thread",
+    });
+  });
+
+  it("starts when legacy state has no system context hash", () => {
+    expect(decideCodexThreadResume({ provider: "codex", threadId: "legacy" }, hashSystemContext("context"))).toEqual({
+      action: "start",
+      reason: "missing-system-context-hash",
+    });
+  });
+
+  it("starts when the hash version is absent or unsupported", () => {
+    const systemContextHash = hashSystemContext("context");
+    expect(decideCodexThreadResume({
+      provider: "codex",
+      threadId: "old-thread",
+      systemContextHash,
+    }, systemContextHash)).toEqual({
+      action: "start",
+      reason: "unsupported-system-context-hash-version",
+    });
+    expect(decideCodexThreadResume({
+      provider: "codex",
+      threadId: "old-thread",
+      systemContextHash,
+      systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION + 1,
+    }, systemContextHash)).toEqual({
+      action: "start",
+      reason: "unsupported-system-context-hash-version",
+    });
+  });
+
+  it("starts when the system context changed", () => {
+    expect(decideCodexThreadResume({
+      provider: "codex",
+      threadId: "old-thread",
+      systemContextHash: hashSystemContext("old"),
+      systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+    }, hashSystemContext("new"))).toEqual({
+      action: "start",
+      reason: "system-context-changed",
+    });
+  });
+
+  it("treats empty and non-empty context transitions as changes", () => {
+    const emptyHash = hashSystemContext("");
+    const nonEmptyHash = hashSystemContext("context");
+    const stored = {
+      provider: "codex",
+      threadId: "old-thread",
+      systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+    };
+
+    expect(decideCodexThreadResume({ ...stored, systemContextHash: emptyHash }, nonEmptyHash)).toMatchObject({
+      action: "start",
+      reason: "system-context-changed",
+    });
+    expect(decideCodexThreadResume({ ...stored, systemContextHash: nonEmptyHash }, emptyHash)).toMatchObject({
+      action: "start",
+      reason: "system-context-changed",
+    });
+  });
+
+  it("resumes only when the hash and version match", () => {
+    const systemContextHash = hashSystemContext("context");
+    expect(decideCodexThreadResume({
+      provider: "codex",
+      threadId: "old-thread",
+      systemContextHash,
+      systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+    }, systemContextHash)).toEqual({
+      action: "resume",
+      threadId: "old-thread",
+    });
+  });
+
+  it("emits warnings only when an existing thread is rejected", () => {
+    expect(codexThreadStartWarning("no-stored-thread")).toBeNull();
+    expect(codexThreadStartWarning("missing-system-context-hash")).toContain("no system context fingerprint");
+    expect(codexThreadStartWarning("unsupported-system-context-hash-version")).toContain("unsupported");
+    expect(codexThreadStartWarning("system-context-changed")).toContain("system context changed");
+  });
+});

--- a/runtime/javascript/test/runner-execution.test.ts
+++ b/runtime/javascript/test/runner-execution.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CODEX_SYSTEM_CONTEXT_HASH_VERSION, hashSystemContext } from "../src/codex-thread-resume.js";
 import { captureStdio, runnerOptions, withTempSession } from "./helpers.js";
 
 const codexState = vi.hoisted(() => ({
@@ -11,6 +12,7 @@ const codexState = vi.hoisted(() => ({
   threadId: "thread-new",
   resumedThreadId: "thread-resumed",
   resumed: "",
+  started: 0,
   runStreamedCalls: [] as Array<{ input: unknown; options: unknown }>,
 }));
 
@@ -18,19 +20,22 @@ vi.mock("@openai/codex-sdk", () => ({
   Codex: vi.fn().mockImplementation(function Codex(options: Record<string, unknown>) {
     codexState.constructorOptions.push(options);
     return {
-      startThread: vi.fn(() => ({
-        id: codexState.threadId,
-        runStreamed: vi.fn(async (input: unknown, options: unknown) => {
-          codexState.runStreamedCalls.push({ input, options });
-          return {
-            events: (async function* events() {
-              for (const event of codexState.events) {
-                yield event;
-              }
-            })(),
-          };
-        }),
-      })),
+      startThread: vi.fn(() => {
+        codexState.started += 1;
+        return {
+          id: codexState.threadId,
+          runStreamed: vi.fn(async (input: unknown, options: unknown) => {
+            codexState.runStreamedCalls.push({ input, options });
+            return {
+              events: (async function* events() {
+                for (const event of codexState.events) {
+                  yield event;
+                }
+              })(),
+            };
+          }),
+        };
+      }),
       resumeThread: vi.fn((threadId: string) => {
         codexState.resumed = threadId;
         return {
@@ -121,6 +126,7 @@ describe("runner execution", () => {
     codexState.threadId = "thread-new";
     codexState.resumedThreadId = "thread-resumed";
     codexState.resumed = "";
+    codexState.started = 0;
     codexState.runStreamedCalls = [];
     claudeState.messages = [];
     claudeState.closed = false;
@@ -160,7 +166,11 @@ describe("runner execution", () => {
         config: { developer_instructions: "catalog body" },
       });
       const stored = JSON.parse(await fs.readFile(path.join(root, "state", "agents", "providers", "codex.json"), "utf8"));
-      expect(stored.threadId).toBe("thread-new");
+      expect(stored).toMatchObject({
+        threadId: "thread-new",
+        systemContextHash: hashSystemContext("catalog body"),
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+      });
     });
   });
 
@@ -267,7 +277,7 @@ describe("runner execution", () => {
     });
   });
 
-  it("resumes a stored Codex thread", async () => {
+  it("resumes a stored Codex thread when the system context fingerprint matches", async () => {
     const { CodexRunner } = await import("../src/runners/codex.js");
     await withTempSession(async (root) => {
       const providerRoot = path.join(root, "state", "agents", "providers");
@@ -275,16 +285,98 @@ describe("runner execution", () => {
       await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
         provider: "codex",
         threadId: "old-thread",
+        systemContextHash: hashSystemContext("catalog body"),
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
       }), "utf8");
       codexState.events = [{ type: "item.completed", item: { id: "a2", type: "agent_message", text: "resumed" } }];
       const stdio = captureStdio();
       try {
-        const result = await new CodexRunner(runnerOptions(root)).runPrompt("prompt");
+        const result = await new CodexRunner(runnerOptions(root, "catalog body")).runPrompt("prompt");
         expect(result.threadId).toBe("thread-resumed");
       } finally {
         stdio.restore();
       }
       expect(codexState.resumed).toBe("old-thread");
+      expect(codexState.started).toBe(0);
+    });
+  });
+
+  it("starts a new Codex thread when stored state has no system context fingerprint", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        threadId: "legacy-thread",
+      }), "utf8");
+      codexState.events = [{ type: "item.completed", item: { id: "a2", type: "agent_message", text: "fresh" } }];
+      const stdio = captureStdio();
+      try {
+        const result = await new CodexRunner(runnerOptions(root, "catalog body")).runPrompt("prompt");
+        expect(result.threadId).toBe("thread-new");
+        expect(stdio.stderr).toContain("stored Codex thread has no system context fingerprint");
+      } finally {
+        stdio.restore();
+      }
+      expect(codexState.resumed).toBe("");
+      expect(codexState.started).toBe(1);
+    });
+  });
+
+  it("starts a new Codex thread when the system context changed", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        threadId: "old-thread",
+        systemContextHash: hashSystemContext(""),
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+      }), "utf8");
+      codexState.events = [{ type: "item.completed", item: { id: "a2", type: "agent_message", text: "fresh" } }];
+      const stdio = captureStdio();
+      try {
+        const result = await new CodexRunner(runnerOptions(root, "new context")).runPrompt("prompt");
+        expect(result.threadId).toBe("thread-new");
+        expect(stdio.stderr).toContain("system context changed");
+      } finally {
+        stdio.restore();
+      }
+      expect(codexState.resumed).toBe("");
+      expect(codexState.started).toBe(1);
+      const stored = JSON.parse(await fs.readFile(path.join(providerRoot, "codex.json"), "utf8"));
+      expect(stored).toMatchObject({
+        threadId: "thread-new",
+        systemContextHash: hashSystemContext("new context"),
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+      });
+    });
+  });
+
+  it("starts a new Codex thread when the stored fingerprint version is unsupported", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        threadId: "old-thread",
+        systemContextHash: hashSystemContext("context"),
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION + 1,
+      }), "utf8");
+      codexState.events = [{ type: "item.completed", item: { id: "a2", type: "agent_message", text: "fresh" } }];
+      const stdio = captureStdio();
+      try {
+        const result = await new CodexRunner(runnerOptions(root, "context")).runPrompt("prompt");
+        expect(result.threadId).toBe("thread-new");
+        expect(stdio.stderr).toContain("unsupported system context fingerprint version");
+      } finally {
+        stdio.restore();
+      }
+      expect(codexState.resumed).toBe("");
+      expect(codexState.started).toBe(1);
     });
   });
 

--- a/runtime/javascript/test/session-state.test.ts
+++ b/runtime/javascript/test/session-state.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { CODEX_SYSTEM_CONTEXT_HASH_VERSION, hashSystemContext } from "../src/codex-thread-resume.js";
 import { providerStatePath, readStoredThread, writeStoredThread } from "../src/session-state.js";
 import { withTempSession } from "./helpers.js";
 
@@ -38,6 +39,7 @@ describe("provider thread state", () => {
       await fs.writeFile(target, "{\"threadId\":\"   \",\"updatedAt\":\"2026-01-01T00:00:00.000Z\"}", "utf8");
 
       await expect(readStoredThread(stateRoot, "codex")).resolves.toEqual({
+        provider: "codex",
         threadId: "   ",
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
@@ -55,6 +57,46 @@ describe("provider thread state", () => {
         provider: "claude",
         threadId: "thread-1",
         updatedAt: now.toISOString(),
+      });
+    });
+  });
+
+  it("writes and reads Codex system context fingerprint state", async () => {
+    await withTempSession(async (root) => {
+      const stateRoot = path.join(root, "state");
+      const now = new Date("2026-01-01T00:00:00.000Z");
+      const systemContextHash = hashSystemContext("catalog body");
+
+      await writeStoredThread(stateRoot, "codex", "thread-1", now, {
+        systemContextHash,
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+      });
+
+      await expect(readStoredThread(stateRoot, "codex")).resolves.toEqual({
+        provider: "codex",
+        threadId: "thread-1",
+        updatedAt: now.toISOString(),
+        systemContextHash,
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+      });
+    });
+  });
+
+  it("ignores malformed optional fingerprint fields", async () => {
+    await withTempSession(async (root) => {
+      const stateRoot = path.join(root, "state");
+      const target = providerStatePath(stateRoot, "codex");
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.writeFile(target, JSON.stringify({
+        provider: "codex",
+        threadId: "thread-1",
+        systemContextHash: 3,
+        systemContextHashVersion: "1",
+      }), "utf8");
+
+      await expect(readStoredThread(stateRoot, "codex")).resolves.toEqual({
+        provider: "codex",
+        threadId: "thread-1",
       });
     });
   });

--- a/runtime/javascript/test/stream.test.ts
+++ b/runtime/javascript/test/stream.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CODEX_SYSTEM_CONTEXT_HASH_VERSION, hashSystemContext } from "../src/codex-thread-resume.js";
 import { decodeBinary, decodeFrame, encodeBinary, encodeFrame, FRAME_VERSION, type StreamFrame } from "../src/frame.js";
 import { OpenCodeRunner } from "../src/runners/opencode.js";
 import { PiRunner } from "../src/runners/pi.js";
@@ -144,6 +145,42 @@ describe("runStreamCommand", () => {
         transcript: "answer 1\nanswer 2",
       });
       expect(parseOutput(stdout.text)).toHaveLength(8);
+      const stored = JSON.parse(await fs.readFile(path.join(root, "state", "agents", "providers", "codex.json"), "utf8"));
+      expect(stored).toMatchObject({
+        threadId: "thread-1",
+        systemContextHash: hashSystemContext(""),
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+      });
+    });
+  });
+
+  it("resumes an interactive Codex thread only when the system context fingerprint matches", async () => {
+    await withTempSession(async (root) => {
+      const providerRoot = path.join(root, "state", "agents", "providers");
+      await fs.mkdir(providerRoot, { recursive: true });
+      await fs.writeFile(path.join(providerRoot, "codex.json"), JSON.stringify({
+        provider: "codex",
+        threadId: "stored-thread",
+        systemContextHash: hashSystemContext(""),
+        systemContextHashVersion: CODEX_SYSTEM_CONTEXT_HASH_VERSION,
+      }), "utf8");
+      const stdout = new MemoryWritable();
+
+      await runStreamCommand({
+        stdin: Readable.from([
+          frame({ seq: 0, type: "start", provider: "codex", stateRoot: `${root}/state`, workspace: `${root}/workspace`, home: `${root}/home` }),
+          frame({ seq: 1, type: "eof" }),
+        ]),
+        stdout,
+        stderr: new MemoryWritable(),
+      });
+
+      expect(resumeThread).toHaveBeenCalledWith("stored-thread", expect.any(Object));
+      expect(startThread).not.toHaveBeenCalled();
+      expect(parseOutput(stdout.text)[0]).toMatchObject({
+        type: "started",
+        threadId: "stored-thread",
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fix Codex thread resume so a changed composed system context cannot reuse a thread that may still carry stale developer instructions.

### What changed

- Compute a SHA-256 fingerprint over the exact composed `systemContext` passed as Codex `developer_instructions`.
- Persist the fingerprint as `systemContextHash` with `systemContextHashVersion: 1` in Codex provider state.
- Resume a stored Codex thread only when both the fingerprint and version match the current context.
- Start a new thread and emit a clear runtime warning when stored state is legacy/missing a fingerprint, uses an unsupported version, or has a different context hash.
- Apply the same resume policy to both non-interactive `CodexRunner` execution and interactive Codex sessions.
- Parse optional provider-state fingerprint fields defensively while preserving legacy `sessionId` compatibility and leaving other providers unchanged.
- Document the safety-first migration behavior, persistence contract, warning semantics, and the upstream Codex resume limitation tracked in openai/codex#19045.

### Compatibility and behavior

Existing Codex state without a fingerprint resets once after upgrade. This intentionally prioritizes instruction correctness over preserving provider conversation history when the previous system context cannot be verified. Matching context continues to resume the existing thread.

## Testing

- `npm exec --yes --package=node@24 -- node runtime/javascript/node_modules/vitest/vitest.mjs run runtime/javascript/test/codex-thread-resume.test.ts runtime/javascript/test/session-state.test.ts runtime/javascript/test/runner-execution.test.ts runtime/javascript/test/stream.test.ts`
  - 4 test files passed, 57/57 tests passed.
- `npm exec --yes --package=node@24 -- node runtime/javascript/node_modules/typescript/bin/tsc -p runtime/javascript/tsconfig.json --noEmit`
  - Passed.
- From `runtime/javascript`: `npm exec --yes --package=node@24 -- node node_modules/vitest/vitest.mjs run`
  - 177/178 tests passed.
  - The remaining unrelated Pi runner test fails on macOS because the expected `/var/...` skill path is normalized to `/private/var/...`.
- Local Docker + Chrome E2E:
  - Matching context retained the same Codex thread and returned the original system-prompt response on consecutive turns.
  - Editing the system prompt in the same UI conversation returned the new prompt response on the first subsequent turn.
  - Provider state contained a new thread ID, a new SHA-256 hash, and fingerprint version 1.
  - Cell output contained the expected `system context changed; started a new Codex thread` warning.
- `task lint`, `task build`, and `task test` were not run because Task v3 is not installed in this environment; the changed runtime package was verified directly with Node 24 as listed above.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
