### PR TITLE
fix(api): clarify submitted project spec hash

### DIFF
--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -107,7 +107,7 @@ func runComposeUpCommand(cmd *cobra.Command, cli cliOptions) error {
 			ComposePath: composePath,
 			ProjectDir:  filepath.Dir(composePath),
 		},
-		ExpectedSpecHash: specHash,
+		SubmittedSpecHash: specHash,
 	}))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("apply project %s: %w", normalized.Name, err))

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -106,8 +106,8 @@ agents:
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("up stdout=%q stderr=%q exit=%d", stdout, stderr, exitCode)
 	}
-	if captured == nil || captured.GetExpectedSpecHash() != expectedHash {
-		t.Fatalf("Apply request = %#v, want expected hash %q", captured, expectedHash)
+	if captured == nil || captured.GetSubmittedSpecHash() != expectedHash {
+		t.Fatalf("Apply request = %#v, want submitted hash %q", captured, expectedHash)
 	}
 	gotScript := captured.GetSpec().GetAgents()[0].GetScheduler().GetScript()
 	if gotScript != script {

--- a/docs/design/project-spec-hash-contract.md
+++ b/docs/design/project-spec-hash-contract.md
@@ -1,0 +1,35 @@
+# Project spec hash contract
+
+`ValidateProjectRequest.submitted_spec_hash` and
+`ApplyProjectRequest.submitted_spec_hash` are optional integrity checks for the
+spec carried by that request. The daemon normalizes the submitted `ProjectSpec`,
+computes its hash, and compares that result with the non-empty request value. A
+mismatch is returned as a validation issue at `submitted_spec_hash`. An empty
+value skips the comparison.
+
+This check never reads the persisted project's current revision or spec hash.
+It is therefore not an optimistic-concurrency precondition: a later valid apply
+may replace an earlier apply to the same project.
+
+## Canonical form and algorithm
+
+The Go `pkg/compose` package owns normalization and the hash contract. After
+normalization, `NormalizedProjectSpec.MarshalCanonicalJSON(false)` produces the
+canonical bytes, including secrets and using the package's stable ordered wire
+shape. `NormalizedProjectSpec.Hash` computes SHA-256 over those bytes and
+encodes the result as lowercase hexadecimal prefixed with `sha256:`.
+
+Clients do not need to reproduce this algorithm to validate a project: they may
+leave `submitted_spec_hash` empty and use `ValidateProjectResponse.spec_hash`.
+The CLI computes the same normalized hash locally and sends it on apply so that
+client/server normalization drift is reported consistently.
+
+## Future concurrency preconditions
+
+Optimistic concurrency can be added compatibly with a new optional
+`expected_revision` or `expected_current_spec_hash` field. Such a field must be
+checked against persisted state, including for dry runs and unchanged applies,
+and should fail with a transport-level precondition error rather than a
+submitted-spec validation issue. If both future preconditions are provided,
+both must match (logical AND). The existing `submitted_spec_hash` check remains
+independent and keeps its request-integrity semantics.

--- a/pkg/agentcompose/app/controller_helpers_coverage_test.go
+++ b/pkg/agentcompose/app/controller_helpers_coverage_test.go
@@ -37,7 +37,7 @@ func TestAppProjectControllerHelperCoverage(t *testing.T) {
 		}},
 	}
 	normalized, issues, err := normalizeProjectRequest(validSpec, &agentcomposev2.ProjectSource{ProjectDir: "/repo"}, "mismatch")
-	if err != nil || normalized.Spec == nil || len(issues) != 1 || issues[0].Path != "expected_spec_hash" {
+	if err != nil || normalized.Spec == nil || len(issues) != 1 || issues[0].Path != "submitted_spec_hash" {
 		t.Fatalf("normalizeProjectRequest mismatch normalized=%#v issues=%#v err=%v", normalized, issues, err)
 	}
 	normalized, issues, err = normalizeProjectRequest(validSpec, &agentcomposev2.ProjectSource{ComposePath: "/repo/custom.yml"}, "")

--- a/pkg/agentcompose/app/project_controller.go
+++ b/pkg/agentcompose/app/project_controller.go
@@ -105,7 +105,7 @@ type projectControllerDelegate struct {
 }
 
 func (d projectControllerDelegate) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {
-	normalized, issues, err := normalizeProjectRequest(req.Msg.GetSpec(), req.Msg.GetSource(), req.Msg.GetExpectedSpecHash())
+	normalized, issues, err := normalizeProjectRequest(req.Msg.GetSpec(), req.Msg.GetSource(), req.Msg.GetSubmittedSpecHash())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -121,7 +121,7 @@ func (d projectControllerDelegate) ValidateProject(ctx context.Context, req *con
 }
 
 func (d projectControllerDelegate) ApplyProject(ctx context.Context, req *connect.Request[agentcomposev2.ApplyProjectRequest]) (*connect.Response[agentcomposev2.ApplyProjectResponse], error) {
-	normalized, issues, err := normalizeProjectRequest(req.Msg.GetSpec(), req.Msg.GetSource(), req.Msg.GetExpectedSpecHash())
+	normalized, issues, err := normalizeProjectRequest(req.Msg.GetSpec(), req.Msg.GetSource(), req.Msg.GetSubmittedSpecHash())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -170,7 +170,7 @@ func (d projectControllerDelegate) WatchProject(ctx context.Context, req *connec
 	return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("project watch is not implemented"))
 }
 
-func normalizeProjectRequest(spec *agentcomposev2.ProjectSpec, source *agentcomposev2.ProjectSource, expectedHash string) (projects.NormalizedProject, []projects.ValidationIssue, error) {
+func normalizeProjectRequest(spec *agentcomposev2.ProjectSpec, source *agentcomposev2.ProjectSource, submittedHash string) (projects.NormalizedProject, []projects.ValidationIssue, error) {
 	if spec == nil {
 		return projects.NormalizedProject{}, []projects.ValidationIssue{{Path: "spec", Message: "project spec is required"}}, nil
 	}
@@ -207,9 +207,9 @@ func normalizeProjectRequest(spec *agentcomposev2.ProjectSpec, source *agentcomp
 		SpecHash:   hash,
 		SourcePath: sourcePath,
 	}
-	expectedHash = strings.TrimSpace(expectedHash)
-	if expectedHash != "" && expectedHash != hash {
-		return result, []projects.ValidationIssue{{Path: "expected_spec_hash", Message: fmt.Sprintf("expected spec hash %s does not match normalized spec hash %s", expectedHash, hash)}}, nil
+	submittedHash = strings.TrimSpace(submittedHash)
+	if submittedHash != "" && submittedHash != hash {
+		return result, []projects.ValidationIssue{{Path: "submitted_spec_hash", Message: fmt.Sprintf("submitted spec hash %s does not match normalized spec hash %s", submittedHash, hash)}}, nil
 	}
 	return result, nil, nil
 }

--- a/pkg/agentcompose/app/project_submitted_hash_test.go
+++ b/pkg/agentcompose/app/project_submitted_hash_test.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"testing"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestNormalizeProjectRequestSubmittedSpecHashContract(t *testing.T) {
+	spec := &agentcomposev2.ProjectSpec{Name: "hash-contract"}
+	normalized, issues, err := normalizeProjectRequest(spec, nil, "")
+	if err != nil || len(issues) != 0 {
+		t.Fatalf("normalize without submitted hash: issues=%#v err=%v", issues, err)
+	}
+
+	for _, tc := range []struct {
+		name          string
+		submittedHash string
+		wantIssue     bool
+	}{
+		{name: "empty skips validation"},
+		{name: "matching normalized hash", submittedHash: normalized.SpecHash},
+		{name: "mismatch reports submitted field", submittedHash: "sha256:not-the-submitted-spec", wantIssue: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotIssues, gotErr := normalizeProjectRequest(spec, nil, tc.submittedHash)
+			if gotErr != nil {
+				t.Fatalf("normalize: %v", gotErr)
+			}
+			if got.SpecHash != normalized.SpecHash {
+				t.Fatalf("spec hash = %q, want %q", got.SpecHash, normalized.SpecHash)
+			}
+			if tc.wantIssue {
+				if len(gotIssues) != 1 || gotIssues[0].Path != "submitted_spec_hash" {
+					t.Fatalf("issues = %#v, want submitted_spec_hash mismatch", gotIssues)
+				}
+				return
+			}
+			if len(gotIssues) != 0 {
+				t.Fatalf("issues = %#v, want none", gotIssues)
+			}
+		})
+	}
+}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -1298,12 +1298,16 @@ func (SandboxWatchEventType) EnumDescriptor() ([]byte, []int) {
 }
 
 type ValidateProjectRequest struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	Spec             *ProjectSpec           `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
-	Source           *ProjectSource         `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
-	ExpectedSpecHash string                 `protobuf:"bytes,3,opt,name=expected_spec_hash,json=expectedSpecHash,proto3" json:"expected_spec_hash,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Spec   *ProjectSpec           `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	Source *ProjectSource         `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	// submitted_spec_hash optionally verifies the submitted spec after the server
+	// normalizes it. It is not compared with the currently stored project and is
+	// not an optimistic-concurrency precondition. An empty value skips this check.
+	// Canonicalization, encoding, and hashing are defined by pkg/compose.
+	SubmittedSpecHash string `protobuf:"bytes,3,opt,name=submitted_spec_hash,json=submittedSpecHash,proto3" json:"submitted_spec_hash,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ValidateProjectRequest) Reset() {
@@ -1350,9 +1354,9 @@ func (x *ValidateProjectRequest) GetSource() *ProjectSource {
 	return nil
 }
 
-func (x *ValidateProjectRequest) GetExpectedSpecHash() string {
+func (x *ValidateProjectRequest) GetSubmittedSpecHash() string {
 	if x != nil {
-		return x.ExpectedSpecHash
+		return x.SubmittedSpecHash
 	}
 	return ""
 }
@@ -1418,13 +1422,17 @@ func (x *ValidateProjectResponse) GetSpecHash() string {
 }
 
 type ApplyProjectRequest struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	Spec             *ProjectSpec           `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
-	Source           *ProjectSource         `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
-	ExpectedSpecHash string                 `protobuf:"bytes,3,opt,name=expected_spec_hash,json=expectedSpecHash,proto3" json:"expected_spec_hash,omitempty"`
-	DryRun           bool                   `protobuf:"varint,4,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Spec   *ProjectSpec           `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	Source *ProjectSource         `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	// submitted_spec_hash optionally verifies the submitted spec after the server
+	// normalizes it. It is not compared with the currently stored project and is
+	// not an optimistic-concurrency precondition. An empty value skips this check.
+	// Canonicalization, encoding, and hashing are defined by pkg/compose.
+	SubmittedSpecHash string `protobuf:"bytes,3,opt,name=submitted_spec_hash,json=submittedSpecHash,proto3" json:"submitted_spec_hash,omitempty"`
+	DryRun            bool   `protobuf:"varint,4,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ApplyProjectRequest) Reset() {
@@ -1471,9 +1479,9 @@ func (x *ApplyProjectRequest) GetSource() *ProjectSource {
 	return nil
 }
 
-func (x *ApplyProjectRequest) GetExpectedSpecHash() string {
+func (x *ApplyProjectRequest) GetSubmittedSpecHash() string {
 	if x != nil {
-		return x.ExpectedSpecHash
+		return x.SubmittedSpecHash
 	}
 	return ""
 }
@@ -17827,19 +17835,19 @@ var File_agentcompose_v2_agentcompose_proto protoreflect.FileDescriptor
 
 const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
-	"\"agentcompose/v2/agentcompose.proto\x12\x0fagentcompose.v2\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb0\x01\n" +
+	"\"agentcompose/v2/agentcompose.proto\x12\x0fagentcompose.v2\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb2\x01\n" +
 	"\x16ValidateProjectRequest\x120\n" +
 	"\x04spec\x18\x01 \x01(\v2\x1c.agentcompose.v2.ProjectSpecR\x04spec\x126\n" +
-	"\x06source\x18\x02 \x01(\v2\x1e.agentcompose.v2.ProjectSourceR\x06source\x12,\n" +
-	"\x12expected_spec_hash\x18\x03 \x01(\tR\x10expectedSpecHash\"\x8d\x01\n" +
+	"\x06source\x18\x02 \x01(\v2\x1e.agentcompose.v2.ProjectSourceR\x06source\x12.\n" +
+	"\x13submitted_spec_hash\x18\x03 \x01(\tR\x11submittedSpecHash\"\x8d\x01\n" +
 	"\x17ValidateProjectResponse\x12\x14\n" +
 	"\x05valid\x18\x01 \x01(\bR\x05valid\x12?\n" +
 	"\x06issues\x18\x02 \x03(\v2'.agentcompose.v2.ProjectValidationIssueR\x06issues\x12\x1b\n" +
-	"\tspec_hash\x18\x03 \x01(\tR\bspecHash\"\xc6\x01\n" +
+	"\tspec_hash\x18\x03 \x01(\tR\bspecHash\"\xc8\x01\n" +
 	"\x13ApplyProjectRequest\x120\n" +
 	"\x04spec\x18\x01 \x01(\v2\x1c.agentcompose.v2.ProjectSpecR\x04spec\x126\n" +
-	"\x06source\x18\x02 \x01(\v2\x1e.agentcompose.v2.ProjectSourceR\x06source\x12,\n" +
-	"\x12expected_spec_hash\x18\x03 \x01(\tR\x10expectedSpecHash\x12\x17\n" +
+	"\x06source\x18\x02 \x01(\v2\x1e.agentcompose.v2.ProjectSourceR\x06source\x12.\n" +
+	"\x13submitted_spec_hash\x18\x03 \x01(\tR\x11submittedSpecHash\x12\x17\n" +
 	"\adry_run\x18\x04 \x01(\bR\x06dryRun\"\xbb\x02\n" +
 	"\x14ApplyProjectResponse\x122\n" +
 	"\aproject\x18\x01 \x01(\v2\x18.agentcompose.v2.ProjectR\aproject\x12<\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -294,7 +294,11 @@ enum ResourceKind {
 message ValidateProjectRequest {
   ProjectSpec spec = 1;
   ProjectSource source = 2;
-  string expected_spec_hash = 3;
+  // submitted_spec_hash optionally verifies the submitted spec after the server
+  // normalizes it. It is not compared with the currently stored project and is
+  // not an optimistic-concurrency precondition. An empty value skips this check.
+  // Canonicalization, encoding, and hashing are defined by pkg/compose.
+  string submitted_spec_hash = 3;
 }
 
 message ValidateProjectResponse {
@@ -306,7 +310,11 @@ message ValidateProjectResponse {
 message ApplyProjectRequest {
   ProjectSpec spec = 1;
   ProjectSource source = 2;
-  string expected_spec_hash = 3;
+  // submitted_spec_hash optionally verifies the submitted spec after the server
+  // normalizes it. It is not compared with the currently stored project and is
+  // not an optimistic-concurrency precondition. An empty value skips this check.
+  // Canonicalization, encoding, and hashing are defined by pkg/compose.
+  string submitted_spec_hash = 3;
   bool dry_run = 4;
 }
 


### PR DESCRIPTION
## Summary

- Rename `expected_spec_hash` to `submitted_spec_hash` in `ValidateProjectRequest` and `ApplyProjectRequest` while preserving protobuf field number 3.
- Clarify that the field validates the normalized spec submitted in the request and is not an optimistic-concurrency precondition against persisted project state.
- Update the CLI and daemon to use the renamed field consistently.
- Document canonicalization, SHA-256 encoding, empty-value behavior, mismatch handling, and the compatibility path for future concurrency preconditions.
- Add contract tests covering an empty hash, a matching normalized hash, and a normalized hash mismatch.

Fixes chaitin/agent-compose#478

## Testing

- `go test ./pkg/agentcompose/app ./cmd/agent-compose`
- `task lint`
- `task build`
- `task test`
- `task docs:build`
- `task generate:proto`
- `git diff --check`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.