### PR TITLE
fix(storage): make webhook event commits unambiguous

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ HTTP_LISTEN=0.0.0.0:7410
 AGENT_COMPOSE_AUTH_TOKEN=
 DATA_ROOT=/data
 # SANDBOX_ROOT=/data/sandboxes
+# Maximum runtime connections to the shared SQLite database. Startup migrations
+# always use one connection, and in-memory databases always remain single-connection.
+# SQLITE_MAX_OPEN_CONNS=4
 
 # Jupyter proxy base path. Keep this in sync with any external reverse proxy.
 JUPYTER_PROXY_BASE=/jupyter

--- a/cmd/agent-compose/cli_daemon_lifecycle_test.go
+++ b/cmd/agent-compose/cli_daemon_lifecycle_test.go
@@ -281,7 +281,7 @@ agents:
 		t.Fatalf("create test data root: %v", err)
 	}
 	storeConfig := &config.Config{DataRoot: dataRoot, DbAddr: filepath.Join(dataRoot, "data.db")}
-	database, err := storagesqlite.Open(storeConfig.DbAddr, storeConfig.DbTimeout)
+	database, err := storagesqlite.OpenWithMaxOpenConns(storeConfig.DbAddr, storeConfig.DbTimeout, storeConfig.EffectiveSQLiteMaxOpenConns())
 	if err != nil {
 		t.Fatalf("open test database: %v", err)
 	}

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -90,6 +90,20 @@ Without `env_file`, the CLI first looks for `.env` in the project directory, the
 
 Later files override earlier files, and the environment inherited by the CLI overrides every env file. Project env files are only used to render `agent-compose.yml`; they do not change CLI connection settings such as `--host` or authentication.
 
+### Daemon database concurrency
+
+The daemon uses one SQLite connection while applying startup migrations. After
+migration succeeds, a file-backed database uses up to four runtime connections
+by default so WAL readers can make progress alongside a writer. Set
+`SQLITE_MAX_OPEN_CONNS` to an integer from `1` through `32` to override that
+limit. In-memory SQLite databases always remain limited to one connection,
+regardless of the configured value.
+
+Increasing the limit enables more concurrent database operations but does not
+create additional SQLite writers: WAL still permits only one active writer.
+Values above the default should therefore be justified by observed connection
+wait time and tested under the deployment's write workload.
+
 ## Common Workflows
 
 Local development:

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -86,6 +86,17 @@ env_file:
 
 变量冲突时，后声明的 env 文件覆盖先声明的文件，启动 CLI 时已有的进程环境覆盖所有 env 文件。Project 环境文件只参与 `agent-compose.yml` 渲染，不会改变 `--host`、认证等 CLI 连接配置。
 
+### Daemon 数据库并发
+
+daemon 在启动 migration 期间只使用一个 SQLite 连接。migration 成功后，文件型
+数据库默认最多使用四个运行期连接，使 WAL reader 可以和 writer 并发推进。可以将
+`SQLITE_MAX_OPEN_CONNS` 设置为 `1` 到 `32` 之间的整数来覆盖该限制。无论配置值
+是多少，内存 SQLite 数据库始终限制为一个连接。
+
+增大连接数可以允许更多数据库操作并发执行，但不会增加 SQLite writer 数量：WAL
+仍然只允许一个活跃 writer。因此，只有在连接等待指标表明确有需要，并且已经用部署
+环境的写入负载验证后，才应设置高于默认值的连接数。
+
 ## 常见工作流
 
 本地开发：

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -437,7 +437,7 @@ func NewDatabase(di do.Injector) (*storagesqlite.Database, error) {
 	if err := os.MkdirAll(config.DataRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("create agent-compose data root: %w", err)
 	}
-	return storagesqlite.Open(config.DbAddr, config.DbTimeout)
+	return storagesqlite.OpenWithMaxOpenConns(config.DbAddr, config.DbTimeout, config.EffectiveSQLiteMaxOpenConns())
 }
 
 func NewConfigStore(di do.Injector) (*configstore.ConfigStore, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	DbAddr                     string
 	DbName                     string
 	DbTimeout                  time.Duration
+	SQLiteMaxOpenConns         int
 	DataRoot                   string
 	SandboxRoot                string
 	SandboxRootExplicit        bool
@@ -126,6 +127,10 @@ func NewConfig(di do.Injector) (*Config, error) {
 			dbTimeout = parsed
 			logger.Info("dbTimeout updated", "dbTimeout", dbTimeout)
 		}
+	}
+	sqliteMaxOpenConns, err := sqliteMaxOpenConnsFromEnvironment()
+	if err != nil {
+		return nil, err
 	}
 
 	sandboxRootExplicit := strings.TrimSpace(os.Getenv("SANDBOX_ROOT")) != "" || strings.TrimSpace(os.Getenv("SESSION_ROOT")) != ""
@@ -449,6 +454,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		DbAddr:                     dbPath,
 		DbName:                     dbName,
 		DbTimeout:                  dbTimeout,
+		SQLiteMaxOpenConns:         sqliteMaxOpenConns,
 		DataRoot:                   dataRoot,
 		SandboxRoot:                sandboxRoot,
 		SandboxRootExplicit:        sandboxRootExplicit,

--- a/pkg/config/sqlite.go
+++ b/pkg/config/sqlite.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	storagesqlite "agent-compose/pkg/storage/sqlite"
+)
+
+const (
+	DefaultSQLiteMaxOpenConns = storagesqlite.DefaultMaxOpenConns
+	maxSQLiteMaxOpenConns     = 32
+)
+
+func sqliteMaxOpenConnsFromEnvironment() (int, error) {
+	raw := strings.TrimSpace(os.Getenv("SQLITE_MAX_OPEN_CONNS"))
+	if raw == "" {
+		return DefaultSQLiteMaxOpenConns, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 1 || value > maxSQLiteMaxOpenConns {
+		return 0, fmt.Errorf("SQLITE_MAX_OPEN_CONNS must be an integer between 1 and %d", maxSQLiteMaxOpenConns)
+	}
+	return value, nil
+}
+
+// EffectiveSQLiteMaxOpenConns returns the configured runtime connection
+// limit. The fallback keeps manually constructed Config values aligned with
+// the daemon default.
+func (c *Config) EffectiveSQLiteMaxOpenConns() int {
+	if c == nil || c.SQLiteMaxOpenConns == 0 {
+		return DefaultSQLiteMaxOpenConns
+	}
+	return c.SQLiteMaxOpenConns
+}

--- a/pkg/config/sqlite_test.go
+++ b/pkg/config/sqlite_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/samber/do/v2"
+)
+
+func TestNewConfigSQLiteMaxOpenConns(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{name: "default", want: DefaultSQLiteMaxOpenConns},
+		{name: "configured", value: "8", want: 8},
+		{name: "minimum", value: "1", want: 1},
+		{name: "maximum", value: "32", want: 32},
+		{name: "zero", value: "0", wantErr: true},
+		{name: "above maximum", value: "33", wantErr: true},
+		{name: "not an integer", value: "many", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("DATA_ROOT", filepath.Join(t.TempDir(), "data"))
+			t.Setenv("SQLITE_MAX_OPEN_CONNS", test.value)
+			di := do.New()
+			do.ProvideValue(di, slog.Default())
+
+			config, err := NewConfig(di)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("NewConfig returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewConfig returned error: %v", err)
+			}
+			if config.SQLiteMaxOpenConns != test.want {
+				t.Fatalf("SQLiteMaxOpenConns = %d, want %d", config.SQLiteMaxOpenConns, test.want)
+			}
+		})
+	}
+}
+
+func TestConfigEffectiveSQLiteMaxOpenConnsDefaultsConstructedValues(t *testing.T) {
+	if got := (&Config{}).EffectiveSQLiteMaxOpenConns(); got != DefaultSQLiteMaxOpenConns {
+		t.Fatalf("EffectiveSQLiteMaxOpenConns = %d, want %d", got, DefaultSQLiteMaxOpenConns)
+	}
+	if got := (&Config{SQLiteMaxOpenConns: 7}).EffectiveSQLiteMaxOpenConns(); got != 7 {
+		t.Fatalf("EffectiveSQLiteMaxOpenConns = %d, want 7", got)
+	}
+}

--- a/pkg/events/webhooks/coverage_shape_workflows_test.go
+++ b/pkg/events/webhooks/coverage_shape_workflows_test.go
@@ -281,13 +281,6 @@ func (s *webhookRouteStore) CreateEvent(_ context.Context, event domain.TopicEve
 	return event, nil
 }
 
-func (s *webhookRouteStore) UpdateEventPayload(_ context.Context, eventID, payloadJSON string) error {
-	event := s.events[eventID]
-	event.PayloadJSON = payloadJSON
-	s.events[eventID] = event
-	return nil
-}
-
 func (s *webhookRouteStore) GetEvent(_ context.Context, eventID string) (domain.TopicEventRecord, error) {
 	event, ok := s.events[eventID]
 	if !ok {

--- a/pkg/events/webhooks/http.go
+++ b/pkg/events/webhooks/http.go
@@ -18,7 +18,6 @@ import (
 type Store interface {
 	FindEventByIdempotencyKey(context.Context, string, string) (domain.TopicEventRecord, bool, error)
 	CreateEvent(context.Context, domain.TopicEventRecord) (domain.TopicEventRecord, error)
-	UpdateEventPayload(context.Context, string, string) error
 	GetEvent(context.Context, string) (domain.TopicEventRecord, error)
 	ListEvents(context.Context, domain.TopicEventFilter) ([]domain.TopicEventRecord, error)
 	ListDescendantEventIDs(context.Context, string, int) ([]string, error)
@@ -145,25 +144,6 @@ func (h routeHandler) handleWebhook(c echo.Context) error {
 			return c.JSON(http.StatusConflict, map[string]string{"error": "idempotency key conflicts with existing payload"})
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to store webhook event"})
-	}
-	if created.ID != eventID {
-		return c.JSON(http.StatusAccepted, AcceptedResponse{
-			Accepted:      true,
-			Topic:         created.Topic,
-			EventID:       created.ID,
-			Sequence:      created.Sequence,
-			CorrelationID: created.CorrelationID,
-		})
-	}
-	if created.Sequence != 0 {
-		payload = BuildPayload(c.Request(), created.ID, created.Sequence, topic, created.CorrelationID, created.IdempotencyKey, source, body)
-		payloadJSON, err = h.marshalJSONCompact(payload)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to encode webhook payload"})
-		}
-		if err := h.store().UpdateEventPayload(c.Request().Context(), created.ID, payloadJSON); err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to store webhook event payload"})
-		}
 	}
 	return c.JSON(http.StatusAccepted, AcceptedResponse{
 		Accepted:      true,

--- a/pkg/events/webhooks/http_commit_test.go
+++ b/pkg/events/webhooks/http_commit_test.go
@@ -1,0 +1,53 @@
+package webhooks
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestWebhookReturnsAcceptedWhenContextIsCanceledAfterEventCommit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &cancelAfterCreateWebhookStore{
+		webhookRouteStore: newWebhookRouteStore(),
+		cancel:            cancel,
+	}
+	app := echo.New()
+	RegisterRoutes(app, RouteOptions{
+		Store:            store,
+		WebhookBodyLimit: 1 << 20,
+		NewEventID:       func() string { return "event-committed" },
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", strings.NewReader(`{"intent":"push"}`)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook status = %d body=%s, want %d", rec.Code, rec.Body.String(), http.StatusAccepted)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("committed events = %d, want 1", len(store.events))
+	}
+}
+
+type cancelAfterCreateWebhookStore struct {
+	*webhookRouteStore
+	cancel context.CancelFunc
+}
+
+func (s *cancelAfterCreateWebhookStore) CreateEvent(ctx context.Context, event domain.TopicEventRecord) (domain.TopicEventRecord, error) {
+	created, err := s.webhookRouteStore.CreateEvent(ctx, event)
+	if err == nil {
+		s.cancel()
+	}
+	return created, err
+}

--- a/pkg/internal/testutil/storage.go
+++ b/pkg/internal/testutil/storage.go
@@ -50,7 +50,7 @@ func openDatabase(t testing.TB, config *appconfig.Config) (*storagesqlite.Databa
 	if err := os.MkdirAll(config.DataRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("create test data root: %w", err)
 	}
-	database, err := storagesqlite.Open(config.DbAddr, config.DbTimeout)
+	database, err := storagesqlite.OpenWithMaxOpenConns(config.DbAddr, config.DbTimeout, config.EffectiveSQLiteMaxOpenConns())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/configstore/topic_event_create.go
+++ b/pkg/storage/configstore/topic_event_create.go
@@ -1,0 +1,148 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+func (s *eventStore) CreateEvent(ctx context.Context, item domain.TopicEventRecord) (domain.TopicEventRecord, error) {
+	normalized, err := normalizeTopicEventRecord(item, true)
+	if err != nil {
+		return domain.TopicEventRecord{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return domain.TopicEventRecord{}, fmt.Errorf("begin event transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result, err := insertTopicEvent(ctx, tx, normalized)
+	if err != nil {
+		_ = tx.Rollback()
+		return s.resolveTopicEventInsertError(ctx, normalized, err)
+	}
+	sequence, err := result.LastInsertId()
+	if err != nil {
+		return domain.TopicEventRecord{}, fmt.Errorf("read event sequence: %w", err)
+	}
+	normalized.Sequence = sequence
+	if err := storeSequencedTopicEventPayload(ctx, tx, &normalized); err != nil {
+		return domain.TopicEventRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.TopicEventRecord{}, fmt.Errorf("commit event: %w", err)
+	}
+	return normalized, nil
+}
+
+func insertTopicEvent(ctx context.Context, tx *sql.Tx, item domain.TopicEventRecord) (sql.Result, error) {
+	return tx.ExecContext(ctx, `INSERT INTO event(
+		id, topic, source, provider, intent, correlation_id, idempotency_key, delivery_id, payload_hash, payload_json,
+		dispatch_status, parent_event_id, publisher_type, publisher_id, publisher_run_id, replay_of_event_id,
+		claim_id, claim_until, attempt_count, next_attempt_at, last_error, dead_letter_at, created_at, dispatched_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		item.ID,
+		item.Topic,
+		item.Source,
+		item.Provider,
+		item.Intent,
+		item.CorrelationID,
+		item.IdempotencyKey,
+		item.DeliveryID,
+		item.PayloadHash,
+		item.PayloadJSON,
+		item.DispatchStatus,
+		item.ParentEventID,
+		item.PublisherType,
+		item.PublisherID,
+		item.PublisherRunID,
+		item.ReplayOfEventID,
+		item.ClaimID,
+		domain.NonZeroTimeUnixMilli(item.ClaimUntil),
+		item.AttemptCount,
+		domain.NonZeroTimeUnixMilli(item.NextAttemptAt),
+		item.LastError,
+		domain.NonZeroTimeUnixMilli(item.DeadLetterAt),
+		item.CreatedAt.UnixMilli(),
+		domain.NonZeroTimeUnixMilli(item.DispatchedAt),
+	)
+}
+
+func (s *eventStore) resolveTopicEventInsertError(ctx context.Context, item domain.TopicEventRecord, insertErr error) (domain.TopicEventRecord, error) {
+	if item.IdempotencyKey != "" {
+		if existing, ok, lookupErr := s.FindEventByIdempotencyKey(ctx, item.Topic, item.IdempotencyKey); lookupErr != nil {
+			return domain.TopicEventRecord{}, lookupErr
+		} else if ok {
+			itemPayloadHash, hashErr := topicEventPayloadHashForSequence(item.PayloadJSON, item.PayloadHash, existing.Sequence)
+			if hashErr != nil {
+				return domain.TopicEventRecord{}, fmt.Errorf("sequence duplicate event payload: %w", hashErr)
+			}
+			if existing.PayloadHash != itemPayloadHash {
+				return domain.TopicEventRecord{}, domain.ResourceError(domain.ErrConflict, "event", item.Topic, fmt.Sprintf("event idempotency conflict for topic %q", item.Topic), nil)
+			}
+			return existing, nil
+		}
+	}
+	return domain.TopicEventRecord{}, fmt.Errorf("insert event %s: %w", item.ID, insertErr)
+}
+
+func storeSequencedTopicEventPayload(ctx context.Context, tx *sql.Tx, item *domain.TopicEventRecord) error {
+	sequencedPayload, changed, err := topicEventPayloadWithSequence(item.PayloadJSON, item.Sequence)
+	if err != nil {
+		return fmt.Errorf("sequence event payload: %w", err)
+	}
+	if !changed {
+		return nil
+	}
+	item.PayloadJSON = sequencedPayload
+	item.PayloadHash = domain.TopicEventPayloadSHA256(sequencedPayload)
+	update, err := tx.ExecContext(ctx, `UPDATE event SET payload_hash = ?, payload_json = ? WHERE id = ?`, item.PayloadHash, item.PayloadJSON, item.ID)
+	if err != nil {
+		return fmt.Errorf("store sequenced event payload: %w", err)
+	}
+	updated, err := update.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read sequenced event update count: %w", err)
+	}
+	if updated != 1 {
+		return fmt.Errorf("updated %d sequenced events, want 1", updated)
+	}
+	return nil
+}
+
+func topicEventPayloadWithSequence(payloadJSON string, sequence int64) (string, bool, error) {
+	trimmed := strings.TrimSpace(payloadJSON)
+	if trimmed == "" || trimmed[0] != '{' {
+		return payloadJSON, false, nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return "", false, err
+	}
+	if _, ok := payload["sequence"]; !ok {
+		return payloadJSON, false, nil
+	}
+	payload["sequence"] = json.RawMessage(strconv.FormatInt(sequence, 10))
+	sequenced, err := domain.MarshalJSONCompact(payload)
+	if err != nil {
+		return "", false, err
+	}
+	return sequenced, sequenced != payloadJSON, nil
+}
+
+func topicEventPayloadHashForSequence(payloadJSON, payloadHash string, sequence int64) (string, error) {
+	sequencedPayload, changed, err := topicEventPayloadWithSequence(payloadJSON, sequence)
+	if err != nil {
+		return "", err
+	}
+	if !changed {
+		return payloadHash, nil
+	}
+	return domain.TopicEventPayloadSHA256(sequencedPayload), nil
+}

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -16,62 +16,6 @@ type eventStore struct {
 	db *sql.DB
 }
 
-func (s *eventStore) CreateEvent(ctx context.Context, item domain.TopicEventRecord) (domain.TopicEventRecord, error) {
-	normalized, err := normalizeTopicEventRecord(item, true)
-	if err != nil {
-		return domain.TopicEventRecord{}, err
-	}
-	result, err := s.db.ExecContext(ctx, `INSERT INTO event(
-		id, topic, source, provider, intent, correlation_id, idempotency_key, delivery_id, payload_hash, payload_json,
-		dispatch_status, parent_event_id, publisher_type, publisher_id, publisher_run_id, replay_of_event_id,
-		claim_id, claim_until, attempt_count, next_attempt_at, last_error, dead_letter_at, created_at, dispatched_at
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		normalized.ID,
-		normalized.Topic,
-		normalized.Source,
-		normalized.Provider,
-		normalized.Intent,
-		normalized.CorrelationID,
-		normalized.IdempotencyKey,
-		normalized.DeliveryID,
-		normalized.PayloadHash,
-		normalized.PayloadJSON,
-		normalized.DispatchStatus,
-		normalized.ParentEventID,
-		normalized.PublisherType,
-		normalized.PublisherID,
-		normalized.PublisherRunID,
-		normalized.ReplayOfEventID,
-		normalized.ClaimID,
-		domain.NonZeroTimeUnixMilli(normalized.ClaimUntil),
-		normalized.AttemptCount,
-		domain.NonZeroTimeUnixMilli(normalized.NextAttemptAt),
-		normalized.LastError,
-		domain.NonZeroTimeUnixMilli(normalized.DeadLetterAt),
-		normalized.CreatedAt.UnixMilli(),
-		domain.NonZeroTimeUnixMilli(normalized.DispatchedAt),
-	)
-	if err != nil {
-		if normalized.IdempotencyKey != "" {
-			if existing, ok, lookupErr := s.FindEventByIdempotencyKey(ctx, normalized.Topic, normalized.IdempotencyKey); lookupErr != nil {
-				return domain.TopicEventRecord{}, lookupErr
-			} else if ok {
-				if existing.PayloadHash != normalized.PayloadHash {
-					return domain.TopicEventRecord{}, domain.ResourceError(domain.ErrConflict, "event", normalized.Topic, fmt.Sprintf("event idempotency conflict for topic %q", normalized.Topic), nil)
-				}
-				return existing, nil
-			}
-		}
-		return domain.TopicEventRecord{}, fmt.Errorf("insert event %s: %w", normalized.ID, err)
-	}
-	sequence, err := result.LastInsertId()
-	if err != nil {
-		return domain.TopicEventRecord{}, fmt.Errorf("read event sequence: %w", err)
-	}
-	normalized.Sequence = sequence
-	return s.GetEvent(ctx, normalized.ID)
-}
-
 func (s *eventStore) GetEvent(ctx context.Context, eventID string) (domain.TopicEventRecord, error) {
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {

--- a/pkg/storage/configstore/topic_event_store_test.go
+++ b/pkg/storage/configstore/topic_event_store_test.go
@@ -1,0 +1,168 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+	storagesqlite "agent-compose/pkg/storage/sqlite"
+
+	modernsqlite "modernc.org/sqlite"
+)
+
+func TestTopicEventPayloadWithSequencePreservesRawBodyValues(t *testing.T) {
+	payload := `{"sequence":0,"body":{"large":9007199254740993}}`
+	sequenced, changed, err := topicEventPayloadWithSequence(payload, 7)
+	if err != nil {
+		t.Fatalf("topicEventPayloadWithSequence returned error: %v", err)
+	}
+	if !changed || sequenced != `{"body":{"large":9007199254740993},"sequence":7}` {
+		t.Fatalf("topicEventPayloadWithSequence = %s changed=%v", sequenced, changed)
+	}
+
+	plain := `{"body":{"large":9007199254740993}}`
+	sequenced, changed, err = topicEventPayloadWithSequence(plain, 7)
+	if err != nil || changed || sequenced != plain {
+		t.Fatalf("payload without sequence = %s changed=%v err=%v", sequenced, changed, err)
+	}
+}
+
+func TestCreateEventAcceptsIdempotentPayloadWithSequencePlaceholder(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	item := domain.TopicEventRecord{
+		ID:             "event-original",
+		Topic:          "webhook.github.push",
+		Source:         domain.TopicEventSourceWebhook,
+		IdempotencyKey: "delivery-1",
+		PayloadJSON:    `{"sequence":0,"body":{"branch":"main"}}`,
+		DispatchStatus: domain.TopicEventDispatchPending,
+	}
+	created, err := store.CreateEvent(ctx, item)
+	if err != nil {
+		t.Fatalf("create original event: %v", err)
+	}
+
+	item.ID = "event-duplicate"
+	duplicate, err := store.CreateEvent(ctx, item)
+	if err != nil {
+		t.Fatalf("create idempotent duplicate: %v", err)
+	}
+	if duplicate.ID != created.ID || duplicate.PayloadHash != created.PayloadHash {
+		t.Fatalf("duplicate = %#v, want original %#v", duplicate, created)
+	}
+}
+
+func TestCreateEventReturnsSequencedRecordWhenContextIsCanceledAfterCommit(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "events.db")
+	setup, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatalf("open setup database: %v", err)
+	}
+	if err := storagesqlite.Migrate(context.Background(), setup); err != nil {
+		_ = setup.Close()
+		t.Fatalf("migrate setup database: %v", err)
+	}
+	if err := setup.Close(); err != nil {
+		t.Fatalf("close setup database: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	driverName := "sqlite_cancel_after_event_commit:" + databasePath
+	sql.Register(driverName, &cancelAfterEventCommitDriver{
+		delegate: &modernsqlite.Driver{},
+		cancel:   cancel,
+	})
+	database, err := sql.Open(driverName, databasePath)
+	if err != nil {
+		t.Fatalf("open instrumented database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close instrumented database: %v", err)
+		}
+	})
+
+	created, err := FromDB(database).CreateEvent(ctx, domain.TopicEventRecord{
+		ID:             "event-committed",
+		Topic:          "webhook.github.push",
+		Source:         domain.TopicEventSourceWebhook,
+		PayloadJSON:    `{"sequence":0,"body":{"branch":"main"}}`,
+		DispatchStatus: domain.TopicEventDispatchPending,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent returned error after commit: %v", err)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("context was not canceled after COMMIT")
+	}
+	if created.ID != "event-committed" || created.Sequence == 0 {
+		t.Fatalf("CreateEvent returned %#v", created)
+	}
+	wantSequence := `"sequence":` + strconv.FormatInt(created.Sequence, 10)
+	if !strings.Contains(created.PayloadJSON, wantSequence) {
+		t.Fatalf("CreateEvent payload = %s, want %s", created.PayloadJSON, wantSequence)
+	}
+
+	var storedPayload string
+	if err := database.QueryRowContext(context.Background(), `SELECT payload_json FROM event WHERE id = ?`, created.ID).Scan(&storedPayload); err != nil {
+		t.Fatalf("query committed event: %v", err)
+	}
+	if storedPayload != created.PayloadJSON {
+		t.Fatalf("stored payload = %s, want %s", storedPayload, created.PayloadJSON)
+	}
+}
+
+type cancelAfterEventCommitDriver struct {
+	delegate driver.Driver
+	cancel   context.CancelFunc
+	once     sync.Once
+}
+
+func (d *cancelAfterEventCommitDriver) Open(name string) (driver.Conn, error) {
+	connection, err := d.delegate.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &cancelAfterEventCommitConn{Conn: connection, owner: d}, nil
+}
+
+type cancelAfterEventCommitConn struct {
+	driver.Conn
+	owner *cancelAfterEventCommitDriver
+}
+
+func (c *cancelAfterEventCommitConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	beginner, ok := c.Conn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	transaction, err := beginner.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &cancelAfterEventCommitTx{Tx: transaction, owner: c.owner}, nil
+}
+
+type cancelAfterEventCommitTx struct {
+	driver.Tx
+	owner *cancelAfterEventCommitDriver
+}
+
+func (t *cancelAfterEventCommitTx) Commit() error {
+	if err := t.Tx.Commit(); err != nil {
+		return err
+	}
+	t.owner.once.Do(t.owner.cancel)
+	return nil
+}

--- a/pkg/storage/sessionstore/store.go
+++ b/pkg/storage/sessionstore/store.go
@@ -86,7 +86,7 @@ func NewWithConfig(config *appconfig.Config) (*Store, error) {
 	if dbPath == "" {
 		dbPath = filepath.Join(config.SandboxRoot, "data.db")
 	}
-	database, err := storagesqlite.Open(dbPath, config.DbTimeout)
+	database, err := storagesqlite.OpenWithMaxOpenConns(dbPath, config.DbTimeout, config.EffectiveSQLiteMaxOpenConns())
 	if err != nil {
 		return newStoreWithIndex(config, nil, dbPath, err, nil)
 	}

--- a/pkg/storage/sqlite/database.go
+++ b/pkg/storage/sqlite/database.go
@@ -6,13 +6,19 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
 )
 
-const defaultBusyTimeout = 16 * time.Second
+const (
+	defaultBusyTimeout = 16 * time.Second
+
+	// DefaultMaxOpenConns is the runtime connection limit used by Open.
+	DefaultMaxOpenConns = 4
+)
 
 // Database owns the application's shared SQLite connection. All storage
 // facades receive DB() and must not close it themselves.
@@ -25,6 +31,18 @@ type Database struct {
 // Open opens and migrates one application database. The returned Database owns
 // the connection and must be closed by its composition root.
 func Open(path string, busyTimeout time.Duration) (*Database, error) {
+	return OpenWithMaxOpenConns(path, busyTimeout, DefaultMaxOpenConns)
+}
+
+// OpenWithMaxOpenConns opens and migrates one application database, then applies
+// the provided runtime connection limit.
+func OpenWithMaxOpenConns(path string, busyTimeout time.Duration, runtimeMaxOpenConns int) (*Database, error) {
+	if runtimeMaxOpenConns <= 0 {
+		return nil, fmt.Errorf("SQLite maximum open connections must be positive")
+	}
+	if isMemoryDatabase(path) {
+		runtimeMaxOpenConns = 1
+	}
 	db, err := sql.Open("sqlite", sqliteDSN(path, busyTimeout))
 	if err != nil {
 		return nil, fmt.Errorf("open SQLite database: %w", err)
@@ -43,7 +61,21 @@ func Open(path string, busyTimeout time.Duration) (*Database, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	db.SetMaxOpenConns(runtimeMaxOpenConns)
+	db.SetMaxIdleConns(runtimeMaxOpenConns)
 	return &Database{db: db}, nil
+}
+
+func isMemoryDatabase(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == ":memory:" {
+		return true
+	}
+	uri, err := url.Parse(path)
+	if err != nil || uri.Scheme != "file" {
+		return false
+	}
+	return uri.Opaque == ":memory:" || uri.Path == ":memory:" || strings.EqualFold(uri.Query().Get("mode"), "memory")
 }
 
 // DB returns the shared connection. Database retains ownership; callers must

--- a/pkg/storage/sqlite/database_pool_test.go
+++ b/pkg/storage/sqlite/database_pool_test.go
@@ -1,0 +1,93 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestOpenUsesDefaultRuntimeConnectionLimitAfterMigration(t *testing.T) {
+	database, err := Open(filepath.Join(t.TempDir(), "data.db"), 0)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+
+	if got := database.DB().Stats().MaxOpenConnections; got != DefaultMaxOpenConns {
+		t.Fatalf("MaxOpenConnections = %d, want %d", got, DefaultMaxOpenConns)
+	}
+	if err := database.DB().QueryRowContext(context.Background(), `SELECT count(*) FROM schema_migrations`).Scan(new(int)); err != nil {
+		t.Fatalf("query migrated schema: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	connections := make([]*sql.Conn, 0, DefaultMaxOpenConns)
+	for range DefaultMaxOpenConns {
+		connection, err := database.DB().Conn(ctx)
+		if err != nil {
+			t.Fatalf("acquire runtime connection: %v", err)
+		}
+		connections = append(connections, connection)
+	}
+	for _, connection := range connections {
+		if err := connection.Close(); err != nil {
+			t.Errorf("release runtime connection: %v", err)
+		}
+	}
+}
+
+func TestOpenWithMaxOpenConnsUsesConfiguredLimit(t *testing.T) {
+	database, err := OpenWithMaxOpenConns(filepath.Join(t.TempDir(), "configured.db"), 0, 7)
+	if err != nil {
+		t.Fatalf("OpenWithMaxOpenConns returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+
+	if got := database.DB().Stats().MaxOpenConnections; got != 7 {
+		t.Fatalf("MaxOpenConnections = %d, want 7", got)
+	}
+}
+
+func TestOpenKeepsMemoryDatabaseOnOneConnection(t *testing.T) {
+	for _, path := range []string{
+		":memory:",
+		"file::memory:?cache=shared",
+		"file:test-memory?mode=memory&cache=shared",
+	} {
+		t.Run(path, func(t *testing.T) {
+			database, err := Open(path, 0)
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			t.Cleanup(func() {
+				if err := database.Close(); err != nil {
+					t.Errorf("close database: %v", err)
+				}
+			})
+
+			if got := database.DB().Stats().MaxOpenConnections; got != 1 {
+				t.Fatalf("MaxOpenConnections = %d, want 1", got)
+			}
+			if err := database.DB().QueryRowContext(context.Background(), `SELECT count(*) FROM schema_migrations`).Scan(new(int)); err != nil {
+				t.Fatalf("query migrated schema: %v", err)
+			}
+		})
+	}
+}
+
+func TestOpenRejectsNonPositiveRuntimeConnectionLimit(t *testing.T) {
+	if _, err := OpenWithMaxOpenConns(filepath.Join(t.TempDir(), "data.db"), 0, 0); err == nil {
+		t.Fatal("OpenWithMaxOpenConns returned nil error")
+	}
+}


### PR DESCRIPTION
## Summary

- make the file-backed SQLite runtime pool configurable through `SQLITE_MAX_OPEN_CONNS`, defaulting to 4 while keeping migrations and in-memory databases on one connection
- finalize event sequence, payload, and payload hash in one transaction so dispatchers cannot observe a pending event with `sequence: 0`
- return the committed event directly and remove the webhook handler's post-commit read/write path, avoiding HTTP 500 after a successful commit
- preserve large JSON integers and idempotent retries while finalizing payload sequences

Fixes #439

## Testing

- `go test ./...` (run against the exact staged snapshot in a temporary worktree)
- `go test -count=2 -race ./pkg/storage/configstore ./pkg/events/webhooks ./pkg/loaders`
- `task lint`
- `task build`
- `task docs:build`

`task test` was not run because this macOS host does not provide GNU `sha256sum`; the complete Go suite was run directly as listed above.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
