### PR TITLE
fix(sandbox): reject unknown status filters

### DIFF
--- a/cmd/agent-compose/cli_project_display.go
+++ b/cmd/agent-compose/cli_project_display.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+
+	domain "agent-compose/pkg/model"
 )
 
 type composeDisplayChangeBuilder struct {
@@ -55,7 +57,11 @@ func composePSStatusFilter(options composePSOptions) (map[string]bool, error) {
 		if value == "" {
 			continue
 		}
-		result[value] = true
+		status, err := domain.NormalizeSandboxVMStatus(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --status %q: expected %s", value, composePSSupportedStatusExpectation())
+		}
+		result[strings.ToLower(status)] = true
 	}
 	if len(result) > 0 {
 		return result, nil
@@ -64,6 +70,14 @@ func composePSStatusFilter(options composePSOptions) (map[string]bool, error) {
 		return nil, nil
 	}
 	return map[string]bool{"running": true}, nil
+}
+
+func composePSSupportedStatusExpectation() string {
+	statuses := domain.SupportedSandboxVMStatuses()
+	for index := range statuses {
+		statuses[index] = strings.ToLower(statuses[index])
+	}
+	return strings.Join(statuses[:len(statuses)-1], ", ") + ", or " + statuses[len(statuses)-1]
 }
 
 func composePSStatusValues(filter map[string]bool) []string {

--- a/cmd/agent-compose/cli_ps_command.go
+++ b/cmd/agent-compose/cli_ps_command.go
@@ -18,7 +18,7 @@ func newCLISandboxListCommand(cli *cliOptions, use, short string, options *compo
 		},
 	}
 	cmd.Flags().BoolVarP(&options.All, "all", "a", false, "Show current project sandboxes in all statuses")
-	cmd.Flags().StringVar(&options.Status, "status", "", "Filter sandboxes by status, comma-separated")
+	cmd.Flags().StringVar(&options.Status, "status", "", "Filter sandboxes by status: pending, running, stopped, failed, or deleting (comma-separated)")
 	cmd.Flags().BoolVar(&options.Verbose, "verbose", false, "Show more sandbox details")
 	return cmd
 }

--- a/cmd/agent-compose/cli_ps_project_test.go
+++ b/cmd/agent-compose/cli_ps_project_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +13,39 @@ import (
 
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
+
+func TestCLIPSRejectsInvalidStatusBeforeDaemonRequests(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requestCount++
+	}))
+	t.Cleanup(server.Close)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "ps single invalid", args: []string{"ps", "--status", "definitely-invalid"}},
+		{name: "sandbox list mixed invalid", args: []string{"sandbox", "ls", "--status", "running,definitely-invalid", "--json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append(append([]string(nil), tt.args...), "--host", server.URL, "--project-name", "status-validation")
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != exitCodeUsage || stdout != "" {
+				t.Fatalf("code/stdout/stderr = %d / %q / %q; want usage with empty stdout", exitCode, stdout, stderr)
+			}
+			for _, want := range []string{`invalid --status "definitely-invalid"`, "pending, running, stopped, failed, or deleting"} {
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("stderr = %q, want %q", stderr, want)
+				}
+			}
+		})
+	}
+	if requestCount != 0 {
+		t.Fatalf("invalid status triggered %d daemon request(s), want 0", requestCount)
+	}
+}
 
 func TestIntegrationCLIPSSelectsStoredProjectByNameWithoutComposeFile(t *testing.T) {
 	for _, command := range [][]string{{"ps"}, {"sandbox", "ls"}} {

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -466,6 +466,9 @@ func normalizeOptionalRunModeValue(value string) string {
 }
 
 func runComposePSCommand(cmd *cobra.Command, cli cliOptions, options composePSOptions) error {
+	if _, err := composePSStatusFilter(options); err != nil {
+		return commandExitError{Code: exitCodeUsage, Err: err}
+	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err

--- a/cmd/agent-compose/cli_sandbox_integration_prune_test.go
+++ b/cmd/agent-compose/cli_sandbox_integration_prune_test.go
@@ -138,9 +138,9 @@ agents:
 		}
 	}
 
-	statusMatches := matched(runPrune("--status", "error"))
-	if !reflect.DeepEqual(statusMatches, map[string]bool{"session-error": true}) {
-		t.Fatalf("status error matches = %#v", statusMatches)
+	statusMatches := matched(runPrune("--status", "failed"))
+	if !reflect.DeepEqual(statusMatches, map[string]bool{"session-failed": true}) {
+		t.Fatalf("status failed matches = %#v", statusMatches)
 	}
 
 	agentMatches := matched(runPrune("--agent", "worker"))
@@ -382,14 +382,23 @@ agents:
 }
 
 func TestIntegrationCLISandboxPruneRejectsUnsafeStatuses(t *testing.T) {
-	for _, status := range []string{"running", "pending"} {
-		t.Run(status, func(t *testing.T) {
-			stdout, stderr, _, exitCode := executeCLICommand("sandbox", "prune", "--status", status)
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{status: "running", want: "sandbox prune cannot target running sandboxes"},
+		{status: "pending", want: "sandbox prune cannot target pending sandboxes"},
+		{status: "deleting", want: "sandbox prune cannot target deleting sandboxes"},
+		{status: "definitely-invalid", want: `invalid --status "definitely-invalid": expected stopped or failed`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			stdout, stderr, _, exitCode := executeCLICommand("sandbox", "prune", "--status", tt.status)
 			if exitCode != exitCodeUsage {
-				t.Fatalf("sandbox prune --status %s exit code = %d, want usage; stderr=%q", status, exitCode, stderr)
+				t.Fatalf("sandbox prune --status %s exit code = %d, want usage; stderr=%q", tt.status, exitCode, stderr)
 			}
-			if stdout != "" || !strings.Contains(stderr, "sandbox prune cannot target "+status+" sandboxes") {
-				t.Fatalf("sandbox prune --status %s stdout/stderr = %q / %q", status, stdout, stderr)
+			if stdout != "" || !strings.Contains(stderr, tt.want) {
+				t.Fatalf("sandbox prune --status %s stdout/stderr = %q / %q", tt.status, stdout, stderr)
 			}
 		})
 	}

--- a/cmd/agent-compose/cli_sandbox_prune.go
+++ b/cmd/agent-compose/cli_sandbox_prune.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +11,9 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
 type composeSandboxPruneOptions struct {
@@ -24,7 +26,7 @@ type composeSandboxPruneOptions struct {
 }
 
 func addSandboxPruneFlags(cmd *cobra.Command, options *composeSandboxPruneOptions) {
-	cmd.Flags().StringVar(&options.Status, "status", "", "Filter sandboxes by status, comma-separated")
+	cmd.Flags().StringVar(&options.Status, "status", "", "Filter sandboxes by status: stopped or failed (comma-separated)")
 	cmd.Flags().StringVar(&options.Agent, "agent", "", "Filter sandboxes by agent name")
 	cmd.Flags().StringVar(&options.Driver, "driver", "", "Filter sandboxes by driver: docker, boxlite, or microsandbox")
 	cmd.Flags().StringVar(&options.OlderThan, "older-than", "", "Only match sandboxes older than a duration such as 7d or 24h")
@@ -191,8 +193,12 @@ func sandboxPruneStatusFilter(value string) (map[string]bool, error) {
 		if status == "" {
 			continue
 		}
-		if status == "running" || status == "pending" {
-			return nil, fmt.Errorf("sandbox prune cannot target %s sandboxes; use `agent-compose sandbox rm --force <sandbox>` for running sandboxes", status)
+		canonical, err := domain.NormalizeSandboxVMStatus(status)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --status %q: expected stopped or failed", status)
+		}
+		if canonical != domain.VMStatusStopped && canonical != domain.VMStatusFailed {
+			return nil, fmt.Errorf("sandbox prune cannot target %s sandboxes; only stopped or failed sandboxes are safe to prune", status)
 		}
 		result[status] = true
 	}

--- a/cmd/agent-compose/cli_workflow_integration_test.go
+++ b/cmd/agent-compose/cli_workflow_integration_test.go
@@ -32,7 +32,7 @@ agents:
 	sessions := []*agentcomposev2.Sandbox{
 		testCLISessionSummary("session-running", "RUNNING", "project-cli-ps", "reviewer", "run-running"),
 		testCLISessionSummary("session-stopped", "STOPPED", "project-cli-ps", "worker", "run-stopped"),
-		testCLISessionSummary("session-error", "ERROR", "foreign-project", "", ""),
+		testCLISessionSummary("session-error", "FAILED", "foreign-project", "", ""),
 		testCLISessionSummary("session-foreign", "RUNNING", "foreign-project", "reviewer", "run-foreign"),
 	}
 	runs := []*agentcomposev2.RunSummary{
@@ -138,7 +138,7 @@ agents:
 		t.Fatalf("ps --all output %q contains foreign sandbox", allOut)
 	}
 
-	statusOut, statusErr, _, statusCode := executeCLICommand("ps", "--host", server.URL, "--file", composePath, "--status", "error")
+	statusOut, statusErr, _, statusCode := executeCLICommand("ps", "--host", server.URL, "--file", composePath, "--status", "failed")
 	if statusCode != 0 || statusErr != "" {
 		t.Fatalf("ps --status code/stderr = %d / %q", statusCode, statusErr)
 	}

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -282,7 +282,7 @@ agent-compose ps
 agent-compose ps -a
 agent-compose ps --all
 agent-compose ps --status running
-agent-compose ps --status exited,error
+agent-compose ps --status stopped,failed
 agent-compose ps --verbose
 agent-compose ps --json
 ```
@@ -291,7 +291,7 @@ agent-compose ps --json
 | --- | --- |
 | `-a, --all` | Show current project sandboxes in all statuses. |
 | `--verbose` | Show additional columns. |
-| `--status <status>[,<status>...]` | Filter by sandbox status. |
+| `--status <status>[,<status>...]` | Filter by `pending`, `running`, `stopped`, `failed`, or `deleting`. Every non-empty comma-separated value must be valid. |
 
 Default columns:
 
@@ -317,7 +317,7 @@ agent-compose sandbox rm <sandbox>
 agent-compose sandbox rm --force <sandbox>
 agent-compose sandbox prune
 agent-compose sandbox prune --older-than 7d
-agent-compose sandbox prune --status error --json
+agent-compose sandbox prune --status failed --json
 agent-compose sandbox prune --agent worker --driver microsandbox --force
 agent-compose sandbox prune --include-orphans
 ```

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -282,7 +282,7 @@ agent-compose ps
 agent-compose ps -a
 agent-compose ps --all
 agent-compose ps --status running
-agent-compose ps --status exited,error
+agent-compose ps --status stopped,failed
 agent-compose ps --verbose
 agent-compose ps --json
 ```
@@ -293,7 +293,7 @@ agent-compose ps --json
 | --- | --- |
 | `-a, --all` | 显示当前 project 中所有状态的 sandbox。 |
 | `--verbose` | 显示更多列。 |
-| `--status <status>[,<status>...]` | 按状态过滤。 |
+| `--status <status>[,<status>...]` | 按 `pending`、`running`、`stopped`、`failed` 或 `deleting` 过滤；逗号分隔的每个非空值都必须合法。 |
 
 默认输出字段：
 
@@ -319,7 +319,7 @@ agent-compose sandbox rm <sandbox>
 agent-compose sandbox rm --force <sandbox>
 agent-compose sandbox prune
 agent-compose sandbox prune --older-than 7d
-agent-compose sandbox prune --status error --json
+agent-compose sandbox prune --status failed --json
 agent-compose sandbox prune --agent worker --driver microsandbox --force
 agent-compose sandbox prune --include-orphans
 ```

--- a/pkg/agentcompose/adapters/sandbox_rpc_json.go
+++ b/pkg/agentcompose/adapters/sandbox_rpc_json.go
@@ -48,6 +48,10 @@ type sandboxRPCListRequest struct {
 }
 
 func (r sandboxRPCListRequest) Options() (domain.SandboxListOptions, error) {
+	vmStatus, err := domain.NormalizeSandboxVMStatus(r.VMStatus)
+	if err != nil {
+		return domain.SandboxListOptions{}, err
+	}
 	createdFrom, err := sandboxRPCOptionalTime(r.CreatedFrom, "createdFrom")
 	if err != nil {
 		return domain.SandboxListOptions{}, err
@@ -66,7 +70,7 @@ func (r sandboxRPCListRequest) Options() (domain.SandboxListOptions, error) {
 	}
 	return domain.SandboxListOptions{
 		SandboxType: r.SessionType, TriggerSourceQuery: r.TriggerSource, TitleQuery: r.Title,
-		WorkspaceQuery: r.Workspace, Driver: r.Driver, VMStatus: r.VMStatus,
+		WorkspaceQuery: r.Workspace, Driver: r.Driver, VMStatus: vmStatus,
 		CreatedFrom: createdFrom, CreatedTo: createdTo, UpdatedFrom: updatedFrom, UpdatedTo: updatedTo,
 		Offset: int(r.Offset), Limit: int(r.Limit),
 	}, nil

--- a/pkg/agentcompose/adapters/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_test.go
@@ -126,7 +126,7 @@ func TestSandboxRPCBridgeCallJSONSupportsSessionRPCs(t *testing.T) {
 		t.Fatalf("GetSession session id = %q, want %q", gotSession.Session.Summary.SessionID, sessionID)
 	}
 
-	listJSON, err := bridge.CallJSON(ctx, "ListSessions", ``)
+	listJSON, err := bridge.CallJSON(ctx, "ListSessions", `{"vmStatus":" running "}`)
 	if err != nil {
 		t.Fatalf("ListSessions returned error: %v", err)
 	}
@@ -136,6 +136,9 @@ func TestSandboxRPCBridgeCallJSONSupportsSessionRPCs(t *testing.T) {
 	}
 	if len(listed.Sessions) != 1 || listed.Sessions[0].SessionID != sessionID {
 		t.Fatalf("listed sessions = %#v, want one session %s", listed.Sessions, sessionID)
+	}
+	if _, err := bridge.CallJSON(ctx, "ListSessions", `{"vmStatus":"definitely-invalid"}`); !errors.Is(err, domain.ErrInvalidArgument) || !strings.Contains(err.Error(), `invalid sandbox status "definitely-invalid"`) {
+		t.Fatalf("ListSessions invalid vmStatus error = %v", err)
 	}
 
 	if _, err := bridge.CallJSON(ctx, "GetSessionProxy", `{"sessionId":"`+sessionID+`"}`); err == nil || !strings.Contains(err.Error(), "jupyter is not enabled") {

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -167,13 +167,17 @@ func (h *SandboxHandler) ListSandboxes(ctx context.Context, req *connect.Request
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	statuses, err := domain.NormalizeSandboxVMStatuses(req.Msg.GetStatus())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
 	store, ok := h.store.(SandboxListStore)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("sandbox list store is required"))
 	}
 	result, err := store.ListSandboxes(ctx, domain.SandboxListOptions{
 		ProjectID:       strings.TrimSpace(req.Msg.GetProjectId()),
-		VMStatuses:      append([]string(nil), req.Msg.GetStatus()...),
+		VMStatuses:      statuses,
 		Limit:           limit,
 		BeforeUpdatedAt: cursor.UpdatedAt,
 		BeforeID:        cursor.SandboxID,

--- a/pkg/agentcompose/api/sandbox_characterization_test.go
+++ b/pkg/agentcompose/api/sandbox_characterization_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -216,7 +217,7 @@ func TestV2ListSandboxesPassesProjectAndStatusFiltersToStore(t *testing.T) {
 	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
 
 	_, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{
-		ProjectId: " project-a ", Status: []string{"running", "stopped"},
+		ProjectId: " project-a ", Status: []string{" running ", "", "STOPPED", "running"},
 	}))
 	if err != nil {
 		t.Fatalf("ListSandboxes() error = %v", err)
@@ -225,8 +226,25 @@ func TestV2ListSandboxesPassesProjectAndStatusFiltersToStore(t *testing.T) {
 		t.Fatalf("list options count = %d, want 1", len(store.listOptions))
 	}
 	options := store.listOptions[0]
-	if options.ProjectID != "project-a" || !slices.Equal(options.VMStatuses, []string{"running", "stopped"}) {
+	if options.ProjectID != "project-a" || !slices.Equal(options.VMStatuses, []string{domain.VMStatusRunning, domain.VMStatusStopped}) {
 		t.Fatalf("list options = %#v", options)
+	}
+}
+
+func TestV2ListSandboxesRejectsInvalidStatusBeforeStore(t *testing.T) {
+	for _, statuses := range [][]string{{"definitely-invalid"}, {"running", "definitely-invalid"}} {
+		t.Run(strings.Join(statuses, ","), func(t *testing.T) {
+			store := &characterizationSandboxStore{}
+			handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+
+			_, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{Status: statuses}))
+			if connect.CodeOf(err) != connect.CodeInvalidArgument || !strings.Contains(err.Error(), `invalid sandbox status "definitely-invalid"`) {
+				t.Fatalf("ListSandboxes() code/error = %v / %v", connect.CodeOf(err), err)
+			}
+			if len(store.listOptions) != 0 {
+				t.Fatalf("invalid status reached store with options %#v", store.listOptions)
+			}
+		})
 	}
 }
 

--- a/pkg/agentcompose/api/sandbox_list_integration_test.go
+++ b/pkg/agentcompose/api/sandbox_list_integration_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestIntegrationListSandboxesRejectsInvalidStatusOverConnect(t *testing.T) {
+	store := &characterizationSandboxStore{}
+	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	path, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
+	mux := http.NewServeMux()
+	mux.Handle(path, serviceHandler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewSandboxServiceClient(server.Client(), server.URL)
+
+	_, err := client.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{
+		Status: []string{"running", "definitely-invalid"},
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument || !strings.Contains(err.Error(), `invalid sandbox status "definitely-invalid"`) {
+		t.Fatalf("ListSandboxes() code/error = %v / %v", connect.CodeOf(err), err)
+	}
+	if len(store.listOptions) != 0 {
+		t.Fatalf("invalid status reached store with options %#v", store.listOptions)
+	}
+}

--- a/pkg/model/sandbox_status.go
+++ b/pkg/model/sandbox_status.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+var supportedSandboxVMStatuses = [...]string{
+	VMStatusPending,
+	VMStatusRunning,
+	VMStatusStopped,
+	VMStatusFailed,
+	VMStatusDeleting,
+}
+
+// SupportedSandboxVMStatuses returns the canonical sandbox VM statuses in
+// lifecycle order. The returned slice is owned by the caller.
+func SupportedSandboxVMStatuses() []string {
+	return append([]string(nil), supportedSandboxVMStatuses[:]...)
+}
+
+// NormalizeSandboxVMStatus canonicalizes one optional sandbox VM status.
+func NormalizeSandboxVMStatus(value string) (string, error) {
+	status := strings.ToUpper(strings.TrimSpace(value))
+	if status == "" {
+		return "", nil
+	}
+	for _, supported := range supportedSandboxVMStatuses {
+		if status == supported {
+			return supported, nil
+		}
+	}
+	return "", ClassifyError(
+		ErrInvalidArgument,
+		fmt.Sprintf("invalid sandbox status %q: expected %s", strings.TrimSpace(value), sandboxVMStatusExpectation()),
+		nil,
+	)
+}
+
+// NormalizeSandboxVMStatuses canonicalizes, removes empty entries, and
+// de-duplicates a sandbox VM status filter without mutating the input.
+func NormalizeSandboxVMStatuses(values []string) ([]string, error) {
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		status, err := NormalizeSandboxVMStatus(value)
+		if err != nil {
+			return nil, err
+		}
+		if status == "" {
+			continue
+		}
+		if _, ok := seen[status]; ok {
+			continue
+		}
+		seen[status] = struct{}{}
+		normalized = append(normalized, status)
+	}
+	return normalized, nil
+}
+
+func sandboxVMStatusExpectation() string {
+	names := make([]string, 0, len(supportedSandboxVMStatuses))
+	for _, status := range supportedSandboxVMStatuses {
+		names = append(names, strings.ToLower(status))
+	}
+	return strings.Join(names[:len(names)-1], ", ") + ", or " + names[len(names)-1]
+}

--- a/pkg/model/sandbox_status_test.go
+++ b/pkg/model/sandbox_status_test.go
@@ -1,0 +1,55 @@
+package model_test
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestNormalizeSandboxVMStatus(t *testing.T) {
+	for _, status := range domain.SupportedSandboxVMStatuses() {
+		t.Run(strings.ToLower(status), func(t *testing.T) {
+			got, err := domain.NormalizeSandboxVMStatus("  " + strings.ToLower(status) + "  ")
+			if err != nil || got != status {
+				t.Fatalf("NormalizeSandboxVMStatus() = %q, %v; want %q", got, err, status)
+			}
+		})
+	}
+
+	if got, err := domain.NormalizeSandboxVMStatus("  "); err != nil || got != "" {
+		t.Fatalf("empty status = %q, %v; want empty", got, err)
+	}
+	if _, err := domain.NormalizeSandboxVMStatus("definitely-invalid"); !errors.Is(err, domain.ErrInvalidArgument) ||
+		!strings.Contains(err.Error(), `invalid sandbox status "definitely-invalid"`) ||
+		!strings.Contains(err.Error(), "pending, running, stopped, failed, or deleting") {
+		t.Fatalf("invalid status error = %v", err)
+	}
+}
+
+func TestNormalizeSandboxVMStatuses(t *testing.T) {
+	input := []string{" running ", "", "STOPPED", "running", " failed "}
+	got, err := domain.NormalizeSandboxVMStatuses(input)
+	if err != nil {
+		t.Fatalf("NormalizeSandboxVMStatuses() error = %v", err)
+	}
+	want := []string{domain.VMStatusRunning, domain.VMStatusStopped, domain.VMStatusFailed}
+	if !slices.Equal(got, want) {
+		t.Fatalf("normalized statuses = %#v, want %#v", got, want)
+	}
+	if !slices.Equal(input, []string{" running ", "", "STOPPED", "running", " failed "}) {
+		t.Fatalf("NormalizeSandboxVMStatuses mutated input: %#v", input)
+	}
+
+	if got, err := domain.NormalizeSandboxVMStatuses([]string{"running", "definitely-invalid"}); err == nil || got != nil || !errors.Is(err, domain.ErrInvalidArgument) {
+		t.Fatalf("mixed invalid statuses = %#v, %v; want nil invalid-argument error", got, err)
+	}
+
+	statuses := domain.SupportedSandboxVMStatuses()
+	statuses[0] = "MUTATED"
+	if domain.SupportedSandboxVMStatuses()[0] != domain.VMStatusPending {
+		t.Fatal("SupportedSandboxVMStatuses exposed shared mutable state")
+	}
+}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -8403,14 +8403,15 @@ func (x *RemoveSandboxResponse) GetRemoved() bool {
 }
 
 type PruneSandboxesRequest struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	ProjectId        string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
-	Status           []string               `protobuf:"bytes,2,rep,name=status,proto3" json:"status,omitempty"`
-	AgentName        string                 `protobuf:"bytes,3,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
-	Driver           string                 `protobuf:"bytes,4,opt,name=driver,proto3" json:"driver,omitempty"`
-	OlderThanSeconds uint64                 `protobuf:"varint,5,opt,name=older_than_seconds,json=olderThanSeconds,proto3" json:"older_than_seconds,omitempty"`
-	IncludeOrphans   bool                   `protobuf:"varint,6,opt,name=include_orphans,json=includeOrphans,proto3" json:"include_orphans,omitempty"`
-	Force            bool                   `protobuf:"varint,7,opt,name=force,proto3" json:"force,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	ProjectId string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	// Optional case-insensitive filter. Only stopped and failed are safe to prune.
+	Status           []string `protobuf:"bytes,2,rep,name=status,proto3" json:"status,omitempty"`
+	AgentName        string   `protobuf:"bytes,3,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	Driver           string   `protobuf:"bytes,4,opt,name=driver,proto3" json:"driver,omitempty"`
+	OlderThanSeconds uint64   `protobuf:"varint,5,opt,name=older_than_seconds,json=olderThanSeconds,proto3" json:"older_than_seconds,omitempty"`
+	IncludeOrphans   bool     `protobuf:"varint,6,opt,name=include_orphans,json=includeOrphans,proto3" json:"include_orphans,omitempty"`
+	Force            bool     `protobuf:"varint,7,opt,name=force,proto3" json:"force,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -9067,11 +9068,13 @@ func (x *SandboxTag) GetValue() string {
 }
 
 type ListSandboxesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Limit         uint32                 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
-	Cursor        string                 `protobuf:"bytes,2,opt,name=cursor,proto3" json:"cursor,omitempty"`
-	ProjectId     string                 `protobuf:"bytes,3,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
-	Status        []string               `protobuf:"bytes,4,rep,name=status,proto3" json:"status,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Limit     uint32                 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
+	Cursor    string                 `protobuf:"bytes,2,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	ProjectId string                 `protobuf:"bytes,3,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	// Optional case-insensitive filter. Accepted values are pending, running,
+	// stopped, failed, and deleting. Empty entries are ignored.
+	Status        []string `protobuf:"bytes,4,rep,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -1050,6 +1050,7 @@ message RemoveSandboxResponse {
 
 message PruneSandboxesRequest {
   string project_id = 1;
+  // Optional case-insensitive filter. Only stopped and failed are safe to prune.
   repeated string status = 2;
   string agent_name = 3;
   string driver = 4;
@@ -1123,6 +1124,8 @@ message ListSandboxesRequest {
   uint32 limit = 1;
   string cursor = 2;
   string project_id = 3;
+  // Optional case-insensitive filter. Accepted values are pending, running,
+  // stopped, failed, and deleting. Empty entries are ignored.
   repeated string status = 4;
 }
 


### PR DESCRIPTION
## Summary

- centralize the canonical sandbox status set and reject unknown values instead of treating them as empty-result filters
- validate `ps` and `sandbox ls` before client creation, validate V2 `ListSandboxes` before storage access, and validate Scheduler `vmStatus` at the shared JSON adapter boundary
- keep storage permissive for internal callers and historical records; unfiltered `--all` can still display unknown persisted statuses
- restrict local `sandbox prune --status` input to the domain-safe `stopped` and `failed` states
- document the accepted status contract without changing protobuf wire types

Invalid CLI status values now return usage exit code 2 with empty stdout and do not send daemon requests. Direct API callers receive Connect `InvalidArgument`.

Fixes #455

## Testing

- `GOFLAGS=-buildvcs=false go test ./pkg/model ./pkg/agentcompose/api ./pkg/agentcompose/adapters ./cmd/agent-compose -count=1`
- `task docs:build`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`

Full test coverage summary: Unit 75.13%, Integration 60.76%, E2E 60.57%, Combined 79.15%.

`GOFLAGS=-buildvcs=false` is the documented local linked-worktree compatibility setting. Runtime JavaScript dependencies were installed from the committed lockfile before the final full test run.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.