### PR TITLE
fix(ci): decouple image tags from releases

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,7 +22,7 @@ on:
     branches:
       - main
     tags:
-      - "v*"
+      - "*"
   workflow_dispatch:
 
 permissions:
@@ -348,11 +348,11 @@ jobs:
             --image ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ steps.meta.outputs.version }} \
             --platforms ${{ matrix.platforms }}
 
-  # Publish the installer assets. The stack pulls its multi-arch images from the
-  # registry at install time, so no per-arch binary artifacts are shipped here.
+  # Arbitrary tags stop after publishing images. Only version tags publish the
+  # installer assets and create a GitHub Release.
   release:
     name: Publish GitHub release
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     needs:
       - merge
     runs-on: ubuntu-latest

--- a/docs/pages/guest-image-abi.md
+++ b/docs/pages/guest-image-abi.md
@@ -315,9 +315,10 @@ task image:agent-compose-guest-archlinux
 ```
 
 Image CI builds this variant on pull requests and publishes it as
-`chaitin/agent-compose-guest-archlinux` on Docker Hub on pushes to `main` and version
-tags. It follows the default images' branch, version, SHA, and release `latest`
-tagging policy, but its manifest contains only `linux/amd64`. The upstream
+`chaitin/agent-compose-guest-archlinux` on Docker Hub on pushes to `main` and any
+Git tag. It follows the default images' branch, Git tag, and SHA policy, while
+only `v*` release tags also update `latest`; its manifest contains only
+`linux/amd64`. The upstream
 `library/archlinux` image used by the build is x86_64-only; a team that supplies
 its own compatible Arch Linux base for another architecture must build and
 validate that variant independently. The Arch Linux guest is not the deployment

--- a/docs/pages/zh-CN/guest-image-abi.md
+++ b/docs/pages/zh-CN/guest-image-abi.md
@@ -216,7 +216,7 @@ ARCHLINUX_TAG=<pinned-tag> \
 task image:agent-compose-guest-archlinux
 ```
 
-镜像 CI 会在 pull request 中构建该变体，并在推送到 `main` 或版本 tag 时将其发布到 Docker Hub 的 `chaitin/agent-compose-guest-archlinux`。它沿用默认镜像的分支、版本、SHA 和 release `latest` tag 策略，但 manifest 仅包含 `linux/amd64`。默认构建使用的上游 `library/archlinux` 镜像仅支持 x86_64；如果团队为其他架构提供了兼容的 Arch Linux base，必须单独构建并验证该变体。Arch Linux guest 不是部署默认镜像，使用时需要在 agent spec 中显式选择，并在投入使用前执行第 10 节中的验证。
+镜像 CI 会在 pull request 中构建该变体，并在推送到 `main` 或任意 Git tag 时将其发布到 Docker Hub 的 `chaitin/agent-compose-guest-archlinux`。它沿用默认镜像的分支、Git tag 和 SHA 策略，只有 `v*` release tag 会同时更新 `latest`；manifest 仅包含 `linux/amd64`。默认构建使用的上游 `library/archlinux` 镜像仅支持 x86_64；如果团队为其他架构提供了兼容的 Arch Linux base，必须单独构建并验证该变体。Arch Linux guest 不是部署默认镜像，使用时需要在 agent spec 中显式选择，并在投入使用前执行第 10 节中的验证。
 
 ## 7. 推荐构建方式：继承官方 Guest
 

--- a/scripts/tests/test-image-ci-contract.sh
+++ b/scripts/tests/test-image-ci-contract.sh
@@ -97,6 +97,10 @@ require_regex "$header" '^[[:space:]]*-[[:space:]]*docker-compose\.kvm\.yml[[:sp
 require_regex "$header" 'REGISTRY:[[:space:]]*docker\.io' 'Docker Hub registry'
 require_regex "$header" 'IMAGE_PREFIX:[[:space:]]*chaitin' 'Docker Hub chaitin namespace'
 forbid_regex "$header" 'ghcr\.io' 'GHCR registry configuration'
+require_regex "$header" '^[[:space:]]*-[[:space:]]*"\*"[[:space:]]*$' \
+  'all-tag image publication trigger'
+forbid_regex "$header" '^[[:space:]]*-[[:space:]]*"v\*"[[:space:]]*$' \
+  'version-only image publication trigger'
 
 load_job setup setup_job
 load_job build build_job
@@ -321,6 +325,9 @@ if [[ -n $merge_job ]]; then
   require_regex "$merge_job" 'platforms:[[:space:]]*linux/amd64[[:space:]]*$' \
     'Arch Linux guest amd64-only manifest entry'
   require_regex "$merge_job" 'docker buildx imagetools create' 'multi-arch manifest creation'
+  require_regex "$merge_job" 'type=ref,event=tag' 'pushed Git tag image metadata'
+  require_regex "$merge_job" "type=raw,value=latest,enable=\\$\\{\\{[[:space:]]*startsWith\\(github\\.ref,[[:space:]]*['\"]refs/tags/v['\"]\\)[[:space:]]*\\}\\}" \
+    'version-tag-only latest image metadata'
   require_regex "$merge_job" 'username:[[:space:]]*\$\{\{[[:space:]]*secrets\.DOCKERIO_USERNAME' \
     'manifest Docker Hub username secret'
   require_regex "$merge_job" 'password:[[:space:]]*\$\{\{[[:space:]]*secrets\.DOCKERIO_PASSWORD' \
@@ -342,8 +349,8 @@ if [[ -n $merge_job ]]; then
 fi
 
 if [[ -n $release_job ]]; then
-  require_regex "$release_job" "if:[[:space:]]*github\\.ref_type[[:space:]]*==[[:space:]]*[\"']tag[\"']" \
-    'tag-only release guard'
+  require_regex "$release_job" "if:.*github\\.ref_type[[:space:]]*==[[:space:]]*['\"]tag['\"].*startsWith\\(github\\.ref_name,[[:space:]]*['\"]v['\"]\\)" \
+    'version-tag-only release guard'
   require_regex "$release_job" '\./scripts/build-installer-assets\.sh[[:space:]]+\./upload' \
     'shared installer asset builder in release job'
   require_regex "$release_job" 'gh release (upload|create).*upload/\*' \


### PR DESCRIPTION
## Summary

- publish daemon and guest Docker images for every pushed Git tag
- keep GitHub Release creation and `latest` image updates restricted to `v*` tags
- preserve the existing DingTalk notification guard so ordinary image-test tags do not notify releases
- document the tag behavior in both English and Chinese guest image manuals

## Testing

- `./scripts/tests/test-image-ci-contract.sh`
- `task test:scripts`
- `task docs:build`
- `task lint`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.