### PR TITLE
perf(projects): push project listing into SQLite

### DIFF
--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -1295,7 +1295,22 @@ func (s *apiProjectRunStore) GetProject(_ context.Context, projectID string) (do
 }
 
 func (s *apiProjectRunStore) ListProjects(_ context.Context, _ domain.ProjectListOptions) (domain.ProjectListResult, error) {
-	return domain.ProjectListResult{Projects: s.projects, TotalCount: len(s.projects)}, nil
+	counts := make(map[string]domain.ProjectListCounts, len(s.projects))
+	for _, project := range s.projects {
+		var projectCounts domain.ProjectListCounts
+		for _, agent := range s.agents {
+			if agent.ProjectID == project.ID && (project.CurrentRevision <= 0 || agent.Revision == project.CurrentRevision) {
+				projectCounts.AgentCount++
+			}
+		}
+		for _, scheduler := range s.schedulers {
+			if scheduler.ProjectID == project.ID && (project.CurrentRevision <= 0 || scheduler.Revision == project.CurrentRevision) {
+				projectCounts.SchedulerCount++
+			}
+		}
+		counts[project.ID] = projectCounts
+	}
+	return domain.ProjectListResult{Projects: s.projects, CountsByProjectID: counts, TotalCount: len(s.projects)}, nil
 }
 
 func (s *apiProjectRunStore) ListProjectAgents(context.Context, string) ([]domain.ProjectAgentRecord, error) {

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -30,14 +30,18 @@ func ProjectToProto(project domain.ProjectRecord, spec *agentcomposev2.ProjectSp
 func ProjectSummaryToProto(project domain.ProjectRecord, agents []domain.ProjectAgentRecord, schedulers []domain.ProjectSchedulerRecord) *agentcomposev2.ProjectSummary {
 	agents = currentProjectAgents(project, agents)
 	schedulers = currentProjectSchedulers(project, schedulers)
+	return projectSummaryWithCountsToProto(project, uint32(len(agents)), uint32(len(schedulers)))
+}
+
+func projectSummaryWithCountsToProto(project domain.ProjectRecord, agentCount, schedulerCount uint32) *agentcomposev2.ProjectSummary {
 	return &agentcomposev2.ProjectSummary{
 		ProjectId:       project.ID,
 		Name:            project.Name,
 		SourcePath:      project.SourcePath,
 		CurrentRevision: uint64(project.CurrentRevision),
 		SpecHash:        project.SpecHash,
-		AgentCount:      uint32(len(agents)),
-		SchedulerCount:  uint32(len(schedulers)),
+		AgentCount:      agentCount,
+		SchedulerCount:  schedulerCount,
 		CreatedAt:       FormatProjectTime(project.CreatedAt),
 		UpdatedAt:       FormatProjectTime(project.UpdatedAt),
 		RemovedAt:       FormatProjectTime(project.RemovedAt),

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -431,15 +431,8 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *connect.Request[
 		Total: uint32(result.TotalCount),
 	}
 	for _, project := range result.Projects {
-		agents, err := h.store.ListProjectAgents(ctx, project.ID)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		schedulers, err := h.store.ListProjectSchedulers(ctx, project.ID)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		resp.Projects = append(resp.Projects, ProjectSummaryToProto(project, agents, schedulers))
+		counts := result.CountsByProjectID[project.ID]
+		resp.Projects = append(resp.Projects, projectSummaryWithCountsToProto(project, counts.AgentCount, counts.SchedulerCount))
 	}
 	return connect.NewResponse(resp), nil
 }

--- a/pkg/agentcompose/api/project_list_handler_test.go
+++ b/pkg/agentcompose/api/project_list_handler_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestListProjectsUsesAggregatedResourceCounts(t *testing.T) {
+	project := domain.ProjectRecord{ID: "project-1", Name: "Project", CurrentRevision: 2}
+	store := &projectListStoreStub{
+		result: domain.ProjectListResult{
+			Projects: []domain.ProjectRecord{project},
+			CountsByProjectID: map[string]domain.ProjectListCounts{
+				project.ID: {AgentCount: 7, SchedulerCount: 3},
+			},
+			TotalCount: 1,
+		},
+	}
+	handler := NewProjectHandler(nil, store, nil)
+
+	response, err := handler.ListProjects(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectsRequest{
+		Query: "project", IncludeRemoved: true, Offset: 4, Limit: 25,
+	}))
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if len(response.Msg.GetProjects()) != 1 || response.Msg.GetTotal() != 1 {
+		t.Fatalf("ListProjects response = %#v", response.Msg)
+	}
+	summary := response.Msg.GetProjects()[0]
+	if summary.GetAgentCount() != 7 || summary.GetSchedulerCount() != 3 {
+		t.Fatalf("summary counts = agents %d schedulers %d", summary.GetAgentCount(), summary.GetSchedulerCount())
+	}
+	if store.listAgentsCalls != 0 || store.listSchedulersCalls != 0 {
+		t.Fatalf("per-project queries = agents %d schedulers %d", store.listAgentsCalls, store.listSchedulersCalls)
+	}
+	if store.options.Query != "project" || !store.options.IncludeRemoved || store.options.Offset != 4 || store.options.Limit != 25 {
+		t.Fatalf("ListProjects options = %#v", store.options)
+	}
+}
+
+type projectListStoreStub struct {
+	result              domain.ProjectListResult
+	options             domain.ProjectListOptions
+	listAgentsCalls     int
+	listSchedulersCalls int
+}
+
+func (s *projectListStoreStub) GetProject(context.Context, string) (domain.ProjectRecord, error) {
+	return domain.ProjectRecord{}, nil
+}
+
+func (s *projectListStoreStub) ListProjects(_ context.Context, options domain.ProjectListOptions) (domain.ProjectListResult, error) {
+	s.options = options
+	return s.result, nil
+}
+
+func (s *projectListStoreStub) ListProjectAgents(context.Context, string) ([]domain.ProjectAgentRecord, error) {
+	s.listAgentsCalls++
+	return nil, nil
+}
+
+func (s *projectListStoreStub) ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error) {
+	s.listSchedulersCalls++
+	return nil, nil
+}
+
+func (s *projectListStoreStub) GetProjectRevision(context.Context, string, int64) (domain.ProjectRevisionRecord, error) {
+	return domain.ProjectRevisionRecord{}, nil
+}

--- a/pkg/model/project_model.go
+++ b/pkg/model/project_model.go
@@ -155,10 +155,16 @@ type ProjectAgentRunState struct {
 }
 
 type ProjectListResult struct {
-	Projects   []ProjectRecord
-	TotalCount int
-	HasMore    bool
-	NextOffset int
+	Projects          []ProjectRecord
+	CountsByProjectID map[string]ProjectListCounts
+	TotalCount        int
+	HasMore           bool
+	NextOffset        int
+}
+
+type ProjectListCounts struct {
+	AgentCount     uint32
+	SchedulerCount uint32
 }
 
 type ProjectSandboxRelationFilter struct {

--- a/pkg/storage/configstore/project_list.go
+++ b/pkg/storage/configstore/project_list.go
@@ -1,0 +1,135 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+)
+
+const (
+	defaultProjectListLimit = 50
+	maxProjectListLimit     = 500
+)
+
+// ListProjects returns one stable project page and the current-revision
+// resource counts used by the public project summary. Count and page queries
+// share a read transaction so concurrent project updates cannot make the page
+// disagree with its reported total.
+func (s *projectStore) ListProjects(ctx context.Context, options ProjectListOptions) (ProjectListResult, error) {
+	limit, offset := projectListBounds(options)
+	where, args := projectListWhere(options)
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return ProjectListResult{}, fmt.Errorf("begin project list transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var total int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM project p WHERE `+where, args...).Scan(&total); err != nil {
+		return ProjectListResult{}, fmt.Errorf("count projects: %w", err)
+	}
+	result := ProjectListResult{
+		Projects:          []ProjectRecord{},
+		CountsByProjectID: make(map[string]domain.ProjectListCounts),
+		TotalCount:        total,
+		NextOffset:        min(offset, total),
+	}
+	if offset >= total {
+		if err := tx.Commit(); err != nil {
+			return ProjectListResult{}, fmt.Errorf("commit empty project list transaction: %w", err)
+		}
+		return result, nil
+	}
+
+	pageArgs := append(append([]any(nil), args...), limit, offset)
+	rows, err := tx.QueryContext(ctx, `SELECT
+		p.id, p.name, p.short_id, p.source_path, p.source_json,
+		p.current_revision, p.spec_hash, p.created_at, p.updated_at, p.removed_at,
+		(SELECT COUNT(*) FROM project_agent a
+			WHERE a.project_id = p.id AND (p.current_revision <= 0 OR a.revision = p.current_revision)),
+		(SELECT COUNT(*) FROM project_scheduler s
+			WHERE s.project_id = p.id AND (p.current_revision <= 0 OR s.revision = p.current_revision))
+		FROM project p
+		WHERE `+where+`
+		ORDER BY p.updated_at DESC, p.created_at DESC, p.id ASC
+		LIMIT ? OFFSET ?`, pageArgs...)
+	if err != nil {
+		return ProjectListResult{}, fmt.Errorf("query project page: %w", err)
+	}
+	for rows.Next() {
+		project, counts, scanErr := scanProjectListRow(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return ProjectListResult{}, scanErr
+		}
+		result.Projects = append(result.Projects, project)
+		result.CountsByProjectID[project.ID] = counts
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return ProjectListResult{}, fmt.Errorf("iterate project page: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return ProjectListResult{}, fmt.Errorf("close project page: %w", err)
+	}
+
+	result.NextOffset = offset + len(result.Projects)
+	result.HasMore = result.NextOffset < total
+	if err := tx.Commit(); err != nil {
+		return ProjectListResult{}, fmt.Errorf("commit project list transaction: %w", err)
+	}
+	return result, nil
+}
+
+func projectListBounds(options ProjectListOptions) (limit, offset int) {
+	limit = options.Limit
+	if limit <= 0 {
+		limit = defaultProjectListLimit
+	}
+	if limit > maxProjectListLimit {
+		limit = maxProjectListLimit
+	}
+	offset = max(options.Offset, 0)
+	return limit, offset
+}
+
+func projectListWhere(options ProjectListOptions) (string, []any) {
+	clauses := make([]string, 0, 2)
+	args := make([]any, 0, 3)
+	if !options.IncludeRemoved {
+		clauses = append(clauses, "p.removed_at = 0")
+	}
+	if query := strings.ToLower(strings.TrimSpace(options.Query)); query != "" {
+		clauses = append(clauses, `(instr(lower(p.id), ?) > 0 OR instr(lower(p.name), ?) > 0 OR instr(lower(p.source_path), ?) > 0)`)
+		args = append(args, query, query, query)
+	}
+	if len(clauses) == 0 {
+		return "1 = 1", args
+	}
+	return strings.Join(clauses, " AND "), args
+}
+
+type projectListRows interface {
+	Scan(...any) error
+}
+
+func scanProjectListRow(row projectListRows) (ProjectRecord, domain.ProjectListCounts, error) {
+	var agentCount int64
+	var schedulerCount int64
+	project, err := projects.ScanProject(func(dest ...any) error {
+		dest = append(dest, &agentCount, &schedulerCount)
+		return row.Scan(dest...)
+	})
+	if err != nil {
+		return ProjectRecord{}, domain.ProjectListCounts{}, err
+	}
+	return project, domain.ProjectListCounts{
+		AgentCount:     uint32(agentCount),
+		SchedulerCount: uint32(schedulerCount),
+	}, nil
+}

--- a/pkg/storage/configstore/project_list_test.go
+++ b/pkg/storage/configstore/project_list_test.go
@@ -1,0 +1,144 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestListProjectsFiltersPagesAndCountsCurrentRevision(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	seedProjectListProject(t, store, "project-alpha", "Alpha NEEDLE", "/work/alpha", 2, 300, 0)
+	seedProjectListProject(t, store, "project-beta", "Beta", "/work/needle-beta", 1, 200, 0)
+	seedProjectListProject(t, store, "project-needle-removed", "Removed", "/work/removed", 1, 400, 350)
+	seedProjectListResources(t, store, "project-alpha", 1, "old", true)
+	seedProjectListResources(t, store, "project-alpha", 2, "current", true)
+	seedProjectListResources(t, store, "project-beta", 1, "current", false)
+
+	result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "NeEdLe", Limit: 1})
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if result.TotalCount != 2 || len(result.Projects) != 1 || result.Projects[0].ID != "project-alpha" {
+		t.Fatalf("first page = %#v", result)
+	}
+	if !result.HasMore || result.NextOffset != 1 {
+		t.Fatalf("first page state = has_more %v next %d", result.HasMore, result.NextOffset)
+	}
+	if counts := result.CountsByProjectID["project-alpha"]; counts.AgentCount != 1 || counts.SchedulerCount != 1 {
+		t.Fatalf("current revision counts = %#v", counts)
+	}
+
+	second, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "needle", Limit: 1, Offset: 1})
+	if err != nil {
+		t.Fatalf("ListProjects second page: %v", err)
+	}
+	if second.TotalCount != 2 || len(second.Projects) != 1 || second.Projects[0].ID != "project-beta" || second.HasMore || second.NextOffset != 2 {
+		t.Fatalf("second page = %#v", second)
+	}
+	if counts := second.CountsByProjectID["project-beta"]; counts.AgentCount != 1 || counts.SchedulerCount != 0 {
+		t.Fatalf("second project counts = %#v", counts)
+	}
+
+	withRemoved, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "needle", IncludeRemoved: true, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListProjects including removed: %v", err)
+	}
+	if withRemoved.TotalCount != 3 || len(withRemoved.Projects) != 3 || withRemoved.Projects[0].ID != "project-needle-removed" {
+		t.Fatalf("page including removed = %#v", withRemoved)
+	}
+
+	beyond, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "needle", Limit: 10, Offset: 20})
+	if err != nil {
+		t.Fatalf("ListProjects beyond total: %v", err)
+	}
+	if beyond.TotalCount != 2 || len(beyond.Projects) != 0 || beyond.HasMore || beyond.NextOffset != 2 {
+		t.Fatalf("page beyond total = %#v", beyond)
+	}
+}
+
+func TestListProjectsTreatsSearchMetacharactersLiterally(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	seedProjectListProject(t, store, "project-percent", "100% Ready", "/work/percent", 0, 100, 0)
+	seedProjectListProject(t, store, "project-underscore", "Under_score", "/work/underscore", 0, 90, 0)
+	seedProjectListProject(t, store, "project-plain", "Plain", "/work/plain", 0, 80, 0)
+
+	for _, test := range []struct {
+		query string
+		want  string
+	}{
+		{query: "%", want: "project-percent"},
+		{query: "_", want: "project-underscore"},
+		{query: "PROJECT-PLAIN", want: "project-plain"},
+	} {
+		result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: test.query, Limit: 10})
+		if err != nil {
+			t.Fatalf("ListProjects query %q: %v", test.query, err)
+		}
+		if result.TotalCount != 1 || len(result.Projects) != 1 || result.Projects[0].ID != test.want {
+			t.Fatalf("ListProjects query %q = %#v", test.query, result)
+		}
+	}
+}
+
+func TestListProjectsReturnsMoreThanLegacyTwoHundredLimit(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	for index := range 205 {
+		id := fmt.Sprintf("project-%03d", index)
+		seedProjectListProject(t, store, id, id, "/work/"+id, 0, int64(1000-index), 0)
+	}
+
+	result, err := store.ListProjects(ctx, domain.ProjectListOptions{Limit: 500, Offset: -10})
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if result.TotalCount != 205 || len(result.Projects) != 205 || result.HasMore || result.NextOffset != 205 {
+		t.Fatalf("large page = total %d projects %d has_more %v next %d", result.TotalCount, len(result.Projects), result.HasMore, result.NextOffset)
+	}
+}
+
+func seedProjectListProject(t *testing.T, store *ConfigStore, id, name, sourcePath string, revision, updatedAt, removedAt int64) {
+	t.Helper()
+	_, err := store.db.Exec(`INSERT INTO project(
+		id, name, short_id, source_path, source_json, current_revision, spec_hash, created_at, updated_at, removed_at
+	) VALUES(?, ?, ?, ?, '{}', ?, '', ?, ?, ?)`, id, name, id, sourcePath, revision, updatedAt, updatedAt, removedAt)
+	if err != nil {
+		t.Fatalf("seed project %s: %v", id, err)
+	}
+}
+
+func seedProjectListResources(t *testing.T, store *ConfigStore, projectID string, revision int64, suffix string, scheduler bool) {
+	t.Helper()
+	agentName := "agent-" + suffix
+	agentID := projectID + "-" + suffix
+	if _, err := store.db.Exec(`INSERT INTO project_agent(
+		id, name, short_id, project_id, agent_name, revision, spec_json, created_at, updated_at
+	) VALUES(?, ?, ?, ?, ?, ?, '{}', 1, 1)`, agentID, agentName, agentID, projectID, agentName, revision); err != nil {
+		t.Fatalf("seed project agent %s: %v", agentID, err)
+	}
+	if !scheduler {
+		return
+	}
+	schedulerID := projectID + "-scheduler-" + suffix
+	if _, err := store.db.Exec(`INSERT INTO project_scheduler(
+		id, short_id, project_id, scheduler_id, agent_name, revision, spec_json, created_at, updated_at
+	) VALUES(?, ?, ?, ?, ?, ?, '{}', 1, 1)`, schedulerID, schedulerID, projectID, schedulerID, agentName, revision); err != nil {
+		t.Fatalf("seed project scheduler %s: %v", schedulerID, err)
+	}
+}

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -180,59 +180,6 @@ func (s *projectStore) GetProject(ctx context.Context, projectID string) (Projec
 	return item, nil
 }
 
-func (s *projectStore) ListProjects(ctx context.Context, options ProjectListOptions) (ProjectListResult, error) {
-	limit := options.Limit
-	if limit <= 0 {
-		limit = 50
-	}
-	if limit > 200 {
-		limit = 200
-	}
-	offset := options.Offset
-	if offset < 0 {
-		offset = 0
-	}
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, short_id, source_path, source_json, current_revision, spec_hash, created_at, updated_at, removed_at
-		FROM project ORDER BY updated_at DESC, created_at DESC, id ASC`)
-	if err != nil {
-		return ProjectListResult{}, fmt.Errorf("query projects: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	query := strings.ToLower(strings.TrimSpace(options.Query))
-	matched := make([]ProjectRecord, 0)
-	for rows.Next() {
-		item, err := projects.ScanProject(rows.Scan)
-		if err != nil {
-			return ProjectListResult{}, err
-		}
-		if !options.IncludeRemoved && !item.RemovedAt.IsZero() {
-			continue
-		}
-		if query != "" && !projects.RecordMatchesQuery(item, query) {
-			continue
-		}
-		matched = append(matched, item)
-	}
-	if err := rows.Err(); err != nil {
-		return ProjectListResult{}, fmt.Errorf("iterate projects: %w", err)
-	}
-	total := len(matched)
-	end := offset + limit
-	if offset > total {
-		offset = total
-	}
-	if end > total {
-		end = total
-	}
-	return ProjectListResult{
-		Projects:   matched[offset:end],
-		TotalCount: total,
-		HasMore:    end < total,
-		NextOffset: end,
-	}, nil
-}
-
 func (s *projectStore) GetProjectRevision(ctx context.Context, projectID string, revision int64) (ProjectRevisionRecord, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT project_id, revision, spec_hash, spec_json, created_at
 		FROM project_revision WHERE project_id = ? AND revision = ?`, strings.TrimSpace(projectID), revision)

--- a/pkg/storage/sqlite/migrations/README.md
+++ b/pkg/storage/sqlite/migrations/README.md
@@ -11,3 +11,7 @@ Migration files are embedded into the agent-compose binary and applied by the
 - Add schema changes only as a new migration; do not add startup-time schema
   inspection or `CREATE TABLE` statements to store implementations.
 - Keep connection PRAGMAs and operations such as `VACUUM` out of migrations.
+- Store new business timestamps as Unix milliseconds, with `0` representing an
+  optional timestamp that has not been set. Existing second-, millisecond-, and
+  nanosecond-based columns retain their released units and are converted at
+  their owning storage boundary rather than rewritten in place.

--- a/scripts/tests/test-coverage-contract.sh
+++ b/scripts/tests/test-coverage-contract.sh
@@ -139,7 +139,7 @@ fi
 
 listed_e2e_tests="$(go test -list '^Test' ./test/e2e | awk '/^Test/ { print }')"
 listed_e2e_count="$(printf '%s\n' "$listed_e2e_tests" | awk 'NF { count++ } END { print count + 0 }')"
-assert_equal 8 "$listed_e2e_count" "unexpected test/e2e package test count"
+assert_equal 9 "$listed_e2e_count" "unexpected test/e2e package test count"
 
 e2e_output="$(go test -run '^Test' -v ./test/e2e)"
 while IFS= read -r test_name; do

--- a/test/e2e/project_list_host_daemon_test.go
+++ b/test/e2e/project_list_host_daemon_test.go
@@ -1,0 +1,168 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/configstore"
+	storagesqlite "agent-compose/pkg/storage/sqlite"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestE2EProjectListSQLitePagination(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	testRoot, err := os.MkdirTemp(repoRoot, ".project-list-e2e-")
+	if err != nil {
+		t.Fatalf("create project list E2E root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(testRoot) })
+	seedE2EProjectListDatabase(t, ctx, filepath.Join(testRoot, "data.db"), 205)
+	binary := e2eDaemonBinary(t, ctx, repoRoot, testRoot)
+
+	firstAddress := unusedLoopbackAddress(t)
+	firstDaemon := startE2EDaemon(t, binary, repoRoot, testRoot, firstAddress, "debian:bookworm-slim")
+	firstBaseURL := "http://" + firstAddress
+	waitForE2EDaemon(t, ctx, firstDaemon, firstBaseURL)
+	assertE2EProjectListResponses(t, ctx, binary, firstBaseURL)
+	firstDaemon.stop(t)
+	assertE2EDaemonReleased(t, firstDaemon, filepath.Join(testRoot, "agent-compose.sock"), firstAddress)
+
+	secondAddress := unusedLoopbackAddress(t)
+	secondDaemon := startE2EDaemon(t, binary, repoRoot, testRoot, secondAddress, "debian:bookworm-slim")
+	secondBaseURL := "http://" + secondAddress
+	waitForE2EDaemon(t, ctx, secondDaemon, secondBaseURL)
+	client := newE2EHTTPClient()
+	t.Cleanup(client.CloseIdleConnections)
+	projectClient := agentcomposev2connect.NewProjectServiceClient(client, secondBaseURL)
+	response, err := projectClient.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{Limit: 500}))
+	if err != nil {
+		t.Fatalf("ListProjects after daemon restart: %v", err)
+	}
+	if response.Msg.GetTotal() != 204 || len(response.Msg.GetProjects()) != 204 {
+		t.Fatalf("project list after restart = total %d projects %d", response.Msg.GetTotal(), len(response.Msg.GetProjects()))
+	}
+	secondDaemon.stop(t)
+	assertE2EDaemonReleased(t, secondDaemon, filepath.Join(testRoot, "agent-compose.sock"), secondAddress)
+}
+
+func seedE2EProjectListDatabase(t *testing.T, ctx context.Context, databasePath string, count int) {
+	t.Helper()
+	database, err := storagesqlite.Open(databasePath, 0)
+	if err != nil {
+		t.Fatalf("open project list database: %v", err)
+	}
+	store := configstore.FromDB(database.DB())
+	for index := range count {
+		id := fmt.Sprintf("project-%03d", index)
+		name := fmt.Sprintf("Project %03d", index)
+		if index == 42 {
+			name = "Needle Project 042"
+		}
+		project, err := store.UpsertProject(ctx, domain.ProjectRecord{
+			ID: id, Name: name, SourcePath: filepath.Join("/projects", id, "agent-compose.yml"), SourceJSON: `{"kind":"local"}`,
+		})
+		if err != nil {
+			_ = database.Close()
+			t.Fatalf("seed project %s: %v", id, err)
+		}
+		revision, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{
+			ProjectID: project.ID, SpecHash: "hash-" + id, SpecJSON: `{"agents":[]}`,
+		})
+		if err != nil {
+			_ = database.Close()
+			t.Fatalf("seed project revision %s: %v", id, err)
+		}
+		if _, err := store.UpsertProjectAgent(ctx, domain.ProjectAgentRecord{
+			ID: id + "-agent", ProjectID: id, AgentName: "worker", Revision: revision.Revision, Provider: "codex", SpecJSON: `{"name":"worker"}`,
+		}); err != nil {
+			_ = database.Close()
+			t.Fatalf("seed project agent %s: %v", id, err)
+		}
+	}
+	if _, err := store.MarkProjectRemoved(ctx, "project-001"); err != nil {
+		_ = database.Close()
+		t.Fatalf("mark E2E project removed: %v", err)
+	}
+	if _, err := database.DB().ExecContext(ctx, `UPDATE project SET created_at = 1000, updated_at = 1000 WHERE removed_at = 0`); err != nil {
+		_ = database.Close()
+		t.Fatalf("stabilize E2E project ordering: %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close project list database: %v", err)
+	}
+}
+
+func assertE2EProjectListResponses(t *testing.T, ctx context.Context, binary, baseURL string) {
+	t.Helper()
+	httpClient := newE2EHTTPClient()
+	t.Cleanup(httpClient.CloseIdleConnections)
+	projectClient := agentcomposev2connect.NewProjectServiceClient(httpClient, baseURL)
+
+	all, err := projectClient.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{Limit: 500}))
+	if err != nil {
+		t.Fatalf("ListProjects large page: %v", err)
+	}
+	if all.Msg.GetTotal() != 204 || len(all.Msg.GetProjects()) != 204 {
+		t.Fatalf("large project page = total %d projects %d", all.Msg.GetTotal(), len(all.Msg.GetProjects()))
+	}
+	if first := all.Msg.GetProjects()[0]; first.GetProjectId() != "project-000" || first.GetAgentCount() != 1 || first.GetSchedulerCount() != 0 {
+		t.Fatalf("first project summary = %#v", first)
+	}
+
+	tail, err := projectClient.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{Offset: 200, Limit: 10}))
+	if err != nil {
+		t.Fatalf("ListProjects tail page: %v", err)
+	}
+	if tail.Msg.GetTotal() != 204 || len(tail.Msg.GetProjects()) != 4 {
+		t.Fatalf("tail project page = total %d projects %d", tail.Msg.GetTotal(), len(tail.Msg.GetProjects()))
+	}
+
+	matched, err := projectClient.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{Query: "needle", Limit: 10}))
+	if err != nil {
+		t.Fatalf("ListProjects query: %v", err)
+	}
+	if matched.Msg.GetTotal() != 1 || len(matched.Msg.GetProjects()) != 1 || matched.Msg.GetProjects()[0].GetProjectId() != "project-042" {
+		t.Fatalf("queried project page = %#v", matched.Msg)
+	}
+
+	includingRemoved, err := projectClient.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{IncludeRemoved: true, Limit: 500}))
+	if err != nil {
+		t.Fatalf("ListProjects including removed: %v", err)
+	}
+	if includingRemoved.Msg.GetTotal() != 205 || len(includingRemoved.Msg.GetProjects()) != 205 {
+		t.Fatalf("project page including removed = total %d projects %d", includingRemoved.Msg.GetTotal(), len(includingRemoved.Msg.GetProjects()))
+	}
+
+	command := exec.CommandContext(ctx, binary, "--host", baseURL, "--json", "project", "ls", "--limit", "500")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("project ls against real daemon: %v\n%s", err, output)
+	}
+	var cliPage struct {
+		Projects []struct {
+			ID             string `json:"id"`
+			AgentCount     uint32 `json:"agent_count"`
+			SchedulerCount uint32 `json:"scheduler_count"`
+		} `json:"projects"`
+		Total uint32 `json:"total"`
+	}
+	if err := json.Unmarshal(output, &cliPage); err != nil {
+		t.Fatalf("decode project ls output: %v\n%s", err, output)
+	}
+	if cliPage.Total != 204 || len(cliPage.Projects) != 204 || cliPage.Projects[0].ID != "project-000" || cliPage.Projects[0].AgentCount != 1 {
+		t.Fatalf("project ls output = total %d projects %d first %#v", cliPage.Total, len(cliPage.Projects), cliPage.Projects[0])
+	}
+}


### PR DESCRIPTION
## Summary

- push project filtering, counting, stable ordering, and pagination into a shared SQLite read transaction
- return current-revision agent and scheduler counts with each project page so the API no longer performs per-project queries
- align the storage limit with the public 500-item contract and document Unix-millisecond conventions for new timestamps
- cover the change with focused storage/API tests and a real host-daemon SQLite/CLI E2E across daemon restart

## Testing

- `go test ./pkg/projects ./pkg/storage/sqlite ./pkg/storage/configstore ./pkg/agentcompose/api`
- `go test ./test/e2e -run ^TestE2EProjectListSQLitePagination$ -count=1`
- `./scripts/tests/test-coverage-contract.sh`
- `task lint` (0 issues)
- `task build`
- `task test`
  - Unit: 74.80%
  - Integration: 60.75%
  - E2E: 60.25%
  - Combined: 78.97%

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
