### PR TITLE
fix(cli): 修复 scheduler JSON 项目摘要

### DIFF
--- a/cmd/agent-compose/cli_runtime_project.go
+++ b/cmd/agent-compose/cli_runtime_project.go
@@ -12,9 +12,10 @@ import (
 )
 
 type composeRuntimeProject struct {
-	composePath string
-	project     *agentcomposev2.Project
-	spec        *compose.NormalizedProjectSpec
+	composePath   string
+	project       *agentcomposev2.Project
+	spec          *compose.NormalizedProjectSpec
+	summaryLoaded bool
 }
 
 type composeRuntimeProjectSelection struct {
@@ -70,9 +71,10 @@ func resolveComposeRuntimeProject(ctx context.Context, client agentcomposev2conn
 		return composeRuntimeProject{}, fmt.Errorf("get project %s: response did not include a project", selection.requestedName)
 	}
 	return composeRuntimeProject{
-		composePath: selection.composePath,
-		project:     project,
-		spec:        normalizedRuntimeProjectSpec(project),
+		composePath:   selection.composePath,
+		project:       project,
+		spec:          normalizedRuntimeProjectSpec(project),
+		summaryLoaded: true,
 	}, nil
 }
 

--- a/cmd/agent-compose/cli_scheduler_command.go
+++ b/cmd/agent-compose/cli_scheduler_command.go
@@ -72,8 +72,8 @@ func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options 
 		}
 		agentRef = args[0]
 	}
-	project := composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: runtimeProject.name()}
 	if cli.JSON {
+		project := schedulerProjectOutput(cmd.Context(), clients.project, runtimeProject)
 		writer, err := newSchedulerJSONStreamWriter[composeSchedulerRunItem](cmd.OutOrStdout(), schedulerRunsJSONPrefix{Project: project}, "runs")
 		if err != nil {
 			return err
@@ -155,8 +155,8 @@ func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options 
 		}
 		triggerID = resolvedTriggerID
 	}
-	project := composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: runtimeProject.name()}
 	if cli.JSON {
+		project := schedulerProjectOutput(cmd.Context(), clients.project, runtimeProject)
 		writer, err := newSchedulerJSONStreamWriter[composeSchedulerLogEvent](cmd.OutOrStdout(), schedulerLogsJSONPrefix{Project: project, Run: selected}, "events")
 		if err != nil {
 			return err
@@ -193,7 +193,7 @@ func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, optio
 	}
 	normalized := runtimeProject.spec
 	projectID := runtimeProject.id()
-	output := composeSchedulerInspectOutput{Project: composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: runtimeProject.name()}}
+	output := composeSchedulerInspectOutput{}
 	ref := strings.TrimSpace(rawRef)
 	if schedulerRef := strings.TrimSpace(options.SchedulerRef); schedulerRef != "" {
 		trigger, err := resolveComposeSchedulerTrigger(cmd.Context(), clients, normalized, projectID, schedulerRef, ref)
@@ -243,6 +243,7 @@ func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, optio
 		}
 	}
 	if cli.JSON {
+		output.Project = schedulerProjectOutput(cmd.Context(), clients.project, runtimeProject)
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
 			return err

--- a/cmd/agent-compose/cli_scheduler_output.go
+++ b/cmd/agent-compose/cli_scheduler_output.go
@@ -3,11 +3,14 @@ package main
 import (
 	"agent-compose/pkg/agentcompose/api"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+	"context"
 	"fmt"
 	"io"
 	"strings"
 	"text/tabwriter"
 
+	"connectrpc.com/connect"
 	"gopkg.in/yaml.v3"
 )
 
@@ -110,6 +113,62 @@ func writeSchedulerLogsText(out io.Writer, output composeSchedulerLogsOutput) er
 	return nil
 }
 
+type composeSchedulerProjectOutput struct {
+	ID              string  `json:"id"`
+	Name            string  `json:"name"`
+	ShortID         string  `json:"short_id"`
+	SourcePath      string  `json:"source_path,omitempty"`
+	CurrentRevision *uint64 `json:"current_revision,omitempty"`
+	SpecHash        string  `json:"spec_hash,omitempty"`
+	AgentCount      *uint32 `json:"agent_count,omitempty"`
+	SchedulerCount  *uint32 `json:"scheduler_count,omitempty"`
+}
+
+func schedulerProjectOutput(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, runtimeProject composeRuntimeProject) composeSchedulerProjectOutput {
+	// 权威摘要来自 daemon 已应用状态，字段规范化由 daemon 负责。此处与
+	// composeProjectSummaryOutput 同源直接映射，保证 scheduler JSON 的 project
+	// 字段与 `inspect project --json` 一致。
+	if runtimeProject.summaryLoaded {
+		return schedulerProjectOutputFromSummary(runtimeProject.project.GetSummary())
+	}
+
+	// 退化路径：只能解析本地项目身份时，按需补全摘要。补全仅服务 JSON 展示，
+	// scheduler 历史查询不依赖当前部署状态，失败时退化为最小项目引用。
+	response, err := client.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: runtimeProject.id()}},
+	}))
+	if err == nil && response != nil && response.Msg != nil {
+		if loadedSummary := response.Msg.GetProject().GetSummary(); strings.TrimSpace(loadedSummary.GetProjectId()) != "" {
+			return schedulerProjectOutputFromSummary(loadedSummary)
+		}
+	}
+
+	summary := runtimeProject.project.GetSummary()
+	return composeSchedulerProjectOutput{
+		ID:         displayOpaqueID(summary.GetProjectId()),
+		Name:       summary.GetName(),
+		ShortID:    shortOpaqueID(summary.GetProjectId()),
+		SourcePath: firstNonEmptyString(summary.GetSourcePath(), runtimeProject.composePath),
+	}
+}
+
+// schedulerProjectOutputFromSummary 映射权威项目摘要，数值字段用指针保留合法的零值。
+func schedulerProjectOutputFromSummary(summary *agentcomposev2.ProjectSummary) composeSchedulerProjectOutput {
+	currentRevision := summary.GetCurrentRevision()
+	agentCount := summary.GetAgentCount()
+	schedulerCount := summary.GetSchedulerCount()
+	return composeSchedulerProjectOutput{
+		ID:              displayOpaqueID(summary.GetProjectId()),
+		Name:            summary.GetName(),
+		ShortID:         shortOpaqueID(summary.GetProjectId()),
+		SourcePath:      summary.GetSourcePath(),
+		CurrentRevision: &currentRevision,
+		SpecHash:        summary.GetSpecHash(),
+		AgentCount:      &agentCount,
+		SchedulerCount:  &schedulerCount,
+	}
+}
+
 type composeProjectSchedulerOutput struct {
 	AgentName    string `json:"agent_name"`
 	SchedulerID  string `json:"scheduler_id"`
@@ -118,31 +177,31 @@ type composeProjectSchedulerOutput struct {
 }
 
 type composeSchedulerListOutput struct {
-	Project  composeUpProjectOutput        `json:"project"`
+	Project  composeSchedulerProjectOutput `json:"project"`
 	Triggers []composeSchedulerTriggerItem `json:"triggers"`
 }
 
 type composeSchedulerInspectOutput struct {
-	Project    composeUpProjectOutput       `json:"project"`
-	Resource   string                       `json:"resource"`
-	Source     string                       `json:"source"`
-	AgentName  string                       `json:"agent_name"`
-	Scheduler  *composeSchedulerItem        `json:"scheduler,omitempty"`
-	Trigger    *composeSchedulerTriggerItem `json:"trigger,omitempty"`
-	Run        *composeSchedulerRunItem     `json:"run,omitempty"`
-	Definition map[string]any               `json:"definition,omitempty"`
-	Registered map[string]any               `json:"registered,omitempty"`
+	Project    composeSchedulerProjectOutput `json:"project"`
+	Resource   string                        `json:"resource"`
+	Source     string                        `json:"source"`
+	AgentName  string                        `json:"agent_name"`
+	Scheduler  *composeSchedulerItem         `json:"scheduler,omitempty"`
+	Trigger    *composeSchedulerTriggerItem  `json:"trigger,omitempty"`
+	Run        *composeSchedulerRunItem      `json:"run,omitempty"`
+	Definition map[string]any                `json:"definition,omitempty"`
+	Registered map[string]any                `json:"registered,omitempty"`
 }
 
 type composeSchedulerRunsOutput struct {
-	Project composeUpProjectOutput    `json:"project"`
-	Runs    []composeSchedulerRunItem `json:"runs"`
+	Project composeSchedulerProjectOutput `json:"project"`
+	Runs    []composeSchedulerRunItem     `json:"runs"`
 }
 
 type composeSchedulerLogsOutput struct {
-	Project composeUpProjectOutput     `json:"project"`
-	Run     *composeSchedulerRunItem   `json:"run,omitempty"`
-	Events  []composeSchedulerLogEvent `json:"events"`
+	Project composeSchedulerProjectOutput `json:"project"`
+	Run     *composeSchedulerRunItem      `json:"run,omitempty"`
+	Events  []composeSchedulerLogEvent    `json:"events"`
 }
 
 func composeProjectSchedulerOutputFromProto(scheduler *agentcomposev2.ProjectScheduler) composeProjectSchedulerOutput {

--- a/cmd/agent-compose/cli_scheduler_output_test.go
+++ b/cmd/agent-compose/cli_scheduler_output_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestSchedulerProjectOutput(t *testing.T) {
+	const (
+		projectID   = "project-summary-output"
+		projectName = "summary-output"
+		sourcePath  = "/work/agent-compose.yml"
+	)
+	localProject := &agentcomposev2.Project{Summary: &agentcomposev2.ProjectSummary{
+		ProjectId: projectID, Name: projectName, SourcePath: sourcePath,
+	}}
+
+	t.Run("权威摘要保留合法零值", func(t *testing.T) {
+		project := testCLIProject(projectID, projectName, sourcePath)
+		project.Summary.CurrentRevision = 0
+		project.Summary.AgentCount = 0
+		project.Summary.SchedulerCount = 0
+		server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+			getProject: func(context.Context, *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				t.Fatal("权威摘要不应重复请求 GetProject")
+				return nil, nil
+			},
+		}})
+		t.Cleanup(server.Close)
+
+		output := schedulerProjectOutput(t.Context(), agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL), composeRuntimeProject{
+			composePath: sourcePath, project: project, summaryLoaded: true,
+		})
+		assertSchedulerProjectOutputMatchesSummary(t, output, project.Summary)
+	})
+
+	t.Run("仅身份模式按需补全摘要", func(t *testing.T) {
+		project := testCLIProject(projectID, projectName, "/daemon/agent-compose.yml")
+		var requests int
+		server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+			getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				requests++
+				if req.Msg.GetProject().GetProjectId() != projectID || req.Msg.GetIncludeSpec() {
+					t.Fatalf("GetProject request = %#v", req.Msg)
+				}
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
+			},
+		}})
+		t.Cleanup(server.Close)
+
+		output := schedulerProjectOutput(t.Context(), agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL), composeRuntimeProject{
+			composePath: sourcePath, project: localProject,
+		})
+		if requests != 1 {
+			t.Fatalf("GetProject calls = %d, want 1", requests)
+		}
+		assertSchedulerProjectOutputMatchesSummary(t, output, project.Summary)
+	})
+
+	t.Run("摘要不可用时省略未知字段", func(t *testing.T) {
+		server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{}})
+		t.Cleanup(server.Close)
+
+		output := schedulerProjectOutput(t.Context(), agentcomposev2connect.NewProjectServiceClient(server.Client(), server.URL), composeRuntimeProject{
+			composePath: sourcePath, project: localProject,
+		})
+		if output.ID != displayOpaqueID(projectID) || output.Name != projectName || output.ShortID != shortOpaqueID(projectID) || output.SourcePath != sourcePath {
+			t.Fatalf("最小项目摘要 = %#v", output)
+		}
+		if output.CurrentRevision != nil || output.SpecHash != "" || output.AgentCount != nil || output.SchedulerCount != nil {
+			t.Fatalf("最小项目摘要包含未知状态 = %#v", output)
+		}
+		assertSchedulerProjectFieldsOmitted(t, output)
+	})
+}
+
+func assertSchedulerProjectJSONMatchesSummary(t *testing.T, data string, summary *agentcomposev2.ProjectSummary) {
+	t.Helper()
+	var envelope struct {
+		Project composeSchedulerProjectOutput `json:"project"`
+	}
+	if err := json.Unmarshal([]byte(data), &envelope); err != nil {
+		t.Fatalf("解析 scheduler JSON 输出: %v\n%s", err, data)
+	}
+	assertSchedulerProjectOutputMatchesSummary(t, envelope.Project, summary)
+}
+
+func assertSchedulerProjectJSONMinimal(t *testing.T, data string, summary *agentcomposev2.ProjectSummary) {
+	t.Helper()
+	var envelope struct {
+		Project composeSchedulerProjectOutput `json:"project"`
+	}
+	if err := json.Unmarshal([]byte(data), &envelope); err != nil {
+		t.Fatalf("解析 scheduler JSON 输出: %v\n%s", err, data)
+	}
+	project := envelope.Project
+	if project.ID != displayOpaqueID(summary.GetProjectId()) || project.Name != summary.GetName() || project.ShortID != shortOpaqueID(summary.GetProjectId()) || project.SourcePath != summary.GetSourcePath() {
+		t.Fatalf("最小项目摘要 = %#v, 本地摘要 = %#v", project, summary)
+	}
+	if project.CurrentRevision != nil || project.SpecHash != "" || project.AgentCount != nil || project.SchedulerCount != nil {
+		t.Fatalf("最小项目摘要包含未知状态 = %#v", project)
+	}
+	assertSchedulerProjectFieldsOmitted(t, project)
+}
+
+func testSchedulerProjectSummary(t *testing.T, name, sourcePath string) *agentcomposev2.ProjectSummary {
+	t.Helper()
+	projectID, err := domain.StableProjectID(name, sourcePath)
+	if err != nil {
+		t.Fatalf("StableProjectID returned error: %v", err)
+	}
+	return testCLIProject(projectID, name, sourcePath).GetSummary()
+}
+
+func assertSchedulerProjectOutputMatchesSummary(t *testing.T, output composeSchedulerProjectOutput, summary *agentcomposev2.ProjectSummary) {
+	t.Helper()
+	if output.ID != displayOpaqueID(summary.GetProjectId()) || output.Name != summary.GetName() || output.ShortID != shortOpaqueID(summary.GetProjectId()) || output.SourcePath != summary.GetSourcePath() ||
+		output.CurrentRevision == nil || *output.CurrentRevision != summary.GetCurrentRevision() || output.SpecHash != summary.GetSpecHash() ||
+		output.AgentCount == nil || *output.AgentCount != summary.GetAgentCount() || output.SchedulerCount == nil || *output.SchedulerCount != summary.GetSchedulerCount() {
+		t.Fatalf("scheduler 项目摘要 = %#v, daemon 摘要 = %#v", output, summary)
+	}
+}
+
+func assertSchedulerProjectFieldsOmitted(t *testing.T, output composeSchedulerProjectOutput) {
+	t.Helper()
+	data, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("编码 scheduler 项目摘要: %v", err)
+	}
+	for _, field := range []string{"current_revision", "spec_hash", "agent_count", "scheduler_count"} {
+		if strings.Contains(string(data), `"`+field+`"`) {
+			t.Fatalf("最小项目摘要不应包含 %q: %s", field, data)
+		}
+	}
+}

--- a/cmd/agent-compose/cli_scheduler_prune.go
+++ b/cmd/agent-compose/cli_scheduler_prune.go
@@ -42,7 +42,7 @@ type composeSchedulerPruneResidue struct {
 type composeSchedulerPruneOutput struct {
 	RecordScope string                         `json:"record_scope"`
 	DryRun      bool                           `json:"dry_run"`
-	Project     composeUpProjectOutput         `json:"project"`
+	Project     composeSchedulerProjectOutput  `json:"project"`
 	Scheduler   string                         `json:"scheduler,omitempty"`
 	TriggerID   string                         `json:"trigger_id,omitempty"`
 	Statuses    []string                       `json:"statuses,omitempty"`
@@ -109,7 +109,9 @@ func runComposeSchedulerPruneCommand(cmd interface {
 		return commandExitErrorForConnect(fmt.Errorf("prune scheduler runs: %w", err))
 	}
 	output := composeSchedulerPruneOutputFromResponse(response.Msg)
-	output.Project = composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: runtimeProject.name()}
+	if cli.JSON {
+		output.Project = schedulerProjectOutput(cmd.Context(), clients.project, runtimeProject)
+	}
 	output.Scheduler = agentName
 	output.TriggerID = triggerID
 	output.Statuses = statusNames

--- a/cmd/agent-compose/cli_scheduler_prune_test.go
+++ b/cmd/agent-compose/cli_scheduler_prune_test.go
@@ -70,6 +70,9 @@ func TestIntegrationCLISchedulerPruneMapsFiltersAndJSONStats(t *testing.T) {
 	composePath := writeSchedulerPruneCompose(t)
 	var captured *agentcomposev2.PruneSchedulerRunsRequest
 	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+		getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+			return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "scheduler-prune-test", composePath)}), nil
+		},
 		pruneSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error) {
 			captured = req.Msg
 			return connect.NewResponse(&agentcomposev2.PruneSchedulerRunsResponse{
@@ -105,6 +108,7 @@ func TestIntegrationCLISchedulerPruneMapsFiltersAndJSONStats(t *testing.T) {
 		output.Scheduler != "reviewer" || output.TriggerID != captured.GetTriggerId() || !slices.Equal(output.Statuses, []string{"failed", "succeeded"}) {
 		t.Fatalf("output=%#v", output)
 	}
+	assertSchedulerProjectJSONMatchesSummary(t, stdout, testSchedulerProjectSummary(t, "scheduler-prune-test", composePath))
 }
 
 func TestIntegrationCLISchedulerPruneSupportsHistoricalTriggerID(t *testing.T) {

--- a/cmd/agent-compose/cli_scheduler_query.go
+++ b/cmd/agent-compose/cli_scheduler_query.go
@@ -44,11 +44,9 @@ func runComposeSchedulerListCommand(cmd *cobra.Command, cli cliOptions, options 
 	if err != nil {
 		return err
 	}
-	output := composeSchedulerListOutput{
-		Project:  composeUpProjectOutput{ID: displayOpaqueID(projectID), Name: runtimeProject.name()},
-		Triggers: triggers,
-	}
+	output := composeSchedulerListOutput{Triggers: triggers}
 	if cli.JSON {
+		output.Project = schedulerProjectOutput(cmd.Context(), clients.project, runtimeProject)
 		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
 			return err

--- a/cmd/agent-compose/cli_scheduler_stream.go
+++ b/cmd/agent-compose/cli_scheduler_stream.go
@@ -258,10 +258,10 @@ func (w *schedulerJSONStreamWriter[T]) start() error {
 }
 
 type schedulerRunsJSONPrefix struct {
-	Project composeUpProjectOutput `json:"project"`
+	Project composeSchedulerProjectOutput `json:"project"`
 }
 
 type schedulerLogsJSONPrefix struct {
-	Project composeUpProjectOutput   `json:"project"`
-	Run     *composeSchedulerRunItem `json:"run,omitempty"`
+	Project composeSchedulerProjectOutput `json:"project"`
+	Run     *composeSchedulerRunItem      `json:"run,omitempty"`
 }

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -351,6 +351,7 @@ agents:
 		!strings.Contains(jsonOut, `"trigger_short_id": "`) || strings.Contains(jsonOut, "managed_loader") {
 		t.Fatalf("scheduler ls --json code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
 	}
+	assertSchedulerProjectJSONMatchesSummary(t, jsonOut, testCLIProject(projectID, "cli-scheduler-list", composePath).GetSummary())
 }
 
 func TestComposeUpUsesDistinctStableTriggerIDs(t *testing.T) {
@@ -484,16 +485,25 @@ agents:
 	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, `"sandbox_ids": [`) || !strings.Contains(jsonOut, sandboxID) {
 		t.Fatalf("scheduler runs --json code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
 	}
+	projectSummary := testSchedulerProjectSummary(t, "cli-scheduler-observability", composePath)
+	assertSchedulerProjectJSONMatchesSummary(t, jsonOut, projectSummary)
 
 	stdout, stderr, _, exitCode = executeCLICommand("scheduler", "logs", runID[:12], "--host", server.URL, "--file", composePath)
 	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, "scheduler.status") || !strings.Contains(stdout, "scheduler.agent.activity") || strings.Index(stdout, "started") > strings.Index(stdout, "done") {
 		t.Fatalf("scheduler logs code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 
+	jsonOut, jsonErr, _, jsonCode = executeCLICommand("scheduler", "logs", runID[:12], "--json", "--host", server.URL, "--file", composePath)
+	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, `"message": "started"`) || !strings.Contains(jsonOut, `"message": "done"`) {
+		t.Fatalf("scheduler logs --json code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
+	}
+	assertSchedulerProjectJSONMatchesSummary(t, jsonOut, projectSummary)
+
 	jsonOut, jsonErr, _, jsonCode = executeCLICommand("scheduler", "inspect", runID[:12], "--json", "--host", server.URL, "--file", composePath)
 	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, `"resource": "run"`) || !strings.Contains(jsonOut, sandboxID) {
 		t.Fatalf("scheduler inspect run code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
 	}
+	assertSchedulerProjectJSONMatchesSummary(t, jsonOut, projectSummary)
 
 	jsonOut, jsonErr, _, jsonCode = executeCLICommand("scheduler", "inspect", legacyRunID, "--json", "--host", server.URL, "--file", composePath)
 	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, legacyRunID) {
@@ -504,8 +514,8 @@ agents:
 	if jsonCode != 0 || jsonErr != "" || !strings.Contains(jsonOut, `"resource": "scheduler"`) || !strings.Contains(jsonOut, `"agent_name": "reviewer"`) {
 		t.Fatalf("scheduler inspect scheduler code/stdout/stderr = %d / %q / %q", jsonCode, jsonOut, jsonErr)
 	}
-	if getSchedulerRunCalls != 3 {
-		t.Fatalf("GetSchedulerRun calls = %d, want 3; scheduler name inspection must not probe runs", getSchedulerRunCalls)
+	if getSchedulerRunCalls != 4 {
+		t.Fatalf("GetSchedulerRun calls = %d, want 4; scheduler name inspection must not probe runs", getSchedulerRunCalls)
 	}
 
 	_, stderr, _, exitCode = executeCLICommand("scheduler", "inspect", errorRunID, "--host", server.URL, "--file", composePath)
@@ -591,6 +601,7 @@ agents:
 	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, historicalRunID) || !strings.Contains(stdout, `"trigger_id": "`+historicalTriggerID+`"`) {
 		t.Fatalf("historical scheduler runs code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
+	assertSchedulerProjectJSONMinimal(t, stdout, testSchedulerProjectSummary(t, "cli-scheduler-historical-triggers", composePath))
 
 	stdout, stderr, _, exitCode = executeCLICommand("scheduler", "logs", "--trigger", historicalTriggerID, "--json", "--host", server.URL, "--file", composePath)
 	if exitCode != 0 || stderr != "" || !strings.Contains(stdout, `"id": "historical-event"`) || !strings.Contains(stdout, `"message": "historical log"`) {


### PR DESCRIPTION
## Summary

- 为 scheduler JSON 输出引入专用项目摘要模型，区分“未知字段”和合法零值。
- 在仅解析到本地项目身份时，按需调用 `GetProject(include_spec=false)` 补全权威摘要；补全失败时保留历史 runs、logs、prune 查询能力并省略未知字段。
- 统一修复 `scheduler ls`、`runs`、`logs`、`inspect` 和 `prune` 的项目摘要输出，并补充完整摘要、零值和历史查询退化场景测试。

Closes #468

<img width="1346" height="1014" alt="image" src="https://github.com/user-attachments/assets/0ecf2a2b-a274-45fc-b66f-9dad97faecca" />

## Testing

- `go test ./cmd/agent-compose`
- `task lint`
- `task build`
- `task test`：当前 macOS 环境中 installer 测试因 `/var` 是符号链接而触发安装路径安全校验，未执行到后续覆盖门禁；与本次 CLI 改动无关。
- `./scripts/with-go-toolchain.sh ./scripts/test-coverage.sh`：`cmd/agent-compose` 及此前包通过，`pkg/volumes` 因 macOS `/var` 与 `/private/var` 路径差异失败。

## Checklist

- [x] 本次不涉及公共配置、API、protobuf 或 compose schema，无需更新公共文档。
- [x] 已为用户可见行为新增或更新测试。
- [x] 未包含密钥、私有端点、内部证书或本地运行数据。