### PR TITLE
feat(installer): accept explicit image references

### DIFF
--- a/cmd/installer/command.go
+++ b/cmd/installer/command.go
@@ -35,8 +35,7 @@ func newRootCommand(out, errOut io.Writer) *cobra.Command {
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			options.PortSet = cmd.Flags().Changed("port")
-			options.WithUISet = cmd.Flags().Changed("with-ui")
+			markExplicitOptions(cmd, options)
 			if options.legacyUpgrade || options.yes || hasInstallerFlags(cmd) {
 				operation := core.OperationInstall
 				if options.legacyUpgrade {
@@ -64,10 +63,14 @@ func newRootCommand(out, errOut io.Writer) *cobra.Command {
 	flags.BoolVar(&options.SkipGuestPull, "skip-guest-pull", false, "do not pre-pull the sandbox guest image")
 	flags.StringVar(&options.Version, "version", options.Version, "application release version")
 	flags.StringVar(&options.ImagePrefix, "image-prefix", "", "image registry prefix")
+	flags.StringVar(&options.BackendImage, "backend-image", "", "complete backend image reference")
+	flags.StringVar(&options.FrontendImage, "frontend-image", "", "complete frontend image reference")
+	flags.StringVar(&options.GuestImage, "guest-image", "", "complete sandbox guest image reference")
 	flags.BoolVar(&options.NoStart, "no-start", false, "prepare files without starting services")
 	flags.BoolVarP(&options.yes, "yes", "y", options.yes, "skip confirmation prompts")
 	flags.BoolVar(&options.legacyUpgrade, "upgrade", false, "upgrade an existing installation (legacy form)")
 	_ = flags.MarkHidden("upgrade")
+	_ = flags.MarkDeprecated("image-prefix", "use --backend-image, --frontend-image, and --guest-image instead")
 
 	root.AddCommand(newOperationCommand(core.OperationInstall, options, out, errOut))
 	root.AddCommand(newOperationCommand(core.OperationUpgrade, options, out, errOut))
@@ -92,11 +95,18 @@ func newOperationCommand(operation core.Operation, options *commandOptions, out,
 		Short: strings.ToUpper(string(operation[:1])) + string(operation[1:]) + " agent-compose",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			options.PortSet = cmd.Flags().Changed("port")
-			options.WithUISet = cmd.Flags().Changed("with-ui")
+			markExplicitOptions(cmd, options)
 			return executeOperation(cmd.Context(), operation, options, out, errOut)
 		},
 	}
+}
+
+func markExplicitOptions(cmd *cobra.Command, options *commandOptions) {
+	options.PortSet = cmd.Flags().Changed("port")
+	options.WithUISet = cmd.Flags().Changed("with-ui")
+	options.BackendImageSet = cmd.Flags().Changed("backend-image")
+	options.FrontendImageSet = cmd.Flags().Changed("frontend-image")
+	options.GuestImageSet = cmd.Flags().Changed("guest-image")
 }
 
 func executeOperation(ctx context.Context, operation core.Operation, options *commandOptions, out, errOut io.Writer) error {
@@ -202,7 +212,7 @@ func writeResult(out io.Writer, operation core.Operation, result core.Result, pu
 }
 
 func hasInstallerFlags(cmd *cobra.Command) bool {
-	for _, name := range []string{"dir", "port", "version", "image-prefix", "no-start", "yes", "with-ui", "skip-guest-pull"} {
+	for _, name := range []string{"dir", "port", "version", "image-prefix", "backend-image", "frontend-image", "guest-image", "no-start", "yes", "with-ui", "skip-guest-pull"} {
 		if cmd.Flags().Changed(name) {
 			return true
 		}

--- a/cmd/installer/command_test.go
+++ b/cmd/installer/command_test.go
@@ -24,10 +24,18 @@ func TestRootHelpDocumentsOperationsAndDefaultDirectory(t *testing.T) {
 	if err := command.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	for _, expected := range []string{"install", "upgrade", "uninstall", "/opt/agent-compose"} {
+	for _, expected := range []string{"install", "upgrade", "uninstall", "/opt/agent-compose", "--backend-image", "--frontend-image", "--guest-image"} {
 		if !strings.Contains(output.String(), expected) {
 			t.Fatalf("help missing %q:\n%s", expected, output.String())
 		}
+	}
+}
+
+func TestRootRejectsExplicitEmptyImage(t *testing.T) {
+	command := newRootCommand(&bytes.Buffer{}, &bytes.Buffer{})
+	command.SetArgs([]string{"install", "--backend-image", "", "--yes"})
+	if err := command.Execute(); err == nil || !strings.Contains(err.Error(), "backend image must be a non-empty image reference") {
+		t.Fatalf("Execute error = %v", err)
 	}
 }
 

--- a/cmd/installer/internal/core/installer_e2e_test.go
+++ b/cmd/installer/internal/core/installer_e2e_test.go
@@ -27,6 +27,8 @@ func TestE2EInstallerLifecycle(t *testing.T) {
 	options.BundleDir = makeTestBundle(t, "v1")
 	options.KVMPath = filepath.Join(root, "missing-kvm")
 	options.InstallerPath = installerPath
+	options.GuestImage = "custom.example/guest:v1"
+	options.GuestImageSet = true
 
 	installed, err := service.Apply(context.Background(), OperationInstall, options)
 	if err != nil {
@@ -43,7 +45,7 @@ func TestE2EInstallerLifecycle(t *testing.T) {
 		"|docker compose version --short",
 		installDir + "|docker compose config --quiet",
 		installDir + "|docker compose pull",
-		installDir + "|docker pull registry.example/agent-compose-guest:v1",
+		installDir + "|docker pull custom.example/guest:v1",
 		installDir + "|docker compose up -d",
 	}, "\n") {
 		t.Fatalf("install calls:\n%s", strings.Join(runner.calls, "\n"))

--- a/cmd/installer/internal/core/options.go
+++ b/cmd/installer/internal/core/options.go
@@ -23,22 +23,28 @@ const (
 )
 
 type Options struct {
-	InstallDir      string
-	Repository      string
-	ReleaseBaseURL  string
-	Version         string
-	ImagePrefix     string
-	FrontendVersion string
-	Port            int
-	PortSet         bool
-	WithUI          bool
-	WithUISet       bool
-	SkipGuestPull   bool
-	NoStart         bool
-	Purge           bool
-	KVMPath         string
-	BundleDir       string
-	InstallerPath   string
+	InstallDir       string
+	Repository       string
+	ReleaseBaseURL   string
+	Version          string
+	ImagePrefix      string
+	BackendImage     string
+	BackendImageSet  bool
+	FrontendImage    string
+	FrontendImageSet bool
+	GuestImage       string
+	GuestImageSet    bool
+	FrontendVersion  string
+	Port             int
+	PortSet          bool
+	WithUI           bool
+	WithUISet        bool
+	SkipGuestPull    bool
+	NoStart          bool
+	Purge            bool
+	KVMPath          string
+	BundleDir        string
+	InstallerPath    string
 }
 
 func DefaultOptions() Options {
@@ -68,6 +74,19 @@ func (o Options) Validate(operation Operation) error {
 		}
 		if o.Port < 1 || o.Port > 65535 {
 			return fmt.Errorf("port must be between 1 and 65535")
+		}
+		for _, image := range []struct {
+			name  string
+			value string
+			set   bool
+		}{
+			{name: "backend image", value: o.BackendImage, set: o.BackendImageSet},
+			{name: "frontend image", value: o.FrontendImage, set: o.FrontendImageSet},
+			{name: "guest image", value: o.GuestImage, set: o.GuestImageSet},
+		} {
+			if image.set && (strings.TrimSpace(image.value) == "" || strings.ContainsAny(image.value, "\r\n")) {
+				return fmt.Errorf("%s must be a non-empty image reference", image.name)
+			}
 		}
 	}
 	return nil

--- a/cmd/installer/internal/core/service.go
+++ b/cmd/installer/internal/core/service.go
@@ -414,6 +414,11 @@ func ensureSecrets(env *envFile) (string, error) {
 
 func applyImageReferences(env, state, manifest *envFile, options Options, mode string) error {
 	desired := map[string]string{}
+	explicit := map[string]bool{
+		"AGENT_COMPOSE_IMAGE":          options.BackendImageSet,
+		"AGENT_COMPOSE_FRONTEND_IMAGE": options.FrontendImageSet,
+		"DEFAULT_IMAGE":                options.GuestImageSet,
+	}
 	if options.ImagePrefix != "" {
 		version := options.Version
 		if image, ok := manifest.Get("AGENT_COMPOSE_IMAGE"); ok {
@@ -436,10 +441,19 @@ func applyImageReferences(env, state, manifest *envFile, options Options, mode s
 			}
 		}
 	}
+	if options.BackendImageSet {
+		desired["AGENT_COMPOSE_IMAGE"] = strings.TrimSpace(options.BackendImage)
+	}
+	if options.FrontendImageSet {
+		desired["AGENT_COMPOSE_FRONTEND_IMAGE"] = strings.TrimSpace(options.FrontendImage)
+	}
+	if options.GuestImageSet {
+		desired["DEFAULT_IMAGE"] = strings.TrimSpace(options.GuestImage)
+	}
 	for key, value := range desired {
 		current, currentExists := env.Get(key)
 		managed, managedExists := state.Get(key)
-		shouldSet := mode == "install" || !currentExists || current == ""
+		shouldSet := explicit[key] || mode == "install" || !currentExists || current == ""
 		if mode == "upgrade" && managedExists && current == managed {
 			shouldSet = true
 		}

--- a/cmd/installer/internal/core/service_integration_test.go
+++ b/cmd/installer/internal/core/service_integration_test.go
@@ -128,6 +128,81 @@ func TestIntegrationUpgradePreservesPortUnlessExplicitlySet(t *testing.T) {
 	}
 }
 
+func TestIntegrationExplicitImagesOverrideIndependently(t *testing.T) {
+	root := t.TempDir()
+	installDir := filepath.Join(root, "install")
+	options := DefaultOptions()
+	options.InstallDir = installDir
+	options.BundleDir = makeTestBundle(t, "v1")
+	options.KVMPath = filepath.Join(root, "missing-kvm")
+	options.NoStart = true
+	options.ImagePrefix = "mirror.example/team"
+	options.FrontendImage = "frontend.example/ui:chosen"
+	options.FrontendImageSet = true
+	service := Service{Runner: &fakeRunner{}}
+
+	if _, err := service.Apply(context.Background(), OperationInstall, options); err != nil {
+		t.Fatal(err)
+	}
+	envPath := filepath.Join(installDir, ".env")
+	env := readTestEnv(t, envPath)
+	assertTestEnv(t, env, "AGENT_COMPOSE_IMAGE", "mirror.example/team/agent-compose:v1")
+	assertTestEnv(t, env, "AGENT_COMPOSE_FRONTEND_IMAGE", "frontend.example/ui:chosen")
+	assertTestEnv(t, env, "DEFAULT_IMAGE", "mirror.example/team/agent-compose-guest:v1")
+	if err := env.Set("AGENT_COMPOSE_FRONTEND_IMAGE", "operator.example/ui:keep"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envPath, env.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	options.BundleDir = makeTestBundle(t, "v2")
+	options.FrontendImage = ""
+	options.FrontendImageSet = false
+	options.BackendImage = "backend.example/daemon@sha256:abc"
+	options.BackendImageSet = true
+	options.GuestImage = "guest.example/runtime:v9"
+	options.GuestImageSet = true
+	if _, err := service.Apply(context.Background(), OperationUpgrade, options); err != nil {
+		t.Fatal(err)
+	}
+
+	upgraded := readTestEnv(t, envPath)
+	assertTestEnv(t, upgraded, "AGENT_COMPOSE_IMAGE", "backend.example/daemon@sha256:abc")
+	assertTestEnv(t, upgraded, "AGENT_COMPOSE_FRONTEND_IMAGE", "operator.example/ui:keep")
+	assertTestEnv(t, upgraded, "DEFAULT_IMAGE", "guest.example/runtime:v9")
+	state := readTestEnv(t, filepath.Join(installDir, ".installer-state.env"))
+	assertTestEnv(t, state, "AGENT_COMPOSE_IMAGE", "backend.example/daemon@sha256:abc")
+	assertTestEnv(t, state, "AGENT_COMPOSE_FRONTEND_IMAGE", "frontend.example/ui:chosen")
+	assertTestEnv(t, state, "DEFAULT_IMAGE", "guest.example/runtime:v9")
+}
+
+func TestOptionsRejectExplicitInvalidImages(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		set     func(*Options)
+		wantErr string
+	}{
+		{name: "empty backend", set: func(options *Options) { options.BackendImageSet = true }, wantErr: "backend image"},
+		{name: "newline frontend", set: func(options *Options) {
+			options.FrontendImage = "example/ui:v1\nINJECTED=value"
+			options.FrontendImageSet = true
+		}, wantErr: "frontend image"},
+		{name: "blank guest", set: func(options *Options) {
+			options.GuestImage = "  "
+			options.GuestImageSet = true
+		}, wantErr: "guest image"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			options := DefaultOptions()
+			testCase.set(&options)
+			if err := options.Validate(OperationInstall); err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("Validate error = %v", err)
+			}
+		})
+	}
+}
+
 func TestIntegrationInstallRollbackRestoresManagedFiles(t *testing.T) {
 	root := t.TempDir()
 	installDir := filepath.Join(root, "install")

--- a/cmd/installer/internal/tui/form.go
+++ b/cmd/installer/internal/tui/form.go
@@ -14,6 +14,9 @@ type fieldID int
 const (
 	fieldInstallDir fieldID = iota
 	fieldVersion
+	fieldBackendImage
+	fieldFrontendImage
+	fieldGuestImage
 	fieldWithUI
 	fieldPort
 	fieldGuestPull
@@ -46,6 +49,9 @@ func (m *model) buildFields() {
 	if m.operation != core.OperationUninstall {
 		m.fields = append(m.fields,
 			newTextField(fieldVersion, m.options.Version),
+			newTextField(fieldBackendImage, m.options.BackendImage),
+			newTextField(fieldFrontendImage, m.options.FrontendImage),
+			newTextField(fieldGuestImage, m.options.GuestImage),
 			newToggleField(fieldWithUI, m.options.WithUI),
 			newTextField(fieldPort, strconv.Itoa(m.options.Port)),
 			newToggleField(fieldGuestPull, !m.options.SkipGuestPull),
@@ -113,6 +119,15 @@ func (m *model) readFields() error {
 			m.options.InstallDir = strings.TrimSpace(field.input.Value())
 		case fieldVersion:
 			m.options.Version = strings.TrimSpace(field.input.Value())
+		case fieldBackendImage:
+			m.options.BackendImage = strings.TrimSpace(field.input.Value())
+			m.options.BackendImageSet = m.options.BackendImage != ""
+		case fieldFrontendImage:
+			m.options.FrontendImage = strings.TrimSpace(field.input.Value())
+			m.options.FrontendImageSet = m.options.FrontendImage != ""
+		case fieldGuestImage:
+			m.options.GuestImage = strings.TrimSpace(field.input.Value())
+			m.options.GuestImageSet = m.options.GuestImage != ""
 		case fieldWithUI:
 			m.options.WithUI = field.on
 			m.options.WithUISet = true
@@ -146,6 +161,12 @@ func (m *model) fieldLabel(id fieldID) string {
 		return m.text("安装目录", "Install directory")
 	case fieldVersion:
 		return m.text("应用版本", "Application version")
+	case fieldBackendImage:
+		return m.text("后端镜像（可选）", "Backend image (optional)")
+	case fieldFrontendImage:
+		return m.text("前端镜像（可选）", "Frontend image (optional)")
+	case fieldGuestImage:
+		return m.text("Guest 镜像（可选）", "Guest image (optional)")
 	case fieldWithUI:
 		return m.text("安装 Web UI", "Install web UI")
 	case fieldPort:

--- a/cmd/installer/internal/tui/model.go
+++ b/cmd/installer/internal/tui/model.go
@@ -323,11 +323,11 @@ func (m *model) renderMenu(body *strings.Builder, title string, choices []string
 func (m *model) formHeading() (string, string) {
 	switch m.operation {
 	case core.OperationUpgrade:
-		return m.text("配置升级", "Configure upgrade"), m.text("确认安装位置和要升级到的版本", "Review the installation and target version")
+		return m.text("配置升级", "Configure upgrade"), m.text("确认安装位置、目标版本和可选镜像覆盖", "Review the location, target version, and optional image overrides")
 	case core.OperationUninstall:
 		return m.text("选择安装位置", "Select installation"), m.text("指定要卸载的 agent-compose 目录", "Choose the agent-compose directory to uninstall")
 	default:
-		return m.text("配置安装", "Configure installation"), m.text("确认安装位置、发布版本、Web UI 和 guest 镜像", "Review the location, release, web UI, and guest image")
+		return m.text("配置安装", "Configure installation"), m.text("确认安装位置、发布版本、镜像和 Web UI", "Review the location, release, images, and web UI")
 	}
 }
 
@@ -338,6 +338,9 @@ func (m *model) renderConfirm(body *strings.Builder) {
 		fmt.Fprintf(body, "  %s: %t\n", m.text("删除数据", "Purge data"), m.options.Purge)
 	} else {
 		fmt.Fprintf(body, "  %s: %s\n", m.text("版本", "Version"), m.options.Version)
+		fmt.Fprintf(body, "  %s: %s\n", m.text("后端镜像", "Backend image"), m.imageSelection(m.options.BackendImageSet, m.options.BackendImage))
+		fmt.Fprintf(body, "  %s: %s\n", m.text("前端镜像", "Frontend image"), m.imageSelection(m.options.FrontendImageSet, m.options.FrontendImage))
+		fmt.Fprintf(body, "  %s: %s\n", m.text("Guest 镜像", "Guest image"), m.imageSelection(m.options.GuestImageSet, m.options.GuestImage))
 		fmt.Fprintf(body, "  %s: %s\n", m.text("安装 Web UI", "Install web UI"), m.yesNo(m.options.WithUI))
 		if m.options.WithUI {
 			fmt.Fprintf(body, "  %s: %d\n", m.text("Web UI 端口", "Web UI port"), m.options.Port)
@@ -346,6 +349,16 @@ func (m *model) renderConfirm(body *strings.Builder) {
 	}
 	body.WriteString("\n")
 	m.renderMenu(body, m.text("确认继续？", "Continue?"), []string{m.text("继续", "Continue"), m.text("返回", "Back")})
+}
+
+func (m *model) imageSelection(set bool, image string) string {
+	if set {
+		return image
+	}
+	if m.operation == core.OperationUpgrade {
+		return m.text("保留自定义值，否则使用发布默认值", "Preserve custom value, otherwise use release default")
+	}
+	return m.text("使用发布默认值", "Use release default")
 }
 
 func (m *model) renderDone(body *strings.Builder) {

--- a/cmd/installer/internal/tui/model_test.go
+++ b/cmd/installer/internal/tui/model_test.go
@@ -20,11 +20,11 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 		t.Fatalf("language screen = %q, %d", m.language, m.screen)
 	}
 	press(t, m, "enter")
-	if m.operation != core.OperationInstall || m.screen != screenForm || len(m.fields) != 5 {
+	if m.operation != core.OperationInstall || m.screen != screenForm || len(m.fields) != 8 {
 		t.Fatalf("install form = %q, %d, %d fields", m.operation, m.screen, len(m.fields))
 	}
 	form := m.View()
-	for _, expected := range []string{"Configure installation", "Install directory", "Application version", "Install web UI", "Web UI port", "Pre-pull guest image", "╭", "Tab / ↑↓ move"} {
+	for _, expected := range []string{"Configure installation", "Install directory", "Application version", "Backend image (optional)", "Frontend image (optional)", "Guest image (optional)", "Install web UI", "Web UI port", "Pre-pull guest image", "╭", "Tab / ↑↓ move"} {
 		if !strings.Contains(form, expected) {
 			t.Fatalf("install form missing %q:\n%s", expected, form)
 		}
@@ -43,13 +43,37 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 		t.Fatalf("screen = %d, want confirmation", m.screen)
 	}
 	confirmation := m.View()
-	for _, expected := range []string{"/opt/agent-compose", "latest", "Install web UI: No", "Pre-pull guest image: Yes"} {
+	for _, expected := range []string{"/opt/agent-compose", "latest", "Backend image: Use release default", "Frontend image: Use release default", "Guest image: Use release default", "Install web UI: No", "Pre-pull guest image: Yes"} {
 		if !strings.Contains(confirmation, expected) {
 			t.Fatalf("confirmation missing %q:\n%s", expected, confirmation)
 		}
 	}
 	if strings.Contains(confirmation, "Web UI port") {
 		t.Fatalf("confirmation offered a port without the web UI:\n%s", confirmation)
+	}
+}
+
+func TestModelReadsExplicitImageOverrides(t *testing.T) {
+	m := installForm(t)
+	m.field(fieldBackendImage).input.SetValue(" registry.example/backend:v1 ")
+	m.field(fieldFrontendImage).input.SetValue("registry.example/frontend@sha256:abc")
+	m.field(fieldGuestImage).input.SetValue("registry.example/guest:v2")
+
+	press(t, m, "enter")
+	if !m.options.BackendImageSet || m.options.BackendImage != "registry.example/backend:v1" {
+		t.Fatalf("backend image = %q, set=%t", m.options.BackendImage, m.options.BackendImageSet)
+	}
+	if !m.options.FrontendImageSet || m.options.FrontendImage != "registry.example/frontend@sha256:abc" {
+		t.Fatalf("frontend image = %q, set=%t", m.options.FrontendImage, m.options.FrontendImageSet)
+	}
+	if !m.options.GuestImageSet || m.options.GuestImage != "registry.example/guest:v2" {
+		t.Fatalf("guest image = %q, set=%t", m.options.GuestImage, m.options.GuestImageSet)
+	}
+	confirmation := m.View()
+	for _, image := range []string{m.options.BackendImage, m.options.FrontendImage, m.options.GuestImage} {
+		if !strings.Contains(confirmation, image) {
+			t.Fatalf("confirmation missing %q:\n%s", image, confirmation)
+		}
 	}
 }
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,13 +34,15 @@ The bootstrap forwards all arguments to the downloaded binary:
 curl -fsSL https://github.com/chaitin/agent-compose/releases/download/installer-latest/install.sh | \
   sudo bash -s -- install --yes
 
-# Select a release, directory, UI port, or image mirror.
+# Select a release, directory, UI port, or complete image references.
 sudo /opt/agent-compose/installer install \
   --version v1.2.3 \
   --dir /srv/agent-compose \
   --with-ui \
   --port 8080 \
-  --image-prefix registry.example.com/agent-compose \
+  --backend-image registry.example.com/team/agent-compose:v1.2.3 \
+  --frontend-image registry.example.com/team/agent-compose-ui:v1.2.3 \
+  --guest-image registry.example.com/team/agent-compose-guest:v1.2.3 \
   --yes
 
 # Skip the guest image pre-pull; the first sandbox downloads it instead.
@@ -54,8 +56,10 @@ sudo /opt/agent-compose/installer install --no-start --yes
 ```
 
 The legacy top-level form, including `--upgrade`, `--dir`, `--version`,
-`--image-prefix`, `--no-start`, and `--yes`, remains accepted. New automation
-should use the explicit `install`, `upgrade`, and `uninstall` subcommands.
+`--image-prefix`, `--no-start`, and `--yes`, remains accepted. `--image-prefix`
+is deprecated; use the three complete image options when selecting a mirror or
+custom image. New automation should use the explicit `install`, `upgrade`, and
+`uninstall` subcommands.
 
 Environment overrides retained for automation are:
 
@@ -86,6 +90,16 @@ On first installation the installer generates `AUTH_SECRET` and an `admin`
 password. The password is printed once and stored in `.env`. Existing settings
 are preserved. During upgrade, image references advance only when their current
 value still matches `.installer-state.env`; user overrides are never replaced.
+
+The interactive form and non-interactive CLI can independently override the
+backend (`--backend-image`), frontend (`--frontend-image`), and sandbox guest
+(`--guest-image`) image with a complete tag or digest reference. An explicit
+image always replaces that one value and becomes installer-managed, including
+during upgrade. Images omitted from the command retain the normal upgrade
+protection above. If the deprecated `--image-prefix` is combined with complete
+image options, the complete option wins for its image and the prefix supplies
+the omitted images. Without either form of override, the Docker Hub references
+from the selected Release bundle are used.
 
 New installations persist `AGENT_COMPOSE_DATA_DIR=./data`. If an older database
 exists only under `./data/agent-compose`, that path is retained. When databases


### PR DESCRIPTION
## Summary

- add independent `--backend-image`, `--frontend-image`, and `--guest-image` overrides to the installer CLI and TUI
- make explicit image references take precedence during install and upgrade while preserving unmanaged values for omitted images
- retain deprecated `--image-prefix` compatibility and document the migration path

## Testing

- `go -C cmd/installer test ./...`
- `task test:deploy`
- `task lint`
- `task build`
- `task test`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.