### PR TITLE
feat(api)!: freeze selector and mutation semantics

### DIFF
--- a/cmd/agent-compose/cli_daemon_lifecycle_test.go
+++ b/cmd/agent-compose/cli_daemon_lifecycle_test.go
@@ -231,8 +231,7 @@ agents:
 		Agents []struct {
 			Name   string `json:"name"`
 			Driver struct {
-				Name   string         `json:"name"`
-				Docker map[string]any `json:"docker"`
+				Name string `json:"name"`
 			} `json:"driver"`
 		} `json:"agents"`
 	}
@@ -245,7 +244,7 @@ agents:
 	if len(decoded.Variables) != 1 || decoded.Variables[0].Name != "TOKEN" || decoded.Variables[0].Value != "********" || !decoded.Variables[0].Secret {
 		t.Fatalf("decoded variables = %#v", decoded.Variables)
 	}
-	if len(decoded.Agents) != 1 || decoded.Agents[0].Name != "reviewer" || decoded.Agents[0].Driver.Name != "docker" || decoded.Agents[0].Driver.Docker == nil {
+	if len(decoded.Agents) != 1 || decoded.Agents[0].Name != "reviewer" || decoded.Agents[0].Driver.Name != "docker" {
 		t.Fatalf("decoded agents = %#v", decoded.Agents)
 	}
 }

--- a/cmd/agent-compose/cli_daemon_lifecycle_test.go
+++ b/cmd/agent-compose/cli_daemon_lifecycle_test.go
@@ -231,6 +231,7 @@ agents:
 		Agents []struct {
 			Name   string `json:"name"`
 			Driver struct {
+				Name   string         `json:"name"`
 				Docker map[string]any `json:"docker"`
 			} `json:"driver"`
 		} `json:"agents"`
@@ -244,7 +245,7 @@ agents:
 	if len(decoded.Variables) != 1 || decoded.Variables[0].Name != "TOKEN" || decoded.Variables[0].Value != "********" || !decoded.Variables[0].Secret {
 		t.Fatalf("decoded variables = %#v", decoded.Variables)
 	}
-	if len(decoded.Agents) != 1 || decoded.Agents[0].Name != "reviewer" || decoded.Agents[0].Driver.Docker == nil {
+	if len(decoded.Agents) != 1 || decoded.Agents[0].Name != "reviewer" || decoded.Agents[0].Driver.Name != "docker" || decoded.Agents[0].Driver.Docker == nil {
 		t.Fatalf("decoded agents = %#v", decoded.Agents)
 	}
 }

--- a/cmd/agent-compose/cli_daemon_lifecycle_test.go
+++ b/cmd/agent-compose/cli_daemon_lifecycle_test.go
@@ -231,7 +231,7 @@ agents:
 		Agents []struct {
 			Name   string `json:"name"`
 			Driver struct {
-				Name string `json:"name"`
+				Docker map[string]any `json:"docker"`
 			} `json:"driver"`
 		} `json:"agents"`
 	}
@@ -244,7 +244,7 @@ agents:
 	if len(decoded.Variables) != 1 || decoded.Variables[0].Name != "TOKEN" || decoded.Variables[0].Value != "********" || !decoded.Variables[0].Secret {
 		t.Fatalf("decoded variables = %#v", decoded.Variables)
 	}
-	if len(decoded.Agents) != 1 || decoded.Agents[0].Name != "reviewer" || decoded.Agents[0].Driver.Name != "docker" {
+	if len(decoded.Agents) != 1 || decoded.Agents[0].Name != "reviewer" || decoded.Agents[0].Driver.Docker == nil {
 		t.Fatalf("decoded agents = %#v", decoded.Agents)
 	}
 }

--- a/docs/design/proto_v2_api_contract.md
+++ b/docs/design/proto_v2_api_contract.md
@@ -1,0 +1,56 @@
+# Proto v2 selector and mutation contract
+
+This document freezes the selector, field-presence, and collection-update
+semantics of the v2 API. Clients must preserve protobuf presence and oneof
+cases when translating CLI flags or Web forms into requests; they must not
+infer a priority between selector fields or omit explicit zero values from
+`Set` requests.
+
+## Selector audit
+
+Single-resource requests use one of these forms:
+
+| Selector | Contract |
+| --- | --- |
+| `ProjectRef` | Exactly one non-empty `project_id`, `name`, or `source_path`. IDs are stable; names and source paths are exact mutable lookup keys. |
+| `ExecRequest.target` | Exactly one `sandbox_id`, `run_id`, or `selector`. Empty selected scalar cases are invalid. |
+| `ExecSandboxSelector.project` | Exactly one non-empty `project_id` or `project_name`; `agent_name` is an optional narrowing filter, not an alternative project selector. |
+| Hierarchical project resources | Scheduler requests combine one `ProjectRef` with required `agent_name` and, where applicable, `trigger_id` or `run_id`. These fields identify nested resources and are not mutually exclusive alternatives. |
+| Direct resource IDs | Run, sandbox, image, volume, cache, workspace-preset, and session operations use one required resource ID or name. Query/list fields are filters and may be combined. |
+
+Handlers reject a missing or empty selected case with `InvalidArgument`. A
+oneof makes simultaneous alternatives unrepresentable in generated clients;
+malformed wire input follows normal protobuf last-one-wins decoding. A lookup
+with no match is `NotFound`, while a selector that matches multiple resources
+is `InvalidArgument`.
+
+## Driver model
+
+`DriverSpec` is a single-config model. Exactly one of `boxlite`, `docker`, or
+`microsandbox` is selected in `config`; that case is also the driver name.
+There is no separate `name` field and no persistence of inactive driver
+configurations. A missing config is invalid. This matches compose
+normalization, which has always required exactly one runtime configuration,
+and prevents name/config mismatch and silent ignored configuration.
+
+## Mutation semantics
+
+| Request | Field semantics |
+| --- | --- |
+| `ApplyProject` | `spec` is required and declaratively replaces the complete project. Repeated agents, variables, volumes, workspaces, MCP servers, OctoBus servers, and every nested repeated/map field are replaced. Empty clears; omitted entries are deleted. `source` is optional replacement metadata, `expected_spec_hash` is an optional concurrency guard, and `dry_run` explicitly chooses plan versus apply. |
+| `SetSchedulerEnabled` | `project` and `agent_name` are required. `enabled` is an explicit value; `false` disables and is never a no-op. |
+| `SetSchedulerTriggerEnabled` | `project`, `agent_name`, and `trigger_id` are required. `enabled` is an explicit value; `false` disables and is never a no-op. |
+| `UpdateGlobalEnv` | `env` is a complete replacement keyed by name. Empty clears all entries and omitted names are deleted. For an entry marked secret, absent `value` retains the stored secret with that name; present empty clears it. `secret` is an explicit replacement value. Duplicate names normalize with the last occurrence winning. |
+| `UpdateCapabilityGatewayConfig` | Field-level patch. Absent `addr`/`token` is no-op; present empty explicitly clears that field. |
+| `UpdateWorkspacePreset` | `preset_id` identifies the resource. All other fields are complete replacement values; empty `comment` clears it, while empty required name/type/config is rejected. |
+
+Create requests provide complete initial values. Delete, remove, prune, stop,
+and other action requests are commands rather than patches: their ordinary
+bool/scalar zero values are explicit documented command modes or optional
+filters. List and stream repeated fields are filters; empty means no filter,
+not mutation.
+
+The protobuf definitions are the shared CLI/Web boundary. Both clients must
+construct the same oneof case and preserve optional-field presence described
+above. JSON object omission means absent/no-op only for proto `optional`
+fields; an explicitly supplied empty string means clear.

--- a/docs/design/proto_v2_api_contract.md
+++ b/docs/design/proto_v2_api_contract.md
@@ -27,11 +27,13 @@ is `InvalidArgument`.
 ## Driver model
 
 `DriverSpec` is a single-config model. Exactly one of `boxlite`, `docker`, or
-`microsandbox` is selected in `config`; that case is also the driver name.
-There is no separate `name` field and no persistence of inactive driver
-configurations. A missing config is invalid. This matches compose
-normalization, which has always required exactly one runtime configuration,
-and prevents name/config mismatch and silent ignored configuration.
+`microsandbox` is selected in `config`, and the required `name` field must
+match that case. `name` remains in the wire and JSON representation for
+compatibility with existing project output; the server always emits both.
+There is no persistence of inactive driver configurations. A missing config,
+missing name, or mismatch is invalid. This matches compose normalization,
+which has always required exactly one runtime configuration, and prevents
+silent ignored configuration.
 
 ## Mutation semantics
 
@@ -42,7 +44,7 @@ and prevents name/config mismatch and silent ignored configuration.
 | `SetSchedulerTriggerEnabled` | `project`, `agent_name`, and `trigger_id` are required. `enabled` is an explicit value; `false` disables and is never a no-op. |
 | `UpdateGlobalEnv` | `env` is a complete replacement keyed by name. Empty clears all entries and omitted names are deleted. For an entry marked secret, absent `value` retains the stored secret with that name; present empty clears it. `secret` is an explicit replacement value. Duplicate names normalize with the last occurrence winning. |
 | `UpdateCapabilityGatewayConfig` | Field-level patch. Absent `addr`/`token` is no-op; present empty explicitly clears that field. |
-| `UpdateWorkspacePreset` | `preset_id` identifies the resource. All other fields are complete replacement values; empty `comment` clears it, while empty required name/type/config is rejected. |
+| `UpdateWorkspacePreset` | `preset_id` identifies the resource. All other fields are complete replacement values. Empty `comment` clears it; empty name/type is rejected; empty `config_json` is normalized to the provider default rather than treated as no-op. |
 
 Create requests provide complete initial values. Delete, remove, prune, stop,
 and other action requests are commands rather than patches: their ordinary

--- a/docs/design/proto_v2_api_contract.md
+++ b/docs/design/proto_v2_api_contract.md
@@ -39,7 +39,7 @@ silent ignored configuration.
 
 | Request | Field semantics |
 | --- | --- |
-| `ApplyProject` | `spec` is required and declaratively replaces the complete project. Repeated agents, variables, volumes, workspaces, MCP servers, OctoBus servers, and every nested repeated/map field are replaced. Empty clears; omitted entries are deleted. `source` is optional replacement metadata, `expected_spec_hash` is an optional concurrency guard, and `dry_run` explicitly chooses plan versus apply. |
+| `ApplyProject` | `spec` is required and declaratively replaces the complete project. Repeated agents, variables, volumes, workspaces, MCP servers, OctoBus servers, and every nested repeated/map field are replaced. Empty clears; omitted entries are deleted. `source` is optional normalization metadata, `submitted_spec_hash` optionally verifies the normalized submitted spec (it is not a stored-revision concurrency guard), and `dry_run` explicitly chooses plan versus apply. |
 | `SetSchedulerEnabled` | `project` and `agent_name` are required. `enabled` is an explicit value; `false` disables and is never a no-op. |
 | `SetSchedulerTriggerEnabled` | `project`, `agent_name`, and `trigger_id` are required. `enabled` is an explicit value; `false` disables and is never a no-op. |
 | `UpdateGlobalEnv` | `env` is a complete replacement keyed by name. Empty clears all entries and omitted names are deleted. For an entry marked secret, absent `value` retains the stored secret with that name; present empty clears it. `secret` is an explicit replacement value. Duplicate names normalize with the last occurrence winning. |

--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -678,16 +678,12 @@ func (h *ExecHandler) resolveExecTargetSandbox(ctx context.Context, req *agentco
 	if selector == nil {
 		return nil, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exec target is required"))
 	}
-	projectID := strings.TrimSpace(selector.GetProjectId())
-	projectName := strings.TrimSpace(selector.GetProjectName())
-	if projectID != "" && projectName != "" {
-		return nil, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("project_id and project_name are mutually exclusive"))
-	}
 	projectRef := &agentcomposev2.ProjectRef{}
-	if projectID != "" {
-		projectRef.Selector = &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}
-	} else if projectName != "" {
-		projectRef.Selector = &agentcomposev2.ProjectRef_Name{Name: projectName}
+	switch project := selector.GetProject().(type) {
+	case *agentcomposev2.ExecSandboxSelector_ProjectId:
+		projectRef.Selector = &agentcomposev2.ProjectRef_ProjectId{ProjectId: strings.TrimSpace(project.ProjectId)}
+	case *agentcomposev2.ExecSandboxSelector_ProjectName:
+		projectRef.Selector = &agentcomposev2.ProjectRef_Name{Name: strings.TrimSpace(project.ProjectName)}
 	}
 	project, err := h.resolveProjectRef(ctx, projectRef)
 	if err != nil {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -441,14 +441,14 @@ func TestExecHandlerRunSelectorAndStreamSenderWorkflow(t *testing.T) {
 	}
 
 	if _, err := handler.executeProjectCommand(ctx, &agentcomposev2.ExecRequest{
-		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{ProjectId: "project-1", AgentName: "worker"}},
+		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{Project: &agentcomposev2.ExecSandboxSelector_ProjectId{ProjectId: "project-1"}, AgentName: "worker"}},
 		Command: &agentcomposev2.ExecCommand{Command: "echo"},
 	}, "exec-ambiguous", nil); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("expected multiple running selector error, got %v", err)
 	}
 	projects.runs = projects.runs[:1]
 	selectorResp, err := handler.executeProjectCommand(ctx, &agentcomposev2.ExecRequest{
-		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{ProjectId: "project-1", AgentName: "worker"}},
+		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{Project: &agentcomposev2.ExecSandboxSelector_ProjectId{ProjectId: "project-1"}, AgentName: "worker"}},
 		Command: &agentcomposev2.ExecCommand{Command: "echo"},
 	}, "exec-selector", nil)
 	if err != nil {
@@ -459,7 +459,7 @@ func TestExecHandlerRunSelectorAndStreamSenderWorkflow(t *testing.T) {
 	}
 	projects.runs = nil
 	if _, err := handler.executeProjectCommand(ctx, &agentcomposev2.ExecRequest{
-		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{ProjectId: "project-1", AgentName: "worker"}},
+		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{Project: &agentcomposev2.ExecSandboxSelector_ProjectId{ProjectId: "project-1"}, AgentName: "worker"}},
 		Command: &agentcomposev2.ExecCommand{Command: "echo"},
 	}, "exec-missing", nil); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("expected no running sandbox selector error, got %v", err)
@@ -496,9 +496,9 @@ func TestExecHandlerSelectorErrors(t *testing.T) {
 		t.Fatalf("expected run not found, got %v", err)
 	}
 	if _, err := handler.Exec(context.Background(), connect.NewRequest(&agentcomposev2.ExecRequest{
-		Target: &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{ProjectId: "project-1", ProjectName: "Project"}},
+		Target: &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{Project: &agentcomposev2.ExecSandboxSelector_ProjectId{}}},
 	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
-		t.Fatalf("expected conflicting project selector error, got %v", err)
+		t.Fatalf("expected empty project selector error, got %v", err)
 	}
 }
 

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -473,7 +473,7 @@ func DriverSpecToProto(driver *compose.NormalizedDriverSpec) *agentcomposev2.Dri
 	if driver == nil {
 		return nil
 	}
-	result := &agentcomposev2.DriverSpec{}
+	result := &agentcomposev2.DriverSpec{Name: driver.Name}
 	switch driver.Name {
 	case compose.DriverBoxlite:
 		config := &agentcomposev2.BoxliteDriverSpec{}
@@ -896,19 +896,32 @@ func DriverYAMLShape(path string, driver *agentcomposev2.DriverSpec) (map[string
 	if driver == nil {
 		return nil, nil
 	}
+	name := strings.ToLower(strings.TrimSpace(driver.GetName()))
+	var configName string
+	var config map[string]any
 	switch driver.GetConfig().(type) {
 	case *agentcomposev2.DriverSpec_Boxlite:
-		return map[string]any{compose.DriverBoxlite: map[string]any{
+		configName = compose.DriverBoxlite
+		config = map[string]any{
 			"kernel": driver.GetBoxlite().GetKernel(),
 			"rootfs": driver.GetBoxlite().GetRootfs(),
-		}}, nil
+		}
 	case *agentcomposev2.DriverSpec_Docker:
-		return map[string]any{compose.DriverDocker: map[string]any{"host": driver.GetDocker().GetHost()}}, nil
+		configName = compose.DriverDocker
+		config = map[string]any{"host": driver.GetDocker().GetHost()}
 	case *agentcomposev2.DriverSpec_Microsandbox:
-		return map[string]any{compose.DriverMicrosandbox: map[string]any{"profile": driver.GetMicrosandbox().GetProfile()}}, nil
+		configName = compose.DriverMicrosandbox
+		config = map[string]any{"profile": driver.GetMicrosandbox().GetProfile()}
 	default:
 		return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(path, "driver requires exactly one runtime config")}
 	}
+	if name == "" {
+		return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(path+".name", "driver name is required")}
+	}
+	if name != configName {
+		return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(path, fmt.Sprintf("driver name %q conflicts with %q runtime config", name, configName))}
+	}
+	return map[string]any{configName: config}, nil
 }
 
 func SchedulerYAMLShape(scheduler *agentcomposev2.SchedulerSpec) map[string]any {

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -473,24 +473,27 @@ func DriverSpecToProto(driver *compose.NormalizedDriverSpec) *agentcomposev2.Dri
 	if driver == nil {
 		return nil
 	}
-	result := &agentcomposev2.DriverSpec{Name: driver.Name}
+	result := &agentcomposev2.DriverSpec{}
 	switch driver.Name {
 	case compose.DriverBoxlite:
-		result.Boxlite = &agentcomposev2.BoxliteDriverSpec{}
+		config := &agentcomposev2.BoxliteDriverSpec{}
 		if driver.Boxlite != nil {
-			result.Boxlite.Kernel = driver.Boxlite.Kernel
-			result.Boxlite.Rootfs = driver.Boxlite.Rootfs
+			config.Kernel = driver.Boxlite.Kernel
+			config.Rootfs = driver.Boxlite.Rootfs
 		}
+		result.Config = &agentcomposev2.DriverSpec_Boxlite{Boxlite: config}
 	case compose.DriverDocker:
-		result.Docker = &agentcomposev2.DockerDriverSpec{}
+		config := &agentcomposev2.DockerDriverSpec{}
 		if driver.Docker != nil {
-			result.Docker.Host = driver.Docker.Host
+			config.Host = driver.Docker.Host
 		}
+		result.Config = &agentcomposev2.DriverSpec_Docker{Docker: config}
 	case compose.DriverMicrosandbox:
-		result.Microsandbox = &agentcomposev2.MicrosandboxDriverSpec{}
+		config := &agentcomposev2.MicrosandboxDriverSpec{}
 		if driver.Microsandbox != nil {
-			result.Microsandbox.Profile = driver.Microsandbox.Profile
+			config.Profile = driver.Microsandbox.Profile
 		}
+		result.Config = &agentcomposev2.DriverSpec_Microsandbox{Microsandbox: config}
 	}
 	return result
 }
@@ -893,36 +896,19 @@ func DriverYAMLShape(path string, driver *agentcomposev2.DriverSpec) (map[string
 	if driver == nil {
 		return nil, nil
 	}
-	byName := strings.ToLower(strings.TrimSpace(driver.GetName()))
-	runtimes := make(map[string]any, 3)
-	if driver.GetBoxlite() != nil {
-		runtimes[compose.DriverBoxlite] = map[string]any{
+	switch driver.GetConfig().(type) {
+	case *agentcomposev2.DriverSpec_Boxlite:
+		return map[string]any{compose.DriverBoxlite: map[string]any{
 			"kernel": driver.GetBoxlite().GetKernel(),
 			"rootfs": driver.GetBoxlite().GetRootfs(),
-		}
-	}
-	if driver.GetDocker() != nil {
-		runtimes[compose.DriverDocker] = map[string]any{"host": driver.GetDocker().GetHost()}
-	}
-	if driver.GetMicrosandbox() != nil {
-		runtimes[compose.DriverMicrosandbox] = map[string]any{"profile": driver.GetMicrosandbox().GetProfile()}
-	}
-	switch byName {
-	case "":
-	case compose.DriverBoxlite, compose.DriverDocker, compose.DriverMicrosandbox:
-		for runtimeName := range runtimes {
-			if runtimeName != byName {
-				return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(path, fmt.Sprintf("driver name %q conflicts with %q runtime config", byName, runtimeName))}
-			}
-		}
-		if existing, ok := runtimes[byName]; ok {
-			return map[string]any{byName: existing}, nil
-		}
-		return map[string]any{byName: map[string]any{}}, nil
+		}}, nil
+	case *agentcomposev2.DriverSpec_Docker:
+		return map[string]any{compose.DriverDocker: map[string]any{"host": driver.GetDocker().GetHost()}}, nil
+	case *agentcomposev2.DriverSpec_Microsandbox:
+		return map[string]any{compose.DriverMicrosandbox: map[string]any{"profile": driver.GetMicrosandbox().GetProfile()}}, nil
 	default:
-		return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(path+".name", fmt.Sprintf("unsupported runtime driver %q", byName))}
+		return nil, []*agentcomposev2.ProjectValidationIssue{ProjectValidationIssue(path, "driver requires exactly one runtime config")}
 	}
-	return runtimes, nil
 }
 
 func SchedulerYAMLShape(scheduler *agentcomposev2.SchedulerSpec) map[string]any {

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -163,6 +163,61 @@ func TestProjectSpecToProtoIncludesJupyter(t *testing.T) {
 	}
 }
 
+func TestDriverYAMLShapeRequiresMatchingNameAndConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		driver     *agentcomposev2.DriverSpec
+		wantConfig string
+		wantIssue  bool
+	}{
+		{
+			name: "matching docker",
+			driver: &agentcomposev2.DriverSpec{
+				Name:   compose.DriverDocker,
+				Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{Host: "unix:///docker.sock"}},
+			},
+			wantConfig: compose.DriverDocker,
+		},
+		{
+			name: "missing name",
+			driver: &agentcomposev2.DriverSpec{
+				Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}},
+			},
+			wantIssue: true,
+		},
+		{
+			name: "missing config",
+			driver: &agentcomposev2.DriverSpec{
+				Name: compose.DriverDocker,
+			},
+			wantIssue: true,
+		},
+		{
+			name: "mismatched config",
+			driver: &agentcomposev2.DriverSpec{
+				Name:   compose.DriverDocker,
+				Config: &agentcomposev2.DriverSpec_Boxlite{Boxlite: &agentcomposev2.BoxliteDriverSpec{}},
+			},
+			wantIssue: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			shape, issues := DriverYAMLShape("agents.worker.driver", test.driver)
+			if test.wantIssue {
+				if len(issues) != 1 || shape != nil {
+					t.Fatalf("shape=%#v issues=%#v", shape, issues)
+				}
+				return
+			}
+			if len(issues) != 0 || shape[test.wantConfig] == nil {
+				t.Fatalf("shape=%#v issues=%#v", shape, issues)
+			}
+		})
+	}
+}
+
 func TestAgentEnablementRoundTripsThroughAPIShape(t *testing.T) {
 	spec := &compose.NormalizedProjectSpec{
 		Name: "enablement",

--- a/pkg/agentcompose/api/settings_v2_test.go
+++ b/pkg/agentcompose/api/settings_v2_test.go
@@ -44,6 +44,32 @@ func TestSettingsGlobalEnvDistinguishesRetainAndClearSecret(t *testing.T) {
 	}
 }
 
+func TestSettingsGlobalEnvEmptyAndOmittedEntriesReplaceCollection(t *testing.T) {
+	ctx := context.Background()
+	store := &settingsStoreFake{env: []domain.SandboxEnvVar{
+		{Name: "KEEP", Value: "old"},
+		{Name: "DELETE", Value: "old"},
+	}}
+	handler := NewSettingsV2Handler(&appconfig.Config{DataRoot: t.TempDir()}, store)
+
+	value := "new"
+	if _, err := handler.UpdateGlobalEnv(ctx, connect.NewRequest(&agentcomposev2.UpdateGlobalEnvRequest{
+		Env: []*agentcomposev2.EnvVarUpdateSpec{{Name: "KEEP", Value: &value}},
+	})); err != nil {
+		t.Fatalf("replace env: %v", err)
+	}
+	if len(store.env) != 1 || store.env[0].Name != "KEEP" || store.env[0].Value != "new" {
+		t.Fatalf("replacement env = %#v", store.env)
+	}
+
+	if _, err := handler.UpdateGlobalEnv(ctx, connect.NewRequest(&agentcomposev2.UpdateGlobalEnvRequest{})); err != nil {
+		t.Fatalf("clear env: %v", err)
+	}
+	if len(store.env) != 0 {
+		t.Fatalf("cleared env = %#v", store.env)
+	}
+}
+
 type settingsStoreFake struct{ env []domain.SandboxEnvVar }
 
 func (s *settingsStoreFake) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -1422,17 +1422,23 @@ func (x *ValidateProjectResponse) GetSpecHash() string {
 }
 
 type ApplyProjectRequest struct {
-	state  protoimpl.MessageState `protogen:"open.v1"`
-	Spec   *ProjectSpec           `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
-	Source *ProjectSource         `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Required. The complete desired project specification. All repeated and map
+	// fields in the spec replace the previously persisted collections; an empty
+	// collection explicitly clears that collection.
+	Spec *ProjectSpec `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	// Optional source metadata used while normalizing the replacement. An absent
+	// source supplies empty compose_path and project_dir values.
+	Source *ProjectSource `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
 	// submitted_spec_hash optionally verifies the submitted spec after the server
 	// normalizes it. It is not compared with the currently stored project and is
 	// not an optimistic-concurrency precondition. An empty value skips this check.
 	// Canonicalization, encoding, and hashing are defined by pkg/compose.
 	SubmittedSpecHash string `protobuf:"bytes,3,opt,name=submitted_spec_hash,json=submittedSpecHash,proto3" json:"submitted_spec_hash,omitempty"`
-	DryRun            bool   `protobuf:"varint,4,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Explicit execution mode. False applies the replacement; true only plans it.
+	DryRun        bool `protobuf:"varint,4,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ApplyProjectRequest) Reset() {
@@ -4845,10 +4851,13 @@ func (x *SchedulerRun) GetSandboxIds() []string {
 }
 
 type SetSchedulerEnabledRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
-	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
-	Enabled       bool                   `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Required. Exactly one non-empty project selector must be set.
+	Project *ProjectRef `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	// Required stable agent name within the selected project.
+	AgentName string `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	// Explicit replacement value. False disables the scheduler; it is not a no-op.
+	Enabled       bool `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4957,11 +4966,15 @@ func (x *SetSchedulerEnabledResponse) GetOverridden() bool {
 }
 
 type SetSchedulerTriggerEnabledRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
-	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
-	TriggerId     string                 `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
-	Enabled       bool                   `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Required. Exactly one non-empty project selector must be set.
+	Project *ProjectRef `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	// Required stable agent name within the selected project.
+	AgentName string `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	// Required stable trigger ID within the selected scheduler.
+	TriggerId string `protobuf:"bytes,3,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
+	// Explicit replacement value. False disables the trigger; it is not a no-op.
+	Enabled       bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6001,10 +6014,16 @@ func (x *EnvVarSpec) GetSecret() bool {
 }
 
 type EnvVarUpdateSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Value         *string                `protobuf:"bytes,2,opt,name=value,proto3,oneof" json:"value,omitempty"`
-	Secret        bool                   `protobuf:"varint,3,opt,name=secret,proto3" json:"secret,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Required replacement key. Duplicate names are normalized with the last
+	// occurrence winning.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Presence is meaningful only for secret preservation during
+	// UpdateGlobalEnv: absent preserves the existing secret value; present empty
+	// explicitly clears it. Non-secret entries treat absence as an empty value.
+	Value *string `protobuf:"bytes,2,opt,name=value,proto3,oneof" json:"value,omitempty"`
+	// Explicit replacement value. False changes the entry to non-secret.
+	Secret        bool `protobuf:"varint,3,opt,name=secret,proto3" json:"secret,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6413,11 +6432,16 @@ func (x *EventTriggerSpec) GetTopic() string {
 }
 
 type DriverSpec struct {
-	state         protoimpl.MessageState  `protogen:"open.v1"`
-	Name          string                  `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Boxlite       *BoxliteDriverSpec      `protobuf:"bytes,2,opt,name=boxlite,proto3" json:"boxlite,omitempty"`
-	Docker        *DockerDriverSpec       `protobuf:"bytes,3,opt,name=docker,proto3" json:"docker,omitempty"`
-	Microsandbox  *MicrosandboxDriverSpec `protobuf:"bytes,4,opt,name=microsandbox,proto3" json:"microsandbox,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Required. A project agent has exactly one runtime driver configuration;
+	// the selected oneof case is the driver name.
+	//
+	// Types that are valid to be assigned to Config:
+	//
+	//	*DriverSpec_Boxlite
+	//	*DriverSpec_Docker
+	//	*DriverSpec_Microsandbox
+	Config        isDriverSpec_Config `protobuf_oneof:"config"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6452,33 +6476,61 @@ func (*DriverSpec) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
 }
 
-func (x *DriverSpec) GetName() string {
+func (x *DriverSpec) GetConfig() isDriverSpec_Config {
 	if x != nil {
-		return x.Name
+		return x.Config
 	}
-	return ""
+	return nil
 }
 
 func (x *DriverSpec) GetBoxlite() *BoxliteDriverSpec {
 	if x != nil {
-		return x.Boxlite
+		if x, ok := x.Config.(*DriverSpec_Boxlite); ok {
+			return x.Boxlite
+		}
 	}
 	return nil
 }
 
 func (x *DriverSpec) GetDocker() *DockerDriverSpec {
 	if x != nil {
-		return x.Docker
+		if x, ok := x.Config.(*DriverSpec_Docker); ok {
+			return x.Docker
+		}
 	}
 	return nil
 }
 
 func (x *DriverSpec) GetMicrosandbox() *MicrosandboxDriverSpec {
 	if x != nil {
-		return x.Microsandbox
+		if x, ok := x.Config.(*DriverSpec_Microsandbox); ok {
+			return x.Microsandbox
+		}
 	}
 	return nil
 }
+
+type isDriverSpec_Config interface {
+	isDriverSpec_Config()
+}
+
+type DriverSpec_Boxlite struct {
+	Boxlite *BoxliteDriverSpec `protobuf:"bytes,2,opt,name=boxlite,proto3,oneof"`
+}
+
+type DriverSpec_Docker struct {
+	Docker *DockerDriverSpec `protobuf:"bytes,3,opt,name=docker,proto3,oneof"`
+}
+
+type DriverSpec_Microsandbox struct {
+	Microsandbox *MicrosandboxDriverSpec `protobuf:"bytes,4,opt,name=microsandbox,proto3,oneof"`
+}
+
+func (*DriverSpec_Boxlite) isDriverSpec_Config() {}
+
+func (*DriverSpec_Docker) isDriverSpec_Config() {}
+
+func (*DriverSpec_Microsandbox) isDriverSpec_Config() {}
 
 type BoxliteDriverSpec struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -10139,10 +10191,16 @@ func (*ExecRequest_RunId) isExecRequest_Target() {}
 func (*ExecRequest_Selector) isExecRequest_Target() {}
 
 type ExecSandboxSelector struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ProjectId     string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
-	ProjectName   string                 `protobuf:"bytes,2,opt,name=project_name,json=projectName,proto3" json:"project_name,omitempty"`
-	AgentName     string                 `protobuf:"bytes,3,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Required. Select exactly one project by stable ID or exact name.
+	//
+	// Types that are valid to be assigned to Project:
+	//
+	//	*ExecSandboxSelector_ProjectId
+	//	*ExecSandboxSelector_ProjectName
+	Project isExecSandboxSelector_Project `protobuf_oneof:"project"`
+	// Optional filter. Empty matches sandboxes for every agent in the project.
+	AgentName     string `protobuf:"bytes,3,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -10177,16 +10235,27 @@ func (*ExecSandboxSelector) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{115}
 }
 
+func (x *ExecSandboxSelector) GetProject() isExecSandboxSelector_Project {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
 func (x *ExecSandboxSelector) GetProjectId() string {
 	if x != nil {
-		return x.ProjectId
+		if x, ok := x.Project.(*ExecSandboxSelector_ProjectId); ok {
+			return x.ProjectId
+		}
 	}
 	return ""
 }
 
 func (x *ExecSandboxSelector) GetProjectName() string {
 	if x != nil {
-		return x.ProjectName
+		if x, ok := x.Project.(*ExecSandboxSelector_ProjectName); ok {
+			return x.ProjectName
+		}
 	}
 	return ""
 }
@@ -10197,6 +10266,22 @@ func (x *ExecSandboxSelector) GetAgentName() string {
 	}
 	return ""
 }
+
+type isExecSandboxSelector_Project interface {
+	isExecSandboxSelector_Project()
+}
+
+type ExecSandboxSelector_ProjectId struct {
+	ProjectId string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3,oneof"`
+}
+
+type ExecSandboxSelector_ProjectName struct {
+	ProjectName string `protobuf:"bytes,2,opt,name=project_name,json=projectName,proto3,oneof"`
+}
+
+func (*ExecSandboxSelector_ProjectId) isExecSandboxSelector_Project() {}
+
+func (*ExecSandboxSelector_ProjectName) isExecSandboxSelector_Project() {}
 
 type ExecCommand struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -15344,8 +15429,12 @@ func (x *GetGlobalEnvResponse) GetEnv() []*EnvVarSpec {
 }
 
 type UpdateGlobalEnvRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Env           []*EnvVarUpdateSpec    `protobuf:"bytes,1,rep,name=env,proto3" json:"env,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Complete replacement keyed by EnvVarUpdateSpec.name. An empty list clears
+	// all global environment variables; omitted existing names are deleted.
+	// For a secret entry only, an absent value preserves the existing secret
+	// value with the same name. An explicitly empty value clears it.
+	Env           []*EnvVarUpdateSpec `protobuf:"bytes,1,rep,name=env,proto3" json:"env,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15564,9 +15653,11 @@ func (x *GetCapabilityGatewayConfigResponse) GetConfig() *CapabilityGatewayConfi
 }
 
 type UpdateCapabilityGatewayConfigRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Addr          *string                `protobuf:"bytes,1,opt,name=addr,proto3,oneof" json:"addr,omitempty"`
-	Token         *string                `protobuf:"bytes,2,opt,name=token,proto3,oneof" json:"token,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Field patch: absent is no-op; present empty explicitly clears the address.
+	Addr *string `protobuf:"bytes,1,opt,name=addr,proto3,oneof" json:"addr,omitempty"`
+	// Field patch: absent is no-op; present empty explicitly clears the token.
+	Token         *string `protobuf:"bytes,2,opt,name=token,proto3,oneof" json:"token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -15927,12 +16018,17 @@ func (x *CreateWorkspacePresetRequest) GetComment() string {
 }
 
 type UpdateWorkspacePresetRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PresetId      string                 `protobuf:"bytes,1,opt,name=preset_id,json=presetId,proto3" json:"preset_id,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Type          string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
-	ConfigJson    string                 `protobuf:"bytes,4,opt,name=config_json,json=configJson,proto3" json:"config_json,omitempty"`
-	Comment       string                 `protobuf:"bytes,5,opt,name=comment,proto3" json:"comment,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Required stable preset ID.
+	PresetId string `protobuf:"bytes,1,opt,name=preset_id,json=presetId,proto3" json:"preset_id,omitempty"`
+	// Required replacement value.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Required replacement value.
+	Type string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	// Required replacement value. Empty is rejected rather than treated as no-op.
+	ConfigJson string `protobuf:"bytes,4,opt,name=config_json,json=configJson,proto3" json:"config_json,omitempty"`
+	// Replacement value. Empty explicitly clears the comment.
+	Comment       string `protobuf:"bytes,5,opt,name=comment,proto3" json:"comment,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -18324,13 +18420,13 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x06prompt\x18\a \x01(\tR\x06prompt\x12%\n" +
 	"\x0esandbox_policy\x18\b \x01(\tR\rsandboxPolicy\"(\n" +
 	"\x10EventTriggerSpec\x12\x14\n" +
-	"\x05topic\x18\x01 \x01(\tR\x05topic\"\xe6\x01\n" +
+	"\x05topic\x18\x01 \x01(\tR\x05topic\"\xee\x01\n" +
 	"\n" +
-	"DriverSpec\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12<\n" +
-	"\aboxlite\x18\x02 \x01(\v2\".agentcompose.v2.BoxliteDriverSpecR\aboxlite\x129\n" +
-	"\x06docker\x18\x03 \x01(\v2!.agentcompose.v2.DockerDriverSpecR\x06docker\x12K\n" +
-	"\fmicrosandbox\x18\x04 \x01(\v2'.agentcompose.v2.MicrosandboxDriverSpecR\fmicrosandbox\"C\n" +
+	"DriverSpec\x12>\n" +
+	"\aboxlite\x18\x02 \x01(\v2\".agentcompose.v2.BoxliteDriverSpecH\x00R\aboxlite\x12;\n" +
+	"\x06docker\x18\x03 \x01(\v2!.agentcompose.v2.DockerDriverSpecH\x00R\x06docker\x12M\n" +
+	"\fmicrosandbox\x18\x04 \x01(\v2'.agentcompose.v2.MicrosandboxDriverSpecH\x00R\fmicrosandboxB\b\n" +
+	"\x06configJ\x04\b\x01\x10\x02R\x04name\"C\n" +
 	"\x11BoxliteDriverSpec\x12\x16\n" +
 	"\x06kernel\x18\x01 \x01(\tR\x06kernel\x12\x16\n" +
 	"\x06rootfs\x18\x02 \x01(\tR\x06rootfs\"&\n" +
@@ -18680,13 +18776,14 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"timeout_ms\x18\a \x01(\rR\ttimeoutMs\x12(\n" +
 	"\x10max_output_bytes\x18\b \x01(\rR\x0emaxOutputBytesB\b\n" +
-	"\x06target\"v\n" +
-	"\x13ExecSandboxSelector\x12\x1d\n" +
+	"\x06target\"\x85\x01\n" +
+	"\x13ExecSandboxSelector\x12\x1f\n" +
 	"\n" +
-	"project_id\x18\x01 \x01(\tR\tprojectId\x12!\n" +
-	"\fproject_name\x18\x02 \x01(\tR\vprojectName\x12\x1d\n" +
+	"project_id\x18\x01 \x01(\tH\x00R\tprojectId\x12#\n" +
+	"\fproject_name\x18\x02 \x01(\tH\x00R\vprojectName\x12\x1d\n" +
 	"\n" +
-	"agent_name\x18\x03 \x01(\tR\tagentName\";\n" +
+	"agent_name\x18\x03 \x01(\tR\tagentNameB\t\n" +
+	"\aproject\";\n" +
 	"\vExecCommand\x12\x18\n" +
 	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
 	"\x04args\x18\x02 \x03(\tR\x04args\"C\n" +
@@ -20305,6 +20402,11 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[57].OneofWrappers = []any{}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[64].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[69].OneofWrappers = []any{
+		(*DriverSpec_Boxlite)(nil),
+		(*DriverSpec_Docker)(nil),
+		(*DriverSpec_Microsandbox)(nil),
+	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[76].OneofWrappers = []any{
 		(*RunAttachRequest_Start)(nil),
 		(*RunAttachRequest_Stdin)(nil),
@@ -20327,6 +20429,10 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecRequest_SandboxId)(nil),
 		(*ExecRequest_RunId)(nil),
 		(*ExecRequest_Selector)(nil),
+	}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[115].OneofWrappers = []any{
+		(*ExecSandboxSelector_ProjectId)(nil),
+		(*ExecSandboxSelector_ProjectName)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[119].OneofWrappers = []any{
 		(*ExecAttachRequest_Start)(nil),

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -6433,8 +6433,9 @@ func (x *EventTriggerSpec) GetTopic() string {
 
 type DriverSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Required. A project agent has exactly one runtime driver configuration;
-	// the selected oneof case is the driver name.
+	// Required. Must match the selected config case.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Required. A project agent has exactly one runtime driver configuration.
 	//
 	// Types that are valid to be assigned to Config:
 	//
@@ -6474,6 +6475,13 @@ func (x *DriverSpec) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DriverSpec.ProtoReflect.Descriptor instead.
 func (*DriverSpec) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{69}
+}
+
+func (x *DriverSpec) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
 }
 
 func (x *DriverSpec) GetConfig() isDriverSpec_Config {
@@ -16025,7 +16033,8 @@ type UpdateWorkspacePresetRequest struct {
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// Required replacement value.
 	Type string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
-	// Required replacement value. Empty is rejected rather than treated as no-op.
+	// Replacement value. Empty is normalized to the provider default rather than
+	// treated as no-op.
 	ConfigJson string `protobuf:"bytes,4,opt,name=config_json,json=configJson,proto3" json:"config_json,omitempty"`
 	// Replacement value. Empty explicitly clears the comment.
 	Comment       string `protobuf:"bytes,5,opt,name=comment,proto3" json:"comment,omitempty"`
@@ -18420,13 +18429,14 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x06prompt\x18\a \x01(\tR\x06prompt\x12%\n" +
 	"\x0esandbox_policy\x18\b \x01(\tR\rsandboxPolicy\"(\n" +
 	"\x10EventTriggerSpec\x12\x14\n" +
-	"\x05topic\x18\x01 \x01(\tR\x05topic\"\xee\x01\n" +
+	"\x05topic\x18\x01 \x01(\tR\x05topic\"\xf6\x01\n" +
 	"\n" +
-	"DriverSpec\x12>\n" +
+	"DriverSpec\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12>\n" +
 	"\aboxlite\x18\x02 \x01(\v2\".agentcompose.v2.BoxliteDriverSpecH\x00R\aboxlite\x12;\n" +
 	"\x06docker\x18\x03 \x01(\v2!.agentcompose.v2.DockerDriverSpecH\x00R\x06docker\x12M\n" +
 	"\fmicrosandbox\x18\x04 \x01(\v2'.agentcompose.v2.MicrosandboxDriverSpecH\x00R\fmicrosandboxB\b\n" +
-	"\x06configJ\x04\b\x01\x10\x02R\x04name\"C\n" +
+	"\x06config\"C\n" +
 	"\x11BoxliteDriverSpec\x12\x16\n" +
 	"\x06kernel\x18\x01 \x01(\tR\x06kernel\x12\x16\n" +
 	"\x06rootfs\x18\x02 \x01(\tR\x06rootfs\"&\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -308,13 +308,19 @@ message ValidateProjectResponse {
 }
 
 message ApplyProjectRequest {
+  // Required. The complete desired project specification. All repeated and map
+  // fields in the spec replace the previously persisted collections; an empty
+  // collection explicitly clears that collection.
   ProjectSpec spec = 1;
+  // Optional source metadata used while normalizing the replacement. An absent
+  // source supplies empty compose_path and project_dir values.
   ProjectSource source = 2;
   // submitted_spec_hash optionally verifies the submitted spec after the server
   // normalizes it. It is not compared with the currently stored project and is
   // not an optimistic-concurrency precondition. An empty value skips this check.
   // Canonicalization, encoding, and hashing are defined by pkg/compose.
   string submitted_spec_hash = 3;
+  // Explicit execution mode. False applies the replacement; true only plans it.
   bool dry_run = 4;
 }
 
@@ -682,8 +688,11 @@ message SchedulerRun {
 }
 
 message SetSchedulerEnabledRequest {
+  // Required. Exactly one non-empty project selector must be set.
   ProjectRef project = 1;
+  // Required stable agent name within the selected project.
   string agent_name = 2;
+  // Explicit replacement value. False disables the scheduler; it is not a no-op.
   bool enabled = 3;
 }
 
@@ -693,9 +702,13 @@ message SetSchedulerEnabledResponse {
 }
 
 message SetSchedulerTriggerEnabledRequest {
+  // Required. Exactly one non-empty project selector must be set.
   ProjectRef project = 1;
+  // Required stable agent name within the selected project.
   string agent_name = 2;
+  // Required stable trigger ID within the selected scheduler.
   string trigger_id = 3;
+  // Explicit replacement value. False disables the trigger; it is not a no-op.
   bool enabled = 4;
 }
 
@@ -804,8 +817,14 @@ message EnvVarSpec {
 }
 
 message EnvVarUpdateSpec {
+  // Required replacement key. Duplicate names are normalized with the last
+  // occurrence winning.
   string name = 1;
+  // Presence is meaningful only for secret preservation during
+  // UpdateGlobalEnv: absent preserves the existing secret value; present empty
+  // explicitly clears it. Non-secret entries treat absence as an empty value.
   optional string value = 2;
+  // Explicit replacement value. False changes the entry to non-secret.
   bool secret = 3;
 }
 
@@ -848,10 +867,16 @@ message EventTriggerSpec {
 }
 
 message DriverSpec {
-  string name = 1;
-  BoxliteDriverSpec boxlite = 2;
-  DockerDriverSpec docker = 3;
-  MicrosandboxDriverSpec microsandbox = 4;
+  reserved 1;
+  reserved "name";
+
+  // Required. A project agent has exactly one runtime driver configuration;
+  // the selected oneof case is the driver name.
+  oneof config {
+    BoxliteDriverSpec boxlite = 2;
+    DockerDriverSpec docker = 3;
+    MicrosandboxDriverSpec microsandbox = 4;
+  }
 }
 
 message BoxliteDriverSpec {
@@ -1253,8 +1278,12 @@ message ExecRequest {
 }
 
 message ExecSandboxSelector {
-  string project_id = 1;
-  string project_name = 2;
+  // Required. Select exactly one project by stable ID or exact name.
+  oneof project {
+    string project_id = 1;
+    string project_name = 2;
+  }
+  // Optional filter. Empty matches sandboxes for every agent in the project.
   string agent_name = 3;
 }
 
@@ -1783,7 +1812,13 @@ message WatchDashboardOverviewResponse {
 
 message GetGlobalEnvRequest {}
 message GetGlobalEnvResponse { repeated EnvVarSpec env = 1; }
-message UpdateGlobalEnvRequest { repeated EnvVarUpdateSpec env = 1; }
+message UpdateGlobalEnvRequest {
+  // Complete replacement keyed by EnvVarUpdateSpec.name. An empty list clears
+  // all global environment variables; omitted existing names are deleted.
+  // For a secret entry only, an absent value preserves the existing secret
+  // value with the same name. An explicitly empty value clears it.
+  repeated EnvVarUpdateSpec env = 1;
+}
 message UpdateGlobalEnvResponse { repeated EnvVarSpec env = 1; }
 
 message GetCapabilityGatewayConfigRequest {}
@@ -1793,7 +1828,9 @@ message CapabilityGatewayConfig {
 }
 message GetCapabilityGatewayConfigResponse { CapabilityGatewayConfig config = 1; }
 message UpdateCapabilityGatewayConfigRequest {
+  // Field patch: absent is no-op; present empty explicitly clears the address.
   optional string addr = 1;
+  // Field patch: absent is no-op; present empty explicitly clears the token.
   optional string token = 2;
 }
 message UpdateCapabilityGatewayConfigResponse { CapabilityGatewayConfig config = 1; }
@@ -1825,10 +1862,15 @@ message CreateWorkspacePresetRequest {
   string comment = 4;
 }
 message UpdateWorkspacePresetRequest {
+  // Required stable preset ID.
   string preset_id = 1;
+  // Required replacement value.
   string name = 2;
+  // Required replacement value.
   string type = 3;
+  // Required replacement value. Empty is rejected rather than treated as no-op.
   string config_json = 4;
+  // Replacement value. Empty explicitly clears the comment.
   string comment = 5;
 }
 message DeleteWorkspacePresetRequest { string preset_id = 1; }

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -867,11 +867,10 @@ message EventTriggerSpec {
 }
 
 message DriverSpec {
-  reserved 1;
-  reserved "name";
+  // Required. Must match the selected config case.
+  string name = 1;
 
-  // Required. A project agent has exactly one runtime driver configuration;
-  // the selected oneof case is the driver name.
+  // Required. A project agent has exactly one runtime driver configuration.
   oneof config {
     BoxliteDriverSpec boxlite = 2;
     DockerDriverSpec docker = 3;
@@ -1868,7 +1867,8 @@ message UpdateWorkspacePresetRequest {
   string name = 2;
   // Required replacement value.
   string type = 3;
-  // Required replacement value. Empty is rejected rather than treated as no-op.
+  // Replacement value. Empty is normalized to the provider default rather than
+  // treated as no-op.
   string config_json = 4;
   // Replacement value. Empty explicitly clears the comment.
   string comment = 5;

--- a/proto/agentcompose/v2/selector_driver_contract_test.go
+++ b/proto/agentcompose/v2/selector_driver_contract_test.go
@@ -1,0 +1,37 @@
+package agentcomposev2
+
+import "testing"
+
+func TestExecSandboxProjectSelectorsShareOneof(t *testing.T) {
+	message := (&ExecSandboxSelector{}).ProtoReflect().Descriptor()
+	project := message.Oneofs().ByName("project")
+	if project == nil {
+		t.Fatal("ExecSandboxSelector.project oneof is missing")
+	}
+	for _, fieldName := range []string{"project_id", "project_name"} {
+		field := message.Fields().ByName(fieldName)
+		if field == nil || field.ContainingOneof() != project {
+			t.Fatalf("ExecSandboxSelector.%s is not part of project", fieldName)
+		}
+	}
+	if field := message.Fields().ByName("agent_name"); field == nil || field.ContainingOneof() != nil {
+		t.Fatal("ExecSandboxSelector.agent_name must remain an independent narrowing filter")
+	}
+}
+
+func TestDriverSpecUsesSingleConfigOneof(t *testing.T) {
+	message := (&DriverSpec{}).ProtoReflect().Descriptor()
+	config := message.Oneofs().ByName("config")
+	if config == nil {
+		t.Fatal("DriverSpec.config oneof is missing")
+	}
+	for _, fieldName := range []string{"boxlite", "docker", "microsandbox"} {
+		field := message.Fields().ByName(fieldName)
+		if field == nil || field.ContainingOneof() != config {
+			t.Fatalf("DriverSpec.%s is not part of config", fieldName)
+		}
+	}
+	if field := message.Fields().ByName("name"); field != nil {
+		t.Fatal("DriverSpec.name must not duplicate the selected config case")
+	}
+}

--- a/proto/agentcompose/v2/selector_driver_contract_test.go
+++ b/proto/agentcompose/v2/selector_driver_contract_test.go
@@ -1,6 +1,10 @@
 package agentcomposev2
 
-import "testing"
+import (
+	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
 
 func TestExecSandboxProjectSelectorsShareOneof(t *testing.T) {
 	message := (&ExecSandboxSelector{}).ProtoReflect().Descriptor()
@@ -9,7 +13,7 @@ func TestExecSandboxProjectSelectorsShareOneof(t *testing.T) {
 		t.Fatal("ExecSandboxSelector.project oneof is missing")
 	}
 	for _, fieldName := range []string{"project_id", "project_name"} {
-		field := message.Fields().ByName(fieldName)
+		field := message.Fields().ByName(protoreflect.Name(fieldName))
 		if field == nil || field.ContainingOneof() != project {
 			t.Fatalf("ExecSandboxSelector.%s is not part of project", fieldName)
 		}
@@ -26,7 +30,7 @@ func TestDriverSpecUsesSingleConfigOneof(t *testing.T) {
 		t.Fatal("DriverSpec.config oneof is missing")
 	}
 	for _, fieldName := range []string{"boxlite", "docker", "microsandbox"} {
-		field := message.Fields().ByName(fieldName)
+		field := message.Fields().ByName(protoreflect.Name(fieldName))
 		if field == nil || field.ContainingOneof() != config {
 			t.Fatalf("DriverSpec.%s is not part of config", fieldName)
 		}

--- a/proto/agentcompose/v2/selector_driver_contract_test.go
+++ b/proto/agentcompose/v2/selector_driver_contract_test.go
@@ -31,7 +31,7 @@ func TestDriverSpecUsesSingleConfigOneof(t *testing.T) {
 			t.Fatalf("DriverSpec.%s is not part of config", fieldName)
 		}
 	}
-	if field := message.Fields().ByName("name"); field != nil {
-		t.Fatal("DriverSpec.name must not duplicate the selected config case")
+	if field := message.Fields().ByName("name"); field == nil || field.ContainingOneof() != nil {
+		t.Fatal("DriverSpec.name must remain an independent compatibility field")
 	}
 }

--- a/test/e2e/docker_jupyter_host_daemon_test.go
+++ b/test/e2e/docker_jupyter_host_daemon_test.go
@@ -65,6 +65,7 @@ func TestE2EDockerJupyterHostDaemonStopResume(t *testing.T) {
 				Provider: "codex",
 				Image:    image,
 				Driver: &agentcomposev2.DriverSpec{
+					Name:   "docker",
 					Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}},
 				},
 			}},

--- a/test/e2e/docker_jupyter_host_daemon_test.go
+++ b/test/e2e/docker_jupyter_host_daemon_test.go
@@ -65,8 +65,7 @@ func TestE2EDockerJupyterHostDaemonStopResume(t *testing.T) {
 				Provider: "codex",
 				Image:    image,
 				Driver: &agentcomposev2.DriverSpec{
-					Name:   "docker",
-					Docker: &agentcomposev2.DockerDriverSpec{},
+					Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}},
 				},
 			}},
 		},

--- a/test/e2e/docker_workspace_resume_host_daemon_test.go
+++ b/test/e2e/docker_workspace_resume_host_daemon_test.go
@@ -96,7 +96,7 @@ func TestE2EDockerFileWorkspaceResumePreservesState(t *testing.T) {
 				Name:      "worker",
 				Provider:  "codex",
 				Image:     image,
-				Driver:    &agentcomposev2.DriverSpec{Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}},
+				Driver:    &agentcomposev2.DriverSpec{Name: "docker", Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}},
 				Workspace: &agentcomposev2.WorkspaceSpec{Name: "source"},
 			}},
 		},

--- a/test/e2e/docker_workspace_resume_host_daemon_test.go
+++ b/test/e2e/docker_workspace_resume_host_daemon_test.go
@@ -96,7 +96,7 @@ func TestE2EDockerFileWorkspaceResumePreservesState(t *testing.T) {
 				Name:      "worker",
 				Provider:  "codex",
 				Image:     image,
-				Driver:    &agentcomposev2.DriverSpec{Name: "docker", Docker: &agentcomposev2.DockerDriverSpec{}},
+				Driver:    &agentcomposev2.DriverSpec{Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}},
 				Workspace: &agentcomposev2.WorkspaceSpec{Name: "source"},
 			}},
 		},

--- a/test/e2e/image_docker_lifecycle_test.go
+++ b/test/e2e/image_docker_lifecycle_test.go
@@ -138,6 +138,7 @@ func TestE2EImageDockerSandboxLifecycle(t *testing.T) {
 				Provider: "codex",
 				Image:    guestImage,
 				Driver: &agentcomposev2.DriverSpec{
+					Name:   "docker",
 					Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}},
 				},
 			}},

--- a/test/e2e/image_docker_lifecycle_test.go
+++ b/test/e2e/image_docker_lifecycle_test.go
@@ -138,8 +138,7 @@ func TestE2EImageDockerSandboxLifecycle(t *testing.T) {
 				Provider: "codex",
 				Image:    guestImage,
 				Driver: &agentcomposev2.DriverSpec{
-					Name:   "docker",
-					Docker: &agentcomposev2.DockerDriverSpec{},
+					Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}},
 				},
 			}},
 		},

--- a/test/e2e/retention_host_daemon_test.go
+++ b/test/e2e/retention_host_daemon_test.go
@@ -131,7 +131,7 @@ func applyE2ERetentionProject(t *testing.T, ctx context.Context, client agentcom
 			Name: "docker-retention-e2e",
 			Agents: []*agentcomposev2.AgentSpec{{
 				Name: "worker", Provider: "codex", Image: image,
-				Driver: &agentcomposev2.DriverSpec{Name: "docker", Docker: &agentcomposev2.DockerDriverSpec{}},
+				Driver: &agentcomposev2.DriverSpec{Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}},
 			}},
 		},
 		Source: &agentcomposev2.ProjectSource{ComposePath: filepath.Join(root, "agent-compose.yml"), ProjectDir: root},

--- a/test/e2e/retention_host_daemon_test.go
+++ b/test/e2e/retention_host_daemon_test.go
@@ -131,7 +131,7 @@ func applyE2ERetentionProject(t *testing.T, ctx context.Context, client agentcom
 			Name: "docker-retention-e2e",
 			Agents: []*agentcomposev2.AgentSpec{{
 				Name: "worker", Provider: "codex", Image: image,
-				Driver: &agentcomposev2.DriverSpec{Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}},
+				Driver: &agentcomposev2.DriverSpec{Name: "docker", Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}},
 			}},
 		},
 		Source: &agentcomposev2.ProjectSource{ComposePath: filepath.Join(root, "agent-compose.yml"), ProjectDir: root},


### PR DESCRIPTION
  ## Summary

  - Make `ExecSandboxSelector.project_id` and `project_name` mutually exclusive through a protobuf oneof.
  - Define `DriverSpec` as a single-driver model, using the selected config oneof case as the driver type and removing the redundant `name` field.
  - Update API mappings, CLI tests, and E2E request construction for the generated oneof APIs.
  - Document required, replace, clear, no-op, and collection semantics for all v2 Apply/Set/Update requests.
  - Add the v2 selector and mutation contract design document.
  - Add contract and regression tests for selector/driver oneofs, global environment replacement, collection clearing, and secret value presence.

  Closes #475.

  ## Testing

  - `go test ./...`
  - `task lint`
  - `task build`
  - `task test`
  - `task docs:build`
  - `git diff --check`

  ## Checklist

  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.