### PR TITLE
fix(daemon): recover sandbox deletions asynchronously

### DIFF
--- a/cmd/agent-compose/cli_daemon.go
+++ b/cmd/agent-compose/cli_daemon.go
@@ -7,6 +7,7 @@ import (
 	"agent-compose/pkg/fxgo/restful"
 	"agent-compose/pkg/fxgo/utils"
 	"agent-compose/pkg/health"
+	"agent-compose/pkg/sandboxes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -35,6 +36,8 @@ import (
 )
 
 type daemonRunner func(context.Context) error
+
+const daemonStatusTimeout = 5 * time.Second
 
 type DaemonOptions struct {
 	LoadDotEnv      bool
@@ -79,7 +82,7 @@ func NewEcho(di do.Injector) (*echo.Echo, error) {
 		now := time.Now()
 		timezone, timezoneOffset := now.Zone()
 		build := buildInfoForVersion(conf.Version)
-		return c.JSON(http.StatusOK, restful.NewResponse[map[string]any, restful.StrStatusResp[map[string]any]](nil, codes.OK.String(), map[string]any{
+		data := map[string]any{
 			"version":          build.Version,
 			"os":               build.OS,
 			"arch":             build.Arch,
@@ -87,7 +90,11 @@ func NewEcho(di do.Injector) (*echo.Echo, error) {
 			"timestamp":        float64(now.UnixNano()) / 1e9,
 			"timezone":         timezone,
 			"timezone_offset":  timezoneOffset,
-		}))
+		}
+		if recovery, err := do.Invoke[*sandboxes.DeletionRecovery](di); err == nil {
+			data["deletion_recovery"] = recovery.Status()
+		}
+		return c.JSON(http.StatusOK, restful.NewResponse[map[string]any, restful.StrStatusResp[map[string]any]](nil, codes.OK.String(), data))
 	})
 	e.GET("/api/null", echofn.EchoWrap(restful.NullHandler[restful.StrStatusResp[any]]))
 	return e, nil
@@ -392,13 +399,28 @@ func runDaemon(ctx context.Context) error {
 }
 
 func fetchDaemonVersion(ctx context.Context, clientConfig cliClientConfig) ([]byte, error) {
+	return fetchDaemonVersionWithTimeout(ctx, clientConfig, daemonStatusTimeout)
+}
+
+func fetchDaemonVersionWithTimeout(ctx context.Context, clientConfig cliClientConfig, timeout time.Duration) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	client := newDaemonHTTPClient(clientConfig)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientConfig.BaseURL+"/api/version", nil)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, clientConfig.BaseURL+"/api/version", nil)
 	if err != nil {
 		return nil, fmt.Errorf("create daemon request for %s %q: %w", clientConfig.Source, clientConfig.SourceValue, err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		if ctx.Err() == nil && errors.Is(requestCtx.Err(), context.DeadlineExceeded) {
+			return nil, commandExitError{
+				Code: exitCodeUnavailable,
+				Err:  fmt.Errorf("daemon status request via %s %q timed out after %s: %w", clientConfig.Source, clientConfig.SourceValue, timeout, err),
+			}
+		}
 		return nil, commandExitError{Code: exitCodeUnavailable, Err: fmt.Errorf("connect daemon via %s %q: %w", clientConfig.Source, clientConfig.SourceValue, err)}
 	}
 	defer func() {
@@ -424,13 +446,14 @@ type daemonStatusResponse struct {
 	Err  json.RawMessage `json:"err"`
 	Msg  string          `json:"msg"`
 	Data struct {
-		Timestamp       float64  `json:"timestamp"`
-		Timezone        string   `json:"timezone"`
-		TimezoneOffset  *int     `json:"timezone_offset"`
-		Version         string   `json:"version"`
-		OS              string   `json:"os"`
-		Arch            string   `json:"arch"`
-		CompiledDrivers []string `json:"compiled_drivers"`
+		Timestamp        float64                          `json:"timestamp"`
+		Timezone         string                           `json:"timezone"`
+		TimezoneOffset   *int                             `json:"timezone_offset"`
+		Version          string                           `json:"version"`
+		OS               string                           `json:"os"`
+		Arch             string                           `json:"arch"`
+		CompiledDrivers  []string                         `json:"compiled_drivers"`
+		DeletionRecovery sandboxes.DeletionRecoveryStatus `json:"deletion_recovery"`
 	} `json:"data"`
 }
 
@@ -446,6 +469,12 @@ func writeDaemonStatusText(out io.Writer, body []byte) error {
 	}
 	if len(response.Err) > 0 && string(response.Err) != "null" {
 		status = "error"
+	} else if response.Data.DeletionRecovery.InProgress {
+		status = "RECOVERING"
+	} else if response.Data.DeletionRecovery.Remaining > 0 ||
+		response.Data.DeletionRecovery.Failed > 0 ||
+		strings.TrimSpace(response.Data.DeletionRecovery.LastError) != "" {
+		status = "DEGRADED"
 	}
 	uptime := "-"
 	if response.Data.Timestamp > 0 {

--- a/cmd/agent-compose/cli_daemon.go
+++ b/cmd/agent-compose/cli_daemon.go
@@ -7,7 +7,6 @@ import (
 	"agent-compose/pkg/fxgo/restful"
 	"agent-compose/pkg/fxgo/utils"
 	"agent-compose/pkg/health"
-	"agent-compose/pkg/sandboxes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -82,7 +81,7 @@ func NewEcho(di do.Injector) (*echo.Echo, error) {
 		now := time.Now()
 		timezone, timezoneOffset := now.Zone()
 		build := buildInfoForVersion(conf.Version)
-		data := map[string]any{
+		return c.JSON(http.StatusOK, restful.NewResponse[map[string]any, restful.StrStatusResp[map[string]any]](nil, codes.OK.String(), map[string]any{
 			"version":          build.Version,
 			"os":               build.OS,
 			"arch":             build.Arch,
@@ -90,11 +89,7 @@ func NewEcho(di do.Injector) (*echo.Echo, error) {
 			"timestamp":        float64(now.UnixNano()) / 1e9,
 			"timezone":         timezone,
 			"timezone_offset":  timezoneOffset,
-		}
-		if recovery, err := do.Invoke[*sandboxes.DeletionRecovery](di); err == nil {
-			data["deletion_recovery"] = recovery.Status()
-		}
-		return c.JSON(http.StatusOK, restful.NewResponse[map[string]any, restful.StrStatusResp[map[string]any]](nil, codes.OK.String(), data))
+		}))
 	})
 	e.GET("/api/null", echofn.EchoWrap(restful.NullHandler[restful.StrStatusResp[any]]))
 	return e, nil
@@ -446,14 +441,13 @@ type daemonStatusResponse struct {
 	Err  json.RawMessage `json:"err"`
 	Msg  string          `json:"msg"`
 	Data struct {
-		Timestamp        float64                          `json:"timestamp"`
-		Timezone         string                           `json:"timezone"`
-		TimezoneOffset   *int                             `json:"timezone_offset"`
-		Version          string                           `json:"version"`
-		OS               string                           `json:"os"`
-		Arch             string                           `json:"arch"`
-		CompiledDrivers  []string                         `json:"compiled_drivers"`
-		DeletionRecovery sandboxes.DeletionRecoveryStatus `json:"deletion_recovery"`
+		Timestamp       float64  `json:"timestamp"`
+		Timezone        string   `json:"timezone"`
+		TimezoneOffset  *int     `json:"timezone_offset"`
+		Version         string   `json:"version"`
+		OS              string   `json:"os"`
+		Arch            string   `json:"arch"`
+		CompiledDrivers []string `json:"compiled_drivers"`
 	} `json:"data"`
 }
 
@@ -469,12 +463,6 @@ func writeDaemonStatusText(out io.Writer, body []byte) error {
 	}
 	if len(response.Err) > 0 && string(response.Err) != "null" {
 		status = "error"
-	} else if response.Data.DeletionRecovery.InProgress {
-		status = "RECOVERING"
-	} else if response.Data.DeletionRecovery.Remaining > 0 ||
-		response.Data.DeletionRecovery.Failed > 0 ||
-		strings.TrimSpace(response.Data.DeletionRecovery.LastError) != "" {
-		status = "DEGRADED"
 	}
 	uptime := "-"
 	if response.Data.Timestamp > 0 {

--- a/cmd/agent-compose/cli_daemon_recovery_test.go
+++ b/cmd/agent-compose/cli_daemon_recovery_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -21,7 +20,7 @@ import (
 	"agent-compose/pkg/sandboxes"
 )
 
-func TestAPIVersionRespondsWhileDeletionRecoveryIsBlocked(t *testing.T) {
+func TestAPIVersionContractUnchangedWhileDeletionRecoveryIsBlocked(t *testing.T) {
 	root := t.TempDir()
 	const sandboxID = "blocked"
 	if err := sandboxes.WriteOwnershipRecord(root, sandboxes.OwnershipRecord{
@@ -64,16 +63,27 @@ func TestAPIVersionRespondsWhileDeletionRecoveryIsBlocked(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("GET /api/version status = %d, want 200", response.StatusCode)
 	}
-	var status daemonStatusResponse
+	var status struct {
+		Msg  string                     `json:"msg"`
+		Data map[string]json.RawMessage `json:"data"`
+	}
 	if err := decodeJSONBody(response.Body, &status); err != nil {
 		t.Fatalf("decode /api/version: %v", err)
 	}
 	if status.Msg != "OK" {
 		t.Fatalf("/api/version message = %q, want compatibility value OK", status.Msg)
 	}
-	got := status.Data.DeletionRecovery
-	if !got.InProgress || got.Total != 1 || got.Remaining != 1 || len(got.ActiveSandboxIDs) != 1 || got.ActiveSandboxIDs[0] != sandboxID {
-		t.Fatalf("/api/version deletion recovery = %#v", got)
+	if _, exists := status.Data["deletion_recovery"]; exists {
+		t.Fatal("/api/version unexpectedly exposes deletion recovery state")
+	}
+	wantKeys := []string{"version", "os", "arch", "compiled_drivers", "timestamp", "timezone", "timezone_offset"}
+	for _, key := range wantKeys {
+		if _, exists := status.Data[key]; !exists {
+			t.Errorf("/api/version data is missing legacy field %q", key)
+		}
+	}
+	if len(status.Data) != len(wantKeys) {
+		t.Fatalf("/api/version data keys = %v, want legacy seven-field contract", status.Data)
 	}
 
 	cancelRecovery()
@@ -81,36 +91,6 @@ func TestAPIVersionRespondsWhileDeletionRecoveryIsBlocked(t *testing.T) {
 	defer cancelShutdown()
 	if err := recovery.Shutdown(shutdownCtx); err != nil {
 		t.Fatalf("shutdown deletion recovery: %v", err)
-	}
-}
-
-func TestDaemonStatusTextReflectsDeletionRecovery(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-		want string
-	}{
-		{name: "legacy healthy", body: `{"err":null,"msg":"OK","data":{"version":"v"}}`, want: "OK"},
-		{name: "recovering", body: `{"err":null,"msg":"OK","data":{"version":"v","deletion_recovery":{"in_progress":true,"total":2,"remaining":2}}}`, want: "RECOVERING"},
-		{name: "failed", body: `{"err":null,"msg":"OK","data":{"version":"v","deletion_recovery":{"failed":1,"remaining":1,"last_error":"remove failed"}}}`, want: "DEGRADED"},
-		{name: "journal warning", body: `{"err":null,"msg":"OK","data":{"version":"v","deletion_recovery":{"last_error":"invalid journal"}}}`, want: "DEGRADED"},
-		{name: "envelope error wins", body: `{"err":"broken","msg":"OK","data":{"version":"v","deletion_recovery":{"in_progress":true}}}`, want: "error"},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var output bytes.Buffer
-			if err := writeDaemonStatusText(&output, []byte(test.body)); err != nil {
-				t.Fatalf("writeDaemonStatusText returned error: %v", err)
-			}
-			lines := strings.Split(strings.TrimSpace(output.String()), "\n")
-			if len(lines) != 2 {
-				t.Fatalf("status output = %q", output.String())
-			}
-			fields := strings.Fields(lines[1])
-			if len(fields) == 0 || fields[0] != test.want {
-				t.Fatalf("status output = %q, want status %s", output.String(), test.want)
-			}
-		})
 	}
 }
 

--- a/cmd/agent-compose/cli_daemon_recovery_test.go
+++ b/cmd/agent-compose/cli_daemon_recovery_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/do/v2"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sandboxes"
+)
+
+func TestAPIVersionRespondsWhileDeletionRecoveryIsBlocked(t *testing.T) {
+	root := t.TempDir()
+	const sandboxID = "blocked"
+	if err := sandboxes.WriteOwnershipRecord(root, sandboxes.OwnershipRecord{
+		SandboxID: sandboxID, SandboxPath: filepath.Join(root, sandboxID), LifecycleState: "deleting",
+	}); err != nil {
+		t.Fatalf("write deletion journal: %v", err)
+	}
+	runtime := &daemonRecoveryRuntime{started: make(chan struct{}, 1)}
+	recovery := sandboxes.NewDeletionRecovery(&sandboxes.RemovalCoordinator{
+		SandboxRoot: root,
+		Store:       daemonRecoveryStore{},
+		Runtime:     runtime,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	recoveryCtx, cancelRecovery := context.WithCancel(context.Background())
+	defer cancelRecovery()
+	if err := recovery.Start(recoveryCtx); err != nil {
+		t.Fatalf("start deletion recovery: %v", err)
+	}
+	select {
+	case <-runtime.started:
+	case <-time.After(time.Second):
+		t.Fatal("blocked deletion did not start")
+	}
+
+	di := do.New()
+	do.ProvideValue(di, &appconfig.Config{Version: "recovery-test"})
+	do.ProvideValue(di, recovery)
+	app, err := NewEcho(di)
+	if err != nil {
+		t.Fatalf("NewEcho returned error: %v", err)
+	}
+	server := httptest.NewServer(app)
+	defer server.Close()
+	client := &http.Client{Timeout: time.Second}
+	response, err := client.Get(server.URL + "/api/version")
+	if err != nil {
+		t.Fatalf("GET /api/version while recovery blocked: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET /api/version status = %d, want 200", response.StatusCode)
+	}
+	var status daemonStatusResponse
+	if err := decodeJSONBody(response.Body, &status); err != nil {
+		t.Fatalf("decode /api/version: %v", err)
+	}
+	if status.Msg != "OK" {
+		t.Fatalf("/api/version message = %q, want compatibility value OK", status.Msg)
+	}
+	got := status.Data.DeletionRecovery
+	if !got.InProgress || got.Total != 1 || got.Remaining != 1 || len(got.ActiveSandboxIDs) != 1 || got.ActiveSandboxIDs[0] != sandboxID {
+		t.Fatalf("/api/version deletion recovery = %#v", got)
+	}
+
+	cancelRecovery()
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), time.Second)
+	defer cancelShutdown()
+	if err := recovery.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown deletion recovery: %v", err)
+	}
+}
+
+func TestDaemonStatusTextReflectsDeletionRecovery(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "legacy healthy", body: `{"err":null,"msg":"OK","data":{"version":"v"}}`, want: "OK"},
+		{name: "recovering", body: `{"err":null,"msg":"OK","data":{"version":"v","deletion_recovery":{"in_progress":true,"total":2,"remaining":2}}}`, want: "RECOVERING"},
+		{name: "failed", body: `{"err":null,"msg":"OK","data":{"version":"v","deletion_recovery":{"failed":1,"remaining":1,"last_error":"remove failed"}}}`, want: "DEGRADED"},
+		{name: "journal warning", body: `{"err":null,"msg":"OK","data":{"version":"v","deletion_recovery":{"last_error":"invalid journal"}}}`, want: "DEGRADED"},
+		{name: "envelope error wins", body: `{"err":"broken","msg":"OK","data":{"version":"v","deletion_recovery":{"in_progress":true}}}`, want: "error"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := writeDaemonStatusText(&output, []byte(test.body)); err != nil {
+				t.Fatalf("writeDaemonStatusText returned error: %v", err)
+			}
+			lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+			if len(lines) != 2 {
+				t.Fatalf("status output = %q", output.String())
+			}
+			fields := strings.Fields(lines[1])
+			if len(fields) == 0 || fields[0] != test.want {
+				t.Fatalf("status output = %q, want status %s", output.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestFetchDaemonVersionHasBoundedStatusTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	const timeout = 20 * time.Millisecond
+	_, err := fetchDaemonVersionWithTimeout(context.Background(), cliClientConfig{
+		BaseURL: server.URL, Source: "--host", SourceValue: server.URL,
+	}, timeout)
+	var exitErr commandExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != exitCodeUnavailable {
+		t.Fatalf("status timeout error = %v, want unavailable command exit error", err)
+	}
+	for _, want := range []string{"daemon status request", "timed out after 20ms", server.URL} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("status timeout error = %q, want %q", err, want)
+		}
+	}
+	if daemonStatusTimeout != 5*time.Second {
+		t.Fatalf("daemon status timeout = %v, want 5s", daemonStatusTimeout)
+	}
+}
+
+func decodeJSONBody(reader io.Reader, target any) error {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, target)
+}
+
+type daemonRecoveryStore struct{}
+
+func (daemonRecoveryStore) GetSandbox(_ context.Context, id string) (*domain.Sandbox, error) {
+	return &domain.Sandbox{Summary: domain.SandboxSummary{ID: id}}, nil
+}
+
+func (daemonRecoveryStore) ListSandboxes(context.Context, domain.SandboxListOptions) (domain.SandboxListResult, error) {
+	return domain.SandboxListResult{}, nil
+}
+
+func (daemonRecoveryStore) UpdateSandbox(context.Context, *domain.Sandbox) error { return nil }
+func (daemonRecoveryStore) RemoveSandbox(context.Context, string) error          { return nil }
+
+type daemonRecoveryRuntime struct {
+	started chan struct{}
+}
+
+func (r *daemonRecoveryRuntime) StopSandboxVM(context.Context, *domain.Sandbox) error { return nil }
+
+func (r *daemonRecoveryRuntime) RemoveSandboxVM(ctx context.Context, _ *domain.Sandbox) error {
+	r.started <- struct{}{}
+	<-ctx.Done()
+	return ctx.Err()
+}

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -677,21 +677,12 @@ agent-compose status --json
 
 Default columns:
 
-- `STATUS`: `OK` when the daemon has no outstanding startup deletion work,
-  `RECOVERING` while durable sandbox deletions are being resumed, or `DEGRADED`
-  when a deletion journal could not be read or removed and remains for a future
-  daemon restart.
+- `STATUS`: daemon response status.
 - `UPTIME`: daemon-reported timestamp rendered in the daemon timezone when available.
 - `VERSION`: daemon build version.
 
 Status requests have a five-second timeout. Use `--json` to print the raw daemon
-status response for automation. Its additive `data.deletion_recovery` object
-reports `in_progress`, `total`, successfully `completed`, `failed`, and
-`remaining` deletion counts, plus currently active `active_sandbox_ids` and the
-most recent `last_error` when present. Failed deletions remain in `remaining`
-because their durable journals are retried on the next daemon start. The legacy
-response envelope remains successful with `msg: "OK"`; the text command derives
-`RECOVERING` and `DEGRADED` from the recovery object.
+status response for automation.
 
 ## Other Commands
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -677,11 +677,21 @@ agent-compose status --json
 
 Default columns:
 
-- `STATUS`: daemon response status.
+- `STATUS`: `OK` when the daemon has no outstanding startup deletion work,
+  `RECOVERING` while durable sandbox deletions are being resumed, or `DEGRADED`
+  when a deletion journal could not be read or removed and remains for a future
+  daemon restart.
 - `UPTIME`: daemon-reported timestamp rendered in the daemon timezone when available.
 - `VERSION`: daemon build version.
 
-Use `--json` to print the raw daemon status response for automation.
+Status requests have a five-second timeout. Use `--json` to print the raw daemon
+status response for automation. Its additive `data.deletion_recovery` object
+reports `in_progress`, `total`, successfully `completed`, `failed`, and
+`remaining` deletion counts, plus currently active `active_sandbox_ids` and the
+most recent `last_error` when present. Failed deletions remain in `remaining`
+because their durable journals are retried on the next daemon start. The legacy
+response envelope remains successful with `msg: "OK"`; the text command derives
+`RECOVERING` and `DEGRADED` from the recovery object.
 
 ## Other Commands
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -682,11 +682,19 @@ agent-compose status --json
 
 默认输出字段：
 
-- `STATUS`：daemon 响应状态。
+- `STATUS`：没有待处理的启动期删除任务时为 `OK`；正在恢复持久化 sandbox
+  删除任务时为 `RECOVERING`；删除日志无法读取或删除失败、需要后续 daemon
+  重启重试时为 `DEGRADED`。
 - `UPTIME`：daemon 返回的时间戳；如果 daemon 返回了时区信息，则按 daemon 时区展示。
 - `VERSION`：daemon 构建版本。
 
-自动化场景使用 `--json` 输出 daemon 原始 status 响应。
+status 请求的超时时间为五秒。自动化场景使用 `--json` 输出 daemon 原始
+status 响应。增量字段 `data.deletion_recovery` 包含 `in_progress`、`total`、
+成功 `completed`、`failed`、`remaining` 等删除计数，以及当前执行中的
+`active_sandbox_ids` 和存在错误时的最新 `last_error`。失败的删除仍计入
+`remaining`，因为对应持久化日志会在下一次 daemon 启动时重试。兼容性的响应
+信封仍保持 `msg: "OK"`，文本命令根据恢复对象计算 `RECOVERING` 或
+`DEGRADED`。
 
 ## 其他命令
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -682,19 +682,12 @@ agent-compose status --json
 
 默认输出字段：
 
-- `STATUS`：没有待处理的启动期删除任务时为 `OK`；正在恢复持久化 sandbox
-  删除任务时为 `RECOVERING`；删除日志无法读取或删除失败、需要后续 daemon
-  重启重试时为 `DEGRADED`。
+- `STATUS`：daemon 响应状态。
 - `UPTIME`：daemon 返回的时间戳；如果 daemon 返回了时区信息，则按 daemon 时区展示。
 - `VERSION`：daemon 构建版本。
 
 status 请求的超时时间为五秒。自动化场景使用 `--json` 输出 daemon 原始
-status 响应。增量字段 `data.deletion_recovery` 包含 `in_progress`、`total`、
-成功 `completed`、`failed`、`remaining` 等删除计数，以及当前执行中的
-`active_sandbox_ids` 和存在错误时的最新 `last_error`。失败的删除仍计入
-`remaining`，因为对应持久化日志会在下一次 daemon 启动时重试。兼容性的响应
-信封仍保持 `msg: "OK"`，文本命令根据恢复对象计算 `RECOVERING` 或
-`DEGRADED`。
+status 响应。
 
 ## 其他命令
 

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -87,6 +87,7 @@ func RegisterDependencies(di do.Injector) {
 	do.Provide(di, NewRunController)
 	do.Provide(di, NewSandboxRunTargetResolver)
 	do.Provide(di, NewSandboxRemovalCoordinator)
+	do.Provide(di, NewDeletionRecovery)
 	do.Provide(di, NewCleanupRunner)
 	do.Provide(di, NewRunSupervisor)
 	do.Provide(di, NewProjectController)
@@ -200,6 +201,13 @@ func NewSandboxRemovalCoordinator(di do.Injector) (*sandboxes.RemovalCoordinator
 	}, nil
 }
 
+func NewDeletionRecovery(di do.Injector) (*sandboxes.DeletionRecovery, error) {
+	return sandboxes.NewDeletionRecovery(
+		do.MustInvoke[*sandboxes.RemovalCoordinator](di),
+		do.MustInvoke[*slog.Logger](di),
+	), nil
+}
+
 func NewCleanupRunner(di do.Injector) (*cleanup.Runner, error) {
 	config := do.MustInvoke[*appconfig.Config](di)
 	store := do.MustInvoke[*sandboxstore.Store](di)
@@ -225,9 +233,6 @@ func StartBackground(di do.Injector) error {
 	// sandbox store. Do this before resolving or starting any component that can
 	// create a sandbox, so the initial cleanup pass cannot race registration.
 	runner := do.MustInvoke[*cleanup.Runner](di)
-	for _, warning := range do.MustInvoke[*sandboxes.RemovalCoordinator](di).Recover(do.MustInvoke[context.Context](di)) {
-		slog.Warn("failed to recover sandbox deletion", "warning", warning)
-	}
 	ctx := do.MustInvoke[context.Context](di)
 	if err := startBackgroundManagers(
 		ctx,
@@ -241,16 +246,20 @@ func StartBackground(di do.Injector) error {
 	); err != nil {
 		return err
 	}
+	if err := do.MustInvoke[*sandboxes.DeletionRecovery](di).Start(ctx); err != nil {
+		return fmt.Errorf("start sandbox deletion recovery: %w", err)
+	}
 	runner.Start(ctx)
 	return nil
 }
 
 func StopBackground(ctx context.Context, di do.Injector) error {
-	runner, err := do.Invoke[*cleanup.Runner](di)
-	if err != nil {
-		return err
-	}
-	return runner.Shutdown(ctx)
+	recovery, recoveryErr := do.Invoke[*sandboxes.DeletionRecovery](di)
+	runner, runnerErr := do.Invoke[*cleanup.Runner](di)
+	return stopBackgroundComponents(ctx, []backgroundComponent{
+		{name: "sandbox deletion recovery", shutdown: recovery.Shutdown},
+		{name: "cleanup runner", shutdown: runner.Shutdown},
+	}, recoveryErr, runnerErr)
 }
 
 func NewCapProxyServer(di do.Injector) (*capproxy.Server, error) {

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -254,12 +254,22 @@ func StartBackground(di do.Injector) error {
 }
 
 func StopBackground(ctx context.Context, di do.Injector) error {
+	components := make([]backgroundComponent, 0, 2)
+	var setupErrors []error
+
 	recovery, recoveryErr := do.Invoke[*sandboxes.DeletionRecovery](di)
+	if recoveryErr != nil {
+		setupErrors = append(setupErrors, fmt.Errorf("resolve sandbox deletion recovery: %w", recoveryErr))
+	} else {
+		components = append(components, backgroundComponent{name: "sandbox deletion recovery", shutdown: recovery.Shutdown})
+	}
 	runner, runnerErr := do.Invoke[*cleanup.Runner](di)
-	return stopBackgroundComponents(ctx, []backgroundComponent{
-		{name: "sandbox deletion recovery", shutdown: recovery.Shutdown},
-		{name: "cleanup runner", shutdown: runner.Shutdown},
-	}, recoveryErr, runnerErr)
+	if runnerErr != nil {
+		setupErrors = append(setupErrors, fmt.Errorf("resolve cleanup runner: %w", runnerErr))
+	} else {
+		components = append(components, backgroundComponent{name: "cleanup runner", shutdown: runner.Shutdown})
+	}
+	return stopBackgroundComponents(ctx, components, setupErrors...)
 }
 
 func NewCapProxyServer(di do.Injector) (*capproxy.Server, error) {

--- a/pkg/agentcompose/app/app_test.go
+++ b/pkg/agentcompose/app/app_test.go
@@ -22,6 +22,7 @@ import (
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/projects"
 	"agent-compose/pkg/runs"
+	"agent-compose/pkg/sandboxes"
 	"agent-compose/pkg/schedulers"
 	"agent-compose/pkg/volumes"
 	"agent-compose/pkg/workspaces"
@@ -111,13 +112,17 @@ func TestStartBackgroundConstructsCleanupBeforeLoader(t *testing.T) {
 		constructionOrder = append(constructionOrder, "loader")
 		return NewSchedulerController(di)
 	})
+	do.Override(di, func(di do.Injector) (*sandboxes.DeletionRecovery, error) {
+		constructionOrder = append(constructionOrder, "recovery")
+		return NewDeletionRecovery(di)
+	})
 
 	if err := StartBackground(di); err != nil {
 		t.Fatalf("StartBackground returned error: %v", err)
 	}
 	cancel()
-	if len(constructionOrder) < 2 || constructionOrder[0] != "cleanup" || constructionOrder[1] != "loader" {
-		t.Fatalf("background construction order = %v, want cleanup before loader", constructionOrder)
+	if len(constructionOrder) < 3 || constructionOrder[0] != "cleanup" || constructionOrder[1] != "loader" || constructionOrder[2] != "recovery" {
+		t.Fatalf("background construction order = %v, want cleanup before loader before recovery", constructionOrder)
 	}
 }
 

--- a/pkg/agentcompose/app/background_shutdown.go
+++ b/pkg/agentcompose/app/background_shutdown.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+type backgroundComponent struct {
+	name     string
+	shutdown func(context.Context) error
+}
+
+func stopBackgroundComponents(ctx context.Context, components []backgroundComponent, setupErrors ...error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var joined error
+	for _, err := range setupErrors {
+		if err != nil {
+			joined = errors.Join(joined, err)
+		}
+	}
+
+	results := make(chan error, len(components))
+	for _, component := range components {
+		go func() {
+			if component.shutdown == nil {
+				results <- nil
+				return
+			}
+			if err := component.shutdown(ctx); err != nil {
+				results <- fmt.Errorf("stop %s: %w", component.name, err)
+				return
+			}
+			results <- nil
+		}()
+	}
+	for range components {
+		joined = errors.Join(joined, <-results)
+	}
+	return joined
+}

--- a/pkg/agentcompose/app/background_shutdown_test.go
+++ b/pkg/agentcompose/app/background_shutdown_test.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStopBackgroundComponentsCancelsComponentsConcurrently(t *testing.T) {
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondRelease := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- stopBackgroundComponents(context.Background(), []backgroundComponent{
+			{name: "first", shutdown: blockingBackgroundShutdown(firstEntered, firstRelease)},
+			{name: "second", shutdown: blockingBackgroundShutdown(secondEntered, secondRelease)},
+		})
+	}()
+
+	for name, entered := range map[string]<-chan struct{}{"first": firstEntered, "second": secondEntered} {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatalf("%s background component did not begin shutdown", name)
+		}
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("stop returned before components were released: %v", err)
+	default:
+	}
+	close(firstRelease)
+	close(secondRelease)
+	if err := <-done; err != nil {
+		t.Fatalf("stop returned error: %v", err)
+	}
+}
+
+func TestStopBackgroundComponentsJoinsSetupAndShutdownErrors(t *testing.T) {
+	setupErr := errors.New("resolve recovery")
+	shutdownErr := errors.New("cleanup stuck")
+	err := stopBackgroundComponents(context.TODO(), []backgroundComponent{{
+		name: "cleanup runner",
+		shutdown: func(context.Context) error {
+			return shutdownErr
+		},
+	}}, setupErr)
+	if !errors.Is(err, setupErr) || !errors.Is(err, shutdownErr) {
+		t.Fatalf("stop error = %v, want both setup and shutdown failures", err)
+	}
+	if !strings.Contains(err.Error(), "stop cleanup runner") {
+		t.Fatalf("stop error = %q, want component context", err)
+	}
+}
+
+func blockingBackgroundShutdown(entered chan<- struct{}, release <-chan struct{}) func(context.Context) error {
+	return func(ctx context.Context) error {
+		close(entered)
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/pkg/agentcompose/app/background_shutdown_test.go
+++ b/pkg/agentcompose/app/background_shutdown_test.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/samber/do/v2"
+
+	"agent-compose/pkg/cleanup"
+	"agent-compose/pkg/sandboxes"
 )
 
 func TestStopBackgroundComponentsCancelsComponentsConcurrently(t *testing.T) {
@@ -54,6 +59,28 @@ func TestStopBackgroundComponentsJoinsSetupAndShutdownErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "stop cleanup runner") {
 		t.Fatalf("stop error = %q, want component context", err)
+	}
+}
+
+func TestStopBackgroundSkipsComponentsThatFailToResolve(t *testing.T) {
+	recoveryErr := errors.New("recovery setup failed")
+	runnerErr := errors.New("cleanup setup failed")
+	di := do.New()
+	do.Provide(di, func(do.Injector) (*sandboxes.DeletionRecovery, error) {
+		return nil, recoveryErr
+	})
+	do.Provide(di, func(do.Injector) (*cleanup.Runner, error) {
+		return nil, runnerErr
+	})
+
+	err := StopBackground(context.Background(), di)
+	if !errors.Is(err, recoveryErr) || !errors.Is(err, runnerErr) {
+		t.Fatalf("StopBackground error = %v, want both setup failures", err)
+	}
+	for _, want := range []string{"resolve sandbox deletion recovery", "resolve cleanup runner"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("StopBackground error = %q, want %q", err, want)
+		}
 	}
 }
 

--- a/pkg/sandboxes/deletion_recovery.go
+++ b/pkg/sandboxes/deletion_recovery.go
@@ -1,0 +1,206 @@
+package sandboxes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+)
+
+const deletionRecoveryWorkers = 2
+
+// DeletionRecoveryStatus describes durable sandbox deletions being resumed
+// after daemon startup. Remaining includes deletions that failed and must be
+// retried by a future daemon instance.
+type DeletionRecoveryStatus struct {
+	InProgress       bool     `json:"in_progress"`
+	Total            int      `json:"total"`
+	Completed        int      `json:"completed"`
+	Failed           int      `json:"failed"`
+	Remaining        int      `json:"remaining"`
+	ActiveSandboxIDs []string `json:"active_sandbox_ids,omitempty"`
+	LastError        string   `json:"last_error,omitempty"`
+}
+
+// DeletionRecovery owns asynchronous recovery of sandbox deletion journals.
+type DeletionRecovery struct {
+	coordinator *RemovalCoordinator
+	logger      *slog.Logger
+
+	mu      sync.RWMutex
+	status  DeletionRecoveryStatus
+	cancel  context.CancelFunc
+	done    chan struct{}
+	started bool
+}
+
+// NewDeletionRecovery creates a one-shot deletion recovery component.
+func NewDeletionRecovery(coordinator *RemovalCoordinator, logger *slog.Logger) *DeletionRecovery {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &DeletionRecovery{coordinator: coordinator, logger: logger}
+}
+
+// Start begins recovery and returns without waiting for the lifecycle scan or
+// any pending deletion.
+func (r *DeletionRecovery) Start(parent context.Context) error {
+	if r == nil || r.coordinator == nil {
+		return fmt.Errorf("deletion recovery is not configured")
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	r.mu.Lock()
+	if r.started {
+		r.mu.Unlock()
+		return nil
+	}
+	ctx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+	r.started = true
+	r.cancel = cancel
+	r.done = done
+	r.status = DeletionRecoveryStatus{InProgress: true}
+	r.mu.Unlock()
+
+	go r.run(ctx, done)
+	return nil
+}
+
+// Shutdown cancels recovery and waits for all workers to exit.
+func (r *DeletionRecovery) Shutdown(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	r.mu.RLock()
+	cancel := r.cancel
+	done := r.done
+	r.mu.RUnlock()
+	if cancel == nil || done == nil {
+		return nil
+	}
+	cancel()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Status returns an immutable snapshot of the current recovery state.
+func (r *DeletionRecovery) Status() DeletionRecoveryStatus {
+	if r == nil {
+		return DeletionRecoveryStatus{}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	status := r.status
+	status.ActiveSandboxIDs = append([]string(nil), r.status.ActiveSandboxIDs...)
+	return status
+}
+
+func (r *DeletionRecovery) run(ctx context.Context, done chan struct{}) {
+	defer func() {
+		r.mu.Lock()
+		r.status.InProgress = false
+		r.status.ActiveSandboxIDs = nil
+		r.mu.Unlock()
+		close(done)
+	}()
+
+	records, warnings := ListOwnershipRecords(r.coordinator.SandboxRoot)
+	deleting := make([]OwnershipRecord, 0, len(records))
+	for _, record := range records {
+		if record.LifecycleState == "deleting" {
+			deleting = append(deleting, record)
+		}
+	}
+	r.mu.Lock()
+	r.status.Total = len(deleting)
+	r.status.Remaining = len(deleting)
+	for _, warning := range warnings {
+		r.status.LastError = warning
+	}
+	r.mu.Unlock()
+	for _, warning := range warnings {
+		r.logger.Warn("failed to read sandbox deletion journal", "warning", warning)
+	}
+	if len(deleting) == 0 || ctx.Err() != nil {
+		return
+	}
+
+	jobs := make(chan OwnershipRecord)
+	var workers sync.WaitGroup
+	workerCount := min(deletionRecoveryWorkers, len(deleting))
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for record := range jobs {
+				r.setActive(record.SandboxID, true)
+				result, err := r.coordinator.Remove(ctx, record.SandboxID, true)
+				r.setActive(record.SandboxID, false)
+				if err == nil && !result.Removed {
+					err = fmt.Errorf("sandbox deletion did not complete")
+				}
+				r.recordResult(ctx, record.SandboxID, err)
+			}
+		}()
+	}
+
+sendRecords:
+	for _, record := range deleting {
+		select {
+		case jobs <- record:
+		case <-ctx.Done():
+			break sendRecords
+		}
+	}
+	close(jobs)
+	workers.Wait()
+}
+
+func (r *DeletionRecovery) setActive(sandboxID string, active bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if active {
+		r.status.ActiveSandboxIDs = append(r.status.ActiveSandboxIDs, sandboxID)
+		sort.Strings(r.status.ActiveSandboxIDs)
+		return
+	}
+	for index, current := range r.status.ActiveSandboxIDs {
+		if current == sandboxID {
+			r.status.ActiveSandboxIDs = append(r.status.ActiveSandboxIDs[:index], r.status.ActiveSandboxIDs[index+1:]...)
+			return
+		}
+	}
+}
+
+func (r *DeletionRecovery) recordResult(ctx context.Context, sandboxID string, err error) {
+	if err == nil {
+		r.mu.Lock()
+		r.status.Completed++
+		r.status.Remaining = r.status.Total - r.status.Completed
+		r.mu.Unlock()
+		return
+	}
+	if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		return
+	}
+
+	wrapped := fmt.Errorf("resume sandbox deletion %s: %w", sandboxID, err)
+	r.logger.Warn("failed to recover sandbox deletion", "sandbox_id", sandboxID, "error", err)
+	r.mu.Lock()
+	r.status.Failed++
+	r.status.LastError = wrapped.Error()
+	r.mu.Unlock()
+}

--- a/pkg/sandboxes/deletion_recovery.go
+++ b/pkg/sandboxes/deletion_recovery.go
@@ -5,32 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"sync"
 )
 
 const deletionRecoveryWorkers = 2
-
-// DeletionRecoveryStatus describes durable sandbox deletions being resumed
-// after daemon startup. Remaining includes deletions that failed and must be
-// retried by a future daemon instance.
-type DeletionRecoveryStatus struct {
-	InProgress       bool     `json:"in_progress"`
-	Total            int      `json:"total"`
-	Completed        int      `json:"completed"`
-	Failed           int      `json:"failed"`
-	Remaining        int      `json:"remaining"`
-	ActiveSandboxIDs []string `json:"active_sandbox_ids,omitempty"`
-	LastError        string   `json:"last_error,omitempty"`
-}
 
 // DeletionRecovery owns asynchronous recovery of sandbox deletion journals.
 type DeletionRecovery struct {
 	coordinator *RemovalCoordinator
 	logger      *slog.Logger
 
-	mu      sync.RWMutex
-	status  DeletionRecoveryStatus
+	mu      sync.Mutex
 	cancel  context.CancelFunc
 	done    chan struct{}
 	started bool
@@ -64,7 +49,6 @@ func (r *DeletionRecovery) Start(parent context.Context) error {
 	r.started = true
 	r.cancel = cancel
 	r.done = done
-	r.status = DeletionRecoveryStatus{InProgress: true}
 	r.mu.Unlock()
 
 	go r.run(ctx, done)
@@ -80,10 +64,10 @@ func (r *DeletionRecovery) Shutdown(ctx context.Context) error {
 		ctx = context.Background()
 	}
 
-	r.mu.RLock()
+	r.mu.Lock()
 	cancel := r.cancel
 	done := r.done
-	r.mu.RUnlock()
+	r.mu.Unlock()
 	if cancel == nil || done == nil {
 		return nil
 	}
@@ -96,26 +80,8 @@ func (r *DeletionRecovery) Shutdown(ctx context.Context) error {
 	}
 }
 
-// Status returns an immutable snapshot of the current recovery state.
-func (r *DeletionRecovery) Status() DeletionRecoveryStatus {
-	if r == nil {
-		return DeletionRecoveryStatus{}
-	}
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	status := r.status
-	status.ActiveSandboxIDs = append([]string(nil), r.status.ActiveSandboxIDs...)
-	return status
-}
-
 func (r *DeletionRecovery) run(ctx context.Context, done chan struct{}) {
-	defer func() {
-		r.mu.Lock()
-		r.status.InProgress = false
-		r.status.ActiveSandboxIDs = nil
-		r.mu.Unlock()
-		close(done)
-	}()
+	defer close(done)
 
 	records, warnings := ListOwnershipRecords(r.coordinator.SandboxRoot)
 	deleting := make([]OwnershipRecord, 0, len(records))
@@ -124,13 +90,6 @@ func (r *DeletionRecovery) run(ctx context.Context, done chan struct{}) {
 			deleting = append(deleting, record)
 		}
 	}
-	r.mu.Lock()
-	r.status.Total = len(deleting)
-	r.status.Remaining = len(deleting)
-	for _, warning := range warnings {
-		r.status.LastError = warning
-	}
-	r.mu.Unlock()
 	for _, warning := range warnings {
 		r.logger.Warn("failed to read sandbox deletion journal", "warning", warning)
 	}
@@ -146,13 +105,11 @@ func (r *DeletionRecovery) run(ctx context.Context, done chan struct{}) {
 		go func() {
 			defer workers.Done()
 			for record := range jobs {
-				r.setActive(record.SandboxID, true)
 				result, err := r.coordinator.Remove(ctx, record.SandboxID, true)
-				r.setActive(record.SandboxID, false)
 				if err == nil && !result.Removed {
 					err = fmt.Errorf("sandbox deletion did not complete")
 				}
-				r.recordResult(ctx, record.SandboxID, err)
+				r.logFailure(ctx, record.SandboxID, err)
 			}
 		}()
 	}
@@ -169,38 +126,13 @@ sendRecords:
 	workers.Wait()
 }
 
-func (r *DeletionRecovery) setActive(sandboxID string, active bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if active {
-		r.status.ActiveSandboxIDs = append(r.status.ActiveSandboxIDs, sandboxID)
-		sort.Strings(r.status.ActiveSandboxIDs)
-		return
-	}
-	for index, current := range r.status.ActiveSandboxIDs {
-		if current == sandboxID {
-			r.status.ActiveSandboxIDs = append(r.status.ActiveSandboxIDs[:index], r.status.ActiveSandboxIDs[index+1:]...)
-			return
-		}
-	}
-}
-
-func (r *DeletionRecovery) recordResult(ctx context.Context, sandboxID string, err error) {
+func (r *DeletionRecovery) logFailure(ctx context.Context, sandboxID string, err error) {
 	if err == nil {
-		r.mu.Lock()
-		r.status.Completed++
-		r.status.Remaining = r.status.Total - r.status.Completed
-		r.mu.Unlock()
 		return
 	}
 	if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return
 	}
 
-	wrapped := fmt.Errorf("resume sandbox deletion %s: %w", sandboxID, err)
 	r.logger.Warn("failed to recover sandbox deletion", "sandbox_id", sandboxID, "error", err)
-	r.mu.Lock()
-	r.status.Failed++
-	r.status.LastError = wrapped.Error()
-	r.mu.Unlock()
 }

--- a/pkg/sandboxes/deletion_recovery_test.go
+++ b/pkg/sandboxes/deletion_recovery_test.go
@@ -1,6 +1,7 @@
 package sandboxes
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -45,28 +46,15 @@ func TestDeletionRecoveryRunsPendingDeletionsConcurrentlyAndStops(t *testing.T) 
 		t.Fatal("unblocked deletion waited behind blocked deletion")
 	}
 
-	status := waitForDeletionRecoveryStatus(t, recovery, func(status DeletionRecoveryStatus) bool {
-		return status.Completed == 1 && status.Remaining == 1
-	})
-	if !status.InProgress || status.Total != 2 || status.Failed != 0 {
-		t.Fatalf("Status = %#v, want one of two deletions completed", status)
-	}
-	if len(status.ActiveSandboxIDs) != 1 || status.ActiveSandboxIDs[0] != "a" {
-		t.Fatalf("active sandbox IDs = %v, want [a]", status.ActiveSandboxIDs)
-	}
-	status.ActiveSandboxIDs[0] = "mutated"
-	if got := recovery.Status().ActiveSandboxIDs; len(got) != 1 || got[0] != "a" {
-		t.Fatalf("Status returned shared active sandbox IDs: %v", got)
-	}
+	waitForRecoveryJournalRemoval(t, root, "b")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := recovery.Shutdown(shutdownCtx); err != nil {
 		t.Fatalf("Shutdown returned error: %v", err)
 	}
-	status = recovery.Status()
-	if status.InProgress || status.Completed != 1 || status.Failed != 0 || status.Remaining != 1 || len(status.ActiveSandboxIDs) != 0 {
-		t.Fatalf("Status after shutdown = %#v, want one durable deletion remaining without a failure", status)
+	if _, err := ReadOwnershipRecord(root, "a"); err != nil {
+		t.Fatalf("canceled deletion did not retain its journal: %v", err)
 	}
 }
 
@@ -78,15 +66,7 @@ func TestDeletionRecoveryReportsFailureAndRetriesOnNextInstance(t *testing.T) {
 	if err := first.Start(context.Background()); err != nil {
 		t.Fatalf("first Start returned error: %v", err)
 	}
-	failed := waitForDeletionRecoveryStatus(t, first, func(status DeletionRecoveryStatus) bool {
-		return !status.InProgress
-	})
-	if failed.Total != 1 || failed.Completed != 0 || failed.Failed != 1 || failed.Remaining != 1 {
-		t.Fatalf("failed recovery Status = %#v", failed)
-	}
-	if !strings.Contains(failed.LastError, "retry") || !strings.Contains(failed.LastError, "runtime removal failed") {
-		t.Fatalf("failed recovery last error = %q", failed.LastError)
-	}
+	waitForDeletionRecoveryDone(t, first)
 	if _, err := ReadOwnershipRecord(root, "retry"); err != nil {
 		t.Fatalf("failed deletion did not retain its journal: %v", err)
 	}
@@ -96,15 +76,8 @@ func TestDeletionRecoveryReportsFailureAndRetriesOnNextInstance(t *testing.T) {
 	if err := second.Start(context.Background()); err != nil {
 		t.Fatalf("second Start returned error: %v", err)
 	}
-	succeeded := waitForDeletionRecoveryStatus(t, second, func(status DeletionRecoveryStatus) bool {
-		return !status.InProgress
-	})
-	if succeeded.Total != 1 || succeeded.Completed != 1 || succeeded.Failed != 0 || succeeded.Remaining != 0 || succeeded.LastError != "" {
-		t.Fatalf("retried recovery Status = %#v", succeeded)
-	}
-	if _, err := ReadOwnershipRecord(root, "retry"); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("successful retry journal error = %v, want not exist", err)
-	}
+	waitForRecoveryJournalRemoval(t, root, "retry")
+	waitForDeletionRecoveryDone(t, second)
 }
 
 func TestDeletionRecoveryReportsUnreadableJournal(t *testing.T) {
@@ -117,15 +90,18 @@ func TestDeletionRecoveryReportsUnreadableJournal(t *testing.T) {
 		t.Fatalf("write broken lifecycle journal: %v", err)
 	}
 
-	recovery := newTestDeletionRecovery(root, &recoveryRuntime{})
+	var logs bytes.Buffer
+	recovery := NewDeletionRecovery(&RemovalCoordinator{
+		SandboxRoot: root,
+		Store:       recoveryStore{},
+		Runtime:     &recoveryRuntime{},
+	}, slog.New(slog.NewTextHandler(&logs, nil)))
 	if err := recovery.Start(context.Background()); err != nil {
 		t.Fatalf("Start returned error: %v", err)
 	}
-	status := waitForDeletionRecoveryStatus(t, recovery, func(status DeletionRecoveryStatus) bool {
-		return !status.InProgress
-	})
-	if status.Total != 0 || status.Completed != 0 || status.Remaining != 0 || !strings.Contains(status.LastError, "broken.json") {
-		t.Fatalf("Status = %#v, want unreadable journal warning", status)
+	waitForDeletionRecoveryDone(t, recovery)
+	if !strings.Contains(logs.String(), "broken.json") {
+		t.Fatalf("recovery log = %q, want unreadable journal warning", logs.String())
 	}
 }
 
@@ -148,9 +124,7 @@ func TestDeletionRecoveryLifecycleEdges(t *testing.T) {
 		if err := recovery.Start(context.Background()); err != nil {
 			t.Fatalf("second Start returned error: %v", err)
 		}
-		waitForDeletionRecoveryStatus(t, recovery, func(status DeletionRecoveryStatus) bool {
-			return !status.InProgress
-		})
+		waitForDeletionRecoveryDone(t, recovery)
 	})
 
 	t.Run("shutdown honors deadline", func(t *testing.T) {
@@ -198,20 +172,38 @@ func writeDeletingRecoveryRecords(t *testing.T, root string, ids ...string) {
 	}
 }
 
-func waitForDeletionRecoveryStatus(t *testing.T, recovery *DeletionRecovery, ready func(DeletionRecoveryStatus) bool) DeletionRecoveryStatus {
+func waitForDeletionRecoveryDone(t *testing.T, recovery *DeletionRecovery) {
+	t.Helper()
+	recovery.mu.Lock()
+	done := recovery.done
+	recovery.mu.Unlock()
+	if done == nil {
+		t.Fatal("deletion recovery did not initialize its completion signal")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("deletion recovery did not finish")
+	}
+}
+
+func waitForRecoveryJournalRemoval(t *testing.T, root, sandboxID string) {
 	t.Helper()
 	deadline := time.NewTimer(time.Second)
 	defer deadline.Stop()
 	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
 	for {
-		status := recovery.Status()
-		if ready(status) {
-			return status
+		_, err := ReadOwnershipRecord(root, sandboxID)
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("read recovery journal %s: %v", sandboxID, err)
 		}
 		select {
 		case <-deadline.C:
-			t.Fatalf("deletion recovery status did not converge: %#v", status)
+			t.Fatalf("recovery journal %s was not removed", sandboxID)
 		case <-ticker.C:
 		}
 	}

--- a/pkg/sandboxes/deletion_recovery_test.go
+++ b/pkg/sandboxes/deletion_recovery_test.go
@@ -1,0 +1,274 @@
+package sandboxes
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestDeletionRecoveryRunsPendingDeletionsConcurrentlyAndStops(t *testing.T) {
+	root := t.TempDir()
+	writeDeletingRecoveryRecords(t, root, "a", "b")
+	runtime := &recoveryRuntime{
+		blockedID: "a",
+		started:   make(chan string, 2),
+		completed: make(chan string, 2),
+	}
+	recovery := newTestDeletionRecovery(root, runtime)
+	if err := recovery.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	wantStarted := map[string]bool{"a": false, "b": false}
+	for range wantStarted {
+		select {
+		case id := <-runtime.started:
+			wantStarted[id] = true
+		case <-time.After(time.Second):
+			t.Fatalf("recovery workers did not start both deletions: %v", wantStarted)
+		}
+	}
+	select {
+	case id := <-runtime.completed:
+		if id != "b" {
+			t.Fatalf("completed deletion = %q, want unblocked sandbox b", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("unblocked deletion waited behind blocked deletion")
+	}
+
+	status := waitForDeletionRecoveryStatus(t, recovery, func(status DeletionRecoveryStatus) bool {
+		return status.Completed == 1 && status.Remaining == 1
+	})
+	if !status.InProgress || status.Total != 2 || status.Failed != 0 {
+		t.Fatalf("Status = %#v, want one of two deletions completed", status)
+	}
+	if len(status.ActiveSandboxIDs) != 1 || status.ActiveSandboxIDs[0] != "a" {
+		t.Fatalf("active sandbox IDs = %v, want [a]", status.ActiveSandboxIDs)
+	}
+	status.ActiveSandboxIDs[0] = "mutated"
+	if got := recovery.Status().ActiveSandboxIDs; len(got) != 1 || got[0] != "a" {
+		t.Fatalf("Status returned shared active sandbox IDs: %v", got)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := recovery.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+	status = recovery.Status()
+	if status.InProgress || status.Completed != 1 || status.Failed != 0 || status.Remaining != 1 || len(status.ActiveSandboxIDs) != 0 {
+		t.Fatalf("Status after shutdown = %#v, want one durable deletion remaining without a failure", status)
+	}
+}
+
+func TestDeletionRecoveryReportsFailureAndRetriesOnNextInstance(t *testing.T) {
+	root := t.TempDir()
+	writeDeletingRecoveryRecords(t, root, "retry")
+	failedRuntime := &recoveryRuntime{failureID: "retry", started: make(chan string, 1), completed: make(chan string, 1)}
+	first := newTestDeletionRecovery(root, failedRuntime)
+	if err := first.Start(context.Background()); err != nil {
+		t.Fatalf("first Start returned error: %v", err)
+	}
+	failed := waitForDeletionRecoveryStatus(t, first, func(status DeletionRecoveryStatus) bool {
+		return !status.InProgress
+	})
+	if failed.Total != 1 || failed.Completed != 0 || failed.Failed != 1 || failed.Remaining != 1 {
+		t.Fatalf("failed recovery Status = %#v", failed)
+	}
+	if !strings.Contains(failed.LastError, "retry") || !strings.Contains(failed.LastError, "runtime removal failed") {
+		t.Fatalf("failed recovery last error = %q", failed.LastError)
+	}
+	if _, err := ReadOwnershipRecord(root, "retry"); err != nil {
+		t.Fatalf("failed deletion did not retain its journal: %v", err)
+	}
+
+	successRuntime := &recoveryRuntime{started: make(chan string, 1), completed: make(chan string, 1)}
+	second := newTestDeletionRecovery(root, successRuntime)
+	if err := second.Start(context.Background()); err != nil {
+		t.Fatalf("second Start returned error: %v", err)
+	}
+	succeeded := waitForDeletionRecoveryStatus(t, second, func(status DeletionRecoveryStatus) bool {
+		return !status.InProgress
+	})
+	if succeeded.Total != 1 || succeeded.Completed != 1 || succeeded.Failed != 0 || succeeded.Remaining != 0 || succeeded.LastError != "" {
+		t.Fatalf("retried recovery Status = %#v", succeeded)
+	}
+	if _, err := ReadOwnershipRecord(root, "retry"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("successful retry journal error = %v, want not exist", err)
+	}
+}
+
+func TestDeletionRecoveryReportsUnreadableJournal(t *testing.T) {
+	root := t.TempDir()
+	lifecycleRoot := LifecycleRoot(root)
+	if err := os.MkdirAll(lifecycleRoot, 0o700); err != nil {
+		t.Fatalf("create lifecycle root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(lifecycleRoot, "broken.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write broken lifecycle journal: %v", err)
+	}
+
+	recovery := newTestDeletionRecovery(root, &recoveryRuntime{})
+	if err := recovery.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	status := waitForDeletionRecoveryStatus(t, recovery, func(status DeletionRecoveryStatus) bool {
+		return !status.InProgress
+	})
+	if status.Total != 0 || status.Completed != 0 || status.Remaining != 0 || !strings.Contains(status.LastError, "broken.json") {
+		t.Fatalf("Status = %#v, want unreadable journal warning", status)
+	}
+}
+
+func TestDeletionRecoveryLifecycleEdges(t *testing.T) {
+	t.Run("missing coordinator", func(t *testing.T) {
+		recovery := NewDeletionRecovery(nil, discardRecoveryLogger())
+		if err := recovery.Start(context.Background()); err == nil {
+			t.Fatal("Start returned nil error without a coordinator")
+		}
+		if err := recovery.Shutdown(context.Background()); err != nil {
+			t.Fatalf("Shutdown before Start returned error: %v", err)
+		}
+	})
+
+	t.Run("start is idempotent", func(t *testing.T) {
+		recovery := newTestDeletionRecovery(t.TempDir(), &recoveryRuntime{})
+		if err := recovery.Start(context.Background()); err != nil {
+			t.Fatalf("first Start returned error: %v", err)
+		}
+		if err := recovery.Start(context.Background()); err != nil {
+			t.Fatalf("second Start returned error: %v", err)
+		}
+		waitForDeletionRecoveryStatus(t, recovery, func(status DeletionRecoveryStatus) bool {
+			return !status.InProgress
+		})
+	})
+
+	t.Run("shutdown honors deadline", func(t *testing.T) {
+		root := t.TempDir()
+		writeDeletingRecoveryRecords(t, root, "slow")
+		release := make(chan struct{})
+		runtime := &recoveryRuntime{blockedID: "slow", ignoreCancellation: true, release: release, started: make(chan string, 1)}
+		recovery := newTestDeletionRecovery(root, runtime)
+		if err := recovery.Start(context.Background()); err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+		select {
+		case <-runtime.started:
+		case <-time.After(time.Second):
+			t.Fatal("slow deletion did not start")
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		if err := recovery.Shutdown(shutdownCtx); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Shutdown error = %v, want deadline exceeded", err)
+		}
+		close(release)
+		if err := recovery.Shutdown(context.Background()); err != nil {
+			t.Fatalf("Shutdown after release returned error: %v", err)
+		}
+	})
+}
+
+func newTestDeletionRecovery(root string, runtime RemovalRuntime) *DeletionRecovery {
+	return NewDeletionRecovery(&RemovalCoordinator{
+		SandboxRoot: root,
+		Store:       recoveryStore{},
+		Runtime:     runtime,
+	}, discardRecoveryLogger())
+}
+
+func writeDeletingRecoveryRecords(t *testing.T, root string, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		if err := WriteOwnershipRecord(root, OwnershipRecord{
+			SandboxID: id, SandboxPath: filepath.Join(root, id), LifecycleState: "deleting",
+		}); err != nil {
+			t.Fatalf("write ownership record %s: %v", id, err)
+		}
+	}
+}
+
+func waitForDeletionRecoveryStatus(t *testing.T, recovery *DeletionRecovery, ready func(DeletionRecoveryStatus) bool) DeletionRecoveryStatus {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		status := recovery.Status()
+		if ready(status) {
+			return status
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("deletion recovery status did not converge: %#v", status)
+		case <-ticker.C:
+		}
+	}
+}
+
+func discardRecoveryLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type recoveryStore struct{}
+
+func (recoveryStore) GetSandbox(_ context.Context, id string) (*domain.Sandbox, error) {
+	return &domain.Sandbox{Summary: domain.SandboxSummary{ID: id}}, nil
+}
+
+func (recoveryStore) ListSandboxes(context.Context, domain.SandboxListOptions) (domain.SandboxListResult, error) {
+	return domain.SandboxListResult{}, nil
+}
+
+func (recoveryStore) UpdateSandbox(context.Context, *domain.Sandbox) error { return nil }
+func (recoveryStore) RemoveSandbox(context.Context, string) error          { return nil }
+
+type recoveryRuntime struct {
+	blockedID          string
+	failureID          string
+	ignoreCancellation bool
+	release            <-chan struct{}
+	started            chan string
+	completed          chan string
+}
+
+func (r *recoveryRuntime) StopSandboxVM(context.Context, *domain.Sandbox) error { return nil }
+
+func (r *recoveryRuntime) RemoveSandboxVM(ctx context.Context, sandbox *domain.Sandbox) error {
+	if sandbox == nil {
+		return errors.New("sandbox is nil")
+	}
+	if r.started != nil {
+		r.started <- sandbox.Summary.ID
+	}
+	if sandbox.Summary.ID == r.failureID {
+		return errors.New("runtime removal failed")
+	}
+	if sandbox.Summary.ID == r.blockedID {
+		if r.ignoreCancellation {
+			<-r.release
+		} else {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	}
+	if r.completed != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case r.completed <- sandbox.Summary.ID:
+		}
+	}
+	return nil
+}

--- a/scripts/test-agent-compose-daemon-startup.sh
+++ b/scripts/test-agent-compose-daemon-startup.sh
@@ -226,17 +226,11 @@ jq -e \
   'keys == ["data", "err", "msg"] and
    .err == null and
    .msg == "OK" and
-   (.data | keys) == ["arch", "compiled_drivers", "deletion_recovery", "os", "timestamp", "timezone", "timezone_offset", "version"] and
+   (.data | keys) == ["arch", "compiled_drivers", "os", "timestamp", "timezone", "timezone_offset", "version"] and
    .data.version == $version and
    .data.os == $os and
    .data.arch == $arch and
    .data.compiled_drivers == ($drivers | split(",")) and
-   (.data.deletion_recovery | keys) == ["completed", "failed", "in_progress", "remaining", "total"] and
-   (.data.deletion_recovery.in_progress | type == "boolean") and
-   .data.deletion_recovery.total == 0 and
-   .data.deletion_recovery.completed == 0 and
-   .data.deletion_recovery.failed == 0 and
-   .data.deletion_recovery.remaining == 0 and
    (.data.timestamp | type == "number" and . > 0) and
    (.data.timezone | type == "string" and length > 0) and
    (.data.timezone_offset | type == "number")' \

--- a/scripts/test-agent-compose-daemon-startup.sh
+++ b/scripts/test-agent-compose-daemon-startup.sh
@@ -226,11 +226,17 @@ jq -e \
   'keys == ["data", "err", "msg"] and
    .err == null and
    .msg == "OK" and
-   (.data | keys) == ["arch", "compiled_drivers", "os", "timestamp", "timezone", "timezone_offset", "version"] and
+   (.data | keys) == ["arch", "compiled_drivers", "deletion_recovery", "os", "timestamp", "timezone", "timezone_offset", "version"] and
    .data.version == $version and
    .data.os == $os and
    .data.arch == $arch and
    .data.compiled_drivers == ($drivers | split(",")) and
+   (.data.deletion_recovery | keys) == ["completed", "failed", "in_progress", "remaining", "total"] and
+   (.data.deletion_recovery.in_progress | type == "boolean") and
+   .data.deletion_recovery.total == 0 and
+   .data.deletion_recovery.completed == 0 and
+   .data.deletion_recovery.failed == 0 and
+   .data.deletion_recovery.remaining == 0 and
    (.data.timestamp | type == "number" and . > 0) and
    (.data.timezone | type == "string" and length > 0) and
    (.data.timezone_offset | type == "number")' \


### PR DESCRIPTION
## Problem

Daemon startup synchronously resumed every pending sandbox deletion before serving the control plane, so a slow workspace deletion made health, version, and CLI status requests hang.

## Solution

- Rebased onto current `main` and moved recovery under the owning `pkg/sandboxes` domain.
- Added an owned one-shot deletion recovery component with two bounded workers, cancellation, shutdown waiting, and explicit failure logging.
- Failed or canceled deletions retain their durable journals for a future daemon restart.
- Startup completes synchronous reconciliation before launching deletion recovery. Background recovery and cleanup are canceled and awaited concurrently during shutdown.
- `/api/version` keeps its existing response contract unchanged and remains responsive while deletion recovery runs in the background.
- `agent-compose status` now has a five-second timeout with an actionable timeout error.
- Updated the daemon startup smoke contract and the English and Chinese command manuals for the timeout behavior.

This intentionally implements only the background recovery and bounded status timeout needed to keep the control plane usable. It does not expose deletion recovery progress through `/api/version` or add a new public status API.

## Tests

- `go test ./pkg/sandboxes ./pkg/agentcompose/app ./cmd/agent-compose -count=1` — passed
- `go test -race ./pkg/sandboxes ./pkg/agentcompose/app ./cmd/agent-compose -run "Test(DeletionRecovery|StopBackground|StartBackgroundConstructsCleanupBeforeLoader|APIVersionContractUnchangedWhileDeletionRecoveryIsBlocked|FetchDaemonVersionHasBoundedStatusTimeout)" -count=1` — passed
- `task lint` — passed, 0 issues
- `task docs:build` — passed
- `task test:scripts` — passed

## Compatibility

A regression test starts a blocked deletion recovery and verifies that `/api/version` still responds promptly with exactly its legacy seven data fields and no `deletion_recovery` field.

Closes #436