### PR TITLE
fix(api): decode persisted scheduler specs

### DIFF
--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -266,8 +266,8 @@ func runtimeTriggerSpec(trigger domain.SchedulerTrigger) *agentcomposev2.Trigger
 }
 
 func declaredTriggerSpec(scheduler domain.ProjectSchedulerRecord, triggerID string) *agentcomposev2.TriggerSpec {
-	var spec agentcomposev2.SchedulerSpec
-	if json.Unmarshal([]byte(scheduler.SpecJSON), &spec) != nil {
+	spec, err := decodeProjectSchedulerSpec(scheduler.SpecJSON)
+	if err != nil {
 		return nil
 	}
 	for index, trigger := range spec.GetTriggers() {
@@ -301,10 +301,11 @@ func (h *ProjectHandler) resolveProjectScheduler(ctx context.Context, ref *agent
 }
 
 func (h *ProjectHandler) schedulerResponse(ctx context.Context, scheduler domain.ProjectSchedulerRecord) (*agentcomposev2.GetSchedulerResponse, error) {
-	response := &agentcomposev2.GetSchedulerResponse{Scheduler: ProjectSchedulersToProto([]domain.ProjectSchedulerRecord{scheduler})[0], Spec: &agentcomposev2.SchedulerSpec{}}
-	if err := json.Unmarshal([]byte(scheduler.SpecJSON), response.Spec); err != nil {
+	spec, err := decodeProjectSchedulerSpec(scheduler.SpecJSON)
+	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("decode scheduler spec: %w", err))
 	}
+	response := &agentcomposev2.GetSchedulerResponse{Scheduler: ProjectSchedulersToProto([]domain.ProjectSchedulerRecord{scheduler})[0], Spec: spec}
 	schedulerStore, ok := h.store.(ProjectSchedulerStore)
 	if !ok || scheduler.ID == "" {
 		return response, nil

--- a/pkg/agentcompose/api/project_scheduler_run_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -41,8 +40,8 @@ func (h *ProjectHandler) InvokeScheduler(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, ConnectErrorForDomain(err)
 	}
-	var spec agentcomposev2.SchedulerSpec
-	if err := json.Unmarshal([]byte(scheduler.SpecJSON), &spec); err != nil {
+	spec, err := decodeProjectSchedulerSpec(scheduler.SpecJSON)
+	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("decode scheduler spec: %w", err))
 	}
 	if strings.TrimSpace(spec.GetScript()) == "" {

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -278,7 +278,7 @@ func newSchedulerRunHandlerFixture() (*schedulerRunProjectStoreFake, *schedulerR
 			ID:          "loader-1",
 			Revision:    1,
 			Enabled:     false,
-			SpecJSON:    `{"script":"function main() {}"}`,
+			SpecJSON:    `{"sandbox_policy":"new","concurrency_policy":"skip","script":"function main() {}"}`,
 		},
 	}
 	runtime := &schedulerRunRuntimeFake{}

--- a/pkg/agentcompose/api/project_scheduler_spec.go
+++ b/pkg/agentcompose/api/project_scheduler_spec.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"encoding/json"
+
+	"agent-compose/pkg/compose"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+// decodeProjectSchedulerSpec maps the normalized scheduler snapshot stored by
+// the projects domain back to its transport representation.
+func decodeProjectSchedulerSpec(raw string) (*agentcomposev2.SchedulerSpec, error) {
+	var normalized compose.NormalizedSchedulerSpec
+	if err := json.Unmarshal([]byte(raw), &normalized); err != nil {
+		return nil, err
+	}
+	return SchedulerSpecToProto(&normalized), nil
+}

--- a/pkg/agentcompose/api/project_scheduler_spec_test.go
+++ b/pkg/agentcompose/api/project_scheduler_spec_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"testing"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestDecodeProjectSchedulerSpecMapsPersistedValues(t *testing.T) {
+	spec, err := decodeProjectSchedulerSpec(`{
+		"enabled":true,
+		"sandbox_policy":"new",
+		"concurrency_policy":"skip",
+		"script":"run()",
+		"triggers":[{"name":"accepted","kind":"event","event":{"topic":"ui.accepted"},"sandbox_policy":"sticky"}]
+	}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.GetSandboxPolicy() != agentcomposev2.SchedulerSandboxPolicy_SCHEDULER_SANDBOX_POLICY_NEW {
+		t.Fatalf("sandbox policy = %v", spec.GetSandboxPolicy())
+	}
+	if spec.GetConcurrencyPolicy() != agentcomposev2.SchedulerConcurrencyPolicy_SCHEDULER_CONCURRENCY_POLICY_SKIP {
+		t.Fatalf("concurrency policy = %v", spec.GetConcurrencyPolicy())
+	}
+	trigger := spec.GetTriggers()[0]
+	if trigger.GetKind() != agentcomposev2.TriggerKind_TRIGGER_KIND_EVENT || trigger.GetEvent().GetTopic() != "ui.accepted" ||
+		trigger.GetSandboxPolicy() != agentcomposev2.SchedulerSandboxPolicy_SCHEDULER_SANDBOX_POLICY_STICKY {
+		t.Fatalf("trigger = %#v", trigger)
+	}
+}
+
+func TestDecodeProjectSchedulerSpecRejectsInvalidJSON(t *testing.T) {
+	if _, err := decodeProjectSchedulerSpec(`{bad`); err == nil {
+		t.Fatal("expected invalid JSON error")
+	}
+}


### PR DESCRIPTION
## Summary

- decode persisted project scheduler snapshots through the normalized compose representation
- map scheduler and trigger policies back to protobuf enums at the API boundary
- use the shared decoder for scheduler details, manual invocation, and declared trigger lookup

## Problem

Project reconciliation persists `compose.NormalizedSchedulerSpec` as JSON, where policies and trigger kinds are strings such as `new`, `skip`, and `event`. After the protobuf fields changed to enums, the API attempted to decode those snapshots directly with `encoding/json` into `agentcomposev2.SchedulerSpec`. `GetScheduler` and scheduler execution then failed with `cannot unmarshal string into Go struct field SchedulerSpec.sandbox_policy`.

## Tests

- `go test ./pkg/agentcompose/api`
- `task lint`
- `task build`
- `task test`
- real daemon regression with existing data: `GetScheduler` returned 200
- real UI regression: scheduler run `516ab8a0a61d88f5e18a7739f3f07a99508f58ae7bd9b4bc748c1555f92eaa8f` succeeded and its Agent executed the Shell marker `PROTOCOL_AGENT_SHELL_OK`

## Checklist

- [x] Regression tests added
- [x] No protobuf or generated source changed
- [x] No configuration or documentation changes required