### PR TITLE
fix(runs): reject cross-agent sandbox reuse

### DIFF
--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -257,6 +257,7 @@ Rules:
 - `run -i/--interactive` must select `--prompt` or `--command`; it cannot be combined with `--json`.
 - Empty REPL lines do not create runs. Enter `/exit` or press Ctrl+D to exit.
 - REPL mode is not TTY/PTY or running stdin passthrough. Each input is one independent `StreamAgentRun` call that reuses the same sandbox.
+- `--sandbox` can reuse only a sandbox owned by the selected project and agent. Cross-project or cross-agent reuse is rejected without modifying or stopping the owner sandbox.
 - Detached runs can be observed with the printed `agent-compose logs --run <run-id> --follow` command, or managed later with `stop` and `logs`.
 - `run -i --prompt` supports providers with reusable provider conversations: Codex, Claude/cc, OpenCode, and Pi. Gemini currently returns unsupported.
 - `StopRun` requests cancellation for active in-daemon runs. Pending/running runs left behind after daemon restart are reconciled to failed with a `daemon interrupted` error.

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -254,6 +254,7 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 - `run -i/--interactive` 必须选择 `--prompt` 或 `--command`，不能与 `--json` 组合。
 - REPL 中空行不会创建 run；输入 `/exit` 或 Ctrl+D 退出。
 - REPL 不是 TTY/PTY 或运行中 stdin 透传；每条输入都是一次独立 `StreamAgentRun`，但复用同一个 sandbox。
+- `--sandbox` 只能复用属于当前 project 和所选 agent 的 sandbox；跨 project 或跨 agent 复用会被拒绝，且不会修改或停止原 sandbox。
 - detached run 可通过输出的 `agent-compose logs --run <run-id> --follow` 命令观察输出，也可继续使用 `stop`/`logs` 操作该 run。
 - `run -i --prompt` 仅支持可复用 provider conversation 的 Codex、Claude/cc、OpenCode 和 Pi；Gemini 当前会返回 unsupported。
 - `StopRun` 会请求 daemon 内当前活动 run 取消；daemon 重启后遗留的 running/pending run 会在启动 reconcile 中标记为 failed，并带 `daemon interrupted` 错误。

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -2064,6 +2064,9 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 			unlock()
 			locked = false
 		} else {
+			if err := validateProjectRunSandboxOwnership(sandbox, run); err != nil {
+				return SandboxResult{}, err
+			}
 			if sandbox.Summary.VMStatus == domain.VMStatusDeleting {
 				return SandboxResult{Sandbox: sandbox}, fmt.Errorf("sandbox %s is being deleted", sandboxID)
 			}

--- a/pkg/runs/sandbox_ownership.go
+++ b/pkg/runs/sandbox_ownership.go
@@ -1,0 +1,113 @@
+package runs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+type sandboxRunOwnership struct {
+	ProjectID string
+	AgentName string
+	AgentID   string
+}
+
+func validateProjectRunSandboxOwnership(sandbox *domain.Sandbox, run domain.ProjectRunRecord) error {
+	if sandbox == nil {
+		return nil
+	}
+	ownership, err := projectRunSandboxOwnership(sandbox)
+	if err != nil {
+		return fmt.Errorf("%w: sandbox %s has conflicting ownership metadata: %v", ErrInvalidRequest, sandbox.Summary.ID, err)
+	}
+	if ownership.ProjectID != "" && ownership.ProjectID != strings.TrimSpace(run.ProjectID) {
+		return projectRunSandboxOwnershipMismatch(sandbox.Summary.ID, ownership, run)
+	}
+	if ownership.AgentName != "" && ownership.AgentName != strings.TrimSpace(run.AgentName) {
+		return projectRunSandboxOwnershipMismatch(sandbox.Summary.ID, ownership, run)
+	}
+	if ownership.AgentID != "" && strings.TrimSpace(run.AgentID) != "" && ownership.AgentID != strings.TrimSpace(run.AgentID) {
+		return projectRunSandboxOwnershipMismatch(sandbox.Summary.ID, ownership, run)
+	}
+	return nil
+}
+
+func projectRunSandboxOwnership(sandbox *domain.Sandbox) (sandboxRunOwnership, error) {
+	if sandbox == nil {
+		return sandboxRunOwnership{}, nil
+	}
+	projectID, err := uniqueSandboxTagValue(sandbox.Summary.Tags, "project", "project_id")
+	if err != nil {
+		return sandboxRunOwnership{}, fmt.Errorf("project: %w", err)
+	}
+	agentName, err := uniqueSandboxTagValue(sandbox.Summary.Tags, "agent")
+	if err != nil {
+		return sandboxRunOwnership{}, fmt.Errorf("agent: %w", err)
+	}
+	agentID, err := uniqueSandboxTagValue(sandbox.Summary.Tags, domain.AgentSandboxTagID)
+	if err != nil {
+		return sandboxRunOwnership{}, fmt.Errorf("agent id: %w", err)
+	}
+	return sandboxRunOwnership{ProjectID: projectID, AgentName: agentName, AgentID: agentID}, nil
+}
+
+func uniqueSandboxTagValue(tags []domain.SandboxTag, names ...string) (string, error) {
+	wanted := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		wanted[name] = struct{}{}
+	}
+	values := make(map[string]struct{})
+	for _, tag := range tags {
+		name := strings.TrimSpace(tag.Name)
+		if _, ok := wanted[name]; !ok {
+			continue
+		}
+		value := strings.TrimSpace(tag.Value)
+		if value != "" {
+			values[value] = struct{}{}
+		}
+	}
+	if len(values) == 0 {
+		return "", nil
+	}
+	if len(values) == 1 {
+		for value := range values {
+			return value, nil
+		}
+	}
+	conflicts := make([]string, 0, len(values))
+	for value := range values {
+		conflicts = append(conflicts, value)
+	}
+	sort.Strings(conflicts)
+	return "", fmt.Errorf("multiple values %q", conflicts)
+}
+
+func projectRunSandboxOwnershipMismatch(sandboxID string, ownership sandboxRunOwnership, run domain.ProjectRunRecord) error {
+	owner := sandboxRunOwnershipDescription(ownership)
+	requested := sandboxRunOwnershipDescription(sandboxRunOwnership{
+		ProjectID: strings.TrimSpace(run.ProjectID),
+		AgentName: strings.TrimSpace(run.AgentName),
+		AgentID:   strings.TrimSpace(run.AgentID),
+	})
+	return fmt.Errorf("%w: sandbox %s belongs to %s; cannot reuse it for %s", ErrInvalidRequest, sandboxID, owner, requested)
+}
+
+func sandboxRunOwnershipDescription(ownership sandboxRunOwnership) string {
+	parts := make([]string, 0, 3)
+	if ownership.ProjectID != "" {
+		parts = append(parts, fmt.Sprintf("project %q", ownership.ProjectID))
+	}
+	if ownership.AgentName != "" {
+		parts = append(parts, fmt.Sprintf("agent %q", ownership.AgentName))
+	}
+	if ownership.AgentID != "" {
+		parts = append(parts, fmt.Sprintf("agent ID %q", ownership.AgentID))
+	}
+	if len(parts) == 0 {
+		return "an unowned sandbox"
+	}
+	return strings.Join(parts, " ")
+}

--- a/pkg/runs/sandbox_ownership_test.go
+++ b/pkg/runs/sandbox_ownership_test.go
@@ -1,0 +1,172 @@
+package runs
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	driverpkg "agent-compose/pkg/driver"
+	domain "agent-compose/pkg/model"
+)
+
+func TestValidateProjectRunSandboxOwnership(t *testing.T) {
+	t.Parallel()
+	requested := domain.ProjectRunRecord{ProjectID: "project-1", AgentName: "worker", AgentID: "agent-worker"}
+	tests := []struct {
+		name      string
+		tags      []domain.SandboxTag
+		wantError string
+	}{
+		{
+			name: "matching owner",
+			tags: []domain.SandboxTag{
+				{Name: "project", Value: "project-1"},
+				{Name: "agent", Value: "worker"},
+				{Name: domain.AgentSandboxTagID, Value: "agent-worker"},
+				{Name: domain.AgentSandboxTagID, Value: "agent-worker"},
+			},
+		},
+		{
+			name: "matching legacy project tag",
+			tags: []domain.SandboxTag{
+				{Name: "project_id", Value: "project-1"},
+				{Name: "agent", Value: "worker"},
+			},
+		},
+		{name: "unowned manual sandbox"},
+		{
+			name: "different agent",
+			tags: []domain.SandboxTag{
+				{Name: "project", Value: "project-1"},
+				{Name: "agent", Value: "reviewer"},
+				{Name: domain.AgentSandboxTagID, Value: "agent-reviewer"},
+			},
+			wantError: `belongs to project "project-1" agent "reviewer"`,
+		},
+		{
+			name: "different project",
+			tags: []domain.SandboxTag{
+				{Name: "project", Value: "project-2"},
+				{Name: "agent", Value: "worker"},
+			},
+			wantError: `belongs to project "project-2" agent "worker"`,
+		},
+		{
+			name: "different stable agent id",
+			tags: []domain.SandboxTag{
+				{Name: "project", Value: "project-1"},
+				{Name: "agent", Value: "worker"},
+				{Name: domain.AgentSandboxTagID, Value: "stale-agent-worker"},
+			},
+			wantError: `agent ID "stale-agent-worker"`,
+		},
+		{
+			name: "conflicting agent owners",
+			tags: []domain.SandboxTag{
+				{Name: "project", Value: "project-1"},
+				{Name: "agent", Value: "reviewer"},
+				{Name: "agent", Value: "worker"},
+			},
+			wantError: "conflicting ownership metadata",
+		},
+		{
+			name: "conflicting project aliases",
+			tags: []domain.SandboxTag{
+				{Name: "project", Value: "project-1"},
+				{Name: "project_id", Value: "project-2"},
+				{Name: "agent", Value: "worker"},
+			},
+			wantError: "conflicting ownership metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", Tags: tt.tags}}
+			err := validateProjectRunSandboxOwnership(sandbox, requested)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateProjectRunSandboxOwnership returned error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, ErrInvalidRequest) || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %v, want ErrInvalidRequest containing %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestRunsControllerRejectsCrossAgentSandboxReuseWithoutMutatingOwnerSandbox(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	ownerRun := domain.ProjectRunRecord{
+		RunID: "owner-run", ProjectID: "project-1", AgentName: "reviewer", AgentID: "agent-reviewer",
+	}
+	originalWorkspace := &domain.SandboxWorkspace{
+		ID: "reviewer-workspace", Name: "Reviewer workspace", Type: "file", ConfigJSON: `{"path":"/reviewer"}`,
+	}
+	originalEnv := []domain.SandboxEnvVar{{Name: "OWNER_SECRET", Value: "reviewer-secret", Secret: true}}
+	sandbox, err := fixture.store.CreateSandbox(
+		fixture.ctx,
+		"reviewer sandbox",
+		"",
+		driverpkg.RuntimeDriverDocker,
+		"guest:latest",
+		"",
+		domain.SandboxTypeManual,
+		originalWorkspace,
+		originalEnv,
+		SandboxTags(ownerRun),
+	)
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandbox.Summary.VMStatus = domain.VMStatusRunning
+	if err := fixture.store.UpdateSandbox(fixture.ctx, sandbox); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+	originalTags := append([]domain.SandboxTag(nil), sandbox.Summary.Tags...)
+
+	run, execErr, err := fixture.controller.RunProjectAgent(fixture.ctx, RunAgentRequest{
+		ProjectID:       "project-1",
+		AgentName:       "worker",
+		Command:         "printf should-not-run",
+		SandboxID:       sandbox.Summary.ID,
+		Source:          domain.ProjectRunSourceAPI,
+		ClientRequestID: "cross-agent-sandbox-reuse",
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunProjectAgent returned controller error: %v", err)
+	}
+	if !errors.Is(execErr, ErrInvalidRequest) || !strings.Contains(execErr.Error(), `agent "reviewer"`) || !strings.Contains(execErr.Error(), `agent "worker"`) {
+		t.Fatalf("execution error = %v, want cross-agent ErrInvalidRequest", execErr)
+	}
+	if run.Status != domain.ProjectRunStatusFailed || run.SandboxID != "" {
+		t.Fatalf("rejected run = %#v, want failed without sandbox association", run)
+	}
+	if fixture.driver.started || fixture.driver.stopped || fixture.driver.removed {
+		t.Fatalf("sandbox driver was invoked: %#v", fixture.driver)
+	}
+	if fixture.executor.prepareCalls != 0 || fixture.executor.prepareFromTagsCalls != 0 {
+		t.Fatalf("agent executor was invoked: %#v", fixture.executor)
+	}
+
+	stored, err := fixture.store.GetSandbox(fixture.ctx, sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if stored.Summary.VMStatus != domain.VMStatusRunning {
+		t.Fatalf("owner sandbox status = %q, want %q", stored.Summary.VMStatus, domain.VMStatusRunning)
+	}
+	if !reflect.DeepEqual(stored.Summary.Tags, originalTags) {
+		t.Fatalf("owner sandbox tags changed: got %#v want %#v", stored.Summary.Tags, originalTags)
+	}
+	if !reflect.DeepEqual(stored.EnvItems, originalEnv) {
+		t.Fatalf("owner sandbox env changed: got %#v want %#v", stored.EnvItems, originalEnv)
+	}
+	if !reflect.DeepEqual(stored.Workspace, originalWorkspace) {
+		t.Fatalf("owner sandbox workspace changed: got %#v want %#v", stored.Workspace, originalWorkspace)
+	}
+}


### PR DESCRIPTION
## Summary

- reject reuse of an existing sandbox when its persisted project, agent, or stable agent ID does not match the requested run
- fail closed for conflicting historical ownership tags and perform the check before environment/tag mutation or runtime resume
- keep rejected sandboxes unassociated with the failed run so cleanup cannot stop or modify the owner sandbox
- document the `run --sandbox` ownership constraint in the English and Chinese CLI manuals

Fixes #449.

## Testing

- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Unit: 74.85%
  - Integration: 60.73%
  - E2E: 60.37%
  - Combined: 78.89%
- `task docs:build`

`GOFLAGS=-buildvcs=false` is the documented compatibility setting for this local linked-worktree layout.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
