### PR TITLE
fix(driver): wait for docker jupyter port binding

### DIFF
--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -36,6 +37,8 @@ const (
 
 	dockerStopAPIMargin             = 5 * time.Second
 	dockerStopFallbackActionTimeout = 5 * time.Second
+	dockerJupyterPortBindingWait    = 5 * time.Second
+	dockerJupyterPortBindingPoll    = 50 * time.Millisecond
 )
 
 type dockerRuntime struct {
@@ -45,6 +48,8 @@ type dockerRuntime struct {
 type dockerContainerRemover interface {
 	ContainerRemove(context.Context, string, containerapi.RemoveOptions) error
 }
+
+type dockerContainerInspector func(context.Context, string) (containerapi.InspectResponse, error)
 
 type dockerDaemonTopology struct {
 	networkMode   containerapi.NetworkMode
@@ -174,7 +179,17 @@ func (r *dockerRuntime) EnsureSandbox(ctx context.Context, sandbox *Sandbox, vmS
 	if err != nil {
 		return SandboxVMInfo{}, fmt.Errorf("inspect started docker container %s: %w", containerInfo.ID, err)
 	}
-	proxyState, err = r.dockerSandboxProxyState(sandbox, vmState, proxyState, containerInfo, topology.containerized)
+	containerInfo, proxyState, err = r.waitForDockerJupyterProxyState(
+		ctx,
+		dockerClient.ContainerInspect,
+		sandbox,
+		vmState,
+		proxyState,
+		containerInfo,
+		topology.containerized,
+		dockerJupyterPortBindingWait,
+		dockerJupyterPortBindingPoll,
+	)
 	if err != nil {
 		return SandboxVMInfo{}, err
 	}
@@ -1173,6 +1188,49 @@ func (r *dockerRuntime) dockerSandboxProxyState(sandbox *Sandbox, vmState VMStat
 		proxyState.GuestHost = r.containerName(sandbox, vmState)
 	}
 	return proxyState, nil
+}
+
+func (r *dockerRuntime) waitForDockerJupyterProxyState(
+	ctx context.Context,
+	inspect dockerContainerInspector,
+	sandbox *Sandbox,
+	vmState VMState,
+	proxyState ProxyState,
+	containerInfo containerapi.InspectResponse,
+	containerizedDaemon bool,
+	waitTimeout time.Duration,
+	pollInterval time.Duration,
+) (containerapi.InspectResponse, ProxyState, error) {
+	currentState, err := r.dockerSandboxProxyState(sandbox, vmState, proxyState, containerInfo, containerizedDaemon)
+	if err == nil || !proxyState.Enabled || waitTimeout <= 0 || pollInterval <= 0 {
+		return containerInfo, currentState, err
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	lastErr := err
+	for {
+		select {
+		case <-waitCtx.Done():
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return containerInfo, ProxyState{}, lastErr
+			}
+			return containerInfo, ProxyState{}, waitCtx.Err()
+		case <-ticker.C:
+			refreshed, inspectErr := inspect(waitCtx, containerInfo.ID)
+			if inspectErr != nil {
+				return containerInfo, ProxyState{}, fmt.Errorf("inspect started docker container %s: %w", containerInfo.ID, inspectErr)
+			}
+			currentState, err = r.dockerSandboxProxyState(sandbox, vmState, proxyState, refreshed, containerizedDaemon)
+			if err == nil {
+				return refreshed, currentState, nil
+			}
+			containerInfo = refreshed
+			lastErr = err
+		}
+	}
 }
 
 func dockerJupyterHostPort(containerInfo containerapi.InspectResponse, guestPort int) (int, error) {

--- a/pkg/driver/docker_runtime_test.go
+++ b/pkg/driver/docker_runtime_test.go
@@ -708,6 +708,62 @@ func TestDockerRuntimeSandboxProxyStateUsesContainerNameAndGuestPort(t *testing.
 	}
 }
 
+func TestDockerRuntimeWaitForJupyterProxyStateRetriesUntilBindingVisible(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{
+		Summary: SandboxSummary{
+			ID:         "session-1",
+			RuntimeRef: "runtime-ref",
+		},
+	}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, nil)
+	inspectCalls := 0
+	inspect := func(ctx context.Context, containerID string) (containerapi.InspectResponse, error) {
+		inspectCalls++
+		if containerID != "container-1" {
+			t.Fatalf("inspect containerID = %q, want container-1", containerID)
+		}
+		return dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "42000"}}), nil
+	}
+
+	containerInfo, proxyState, err := runtime.waitForDockerJupyterProxyState(context.Background(), inspect, sandbox, VMState{}, state, initialInfo, false, time.Second, time.Nanosecond)
+	if err != nil {
+		t.Fatalf("waitForDockerJupyterProxyState returned error: %v", err)
+	}
+	if inspectCalls != 1 {
+		t.Fatalf("inspect calls = %d, want 1", inspectCalls)
+	}
+	if containerInfo.ID != "container-1" || proxyState.GuestHost != "127.0.0.1" || proxyState.HostPort != 42000 || proxyState.Token != "secret" {
+		t.Fatalf("proxy state = %+v container = %+v, want refreshed loopback binding", proxyState, containerInfo.ContainerJSONBase)
+	}
+}
+
+func TestDockerRuntimeWaitForJupyterProxyStateReturnsContextCancellation(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{Summary: SandboxSummary{ID: "session-1", RuntimeRef: "runtime-ref"}}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := runtime.waitForDockerJupyterProxyState(ctx, func(context.Context, string) (containerapi.InspectResponse, error) {
+		t.Fatal("inspect must not run after context cancellation")
+		return containerapi.InspectResponse{}, nil
+	}, sandbox, VMState{}, state, initialInfo, false, time.Second, time.Nanosecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForDockerJupyterProxyState err = %v, want context.Canceled", err)
+	}
+}
+
 func dockerInspectWithJupyterBindings(id, name string, guestPort int, bindings []nat.PortBinding) containerapi.InspectResponse {
 	networkSettings := &containerapi.NetworkSettings{}
 	networkSettings.Ports = nat.PortMap{nat.Port(strconv.Itoa(guestPort) + "/tcp"): bindings}


### PR DESCRIPTION
## Summary
- wait briefly for Docker to publish dynamic Jupyter port bindings after container start
- keep the refreshed Docker inspect result when building proxy state
- add a regression test for delayed Jupyter port binding visibility

Fixes #458

## Tests
- go test ./pkg/driver ./pkg/runs ./pkg/sandboxes ./pkg/storage/sandboxstore
- PATH="/Users/xiaoluer/go/bin:$PATH" task lint
