### PR TITLE
test(api): enforce control-plane transport coverage

### DIFF
--- a/cmd/agent-compose/rpc_transport_contract_test.go
+++ b/cmd/agent-compose/rpc_transport_contract_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestDaemonHTTPRouteAllowlist(t *testing.T) {
+	app, cancel := newTestDaemonApp(t, "127.0.0.1:0", nil)
+	defer cancel()
+
+	allowed := map[string]string{
+		"GET /api/version":                                                       "bootstrap",
+		"GET /api/null":                                                          "bootstrap",
+		"POST /api/webhooks/:topic":                                              "webhook ingress",
+		"GET /api/webhook-sources":                                               "webhook administration and event queries",
+		"PUT /api/webhook-sources/:source_id":                                    "webhook administration and event queries",
+		"DELETE /api/webhook-sources/:source_id":                                 "webhook administration and event queries",
+		"GET /api/events":                                                        "webhook administration and event queries",
+		"GET /api/events/:event_id":                                              "webhook administration and event queries",
+		"GET /api/events/:event_id/sessions":                                     "webhook administration and event queries",
+		"GET /api/events/:event_id/sandboxes":                                    "webhook administration and event queries",
+		"GET /api/events/:event_id/runs":                                         "webhook administration and event queries",
+		"GET /api/agent-compose/workspaces/:workspaceID/files":                   "workspace data plane",
+		"POST /api/agent-compose/workspaces/:workspaceID/upload":                 "workspace data plane",
+		"GET /api/agent-compose/workspaces/:workspaceID/download":                "workspace data plane",
+		"GET /jupyter/:sessionID":                                                "Jupyter proxy",
+		"ANY /jupyter/:sessionID/*":                                              "Jupyter proxy",
+		"POST /api/runtime/sandboxes/:sandbox_id/llm/openai/v1/responses":        "runtime provider-compatible LLM facade",
+		"POST /api/runtime/sandboxes/:sandbox_id/llm/openai/v1/chat/completions": "runtime provider-compatible LLM facade",
+		"POST /api/runtime/sandboxes/:sandbox_id/llm/anthropic/v1/messages":      "runtime provider-compatible LLM facade",
+	}
+
+	var unexpected []string
+	seen := make(map[string]bool, len(allowed))
+	for _, route := range app.Echo.Routes() {
+		if strings.HasPrefix(route.Path, "/agentcompose.v2.") ||
+			strings.HasPrefix(route.Path, "/health.v1.") {
+			continue
+		}
+		if route.Path == "/jupyter/:sessionID/*" {
+			seen["ANY "+route.Path] = true
+			continue
+		}
+		key := route.Method + " " + route.Path
+		if _, ok := allowed[key]; !ok {
+			unexpected = append(unexpected, key)
+			continue
+		}
+		seen[key] = true
+	}
+	var missing []string
+	for route := range allowed {
+		if !seen[route] {
+			missing = append(missing, route)
+		}
+	}
+	sort.Strings(unexpected)
+	sort.Strings(missing)
+	if len(unexpected) > 0 || len(missing) > 0 {
+		t.Fatalf("HTTP route allowlist drifted; unexpected=%v missing=%v", unexpected, missing)
+	}
+}
+
+// TestDaemonV2RPCInventoryReachesConcreteHandlers is intentionally driven by
+// the protobuf descriptor. Adding an RPC without registering a concrete daemon
+// handler therefore fails this test without requiring a second hand-maintained
+// list of protocol methods.
+func TestDaemonV2RPCInventoryReachesConcreteHandlers(t *testing.T) {
+	app, cancel := newTestDaemonApp(t, "127.0.0.1:0", nil)
+	defer cancel()
+
+	server := httptest.NewServer(app.Echo)
+	defer server.Close()
+
+	services := agentcomposev2.File_agentcompose_v2_agentcompose_proto.Services()
+	methodCount := 0
+	for serviceIndex := 0; serviceIndex < services.Len(); serviceIndex++ {
+		service := services.Get(serviceIndex)
+		servicePath := "/" + string(service.FullName()) + "/"
+		if !hasRoute(app, "POST", servicePath+"*") {
+			t.Errorf("Connect route %s* is not registered", servicePath)
+		}
+
+		methods := service.Methods()
+		for methodIndex := 0; methodIndex < methods.Len(); methodIndex++ {
+			method := methods.Get(methodIndex)
+			methodCount++
+			t.Run(string(method.FullName()), func(t *testing.T) {
+				t.Parallel()
+				assertRPCReachesConcreteHandler(t, server, method)
+			})
+		}
+	}
+
+	if services.Len() == 0 || methodCount == 0 {
+		t.Fatalf("empty v2 descriptor inventory: services=%d methods=%d", services.Len(), methodCount)
+	}
+	t.Logf("verified descriptor inventory: services=%d methods=%d", services.Len(), methodCount)
+}
+
+func assertRPCReachesConcreteHandler(t *testing.T, server *httptest.Server, method protoreflect.MethodDescriptor) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	procedure := "/" + string(method.FullName())
+	client := connect.NewClient[dynamicpb.Message, dynamicpb.Message](
+		server.Client(),
+		server.URL+procedure,
+		connect.WithSchema(method),
+	)
+	request := dynamicpb.NewMessage(method.Input())
+
+	var err error
+	switch {
+	case method.IsStreamingClient():
+		stream := client.CallBidiStream(ctx)
+		if sendErr := stream.Send(request); sendErr != nil {
+			err = sendErr
+			break
+		}
+		if closeErr := stream.CloseRequest(); closeErr != nil {
+			err = closeErr
+			break
+		}
+		_, err = stream.Receive()
+		_ = stream.CloseResponse()
+	case method.IsStreamingServer():
+		stream, callErr := client.CallServerStream(ctx, connect.NewRequest(request))
+		if callErr != nil {
+			err = callErr
+			break
+		}
+		if !stream.Receive() {
+			err = stream.Err()
+		}
+		_ = stream.Close()
+	default:
+		_, err = client.CallUnary(ctx, connect.NewRequest(request))
+	}
+
+	defaultFallback := fmt.Sprintf("%s is not implemented", strings.TrimPrefix(procedure, "/"))
+	if connect.CodeOf(err) == connect.CodeUnimplemented && strings.Contains(err.Error(), defaultFallback) {
+		t.Fatalf("RPC reached generated Unimplemented fallback: %v", err)
+	}
+}

--- a/docs/design/control_plane_transport_contract.md
+++ b/docs/design/control_plane_transport_contract.md
@@ -1,0 +1,102 @@
+# Control-plane transport contract
+
+## Scope
+
+Connect RPC is the only control-plane transport for operations performed by the
+CLI or Web UI against a running daemon. Local compose and `.env` authoring,
+daemon process lifecycle, and the data-plane and bootstrap exceptions below do
+not violate this rule.
+
+The authoritative RPC inventory is
+`agentcompose.v2.File_agentcompose_v2_agentcompose_proto`. The transport
+contract test enumerates that descriptor, starts an in-process daemon, invokes
+every procedure over a real Connect transport, and rejects the generated
+`UnimplementedXServiceHandler` error. It covers unary, server-streaming, and
+bidirectional-streaming methods with bounded contexts. Consequently, the
+service and method counts in this document are informational rather than a
+second source of truth. At the time this contract was introduced the descriptor
+contained 12 services and 73 methods.
+
+An RPC may deliberately return `CodeUnimplemented` for an unsupported compiled
+or runtime capability. That is a business result from a concrete handler and is
+distinct from the generated fallback error `<fully-qualified RPC> is not
+implemented`, which fails the contract test.
+
+## CLI command to RPC matrix
+
+Aliases have the same transport behavior as their canonical command. A
+fallback listed below is an RPC-to-RPC compatibility fallback; none accesses a
+daemon controller or store directly.
+
+| CLI operation | Connect RPC(s) | Stream | Fallback or local responsibility |
+| --- | --- | --- | --- |
+| `project up`, `up` | `ProjectService.ValidateProject`, `ApplyProject` | no | Reads compose and `.env` locally before RPC |
+| `project ls` | `ProjectService.ListProjects` | no | none |
+| `project down`, `down` | `GetProject`, `ListSchedulers`, `SetSchedulerEnabled`, `ListSandboxes`, `StopSandbox` | no | local compose only selects the project |
+| `agent ls`, `ls` | `ProjectService.GetProject` | no | none |
+| `run` | `ResourceService.ResolveID`, `RunService.RunAgent`, `RunAgentStream`, or `RunAttach` | server or bidi | streaming mode selects the matching RPC |
+| `exec` | `ResourceService.ResolveID`, `ExecService.Exec`, `ExecStream`, or `ExecAttach` | server or bidi | streaming mode selects the matching RPC |
+| `logs` | `GetProject`, `ListRuns`, `ListRunEvents`, `FollowRunLogs` | optional server | non-follow compatibility stays on listed RPCs |
+| `scheduler ls`, `inspect` | `GetProject`, `GetScheduler`, `ListSchedulers`, `ListSchedulerEvents`, `GetSchedulerRun` | no | reference resolution uses `ResourceService.ResolveID` where required |
+| `scheduler invoke`, `trigger` | `InvokeScheduler`, `RunScheduler`, `StartSchedulerRun` | no | none |
+| `scheduler runs`, `logs` | `ListSchedulerRuns`, `ListSchedulerEvents`, `StreamSchedulerRuns`, `StreamProjectSchedulerEvents` | optional server | non-follow compatibility stays on listed RPCs |
+| `scheduler stop`, `prune` | `StopSchedulerRun`, `PruneSchedulerRuns` | no | none |
+| `ps`, `sandbox ls` | `SandboxService.ListSandboxes` | no | none |
+| `stop`, `resume`, `rm` and `sandbox` equivalents | `GetSandbox`, `StopSandbox`, `ResumeSandbox`, `RemoveSandbox` | no | none |
+| `sandbox prune` | `SandboxService.PruneSandboxes` | no | older-daemon unsupported is reported to the user |
+| `stats` | `SandboxService.GetSandboxStats` | no | runtime capability unsupported is a concrete-handler result |
+| `images`, `pull`, `build`, `rmi` and `image` equivalents | `ImageService.ListImages`, `PullImage`, `BuildImage`, `RemoveImage`, `InspectImage` | build is server-streaming | none |
+| `cache ls`, `inspect`, `prune`, `rm` | matching `CacheService` RPC | no | none |
+| `volume ls`, `create`, `inspect`, `prune`, `rm` | matching `VolumeService` RPC | no | none |
+| generic `inspect` | `ResourceService.ResolveID` then the matching project/run/sandbox/image/cache/volume RPC | no | none |
+| `config` | none | no | local authoring: parse, validate, normalize, and redact compose data |
+| `daemon`, `version`, `status`, `auth` | none | no | process/bootstrap responsibility; `status` and auth discovery use approved bootstrap HTTP endpoints |
+
+## Web operation to RPC matrix
+
+Browser clients use the generated Connect-Web client for these control-plane
+capabilities. Page layout is intentionally not part of this stable contract.
+
+| Web operation | Connect service and methods |
+| --- | --- |
+| Project validation/apply/list/get/remove/watch | `ProjectService.ValidateProject`, `ApplyProject`, `ListProjects`, `GetProject`, `RemoveProject`, `WatchProject` |
+| Run start/stream/attach/stop/log/events | `RunService.RunAgent`, `StartRun`, `RunAgentStream`, `RunAttach`, `StopRun`, `FollowRunLogs`, `ListRunEvents`, `ListSandboxRunEvents` |
+| Scheduler configuration, invocation, runs, events, and streams | the scheduler methods on `ProjectService` |
+| Sandbox list/get/history/watch/lifecycle/stats | `SandboxService` |
+| Interactive execution | `ExecService.ExecAttach`; non-interactive execution uses `Exec` or `ExecStream` |
+| Image/cache/volume management | `ImageService`, `CacheService`, `VolumeService` |
+| Settings and workspace presets | `SettingsService` |
+| Capability status and catalog | `CapabilityService` |
+| Dashboard overview and watch | `DashboardService` |
+| Control-plane LLM generation | `LLMService.Generate` |
+| Polymorphic identifier lookup | `ResourceService.ResolveID` |
+
+## Approved non-Connect HTTP routes
+
+The exact route set is executable policy in `TestDaemonHTTPRouteAllowlist`.
+Adding a route requires updating that test and architecture review of its
+category. The approved categories are:
+
+| Category | Routes | Reason |
+| --- | --- | --- |
+| Bootstrap | `GET /api/version`, `GET /api/null`, Health Connect service | daemon discovery, compatibility, and health before a control client is established |
+| Webhook/event boundary | `/api/webhooks/:topic`, `/api/webhook-sources*`, `/api/events*` | inbound integration and its event-source/query compatibility surface; it must not grow into general project/run control |
+| Jupyter proxy | configured Jupyter base path under `/jupyter/:sandbox` | protocol and browser proxy data plane |
+| Workspace file proxy | `/api/agent-compose/workspaces/:workspace/files`, `/upload`, `/download` | binary/file data plane |
+| Runtime LLM facade | `/api/runtime/sandboxes/:sandbox/llm/openai/v1/*`, `/anthropic/v1/messages` | provider-compatible workload API, not daemon control |
+
+Static browser entry points may be added only at the process/static-serving
+boundary and must be explicitly allowlisted. A project, run, scheduler,
+sandbox, image, cache, volume, settings, capability, or dashboard operation is
+not eligible for this exception merely because it is called from a browser.
+
+## Change gate
+
+- A proto change is picked up automatically by descriptor traversal; a new RPC
+  fails if its daemon route or concrete handler is missing.
+- A new HTTP route fails the exact allowlist test.
+- A new daemon-facing CLI or Web operation must update the matrices above and
+  use a generated Connect client. Reviews should reject imports of daemon
+  controllers or stores from `cmd/agent-compose` or browser code.
+- Streaming checks use per-RPC bounded contexts and protocol handshakes; they do
+  not use sleeps.


### PR DESCRIPTION
## Summary

  - Add a descriptor-driven transport contract test that enumerates every `agentcompose.v2` service and RPC.
  - Exercise unary, server-streaming, and bidirectional-streaming RPCs through an in-process daemon using real Connect transport.
  - Fail when an RPC route is missing or reaches a generated `UnimplementedXServiceHandler` fallback, while preserving concrete-handler `CodeUnimplemented`
  results for unsupported runtime capabilities.
  - Add an explicit allowlist gate for approved non-Connect HTTP data-plane and bootstrap routes.
  - Document the CLI command → RPC matrix, Web operation → RPC matrix, HTTP exceptions, and change-gate policy.

  At the time of this change, the descriptor contains 12 services and 73 RPCs. The test derives the inventory dynamically and does not hard-code these
  counts.

  Closes #477.

  ## Testing

  - `go test ./cmd/agent-compose -count=1`
  - `go test -race ./cmd/agent-compose -run 'TestDaemon(V2RPCInventoryReachesConcreteHandlers|HTTPRouteAllowlist)' -count=1`
  - `task lint`
  - `task build`
  - `task test`
  - `git diff --check`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.