### PR TITLE
feat(projects): stabilize name-based identity and lifecycle

### DIFF
--- a/cmd/agent-compose-migrate/main_test.go
+++ b/cmd/agent-compose-migrate/main_test.go
@@ -91,7 +91,7 @@ func TestE2ELegacyMigratorCLITextDryRun(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", exitCode)
 	}
-	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 8 is eligible"; got != want {
+	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 9 is eligible"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {

--- a/cmd/agent-compose-migrate/main_test.go
+++ b/cmd/agent-compose-migrate/main_test.go
@@ -46,7 +46,7 @@ func TestE2ELegacyMigratorCLIJSONDryRun(t *testing.T) {
 	if err := reader.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 8 || !report.DryRun {
+	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 9 || !report.DryRun {
 		t.Fatalf("exit=%d report=%+v", exitCode, report)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -153,7 +153,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 	}
 
 	report := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 8 || report.Backup == "" {
+	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 9 || report.Backup == "" {
 		t.Fatalf("in-place report=%+v", report)
 	}
 	nativeInfo, err := os.Stat(filepath.Join(root, "sandboxes", sandboxID, "state.bin"))
@@ -164,7 +164,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 		t.Fatalf("database backup is unavailable: %v", err)
 	}
 	repeated := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if repeated.Stage != "complete" || repeated.TargetVersion != 8 {
+	if repeated.Stage != "complete" || repeated.TargetVersion != 9 {
 		t.Fatalf("repeated in-place report=%+v", repeated)
 	}
 }

--- a/cmd/agent-compose-migrate/migrate/legacy_projection_reconciliation_test.go
+++ b/cmd/agent-compose-migrate/migrate/legacy_projection_reconciliation_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"agent-compose/pkg/identity"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/storage/sqlite"
 )
@@ -36,10 +37,7 @@ func TestRunReconcilesExistingLegacyProjectProjections(t *testing.T) {
 		t.Fatalf("create legacy event session links: %v", err)
 	}
 
-	projectID, err := domain.StableProjectID(legacyDefaultProjectName, "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	projectID := identity.NewID(identity.ResourceProject, legacyDefaultProjectName, "")
 	existingAgentID, err := domain.StableProjectAgentID(projectID, "duplicate")
 	if err != nil {
 		t.Fatal(err)
@@ -163,10 +161,7 @@ func TestRunReconcilesExistingLegacyProjectProjections(t *testing.T) {
 }
 
 func TestPlanStandaloneAgentsRejectsDifferentExistingAgent(t *testing.T) {
-	projectID, err := domain.StableProjectID(legacyDefaultProjectName, "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	projectID := identity.NewID(identity.ResourceProject, legacyDefaultProjectName, "")
 	existingID, err := domain.StableProjectAgentID(projectID, "worker")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/agent-compose-migrate/migrate/migrate.go
+++ b/cmd/agent-compose-migrate/migrate/migrate.go
@@ -22,7 +22,7 @@ const (
 	databaseName         = "data.db"
 	journalName          = ".agent-compose-migrate.json"
 	inPlaceBackupName    = ".agent-compose-migrate-backup"
-	currentSchemaVersion = 8
+	currentSchemaVersion = 9
 )
 
 var knownMigrationChecksums = map[int64]string{
@@ -34,6 +34,7 @@ var knownMigrationChecksums = map[int64]string{
 	6: "92da2ea1c85e7d1321ca1e4260370a3d12057219005a83808529dbdd8d25299a",
 	7: "a8cb740e25992d3f3121bcfbff07c67cff699e8625d281edf60c0e76f91ce9ba",
 	8: "4569a4d7f82de70d3a2545dcdff07e0929e55daffaedf13fd6f2b8a8bcbf1d3e",
+	9: "7090094be268e368c74fd6a98709d01fc2423534ee6f03a0202b426d050ade48",
 }
 
 var ErrReported = errors.New("migration failure is included in the report")

--- a/cmd/agent-compose-migrate/migrate/migrate.go
+++ b/cmd/agent-compose-migrate/migrate/migrate.go
@@ -34,7 +34,7 @@ var knownMigrationChecksums = map[int64]string{
 	6: "92da2ea1c85e7d1321ca1e4260370a3d12057219005a83808529dbdd8d25299a",
 	7: "a8cb740e25992d3f3121bcfbff07c67cff699e8625d281edf60c0e76f91ce9ba",
 	8: "4569a4d7f82de70d3a2545dcdff07e0929e55daffaedf13fd6f2b8a8bcbf1d3e",
-	9: "7090094be268e368c74fd6a98709d01fc2423534ee6f03a0202b426d050ade48",
+	9: "916b84e78f6956ae5af9e38720fa4c6c0c7dfe9d72ddba068790ce44a80e7fb3",
 }
 
 var ErrReported = errors.New("migration failure is included in the report")

--- a/cmd/agent-compose-migrate/migrate/report_test.go
+++ b/cmd/agent-compose-migrate/migrate/report_test.go
@@ -12,11 +12,11 @@ func TestReportTextIncludesWarningsForEverySuccessfulMode(t *testing.T) {
 	if got := (Report{DryRun: true, SourceVersion: 4}).Text(); got != "legacy migration dry run: source schema version 4 is eligible" {
 		t.Fatalf("dry-run report text = %q", got)
 	}
-	if got := (Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v8, 2 files (9 bytes) copied to /target" {
+	if got := (Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v9, 2 files (9 bytes) copied to /target" {
 		t.Fatalf("complete report text = %q", got)
 	}
 	warningReport := Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, Target: "/target", Warnings: []string{"unresolved scheduler link", "  external path retained  ", ""}}
-	if got, want := warningReport.Text(), "legacy migration complete: schema v8, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
+	if got, want := warningReport.Text(), "legacy migration complete: schema v9, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
 		t.Fatalf("warning report text = %q, want %q", got, want)
 	}
 	for name, report := range map[string]Report{

--- a/cmd/agent-compose/cli_exec_command.go
+++ b/cmd/agent-compose/cli_exec_command.go
@@ -103,11 +103,14 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 	if !cmd.Flags().Changed("run") && len(args) > 0 && strings.TrimSpace(args[0]) == "" {
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec requires non-empty sandbox")}
 	}
+	if cmd.Flags().Changed("run") && strings.TrimSpace(options.RunID) == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("exec --run requires a value")}
+	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "exec", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "exec")
 	if err != nil {
 		return err
 	}

--- a/cmd/agent-compose/cli_logs.go
+++ b/cmd/agent-compose/cli_logs.go
@@ -45,7 +45,7 @@ func runComposeLogsCommand(cmd *cobra.Command, cli cliOptions, options composeLo
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "logs", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "logs")
 	if err != nil {
 		return err
 	}

--- a/cmd/agent-compose/cli_misc_helpers_test.go
+++ b/cmd/agent-compose/cli_misc_helpers_test.go
@@ -259,8 +259,8 @@ agents:
 			{args: []string{"inspect", "--file", composePath, "session"}, code: exitCodeUsage, want: "requires a sandbox"},
 			{args: []string{"inspect", "--file", composePath, "unknown"}, code: exitCodeUsage, want: "unsupported inspect target"},
 			{args: []string{"inspect", "--host", server.URL, "--file", composePath, "project"}, code: exitCodeUsage, want: "has not been started"},
-			{args: []string{"inspect", "--host", server.URL, "--file", composePath, "run", "missing"}, code: exitCodeUsage, want: "run missing"},
-			{args: []string{"inspect", "--host", server.URL, "--file", composePath, "sandbox", "sandbox-1"}, code: exitCodeUnavailable, want: "sandbox unavailable"},
+			{args: []string{"inspect", "--host", server.URL, "--file", composePath, "run", "missing"}, code: exitCodeUsage, want: "has not been started"},
+			{args: []string{"inspect", "--host", server.URL, "--file", composePath, "sandbox", "sandbox-1"}, code: exitCodeUsage, want: "has not been started"},
 		} {
 			stdout, stderr, _, exitCode := executeCLICommand(tc.args...)
 			if exitCode != tc.code || stdout != "" || !strings.Contains(stderr, tc.want) {

--- a/cmd/agent-compose/cli_project_agent_commands.go
+++ b/cmd/agent-compose/cli_project_agent_commands.go
@@ -94,7 +94,7 @@ func runComposeListAgentsCommand(cmd *cobra.Command, options cliOptions) error {
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, options, "agent ls", runtimeProjectWithState)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, options, "agent ls")
 	if err != nil {
 		return err
 	}

--- a/cmd/agent-compose/cli_project_inspect.go
+++ b/cmd/agent-compose/cli_project_inspect.go
@@ -16,7 +16,7 @@ import (
 func runComposeProjectInspectCommand(cmd *cobra.Command, cli cliOptions, clients cliServiceClients, ref string) error {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
-		runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "inspect project", runtimeProjectWithState)
+		runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "inspect project")
 		if err != nil {
 			return err
 		}

--- a/cmd/agent-compose/cli_project_test.go
+++ b/cmd/agent-compose/cli_project_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"agent-compose/pkg/agentcompose/api"
+	"agent-compose/pkg/compose"
+	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"context"
@@ -736,6 +739,13 @@ func TestComposePSAllIncludesEveryStatusOnlyForCurrentProject(t *testing.T) {
 }
 
 func testCLIProject(projectID, name, sourcePath string) *agentcomposev2.Project {
+	if strings.TrimSpace(projectID) == "" {
+		var err error
+		projectID, err = domain.StableProjectID(name, sourcePath)
+		if err != nil {
+			panic(fmt.Sprintf("resolve test project ID: %v", err))
+		}
+	}
 	return &agentcomposev2.Project{
 		Summary: &agentcomposev2.ProjectSummary{
 			ProjectId:       projectID,
@@ -778,4 +788,19 @@ func testCLIProject(projectID, name, sourcePath string) *agentcomposev2.Project 
 			},
 		},
 	}
+}
+
+func testCLIProjectFromCompose(t *testing.T, projectID, sourcePath string) *agentcomposev2.Project {
+	t.Helper()
+	normalized, err := compose.NormalizeFile(sourcePath)
+	if err != nil {
+		t.Fatalf("normalize project fixture: %v", err)
+	}
+	spec, err := api.ProjectSpecToProtoChecked(normalized)
+	if err != nil {
+		t.Fatalf("encode project fixture: %v", err)
+	}
+	project := testCLIProject(projectID, normalized.Name, sourcePath)
+	project.Spec = spec
+	return project
 }

--- a/cmd/agent-compose/cli_project_workflow_test.go
+++ b/cmd/agent-compose/cli_project_workflow_test.go
@@ -306,8 +306,8 @@ agents:
 			project: projectServiceStub{
 				removeProject: func(_ context.Context, req *connect.Request[agentcomposev2.RemoveProjectRequest]) (*connect.Response[agentcomposev2.RemoveProjectResponse], error) {
 					callCount++
-					if strings.TrimSpace(req.Msg.GetProject().GetProjectId()) == "" {
-						t.Fatalf("RemoveProject project id is empty: %#v", req.Msg.GetProject())
+					if req.Msg.GetProject().GetName() != "cli-down-demo" || req.Msg.GetProject().GetProjectId() != "" {
+						t.Fatalf("RemoveProject selector = %#v, want project name", req.Msg.GetProject())
 					}
 					project := testCLIProject("project-down", "cli-down-demo", "compose.yml")
 					if callCount == 1 {

--- a/cmd/agent-compose/cli_ps_run_association_test.go
+++ b/cmd/agent-compose/cli_ps_run_association_test.go
@@ -95,8 +95,9 @@ agents:
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
-				projectID = req.Msg.GetProject().GetProjectId()
-				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(projectID, "cli-ps-scheduler-run", composePath)}), nil
+				project := testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-ps-scheduler-run", composePath)
+				projectID = project.GetSummary().GetProjectId()
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
 			},
 			batchGetLatestSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.BatchGetLatestSchedulerRunsRequest]) (*connect.Response[agentcomposev2.BatchGetLatestSchedulerRunsResponse], error) {
 				if req.Msg.GetProject().GetProjectId() != projectID || len(req.Msg.GetSandboxIds()) != 1 || req.Msg.GetSandboxIds()[0] != sandboxID {

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -134,15 +134,15 @@ func runComposeDownCommand(cmd *cobra.Command, cli cliOptions) error {
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "down", runtimeProjectIdentityOnly)
+	selection, err := resolveComposeRuntimeProjectSelectionForCLI(cli)
 	if err != nil {
 		return err
 	}
 	resp, err := clients.project.RemoveProject(cmd.Context(), connect.NewRequest(&agentcomposev2.RemoveProjectRequest{
-		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: runtimeProject.id()}},
+		Project: selection.ref,
 	}))
 	if err != nil {
-		return commandExitErrorForConnect(fmt.Errorf("down project %s: %w", runtimeProject.name(), err))
+		return commandExitErrorForConnect(fmt.Errorf("down project %s: %w", selection.requestedName, err))
 	}
 	output := composeDownOutputFromResponse(resp.Msg)
 	if cli.JSON {
@@ -153,13 +153,13 @@ func runComposeDownCommand(cmd *cobra.Command, cli cliOptions) error {
 		if err := writeCommandOutput(cmd.OutOrStdout(), append(data, '\n')); err != nil {
 			return err
 		}
-	} else if err := writeComposeDownText(cmd.OutOrStdout(), composeDownDisplayChanges(resp.Msg, runtimeProject.spec)); err != nil {
+	} else if err := writeComposeDownText(cmd.OutOrStdout(), composeDownDisplayChanges(resp.Msg, selection.localSpec)); err != nil {
 		return err
 	}
 	if output.FailedSandboxStops > 0 {
 		return commandExitError{
 			Code: exitCodeGeneral,
-			Err:  fmt.Errorf("down project %s completed with %d sandbox stop failure(s)", runtimeProject.name(), output.FailedSandboxStops),
+			Err:  fmt.Errorf("down project %s completed with %d sandbox stop failure(s)", selection.requestedName, output.FailedSandboxStops),
 		}
 	}
 	return nil
@@ -173,7 +173,7 @@ func runComposeStatsCommand(cmd *cobra.Command, cli cliOptions, args []string) e
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "stats", runtimeProjectWithState)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "stats")
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "run", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "run")
 	if err != nil {
 		return err
 	}
@@ -479,7 +479,7 @@ func runComposePSCommand(cmd *cobra.Command, cli cliOptions, options composePSOp
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "ps", runtimeProjectWithState)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "ps")
 	if err != nil {
 		return err
 	}
@@ -548,11 +548,7 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 	if kind == "project" {
 		return runComposeProjectInspectCommand(cmd, cli, clients, target)
 	}
-	loadMode := runtimeProjectIdentityOnly
-	if kind == "agent" {
-		loadMode = runtimeProjectWithState
-	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "inspect "+kind, loadMode)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "inspect "+kind)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent-compose/cli_run_stream_test.go
+++ b/cmd/agent-compose/cli_run_stream_test.go
@@ -19,7 +19,13 @@ agents:
   reviewer:
     provider: %s
 `, provider, provider))
-			stdout, stderr, _, exitCode := executeCLICommandWithInput("hello\n", "run", "--file", composePath, "reviewer", "-i", "-t", "--prompt", "hello")
+			server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
+				getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+					return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProjectFromCompose(t, req.Msg.GetProject().GetProjectId(), composePath)}), nil
+				},
+			}})
+			defer server.Close()
+			stdout, stderr, _, exitCode := executeCLICommandWithInput("hello\n", "run", "--host", server.URL, "--file", composePath, "reviewer", "-i", "-t", "--prompt", "hello")
 			if exitCode != exitCodeUnsupported {
 				t.Fatalf("run --prompt -it %s exit code = %d, want %d; stderr=%q", provider, exitCode, exitCodeUnsupported, stderr)
 			}

--- a/cmd/agent-compose/cli_runtime_project.go
+++ b/cmd/agent-compose/cli_runtime_project.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"agent-compose/pkg/compose"
+	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"context"
@@ -25,13 +26,6 @@ type composeRuntimeProjectSelection struct {
 	localSpec     *compose.NormalizedProjectSpec
 }
 
-type composeRuntimeProjectLoadMode uint8
-
-const (
-	runtimeProjectIdentityOnly composeRuntimeProjectLoadMode = iota
-	runtimeProjectWithState
-)
-
 func (p composeRuntimeProject) id() string {
 	return strings.TrimSpace(p.project.GetSummary().GetProjectId())
 }
@@ -43,27 +37,31 @@ func (p composeRuntimeProject) name() string {
 // resolveComposeRuntimeProject resolves an explicit project name as an
 // already-applied project filter. Without one, the compose file identifies the
 // project.
-func resolveComposeRuntimeProject(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, cli cliOptions, command string, loadMode composeRuntimeProjectLoadMode) (composeRuntimeProject, error) {
+func resolveComposeRuntimeProject(ctx context.Context, client agentcomposev2connect.ProjectServiceClient, cli cliOptions, command string) (composeRuntimeProject, error) {
 	selection, err := resolveComposeRuntimeProjectSelectionForCLI(cli)
 	if err != nil {
 		return composeRuntimeProject{}, err
-	}
-	if selection.localSpec != nil && loadMode == runtimeProjectIdentityOnly {
-		return composeRuntimeProject{
-			composePath: selection.composePath,
-			project: &agentcomposev2.Project{Summary: &agentcomposev2.ProjectSummary{
-				ProjectId:  selection.ref.GetProjectId(),
-				Name:       selection.requestedName,
-				SourcePath: selection.composePath,
-			}},
-			spec: selection.localSpec,
-		}, nil
 	}
 	response, err := client.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
 		Project:     selection.ref,
 		IncludeSpec: true,
 	}))
 	if err != nil {
+		if connect.CodeOf(err) == connect.CodeUnimplemented && selection.localSpec != nil {
+			projectID, idErr := domain.StableProjectID(selection.requestedName, "")
+			if idErr != nil {
+				return composeRuntimeProject{}, idErr
+			}
+			return composeRuntimeProject{
+				composePath: selection.composePath,
+				project: &agentcomposev2.Project{Summary: &agentcomposev2.ProjectSummary{
+					ProjectId:  projectID,
+					Name:       selection.requestedName,
+					SourcePath: selection.composePath,
+				}},
+				spec: selection.localSpec,
+			}, nil
+		}
 		return composeRuntimeProject{}, commandExitErrorForComposeProject(fmt.Errorf("get project %s: %w", selection.requestedName, err), command, selection.requestedName, selection.composePath)
 	}
 	project := response.Msg.GetProject()
@@ -91,14 +89,14 @@ func resolveComposeRuntimeProjectSelectionForCLI(cli cliOptions) (composeRuntime
 	if projectName != "" {
 		return composeRuntimeProjectSelection{requestedName: projectName, ref: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_Name{Name: projectName}}}, nil
 	}
-	composePath, normalized, projectID, err := resolveComposeProject(cli)
+	composePath, normalized, _, err := resolveComposeProject(cli)
 	if err != nil {
 		return composeRuntimeProjectSelection{}, err
 	}
 	return composeRuntimeProjectSelection{
 		composePath:   composePath,
 		requestedName: normalized.Name,
-		ref:           &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
+		ref:           &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_Name{Name: normalized.Name}},
 		localSpec:     normalized,
 	}, nil
 }
@@ -108,8 +106,8 @@ func resolveComposeRuntimeProjectSelectionForCLI(cli cliOptions) (composeRuntime
 // daemon remains the source of truth; no local config is read here.
 func normalizedRuntimeProjectSpec(project *agentcomposev2.Project) *compose.NormalizedProjectSpec {
 	result := &compose.NormalizedProjectSpec{Name: project.GetSummary().GetName()}
-	if spec := project.GetSpec(); spec != nil {
-		result.Name = firstNonEmptyString(spec.GetName(), result.Name)
+	if spec := project.GetSpec(); spec != nil && (len(spec.GetAgents()) > 0 || len(project.GetAgents()) == 0) {
+		result.Name = firstNonEmptyString(result.Name, spec.GetName())
 		result.Agents = make([]compose.NormalizedAgentSpec, 0, len(spec.GetAgents()))
 		for _, agent := range spec.GetAgents() {
 			result.Agents = append(result.Agents, normalizedRuntimeAgentSpec(agent))

--- a/cmd/agent-compose/cli_runtime_project_test.go
+++ b/cmd/agent-compose/cli_runtime_project_test.go
@@ -49,7 +49,7 @@ func TestIntegrationCLIRuntimeCommandsSelectStoredProjectByName(t *testing.T) {
 				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
 			},
 			removeProject: func(_ context.Context, req *connect.Request[agentcomposev2.RemoveProjectRequest]) (*connect.Response[agentcomposev2.RemoveProjectResponse], error) {
-				if req.Msg.GetProject().GetProjectId() != "project-stored" {
+				if req.Msg.GetProject().GetName() != "stored-project" || req.Msg.GetProject().GetProjectId() != "" {
 					t.Fatalf("RemoveProject ref = %#v", req.Msg.GetProject())
 				}
 				return connect.NewResponse(&agentcomposev2.RemoveProjectResponse{Project: project}), nil
@@ -106,8 +106,8 @@ func TestIntegrationCLIRuntimeCommandsSelectStoredProjectByName(t *testing.T) {
 			}
 		})
 	}
-	if getProjectCalls != len(tests) {
-		t.Fatalf("GetProject calls = %d, want %d", getProjectCalls, len(tests))
+	if getProjectCalls != len(tests)-1 {
+		t.Fatalf("GetProject calls = %d, want %d", getProjectCalls, len(tests)-1)
 	}
 }
 

--- a/cmd/agent-compose/cli_sandbox_lifecycle.go
+++ b/cmd/agent-compose/cli_sandbox_lifecycle.go
@@ -302,7 +302,7 @@ func resolveComposeSandboxRefsForCommand(ctx context.Context, cli cliOptions, cl
 			continue
 		}
 		if projectID == "" {
-			runtimeProject, err := resolveComposeRuntimeProject(ctx, clients.project, cli, "resolve sandbox", runtimeProjectIdentityOnly)
+			runtimeProject, err := resolveComposeRuntimeProject(ctx, clients.project, cli, "resolve sandbox")
 			if err != nil {
 				return nil, err
 			}
@@ -325,7 +325,7 @@ func resolveComposeSandboxRefForCommand(ctx context.Context, cli cliOptions, cli
 	if !shouldResolveComposeLogResourceRef(ref) {
 		return ref, nil
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(ctx, clients.project, cli, "resolve sandbox", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(ctx, clients.project, cli, "resolve sandbox")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/agent-compose/cli_sandbox_prune.go
+++ b/cmd/agent-compose/cli_sandbox_prune.go
@@ -55,7 +55,7 @@ func runComposeSandboxPruneCommand(cmd *cobra.Command, cli cliOptions, options c
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "sandbox prune", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "sandbox prune")
 	if err != nil {
 		return err
 	}

--- a/cmd/agent-compose/cli_scheduler_command.go
+++ b/cmd/agent-compose/cli_scheduler_command.go
@@ -59,7 +59,7 @@ func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options 
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler runs", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler runs")
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options 
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler logs", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler logs")
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, optio
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler inspect", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler inspect")
 	if err != nil {
 		return err
 	}

--- a/cmd/agent-compose/cli_scheduler_prune.go
+++ b/cmd/agent-compose/cli_scheduler_prune.go
@@ -58,11 +58,19 @@ func runComposeSchedulerPruneCommand(cmd interface {
 	Context() context.Context
 	OutOrStdout() io.Writer
 }, cli cliOptions, options composeSchedulerPruneOptions) error {
+	statuses, statusNames, err := parseSchedulerRunPruneStatuses(options.Status)
+	if err != nil {
+		return err
+	}
+	olderThanSeconds, err := parseOlderThanSeconds(options.OlderThan)
+	if err != nil {
+		return commandExitError{Code: exitCodeUsage, Err: err}
+	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler prune", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler prune")
 	if err != nil {
 		return err
 	}
@@ -85,14 +93,6 @@ func runComposeSchedulerPruneCommand(cmd interface {
 			}
 			return err
 		}
-	}
-	statuses, statusNames, err := parseSchedulerRunPruneStatuses(options.Status)
-	if err != nil {
-		return err
-	}
-	olderThanSeconds, err := parseOlderThanSeconds(options.OlderThan)
-	if err != nil {
-		return commandExitError{Code: exitCodeUsage, Err: err}
 	}
 	response, err := clients.project.PruneSchedulerRuns(cmd.Context(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
 		Project:          &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},

--- a/cmd/agent-compose/cli_scheduler_prune_test.go
+++ b/cmd/agent-compose/cli_scheduler_prune_test.go
@@ -71,7 +71,7 @@ func TestIntegrationCLISchedulerPruneMapsFiltersAndJSONStats(t *testing.T) {
 	var captured *agentcomposev2.PruneSchedulerRunsRequest
 	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
 		getProject: func(_ context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
-			return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "scheduler-prune-test", composePath)}), nil
+			return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProjectFromCompose(t, req.Msg.GetProject().GetProjectId(), composePath)}), nil
 		},
 		pruneSchedulerRuns: func(_ context.Context, req *connect.Request[agentcomposev2.PruneSchedulerRunsRequest]) (*connect.Response[agentcomposev2.PruneSchedulerRunsResponse], error) {
 			captured = req.Msg

--- a/cmd/agent-compose/cli_scheduler_query.go
+++ b/cmd/agent-compose/cli_scheduler_query.go
@@ -27,7 +27,7 @@ func runComposeSchedulerListCommand(cmd *cobra.Command, cli cliOptions, options 
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler ls", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler ls")
 	if err != nil {
 		return err
 	}

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -301,7 +301,7 @@ agents:
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
-				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-scheduler-list", composePath)}), nil
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProjectFromCompose(t, req.Msg.GetProject().GetProjectId(), composePath)}), nil
 			},
 			listSchedulerEvents: func(context.Context, *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error) {
 				return connect.NewResponse(&agentcomposev2.ListSchedulerEventsResponse{}), nil
@@ -444,7 +444,11 @@ agents:
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
-				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-scheduler-observability", composePath)}), nil
+				projectID, err := domain.StableProjectID("cli-scheduler-observability", "")
+				if err != nil {
+					t.Fatalf("resolve test project ID: %v", err)
+				}
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(projectID, "cli-scheduler-observability", composePath)}), nil
 			},
 			listSchedulerRuns: func(context.Context, *connect.Request[agentcomposev2.ListSchedulerRunsRequest]) (*connect.Response[agentcomposev2.ListSchedulerRunsResponse], error) {
 				return connect.NewResponse(&agentcomposev2.ListSchedulerRunsResponse{Runs: []*agentcomposev2.SchedulerRun{{
@@ -725,7 +729,7 @@ agents:
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
-				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-scheduler-inspect", composePath)}), nil
+				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: testCLIProjectFromCompose(t, req.Msg.GetProject().GetProjectId(), composePath)}), nil
 			},
 		},
 	})
@@ -770,7 +774,7 @@ agents:
 	server := newComposeServiceStubServer(t, composeServiceStubs{
 		project: projectServiceStub{
 			getProject: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
-				project := testCLIProject(req.Msg.GetProject().GetProjectId(), "cli-scheduler-loader", composePath)
+				project := testCLIProjectFromCompose(t, req.Msg.GetProject().GetProjectId(), composePath)
 				return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
 			},
 			getScheduler: func(_ context.Context, req *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error) {

--- a/cmd/agent-compose/scheduler_runs.go
+++ b/cmd/agent-compose/scheduler_runs.go
@@ -67,7 +67,7 @@ func runComposeSchedulerInvokeCommand(cmd *cobra.Command, cli cliOptions, option
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler invoke", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler invoke")
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func runComposeSchedulerTriggerV2Command(cmd *cobra.Command, cli cliOptions, opt
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler trigger", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler trigger")
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func runComposeSchedulerStopCommand(cmd *cobra.Command, cli cliOptions, options 
 	if err != nil {
 		return err
 	}
-	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler stop", runtimeProjectIdentityOnly)
+	runtimeProject, err := resolveComposeRuntimeProject(cmd.Context(), clients.project, cli, "scheduler stop")
 	if err != nil {
 		return err
 	}

--- a/docs/design/proto_v2_api_contract.md
+++ b/docs/design/proto_v2_api_contract.md
@@ -12,7 +12,7 @@ Single-resource requests use one of these forms:
 
 | Selector | Contract |
 | --- | --- |
-| `ProjectRef` | Exactly one non-empty `project_id`, `name`, or `source_path`. IDs are stable; names and source paths are exact mutable lookup keys. |
+| `ProjectRef` | Exactly one non-empty `project_id`, `name`, or `source_path`. IDs are stable, names are daemon-unique project identities, and source paths are exact mutable lookup keys. |
 | `ExecRequest.target` | Exactly one `sandbox_id`, `run_id`, or `selector`. Empty selected scalar cases are invalid. |
 | `ExecSandboxSelector.project` | Exactly one non-empty `project_id` or `project_name`; `agent_name` is an optional narrowing filter, not an alternative project selector. |
 | Hierarchical project resources | Scheduler requests combine one `ProjectRef` with required `agent_name` and, where applicable, `trigger_id` or `run_id`. These fields identify nested resources and are not mutually exclusive alternatives. |

--- a/docs/design/resource_identity_cli_design.md
+++ b/docs/design/resource_identity_cli_design.md
@@ -38,6 +38,16 @@ The key idea is to separate human names from opaque identity:
 
 Declared resources come from `agent-compose.yml` or the project directory.
 
+The normalized project name is unique within one daemon and is the project
+identity. The compose source path is mutable metadata and does not participate
+in ID generation.
+
+When uniqueness is introduced for an existing database, duplicate projects are
+not merged. Active records rank before removed records, followed by
+`updated_at DESC`, `created_at DESC`, and full `id ASC`. The first record keeps
+the name; later records receive the next unused `<name>-N` suffix. IDs and all
+project-owned relationships remain unchanged.
+
 | Resource | Public identifier | Default display | Additional handles |
 | --- | --- | --- | --- |
 | Project | `name`, or config directory name when omitted | project name | `id`, `short_id` in verbose/JSON |

--- a/docs/design/resource_identity_cli_design.md
+++ b/docs/design/resource_identity_cli_design.md
@@ -38,9 +38,9 @@ The key idea is to separate human names from opaque identity:
 
 Declared resources come from `agent-compose.yml` or the project directory.
 
-The normalized project name is unique within one daemon and is the project
-identity. The compose source path is mutable metadata and does not participate
-in ID generation.
+The normalized project name is a unique public selector within one daemon. The
+opaque project ID is the durable identity, while the compose source path is
+mutable metadata and does not participate in initial ID generation.
 
 When uniqueness is introduced for an existing database, duplicate projects are
 not merged. Active records rank before removed records, followed by

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -149,7 +149,7 @@ agents:
 - Unknown fields are rejected rather than silently ignored.
 - A field repeated in the same mapping is rejected as a duplicate.
 - Boolean fields must be YAML booleans, list fields must be sequences, and object fields must be mappings.
-- Project names, agent names, project workspace keys, MCP names, volume keys, and final skill names must match `^[a-z][a-z0-9_-]*$`.
+- Project names must match `^[a-z0-9][a-z0-9_-]*$`. Agent names, project workspace keys, MCP names, volume keys, and final skill names use the stricter `^[a-z][a-z0-9_-]*$` form.
 - Relative paths use field-specific base directories described below.
 
 ### Environment sources and precedence
@@ -196,7 +196,7 @@ SECRET_VALUE:
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
-| `name` | string | Conditionally | Project identifier. If omitted, the compose directory name is used; the final value must be a stable identifier. |
+| `name` | string | Conditionally | Project identifier. If omitted, a Docker Compose-compatible name is derived from the compose directory. |
 | `env_file` | string or string[] | No | Dotenv files used for interpolation. Relative paths are resolved from the compose directory. |
 | `variables` | map | No | Project-level named values and secret metadata stored in the normalized project specification. |
 | `workspaces` | map | No | Reusable project workspace definitions. Only the plural top-level form is valid. |
@@ -211,7 +211,7 @@ SECRET_VALUE:
 name: code-review
 ```
 
-The value must begin with a lowercase letter and may then contain lowercase letters, digits, `_`, and `-`. `review-v2` is valid; `Review`, `2-review`, and names containing spaces are not. Project identity also incorporates the normalized source path, allowing projects with the same name from different compose paths to remain distinct.
+The value must match `^[a-z0-9][a-z0-9_-]*$`. `review-v2` and `2-review` are valid; `Review` and names containing spaces are not. When omitted, the compose directory basename is lowercased, unsupported characters are removed, and leading `_` or `-` characters are trimmed. The resulting name is the daemon-wide project identity; moving the compose file does not create another project.
 
 ### `env_file`
 
@@ -873,6 +873,12 @@ jupyter:
 Setting `guest_port` while leaving `enabled: false` retains the port configuration without enabling Jupyter by default. `agent-compose run --jupyter` can enable it for one run.
 
 ## Common errors and migration notes
+
+### Duplicate project names during upgrade
+
+An upgrade does not merge projects that already have the same name, because matching names and compose paths do not prove that their histories are equivalent. One project keeps the original name; active projects are preferred, then the most recently updated project, with creation time and full ID as deterministic tie-breakers. The others are renamed to the next available `<name>-N` value. Existing numeric suffixes are skipped.
+
+Every project ID and its revisions, agents, schedulers, runs, sandboxes, and volume associations remain attached to the same project. Use `agent-compose project ls` after the upgrade to see the assigned names. To update a suffixed project later, set that assigned name in its compose file.
 
 ### Using top-level `workspace`
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -183,6 +183,10 @@ agent-compose -f /path/to/project/agent-compose.yml up
 
 Current `up` semantics are daemon-style: the command applies the project and returns. It does not attach project logs and does not support `-d/--detach`.
 
+Project identity is resolved by the normalized project name, not by the compose file path. Applying the same name from a moved compose file updates the existing daemon project and retains its ID and history.
+
+If an upgrade finds multiple stored projects with the same name, it preserves every project and deterministically renames the additional records to available `<name>-N` values. Check `project ls` before operating on those projects and use the assigned name in the corresponding compose file.
+
 The top-level `up` command is an alias for `project up`.
 
 ## `project down`: Stop a Project
@@ -201,7 +205,7 @@ Notes:
 
 - `down` only affects the selected project.
 - When using `-f` or `--project-name`, verify that the command targets the intended project.
-- If some sandboxes cannot be stopped, the command exits non-zero and reports the failed items.
+- If some sandboxes cannot be stopped, the command exits non-zero, reports the failed items, and leaves the project active so `down` can be retried.
 
 ## `run`: Run a Sandbox
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -183,7 +183,7 @@ agent-compose -f /path/to/project/agent-compose.yml up
 
 Current `up` semantics are daemon-style: the command applies the project and returns. It does not attach project logs and does not support `-d/--detach`.
 
-Project identity is resolved by the normalized project name, not by the compose file path. Applying the same name from a moved compose file updates the existing daemon project and retains its ID and history.
+Project application is resolved by the normalized project name, not by the compose file path. Applying the same name from a moved compose file updates the existing daemon project and retains its durable ID and history.
 
 If an upgrade finds multiple stored projects with the same name, it preserves every project and deterministically renames the additional records to available `<name>-N` values. Check `project ls` before operating on those projects and use the assigned name in the corresponding compose file.
 

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -148,7 +148,7 @@ agents:
 - 顶层和各对象中的未知字段会报 `unknown field`，不会被静默忽略。
 - 同一映射中的重复字段会报 `duplicate field`。
 - 布尔字段必须是布尔值，列表字段必须是 YAML sequence，映射字段必须是 YAML mapping。
-- 项目名、Agent 名、顶层 Workspace 键、MCP 名、Volume 键和最终 Skill 名使用稳定标识符格式：`^[a-z][a-z0-9_-]*$`。
+- 项目名必须匹配 `^[a-z0-9][a-z0-9_-]*$`。Agent 名、顶层 Workspace 键、MCP 名、Volume 键和最终 Skill 名使用更严格的 `^[a-z][a-z0-9_-]*$` 格式。
 - 路径和 URL 的相对基准因字段而异，具体见对应章节。
 
 ### 环境变量来源和优先级
@@ -195,7 +195,7 @@ SECRET_VALUE:
 
 | 字段 | 类型 | 必填 | 作用 |
 | --- | --- | --- | --- |
-| `name` | string | 条件必填 | 项目标识。省略时尝试使用配置文件所在目录名；最终必须符合稳定标识符格式。 |
+| `name` | string | 条件必填 | 项目标识。省略时按照 Docker Compose 规则从配置文件目录推导。 |
 | `env_file` | string 或 string[] | 否 | 指定插值使用的 dotenv 文件。相对路径以配置文件目录为基准。 |
 | `variables` | map | 否 | 项目级命名变量及 secret 元数据，写入规范化项目配置。它们不会自动继承到 Agent 的 `env`，也不会成为其他 `${NAME}` 的变量来源。 |
 | `workspaces` | map | 否 | 可复用的项目级 Workspace 定义。只能使用复数形式。 |
@@ -210,7 +210,7 @@ SECRET_VALUE:
 name: code-review
 ```
 
-允许小写字母开头，后续可包含小写字母、数字、`_` 和 `-`。例如 `review-v2` 合法，`Review`、`2-review` 和包含空格的名称不合法。项目身份同时受规范化的配置文件路径影响，因此同名但来自不同路径的项目可被区分。
+名称必须匹配 `^[a-z0-9][a-z0-9_-]*$`。例如 `review-v2` 和 `2-review` 合法，`Review` 和包含空格的名称不合法。省略名称时，目录 basename 会转为小写、移除不支持的字符并裁掉开头的 `_` 或 `-`。最终名称是 daemon 内全局唯一的 project 身份；移动 compose 文件不会创建另一个 project。
 
 ### `env_file`
 
@@ -878,6 +878,12 @@ jupyter:
 设置 `guest_port` 但保持 `enabled: false` 会保留端口配置，但默认不启动 Jupyter。CLI `run --jupyter` 可以为单次运行启用。
 
 ## 常见错误与迁移提示
+
+### 升级时存在同名 project
+
+升级不会归并已有的同名 project，因为名称和 compose 路径相同并不能证明它们的历史数据等价。一个 project 保留原名：优先 active project，其次按最近更新时间排序，最后使用创建时间和完整 ID 做确定性排序。其余 project 依次改为下一个可用的 `<name>-N`，并跳过已经存在的数字后缀。
+
+每个 project 的 ID 以及 revision、agent、scheduler、run、sandbox 和 volume 关联仍属于原 project。升级后使用 `agent-compose project ls` 查看分配后的名称；后续如需更新带后缀的 project，应在对应 compose 文件中设置该名称。
 
 ### 顶层误写 `workspace`
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -178,6 +178,10 @@ agent-compose -f /path/to/project/agent-compose.yml up
 
 当前 `up` 的行为是将 project 应用到 daemon 后返回，project 后续由 daemon 管理。它不会 attach project 日志，也不提供 `-d/--detach` 参数。
 
+Project 身份由规范化后的 project name 决定，不再由 compose 文件路径决定。同名 compose 文件移动后再次执行 `up`，会更新 daemon 中原有 project，并保留其 ID 和历史。
+
+如果升级时数据库中已有多个同名 project，系统会保留每个 project，并把其余记录确定性地改为可用的 `<name>-N`。操作这些 project 前应先查看 `project ls`，并在对应 compose 文件中使用迁移后分配的名称。
+
 顶级 `up` 是 `project up` 的别名。
 
 ## `project down`：关闭 project
@@ -196,7 +200,7 @@ agent-compose -f /path/to/project/agent-compose.yml down
 
 - `down` 只影响当前 project。
 - 使用 `-f` 或 `--project-name` 时，应确认定位到的是预期 project。
-- 如果部分 sandbox 停止失败，命令返回非零退出码，并在输出中说明失败项。
+- 如果部分 sandbox 停止失败，命令返回非零退出码并说明失败项，同时保持 project 为 active，以便再次执行 `down`。
 
 ## `run`：运行 sandbox
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -178,7 +178,7 @@ agent-compose -f /path/to/project/agent-compose.yml up
 
 当前 `up` 的行为是将 project 应用到 daemon 后返回，project 后续由 daemon 管理。它不会 attach project 日志，也不提供 `-d/--detach` 参数。
 
-Project 身份由规范化后的 project name 决定，不再由 compose 文件路径决定。同名 compose 文件移动后再次执行 `up`，会更新 daemon 中原有 project，并保留其 ID 和历史。
+Project 应用通过规范化后的 project name 解析，不再由 compose 文件路径决定。同名 compose 文件移动后再次执行 `up`，会更新 daemon 中原有 project，并保留其持久 ID 和历史。
 
 如果升级时数据库中已有多个同名 project，系统会保留每个 project，并把其余记录确定性地改为可用的 `<name>-N`。操作这些 project 前应先查看 `project ls`，并在对应 compose 文件中使用迁移后分配的名称。
 

--- a/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
@@ -329,7 +329,7 @@ func TestLoaderSandboxRunnerResolvesVolumeMounts(t *testing.T) {
 	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, resolver, bridge.streams, nil, nil, bridge.agentExecutor)
 	projectRoot := t.TempDir()
 	projectPath := filepath.Join(projectRoot, "agent-compose.yml")
-	if _, err := bridge.configDB.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "Project", SourcePath: projectPath}); err != nil {
+	if _, err := bridge.configDB.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "project", SourcePath: projectPath}); err != nil {
 		t.Fatalf("UpsertProject returned error: %v", err)
 	}
 	projectVolume, err := bridge.configDB.CreateVolume(ctx, domain.VolumeRecord{ID: "vol-request-cache", Name: "project_request-cache", Driver: domain.VolumeDriverLocal, Path: t.TempDir()})

--- a/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
@@ -37,7 +37,7 @@ func TestIntegrationBatchGetLatestSchedulerRunsFindsRunBeyondFirstPage(t *testin
 
 	project, err := store.UpsertProject(ctx, domain.ProjectRecord{
 		ID:         "project-regression",
-		Name:       "Scheduler run regression",
+		Name:       "scheduler-run-regression",
 		SourcePath: "/tmp/scheduler-run-regression",
 		SourceJSON: `{"kind":"local"}`,
 	})
@@ -47,7 +47,7 @@ func TestIntegrationBatchGetLatestSchedulerRunsFindsRunBeyondFirstPage(t *testin
 	revision, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{
 		ProjectID: project.ID,
 		SpecHash:  "regression-spec",
-		SpecJSON:  `{"name":"Scheduler run regression","agents":[{"name":"reviewer","enabled":true,"scheduler":{"enabled":true,"sandbox_policy":"sticky","concurrency_policy":"skip","script":"function main() {}"}}]}`,
+		SpecJSON:  `{"name":"scheduler-run-regression","agents":[{"name":"reviewer","enabled":true,"scheduler":{"enabled":true,"sandbox_policy":"sticky","concurrency_policy":"skip","script":"function main() {}"}}]}`,
 	})
 	if err != nil {
 		t.Fatalf("create project revision: %v", err)

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 func TestProjectToProtoOnlyIncludesCurrentRevisionArtifacts(t *testing.T) {
-	project := domain.ProjectRecord{ID: "project", CurrentRevision: 2}
+	project := domain.ProjectRecord{ID: "project", Name: "current-name", CurrentRevision: 2}
 	agents := []domain.ProjectAgentRecord{{ProjectID: "project", AgentName: "old", Revision: 1}, {ProjectID: "project", AgentName: "current", Revision: 2}}
 	schedulers := []domain.ProjectSchedulerRecord{{ProjectID: "project", SchedulerID: "old", Revision: 1}, {ProjectID: "project", SchedulerID: "current", Revision: 2}}
-	result := ProjectToProto(project, nil, agents, schedulers)
+	revisionSpec := &agentcomposev2.ProjectSpec{Name: "historical-name"}
+	result := ProjectToProto(project, revisionSpec, agents, schedulers)
 	if len(result.GetAgents()) != 1 || result.GetAgents()[0].GetAgentName() != "current" {
 		t.Fatalf("agents = %#v", result.GetAgents())
 	}
@@ -27,6 +28,9 @@ func TestProjectToProtoOnlyIncludesCurrentRevisionArtifacts(t *testing.T) {
 	}
 	if result.GetSummary().GetAgentCount() != 1 || result.GetSummary().GetSchedulerCount() != 1 {
 		t.Fatalf("summary = %#v", result.GetSummary())
+	}
+	if result.GetSpec() != revisionSpec || result.GetSpec().GetName() != "historical-name" {
+		t.Fatalf("returned revision spec = %#v, want unchanged input %#v", result.GetSpec(), revisionSpec)
 	}
 }
 

--- a/pkg/agentcompose/app/run_supervisor_test.go
+++ b/pkg/agentcompose/app/run_supervisor_test.go
@@ -18,7 +18,7 @@ func TestRunSupervisorStopActiveRunRemovesActiveBeforeMarkCanceled(t *testing.T)
 	store := newRunSupervisorTestConfigStore(t)
 	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{
 		ID:         "project-1",
-		Name:       "Project",
+		Name:       "project",
 		SourcePath: "/tmp/project",
 		SourceJSON: "{}",
 	}); err != nil {
@@ -31,7 +31,7 @@ func TestRunSupervisorStopActiveRunRemovesActiveBeforeMarkCanceled(t *testing.T)
 	if _, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
 		RunID:       "run-1",
 		ProjectID:   "project-1",
-		ProjectName: "Project",
+		ProjectName: "project",
 		AgentName:   "worker",
 		AgentID:     agent.ID,
 		Source:      domain.ProjectRunSourceManual,

--- a/pkg/compose/canonical_json.go
+++ b/pkg/compose/canonical_json.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
 )
 
 // ParseCanonicalJSON decodes the immutable representation produced by
@@ -14,6 +17,7 @@ func ParseCanonicalJSON(data []byte) (*NormalizedProjectSpec, error) {
 		return nil, fmt.Errorf("decode canonical project spec: %w", err)
 	}
 	applyHistoricalAgentEnabledDefaults(data, ordered.Agents)
+	applyHistoricalSchedulerDefaults(ordered.Agents)
 	return normalizedProjectSpecFromOrdered(ordered), nil
 }
 
@@ -64,6 +68,21 @@ func applyHistoricalAgentEnabledDefaults(data []byte, agents []orderedAgentSpec)
 	for index := range agents {
 		if index >= len(shape.Agents) || shape.Agents[index].Enabled == nil {
 			agents[index].Enabled = true
+		}
+	}
+}
+
+func applyHistoricalSchedulerDefaults(agents []orderedAgentSpec) {
+	for index := range agents {
+		scheduler := agents[index].Scheduler
+		if scheduler == nil {
+			continue
+		}
+		if strings.TrimSpace(scheduler.SandboxPolicy) == "" {
+			scheduler.SandboxPolicy = domain.SchedulerSandboxPolicyNew
+		}
+		if strings.TrimSpace(scheduler.ConcurrencyPolicy) == "" {
+			scheduler.ConcurrencyPolicy = domain.SchedulerConcurrencyPolicySkip
 		}
 	}
 }

--- a/pkg/compose/canonical_json_test.go
+++ b/pkg/compose/canonical_json_test.go
@@ -74,6 +74,18 @@ func TestParseCanonicalJSONDefaultsHistoricalAgentEnabled(t *testing.T) {
 	}
 }
 
+func TestParseCanonicalJSONDefaultsHistoricalSchedulerPolicies(t *testing.T) {
+	parsed, err := ParseCanonicalJSON([]byte(`{"name":"historical","agents":[{"name":"missing","scheduler":{}},{"name":"empty","scheduler":{"sandbox_policy":"","concurrency_policy":""}}]}`))
+	if err != nil {
+		t.Fatalf("ParseCanonicalJSON returned error: %v", err)
+	}
+	for _, agent := range parsed.Agents {
+		if agent.Scheduler == nil || agent.Scheduler.SandboxPolicy != "new" || agent.Scheduler.ConcurrencyPolicy != "skip" {
+			t.Fatalf("historical scheduler default for %s = %#v", agent.Name, agent.Scheduler)
+		}
+	}
+}
+
 func TestParseCanonicalJSONRejectsMalformedJSON(t *testing.T) {
 	if _, err := ParseCanonicalJSON([]byte(`{"agents":`)); err == nil {
 		t.Fatal("ParseCanonicalJSON accepted malformed JSON")

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -26,6 +26,7 @@ const (
 )
 
 var stableIdentifierPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+var invalidDefaultProjectNamePattern = regexp.MustCompile(`[^a-z0-9_-]`)
 var volumeSourceNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
 var envReferencePattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 var composeCronParser = cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
@@ -190,7 +191,7 @@ func Normalize(spec *ProjectSpec, options NormalizeOptions) (*NormalizedProjectS
 	if name == "" {
 		name = defaultProjectName(options)
 	}
-	if err := validateStableIdentifier("name", name, "project name"); err != nil {
+	if err := validateProjectName("name", name); err != nil {
 		return nil, err
 	}
 
@@ -1358,6 +1359,16 @@ func validateStableIdentifier(path string, value string, label string) error {
 	return nil
 }
 
+func validateProjectName(path, value string) error {
+	if value == "" {
+		return &ValidationError{Path: path, Message: "project name is required"}
+	}
+	if !domain.IsProjectName(value) {
+		return &ValidationError{Path: path, Message: "project name must match " + domain.ProjectNamePattern}
+	}
+	return nil
+}
+
 func defaultProjectName(options NormalizeOptions) string {
 	dir := strings.TrimSpace(options.ProjectDir)
 	if dir == "" && strings.TrimSpace(options.ComposePath) != "" {
@@ -1373,7 +1384,9 @@ func defaultProjectName(options NormalizeOptions) string {
 	if abs, err := filepath.Abs(dir); err == nil {
 		dir = abs
 	}
-	return filepath.Base(filepath.Clean(dir))
+	name := strings.ToLower(filepath.Base(filepath.Clean(dir)))
+	name = invalidDefaultProjectNamePattern.ReplaceAllString(name, "")
+	return strings.TrimLeft(name, "-_")
 }
 
 func normalizeEnvVarMap(path string, values map[string]EnvVarSpec, options NormalizeOptions) (map[string]EnvVarSpec, error) {

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -96,6 +96,58 @@ agents:
 	}
 }
 
+func TestNormalizeProjectNameMatchesDockerComposeRules(t *testing.T) {
+	spec := mustParseCompose(t, "name: 1project\nagents: {}\n")
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize digit-prefixed project name: %v", err)
+	}
+	if normalized.Name != "1project" {
+		t.Fatalf("Name = %q, want 1project", normalized.Name)
+	}
+
+	defaulted, err := Normalize(mustParseCompose(t, "agents: {}\n"), NormalizeOptions{ProjectDir: "/tmp/Agent.Compose_Name"})
+	if err != nil {
+		t.Fatalf("Normalize default project name: %v", err)
+	}
+	if defaulted.Name != "agentcompose_name" {
+		t.Fatalf("default Name = %q, want agentcompose_name", defaulted.Name)
+	}
+}
+
+func TestNormalizeDefaultProjectNameMatchesDockerComposeDirectoryRules(t *testing.T) {
+	tests := []struct {
+		name       string
+		projectDir string
+		want       string
+		wantErr    string
+	}{
+		{name: "remove punctuation and lowercase", projectDir: "/tmp/Agent.Compose_Name", want: "agentcompose_name"},
+		{name: "trim leading hyphens", projectDir: "/tmp/---Foo.Bar", want: "foobar"},
+		{name: "trim leading underscores and allow digit", projectDir: "/tmp/___123.Project", want: "123project"},
+		{name: "preserve supported separators", projectDir: "/tmp/foo--BAR__", want: "foo--bar__"},
+		{name: "reject empty normalized name", projectDir: "/tmp/---...", wantErr: "project name is required"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			normalized, err := Normalize(mustParseCompose(t, "agents: {}\n"), NormalizeOptions{ProjectDir: test.projectDir})
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("Normalize error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize returned error: %v", err)
+			}
+			if normalized.Name != test.want {
+				t.Fatalf("Name = %q, want %q", normalized.Name, test.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeRequiresProjectNameWithoutDefaultPath(t *testing.T) {
 	spec := mustParseCompose(t, `
 agents:

--- a/pkg/model/project_ids.go
+++ b/pkg/model/project_ids.go
@@ -8,15 +8,21 @@ import (
 	"agent-compose/pkg/identity"
 )
 
-func StableProjectID(name, sourcePath string) (string, error) {
+// ProjectNamePattern is the Docker Compose-compatible project name contract.
+const ProjectNamePattern = `^[a-z0-9][a-z0-9_-]*$`
+
+// StableProjectID derives project identity from name alone. The source-path
+// parameter remains in the signature so existing callers do not need a
+// compatibility wrapper; moving a compose file must not change its identity.
+func StableProjectID(name, _ string) (string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return "", fmt.Errorf("project name is required")
 	}
-	if !IsProjectStableIdentifier(name) {
-		return "", fmt.Errorf("project name %q is not a stable identifier", name)
+	if !IsProjectName(name) {
+		return "", fmt.Errorf("project name %q must match %s", name, ProjectNamePattern)
 	}
-	return identity.NewID(identity.ResourceProject, name, NormalizeProjectSourcePath(sourcePath)), nil
+	return identity.NewID(identity.ResourceProject, name), nil
 }
 
 func StableProjectAgentID(projectID, agentName string) (string, error) {
@@ -112,6 +118,28 @@ func IsProjectStableIdentifier(value string) bool {
 	for i, r := range value {
 		switch {
 		case i == 0 && r >= 'a' && r <= 'z':
+		case i > 0 && r >= 'a' && r <= 'z':
+		case i > 0 && r >= '0' && r <= '9':
+		case i > 0 && (r == '-' || r == '_'):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// IsProjectName reports whether value follows the Docker Compose project-name
+// character contract. Other project-scoped resource names intentionally keep
+// the stricter stable-identifier contract.
+func IsProjectName(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		switch {
+		case i == 0 && r >= 'a' && r <= 'z':
+		case i == 0 && r >= '0' && r <= '9':
 		case i > 0 && r >= 'a' && r <= 'z':
 		case i > 0 && r >= '0' && r <= '9':
 		case i > 0 && (r == '-' || r == '_'):

--- a/pkg/model/project_ids.go
+++ b/pkg/model/project_ids.go
@@ -11,9 +11,10 @@ import (
 // ProjectNamePattern is the Docker Compose-compatible project name contract.
 const ProjectNamePattern = `^[a-z0-9][a-z0-9_-]*$`
 
-// StableProjectID derives project identity from name alone. The source-path
-// parameter remains in the signature so existing callers do not need a
-// compatibility wrapper; moving a compose file must not change its identity.
+// StableProjectID derives the initial project ID from name alone. The
+// source-path parameter remains in the signature so existing callers do not
+// need a compatibility wrapper; moving a compose file must not change its
+// identity.
 func StableProjectID(name, _ string) (string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {

--- a/pkg/model/stable_ids_test.go
+++ b/pkg/model/stable_ids_test.go
@@ -24,8 +24,8 @@ func TestProjectStableIDHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("other domain.StableProjectID returned error: %v", err)
 	}
-	if otherProjectID == projectID {
-		t.Fatalf("project id did not include source path: %q", projectID)
+	if otherProjectID != projectID {
+		t.Fatalf("project id changed with source path: %q != %q", otherProjectID, projectID)
 	}
 
 	agentID, err := domain.StableProjectAgentID(projectID, "reviewer")
@@ -70,6 +70,9 @@ func TestProjectStableIDHelpers(t *testing.T) {
 	}
 	if _, err := domain.StableProjectID("Demo", ""); err == nil {
 		t.Fatalf("domain.StableProjectID accepted non-normalized project name")
+	}
+	if _, err := domain.StableProjectID("1demo", ""); err != nil {
+		t.Fatalf("domain.StableProjectID rejected digit-prefixed project name: %v", err)
 	}
 	if _, err := domain.StableProjectAgentID(projectID, "Bad Agent"); err == nil {
 		t.Fatalf("domain.StableProjectAgentID accepted non-normalized agent name")

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -81,6 +81,7 @@ type SchedulerValidator interface {
 type VolumeManager interface {
 	Ensure(ctx context.Context, item domain.VolumeRecord) (domain.VolumeRecord, bool, error)
 	Inspect(ctx context.Context, nameOrID string) (domain.VolumeRecord, error)
+	ListProjectVolumes(ctx context.Context, projectID string) (map[string]domain.VolumeRecord, error)
 	ReplaceProjectVolumes(ctx context.Context, projectID string, links map[string]domain.ProjectVolumeLink) error
 	RemoveProjectVolumes(ctx context.Context, projectID string) error
 }
@@ -95,6 +96,7 @@ type Controller struct {
 	gateway    CapabilityGatewaySource
 	stop       func(context.Context, *domain.Sandbox) error
 	defaultDR  string
+	lifecycle  projectLifecycleGates
 }
 
 type ControllerDependencies struct {
@@ -184,6 +186,19 @@ func (c *Controller) ApplyProject(ctx context.Context, req ApplyRequest) (ApplyR
 	}
 	if issues := c.validateProjectAgentDefinitions(normalized); len(issues) > 0 {
 		return ApplyResult{Issues: issues, RevisionSpec: normalized.Spec}, nil
+	}
+	release, err := c.lifecycle.acquire(ctx, project.Name)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("apply project %s: wait for lifecycle operation: %w", normalized.Spec.Name, err)
+	}
+	defer release()
+	existingByName, nameFound, err := c.projectByNameIfExists(ctx, project.Name)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("apply project %s: resolve existing name: %w", normalized.Spec.Name, err)
+	}
+	if nameFound {
+		project.ID = existingByName.ID
+		project.ShortID = existingByName.ShortID
 	}
 	if issues := c.validateSchedulers(ctx, normalized); len(issues) > 0 {
 		return ApplyResult{Issues: issues, RevisionSpec: normalized.Spec}, nil
@@ -333,6 +348,17 @@ func (c *Controller) ApplyProject(ctx context.Context, req ApplyRequest) (ApplyR
 	}, nil
 }
 
+func (c *Controller) projectByNameIfExists(ctx context.Context, name string) (domain.ProjectRecord, bool, error) {
+	project, err := c.resolveProjectRef(ctx, ProjectRefByName(name), true)
+	if err == nil {
+		return project, true, nil
+	}
+	if errors.Is(err, domain.ErrNotFound) {
+		return domain.ProjectRecord{}, false, nil
+	}
+	return domain.ProjectRecord{}, false, err
+}
+
 func (c *Controller) capabilityGatewayWarnings(ctx context.Context, spec *compose.NormalizedProjectSpec) ([]ValidationIssue, error) {
 	if c.gateway == nil || !usesGlobalCapabilityGateway(spec) {
 		return nil, nil
@@ -389,6 +415,15 @@ func (c *Controller) RemoveProject(ctx context.Context, req RemoveRequest) (Remo
 	if err != nil {
 		return RemoveResult{}, err
 	}
+	release, err := c.lifecycle.acquire(ctx, project.Name)
+	if err != nil {
+		return RemoveResult{}, fmt.Errorf("remove project %s: wait for lifecycle operation: %w", project.Name, err)
+	}
+	defer release()
+	project, err = c.resolveProjectRef(ctx, ProjectRefByID(project.ID), true)
+	if err != nil {
+		return RemoveResult{}, err
+	}
 	downChanges, err := DownProject(ctx, project, DownOptions{
 		Store:             c.store,
 		Sandboxes:         c.sandboxes,
@@ -398,6 +433,17 @@ func (c *Controller) RemoveProject(ctx context.Context, req RemoveRequest) (Remo
 	changes := downChangesToChanges(downChanges)
 	if err != nil {
 		return RemoveResult{Project: project, Changes: changes}, err
+	}
+	if DownChangesHaveFailures(downChanges) {
+		agents, listAgentsErr := c.store.ListProjectAgents(ctx, project.ID)
+		if listAgentsErr != nil {
+			return RemoveResult{Project: project, Changes: changes}, listAgentsErr
+		}
+		schedulers, listSchedulersErr := c.store.ListProjectSchedulers(ctx, project.ID)
+		if listSchedulersErr != nil {
+			return RemoveResult{Project: project, Agents: agents, Changes: changes}, listSchedulersErr
+		}
+		return RemoveResult{Project: project, Agents: agents, Schedulers: schedulers, Changes: changes}, nil
 	}
 	if project.RemovedAt.IsZero() {
 		removedProject, err := c.store.MarkProjectRemoved(ctx, project.ID)
@@ -412,10 +458,10 @@ func (c *Controller) RemoveProject(ctx context.Context, req RemoveRequest) (Remo
 			Name:         project.Name,
 			Message:      "removed by project down",
 		})
-		if c.volumes != nil {
-			if err := c.volumes.RemoveProjectVolumes(ctx, project.ID); err != nil {
-				return RemoveResult{Project: project, Changes: changes}, err
-			}
+	}
+	if c.volumes != nil {
+		if err := c.volumes.RemoveProjectVolumes(ctx, project.ID); err != nil {
+			return RemoveResult{Project: project, Changes: changes}, err
 		}
 	}
 	agents, err := c.store.ListProjectAgents(ctx, project.ID)

--- a/pkg/projects/controller_coverage_test.go
+++ b/pkg/projects/controller_coverage_test.go
@@ -54,10 +54,7 @@ agents:
 		t.Fatalf("Hash returned error: %v", err)
 	}
 	store := &controllerCoverageStore{
-		projects: []domain.ProjectRecord{
-			{ID: "project-1", Name: "coverage-project", SourcePath: "/one"},
-			{ID: "project-2", Name: "coverage-project", SourcePath: "/two"},
-		},
+		projects: []domain.ProjectRecord{{ID: "project-1", Name: "coverage-project", SourcePath: "/one"}},
 	}
 	controller := NewController(ControllerDependencies{
 		Config:     &appconfig.Config{RuntimeDriver: driverpkg.RuntimeDriverDocker},
@@ -73,7 +70,7 @@ agents:
 	if err != nil {
 		t.Fatalf("ApplyProject dry-run returned error: %v", err)
 	}
-	if dryRun.Applied || len(dryRun.Agents) != 1 || len(dryRun.Schedulers) != 1 || len(dryRun.Changes) < 4 {
+	if dryRun.Applied || dryRun.Project.ID != "project-1" || len(dryRun.Agents) != 1 || len(dryRun.Schedulers) != 1 || len(dryRun.Changes) < 4 {
 		t.Fatalf("dryRun = %#v", dryRun)
 	}
 	if !strings.Contains(dryRun.Agents[0].SpecJSON, `"jupyter"`) {
@@ -85,6 +82,7 @@ agents:
 	if missingSpec, err := controller.ValidateProject(ctx, NormalizedProject{}, nil); err != nil || missingSpec.Valid {
 		t.Fatalf("ValidateProject missing spec=%#v err=%v", missingSpec, err)
 	}
+	store.projects = append(store.projects, domain.ProjectRecord{ID: "project-2", Name: "coverage-project", SourcePath: "/two"})
 	if _, err := controller.ResolveProjectRef(ctx, ProjectRefByName("coverage-project")); !errors.Is(err, domain.ErrAmbiguous) {
 		t.Fatalf("expected ambiguous project error, got %v", err)
 	}
@@ -130,6 +128,66 @@ func TestControllerRemoveProjectMarksProjectRemovedAndIsIdempotent(t *testing.T)
 	}
 	if len(repeated.Changes) != 0 {
 		t.Fatalf("repeated RemoveProject changes=%#v, want unchanged", repeated.Changes)
+	}
+}
+
+func TestControllerRemoveProjectKeepsProjectActiveWhenSandboxStopFails(t *testing.T) {
+	project := domain.ProjectRecord{ID: "project-partial", Name: "partial-down"}
+	store := &controllerCoverageStore{projects: []domain.ProjectRecord{project}}
+	volumeManager := &controllerCoverageVolumeManager{}
+	controller := NewController(ControllerDependencies{
+		Store: store,
+		Sandboxes: downCoverageSessions{sessions: []*domain.Sandbox{{Summary: domain.SandboxSummary{
+			ID: "sandbox-failed", Tags: []domain.SandboxTag{{Name: "project", Value: project.ID}},
+		}}}},
+		Volumes: volumeManager,
+		StopSandbox: func(context.Context, *domain.Sandbox) error {
+			return errors.New("stop failed")
+		},
+	})
+	result, err := controller.RemoveProject(context.Background(), RemoveRequest{Project: ProjectRefByID(project.ID)})
+	if err != nil {
+		t.Fatalf("RemoveProject returned error: %v", err)
+	}
+	if !result.Project.RemovedAt.IsZero() {
+		t.Fatalf("partially stopped project was marked removed: %#v", result.Project)
+	}
+	if len(volumeManager.removedProjects) != 0 {
+		t.Fatalf("partial down removed volume links: %#v", volumeManager.removedProjects)
+	}
+	failureReported := false
+	for _, change := range result.Changes {
+		if change.ResourceType == "sandbox" && change.Action == ChangeActionUnchanged && strings.Contains(change.Message, "failed to stop") {
+			failureReported = true
+		}
+	}
+	if !failureReported {
+		t.Fatalf("partial down changes did not report failure: %#v", result.Changes)
+	}
+}
+
+func TestControllerRemoveProjectRetriesVolumeCleanupAfterRemoval(t *testing.T) {
+	project := domain.ProjectRecord{ID: "project-volume-retry", Name: "volume-retry"}
+	store := &controllerCoverageStore{projects: []domain.ProjectRecord{project}}
+	volumeManager := &controllerCoverageVolumeManager{removeErr: errors.New("volume cleanup failed")}
+	controller := NewController(ControllerDependencies{
+		Store: store, Sandboxes: controllerCoverageSessionStore{}, Volumes: volumeManager,
+	})
+
+	first, err := controller.RemoveProject(context.Background(), RemoveRequest{Project: ProjectRefByID(project.ID)})
+	if err == nil || first.Project.RemovedAt.IsZero() {
+		t.Fatalf("first down result=%#v err=%v, want removed project and cleanup error", first, err)
+	}
+	volumeManager.removeErr = nil
+	second, err := controller.RemoveProject(context.Background(), RemoveRequest{Project: ProjectRefByID(project.ID)})
+	if err != nil {
+		t.Fatalf("retry down returned error: %v", err)
+	}
+	if len(volumeManager.removedProjects) != 2 {
+		t.Fatalf("volume cleanup calls = %#v, want two attempts", volumeManager.removedProjects)
+	}
+	if !second.Project.RemovedAt.Equal(first.Project.RemovedAt) {
+		t.Fatalf("retry changed removed time from %v to %v", first.Project.RemovedAt, second.Project.RemovedAt)
 	}
 }
 
@@ -204,6 +262,9 @@ func TestDownProjectSandboxAndSchedulerWorkflows(t *testing.T) {
 	assertDownChange(t, changes, DownChangeUnchanged, "sandbox", "session-fail")
 	assertDownChange(t, changes, DownChangeUpdated, "sandbox", "session-ok")
 	assertDownChange(t, changes, DownChangeUpdated, "sandbox", "session-legacy")
+	if !DownChangesHaveFailures(changes) || DownChangesHaveFailures(nil) {
+		t.Fatalf("DownChangesHaveFailures(%#v) returned unexpected result", changes)
+	}
 	if SandboxHasTag(nil, "project", project.ID) || !SandboxHasTag(sessionStore.sessions[2], "project", project.ID) {
 		t.Fatalf("SandboxHasTag returned unexpected values")
 	}
@@ -374,6 +435,7 @@ func (controllerCoverageSessionStore) ListSandboxes(context.Context, domain.Sand
 
 type controllerCoverageVolumeManager struct {
 	removedProjects []string
+	removeErr       error
 }
 
 func (m *controllerCoverageVolumeManager) Ensure(context.Context, domain.VolumeRecord) (domain.VolumeRecord, bool, error) {
@@ -384,13 +446,17 @@ func (m *controllerCoverageVolumeManager) Inspect(context.Context, string) (doma
 	return domain.VolumeRecord{}, nil
 }
 
+func (m *controllerCoverageVolumeManager) ListProjectVolumes(context.Context, string) (map[string]domain.VolumeRecord, error) {
+	return nil, nil
+}
+
 func (m *controllerCoverageVolumeManager) ReplaceProjectVolumes(context.Context, string, map[string]domain.ProjectVolumeLink) error {
 	return nil
 }
 
 func (m *controllerCoverageVolumeManager) RemoveProjectVolumes(_ context.Context, projectID string) error {
 	m.removedProjects = append(m.removedProjects, projectID)
-	return nil
+	return m.removeErr
 }
 
 func assertProjectChange(t *testing.T, changes []Change, action, resourceType, resourceID string) {

--- a/pkg/projects/controller_coverage_test.go
+++ b/pkg/projects/controller_coverage_test.go
@@ -137,7 +137,7 @@ func TestControllerRemoveProjectKeepsProjectActiveWhenSandboxStopFails(t *testin
 	volumeManager := &controllerCoverageVolumeManager{}
 	controller := NewController(ControllerDependencies{
 		Store: store,
-		Sandboxes: downCoverageSessions{sessions: []*domain.Sandbox{{Summary: domain.SandboxSummary{
+		Sandboxes: &downCoverageSessions{sessions: []*domain.Sandbox{{Summary: domain.SandboxSummary{
 			ID: "sandbox-failed", Tags: []domain.SandboxTag{{Name: "project", Value: project.ID}},
 		}}}},
 		Volumes: volumeManager,
@@ -226,7 +226,7 @@ func TestDownProjectSandboxAndSchedulerWorkflows(t *testing.T) {
 		{ProjectID: project.ID, SchedulerID: "scheduler-disabled", AgentName: "idle", ID: "loader-idle", Enabled: false},
 		{ProjectID: project.ID, SchedulerID: "scheduler-1", AgentName: "worker", ID: "loader-1", Enabled: true},
 	}}
-	sessionStore := downCoverageSessions{sessions: []*domain.Sandbox{
+	sessionStore := &downCoverageSessions{sessions: []*domain.Sandbox{
 		nil,
 		{Summary: domain.SandboxSummary{ID: "other", Title: "Other", Tags: []domain.SandboxTag{{Name: "project", Value: "other"}}}},
 		{Summary: domain.SandboxSummary{ID: "session-fail", Title: "Fail", Tags: []domain.SandboxTag{{Name: " project ", Value: " project-1 "}}}},
@@ -257,6 +257,9 @@ func TestDownProjectSandboxAndSchedulerWorkflows(t *testing.T) {
 	if !refreshed || len(stopped) != 3 {
 		t.Fatalf("refreshed/stopped = %v/%#v", refreshed, stopped)
 	}
+	if len(sessionStore.listOptions) != 1 || sessionStore.listOptions[0].ProjectID != "" || sessionStore.listOptions[0].VMStatus != domain.VMStatusRunning {
+		t.Fatalf("sandbox list options = %#v, want all running sandboxes without project prefilter", sessionStore.listOptions)
+	}
 	assertDownChange(t, changes, DownChangeUpdated, "project_scheduler", "scheduler-1")
 	assertDownChange(t, changes, DownChangeUpdated, "loader", "loader-1")
 	assertDownChange(t, changes, DownChangeUnchanged, "sandbox", "session-fail")
@@ -286,10 +289,10 @@ func TestDownProjectSandboxAndSchedulerWorkflows(t *testing.T) {
 	if _, err := StopProjectRunningSandboxes(ctx, project, DownOptions{}); err == nil {
 		t.Fatalf("StopProjectRunningSandboxes without sandboxes returned nil error")
 	}
-	if _, err := StopProjectRunningSandboxes(ctx, project, DownOptions{Sandboxes: downCoverageSessions{err: errors.New("list failed")}}); err == nil {
+	if _, err := StopProjectRunningSandboxes(ctx, project, DownOptions{Sandboxes: &downCoverageSessions{err: errors.New("list failed")}}); err == nil {
 		t.Fatalf("StopProjectRunningSandboxes list error returned nil error")
 	}
-	if _, err := StopProjectRunningSandboxes(ctx, project, DownOptions{Sandboxes: downCoverageSessions{sessions: []*domain.Sandbox{{Summary: domain.SandboxSummary{ID: "session-1", Tags: []domain.SandboxTag{{Name: "project", Value: project.ID}}}}}}}); err == nil {
+	if _, err := StopProjectRunningSandboxes(ctx, project, DownOptions{Sandboxes: &downCoverageSessions{sessions: []*domain.Sandbox{{Summary: domain.SandboxSummary{ID: "session-1", Tags: []domain.SandboxTag{{Name: "project", Value: project.ID}}}}}}}); err == nil {
 		t.Fatalf("StopProjectRunningSandboxes without stopper returned nil error")
 	}
 }
@@ -492,11 +495,13 @@ func (s *downCoverageStore) SetProjectSchedulerEnabled(_ context.Context, projec
 }
 
 type downCoverageSessions struct {
-	sessions []*domain.Sandbox
-	err      error
+	sessions    []*domain.Sandbox
+	err         error
+	listOptions []domain.SandboxListOptions
 }
 
-func (s downCoverageSessions) ListSandboxes(context.Context, domain.SandboxListOptions) (domain.SandboxListResult, error) {
+func (s *downCoverageSessions) ListSandboxes(_ context.Context, options domain.SandboxListOptions) (domain.SandboxListResult, error) {
+	s.listOptions = append(s.listOptions, options)
 	return domain.SandboxListResult{Sandboxes: s.sessions}, s.err
 }
 

--- a/pkg/projects/down.go
+++ b/pkg/projects/down.go
@@ -98,7 +98,7 @@ func StopProjectRunningSandboxes(ctx context.Context, project domain.ProjectReco
 	if options.Sandboxes == nil {
 		return nil, fmt.Errorf("sandbox store is required")
 	}
-	result, err := options.Sandboxes.ListSandboxes(ctx, domain.SandboxListOptions{VMStatus: domain.VMStatusRunning, Limit: 1 << 30})
+	result, err := options.Sandboxes.ListSandboxes(ctx, domain.SandboxListOptions{ProjectID: project.ID, VMStatus: domain.VMStatusRunning, Limit: 1 << 30})
 	if err != nil {
 		return nil, fmt.Errorf("list running sandboxes for project down %s: %w", project.Name, err)
 	}
@@ -129,6 +129,15 @@ func StopProjectRunningSandboxes(ctx context.Context, project domain.ProjectReco
 		})
 	}
 	return changes, nil
+}
+
+func DownChangesHaveFailures(changes []DownChange) bool {
+	for _, change := range changes {
+		if change.ResourceType == "sandbox" && change.Action == DownChangeUnchanged {
+			return true
+		}
+	}
+	return false
 }
 
 func SandboxBelongsToProject(sandbox *domain.Sandbox, projectID string) bool {

--- a/pkg/projects/down.go
+++ b/pkg/projects/down.go
@@ -98,7 +98,7 @@ func StopProjectRunningSandboxes(ctx context.Context, project domain.ProjectReco
 	if options.Sandboxes == nil {
 		return nil, fmt.Errorf("sandbox store is required")
 	}
-	result, err := options.Sandboxes.ListSandboxes(ctx, domain.SandboxListOptions{ProjectID: project.ID, VMStatus: domain.VMStatusRunning, Limit: 1 << 30})
+	result, err := options.Sandboxes.ListSandboxes(ctx, domain.SandboxListOptions{VMStatus: domain.VMStatusRunning, Limit: 1 << 30})
 	if err != nil {
 		return nil, fmt.Errorf("list running sandboxes for project down %s: %w", project.Name, err)
 	}

--- a/pkg/projects/lifecycle_gate.go
+++ b/pkg/projects/lifecycle_gate.go
@@ -1,0 +1,55 @@
+package projects
+
+import (
+	"context"
+	"sync"
+)
+
+type projectLifecycleGates struct {
+	mu    sync.Mutex
+	gates map[string]*projectLifecycleGate
+}
+
+type projectLifecycleGate struct {
+	token chan struct{}
+	refs  int
+}
+
+func (g *projectLifecycleGates) acquire(ctx context.Context, name string) (func(), error) {
+	g.mu.Lock()
+	if g.gates == nil {
+		g.gates = make(map[string]*projectLifecycleGate)
+	}
+	gate := g.gates[name]
+	if gate == nil {
+		gate = &projectLifecycleGate{token: make(chan struct{}, 1)}
+		gate.token <- struct{}{}
+		g.gates[name] = gate
+	}
+	gate.refs++
+	g.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		g.releaseRef(name, gate)
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		g.releaseRef(name, gate)
+		return nil, ctx.Err()
+	case <-gate.token:
+		return func() {
+			gate.token <- struct{}{}
+			g.releaseRef(name, gate)
+		}, nil
+	}
+}
+
+func (g *projectLifecycleGates) releaseRef(name string, gate *projectLifecycleGate) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	gate.refs--
+	if gate.refs == 0 {
+		delete(g.gates, name)
+	}
+}

--- a/pkg/projects/lifecycle_gate.go
+++ b/pkg/projects/lifecycle_gate.go
@@ -38,10 +38,10 @@ func (g *projectLifecycleGates) acquire(ctx context.Context, name string) (func(
 		g.releaseRef(name, gate)
 		return nil, ctx.Err()
 	case <-gate.token:
-		return func() {
+		return sync.OnceFunc(func() {
 			gate.token <- struct{}{}
 			g.releaseRef(name, gate)
-		}, nil
+		}), nil
 	}
 }
 

--- a/pkg/projects/lifecycle_gate_test.go
+++ b/pkg/projects/lifecycle_gate_test.go
@@ -64,6 +64,32 @@ func TestProjectLifecycleGatesHonorCancellationAndAllowDifferentNames(t *testing
 	releaseDemo()
 }
 
+func TestProjectLifecycleGateReleaseIsIdempotent(t *testing.T) {
+	var gates projectLifecycleGates
+	release, err := gates.acquire(context.Background(), "demo")
+	if err != nil {
+		t.Fatalf("acquire gate: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		release()
+		release()
+		close(released)
+	}()
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("repeated lifecycle release blocked")
+	}
+
+	gates.mu.Lock()
+	defer gates.mu.Unlock()
+	if len(gates.gates) != 0 {
+		t.Fatalf("released lifecycle gates = %#v, want empty", gates.gates)
+	}
+}
+
 func waitForLifecycleGateRefs(t *testing.T, gates *projectLifecycleGates, name string, want int) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)

--- a/pkg/projects/lifecycle_gate_test.go
+++ b/pkg/projects/lifecycle_gate_test.go
@@ -1,0 +1,83 @@
+package projects
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestProjectLifecycleGatesSerializeSameNameAndReleaseEntries(t *testing.T) {
+	var gates projectLifecycleGates
+	releaseFirst, err := gates.acquire(context.Background(), "demo")
+	if err != nil {
+		t.Fatalf("acquire first gate: %v", err)
+	}
+
+	acquired := make(chan func(), 1)
+	go func() {
+		release, acquireErr := gates.acquire(context.Background(), "demo")
+		if acquireErr == nil {
+			acquired <- release
+		}
+	}()
+	waitForLifecycleGateRefs(t, &gates, "demo", 2)
+	select {
+	case release := <-acquired:
+		release()
+		t.Fatal("same-name lifecycle operation acquired before release")
+	default:
+	}
+
+	releaseFirst()
+	select {
+	case release := <-acquired:
+		release()
+	case <-time.After(time.Second):
+		t.Fatal("same-name lifecycle operation did not acquire after release")
+	}
+	gates.mu.Lock()
+	defer gates.mu.Unlock()
+	if len(gates.gates) != 0 {
+		t.Fatalf("released lifecycle gates = %#v, want empty", gates.gates)
+	}
+}
+
+func TestProjectLifecycleGatesHonorCancellationAndAllowDifferentNames(t *testing.T) {
+	var gates projectLifecycleGates
+	releaseDemo, err := gates.acquire(context.Background(), "demo")
+	if err != nil {
+		t.Fatalf("acquire demo gate: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := gates.acquire(ctx, "demo"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled acquire error = %v, want context canceled", err)
+	}
+	releaseOther, err := gates.acquire(context.Background(), "other")
+	if err != nil {
+		t.Fatalf("acquire different-name gate: %v", err)
+	}
+	releaseOther()
+	releaseDemo()
+}
+
+func waitForLifecycleGateRefs(t *testing.T, gates *projectLifecycleGates, name string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		gates.mu.Lock()
+		refs := 0
+		if gate := gates.gates[name]; gate != nil {
+			refs = gate.refs
+		}
+		gates.mu.Unlock()
+		if refs == want {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("lifecycle gate %q did not reach %d references", name, want)
+}

--- a/pkg/projects/normalize.go
+++ b/pkg/projects/normalize.go
@@ -22,6 +22,9 @@ func NormalizeRecord(project domain.ProjectRecord) (domain.ProjectRecord, error)
 	if project.Name == "" {
 		return domain.ProjectRecord{}, fmt.Errorf("project name is required")
 	}
+	if !domain.IsProjectName(project.Name) {
+		return domain.ProjectRecord{}, fmt.Errorf("project name %q must match %s", project.Name, domain.ProjectNamePattern)
+	}
 	if project.ShortID == "" {
 		project.ShortID = identity.ShortID(project.ID)
 	}

--- a/pkg/projects/project_ref.go
+++ b/pkg/projects/project_ref.go
@@ -45,6 +45,14 @@ type ProjectRefStore interface {
 	ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error)
 }
 
+type projectNameStore interface {
+	GetProjectByName(context.Context, string, bool) (domain.ProjectRecord, error)
+}
+
+type projectSourcePathStore interface {
+	GetProjectBySourcePath(context.Context, string, bool) (domain.ProjectRecord, error)
+}
+
 // ResolveProjectRef resolves one project selector against active projects.
 func ResolveProjectRef(ctx context.Context, store ProjectRefStore, ref ProjectRef) (domain.ProjectRecord, error) {
 	if store == nil {
@@ -79,6 +87,16 @@ func resolveProjectByExactMatch(
 	selectorName string,
 	projectValue func(domain.ProjectRecord) string,
 ) (domain.ProjectRecord, error) {
+	if selectorName == "name" {
+		if nameStore, ok := store.(projectNameStore); ok {
+			return nameStore.GetProjectByName(ctx, value, includeRemoved)
+		}
+	}
+	if selectorName == "source path" {
+		if sourcePathStore, ok := store.(projectSourcePathStore); ok {
+			return sourcePathStore.GetProjectBySourcePath(ctx, value, includeRemoved)
+		}
+	}
 	const pageSize = 200
 	var matches []domain.ProjectRecord
 	for offset := 0; ; offset += pageSize {

--- a/pkg/projects/scheduler_coverage_test.go
+++ b/pkg/projects/scheduler_coverage_test.go
@@ -77,7 +77,7 @@ func TestManagedLoaderTriggerRegistrationCoverage(t *testing.T) {
 }
 
 func TestProjectNormalizeAndScanCoverage(t *testing.T) {
-	project, err := NormalizeRecord(domain.ProjectRecord{ID: " project-1 ", Name: " Project ", SourcePath: ".", CurrentRevision: 2})
+	project, err := NormalizeRecord(domain.ProjectRecord{ID: " project-1 ", Name: " project ", SourcePath: ".", CurrentRevision: 2})
 	if err != nil {
 		t.Fatalf("NormalizeRecord returned error: %v", err)
 	}

--- a/pkg/projects/volumes.go
+++ b/pkg/projects/volumes.go
@@ -16,11 +16,18 @@ func (c *Controller) ensureProjectVolumes(ctx context.Context, project domain.Pr
 	if spec == nil || len(spec.Volumes) == 0 {
 		return c.volumes.ReplaceProjectVolumes(ctx, project.ID, nil)
 	}
+	existing, err := c.volumes.ListProjectVolumes(ctx, project.ID)
+	if err != nil {
+		return fmt.Errorf("list project volumes: %w", err)
+	}
 	links := make(map[string]domain.ProjectVolumeLink, len(spec.Volumes))
 	for key, volumeSpec := range spec.Volumes {
 		name := strings.TrimSpace(volumeSpec.Name)
 		if name == "" {
-			name = fmt.Sprintf("%s_%s", spec.Name, key)
+			name = strings.TrimSpace(existing[key].Name)
+			if name == "" {
+				name = fmt.Sprintf("%s_%s", spec.Name, key)
+			}
 		}
 		var record domain.VolumeRecord
 		var err error

--- a/pkg/projects/volumes_test.go
+++ b/pkg/projects/volumes_test.go
@@ -12,9 +12,18 @@ import (
 type projectVolumeManagerStub struct {
 	ensured      map[string]domain.VolumeRecord
 	inspected    map[string]domain.VolumeRecord
+	listed       map[string]domain.VolumeRecord
 	replaced     map[string]domain.ProjectVolumeLink
 	replacedProj string
 	removeCalls  []string
+}
+
+func (m *projectVolumeManagerStub) ListProjectVolumes(_ context.Context, _ string) (map[string]domain.VolumeRecord, error) {
+	result := make(map[string]domain.VolumeRecord, len(m.listed))
+	for key, record := range m.listed {
+		result[key] = record
+	}
+	return result, nil
 }
 
 func (m *projectVolumeManagerStub) Ensure(_ context.Context, item domain.VolumeRecord) (domain.VolumeRecord, bool, error) {
@@ -84,5 +93,32 @@ func TestEnsureProjectVolumesClearsRemovedLinksWhenSpecEmpty(t *testing.T) {
 	}
 	if len(manager.replaced) != 0 {
 		t.Fatalf("replaced links = %#v, want empty", manager.replaced)
+	}
+}
+
+func TestEnsureProjectVolumesReusesImplicitVolumeAfterProjectRename(t *testing.T) {
+	ctx := context.Background()
+	manager := &projectVolumeManagerStub{
+		listed: map[string]domain.VolumeRecord{
+			"cache": {ID: "vol-cache", Name: "demo_cache"},
+		},
+		ensured: map[string]domain.VolumeRecord{
+			"demo_cache": {ID: "vol-cache", Name: "demo_cache"},
+		},
+	}
+	controller := &Controller{volumes: manager}
+	project := domain.ProjectRecord{ID: "project-1", Name: "demo-2"}
+	spec := &compose.NormalizedProjectSpec{
+		Name: "demo-2",
+		Volumes: map[string]compose.NormalizedVolumeSpec{
+			"cache": {Driver: domain.VolumeDriverLocal},
+		},
+	}
+
+	if err := controller.ensureProjectVolumes(ctx, project, spec); err != nil {
+		t.Fatalf("ensureProjectVolumes after rename: %v", err)
+	}
+	if link := manager.replaced["cache"]; link.VolumeID != "vol-cache" {
+		t.Fatalf("cache link = %#v, want preserved volume vol-cache", link)
 	}
 }

--- a/pkg/runs/preparation_closed_sets.go
+++ b/pkg/runs/preparation_closed_sets.go
@@ -3,6 +3,7 @@ package runs
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
@@ -22,9 +23,11 @@ func normalizeRevisionClosedSetsJSON(data []byte) ([]byte, error) {
 		if scheduler == nil {
 			continue
 		}
+		defaultClosedSetString(scheduler, "sandbox_policy", "new")
 		if err := replaceClosedSetString(scheduler, "sandbox_policy", map[string]int32{"sticky": int32(agentcomposev2.SchedulerSandboxPolicy_SCHEDULER_SANDBOX_POLICY_STICKY), "new": int32(agentcomposev2.SchedulerSandboxPolicy_SCHEDULER_SANDBOX_POLICY_NEW)}); err != nil {
 			return nil, fmt.Errorf("agents[%d].scheduler.sandbox_policy: %w", index, err)
 		}
+		defaultClosedSetString(scheduler, "concurrency_policy", "skip")
 		if err := replaceClosedSetString(scheduler, "concurrency_policy", map[string]int32{"skip": int32(agentcomposev2.SchedulerConcurrencyPolicy_SCHEDULER_CONCURRENCY_POLICY_SKIP), "parallel": int32(agentcomposev2.SchedulerConcurrencyPolicy_SCHEDULER_CONCURRENCY_POLICY_PARALLEL)}); err != nil {
 			return nil, fmt.Errorf("agents[%d].scheduler.concurrency_policy: %w", index, err)
 		}
@@ -40,6 +43,20 @@ func normalizeRevisionClosedSetsJSON(data []byte) ([]byte, error) {
 		}
 	}
 	return json.Marshal(root)
+}
+
+func defaultClosedSetString(object map[string]any, field, fallback string) {
+	if object == nil {
+		return
+	}
+	raw, exists := object[field]
+	if !exists || raw == nil {
+		object[field] = fallback
+		return
+	}
+	if text, ok := raw.(string); ok && strings.TrimSpace(text) == "" {
+		object[field] = fallback
+	}
 }
 
 func normalizeRevisionVolumes(value any) error {

--- a/pkg/runs/preparation_closed_sets_test.go
+++ b/pkg/runs/preparation_closed_sets_test.go
@@ -23,6 +23,21 @@ func TestDecodeRevisionSpecMapsStoredClosedSetStrings(t *testing.T) {
 	}
 }
 
+func TestDecodeRevisionSpecDefaultsHistoricalSchedulerPolicies(t *testing.T) {
+	spec, err := DecodeRevisionSpec(`{"name":"historical","agents":[{"name":"missing","scheduler":{}},{"name":"empty","scheduler":{"sandbox_policy":"","concurrency_policy":""}}]}`)
+	if err != nil {
+		t.Fatalf("DecodeRevisionSpec returned error: %v", err)
+	}
+	for _, agent := range spec.GetAgents() {
+		if agent.GetScheduler().GetSandboxPolicy() != agentcomposev2.SchedulerSandboxPolicy_SCHEDULER_SANDBOX_POLICY_NEW {
+			t.Fatalf("scheduler sandbox policy for %s = %s", agent.GetName(), agent.GetScheduler().GetSandboxPolicy())
+		}
+		if agent.GetScheduler().GetConcurrencyPolicy() != agentcomposev2.SchedulerConcurrencyPolicy_SCHEDULER_CONCURRENCY_POLICY_SKIP {
+			t.Fatalf("scheduler concurrency policy for %s = %s", agent.GetName(), agent.GetScheduler().GetConcurrencyPolicy())
+		}
+	}
+}
+
 func TestDecodeRevisionSpecRejectsUnknownStoredClosedSetString(t *testing.T) {
 	if _, err := DecodeRevisionSpec(`{"agents":[{"scheduler":{"concurrency_policy":"queue"}}]}`); err == nil {
 		t.Fatal("DecodeRevisionSpec accepted an unknown concurrency policy")

--- a/pkg/runs/project_workspace_resume_integration_test.go
+++ b/pkg/runs/project_workspace_resume_integration_test.go
@@ -50,7 +50,7 @@ func TestIntegrationProjectLocalWorkspaceExistingAndNewSandboxState(t *testing.T
 	const projectID = "project-local-resume"
 	project, err := configDB.UpsertProject(ctx, domain.ProjectRecord{
 		ID:         projectID,
-		Name:       "Project Local Resume",
+		Name:       "project-local-resume",
 		SourcePath: filepath.Join(projectRoot, "agent-compose.yaml"),
 	})
 	if err != nil {

--- a/pkg/storage/configstore/native_fixture_test.go
+++ b/pkg/storage/configstore/native_fixture_test.go
@@ -47,11 +47,12 @@ func upsertNativeTestScheduler(ctx context.Context, store *ConfigStore, schedule
 	if driver := strings.TrimSpace(scheduler.Summary.Driver); driver != "" {
 		agent.Driver = &compose.NormalizedDriverSpec{Name: driver}
 	}
-	specJSON, err := (&compose.NormalizedProjectSpec{Name: "test-project", Agents: []compose.NormalizedAgentSpec{agent}}).MarshalCanonicalJSON(false)
+	projectName := "test-" + projectID
+	specJSON, err := (&compose.NormalizedProjectSpec{Name: projectName, Agents: []compose.NormalizedAgentSpec{agent}}).MarshalCanonicalJSON(false)
 	if err != nil {
 		return domain.Scheduler{}, fmt.Errorf("marshal native scheduler fixture: %w", err)
 	}
-	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: projectID, Name: "test-project"})
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: projectID, Name: projectName})
 	if err != nil {
 		return domain.Scheduler{}, err
 	}

--- a/pkg/storage/configstore/project_agent_run_state_store_test.go
+++ b/pkg/storage/configstore/project_agent_run_state_store_test.go
@@ -14,7 +14,7 @@ func TestListProjectAgentRunStatesAggregatesAllAgentRuns(t *testing.T) {
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("init schema: %v", err)
 	}
-	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-run-states", Name: "run states"})
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-run-states", Name: "run-states"})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}

--- a/pkg/storage/configstore/project_identity_test.go
+++ b/pkg/storage/configstore/project_identity_test.go
@@ -9,7 +9,7 @@ import (
 	"agent-compose/pkg/projects"
 )
 
-func TestProjectNameIsUniqueAndReusesIdentityAcrossSourceMoves(t *testing.T) {
+func TestProjectNameIsUniqueAndKeepsIdentityAcrossRenameAndSourceMoves(t *testing.T) {
 	ctx := context.Background()
 	store := FromDB(newMemoryDB(t))
 	if err := store.initSchema(ctx); err != nil {
@@ -26,24 +26,37 @@ func TestProjectNameIsUniqueAndReusesIdentityAcrossSourceMoves(t *testing.T) {
 	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "other-id", Name: "demo", SourcePath: "/other/agent-compose.yml"}); err == nil {
 		t.Fatal("duplicate project name was accepted")
 	}
-	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: created.ID, Name: "renamed", SourcePath: created.SourcePath}); err == nil {
-		t.Fatal("existing project identity accepted a name change")
+	renamed, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: created.ID, Name: "renamed", SourcePath: created.SourcePath})
+	if err != nil {
+		t.Fatalf("rename project: %v", err)
+	}
+	if renamed.ID != created.ID || renamed.Name != "renamed" {
+		t.Fatalf("renamed project = %#v, want stable id %s", renamed, created.ID)
+	}
+	if _, err := store.GetProjectByName(ctx, "demo", true); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("old project name lookup error = %v, want not found", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "other-id", Name: "other", SourcePath: "/other/agent-compose.yml"}); err != nil {
+		t.Fatalf("create second project: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: created.ID, Name: "other", SourcePath: created.SourcePath}); err == nil {
+		t.Fatal("rename to an existing project name was accepted")
 	}
 	unchanged, err := store.GetProject(ctx, created.ID)
-	if err != nil || unchanged.Name != "demo" {
-		t.Fatalf("project after rejected rename = %#v, %v", unchanged, err)
+	if err != nil || unchanged.Name != "renamed" {
+		t.Fatalf("project after rejected conflicting rename = %#v, %v", unchanged, err)
 	}
 	if _, err := store.MarkProjectRemoved(ctx, created.ID); err != nil {
 		t.Fatalf("mark project removed: %v", err)
 	}
-	if _, err := store.GetProjectByName(ctx, "demo", false); !errors.Is(err, domain.ErrNotFound) {
+	if _, err := store.GetProjectByName(ctx, "renamed", false); !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("active lookup after down error = %v, want not found", err)
 	}
-	removed, err := store.GetProjectByName(ctx, "demo", true)
+	removed, err := store.GetProjectByName(ctx, "renamed", true)
 	if err != nil || removed.ID != created.ID {
 		t.Fatalf("removed lookup = %#v, %v", removed, err)
 	}
-	reactivated, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: created.ID, Name: "demo", SourcePath: "/moved/agent-compose.yml"})
+	reactivated, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: created.ID, Name: "renamed", SourcePath: "/moved/agent-compose.yml"})
 	if err != nil {
 		t.Fatalf("reactivate moved project: %v", err)
 	}

--- a/pkg/storage/configstore/project_identity_test.go
+++ b/pkg/storage/configstore/project_identity_test.go
@@ -1,0 +1,95 @@
+package configstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+)
+
+func TestProjectNameIsUniqueAndReusesIdentityAcrossSourceMoves(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	created, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "legacy-path-id", Name: "demo", SourcePath: "/old/agent-compose.yml"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	byName, err := store.GetProjectByName(ctx, "demo", false)
+	if err != nil || byName.ID != created.ID {
+		t.Fatalf("GetProjectByName = %#v, %v", byName, err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "other-id", Name: "demo", SourcePath: "/other/agent-compose.yml"}); err == nil {
+		t.Fatal("duplicate project name was accepted")
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: created.ID, Name: "renamed", SourcePath: created.SourcePath}); err == nil {
+		t.Fatal("existing project identity accepted a name change")
+	}
+	unchanged, err := store.GetProject(ctx, created.ID)
+	if err != nil || unchanged.Name != "demo" {
+		t.Fatalf("project after rejected rename = %#v, %v", unchanged, err)
+	}
+	if _, err := store.MarkProjectRemoved(ctx, created.ID); err != nil {
+		t.Fatalf("mark project removed: %v", err)
+	}
+	if _, err := store.GetProjectByName(ctx, "demo", false); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("active lookup after down error = %v, want not found", err)
+	}
+	removed, err := store.GetProjectByName(ctx, "demo", true)
+	if err != nil || removed.ID != created.ID {
+		t.Fatalf("removed lookup = %#v, %v", removed, err)
+	}
+	reactivated, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: created.ID, Name: "demo", SourcePath: "/moved/agent-compose.yml"})
+	if err != nil {
+		t.Fatalf("reactivate moved project: %v", err)
+	}
+	if reactivated.ID != created.ID || reactivated.SourcePath != "/moved/agent-compose.yml" || !reactivated.RemovedAt.IsZero() {
+		t.Fatalf("reactivated project = %#v", reactivated)
+	}
+}
+
+func TestResolveProjectByExactUnicodeSourcePath(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	const sourcePath = "/tmp/Äpp/agent-compose.yml"
+	created, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "unicode-path", Name: "unicode-path", SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	resolved, err := projects.ResolveProjectRef(ctx, store, projects.ProjectRefBySourcePath(sourcePath))
+	if err != nil {
+		t.Fatalf("resolve exact Unicode source path: %v", err)
+	}
+	if resolved.ID != created.ID {
+		t.Fatalf("resolved project = %#v, want %s", resolved, created.ID)
+	}
+}
+
+func TestResolveProjectBySourcePathRejectsAmbiguousRows(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	const sourcePath = "/tmp/shared/agent-compose.yml"
+	for _, project := range []domain.ProjectRecord{
+		{ID: "shared-one", Name: "shared-one", SourcePath: sourcePath},
+		{ID: "shared-two", Name: "shared-two", SourcePath: sourcePath},
+	} {
+		if _, err := store.UpsertProject(ctx, project); err != nil {
+			t.Fatalf("create project %s: %v", project.ID, err)
+		}
+	}
+
+	if _, err := projects.ResolveProjectRef(ctx, store, projects.ProjectRefBySourcePath(sourcePath)); !errors.Is(err, domain.ErrAmbiguous) {
+		t.Fatalf("resolve ambiguous source path error = %v, want ErrAmbiguous", err)
+	}
+}

--- a/pkg/storage/configstore/project_lookup_store.go
+++ b/pkg/storage/configstore/project_lookup_store.go
@@ -1,0 +1,68 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+)
+
+func (s *projectStore) GetProjectByName(ctx context.Context, name string, includeRemoved bool) (ProjectRecord, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ProjectRecord{}, fmt.Errorf("project name is required")
+	}
+	where := "name = ? AND removed_at = 0"
+	if includeRemoved {
+		where = "name = ?"
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id, name, short_id, source_path, source_json, current_revision, spec_hash, created_at, updated_at, removed_at
+		FROM project WHERE `+where, name)
+	item, err := projects.ScanProject(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", name, fmt.Sprintf("project with name %s not found", name), err)
+		}
+		return ProjectRecord{}, err
+	}
+	return item, nil
+}
+
+func (s *projectStore) GetProjectBySourcePath(ctx context.Context, sourcePath string, includeRemoved bool) (ProjectRecord, error) {
+	sourcePath = domain.NormalizeProjectSourcePath(sourcePath)
+	if sourcePath == "" {
+		return ProjectRecord{}, fmt.Errorf("project source path is required")
+	}
+	where := "source_path = ? AND removed_at = 0"
+	if includeRemoved {
+		where = "source_path = ?"
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, short_id, source_path, source_json, current_revision, spec_hash, created_at, updated_at, removed_at
+		FROM project WHERE `+where+` ORDER BY updated_at DESC, created_at DESC, id ASC LIMIT 2`, sourcePath)
+	if err != nil {
+		return ProjectRecord{}, fmt.Errorf("query project by source path %s: %w", sourcePath, err)
+	}
+	defer func() { _ = rows.Close() }()
+	items := make([]ProjectRecord, 0, 2)
+	for rows.Next() {
+		item, err := projects.ScanProject(rows.Scan)
+		if err != nil {
+			return ProjectRecord{}, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return ProjectRecord{}, fmt.Errorf("iterate projects by source path %s: %w", sourcePath, err)
+	}
+	if len(items) == 0 {
+		return ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", sourcePath, fmt.Sprintf("project with source path %s not found", sourcePath), sql.ErrNoRows)
+	}
+	if len(items) > 1 {
+		return ProjectRecord{}, domain.ClassifyError(domain.ErrAmbiguous, fmt.Sprintf("project source path %s is ambiguous; use project_id", sourcePath), nil)
+	}
+	return items[0], nil
+}

--- a/pkg/storage/configstore/project_run_filter_test.go
+++ b/pkg/storage/configstore/project_run_filter_test.go
@@ -15,7 +15,7 @@ func TestListProjectRunsByOptionsFiltersInclusiveStartRange(t *testing.T) {
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("init schema: %v", err)
 	}
-	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "Project", SourcePath: "/project", SourceJSON: `{}`})
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "project", SourcePath: "/project", SourceJSON: `{}`})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}

--- a/pkg/storage/configstore/project_scheduler_page_test.go
+++ b/pkg/storage/configstore/project_scheduler_page_test.go
@@ -15,7 +15,7 @@ func TestProjectSchedulerPageUsesStableCursorAndProjectQuery(t *testing.T) {
 	if err := store.initSchema(ctx); err != nil {
 		t.Fatalf("init schema: %v", err)
 	}
-	for _, project := range []domain.ProjectRecord{{ID: "project-a", Name: "Alpha"}, {ID: "project-b", Name: "Beta"}} {
+	for _, project := range []domain.ProjectRecord{{ID: "project-a", Name: "alpha"}, {ID: "project-b", Name: "beta"}} {
 		if _, err := store.UpsertProject(ctx, project); err != nil {
 			t.Fatalf("upsert project %s: %v", project.ID, err)
 		}

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -24,38 +24,21 @@ func (s *projectStore) UpsertProject(ctx context.Context, project ProjectRecord)
 		return ProjectRecord{}, err
 	}
 	now := time.Now().UTC()
-	existing, found, err := s.getProject(ctx, project.ID, true)
-	if err != nil {
-		return ProjectRecord{}, err
-	}
-	if found {
-		project.CreatedAt = existing.CreatedAt
-		project.CurrentRevision = existing.CurrentRevision
-		if project.SpecHash == "" {
-			project.SpecHash = existing.SpecHash
-		}
-		project.UpdatedAt = now
-		project.RemovedAt = time.Time{}
-		result, err := s.db.ExecContext(ctx, `UPDATE project SET
-			name = ?, short_id = ?, source_path = ?, source_json = ?, spec_hash = ?, updated_at = ?, removed_at = 0
-			WHERE id = ?`,
-			project.Name, project.ShortID, project.SourcePath, project.SourceJSON, project.SpecHash, project.UpdatedAt.Unix(), project.ID)
-		if err != nil {
-			return ProjectRecord{}, fmt.Errorf("update project %s: %w", project.ID, err)
-		}
-		if rows, _ := result.RowsAffected(); rows == 0 {
-			return ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", project.ID, fmt.Sprintf("project %s not found", project.ID), nil)
-		}
-		return s.GetProject(ctx, project.ID)
-	}
-
 	project.CreatedAt = now
 	project.UpdatedAt = now
 	if _, err := s.db.ExecContext(ctx, `INSERT INTO project(
 		id, name, short_id, source_path, source_json, current_revision, spec_hash, created_at, updated_at, removed_at
-	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+	ON CONFLICT(id) DO UPDATE SET
+		name = excluded.name,
+		short_id = excluded.short_id,
+		source_path = excluded.source_path,
+		source_json = excluded.source_json,
+		spec_hash = CASE WHEN excluded.spec_hash = '' THEN project.spec_hash ELSE excluded.spec_hash END,
+		updated_at = excluded.updated_at,
+		removed_at = 0`,
 		project.ID, project.Name, project.ShortID, project.SourcePath, project.SourceJSON, project.CurrentRevision, project.SpecHash, project.CreatedAt.Unix(), project.UpdatedAt.Unix()); err != nil {
-		return ProjectRecord{}, fmt.Errorf("insert project %s: %w", project.ID, err)
+		return ProjectRecord{}, fmt.Errorf("upsert project %s: %w", project.ID, err)
 	}
 	return s.GetProject(ctx, project.ID)
 }

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -84,10 +84,9 @@ func testConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 		t.Fatalf("UpsertProject returned error: %v", err)
 	}
 	project.Name = "project-renamed"
-	if _, err := store.UpsertProject(ctx, project); err == nil {
-		t.Fatal("UpsertProject renamed an existing project")
+	if project, err = store.UpsertProject(ctx, project); err != nil || project.Name != "project-renamed" {
+		t.Fatalf("UpsertProject rename project=%#v err=%v", project, err)
 	}
-	project.Name = "project"
 	project.SourcePath = "/tmp/project-updated"
 	if project, err = store.UpsertProject(ctx, project); err != nil || project.SourcePath != "/tmp/project-updated" {
 		t.Fatalf("UpsertProject update project=%#v err=%v", project, err)

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -79,12 +79,17 @@ func testConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 	if _, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{ProjectID: "missing-project", SpecHash: "hash", SpecJSON: `{bad json`}); err == nil {
 		t.Fatalf("SaveProjectRevision invalid JSON returned nil error")
 	}
-	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "Project", SourcePath: "/tmp/project", SourceJSON: `{"kind":"local"}`, SpecHash: "hash-0"})
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "project", SourcePath: "/tmp/project", SourceJSON: `{"kind":"local"}`, SpecHash: "hash-0"})
 	if err != nil {
 		t.Fatalf("UpsertProject returned error: %v", err)
 	}
-	project.Name = "Project Updated"
-	if project, err = store.UpsertProject(ctx, project); err != nil || project.Name != "Project Updated" {
+	project.Name = "project-renamed"
+	if _, err := store.UpsertProject(ctx, project); err == nil {
+		t.Fatal("UpsertProject renamed an existing project")
+	}
+	project.Name = "project"
+	project.SourcePath = "/tmp/project-updated"
+	if project, err = store.UpsertProject(ctx, project); err != nil || project.SourcePath != "/tmp/project-updated" {
 		t.Fatalf("UpsertProject update project=%#v err=%v", project, err)
 	}
 	revision, created, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{ProjectID: project.ID, SpecHash: "hash-1", SpecJSON: `{"agents":[]}`})
@@ -114,7 +119,7 @@ func testConfigStoreProjectCRUDCoverageWorkflows(t *testing.T) {
 	if result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "updated", Limit: 10}); err != nil || result.TotalCount != 1 {
 		t.Fatalf("ListProjects result=%#v err=%v", result, err)
 	}
-	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-2", Name: "Other Project", SourcePath: "/tmp/other", SourceJSON: `{"kind":"local"}`}); err != nil {
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-2", Name: "other-project", SourcePath: "/tmp/other", SourceJSON: `{"kind":"local"}`}); err != nil {
 		t.Fatalf("UpsertProject second project returned error: %v", err)
 	}
 	if result, err := store.ListProjects(ctx, domain.ProjectListOptions{Limit: 1, Offset: -5}); err != nil || result.TotalCount != 2 || len(result.Projects) != 1 || !result.HasMore || result.NextOffset != 1 {

--- a/pkg/storage/sqlite/migrations.go
+++ b/pkg/storage/sqlite/migrations.go
@@ -168,6 +168,9 @@ func applyMigrationSet(ctx context.Context, db *sql.DB, migrations []migration) 
 
 	pending := migrations[len(applied):]
 	for _, item := range pending {
+		if err := applyMigrationDataStep(ctx, conn, item); err != nil {
+			return fmt.Errorf("prepare SQLite migration %s: %w", item.name, err)
+		}
 		if _, err := conn.ExecContext(ctx, item.statement); err != nil {
 			return fmt.Errorf("apply SQLite migration %s: %w", item.name, err)
 		}

--- a/pkg/storage/sqlite/migrations/000009_unique_project_name.sql
+++ b/pkg/storage/sqlite/migrations/000009_unique_project_name.sql
@@ -2,10 +2,3 @@
 -- matching migration data step.
 DROP INDEX IF EXISTS idx_project_name;
 CREATE UNIQUE INDEX idx_project_name ON project(name);
-
-CREATE TRIGGER project_name_immutable
-BEFORE UPDATE OF name ON project
-WHEN OLD.name <> NEW.name
-BEGIN
-    SELECT RAISE(ABORT, 'project name is immutable');
-END;

--- a/pkg/storage/sqlite/migrations/000009_unique_project_name.sql
+++ b/pkg/storage/sqlite/migrations/000009_unique_project_name.sql
@@ -1,0 +1,11 @@
+-- Project names become daemon-unique after duplicate rows are renamed by the
+-- matching migration data step.
+DROP INDEX IF EXISTS idx_project_name;
+CREATE UNIQUE INDEX idx_project_name ON project(name);
+
+CREATE TRIGGER project_name_immutable
+BEFORE UPDATE OF name ON project
+WHEN OLD.name <> NEW.name
+BEGIN
+    SELECT RAISE(ABORT, 'project name is immutable');
+END;

--- a/pkg/storage/sqlite/migrations/README.md
+++ b/pkg/storage/sqlite/migrations/README.md
@@ -6,6 +6,9 @@ Migration files are embedded into the agent-compose binary and applied by the
 - Name files `NNNNNN_description.sql` with a unique, increasing six-digit
   version.
 - Migrations are forward-only and must run inside a SQLite transaction.
+- A data rewrite that is clearer in Go may use an exact version-and-name data
+  step in `pkg/storage/sqlite`; it runs before the matching SQL on the same
+  pinned transaction connection and is immutable after release.
 - Never edit, rename, reorder, or remove a released migration. The runner
   stores and verifies each file's SHA-256 checksum.
 - Add schema changes only as a new migration; do not add startup-time schema

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -79,6 +79,7 @@ func TestMigrationBaseline(t *testing.T) {
 		assertSQLiteIndexExists(t, db, index)
 	}
 	assertSQLiteIndexUnique(t, db, "idx_event_idempotency", true)
+	assertSQLiteIndexUnique(t, db, "idx_project_name", true)
 	var idempotencyIndexSQL string
 	if err := db.QueryRowContext(ctx,
 		`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_event_idempotency'`).Scan(&idempotencyIndexSQL); err != nil {

--- a/pkg/storage/sqlite/project_name_migration.go
+++ b/pkg/storage/sqlite/project_name_migration.go
@@ -1,0 +1,196 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"agent-compose/pkg/compose"
+)
+
+const uniqueProjectNameMigrationVersion int64 = 9
+
+const uniqueProjectNameMigration = "000009_unique_project_name"
+
+type projectNameMigrationRow struct {
+	id              string
+	name            string
+	currentRevision int64
+}
+
+func applyMigrationDataStep(ctx context.Context, conn migrationConn, item migration) error {
+	// Released cases are immutable migration steps, just like their SQL asset.
+	if item.version != uniqueProjectNameMigrationVersion || item.name != uniqueProjectNameMigration {
+		return nil
+	}
+	return renameDuplicateProjects(ctx, conn)
+}
+
+func renameDuplicateProjects(ctx context.Context, conn migrationConn) error {
+	rows, err := conn.QueryContext(ctx, `SELECT id, name, current_revision
+		FROM project
+		ORDER BY name ASC,
+			CASE WHEN removed_at = 0 THEN 0 ELSE 1 END,
+			updated_at DESC,
+			created_at DESC,
+			id ASC`)
+	if err != nil {
+		return fmt.Errorf("list projects before enforcing unique names: %w", err)
+	}
+
+	var projects []projectNameMigrationRow
+	usedNames := make(map[string]struct{})
+	for rows.Next() {
+		var project projectNameMigrationRow
+		if err := rows.Scan(&project.id, &project.name, &project.currentRevision); err != nil {
+			_ = rows.Close() // Preserve the scan error as the primary failure.
+			return fmt.Errorf("scan project before enforcing unique names: %w", err)
+		}
+		projects = append(projects, project)
+		usedNames[project.name] = struct{}{}
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close projects before enforcing unique names: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate projects before enforcing unique names: %w", err)
+	}
+
+	seenNames := make(map[string]struct{}, len(usedNames))
+	for _, project := range projects {
+		if _, seen := seenNames[project.name]; !seen {
+			seenNames[project.name] = struct{}{}
+			continue
+		}
+		newName, ok := nextAvailableProjectName(project.name, usedNames, len(projects))
+		if !ok {
+			return fmt.Errorf("allocate unique name for duplicate project %s", project.id)
+		}
+		if err := renameDuplicateProject(ctx, conn, project, newName); err != nil {
+			return err
+		}
+		usedNames[newName] = struct{}{}
+	}
+	return nil
+}
+
+func renameDuplicateProject(ctx context.Context, conn migrationConn, project projectNameMigrationRow, newName string) error {
+	if project.currentRevision <= 0 {
+		return updateMigratedProject(ctx, conn, project, newName, 0, "")
+	}
+
+	revision, specHash, err := createRenamedProjectRevision(ctx, conn, project, newName)
+	if err != nil {
+		return err
+	}
+	if err := updateMigratedProject(ctx, conn, project, newName, revision, specHash); err != nil {
+		return err
+	}
+	for _, table := range []string{"project_agent", "project_scheduler"} {
+		if _, err := conn.ExecContext(ctx, `UPDATE `+table+` SET revision = ? WHERE project_id = ?`, revision, project.id); err != nil {
+			return fmt.Errorf("move %s rows for renamed project %s to revision %d: %w", table, project.id, revision, err)
+		}
+	}
+	return nil
+}
+
+func createRenamedProjectRevision(ctx context.Context, conn migrationConn, project projectNameMigrationRow, newName string) (int64, string, error) {
+	var specJSON string
+	if err := conn.QueryRowContext(ctx, `SELECT spec_json FROM project_revision WHERE project_id = ? AND revision = ?`, project.id, project.currentRevision).Scan(&specJSON); err != nil {
+		return 0, "", fmt.Errorf("load current revision %s/%d before rename: %w", project.id, project.currentRevision, err)
+	}
+	spec, err := compose.ParseCanonicalJSON([]byte(specJSON))
+	if err != nil {
+		return 0, "", fmt.Errorf("decode current revision %s/%d before rename: %w", project.id, project.currentRevision, err)
+	}
+	spec.Name = newName
+	if err := materializeImplicitProjectVolumeNames(ctx, conn, project.id, spec); err != nil {
+		return 0, "", err
+	}
+	canonicalJSON, err := spec.MarshalCanonicalJSON(false)
+	if err != nil {
+		return 0, "", fmt.Errorf("encode renamed project revision %s: %w", project.id, err)
+	}
+	specHash, err := spec.Hash()
+	if err != nil {
+		return 0, "", fmt.Errorf("hash renamed project revision %s: %w", project.id, err)
+	}
+	var nextRevision int64
+	if err := conn.QueryRowContext(ctx, `SELECT COALESCE(MAX(revision), 0) + 1 FROM project_revision WHERE project_id = ?`, project.id).Scan(&nextRevision); err != nil {
+		return 0, "", fmt.Errorf("allocate renamed project revision %s: %w", project.id, err)
+	}
+	if _, err := conn.ExecContext(ctx, `INSERT INTO project_revision(project_id, revision, spec_hash, spec_json) VALUES(?, ?, ?, ?)`, project.id, nextRevision, specHash, string(canonicalJSON)); err != nil {
+		return 0, "", fmt.Errorf("insert renamed project revision %s/%d: %w", project.id, nextRevision, err)
+	}
+	return nextRevision, specHash, nil
+}
+
+func materializeImplicitProjectVolumeNames(ctx context.Context, conn migrationConn, projectID string, spec *compose.NormalizedProjectSpec) error {
+	if spec == nil || len(spec.Volumes) == 0 {
+		return nil
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT project_volumes.volume_key, volumes.name
+		FROM project_volumes
+		JOIN volumes ON volumes.id = project_volumes.volume_id
+		WHERE project_volumes.project_id = ?`, projectID)
+	if err != nil {
+		return fmt.Errorf("list volumes for renamed project %s: %w", projectID, err)
+	}
+	linkedNames := make(map[string]string)
+	for rows.Next() {
+		var key, name string
+		if err := rows.Scan(&key, &name); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan volume for renamed project %s: %w", projectID, err)
+		}
+		linkedNames[key] = name
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close volumes for renamed project %s: %w", projectID, err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate volumes for renamed project %s: %w", projectID, err)
+	}
+	for key, volume := range spec.Volumes {
+		if strings.TrimSpace(volume.Name) != "" {
+			continue
+		}
+		if name := strings.TrimSpace(linkedNames[key]); name != "" {
+			volume.Name = name
+			spec.Volumes[key] = volume
+		}
+	}
+	return nil
+}
+
+func updateMigratedProject(ctx context.Context, conn migrationConn, project projectNameMigrationRow, newName string, revision int64, specHash string) error {
+	query := `UPDATE project SET name = ? WHERE id = ? AND name = ?`
+	args := []any{newName, project.id, project.name}
+	if revision > 0 {
+		query = `UPDATE project SET name = ?, current_revision = ?, spec_hash = ? WHERE id = ? AND name = ? AND current_revision = ?`
+		args = []any{newName, revision, specHash, project.id, project.name, project.currentRevision}
+	}
+	result, err := conn.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("rename duplicate project %s to %s: %w", project.id, newName, err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count renamed duplicate project %s: %w", project.id, err)
+	}
+	if updated != 1 {
+		return fmt.Errorf("rename duplicate project %s updated %d rows", project.id, updated)
+	}
+	return nil
+}
+
+func nextAvailableProjectName(name string, used map[string]struct{}, projectCount int) (string, bool) {
+	for suffix := 2; suffix <= projectCount+1; suffix++ {
+		candidate := name + "-" + strconv.Itoa(suffix)
+		if _, exists := used[candidate]; !exists {
+			return candidate, true
+		}
+	}
+	return "", false
+}

--- a/pkg/storage/sqlite/project_name_migration_test.go
+++ b/pkg/storage/sqlite/project_name_migration_test.go
@@ -1,0 +1,328 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"agent-compose/pkg/compose"
+)
+
+func TestUniqueProjectNameMigrationRenamesDuplicatesInStableOrder(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	if err := MigrateThrough(ctx, db, 8); err != nil {
+		t.Fatalf("MigrateThrough v8: %v", err)
+	}
+
+	for _, statement := range []string{
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at,removed_at) VALUES('canonical','demo',1,'canonical-hash',1,20,0)`,
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at,removed_at) VALUES('older-active','demo',1,'active-hash',2,10,0)`,
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at,removed_at) VALUES('newer-removed','demo',1,'removed-hash',3,100,99)`,
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at,removed_at) VALUES('reserved','demo-2',1,'reserved-hash',4,5,0)`,
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at,removed_at) VALUES('huge-suffix','demo-999999999999999999999999999999999999',1,'huge-suffix-hash',5,5,0)`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			t.Fatalf("insert migration fixture project: %v", err)
+		}
+	}
+	for _, item := range []struct {
+		id   string
+		hash string
+	}{
+		{id: "canonical", hash: "canonical-hash"},
+		{id: "older-active", hash: "active-hash"},
+		{id: "newer-removed", hash: "removed-hash"},
+		{id: "reserved", hash: "reserved-hash"},
+		{id: "huge-suffix", hash: "huge-suffix-hash"},
+	} {
+		specJSON := `{"name":"demo"}`
+		if item.id == "older-active" {
+			specJSON = `{"name":"demo","agents":[{"name":"worker","scheduler":{}}],"volumes":[{"key":"cache"}]}`
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO project_revision(project_id,revision,spec_hash,spec_json,created_at) VALUES(?,1,?,?,1)`, item.id, item.hash, specJSON); err != nil {
+			t.Fatalf("insert migration fixture revision %s: %v", item.id, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO project_agent(id,name,short_id,project_id,agent_name,revision,spec_json,created_at,updated_at) VALUES('older-agent','worker','older','older-active','worker',1,'{}',1,1)`); err != nil {
+		t.Fatalf("insert migration fixture agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO project_scheduler(id,short_id,project_id,scheduler_id,agent_name,revision,spec_json,created_at,updated_at) VALUES('older-scheduler','sched','older-active','older-scheduler','worker',1,'{}',1,1)`); err != nil {
+		t.Fatalf("insert migration fixture scheduler: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO volumes(id,name,project_id) VALUES('older-cache','demo_cache','older-active')`); err != nil {
+		t.Fatalf("insert migration fixture volume: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO project_volumes(project_id,volume_key,volume_id) VALUES('older-active','cache','older-cache')`); err != nil {
+		t.Fatalf("insert migration fixture volume link: %v", err)
+	}
+
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("Migrate v9: %v", err)
+	}
+	for id, wantName := range map[string]string{
+		"canonical":     "demo",
+		"older-active":  "demo-3",
+		"newer-removed": "demo-4",
+		"reserved":      "demo-2",
+		"huge-suffix":   "demo-999999999999999999999999999999999999",
+	} {
+		var name string
+		if err := db.QueryRowContext(ctx, `SELECT name FROM project WHERE id = ?`, id).Scan(&name); err != nil {
+			t.Fatalf("query migrated project %s: %v", id, err)
+		}
+		if name != wantName {
+			t.Errorf("project %s name = %q, want %q", id, name, wantName)
+		}
+	}
+	var revision int64
+	var projectHash string
+	if err := db.QueryRowContext(ctx, `SELECT current_revision,spec_hash FROM project WHERE id='older-active'`).Scan(&revision, &projectHash); err != nil {
+		t.Fatalf("query renamed project revision: %v", err)
+	}
+	if revision != 2 {
+		t.Fatalf("renamed project revision = %d, want migration revision 2", revision)
+	}
+	var revisionHash, revisionJSON string
+	if err := db.QueryRowContext(ctx, `SELECT spec_hash,spec_json FROM project_revision WHERE project_id='older-active' AND revision=2`).Scan(&revisionHash, &revisionJSON); err != nil {
+		t.Fatalf("query migrated project revision: %v", err)
+	}
+	migratedSpec, err := compose.ParseCanonicalJSON([]byte(revisionJSON))
+	if err != nil {
+		t.Fatalf("parse migrated project revision: %v", err)
+	}
+	canonicalHash, err := migratedSpec.Hash()
+	if err != nil {
+		t.Fatalf("hash migrated project revision: %v", err)
+	}
+	if migratedSpec.Name != "demo-3" || migratedSpec.Volumes["cache"].Name != "demo_cache" || len(migratedSpec.Agents) != 1 ||
+		migratedSpec.Agents[0].Scheduler == nil || migratedSpec.Agents[0].Scheduler.SandboxPolicy != "new" ||
+		migratedSpec.Agents[0].Scheduler.ConcurrencyPolicy != "skip" {
+		t.Fatalf("migrated spec = %#v, want renamed project with materialized demo_cache", migratedSpec)
+	}
+	if projectHash != revisionHash || revisionHash != canonicalHash {
+		t.Fatalf("project/revision/canonical hashes = %q/%q/%q", projectHash, revisionHash, canonicalHash)
+	}
+	var originalJSON string
+	if err := db.QueryRowContext(ctx, `SELECT spec_json FROM project_revision WHERE project_id='older-active' AND revision=1`).Scan(&originalJSON); err != nil {
+		t.Fatalf("query original project revision: %v", err)
+	}
+	if originalJSON != `{"name":"demo","agents":[{"name":"worker","scheduler":{}}],"volumes":[{"key":"cache"}]}` {
+		t.Fatalf("original project revision changed to %s", originalJSON)
+	}
+	for table := range map[string]struct{}{"project_agent": {}, "project_scheduler": {}} {
+		if err := db.QueryRowContext(ctx, `SELECT revision FROM `+table+` WHERE project_id='older-active'`).Scan(&revision); err != nil {
+			t.Fatalf("query %s revision: %v", table, err)
+		}
+		if revision != 2 {
+			t.Errorf("%s revision = %d, want migration revision 2", table, revision)
+		}
+	}
+	var volumeID string
+	if err := db.QueryRowContext(ctx, `SELECT volume_id FROM project_volumes WHERE project_id='older-active' AND volume_key='cache'`).Scan(&volumeID); err != nil {
+		t.Fatalf("query preserved project volume link: %v", err)
+	}
+	if volumeID != "older-cache" {
+		t.Fatalf("preserved project volume id = %q, want older-cache", volumeID)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO project(id,name,created_at,updated_at) VALUES('duplicate','demo',1,1)`); err == nil {
+		t.Fatal("unique project name index accepted duplicate name")
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE project SET name='renamed' WHERE id='canonical'`); err == nil {
+		t.Fatal("project name immutability trigger accepted a rename")
+	}
+	rows, err := db.QueryContext(ctx, `PRAGMA foreign_key_check`)
+	if err != nil {
+		t.Fatalf("run foreign key check: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if rows.Next() {
+		t.Fatal("foreign key check reported a violation")
+	}
+}
+
+func TestUniqueProjectNameMigrationPreservesProjectListDuplicateData(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	if err := MigrateThrough(ctx, db, 8); err != nil {
+		t.Fatalf("MigrateThrough v8: %v", err)
+	}
+
+	type projectFixture struct {
+		id, name, sourcePath string
+		updatedAt            int64
+	}
+	const relatedProjectID = "project-facade-file"
+	fixtures := []projectFixture{
+		{id: "b96a99621d61-legacy", name: "legacy-v1-default", updatedAt: 10},
+		{id: "884486024b96-cli", name: "cli-smoke", sourcePath: "/data/projects/cli-smoke/agent-compose.yml", updatedAt: 60},
+		{id: "project-facade-pilot", name: "facade-smoke-pilot-patched-20260701", sourcePath: "/tmp/facade-smoke-pilot-patched/agent-compose.yml", updatedAt: 50},
+		{id: "project-facade-workspace", name: "facade-smoke-20260701", sourcePath: "/tmp/facade-smoke-workspace/agent-compose.yml", updatedAt: 40},
+		{id: "project-facade-file", name: "facade-smoke-20260701", sourcePath: "/tmp/agent-compose-facade-smoke.yml", updatedAt: 30},
+		{id: "project-cli-source", name: "cli-smoke", sourcePath: "/data/projects/cli-smoke/agent-compose.yml", updatedAt: 20},
+	}
+	for _, item := range fixtures {
+		hash := "hash-" + item.id
+		specJSON := fmt.Sprintf(`{"name":%q}`, item.name)
+		if item.id == relatedProjectID {
+			specJSON = fmt.Sprintf(`{"name":%q,"volumes":[{"key":"cache"}]}`, item.name)
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO project(
+			id,name,source_path,current_revision,spec_hash,created_at,updated_at,removed_at
+		) VALUES(?,?,?,1,?,1,?,0)`, item.id, item.name, item.sourcePath, hash, item.updatedAt); err != nil {
+			t.Fatalf("insert project %s: %v", item.id, err)
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO project_revision(
+			project_id,revision,spec_hash,spec_json,created_at
+		) VALUES(?,1,?,?,1)`, item.id, hash, specJSON); err != nil {
+			t.Fatalf("insert revision for %s: %v", item.id, err)
+		}
+	}
+
+	for _, statement := range []string{
+		`INSERT INTO project_agent(id,name,project_id,agent_name,revision,spec_json,created_at,updated_at)
+		 VALUES('facade-agent','worker','project-facade-file','worker',1,'{}',1,1)`,
+		`INSERT INTO project_scheduler(id,project_id,scheduler_id,agent_name,revision,spec_json,created_at,updated_at)
+		 VALUES('facade-scheduler','project-facade-file','facade-scheduler','worker',1,'{}',1,1)`,
+		`INSERT INTO scheduler_run(scheduler_id,run_id,status,started_at)
+		 VALUES('facade-scheduler','facade-scheduler-run','succeeded',1)`,
+		`INSERT INTO project_run(run_id,project_id,project_name,project_revision,agent_name,agent_id,status,created_at,updated_at)
+		 VALUES('facade-project-run','project-facade-file','facade-smoke-20260701',1,'worker','facade-agent','succeeded',1,1)`,
+		`INSERT INTO sandboxes(id,project_id,project_id_search)
+		 VALUES('facade-sandbox','project-facade-file','project-facade-file')`,
+		`INSERT INTO volumes(id,name,project_id) VALUES('facade-volume','facade-volume','project-facade-file')`,
+		`INSERT INTO project_volumes(project_id,volume_key,volume_id)
+		 VALUES('project-facade-file','cache','facade-volume')`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			t.Fatalf("insert related project data: %v", err)
+		}
+	}
+
+	if err := Migrate(ctx, db); err != nil {
+		t.Fatalf("Migrate v9: %v", err)
+	}
+	wantNames := map[string]string{
+		"b96a99621d61-legacy":      "legacy-v1-default",
+		"884486024b96-cli":         "cli-smoke",
+		"project-facade-pilot":     "facade-smoke-pilot-patched-20260701",
+		"project-facade-workspace": "facade-smoke-20260701",
+		"project-facade-file":      "facade-smoke-20260701-2",
+		"project-cli-source":       "cli-smoke-2",
+	}
+	for _, item := range fixtures {
+		var name, sourcePath string
+		if err := db.QueryRowContext(ctx, `SELECT name,source_path FROM project WHERE id=?`, item.id).Scan(&name, &sourcePath); err != nil {
+			t.Fatalf("query project %s: %v", item.id, err)
+		}
+		if name != wantNames[item.id] || sourcePath != item.sourcePath {
+			t.Errorf("project %s = name %q source %q, want %q and %q", item.id, name, sourcePath, wantNames[item.id], item.sourcePath)
+		}
+	}
+
+	relationQueries := map[string]string{
+		"revision":       `SELECT project_id FROM project_revision WHERE spec_hash='hash-project-facade-file'`,
+		"agent":          `SELECT project_id FROM project_agent WHERE id='facade-agent'`,
+		"scheduler":      `SELECT project_id FROM project_scheduler WHERE id='facade-scheduler'`,
+		"scheduler run":  `SELECT project_scheduler.project_id FROM scheduler_run JOIN project_scheduler ON project_scheduler.id=scheduler_run.scheduler_id WHERE scheduler_run.run_id='facade-scheduler-run'`,
+		"project run":    `SELECT project_id FROM project_run WHERE run_id='facade-project-run'`,
+		"sandbox":        `SELECT project_id FROM sandboxes WHERE id='facade-sandbox'`,
+		"volume":         `SELECT project_id FROM volumes WHERE id='facade-volume'`,
+		"project volume": `SELECT project_id FROM project_volumes WHERE volume_id='facade-volume'`,
+	}
+	for relation, query := range relationQueries {
+		var projectID string
+		if err := db.QueryRowContext(ctx, query).Scan(&projectID); err != nil {
+			t.Fatalf("query %s owner: %v", relation, err)
+		}
+		if projectID != relatedProjectID {
+			t.Errorf("%s project_id = %q, want %q", relation, projectID, relatedProjectID)
+		}
+	}
+	var currentRevision int64
+	var currentHash string
+	if err := db.QueryRowContext(ctx, `SELECT current_revision,spec_hash FROM project WHERE id=?`, relatedProjectID).Scan(&currentRevision, &currentHash); err != nil {
+		t.Fatalf("query related project current revision: %v", err)
+	}
+	if currentRevision != 2 {
+		t.Fatalf("related project current revision = %d, want 2", currentRevision)
+	}
+	var migratedHash, migratedJSON string
+	if err := db.QueryRowContext(ctx, `SELECT spec_hash,spec_json FROM project_revision WHERE project_id=? AND revision=2`, relatedProjectID).Scan(&migratedHash, &migratedJSON); err != nil {
+		t.Fatalf("query related project migrated revision: %v", err)
+	}
+	migratedSpec, err := compose.ParseCanonicalJSON([]byte(migratedJSON))
+	if err != nil {
+		t.Fatalf("parse related project migrated revision: %v", err)
+	}
+	canonicalHash, err := migratedSpec.Hash()
+	if err != nil {
+		t.Fatalf("hash related project migrated revision: %v", err)
+	}
+	if migratedSpec.Name != "facade-smoke-20260701-2" || migratedSpec.Volumes["cache"].Name != "facade-volume" {
+		t.Fatalf("related project migrated spec = %#v", migratedSpec)
+	}
+	if currentHash != migratedHash || migratedHash != canonicalHash {
+		t.Fatalf("related project hashes = %q/%q/%q", currentHash, migratedHash, canonicalHash)
+	}
+	for _, table := range []string{"project_agent", "project_scheduler"} {
+		var artifactRevision int64
+		if err := db.QueryRowContext(ctx, `SELECT revision FROM `+table+` WHERE project_id=?`, relatedProjectID).Scan(&artifactRevision); err != nil {
+			t.Fatalf("query related %s revision: %v", table, err)
+		}
+		if artifactRevision != currentRevision {
+			t.Errorf("related %s revision = %d, want %d", table, artifactRevision, currentRevision)
+		}
+	}
+	var projectCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM project`).Scan(&projectCount); err != nil {
+		t.Fatalf("count projects: %v", err)
+	}
+	if projectCount != len(fixtures) {
+		t.Fatalf("project count = %d, want all %d projects preserved", projectCount, len(fixtures))
+	}
+}
+
+func TestUniqueProjectNameMigrationRollsBackMalformedCurrentRevision(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	if err := MigrateThrough(ctx, db, 8); err != nil {
+		t.Fatalf("MigrateThrough v8: %v", err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at) VALUES('canonical','demo',1,'canonical-hash',1,30)`,
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at) VALUES('valid','demo',1,'valid-hash',1,20)`,
+		`INSERT INTO project(id,name,current_revision,spec_hash,created_at,updated_at) VALUES('malformed','demo',1,'malformed-hash',1,10)`,
+		`INSERT INTO project_revision(project_id,revision,spec_hash,spec_json,created_at) VALUES('canonical',1,'canonical-hash','{"name":"demo"}',1)`,
+		`INSERT INTO project_revision(project_id,revision,spec_hash,spec_json,created_at) VALUES('valid',1,'valid-hash','{"name":"demo"}',1)`,
+		`INSERT INTO project_revision(project_id,revision,spec_hash,spec_json,created_at) VALUES('malformed',1,'malformed-hash','{"name":',1)`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			t.Fatalf("insert malformed migration fixture: %v", err)
+		}
+	}
+
+	err := Migrate(ctx, db)
+	if err == nil || !strings.Contains(err.Error(), "decode current revision malformed/1 before rename") {
+		t.Fatalf("Migrate error = %v, want malformed current revision failure", err)
+	}
+	var name string
+	var currentRevision, revisionCount int64
+	if err := db.QueryRowContext(ctx, `SELECT name,current_revision FROM project WHERE id='valid'`).Scan(&name, &currentRevision); err != nil {
+		t.Fatalf("query valid project after rollback: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM project_revision WHERE project_id='valid'`).Scan(&revisionCount); err != nil {
+		t.Fatalf("count valid project revisions after rollback: %v", err)
+	}
+	if name != "demo" || currentRevision != 1 || revisionCount != 1 {
+		t.Fatalf("valid project after rollback = name %q revision %d count %d", name, currentRevision, revisionCount)
+	}
+	var migrationCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_migrations WHERE version=9`).Scan(&migrationCount); err != nil {
+		t.Fatalf("query v8 history after rollback: %v", err)
+	}
+	if migrationCount != 0 {
+		t.Fatalf("v8 migration history count after rollback = %d, want 0", migrationCount)
+	}
+}

--- a/pkg/storage/sqlite/project_name_migration_test.go
+++ b/pkg/storage/sqlite/project_name_migration_test.go
@@ -324,9 +324,9 @@ func TestUniqueProjectNameMigrationRollsBackMalformedCurrentRevision(t *testing.
 	}
 	var migrationCount int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_migrations WHERE version=9`).Scan(&migrationCount); err != nil {
-		t.Fatalf("query v8 history after rollback: %v", err)
+		t.Fatalf("query v9 history after rollback: %v", err)
 	}
 	if migrationCount != 0 {
-		t.Fatalf("v8 migration history count after rollback = %d, want 0", migrationCount)
+		t.Fatalf("v9 migration history count after rollback = %d, want 0", migrationCount)
 	}
 }

--- a/pkg/storage/sqlite/project_name_migration_test.go
+++ b/pkg/storage/sqlite/project_name_migration_test.go
@@ -129,8 +129,12 @@ func TestUniqueProjectNameMigrationRenamesDuplicatesInStableOrder(t *testing.T) 
 	if _, err := db.ExecContext(ctx, `INSERT INTO project(id,name,created_at,updated_at) VALUES('duplicate','demo',1,1)`); err == nil {
 		t.Fatal("unique project name index accepted duplicate name")
 	}
-	if _, err := db.ExecContext(ctx, `UPDATE project SET name='renamed' WHERE id='canonical'`); err == nil {
-		t.Fatal("project name immutability trigger accepted a rename")
+	if _, err := db.ExecContext(ctx, `UPDATE project SET name='renamed' WHERE id='canonical'`); err != nil {
+		t.Fatalf("rename uniquely named project: %v", err)
+	}
+	var renamedProjectName string
+	if err := db.QueryRowContext(ctx, `SELECT name FROM project WHERE id='canonical'`).Scan(&renamedProjectName); err != nil || renamedProjectName != "renamed" {
+		t.Fatalf("renamed project name = %q, %v", renamedProjectName, err)
 	}
 	rows, err := db.QueryContext(ctx, `PRAGMA foreign_key_check`)
 	if err != nil {

--- a/pkg/storage/sqlite/v2_migration_design_test.go
+++ b/pkg/storage/sqlite/v2_migration_design_test.go
@@ -97,8 +97,8 @@ func TestV2MigrationDesignPreservesManagedHistory(t *testing.T) {
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_migrations`).Scan(&historyCount); err != nil {
 		t.Fatalf("count v2 migration history: %v", err)
 	}
-	if historyCount != 8 {
-		t.Fatalf("v2 migration history count = %d, want 8", historyCount)
+	if historyCount != len(chain) {
+		t.Fatalf("v2 migration history count = %d, want %d", historyCount, len(chain))
 	}
 }
 
@@ -372,7 +372,7 @@ func TestCronLocalTimezoneMigrationOnlyUpdatesDeclarativeSchedulers(t *testing.T
 			if _, err := db.ExecContext(ctx, `UPDATE scheduler_trigger SET spec_json = '{"kind":"cron","expr":"0 9 * * *","timezone":"UTC"}', next_fire_at = 2000 WHERE scheduler_id = 'scheduler-1'`); err != nil {
 				t.Fatalf("set cron trigger: %v", err)
 			}
-			if err := applyMigrationSet(ctx, db, chain); err != nil {
+			if err := applyMigrationSet(ctx, db, chain[:8]); err != nil {
 				t.Fatalf("apply local timezone migration: %v", err)
 			}
 			var specJSON string
@@ -393,8 +393,8 @@ func loadV2MigrationDesignChain(t *testing.T) []migration {
 	if err != nil {
 		t.Fatalf("load migrations: %v", err)
 	}
-	if len(chain) != 8 {
-		t.Fatalf("migration count = %d, want 8", len(chain))
+	if len(chain) != 9 {
+		t.Fatalf("migration count = %d, want 9", len(chain))
 	}
 	return chain
 }

--- a/pkg/volumes/manager.go
+++ b/pkg/volumes/manager.go
@@ -150,6 +150,13 @@ func (m *Manager) ReplaceProjectVolumes(ctx context.Context, projectID string, l
 	return m.Project.ReplaceProjectVolumes(ctx, projectID, links)
 }
 
+func (m *Manager) ListProjectVolumes(ctx context.Context, projectID string) (map[string]domain.VolumeRecord, error) {
+	if m == nil || m.Project == nil {
+		return nil, fmt.Errorf("project volume store is required")
+	}
+	return m.Project.ListProjectVolumes(ctx, projectID)
+}
+
 func (m *Manager) RemoveProjectVolumes(ctx context.Context, projectID string) error {
 	if m == nil || m.Project == nil {
 		return fmt.Errorf("project volume store is required")

--- a/pkg/volumes/manager_integration_test.go
+++ b/pkg/volumes/manager_integration_test.go
@@ -63,7 +63,7 @@ func TestIntegrationManagerPersistsProjectVolumeLifecycle(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("ReplaceProjectVolumes: %v", err)
 	}
-	projectVolumes, err := store.ListProjectVolumes(ctx, "project-1")
+	projectVolumes, err := manager.ListProjectVolumes(ctx, "project-1")
 	if err != nil {
 		t.Fatalf("ListProjectVolumes: %v", err)
 	}

--- a/test/e2e/project_list_host_daemon_test.go
+++ b/test/e2e/project_list_host_daemon_test.go
@@ -67,9 +67,9 @@ func seedE2EProjectListDatabase(t *testing.T, ctx context.Context, databasePath 
 	store := configstore.FromDB(database.DB())
 	for index := range count {
 		id := fmt.Sprintf("project-%03d", index)
-		name := fmt.Sprintf("Project %03d", index)
+		name := id
 		if index == 42 {
-			name = "Needle Project 042"
+			name = "needle-" + id
 		}
 		project, err := store.UpsertProject(ctx, domain.ProjectRecord{
 			ID: id, Name: name, SourcePath: filepath.Join("/projects", id, "agent-compose.yml"), SourceJSON: `{"kind":"local"}`,

--- a/test/e2e/v2_storage_cutover_host_daemon_test.go
+++ b/test/e2e/v2_storage_cutover_host_daemon_test.go
@@ -189,8 +189,8 @@ func runV2StorageMigrator(t *testing.T, ctx context.Context, binary, dataRoot st
 	if err := json.Unmarshal(output, &report); err != nil {
 		t.Fatalf("decode V2 storage migrator report %q: %v", output, err)
 	}
-	if report.Stage != "complete" || report.SourceVersion != 4 || report.TargetVersion != 7 || !report.InPlace {
-		t.Fatalf("V2 storage migrator report = %+v, want in-place v4 to v7 completion", report)
+	if report.Stage != "complete" || report.SourceVersion != 4 || report.TargetVersion != 8 || !report.InPlace {
+		t.Fatalf("V2 storage migrator report = %+v, want in-place v4 to v9 completion", report)
 	}
 }
 

--- a/test/e2e/v2_storage_cutover_host_daemon_test.go
+++ b/test/e2e/v2_storage_cutover_host_daemon_test.go
@@ -13,6 +13,7 @@ import (
 
 	"connectrpc.com/connect"
 
+	domain "agent-compose/pkg/model"
 	storagesqlite "agent-compose/pkg/storage/sqlite"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
@@ -79,13 +80,14 @@ func TestE2EV2StorageMigratorDockerCutover(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSandbox after cutover: %v", err)
 	}
-	if sandboxResp.Msg.GetSandbox().GetStatus() != agentcomposev2.SandboxStatus_SANDBOX_STATUS_STOPPED || sandboxResp.Msg.GetSandbox().GetProjectId() != projectID {
-		t.Fatalf("migrated scheduler sandbox = %#v, want completed stopped sandbox for project %s", sandboxResp.Msg.GetSandbox(), projectID)
+	sandbox := sandboxResp.Msg.GetSandbox()
+	if sandbox.GetStatus() != agentcomposev2.SandboxStatus_SANDBOX_STATUS_STOPPED || sandbox.GetProjectId() != projectID {
+		t.Fatalf("migrated scheduler sandbox = %#v, want completed stopped sandbox for project %s", sandbox, projectID)
 	}
-	container := inspectE2EDockerSandboxContainer(t, ctx, dockerClient, sandboxID)
-	if container.State == nil || container.State.Running {
-		t.Fatalf("migrated scheduler Docker sandbox = %#v, want stopped container after one-shot execution", container.State)
+	if sandbox.GetStoppedRuntimePolicy() != domain.StoppedRuntimePolicyRemove || sandbox.GetStoppedRuntimeState() != domain.StoppedRuntimeStateReleased {
+		t.Fatalf("migrated scheduler runtime policy/state = %q/%q, want remove/released", sandbox.GetStoppedRuntimePolicy(), sandbox.GetStoppedRuntimeState())
 	}
+	assertE2EDockerSandboxContainerCount(t, ctx, dockerClient, sandboxID, 0)
 	removeResp, err := sandboxClient.RemoveSandbox(ctx, connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID, Force: true}))
 	if err != nil {
 		t.Fatalf("RemoveSandbox after cutover: %v", err)
@@ -189,7 +191,7 @@ func runV2StorageMigrator(t *testing.T, ctx context.Context, binary, dataRoot st
 	if err := json.Unmarshal(output, &report); err != nil {
 		t.Fatalf("decode V2 storage migrator report %q: %v", output, err)
 	}
-	if report.Stage != "complete" || report.SourceVersion != 4 || report.TargetVersion != 8 || !report.InPlace {
+	if report.Stage != "complete" || report.SourceVersion != 4 || report.TargetVersion != 9 || !report.InPlace {
 		t.Fatalf("V2 storage migrator report = %+v, want in-place v4 to v9 completion", report)
 	}
 }


### PR DESCRIPTION
## Summary

- Align project application and `up`/`down` selection with Docker Compose project-name behavior: the normalized name is a daemon-unique public selector, moving a compose file keeps the same durable project ID, and no new CLI option or `-p` alias is added.
- Preserve main's published schema v8 cron-timezone migration and add the unique project-name change as schema v9. Existing duplicate names are not merged; active/newer records keep the base name and the rest receive deterministic `<name>-N` suffixes while preserving IDs, relationships, history, implicit volumes, and a matching current revision/hash.
- Enforce daemon-wide name uniqueness with the existing migration framework and a unique project-name index while keeping names mutable for ID-addressed storage updates. A rename retains the opaque project ID, and a conflicting name is rejected atomically. No CLI or protobuf rename flow is added.
- Serialize same-name lifecycle operations, make partial `down` retryable, and enumerate all running sandboxes before project-tag ownership filtering so legacy project-only records are not skipped.
- Retain exact Unicode source-path lookup behavior and decode historical scheduler defaults needed by migrated revision snapshots while preserving trigger inheritance semantics.

## Testing

- `task generate:proto`
- `go test -count=1 ./pkg/storage/sqlite ./cmd/agent-compose-migrate/migrate ./cmd/agent-compose-migrate ./pkg/storage/configstore ./pkg/projects ./pkg/compose ./test/e2e`
- `go test -race -count=1 ./pkg/projects`
- `task test:e2e:docker-v2-storage-cutover`
  - Real Docker daemon and `agent-compose-guest:latest`: migrated a schema-v4 standalone scheduler through the one-shot migrator to schema v9, started the rebased daemon, executed the scheduler, verified persisted environment/result/event/sandbox data and `remove/released` runtime state, then verified cleanup.
- `task docs:build`
- `task lint`
- `task test`
  - unit: 74.92%
  - integration: 60.69%
  - E2E: 60.15%
  - combined: 79.09%
- `task build`
  - Full Linux binary built with Docker, BoxLite, and Microsandbox compiled in; downloaded runtime artifacts passed their upstream checksums.
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

## Real upgrade regression

Using isolated copies of representative historical project data (source details omitted):

- Started matching v2607.9.0 and v2607.10.0 daemons and verified their bundled CLIs could list the existing projects.
- Ran the candidate standalone migrator from schema v4 to v9. SQLite integrity checks passed, duplicate project names were deterministically suffixed, the unique project-name index was present, and a second migration run was idempotent.
- Started the candidate daemon with the candidate CLI against both upgraded data sets. project ls, inspect, project up, project down, repeated down, and Compose-compatible default-name normalization all passed.
- Applying the same project name from two different compose-file locations reused one project ID and reported updated; no -p option was used.