### PR TITLE
feat(scheduler): use daemon timezone for cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,7 +79,8 @@ DEFAULT_IMAGE=ghcr.io/chaitin/agent-compose-guest:latest
 # Change these only when your deployment environment requires custom runtime
 # paths, image cache behavior, or driver-specific images.
 # ---------------------------------------------------------------------------
-# Daemon process timezone.
+# Daemon process timezone. By default the Compose deployment inherits the
+# Linux host's /etc/localtime. Set TZ only to override the host timezone.
 # TZ=Asia/Shanghai
 
 # Guest paths and ports.

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ COPY --from=go-build /out/agent-compose /out/agent-compose
 FROM ${REGISTRY_MIRROR}/library/debian:trixie-slim
 RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update &&     apt-get install -y --no-install-recommends ca-certificates git python3 tini tzdata e2fsprogs qemu-utils &&     rm -rf /var/lib/apt/lists/*
-RUN ln -sfv /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo "Asia/Shanghai" > /etc/timezone
 WORKDIR /app
 COPY --from=go-build /out/agent-compose /app/agent-compose
 RUN ln -sf /app/agent-compose /usr/local/bin/agent-compose

--- a/Dockerfile.agent-compose-local
+++ b/Dockerfile.agent-compose-local
@@ -51,7 +51,6 @@ COPY --from=go-build /out/agent-compose /out/agent-compose
 FROM ${REGISTRY_MIRROR}/library/debian:trixie-slim
 RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update &&     apt-get install -y --no-install-recommends ca-certificates git python3 tini tzdata e2fsprogs qemu-utils &&     rm -rf /var/lib/apt/lists/*
-RUN ln -sfv /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo "Asia/Shanghai" > /etc/timezone
 WORKDIR /app
 COPY --from=go-build /out/agent-compose /app/agent-compose
 RUN ln -sf /app/agent-compose /usr/local/bin/agent-compose

--- a/README.md
+++ b/README.md
@@ -419,6 +419,11 @@ overlay:
 docker compose -f docker-compose.yml -f docker-compose.kvm.yml up -d
 ```
 
+The daemon also mounts the Linux host's `/etc/localtime` read-only. Cron
+triggers without an explicit `timezone` therefore follow the host timezone.
+Set `TZ` in `.env` only to override it, and restart the daemon after changing
+the timezone.
+
 The installer checks for `/dev/kvm` on a new installation and persists either
 the base file or the base-plus-KVM file set as `COMPOSE_FILE` in `.env`. This is
 deployment selection, not proof that KVM or either native runtime is healthy.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -340,6 +340,8 @@ docker compose --profile with-ui up -d   # 同时启动 Web UI
 
 以上命令默认使用不含 KVM 权限的基础 Compose。需要在 Linux KVM 主机显式启用 BoxLite/Microsandbox 时，把 `COMPOSE_FILE=docker-compose.yml:docker-compose.kvm.yml` 写入部署目录的 `.env`；`docker-compose.kvm.yml` 只增加 `privileged` 和 `/dev/kvm` 能力，不是本地 build override。
 
+Daemon 还会以只读方式挂载 Linux 宿主机的 `/etc/localtime`，因此未显式设置 `timezone` 的 cron trigger 会跟随宿主机时区。仅在需要覆盖宿主机时区时才在 `.env` 中设置 `TZ`，修改后需要重启 daemon。
+
 **[`.env.example`](.env.example) 是权威的、带完整注释的配置参考。** 对外部署前至少检查这些：
 
 - `AUTH_PASSWORD`、`AUTH_SECRET` —— UI server 登录 secret（务必替换示例值）。

--- a/cmd/agent-compose-migrate/main_test.go
+++ b/cmd/agent-compose-migrate/main_test.go
@@ -46,7 +46,7 @@ func TestE2ELegacyMigratorCLIJSONDryRun(t *testing.T) {
 	if err := reader.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 7 || !report.DryRun {
+	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 8 || !report.DryRun {
 		t.Fatalf("exit=%d report=%+v", exitCode, report)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -91,7 +91,7 @@ func TestE2ELegacyMigratorCLITextDryRun(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", exitCode)
 	}
-	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 7 is eligible"; got != want {
+	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 8 is eligible"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -153,7 +153,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 	}
 
 	report := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 7 || report.Backup == "" {
+	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 8 || report.Backup == "" {
 		t.Fatalf("in-place report=%+v", report)
 	}
 	nativeInfo, err := os.Stat(filepath.Join(root, "sandboxes", sandboxID, "state.bin"))
@@ -164,7 +164,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 		t.Fatalf("database backup is unavailable: %v", err)
 	}
 	repeated := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if repeated.Stage != "complete" || repeated.TargetVersion != 7 {
+	if repeated.Stage != "complete" || repeated.TargetVersion != 8 {
 		t.Fatalf("repeated in-place report=%+v", repeated)
 	}
 }

--- a/cmd/agent-compose-migrate/migrate/in_place.go
+++ b/cmd/agent-compose-migrate/migrate/in_place.go
@@ -198,7 +198,7 @@ func continueInPlaceMigration(ctx context.Context, report Report, root, runtimeR
 		}
 	}
 	report.Stage = "complete"
-	report.TargetVersion = 7
+	report.TargetVersion = currentSchemaVersion
 	report.Warnings = append([]string(nil), state.Warnings...)
 	writeMigrationProgress(progress, "complete", "in-place migration completed")
 	return report, nil
@@ -338,7 +338,7 @@ func switchInPlaceDatabase(ctx context.Context, root string) error {
 	converted := filepath.Join(backupRoot, inPlaceConvertedDB)
 	if version, err := databaseVersionIfPresent(ctx, current); err != nil {
 		return err
-	} else if version == 7 {
+	} else if version == currentSchemaVersion {
 		if err := os.Remove(converted); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("remove redundant converted database: %w", err)
 		}

--- a/cmd/agent-compose-migrate/migrate/in_place_test.go
+++ b/cmd/agent-compose-migrate/migrate/in_place_test.go
@@ -91,7 +91,7 @@ func TestIntegrationRunMigratesDataRootInPlaceWithoutCopyingSandboxData(t *testi
 	}
 
 	report, err := Run(context.Background(), Options{Source: root, Target: root})
-	if err != nil || report.Stage != "complete" || report.TargetVersion != 7 || !report.InPlace || report.CopiedBytes != 0 {
+	if err != nil || report.Stage != "complete" || report.TargetVersion != currentSchemaVersion || !report.InPlace || report.CopiedBytes != 0 {
 		t.Fatalf("in-place migration report=%+v err=%v", report, err)
 	}
 	if report.SourceFingerprint != "" {
@@ -164,7 +164,7 @@ func TestIntegrationRunMigratesDataRootInPlaceWithoutCopyingSandboxData(t *testi
 	summary["vm_status"] = "RUNNING"
 	writeMigrationJSON(t, filepath.Join(root, "sandboxes", sandboxID, "metadata.json"), metadata)
 	repeated, err := Run(context.Background(), Options{Source: root, Target: root})
-	if err != nil || repeated.Stage != "complete" || repeated.TargetVersion != 7 {
+	if err != nil || repeated.Stage != "complete" || repeated.TargetVersion != currentSchemaVersion {
 		t.Fatalf("repeated in-place migration report=%+v err=%v", repeated, err)
 	}
 }
@@ -250,7 +250,7 @@ func TestIntegrationRunMigratesUnversionedAndMixedStandaloneDataInPlace(t *testi
 			}
 
 			report, err := Run(context.Background(), Options{Source: root, Target: root})
-			if err != nil || report.Stage != "complete" || report.TargetVersion != 7 {
+			if err != nil || report.Stage != "complete" || report.TargetVersion != currentSchemaVersion {
 				t.Fatalf("mixed in-place migration report=%+v err=%v", report, err)
 			}
 			targetDB, err := openReadOnly(filepath.Join(root, databaseName))
@@ -415,7 +415,7 @@ func TestIntegrationRunResumesInPlaceAfterOriginalDatabaseMove(t *testing.T) {
 	}
 
 	report, err := Run(ctx, Options{Source: root, Target: root})
-	if err != nil || report.Stage != "complete" || report.TargetVersion != 7 {
+	if err != nil || report.Stage != "complete" || report.TargetVersion != currentSchemaVersion {
 		t.Fatalf("resumed switch report=%+v err=%v", report, err)
 	}
 	if _, err := os.Stat(filepath.Join(root, databaseName)); err != nil {

--- a/cmd/agent-compose-migrate/migrate/legacy_projection_reconciliation_test.go
+++ b/cmd/agent-compose-migrate/migrate/legacy_projection_reconciliation_test.go
@@ -101,7 +101,7 @@ func TestRunReconcilesExistingLegacyProjectProjections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run returned error: %v (%+v)", err, report)
 	}
-	if report.TargetVersion != 7 || report.Stage != "complete" {
+	if report.TargetVersion != currentSchemaVersion || report.Stage != "complete" {
 		t.Fatalf("report = %+v", report)
 	}
 	for _, warning := range []string{

--- a/cmd/agent-compose-migrate/migrate/migrate.go
+++ b/cmd/agent-compose-migrate/migrate/migrate.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	databaseName      = "data.db"
-	journalName       = ".agent-compose-migrate.json"
-	inPlaceBackupName = ".agent-compose-migrate-backup"
+	databaseName         = "data.db"
+	journalName          = ".agent-compose-migrate.json"
+	inPlaceBackupName    = ".agent-compose-migrate-backup"
+	currentSchemaVersion = 8
 )
 
 var knownMigrationChecksums = map[int64]string{
@@ -32,6 +33,7 @@ var knownMigrationChecksums = map[int64]string{
 	5: "e43cc1ffdfcd45e5e81a8fc098a6e77299e6e437f8c447eb0db49443a3bd29d2",
 	6: "92da2ea1c85e7d1321ca1e4260370a3d12057219005a83808529dbdd8d25299a",
 	7: "a8cb740e25992d3f3121bcfbff07c67cff699e8625d281edf60c0e76f91ce9ba",
+	8: "4569a4d7f82de70d3a2545dcdff07e0929e55daffaedf13fd6f2b8a8bcbf1d3e",
 }
 
 var ErrReported = errors.New("migration failure is included in the report")
@@ -110,7 +112,7 @@ func Run(ctx context.Context, options Options) (Report, error) {
 		return fail(err)
 	}
 	report.SourceVersion = version
-	if version < 0 || version > 7 {
+	if version < 0 || version > currentSchemaVersion {
 		return fail(fmt.Errorf("source database has an unknown migration version"))
 	}
 	if version == 0 {

--- a/cmd/agent-compose-migrate/migrate/migrate_test.go
+++ b/cmd/agent-compose-migrate/migrate/migrate_test.go
@@ -40,7 +40,7 @@ func TestRunCopiesLatestDataRootAndResumes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run returned error: %v (%+v)", err, report)
 	}
-	if report.TargetVersion != 7 || report.CopiedFiles != 2 || report.Stage != "complete" || report.SourceFingerprint == "" {
+	if report.TargetVersion != currentSchemaVersion || report.CopiedFiles != 2 || report.Stage != "complete" || report.SourceFingerprint == "" {
 		t.Fatalf("report = %+v", report)
 	}
 	data, err := os.ReadFile(filepath.Join(target, "sandboxes", "sandbox-1", "artifact.txt"))
@@ -431,7 +431,7 @@ func TestRunConvertsStandaloneVersionedAndUnversionedSources(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Run returned error: %v (%+v)", err, report)
 			}
-			if report.TargetVersion != 7 || len(report.Warnings) != 1 {
+			if report.TargetVersion != currentSchemaVersion || len(report.Warnings) != 1 {
 				t.Fatalf("report = %+v", report)
 			}
 			targetDatabase, err := sqlite.Open(filepath.Join(target, databaseName), 0)
@@ -687,7 +687,7 @@ func TestRunAppendsProjectionRevisionAndBackfillsProvableSchedulerRun(t *testing
 	if err != nil {
 		t.Fatalf("Run returned error: %v (%+v)", err, report)
 	}
-	if len(report.Warnings) != 1 || report.TargetVersion != 7 {
+	if len(report.Warnings) != 1 || report.TargetVersion != currentSchemaVersion {
 		t.Fatalf("report = %+v", report)
 	}
 	targetDB, err := sql.Open("sqlite", filepath.Join(target, databaseName))

--- a/cmd/agent-compose-migrate/migrate/report_test.go
+++ b/cmd/agent-compose-migrate/migrate/report_test.go
@@ -12,16 +12,16 @@ func TestReportTextIncludesWarningsForEverySuccessfulMode(t *testing.T) {
 	if got := (Report{DryRun: true, SourceVersion: 4}).Text(); got != "legacy migration dry run: source schema version 4 is eligible" {
 		t.Fatalf("dry-run report text = %q", got)
 	}
-	if got := (Report{TargetVersion: 7, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v7, 2 files (9 bytes) copied to /target" {
+	if got := (Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v8, 2 files (9 bytes) copied to /target" {
 		t.Fatalf("complete report text = %q", got)
 	}
-	warningReport := Report{TargetVersion: 7, CopiedFiles: 2, Target: "/target", Warnings: []string{"unresolved scheduler link", "  external path retained  ", ""}}
-	if got, want := warningReport.Text(), "legacy migration complete: schema v7, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
+	warningReport := Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, Target: "/target", Warnings: []string{"unresolved scheduler link", "  external path retained  ", ""}}
+	if got, want := warningReport.Text(), "legacy migration complete: schema v8, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
 		t.Fatalf("warning report text = %q, want %q", got, want)
 	}
 	for name, report := range map[string]Report{
 		"dry run":  {DryRun: true, SourceVersion: 4, Warnings: []string{"dry-run warning"}},
-		"in place": {InPlace: true, TargetVersion: 7, Target: "/data", Backup: "/data/backup", Warnings: []string{"in-place warning"}},
+		"in place": {InPlace: true, TargetVersion: currentSchemaVersion, Target: "/data", Backup: "/data/backup", Warnings: []string{"in-place warning"}},
 	} {
 		t.Run(name+" warnings", func(t *testing.T) {
 			if got := report.Text(); !strings.Contains(got, "\nwarning: "+report.Warnings[0]) {

--- a/cmd/agent-compose-migrate/migrate/resume_test.go
+++ b/cmd/agent-compose-migrate/migrate/resume_test.go
@@ -41,7 +41,7 @@ func TestRunResumesFileCopyFromPersistedSchedulerMappings(t *testing.T) {
 			}
 
 			report, err := Run(context.Background(), Options{Source: source, Target: target})
-			if err != nil || report.Stage != "complete" || report.TargetVersion != 7 {
+			if err != nil || report.Stage != "complete" || report.TargetVersion != currentSchemaVersion {
 				t.Fatalf("resumed migration report=%+v err=%v", report, err)
 			}
 			if len(report.Warnings) != 1 || report.Warnings[0] != "preserved warning" {
@@ -80,7 +80,7 @@ func TestRunResumesDatabaseStageAfterTargetUpgrade(t *testing.T) {
 	}
 
 	report, err := Run(context.Background(), Options{Source: source, Target: target})
-	if err != nil || report.Stage != "complete" || report.TargetVersion != 7 {
+	if err != nil || report.Stage != "complete" || report.TargetVersion != currentSchemaVersion {
 		t.Fatalf("database-stage resume report=%+v err=%v", report, err)
 	}
 	if data, err := os.ReadFile(copiedArtifact); err != nil || string(data) != "preserved" {

--- a/cmd/agent-compose-migrate/migrate/target_database.go
+++ b/cmd/agent-compose-migrate/migrate/target_database.go
@@ -41,7 +41,7 @@ func prepareTargetDatabase(
 			return nil, nil, nil, err
 		}
 	}
-	if version < 1 || version > 7 {
+	if version < 1 || version > currentSchemaVersion {
 		return nil, nil, nil, fmt.Errorf("target database has an unknown migration version %d", version)
 	}
 	if err := validateVersionedPrefix(ctx, db, version); err != nil {
@@ -398,8 +398,8 @@ func verifyLatestTargetDatabase(ctx context.Context, path string) (int64, error)
 	if err != nil {
 		return 0, err
 	}
-	if version != 7 {
-		return 0, fmt.Errorf("resumable target database is schema v%d, want v7", version)
+	if version != currentSchemaVersion {
+		return 0, fmt.Errorf("resumable target database is schema v%d, want v%d", version, currentSchemaVersion)
 	}
 	if err := validateVersionedPrefix(ctx, db, version); err != nil {
 		return 0, fmt.Errorf("validate resumable target database: %w", err)

--- a/cmd/agent-compose/compose_env_e2e_test.go
+++ b/cmd/agent-compose/compose_env_e2e_test.go
@@ -29,6 +29,7 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 	composeData := readRepoFileForComposeEnvTest(t, root, "docker-compose.yml")
 	envExample := string(readRepoFileForComposeEnvTest(t, root, ".env.example"))
 	dockerfile := string(readRepoFileForComposeEnvTest(t, root, "Dockerfile"))
+	localDockerfile := string(readRepoFileForComposeEnvTest(t, root, "Dockerfile.agent-compose-local"))
 
 	var composeFile composeEnvContractFile
 	if err := yaml.Unmarshal(composeData, &composeFile); err != nil {
@@ -49,7 +50,7 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 			t.Fatalf("compose service still exposes legacy session root env %q", key)
 		}
 	}
-	for _, volume := range []string{"/var/run/docker.sock:/var/run/docker.sock", "${AGENT_COMPOSE_DATA_DIR:-./data}:/data", "./.env:/data/work/.env:ro"} {
+	for _, volume := range []string{"/var/run/docker.sock:/var/run/docker.sock", "/etc/localtime:/etc/localtime:ro", "${AGENT_COMPOSE_DATA_DIR:-./data}:/data", "./.env:/data/work/.env:ro"} {
 		if !stringSliceContains(service.Volumes, volume) {
 			t.Fatalf("agent-compose volumes = %#v, want %q", service.Volumes, volume)
 		}
@@ -82,6 +83,9 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 	}
 	if strings.Contains(dockerfile, "ENV SESSION_ROOT=") {
 		t.Fatalf("Dockerfile still defines legacy SESSION_ROOT")
+	}
+	if strings.Contains(dockerfile, "/usr/share/zoneinfo/Asia/Shanghai") || strings.Contains(localDockerfile, "/usr/share/zoneinfo/Asia/Shanghai") {
+		t.Fatal("daemon Dockerfiles must not hard-code the timezone")
 	}
 }
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -140,6 +140,10 @@ The base topology mounts the Docker socket without privilege or KVM. Use the
 persisted KVM overlay only on a prepared host when selecting BoxLite or
 Microsandbox.
 
+It also mounts the Linux host's `/etc/localtime` read-only so daemon-local cron
+schedules follow the host timezone. Set `TZ` in `.env` only when the daemon
+should intentionally use another timezone, then restart the daemon.
+
 ## Release model
 
 The fixed `installer-latest` prerelease contains:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       AGENT_COMPOSE_RUNTIME_BASE_URL: ${AGENT_COMPOSE_RUNTIME_BASE_URL:-http://agent-compose:7410}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /etc/localtime:/etc/localtime:ro
       - ${AGENT_COMPOSE_DATA_DIR:-./data}:/data
       - ./.env:/data/work/.env:ro
     working_dir: /data/work

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -938,6 +938,13 @@ Main JavaScript APIs:
 - `scheduler.on(...)`
 - `scheduler.cron(...)`
 
+Cron registration accepts an explicit IANA timezone. When it is omitted, the
+scheduler uses the daemon process's local timezone (`TZ`, then
+`/etc/localtime`); persisted fire timestamps remain UTC. Declarative YAML cron
+triggers expose the same optional `timezone` override. The deployment image
+contains `tzdata`, and the base Docker Compose topology mounts the Linux host's
+`/etc/localtime` read-only.
+
 `scheduler.agent` and `scheduler.llm` support `outputSchema` / `schema`. Passing
 a `scheduler.z` schema generates JSON Schema and validates the returned value
 locally. Passing plain JSON Schema performs JSON parsing.

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -786,6 +786,7 @@ scheduler:
   triggers:
     - name: nightly
       cron: "0 2 * * *"
+      timezone: Asia/Shanghai
       prompt: Run the nightly review.
     - name: heartbeat
       interval: 30m
@@ -803,12 +804,15 @@ scheduler:
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
 | `name` | string | No | Readable stable name. Non-empty names must be unique within the scheduler. If omitted, identity also incorporates list position. |
-| `cron` | string | One of four | Five-field cron expression with optional seconds and robfig/cron descriptors. Declarative cron triggers use UTC. |
+| `cron` | string | One of four | Five-field cron expression with optional seconds and robfig/cron descriptors. By default it uses the daemon's local timezone. |
+| `timezone` | string | No | IANA timezone for a `cron` trigger, such as `UTC` or `Asia/Shanghai`. `Local` and an omitted value use the daemon's local timezone. It is invalid for other trigger kinds. |
 | `interval` | duration | One of four | Positive period such as `30s`, `5m`, or `2h`; registration precision is at least 1 ms. |
 | `timeout` | duration | One of four | Positive one-shot delay such as `15s`; registration precision is at least 1 ms. |
 | `event.topic` | string | One of four | The nested `topic` is the non-empty subscribed topic, for example `webhook.github.push`. |
 | `prompt` | string | No | Prompt sent to the agent. An empty prompt becomes `Run agent <name>.` |
 | `sandbox_policy` | string | No | `sticky` or `new` for this generated agent call. If omitted, no call-level override is emitted. |
+
+The daemon local timezone comes from `TZ` when it is set, otherwise from the operating system's `/etc/localtime`. The shipped Docker Compose deployment mounts the host's `/etc/localtime` read-only. Set `TZ` in `.env` only when the daemon should intentionally differ from the host. Restart the daemon after changing its timezone. Stored timestamps remain UTC.
 
 #### Inline script
 

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -791,6 +791,7 @@ scheduler:
   triggers:
     - name: nightly
       cron: "0 2 * * *"
+      timezone: Asia/Shanghai
       prompt: Run the nightly review.
     - name: heartbeat
       interval: 30m
@@ -808,12 +809,15 @@ scheduler:
 | 字段 | 类型 | 必填 | 作用 |
 | --- | --- | --- | --- |
 | `name` | string | 否 | 可读的稳定名称；同一 Scheduler 中非空名称不可重复。省略时 ID 会结合列表位置稳定派生。 |
-| `cron` | string | 四选一 | 5 字段 cron，支持可选秒字段和 robfig/cron descriptor。声明式 cron trigger 使用 UTC。 |
+| `cron` | string | 四选一 | 5 字段 cron，支持可选秒字段和 robfig/cron descriptor。默认使用 daemon 的本地时区。 |
+| `timezone` | string | 否 | `cron` trigger 使用的 IANA 时区，例如 `UTC` 或 `Asia/Shanghai`。`Local` 或省略该字段时使用 daemon 本地时区；其他 trigger 类型不能使用。 |
 | `interval` | duration | 四选一 | 周期，例如 `30s`、`5m`、`2h`；必须大于 0，实际注册精度至少 1ms。 |
 | `timeout` | duration | 四选一 | 一次性延迟，例如 `15s`；必须大于 0，实际注册精度至少 1ms。 |
 | `event.topic` | string | 四选一 | 内层 `topic` 是订阅的非空 topic，可使用如 `webhook.github.push`。 |
 | `prompt` | string | 否 | 触发后发送给 Agent 的 prompt；空值默认为 `Run agent <name>.`。 |
 | `sandbox_policy` | string | 否 | 本次 Agent 调用使用 `sticky` 或 `new`；省略时不在生成的调用中显式覆盖。 |
+
+Daemon 本地时区优先取 `TZ`，未设置时取操作系统的 `/etc/localtime`。项目提供的 Docker Compose 会以只读方式挂载宿主机 `/etc/localtime`；仅当 daemon 需要有意使用不同于宿主机的时区时，才在 `.env` 中设置 `TZ`。修改时区后需要重启 daemon。持久化时间戳仍统一使用 UTC。
 
 #### 内联脚本
 

--- a/examples/scheduler-script/README.md
+++ b/examples/scheduler-script/README.md
@@ -107,6 +107,8 @@ scheduler.schedule(triggerId, expression, callback, options);
 
 也可以用 `{ tz: "Asia/Shanghai" }`。全局 `setInterval`、`setTimeout`、`clearInterval`、`clearTimeout` 以及 `scheduler.setInterval`、`scheduler.setTimeout` 仍然可用，主要用于兼容 JavaScript timer 写法。
 
+省略 `timezone` 时，cron 使用 daemon 的本地时区（`TZ` 优先，否则使用 `/etc/localtime`）；显式使用 `UTC` 可固定为 UTC 调度。
+
 ## 运行入口和载荷
 
 手动运行时，agent-compose 会优先调用全局 `main(payload)`。如果没有 `main()` 且脚本只注册了一个触发器，则会调用这个触发器的 callback；如果有多个触发器，必须显式选择触发器或定义 `main()`。

--- a/pkg/agentcompose/api/project.go
+++ b/pkg/agentcompose/api/project.go
@@ -538,6 +538,7 @@ func TriggerSpecToProto(trigger compose.NormalizedTriggerSpec) *agentcomposev2.T
 		Kind:          triggerKindToProto(trigger.Kind),
 		Prompt:        trigger.Prompt,
 		SandboxPolicy: schedulerSandboxPolicyToProto(trigger.SandboxPolicy),
+		Timezone:      trigger.Timezone,
 	}
 	switch trigger.Kind {
 	case "cron":
@@ -976,6 +977,9 @@ func TriggerYAMLShape(trigger *agentcomposev2.TriggerSpec) map[string]any {
 	}
 	if trigger.GetPrompt() != "" {
 		raw["prompt"] = trigger.GetPrompt()
+	}
+	if strings.TrimSpace(trigger.GetTimezone()) != "" {
+		raw["timezone"] = trigger.GetTimezone()
 	}
 	if policy := schedulerSandboxPolicyText(trigger.GetSandboxPolicy()); policy != "" {
 		raw["sandbox_policy"] = policy

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -331,6 +331,7 @@ agents:
       triggers:
         - name: hourly
           cron: "0 * * * *"
+          timezone: Asia/Shanghai
           prompt: Review hourly changes
         - name: frequent
           interval: 5m
@@ -361,6 +362,9 @@ agents:
 	if got := wireSpec.GetAgents()[0].GetScheduler().GetConcurrencyPolicy(); got != agentcomposev2.SchedulerConcurrencyPolicy_SCHEDULER_CONCURRENCY_POLICY_PARALLEL {
 		t.Fatalf("protobuf concurrency policy = %q, want parallel", got)
 	}
+	if got := wireSpec.GetAgents()[0].GetScheduler().GetTriggers()[0].GetTimezone(); got != "Asia/Shanghai" {
+		t.Fatalf("protobuf cron timezone = %q", got)
+	}
 	shape, issues := ProjectSpecYAMLShape(wireSpec)
 	if len(issues) != 0 {
 		t.Fatalf("convert protobuf project to YAML shape: %#v", issues)
@@ -369,8 +373,8 @@ agents:
 	if err != nil {
 		t.Fatalf("marshal reconstructed YAML: %v", err)
 	}
-	if !strings.Contains(string(data), "concurrency_policy: parallel") {
-		t.Fatalf("reconstructed YAML lost concurrency policy:\n%s", data)
+	if !strings.Contains(string(data), "concurrency_policy: parallel") || !strings.Contains(string(data), "timezone: Asia/Shanghai") {
+		t.Fatalf("reconstructed YAML lost scheduler fields:\n%s", data)
 	}
 
 	reparsed, err := compose.Parse(data)
@@ -392,6 +396,9 @@ agents:
 		if scheduler.Triggers[index].Kind != kind {
 			t.Fatalf("round-tripped trigger %d = %#v, want kind %q", index, scheduler.Triggers[index], kind)
 		}
+	}
+	if scheduler.Triggers[0].Timezone != "Asia/Shanghai" {
+		t.Fatalf("round-tripped cron timezone = %q", scheduler.Triggers[0].Timezone)
 	}
 }
 

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -161,6 +161,7 @@ type NormalizedTriggerSpec struct {
 	Name          string            `yaml:"name,omitempty" json:"name,omitempty"`
 	Kind          string            `yaml:"kind" json:"kind"`
 	Cron          string            `yaml:"cron,omitempty" json:"cron,omitempty"`
+	Timezone      string            `yaml:"timezone,omitempty" json:"timezone,omitempty"`
 	Interval      string            `yaml:"interval,omitempty" json:"interval,omitempty"`
 	Timeout       string            `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Event         *EventTriggerSpec `yaml:"event,omitempty" json:"event,omitempty"`
@@ -1268,17 +1269,35 @@ func normalizeTriggerSpec(path string, trigger TriggerSpec) (NormalizedTriggerSp
 		if _, err := composeCronParser.Parse(normalized.Cron); err != nil {
 			return NormalizedTriggerSpec{}, &ValidationError{Path: path + ".cron", Message: fmt.Sprintf("invalid cron expression: %v", err)}
 		}
+		normalized.Timezone = strings.TrimSpace(trigger.Timezone)
+		if strings.EqualFold(normalized.Timezone, "local") {
+			normalized.Timezone = "Local"
+		}
+		if normalized.Timezone != "" {
+			if _, err := time.LoadLocation(normalized.Timezone); err != nil {
+				return NormalizedTriggerSpec{}, &ValidationError{Path: path + ".timezone", Message: fmt.Sprintf("invalid timezone: %v", err)}
+			}
+		}
 	case "interval":
+		if strings.TrimSpace(trigger.Timezone) != "" {
+			return NormalizedTriggerSpec{}, &ValidationError{Path: path + ".timezone", Message: "timezone is only supported for cron triggers"}
+		}
 		normalized.Interval = strings.TrimSpace(trigger.Interval)
 		if err := validatePositiveDuration(path+".interval", normalized.Interval); err != nil {
 			return NormalizedTriggerSpec{}, err
 		}
 	case "timeout":
+		if strings.TrimSpace(trigger.Timezone) != "" {
+			return NormalizedTriggerSpec{}, &ValidationError{Path: path + ".timezone", Message: "timezone is only supported for cron triggers"}
+		}
 		normalized.Timeout = strings.TrimSpace(trigger.Timeout)
 		if err := validatePositiveDuration(path+".timeout", normalized.Timeout); err != nil {
 			return NormalizedTriggerSpec{}, err
 		}
 	case "event":
+		if strings.TrimSpace(trigger.Timezone) != "" {
+			return NormalizedTriggerSpec{}, &ValidationError{Path: path + ".timezone", Message: "timezone is only supported for cron triggers"}
+		}
 		if trigger.Event == nil {
 			return NormalizedTriggerSpec{}, &ValidationError{Path: path + ".event.topic", Message: "event trigger topic is required"}
 		}

--- a/pkg/compose/normalize_test.go
+++ b/pkg/compose/normalize_test.go
@@ -741,6 +741,60 @@ agents:
 	}
 }
 
+func TestNormalizeCronTimezone(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: cron-timezone
+agents:
+  reviewer:
+    scheduler:
+      triggers:
+        - cron: "0 9 * * *"
+          timezone: asia/shanghai
+`)
+
+	_, err := Normalize(spec, NormalizeOptions{})
+	if err == nil || !strings.Contains(err.Error(), "triggers[0].timezone") {
+		t.Fatalf("Normalize invalid timezone error = %v", err)
+	}
+
+	spec = mustParseCompose(t, `
+name: cron-timezone
+agents:
+  reviewer:
+    scheduler:
+      triggers:
+        - cron: "0 9 * * *"
+          timezone: local
+        - cron: "0 1 * * *"
+          timezone: Asia/Shanghai
+`)
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	triggers := normalized.Agents[0].Scheduler.Triggers
+	if triggers[0].Timezone != "Local" || triggers[1].Timezone != "Asia/Shanghai" {
+		t.Fatalf("normalized cron timezones = %q, %q", triggers[0].Timezone, triggers[1].Timezone)
+	}
+}
+
+func TestNormalizeRejectsTimezoneOnNonCronTrigger(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: interval-timezone
+agents:
+  reviewer:
+    scheduler:
+      triggers:
+        - interval: 1m
+          timezone: UTC
+`)
+
+	_, err := Normalize(spec, NormalizeOptions{})
+	if err == nil || !strings.Contains(err.Error(), "triggers[0].timezone") || !strings.Contains(err.Error(), "only supported for cron") {
+		t.Fatalf("Normalize non-cron timezone error = %v", err)
+	}
+}
+
 func TestNormalizePreservesSchedulerScript(t *testing.T) {
 	spec := mustParseCompose(t, `
 name: inline-script

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -196,6 +196,7 @@ func (s ScriptSource) MarshalYAML() (any, error) {
 type TriggerSpec struct {
 	Name          string            `yaml:"name,omitempty" json:"name,omitempty"`
 	Cron          string            `yaml:"cron,omitempty" json:"cron,omitempty"`
+	Timezone      string            `yaml:"timezone,omitempty" json:"timezone,omitempty"`
 	Interval      string            `yaml:"interval,omitempty" json:"interval,omitempty"`
 	Timeout       string            `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Event         *EventTriggerSpec `yaml:"event,omitempty" json:"event,omitempty"`
@@ -741,6 +742,7 @@ func validateTrigger(node *yaml.Node, path string) error {
 	return validateMapping(node, path, map[string]nodeValidator{
 		"name":           validateScalar,
 		"cron":           validateScalar,
+		"timezone":       validateScalar,
 		"interval":       validateScalar,
 		"timeout":        validateScalar,
 		"event":          validateEventTrigger,

--- a/pkg/projects/scheduler.go
+++ b/pkg/projects/scheduler.go
@@ -56,16 +56,20 @@ func ProjectSchedulerTriggerAndRegistration(id, agentName string, trigger compos
 	callback := fmt.Sprintf("async function(event) { return %s; }", agentCall)
 	switch trigger.Kind {
 	case "cron":
-		specJSON, err := schedulers.SchedulerCronSpecJSON(trigger.Cron, "")
+		specJSON, err := schedulers.SchedulerCronSpecJSON(trigger.Cron, trigger.Timezone)
 		if err != nil {
 			return domain.SchedulerTrigger{}, "", err
+		}
+		options := ""
+		if trigger.Timezone != "" {
+			options = fmt.Sprintf(", { timezone: %s }", JSStringLiteral(trigger.Timezone))
 		}
 		return domain.SchedulerTrigger{
 			ID:       id,
 			Kind:     domain.SchedulerTriggerKindCron,
 			Enabled:  true,
 			SpecJSON: specJSON,
-		}, fmt.Sprintf("scheduler.cron(%s, %s, %s);\n", JSStringLiteral(id), JSStringLiteral(trigger.Cron), callback), nil
+		}, fmt.Sprintf("scheduler.cron(%s, %s, %s%s);\n", JSStringLiteral(id), JSStringLiteral(trigger.Cron), callback, options), nil
 	case "interval":
 		interval, err := time.ParseDuration(trigger.Interval)
 		if err != nil {

--- a/pkg/projects/scheduler_coverage_test.go
+++ b/pkg/projects/scheduler_coverage_test.go
@@ -14,6 +14,7 @@ func TestManagedLoaderTriggerRegistrationCoverage(t *testing.T) {
 	triggers, script, err := ProjectSchedulerTriggersAndScript("project-1", "worker", "nightly", &compose.NormalizedSchedulerSpec{
 		Triggers: []compose.NormalizedTriggerSpec{
 			{Name: "cron-main", Kind: "cron", Cron: "*/5 * * * *", Prompt: "Run cron"},
+			{Name: "cron-shanghai", Kind: "cron", Cron: "0 9 * * *", Timezone: "Asia/Shanghai", Prompt: "Run local cron"},
 			{Name: "interval-main", Kind: "interval", Interval: "2s"},
 			{Name: "timeout-main", Kind: "timeout", Timeout: "3s"},
 			{Name: "event-main", Kind: "event", Event: &compose.EventTriggerSpec{Topic: "webhook.github.push"}, Prompt: `quote "prompt"`},
@@ -22,11 +23,14 @@ func TestManagedLoaderTriggerRegistrationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProjectSchedulerTriggersAndScript returned error: %v", err)
 	}
-	if len(triggers) != 4 {
+	if len(triggers) != 5 {
 		t.Fatalf("triggers = %#v", triggers)
 	}
-	if triggers[0].Kind != domain.SchedulerTriggerKindCron || triggers[1].IntervalMs != 2000 || triggers[2].Kind != domain.SchedulerTriggerKindTimeout || triggers[3].Topic != "webhook.github.push" {
+	if triggers[0].Kind != domain.SchedulerTriggerKindCron || !strings.Contains(triggers[0].SpecJSON, `"timezone":"Local"`) || !strings.Contains(triggers[1].SpecJSON, `"timezone":"Asia/Shanghai"`) || triggers[2].IntervalMs != 2000 || triggers[3].Kind != domain.SchedulerTriggerKindTimeout || triggers[4].Topic != "webhook.github.push" {
 		t.Fatalf("trigger shapes = %#v", triggers)
+	}
+	if !strings.Contains(script, `{ timezone: "Asia/Shanghai" }`) {
+		t.Fatalf("script missing explicit cron timezone: %s", script)
 	}
 	for _, want := range []string{"scheduler.cron(", "scheduler.interval(", "scheduler.timeout(", "scheduler.on(", `quote \"prompt\"`} {
 		if !strings.Contains(script, want) {

--- a/pkg/schedulers/controller.go
+++ b/pkg/schedulers/controller.go
@@ -27,6 +27,7 @@ type ControllerStore interface {
 	ListSchedulers(ctx context.Context) ([]domain.Scheduler, error)
 	GetScheduler(ctx context.Context, schedulerID string) (domain.Scheduler, error)
 	ReplaceSchedulerTriggers(ctx context.Context, schedulerID string, triggers []domain.SchedulerTrigger) ([]domain.SchedulerTrigger, error)
+	SetSchedulerTriggerNextFireAt(ctx context.Context, schedulerID, triggerID string, nextFireAt time.Time) error
 	SetSchedulerEnabled(ctx context.Context, schedulerID string, enabled bool) error
 	SetSchedulerTriggerEnabled(ctx context.Context, schedulerID, triggerID string, enabled bool) error
 	AddSchedulerEvent(ctx context.Context, event domain.SchedulerEvent) error
@@ -217,6 +218,9 @@ func (c *Controller) ScheduleLoop() {
 func (c *Controller) Refresh(ctx context.Context) error {
 	items, err := c.deps.Store.ListSchedulers(ctx)
 	if err != nil {
+		return err
+	}
+	if err := c.initializeCronSchedules(ctx, items); err != nil {
 		return err
 	}
 	next := make(map[string]domain.Scheduler, len(items))

--- a/pkg/schedulers/controller_coverage_test.go
+++ b/pkg/schedulers/controller_coverage_test.go
@@ -174,11 +174,12 @@ func (controllerTestEngine) Execute(context.Context, SchedulerExecutionRequest, 
 }
 
 type controllerTestStore struct {
-	schedulers map[string]domain.Scheduler
-	runs       []domain.SchedulerRunSummary
-	events     []domain.SchedulerEvent
-	deliveries []domain.EventDelivery
-	replaceErr error
+	schedulers  map[string]domain.Scheduler
+	runs        []domain.SchedulerRunSummary
+	events      []domain.SchedulerEvent
+	deliveries  []domain.EventDelivery
+	replaceErr  error
+	nextFireErr error
 }
 
 func newControllerTestStore() *controllerTestStore {
@@ -236,6 +237,20 @@ func (s *controllerTestStore) SetSchedulerTriggerEnabled(_ context.Context, sche
 	for i := range scheduler.Triggers {
 		if scheduler.Triggers[i].ID == triggerID {
 			scheduler.Triggers[i].Enabled = enabled
+		}
+	}
+	s.schedulers[schedulerID] = scheduler
+	return nil
+}
+
+func (s *controllerTestStore) SetSchedulerTriggerNextFireAt(_ context.Context, schedulerID, triggerID string, nextFireAt time.Time) error {
+	if s.nextFireErr != nil {
+		return s.nextFireErr
+	}
+	scheduler := s.schedulers[schedulerID]
+	for i := range scheduler.Triggers {
+		if scheduler.Triggers[i].ID == triggerID {
+			scheduler.Triggers[i].NextFireAt = nextFireAt
 		}
 	}
 	s.schedulers[schedulerID] = scheduler

--- a/pkg/schedulers/cron_schedule_initialization.go
+++ b/pkg/schedulers/cron_schedule_initialization.go
@@ -1,0 +1,33 @@
+package schedulers
+
+import (
+	"context"
+	"fmt"
+
+	domain "agent-compose/pkg/model"
+)
+
+func (c *Controller) initializeCronSchedules(ctx context.Context, items []domain.Scheduler) error {
+	now := c.deps.Now().UTC()
+	for schedulerIndex := range items {
+		scheduler := &items[schedulerIndex]
+		if !scheduler.Summary.Enabled {
+			continue
+		}
+		for triggerIndex := range scheduler.Triggers {
+			trigger := &scheduler.Triggers[triggerIndex]
+			if !trigger.Enabled || trigger.Kind != domain.SchedulerTriggerKindCron || !trigger.NextFireAt.IsZero() {
+				continue
+			}
+			nextFireAt, err := SchedulerTriggerNextFireAt(now, *trigger, false)
+			if err != nil {
+				return fmt.Errorf("initialize loader cron trigger %s/%s: %w", scheduler.Summary.ID, trigger.ID, err)
+			}
+			if err := c.deps.Store.SetSchedulerTriggerNextFireAt(ctx, scheduler.Summary.ID, trigger.ID, nextFireAt); err != nil {
+				return fmt.Errorf("persist loader cron trigger schedule %s/%s: %w", scheduler.Summary.ID, trigger.ID, err)
+			}
+			trigger.NextFireAt = nextFireAt
+		}
+	}
+	return nil
+}

--- a/pkg/schedulers/cron_schedule_initialization_test.go
+++ b/pkg/schedulers/cron_schedule_initialization_test.go
@@ -1,0 +1,68 @@
+package schedulers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestControllerRefreshInitializesCronWithoutNextFireTime(t *testing.T) {
+	now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	cronSpec, err := SchedulerCronSpecJSON("0 9 * * *", "Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newControllerTestStore()
+	store.schedulers["scheduler-1"] = domain.Scheduler{
+		Summary: domain.SchedulerSummary{ID: "scheduler-1", Enabled: true},
+		Triggers: []domain.SchedulerTrigger{
+			{ID: "cron", Kind: domain.SchedulerTriggerKindCron, Enabled: true, SpecJSON: cronSpec},
+			{ID: "interval", Kind: domain.SchedulerTriggerKindInterval, Enabled: true, IntervalMs: 1000},
+			{ID: "disabled", Kind: domain.SchedulerTriggerKindCron, Enabled: false, SpecJSON: cronSpec},
+		},
+	}
+	controller := NewController(ControllerDependencies{Store: store, Now: func() time.Time { return now }})
+
+	if err := controller.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	got := controller.CachedSchedulersMap()["scheduler-1"].Triggers
+	want := time.Date(2026, 6, 2, 1, 0, 0, 0, time.UTC)
+	if !got[0].NextFireAt.Equal(want) {
+		t.Fatalf("initialized cron next fire = %s, want %s", got[0].NextFireAt, want)
+	}
+	if !got[1].NextFireAt.IsZero() || !got[2].NextFireAt.IsZero() {
+		t.Fatalf("non-target next fire times = %s/%s", got[1].NextFireAt, got[2].NextFireAt)
+	}
+}
+
+func TestControllerRefreshReportsCronInitializationFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		specJSON  string
+		storeErr  error
+		wantError string
+	}{
+		{name: "invalid schedule", specJSON: `{"expr":"bad cron","timezone":"UTC"}`, wantError: "initialize loader cron trigger"},
+		{name: "persist schedule", specJSON: `{"expr":"0 9 * * *","timezone":"UTC"}`, storeErr: errors.New("write failed"), wantError: "persist loader cron trigger schedule"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newControllerTestStore()
+			store.nextFireErr = tt.storeErr
+			store.schedulers["scheduler-1"] = domain.Scheduler{
+				Summary:  domain.SchedulerSummary{ID: "scheduler-1", Enabled: true},
+				Triggers: []domain.SchedulerTrigger{{ID: "cron", Kind: domain.SchedulerTriggerKindCron, Enabled: true, SpecJSON: tt.specJSON}},
+			}
+			controller := NewController(ControllerDependencies{Store: store})
+			err := controller.Refresh(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Refresh error = %v, want %q", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/schedulers/engine_helpers.go
+++ b/pkg/schedulers/engine_helpers.go
@@ -10,7 +10,7 @@ import (
 	cronlib "github.com/robfig/cron/v3"
 )
 
-const schedulerDefaultCronTimezone = "UTC"
+const schedulerDefaultCronTimezone = "Local"
 
 type schedulerCronSpec struct {
 	Kind     string `json:"kind,omitempty"`

--- a/pkg/schedulers/schedule_test.go
+++ b/pkg/schedulers/schedule_test.go
@@ -3,10 +3,40 @@ package schedulers_test
 import (
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/schedulers"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestCronDefaultsToProcessLocalTimezone(t *testing.T) {
+	if os.Getenv("AGENT_COMPOSE_CRON_LOCAL_TEST") == "1" {
+		now := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+		specJSON, err := schedulers.SchedulerCronSpecJSON("0 9 * * *", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		next, err := schedulers.SchedulerTriggerNextFireAt(now, domain.SchedulerTrigger{
+			Kind:     domain.SchedulerTriggerKindCron,
+			SpecJSON: specJSON,
+		}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := time.Date(2026, 6, 2, 1, 0, 0, 0, time.UTC)
+		if !next.Equal(want) {
+			t.Fatalf("next local cron fire = %s, want %s", next, want)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCronDefaultsToProcessLocalTimezone$")
+	cmd.Env = append(os.Environ(), "AGENT_COMPOSE_CRON_LOCAL_TEST=1", "TZ=Asia/Shanghai")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("local timezone subprocess failed: %v\n%s", err, output)
+	}
+}
 
 func TestLoaderScheduleModelWorkflows(t *testing.T) {
 	testLoaderScheduleModelWorkflows(t)
@@ -59,8 +89,12 @@ func testLoaderScheduleModelWorkflows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("normalizeSchedulerCronSpecJSON returned error: %v", err)
 	}
-	if !strings.Contains(normalized, `"timezone":"UTC"`) {
+	if !strings.Contains(normalized, `"timezone":"Local"`) {
 		t.Fatalf("normalized cron spec = %q", normalized)
+	}
+	explicitUTC, err := schedulers.SchedulerCronSpecJSON("0 9 * * *", "UTC")
+	if err != nil || !strings.Contains(explicitUTC, `"timezone":"UTC"`) {
+		t.Fatalf("explicit UTC cron spec = %q, err=%v", explicitUTC, err)
 	}
 	if _, err := schedulers.NormalizeSchedulerCronSpecJSON(`{"expr":""}`); err == nil {
 		t.Fatalf("empty cron expression returned nil error")

--- a/pkg/storage/configstore/scheduler_store.go
+++ b/pkg/storage/configstore/scheduler_store.go
@@ -322,6 +322,23 @@ func (s *schedulerStore) MarkSchedulerTriggerFired(ctx context.Context, schedule
 	return nil
 }
 
+func (s *schedulerStore) SetSchedulerTriggerNextFireAt(ctx context.Context, schedulerID, triggerID string, nextFireAt time.Time) error {
+	schedulerID = strings.TrimSpace(schedulerID)
+	triggerID = strings.TrimSpace(triggerID)
+	if schedulerID == "" || triggerID == "" {
+		return fmt.Errorf("loader trigger id is required")
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE scheduler_trigger SET next_fire_at = ? WHERE scheduler_id = ? AND trigger_id = ?`, domain.NonZeroTimeUnixMilli(nextFireAt), schedulerID, triggerID)
+	if err != nil {
+		return fmt.Errorf("update loader trigger next fire time: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		id := schedulerID + "/" + triggerID
+		return domain.ResourceError(domain.ErrNotFound, "loader trigger", id, fmt.Sprintf("loader trigger %s not found", id), nil)
+	}
+	return nil
+}
+
 func (s *schedulerStore) CreateSchedulerRun(ctx context.Context, run domain.SchedulerRunSummary) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO scheduler_run(
         scheduler_id, run_id, trigger_id, trigger_kind, trigger_source, status, started_at, completed_at, duration_ms, error, result_json, payload_json, source_script_sha256, artifacts_dir

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -538,6 +538,15 @@ func testConfigStoreCRUDCoverageWorkflows(t *testing.T) {
 	if err := store.MarkSchedulerTriggerFired(ctx, loader.Summary.ID, "interval", time.Now().UTC(), time.Now().UTC().Add(time.Hour)); err != nil {
 		t.Fatalf("MarkSchedulerTriggerFired returned error: %v", err)
 	}
+	if err := store.SetSchedulerTriggerNextFireAt(ctx, loader.Summary.ID, "interval", time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("SetSchedulerTriggerNextFireAt returned error: %v", err)
+	}
+	if err := store.SetSchedulerTriggerNextFireAt(ctx, loader.Summary.ID, "missing", time.Now().UTC()); err == nil {
+		t.Fatal("SetSchedulerTriggerNextFireAt missing trigger returned nil error")
+	}
+	if err := store.SetSchedulerTriggerNextFireAt(ctx, "", "interval", time.Now().UTC()); err == nil {
+		t.Fatal("SetSchedulerTriggerNextFireAt empty scheduler returned nil error")
+	}
 	if err := store.UpdateSchedulerLastError(ctx, loader.Summary.ID, "last error"); err != nil {
 		t.Fatalf("UpdateSchedulerLastError returned error: %v", err)
 	}

--- a/pkg/storage/sqlite/migrations/000008_cron_local_timezone.sql
+++ b/pkg/storage/sqlite/migrations/000008_cron_local_timezone.sql
@@ -1,0 +1,15 @@
+-- Declarative cron triggers historically materialized the implicit timezone as
+-- UTC. Their authoring spec could not explicitly select UTC, so these rows can
+-- safely adopt the new daemon-local default. Script schedulers are excluded
+-- because their historical UTC value may have been explicit.
+UPDATE scheduler_trigger
+SET spec_json = json_set(spec_json, '$.timezone', 'Local'),
+    next_fire_at = 0
+WHERE kind = 'cron'
+  AND json_extract(spec_json, '$.timezone') = 'UTC'
+  AND scheduler_id IN (
+      SELECT id
+      FROM project_scheduler
+      WHERE json_type(spec_json, '$.triggers') = 'array'
+        AND json_array_length(spec_json, '$.triggers') > 0
+  );

--- a/pkg/storage/sqlite/v2_migration_design_test.go
+++ b/pkg/storage/sqlite/v2_migration_design_test.go
@@ -97,8 +97,8 @@ func TestV2MigrationDesignPreservesManagedHistory(t *testing.T) {
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_migrations`).Scan(&historyCount); err != nil {
 		t.Fatalf("count v2 migration history: %v", err)
 	}
-	if historyCount != 7 {
-		t.Fatalf("v2 migration history count = %d, want 7", historyCount)
+	if historyCount != 8 {
+		t.Fatalf("v2 migration history count = %d, want 8", historyCount)
 	}
 }
 
@@ -345,14 +345,56 @@ func TestHistoricalMigrationChecksumsRemainImmutable(t *testing.T) {
 	}
 }
 
+func TestCronLocalTimezoneMigrationOnlyUpdatesDeclarativeSchedulers(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		schedulerSpec string
+		wantTimezone  string
+		wantNextFire  int64
+	}{
+		{name: "declarative", schedulerSpec: `{"enabled":true,"triggers":[{"kind":"cron","cron":"0 9 * * *"}]}`, wantTimezone: "Local", wantNextFire: 0},
+		{name: "script", schedulerSpec: `{"enabled":true,"script":"scheduler.cron('0 9 * * *', run, { timezone: 'UTC' })"}`, wantTimezone: "UTC", wantNextFire: 2000},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newMemoryDB(t)
+			chain := loadV2MigrationDesignChain(t)
+			if err := applyMigrationSet(ctx, db, chain[:4]); err != nil {
+				t.Fatalf("apply v4 prefix: %v", err)
+			}
+			seedManagedV4Fixture(t, db)
+			if err := applyMigrationSet(ctx, db, chain[:7]); err != nil {
+				t.Fatalf("apply v7 prefix: %v", err)
+			}
+			if _, err := db.ExecContext(ctx, `UPDATE project_scheduler SET spec_json = ? WHERE id = 'scheduler-1'`, tt.schedulerSpec); err != nil {
+				t.Fatalf("set scheduler spec: %v", err)
+			}
+			if _, err := db.ExecContext(ctx, `UPDATE scheduler_trigger SET spec_json = '{"kind":"cron","expr":"0 9 * * *","timezone":"UTC"}', next_fire_at = 2000 WHERE scheduler_id = 'scheduler-1'`); err != nil {
+				t.Fatalf("set cron trigger: %v", err)
+			}
+			if err := applyMigrationSet(ctx, db, chain); err != nil {
+				t.Fatalf("apply local timezone migration: %v", err)
+			}
+			var specJSON string
+			var nextFire int64
+			if err := db.QueryRowContext(ctx, `SELECT spec_json, next_fire_at FROM scheduler_trigger WHERE scheduler_id = 'scheduler-1'`).Scan(&specJSON, &nextFire); err != nil {
+				t.Fatalf("read migrated cron trigger: %v", err)
+			}
+			if !strings.Contains(specJSON, `"timezone":"`+tt.wantTimezone+`"`) || nextFire != tt.wantNextFire {
+				t.Fatalf("migrated cron trigger = %s/%d, want timezone %s and next fire %d", specJSON, nextFire, tt.wantTimezone, tt.wantNextFire)
+			}
+		})
+	}
+}
+
 func loadV2MigrationDesignChain(t *testing.T) []migration {
 	t.Helper()
 	chain, err := loadMigrations(embeddedMigrations)
 	if err != nil {
 		t.Fatalf("load migrations: %v", err)
 	}
-	if len(chain) != 7 {
-		t.Fatalf("migration count = %d, want 7", len(chain))
+	if len(chain) != 8 {
+		t.Fatalf("migration count = %d, want 8", len(chain))
 	}
 	return chain
 }

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -946,6 +946,8 @@ message TriggerSpec {
   EventTriggerSpec event = 6;
   string prompt = 7;
   SchedulerSandboxPolicy sandbox_policy = 8;
+  // Optional IANA timezone. Unset cron triggers use the daemon's local timezone.
+  string timezone = 9;
 }
 
 message EventTriggerSpec {


### PR DESCRIPTION
## Summary

- make cron triggers without an explicit timezone follow the daemon local timezone while preserving explicit UTC and IANA timezone overrides
- add the YAML timezone field, protobuf transport mapping, persisted-trigger migration, and startup schedule repair
- inherit the Linux host timezone through the base Docker Compose topology and remove the image-level Asia/Shanghai default
- update English and Chinese documentation for timezone precedence and deployment behavior

## Testing

- task lint
- task build
- task test
- task test:deploy
- task docs:build

Coverage from task test:
- Unit: 74.90%
- Integration: 60.78%
- E2E: 60.23%
- Combined: 79.04%

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.