### PR TITLE
fix(llms): normalize custom v1 endpoints

### DIFF
--- a/pkg/llms/config_endpoint_test.go
+++ b/pkg/llms/config_endpoint_test.go
@@ -1,0 +1,43 @@
+package llms
+
+import "testing"
+
+func TestNormalizeAPIEndpointForProtocolCustomV1Prefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		want     string
+	}{
+		{
+			name:     "chat completions",
+			protocol: APIProtocolChatCompletions,
+			want:     "https://api.example.test/qwen3-14b/v1/chat/completions",
+		},
+		{
+			name:     "responses",
+			protocol: APIProtocolResponses,
+			want:     "https://api.example.test/qwen3-14b/v1/responses",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeAPIEndpointForProtocol("https://api.example.test/qwen3-14b/v1", tt.protocol)
+			if got != tt.want {
+				t.Fatalf("NormalizeAPIEndpointForProtocol() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointForEnvDefaultProviderCustomV1Prefix(t *testing.T) {
+	got := EndpointForProvider(Provider{
+		ProviderType: ProviderFamilyOpenAI,
+		BaseURL:      "https://api.example.test/qwen3-14b/v1/chat/completions",
+		Scope:        ProviderScopeEnvDefault,
+	}, APIProtocolChatCompletions)
+	want := "https://api.example.test/qwen3-14b/v1/chat/completions"
+	if got != want {
+		t.Fatalf("EndpointForProvider() = %q, want %q", got, want)
+	}
+}

--- a/pkg/llms/config_helpers.go
+++ b/pkg/llms/config_helpers.go
@@ -152,7 +152,7 @@ func NormalizeAPIEndpointForProtocol(raw, protocol string) string {
 		return parsed.String()
 	}
 	cleanPath := strings.TrimRight(parsed.Path, "/")
-	if normalizedProtocol == APIProtocolChatCompletions && (cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/openai/v1")) {
+	if normalizedProtocol == APIProtocolChatCompletions && strings.HasSuffix(cleanPath, "/v1") {
 		parsed.Path = pathpkg.Join(parsed.Path, "/chat/completions")
 		return parsed.String()
 	}
@@ -164,7 +164,7 @@ func NormalizeAPIEndpointForProtocol(raw, protocol string) string {
 		parsed.Path = pathpkg.Join(parsed.Path, "/v1/responses")
 		return parsed.String()
 	}
-	if normalizedProtocol == APIProtocolResponses && (cleanPath == "/v1" || strings.HasSuffix(cleanPath, "/openai/v1")) {
+	if normalizedProtocol == APIProtocolResponses && strings.HasSuffix(cleanPath, "/v1") {
 		parsed.Path = pathpkg.Join(parsed.Path, "/responses")
 		return parsed.String()
 	}


### PR DESCRIPTION
## Summary

- recognize OpenAI-compatible endpoints with arbitrary path prefixes ending in `/v1`
- append `chat/completions` or `responses` consistently for env-backed providers
- add regression coverage for custom-prefixed Qwen-compatible endpoints and the env-default provider resolution path

## Problem

`NormalizeAPIBaseURL` removes an explicit protocol suffix before rebuilding the endpoint. `NormalizeAPIEndpointForProtocol` only rebuilt exact `/v1` and `/openai/v1` paths, so a base such as `/models/qwen/v1` was requested directly and returned 404.

## Verification

- `go test ./pkg/llms`
- `task lint` (0 issues)
- `task build`
- `task test` progressed through script contracts and failed only in installer tests because macOS maps `/var` through a symlink (`refusing install path with symlink component: /var`); unrelated to this change