### PR TITLE
fix(runs): separate agent messages from execution activity

### DIFF
--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -364,7 +364,7 @@ After the `prompt` subcommand completes successfully, stdout contains one
 structured result line:
 
 ```text
-__AGENT_RESULT__{"provider":"codex","threadId":"...","stopReason":"completed","finalText":"...","transcript":"...","stderr":""}
+__AGENT_RESULT__{"provider":"codex","threadId":"...","stopReason":"completed","finalText":"...","finalTextSource":"provider_message","transcript":"...","stderr":""}
 ```
 
 Fixed prefix:
@@ -381,8 +381,14 @@ JSON fields:
 | `threadId` | string | agent-compose thread id; adapters map provider-native resume ids into this field |
 | `stopReason` | string | Stop reason, usually `completed` |
 | `finalText` | string | Final response text |
+| `finalTextSource` | string | `provider_message` when the provider emitted a final assistant response, `transcript_fallback` when compatibility fallback copied the transcript, or `none` when no text is available |
 | `transcript` | string | Aggregated human-readable transcript |
 | `stderr` | string | Reserved field; currently empty for most providers |
+
+Consumers that create conversation messages must only use `finalText` when
+`finalTextSource` is `provider_message`. A transcript fallback remains available
+for compatibility and diagnostics, but represents execution activity rather
+than an assistant-authored response.
 
 The host parser searches backward from the last stdout line for the payload. If
 stdout does not contain it, the parser also searches merged output. The parser is

--- a/pkg/agentcompose/adapters/agent_executor.go
+++ b/pkg/agentcompose/adapters/agent_executor.go
@@ -253,7 +253,7 @@ func (e *AgentExecutor) ExecuteAgentRequest(ctx context.Context, session *domain
 		e.streams.PublishCellCompleted(session.Summary.ID, cellSnapshot)
 	}
 
-	assistantEvent := domain.SandboxEvent{ID: uuid.NewString(), Type: "agent.assistant", Level: "info", CreatedAt: time.Now().UTC(), Message: summarizeAgentResult(result)}
+	assistantEvent := domain.SandboxEvent{ID: uuid.NewString(), Type: "agent.assistant", Level: "info", CreatedAt: time.Now().UTC(), Message: agentAssistantMessage(result)}
 	if !cellSnapshot.Success {
 		assistantEvent.Type = "agent.assistant.failed"
 		assistantEvent.Level = "error"
@@ -287,13 +287,12 @@ func cloneSessionForAgentExecution(session *domain.Sandbox, providerEnvItems []d
 	return &execSession
 }
 
-func summarizeAgentResult(result domain.AgentRunResult) string {
-	body := firstNonEmpty(result.FinalText, result.DisplayOutput, result.Transcript)
-	if strings.TrimSpace(body) == "" {
-		if result.Success {
-			return fmt.Sprintf("%s finished without output", result.Agent)
-		}
+func agentAssistantMessage(result domain.AgentRunResult) string {
+	if finalText := strings.TrimSpace(result.FinalText); finalText != "" && result.FinalTextSource == domain.AgentFinalTextSourceProviderMessage {
+		return finalText
+	}
+	if !result.Success {
 		return fmt.Sprintf("%s failed without output", result.Agent)
 	}
-	return body
+	return ""
 }

--- a/pkg/agentcompose/adapters/agent_executor_test.go
+++ b/pkg/agentcompose/adapters/agent_executor_test.go
@@ -87,6 +87,28 @@ func TestAgentExecutorExecuteAgentRequestPersistsCellAndEvents(t *testing.T) {
 	}
 }
 
+func TestAgentAssistantMessageExcludesTranscriptFallback(t *testing.T) {
+	transcript := "$ command\ntool output"
+	if got := agentAssistantMessage(domain.AgentRunResult{
+		Agent:           "codex",
+		FinalText:       transcript,
+		FinalTextSource: domain.AgentFinalTextSourceTranscriptFallback,
+		Transcript:      transcript,
+		Success:         true,
+	}); got != "" {
+		t.Fatalf("fallback summary = %q, want empty", got)
+	}
+	if got := agentAssistantMessage(domain.AgentRunResult{
+		Agent:           "codex",
+		FinalText:       "final answer",
+		FinalTextSource: domain.AgentFinalTextSourceProviderMessage,
+		Transcript:      transcript + "\nfinal answer",
+		Success:         true,
+	}); got != "final answer" {
+		t.Fatalf("provider summary = %q", got)
+	}
+}
+
 func TestAgentExecutorStreamsOnlyHumanVisibleAgentOutput(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()

--- a/pkg/execution/parse.go
+++ b/pkg/execution/parse.go
@@ -14,13 +14,14 @@ const (
 )
 
 type agentExecResponse struct {
-	Provider   string `json:"provider"`
-	ThreadID   string `json:"threadId"`
-	StopReason string `json:"stopReason"`
-	FinalText  string `json:"finalText"`
-	JSON       any    `json:"json"`
-	Transcript string `json:"transcript"`
-	Stderr     string `json:"stderr"`
+	Provider        string `json:"provider"`
+	ThreadID        string `json:"threadId"`
+	StopReason      string `json:"stopReason"`
+	FinalText       string `json:"finalText"`
+	FinalTextSource string `json:"finalTextSource"`
+	JSON            any    `json:"json"`
+	Transcript      string `json:"transcript"`
+	Stderr          string `json:"stderr"`
 }
 
 func ParseAgentExecResult(agent string, result domain.ExecResult) (domain.AgentRunResult, error) {
@@ -47,17 +48,44 @@ func ParseAgentExecResult(agent string, result domain.ExecResult) (domain.AgentR
 	} else if strings.TrimSpace(humanOutput) == "" {
 		humanOutput = strings.TrimSpace(payload.FinalText)
 	}
+	finalText := strings.TrimSpace(payload.FinalText)
+	transcript := strings.TrimSpace(payload.Transcript)
 	return domain.AgentRunResult{
-		Agent:         firstNonEmpty(strings.TrimSpace(payload.Provider), domain.NormalizeAgentKind(agent)),
-		DisplayOutput: humanOutput,
-		FinalText:     strings.TrimSpace(payload.FinalText),
-		JSONText:      strings.TrimSpace(payload.FinalText),
-		Transcript:    strings.TrimSpace(payload.Transcript),
-		ThreadID:      strings.TrimSpace(payload.ThreadID),
-		StopReason:    strings.TrimSpace(payload.StopReason),
-		ExitCode:      result.ExitCode,
-		Success:       result.Success,
+		Agent:           firstNonEmpty(strings.TrimSpace(payload.Provider), domain.NormalizeAgentKind(agent)),
+		DisplayOutput:   humanOutput,
+		FinalText:       finalText,
+		FinalTextSource: normalizeFinalTextSource(payload.FinalTextSource, finalText, transcript),
+		JSONText:        finalText,
+		Transcript:      transcript,
+		ThreadID:        strings.TrimSpace(payload.ThreadID),
+		StopReason:      strings.TrimSpace(payload.StopReason),
+		ExitCode:        result.ExitCode,
+		Success:         result.Success,
 	}, nil
+}
+
+func normalizeFinalTextSource(source, finalText, transcript string) domain.AgentFinalTextSource {
+	switch normalized := domain.AgentFinalTextSource(strings.TrimSpace(source)); normalized {
+	case domain.AgentFinalTextSourceProviderMessage:
+		return domain.AgentFinalTextSourceProviderMessage
+	case domain.AgentFinalTextSourceTranscriptFallback:
+		return domain.AgentFinalTextSourceTranscriptFallback
+	case domain.AgentFinalTextSourceNone:
+		return domain.AgentFinalTextSourceNone
+	case "":
+		if finalText == "" {
+			return domain.AgentFinalTextSourceNone
+		}
+		if transcript != "" && finalText == transcript {
+			return domain.AgentFinalTextSourceTranscriptFallback
+		}
+		return domain.AgentFinalTextSourceProviderMessage
+	default:
+		if finalText == "" {
+			return domain.AgentFinalTextSourceNone
+		}
+		return domain.AgentFinalTextSourceTranscriptFallback
+	}
 }
 
 func ParseCommandExecResult(result domain.ExecResult) (domain.RuntimeCommandResult, error) {

--- a/pkg/execution/parse_coverage_test.go
+++ b/pkg/execution/parse_coverage_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestParseAgentAndCommandExecResultWorkflows(t *testing.T) {
-	agentPayload := AgentResultPrefix + `{"provider":"codex","threadId":"agent-thread","stopReason":"done","finalText":"final","transcript":"transcript"}`
+	agentPayload := AgentResultPrefix + `{"provider":"codex","threadId":"agent-thread","stopReason":"done","finalText":"final","finalTextSource":"provider_message","transcript":"transcript"}`
 	agent, err := ParseAgentExecResult("codex", domain.ExecResult{Stdout: "logs\n" + agentPayload, ExitCode: 0, Success: true})
 	if err != nil {
 		t.Fatalf("ParseAgentExecResult returned error: %v", err)
 	}
-	if agent.Agent != "codex" || agent.ThreadID != "agent-thread" || agent.DisplayOutput != "transcript" {
+	if agent.Agent != "codex" || agent.ThreadID != "agent-thread" || agent.DisplayOutput != "transcript" || agent.FinalTextSource != domain.AgentFinalTextSourceProviderMessage {
 		t.Fatalf("agent result = %#v", agent)
 	}
 	if _, err := ParseAgentExecResult("codex", domain.ExecResult{Stderr: strings.Repeat("x", 300)}); err == nil || !strings.Contains(err.Error(), "...") {
@@ -51,6 +51,31 @@ func TestParseAgentAndCommandExecResultWorkflows(t *testing.T) {
 	}
 	if _, err := ParseCommandExecResult(domain.ExecResult{Stdout: "noise"}); err == nil {
 		t.Fatalf("expected missing command payload error")
+	}
+}
+
+func TestParseAgentExecResultClassifiesFinalTextFallback(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    string
+		wantSource domain.AgentFinalTextSource
+	}{
+		{name: "explicit provider message", payload: `{"finalText":"answer","finalTextSource":"provider_message","transcript":"answer"}`, wantSource: domain.AgentFinalTextSourceProviderMessage},
+		{name: "explicit transcript fallback", payload: `{"finalText":"$ command\\noutput","finalTextSource":"transcript_fallback","transcript":"$ command\\noutput"}`, wantSource: domain.AgentFinalTextSourceTranscriptFallback},
+		{name: "legacy transcript fallback", payload: `{"finalText":"$ command\\noutput","transcript":"$ command\\noutput"}`, wantSource: domain.AgentFinalTextSourceTranscriptFallback},
+		{name: "legacy distinct final", payload: `{"finalText":"answer","transcript":"$ command\\noutput\\nanswer"}`, wantSource: domain.AgentFinalTextSourceProviderMessage},
+		{name: "unknown source", payload: `{"finalText":"answer","finalTextSource":"future_source","transcript":"activity\\nanswer"}`, wantSource: domain.AgentFinalTextSourceTranscriptFallback},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseAgentExecResult("codex", domain.ExecResult{Stdout: AgentResultPrefix + tt.payload, Success: true})
+			if err != nil {
+				t.Fatalf("ParseAgentExecResult returned error: %v", err)
+			}
+			if result.FinalTextSource != tt.wantSource {
+				t.Fatalf("final text source = %q, want %q", result.FinalTextSource, tt.wantSource)
+			}
+		})
 	}
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -523,13 +523,26 @@ type ExecSpec struct {
 }
 
 type AgentRunResult struct {
-	Agent         string
-	DisplayOutput string
-	FinalText     string
-	JSONText      string
-	Transcript    string
-	Success       bool
-	ExitCode      int
-	ThreadID      string
-	StopReason    string
+	Agent           string
+	DisplayOutput   string
+	FinalText       string
+	FinalTextSource AgentFinalTextSource
+	JSONText        string
+	Transcript      string
+	Success         bool
+	ExitCode        int
+	ThreadID        string
+	StopReason      string
 }
+
+// AgentFinalTextSource identifies how an agent result obtained FinalText.
+type AgentFinalTextSource string
+
+const (
+	// AgentFinalTextSourceNone means the provider produced no final text.
+	AgentFinalTextSourceNone AgentFinalTextSource = "none"
+	// AgentFinalTextSourceProviderMessage means FinalText came from a provider assistant-message event.
+	AgentFinalTextSourceProviderMessage AgentFinalTextSource = "provider_message"
+	// AgentFinalTextSourceTranscriptFallback means FinalText is a compatibility fallback containing the transcript.
+	AgentFinalTextSourceTranscriptFallback AgentFinalTextSource = "transcript_fallback"
+)

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -440,7 +440,7 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 		run = withRunWarnings(run, warnings)
 		return run, err, nil
 	}
-	cell, _, _, execErr := c.executor.ExecuteAgentRequest(ctx, sandboxResult.Sandbox, execution.ExecuteAgentRequest{
+	cell, _, assistantEvent, execErr := c.executor.ExecuteAgentRequest(ctx, sandboxResult.Sandbox, execution.ExecuteAgentRequest{
 		Agent:             agentConfig.Provider,
 		AgentDefinitionID: run.ManagedAgentID,
 		Model:             agentConfig.Model,
@@ -450,6 +450,7 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 		Stream:            projectRunAgentExecutionStream(transitionCtx, coordinator, run, sandboxResult.Sandbox, stream, c.runLogs),
 	})
 	transition := TransitionFromAgentCell(run, sandboxResult.Sandbox, cell, execErr)
+	transition.TerminalEvents = projectAgentTerminalEvents(run, cell, assistantEvent, execErr)
 	if execErr != nil || !cell.Success {
 		run, err = markProjectRunTerminalError(transitionCtx, coordinator, transition, execErr)
 		if err != nil {
@@ -1119,12 +1120,13 @@ func projectRunAgentExecutionStream(ctx context.Context, coordinator *Coordinato
 func transitionFromCommandResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, commandText string, result domain.ExecResult, execErr error) TransitionRequest {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	req := TransitionRequest{
-		RunID:        run.RunID,
-		SandboxID:    sandbox.Summary.ID,
-		ExitCode:     result.ExitCode,
-		Output:       result.Output,
-		ArtifactsDir: artifactsDir,
-		LogsPath:     filepath.Join(artifactsDir, "output.txt"),
+		RunID:          run.RunID,
+		SandboxID:      sandbox.Summary.ID,
+		ExitCode:       result.ExitCode,
+		Output:         result.Output,
+		ArtifactsDir:   artifactsDir,
+		LogsPath:       filepath.Join(artifactsDir, "output.txt"),
+		TerminalEvents: commandTerminalEvents(run, commandText, result),
 	}
 	resultJSON, err := json.Marshal(map[string]any{
 		"mode":     "command",
@@ -1399,6 +1401,7 @@ type promptAttachProjector struct {
 	buffer                 []byte
 	itemTexts              map[string]string
 	loggedText             string
+	turnText               string
 	hasLoggedText          bool
 	logEndsWithNewline     bool
 	persistedAssistantTurn bool
@@ -1455,15 +1458,16 @@ func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.RunAttac
 
 func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunAttachResponse, *TransitionRequest, error) {
 	var frame struct {
-		Type       string          `json:"type"`
-		Event      json.RawMessage `json:"event"`
-		FinalText  string          `json:"finalText"`
-		SandboxID  string          `json:"sandboxId"`
-		StopReason string          `json:"stopReason"`
-		Code       string          `json:"code"`
-		Message    string          `json:"message"`
-		Provider   string          `json:"provider"`
-		Seq        uint64          `json:"seq"`
+		Type            string                      `json:"type"`
+		Event           json.RawMessage             `json:"event"`
+		FinalText       string                      `json:"finalText"`
+		FinalTextSource domain.AgentFinalTextSource `json:"finalTextSource"`
+		SandboxID       string                      `json:"sandboxId"`
+		StopReason      string                      `json:"stopReason"`
+		Code            string                      `json:"code"`
+		Message         string                      `json:"message"`
+		Provider        string                      `json:"provider"`
+		Seq             uint64                      `json:"seq"`
 	}
 	if err := json.Unmarshal(line, &frame); err != nil {
 		return nil, nil, err
@@ -1481,7 +1485,7 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunA
 		if err := p.appendLogFinalText(frame.FinalText); err != nil {
 			return nil, nil, err
 		}
-		if err := p.appendAssistantEvent(line, frame.Seq, frame.FinalText, frame.Provider, frame.StopReason); err != nil {
+		if err := p.appendAssistantEvent(line, frame.Seq, agentTurnProjection{FinalText: frame.FinalText, FinalTextSource: frame.FinalTextSource, Provider: frame.Provider, StopReason: frame.StopReason}); err != nil {
 			return nil, nil, err
 		}
 		return []*agentcomposev2.RunAttachResponse{runAttachAgentTurnCompletedResponse(p.run, string(line), warningsFromRun(p.run))}, nil, nil
@@ -1490,7 +1494,7 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunA
 			return nil, nil, err
 		}
 		transition := transitionFromPromptWrapperResult(p.run, p.sandbox, p.logsPath, line, frame.FinalText, frame.StopReason, "")
-		transition.SkipTerminalAgentEvent = p.persistedAssistantTurn
+		transition.TerminalEvents = p.terminalTurnEvents(agentTurnProjection{FinalText: frame.FinalText, FinalTextSource: frame.FinalTextSource, Provider: frame.Provider, StopReason: frame.StopReason})
 		return nil, &transition, nil
 	case "error":
 		message := firstNonEmpty(frame.Message, "runtime stream error")
@@ -1561,6 +1565,7 @@ func (p *promptAttachProjector) appendLogText(text string) error {
 		return err
 	}
 	p.loggedText += text
+	p.turnText += text
 	return nil
 }
 
@@ -1579,6 +1584,7 @@ func (p *promptAttachProjector) appendLogFinalText(finalText string) error {
 			return err
 		}
 		p.loggedText += text
+		p.turnText += text
 		return nil
 	}
 	if p.loggedText == "" {
@@ -1586,6 +1592,7 @@ func (p *promptAttachProjector) appendLogFinalText(finalText string) error {
 			return err
 		}
 		p.loggedText = finalText
+		p.turnText += finalText
 	}
 	return nil
 }
@@ -1598,6 +1605,7 @@ func (p *promptAttachProjector) AppendHumanMessageFrame(message, clientFrameID s
 	text := promptAttachHumanLogText(message)
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.persistedAssistantTurn = false
 	if text != "" {
 		if p.hasLoggedText && !p.logEndsWithNewline {
 			text = "\n" + text
@@ -1622,22 +1630,44 @@ func (p *promptAttachProjector) AppendStderr(text string) error {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.appendLogChunkLocked(domain.ExecChunk{Text: text, Stream: domain.StdioStderr})
+	if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text, Stream: domain.StdioStderr}); err != nil {
+		return err
+	}
+	p.turnText += text
+	return nil
 }
 
-func (p *promptAttachProjector) appendAssistantEvent(line []byte, seq uint64, text, provider, stopReason string) error {
-	if p.events == nil || strings.TrimSpace(text) == "" {
+func (p *promptAttachProjector) appendAssistantEvent(line []byte, seq uint64, turn agentTurnProjection) error {
+	p.mu.Lock()
+	store := p.events
+	turn.Transcript = p.turnText
+	p.mu.Unlock()
+	if store == nil {
 		return nil
+	}
+	events := attachedAgentTurnEvents(p.run, seq, line, turn)
+	if len(events) > 0 {
+		if _, _, err := store.AppendProjectRunEvents(p.eventContext(), events); err != nil {
+			return err
+		}
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	_, _, err := p.events.AppendProjectRunEvent(p.eventContext(), domain.ProjectRunEventRecord{
-		ID: attachedAgentEventID(p.run.RunID, seq, line), RunID: p.run.RunID, Kind: domain.ProjectRunEventKindAgentMessage, Text: text, Agent: firstNonEmpty(provider, p.run.AgentName), StopReason: stopReason, Success: true,
-	})
-	if err == nil {
-		p.persistedAssistantTurn = true
+	p.turnText = ""
+	p.persistedAssistantTurn = len(events) > 0
+	return nil
+}
+
+func (p *promptAttachProjector) terminalTurnEvents(turn agentTurnProjection) []domain.ProjectRunEventRecord {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.persistedAssistantTurn {
+		return nil
 	}
-	return err
+	turn.Transcript = p.turnText
+	events := terminalPromptTurnEvents(p.run, turn)
+	p.turnText = ""
+	return events
 }
 
 func (p *promptAttachProjector) eventContext() context.Context {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1120,13 +1120,12 @@ func projectRunAgentExecutionStream(ctx context.Context, coordinator *Coordinato
 func transitionFromCommandResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, commandText string, result domain.ExecResult, execErr error) TransitionRequest {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	req := TransitionRequest{
-		RunID:          run.RunID,
-		SandboxID:      sandbox.Summary.ID,
-		ExitCode:       result.ExitCode,
-		Output:         result.Output,
-		ArtifactsDir:   artifactsDir,
-		LogsPath:       filepath.Join(artifactsDir, "output.txt"),
-		TerminalEvents: commandTerminalEvents(run, commandText, result),
+		RunID:        run.RunID,
+		SandboxID:    sandbox.Summary.ID,
+		ExitCode:     result.ExitCode,
+		Output:       result.Output,
+		ArtifactsDir: artifactsDir,
+		LogsPath:     filepath.Join(artifactsDir, "output.txt"),
 	}
 	resultJSON, err := json.Marshal(map[string]any{
 		"mode":     "command",

--- a/pkg/runs/coordinator.go
+++ b/pkg/runs/coordinator.go
@@ -25,17 +25,17 @@ type StartRequest struct {
 }
 
 type TransitionRequest struct {
-	RunID                  string
-	Status                 string
-	SandboxID              string
-	ExitCode               int
-	Error                  string
-	Output                 string
-	ResultJSON             string
-	LogsPath               string
-	ArtifactsDir           string
-	CleanupError           string
-	SkipTerminalAgentEvent bool
+	RunID          string
+	Status         string
+	SandboxID      string
+	ExitCode       int
+	Error          string
+	Output         string
+	ResultJSON     string
+	LogsPath       string
+	ArtifactsDir   string
+	CleanupError   string
+	TerminalEvents []domain.ProjectRunEventRecord
 }
 
 type ManagedAgentDefinition struct {
@@ -225,11 +225,9 @@ func (c *Coordinator) TransitionRun(ctx context.Context, req TransitionRequest) 
 		}
 		next.DurationMs = max(0, next.CompletedAt.Sub(next.StartedAt).Milliseconds())
 	}
-	batch := make([]domain.ProjectRunEventRecord, 0, 2)
+	batch := make([]domain.ProjectRunEventRecord, 0, len(req.TerminalEvents)+1)
 	if StatusIsTerminal(next.Status) {
-		if next.Output != "" && !req.SkipTerminalAgentEvent {
-			batch = append(batch, domain.ProjectRunEventRecord{ID: terminalAgentEventID(next.RunID), RunID: next.RunID, Kind: domain.ProjectRunEventKindAgentMessage, Text: next.Output, Agent: next.AgentName, Success: next.Status == domain.ProjectRunStatusSucceeded, ExitCode: next.ExitCode, StopReason: next.Error})
-		}
+		batch = append(batch, req.TerminalEvents...)
 		batch = append(batch, domain.ProjectRunEventRecord{ID: terminalStatusEventID(next.RunID), RunID: next.RunID, Kind: domain.ProjectRunEventKindStatus, PayloadJSON: next.ResultJSON, Success: next.Status == domain.ProjectRunStatusSucceeded, ExitCode: next.ExitCode, StopReason: next.Error})
 	}
 	updated, err := c.store.UpdateProjectRunWithEvents(ctx, next, batch)

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -79,6 +79,9 @@ func TestRunsCoordinatorAndHelperWorkflows(t *testing.T) {
 	if succeeded, err := coord.MarkSucceeded(ctx, TransitionRequest{RunID: run.RunID, ExitCode: 0, Output: "ok", ResultJSON: `{"ok":true}`, LogsPath: "/logs", ArtifactsDir: "/artifacts"}); err != nil || succeeded.Status != domain.ProjectRunStatusSucceeded || succeeded.DurationMs < 0 {
 		t.Fatalf("MarkSucceeded run=%#v err=%v", succeeded, err)
 	}
+	if len(store.events) != 2 || store.events[0].Kind != domain.ProjectRunEventKindUserMessage || store.events[1].Kind != domain.ProjectRunEventKindStatus {
+		t.Fatalf("coordinator inferred events from output: %#v", store.events)
+	}
 	if _, err := coord.MarkFailed(ctx, TransitionRequest{RunID: run.RunID, Error: "late"}); err == nil {
 		t.Fatalf("expected terminal transition error")
 	}
@@ -288,7 +291,16 @@ func TestRunsControllerRunProjectAgentSuccessWorkflow(t *testing.T) {
 		runs:   map[string]domain.ProjectRunRecord{},
 	}
 	driver := &fakeControllerDriver{store: store}
-	executor := &fakeControllerExecutor{}
+	executor := &fakeControllerExecutor{
+		cell: domain.NotebookCell{
+			ID:      "cell-1",
+			Type:    execution.CellTypeAgent,
+			Agent:   "codex",
+			Output:  "checking weather\n$ curl https://weather.test\n{\"temperature\":26}\nBeijing is 26°C today.",
+			Success: true,
+		},
+		assistantEvent: domain.SandboxEvent{ID: "assistant", Type: "agent.assistant", Message: "Beijing is 26°C today."},
+	}
 	bus := &fakeControllerPublisher{}
 	dashboard := &fakeControllerDashboard{}
 	controller := NewController(ControllerDependencies{
@@ -329,8 +341,14 @@ func TestRunsControllerRunProjectAgentSuccessWorkflow(t *testing.T) {
 	if err != nil || execErr != nil {
 		t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
 	}
-	if run.Status != domain.ProjectRunStatusSucceeded || run.SandboxID == "" || run.Output != "done" {
+	if run.Status != domain.ProjectRunStatusSucceeded || run.SandboxID == "" || !strings.Contains(run.Output, "curl https://weather.test") {
 		t.Fatalf("run = %#v", run)
+	}
+	if len(configDB.events) != 4 ||
+		configDB.events[1].Kind != domain.ProjectRunEventKindAgentActivity || !strings.Contains(configDB.events[1].Text, "curl https://weather.test") ||
+		configDB.events[2].Kind != domain.ProjectRunEventKindAgentMessage || configDB.events[2].Text != "Beijing is 26°C today." ||
+		strings.Contains(configDB.events[2].Text, "curl") || configDB.events[3].Kind != domain.ProjectRunEventKindStatus {
+		t.Fatalf("project run events = %#v", configDB.events)
 	}
 	if !strings.Contains(run.ArtifactsDir, filepath.Join("state", "cells", "cell-1")) || filepath.Base(run.LogsPath) != "output.txt" {
 		t.Fatalf("agent run artifact paths = artifacts:%q logs:%q", run.ArtifactsDir, run.LogsPath)
@@ -592,6 +610,9 @@ func TestRunsControllerRunProjectAgentCommandWorkflow(t *testing.T) {
 	if run.Status != domain.ProjectRunStatusSucceeded || run.Output != "command output\n" || run.ArtifactsDir == "" || run.LogsPath == "" {
 		t.Fatalf("command run = %#v", run)
 	}
+	if len(configDB.events) != 2 || configDB.events[0].Kind != domain.ProjectRunEventKindAgentActivity || configDB.events[0].Name != commandExecutionActivityName || configDB.events[1].Kind != domain.ProjectRunEventKindStatus {
+		t.Fatalf("command run events = %#v", configDB.events)
+	}
 	if !strings.Contains(run.ArtifactsDir, filepath.Join("state", "runs", run.RunID)) || filepath.Base(run.LogsPath) != "transcript.txt" {
 		t.Fatalf("command run artifact paths = artifacts:%q logs:%q", run.ArtifactsDir, run.LogsPath)
 	}
@@ -756,6 +777,9 @@ func TestRunsControllerRunProjectAgentCommandNonZeroExitPreservesOutput(t *testi
 	if run.Status != domain.ProjectRunStatusFailed || run.ExitCode != 7 || run.Output != "partial stdout\nfailure stderr\n" {
 		t.Fatalf("failed command run = %#v", run)
 	}
+	if len(configDB.events) != 2 || configDB.events[0].Kind != domain.ProjectRunEventKindAgentActivity || configDB.events[0].Success || configDB.events[1].Kind != domain.ProjectRunEventKindStatus {
+		t.Fatalf("failed command events = %#v", configDB.events)
+	}
 	if len(chunks) != 2 || domain.NormalizeStdioStream(chunks[0].Stream) != domain.StdioStdout || domain.NormalizeStdioStream(chunks[1].Stream) != domain.StdioStderr {
 		t.Fatalf("stream chunks = %#v", chunks)
 	}
@@ -828,6 +852,9 @@ func TestRunsControllerRunProjectCommandAttachProjectsOutputAndResult(t *testing
 	if err != nil || string(data) != "hello\nwarn\n" {
 		t.Fatalf("attach transcript = %q err=%v", string(data), err)
 	}
+	if len(configDB.events) != 2 || configDB.events[0].Kind != domain.ProjectRunEventKindAgentActivity || configDB.events[0].Name != commandExecutionActivityName || configDB.events[1].Kind != domain.ProjectRunEventKindStatus {
+		t.Fatalf("command attach events = %#v", configDB.events)
+	}
 }
 
 func TestRunsControllerRunProjectCommandAttachValidatesStartFrame(t *testing.T) {
@@ -846,8 +873,8 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 		{Type: driverpkg.RuntimeOutputStarted},
 		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":0,"type":"started","provider":"claude","sessionId":"thread-1"}` + "\n")},
 		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":1,"type":"agent_event","event":{"type":"output","provider":"claude","text":"hello agent\n"}}` + "\n")},
-		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"claude","sessionId":"thread-1","finalText":"hello agent\n"}` + "\n")},
-		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":3,"type":"result","provider":"claude","sessionId":"thread-1","stopReason":"eof","finalText":"hello agent\n","transcript":"hello agent\n"}` + "\n")},
+		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"claude","sessionId":"thread-1","finalText":"hello agent\n","finalTextSource":"provider_message"}` + "\n")},
+		{Type: driverpkg.RuntimeOutputStdout, Data: []byte(`{"v":1,"seq":3,"type":"result","provider":"claude","sessionId":"thread-1","stopReason":"eof","finalText":"hello agent\n","finalTextSource":"provider_message","transcript":"hello agent\n"}` + "\n")},
 		{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", ExitCode: 0, Success: true}},
 	})
 	configDB.agent.Provider = "claude"
@@ -912,6 +939,9 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	if string(transcript) != "hello agent\n" {
 		t.Fatalf("prompt attach transcript = %q", string(transcript))
 	}
+	if len(configDB.events) != 3 || configDB.events[0].Kind != domain.ProjectRunEventKindUserMessage || configDB.events[1].Kind != domain.ProjectRunEventKindAgentMessage || configDB.events[1].Text != "hello agent" || configDB.events[2].Kind != domain.ProjectRunEventKindStatus {
+		t.Fatalf("prompt attach events = %#v", configDB.events)
+	}
 }
 
 func TestRunsControllerRunProjectPromptAttachGatesQueuedTurnsAndOrdersTranscript(t *testing.T) {
@@ -952,18 +982,18 @@ func TestRunsControllerRunProjectPromptAttachGatesQueuedTurnsAndOrdersTranscript
 	interaction.frames <- driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputStarted}
 	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":0,"type":"started","provider":"codex","sessionId":"thread-1"}`)
 	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":1,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m1","type":"agent_message","text":"agent-1\n"}}}`)
-	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-1\n"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":2,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-1\n","finalTextSource":"provider_message"}`)
 	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-2")
 	assertNoRuntimeInputFrame(t, interaction.sent)
 
 	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":3,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m2","type":"agent_message","text":"agent-2\n"}}}`)
-	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":4,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-2\n"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":4,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-2\n","finalTextSource":"provider_message"}`)
 	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "human-3")
 	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "eof", "")
 
 	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":5,"type":"agent_event","event":{"type":"item.completed","item":{"id":"m3","type":"agent_message","text":"agent-3\n"}}}`)
-	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":6,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-3\n"}`)
-	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":7,"type":"result","provider":"codex","sessionId":"thread-1","stopReason":"eof","finalText":"agent-3\n","transcript":"agent-1\nagent-2\nagent-3\n"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":6,"type":"agent_turn_completed","provider":"codex","sessionId":"thread-1","finalText":"agent-3\n","finalTextSource":"provider_message"}`)
+	interaction.frames <- promptRuntimeStdoutFrame(`{"v":1,"seq":7,"type":"result","provider":"codex","sessionId":"thread-1","stopReason":"eof","finalText":"agent-3\n","finalTextSource":"provider_message","transcript":"agent-1\nagent-2\nagent-3\n"}`)
 	interaction.frames <- driverpkg.RuntimeOutputFrame{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", Success: true}}
 
 	select {
@@ -1005,7 +1035,7 @@ func promptRuntimeStdoutFrame(line string) driverpkg.RuntimeOutputFrame {
 func TestPromptAttachProjectorLogsResultFinalTextWithoutAgentEventText(t *testing.T) {
 	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
 	projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-final"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-final"}}, logsPath, nil)
-	_, transition, err := projector.Project([]byte(`{"type":"result","finalText":"final only\n","stopReason":"eof"}` + "\n"))
+	_, transition, err := projector.Project([]byte(`{"type":"result","finalText":"final only\n","finalTextSource":"provider_message","stopReason":"eof"}` + "\n"))
 	if err != nil {
 		t.Fatalf("project final text result: %v", err)
 	}
@@ -1033,7 +1063,7 @@ func TestPromptAttachProjectorLogsHumanMessagesAndTurnFinalText(t *testing.T) {
 	if err := projector.AppendHumanMessage("next question"); err != nil {
 		t.Fatalf("append human message: %v", err)
 	}
-	if _, _, err := projector.Project([]byte(`{"type":"agent_turn_completed","finalText":"first answer\n"}` + "\n")); err != nil {
+	if _, _, err := projector.Project([]byte(`{"type":"agent_turn_completed","finalText":"first answer\n","finalTextSource":"provider_message"}` + "\n")); err != nil {
 		t.Fatalf("project first turn completion: %v", err)
 	}
 	transcript, err := os.ReadFile(logsPath)
@@ -1053,7 +1083,7 @@ func TestPromptAttachProjectorLogsHumanMessagesAndTurnFinalText(t *testing.T) {
 func TestPromptAttachProjectorLogsTurnFinalTextWithoutAgentEventText(t *testing.T) {
 	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
 	projector := newPromptAttachProjector(domain.ProjectRunRecord{RunID: "run-turn-final"}, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-turn-final"}}, logsPath, nil)
-	if _, _, err := projector.Project([]byte(`{"type":"agent_turn_completed","finalText":"turn only\n"}` + "\n")); err != nil {
+	if _, _, err := projector.Project([]byte(`{"type":"agent_turn_completed","finalText":"turn only\n","finalTextSource":"provider_message"}` + "\n")); err != nil {
 		t.Fatalf("project turn final text: %v", err)
 	}
 	transcript, err := os.ReadFile(logsPath)
@@ -1142,39 +1172,46 @@ func TestPromptAttachProjectorPersistsEachFrameIdempotently(t *testing.T) {
 	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("retry human frame: %v", err)
 	}
-	turn := []byte(`{"seq":42,"type":"agent_turn_completed","provider":"codex","finalText":"answer","stopReason":"end_turn"}` + "\n")
+	activity := []byte(`{"seq":41,"type":"agent_event","event":{"type":"item.completed","item":{"id":"cmd-1","type":"command_execution","command":"curl https://weather.test","aggregated_output":"{\"temperature\":26}\n"}}}` + "\n")
+	if _, _, err := projector.Project(activity); err != nil {
+		t.Fatalf("project activity: %v", err)
+	}
+	turn := []byte(`{"seq":42,"type":"agent_turn_completed","provider":"codex","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n")
 	if _, _, err := projector.Project(turn); err != nil {
 		t.Fatalf("project assistant turn: %v", err)
 	}
 	if _, _, err := projector.Project(turn); err != nil {
 		t.Fatalf("retry assistant turn: %v", err)
 	}
-	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","stopReason":"end_turn"}` + "\n"))
-	if err != nil || transition == nil || !transition.SkipTerminalAgentEvent {
+	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n"))
+	if err != nil || transition == nil || len(transition.TerminalEvents) != 0 {
 		t.Fatalf("result transition = %#v err=%v", transition, err)
 	}
-	if len(store.events) != 2 {
+	if len(store.events) != 3 {
 		t.Fatalf("persisted events = %#v", store.events)
 	}
 	if store.events[0].Kind != domain.ProjectRunEventKindUserMessage || store.events[0].ID != attachedHumanEventID("run-events", "client-frame-1", 1, "question") {
 		t.Fatalf("human event = %#v", store.events[0])
 	}
-	if store.events[1].Kind != domain.ProjectRunEventKindAgentMessage || store.events[1].ID != attachedAgentEventID("run-events", 42, turn) || store.events[1].Text != "answer" {
-		t.Fatalf("assistant event = %#v", store.events[1])
+	if store.events[1].Kind != domain.ProjectRunEventKindAgentActivity || store.events[1].ID != attachedActivityEventID("run-events", 42, turn) || !strings.Contains(store.events[1].Text, "curl https://weather.test") {
+		t.Fatalf("activity event = %#v", store.events[1])
+	}
+	if store.events[2].Kind != domain.ProjectRunEventKindAgentMessage || store.events[2].ID != attachedAgentEventID("run-events", 42, turn) || store.events[2].Text != "answer" {
+		t.Fatalf("assistant event = %#v", store.events[2])
 	}
 }
 
-func TestPromptAttachProjectorDoesNotSkipTerminalAgentEventAfterOnlyHumanMessage(t *testing.T) {
+func TestPromptAttachProjectorProjectsTerminalAgentEventAfterOnlyHumanMessage(t *testing.T) {
 	store := &projectorEventStore{keys: map[string]struct{}{}}
 	projector := newPersistentPromptAttachProjector(context.Background(), domain.ProjectRunRecord{RunID: "run-result-only", AgentName: "worker"}, &domain.Sandbox{}, filepath.Join(t.TempDir(), "transcript.txt"), nil, store)
 	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
-	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","stopReason":"end_turn"}` + "\n"))
+	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n"))
 	if err != nil {
 		t.Fatalf("project result: %v", err)
 	}
-	if transition == nil || transition.SkipTerminalAgentEvent {
+	if transition == nil || len(transition.TerminalEvents) != 1 || transition.TerminalEvents[0].Kind != domain.ProjectRunEventKindAgentMessage || transition.TerminalEvents[0].Text != "answer" {
 		t.Fatalf("result transition = %#v", transition)
 	}
 	if len(store.events) != 1 || store.events[0].Kind != domain.ProjectRunEventKindUserMessage {
@@ -1188,22 +1225,22 @@ func TestIntegrationPromptAttachProjectorPersistsAssistantTurnBeforeSkippingTerm
 	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
-	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","stopReason":"end_turn"}` + "\n"))
+	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n"))
 	if err != nil {
 		t.Fatalf("project result without assistant turn: %v", err)
 	}
-	if transition == nil || transition.SkipTerminalAgentEvent {
+	if transition == nil || len(transition.TerminalEvents) != 1 || transition.TerminalEvents[0].Kind != domain.ProjectRunEventKindAgentMessage {
 		t.Fatalf("result-only transition = %#v", transition)
 	}
-	turn := []byte(`{"seq":44,"type":"agent_turn_completed","provider":"codex","finalText":"answer","stopReason":"end_turn"}` + "\n")
+	turn := []byte(`{"seq":44,"type":"agent_turn_completed","provider":"codex","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n")
 	if _, _, err := projector.Project(turn); err != nil {
 		t.Fatalf("project assistant turn: %v", err)
 	}
-	_, transition, err = projector.Project([]byte(`{"seq":45,"type":"result","finalText":"answer","stopReason":"end_turn"}` + "\n"))
+	_, transition, err = projector.Project([]byte(`{"seq":45,"type":"result","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n"))
 	if err != nil {
 		t.Fatalf("project result after assistant turn: %v", err)
 	}
-	if transition == nil || !transition.SkipTerminalAgentEvent {
+	if transition == nil || len(transition.TerminalEvents) != 0 {
 		t.Fatalf("assistant transition = %#v", transition)
 	}
 	if len(store.events) != 2 || store.events[0].Kind != domain.ProjectRunEventKindUserMessage || store.events[1].Kind != domain.ProjectRunEventKindAgentMessage {
@@ -2369,6 +2406,7 @@ type fakeRunStore struct {
 	projectAgent domain.ProjectAgentRecord
 	agent        ManagedAgentDefinition
 	runs         map[string]domain.ProjectRunRecord
+	events       []domain.ProjectRunEventRecord
 }
 
 func (s *fakeRunStore) GetProject(context.Context, string) (domain.ProjectRecord, error) {
@@ -2391,11 +2429,12 @@ func (s *fakeRunStore) CreateProjectRun(_ context.Context, run domain.ProjectRun
 	return run, nil
 }
 
-func (s *fakeRunStore) CreateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, _ []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
+func (s *fakeRunStore) CreateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, events []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
 	created, err := s.CreateProjectRun(ctx, run)
 	if err != nil {
 		return s.GetProjectRun(ctx, run.RunID)
 	}
+	s.events = append(s.events, events...)
 	return created, nil
 }
 
@@ -2412,8 +2451,10 @@ func (s *fakeRunStore) UpdateProjectRun(_ context.Context, run domain.ProjectRun
 	return run, nil
 }
 
-func (s *fakeRunStore) UpdateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, _ []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
-	return s.UpdateProjectRun(ctx, run)
+func (s *fakeRunStore) UpdateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, events []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
+	updated, err := s.UpdateProjectRun(ctx, run)
+	s.events = append(s.events, events...)
+	return updated, err
 }
 
 type fakePreparationStore struct {
@@ -2476,6 +2517,7 @@ type fakeControllerStore struct {
 	schedulers     []domain.ProjectSchedulerRecord
 	loaders        map[string]domain.Loader
 	bindings       map[string]domain.LoaderBinding
+	events         []domain.ProjectRunEventRecord
 }
 
 func (s *fakeControllerStore) GetProject(context.Context, string) (domain.ProjectRecord, error) {
@@ -2501,11 +2543,12 @@ func (s *fakeControllerStore) CreateProjectRun(_ context.Context, run domain.Pro
 	return run, nil
 }
 
-func (s *fakeControllerStore) CreateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, _ []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
+func (s *fakeControllerStore) CreateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, events []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
 	created, err := s.CreateProjectRun(ctx, run)
 	if err != nil {
 		return s.GetProjectRun(ctx, run.RunID)
 	}
+	s.events = append(s.events, events...)
 	return created, nil
 }
 
@@ -2522,8 +2565,10 @@ func (s *fakeControllerStore) UpdateProjectRun(_ context.Context, run domain.Pro
 	return run, nil
 }
 
-func (s *fakeControllerStore) UpdateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, _ []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
-	return s.UpdateProjectRun(ctx, run)
+func (s *fakeControllerStore) UpdateProjectRunWithEvents(ctx context.Context, run domain.ProjectRunRecord, events []domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
+	updated, err := s.UpdateProjectRun(ctx, run)
+	s.events = append(s.events, events...)
+	return updated, err
 }
 
 func (s *fakeControllerStore) GetProjectRevision(context.Context, string, int64) (domain.ProjectRevisionRecord, error) {
@@ -2649,6 +2694,7 @@ func (d *fakeControllerDriver) RemoveSandboxVM(context.Context, *domain.Sandbox)
 type fakeControllerExecutor struct {
 	request              execution.ExecuteAgentRequest
 	cell                 domain.NotebookCell
+	assistantEvent       domain.SandboxEvent
 	execErr              error
 	prepareCalls         int
 	prepareFromTagsCalls int
@@ -2685,9 +2731,13 @@ func (e *fakeControllerExecutor) ExecuteAgentRequest(_ context.Context, _ *domai
 	if strings.TrimSpace(cell.ID) == "" {
 		cell = domain.NotebookCell{ID: "cell-1", Type: execution.CellTypeAgent, Output: "done", Success: true, ExitCode: 0}
 	}
+	assistantEvent := e.assistantEvent
+	if strings.TrimSpace(assistantEvent.Message) == "" {
+		assistantEvent = domain.SandboxEvent{ID: "assistant", Type: "assistant", Message: "done"}
+	}
 	return cell,
 		domain.SandboxEvent{ID: "user", Type: "user", Message: req.Message},
-		domain.SandboxEvent{ID: "assistant", Type: "assistant", Message: "done"},
+		assistantEvent,
 		e.execErr
 }
 

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -344,10 +344,9 @@ func TestRunsControllerRunProjectAgentSuccessWorkflow(t *testing.T) {
 	if run.Status != domain.ProjectRunStatusSucceeded || run.SandboxID == "" || !strings.Contains(run.Output, "curl https://weather.test") {
 		t.Fatalf("run = %#v", run)
 	}
-	if len(configDB.events) != 4 ||
-		configDB.events[1].Kind != domain.ProjectRunEventKindAgentActivity || !strings.Contains(configDB.events[1].Text, "curl https://weather.test") ||
-		configDB.events[2].Kind != domain.ProjectRunEventKindAgentMessage || configDB.events[2].Text != "Beijing is 26°C today." ||
-		strings.Contains(configDB.events[2].Text, "curl") || configDB.events[3].Kind != domain.ProjectRunEventKindStatus {
+	if len(configDB.events) != 3 ||
+		configDB.events[1].Kind != domain.ProjectRunEventKindAgentMessage || configDB.events[1].Text != "Beijing is 26°C today." ||
+		strings.Contains(configDB.events[1].Text, "curl") || configDB.events[2].Kind != domain.ProjectRunEventKindStatus {
 		t.Fatalf("project run events = %#v", configDB.events)
 	}
 	if !strings.Contains(run.ArtifactsDir, filepath.Join("state", "cells", "cell-1")) || filepath.Base(run.LogsPath) != "output.txt" {
@@ -610,7 +609,7 @@ func TestRunsControllerRunProjectAgentCommandWorkflow(t *testing.T) {
 	if run.Status != domain.ProjectRunStatusSucceeded || run.Output != "command output\n" || run.ArtifactsDir == "" || run.LogsPath == "" {
 		t.Fatalf("command run = %#v", run)
 	}
-	if len(configDB.events) != 2 || configDB.events[0].Kind != domain.ProjectRunEventKindAgentActivity || configDB.events[0].Name != commandExecutionActivityName || configDB.events[1].Kind != domain.ProjectRunEventKindStatus {
+	if len(configDB.events) != 1 || configDB.events[0].Kind != domain.ProjectRunEventKindStatus {
 		t.Fatalf("command run events = %#v", configDB.events)
 	}
 	if !strings.Contains(run.ArtifactsDir, filepath.Join("state", "runs", run.RunID)) || filepath.Base(run.LogsPath) != "transcript.txt" {
@@ -777,7 +776,7 @@ func TestRunsControllerRunProjectAgentCommandNonZeroExitPreservesOutput(t *testi
 	if run.Status != domain.ProjectRunStatusFailed || run.ExitCode != 7 || run.Output != "partial stdout\nfailure stderr\n" {
 		t.Fatalf("failed command run = %#v", run)
 	}
-	if len(configDB.events) != 2 || configDB.events[0].Kind != domain.ProjectRunEventKindAgentActivity || configDB.events[0].Success || configDB.events[1].Kind != domain.ProjectRunEventKindStatus {
+	if len(configDB.events) != 1 || configDB.events[0].Kind != domain.ProjectRunEventKindStatus || configDB.events[0].Success {
 		t.Fatalf("failed command events = %#v", configDB.events)
 	}
 	if len(chunks) != 2 || domain.NormalizeStdioStream(chunks[0].Stream) != domain.StdioStdout || domain.NormalizeStdioStream(chunks[1].Stream) != domain.StdioStderr {
@@ -852,7 +851,7 @@ func TestRunsControllerRunProjectCommandAttachProjectsOutputAndResult(t *testing
 	if err != nil || string(data) != "hello\nwarn\n" {
 		t.Fatalf("attach transcript = %q err=%v", string(data), err)
 	}
-	if len(configDB.events) != 2 || configDB.events[0].Kind != domain.ProjectRunEventKindAgentActivity || configDB.events[0].Name != commandExecutionActivityName || configDB.events[1].Kind != domain.ProjectRunEventKindStatus {
+	if len(configDB.events) != 1 || configDB.events[0].Kind != domain.ProjectRunEventKindStatus {
 		t.Fatalf("command attach events = %#v", configDB.events)
 	}
 }
@@ -1187,17 +1186,14 @@ func TestPromptAttachProjectorPersistsEachFrameIdempotently(t *testing.T) {
 	if err != nil || transition == nil || len(transition.TerminalEvents) != 0 {
 		t.Fatalf("result transition = %#v err=%v", transition, err)
 	}
-	if len(store.events) != 3 {
+	if len(store.events) != 2 {
 		t.Fatalf("persisted events = %#v", store.events)
 	}
 	if store.events[0].Kind != domain.ProjectRunEventKindUserMessage || store.events[0].ID != attachedHumanEventID("run-events", "client-frame-1", 1, "question") {
 		t.Fatalf("human event = %#v", store.events[0])
 	}
-	if store.events[1].Kind != domain.ProjectRunEventKindAgentActivity || store.events[1].ID != attachedActivityEventID("run-events", 42, turn) || !strings.Contains(store.events[1].Text, "curl https://weather.test") {
-		t.Fatalf("activity event = %#v", store.events[1])
-	}
-	if store.events[2].Kind != domain.ProjectRunEventKindAgentMessage || store.events[2].ID != attachedAgentEventID("run-events", 42, turn) || store.events[2].Text != "answer" {
-		t.Fatalf("assistant event = %#v", store.events[2])
+	if store.events[1].Kind != domain.ProjectRunEventKindAgentMessage || store.events[1].ID != attachedAgentEventID("run-events", 42, turn) || store.events[1].Text != "answer" {
+		t.Fatalf("assistant event = %#v", store.events[1])
 	}
 }
 

--- a/pkg/runs/run_event.go
+++ b/pkg/runs/run_event.go
@@ -15,11 +15,13 @@ const (
 	attachedEventDerivedToken     byte = 2
 
 	// These values participate in persisted event IDs. Keep existing values stable.
-	runEventIdentityInitialPrompt  runEventIdentityKind = 1
-	runEventIdentityAttachedHuman  runEventIdentityKind = 2
-	runEventIdentityAttachedAgent  runEventIdentityKind = 3
-	runEventIdentityTerminalAgent  runEventIdentityKind = 4
-	runEventIdentityTerminalStatus runEventIdentityKind = 5
+	runEventIdentityInitialPrompt    runEventIdentityKind = 1
+	runEventIdentityAttachedHuman    runEventIdentityKind = 2
+	runEventIdentityAttachedAgent    runEventIdentityKind = 3
+	runEventIdentityTerminalAgent    runEventIdentityKind = 4
+	runEventIdentityTerminalStatus   runEventIdentityKind = 5
+	runEventIdentityAttachedActivity runEventIdentityKind = 6
+	runEventIdentityTerminalActivity runEventIdentityKind = 7
 )
 
 func initialPromptEventID(runID string) string {
@@ -42,8 +44,20 @@ func attachedAgentEventID(runID string, sequence uint64, frame []byte) string {
 	return stableRunEventID(runID, runEventIdentityAttachedAgent, identityToken(attachedEventDerivedToken, digest[:]))
 }
 
+func attachedActivityEventID(runID string, sequence uint64, frame []byte) string {
+	if sequence != 0 {
+		return stableRunEventID(runID, runEventIdentityAttachedActivity, identityToken(attachedEventExplicitToken, uint64Bytes(sequence)))
+	}
+	digest := sha256.Sum256(frame)
+	return stableRunEventID(runID, runEventIdentityAttachedActivity, identityToken(attachedEventDerivedToken, digest[:]))
+}
+
 func terminalAgentEventID(runID string) string {
 	return stableRunEventID(runID, runEventIdentityTerminalAgent, nil)
+}
+
+func terminalActivityEventID(runID string) string {
+	return stableRunEventID(runID, runEventIdentityTerminalActivity, nil)
 }
 
 func terminalStatusEventID(runID string) string {

--- a/pkg/runs/run_event.go
+++ b/pkg/runs/run_event.go
@@ -15,13 +15,11 @@ const (
 	attachedEventDerivedToken     byte = 2
 
 	// These values participate in persisted event IDs. Keep existing values stable.
-	runEventIdentityInitialPrompt    runEventIdentityKind = 1
-	runEventIdentityAttachedHuman    runEventIdentityKind = 2
-	runEventIdentityAttachedAgent    runEventIdentityKind = 3
-	runEventIdentityTerminalAgent    runEventIdentityKind = 4
-	runEventIdentityTerminalStatus   runEventIdentityKind = 5
-	runEventIdentityAttachedActivity runEventIdentityKind = 6
-	runEventIdentityTerminalActivity runEventIdentityKind = 7
+	runEventIdentityInitialPrompt  runEventIdentityKind = 1
+	runEventIdentityAttachedHuman  runEventIdentityKind = 2
+	runEventIdentityAttachedAgent  runEventIdentityKind = 3
+	runEventIdentityTerminalAgent  runEventIdentityKind = 4
+	runEventIdentityTerminalStatus runEventIdentityKind = 5
 )
 
 func initialPromptEventID(runID string) string {
@@ -44,20 +42,8 @@ func attachedAgentEventID(runID string, sequence uint64, frame []byte) string {
 	return stableRunEventID(runID, runEventIdentityAttachedAgent, identityToken(attachedEventDerivedToken, digest[:]))
 }
 
-func attachedActivityEventID(runID string, sequence uint64, frame []byte) string {
-	if sequence != 0 {
-		return stableRunEventID(runID, runEventIdentityAttachedActivity, identityToken(attachedEventExplicitToken, uint64Bytes(sequence)))
-	}
-	digest := sha256.Sum256(frame)
-	return stableRunEventID(runID, runEventIdentityAttachedActivity, identityToken(attachedEventDerivedToken, digest[:]))
-}
-
 func terminalAgentEventID(runID string) string {
 	return stableRunEventID(runID, runEventIdentityTerminalAgent, nil)
-}
-
-func terminalActivityEventID(runID string) string {
-	return stableRunEventID(runID, runEventIdentityTerminalActivity, nil)
 }
 
 func terminalStatusEventID(runID string) string {

--- a/pkg/runs/run_event_projection.go
+++ b/pkg/runs/run_event_projection.go
@@ -6,11 +6,6 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
-const (
-	agentExecutionActivityName   = "agent_execution"
-	commandExecutionActivityName = "command_execution"
-)
-
 type agentTurnProjection struct {
 	Transcript      string
 	FinalText       string
@@ -20,118 +15,55 @@ type agentTurnProjection struct {
 }
 
 func projectAgentTerminalEvents(run domain.ProjectRunRecord, cell domain.NotebookCell, assistant domain.SandboxEvent, execErr error) []domain.ProjectRunEventRecord {
-	agent := firstNonEmpty(cell.Agent, run.AgentName)
-	finalText := ""
-	if execErr == nil && cell.Success {
-		finalText = strings.TrimSpace(assistant.Message)
+	if execErr != nil || !cell.Success {
+		return nil
 	}
-	activityText := agentActivityText(cell.Output, finalText)
-	events := make([]domain.ProjectRunEventRecord, 0, 2)
-	if activityText != "" {
-		events = append(events, domain.ProjectRunEventRecord{
-			ID:         terminalActivityEventID(run.RunID),
-			RunID:      run.RunID,
-			Kind:       domain.ProjectRunEventKindAgentActivity,
-			Text:       activityText,
-			Agent:      agent,
-			Name:       agentExecutionActivityName,
-			Success:    cell.Success,
-			ExitCode:   cell.ExitCode,
-			StopReason: cell.StopReason,
-		})
-	}
-	if finalText != "" {
-		events = append(events, domain.ProjectRunEventRecord{
-			ID:         terminalAgentEventID(run.RunID),
-			RunID:      run.RunID,
-			Kind:       domain.ProjectRunEventKindAgentMessage,
-			Text:       finalText,
-			Agent:      agent,
-			Success:    true,
-			ExitCode:   cell.ExitCode,
-			StopReason: cell.StopReason,
-		})
-	}
-	return events
-}
-
-func commandTerminalEvents(run domain.ProjectRunRecord, command string, result domain.ExecResult) []domain.ProjectRunEventRecord {
-	text := commandActivityText(command, result.Output)
-	if text == "" {
+	finalText := strings.TrimSpace(assistant.Message)
+	if finalText == "" {
 		return nil
 	}
 	return []domain.ProjectRunEventRecord{{
-		ID:       terminalActivityEventID(run.RunID),
-		RunID:    run.RunID,
-		Kind:     domain.ProjectRunEventKindAgentActivity,
-		Text:     text,
-		Agent:    run.AgentName,
-		Name:     commandExecutionActivityName,
-		Success:  result.Success,
-		ExitCode: result.ExitCode,
+		ID:         terminalAgentEventID(run.RunID),
+		RunID:      run.RunID,
+		Kind:       domain.ProjectRunEventKindAgentMessage,
+		Text:       finalText,
+		Agent:      firstNonEmpty(cell.Agent, run.AgentName),
+		Success:    true,
+		ExitCode:   cell.ExitCode,
+		StopReason: cell.StopReason,
 	}}
 }
 
 func attachedAgentTurnEvents(run domain.ProjectRunRecord, sequence uint64, frame []byte, turn agentTurnProjection) []domain.ProjectRunEventRecord {
-	agent := firstNonEmpty(turn.Provider, run.AgentName)
 	finalText := projectableFinalText(turn)
-	activityText := agentActivityText(turn.Transcript, finalText)
-	events := make([]domain.ProjectRunEventRecord, 0, 2)
-	if activityText != "" {
-		events = append(events, domain.ProjectRunEventRecord{
-			ID:         attachedActivityEventID(run.RunID, sequence, frame),
-			RunID:      run.RunID,
-			Kind:       domain.ProjectRunEventKindAgentActivity,
-			Text:       activityText,
-			Agent:      agent,
-			Name:       agentExecutionActivityName,
-			Success:    true,
-			StopReason: turn.StopReason,
-		})
+	if finalText == "" {
+		return nil
 	}
-	if finalText != "" {
-		events = append(events, domain.ProjectRunEventRecord{
-			ID:         attachedAgentEventID(run.RunID, sequence, frame),
-			RunID:      run.RunID,
-			Kind:       domain.ProjectRunEventKindAgentMessage,
-			Text:       finalText,
-			Agent:      agent,
-			Success:    true,
-			StopReason: turn.StopReason,
-		})
-	}
-	return events
+	return []domain.ProjectRunEventRecord{{
+		ID:         attachedAgentEventID(run.RunID, sequence, frame),
+		RunID:      run.RunID,
+		Kind:       domain.ProjectRunEventKindAgentMessage,
+		Text:       finalText,
+		Agent:      firstNonEmpty(turn.Provider, run.AgentName),
+		Success:    true,
+		StopReason: turn.StopReason,
+	}}
 }
 
 func terminalPromptTurnEvents(run domain.ProjectRunRecord, turn agentTurnProjection) []domain.ProjectRunEventRecord {
-	agent := firstNonEmpty(turn.Provider, run.AgentName)
 	finalText := projectableFinalText(turn)
-	activityText := agentActivityText(turn.Transcript, finalText)
-	events := make([]domain.ProjectRunEventRecord, 0, 2)
-	if activityText != "" {
-		events = append(events, domain.ProjectRunEventRecord{
-			ID:         terminalActivityEventID(run.RunID),
-			RunID:      run.RunID,
-			Kind:       domain.ProjectRunEventKindAgentActivity,
-			Text:       activityText,
-			Agent:      agent,
-			Name:       agentExecutionActivityName,
-			Success:    true,
-			StopReason: turn.StopReason,
-		})
+	if finalText == "" {
+		return nil
 	}
-	if finalText != "" {
-		events = append(events, domain.ProjectRunEventRecord{
-			ID:         terminalAgentEventID(run.RunID),
-			RunID:      run.RunID,
-			Kind:       domain.ProjectRunEventKindAgentMessage,
-			Text:       finalText,
-			Agent:      agent,
-			Success:    true,
-			StopReason: turn.StopReason,
-		})
-	}
-	return events
+	return []domain.ProjectRunEventRecord{{
+		ID:         terminalAgentEventID(run.RunID),
+		RunID:      run.RunID,
+		Kind:       domain.ProjectRunEventKindAgentMessage,
+		Text:       finalText,
+		Agent:      firstNonEmpty(turn.Provider, run.AgentName),
+		Success:    true,
+		StopReason: turn.StopReason,
+	}}
 }
 
 func projectableFinalText(turn agentTurnProjection) string {
@@ -146,45 +78,4 @@ func projectableFinalText(turn agentTurnProjection) string {
 		return ""
 	}
 	return finalText
-}
-
-func agentActivityText(transcript, finalText string) string {
-	transcript = strings.TrimSpace(transcript)
-	finalText = strings.TrimSpace(finalText)
-	if transcript == "" {
-		return ""
-	}
-	if finalText == "" {
-		return transcript
-	}
-	index := strings.LastIndex(transcript, finalText)
-	if index < 0 {
-		return transcript
-	}
-	before := strings.TrimSpace(transcript[:index])
-	after := strings.TrimSpace(transcript[index+len(finalText):])
-	return strings.TrimSpace(strings.Join(nonEmptyStrings(before, after), "\n"))
-}
-
-func commandActivityText(command, output string) string {
-	command = strings.TrimSpace(command)
-	output = strings.TrimSpace(output)
-	parts := make([]string, 0, 2)
-	if command != "" {
-		parts = append(parts, "$ "+command)
-	}
-	if output != "" {
-		parts = append(parts, output)
-	}
-	return strings.Join(parts, "\n")
-}
-
-func nonEmptyStrings(values ...string) []string {
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		if value != "" {
-			result = append(result, value)
-		}
-	}
-	return result
 }

--- a/pkg/runs/run_event_projection.go
+++ b/pkg/runs/run_event_projection.go
@@ -1,0 +1,190 @@
+package runs
+
+import (
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+const (
+	agentExecutionActivityName   = "agent_execution"
+	commandExecutionActivityName = "command_execution"
+)
+
+type agentTurnProjection struct {
+	Transcript      string
+	FinalText       string
+	FinalTextSource domain.AgentFinalTextSource
+	Provider        string
+	StopReason      string
+}
+
+func projectAgentTerminalEvents(run domain.ProjectRunRecord, cell domain.NotebookCell, assistant domain.SandboxEvent, execErr error) []domain.ProjectRunEventRecord {
+	agent := firstNonEmpty(cell.Agent, run.AgentName)
+	finalText := ""
+	if execErr == nil && cell.Success {
+		finalText = strings.TrimSpace(assistant.Message)
+	}
+	activityText := agentActivityText(cell.Output, finalText)
+	events := make([]domain.ProjectRunEventRecord, 0, 2)
+	if activityText != "" {
+		events = append(events, domain.ProjectRunEventRecord{
+			ID:         terminalActivityEventID(run.RunID),
+			RunID:      run.RunID,
+			Kind:       domain.ProjectRunEventKindAgentActivity,
+			Text:       activityText,
+			Agent:      agent,
+			Name:       agentExecutionActivityName,
+			Success:    cell.Success,
+			ExitCode:   cell.ExitCode,
+			StopReason: cell.StopReason,
+		})
+	}
+	if finalText != "" {
+		events = append(events, domain.ProjectRunEventRecord{
+			ID:         terminalAgentEventID(run.RunID),
+			RunID:      run.RunID,
+			Kind:       domain.ProjectRunEventKindAgentMessage,
+			Text:       finalText,
+			Agent:      agent,
+			Success:    true,
+			ExitCode:   cell.ExitCode,
+			StopReason: cell.StopReason,
+		})
+	}
+	return events
+}
+
+func commandTerminalEvents(run domain.ProjectRunRecord, command string, result domain.ExecResult) []domain.ProjectRunEventRecord {
+	text := commandActivityText(command, result.Output)
+	if text == "" {
+		return nil
+	}
+	return []domain.ProjectRunEventRecord{{
+		ID:       terminalActivityEventID(run.RunID),
+		RunID:    run.RunID,
+		Kind:     domain.ProjectRunEventKindAgentActivity,
+		Text:     text,
+		Agent:    run.AgentName,
+		Name:     commandExecutionActivityName,
+		Success:  result.Success,
+		ExitCode: result.ExitCode,
+	}}
+}
+
+func attachedAgentTurnEvents(run domain.ProjectRunRecord, sequence uint64, frame []byte, turn agentTurnProjection) []domain.ProjectRunEventRecord {
+	agent := firstNonEmpty(turn.Provider, run.AgentName)
+	finalText := projectableFinalText(turn)
+	activityText := agentActivityText(turn.Transcript, finalText)
+	events := make([]domain.ProjectRunEventRecord, 0, 2)
+	if activityText != "" {
+		events = append(events, domain.ProjectRunEventRecord{
+			ID:         attachedActivityEventID(run.RunID, sequence, frame),
+			RunID:      run.RunID,
+			Kind:       domain.ProjectRunEventKindAgentActivity,
+			Text:       activityText,
+			Agent:      agent,
+			Name:       agentExecutionActivityName,
+			Success:    true,
+			StopReason: turn.StopReason,
+		})
+	}
+	if finalText != "" {
+		events = append(events, domain.ProjectRunEventRecord{
+			ID:         attachedAgentEventID(run.RunID, sequence, frame),
+			RunID:      run.RunID,
+			Kind:       domain.ProjectRunEventKindAgentMessage,
+			Text:       finalText,
+			Agent:      agent,
+			Success:    true,
+			StopReason: turn.StopReason,
+		})
+	}
+	return events
+}
+
+func terminalPromptTurnEvents(run domain.ProjectRunRecord, turn agentTurnProjection) []domain.ProjectRunEventRecord {
+	agent := firstNonEmpty(turn.Provider, run.AgentName)
+	finalText := projectableFinalText(turn)
+	activityText := agentActivityText(turn.Transcript, finalText)
+	events := make([]domain.ProjectRunEventRecord, 0, 2)
+	if activityText != "" {
+		events = append(events, domain.ProjectRunEventRecord{
+			ID:         terminalActivityEventID(run.RunID),
+			RunID:      run.RunID,
+			Kind:       domain.ProjectRunEventKindAgentActivity,
+			Text:       activityText,
+			Agent:      agent,
+			Name:       agentExecutionActivityName,
+			Success:    true,
+			StopReason: turn.StopReason,
+		})
+	}
+	if finalText != "" {
+		events = append(events, domain.ProjectRunEventRecord{
+			ID:         terminalAgentEventID(run.RunID),
+			RunID:      run.RunID,
+			Kind:       domain.ProjectRunEventKindAgentMessage,
+			Text:       finalText,
+			Agent:      agent,
+			Success:    true,
+			StopReason: turn.StopReason,
+		})
+	}
+	return events
+}
+
+func projectableFinalText(turn agentTurnProjection) string {
+	finalText := strings.TrimSpace(turn.FinalText)
+	if turn.FinalTextSource == domain.AgentFinalTextSourceProviderMessage {
+		return finalText
+	}
+	if turn.FinalTextSource != "" || finalText == "" {
+		return ""
+	}
+	if transcript := strings.TrimSpace(turn.Transcript); transcript != "" && transcript == finalText {
+		return ""
+	}
+	return finalText
+}
+
+func agentActivityText(transcript, finalText string) string {
+	transcript = strings.TrimSpace(transcript)
+	finalText = strings.TrimSpace(finalText)
+	if transcript == "" {
+		return ""
+	}
+	if finalText == "" {
+		return transcript
+	}
+	index := strings.LastIndex(transcript, finalText)
+	if index < 0 {
+		return transcript
+	}
+	before := strings.TrimSpace(transcript[:index])
+	after := strings.TrimSpace(transcript[index+len(finalText):])
+	return strings.TrimSpace(strings.Join(nonEmptyStrings(before, after), "\n"))
+}
+
+func commandActivityText(command, output string) string {
+	command = strings.TrimSpace(command)
+	output = strings.TrimSpace(output)
+	parts := make([]string, 0, 2)
+	if command != "" {
+		parts = append(parts, "$ "+command)
+	}
+	if output != "" {
+		parts = append(parts, output)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func nonEmptyStrings(values ...string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}

--- a/pkg/runs/run_event_projection_test.go
+++ b/pkg/runs/run_event_projection_test.go
@@ -1,13 +1,12 @@
 package runs
 
 import (
-	"strings"
 	"testing"
 
 	domain "agent-compose/pkg/model"
 )
 
-func TestProjectAgentTerminalEventsSeparateTranscriptFromFinalMessage(t *testing.T) {
+func TestProjectAgentTerminalEventsOnlyPersistFinalMessage(t *testing.T) {
 	run := domain.ProjectRunRecord{RunID: "run-agent-events", AgentName: "worker"}
 	cell := domain.NotebookCell{
 		Agent:      "codex",
@@ -16,48 +15,24 @@ func TestProjectAgentTerminalEventsSeparateTranscriptFromFinalMessage(t *testing
 		StopReason: "completed",
 	}
 	events := projectAgentTerminalEvents(run, cell, domain.SandboxEvent{Message: "Beijing is 26°C today."}, nil)
-	if len(events) != 2 {
+	if len(events) != 1 {
 		t.Fatalf("terminal events = %#v", events)
 	}
-	if events[0].Kind != domain.ProjectRunEventKindAgentActivity || !strings.Contains(events[0].Text, "curl https://weather.test") || strings.Contains(events[0].Text, "Beijing is 26°C today.") {
-		t.Fatalf("activity event = %#v", events[0])
-	}
-	if events[1].Kind != domain.ProjectRunEventKindAgentMessage || events[1].Text != "Beijing is 26°C today." || strings.Contains(events[1].Text, "curl") {
-		t.Fatalf("agent message event = %#v", events[1])
+	if events[0].Kind != domain.ProjectRunEventKindAgentMessage || events[0].Text != "Beijing is 26°C today." {
+		t.Fatalf("agent message event = %#v", events[0])
 	}
 }
 
-func TestCommandTerminalEventsOnlyProjectActivity(t *testing.T) {
-	events := commandTerminalEvents(
-		domain.ProjectRunRecord{RunID: "run-command-events", AgentName: "worker"},
-		"curl https://weather.test",
-		domain.ExecResult{Output: "{\"temperature\":26}\n", Success: true},
-	)
-	if len(events) != 1 || events[0].Kind != domain.ProjectRunEventKindAgentActivity || events[0].Name != commandExecutionActivityName {
-		t.Fatalf("command events = %#v", events)
-	}
-	if !strings.Contains(events[0].Text, "$ curl https://weather.test") || !strings.Contains(events[0].Text, `{"temperature":26}`) {
-		t.Fatalf("command activity text = %q", events[0].Text)
-	}
-}
-
-func TestAgentActivityTextKeepsTranscriptWhenFinalMessageIsUnavailable(t *testing.T) {
-	transcript := "$ command\noutput"
-	if got := agentActivityText(transcript, "different final"); got != transcript {
-		t.Fatalf("activity text = %q, want %q", got, transcript)
-	}
-}
-
-func TestFailedAgentTerminalEventsDoNotCreateAssistantMessage(t *testing.T) {
+func TestFailedAgentTerminalEventsDoNotPersistTranscript(t *testing.T) {
 	run := domain.ProjectRunRecord{RunID: "run-agent-failure", AgentName: "worker"}
 	cell := domain.NotebookCell{Agent: "codex", Output: "$ curl https://weather.test\nrequest failed", ExitCode: 1}
 	events := projectAgentTerminalEvents(run, cell, domain.SandboxEvent{Message: "codex run failed"}, nil)
-	if len(events) != 1 || events[0].Kind != domain.ProjectRunEventKindAgentActivity || events[0].Success {
-		t.Fatalf("failed agent events = %#v", events)
+	if len(events) != 0 {
+		t.Fatalf("failed agent events = %#v, want none", events)
 	}
 }
 
-func TestTranscriptFallbackOnlyProjectsAgentActivity(t *testing.T) {
+func TestTranscriptFallbackDoesNotPersistRunEvent(t *testing.T) {
 	transcript := "$ curl https://weather.test\n{\"temperature\":26}"
 	events := attachedAgentTurnEvents(
 		domain.ProjectRunRecord{RunID: "run-fallback", AgentName: "worker"},
@@ -70,15 +45,12 @@ func TestTranscriptFallbackOnlyProjectsAgentActivity(t *testing.T) {
 			Provider:        "codex",
 		},
 	)
-	if len(events) != 1 || events[0].Kind != domain.ProjectRunEventKindAgentActivity {
-		t.Fatalf("fallback events = %#v", events)
-	}
-	if events[0].Text != transcript {
-		t.Fatalf("fallback activity text = %q, want %q", events[0].Text, transcript)
+	if len(events) != 0 {
+		t.Fatalf("fallback events = %#v, want none", events)
 	}
 }
 
-func TestProviderFinalTextProjectsAgentMessage(t *testing.T) {
+func TestProviderFinalTextPersistsAgentMessage(t *testing.T) {
 	events := terminalPromptTurnEvents(
 		domain.ProjectRunRecord{RunID: "run-provider-message", AgentName: "worker"},
 		agentTurnProjection{
@@ -88,7 +60,7 @@ func TestProviderFinalTextProjectsAgentMessage(t *testing.T) {
 			Provider:        "codex",
 		},
 	)
-	if len(events) != 2 || events[1].Kind != domain.ProjectRunEventKindAgentMessage || events[1].Text != "final answer" {
+	if len(events) != 1 || events[0].Kind != domain.ProjectRunEventKindAgentMessage || events[0].Text != "final answer" {
 		t.Fatalf("provider message events = %#v", events)
 	}
 }

--- a/pkg/runs/run_event_projection_test.go
+++ b/pkg/runs/run_event_projection_test.go
@@ -1,0 +1,94 @@
+package runs
+
+import (
+	"strings"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestProjectAgentTerminalEventsSeparateTranscriptFromFinalMessage(t *testing.T) {
+	run := domain.ProjectRunRecord{RunID: "run-agent-events", AgentName: "worker"}
+	cell := domain.NotebookCell{
+		Agent:      "codex",
+		Output:     "checking weather\n$ curl https://weather.test\n{\"temperature\":26}\nBeijing is 26°C today.",
+		Success:    true,
+		StopReason: "completed",
+	}
+	events := projectAgentTerminalEvents(run, cell, domain.SandboxEvent{Message: "Beijing is 26°C today."}, nil)
+	if len(events) != 2 {
+		t.Fatalf("terminal events = %#v", events)
+	}
+	if events[0].Kind != domain.ProjectRunEventKindAgentActivity || !strings.Contains(events[0].Text, "curl https://weather.test") || strings.Contains(events[0].Text, "Beijing is 26°C today.") {
+		t.Fatalf("activity event = %#v", events[0])
+	}
+	if events[1].Kind != domain.ProjectRunEventKindAgentMessage || events[1].Text != "Beijing is 26°C today." || strings.Contains(events[1].Text, "curl") {
+		t.Fatalf("agent message event = %#v", events[1])
+	}
+}
+
+func TestCommandTerminalEventsOnlyProjectActivity(t *testing.T) {
+	events := commandTerminalEvents(
+		domain.ProjectRunRecord{RunID: "run-command-events", AgentName: "worker"},
+		"curl https://weather.test",
+		domain.ExecResult{Output: "{\"temperature\":26}\n", Success: true},
+	)
+	if len(events) != 1 || events[0].Kind != domain.ProjectRunEventKindAgentActivity || events[0].Name != commandExecutionActivityName {
+		t.Fatalf("command events = %#v", events)
+	}
+	if !strings.Contains(events[0].Text, "$ curl https://weather.test") || !strings.Contains(events[0].Text, `{"temperature":26}`) {
+		t.Fatalf("command activity text = %q", events[0].Text)
+	}
+}
+
+func TestAgentActivityTextKeepsTranscriptWhenFinalMessageIsUnavailable(t *testing.T) {
+	transcript := "$ command\noutput"
+	if got := agentActivityText(transcript, "different final"); got != transcript {
+		t.Fatalf("activity text = %q, want %q", got, transcript)
+	}
+}
+
+func TestFailedAgentTerminalEventsDoNotCreateAssistantMessage(t *testing.T) {
+	run := domain.ProjectRunRecord{RunID: "run-agent-failure", AgentName: "worker"}
+	cell := domain.NotebookCell{Agent: "codex", Output: "$ curl https://weather.test\nrequest failed", ExitCode: 1}
+	events := projectAgentTerminalEvents(run, cell, domain.SandboxEvent{Message: "codex run failed"}, nil)
+	if len(events) != 1 || events[0].Kind != domain.ProjectRunEventKindAgentActivity || events[0].Success {
+		t.Fatalf("failed agent events = %#v", events)
+	}
+}
+
+func TestTranscriptFallbackOnlyProjectsAgentActivity(t *testing.T) {
+	transcript := "$ curl https://weather.test\n{\"temperature\":26}"
+	events := attachedAgentTurnEvents(
+		domain.ProjectRunRecord{RunID: "run-fallback", AgentName: "worker"},
+		7,
+		[]byte("fallback-frame"),
+		agentTurnProjection{
+			Transcript:      transcript,
+			FinalText:       transcript,
+			FinalTextSource: domain.AgentFinalTextSourceTranscriptFallback,
+			Provider:        "codex",
+		},
+	)
+	if len(events) != 1 || events[0].Kind != domain.ProjectRunEventKindAgentActivity {
+		t.Fatalf("fallback events = %#v", events)
+	}
+	if events[0].Text != transcript {
+		t.Fatalf("fallback activity text = %q, want %q", events[0].Text, transcript)
+	}
+}
+
+func TestProviderFinalTextProjectsAgentMessage(t *testing.T) {
+	events := terminalPromptTurnEvents(
+		domain.ProjectRunRecord{RunID: "run-provider-message", AgentName: "worker"},
+		agentTurnProjection{
+			Transcript:      "$ command\noutput\nfinal answer",
+			FinalText:       "final answer",
+			FinalTextSource: domain.AgentFinalTextSourceProviderMessage,
+			Provider:        "codex",
+		},
+	)
+	if len(events) != 2 || events[1].Kind != domain.ProjectRunEventKindAgentMessage || events[1].Text != "final answer" {
+		t.Fatalf("provider message events = %#v", events)
+	}
+}

--- a/pkg/runs/run_event_test.go
+++ b/pkg/runs/run_event_test.go
@@ -9,7 +9,9 @@ func TestRunEventIDsAreStableAndTypeSeparated(t *testing.T) {
 		initialPromptEventID(runID),
 		attachedHumanEventID(runID, "frame-1", 1, "question"),
 		attachedAgentEventID(runID, 1, frame),
+		attachedActivityEventID(runID, 1, frame),
 		terminalAgentEventID(runID),
+		terminalActivityEventID(runID),
 		terminalStatusEventID(runID),
 	}
 	seen := make(map[string]struct{}, len(identities))
@@ -28,6 +30,9 @@ func TestRunEventIDsAreStableAndTypeSeparated(t *testing.T) {
 	if got := attachedAgentEventID(runID, 1, []byte("changed")); got != identities[2] {
 		t.Fatalf("sequenced agent retry id = %q, want %q", got, identities[2])
 	}
+	if got := attachedActivityEventID(runID, 1, []byte("changed")); got != identities[3] {
+		t.Fatalf("sequenced activity retry id = %q, want %q", got, identities[3])
+	}
 }
 
 func TestRunEventFallbackIDsIncludeFrameIdentity(t *testing.T) {
@@ -45,5 +50,12 @@ func TestRunEventFallbackIDsIncludeFrameIdentity(t *testing.T) {
 	}
 	if changedFrame := attachedAgentEventID(runID, 0, []byte("frame-two")); changedFrame == agent {
 		t.Fatal("different agent frame produced the same event id")
+	}
+	activity := attachedActivityEventID(runID, 0, []byte("frame-one"))
+	if repeated := attachedActivityEventID(runID, 0, []byte("frame-one")); repeated != activity {
+		t.Fatalf("activity fallback retry id = %q, want %q", repeated, activity)
+	}
+	if changedFrame := attachedActivityEventID(runID, 0, []byte("frame-two")); changedFrame == activity {
+		t.Fatal("different activity frame produced the same event id")
 	}
 }

--- a/pkg/runs/run_event_test.go
+++ b/pkg/runs/run_event_test.go
@@ -9,9 +9,7 @@ func TestRunEventIDsAreStableAndTypeSeparated(t *testing.T) {
 		initialPromptEventID(runID),
 		attachedHumanEventID(runID, "frame-1", 1, "question"),
 		attachedAgentEventID(runID, 1, frame),
-		attachedActivityEventID(runID, 1, frame),
 		terminalAgentEventID(runID),
-		terminalActivityEventID(runID),
 		terminalStatusEventID(runID),
 	}
 	seen := make(map[string]struct{}, len(identities))
@@ -30,9 +28,6 @@ func TestRunEventIDsAreStableAndTypeSeparated(t *testing.T) {
 	if got := attachedAgentEventID(runID, 1, []byte("changed")); got != identities[2] {
 		t.Fatalf("sequenced agent retry id = %q, want %q", got, identities[2])
 	}
-	if got := attachedActivityEventID(runID, 1, []byte("changed")); got != identities[3] {
-		t.Fatalf("sequenced activity retry id = %q, want %q", got, identities[3])
-	}
 }
 
 func TestRunEventFallbackIDsIncludeFrameIdentity(t *testing.T) {
@@ -50,12 +45,5 @@ func TestRunEventFallbackIDsIncludeFrameIdentity(t *testing.T) {
 	}
 	if changedFrame := attachedAgentEventID(runID, 0, []byte("frame-two")); changedFrame == agent {
 		t.Fatal("different agent frame produced the same event id")
-	}
-	activity := attachedActivityEventID(runID, 0, []byte("frame-one"))
-	if repeated := attachedActivityEventID(runID, 0, []byte("frame-one")); repeated != activity {
-		t.Fatalf("activity fallback retry id = %q, want %q", repeated, activity)
-	}
-	if changedFrame := attachedActivityEventID(runID, 0, []byte("frame-two")); changedFrame == activity {
-		t.Fatal("different activity frame produced the same event id")
 	}
 }

--- a/runtime/javascript/src/interactive.ts
+++ b/runtime/javascript/src/interactive.ts
@@ -56,6 +56,7 @@ export class CodexInteractiveSession implements InteractiveSession {
       threadId: "",
       stopReason: "completed",
       finalText: "",
+      finalTextSource: "none",
       transcript: "",
       stderr: "",
     };
@@ -90,6 +91,8 @@ export class CodexInteractiveSession implements InteractiveSession {
       this.writer.beginTurn();
     }
     this.turnCount++;
+    this.result.finalText = "";
+    this.result.finalTextSource = "none";
     const { events } = await this.thread.runStreamed(
       message,
       this.options.outputSchema ? { outputSchema: this.options.outputSchema } : undefined,
@@ -103,12 +106,14 @@ export class CodexInteractiveSession implements InteractiveSession {
     this.result.transcript = this.runner.transcript();
     if (!this.result.finalText && this.result.transcript) {
       this.result.finalText = this.result.transcript;
+      this.result.finalTextSource = "transcript_fallback";
     }
     await writeStoredThread(this.options.stateRoot, "codex", this.result.threadId);
     this.emit("agent_turn_completed", {
       provider: "codex",
       threadId: this.result.threadId,
       finalText: this.result.finalText,
+      finalTextSource: this.result.finalTextSource,
     });
   }
 
@@ -116,9 +121,6 @@ export class CodexInteractiveSession implements InteractiveSession {
     this.result.stopReason = stopReason;
     this.result.threadId = this.thread?.id || this.result.threadId;
     this.result.transcript = this.runner.transcript();
-    if (!this.result.finalText && this.result.transcript) {
-      this.result.finalText = this.result.transcript;
-    }
     if (this.result.threadId) {
       await writeStoredThread(this.options.stateRoot, "codex", this.result.threadId);
     }
@@ -150,6 +152,7 @@ class PromptRunnerInteractiveSession implements InteractiveSession {
       threadId: "",
       stopReason: "completed",
       finalText: "",
+      finalTextSource: "none",
       transcript: "",
       stderr: "",
     };
@@ -177,12 +180,14 @@ class PromptRunnerInteractiveSession implements InteractiveSession {
     this.result.threadId = turnResult.threadId || this.result.threadId;
     this.result.stopReason = turnResult.stopReason;
     this.result.finalText = turnResult.finalText;
+    this.result.finalTextSource = turnResult.finalTextSource;
     this.result.transcript = turnResult.transcript;
     this.result.stderr = turnResult.stderr;
     this.emit("agent_turn_completed", {
       provider: this.provider,
       threadId: this.result.threadId,
       finalText: this.result.finalText,
+      finalTextSource: this.result.finalTextSource,
       stopReason: this.result.stopReason,
     });
   }

--- a/runtime/javascript/src/runners/claude.ts
+++ b/runtime/javascript/src/runners/claude.ts
@@ -198,6 +198,7 @@ export class ClaudeRunner {
       threadId: stored?.threadId || "",
       stopReason: "completed",
       finalText: "",
+      finalTextSource: "none",
       transcript: "",
       stderr: "",
     };
@@ -222,6 +223,7 @@ export class ClaudeRunner {
                 : "";
               if (textBlocks) {
                 result.finalText = textBlocks;
+                result.finalTextSource = "provider_message";
               }
             }
             break;
@@ -247,9 +249,13 @@ export class ClaudeRunner {
           case "result":
             result.stopReason = String(message.stop_reason || result.stopReason);
             if (message.subtype === "success") {
-              result.finalText = hasOwn(message, "structured_output")
+              const finalText = hasOwn(message, "structured_output")
                 ? JSON.stringify(message.structured_output)
                 : String(message.result || result.finalText);
+              if (finalText) {
+                result.finalText = finalText;
+                result.finalTextSource = "provider_message";
+              }
               stream.close?.();
               break messages;
             } else {
@@ -273,6 +279,7 @@ export class ClaudeRunner {
     result.transcript = this.writer.transcript();
     if (!result.finalText && result.transcript) {
       result.finalText = result.transcript;
+      result.finalTextSource = "transcript_fallback";
     }
     await writeStoredThread(this.options.stateRoot, "claude", result.threadId);
     return result;

--- a/runtime/javascript/src/runners/codex.ts
+++ b/runtime/javascript/src/runners/codex.ts
@@ -155,7 +155,11 @@ export class CodexRunner {
       case "agent_message":
         appendDelta(this.writer, this.itemState as Map<string, string>, item.id, String(item.text || ""));
         if (event.type === "item.completed") {
-          result.finalText = String(item.text || result.finalText);
+          const finalText = String(item.text || "");
+          if (finalText) {
+            result.finalText = finalText;
+            result.finalTextSource = "provider_message";
+          }
         }
         break;
       case "reasoning":
@@ -206,6 +210,7 @@ export class CodexRunner {
       threadId: stored?.threadId || "",
       stopReason: "completed",
       finalText: "",
+      finalTextSource: "none",
       transcript: "",
       stderr: "",
     };
@@ -221,6 +226,7 @@ export class CodexRunner {
     result.transcript = this.writer.transcript();
     if (!result.finalText && result.transcript) {
       result.finalText = result.transcript;
+      result.finalTextSource = "transcript_fallback";
     }
     await writeStoredThread(this.options.stateRoot, "codex", result.threadId);
     return result;

--- a/runtime/javascript/src/runners/gemini.ts
+++ b/runtime/javascript/src/runners/gemini.ts
@@ -59,6 +59,7 @@ export class GeminiRunner {
       threadId: "",
       stopReason: "completed",
       finalText: "",
+      finalTextSource: "none",
       transcript: "",
       stderr: "",
     };
@@ -128,7 +129,11 @@ export class GeminiRunner {
         continue;
       }
       if (eventType === "result") {
-        result.finalText = extractText(event?.response) || extractText(event?.result) || result.finalText;
+        const finalText = extractText(event?.response) || extractText(event?.result);
+        if (finalText) {
+          result.finalText = finalText;
+          result.finalTextSource = "provider_message";
+        }
         result.stopReason = event?.error ? "error" : "completed";
       }
     }
@@ -144,6 +149,7 @@ export class GeminiRunner {
     result.transcript = this.writer.transcript();
     if (!result.finalText && result.transcript) {
       result.finalText = result.transcript;
+      result.finalTextSource = "transcript_fallback";
     }
     return result;
   }

--- a/runtime/javascript/src/runners/opencode.ts
+++ b/runtime/javascript/src/runners/opencode.ts
@@ -164,6 +164,7 @@ export class OpenCodeRunner {
       const finalText = extractText(event.response) || extractText(event.result) || text;
       if (finalText) {
         result.finalText = finalText;
+        result.finalTextSource = "provider_message";
       }
       result.stopReason = stringField(event, "stopReason", "stop_reason", "finishReason", "finish_reason") || result.stopReason;
     }
@@ -181,6 +182,7 @@ export class OpenCodeRunner {
       threadId: stored?.threadId || "",
       stopReason: "completed",
       finalText: "",
+      finalTextSource: "none",
       transcript: "",
       stderr: "",
     };
@@ -233,6 +235,7 @@ export class OpenCodeRunner {
     result.transcript = this.writer.transcript();
     if (!result.finalText && result.transcript) {
       result.finalText = result.transcript;
+      result.finalTextSource = "transcript_fallback";
     }
     await writeStoredThread(this.options.stateRoot, "opencode", result.threadId);
     return result;

--- a/runtime/javascript/src/runners/opencode.ts
+++ b/runtime/javascript/src/runners/opencode.ts
@@ -12,6 +12,8 @@ import { flattenEnvMap } from "../mcp-config.js";
 
 export class OpenCodeRunner {
   private skillsConfigDir?: string;
+  private providerMessageID = "";
+  private providerMessageText = "";
 
   constructor(
     private readonly options: RunnerOptions,
@@ -160,6 +162,29 @@ export class OpenCodeRunner {
       this.writer.write(text);
     }
 
+    if (eventType === "text" && text) {
+      const part = isRecord(event.part) ? event.part : {};
+      const messageID = stringField(part, "messageID", "messageId", "message_id") ||
+        stringField(event, "messageID", "messageId", "message_id");
+      if (messageID && messageID !== this.providerMessageID) {
+        this.providerMessageID = messageID;
+        this.providerMessageText = "";
+      }
+      this.providerMessageText += text;
+    }
+
+    if (eventType === "step_finish" || eventType === "step-finish") {
+      const part = isRecord(event.part) ? event.part : {};
+      const stopReason = stringField(part, "reason", "stopReason", "stop_reason");
+      result.stopReason = stopReason || result.stopReason;
+      if (this.providerMessageText && stopReason !== "tool-calls" && stopReason !== "tool_calls") {
+        result.finalText = this.providerMessageText;
+        result.finalTextSource = "provider_message";
+      }
+      this.providerMessageID = "";
+      this.providerMessageText = "";
+    }
+
     if (eventType === "result" || eventType === "complete" || eventType === "completed") {
       const finalText = extractText(event.response) || extractText(event.result) || text;
       if (finalText) {
@@ -175,6 +200,8 @@ export class OpenCodeRunner {
     if (this.options.outputSchema) {
       throw new Error("structured JSON output is not supported by opencode runner");
     }
+    this.providerMessageID = "";
+    this.providerMessageText = "";
 
     const stored = await readStoredThread(this.options.stateRoot, "opencode");
     const result: AgentResult = {

--- a/runtime/javascript/src/runners/pi.ts
+++ b/runtime/javascript/src/runners/pi.ts
@@ -66,6 +66,7 @@ export class PiRunner {
         threadId: "",
         stopReason: "completed",
         finalText: "",
+        finalTextSource: "none",
         transcript: "",
         stderr: "",
       };
@@ -98,7 +99,10 @@ export class PiRunner {
         throw new Error("pi completed without emitting a session id");
       }
       result.transcript = this.writer.transcript();
-      if (!result.finalText) result.finalText = lastAssistantTextFromTranscript(result.transcript);
+      if (!result.finalText && result.transcript) {
+        result.finalText = lastAssistantTextFromTranscript(result.transcript);
+        result.finalTextSource = "transcript_fallback";
+      }
       await writeStoredThread(this.options.stateRoot, "pi", result.threadId);
       return result;
     } finally {
@@ -162,7 +166,11 @@ export class PiRunner {
         } else {
           this.latestAssistantError = null;
         }
-        result.finalText = extractText(message?.content) || extractText(event.content) || result.finalText;
+        const finalText = extractText(message?.content) || extractText(event.content);
+        if (finalText) {
+          result.finalText = finalText;
+          result.finalTextSource = "provider_message";
+        }
       }
       return;
     }
@@ -171,7 +179,13 @@ export class PiRunner {
     }
     if (type === "agent_end") {
       result.stopReason = firstString(event, "stopReason", "stop_reason") || "completed";
-      result.finalText ||= lastAssistantMessage(event.messages);
+      if (!result.finalText) {
+        const finalText = lastAssistantMessage(event.messages);
+        if (finalText) {
+          result.finalText = finalText;
+          result.finalTextSource = "provider_message";
+        }
+      }
       this.reportedError ??= this.latestAssistantError
         || (result.stopReason === "error" ? new Error("pi agent ended with an error") : null);
       return;
@@ -254,5 +268,5 @@ function lastAssistantMessage(value: unknown): string {
 }
 
 function lastAssistantTextFromTranscript(transcript: string): string {
-  return transcript.trim();
+	return transcript.trim();
 }

--- a/runtime/javascript/src/types.ts
+++ b/runtime/javascript/src/types.ts
@@ -1,11 +1,13 @@
 export type Provider = "codex" | "claude" | "gemini" | "opencode" | "pi";
 export type RuntimeJsonSchema = Record<string, unknown>;
+export type FinalTextSource = "none" | "provider_message" | "transcript_fallback";
 
 export interface AgentResult {
   provider: Provider;
   threadId: string;
   stopReason: string;
   finalText: string;
+  finalTextSource: FinalTextSource;
   transcript: string;
   stderr: string;
 }

--- a/runtime/javascript/test/pi-runner.test.ts
+++ b/runtime/javascript/test/pi-runner.test.ts
@@ -82,6 +82,7 @@ describe("PiRunner", () => {
           threadId: "pi-session",
           stopReason: "end_turn",
           finalText: "final answer",
+          finalTextSource: "provider_message",
         });
         expect(result.transcript).toContain("hello");
         expect(result.transcript).not.toContain("secret-tool");
@@ -112,6 +113,21 @@ describe("PiRunner", () => {
       await expect(fs.access(systemPath)).rejects.toThrow();
       const stored = JSON.parse(await fs.readFile(path.join(root, "state", "agents", "providers", "pi.json"), "utf8"));
       expect(stored.threadId).toBe("pi-session");
+    });
+  });
+
+  it("marks Pi transcript fallback when no assistant message completes", async () => {
+    const { PiRunner } = await import("../src/runners/pi.js");
+    await withTempSession(async (root) => {
+      processState.lines = [
+        JSON.stringify({ type: "session", id: "pi-session" }),
+        JSON.stringify({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "partial output" } }),
+        JSON.stringify({ type: "agent_end", stopReason: "completed" }),
+      ];
+      const result = await new PiRunner(runnerOptions(root, "", "pi")).runPrompt("prompt");
+      expect(result.finalText).toBe("partial output");
+      expect(result.finalTextSource).toBe("transcript_fallback");
+      expect(result.transcript).toBe(result.finalText);
     });
   });
 

--- a/runtime/javascript/test/runner-execution.test.ts
+++ b/runtime/javascript/test/runner-execution.test.ts
@@ -618,6 +618,39 @@ describe("runner execution", () => {
     });
   });
 
+  it("recognizes current OpenCode CLI text events as a provider message", async () => {
+    const { OpenCodeRunner } = await import("../src/runners/opencode.js");
+    await withTempSession(async (root) => {
+      childProcessState.stdoutLines = [
+        JSON.stringify({
+          type: "step_start",
+          sessionID: "opencode-session",
+          part: { type: "step-start", messageID: "opencode-message" },
+        }),
+        JSON.stringify({
+          type: "text",
+          sessionID: "opencode-session",
+          part: { type: "text", messageID: "opencode-message", text: "OpenCode final" },
+        }),
+        JSON.stringify({
+          type: "step_finish",
+          sessionID: "opencode-session",
+          part: { type: "step-finish", messageID: "opencode-message", reason: "stop" },
+        }),
+      ];
+
+      const result = await new OpenCodeRunner(runnerOptions(root, "", "opencode")).runPrompt("prompt");
+
+      expect(result).toMatchObject({
+        threadId: "opencode-session",
+        stopReason: "stop",
+        finalText: "OpenCode final",
+        finalTextSource: "provider_message",
+        transcript: "OpenCode final",
+      });
+    });
+  });
+
   it("runs Gemini stream-json output and keeps stdout protocol clean", async () => {
     const { GeminiRunner } = await import("../src/runners/gemini.js");
     await withTempSession(async (root) => {

--- a/runtime/javascript/test/runner-execution.test.ts
+++ b/runtime/javascript/test/runner-execution.test.ts
@@ -149,6 +149,7 @@ describe("runner execution", () => {
           provider: "codex",
           threadId: "thread-new",
           finalText: "codex answer",
+          finalTextSource: "provider_message",
           transcript: "codex answer",
         });
       } finally {
@@ -160,6 +161,19 @@ describe("runner execution", () => {
       });
       const stored = JSON.parse(await fs.readFile(path.join(root, "state", "agents", "providers", "codex.json"), "utf8"));
       expect(stored.threadId).toBe("thread-new");
+    });
+  });
+
+  it("marks Codex transcript fallback without treating it as a provider message", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      codexState.events = [
+        { type: "item.completed", item: { id: "cmd", type: "command_execution", command: "pwd", aggregated_output: "/work\n" } },
+      ];
+      const result = await new CodexRunner(runnerOptions(root)).runPrompt("prompt");
+      expect(result.finalText).toContain("$ pwd");
+      expect(result.finalTextSource).toBe("transcript_fallback");
+      expect(result.transcript).toBe(result.finalText);
     });
   });
 
@@ -317,6 +331,7 @@ describe("runner execution", () => {
           threadId: "claude-session",
           stopReason: "end_turn",
           finalText: "final claude",
+          finalTextSource: "provider_message",
         });
         expect(result.transcript).toContain("partial");
         expect(result.transcript).toContain("used tool");
@@ -497,7 +512,7 @@ describe("runner execution", () => {
     });
   });
 
-  it("uses Claude transcript as final text when no result text is present", async () => {
+  it("marks Claude transcript fallback when no provider message is present", async () => {
     const { ClaudeRunner } = await import("../src/runners/claude.js");
     await withTempSession(async (root) => {
       claudeState.messages = [
@@ -507,9 +522,24 @@ describe("runner execution", () => {
       try {
         const result = await new ClaudeRunner(runnerOptions(root, "", "claude")).runPrompt("prompt");
         expect(result.finalText).toBe("transcript only");
+        expect(result.finalTextSource).toBe("transcript_fallback");
       } finally {
         stdio.restore();
       }
+    });
+  });
+
+  it("marks Gemini transcript fallback when no result message is present", async () => {
+    const { GeminiRunner } = await import("../src/runners/gemini.js");
+    await withTempSession(async (root) => {
+      childProcessState.stdoutLines = [
+        JSON.stringify({ type: "message", message: { text: "working" } }),
+        JSON.stringify({ type: "tool_result", result: { text: "tool output" } }),
+      ];
+      const result = await new GeminiRunner(runnerOptions(root, "", "gemini")).runPrompt("prompt");
+      expect(result.finalText).toContain("tool output");
+      expect(result.finalTextSource).toBe("transcript_fallback");
+      expect(result.transcript).toBe(result.finalText);
     });
   });
 
@@ -533,6 +563,7 @@ describe("runner execution", () => {
           provider: "gemini",
           threadId: "gemini-session",
           finalText: "gemini final",
+          finalTextSource: "provider_message",
         });
         expect(childProcessState.spawnCalls.at(-1)).toMatchObject({
           command: "gemini",
@@ -573,6 +604,20 @@ describe("runner execution", () => {
     });
   });
 
+  it("marks OpenCode transcript fallback when no completion message is present", async () => {
+    const { OpenCodeRunner } = await import("../src/runners/opencode.js");
+    await withTempSession(async (root) => {
+      childProcessState.stdoutLines = [
+        JSON.stringify({ type: "message", sessionID: "opencode-session", message: { content: "working" } }),
+        JSON.stringify({ type: "tool_result", result: { text: "tool output" } }),
+      ];
+      const result = await new OpenCodeRunner(runnerOptions(root, "", "opencode")).runPrompt("prompt");
+      expect(result.finalText).toContain("tool output");
+      expect(result.finalTextSource).toBe("transcript_fallback");
+      expect(result.transcript).toBe(result.finalText);
+    });
+  });
+
   it("runs Gemini stream-json output and keeps stdout protocol clean", async () => {
     const { GeminiRunner } = await import("../src/runners/gemini.js");
     await withTempSession(async (root) => {
@@ -596,6 +641,7 @@ describe("runner execution", () => {
           provider: "gemini",
           threadId: "gemini-session",
           finalText: "gemini final",
+          finalTextSource: "provider_message",
         });
         expect(result.transcript).toContain("hello");
         expect(result.transcript).toContain("[tool:ReadFile]");

--- a/runtime/javascript/test/runners.test.ts
+++ b/runtime/javascript/test/runners.test.ts
@@ -37,6 +37,7 @@ describe("CodexRunner", () => {
         threadId: "",
         stopReason: "completed",
         finalText: "",
+        finalTextSource: "none" as const,
         transcript: "",
         stderr: "",
       };
@@ -89,6 +90,7 @@ describe("CodexRunner", () => {
 
       expect(result.threadId).toBe("thread-1");
       expect(result.finalText).toBe("hello!");
+      expect(result.finalTextSource).toBe("provider_message");
       expect(stdio.stderr).toContain("hello");
       expect(stdio.stderr).toContain("$ pwd");
       expect(stdio.stderr).toContain("[file_change]");
@@ -114,6 +116,7 @@ describe("CodexRunner", () => {
         threadId: "",
         stopReason: "completed",
         finalText: "",
+        finalTextSource: "none" as const,
         transcript: "",
         stderr: "",
       };
@@ -145,6 +148,7 @@ describe("CodexRunner", () => {
         threadId: "",
         stopReason: "completed",
         finalText: "",
+        finalTextSource: "none" as const,
         transcript: "",
         stderr: "",
       };
@@ -168,6 +172,7 @@ describe("CodexRunner", () => {
         threadId: "",
         stopReason: "completed",
         finalText: "",
+        finalTextSource: "none" as const,
         transcript: "",
         stderr: "",
       };
@@ -547,6 +552,7 @@ describe("OpenCodeRunner", () => {
         threadId: "",
         stopReason: "completed",
         finalText: "",
+        finalTextSource: "none" as const,
         transcript: "",
         stderr: "",
       };
@@ -563,6 +569,7 @@ describe("OpenCodeRunner", () => {
 
       expect(result.threadId).toBe("session-1");
       expect(result.finalText).toBe("done");
+      expect(result.finalTextSource).toBe("provider_message");
       expect(stdio.stderr).toContain("hello");
       expect(stdio.stderr).toContain(" from part");
       expect(stdio.stderr).toContain("[tool:bash]");
@@ -578,6 +585,7 @@ describe("OpenCodeRunner", () => {
         threadId: "",
         stopReason: "completed",
         finalText: "",
+        finalTextSource: "none" as const,
         transcript: "",
         stderr: "",
       })).toThrow("bad");

--- a/runtime/javascript/test/runners.test.ts
+++ b/runtime/javascript/test/runners.test.ts
@@ -577,6 +577,60 @@ describe("OpenCodeRunner", () => {
     });
   });
 
+  it("uses current OpenCode text and step finish events as the provider message", async () => {
+    await withTempSession(async (root) => {
+      const runner = new OpenCodeRunner(runnerOptions(root, "", "opencode"));
+      const result = {
+        provider: "opencode" as const,
+        threadId: "",
+        stopReason: "completed",
+        finalText: "",
+        finalTextSource: "none" as const,
+        transcript: "",
+        stderr: "",
+      };
+      const stdio = captureStdio();
+      try {
+        runner.handleEvent({
+          type: "text",
+          sessionID: "session-1",
+          part: { type: "text", messageID: "message-1", text: "working" },
+        }, result);
+        runner.handleEvent({
+          type: "step_finish",
+          sessionID: "session-1",
+          part: { type: "step-finish", messageID: "message-1", reason: "tool-calls" },
+        }, result);
+        expect(result.finalTextSource).toBe("none");
+        runner.handleEvent({
+          type: "text",
+          sessionID: "session-1",
+          part: { type: "text", messageID: "message-2", text: "final " },
+        }, result);
+        runner.handleEvent({
+          type: "text",
+          sessionID: "session-1",
+          part: { type: "text", messageID: "message-2", text: "answer" },
+        }, result);
+        runner.handleEvent({
+          type: "step_finish",
+          sessionID: "session-1",
+          part: { type: "step-finish", messageID: "message-2", reason: "stop" },
+        }, result);
+      } finally {
+        stdio.restore();
+      }
+
+      expect(result).toMatchObject({
+        threadId: "session-1",
+        stopReason: "stop",
+        finalText: "final answer",
+        finalTextSource: "provider_message",
+      });
+      expect(stdio.stderr).toContain("workingfinal answer");
+    });
+  });
+
   it("throws OpenCode event errors and rejects structured output", async () => {
     await withTempSession(async (root) => {
       const runner = new OpenCodeRunner(runnerOptions(root, "", "opencode"));

--- a/runtime/javascript/test/stream.test.ts
+++ b/runtime/javascript/test/stream.test.ts
@@ -9,12 +9,13 @@ import { runStreamCommand } from "../src/stream.js";
 import { withTempSession } from "./helpers.js";
 
 const runInputs: string[] = [];
+let codexEventFactory: ((turn: number) => Array<Record<string, unknown>>) | undefined;
 const thread = {
   id: "thread-1",
   async runStreamed(input: string) {
     runInputs.push(input);
     return {
-      events: asyncGenerator([
+      events: asyncGenerator(codexEventFactory?.(runInputs.length) || [
         { type: "thread.started", thread_id: "thread-1" },
         { type: "item.completed", item: { id: `msg-${runInputs.length}`, type: "agent_message", text: `answer ${runInputs.length}` } },
       ]),
@@ -67,6 +68,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 
 afterEach(() => {
   runInputs.length = 0;
+  codexEventFactory = undefined;
   startThread.mockClear();
   resumeThread.mockClear();
   claudeState.queryCalls = [];
@@ -138,9 +140,41 @@ describe("runStreamCommand", () => {
         threadId: "thread-1",
         stopReason: "eof",
         finalText: "answer 2",
+        finalTextSource: "provider_message",
         transcript: "answer 1\nanswer 2",
       });
       expect(parseOutput(stdout.text)).toHaveLength(8);
+    });
+  });
+
+  it("marks Codex interactive transcript fallback in turn and result frames", async () => {
+    await withTempSession(async (root) => {
+      codexEventFactory = () => [
+        { type: "thread.started", thread_id: "thread-1" },
+        { type: "item.completed", item: { id: "cmd", type: "command_execution", command: "pwd", aggregated_output: "/work\n" } },
+      ];
+      const stdout = new MemoryWritable();
+
+      await runStreamCommand({
+        stdin: Readable.from([
+          frame({ seq: 0, type: "start", provider: "codex", stateRoot: `${root}/state`, workspace: `${root}/workspace`, home: `${root}/home` }),
+          frame({ seq: 1, type: "human_message", message: "inspect" }),
+          frame({ seq: 2, type: "eof" }),
+        ]),
+        stdout,
+        stderr: new MemoryWritable(),
+      });
+
+      const frames = parseOutput(stdout.text);
+      const completed = frames.find((entry) => entry.type === "agent_turn_completed");
+      expect(completed).toMatchObject({
+        finalTextSource: "transcript_fallback",
+      });
+      expect(String(completed?.finalText)).toContain("$ pwd");
+      expect(frames.at(-1)).toMatchObject({
+        type: "result",
+        finalTextSource: "transcript_fallback",
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- persist only user messages, provider-authored final agent messages, and status events for Project runs
- keep complete execution transcripts in `cell.Output`, `run.Output`, and `run.LogsPath` without duplicating commands, stdout/stderr, or tool output into the Project Run event database
- normalize provider output with `finalTextSource` so transcript fallback remains available for compatibility and diagnostics without being mistaken for an assistant-authored message
- make terminal event persistence explicit and atomic instead of inferring an `agent_message` from non-empty `run.Output`

Fixes #444

## Testing

Passed:

- `go test ./pkg/runs ./pkg/execution ./pkg/agentcompose/adapters ./pkg/storage/configstore ./pkg/agentcompose/api`
- `go test -race ./pkg/runs`
- `npm run typecheck` in `runtime/javascript`
- `npx vitest run test/runner-execution.test.ts test/runners.test.ts test/stream.test.ts` in `runtime/javascript` (66 tests)
- `npx vitest run test/pi-runner.test.ts -t "marks Pi transcript fallback when no assistant message completes"` in `runtime/javascript`
- `task lint`
- `task build`

Known macOS environment failures:

- full `npm run test:unit` passes 167/168 tests; the existing Pi path assertion compares `/var/...` with its resolved `/private/var/...` path
- `task test` reaches `test:deploy` and fails existing installer tests because macOS exposes `/var` as a symlink and the installer rejects symlink path components

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.