### PR TITLE
fix(runs): finalize runs after sandbox cleanup

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -94,6 +94,19 @@ it before creating and validating a date-partitioned sandbox of its own.
 This focused task is intentionally absent from `task test` and GitHub Actions
 because GitHub-hosted CI does not provide its prebuilt guest-image prerequisite.
 
+Interrupted run cleanup has an opt-in hard-restart Docker E2E:
+
+```bash
+task image:agent-compose-guest
+task test:e2e:docker-run-completion-recovery
+```
+
+Set `AGENT_COMPOSE_E2E_RUN_COMPLETION_IMAGE` to use another compatible local
+guest image. The test starts a long-running command through the public API,
+hard-kills the host daemon, restarts it against the same data root, and verifies
+that the interrupted run becomes `FAILED` only after its Docker sandbox no
+longer consumes active compute resources.
+
 The daemon retention cleanup has a separate opt-in real Docker E2E:
 
 ```bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -243,6 +243,22 @@ tasks:
           GOCACHE={{.GO_BUILD_CACHE_DIR}} \
           {{.GO_TOOLCHAIN_ENV}} go test ./test/e2e -run '^TestE2EDockerFileWorkspaceResumePreservesState$' -count=1 -v
 
+  test:e2e:docker-run-completion-recovery:
+    desc: Run the opt-in host-daemon Docker hard-restart run completion E2E test
+    dir: '{{.TASKFILE_DIR}}'
+    deps: ['build:agent-compose']
+    cmds:
+      - |
+        image="${AGENT_COMPOSE_E2E_RUN_COMPLETION_IMAGE:-agent-compose-guest:latest}"
+        if ! docker image inspect "$image" >/dev/null 2>&1; then
+          echo "Docker run-completion image $image is unavailable; run 'task image:agent-compose-guest' or set AGENT_COMPOSE_E2E_RUN_COMPLETION_IMAGE" >&2
+          exit 1
+        fi
+        AGENT_COMPOSE_E2E_BINARY="$PWD/build/agent-compose" \
+          AGENT_COMPOSE_E2E_RUN_COMPLETION_IMAGE="$image" \
+          GOCACHE={{.GO_BUILD_CACHE_DIR}} \
+          {{.GO_TOOLCHAIN_ENV}} go test ./test/e2e -run '^TestE2EDockerRunCompletionRecoversAfterDaemonHardKill$' -count=1 -v
+
   test:e2e:docker-retention:
     desc: Run the opt-in host-daemon Docker retention cleanup E2E test
     dir: '{{.TASKFILE_DIR}}'

--- a/cmd/agent-compose-migrate/main_test.go
+++ b/cmd/agent-compose-migrate/main_test.go
@@ -46,7 +46,7 @@ func TestE2ELegacyMigratorCLIJSONDryRun(t *testing.T) {
 	if err := reader.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 9 || !report.DryRun {
+	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 10 || !report.DryRun {
 		t.Fatalf("exit=%d report=%+v", exitCode, report)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -91,7 +91,7 @@ func TestE2ELegacyMigratorCLITextDryRun(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", exitCode)
 	}
-	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 9 is eligible"; got != want {
+	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 10 is eligible"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -153,7 +153,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 	}
 
 	report := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 9 || report.Backup == "" {
+	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 10 || report.Backup == "" {
 		t.Fatalf("in-place report=%+v", report)
 	}
 	nativeInfo, err := os.Stat(filepath.Join(root, "sandboxes", sandboxID, "state.bin"))
@@ -164,7 +164,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 		t.Fatalf("database backup is unavailable: %v", err)
 	}
 	repeated := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if repeated.Stage != "complete" || repeated.TargetVersion != 9 {
+	if repeated.Stage != "complete" || repeated.TargetVersion != 10 {
 		t.Fatalf("repeated in-place report=%+v", repeated)
 	}
 }

--- a/cmd/agent-compose-migrate/migrate/migrate.go
+++ b/cmd/agent-compose-migrate/migrate/migrate.go
@@ -22,19 +22,20 @@ const (
 	databaseName         = "data.db"
 	journalName          = ".agent-compose-migrate.json"
 	inPlaceBackupName    = ".agent-compose-migrate-backup"
-	currentSchemaVersion = 9
+	currentSchemaVersion = 10
 )
 
 var knownMigrationChecksums = map[int64]string{
-	1: "6d2a07e2df01c38a57989accc3eb265cc3238ae3322f5dd540383235e59e27a9",
-	2: "fa328b0bd1be3620d4a92b94bd39d6cb4a3a6d454ce1de643e82598f9c028a49",
-	3: "5bdbd3258245ce7fc025121625408b35b444a425ffcb89aed0b8b7a846969183",
-	4: "3d5c2ab028a6f7e1c461f0af3fc6d898807b60159f1625b8939987d6ce7b91cb",
-	5: "e43cc1ffdfcd45e5e81a8fc098a6e77299e6e437f8c447eb0db49443a3bd29d2",
-	6: "92da2ea1c85e7d1321ca1e4260370a3d12057219005a83808529dbdd8d25299a",
-	7: "a8cb740e25992d3f3121bcfbff07c67cff699e8625d281edf60c0e76f91ce9ba",
-	8: "4569a4d7f82de70d3a2545dcdff07e0929e55daffaedf13fd6f2b8a8bcbf1d3e",
-	9: "916b84e78f6956ae5af9e38720fa4c6c0c7dfe9d72ddba068790ce44a80e7fb3",
+	1:  "6d2a07e2df01c38a57989accc3eb265cc3238ae3322f5dd540383235e59e27a9",
+	2:  "fa328b0bd1be3620d4a92b94bd39d6cb4a3a6d454ce1de643e82598f9c028a49",
+	3:  "5bdbd3258245ce7fc025121625408b35b444a425ffcb89aed0b8b7a846969183",
+	4:  "3d5c2ab028a6f7e1c461f0af3fc6d898807b60159f1625b8939987d6ce7b91cb",
+	5:  "e43cc1ffdfcd45e5e81a8fc098a6e77299e6e437f8c447eb0db49443a3bd29d2",
+	6:  "92da2ea1c85e7d1321ca1e4260370a3d12057219005a83808529dbdd8d25299a",
+	7:  "a8cb740e25992d3f3121bcfbff07c67cff699e8625d281edf60c0e76f91ce9ba",
+	8:  "4569a4d7f82de70d3a2545dcdff07e0929e55daffaedf13fd6f2b8a8bcbf1d3e",
+	9:  "916b84e78f6956ae5af9e38720fa4c6c0c7dfe9d72ddba068790ce44a80e7fb3",
+	10: "63a1d45d94cbd1ade08ee556c7615f2dcbdd4411740f03ed12d93d67a1509d78",
 }
 
 var ErrReported = errors.New("migration failure is included in the report")

--- a/cmd/agent-compose-migrate/migrate/report_test.go
+++ b/cmd/agent-compose-migrate/migrate/report_test.go
@@ -12,11 +12,11 @@ func TestReportTextIncludesWarningsForEverySuccessfulMode(t *testing.T) {
 	if got := (Report{DryRun: true, SourceVersion: 4}).Text(); got != "legacy migration dry run: source schema version 4 is eligible" {
 		t.Fatalf("dry-run report text = %q", got)
 	}
-	if got := (Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v9, 2 files (9 bytes) copied to /target" {
+	if got := (Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v10, 2 files (9 bytes) copied to /target" {
 		t.Fatalf("complete report text = %q", got)
 	}
 	warningReport := Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, Target: "/target", Warnings: []string{"unresolved scheduler link", "  external path retained  ", ""}}
-	if got, want := warningReport.Text(), "legacy migration complete: schema v9, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
+	if got, want := warningReport.Text(), "legacy migration complete: schema v10, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
 		t.Fatalf("warning report text = %q, want %q", got, want)
 	}
 	for name, report := range map[string]Report{

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -421,13 +421,18 @@ scheduler trigger, or future API clients.
 5. Create a new sandbox or reuse an existing sandbox with `--sandbox`.
 6. Write project, agent, run_id, scheduler_id, source, and related tags to the
    sandbox.
-7. Mark run as running and call the existing agent executor.
+7. Persist the run/sandbox binding before starting or resuming runtime, mark
+   the run as running, and call the existing agent executor.
 8. Stream start/output/completed events for streaming requests.
-9. Persist terminal run state for success, failure, cancellation, workspace
-  preparation failure, sandbox startup failure, agent execution failure, and
-   stream send failure.
-10. Stop the runtime by default while preserving sandbox/run history. The
-    `KEEP_RUNNING` cleanup policy keeps the sandbox running.
+9. Atomically stage the exact completion result and stable final agent/result
+   events in a durable completion journal. The run remains running and has no
+   terminal status event while cleanup is pending.
+10. Stop the runtime by default, fully remove a newly created sandbox for
+    `REMOVE_ON_COMPLETION`, or skip cleanup for `KEEP_RUNNING`. Cleanup failures
+    are retried with bounded backoff and recovered after daemon restart.
+11. After cleanup succeeds, atomically commit the terminal run fields and its
+    unique status event and remove the completion journal. `StopRun` is a
+    cancellation request and can therefore return before this terminal commit.
 
 State queries primarily use project/run relationships in SQLite. Sandbox tags
 are used for compatibility queries, `down` stopping project sandboxes, and

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -268,7 +268,9 @@ Rules:
 - `--sandbox` can reuse only a sandbox owned by the selected project and agent. Cross-project or cross-agent reuse is rejected without modifying or stopping the owner sandbox.
 - Detached runs can be observed with the printed `agent-compose logs --run <run-id> --follow` command, or managed later with `stop` and `logs`.
 - `run -i --prompt` supports providers with reusable provider conversations: Codex, Claude/cc, OpenCode, and Pi. Gemini currently returns unsupported.
-- `StopRun` requests cancellation for active in-daemon runs. Pending/running runs left behind after daemon restart are reconciled to failed with a `daemon interrupted` error.
+- A run becomes terminal only after its completion cleanup succeeds. The default policy stops the sandbox; remove-on-completion fully deletes a sandbox created by that run, while a reused sandbox is only stopped. Keep-running is the explicit exception and performs no cleanup.
+- Cleanup failures leave the run `running` with `cleanup_error` populated. The daemon retries immediately and then with bounded backoff, including after restart; foreground and streaming calls continue waiting, while detached starts remain asynchronous.
+- `StopRun` requests cancellation and can return `stop_requested=true` while the run is still `running`. Execution records the cancellation result, performs the configured cleanup, and only then commits `canceled`. Pending/running runs left behind after daemon restart follow the same path to `failed` with a `daemon interrupted` error.
 
 ## `scheduler`: Invoke, Inspect, and Operate Project Schedulers
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -265,7 +265,9 @@ agent-compose run reviewer --jupyter --jupyter-expose --prompt "Inspect the note
 - `--sandbox` 只能复用属于当前 project 和所选 agent 的 sandbox；跨 project 或跨 agent 复用会被拒绝，且不会修改或停止原 sandbox。
 - detached run 可通过输出的 `agent-compose logs --run <run-id> --follow` 命令观察输出，也可继续使用 `stop`/`logs` 操作该 run。
 - `run -i --prompt` 仅支持可复用 provider conversation 的 Codex、Claude/cc、OpenCode 和 Pi；Gemini 当前会返回 unsupported。
-- `StopRun` 会请求 daemon 内当前活动 run 取消；daemon 重启后遗留的 running/pending run 会在启动 reconcile 中标记为 failed，并带 `daemon interrupted` 错误。
+- run 只有在 completion cleanup 成功后才进入终态。默认策略停止 sandbox；remove-on-completion 会完整删除由本 run 新建的 sandbox，但复用的 sandbox 只会停止；keep-running 是不执行清理的显式例外。
+- cleanup 失败时 run 保持 `running` 并写入 `cleanup_error`。daemon 会立即重试并采用有上限的退避，重启后也会继续；前台与流式调用继续等待，detached start 仍立即返回。
+- `StopRun` 只请求取消，因此可能返回 `stop_requested=true` 而 run 仍为 `running`。执行路径先记录取消结果并完成配置的 cleanup，再提交 `canceled`；daemon 重启后遗留的 running/pending run 也通过同一路径在清理后变为 `failed`，错误为 `daemon interrupted`。
 
 ## `scheduler`：调用、查看和操作 project scheduler
 

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -697,6 +697,13 @@ func TestExecAttachInputFrameMapping(t *testing.T) {
 	}
 }
 
+type sequenceRunStopper struct{ calls int }
+
+func (s *sequenceRunStopper) StopActiveRun(context.Context, string, string) (bool, error) {
+	s.calls++
+	return s.calls == 1, nil
+}
+
 func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	ctx := context.Background()
 	store := &apiProjectRunStore{
@@ -785,7 +792,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 		t.Fatalf("expected missing project ref error, got %v", err)
 	}
 
-	runHandler := NewRunHandler(nil, store)
+	runHandler := NewRunHandler(nil, store, &sequenceRunStopper{})
 	runResp, err := runHandler.GetRun(ctx, connect.NewRequest(&agentcomposev2.GetRunRequest{RunId: "run-1", ProjectId: "project-1"}))
 	if err != nil || runResp.Msg.GetRun().GetSummary().GetRunId() != "run-1" {
 		t.Fatalf("GetRun resp=%#v err=%v", runResp, err)
@@ -803,12 +810,12 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 		t.Fatalf("ListSandboxRunEvents resp=%#v err=%v", batchEvents, err)
 	}
 	stopResp, err := runHandler.StopRun(ctx, connect.NewRequest(&agentcomposev2.StopRunRequest{RunId: "run-1", Reason: "stop"}))
-	if err != nil || !stopResp.Msg.GetStopRequested() || stopResp.Msg.GetRun().GetSummary().GetStatus() != agentcomposev2.RunStatus_RUN_STATUS_CANCELED {
+	if err != nil || !stopResp.Msg.GetStopRequested() || stopResp.Msg.GetRun().GetSummary().GetStatus() != agentcomposev2.RunStatus_RUN_STATUS_RUNNING {
 		t.Fatalf("StopRun resp=%#v err=%v", stopResp, err)
 	}
-	terminalResp, err := runHandler.StopRun(ctx, connect.NewRequest(&agentcomposev2.StopRunRequest{RunId: "run-1"}))
-	if err != nil || terminalResp.Msg.GetStopRequested() {
-		t.Fatalf("terminal StopRun resp=%#v err=%v", terminalResp, err)
+	inactiveResp, err := runHandler.StopRun(ctx, connect.NewRequest(&agentcomposev2.StopRunRequest{RunId: "run-1"}))
+	if err != nil || inactiveResp.Msg.GetStopRequested() || inactiveResp.Msg.GetRun().GetSummary().GetStatus() != agentcomposev2.RunStatus_RUN_STATUS_RUNNING {
+		t.Fatalf("inactive StopRun resp=%#v err=%v", inactiveResp, err)
 	}
 	if _, err := runHandler.GetRun(ctx, connect.NewRequest(&agentcomposev2.GetRunRequest{})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("expected run id error, got %v", err)

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -538,7 +538,6 @@ func (h *RunHandler) StopRun(ctx context.Context, req *connect.Request[agentcomp
 			}), nil
 		}
 	}
-	coordinator := runs.NewCoordinator(h.store, domain.StableProjectRunID)
 	current, err := h.store.GetProjectRun(ctx, runID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -552,19 +551,8 @@ func (h *RunHandler) StopRun(ctx context.Context, req *connect.Request[agentcomp
 			StopRequested: false,
 		}), nil
 	}
-	reason := strings.TrimSpace(req.Msg.GetReason())
-	if reason == "" {
-		reason = "stop requested"
-	}
-	run, err := coordinator.MarkCanceled(ctx, runs.TransitionRequest{
-		RunID: runID,
-		Error: reason,
-	})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
 	return connect.NewResponse(&agentcomposev2.StopRunResponse{
-		Run:           ProjectRunDetailToProto(run),
-		StopRequested: true,
+		Run:           ProjectRunDetailToProto(current),
+		StopRequested: false,
 	}), nil
 }

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -87,6 +87,7 @@ func RegisterDependencies(di do.Injector) {
 	do.Provide(di, NewRunController)
 	do.Provide(di, NewSandboxRunTargetResolver)
 	do.Provide(di, NewSandboxRemovalCoordinator)
+	do.Provide(di, NewRunCompletionManager)
 	do.Provide(di, NewDeletionRecovery)
 	do.Provide(di, NewCleanupRunner)
 	do.Provide(di, NewRunSupervisor)
@@ -246,6 +247,7 @@ func StartBackground(di do.Injector) error {
 		do.MustInvoke[*events.Dispatcher](di),
 		do.MustInvoke[*capproxy.Server](di),
 		do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
+		do.MustInvoke[*runs.CompletionManager](di),
 	); err != nil {
 		return err
 	}
@@ -259,6 +261,17 @@ func StartBackground(di do.Injector) error {
 func StopBackground(ctx context.Context, di do.Injector) error {
 	components := make([]backgroundComponent, 0, 2)
 	var setupErrors []error
+	if supervisor, err := do.Invoke[*RunSupervisor](di); err != nil {
+		setupErrors = append(setupErrors, fmt.Errorf("resolve run supervisor: %w", err))
+	} else if err := supervisor.Shutdown(ctx); err != nil {
+		setupErrors = append(setupErrors, fmt.Errorf("stop run supervisor: %w", err))
+	}
+	completion, completionErr := do.Invoke[*runs.CompletionManager](di)
+	if completionErr != nil {
+		setupErrors = append(setupErrors, fmt.Errorf("resolve project run completion manager: %w", completionErr))
+	} else {
+		components = append(components, backgroundComponent{name: "project run completion manager", shutdown: completion.Shutdown})
+	}
 
 	recovery, recoveryErr := do.Invoke[*sandboxes.DeletionRecovery](di)
 	if recoveryErr != nil {

--- a/pkg/agentcompose/app/app_test.go
+++ b/pkg/agentcompose/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/labstack/echo/v4"
@@ -50,6 +51,11 @@ func TestSetupRegistersServiceGraph(t *testing.T) {
 	do.ProvideValue(di, slog.Default())
 	do.ProvideValue(di, echo.New())
 	Setup(di)
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		_ = StopBackground(shutdownCtx, di)
+	})
 	cancel()
 
 	app := do.MustInvoke[*echo.Echo](di)
@@ -122,6 +128,11 @@ func TestStartBackgroundConstructsCleanupBeforeScheduler(t *testing.T) {
 		t.Fatalf("StartBackground returned error: %v", err)
 	}
 	cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer shutdownCancel()
+	if err := StopBackground(shutdownCtx, di); err != nil {
+		t.Fatalf("StopBackground returned error: %v", err)
+	}
 	if len(constructionOrder) < 3 || constructionOrder[0] != "cleanup" || constructionOrder[1] != "scheduler" || constructionOrder[2] != "recovery" {
 		t.Fatalf("background construction order = %v, want cleanup before scheduler before recovery", constructionOrder)
 	}

--- a/pkg/agentcompose/app/background.go
+++ b/pkg/agentcompose/app/background.go
@@ -11,7 +11,6 @@ import (
 	"agent-compose/pkg/agentcompose/adapters"
 	"agent-compose/pkg/capproxy"
 	"agent-compose/pkg/events"
-	"agent-compose/pkg/execution"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/runs"
 	"agent-compose/pkg/storage/configstore"
@@ -30,11 +29,11 @@ type backgroundSchedulerController interface {
 	Start()
 }
 
-func startBackgroundManagers(ctx context.Context, sandboxes *sandboxstore.Store, configDB *configstore.ConfigStore, bridge runtimeReconciler, schedulers backgroundSchedulerController, events *events.Dispatcher, capProxy *capproxy.Server, capTokens *adapters.CapabilitySandboxResolver) error {
+func startBackgroundManagers(ctx context.Context, sandboxes *sandboxstore.Store, configDB *configstore.ConfigStore, bridge runtimeReconciler, schedulers backgroundSchedulerController, events *events.Dispatcher, capProxy *capproxy.Server, capTokens *adapters.CapabilitySandboxResolver, completions *runs.CompletionManager) error {
 	startedAt := time.Now().UTC()
 	reconcileCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := reconcilePersistedSandboxes(reconcileCtx, sandboxes, configDB, bridge, startedAt); err != nil {
+	if err := reconcilePersistedSandboxes(reconcileCtx, sandboxes, bridge, startedAt); err != nil {
 		slog.Warn("failed to reconcile persisted sandbox state on startup", "error", err)
 	}
 	if capTokens != nil {
@@ -45,12 +44,18 @@ func startBackgroundManagers(ctx context.Context, sandboxes *sandboxstore.Store,
 	if err := schedulers.RecoverInterruptedRuns(reconcileCtx, startedAt); err != nil {
 		slog.Warn("failed to recover interrupted scheduler runs", "error", err)
 	}
+	if err := completions.Start(ctx); err != nil {
+		return err
+	}
+	if err := reconcilePersistedProjectRuns(reconcileCtx, configDB, completions, startedAt); err != nil {
+		slog.Warn("failed to reconcile persisted project runs", "error", err)
+	}
 	schedulers.Start()
 	events.Start()
 	return startCapabilityProxy(ctx, capProxy)
 }
 
-func reconcilePersistedSandboxes(ctx context.Context, store *sandboxstore.Store, configDB *configstore.ConfigStore, bridge runtimeReconciler, startedAt time.Time) error {
+func reconcilePersistedSandboxes(ctx context.Context, store *sandboxstore.Store, bridge runtimeReconciler, startedAt time.Time) error {
 	result, err := store.ListSandboxes(ctx, domain.SandboxListOptions{Limit: 1 << 30})
 	if err != nil {
 		return err
@@ -64,9 +69,6 @@ func reconcilePersistedSandboxes(ctx context.Context, store *sandboxstore.Store,
 		if _, err := bridge.ReconcileRuntimeState(ctx, reconciled); err != nil {
 			slog.Warn("failed to reconcile sandbox runtime state", "sandbox_id", session.Summary.ID, "error", err)
 		}
-	}
-	if err := reconcilePersistedProjectRuns(ctx, configDB, startedAt); err != nil {
-		slog.Warn("failed to reconcile persisted project runs", "error", err)
 	}
 	return nil
 }
@@ -108,20 +110,19 @@ func reconcilePendingSandboxState(ctx context.Context, store *sandboxstore.Store
 	return store.GetSandbox(ctx, session.Summary.ID)
 }
 
-func reconcilePersistedProjectRuns(ctx context.Context, configDB *configstore.ConfigStore, startedAt time.Time) error {
+func reconcilePersistedProjectRuns(ctx context.Context, configDB *configstore.ConfigStore, completions *runs.CompletionManager, startedAt time.Time) error {
 	if configDB == nil {
 		return nil
 	}
-	coordinator := runs.NewCoordinator(configDB, domain.StableProjectRunID)
 	for _, status := range []string{domain.ProjectRunStatusPending, domain.ProjectRunStatusRunning} {
-		if err := reconcilePersistedProjectRunsWithStatus(ctx, configDB, coordinator, status, startedAt); err != nil {
+		if err := reconcilePersistedProjectRunsWithStatus(ctx, configDB, completions, status, startedAt); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func reconcilePersistedProjectRunsWithStatus(ctx context.Context, configDB *configstore.ConfigStore, coordinator *runs.Coordinator, status string, startedAt time.Time) error {
+func reconcilePersistedProjectRunsWithStatus(ctx context.Context, configDB *configstore.ConfigStore, completions *runs.CompletionManager, status string, startedAt time.Time) error {
 	var staleRuns []domain.ProjectRunRecord
 	offset := 0
 	for {
@@ -145,12 +146,8 @@ func reconcilePersistedProjectRunsWithStatus(ctx context.Context, configDB *conf
 		offset += len(runs)
 	}
 	for _, run := range staleRuns {
-		if _, err := coordinator.MarkFailed(ctx, runs.TransitionRequest{
-			RunID:    run.RunID,
-			ExitCode: execution.FirstNonZeroInt(run.ExitCode, 1),
-			Error:    staleProjectRunError,
-		}); err != nil {
-			slog.Warn("failed to mark stale project run failed", "run_id", run.RunID, "error", err)
+		if err := completions.StageInterrupted(ctx, run, staleProjectRunError); err != nil {
+			slog.Warn("failed to stage stale project run completion", "run_id", run.RunID, "error", err)
 		}
 	}
 	return nil

--- a/pkg/agentcompose/app/background_coverage_test.go
+++ b/pkg/agentcompose/app/background_coverage_test.go
@@ -13,6 +13,7 @@ import (
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/internal/testutil"
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/runs"
 	"agent-compose/pkg/storage/sandboxstore"
 )
 
@@ -106,10 +107,14 @@ func TestReconcilePersistedProjectRunsMarksInterruptedRunsFailed(t *testing.T) {
 			t.Fatalf("CreateProjectRun(%s) returned error: %v", run.RunID, err)
 		}
 	}
-	if err := reconcilePersistedProjectRuns(ctx, store, time.Now().Add(2*time.Second)); err != nil {
+	completions := runs.NewCompletionManager(store, nil, nil, nil, nil)
+	if err := reconcilePersistedProjectRuns(ctx, store, completions, time.Now().Add(2*time.Second)); err != nil {
 		t.Fatalf("reconcilePersistedProjectRuns returned error: %v", err)
 	}
 	for _, runID := range []string{"run-pending", "run-running"} {
+		if _, err := completions.Complete(ctx, runs.TransitionRequest{RunID: runID, Status: domain.ProjectRunStatusFailed}); err != nil {
+			t.Fatalf("complete reconciled run %s: %v", runID, err)
+		}
 		run, err := store.GetProjectRun(ctx, runID)
 		if err != nil {
 			t.Fatalf("GetProjectRun(%s) returned error: %v", runID, err)
@@ -135,7 +140,7 @@ func TestReconcilePersistedProjectRunsMarksInterruptedRunsFailed(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateProjectRun(run-fresh) returned error: %v", err)
 	}
-	if err := reconcilePersistedProjectRuns(ctx, store, time.Now().Add(-2*time.Second)); err != nil {
+	if err := reconcilePersistedProjectRuns(ctx, store, completions, time.Now().Add(-2*time.Second)); err != nil {
 		t.Fatalf("fresh reconcilePersistedProjectRuns returned error: %v", err)
 	}
 	fresh, err := store.GetProjectRun(ctx, "run-fresh")

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"connectrpc.com/connect"
@@ -53,7 +54,33 @@ func NewRunController(di do.Injector) (*runs.Controller, error) {
 		RunLogs:         do.MustInvoke[*runs.RunLogHub](di),
 		LifecycleLocks:  do.MustInvoke[*sandboxes.LifecycleLocks](di),
 		Removal:         do.MustInvoke[*sandboxes.RemovalCoordinator](di),
+		Completion:      do.MustInvoke[*runs.CompletionManager](di),
 	}), nil
+}
+
+type runCompletionStopper struct {
+	config    *appconfig.Config
+	store     *sandboxstore.Store
+	driver    *adapters.SandboxDriver
+	streams   *sandboxes.StreamBroker
+	locks     *sandboxes.LifecycleLocks
+	capTokens *adapters.CapabilitySandboxResolver
+}
+
+func (s runCompletionStopper) Stop(ctx context.Context, sandbox *domain.Sandbox) error {
+	return stopProjectSandbox(ctx, s.config.SandboxRoot, s.locks, s.store, s.driver, s.streams, sandbox, s.capTokens)
+}
+
+func NewRunCompletionManager(di do.Injector) (*runs.CompletionManager, error) {
+	stopper := runCompletionStopper{
+		config: do.MustInvoke[*appconfig.Config](di), store: do.MustInvoke[*sandboxstore.Store](di),
+		driver: do.MustInvoke[*adapters.SandboxDriver](di), streams: do.MustInvoke[*sandboxes.StreamBroker](di),
+		locks: do.MustInvoke[*sandboxes.LifecycleLocks](di), capTokens: do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
+	}
+	return runs.NewCompletionManager(
+		do.MustInvoke[*configstore.ConfigStore](di), do.MustInvoke[*sandboxstore.Store](di), stopper,
+		do.MustInvoke[*sandboxes.RemovalCoordinator](di), do.MustInvoke[*slog.Logger](di),
+	), nil
 }
 
 type runControllerDelegate struct {
@@ -62,11 +89,17 @@ type runControllerDelegate struct {
 }
 
 func (d runControllerDelegate) RunProjectCommandAttach(ctx context.Context, receive runs.RunAttachReceiver, send runs.RunAttachSender) error {
-	return runConnectError(d.controller.RunProjectCommandAttach(ctx, receive, send))
+	if d.supervisor == nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("run supervisor is required"))
+	}
+	return runConnectError(d.supervisor.Attach(ctx, receive, send))
 }
 
 func (d runControllerDelegate) RunAgent(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest]) (*connect.Response[agentcomposev2.RunAgentResponse], error) {
-	run, _, err := d.controller.RunProjectAgent(ctx, runAgentRequestFromProto(req.Msg), nil)
+	if d.supervisor == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("run supervisor is required"))
+	}
+	run, _, err := d.supervisor.Run(ctx, runAgentRequestFromProto(req.Msg), nil)
 	if err != nil {
 		return nil, runConnectError(err)
 	}
@@ -101,7 +134,10 @@ func (d runControllerDelegate) StreamAgentRun(ctx context.Context, req *connect.
 			return sendRunAgentStreamChunk(stream, runID, chunk, createdAt)
 		},
 	}
-	run, execErr, err := d.controller.RunProjectAgent(ctx, runAgentRequestFromProto(req.Msg), &sink)
+	if d.supervisor == nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("run supervisor is required"))
+	}
+	run, execErr, err := d.supervisor.Run(ctx, runAgentRequestFromProto(req.Msg), &sink)
 	if err != nil {
 		return runConnectError(err)
 	}

--- a/pkg/agentcompose/app/run_supervisor.go
+++ b/pkg/agentcompose/app/run_supervisor.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 
@@ -19,10 +20,11 @@ type RunSupervisor struct {
 
 	mu     sync.Mutex
 	active map[string]*activeRun
+	wg     sync.WaitGroup
 }
 
 type activeRun struct {
-	cancel   context.CancelFunc
+	cancel   context.CancelCauseFunc
 	stopOnce sync.Once
 	stopping bool
 	stopped  bool
@@ -46,13 +48,65 @@ func (s *RunSupervisor) StartRun(ctx context.Context, req runs.RunAgentRequest) 
 	if runs.StatusIsTerminal(started.Run.Status) {
 		return started.Run, nil
 	}
-	execCtx, cancel := context.WithCancel(s.root)
+	execCtx, cancel := context.WithCancelCause(s.root)
 	s.register(started.Run.RunID, cancel)
+	s.wg.Add(1)
 	go func() {
+		defer s.wg.Done()
 		defer s.unregister(started.Run.RunID)
 		_, _, _ = started.Execute(execCtx, nil)
 	}()
 	return started.Run, nil
+}
+
+func (s *RunSupervisor) Run(ctx context.Context, req runs.RunAgentRequest, stream *runs.StreamSink) (domain.ProjectRunRecord, error, error) {
+	started, err := s.controller.StartProjectRun(ctx, req)
+	if err != nil {
+		return domain.ProjectRunRecord{}, nil, err
+	}
+	if runs.StatusIsTerminal(started.Run.Status) {
+		return started.Run, nil, nil
+	}
+	execCtx, cancel := context.WithCancelCause(ctx)
+	s.register(started.Run.RunID, cancel)
+	s.wg.Add(1)
+	defer s.wg.Done()
+	defer s.unregister(started.Run.RunID)
+	return started.Execute(execCtx, stream)
+}
+
+func (s *RunSupervisor) Attach(ctx context.Context, receive runs.RunAttachReceiver, send runs.RunAttachSender) error {
+	execCtx, cancel := context.WithCancelCause(ctx)
+	var runID string
+	err := s.controller.RunProjectCommandAttachRegistered(execCtx, receive, send, func(startedRunID string) {
+		runID = startedRunID
+		s.register(runID, cancel)
+		s.wg.Add(1)
+	})
+	if runID != "" {
+		s.wg.Done()
+		s.unregister(runID)
+	} else {
+		cancel(nil)
+	}
+	return err
+}
+
+func (s *RunSupervisor) Shutdown(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (s *RunSupervisor) StopActiveRun(ctx context.Context, runID, reason string) (bool, error) {
@@ -70,30 +124,17 @@ func (s *RunSupervisor) StopActiveRun(ctx context.Context, runID, reason string)
 		return false, nil
 	}
 	active.stopOnce.Do(func() {
-		active.cancel()
 		reason = strings.TrimSpace(reason)
 		if reason == "" {
 			reason = "stop requested"
 		}
-		coordinator := runs.NewCoordinator(s.store, domain.StableProjectRunID)
-		_, active.stopErr = coordinator.MarkCanceled(ctx, runs.TransitionRequest{RunID: runID, Error: reason})
-		if active.stopErr != nil {
-			if current, err := s.store.GetProjectRun(ctx, runID); err == nil && runs.StatusIsTerminal(current.Status) {
-				active.stopErr = nil
-			}
-		}
-		active.stopped = active.stopErr == nil
-
-		s.mu.Lock()
-		if current := s.active[runID]; current == active {
-			delete(s.active, runID)
-		}
-		s.mu.Unlock()
+		active.cancel(errors.New(reason))
+		active.stopped = true
 	})
 	return active.stopped, active.stopErr
 }
 
-func (s *RunSupervisor) register(runID string, cancel context.CancelFunc) {
+func (s *RunSupervisor) register(runID string, cancel context.CancelCauseFunc) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.active[runID] = &activeRun{cancel: cancel}
@@ -102,8 +143,5 @@ func (s *RunSupervisor) register(runID string, cancel context.CancelFunc) {
 func (s *RunSupervisor) unregister(runID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if active := s.active[runID]; active != nil && active.stopping {
-		return
-	}
 	delete(s.active, runID)
 }

--- a/pkg/agentcompose/app/run_supervisor_test.go
+++ b/pkg/agentcompose/app/run_supervisor_test.go
@@ -13,7 +13,7 @@ import (
 	"agent-compose/pkg/storage/configstore"
 )
 
-func TestRunSupervisorStopActiveRunRemovesActiveBeforeMarkCanceled(t *testing.T) {
+func TestRunSupervisorStopActiveRunRequestsCancellationWithoutMarkingTerminal(t *testing.T) {
 	ctx := context.Background()
 	store := newRunSupervisorTestConfigStore(t)
 	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{
@@ -42,54 +42,53 @@ func TestRunSupervisorStopActiveRunRemovesActiveBeforeMarkCanceled(t *testing.T)
 	}
 
 	cancelCalls := 0
+	var cancelCause error
 	supervisor := &RunSupervisor{
 		store:  store,
-		active: map[string]*activeRun{"run-1": {cancel: func() { cancelCalls++ }}},
+		active: map[string]*activeRun{"run-1": {cancel: func(cause error) { cancelCalls++; cancelCause = cause }}},
 	}
 	stopped, err := supervisor.StopActiveRun(ctx, "run-1", "user stop")
 	if err != nil {
 		t.Fatalf("StopActiveRun returned error: %v", err)
 	}
-	if !stopped || cancelCalls != 1 {
+	if !stopped || cancelCalls != 1 || cancelCause == nil || cancelCause.Error() != "user stop" {
 		t.Fatalf("first stop stopped=%v cancelCalls=%d, want true/1", stopped, cancelCalls)
 	}
-	if _, ok := supervisor.active["run-1"]; ok {
-		t.Fatalf("run remained active after stop")
+	if _, ok := supervisor.active["run-1"]; !ok {
+		t.Fatalf("run was removed before execution exited")
 	}
 
 	stopped, err = supervisor.StopActiveRun(ctx, "run-1", "second stop")
 	if err != nil {
 		t.Fatalf("second StopActiveRun returned error: %v", err)
 	}
-	if stopped || cancelCalls != 1 {
-		t.Fatalf("second stop stopped=%v cancelCalls=%d, want false/1", stopped, cancelCalls)
+	if !stopped || cancelCalls != 1 {
+		t.Fatalf("second stop stopped=%v cancelCalls=%d, want true/1", stopped, cancelCalls)
 	}
 	run, err := store.GetProjectRun(ctx, "run-1")
 	if err != nil {
 		t.Fatalf("GetProjectRun returned error: %v", err)
 	}
-	if run.Status != domain.ProjectRunStatusCanceled || run.Error != "user stop" {
+	if run.Status != domain.ProjectRunStatusRunning || run.Error != "" {
 		t.Fatalf("run after stop = %#v", run)
+	}
+	supervisor.unregister("run-1")
+	if _, ok := supervisor.active["run-1"]; ok {
+		t.Fatal("run remained active after execution exit")
 	}
 }
 
-func TestRunSupervisorUnregisterKeepsStoppingRun(t *testing.T) {
+func TestRunSupervisorUnregisterRemovesStoppingRun(t *testing.T) {
 	active := &activeRun{
-		cancel:   func() {},
+		cancel:   func(error) {},
 		stopping: true,
 	}
 	supervisor := &RunSupervisor{
 		active: map[string]*activeRun{"run-1": active},
 	}
 	supervisor.unregister("run-1")
-	if got := supervisor.active["run-1"]; got != active {
-		t.Fatalf("stopping run was unregistered: %#v", supervisor.active)
-	}
-
-	active.stopping = false
-	supervisor.unregister("run-1")
 	if _, ok := supervisor.active["run-1"]; ok {
-		t.Fatalf("inactive run remained registered")
+		t.Fatalf("stopping run remained registered")
 	}
 }
 

--- a/pkg/model/project_model.go
+++ b/pkg/model/project_model.go
@@ -12,6 +12,14 @@ const (
 	ProjectRunSourceManual    = "manual"
 	ProjectRunSourceScheduler = "scheduler"
 	ProjectRunSourceAPI       = "api"
+
+	ProjectRunCleanupStopOnCompletion   = "stop_on_completion"
+	ProjectRunCleanupKeepRunning        = "keep_running"
+	ProjectRunCleanupRemoveOnCompletion = "remove_on_completion"
+
+	ProjectRunCompletionActionNone   = "none"
+	ProjectRunCompletionActionStop   = "stop"
+	ProjectRunCompletionActionRemove = "remove"
 )
 
 type ProjectRecord struct {
@@ -90,6 +98,8 @@ type ProjectRunRecord struct {
 	LogsPath        string    `json:"logs_path,omitempty"`
 	ArtifactsDir    string    `json:"artifacts_dir,omitempty"`
 	CleanupError    string    `json:"cleanup_error,omitempty"`
+	CleanupPolicy   string    `json:"cleanup_policy"`
+	SandboxCreated  bool      `json:"sandbox_created"`
 	Driver          string    `json:"driver,omitempty"`
 	ImageRef        string    `json:"image_ref,omitempty"`
 	StartedAt       time.Time `json:"started_at,omitempty"`
@@ -98,6 +108,21 @@ type ProjectRunRecord struct {
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
 	Warnings        []string  `json:"warnings,omitempty"`
+}
+
+// ProjectRunCompletionRecord is the durable intent to finish a run after its
+// sandbox lifecycle action succeeds. TransitionJSON preserves the exact
+// result selected by the first completion writer across daemon restarts.
+type ProjectRunCompletionRecord struct {
+	RunID          string    `json:"run_id"`
+	TargetStatus   string    `json:"target_status"`
+	TransitionJSON string    `json:"transition_json"`
+	CleanupAction  string    `json:"cleanup_action"`
+	Attempt        int       `json:"attempt"`
+	LastError      string    `json:"last_error,omitempty"`
+	NextAttemptAt  time.Time `json:"next_attempt_at,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 type ProjectRunEventKind string

--- a/pkg/projects/normalize.go
+++ b/pkg/projects/normalize.go
@@ -140,6 +140,7 @@ func NormalizeRunRecord(run domain.ProjectRunRecord) (domain.ProjectRunRecord, e
 	run.ResultJSON = strings.TrimSpace(run.ResultJSON)
 	run.LogsPath = strings.TrimSpace(run.LogsPath)
 	run.ArtifactsDir = strings.TrimSpace(run.ArtifactsDir)
+	run.CleanupPolicy = NormalizeRunCleanupPolicy(run.CleanupPolicy)
 	run.Driver = strings.TrimSpace(run.Driver)
 	run.ImageRef = strings.TrimSpace(run.ImageRef)
 	if run.RunID == "" || run.ProjectID == "" {
@@ -155,6 +156,17 @@ func NormalizeRunRecord(run domain.ProjectRunRecord) (domain.ProjectRunRecord, e
 		return domain.ProjectRunRecord{}, fmt.Errorf("project run result_json must be valid JSON")
 	}
 	return run, nil
+}
+
+func NormalizeRunCleanupPolicy(policy string) string {
+	switch strings.ToLower(strings.TrimSpace(policy)) {
+	case domain.ProjectRunCleanupKeepRunning:
+		return domain.ProjectRunCleanupKeepRunning
+	case domain.ProjectRunCleanupRemoveOnCompletion:
+		return domain.ProjectRunCleanupRemoveOnCompletion
+	default:
+		return domain.ProjectRunCleanupStopOnCompletion
+	}
 }
 
 func NormalizeRunStatus(status string) string {

--- a/pkg/projects/scan.go
+++ b/pkg/projects/scan.go
@@ -103,19 +103,21 @@ func ScanProjectSchedulerPage(scan func(dest ...any) error) (domain.ProjectSched
 func ScanProjectRun(scan func(dest ...any) error) (domain.ProjectRunRecord, error) {
 	var item domain.ProjectRunRecord
 	var schedulerRunID sql.NullString
+	var sandboxCreated int
 	var startedAtRaw any
 	var completedAtRaw any
 	var createdAtRaw any
 	var updatedAtRaw any
 	if err := scan(
 		&item.RunID, &item.ProjectID, &item.ProjectName, &item.ProjectRevision, &item.AgentName, &item.AgentID, &item.Source, &item.SchedulerID, &schedulerRunID, &item.TriggerID, &item.Status,
-		&item.SandboxID, &item.ExitCode, &item.Error, &item.Prompt, &item.Output, &item.ResultJSON, &item.LogsPath, &item.ArtifactsDir, &item.CleanupError, &item.Driver, &item.ImageRef,
+		&item.SandboxID, &item.ExitCode, &item.Error, &item.Prompt, &item.Output, &item.ResultJSON, &item.LogsPath, &item.ArtifactsDir, &item.CleanupError, &item.CleanupPolicy, &sandboxCreated, &item.Driver, &item.ImageRef,
 		&startedAtRaw, &completedAtRaw, &item.DurationMs, &createdAtRaw, &updatedAtRaw,
 	); err != nil {
 		return domain.ProjectRunRecord{}, fmt.Errorf("scan project run: %w", err)
 	}
 	item.StartedAt = parseStoredUnixTimeAuto(AsInt64Time(startedAtRaw))
 	item.SchedulerRunID = schedulerRunID.String
+	item.SandboxCreated = sandboxCreated != 0
 	item.CompletedAt = parseStoredUnixTimeAuto(AsInt64Time(completedAtRaw))
 	item.CreatedAt = parseStoredTime(createdAtRaw)
 	item.UpdatedAt = parseStoredTime(updatedAtRaw)
@@ -212,6 +214,6 @@ func ParseInt64String(value string) (int64, bool) {
 
 func SelectProjectRunSQL() string {
 	return `SELECT run_id, project_id, project_name, project_revision, agent_name, agent_id, source, scheduler_id, scheduler_run_id, trigger_id, status,
-		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, driver, image_ref,
+		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
 		started_at, completed_at, duration_ms, created_at, updated_at FROM project_run`
 }

--- a/pkg/projects/scheduler_coverage_test.go
+++ b/pkg/projects/scheduler_coverage_test.go
@@ -171,7 +171,7 @@ func TestProjectNormalizeAndScanCoverage(t *testing.T) {
 		t.Fatalf("ScanProject scanned=%#v err=%v", scanned, err)
 	}
 	scannedRun, err := ScanProjectRun(func(dest ...any) error {
-		values := []any{"run-1", "project-1", "Project", int64(1), "worker", "agent-1", "api", "scheduler-1", "scheduler-run-1", "trigger-1", "running", "session-1", 0, "", "prompt", "output", "{}", "logs", "artifacts", "", "docker", "image", int64(1_720_000_000_000), "1720000001000", int64(1000), float64(1720000002), time.Date(2026, 7, 3, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)}
+		values := []any{"run-1", "project-1", "Project", int64(1), "worker", "agent-1", "api", "scheduler-1", "scheduler-run-1", "trigger-1", "running", "session-1", 0, "", "prompt", "output", "{}", "logs", "artifacts", "", "stop_on_completion", 0, "docker", "image", int64(1_720_000_000_000), "1720000001000", int64(1000), float64(1720000002), time.Date(2026, 7, 3, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)}
 		for i, value := range values {
 			switch ptr := dest[i].(type) {
 			case *string:

--- a/pkg/runs/completion.go
+++ b/pkg/runs/completion.go
@@ -1,0 +1,345 @@
+package runs
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sandboxes"
+)
+
+const completionWorkerCount = 2
+
+type CompletionStore interface {
+	GetProjectRun(context.Context, string) (domain.ProjectRunRecord, error)
+	StageProjectRunCompletion(context.Context, domain.ProjectRunCompletionRecord, []domain.ProjectRunEventRecord) (domain.ProjectRunCompletionRecord, bool, error)
+	GetProjectRunCompletion(context.Context, string) (domain.ProjectRunCompletionRecord, error)
+	ListDueProjectRunCompletions(context.Context, time.Time, int) ([]domain.ProjectRunCompletionRecord, error)
+	RecordProjectRunCompletionFailure(context.Context, string, string, int, time.Time) error
+	FinalizeProjectRunCompletion(context.Context, domain.ProjectRunRecord, domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error)
+	ProjectRunCompletionForSandbox(context.Context, string) (string, bool, error)
+}
+
+type CompletionSandboxStore interface {
+	GetSandbox(context.Context, string) (*domain.Sandbox, error)
+}
+
+type CompletionSandboxLifecycle interface {
+	Stop(context.Context, *domain.Sandbox) error
+}
+
+type CompletionManager struct {
+	store     CompletionStore
+	sandboxes CompletionSandboxStore
+	lifecycle CompletionSandboxLifecycle
+	removal   SandboxRemoval
+	logger    *slog.Logger
+	now       func() time.Time
+
+	mu      sync.Mutex
+	locks   map[string]*sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	wake    chan struct{}
+	started bool
+}
+
+func NewCompletionManager(store CompletionStore, sandboxStore CompletionSandboxStore, lifecycle CompletionSandboxLifecycle, removal SandboxRemoval, logger *slog.Logger) *CompletionManager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &CompletionManager{
+		store: store, sandboxes: sandboxStore, lifecycle: lifecycle, removal: removal, logger: logger,
+		now: func() time.Time { return time.Now().UTC() }, locks: map[string]*sync.Mutex{}, wake: make(chan struct{}, 1),
+	}
+}
+
+func (m *CompletionManager) Complete(ctx context.Context, req TransitionRequest) (domain.ProjectRunRecord, error) {
+	if m == nil || m.store == nil {
+		return domain.ProjectRunRecord{}, fmt.Errorf("project run completion store is required")
+	}
+	req.RunID = strings.TrimSpace(req.RunID)
+	req.Status = NormalizeStatus(req.Status)
+	if req.RunID == "" || !StatusIsTerminal(req.Status) {
+		return domain.ProjectRunRecord{}, fmt.Errorf("terminal project run completion is required")
+	}
+	current, err := m.store.GetProjectRun(ctx, req.RunID)
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	if StatusIsTerminal(current.Status) {
+		return current, nil
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return domain.ProjectRunRecord{}, fmt.Errorf("encode project run completion: %w", err)
+	}
+	action := CompletionCleanupAction(current.CleanupPolicy, strings.TrimSpace(current.SandboxID) != "", current.SandboxCreated)
+	staged, _, err := m.store.StageProjectRunCompletion(ctx, domain.ProjectRunCompletionRecord{
+		RunID: req.RunID, TargetStatus: req.Status, TransitionJSON: string(payload), CleanupAction: action,
+	}, req.TerminalEvents)
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	m.signal()
+	for {
+		run, processErr := m.process(ctx, staged.RunID)
+		if processErr == nil && StatusIsTerminal(run.Status) {
+			return run, nil
+		}
+		select {
+		case <-ctx.Done():
+			return m.store.GetProjectRun(context.WithoutCancel(ctx), staged.RunID)
+		case <-time.After(100 * time.Millisecond):
+		}
+		staged, err = m.store.GetProjectRunCompletion(ctx, staged.RunID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return m.store.GetProjectRun(ctx, req.RunID)
+		}
+		if err != nil {
+			return domain.ProjectRunRecord{}, err
+		}
+		if staged.NextAttemptAt.After(m.nowUTC()) {
+			wait := time.Until(staged.NextAttemptAt)
+			if wait > 250*time.Millisecond {
+				wait = 250 * time.Millisecond
+			}
+			select {
+			case <-ctx.Done():
+				return m.store.GetProjectRun(context.WithoutCancel(ctx), staged.RunID)
+			case <-time.After(wait):
+			}
+		}
+	}
+}
+
+func (m *CompletionManager) StageInterrupted(ctx context.Context, run domain.ProjectRunRecord, message string) error {
+	req := TransitionRequest{RunID: run.RunID, Status: domain.ProjectRunStatusFailed, ExitCode: max(run.ExitCode, 1), Error: message}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	_, _, err = m.store.StageProjectRunCompletion(ctx, domain.ProjectRunCompletionRecord{
+		RunID: run.RunID, TargetStatus: req.Status, TransitionJSON: string(payload),
+		CleanupAction: CompletionCleanupAction(run.CleanupPolicy, strings.TrimSpace(run.SandboxID) != "", run.SandboxCreated),
+	}, nil)
+	m.signal()
+	return err
+}
+
+func (m *CompletionManager) PendingForSandbox(ctx context.Context, sandboxID string) (string, bool, error) {
+	return m.store.ProjectRunCompletionForSandbox(ctx, sandboxID)
+}
+
+func (m *CompletionManager) Start(parent context.Context) error {
+	if m == nil || m.store == nil {
+		return fmt.Errorf("project run completion manager is not configured")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.started {
+		return nil
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	m.cancel = cancel
+	m.done = make(chan struct{})
+	m.started = true
+	go m.run(ctx, m.done)
+	return nil
+}
+
+func (m *CompletionManager) Shutdown(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	cancel, done := m.cancel, m.done
+	m.mu.Unlock()
+	if cancel == nil || done == nil {
+		return nil
+	}
+	cancel()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *CompletionManager) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
+	var workers sync.WaitGroup
+	workers.Add(completionWorkerCount)
+	for range completionWorkerCount {
+		go func() {
+			defer workers.Done()
+			ticker := time.NewTicker(250 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				if err := m.processDue(ctx); err != nil && ctx.Err() == nil {
+					m.logger.Warn("failed to process project run completions", "error", err)
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case <-m.wake:
+				case <-ticker.C:
+				}
+			}
+		}()
+	}
+	workers.Wait()
+}
+
+func (m *CompletionManager) processDue(ctx context.Context) error {
+	items, err := m.store.ListDueProjectRunCompletions(ctx, m.nowUTC(), 100)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if _, err := m.process(ctx, item.RunID); err != nil && ctx.Err() == nil {
+			continue
+		}
+	}
+	return nil
+}
+
+func (m *CompletionManager) process(ctx context.Context, runID string) (domain.ProjectRunRecord, error) {
+	lock := m.runLock(runID)
+	lock.Lock()
+	defer lock.Unlock()
+	completion, err := m.store.GetProjectRunCompletion(ctx, runID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return m.store.GetProjectRun(ctx, runID)
+	}
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	if completion.NextAttemptAt.After(m.nowUTC()) {
+		return m.store.GetProjectRun(ctx, runID)
+	}
+	run, err := m.store.GetProjectRun(ctx, runID)
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	if err := m.cleanup(ctx, run, completion.CleanupAction); err != nil {
+		attempt := completion.Attempt + 1
+		next := m.nowUTC().Add(completionRetryDelay(attempt))
+		if recordErr := m.store.RecordProjectRunCompletionFailure(context.WithoutCancel(ctx), runID, err.Error(), attempt, next); recordErr != nil {
+			return run, errors.Join(err, recordErr)
+		}
+		m.logger.Warn("project run sandbox cleanup failed", "run_id", runID, "sandbox_id", run.SandboxID, "action", completion.CleanupAction, "attempt", attempt, "next_attempt_at", next, "error", err)
+		return run, err
+	}
+	var req TransitionRequest
+	if err := json.Unmarshal([]byte(completion.TransitionJSON), &req); err != nil {
+		return run, fmt.Errorf("decode project run completion %s: %w", runID, err)
+	}
+	now := m.nowUTC()
+	next := run
+	next.Status = completion.TargetStatus
+	applyProjectRunTransitionFields(&next, req)
+	if next.StartedAt.IsZero() {
+		next.StartedAt = now
+	}
+	next.CompletedAt = now
+	next.DurationMs = max(0, next.CompletedAt.Sub(next.StartedAt).Milliseconds())
+	statusEvent := domain.ProjectRunEventRecord{ID: terminalStatusEventID(runID), RunID: runID, Kind: domain.ProjectRunEventKindStatus, PayloadJSON: next.ResultJSON, Success: next.Status == domain.ProjectRunStatusSucceeded, ExitCode: next.ExitCode, StopReason: next.Error}
+	return m.store.FinalizeProjectRunCompletion(ctx, next, statusEvent)
+}
+
+func (m *CompletionManager) cleanup(ctx context.Context, run domain.ProjectRunRecord, action string) error {
+	if action == domain.ProjectRunCompletionActionNone || strings.TrimSpace(run.SandboxID) == "" {
+		return nil
+	}
+	if action == domain.ProjectRunCompletionActionRemove {
+		if m.removal == nil {
+			return fmt.Errorf("sandbox removal coordinator is required")
+		}
+		result, err := m.removal.Remove(ctx, run.SandboxID, true)
+		if err == nil && result.Removed {
+			return nil
+		}
+		if err == nil {
+			return fmt.Errorf("sandbox removal did not complete")
+		}
+		if errors.Is(err, sandboxes.ErrOwnershipUnknown) && m.sandboxMissing(ctx, run.SandboxID) {
+			return nil
+		}
+		return err
+	}
+	if m.sandboxes == nil || m.lifecycle == nil {
+		return fmt.Errorf("sandbox stop lifecycle is required")
+	}
+	sandbox, err := m.sandboxes.GetSandbox(ctx, run.SandboxID)
+	if err != nil {
+		if completionSandboxMissing(err) {
+			return nil
+		}
+		return err
+	}
+	return m.lifecycle.Stop(ctx, sandbox)
+}
+
+func (m *CompletionManager) sandboxMissing(ctx context.Context, sandboxID string) bool {
+	if m.sandboxes == nil {
+		return false
+	}
+	_, err := m.sandboxes.GetSandbox(ctx, sandboxID)
+	return completionSandboxMissing(err)
+}
+
+func completionSandboxMissing(err error) bool {
+	return err != nil && (errors.Is(err, sql.ErrNoRows) || errors.Is(err, os.ErrNotExist) || errors.Is(err, domain.ErrNotFound))
+}
+
+func completionRetryDelay(attempt int) time.Duration {
+	delays := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second, 30 * time.Second}
+	if attempt <= 0 {
+		return 0
+	}
+	if attempt > len(delays) {
+		return 30 * time.Second
+	}
+	return delays[attempt-1]
+}
+
+func (m *CompletionManager) runLock(runID string) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lock := m.locks[runID]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		m.locks[runID] = lock
+	}
+	return lock
+}
+
+func (m *CompletionManager) signal() {
+	if m == nil {
+		return
+	}
+	select {
+	case m.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (m *CompletionManager) nowUTC() time.Time {
+	if m.now != nil {
+		return m.now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/pkg/runs/completion_test.go
+++ b/pkg/runs/completion_test.go
@@ -1,0 +1,154 @@
+package runs_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samber/do/v2"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/internal/testutil"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/runs"
+	"agent-compose/pkg/storage/configstore"
+)
+
+func TestCompletionCleanupAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		has     bool
+		created bool
+		want    string
+	}{
+		{name: "no sandbox", policy: domain.ProjectRunCleanupStopOnCompletion, want: domain.ProjectRunCompletionActionNone},
+		{name: "keep running", policy: domain.ProjectRunCleanupKeepRunning, has: true, created: true, want: domain.ProjectRunCompletionActionNone},
+		{name: "stop", policy: domain.ProjectRunCleanupStopOnCompletion, has: true, created: true, want: domain.ProjectRunCompletionActionStop},
+		{name: "remove created", policy: domain.ProjectRunCleanupRemoveOnCompletion, has: true, created: true, want: domain.ProjectRunCompletionActionRemove},
+		{name: "remove reused degrades to stop", policy: domain.ProjectRunCleanupRemoveOnCompletion, has: true, want: domain.ProjectRunCompletionActionStop},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runs.CompletionCleanupAction(tt.policy, tt.has, tt.created); got != tt.want {
+				t.Fatalf("CompletionCleanupAction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t *testing.T) {
+	ctx := context.Background()
+	store := newCompletionTestStore(t)
+	run := createCompletionTestRun(t, store, domain.ProjectRunRecord{
+		RunID: "completion-run", ProjectID: "project-1", AgentName: "worker", AgentID: "agent-1",
+		Status: domain.ProjectRunStatusRunning, SandboxID: "sandbox-1", CleanupPolicy: domain.ProjectRunCleanupStopOnCompletion,
+	})
+	sandboxes := completionSandboxStoreFake{sandbox: &domain.Sandbox{Summary: domain.SandboxSummary{ID: run.SandboxID, VMStatus: domain.VMStatusRunning}}}
+	stopper := &completionStopperFake{err: errors.New("stop unavailable")}
+	manager := runs.NewCompletionManager(store, sandboxes, stopper, nil, nil)
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	staged, err := manager.Complete(timeoutCtx, runs.TransitionRequest{
+		RunID: run.RunID, Status: domain.ProjectRunStatusSucceeded, Output: "exact output", ResultJSON: `{"ok":true}`,
+		TerminalEvents: []domain.ProjectRunEventRecord{{ID: "final-agent-event", RunID: run.RunID, Kind: domain.ProjectRunEventKindAgentMessage, Text: "done"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete while cleanup failed: %v", err)
+	}
+	if staged.Status != domain.ProjectRunStatusRunning || staged.CleanupError == "" {
+		t.Fatalf("staged run = %#v, want running with cleanup error", staged)
+	}
+	events, err := store.ListProjectRunEvents(ctx, run.RunID, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].ID != "final-agent-event" || events[0].Kind == domain.ProjectRunEventKindStatus {
+		t.Fatalf("events before cleanup = %#v", events)
+	}
+	journal, err := store.GetProjectRunCompletion(ctx, run.RunID)
+	if err != nil || journal.Attempt != 1 || journal.CleanupAction != domain.ProjectRunCompletionActionStop {
+		t.Fatalf("journal = %#v, err=%v", journal, err)
+	}
+
+	stopper.err = nil
+	if err := store.RecordProjectRunCompletionFailure(ctx, run.RunID, journal.LastError, journal.Attempt, time.Now().Add(-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := manager.Complete(ctx, runs.TransitionRequest{RunID: run.RunID, Status: domain.ProjectRunStatusCanceled, Error: "late cancellation"})
+	if err != nil {
+		t.Fatalf("Complete retry: %v", err)
+	}
+	if completed.Status != domain.ProjectRunStatusSucceeded || completed.Output != "exact output" || completed.ResultJSON != `{"ok":true}` || completed.CleanupError != "" {
+		t.Fatalf("completed run = %#v", completed)
+	}
+	events, err = store.ListProjectRunEvents(ctx, run.RunID, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 || events[1].Kind != domain.ProjectRunEventKindStatus {
+		t.Fatalf("events after cleanup = %#v", events)
+	}
+	if _, err := store.GetProjectRunCompletion(ctx, run.RunID); err == nil {
+		t.Fatal("completion journal remained after terminal commit")
+	}
+}
+
+func TestIntegrationCompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t *testing.T) {
+	TestCompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t)
+}
+
+func TestE2ECompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t *testing.T) {
+	TestCompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t)
+}
+
+type completionSandboxStoreFake struct{ sandbox *domain.Sandbox }
+
+func (s completionSandboxStoreFake) GetSandbox(context.Context, string) (*domain.Sandbox, error) {
+	if s.sandbox == nil {
+		return nil, domain.ErrNotFound
+	}
+	return s.sandbox, nil
+}
+
+type completionStopperFake struct {
+	err   error
+	calls int
+}
+
+func (s *completionStopperFake) Stop(context.Context, *domain.Sandbox) error {
+	s.calls++
+	return s.err
+}
+
+func newCompletionTestStore(t *testing.T) *configstore.ConfigStore {
+	t.Helper()
+	root := t.TempDir()
+	di := do.New()
+	do.ProvideValue(di, context.Background())
+	do.ProvideValue(di, &appconfig.Config{DataRoot: root, DbAddr: filepath.Join(root, "data.db")})
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.DB().Close() })
+	if _, err := store.UpsertProject(context.Background(), domain.ProjectRecord{ID: "project-1", Name: "project", SourcePath: "/project", SourceJSON: `{}`}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertProjectAgent(context.Background(), domain.ProjectAgentRecord{ID: "agent-1", ProjectID: "project-1", AgentName: "worker"}); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func createCompletionTestRun(t *testing.T, store *configstore.ConfigStore, run domain.ProjectRunRecord) domain.ProjectRunRecord {
+	t.Helper()
+	created, err := store.CreateProjectRun(context.Background(), run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created
+}

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -131,6 +131,7 @@ type Controller struct {
 	runLogs          *RunLogHub
 	lifecycleLocks   *sandboxes.LifecycleLocks
 	removal          SandboxRemoval
+	completion       *CompletionManager
 }
 
 type llmFacadeTokenDeleter interface {
@@ -161,6 +162,7 @@ type ControllerDependencies struct {
 	RunLogs          *RunLogHub
 	LifecycleLocks   *sandboxes.LifecycleLocks
 	Removal          SandboxRemoval
+	Completion       *CompletionManager
 }
 
 type SandboxRemoval interface {
@@ -187,6 +189,7 @@ func NewController(deps ControllerDependencies) *Controller {
 		runLogs:          deps.RunLogs,
 		lifecycleLocks:   deps.LifecycleLocks,
 		removal:          deps.Removal,
+		completion:       deps.Completion,
 	}
 }
 
@@ -266,6 +269,7 @@ func (c *Controller) StartProjectRun(ctx context.Context, req RunAgentRequest) (
 		TriggerID:       req.TriggerID,
 		Prompt:          req.Prompt,
 		Driver:          req.Driver,
+		CleanupPolicy:   CleanupPolicyFromProto(req.CleanupPolicy),
 		ClientRequestID: req.ClientRequestID,
 	})
 	if err != nil {
@@ -290,6 +294,10 @@ func (c *Controller) RunProjectAgent(ctx context.Context, req RunAgentRequest, s
 }
 
 func (c *Controller) RunProjectCommandAttach(ctx context.Context, receive RunAttachReceiver, send RunAttachSender) error {
+	return c.RunProjectCommandAttachRegistered(ctx, receive, send, nil)
+}
+
+func (c *Controller) RunProjectCommandAttachRegistered(ctx context.Context, receive RunAttachReceiver, send RunAttachSender, onStarted func(string)) error {
 	if receive == nil || send == nil {
 		return fmt.Errorf("run attach stream is required")
 	}
@@ -326,6 +334,9 @@ func (c *Controller) RunProjectCommandAttach(ctx context.Context, receive RunAtt
 	if err != nil {
 		return err
 	}
+	if onStarted != nil {
+		onStarted(started.Run.RunID)
+	}
 	run, execErr, err := c.executeStartedProjectRunAttach(ctx, started.Run, req, started.Warnings, start, mode, receive, send)
 	if err != nil {
 		return err
@@ -346,7 +357,7 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 			RunID: run.RunID,
 			Error: fmt.Sprintf("workspace preparation failed: %v", err),
 		}
-		run, markErr := markProjectRunTerminalError(transitionCtx, coordinator, transition, err)
+		run, markErr := c.completeProjectRunError(transitionCtx, ctx, transition, err)
 		if markErr != nil {
 			return domain.ProjectRunRecord{}, nil, markErr
 		}
@@ -362,30 +373,33 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 		if sandboxResult.Sandbox != nil {
 			transition.SandboxID = sandboxResult.Sandbox.Summary.ID
 		}
-		run, markErr := markProjectRunTerminalError(transitionCtx, coordinator, transition, err)
+		run, markErr := c.completeProjectRunError(transitionCtx, ctx, transition, err)
 		if markErr != nil {
 			return domain.ProjectRunRecord{}, nil, markErr
 		}
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 		run = withRunWarnings(run, warnings)
 		return run, err, nil
 	}
 	warnings = append(warnings, sandboxResult.Warnings...)
 	if err := ctx.Err(); err != nil {
-		run, markErr := coordinator.MarkCanceled(transitionCtx, TransitionRequest{
+		stopReason := err.Error()
+		if cause := context.Cause(ctx); cause != nil {
+			stopReason = cause.Error()
+		}
+		run, markErr := c.completeProjectRun(transitionCtx, TransitionRequest{
 			RunID:     run.RunID,
+			Status:    domain.ProjectRunStatusCanceled,
 			SandboxID: sandboxResult.Sandbox.Summary.ID,
-			Error:     err.Error(),
+			Error:     stopReason,
 		})
 		if markErr != nil {
 			return domain.ProjectRunRecord{}, nil, markErr
 		}
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 		run = withRunWarnings(run, warnings)
 		return run, err, nil
 	}
 	if current, loadErr := c.configDB.GetProjectRun(transitionCtx, run.RunID); loadErr == nil && StatusIsTerminal(current.Status) {
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, current, sandboxResult, req.CleanupPolicy)
+		run = current
 		run = withRunWarnings(run, warnings)
 		return run, context.Canceled, nil
 	}
@@ -397,26 +411,26 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 	if commandText != "" {
 		transition, execErr := c.executeProjectRunCommand(ctx, run, sandboxResult.Sandbox, req, commandText, stream)
 		if execErr != nil || transition.ExitCode != 0 {
-			run, err = markProjectRunTerminalError(transitionCtx, coordinator, transition, execErr)
+			run, err = c.completeProjectRunError(transitionCtx, ctx, transition, execErr)
 			if err != nil {
 				return domain.ProjectRunRecord{}, nil, err
 			}
-			run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 			run = withRunWarnings(run, warnings)
 			return run, execErr, nil
 		}
-		run, err = coordinator.MarkSucceeded(transitionCtx, transition)
+		transition.Status = domain.ProjectRunStatusSucceeded
+		run, err = c.completeProjectRun(transitionCtx, transition)
 		if err != nil {
 			return domain.ProjectRunRecord{}, nil, err
 		}
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 		run = withRunWarnings(run, warnings)
 		return run, nil, nil
 	}
 	agentConfig, err := c.projectRunAgentConfig(ctx, run)
 	if err != nil {
-		run, markErr := coordinator.MarkFailed(transitionCtx, TransitionRequest{
+		run, markErr := c.completeProjectRun(transitionCtx, TransitionRequest{
 			RunID:     run.RunID,
+			Status:    domain.ProjectRunStatusFailed,
 			SandboxID: sandboxResult.Sandbox.Summary.ID,
 			ExitCode:  1,
 			Error:     fmt.Sprintf("agent execution failed: %v", err),
@@ -424,14 +438,14 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 		if markErr != nil {
 			return domain.ProjectRunRecord{}, nil, markErr
 		}
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 		run = withRunWarnings(run, warnings)
 		return run, err, nil
 	}
 	if c.executor == nil {
 		err = fmt.Errorf("executor is required")
-		run, markErr := coordinator.MarkFailed(transitionCtx, TransitionRequest{
+		run, markErr := c.completeProjectRun(transitionCtx, TransitionRequest{
 			RunID:     run.RunID,
+			Status:    domain.ProjectRunStatusFailed,
 			SandboxID: sandboxResult.Sandbox.Summary.ID,
 			ExitCode:  1,
 			Error:     fmt.Sprintf("agent execution failed: %v", err),
@@ -439,7 +453,6 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 		if markErr != nil {
 			return domain.ProjectRunRecord{}, nil, markErr
 		}
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 		run = withRunWarnings(run, warnings)
 		return run, err, nil
 	}
@@ -455,19 +468,18 @@ func (c *Controller) executeStartedProjectRun(ctx context.Context, coordinator *
 	transition := TransitionFromAgentCell(run, sandboxResult.Sandbox, cell, execErr)
 	transition.TerminalEvents = projectAgentTerminalEvents(run, cell, assistantEvent, execErr)
 	if execErr != nil || !cell.Success {
-		run, err = markProjectRunTerminalError(transitionCtx, coordinator, transition, execErr)
+		run, err = c.completeProjectRunError(transitionCtx, ctx, transition, execErr)
 		if err != nil {
 			return domain.ProjectRunRecord{}, nil, err
 		}
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 		run = withRunWarnings(run, warnings)
 		return run, execErr, nil
 	}
-	run, err = coordinator.MarkSucceeded(transitionCtx, transition)
+	transition.Status = domain.ProjectRunStatusSucceeded
+	run, err = c.completeProjectRun(transitionCtx, transition)
 	if err != nil {
 		return domain.ProjectRunRecord{}, nil, err
 	}
-	run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 	run = withRunWarnings(run, warnings)
 	return run, nil, nil
 }
@@ -482,6 +494,90 @@ func markProjectRunTerminalError(ctx context.Context, coordinator *Coordinator, 
 		return coordinator.MarkCanceled(ctx, transition)
 	}
 	return coordinator.MarkFailed(ctx, transition)
+}
+
+func (c *Controller) completeProjectRunError(ctx, executionCtx context.Context, transition TransitionRequest, err error) (domain.ProjectRunRecord, error) {
+	transition.Status = domain.ProjectRunStatusFailed
+	if errors.Is(err, context.Canceled) {
+		transition.Status = domain.ProjectRunStatusCanceled
+		if cause := context.Cause(executionCtx); cause != nil {
+			transition.Error = cause.Error()
+		}
+	}
+	return c.completeProjectRun(ctx, transition)
+}
+
+func (c *Controller) completeProjectRun(ctx context.Context, transition TransitionRequest) (domain.ProjectRunRecord, error) {
+	manager, err := c.completionManager()
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	if manager == nil {
+		return c.completeProjectRunWithoutJournal(ctx, transition)
+	}
+	return manager.Complete(ctx, transition)
+}
+
+func (c *Controller) completeProjectRunWithoutJournal(ctx context.Context, transition TransitionRequest) (domain.ProjectRunRecord, error) {
+	current, err := c.configDB.GetProjectRun(ctx, transition.RunID)
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	action := CompletionCleanupAction(current.CleanupPolicy, current.SandboxID != "", current.SandboxCreated)
+	if action != domain.ProjectRunCompletionActionNone {
+		sandbox, loadErr := c.store.GetSandbox(ctx, current.SandboxID)
+		if loadErr != nil && !completionSandboxMissing(loadErr) {
+			return current, loadErr
+		}
+		if sandbox != nil {
+			policy := agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION
+			if action == domain.ProjectRunCompletionActionRemove {
+				policy = agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION
+			}
+			if err := c.cleanupProjectRunSandboxByPolicy(ctx, SandboxResult{Sandbox: sandbox, Created: current.SandboxCreated}, policy); err != nil {
+				current.Status = domain.ProjectRunStatusRunning
+				current.CleanupError = err.Error()
+				applyProjectRunTransitionFields(&current, transition)
+				return c.configDB.UpdateProjectRun(ctx, current)
+			}
+		}
+	}
+	return NewCoordinator(c.configDB, domain.StableProjectRunID).TransitionRun(ctx, transition)
+}
+
+type controllerCompletionStopper struct{ controller *Controller }
+
+func (s controllerCompletionStopper) Stop(ctx context.Context, sandbox *domain.Sandbox) error {
+	return s.controller.stopProjectRunSandbox(ctx, sandbox)
+}
+
+type controllerCompletionRemoval struct{ controller *Controller }
+
+func (r controllerCompletionRemoval) Remove(ctx context.Context, sandboxID string, _ bool) (sandboxes.RemovalResult, error) {
+	sandbox, err := r.controller.store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return sandboxes.RemovalResult{}, err
+	}
+	if err := r.controller.cleanupProjectRunSandboxByPolicy(ctx, SandboxResult{Sandbox: sandbox, Created: true}, agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION); err != nil {
+		return sandboxes.RemovalResult{SandboxID: sandboxID}, err
+	}
+	return sandboxes.RemovalResult{SandboxID: sandboxID, Stopped: true, Removed: true}, nil
+}
+
+func (c *Controller) completionManager() (*CompletionManager, error) {
+	if c.completion != nil {
+		return c.completion, nil
+	}
+	store, ok := c.configDB.(CompletionStore)
+	if !ok {
+		return nil, nil
+	}
+	removal := c.removal
+	if removal == nil {
+		removal = controllerCompletionRemoval{controller: c}
+	}
+	c.completion = NewCompletionManager(store, c.store, controllerCompletionStopper{controller: c}, removal, slog.Default())
+	return c.completion, nil
 }
 
 func (c *Controller) executeProjectRunCommand(ctx context.Context, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, commandText string, sink *StreamSink) (TransitionRequest, error) {
@@ -600,7 +696,7 @@ func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run dom
 	transitionCtx := context.WithoutCancel(ctx)
 	prepared, err := c.prepareProjectRun(ctx, run, req.Env)
 	if err != nil {
-		run, markErr := markProjectRunTerminalError(transitionCtx, coordinator, TransitionRequest{
+		run, markErr := c.completeProjectRunError(transitionCtx, ctx, TransitionRequest{
 			RunID: run.RunID,
 			Error: fmt.Sprintf("workspace preparation failed: %v", err),
 		}, err)
@@ -615,10 +711,7 @@ func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run dom
 		if sandboxResult.Sandbox != nil {
 			transition.SandboxID = sandboxResult.Sandbox.Summary.ID
 		}
-		run, markErr := markProjectRunTerminalError(transitionCtx, coordinator, transition, err)
-		if sandboxResult.Sandbox != nil {
-			run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
-		}
+		run, markErr := c.completeProjectRunError(transitionCtx, ctx, transition, err)
 		return withRunWarnings(run, warnings), err, markErr
 	}
 	warnings = append(warnings, sandboxResult.Warnings...)
@@ -636,20 +729,19 @@ func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run dom
 		transition, execErr = c.runCommandInteraction(ctx, coordinator, run, sandboxResult.Sandbox, req, commandText, start, receive, send)
 	}
 	if execErr != nil || transition.ExitCode != 0 {
-		run, err = markProjectRunTerminalError(transitionCtx, coordinator, transition, execErr)
+		run, err = c.completeProjectRunError(transitionCtx, ctx, transition, execErr)
 		if err != nil {
 			return domain.ProjectRunRecord{}, nil, err
 		}
-		run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 		run = withRunWarnings(run, warnings)
 		_ = send(runAttachResultResponse(run, transition, false))
 		return run, execErr, nil
 	}
-	run, err = coordinator.MarkSucceeded(transitionCtx, transition)
+	transition.Status = domain.ProjectRunStatusSucceeded
+	run, err = c.completeProjectRun(transitionCtx, transition)
 	if err != nil {
 		return domain.ProjectRunRecord{}, nil, err
 	}
-	run = c.cleanupProjectRunSandbox(transitionCtx, coordinator, run, sandboxResult, req.CleanupPolicy)
 	run = withRunWarnings(run, warnings)
 	if err := send(runAttachResultResponse(run, transition, true)); err != nil {
 		return domain.ProjectRunRecord{}, nil, err
@@ -2067,6 +2159,11 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 			if err := validateProjectRunSandboxOwnership(sandbox, run); err != nil {
 				return SandboxResult{}, err
 			}
+			if pendingRunID, pending, err := c.pendingCompletionForSandbox(ctx, sandboxID); err != nil {
+				return SandboxResult{}, err
+			} else if pending && pendingRunID != run.RunID {
+				return SandboxResult{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("sandbox %s has pending completion for run %s", sandboxID, pendingRunID), nil)
+			}
 			if sandbox.Summary.VMStatus == domain.VMStatusDeleting {
 				return SandboxResult{Sandbox: sandbox}, fmt.Errorf("sandbox %s is being deleted", sandboxID)
 			}
@@ -2076,6 +2173,9 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 			}
 			if err := c.validateSandboxRuntimeDriver(driver); err != nil {
 				return SandboxResult{Sandbox: sandbox}, err
+			}
+			if _, err := NewCoordinator(c.configDB, domain.StableProjectRunID).BindSandbox(ctx, run.RunID, sandboxID, false); err != nil {
+				return SandboxResult{Sandbox: sandbox}, fmt.Errorf("bind reused sandbox to project run: %w", err)
 			}
 			if sandbox.Summary.VMStatus != domain.VMStatusRunning {
 				if err := c.applyJupyterOptionsToSandbox(sandbox, jupyterOptions); err != nil {
@@ -2139,6 +2239,14 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 	if err != nil {
 		return SandboxResult{}, err
 	}
+	if _, err := NewCoordinator(c.configDB, domain.StableProjectRunID).BindSandbox(ctx, run.RunID, sandbox.Summary.ID, true); err != nil {
+		bindErr := fmt.Errorf("bind created sandbox to project run: %w", err)
+		if c.removal == nil {
+			return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, bindErr
+		}
+		_, removeErr := c.removal.Remove(context.WithoutCancel(ctx), sandbox.Summary.ID, true)
+		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, errors.Join(bindErr, removeErr)
+	}
 	llms.SetSandboxProviderEnvItems(sandbox, prepared.ProviderEnvItems)
 	if err := c.ensureProjectRunSandboxWorkspace(ctx, sandbox); err != nil {
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
@@ -2194,6 +2302,14 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 	}
 	volumeWarnings = append(warnings, volumeWarnings...)
 	return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, nil
+}
+
+func (c *Controller) pendingCompletionForSandbox(ctx context.Context, sandboxID string) (string, bool, error) {
+	store, ok := c.configDB.(CompletionStore)
+	if !ok {
+		return "", false, nil
+	}
+	return store.ProjectRunCompletionForSandbox(ctx, sandboxID)
 }
 
 func (c *Controller) validateSandboxRuntimeDriver(driver string) error {

--- a/pkg/runs/coordinator.go
+++ b/pkg/runs/coordinator.go
@@ -23,6 +23,7 @@ type StartRequest struct {
 	TriggerID       string
 	Prompt          string
 	Driver          string
+	CleanupPolicy   string
 	ClientRequestID string
 }
 
@@ -147,6 +148,7 @@ func (c *Coordinator) BeginRun(ctx context.Context, req StartRequest) (domain.Pr
 		Prompt:          req.Prompt,
 		Driver:          driver,
 		ImageRef:        firstNonEmpty(agent.GuestImage, projectAgent.Image),
+		CleanupPolicy:   NormalizeCleanupPolicy(req.CleanupPolicy),
 		ResultJSON:      "{}",
 	}
 	var initialEvents []domain.ProjectRunEventRecord
@@ -158,6 +160,19 @@ func (c *Coordinator) BeginRun(ctx context.Context, req StartRequest) (domain.Pr
 		return domain.ProjectRunRecord{}, err
 	}
 	return created, nil
+}
+
+func (c *Coordinator) BindSandbox(ctx context.Context, runID, sandboxID string, created bool) (domain.ProjectRunRecord, error) {
+	current, err := c.store.GetProjectRun(ctx, strings.TrimSpace(runID))
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	if StatusIsTerminal(current.Status) {
+		return domain.ProjectRunRecord{}, fmt.Errorf("project run %s is already terminal", current.RunID)
+	}
+	current.SandboxID = strings.TrimSpace(sandboxID)
+	current.SandboxCreated = created
+	return c.store.UpdateProjectRun(ctx, current)
 }
 
 func (c *Coordinator) MarkRunning(ctx context.Context, runID, sessionID string) (domain.ProjectRunRecord, error) {

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -669,9 +669,10 @@ func TestRunsControllerExistingSandboxDoesNotRepeatAgentEnvironmentPreparation(t
 	if err := fixture.store.UpdateSandbox(fixture.ctx, sandbox); err != nil {
 		t.Fatalf("UpdateSandbox returned error: %v", err)
 	}
-	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, domain.ProjectRunRecord{
+	run := persistControllerFixtureRun(t, fixture, domain.ProjectRunRecord{
 		RunID: "run-existing", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", Driver: driverpkg.RuntimeDriverDocker, ImageRef: "guest:latest",
-	}, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
+	})
+	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, run, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
 	if err != nil {
 		t.Fatalf("ensureProjectRunSandbox returned error: %v", err)
 	}
@@ -696,9 +697,10 @@ func TestRunsControllerFailedFreshSandboxRetryPreparesAgentEnvironment(t *testin
 		t.Fatalf("UpdateSandbox returned error: %v", err)
 	}
 
-	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, domain.ProjectRunRecord{
+	run := persistControllerFixtureRun(t, fixture, domain.ProjectRunRecord{
 		RunID: "run-retry", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", Driver: driverpkg.RuntimeDriverDocker, ImageRef: "guest:latest",
-	}, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
+	})
+	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, run, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
 	if err != nil {
 		t.Fatalf("ensureProjectRunSandbox returned error: %v", err)
 	}
@@ -730,9 +732,10 @@ func TestRunsControllerReleasedRuntimeResumePreparesAgentEnvironment(t *testing.
 		t.Fatalf("SaveVMState returned error: %v", err)
 	}
 
-	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, domain.ProjectRunRecord{
+	run := persistControllerFixtureRun(t, fixture, domain.ProjectRunRecord{
 		RunID: "run-released", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", Driver: driverpkg.RuntimeDriverDocker, ImageRef: "guest:latest",
-	}, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
+	})
+	result, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, run, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
 	if err != nil {
 		t.Fatalf("ensureProjectRunSandbox returned error: %v", err)
 	}
@@ -1528,6 +1531,24 @@ func newControllerRunFixture(t *testing.T) *controllerRunFixture {
 	}
 }
 
+func persistControllerFixtureRun(t *testing.T, fixture *controllerRunFixture, run domain.ProjectRunRecord) domain.ProjectRunRecord {
+	t.Helper()
+	created, err := fixture.configDB.CreateProjectRun(fixture.ctx, run)
+	if err != nil {
+		t.Fatalf("CreateProjectRun returned error: %v", err)
+	}
+	return created
+}
+
+func assertNoTerminalStatusEvent(t *testing.T, events []domain.ProjectRunEventRecord) {
+	t.Helper()
+	for _, event := range events {
+		if event.Kind == domain.ProjectRunEventKindStatus {
+			t.Fatalf("unexpected terminal status event: %#v", event)
+		}
+	}
+}
+
 func runAgentWithRemoveOnCompletion(t *testing.T, fixture *controllerRunFixture, extra func(*RunAgentRequest)) (domain.ProjectRunRecord, error, error) {
 	t.Helper()
 	req := RunAgentRequest{
@@ -1639,9 +1660,10 @@ func TestRunsControllerRunProjectAgentCleanupErrorRecording(t *testing.T) {
 		if err != nil || execErr != nil {
 			t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
 		}
-		if run.Status != domain.ProjectRunStatusSucceeded || !strings.Contains(run.CleanupError, "stop failed") {
+		if run.Status != domain.ProjectRunStatusRunning || !strings.Contains(run.CleanupError, "stop failed") {
 			t.Fatalf("run = %#v", run)
 		}
+		assertNoTerminalStatusEvent(t, fixture.configDB.events)
 		if _, statErr := os.Stat(fixture.store.SandboxDir(run.SandboxID)); statErr != nil {
 			t.Fatalf("sandbox dir should remain when cleanup fails: %v", statErr)
 		}
@@ -1657,6 +1679,10 @@ func TestRunsControllerRunProjectAgentCleanupErrorRecording(t *testing.T) {
 		if !strings.Contains(run.CleanupError, "runtime remove failed") {
 			t.Fatalf("cleanup error = %q", run.CleanupError)
 		}
+		if run.Status != domain.ProjectRunStatusRunning {
+			t.Fatalf("run status = %q, want running", run.Status)
+		}
+		assertNoTerminalStatusEvent(t, fixture.configDB.events)
 		if _, statErr := os.Stat(fixture.store.SandboxDir(run.SandboxID)); statErr != nil {
 			t.Fatalf("sandbox dir should remain when runtime removal fails: %v", statErr)
 		}
@@ -1671,9 +1697,10 @@ func TestRunsControllerRunProjectAgentCleanupErrorRecording(t *testing.T) {
 		if err != nil || execErr == nil || !strings.Contains(execErr.Error(), "agent failed") {
 			t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
 		}
-		if run.Status != domain.ProjectRunStatusFailed || !strings.Contains(run.Error, "agent failed") || !strings.Contains(run.CleanupError, "stop failed") {
+		if run.Status != domain.ProjectRunStatusRunning || !strings.Contains(run.Error, "agent failed") || !strings.Contains(run.CleanupError, "stop failed") {
 			t.Fatalf("run = %#v", run)
 		}
+		assertNoTerminalStatusEvent(t, fixture.configDB.events)
 	})
 
 	t.Run("session start failure cleans created sandbox", func(t *testing.T) {

--- a/pkg/runs/execution.go
+++ b/pkg/runs/execution.go
@@ -59,3 +59,35 @@ func CleanupPolicyStopsSandbox(policy agentcomposev2.RunSandboxCleanupPolicy) bo
 func CleanupPolicyRemovesSandbox(policy agentcomposev2.RunSandboxCleanupPolicy) bool {
 	return policy == agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION
 }
+
+func CleanupPolicyFromProto(policy agentcomposev2.RunSandboxCleanupPolicy) string {
+	switch policy {
+	case agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_KEEP_RUNNING:
+		return domain.ProjectRunCleanupKeepRunning
+	case agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_REMOVE_ON_COMPLETION:
+		return domain.ProjectRunCleanupRemoveOnCompletion
+	default:
+		return domain.ProjectRunCleanupStopOnCompletion
+	}
+}
+
+func NormalizeCleanupPolicy(policy string) string {
+	switch strings.ToLower(strings.TrimSpace(policy)) {
+	case domain.ProjectRunCleanupKeepRunning:
+		return domain.ProjectRunCleanupKeepRunning
+	case domain.ProjectRunCleanupRemoveOnCompletion:
+		return domain.ProjectRunCleanupRemoveOnCompletion
+	default:
+		return domain.ProjectRunCleanupStopOnCompletion
+	}
+}
+
+func CompletionCleanupAction(policy string, hasSandbox, sandboxCreated bool) string {
+	if !hasSandbox || NormalizeCleanupPolicy(policy) == domain.ProjectRunCleanupKeepRunning {
+		return domain.ProjectRunCompletionActionNone
+	}
+	if NormalizeCleanupPolicy(policy) == domain.ProjectRunCleanupRemoveOnCompletion && sandboxCreated {
+		return domain.ProjectRunCompletionActionRemove
+	}
+	return domain.ProjectRunCompletionActionStop
+}

--- a/pkg/runs/project_run_workspace_ensurer_test.go
+++ b/pkg/runs/project_run_workspace_ensurer_test.go
@@ -50,7 +50,7 @@ func TestRunsControllerProjectRunWorkspaceEnsurerPaths(t *testing.T) {
 
 		result, err := fixture.controller.ensureProjectRunSandbox(
 			fixture.ctx,
-			projectRunEnsurerRecord("run-new"),
+			persistProjectRunEnsurerRecord(t, fixture, "run-new"),
 			prepared,
 			RunAgentRequest{},
 		)
@@ -75,7 +75,7 @@ func TestRunsControllerProjectRunWorkspaceEnsurerPaths(t *testing.T) {
 
 		result, err := fixture.controller.ensureProjectRunSandbox(
 			fixture.ctx,
-			projectRunEnsurerRecord("run-explicit"),
+			persistProjectRunEnsurerRecord(t, fixture, "run-explicit"),
 			Preparation{Workspace: projectRunWorkspaceSnapshot("prepared-conflict")},
 			RunAgentRequest{SandboxID: sandbox.Summary.ID},
 		)
@@ -110,7 +110,7 @@ func TestRunsControllerProjectRunWorkspaceEnsurerPaths(t *testing.T) {
 
 		result, err := fixture.controller.ensureProjectRunSandbox(
 			fixture.ctx,
-			projectRunEnsurerRecord("run-sticky"),
+			persistProjectRunEnsurerRecord(t, fixture, "run-sticky"),
 			Preparation{Workspace: projectRunWorkspaceSnapshot("prepared-conflict")},
 			RunAgentRequest{StickyBindingSchedulerID: "scheduler-1", StickyBindingTriggerID: "trigger-1"},
 		)
@@ -144,7 +144,7 @@ func TestRunsControllerProjectRunWorkspaceEnsurerPaths(t *testing.T) {
 
 		result, err := fixture.controller.ensureProjectRunSandbox(
 			fixture.ctx,
-			projectRunEnsurerRecord("run-running"),
+			persistProjectRunEnsurerRecord(t, fixture, "run-running"),
 			Preparation{Workspace: projectRunWorkspaceSnapshot("prepared-conflict")},
 			RunAgentRequest{SandboxID: sandbox.Summary.ID},
 		)
@@ -249,7 +249,7 @@ func TestRunsControllerProjectRunRuntimeFailurePreservesReadyWorkspace(t *testin
 
 	result, err := fixture.controller.ensureProjectRunSandbox(
 		fixture.ctx,
-		projectRunEnsurerRecord("run-runtime-failure"),
+		persistProjectRunEnsurerRecord(t, fixture, "run-runtime-failure"),
 		prepared,
 		RunAgentRequest{},
 	)
@@ -291,6 +291,16 @@ func projectRunEnsurerRecord(runID string) domain.ProjectRunRecord {
 		Driver:      "docker",
 		ImageRef:    "guest:latest",
 	}
+}
+
+func persistProjectRunEnsurerRecord(t *testing.T, fixture *controllerRunFixture, runID string) domain.ProjectRunRecord {
+	t.Helper()
+	run := projectRunEnsurerRecord(runID)
+	created, err := fixture.configDB.CreateProjectRun(fixture.ctx, run)
+	if err != nil {
+		t.Fatalf("CreateProjectRun returned error: %v", err)
+	}
+	return created
 }
 
 func projectRunWorkspaceSnapshot(id string) *domain.SandboxWorkspace {

--- a/pkg/runs/sandbox_cleanup.go
+++ b/pkg/runs/sandbox_cleanup.go
@@ -9,27 +9,6 @@ import (
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
-func (c *Controller) cleanupProjectRunSandbox(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandboxResult SandboxResult, policy agentcomposev2.RunSandboxCleanupPolicy) domain.ProjectRunRecord {
-	sandbox := sandboxResult.Sandbox
-	if !CleanupPolicyStopsSandbox(policy) || sandbox == nil {
-		return run
-	}
-	cleanupErr := c.cleanupProjectRunSandboxByPolicy(ctx, sandboxResult, policy)
-	if cleanupErr == nil {
-		return run
-	}
-	updated, err := coordinator.TransitionRun(ctx, TransitionRequest{
-		RunID:        run.RunID,
-		Status:       run.Status,
-		SandboxID:    run.SandboxID,
-		CleanupError: cleanupErr.Error(),
-	})
-	if err != nil {
-		return run
-	}
-	return updated
-}
-
 func (c *Controller) cleanupProjectRunSandboxByPolicy(ctx context.Context, sandboxResult SandboxResult, policy agentcomposev2.RunSandboxCleanupPolicy) error {
 	sandbox := sandboxResult.Sandbox
 	if CleanupPolicyRemovesSandbox(policy) && sandboxResult.Created {

--- a/pkg/runs/sticky_scheduler_binding.go
+++ b/pkg/runs/sticky_scheduler_binding.go
@@ -98,6 +98,11 @@ func (c *Controller) resolveStickySchedulerBinding(ctx context.Context, store st
 		if !found {
 			return "", nil, nil, nil
 		}
+		if pendingRunID, pending, err := c.pendingCompletionForSandbox(ctx, binding.SandboxID); err != nil {
+			return "", &binding, nil, err
+		} else if pending {
+			return "", &binding, nil, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("sandbox %s has pending completion for run %s", binding.SandboxID, pendingRunID), nil)
+		}
 		retiringHash, retiring := schedulers.RetiringSchedulerBindingConfigHash(binding)
 		if retiring && retiringHash == configHash {
 			return "", &binding, nil, nil

--- a/pkg/runs/sticky_scheduler_binding_test.go
+++ b/pkg/runs/sticky_scheduler_binding_test.go
@@ -211,6 +211,9 @@ func TestResolveStickySchedulerBindingDoesNotReuseRetiringLegacyBinding(t *testi
 func TestEnsureProjectRunSandboxConcurrentStickyClaimReusesWinner(t *testing.T) {
 	fixture := newControllerRunFixture(t)
 	run := domain.ProjectRunRecord{RunID: "run-1", ProjectID: "project-1", ProjectRevision: 1, ProjectName: "Project", AgentName: "worker", AgentID: "agent-1"}
+	if _, err := fixture.configDB.CreateProjectRun(fixture.ctx, run); err != nil {
+		t.Fatalf("CreateProjectRun returned error: %v", err)
+	}
 	prepared := Preparation{}
 	baseHash := "sha256:scheduler"
 	configHash, err := stickyProjectRunConfigHash(baseHash, run, prepared, "docker", "guest:latest", nil, sandboxstore.CreateSandboxOptions{})

--- a/pkg/storage/configstore/project_run_completion.go
+++ b/pkg/storage/configstore/project_run_completion.go
@@ -1,0 +1,170 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+)
+
+func (s *projectStore) StageProjectRunCompletion(ctx context.Context, completion domain.ProjectRunCompletionRecord, events []domain.ProjectRunEventRecord) (domain.ProjectRunCompletionRecord, bool, error) {
+	completion.RunID = strings.TrimSpace(completion.RunID)
+	if completion.RunID == "" || strings.TrimSpace(completion.TargetStatus) == "" || strings.TrimSpace(completion.TransitionJSON) == "" {
+		return domain.ProjectRunCompletionRecord{}, false, fmt.Errorf("run completion id, target status, and transition are required")
+	}
+	if err := validateRunEventBatch(completion.RunID, events); err != nil {
+		return domain.ProjectRunCompletionRecord{}, false, err
+	}
+	now := time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return domain.ProjectRunCompletionRecord{}, false, fmt.Errorf("begin stage project run completion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, `INSERT INTO project_run_completion(
+		run_id, target_status, transition_json, cleanup_action, attempt, last_error, next_attempt_at, created_at, updated_at
+	) VALUES(?, ?, ?, ?, 0, '', 0, ?, ?) ON CONFLICT(run_id) DO NOTHING`,
+		completion.RunID, completion.TargetStatus, completion.TransitionJSON, completion.CleanupAction, now.UnixMilli(), now.UnixMilli())
+	if err != nil {
+		return domain.ProjectRunCompletionRecord{}, false, fmt.Errorf("insert project run completion %s: %w", completion.RunID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return domain.ProjectRunCompletionRecord{}, false, fmt.Errorf("inspect project run completion insert %s: %w", completion.RunID, err)
+	}
+	created := rows > 0
+	if created {
+		if _, _, err := appendProjectRunEventsTx(ctx, tx, events); err != nil {
+			return domain.ProjectRunCompletionRecord{}, false, fmt.Errorf("append staged project run completion events: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE project_run SET status = 'running', cleanup_error = '',
+			started_at = CASE WHEN started_at = 0 THEN ? ELSE started_at END, updated_at = ?
+			WHERE run_id = ? AND status IN ('pending', 'running')`, now.UnixMilli(), now.Unix(), completion.RunID); err != nil {
+			return domain.ProjectRunCompletionRecord{}, false, fmt.Errorf("keep project run %s active during completion: %w", completion.RunID, err)
+		}
+	}
+	stored, err := getProjectRunCompletionTx(ctx, tx, completion.RunID)
+	if err != nil {
+		return domain.ProjectRunCompletionRecord{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.ProjectRunCompletionRecord{}, false, fmt.Errorf("commit staged project run completion: %w", err)
+	}
+	return stored, created, nil
+}
+
+func (s *projectStore) GetProjectRunCompletion(ctx context.Context, runID string) (domain.ProjectRunCompletionRecord, error) {
+	return scanProjectRunCompletion(s.db.QueryRowContext(ctx, projectRunCompletionSelect+` WHERE run_id = ?`, strings.TrimSpace(runID)).Scan)
+}
+
+func (s *projectStore) ListDueProjectRunCompletions(ctx context.Context, now time.Time, limit int) ([]domain.ProjectRunCompletionRecord, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, projectRunCompletionSelect+` WHERE next_attempt_at <= ? ORDER BY next_attempt_at, created_at LIMIT ?`, now.UTC().UnixMilli(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("query due project run completions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var items []domain.ProjectRunCompletionRecord
+	for rows.Next() {
+		item, scanErr := scanProjectRunCompletion(rows.Scan)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func (s *projectStore) RecordProjectRunCompletionFailure(ctx context.Context, runID, message string, attempt int, next time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin record project run completion failure: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `UPDATE project_run_completion SET attempt = ?, last_error = ?, next_attempt_at = ?, updated_at = ? WHERE run_id = ?`, attempt, message, next.UTC().UnixMilli(), time.Now().UTC().UnixMilli(), runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE project_run SET cleanup_error = ?, updated_at = ? WHERE run_id = ?`, message, time.Now().UTC().Unix(), runID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *projectStore) FinalizeProjectRunCompletion(ctx context.Context, run domain.ProjectRunRecord, statusEvent domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error) {
+	run, err := projects.NormalizeRunRecord(run)
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return domain.ProjectRunRecord{}, fmt.Errorf("begin finalize project run completion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := getProjectRunCompletionTx(ctx, tx, run.RunID); err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	run.CleanupError = ""
+	result, err := tx.ExecContext(ctx, `UPDATE project_run SET
+		project_id=?, project_name=?, project_revision=?, agent_name=?, agent_id=?, source=?, scheduler_id=?, scheduler_run_id=?, trigger_id=?, status=?,
+		sandbox_id=?, exit_code=?, error=?, prompt=?, output=?, result_json=?, logs_path=?, artifacts_dir=?, cleanup_error='', cleanup_policy=?, sandbox_created=?, driver=?, image_ref=?,
+		started_at=?, completed_at=?, duration_ms=?, updated_at=? WHERE run_id=?`,
+		run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
+		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
+		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, time.Now().UTC().Unix(), run.RunID)
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return domain.ProjectRunRecord{}, domain.ResourceError(domain.ErrNotFound, "project run", run.RunID, "project run not found", nil)
+	}
+	if _, _, err := appendProjectRunEventsTx(ctx, tx, []domain.ProjectRunEventRecord{statusEvent}); err != nil {
+		return domain.ProjectRunRecord{}, fmt.Errorf("append terminal project run status event: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM project_run_completion WHERE run_id = ?`, run.RunID); err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	stored, err := getProjectRunTx(ctx, tx, run.RunID)
+	if err != nil {
+		return domain.ProjectRunRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.ProjectRunRecord{}, fmt.Errorf("commit finalized project run completion: %w", err)
+	}
+	return stored, nil
+}
+
+func (s *projectStore) ProjectRunCompletionForSandbox(ctx context.Context, sandboxID string) (string, bool, error) {
+	var runID string
+	err := s.db.QueryRowContext(ctx, `SELECT c.run_id FROM project_run_completion c JOIN project_run r ON r.run_id=c.run_id WHERE r.sandbox_id=? LIMIT 1`, strings.TrimSpace(sandboxID)).Scan(&runID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	return runID, err == nil, err
+}
+
+const projectRunCompletionSelect = `SELECT run_id, target_status, transition_json, cleanup_action, attempt, last_error, next_attempt_at, created_at, updated_at FROM project_run_completion`
+
+func getProjectRunCompletionTx(ctx context.Context, tx *sql.Tx, runID string) (domain.ProjectRunCompletionRecord, error) {
+	return scanProjectRunCompletion(tx.QueryRowContext(ctx, projectRunCompletionSelect+` WHERE run_id = ?`, runID).Scan)
+}
+
+func scanProjectRunCompletion(scan func(...any) error) (domain.ProjectRunCompletionRecord, error) {
+	var item domain.ProjectRunCompletionRecord
+	var next, created, updated int64
+	if err := scan(&item.RunID, &item.TargetStatus, &item.TransitionJSON, &item.CleanupAction, &item.Attempt, &item.LastError, &next, &created, &updated); err != nil {
+		return domain.ProjectRunCompletionRecord{}, err
+	}
+	if next > 0 {
+		item.NextAttemptAt = time.UnixMilli(next).UTC()
+	}
+	item.CreatedAt = time.UnixMilli(created).UTC()
+	item.UpdatedAt = time.UnixMilli(updated).UTC()
+	return item, nil
+}

--- a/pkg/storage/configstore/project_run_event_transaction.go
+++ b/pkg/storage/configstore/project_run_event_transaction.go
@@ -28,12 +28,12 @@ func (s *projectStore) CreateProjectRunWithEvents(ctx context.Context, run Proje
 	}
 	result, err := tx.ExecContext(ctx, `INSERT INTO project_run(
 		run_id, project_id, project_name, project_revision, agent_name, agent_id, source, scheduler_id, scheduler_run_id, trigger_id, status,
-		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, driver, image_ref,
+		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
 		started_at, completed_at, duration_ms, created_at, updated_at
-	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON CONFLICT(run_id) DO NOTHING`,
 		run.RunID, run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, run.CreatedAt.Unix(), run.UpdatedAt.Unix())
 	if err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("insert project run %s: %w", run.RunID, err)
@@ -78,10 +78,10 @@ func (s *projectStore) UpdateProjectRunWithEvents(ctx context.Context, run Proje
 	defer func() { _ = tx.Rollback() }()
 	result, err := tx.ExecContext(ctx, `UPDATE project_run SET
 		project_id = ?, project_name = ?, project_revision = ?, agent_name = ?, agent_id = ?, source = ?, scheduler_id = ?, scheduler_run_id = ?, trigger_id = ?, status = ?,
-		sandbox_id = ?, exit_code = ?, error = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, driver = ?, image_ref = ?,
+		sandbox_id = ?, exit_code = ?, error = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, cleanup_policy = ?, sandbox_created = ?, driver = ?, image_ref = ?,
 		started_at = ?, completed_at = ?, duration_ms = ?, updated_at = ? WHERE run_id = ?`,
 		run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, now.Unix(), run.RunID)
 	if err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("update project run %s: %w", run.RunID, err)

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -414,11 +414,11 @@ func (s *projectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecor
 	run.UpdatedAt = now
 	if _, err := s.db.ExecContext(ctx, `INSERT INTO project_run(
 		run_id, project_id, project_name, project_revision, agent_name, agent_id, source, scheduler_id, scheduler_run_id, trigger_id, status,
-		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, driver, image_ref,
+		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
 		started_at, completed_at, duration_ms, created_at, updated_at
-	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.RunID, run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, run.CreatedAt.Unix(), run.UpdatedAt.Unix()); err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("insert project run %s: %w", run.RunID, err)
 	}
@@ -433,11 +433,11 @@ func (s *projectStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecor
 	now := time.Now().UTC()
 	result, err := s.db.ExecContext(ctx, `UPDATE project_run SET
 		project_id = ?, project_name = ?, project_revision = ?, agent_name = ?, agent_id = ?, source = ?, scheduler_id = ?, scheduler_run_id = ?, trigger_id = ?, status = ?,
-		sandbox_id = ?, exit_code = ?, error = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, driver = ?, image_ref = ?,
+		sandbox_id = ?, exit_code = ?, error = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, cleanup_policy = ?, sandbox_created = ?, driver = ?, image_ref = ?,
 		started_at = ?, completed_at = ?, duration_ms = ?, updated_at = ?
 		WHERE run_id = ?`,
 		run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, now.Unix(), run.RunID)
 	if err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("update project run %s: %w", run.RunID, err)

--- a/pkg/storage/sqlite/migrations/000010_project_run_completion.sql
+++ b/pkg/storage/sqlite/migrations/000010_project_run_completion.sql
@@ -1,0 +1,18 @@
+ALTER TABLE project_run ADD COLUMN cleanup_policy TEXT NOT NULL DEFAULT 'stop_on_completion';
+ALTER TABLE project_run ADD COLUMN sandbox_created INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE project_run_completion (
+    run_id TEXT PRIMARY KEY,
+    target_status TEXT NOT NULL,
+    transition_json TEXT NOT NULL,
+    cleanup_action TEXT NOT NULL,
+    attempt INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NOT NULL DEFAULT '',
+    next_attempt_at INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY(run_id) REFERENCES project_run(run_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_project_run_completion_retry
+    ON project_run_completion(next_attempt_at, created_at);

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -39,7 +39,7 @@ func TestMigrationBaseline(t *testing.T) {
 		"capability_gateway", "volumes", "project_volumes", "scheduler_trigger",
 		"scheduler_run", "scheduler_event", "scheduler_state", "scheduler_sandbox_binding", "project",
 		"project_revision", "project_agent", "project_scheduler", "project_run",
-		"project_run_event", "event", "webhook_source", "event_delivery", "event_sandbox_link",
+		"project_run_event", "project_run_completion", "event", "webhook_source", "event_delivery", "event_sandbox_link",
 		"sandbox_projection_meta", "sandboxes",
 	}
 	for _, table := range tables {
@@ -70,6 +70,7 @@ func TestMigrationBaseline(t *testing.T) {
 		"idx_scheduler_trigger_schedule",
 		"idx_project_name", "idx_project_revision_hash", "idx_project_run_agent",
 		"idx_project_run_event_sequence", "idx_project_run_project_status", "idx_project_run_sandbox",
+		"idx_project_run_completion_retry",
 		"idx_project_run_scheduler", "idx_project_scheduler_agent",
 		"idx_project_run_scheduler_run", "idx_project_short_id", "idx_project_source_path",
 		"idx_project_volumes_volume", "idx_sandboxes_project_updated", "idx_sandboxes_type_updated", "idx_sandboxes_updated",

--- a/pkg/storage/sqlite/v2_migration_design_test.go
+++ b/pkg/storage/sqlite/v2_migration_design_test.go
@@ -258,6 +258,36 @@ func TestV2MigrationDesignAppliesEachNewVersionIndependently(t *testing.T) {
 	assertNoForeignKeyViolations(t, db)
 }
 
+func TestProjectRunCompletionMigrationPreservesV9Runs(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	chain := loadV2MigrationDesignChain(t)
+	if err := applyMigrationSet(ctx, db, chain[:9]); err != nil {
+		t.Fatalf("apply v9 prefix: %v", err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO project(id,name) VALUES('project-1','project')`,
+		`INSERT INTO project_agent(id,project_id,agent_name,created_at,updated_at) VALUES('agent-1','project-1','worker',1,1)`,
+		`INSERT INTO project_run(run_id,project_id,agent_id,status,sandbox_id,result_json,created_at,updated_at) VALUES('run-1','project-1','agent-1','running','sandbox-1','{}',1,1)`,
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			t.Fatalf("seed v9 run with %q: %v", statement, err)
+		}
+	}
+	if err := applyMigrationSet(ctx, db, chain); err != nil {
+		t.Fatalf("apply v10 migration: %v", err)
+	}
+	var policy string
+	var created int
+	if err := db.QueryRowContext(ctx, `SELECT cleanup_policy, sandbox_created FROM project_run WHERE run_id='run-1'`).Scan(&policy, &created); err != nil {
+		t.Fatal(err)
+	}
+	if policy != "stop_on_completion" || created != 0 {
+		t.Fatalf("migrated run policy/created = %q/%d", policy, created)
+	}
+	assertSQLiteTablesPresent(t, db, "project_run_completion")
+}
+
 func TestV2MigrationDesignDeduplicatesEquivalentLegacyEventLinks(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
@@ -393,8 +423,8 @@ func loadV2MigrationDesignChain(t *testing.T) []migration {
 	if err != nil {
 		t.Fatalf("load migrations: %v", err)
 	}
-	if len(chain) != 9 {
-		t.Fatalf("migration count = %d, want 9", len(chain))
+	if len(chain) != 10 {
+		t.Fatalf("migration count = %d, want 10", len(chain))
 	}
 	return chain
 }

--- a/scripts/tests/test-coverage-contract.sh
+++ b/scripts/tests/test-coverage-contract.sh
@@ -139,7 +139,7 @@ fi
 
 listed_e2e_tests="$(go test -list '^Test' ./test/e2e | awk '/^Test/ { print }')"
 listed_e2e_count="$(printf '%s\n' "$listed_e2e_tests" | awk 'NF { count++ } END { print count + 0 }')"
-assert_equal 9 "$listed_e2e_count" "unexpected test/e2e package test count"
+assert_equal 10 "$listed_e2e_count" "unexpected test/e2e package test count"
 
 e2e_output="$(go test -run '^Test' -v ./test/e2e)"
 while IFS= read -r test_name; do

--- a/test/e2e/host_daemon_helpers_test.go
+++ b/test/e2e/host_daemon_helpers_test.go
@@ -105,6 +105,23 @@ func (p *e2eDaemonProcess) stop(t *testing.T) {
 	})
 }
 
+func (p *e2eDaemonProcess) hardKill(t *testing.T) {
+	t.Helper()
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		t.Fatal("agent-compose daemon process is unavailable")
+	}
+	p.stopOnce.Do(func() {
+		if err := p.cmd.Process.Kill(); err != nil {
+			t.Fatalf("hard-kill agent-compose daemon: %v", err)
+		}
+		select {
+		case <-p.done:
+		case <-time.After(15 * time.Second):
+			t.Fatal("hard-killed agent-compose daemon did not exit")
+		}
+	})
+}
+
 func waitForE2EDaemon(t *testing.T, ctx context.Context, daemon *e2eDaemonProcess, baseURL string) {
 	t.Helper()
 	client := newE2EHTTPClient()

--- a/test/e2e/run_completion_restart_host_daemon_test.go
+++ b/test/e2e/run_completion_restart_host_daemon_test.go
@@ -1,0 +1,172 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	containerapi "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+const dockerRunCompletionE2EImageEnv = "AGENT_COMPOSE_E2E_RUN_COMPLETION_IMAGE"
+
+func TestE2EDockerRunCompletionRecoversAfterDaemonHardKill(t *testing.T) {
+	image := strings.TrimSpace(os.Getenv(dockerRunCompletionE2EImageEnv))
+	if image == "" {
+		t.Skipf("set %s to a local Docker guest image", dockerRunCompletionE2EImageEnv)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	repoRoot := e2eRepoRoot(t)
+	testRoot, err := os.MkdirTemp(repoRoot, ".docker-run-completion-e2e-")
+	if err != nil {
+		t.Fatalf("create Docker-visible E2E root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(testRoot) })
+	dockerClient := newE2EDockerClient(t, ctx, image)
+	binary := e2eDaemonBinary(t, ctx, repoRoot, testRoot)
+
+	firstAddress := unusedLoopbackAddress(t)
+	firstBaseURL := "http://" + firstAddress
+	firstDaemon := startE2EDaemonWithEnv(t, binary, repoRoot, testRoot, firstAddress, image, map[string]string{
+		"AGENT_COMPOSE_RUNTIME_BASE_URL": dockerDesktopRuntimeBaseURL(t, firstAddress),
+	})
+	waitForE2EDaemon(t, ctx, firstDaemon, firstBaseURL)
+	firstHTTPClient := newE2EHTTPClient()
+	projectClient := agentcomposev2connect.NewProjectServiceClient(firstHTTPClient, firstBaseURL)
+	firstRunClient := agentcomposev2connect.NewRunServiceClient(firstHTTPClient, firstBaseURL)
+	projectID := applyE2ERunCompletionProject(t, ctx, projectClient, testRoot, image)
+
+	start, err := firstRunClient.StartAgentRun(ctx, connect.NewRequest(&agentcomposev2.StartAgentRunRequest{
+		Run: &agentcomposev2.RunAgentRequest{
+			ProjectId:       projectID,
+			AgentName:       "worker",
+			Command:         "printf run-started; sleep 300",
+			Source:          agentcomposev2.RunSource_RUN_SOURCE_API,
+			ClientRequestId: "docker-run-completion-hard-kill",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("StartAgentRun returned error: %v\ndaemon log:\n%s", err, firstDaemon.logs.String())
+	}
+	runID := start.Msg.GetRun().GetRunId()
+	if runID == "" || !start.Msg.GetStarted() {
+		t.Fatalf("StartAgentRun response = %#v, want newly started run", start.Msg)
+	}
+
+	sandboxID := waitForE2ERunningRunSandbox(t, ctx, firstRunClient, dockerClient, runID)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		removeE2EDockerSandboxFallback(t, cleanupCtx, dockerClient, sandboxID)
+	})
+	firstDaemon.hardKill(t)
+	assertE2ESandboxContainerRunningState(t, ctx, dockerClient, sandboxID, true)
+
+	secondAddress := unusedLoopbackAddress(t)
+	secondBaseURL := "http://" + secondAddress
+	secondDaemon := startE2EDaemonWithEnv(t, binary, repoRoot, testRoot, secondAddress, image, map[string]string{
+		"AGENT_COMPOSE_RUNTIME_BASE_URL": dockerDesktopRuntimeBaseURL(t, secondAddress),
+	})
+	waitForE2EDaemon(t, ctx, secondDaemon, secondBaseURL)
+	secondHTTPClient := newE2EHTTPClient()
+	secondRunClient := agentcomposev2connect.NewRunServiceClient(secondHTTPClient, secondBaseURL)
+
+	var completed *agentcomposev2.RunDetail
+	waitForE2ECondition(t, 30*time.Second, func() bool {
+		response, getErr := secondRunClient.GetRun(ctx, connect.NewRequest(&agentcomposev2.GetRunRequest{RunId: runID}))
+		if getErr != nil {
+			return false
+		}
+		completed = response.Msg.GetRun()
+		return completed.GetSummary().GetStatus() == agentcomposev2.RunStatus_RUN_STATUS_FAILED
+	}, "interrupted run did not recover to failed")
+	if summary := completed.GetSummary(); summary.GetExitCode() == 0 || !strings.Contains(summary.GetError(), "daemon interrupted") || summary.GetCompletedAt() == nil || completed.GetCleanupError() != "" {
+		t.Fatalf("recovered run = %#v, want failed interrupted result without cleanup error", completed)
+	}
+	assertE2ESandboxContainerRunningState(t, ctx, dockerClient, sandboxID, false)
+}
+
+func applyE2ERunCompletionProject(t *testing.T, ctx context.Context, client agentcomposev2connect.ProjectServiceClient, root, image string) string {
+	t.Helper()
+	response, err := client.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec: &agentcomposev2.ProjectSpec{
+			Name: "docker-run-completion-e2e",
+			Agents: []*agentcomposev2.AgentSpec{{
+				Name: "worker", Provider: "codex", Image: image,
+				Driver: &agentcomposev2.DriverSpec{Name: "docker", Config: &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}},
+			}},
+		},
+		Source: &agentcomposev2.ProjectSource{ComposePath: filepath.Join(root, "agent-compose.yml"), ProjectDir: root},
+	}))
+	if err != nil {
+		t.Fatalf("ApplyProject returned error: %v", err)
+	}
+	projectID := response.Msg.GetProject().GetSummary().GetProjectId()
+	if !response.Msg.GetApplied() || projectID == "" {
+		t.Fatalf("ApplyProject response = %#v, want applied project", response.Msg)
+	}
+	return projectID
+}
+
+func waitForE2ERunningRunSandbox(t *testing.T, ctx context.Context, runClient agentcomposev2connect.RunServiceClient, dockerClient *client.Client, runID string) string {
+	t.Helper()
+	var sandboxID string
+	waitForE2ECondition(t, 2*time.Minute, func() bool {
+		response, err := runClient.GetRun(ctx, connect.NewRequest(&agentcomposev2.GetRunRequest{RunId: runID}))
+		if err != nil {
+			return false
+		}
+		summary := response.Msg.GetRun().GetSummary()
+		if summary.GetStatus() == agentcomposev2.RunStatus_RUN_STATUS_FAILED || summary.GetStatus() == agentcomposev2.RunStatus_RUN_STATUS_CANCELED || summary.GetStatus() == agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED {
+			t.Fatalf("run reached unexpected terminal state before hard kill: status=%s error=%q", summary.GetStatus(), summary.GetError())
+		}
+		if summary.GetStatus() != agentcomposev2.RunStatus_RUN_STATUS_RUNNING {
+			return false
+		}
+		sandboxID = summary.GetSandboxId()
+		if sandboxID == "" {
+			return false
+		}
+		containers, err := listE2EDockerSandboxContainers(ctx, dockerClient, sandboxID)
+		return err == nil && len(containers) == 1 && containers[0].State == "running"
+	}, "run did not start in a running Docker sandbox")
+	return sandboxID
+}
+
+func assertE2ESandboxContainerRunningState(t *testing.T, ctx context.Context, dockerClient *client.Client, sandboxID string, wantRunning bool) {
+	t.Helper()
+	containers, err := listE2EDockerSandboxContainers(ctx, dockerClient, sandboxID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range containers {
+		if item.State == "running" {
+			if !wantRunning {
+				t.Fatalf("Docker sandbox container %s remains running after interrupted run recovery", item.ID)
+			}
+			return
+		}
+	}
+	if wantRunning {
+		t.Fatalf("Docker sandbox %s stopped before daemon restart recovery", sandboxID)
+	}
+}
+
+func listE2EDockerSandboxContainers(ctx context.Context, dockerClient *client.Client, sandboxID string) ([]containerapi.Summary, error) {
+	args := filters.NewArgs(
+		filters.Arg("label", "agent-compose.sandbox_id="+sandboxID),
+		filters.Arg("label", "agent-compose.driver=docker"),
+	)
+	return dockerClient.ContainerList(ctx, containerapi.ListOptions{All: true, Filters: args})
+}


### PR DESCRIPTION
## Problem

A project run could previously be persisted as terminal before its sandbox cleanup completed. This created several inconsistent and unsafe states:

- a run could report succeeded, failed, or canceled while its sandbox was still consuming compute resources
- a stop or removal failure happened after the terminal result was already committed, so retrying cleanup could not preserve the invariant between run state and sandbox state
- a daemon crash between terminal persistence and cleanup could permanently leave an active sandbox behind
- startup recovery reconstructed a generic failed result instead of resuming the exact completion that had already been selected
- StopRun wrote CANCELED directly, racing with the execution result and bypassing cleanup
- a sandbox awaiting cleanup could be reused by another run while the old cleanup was retrying

The core issue was that terminal-state persistence and sandbox lifecycle management were two independent operations with the terminal write happening first.

## Fix approach

This change establishes one invariant: a run may enter a terminal state only after its configured completion cleanup has succeeded. KEEP_RUNNING is the explicit exception because it requires no cleanup.

Completion is split into three durable phases:

1. Stage the exact first completion result and stable final agent/result events in SQLite. Keep the run RUNNING and do not write a terminal status event.
2. Execute the derived cleanup action idempotently and retry failures in the background with bounded backoff.
3. After cleanup succeeds, atomically commit the terminal run fields, append the unique terminal status event, clear cleanup_error, and delete the completion journal.

This ordering closes the daemon-crash windows while preserving the exact original result through retries and restarts. Competing completion or cancellation requests use first-writer-wins semantics and cannot overwrite the staged result.

## Solution details

### Cleanup semantics

- STOP_ON_COMPLETION: stop the associated sandbox before finalizing the run.
- REMOVE_ON_COMPLETION: fully remove a sandbox created by this run; a reused sandbox is stopped instead.
- KEEP_RUNNING: perform no cleanup and finalize immediately.
- no associated sandbox: perform no cleanup and finalize immediately.

Already-stopped or missing sandboxes are treated as successful stop outcomes. Removal is also idempotent when both the sandbox and its deletion journal are already gone, covering a crash after external deletion but before the terminal transaction.

### Durable completion and recovery

SQLite schema v10 adds persisted cleanup policy and sandbox ownership fields plus project_run_completion, a recovery journal containing the target terminal state, exact serialized transition, cleanup action, retry state, last error, and next attempt time.

Two completion workers process due journals. Cleanup failures leave the run RUNNING, populate cleanup_error, and do not create a terminal status event. Retries use 1s, 2s, 4s, 8s, 16s, and 30s delays, then remain at 30s.

On daemon startup, sandbox runtime state is reconciled first. Existing completion journals resume their exact staged result. Legacy PENDING or RUNNING runs without a journal receive an interrupted FAILED completion, then follow the same cleanup and finalization path. Completion recovery starts before schedulers so a new run cannot claim a sandbox that is still being cleaned up.

### Execution and cancellation

All success, execution failure, cancellation, preparation failure, sandbox startup failure, command, agent, streaming, detached, and attach paths now complete through the same completion manager.

RunSupervisor registers unary, streaming, detached, and attach executions with context.WithCancelCause. StopRun now requests cancellation with the user reason instead of directly writing CANCELED. The execution stages the cancellation result, applies cleanup, and commits CANCELED only after cleanup succeeds. Repeated StopRun calls remain idempotent.

### Sandbox safety

The run and sandbox association is persisted before a new runtime is started or an existing sandbox is resumed. A binding failure prevents runtime startup; a newly created sandbox is rolled back through the removal path.

Explicit and sticky reuse reject a sandbox that has a pending completion journal, preventing cleanup retries from racing with new execution.

## Changes made

- added SQLite v10 migration and standalone migrator schema/checksum updates
- added cleanup policy/action domain normalization and persistence
- added runs.CompletionManager with durable staging, retry workers, idempotent cleanup, and atomic finalization
- persisted sandbox bindings before runtime start/resume
- routed all run completion paths through the completion manager
- changed StopRun to asynchronous supervised cancellation
- added daemon startup recovery and shutdown ordering for completion work
- blocked reuse of pending-completion sandboxes
- updated English and Chinese CLI documentation plus the design document
- added unit, persistence, recovery, cancellation, and sandbox-binding coverage
- added an opt-in real Docker hard-restart E2E that verifies an interrupted run becomes FAILED only after its container stops consuming active compute resources

## User-visible behavior

- RunAgent, StreamAgentRun, and foreground CLI runs continue waiting while cleanup is retrying. Client cancellation ends the wait but background completion continues.
- StartAgentRun still returns immediately after submission.
- StopRun may return stop_requested=true while the run is still RUNNING. The run becomes CANCELED after cleanup succeeds.
- cleanup_error explains the latest cleanup failure while the run remains recoverable.
- CompletedAt and DurationMs are calculated when terminal state is committed, so duration includes cleanup retry time.
- permanent driver failures intentionally leave the run RUNNING until the runtime is repaired or removed.

## Testing

- task lint
- task build
- task test
  - unit: 74.89%
  - integration: 60.88%
  - E2E: 60.33%
  - combined: 79.07%
- go test -race ./pkg/runs ./pkg/agentcompose/app ./pkg/sandboxes -timeout 300s
- focused tests for runs, app, API, sandboxes, SQLite/configstore, projects, and standalone migrator
- task docs:build
- task test:e2e:docker-run-completion-recovery

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.