### PR TITLE
fix(cli): reject conflicting run cleanup flags

### DIFF
--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -432,6 +432,9 @@ func (w *terminalStreamWriter) Finish() error {
 func normalizeComposeRunOptions(cmd *cobra.Command, options composeRunOptions) (composeRunOptions, error) {
 	options.SandboxID = strings.TrimSpace(options.SandboxID)
 	options.Driver = strings.TrimSpace(options.Driver)
+	if options.Remove && options.KeepRunning {
+		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("run --rm cannot be combined with --keep-running")}
+	}
 	if options.Driver != "" {
 		driver, err := driverpkg.ResolveSandboxRuntimeDriver(options.Driver, "")
 		if err != nil {

--- a/cmd/agent-compose/cli_run_command_test.go
+++ b/cmd/agent-compose/cli_run_command_test.go
@@ -105,6 +105,16 @@ agents:
 			want: "run --driver cannot be combined with --sandbox",
 		},
 		{
+			name: "remove with keep running",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--rm", "--keep-running", "--prompt", "check"},
+			want: "run --rm cannot be combined with --keep-running",
+		},
+		{
+			name: "keep running with remove",
+			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--keep-running", "--rm", "--prompt", "check"},
+			want: "run --rm cannot be combined with --keep-running",
+		},
+		{
 			name: "command and prompt flags",
 			args: []string{"run", "--host", server.URL, "--file", composePath, "reviewer", "--command", "echo hi", "--prompt", "check"},
 			want: "only one of --prompt or --command",


### PR DESCRIPTION
## Summary

- reject `agent-compose run --rm --keep-running` as an invalid CLI request before creating service clients or sending a run request
- return a clear usage error instead of silently giving `--keep-running` precedence
- cover both flag orders with regression tests

Fixes #450

## Testing

- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -run '^TestCLIRunInputModeUsageErrors$' -count=1`
- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 75.02%
  - Integration: 60.80%
  - E2E: 60.59%
  - Combined: 79.12%

## Checklist

- [x] Documentation reviewed; no update is required for validation of an invalid flag combination.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
