### PR TITLE
docs: fix inline code formatting for project and service names in SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for considering a contribution to agent-compose.
+Thanks for considering a contribution to `agent-compose`.
 
 The project is still in preview. Please keep changes focused, explain behavior
 changes clearly, and include tests for user-visible behavior.
@@ -10,7 +10,7 @@ changes clearly, and include tests for user-visible behavior.
 ### Prerequisites
 
 - **Go 1.26.2**, matching the `go` directive in [`go.mod`](go.mod). Install it
-  from the [official Go downloads](https://go.dev/dl/), or use an existing Go
+  from the [official Go downloads page](https://go.dev/dl/), or use an existing Go
   installation with automatic toolchain downloads enabled (`GOTOOLCHAIN=auto`).
   Distribution packages may be older than the version required by this
   repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-agent-compose is an experimental project. Please review its security model
+`agent-compose` is an experimental project. Please review its security model
 before exposing it outside a local development environment.
 
 ## Reporting Vulnerabilities
@@ -26,7 +26,7 @@ development branch until versioned release support is documented.
 
 ## Deployment Guidance
 
-- Expose browser access through the agent-compose-ui server, not directly
+- Expose browser access through the `agent-compose-ui` server, not directly
   through the daemon.
 - Set `AUTH_PASSWORD` and a stable, high-entropy `AUTH_SECRET` for the UI server
   before exposing the Web UI to other users.
@@ -34,7 +34,7 @@ development branch until versioned release support is documented.
 - Treat `HTTP_LISTEN=0.0.0.0:7410` as an internal daemon API. Startup emits a
   warning but still proceeds; use container networking, reverse proxies, VPNs,
   or equivalent controls to avoid direct public access.
-- Do not expose guest Jupyter ports directly. Use the agent-compose proxy.
+- Do not expose guest Jupyter ports directly. Use the `agent-compose` proxy.
 - Treat workspace uploads, Git credentials, environment variables, webhook
   tokens, and LLM API keys as secrets.
 - Review runtime driver network behavior before running untrusted workloads.


### PR DESCRIPTION
## Description
This PR adds backticks for project and service names in `SECURITY.md`.

## Details
Updated references (`agent-compose` and `agent-compose-ui`) to use inline code formatting.