### PR TITLE
fix(api): make project ref selectors exclusive

### DIFF
--- a/cmd/agent-compose/cli_ps_run_association.go
+++ b/cmd/agent-compose/cli_ps_run_association.go
@@ -30,7 +30,7 @@ func latestSchedulerRunsBySandbox(ctx context.Context, clients cliServiceClients
 	for start := 0; start < len(targetSandboxIDs); start += schedulerRunLookupBatchSize {
 		end := min(start+schedulerRunLookupBatchSize, len(targetSandboxIDs))
 		response, err := clients.project.BatchGetLatestSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.BatchGetLatestSchedulerRunsRequest{
-			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, SandboxIds: targetSandboxIDs[start:end],
+			Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, SandboxIds: targetSandboxIDs[start:end],
 		}))
 		if err != nil {
 			return nil, commandExitErrorForConnect(err)

--- a/cmd/agent-compose/cli_resource_locator.go
+++ b/cmd/agent-compose/cli_resource_locator.go
@@ -55,13 +55,13 @@ func inspectResolvedTarget(cmd *cobra.Command, cli cliOptions, clients cliServic
 	}
 	switch target.GetKind() {
 	case agentcomposev2.ResourceKind_RESOURCE_KIND_PROJECT:
-		project, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{ProjectId: target.GetId()}, IncludeSpec: true}))
+		project, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: target.GetId()}}, IncludeSpec: true}))
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("inspect project %s: %w", target.GetId(), err))
 		}
 		return writeComposeInspectOutput(cmd, composeProjectOutputFromProject(project.Msg.GetProject()))
 	case agentcomposev2.ResourceKind_RESOURCE_KIND_AGENT:
-		project, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{ProjectId: target.GetProjectId()}, IncludeSpec: true}))
+		project, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: target.GetProjectId()}}, IncludeSpec: true}))
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("inspect agent %s: %w", target.GetAgentName(), err))
 		}

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -136,7 +136,7 @@ func runComposeDownCommand(cmd *cobra.Command, cli cliOptions) error {
 		return err
 	}
 	resp, err := clients.project.RemoveProject(cmd.Context(), connect.NewRequest(&agentcomposev2.RemoveProjectRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: runtimeProject.id()},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: runtimeProject.id()}},
 	}))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("down project %s: %w", runtimeProject.name(), err))

--- a/cmd/agent-compose/cli_runtime_project.go
+++ b/cmd/agent-compose/cli_runtime_project.go
@@ -87,7 +87,7 @@ func resolveComposeRuntimeProjectRef(cli cliOptions) (string, string, *agentcomp
 func resolveComposeRuntimeProjectSelectionForCLI(cli cliOptions) (composeRuntimeProjectSelection, error) {
 	projectName := strings.TrimSpace(cli.ProjectName)
 	if projectName != "" {
-		return composeRuntimeProjectSelection{requestedName: projectName, ref: &agentcomposev2.ProjectRef{Name: projectName}}, nil
+		return composeRuntimeProjectSelection{requestedName: projectName, ref: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_Name{Name: projectName}}}, nil
 	}
 	composePath, normalized, projectID, err := resolveComposeProject(cli)
 	if err != nil {
@@ -96,7 +96,7 @@ func resolveComposeRuntimeProjectSelectionForCLI(cli cliOptions) (composeRuntime
 	return composeRuntimeProjectSelection{
 		composePath:   composePath,
 		requestedName: normalized.Name,
-		ref:           &agentcomposev2.ProjectRef{ProjectId: projectID},
+		ref:           &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 		localSpec:     normalized,
 	}, nil
 }

--- a/cmd/agent-compose/cli_sandbox_lifecycle.go
+++ b/cmd/agent-compose/cli_sandbox_lifecycle.go
@@ -334,7 +334,7 @@ func resolveComposeSandboxRefWithProject(ctx context.Context, clients cliService
 		return ref, nil
 	}
 	project, err := clients.project.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 	}))
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {

--- a/cmd/agent-compose/cli_sandbox_prune.go
+++ b/cmd/agent-compose/cli_sandbox_prune.go
@@ -88,7 +88,7 @@ func runComposeSandboxPruneCommand(cmd *cobra.Command, cli cliOptions, options c
 
 func runLegacyComposeSandboxPrune(cmd *cobra.Command, cli cliOptions, options composeSandboxPruneOptions, clients cliServiceClients, runtimeProject composeRuntimeProject, statusFilter map[string]bool, olderThanSeconds uint64) error {
 	project, err := clients.project.GetProject(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProjectRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: runtimeProject.id()},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: runtimeProject.id()}},
 	}))
 	if err != nil {
 		return commandExitErrorForComposeProject(fmt.Errorf("get project %s: %w", runtimeProject.name(), err), "sandbox prune", runtimeProject.name(), runtimeProject.composePath)

--- a/cmd/agent-compose/cli_scheduler_prune.go
+++ b/cmd/agent-compose/cli_scheduler_prune.go
@@ -95,7 +95,7 @@ func runComposeSchedulerPruneCommand(cmd interface {
 		return commandExitError{Code: exitCodeUsage, Err: err}
 	}
 	response, err := clients.project.PruneSchedulerRuns(cmd.Context(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
-		Project:          &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project:          &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 		AgentName:        agentName,
 		TriggerId:        triggerID,
 		Status:           statuses,

--- a/cmd/agent-compose/cli_scheduler_query.go
+++ b/cmd/agent-compose/cli_scheduler_query.go
@@ -78,7 +78,7 @@ func listComposeSchedulerTriggers(ctx context.Context, clients cliServiceClients
 		}
 		schedulerEnabled := agent.Scheduler.Enabled
 		if agent.Scheduler.HasScript() {
-			scheduler, err := clients.project.GetScheduler(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRequest{Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agent.Name}))
+			scheduler, err := clients.project.GetScheduler(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRequest{Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: agent.Name}))
 			if err != nil {
 				return nil, commandExitErrorForConnect(fmt.Errorf("get scheduler %s: %w", schedulerID, err))
 			}
@@ -120,7 +120,7 @@ func listComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, no
 			return items, nil
 		}
 		resp, err := clients.project.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
-			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentFilter, TriggerId: triggerID, Status: runStatus, Limit: pageLimit, Cursor: cursor,
+			Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: agentFilter, TriggerId: triggerID, Status: runStatus, Limit: pageLimit, Cursor: cursor,
 		}))
 		if err != nil {
 			if connect.CodeOf(err) == connect.CodeUnimplemented {
@@ -223,7 +223,7 @@ func resolveHistoricalSchedulerTriggerID(ctx context.Context, client agentcompos
 			continue
 		}
 		resp, err := client.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
-			Project:   &agentcomposev2.ProjectRef{ProjectId: projectID},
+			Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 			AgentName: agent.Name,
 			TriggerId: triggerID,
 			Limit:     1,
@@ -292,7 +292,7 @@ func schedulerRuntimeRunItem(schedulerID, loaderID string, run *agentcomposev2.S
 func resolveSchedulerRuntimeRun(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, normalized *compose.NormalizedProjectSpec, projectID, ref string) (*composeSchedulerRunItem, error) {
 	ref = strings.TrimSpace(ref)
 	response, err := client.GetSchedulerRun(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRunRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, RunId: ref,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, RunId: ref,
 	}))
 	if err == nil && response != nil && response.Msg.GetRun() != nil {
 		run := response.Msg.GetRun()
@@ -326,7 +326,7 @@ func listProjectSchedulerLogEvents(ctx context.Context, client agentcomposev2con
 			break
 		}
 		resp, err := client.ListProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
-			Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, TriggerId: triggerID, RunId: runID, Limit: pageLimit, Cursor: cursor,
+			Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: agentName, TriggerId: triggerID, RunId: runID, Limit: pageLimit, Cursor: cursor,
 		}))
 		if err != nil {
 			if connect.CodeOf(err) == connect.CodeUnimplemented {

--- a/cmd/agent-compose/cli_scheduler_stream.go
+++ b/cmd/agent-compose/cli_scheduler_stream.go
@@ -23,7 +23,7 @@ func streamComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, 
 		return err
 	}
 	stream, err := clients.projectStream.StreamSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentFilter, TriggerId: triggerID,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: agentFilter, TriggerId: triggerID,
 		Status: runStatus, BatchSize: schedulerCLIBatchSize, Limit: limit,
 	}))
 	if err != nil {
@@ -92,7 +92,7 @@ func streamProjectSchedulerLogEvents(ctx context.Context, clients cliServiceClie
 		streamTail = uint32(tail)
 	}
 	stream, err := clients.projectStream.StreamProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: agentName, TriggerId: triggerID, RunId: runID,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: agentName, TriggerId: triggerID, RunId: runID,
 		BatchSize: schedulerCLIBatchSize, Tail: streamTail,
 	}))
 	if err != nil {

--- a/cmd/agent-compose/e2e_docker_scheduler_test.go
+++ b/cmd/agent-compose/e2e_docker_scheduler_test.go
@@ -118,7 +118,7 @@ agents:
 	projectClient := agentcomposev2connect.NewProjectServiceClient(client, "http://agent-compose")
 	scheduler := waitForManagedHelloScheduler(t, projectClient)
 	detail, err := projectClient.GetScheduler(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRequest{
-		Project:   &agentcomposev2.ProjectRef{ProjectId: scheduler.GetProjectId()},
+		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: scheduler.GetProjectId()}},
 		AgentName: scheduler.GetAgentName(),
 	}))
 	if err != nil {
@@ -285,7 +285,7 @@ func waitForScheduledHelloRun(t *testing.T, projectClient agentcomposev2connect.
 	var lastErr error
 	for time.Now().Before(deadline) {
 		eventsResp, err := projectClient.ListSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
-			Project:   &agentcomposev2.ProjectRef{ProjectId: scheduler.GetProjectId()},
+			Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: scheduler.GetProjectId()}},
 			AgentName: scheduler.GetAgentName(),
 			Limit:     100,
 		}))

--- a/cmd/agent-compose/scheduler_runs.go
+++ b/cmd/agent-compose/scheduler_runs.go
@@ -89,7 +89,7 @@ func runComposeSchedulerInvokeCommand(cmd *cobra.Command, cli cliOptions, option
 		}
 	}
 	response, err := clients.project.InvokeScheduler(cmd.Context(), connect.NewRequest(&agentcomposev2.InvokeSchedulerRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, AgentName: scheduler.AgentName, PayloadJson: payloadJSON,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: scheduler.AgentName, PayloadJson: payloadJSON,
 	}))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("invoke scheduler %s in project %s: %w", scheduler.AgentName, runtimeProject.name(), err))
@@ -145,7 +145,7 @@ func runComposeSchedulerTriggerV2Command(cmd *cobra.Command, cli cliOptions, opt
 }
 
 func executeComposeSchedulerRun(cmd *cobra.Command, cli cliOptions, projectName, projectID, agentName, triggerID string, options composeSchedulerTriggerOptions, client agentcomposev2connect.ProjectServiceClient) error {
-	project := &agentcomposev2.ProjectRef{ProjectId: projectID}
+	project := &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}
 	var run *agentcomposev2.SchedulerRun
 	if options.Detach {
 		response, err := client.StartSchedulerRun(cmd.Context(), connect.NewRequest(&agentcomposev2.StartSchedulerRunRequest{
@@ -196,7 +196,7 @@ func runComposeSchedulerStopCommand(cmd *cobra.Command, cli cliOptions, options 
 	}
 	projectID := runtimeProject.id()
 	response, err := clients.project.StopSchedulerRun(cmd.Context(), connect.NewRequest(&agentcomposev2.StopSchedulerRunRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, RunId: runID, Reason: strings.TrimSpace(options.Reason),
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, RunId: runID, Reason: strings.TrimSpace(options.Reason),
 	}))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("stop scheduler run %s in project %s: %w", runID, runtimeProject.name(), err))
@@ -233,7 +233,7 @@ func inspectComposeRunOutput(ctx context.Context, clients cliServiceClients, pro
 		return nil, commandExitErrorForConnect(fmt.Errorf("inspect run %s in project %s: %w", runID, projectName, err))
 	}
 	schedulerRun, schedulerErr := clients.project.GetSchedulerRun(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRunRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID}, RunId: runID,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, RunId: runID,
 	}))
 	if schedulerErr != nil {
 		return nil, commandExitErrorForConnect(fmt.Errorf("inspect run %s in project %s: %w", runID, projectName, schedulerErr))

--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -678,10 +678,18 @@ func (h *ExecHandler) resolveExecTargetSandbox(ctx context.Context, req *agentco
 	if selector == nil {
 		return nil, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exec target is required"))
 	}
-	project, err := h.resolveProjectRef(ctx, &agentcomposev2.ProjectRef{
-		ProjectId: selector.GetProjectId(),
-		Name:      selector.GetProjectName(),
-	})
+	projectID := strings.TrimSpace(selector.GetProjectId())
+	projectName := strings.TrimSpace(selector.GetProjectName())
+	if projectID != "" && projectName != "" {
+		return nil, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("project_id and project_name are mutually exclusive"))
+	}
+	projectRef := &agentcomposev2.ProjectRef{}
+	if projectID != "" {
+		projectRef.Selector = &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}
+	} else if projectName != "" {
+		projectRef.Selector = &agentcomposev2.ProjectRef_Name{Name: projectName}
+	}
+	project, err := h.resolveProjectRef(ctx, projectRef)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, "", connect.NewError(connect.CodeNotFound, err)
@@ -766,41 +774,7 @@ func appendExecTranscriptChunk(path string, chunk domain.ExecChunk) error {
 }
 
 func (h *ExecHandler) resolveProjectRef(ctx context.Context, ref *agentcomposev2.ProjectRef) (domain.ProjectRecord, error) {
-	if ref == nil {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project ref is required", nil)
-	}
-	if projectID := strings.TrimSpace(ref.GetProjectId()); projectID != "" {
-		return h.projects.GetProject(ctx, projectID)
-	}
-	name := strings.TrimSpace(ref.GetName())
-	sourcePath := strings.TrimSpace(ref.GetSourcePath())
-	if name != "" && sourcePath != "" {
-		projectID, err := domain.StableProjectID(name, sourcePath)
-		if err != nil {
-			return domain.ProjectRecord{}, err
-		}
-		return h.projects.GetProject(ctx, projectID)
-	}
-	if name == "" {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project id or name is required", nil)
-	}
-	result, err := h.projects.ListProjects(ctx, domain.ProjectListOptions{Query: name, Limit: 200})
-	if err != nil {
-		return domain.ProjectRecord{}, err
-	}
-	var matches []domain.ProjectRecord
-	for _, project := range result.Projects {
-		if project.Name == name {
-			matches = append(matches, project)
-		}
-	}
-	if len(matches) == 0 {
-		return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", name, fmt.Sprintf("project %s not found", name), sql.ErrNoRows)
-	}
-	if len(matches) > 1 {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrAmbiguous, fmt.Sprintf("project name %s is ambiguous; use project_id or source_path", name), nil)
-	}
-	return matches[0], nil
+	return resolveProjectReference(ctx, h.projects, ref)
 }
 
 func ExecEnvMap(items []*agentcomposev2.EnvVarSpec) map[string]string {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -480,7 +480,7 @@ func TestExecHandlerRunSelectorAndStreamSenderWorkflow(t *testing.T) {
 	})); connect.CodeOf(err) != connect.CodeFailedPrecondition {
 		t.Fatalf("expected stopped run sandbox error, got %v", err)
 	}
-	if _, err := handler.resolveProjectRef(ctx, &agentcomposev2.ProjectRef{Name: "Project"}); !errors.Is(err, domain.ErrAmbiguous) {
+	if _, err := handler.resolveProjectRef(ctx, &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_Name{Name: "Project"}}); !errors.Is(err, domain.ErrAmbiguous) {
 		t.Fatalf("expected ambiguous project ref error, got %v", err)
 	}
 }
@@ -494,6 +494,11 @@ func TestExecHandlerSelectorErrors(t *testing.T) {
 	}
 	if _, err := handler.Exec(context.Background(), connect.NewRequest(&agentcomposev2.ExecRequest{Target: &agentcomposev2.ExecRequest_RunId{RunId: "missing"}, Command: &agentcomposev2.ExecCommand{Command: "echo"}})); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("expected run not found, got %v", err)
+	}
+	if _, err := handler.Exec(context.Background(), connect.NewRequest(&agentcomposev2.ExecRequest{
+		Target: &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{ProjectId: "project-1", ProjectName: "Project"}},
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("expected conflicting project selector error, got %v", err)
 	}
 }
 
@@ -695,7 +700,7 @@ func TestExecAttachInputFrameMapping(t *testing.T) {
 func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	ctx := context.Background()
 	store := &apiProjectRunStore{
-		projects: []domain.ProjectRecord{{ID: "project-1", Name: "Project", CurrentRevision: 1}},
+		projects: []domain.ProjectRecord{{ID: "project-1", Name: "Project", SourcePath: "/repo/agent-compose.yml", CurrentRevision: 1}},
 		agents: []domain.ProjectAgentRecord{
 			{ProjectID: "project-1", AgentName: "worker", ManagedAgentID: "agent-1", Revision: 1, Driver: "boxlite", Image: "guest:latest"},
 			{ProjectID: "project-1", AgentName: "worker-2", ManagedAgentID: "agent-2", Revision: 1, Driver: "boxlite", Image: "guest:latest"},
@@ -719,7 +724,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 		runEvents: []domain.ProjectRunEventRecord{{ID: "event-1", RunID: "run-1", Sequence: 1, Kind: domain.ProjectRunEventKindUserMessage, Text: "hello", CreatedAt: time.Unix(1, 0)}},
 	}
 	projectHandler := NewProjectHandler(nil, store, nil)
-	projectResp, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Name: "Project"}, IncludeSpec: true}))
+	projectResp, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_Name{Name: "Project"}}, IncludeSpec: true}))
 	if err != nil {
 		t.Fatalf("GetProject returned error: %v", err)
 	}
@@ -737,6 +742,12 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	if store.agentRunStateCalls != 1 || projectAgent.GetCurrentRun().GetRunningRunCount() != 1 || projectAgent.GetCurrentRun().GetRunningSchedulerRunCount() != 2 || projectAgent.GetLatestRun().GetRunId() != "run-1" || projectAgent.GetHealth() != agentcomposev2.ProjectAgentHealth_PROJECT_AGENT_HEALTH_AT_RISK {
 		t.Fatalf("project agent run enrichment calls=%d agent=%#v", store.agentRunStateCalls, projectAgent)
 	}
+	projectByPath, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_SourcePath{SourcePath: "/repo/./agent-compose.yml"}},
+	}))
+	if err != nil || projectByPath.Msg.GetProject().GetSummary().GetProjectId() != "project-1" {
+		t.Fatalf("GetProject by source path response=%#v err=%v", projectByPath, err)
+	}
 	listProjects, err := projectHandler.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{Query: "Project", Limit: 10}))
 	if err != nil || len(listProjects.Msg.GetProjects()) != 1 {
 		t.Fatalf("ListProjects resp=%#v err=%v", listProjects, err)
@@ -744,7 +755,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	if summary := listProjects.Msg.GetProjects()[0]; summary.GetAgentCount() != 2 || summary.GetSchedulerCount() != 2 {
 		t.Fatalf("ListProjects summary counts = agents %d schedulers %d", summary.GetAgentCount(), summary.GetSchedulerCount())
 	}
-	scheduler, err := projectHandler.GetScheduler(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRequest{Project: &agentcomposev2.ProjectRef{ProjectId: "project-1"}, AgentName: "worker"}))
+	scheduler, err := projectHandler.GetScheduler(ctx, connect.NewRequest(&agentcomposev2.GetSchedulerRequest{Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: "project-1"}}, AgentName: "worker"}))
 	if err != nil || scheduler.Msg.GetScheduler().GetSchedulerId() != "scheduler-1" || scheduler.Msg.GetScheduler().GetDisplayName() != "每日巡检" || scheduler.Msg.GetSpec().GetScript() != "run()" || scheduler.Msg.GetSpec().GetDescription() != "每天汇总巡检结果" {
 		t.Fatalf("GetScheduler resp=%#v err=%v", scheduler, err)
 	}
@@ -766,7 +777,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	}
 	store.loaders["loader-2"] = domain.Loader{Summary: domain.LoaderSummary{ID: "loader-2", Enabled: true}}
 	store.projects = append(store.projects, domain.ProjectRecord{ID: "project-2", Name: "Project"})
-	if _, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Name: "Project"}})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+	if _, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_Name{Name: "Project"}}})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("expected ambiguous project error, got %v", err)
 	}
 	store.projects = store.projects[:1]

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -518,39 +518,5 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *connect.Request[
 }
 
 func (h *ProjectHandler) resolveProjectRef(ctx context.Context, ref *agentcomposev2.ProjectRef) (domain.ProjectRecord, error) {
-	if ref == nil {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project ref is required", nil)
-	}
-	if projectID := strings.TrimSpace(ref.GetProjectId()); projectID != "" {
-		return h.store.GetProject(ctx, projectID)
-	}
-	name := strings.TrimSpace(ref.GetName())
-	sourcePath := strings.TrimSpace(ref.GetSourcePath())
-	if name != "" && sourcePath != "" {
-		projectID, err := domain.StableProjectID(name, sourcePath)
-		if err != nil {
-			return domain.ProjectRecord{}, err
-		}
-		return h.store.GetProject(ctx, projectID)
-	}
-	if name == "" {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project id or name is required", nil)
-	}
-	result, err := h.store.ListProjects(ctx, domain.ProjectListOptions{Query: name, Limit: 200})
-	if err != nil {
-		return domain.ProjectRecord{}, err
-	}
-	var matches []domain.ProjectRecord
-	for _, project := range result.Projects {
-		if project.Name == name {
-			matches = append(matches, project)
-		}
-	}
-	if len(matches) == 0 {
-		return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", name, fmt.Sprintf("project %s not found", name), sql.ErrNoRows)
-	}
-	if len(matches) > 1 {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrAmbiguous, fmt.Sprintf("project name %s is ambiguous; use project_id or source_path", name), nil)
-	}
-	return matches[0], nil
+	return resolveProjectReference(ctx, h.store, ref)
 }

--- a/pkg/agentcompose/api/project_handler_scheduler_runtime_test.go
+++ b/pkg/agentcompose/api/project_handler_scheduler_runtime_test.go
@@ -33,7 +33,7 @@ func TestProjectHandlerSchedulerUpdatesUseLoaderRuntime(t *testing.T) {
 	handler := NewProjectHandler(nil, store, runtime)
 
 	enabled, err := handler.SetSchedulerEnabled(context.Background(), connect.NewRequest(&agentcomposev2.SetSchedulerEnabledRequest{
-		Project:   &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 		AgentName: agentName,
 		Enabled:   true,
 	}))
@@ -45,7 +45,7 @@ func TestProjectHandlerSchedulerUpdatesUseLoaderRuntime(t *testing.T) {
 	}
 
 	trigger, err := handler.SetSchedulerTriggerEnabled(context.Background(), connect.NewRequest(&agentcomposev2.SetSchedulerTriggerEnabledRequest{
-		Project:   &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 		AgentName: agentName,
 		TriggerId: triggerID,
 		Enabled:   true,

--- a/pkg/agentcompose/api/project_ref.go
+++ b/pkg/agentcompose/api/project_ref.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"context"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func resolveProjectReference(ctx context.Context, store projects.ProjectRefStore, ref *agentcomposev2.ProjectRef) (domain.ProjectRecord, error) {
+	return projects.ResolveProjectRef(ctx, store, projectReferenceFromProto(ref))
+}
+
+func projectReferenceFromProto(ref *agentcomposev2.ProjectRef) projects.ProjectRef {
+	if ref == nil {
+		return projects.ProjectRef{}
+	}
+	switch selector := ref.GetSelector().(type) {
+	case *agentcomposev2.ProjectRef_ProjectId:
+		return projects.ProjectRefByID(selector.ProjectId)
+	case *agentcomposev2.ProjectRef_Name:
+		return projects.ProjectRefByName(selector.Name)
+	case *agentcomposev2.ProjectRef_SourcePath:
+		return projects.ProjectRefBySourcePath(selector.SourcePath)
+	default:
+		return projects.ProjectRef{}
+	}
+}

--- a/pkg/agentcompose/api/project_scheduler_prune_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_prune_handler_test.go
@@ -26,7 +26,7 @@ func TestProjectHandlerPruneSchedulerRunsMapsRequestAndResult(t *testing.T) {
 		Warnings:    []string{"warning"},
 	}
 	response, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
-		Project:   &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		AgentName: store.scheduler.AgentName,
 		TriggerId: " trigger-history ",
 		Status: []agentcomposev2.SchedulerRunStatus{
@@ -63,7 +63,7 @@ func TestProjectHandlerPruneSchedulerRunsUsesCurrentProjectSchedulers(t *testing
 	store.schedulers = []domain.ProjectSchedulerRecord{store.scheduler, stale, currentSecond}
 
 	_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Force: true,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, Force: true,
 	}))
 	if err != nil {
 		t.Fatalf("PruneSchedulerRuns: %v", err)
@@ -80,14 +80,14 @@ func TestProjectHandlerPruneSchedulerRunsRejectsInvalidStatusAndDuration(t *test
 		agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_RUNNING,
 	} {
 		_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
-			Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Status: []agentcomposev2.SchedulerRunStatus{status},
+			Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, Status: []agentcomposev2.SchedulerRunStatus{status},
 		}))
 		if connect.CodeOf(err) != connect.CodeInvalidArgument {
 			t.Fatalf("status %v code=%v err=%v", status, connect.CodeOf(err), err)
 		}
 	}
 	_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, OlderThanSeconds: math.MaxUint64,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, OlderThanSeconds: math.MaxUint64,
 	}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("overflow duration code=%v err=%v", connect.CodeOf(err), err)
@@ -101,7 +101,7 @@ func TestProjectHandlerPruneSchedulerRunsRuntimeUnavailable(t *testing.T) {
 	store, _, _ := newSchedulerRunHandlerFixture()
 	handler := NewProjectHandler(nil, store, &schedulerRuntimeFake{})
 	_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 	}))
 	if connect.CodeOf(err) != connect.CodeUnavailable {
 		t.Fatalf("runtime unavailable code=%v err=%v", connect.CodeOf(err), err)

--- a/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
@@ -127,7 +127,7 @@ func TestIntegrationBatchGetLatestSchedulerRunsFindsRunBeyondFirstPage(t *testin
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 	client := agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL)
-	projectRef := &agentcomposev2.ProjectRef{ProjectId: project.ID}
+	projectRef := &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: project.ID}}
 
 	page, err := client.ListSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
 		Project: projectRef,

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -42,7 +42,7 @@ func TestProjectHandlerRunSchedulerSupportsMainAndTerminalStatuses(t *testing.T)
 				PayloadJSON: `{"value":true}`,
 			}
 			response, err := handler.RunScheduler(context.Background(), connect.NewRequest(&agentcomposev2.RunSchedulerRequest{
-				Project:     &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+				Project:     &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 				AgentName:   store.scheduler.AgentName,
 				TriggerId:   test.triggerID,
 				PayloadJson: ` { "value" : true } `,
@@ -63,7 +63,7 @@ func TestProjectHandlerRunSchedulerSupportsMainAndTerminalStatuses(t *testing.T)
 func TestProjectHandlerRunSchedulerValidatesPayloadAndMissingTrigger(t *testing.T) {
 	store, runtime, handler := newSchedulerRunHandlerFixture()
 	request := &agentcomposev2.RunSchedulerRequest{
-		Project:   &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		AgentName: store.scheduler.AgentName,
 	}
 	request.PayloadJson = `{bad`
@@ -86,7 +86,7 @@ func TestProjectHandlerInvokeSchedulerReturnsValueWithoutRunResource(t *testing.
 	store, runtime, handler := newSchedulerRunHandlerFixture()
 	runtime.invokeResult = loaders.InvocationResult{ResultJSON: `{"ok":true}`, DurationMs: 42, Warnings: []string{"warning"}}
 	response, err := handler.InvokeScheduler(context.Background(), connect.NewRequest(&agentcomposev2.InvokeSchedulerRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, AgentName: store.scheduler.AgentName, PayloadJson: ` { "value" : true } `,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, AgentName: store.scheduler.AgentName, PayloadJson: ` { "value" : true } `,
 	}))
 	if err != nil || response.Msg.GetResultJson() != `{"ok":true}` || response.Msg.GetDurationMs() != 42 || len(response.Msg.GetWarnings()) != 1 {
 		t.Fatalf("InvokeScheduler response=%#v err=%v", response, err)
@@ -96,7 +96,7 @@ func TestProjectHandlerInvokeSchedulerReturnsValueWithoutRunResource(t *testing.
 	}
 	store.scheduler.SpecJSON = `{"triggers":[{"name":"nightly"}]}`
 	if _, err := handler.InvokeScheduler(context.Background(), connect.NewRequest(&agentcomposev2.InvokeSchedulerRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, AgentName: store.scheduler.AgentName,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, AgentName: store.scheduler.AgentName,
 	})); connect.CodeOf(err) != connect.CodeFailedPrecondition {
 		t.Fatalf("declarative invoke code=%v err=%v", connect.CodeOf(err), err)
 	}
@@ -107,7 +107,7 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	startedAt := time.Unix(200, 0).UTC()
 	runtime.startResult = domain.LoaderRunSummary{ID: "run-start", LoaderID: store.scheduler.ManagedLoaderID, TriggerID: "trigger-1", Status: domain.LoaderRunStatusRunning, StartedAt: startedAt}
 	started, err := handler.StartSchedulerRun(context.Background(), connect.NewRequest(&agentcomposev2.StartSchedulerRunRequest{
-		Project:     &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project:     &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		AgentName:   store.scheduler.AgentName,
 		TriggerId:   "trigger-1",
 		PayloadJson: `{"start":true}`,
@@ -120,7 +120,7 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	store.runs = []domain.LoaderRunSummary{getRun}
 	runtime.getResult = getRun
 	got, err := handler.GetSchedulerRun(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRunRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		RunId:   getRun.ID,
 	}))
 	if err != nil || got.Msg.GetRun().GetStatus() != agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_CANCELED || got.Msg.GetRun().GetError() != "user stop" {
@@ -132,14 +132,14 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	store.runs = []domain.LoaderRunSummary{newer, older}
 	store.sandboxIDs = map[loaders.LoaderRunKey][]string{{LoaderID: newer.LoaderID, RunID: newer.ID}: {"sandbox-1"}}
 	first, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		Limit:   1,
 	}))
 	if err != nil || len(first.Msg.GetRuns()) != 1 || first.Msg.GetRuns()[0].GetRunId() != newer.ID || len(first.Msg.GetRuns()[0].GetSandboxIds()) != 1 || first.Msg.GetNextCursor() == "" {
 		t.Fatalf("ListSchedulerRuns first=%#v err=%v", first, err)
 	}
 	second, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		Limit:   1,
 		Cursor:  first.Msg.GetNextCursor(),
 	}))
@@ -147,7 +147,7 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 		t.Fatalf("ListSchedulerRuns second=%#v err=%v", second, err)
 	}
 	if _, err := handler.ListSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, TriggerId: "trigger-1", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED, Limit: 1,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, TriggerId: "trigger-1", Status: agentcomposev2.SchedulerRunStatus_SCHEDULER_RUN_STATUS_SKIPPED, Limit: 1,
 	})); err != nil || !store.lastRunFilter.RequireTrigger || store.lastRunFilter.TriggerID != "trigger-1" || store.lastRunFilter.Status != domain.LoaderRunStatusSkipped {
 		t.Fatalf("ListSchedulerRuns filter=%#v err=%v", store.lastRunFilter, err)
 	}
@@ -156,7 +156,7 @@ func TestProjectHandlerSchedulerRunLifecycle(t *testing.T) {
 	runtime.stopResult = getRun
 	runtime.stopRequested = true
 	stopped, err := handler.StopSchedulerRun(context.Background(), connect.NewRequest(&agentcomposev2.StopSchedulerRunRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		RunId:   getRun.ID,
 		Reason:  "user stop",
 	}))
@@ -173,7 +173,7 @@ func TestProjectHandlerBatchGetsLatestSchedulerRuns(t *testing.T) {
 	}
 	store.batchRunsBySandbox = map[string]domain.LoaderRunSummary{"sandbox-a": run}
 	response, err := handler.BatchGetLatestSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.BatchGetLatestSchedulerRunsRequest{
-		Project:    &agentcomposev2.ProjectRef{ProjectId: store.project.ID},
+		Project:    &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 		SandboxIds: []string{" sandbox-a ", "sandbox-missing", "sandbox-a", ""},
 	}))
 	if err != nil {
@@ -197,7 +197,7 @@ func TestProjectHandlerRejectsExcessiveSchedulerRunBatch(t *testing.T) {
 		sandboxIDs[index] = fmt.Sprintf("sandbox-%d", index)
 	}
 	_, err := handler.BatchGetLatestSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.BatchGetLatestSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, SandboxIds: sandboxIDs,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, SandboxIds: sandboxIDs,
 	}))
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("excessive batch query code=%v err=%v", connect.CodeOf(err), err)
@@ -212,14 +212,14 @@ func TestProjectHandlerListsProjectSchedulerEventsWithIdentityAndCursor(t *testi
 		{ID: "event-1", LoaderID: store.scheduler.ManagedLoaderID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.run.started", CreatedAt: createdAt.Add(-time.Second)},
 	}
 	first, err := handler.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Limit: 1,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, Limit: 1,
 	}))
 	if err != nil || len(first.Msg.GetEvents()) != 1 || first.Msg.GetEvents()[0].GetAgentName() != store.scheduler.AgentName ||
 		first.Msg.GetEvents()[0].GetSchedulerId() != store.scheduler.SchedulerID || first.Msg.GetEvents()[0].GetLinkedSandboxId() != "sandbox-1" || first.Msg.GetNextCursor() == "" {
 		t.Fatalf("first event page=%#v err=%v", first, err)
 	}
 	second, err := handler.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, Limit: 1, Cursor: first.Msg.GetNextCursor(),
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, Limit: 1, Cursor: first.Msg.GetNextCursor(),
 	}))
 	if err != nil || len(second.Msg.GetEvents()) != 1 || second.Msg.GetEvents()[0].GetId() != "event-1" || second.Msg.GetNextCursor() != "" {
 		t.Fatalf("second event page=%#v err=%v", second, err)

--- a/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
@@ -25,7 +25,7 @@ func TestStreamSchedulerRunsBatchesAndCompletes(t *testing.T) {
 	client, closeServer := schedulerStreamTestClient(t, handler)
 	defer closeServer()
 	stream, err := client.StreamSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, BatchSize: 1, Limit: 2,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, BatchSize: 1, Limit: 2,
 	}))
 	if err != nil {
 		t.Fatalf("StreamSchedulerRuns returned error: %v", err)
@@ -55,7 +55,7 @@ func TestStreamProjectSchedulerEventsTailsInDisplayOrder(t *testing.T) {
 	client, closeServer := schedulerStreamTestClient(t, handler)
 	defer closeServer()
 	stream, err := client.StreamProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: store.project.ID}, BatchSize: 1, Tail: 2,
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, BatchSize: 1, Tail: 2,
 	}))
 	if err != nil {
 		t.Fatalf("StreamProjectSchedulerEvents returned error: %v", err)

--- a/pkg/agentcompose/app/controller_helpers_coverage_test.go
+++ b/pkg/agentcompose/app/controller_helpers_coverage_test.go
@@ -47,8 +47,14 @@ func TestAppProjectControllerHelperCoverage(t *testing.T) {
 	if normalizedSpecToProto(nil) != nil {
 		t.Fatalf("normalizedSpecToProto nil returned non-nil")
 	}
-	if ref := projectRefFromProto(&agentcomposev2.ProjectRef{ProjectId: "project-1", Name: "Project", SourcePath: "/repo"}); ref.ProjectID != "project-1" || ref.Name != "Project" || ref.SourcePath != "/repo" {
-		t.Fatalf("projectRefFromProto = %#v", ref)
+	for _, ref := range []*agentcomposev2.ProjectRef{
+		{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: "project-1"}},
+		{Selector: &agentcomposev2.ProjectRef_Name{Name: "Project"}},
+		{Selector: &agentcomposev2.ProjectRef_SourcePath{SourcePath: "/repo"}},
+	} {
+		if got := projectRefFromProto(ref); got == (projects.ProjectRef{}) {
+			t.Fatalf("projectRefFromProto(%T) returned empty ref", ref.GetSelector())
+		}
 	}
 	if ref := projectRefFromProto(nil); ref != (projects.ProjectRef{}) {
 		t.Fatalf("projectRefFromProto nil = %#v", ref)

--- a/pkg/agentcompose/app/project_controller.go
+++ b/pkg/agentcompose/app/project_controller.go
@@ -225,10 +225,15 @@ func projectRefFromProto(ref *agentcomposev2.ProjectRef) projects.ProjectRef {
 	if ref == nil {
 		return projects.ProjectRef{}
 	}
-	return projects.ProjectRef{
-		ProjectID:  ref.GetProjectId(),
-		Name:       ref.GetName(),
-		SourcePath: ref.GetSourcePath(),
+	switch selector := ref.GetSelector().(type) {
+	case *agentcomposev2.ProjectRef_ProjectId:
+		return projects.ProjectRefByID(selector.ProjectId)
+	case *agentcomposev2.ProjectRef_Name:
+		return projects.ProjectRefByName(selector.Name)
+	case *agentcomposev2.ProjectRef_SourcePath:
+		return projects.ProjectRefBySourcePath(selector.SourcePath)
+	default:
+		return projects.ProjectRef{}
 	}
 }
 

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -59,12 +59,6 @@ type NormalizedProject struct {
 	managedLoaderOverrides map[string]legacyManagedLoaderOverride
 }
 
-type ProjectRef struct {
-	ProjectID  string
-	Name       string
-	SourcePath string
-}
-
 type ControllerStore interface {
 	GetProject(context.Context, string) (domain.ProjectRecord, error)
 	GetProjectIfExists(context.Context, string, bool) (domain.ProjectRecord, bool, error)
@@ -447,58 +441,36 @@ func (c *Controller) resolveProjectRef(ctx context.Context, ref ProjectRef, incl
 	if c.store == nil {
 		return domain.ProjectRecord{}, fmt.Errorf("config store is required")
 	}
-	if projectID := strings.TrimSpace(ref.ProjectID); projectID != "" {
-		if includeRemoved {
-			project, found, err := c.store.GetProjectIfExists(ctx, projectID, true)
-			if err != nil {
-				return domain.ProjectRecord{}, err
-			}
-			if found {
-				return project, nil
-			}
-			return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", projectID, fmt.Sprintf("project %s not found", projectID), sql.ErrNoRows)
-		}
-		return c.store.GetProject(ctx, projectID)
+	if !includeRemoved {
+		return ResolveProjectRef(ctx, c.store, ref)
 	}
-	name := strings.TrimSpace(ref.Name)
-	sourcePath := strings.TrimSpace(ref.SourcePath)
-	if name != "" && sourcePath != "" {
-		projectID, err := domain.StableProjectID(name, sourcePath)
+	value := strings.TrimSpace(ref.value)
+	if value == "" {
+		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project selector is required", nil)
+	}
+	if ref.kind == projectRefID {
+		project, found, err := c.store.GetProjectIfExists(ctx, value, true)
 		if err != nil {
 			return domain.ProjectRecord{}, err
 		}
-		if includeRemoved {
-			project, found, err := c.store.GetProjectIfExists(ctx, projectID, true)
-			if err != nil {
-				return domain.ProjectRecord{}, err
-			}
-			if found {
-				return project, nil
-			}
-			return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", projectID, fmt.Sprintf("project %s not found", projectID), sql.ErrNoRows)
+		if found {
+			return project, nil
 		}
-		return c.store.GetProject(ctx, projectID)
+		return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", value, fmt.Sprintf("project %s not found", value), sql.ErrNoRows)
 	}
-	if name == "" {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project id or name is required", nil)
-	}
-	result, err := c.store.ListProjects(ctx, domain.ProjectListOptions{Query: name, IncludeRemoved: includeRemoved, Limit: 200})
-	if err != nil {
-		return domain.ProjectRecord{}, err
-	}
-	var matches []domain.ProjectRecord
-	for _, project := range result.Projects {
-		if project.Name == name {
-			matches = append(matches, project)
+	query := value
+	projectValue := func(project domain.ProjectRecord) string { return project.Name }
+	selectorName := "name"
+	if ref.kind == projectRefSourcePath {
+		query = domain.NormalizeProjectSourcePath(value)
+		projectValue = func(project domain.ProjectRecord) string {
+			return domain.NormalizeProjectSourcePath(project.SourcePath)
 		}
+		selectorName = "source path"
+	} else if ref.kind != projectRefName {
+		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project selector is required", nil)
 	}
-	if len(matches) == 0 {
-		return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", name, fmt.Sprintf("project %s not found", name), sql.ErrNoRows)
-	}
-	if len(matches) > 1 {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrAmbiguous, fmt.Sprintf("project name %s is ambiguous; use project_id or source_path", name), nil)
-	}
-	return matches[0], nil
+	return resolveProjectByExactMatch(ctx, c.store, query, true, selectorName, projectValue)
 }
 
 func (c *Controller) projectArtifacts(ctx context.Context, project domain.ProjectRecord, revision int64, normalized NormalizedProject) ([]domain.ProjectAgentRecord, []domain.AgentDefinition, []domain.ProjectSchedulerRecord, []domain.Loader, error) {

--- a/pkg/projects/controller_coverage_test.go
+++ b/pkg/projects/controller_coverage_test.go
@@ -85,11 +85,11 @@ agents:
 	if missingSpec, err := controller.ValidateProject(ctx, NormalizedProject{}, nil); err != nil || missingSpec.Valid {
 		t.Fatalf("ValidateProject missing spec=%#v err=%v", missingSpec, err)
 	}
-	if _, err := controller.ResolveProjectRef(ctx, ProjectRef{Name: "coverage-project"}); !errors.Is(err, domain.ErrAmbiguous) {
+	if _, err := controller.ResolveProjectRef(ctx, ProjectRefByName("coverage-project")); !errors.Is(err, domain.ErrAmbiguous) {
 		t.Fatalf("expected ambiguous project error, got %v", err)
 	}
 	store.projects = []domain.ProjectRecord{{ID: "project-1", Name: "coverage-project", SourcePath: "/repo"}}
-	resolved, err := controller.ResolveProjectRef(ctx, ProjectRef{Name: "coverage-project"})
+	resolved, err := controller.ResolveProjectRef(ctx, ProjectRefByName("coverage-project"))
 	if err != nil || resolved.ID != "project-1" {
 		t.Fatalf("ResolveProjectRef resolved=%#v err=%v", resolved, err)
 	}
@@ -109,7 +109,7 @@ func TestControllerRemoveProjectMarksProjectRemovedAndIsIdempotent(t *testing.T)
 		Sandboxes: controllerCoverageSessionStore{},
 		Volumes:   volumeManager,
 	})
-	removed, err := controller.RemoveProject(ctx, RemoveRequest{Project: ProjectRef{ProjectID: "project-1"}})
+	removed, err := controller.RemoveProject(ctx, RemoveRequest{Project: ProjectRefByID("project-1")})
 	if err != nil {
 		t.Fatalf("RemoveProject returned error: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestControllerRemoveProjectMarksProjectRemovedAndIsIdempotent(t *testing.T)
 		t.Fatalf("RemoveProject volume cleanup = %#v", volumeManager.removedProjects)
 	}
 
-	repeated, err := controller.RemoveProject(ctx, RemoveRequest{Project: ProjectRef{ProjectID: "project-1"}})
+	repeated, err := controller.RemoveProject(ctx, RemoveRequest{Project: ProjectRefByID("project-1")})
 	if err != nil {
 		t.Fatalf("repeated RemoveProject returned error: %v", err)
 	}

--- a/pkg/projects/legacy_default_project_integration_test.go
+++ b/pkg/projects/legacy_default_project_integration_test.go
@@ -160,7 +160,7 @@ scheduler.on("news.ready", "on-news", function onNews() {});
 	if err != nil {
 		t.Fatalf("load legacy project: %v", err)
 	}
-	resolved, err := controller.ResolveProjectRef(ctx, projects.ProjectRef{Name: result.Project.Name, SourcePath: result.Project.SourcePath})
+	resolved, err := controller.ResolveProjectRef(ctx, projects.ProjectRefByName(result.Project.Name))
 	if err != nil || resolved.ID != project.ID {
 		t.Fatalf("resolve returned legacy project ref = %#v, err = %v", resolved, err)
 	}

--- a/pkg/projects/project_ref.go
+++ b/pkg/projects/project_ref.go
@@ -1,0 +1,105 @@
+package projects
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+// ProjectRef identifies a project through exactly one stable selector.
+type ProjectRef struct {
+	kind  projectRefKind
+	value string
+}
+
+type projectRefKind uint8
+
+const (
+	projectRefUnset projectRefKind = iota
+	projectRefID
+	projectRefName
+	projectRefSourcePath
+)
+
+// ProjectRefByID selects a project by its stable ID.
+func ProjectRefByID(projectID string) ProjectRef {
+	return ProjectRef{kind: projectRefID, value: projectID}
+}
+
+// ProjectRefByName selects a project by its exact name.
+func ProjectRefByName(name string) ProjectRef {
+	return ProjectRef{kind: projectRefName, value: name}
+}
+
+// ProjectRefBySourcePath selects a project by its normalized source path.
+func ProjectRefBySourcePath(sourcePath string) ProjectRef {
+	return ProjectRef{kind: projectRefSourcePath, value: sourcePath}
+}
+
+// ProjectRefStore provides the project lookups required to resolve a reference.
+type ProjectRefStore interface {
+	GetProject(context.Context, string) (domain.ProjectRecord, error)
+	ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error)
+}
+
+// ResolveProjectRef resolves one project selector against active projects.
+func ResolveProjectRef(ctx context.Context, store ProjectRefStore, ref ProjectRef) (domain.ProjectRecord, error) {
+	if store == nil {
+		return domain.ProjectRecord{}, fmt.Errorf("project store is required")
+	}
+	value := strings.TrimSpace(ref.value)
+	if value == "" {
+		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project selector is required", nil)
+	}
+	switch ref.kind {
+	case projectRefID:
+		return store.GetProject(ctx, value)
+	case projectRefName:
+		return resolveProjectByExactMatch(ctx, store, value, false, "name", func(project domain.ProjectRecord) string {
+			return project.Name
+		})
+	case projectRefSourcePath:
+		value = domain.NormalizeProjectSourcePath(value)
+		return resolveProjectByExactMatch(ctx, store, value, false, "source path", func(project domain.ProjectRecord) string {
+			return domain.NormalizeProjectSourcePath(project.SourcePath)
+		})
+	default:
+		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project selector is required", nil)
+	}
+}
+
+func resolveProjectByExactMatch(
+	ctx context.Context,
+	store ProjectRefStore,
+	value string,
+	includeRemoved bool,
+	selectorName string,
+	projectValue func(domain.ProjectRecord) string,
+) (domain.ProjectRecord, error) {
+	const pageSize = 200
+	var matches []domain.ProjectRecord
+	for offset := 0; ; offset += pageSize {
+		result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: value, IncludeRemoved: includeRemoved, Offset: offset, Limit: pageSize})
+		if err != nil {
+			return domain.ProjectRecord{}, err
+		}
+		for _, project := range result.Projects {
+			if projectValue(project) == value {
+				matches = append(matches, project)
+			}
+		}
+		if !result.HasMore {
+			break
+		}
+	}
+	if len(matches) == 0 {
+		return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", value, fmt.Sprintf("project with %s %s not found", selectorName, value), sql.ErrNoRows)
+	}
+	if len(matches) > 1 {
+		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrAmbiguous, fmt.Sprintf("project %s %s is ambiguous; use project_id", selectorName, value), nil)
+	}
+	return matches[0], nil
+}

--- a/pkg/projects/project_ref_test.go
+++ b/pkg/projects/project_ref_test.go
@@ -1,0 +1,94 @@
+package projects
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestResolveProjectRefSelectors(t *testing.T) {
+	t.Parallel()
+	sourcePath := filepath.Join(t.TempDir(), "agent-compose.yml")
+	store := projectRefStoreFake{projects: []domain.ProjectRecord{
+		{ID: "project-1", Name: "alpha", SourcePath: sourcePath},
+		{ID: "project-2", Name: "alphabet", SourcePath: "/projects/other.yml"},
+	}}
+
+	tests := []struct {
+		name string
+		ref  ProjectRef
+	}{
+		{name: "project id", ref: ProjectRefByID(" project-1 ")},
+		{name: "exact name", ref: ProjectRefByName(" alpha ")},
+		{name: "normalized source path", ref: ProjectRefBySourcePath(filepath.Join(filepath.Dir(sourcePath), ".", filepath.Base(sourcePath)))},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			project, err := ResolveProjectRef(context.Background(), store, test.ref)
+			if err != nil || project.ID != "project-1" {
+				t.Fatalf("ResolveProjectRef() = %#v, %v; want project-1", project, err)
+			}
+		})
+	}
+}
+
+func TestResolveProjectRefRejectsEmptySelectors(t *testing.T) {
+	t.Parallel()
+	store := projectRefStoreFake{}
+	for _, ref := range []ProjectRef{
+		{},
+		ProjectRefByID(" "),
+		ProjectRefByName(" "),
+		ProjectRefBySourcePath(" "),
+	} {
+		if _, err := ResolveProjectRef(context.Background(), store, ref); !errors.Is(err, domain.ErrRequired) {
+			t.Fatalf("ResolveProjectRef(%#v) error = %v, want ErrRequired", ref, err)
+		}
+	}
+}
+
+func TestResolveProjectRefRejectsAmbiguousSelectors(t *testing.T) {
+	t.Parallel()
+	store := projectRefStoreFake{projects: []domain.ProjectRecord{
+		{ID: "project-1", Name: "duplicate", SourcePath: "/projects/shared.yml"},
+		{ID: "project-2", Name: "duplicate", SourcePath: "/projects/shared.yml"},
+	}}
+	for _, ref := range []ProjectRef{
+		ProjectRefByName("duplicate"),
+		ProjectRefBySourcePath("/projects/shared.yml"),
+	} {
+		if _, err := ResolveProjectRef(context.Background(), store, ref); !errors.Is(err, domain.ErrAmbiguous) {
+			t.Fatalf("ResolveProjectRef(%#v) error = %v, want ErrAmbiguous", ref, err)
+		}
+	}
+}
+
+type projectRefStoreFake struct {
+	projects []domain.ProjectRecord
+}
+
+func (s projectRefStoreFake) GetProject(_ context.Context, projectID string) (domain.ProjectRecord, error) {
+	for _, project := range s.projects {
+		if project.ID == projectID {
+			return project, nil
+		}
+	}
+	return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", projectID, "", nil)
+}
+
+func (s projectRefStoreFake) ListProjects(_ context.Context, options domain.ProjectListOptions) (domain.ProjectListResult, error) {
+	query := strings.ToLower(strings.TrimSpace(options.Query))
+	var matches []domain.ProjectRecord
+	for _, project := range s.projects {
+		if query == "" || RecordMatchesQuery(project, query) {
+			matches = append(matches, project)
+		}
+	}
+	start := min(options.Offset, len(matches))
+	end := min(start+options.Limit, len(matches))
+	return domain.ProjectListResult{Projects: matches[start:end], HasMore: end < len(matches)}, nil
+}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -2026,10 +2026,15 @@ func (x *WatchProjectResponse) GetChanges() []*ProjectChange {
 }
 
 type ProjectRef struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ProjectId     string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	SourcePath    string                 `protobuf:"bytes,3,opt,name=source_path,json=sourcePath,proto3" json:"source_path,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Select exactly one stable project identifier.
+	//
+	// Types that are valid to be assigned to Selector:
+	//
+	//	*ProjectRef_ProjectId
+	//	*ProjectRef_Name
+	//	*ProjectRef_SourcePath
+	Selector      isProjectRef_Selector `protobuf_oneof:"selector"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2064,26 +2069,61 @@ func (*ProjectRef) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{12}
 }
 
+func (x *ProjectRef) GetSelector() isProjectRef_Selector {
+	if x != nil {
+		return x.Selector
+	}
+	return nil
+}
+
 func (x *ProjectRef) GetProjectId() string {
 	if x != nil {
-		return x.ProjectId
+		if x, ok := x.Selector.(*ProjectRef_ProjectId); ok {
+			return x.ProjectId
+		}
 	}
 	return ""
 }
 
 func (x *ProjectRef) GetName() string {
 	if x != nil {
-		return x.Name
+		if x, ok := x.Selector.(*ProjectRef_Name); ok {
+			return x.Name
+		}
 	}
 	return ""
 }
 
 func (x *ProjectRef) GetSourcePath() string {
 	if x != nil {
-		return x.SourcePath
+		if x, ok := x.Selector.(*ProjectRef_SourcePath); ok {
+			return x.SourcePath
+		}
 	}
 	return ""
 }
+
+type isProjectRef_Selector interface {
+	isProjectRef_Selector()
+}
+
+type ProjectRef_ProjectId struct {
+	ProjectId string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3,oneof"`
+}
+
+type ProjectRef_Name struct {
+	Name string `protobuf:"bytes,2,opt,name=name,proto3,oneof"`
+}
+
+type ProjectRef_SourcePath struct {
+	SourcePath string `protobuf:"bytes,3,opt,name=source_path,json=sourcePath,proto3,oneof"`
+}
+
+func (*ProjectRef_ProjectId) isProjectRef_Selector() {}
+
+func (*ProjectRef_Name) isProjectRef_Selector() {}
+
+func (*ProjectRef_SourcePath) isProjectRef_Selector() {}
 
 type ProjectSource struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -17694,14 +17734,16 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x04type\x18\x01 \x01(\x0e2&.agentcompose.v2.ProjectWatchEventTypeR\x04type\x122\n" +
 	"\aproject\x18\x02 \x01(\v2\x18.agentcompose.v2.ProjectR\aproject\x12<\n" +
 	"\brevision\x18\x03 \x01(\v2 .agentcompose.v2.ProjectRevisionR\brevision\x128\n" +
-	"\achanges\x18\x04 \x03(\v2\x1e.agentcompose.v2.ProjectChangeR\achanges\"`\n" +
+	"\achanges\x18\x04 \x03(\v2\x1e.agentcompose.v2.ProjectChangeR\achanges\"r\n" +
 	"\n" +
-	"ProjectRef\x12\x1d\n" +
+	"ProjectRef\x12\x1f\n" +
 	"\n" +
-	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1f\n" +
-	"\vsource_path\x18\x03 \x01(\tR\n" +
-	"sourcePath\"S\n" +
+	"project_id\x18\x01 \x01(\tH\x00R\tprojectId\x12\x14\n" +
+	"\x04name\x18\x02 \x01(\tH\x00R\x04name\x12!\n" +
+	"\vsource_path\x18\x03 \x01(\tH\x00R\n" +
+	"sourcePathB\n" +
+	"\n" +
+	"\bselector\"S\n" +
 	"\rProjectSource\x12!\n" +
 	"\fcompose_path\x18\x01 \x01(\tR\vcomposePath\x12\x1f\n" +
 	"\vproject_dir\x18\x02 \x01(\tR\n" +
@@ -20101,6 +20143,11 @@ func init() { file_agentcompose_v2_agentcompose_proto_init() }
 func file_agentcompose_v2_agentcompose_proto_init() {
 	if File_agentcompose_v2_agentcompose_proto != nil {
 		return
+	}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[12].OneofWrappers = []any{
+		(*ProjectRef_ProjectId)(nil),
+		(*ProjectRef_Name)(nil),
+		(*ProjectRef_SourcePath)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[57].OneofWrappers = []any{}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[64].OneofWrappers = []any{}

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -373,9 +373,12 @@ message WatchProjectResponse {
 }
 
 message ProjectRef {
-  string project_id = 1;
-  string name = 2;
-  string source_path = 3;
+  // Select exactly one stable project identifier.
+  oneof selector {
+    string project_id = 1;
+    string name = 2;
+    string source_path = 3;
+  }
 }
 
 message ProjectSource {

--- a/proto/agentcompose/v2/project_ref_contract_test.go
+++ b/proto/agentcompose/v2/project_ref_contract_test.go
@@ -1,0 +1,23 @@
+package agentcomposev2
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestProjectRefSelectorsShareOneof(t *testing.T) {
+	t.Parallel()
+	descriptor := (&ProjectRef{}).ProtoReflect().Descriptor()
+	oneofs := descriptor.Oneofs()
+	if oneofs.Len() != 1 || string(oneofs.Get(0).Name()) != "selector" {
+		t.Fatalf("ProjectRef oneofs = %v, want selector", oneofs.Len())
+	}
+	selector := oneofs.Get(0)
+	for _, fieldName := range []string{"project_id", "name", "source_path"} {
+		field := descriptor.Fields().ByName(protoreflect.Name(fieldName))
+		if field == nil || field.ContainingOneof() != selector {
+			t.Fatalf("ProjectRef.%s is not part of selector", fieldName)
+		}
+	}
+}

--- a/test/e2e/docker_workspace_resume_host_daemon_test.go
+++ b/test/e2e/docker_workspace_resume_host_daemon_test.go
@@ -173,7 +173,7 @@ func TestE2EDockerFileWorkspaceResumePreservesState(t *testing.T) {
 	sandboxClient = agentcomposev2connect.NewSandboxServiceClient(httpClient2, baseURL2)
 
 	getProjectResp, err := projectClient.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
-		Project:     &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project:     &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 		IncludeSpec: true,
 	}))
 	if err != nil || getProjectResp.Msg.GetProject().GetSummary().GetProjectId() != projectID {
@@ -227,7 +227,7 @@ func TestE2EDockerFileWorkspaceResumePreservesState(t *testing.T) {
 	assertE2EDockerSandboxContainerCount(t, ctx, dockerClient, sandboxAID, 0)
 
 	if _, err := projectClient.RemoveProject(ctx, connect.NewRequest(&agentcomposev2.RemoveProjectRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 	})); err != nil {
 		t.Fatalf("RemoveProject returned error: %v", err)
 	}

--- a/test/e2e/legacy_loader_env_host_daemon_test.go
+++ b/test/e2e/legacy_loader_env_host_daemon_test.go
@@ -426,7 +426,7 @@ func runLegacyEnvPriorityE2E(
 ) {
 	t.Helper()
 	response, err := projectClient.RunScheduler(ctx, connect.NewRequest(&agentcomposev2.RunSchedulerRequest{
-		Project:     &agentcomposev2.ProjectRef{ProjectId: project.GetSummary().GetProjectId()},
+		Project:     &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: project.GetSummary().GetProjectId()}},
 		AgentName:   project.GetAgents()[0].GetAgentName(),
 		TriggerId:   "legacy-env-e2e",
 		PayloadJson: `{}`,
@@ -491,7 +491,7 @@ func linkedE2ESandboxID(
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		response, err := projectClient.ListProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
-			Project:   &agentcomposev2.ProjectRef{ProjectId: project.GetSummary().GetProjectId()},
+			Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: project.GetSummary().GetProjectId()}},
 			AgentName: project.GetAgents()[0].GetAgentName(),
 			RunId:     runID,
 			Limit:     100,
@@ -527,7 +527,7 @@ func getE2EProject(
 ) *agentcomposev2.Project {
 	t.Helper()
 	response, err := client.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
-		Project:     &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project:     &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 		IncludeSpec: true,
 	}))
 	if err != nil {

--- a/test/e2e/retention_host_daemon_test.go
+++ b/test/e2e/retention_host_daemon_test.go
@@ -95,7 +95,7 @@ func TestE2EDockerDaemonRetentionCleanup(t *testing.T) {
 	removeE2EDockerSandboxFallback(t, ctx, dockerClient, sandboxID)
 	assertE2EDockerSandboxContainerCount(t, ctx, dockerClient, sandboxID, 0)
 	if _, err := projectClient.RemoveProject(ctx, connect.NewRequest(&agentcomposev2.RemoveProjectRequest{
-		Project: &agentcomposev2.ProjectRef{ProjectId: projectID},
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
 	})); err != nil {
 		t.Fatalf("RemoveProject returned error: %v", err)
 	}


### PR DESCRIPTION
  ## Summary

  - Change `ProjectRef` to use a protobuf `oneof`, making `project_id`, `name`, and `source_path` mutually exclusive selectors.
  - Centralize project reference resolution across Project and Exec handlers.
  - Support exact project lookup by normalized source path.
  - Consistently reject missing selectors, empty selector values, and ambiguous name or source-path matches.
  - Regenerate protobuf sources and update all CLI, API, integration, and E2E call sites.
  - Add protobuf contract and resolver regression tests.

  Closes #403.

  ## Testing

  - `task generate:proto`
  - `go test ./proto/agentcompose/v2 ./pkg/projects ./pkg/agentcompose/api ./pkg/agentcompose/app ./cmd/agent-compose`
  - `task lint`
  - `task build`
  - `task test`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.