### PR TITLE
fix(cli): correct run rm help text

### DIFF
--- a/cmd/agent-compose/cli_run_command_test.go
+++ b/cmd/agent-compose/cli_run_command_test.go
@@ -45,6 +45,22 @@ func TestRunHelpHidesOptionalModeFlagSentinel(t *testing.T) {
 	}
 }
 
+func TestRunHelpDescribesRemoveOnCompletion(t *testing.T) {
+	stdout, stderr, runCount, exitCode := executeCLICommand("run", "--help")
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("run --help code/stderr = %d / %q", exitCode, stderr)
+	}
+	if runCount != 0 {
+		t.Fatalf("daemon runner called %d times, want 0", runCount)
+	}
+	if !strings.Contains(stdout, "Remove a newly created sandbox after run completion") {
+		t.Fatalf("run --help does not describe completion-based sandbox removal:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "Remove the sandbox after a successful run") {
+		t.Fatalf("run --help still limits sandbox removal to successful runs:\n%s", stdout)
+	}
+}
+
 func TestResolveAgentComposeSocketForCLIFallsBackToVarRun(t *testing.T) {
 	t.Setenv("XDG_RUNTIME_DIR", "")
 

--- a/cmd/agent-compose/cli_run_definition.go
+++ b/cmd/agent-compose/cli_run_definition.go
@@ -17,7 +17,7 @@ func newCLIRunCommand(cli *cliOptions) *cobra.Command {
 	cmd.Flags().StringVar(&options.SandboxID, "sandbox", "", "Reuse an existing sandbox")
 	cmd.Flags().StringVar(&options.Driver, "driver", "", "Runtime driver override for a new sandbox")
 	cmd.Flags().BoolVar(&options.KeepRunning, "keep-running", false, "Keep the sandbox runtime running after completion")
-	cmd.Flags().BoolVar(&options.Remove, "rm", false, "Remove the sandbox after a successful run")
+	cmd.Flags().BoolVar(&options.Remove, "rm", false, "Remove a newly created sandbox after run completion")
 	cmd.Flags().BoolVar(&options.Jupyter, "jupyter", false, "Enable Jupyter for this run")
 	cmd.Flags().BoolVar(&options.JupyterExpose, "jupyter-expose", false, "Mark the Jupyter proxy endpoint for this run as user-accessible")
 	cmd.Flags().BoolVarP(&options.Detach, "detach", "d", false, "Start the run in the daemon and return immediately")


### PR DESCRIPTION
## Summary

- Correct the `agent-compose run --rm` help text to describe completion-based cleanup instead of limiting it to successful runs.
- Clarify that `--rm` removes only a sandbox newly created for the run, matching the existing cleanup policy for explicitly reused sandboxes.
- Add a regression test that requires the corrected help text and rejects the old success-only wording.

Closes #448

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
- Coverage: Unit 75.02%, Integration 60.79%, E2E 60.52%, Combined 79.12%

## Checklist

- [x] Documentation updated when behavior or configuration changed. (Not applicable: runtime behavior is unchanged, and the command-line manual already documents terminal-state cleanup.)
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
