### PR TITLE
fix(api)!: normalize execution RPC names

### DIFF
--- a/cmd/agent-compose/cli_daemon_http_test.go
+++ b/cmd/agent-compose/cli_daemon_http_test.go
@@ -113,7 +113,7 @@ func TestDaemonHTTPClientUsesH2COnlyForAttachRPCs(t *testing.T) {
 	defer server.Close()
 
 	client := newDaemonHTTPClient(cliClientConfig{BaseURL: server.URL})
-	for _, path := range []string{"/api/version", agentcomposev2connect.RunServiceRunAttachProcedure} {
+	for _, path := range []string{"/api/version", agentcomposev2connect.RunServiceAttachAgentRunProcedure} {
 		req, err := http.NewRequest(http.MethodPost, server.URL+path, nil)
 		if err != nil {
 			t.Fatalf("NewRequest(%q) error = %v", path, err)
@@ -128,16 +128,16 @@ func TestDaemonHTTPClientUsesH2COnlyForAttachRPCs(t *testing.T) {
 	if got, want := <-seen, "/api/version HTTP/1.1"; got != want {
 		t.Fatalf("ordinary request protocol = %q, want %q", got, want)
 	}
-	if got, want := <-seen, agentcomposev2connect.RunServiceRunAttachProcedure+" HTTP/2.0"; got != want {
+	if got, want := <-seen, agentcomposev2connect.RunServiceAttachAgentRunProcedure+" HTTP/2.0"; got != want {
 		t.Fatalf("attach request protocol = %q, want %q", got, want)
 	}
 }
 
-func TestDaemonHTTPClientRunAttachBidiUsesH2C(t *testing.T) {
+func TestDaemonHTTPClientAttachAgentRunBidiUsesH2C(t *testing.T) {
 	seen := make(chan string, 1)
 	mux := http.NewServeMux()
 	path, handler := agentcomposev2connect.NewRunServiceHandler(runServiceStub{
-		runAttach: func(_ context.Context, stream *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error {
+		runAttach: func(_ context.Context, stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
 			req, err := stream.Receive()
 			if err != nil {
 				return err
@@ -145,14 +145,14 @@ func TestDaemonHTTPClientRunAttachBidiUsesH2C(t *testing.T) {
 			if req.GetStart() == nil {
 				return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("start frame is required"))
 			}
-			return stream.Send(&agentcomposev2.RunAttachResponse{
-				Frame: &agentcomposev2.RunAttachResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}},
+			return stream.Send(&agentcomposev2.AttachAgentRunResponse{
+				Frame: &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}},
 			})
 		},
 	})
 	mux.Handle(path, handler)
 	server := httptest.NewServer(h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:staticcheck // Tests required h2c transport compatibility.
-		if r.URL.Path == agentcomposev2connect.RunServiceRunAttachProcedure {
+		if r.URL.Path == agentcomposev2connect.RunServiceAttachAgentRunProcedure {
 			seen <- r.Proto
 		}
 		mux.ServeHTTP(w, r)
@@ -160,27 +160,27 @@ func TestDaemonHTTPClientRunAttachBidiUsesH2C(t *testing.T) {
 	defer server.Close()
 
 	client := agentcomposev2connect.NewRunServiceClient(newDaemonHTTPClient(cliClientConfig{BaseURL: server.URL}), server.URL)
-	stream := client.RunAttach(context.Background())
-	if err := stream.Send(&agentcomposev2.RunAttachRequest{
-		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	stream := client.AttachAgentRun(context.Background())
+	if err := stream.Send(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 			Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "dialog", Command: "bash"},
 			Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND,
 		}},
 	}); err != nil {
-		t.Fatalf("RunAttach Send() error = %v", err)
+		t.Fatalf("AttachAgentRun Send() error = %v", err)
 	}
 	if err := stream.CloseRequest(); err != nil {
-		t.Fatalf("RunAttach CloseRequest() error = %v", err)
+		t.Fatalf("AttachAgentRun CloseRequest() error = %v", err)
 	}
 	resp, err := stream.Receive()
 	if err != nil {
-		t.Fatalf("RunAttach Receive() error = %v", err)
+		t.Fatalf("AttachAgentRun Receive() error = %v", err)
 	}
 	if !resp.GetResult().GetSuccess() {
-		t.Fatalf("RunAttach result = %#v, want success", resp)
+		t.Fatalf("AttachAgentRun result = %#v, want success", resp)
 	}
 	if got, want := <-seen, "HTTP/2.0"; got != want {
-		t.Fatalf("RunAttach protocol = %q, want %q", got, want)
+		t.Fatalf("AttachAgentRun protocol = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/agent-compose/cli_daemon_integration_test.go
+++ b/cmd/agent-compose/cli_daemon_integration_test.go
@@ -56,10 +56,10 @@ agents:
 				inspectedRun = req.Msg.GetRunId()
 				return connect.NewResponse(&agentcomposev2.GetRunResponse{Run: testRunDetail(projectID, req.Msg.GetRunId(), "reviewer", sandboxID, agentcomposev2.RunStatus_RUN_STATUS_RUNNING, 0, "ok")}), nil
 			},
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				runSandbox = req.Msg.GetSandboxId()
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     runID,
 					Run:       run,
 				})
@@ -79,10 +79,10 @@ agents:
 			},
 		},
 		exec: execServiceStub{
-			execStream: func(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+			execStream: func(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.StreamExecResponse]) error {
 				execSandbox = req.Msg.GetSandboxId()
-				return stream.Send(&agentcomposev2.ExecStreamResponse{
-					EventType: agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamExecResponse{
+					EventType: agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED,
 					Result: &agentcomposev2.ExecResult{
 						ExecId:    "exec-short",
 						SandboxId: req.Msg.GetSandboxId(),

--- a/cmd/agent-compose/cli_daemon_server_test.go
+++ b/cmd/agent-compose/cli_daemon_server_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/samber/do/v2"
 )
 
-func TestDaemonTCPServerRunAttachBidiUsesH2C(t *testing.T) {
+func TestDaemonTCPServerAttachAgentRunBidiUsesH2C(t *testing.T) {
 	seen := make(chan string, 1)
 	mux := http.NewServeMux()
 	path, handler := agentcomposev2connect.NewRunServiceHandler(runServiceStub{
-		runAttach: func(_ context.Context, stream *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error {
+		runAttach: func(_ context.Context, stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
 			req, err := stream.Receive()
 			if err != nil {
 				return err
@@ -34,8 +34,8 @@ func TestDaemonTCPServerRunAttachBidiUsesH2C(t *testing.T) {
 			if req.GetStart() == nil {
 				return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("start frame is required"))
 			}
-			return stream.Send(&agentcomposev2.RunAttachResponse{
-				Frame: &agentcomposev2.RunAttachResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}},
+			return stream.Send(&agentcomposev2.AttachAgentRunResponse{
+				Frame: &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}},
 			})
 		},
 	})
@@ -65,27 +65,27 @@ func TestDaemonTCPServerRunAttachBidiUsesH2C(t *testing.T) {
 
 	baseURL := "http://" + listener.Addr().String()
 	client := agentcomposev2connect.NewRunServiceClient(newDaemonHTTPClient(cliClientConfig{BaseURL: baseURL}), baseURL)
-	stream := client.RunAttach(context.Background())
-	if err := stream.Send(&agentcomposev2.RunAttachRequest{
-		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	stream := client.AttachAgentRun(context.Background())
+	if err := stream.Send(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 			Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "dialog", Command: "bash"},
 			Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND,
 		}},
 	}); err != nil {
-		t.Fatalf("RunAttach Send() error = %v", err)
+		t.Fatalf("AttachAgentRun Send() error = %v", err)
 	}
 	if err := stream.CloseRequest(); err != nil {
-		t.Fatalf("RunAttach CloseRequest() error = %v", err)
+		t.Fatalf("AttachAgentRun CloseRequest() error = %v", err)
 	}
 	resp, err := stream.Receive()
 	if err != nil {
-		t.Fatalf("RunAttach Receive() error = %v", err)
+		t.Fatalf("AttachAgentRun Receive() error = %v", err)
 	}
 	if !resp.GetResult().GetSuccess() {
-		t.Fatalf("RunAttach result = %#v, want success", resp)
+		t.Fatalf("AttachAgentRun result = %#v, want success", resp)
 	}
 	if got, want := <-seen, "HTTP/2.0"; got != want {
-		t.Fatalf("RunAttach protocol = %q, want %q", got, want)
+		t.Fatalf("AttachAgentRun protocol = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/agent-compose/cli_exec_attach.go
+++ b/cmd/agent-compose/cli_exec_attach.go
@@ -15,8 +15,8 @@ import (
 )
 
 func runComposeExecPromptOnceCommand(cmd *cobra.Command, projectName string, client execAttachClient, req *agentcomposev2.ExecRequest, options composeExecOptions, jsonOutput bool) error {
-	stream := client.ExecAttach(cmd.Context())
-	if err := stream.Send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Start{Start: &agentcomposev2.ExecAttachStart{
+	stream := client.AttachExec(cmd.Context())
+	if err := stream.Send(&agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_Start{Start: &agentcomposev2.AttachExecStart{
 		Request: req, Mode: agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
 		Prompt: strings.TrimSpace(options.Prompt), AttachStdin: false, Tty: false,
 	}}}); err != nil {
@@ -36,21 +36,21 @@ func runComposeExecPromptOnceCommand(cmd *cobra.Command, projectName string, cli
 			return commandExitErrorForConnect(fmt.Errorf("exec project %s prompt: %w", projectName, err))
 		}
 		switch frame := event.GetFrame().(type) {
-		case *agentcomposev2.ExecAttachResponse_Output:
+		case *agentcomposev2.AttachExecResponse_Output:
 			if !jsonOutput {
-				if err := writeExecAttachOutput(output, frame.Output); err != nil {
+				if err := writeAttachExecOutput(output, frame.Output); err != nil {
 					return err
 				}
 			}
-		case *agentcomposev2.ExecAttachResponse_AgentEvent:
+		case *agentcomposev2.AttachExecResponse_AgentEvent:
 			if !jsonOutput && frame.AgentEvent.GetText() != "" {
 				if _, err := io.WriteString(cmd.OutOrStdout(), frame.AgentEvent.GetText()); err != nil {
 					return err
 				}
 			}
-		case *agentcomposev2.ExecAttachResponse_Result:
+		case *agentcomposev2.AttachExecResponse_Result:
 			result = frame.Result
-		case *agentcomposev2.ExecAttachResponse_Error:
+		case *agentcomposev2.AttachExecResponse_Error:
 			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("exec project %s prompt failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
 		}
 	}
@@ -78,28 +78,28 @@ func runComposeExecPromptOnceCommand(cmd *cobra.Command, projectName string, cli
 }
 
 type execAttachClient interface {
-	ExecAttach(context.Context) execAttachStream
+	AttachExec(context.Context) execAttachStream
 }
 
 type runAttachClient interface {
-	RunAttach(context.Context) runAttachStream
+	AttachAgentRun(context.Context) runAttachStream
 }
 
 type runAttachStream interface {
-	Send(*agentcomposev2.RunAttachRequest) error
-	Receive() (*agentcomposev2.RunAttachResponse, error)
+	Send(*agentcomposev2.AttachAgentRunRequest) error
+	Receive() (*agentcomposev2.AttachAgentRunResponse, error)
 	CloseRequest() error
 }
 
-type connectRunAttachClient struct {
+type connectAttachAgentRunClient struct {
 	client agentcomposev2connect.RunServiceClient
 }
 
-func (c connectRunAttachClient) RunAttach(ctx context.Context) runAttachStream {
-	return c.client.RunAttach(ctx)
+func (c connectAttachAgentRunClient) AttachAgentRun(ctx context.Context) runAttachStream {
+	return c.client.AttachAgentRun(ctx)
 }
 
-func runComposeRunAttachCommand(cmd *cobra.Command, projectName string, client runAttachClient, req *agentcomposev2.RunAgentRequest, options composeRunOptions) (err error) {
+func runComposeAttachAgentRunCommand(cmd *cobra.Command, projectName string, client runAttachClient, req *agentcomposev2.RunAgentRequest, options composeRunOptions) (err error) {
 	stdin := cmd.InOrStdin()
 	stdout := cmd.OutOrStdout()
 	stderr := cmd.ErrOrStderr()
@@ -128,9 +128,9 @@ func runComposeRunAttachCommand(cmd *cobra.Command, projectName string, client r
 		}()
 		initialSize = terminalSizeForFD(stdoutFD)
 	}
-	stream := client.RunAttach(cmd.Context())
+	stream := client.AttachAgentRun(cmd.Context())
 	var sendMu sync.Mutex
-	send := func(frame *agentcomposev2.RunAttachRequest) error {
+	send := func(frame *agentcomposev2.AttachAgentRunRequest) error {
 		sendMu.Lock()
 		defer sendMu.Unlock()
 		return stream.Send(frame)
@@ -140,8 +140,8 @@ func runComposeRunAttachCommand(cmd *cobra.Command, projectName string, client r
 		defer sendMu.Unlock()
 		return stream.CloseRequest()
 	}
-	if err := send(&agentcomposev2.RunAttachRequest{
-		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	if err := send(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 			Request:      req,
 			Mode:         agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND,
 			AttachStdin:  true,
@@ -154,12 +154,12 @@ func runComposeRunAttachCommand(cmd *cobra.Command, projectName string, client r
 	resizeCtx, stopResize := context.WithCancel(cmd.Context())
 	defer stopResize()
 	if options.TTY {
-		stopResizePump := startRunAttachResizePump(resizeCtx, stdoutFD, send)
+		stopResizePump := startAttachAgentRunResizePump(resizeCtx, stdoutFD, send)
 		defer stopResizePump()
 	}
 	stdinErr := make(chan error, 1)
 	go func() {
-		stdinErr <- pumpRunAttachStdin(stdin, send, closeRequest)
+		stdinErr <- pumpAttachAgentRunStdin(stdin, send, closeRequest)
 	}()
 	var result *agentcomposev2.AttachResult
 	output := newTerminalStreamOutput(stdout, stderr)
@@ -172,13 +172,13 @@ func runComposeRunAttachCommand(cmd *cobra.Command, projectName string, client r
 			return commandExitErrorForConnect(fmt.Errorf("run project %s attach: %w", projectName, err))
 		}
 		switch frame := event.GetFrame().(type) {
-		case *agentcomposev2.RunAttachResponse_Output:
-			if err := writeExecAttachOutput(output, frame.Output); err != nil {
+		case *agentcomposev2.AttachAgentRunResponse_Output:
+			if err := writeAttachExecOutput(output, frame.Output); err != nil {
 				return err
 			}
-		case *agentcomposev2.RunAttachResponse_Result:
+		case *agentcomposev2.AttachAgentRunResponse_Result:
 			result = frame.Result
-		case *agentcomposev2.RunAttachResponse_Error:
+		case *agentcomposev2.AttachAgentRunResponse_Error:
 			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("run project %s attach failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
 		}
 	}
@@ -216,9 +216,9 @@ func runComposeRunPromptAttachCommand(cmd *cobra.Command, projectName string, cl
 	defer func() { retErr = errors.Join(retErr, input.Close()) }()
 	attachCtx, cancelAttach := context.WithCancel(cmd.Context())
 	defer cancelAttach()
-	stream := client.RunAttach(attachCtx)
+	stream := client.AttachAgentRun(attachCtx)
 	var sendMu sync.Mutex
-	send := func(frame *agentcomposev2.RunAttachRequest) error {
+	send := func(frame *agentcomposev2.AttachAgentRunRequest) error {
 		sendMu.Lock()
 		defer sendMu.Unlock()
 		return stream.Send(frame)
@@ -228,8 +228,8 @@ func runComposeRunPromptAttachCommand(cmd *cobra.Command, projectName string, cl
 		defer sendMu.Unlock()
 		return stream.CloseRequest()
 	}
-	if err := send(&agentcomposev2.RunAttachRequest{
-		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	if err := send(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 			Request:     req,
 			Mode:        agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
 			AttachStdin: true,
@@ -256,8 +256,8 @@ func runComposeRunPromptAttachCommand(cmd *cobra.Command, projectName string, cl
 			}
 			line, err := input.ReadLine(prompt)
 			if errors.Is(err, io.EOF) {
-				if err := send(&agentcomposev2.RunAttachRequest{
-					Frame: &agentcomposev2.RunAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
+				if err := send(&agentcomposev2.AttachAgentRunRequest{
+					Frame: &agentcomposev2.AttachAgentRunRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
 				}); err != nil {
 					return err
 				}
@@ -271,16 +271,16 @@ func runComposeRunPromptAttachCommand(cmd *cobra.Command, projectName string, cl
 				continue
 			}
 			if text == "/exit" {
-				if err := send(&agentcomposev2.RunAttachRequest{
-					Frame: &agentcomposev2.RunAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
+				if err := send(&agentcomposev2.AttachAgentRunRequest{
+					Frame: &agentcomposev2.AttachAgentRunRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
 				}); err != nil {
 					return err
 				}
 				return closeRequest()
 			}
 			lastOutputEndedWithNewline = true
-			return send(&agentcomposev2.RunAttachRequest{
-				Frame: &agentcomposev2.RunAttachRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}},
+			return send(&agentcomposev2.AttachAgentRunRequest{
+				Frame: &agentcomposev2.AttachAgentRunRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}},
 			})
 		}
 	}
@@ -295,30 +295,30 @@ func runComposeRunPromptAttachCommand(cmd *cobra.Command, projectName string, cl
 			return commandExitErrorForConnect(fmt.Errorf("run project %s prompt attach: %w", projectName, err))
 		}
 		switch frame := event.GetFrame().(type) {
-		case *agentcomposev2.RunAttachResponse_Started:
+		case *agentcomposev2.AttachAgentRunResponse_Started:
 			inputPrompt.UpdateFromStarted(frame.Started)
-		case *agentcomposev2.RunAttachResponse_Output:
-			if err := writeExecAttachOutput(output, frame.Output); err != nil {
+		case *agentcomposev2.AttachAgentRunResponse_Output:
+			if err := writeAttachExecOutput(output, frame.Output); err != nil {
 				return err
 			}
 			if data := frame.Output.GetData(); len(data) > 0 {
 				lastOutputEndedWithNewline = data[len(data)-1] == '\n'
 			}
-		case *agentcomposev2.RunAttachResponse_AgentEvent:
+		case *agentcomposev2.AttachAgentRunResponse_AgentEvent:
 			if text := frame.AgentEvent.GetText(); text != "" {
 				if _, err := io.WriteString(stdout, text); err != nil {
 					return err
 				}
 				lastOutputEndedWithNewline = strings.HasSuffix(text, "\n")
 			}
-		case *agentcomposev2.RunAttachResponse_AgentTurnCompleted:
+		case *agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted:
 			if err := promptForInput(); err != nil {
 				return err
 			}
-		case *agentcomposev2.RunAttachResponse_Result:
+		case *agentcomposev2.AttachAgentRunResponse_Result:
 			result = frame.Result
 			inputPrompt.UpdateFromRun(result.GetRun())
-		case *agentcomposev2.RunAttachResponse_Error:
+		case *agentcomposev2.AttachAgentRunResponse_Error:
 			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("run project %s prompt attach failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
 		}
 	}
@@ -338,7 +338,7 @@ func runComposeRunPromptAttachCommand(cmd *cobra.Command, projectName string, cl
 	return nil
 }
 
-func pumpRunAttachStdin(stdin io.Reader, send func(*agentcomposev2.RunAttachRequest) error, closeRequest func() error) (err error) {
+func pumpAttachAgentRunStdin(stdin io.Reader, send func(*agentcomposev2.AttachAgentRunRequest) error, closeRequest func() error) (err error) {
 	defer func() {
 		err = errors.Join(err, closeRequest())
 	}()
@@ -347,15 +347,15 @@ func pumpRunAttachStdin(stdin io.Reader, send func(*agentcomposev2.RunAttachRequ
 		n, readErr := stdin.Read(buffer)
 		if n > 0 {
 			chunk := append([]byte(nil), buffer[:n]...)
-			if err := send(&agentcomposev2.RunAttachRequest{
-				Frame: &agentcomposev2.RunAttachRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: chunk}},
+			if err := send(&agentcomposev2.AttachAgentRunRequest{
+				Frame: &agentcomposev2.AttachAgentRunRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: chunk}},
 			}); err != nil {
 				return err
 			}
 		}
 		if errors.Is(readErr, io.EOF) {
-			return send(&agentcomposev2.RunAttachRequest{
-				Frame: &agentcomposev2.RunAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
+			return send(&agentcomposev2.AttachAgentRunRequest{
+				Frame: &agentcomposev2.AttachAgentRunRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
 			})
 		}
 		if readErr != nil {
@@ -372,20 +372,20 @@ func attachResultExitCode(result *agentcomposev2.AttachResult) int {
 }
 
 type execAttachStream interface {
-	Send(*agentcomposev2.ExecAttachRequest) error
-	Receive() (*agentcomposev2.ExecAttachResponse, error)
+	Send(*agentcomposev2.AttachExecRequest) error
+	Receive() (*agentcomposev2.AttachExecResponse, error)
 	CloseRequest() error
 }
 
-type connectExecAttachClient struct {
+type connectAttachExecClient struct {
 	client agentcomposev2connect.ExecServiceClient
 }
 
-func (c connectExecAttachClient) ExecAttach(ctx context.Context) execAttachStream {
-	return c.client.ExecAttach(ctx)
+func (c connectAttachExecClient) AttachExec(ctx context.Context) execAttachStream {
+	return c.client.AttachExec(ctx)
 }
 
-func runComposeExecAttachCommand(cmd *cobra.Command, projectName string, client execAttachClient, req *agentcomposev2.ExecRequest, options composeExecOptions) (err error) {
+func runComposeAttachExecCommand(cmd *cobra.Command, projectName string, client execAttachClient, req *agentcomposev2.ExecRequest, options composeExecOptions) (err error) {
 	stdin := cmd.InOrStdin()
 	stdout := cmd.OutOrStdout()
 	stderr := cmd.ErrOrStderr()
@@ -414,9 +414,9 @@ func runComposeExecAttachCommand(cmd *cobra.Command, projectName string, client 
 		}()
 		initialSize = terminalSizeForFD(stdoutFD)
 	}
-	stream := client.ExecAttach(cmd.Context())
+	stream := client.AttachExec(cmd.Context())
 	var sendMu sync.Mutex
-	send := func(frame *agentcomposev2.ExecAttachRequest) error {
+	send := func(frame *agentcomposev2.AttachExecRequest) error {
 		sendMu.Lock()
 		defer sendMu.Unlock()
 		return stream.Send(frame)
@@ -426,8 +426,8 @@ func runComposeExecAttachCommand(cmd *cobra.Command, projectName string, client 
 		defer sendMu.Unlock()
 		return stream.CloseRequest()
 	}
-	if err := send(&agentcomposev2.ExecAttachRequest{
-		Frame: &agentcomposev2.ExecAttachRequest_Start{Start: &agentcomposev2.ExecAttachStart{
+	if err := send(&agentcomposev2.AttachExecRequest{
+		Frame: &agentcomposev2.AttachExecRequest_Start{Start: &agentcomposev2.AttachExecStart{
 			Request:      req,
 			AttachStdin:  true,
 			Tty:          options.TTY,
@@ -440,12 +440,12 @@ func runComposeExecAttachCommand(cmd *cobra.Command, projectName string, client 
 	resizeCtx, stopResize := context.WithCancel(cmd.Context())
 	defer stopResize()
 	if options.TTY {
-		stopResizePump := startExecAttachResizePump(resizeCtx, stdoutFD, send)
+		stopResizePump := startAttachExecResizePump(resizeCtx, stdoutFD, send)
 		defer stopResizePump()
 	}
 	stdinErr := make(chan error, 1)
 	go func() {
-		stdinErr <- pumpExecAttachStdin(stdin, send, closeRequest)
+		stdinErr <- pumpAttachExecStdin(stdin, send, closeRequest)
 	}()
 	var result *agentcomposev2.ExecResult
 	output := newTerminalStreamOutput(stdout, stderr)
@@ -458,13 +458,13 @@ func runComposeExecAttachCommand(cmd *cobra.Command, projectName string, client 
 			return commandExitErrorForConnect(fmt.Errorf("exec project %s attach: %w", projectName, err))
 		}
 		switch frame := event.GetFrame().(type) {
-		case *agentcomposev2.ExecAttachResponse_Output:
-			if err := writeExecAttachOutput(output, frame.Output); err != nil {
+		case *agentcomposev2.AttachExecResponse_Output:
+			if err := writeAttachExecOutput(output, frame.Output); err != nil {
 				return err
 			}
-		case *agentcomposev2.ExecAttachResponse_Result:
+		case *agentcomposev2.AttachExecResponse_Result:
 			result = execResultFromAttachResult(frame.Result)
-		case *agentcomposev2.ExecAttachResponse_Error:
+		case *agentcomposev2.AttachExecResponse_Error:
 			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("exec project %s attach failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
 		}
 	}
@@ -496,9 +496,9 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 	stderr := cmd.ErrOrStderr()
 	attachCtx, cancelAttach := context.WithCancel(cmd.Context())
 	defer cancelAttach()
-	stream := client.ExecAttach(attachCtx)
+	stream := client.AttachExec(attachCtx)
 	var sendMu sync.Mutex
-	send := func(frame *agentcomposev2.ExecAttachRequest) error {
+	send := func(frame *agentcomposev2.AttachExecRequest) error {
 		sendMu.Lock()
 		defer sendMu.Unlock()
 		return stream.Send(frame)
@@ -508,8 +508,8 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 		defer sendMu.Unlock()
 		return stream.CloseRequest()
 	}
-	if err := send(&agentcomposev2.ExecAttachRequest{
-		Frame: &agentcomposev2.ExecAttachRequest_Start{Start: &agentcomposev2.ExecAttachStart{
+	if err := send(&agentcomposev2.AttachExecRequest{
+		Frame: &agentcomposev2.AttachExecRequest_Start{Start: &agentcomposev2.AttachExecStart{
 			Request:     req,
 			Mode:        agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
 			Prompt:      strings.TrimSpace(options.Prompt),
@@ -555,8 +555,8 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 			}
 			line, err := input.ReadLine(prompt)
 			if errors.Is(err, io.EOF) {
-				if err := send(&agentcomposev2.ExecAttachRequest{
-					Frame: &agentcomposev2.ExecAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
+				if err := send(&agentcomposev2.AttachExecRequest{
+					Frame: &agentcomposev2.AttachExecRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
 				}); err != nil {
 					return err
 				}
@@ -570,16 +570,16 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 				continue
 			}
 			if text == "/exit" {
-				if err := send(&agentcomposev2.ExecAttachRequest{
-					Frame: &agentcomposev2.ExecAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
+				if err := send(&agentcomposev2.AttachExecRequest{
+					Frame: &agentcomposev2.AttachExecRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
 				}); err != nil {
 					return err
 				}
 				return closeRequest()
 			}
 			lastOutputEndedWithNewline = true
-			return send(&agentcomposev2.ExecAttachRequest{
-				Frame: &agentcomposev2.ExecAttachRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}},
+			return send(&agentcomposev2.AttachExecRequest{
+				Frame: &agentcomposev2.AttachExecRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}},
 			})
 		}
 	}
@@ -594,32 +594,32 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 			return commandExitErrorForConnect(fmt.Errorf("exec project %s prompt attach: %w", projectName, err))
 		}
 		switch frame := event.GetFrame().(type) {
-		case *agentcomposev2.ExecAttachResponse_Started:
+		case *agentcomposev2.AttachExecResponse_Started:
 			inputPrompt.UpdateFromStarted(frame.Started)
-		case *agentcomposev2.ExecAttachResponse_Output:
-			if err := writeExecAttachOutput(output, frame.Output); err != nil {
+		case *agentcomposev2.AttachExecResponse_Output:
+			if err := writeAttachExecOutput(output, frame.Output); err != nil {
 				return err
 			}
 			if data := frame.Output.GetData(); len(data) > 0 {
 				lastOutputEndedWithNewline = data[len(data)-1] == '\n'
 			}
-		case *agentcomposev2.ExecAttachResponse_AgentEvent:
+		case *agentcomposev2.AttachExecResponse_AgentEvent:
 			if text := frame.AgentEvent.GetText(); text != "" {
 				if _, err := io.WriteString(stdout, text); err != nil {
 					return err
 				}
 				lastOutputEndedWithNewline = strings.HasSuffix(text, "\n")
 			}
-		case *agentcomposev2.ExecAttachResponse_AgentTurnCompleted:
+		case *agentcomposev2.AttachExecResponse_AgentTurnCompleted:
 			if stdinIsTerminal {
 				if err := promptForInput(); err != nil {
 					return err
 				}
 			}
-		case *agentcomposev2.ExecAttachResponse_Result:
+		case *agentcomposev2.AttachExecResponse_Result:
 			result = frame.Result
 			inputPrompt.UpdateFromRun(result.GetRun())
-		case *agentcomposev2.ExecAttachResponse_Error:
+		case *agentcomposev2.AttachExecResponse_Error:
 			return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("exec project %s prompt attach failed: %s", projectName, firstNonEmptyString(frame.Error.GetMessage(), frame.Error.GetCode(), "attach failed"))}
 		}
 	}
@@ -649,7 +649,7 @@ func runComposeExecPromptAttachCommand(cmd *cobra.Command, projectName string, c
 	return nil
 }
 
-func pumpExecPromptMessages(input *promptLineReader, send func(*agentcomposev2.ExecAttachRequest) error, closeRequest func() error) (err error) {
+func pumpExecPromptMessages(input *promptLineReader, send func(*agentcomposev2.AttachExecRequest) error, closeRequest func() error) (err error) {
 	defer func() { err = errors.Join(err, closeRequest()) }()
 	for {
 		line, readErr := input.ReadLine("")
@@ -666,14 +666,14 @@ func pumpExecPromptMessages(input *promptLineReader, send func(*agentcomposev2.E
 		if text == "/exit" {
 			break
 		}
-		if err := send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}}}); err != nil {
+		if err := send(&agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text}}}); err != nil {
 			return err
 		}
 	}
-	return send(&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}})
+	return send(&agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}})
 }
 
-func pumpExecAttachStdin(stdin io.Reader, send func(*agentcomposev2.ExecAttachRequest) error, closeRequest func() error) (err error) {
+func pumpAttachExecStdin(stdin io.Reader, send func(*agentcomposev2.AttachExecRequest) error, closeRequest func() error) (err error) {
 	defer func() {
 		err = errors.Join(err, closeRequest())
 	}()
@@ -682,15 +682,15 @@ func pumpExecAttachStdin(stdin io.Reader, send func(*agentcomposev2.ExecAttachRe
 		n, readErr := stdin.Read(buffer)
 		if n > 0 {
 			chunk := append([]byte(nil), buffer[:n]...)
-			if err := send(&agentcomposev2.ExecAttachRequest{
-				Frame: &agentcomposev2.ExecAttachRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: chunk}},
+			if err := send(&agentcomposev2.AttachExecRequest{
+				Frame: &agentcomposev2.AttachExecRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: chunk}},
 			}); err != nil {
 				return err
 			}
 		}
 		if errors.Is(readErr, io.EOF) {
-			return send(&agentcomposev2.ExecAttachRequest{
-				Frame: &agentcomposev2.ExecAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
+			return send(&agentcomposev2.AttachExecRequest{
+				Frame: &agentcomposev2.AttachExecRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}},
 			})
 		}
 		if readErr != nil {
@@ -699,7 +699,7 @@ func pumpExecAttachStdin(stdin io.Reader, send func(*agentcomposev2.ExecAttachRe
 	}
 }
 
-func writeExecAttachOutput(output *terminalStreamOutput, attachOutput *agentcomposev2.AttachOutput) error {
+func writeAttachExecOutput(output *terminalStreamOutput, attachOutput *agentcomposev2.AttachOutput) error {
 	if attachOutput == nil {
 		return nil
 	}
@@ -726,7 +726,7 @@ func execResultFromAttachResult(result *agentcomposev2.AttachResult) *agentcompo
 	}
 }
 
-func newCLIRunAttachServiceClient(cli cliOptions) (agentcomposev2connect.RunServiceClient, error) {
+func newCLIAttachAgentRunServiceClient(cli cliOptions) (agentcomposev2connect.RunServiceClient, error) {
 	clientConfig, err := resolveCLIClientConfig(cli.Host)
 	if err != nil {
 		return nil, err
@@ -734,7 +734,7 @@ func newCLIRunAttachServiceClient(cli cliOptions) (agentcomposev2connect.RunServ
 	return agentcomposev2connect.NewRunServiceClient(newDaemonAttachHTTPClient(clientConfig), clientConfig.BaseURL), nil
 }
 
-func newCLIExecAttachServiceClient(cli cliOptions) (agentcomposev2connect.ExecServiceClient, error) {
+func newCLIAttachExecServiceClient(cli cliOptions) (agentcomposev2connect.ExecServiceClient, error) {
 	clientConfig, err := resolveCLIClientConfig(cli.Host)
 	if err != nil {
 		return nil, err
@@ -751,5 +751,5 @@ func isAttachHTTP2TransportMismatch(err error) bool {
 }
 
 func isAttachRPCPath(path string) bool {
-	return path == agentcomposev2connect.RunServiceRunAttachProcedure || path == agentcomposev2connect.ExecServiceExecAttachProcedure
+	return path == agentcomposev2connect.RunServiceAttachAgentRunProcedure || path == agentcomposev2connect.ExecServiceAttachExecProcedure
 }

--- a/cmd/agent-compose/cli_exec_attach_test.go
+++ b/cmd/agent-compose/cli_exec_attach_test.go
@@ -52,11 +52,11 @@ func TestPromptAttachInputPromptUpdatesFromAttachMetadata(t *testing.T) {
 }
 
 func TestRunComposeExecPromptOnceCommand(t *testing.T) {
-	stream := newFakeExecAttachStream([]*agentcomposev2.ExecAttachResponse{
-		{Frame: &agentcomposev2.ExecAttachResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "prompt reply\n"}}},
-		{Frame: &agentcomposev2.ExecAttachResponse_Result{Result: &agentcomposev2.AttachResult{Success: true, Run: &agentcomposev2.RunSummary{RunId: "run-prompt", SandboxId: "sandbox-prompt"}}}},
+	stream := newFakeAttachExecStream([]*agentcomposev2.AttachExecResponse{
+		{Frame: &agentcomposev2.AttachExecResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "prompt reply\n"}}},
+		{Frame: &agentcomposev2.AttachExecResponse_Result{Result: &agentcomposev2.AttachResult{Success: true, Run: &agentcomposev2.RunSummary{RunId: "run-prompt", SandboxId: "sandbox-prompt"}}}},
 	})
-	client := &fakeExecAttachClient{stream: stream}
+	client := &fakeAttachExecClient{stream: stream}
 	var stdout bytes.Buffer
 	cmd := &cobra.Command{Use: "exec"}
 	cmd.SetContext(context.Background())
@@ -80,17 +80,17 @@ func TestRunComposeExecPromptOnceCommand(t *testing.T) {
 	}
 }
 
-func TestCLIExecInteractiveUsesExecAttachClient(t *testing.T) {
-	stream := newFakeExecAttachStream([]*agentcomposev2.ExecAttachResponse{
-		{Frame: &agentcomposev2.ExecAttachResponse_Output{Output: &agentcomposev2.AttachOutput{
+func TestCLIExecInteractiveUsesAttachExecClient(t *testing.T) {
+	stream := newFakeAttachExecStream([]*agentcomposev2.AttachExecResponse{
+		{Frame: &agentcomposev2.AttachExecResponse_Output{Output: &agentcomposev2.AttachOutput{
 			Data:   []byte("attach stdout\n"),
 			Stream: agentcomposev2.StdioStream_STDIO_STREAM_STDOUT,
 		}}},
-		{Frame: &agentcomposev2.ExecAttachResponse_Output{Output: &agentcomposev2.AttachOutput{
+		{Frame: &agentcomposev2.AttachExecResponse_Output{Output: &agentcomposev2.AttachOutput{
 			Data:   []byte("attach stderr\n"),
 			Stream: agentcomposev2.StdioStream_STDIO_STREAM_STDERR,
 		}}},
-		{Frame: &agentcomposev2.ExecAttachResponse_Result{Result: &agentcomposev2.AttachResult{
+		{Frame: &agentcomposev2.AttachExecResponse_Result{Result: &agentcomposev2.AttachResult{
 			Success:  true,
 			ExitCode: 0,
 			ExecResult: &agentcomposev2.ExecResult{
@@ -101,7 +101,7 @@ func TestCLIExecInteractiveUsesExecAttachClient(t *testing.T) {
 			},
 		}}},
 	})
-	client := &fakeExecAttachClient{stream: stream}
+	client := &fakeAttachExecClient{stream: stream}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: "exec"}
@@ -109,7 +109,7 @@ func TestCLIExecInteractiveUsesExecAttachClient(t *testing.T) {
 	cmd.SetIn(strings.NewReader("hello attach\n"))
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	err := runComposeExecAttachCommand(cmd, "cli-exec-attach", client, &agentcomposev2.ExecRequest{
+	err := runComposeAttachExecCommand(cmd, "cli-exec-attach", client, &agentcomposev2.ExecRequest{
 		Target:  &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
 		Command: &agentcomposev2.ExecCommand{Command: "cat"},
 	}, composeExecOptions{Interactive: true})
@@ -117,40 +117,40 @@ func TestCLIExecInteractiveUsesExecAttachClient(t *testing.T) {
 		t.Fatalf("exec attach returned error: %v", err)
 	}
 	if client.calls != 1 {
-		t.Fatalf("ExecAttach calls = %d, want 1", client.calls)
+		t.Fatalf("AttachExec calls = %d, want 1", client.calls)
 	}
 	if stdout.String() != "attach stdout\n" || stderr.String() != "attach stderr\n" {
 		t.Fatalf("exec attach stdout/stderr = %q / %q", stdout.String(), stderr.String())
 	}
 	sent := stream.sentFrames()
 	if len(sent) != 3 {
-		t.Fatalf("ExecAttach sent %d frames, want start/stdin/eof: %#v", len(sent), sent)
+		t.Fatalf("AttachExec sent %d frames, want start/stdin/eof: %#v", len(sent), sent)
 	}
 	if start := sent[0].GetStart(); start == nil || !start.GetAttachStdin() || start.GetTty() || start.GetRequest().GetSandboxId() != "sandbox-attach" {
-		t.Fatalf("ExecAttach start = %#v", sent[0])
+		t.Fatalf("AttachExec start = %#v", sent[0])
 	}
 	if sent[0].GetStart().GetMode() != agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND {
-		t.Fatalf("ExecAttach command mode = %s", sent[0].GetStart().GetMode())
+		t.Fatalf("AttachExec command mode = %s", sent[0].GetStart().GetMode())
 	}
 	if string(sent[1].GetStdin().GetData()) != "hello attach\n" {
-		t.Fatalf("ExecAttach stdin = %#v", sent[1])
+		t.Fatalf("AttachExec stdin = %#v", sent[1])
 	}
 	if sent[2].GetStdinEof() == nil || !stream.closedRequest() {
-		t.Fatalf("ExecAttach eof/close eof=%#v closed=%v", sent[2], stream.closedRequest())
+		t.Fatalf("AttachExec eof/close eof=%#v closed=%v", sent[2], stream.closedRequest())
 	}
 }
 
-func TestCLIExecPromptAttachUsesExecAttachClient(t *testing.T) {
-	stream := newFakeExecAttachStream([]*agentcomposev2.ExecAttachResponse{
-		{Frame: &agentcomposev2.ExecAttachResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "hello agent"}}},
-		{Frame: &agentcomposev2.ExecAttachResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-1"}}},
-		{Frame: &agentcomposev2.ExecAttachResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-2"}}},
-		{Frame: &agentcomposev2.ExecAttachResponse_Result{Result: &agentcomposev2.AttachResult{
+func TestCLIExecPromptAttachUsesAttachExecClient(t *testing.T) {
+	stream := newFakeAttachExecStream([]*agentcomposev2.AttachExecResponse{
+		{Frame: &agentcomposev2.AttachExecResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "hello agent"}}},
+		{Frame: &agentcomposev2.AttachExecResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-1"}}},
+		{Frame: &agentcomposev2.AttachExecResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-2"}}},
+		{Frame: &agentcomposev2.AttachExecResponse_Result{Result: &agentcomposev2.AttachResult{
 			Success: true,
 			Run:     &agentcomposev2.RunSummary{RunId: "run-1", SandboxId: "sandbox-attach"},
 		}}},
 	})
-	client := &fakeExecAttachClient{stream: stream}
+	client := &fakeAttachExecClient{stream: stream}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: "exec"}
@@ -184,7 +184,7 @@ func TestCLIExecPromptAttachUsesExecAttachClient(t *testing.T) {
 }
 
 func TestCLIExecPromptAttachDoesNotWaitForOpenStdin(t *testing.T) {
-	stream := newFakeExecAttachStream(nil)
+	stream := newFakeAttachExecStream(nil)
 	stream.recvErr = io.EOF
 	stdin, stdinWriter := io.Pipe()
 	defer func() { _ = stdin.Close() }()
@@ -198,7 +198,7 @@ func TestCLIExecPromptAttachDoesNotWaitForOpenStdin(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runComposeExecPromptAttachCommand(cmd, "cli-exec-prompt", &fakeExecAttachClient{stream: stream}, &agentcomposev2.ExecRequest{
+		done <- runComposeExecPromptAttachCommand(cmd, "cli-exec-prompt", &fakeAttachExecClient{stream: stream}, &agentcomposev2.ExecRequest{
 			Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
 		}, composeExecOptions{Interactive: true, Prompt: "hi"})
 	}()
@@ -223,7 +223,7 @@ func TestCLIExecPromptAttachDoesNotWaitForOpenStdin(t *testing.T) {
 
 func TestCLIExecPromptAttachReceiveErrorDoesNotCloseCallerStdin(t *testing.T) {
 	receiveErr := connect.NewError(connect.CodeUnavailable, errors.New("stream lost"))
-	stream := newFakeExecAttachStream(nil)
+	stream := newFakeAttachExecStream(nil)
 	stream.recvErr = receiveErr
 	stdin, stdinWriter := io.Pipe()
 	defer func() { _ = stdin.Close() }()
@@ -237,7 +237,7 @@ func TestCLIExecPromptAttachReceiveErrorDoesNotCloseCallerStdin(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runComposeExecPromptAttachCommand(cmd, "cli-exec-prompt", &fakeExecAttachClient{stream: stream}, &agentcomposev2.ExecRequest{
+		done <- runComposeExecPromptAttachCommand(cmd, "cli-exec-prompt", &fakeAttachExecClient{stream: stream}, &agentcomposev2.ExecRequest{
 			Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
 		}, composeExecOptions{Interactive: true, Prompt: "hi"})
 	}()
@@ -264,10 +264,10 @@ func TestCLIExecPromptAttachReceiveErrorDoesNotCloseCallerStdin(t *testing.T) {
 }
 
 func TestCLIRunPromptAttachInterruptCancelsStream(t *testing.T) {
-	stream := newFakeRunAttachStream([]*agentcomposev2.RunAttachResponse{
-		{Frame: &agentcomposev2.RunAttachResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-prompt"}}},
+	stream := newFakeAttachAgentRunStream([]*agentcomposev2.AttachAgentRunResponse{
+		{Frame: &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-prompt"}}},
 	})
-	client := &fakeRunAttachClient{stream: stream}
+	client := &fakeAttachAgentRunClient{stream: stream}
 	cmd := &cobra.Command{Use: "run"}
 	cmd.SetContext(context.Background())
 	cmd.SetIn(promptErrorReader{err: errPromptInterrupted})
@@ -288,30 +288,30 @@ func TestCLIRunPromptAttachInterruptCancelsStream(t *testing.T) {
 		t.Fatal("run prompt attach context was not canceled after input interruption")
 	}
 	if sent := stream.sentFrames(); len(sent) != 1 || sent[0].GetStart() == nil {
-		t.Fatalf("RunAttach sent frames = %#v, want only start", sent)
+		t.Fatalf("AttachAgentRun sent frames = %#v, want only start", sent)
 	}
 	if stream.closedRequest() {
 		t.Fatal("input interruption must cancel the stream without sending stdin EOF")
 	}
 }
 
-func TestCLIRunInteractiveCommandUsesRunAttachClient(t *testing.T) {
-	stream := newFakeRunAttachStream([]*agentcomposev2.RunAttachResponse{
-		{Frame: &agentcomposev2.RunAttachResponse_Output{Output: &agentcomposev2.AttachOutput{
+func TestCLIRunInteractiveCommandUsesAttachAgentRunClient(t *testing.T) {
+	stream := newFakeAttachAgentRunStream([]*agentcomposev2.AttachAgentRunResponse{
+		{Frame: &agentcomposev2.AttachAgentRunResponse_Output{Output: &agentcomposev2.AttachOutput{
 			Data:   []byte("attach stdout\n"),
 			Stream: agentcomposev2.StdioStream_STDIO_STREAM_STDOUT,
 		}}},
-		{Frame: &agentcomposev2.RunAttachResponse_Output{Output: &agentcomposev2.AttachOutput{
+		{Frame: &agentcomposev2.AttachAgentRunResponse_Output{Output: &agentcomposev2.AttachOutput{
 			Data:   []byte("attach stderr\n"),
 			Stream: agentcomposev2.StdioStream_STDIO_STREAM_STDERR,
 		}}},
-		{Frame: &agentcomposev2.RunAttachResponse_Result{Result: &agentcomposev2.AttachResult{
+		{Frame: &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{
 			Success:  true,
 			ExitCode: 0,
 			Run:      &agentcomposev2.RunSummary{RunId: "run-attach", SandboxId: "sandbox-attach"},
 		}}},
 	})
-	client := &fakeRunAttachClient{stream: stream}
+	client := &fakeAttachAgentRunClient{stream: stream}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: "run"}
@@ -319,7 +319,7 @@ func TestCLIRunInteractiveCommandUsesRunAttachClient(t *testing.T) {
 	cmd.SetIn(strings.NewReader("hello attach\n"))
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	err := runComposeRunAttachCommand(cmd, "cli-run-attach", client, &agentcomposev2.RunAgentRequest{
+	err := runComposeAttachAgentRunCommand(cmd, "cli-run-attach", client, &agentcomposev2.RunAgentRequest{
 		ProjectId: "project-1",
 		AgentName: "reviewer",
 		Command:   "cat",
@@ -329,27 +329,27 @@ func TestCLIRunInteractiveCommandUsesRunAttachClient(t *testing.T) {
 		t.Fatalf("run attach returned error: %v", err)
 	}
 	if client.calls != 1 {
-		t.Fatalf("RunAttach calls = %d, want 1", client.calls)
+		t.Fatalf("AttachAgentRun calls = %d, want 1", client.calls)
 	}
 	if stdout.String() != "attach stdout\n" || stderr.String() != "attach stderr\n" {
 		t.Fatalf("run attach stdout/stderr = %q / %q", stdout.String(), stderr.String())
 	}
 	sent := stream.sentFrames()
 	if len(sent) != 3 {
-		t.Fatalf("RunAttach sent %d frames, want start/stdin/eof: %#v", len(sent), sent)
+		t.Fatalf("AttachAgentRun sent %d frames, want start/stdin/eof: %#v", len(sent), sent)
 	}
 	if start := sent[0].GetStart(); start == nil || start.GetMode() != agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND || !start.GetAttachStdin() || start.GetTty() || start.GetRequest().GetCommand() != "cat" {
-		t.Fatalf("RunAttach start = %#v", sent[0])
+		t.Fatalf("AttachAgentRun start = %#v", sent[0])
 	}
 	if string(sent[1].GetStdin().GetData()) != "hello attach\n" {
-		t.Fatalf("RunAttach stdin = %#v", sent[1])
+		t.Fatalf("AttachAgentRun stdin = %#v", sent[1])
 	}
 	if sent[2].GetStdinEof() == nil || !stream.closedRequest() {
-		t.Fatalf("RunAttach eof/close eof=%#v closed=%v", sent[2], stream.closedRequest())
+		t.Fatalf("AttachAgentRun eof/close eof=%#v closed=%v", sent[2], stream.closedRequest())
 	}
 }
 
-func TestExecAttachResultProjectionWithoutExecResult(t *testing.T) {
+func TestAttachExecResultProjectionWithoutExecResult(t *testing.T) {
 	result := execResultFromAttachResult(&agentcomposev2.AttachResult{
 		ExitCode: 7,
 		Success:  false,
@@ -369,71 +369,71 @@ func (r promptErrorReader) Read([]byte) (int, error) {
 	return 0, r.err
 }
 
-type fakeRunAttachClient struct {
-	stream *fakeRunAttachStream
+type fakeAttachAgentRunClient struct {
+	stream *fakeAttachAgentRunStream
 	calls  int
 	ctx    context.Context
 }
 
-func (c *fakeRunAttachClient) RunAttach(ctx context.Context) runAttachStream {
+func (c *fakeAttachAgentRunClient) AttachAgentRun(ctx context.Context) runAttachStream {
 	c.calls++
 	c.ctx = ctx
 	return c.stream
 }
 
-type fakeRunAttachStream struct {
+type fakeAttachAgentRunStream struct {
 	mu        sync.Mutex
-	sent      []*agentcomposev2.RunAttachRequest
-	responses []*agentcomposev2.RunAttachResponse
+	sent      []*agentcomposev2.AttachAgentRunRequest
+	responses []*agentcomposev2.AttachAgentRunResponse
 	recvIndex int
 	closed    bool
 	closedCh  chan struct{}
 }
 
-func newFakeRunAttachStream(responses []*agentcomposev2.RunAttachResponse) *fakeRunAttachStream {
-	return &fakeRunAttachStream{
+func newFakeAttachAgentRunStream(responses []*agentcomposev2.AttachAgentRunResponse) *fakeAttachAgentRunStream {
+	return &fakeAttachAgentRunStream{
 		responses: responses,
 		closedCh:  make(chan struct{}),
 	}
 }
 
-type fakeExecAttachClient struct {
-	stream *fakeExecAttachStream
+type fakeAttachExecClient struct {
+	stream *fakeAttachExecStream
 	calls  int
 }
 
-func (c *fakeExecAttachClient) ExecAttach(context.Context) execAttachStream {
+func (c *fakeAttachExecClient) AttachExec(context.Context) execAttachStream {
 	c.calls++
 	return c.stream
 }
 
-type fakeExecAttachStream struct {
+type fakeAttachExecStream struct {
 	mu        sync.Mutex
-	sent      []*agentcomposev2.ExecAttachRequest
-	responses []*agentcomposev2.ExecAttachResponse
+	sent      []*agentcomposev2.AttachExecRequest
+	responses []*agentcomposev2.AttachExecResponse
 	recvErr   error
 	recvIndex int
 	closed    bool
 	closedCh  chan struct{}
 }
 
-func newFakeExecAttachStream(responses []*agentcomposev2.ExecAttachResponse) *fakeExecAttachStream {
-	return &fakeExecAttachStream{
+func newFakeAttachExecStream(responses []*agentcomposev2.AttachExecResponse) *fakeAttachExecStream {
+	return &fakeAttachExecStream{
 		responses: responses,
 		closedCh:  make(chan struct{}),
 	}
 }
 
-func (s runServiceStub) RunAttach(ctx context.Context, stream *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error {
+func (s runServiceStub) AttachAgentRun(ctx context.Context, stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
 	if s.runAttach == nil {
-		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("RunAttach stub is not configured"))
+		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("AttachAgentRun stub is not configured"))
 	}
 	return s.runAttach(ctx, stream)
 }
 
-func (s execServiceStub) ExecAttach(ctx context.Context, stream *connect.BidiStream[agentcomposev2.ExecAttachRequest, agentcomposev2.ExecAttachResponse]) error {
+func (s execServiceStub) AttachExec(ctx context.Context, stream *connect.BidiStream[agentcomposev2.AttachExecRequest, agentcomposev2.AttachExecResponse]) error {
 	if s.execAttach == nil {
-		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ExecAttach stub is not configured"))
+		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("AttachExec stub is not configured"))
 	}
 	return s.execAttach(ctx, stream)
 }

--- a/cmd/agent-compose/cli_exec_command.go
+++ b/cmd/agent-compose/cli_exec_command.go
@@ -117,23 +117,23 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 		return err
 	}
 	if options.Interactive {
-		attachClient, err := newCLIExecAttachServiceClient(cli)
+		attachClient, err := newCLIAttachExecServiceClient(cli)
 		if err != nil {
 			return err
 		}
 		if strings.TrimSpace(options.Prompt) != "" {
-			return runComposeExecPromptAttachCommand(cmd, runtimeProject.name(), connectExecAttachClient{client: attachClient}, req, options)
+			return runComposeExecPromptAttachCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: attachClient}, req, options)
 		}
-		return runComposeExecAttachCommand(cmd, runtimeProject.name(), connectExecAttachClient{client: attachClient}, req, options)
+		return runComposeAttachExecCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: attachClient}, req, options)
 	}
 	if strings.TrimSpace(options.Prompt) != "" {
-		attachClient, err := newCLIExecAttachServiceClient(cli)
+		attachClient, err := newCLIAttachExecServiceClient(cli)
 		if err != nil {
 			return err
 		}
-		return runComposeExecPromptOnceCommand(cmd, runtimeProject.name(), connectExecAttachClient{client: attachClient}, req, options, cli.JSON)
+		return runComposeExecPromptOnceCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: attachClient}, req, options, cli.JSON)
 	}
-	stream, err := clients.execStream.ExecStream(cmd.Context(), connect.NewRequest(req))
+	stream, err := clients.execStream.StreamExec(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("exec project %s: %w", runtimeProject.name(), err))
 	}
@@ -142,14 +142,14 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 	for stream.Receive() {
 		event := stream.Msg()
 		switch event.GetEventType() {
-		case agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_OUTPUT:
+		case agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT:
 			if cli.JSON {
 				continue
 			}
 			if err := output.Write(event.GetTranscript(), event.GetChunk(), event.GetStream()); err != nil {
 				return err
 			}
-		case agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED:
+		case agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED:
 			result = event.GetResult()
 		}
 	}

--- a/cmd/agent-compose/cli_exec_command_test.go
+++ b/cmd/agent-compose/cli_exec_command_test.go
@@ -110,7 +110,7 @@ func TestCLIExecInteractiveReservedUnsupported(t *testing.T) {
 }
 
 func TestCLIExecInteractiveUnsupportedUsesUnsupportedExitCode(t *testing.T) {
-	client := &fakeExecAttachClient{stream: &fakeExecAttachStream{
+	client := &fakeAttachExecClient{stream: &fakeAttachExecStream{
 		closedCh: make(chan struct{}),
 		recvErr:  connect.NewError(connect.CodeUnimplemented, fmt.Errorf("exec attach unsupported")),
 	}}
@@ -121,7 +121,7 @@ func TestCLIExecInteractiveUnsupportedUsesUnsupportedExitCode(t *testing.T) {
 	cmd.SetIn(strings.NewReader(""))
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	err := runComposeExecAttachCommand(cmd, "cli-exec-attach", client, &agentcomposev2.ExecRequest{
+	err := runComposeAttachExecCommand(cmd, "cli-exec-attach", client, &agentcomposev2.ExecRequest{
 		Target:  &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
 		Command: &agentcomposev2.ExecCommand{Command: "sh"},
 	}, composeExecOptions{Interactive: true})
@@ -129,12 +129,12 @@ func TestCLIExecInteractiveUnsupportedUsesUnsupportedExitCode(t *testing.T) {
 		t.Fatalf("exec attach unsupported err=%v code=%d, want %d", err, commandExitCode(err), exitCodeUnsupported)
 	}
 	if client.calls != 1 {
-		t.Fatalf("ExecAttach calls = %d, want 1", client.calls)
+		t.Fatalf("AttachExec calls = %d, want 1", client.calls)
 	}
 }
 
 func TestCLIExecTTYRequiresLocalTerminal(t *testing.T) {
-	client := &fakeExecAttachClient{stream: newFakeExecAttachStream(nil)}
+	client := &fakeAttachExecClient{stream: newFakeAttachExecStream(nil)}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: "exec"}
@@ -142,7 +142,7 @@ func TestCLIExecTTYRequiresLocalTerminal(t *testing.T) {
 	cmd.SetIn(strings.NewReader(""))
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	err := runComposeExecAttachCommand(cmd, "cli-exec-attach", client, &agentcomposev2.ExecRequest{
+	err := runComposeAttachExecCommand(cmd, "cli-exec-attach", client, &agentcomposev2.ExecRequest{
 		Target:  &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-attach"},
 		Command: &agentcomposev2.ExecCommand{Command: "sh"},
 	}, composeExecOptions{Interactive: true, TTY: true})
@@ -150,18 +150,18 @@ func TestCLIExecTTYRequiresLocalTerminal(t *testing.T) {
 		t.Fatalf("exec -it non-terminal err=%v code=%d", err, commandExitCode(err))
 	}
 	if client.calls != 0 {
-		t.Fatalf("ExecAttach calls = %d, want 0", client.calls)
+		t.Fatalf("AttachExec calls = %d, want 0", client.calls)
 	}
 }
 
-func (s *fakeRunAttachStream) Send(req *agentcomposev2.RunAttachRequest) error {
+func (s *fakeAttachAgentRunStream) Send(req *agentcomposev2.AttachAgentRunRequest) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sent = append(s.sent, req)
 	return nil
 }
 
-func (s *fakeRunAttachStream) Receive() (*agentcomposev2.RunAttachResponse, error) {
+func (s *fakeAttachAgentRunStream) Receive() (*agentcomposev2.AttachAgentRunResponse, error) {
 	for {
 		s.mu.Lock()
 		if s.recvIndex < len(s.responses) {
@@ -179,7 +179,7 @@ func (s *fakeRunAttachStream) Receive() (*agentcomposev2.RunAttachResponse, erro
 	}
 }
 
-func (s *fakeRunAttachStream) CloseRequest() error {
+func (s *fakeAttachAgentRunStream) CloseRequest() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.closed {
@@ -189,26 +189,26 @@ func (s *fakeRunAttachStream) CloseRequest() error {
 	return nil
 }
 
-func (s *fakeRunAttachStream) sentFrames() []*agentcomposev2.RunAttachRequest {
+func (s *fakeAttachAgentRunStream) sentFrames() []*agentcomposev2.AttachAgentRunRequest {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]*agentcomposev2.RunAttachRequest(nil), s.sent...)
+	return append([]*agentcomposev2.AttachAgentRunRequest(nil), s.sent...)
 }
 
-func (s *fakeRunAttachStream) closedRequest() bool {
+func (s *fakeAttachAgentRunStream) closedRequest() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.closed
 }
 
-func (s *fakeExecAttachStream) Send(req *agentcomposev2.ExecAttachRequest) error {
+func (s *fakeAttachExecStream) Send(req *agentcomposev2.AttachExecRequest) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sent = append(s.sent, req)
 	return nil
 }
 
-func (s *fakeExecAttachStream) Receive() (*agentcomposev2.ExecAttachResponse, error) {
+func (s *fakeAttachExecStream) Receive() (*agentcomposev2.AttachExecResponse, error) {
 	if s.recvErr != nil {
 		return nil, s.recvErr
 	}
@@ -229,7 +229,7 @@ func (s *fakeExecAttachStream) Receive() (*agentcomposev2.ExecAttachResponse, er
 	}
 }
 
-func (s *fakeExecAttachStream) CloseRequest() error {
+func (s *fakeAttachExecStream) CloseRequest() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.closed {
@@ -239,13 +239,13 @@ func (s *fakeExecAttachStream) CloseRequest() error {
 	return nil
 }
 
-func (s *fakeExecAttachStream) sentFrames() []*agentcomposev2.ExecAttachRequest {
+func (s *fakeAttachExecStream) sentFrames() []*agentcomposev2.AttachExecRequest {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]*agentcomposev2.ExecAttachRequest(nil), s.sent...)
+	return append([]*agentcomposev2.AttachExecRequest(nil), s.sent...)
 }
 
-func (s *fakeExecAttachStream) closedRequest() bool {
+func (s *fakeAttachExecStream) closedRequest() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.closed
@@ -263,8 +263,8 @@ func TestCLIExecAgentFlagIsRemoved(t *testing.T) {
 
 type execServiceStub struct {
 	exec       func(context.Context, *connect.Request[agentcomposev2.ExecRequest]) (*connect.Response[agentcomposev2.ExecResponse], error)
-	execStream func(context.Context, *connect.Request[agentcomposev2.ExecRequest], *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error
-	execAttach func(context.Context, *connect.BidiStream[agentcomposev2.ExecAttachRequest, agentcomposev2.ExecAttachResponse]) error
+	execStream func(context.Context, *connect.Request[agentcomposev2.ExecRequest], *connect.ServerStream[agentcomposev2.StreamExecResponse]) error
+	execAttach func(context.Context, *connect.BidiStream[agentcomposev2.AttachExecRequest, agentcomposev2.AttachExecResponse]) error
 
 	agentcomposev2connect.UnimplementedExecServiceHandler
 }
@@ -276,9 +276,9 @@ func (s execServiceStub) Exec(ctx context.Context, req *connect.Request[agentcom
 	return s.exec(ctx, req)
 }
 
-func (s execServiceStub) ExecStream(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+func (s execServiceStub) StreamExec(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.StreamExecResponse]) error {
 	if s.execStream == nil {
-		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ExecStream stub is not configured"))
+		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StreamExec stub is not configured"))
 	}
 	return s.execStream(ctx, req, stream)
 }

--- a/cmd/agent-compose/cli_exec_integration_test.go
+++ b/cmd/agent-compose/cli_exec_integration_test.go
@@ -13,18 +13,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestIntegrationCLIRunPromptTTYUsesRunAttach(t *testing.T) {
-	stream := newFakeRunAttachStream([]*agentcomposev2.RunAttachResponse{
-		{Frame: &agentcomposev2.RunAttachResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "first output\n"}}},
-		{Frame: &agentcomposev2.RunAttachResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-prompt-attach"}}},
-		{Frame: &agentcomposev2.RunAttachResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "second output\n"}}},
-		{Frame: &agentcomposev2.RunAttachResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-prompt-attach"}}},
-		{Frame: &agentcomposev2.RunAttachResponse_Result{Result: &agentcomposev2.AttachResult{
+func TestIntegrationCLIRunPromptTTYUsesAttachAgentRun(t *testing.T) {
+	stream := newFakeAttachAgentRunStream([]*agentcomposev2.AttachAgentRunResponse{
+		{Frame: &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "first output\n"}}},
+		{Frame: &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-prompt-attach"}}},
+		{Frame: &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "second output\n"}}},
+		{Frame: &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: "run-prompt-attach"}}},
+		{Frame: &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{
 			Success: true,
 			Run:     &agentcomposev2.RunSummary{RunId: "run-prompt-attach", Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED},
 		}}},
 	})
-	client := &fakeRunAttachClient{stream: stream}
+	client := &fakeAttachAgentRunClient{stream: stream}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: "run"}
@@ -45,20 +45,20 @@ func TestIntegrationCLIRunPromptTTYUsesRunAttach(t *testing.T) {
 	}
 	sent := stream.sentFrames()
 	if len(sent) != 3 {
-		t.Fatalf("RunAttach sent %d frames, want start/human/eof: %#v", len(sent), sent)
+		t.Fatalf("AttachAgentRun sent %d frames, want start/human/eof: %#v", len(sent), sent)
 	}
 	if start := sent[0].GetStart(); start == nil || start.GetMode() != agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT || start.GetTty() || start.GetRequest().GetPrompt() != "first prompt" {
-		t.Fatalf("RunAttach prompt start = %#v", sent[0])
+		t.Fatalf("AttachAgentRun prompt start = %#v", sent[0])
 	}
 	if sent[1].GetHumanMessage().GetText() != "second prompt" {
-		t.Fatalf("RunAttach human message = %#v", sent[1])
+		t.Fatalf("AttachAgentRun human message = %#v", sent[1])
 	}
 	if sent[2].GetStdinEof() == nil || !stream.closedRequest() {
-		t.Fatalf("RunAttach eof/close eof=%#v closed=%v", sent[2], stream.closedRequest())
+		t.Fatalf("AttachAgentRun eof/close eof=%#v closed=%v", sent[2], stream.closedRequest())
 	}
 }
 
-func TestIntegrationCLIExecStreamsAndSupportsJSON(t *testing.T) {
+func TestIntegrationCLIStreamExecsAndSupportsJSON(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
 name: cli-exec-demo
 agents:
@@ -69,21 +69,21 @@ agents:
 	var sawCommand bool
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		exec: execServiceStub{
-			execStream: func(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+			execStream: func(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.StreamExecResponse]) error {
 				if req.Msg.GetSandboxId() == "sandbox-exec" {
 					sawSandbox = true
 					if req.Msg.GetCommand().GetCommand() != "bash" || req.Msg.GetCommand().GetArgs()[0] != "-lc" {
-						t.Fatalf("ExecStream sandbox request = %#v", req.Msg)
+						t.Fatalf("StreamExec sandbox request = %#v", req.Msg)
 					}
 				}
 				if req.Msg.GetSandboxId() == "sandbox-command" {
 					sawCommand = true
 					if req.Msg.GetCommand().GetCommand() != "bash" || len(req.Msg.GetCommand().GetArgs()) != 2 || req.Msg.GetCommand().GetArgs()[0] != "-lc" || req.Msg.GetCommand().GetArgs()[1] != "git status --short" {
-						t.Fatalf("ExecStream --command request = %#v", req.Msg)
+						t.Fatalf("StreamExec --command request = %#v", req.Msg)
 					}
 				}
-				if err := stream.Send(&agentcomposev2.ExecStreamResponse{
-					EventType:  agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamExecResponse{
+					EventType:  agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT,
 					ExecId:     "exec-cli",
 					SandboxId:  "session-exec",
 					RunId:      "run-exec",
@@ -91,8 +91,8 @@ agents:
 				}); err != nil {
 					return err
 				}
-				if err := stream.Send(&agentcomposev2.ExecStreamResponse{
-					EventType:  agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamExecResponse{
+					EventType:  agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT,
 					ExecId:     "exec-cli",
 					SandboxId:  "session-exec",
 					RunId:      "run-exec",
@@ -100,8 +100,8 @@ agents:
 				}); err != nil {
 					return err
 				}
-				return stream.Send(&agentcomposev2.ExecStreamResponse{
-					EventType: agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamExecResponse{
+					EventType: agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED,
 					ExecId:    "exec-cli",
 					SandboxId: "session-exec",
 					RunId:     "run-exec",
@@ -119,8 +119,8 @@ agents:
 					},
 				})
 			},
-			execAttach: func(context.Context, *connect.BidiStream[agentcomposev2.ExecAttachRequest, agentcomposev2.ExecAttachResponse]) error {
-				t.Fatalf("ExecAttach should not be called for non-interactive exec")
+			execAttach: func(context.Context, *connect.BidiStream[agentcomposev2.AttachExecRequest, agentcomposev2.AttachExecResponse]) error {
+				t.Fatalf("AttachExec should not be called for non-interactive exec")
 				return nil
 			},
 		},
@@ -135,7 +135,7 @@ agents:
 		t.Fatalf("exec stdout/stderr = %q / %q", stdout, stderr)
 	}
 	if !sawSandbox {
-		t.Fatal("ExecStream sandbox target was not used")
+		t.Fatal("StreamExec sandbox target was not used")
 	}
 
 	commandOut, commandErr, _, commandCode := executeCLICommand("exec", "--host", server.URL, "--file", composePath, "sandbox-command", "--command", "git status --short")
@@ -146,7 +146,7 @@ agents:
 		t.Fatalf("exec --command stdout/stderr = %q / %q", commandOut, commandErr)
 	}
 	if !sawCommand {
-		t.Fatal("ExecStream --command target was not used")
+		t.Fatal("StreamExec --command target was not used")
 	}
 
 	jsonOut, jsonErr, _, jsonCode := executeCLICommand("exec", "--host", server.URL, "--file", composePath, "--json", "session-exec", "--command", "bash")
@@ -191,7 +191,7 @@ agents:
 	var execStreamCalls atomic.Int32
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		exec: execServiceStub{
-			execStream: func(context.Context, *connect.Request[agentcomposev2.ExecRequest], *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+			execStream: func(context.Context, *connect.Request[agentcomposev2.ExecRequest], *connect.ServerStream[agentcomposev2.StreamExecResponse]) error {
 				execStreamCalls.Add(1)
 				return nil
 			},
@@ -216,6 +216,6 @@ agents:
 		t.Fatalf("exec conflicting targets emitted deprecation warning: %q", stderr)
 	}
 	if calls := execStreamCalls.Load(); calls != 0 {
-		t.Fatalf("ExecStream calls = %d, want 0", calls)
+		t.Fatalf("StreamExec calls = %d, want 0", calls)
 	}
 }

--- a/cmd/agent-compose/cli_logs_test.go
+++ b/cmd/agent-compose/cli_logs_test.go
@@ -25,12 +25,12 @@ agents:
 	var followRequests []*agentcomposev2.FollowRunLogsRequest
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 				if req.Msg.GetRun().GetCommand() != "printf detached" {
-					t.Fatalf("StartRun command = %#v", req.Msg.GetRun())
+					t.Fatalf("StartAgentRun command = %#v", req.Msg.GetRun())
 				}
 				sawCommand = true
-				return connect.NewResponse(&agentcomposev2.StartRunResponse{Run: &agentcomposev2.RunSummary{
+				return connect.NewResponse(&agentcomposev2.StartAgentRunResponse{Run: &agentcomposev2.RunSummary{
 					RunId:     "run-detached-logs",
 					ProjectId: req.Msg.GetRun().GetProjectId(),
 					AgentName: "reviewer",

--- a/cmd/agent-compose/cli_misc_helpers_test.go
+++ b/cmd/agent-compose/cli_misc_helpers_test.go
@@ -114,15 +114,15 @@ agents:
 `)
 		server := newComposeServiceStubServer(t, composeServiceStubs{
 			exec: execServiceStub{
-				execStream: func(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+				execStream: func(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.StreamExecResponse]) error {
 					switch target := req.Msg.GetTarget().(type) {
 					case *agentcomposev2.ExecRequest_SandboxId:
 						switch target.SandboxId {
 						case "no-result":
 							return nil
 						case "failed":
-							return stream.Send(&agentcomposev2.ExecStreamResponse{
-								EventType: agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED,
+							return stream.Send(&agentcomposev2.StreamExecResponse{
+								EventType: agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED,
 								Result: &agentcomposev2.ExecResult{
 									ExecId: "exec-failed", SandboxId: target.SandboxId,
 									Command: req.Msg.GetCommand(), ExitCode: 42, Success: false, Stderr: "boom\n",
@@ -132,8 +132,8 @@ agents:
 							if req.Msg.GetCommand().GetCommand() != "sh" || len(req.Msg.GetCommand().GetArgs()) != 0 {
 								t.Fatalf("default shell request = %#v", req.Msg.GetCommand())
 							}
-							return stream.Send(&agentcomposev2.ExecStreamResponse{
-								EventType: agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED,
+							return stream.Send(&agentcomposev2.StreamExecResponse{
+								EventType: agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED,
 								Result:    &agentcomposev2.ExecResult{ExecId: "exec-shell", SandboxId: target.SandboxId, Command: req.Msg.GetCommand(), Success: true},
 							})
 						}

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -347,18 +347,18 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 	client = clients.runStream
 	if normalizedOptions.Interactive {
 		if normalizedOptions.TTY {
-			attachClient, err := newCLIRunAttachServiceClient(cli)
+			attachClient, err := newCLIAttachAgentRunServiceClient(cli)
 			if err != nil {
 				return err
 			}
 			if promptFlagChanged {
 				runReq.Prompt = prompt
 				runReq.Command = ""
-				return runComposeRunPromptAttachCommand(cmd, runtimeProject.name(), connectRunAttachClient{client: attachClient}, runReq)
+				return runComposeRunPromptAttachCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: attachClient}, runReq)
 			}
 			runReq.Prompt = ""
 			runReq.Command = commandText
-			return runComposeRunAttachCommand(cmd, runtimeProject.name(), connectRunAttachClient{client: attachClient}, runReq, normalizedOptions)
+			return runComposeAttachAgentRunCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: attachClient}, runReq, normalizedOptions)
 		}
 		runReq.Prompt = ""
 		runReq.Command = ""

--- a/cmd/agent-compose/cli_run_command_test.go
+++ b/cmd/agent-compose/cli_run_command_test.go
@@ -82,8 +82,8 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				t.Fatalf("RunAgentStream should not be called for invalid input mode")
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				t.Fatalf("StreamAgentRun should not be called for invalid input mode")
 				return nil
 			},
 		},
@@ -191,9 +191,9 @@ func TestCLIRunCompletionErrorBranches(t *testing.T) {
 }
 
 type runServiceStub struct {
-	startRun       func(context.Context, *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error)
-	runAgentStream func(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error
-	runAttach      func(context.Context, *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error
+	startRun       func(context.Context, *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error)
+	runAgentStream func(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error
+	runAttach      func(context.Context, *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error
 	getRun         func(context.Context, *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error)
 	listRuns       func(context.Context, *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error)
 	listRunEvents  func(context.Context, *connect.Request[agentcomposev2.ListRunEventsRequest]) (*connect.Response[agentcomposev2.ListRunEventsResponse], error)
@@ -202,9 +202,9 @@ type runServiceStub struct {
 	agentcomposev2connect.UnimplementedRunServiceHandler
 }
 
-func (s runServiceStub) StartRun(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+func (s runServiceStub) StartAgentRun(ctx context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 	if s.startRun == nil {
-		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StartRun stub is not configured"))
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StartAgentRun stub is not configured"))
 	}
 	return s.startRun(ctx, req)
 }

--- a/cmd/agent-compose/cli_run_integration_test.go
+++ b/cmd/agent-compose/cli_run_integration_test.go
@@ -22,16 +22,16 @@ agents:
 	var sawStart bool
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 				sawStart = true
 				runReq := req.Msg.GetRun()
 				if runReq.GetAgentName() != "reviewer" || runReq.GetCommand() != "echo detached" || runReq.GetSandboxId() != "" || runReq.GetDriver() != "microsandbox" {
-					t.Fatalf("StartRun request = %#v", runReq)
+					t.Fatalf("StartAgentRun request = %#v", runReq)
 				}
 				if runReq.GetSource() != agentcomposev2.RunSource_RUN_SOURCE_MANUAL {
-					t.Fatalf("StartRun source = %#v", runReq.GetSource())
+					t.Fatalf("StartAgentRun source = %#v", runReq.GetSource())
 				}
-				return connect.NewResponse(&agentcomposev2.StartRunResponse{
+				return connect.NewResponse(&agentcomposev2.StartAgentRunResponse{
 					Run: &agentcomposev2.RunSummary{
 						RunId:       "run-detached",
 						ProjectId:   runReq.GetProjectId(),
@@ -45,8 +45,8 @@ agents:
 					Started:  true,
 				}), nil
 			},
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				t.Fatalf("RunAgentStream should not be called for detached run")
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				t.Fatalf("StreamAgentRun should not be called for detached run")
 				return nil
 			},
 		},
@@ -71,7 +71,7 @@ agents:
 		t.Fatalf("run -d stderr = %q", stderr)
 	}
 	if !sawStart {
-		t.Fatal("StartRun was not called")
+		t.Fatal("StartAgentRun was not called")
 	}
 }
 
@@ -84,12 +84,12 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 				runReq := req.Msg.GetRun()
 				if runReq.GetJupyter() == nil || !runReq.GetJupyter().GetEnabled() || !runReq.GetJupyter().GetExpose() {
-					t.Fatalf("StartRun jupyter request = %#v", runReq)
+					t.Fatalf("StartAgentRun jupyter request = %#v", runReq)
 				}
-				return connect.NewResponse(&agentcomposev2.StartRunResponse{
+				return connect.NewResponse(&agentcomposev2.StartAgentRunResponse{
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-detached-jupyter",
 						ProjectId: runReq.GetProjectId(),
@@ -133,9 +133,9 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+			startRun: func(ctx context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 				runReq := req.Msg.GetRun()
-				return connect.NewResponse(&agentcomposev2.StartRunResponse{
+				return connect.NewResponse(&agentcomposev2.StartAgentRunResponse{
 					Run: &agentcomposev2.RunSummary{
 						RunId:       "run-detached-json",
 						ProjectId:   runReq.GetProjectId(),
@@ -180,13 +180,13 @@ agents:
 	var sawRequest bool
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				sawRequest = true
 				if req.Msg.GetJupyter() == nil || !req.Msg.GetJupyter().GetEnabled() || !req.Msg.GetJupyter().GetExpose() {
-					t.Fatalf("RunAgentStream jupyter request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun jupyter request = %#v", req.Msg)
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-jupyter",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-jupyter",
@@ -220,7 +220,7 @@ agents:
 		t.Fatalf("run --jupyter-expose stdout = %q, want %q", stdout, want)
 	}
 	if !sawRequest {
-		t.Fatal("RunAgentStream was not called")
+		t.Fatal("StreamAgentRun was not called")
 	}
 }
 
@@ -233,12 +233,12 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetJupyter() == nil || !req.Msg.GetJupyter().GetEnabled() || req.Msg.GetJupyter().GetExpose() {
-					t.Fatalf("RunAgentStream jupyter request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun jupyter request = %#v", req.Msg)
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-jupyter-private",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-jupyter-private",
@@ -284,15 +284,15 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetJupyter() == nil || !req.Msg.GetJupyter().GetEnabled() || !req.Msg.GetJupyter().GetExpose() {
-					t.Fatalf("RunAgentStream jupyter request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun jupyter request = %#v", req.Msg)
 				}
 				if req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION {
-					t.Fatalf("RunAgentStream cleanup policy = %#v", req.Msg.GetCleanupPolicy())
+					t.Fatalf("StreamAgentRun cleanup policy = %#v", req.Msg.GetCleanupPolicy())
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-jupyter-stopped",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-jupyter-stopped",
@@ -331,12 +331,12 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetJupyter() == nil || !req.Msg.GetJupyter().GetEnabled() || !req.Msg.GetJupyter().GetExpose() {
-					t.Fatalf("RunAgentStream jupyter request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun jupyter request = %#v", req.Msg)
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-jupyter-json",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-jupyter-json",
@@ -381,9 +381,9 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-jupyter-json-stopped",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-jupyter-json-stopped",
@@ -430,28 +430,28 @@ agents:
 	var sawRequest bool
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				sawRequest = true
 				if req.Msg.GetAgentName() != "reviewer" || req.Msg.GetCommand() != "echo command" || req.Msg.GetPrompt() != "" || req.Msg.GetTriggerId() != "" {
-					t.Fatalf("RunAgentStream command request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun command request = %#v", req.Msg)
 				}
-				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:     "run-command",
 					Chunk:     "command stdout",
 				}); err != nil {
 					return err
 				}
-				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:     "run-command",
 					Chunk:     "command stderr",
 					Stream:    agentcomposev2.StdioStream_STDIO_STREAM_STDERR,
 				}); err != nil {
 					return err
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-command",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-command",
@@ -462,8 +462,8 @@ agents:
 					},
 				})
 			},
-			runAttach: func(context.Context, *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error {
-				t.Fatalf("RunAttach should not be called for non-interactive run --command")
+			runAttach: func(context.Context, *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
+				t.Fatalf("AttachAgentRun should not be called for non-interactive run --command")
 				return nil
 			},
 			getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
@@ -486,7 +486,7 @@ agents:
 		t.Fatalf("run --command code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 	if !sawRequest {
-		t.Fatal("RunAgentStream was not called")
+		t.Fatal("StreamAgentRun was not called")
 	}
 }
 
@@ -499,10 +499,10 @@ agents:
 	var sawRun bool
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				sawRun = true
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-default-provider",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-default-provider",
@@ -525,7 +525,7 @@ agents:
 		t.Fatalf("run -i --prompt default provider code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
 	}
 	if !sawRun {
-		t.Fatal("RunAgentStream was not called")
+		t.Fatal("StreamAgentRun was not called")
 	}
 }
 
@@ -537,17 +537,17 @@ agents:
     provider: codex
 `)
 	server := newRunServiceStubServer(t, runServiceStub{
-		runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-			if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-				EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+		runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+			if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+				EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 				RunId:     "run-failed",
 				Chunk:     "agent failed\n",
 				Stream:    agentcomposev2.StdioStream_STDIO_STREAM_STDERR,
 			}); err != nil {
 				return err
 			}
-			return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-				EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+			return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+				EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 				RunId:     "run-failed",
 				Run: &agentcomposev2.RunSummary{
 					RunId:     "run-failed",

--- a/cmd/agent-compose/cli_run_output.go
+++ b/cmd/agent-compose/cli_run_output.go
@@ -14,7 +14,7 @@ import (
 )
 
 func startDetachedRun(cmd *cobra.Command, cli cliOptions, projectName string, client agentcomposev2connect.RunServiceClient, req *agentcomposev2.RunAgentRequest) error {
-	resp, err := client.StartRun(cmd.Context(), connect.NewRequest(&agentcomposev2.StartRunRequest{Run: req}))
+	resp, err := client.StartAgentRun(cmd.Context(), connect.NewRequest(&agentcomposev2.StartAgentRunRequest{Run: req}))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("start run project %s agent %s: %w", projectName, req.GetAgentName(), err))
 	}

--- a/cmd/agent-compose/cli_run_output_test.go
+++ b/cmd/agent-compose/cli_run_output_test.go
@@ -31,7 +31,7 @@ func TestWritePrefixedRunOutputHonorsTimestampFlag(t *testing.T) {
 func TestCLIRunStreamAndDetailEdgeBranches(t *testing.T) {
 	t.Run("stream completes without terminal run", func(t *testing.T) {
 		server := newRunServiceStubServer(t, runServiceStub{
-			runAgentStream: func(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				return nil
 			},
 		})
@@ -45,7 +45,7 @@ func TestCLIRunStreamAndDetailEdgeBranches(t *testing.T) {
 
 	t.Run("stream rpc error", func(t *testing.T) {
 		server := newRunServiceStubServer(t, runServiceStub{
-			runAgentStream: func(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				return connect.NewError(connect.CodeUnavailable, fmt.Errorf("runner unavailable"))
 			},
 		})
@@ -59,17 +59,17 @@ func TestCLIRunStreamAndDetailEdgeBranches(t *testing.T) {
 
 	t.Run("warnings aggregate and output can be suppressed", func(t *testing.T) {
 		server := newRunServiceStubServer(t, runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:     "run-warn",
 					Warnings:  []string{"event warning"},
 					Chunk:     "hidden\n",
 				}); err != nil {
 					return err
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-warn",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-warn",
@@ -103,9 +103,9 @@ func TestCLIRunStreamAndDetailEdgeBranches(t *testing.T) {
 
 	t.Run("output writer error stops stream", func(t *testing.T) {
 		server := newRunServiceStubServer(t, runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:     "run-write-error",
 					Chunk:     "cannot write\n",
 				})
@@ -121,9 +121,9 @@ func TestCLIRunStreamAndDetailEdgeBranches(t *testing.T) {
 
 	t.Run("get detail error is wrapped", func(t *testing.T) {
 		server := newRunServiceStubServer(t, runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-detail-missing",
 					Run:       &agentcomposev2.RunSummary{RunId: "run-detail-missing", ProjectId: req.Msg.GetProjectId(), AgentName: req.Msg.GetAgentName(), Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED},
 				})
@@ -152,13 +152,13 @@ agents:
 		var sawRequest bool
 		server := newComposeServiceStubServer(t, composeServiceStubs{
 			run: runServiceStub{
-				runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+				runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 					sawRequest = true
 					if req.Msg.GetPrompt() != "positional prompt" || req.Msg.GetCommand() != "" || req.Msg.GetTriggerId() != "" {
-						t.Fatalf("RunAgentStream request = %#v", req.Msg)
+						t.Fatalf("StreamAgentRun request = %#v", req.Msg)
 					}
-					return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-						EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+					return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+						EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 						RunId:     "run-optional-prompt",
 						Run:       &agentcomposev2.RunSummary{RunId: "run-optional-prompt", ProjectId: req.Msg.GetProjectId(), AgentName: "reviewer", Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED},
 					})
@@ -186,13 +186,13 @@ agents:
 		var sawRequest bool
 		server := newComposeServiceStubServer(t, composeServiceStubs{
 			run: runServiceStub{
-				runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+				runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 					sawRequest = true
 					if req.Msg.GetCommand() != "echo positional" || req.Msg.GetPrompt() != "" || req.Msg.GetTriggerId() != "" {
-						t.Fatalf("RunAgentStream request = %#v", req.Msg)
+						t.Fatalf("StreamAgentRun request = %#v", req.Msg)
 					}
-					return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-						EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+					return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+						EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 						RunId:     "run-optional-command",
 						Run:       &agentcomposev2.RunSummary{RunId: "run-optional-command", ProjectId: req.Msg.GetProjectId(), AgentName: "reviewer", Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED},
 					})
@@ -219,8 +219,8 @@ agents:
 `)
 		server := newComposeServiceStubServer(t, composeServiceStubs{
 			run: runServiceStub{
-				startRun: func(context.Context, *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
-					return connect.NewResponse(&agentcomposev2.StartRunResponse{Started: true}), nil
+				startRun: func(context.Context, *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
+					return connect.NewResponse(&agentcomposev2.StartAgentRunResponse{Started: true}), nil
 				},
 			},
 		})
@@ -241,9 +241,9 @@ agents:
 `)
 		server := newComposeServiceStubServer(t, composeServiceStubs{
 			run: runServiceStub{
-				runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-					return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-						EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+					return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+						EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 						RunId:     "run-interactive-cleanup",
 						Run:       &agentcomposev2.RunSummary{RunId: "run-interactive-cleanup", ProjectId: req.Msg.GetProjectId(), AgentName: "reviewer", Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, SandboxId: "sandbox-cleanup"},
 					})

--- a/cmd/agent-compose/cli_run_stream.go
+++ b/cmd/agent-compose/cli_run_stream.go
@@ -15,7 +15,7 @@ import (
 )
 
 func runComposeRunStreamAndDetail(ctx context.Context, stdout, stderr io.Writer, client agentcomposev2connect.RunServiceClient, projectID, projectName string, runReq *agentcomposev2.RunAgentRequest, suppressOutput bool) (*agentcomposev2.RunDetail, *agentcomposev2.RunSummary, []string, error) {
-	stream, err := client.RunAgentStream(ctx, connect.NewRequest(runReq))
+	stream, err := client.StreamAgentRun(ctx, connect.NewRequest(runReq))
 	if err != nil {
 		return nil, nil, nil, commandExitErrorForConnect(fmt.Errorf("run project %s agent %s: %w", projectName, runReq.GetAgentName(), err))
 	}
@@ -41,14 +41,14 @@ func runComposeRunStreamAndDetail(ctx context.Context, stdout, stderr io.Writer,
 			warnings = appendUniqueStrings(warnings, event.GetRun().GetWarnings()...)
 		}
 		switch event.GetEventType() {
-		case agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT:
+		case agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT:
 			if suppressOutput {
 				continue
 			}
 			if err := output.Write(event.GetTranscript(), event.GetChunk(), event.GetStream()); err != nil {
 				return nil, nil, nil, err
 			}
-		case agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED:
+		case agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED:
 			completed = event.GetRun()
 			if completed.GetRunId() != "" {
 				runID = completed.GetRunId()

--- a/cmd/agent-compose/cli_run_stream_test.go
+++ b/cmd/agent-compose/cli_run_stream_test.go
@@ -105,9 +105,9 @@ func TestWriteTranscriptOrChunkRoutesTranscriptAndChunks(t *testing.T) {
 	}
 }
 
-func (s runServiceStub) RunAgentStream(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+func (s runServiceStub) StreamAgentRun(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 	if s.runAgentStream == nil {
-		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("RunAgentStream stub is not configured"))
+		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("StreamAgentRun stub is not configured"))
 	}
 	return s.runAgentStream(ctx, req, stream)
 }

--- a/cmd/agent-compose/cli_runtime_project_test.go
+++ b/cmd/agent-compose/cli_runtime_project_test.go
@@ -56,11 +56,11 @@ func TestIntegrationCLIRuntimeCommandsSelectStoredProjectByName(t *testing.T) {
 			},
 		},
 		run: runServiceStub{
-			startRun: func(_ context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+			startRun: func(_ context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 				if req.Msg.GetRun().GetProjectId() != "project-stored" || req.Msg.GetRun().GetAgentName() != "worker" {
-					t.Fatalf("StartRun request = %#v", req.Msg.GetRun())
+					t.Fatalf("StartAgentRun request = %#v", req.Msg.GetRun())
 				}
-				return connect.NewResponse(&agentcomposev2.StartRunResponse{Run: &agentcomposev2.RunSummary{
+				return connect.NewResponse(&agentcomposev2.StartAgentRunResponse{Run: &agentcomposev2.RunSummary{
 					RunId: "run-stored", ProjectId: "project-stored", ProjectName: "stored-project", AgentName: "worker", Status: agentcomposev2.RunStatus_RUN_STATUS_PENDING,
 				}, Started: true}), nil
 			},
@@ -71,11 +71,11 @@ func TestIntegrationCLIRuntimeCommandsSelectStoredProjectByName(t *testing.T) {
 				return connect.NewResponse(&agentcomposev2.ListRunsResponse{}), nil
 			},
 		},
-		exec: execServiceStub{execStream: func(_ context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+		exec: execServiceStub{execStream: func(_ context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.StreamExecResponse]) error {
 			if req.Msg.GetSandboxId() != "sandbox-stored" {
-				t.Fatalf("ExecStream target = %#v", req.Msg.GetTarget())
+				t.Fatalf("StreamExec target = %#v", req.Msg.GetTarget())
 			}
-			return stream.Send(&agentcomposev2.ExecStreamResponse{EventType: agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED, Result: &agentcomposev2.ExecResult{
+			return stream.Send(&agentcomposev2.StreamExecResponse{EventType: agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED, Result: &agentcomposev2.ExecResult{
 				ExecId: "exec-stored", SandboxId: "sandbox-stored", Success: true,
 			}})
 		}},

--- a/cmd/agent-compose/cli_sandbox_integration_lifecycle_test.go
+++ b/cmd/agent-compose/cli_sandbox_integration_lifecycle_test.go
@@ -24,29 +24,29 @@ agents:
 `)
 	var sawRequest bool
 	server := newRunServiceStubServer(t, runServiceStub{
-		runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+		runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 			sawRequest = true
 			if req.Msg.GetAgentName() != "reviewer" || req.Msg.GetPrompt() != "check this" || req.Msg.GetSandboxId() != "session-reuse" || req.Msg.GetTriggerId() != "" {
-				t.Fatalf("RunAgentStream request = %#v", req.Msg)
+				t.Fatalf("StreamAgentRun request = %#v", req.Msg)
 			}
 			if req.Msg.GetSource() != agentcomposev2.RunSource_RUN_SOURCE_MANUAL || req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_KEEP_RUNNING {
-				t.Fatalf("RunAgentStream source/cleanup = %#v", req.Msg)
+				t.Fatalf("StreamAgentRun source/cleanup = %#v", req.Msg)
 			}
-			if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-				EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_STARTED,
+			if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+				EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_STARTED,
 				RunId:     "run-success",
 			}); err != nil {
 				return err
 			}
-			if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-				EventType:  agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+			if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+				EventType:  agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 				RunId:      "run-success",
 				Transcript: &agentcomposev2.TranscriptEvent{Stream: agentcomposev2.StdioStream_STDIO_STREAM_STDOUT, Text: "live output\n"},
 			}); err != nil {
 				return err
 			}
-			return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-				EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+			return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+				EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 				RunId:     "run-success",
 				Run: &agentcomposev2.RunSummary{
 					RunId:     "run-success",
@@ -57,8 +57,8 @@ agents:
 				},
 			})
 		},
-		runAttach: func(context.Context, *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error {
-			t.Fatalf("RunAttach should not be called for non-interactive run --prompt")
+		runAttach: func(context.Context, *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
+			t.Fatalf("AttachAgentRun should not be called for non-interactive run --prompt")
 			return nil
 		},
 		getRun: func(ctx context.Context, req *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
@@ -78,7 +78,7 @@ agents:
 		t.Fatalf("daemon runner called %d times, want 0", runCount)
 	}
 	if !sawRequest {
-		t.Fatal("RunAgentStream was not called")
+		t.Fatal("StreamAgentRun was not called")
 	}
 
 	for _, tc := range []struct {
@@ -110,25 +110,25 @@ agents:
 	var sessions []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				prompts = append(prompts, req.Msg.GetPrompt())
 				sessions = append(sessions, req.Msg.GetSandboxId())
 				if req.Msg.GetCommand() != "" || req.Msg.GetTriggerId() != "" {
-					t.Fatalf("RunAgentStream interactive prompt request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun interactive prompt request = %#v", req.Msg)
 				}
 				if req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_KEEP_RUNNING {
-					t.Fatalf("RunAgentStream cleanup policy = %#v", req.Msg.GetCleanupPolicy())
+					t.Fatalf("StreamAgentRun cleanup policy = %#v", req.Msg.GetCleanupPolicy())
 				}
 				runID := fmt.Sprintf("run-repl-%d", len(prompts))
-				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType:  agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType:  agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:      runID,
 					Transcript: &agentcomposev2.TranscriptEvent{Text: fmt.Sprintf("prompt %d output\n", len(prompts))},
 				}); err != nil {
 					return err
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     runID,
 					Run: &agentcomposev2.RunSummary{
 						RunId:     runID,
@@ -173,23 +173,23 @@ agents:
 	var sessions []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				drivers = append(drivers, req.Msg.GetDriver())
 				prompts = append(prompts, req.Msg.GetPrompt())
 				sessions = append(sessions, req.Msg.GetSandboxId())
 				if req.Msg.GetCommand() != "" || req.Msg.GetTriggerId() != "" {
-					t.Fatalf("RunAgentStream interactive prompt request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun interactive prompt request = %#v", req.Msg)
 				}
 				runID := fmt.Sprintf("run-driver-repl-%d", len(prompts))
-				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType:  agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType:  agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:      runID,
 					Transcript: &agentcomposev2.TranscriptEvent{Text: fmt.Sprintf("driver %d output\n", len(prompts))},
 				}); err != nil {
 					return err
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     runID,
 					Run: &agentcomposev2.RunSummary{
 						RunId:     runID,
@@ -236,25 +236,25 @@ agents:
 	var sessions []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				commands = append(commands, req.Msg.GetCommand())
 				sessions = append(sessions, req.Msg.GetSandboxId())
 				if req.Msg.GetPrompt() != "" || req.Msg.GetTriggerId() != "" {
-					t.Fatalf("RunAgentStream interactive command request = %#v", req.Msg)
+					t.Fatalf("StreamAgentRun interactive command request = %#v", req.Msg)
 				}
 				if req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_KEEP_RUNNING {
-					t.Fatalf("RunAgentStream cleanup policy = %#v", req.Msg.GetCleanupPolicy())
+					t.Fatalf("StreamAgentRun cleanup policy = %#v", req.Msg.GetCleanupPolicy())
 				}
 				runID := fmt.Sprintf("run-command-repl-%d", len(commands))
-				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType:  agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType:  agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:      runID,
 					Transcript: &agentcomposev2.TranscriptEvent{Text: fmt.Sprintf("command %d output\n", len(commands))},
 				}); err != nil {
 					return err
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     runID,
 					Run: &agentcomposev2.RunSummary{
 						RunId:     runID,
@@ -297,9 +297,9 @@ agents:
 	var removed []string
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-repl-rm",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-repl-rm",
@@ -344,19 +344,19 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION {
-					t.Fatalf("RunAgentStream cleanup policy = %#v", req.Msg.GetCleanupPolicy())
+					t.Fatalf("StreamAgentRun cleanup policy = %#v", req.Msg.GetCleanupPolicy())
 				}
-				if err := stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+				if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 					RunId:     "run-rm",
 					Chunk:     "done\n",
 				}); err != nil {
 					return err
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-rm",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-rm",
@@ -392,12 +392,12 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION {
-					t.Fatalf("RunAgentStream cleanup policy = %#v", req.Msg.GetCleanupPolicy())
+					t.Fatalf("StreamAgentRun cleanup policy = %#v", req.Msg.GetCleanupPolicy())
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-rm-detail",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-rm-detail",
@@ -432,12 +432,12 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION {
-					t.Fatalf("RunAgentStream cleanup policy = %#v", req.Msg.GetCleanupPolicy())
+					t.Fatalf("StreamAgentRun cleanup policy = %#v", req.Msg.GetCleanupPolicy())
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-rm-error",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-rm-error",

--- a/cmd/agent-compose/cli_sandbox_integration_list_test.go
+++ b/cmd/agent-compose/cli_sandbox_integration_list_test.go
@@ -20,12 +20,12 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetSandboxId() != "sandbox-existing" {
-					t.Fatalf("RunAgentStream sandbox = %q, want sandbox-existing", req.Msg.GetSandboxId())
+					t.Fatalf("StreamAgentRun sandbox = %q, want sandbox-existing", req.Msg.GetSandboxId())
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-repl-existing",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-repl-existing",
@@ -64,12 +64,12 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 				if req.Msg.GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION {
-					t.Fatalf("RunAgentStream cleanup policy = %#v", req.Msg.GetCleanupPolicy())
+					t.Fatalf("StreamAgentRun cleanup policy = %#v", req.Msg.GetCleanupPolicy())
 				}
-				return stream.Send(&agentcomposev2.RunAgentStreamResponse{
-					EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+				return stream.Send(&agentcomposev2.StreamAgentRunResponse{
+					EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 					RunId:     "run-rm-failed",
 					Run: &agentcomposev2.RunSummary{
 						RunId:     "run-rm-failed",

--- a/cmd/agent-compose/cli_sandbox_workflows_e2e_test.go
+++ b/cmd/agent-compose/cli_sandbox_workflows_e2e_test.go
@@ -17,7 +17,7 @@ func TestE2ECLISandboxNamingUserWorkflows(t *testing.T) {
 		},
 		{
 			name: "exec <sandbox> --command",
-			run:  TestIntegrationCLIExecStreamsAndSupportsJSON,
+			run:  TestIntegrationCLIStreamExecsAndSupportsJSON,
 		},
 		{
 			name: "logs --sandbox",

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -240,8 +240,8 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				t.Fatalf("RunAgentStream should not be called for positional trigger")
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				t.Fatalf("StreamAgentRun should not be called for positional trigger")
 				return nil
 			},
 		},
@@ -268,8 +268,8 @@ agents:
 `)
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		run: runServiceStub{
-			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
-				t.Fatalf("RunAgentStream should not be called for positional trigger")
+			runAgentStream: func(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+				t.Fatalf("StreamAgentRun should not be called for positional trigger")
 				return nil
 			},
 		},

--- a/cmd/agent-compose/coverage_shape_workflows_test.go
+++ b/cmd/agent-compose/coverage_shape_workflows_test.go
@@ -75,7 +75,7 @@ func TestE2ECLISandboxOperationsPublicContractWorkflow(t *testing.T) {
 	TestIntegrationCLIStatsWithoutSandboxUsesProjectRunningSandboxes(t)
 	TestIntegrationCLIStatsWithoutSandboxAllowsNoRunningSandboxes(t)
 	TestIntegrationCLIRemoveSandboxes(t)
-	TestIntegrationCLIExecStreamsAndSupportsJSON(t)
+	TestIntegrationCLIStreamExecsAndSupportsJSON(t)
 }
 
 func TestE2ECLIProjectAndRunPublicContractWorkflow(t *testing.T) {
@@ -116,7 +116,7 @@ func TestE2ECLIInteractiveAndJupyterPublicContractWorkflow(t *testing.T) {
 	TestIntegrationCLIRunJupyterExposeJSONIncludesURL(t)
 	TestIntegrationCLIRunJupyterExposeJSONDefaultCleanupOmitsURL(t)
 	TestIntegrationCLIRunInteractivePromptReusesSession(t)
-	TestIntegrationCLIRunPromptTTYUsesRunAttach(t)
+	TestIntegrationCLIRunPromptTTYUsesAttachAgentRun(t)
 	TestIntegrationCLIRunInteractiveDriverOnlySentForInitialSandbox(t)
 	TestIntegrationCLIRunInteractiveCommandReusesSession(t)
 	TestIntegrationCLIRunInteractiveRemoveCreatedSandboxOnExit(t)

--- a/cmd/agent-compose/main_integration_test.go
+++ b/cmd/agent-compose/main_integration_test.go
@@ -68,7 +68,7 @@ func testDaemonListenConfigWorkflow(t *testing.T) {
 	t.Run("cli remove sandbox usage errors", TestCLIRemoveSandboxUsageErrors)
 	t.Run("cli stop requires sandbox", TestCLIStopRequiresSandboxUsageError)
 	t.Run("cli resume rejects empty sandbox", TestCLIResumeRejectsEmptySandboxUsageError)
-	t.Run("cli exec streams and json", TestIntegrationCLIExecStreamsAndSupportsJSON)
+	t.Run("cli exec streams and json", TestIntegrationCLIStreamExecsAndSupportsJSON)
 	t.Run("cli exec interactive reserved unsupported", TestCLIExecInteractiveReservedUnsupported)
 	t.Run("cli exec rejects empty sandbox", TestCLIExecRejectsEmptySandboxUsageError)
 	t.Run("cli exec agent flag is removed", TestCLIExecAgentFlagIsRemoved)

--- a/cmd/agent-compose/public_cli_e2e_test.go
+++ b/cmd/agent-compose/public_cli_e2e_test.go
@@ -7,8 +7,8 @@ func TestE2ECLIStreamingAndFailureWorkflows(t *testing.T) {
 	t.Run("run output branches", TestCLIRunStreamAndDetailEdgeBranches)
 	t.Run("run completion failures", TestCLIRunCompletionErrorBranches)
 	t.Run("run command edges", TestCLIRunCommandAdditionalEdgeWorkflows)
-	t.Run("exec interaction", TestCLIExecInteractiveUsesExecAttachClient)
-	t.Run("exec prompt interaction", TestCLIExecPromptAttachUsesExecAttachClient)
-	t.Run("daemon HTTP attach", TestDaemonHTTPClientRunAttachBidiUsesH2C)
-	t.Run("daemon TCP attach", TestDaemonTCPServerRunAttachBidiUsesH2C)
+	t.Run("exec interaction", TestCLIExecInteractiveUsesAttachExecClient)
+	t.Run("exec prompt interaction", TestCLIExecPromptAttachUsesAttachExecClient)
+	t.Run("daemon HTTP attach", TestDaemonHTTPClientAttachAgentRunBidiUsesH2C)
+	t.Run("daemon TCP attach", TestDaemonTCPServerAttachAgentRunBidiUsesH2C)
 }

--- a/cmd/agent-compose/terminal_other.go
+++ b/cmd/agent-compose/terminal_other.go
@@ -25,10 +25,10 @@ func terminalSizeForFD(int) *agentcomposev2.AttachTerminalSize {
 	return nil
 }
 
-func startExecAttachResizePump(context.Context, int, func(*agentcomposev2.ExecAttachRequest) error) func() {
+func startAttachExecResizePump(context.Context, int, func(*agentcomposev2.AttachExecRequest) error) func() {
 	return func() {}
 }
 
-func startRunAttachResizePump(context.Context, int, func(*agentcomposev2.RunAttachRequest) error) func() {
+func startAttachAgentRunResizePump(context.Context, int, func(*agentcomposev2.AttachAgentRunRequest) error) func() {
 	return func() {}
 }

--- a/cmd/agent-compose/terminal_unix.go
+++ b/cmd/agent-compose/terminal_unix.go
@@ -51,7 +51,7 @@ func terminalSizeForFD(fd int) *agentcomposev2.AttachTerminalSize {
 	}
 }
 
-func startExecAttachResizePump(ctx context.Context, fd int, send func(*agentcomposev2.ExecAttachRequest) error) func() {
+func startAttachExecResizePump(ctx context.Context, fd int, send func(*agentcomposev2.AttachExecRequest) error) func() {
 	ctx, cancel := context.WithCancel(ctx)
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGWINCH)
@@ -67,8 +67,8 @@ func startExecAttachResizePump(ctx context.Context, fd int, send func(*agentcomp
 				if size == nil {
 					continue
 				}
-				_ = send(&agentcomposev2.ExecAttachRequest{
-					Frame: &agentcomposev2.ExecAttachRequest_Resize{Resize: &agentcomposev2.AttachResize{TerminalSize: size}},
+				_ = send(&agentcomposev2.AttachExecRequest{
+					Frame: &agentcomposev2.AttachExecRequest_Resize{Resize: &agentcomposev2.AttachResize{TerminalSize: size}},
 				})
 			}
 		}
@@ -80,7 +80,7 @@ func startExecAttachResizePump(ctx context.Context, fd int, send func(*agentcomp
 	}
 }
 
-func startRunAttachResizePump(ctx context.Context, fd int, send func(*agentcomposev2.RunAttachRequest) error) func() {
+func startAttachAgentRunResizePump(ctx context.Context, fd int, send func(*agentcomposev2.AttachAgentRunRequest) error) func() {
 	ctx, cancel := context.WithCancel(ctx)
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGWINCH)
@@ -96,8 +96,8 @@ func startRunAttachResizePump(ctx context.Context, fd int, send func(*agentcompo
 				if size == nil {
 					continue
 				}
-				_ = send(&agentcomposev2.RunAttachRequest{
-					Frame: &agentcomposev2.RunAttachRequest_Resize{Resize: &agentcomposev2.AttachResize{TerminalSize: size}},
+				_ = send(&agentcomposev2.AttachAgentRunRequest{
+					Frame: &agentcomposev2.AttachAgentRunRequest_Resize{Resize: &agentcomposev2.AttachResize{TerminalSize: size}},
 				})
 			}
 		}

--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -342,7 +342,7 @@ enum StdioStream {
 }
 ```
 
-`RunAgentStreamResponse`, `ExecStreamResponse`, and `TranscriptEvent` carry a
+`StreamAgentRunResponse`, `StreamExecResponse`, and `TranscriptEvent` carry a
 `stream` field. `STDIO_STREAM_UNSPECIFIED` is treated as stdout by CLI and host
 consumers. The v1 API keeps its historical `is_stderr` fields for compatibility;
 the conversion to that boolean happens only at v1/session compatibility

--- a/docs/design/runtime-bidirectional-stream-design.md
+++ b/docs/design/runtime-bidirectional-stream-design.md
@@ -295,15 +295,15 @@ Existing unary and server-stream APIs cannot carry client stdin/resize/human mes
 ```proto
 service ExecService {
   rpc Exec(ExecRequest) returns (ExecResponse);
-  rpc ExecStream(ExecRequest) returns (stream ExecStreamResponse);
-  rpc ExecAttach(stream ExecAttachRequest) returns (stream ExecAttachResponse);
+  rpc ExecStream(ExecRequest) returns (stream StreamExecResponse);
+  rpc ExecAttach(stream AttachExecRequest) returns (stream AttachExecResponse);
 }
 
 service RunService {
   rpc RunAgent(RunAgentRequest) returns (RunAgentResponse);
-  rpc StartRun(StartRunRequest) returns (StartRunResponse);
-  rpc RunAgentStream(RunAgentRequest) returns (stream RunAgentStreamResponse);
-  rpc RunAttach(stream RunAttachRequest) returns (stream RunAttachResponse);
+  rpc StartRun(StartAgentRunRequest) returns (StartAgentRunResponse);
+  rpc RunAgentStream(RunAgentRequest) returns (stream StreamAgentRunResponse);
+  rpc RunAttach(stream AttachAgentRunRequest) returns (stream AttachAgentRunResponse);
 }
 ```
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -256,7 +256,7 @@ Rules:
 - `run -d/--detach` and `run -i/--interactive` are mutually exclusive.
 - `run -i/--interactive` must select `--prompt` or `--command`; it cannot be combined with `--json`.
 - Empty REPL lines do not create runs. Enter `/exit` or press Ctrl+D to exit.
-- REPL mode is not TTY/PTY or running stdin passthrough. Each input is one independent `RunAgentStream` call that reuses the same sandbox.
+- REPL mode is not TTY/PTY or running stdin passthrough. Each input is one independent `StreamAgentRun` call that reuses the same sandbox.
 - Detached runs can be observed with the printed `agent-compose logs --run <run-id> --follow` command, or managed later with `stop` and `logs`.
 - `run -i --prompt` supports providers with reusable provider conversations: Codex, Claude/cc, OpenCode, and Pi. Gemini currently returns unsupported.
 - `StopRun` requests cancellation for active in-daemon runs. Pending/running runs left behind after daemon restart are reconciled to failed with a `daemon interrupted` error.

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -253,7 +253,7 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 - `run -d/--detach` 和 `run -i/--interactive` 互斥。
 - `run -i/--interactive` 必须选择 `--prompt` 或 `--command`，不能与 `--json` 组合。
 - REPL 中空行不会创建 run；输入 `/exit` 或 Ctrl+D 退出。
-- REPL 不是 TTY/PTY 或运行中 stdin 透传；每条输入都是一次独立 `RunAgentStream`，但复用同一个 sandbox。
+- REPL 不是 TTY/PTY 或运行中 stdin 透传；每条输入都是一次独立 `StreamAgentRun`，但复用同一个 sandbox。
 - detached run 可通过输出的 `agent-compose logs --run <run-id> --follow` 命令观察输出，也可继续使用 `stop`/`logs` 操作该 run。
 - `run -i --prompt` 仅支持可复用 provider conversation 的 Codex、Claude/cc、OpenCode 和 Pi；Gemini 当前会返回 unsupported。
 - `StopRun` 会请求 daemon 内当前活动 run 取消；daemon 重启后遗留的 running/pending run 会在启动 reconcile 中标记为 failed，并带 `daemon interrupted` 错误。

--- a/pkg/agentcompose/api/attach_input_test.go
+++ b/pkg/agentcompose/api/attach_input_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPumpExecAttachInputClosesRuntimeInputOnReceiveError(t *testing.T) {
 	interaction := &execClosingRuntimeInteraction{}
-	pumpExecAttachInput(func() (*agentcomposev2.ExecAttachRequest, error) {
+	pumpExecAttachInput(func() (*agentcomposev2.AttachExecRequest, error) {
 		return nil, errors.New("stream reset")
 	}, interaction)
 	if interaction.closeCalls != 1 {

--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -86,17 +86,17 @@ func (h *ExecHandler) Exec(ctx context.Context, req *connect.Request[agentcompos
 	return connect.NewResponse(&agentcomposev2.ExecResponse{Result: result}), nil
 }
 
-func (h *ExecHandler) ExecStream(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.ExecStreamResponse]) error {
+func (h *ExecHandler) StreamExec(ctx context.Context, req *connect.Request[agentcomposev2.ExecRequest], stream *connect.ServerStream[agentcomposev2.StreamExecResponse]) error {
 	PrepareStreamingHeaders(stream.ResponseHeader())
 	execID := uuid.NewString()
-	result, err := h.executeProjectCommand(ctx, req.Msg, execID, func(resp *agentcomposev2.ExecStreamResponse) error {
+	result, err := h.executeProjectCommand(ctx, req.Msg, execID, func(resp *agentcomposev2.StreamExecResponse) error {
 		return stream.Send(resp)
 	})
 	if err != nil {
 		return err
 	}
-	return stream.Send(&agentcomposev2.ExecStreamResponse{
-		EventType: agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED,
+	return stream.Send(&agentcomposev2.StreamExecResponse{
+		EventType: agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED,
 		ExecId:    execID,
 		SandboxId: result.GetSandboxId(),
 		RunId:     result.GetRunId(),
@@ -104,13 +104,13 @@ func (h *ExecHandler) ExecStream(ctx context.Context, req *connect.Request[agent
 	})
 }
 
-func (h *ExecHandler) ExecAttach(ctx context.Context, stream *connect.BidiStream[agentcomposev2.ExecAttachRequest, agentcomposev2.ExecAttachResponse]) error {
+func (h *ExecHandler) AttachExec(ctx context.Context, stream *connect.BidiStream[agentcomposev2.AttachExecRequest, agentcomposev2.AttachExecResponse]) error {
 	return h.execAttach(ctx, stream.Receive, stream.Send)
 }
 
-type execStreamSender func(*agentcomposev2.ExecStreamResponse) error
-type execAttachReceiver func() (*agentcomposev2.ExecAttachRequest, error)
-type execAttachSender func(*agentcomposev2.ExecAttachResponse) error
+type execStreamSender func(*agentcomposev2.StreamExecResponse) error
+type execAttachReceiver func() (*agentcomposev2.AttachExecRequest, error)
+type execAttachSender func(*agentcomposev2.AttachExecResponse) error
 
 func (h *ExecHandler) execAttach(ctx context.Context, receive execAttachReceiver, send execAttachSender) error {
 	if h.store == nil || h.projects == nil || h.runtime == nil {
@@ -197,7 +197,7 @@ func (r execAttachRunner) runInteraction(interaction driverpkg.RuntimeInteractio
 	}
 }
 
-func (h *ExecHandler) execPromptAttach(ctx context.Context, start *agentcomposev2.ExecAttachStart, receive execAttachReceiver, send execAttachSender) error {
+func (h *ExecHandler) execPromptAttach(ctx context.Context, start *agentcomposev2.AttachExecStart, receive execAttachReceiver, send execAttachSender) error {
 	if h.runAttach == nil {
 		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("exec prompt attach is unsupported"))
 	}
@@ -226,8 +226,8 @@ func (h *ExecHandler) execPromptAttach(ctx context.Context, start *agentcomposev
 	if projectID == "" || agentName == "" {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exec prompt target must be associated with a project agent"))
 	}
-	initial := &agentcomposev2.RunAttachRequest{
-		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	initial := &agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 			Request: &agentcomposev2.RunAgentRequest{
 				ProjectId:     projectID,
 				AgentName:     agentName,
@@ -242,22 +242,22 @@ func (h *ExecHandler) execPromptAttach(ctx context.Context, start *agentcomposev
 		}},
 	}
 	receiver := newExecPromptRunAttachReceiver(initial, receive)
-	return h.runAttach.RunProjectCommandAttach(ctx, receiver.Receive, func(resp *agentcomposev2.RunAttachResponse) error {
+	return h.runAttach.RunProjectCommandAttach(ctx, receiver.Receive, func(resp *agentcomposev2.AttachAgentRunResponse) error {
 		return send(execAttachResponseFromRunAttach(resp))
 	})
 }
 
 type execPromptRunAttachReceiver struct {
-	initial   *agentcomposev2.RunAttachRequest
+	initial   *agentcomposev2.AttachAgentRunRequest
 	receive   execAttachReceiver
 	sentStart bool
 }
 
-func newExecPromptRunAttachReceiver(initial *agentcomposev2.RunAttachRequest, receive execAttachReceiver) *execPromptRunAttachReceiver {
+func newExecPromptRunAttachReceiver(initial *agentcomposev2.AttachAgentRunRequest, receive execAttachReceiver) *execPromptRunAttachReceiver {
 	return &execPromptRunAttachReceiver{initial: initial, receive: receive}
 }
 
-func (r *execPromptRunAttachReceiver) Receive() (*agentcomposev2.RunAttachRequest, error) {
+func (r *execPromptRunAttachReceiver) Receive() (*agentcomposev2.AttachAgentRunRequest, error) {
 	if !r.sentStart {
 		r.sentStart = true
 		return r.initial, nil
@@ -267,37 +267,37 @@ func (r *execPromptRunAttachReceiver) Receive() (*agentcomposev2.RunAttachReques
 		return nil, err
 	}
 	switch frame := req.GetFrame().(type) {
-	case *agentcomposev2.ExecAttachRequest_StdinEof:
-		return &agentcomposev2.RunAttachRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.RunAttachRequest_StdinEof{StdinEof: frame.StdinEof}}, nil
-	case *agentcomposev2.ExecAttachRequest_Resize:
-		return &agentcomposev2.RunAttachRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.RunAttachRequest_Resize{Resize: frame.Resize}}, nil
-	case *agentcomposev2.ExecAttachRequest_Cancel:
-		return &agentcomposev2.RunAttachRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.RunAttachRequest_Cancel{Cancel: frame.Cancel}}, nil
-	case *agentcomposev2.ExecAttachRequest_HumanMessage:
-		return &agentcomposev2.RunAttachRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.RunAttachRequest_HumanMessage{HumanMessage: frame.HumanMessage}}, nil
+	case *agentcomposev2.AttachExecRequest_StdinEof:
+		return &agentcomposev2.AttachAgentRunRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.AttachAgentRunRequest_StdinEof{StdinEof: frame.StdinEof}}, nil
+	case *agentcomposev2.AttachExecRequest_Resize:
+		return &agentcomposev2.AttachAgentRunRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.AttachAgentRunRequest_Resize{Resize: frame.Resize}}, nil
+	case *agentcomposev2.AttachExecRequest_Cancel:
+		return &agentcomposev2.AttachAgentRunRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.AttachAgentRunRequest_Cancel{Cancel: frame.Cancel}}, nil
+	case *agentcomposev2.AttachExecRequest_HumanMessage:
+		return &agentcomposev2.AttachAgentRunRequest{ClientFrameId: req.GetClientFrameId(), Frame: &agentcomposev2.AttachAgentRunRequest_HumanMessage{HumanMessage: frame.HumanMessage}}, nil
 	default:
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid exec prompt attach frame"))
 	}
 }
 
-func execAttachResponseFromRunAttach(resp *agentcomposev2.RunAttachResponse) *agentcomposev2.ExecAttachResponse {
-	out := &agentcomposev2.ExecAttachResponse{
+func execAttachResponseFromRunAttach(resp *agentcomposev2.AttachAgentRunResponse) *agentcomposev2.AttachExecResponse {
+	out := &agentcomposev2.AttachExecResponse{
 		ServerFrameId: resp.GetServerFrameId(),
 		CreatedAt:     resp.GetCreatedAt(),
 	}
 	switch frame := resp.GetFrame().(type) {
-	case *agentcomposev2.RunAttachResponse_Started:
-		out.Frame = &agentcomposev2.ExecAttachResponse_Started{Started: frame.Started}
-	case *agentcomposev2.RunAttachResponse_Output:
-		out.Frame = &agentcomposev2.ExecAttachResponse_Output{Output: frame.Output}
-	case *agentcomposev2.RunAttachResponse_Result:
-		out.Frame = &agentcomposev2.ExecAttachResponse_Result{Result: frame.Result}
-	case *agentcomposev2.RunAttachResponse_Error:
-		out.Frame = &agentcomposev2.ExecAttachResponse_Error{Error: frame.Error}
-	case *agentcomposev2.RunAttachResponse_AgentEvent:
-		out.Frame = &agentcomposev2.ExecAttachResponse_AgentEvent{AgentEvent: frame.AgentEvent}
-	case *agentcomposev2.RunAttachResponse_AgentTurnCompleted:
-		out.Frame = &agentcomposev2.ExecAttachResponse_AgentTurnCompleted{AgentTurnCompleted: frame.AgentTurnCompleted}
+	case *agentcomposev2.AttachAgentRunResponse_Started:
+		out.Frame = &agentcomposev2.AttachExecResponse_Started{Started: frame.Started}
+	case *agentcomposev2.AttachAgentRunResponse_Output:
+		out.Frame = &agentcomposev2.AttachExecResponse_Output{Output: frame.Output}
+	case *agentcomposev2.AttachAgentRunResponse_Result:
+		out.Frame = &agentcomposev2.AttachExecResponse_Result{Result: frame.Result}
+	case *agentcomposev2.AttachAgentRunResponse_Error:
+		out.Frame = &agentcomposev2.AttachExecResponse_Error{Error: frame.Error}
+	case *agentcomposev2.AttachAgentRunResponse_AgentEvent:
+		out.Frame = &agentcomposev2.AttachExecResponse_AgentEvent{AgentEvent: frame.AgentEvent}
+	case *agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted:
+		out.Frame = &agentcomposev2.AttachExecResponse_AgentTurnCompleted{AgentTurnCompleted: frame.AgentTurnCompleted}
 	}
 	return out
 }
@@ -325,7 +325,7 @@ type execAttachState struct {
 	tty     bool
 }
 
-func (h *ExecHandler) prepareExecAttach(ctx context.Context, start *agentcomposev2.ExecAttachStart) (*execAttachState, error) {
+func (h *ExecHandler) prepareExecAttach(ctx context.Context, start *agentcomposev2.AttachExecStart) (*execAttachState, error) {
 	req := start.GetRequest()
 	if req == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exec attach request is required"))
@@ -403,18 +403,18 @@ func pumpExecAttachInput(receive execAttachReceiver, interaction driverpkg.Runti
 	}
 }
 
-func runtimeInputFrameFromExecAttach(req *agentcomposev2.ExecAttachRequest) (driverpkg.RuntimeInputFrame, bool) {
+func runtimeInputFrameFromExecAttach(req *agentcomposev2.AttachExecRequest) (driverpkg.RuntimeInputFrame, bool) {
 	switch frame := req.GetFrame().(type) {
-	case *agentcomposev2.ExecAttachRequest_Stdin:
+	case *agentcomposev2.AttachExecRequest_Stdin:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: frame.Stdin.GetData()}, true
-	case *agentcomposev2.ExecAttachRequest_StdinEof:
+	case *agentcomposev2.AttachExecRequest_StdinEof:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdinEOF}, true
-	case *agentcomposev2.ExecAttachRequest_Resize:
+	case *agentcomposev2.AttachExecRequest_Resize:
 		size := frame.Resize.GetTerminalSize()
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputResize, Rows: size.GetRows(), Cols: size.GetCols()}, true
-	case *agentcomposev2.ExecAttachRequest_Signal:
+	case *agentcomposev2.AttachExecRequest_Signal:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputSignal, Signal: driverpkg.RuntimeSignal(strings.TrimSpace(frame.Signal.GetSignal()))}, true
-	case *agentcomposev2.ExecAttachRequest_Cancel:
+	case *agentcomposev2.AttachExecRequest_Cancel:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputCancel, Message: frame.Cancel.GetReason()}, true
 	default:
 		return driverpkg.RuntimeInputFrame{}, false
@@ -430,15 +430,15 @@ func newExecAttachProjection(state *execAttachState) *execAttachProjection {
 	return &execAttachProjection{state: state}
 }
 
-func (p *execAttachProjection) responseFromRuntimeFrame(frame driverpkg.RuntimeOutputFrame) *agentcomposev2.ExecAttachResponse {
+func (p *execAttachProjection) responseFromRuntimeFrame(frame driverpkg.RuntimeOutputFrame) *agentcomposev2.AttachExecResponse {
 	return p.state.responseFromRuntimeFrame(frame, &p.accumulator)
 }
 
-func (s *execAttachState) responseFromRuntimeFrame(frame driverpkg.RuntimeOutputFrame, accumulator *execution.ExecStreamAccumulator) *agentcomposev2.ExecAttachResponse {
-	resp := newExecAttachResponse()
+func (s *execAttachState) responseFromRuntimeFrame(frame driverpkg.RuntimeOutputFrame, accumulator *execution.ExecStreamAccumulator) *agentcomposev2.AttachExecResponse {
+	resp := newAttachExecResponse()
 	switch frame.Type {
 	case driverpkg.RuntimeOutputStarted:
-		resp.Frame = &agentcomposev2.ExecAttachResponse_Started{Started: &agentcomposev2.AttachStarted{
+		resp.Frame = &agentcomposev2.AttachExecResponse_Started{Started: &agentcomposev2.AttachStarted{
 			OperationId: s.execID,
 			ExecId:      s.execID,
 			RunId:       s.runID,
@@ -449,7 +449,7 @@ func (s *execAttachState) responseFromRuntimeFrame(frame driverpkg.RuntimeOutput
 		if accumulator != nil {
 			accumulator.WriteChunk(domain.ExecChunk{Text: string(frame.Data), Stream: protoStreamToDomain(stream)})
 		}
-		resp.Frame = &agentcomposev2.ExecAttachResponse_Output{Output: &agentcomposev2.AttachOutput{
+		resp.Frame = &agentcomposev2.AttachExecResponse_Output{Output: &agentcomposev2.AttachOutput{
 			Data:   append([]byte(nil), frame.Data...),
 			Stream: stream,
 			Tty:    s.tty,
@@ -472,7 +472,7 @@ func (s *execAttachState) responseFromRuntimeFrame(frame driverpkg.RuntimeOutput
 			accumulated.Success = false
 		}
 		execResult := ExecResultToProto(s.execID, s.sandbox.Summary.ID, s.runID, s.request, s.cwd, accumulated, errorFromString(result.Error))
-		resp.Frame = &agentcomposev2.ExecAttachResponse_Result{Result: &agentcomposev2.AttachResult{
+		resp.Frame = &agentcomposev2.AttachExecResponse_Result{Result: &agentcomposev2.AttachResult{
 			ExitCode:   int32(result.ExitCode),
 			Success:    result.Success,
 			ExecResult: execResult,
@@ -486,15 +486,15 @@ func (s *execAttachState) responseFromRuntimeFrame(frame driverpkg.RuntimeOutput
 			code = firstNonEmpty(frame.Error.Code, code)
 			message = firstNonEmpty(frame.Error.Message, message)
 		}
-		resp.Frame = &agentcomposev2.ExecAttachResponse_Error{Error: &agentcomposev2.AttachError{Code: code, Message: message, Terminal: true}}
+		resp.Frame = &agentcomposev2.AttachExecResponse_Error{Error: &agentcomposev2.AttachError{Code: code, Message: message, Terminal: true}}
 	default:
 		return nil
 	}
 	return resp
 }
 
-func newExecAttachResponse() *agentcomposev2.ExecAttachResponse {
-	return &agentcomposev2.ExecAttachResponse{
+func newAttachExecResponse() *agentcomposev2.AttachExecResponse {
+	return &agentcomposev2.AttachExecResponse{
 		ServerFrameId: uuid.NewString(),
 		CreatedAt:     timestamppb.Now(),
 	}
@@ -515,8 +515,8 @@ func protoStreamToDomain(stream agentcomposev2.StdioStream) domain.StdioStream {
 }
 
 func sendExecAttachError(send execAttachSender, code, message string, terminal bool) error {
-	resp := newExecAttachResponse()
-	resp.Frame = &agentcomposev2.ExecAttachResponse_Error{Error: &agentcomposev2.AttachError{
+	resp := newAttachExecResponse()
+	resp.Frame = &agentcomposev2.AttachExecResponse_Error{Error: &agentcomposev2.AttachError{
 		Code:     code,
 		Message:  message,
 		Terminal: terminal,
@@ -553,8 +553,8 @@ func (h *ExecHandler) executeProjectCommand(ctx context.Context, req *agentcompo
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exec command is required"))
 	}
 	if send != nil {
-		if err := send(&agentcomposev2.ExecStreamResponse{
-			EventType: agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_STARTED,
+		if err := send(&agentcomposev2.StreamExecResponse{
+			EventType: agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_STARTED,
 			ExecId:    execID,
 			SandboxId: sandbox.Summary.ID,
 			RunId:     runID,
@@ -611,8 +611,8 @@ func (h *ExecHandler) executeProjectCommand(ctx context.Context, req *agentcompo
 		}
 		if send != nil {
 			createdAt := time.Now().UTC()
-			sendErr = send(&agentcomposev2.ExecStreamResponse{
-				EventType:  agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_OUTPUT,
+			sendErr = send(&agentcomposev2.StreamExecResponse{
+				EventType:  agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT,
 				ExecId:     execID,
 				SandboxId:  sandbox.Summary.ID,
 				RunId:      runID,

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -404,14 +404,14 @@ func TestExecHandlerRunSelectorAndStreamSenderWorkflow(t *testing.T) {
 		return runtime, nil
 	})
 
-	var events []*agentcomposev2.ExecStreamResponse
+	var events []*agentcomposev2.StreamExecResponse
 	resp, err := handler.executeProjectCommand(ctx, &agentcomposev2.ExecRequest{
 		Target:    &agentcomposev2.ExecRequest_RunId{RunId: "run-1"},
 		Command:   &agentcomposev2.ExecCommand{Command: "echo", Args: []string{"hi"}},
 		Cwd:       "/custom",
 		Env:       []*agentcomposev2.EnvVarSpec{{Name: "A", Value: "B"}},
 		TimeoutMs: 1000,
-	}, "exec-run", func(event *agentcomposev2.ExecStreamResponse) error {
+	}, "exec-run", func(event *agentcomposev2.StreamExecResponse) error {
 		events = append(events, event)
 		return nil
 	})
@@ -421,8 +421,8 @@ func TestExecHandlerRunSelectorAndStreamSenderWorkflow(t *testing.T) {
 	if resp.GetRunId() != "run-1" || resp.GetSandboxId() != "sandbox-running" || resp.GetCwd() != "/custom" || len(events) < 2 {
 		t.Fatalf("run target resp=%#v events=%#v", resp, events)
 	}
-	if events[0].GetEventType() != agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_STARTED ||
-		events[1].GetEventType() != agentcomposev2.ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_OUTPUT ||
+	if events[0].GetEventType() != agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_STARTED ||
+		events[1].GetEventType() != agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT ||
 		events[1].GetTranscript().GetText() == "" {
 		t.Fatalf("stream events = %#v", events)
 	}
@@ -504,7 +504,7 @@ func TestExecHandlerSelectorErrors(t *testing.T) {
 
 func TestExecAttachRequiresStartFrame(t *testing.T) {
 	handler := newExecAttachTestHandler(t, &apiExecRuntime{})
-	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(), func(*agentcomposev2.ExecAttachResponse) error {
+	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(), func(*agentcomposev2.AttachExecResponse) error {
 		t.Fatal("unexpected send")
 		return nil
 	})
@@ -512,9 +512,9 @@ func TestExecAttachRequiresStartFrame(t *testing.T) {
 		t.Fatalf("empty stream error = %v", err)
 	}
 
-	err = handler.execAttach(context.Background(), sliceExecAttachReceiver(&agentcomposev2.ExecAttachRequest{
-		Frame: &agentcomposev2.ExecAttachRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: []byte("x")}},
-	}), func(*agentcomposev2.ExecAttachResponse) error {
+	err = handler.execAttach(context.Background(), sliceExecAttachReceiver(&agentcomposev2.AttachExecRequest{
+		Frame: &agentcomposev2.AttachExecRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: []byte("x")}},
+	}), func(*agentcomposev2.AttachExecResponse) error {
 		t.Fatal("unexpected send")
 		return nil
 	})
@@ -525,8 +525,8 @@ func TestExecAttachRequiresStartFrame(t *testing.T) {
 
 func TestExecAttachRuntimeUnsupportedIsUnimplemented(t *testing.T) {
 	handler := newExecAttachTestHandler(t, &apiExecRuntime{})
-	var sent []*agentcomposev2.ExecAttachResponse
-	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(execAttachStartRequest()), func(resp *agentcomposev2.ExecAttachResponse) error {
+	var sent []*agentcomposev2.AttachExecResponse
+	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(execAttachStartRequest()), func(resp *agentcomposev2.AttachExecResponse) error {
 		sent = append(sent, resp)
 		return nil
 	})
@@ -546,8 +546,8 @@ func TestExecAttachProjectsStdoutAndResult(t *testing.T) {
 		{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{ExitCode: 7, Success: false, Error: "boom"}},
 	}}}
 	handler := newExecAttachTestHandler(t, runtime)
-	var sent []*agentcomposev2.ExecAttachResponse
-	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(execAttachStartRequest()), func(resp *agentcomposev2.ExecAttachResponse) error {
+	var sent []*agentcomposev2.AttachExecResponse
+	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(execAttachStartRequest()), func(resp *agentcomposev2.AttachExecResponse) error {
 		sent = append(sent, resp)
 		return nil
 	})
@@ -590,8 +590,8 @@ func TestExecAttachRunnerProjectsInteractionFramesWithoutRPC(t *testing.T) {
 		{Type: driverpkg.RuntimeOutputStderr, Data: []byte("beta\n")},
 		{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{ExitCode: 0, Success: true}},
 	}}
-	var sent []*agentcomposev2.ExecAttachResponse
-	runner.send = func(resp *agentcomposev2.ExecAttachResponse) error {
+	var sent []*agentcomposev2.AttachExecResponse
+	runner.send = func(resp *agentcomposev2.AttachExecResponse) error {
 		sent = append(sent, resp)
 		return nil
 	}
@@ -629,15 +629,15 @@ func TestExecAttachPromptDelegatesToRunAttach(t *testing.T) {
 	handler := NewExecHandler(&appconfig.Config{}, store, projects, func(*domain.Sandbox) (ExecRuntime, error) {
 		return &apiExecRuntime{}, nil
 	}, delegate)
-	var sent []*agentcomposev2.ExecAttachResponse
+	var sent []*agentcomposev2.AttachExecResponse
 	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(
-		&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Start{Start: &agentcomposev2.ExecAttachStart{
+		&agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_Start{Start: &agentcomposev2.AttachExecStart{
 			Request: &agentcomposev2.ExecRequest{Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "session-attach"}},
 			Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
 			Prompt:  "hi",
 		}}},
-		&agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: "next"}}},
-	), func(resp *agentcomposev2.ExecAttachResponse) error {
+		&agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_HumanMessage{HumanMessage: &agentcomposev2.AttachHumanMessage{Text: "next"}}},
+	), func(resp *agentcomposev2.AttachExecResponse) error {
 		sent = append(sent, resp)
 		return nil
 	})
@@ -658,32 +658,32 @@ func TestExecAttachPromptDelegatesToRunAttach(t *testing.T) {
 func TestExecAttachInputFrameMapping(t *testing.T) {
 	cases := []struct {
 		name string
-		req  *agentcomposev2.ExecAttachRequest
+		req  *agentcomposev2.AttachExecRequest
 		want driverpkg.RuntimeInputFrame
 	}{
 		{
 			name: "stdin",
-			req:  &agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: []byte("hi")}}},
+			req:  &agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: []byte("hi")}}},
 			want: driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: []byte("hi")},
 		},
 		{
 			name: "stdin eof",
-			req:  &agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}},
+			req:  &agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}},
 			want: driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdinEOF},
 		},
 		{
 			name: "resize",
-			req:  &agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Resize{Resize: &agentcomposev2.AttachResize{TerminalSize: &agentcomposev2.AttachTerminalSize{Rows: 24, Cols: 80}}}},
+			req:  &agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_Resize{Resize: &agentcomposev2.AttachResize{TerminalSize: &agentcomposev2.AttachTerminalSize{Rows: 24, Cols: 80}}}},
 			want: driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputResize, Rows: 24, Cols: 80},
 		},
 		{
 			name: "signal",
-			req:  &agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Signal{Signal: &agentcomposev2.AttachSignal{Signal: " interrupt "}}},
+			req:  &agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_Signal{Signal: &agentcomposev2.AttachSignal{Signal: " interrupt "}}},
 			want: driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputSignal, Signal: driverpkg.RuntimeSignalInterrupt},
 		},
 		{
 			name: "cancel",
-			req:  &agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Cancel{Cancel: &agentcomposev2.AttachCancel{Reason: "stop"}}},
+			req:  &agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_Cancel{Cancel: &agentcomposev2.AttachCancel{Reason: "stop"}}},
 			want: driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputCancel, Message: "stop"},
 		},
 	}
@@ -1125,8 +1125,8 @@ func newExecAttachTestHandler(t *testing.T, runtime ExecRuntime) *ExecHandler {
 	})
 }
 
-func execAttachStartRequest() *agentcomposev2.ExecAttachRequest {
-	return &agentcomposev2.ExecAttachRequest{Frame: &agentcomposev2.ExecAttachRequest_Start{Start: &agentcomposev2.ExecAttachStart{
+func execAttachStartRequest() *agentcomposev2.AttachExecRequest {
+	return &agentcomposev2.AttachExecRequest{Frame: &agentcomposev2.AttachExecRequest_Start{Start: &agentcomposev2.AttachExecStart{
 		Request: &agentcomposev2.ExecRequest{
 			Target:    &agentcomposev2.ExecRequest_SandboxId{SandboxId: "session-attach"},
 			Command:   &agentcomposev2.ExecCommand{Command: "printf", Args: []string{"hi"}},
@@ -1151,9 +1151,9 @@ func execAttachProjectionTestState() *execAttachState {
 	}
 }
 
-func sliceExecAttachReceiver(items ...*agentcomposev2.ExecAttachRequest) execAttachReceiver {
+func sliceExecAttachReceiver(items ...*agentcomposev2.AttachExecRequest) execAttachReceiver {
 	index := 0
-	return func() (*agentcomposev2.ExecAttachRequest, error) {
+	return func() (*agentcomposev2.AttachExecRequest, error) {
 		if index >= len(items) {
 			return nil, io.EOF
 		}
@@ -1164,7 +1164,7 @@ func sliceExecAttachReceiver(items ...*agentcomposev2.ExecAttachRequest) execAtt
 }
 
 type apiExecPromptRunAttachDelegate struct {
-	start *agentcomposev2.RunAttachStart
+	start *agentcomposev2.AttachAgentRunStart
 	human *agentcomposev2.AttachHumanMessage
 }
 
@@ -1179,10 +1179,10 @@ func (d *apiExecPromptRunAttachDelegate) RunProjectCommandAttach(_ context.Conte
 		return err
 	}
 	d.human = second.GetHumanMessage()
-	if err := send(&agentcomposev2.RunAttachResponse{Frame: &agentcomposev2.RunAttachResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "agent says hi"}}}); err != nil {
+	if err := send(&agentcomposev2.AttachAgentRunResponse{Frame: &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "agent says hi"}}}); err != nil {
 		return err
 	}
-	return send(&agentcomposev2.RunAttachResponse{Frame: &agentcomposev2.RunAttachResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}}})
+	return send(&agentcomposev2.AttachAgentRunResponse{Frame: &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}}})
 }
 
 type apiExecRuntime struct {

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -22,9 +22,9 @@ import (
 
 type RunAgentDelegate interface {
 	RunAgent(context.Context, *connect.Request[agentcomposev2.RunAgentRequest]) (*connect.Response[agentcomposev2.RunAgentResponse], error)
-	StartRun(context.Context, *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error)
-	RunAgentStream(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error
-	RunAttach(context.Context, *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error
+	StartAgentRun(context.Context, *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error)
+	StreamAgentRun(context.Context, *connect.Request[agentcomposev2.RunAgentRequest], *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error
+	AttachAgentRun(context.Context, *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error
 }
 
 type ActiveRunStopper interface {
@@ -78,23 +78,23 @@ func (h *RunHandler) RunAgent(ctx context.Context, req *connect.Request[agentcom
 	return h.delegate.RunAgent(ctx, req)
 }
 
-func (h *RunHandler) StartRun(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+func (h *RunHandler) StartAgentRun(ctx context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 	if h.delegate == nil {
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("start run is not configured"))
 	}
-	return h.delegate.StartRun(ctx, req)
+	return h.delegate.StartAgentRun(ctx, req)
 }
 
-func (h *RunHandler) RunAgentStream(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+func (h *RunHandler) StreamAgentRun(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 	PrepareStreamingHeaders(stream.ResponseHeader())
-	return h.delegate.RunAgentStream(ctx, req, stream)
+	return h.delegate.StreamAgentRun(ctx, req, stream)
 }
 
-func (h *RunHandler) RunAttach(ctx context.Context, stream *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error {
+func (h *RunHandler) AttachAgentRun(ctx context.Context, stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
 	if h.delegate == nil {
 		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("run attach is not configured"))
 	}
-	if err := h.delegate.RunAttach(ctx, stream); err != nil {
+	if err := h.delegate.AttachAgentRun(ctx, stream); err != nil {
 		var connectErr *connect.Error
 		if errors.As(err, &connectErr) {
 			return connectErr

--- a/pkg/agentcompose/api/runtime_driver_compiled_boundary_test.go
+++ b/pkg/agentcompose/api/runtime_driver_compiled_boundary_test.go
@@ -60,7 +60,7 @@ func TestRuntimeDriverNotCompiledConnectBoundaries(t *testing.T) {
 		if connect.CodeOf(err) != connect.CodeUnimplemented || !errors.Is(err, driverpkg.ErrRuntimeDriverNotCompiled) {
 			t.Fatalf("Exec error = %v, code=%v; want unimplemented typed error", err, connect.CodeOf(err))
 		}
-		_, err = handler.prepareExecAttach(context.Background(), &agentcomposev2.ExecAttachStart{Request: req})
+		_, err = handler.prepareExecAttach(context.Background(), &agentcomposev2.AttachExecStart{Request: req})
 		if connect.CodeOf(err) != connect.CodeUnimplemented || !errors.Is(err, driverpkg.ErrRuntimeDriverNotCompiled) {
 			t.Fatalf("prepareExecAttach error = %v, code=%v; want unimplemented typed error", err, connect.CodeOf(err))
 		}

--- a/pkg/agentcompose/app/controller_helpers_coverage_test.go
+++ b/pkg/agentcompose/app/controller_helpers_coverage_test.go
@@ -137,7 +137,7 @@ func TestAppRunControllerHelperCoverage(t *testing.T) {
 	if req.ProjectID != "project-1" || req.Source != domain.ProjectRunSourceAPI || req.Jupyter == nil || len(req.Env) != 1 {
 		t.Fatalf("runAgentRequestFromProto = %#v", req)
 	}
-	if _, err := (runControllerDelegate{}).StartRun(context.Background(), connect.NewRequest(&agentcomposev2.StartRunRequest{Run: msg})); connect.CodeOf(err) != connect.CodeInternal {
+	if _, err := (runControllerDelegate{}).StartAgentRun(context.Background(), connect.NewRequest(&agentcomposev2.StartAgentRunRequest{Run: msg})); connect.CodeOf(err) != connect.CodeInternal {
 		t.Fatalf("StartRun nil supervisor err=%v", err)
 	}
 	for _, tc := range []struct {

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -76,7 +76,7 @@ func (d runControllerDelegate) RunAgent(ctx context.Context, req *connect.Reques
 	}), nil
 }
 
-func (d runControllerDelegate) StartRun(ctx context.Context, req *connect.Request[agentcomposev2.StartRunRequest]) (*connect.Response[agentcomposev2.StartRunResponse], error) {
+func (d runControllerDelegate) StartAgentRun(ctx context.Context, req *connect.Request[agentcomposev2.StartAgentRunRequest]) (*connect.Response[agentcomposev2.StartAgentRunResponse], error) {
 	if d.supervisor == nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("run supervisor is required"))
 	}
@@ -84,14 +84,14 @@ func (d runControllerDelegate) StartRun(ctx context.Context, req *connect.Reques
 	if err != nil {
 		return nil, runConnectError(err)
 	}
-	return connect.NewResponse(&agentcomposev2.StartRunResponse{
+	return connect.NewResponse(&agentcomposev2.StartAgentRunResponse{
 		Run:      api.ProjectRunSummaryToProto(run),
 		Warnings: append([]string(nil), run.Warnings...),
 		Started:  !runs.StatusIsTerminal(run.Status),
 	}), nil
 }
 
-func (d runControllerDelegate) RunAgentStream(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse]) error {
+func (d runControllerDelegate) StreamAgentRun(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
 	runs.PrepareStreamingHeaders(stream.ResponseHeader())
 	sink := runs.StreamSink{
 		SendStarted: func(run domain.ProjectRunRecord, createdAt time.Time) error {
@@ -114,23 +114,23 @@ func (d runControllerDelegate) RunAgentStream(ctx context.Context, req *connect.
 	return nil
 }
 
-func sendRunAgentStreamStarted(stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse], run domain.ProjectRunRecord, createdAt time.Time) error {
+func sendRunAgentStreamStarted(stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse], run domain.ProjectRunRecord, createdAt time.Time) error {
 	if err := stream.Send(runAgentStreamStartedProjection(run, createdAt)); err != nil {
 		return fmt.Errorf("%w: %w", runs.ErrRunAgentStreamSend, err)
 	}
 	return nil
 }
 
-func sendRunAgentStreamChunk(stream *connect.ServerStream[agentcomposev2.RunAgentStreamResponse], runID string, chunk domain.ExecChunk, createdAt time.Time) error {
+func sendRunAgentStreamChunk(stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse], runID string, chunk domain.ExecChunk, createdAt time.Time) error {
 	if err := stream.Send(runAgentStreamChunkProjection(runID, chunk, createdAt)); err != nil {
 		return fmt.Errorf("%w: %w", runs.ErrRunAgentStreamSend, err)
 	}
 	return nil
 }
 
-func runAgentStreamStartedProjection(run domain.ProjectRunRecord, createdAt time.Time) *agentcomposev2.RunAgentStreamResponse {
-	return &agentcomposev2.RunAgentStreamResponse{
-		EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_STARTED,
+func runAgentStreamStartedProjection(run domain.ProjectRunRecord, createdAt time.Time) *agentcomposev2.StreamAgentRunResponse {
+	return &agentcomposev2.StreamAgentRunResponse{
+		EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_STARTED,
 		Run:       api.ProjectRunSummaryToProto(run),
 		RunId:     run.RunID,
 		CreatedAt: api.FormatProjectTime(createdAt),
@@ -138,9 +138,9 @@ func runAgentStreamStartedProjection(run domain.ProjectRunRecord, createdAt time
 	}
 }
 
-func runAgentStreamChunkProjection(runID string, chunk domain.ExecChunk, createdAt time.Time) *agentcomposev2.RunAgentStreamResponse {
-	return &agentcomposev2.RunAgentStreamResponse{
-		EventType:  agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT,
+func runAgentStreamChunkProjection(runID string, chunk domain.ExecChunk, createdAt time.Time) *agentcomposev2.StreamAgentRunResponse {
+	return &agentcomposev2.StreamAgentRunResponse{
+		EventType:  agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT,
 		RunId:      runID,
 		Chunk:      chunk.Text,
 		Stream:     api.StdioStreamToProto(chunk.Stream),
@@ -149,9 +149,9 @@ func runAgentStreamChunkProjection(runID string, chunk domain.ExecChunk, created
 	}
 }
 
-func runAgentStreamCompletedProjection(run domain.ProjectRunRecord, createdAt time.Time) *agentcomposev2.RunAgentStreamResponse {
-	return &agentcomposev2.RunAgentStreamResponse{
-		EventType: agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED,
+func runAgentStreamCompletedProjection(run domain.ProjectRunRecord, createdAt time.Time) *agentcomposev2.StreamAgentRunResponse {
+	return &agentcomposev2.StreamAgentRunResponse{
+		EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED,
 		Run:       api.ProjectRunSummaryToProto(run),
 		RunId:     run.RunID,
 		CreatedAt: api.FormatProjectTime(createdAt),
@@ -159,7 +159,7 @@ func runAgentStreamCompletedProjection(run domain.ProjectRunRecord, createdAt ti
 	}
 }
 
-func (d runControllerDelegate) RunAttach(ctx context.Context, stream *connect.BidiStream[agentcomposev2.RunAttachRequest, agentcomposev2.RunAttachResponse]) error {
+func (d runControllerDelegate) AttachAgentRun(ctx context.Context, stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
 	if d.controller == nil {
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("run controller is required"))
 	}

--- a/pkg/agentcompose/app/run_controller_projection_test.go
+++ b/pkg/agentcompose/app/run_controller_projection_test.go
@@ -28,7 +28,7 @@ func TestRunAgentStreamStartedProjectionPreservesResponseFields(t *testing.T) {
 	resp := runAgentStreamStartedProjection(run, createdAt)
 	run.Warnings[0] = "mutated"
 
-	if resp.GetEventType() != agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_STARTED {
+	if resp.GetEventType() != agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_STARTED {
 		t.Fatalf("event type = %s", resp.GetEventType())
 	}
 	if resp.GetRunId() != "run-1" || !resp.GetCreatedAt().AsTime().Equal(createdAt) {
@@ -53,7 +53,7 @@ func TestRunAgentStreamChunkProjectionPreservesOutputFields(t *testing.T) {
 		Stream: domain.StdioStderr,
 	}, createdAt)
 
-	if resp.GetEventType() != agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT {
+	if resp.GetEventType() != agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT {
 		t.Fatalf("event type = %s", resp.GetEventType())
 	}
 	if resp.GetRunId() != "run-1" || resp.GetChunk() != "stderr text\n" || !resp.GetCreatedAt().AsTime().Equal(createdAt) {
@@ -80,7 +80,7 @@ func TestRunAgentStreamCompletedProjectionPreservesResponseFields(t *testing.T) 
 	resp := runAgentStreamCompletedProjection(run, createdAt)
 	run.Warnings[0] = "mutated"
 
-	if resp.GetEventType() != agentcomposev2.RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED {
+	if resp.GetEventType() != agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED {
 		t.Fatalf("event type = %s", resp.GetEventType())
 	}
 	if resp.GetRunId() != "run-1" || !resp.GetCreatedAt().AsTime().Equal(createdAt) {

--- a/pkg/runs/attach_input_test.go
+++ b/pkg/runs/attach_input_test.go
@@ -18,7 +18,7 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 
 	t.Run("command", func(t *testing.T) {
 		interaction := &closingRuntimeInteraction{}
-		pumpRunAttachInput(func() (*agentcomposev2.RunAttachRequest, error) {
+		pumpRunAttachInput(func() (*agentcomposev2.AttachAgentRunRequest, error) {
 			return nil, receiveErr
 		}, interaction)
 		if interaction.closeCalls != 1 {
@@ -29,7 +29,7 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 	t.Run("prompt", func(t *testing.T) {
 		interaction := &closingRuntimeInteraction{}
 		input := &promptWrapperInput{interaction: interaction}
-		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.RunAttachRequest, error) {
+		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.AttachAgentRunRequest, error) {
 			return nil, receiveErr
 		}, input, nil, nil)
 		if interaction.closeCalls != 1 {
@@ -42,7 +42,7 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 }
 
 func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t *testing.T) {
-	requests := make(chan *agentcomposev2.RunAttachRequest, 2)
+	requests := make(chan *agentcomposev2.AttachAgentRunRequest, 2)
 	received := make(chan struct{}, 2)
 	interaction := newObservedRuntimeInteraction()
 	input := &promptWrapperInput{interaction: interaction}
@@ -51,7 +51,7 @@ func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t 
 
 	go func() {
 		defer close(done)
-		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.RunAttachRequest, error) {
+		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.AttachAgentRunRequest, error) {
 			req, ok := <-requests
 			if !ok {
 				return nil, io.EOF
@@ -88,7 +88,7 @@ func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t 
 
 func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	requests := make(chan *agentcomposev2.RunAttachRequest, 1)
+	requests := make(chan *agentcomposev2.AttachAgentRunRequest, 1)
 	received := make(chan struct{}, 1)
 	interaction := newObservedRuntimeInteraction()
 	input := &promptWrapperInput{interaction: interaction}
@@ -96,7 +96,7 @@ func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
 
 	go func() {
 		defer close(done)
-		pumpRunPromptAttachInput(ctx, func() (*agentcomposev2.RunAttachRequest, error) {
+		pumpRunPromptAttachInput(ctx, func() (*agentcomposev2.AttachAgentRunRequest, error) {
 			req := <-requests
 			received <- struct{}{}
 			return req, nil
@@ -117,8 +117,8 @@ func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
 	}
 }
 
-func humanMessageAttachRequest(message string) *agentcomposev2.RunAttachRequest {
-	return &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_HumanMessage{
+func humanMessageAttachRequest(message string) *agentcomposev2.AttachAgentRunRequest {
+	return &agentcomposev2.AttachAgentRunRequest{Frame: &agentcomposev2.AttachAgentRunRequest_HumanMessage{
 		HumanMessage: &agentcomposev2.AttachHumanMessage{Text: message},
 	}}
 }

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -218,8 +218,8 @@ type StreamSink struct {
 	SendChunk   func(runID string, chunk domain.ExecChunk, createdAt time.Time) error
 }
 
-type RunAttachReceiver func() (*agentcomposev2.RunAttachRequest, error)
-type RunAttachSender func(*agentcomposev2.RunAttachResponse) error
+type RunAttachReceiver func() (*agentcomposev2.AttachAgentRunRequest, error)
+type RunAttachSender func(*agentcomposev2.AttachAgentRunResponse) error
 
 func PrepareStreamingHeaders(headers http.Header) {
 	if headers == nil {
@@ -594,7 +594,7 @@ func (c *Controller) executeProjectRunCommand(ctx context.Context, run domain.Pr
 	return transition, nil
 }
 
-func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run domain.ProjectRunRecord, req RunAgentRequest, warnings []string, start *agentcomposev2.RunAttachStart, mode agentcomposev2.AttachRunMode, receive RunAttachReceiver, send RunAttachSender) (domain.ProjectRunRecord, error, error) {
+func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run domain.ProjectRunRecord, req RunAgentRequest, warnings []string, start *agentcomposev2.AttachAgentRunStart, mode agentcomposev2.AttachRunMode, receive RunAttachReceiver, send RunAttachSender) (domain.ProjectRunRecord, error, error) {
 	coordinator := NewCoordinator(c.configDB, domain.StableProjectRunID)
 	commandText := strings.TrimSpace(req.Command)
 	transitionCtx := context.WithoutCancel(ctx)
@@ -657,7 +657,7 @@ func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run dom
 	return run, nil, nil
 }
 
-func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, commandText string, start *agentcomposev2.RunAttachStart, receive RunAttachReceiver, send RunAttachSender) (TransitionRequest, error) {
+func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, commandText string, start *agentcomposev2.AttachAgentRunStart, receive RunAttachReceiver, send RunAttachSender) (TransitionRequest, error) {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	logsPath := filepath.Join(artifactsDir, "transcript.txt")
 	transition := TransitionRequest{RunID: run.RunID, SandboxID: sandbox.Summary.ID, LogsPath: logsPath}
@@ -800,7 +800,7 @@ func markProjectRunInteractionArtifacts(ctx context.Context, coordinator *Coordi
 	})
 }
 
-func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, start *agentcomposev2.RunAttachStart, receive RunAttachReceiver, send RunAttachSender) (transitionResult TransitionRequest, returnErr error) {
+func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, start *agentcomposev2.AttachAgentRunStart, receive RunAttachReceiver, send RunAttachSender) (transitionResult TransitionRequest, returnErr error) {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	logsPath := filepath.Join(artifactsDir, "transcript.txt")
 	transition := TransitionRequest{RunID: run.RunID, SandboxID: sandbox.Summary.ID, LogsPath: logsPath}
@@ -1170,7 +1170,7 @@ func transitionFromCommandResult(run domain.ProjectRunRecord, sandbox *domain.Sa
 	return req
 }
 
-func runAgentRequestFromAttachStart(start *agentcomposev2.RunAttachStart) RunAgentRequest {
+func runAgentRequestFromAttachStart(start *agentcomposev2.AttachAgentRunStart) RunAgentRequest {
 	msg := start.GetRequest()
 	if msg == nil {
 		return RunAgentRequest{}
@@ -1281,18 +1281,18 @@ func pumpRunAttachInput(receive RunAttachReceiver, interaction driverpkg.Runtime
 	}
 }
 
-func runtimeInputFrameFromRunAttach(req *agentcomposev2.RunAttachRequest) (driverpkg.RuntimeInputFrame, bool) {
+func runtimeInputFrameFromRunAttach(req *agentcomposev2.AttachAgentRunRequest) (driverpkg.RuntimeInputFrame, bool) {
 	switch frame := req.GetFrame().(type) {
-	case *agentcomposev2.RunAttachRequest_Stdin:
+	case *agentcomposev2.AttachAgentRunRequest_Stdin:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: frame.Stdin.GetData()}, true
-	case *agentcomposev2.RunAttachRequest_StdinEof:
+	case *agentcomposev2.AttachAgentRunRequest_StdinEof:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdinEOF}, true
-	case *agentcomposev2.RunAttachRequest_Resize:
+	case *agentcomposev2.AttachAgentRunRequest_Resize:
 		size := frame.Resize.GetTerminalSize()
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputResize, Rows: size.GetRows(), Cols: size.GetCols()}, true
-	case *agentcomposev2.RunAttachRequest_Signal:
+	case *agentcomposev2.AttachAgentRunRequest_Signal:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputSignal, Signal: driverpkg.RuntimeSignal(strings.TrimSpace(frame.Signal.GetSignal()))}, true
-	case *agentcomposev2.RunAttachRequest_Cancel:
+	case *agentcomposev2.AttachAgentRunRequest_Cancel:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputCancel, Message: frame.Cancel.GetReason()}, true
 	default:
 		return driverpkg.RuntimeInputFrame{}, false
@@ -1364,20 +1364,20 @@ func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, in
 			return
 		}
 		switch frame := req.GetFrame().(type) {
-		case *agentcomposev2.RunAttachRequest_HumanMessage:
+		case *agentcomposev2.AttachAgentRunRequest_HumanMessage:
 			text := frame.HumanMessage.GetText()
 			if !forwardPromptHumanMessage(ctx, input, turnReady, text, req.GetClientFrameId(), onHumanMessage) {
 				return
 			}
-		case *agentcomposev2.RunAttachRequest_Stdin:
+		case *agentcomposev2.AttachAgentRunRequest_Stdin:
 			text := string(frame.Stdin.GetData())
 			if !forwardPromptHumanMessage(ctx, input, turnReady, text, req.GetClientFrameId(), onHumanMessage) {
 				return
 			}
-		case *agentcomposev2.RunAttachRequest_StdinEof:
+		case *agentcomposev2.AttachAgentRunRequest_StdinEof:
 			_ = input.EOF()
 			return
-		case *agentcomposev2.RunAttachRequest_Cancel:
+		case *agentcomposev2.AttachAgentRunRequest_Cancel:
 			_ = input.Cancel(frame.Cancel.GetReason())
 			return
 		default:
@@ -1445,7 +1445,7 @@ func newPromptAttachProjector(run domain.ProjectRunRecord, sandbox *domain.Sandb
 	}
 }
 
-func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.RunAttachResponse, *TransitionRequest, error) {
+func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.AttachAgentRunResponse, *TransitionRequest, error) {
 	p.buffer = append(p.buffer, data...)
 	lines := make([][]byte, 0)
 	for {
@@ -1459,7 +1459,7 @@ func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.RunAttac
 			lines = append(lines, line)
 		}
 	}
-	var responses []*agentcomposev2.RunAttachResponse
+	var responses []*agentcomposev2.AttachAgentRunResponse
 	var transition *TransitionRequest
 	for _, line := range lines {
 		nextResponses, nextTransition, err := p.projectLine(line)
@@ -1474,7 +1474,7 @@ func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.RunAttac
 	return responses, transition, nil
 }
 
-func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunAttachResponse, *TransitionRequest, error) {
+func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.AttachAgentRunResponse, *TransitionRequest, error) {
 	var frame struct {
 		Type            string                      `json:"type"`
 		Event           json.RawMessage             `json:"event"`
@@ -1492,13 +1492,13 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunA
 	}
 	switch frame.Type {
 	case "started":
-		return []*agentcomposev2.RunAttachResponse{runAttachAgentEventResponse("started", "", string(line))}, nil, nil
+		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentEventResponse("started", "", string(line))}, nil, nil
 	case "agent_event":
 		name, text := p.agentEventText(frame.Event)
 		if err := p.appendLogText(text); err != nil {
 			return nil, nil, err
 		}
-		return []*agentcomposev2.RunAttachResponse{runAttachAgentEventResponse(firstNonEmpty(name, "agent_event"), text, string(frame.Event))}, nil, nil
+		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentEventResponse(firstNonEmpty(name, "agent_event"), text, string(frame.Event))}, nil, nil
 	case "agent_turn_completed":
 		if err := p.appendLogFinalText(frame.FinalText); err != nil {
 			return nil, nil, err
@@ -1506,7 +1506,7 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunA
 		if err := p.appendAssistantEvent(line, frame.Seq, agentTurnProjection{FinalText: frame.FinalText, FinalTextSource: frame.FinalTextSource, Provider: frame.Provider, StopReason: frame.StopReason}); err != nil {
 			return nil, nil, err
 		}
-		return []*agentcomposev2.RunAttachResponse{runAttachAgentTurnCompletedResponse(p.run, string(line), warningsFromRun(p.run))}, nil, nil
+		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentTurnCompletedResponse(p.run, string(line), warningsFromRun(p.run))}, nil, nil
 	case "result":
 		if err := p.appendLogFinalText(frame.FinalText); err != nil {
 			return nil, nil, err
@@ -1517,9 +1517,9 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.RunA
 	case "error":
 		message := firstNonEmpty(frame.Message, "runtime stream error")
 		transition := transitionFromPromptWrapperResult(p.run, p.sandbox, p.logsPath, line, "", frame.StopReason, message)
-		return []*agentcomposev2.RunAttachResponse{runAttachErrorResponse(firstNonEmpty(frame.Code, "runtime_stream_error"), message, true)}, &transition, nil
+		return []*agentcomposev2.AttachAgentRunResponse{runAttachErrorResponse(firstNonEmpty(frame.Code, "runtime_stream_error"), message, true)}, &transition, nil
 	default:
-		return []*agentcomposev2.RunAttachResponse{runAttachAgentEventResponse(firstNonEmpty(frame.Type, "agent_event"), "", string(line))}, nil, nil
+		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentEventResponse(firstNonEmpty(frame.Type, "agent_event"), "", string(line))}, nil, nil
 	}
 }
 
@@ -1727,12 +1727,12 @@ func bytesIndexByte(data []byte, needle byte) int {
 	return -1
 }
 
-func runAttachStartedResponse(run domain.ProjectRunRecord, sandbox *domain.Sandbox, warnings []string, startedAt time.Time) *agentcomposev2.RunAttachResponse {
-	resp := newRunAttachResponse()
+func runAttachStartedResponse(run domain.ProjectRunRecord, sandbox *domain.Sandbox, warnings []string, startedAt time.Time) *agentcomposev2.AttachAgentRunResponse {
+	resp := newAttachAgentRunResponse()
 	if !startedAt.IsZero() {
 		resp.CreatedAt = timestamppb.New(startedAt)
 	}
-	resp.Frame = &agentcomposev2.RunAttachResponse_Started{Started: &agentcomposev2.AttachStarted{
+	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Started{Started: &agentcomposev2.AttachStarted{
 		OperationId: run.RunID,
 		RunId:       run.RunID,
 		SandboxId:   sandbox.Summary.ID,
@@ -1742,9 +1742,9 @@ func runAttachStartedResponse(run domain.ProjectRunRecord, sandbox *domain.Sandb
 	return resp
 }
 
-func runAttachOutputResponse(data []byte, stream agentcomposev2.StdioStream, tty bool) *agentcomposev2.RunAttachResponse {
-	resp := newRunAttachResponse()
-	resp.Frame = &agentcomposev2.RunAttachResponse_Output{Output: &agentcomposev2.AttachOutput{
+func runAttachOutputResponse(data []byte, stream agentcomposev2.StdioStream, tty bool) *agentcomposev2.AttachAgentRunResponse {
+	resp := newAttachAgentRunResponse()
+	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Output{Output: &agentcomposev2.AttachOutput{
 		Data:   append([]byte(nil), data...),
 		Stream: stream,
 		Tty:    tty,
@@ -1757,9 +1757,9 @@ func runAttachOutputResponse(data []byte, stream agentcomposev2.StdioStream, tty
 	return resp
 }
 
-func runAttachAgentEventResponse(name, text, payloadJSON string) *agentcomposev2.RunAttachResponse {
-	resp := newRunAttachResponse()
-	resp.Frame = &agentcomposev2.RunAttachResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{
+func runAttachAgentEventResponse(name, text, payloadJSON string) *agentcomposev2.AttachAgentRunResponse {
+	resp := newAttachAgentRunResponse()
+	resp.Frame = &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{
 		Name:        name,
 		Text:        text,
 		PayloadJson: payloadJSON,
@@ -1768,9 +1768,9 @@ func runAttachAgentEventResponse(name, text, payloadJSON string) *agentcomposev2
 	return resp
 }
 
-func runAttachAgentTurnCompletedResponse(run domain.ProjectRunRecord, resultJSON string, warnings []string) *agentcomposev2.RunAttachResponse {
-	resp := newRunAttachResponse()
-	resp.Frame = &agentcomposev2.RunAttachResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{
+func runAttachAgentTurnCompletedResponse(run domain.ProjectRunRecord, resultJSON string, warnings []string) *agentcomposev2.AttachAgentRunResponse {
+	resp := newAttachAgentRunResponse()
+	resp.Frame = &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{
 		RunId:      run.RunID,
 		ResultJson: resultJSON,
 		Warnings:   append([]string(nil), warnings...),
@@ -1778,9 +1778,9 @@ func runAttachAgentTurnCompletedResponse(run domain.ProjectRunRecord, resultJSON
 	return resp
 }
 
-func runAttachResultResponse(run domain.ProjectRunRecord, transition TransitionRequest, success bool) *agentcomposev2.RunAttachResponse {
-	resp := newRunAttachResponse()
-	resp.Frame = &agentcomposev2.RunAttachResponse_Result{Result: &agentcomposev2.AttachResult{
+func runAttachResultResponse(run domain.ProjectRunRecord, transition TransitionRequest, success bool) *agentcomposev2.AttachAgentRunResponse {
+	resp := newAttachAgentRunResponse()
+	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{
 		ExitCode:   int32(transition.ExitCode),
 		Success:    success,
 		Run:        projectRunSummaryForAttach(run),
@@ -1791,9 +1791,9 @@ func runAttachResultResponse(run domain.ProjectRunRecord, transition TransitionR
 	return resp
 }
 
-func runAttachErrorResponse(code, message string, terminal bool) *agentcomposev2.RunAttachResponse {
-	resp := newRunAttachResponse()
-	resp.Frame = &agentcomposev2.RunAttachResponse_Error{Error: &agentcomposev2.AttachError{
+func runAttachErrorResponse(code, message string, terminal bool) *agentcomposev2.AttachAgentRunResponse {
+	resp := newAttachAgentRunResponse()
+	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Error{Error: &agentcomposev2.AttachError{
 		Code:     code,
 		Message:  message,
 		Terminal: terminal,
@@ -1801,8 +1801,8 @@ func runAttachErrorResponse(code, message string, terminal bool) *agentcomposev2
 	return resp
 }
 
-func newRunAttachResponse() *agentcomposev2.RunAttachResponse {
-	return &agentcomposev2.RunAttachResponse{
+func newAttachAgentRunResponse() *agentcomposev2.AttachAgentRunResponse {
+	return &agentcomposev2.AttachAgentRunResponse{
 		ServerFrameId: uuid.NewString(),
 		CreatedAt:     timestamppb.Now(),
 	}

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -798,8 +798,8 @@ func TestRunsControllerRunProjectCommandAttachProjectsOutputAndResult(t *testing
 		{Type: driverpkg.RuntimeOutputStderr, Data: []byte("warn\n")},
 		{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", ExitCode: 0, Success: true}},
 	})
-	requests := []*agentcomposev2.RunAttachRequest{{
-		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	requests := []*agentcomposev2.AttachAgentRunRequest{{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 			Request: &agentcomposev2.RunAgentRequest{
 				ProjectId:       "project-1",
 				AgentName:       "worker",
@@ -811,8 +811,8 @@ func TestRunsControllerRunProjectCommandAttachProjectsOutputAndResult(t *testing
 			AttachStdin: true,
 		}},
 	}}
-	var responses []*agentcomposev2.RunAttachResponse
-	err := controller.RunProjectCommandAttach(ctx, recvRunAttachRequests(requests), func(resp *agentcomposev2.RunAttachResponse) error {
+	var responses []*agentcomposev2.AttachAgentRunResponse
+	err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(resp *agentcomposev2.AttachAgentRunResponse) error {
 		if started := resp.GetStarted(); started != nil {
 			stored, err := configDB.GetProjectRun(ctx, started.GetRunId())
 			if err != nil {
@@ -856,9 +856,9 @@ func TestRunsControllerRunProjectCommandAttachProjectsOutputAndResult(t *testing
 
 func TestRunsControllerRunProjectCommandAttachValidatesStartFrame(t *testing.T) {
 	controller, _, _ := newTestRunAttachController(t, nil)
-	err := controller.RunProjectCommandAttach(context.Background(), recvRunAttachRequests([]*agentcomposev2.RunAttachRequest{{
-		Frame: &agentcomposev2.RunAttachRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: []byte("x")}},
-	}}), func(*agentcomposev2.RunAttachResponse) error { return nil })
+	err := controller.RunProjectCommandAttach(context.Background(), recvAttachAgentRunRequests([]*agentcomposev2.AttachAgentRunRequest{{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: []byte("x")}},
+	}}), func(*agentcomposev2.AttachAgentRunResponse) error { return nil })
 	if !errors.Is(err, ErrInvalidRequest) {
 		t.Fatalf("RunProjectCommandAttach first frame error = %v, want ErrInvalidRequest", err)
 	}
@@ -875,14 +875,14 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 		{Type: driverpkg.RuntimeOutputResult, Result: &driverpkg.RuntimeResult{OperationID: "run-attach", ExitCode: 0, Success: true}},
 	})
 	configDB.revision.SpecJSON = `{"agents":[{"name":"worker","provider":"claude"}]}`
-	requests := []*agentcomposev2.RunAttachRequest{{
-		Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	requests := []*agentcomposev2.AttachAgentRunRequest{{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 			Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "hello"},
 			Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
 		}},
 	}}
-	var responses []*agentcomposev2.RunAttachResponse
-	err := controller.RunProjectCommandAttach(ctx, recvRunAttachRequests(requests), func(resp *agentcomposev2.RunAttachResponse) error {
+	var responses []*agentcomposev2.AttachAgentRunResponse
+	err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(resp *agentcomposev2.AttachAgentRunResponse) error {
 		if started := resp.GetStarted(); started != nil {
 			stored, err := configDB.GetProjectRun(ctx, started.GetRunId())
 			if err != nil {
@@ -947,26 +947,26 @@ func TestRunsControllerRunProjectPromptAttachGatesQueuedTurnsAndOrdersTranscript
 	interaction := newScriptedRunAttachInteraction()
 	runtime.interactionOverride = interaction
 
-	requests := make(chan *agentcomposev2.RunAttachRequest, 4)
-	requests <- &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+	requests := make(chan *agentcomposev2.AttachAgentRunRequest, 4)
+	requests <- &agentcomposev2.AttachAgentRunRequest{Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 		Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "human-1"},
 		Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
 	}}}
 	requests <- humanMessageAttachRequest("human-2")
 	requests <- humanMessageAttachRequest("human-3")
-	requests <- &agentcomposev2.RunAttachRequest{Frame: &agentcomposev2.RunAttachRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}}
+	requests <- &agentcomposev2.AttachAgentRunRequest{Frame: &agentcomposev2.AttachAgentRunRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}}
 	close(requests)
 
-	var responses []*agentcomposev2.RunAttachResponse
+	var responses []*agentcomposev2.AttachAgentRunResponse
 	done := make(chan error, 1)
 	go func() {
-		done <- controller.RunProjectCommandAttach(ctx, func() (*agentcomposev2.RunAttachRequest, error) {
+		done <- controller.RunProjectCommandAttach(ctx, func() (*agentcomposev2.AttachAgentRunRequest, error) {
 			req, ok := <-requests
 			if !ok {
 				return nil, io.EOF
 			}
 			return req, nil
-		}, func(resp *agentcomposev2.RunAttachResponse) error {
+		}, func(resp *agentcomposev2.AttachAgentRunResponse) error {
 			responses = append(responses, resp)
 			return nil
 		})
@@ -1285,14 +1285,14 @@ func TestRunsControllerRunProjectPromptAttachUnsupportedProvidersDoNotOpenRuntim
 			ctx := context.Background()
 			controller, configDB, runtime := newTestRunAttachController(t, nil)
 			configDB.revision.SpecJSON = `{"agents":[{"name":"worker","provider":"` + provider + `"}]}`
-			requests := []*agentcomposev2.RunAttachRequest{{
-				Frame: &agentcomposev2.RunAttachRequest_Start{Start: &agentcomposev2.RunAttachStart{
+			requests := []*agentcomposev2.AttachAgentRunRequest{{
+				Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
 					Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "hello"},
 					Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
 				}},
 			}}
-			var responses []*agentcomposev2.RunAttachResponse
-			err := controller.RunProjectCommandAttach(ctx, recvRunAttachRequests(requests), func(resp *agentcomposev2.RunAttachResponse) error {
+			var responses []*agentcomposev2.AttachAgentRunResponse
+			err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(resp *agentcomposev2.AttachAgentRunResponse) error {
 				responses = append(responses, resp)
 				return nil
 			})
@@ -2900,9 +2900,9 @@ func (i *fakeRunAttachInteraction) Wait() (driverpkg.RuntimeResult, error) {
 	return driverpkg.RuntimeResult{Success: true}, nil
 }
 
-func recvRunAttachRequests(requests []*agentcomposev2.RunAttachRequest) RunAttachReceiver {
+func recvAttachAgentRunRequests(requests []*agentcomposev2.AttachAgentRunRequest) RunAttachReceiver {
 	index := 0
-	return func() (*agentcomposev2.RunAttachRequest, error) {
+	return func() (*agentcomposev2.AttachAgentRunRequest, error) {
 		if index >= len(requests) {
 			return nil, io.EOF
 		}

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -502,58 +502,58 @@ func (RunEventKind) EnumDescriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{8}
 }
 
-type RunAgentStreamEventType int32
+type StreamAgentRunEventType int32
 
 const (
-	RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_UNSPECIFIED RunAgentStreamEventType = 0
-	RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_STARTED     RunAgentStreamEventType = 1
-	RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT      RunAgentStreamEventType = 2
-	RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_STATUS      RunAgentStreamEventType = 3
-	RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED   RunAgentStreamEventType = 4
+	StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_UNSPECIFIED StreamAgentRunEventType = 0
+	StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_STARTED     StreamAgentRunEventType = 1
+	StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT      StreamAgentRunEventType = 2
+	StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_STATUS      StreamAgentRunEventType = 3
+	StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED   StreamAgentRunEventType = 4
 )
 
-// Enum value maps for RunAgentStreamEventType.
+// Enum value maps for StreamAgentRunEventType.
 var (
-	RunAgentStreamEventType_name = map[int32]string{
-		0: "RUN_AGENT_STREAM_EVENT_TYPE_UNSPECIFIED",
-		1: "RUN_AGENT_STREAM_EVENT_TYPE_STARTED",
-		2: "RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT",
-		3: "RUN_AGENT_STREAM_EVENT_TYPE_STATUS",
-		4: "RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED",
+	StreamAgentRunEventType_name = map[int32]string{
+		0: "STREAM_AGENT_RUN_EVENT_TYPE_UNSPECIFIED",
+		1: "STREAM_AGENT_RUN_EVENT_TYPE_STARTED",
+		2: "STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT",
+		3: "STREAM_AGENT_RUN_EVENT_TYPE_STATUS",
+		4: "STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED",
 	}
-	RunAgentStreamEventType_value = map[string]int32{
-		"RUN_AGENT_STREAM_EVENT_TYPE_UNSPECIFIED": 0,
-		"RUN_AGENT_STREAM_EVENT_TYPE_STARTED":     1,
-		"RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT":      2,
-		"RUN_AGENT_STREAM_EVENT_TYPE_STATUS":      3,
-		"RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED":   4,
+	StreamAgentRunEventType_value = map[string]int32{
+		"STREAM_AGENT_RUN_EVENT_TYPE_UNSPECIFIED": 0,
+		"STREAM_AGENT_RUN_EVENT_TYPE_STARTED":     1,
+		"STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT":      2,
+		"STREAM_AGENT_RUN_EVENT_TYPE_STATUS":      3,
+		"STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED":   4,
 	}
 )
 
-func (x RunAgentStreamEventType) Enum() *RunAgentStreamEventType {
-	p := new(RunAgentStreamEventType)
+func (x StreamAgentRunEventType) Enum() *StreamAgentRunEventType {
+	p := new(StreamAgentRunEventType)
 	*p = x
 	return p
 }
 
-func (x RunAgentStreamEventType) String() string {
+func (x StreamAgentRunEventType) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (RunAgentStreamEventType) Descriptor() protoreflect.EnumDescriptor {
+func (StreamAgentRunEventType) Descriptor() protoreflect.EnumDescriptor {
 	return file_agentcompose_v2_agentcompose_proto_enumTypes[9].Descriptor()
 }
 
-func (RunAgentStreamEventType) Type() protoreflect.EnumType {
+func (StreamAgentRunEventType) Type() protoreflect.EnumType {
 	return &file_agentcompose_v2_agentcompose_proto_enumTypes[9]
 }
 
-func (x RunAgentStreamEventType) Number() protoreflect.EnumNumber {
+func (x StreamAgentRunEventType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use RunAgentStreamEventType.Descriptor instead.
-func (RunAgentStreamEventType) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use StreamAgentRunEventType.Descriptor instead.
+func (StreamAgentRunEventType) EnumDescriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{9}
 }
 
@@ -609,55 +609,55 @@ func (RunSandboxCleanupPolicy) EnumDescriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{10}
 }
 
-type ExecStreamEventType int32
+type StreamExecEventType int32
 
 const (
-	ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_UNSPECIFIED ExecStreamEventType = 0
-	ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_STARTED     ExecStreamEventType = 1
-	ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_OUTPUT      ExecStreamEventType = 2
-	ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_COMPLETED   ExecStreamEventType = 3
+	StreamExecEventType_STREAM_EXEC_EVENT_TYPE_UNSPECIFIED StreamExecEventType = 0
+	StreamExecEventType_STREAM_EXEC_EVENT_TYPE_STARTED     StreamExecEventType = 1
+	StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT      StreamExecEventType = 2
+	StreamExecEventType_STREAM_EXEC_EVENT_TYPE_COMPLETED   StreamExecEventType = 3
 )
 
-// Enum value maps for ExecStreamEventType.
+// Enum value maps for StreamExecEventType.
 var (
-	ExecStreamEventType_name = map[int32]string{
-		0: "EXEC_STREAM_EVENT_TYPE_UNSPECIFIED",
-		1: "EXEC_STREAM_EVENT_TYPE_STARTED",
-		2: "EXEC_STREAM_EVENT_TYPE_OUTPUT",
-		3: "EXEC_STREAM_EVENT_TYPE_COMPLETED",
+	StreamExecEventType_name = map[int32]string{
+		0: "STREAM_EXEC_EVENT_TYPE_UNSPECIFIED",
+		1: "STREAM_EXEC_EVENT_TYPE_STARTED",
+		2: "STREAM_EXEC_EVENT_TYPE_OUTPUT",
+		3: "STREAM_EXEC_EVENT_TYPE_COMPLETED",
 	}
-	ExecStreamEventType_value = map[string]int32{
-		"EXEC_STREAM_EVENT_TYPE_UNSPECIFIED": 0,
-		"EXEC_STREAM_EVENT_TYPE_STARTED":     1,
-		"EXEC_STREAM_EVENT_TYPE_OUTPUT":      2,
-		"EXEC_STREAM_EVENT_TYPE_COMPLETED":   3,
+	StreamExecEventType_value = map[string]int32{
+		"STREAM_EXEC_EVENT_TYPE_UNSPECIFIED": 0,
+		"STREAM_EXEC_EVENT_TYPE_STARTED":     1,
+		"STREAM_EXEC_EVENT_TYPE_OUTPUT":      2,
+		"STREAM_EXEC_EVENT_TYPE_COMPLETED":   3,
 	}
 )
 
-func (x ExecStreamEventType) Enum() *ExecStreamEventType {
-	p := new(ExecStreamEventType)
+func (x StreamExecEventType) Enum() *StreamExecEventType {
+	p := new(StreamExecEventType)
 	*p = x
 	return p
 }
 
-func (x ExecStreamEventType) String() string {
+func (x StreamExecEventType) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (ExecStreamEventType) Descriptor() protoreflect.EnumDescriptor {
+func (StreamExecEventType) Descriptor() protoreflect.EnumDescriptor {
 	return file_agentcompose_v2_agentcompose_proto_enumTypes[11].Descriptor()
 }
 
-func (ExecStreamEventType) Type() protoreflect.EnumType {
+func (StreamExecEventType) Type() protoreflect.EnumType {
 	return &file_agentcompose_v2_agentcompose_proto_enumTypes[11]
 }
 
-func (x ExecStreamEventType) Number() protoreflect.EnumNumber {
+func (x StreamExecEventType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use ExecStreamEventType.Descriptor instead.
-func (ExecStreamEventType) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use StreamExecEventType.Descriptor instead.
+func (StreamExecEventType) EnumDescriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{11}
 }
 
@@ -6631,15 +6631,17 @@ type RunAgentRequest struct {
 	SchedulerId      string                  `protobuf:"bytes,7,opt,name=scheduler_id,json=schedulerId,proto3" json:"scheduler_id,omitempty"`
 	TriggerId        string                  `protobuf:"bytes,8,opt,name=trigger_id,json=triggerId,proto3" json:"trigger_id,omitempty"`
 	OutputSchemaJson string                  `protobuf:"bytes,9,opt,name=output_schema_json,json=outputSchemaJson,proto3" json:"output_schema_json,omitempty"`
-	ClientRequestId  string                  `protobuf:"bytes,10,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
-	Command          string                  `protobuf:"bytes,11,opt,name=command,proto3" json:"command,omitempty"`
-	Jupyter          *RunJupyterSpec         `protobuf:"bytes,12,opt,name=jupyter,proto3" json:"jupyter,omitempty"`
-	Driver           string                  `protobuf:"bytes,13,opt,name=driver,proto3" json:"driver,omitempty"`
-	SandboxId        string                  `protobuf:"bytes,14,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
-	Volumes          []*VolumeMountSpec      `protobuf:"bytes,15,rep,name=volumes,proto3" json:"volumes,omitempty"`
-	PayloadJson      string                  `protobuf:"bytes,16,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Idempotency key scoped by project, agent, and run source. Retries with the
+	// same key resolve to the same persistent Run ID.
+	ClientRequestId string             `protobuf:"bytes,10,opt,name=client_request_id,json=clientRequestId,proto3" json:"client_request_id,omitempty"`
+	Command         string             `protobuf:"bytes,11,opt,name=command,proto3" json:"command,omitempty"`
+	Jupyter         *RunJupyterSpec    `protobuf:"bytes,12,opt,name=jupyter,proto3" json:"jupyter,omitempty"`
+	Driver          string             `protobuf:"bytes,13,opt,name=driver,proto3" json:"driver,omitempty"`
+	SandboxId       string             `protobuf:"bytes,14,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
+	Volumes         []*VolumeMountSpec `protobuf:"bytes,15,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	PayloadJson     string             `protobuf:"bytes,16,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *RunAgentRequest) Reset() {
@@ -6836,9 +6838,9 @@ func (x *RunAgentResponse) GetWarnings() []string {
 	return nil
 }
 
-type RunAgentStreamResponse struct {
+type StreamAgentRunResponse struct {
 	state         protoimpl.MessageState  `protogen:"open.v1"`
-	EventType     RunAgentStreamEventType `protobuf:"varint,1,opt,name=event_type,json=eventType,proto3,enum=agentcompose.v2.RunAgentStreamEventType" json:"event_type,omitempty"`
+	EventType     StreamAgentRunEventType `protobuf:"varint,1,opt,name=event_type,json=eventType,proto3,enum=agentcompose.v2.StreamAgentRunEventType" json:"event_type,omitempty"`
 	Run           *RunSummary             `protobuf:"bytes,2,opt,name=run,proto3" json:"run,omitempty"`
 	RunId         string                  `protobuf:"bytes,3,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	Chunk         string                  `protobuf:"bytes,4,opt,name=chunk,proto3" json:"chunk,omitempty"`
@@ -6850,20 +6852,20 @@ type RunAgentStreamResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *RunAgentStreamResponse) Reset() {
-	*x = RunAgentStreamResponse{}
+func (x *StreamAgentRunResponse) Reset() {
+	*x = StreamAgentRunResponse{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RunAgentStreamResponse) String() string {
+func (x *StreamAgentRunResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RunAgentStreamResponse) ProtoMessage() {}
+func (*StreamAgentRunResponse) ProtoMessage() {}
 
-func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
+func (x *StreamAgentRunResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -6875,100 +6877,100 @@ func (x *RunAgentStreamResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RunAgentStreamResponse.ProtoReflect.Descriptor instead.
-func (*RunAgentStreamResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use StreamAgentRunResponse.ProtoReflect.Descriptor instead.
+func (*StreamAgentRunResponse) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{75}
 }
 
-func (x *RunAgentStreamResponse) GetEventType() RunAgentStreamEventType {
+func (x *StreamAgentRunResponse) GetEventType() StreamAgentRunEventType {
 	if x != nil {
 		return x.EventType
 	}
-	return RunAgentStreamEventType_RUN_AGENT_STREAM_EVENT_TYPE_UNSPECIFIED
+	return StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_UNSPECIFIED
 }
 
-func (x *RunAgentStreamResponse) GetRun() *RunSummary {
+func (x *StreamAgentRunResponse) GetRun() *RunSummary {
 	if x != nil {
 		return x.Run
 	}
 	return nil
 }
 
-func (x *RunAgentStreamResponse) GetRunId() string {
+func (x *StreamAgentRunResponse) GetRunId() string {
 	if x != nil {
 		return x.RunId
 	}
 	return ""
 }
 
-func (x *RunAgentStreamResponse) GetChunk() string {
+func (x *StreamAgentRunResponse) GetChunk() string {
 	if x != nil {
 		return x.Chunk
 	}
 	return ""
 }
 
-func (x *RunAgentStreamResponse) GetStream() StdioStream {
+func (x *StreamAgentRunResponse) GetStream() StdioStream {
 	if x != nil {
 		return x.Stream
 	}
 	return StdioStream_STDIO_STREAM_UNSPECIFIED
 }
 
-func (x *RunAgentStreamResponse) GetCreatedAt() *timestamppb.Timestamp {
+func (x *StreamAgentRunResponse) GetCreatedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.CreatedAt
 	}
 	return nil
 }
 
-func (x *RunAgentStreamResponse) GetWarnings() []string {
+func (x *StreamAgentRunResponse) GetWarnings() []string {
 	if x != nil {
 		return x.Warnings
 	}
 	return nil
 }
 
-func (x *RunAgentStreamResponse) GetTranscript() *TranscriptEvent {
+func (x *StreamAgentRunResponse) GetTranscript() *TranscriptEvent {
 	if x != nil {
 		return x.Transcript
 	}
 	return nil
 }
 
-type RunAttachRequest struct {
+type AttachAgentRunRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Frame variants occupy the low-number range. Envelope metadata starts at
 	// 15 so future frame variants can be added without moving metadata fields.
 	ClientFrameId string `protobuf:"bytes,15,opt,name=client_frame_id,json=clientFrameId,proto3" json:"client_frame_id,omitempty"`
 	// Types that are valid to be assigned to Frame:
 	//
-	//	*RunAttachRequest_Start
-	//	*RunAttachRequest_Stdin
-	//	*RunAttachRequest_StdinEof
-	//	*RunAttachRequest_Resize
-	//	*RunAttachRequest_Signal
-	//	*RunAttachRequest_HumanMessage
-	//	*RunAttachRequest_Cancel
-	Frame         isRunAttachRequest_Frame `protobuf_oneof:"frame"`
+	//	*AttachAgentRunRequest_Start
+	//	*AttachAgentRunRequest_Stdin
+	//	*AttachAgentRunRequest_StdinEof
+	//	*AttachAgentRunRequest_Resize
+	//	*AttachAgentRunRequest_Signal
+	//	*AttachAgentRunRequest_HumanMessage
+	//	*AttachAgentRunRequest_Cancel
+	Frame         isAttachAgentRunRequest_Frame `protobuf_oneof:"frame"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *RunAttachRequest) Reset() {
-	*x = RunAttachRequest{}
+func (x *AttachAgentRunRequest) Reset() {
+	*x = AttachAgentRunRequest{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RunAttachRequest) String() string {
+func (x *AttachAgentRunRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RunAttachRequest) ProtoMessage() {}
+func (*AttachAgentRunRequest) ProtoMessage() {}
 
-func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
+func (x *AttachAgentRunRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -6980,135 +6982,135 @@ func (x *RunAttachRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RunAttachRequest.ProtoReflect.Descriptor instead.
-func (*RunAttachRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachAgentRunRequest.ProtoReflect.Descriptor instead.
+func (*AttachAgentRunRequest) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{76}
 }
 
-func (x *RunAttachRequest) GetClientFrameId() string {
+func (x *AttachAgentRunRequest) GetClientFrameId() string {
 	if x != nil {
 		return x.ClientFrameId
 	}
 	return ""
 }
 
-func (x *RunAttachRequest) GetFrame() isRunAttachRequest_Frame {
+func (x *AttachAgentRunRequest) GetFrame() isAttachAgentRunRequest_Frame {
 	if x != nil {
 		return x.Frame
 	}
 	return nil
 }
 
-func (x *RunAttachRequest) GetStart() *RunAttachStart {
+func (x *AttachAgentRunRequest) GetStart() *AttachAgentRunStart {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachRequest_Start); ok {
+		if x, ok := x.Frame.(*AttachAgentRunRequest_Start); ok {
 			return x.Start
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachRequest) GetStdin() *AttachStdin {
+func (x *AttachAgentRunRequest) GetStdin() *AttachStdin {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachRequest_Stdin); ok {
+		if x, ok := x.Frame.(*AttachAgentRunRequest_Stdin); ok {
 			return x.Stdin
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachRequest) GetStdinEof() *AttachStdinEOF {
+func (x *AttachAgentRunRequest) GetStdinEof() *AttachStdinEOF {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachRequest_StdinEof); ok {
+		if x, ok := x.Frame.(*AttachAgentRunRequest_StdinEof); ok {
 			return x.StdinEof
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachRequest) GetResize() *AttachResize {
+func (x *AttachAgentRunRequest) GetResize() *AttachResize {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachRequest_Resize); ok {
+		if x, ok := x.Frame.(*AttachAgentRunRequest_Resize); ok {
 			return x.Resize
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachRequest) GetSignal() *AttachSignal {
+func (x *AttachAgentRunRequest) GetSignal() *AttachSignal {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachRequest_Signal); ok {
+		if x, ok := x.Frame.(*AttachAgentRunRequest_Signal); ok {
 			return x.Signal
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachRequest) GetHumanMessage() *AttachHumanMessage {
+func (x *AttachAgentRunRequest) GetHumanMessage() *AttachHumanMessage {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachRequest_HumanMessage); ok {
+		if x, ok := x.Frame.(*AttachAgentRunRequest_HumanMessage); ok {
 			return x.HumanMessage
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachRequest) GetCancel() *AttachCancel {
+func (x *AttachAgentRunRequest) GetCancel() *AttachCancel {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachRequest_Cancel); ok {
+		if x, ok := x.Frame.(*AttachAgentRunRequest_Cancel); ok {
 			return x.Cancel
 		}
 	}
 	return nil
 }
 
-type isRunAttachRequest_Frame interface {
-	isRunAttachRequest_Frame()
+type isAttachAgentRunRequest_Frame interface {
+	isAttachAgentRunRequest_Frame()
 }
 
-type RunAttachRequest_Start struct {
-	Start *RunAttachStart `protobuf:"bytes,1,opt,name=start,proto3,oneof"`
+type AttachAgentRunRequest_Start struct {
+	Start *AttachAgentRunStart `protobuf:"bytes,1,opt,name=start,proto3,oneof"`
 }
 
-type RunAttachRequest_Stdin struct {
+type AttachAgentRunRequest_Stdin struct {
 	Stdin *AttachStdin `protobuf:"bytes,2,opt,name=stdin,proto3,oneof"`
 }
 
-type RunAttachRequest_StdinEof struct {
+type AttachAgentRunRequest_StdinEof struct {
 	StdinEof *AttachStdinEOF `protobuf:"bytes,3,opt,name=stdin_eof,json=stdinEof,proto3,oneof"`
 }
 
-type RunAttachRequest_Resize struct {
+type AttachAgentRunRequest_Resize struct {
 	Resize *AttachResize `protobuf:"bytes,4,opt,name=resize,proto3,oneof"`
 }
 
-type RunAttachRequest_Signal struct {
+type AttachAgentRunRequest_Signal struct {
 	Signal *AttachSignal `protobuf:"bytes,5,opt,name=signal,proto3,oneof"`
 }
 
-type RunAttachRequest_HumanMessage struct {
+type AttachAgentRunRequest_HumanMessage struct {
 	HumanMessage *AttachHumanMessage `protobuf:"bytes,6,opt,name=human_message,json=humanMessage,proto3,oneof"`
 }
 
-type RunAttachRequest_Cancel struct {
+type AttachAgentRunRequest_Cancel struct {
 	Cancel *AttachCancel `protobuf:"bytes,7,opt,name=cancel,proto3,oneof"`
 }
 
-func (*RunAttachRequest_Start) isRunAttachRequest_Frame() {}
+func (*AttachAgentRunRequest_Start) isAttachAgentRunRequest_Frame() {}
 
-func (*RunAttachRequest_Stdin) isRunAttachRequest_Frame() {}
+func (*AttachAgentRunRequest_Stdin) isAttachAgentRunRequest_Frame() {}
 
-func (*RunAttachRequest_StdinEof) isRunAttachRequest_Frame() {}
+func (*AttachAgentRunRequest_StdinEof) isAttachAgentRunRequest_Frame() {}
 
-func (*RunAttachRequest_Resize) isRunAttachRequest_Frame() {}
+func (*AttachAgentRunRequest_Resize) isAttachAgentRunRequest_Frame() {}
 
-func (*RunAttachRequest_Signal) isRunAttachRequest_Frame() {}
+func (*AttachAgentRunRequest_Signal) isAttachAgentRunRequest_Frame() {}
 
-func (*RunAttachRequest_HumanMessage) isRunAttachRequest_Frame() {}
+func (*AttachAgentRunRequest_HumanMessage) isAttachAgentRunRequest_Frame() {}
 
-func (*RunAttachRequest_Cancel) isRunAttachRequest_Frame() {}
+func (*AttachAgentRunRequest_Cancel) isAttachAgentRunRequest_Frame() {}
 
-type RunAttachResponse struct {
+type AttachAgentRunResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Frame variants occupy the low-number range. Envelope metadata starts at
 	// 15 so future frame variants can be added without moving metadata fields.
@@ -7116,31 +7118,31 @@ type RunAttachResponse struct {
 	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Types that are valid to be assigned to Frame:
 	//
-	//	*RunAttachResponse_Started
-	//	*RunAttachResponse_Output
-	//	*RunAttachResponse_AgentEvent
-	//	*RunAttachResponse_AgentTurnCompleted
-	//	*RunAttachResponse_Result
-	//	*RunAttachResponse_Error
-	Frame         isRunAttachResponse_Frame `protobuf_oneof:"frame"`
+	//	*AttachAgentRunResponse_Started
+	//	*AttachAgentRunResponse_Output
+	//	*AttachAgentRunResponse_AgentEvent
+	//	*AttachAgentRunResponse_AgentTurnCompleted
+	//	*AttachAgentRunResponse_Result
+	//	*AttachAgentRunResponse_Error
+	Frame         isAttachAgentRunResponse_Frame `protobuf_oneof:"frame"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *RunAttachResponse) Reset() {
-	*x = RunAttachResponse{}
+func (x *AttachAgentRunResponse) Reset() {
+	*x = AttachAgentRunResponse{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RunAttachResponse) String() string {
+func (x *AttachAgentRunResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RunAttachResponse) ProtoMessage() {}
+func (*AttachAgentRunResponse) ProtoMessage() {}
 
-func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
+func (x *AttachAgentRunResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -7152,127 +7154,127 @@ func (x *RunAttachResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RunAttachResponse.ProtoReflect.Descriptor instead.
-func (*RunAttachResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachAgentRunResponse.ProtoReflect.Descriptor instead.
+func (*AttachAgentRunResponse) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{77}
 }
 
-func (x *RunAttachResponse) GetServerFrameId() string {
+func (x *AttachAgentRunResponse) GetServerFrameId() string {
 	if x != nil {
 		return x.ServerFrameId
 	}
 	return ""
 }
 
-func (x *RunAttachResponse) GetCreatedAt() *timestamppb.Timestamp {
+func (x *AttachAgentRunResponse) GetCreatedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.CreatedAt
 	}
 	return nil
 }
 
-func (x *RunAttachResponse) GetFrame() isRunAttachResponse_Frame {
+func (x *AttachAgentRunResponse) GetFrame() isAttachAgentRunResponse_Frame {
 	if x != nil {
 		return x.Frame
 	}
 	return nil
 }
 
-func (x *RunAttachResponse) GetStarted() *AttachStarted {
+func (x *AttachAgentRunResponse) GetStarted() *AttachStarted {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachResponse_Started); ok {
+		if x, ok := x.Frame.(*AttachAgentRunResponse_Started); ok {
 			return x.Started
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachResponse) GetOutput() *AttachOutput {
+func (x *AttachAgentRunResponse) GetOutput() *AttachOutput {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachResponse_Output); ok {
+		if x, ok := x.Frame.(*AttachAgentRunResponse_Output); ok {
 			return x.Output
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachResponse) GetAgentEvent() *AttachAgentEvent {
+func (x *AttachAgentRunResponse) GetAgentEvent() *AttachAgentEvent {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachResponse_AgentEvent); ok {
+		if x, ok := x.Frame.(*AttachAgentRunResponse_AgentEvent); ok {
 			return x.AgentEvent
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachResponse) GetAgentTurnCompleted() *AttachAgentTurnCompleted {
+func (x *AttachAgentRunResponse) GetAgentTurnCompleted() *AttachAgentTurnCompleted {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachResponse_AgentTurnCompleted); ok {
+		if x, ok := x.Frame.(*AttachAgentRunResponse_AgentTurnCompleted); ok {
 			return x.AgentTurnCompleted
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachResponse) GetResult() *AttachResult {
+func (x *AttachAgentRunResponse) GetResult() *AttachResult {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachResponse_Result); ok {
+		if x, ok := x.Frame.(*AttachAgentRunResponse_Result); ok {
 			return x.Result
 		}
 	}
 	return nil
 }
 
-func (x *RunAttachResponse) GetError() *AttachError {
+func (x *AttachAgentRunResponse) GetError() *AttachError {
 	if x != nil {
-		if x, ok := x.Frame.(*RunAttachResponse_Error); ok {
+		if x, ok := x.Frame.(*AttachAgentRunResponse_Error); ok {
 			return x.Error
 		}
 	}
 	return nil
 }
 
-type isRunAttachResponse_Frame interface {
-	isRunAttachResponse_Frame()
+type isAttachAgentRunResponse_Frame interface {
+	isAttachAgentRunResponse_Frame()
 }
 
-type RunAttachResponse_Started struct {
+type AttachAgentRunResponse_Started struct {
 	Started *AttachStarted `protobuf:"bytes,1,opt,name=started,proto3,oneof"`
 }
 
-type RunAttachResponse_Output struct {
+type AttachAgentRunResponse_Output struct {
 	Output *AttachOutput `protobuf:"bytes,2,opt,name=output,proto3,oneof"`
 }
 
-type RunAttachResponse_AgentEvent struct {
+type AttachAgentRunResponse_AgentEvent struct {
 	AgentEvent *AttachAgentEvent `protobuf:"bytes,3,opt,name=agent_event,json=agentEvent,proto3,oneof"`
 }
 
-type RunAttachResponse_AgentTurnCompleted struct {
+type AttachAgentRunResponse_AgentTurnCompleted struct {
 	AgentTurnCompleted *AttachAgentTurnCompleted `protobuf:"bytes,4,opt,name=agent_turn_completed,json=agentTurnCompleted,proto3,oneof"`
 }
 
-type RunAttachResponse_Result struct {
+type AttachAgentRunResponse_Result struct {
 	Result *AttachResult `protobuf:"bytes,5,opt,name=result,proto3,oneof"`
 }
 
-type RunAttachResponse_Error struct {
+type AttachAgentRunResponse_Error struct {
 	Error *AttachError `protobuf:"bytes,6,opt,name=error,proto3,oneof"`
 }
 
-func (*RunAttachResponse_Started) isRunAttachResponse_Frame() {}
+func (*AttachAgentRunResponse_Started) isAttachAgentRunResponse_Frame() {}
 
-func (*RunAttachResponse_Output) isRunAttachResponse_Frame() {}
+func (*AttachAgentRunResponse_Output) isAttachAgentRunResponse_Frame() {}
 
-func (*RunAttachResponse_AgentEvent) isRunAttachResponse_Frame() {}
+func (*AttachAgentRunResponse_AgentEvent) isAttachAgentRunResponse_Frame() {}
 
-func (*RunAttachResponse_AgentTurnCompleted) isRunAttachResponse_Frame() {}
+func (*AttachAgentRunResponse_AgentTurnCompleted) isAttachAgentRunResponse_Frame() {}
 
-func (*RunAttachResponse_Result) isRunAttachResponse_Frame() {}
+func (*AttachAgentRunResponse_Result) isAttachAgentRunResponse_Frame() {}
 
-func (*RunAttachResponse_Error) isRunAttachResponse_Frame() {}
+func (*AttachAgentRunResponse_Error) isAttachAgentRunResponse_Frame() {}
 
-type RunAttachStart struct {
+type AttachAgentRunStart struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Request       *RunAgentRequest       `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
 	Mode          AttachRunMode          `protobuf:"varint,2,opt,name=mode,proto3,enum=agentcompose.v2.AttachRunMode" json:"mode,omitempty"`
@@ -7283,20 +7285,20 @@ type RunAttachStart struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *RunAttachStart) Reset() {
-	*x = RunAttachStart{}
+func (x *AttachAgentRunStart) Reset() {
+	*x = AttachAgentRunStart{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RunAttachStart) String() string {
+func (x *AttachAgentRunStart) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RunAttachStart) ProtoMessage() {}
+func (*AttachAgentRunStart) ProtoMessage() {}
 
-func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
+func (x *AttachAgentRunStart) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -7308,40 +7310,40 @@ func (x *RunAttachStart) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RunAttachStart.ProtoReflect.Descriptor instead.
-func (*RunAttachStart) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachAgentRunStart.ProtoReflect.Descriptor instead.
+func (*AttachAgentRunStart) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{78}
 }
 
-func (x *RunAttachStart) GetRequest() *RunAgentRequest {
+func (x *AttachAgentRunStart) GetRequest() *RunAgentRequest {
 	if x != nil {
 		return x.Request
 	}
 	return nil
 }
 
-func (x *RunAttachStart) GetMode() AttachRunMode {
+func (x *AttachAgentRunStart) GetMode() AttachRunMode {
 	if x != nil {
 		return x.Mode
 	}
 	return AttachRunMode_ATTACH_RUN_MODE_UNSPECIFIED
 }
 
-func (x *RunAttachStart) GetAttachStdin() bool {
+func (x *AttachAgentRunStart) GetAttachStdin() bool {
 	if x != nil {
 		return x.AttachStdin
 	}
 	return false
 }
 
-func (x *RunAttachStart) GetTty() bool {
+func (x *AttachAgentRunStart) GetTty() bool {
 	if x != nil {
 		return x.Tty
 	}
 	return false
 }
 
-func (x *RunAttachStart) GetTerminalSize() *AttachTerminalSize {
+func (x *AttachAgentRunStart) GetTerminalSize() *AttachTerminalSize {
 	if x != nil {
 		return x.TerminalSize
 	}
@@ -10294,9 +10296,9 @@ func (x *ExecResponse) GetResult() *ExecResult {
 	return nil
 }
 
-type ExecStreamResponse struct {
+type StreamExecResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	EventType     ExecStreamEventType    `protobuf:"varint,1,opt,name=event_type,json=eventType,proto3,enum=agentcompose.v2.ExecStreamEventType" json:"event_type,omitempty"`
+	EventType     StreamExecEventType    `protobuf:"varint,1,opt,name=event_type,json=eventType,proto3,enum=agentcompose.v2.StreamExecEventType" json:"event_type,omitempty"`
 	ExecId        string                 `protobuf:"bytes,2,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
 	SandboxId     string                 `protobuf:"bytes,3,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
 	RunId         string                 `protobuf:"bytes,4,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
@@ -10308,20 +10310,20 @@ type ExecStreamResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ExecStreamResponse) Reset() {
-	*x = ExecStreamResponse{}
+func (x *StreamExecResponse) Reset() {
+	*x = StreamExecResponse{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExecStreamResponse) String() string {
+func (x *StreamExecResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExecStreamResponse) ProtoMessage() {}
+func (*StreamExecResponse) ProtoMessage() {}
 
-func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
+func (x *StreamExecResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -10333,100 +10335,100 @@ func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExecStreamResponse.ProtoReflect.Descriptor instead.
-func (*ExecStreamResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use StreamExecResponse.ProtoReflect.Descriptor instead.
+func (*StreamExecResponse) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{118}
 }
 
-func (x *ExecStreamResponse) GetEventType() ExecStreamEventType {
+func (x *StreamExecResponse) GetEventType() StreamExecEventType {
 	if x != nil {
 		return x.EventType
 	}
-	return ExecStreamEventType_EXEC_STREAM_EVENT_TYPE_UNSPECIFIED
+	return StreamExecEventType_STREAM_EXEC_EVENT_TYPE_UNSPECIFIED
 }
 
-func (x *ExecStreamResponse) GetExecId() string {
+func (x *StreamExecResponse) GetExecId() string {
 	if x != nil {
 		return x.ExecId
 	}
 	return ""
 }
 
-func (x *ExecStreamResponse) GetSandboxId() string {
+func (x *StreamExecResponse) GetSandboxId() string {
 	if x != nil {
 		return x.SandboxId
 	}
 	return ""
 }
 
-func (x *ExecStreamResponse) GetRunId() string {
+func (x *StreamExecResponse) GetRunId() string {
 	if x != nil {
 		return x.RunId
 	}
 	return ""
 }
 
-func (x *ExecStreamResponse) GetChunk() string {
+func (x *StreamExecResponse) GetChunk() string {
 	if x != nil {
 		return x.Chunk
 	}
 	return ""
 }
 
-func (x *ExecStreamResponse) GetStream() StdioStream {
+func (x *StreamExecResponse) GetStream() StdioStream {
 	if x != nil {
 		return x.Stream
 	}
 	return StdioStream_STDIO_STREAM_UNSPECIFIED
 }
 
-func (x *ExecStreamResponse) GetResult() *ExecResult {
+func (x *StreamExecResponse) GetResult() *ExecResult {
 	if x != nil {
 		return x.Result
 	}
 	return nil
 }
 
-func (x *ExecStreamResponse) GetTranscript() *TranscriptEvent {
+func (x *StreamExecResponse) GetTranscript() *TranscriptEvent {
 	if x != nil {
 		return x.Transcript
 	}
 	return nil
 }
 
-type ExecAttachRequest struct {
+type AttachExecRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Frame variants occupy the low-number range. Envelope metadata starts at
 	// 15 so future frame variants can be added without moving metadata fields.
 	ClientFrameId string `protobuf:"bytes,15,opt,name=client_frame_id,json=clientFrameId,proto3" json:"client_frame_id,omitempty"`
 	// Types that are valid to be assigned to Frame:
 	//
-	//	*ExecAttachRequest_Start
-	//	*ExecAttachRequest_Stdin
-	//	*ExecAttachRequest_StdinEof
-	//	*ExecAttachRequest_Resize
-	//	*ExecAttachRequest_Signal
-	//	*ExecAttachRequest_Cancel
-	//	*ExecAttachRequest_HumanMessage
-	Frame         isExecAttachRequest_Frame `protobuf_oneof:"frame"`
+	//	*AttachExecRequest_Start
+	//	*AttachExecRequest_Stdin
+	//	*AttachExecRequest_StdinEof
+	//	*AttachExecRequest_Resize
+	//	*AttachExecRequest_Signal
+	//	*AttachExecRequest_Cancel
+	//	*AttachExecRequest_HumanMessage
+	Frame         isAttachExecRequest_Frame `protobuf_oneof:"frame"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ExecAttachRequest) Reset() {
-	*x = ExecAttachRequest{}
+func (x *AttachExecRequest) Reset() {
+	*x = AttachExecRequest{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExecAttachRequest) String() string {
+func (x *AttachExecRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExecAttachRequest) ProtoMessage() {}
+func (*AttachExecRequest) ProtoMessage() {}
 
-func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
+func (x *AttachExecRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -10438,135 +10440,135 @@ func (x *ExecAttachRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExecAttachRequest.ProtoReflect.Descriptor instead.
-func (*ExecAttachRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachExecRequest.ProtoReflect.Descriptor instead.
+func (*AttachExecRequest) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{119}
 }
 
-func (x *ExecAttachRequest) GetClientFrameId() string {
+func (x *AttachExecRequest) GetClientFrameId() string {
 	if x != nil {
 		return x.ClientFrameId
 	}
 	return ""
 }
 
-func (x *ExecAttachRequest) GetFrame() isExecAttachRequest_Frame {
+func (x *AttachExecRequest) GetFrame() isAttachExecRequest_Frame {
 	if x != nil {
 		return x.Frame
 	}
 	return nil
 }
 
-func (x *ExecAttachRequest) GetStart() *ExecAttachStart {
+func (x *AttachExecRequest) GetStart() *AttachExecStart {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachRequest_Start); ok {
+		if x, ok := x.Frame.(*AttachExecRequest_Start); ok {
 			return x.Start
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachRequest) GetStdin() *AttachStdin {
+func (x *AttachExecRequest) GetStdin() *AttachStdin {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachRequest_Stdin); ok {
+		if x, ok := x.Frame.(*AttachExecRequest_Stdin); ok {
 			return x.Stdin
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachRequest) GetStdinEof() *AttachStdinEOF {
+func (x *AttachExecRequest) GetStdinEof() *AttachStdinEOF {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachRequest_StdinEof); ok {
+		if x, ok := x.Frame.(*AttachExecRequest_StdinEof); ok {
 			return x.StdinEof
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachRequest) GetResize() *AttachResize {
+func (x *AttachExecRequest) GetResize() *AttachResize {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachRequest_Resize); ok {
+		if x, ok := x.Frame.(*AttachExecRequest_Resize); ok {
 			return x.Resize
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachRequest) GetSignal() *AttachSignal {
+func (x *AttachExecRequest) GetSignal() *AttachSignal {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachRequest_Signal); ok {
+		if x, ok := x.Frame.(*AttachExecRequest_Signal); ok {
 			return x.Signal
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachRequest) GetCancel() *AttachCancel {
+func (x *AttachExecRequest) GetCancel() *AttachCancel {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachRequest_Cancel); ok {
+		if x, ok := x.Frame.(*AttachExecRequest_Cancel); ok {
 			return x.Cancel
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachRequest) GetHumanMessage() *AttachHumanMessage {
+func (x *AttachExecRequest) GetHumanMessage() *AttachHumanMessage {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachRequest_HumanMessage); ok {
+		if x, ok := x.Frame.(*AttachExecRequest_HumanMessage); ok {
 			return x.HumanMessage
 		}
 	}
 	return nil
 }
 
-type isExecAttachRequest_Frame interface {
-	isExecAttachRequest_Frame()
+type isAttachExecRequest_Frame interface {
+	isAttachExecRequest_Frame()
 }
 
-type ExecAttachRequest_Start struct {
-	Start *ExecAttachStart `protobuf:"bytes,1,opt,name=start,proto3,oneof"`
+type AttachExecRequest_Start struct {
+	Start *AttachExecStart `protobuf:"bytes,1,opt,name=start,proto3,oneof"`
 }
 
-type ExecAttachRequest_Stdin struct {
+type AttachExecRequest_Stdin struct {
 	Stdin *AttachStdin `protobuf:"bytes,2,opt,name=stdin,proto3,oneof"`
 }
 
-type ExecAttachRequest_StdinEof struct {
+type AttachExecRequest_StdinEof struct {
 	StdinEof *AttachStdinEOF `protobuf:"bytes,3,opt,name=stdin_eof,json=stdinEof,proto3,oneof"`
 }
 
-type ExecAttachRequest_Resize struct {
+type AttachExecRequest_Resize struct {
 	Resize *AttachResize `protobuf:"bytes,4,opt,name=resize,proto3,oneof"`
 }
 
-type ExecAttachRequest_Signal struct {
+type AttachExecRequest_Signal struct {
 	Signal *AttachSignal `protobuf:"bytes,5,opt,name=signal,proto3,oneof"`
 }
 
-type ExecAttachRequest_Cancel struct {
+type AttachExecRequest_Cancel struct {
 	Cancel *AttachCancel `protobuf:"bytes,6,opt,name=cancel,proto3,oneof"`
 }
 
-type ExecAttachRequest_HumanMessage struct {
+type AttachExecRequest_HumanMessage struct {
 	HumanMessage *AttachHumanMessage `protobuf:"bytes,7,opt,name=human_message,json=humanMessage,proto3,oneof"`
 }
 
-func (*ExecAttachRequest_Start) isExecAttachRequest_Frame() {}
+func (*AttachExecRequest_Start) isAttachExecRequest_Frame() {}
 
-func (*ExecAttachRequest_Stdin) isExecAttachRequest_Frame() {}
+func (*AttachExecRequest_Stdin) isAttachExecRequest_Frame() {}
 
-func (*ExecAttachRequest_StdinEof) isExecAttachRequest_Frame() {}
+func (*AttachExecRequest_StdinEof) isAttachExecRequest_Frame() {}
 
-func (*ExecAttachRequest_Resize) isExecAttachRequest_Frame() {}
+func (*AttachExecRequest_Resize) isAttachExecRequest_Frame() {}
 
-func (*ExecAttachRequest_Signal) isExecAttachRequest_Frame() {}
+func (*AttachExecRequest_Signal) isAttachExecRequest_Frame() {}
 
-func (*ExecAttachRequest_Cancel) isExecAttachRequest_Frame() {}
+func (*AttachExecRequest_Cancel) isAttachExecRequest_Frame() {}
 
-func (*ExecAttachRequest_HumanMessage) isExecAttachRequest_Frame() {}
+func (*AttachExecRequest_HumanMessage) isAttachExecRequest_Frame() {}
 
-type ExecAttachResponse struct {
+type AttachExecResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Frame variants occupy the low-number range. Envelope metadata starts at
 	// 15 so future frame variants can be added without moving metadata fields.
@@ -10574,31 +10576,31 @@ type ExecAttachResponse struct {
 	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Types that are valid to be assigned to Frame:
 	//
-	//	*ExecAttachResponse_Started
-	//	*ExecAttachResponse_Output
-	//	*ExecAttachResponse_Result
-	//	*ExecAttachResponse_Error
-	//	*ExecAttachResponse_AgentEvent
-	//	*ExecAttachResponse_AgentTurnCompleted
-	Frame         isExecAttachResponse_Frame `protobuf_oneof:"frame"`
+	//	*AttachExecResponse_Started
+	//	*AttachExecResponse_Output
+	//	*AttachExecResponse_Result
+	//	*AttachExecResponse_Error
+	//	*AttachExecResponse_AgentEvent
+	//	*AttachExecResponse_AgentTurnCompleted
+	Frame         isAttachExecResponse_Frame `protobuf_oneof:"frame"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ExecAttachResponse) Reset() {
-	*x = ExecAttachResponse{}
+func (x *AttachExecResponse) Reset() {
+	*x = AttachExecResponse{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExecAttachResponse) String() string {
+func (x *AttachExecResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExecAttachResponse) ProtoMessage() {}
+func (*AttachExecResponse) ProtoMessage() {}
 
-func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
+func (x *AttachExecResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -10610,127 +10612,127 @@ func (x *ExecAttachResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExecAttachResponse.ProtoReflect.Descriptor instead.
-func (*ExecAttachResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachExecResponse.ProtoReflect.Descriptor instead.
+func (*AttachExecResponse) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{120}
 }
 
-func (x *ExecAttachResponse) GetServerFrameId() string {
+func (x *AttachExecResponse) GetServerFrameId() string {
 	if x != nil {
 		return x.ServerFrameId
 	}
 	return ""
 }
 
-func (x *ExecAttachResponse) GetCreatedAt() *timestamppb.Timestamp {
+func (x *AttachExecResponse) GetCreatedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.CreatedAt
 	}
 	return nil
 }
 
-func (x *ExecAttachResponse) GetFrame() isExecAttachResponse_Frame {
+func (x *AttachExecResponse) GetFrame() isAttachExecResponse_Frame {
 	if x != nil {
 		return x.Frame
 	}
 	return nil
 }
 
-func (x *ExecAttachResponse) GetStarted() *AttachStarted {
+func (x *AttachExecResponse) GetStarted() *AttachStarted {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachResponse_Started); ok {
+		if x, ok := x.Frame.(*AttachExecResponse_Started); ok {
 			return x.Started
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachResponse) GetOutput() *AttachOutput {
+func (x *AttachExecResponse) GetOutput() *AttachOutput {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachResponse_Output); ok {
+		if x, ok := x.Frame.(*AttachExecResponse_Output); ok {
 			return x.Output
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachResponse) GetResult() *AttachResult {
+func (x *AttachExecResponse) GetResult() *AttachResult {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachResponse_Result); ok {
+		if x, ok := x.Frame.(*AttachExecResponse_Result); ok {
 			return x.Result
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachResponse) GetError() *AttachError {
+func (x *AttachExecResponse) GetError() *AttachError {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachResponse_Error); ok {
+		if x, ok := x.Frame.(*AttachExecResponse_Error); ok {
 			return x.Error
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachResponse) GetAgentEvent() *AttachAgentEvent {
+func (x *AttachExecResponse) GetAgentEvent() *AttachAgentEvent {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachResponse_AgentEvent); ok {
+		if x, ok := x.Frame.(*AttachExecResponse_AgentEvent); ok {
 			return x.AgentEvent
 		}
 	}
 	return nil
 }
 
-func (x *ExecAttachResponse) GetAgentTurnCompleted() *AttachAgentTurnCompleted {
+func (x *AttachExecResponse) GetAgentTurnCompleted() *AttachAgentTurnCompleted {
 	if x != nil {
-		if x, ok := x.Frame.(*ExecAttachResponse_AgentTurnCompleted); ok {
+		if x, ok := x.Frame.(*AttachExecResponse_AgentTurnCompleted); ok {
 			return x.AgentTurnCompleted
 		}
 	}
 	return nil
 }
 
-type isExecAttachResponse_Frame interface {
-	isExecAttachResponse_Frame()
+type isAttachExecResponse_Frame interface {
+	isAttachExecResponse_Frame()
 }
 
-type ExecAttachResponse_Started struct {
+type AttachExecResponse_Started struct {
 	Started *AttachStarted `protobuf:"bytes,1,opt,name=started,proto3,oneof"`
 }
 
-type ExecAttachResponse_Output struct {
+type AttachExecResponse_Output struct {
 	Output *AttachOutput `protobuf:"bytes,2,opt,name=output,proto3,oneof"`
 }
 
-type ExecAttachResponse_Result struct {
+type AttachExecResponse_Result struct {
 	Result *AttachResult `protobuf:"bytes,3,opt,name=result,proto3,oneof"`
 }
 
-type ExecAttachResponse_Error struct {
+type AttachExecResponse_Error struct {
 	Error *AttachError `protobuf:"bytes,4,opt,name=error,proto3,oneof"`
 }
 
-type ExecAttachResponse_AgentEvent struct {
+type AttachExecResponse_AgentEvent struct {
 	AgentEvent *AttachAgentEvent `protobuf:"bytes,5,opt,name=agent_event,json=agentEvent,proto3,oneof"`
 }
 
-type ExecAttachResponse_AgentTurnCompleted struct {
+type AttachExecResponse_AgentTurnCompleted struct {
 	AgentTurnCompleted *AttachAgentTurnCompleted `protobuf:"bytes,6,opt,name=agent_turn_completed,json=agentTurnCompleted,proto3,oneof"`
 }
 
-func (*ExecAttachResponse_Started) isExecAttachResponse_Frame() {}
+func (*AttachExecResponse_Started) isAttachExecResponse_Frame() {}
 
-func (*ExecAttachResponse_Output) isExecAttachResponse_Frame() {}
+func (*AttachExecResponse_Output) isAttachExecResponse_Frame() {}
 
-func (*ExecAttachResponse_Result) isExecAttachResponse_Frame() {}
+func (*AttachExecResponse_Result) isAttachExecResponse_Frame() {}
 
-func (*ExecAttachResponse_Error) isExecAttachResponse_Frame() {}
+func (*AttachExecResponse_Error) isAttachExecResponse_Frame() {}
 
-func (*ExecAttachResponse_AgentEvent) isExecAttachResponse_Frame() {}
+func (*AttachExecResponse_AgentEvent) isAttachExecResponse_Frame() {}
 
-func (*ExecAttachResponse_AgentTurnCompleted) isExecAttachResponse_Frame() {}
+func (*AttachExecResponse_AgentTurnCompleted) isAttachExecResponse_Frame() {}
 
-type ExecAttachStart struct {
+type AttachExecStart struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Request       *ExecRequest           `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
 	AttachStdin   bool                   `protobuf:"varint,2,opt,name=attach_stdin,json=attachStdin,proto3" json:"attach_stdin,omitempty"`
@@ -10742,20 +10744,20 @@ type ExecAttachStart struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ExecAttachStart) Reset() {
-	*x = ExecAttachStart{}
+func (x *AttachExecStart) Reset() {
+	*x = AttachExecStart{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExecAttachStart) String() string {
+func (x *AttachExecStart) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExecAttachStart) ProtoMessage() {}
+func (*AttachExecStart) ProtoMessage() {}
 
-func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
+func (x *AttachExecStart) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -10767,47 +10769,47 @@ func (x *ExecAttachStart) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExecAttachStart.ProtoReflect.Descriptor instead.
-func (*ExecAttachStart) Descriptor() ([]byte, []int) {
+// Deprecated: Use AttachExecStart.ProtoReflect.Descriptor instead.
+func (*AttachExecStart) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{121}
 }
 
-func (x *ExecAttachStart) GetRequest() *ExecRequest {
+func (x *AttachExecStart) GetRequest() *ExecRequest {
 	if x != nil {
 		return x.Request
 	}
 	return nil
 }
 
-func (x *ExecAttachStart) GetAttachStdin() bool {
+func (x *AttachExecStart) GetAttachStdin() bool {
 	if x != nil {
 		return x.AttachStdin
 	}
 	return false
 }
 
-func (x *ExecAttachStart) GetTty() bool {
+func (x *AttachExecStart) GetTty() bool {
 	if x != nil {
 		return x.Tty
 	}
 	return false
 }
 
-func (x *ExecAttachStart) GetTerminalSize() *AttachTerminalSize {
+func (x *AttachExecStart) GetTerminalSize() *AttachTerminalSize {
 	if x != nil {
 		return x.TerminalSize
 	}
 	return nil
 }
 
-func (x *ExecAttachStart) GetMode() AttachRunMode {
+func (x *AttachExecStart) GetMode() AttachRunMode {
 	if x != nil {
 		return x.Mode
 	}
 	return AttachRunMode_ATTACH_RUN_MODE_UNSPECIFIED
 }
 
-func (x *ExecAttachStart) GetPrompt() string {
+func (x *AttachExecStart) GetPrompt() string {
 	if x != nil {
 		return x.Prompt
 	}
@@ -14583,27 +14585,27 @@ func (x *RunJupyterSpec) GetExpose() bool {
 	return false
 }
 
-type StartRunRequest struct {
+type StartAgentRunRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Run           *RunAgentRequest       `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *StartRunRequest) Reset() {
-	*x = StartRunRequest{}
+func (x *StartAgentRunRequest) Reset() {
+	*x = StartAgentRunRequest{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *StartRunRequest) String() string {
+func (x *StartAgentRunRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*StartRunRequest) ProtoMessage() {}
+func (*StartAgentRunRequest) ProtoMessage() {}
 
-func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
+func (x *StartAgentRunRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -14615,19 +14617,19 @@ func (x *StartRunRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use StartRunRequest.ProtoReflect.Descriptor instead.
-func (*StartRunRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use StartAgentRunRequest.ProtoReflect.Descriptor instead.
+func (*StartAgentRunRequest) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{176}
 }
 
-func (x *StartRunRequest) GetRun() *RunAgentRequest {
+func (x *StartAgentRunRequest) GetRun() *RunAgentRequest {
 	if x != nil {
 		return x.Run
 	}
 	return nil
 }
 
-type StartRunResponse struct {
+type StartAgentRunResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Run           *RunSummary            `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
 	Warnings      []string               `protobuf:"bytes,2,rep,name=warnings,proto3" json:"warnings,omitempty"`
@@ -14636,20 +14638,20 @@ type StartRunResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *StartRunResponse) Reset() {
-	*x = StartRunResponse{}
+func (x *StartAgentRunResponse) Reset() {
+	*x = StartAgentRunResponse{}
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *StartRunResponse) String() string {
+func (x *StartAgentRunResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*StartRunResponse) ProtoMessage() {}
+func (*StartAgentRunResponse) ProtoMessage() {}
 
-func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
+func (x *StartAgentRunResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -14661,26 +14663,26 @@ func (x *StartRunResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use StartRunResponse.ProtoReflect.Descriptor instead.
-func (*StartRunResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use StartAgentRunResponse.ProtoReflect.Descriptor instead.
+func (*StartAgentRunResponse) Descriptor() ([]byte, []int) {
 	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{177}
 }
 
-func (x *StartRunResponse) GetRun() *RunSummary {
+func (x *StartAgentRunResponse) GetRun() *RunSummary {
 	if x != nil {
 		return x.Run
 	}
 	return nil
 }
 
-func (x *StartRunResponse) GetWarnings() []string {
+func (x *StartAgentRunResponse) GetWarnings() []string {
 	if x != nil {
 		return x.Warnings
 	}
 	return nil
 }
 
-func (x *StartRunResponse) GetStarted() bool {
+func (x *StartAgentRunResponse) GetStarted() bool {
 	if x != nil {
 		return x.Started
 	}
@@ -18363,9 +18365,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x10RunAgentResponse\x12,\n" +
 	"\x03run\x18\x01 \x01(\v2\x1a.agentcompose.v2.RunDetailR\x03run\x12\x1a\n" +
 	"\bwarnings\x18\x02 \x03(\tR\bwarnings\"\x8c\x03\n" +
-	"\x16RunAgentStreamResponse\x12G\n" +
+	"\x16StreamAgentRunResponse\x12G\n" +
 	"\n" +
-	"event_type\x18\x01 \x01(\x0e2(.agentcompose.v2.RunAgentStreamEventTypeR\teventType\x12-\n" +
+	"event_type\x18\x01 \x01(\x0e2(.agentcompose.v2.StreamAgentRunEventTypeR\teventType\x12-\n" +
 	"\x03run\x18\x02 \x01(\v2\x1b.agentcompose.v2.RunSummaryR\x03run\x12\x15\n" +
 	"\x06run_id\x18\x03 \x01(\tR\x05runId\x12\x14\n" +
 	"\x05chunk\x18\x04 \x01(\tR\x05chunk\x124\n" +
@@ -18375,18 +18377,18 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\bwarnings\x18\a \x03(\tR\bwarnings\x12@\n" +
 	"\n" +
 	"transcript\x18\b \x01(\v2 .agentcompose.v2.TranscriptEventR\n" +
-	"transcript\"\xe9\x03\n" +
-	"\x10RunAttachRequest\x12&\n" +
-	"\x0fclient_frame_id\x18\x0f \x01(\tR\rclientFrameId\x127\n" +
-	"\x05start\x18\x01 \x01(\v2\x1f.agentcompose.v2.RunAttachStartH\x00R\x05start\x124\n" +
+	"transcript\"\xf3\x03\n" +
+	"\x15AttachAgentRunRequest\x12&\n" +
+	"\x0fclient_frame_id\x18\x0f \x01(\tR\rclientFrameId\x12<\n" +
+	"\x05start\x18\x01 \x01(\v2$.agentcompose.v2.AttachAgentRunStartH\x00R\x05start\x124\n" +
 	"\x05stdin\x18\x02 \x01(\v2\x1c.agentcompose.v2.AttachStdinH\x00R\x05stdin\x12>\n" +
 	"\tstdin_eof\x18\x03 \x01(\v2\x1f.agentcompose.v2.AttachStdinEOFH\x00R\bstdinEof\x127\n" +
 	"\x06resize\x18\x04 \x01(\v2\x1d.agentcompose.v2.AttachResizeH\x00R\x06resize\x127\n" +
 	"\x06signal\x18\x05 \x01(\v2\x1d.agentcompose.v2.AttachSignalH\x00R\x06signal\x12J\n" +
 	"\rhuman_message\x18\x06 \x01(\v2#.agentcompose.v2.AttachHumanMessageH\x00R\fhumanMessage\x127\n" +
 	"\x06cancel\x18\a \x01(\v2\x1d.agentcompose.v2.AttachCancelH\x00R\x06cancelB\a\n" +
-	"\x05frame\"\x88\x04\n" +
-	"\x11RunAttachResponse\x12&\n" +
+	"\x05frame\"\x8d\x04\n" +
+	"\x16AttachAgentRunResponse\x12&\n" +
 	"\x0fserver_frame_id\x18\x0f \x01(\tR\rserverFrameId\x129\n" +
 	"\n" +
 	"created_at\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12:\n" +
@@ -18397,8 +18399,8 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x14agent_turn_completed\x18\x04 \x01(\v2).agentcompose.v2.AttachAgentTurnCompletedH\x00R\x12agentTurnCompleted\x127\n" +
 	"\x06result\x18\x05 \x01(\v2\x1d.agentcompose.v2.AttachResultH\x00R\x06result\x124\n" +
 	"\x05error\x18\x06 \x01(\v2\x1c.agentcompose.v2.AttachErrorH\x00R\x05errorB\a\n" +
-	"\x05frame\"\xff\x01\n" +
-	"\x0eRunAttachStart\x12:\n" +
+	"\x05frame\"\x84\x02\n" +
+	"\x13AttachAgentRunStart\x12:\n" +
 	"\arequest\x18\x01 \x01(\v2 .agentcompose.v2.RunAgentRequestR\arequest\x122\n" +
 	"\x04mode\x18\x02 \x01(\x0e2\x1e.agentcompose.v2.AttachRunModeR\x04mode\x12!\n" +
 	"\fattach_stdin\x18\x03 \x01(\bR\vattachStdin\x12\x10\n" +
@@ -18692,9 +18694,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x04args\x18\x02 \x03(\tR\x04args\"C\n" +
 	"\fExecResponse\x123\n" +
 	"\x06result\x18\x01 \x01(\v2\x1b.agentcompose.v2.ExecResultR\x06result\"\xeb\x02\n" +
-	"\x12ExecStreamResponse\x12C\n" +
+	"\x12StreamExecResponse\x12C\n" +
 	"\n" +
-	"event_type\x18\x01 \x01(\x0e2$.agentcompose.v2.ExecStreamEventTypeR\teventType\x12\x17\n" +
+	"event_type\x18\x01 \x01(\x0e2$.agentcompose.v2.StreamExecEventTypeR\teventType\x12\x17\n" +
 	"\aexec_id\x18\x02 \x01(\tR\x06execId\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x03 \x01(\tR\tsandboxId\x12\x15\n" +
@@ -18705,9 +18707,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"transcript\x18\b \x01(\v2 .agentcompose.v2.TranscriptEventR\n" +
 	"transcript\"\xeb\x03\n" +
-	"\x11ExecAttachRequest\x12&\n" +
+	"\x11AttachExecRequest\x12&\n" +
 	"\x0fclient_frame_id\x18\x0f \x01(\tR\rclientFrameId\x128\n" +
-	"\x05start\x18\x01 \x01(\v2 .agentcompose.v2.ExecAttachStartH\x00R\x05start\x124\n" +
+	"\x05start\x18\x01 \x01(\v2 .agentcompose.v2.AttachExecStartH\x00R\x05start\x124\n" +
 	"\x05stdin\x18\x02 \x01(\v2\x1c.agentcompose.v2.AttachStdinH\x00R\x05stdin\x12>\n" +
 	"\tstdin_eof\x18\x03 \x01(\v2\x1f.agentcompose.v2.AttachStdinEOFH\x00R\bstdinEof\x127\n" +
 	"\x06resize\x18\x04 \x01(\v2\x1d.agentcompose.v2.AttachResizeH\x00R\x06resize\x127\n" +
@@ -18715,7 +18717,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x06cancel\x18\x06 \x01(\v2\x1d.agentcompose.v2.AttachCancelH\x00R\x06cancel\x12J\n" +
 	"\rhuman_message\x18\a \x01(\v2#.agentcompose.v2.AttachHumanMessageH\x00R\fhumanMessageB\a\n" +
 	"\x05frame\"\x89\x04\n" +
-	"\x12ExecAttachResponse\x12&\n" +
+	"\x12AttachExecResponse\x12&\n" +
 	"\x0fserver_frame_id\x18\x0f \x01(\tR\rserverFrameId\x129\n" +
 	"\n" +
 	"created_at\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12:\n" +
@@ -18727,7 +18729,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"agentEvent\x12]\n" +
 	"\x14agent_turn_completed\x18\x06 \x01(\v2).agentcompose.v2.AttachAgentTurnCompletedH\x00R\x12agentTurnCompletedB\a\n" +
 	"\x05frame\"\x94\x02\n" +
-	"\x0fExecAttachStart\x126\n" +
+	"\x0fAttachExecStart\x126\n" +
 	"\arequest\x18\x01 \x01(\v2\x1c.agentcompose.v2.ExecRequestR\arequest\x12!\n" +
 	"\fattach_stdin\x18\x02 \x01(\bR\vattachStdin\x12\x10\n" +
 	"\x03tty\x18\x03 \x01(\bR\x03tty\x12H\n" +
@@ -19071,10 +19073,10 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1d\n" +
 	"\n" +
 	"guest_port\x18\x02 \x01(\rR\tguestPort\x12\x16\n" +
-	"\x06expose\x18\x03 \x01(\bR\x06expose\"E\n" +
-	"\x0fStartRunRequest\x122\n" +
-	"\x03run\x18\x01 \x01(\v2 .agentcompose.v2.RunAgentRequestR\x03run\"w\n" +
-	"\x10StartRunResponse\x12-\n" +
+	"\x06expose\x18\x03 \x01(\bR\x06expose\"J\n" +
+	"\x14StartAgentRunRequest\x122\n" +
+	"\x03run\x18\x01 \x01(\v2 .agentcompose.v2.RunAgentRequestR\x03run\"|\n" +
+	"\x15StartAgentRunResponse\x12-\n" +
 	"\x03run\x18\x01 \x01(\v2\x1b.agentcompose.v2.RunSummaryR\x03run\x12\x1a\n" +
 	"\bwarnings\x18\x02 \x03(\tR\bwarnings\x12\x18\n" +
 	"\astarted\x18\x03 \x01(\bR\astarted\"\xd9\x01\n" +
@@ -19379,22 +19381,22 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x1cRUN_EVENT_KIND_AGENT_MESSAGE\x10\x02\x12!\n" +
 	"\x1dRUN_EVENT_KIND_AGENT_ACTIVITY\x10\x03\x12\x19\n" +
 	"\x15RUN_EVENT_KIND_STATUS\x10\x04*\xea\x01\n" +
-	"\x17RunAgentStreamEventType\x12+\n" +
-	"'RUN_AGENT_STREAM_EVENT_TYPE_UNSPECIFIED\x10\x00\x12'\n" +
-	"#RUN_AGENT_STREAM_EVENT_TYPE_STARTED\x10\x01\x12&\n" +
-	"\"RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT\x10\x02\x12&\n" +
-	"\"RUN_AGENT_STREAM_EVENT_TYPE_STATUS\x10\x03\x12)\n" +
-	"%RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED\x10\x04*\xda\x01\n" +
+	"\x17StreamAgentRunEventType\x12+\n" +
+	"'STREAM_AGENT_RUN_EVENT_TYPE_UNSPECIFIED\x10\x00\x12'\n" +
+	"#STREAM_AGENT_RUN_EVENT_TYPE_STARTED\x10\x01\x12&\n" +
+	"\"STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT\x10\x02\x12&\n" +
+	"\"STREAM_AGENT_RUN_EVENT_TYPE_STATUS\x10\x03\x12)\n" +
+	"%STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED\x10\x04*\xda\x01\n" +
 	"\x17RunSandboxCleanupPolicy\x12*\n" +
 	"&RUN_SANDBOX_CLEANUP_POLICY_UNSPECIFIED\x10\x00\x121\n" +
 	"-RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION\x10\x01\x12+\n" +
 	"'RUN_SANDBOX_CLEANUP_POLICY_KEEP_RUNNING\x10\x02\x123\n" +
 	"/RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION\x10\x03*\xaa\x01\n" +
-	"\x13ExecStreamEventType\x12&\n" +
-	"\"EXEC_STREAM_EVENT_TYPE_UNSPECIFIED\x10\x00\x12\"\n" +
-	"\x1eEXEC_STREAM_EVENT_TYPE_STARTED\x10\x01\x12!\n" +
-	"\x1dEXEC_STREAM_EVENT_TYPE_OUTPUT\x10\x02\x12$\n" +
-	" EXEC_STREAM_EVENT_TYPE_COMPLETED\x10\x03*i\n" +
+	"\x13StreamExecEventType\x12&\n" +
+	"\"STREAM_EXEC_EVENT_TYPE_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eSTREAM_EXEC_EVENT_TYPE_STARTED\x10\x01\x12!\n" +
+	"\x1dSTREAM_EXEC_EVENT_TYPE_OUTPUT\x10\x02\x12$\n" +
+	" STREAM_EXEC_EVENT_TYPE_COMPLETED\x10\x03*i\n" +
 	"\rAttachRunMode\x12\x1f\n" +
 	"\x1bATTACH_RUN_MODE_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17ATTACH_RUN_MODE_COMMAND\x10\x01\x12\x1a\n" +
@@ -19482,13 +19484,13 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x12PruneSchedulerRuns\x12*.agentcompose.v2.PruneSchedulerRunsRequest\x1a+.agentcompose.v2.PruneSchedulerRunsResponse\x12g\n" +
 	"\x10StopSchedulerRun\x12(.agentcompose.v2.StopSchedulerRunRequest\x1a).agentcompose.v2.StopSchedulerRunResponse\x12p\n" +
 	"\x13SetSchedulerEnabled\x12+.agentcompose.v2.SetSchedulerEnabledRequest\x1a,.agentcompose.v2.SetSchedulerEnabledResponse\x12\x85\x01\n" +
-	"\x1aSetSchedulerTriggerEnabled\x122.agentcompose.v2.SetSchedulerTriggerEnabledRequest\x1a3.agentcompose.v2.SetSchedulerTriggerEnabledResponse2\xfc\x06\n" +
+	"\x1aSetSchedulerTriggerEnabled\x122.agentcompose.v2.SetSchedulerTriggerEnabledRequest\x1a3.agentcompose.v2.SetSchedulerTriggerEnabledResponse2\x9a\a\n" +
 	"\n" +
 	"RunService\x12O\n" +
-	"\bRunAgent\x12 .agentcompose.v2.RunAgentRequest\x1a!.agentcompose.v2.RunAgentResponse\x12O\n" +
-	"\bStartRun\x12 .agentcompose.v2.StartRunRequest\x1a!.agentcompose.v2.StartRunResponse\x12]\n" +
-	"\x0eRunAgentStream\x12 .agentcompose.v2.RunAgentRequest\x1a'.agentcompose.v2.RunAgentStreamResponse0\x01\x12V\n" +
-	"\tRunAttach\x12!.agentcompose.v2.RunAttachRequest\x1a\".agentcompose.v2.RunAttachResponse(\x010\x01\x12I\n" +
+	"\bRunAgent\x12 .agentcompose.v2.RunAgentRequest\x1a!.agentcompose.v2.RunAgentResponse\x12^\n" +
+	"\rStartAgentRun\x12%.agentcompose.v2.StartAgentRunRequest\x1a&.agentcompose.v2.StartAgentRunResponse\x12]\n" +
+	"\x0eStreamAgentRun\x12 .agentcompose.v2.RunAgentRequest\x1a'.agentcompose.v2.StreamAgentRunResponse0\x01\x12e\n" +
+	"\x0eAttachAgentRun\x12&.agentcompose.v2.AttachAgentRunRequest\x1a'.agentcompose.v2.AttachAgentRunResponse(\x010\x01\x12I\n" +
 	"\x06GetRun\x12\x1e.agentcompose.v2.GetRunRequest\x1a\x1f.agentcompose.v2.GetRunResponse\x12O\n" +
 	"\bListRuns\x12 .agentcompose.v2.ListRunsRequest\x1a!.agentcompose.v2.ListRunsResponse\x12V\n" +
 	"\rFollowRunLogs\x12%.agentcompose.v2.FollowRunLogsRequest\x1a\x1c.agentcompose.v2.RunLogChunk0\x01\x12L\n" +
@@ -19498,9 +19500,9 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\vExecService\x12C\n" +
 	"\x04Exec\x12\x1c.agentcompose.v2.ExecRequest\x1a\x1d.agentcompose.v2.ExecResponse\x12Q\n" +
 	"\n" +
-	"ExecStream\x12\x1c.agentcompose.v2.ExecRequest\x1a#.agentcompose.v2.ExecStreamResponse0\x01\x12Y\n" +
+	"StreamExec\x12\x1c.agentcompose.v2.ExecRequest\x1a#.agentcompose.v2.StreamExecResponse0\x01\x12Y\n" +
 	"\n" +
-	"ExecAttach\x12\".agentcompose.v2.ExecAttachRequest\x1a#.agentcompose.v2.ExecAttachResponse(\x010\x012\xc6\x03\n" +
+	"AttachExec\x12\".agentcompose.v2.AttachExecRequest\x1a#.agentcompose.v2.AttachExecResponse(\x010\x012\xc6\x03\n" +
 	"\fImageService\x12U\n" +
 	"\n" +
 	"ListImages\x12\".agentcompose.v2.ListImagesRequest\x1a#.agentcompose.v2.ListImagesResponse\x12R\n" +
@@ -19578,9 +19580,9 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectAgentAvailability)(0),                 // 6: agentcompose.v2.ProjectAgentAvailability
 	(ProjectAgentHealth)(0),                       // 7: agentcompose.v2.ProjectAgentHealth
 	(RunEventKind)(0),                             // 8: agentcompose.v2.RunEventKind
-	(RunAgentStreamEventType)(0),                  // 9: agentcompose.v2.RunAgentStreamEventType
+	(StreamAgentRunEventType)(0),                  // 9: agentcompose.v2.StreamAgentRunEventType
 	(RunSandboxCleanupPolicy)(0),                  // 10: agentcompose.v2.RunSandboxCleanupPolicy
-	(ExecStreamEventType)(0),                      // 11: agentcompose.v2.ExecStreamEventType
+	(StreamExecEventType)(0),                      // 11: agentcompose.v2.StreamExecEventType
 	(AttachRunMode)(0),                            // 12: agentcompose.v2.AttachRunMode
 	(StdioStream)(0),                              // 13: agentcompose.v2.StdioStream
 	(ImageStoreKind)(0),                           // 14: agentcompose.v2.ImageStoreKind
@@ -19668,10 +19670,10 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*MicrosandboxDriverSpec)(nil),                // 96: agentcompose.v2.MicrosandboxDriverSpec
 	(*RunAgentRequest)(nil),                       // 97: agentcompose.v2.RunAgentRequest
 	(*RunAgentResponse)(nil),                      // 98: agentcompose.v2.RunAgentResponse
-	(*RunAgentStreamResponse)(nil),                // 99: agentcompose.v2.RunAgentStreamResponse
-	(*RunAttachRequest)(nil),                      // 100: agentcompose.v2.RunAttachRequest
-	(*RunAttachResponse)(nil),                     // 101: agentcompose.v2.RunAttachResponse
-	(*RunAttachStart)(nil),                        // 102: agentcompose.v2.RunAttachStart
+	(*StreamAgentRunResponse)(nil),                // 99: agentcompose.v2.StreamAgentRunResponse
+	(*AttachAgentRunRequest)(nil),                 // 100: agentcompose.v2.AttachAgentRunRequest
+	(*AttachAgentRunResponse)(nil),                // 101: agentcompose.v2.AttachAgentRunResponse
+	(*AttachAgentRunStart)(nil),                   // 102: agentcompose.v2.AttachAgentRunStart
 	(*TranscriptEvent)(nil),                       // 103: agentcompose.v2.TranscriptEvent
 	(*GetRunRequest)(nil),                         // 104: agentcompose.v2.GetRunRequest
 	(*GetRunResponse)(nil),                        // 105: agentcompose.v2.GetRunResponse
@@ -19711,10 +19713,10 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*ExecSandboxSelector)(nil),                   // 139: agentcompose.v2.ExecSandboxSelector
 	(*ExecCommand)(nil),                           // 140: agentcompose.v2.ExecCommand
 	(*ExecResponse)(nil),                          // 141: agentcompose.v2.ExecResponse
-	(*ExecStreamResponse)(nil),                    // 142: agentcompose.v2.ExecStreamResponse
-	(*ExecAttachRequest)(nil),                     // 143: agentcompose.v2.ExecAttachRequest
-	(*ExecAttachResponse)(nil),                    // 144: agentcompose.v2.ExecAttachResponse
-	(*ExecAttachStart)(nil),                       // 145: agentcompose.v2.ExecAttachStart
+	(*StreamExecResponse)(nil),                    // 142: agentcompose.v2.StreamExecResponse
+	(*AttachExecRequest)(nil),                     // 143: agentcompose.v2.AttachExecRequest
+	(*AttachExecResponse)(nil),                    // 144: agentcompose.v2.AttachExecResponse
+	(*AttachExecStart)(nil),                       // 145: agentcompose.v2.AttachExecStart
 	(*AttachTerminalSize)(nil),                    // 146: agentcompose.v2.AttachTerminalSize
 	(*AttachStdin)(nil),                           // 147: agentcompose.v2.AttachStdin
 	(*AttachStdinEOF)(nil),                        // 148: agentcompose.v2.AttachStdinEOF
@@ -19769,8 +19771,8 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*ImagePullProgress)(nil),                     // 197: agentcompose.v2.ImagePullProgress
 	(*JupyterSpec)(nil),                           // 198: agentcompose.v2.JupyterSpec
 	(*RunJupyterSpec)(nil),                        // 199: agentcompose.v2.RunJupyterSpec
-	(*StartRunRequest)(nil),                       // 200: agentcompose.v2.StartRunRequest
-	(*StartRunResponse)(nil),                      // 201: agentcompose.v2.StartRunResponse
+	(*StartAgentRunRequest)(nil),                  // 200: agentcompose.v2.StartAgentRunRequest
+	(*StartAgentRunResponse)(nil),                 // 201: agentcompose.v2.StartAgentRunResponse
 	(*SkillSpec)(nil),                             // 202: agentcompose.v2.SkillSpec
 	(*ResolveResourceIDRequest)(nil),              // 203: agentcompose.v2.ResolveResourceIDRequest
 	(*ResolveResourceIDResponse)(nil),             // 204: agentcompose.v2.ResolveResourceIDResponse
@@ -19945,28 +19947,28 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	199, // 105: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
 	85,  // 106: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
 	137, // 107: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
-	9,   // 108: agentcompose.v2.RunAgentStreamResponse.event_type:type_name -> agentcompose.v2.RunAgentStreamEventType
-	136, // 109: agentcompose.v2.RunAgentStreamResponse.run:type_name -> agentcompose.v2.RunSummary
-	13,  // 110: agentcompose.v2.RunAgentStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	265, // 111: agentcompose.v2.RunAgentStreamResponse.created_at:type_name -> google.protobuf.Timestamp
-	103, // 112: agentcompose.v2.RunAgentStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	102, // 113: agentcompose.v2.RunAttachRequest.start:type_name -> agentcompose.v2.RunAttachStart
-	147, // 114: agentcompose.v2.RunAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	148, // 115: agentcompose.v2.RunAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	149, // 116: agentcompose.v2.RunAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	150, // 117: agentcompose.v2.RunAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	151, // 118: agentcompose.v2.RunAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	152, // 119: agentcompose.v2.RunAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	265, // 120: agentcompose.v2.RunAttachResponse.created_at:type_name -> google.protobuf.Timestamp
-	153, // 121: agentcompose.v2.RunAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	154, // 122: agentcompose.v2.RunAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	155, // 123: agentcompose.v2.RunAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	156, // 124: agentcompose.v2.RunAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	157, // 125: agentcompose.v2.RunAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	158, // 126: agentcompose.v2.RunAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	97,  // 127: agentcompose.v2.RunAttachStart.request:type_name -> agentcompose.v2.RunAgentRequest
-	12,  // 128: agentcompose.v2.RunAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
-	146, // 129: agentcompose.v2.RunAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	9,   // 108: agentcompose.v2.StreamAgentRunResponse.event_type:type_name -> agentcompose.v2.StreamAgentRunEventType
+	136, // 109: agentcompose.v2.StreamAgentRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	13,  // 110: agentcompose.v2.StreamAgentRunResponse.stream:type_name -> agentcompose.v2.StdioStream
+	265, // 111: agentcompose.v2.StreamAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
+	103, // 112: agentcompose.v2.StreamAgentRunResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	102, // 113: agentcompose.v2.AttachAgentRunRequest.start:type_name -> agentcompose.v2.AttachAgentRunStart
+	147, // 114: agentcompose.v2.AttachAgentRunRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	148, // 115: agentcompose.v2.AttachAgentRunRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	149, // 116: agentcompose.v2.AttachAgentRunRequest.resize:type_name -> agentcompose.v2.AttachResize
+	150, // 117: agentcompose.v2.AttachAgentRunRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	151, // 118: agentcompose.v2.AttachAgentRunRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	152, // 119: agentcompose.v2.AttachAgentRunRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	265, // 120: agentcompose.v2.AttachAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
+	153, // 121: agentcompose.v2.AttachAgentRunResponse.started:type_name -> agentcompose.v2.AttachStarted
+	154, // 122: agentcompose.v2.AttachAgentRunResponse.output:type_name -> agentcompose.v2.AttachOutput
+	155, // 123: agentcompose.v2.AttachAgentRunResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	156, // 124: agentcompose.v2.AttachAgentRunResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	157, // 125: agentcompose.v2.AttachAgentRunResponse.result:type_name -> agentcompose.v2.AttachResult
+	158, // 126: agentcompose.v2.AttachAgentRunResponse.error:type_name -> agentcompose.v2.AttachError
+	97,  // 127: agentcompose.v2.AttachAgentRunStart.request:type_name -> agentcompose.v2.RunAgentRequest
+	12,  // 128: agentcompose.v2.AttachAgentRunStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	146, // 129: agentcompose.v2.AttachAgentRunStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
 	13,  // 130: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
 	265, // 131: agentcompose.v2.TranscriptEvent.created_at:type_name -> google.protobuf.Timestamp
 	137, // 132: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
@@ -20017,27 +20019,27 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	140, // 177: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
 	87,  // 178: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
 	159, // 179: agentcompose.v2.ExecResponse.result:type_name -> agentcompose.v2.ExecResult
-	11,  // 180: agentcompose.v2.ExecStreamResponse.event_type:type_name -> agentcompose.v2.ExecStreamEventType
-	13,  // 181: agentcompose.v2.ExecStreamResponse.stream:type_name -> agentcompose.v2.StdioStream
-	159, // 182: agentcompose.v2.ExecStreamResponse.result:type_name -> agentcompose.v2.ExecResult
-	103, // 183: agentcompose.v2.ExecStreamResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	145, // 184: agentcompose.v2.ExecAttachRequest.start:type_name -> agentcompose.v2.ExecAttachStart
-	147, // 185: agentcompose.v2.ExecAttachRequest.stdin:type_name -> agentcompose.v2.AttachStdin
-	148, // 186: agentcompose.v2.ExecAttachRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
-	149, // 187: agentcompose.v2.ExecAttachRequest.resize:type_name -> agentcompose.v2.AttachResize
-	150, // 188: agentcompose.v2.ExecAttachRequest.signal:type_name -> agentcompose.v2.AttachSignal
-	152, // 189: agentcompose.v2.ExecAttachRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	151, // 190: agentcompose.v2.ExecAttachRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	265, // 191: agentcompose.v2.ExecAttachResponse.created_at:type_name -> google.protobuf.Timestamp
-	153, // 192: agentcompose.v2.ExecAttachResponse.started:type_name -> agentcompose.v2.AttachStarted
-	154, // 193: agentcompose.v2.ExecAttachResponse.output:type_name -> agentcompose.v2.AttachOutput
-	157, // 194: agentcompose.v2.ExecAttachResponse.result:type_name -> agentcompose.v2.AttachResult
-	158, // 195: agentcompose.v2.ExecAttachResponse.error:type_name -> agentcompose.v2.AttachError
-	155, // 196: agentcompose.v2.ExecAttachResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
-	156, // 197: agentcompose.v2.ExecAttachResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
-	138, // 198: agentcompose.v2.ExecAttachStart.request:type_name -> agentcompose.v2.ExecRequest
-	146, // 199: agentcompose.v2.ExecAttachStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	12,  // 200: agentcompose.v2.ExecAttachStart.mode:type_name -> agentcompose.v2.AttachRunMode
+	11,  // 180: agentcompose.v2.StreamExecResponse.event_type:type_name -> agentcompose.v2.StreamExecEventType
+	13,  // 181: agentcompose.v2.StreamExecResponse.stream:type_name -> agentcompose.v2.StdioStream
+	159, // 182: agentcompose.v2.StreamExecResponse.result:type_name -> agentcompose.v2.ExecResult
+	103, // 183: agentcompose.v2.StreamExecResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
+	145, // 184: agentcompose.v2.AttachExecRequest.start:type_name -> agentcompose.v2.AttachExecStart
+	147, // 185: agentcompose.v2.AttachExecRequest.stdin:type_name -> agentcompose.v2.AttachStdin
+	148, // 186: agentcompose.v2.AttachExecRequest.stdin_eof:type_name -> agentcompose.v2.AttachStdinEOF
+	149, // 187: agentcompose.v2.AttachExecRequest.resize:type_name -> agentcompose.v2.AttachResize
+	150, // 188: agentcompose.v2.AttachExecRequest.signal:type_name -> agentcompose.v2.AttachSignal
+	152, // 189: agentcompose.v2.AttachExecRequest.cancel:type_name -> agentcompose.v2.AttachCancel
+	151, // 190: agentcompose.v2.AttachExecRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
+	265, // 191: agentcompose.v2.AttachExecResponse.created_at:type_name -> google.protobuf.Timestamp
+	153, // 192: agentcompose.v2.AttachExecResponse.started:type_name -> agentcompose.v2.AttachStarted
+	154, // 193: agentcompose.v2.AttachExecResponse.output:type_name -> agentcompose.v2.AttachOutput
+	157, // 194: agentcompose.v2.AttachExecResponse.result:type_name -> agentcompose.v2.AttachResult
+	158, // 195: agentcompose.v2.AttachExecResponse.error:type_name -> agentcompose.v2.AttachError
+	155, // 196: agentcompose.v2.AttachExecResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
+	156, // 197: agentcompose.v2.AttachExecResponse.agent_turn_completed:type_name -> agentcompose.v2.AttachAgentTurnCompleted
+	138, // 198: agentcompose.v2.AttachExecStart.request:type_name -> agentcompose.v2.ExecRequest
+	146, // 199: agentcompose.v2.AttachExecStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
+	12,  // 200: agentcompose.v2.AttachExecStart.mode:type_name -> agentcompose.v2.AttachRunMode
 	146, // 201: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
 	256, // 202: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
 	136, // 203: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
@@ -20101,8 +20103,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	196, // 261: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
 	263, // 262: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
 	14,  // 263: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
-	97,  // 264: agentcompose.v2.StartRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
-	136, // 265: agentcompose.v2.StartRunResponse.run:type_name -> agentcompose.v2.RunSummary
+	97,  // 264: agentcompose.v2.StartAgentRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
+	136, // 265: agentcompose.v2.StartAgentRunResponse.run:type_name -> agentcompose.v2.RunSummary
 	22,  // 266: agentcompose.v2.ResolveResourceIDRequest.kinds:type_name -> agentcompose.v2.ResourceKind
 	205, // 267: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
 	22,  // 268: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
@@ -20163,9 +20165,9 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	73,  // 323: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
 	75,  // 324: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
 	97,  // 325: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	200, // 326: agentcompose.v2.RunService.StartRun:input_type -> agentcompose.v2.StartRunRequest
-	97,  // 327: agentcompose.v2.RunService.RunAgentStream:input_type -> agentcompose.v2.RunAgentRequest
-	100, // 328: agentcompose.v2.RunService.RunAttach:input_type -> agentcompose.v2.RunAttachRequest
+	200, // 326: agentcompose.v2.RunService.StartAgentRun:input_type -> agentcompose.v2.StartAgentRunRequest
+	97,  // 327: agentcompose.v2.RunService.StreamAgentRun:input_type -> agentcompose.v2.RunAgentRequest
+	100, // 328: agentcompose.v2.RunService.AttachAgentRun:input_type -> agentcompose.v2.AttachAgentRunRequest
 	104, // 329: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
 	106, // 330: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
 	108, // 331: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
@@ -20173,8 +20175,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	112, // 333: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
 	115, // 334: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
 	138, // 335: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	138, // 336: agentcompose.v2.ExecService.ExecStream:input_type -> agentcompose.v2.ExecRequest
-	143, // 337: agentcompose.v2.ExecService.ExecAttach:input_type -> agentcompose.v2.ExecAttachRequest
+	138, // 336: agentcompose.v2.ExecService.StreamExec:input_type -> agentcompose.v2.ExecRequest
+	143, // 337: agentcompose.v2.ExecService.AttachExec:input_type -> agentcompose.v2.AttachExecRequest
 	160, // 338: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
 	162, // 339: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
 	164, // 340: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
@@ -20236,9 +20238,9 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	74,  // 396: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
 	76,  // 397: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
 	98,  // 398: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	201, // 399: agentcompose.v2.RunService.StartRun:output_type -> agentcompose.v2.StartRunResponse
-	99,  // 400: agentcompose.v2.RunService.RunAgentStream:output_type -> agentcompose.v2.RunAgentStreamResponse
-	101, // 401: agentcompose.v2.RunService.RunAttach:output_type -> agentcompose.v2.RunAttachResponse
+	201, // 399: agentcompose.v2.RunService.StartAgentRun:output_type -> agentcompose.v2.StartAgentRunResponse
+	99,  // 400: agentcompose.v2.RunService.StreamAgentRun:output_type -> agentcompose.v2.StreamAgentRunResponse
+	101, // 401: agentcompose.v2.RunService.AttachAgentRun:output_type -> agentcompose.v2.AttachAgentRunResponse
 	105, // 402: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
 	107, // 403: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
 	109, // 404: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
@@ -20246,8 +20248,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	114, // 406: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
 	116, // 407: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
 	141, // 408: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	142, // 409: agentcompose.v2.ExecService.ExecStream:output_type -> agentcompose.v2.ExecStreamResponse
-	144, // 410: agentcompose.v2.ExecService.ExecAttach:output_type -> agentcompose.v2.ExecAttachResponse
+	142, // 409: agentcompose.v2.ExecService.StreamExec:output_type -> agentcompose.v2.StreamExecResponse
+	144, // 410: agentcompose.v2.ExecService.AttachExec:output_type -> agentcompose.v2.AttachExecResponse
 	161, // 411: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
 	163, // 412: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
 	165, // 413: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
@@ -20306,21 +20308,21 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 	file_agentcompose_v2_agentcompose_proto_msgTypes[57].OneofWrappers = []any{}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[64].OneofWrappers = []any{}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[76].OneofWrappers = []any{
-		(*RunAttachRequest_Start)(nil),
-		(*RunAttachRequest_Stdin)(nil),
-		(*RunAttachRequest_StdinEof)(nil),
-		(*RunAttachRequest_Resize)(nil),
-		(*RunAttachRequest_Signal)(nil),
-		(*RunAttachRequest_HumanMessage)(nil),
-		(*RunAttachRequest_Cancel)(nil),
+		(*AttachAgentRunRequest_Start)(nil),
+		(*AttachAgentRunRequest_Stdin)(nil),
+		(*AttachAgentRunRequest_StdinEof)(nil),
+		(*AttachAgentRunRequest_Resize)(nil),
+		(*AttachAgentRunRequest_Signal)(nil),
+		(*AttachAgentRunRequest_HumanMessage)(nil),
+		(*AttachAgentRunRequest_Cancel)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[77].OneofWrappers = []any{
-		(*RunAttachResponse_Started)(nil),
-		(*RunAttachResponse_Output)(nil),
-		(*RunAttachResponse_AgentEvent)(nil),
-		(*RunAttachResponse_AgentTurnCompleted)(nil),
-		(*RunAttachResponse_Result)(nil),
-		(*RunAttachResponse_Error)(nil),
+		(*AttachAgentRunResponse_Started)(nil),
+		(*AttachAgentRunResponse_Output)(nil),
+		(*AttachAgentRunResponse_AgentEvent)(nil),
+		(*AttachAgentRunResponse_AgentTurnCompleted)(nil),
+		(*AttachAgentRunResponse_Result)(nil),
+		(*AttachAgentRunResponse_Error)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[110].OneofWrappers = []any{}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[114].OneofWrappers = []any{
@@ -20329,21 +20331,21 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*ExecRequest_Selector)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[119].OneofWrappers = []any{
-		(*ExecAttachRequest_Start)(nil),
-		(*ExecAttachRequest_Stdin)(nil),
-		(*ExecAttachRequest_StdinEof)(nil),
-		(*ExecAttachRequest_Resize)(nil),
-		(*ExecAttachRequest_Signal)(nil),
-		(*ExecAttachRequest_Cancel)(nil),
-		(*ExecAttachRequest_HumanMessage)(nil),
+		(*AttachExecRequest_Start)(nil),
+		(*AttachExecRequest_Stdin)(nil),
+		(*AttachExecRequest_StdinEof)(nil),
+		(*AttachExecRequest_Resize)(nil),
+		(*AttachExecRequest_Signal)(nil),
+		(*AttachExecRequest_Cancel)(nil),
+		(*AttachExecRequest_HumanMessage)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[120].OneofWrappers = []any{
-		(*ExecAttachResponse_Started)(nil),
-		(*ExecAttachResponse_Output)(nil),
-		(*ExecAttachResponse_Result)(nil),
-		(*ExecAttachResponse_Error)(nil),
-		(*ExecAttachResponse_AgentEvent)(nil),
-		(*ExecAttachResponse_AgentTurnCompleted)(nil),
+		(*AttachExecResponse_Started)(nil),
+		(*AttachExecResponse_Output)(nil),
+		(*AttachExecResponse_Result)(nil),
+		(*AttachExecResponse_Error)(nil),
+		(*AttachExecResponse_AgentEvent)(nil),
+		(*AttachExecResponse_AgentTurnCompleted)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[195].OneofWrappers = []any{}
 	type x struct{}

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -18,8 +18,16 @@ service ProjectService {
   rpc ListSchedulerEvents(ListSchedulerEventsRequest) returns (ListSchedulerEventsResponse);
   rpc ListProjectSchedulerEvents(ListProjectSchedulerEventsRequest) returns (ListProjectSchedulerEventsResponse);
   rpc StreamProjectSchedulerEvents(StreamProjectSchedulerEventsRequest) returns (stream StreamProjectSchedulerEventsResponse);
+  // Invokes the scheduler directly and returns its value without creating a
+  // persistent SchedulerRun. Cancellation cancels the invocation.
   rpc InvokeScheduler(InvokeSchedulerRequest) returns (InvokeSchedulerResponse);
+  // Creates a persistent SchedulerRun and waits for it to reach a terminal
+  // state. The returned run is queryable with GetSchedulerRun and
+  // ListSchedulerRuns. Cancellation requests cancellation of the execution.
   rpc RunScheduler(RunSchedulerRequest) returns (RunSchedulerResponse);
+  // Creates a persistent SchedulerRun and returns after submission, without
+  // waiting for a terminal state. Disconnecting after submission does not
+  // cancel the run; use StopSchedulerRun to cancel it.
   rpc StartSchedulerRun(StartSchedulerRunRequest) returns (StartSchedulerRunResponse);
   rpc GetSchedulerRun(GetSchedulerRunRequest) returns (GetSchedulerRunResponse);
   rpc ListSchedulerRuns(ListSchedulerRunsRequest) returns (ListSchedulerRunsResponse);
@@ -32,13 +40,28 @@ service ProjectService {
 }
 
 service RunService {
+  // Creates a persistent Agent Run and waits for it to reach a terminal state.
+  // The final RunDetail is equivalent to GetRun for the returned run ID. Client
+  // cancellation requests cancellation of the execution and its cleanup policy
+  // still applies.
   rpc RunAgent(RunAgentRequest) returns (RunAgentResponse);
-  rpc StartRun(StartRunRequest) returns (StartRunResponse);
-  // Stable server-stream projection of RunAgent for non-interactive stream views.
-  // Interactive clients that need stdin, resize, signal, or multi-turn prompt
-  // attachment should use RunAttach.
-  rpc RunAgentStream(RunAgentRequest) returns (stream RunAgentStreamResponse);
-  rpc RunAttach(stream RunAttachRequest) returns (stream RunAttachResponse);
+  // Creates or reuses a persistent Agent Run and returns after submission.
+  // started is true only when this call returns a non-terminal run that has been
+  // scheduled for background execution. A false value means the returned run
+  // was already terminal; it never means that submission failed. Disconnecting
+  // after submission does not cancel the run; use StopRun to cancel it.
+  rpc StartAgentRun(StartAgentRunRequest) returns (StartAgentRunResponse);
+  // Creates a persistent Agent Run and projects started, output, status, and
+  // completed events for non-interactive clients. The completed run has the same
+  // terminal state and common fields as RunAgent/GetRun. Client cancellation
+  // requests cancellation of the execution and its cleanup policy still applies.
+  rpc StreamAgentRun(RunAgentRequest) returns (stream StreamAgentRunResponse);
+  // Starts an interactive Agent Run. The first client frame must be start and
+  // start may appear exactly once. Frames before start, duplicate start frames,
+  // and frames after a terminal server frame are invalid. stdin_eof closes only
+  // stdin; cancel requests cancellation of the execution. Client half-close or
+  // disconnection ends the attachment and requests cancellation of the run.
+  rpc AttachAgentRun(stream AttachAgentRunRequest) returns (stream AttachAgentRunResponse);
   rpc GetRun(GetRunRequest) returns (GetRunResponse);
   rpc ListRuns(ListRunsRequest) returns (ListRunsResponse);
   rpc FollowRunLogs(FollowRunLogsRequest) returns (stream RunLogChunk);
@@ -48,12 +71,19 @@ service RunService {
 }
 
 service ExecService {
+  // Executes a non-persistent command and waits for its final exit result.
+  // Cancellation requests cancellation of the command. Exec IDs, when emitted
+  // by streaming forms, are correlation IDs and are not queryable resources.
   rpc Exec(ExecRequest) returns (ExecResponse);
-  // Stable server-stream projection of Exec for non-interactive stream views.
-  // Interactive clients that need stdin, resize, or signal attachment should use
-  // ExecAttach.
-  rpc ExecStream(ExecRequest) returns (stream ExecStreamResponse);
-  rpc ExecAttach(stream ExecAttachRequest) returns (stream ExecAttachResponse);
+  // Executes a non-persistent command and projects output and the same final
+  // ExecResult returned by Exec. Client cancellation cancels the command.
+  rpc StreamExec(ExecRequest) returns (stream StreamExecResponse);
+  // Starts an interactive, non-persistent command. The first client frame must
+  // be start and start may appear exactly once. Frames before start, duplicate
+  // start frames, and frames after a terminal server frame are invalid.
+  // stdin_eof closes only stdin; cancel, half-close, or disconnection requests
+  // cancellation of the command.
+  rpc AttachExec(stream AttachExecRequest) returns (stream AttachExecResponse);
 }
 
 service ImageService {
@@ -188,12 +218,12 @@ enum RunEventKind {
   RUN_EVENT_KIND_STATUS = 4;
 }
 
-enum RunAgentStreamEventType {
-  RUN_AGENT_STREAM_EVENT_TYPE_UNSPECIFIED = 0;
-  RUN_AGENT_STREAM_EVENT_TYPE_STARTED = 1;
-  RUN_AGENT_STREAM_EVENT_TYPE_OUTPUT = 2;
-  RUN_AGENT_STREAM_EVENT_TYPE_STATUS = 3;
-  RUN_AGENT_STREAM_EVENT_TYPE_COMPLETED = 4;
+enum StreamAgentRunEventType {
+  STREAM_AGENT_RUN_EVENT_TYPE_UNSPECIFIED = 0;
+  STREAM_AGENT_RUN_EVENT_TYPE_STARTED = 1;
+  STREAM_AGENT_RUN_EVENT_TYPE_OUTPUT = 2;
+  STREAM_AGENT_RUN_EVENT_TYPE_STATUS = 3;
+  STREAM_AGENT_RUN_EVENT_TYPE_COMPLETED = 4;
 }
 
 enum RunSandboxCleanupPolicy {
@@ -204,11 +234,11 @@ enum RunSandboxCleanupPolicy {
   RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION = 3;
 }
 
-enum ExecStreamEventType {
-  EXEC_STREAM_EVENT_TYPE_UNSPECIFIED = 0;
-  EXEC_STREAM_EVENT_TYPE_STARTED = 1;
-  EXEC_STREAM_EVENT_TYPE_OUTPUT = 2;
-  EXEC_STREAM_EVENT_TYPE_COMPLETED = 3;
+enum StreamExecEventType {
+  STREAM_EXEC_EVENT_TYPE_UNSPECIFIED = 0;
+  STREAM_EXEC_EVENT_TYPE_STARTED = 1;
+  STREAM_EXEC_EVENT_TYPE_OUTPUT = 2;
+  STREAM_EXEC_EVENT_TYPE_COMPLETED = 3;
 }
 
 enum AttachRunMode {
@@ -878,6 +908,8 @@ message RunAgentRequest {
   string scheduler_id = 7;
   string trigger_id = 8;
   string output_schema_json = 9;
+  // Idempotency key scoped by project, agent, and run source. Retries with the
+  // same key resolve to the same persistent Run ID.
   string client_request_id = 10;
   string command = 11;
   RunJupyterSpec jupyter = 12;
@@ -892,8 +924,8 @@ message RunAgentResponse {
   repeated string warnings = 2;
 }
 
-message RunAgentStreamResponse {
-  RunAgentStreamEventType event_type = 1;
+message StreamAgentRunResponse {
+  StreamAgentRunEventType event_type = 1;
   RunSummary run = 2;
   string run_id = 3;
   string chunk = 4;
@@ -903,13 +935,13 @@ message RunAgentStreamResponse {
   TranscriptEvent transcript = 8;
 }
 
-message RunAttachRequest {
+message AttachAgentRunRequest {
   // Frame variants occupy the low-number range. Envelope metadata starts at
   // 15 so future frame variants can be added without moving metadata fields.
   string client_frame_id = 15;
 
   oneof frame {
-    RunAttachStart start = 1;
+    AttachAgentRunStart start = 1;
     AttachStdin stdin = 2;
     AttachStdinEOF stdin_eof = 3;
     AttachResize resize = 4;
@@ -919,7 +951,7 @@ message RunAttachRequest {
   }
 }
 
-message RunAttachResponse {
+message AttachAgentRunResponse {
   // Frame variants occupy the low-number range. Envelope metadata starts at
   // 15 so future frame variants can be added without moving metadata fields.
   string server_frame_id = 15;
@@ -935,7 +967,7 @@ message RunAttachResponse {
   }
 }
 
-message RunAttachStart {
+message AttachAgentRunStart {
   RunAgentRequest request = 1;
   AttachRunMode mode = 2;
   bool attach_stdin = 3;
@@ -1267,9 +1299,9 @@ message ExecResponse {
   ExecResult result = 1;
 }
 
-message ExecStreamResponse {
+message StreamExecResponse {
 
-  ExecStreamEventType event_type = 1;
+  StreamExecEventType event_type = 1;
   string exec_id = 2;
   string sandbox_id = 3;
   string run_id = 4;
@@ -1279,13 +1311,13 @@ message ExecStreamResponse {
   TranscriptEvent transcript = 8;
 }
 
-message ExecAttachRequest {
+message AttachExecRequest {
   // Frame variants occupy the low-number range. Envelope metadata starts at
   // 15 so future frame variants can be added without moving metadata fields.
   string client_frame_id = 15;
 
   oneof frame {
-    ExecAttachStart start = 1;
+    AttachExecStart start = 1;
     AttachStdin stdin = 2;
     AttachStdinEOF stdin_eof = 3;
     AttachResize resize = 4;
@@ -1295,7 +1327,7 @@ message ExecAttachRequest {
   }
 }
 
-message ExecAttachResponse {
+message AttachExecResponse {
   // Frame variants occupy the low-number range. Envelope metadata starts at
   // 15 so future frame variants can be added without moving metadata fields.
   string server_frame_id = 15;
@@ -1311,7 +1343,7 @@ message ExecAttachResponse {
   }
 }
 
-message ExecAttachStart {
+message AttachExecStart {
   ExecRequest request = 1;
   bool attach_stdin = 2;
   bool tty = 3;
@@ -1720,11 +1752,11 @@ message RunJupyterSpec {
   bool expose = 3;
 }
 
-message StartRunRequest {
+message StartAgentRunRequest {
   RunAgentRequest run = 1;
 }
 
-message StartRunResponse {
+message StartAgentRunResponse {
   RunSummary run = 1;
   repeated string warnings = 2;
   bool started = 3;

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -123,13 +123,15 @@ const (
 	ProjectServiceSetSchedulerTriggerEnabledProcedure = "/agentcompose.v2.ProjectService/SetSchedulerTriggerEnabled"
 	// RunServiceRunAgentProcedure is the fully-qualified name of the RunService's RunAgent RPC.
 	RunServiceRunAgentProcedure = "/agentcompose.v2.RunService/RunAgent"
-	// RunServiceStartRunProcedure is the fully-qualified name of the RunService's StartRun RPC.
-	RunServiceStartRunProcedure = "/agentcompose.v2.RunService/StartRun"
-	// RunServiceRunAgentStreamProcedure is the fully-qualified name of the RunService's RunAgentStream
+	// RunServiceStartAgentRunProcedure is the fully-qualified name of the RunService's StartAgentRun
 	// RPC.
-	RunServiceRunAgentStreamProcedure = "/agentcompose.v2.RunService/RunAgentStream"
-	// RunServiceRunAttachProcedure is the fully-qualified name of the RunService's RunAttach RPC.
-	RunServiceRunAttachProcedure = "/agentcompose.v2.RunService/RunAttach"
+	RunServiceStartAgentRunProcedure = "/agentcompose.v2.RunService/StartAgentRun"
+	// RunServiceStreamAgentRunProcedure is the fully-qualified name of the RunService's StreamAgentRun
+	// RPC.
+	RunServiceStreamAgentRunProcedure = "/agentcompose.v2.RunService/StreamAgentRun"
+	// RunServiceAttachAgentRunProcedure is the fully-qualified name of the RunService's AttachAgentRun
+	// RPC.
+	RunServiceAttachAgentRunProcedure = "/agentcompose.v2.RunService/AttachAgentRun"
 	// RunServiceGetRunProcedure is the fully-qualified name of the RunService's GetRun RPC.
 	RunServiceGetRunProcedure = "/agentcompose.v2.RunService/GetRun"
 	// RunServiceListRunsProcedure is the fully-qualified name of the RunService's ListRuns RPC.
@@ -147,10 +149,10 @@ const (
 	RunServiceListSandboxRunEventsProcedure = "/agentcompose.v2.RunService/ListSandboxRunEvents"
 	// ExecServiceExecProcedure is the fully-qualified name of the ExecService's Exec RPC.
 	ExecServiceExecProcedure = "/agentcompose.v2.ExecService/Exec"
-	// ExecServiceExecStreamProcedure is the fully-qualified name of the ExecService's ExecStream RPC.
-	ExecServiceExecStreamProcedure = "/agentcompose.v2.ExecService/ExecStream"
-	// ExecServiceExecAttachProcedure is the fully-qualified name of the ExecService's ExecAttach RPC.
-	ExecServiceExecAttachProcedure = "/agentcompose.v2.ExecService/ExecAttach"
+	// ExecServiceStreamExecProcedure is the fully-qualified name of the ExecService's StreamExec RPC.
+	ExecServiceStreamExecProcedure = "/agentcompose.v2.ExecService/StreamExec"
+	// ExecServiceAttachExecProcedure is the fully-qualified name of the ExecService's AttachExec RPC.
+	ExecServiceAttachExecProcedure = "/agentcompose.v2.ExecService/AttachExec"
 	// ImageServiceListImagesProcedure is the fully-qualified name of the ImageService's ListImages RPC.
 	ImageServiceListImagesProcedure = "/agentcompose.v2.ImageService/ListImages"
 	// ImageServicePullImageProcedure is the fully-qualified name of the ImageService's PullImage RPC.
@@ -275,8 +277,16 @@ type ProjectServiceClient interface {
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
 	ListProjectSchedulerEvents(context.Context, *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error)
 	StreamProjectSchedulerEvents(context.Context, *connect.Request[v2.StreamProjectSchedulerEventsRequest]) (*connect.ServerStreamForClient[v2.StreamProjectSchedulerEventsResponse], error)
+	// Invokes the scheduler directly and returns its value without creating a
+	// persistent SchedulerRun. Cancellation cancels the invocation.
 	InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error)
+	// Creates a persistent SchedulerRun and waits for it to reach a terminal
+	// state. The returned run is queryable with GetSchedulerRun and
+	// ListSchedulerRuns. Cancellation requests cancellation of the execution.
 	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
+	// Creates a persistent SchedulerRun and returns after submission, without
+	// waiting for a terminal state. Disconnecting after submission does not
+	// cancel the run; use StopSchedulerRun to cancel it.
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
@@ -583,8 +593,16 @@ type ProjectServiceHandler interface {
 	ListSchedulerEvents(context.Context, *connect.Request[v2.ListSchedulerEventsRequest]) (*connect.Response[v2.ListSchedulerEventsResponse], error)
 	ListProjectSchedulerEvents(context.Context, *connect.Request[v2.ListProjectSchedulerEventsRequest]) (*connect.Response[v2.ListProjectSchedulerEventsResponse], error)
 	StreamProjectSchedulerEvents(context.Context, *connect.Request[v2.StreamProjectSchedulerEventsRequest], *connect.ServerStream[v2.StreamProjectSchedulerEventsResponse]) error
+	// Invokes the scheduler directly and returns its value without creating a
+	// persistent SchedulerRun. Cancellation cancels the invocation.
 	InvokeScheduler(context.Context, *connect.Request[v2.InvokeSchedulerRequest]) (*connect.Response[v2.InvokeSchedulerResponse], error)
+	// Creates a persistent SchedulerRun and waits for it to reach a terminal
+	// state. The returned run is queryable with GetSchedulerRun and
+	// ListSchedulerRuns. Cancellation requests cancellation of the execution.
 	RunScheduler(context.Context, *connect.Request[v2.RunSchedulerRequest]) (*connect.Response[v2.RunSchedulerResponse], error)
+	// Creates a persistent SchedulerRun and returns after submission, without
+	// waiting for a terminal state. Disconnecting after submission does not
+	// cancel the run; use StopSchedulerRun to cancel it.
 	StartSchedulerRun(context.Context, *connect.Request[v2.StartSchedulerRunRequest]) (*connect.Response[v2.StartSchedulerRunResponse], error)
 	GetSchedulerRun(context.Context, *connect.Request[v2.GetSchedulerRunRequest]) (*connect.Response[v2.GetSchedulerRunResponse], error)
 	ListSchedulerRuns(context.Context, *connect.Request[v2.ListSchedulerRunsRequest]) (*connect.Response[v2.ListSchedulerRunsResponse], error)
@@ -880,13 +898,28 @@ func (UnimplementedProjectServiceHandler) SetSchedulerTriggerEnabled(context.Con
 
 // RunServiceClient is a client for the agentcompose.v2.RunService service.
 type RunServiceClient interface {
+	// Creates a persistent Agent Run and waits for it to reach a terminal state.
+	// The final RunDetail is equivalent to GetRun for the returned run ID. Client
+	// cancellation requests cancellation of the execution and its cleanup policy
+	// still applies.
 	RunAgent(context.Context, *connect.Request[v2.RunAgentRequest]) (*connect.Response[v2.RunAgentResponse], error)
-	StartRun(context.Context, *connect.Request[v2.StartRunRequest]) (*connect.Response[v2.StartRunResponse], error)
-	// Stable server-stream projection of RunAgent for non-interactive stream views.
-	// Interactive clients that need stdin, resize, signal, or multi-turn prompt
-	// attachment should use RunAttach.
-	RunAgentStream(context.Context, *connect.Request[v2.RunAgentRequest]) (*connect.ServerStreamForClient[v2.RunAgentStreamResponse], error)
-	RunAttach(context.Context) *connect.BidiStreamForClient[v2.RunAttachRequest, v2.RunAttachResponse]
+	// Creates or reuses a persistent Agent Run and returns after submission.
+	// started is true only when this call returns a non-terminal run that has been
+	// scheduled for background execution. A false value means the returned run
+	// was already terminal; it never means that submission failed. Disconnecting
+	// after submission does not cancel the run; use StopRun to cancel it.
+	StartAgentRun(context.Context, *connect.Request[v2.StartAgentRunRequest]) (*connect.Response[v2.StartAgentRunResponse], error)
+	// Creates a persistent Agent Run and projects started, output, status, and
+	// completed events for non-interactive clients. The completed run has the same
+	// terminal state and common fields as RunAgent/GetRun. Client cancellation
+	// requests cancellation of the execution and its cleanup policy still applies.
+	StreamAgentRun(context.Context, *connect.Request[v2.RunAgentRequest]) (*connect.ServerStreamForClient[v2.StreamAgentRunResponse], error)
+	// Starts an interactive Agent Run. The first client frame must be start and
+	// start may appear exactly once. Frames before start, duplicate start frames,
+	// and frames after a terminal server frame are invalid. stdin_eof closes only
+	// stdin; cancel requests cancellation of the execution. Client half-close or
+	// disconnection ends the attachment and requests cancellation of the run.
+	AttachAgentRun(context.Context) *connect.BidiStreamForClient[v2.AttachAgentRunRequest, v2.AttachAgentRunResponse]
 	GetRun(context.Context, *connect.Request[v2.GetRunRequest]) (*connect.Response[v2.GetRunResponse], error)
 	ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error)
 	FollowRunLogs(context.Context, *connect.Request[v2.FollowRunLogsRequest]) (*connect.ServerStreamForClient[v2.RunLogChunk], error)
@@ -912,22 +945,22 @@ func NewRunServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 			connect.WithSchema(runServiceMethods.ByName("RunAgent")),
 			connect.WithClientOptions(opts...),
 		),
-		startRun: connect.NewClient[v2.StartRunRequest, v2.StartRunResponse](
+		startAgentRun: connect.NewClient[v2.StartAgentRunRequest, v2.StartAgentRunResponse](
 			httpClient,
-			baseURL+RunServiceStartRunProcedure,
-			connect.WithSchema(runServiceMethods.ByName("StartRun")),
+			baseURL+RunServiceStartAgentRunProcedure,
+			connect.WithSchema(runServiceMethods.ByName("StartAgentRun")),
 			connect.WithClientOptions(opts...),
 		),
-		runAgentStream: connect.NewClient[v2.RunAgentRequest, v2.RunAgentStreamResponse](
+		streamAgentRun: connect.NewClient[v2.RunAgentRequest, v2.StreamAgentRunResponse](
 			httpClient,
-			baseURL+RunServiceRunAgentStreamProcedure,
-			connect.WithSchema(runServiceMethods.ByName("RunAgentStream")),
+			baseURL+RunServiceStreamAgentRunProcedure,
+			connect.WithSchema(runServiceMethods.ByName("StreamAgentRun")),
 			connect.WithClientOptions(opts...),
 		),
-		runAttach: connect.NewClient[v2.RunAttachRequest, v2.RunAttachResponse](
+		attachAgentRun: connect.NewClient[v2.AttachAgentRunRequest, v2.AttachAgentRunResponse](
 			httpClient,
-			baseURL+RunServiceRunAttachProcedure,
-			connect.WithSchema(runServiceMethods.ByName("RunAttach")),
+			baseURL+RunServiceAttachAgentRunProcedure,
+			connect.WithSchema(runServiceMethods.ByName("AttachAgentRun")),
 			connect.WithClientOptions(opts...),
 		),
 		getRun: connect.NewClient[v2.GetRunRequest, v2.GetRunResponse](
@@ -972,9 +1005,9 @@ func NewRunServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 // runServiceClient implements RunServiceClient.
 type runServiceClient struct {
 	runAgent             *connect.Client[v2.RunAgentRequest, v2.RunAgentResponse]
-	startRun             *connect.Client[v2.StartRunRequest, v2.StartRunResponse]
-	runAgentStream       *connect.Client[v2.RunAgentRequest, v2.RunAgentStreamResponse]
-	runAttach            *connect.Client[v2.RunAttachRequest, v2.RunAttachResponse]
+	startAgentRun        *connect.Client[v2.StartAgentRunRequest, v2.StartAgentRunResponse]
+	streamAgentRun       *connect.Client[v2.RunAgentRequest, v2.StreamAgentRunResponse]
+	attachAgentRun       *connect.Client[v2.AttachAgentRunRequest, v2.AttachAgentRunResponse]
 	getRun               *connect.Client[v2.GetRunRequest, v2.GetRunResponse]
 	listRuns             *connect.Client[v2.ListRunsRequest, v2.ListRunsResponse]
 	followRunLogs        *connect.Client[v2.FollowRunLogsRequest, v2.RunLogChunk]
@@ -988,19 +1021,19 @@ func (c *runServiceClient) RunAgent(ctx context.Context, req *connect.Request[v2
 	return c.runAgent.CallUnary(ctx, req)
 }
 
-// StartRun calls agentcompose.v2.RunService.StartRun.
-func (c *runServiceClient) StartRun(ctx context.Context, req *connect.Request[v2.StartRunRequest]) (*connect.Response[v2.StartRunResponse], error) {
-	return c.startRun.CallUnary(ctx, req)
+// StartAgentRun calls agentcompose.v2.RunService.StartAgentRun.
+func (c *runServiceClient) StartAgentRun(ctx context.Context, req *connect.Request[v2.StartAgentRunRequest]) (*connect.Response[v2.StartAgentRunResponse], error) {
+	return c.startAgentRun.CallUnary(ctx, req)
 }
 
-// RunAgentStream calls agentcompose.v2.RunService.RunAgentStream.
-func (c *runServiceClient) RunAgentStream(ctx context.Context, req *connect.Request[v2.RunAgentRequest]) (*connect.ServerStreamForClient[v2.RunAgentStreamResponse], error) {
-	return c.runAgentStream.CallServerStream(ctx, req)
+// StreamAgentRun calls agentcompose.v2.RunService.StreamAgentRun.
+func (c *runServiceClient) StreamAgentRun(ctx context.Context, req *connect.Request[v2.RunAgentRequest]) (*connect.ServerStreamForClient[v2.StreamAgentRunResponse], error) {
+	return c.streamAgentRun.CallServerStream(ctx, req)
 }
 
-// RunAttach calls agentcompose.v2.RunService.RunAttach.
-func (c *runServiceClient) RunAttach(ctx context.Context) *connect.BidiStreamForClient[v2.RunAttachRequest, v2.RunAttachResponse] {
-	return c.runAttach.CallBidiStream(ctx)
+// AttachAgentRun calls agentcompose.v2.RunService.AttachAgentRun.
+func (c *runServiceClient) AttachAgentRun(ctx context.Context) *connect.BidiStreamForClient[v2.AttachAgentRunRequest, v2.AttachAgentRunResponse] {
+	return c.attachAgentRun.CallBidiStream(ctx)
 }
 
 // GetRun calls agentcompose.v2.RunService.GetRun.
@@ -1035,13 +1068,28 @@ func (c *runServiceClient) ListSandboxRunEvents(ctx context.Context, req *connec
 
 // RunServiceHandler is an implementation of the agentcompose.v2.RunService service.
 type RunServiceHandler interface {
+	// Creates a persistent Agent Run and waits for it to reach a terminal state.
+	// The final RunDetail is equivalent to GetRun for the returned run ID. Client
+	// cancellation requests cancellation of the execution and its cleanup policy
+	// still applies.
 	RunAgent(context.Context, *connect.Request[v2.RunAgentRequest]) (*connect.Response[v2.RunAgentResponse], error)
-	StartRun(context.Context, *connect.Request[v2.StartRunRequest]) (*connect.Response[v2.StartRunResponse], error)
-	// Stable server-stream projection of RunAgent for non-interactive stream views.
-	// Interactive clients that need stdin, resize, signal, or multi-turn prompt
-	// attachment should use RunAttach.
-	RunAgentStream(context.Context, *connect.Request[v2.RunAgentRequest], *connect.ServerStream[v2.RunAgentStreamResponse]) error
-	RunAttach(context.Context, *connect.BidiStream[v2.RunAttachRequest, v2.RunAttachResponse]) error
+	// Creates or reuses a persistent Agent Run and returns after submission.
+	// started is true only when this call returns a non-terminal run that has been
+	// scheduled for background execution. A false value means the returned run
+	// was already terminal; it never means that submission failed. Disconnecting
+	// after submission does not cancel the run; use StopRun to cancel it.
+	StartAgentRun(context.Context, *connect.Request[v2.StartAgentRunRequest]) (*connect.Response[v2.StartAgentRunResponse], error)
+	// Creates a persistent Agent Run and projects started, output, status, and
+	// completed events for non-interactive clients. The completed run has the same
+	// terminal state and common fields as RunAgent/GetRun. Client cancellation
+	// requests cancellation of the execution and its cleanup policy still applies.
+	StreamAgentRun(context.Context, *connect.Request[v2.RunAgentRequest], *connect.ServerStream[v2.StreamAgentRunResponse]) error
+	// Starts an interactive Agent Run. The first client frame must be start and
+	// start may appear exactly once. Frames before start, duplicate start frames,
+	// and frames after a terminal server frame are invalid. stdin_eof closes only
+	// stdin; cancel requests cancellation of the execution. Client half-close or
+	// disconnection ends the attachment and requests cancellation of the run.
+	AttachAgentRun(context.Context, *connect.BidiStream[v2.AttachAgentRunRequest, v2.AttachAgentRunResponse]) error
 	GetRun(context.Context, *connect.Request[v2.GetRunRequest]) (*connect.Response[v2.GetRunResponse], error)
 	ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error)
 	FollowRunLogs(context.Context, *connect.Request[v2.FollowRunLogsRequest], *connect.ServerStream[v2.RunLogChunk]) error
@@ -1063,22 +1111,22 @@ func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) 
 		connect.WithSchema(runServiceMethods.ByName("RunAgent")),
 		connect.WithHandlerOptions(opts...),
 	)
-	runServiceStartRunHandler := connect.NewUnaryHandler(
-		RunServiceStartRunProcedure,
-		svc.StartRun,
-		connect.WithSchema(runServiceMethods.ByName("StartRun")),
+	runServiceStartAgentRunHandler := connect.NewUnaryHandler(
+		RunServiceStartAgentRunProcedure,
+		svc.StartAgentRun,
+		connect.WithSchema(runServiceMethods.ByName("StartAgentRun")),
 		connect.WithHandlerOptions(opts...),
 	)
-	runServiceRunAgentStreamHandler := connect.NewServerStreamHandler(
-		RunServiceRunAgentStreamProcedure,
-		svc.RunAgentStream,
-		connect.WithSchema(runServiceMethods.ByName("RunAgentStream")),
+	runServiceStreamAgentRunHandler := connect.NewServerStreamHandler(
+		RunServiceStreamAgentRunProcedure,
+		svc.StreamAgentRun,
+		connect.WithSchema(runServiceMethods.ByName("StreamAgentRun")),
 		connect.WithHandlerOptions(opts...),
 	)
-	runServiceRunAttachHandler := connect.NewBidiStreamHandler(
-		RunServiceRunAttachProcedure,
-		svc.RunAttach,
-		connect.WithSchema(runServiceMethods.ByName("RunAttach")),
+	runServiceAttachAgentRunHandler := connect.NewBidiStreamHandler(
+		RunServiceAttachAgentRunProcedure,
+		svc.AttachAgentRun,
+		connect.WithSchema(runServiceMethods.ByName("AttachAgentRun")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceGetRunHandler := connect.NewUnaryHandler(
@@ -1121,12 +1169,12 @@ func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) 
 		switch r.URL.Path {
 		case RunServiceRunAgentProcedure:
 			runServiceRunAgentHandler.ServeHTTP(w, r)
-		case RunServiceStartRunProcedure:
-			runServiceStartRunHandler.ServeHTTP(w, r)
-		case RunServiceRunAgentStreamProcedure:
-			runServiceRunAgentStreamHandler.ServeHTTP(w, r)
-		case RunServiceRunAttachProcedure:
-			runServiceRunAttachHandler.ServeHTTP(w, r)
+		case RunServiceStartAgentRunProcedure:
+			runServiceStartAgentRunHandler.ServeHTTP(w, r)
+		case RunServiceStreamAgentRunProcedure:
+			runServiceStreamAgentRunHandler.ServeHTTP(w, r)
+		case RunServiceAttachAgentRunProcedure:
+			runServiceAttachAgentRunHandler.ServeHTTP(w, r)
 		case RunServiceGetRunProcedure:
 			runServiceGetRunHandler.ServeHTTP(w, r)
 		case RunServiceListRunsProcedure:
@@ -1152,16 +1200,16 @@ func (UnimplementedRunServiceHandler) RunAgent(context.Context, *connect.Request
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.RunService.RunAgent is not implemented"))
 }
 
-func (UnimplementedRunServiceHandler) StartRun(context.Context, *connect.Request[v2.StartRunRequest]) (*connect.Response[v2.StartRunResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.RunService.StartRun is not implemented"))
+func (UnimplementedRunServiceHandler) StartAgentRun(context.Context, *connect.Request[v2.StartAgentRunRequest]) (*connect.Response[v2.StartAgentRunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.RunService.StartAgentRun is not implemented"))
 }
 
-func (UnimplementedRunServiceHandler) RunAgentStream(context.Context, *connect.Request[v2.RunAgentRequest], *connect.ServerStream[v2.RunAgentStreamResponse]) error {
-	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.RunService.RunAgentStream is not implemented"))
+func (UnimplementedRunServiceHandler) StreamAgentRun(context.Context, *connect.Request[v2.RunAgentRequest], *connect.ServerStream[v2.StreamAgentRunResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.RunService.StreamAgentRun is not implemented"))
 }
 
-func (UnimplementedRunServiceHandler) RunAttach(context.Context, *connect.BidiStream[v2.RunAttachRequest, v2.RunAttachResponse]) error {
-	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.RunService.RunAttach is not implemented"))
+func (UnimplementedRunServiceHandler) AttachAgentRun(context.Context, *connect.BidiStream[v2.AttachAgentRunRequest, v2.AttachAgentRunResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.RunService.AttachAgentRun is not implemented"))
 }
 
 func (UnimplementedRunServiceHandler) GetRun(context.Context, *connect.Request[v2.GetRunRequest]) (*connect.Response[v2.GetRunResponse], error) {
@@ -1190,12 +1238,19 @@ func (UnimplementedRunServiceHandler) ListSandboxRunEvents(context.Context, *con
 
 // ExecServiceClient is a client for the agentcompose.v2.ExecService service.
 type ExecServiceClient interface {
+	// Executes a non-persistent command and waits for its final exit result.
+	// Cancellation requests cancellation of the command. Exec IDs, when emitted
+	// by streaming forms, are correlation IDs and are not queryable resources.
 	Exec(context.Context, *connect.Request[v2.ExecRequest]) (*connect.Response[v2.ExecResponse], error)
-	// Stable server-stream projection of Exec for non-interactive stream views.
-	// Interactive clients that need stdin, resize, or signal attachment should use
-	// ExecAttach.
-	ExecStream(context.Context, *connect.Request[v2.ExecRequest]) (*connect.ServerStreamForClient[v2.ExecStreamResponse], error)
-	ExecAttach(context.Context) *connect.BidiStreamForClient[v2.ExecAttachRequest, v2.ExecAttachResponse]
+	// Executes a non-persistent command and projects output and the same final
+	// ExecResult returned by Exec. Client cancellation cancels the command.
+	StreamExec(context.Context, *connect.Request[v2.ExecRequest]) (*connect.ServerStreamForClient[v2.StreamExecResponse], error)
+	// Starts an interactive, non-persistent command. The first client frame must
+	// be start and start may appear exactly once. Frames before start, duplicate
+	// start frames, and frames after a terminal server frame are invalid.
+	// stdin_eof closes only stdin; cancel, half-close, or disconnection requests
+	// cancellation of the command.
+	AttachExec(context.Context) *connect.BidiStreamForClient[v2.AttachExecRequest, v2.AttachExecResponse]
 }
 
 // NewExecServiceClient constructs a client for the agentcompose.v2.ExecService service. By default,
@@ -1215,16 +1270,16 @@ func NewExecServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(execServiceMethods.ByName("Exec")),
 			connect.WithClientOptions(opts...),
 		),
-		execStream: connect.NewClient[v2.ExecRequest, v2.ExecStreamResponse](
+		streamExec: connect.NewClient[v2.ExecRequest, v2.StreamExecResponse](
 			httpClient,
-			baseURL+ExecServiceExecStreamProcedure,
-			connect.WithSchema(execServiceMethods.ByName("ExecStream")),
+			baseURL+ExecServiceStreamExecProcedure,
+			connect.WithSchema(execServiceMethods.ByName("StreamExec")),
 			connect.WithClientOptions(opts...),
 		),
-		execAttach: connect.NewClient[v2.ExecAttachRequest, v2.ExecAttachResponse](
+		attachExec: connect.NewClient[v2.AttachExecRequest, v2.AttachExecResponse](
 			httpClient,
-			baseURL+ExecServiceExecAttachProcedure,
-			connect.WithSchema(execServiceMethods.ByName("ExecAttach")),
+			baseURL+ExecServiceAttachExecProcedure,
+			connect.WithSchema(execServiceMethods.ByName("AttachExec")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -1233,8 +1288,8 @@ func NewExecServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 // execServiceClient implements ExecServiceClient.
 type execServiceClient struct {
 	exec       *connect.Client[v2.ExecRequest, v2.ExecResponse]
-	execStream *connect.Client[v2.ExecRequest, v2.ExecStreamResponse]
-	execAttach *connect.Client[v2.ExecAttachRequest, v2.ExecAttachResponse]
+	streamExec *connect.Client[v2.ExecRequest, v2.StreamExecResponse]
+	attachExec *connect.Client[v2.AttachExecRequest, v2.AttachExecResponse]
 }
 
 // Exec calls agentcompose.v2.ExecService.Exec.
@@ -1242,24 +1297,31 @@ func (c *execServiceClient) Exec(ctx context.Context, req *connect.Request[v2.Ex
 	return c.exec.CallUnary(ctx, req)
 }
 
-// ExecStream calls agentcompose.v2.ExecService.ExecStream.
-func (c *execServiceClient) ExecStream(ctx context.Context, req *connect.Request[v2.ExecRequest]) (*connect.ServerStreamForClient[v2.ExecStreamResponse], error) {
-	return c.execStream.CallServerStream(ctx, req)
+// StreamExec calls agentcompose.v2.ExecService.StreamExec.
+func (c *execServiceClient) StreamExec(ctx context.Context, req *connect.Request[v2.ExecRequest]) (*connect.ServerStreamForClient[v2.StreamExecResponse], error) {
+	return c.streamExec.CallServerStream(ctx, req)
 }
 
-// ExecAttach calls agentcompose.v2.ExecService.ExecAttach.
-func (c *execServiceClient) ExecAttach(ctx context.Context) *connect.BidiStreamForClient[v2.ExecAttachRequest, v2.ExecAttachResponse] {
-	return c.execAttach.CallBidiStream(ctx)
+// AttachExec calls agentcompose.v2.ExecService.AttachExec.
+func (c *execServiceClient) AttachExec(ctx context.Context) *connect.BidiStreamForClient[v2.AttachExecRequest, v2.AttachExecResponse] {
+	return c.attachExec.CallBidiStream(ctx)
 }
 
 // ExecServiceHandler is an implementation of the agentcompose.v2.ExecService service.
 type ExecServiceHandler interface {
+	// Executes a non-persistent command and waits for its final exit result.
+	// Cancellation requests cancellation of the command. Exec IDs, when emitted
+	// by streaming forms, are correlation IDs and are not queryable resources.
 	Exec(context.Context, *connect.Request[v2.ExecRequest]) (*connect.Response[v2.ExecResponse], error)
-	// Stable server-stream projection of Exec for non-interactive stream views.
-	// Interactive clients that need stdin, resize, or signal attachment should use
-	// ExecAttach.
-	ExecStream(context.Context, *connect.Request[v2.ExecRequest], *connect.ServerStream[v2.ExecStreamResponse]) error
-	ExecAttach(context.Context, *connect.BidiStream[v2.ExecAttachRequest, v2.ExecAttachResponse]) error
+	// Executes a non-persistent command and projects output and the same final
+	// ExecResult returned by Exec. Client cancellation cancels the command.
+	StreamExec(context.Context, *connect.Request[v2.ExecRequest], *connect.ServerStream[v2.StreamExecResponse]) error
+	// Starts an interactive, non-persistent command. The first client frame must
+	// be start and start may appear exactly once. Frames before start, duplicate
+	// start frames, and frames after a terminal server frame are invalid.
+	// stdin_eof closes only stdin; cancel, half-close, or disconnection requests
+	// cancellation of the command.
+	AttachExec(context.Context, *connect.BidiStream[v2.AttachExecRequest, v2.AttachExecResponse]) error
 }
 
 // NewExecServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -1275,26 +1337,26 @@ func NewExecServiceHandler(svc ExecServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(execServiceMethods.ByName("Exec")),
 		connect.WithHandlerOptions(opts...),
 	)
-	execServiceExecStreamHandler := connect.NewServerStreamHandler(
-		ExecServiceExecStreamProcedure,
-		svc.ExecStream,
-		connect.WithSchema(execServiceMethods.ByName("ExecStream")),
+	execServiceStreamExecHandler := connect.NewServerStreamHandler(
+		ExecServiceStreamExecProcedure,
+		svc.StreamExec,
+		connect.WithSchema(execServiceMethods.ByName("StreamExec")),
 		connect.WithHandlerOptions(opts...),
 	)
-	execServiceExecAttachHandler := connect.NewBidiStreamHandler(
-		ExecServiceExecAttachProcedure,
-		svc.ExecAttach,
-		connect.WithSchema(execServiceMethods.ByName("ExecAttach")),
+	execServiceAttachExecHandler := connect.NewBidiStreamHandler(
+		ExecServiceAttachExecProcedure,
+		svc.AttachExec,
+		connect.WithSchema(execServiceMethods.ByName("AttachExec")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/agentcompose.v2.ExecService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ExecServiceExecProcedure:
 			execServiceExecHandler.ServeHTTP(w, r)
-		case ExecServiceExecStreamProcedure:
-			execServiceExecStreamHandler.ServeHTTP(w, r)
-		case ExecServiceExecAttachProcedure:
-			execServiceExecAttachHandler.ServeHTTP(w, r)
+		case ExecServiceStreamExecProcedure:
+			execServiceStreamExecHandler.ServeHTTP(w, r)
+		case ExecServiceAttachExecProcedure:
+			execServiceAttachExecHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -1308,12 +1370,12 @@ func (UnimplementedExecServiceHandler) Exec(context.Context, *connect.Request[v2
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ExecService.Exec is not implemented"))
 }
 
-func (UnimplementedExecServiceHandler) ExecStream(context.Context, *connect.Request[v2.ExecRequest], *connect.ServerStream[v2.ExecStreamResponse]) error {
-	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ExecService.ExecStream is not implemented"))
+func (UnimplementedExecServiceHandler) StreamExec(context.Context, *connect.Request[v2.ExecRequest], *connect.ServerStream[v2.StreamExecResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ExecService.StreamExec is not implemented"))
 }
 
-func (UnimplementedExecServiceHandler) ExecAttach(context.Context, *connect.BidiStream[v2.ExecAttachRequest, v2.ExecAttachResponse]) error {
-	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ExecService.ExecAttach is not implemented"))
+func (UnimplementedExecServiceHandler) AttachExec(context.Context, *connect.BidiStream[v2.AttachExecRequest, v2.AttachExecResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.ExecService.AttachExec is not implemented"))
 }
 
 // ImageServiceClient is a client for the agentcompose.v2.ImageService service.

--- a/proto/agentcompose/v2/execution_rpc_contract_test.go
+++ b/proto/agentcompose/v2/execution_rpc_contract_test.go
@@ -1,0 +1,82 @@
+package agentcomposev2
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestExecutionRPCNamesAndStreamingShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		service         protoreflect.Name
+		method          protoreflect.Name
+		input           protoreflect.FullName
+		output          protoreflect.FullName
+		clientStreaming bool
+		serverStreaming bool
+	}{
+		{"RunService", "RunAgent", "agentcompose.v2.RunAgentRequest", "agentcompose.v2.RunAgentResponse", false, false},
+		{"RunService", "StartAgentRun", "agentcompose.v2.StartAgentRunRequest", "agentcompose.v2.StartAgentRunResponse", false, false},
+		{"RunService", "StreamAgentRun", "agentcompose.v2.RunAgentRequest", "agentcompose.v2.StreamAgentRunResponse", false, true},
+		{"RunService", "AttachAgentRun", "agentcompose.v2.AttachAgentRunRequest", "agentcompose.v2.AttachAgentRunResponse", true, true},
+		{"ExecService", "Exec", "agentcompose.v2.ExecRequest", "agentcompose.v2.ExecResponse", false, false},
+		{"ExecService", "StreamExec", "agentcompose.v2.ExecRequest", "agentcompose.v2.StreamExecResponse", false, true},
+		{"ExecService", "AttachExec", "agentcompose.v2.AttachExecRequest", "agentcompose.v2.AttachExecResponse", true, true},
+		{"ProjectService", "InvokeScheduler", "agentcompose.v2.InvokeSchedulerRequest", "agentcompose.v2.InvokeSchedulerResponse", false, false},
+		{"ProjectService", "RunScheduler", "agentcompose.v2.RunSchedulerRequest", "agentcompose.v2.RunSchedulerResponse", false, false},
+		{"ProjectService", "StartSchedulerRun", "agentcompose.v2.StartSchedulerRunRequest", "agentcompose.v2.StartSchedulerRunResponse", false, false},
+	}
+
+	services := File_agentcompose_v2_agentcompose_proto.Services()
+	for _, test := range tests {
+		t.Run(string(test.service)+"/"+string(test.method), func(t *testing.T) {
+			service := services.ByName(test.service)
+			if service == nil {
+				t.Fatalf("service %q not found", test.service)
+			}
+			method := service.Methods().ByName(test.method)
+			if method == nil {
+				t.Fatalf("method %q not found", test.method)
+			}
+			if got := method.Input().FullName(); got != test.input {
+				t.Errorf("input = %q, want %q", got, test.input)
+			}
+			if got := method.Output().FullName(); got != test.output {
+				t.Errorf("output = %q, want %q", got, test.output)
+			}
+			if got := method.IsStreamingClient(); got != test.clientStreaming {
+				t.Errorf("client streaming = %t, want %t", got, test.clientStreaming)
+			}
+			if got := method.IsStreamingServer(); got != test.serverStreaming {
+				t.Errorf("server streaming = %t, want %t", got, test.serverStreaming)
+			}
+		})
+	}
+}
+
+func TestLegacyExecutionRPCNamesAreNotExposed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		service protoreflect.Name
+		methods []protoreflect.Name
+	}{
+		{"RunService", []protoreflect.Name{"StartRun", "RunAgentStream", "RunAttach"}},
+		{"ExecService", []protoreflect.Name{"ExecStream", "ExecAttach"}},
+	}
+
+	services := File_agentcompose_v2_agentcompose_proto.Services()
+	for _, test := range tests {
+		service := services.ByName(test.service)
+		if service == nil {
+			t.Fatalf("service %q not found", test.service)
+		}
+		for _, method := range test.methods {
+			if service.Methods().ByName(method) != nil {
+				t.Errorf("legacy method %s/%s is still exposed", test.service, method)
+			}
+		}
+	}
+}

--- a/proto/agentcompose/v2/field_layout_contract_test.go
+++ b/proto/agentcompose/v2/field_layout_contract_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestV2FieldNumbersHaveNoUnexplainedGaps(t *testing.T) {
 	intentionalGaps := map[protoreflect.FullName]map[protoreflect.FieldNumber]struct{}{
-		"agentcompose.v2.RunAttachRequest":   fieldNumberRange(8, 14),
-		"agentcompose.v2.RunAttachResponse":  fieldNumberRange(7, 14),
-		"agentcompose.v2.ExecAttachRequest":  fieldNumberRange(8, 14),
-		"agentcompose.v2.ExecAttachResponse": fieldNumberRange(7, 14),
+		"agentcompose.v2.AttachAgentRunRequest":  fieldNumberRange(8, 14),
+		"agentcompose.v2.AttachAgentRunResponse": fieldNumberRange(7, 14),
+		"agentcompose.v2.AttachExecRequest":      fieldNumberRange(8, 14),
+		"agentcompose.v2.AttachExecResponse":     fieldNumberRange(7, 14),
 	}
 
 	assertMessageNumbersHaveNoGaps(t, File_agentcompose_v2_agentcompose_proto.Messages(), intentionalGaps)
@@ -21,19 +21,19 @@ func TestV2FieldNumbersHaveNoUnexplainedGaps(t *testing.T) {
 
 func TestV2FreezeFieldLayout(t *testing.T) {
 	want := map[protoreflect.FullName]map[protoreflect.Name]protoreflect.FieldNumber{
-		"agentcompose.v2.ProjectScheduler":   {"enabled": 4, "description": 7},
-		"agentcompose.v2.ProjectSpec":        {"agents": 3, "octobus_servers": 7},
-		"agentcompose.v2.RunAgentRequest":    {"env": 5, "payload_json": 16},
-		"agentcompose.v2.ListRunsRequest":    {"scheduler_id": 3, "sandbox_id": 10},
-		"agentcompose.v2.RunSummary":         {"exit_code": 11, "sandbox_short_id": 21},
-		"agentcompose.v2.TranscriptEvent":    {"name": 3, "created_at": 5},
-		"agentcompose.v2.ListImagesResponse": {"store_status": 3},
-		"agentcompose.v2.PruneCachesRequest": {"force": 2},
-		"agentcompose.v2.CacheItem":          {"status": 10, "warnings": 16},
-		"agentcompose.v2.RunAttachRequest":   {"start": 1, "cancel": 7, "client_frame_id": 15},
-		"agentcompose.v2.RunAttachResponse":  {"started": 1, "error": 6, "server_frame_id": 15, "created_at": 16},
-		"agentcompose.v2.ExecAttachRequest":  {"start": 1, "human_message": 7, "client_frame_id": 15},
-		"agentcompose.v2.ExecAttachResponse": {"started": 1, "agent_turn_completed": 6, "server_frame_id": 15, "created_at": 16},
+		"agentcompose.v2.ProjectScheduler":       {"enabled": 4, "description": 7},
+		"agentcompose.v2.ProjectSpec":            {"agents": 3, "octobus_servers": 7},
+		"agentcompose.v2.RunAgentRequest":        {"env": 5, "payload_json": 16},
+		"agentcompose.v2.ListRunsRequest":        {"scheduler_id": 3, "sandbox_id": 10},
+		"agentcompose.v2.RunSummary":             {"exit_code": 11, "sandbox_short_id": 21},
+		"agentcompose.v2.TranscriptEvent":        {"name": 3, "created_at": 5},
+		"agentcompose.v2.ListImagesResponse":     {"store_status": 3},
+		"agentcompose.v2.PruneCachesRequest":     {"force": 2},
+		"agentcompose.v2.CacheItem":              {"status": 10, "warnings": 16},
+		"agentcompose.v2.AttachAgentRunRequest":  {"start": 1, "cancel": 7, "client_frame_id": 15},
+		"agentcompose.v2.AttachAgentRunResponse": {"started": 1, "error": 6, "server_frame_id": 15, "created_at": 16},
+		"agentcompose.v2.AttachExecRequest":      {"start": 1, "human_message": 7, "client_frame_id": 15},
+		"agentcompose.v2.AttachExecResponse":     {"started": 1, "agent_turn_completed": 6, "server_frame_id": 15, "created_at": 16},
 	}
 
 	messages := File_agentcompose_v2_agentcompose_proto.Messages()


### PR DESCRIPTION
## Summary

- Normalize the v2 execution RPCs around verb-first, unambiguous names: `StartAgentRun`, `StreamAgentRun`, `AttachAgentRun`, `StreamExec`, and `AttachExec`.
- Rename the associated request, response, start-frame, and event types while preserving protobuf field numbers and enum values, then regenerate the Go and Connect sources.
- Update daemon handlers, CLI clients, fallback paths, tests, and English/Chinese documentation to use the new contract.
- Document persistent-resource, return-timing, streaming, cancellation, and Scheduler invocation semantics in the proto comments.
- Add descriptor-level contract tests that fix the new RPC names and streaming shapes and prevent the legacy names from being exposed again.

Refs #476

## Testing

- `go test ./proto/agentcompose/v2 ./pkg/agentcompose/api ./pkg/agentcompose/app ./cmd/agent-compose`
- `task lint`
- `task build`
- `task docs:build`
- `task test` — deployment/script checks passed, but the unit coverage phase failed in existing `pkg/agentcompose/adapters` sandbox RPC bridge tests because `AGENT_COMPOSE_RUNTIME_BASE_URL` is not configured in this environment. The failure is unrelated to the execution RPC rename.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
