### PR TITLE
fix(ci): rerun protobuf gate after approval

### DIFF
--- a/.github/workflows/proto-compatibility-review.yml
+++ b/.github/workflows/proto-compatibility-review.yml
@@ -1,0 +1,38 @@
+name: Refresh Protobuf compatibility approval
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+# Share the required workflow's group so a review submitted while Buf is still
+# running waits for that run to finish before requesting a new attempt.
+concurrency:
+  group: proto-compatibility-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  refresh-proto-breaking-approval:
+    name: Refresh Protobuf compatibility approval
+    if: github.event.action == 'dismissed' || github.event.review.state == 'approved' || github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun compatibility check for current commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          run_id=$(gh api \
+            "repos/$GH_REPO/actions/workflows/proto-compatibility.yml/runs?event=pull_request&head_sha=$PR_HEAD_SHA&per_page=20" \
+            --jq '.workflow_runs | sort_by(.created_at) | last | .id // empty')
+          if [[ -z $run_id ]]; then
+            echo "no Protobuf compatibility run found for PR #$PR_NUMBER at $PR_HEAD_SHA" >&2
+            exit 1
+          fi
+          gh api --method POST "repos/$GH_REPO/actions/runs/$run_id/rerun"

--- a/.github/workflows/proto-compatibility.yml
+++ b/.github/workflows/proto-compatibility.yml
@@ -2,9 +2,7 @@ name: Protobuf compatibility
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-  pull_request_review:
-    types: [submitted, dismissed]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -12,7 +10,9 @@ permissions:
 
 concurrency:
   group: proto-compatibility-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Review refreshes share this group and must wait for the initial Buf run.
+  # Keeping the running attempt alive also lets the refresh workflow rerun it.
+  cancel-in-progress: false
 
 jobs:
   proto-breaking:
@@ -55,10 +55,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          REQUIRED_LABEL: protobuf-breaking-approved
         run: |
-          label_present=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER" \
-            --jq '[.labels[].name] | index(env.REQUIRED_LABEL) != null')
           reviews=$(gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/reviews?per_page=100")
           approved_reviewers=$(jq -r --arg head "$PR_HEAD_SHA" '
             [.[][] | select(
@@ -81,7 +78,7 @@ jobs:
             fi
           done <<<"$approved_reviewers"
 
-          if [[ $label_present == true && -n $approving_maintainer ]]; then
+          if [[ -n $approving_maintainer ]]; then
             printf 'Breaking Protobuf change approved by maintainer @%s for commit %s.\n' \
               "$approving_maintainer" "$PR_HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -90,7 +87,6 @@ jobs:
           {
             echo '### Breaking Protobuf change requires approval'
             echo
-            echo "- Required label \`$REQUIRED_LABEL\`: \`$label_present\`"
-            echo "- Maintainer approval for current commit: \`$([[ -n $approving_maintainer ]] && echo true || echo false)\`"
+            echo 'A maintainer must approve the current PR commit. The compatibility check will rerun automatically after review.'
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1

--- a/scripts/tests/test-proto-breaking-ci-contract.sh
+++ b/scripts/tests/test-proto-breaking-ci-contract.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
 PROTO_WORKFLOW="$ROOT_DIR/.github/workflows/proto-compatibility.yml"
+APPROVAL_WORKFLOW="$ROOT_DIR/.github/workflows/proto-compatibility-review.yml"
 
 job=$(awk '
   $0 == "  proto-breaking:" {
@@ -29,6 +30,7 @@ require() {
 }
 
 workflow=$(<"$PROTO_WORKFLOW")
+approval_workflow=$(<"$APPROVAL_WORKFLOW")
 
 require_workflow() {
   if ! grep -Eq -- "$1" <<<"$workflow"; then
@@ -37,18 +39,42 @@ require_workflow() {
   fi
 }
 
-require_workflow 'pull_request_review:' 'pull request review trigger'
-require_workflow 'types: \[submitted, dismissed\]' 'review submission and dismissal triggers'
-require_workflow 'types: \[opened, synchronize, reopened, labeled, unlabeled\]' 'PR and label triggers'
+require_workflow 'types: \[opened, synchronize, reopened\]' 'PR revision triggers'
 require_workflow 'pull-requests:[[:space:]]*read' 'pull request read permission'
+require_workflow 'cancel-in-progress:[[:space:]]*false' 'review-safe compatibility concurrency'
 require 'fetch-depth:[[:space:]]*0' 'complete Git history checkout'
 require 'ref: refs/pull/\$\{\{ github\.event\.pull_request\.number \}\}/merge' 'PR merge revision checkout'
 require 'buf@v1\.68\.1' 'pinned Buf version'
 require 'PROTO_BASE: \.git#ref=\$\{\{ github\.event\.pull_request\.base\.sha \}\}' 'exact PR base revision'
 require 'buf breaking --against "\$PROTO_BASE" --error-format=github-actions' 'Buf breaking check with PR annotations'
 require 'steps\.breaking\.outputs\.exit-code == '\''100'\''' 'breaking violation approval path'
-require 'REQUIRED_LABEL: protobuf-breaking-approved' 'breaking approval label'
 require 'select\(\.state == "APPROVED" and \.commit_id == \$head\)' 'approval for current PR commit'
 require 'collaborators/\$reviewer/permission' 'reviewer repository permission lookup'
 require 'permissions\.maintain == true' 'maintain permission requirement'
 require 'permissions\.admin == true' 'admin permission requirement'
+
+require_approval_workflow() {
+  if ! grep -Eq -- "$1" <<<"$approval_workflow"; then
+    printf 'test-proto-breaking-ci-contract: approval workflow missing %s\n' "$2" >&2
+    exit 1
+  fi
+}
+
+if grep -Eq 'pull_request_review:|labeled|unlabeled|protobuf-breaking-approved' <<<"$workflow"; then
+  echo 'test-proto-breaking-ci-contract: required workflow must not create checks for review or label events' >&2
+  exit 1
+fi
+
+require_approval_workflow 'pull_request_review:' 'pull request review trigger'
+require_approval_workflow 'types: \[submitted, dismissed\]' 'review submission and dismissal triggers'
+require_approval_workflow "review.state == 'approved'.*review.state == 'changes_requested'" 'approval-changing review filter'
+require_approval_workflow 'actions:[[:space:]]*write' 'Actions rerun permission'
+require_approval_workflow 'group: proto-compatibility-\$\{\{ github\.event\.pull_request\.number \}\}' 'shared compatibility concurrency group'
+require_approval_workflow 'head_sha=\$PR_HEAD_SHA' 'current PR commit run lookup'
+require_approval_workflow '\.workflow_runs \| sort_by\(\.created_at\) \| last \| \.id' 'latest workflow run selection'
+require_approval_workflow 'actions/runs/\$run_id/rerun' 'original compatibility run retry'
+
+if grep -Eq 'actions/checkout|buf breaking' <<<"$approval_workflow"; then
+  echo 'test-proto-breaking-ci-contract: approval workflow must not checkout or execute PR code' >&2
+  exit 1
+fi


### PR DESCRIPTION
  ## Summary

  - Separate Protobuf compatibility checks from review events so different event types no longer create conflicting required checks.
  - Remove the redundant `protobuf-breaking-approved` label requirement. A maintainer approval for the current PR head commit is now sufficient.
  - Add a review listener that automatically reruns the original Protobuf compatibility workflow after an approval, change request, or review dismissal.
  - Share a concurrency group between the compatibility and review workflows so early reviews wait for the initial Buf check to finish.
  - Keep the review listener isolated from PR code: it does not checkout or execute PR contents and only requests an Actions rerun.
  - Update the CI contract test to enforce the new approval flow and permission boundary.

  The resulting flow is:

  1. Push a PR containing a breaking Protobuf change.
  2. The compatibility check reports that maintainer approval is required.
  3. A maintainer approves the current head commit.
  4. The original required check is rerun automatically and passes.
  5. A new push invalidates the previous approval because the head SHA changes.

  ## Testing

  - `ruby -e 'require "yaml"; ARGV.each { |path| YAML.parse_file(path) }' .github/workflows/proto-compatibility.yml .github/workflows/proto-compatibility-
  review.yml`
  - `./scripts/tests/test-proto-breaking-ci-contract.sh`
  - `task test:scripts`
  - `task lint`
  - Verified the workflow-run lookup against the GitHub Actions API using an existing Protobuf compatibility run.
  - `task test` was run after `task prepare`, but did not complete successfully because existing `SandboxRPCBridge` tests require
  `AGENT_COMPOSE_RUNTIME_BASE_URL` in the local environment. The workflow contract, deployment checks, and unrelated packages completed before that
  environment-dependent failure.

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.