### PR TITLE
fix(webhooks): return existing event on idempotency conflict

### DIFF
--- a/docs/design/webhook_design.md
+++ b/docs/design/webhook_design.md
@@ -311,12 +311,15 @@ Idempotency rules:
   `X-GitHub-Delivery`.
 - Without an available idempotency key, platform-level deduplication is not
   performed.
-- Same `topic + idempotency_key` with identical `payload_hash` returns the
-  existing event and `202 Accepted`.
-- Same `topic + idempotency_key` with different `payload_hash` returns
-  `409 Conflict`. The response uses code `idempotency_payload_mismatch` and
-  includes the existing event metadata so an authorized publisher can recover
-  the accepted delivery without creating a second event.
+- Same `topic + idempotency_key` with an identical canonical JSON request body
+  returns the existing event and `202 Accepted`. Generated event metadata,
+  correlation headers, other request headers, and query values are not part of
+  this comparison.
+- Same `topic + idempotency_key` with a different canonical JSON request body
+  returns `409 Conflict`. The response uses code
+  `idempotency_payload_mismatch` and includes the existing event metadata so an
+  authorized publisher can recover the accepted delivery without creating a
+  second event.
 
 ## Dispatcher Semantics
 

--- a/docs/design/webhook_design.md
+++ b/docs/design/webhook_design.md
@@ -314,7 +314,9 @@ Idempotency rules:
 - Same `topic + idempotency_key` with identical `payload_hash` returns the
   existing event and `202 Accepted`.
 - Same `topic + idempotency_key` with different `payload_hash` returns
-  `409 Conflict`.
+  `409 Conflict`. The response uses code `idempotency_payload_mismatch` and
+  includes the existing event metadata so an authorized publisher can recover
+  the accepted delivery without creating a second event.
 
 ## Dispatcher Semantics
 

--- a/pkg/events/webhooks/dto.go
+++ b/pkg/events/webhooks/dto.go
@@ -1,11 +1,19 @@
 package webhooks
 
+const idempotencyPayloadMismatchCode = "idempotency_payload_mismatch"
+
 type AcceptedResponse struct {
 	Accepted      bool   `json:"accepted"`
 	Topic         string `json:"topic"`
 	EventID       string `json:"event_id"`
 	Sequence      int64  `json:"sequence"`
 	CorrelationID string `json:"correlation_id"`
+}
+
+type idempotencyConflictResponse struct {
+	Code          string           `json:"code"`
+	Error         string           `json:"error"`
+	ExistingEvent AcceptedResponse `json:"existing_event"`
 }
 
 type TopicEventResponse struct {

--- a/pkg/events/webhooks/http.go
+++ b/pkg/events/webhooks/http.go
@@ -103,15 +103,9 @@ func (h routeHandler) handleWebhook(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load webhook event"})
 	} else if ok {
 		if ExistingBodyHash(existing.PayloadJSON) != domain.TopicEventPayloadSHA256(compactBody) {
-			return c.JSON(http.StatusConflict, map[string]string{"error": "idempotency key conflicts with existing payload"})
+			return c.JSON(http.StatusConflict, idempotencyConflictResponseFor(existing))
 		}
-		return c.JSON(http.StatusAccepted, AcceptedResponse{
-			Accepted:      true,
-			Topic:         existing.Topic,
-			EventID:       existing.ID,
-			Sequence:      existing.Sequence,
-			CorrelationID: existing.CorrelationID,
-		})
+		return c.JSON(http.StatusAccepted, acceptedResponseFor(existing))
 	}
 
 	eventID := h.newEventID()
@@ -141,17 +135,24 @@ func (h routeHandler) handleWebhook(c echo.Context) error {
 	})
 	if err != nil {
 		if errors.Is(err, domain.ErrConflict) {
-			return c.JSON(http.StatusConflict, map[string]string{"error": "idempotency key conflicts with existing payload"})
+			existing, ok, lookupErr := h.store().FindEventByIdempotencyKey(c.Request().Context(), topic, idempotencyKey)
+			if lookupErr != nil {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load conflicting webhook event"})
+			}
+			if ok {
+				if ExistingBodyHash(existing.PayloadJSON) == domain.TopicEventPayloadSHA256(compactBody) {
+					return c.JSON(http.StatusAccepted, acceptedResponseFor(existing))
+				}
+				return c.JSON(http.StatusConflict, idempotencyConflictResponseFor(existing))
+			}
+			return c.JSON(http.StatusConflict, map[string]string{
+				"code":  idempotencyPayloadMismatchCode,
+				"error": idempotencyPayloadMismatchMessage,
+			})
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to store webhook event"})
 	}
-	return c.JSON(http.StatusAccepted, AcceptedResponse{
-		Accepted:      true,
-		Topic:         created.Topic,
-		EventID:       created.ID,
-		Sequence:      created.Sequence,
-		CorrelationID: created.CorrelationID,
-	})
+	return c.JSON(http.StatusAccepted, acceptedResponseFor(created))
 }
 
 func (h routeHandler) handleGetEvent(c echo.Context) error {

--- a/pkg/events/webhooks/http.go
+++ b/pkg/events/webhooks/http.go
@@ -134,21 +134,19 @@ func (h routeHandler) handleWebhook(c echo.Context) error {
 		PublisherType:  domain.TopicEventSourceWebhook,
 	})
 	if err != nil {
+		var conflict *domain.TopicEventIdempotencyConflictError
+		if errors.As(err, &conflict) {
+			existing := conflict.Existing
+			if strings.TrimSpace(existing.ID) == "" || strings.TrimSpace(existing.Topic) != topic {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"error": "invalid conflicting webhook event"})
+			}
+			if ExistingBodyHash(existing.PayloadJSON) == domain.TopicEventPayloadSHA256(compactBody) {
+				return c.JSON(http.StatusAccepted, acceptedResponseFor(existing))
+			}
+			return c.JSON(http.StatusConflict, idempotencyConflictResponseFor(existing))
+		}
 		if errors.Is(err, domain.ErrConflict) {
-			existing, ok, lookupErr := h.store().FindEventByIdempotencyKey(c.Request().Context(), topic, idempotencyKey)
-			if lookupErr != nil {
-				return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load conflicting webhook event"})
-			}
-			if ok {
-				if ExistingBodyHash(existing.PayloadJSON) == domain.TopicEventPayloadSHA256(compactBody) {
-					return c.JSON(http.StatusAccepted, acceptedResponseFor(existing))
-				}
-				return c.JSON(http.StatusConflict, idempotencyConflictResponseFor(existing))
-			}
-			return c.JSON(http.StatusConflict, map[string]string{
-				"code":  idempotencyPayloadMismatchCode,
-				"error": idempotencyPayloadMismatchMessage,
-			})
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "webhook event conflict did not include the existing event"})
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to store webhook event"})
 	}

--- a/pkg/events/webhooks/http_idempotency_conflict_test.go
+++ b/pkg/events/webhooks/http_idempotency_conflict_test.go
@@ -3,6 +3,7 @@ package webhooks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -37,8 +38,8 @@ func TestWebhookConcurrentPayloadConflictReturnsExistingEvent(t *testing.T) {
 
 	response := postWebhookWithIdempotencyKey(t, store, `{"intent":"changed"}`)
 	assertIdempotencyConflictResponse(t, response, existing)
-	if store.lookupCount != 2 {
-		t.Fatalf("idempotency lookups = %d, want 2", store.lookupCount)
+	if store.lookupCount != 1 {
+		t.Fatalf("idempotency lookups = %d, want 1", store.lookupCount)
 	}
 }
 
@@ -62,8 +63,44 @@ func TestWebhookConcurrentIdenticalPayloadReturnsExistingEvent(t *testing.T) {
 	if !accepted.Accepted || accepted.EventID != existing.ID || accepted.Topic != existing.Topic {
 		t.Fatalf("accepted response = %#v", accepted)
 	}
-	if store.lookupCount != 2 {
-		t.Fatalf("idempotency lookups = %d, want 2", store.lookupCount)
+	if store.lookupCount != 1 {
+		t.Fatalf("idempotency lookups = %d, want 1", store.lookupCount)
+	}
+}
+
+func TestWebhookIdempotencyComparesCanonicalRequestBodyOnly(t *testing.T) {
+	existing := webhookConflictEvent()
+	existing.PayloadJSON = `{
+		"body":{"intent":"original"},
+		"correlationId":"correlation-original",
+		"headers":{"user-agent":"original-agent"},
+		"query":{"delivery":"original"}
+	}`
+	store := newWebhookRouteStore()
+	store.events[existing.ID] = existing
+	store.existingID = existing.ID
+
+	response := postWebhookWithHeaders(t, store, `{"intent":"original"}`, http.Header{
+		"User-Agent":       {"changed-agent"},
+		"X-Correlation-ID": {"correlation-changed"},
+	})
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body=%s, want %d", response.Code, response.Body.String(), http.StatusAccepted)
+	}
+	var accepted AcceptedResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &accepted); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if accepted.EventID != existing.ID || accepted.CorrelationID != existing.CorrelationID {
+		t.Fatalf("accepted response = %#v", accepted)
+	}
+}
+
+func TestWebhookConflictWithoutExistingEventReturnsInternalError(t *testing.T) {
+	store := &untypedWebhookConflictStore{webhookRouteStore: newWebhookRouteStore()}
+	response := postWebhookWithIdempotencyKey(t, store, `{"intent":"original"}`)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d body=%s, want %d", response.Code, response.Body.String(), http.StatusInternalServerError)
 	}
 }
 
@@ -80,6 +117,11 @@ func webhookConflictEvent() domain.TopicEventRecord {
 
 func postWebhookWithIdempotencyKey(t *testing.T, store Store, body string) *httptest.ResponseRecorder {
 	t.Helper()
+	return postWebhookWithHeaders(t, store, body, nil)
+}
+
+func postWebhookWithHeaders(t *testing.T, store Store, body string, headers http.Header) *httptest.ResponseRecorder {
+	t.Helper()
 	app := echo.New()
 	RegisterRoutes(app, RouteOptions{
 		Store:            store,
@@ -90,6 +132,11 @@ func postWebhookWithIdempotencyKey(t *testing.T, store Store, body string) *http
 	req.Header.Set("Authorization", "Bearer token")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Idempotency-Key", "idem-existing")
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
 	rec := httptest.NewRecorder()
 	app.ServeHTTP(rec, req)
 	return rec
@@ -125,9 +172,17 @@ func (s *concurrentWebhookConflictStore) FindEventByIdempotencyKey(context.Conte
 	if s.lookupCount == 1 {
 		return domain.TopicEventRecord{}, false, nil
 	}
-	return s.existing, true, nil
+	return domain.TopicEventRecord{}, false, errors.New("unexpected second idempotency lookup")
 }
 
 func (s *concurrentWebhookConflictStore) CreateEvent(context.Context, domain.TopicEventRecord) (domain.TopicEventRecord, error) {
+	return domain.TopicEventRecord{}, &domain.TopicEventIdempotencyConflictError{Existing: s.existing}
+}
+
+type untypedWebhookConflictStore struct {
+	*webhookRouteStore
+}
+
+func (s *untypedWebhookConflictStore) CreateEvent(context.Context, domain.TopicEventRecord) (domain.TopicEventRecord, error) {
 	return domain.TopicEventRecord{}, domain.ErrConflict
 }

--- a/pkg/events/webhooks/http_idempotency_conflict_test.go
+++ b/pkg/events/webhooks/http_idempotency_conflict_test.go
@@ -1,0 +1,133 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestWebhookPayloadConflictReturnsExistingEvent(t *testing.T) {
+	existing := webhookConflictEvent()
+	store := newWebhookRouteStore()
+	store.events[existing.ID] = existing
+	store.existingID = existing.ID
+
+	response := postWebhookWithIdempotencyKey(t, store, `{"intent":"changed"}`)
+	assertIdempotencyConflictResponse(t, response, existing)
+	if len(store.events) != 1 {
+		t.Fatalf("stored events = %d, want 1", len(store.events))
+	}
+}
+
+func TestWebhookConcurrentPayloadConflictReturnsExistingEvent(t *testing.T) {
+	existing := webhookConflictEvent()
+	base := newWebhookRouteStore()
+	base.events[existing.ID] = existing
+	store := &concurrentWebhookConflictStore{
+		webhookRouteStore: base,
+		existing:          existing,
+	}
+
+	response := postWebhookWithIdempotencyKey(t, store, `{"intent":"changed"}`)
+	assertIdempotencyConflictResponse(t, response, existing)
+	if store.lookupCount != 2 {
+		t.Fatalf("idempotency lookups = %d, want 2", store.lookupCount)
+	}
+}
+
+func TestWebhookConcurrentIdenticalPayloadReturnsExistingEvent(t *testing.T) {
+	existing := webhookConflictEvent()
+	base := newWebhookRouteStore()
+	base.events[existing.ID] = existing
+	store := &concurrentWebhookConflictStore{
+		webhookRouteStore: base,
+		existing:          existing,
+	}
+
+	response := postWebhookWithIdempotencyKey(t, store, `{"intent":"original"}`)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body=%s, want %d", response.Code, response.Body.String(), http.StatusAccepted)
+	}
+	var accepted AcceptedResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &accepted); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !accepted.Accepted || accepted.EventID != existing.ID || accepted.Topic != existing.Topic {
+		t.Fatalf("accepted response = %#v", accepted)
+	}
+	if store.lookupCount != 2 {
+		t.Fatalf("idempotency lookups = %d, want 2", store.lookupCount)
+	}
+}
+
+func webhookConflictEvent() domain.TopicEventRecord {
+	return domain.TopicEventRecord{
+		ID:             "event-existing",
+		Topic:          "webhook.github.push",
+		CorrelationID:  "correlation-existing",
+		IdempotencyKey: "idem-existing",
+		PayloadJSON:    `{"body":{"intent":"original"}}`,
+		Sequence:       17,
+	}
+}
+
+func postWebhookWithIdempotencyKey(t *testing.T, store Store, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	app := echo.New()
+	RegisterRoutes(app, RouteOptions{
+		Store:            store,
+		WebhookBodyLimit: 1 << 20,
+		NewEventID:       func() string { return "event-new" },
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "idem-existing")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	return rec
+}
+
+func assertIdempotencyConflictResponse(t *testing.T, rec *httptest.ResponseRecorder, existing domain.TopicEventRecord) {
+	t.Helper()
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%s, want %d", rec.Code, rec.Body.String(), http.StatusConflict)
+	}
+	var response idempotencyConflictResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code != idempotencyPayloadMismatchCode || response.Error != idempotencyPayloadMismatchMessage {
+		t.Fatalf("conflict response = %#v", response)
+	}
+	if !response.ExistingEvent.Accepted || response.ExistingEvent.EventID != existing.ID ||
+		response.ExistingEvent.Topic != existing.Topic || response.ExistingEvent.Sequence != existing.Sequence ||
+		response.ExistingEvent.CorrelationID != existing.CorrelationID {
+		t.Fatalf("existing event = %#v, want %#v", response.ExistingEvent, existing)
+	}
+}
+
+type concurrentWebhookConflictStore struct {
+	*webhookRouteStore
+	existing    domain.TopicEventRecord
+	lookupCount int
+}
+
+func (s *concurrentWebhookConflictStore) FindEventByIdempotencyKey(context.Context, string, string) (domain.TopicEventRecord, bool, error) {
+	s.lookupCount++
+	if s.lookupCount == 1 {
+		return domain.TopicEventRecord{}, false, nil
+	}
+	return s.existing, true, nil
+}
+
+func (s *concurrentWebhookConflictStore) CreateEvent(context.Context, domain.TopicEventRecord) (domain.TopicEventRecord, error) {
+	return domain.TopicEventRecord{}, domain.ErrConflict
+}

--- a/pkg/events/webhooks/response.go
+++ b/pkg/events/webhooks/response.go
@@ -8,6 +8,26 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
+const idempotencyPayloadMismatchMessage = "idempotency key conflicts with existing payload"
+
+func acceptedResponseFor(item domain.TopicEventRecord) AcceptedResponse {
+	return AcceptedResponse{
+		Accepted:      true,
+		Topic:         item.Topic,
+		EventID:       item.ID,
+		Sequence:      item.Sequence,
+		CorrelationID: item.CorrelationID,
+	}
+}
+
+func idempotencyConflictResponseFor(item domain.TopicEventRecord) idempotencyConflictResponse {
+	return idempotencyConflictResponse{
+		Code:          idempotencyPayloadMismatchCode,
+		Error:         idempotencyPayloadMismatchMessage,
+		ExistingEvent: acceptedResponseFor(item),
+	}
+}
+
 func SourceToJSON(source domain.WebhookSource) SourceJSON {
 	return SourceJSON{
 		ID:                 source.ID,

--- a/pkg/model/topic_event_model.go
+++ b/pkg/model/topic_event_model.go
@@ -59,6 +59,23 @@ type TopicEventRecord struct {
 	DispatchedAt    time.Time `json:"dispatched_at,omitempty"`
 }
 
+// TopicEventIdempotencyConflictError reports a duplicate topic and idempotency
+// key while carrying the event record that already owns them.
+type TopicEventIdempotencyConflictError struct {
+	Existing TopicEventRecord
+}
+
+func (e *TopicEventIdempotencyConflictError) Error() string {
+	if e == nil || strings.TrimSpace(e.Existing.Topic) == "" {
+		return "event idempotency conflict"
+	}
+	return fmt.Sprintf("event idempotency conflict for topic %q", e.Existing.Topic)
+}
+
+func (e *TopicEventIdempotencyConflictError) Unwrap() error {
+	return ErrConflict
+}
+
 type TopicEventFilter struct {
 	EventID        string
 	Topic          string

--- a/pkg/storage/configstore/topic_event_create.go
+++ b/pkg/storage/configstore/topic_event_create.go
@@ -84,7 +84,7 @@ func (s *eventStore) resolveTopicEventInsertError(ctx context.Context, item doma
 				return domain.TopicEventRecord{}, fmt.Errorf("sequence duplicate event payload: %w", hashErr)
 			}
 			if existing.PayloadHash != itemPayloadHash {
-				return domain.TopicEventRecord{}, domain.ResourceError(domain.ErrConflict, "event", item.Topic, fmt.Sprintf("event idempotency conflict for topic %q", item.Topic), nil)
+				return domain.TopicEventRecord{}, &domain.TopicEventIdempotencyConflictError{Existing: existing}
 			}
 			return existing, nil
 		}

--- a/pkg/storage/configstore/topic_event_store_test.go
+++ b/pkg/storage/configstore/topic_event_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -60,6 +61,45 @@ func TestCreateEventAcceptsIdempotentPayloadWithSequencePlaceholder(t *testing.T
 	}
 	if duplicate.ID != created.ID || duplicate.PayloadHash != created.PayloadHash {
 		t.Fatalf("duplicate = %#v, want original %#v", duplicate, created)
+	}
+}
+
+func TestCreateEventPayloadConflictCarriesExistingEvent(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	created, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID:             "event-original",
+		Topic:          "webhook.github.push",
+		Source:         domain.TopicEventSourceWebhook,
+		IdempotencyKey: "delivery-1",
+		PayloadJSON:    `{"sequence":0,"body":{"branch":"main"}}`,
+		DispatchStatus: domain.TopicEventDispatchPending,
+	})
+	if err != nil {
+		t.Fatalf("create original event: %v", err)
+	}
+
+	_, err = store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID:             "event-conflict",
+		Topic:          created.Topic,
+		Source:         domain.TopicEventSourceWebhook,
+		IdempotencyKey: created.IdempotencyKey,
+		PayloadJSON:    `{"sequence":0,"body":{"branch":"changed"}}`,
+		DispatchStatus: domain.TopicEventDispatchPending,
+	})
+	if !errors.Is(err, domain.ErrConflict) {
+		t.Fatalf("conflict error = %v, want ErrConflict", err)
+	}
+	var conflict *domain.TopicEventIdempotencyConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("conflict error type = %T, want TopicEventIdempotencyConflictError", err)
+	}
+	if conflict.Existing.ID != created.ID || conflict.Existing.Sequence != created.Sequence {
+		t.Fatalf("conflicting existing event = %#v, want %#v", conflict.Existing, created)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Return structured idempotency_payload_mismatch 409 responses with the already accepted event metadata.
- Recheck the idempotency record after CreateEvent conflicts so concurrent identical requests recover with 202 while changed payloads remain 409.
- Document the webhook idempotency recovery contract.

## Testing

- [x] go test ./pkg/events/webhooks -count=1
- [x] go test -race ./pkg/events/webhooks -count=1
- [x] go vet ./pkg/events/webhooks
- [x] task build
- [ ] task lint — blocked locally because golangci-lint was built with Go 1.25 while the repository requires Go 1.26.2; no generated files changed.
- [ ] task test — relevant package tests pass; the full run is blocked by the existing macOS /var symlink installer test.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.