### PR TITLE
refactor(scheduler)!: rename loader event types

### DIFF
--- a/cmd/agent-compose/cli_scheduler_prune_e2e_test.go
+++ b/cmd/agent-compose/cli_scheduler_prune_e2e_test.go
@@ -123,7 +123,7 @@ func (f *schedulerPruneE2EFixture) seedHistory(t *testing.T, dataRoot string) {
 	}
 	if err := f.store.AddSchedulerEvent(ctx, domain.SchedulerEvent{
 		ID: "loader-event-scheduler-prune-e2e", SchedulerID: f.scheduler.ID, RunID: f.runID, TriggerID: f.triggerID,
-		Type: "loader.run.completed", Level: "info", Message: "scheduler prune e2e completed", CreatedAt: completedAt,
+		Type: "scheduler.run.completed", Level: "info", Message: "scheduler prune e2e completed", CreatedAt: completedAt,
 	}); err != nil {
 		t.Fatalf("add loader event: %v", err)
 	}

--- a/cmd/agent-compose/cli_scheduler_stream_test.go
+++ b/cmd/agent-compose/cli_scheduler_stream_test.go
@@ -49,7 +49,7 @@ agents:
 			args:   []string{"scheduler", "logs"},
 			marker: "first-stream-event",
 			stub: projectServiceStub{streamSchedulerEvents: func(ctx context.Context, _ *connect.Request[agentcomposev2.StreamProjectSchedulerEventsRequest], stream *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]) error {
-				if err := stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Events: []*agentcomposev2.SchedulerEvent{{Id: "event-first", AgentName: "reviewer", TriggerId: "nightly", Type: "loader.log", Message: "first-stream-event"}}}); err != nil {
+				if err := stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Events: []*agentcomposev2.SchedulerEvent{{Id: "event-first", AgentName: "reviewer", TriggerId: "nightly", Type: "scheduler.log", Message: "first-stream-event"}}}); err != nil {
 					return err
 				}
 				<-ctx.Done()

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -467,8 +467,8 @@ agents:
 			},
 			listProjectSchedulerEvents: func(context.Context, *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {
 				return connect.NewResponse(&agentcomposev2.ListProjectSchedulerEventsResponse{Events: []*agentcomposev2.SchedulerEvent{
-					{Id: "event-2", RunId: runID, AgentName: "reviewer", TriggerId: "nightly", Type: "loader.agent.activity", Level: "info", Message: "done", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 2, 0, time.UTC))},
-					{Id: "event-1", RunId: runID, AgentName: "reviewer", TriggerId: "nightly", Type: "loader.status", Level: "info", Message: "started", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 0, 0, time.UTC))},
+					{Id: "event-2", RunId: runID, AgentName: "reviewer", TriggerId: "nightly", Type: "scheduler.agent.activity", Level: "info", Message: "done", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 2, 0, time.UTC))},
+					{Id: "event-1", RunId: runID, AgentName: "reviewer", TriggerId: "nightly", Type: "scheduler.status", Level: "info", Message: "started", CreatedAt: timestamppb.New(time.Date(2026, 7, 15, 1, 0, 0, 0, time.UTC))},
 				}}), nil
 			},
 		},

--- a/cmd/agent-compose/e2e_docker_scheduler_test.go
+++ b/cmd/agent-compose/e2e_docker_scheduler_test.go
@@ -295,11 +295,11 @@ func waitForScheduledHelloRun(t *testing.T, projectClient agentcomposev2connect.
 			continue
 		}
 		for _, event := range eventsResp.Msg.GetEvents() {
-			if event.GetType() == "loader.run.failed" {
+			if event.GetType() == "scheduler.run.failed" {
 				lastErr = fmt.Errorf("loader run %s failed: %s", event.GetRunId(), event.GetMessage())
 				continue
 			}
-			if event.GetRunId() != "" && event.GetType() == "loader.command.completed" && event.GetLevel() == "info" && strings.Contains(event.GetMessage(), helloText) {
+			if event.GetRunId() != "" && event.GetType() == "scheduler.command.completed" && event.GetLevel() == "info" && strings.Contains(event.GetMessage(), helloText) {
 				return event.GetRunId(), event
 			}
 		}

--- a/cmd/agent-compose/scheduler_runs_test.go
+++ b/cmd/agent-compose/scheduler_runs_test.go
@@ -61,8 +61,8 @@ agents:
 `)
 	var requests []*agentcomposev2.ListProjectSchedulerEventsRequest
 	events := []*agentcomposev2.SchedulerEvent{
-		{Id: "event-new", RunId: "run-new", AgentName: "reviewer", TriggerId: "trigger-new", Type: "loader.log", Level: "info", Message: "newest", CreatedAt: timestamppb.New(time.Unix(200, 0).UTC())},
-		{Id: "event-old", RunId: "run-old", AgentName: "reviewer", TriggerId: "trigger-old", Type: "loader.log", Level: "info", Message: "oldest", CreatedAt: timestamppb.New(time.Unix(100, 0).UTC())},
+		{Id: "event-new", RunId: "run-new", AgentName: "reviewer", TriggerId: "trigger-new", Type: "scheduler.log", Level: "info", Message: "newest", CreatedAt: timestamppb.New(time.Unix(200, 0).UTC())},
+		{Id: "event-old", RunId: "run-old", AgentName: "reviewer", TriggerId: "trigger-old", Type: "scheduler.log", Level: "info", Message: "oldest", CreatedAt: timestamppb.New(time.Unix(100, 0).UTC())},
 	}
 	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
 		listProjectSchedulerEvents: func(_ context.Context, req *connect.Request[agentcomposev2.ListProjectSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListProjectSchedulerEventsResponse], error) {

--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -469,7 +469,7 @@ LoaderHost.Command
   -> parseCommandExecResult
   -> preserve guest command-result.json; mirror stdout/stderr/output artifacts
   -> Store.AddCell(completed SHELL)
-  -> loader.command.completed / loader.command.failed
+  -> scheduler.command.completed / scheduler.command.failed
 ```
 
 After parsing succeeds, the guest runtime has already written
@@ -481,7 +481,7 @@ Artifact paths returned to the loader script are host-side paths.
 
 Multiple command/shell calls in the same loader run reuse the loader sandbox for
 that run. After the run ends, the host stops command sandboxes used by that run
-and records `loader.sandbox.stopped`. `scheduler.agent` sandbox stop behavior
+and records `scheduler.sandbox.stopped`. `scheduler.agent` sandbox stop behavior
 still follows the agent path.
 
 ## 8. Resume State Convention
@@ -700,11 +700,11 @@ Loader command error semantics:
 
 - When command/shell exit code is non-zero, `scheduler.exec` /
   `scheduler.shell` does not throw. It returns `success=false` and records an
-  error-level `loader.command.completed`.
+  error-level `scheduler.command.completed`.
 - Runtime driver exec failure, missing parseable command payload from
   `agent-compose-runtime exec`, timeout/context cancellation, or artifact write
   failure makes `scheduler.exec` / `scheduler.shell` throw and records
-  `loader.command.failed`.
+  `scheduler.command.failed`.
 - Command cells use the `SHELL` type. No new proto cell enum is introduced.
 
 ## 12. Guest Runtime SDK

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -862,9 +862,9 @@ other creation paths:
 5. Prepare managed capability, runtime, state, and home resources.
 6. Start runtime through the driver.
 7. Mark sandbox as `RUNNING`.
-8. Record sandbox-created state. Loader lifecycle events use
-   `loader.sandbox.*`; the historical `agent-compose.session.*` topic prefix is
-   retained only where the v1 compatibility event bus still emits it.
+8. Record sandbox-created state. Scheduler lifecycle events use
+   `scheduler.sandbox.*`; the historical `agent-compose.session.*` topic prefix
+   is retained only where the v1 compatibility event bus still emits it.
 
 `ResumeSession` is the v1-compatible resume method. It loads the same sandbox,
 runs the shared Provisioner, and starts its runtime; a `ready` workspace is left

--- a/pkg/agentcompose/adapters/scheduler_session_runner.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner.go
@@ -272,8 +272,8 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 	}
 	domain.RestoreSandboxTransientFields(loaded, session)
 	r.indexCapabilitySandbox(loaded)
-	// This topic payload and returned event type are historical external
-	// contracts; source, loaderId, and loader.sandbox.created stay unchanged.
+	// This topic payload is a historical external contract; source, loaderId,
+	// and the agent-compose.session.created topic stay unchanged.
 	r.publish("agent-compose.session.created", map[string]any{
 		"sandboxId":     loaded.Summary.ID,
 		"title":         loaded.Summary.Title,
@@ -282,7 +282,7 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 		"source":        "loader",
 		"loaderId":      scheduler.Summary.ID,
 	})
-	return loaded, "loader.sandbox.created", nil
+	return loaded, "scheduler.sandbox.created", nil
 }
 
 func (r *SchedulerSandboxRunner) Load(ctx context.Context, sessionID string) (*domain.Sandbox, error) {
@@ -351,7 +351,7 @@ func (r *SchedulerSandboxRunner) loadOrResumeLocked(ctx context.Context, session
 		"driver":    loaded.Summary.Driver,
 		"source":    "loader",
 	})
-	return loaded, "loader.sandbox.resumed", nil
+	return loaded, "scheduler.sandbox.resumed", nil
 }
 
 func (r *SchedulerSandboxRunner) indexCapabilitySandbox(session *domain.Sandbox) {

--- a/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
@@ -52,7 +52,7 @@ func TestLoaderSandboxRunnerLoadResumeAndShutdownCoverage(t *testing.T) {
 		t.Fatalf("UpdateSession stopped returned error: %v", err)
 	}
 	resumed, eventType, err = runner.LoadOrResume(ctx, stopped.Summary.ID)
-	if err != nil || resumed.Summary.VMStatus != domain.VMStatusRunning || eventType != "loader.sandbox.resumed" || len(driver.startCalls) != 1 {
+	if err != nil || resumed.Summary.VMStatus != domain.VMStatusRunning || eventType != "scheduler.sandbox.resumed" || len(driver.startCalls) != 1 {
 		t.Fatalf("LoadOrResume stopped resumed=%#v event=%q err=%v starts=%#v", resumed, eventType, err, driver.startCalls)
 	}
 	if token := domain.SandboxEnvMap(driver.startSessions[0].RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]; token == "" {
@@ -255,7 +255,7 @@ func TestLoaderSandboxRunnerResolvesVolumeMounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ensure returned error: %v", err)
 	}
-	if eventType != "loader.sandbox.created" || len(driver.startCalls) != 1 {
+	if eventType != "scheduler.sandbox.created" || len(driver.startCalls) != 1 {
 		t.Fatalf("eventType=%q startCalls=%#v", eventType, driver.startCalls)
 	}
 	if len(resolver.specs) != 1 || resolver.specs[0].Source != "request-cache" {

--- a/pkg/agentcompose/adapters/scheduler_session_runner_workspace_ensurer_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_workspace_ensurer_test.go
@@ -99,8 +99,8 @@ func TestLoaderSandboxRunnerEnsureUsesWorkspaceEnsurerBeforeGuideAndDriver(t *te
 	if err != nil {
 		t.Fatalf("Ensure returned error: %v", err)
 	}
-	if eventType != "loader.sandbox.created" {
-		t.Fatalf("Ensure event type = %q, want loader.sandbox.created", eventType)
+	if eventType != "scheduler.sandbox.created" {
+		t.Fatalf("Ensure event type = %q, want scheduler.sandbox.created", eventType)
 	}
 	if len(ensurer.calls) != 1 || ensurer.initialIDs[0] != sandbox.Summary.ID {
 		t.Fatalf("workspace Ensure calls = %#v ids=%#v, want sandbox %q once", ensurer.calls, ensurer.initialIDs, sandbox.Summary.ID)
@@ -286,7 +286,7 @@ func TestLoaderSandboxRunnerLoadOrResumeUsesWorkspaceEnsurer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadOrResume returned error: %v", err)
 		}
-		if eventType != "loader.sandbox.resumed" || resumed.Summary.VMStatus != domain.VMStatusRunning {
+		if eventType != "scheduler.sandbox.resumed" || resumed.Summary.VMStatus != domain.VMStatusRunning {
 			t.Fatalf("resumed event/status = %q/%q", eventType, resumed.Summary.VMStatus)
 		}
 		if len(ensurer.calls) != 1 || ensurer.initialIDs[0] != stopped.Summary.ID || ensurer.calls[0] != driver.startSessions[0] {
@@ -624,8 +624,8 @@ func TestLoaderSandboxRunnerStickyWorkspaceConfigChangeCreatesReplacement(t *tes
 	if err != nil {
 		t.Fatalf("Ensure after workspace update returned error: %v", err)
 	}
-	if replacement.Summary.ID == first.Summary.ID || eventType != "loader.sandbox.created" {
-		t.Fatalf("replacement sandbox/event = %q/%q, want a new sandbox/loader.sandbox.created", replacement.Summary.ID, eventType)
+	if replacement.Summary.ID == first.Summary.ID || eventType != "scheduler.sandbox.created" {
+		t.Fatalf("replacement sandbox/event = %q/%q, want a new sandbox/scheduler.sandbox.created", replacement.Summary.ID, eventType)
 	}
 	if replacement.Workspace == nil || replacement.Workspace.ConfigJSON != workspace.ConfigJSON {
 		t.Fatalf("replacement workspace = %#v, want updated %#v", replacement.Workspace, workspace)
@@ -687,8 +687,8 @@ func TestLoaderSandboxRunnerStickyRunningConfigChangeCreatesReplacement(t *testi
 	if err != nil {
 		t.Fatalf("Ensure after Scheduler update returned error: %v", err)
 	}
-	if replacement.Summary.ID == first.Summary.ID || eventType != "loader.sandbox.created" {
-		t.Fatalf("replacement sandbox/event = %q/%q, want a new sandbox/loader.sandbox.created", replacement.Summary.ID, eventType)
+	if replacement.Summary.ID == first.Summary.ID || eventType != "scheduler.sandbox.created" {
+		t.Fatalf("replacement sandbox/event = %q/%q, want a new sandbox/scheduler.sandbox.created", replacement.Summary.ID, eventType)
 	}
 	if got := domain.SandboxEnvMap(replacement.EnvItems)["BUG_VALUE"]; got != "B" {
 		t.Fatalf("replacement BUG_VALUE = %q, want B", got)
@@ -751,8 +751,8 @@ func TestLoaderSandboxRunnerStickyStoppedConfigChangeDoesNotResume(t *testing.T)
 	if err != nil {
 		t.Fatalf("Ensure after Scheduler update returned error: %v", err)
 	}
-	if replacement.Summary.ID == first.Summary.ID || eventType != "loader.sandbox.created" {
-		t.Fatalf("replacement sandbox/event = %q/%q, want a new sandbox/loader.sandbox.created", replacement.Summary.ID, eventType)
+	if replacement.Summary.ID == first.Summary.ID || eventType != "scheduler.sandbox.created" {
+		t.Fatalf("replacement sandbox/event = %q/%q, want a new sandbox/scheduler.sandbox.created", replacement.Summary.ID, eventType)
 	}
 	if len(driver.startCalls) != 2 || driver.startCalls[0] != first.Summary.ID || driver.startCalls[1] != replacement.Summary.ID {
 		t.Fatalf("driver start calls = %#v, want create/create without old resume", driver.startCalls)

--- a/pkg/agentcompose/adapters/scheduler_session_runner_workspace_resume_integration_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_workspace_resume_integration_test.go
@@ -76,8 +76,8 @@ func TestIntegrationLoaderStickyResumePreservesReadyFileWorkspace(t *testing.T) 
 	if err != nil {
 		t.Fatalf("first sticky Ensure returned error: %v", err)
 	}
-	if eventType != "loader.sandbox.created" {
-		t.Fatalf("first sticky Ensure event type = %q, want %q", eventType, "loader.sandbox.created")
+	if eventType != "scheduler.sandbox.created" {
+		t.Fatalf("first sticky Ensure event type = %q, want %q", eventType, "scheduler.sandbox.created")
 	}
 	if created.Summary.ID == "" {
 		t.Fatal("first sticky Ensure returned an empty sandbox ID")
@@ -178,8 +178,8 @@ func TestIntegrationLoaderStickyResumePreservesReadyFileWorkspace(t *testing.T) 
 	if err != nil {
 		t.Fatalf("second sticky Ensure returned error: %v", err)
 	}
-	if eventType != "loader.sandbox.resumed" {
-		t.Fatalf("second sticky Ensure event type = %q, want %q", eventType, "loader.sandbox.resumed")
+	if eventType != "scheduler.sandbox.resumed" {
+		t.Fatalf("second sticky Ensure event type = %q, want %q", eventType, "scheduler.sandbox.resumed")
 	}
 	if resumed.Summary.ID != sandboxID {
 		t.Fatalf("second sticky Ensure sandbox ID = %q, want original %q", resumed.Summary.ID, sandboxID)

--- a/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
@@ -84,7 +84,7 @@ func TestIntegrationBatchGetLatestSchedulerRunsFindsRunBeyondFirstPage(t *testin
 	}
 	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{
 		ID: "event-target", SchedulerID: schedulerID, RunID: targetRunID,
-		TriggerID: "trigger-regression", Type: "loader.agent.completed",
+		TriggerID: "trigger-regression", Type: "scheduler.agent.completed",
 		LinkedSandboxID: targetID, CreatedAt: startedAt,
 	}); err != nil {
 		t.Fatalf("link target scheduler run to sandbox: %v", err)

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -208,8 +208,8 @@ func TestProjectHandlerListsProjectSchedulerEventsWithIdentityAndOffset(t *testi
 	store, _, handler := newSchedulerRunHandlerFixture()
 	createdAt := time.Unix(300, 0).UTC()
 	store.events = []domain.SchedulerEvent{
-		{ID: "event-2", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", LinkedSandboxID: "sandbox-1", CreatedAt: createdAt},
-		{ID: "event-1", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.run.started", CreatedAt: createdAt.Add(-time.Second)},
+		{ID: "event-2", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "scheduler.log", LinkedSandboxID: "sandbox-1", CreatedAt: createdAt},
+		{ID: "event-1", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "scheduler.run.started", CreatedAt: createdAt.Add(-time.Second)},
 	}
 	first, err := handler.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
 		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, Limit: 1,

--- a/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
@@ -48,9 +48,9 @@ func TestStreamProjectSchedulerEventsTailsInDisplayOrder(t *testing.T) {
 	store, _, handler := newSchedulerRunHandlerFixture()
 	createdAt := time.Unix(600, 0).UTC()
 	store.events = []domain.SchedulerEvent{
-		{ID: "event-3", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", CreatedAt: createdAt.Add(2 * time.Second)},
-		{ID: "event-2", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", CreatedAt: createdAt.Add(time.Second)},
-		{ID: "event-1", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "loader.log", CreatedAt: createdAt},
+		{ID: "event-3", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "scheduler.log", CreatedAt: createdAt.Add(2 * time.Second)},
+		{ID: "event-2", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "scheduler.log", CreatedAt: createdAt.Add(time.Second)},
+		{ID: "event-1", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1", Type: "scheduler.log", CreatedAt: createdAt},
 	}
 	client, closeServer := schedulerStreamTestClient(t, handler)
 	defer closeServer()

--- a/pkg/schedulers/controller_coverage_test.go
+++ b/pkg/schedulers/controller_coverage_test.go
@@ -106,11 +106,11 @@ func TestControllerCoverageWorkflow(t *testing.T) {
 		t.Fatalf("parallel EnterRun should succeed")
 	}
 	controller.LeaveRun(created.Summary.ID)
-	event, err := controller.AddSchedulerEventRecord(ctx, created.Summary.ID, "run-1", "trigger-1", "loader.test", "", "message", map[string]any{"ok": true}, "session-1", "cell-1", "agent-session")
+	event, err := controller.AddSchedulerEventRecord(ctx, created.Summary.ID, "run-1", "trigger-1", "scheduler.test", "", "message", map[string]any{"ok": true}, "session-1", "cell-1", "agent-session")
 	if err != nil || event.ID != "event-id" || event.Level != "info" {
 		t.Fatalf("AddSchedulerEventRecord event=%#v err=%v", event, err)
 	}
-	if _, err := controller.AddSchedulerEventRecord(ctx, created.Summary.ID, "run-1", "trigger-1", "loader.bad", "", "message", func() {}, "", "", ""); err == nil {
+	if _, err := controller.AddSchedulerEventRecord(ctx, created.Summary.ID, "run-1", "trigger-1", "scheduler.bad", "", "message", func() {}, "", "", ""); err == nil {
 		t.Fatalf("AddSchedulerEventRecord invalid payload returned nil error")
 	}
 	dir := controller.RunArtifactsDir(created.Summary.ID, "run-1")

--- a/pkg/schedulers/orchestration_test.go
+++ b/pkg/schedulers/orchestration_test.go
@@ -69,7 +69,7 @@ func TestRunExecutorLifecycleWorkflows(t *testing.T) {
 	if len(store.created) != 1 || len(store.updated) != 1 || store.lastError[loader.Summary.ID] != "" {
 		t.Fatalf("store state = %#v/%#v/%#v", store.created, store.updated, store.lastError)
 	}
-	if !containsString(events, "loader.run.started") || !containsString(events, "loader.run.completed") || !containsString(events, "loader.deprecated_alias.warning") {
+	if !containsString(events, "scheduler.run.started") || !containsString(events, "scheduler.run.completed") || !containsString(events, "scheduler.deprecated_alias.warning") {
 		t.Fatalf("events = %#v", events)
 	}
 	if len(deliveries) != 2 || len(notifications) != 2 || refreshes != 1 || len(leaves) != 1 {

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -114,10 +114,10 @@ func NewRuntimeHost(deps RunHostDependencies, scheduler domain.Scheduler, execut
 }
 
 // Runtime host events are persisted and payloads are consumed by existing
-// clients. Keep loader.* event types and loaderId/loaderRunId keys unchanged;
-// scheduler is only the internal domain terminology.
+// clients. Keep loaderId/loaderRunId payload keys unchanged even though
+// scheduler events use the scheduler.* prefix.
 func (h *RuntimeHost) Log(ctx context.Context, message string, payload any) error {
-	return h.addSchedulerEvent(ctx, "loader.log", "info", message, payload, "", "", "")
+	return h.addSchedulerEvent(ctx, "scheduler.log", "info", message, payload, "", "", "")
 }
 
 func (h *RuntimeHost) PublishEvent(ctx context.Context, topic string, payloadJSON string) (domain.TopicEventRecord, error) {
@@ -134,7 +134,7 @@ func (h *RuntimeHost) PublishEvent(ctx context.Context, topic string, payloadJSO
 	}
 	created, err := h.deps.Store.CreateEvent(ctx, published.Record)
 	if err != nil {
-		_ = h.addSchedulerEvent(ctx, "loader.event.publish.failed", "error", err.Error(), map[string]any{"topic": published.Record.Topic}, "", "", "")
+		_ = h.addSchedulerEvent(ctx, "scheduler.event.publish.failed", "error", err.Error(), map[string]any{"topic": published.Record.Topic}, "", "", "")
 		return domain.TopicEventRecord{}, err
 	}
 	if sequenced, err := UpdatePublishedTopicEventSequence(published, created.Sequence); err == nil {
@@ -142,7 +142,7 @@ func (h *RuntimeHost) PublishEvent(ctx context.Context, topic string, payloadJSO
 		created.PayloadJSON = sequenced.PayloadJSON
 		created.PayloadHash = sequenced.PayloadHash
 	}
-	_ = h.addSchedulerEvent(ctx, "loader.event.published", "info", "loader event published", map[string]any{
+	_ = h.addSchedulerEvent(ctx, "scheduler.event.published", "info", "scheduler event published", map[string]any{
 		"eventId":       created.ID,
 		"sequence":      created.Sequence,
 		"topic":         created.Topic,
@@ -176,11 +176,11 @@ func (h *RuntimeHost) CallSandboxRPC(ctx context.Context, method, requestJSON st
 	responseJSON, err := h.deps.SandboxRPC.CallJSONWithSource(ctx, method, requestJSON, domain.SandboxTypeScript+":"+h.scheduler.Summary.ID)
 	linkedSandboxID := h.linkedSandboxID(method, requestJSON, responseJSON)
 	if err != nil {
-		event, _ := h.addSchedulerEventRecord(ctx, "loader.sandbox.rpc.failed", "error", firstHostNonEmpty(err.Error(), fmt.Sprintf("%s failed", method)), map[string]any{"method": method, "requestJson": requestJSON}, linkedSandboxID, "", "")
+		event, _ := h.addSchedulerEventRecord(ctx, "scheduler.sandbox.rpc.failed", "error", firstHostNonEmpty(err.Error(), fmt.Sprintf("%s failed", method)), map[string]any{"method": method, "requestJson": requestJSON}, linkedSandboxID, "", "")
 		h.addEventSandboxLink(ctx, event, linkedSandboxID, "sandbox_rpc_failed")
 		return "", err
 	}
-	event, _ := h.addSchedulerEventRecord(ctx, "loader.sandbox.rpc.completed", "info", fmt.Sprintf("%s completed", method), map[string]any{"method": method, "requestJson": requestJSON, "responseJson": responseJSON}, linkedSandboxID, "", "")
+	event, _ := h.addSchedulerEventRecord(ctx, "scheduler.sandbox.rpc.completed", "info", fmt.Sprintf("%s completed", method), map[string]any{"method": method, "requestJson": requestJSON, "responseJson": responseJSON}, linkedSandboxID, "", "")
 	h.addEventSandboxLink(ctx, event, linkedSandboxID, "sandbox_rpc_completed")
 	return responseJSON, nil
 }
@@ -195,7 +195,7 @@ func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.S
 		return domain.SchedulerAgentResult{}, err
 	}
 	if eventType != "" {
-		_ = h.addLinkedSchedulerEvent(ctx, eventType, "info", "loader sandbox ready", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedSchedulerEvent(ctx, eventType, "info", "scheduler sandbox ready", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 
 	agentConfig := execution.AgentConfig{Provider: domain.NormalizeAgentKind(request.Agent)}
@@ -248,19 +248,19 @@ func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.S
 		ExitCode:      cell.ExitCode,
 	}
 	level := "info"
-	eventName := "loader.agent.completed"
+	eventName := "scheduler.agent.completed"
 	if execErr != nil {
 		level = "error"
-		eventName = "loader.agent.failed"
+		eventName = "scheduler.agent.failed"
 		result.Text = firstHostNonEmpty(result.Text, execErr.Error())
 	}
 	_ = h.addLinkedSchedulerEvent(ctx, eventName, level, firstHostNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SandboxID, result.CellID, result.AgentThreadID)
 	h.publishAgentCompleted(result, nil)
 	if shutdownErr := h.deps.Sessions.Shutdown(ctx, session.Summary.ID); shutdownErr != nil {
 		slog.Warn("failed to stop loader sandbox after agent run", "loader_id", h.scheduler.Summary.ID, "sandbox_id", session.Summary.ID, "error", shutdownErr)
-		_ = h.addLinkedSchedulerEvent(ctx, "loader.sandbox.stop_failed", "error", shutdownErr.Error(), map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedSchedulerEvent(ctx, "scheduler.sandbox.stop_failed", "error", shutdownErr.Error(), map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
 	} else {
-		_ = h.addLinkedSchedulerEvent(ctx, "loader.sandbox.stopped", "info", "loader sandbox stopped after agent run", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedSchedulerEvent(ctx, "scheduler.sandbox.stopped", "info", "scheduler sandbox stopped after agent run", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 	if execErr != nil {
 		return result, execErr
@@ -284,24 +284,24 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.SchedulerComma
 	}
 	session, eventType, err := h.ensureCommandSession(ctx, agentRequest, cleanupSession)
 	if err != nil {
-		_ = h.addSchedulerEvent(ctx, "loader.command.failed", "error", err.Error(), CommandEventPayload(request, domain.SchedulerCommandResult{}), "", "", "")
+		_ = h.addSchedulerEvent(ctx, "scheduler.command.failed", "error", err.Error(), CommandEventPayload(request, domain.SchedulerCommandResult{}), "", "", "")
 		return domain.SchedulerCommandResult{}, err
 	}
 	if eventType != "" {
-		_ = h.addLinkedSchedulerEvent(ctx, eventType, "info", "loader command sandbox ready", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
+		_ = h.addLinkedSchedulerEvent(ctx, eventType, "info", "scheduler command sandbox ready", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 	h.trackCommandSession(session.Summary.ID, cleanupSession)
 
 	result, err := h.deps.CommandExecutor.ExecuteSchedulerCommand(ctx, session, request)
 	if err != nil {
-		_ = h.addLinkedSchedulerEvent(ctx, "loader.command.failed", "error", err.Error(), CommandEventPayload(request, result), result.SandboxID, result.CellID, "")
+		_ = h.addLinkedSchedulerEvent(ctx, "scheduler.command.failed", "error", err.Error(), CommandEventPayload(request, result), result.SandboxID, result.CellID, "")
 		return result, err
 	}
 	level := "info"
 	if !result.Success {
 		level = "error"
 	}
-	_ = h.addLinkedSchedulerEvent(ctx, "loader.command.completed", level, firstHostNonEmpty(result.Output, result.Stdout, result.Stderr, "loader command completed"), CommandEventPayload(request, result), result.SandboxID, result.CellID, "")
+	_ = h.addLinkedSchedulerEvent(ctx, "scheduler.command.completed", level, firstHostNonEmpty(result.Output, result.Stdout, result.Stderr, "scheduler command completed"), CommandEventPayload(request, result), result.SandboxID, result.CellID, "")
 	return result, nil
 }
 
@@ -311,10 +311,10 @@ func (h *RuntimeHost) LLM(ctx context.Context, prompt string, request domain.Sch
 	}
 	result, err := h.deps.LLM.Generate(ctx, prompt, request.Model, request.OutputSchema)
 	if err != nil {
-		_ = h.addSchedulerEvent(ctx, "loader.llm.failed", "error", err.Error(), map[string]any{"model": strings.TrimSpace(request.Model)}, "", "", "")
+		_ = h.addSchedulerEvent(ctx, "scheduler.llm.failed", "error", err.Error(), map[string]any{"model": strings.TrimSpace(request.Model)}, "", "", "")
 		return domain.SchedulerLLMResult{}, err
 	}
-	_ = h.addSchedulerEvent(ctx, "loader.llm.completed", "info", firstHostNonEmpty(result.Text, "llm completed"), result, "", "", "")
+	_ = h.addSchedulerEvent(ctx, "scheduler.llm.completed", "info", firstHostNonEmpty(result.Text, "llm completed"), result, "", "", "")
 	return result, nil
 }
 
@@ -325,10 +325,10 @@ func (h *RuntimeHost) CleanupCommandSessions(ctx context.Context) {
 	for _, sessionID := range sessionIDs {
 		if err := h.deps.Sessions.Shutdown(ctx, sessionID); err != nil {
 			slog.Warn("failed to stop loader command sandbox after run", "loader_id", h.scheduler.Summary.ID, "sandbox_id", sessionID, "error", err)
-			_ = h.addLinkedSchedulerEvent(ctx, "loader.sandbox.stop_failed", "error", err.Error(), map[string]any{"sandboxId": sessionID}, sessionID, "", "")
+			_ = h.addLinkedSchedulerEvent(ctx, "scheduler.sandbox.stop_failed", "error", err.Error(), map[string]any{"sandboxId": sessionID}, sessionID, "", "")
 			continue
 		}
-		_ = h.addLinkedSchedulerEvent(ctx, "loader.sandbox.stopped", "info", "loader command sandbox stopped after run", map[string]any{"sandboxId": sessionID}, sessionID, "", "")
+		_ = h.addLinkedSchedulerEvent(ctx, "scheduler.sandbox.stopped", "info", "scheduler command sandbox stopped after run", map[string]any{"sandboxId": sessionID}, sessionID, "", "")
 	}
 }
 

--- a/pkg/schedulers/run_host_project_agent.go
+++ b/pkg/schedulers/run_host_project_agent.go
@@ -63,10 +63,10 @@ func (h *RuntimeHost) ProjectAgent(ctx context.Context, prompt string, request d
 		execErr = jsonErr
 	}
 	level := "info"
-	eventName := "loader.agent.completed"
+	eventName := "scheduler.agent.completed"
 	if execErr != nil || run.Status != domain.ProjectRunStatusSucceeded {
 		level = "error"
-		eventName = "loader.agent.failed"
+		eventName = "scheduler.agent.failed"
 		result.Text = firstHostNonEmpty(result.Text, run.Error, execErrString(execErr))
 	}
 	_ = h.addLinkedSchedulerEvent(ctx, eventName, level, firstHostNonEmpty(result.Text, fmt.Sprintf("%s completed", result.Agent)), result, result.SandboxID, result.CellID, result.AgentThreadID)

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -71,7 +71,7 @@ func TestRuntimeHostAgentCommandLLMAndSessionRPC(t *testing.T) {
 	if len(publisher.events) != 1 || publisher.events[0].topic != "agent-compose.agent.completed" {
 		t.Fatalf("publisher events = %#v", publisher.events)
 	}
-	if !events.contains("loader.sandbox.created") || !events.contains("loader.agent.completed") || !events.contains("loader.sandbox.stopped") {
+	if !events.contains("scheduler.sandbox.created") || !events.contains("scheduler.agent.completed") || !events.contains("scheduler.sandbox.stopped") {
 		t.Fatalf("agent events = %#v", events.types())
 	}
 
@@ -90,7 +90,7 @@ func TestRuntimeHostAgentCommandLLMAndSessionRPC(t *testing.T) {
 	if len(sandboxes.shutdowns) != 2 || sandboxes.shutdowns[1] != "session-host" {
 		t.Fatalf("shutdowns after cleanup = %#v", sandboxes.shutdowns)
 	}
-	if !events.contains("loader.command.completed") {
+	if !events.contains("scheduler.command.completed") {
 		t.Fatalf("command events = %#v", events.types())
 	}
 
@@ -101,7 +101,7 @@ func TestRuntimeHostAgentCommandLLMAndSessionRPC(t *testing.T) {
 	if llmResult.Text != "llm text" || llm.prompt != "prompt" {
 		t.Fatalf("llm result/prompt = %#v/%q", llmResult, llm.prompt)
 	}
-	if !events.contains("loader.llm.completed") {
+	if !events.contains("scheduler.llm.completed") {
 		t.Fatalf("llm events = %#v", events.types())
 	}
 
@@ -158,7 +158,7 @@ func TestRuntimeHostProjectAgentPath(t *testing.T) {
 	if result.Text != "project output" || projectRunner.request.ProjectID != "project-1" || projectRunner.request.ClientRequestID != run.ID+":agent:1" || projectRunner.request.TriggerID != run.TriggerID || projectRunner.request.SandboxConfigHash != expectedConfigHash {
 		t.Fatalf("project result/request = %#v/%#v", result, projectRunner.request)
 	}
-	if !events.contains("loader.agent.completed") || len(publisher.events) != 1 || publisher.events[0].payload["projectRunId"] != "project-run" {
+	if !events.contains("scheduler.agent.completed") || len(publisher.events) != 1 || publisher.events[0].payload["projectRunId"] != "project-run" {
 		t.Fatalf("events/publisher = %#v/%#v", events.types(), publisher.events)
 	}
 	if publisher.events[0].payload["loaderRunId"] != run.ID {
@@ -230,7 +230,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 		Publisher: &hostPublisherFake{},
 	}, loader, triggerExecution(run), schedulers.TriggerEventMetadata{EventID: "topic-event"})
 	agentResult, err := host.Agent(ctx, "prompt", domain.SchedulerAgentRequest{})
-	if err == nil || agentResult.Text != "agent stderr" || !events.contains("loader.agent.failed") || !events.contains("loader.sandbox.stop_failed") {
+	if err == nil || agentResult.Text != "agent stderr" || !events.contains("scheduler.agent.failed") || !events.contains("scheduler.sandbox.stop_failed") {
 		t.Fatalf("agent error result=%#v err=%v events=%#v", agentResult, err, events.types())
 	}
 
@@ -248,7 +248,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 		Publisher: &hostPublisherFake{},
 	}, projectLoader, triggerExecution(run), schedulers.TriggerEventMetadata{})
 	projectResult, err := projectHost.Agent(ctx, "prompt", domain.SchedulerAgentRequest{})
-	if err != nil || projectResult.Text != "project failed" || !projectEvents.contains("loader.agent.failed") {
+	if err != nil || projectResult.Text != "project failed" || !projectEvents.contains("scheduler.agent.failed") {
 		t.Fatalf("project failed result=%#v err=%v events=%#v", projectResult, err, projectEvents.types())
 	}
 	projectHost = schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
@@ -266,7 +266,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 			ensureErr: errors.New("ensure failed"),
 		},
 	}, loader, triggerExecution(run), schedulers.TriggerEventMetadata{})
-	if _, err := commandHost.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "echo"}); err == nil || !commandEvents.contains("loader.command.failed") {
+	if _, err := commandHost.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "echo"}); err == nil || !commandEvents.contains("scheduler.command.failed") {
 		t.Fatalf("command ensure err=%v events=%#v", err, commandEvents.types())
 	}
 	commandEvents = &hostEventsFake{}
@@ -275,7 +275,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-command", VMStatus: domain.VMStatusRunning}}},
 		CommandExecutor: &hostCommandExecutorFake{err: errors.New("command failed"), result: domain.SchedulerCommandResult{SandboxID: "session-command", CellID: "cell-command", Output: "partial"}},
 	}, loader, triggerExecution(run), schedulers.TriggerEventMetadata{})
-	if result, err := commandHost.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "false"}); err == nil || result.Output != "partial" || !commandEvents.contains("loader.command.failed") {
+	if result, err := commandHost.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "false"}); err == nil || result.Output != "partial" || !commandEvents.contains("scheduler.command.failed") {
 		t.Fatalf("command executor result=%#v err=%v events=%#v", result, err, commandEvents.types())
 	}
 	commandEvents = &hostEventsFake{}
@@ -284,7 +284,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-command", VMStatus: domain.VMStatusRunning}}},
 		CommandExecutor: &hostCommandExecutorFake{result: domain.SchedulerCommandResult{Output: "bad", Success: false, SandboxID: "session-command"}},
 	}, loader, triggerExecution(run), schedulers.TriggerEventMetadata{})
-	if result, err := commandHost.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "false"}); err != nil || result.Success || !commandEvents.contains("loader.command.completed") {
+	if result, err := commandHost.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "false"}); err != nil || result.Success || !commandEvents.contains("scheduler.command.completed") {
 		t.Fatalf("command nonzero result=%#v err=%v events=%#v", result, err, commandEvents.types())
 	}
 
@@ -296,7 +296,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 		Events: llmEvents,
 		LLM:    &hostLLMFake{err: errors.New("llm failed")},
 	}, loader, triggerExecution(run), schedulers.TriggerEventMetadata{})
-	if _, err := llmHost.LLM(ctx, "prompt", domain.SchedulerLLMRequest{Model: "model-a"}); err == nil || !llmEvents.contains("loader.llm.failed") {
+	if _, err := llmHost.LLM(ctx, "prompt", domain.SchedulerLLMRequest{Model: "model-a"}); err == nil || !llmEvents.contains("scheduler.llm.failed") {
 		t.Fatalf("llm err=%v events=%#v", err, llmEvents.types())
 	}
 
@@ -316,7 +316,7 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 			return ""
 		},
 	}, loader, triggerExecution(run), schedulers.TriggerEventMetadata{EventID: "topic-event"})
-	if _, err := rpcHost.CallSandboxRPC(ctx, "GetSandbox", `{"sandboxId":"sandbox-rpc"}`); err == nil || !rpcEvents.contains("loader.sandbox.rpc.failed") || !rpcStore.containsLink("sandbox-rpc", "sandbox_rpc_failed") {
+	if _, err := rpcHost.CallSandboxRPC(ctx, "GetSandbox", `{"sandboxId":"sandbox-rpc"}`); err == nil || !rpcEvents.contains("scheduler.sandbox.rpc.failed") || !rpcStore.containsLink("sandbox-rpc", "sandbox_rpc_failed") {
 		t.Fatalf("rpc err=%v events=%#v links=%#v", err, rpcEvents.types(), rpcStore.links)
 	}
 }
@@ -338,7 +338,7 @@ func TestRuntimeHostLogPublishEventAndState(t *testing.T) {
 	if err := host.Log(ctx, "hello", map[string]any{"ok": true}); err != nil {
 		t.Fatalf("Log returned error: %v", err)
 	}
-	if !events.contains("loader.log") {
+	if !events.contains("scheduler.log") {
 		t.Fatalf("events after Log = %#v", events.types())
 	}
 
@@ -352,7 +352,7 @@ func TestRuntimeHostLogPublishEventAndState(t *testing.T) {
 	if created.PublisherRunID != run.ID {
 		t.Fatalf("trigger publisher run ID = %q, want %q", created.PublisherRunID, run.ID)
 	}
-	if !events.contains("loader.event.published") {
+	if !events.contains("scheduler.event.published") {
 		t.Fatalf("events after PublishEvent = %#v", events.types())
 	}
 	invocationStore := &hostStoreFake{}
@@ -504,7 +504,7 @@ func (s *hostSessionsFake) Ensure(context.Context, domain.Scheduler, domain.Sche
 	if s.ensureErr != nil {
 		return nil, "", s.ensureErr
 	}
-	return s.session, "loader.sandbox.created", nil
+	return s.session, "scheduler.sandbox.created", nil
 }
 
 func (s *hostSessionsFake) Load(context.Context, string) (*domain.Sandbox, error) {

--- a/pkg/schedulers/run_lifecycle.go
+++ b/pkg/schedulers/run_lifecycle.go
@@ -134,7 +134,7 @@ func (e *RunExecutor) Prepare(ctx context.Context, scheduler domain.Scheduler, t
 		e.updateTriggerEventDelivery(ctx, run)
 		e.notify("loader_run_updated")
 		_ = e.deps.Store.UpdateSchedulerLastError(ctx, scheduler.Summary.ID, run.Error)
-		_ = e.addSchedulerEvent(ctx, scheduler.Summary.ID, run.ID, run.TriggerID, "loader.run.skipped", "warn", run.Error, nil, "", "", "")
+		_ = e.addSchedulerEvent(ctx, scheduler.Summary.ID, run.ID, run.TriggerID, "scheduler.run.skipped", "warn", run.Error, nil, "", "", "")
 		_ = e.writeArtifact(run.ArtifactsDir, "error.txt", run.Error)
 		return PreparedRun{Scheduler: scheduler, Trigger: trigger, Run: run, PayloadJSON: payloadJSON}, nil
 	}
@@ -151,7 +151,7 @@ func (e *RunExecutor) Prepare(ctx context.Context, scheduler domain.Scheduler, t
 	}
 	e.updateTriggerEventDelivery(ctx, run)
 	e.notify("loader_run_updated")
-	_ = e.addSchedulerEvent(ctx, scheduler.Summary.ID, run.ID, run.TriggerID, "loader.run.started", "info", "loader run started", map[string]any{"source": run.TriggerSource}, "", "", "")
+	_ = e.addSchedulerEvent(ctx, scheduler.Summary.ID, run.ID, run.TriggerID, "scheduler.run.started", "info", "scheduler run started", map[string]any{"source": run.TriggerSource}, "", "", "")
 	return PreparedRun{Scheduler: scheduler, Trigger: trigger, Run: run, PayloadJSON: payloadJSON}, nil
 }
 
@@ -178,7 +178,7 @@ func (e *RunExecutor) Execute(ctx context.Context, prepared PreparedRun) (domain
 		host.CleanupCommandSessions(writeCtx)
 	}
 	for _, warning := range execution.Warnings {
-		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "loader.deprecated_alias.warning", "warning", warning, nil, "", "", "")
+		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "scheduler.deprecated_alias.warning", "warning", warning, nil, "", "", "")
 	}
 
 	completedAt := time.Now().UTC()
@@ -189,13 +189,13 @@ func (e *RunExecutor) Execute(ctx context.Context, prepared PreparedRun) (domain
 		run.Error = cancelCause.Error()
 		_ = e.writeArtifact(run.ArtifactsDir, "error.txt", run.Error)
 		_ = e.deps.Store.UpdateSchedulerLastError(writeCtx, prepared.Scheduler.Summary.ID, run.Error)
-		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "loader.run.canceled", "warn", run.Error, nil, "", "", "")
+		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "scheduler.run.canceled", "warn", run.Error, nil, "", "", "")
 	} else if execErr != nil {
 		run.Status = domain.SchedulerRunStatusFailed
 		run.Error = execErr.Error()
 		_ = e.writeArtifact(run.ArtifactsDir, "error.txt", run.Error)
 		_ = e.deps.Store.UpdateSchedulerLastError(writeCtx, prepared.Scheduler.Summary.ID, run.Error)
-		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "loader.run.failed", "error", run.Error, nil, "", "", "")
+		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "scheduler.run.failed", "error", run.Error, nil, "", "", "")
 	} else {
 		run.Status = domain.SchedulerRunStatusSucceeded
 		run.ResultJSON = execution.ResultJSON
@@ -203,7 +203,7 @@ func (e *RunExecutor) Execute(ctx context.Context, prepared PreparedRun) (domain
 			_ = e.writeArtifact(run.ArtifactsDir, "result.json", execution.ResultJSON)
 		}
 		_ = e.deps.Store.UpdateSchedulerLastError(writeCtx, prepared.Scheduler.Summary.ID, "")
-		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "loader.run.completed", "info", "loader run completed", map[string]any{"resultJson": execution.ResultJSON}, "", "", "")
+		_ = e.addSchedulerEvent(writeCtx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "scheduler.run.completed", "info", "scheduler run completed", map[string]any{"resultJson": execution.ResultJSON}, "", "", "")
 	}
 	if err := e.deps.Store.UpdateSchedulerRun(writeCtx, run); err != nil {
 		return domain.SchedulerRunSummary{}, err
@@ -235,7 +235,7 @@ func (e *RunExecutor) Abort(ctx context.Context, prepared PreparedRun, reason st
 	run.Error = reason
 	_ = e.writeArtifact(run.ArtifactsDir, "error.txt", run.Error)
 	_ = e.deps.Store.UpdateSchedulerLastError(ctx, prepared.Scheduler.Summary.ID, run.Error)
-	_ = e.addSchedulerEvent(ctx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "loader.run.failed", "error", run.Error, nil, "", "", "")
+	_ = e.addSchedulerEvent(ctx, prepared.Scheduler.Summary.ID, run.ID, run.TriggerID, "scheduler.run.failed", "error", run.Error, nil, "", "", "")
 	if err := e.deps.Store.UpdateSchedulerRun(ctx, run); err != nil {
 		slog.Warn("failed to abort prepared loader run", "loader_id", prepared.Scheduler.Summary.ID, "run_id", run.ID, "error", err)
 	}

--- a/pkg/schedulers/scheduler_run_prune_test.go
+++ b/pkg/schedulers/scheduler_run_prune_test.go
@@ -192,7 +192,7 @@ func TestControllerRecoverInterruptedRunsMarksFailedAndRecordsEvent(t *testing.T
 			t.Fatalf("updated run=%#v", run)
 		}
 		event := store.events[index]
-		if event.Type != "loader.run.failed" || event.Level != "error" || event.RunID != run.ID || event.TriggerID != run.TriggerID || !strings.Contains(event.PayloadJSON, "daemon_interrupted") {
+		if event.Type != "scheduler.run.failed" || event.Level != "error" || event.RunID != run.ID || event.TriggerID != run.TriggerID || !strings.Contains(event.PayloadJSON, "daemon_interrupted") {
 			t.Fatalf("recovery event=%#v", event)
 		}
 	}

--- a/pkg/schedulers/scheduler_run_recovery.go
+++ b/pkg/schedulers/scheduler_run_recovery.go
@@ -37,7 +37,7 @@ func (c *Controller) RecoverInterruptedRuns(ctx context.Context, startedAt time.
 		}
 		if _, err := c.AddSchedulerEventRecord(
 			ctx, run.SchedulerID, run.ID, run.TriggerID,
-			"loader.run.failed", "error", interruptedSchedulerRunError,
+			"scheduler.run.failed", "error", interruptedSchedulerRunError,
 			map[string]any{"reason": "daemon_interrupted"}, "", "", "",
 		); err != nil {
 			recoveryErrors = append(recoveryErrors, fmt.Errorf("record interrupted scheduler run event %s/%s: %w", run.SchedulerID, run.ID, err))

--- a/pkg/schedulers/scheduler_run_supervisor_test.go
+++ b/pkg/schedulers/scheduler_run_supervisor_test.go
@@ -54,7 +54,7 @@ func TestRunExecutorCancellationWritesCanceledTerminalState(t *testing.T) {
 	if len(store.updated) != 1 || store.updated[0].Status != domain.SchedulerRunStatusCanceled {
 		t.Fatalf("updated runs = %#v", store.updated)
 	}
-	if !slices.Contains(events, "loader.run.canceled") || slices.Contains(events, "loader.run.failed") {
+	if !slices.Contains(events, "scheduler.run.canceled") || slices.Contains(events, "scheduler.run.failed") {
 		t.Fatalf("events = %#v", events)
 	}
 }
@@ -243,7 +243,7 @@ scheduler.interval("pending", async function pending() {
 	}
 	eventMu.Lock()
 	defer eventMu.Unlock()
-	if !slices.Equal(events, []string{"loader.run.started", "loader.run.canceled"}) {
+	if !slices.Equal(events, []string{"scheduler.run.started", "scheduler.run.canceled"}) {
 		t.Fatalf("events = %#v", events)
 	}
 }

--- a/pkg/storage/configstore/scheduler_event_page_test.go
+++ b/pkg/storage/configstore/scheduler_event_page_test.go
@@ -29,11 +29,11 @@ func TestSchedulerEventPageOnlyReturnsEventsJoinedToTriggerRuns(t *testing.T) {
 		}
 	}
 	for _, event := range []domain.SchedulerEvent{
-		{SchedulerID: "loader-a", ID: "event-a2", RunID: "run-a", TriggerID: "wrong-event-trigger", Type: "loader.log", CreatedAt: startedAt.Add(2 * time.Second)},
-		{SchedulerID: "loader-a", ID: "event-a1", RunID: "run-a", TriggerID: "trigger-a", Type: "loader.run.started", CreatedAt: startedAt.Add(time.Second)},
-		{SchedulerID: "loader-a", ID: "event-b", RunID: "run-b", TriggerID: "trigger-b", Type: "loader.log", CreatedAt: startedAt},
-		{SchedulerID: "loader-a", ID: "event-invoke", RunID: "invoke-old", Type: "loader.log", CreatedAt: startedAt.Add(3 * time.Second)},
-		{SchedulerID: "loader-a", ID: "event-orphan", RunID: "missing", TriggerID: "trigger-a", Type: "loader.log", CreatedAt: startedAt.Add(4 * time.Second)},
+		{SchedulerID: "loader-a", ID: "event-a2", RunID: "run-a", TriggerID: "wrong-event-trigger", Type: "scheduler.log", CreatedAt: startedAt.Add(2 * time.Second)},
+		{SchedulerID: "loader-a", ID: "event-a1", RunID: "run-a", TriggerID: "trigger-a", Type: "scheduler.run.started", CreatedAt: startedAt.Add(time.Second)},
+		{SchedulerID: "loader-a", ID: "event-b", RunID: "run-b", TriggerID: "trigger-b", Type: "scheduler.log", CreatedAt: startedAt},
+		{SchedulerID: "loader-a", ID: "event-invoke", RunID: "invoke-old", Type: "scheduler.log", CreatedAt: startedAt.Add(3 * time.Second)},
+		{SchedulerID: "loader-a", ID: "event-orphan", RunID: "missing", TriggerID: "trigger-a", Type: "scheduler.log", CreatedAt: startedAt.Add(4 * time.Second)},
 	} {
 		if err := store.AddSchedulerEvent(ctx, event); err != nil {
 			t.Fatalf("add event %s: %v", event.ID, err)
@@ -70,7 +70,7 @@ func TestSchedulerEventPageSupportsTailBoundaryAndAscendingRange(t *testing.T) {
 		t.Fatalf("create run: %v", err)
 	}
 	for index, id := range []string{"event-1", "event-2", "event-3", "event-4"} {
-		if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{SchedulerID: "loader-a", ID: id, RunID: "run-a", TriggerID: "trigger-a", Type: "loader.log", CreatedAt: startedAt.Add(time.Duration(index) * time.Second)}); err != nil {
+		if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{SchedulerID: "loader-a", ID: id, RunID: "run-a", TriggerID: "trigger-a", Type: "scheduler.log", CreatedAt: startedAt.Add(time.Duration(index) * time.Second)}); err != nil {
 			t.Fatalf("add event %s: %v", id, err)
 		}
 	}

--- a/pkg/storage/configstore/scheduler_run_page_test.go
+++ b/pkg/storage/configstore/scheduler_run_page_test.go
@@ -143,7 +143,7 @@ func TestLoaderRunPageFiltersTriggerRunsBeforeLimitAndBatchesSandboxes(t *testin
 		t.Fatalf("filtered runs=%#v err=%v", filtered, err)
 	}
 	for index, sandboxID := range []string{"sandbox-b", "sandbox-a", "sandbox-a"} {
-		if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{SchedulerID: "loader-a", ID: fmt.Sprintf("event-%d", index), RunID: "run-success", TriggerID: "trigger-a", Type: "loader.test", LinkedSandboxID: sandboxID, CreatedAt: startedAt}); err != nil {
+		if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{SchedulerID: "loader-a", ID: fmt.Sprintf("event-%d", index), RunID: "run-success", TriggerID: "trigger-a", Type: "scheduler.test", LinkedSandboxID: sandboxID, CreatedAt: startedAt}); err != nil {
 			t.Fatalf("add event: %v", err)
 		}
 	}
@@ -185,7 +185,7 @@ func TestBatchGetLatestLoaderRunsBySandboxIDsSelectsLatestTriggerRun(t *testing.
 		if err := store.CreateSchedulerRun(ctx, run); err != nil {
 			t.Fatalf("create run %s: %v", run.ID, err)
 		}
-		if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{SchedulerID: run.SchedulerID, ID: "event-" + run.ID, RunID: run.ID, TriggerID: run.TriggerID, Type: "loader.test", LinkedSandboxID: "sandbox-a", CreatedAt: run.StartedAt}); err != nil {
+		if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{SchedulerID: run.SchedulerID, ID: "event-" + run.ID, RunID: run.ID, TriggerID: run.TriggerID, Type: "scheduler.test", LinkedSandboxID: "sandbox-a", CreatedAt: run.StartedAt}); err != nil {
 			t.Fatalf("add event for run %s: %v", run.ID, err)
 		}
 	}

--- a/pkg/storage/configstore/scheduler_run_prune_test.go
+++ b/pkg/storage/configstore/scheduler_run_prune_test.go
@@ -155,7 +155,7 @@ func createPruneTestLoader(t *testing.T, store *ConfigStore, schedulerID string)
 func addPruneTestRelations(t *testing.T, store *ConfigStore, schedulerID, runID, triggerID string) {
 	t.Helper()
 	ctx := context.Background()
-	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{ID: "loader-event-" + runID, SchedulerID: schedulerID, RunID: runID, TriggerID: triggerID, Type: "loader.run.completed", CreatedAt: time.Now().UTC()}); err != nil {
+	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{ID: "loader-event-" + runID, SchedulerID: schedulerID, RunID: runID, TriggerID: triggerID, Type: "scheduler.run.completed", CreatedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("add loader event: %v", err)
 	}
 	if _, err := store.db.ExecContext(ctx, `INSERT INTO event_delivery(event_id, scheduler_id, trigger_id, scheduler_run_id, status, created_at, updated_at) VALUES(?, ?, ?, ?, 'run_succeeded', 1, 1)`, "event-"+runID, schedulerID, triggerID, runID); err != nil {

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -585,7 +585,7 @@ func testConfigStoreCRUDCoverageWorkflows(t *testing.T) {
 	if runs, err := store.ListRecentSchedulerRuns(ctx, 0); err != nil || len(runs) != 1 {
 		t.Fatalf("ListRecentSchedulerRuns default limit runs=%#v err=%v", runs, err)
 	}
-	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{ID: "event-1", SchedulerID: loader.Summary.ID, RunID: run.ID, Type: "loader.test", Level: "info", CreatedAt: time.Now().UTC()}); err != nil {
+	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{ID: "event-1", SchedulerID: loader.Summary.ID, RunID: run.ID, Type: "scheduler.test", Level: "info", CreatedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("AddSchedulerEvent returned error: %v", err)
 	}
 	if events, err := store.ListSchedulerEvents(ctx, loader.Summary.ID, 10); err != nil || len(events) != 1 {

--- a/test/e2e/v2_storage_cutover_host_daemon_test.go
+++ b/test/e2e/v2_storage_cutover_host_daemon_test.go
@@ -282,7 +282,7 @@ func migratedRunSandboxID(t *testing.T, ctx context.Context, client agentcompose
 		if sandboxID := strings.TrimSpace(event.GetLinkedSandboxId()); sandboxID != "" {
 			linked[sandboxID] = struct{}{}
 		}
-		if event.GetType() == "loader.command.completed" && event.GetLevel() == "info" {
+		if event.GetType() == "scheduler.command.completed" && event.GetLevel() == "info" {
 			completed = true
 		}
 	}


### PR DESCRIPTION
## Summary

- rename newly persisted scheduler event types from `loader.*` to `scheduler.*`
- align scheduler event messages, tests, and design documentation with the v2 scheduler terminology
- leave existing database rows, legacy migration fixtures, and historical `agent-compose.session.*` payload contracts unchanged

## Testing

- `go test ./pkg/schedulers ./pkg/agentcompose/adapters ./pkg/agentcompose/api ./pkg/storage/configstore ./cmd/agent-compose`
- `task lint`
- `task test`
- `task docs:build`
- `task build` attempted twice; protobuf and runtime SDK build/packaging passed, but Linux BoxLite/Microsandbox artifact preparation could not pull `docker.io/library/golang:1-alpine` because Docker Hub timed out

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.