### PR TITLE
fix(projects): bind adopted loaders to managed agents

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -121,6 +121,24 @@ compiled only with the `docker_e2e` build tag, so the ordinary `task test`
 coverage gate does not include this scheduler Docker E2E or create its runtime
 containers.
 
+The legacy Loader environment migration has an opt-in host-daemon E2E because
+real `ApplyProject` validates Docker image availability. It seeds an isolated
+legacy database, starts the candidate daemon, and exercises dry-run and real
+updates through the public ProjectService while checking both legacy and
+ordinary v2 Project persistence:
+
+```bash
+AGENT_COMPOSE_E2E_LEGACY_LOADER_ENV_IMAGE=agent-compose-guest:latest \
+  go test ./test/e2e \
+    -run '^TestE2ELegacyLoaderEnvironmentSurvivesPublicProjectApply$' \
+    -count=1 -v
+```
+
+The selected image must already exist in the local Docker daemon. The test
+starts two short-lived Scheduler sandboxes to verify the effective
+global/Agent/legacy Loader/per-call environment precedence, then removes them
+through the public API and checks Docker cleanup.
+
 The full daemon image Docker lifecycle E2E is opt-in because it starts the
 daemon image and Docker sandbox containers through a local Docker socket. Run
 it after building both local images:

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -386,15 +386,17 @@ carry managed metadata. Manual resources with the same names are not overwritten
 or deleted.
 
 The synthetic `legacy-v1-default` project also preserves the task-local
-environment of each adopted v1 Loader. On the initial migration, the complete
-Loader environment becomes a compatibility overlay. On later `ApplyProject`
-calls, each key is reconciled against the previous managed Agent environment:
-an unchanged Agent key keeps the current Loader value (including out-of-band
-edits and deletions), while an explicitly added, changed, deleted, or
-secret-metadata-changed Agent key removes the Loader overlay for that key. The
-new managed Agent value then takes effect through the Loader runtime precedence
-of global environment, Agent environment, Loader environment, and per-request
-environment, from lowest to highest.
+environment of each adopted v1 Loader. The adopted Loader retains its Loader
+identity, history, trigger state, and task-local settings, but binds to the
+Project's managed Agent so later ProjectSpec Agent changes are used at runtime.
+On the initial migration, the complete Loader environment becomes a
+compatibility overlay. On later `ApplyProject` calls, each key is reconciled
+against the previous managed Agent environment: an unchanged Agent key keeps
+the current Loader value (including out-of-band edits and deletions), while an
+explicitly added, changed, deleted, or secret-metadata-changed Agent key removes
+the Loader overlay for that key. The new managed Agent value then takes effect
+through the Loader runtime precedence of global environment, Agent environment,
+Loader environment, and per-request environment, from lowest to highest.
 
 `ValidateProject` and `ApplyProject` use the same scheduler construction path.
 Declarative schedulers only receive compose and loader trigger structure

--- a/pkg/projects/legacy_loader_env_integration_test.go
+++ b/pkg/projects/legacy_loader_env_integration_test.go
@@ -105,6 +105,9 @@ func TestIntegrationLegacyLoaderEnvironmentSurvivesProjectApply(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load adopted loader: %v", err)
 	}
+	if adopted.Summary.AgentID != migrated.Agents[0].ManagedAgentID {
+		t.Fatalf("adopted loader agent ID = %q, want managed agent %q", adopted.Summary.AgentID, migrated.Agents[0].ManagedAgentID)
+	}
 	assertLegacyEnvItems(t, "initial adopted loader env", adopted.EnvItems, legacyLoaderEnv)
 
 	manualLoaderEnv := []domain.SandboxEnvVar{
@@ -114,6 +117,9 @@ func TestIntegrationLegacyLoaderEnvironmentSurvivesProjectApply(t *testing.T) {
 		{Name: "SECRET_FLAG", Value: "manual-secret"},
 		{Name: "SHARED", Value: "manual-shared", Secret: true},
 	}
+	// Simulate an adopted Loader persisted by an older daemon, which kept the
+	// original v1 Agent binding. The next ordinary Project apply must repair it.
+	adopted.Summary.AgentID = agent.ID
 	adopted.EnvItems = manualLoaderEnv
 	if _, err := store.UpdateLoader(ctx, adopted); err != nil {
 		t.Fatalf("simulate loader env edit: %v", err)
@@ -139,6 +145,9 @@ func TestIntegrationLegacyLoaderEnvironmentSurvivesProjectApply(t *testing.T) {
 	afterScriptOnly, err := store.GetLoader(ctx, loader.Summary.ID)
 	if err != nil {
 		t.Fatalf("load loader after script-only apply: %v", err)
+	}
+	if afterScriptOnly.Summary.AgentID != migrated.Agents[0].ManagedAgentID {
+		t.Fatalf("script-only apply loader agent ID = %q, want managed agent %q", afterScriptOnly.Summary.AgentID, migrated.Agents[0].ManagedAgentID)
 	}
 	assertLegacyEnvItems(t, "loader env after script-only apply", afterScriptOnly.EnvItems, manualLoaderEnv)
 
@@ -167,6 +176,9 @@ func TestIntegrationLegacyLoaderEnvironmentSurvivesProjectApply(t *testing.T) {
 	finalLoader, err := store.GetLoader(ctx, loader.Summary.ID)
 	if err != nil {
 		t.Fatalf("load loader after explicit env apply: %v", err)
+	}
+	if finalLoader.Summary.AgentID != migrated.Agents[0].ManagedAgentID {
+		t.Fatalf("final loader agent ID = %q, want managed agent %q", finalLoader.Summary.AgentID, migrated.Agents[0].ManagedAgentID)
 	}
 	assertLegacyEnvItems(t, "loader overlay after explicit env apply", finalLoader.EnvItems, []domain.SandboxEnvVar{
 		{Name: "LOADER_STAYS", Value: "manual-stays", Secret: true},

--- a/pkg/projects/managed_loader_overrides.go
+++ b/pkg/projects/managed_loader_overrides.go
@@ -48,7 +48,9 @@ func applyManagedLoaderOverrideBuilds(project domain.ProjectRecord, revision int
 func mergeManagedLoaderOverride(current domain.Loader, override legacyManagedLoaderOverride) domain.Loader {
 	loader := loaders.CloneLoader(current)
 	loader.Summary.ID = override.Loader.Summary.ID
-	loader.Summary.AgentID = override.Loader.Summary.AgentID
+	// Keep the compiled managed Agent binding so ProjectSpec Agent changes are
+	// used at runtime. The legacy Loader identity and task-local state remain
+	// attached to the adopted Loader below.
 	loader.Summary.WorkspaceID = override.Loader.Summary.WorkspaceID
 	loader.Summary.CreatedAt = override.Loader.Summary.CreatedAt
 	loader.Summary.UpdatedAt = override.Loader.Summary.UpdatedAt

--- a/pkg/projects/managed_loader_overrides_test.go
+++ b/pkg/projects/managed_loader_overrides_test.go
@@ -3,9 +3,68 @@ package projects
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	domain "agent-compose/pkg/model"
 )
+
+func TestMergeManagedLoaderOverridePreservesLegacyTaskStateAndManagedAgentBinding(t *testing.T) {
+	createdAt := time.Unix(100, 0)
+	updatedAt := time.Unix(200, 0)
+	latestRunAt := time.Unix(300, 0)
+	current := domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:      "compiled-loader",
+			AgentID: "managed-agent",
+		},
+		Triggers: []domain.LoaderTrigger{{ID: "trigger-1", LoaderID: "compiled-loader", Enabled: true}},
+	}
+	override := legacyManagedLoaderOverride{Loader: domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:          "legacy-loader",
+			AgentID:     "legacy-agent",
+			WorkspaceID: "legacy-workspace",
+			CreatedAt:   createdAt,
+			UpdatedAt:   updatedAt,
+			LastError:   "legacy-error",
+			RunCount:    7,
+			EventCount:  11,
+			LatestRunAt: latestRunAt,
+		},
+		Triggers: []domain.LoaderTrigger{{
+			ID:          "trigger-1",
+			LoaderID:    "legacy-loader",
+			Enabled:     false,
+			NextFireAt:  time.Unix(400, 0),
+			LastFiredAt: time.Unix(500, 0),
+		}},
+	}}
+
+	got := mergeManagedLoaderOverride(current, override)
+
+	if got.Summary.ID != "legacy-loader" || got.Summary.AgentID != "managed-agent" {
+		t.Fatalf("adopted loader identity/binding = %#v", got.Summary)
+	}
+	if got.Summary.WorkspaceID != "legacy-workspace" ||
+		got.Summary.CreatedAt != createdAt ||
+		got.Summary.UpdatedAt != updatedAt ||
+		got.Summary.LastError != "legacy-error" ||
+		got.Summary.RunCount != 7 ||
+		got.Summary.EventCount != 11 ||
+		got.Summary.LatestRunAt != latestRunAt {
+		t.Fatalf("legacy task state was not preserved: %#v", got.Summary)
+	}
+	if len(got.Triggers) != 1 ||
+		got.Triggers[0].LoaderID != "legacy-loader" ||
+		got.Triggers[0].Enabled ||
+		got.Triggers[0].NextFireAt != override.Loader.Triggers[0].NextFireAt ||
+		got.Triggers[0].LastFiredAt != override.Loader.Triggers[0].LastFiredAt {
+		t.Fatalf("legacy trigger state was not preserved: %#v", got.Triggers)
+	}
+	if current.Summary.ID != "compiled-loader" || current.Summary.AgentID != "managed-agent" {
+		t.Fatalf("compiled loader was mutated: %#v", current.Summary)
+	}
+}
 
 func TestMergeLegacyManagedLoaderEnv(t *testing.T) {
 	tests := []struct {

--- a/scripts/tests/test-coverage-contract.sh
+++ b/scripts/tests/test-coverage-contract.sh
@@ -139,7 +139,7 @@ fi
 
 listed_e2e_tests="$(go test -list '^Test' ./test/e2e | awk '/^Test/ { print }')"
 listed_e2e_count="$(printf '%s\n' "$listed_e2e_tests" | awk 'NF { count++ } END { print count + 0 }')"
-assert_equal 7 "$listed_e2e_count" "unexpected test/e2e package test count"
+assert_equal 8 "$listed_e2e_count" "unexpected test/e2e package test count"
 
 e2e_output="$(go test -run '^Test' -v ./test/e2e)"
 while IFS= read -r test_name; do

--- a/test/e2e/legacy_loader_env_host_daemon_test.go
+++ b/test/e2e/legacy_loader_env_host_daemon_test.go
@@ -1,0 +1,604 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	dockerclient "github.com/docker/docker/client"
+	"google.golang.org/protobuf/proto"
+
+	driverpkg "agent-compose/pkg/driver"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+	"agent-compose/pkg/storage/configstore"
+	storagesqlite "agent-compose/pkg/storage/sqlite"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+const legacyLoaderEnvE2EImageEnv = "AGENT_COMPOSE_E2E_LEGACY_LOADER_ENV_IMAGE"
+
+func TestE2ELegacyLoaderEnvironmentSurvivesPublicProjectApply(t *testing.T) {
+	image := strings.TrimSpace(os.Getenv(legacyLoaderEnvE2EImageEnv))
+	if image == "" {
+		t.Skipf("set %s to an existing local Docker image", legacyLoaderEnvE2EImageEnv)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	testRoot, err := os.MkdirTemp(repoRoot, ".legacy-loader-env-e2e-")
+	if err != nil {
+		t.Fatalf("create legacy loader env E2E root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(testRoot) })
+	dockerClient := newE2EDockerClient(t, ctx, image)
+	databasePath := filepath.Join(testRoot, "data.db")
+	seedLegacyLoaderEnvironment(t, ctx, databasePath, image)
+
+	binary := e2eDaemonBinary(t, ctx, repoRoot, testRoot)
+	listenAddress := unusedLoopbackAddress(t)
+	baseURL := "http://" + listenAddress
+	daemon := startE2EDaemon(t, binary, repoRoot, testRoot, listenAddress, image)
+	waitForE2EDaemon(t, ctx, daemon, baseURL)
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("agent-compose daemon log:\n%s", daemon.logs.String())
+		}
+	})
+
+	database, store := openLegacyLoaderE2EStore(t, databasePath)
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close E2E inspection database: %v", err)
+		}
+	})
+	httpClient := newE2EHTTPClient()
+	t.Cleanup(httpClient.CloseIdleConnections)
+	client := agentcomposev2connect.NewProjectServiceClient(httpClient, baseURL)
+	settingsClient := agentcomposev2connect.NewSettingsServiceClient(httpClient, baseURL)
+	sandboxClient := agentcomposev2connect.NewSandboxServiceClient(httpClient, baseURL)
+	updateE2EGlobalEnv(t, ctx, settingsClient)
+
+	normalProject := applyOrdinaryEnvProject(t, ctx, client, image)
+	normalBefore := getE2EProject(t, ctx, client, normalProject.GetSummary().GetProjectId())
+	normalLoaderBefore := managedLoaderForE2EProject(t, ctx, store, normalProject.GetSummary().GetProjectId())
+
+	legacyProjectID, err := domain.StableProjectID(projects.LegacyDefaultProjectName, "")
+	if err != nil {
+		t.Fatalf("resolve legacy default project ID: %v", err)
+	}
+	legacyBefore := getE2EProject(t, ctx, client, legacyProjectID)
+	if legacyBefore.GetSummary().GetSourcePath() != "" || len(legacyBefore.GetAgents()) != 1 || len(legacyBefore.GetSchedulers()) != 1 {
+		t.Fatalf("legacy project shape = %#v", legacyBefore)
+	}
+	initialLoader := managedLoaderForE2EProject(t, ctx, store, legacyProjectID)
+	if initialLoader.Summary.AgentID != legacyBefore.GetAgents()[0].GetManagedAgentId() {
+		t.Fatalf(
+			"initial adopted loader agent ID = %q, want managed agent %q",
+			initialLoader.Summary.AgentID,
+			legacyBefore.GetAgents()[0].GetManagedAgentId(),
+		)
+	}
+	assertE2EEnvItems(t, "initial adopted loader env", initialLoader.EnvItems, legacySeedLoaderEnv())
+
+	manualLoaderEnv := []domain.SandboxEnvVar{
+		{Name: "AGENT_LOADER", Value: "manual-agent-loader"},
+		{Name: "GLOBAL_AGENT_LOADER", Value: "manual-global-agent-loader"},
+		{Name: "LOADER_ADDED", Value: "manual-added"},
+		{Name: "LOADER_STAYS", Value: "manual-stays", Secret: true},
+		{Name: "REMOVE_ME", Value: "manual-remove"},
+		{Name: "REQUEST_WINS", Value: "manual-request-wins"},
+		{Name: "SECRET_FLAG", Value: "manual-secret"},
+		{Name: "SHARED", Value: "manual-shared", Secret: true},
+	}
+	// Simulate persisted state from an older daemon, which adopted the Loader
+	// identity but left it bound to the original v1 Agent.
+	initialLoader.Summary.AgentID = "legacy-env-e2e-agent"
+	initialLoader.EnvItems = manualLoaderEnv
+	if _, err := store.UpdateLoader(ctx, initialLoader); err != nil {
+		t.Fatalf("simulate out-of-band legacy loader env edit: %v", err)
+	}
+
+	scriptOnlySpec := proto.Clone(legacyBefore.GetSpec()).(*agentcomposev2.ProjectSpec)
+	scriptOnlySpec.Agents[0].Scheduler.Script += "\n// public script-only update"
+	dryRun, err := client.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec:   scriptOnlySpec,
+		DryRun: true,
+	}))
+	if err != nil {
+		t.Fatalf("dry-run public ApplyProject returned error: %v", err)
+	}
+	if dryRun.Msg.GetApplied() || len(dryRun.Msg.GetIssues()) != 0 {
+		t.Fatalf("dry-run public ApplyProject = %#v", dryRun.Msg)
+	}
+	legacyAfterDryRun := getE2EProject(t, ctx, client, legacyProjectID)
+	assertE2EProjectRevisionUnchanged(t, "legacy project after dry-run", legacyAfterDryRun, legacyBefore)
+	assertE2EEnvItems(
+		t,
+		"legacy loader env after dry-run",
+		managedLoaderForE2EProject(t, ctx, store, legacyProjectID).EnvItems,
+		manualLoaderEnv,
+	)
+
+	scriptOnly, err := client.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{Spec: scriptOnlySpec}))
+	if err != nil {
+		t.Fatalf("public script-only ApplyProject returned error: %v", err)
+	}
+	if !scriptOnly.Msg.GetApplied() || len(scriptOnly.Msg.GetIssues()) != 0 {
+		t.Fatalf("public script-only ApplyProject = %#v", scriptOnly.Msg)
+	}
+	legacyAfterScript := getE2EProject(t, ctx, client, legacyProjectID)
+	if got, want := legacyAfterScript.GetSummary().GetCurrentRevision(), legacyBefore.GetSummary().GetCurrentRevision()+1; got != want {
+		t.Fatalf("legacy revision after public script-only apply = %d, want %d", got, want)
+	}
+	assertE2EEnvItems(
+		t,
+		"legacy loader env after public script-only apply",
+		managedLoaderForE2EProject(t, ctx, store, legacyProjectID).EnvItems,
+		manualLoaderEnv,
+	)
+	legacyLoaderAfterScript := managedLoaderForE2EProject(t, ctx, store, legacyProjectID)
+	if legacyLoaderAfterScript.Summary.AgentID != legacyAfterScript.GetAgents()[0].GetManagedAgentId() {
+		t.Fatalf(
+			"script-only apply loader agent ID = %q, want managed agent %q",
+			legacyLoaderAfterScript.Summary.AgentID,
+			legacyAfterScript.GetAgents()[0].GetManagedAgentId(),
+		)
+	}
+	assertE2EProjectRevisionUnchanged(
+		t,
+		"ordinary project after legacy script-only apply",
+		getE2EProject(t, ctx, client, normalProject.GetSummary().GetProjectId()),
+		normalBefore,
+	)
+	assertE2EEnvItems(
+		t,
+		"ordinary loader after legacy script-only apply",
+		managedLoaderForE2EProject(t, ctx, store, normalProject.GetSummary().GetProjectId()).EnvItems,
+		normalLoaderBefore.EnvItems,
+	)
+	runLegacyEnvPriorityE2E(t, ctx, client, sandboxClient, dockerClient, legacyAfterScript, map[string]string{
+		"AGENT_LOADER":        "manual-agent-loader",
+		"DELETED_MANUALLY":    "",
+		"GLOBAL_AGENT_LOADER": "manual-global-agent-loader",
+		"GLOBAL_ONLY":         "global-only",
+		"LOADER_STAYS":        "manual-stays",
+		"REMOVE_ME":           "manual-remove",
+		"REQUEST_WINS":        "request-value",
+		"SHARED":              "manual-shared",
+	})
+
+	explicitEnvSpec := proto.Clone(legacyAfterScript.GetSpec()).(*agentcomposev2.ProjectSpec)
+	setE2EEnv(explicitEnvSpec.Agents[0], "AGENT_LOADER", "agent-new", false)
+	setE2EEnv(explicitEnvSpec.Agents[0], "SHARED", "agent-new", false)
+	removeE2EEnv(explicitEnvSpec.Agents[0], "REMOVE_ME")
+	setE2EEnv(explicitEnvSpec.Agents[0], "LOADER_ADDED", "agent-claims-key", true)
+	setE2EEnv(explicitEnvSpec.Agents[0], "SECRET_FLAG", "same", true)
+	explicitEnv, err := client.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{Spec: explicitEnvSpec}))
+	if err != nil {
+		t.Fatalf("public explicit env ApplyProject returned error: %v", err)
+	}
+	if !explicitEnv.Msg.GetApplied() || len(explicitEnv.Msg.GetIssues()) != 0 {
+		t.Fatalf("public explicit env ApplyProject = %#v", explicitEnv.Msg)
+	}
+	finalLegacy := getE2EProject(t, ctx, client, legacyProjectID)
+	finalLegacyLoader := managedLoaderForE2EProject(t, ctx, store, legacyProjectID)
+	if finalLegacyLoader.Summary.AgentID != finalLegacy.GetAgents()[0].GetManagedAgentId() {
+		t.Fatalf(
+			"final adopted loader agent ID = %q, want managed agent %q",
+			finalLegacyLoader.Summary.AgentID,
+			finalLegacy.GetAgents()[0].GetManagedAgentId(),
+		)
+	}
+	assertE2EEnvItems(t, "legacy loader overlay after explicit env apply", finalLegacyLoader.EnvItems, []domain.SandboxEnvVar{
+		{Name: "GLOBAL_AGENT_LOADER", Value: "manual-global-agent-loader"},
+		{Name: "LOADER_STAYS", Value: "manual-stays", Secret: true},
+		{Name: "REQUEST_WINS", Value: "manual-request-wins"},
+	})
+	finalLegacyAgent, err := store.GetAgentDefinition(ctx, finalLegacy.GetAgents()[0].GetManagedAgentId())
+	if err != nil {
+		t.Fatalf("load final managed legacy agent: %v", err)
+	}
+	assertE2EEnvItems(t, "effective legacy env after explicit env apply", domain.MergeEnvItems(finalLegacyAgent.EnvItems, finalLegacyLoader.EnvItems), []domain.SandboxEnvVar{
+		{Name: "AGENT_ONLY", Value: "agent-only"},
+		{Name: "AGENT_LOADER", Value: "agent-new"},
+		{Name: "GLOBAL_AGENT_LOADER", Value: "manual-global-agent-loader"},
+		{Name: "LOADER_ADDED", Value: "agent-claims-key", Secret: true},
+		{Name: "LOADER_STAYS", Value: "manual-stays", Secret: true},
+		{Name: "REQUEST_WINS", Value: "manual-request-wins"},
+		{Name: "SECRET_FLAG", Value: "same", Secret: true},
+		{Name: "SHARED", Value: "agent-new"},
+	})
+	runLegacyEnvPriorityE2E(t, ctx, client, sandboxClient, dockerClient, finalLegacy, map[string]string{
+		"AGENT_LOADER":        "agent-new",
+		"DELETED_MANUALLY":    "",
+		"GLOBAL_AGENT_LOADER": "manual-global-agent-loader",
+		"GLOBAL_ONLY":         "global-only",
+		"LOADER_STAYS":        "manual-stays",
+		"REMOVE_ME":           "",
+		"REQUEST_WINS":        "request-value",
+		"SHARED":              "agent-new",
+	})
+	assertE2EProjectRevisionUnchanged(
+		t,
+		"ordinary project after legacy explicit env apply",
+		getE2EProject(t, ctx, client, normalProject.GetSummary().GetProjectId()),
+		normalBefore,
+	)
+
+	manuallyEditedNormal := managedLoaderForE2EProject(t, ctx, store, normalProject.GetSummary().GetProjectId())
+	manuallyEditedNormal.EnvItems = []domain.SandboxEnvVar{{Name: "NORMAL", Value: "out-of-band"}}
+	if _, err := store.UpdateLoader(ctx, manuallyEditedNormal); err != nil {
+		t.Fatalf("simulate out-of-band ordinary loader env edit: %v", err)
+	}
+	normalScriptOnlySpec := proto.Clone(normalBefore.GetSpec()).(*agentcomposev2.ProjectSpec)
+	normalScriptOnlySpec.Agents[0].Scheduler.Script += "\n// ordinary script-only update"
+	normalScriptOnly, err := client.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{Spec: normalScriptOnlySpec}))
+	if err != nil {
+		t.Fatalf("ordinary public script-only ApplyProject returned error: %v", err)
+	}
+	if !normalScriptOnly.Msg.GetApplied() || len(normalScriptOnly.Msg.GetIssues()) != 0 {
+		t.Fatalf("ordinary public script-only ApplyProject = %#v", normalScriptOnly.Msg)
+	}
+	normalLoaderAfter := managedLoaderForE2EProject(t, ctx, store, normalProject.GetSummary().GetProjectId())
+	if normalLoaderAfter.Summary.ID != normalLoaderBefore.Summary.ID {
+		t.Fatalf("ordinary managed loader ID changed from %q to %q", normalLoaderBefore.Summary.ID, normalLoaderAfter.Summary.ID)
+	}
+	assertE2EEnvItems(t, "ordinary loader env remains ProjectSpec-authoritative", normalLoaderAfter.EnvItems, normalLoaderBefore.EnvItems)
+	legacyAfterOrdinaryApply := getE2EProject(t, ctx, client, legacyProjectID)
+	assertE2EProjectRevisionUnchanged(t, "legacy project after ordinary project apply", legacyAfterOrdinaryApply, finalLegacy)
+	assertE2EEnvItems(
+		t,
+		"legacy loader overlay after ordinary project apply",
+		managedLoaderForE2EProject(t, ctx, store, legacyProjectID).EnvItems,
+		finalLegacyLoader.EnvItems,
+	)
+
+	httpClient.CloseIdleConnections()
+	daemon.stop(t)
+	assertE2EDaemonReleased(t, daemon, filepath.Join(testRoot, "agent-compose.sock"), listenAddress)
+}
+
+func seedLegacyLoaderEnvironment(t *testing.T, ctx context.Context, databasePath, image string) {
+	t.Helper()
+	database, err := storagesqlite.Open(databasePath, 16*time.Second)
+	if err != nil {
+		t.Fatalf("open seed database: %v", err)
+	}
+	store := configstore.FromDB(database.DB())
+	agent, err := store.CreateAgentDefinition(ctx, domain.AgentDefinition{
+		ID:         "legacy-env-e2e-agent",
+		Name:       "legacy-env-e2e-agent",
+		Enabled:    true,
+		Provider:   "codex",
+		Driver:     driverpkg.RuntimeDriverDocker,
+		GuestImage: image,
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: "AGENT_ONLY", Value: "agent-only"},
+			{Name: "AGENT_LOADER", Value: "agent"},
+			{Name: "GLOBAL_AGENT_LOADER", Value: "agent"},
+			{Name: "REMOVE_ME", Value: "agent-remove"},
+			{Name: "REQUEST_WINS", Value: "agent"},
+			{Name: "SECRET_FLAG", Value: "same"},
+			{Name: "SHARED", Value: "agent-old"},
+		},
+	})
+	if err != nil {
+		_ = database.Close()
+		t.Fatalf("seed legacy agent: %v", err)
+	}
+	_, err = store.CreateLoader(ctx, domain.Loader{
+		Summary: domain.LoaderSummary{
+			ID:                "legacy-env-e2e-loader",
+			Name:              "Legacy env E2E scheduler",
+			Enabled:           true,
+			Runtime:           domain.LoaderRuntimeScheduler,
+			AgentID:           agent.ID,
+			Driver:            driverpkg.RuntimeDriverDocker,
+			GuestImage:        image,
+			DefaultAgent:      "codex",
+			SandboxPolicy:     domain.LoaderSandboxPolicyNew,
+			ConcurrencyPolicy: domain.LoaderConcurrencyPolicySkip,
+		},
+		Script:   legacyEnvRuntimeScript,
+		EnvItems: legacySeedLoaderEnv(),
+	})
+	if err != nil {
+		_ = database.Close()
+		t.Fatalf("seed legacy loader: %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close seed database: %v", err)
+	}
+}
+
+func legacySeedLoaderEnv() []domain.SandboxEnvVar {
+	return []domain.SandboxEnvVar{
+		{Name: "AGENT_LOADER", Value: "legacy-agent-loader"},
+		{Name: "DELETED_MANUALLY", Value: "legacy-delete"},
+		{Name: "GLOBAL_AGENT_LOADER", Value: "legacy-global-agent-loader"},
+		{Name: "LOADER_STAYS", Value: "legacy-stays"},
+		{Name: "REMOVE_ME", Value: "legacy-remove"},
+		{Name: "REQUEST_WINS", Value: "legacy-request-wins"},
+		{Name: "SECRET_FLAG", Value: "legacy-secret", Secret: true},
+		{Name: "SHARED", Value: "legacy-shared", Secret: true},
+	}
+}
+
+const legacyEnvRuntimeScript = `
+scheduler.on("legacy.env.e2e", "legacy-env-e2e", function legacyEnvE2E() {
+  const result = scheduler.shell(
+    "printf '%s\\n' \"GLOBAL_ONLY=$GLOBAL_ONLY\" \"GLOBAL_AGENT_LOADER=$GLOBAL_AGENT_LOADER\" \"AGENT_LOADER=$AGENT_LOADER\" \"REQUEST_WINS=$REQUEST_WINS\" \"SHARED=$SHARED\" \"LOADER_STAYS=$LOADER_STAYS\" \"REMOVE_ME=$REMOVE_ME\" \"DELETED_MANUALLY=$DELETED_MANUALLY\"",
+    {
+      sandboxPolicy: "new",
+      title: "legacy env precedence e2e",
+      env: { REQUEST_WINS: "request-value" }
+    }
+  );
+  if (!result.success) {
+    throw new Error("environment probe failed");
+  }
+  return { output: result.output || result.stdout || "" };
+});
+`
+
+func openLegacyLoaderE2EStore(t *testing.T, databasePath string) (*storagesqlite.Database, *configstore.ConfigStore) {
+	t.Helper()
+	database, err := storagesqlite.Open(databasePath, 16*time.Second)
+	if err != nil {
+		t.Fatalf("open E2E inspection database: %v", err)
+	}
+	return database, configstore.FromDB(database.DB())
+}
+
+func applyOrdinaryEnvProject(
+	t *testing.T,
+	ctx context.Context,
+	client agentcomposev2connect.ProjectServiceClient,
+	image string,
+) *agentcomposev2.Project {
+	t.Helper()
+	response, err := client.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec: &agentcomposev2.ProjectSpec{
+			Name: "ordinary-env-e2e",
+			Agents: []*agentcomposev2.AgentSpec{{
+				Name:     "worker",
+				Provider: "codex",
+				Image:    image,
+				Driver:   &agentcomposev2.DriverSpec{Name: "docker", Docker: &agentcomposev2.DockerDriverSpec{}},
+				Env: []*agentcomposev2.EnvVarSpec{
+					{Name: "NORMAL", Value: "project-value"},
+					{Name: "NORMAL_SECRET", Value: "project-secret", Secret: true},
+				},
+				Scheduler: &agentcomposev2.SchedulerSpec{
+					Enabled: true,
+					Script:  `scheduler.on("ordinary.env.e2e", "ordinary-env-e2e", function ordinaryEnvE2E() {});`,
+				},
+			}},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("apply ordinary env project: %v", err)
+	}
+	if !response.Msg.GetApplied() || len(response.Msg.GetIssues()) != 0 {
+		t.Fatalf("ordinary env project apply = %#v", response.Msg)
+	}
+	return response.Msg.GetProject()
+}
+
+func updateE2EGlobalEnv(
+	t *testing.T,
+	ctx context.Context,
+	client agentcomposev2connect.SettingsServiceClient,
+) {
+	t.Helper()
+	response, err := client.UpdateGlobalEnv(ctx, connect.NewRequest(&agentcomposev2.UpdateGlobalEnvRequest{
+		Env: []*agentcomposev2.EnvVarUpdateSpec{
+			{Name: "GLOBAL_ONLY", Value: proto.String("global-only")},
+			{Name: "GLOBAL_AGENT_LOADER", Value: proto.String("global")},
+			{Name: "REQUEST_WINS", Value: proto.String("global")},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("UpdateGlobalEnv for runtime precedence: %v", err)
+	}
+	if len(response.Msg.GetEnv()) != 3 {
+		t.Fatalf("UpdateGlobalEnv returned %d items, want 3", len(response.Msg.GetEnv()))
+	}
+}
+
+func runLegacyEnvPriorityE2E(
+	t *testing.T,
+	ctx context.Context,
+	projectClient agentcomposev2connect.ProjectServiceClient,
+	sandboxClient agentcomposev2connect.SandboxServiceClient,
+	dockerClient *dockerclient.Client,
+	project *agentcomposev2.Project,
+	want map[string]string,
+) {
+	t.Helper()
+	response, err := projectClient.RunScheduler(ctx, connect.NewRequest(&agentcomposev2.RunSchedulerRequest{
+		Project:     &agentcomposev2.ProjectRef{ProjectId: project.GetSummary().GetProjectId()},
+		AgentName:   project.GetAgents()[0].GetAgentName(),
+		TriggerId:   "legacy-env-e2e",
+		PayloadJson: `{}`,
+	}))
+	if err != nil {
+		t.Fatalf("RunScheduler environment precedence probe: %v", err)
+	}
+	run := response.Msg.GetRun()
+	if run.GetStatus() != agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SUCCEEDED {
+		t.Fatalf("environment precedence run status = %s, error = %q", run.GetStatus(), run.GetError())
+	}
+	sandboxID := linkedE2ESandboxID(t, ctx, projectClient, project, run.GetRunId())
+	removeLegacyEnvE2ESandboxPublic(t, ctx, sandboxClient, sandboxID)
+	removeE2EDockerSandboxFallback(t, ctx, dockerClient, sandboxID)
+	var result struct {
+		Output string `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(run.GetResultJson()), &result); err != nil {
+		t.Fatalf("decode environment precedence result %q: %v", run.GetResultJson(), err)
+	}
+	got := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(result.Output), "\n") {
+		name, value, ok := strings.Cut(line, "=")
+		if ok {
+			got[name] = value
+		}
+	}
+	for name, value := range want {
+		if got[name] != value {
+			t.Fatalf("runtime env %s = %q, want %q; output = %q", name, got[name], value, result.Output)
+		}
+	}
+}
+
+func removeLegacyEnvE2ESandboxPublic(
+	t *testing.T,
+	ctx context.Context,
+	sandboxClient agentcomposev2connect.SandboxServiceClient,
+	sandboxID string,
+) {
+	t.Helper()
+	response, err := sandboxClient.RemoveSandbox(ctx, connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{
+		SandboxId: sandboxID,
+		Force:     true,
+	}))
+	if err != nil {
+		t.Fatalf("RemoveSandbox %s returned error: %v", sandboxID, err)
+	}
+	if response.Msg.GetSandboxId() != sandboxID || !response.Msg.GetRemoved() {
+		t.Fatalf("RemoveSandbox %s response = %#v, want removed sandbox", sandboxID, response.Msg)
+	}
+}
+
+func linkedE2ESandboxID(
+	t *testing.T,
+	ctx context.Context,
+	projectClient agentcomposev2connect.ProjectServiceClient,
+	project *agentcomposev2.Project,
+	runID string,
+) string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := projectClient.ListProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
+			Project:   &agentcomposev2.ProjectRef{ProjectId: project.GetSummary().GetProjectId()},
+			AgentName: project.GetAgents()[0].GetAgentName(),
+			RunId:     runID,
+			Limit:     100,
+		}))
+		if err != nil {
+			t.Fatalf("ListProjectSchedulerEvents for run %s: %v", runID, err)
+		}
+		sandboxIDs := make(map[string]struct{})
+		for _, event := range response.Msg.GetEvents() {
+			if sandboxID := strings.TrimSpace(event.GetLinkedSandboxId()); sandboxID != "" {
+				sandboxIDs[sandboxID] = struct{}{}
+			}
+		}
+		if len(sandboxIDs) == 1 {
+			for sandboxID := range sandboxIDs {
+				return sandboxID
+			}
+		}
+		if len(sandboxIDs) > 1 {
+			t.Fatalf("scheduler run %s linked sandbox IDs = %v, want one", runID, sandboxIDs)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("scheduler run %s did not expose a linked sandbox event", runID)
+	return ""
+}
+
+func getE2EProject(
+	t *testing.T,
+	ctx context.Context,
+	client agentcomposev2connect.ProjectServiceClient,
+	projectID string,
+) *agentcomposev2.Project {
+	t.Helper()
+	response, err := client.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
+		Project:     &agentcomposev2.ProjectRef{ProjectId: projectID},
+		IncludeSpec: true,
+	}))
+	if err != nil {
+		t.Fatalf("GetProject %s: %v", projectID, err)
+	}
+	if response.Msg.GetProject().GetSpec() == nil {
+		t.Fatalf("GetProject %s returned no spec", projectID)
+	}
+	return response.Msg.GetProject()
+}
+
+func managedLoaderForE2EProject(
+	t *testing.T,
+	ctx context.Context,
+	store *configstore.ConfigStore,
+	projectID string,
+) domain.Loader {
+	t.Helper()
+	schedulers, err := store.ListProjectSchedulers(ctx, projectID)
+	if err != nil {
+		t.Fatalf("list project %s schedulers: %v", projectID, err)
+	}
+	if len(schedulers) != 1 {
+		t.Fatalf("project %s scheduler count = %d, want 1", projectID, len(schedulers))
+	}
+	loader, err := store.GetLoader(ctx, schedulers[0].ManagedLoaderID)
+	if err != nil {
+		t.Fatalf("load project %s managed loader %s: %v", projectID, schedulers[0].ManagedLoaderID, err)
+	}
+	return loader
+}
+
+func assertE2EProjectRevisionUnchanged(t *testing.T, label string, got, want *agentcomposev2.Project) {
+	t.Helper()
+	if got.GetSummary().GetCurrentRevision() != want.GetSummary().GetCurrentRevision() ||
+		got.GetSummary().GetSpecHash() != want.GetSummary().GetSpecHash() {
+		t.Fatalf(
+			"%s revision/hash = %d/%q, want %d/%q",
+			label,
+			got.GetSummary().GetCurrentRevision(),
+			got.GetSummary().GetSpecHash(),
+			want.GetSummary().GetCurrentRevision(),
+			want.GetSummary().GetSpecHash(),
+		)
+	}
+}
+
+func assertE2EEnvItems(t *testing.T, label string, got, want []domain.SandboxEnvVar) {
+	t.Helper()
+	if !projects.SameSandboxEnvItems(got, want) {
+		t.Fatalf("%s = %#v, want %#v", label, got, want)
+	}
+}
+
+func setE2EEnv(agent *agentcomposev2.AgentSpec, name, value string, secret bool) {
+	for _, item := range agent.Env {
+		if item.GetName() == name {
+			item.Value = value
+			item.Secret = secret
+			return
+		}
+	}
+	agent.Env = append(agent.Env, &agentcomposev2.EnvVarSpec{Name: name, Value: value, Secret: secret})
+}
+
+func removeE2EEnv(agent *agentcomposev2.AgentSpec, name string) {
+	filtered := agent.Env[:0]
+	for _, item := range agent.Env {
+		if item.GetName() != name {
+			filtered = append(filtered, item)
+		}
+	}
+	agent.Env = filtered
+}


### PR DESCRIPTION
## Summary

- bind an adopted legacy Loader to the Project-managed Agent while preserving the legacy Loader ID, history, trigger state, workspace, and Loader-level environment overlay
- repair Loader records persisted by older versions on the next ordinary `ApplyProject`
- add an opt-in host-daemon E2E that applies Projects through the public API and runs real Docker Scheduler sandboxes
- document the managed Agent binding and the reusable E2E command

This is a follow-up to #428. The environment overlay was persisted correctly,
but a real Scheduler run showed that the adopted Loader still referenced the
original v1 Agent. As a result, later ProjectSpec Agent environment changes
were stored on the managed Agent but were not used by the sandbox runtime.

The production behavior change is intentionally small: the override merge now
keeps the Agent binding compiled from the current ProjectSpec instead of
restoring the legacy Agent ID.

## Side-effect coverage

The host-daemon E2E uses an isolated database and daemon, public Connect APIs,
and two short-lived Docker Scheduler sandboxes. It verifies:

- dry-run does not mutate the Project revision or Loader environment
- script-only whole-Project apply preserves out-of-band legacy Loader edits
- old persisted v1 Agent bindings are repaired on apply
- explicit Agent env add/change/delete/secret changes take effect
- effective precedence remains global < Agent < Loader < per-request
- Loader-only keys and unchanged Loader overrides remain effective
- an ordinary v2 Project remains ProjectSpec-authoritative and isolated from
  the synthetic legacy Project
- sandboxes are removed through the public API and leave no Docker residue

Focused unit and integration coverage also verifies that Loader identity,
history, trigger timestamps/state, workspace, and the managed Agent binding are
preserved together.

## Testing

- `go test ./pkg/projects -count=1`
- `go test ./pkg/agentcompose/adapters -count=1`
- `go test ./test/e2e -run '^TestE2ELegacyLoaderEnvironmentSurvivesPublicProjectApply$' -count=1`
- `AGENT_COMPOSE_E2E_LEGACY_LOADER_ENV_IMAGE=<existing-image> go test ./test/e2e -run '^TestE2ELegacyLoaderEnvironmentSurvivesPublicProjectApply$' -count=1 -v` on an isolated Linux Docker host
- `go test ./pkg/projects -count=1` on an isolated Linux host
- `go test ./pkg/agentcompose/adapters -run '^TestLoaderSandboxRunnerEnvironmentPrecedence$' -count=1` on an isolated Linux host
- `task lint`
- `task build:agent-compose`
- `task build:proto`
- `git diff --check`

## Checklist

- [x] Documentation updated for the behavior and opt-in E2E.
- [x] Regression tests cover persistence, public API, runtime precedence, and cleanup.
- [x] No API, protobuf, or database schema change.
- [x] No environment-specific hostnames, paths, credentials, or runtime state included.
