### PR TITLE
fix(ci): add Arch Linux package mirror fallback

### DIFF
--- a/guest-images/Dockerfile.agent-compose-guest-archlinux
+++ b/guest-images/Dockerfile.agent-compose-guest-archlinux
@@ -38,7 +38,9 @@ RUN if [ -n "${BUILDPLATFORM}" ] && [ "${BUILDPLATFORM}" != "${TARGETPLATFORM}" 
       sed -i 's/^#DisableSandboxSyscalls/DisableSandboxSyscalls/' /etc/pacman.conf; \
     fi && \
     if [ -n "${ARCHLINUX_MIRROR}" ]; then \
-      printf 'Server = %s/$repo/os/$arch\n' "${ARCHLINUX_MIRROR%/}" > /etc/pacman.d/mirrorlist; \
+      printf 'Server = %s/$repo/os/$arch\n' "${ARCHLINUX_MIRROR%/}" > /tmp/pacman-mirrorlist && \
+      cat /etc/pacman.d/mirrorlist >> /tmp/pacman-mirrorlist && \
+      mv /tmp/pacman-mirrorlist /etc/pacman.d/mirrorlist; \
     fi && \
     pacman -Syu --noconfirm --needed \
       ca-certificates \

--- a/scripts/tests/test-image-ci-contract.sh
+++ b/scripts/tests/test-image-ci-contract.sh
@@ -440,6 +440,8 @@ if [[ -f $ARCHLINUX_GUEST_DOCKERFILE ]]; then
     'configurable Arch Linux base image'
   require_regex "$archlinux_guest_source" 'pacman[[:space:]]+-Syu' \
     'Arch Linux package installation'
+  require_regex "$archlinux_guest_source" 'cat[[:space:]]+/etc/pacman\.d/mirrorlist' \
+    'Arch Linux package mirror fallback'
   require_regex "$archlinux_guest_source" 'nodejs-lts-jod' \
     'Node.js 22 LTS in Arch Linux guest image'
   forbid_regex "$archlinux_guest_source" '^[[:space:]]*base-devel[[:space:]]*\\' \


### PR DESCRIPTION
## Summary

- Keep the configured `ARCHLINUX_MIRROR` as the preferred package source.
- Preserve the Arch base image's existing mirror list as fallback when the preferred mirror times out.
- Add a focused image CI contract assertion for the fallback.
- Leave package versions, installed packages, publication behavior, and runtime image pull policy unchanged.

Closes #470

## Testing

- `./scripts/tests/test-image-ci-contract.sh`
  - Passed.
- `bash -n scripts/tests/test-image-ci-contract.sh`
  - Passed.
- `git diff --check upstream/main...HEAD`
  - Passed.
- Local Arch Linux image build was not run because the Docker daemon is not running in this environment.
- `task lint`, `task build`, and `task test` were not run because Task is not installed in this environment.

## Checklist

- [x] Documentation is not required because no public behavior or configuration contract changed.
- [x] Tests added or updated for the changed CI behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
