### PR TITLE
fix(ci): generate proto for storage migrator

### DIFF
--- a/.github/workflows/v2-storage-migrator.yml
+++ b/.github/workflows/v2-storage-migrator.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Install Buf
+        run: go install github.com/bufbuild/buf/cmd/buf@v1.68.1
+      - name: Generate Protobuf sources
+        run: buf generate
       - name: Test V2 storage migrator
         run: go test ./cmd/agent-compose-migrate/...
       - name: Build linux/amd64 and linux/arm64 assets

--- a/scripts/tests/test-v2-storage-migrator-ci-contract.sh
+++ b/scripts/tests/test-v2-storage-migrator-ci-contract.sh
@@ -20,6 +20,8 @@ if grep -Eq '^[[:space:]]*(push|pull_request|schedule):' <<<"$workflow_source"; 
 fi
 grep -Eq '^[[:space:]]*contents:[[:space:]]+write[[:space:]]*$' <<<"$workflow_source" || fail 'contents write permission is missing'
 grep -Eq '^[[:space:]]*release_tag:' <<<"$workflow_source" || fail 'release tag input is missing'
+grep -Fq 'go install github.com/bufbuild/buf/cmd/buf@v1.68.1' <<<"$workflow_source" || fail 'pinned Buf installation is missing'
+grep -Fq 'run: buf generate' <<<"$workflow_source" || fail 'protobuf source generation is missing'
 grep -Fq 'go test ./cmd/agent-compose-migrate/...' <<<"$workflow_source" || fail 'focused migrator tests are missing'
 grep -Fq './scripts/build-v2-storage-migrator-binaries.sh ./upload-v2-storage-migrator' <<<"$workflow_source" || fail 'shared binary builder is not used'
 grep -Fq 'gh release upload' <<<"$workflow_source" || fail 'existing release upload is missing'


### PR DESCRIPTION
## Problem

The one-time V2 storage migrator workflow runs `go test` immediately after checkout, but generated protobuf Go sources are intentionally ignored. On a clean runner this leaves `proto/agentcompose/v2` without non-test Go files and the publish job fails before building assets.

## Solution

- install the repository-pinned Buf version in the migrator workflow
- generate protobuf sources before testing and building
- extend the workflow contract test to prevent regression

## Tests

- `./scripts/tests/test-v2-storage-migrator-ci-contract.sh`
- `buf generate`
- `go test ./cmd/agent-compose-migrate/...`
- `git diff --check`

## Checklist

- [x] Focused regression coverage added
- [x] No public documentation changes required