### PR TITLE
fix(cli): reject conflicting exec targets

### DIFF
--- a/cmd/agent-compose/cli_exec_command.go
+++ b/cmd/agent-compose/cli_exec_command.go
@@ -77,10 +77,20 @@ func executeComposeRunRequest(cmd *cobra.Command, cli cliOptions, projectName, p
 }
 
 func composeExecArgs(cmd *cobra.Command, args []string) error {
+	if err := validateComposeExecTargetArgs(cmd, args); err != nil {
+		return err
+	}
 	if cmd.Flags().Changed("run") {
 		return nil
 	}
 	return cobra.MinimumNArgs(1)(cmd, args)
+}
+
+func validateComposeExecTargetArgs(cmd *cobra.Command, args []string) error {
+	if cmd.Flags().Changed("run") && len(args) > 0 {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec target can only be specified once: use either <sandbox> or --run")}
+	}
+	return nil
 }
 
 func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeExecOptions, args []string) error {
@@ -204,6 +214,9 @@ func (p promptAttachInputPrompt) String() string {
 }
 
 func normalizeComposeExecRequest(cmd *cobra.Command, clients cliServiceClients, projectID string, options composeExecOptions, args []string) (*agentcomposev2.ExecRequest, error) {
+	if err := validateComposeExecTargetArgs(cmd, args); err != nil {
+		return nil, err
+	}
 	commandText := strings.TrimSpace(options.Command)
 	promptText := strings.TrimSpace(options.Prompt)
 	if commandText != "" && promptText != "" {

--- a/cmd/agent-compose/cli_exec_command_test.go
+++ b/cmd/agent-compose/cli_exec_command_test.go
@@ -70,6 +70,28 @@ func TestComposeExecCommandFromPositionalArgs(t *testing.T) {
 	}
 }
 
+func TestComposeExecRejectsConflictingTargets(t *testing.T) {
+	cmd := &cobra.Command{Use: "exec"}
+	cmd.Flags().String("run", "", "")
+	if err := cmd.Flags().Set("run", "run-b"); err != nil {
+		t.Fatalf("set exec run: %v", err)
+	}
+
+	args := []string{"sandbox-a"}
+	if err := composeExecArgs(cmd, args); commandExitCode(err) != exitCodeUsage || !strings.Contains(err.Error(), "use either <sandbox> or --run") {
+		t.Fatalf("composeExecArgs conflict err=%v code=%d", err, commandExitCode(err))
+	}
+
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	if _, err := normalizeComposeExecRequest(cmd, cliServiceClients{}, "project-a", composeExecOptions{RunID: "run-b", Command: "true"}, args); commandExitCode(err) != exitCodeUsage || !strings.Contains(err.Error(), "use either <sandbox> or --run") {
+		t.Fatalf("normalizeComposeExecRequest conflict err=%v code=%d", err, commandExitCode(err))
+	}
+	if stderr.String() != "" {
+		t.Fatalf("normalizeComposeExecRequest conflict stderr=%q, want empty", stderr.String())
+	}
+}
+
 func TestCLIExecInteractiveReservedUnsupported(t *testing.T) {
 	stdout, stderr, _, exitCode := executeCLICommand("exec", "-t", "sandbox-1")
 	if exitCode != exitCodeUsage {

--- a/cmd/agent-compose/cli_exec_integration_test.go
+++ b/cmd/agent-compose/cli_exec_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -177,5 +178,44 @@ agents:
 	}
 	if ambiguousOut != "" || !strings.Contains(ambiguousErr, "positional command cannot be combined with --command") {
 		t.Fatalf("exec --command ambiguous stdout/stderr = %q / %q", ambiguousOut, ambiguousErr)
+	}
+}
+
+func TestIntegrationCLIExecRejectsConflictingTargetsBeforeRPC(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: cli-exec-target-conflict
+agents:
+  reviewer:
+    provider: codex
+`)
+	var execStreamCalls atomic.Int32
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		exec: execServiceStub{
+			execStream: func(context.Context, *connect.Request[agentcomposev2.ExecRequest], *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+				execStreamCalls.Add(1)
+				return nil
+			},
+		},
+	})
+	defer server.Close()
+
+	sandboxA := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	runB := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	stdout, stderr, _, exitCode := executeCLICommand(
+		"exec", "--host", server.URL, "--file", composePath,
+		sandboxA, "--run", runB, "--command", "cat /tmp/exec-target-marker",
+	)
+
+	if exitCode != exitCodeUsage {
+		t.Fatalf("exec conflicting targets exit code = %d, want %d; stderr=%q", exitCode, exitCodeUsage, stderr)
+	}
+	if stdout != "" || !strings.Contains(stderr, "exec target can only be specified once: use either <sandbox> or --run") {
+		t.Fatalf("exec conflicting targets stdout/stderr = %q / %q", stdout, stderr)
+	}
+	if strings.Contains(stderr, "deprecated") {
+		t.Fatalf("exec conflicting targets emitted deprecation warning: %q", stderr)
+	}
+	if calls := execStreamCalls.Load(); calls != 0 {
+		t.Fatalf("ExecStream calls = %d, want 0", calls)
 	}
 }

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -450,6 +450,8 @@ agent-compose exec <sandbox> --prompt "..."
 | `--agent <agent>` | Deprecated target selection option; use `exec <sandbox>` instead. |
 | `--run <run-id>` | Deprecated target selection option; use `exec <sandbox>` instead. |
 
+The positional `<sandbox>` target and deprecated `--run` target are mutually exclusive. If both are provided, `exec` exits with a usage error before resolving either target or sending an execution request.
+
 Examples:
 
 ```bash

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -456,6 +456,8 @@ agent-compose exec <sandbox> --prompt "..."
 | `--agent <agent>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
 | `--run <run-id>` | 兼容旧目标选择参数，会输出 deprecated warning；新命令应使用 `exec <sandbox>`。 |
 
+位置参数 `<sandbox>` 与已弃用的 `--run` 目标互斥。如果同时提供，`exec` 会在解析任一目标或发送执行请求之前返回用法错误。
+
 示例：
 
 ```bash


### PR DESCRIPTION
## Summary

- reject `agent-compose exec <sandbox> --run <run-id>` during Cobra argument validation, before project or target resolution and before any Exec RPC
- enforce the same target-selection invariant during request normalization so internal callers cannot silently prefer the deprecated run target
- add unit and in-process integration regressions that verify usage exit code 2, no deprecation warning, and zero `ExecStream` calls for conflicting targets
- document the mutual exclusion in the English and Chinese CLI manuals

Closes #457.

## Testing

- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -run '^(TestComposeExecRejectsConflictingTargets|TestIntegrationCLIExecRejectsConflictingTargetsBeforeRPC)$' -count=1 -v`
- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -count=1`
- `task docs:build`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"` (with inherited agent-compose product configuration cleared in the test subshell)

Coverage from the full test gate:

- Unit: 75.12%
- Integration: 60.74%
- E2E: 60.49%
- Combined: 79.12%

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
