### PR TITLE
fix(driver): wait for docker jupyter port binding

### DIFF
--- a/pkg/driver/docker_runtime.go
+++ b/pkg/driver/docker_runtime.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -36,7 +37,27 @@ const (
 
 	dockerStopAPIMargin             = 5 * time.Second
 	dockerStopFallbackActionTimeout = 5 * time.Second
+	dockerJupyterPortBindingWait    = 5 * time.Second
+	dockerJupyterPortBindingPoll    = 50 * time.Millisecond
 )
+
+var errDockerJupyterPortBindingPending = errors.New("docker jupyter port binding pending")
+
+type dockerJupyterPortBindingPendingError struct {
+	cause error
+}
+
+func (e dockerJupyterPortBindingPendingError) Error() string {
+	return e.cause.Error()
+}
+
+func (e dockerJupyterPortBindingPendingError) Unwrap() error {
+	return errDockerJupyterPortBindingPending
+}
+
+func dockerJupyterPortBindingPendingErrorf(format string, args ...any) error {
+	return dockerJupyterPortBindingPendingError{cause: fmt.Errorf(format, args...)}
+}
 
 type dockerRuntime struct {
 	config *appconfig.Config
@@ -45,6 +66,13 @@ type dockerRuntime struct {
 type dockerContainerRemover interface {
 	ContainerRemove(context.Context, string, containerapi.RemoveOptions) error
 }
+
+type dockerContainerFailureCleaner interface {
+	ContainerRemove(context.Context, string, containerapi.RemoveOptions) error
+	ContainerStop(context.Context, string, containerapi.StopOptions) error
+}
+
+type dockerContainerInspector func(context.Context, string) (containerapi.InspectResponse, error)
 
 type dockerDaemonTopology struct {
 	networkMode   containerapi.NetworkMode
@@ -156,27 +184,39 @@ func (r *dockerRuntime) EnsureSandbox(ctx context.Context, sandbox *Sandbox, vmS
 	defer func() { _ = dockerClient.Close() }()
 
 	topology := r.dockerDaemonTopology(ctx, dockerClient)
-	containerInfo, _, err := r.getOrCreateContainer(ctx, dockerClient, sandbox, vmState, proxyState, topology.networkMode)
+	containerInfo, created, err := r.getOrCreateContainer(ctx, dockerClient, sandbox, vmState, proxyState, topology.networkMode)
 	if err != nil {
 		return SandboxVMInfo{}, err
 	}
+	started := false
 	if containerInfo.State == nil || !containerInfo.State.Running {
 		if err := dockerClient.ContainerStart(ctx, containerInfo.ID, containerapi.StartOptions{}); err != nil {
-			return SandboxVMInfo{}, fmt.Errorf("start docker container %s: %w", containerInfo.ID, err)
+			return SandboxVMInfo{}, r.cleanupDockerContainerAfterEnsureFailure(ctx, dockerClient, containerInfo.ID, created, started, fmt.Errorf("start docker container %s: %w", containerInfo.ID, err))
 		}
+		started = true
 	}
 	if topology.containerized {
 		if err := ensureDockerContainerNetwork(ctx, dockerClient, containerInfo, string(topology.networkMode)); err != nil {
-			return SandboxVMInfo{}, err
+			return SandboxVMInfo{}, r.cleanupDockerContainerAfterEnsureFailure(ctx, dockerClient, containerInfo.ID, created, started, err)
 		}
 	}
 	containerInfo, err = dockerClient.ContainerInspect(ctx, containerInfo.ID)
 	if err != nil {
-		return SandboxVMInfo{}, fmt.Errorf("inspect started docker container %s: %w", containerInfo.ID, err)
+		return SandboxVMInfo{}, r.cleanupDockerContainerAfterEnsureFailure(ctx, dockerClient, containerInfo.ID, created, started, fmt.Errorf("inspect started docker container %s: %w", containerInfo.ID, err))
 	}
-	proxyState, err = r.dockerSandboxProxyState(sandbox, vmState, proxyState, containerInfo, topology.containerized)
+	containerInfo, proxyState, err = r.waitForDockerJupyterProxyState(
+		ctx,
+		dockerClient.ContainerInspect,
+		sandbox,
+		vmState,
+		proxyState,
+		containerInfo,
+		topology.containerized,
+		dockerJupyterPortBindingWait,
+		dockerJupyterPortBindingPoll,
+	)
 	if err != nil {
-		return SandboxVMInfo{}, err
+		return SandboxVMInfo{}, r.cleanupDockerContainerAfterEnsureFailure(ctx, dockerClient, containerInfo.ID, created, started, err)
 	}
 	if !jupyterEnabled(proxyState) {
 		return SandboxVMInfo{BoxID: containerInfo.ID, ProxyState: &proxyState}, nil
@@ -190,12 +230,12 @@ func (r *dockerRuntime) EnsureSandbox(ctx context.Context, sandbox *Sandbox, vmS
 			return SandboxVMInfo{BoxID: containerInfo.ID, JupyterURL: jupyterDirectURL(proxyState), ProxyState: &proxyState}, nil
 		}
 		if logText := readSandboxJupyterLog(sandbox); logText != "" {
-			return SandboxVMInfo{}, fmt.Errorf("%w\nGuest log:\n%s", readyErr, logText)
+			return SandboxVMInfo{}, r.cleanupDockerContainerAfterEnsureFailure(ctx, dockerClient, containerInfo.ID, created, started, fmt.Errorf("%w\nGuest log:\n%s", readyErr, logText))
 		}
 		if logText, err := r.readContainerLogs(ctx, dockerClient, containerInfo.ID); err == nil && strings.TrimSpace(logText) != "" {
-			return SandboxVMInfo{}, fmt.Errorf("%w\nContainer log:\n%s", readyErr, strings.TrimSpace(logText))
+			return SandboxVMInfo{}, r.cleanupDockerContainerAfterEnsureFailure(ctx, dockerClient, containerInfo.ID, created, started, fmt.Errorf("%w\nContainer log:\n%s", readyErr, strings.TrimSpace(logText)))
 		}
-		return SandboxVMInfo{}, readyErr
+		return SandboxVMInfo{}, r.cleanupDockerContainerAfterEnsureFailure(ctx, dockerClient, containerInfo.ID, created, started, readyErr)
 	}
 
 	return SandboxVMInfo{BoxID: containerInfo.ID, JupyterURL: jupyterDirectURL(proxyState), ProxyState: &proxyState}, nil
@@ -231,6 +271,31 @@ func removeDockerContainerWithStaleMounts(ctx context.Context, remover dockerCon
 		return fmt.Errorf("remove docker container with stale mounts %s: %w", containerID, err)
 	}
 	return nil
+}
+
+func (r *dockerRuntime) cleanupDockerContainerAfterEnsureFailure(
+	ctx context.Context,
+	cleaner dockerContainerFailureCleaner,
+	containerID string,
+	created bool,
+	started bool,
+	cause error,
+) error {
+	if (!created && !started) || strings.TrimSpace(containerID) == "" || cause == nil {
+		return cause
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dockerStopFallbackActionTimeout)
+	defer cancel()
+	if created {
+		if err := cleaner.ContainerRemove(cleanupCtx, containerID, containerapi.RemoveOptions{Force: true}); err != nil && !isDockerNotFound(err) {
+			return fmt.Errorf("%w; cleanup newly created docker container %s: %v", cause, containerID, err)
+		}
+		return cause
+	}
+	if err := cleaner.ContainerStop(cleanupCtx, containerID, containerapi.StopOptions{}); err != nil && !isDockerNotFound(err) {
+		return fmt.Errorf("%w; stop docker container %s after failed ensure: %v", cause, containerID, err)
+	}
+	return cause
 }
 
 func (r *dockerRuntime) StopSandbox(ctx context.Context, sandbox *Sandbox, vmState VMState) (bool, error) {
@@ -1175,17 +1240,69 @@ func (r *dockerRuntime) dockerSandboxProxyState(sandbox *Sandbox, vmState VMStat
 	return proxyState, nil
 }
 
+func (r *dockerRuntime) waitForDockerJupyterProxyState(
+	ctx context.Context,
+	inspect dockerContainerInspector,
+	sandbox *Sandbox,
+	vmState VMState,
+	proxyState ProxyState,
+	containerInfo containerapi.InspectResponse,
+	containerizedDaemon bool,
+	waitTimeout time.Duration,
+	pollInterval time.Duration,
+) (containerapi.InspectResponse, ProxyState, error) {
+	currentState, err := r.dockerSandboxProxyState(sandbox, vmState, proxyState, containerInfo, containerizedDaemon)
+	if err == nil || !proxyState.Enabled || waitTimeout <= 0 || pollInterval <= 0 {
+		return containerInfo, currentState, err
+	}
+	if !errors.Is(err, errDockerJupyterPortBindingPending) {
+		return containerInfo, ProxyState{}, err
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	lastErr := err
+	for {
+		select {
+		case <-waitCtx.Done():
+			if ctx.Err() != nil {
+				return containerInfo, ProxyState{}, ctx.Err()
+			}
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return containerInfo, ProxyState{}, lastErr
+			}
+			return containerInfo, ProxyState{}, waitCtx.Err()
+		case <-ticker.C:
+			refreshed, inspectErr := inspect(waitCtx, containerInfo.ID)
+			if inspectErr != nil {
+				return containerInfo, ProxyState{}, fmt.Errorf("inspect started docker container %s: %w", containerInfo.ID, inspectErr)
+			}
+			currentState, err = r.dockerSandboxProxyState(sandbox, vmState, proxyState, refreshed, containerizedDaemon)
+			if err == nil {
+				return refreshed, currentState, nil
+			}
+			if !errors.Is(err, errDockerJupyterPortBindingPending) {
+				return refreshed, ProxyState{}, err
+			}
+			containerInfo = refreshed
+			lastErr = err
+		}
+	}
+}
+
 func dockerJupyterHostPort(containerInfo containerapi.InspectResponse, guestPort int) (int, error) {
 	if guestPort <= 0 {
 		return 0, fmt.Errorf("docker jupyter guest port must be positive, got %d", guestPort)
 	}
 	if containerInfo.NetworkSettings == nil {
-		return 0, fmt.Errorf("docker container %s has no network settings", containerInfo.ID)
+		return 0, dockerJupyterPortBindingPendingErrorf("docker container %s has no network settings", containerInfo.ID)
 	}
 	port := nat.Port(strconv.Itoa(guestPort) + "/tcp")
 	bindings, ok := containerInfo.NetworkSettings.Ports[port]
 	if !ok || len(bindings) == 0 {
-		return 0, fmt.Errorf("docker container %s has no binding for jupyter port %s", containerInfo.ID, port)
+		return 0, dockerJupyterPortBindingPendingErrorf("docker container %s has no binding for jupyter port %s", containerInfo.ID, port)
 	}
 	for _, binding := range bindings {
 		hostIP := net.ParseIP(strings.TrimSpace(binding.HostIP))

--- a/pkg/driver/docker_runtime_test.go
+++ b/pkg/driver/docker_runtime_test.go
@@ -565,6 +565,75 @@ func TestRemoveDockerContainerWithStaleMountsRequiresSuccessfulRetirement(t *tes
 	})
 }
 
+func TestCleanupDockerContainerAfterEnsureFailureRevertsOnlyOwnedStartup(t *testing.T) {
+	runtime := &dockerRuntime{}
+	cause := errors.New("ensure failed")
+
+	createdCleaner := &recordingDockerContainerCleaner{}
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := runtime.cleanupDockerContainerAfterEnsureFailure(canceledCtx, createdCleaner, "container-1", true, false, cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("cleanup returned %v, want original cause", err)
+	}
+	if createdCleaner.removedID != "container-1" || !createdCleaner.removeOptions.Force || createdCleaner.stoppedID != "" {
+		t.Fatalf("created cleanup remove=%q stop=%q options=%+v", createdCleaner.removedID, createdCleaner.stoppedID, createdCleaner.removeOptions)
+	}
+	if createdCleaner.removeCtxErr != nil || !createdCleaner.removeCtxHasDeadline {
+		t.Fatalf("created cleanup ctx err=%v has_deadline=%v, want active bounded cleanup context", createdCleaner.removeCtxErr, createdCleaner.removeCtxHasDeadline)
+	}
+
+	startedCleaner := &recordingDockerContainerCleaner{}
+	err = runtime.cleanupDockerContainerAfterEnsureFailure(context.Background(), startedCleaner, "container-2", false, true, cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("started cleanup returned %v, want original cause", err)
+	}
+	if startedCleaner.stoppedID != "container-2" || startedCleaner.removedID != "" {
+		t.Fatalf("started cleanup remove=%q stop=%q", startedCleaner.removedID, startedCleaner.stoppedID)
+	}
+	if startedCleaner.stopCtxErr != nil || !startedCleaner.stopCtxHasDeadline {
+		t.Fatalf("started cleanup ctx err=%v has_deadline=%v, want active bounded cleanup context", startedCleaner.stopCtxErr, startedCleaner.stopCtxHasDeadline)
+	}
+
+	untouchedCleaner := &recordingDockerContainerCleaner{}
+	err = runtime.cleanupDockerContainerAfterEnsureFailure(context.Background(), untouchedCleaner, "container-3", false, false, cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("existing cleanup returned %v, want original cause", err)
+	}
+	if untouchedCleaner.removedID != "" || untouchedCleaner.stoppedID != "" {
+		t.Fatalf("untouched cleanup remove=%q stop=%q", untouchedCleaner.removedID, untouchedCleaner.stoppedID)
+	}
+}
+
+type recordingDockerContainerCleaner struct {
+	removedID            string
+	removeOptions        containerapi.RemoveOptions
+	removeCtxErr         error
+	removeCtxHasDeadline bool
+	removeErr            error
+	stoppedID            string
+	stopOptions          containerapi.StopOptions
+	stopCtxErr           error
+	stopCtxHasDeadline   bool
+	stopErr              error
+}
+
+func (r *recordingDockerContainerCleaner) ContainerRemove(ctx context.Context, containerID string, options containerapi.RemoveOptions) error {
+	r.removedID = containerID
+	r.removeOptions = options
+	r.removeCtxErr = ctx.Err()
+	_, r.removeCtxHasDeadline = ctx.Deadline()
+	return r.removeErr
+}
+
+func (r *recordingDockerContainerCleaner) ContainerStop(ctx context.Context, containerID string, options containerapi.StopOptions) error {
+	r.stoppedID = containerID
+	r.stopOptions = options
+	r.stopCtxErr = ctx.Err()
+	_, r.stopCtxHasDeadline = ctx.Deadline()
+	return r.stopErr
+}
+
 type recordingDockerContainerRemover struct {
 	containerID string
 	options     containerapi.RemoveOptions
@@ -672,6 +741,24 @@ func TestDockerJupyterHostPortRejectsInvalidBindings(t *testing.T) {
 	}
 }
 
+func TestDockerJupyterHostPortClassifiesPendingBinding(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerInfo containerapi.InspectResponse
+	}{
+		{name: "missing network settings", containerInfo: containerapi.InspectResponse{ContainerJSONBase: &containerapi.ContainerJSONBase{ID: "container-1"}}},
+		{name: "missing binding", containerInfo: dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "42000"}})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := dockerJupyterHostPort(tt.containerInfo, 9999)
+			if !errors.Is(err, errDockerJupyterPortBindingPending) {
+				t.Fatalf("dockerJupyterHostPort err = %v, want pending binding", err)
+			}
+		})
+	}
+}
+
 func TestDockerRuntimeSandboxProxyStateUsesContainerNameAndGuestPort(t *testing.T) {
 	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
 	sandbox := &Sandbox{
@@ -705,6 +792,141 @@ func TestDockerRuntimeSandboxProxyStateUsesContainerNameAndGuestPort(t *testing.
 	}
 	if containerState.Token != "secret" {
 		t.Fatalf("dockerSandboxProxyState did not preserve token: %+v", containerState)
+	}
+}
+
+func TestDockerRuntimeWaitForJupyterProxyStateRetriesUntilBindingVisible(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{
+		Summary: SandboxSummary{
+			ID:         "session-1",
+			RuntimeRef: "runtime-ref",
+		},
+	}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, nil)
+	inspectCalls := 0
+	inspect := func(ctx context.Context, containerID string) (containerapi.InspectResponse, error) {
+		inspectCalls++
+		if containerID != "container-1" {
+			t.Fatalf("inspect containerID = %q, want container-1", containerID)
+		}
+		return dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "42000"}}), nil
+	}
+
+	containerInfo, proxyState, err := runtime.waitForDockerJupyterProxyState(context.Background(), inspect, sandbox, VMState{}, state, initialInfo, false, time.Second, time.Nanosecond)
+	if err != nil {
+		t.Fatalf("waitForDockerJupyterProxyState returned error: %v", err)
+	}
+	if inspectCalls != 1 {
+		t.Fatalf("inspect calls = %d, want 1", inspectCalls)
+	}
+	if containerInfo.ID != "container-1" || proxyState.GuestHost != "127.0.0.1" || proxyState.HostPort != 42000 || proxyState.Token != "secret" {
+		t.Fatalf("proxy state = %+v container = %+v, want refreshed loopback binding", proxyState, containerInfo.ContainerJSONBase)
+	}
+}
+
+func TestDockerRuntimeWaitForJupyterProxyStateReturnsContextCancellation(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{Summary: SandboxSummary{ID: "session-1", RuntimeRef: "runtime-ref"}}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := runtime.waitForDockerJupyterProxyState(ctx, func(context.Context, string) (containerapi.InspectResponse, error) {
+		t.Fatal("inspect must not run after context cancellation")
+		return containerapi.InspectResponse{}, nil
+	}, sandbox, VMState{}, state, initialInfo, false, time.Second, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForDockerJupyterProxyState err = %v, want context.Canceled", err)
+	}
+}
+
+func TestDockerRuntimeWaitForJupyterProxyStateReturnsParentDeadline(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{Summary: SandboxSummary{ID: "session-1", RuntimeRef: "runtime-ref"}}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+
+	_, _, err := runtime.waitForDockerJupyterProxyState(ctx, func(context.Context, string) (containerapi.InspectResponse, error) {
+		t.Fatal("inspect must not run after parent context deadline")
+		return containerapi.InspectResponse{}, nil
+	}, sandbox, VMState{}, state, initialInfo, false, time.Second, time.Hour)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitForDockerJupyterProxyState err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestDockerRuntimeWaitForJupyterProxyStateDoesNotRetryPermanentErrors(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{Summary: SandboxSummary{ID: "session-1", RuntimeRef: "runtime-ref"}}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "42000"}})
+
+	_, _, err := runtime.waitForDockerJupyterProxyState(context.Background(), func(context.Context, string) (containerapi.InspectResponse, error) {
+		t.Fatal("inspect must not run for permanent binding errors")
+		return containerapi.InspectResponse{}, nil
+	}, sandbox, VMState{}, state, initialInfo, false, time.Second, time.Nanosecond)
+	if err == nil || errors.Is(err, errDockerJupyterPortBindingPending) || !strings.Contains(err.Error(), "no valid loopback binding") {
+		t.Fatalf("waitForDockerJupyterProxyState err = %v, want permanent loopback binding error", err)
+	}
+}
+
+func TestDockerRuntimeWaitForJupyterProxyStateReturnsPendingErrorAfterTimeout(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{Summary: SandboxSummary{ID: "session-1", RuntimeRef: "runtime-ref"}}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, nil)
+
+	_, _, err := runtime.waitForDockerJupyterProxyState(context.Background(), func(context.Context, string) (containerapi.InspectResponse, error) {
+		t.Fatal("inspect must not run when timeout expires before next poll")
+		return containerapi.InspectResponse{}, nil
+	}, sandbox, VMState{}, state, initialInfo, false, time.Nanosecond, time.Hour)
+	if !errors.Is(err, errDockerJupyterPortBindingPending) || !strings.Contains(err.Error(), "no binding") {
+		t.Fatalf("waitForDockerJupyterProxyState err = %v, want pending binding error", err)
+	}
+}
+
+func TestDockerRuntimeWaitForJupyterProxyStateReturnsInspectError(t *testing.T) {
+	runtime := &dockerRuntime{config: &appconfig.Config{JupyterGuestPort: 8888}}
+	sandbox := &Sandbox{Summary: SandboxSummary{ID: "session-1", RuntimeRef: "runtime-ref"}}
+	state := ProxyState{
+		GuestPort: 8888,
+		Token:     "secret",
+		Enabled:   true,
+	}
+	initialInfo := dockerInspectWithJupyterBindings("container-1", "/runtime-ref", 8888, nil)
+	inspectErr := errors.New("docker inspect failed")
+
+	_, _, err := runtime.waitForDockerJupyterProxyState(context.Background(), func(context.Context, string) (containerapi.InspectResponse, error) {
+		return containerapi.InspectResponse{}, inspectErr
+	}, sandbox, VMState{}, state, initialInfo, false, time.Second, time.Nanosecond)
+	if !errors.Is(err, inspectErr) || !strings.Contains(err.Error(), "inspect started docker container container-1") {
+		t.Fatalf("waitForDockerJupyterProxyState err = %v, want inspect error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- wait briefly for Docker to publish dynamic Jupyter port bindings after container start
- keep the refreshed Docker inspect result when building proxy state
- preserve context cancellation while keeping timeout behavior as the original binding error
- add regression tests for delayed binding visibility and cancellation propagation

Fixes #458

## Tests
- go test ./pkg/driver ./pkg/runs ./pkg/sandboxes ./pkg/storage/sandboxstore
- PATH="/Users/xiaoluer/go/bin:$PATH" task lint
- git diff --check
- go test ./pkg/driver -run 'TestDockerRuntimeWaitForJupyterProxyState' -count=1
