### PR TITLE
fix(projects): preserve legacy loader environment

### DIFF
--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -385,6 +385,17 @@ Managed resources modify only agent definitions, loaders, and triggers that
 carry managed metadata. Manual resources with the same names are not overwritten
 or deleted.
 
+The synthetic `legacy-v1-default` project also preserves the task-local
+environment of each adopted v1 Loader. On the initial migration, the complete
+Loader environment becomes a compatibility overlay. On later `ApplyProject`
+calls, each key is reconciled against the previous managed Agent environment:
+an unchanged Agent key keeps the current Loader value (including out-of-band
+edits and deletions), while an explicitly added, changed, deleted, or
+secret-metadata-changed Agent key removes the Loader overlay for that key. The
+new managed Agent value then takes effect through the Loader runtime precedence
+of global environment, Agent environment, Loader environment, and per-request
+environment, from lowest to highest.
+
 `ValidateProject` and `ApplyProject` use the same scheduler construction path.
 Declarative schedulers only receive compose and loader trigger structure
 validation. Inline QJS schedulers call existing

--- a/pkg/agentcompose/adapters/loader_session_runner_env_test.go
+++ b/pkg/agentcompose/adapters/loader_session_runner_env_test.go
@@ -1,0 +1,86 @@
+package adapters
+
+import (
+	"context"
+	"testing"
+
+	driverpkg "agent-compose/pkg/driver"
+	domain "agent-compose/pkg/model"
+)
+
+func TestLoaderSandboxRunnerEnvironmentPrecedence(t *testing.T) {
+	ctx := context.Background()
+	bridge, driver := newTestSandboxRPCBridge(t)
+	if _, err := bridge.configDB.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{
+		{Name: "GLOBAL_ONLY", Value: "global"},
+		{Name: "SHARED", Value: "global"},
+	}); err != nil {
+		t.Fatalf("replace global env: %v", err)
+	}
+	agent, err := bridge.configDB.CreateAgentDefinition(ctx, domain.AgentDefinition{
+		ID:         "loader-env-agent",
+		Name:       "loader-env-agent",
+		Enabled:    true,
+		Provider:   "codex",
+		Driver:     driverpkg.RuntimeDriverDocker,
+		GuestImage: "guest:latest",
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "AGENT_ONLY", Value: "agent"},
+			{Name: "AGENT_VS_LOADER", Value: "agent"},
+			{Name: "SHARED", Value: "agent"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create agent definition: %v", err)
+	}
+
+	runner := NewLoaderSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, nil, nil)
+	loader := domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:            "loader-env-precedence",
+			Name:          "Loader env precedence",
+			AgentID:       agent.ID,
+			Driver:        driverpkg.RuntimeDriverDocker,
+			GuestImage:    "guest:latest",
+			SandboxPolicy: domain.LoaderSandboxPolicyNew,
+		},
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "AGENT_VS_LOADER", Value: "loader", Secret: true},
+			{Name: "LOADER_ONLY", Value: "loader"},
+			{Name: "LOADER_VS_REQUEST", Value: "loader"},
+			{Name: "SHARED", Value: "loader"},
+		},
+	}
+	request := domain.LoaderAgentRequest{SandboxEnv: []domain.SandboxEnvVar{
+		{Name: "LOADER_VS_REQUEST", Value: "request", Secret: true},
+		{Name: "REQUEST_ONLY", Value: "request"},
+		{Name: "SHARED", Value: "request", Secret: true},
+	}}
+
+	sandbox, _, err := runner.Ensure(ctx, loader, request, false)
+	if err != nil {
+		t.Fatalf("ensure loader sandbox: %v", err)
+	}
+	got := loaderRunnerEnvItemsByName(sandbox.ProviderEnvItems)
+	for name, want := range map[string]domain.SandboxEnvVar{
+		"GLOBAL_ONLY":       {Name: "GLOBAL_ONLY", Value: "global"},
+		"AGENT_ONLY":        {Name: "AGENT_ONLY", Value: "agent"},
+		"AGENT_VS_LOADER":   {Name: "AGENT_VS_LOADER", Value: "loader", Secret: true},
+		"LOADER_ONLY":       {Name: "LOADER_ONLY", Value: "loader"},
+		"LOADER_VS_REQUEST": {Name: "LOADER_VS_REQUEST", Value: "request", Secret: true},
+		"REQUEST_ONLY":      {Name: "REQUEST_ONLY", Value: "request"},
+		"SHARED":            {Name: "SHARED", Value: "request", Secret: true},
+	} {
+		if got[name] != want {
+			t.Fatalf("effective env %s = %#v, want %#v", name, got[name], want)
+		}
+	}
+}
+
+func loaderRunnerEnvItemsByName(items []domain.SandboxEnvVar) map[string]domain.SandboxEnvVar {
+	byName := make(map[string]domain.SandboxEnvVar, len(items))
+	for _, item := range domain.NormalizeEnvItems(items) {
+		byName[item.Name] = item
+	}
+	return byName
+}

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -32,9 +32,9 @@ type NormalizedProject struct {
 	SourcePath string
 
 	// managedLoaderOverrides is populated only by the legacy-v1 compatibility
-	// projection. It lets that boundary adopt an existing loader ID so runs,
-	// events, trigger state, and enablement survive the project migration.
-	managedLoaderOverrides map[string]domain.Loader
+	// projection. It lets that boundary adopt an existing loader so identity,
+	// history, runtime overrides, and task-local environment survive migration.
+	managedLoaderOverrides map[string]legacyManagedLoaderOverride
 }
 
 type ProjectRef struct {

--- a/pkg/projects/legacy_default_project.go
+++ b/pkg/projects/legacy_default_project.go
@@ -202,7 +202,7 @@ func legacyProjectAgentNames(agents []domain.AgentDefinition) []string {
 	return names
 }
 
-func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []domain.Loader, agentByLegacyID, agentByName map[string]int, usedNames map[string]struct{}, workspaceProjection legacyWorkspaceProjection) (map[string]domain.Loader, error) {
+func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []domain.Loader, agentByLegacyID, agentByName map[string]int, usedNames map[string]struct{}, workspaceProjection legacyWorkspaceProjection) (map[string]legacyManagedLoaderOverride, error) {
 	legacyLoaders = append([]domain.Loader(nil), legacyLoaders...)
 	sort.Slice(legacyLoaders, func(i, j int) bool {
 		iManaged := strings.TrimSpace(legacyLoaders[i].Summary.ManagedAgentName) != ""
@@ -217,7 +217,7 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 	})
 
 	scheduledAgents := make(map[string]struct{}, len(legacyLoaders))
-	overrides := make(map[string]domain.Loader, len(legacyLoaders))
+	overrides := make(map[string]legacyManagedLoaderOverride, len(legacyLoaders))
 	for _, loader := range legacyLoaders {
 		sourceIndex, sourceFound := agentByLegacyID[strings.TrimSpace(loader.Summary.AgentID)]
 		managedName := legacyCanonicalAgentName(loader.Summary.ManagedAgentName)
@@ -281,7 +281,7 @@ func projectLegacyLoaders(spec *compose.NormalizedProjectSpec, legacyLoaders []d
 			Script:            projected.Script,
 		}
 		scheduledAgents[targetName] = struct{}{}
-		overrides[targetName] = projected
+		overrides[targetName] = legacyManagedLoaderOverride{Loader: projected}
 	}
 	if len(overrides) == 0 {
 		return nil, nil

--- a/pkg/projects/legacy_default_project_e2e_test.go
+++ b/pkg/projects/legacy_default_project_e2e_test.go
@@ -4,5 +4,6 @@ import "testing"
 
 func TestE2ELegacyDefaultProjectMigrationWorkflows(t *testing.T) {
 	t.Run("legacy resources migrate into the v2 default project", TestIntegrationLegacyDefaultProjectAdoptsLoaderHistoryAtCurrentRevision)
+	t.Run("legacy loader environment survives project apply", TestIntegrationLegacyLoaderEnvironmentSurvivesProjectApply)
 	t.Run("loader file workspaces preserve source and scheduler bindings", TestIntegrationLegacyLoaderFileWorkspacePreservesSourceAndSchedulerBindings)
 }

--- a/pkg/projects/legacy_default_project_test.go
+++ b/pkg/projects/legacy_default_project_test.go
@@ -184,7 +184,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 		t.Fatalf("worker scheduler = %#v", worker.Scheduler)
 	}
 	workerLoader := project.managedLoaderOverrides["worker"]
-	if workerLoader.Summary.ID != "loader-a" || workerLoader.Summary.Enabled || len(workerLoader.Triggers) != 1 || workerLoader.Triggers[0].Enabled {
+	if workerLoader.Loader.Summary.ID != "loader-a" || workerLoader.Loader.Summary.Enabled || len(workerLoader.Loader.Triggers) != 1 || workerLoader.Loader.Triggers[0].Enabled {
 		t.Fatalf("worker loader override = %#v", workerLoader)
 	}
 
@@ -197,7 +197,7 @@ func TestLegacyDefaultNormalizedProjectAdoptsLegacyLoaders(t *testing.T) {
 			}
 		}
 	}
-	if clonedName == "" || project.managedLoaderOverrides[clonedName].Summary.ID != "loader-b" {
+	if clonedName == "" || project.managedLoaderOverrides[clonedName].Loader.Summary.ID != "loader-b" {
 		t.Fatalf("second loader was not projected: name=%q overrides=%#v", clonedName, project.managedLoaderOverrides)
 	}
 
@@ -243,7 +243,7 @@ func TestLegacyDefaultNormalizedProjectKeepsUnboundLoaderVisibleButDisabled(t *t
 	if agent.Scheduler.DisplayName != "未绑定任务" || agent.Scheduler.Description != "迁移后保持可见但禁用" {
 		t.Fatalf("unbound scheduler metadata = %#v", agent.Scheduler)
 	}
-	if adopted := project.managedLoaderOverrides[agent.Name]; adopted.Summary.ID != loader.Summary.ID || adopted.Summary.Enabled {
+	if adopted := project.managedLoaderOverrides[agent.Name]; adopted.Loader.Summary.ID != loader.Summary.ID || adopted.Loader.Summary.Enabled {
 		t.Fatalf("unbound loader override = %#v", adopted)
 	}
 

--- a/pkg/projects/legacy_loader_env_integration_test.go
+++ b/pkg/projects/legacy_loader_env_integration_test.go
@@ -1,0 +1,236 @@
+package projects_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/samber/do/v2"
+
+	"agent-compose/pkg/compose"
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/internal/testutil"
+	"agent-compose/pkg/loaders"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+)
+
+func TestIntegrationLegacyLoaderEnvironmentSurvivesProjectApply(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:           root,
+		DbAddr:             filepath.Join(root, "data.db"),
+		RuntimeDriver:      driverpkg.RuntimeDriverDocker,
+		DockerDefaultImage: "guest:latest",
+	}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("create config store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.DB().Close(); err != nil {
+			t.Errorf("close config store: %v", err)
+		}
+	})
+
+	agentEnv := []domain.SandboxEnvVar{
+		{Name: "AGENT_ONLY", Value: "agent-only"},
+		{Name: "REMOVE_ME", Value: "agent-remove"},
+		{Name: "SECRET_FLAG", Value: "same"},
+		{Name: "SHARED", Value: "agent-old"},
+	}
+	agent, err := store.CreateAgentDefinition(ctx, domain.AgentDefinition{
+		ID:         "legacy-env-agent",
+		Name:       "env-worker",
+		Enabled:    true,
+		Provider:   "codex",
+		Driver:     driverpkg.RuntimeDriverDocker,
+		GuestImage: "guest:latest",
+		EnvItems:   agentEnv,
+	})
+	if err != nil {
+		t.Fatalf("create legacy agent: %v", err)
+	}
+
+	legacyLoaderEnv := []domain.SandboxEnvVar{
+		{Name: "DELETED_MANUALLY", Value: "legacy-delete"},
+		{Name: "LOADER_STAYS", Value: "legacy-stays"},
+		{Name: "REMOVE_ME", Value: "legacy-remove"},
+		{Name: "SECRET_FLAG", Value: "legacy-secret", Secret: true},
+		{Name: "SHARED", Value: "legacy-shared", Secret: true},
+	}
+	const script = `scheduler.on("env.test", "env-test", function envTest() {});`
+	loader, err := store.CreateLoader(ctx, domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:                "legacy-env-loader",
+			Name:              "Legacy env scheduler",
+			Enabled:           true,
+			Runtime:           domain.LoaderRuntimeScheduler,
+			AgentID:           agent.ID,
+			Driver:            driverpkg.RuntimeDriverDocker,
+			GuestImage:        "guest:latest",
+			DefaultAgent:      "codex",
+			SandboxPolicy:     domain.LoaderSandboxPolicyNew,
+			ConcurrencyPolicy: domain.LoaderConcurrencyPolicySkip,
+		},
+		Script:   script,
+		EnvItems: legacyLoaderEnv,
+	})
+	if err != nil {
+		t.Fatalf("create legacy loader: %v", err)
+	}
+
+	engine := &loaders.QJSLoaderEngine{}
+	controller := projects.NewController(projects.ControllerDependencies{
+		Config:  config,
+		Store:   store,
+		Images:  legacyProjectImageBackend{},
+		Loaders: legacyProjectLoaderValidator{engine: engine},
+		Volumes: legacyProjectVolumeManager{},
+	})
+	migrated, err := controller.SyncLegacyDefaultProject(ctx)
+	if err != nil || !migrated.Applied || len(migrated.Issues) != 0 {
+		t.Fatalf("sync legacy default project = %#v, err = %v", migrated, err)
+	}
+	if len(migrated.Agents) != 1 || len(migrated.Schedulers) != 1 || migrated.RevisionSpec == nil {
+		t.Fatalf("migrated project artifacts = %#v", migrated)
+	}
+
+	adopted, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil {
+		t.Fatalf("load adopted loader: %v", err)
+	}
+	assertLegacyEnvItems(t, "initial adopted loader env", adopted.EnvItems, legacyLoaderEnv)
+
+	manualLoaderEnv := []domain.SandboxEnvVar{
+		{Name: "LOADER_ADDED", Value: "manual-added"},
+		{Name: "LOADER_STAYS", Value: "manual-stays", Secret: true},
+		{Name: "REMOVE_ME", Value: "manual-remove"},
+		{Name: "SECRET_FLAG", Value: "manual-secret"},
+		{Name: "SHARED", Value: "manual-shared", Secret: true},
+	}
+	adopted.EnvItems = manualLoaderEnv
+	if _, err := store.UpdateLoader(ctx, adopted); err != nil {
+		t.Fatalf("simulate loader env edit: %v", err)
+	}
+
+	scriptOnlySpec := cloneLegacyEnvProjectSpec(migrated.RevisionSpec)
+	scriptOnlySpec.Agents[0].Scheduler.Script += "\n// script-only update"
+	scriptOnlyProject := normalizedLegacyEnvProject(t, &scriptOnlySpec)
+	dryRun, err := controller.ApplyProject(ctx, projects.ApplyRequest{Normalized: scriptOnlyProject, DryRun: true})
+	if err != nil || dryRun.Applied || len(dryRun.Issues) != 0 {
+		t.Fatalf("dry-run script-only apply = %#v, err = %v", dryRun, err)
+	}
+	afterDryRun, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil {
+		t.Fatalf("load loader after dry-run: %v", err)
+	}
+	assertLegacyEnvItems(t, "loader env after dry-run", afterDryRun.EnvItems, manualLoaderEnv)
+
+	scriptOnly, err := controller.ApplyProject(ctx, projects.ApplyRequest{Normalized: scriptOnlyProject})
+	if err != nil || !scriptOnly.Applied || len(scriptOnly.Issues) != 0 {
+		t.Fatalf("script-only apply = %#v, err = %v", scriptOnly, err)
+	}
+	afterScriptOnly, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil {
+		t.Fatalf("load loader after script-only apply: %v", err)
+	}
+	assertLegacyEnvItems(t, "loader env after script-only apply", afterScriptOnly.EnvItems, manualLoaderEnv)
+
+	managedAgent, err := store.GetAgentDefinition(ctx, migrated.Agents[0].ManagedAgentID)
+	if err != nil {
+		t.Fatalf("load managed agent after script-only apply: %v", err)
+	}
+	effective := legacyEnvItemsByName(domain.MergeEnvItems(managedAgent.EnvItems, afterScriptOnly.EnvItems))
+	if effective["SHARED"].Value != "manual-shared" || effective["SHARED"].Secret != true {
+		t.Fatalf("loader env did not override agent env after script-only apply: %#v", effective["SHARED"])
+	}
+	if _, exists := effective["DELETED_MANUALLY"]; exists {
+		t.Fatalf("manually deleted loader env was restored: %#v", effective["DELETED_MANUALLY"])
+	}
+
+	explicitEnvSpec := cloneLegacyEnvProjectSpec(&scriptOnlySpec)
+	explicitEnvSpec.Agents[0].Env["SHARED"] = compose.EnvVarSpec{Value: "agent-new"}
+	delete(explicitEnvSpec.Agents[0].Env, "REMOVE_ME")
+	explicitEnvSpec.Agents[0].Env["LOADER_ADDED"] = compose.EnvVarSpec{Value: "agent-claims-key", Secret: true}
+	explicitEnvSpec.Agents[0].Env["SECRET_FLAG"] = compose.EnvVarSpec{Value: "same", Secret: true}
+
+	explicitEnv, err := controller.ApplyProject(ctx, projects.ApplyRequest{Normalized: normalizedLegacyEnvProject(t, &explicitEnvSpec)})
+	if err != nil || !explicitEnv.Applied || len(explicitEnv.Issues) != 0 {
+		t.Fatalf("explicit agent env apply = %#v, err = %v", explicitEnv, err)
+	}
+	finalLoader, err := store.GetLoader(ctx, loader.Summary.ID)
+	if err != nil {
+		t.Fatalf("load loader after explicit env apply: %v", err)
+	}
+	assertLegacyEnvItems(t, "loader overlay after explicit env apply", finalLoader.EnvItems, []domain.SandboxEnvVar{
+		{Name: "LOADER_STAYS", Value: "manual-stays", Secret: true},
+	})
+
+	finalAgent, err := store.GetAgentDefinition(ctx, migrated.Agents[0].ManagedAgentID)
+	if err != nil {
+		t.Fatalf("load managed agent after explicit env apply: %v", err)
+	}
+	effective = legacyEnvItemsByName(domain.MergeEnvItems(finalAgent.EnvItems, finalLoader.EnvItems))
+	for name, want := range map[string]domain.SandboxEnvVar{
+		"AGENT_ONLY":   {Name: "AGENT_ONLY", Value: "agent-only"},
+		"LOADER_ADDED": {Name: "LOADER_ADDED", Value: "agent-claims-key", Secret: true},
+		"LOADER_STAYS": {Name: "LOADER_STAYS", Value: "manual-stays", Secret: true},
+		"SECRET_FLAG":  {Name: "SECRET_FLAG", Value: "same", Secret: true},
+		"SHARED":       {Name: "SHARED", Value: "agent-new"},
+	} {
+		if got := effective[name]; got != want {
+			t.Fatalf("effective env %s = %#v, want %#v", name, got, want)
+		}
+	}
+	if _, exists := effective["REMOVE_ME"]; exists {
+		t.Fatalf("explicitly removed agent env still effective: %#v", effective["REMOVE_ME"])
+	}
+}
+
+func cloneLegacyEnvProjectSpec(spec *compose.NormalizedProjectSpec) compose.NormalizedProjectSpec {
+	cloned := *spec
+	cloned.Agents = append([]compose.NormalizedAgentSpec(nil), spec.Agents...)
+	for index := range cloned.Agents {
+		if spec.Agents[index].Scheduler != nil {
+			scheduler := *spec.Agents[index].Scheduler
+			cloned.Agents[index].Scheduler = &scheduler
+		}
+		if spec.Agents[index].Env != nil {
+			cloned.Agents[index].Env = make(map[string]compose.EnvVarSpec, len(spec.Agents[index].Env))
+			for name, value := range spec.Agents[index].Env {
+				cloned.Agents[index].Env[name] = value
+			}
+		}
+	}
+	return cloned
+}
+
+func normalizedLegacyEnvProject(t *testing.T, spec *compose.NormalizedProjectSpec) projects.NormalizedProject {
+	t.Helper()
+	hash, err := spec.Hash()
+	if err != nil {
+		t.Fatalf("hash legacy env project: %v", err)
+	}
+	return projects.NormalizedProject{Spec: spec, SpecHash: hash}
+}
+
+func assertLegacyEnvItems(t *testing.T, label string, got, want []domain.SandboxEnvVar) {
+	t.Helper()
+	if !projects.SameSandboxEnvItems(got, want) {
+		t.Fatalf("%s = %#v, want %#v", label, got, want)
+	}
+}
+
+func legacyEnvItemsByName(items []domain.SandboxEnvVar) map[string]domain.SandboxEnvVar {
+	byName := make(map[string]domain.SandboxEnvVar, len(items))
+	for _, item := range domain.NormalizeEnvItems(items) {
+		byName[item.Name] = item
+	}
+	return byName
+}

--- a/pkg/projects/legacy_managed_loader_reapply.go
+++ b/pkg/projects/legacy_managed_loader_reapply.go
@@ -8,7 +8,7 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
-// preserveLegacyManagedLoaderIdentities keeps adopted v1 loader IDs attached
+// preserveLegacyManagedLoaderIdentities keeps adopted v1 loader state attached
 // when the synthetic project is edited through the ordinary v2 ApplyProject
 // API. The initial migration already carries explicit overrides.
 func (c *Controller) preserveLegacyManagedLoaderIdentities(ctx context.Context, project domain.ProjectRecord, normalized NormalizedProject) (NormalizedProject, error) {
@@ -29,7 +29,7 @@ func (c *Controller) preserveLegacyManagedLoaderIdentities(ctx context.Context, 
 			declared[agent.Name] = struct{}{}
 		}
 	}
-	overrides := make(map[string]domain.Loader, len(schedulers))
+	overrides := make(map[string]legacyManagedLoaderOverride, len(schedulers))
 	for _, scheduler := range schedulers {
 		if _, ok := declared[scheduler.AgentName]; !ok || strings.TrimSpace(scheduler.ManagedLoaderID) == "" {
 			continue
@@ -41,7 +41,22 @@ func (c *Controller) preserveLegacyManagedLoaderIdentities(ctx context.Context, 
 		if !found || !managedLoaderMatchesProjectScheduler(loader, project.ID, scheduler) {
 			continue
 		}
-		overrides[scheduler.AgentName] = loader
+		managedAgentID, err := domain.StableManagedAgentID(project.ID, scheduler.AgentName)
+		if err != nil {
+			return NormalizedProject{}, fmt.Errorf("resolve scheduler %s managed agent: %w", scheduler.SchedulerID, err)
+		}
+		managedAgent, found, err := c.store.GetAgentDefinitionIfExists(ctx, managedAgentID, true)
+		if err != nil {
+			return NormalizedProject{}, fmt.Errorf("load scheduler %s managed agent %s: %w", scheduler.SchedulerID, managedAgentID, err)
+		}
+		if !found || !managedAgentMatchesProjectScheduler(managedAgent, project.ID, scheduler) {
+			return NormalizedProject{}, fmt.Errorf("scheduler %s managed agent %s is unavailable for legacy environment reconciliation", scheduler.SchedulerID, managedAgentID)
+		}
+		overrides[scheduler.AgentName] = legacyManagedLoaderOverride{
+			Loader:           loader,
+			BaselineAgentEnv: append([]domain.SandboxEnvVar(nil), managedAgent.EnvItems...),
+			BaselineKnown:    true,
+		}
 	}
 	if len(overrides) != 0 {
 		normalized.managedLoaderOverrides = overrides
@@ -53,4 +68,9 @@ func managedLoaderMatchesProjectScheduler(loader domain.Loader, projectID string
 	return strings.TrimSpace(loader.Summary.ManagedProjectID) == strings.TrimSpace(projectID) &&
 		strings.TrimSpace(loader.Summary.ManagedAgentName) == strings.TrimSpace(scheduler.AgentName) &&
 		strings.TrimSpace(loader.Summary.ManagedSchedulerID) == strings.TrimSpace(scheduler.SchedulerID)
+}
+
+func managedAgentMatchesProjectScheduler(agent domain.AgentDefinition, projectID string, scheduler domain.ProjectSchedulerRecord) bool {
+	return strings.TrimSpace(agent.ManagedProjectID) == strings.TrimSpace(projectID) &&
+		strings.TrimSpace(agent.ManagedAgentName) == strings.TrimSpace(scheduler.AgentName)
 }

--- a/pkg/projects/legacy_workspace_migration_test.go
+++ b/pkg/projects/legacy_workspace_migration_test.go
@@ -132,7 +132,7 @@ func TestLegacyDefaultNormalizedProjectMapsNamedWorkspaces(t *testing.T) {
 			taskAgent = agent
 		}
 	}
-	if taskAgent.Workspace == nil || taskAgent.Workspace.Name != "tasks" || project.managedLoaderOverrides[taskAgent.Name].Summary.ID != "loader-1" {
+	if taskAgent.Workspace == nil || taskAgent.Workspace.Name != "tasks" || project.managedLoaderOverrides[taskAgent.Name].Loader.Summary.ID != "loader-1" {
 		t.Fatalf("task agent/override = %#v/%#v", taskAgent, project.managedLoaderOverrides)
 	}
 }

--- a/pkg/projects/managed_loader_overrides.go
+++ b/pkg/projects/managed_loader_overrides.go
@@ -8,9 +8,15 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
+type legacyManagedLoaderOverride struct {
+	Loader           domain.Loader
+	BaselineAgentEnv []domain.SandboxEnvVar
+	BaselineKnown    bool
+}
+
 // applyManagedLoaderOverrideBuilds adopts legacy loader identities at the
 // project artifact boundary. Ordinary project specs never populate overrides.
-func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int64, builds []SchedulerBuild, overrides map[string]domain.Loader) ([]SchedulerBuild, error) {
+func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int64, builds []SchedulerBuild, overrides map[string]legacyManagedLoaderOverride) ([]SchedulerBuild, error) {
 	if len(overrides) == 0 {
 		return builds, nil
 	}
@@ -19,7 +25,7 @@ func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int
 		if !ok {
 			continue
 		}
-		loaderID := strings.TrimSpace(override.Summary.ID)
+		loaderID := strings.TrimSpace(override.Loader.Summary.ID)
 		if loaderID == "" {
 			return nil, fmt.Errorf("legacy loader for agent %s has no id", builds[index].Scheduler.AgentName)
 		}
@@ -39,22 +45,23 @@ func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int
 	return builds, nil
 }
 
-func mergeManagedLoaderOverride(current, override domain.Loader) domain.Loader {
+func mergeManagedLoaderOverride(current domain.Loader, override legacyManagedLoaderOverride) domain.Loader {
 	loader := loaders.CloneLoader(current)
-	loader.Summary.ID = override.Summary.ID
-	loader.Summary.AgentID = override.Summary.AgentID
-	loader.Summary.WorkspaceID = override.Summary.WorkspaceID
-	loader.Summary.CreatedAt = override.Summary.CreatedAt
-	loader.Summary.UpdatedAt = override.Summary.UpdatedAt
-	loader.Summary.LastError = override.Summary.LastError
-	loader.Summary.RunCount = override.Summary.RunCount
-	loader.Summary.EventCount = override.Summary.EventCount
-	loader.Summary.LatestRunAt = override.Summary.LatestRunAt
+	loader.Summary.ID = override.Loader.Summary.ID
+	loader.Summary.AgentID = override.Loader.Summary.AgentID
+	loader.Summary.WorkspaceID = override.Loader.Summary.WorkspaceID
+	loader.Summary.CreatedAt = override.Loader.Summary.CreatedAt
+	loader.Summary.UpdatedAt = override.Loader.Summary.UpdatedAt
+	loader.Summary.LastError = override.Loader.Summary.LastError
+	loader.Summary.RunCount = override.Loader.Summary.RunCount
+	loader.Summary.EventCount = override.Loader.Summary.EventCount
+	loader.Summary.LatestRunAt = override.Loader.Summary.LatestRunAt
 	loader.Summary.CapsetIDs = append([]string(nil), current.Summary.CapsetIDs...)
 	loader.Volumes = append([]domain.VolumeMountSpec(nil), current.Volumes...)
+	loader.EnvItems = mergeLegacyManagedLoaderEnv(current.EnvItems, override)
 
-	previousTriggers := make(map[string]domain.LoaderTrigger, len(override.Triggers))
-	for _, trigger := range override.Triggers {
+	previousTriggers := make(map[string]domain.LoaderTrigger, len(override.Loader.Triggers))
+	for _, trigger := range override.Loader.Triggers {
 		previousTriggers[trigger.ID] = trigger
 	}
 	for index := range loader.Triggers {
@@ -70,7 +77,37 @@ func mergeManagedLoaderOverride(current, override domain.Loader) domain.Loader {
 	return loader
 }
 
-func applyManagedLoaderOverrides(project domain.ProjectRecord, revision int64, schedulers []domain.ProjectSchedulerRecord, managedLoaders []domain.Loader, overrides map[string]domain.Loader) ([]domain.ProjectSchedulerRecord, []domain.Loader, error) {
+func mergeLegacyManagedLoaderEnv(candidateAgentEnv []domain.SandboxEnvVar, override legacyManagedLoaderOverride) []domain.SandboxEnvVar {
+	loaderEnv := domain.NormalizeEnvItems(override.Loader.EnvItems)
+	if !override.BaselineKnown {
+		return loaderEnv
+	}
+	// Loader env is the higher-priority compatibility layer. Preserve it only
+	// when the incoming ProjectSpec left the corresponding Agent env key
+	// unchanged; an explicit Agent change must be allowed to take effect.
+	baselineByName := sandboxEnvItemsByName(override.BaselineAgentEnv)
+	candidateByName := sandboxEnvItemsByName(candidateAgentEnv)
+	preserved := make([]domain.SandboxEnvVar, 0, len(loaderEnv))
+	for _, item := range loaderEnv {
+		baseline, baselineExists := baselineByName[item.Name]
+		candidate, candidateExists := candidateByName[item.Name]
+		if baselineExists == candidateExists && (!baselineExists || baseline == candidate) {
+			preserved = append(preserved, item)
+		}
+	}
+	return preserved
+}
+
+func sandboxEnvItemsByName(items []domain.SandboxEnvVar) map[string]domain.SandboxEnvVar {
+	normalized := domain.NormalizeEnvItems(items)
+	byName := make(map[string]domain.SandboxEnvVar, len(normalized))
+	for _, item := range normalized {
+		byName[item.Name] = item
+	}
+	return byName
+}
+
+func applyManagedLoaderOverrides(project domain.ProjectRecord, revision int64, schedulers []domain.ProjectSchedulerRecord, managedLoaders []domain.Loader, overrides map[string]legacyManagedLoaderOverride) ([]domain.ProjectSchedulerRecord, []domain.Loader, error) {
 	if len(overrides) == 0 {
 		return schedulers, managedLoaders, nil
 	}

--- a/pkg/projects/managed_loader_overrides_test.go
+++ b/pkg/projects/managed_loader_overrides_test.go
@@ -1,0 +1,152 @@
+package projects
+
+import (
+	"reflect"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestMergeLegacyManagedLoaderEnv(t *testing.T) {
+	tests := []struct {
+		name            string
+		candidate       []domain.SandboxEnvVar
+		loader          []domain.SandboxEnvVar
+		baseline        []domain.SandboxEnvVar
+		baselineKnown   bool
+		wantOverlay     []domain.SandboxEnvVar
+		wantEffective   []domain.SandboxEnvVar
+		absentEffective []string
+	}{
+		{
+			name:      "initial migration keeps the complete legacy loader layer",
+			candidate: []domain.SandboxEnvVar{{Name: "SHARED", Value: "agent"}},
+			loader: []domain.SandboxEnvVar{
+				{Name: "LOADER_ONLY", Value: "loader-only"},
+				{Name: "SHARED", Value: "loader", Secret: true},
+			},
+			wantOverlay: []domain.SandboxEnvVar{
+				{Name: "LOADER_ONLY", Value: "loader-only"},
+				{Name: "SHARED", Value: "loader", Secret: true},
+			},
+			wantEffective: []domain.SandboxEnvVar{
+				{Name: "LOADER_ONLY", Value: "loader-only"},
+				{Name: "SHARED", Value: "loader", Secret: true},
+			},
+		},
+		{
+			name:          "unchanged project env keeps out of band loader edits and precedence",
+			baselineKnown: true,
+			baseline: []domain.SandboxEnvVar{
+				{Name: "AGENT_ONLY", Value: "agent-only"},
+				{Name: "SHARED", Value: "agent"},
+			},
+			candidate: []domain.SandboxEnvVar{
+				{Name: "AGENT_ONLY", Value: "agent-only"},
+				{Name: "SHARED", Value: "agent"},
+			},
+			loader: []domain.SandboxEnvVar{
+				{Name: "LOADER_ONLY", Value: "manual"},
+				{Name: "SHARED", Value: "manual-shared", Secret: true},
+			},
+			wantOverlay: []domain.SandboxEnvVar{
+				{Name: "LOADER_ONLY", Value: "manual"},
+				{Name: "SHARED", Value: "manual-shared", Secret: true},
+			},
+			wantEffective: []domain.SandboxEnvVar{
+				{Name: "AGENT_ONLY", Value: "agent-only"},
+				{Name: "LOADER_ONLY", Value: "manual"},
+				{Name: "SHARED", Value: "manual-shared", Secret: true},
+			},
+		},
+		{
+			name:          "explicit project changes remove only conflicting loader overrides",
+			baselineKnown: true,
+			baseline: []domain.SandboxEnvVar{
+				{Name: "REMOVE_ME", Value: "old"},
+				{Name: "SECRET_FLAG", Value: "same"},
+				{Name: "SHARED", Value: "agent-old"},
+			},
+			candidate: []domain.SandboxEnvVar{
+				{Name: "LOADER_ADDED", Value: "agent-claims", Secret: true},
+				{Name: "SECRET_FLAG", Value: "same", Secret: true},
+				{Name: "SHARED", Value: "agent-new"},
+			},
+			loader: []domain.SandboxEnvVar{
+				{Name: "LOADER_ADDED", Value: "manual-added"},
+				{Name: "LOADER_STAYS", Value: "manual-stays"},
+				{Name: "REMOVE_ME", Value: "manual-remove"},
+				{Name: "SECRET_FLAG", Value: "manual-secret"},
+				{Name: "SHARED", Value: "manual-shared"},
+			},
+			wantOverlay: []domain.SandboxEnvVar{
+				{Name: "LOADER_STAYS", Value: "manual-stays"},
+			},
+			wantEffective: []domain.SandboxEnvVar{
+				{Name: "LOADER_ADDED", Value: "agent-claims", Secret: true},
+				{Name: "LOADER_STAYS", Value: "manual-stays"},
+				{Name: "SECRET_FLAG", Value: "same", Secret: true},
+				{Name: "SHARED", Value: "agent-new"},
+			},
+			absentEffective: []string{"REMOVE_ME"},
+		},
+		{
+			name:          "unrelated project env change leaves loader only keys alone",
+			baselineKnown: true,
+			baseline:      []domain.SandboxEnvVar{{Name: "AGENT_ONLY", Value: "old"}},
+			candidate:     []domain.SandboxEnvVar{{Name: "AGENT_ONLY", Value: "new"}},
+			loader:        []domain.SandboxEnvVar{{Name: "LOADER_ONLY", Value: "manual", Secret: true}},
+			wantOverlay:   []domain.SandboxEnvVar{{Name: "LOADER_ONLY", Value: "manual", Secret: true}},
+			wantEffective: []domain.SandboxEnvVar{
+				{Name: "AGENT_ONLY", Value: "new"},
+				{Name: "LOADER_ONLY", Value: "manual", Secret: true},
+			},
+		},
+		{
+			name:            "out of band loader deletion stays deleted",
+			baselineKnown:   true,
+			baseline:        []domain.SandboxEnvVar{{Name: "AGENT_ONLY", Value: "same"}},
+			candidate:       []domain.SandboxEnvVar{{Name: "AGENT_ONLY", Value: "same"}},
+			wantEffective:   []domain.SandboxEnvVar{{Name: "AGENT_ONLY", Value: "same"}},
+			absentEffective: []string{"LOADER_ONLY"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidateBefore := append([]domain.SandboxEnvVar(nil), test.candidate...)
+			loaderBefore := append([]domain.SandboxEnvVar(nil), test.loader...)
+			baselineBefore := append([]domain.SandboxEnvVar(nil), test.baseline...)
+			override := legacyManagedLoaderOverride{
+				Loader:           domain.Loader{EnvItems: test.loader},
+				BaselineAgentEnv: test.baseline,
+				BaselineKnown:    test.baselineKnown,
+			}
+
+			got := mergeLegacyManagedLoaderEnv(test.candidate, override)
+			if !SameSandboxEnvItems(got, test.wantOverlay) {
+				t.Fatalf("overlay = %#v, want %#v", got, test.wantOverlay)
+			}
+			effective := domain.MergeEnvItems(test.candidate, got)
+			if !SameSandboxEnvItems(effective, test.wantEffective) {
+				t.Fatalf("effective env = %#v, want %#v", effective, test.wantEffective)
+			}
+			effectiveByName := sandboxEnvItemsByName(effective)
+			for _, name := range test.absentEffective {
+				if _, exists := effectiveByName[name]; exists {
+					t.Fatalf("effective env unexpectedly contains %s: %#v", name, effectiveByName[name])
+				}
+			}
+
+			if !reflect.DeepEqual(test.candidate, candidateBefore) {
+				t.Fatalf("candidate env mutated: got %#v want %#v", test.candidate, candidateBefore)
+			}
+			if !reflect.DeepEqual(test.loader, loaderBefore) {
+				t.Fatalf("loader env mutated: got %#v want %#v", test.loader, loaderBefore)
+			}
+			if !reflect.DeepEqual(test.baseline, baselineBefore) {
+				t.Fatalf("baseline env mutated: got %#v want %#v", test.baseline, baselineBefore)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the task-local environment of adopted v1 Loaders when the synthetic `legacy-v1-default` project is migrated or reapplied
- reconcile Loader environment keys against the previous managed Agent environment so unchanged ProjectSpec keys retain out-of-band Loader edits, while explicit Agent env additions, updates, deletions, and `secret` metadata changes take effect
- retain the existing runtime precedence of global environment, Agent environment, Loader environment, and per-request environment
- add focused unit, SQLite integration, E2E-shape, and runtime-precedence regression coverage
- document the compatibility overlay and reconciliation rule

This fixes whole-project `ApplyProject` calls rebuilding an adopted Loader from `AgentSpec.env` and silently replacing Loader-only environment values. It does not change the public API, protobuf schema, or database schema.

## Testing

- `go test ./pkg/projects -count=1`
- `go test ./pkg/agentcompose/adapters -count=1`
- `go test ./cmd/... ./pkg/... ./proto/health/v1 ./proto/health/v1/healthv1connect ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect`
- `GOPROXY=off GOFLAGS=-mod=vendor go test ./pkg/projects -run '^TestIntegrationLegacyLoaderEnvironmentSurvivesProjectApply$' -count=1 -v` on an isolated Linux checkout
- `GOPROXY=off GOFLAGS=-mod=vendor go test ./pkg/agentcompose/adapters -run '^TestLoaderSandboxRunnerEnvironmentPrecedence$' -count=1 -v` on an isolated Linux checkout
- `task lint`
- `task build`
- `git diff --check`

The single local `task test` wrapper was not used because its deployment and
coverage helpers require GNU `sed` and a modern Bash, while the development
host provides BSD `sed` and Bash 3.2. The PR's Linux CI passed the coverage,
Go, lint, runtime, installer, binary/image build, and full-image Docker smoke
jobs.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
