### PR TITLE
fix(cli): reject conflicting logs selectors

### DIFF
--- a/cmd/agent-compose/cli_logs.go
+++ b/cmd/agent-compose/cli_logs.go
@@ -68,6 +68,8 @@ func runComposeLogsCommand(cmd *cobra.Command, cli cliOptions, options composeLo
 }
 
 func normalizeComposeLogsOptions(cmd *cobra.Command, options composeLogsOptions, args []string) (composeLogsOptions, error) {
+	options.RunID = strings.TrimSpace(options.RunID)
+	options.SandboxID = strings.TrimSpace(options.SandboxID)
 	if len(args) > 0 {
 		if cmd.Flags().Changed("agent") {
 			return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("logs agent can be specified either positionally or with --agent, not both")}
@@ -77,6 +79,9 @@ func normalizeComposeLogsOptions(cmd *cobra.Command, options composeLogsOptions,
 		} else {
 			options.AgentName = args[0]
 		}
+	}
+	if options.RunID != "" && options.SandboxID != "" {
+		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("logs --run cannot be combined with --sandbox")}
 	}
 	if options.TailLines < -1 {
 		return options, commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("logs --tail must be -1 or greater")}

--- a/cmd/agent-compose/cli_logs_command.go
+++ b/cmd/agent-compose/cli_logs_command.go
@@ -13,8 +13,8 @@ func newCLILogsCommand(cli *cliOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&options.AgentName, "agent", "", "Filter logs by agent name")
-	cmd.Flags().StringVar(&options.RunID, "run", "", "Filter logs by run id")
-	cmd.Flags().StringVar(&options.SandboxID, "sandbox", "", "Filter logs by sandbox id")
+	cmd.Flags().StringVar(&options.RunID, "run", "", "Filter logs by run id; cannot be combined with --sandbox")
+	cmd.Flags().StringVar(&options.SandboxID, "sandbox", "", "Filter logs by sandbox id; cannot be combined with --run")
 	cmd.Flags().BoolVar(&options.Follow, "follow", false, "Follow running run output")
 	cmd.Flags().IntVarP(&options.TailLines, "tail", "n", -1, "Show the last N lines of run output")
 	cmd.Flags().BoolVarP(&options.Timestamp, "timestamp", "t", false, "Prefix text log lines with a run-level timestamp")

--- a/cmd/agent-compose/cli_logs_test.go
+++ b/cmd/agent-compose/cli_logs_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -424,6 +425,56 @@ func TestLogsJSONFollowIsUsageError(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "cannot be combined") {
 		t.Fatalf("logs --json --follow stderr = %q", stderr)
+	}
+}
+
+func TestIntegrationCLILogsRunAndSandboxIsUsageErrorBeforeServiceRequests(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-logs-selector-conflict
+agents:
+  reviewer:
+    provider: codex
+`)
+	var serviceCalls atomic.Int32
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				serviceCalls.Add(1)
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{
+					Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-logs-selector-conflict", composePath),
+				}), nil
+			},
+		},
+		run: runServiceStub{
+			getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
+				serviceCalls.Add(1)
+				return connect.NewResponse(&agentcomposev2.GetRunResponse{
+					Run: testRunDetail(req.Msg.GetProjectId(), req.Msg.GetRunId(), "reviewer", "sandbox-conflict", agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, 0, "unexpected\n"),
+				}), nil
+			},
+			followRunLogs: func(ctx context.Context, req *connect.Request[agentcomposev2.FollowRunLogsRequest], stream *connect.ServerStream[agentcomposev2.RunLogChunk]) error {
+				serviceCalls.Add(1)
+				return stream.Send(&agentcomposev2.RunLogChunk{IsFinal: true, RunStatus: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED})
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand(
+		"logs", "--host", server.URL, "--file", composePath,
+		"--run", "run-conflict", "--sandbox", "sandbox-conflict",
+	)
+	if exitCode != exitCodeUsage {
+		t.Fatalf("logs --run --sandbox exit code = %d, want %d", exitCode, exitCodeUsage)
+	}
+	if stdout != "" {
+		t.Fatalf("logs --run --sandbox stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "logs --run cannot be combined with --sandbox") {
+		t.Fatalf("logs --run --sandbox stderr = %q", stderr)
+	}
+	if got := serviceCalls.Load(); got != 0 {
+		t.Fatalf("logs --run --sandbox service calls = %d, want 0", got)
 	}
 }
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -489,6 +489,8 @@ agent-compose logs -t
 | `--run <run-id>` | Filter by run id. |
 | `--sandbox <sandbox>` | Filter by sandbox. |
 
+`--run` and `--sandbox` are mutually exclusive resource selectors. Combining them is a usage error, and no log request is sent.
+
 Examples:
 
 ```bash

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -497,6 +497,8 @@ agent-compose logs -t
 | `--run <run-id>` | 按 run 过滤。 |
 | `--sandbox <sandbox>` | 按 sandbox 过滤。 |
 
+`--run` 和 `--sandbox` 是互斥的资源选择器。同时指定二者会返回用法错误，且不会发送日志请求。
+
 示例：
 
 ```bash


### PR DESCRIPTION
## Summary

- reject `agent-compose logs --run ... --sandbox ...` as a usage error before project resolution or service requests
- document the selector constraint in CLI help and the English and Chinese command manuals
- add a regression test that verifies exit code 2, empty stdout, a clear error, and zero service calls

Fixes #456.

## Testing

- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -run '^(TestIntegrationCLILogsRunAndSandboxIsUsageErrorBeforeServiceRequests|TestLogsJSONFollowIsUsageError|TestLogsAgentFlagAndPositionalIsUsageError|TestE2ECLIHelpDocumentsCommandsAndFlags)$' -count=1`
- `task docs:build`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 75.11%
  - Integration: 60.75%
  - E2E: 60.54%
  - Combined: 79.12%

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
