### PR TITLE
docs: fix project name code formatting and introductory comma in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for considering a contribution to agent-compose.
+Thanks for considering a contribution to `agent-compose`.
 
 The project is still in preview. Please keep changes focused, explain behavior
 changes clearly, and include tests for user-visible behavior.
@@ -10,7 +10,7 @@ changes clearly, and include tests for user-visible behavior.
 ### Prerequisites
 
 - **Go 1.26.2**, matching the `go` directive in [`go.mod`](go.mod). Install it
-  from the [official Go downloads](https://go.dev/dl/), or use an existing Go
+  from the [official Go downloads page](https://go.dev/dl/), or use an existing Go
   installation with automatic toolchain downloads enabled (`GOTOOLCHAIN=auto`).
   Distribution packages may be older than the version required by this
   repository.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 </p>
 
-**agent-compose is a daemon + CLI control plane that runs AI coding agents in isolated sandboxes.** You describe your agents in an `agent-compose.yml` file, and a long-lived daemon builds, runs, schedules, and proxies an isolated runtime for each one.
+**`agent-compose` is a daemon + CLI control plane that runs AI coding agents in isolated sandboxes.** You describe your agents in an `agent-compose.yml` file, and a long-lived daemon builds, runs, schedules, and proxies an isolated runtime for each one.
 
 > Public preview. APIs, runtime packaging, and deployment defaults may still change. It is suitable for experimentation, local development, and preview deployments — not yet a stable production platform.
 
@@ -87,7 +87,7 @@ The installer also pre-pulls the sandbox guest image so the first agent run
 does not stall on a large download; pass `--skip-guest-pull` (or answer no in
 the TUI) to defer it.
 
-On first run the installer generates an `admin` password and prints it once;
+On first run, the installer generates an `admin` password and prints it once;
 use it at the URL the installer prints when the UI is enabled. See
 [deploy/README.md](deploy/README.md) for install, upgrade, uninstall, data
 preservation, and mirror/private-registry options.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-agent-compose is an experimental project. Please review its security model
+`agent-compose` is an experimental project. Please review its security model
 before exposing it outside a local development environment.
 
 ## Reporting Vulnerabilities
@@ -26,7 +26,7 @@ development branch until versioned release support is documented.
 
 ## Deployment Guidance
 
-- Expose browser access through the agent-compose-ui server, not directly
+- Expose browser access through the `agent-compose-ui` server, not directly
   through the daemon.
 - Set `AUTH_PASSWORD` and a stable, high-entropy `AUTH_SECRET` for the UI server
   before exposing the Web UI to other users.
@@ -34,7 +34,7 @@ development branch until versioned release support is documented.
 - Treat `HTTP_LISTEN=0.0.0.0:7410` as an internal daemon API. Startup emits a
   warning but still proceeds; use container networking, reverse proxies, VPNs,
   or equivalent controls to avoid direct public access.
-- Do not expose guest Jupyter ports directly. Use the agent-compose proxy.
+- Do not expose guest Jupyter ports directly. Use the `agent-compose` proxy.
 - Treat workspace uploads, Git credentials, environment variables, webhook
   tokens, and LLM API keys as secrets.
 - Review runtime driver network behavior before running untrusted workloads.


### PR DESCRIPTION
## Description
This PR fixes inline code formatting for the project name and adds an introductory comma in `README.md`.

## Details
1. Formatted project name (`**agent-compose is...**` $\to$ `**`agent-compose` is...**`).
2. Added introductory comma (`On first run the installer` $\to$ `On first run, the installer`).