### PR TITLE
ci(images): publish Arch Linux guest as variant tag

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -160,7 +160,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}/agent-compose-guest-archlinux
+          images: ${{ env.IMAGE_PREFIX }}/agent-compose-guest
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -176,7 +176,7 @@ jobs:
           file: guest-images/Dockerfile.agent-compose-guest-archlinux
           platforms: linux/amd64
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/agent-compose-guest-archlinux,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/agent-compose-guest,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           build-args: |
             REGISTRY_MIRROR=${{ env.REGISTRY_MIRROR }}
             GOPROXY=${{ env.GOPROXY }}
@@ -239,7 +239,7 @@ jobs:
           file: guest-images/Dockerfile.agent-compose-guest-archlinux
           platforms: linux/amd64
           load: true
-          tags: agent-compose-guest-archlinux:image-smoke
+          tags: agent-compose-guest:archlinux-image-smoke
           build-args: |
             REGISTRY_MIRROR=${{ env.REGISTRY_MIRROR }}
             GOPROXY=${{ env.GOPROXY }}
@@ -274,14 +274,14 @@ jobs:
       - name: Run Arch Linux guest no-KVM Docker lifecycle smoke
         env:
           AGENT_COMPOSE_E2E_DAEMON_IMAGE: agent-compose:image-smoke
-          AGENT_COMPOSE_E2E_GUEST_IMAGE: agent-compose-guest-archlinux:image-smoke
+          AGENT_COMPOSE_E2E_GUEST_IMAGE: agent-compose-guest:archlinux-image-smoke
           AGENT_COMPOSE_E2E_DOCKER_SOCKET: /var/run/docker.sock
           GOCACHE: ${{ github.workspace }}/.cache/go-build
         run: ./scripts/test-image-docker-e2e.sh
 
-  # Combine each image's per-platform digests into its published manifest.
+  # Combine each image variant's per-platform digests into its published manifest.
   merge:
-    name: Merge ${{ matrix.image }} manifest
+    name: Merge ${{ matrix.artifact }} manifest
     if: github.event_name != 'pull_request'
     needs:
       - build
@@ -293,18 +293,27 @@ jobs:
       matrix:
         include:
           - image: agent-compose
+            artifact: agent-compose
             platforms: linux/amd64,linux/arm64
+            tag_suffix: ""
+            stable_tag: latest
           - image: agent-compose-guest
+            artifact: agent-compose-guest
             platforms: linux/amd64,linux/arm64
-          - image: agent-compose-guest-archlinux
+            tag_suffix: ""
+            stable_tag: latest
+          - image: agent-compose-guest
+            artifact: agent-compose-guest-archlinux
             platforms: linux/amd64
+            tag_suffix: -archlinux
+            stable_tag: archlinux
     steps:
       - uses: actions/checkout@v4
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ matrix.image }}--*
+          pattern: digests-${{ matrix.artifact }}--*
           merge-multiple: true
       - uses: docker/setup-buildx-action@v3
       - name: Docker metadata
@@ -313,10 +322,10 @@ jobs:
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=branch,suffix=${{ matrix.tag_suffix }}
+            type=ref,event=tag,suffix=${{ matrix.tag_suffix }}
+            type=sha,prefix=sha-,suffix=${{ matrix.tag_suffix }}
+            type=raw,value=${{ matrix.stable_tag }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,7 +124,7 @@ tasks:
     desc: Build the optional Arch Linux agent-compose guest image
     dir: '{{.TASKFILE_DIR}}'
     cmds:
-      - GUEST_IMAGE_DOCKERFILE=./guest-images/Dockerfile.agent-compose-guest-archlinux IMAGE_TAG='{{default "agent-compose-guest-archlinux:latest" .IMAGE_TAG}}' BUILD_PLATFORM='{{default "linux/amd64" .BUILD_PLATFORM}}' ./scripts/build-agent-compose-guest.sh
+      - GUEST_IMAGE_DOCKERFILE=./guest-images/Dockerfile.agent-compose-guest-archlinux IMAGE_TAG='{{default "agent-compose-guest:archlinux" .IMAGE_TAG}}' BUILD_PLATFORM='{{default "linux/amd64" .BUILD_PLATFORM}}' ./scripts/build-agent-compose-guest.sh
 
   lint:
     desc: Lint/format code

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -467,13 +467,13 @@ agents:
 
 At runtime, the selected driver must be able to obtain this image. When `build` is also configured, `image` becomes one of the build output tags. `agent-compose build` fails if neither `image` nor `build.tags` provides a tag.
 
-GitHub CI publishes these images to GHCR:
+GitHub CI publishes these images to Docker Hub:
 
 | Image | Purpose | Dockerfile | Platforms |
 | --- | --- | --- | --- |
 | `chaitin/agent-compose` | Control-plane daemon | `Dockerfile` | `linux/amd64`, `linux/arm64` |
 | `chaitin/agent-compose-guest` | Sandbox guest runtime | `guest-images/Dockerfile.agent-compose-guest` | `linux/amd64`, `linux/arm64` |
-| `chaitin/agent-compose-guest-archlinux` | Optional Arch Linux sandbox guest runtime | `guest-images/Dockerfile.agent-compose-guest-archlinux` | `linux/amd64` |
+| `chaitin/agent-compose-guest:archlinux` | Optional Arch Linux sandbox guest runtime | `guest-images/Dockerfile.agent-compose-guest-archlinux` | `linux/amd64` |
 
 Use either guest image for an agent's `image`. The daemon image deploys the control plane and is not a guest image. Neither guest is tied to one driver: CI does not publish separate BoxLite-only, Microsandbox-only, or other per-driver guest images.
 

--- a/docs/pages/guest-image-abi.md
+++ b/docs/pages/guest-image-abi.md
@@ -302,22 +302,23 @@ Build it locally from the repository root:
 task image:agent-compose-guest-archlinux
 ```
 
-The resulting tag is `agent-compose-guest-archlinux:latest`. The task explicitly
+The resulting tag is `agent-compose-guest:archlinux`. The task explicitly
 targets `linux/amd64`, so it also works through emulation on an Arm development
 host. Override the tag with `IMAGE_TAG`, and use `ARCHLINUX_TAG` or
 `ARCHLINUX_MIRROR` when a deployment needs a pinned base tag or another package
 mirror:
 
 ```bash
-IMAGE_TAG=registry.example.com/team/agent-compose-guest-archlinux:vX.Y.Z \
+IMAGE_TAG=registry.example.com/team/agent-compose-guest:vX.Y.Z-archlinux \
 ARCHLINUX_TAG=<pinned-tag> \
 task image:agent-compose-guest-archlinux
 ```
 
 Image CI builds this variant on pull requests and publishes it as
-`chaitin/agent-compose-guest-archlinux` on Docker Hub on pushes to `main` and any
-Git tag. It follows the default images' branch, Git tag, and SHA policy, while
-only `v*` release tags also update `latest`; its manifest contains only
+`chaitin/agent-compose-guest` on Docker Hub on pushes to `main` and any Git tag.
+Its branch, Git tag, and SHA tags use an `-archlinux` suffix, while `v*` release
+tags also update the stable `archlinux` tag. For example, release `vX.Y.Z`
+publishes both `vX.Y.Z-archlinux` and `archlinux`. Its manifest contains only
 `linux/amd64`. The upstream
 `library/archlinux` image used by the build is x86_64-only; a team that supplies
 its own compatible Arch Linux base for another architecture must build and

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -468,13 +468,13 @@ agents:
 
 运行时会确保所选 driver 能使用该镜像。若同时配置 `build`，`image` 也会加入构建 tag；若两者均未提供 tag，执行 `agent-compose build` 会失败。
 
-GitHub CI 会向 GHCR 发布以下镜像：
+GitHub CI 会向 Docker Hub 发布以下镜像：
 
 | 镜像 | 用途 | Dockerfile | 平台 |
 | --- | --- | --- | --- |
 | `chaitin/agent-compose` | 控制面 daemon | `Dockerfile` | `linux/amd64`、`linux/arm64` |
 | `chaitin/agent-compose-guest` | Sandbox guest runtime | `guest-images/Dockerfile.agent-compose-guest` | `linux/amd64`、`linux/arm64` |
-| `chaitin/agent-compose-guest-archlinux` | 可选的 Arch Linux sandbox guest runtime | `guest-images/Dockerfile.agent-compose-guest-archlinux` | `linux/amd64` |
+| `chaitin/agent-compose-guest:archlinux` | 可选的 Arch Linux sandbox guest runtime | `guest-images/Dockerfile.agent-compose-guest-archlinux` | `linux/amd64` |
 
 Agent 的 `image` 可以使用任一 guest 镜像。daemon 镜像用于部署控制面，不能作为 guest 镜像使用。两个 guest 都不绑定某一个 driver；CI 不发布 BoxLite-only、Microsandbox-only 或其他 driver 专用 guest 镜像。
 

--- a/docs/pages/zh-CN/guest-image-abi.md
+++ b/docs/pages/zh-CN/guest-image-abi.md
@@ -208,15 +208,15 @@ daemon 会自行使用配置的 port、root directory、base URL 和 token 启�
 task image:agent-compose-guest-archlinux
 ```
 
-生成的 tag 为 `agent-compose-guest-archlinux:latest`。该 task 会显式构建 `linux/amd64`，因此也可以在 Arm 开发主机上通过模拟执行。可通过 `IMAGE_TAG` 覆盖 tag；如果部署需要固定 base tag 或使用其他软件包镜像，可设置 `ARCHLINUX_TAG` 或 `ARCHLINUX_MIRROR`：
+生成的 tag 为 `agent-compose-guest:archlinux`。该 task 会显式构建 `linux/amd64`，因此也可以在 Arm 开发主机上通过模拟执行。可通过 `IMAGE_TAG` 覆盖 tag；如果部署需要固定 base tag 或使用其他软件包镜像，可设置 `ARCHLINUX_TAG` 或 `ARCHLINUX_MIRROR`：
 
 ```bash
-IMAGE_TAG=registry.example.com/team/agent-compose-guest-archlinux:vX.Y.Z \
+IMAGE_TAG=registry.example.com/team/agent-compose-guest:vX.Y.Z-archlinux \
 ARCHLINUX_TAG=<pinned-tag> \
 task image:agent-compose-guest-archlinux
 ```
 
-镜像 CI 会在 pull request 中构建该变体，并在推送到 `main` 或任意 Git tag 时将其发布到 Docker Hub 的 `chaitin/agent-compose-guest-archlinux`。它沿用默认镜像的分支、Git tag 和 SHA 策略，只有 `v*` release tag 会同时更新 `latest`；manifest 仅包含 `linux/amd64`。默认构建使用的上游 `library/archlinux` 镜像仅支持 x86_64；如果团队为其他架构提供了兼容的 Arch Linux base，必须单独构建并验证该变体。Arch Linux guest 不是部署默认镜像，使用时需要在 agent spec 中显式选择，并在投入使用前执行第 10 节中的验证。
+镜像 CI 会在 pull request 中构建该变体，并在推送到 `main` 或任意 Git tag 时将其发布到 Docker Hub 的 `chaitin/agent-compose-guest`。它的分支、Git tag 和 SHA tag 使用 `-archlinux` 后缀，`v*` release tag 还会更新稳定 tag `archlinux`。例如，release `vX.Y.Z` 会同时发布 `vX.Y.Z-archlinux` 和 `archlinux`。manifest 仅包含 `linux/amd64`。默认构建使用的上游 `library/archlinux` 镜像仅支持 x86_64；如果团队为其他架构提供了兼容的 Arch Linux base，必须单独构建并验证该变体。Arch Linux guest 不是部署默认镜像，使用时需要在 agent spec 中显式选择，并在投入使用前执行第 10 节中的验证。
 
 ## 7. 推荐构建方式：继承官方 Guest
 

--- a/scripts/tests/test-image-ci-contract.sh
+++ b/scripts/tests/test-image-ci-contract.sh
@@ -226,8 +226,12 @@ if [[ -n $archlinux_build_job ]]; then
     'Arch Linux guest amd64 publication platform'
   forbid_regex "$archlinux_build_job" 'linux/arm64' \
     'Arch Linux guest arm64 publication platform'
-  require_regex "$archlinux_build_job" 'IMAGE_PREFIX[^[:space:]]*\}?/agent-compose-guest-archlinux|IMAGE_PREFIX.*agent-compose-guest-archlinux' \
-    'Arch Linux guest registry image name'
+  require_regex "$archlinux_build_job" 'images:[[:space:]]*\$\{\{[[:space:]]*env\.IMAGE_PREFIX[[:space:]]*\}\}/agent-compose-guest[[:space:]]*$' \
+    'Arch Linux guest shared registry repository'
+  require_regex "$archlinux_build_job" 'outputs:.*name=\$\{\{[[:space:]]*env\.IMAGE_PREFIX[[:space:]]*\}\}/agent-compose-guest,' \
+    'Arch Linux guest shared digest repository'
+  forbid_regex "$archlinux_build_job" 'images:.*agent-compose-guest-archlinux|outputs:.*name=.*agent-compose-guest-archlinux' \
+    'standalone Arch Linux guest registry repository'
   require_regex "$archlinux_build_job" 'push-by-digest=true' \
     'Arch Linux guest push-by-digest output'
   require_regex "$archlinux_build_job" 'name-canonical=true' \
@@ -285,7 +289,7 @@ if [[ -n $image_smoke_job ]]; then
     'image-smoke explicit daemon reference'
   require_regex "$image_smoke_job" 'agent-compose-guest:[[:alnum:]_.${}{}/-]*smoke|smoke[[:alnum:]_.${}{}/-]*agent-compose-guest' \
     'image-smoke explicit guest reference'
-  require_regex "$image_smoke_job" 'agent-compose-guest-archlinux:[[:alnum:]_.${}{}/-]*smoke' \
+  require_regex "$image_smoke_job" 'agent-compose-guest:archlinux-[[:alnum:]_.${}{}/-]*smoke' \
     'image-smoke explicit Arch Linux guest reference'
   require_regex "$image_smoke_job" '(\./)?scripts/verify-agent-compose-image\.sh' \
     'image-smoke daemon image verifier'
@@ -318,16 +322,24 @@ if [[ -n $merge_job ]]; then
     'daemon manifest matrix entry'
   require_regex "$merge_job" '^[[:space:]]*-[[:space:]]*image:[[:space:]]*agent-compose-guest[[:space:]]*$' \
     'default guest manifest matrix entry'
-  require_regex "$merge_job" 'image:[[:space:]]*agent-compose-guest-archlinux' \
-    'Arch Linux guest manifest matrix entry'
+  guest_manifest_count=$(grep -Ec '^[[:space:]]*-[[:space:]]*image:[[:space:]]*agent-compose-guest[[:space:]]*$' <<<"$merge_job" || true)
+  [[ $guest_manifest_count -eq 2 ]] \
+    || fail "merge job has $guest_manifest_count guest manifest entries, expected default and Arch Linux variants"
+  require_regex "$merge_job" 'artifact:[[:space:]]*agent-compose-guest-archlinux' \
+    'Arch Linux guest digest artifact matrix entry'
+  require_regex "$merge_job" 'tag_suffix:[[:space:]]*-archlinux' \
+    'Arch Linux guest variant tag suffix'
+  require_regex "$merge_job" 'stable_tag:[[:space:]]*archlinux' \
+    'Arch Linux guest stable tag'
   require_regex "$merge_job" 'platforms:[[:space:]]*linux/amd64,linux/arm64' \
     'default image multi-architecture manifest entries'
   require_regex "$merge_job" 'platforms:[[:space:]]*linux/amd64[[:space:]]*$' \
     'Arch Linux guest amd64-only manifest entry'
   require_regex "$merge_job" 'docker buildx imagetools create' 'multi-arch manifest creation'
-  require_regex "$merge_job" 'type=ref,event=tag' 'pushed Git tag image metadata'
-  require_regex "$merge_job" "type=raw,value=latest,enable=\\$\\{\\{[[:space:]]*startsWith\\(github\\.ref,[[:space:]]*['\"]refs/tags/v['\"]\\)[[:space:]]*\\}\\}" \
-    'version-tag-only latest image metadata'
+  require_regex "$merge_job" 'type=ref,event=tag,suffix=\$\{\{[[:space:]]*matrix\.tag_suffix' \
+    'variant-aware pushed Git tag image metadata'
+  require_regex "$merge_job" "type=raw,value=\\$\\{\\{[[:space:]]*matrix\.stable_tag[[:space:]]*\\}\\},enable=\\$\\{\\{[[:space:]]*startsWith\\(github\\.ref,[[:space:]]*['\"]refs/tags/v['\"]\\)[[:space:]]*\\}\\}" \
+    'version-tag-only stable image metadata'
   require_regex "$merge_job" 'username:[[:space:]]*\$\{\{[[:space:]]*secrets\.DOCKERIO_USERNAME' \
     'manifest Docker Hub username secret'
   require_regex "$merge_job" 'password:[[:space:]]*\$\{\{[[:space:]]*secrets\.DOCKERIO_PASSWORD' \
@@ -377,7 +389,7 @@ if [[ -f $TASKFILE ]]; then
     'Arch Linux guest image task'
   require_regex "$taskfile_source" 'GUEST_IMAGE_DOCKERFILE=.*Dockerfile\.agent-compose-guest-archlinux' \
     'Arch Linux guest Dockerfile selection in task'
-  require_regex "$taskfile_source" 'agent-compose-guest-archlinux:latest' \
+  require_regex "$taskfile_source" 'agent-compose-guest:archlinux' \
     'Arch Linux guest default local tag'
   require_regex "$taskfile_source" 'BUILD_PLATFORM=.*linux/amd64' \
     'Arch Linux guest amd64 build platform'


### PR DESCRIPTION
## Summary

- publish the optional Arch Linux guest in the shared `chaitin/agent-compose-guest` Docker Hub repository
- expose `archlinux` as the stable variant tag and suffix branch, release, and SHA tags with `-archlinux`
- update the local build default, image CI contract checks, and English/Chinese documentation

## Testing

- `./scripts/tests/test-image-ci-contract.sh`
- `task --dry image:agent-compose-guest-archlinux`
- YAML parse of `.github/workflows/images.yml` and `Taskfile.yml`
- `task lint`
- `task build`
- `task --force docs:build`
- `task test` (all `test:scripts` checks passed; deployment checks could not complete on macOS because the required GNU `sha256sum` and `readelf` tools are unavailable)
- `./scripts/test-coverage.sh` (stopped in the unchanged `pkg/compose` `TestNormalizeCronTimezone`: macOS accepts lowercase `asia/shanghai` on its case-insensitive zoneinfo filesystem)

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.