### PR TITLE
fix(events): paginate webhook events in reverse order

### DIFF
--- a/docs/design/webhook_design.md
+++ b/docs/design/webhook_design.md
@@ -108,17 +108,20 @@ the URL.
 
 ```http
 GET /api/events/:event_id
-GET /api/events?correlation_id=some_system:object:123
+GET /api/events?correlation_id=some_system:object:123&offset=0&limit=100
 GET /api/events?topic=runtime.some_adapter.requested&after_sequence=123&limit=100
 ```
 
 Query constraints:
 
 - `event_id` query returns one event.
-- `correlation_id` query returns the event stream for the same business flow,
-  sorted by `sequence` ascending.
+- Normal list queries explicitly use `offset` and `limit`, return `total`, and sort by
+  `sequence` descending so the newest events are returned first.
 - `topic + after_sequence` can be used by external adapters to poll derived
-  events.
+  events in ascending sequence order. This compatibility mode returns
+  `next_after_sequence` and cannot be combined with `offset`. For compatibility,
+  omitting both parameters also uses ascending sequence order and returns
+  `next_after_sequence`.
 - `limit` defaults to 100 and is capped at 500.
 - List queries must contain at least `correlation_id` or `topic`.
 

--- a/pkg/events/webhooks/coverage_shape_workflows_test.go
+++ b/pkg/events/webhooks/coverage_shape_workflows_test.go
@@ -148,6 +148,18 @@ func TestWebhookHTTPRoutesCoverageWorkflow(t *testing.T) {
 			t.Fatalf("GET %s status=%d body=%s", target, rec.Code, rec.Body.String())
 		}
 	}
+	req = httptest.NewRequest(http.MethodGet, "/api/events?topic=webhook.github.push&offset=3&limit=7", nil)
+	rec = httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || store.lastFilter.Offset != 3 || store.lastFilter.Limit != 7 || !strings.Contains(rec.Body.String(), `"total":1`) {
+		t.Fatalf("paginated events status=%d filter=%#v body=%s", rec.Code, store.lastFilter, rec.Body.String())
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/events?topic=webhook.github.push&offset=1&after_sequence=1", nil)
+	rec = httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("mixed event pagination status=%d body=%s", rec.Code, rec.Body.String())
+	}
 	req = httptest.NewRequest(http.MethodPut, "/api/webhook-sources/github", strings.NewReader(`{"name":"GitHub","enabled":true,"provider":"github","topic_prefix":"webhook.github.","token":"new-token"}`))
 	rec = httptest.NewRecorder()
 	app.ServeHTTP(rec, req)
@@ -255,6 +267,7 @@ type webhookRouteStore struct {
 	events     map[string]domain.TopicEventRecord
 	sources    map[string]domain.WebhookSource
 	existingID string
+	lastFilter domain.TopicEventFilter
 }
 
 func newWebhookRouteStore() *webhookRouteStore {
@@ -289,12 +302,13 @@ func (s *webhookRouteStore) GetEvent(_ context.Context, eventID string) (domain.
 	return event, nil
 }
 
-func (s *webhookRouteStore) ListEvents(context.Context, domain.TopicEventFilter) ([]domain.TopicEventRecord, error) {
+func (s *webhookRouteStore) ListEvents(_ context.Context, filter domain.TopicEventFilter) ([]domain.TopicEventRecord, int, error) {
+	s.lastFilter = filter
 	items := make([]domain.TopicEventRecord, 0, len(s.events))
 	for _, event := range s.events {
 		items = append(items, event)
 	}
-	return items, nil
+	return items, len(items), nil
 }
 
 func (s *webhookRouteStore) ListDescendantEventIDs(context.Context, string, int) ([]string, error) {

--- a/pkg/events/webhooks/dto.go
+++ b/pkg/events/webhooks/dto.go
@@ -22,7 +22,8 @@ type TopicEventResponse struct {
 
 type TopicEventListResponse struct {
 	Items             []TopicEventJSON `json:"items"`
-	NextAfterSequence int64            `json:"next_after_sequence"`
+	Total             int              `json:"total"`
+	NextAfterSequence int64            `json:"next_after_sequence,omitempty"`
 }
 
 type EventSandboxesResponse struct {

--- a/pkg/events/webhooks/http.go
+++ b/pkg/events/webhooks/http.go
@@ -19,7 +19,7 @@ type Store interface {
 	FindEventByIdempotencyKey(context.Context, string, string) (domain.TopicEventRecord, bool, error)
 	CreateEvent(context.Context, domain.TopicEventRecord) (domain.TopicEventRecord, error)
 	GetEvent(context.Context, string) (domain.TopicEventRecord, error)
-	ListEvents(context.Context, domain.TopicEventFilter) ([]domain.TopicEventRecord, error)
+	ListEvents(context.Context, domain.TopicEventFilter) ([]domain.TopicEventRecord, int, error)
 	ListDescendantEventIDs(context.Context, string, int) ([]string, error)
 	ListEventSandboxLinks(context.Context, []string) ([]domain.EventSandboxTraceItem, error)
 	ListEventDeliveries(context.Context, []string) ([]domain.EventDelivery, error)
@@ -184,19 +184,29 @@ func (h routeHandler) handleListEvents(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "limit is invalid"})
 	}
-	items, err := h.store().ListEvents(c.Request().Context(), domain.TopicEventFilter{
+	offset, err := parseOptionalIntQuery(c, "offset")
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "offset is invalid"})
+	}
+	offsetProvided := strings.TrimSpace(c.QueryParam("offset")) != ""
+	if afterSequence > 0 && offsetProvided {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "offset and after_sequence cannot be combined"})
+	}
+	items, total, err := h.store().ListEvents(c.Request().Context(), domain.TopicEventFilter{
 		Topic:         topic,
 		CorrelationID: correlationID,
 		AfterSequence: afterSequence,
+		Offset:        offset,
 		Limit:         limit,
+		SequenceAsc:   !offsetProvided,
 	})
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to list events"})
 	}
-	resp := TopicEventListResponse{Items: make([]TopicEventJSON, 0, len(items))}
+	resp := TopicEventListResponse{Items: make([]TopicEventJSON, 0, len(items)), Total: total}
 	for _, item := range items {
 		resp.Items = append(resp.Items, TopicEventToJSON(item))
-		if item.Sequence > resp.NextAfterSequence {
+		if !offsetProvided && item.Sequence > resp.NextAfterSequence {
 			resp.NextAfterSequence = item.Sequence
 		}
 	}
@@ -365,6 +375,14 @@ func parseOptionalInt64Query(c echo.Context, name string) (int64, error) {
 		return 0, fmt.Errorf("%s is invalid", name)
 	}
 	return value, nil
+}
+
+func parseOptionalIntQuery(c echo.Context, name string) (int, error) {
+	value, err := parseOptionalInt64Query(c, name)
+	if err != nil || value > int64(^uint(0)>>1) {
+		return 0, fmt.Errorf("%s is invalid", name)
+	}
+	return int(value), nil
 }
 
 func parseLimitQuery(c echo.Context, defaultValue, maxValue int) (int, error) {

--- a/pkg/model/topic_event_model.go
+++ b/pkg/model/topic_event_model.go
@@ -83,7 +83,9 @@ type TopicEventFilter struct {
 	Topic          string
 	CorrelationID  string
 	AfterSequence  int64
+	Offset         int
 	Limit          int
+	SequenceAsc    bool
 	DispatchStatus string
 }
 

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -336,16 +336,22 @@ func testConfigStoreTopicEventCoverageWorkflows(t *testing.T) {
 	if pending, err := store.ListPendingEvents(ctx, 10); err != nil || len(pending) != 2 {
 		t.Fatalf("ListPendingEvents pending=%#v err=%v", pending, err)
 	}
-	if events, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: event.Topic, CorrelationID: "corr-1", Limit: 10}); err != nil || len(events) != 2 {
-		t.Fatalf("ListEvents events=%#v err=%v", events, err)
+	if events, total, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: event.Topic, CorrelationID: "corr-1", Limit: 10}); err != nil || len(events) != 2 || total != 2 || events[0].ID != child.ID || events[1].ID != event.ID {
+		t.Fatalf("ListEvents events=%#v total=%d err=%v", events, total, err)
 	}
-	if events, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: event.Topic, AfterSequence: event.Sequence, DispatchStatus: domain.TopicEventDispatchPending, Limit: 1000}); err != nil || len(events) != 1 {
-		t.Fatalf("ListEvents filtered events=%#v err=%v", events, err)
+	if events, total, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: event.Topic, CorrelationID: "corr-1", Offset: 1, Limit: 1}); err != nil || len(events) != 1 || total != 2 || events[0].ID != event.ID {
+		t.Fatalf("ListEvents second page events=%#v total=%d err=%v", events, total, err)
 	}
-	if _, err := store.ListEvents(ctx, domain.TopicEventFilter{}); err == nil {
+	if events, total, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: event.Topic, CorrelationID: "corr-1", SequenceAsc: true, Limit: 10}); err != nil || len(events) != 2 || total != 2 || events[0].ID != event.ID || events[1].ID != child.ID {
+		t.Fatalf("ListEvents legacy events=%#v total=%d err=%v", events, total, err)
+	}
+	if events, total, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: event.Topic, AfterSequence: event.Sequence, DispatchStatus: domain.TopicEventDispatchPending, Limit: 1000}); err != nil || len(events) != 1 || total != 1 || events[0].ID != child.ID {
+		t.Fatalf("ListEvents filtered events=%#v total=%d err=%v", events, total, err)
+	}
+	if _, _, err := store.ListEvents(ctx, domain.TopicEventFilter{}); err == nil {
 		t.Fatalf("ListEvents empty filter returned nil error")
 	}
-	if _, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: "bad topic"}); err == nil {
+	if _, _, err := store.ListEvents(ctx, domain.TopicEventFilter{Topic: "bad topic"}); err == nil {
 		t.Fatalf("ListEvents invalid topic returned nil error")
 	}
 	if err := store.UpdateEventPayload(ctx, event.ID, `{"branch":"dev"}`); err != nil {

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -61,9 +61,9 @@ func (s *eventStore) ListPendingEvents(ctx context.Context, limit int) ([]domain
 	return scanTopicEvents(rows)
 }
 
-func (s *eventStore) ListEvents(ctx context.Context, filter domain.TopicEventFilter) ([]domain.TopicEventRecord, error) {
+func (s *eventStore) ListEvents(ctx context.Context, filter domain.TopicEventFilter) ([]domain.TopicEventRecord, int, error) {
 	if strings.TrimSpace(filter.Topic) == "" && strings.TrimSpace(filter.CorrelationID) == "" {
-		return nil, fmt.Errorf("topic or correlation id is required")
+		return nil, 0, fmt.Errorf("topic or correlation id is required")
 	}
 	limit := filter.Limit
 	if limit <= 0 {
@@ -76,7 +76,7 @@ func (s *eventStore) ListEvents(ctx context.Context, filter domain.TopicEventFil
 	args := make([]any, 0, 5)
 	if topic := strings.TrimSpace(filter.Topic); topic != "" {
 		if err := domain.ValidateTopicEventName(topic); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		clauses = append(clauses, "topic = ?")
 		args = append(args, topic)
@@ -93,14 +93,30 @@ func (s *eventStore) ListEvents(ctx context.Context, filter domain.TopicEventFil
 		clauses = append(clauses, "dispatch_status = ?")
 		args = append(args, status)
 	}
-	args = append(args, limit)
-	query := selectTopicEventSQL() + ` WHERE ` + strings.Join(clauses, " AND ") + ` ORDER BY sequence ASC LIMIT ?`
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	where := ` WHERE ` + strings.Join(clauses, " AND ")
+	var total int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event`+where, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count events: %w", err)
+	}
+	order := ` ORDER BY sequence DESC`
+	pageArgs := append([]any(nil), args...)
+	if filter.AfterSequence > 0 || filter.SequenceAsc {
+		order = ` ORDER BY sequence ASC`
+		pageArgs = append(pageArgs, limit)
+	} else {
+		pageArgs = append(pageArgs, limit, max(filter.Offset, 0))
+	}
+	query := selectTopicEventSQL() + where + order + ` LIMIT ?`
+	if filter.AfterSequence <= 0 && !filter.SequenceAsc {
+		query += ` OFFSET ?`
+	}
+	rows, err := s.db.QueryContext(ctx, query, pageArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("query events: %w", err)
+		return nil, 0, fmt.Errorf("query events: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	return scanTopicEvents(rows)
+	items, err := scanTopicEvents(rows)
+	return items, total, err
 }
 
 func (s *eventStore) MarkEventPublished(ctx context.Context, eventID, claimID string, dispatchedAt time.Time) error {


### PR DESCRIPTION
## Summary

- return webhook/topic events in newest-first order
- replace sequence cursor paging with unified offset and limit parameters
- include total counts for UI pagination
- update storage, HTTP mapping, design docs, and focused coverage-shape tests

## Verification

- `go test ./pkg/events/webhooks ./pkg/storage/configstore`
- Linux/amd64 daemon image build completed with version `pre-2608.1.0`

## Notes

Draft while the h3c-6 upgrade patch is being validated. The local upgrade runbook is intentionally excluded from this PR.