### PR TITLE
fix(cli): honor explicit project inspect refs

### DIFF
--- a/cmd/agent-compose/cli_project_inspect.go
+++ b/cmd/agent-compose/cli_project_inspect.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	"agent-compose/pkg/identity"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func runComposeProjectInspectCommand(cmd *cobra.Command, cli cliOptions, clients cliServiceClients, ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "inspect project", runtimeProjectWithState)
+		if err != nil {
+			return err
+		}
+		return writeComposeInspectOutput(cmd, composeProjectOutputFromProject(runtimeProject.project))
+	}
+
+	project, err := resolveExplicitInspectProject(cmd, clients, ref)
+	if err != nil {
+		return err
+	}
+	return writeComposeInspectOutput(cmd, composeProjectOutputFromProject(project))
+}
+
+func resolveExplicitInspectProject(cmd *cobra.Command, clients cliServiceClients, ref string) (*agentcomposev2.Project, error) {
+	project, err := getInspectProject(cmd.Context(), clients.project, &agentcomposev2.ProjectRef{
+		Selector: &agentcomposev2.ProjectRef_Name{Name: ref},
+	})
+	if err == nil {
+		return project, nil
+	}
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		return nil, explicitInspectProjectError(ref, err)
+	}
+
+	if identity.IsID(ref) {
+		project, err = getInspectProject(cmd.Context(), clients.project, &agentcomposev2.ProjectRef{
+			Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: ref},
+		})
+		if err != nil {
+			return nil, explicitInspectProjectError(ref, err)
+		}
+		return project, nil
+	}
+	if !identity.IsIDPrefix(ref) {
+		return nil, explicitInspectProjectError(ref, err)
+	}
+
+	target, err := resolveCLIResourceID(cmd, clients.resource, ref, []agentcomposev2.ResourceKind{
+		agentcomposev2.ResourceKind_RESOURCE_KIND_PROJECT,
+	})
+	if err != nil {
+		return nil, err
+	}
+	project, err = getInspectProject(cmd.Context(), clients.project, &agentcomposev2.ProjectRef{
+		Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: target.GetId()},
+	})
+	if err != nil {
+		return nil, explicitInspectProjectError(ref, err)
+	}
+	return project, nil
+}
+
+func getInspectProject(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, ref *agentcomposev2.ProjectRef) (*agentcomposev2.Project, error) {
+	response, err := client.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
+		Project:     ref,
+		IncludeSpec: true,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	project := response.Msg.GetProject()
+	if project == nil || strings.TrimSpace(project.GetSummary().GetProjectId()) == "" {
+		return nil, fmt.Errorf("get inspect project: response did not include a project")
+	}
+	return project, nil
+}
+
+func explicitInspectProjectError(ref string, err error) error {
+	return commandExitErrorForComposeProject(
+		fmt.Errorf("inspect project %s: %w", ref, err),
+		"inspect project",
+		ref,
+		"",
+	)
+}

--- a/cmd/agent-compose/cli_project_inspect_test.go
+++ b/cmd/agent-compose/cli_project_inspect_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/identity"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestIntegrationCLIInspectProjectExplicitRefOverridesImplicitSelectors(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: compose-project
+agents: {}
+`)
+	targetID := strings.Repeat("b", 64)
+	targetProject := testCLIProject(targetID, "target-project", "/projects/target/agent-compose.yml")
+	shortID := identity.ShortID(targetID)
+
+	var requestedNames []string
+	var requestedIDs []string
+	resolveRequests := 0
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				switch selector := req.Msg.GetProject().GetSelector().(type) {
+				case *agentcomposev2.ProjectRef_Name:
+					requestedNames = append(requestedNames, selector.Name)
+					if selector.Name == targetProject.GetSummary().GetName() {
+						return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: targetProject}), nil
+					}
+					return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project name %s not found", selector.Name))
+				case *agentcomposev2.ProjectRef_ProjectId:
+					requestedIDs = append(requestedIDs, selector.ProjectId)
+					if selector.ProjectId == targetID {
+						return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: targetProject}), nil
+					}
+					return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project id %s not found", selector.ProjectId))
+				default:
+					return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unexpected project selector %T", selector))
+				}
+			},
+		},
+		resource: resourceServiceStub{
+			resolveID: func(_ context.Context, req *connect.Request[agentcomposev2.ResolveResourceIDRequest]) (*connect.Response[agentcomposev2.ResolveResourceIDResponse], error) {
+				resolveRequests++
+				if req.Msg.GetId() != shortID {
+					t.Fatalf("ResolveID id = %q, want %q", req.Msg.GetId(), shortID)
+				}
+				if len(req.Msg.GetKinds()) != 1 || req.Msg.GetKinds()[0] != agentcomposev2.ResourceKind_RESOURCE_KIND_PROJECT {
+					t.Fatalf("ResolveID kinds = %v, want project only", req.Msg.GetKinds())
+				}
+				return connect.NewResponse(&agentcomposev2.ResolveResourceIDResponse{Targets: []*agentcomposev2.ResourceTarget{{
+					Kind:      agentcomposev2.ResourceKind_RESOURCE_KIND_PROJECT,
+					Id:        targetID,
+					ShortId:   shortID,
+					ProjectId: targetID,
+				}}}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	tests := []struct {
+		name      string
+		ref       string
+		selectors []string
+	}{
+		{name: "name overrides file", ref: targetProject.GetSummary().GetName(), selectors: []string{"--file", composePath}},
+		{name: "full id overrides project name", ref: targetID, selectors: []string{"--project-name", "selected-project"}},
+		{name: "short id overrides file and project name", ref: shortID, selectors: []string{"--file", composePath, "--project-name", "selected-project"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"inspect", "--host", server.URL}
+			args = append(args, test.selectors...)
+			args = append(args, "--json", "project", test.ref)
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != 0 || stderr != "" {
+				t.Fatalf("inspect project %s code/stderr = %d/%q", test.ref, exitCode, stderr)
+			}
+			var output composeProjectOutput
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+				t.Fatalf("decode inspect project %s output: %v\n%s", test.ref, err, stdout)
+			}
+			if output.Project.ID != targetID || output.Project.Name != "target-project" {
+				t.Fatalf("inspect project %s output = %#v", test.ref, output.Project)
+			}
+		})
+	}
+
+	if strings.Contains(strings.Join(requestedNames, "\x00"), "selected-project") {
+		t.Fatalf("explicit refs fell back to --project-name: requested names = %v", requestedNames)
+	}
+	if resolveRequests != 1 {
+		t.Fatalf("ResolveID requests = %d, want 1 for the short ID only", resolveRequests)
+	}
+	if len(requestedIDs) != 2 || requestedIDs[0] != targetID || requestedIDs[1] != targetID {
+		t.Fatalf("project ID requests = %v, want the target full ID twice", requestedIDs)
+	}
+}
+
+func TestIntegrationCLIInspectProjectExplicitMissingRefDoesNotFallback(t *testing.T) {
+	composePath := writeComposeFile(t, t.TempDir(), `
+name: compose-project
+agents: {}
+`)
+	selectedProject := testCLIProject(strings.Repeat("a", 64), "selected-project", composePath)
+	composeProjectID, err := domain.StableProjectID("compose-project", domain.NormalizeProjectSourcePath(composePath))
+	if err != nil {
+		t.Fatalf("StableProjectID returned error: %v", err)
+	}
+	composeProject := testCLIProject(composeProjectID, "compose-project", composePath)
+	missingID := strings.Repeat("c", 64)
+
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				switch selector := req.Msg.GetProject().GetSelector().(type) {
+				case *agentcomposev2.ProjectRef_Name:
+					if selector.Name == selectedProject.GetSummary().GetName() {
+						return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: selectedProject}), nil
+					}
+					return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project name %s not found", selector.Name))
+				case *agentcomposev2.ProjectRef_ProjectId:
+					if selector.ProjectId == composeProjectID {
+						return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: composeProject}), nil
+					}
+					return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project id %s not found", selector.ProjectId))
+				default:
+					return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unexpected project selector %T", selector))
+				}
+			},
+		},
+	})
+	defer server.Close()
+
+	tests := []struct {
+		name      string
+		ref       string
+		selectors []string
+	}{
+		{name: "missing name with file", ref: "missing-project", selectors: []string{"--file", composePath}},
+		{name: "missing full id with project name", ref: missingID, selectors: []string{"--project-name", selectedProject.GetSummary().GetName()}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"inspect", "--host", server.URL}
+			args = append(args, test.selectors...)
+			args = append(args, "--json", "project", test.ref)
+			stdout, stderr, _, exitCode := executeCLICommand(args...)
+			if exitCode != exitCodeUsage {
+				t.Fatalf("inspect missing project %s exit code = %d, want %d; stderr=%q", test.ref, exitCode, exitCodeUsage, stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("inspect missing project %s stdout = %q, want empty", test.ref, stdout)
+			}
+			if !strings.Contains(stderr, test.ref) || !strings.Contains(strings.ToLower(stderr), "not found") {
+				t.Fatalf("inspect missing project %s stderr = %q, want ref and not found", test.ref, stderr)
+			}
+			if strings.Contains(stderr, selectedProject.GetSummary().GetProjectId()) {
+				t.Fatalf("inspect missing project %s fell back to selected project: %q", test.ref, stderr)
+			}
+		})
+	}
+}
+
+func TestIntegrationCLIInspectProjectRejectsAmbiguousShortID(t *testing.T) {
+	shortID := strings.Repeat("d", 12)
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+				return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project name %s not found", req.Msg.GetProject().GetName()))
+			},
+		},
+		resource: resourceServiceStub{
+			resolveID: func(_ context.Context, req *connect.Request[agentcomposev2.ResolveResourceIDRequest]) (*connect.Response[agentcomposev2.ResolveResourceIDResponse], error) {
+				if req.Msg.GetId() != shortID || len(req.Msg.GetKinds()) != 1 || req.Msg.GetKinds()[0] != agentcomposev2.ResourceKind_RESOURCE_KIND_PROJECT {
+					t.Fatalf("ResolveID request = %#v", req.Msg)
+				}
+				return connect.NewResponse(&agentcomposev2.ResolveResourceIDResponse{Targets: []*agentcomposev2.ResourceTarget{
+					{Kind: agentcomposev2.ResourceKind_RESOURCE_KIND_PROJECT, Id: shortID + strings.Repeat("1", 52), ShortId: shortID},
+					{Kind: agentcomposev2.ResourceKind_RESOURCE_KIND_PROJECT, Id: shortID + strings.Repeat("2", 52), ShortId: shortID},
+				}}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("inspect", "--host", server.URL, "--project-name", "selected-project", "project", shortID)
+	if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(strings.ToLower(stderr), "ambiguous") {
+		t.Fatalf("inspect ambiguous project code/stdout/stderr = %d/%q/%q", exitCode, stdout, stderr)
+	}
+}

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -542,8 +542,11 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 	if err != nil {
 		return err
 	}
+	if kind == "project" {
+		return runComposeProjectInspectCommand(cmd, cli, clients, target)
+	}
 	loadMode := runtimeProjectIdentityOnly
-	if kind == "project" || kind == "agent" {
+	if kind == "agent" {
 		loadMode = runtimeProjectWithState
 	}
 	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "inspect "+kind, loadMode)
@@ -553,8 +556,6 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 	projectID := runtimeProject.id()
 	var output any
 	switch kind {
-	case "project":
-		output = composeProjectOutputFromProject(runtimeProject.project)
 	case "agent":
 		if target == "" {
 			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect agent requires an agent name")}

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -524,6 +524,7 @@ Inspect project resources, daemon images, or runtime cache items.
 
 ```bash
 agent-compose inspect project
+agent-compose inspect project <project-name|project-id|short-id>
 agent-compose inspect <project|agent|run|sandbox|image|cache-id>
 agent-compose inspect agent <agent>
 agent-compose inspect run <run-id>
@@ -533,6 +534,8 @@ agent-compose inspect cache <cache-id>
 ```
 
 When a full ID or hexadecimal short ID is passed as the only argument, `inspect` resolves its resource type through the daemon. Names still require the explicit typed form. Ambiguous short IDs are rejected with the matching resource types.
+
+For `inspect project <project-ref>`, the positional project reference takes precedence over both `--project-name` and `--file`. It is resolved as an exact project name first, then as a full ID or unique short ID. If the explicit reference is missing or ambiguous, the command fails instead of falling back to the project selected by flags or the current Compose file. Without a positional project reference, `inspect project` keeps using the normal deployed-project selection rules.
 
 Details:
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -529,6 +529,7 @@ agent-compose logs --run run_123 --json
 
 ```bash
 agent-compose inspect project
+agent-compose inspect project <project-name|project-id|short-id>
 agent-compose inspect <project|agent|run|sandbox|image|cache-id>
 agent-compose inspect agent <agent>
 agent-compose inspect run <run-id>
@@ -538,6 +539,8 @@ agent-compose inspect cache <cache-id>
 ```
 
 当唯一参数是完整 ID 或十六进制短 ID 时，`inspect` 会通过 daemon 自动识别资源类型。名称仍需使用显式类型形式；短 ID 命中多个资源时，命令会报告歧义及候选资源类型。
+
+对于 `inspect project <project-ref>`，位置参数中的 project ref 优先于 `--project-name` 和 `--file`。CLI 会先按精确 project name 解析，再按完整 ID 或唯一 short ID 解析；如果显式 ref 不存在或存在歧义，命令会直接失败，不会回退到 flag 或当前 Compose 文件选中的 project。不提供位置参数时，`inspect project` 继续使用常规的已部署 project 选择规则。
 
 说明：
 


### PR DESCRIPTION
## Summary

- honor the explicit project reference passed to `agent-compose inspect project <ref>` instead of silently falling back to `--project-name` or the current Compose file
- resolve explicit references by exact project name first, then by full ID or unique project short ID, while preserving the existing implicit selection behavior when no reference is supplied
- return clear not-found or ambiguous errors and document the selector precedence in the English and Chinese command manuals
- add CLI integration coverage for name, full ID, short ID, missing references, ambiguous short IDs, and conflicts with `--file` / `--project-name`

Fixes #479

## Testing

- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -run '^TestIntegrationCLIInspectProject' -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.68%
  - Integration: 60.77%
  - E2E: 60.27%
  - Combined: 78.83%
- `GOFLAGS=-buildvcs=false task docs:build`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
