### PR TITLE
docs(examples): align tutorials with current CLI

### DIFF
--- a/cmd/agent-compose/examples_contract_test.go
+++ b/cmd/agent-compose/examples_contract_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/schedulers"
+)
+
+type exampleContract struct {
+	agentCount int
+	schedulers int
+}
+
+func TestExampleFilesContract(t *testing.T) {
+	root := repoRootForComposeEnvTest(t)
+	examplesRoot := filepath.Join(root, "examples", "agent-compose")
+	want := map[string]exampleContract{
+		"docker-minimal":              {agentCount: 1},
+		"docker-scheduler-cron":       {agentCount: 1, schedulers: 1},
+		"docker-scheduler-script-url": {agentCount: 1, schedulers: 1},
+		"docker-scheduler-timeout":    {agentCount: 1, schedulers: 1},
+	}
+
+	entries, err := os.ReadDir(examplesRoot)
+	if err != nil {
+		t.Fatalf("read examples directory: %v", err)
+	}
+	gotNames := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			gotNames = append(gotNames, entry.Name())
+		}
+	}
+	sort.Strings(gotNames)
+	wantNames := make([]string, 0, len(want))
+	for name := range want {
+		wantNames = append(wantNames, name)
+	}
+	sort.Strings(wantNames)
+	if strings.Join(gotNames, "\n") != strings.Join(wantNames, "\n") {
+		t.Fatalf("example directories = %v, want %v", gotNames, wantNames)
+	}
+
+	engine := &schedulers.QJSSchedulerEngine{}
+	for _, name := range wantNames {
+		t.Run(name, func(t *testing.T) {
+			dir := filepath.Join(examplesRoot, name)
+			for _, readme := range []string{"README.md", "README.zh-CN.md"} {
+				assertExampleFileExists(t, filepath.Join(dir, readme))
+			}
+			_, normalized, err := loadResolvedNormalizedCompose(context.Background(), cliOptions{
+				ComposeFile: filepath.Join(dir, "agent-compose.yml"),
+			})
+			if err != nil {
+				t.Fatalf("normalize example: %v", err)
+			}
+			contract := want[name]
+			if normalized.Name != name || len(normalized.Agents) != contract.agentCount {
+				t.Fatalf("normalized project name/agents = %q/%d, want %q/%d", normalized.Name, len(normalized.Agents), name, contract.agentCount)
+			}
+			schedulerCount := 0
+			for _, agent := range normalized.Agents {
+				if !agent.Enabled {
+					t.Fatalf("agent %s is unexpectedly disabled", agent.Name)
+				}
+				if agent.Driver == nil || agent.Driver.Name != "docker" {
+					t.Fatalf("agent %s driver = %#v, want docker", agent.Name, agent.Driver)
+				}
+				if agent.Scheduler == nil {
+					continue
+				}
+				schedulerCount++
+				if agent.Scheduler.SandboxPolicy != domain.SchedulerSandboxPolicyNew || agent.Scheduler.ConcurrencyPolicy != domain.SchedulerConcurrencyPolicySkip {
+					t.Fatalf("agent %s scheduler policies = %q/%q, want new/skip", agent.Name, agent.Scheduler.SandboxPolicy, agent.Scheduler.ConcurrencyPolicy)
+				}
+				if strings.TrimSpace(agent.Scheduler.Script) != "" {
+					if _, err := engine.Validate(context.Background(), domain.SchedulerRuntimeScheduler, agent.Scheduler.Script); err != nil {
+						t.Fatalf("validate scheduler script: %v", err)
+					}
+				}
+			}
+			if schedulerCount != contract.schedulers {
+				t.Fatalf("scheduler count = %d, want %d", schedulerCount, contract.schedulers)
+			}
+		})
+	}
+
+	validateStandaloneSchedulerExamples(t, root, engine)
+	assertExampleDocsDoNotUseStaleContracts(t, root)
+}
+
+func validateStandaloneSchedulerExamples(t *testing.T, root string, engine *schedulers.QJSSchedulerEngine) {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join(root, "examples", "scheduler-script", "*.js"))
+	if err != nil {
+		t.Fatalf("glob scheduler examples: %v", err)
+	}
+	if len(files) != 6 {
+		t.Fatalf("standalone scheduler example count = %d, want 6", len(files))
+	}
+	for _, file := range files {
+		script, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if _, err := engine.Validate(context.Background(), domain.SchedulerRuntimeScheduler, string(script)); err != nil {
+			t.Fatalf("validate %s: %v", file, err)
+		}
+	}
+}
+
+func assertExampleDocsDoNotUseStaleContracts(t *testing.T, root string) {
+	t.Helper()
+	stale := []string{
+		"exec --agent",
+		"SCHEDULER  LATEST RUN",
+		"RunLoaderNow",
+		"project_scheduler",
+		"agent_definition",
+		"Loader 脚本模板",
+	}
+	err := filepath.WalkDir(filepath.Join(root, "examples"), func(file string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "README") || filepath.Ext(entry.Name()) != ".md" {
+			return nil
+		}
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		for _, text := range stale {
+			if strings.Contains(string(data), text) {
+				return fmt.Errorf("%s contains stale CLI/API text %q", file, text)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertExampleFileExists(t *testing.T, path string) {
+	t.Helper()
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		t.Fatalf("required example file %s is unavailable: %v", path, err)
+	}
+}

--- a/examples/agent-compose/README.md
+++ b/examples/agent-compose/README.md
@@ -7,9 +7,9 @@ simplest to most complete.
 
 | Example | What it shows | Needs provider auth |
 | --- | --- | --- |
-| [docker-minimal](docker-minimal/) | Smallest Docker-backed project: one agent, no scheduler. | No, for `config`/`up`/`ps` |
-| [docker-scheduler-cron](docker-scheduler-cron/) | Managed cron scheduler control plane. | No, for `config`/`up`/`ps`/`down` |
-| [docker-scheduler-script-url](docker-scheduler-script-url/) | A scheduler script loaded from a relative `file` source, with an HTTP source alternative. | No, for `config`/`up`/`ps`/`down` |
+| [docker-minimal](docker-minimal/) | Smallest Docker-backed project: one agent, no scheduler. | No, for `config`/`up`/`ls` |
+| [docker-scheduler-cron](docker-scheduler-cron/) | Managed cron scheduler control plane. | No, for `config`/`up`/`ls`/`down` |
+| [docker-scheduler-script-url](docker-scheduler-script-url/) | A scheduler script loaded from a relative `file` source, with an HTTP source alternative. | No, for `config`/`up`/`ls`/`down` |
 | [docker-scheduler-timeout](docker-scheduler-timeout/) | End-to-end scheduled run that fires, executes the agent, and persists logs. | Yes, for the scheduled run |
 
 ## Common prerequisites

--- a/examples/agent-compose/README.zh-CN.md
+++ b/examples/agent-compose/README.zh-CN.md
@@ -6,9 +6,9 @@
 
 | 示例 | 演示内容 | 是否需要 provider 凭证 |
 | --- | --- | --- |
-| [docker-minimal](docker-minimal/) | 最小的 Docker project：一个 agent，不启用 scheduler。 | `config`/`up`/`ps` 不需要 |
-| [docker-scheduler-cron](docker-scheduler-cron/) | managed cron scheduler 的控制面流程。 | `config`/`up`/`ps`/`down` 不需要 |
-| [docker-scheduler-script-url](docker-scheduler-script-url/) | 从相对 `file` 来源加载 scheduler 脚本，并给出 HTTP 来源的替代配置。 | `config`/`up`/`ps`/`down` 不需要 |
+| [docker-minimal](docker-minimal/) | 最小的 Docker project：一个 agent，不启用 scheduler。 | `config`/`up`/`ls` 不需要 |
+| [docker-scheduler-cron](docker-scheduler-cron/) | managed cron scheduler 的控制面流程。 | `config`/`up`/`ls`/`down` 不需要 |
+| [docker-scheduler-script-url](docker-scheduler-script-url/) | 从相对 `file` 来源加载 scheduler 脚本，并给出 HTTP 来源的替代配置。 | `config`/`up`/`ls`/`down` 不需要 |
 | [docker-scheduler-timeout](docker-scheduler-timeout/) | 端到端的定时运行：触发、执行 agent 并持久化日志。 | 定时运行需要 |
 
 ## 通用前置条件

--- a/examples/agent-compose/docker-minimal/README.md
+++ b/examples/agent-compose/docker-minimal/README.md
@@ -2,23 +2,18 @@
 
 Languages: English | [中文](README.zh-CN.md)
 
-This example shows the smallest useful `agent-compose.yml` for running an
-agent-compose project with the Docker runtime driver.
+This example is the smallest useful `agent-compose.yml` for a project using
+the Docker runtime driver: one enabled agent, an explicit guest image, and no
+scheduler.
 
-It is intentionally minimal:
-
-- one project
-- one agent
-- Docker runtime driver
-- explicit guest image
-- no scheduler
-- no model or API key requirement for `config`, `up`, and `ps`
+`config`, `up`, and `ls` exercise only the control plane and do not require a
+model or API key.
 
 ## Prerequisites
 
-- Docker daemon is running.
-- The `agent-compose` daemon is already running.
-- The `agent-compose-guest:latest` image exists locally.
+- The `agent-compose` daemon is running.
+- Docker is required only when starting a real agent sandbox.
+- `agent-compose-guest:latest` exists locally before a real run.
 
 From the repository root, build the guest image if needed:
 
@@ -26,21 +21,16 @@ From the repository root, build the guest image if needed:
 task image:agent-compose-guest
 ```
 
-If you have an installed `agent-compose` binary in `PATH`, use:
+Check the daemon before continuing:
 
 ```bash
 agent-compose status
 ```
 
-When working from the source tree, you can run the CLI directly:
-
-```bash
-go run ./cmd/agent-compose status
-```
+When working from the source tree, replace `agent-compose` with
+`go run ./cmd/agent-compose`.
 
 ## Compose file
-
-This directory contains the minimal Docker-backed project:
 
 ```yaml
 name: docker-minimal
@@ -53,24 +43,17 @@ agents:
       docker: {}
 ```
 
-The important part is:
+The agent defaults to `enabled: true`. The default driver is also Docker, but
+this example keeps `docker: {}` explicit so its runtime requirement is clear.
 
-```yaml
-driver:
-  docker: {}
-```
-
-If the agent omits `driver`, the compose normalizer defaults to `docker`.
-This example sets `docker: {}` explicitly to document the intended runtime.
-
-## Run the example
+## Validate and apply
 
 From this directory:
 
 ```bash
 agent-compose config
 agent-compose up
-agent-compose ps
+agent-compose ls
 ```
 
 From the repository root without installing the binary:
@@ -78,51 +61,23 @@ From the repository root without installing the binary:
 ```bash
 go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml config
 go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml up
-go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml ps
+go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml ls
 ```
 
 Expected result:
 
-- `config` prints a normalized project with `driver.name: docker`.
-- `up` creates or updates the project and managed agent definition.
-- `ps` shows the `reviewer` agent using Docker and `agent-compose-guest:latest`.
+- `config` prints `enabled: true` and `driver.name: docker` after normalization.
+- `up` creates or updates the project and its `reviewer` agent.
+- `ls` shows the agent using Docker and `agent-compose-guest:latest`, with its
+  scheduler set to `false`.
 
-## Optional run test
+Representative normalized output:
 
-To start a runtime session and keep it alive:
-
-```bash
-agent-compose run reviewer --keep-running --prompt "hello from docker minimal example"
-```
-
-A real agent run requires a working guest runtime and provider authentication.
-For `provider: codex`, configure the required Codex credentials or API key in
-the guest environment before expecting model execution to succeed.
-
-If the runtime session is alive, you can run commands in it:
-
-```bash
-agent-compose exec --agent reviewer -- pwd
-agent-compose exec --agent reviewer -- env
-```
-
-Clean up running project sessions:
-
-```bash
-agent-compose down
-```
-
-## Verification output
-
-Output from a local verification run.
-
-### 1. Config normalization
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml config
+```yaml
 name: docker-minimal
 agents:
     - name: reviewer
+      enabled: true
       provider: codex
       image: agent-compose-guest:latest
       driver:
@@ -130,37 +85,40 @@ agents:
         docker: {}
 ```
 
-### 2. Apply project
+Representative control-plane output (IDs depend on the local compose path):
 
 ```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml up
-Project: docker-minimal
-ID: project-docker-minimal-ad604c8bf8d3
-Revision: 1
-Spec: sha256:45c9bab1e2c12ad3e26c2168ae87bbf92fdf9933ba62258b44de00813ff106ce
-Status: applied
-Agents: 1
-Schedulers: 0
+$ agent-compose up
+ID            NAME            TYPE     ACTION
+<project-id>  docker-minimal  project  created
+<agent-id>    reviewer        agent    created
 
-ACTION   TYPE              NAME                                                                     ID
-created  project           docker-minimal                                                           project-docker-minimal-ad604c8bf8d3
-created  project_revision  sha256:45c9bab1e2c12ad3e26c2168ae87bbf92fdf9933ba62258b44de00813ff106ce  project-docker-minimal-ad604c8bf8d3/1
-created  project_agent     reviewer                                                                 agent-reviewer-a9f84de36227
-created  agent_definition  reviewer                                                                 agent-reviewer-a9f84de36227
+$ agent-compose ls
+AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
+reviewer  codex            agent-compose-guest:latest  docker  false
 ```
 
-### 3. Project status
+## Optional real run
 
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml ps
-AGENT     SCHEDULER  LATEST RUN  RUN STATUS  SESSION  DRIVER  IMAGE
-reviewer  disabled   -           -           -        docker  agent-compose-guest:latest
+A real agent run requires Docker, a compatible guest image, and working Codex
+credentials or API access in the guest environment:
+
+```bash
+agent-compose run reviewer --keep-running --prompt "hello from docker minimal example"
 ```
 
-### 4. Docker runtime container
+List the running sandbox, then pass its ID positionally to `exec`:
 
-```console
-$ docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}'
-NAMES                                                IMAGE                        STATUS
-agent-compose-8aa2625d-db67-4428-82ae-8bef1a137a2f   agent-compose-guest:latest   Up 14 seconds
+```bash
+agent-compose ps
+agent-compose exec <sandbox-id> -- pwd
+agent-compose exec <sandbox-id> -- env
+```
+
+The old agent-name target flag is no longer supported by `exec`.
+
+Clean up the project and any running project sandboxes:
+
+```bash
+agent-compose down
 ```

--- a/examples/agent-compose/docker-minimal/README.zh-CN.md
+++ b/examples/agent-compose/docker-minimal/README.zh-CN.md
@@ -2,45 +2,33 @@
 
 语言：[English](README.md) | 中文
 
-本示例展示一个使用 Docker runtime driver 的最小可用
-`agent-compose.yml`。
+本示例给出使用 Docker runtime driver 的最小可用 `agent-compose.yml`：一个
+enabled agent、一个显式 guest image，并且不配置 scheduler。
 
-它刻意保持最小化：
-
-- 一个 project
-- 一个 agent
-- Docker runtime driver
-- 显式指定 guest image
-- 不启用 scheduler
-- `config`、`up` 和 `ps` 不要求配置模型或 API key
+`config`、`up` 和 `ls` 只验证控制面，不要求配置模型或 API key。
 
 ## 前置条件
 
-- Docker daemon 正在运行。
-- `agent-compose` daemon 已经启动。
-- 本地存在 `agent-compose-guest:latest` 镜像。
+- `agent-compose` daemon 正在运行。
+- 只有真正启动 agent sandbox 时才需要 Docker。
+- 真正运行前，本地需要存在 `agent-compose-guest:latest`。
 
-如果还没有 guest image，可以在仓库根目录构建：
+如有需要，可在仓库根目录构建 guest image：
 
 ```bash
 task image:agent-compose-guest
 ```
 
-如果 `agent-compose` 二进制已经在 `PATH` 中，可以直接检查 daemon：
+继续之前先检查 daemon：
 
 ```bash
 agent-compose status
 ```
 
-如果是在源码仓库中调试，也可以直接运行 CLI：
-
-```bash
-go run ./cmd/agent-compose status
-```
+在源码仓库中工作时，可将 `agent-compose` 替换成
+`go run ./cmd/agent-compose`。
 
 ## Compose 文件
-
-本目录包含一个最小 Docker project：
 
 ```yaml
 name: docker-minimal
@@ -53,24 +41,17 @@ agents:
       docker: {}
 ```
 
-关键配置是：
+agent 默认使用 `enabled: true`。默认 driver 也是 Docker；这里仍显式写出
+`docker: {}`，以便清楚表达 runtime 要求。
 
-```yaml
-driver:
-  docker: {}
-```
-
-如果 agent 省略 `driver`，compose normalizer 会默认使用 `docker`。
-本示例显式设置 `docker: {}`，是为了明确说明预期的 runtime。
-
-## 运行示例
+## 校验并应用
 
 在本目录执行：
 
 ```bash
 agent-compose config
 agent-compose up
-agent-compose ps
+agent-compose ls
 ```
 
 如果没有安装二进制，也可以在仓库根目录执行：
@@ -78,50 +59,23 @@ agent-compose ps
 ```bash
 go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml config
 go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml up
-go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml ps
+go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml ls
 ```
 
 预期结果：
 
-- `config` 输出标准化后的 project，并显示 `driver.name: docker`。
-- `up` 创建或更新 project 和 managed agent definition。
-- `ps` 显示 `reviewer` agent 使用 Docker 和 `agent-compose-guest:latest`。
+- `config` 标准化后输出 `enabled: true` 和 `driver.name: docker`。
+- `up` 创建或更新 project 及其 `reviewer` agent。
+- `ls` 显示该 agent 使用 Docker 和 `agent-compose-guest:latest`，scheduler 为
+  `false`。
 
-## 可选运行测试
+标准化输出示例：
 
-启动一次 runtime session，并在运行结束后保留 session：
-
-```bash
-agent-compose run reviewer --keep-running --prompt "hello from docker minimal example"
-```
-
-真正执行 agent 需要 guest runtime 可用，并且 provider 已完成认证。对于
-`provider: codex`，需要先在 guest 环境中配置 Codex 凭据或 API key。
-
-如果 runtime session 仍在运行，可以在其中执行命令：
-
-```bash
-agent-compose exec --agent reviewer -- pwd
-agent-compose exec --agent reviewer -- env
-```
-
-清理正在运行的 project sessions：
-
-```bash
-agent-compose down
-```
-
-## 验证输出
-
-以下为一次本地验证运行的输出。
-
-### 1. 配置标准化
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml config
+```yaml
 name: docker-minimal
 agents:
     - name: reviewer
+      enabled: true
       provider: codex
       image: agent-compose-guest:latest
       driver:
@@ -129,37 +83,40 @@ agents:
         docker: {}
 ```
 
-### 2. 应用 project
+控制面输出示例（ID 会随本地 compose 路径变化）：
 
 ```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml up
-Project: docker-minimal
-ID: project-docker-minimal-ad604c8bf8d3
-Revision: 1
-Spec: sha256:45c9bab1e2c12ad3e26c2168ae87bbf92fdf9933ba62258b44de00813ff106ce
-Status: applied
-Agents: 1
-Schedulers: 0
+$ agent-compose up
+ID            NAME            TYPE     ACTION
+<project-id>  docker-minimal  project  created
+<agent-id>    reviewer        agent    created
 
-ACTION   TYPE              NAME                                                                     ID
-created  project           docker-minimal                                                           project-docker-minimal-ad604c8bf8d3
-created  project_revision  sha256:45c9bab1e2c12ad3e26c2168ae87bbf92fdf9933ba62258b44de00813ff106ce  project-docker-minimal-ad604c8bf8d3/1
-created  project_agent     reviewer                                                                 agent-reviewer-a9f84de36227
-created  agent_definition  reviewer                                                                 agent-reviewer-a9f84de36227
+$ agent-compose ls
+AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
+reviewer  codex            agent-compose-guest:latest  docker  false
 ```
 
-### 3. Project 状态
+## 可选的真实运行
 
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-minimal/agent-compose.yml ps
-AGENT     SCHEDULER  LATEST RUN  RUN STATUS  SESSION  DRIVER  IMAGE
-reviewer  disabled   -           -           -        docker  agent-compose-guest:latest
+真正执行 agent 需要 Docker、兼容的 guest image，以及 guest 环境中可用的
+Codex 凭据或 API 访问能力：
+
+```bash
+agent-compose run reviewer --keep-running --prompt "hello from docker minimal example"
 ```
 
-### 4. Docker runtime 容器
+先列出运行中的 sandbox，再把它的 ID 作为 `exec` 的位置参数：
 
-```console
-$ docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}'
-NAMES                                                IMAGE                        STATUS
-agent-compose-8aa2625d-db67-4428-82ae-8bef1a137a2f   agent-compose-guest:latest   Up 14 seconds
+```bash
+agent-compose ps
+agent-compose exec <sandbox-id> -- pwd
+agent-compose exec <sandbox-id> -- env
+```
+
+`exec` 已不再支持旧的 agent-name 目标参数。
+
+清理 project 和仍在运行的 project sandboxes：
+
+```bash
+agent-compose down
 ```

--- a/examples/agent-compose/docker-scheduler-cron/README.md
+++ b/examples/agent-compose/docker-scheduler-cron/README.md
@@ -2,28 +2,18 @@
 
 Languages: English | [中文](README.zh-CN.md)
 
-This example shows a Docker-backed agent-compose project with a managed cron
-scheduler.
-
-It verifies the scheduler control-plane flow:
-
-- parse a cron trigger from `agent-compose.yml`
-- apply the project to the daemon
-- create a managed project scheduler and loader
-- show the scheduler as enabled
-- disable the scheduler with `agent-compose down`
-
-The example does not require a model call for `config`, `up`, `ps`, or `down`.
-The scheduled run itself still requires a working guest runtime and provider
-authentication.
+This example defines a Docker-backed agent with one managed cron trigger. It
+exercises the current project, agent, scheduler, and trigger control-plane
+model without requiring a model call.
 
 ## Prerequisites
 
-- Docker daemon is running.
-- The `agent-compose` daemon is already running.
-- The `agent-compose-guest:latest` image exists locally.
+- The `agent-compose` daemon is running.
+- Docker and `agent-compose-guest:latest` are needed only when the trigger
+  actually starts an agent sandbox.
+- A real scheduled model run requires provider authentication.
 
-From the repository root, build the guest image if needed:
+Build the guest image from the repository root if needed:
 
 ```bash
 task image:agent-compose-guest
@@ -48,22 +38,24 @@ agents:
           prompt: "Review the current project state and summarize any important changes."
 ```
 
-The trigger uses standard cron syntax. The expression below runs at the top of
-every hour:
+`0 * * * *` runs at the top of every hour. Because this trigger omits
+`timezone`, it uses the daemon's local timezone (`TZ` first, otherwise
+`/etc/localtime`). Add `timezone: UTC` or an IANA timezone such as
+`Asia/Shanghai` when the schedule must be independent of daemon placement.
 
-```yaml
-cron: "0 * * * *"
-```
+The scheduler defaults to `sandbox_policy: new` and
+`concurrency_policy: skip`; both defaults are visible in normalized config.
 
-## Run the example
+## Validate and apply
 
 From this directory:
 
 ```bash
 agent-compose config
 agent-compose up
-agent-compose ps
-agent-compose inspect project docker-scheduler-cron
+agent-compose ls
+agent-compose scheduler ls
+agent-compose inspect project
 agent-compose down
 ```
 
@@ -72,23 +64,58 @@ From the repository root without installing the binary:
 ```bash
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml config
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml up
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml ps
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml inspect project docker-scheduler-cron
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml ls
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml scheduler ls
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml inspect project
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml down
 ```
 
 Expected result:
 
-- `config` prints the trigger as `kind: cron`.
-- `up` creates `project_scheduler` and `loader` resources.
-- `ps` shows the scheduler as `enabled`.
-- `inspect project` shows `scheduler_count: 1` and `trigger_count: 1`.
-- `down` disables the managed scheduler and loader.
+- `config` prints `kind: cron`, plus the scheduler's normalized policies.
+- `up` creates the project, agent, and `hourly-review` trigger.
+- `ls` shows the agent with `SCHEDULER` set to `true`.
+- `scheduler ls` shows the registered cron trigger.
+- `inspect project` reports `scheduler_count: 1` and `trigger_count: 1`.
+- `down` removes the managed trigger, project, and agent from the daemon.
 
-## Making the trigger easier to observe
+Representative normalized scheduler output:
 
-For a local demo where you want the scheduler to fire soon, use an interval
-trigger instead of cron:
+```yaml
+      scheduler:
+        enabled: true
+        sandbox_policy: new
+        concurrency_policy: skip
+        triggers:
+            - name: hourly-review
+              kind: cron
+              cron: 0 * * * *
+              prompt: Review the current project state and summarize any important changes.
+```
+
+Representative control-plane output (IDs depend on the local compose path):
+
+```console
+$ agent-compose up
+ID            NAME                   TYPE     ACTION
+<project-id>  docker-scheduler-cron  project  created
+<agent-id>    reviewer               agent    created
+<trigger-id>  hourly-review          trigger  created
+
+$ agent-compose ls
+AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
+reviewer  codex            agent-compose-guest:latest  docker  true
+
+$ agent-compose down
+ID            NAME                   TYPE     ACTION   MESSAGE
+<trigger-id>  hourly-review          trigger  removed  disabled by project down
+<project-id>  docker-scheduler-cron  project  removed  removed by project down
+<agent-id>    reviewer               agent    removed
+```
+
+## Make the trigger easier to observe
+
+For short local feedback, replace the cron trigger with an interval trigger:
 
 ```yaml
 scheduler:
@@ -99,100 +126,4 @@ scheduler:
       prompt: "Say hello from the interval trigger."
 ```
 
-Use cron when you want calendar-based scheduling. Use interval when you want
-short local feedback while testing.
-
-## Verification output
-
-Output from a local verification run.
-
-### 1. Config normalization
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml config
-name: docker-scheduler-cron
-agents:
-    - name: reviewer
-      provider: codex
-      image: agent-compose-guest:latest
-      driver:
-        name: docker
-        docker: {}
-      scheduler:
-        enabled: true
-        triggers:
-            - name: hourly-review
-              kind: cron
-              cron: 0 * * * *
-              prompt: Review the current project state and summarize any important changes.
-```
-
-### 2. Apply project
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml up
-Project: docker-scheduler-cron
-ID: project-docker-scheduler-cron-034aaf526f91
-Revision: 1
-Spec: sha256:609b72e32d33488851496faefccbe2e3487cf2247e5218dd5cde9ae31d57e964
-Status: applied
-Agents: 1
-Schedulers: 1
-
-ACTION   TYPE               NAME                                                                     ID
-created  project            docker-scheduler-cron                                                    project-docker-scheduler-cron-034aaf526f91
-created  project_revision   sha256:609b72e32d33488851496faefccbe2e3487cf2247e5218dd5cde9ae31d57e964  project-docker-scheduler-cron-034aaf526f91/1
-created  project_agent      reviewer                                                                 agent-reviewer-4bff2fb6372a
-created  agent_definition   reviewer                                                                 agent-reviewer-4bff2fb6372a
-created  project_scheduler  reviewer                                                                 scheduler-reviewer-default-ed0b5bed0daa
-created  loader             docker-scheduler-cron/reviewer scheduler                                 loader-reviewer-default-ed0b5bed0daa
-```
-
-### 3. Scheduler status
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml ps
-AGENT     SCHEDULER  LATEST RUN  RUN STATUS  SESSION  DRIVER  IMAGE
-reviewer  enabled    -           -           -        docker  agent-compose-guest:latest
-```
-
-### 4. Inspect project
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml inspect project docker-scheduler-cron
-{
-  "project": {
-    "id": "project-docker-scheduler-cron-034aaf526f91",
-    "name": "docker-scheduler-cron",
-    "current_revision": 1,
-    "agent_count": 1,
-    "scheduler_count": 1
-  },
-  "agents": [
-    {
-      "agent_name": "reviewer",
-      "provider": "codex",
-      "image": "agent-compose-guest:latest",
-      "driver": "docker",
-      "scheduler_enabled": true
-    }
-  ],
-  "schedulers": [
-    { "agent_name": "reviewer", "enabled": true, "trigger_count": 1 }
-  ]
-}
-```
-
-### 5. Disable scheduler
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml down
-Project: docker-scheduler-cron
-ID: project-docker-scheduler-cron-034aaf526f91
-Status: down
-Failed session stops: 0
-
-ACTION   TYPE               NAME      ID                                       MESSAGE
-updated  project_scheduler  reviewer  scheduler-reviewer-default-ed0b5bed0daa  disabled by project down
-updated  loader             reviewer  loader-reviewer-default-ed0b5bed0daa     disabled by project down
-```
+Use cron for calendar-based schedules and interval for elapsed-time schedules.

--- a/examples/agent-compose/docker-scheduler-cron/README.zh-CN.md
+++ b/examples/agent-compose/docker-scheduler-cron/README.zh-CN.md
@@ -2,27 +2,17 @@
 
 语言：[English](README.md) | 中文
 
-本示例展示一个使用 Docker runtime 的 agent-compose project，并为它配置
-managed cron scheduler。
-
-它验证 scheduler 控制面流程：
-
-- 从 `agent-compose.yml` 解析 cron trigger
-- 将 project 应用到 daemon
-- 创建 managed project scheduler 和 loader
-- 确认 scheduler 处于 enabled 状态
-- 使用 `agent-compose down` 禁用 scheduler
-
-本示例的 `config`、`up`、`ps` 和 `down` 不要求真实调用模型。真正的定时
-运行仍然需要 guest runtime 可用，并且 provider 已完成认证。
+本示例为一个 Docker-backed agent 定义 managed cron trigger。它验证当前的
+project、agent、scheduler 和 trigger 控制面模型，不要求真实调用模型。
 
 ## 前置条件
 
-- Docker daemon 正在运行。
-- `agent-compose` daemon 已经启动。
-- 本地存在 `agent-compose-guest:latest` 镜像。
+- `agent-compose` daemon 正在运行。
+- 只有 trigger 真正启动 agent sandbox 时才需要 Docker 和
+  `agent-compose-guest:latest`。
+- 真正执行 scheduled model run 需要 provider 认证。
 
-如果还没有 guest image，可以在仓库根目录构建：
+如有需要，可在仓库根目录构建 guest image：
 
 ```bash
 task image:agent-compose-guest
@@ -47,21 +37,24 @@ agents:
           prompt: "Review the current project state and summarize any important changes."
 ```
 
-trigger 使用标准 cron 语法。下面的表达式表示每小时整点运行：
+`0 * * * *` 表示每小时整点运行。该 trigger 没有设置 `timezone`，因此使用
+daemon 本地时区（优先读取 `TZ`，否则使用 `/etc/localtime`）。如果调度时间不应
+随 daemon 部署位置变化，请添加 `timezone: UTC` 或 `Asia/Shanghai` 等 IANA
+时区。
 
-```yaml
-cron: "0 * * * *"
-```
+scheduler 默认使用 `sandbox_policy: new` 和 `concurrency_policy: skip`；
+标准化后的 config 会显示这两个默认值。
 
-## 运行示例
+## 校验并应用
 
 在本目录执行：
 
 ```bash
 agent-compose config
 agent-compose up
-agent-compose ps
-agent-compose inspect project docker-scheduler-cron
+agent-compose ls
+agent-compose scheduler ls
+agent-compose inspect project
 agent-compose down
 ```
 
@@ -70,22 +63,58 @@ agent-compose down
 ```bash
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml config
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml up
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml ps
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml inspect project docker-scheduler-cron
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml ls
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml scheduler ls
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml inspect project
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml down
 ```
 
 预期结果：
 
-- `config` 显示 trigger 为 `kind: cron`。
-- `up` 创建 `project_scheduler` 和 `loader` 资源。
-- `ps` 显示 scheduler 为 `enabled`。
+- `config` 显示 `kind: cron` 和 scheduler 标准化后的策略。
+- `up` 创建 project、agent 和 `hourly-review` trigger。
+- `ls` 显示该 agent 的 `SCHEDULER` 为 `true`。
+- `scheduler ls` 显示注册的 cron trigger。
 - `inspect project` 显示 `scheduler_count: 1` 和 `trigger_count: 1`。
-- `down` 禁用 managed scheduler 和 loader。
+- `down` 从 daemon 移除 managed trigger、project 和 agent。
 
-## 更容易观察触发的方法
+标准化后的 scheduler 输出示例：
 
-如果本地演示时希望 scheduler 很快触发，可以使用 interval trigger 替代 cron：
+```yaml
+      scheduler:
+        enabled: true
+        sandbox_policy: new
+        concurrency_policy: skip
+        triggers:
+            - name: hourly-review
+              kind: cron
+              cron: 0 * * * *
+              prompt: Review the current project state and summarize any important changes.
+```
+
+控制面输出示例（ID 会随本地 compose 路径变化）：
+
+```console
+$ agent-compose up
+ID            NAME                   TYPE     ACTION
+<project-id>  docker-scheduler-cron  project  created
+<agent-id>    reviewer               agent    created
+<trigger-id>  hourly-review          trigger  created
+
+$ agent-compose ls
+AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
+reviewer  codex            agent-compose-guest:latest  docker  true
+
+$ agent-compose down
+ID            NAME                   TYPE     ACTION   MESSAGE
+<trigger-id>  hourly-review          trigger  removed  disabled by project down
+<project-id>  docker-scheduler-cron  project  removed  removed by project down
+<agent-id>    reviewer               agent    removed
+```
+
+## 更容易观察 trigger
+
+如需在本地快速观察，可将 cron trigger 替换为 interval trigger：
 
 ```yaml
 scheduler:
@@ -96,99 +125,4 @@ scheduler:
       prompt: "Say hello from the interval trigger."
 ```
 
-需要基于日历时间调度时使用 cron；需要本地快速反馈时使用 interval。
-
-## 验证输出
-
-以下为一次本地验证运行的输出。
-
-### 1. 配置标准化
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml config
-name: docker-scheduler-cron
-agents:
-    - name: reviewer
-      provider: codex
-      image: agent-compose-guest:latest
-      driver:
-        name: docker
-        docker: {}
-      scheduler:
-        enabled: true
-        triggers:
-            - name: hourly-review
-              kind: cron
-              cron: 0 * * * *
-              prompt: Review the current project state and summarize any important changes.
-```
-
-### 2. 应用 project
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml up
-Project: docker-scheduler-cron
-ID: project-docker-scheduler-cron-034aaf526f91
-Revision: 1
-Spec: sha256:609b72e32d33488851496faefccbe2e3487cf2247e5218dd5cde9ae31d57e964
-Status: applied
-Agents: 1
-Schedulers: 1
-
-ACTION   TYPE               NAME                                                                     ID
-created  project            docker-scheduler-cron                                                    project-docker-scheduler-cron-034aaf526f91
-created  project_revision   sha256:609b72e32d33488851496faefccbe2e3487cf2247e5218dd5cde9ae31d57e964  project-docker-scheduler-cron-034aaf526f91/1
-created  project_agent      reviewer                                                                 agent-reviewer-4bff2fb6372a
-created  agent_definition   reviewer                                                                 agent-reviewer-4bff2fb6372a
-created  project_scheduler  reviewer                                                                 scheduler-reviewer-default-ed0b5bed0daa
-created  loader             docker-scheduler-cron/reviewer scheduler                                 loader-reviewer-default-ed0b5bed0daa
-```
-
-### 3. Scheduler 状态
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml ps
-AGENT     SCHEDULER  LATEST RUN  RUN STATUS  SESSION  DRIVER  IMAGE
-reviewer  enabled    -           -           -        docker  agent-compose-guest:latest
-```
-
-### 4. 查看 project
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml inspect project docker-scheduler-cron
-{
-  "project": {
-    "id": "project-docker-scheduler-cron-034aaf526f91",
-    "name": "docker-scheduler-cron",
-    "current_revision": 1,
-    "agent_count": 1,
-    "scheduler_count": 1
-  },
-  "agents": [
-    {
-      "agent_name": "reviewer",
-      "provider": "codex",
-      "image": "agent-compose-guest:latest",
-      "driver": "docker",
-      "scheduler_enabled": true
-    }
-  ],
-  "schedulers": [
-    { "agent_name": "reviewer", "enabled": true, "trigger_count": 1 }
-  ]
-}
-```
-
-### 5. 禁用 scheduler
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-cron/agent-compose.yml down
-Project: docker-scheduler-cron
-ID: project-docker-scheduler-cron-034aaf526f91
-Status: down
-Failed session stops: 0
-
-ACTION   TYPE               NAME      ID                                       MESSAGE
-updated  project_scheduler  reviewer  scheduler-reviewer-default-ed0b5bed0daa  disabled by project down
-updated  loader             reviewer  loader-reviewer-default-ed0b5bed0daa     disabled by project down
-```
+需要基于日历时间调度时使用 cron；需要基于经过时长调度时使用 interval。

--- a/examples/agent-compose/docker-scheduler-script-url/README.md
+++ b/examples/agent-compose/docker-scheduler-script-url/README.md
@@ -19,14 +19,19 @@ snapshot to the daemon. The daemon does not refresh the URL at runtime.
 ```bash
 agent-compose config
 agent-compose up
-agent-compose ps
+agent-compose ls
+agent-compose scheduler ls
+agent-compose scheduler invoke reviewer --payload '{"source":"example"}'
 agent-compose down
 ```
 
 `config` prints the fetched script inline. `up` fetches it once more, hashes the
-content snapshot, and sends only script text to the daemon. Editing
-`scheduler.js` takes effect on the next `up`. The relative path is resolved from
-the directory containing `agent-compose.yml`.
+content snapshot, and sends only script text to the daemon. `ls` shows the
+managed agent and scheduler, while `scheduler ls` shows the registered
+`daily-review` trigger. `scheduler invoke` calls the script's `main(payload)`
+entrypoint without waiting for the cron trigger. Editing `scheduler.js` takes
+effect on the next `up`. The relative path is resolved from the directory
+containing `agent-compose.yml`.
 
 The control-plane commands do not require provider authentication. A scheduled
 run does require a working guest runtime and provider credentials.

--- a/examples/agent-compose/docker-scheduler-script-url/README.zh-CN.md
+++ b/examples/agent-compose/docker-scheduler-script-url/README.zh-CN.md
@@ -19,12 +19,16 @@ daemon；daemon 不会在运行时刷新这个 URL。
 ```bash
 agent-compose config
 agent-compose up
-agent-compose ps
+agent-compose ls
+agent-compose scheduler ls
+agent-compose scheduler invoke reviewer --payload '{"source":"example"}'
 agent-compose down
 ```
 
 `config` 会把获取到的脚本以内联形式输出。`up` 再获取一次，基于内容快照计算
-hash，并且只把脚本文本发送给 daemon。修改 `scheduler.js` 后需再次执行 `up`
+hash，并且只把脚本文本发送给 daemon。`ls` 显示 managed agent 和 scheduler，
+`scheduler ls` 显示注册的 `daily-review` trigger；`scheduler invoke` 无需等待 cron，
+可直接调用脚本的 `main(payload)` 入口。修改 `scheduler.js` 后需再次执行 `up`
 才会生效。相对路径以 `agent-compose.yml` 所在目录为基准。
 
 控制面命令不要求 provider 凭证；实际定时运行仍需要可用的 guest runtime 和

--- a/examples/agent-compose/docker-scheduler-timeout/README.md
+++ b/examples/agent-compose/docker-scheduler-timeout/README.md
@@ -2,27 +2,21 @@
 
 Languages: English | [中文](README.zh-CN.md)
 
-This example runs an end-to-end scheduled agent flow with the Docker runtime.
+This example runs a one-shot timeout trigger through the Docker runtime. It
+shows both layers of the current run model:
 
-It verifies that agent-compose can:
-
-- parse a timeout trigger from `agent-compose.yml`
-- apply the project to the daemon
-- create a managed scheduler and loader
-- let the scheduler fire automatically
-- start a Docker-backed agent runtime session
-- run the configured agent prompt
-- persist the successful project run and logs
-- disable the scheduler with `agent-compose down`
+- the outer scheduler trigger run, queried with `scheduler runs`, `scheduler
+  inspect`, and `scheduler logs`;
+- the inner agent run created by the trigger, whose transcript is queried with
+  the ordinary `logs` command.
 
 ## Prerequisites
 
-- Docker daemon is running.
-- The `agent-compose` daemon is already running.
-- The `agent-compose-guest:latest` image exists locally.
-- The guest image has working Codex credentials or API access.
+- The `agent-compose` daemon and Docker daemon are running.
+- `agent-compose-guest:latest` exists locally.
+- The guest has working Codex credentials or API access.
 
-From the repository root, build the guest image if needed:
+Build the guest image from the repository root if needed:
 
 ```bash
 task image:agent-compose-guest
@@ -47,8 +41,8 @@ agents:
           prompt: "Reply with exactly: timeout scheduler ok"
 ```
 
-The `timeout: 15s` trigger is intentionally short so the full flow can be
-tested quickly.
+The timeout is intentionally short. The scheduler defaults to
+`sandbox_policy: new` and `concurrency_policy: skip`.
 
 ## Run the example
 
@@ -57,55 +51,50 @@ From this directory:
 ```bash
 agent-compose config
 agent-compose up
+agent-compose ls
 sleep 35
-agent-compose ps
-agent-compose inspect run <run-id>
-agent-compose logs --run <run-id>
+agent-compose scheduler runs reviewer --limit 1
+agent-compose scheduler inspect <scheduler-run-id>
+agent-compose scheduler logs <scheduler-run-id>
+agent-compose logs reviewer
+agent-compose ps --all
 agent-compose down
 ```
 
-From the repository root without installing the binary:
+From the repository root without installing the binary, add the compose file to
+each command, for example:
 
 ```bash
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml config
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml up
-sleep 35
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml ps
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml inspect run <run-id>
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run <run-id>
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml scheduler runs reviewer --limit 1
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml scheduler inspect <scheduler-run-id>
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs reviewer
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml down
 ```
 
-Replace `<run-id>` with the run id shown in the `ps` output.
+Replace `<scheduler-run-id>` with the outer run ID printed by `scheduler runs`.
 
 Expected result:
 
-- `config` prints the trigger as `kind: timeout`.
-- `up` creates or updates the managed scheduler and loader.
-- After the timeout fires once, `ps` shows a scheduler-created run.
-- `inspect run <run-id>` shows `source: scheduler`, `status: succeeded`, `driver: docker`, and output from the agent.
-- `logs --run <run-id>` prints the agent output.
-- `down` disables the managed scheduler and loader.
+- `config` prints `kind: timeout` and the normalized scheduler policies.
+- `up` creates the project, agent, and timeout trigger.
+- `ls` shows the agent's scheduler as `true`.
+- `scheduler runs` reports one terminal outer run after the timeout fires.
+- `scheduler inspect` shows its trigger, status, result, and sandbox IDs.
+- `scheduler logs` shows outer structured scheduler events; it intentionally
+  does not contain the inner agent transcript.
+- `logs reviewer` prints the inner project-run transcript, including
+  `timeout scheduler ok` after a successful provider call.
+- `ps --all` lists the sandbox lifecycle state rather than the agent list.
+- `down` stops owned sandboxes and removes the managed project resources.
 
-## Verification output
+Representative normalized scheduler output:
 
-Output from a local verification run. The run id below is from that run; yours
-will differ.
-
-### 1. Config normalization
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml config
-name: docker-scheduler-timeout
-agents:
-    - name: reviewer
-      provider: codex
-      image: agent-compose-guest:latest
-      driver:
-        name: docker
-        docker: {}
+```yaml
       scheduler:
         enabled: true
+        sandbox_policy: new
+        concurrency_policy: skip
         triggers:
             - name: run-once-after-15-seconds
               kind: timeout
@@ -113,73 +102,21 @@ agents:
               prompt: 'Reply with exactly: timeout scheduler ok'
 ```
 
-### 2. Apply project
+Representative control-plane output before the timeout fires (IDs depend on
+the local compose path):
 
 ```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml up
-Project: docker-scheduler-timeout
-ID: project-docker-scheduler-timeout-3a00cafbae27
-Revision: 1
-Spec: sha256:3b8a286e2cf7df774375a5eeeef1a87f9fad75921bde212e539a15c9081b196f
-Status: applied
-Agents: 1
-Schedulers: 1
+$ agent-compose up
+ID            NAME                       TYPE     ACTION
+<project-id>  docker-scheduler-timeout   project  created
+<agent-id>    reviewer                   agent    created
+<trigger-id>  run-once-after-15-seconds  trigger  created
 
-ACTION   TYPE               NAME                                                                     ID
-created  project            docker-scheduler-timeout                                                 project-docker-scheduler-timeout-3a00cafbae27
-created  project_revision   sha256:3b8a286e2cf7df774375a5eeeef1a87f9fad75921bde212e539a15c9081b196f  project-docker-scheduler-timeout-3a00cafbae27/1
-created  project_agent      reviewer                                                                 agent-reviewer-a0befcb745b8
-created  agent_definition   reviewer                                                                 agent-reviewer-a0befcb745b8
-created  project_scheduler  reviewer                                                                 scheduler-reviewer-default-181247660dc1
-created  loader             docker-scheduler-timeout/reviewer scheduler                              loader-reviewer-default-181247660dc1
+$ agent-compose ls
+AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
+reviewer  codex            agent-compose-guest:latest  docker  true
 ```
 
-### 3. Successful scheduled run
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml ps
-AGENT     SCHEDULER  LATEST RUN                 RUN STATUS  SESSION  DRIVER  IMAGE
-reviewer  enabled    run-reviewer-28c0ef985c8d  succeeded   -        docker  agent-compose-guest:latest
-```
-
-### 4. Inspect successful run
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml inspect run run-reviewer-28c0ef985c8d
-{
-  "run_id": "run-reviewer-28c0ef985c8d",
-  "project_name": "docker-scheduler-timeout",
-  "agent_name": "reviewer",
-  "source": "scheduler",
-  "status": "succeeded",
-  "session_id": "23a1ede4-3325-470d-99db-377e3296e7a2",
-  "exit_code": 0,
-  "duration_ms": 10917,
-  "prompt": "Reply with exactly: timeout scheduler ok",
-  "output": "timeout scheduler ok",
-  "result_json": "{\"agent\":\"codex\",\"exitCode\":0,\"stopReason\":\"completed\",\"success\":true}",
-  "driver": "docker",
-  "image_ref": "agent-compose-guest:latest"
-}
-```
-
-### 5. Run logs
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run run-reviewer-28c0ef985c8d
-timeout scheduler ok
-```
-
-### 6. Disable scheduler
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml down
-Project: docker-scheduler-timeout
-ID: project-docker-scheduler-timeout-3a00cafbae27
-Status: down
-Failed session stops: 0
-
-ACTION   TYPE               NAME      ID                                       MESSAGE
-updated  project_scheduler  reviewer  scheduler-reviewer-default-181247660dc1  disabled by project down
-updated  loader             reviewer  loader-reviewer-default-181247660dc1     disabled by project down
-```
+If the outer scheduler run succeeds but the expected transcript is missing,
+inspect the inner agent run through `logs reviewer`; outer scheduler logs and
+inner provider output are intentionally separate streams.

--- a/examples/agent-compose/docker-scheduler-timeout/README.zh-CN.md
+++ b/examples/agent-compose/docker-scheduler-timeout/README.zh-CN.md
@@ -2,27 +2,20 @@
 
 语言：[English](README.md) | 中文
 
-本示例使用 Docker runtime 跑通一个端到端的 scheduled agent 流程。
+本示例通过 Docker runtime 执行一次性 timeout trigger，并展示当前 run 模型的
+两个层次：
 
-它验证 agent-compose 可以完成：
-
-- 从 `agent-compose.yml` 解析 timeout trigger
-- 将 project 应用到 daemon
-- 创建 managed scheduler 和 loader
-- 由 scheduler 自动触发运行
-- 启动 Docker-backed agent runtime session
-- 执行配置的 agent prompt
-- 持久化成功的 project run 和日志
-- 使用 `agent-compose down` 禁用 scheduler
+- 外层 scheduler trigger run，使用 `scheduler runs`、`scheduler inspect` 和
+  `scheduler logs` 查询；
+- trigger 创建的内层 agent run，使用普通 `logs` 命令查询 transcript。
 
 ## 前置条件
 
-- Docker daemon 正在运行。
-- `agent-compose` daemon 已经启动。
-- 本地存在 `agent-compose-guest:latest` 镜像。
-- guest image 中已经配置可用的 Codex 凭据或 API 访问能力。
+- `agent-compose` daemon 和 Docker daemon 正在运行。
+- 本地存在 `agent-compose-guest:latest`。
+- guest 中已配置可用的 Codex 凭据或 API 访问能力。
 
-如果还没有 guest image，可以在仓库根目录构建：
+如有需要，可在仓库根目录构建 guest image：
 
 ```bash
 task image:agent-compose-guest
@@ -47,7 +40,8 @@ agents:
           prompt: "Reply with exactly: timeout scheduler ok"
 ```
 
-`timeout: 15s` 刻意设置得较短，方便快速验证完整流程。
+timeout 刻意设置得较短。scheduler 默认使用 `sandbox_policy: new` 和
+`concurrency_policy: skip`。
 
 ## 运行示例
 
@@ -56,54 +50,49 @@ agents:
 ```bash
 agent-compose config
 agent-compose up
+agent-compose ls
 sleep 35
-agent-compose ps
-agent-compose inspect run <run-id>
-agent-compose logs --run <run-id>
+agent-compose scheduler runs reviewer --limit 1
+agent-compose scheduler inspect <scheduler-run-id>
+agent-compose scheduler logs <scheduler-run-id>
+agent-compose logs reviewer
+agent-compose ps --all
 agent-compose down
 ```
 
-如果没有安装二进制，也可以在仓库根目录执行：
+如果没有安装二进制，可在仓库根目录为每条命令添加 compose 文件，例如：
 
 ```bash
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml config
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml up
-sleep 35
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml ps
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml inspect run <run-id>
-go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run <run-id>
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml scheduler runs reviewer --limit 1
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml scheduler inspect <scheduler-run-id>
+go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs reviewer
 go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml down
 ```
 
-将 `<run-id>` 替换为上一步 `ps` 输出中显示的 run id。
+将 `<scheduler-run-id>` 替换为 `scheduler runs` 输出的外层 run ID。
 
 预期结果：
 
-- `config` 显示 trigger 为 `kind: timeout`。
-- `up` 创建或更新 managed scheduler 和 loader。
-- 等待 timeout 触发一次后，`ps` 显示 scheduler 创建的 run。
-- `inspect run <run-id>` 显示 `source: scheduler`、`status: succeeded`、`driver: docker`，并包含 agent 输出。
-- `logs --run <run-id>` 输出 agent 日志。
-- `down` 禁用 managed scheduler 和 loader。
+- `config` 显示 `kind: timeout` 和标准化后的 scheduler 策略。
+- `up` 创建 project、agent 和 timeout trigger。
+- `ls` 显示该 agent 的 scheduler 为 `true`。
+- timeout 触发后，`scheduler runs` 显示一个已结束的外层 run。
+- `scheduler inspect` 显示其 trigger、状态、结果和 sandbox IDs。
+- `scheduler logs` 显示外层 scheduler 结构化事件；它不会包含内层 agent
+  transcript。
+- provider 调用成功后，`logs reviewer` 输出内层 project-run transcript，其中
+  包含 `timeout scheduler ok`。
+- `ps --all` 列出 sandbox 生命周期状态，而不是 agent 列表。
+- `down` 停止归属该 project 的 sandboxes，并移除 managed project resources。
 
-## 验证输出
+标准化后的 scheduler 输出示例：
 
-以下为一次本地验证运行的输出。其中的 run id 来自该次运行，你本地的会不同。
-
-### 1. 配置标准化
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml config
-name: docker-scheduler-timeout
-agents:
-    - name: reviewer
-      provider: codex
-      image: agent-compose-guest:latest
-      driver:
-        name: docker
-        docker: {}
+```yaml
       scheduler:
         enabled: true
+        sandbox_policy: new
+        concurrency_policy: skip
         triggers:
             - name: run-once-after-15-seconds
               kind: timeout
@@ -111,73 +100,20 @@ agents:
               prompt: 'Reply with exactly: timeout scheduler ok'
 ```
 
-### 2. 应用 project
+timeout 触发前的控制面输出示例（ID 会随本地 compose 路径变化）：
 
 ```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml up
-Project: docker-scheduler-timeout
-ID: project-docker-scheduler-timeout-3a00cafbae27
-Revision: 1
-Spec: sha256:3b8a286e2cf7df774375a5eeeef1a87f9fad75921bde212e539a15c9081b196f
-Status: applied
-Agents: 1
-Schedulers: 1
+$ agent-compose up
+ID            NAME                       TYPE     ACTION
+<project-id>  docker-scheduler-timeout   project  created
+<agent-id>    reviewer                   agent    created
+<trigger-id>  run-once-after-15-seconds  trigger  created
 
-ACTION   TYPE               NAME                                                                     ID
-created  project            docker-scheduler-timeout                                                 project-docker-scheduler-timeout-3a00cafbae27
-created  project_revision   sha256:3b8a286e2cf7df774375a5eeeef1a87f9fad75921bde212e539a15c9081b196f  project-docker-scheduler-timeout-3a00cafbae27/1
-created  project_agent      reviewer                                                                 agent-reviewer-a0befcb745b8
-created  agent_definition   reviewer                                                                 agent-reviewer-a0befcb745b8
-created  project_scheduler  reviewer                                                                 scheduler-reviewer-default-181247660dc1
-created  loader             docker-scheduler-timeout/reviewer scheduler                              loader-reviewer-default-181247660dc1
+$ agent-compose ls
+AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
+reviewer  codex            agent-compose-guest:latest  docker  true
 ```
 
-### 3. 成功的 scheduled run
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml ps
-AGENT     SCHEDULER  LATEST RUN                 RUN STATUS  SESSION  DRIVER  IMAGE
-reviewer  enabled    run-reviewer-28c0ef985c8d  succeeded   -        docker  agent-compose-guest:latest
-```
-
-### 4. 查看成功 run
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml inspect run run-reviewer-28c0ef985c8d
-{
-  "run_id": "run-reviewer-28c0ef985c8d",
-  "project_name": "docker-scheduler-timeout",
-  "agent_name": "reviewer",
-  "source": "scheduler",
-  "status": "succeeded",
-  "session_id": "23a1ede4-3325-470d-99db-377e3296e7a2",
-  "exit_code": 0,
-  "duration_ms": 10917,
-  "prompt": "Reply with exactly: timeout scheduler ok",
-  "output": "timeout scheduler ok",
-  "result_json": "{\"agent\":\"codex\",\"exitCode\":0,\"stopReason\":\"completed\",\"success\":true}",
-  "driver": "docker",
-  "image_ref": "agent-compose-guest:latest"
-}
-```
-
-### 5. Run 日志
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml logs --run run-reviewer-28c0ef985c8d
-timeout scheduler ok
-```
-
-### 6. 禁用 scheduler
-
-```console
-$ go run ./cmd/agent-compose --file examples/agent-compose/docker-scheduler-timeout/agent-compose.yml down
-Project: docker-scheduler-timeout
-ID: project-docker-scheduler-timeout-3a00cafbae27
-Status: down
-Failed session stops: 0
-
-ACTION   TYPE               NAME      ID                                       MESSAGE
-updated  project_scheduler  reviewer  scheduler-reviewer-default-181247660dc1  disabled by project down
-updated  loader             reviewer  loader-reviewer-default-181247660dc1     disabled by project down
-```
+如果外层 scheduler run 成功但看不到预期 transcript，请通过 `logs reviewer`
+检查内层 agent run；外层 scheduler logs 与内层 provider 输出本来就是两条独立
+日志流。

--- a/examples/scheduler-script/README.md
+++ b/examples/scheduler-script/README.md
@@ -1,12 +1,12 @@
-# Loader 脚本模板
+# Scheduler 脚本模板
 
-这个目录放的是 agent-compose Loader 的可复制脚本模板。Loader 脚本运行在 `scheduler` runtime 里，不需要 `import` 或 `require`；宿主会在全局注入 `scheduler` 对象和兼容的 timer 函数。
+这个目录放的是 agent-compose Scheduler 的可复制脚本模板。脚本运行在 `scheduler` runtime 里，不需要 `import` 或 `require`；宿主会在全局注入 `scheduler` 对象和兼容的 timer 函数。
 
 ## 编写建议
 
 - 顶层代码尽量只做函数定义和触发器注册。
 - 真实工作放在 `main(payload)` 或共享 helper 函数里。
-- 返回值必须能被 JSON 序列化，成功运行后会写入 `resultJson`。
+- 返回值必须能被 JSON 序列化，成功运行后会写入 scheduler run 的 `result_json`。
 - 每个触发器都写显式、稳定的 `triggerId`。
 - 需要长期暂停触发器时，用 UI 或 API 禁用触发器。`scheduler.clearInterval(...)` 和 `scheduler.clearTimeout(...)` 只会移除当前脚本求值期间注册出来的触发器，不会持久禁用已经保存的触发器。
 
@@ -30,7 +30,7 @@ agents:
         }
 ```
 
-`scheduler.script` 和声明式 `scheduler.triggers` 是二选一关系。需要简单 cron/interval/event/timeout 加 prompt 时用 `scheduler.triggers`；需要共享状态、多个 trigger 共用 workflow、调用 `scheduler.llm` / `scheduler.exec` / `scheduler.event.publish` 等能力时用 `scheduler.script`。inline scalar 和下面的 URL object 都使用同一套 loader runtime。
+`scheduler.script` 和声明式 `scheduler.triggers` 是二选一关系。需要简单 cron/interval/event/timeout 加 prompt 时用 `scheduler.triggers`；需要共享状态、多个 trigger 共用 workflow、调用 `scheduler.llm` / `scheduler.exec` / `scheduler.event.publish` 等能力时用 `scheduler.script`。inline scalar 和下面的 URL object 都使用同一套 scheduler runtime。
 
 脚本也可以保存在独立文件中，并通过显式 URL 对象引用：
 
@@ -45,12 +45,12 @@ agents:
 无 scheme 的相对路径以 compose 文件目录为基准；也支持绝对路径、`file://`、
 `http://` 和 `https://`。这是 CLI authoring 能力：`agent-compose config` 和
 `agent-compose up` 在本机获取一次并生成内联内容快照，daemon、v2 API、revision
-和 loader 只看到脚本文本。它不是运行时 `import`，来源内容变化只会在下次
+和 scheduler 只看到脚本文本。它不是运行时 `import`，来源内容变化只会在下次
 `up` 时生效。当前仍不支持 `import` / `require`、bundling、鉴权 header 或后台刷新。
 
 ## 触发器 ID
 
-`triggerId` 是一个 Loader 内某条触发规则的稳定名字，不是浏览器 timer handle。agent-compose 会用它持久化调度状态、在 UI 展示触发器行、启停单个触发器、把手动运行路由到指定触发器，并把运行记录和事件记录关联回对应规则。
+`triggerId` 是一个 Scheduler 内某条触发规则的稳定名字，不是浏览器 timer handle。agent-compose 会用它持久化调度状态、在 UI 展示触发器行、启停单个触发器、把手动运行路由到指定触发器，并把运行记录和事件记录关联回对应规则。
 
 推荐写法：
 
@@ -113,7 +113,7 @@ scheduler.schedule(triggerId, expression, callback, options);
 
 手动运行时，agent-compose 会优先调用全局 `main(payload)`。如果没有 `main()` 且脚本只注册了一个触发器，则会调用这个触发器的 callback；如果有多个触发器，必须显式选择触发器或定义 `main()`。
 
-- 手动运行的 `payload` 来自 `RunLoaderNow.payloadJson`。
+- 手动运行的 `payload` 来自 `agent-compose scheduler invoke <scheduler> --payload '<json>'`；对应 API 字段为 `InvokeSchedulerRequest.payload_json`。
 - `scheduler.on(...)` handler 收到事件 envelope：`{ topic, createdAt, payload }`。
 - interval、timeout、cron handler 默认收到 `undefined`，除非你在脚本里自己转发自定义上下文。
 
@@ -144,7 +144,7 @@ const reply = scheduler.agent(prompt, {
   agent: "codex",
   sandboxPolicy: "sticky", // "sticky" | "new" | "reuse"
   timeout: "10m",
-  title: "Loader Agent Sandbox",
+  title: "Scheduler Agent Sandbox",
   driver: "boxlite",
   guestImage: "agent-compose-guest:latest",
   workspaceId: "workspace-id",
@@ -185,7 +185,7 @@ const result = scheduler.llm(prompt, {
 
 ## 命令执行
 
-`scheduler.exec(...)` 和 `scheduler.shell(...)` 会在 Loader 关联的 notebook runtime 里执行命令。
+`scheduler.exec(...)` 和 `scheduler.shell(...)` 会在 Scheduler 关联的 notebook runtime 里执行命令。
 
 ```js
 const result = scheduler.exec({
@@ -196,7 +196,7 @@ const result = scheduler.exec({
   timeoutMs: 30000,
   maxOutputBytes: 4096,
   sandboxPolicy: "new",
-  title: "Loader Command Sandbox",
+  title: "Scheduler Command Sandbox",
   driver: "boxlite",
   guestImage: "agent-compose-guest:latest",
   workspaceId: "workspace-id",
@@ -276,7 +276,7 @@ scheduler.z.object({ key: schema });
 `scheduler.sandbox` 暴露 sandbox lifecycle unary RPC，参数和返回值使用 sandbox JSON shape。
 
 ```js
-const created = scheduler.sandbox.createSandbox({ title: "Loader Sandbox" });
+const created = scheduler.sandbox.createSandbox({ title: "Scheduler Sandbox" });
 const sandboxId = created.sandbox.summary.sandboxId;
 
 const current = scheduler.sandbox.getSandbox({ sandboxId });
@@ -298,7 +298,7 @@ scheduler.runtime.name; // "scheduler"
 
 ## 校验阶段限制
 
-保存或校验 Loader 时，脚本会被求值以收集触发器。此时不要在顶层调用会执行副作用的 host API。
+保存或校验 Scheduler 时，脚本会被求值以收集触发器。此时不要在顶层调用会执行副作用的 host API。
 
 - `scheduler.agent`、`scheduler.llm`、`scheduler.exec`、`scheduler.shell`、`scheduler.event.publish`、`scheduler.sandbox.*` 在校验阶段不可用。
 - `scheduler.log` 在校验阶段是 no-op。
@@ -308,9 +308,9 @@ scheduler.runtime.name; // "scheduler"
 
 ## 目录文件
 
-- `01-manual-main.js`：最小手动运行 Loader，并返回可追踪结果。
+- `01-manual-main.js`：最小手动运行 Scheduler，并返回可追踪结果。
 - `02-interval-heartbeat.js`：带持久状态的 interval 任务，也支持手动重跑。
-- `03-event-to-agent.js`：事件驱动 Loader，把事件交给 agent 处理。
+- `03-event-to-agent.js`：事件驱动 Scheduler，把事件交给 agent 处理。
 - `04-cron-daily-summary.js`：定时 agent 任务，并记录最近运行状态。
 - `05-router-with-multiple-triggers.js`：多个触发器共享一个 workflow 的推荐结构。
 - `06-conditional-triggers.js`：按条件注册或清除 interval/timeout 触发器。


### PR DESCRIPTION
## Summary

- Align the English and Chinese example guides with the current CLI and control-plane model. The old walkthroughs still treated `ps` as the agent list, used obsolete `exec --agent` and run inspection forms, and described managed schedulers with loader-era resource names and output.
- Update scheduler examples to use `scheduler ls/runs/inspect/logs/invoke`, distinguish outer scheduler runs from inner agent runs, document normalized scheduler defaults and daemon-local cron timezone behavior, and replace path-derived fixed IDs with stable placeholders.
- Add an examples contract test that normalizes all four compose examples, validates all six standalone QJS scheduler scripts, checks scheduler defaults and bilingual README coverage, and rejects known stale CLI/API strings.

## Testing

- `GOFLAGS=-buildvcs=false go test ./cmd/agent-compose -run '^TestExampleFilesContract$' -count=1`
- `GOFLAGS=-buildvcs=false task lint GO_BUILD_CACHE_DIR="$GOCACHE" GOLANGCI_LINT_CACHE_DIR="$GOLANGCI_LINT_CACHE"`
- `GOFLAGS=-buildvcs=false task build GO_BUILD_CACHE_DIR="$GOCACHE"`
- `GOFLAGS=-buildvcs=false task test GO_BUILD_CACHE_DIR="$GOCACHE"`
  - Passed through the short logical worktree path `/tmp/ac-examples-wt` to avoid the host Unix socket path-length limit.
  - Coverage: Unit 74.97%, Integration 60.72%, E2E 60.17%, Combined 79.14%.
- `task docs:build`
- `git diff --check`
- Validated all four compose examples with the current `config` command.
- Validated an isolated daemon flow with `up`, `ls`, `inspect`, and `down`, plus real `scheduler ls` and `scheduler invoke reviewer --payload ...` control-plane calls.

Real external provider/model execution was not run; the scheduler invocation validation covered the daemon and scheduler control-plane path without relying on third-party credentials.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
