### PR TITLE
fix(compose): reject duplicate scheduler trigger names

### DIFF
--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -427,6 +427,41 @@ agents:
 	}
 }
 
+func TestConfigCommandQuietRejectsDuplicateSchedulerTriggerNames(t *testing.T) {
+	composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "duplicate-trigger-project"), `
+name: duplicate-trigger-repro
+agents:
+  runner:
+    provider: codex
+    scheduler:
+      triggers:
+        - name: duplicate
+          interval: 1m
+        - name: duplicate
+          interval: 2m
+`)
+
+	stdout, stderr, runCount, exitCode := executeCLICommand("config", "--quiet", "--file", composePath)
+	if exitCode != exitCodeUsage {
+		t.Fatalf("config --quiet exit code = %d, want %d; stderr=%q", exitCode, exitCodeUsage, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("config --quiet stdout = %q, want empty", stdout)
+	}
+	for _, want := range []string{
+		composePath,
+		"agents.runner.scheduler.triggers[1].name",
+		`duplicate scheduler trigger name "duplicate"`,
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("config --quiet stderr %q does not contain %q", stderr, want)
+		}
+	}
+	if runCount != 0 {
+		t.Fatalf("daemon runner called %d times, want 0", runCount)
+	}
+}
+
 func TestIntegrationCLIListProjectsTextVerboseAndJSON(t *testing.T) {
 	requests := 0
 	server := newComposeServiceStubServer(t, composeServiceStubs{

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -136,6 +136,7 @@ func testCLIConfigAndOutputWorkflow(t *testing.T) {
 	TestConfigCommandExpandsSchedulerScriptURLs(t)
 	TestConfigCommandQuietOnlyValidates(t)
 	TestConfigCommandQuietRejectsRemovedNetworkField(t)
+	TestConfigCommandQuietRejectsDuplicateSchedulerTriggerNames(t)
 	TestConfigCommandMissingComposeFileWritesStderrAndExitCode(t)
 	TestConfigCommandProjectNameDoesNotOverrideComposeName(t)
 	TestCLIClientConfigPriority(t)

--- a/pkg/compose/coverage_shape_workflows_test.go
+++ b/pkg/compose/coverage_shape_workflows_test.go
@@ -30,6 +30,7 @@ func TestIntegrationComposeParseNormalizeAndOutputWorkflows(t *testing.T) {
 	t.Run("scheduler script with triggers", TestNormalizeRejectsSchedulerScriptWithTriggers)
 	t.Run("scheduler script URL with triggers", TestNormalizeRejectsSchedulerScriptURLWithTriggers)
 	t.Run("scheduler triggers", TestNormalizePreservesSchedulerTriggersWithoutScript)
+	t.Run("scheduler trigger name uniqueness", TestNormalizeSchedulerTriggerNameUniqueness)
 	t.Run("invalid trigger payloads", TestNormalizeRejectsInvalidTriggerPayloads)
 	t.Run("trigger without kind", TestNormalizeRejectsTriggerWithoutKind)
 	t.Run("duplicate agent keys", TestParseRejectsDuplicateAgentKeys)

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -1130,10 +1130,18 @@ func normalizeSchedulerSpec(path string, scheduler *SchedulerSpec, options Norma
 			}
 		}
 	}
+	seenTriggerNames := make(map[string]struct{}, len(scheduler.Triggers))
 	for i, trigger := range scheduler.Triggers {
-		normalizedTrigger, err := normalizeTriggerSpec(fmt.Sprintf("%s.triggers[%d]", path, i), trigger)
+		triggerPath := fmt.Sprintf("%s.triggers[%d]", path, i)
+		normalizedTrigger, err := normalizeTriggerSpec(triggerPath, trigger)
 		if err != nil {
 			return nil, err
+		}
+		if normalizedTrigger.Name != "" {
+			if _, ok := seenTriggerNames[normalizedTrigger.Name]; ok {
+				return nil, &ValidationError{Path: triggerPath + ".name", Message: fmt.Sprintf("duplicate scheduler trigger name %q", normalizedTrigger.Name)}
+			}
+			seenTriggerNames[normalizedTrigger.Name] = struct{}{}
 		}
 		normalized.Triggers = append(normalized.Triggers, normalizedTrigger)
 	}

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -967,6 +968,65 @@ agents:
 	if trigger := scheduler.Triggers[0]; trigger.Name != "hourly-review" || trigger.Kind != "interval" || trigger.Interval != "1h" || trigger.Prompt != "review changes" {
 		t.Fatalf("scheduler trigger = %#v, want normalized interval trigger", trigger)
 	}
+}
+
+func TestNormalizeSchedulerTriggerNameUniqueness(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		secondName string
+	}{
+		{name: "exact duplicate", secondName: "duplicate"},
+		{name: "duplicate after trimming", secondName: `" duplicate "`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := mustParseCompose(t, `
+name: duplicate-trigger
+agents:
+  runner:
+    scheduler:
+      triggers:
+        - name: duplicate
+          interval: 1m
+        - name: `+tt.secondName+`
+          interval: 2m
+`)
+
+			_, err := Normalize(spec, NormalizeOptions{})
+			if err == nil {
+				t.Fatalf("expected Normalize to fail")
+			}
+			var validationErr *ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("Normalize error = %T %v, want ValidationError", err, err)
+			}
+			if got, want := validationErr.Path, "agents.runner.scheduler.triggers[1].name"; got != want {
+				t.Fatalf("validation path = %q, want %q", got, want)
+			}
+			if got, want := validationErr.Message, `duplicate scheduler trigger name "duplicate"`; got != want {
+				t.Fatalf("validation message = %q, want %q", got, want)
+			}
+		})
+	}
+
+	t.Run("unnamed triggers remain valid", func(t *testing.T) {
+		spec := mustParseCompose(t, `
+name: unnamed-triggers
+agents:
+  runner:
+    scheduler:
+      triggers:
+        - interval: 1m
+        - interval: 2m
+`)
+
+		normalized, err := Normalize(spec, NormalizeOptions{})
+		if err != nil {
+			t.Fatalf("Normalize returned error: %v", err)
+		}
+		if got := len(normalized.Agents[0].Scheduler.Triggers); got != 2 {
+			t.Fatalf("scheduler trigger count = %d, want 2", got)
+		}
+	})
 }
 
 func TestNormalizeRejectsInvalidTriggerPayloads(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject duplicate non-empty scheduler trigger names during Compose normalization, using the trimmed trigger name
- report the duplicate at the second trigger's `.name` field while preserving multiple unnamed triggers
- add Compose and `config --quiet` regression coverage so local validation matches project apply behavior

Closes #447.

## Testing

- `GOFLAGS=-buildvcs=false go test ./pkg/compose ./pkg/projects ./cmd/agent-compose -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 75.12%
  - Integration: 60.74%
  - E2E: 60.55%
  - Combined: 79.12%

## Checklist

- [x] Documentation updated when behavior or configuration changed. Existing English and Chinese YAML manuals already document that non-empty trigger names must be unique.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
