### PR TITLE
fix(cli): make RPC timeout configurable

### DIFF
--- a/cmd/agent-compose/cli_client.go
+++ b/cmd/agent-compose/cli_client.go
@@ -4,6 +4,7 @@ import (
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"os"
 	"strings"
+	"time"
 )
 
 type cliClientConfig struct {
@@ -13,44 +14,45 @@ type cliClientConfig struct {
 	SourceValue   string
 	UseUnixSocket bool
 	AuthToken     string
+	Timeout       time.Duration
 }
 
 type cliServiceClients struct {
-	project       agentcomposev2connect.ProjectServiceClient
-	projectStream agentcomposev2connect.ProjectServiceClient
-	run           agentcomposev2connect.RunServiceClient
-	runStream     agentcomposev2connect.RunServiceClient
-	exec          agentcomposev2connect.ExecServiceClient
-	execStream    agentcomposev2connect.ExecServiceClient
-	resource      agentcomposev2connect.ResourceServiceClient
-	image         agentcomposev2connect.ImageServiceClient
-	imageStream   agentcomposev2connect.ImageServiceClient
-	cache         agentcomposev2connect.CacheServiceClient
-	volume        agentcomposev2connect.VolumeServiceClient
-	sandbox       agentcomposev2connect.SandboxServiceClient
+	project  agentcomposev2connect.ProjectServiceClient
+	run      agentcomposev2connect.RunServiceClient
+	exec     agentcomposev2connect.ExecServiceClient
+	resource agentcomposev2connect.ResourceServiceClient
+	image    agentcomposev2connect.ImageServiceClient
+	cache    agentcomposev2connect.CacheServiceClient
+	volume   agentcomposev2connect.VolumeServiceClient
+	sandbox  agentcomposev2connect.SandboxServiceClient
 }
 
 func newCLIServiceClients(cli cliOptions) (cliServiceClients, error) {
-	clientConfig, err := resolveCLIClientConfig(cli.Host)
+	clientConfig, err := resolveCLIServiceClientConfig(cli)
 	if err != nil {
 		return cliServiceClients{}, err
 	}
 	httpClient := newDaemonHTTPClient(clientConfig)
-	streamingHTTPClient := newDaemonStreamingHTTPClient(clientConfig)
 	return cliServiceClients{
-		project:       agentcomposev2connect.NewProjectServiceClient(httpClient, clientConfig.BaseURL),
-		projectStream: agentcomposev2connect.NewProjectServiceClient(streamingHTTPClient, clientConfig.BaseURL),
-		run:           agentcomposev2connect.NewRunServiceClient(httpClient, clientConfig.BaseURL),
-		runStream:     agentcomposev2connect.NewRunServiceClient(streamingHTTPClient, clientConfig.BaseURL),
-		exec:          agentcomposev2connect.NewExecServiceClient(httpClient, clientConfig.BaseURL),
-		execStream:    agentcomposev2connect.NewExecServiceClient(streamingHTTPClient, clientConfig.BaseURL),
-		resource:      agentcomposev2connect.NewResourceServiceClient(httpClient, clientConfig.BaseURL),
-		image:         agentcomposev2connect.NewImageServiceClient(httpClient, clientConfig.BaseURL),
-		imageStream:   agentcomposev2connect.NewImageServiceClient(streamingHTTPClient, clientConfig.BaseURL),
-		cache:         agentcomposev2connect.NewCacheServiceClient(httpClient, clientConfig.BaseURL),
-		volume:        agentcomposev2connect.NewVolumeServiceClient(httpClient, clientConfig.BaseURL),
-		sandbox:       agentcomposev2connect.NewSandboxServiceClient(httpClient, clientConfig.BaseURL),
+		project:  agentcomposev2connect.NewProjectServiceClient(httpClient, clientConfig.BaseURL),
+		run:      agentcomposev2connect.NewRunServiceClient(httpClient, clientConfig.BaseURL),
+		exec:     agentcomposev2connect.NewExecServiceClient(httpClient, clientConfig.BaseURL),
+		resource: agentcomposev2connect.NewResourceServiceClient(httpClient, clientConfig.BaseURL),
+		image:    agentcomposev2connect.NewImageServiceClient(httpClient, clientConfig.BaseURL),
+		cache:    agentcomposev2connect.NewCacheServiceClient(httpClient, clientConfig.BaseURL),
+		volume:   agentcomposev2connect.NewVolumeServiceClient(httpClient, clientConfig.BaseURL),
+		sandbox:  agentcomposev2connect.NewSandboxServiceClient(httpClient, clientConfig.BaseURL),
 	}, nil
+}
+
+func resolveCLIServiceClientConfig(cli cliOptions) (cliClientConfig, error) {
+	clientConfig, err := resolveCLIClientConfig(cli.Host)
+	if err != nil {
+		return cliClientConfig{}, err
+	}
+	clientConfig.Timeout = cli.Timeout
+	return clientConfig, nil
 }
 
 func resolveCLIClientConfig(hostFlag string) (cliClientConfig, error) {

--- a/cmd/agent-compose/cli_client_test.go
+++ b/cmd/agent-compose/cli_client_test.go
@@ -7,7 +7,21 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestResolveCLIServiceClientConfigIncludesTimeout(t *testing.T) {
+	t.Setenv("AGENT_COMPOSE_HOST", "")
+	t.Setenv("AGENT_COMPOSE_SOCKET", filepath.Join(t.TempDir(), "agent-compose.sock"))
+
+	clientConfig, err := resolveCLIServiceClientConfig(cliOptions{Timeout: 45 * time.Second})
+	if err != nil {
+		t.Fatalf("resolveCLIServiceClientConfig returned error: %v", err)
+	}
+	if clientConfig.Timeout != 45*time.Second {
+		t.Fatalf("client timeout = %v, want 45s", clientConfig.Timeout)
+	}
+}
 
 func TestCLIClientConfigPriority(t *testing.T) {
 	testCLIClientConfigPriority(t)

--- a/cmd/agent-compose/cli_daemon.go
+++ b/cmd/agent-compose/cli_daemon.go
@@ -36,7 +36,10 @@ import (
 
 type daemonRunner func(context.Context) error
 
-const daemonStatusTimeout = 5 * time.Second
+const (
+	daemonStatusTimeout = 5 * time.Second
+	daemonDialTimeout   = 30 * time.Second
+)
 
 type DaemonOptions struct {
 	LoadDotEnv      bool
@@ -496,25 +499,13 @@ func formatDaemonStatusTime(timestamp float64, timezone string, timezoneOffset *
 }
 
 func newDaemonHTTPClient(clientConfig cliClientConfig) *http.Client {
-	return newDaemonHTTPClientWithTimeout(clientConfig, 10*time.Minute)
-}
-
-func newDaemonAttachHTTPClient(clientConfig cliClientConfig) *http.Client {
-	return newDaemonHTTPClientWithTimeout(clientConfig, 0)
-}
-
-func newDaemonStreamingHTTPClient(clientConfig cliClientConfig) *http.Client {
-	return newDaemonHTTPClientWithTimeout(clientConfig, 0)
-}
-
-func newDaemonHTTPClientWithTimeout(clientConfig cliClientConfig, timeout time.Duration) *http.Client {
 	roundTripper := http.RoundTripper(newDaemonBaseRoundTripper(clientConfig))
 	if !clientConfig.UseUnixSocket && clientConfig.AuthToken != "" {
 		roundTripper = bearerAuthRoundTripper{token: clientConfig.AuthToken, next: roundTripper}
 	}
 	return &http.Client{
 		Transport: roundTripper,
-		Timeout:   timeout,
+		Timeout:   clientConfig.Timeout,
 	}
 }
 
@@ -523,7 +514,7 @@ func newDaemonBaseRoundTripper(clientConfig cliClientConfig) http.RoundTripper {
 	if clientConfig.UseUnixSocket {
 		socketPath := clientConfig.SocketPath
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			var dialer net.Dialer
+			dialer := net.Dialer{Timeout: daemonDialTimeout, KeepAlive: 30 * time.Second}
 			return dialer.DialContext(ctx, "unix", socketPath)
 		}
 	}
@@ -537,7 +528,7 @@ func newDaemonBaseRoundTripper(clientConfig cliClientConfig) http.RoundTripper {
 				network = "unix"
 				addr = clientConfig.SocketPath
 			}
-			var dialer net.Dialer
+			dialer := net.Dialer{Timeout: daemonDialTimeout, KeepAlive: 30 * time.Second}
 			return dialer.DialContext(ctx, network, addr)
 		},
 	}

--- a/cmd/agent-compose/cli_daemon_http_test.go
+++ b/cmd/agent-compose/cli_daemon_http_test.go
@@ -184,18 +184,47 @@ func TestDaemonHTTPClientAttachAgentRunBidiUsesH2C(t *testing.T) {
 	}
 }
 
-func TestDaemonStreamingAndAttachHTTPClientsHaveNoRequestTimeout(t *testing.T) {
-	regular := newDaemonHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410"})
-	if regular.Timeout != 10*time.Minute {
-		t.Fatalf("regular daemon client timeout = %v, want 10m", regular.Timeout)
+func TestDaemonHTTPClientUsesConfiguredRPCTimeout(t *testing.T) {
+	client := newDaemonHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410"})
+	if client.Timeout != 0 {
+		t.Fatalf("default daemon client timeout = %v, want none", client.Timeout)
 	}
-	attach := newDaemonAttachHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410"})
-	if attach.Timeout != 0 {
-		t.Fatalf("attach daemon client timeout = %v, want none", attach.Timeout)
+
+	client = newDaemonHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410", Timeout: 45 * time.Second})
+	if client.Timeout != 45*time.Second {
+		t.Fatalf("configured daemon client timeout = %v, want 45s", client.Timeout)
 	}
-	streaming := newDaemonStreamingHTTPClient(cliClientConfig{BaseURL: "http://127.0.0.1:7410"})
-	if streaming.Timeout != 0 {
-		t.Fatalf("streaming daemon client timeout = %v, want none", streaming.Timeout)
+}
+
+func TestDaemonHTTPClientConfiguredTimeoutCoversServerStream(t *testing.T) {
+	server := newRunServiceStubServer(t, runServiceStub{
+		runAgentStream: func(ctx context.Context, _ *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
+			if err := stream.Send(&agentcomposev2.StreamAgentRunResponse{EventType: agentcomposev2.StreamAgentRunEventType_STREAM_AGENT_RUN_EVENT_TYPE_STARTED}); err != nil {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+				return nil
+			}
+		},
+	})
+	defer server.Close()
+
+	client := agentcomposev2connect.NewRunServiceClient(newDaemonHTTPClient(cliClientConfig{BaseURL: server.URL, Timeout: 250 * time.Millisecond}), server.URL)
+	stream, err := client.StreamAgentRun(context.Background(), connect.NewRequest(&agentcomposev2.RunAgentRequest{}))
+	if err != nil {
+		t.Fatalf("StreamAgentRun returned error before receiving the first frame: %v", err)
+	}
+	if !stream.Receive() {
+		t.Fatalf("StreamAgentRun did not receive the first frame: %v", stream.Err())
+	}
+	if stream.Receive() {
+		t.Fatal("StreamAgentRun received an unexpected frame after its configured timeout")
+	}
+	if err := stream.Err(); err == nil || connect.CodeOf(err) != connect.CodeDeadlineExceeded {
+		t.Fatalf("StreamAgentRun error = %v, want deadline_exceeded", err)
 	}
 }
 

--- a/cmd/agent-compose/cli_exec_attach.go
+++ b/cmd/agent-compose/cli_exec_attach.go
@@ -726,22 +726,6 @@ func execResultFromAttachResult(result *agentcomposev2.AttachResult) *agentcompo
 	}
 }
 
-func newCLIAttachAgentRunServiceClient(cli cliOptions) (agentcomposev2connect.RunServiceClient, error) {
-	clientConfig, err := resolveCLIClientConfig(cli.Host)
-	if err != nil {
-		return nil, err
-	}
-	return agentcomposev2connect.NewRunServiceClient(newDaemonAttachHTTPClient(clientConfig), clientConfig.BaseURL), nil
-}
-
-func newCLIAttachExecServiceClient(cli cliOptions) (agentcomposev2connect.ExecServiceClient, error) {
-	clientConfig, err := resolveCLIClientConfig(cli.Host)
-	if err != nil {
-		return nil, err
-	}
-	return agentcomposev2connect.NewExecServiceClient(newDaemonAttachHTTPClient(clientConfig), clientConfig.BaseURL), nil
-}
-
 func isAttachHTTP2TransportMismatch(err error) bool {
 	if err == nil {
 		return false

--- a/cmd/agent-compose/cli_exec_command.go
+++ b/cmd/agent-compose/cli_exec_command.go
@@ -117,23 +117,15 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 		return err
 	}
 	if options.Interactive {
-		attachClient, err := newCLIAttachExecServiceClient(cli)
-		if err != nil {
-			return err
-		}
 		if strings.TrimSpace(options.Prompt) != "" {
-			return runComposeExecPromptAttachCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: attachClient}, req, options)
+			return runComposeExecPromptAttachCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec}, req, options)
 		}
-		return runComposeAttachExecCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: attachClient}, req, options)
+		return runComposeAttachExecCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec}, req, options)
 	}
 	if strings.TrimSpace(options.Prompt) != "" {
-		attachClient, err := newCLIAttachExecServiceClient(cli)
-		if err != nil {
-			return err
-		}
-		return runComposeExecPromptOnceCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: attachClient}, req, options, cli.JSON)
+		return runComposeExecPromptOnceCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec}, req, options, cli.JSON)
 	}
-	stream, err := clients.execStream.StreamExec(cmd.Context(), connect.NewRequest(req))
+	stream, err := clients.exec.StreamExec(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return commandExitErrorForConnect(fmt.Errorf("exec project %s: %w", runtimeProject.name(), err))
 	}

--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -14,7 +14,7 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "root",
 			args: []string{"--help"},
-			want: []string{"agent-compose daemon and CLI", "--host", "--file", "--project-name", "--json", "Available Commands"},
+			want: []string{"agent-compose daemon and CLI", "--host", "--file", "--project-name", "--json", "--timeout", "Available Commands"},
 		},
 		{
 			name: "config",

--- a/cmd/agent-compose/cli_image_command.go
+++ b/cmd/agent-compose/cli_image_command.go
@@ -212,7 +212,7 @@ func runComposeProjectBuildCommand(cmd *cobra.Command, cli cliOptions, options c
 	}
 	output := composeProjectImageBuildOutput{Images: make([]composeImageBuildOutput, 0, len(plans))}
 	for _, plan := range plans {
-		item, err := buildImage(cmd.Context(), cmd.OutOrStdout(), cli.JSON, clients.imageStream, plan)
+		item, err := buildImage(cmd.Context(), cmd.OutOrStdout(), cli.JSON, clients.image, plan)
 		if err != nil {
 			return commandExitErrorForConnect(fmt.Errorf("build image %s: %w", firstNonEmptyString(plan.GetTags()...), err))
 		}

--- a/cmd/agent-compose/cli_logs.go
+++ b/cmd/agent-compose/cli_logs.go
@@ -56,7 +56,7 @@ func runComposeLogsCommand(cmd *cobra.Command, cli cliOptions, options composeLo
 	}
 	if strings.TrimSpace(normalizedOptions.RunID) != "" {
 		if !cli.JSON {
-			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.runStream, projectID, &agentcomposev2.RunSummary{RunId: normalizedOptions.RunID}, normalizedOptions)
+			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.run, projectID, &agentcomposev2.RunSummary{RunId: normalizedOptions.RunID}, normalizedOptions)
 		}
 		run, err := getRunDetail(cmd.Context(), clients.run, projectID, normalizedOptions.RunID)
 		if err != nil {
@@ -160,7 +160,7 @@ func followOrPrintProjectLogs(cmd *cobra.Command, cli cliOptions, clients cliSer
 		}
 		sort.SliceStable(runs, func(i, j int) bool { return logRunSummaryLess(runs[i], runs[j]) })
 		for _, summary := range runs {
-			if err := followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.runStream, projectID, summary, options); err != nil {
+			if err := followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.run, projectID, summary, options); err != nil {
 				return err
 			}
 		}

--- a/cmd/agent-compose/cli_logs_locator.go
+++ b/cmd/agent-compose/cli_logs_locator.go
@@ -45,7 +45,7 @@ func runComposeLogsForResourceID(cmd *cobra.Command, cli cliOptions, options com
 	}
 	if options.RunID != "" {
 		if !cli.JSON {
-			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.runStream, projectID, &agentcomposev2.RunSummary{RunId: options.RunID}, options)
+			return followRunLogStream(cmd.Context(), cmd.OutOrStdout(), clients.run, projectID, &agentcomposev2.RunSummary{RunId: options.RunID}, options)
 		}
 		run, err := getRunDetail(cmd.Context(), clients.run, projectID, options.RunID)
 		if err != nil {

--- a/cmd/agent-compose/cli_root.go
+++ b/cmd/agent-compose/cli_root.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
@@ -40,6 +41,12 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			if options.Timeout < 0 {
+				return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("--timeout must not be negative")}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
@@ -55,6 +62,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 	root.PersistentFlags().StringVarP(&options.ComposeFile, "file", "f", "", "Path to agent-compose.yml")
 	root.PersistentFlags().StringVar(&options.ProjectName, "project-name", "", "Select a deployed project by name (not supported by up or project up)")
 	root.PersistentFlags().BoolVar(&options.JSON, "json", false, "Print machine-readable JSON")
+	root.PersistentFlags().DurationVar(&options.Timeout, "timeout", 0, "Maximum duration of each daemon RPC, including streams; 0 disables the timeout")
 
 	commands := []*cobra.Command{
 		newCLIDaemonCommand(runDaemon),
@@ -93,6 +101,7 @@ type cliOptions struct {
 	ComposeFile string
 	ProjectName string
 	JSON        bool
+	Timeout     time.Duration
 }
 
 func hideOptionalFlagNoValueInUsage(cmd *cobra.Command, flagNames ...string) {
@@ -166,6 +175,8 @@ func commandExitErrorForConnect(err error) error {
 		}
 	}
 	switch connect.CodeOf(err) {
+	case connect.CodeDeadlineExceeded:
+		return commandExitError{Code: exitCodeGeneral, Err: fmt.Errorf("%w; increase --timeout or set --timeout 0, and check daemon-side operation timeouts", err)}
 	case connect.CodeUnimplemented:
 		return commandExitError{Code: exitCodeUnsupported, Err: err}
 	case connect.CodeUnavailable:

--- a/cmd/agent-compose/cli_root_test.go
+++ b/cmd/agent-compose/cli_root_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -81,6 +83,7 @@ func TestCommandExitErrorForConnectClassifiesRPCFailures(t *testing.T) {
 		{name: "failed precondition", err: connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("stopped")), code: exitCodeUsage},
 		{name: "unavailable", err: connect.NewError(connect.CodeUnavailable, fmt.Errorf("daemon down")), code: exitCodeUnavailable},
 		{name: "unsupported", err: connect.NewError(connect.CodeUnimplemented, fmt.Errorf("stats unsupported")), code: exitCodeUnsupported},
+		{name: "deadline exceeded", err: connect.NewError(connect.CodeDeadlineExceeded, context.DeadlineExceeded), code: exitCodeGeneral},
 		{name: "ordinary failure", err: connect.NewError(connect.CodeInternal, fmt.Errorf("boom")), code: exitCodeGeneral},
 	}
 	for _, tc := range tests {
@@ -90,5 +93,15 @@ func TestCommandExitErrorForConnectClassifiesRPCFailures(t *testing.T) {
 				t.Fatalf("exit code = %d, want %d; err=%v", got, tc.code, err)
 			}
 		})
+	}
+}
+
+func TestCLITimeoutRejectsNegativeDuration(t *testing.T) {
+	stdout, stderr, _, exitCode := executeCLICommand("--timeout", "-1s", "version")
+	if exitCode != exitCodeUsage {
+		t.Fatalf("negative --timeout exit code = %d, want %d; stderr=%q", exitCode, exitCodeUsage, stderr)
+	}
+	if stdout != "" || !strings.Contains(stderr, "--timeout must not be negative") {
+		t.Fatalf("negative --timeout stdout/stderr = %q / %q", stdout, stderr)
 	}
 }

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -95,7 +95,7 @@ func runComposeUpCommand(cmd *cobra.Command, cli cliOptions) error {
 	if err != nil {
 		return fmt.Errorf("%s: hash normalized compose spec: %w", composePath, err)
 	}
-	clientConfig, err := resolveCLIClientConfig(cli.Host)
+	clientConfig, err := resolveCLIServiceClientConfig(cli)
 	if err != nil {
 		return err
 	}
@@ -347,21 +347,16 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 	if normalizedOptions.Detach {
 		return startDetachedRun(cmd, cli, runtimeProject.name(), client, runReq)
 	}
-	client = clients.runStream
 	if normalizedOptions.Interactive {
 		if normalizedOptions.TTY {
-			attachClient, err := newCLIAttachAgentRunServiceClient(cli)
-			if err != nil {
-				return err
-			}
 			if promptFlagChanged {
 				runReq.Prompt = prompt
 				runReq.Command = ""
-				return runComposeRunPromptAttachCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: attachClient}, runReq)
+				return runComposeRunPromptAttachCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: clients.run}, runReq)
 			}
 			runReq.Prompt = ""
 			runReq.Command = commandText
-			return runComposeAttachAgentRunCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: attachClient}, runReq, normalizedOptions)
+			return runComposeAttachAgentRunCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: clients.run}, runReq, normalizedOptions)
 		}
 		runReq.Prompt = ""
 		runReq.Command = ""

--- a/cmd/agent-compose/cli_scheduler_stream.go
+++ b/cmd/agent-compose/cli_scheduler_stream.go
@@ -22,7 +22,7 @@ func streamComposeSchedulerRuns(ctx context.Context, clients cliServiceClients, 
 	if err != nil {
 		return err
 	}
-	stream, err := clients.projectStream.StreamSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
+	stream, err := clients.project.StreamSchedulerRuns(ctx, connect.NewRequest(&agentcomposev2.StreamSchedulerRunsRequest{
 		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: agentFilter, TriggerId: triggerID,
 		Status: runStatus, BatchSize: schedulerCLIBatchSize, Limit: limit,
 	}))
@@ -91,7 +91,7 @@ func streamProjectSchedulerLogEvents(ctx context.Context, clients cliServiceClie
 	if tail > 0 {
 		streamTail = uint32(tail)
 	}
-	stream, err := clients.projectStream.StreamProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
+	stream, err := clients.project.StreamProjectSchedulerEvents(ctx, connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
 		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}}, AgentName: agentName, TriggerId: triggerID, RunId: runID,
 		BatchSize: schedulerCLIBatchSize, Tail: streamTail,
 	}))

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -23,6 +23,7 @@ Global options are placed between `agent-compose` and the subcommand, and apply 
 | `--host <endpoint>` | Daemon HTTP endpoint. This can target a local daemon or a remote daemon. |
 | `--project-name <name>` | Select an existing daemon project by name. It is not supported by `up` or `project up` and never changes the project name declared by a compose file. |
 | `--json` | Print machine-readable JSON for scripts, AI agents, and automation. |
+| `--timeout <duration>` | Maximum total duration of each CLI-to-daemon RPC, including streaming responses. The default `0` disables the total RPC timeout. |
 
 Examples:
 
@@ -39,6 +40,9 @@ Rules:
 - Local authoring commands use the project name declared by the compose file (or derived from its directory). `up` and `project up` reject `--project-name` instead of silently ignoring it; `config` never uses it to override the compose project name.
 - With `-f`, the CLI can operate on a project from any working directory.
 - `--host` only selects the daemon. Sandboxes run in the daemon environment.
+- `--timeout` accepts Go durations such as `30s`, `15m`, and `2h`. It applies independently to each unary, server-streaming, or bidirectional RPC; `0` waits until the RPC completes or the user cancels it.
+- Connection establishment and explicit health probes retain their own bounded timeouts even when `--timeout` is `0`.
+- `--timeout` only controls the CLI request. Daemon-side limits such as `AGENT_TIMEOUT`, `SANDBOX_START_TIMEOUT`, and `SANDBOX_STOP_TIMEOUT` remain independent.
 - Automation should use `--json` and avoid parsing human-readable tables.
 
 ### Daemon authentication

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -23,6 +23,7 @@ agent-compose [global options] <command> [command options] [arguments]
 | `--host <endpoint>` | 指定 daemon 地址。可以连接本机 daemon，也可以连接远程 daemon。 |
 | `--project-name <name>` | 按名称选择 daemon 中已部署的 project；`up` 和 `project up` 不支持该参数，且它不会修改 compose 文件声明的项目名称。 |
 | `--json` | 使用 JSON 输出，供脚本、AI 和自动化系统解析。 |
+| `--timeout <duration>` | 每个 CLI→daemon RPC 的最大总时长，包括读取流式响应；默认值 `0` 表示不设置 RPC 总超时。 |
 
 示例：
 
@@ -39,6 +40,9 @@ agent-compose --host http://10.0.0.12:7410 ls --json
 - 本地编排命令始终使用 compose 文件声明的项目名称（或根据其目录推导）。`up` 和 `project up` 会拒绝 `--project-name`，不再静默忽略；`config` 也不会用它覆盖 compose project 名称。
 - 使用 `-f` 时，不需要切换到 project root。
 - `--host` 只决定 CLI 连接哪个 daemon；sandbox 实际运行在 daemon 所在环境中。
+- `--timeout` 接受 `30s`、`15m`、`2h` 等 Go duration。它分别作用于每个 unary、server-streaming 或双向流 RPC；设置为 `0` 时会等待 RPC 完成或用户主动取消。
+- 即使 `--timeout` 为 `0`，连接建立和显式健康检查仍保留各自的有限超时。
+- `--timeout` 只控制 CLI 请求；`AGENT_TIMEOUT`、`SANDBOX_START_TIMEOUT`、`SANDBOX_STOP_TIMEOUT` 等 daemon 侧限制保持独立。
 - daemon 不再消费浏览器登录用的 `AUTH_*` / `OAUTH_*` 配置；UI 浏览器认证由 agent-compose-ui server 处理。
 - 自动化场景应使用 `--json`，不要解析人类可读表格。
 


### PR DESCRIPTION
## Summary

- Remove the undocumented 10-minute CLI HTTP timeout and add a global `--timeout <duration>` option. The default is `0`, so CLI-to-daemon RPCs have no total deadline unless the user explicitly configures one; negative values return a usage error.
- Use one configured HTTP client for unary, server-streaming, and bidirectional attach RPCs. This removes the duplicate `runStream`, `execStream`, `projectStream`, and `imageStream` clients, structurally preventing call sites from selecting a client with a different timeout policy.
- Apply an explicit timeout to the complete RPC, including streaming body reads, while retaining a bounded 30-second connection timeout for custom Unix Socket/h2c dialers. Deadline errors now suggest increasing `--timeout`, disabling it with `--timeout 0`, and checking daemon-side limits.
- Document the option and its interaction with daemon-side operation timeouts in the English and Chinese CLI manuals.

Fixes #502.

## Testing

Passed on the original latest-main base (`cf856d6c`):

```text
GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -count=1
task docs:build
GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"
GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"
GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"
```

Coverage from the full test gate:

- Unit: 74.91%
- Integration: 60.79%
- E2E: 60.16%
- Combined: 79.05%

The full test gate used a temporary short symlink (`/tmp/ac502`) to the same worktree because the original worktree path exceeds the system Unix Socket path-length limit. The symlink was removed after testing.

After rebasing onto current `main` (`5847f06d`), `git diff --check origin/main...HEAD` passes. Re-running the focused CLI test is currently blocked by an unrelated issue introduced by merged PR #505: `proto/agentcompose/v2/agentcompose.proto` adds `TriggerSpec.timezone`, but the corresponding generated `agentcompose.pb.go` was not updated on `main`, so `pkg/agentcompose/api/project.go` cannot compile (`TriggerSpec.Timezone` / `GetTimezone` are missing).

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
