### PR TITLE
fix(cli): reject --project-name for up

### DIFF
--- a/cmd/agent-compose/cli_project_up_test.go
+++ b/cmd/agent-compose/cli_project_up_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+)
+
+func TestCLIUpRejectsProjectNameBeforeReadingComposeOrApplyingProject(t *testing.T) {
+	composePath := writeComposeFile(t, filepath.Join(t.TempDir(), "file-project"), `
+name: file-project
+agents: {}
+`)
+	withWorkingDir(t, t.TempDir())
+
+	applyCalls := 0
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		project: projectServiceStub{
+			applyProject: func(context.Context, *connect.Request[agentcomposev2.ApplyProjectRequest]) (*connect.Response[agentcomposev2.ApplyProjectResponse], error) {
+				applyCalls++
+				return connect.NewResponse(&agentcomposev2.ApplyProjectResponse{}), nil
+			},
+		},
+	})
+	t.Cleanup(server.Close)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "top-level up with a different compose identity",
+			args: []string{"--project-name", "selected-project", "--host", server.URL, "up", "--file", composePath},
+		},
+		{
+			name: "grouped project up with a different compose identity",
+			args: []string{"project", "up", "--project-name", "selected-project", "--host", server.URL, "--file", composePath},
+		},
+		{
+			name: "matching compose identity is still unsupported",
+			args: []string{"up", "--file", composePath, "--project-name", "file-project", "--host", server.URL},
+		},
+		{
+			name: "implicit compose source is not read",
+			args: []string{"up", "--project-name", "selected-project", "--host", server.URL},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr, runCount, exitCode := executeCLICommand(test.args...)
+			if exitCode != exitCodeUsage {
+				t.Fatalf("up exit code = %d, want %d; stderr=%q", exitCode, exitCodeUsage, stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("up stdout = %q, want empty", stdout)
+			}
+			for _, want := range []string{"up does not support --project-name", "project identity comes from the compose file"} {
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("up stderr %q does not contain %q", stderr, want)
+				}
+			}
+			if runCount != 0 {
+				t.Fatalf("daemon runner called %d times, want 0", runCount)
+			}
+		})
+	}
+	if applyCalls != 0 {
+		t.Fatalf("ApplyProject called %d times, want 0", applyCalls)
+	}
+}

--- a/cmd/agent-compose/cli_root.go
+++ b/cmd/agent-compose/cli_root.go
@@ -53,7 +53,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 
 	root.PersistentFlags().StringVar(&options.Host, "host", "", "Daemon HTTP endpoint")
 	root.PersistentFlags().StringVarP(&options.ComposeFile, "file", "f", "", "Path to agent-compose.yml")
-	root.PersistentFlags().StringVar(&options.ProjectName, "project-name", "", "Select a deployed project by name")
+	root.PersistentFlags().StringVar(&options.ProjectName, "project-name", "", "Select a deployed project by name (not supported by up or project up)")
 	root.PersistentFlags().BoolVar(&options.JSON, "json", false, "Print machine-readable JSON")
 
 	commands := []*cobra.Command{

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -84,6 +84,9 @@ func runComposeListProjectsCommand(cmd *cobra.Command, cli cliOptions, options c
 }
 
 func runComposeUpCommand(cmd *cobra.Command, cli cliOptions) error {
+	if cli.ProjectName != "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("up does not support --project-name; project identity comes from the compose file")}
+	}
 	composePath, normalized, err := loadResolvedNormalizedCompose(cmd.Context(), cli)
 	if err != nil {
 		return err

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -21,7 +21,7 @@ Global options are placed between `agent-compose` and the subcommand, and apply 
 | --- | --- |
 | `-f, --file <path>` | Path to the project config file. Both `agent-compose.yml` and `agent-compose.yaml` are supported. When this option is used, the project root is the config file directory, so you do not need to `cd` into it. |
 | `--host <endpoint>` | Daemon HTTP endpoint. This can target a local daemon or a remote daemon. |
-| `--project-name <name>` | Select an existing daemon project by name. It never changes the project name declared by a compose file. |
+| `--project-name <name>` | Select an existing daemon project by name. It is not supported by `up` or `project up` and never changes the project name declared by a compose file. |
 | `--json` | Print machine-readable JSON for scripts, AI agents, and automation. |
 
 Examples:
@@ -36,7 +36,7 @@ Rules:
 
 - Without `-f` or `--project-name`, project-scoped commands look for `agent-compose.yml` or `agent-compose.yaml` in the current directory.
 - With `--project-name`, deployed-project commands select that daemon project directly and do not read a compose file, even when `-f` is also present.
-- Local authoring commands such as `config` and `up` always use the project name declared by the compose file (or derived from its directory); `--project-name` never overrides it.
+- Local authoring commands use the project name declared by the compose file (or derived from its directory). `up` and `project up` reject `--project-name` instead of silently ignoring it; `config` never uses it to override the compose project name.
 - With `-f`, the CLI can operate on a project from any working directory.
 - `--host` only selects the daemon. Sandboxes run in the daemon environment.
 - Automation should use `--json` and avoid parsing human-readable tables.
@@ -289,7 +289,7 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 
 List sandboxes in the current project. By default, only running sandboxes are shown. With `--all`, the command includes all statuses while remaining scoped to the current project.
 The project must already exist on the daemon; after `agent-compose down`, run `agent-compose up` again before using `ps`.
-Use `--project-name <name>` to select an existing daemon project. Compose files are not read for deployed-project selection, including when `--file` is also present. Local authoring commands still require a compose file and never use `--project-name` to change its project name.
+Use `--project-name <name>` to select an existing daemon project. Compose files are not read for deployed-project selection, including when `--file` is also present. Local authoring commands still require a compose file; `up` and `project up` reject `--project-name`, and `config` never uses it to change the compose project name.
 
 ```bash
 agent-compose ps

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -21,7 +21,7 @@ agent-compose [global options] <command> [command options] [arguments]
 | --- | --- |
 | `-f, --file <path>` | 指定 project 配置文件。支持 `agent-compose.yml` 和 `agent-compose.yaml`。使用该参数后，可以在任意目录操作该 project，project root 为配置文件所在目录。 |
 | `--host <endpoint>` | 指定 daemon 地址。可以连接本机 daemon，也可以连接远程 daemon。 |
-| `--project-name <name>` | 按名称选择 daemon 中已部署的 project；它不会修改 compose 文件声明的项目名称。 |
+| `--project-name <name>` | 按名称选择 daemon 中已部署的 project；`up` 和 `project up` 不支持该参数，且它不会修改 compose 文件声明的项目名称。 |
 | `--json` | 使用 JSON 输出，供脚本、AI 和自动化系统解析。 |
 
 示例：
@@ -36,7 +36,7 @@ agent-compose --host http://10.0.0.12:7410 ls --json
 
 - 未指定 `-f` 和 `--project-name` 时，project 范围的命令在当前目录查找 `agent-compose.yml` 或 `agent-compose.yaml`。
 - 指定 `--project-name` 时，已部署项目命令直接选择 daemon project，不读取 compose 文件；即使同时指定 `-f` 也是如此。
-- `config`、`up` 等本地编排命令始终使用 compose 文件声明的项目名称（或根据其目录推导），`--project-name` 不会覆盖该名称。
+- 本地编排命令始终使用 compose 文件声明的项目名称（或根据其目录推导）。`up` 和 `project up` 会拒绝 `--project-name`，不再静默忽略；`config` 也不会用它覆盖 compose project 名称。
 - 使用 `-f` 时，不需要切换到 project root。
 - `--host` 只决定 CLI 连接哪个 daemon；sandbox 实际运行在 daemon 所在环境中。
 - daemon 不再消费浏览器登录用的 `AUTH_*` / `OAUTH_*` 配置；UI 浏览器认证由 agent-compose-ui server 处理。
@@ -286,7 +286,7 @@ agent-compose scheduler inspect <scheduler-or-trigger-or-run-ref> [--scheduler <
 
 查看当前 project 下的 sandbox。默认只显示运行中的 sandbox。使用 `--all` 时仍限定当前 project，但会包含所有状态。
 该 project 必须已经存在于 daemon 中；执行 `agent-compose down` 后，需要先重新执行 `agent-compose up`，再使用 `ps`。
-使用 `--project-name <name>` 时，会直接选择 daemon 中已有的 project；即使同时指定 `--file`，已部署项目选择也不会读取 compose 文件。本地编排命令仍要求 compose 文件，且绝不会用 `--project-name` 修改其中的项目名称。
+使用 `--project-name <name>` 时，会直接选择 daemon 中已有的 project；即使同时指定 `--file`，已部署项目选择也不会读取 compose 文件。本地编排命令仍要求 compose 文件；`up` 和 `project up` 会拒绝 `--project-name`，`config` 也不会用它修改 compose project 名称。
 
 ```bash
 agent-compose ps


### PR DESCRIPTION
## Summary

- Fixes #480 by rejecting `--project-name` for `up` and `project up` before any Compose loading or daemon mutation.
- Keeps project identity for `up` exclusively in the Compose source and documents the contract in English and Chinese.
- Adds regression coverage for both command entrances, matching and different names, and implicit Compose discovery.

## Testing

- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -run 'TestCLIUpRejectsProjectNameBeforeReadingComposeOrApplyingProject|TestIntegrationCLIUpAppliesProjectFirstRepeatedModifiedAndJSON|TestCLIProjectAndAgentCommandLayout' -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `task docs:build`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"` (Unit 74.72%, Integration 60.71%, E2E 60.30%, Combined 78.78%)
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
