### PR TITLE
ci(proto): check breaking changes in pull requests

### DIFF
--- a/.github/workflows/proto-compatibility.yml
+++ b/.github/workflows/proto-compatibility.yml
@@ -1,0 +1,96 @@
+name: Protobuf compatibility
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: proto-compatibility-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  proto-breaking:
+    name: Protobuf compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install Buf
+        run: go install github.com/bufbuild/buf/cmd/buf@v1.68.1
+      - name: Check for breaking Protobuf changes
+        id: breaking
+        continue-on-error: true
+        env:
+          PROTO_BASE: .git#ref=${{ github.event.pull_request.base.sha }}
+        run: |
+          set +e
+          buf breaking --against "$PROTO_BASE" --error-format=github-actions
+          status=$?
+          set -e
+          echo "exit-code=$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
+      - name: Reject unexpected Buf errors
+        if: steps.breaking.outputs.exit-code != '0' && steps.breaking.outputs.exit-code != '100'
+        env:
+          BUF_EXIT_CODE: ${{ steps.breaking.outputs.exit-code }}
+        run: |
+          echo "buf breaking failed unexpectedly with exit code $BUF_EXIT_CODE" >&2
+          exit 1
+      - name: Require approval for breaking changes
+        if: steps.breaking.outputs.exit-code == '100'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REQUIRED_LABEL: protobuf-breaking-approved
+        run: |
+          label_present=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER" \
+            --jq '[.labels[].name] | index(env.REQUIRED_LABEL) != null')
+          reviews=$(gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/reviews?per_page=100")
+          approved_reviewers=$(jq -r --arg head "$PR_HEAD_SHA" '
+            [.[][] | select(
+              (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+            )]
+            | sort_by(.submitted_at)
+            | reduce .[] as $review ({}; .[$review.user.login | ascii_downcase] = $review)
+            | [.[] | select(.state == "APPROVED" and .commit_id == $head)]
+            | .[].user.login
+          ' <<<"$reviews")
+
+          approving_maintainer=''
+          while IFS= read -r reviewer; do
+            [[ -n $reviewer ]] || continue
+            if permission=$(gh api "repos/$GH_REPO/collaborators/$reviewer/permission" \
+              --jq '(.user.permissions.maintain == true) or (.user.permissions.admin == true)' 2>/dev/null) && \
+              [[ $permission == true ]]; then
+              approving_maintainer=$reviewer
+              break
+            fi
+          done <<<"$approved_reviewers"
+
+          if [[ $label_present == true && -n $approving_maintainer ]]; then
+            printf 'Breaking Protobuf change approved by maintainer @%s for commit %s.\n' \
+              "$approving_maintainer" "$PR_HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo '### Breaking Protobuf change requires approval'
+            echo
+            echo "- Required label \`$REQUIRED_LABEL\`: \`$label_present\`"
+            echo "- Maintainer approval for current commit: \`$([[ -n $approving_maintainer ]] && echo true || echo false)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,6 +159,7 @@ tasks:
     desc: Run deterministic build helper, verifier, and CI topology checks
     dir: '{{.TASKFILE_DIR}}'
     cmds:
+      - ./scripts/tests/test-proto-breaking-ci-contract.sh
       - ./scripts/tests/test-build-agent-compose-binary.sh
       - ./scripts/tests/test-verify-agent-compose-binary.sh
       - ./scripts/tests/test-verify-agent-compose-image.sh

--- a/scripts/tests/test-proto-breaking-ci-contract.sh
+++ b/scripts/tests/test-proto-breaking-ci-contract.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+PROTO_WORKFLOW="$ROOT_DIR/.github/workflows/proto-compatibility.yml"
+
+job=$(awk '
+  $0 == "  proto-breaking:" {
+    found = 1
+  }
+  found && $0 ~ /^  [[:alnum:]_-]+:[[:space:]]*$/ && $0 != "  proto-breaking:" {
+    exit
+  }
+  found {
+    print
+  }
+  END {
+    if (!found) {
+      exit 1
+    }
+  }
+' "$PROTO_WORKFLOW")
+
+require() {
+  if ! grep -Eq -- "$1" <<<"$job"; then
+    printf 'test-proto-breaking-ci-contract: missing %s\n' "$2" >&2
+    exit 1
+  fi
+}
+
+workflow=$(<"$PROTO_WORKFLOW")
+
+require_workflow() {
+  if ! grep -Eq -- "$1" <<<"$workflow"; then
+    printf 'test-proto-breaking-ci-contract: missing %s\n' "$2" >&2
+    exit 1
+  fi
+}
+
+require_workflow 'pull_request_review:' 'pull request review trigger'
+require_workflow 'types: \[submitted, dismissed\]' 'review submission and dismissal triggers'
+require_workflow 'types: \[opened, synchronize, reopened, labeled, unlabeled\]' 'PR and label triggers'
+require_workflow 'pull-requests:[[:space:]]*read' 'pull request read permission'
+require 'fetch-depth:[[:space:]]*0' 'complete Git history checkout'
+require 'ref: refs/pull/\$\{\{ github\.event\.pull_request\.number \}\}/merge' 'PR merge revision checkout'
+require 'buf@v1\.68\.1' 'pinned Buf version'
+require 'PROTO_BASE: \.git#ref=\$\{\{ github\.event\.pull_request\.base\.sha \}\}' 'exact PR base revision'
+require 'buf breaking --against "\$PROTO_BASE" --error-format=github-actions' 'Buf breaking check with PR annotations'
+require 'steps\.breaking\.outputs\.exit-code == '\''100'\''' 'breaking violation approval path'
+require 'REQUIRED_LABEL: protobuf-breaking-approved' 'breaking approval label'
+require 'select\(\.state == "APPROVED" and \.commit_id == \$head\)' 'approval for current PR commit'
+require 'collaborators/\$reviewer/permission' 'reviewer repository permission lookup'
+require 'permissions\.maintain == true' 'maintain permission requirement'
+require 'permissions\.admin == true' 'admin permission requirement'


### PR DESCRIPTION
  ## Summary

  - Add a `Protobuf compatibility` CI job for pull requests.
  - Run `buf breaking` against the PR's exact base commit SHA.
  - Emit GitHub Actions annotations for breaking Protobuf changes.
  - Pin Buf to `v1.68.1` and add a CI contract test for the workflow configuration.

Closes #392 

  ## Testing

  - `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml`
  - `./scripts/tests/test-proto-breaking-ci-contract.sh`
  - `task test:scripts`
  - `buf breaking --against '.git#ref=bfbf93961a66e69212255e14a3a4c4eda0f3fa98' --error-format=github-actions`
  - Verified against tag `v2607.10.0`; Buf reported the expected breaking Protobuf changes and GitHub Actions annotations.

  Full `task lint`, `task build`, and `task test` were not run because this change only updates the GitHub Actions workflow and its shell-based CI contract
  test.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed. No public documentation changes were required for this CI-only change.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.