### PR TITLE
chore(runtime): upgrade Microsandbox to v0.6.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     c
 # published checksums. This keeps the FFI lib in lockstep with the
 # microsandbox/sdk/go module pinned in go.mod.
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS microsandbox-fetch
-ARG MICROSANDBOX_VERSION=v0.6.4
+ARG MICROSANDBOX_VERSION=v0.6.8
 ARG GITHUB_MIRROR
 ARG TARGETARCH
 ARG HTTP_PROXY

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/samber/oops v1.21.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
-	github.com/superradcompany/microsandbox/sdk/go v0.6.4
+	github.com/superradcompany/microsandbox/sdk/go v0.6.8
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/superradcompany/microsandbox/sdk/go v0.6.4 h1:ITJhhuwM6FTZWgKpA0u2013bav+K4hBCJjCjJBueYqM=
-github.com/superradcompany/microsandbox/sdk/go v0.6.4/go.mod h1:Nqi2S7Xm1lgsUyV2vo21EVTL4de68lVC/YRDApB+2R0=
+github.com/superradcompany/microsandbox/sdk/go v0.6.8 h1:NlRVtRGhWmTQ/Pix4Uht4C2GMsEO+F6w+ufUCdy7A2Y=
+github.com/superradcompany/microsandbox/sdk/go v0.6.8/go.mod h1:p7Tm/p9zkO7sHO3N8A1fiTVeLB2w/fQoKdYlpN/5neA=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/pkg/driver/microsandbox_managed_resources.go
+++ b/pkg/driver/microsandbox_managed_resources.go
@@ -59,6 +59,7 @@ func listMicrosandboxManagedSandboxes(ctx context.Context, listPage microsandbox
 	labels := microsandbox.WithListLabels(map[string]string{microsandboxManagedLabel: "true"})
 	var handles []*microsandbox.SandboxHandle
 	var cursor string
+	seenCursors := make(map[string]struct{})
 	for {
 		options := []microsandbox.SandboxListOption{labels}
 		if cursor != "" {
@@ -76,9 +77,10 @@ func listMicrosandboxManagedSandboxes(ctx context.Context, listPage microsandbox
 			return handles, nil
 		}
 		nextCursor := strings.TrimSpace(*page.NextCursor)
-		if nextCursor == cursor {
-			return nil, fmt.Errorf("list managed microsandbox sandboxes: pagination cursor did not advance")
+		if _, seen := seenCursors[nextCursor]; seen {
+			return nil, fmt.Errorf("list managed microsandbox sandboxes: pagination cursor repeated")
 		}
+		seenCursors[nextCursor] = struct{}{}
 		cursor = nextCursor
 	}
 }

--- a/pkg/driver/microsandbox_managed_resources.go
+++ b/pkg/driver/microsandbox_managed_resources.go
@@ -18,7 +18,7 @@ func ListMicrosandboxManagedResources(ctx context.Context, config *appconfig.Con
 		return nil, nil, nil
 	}
 	bySandbox := map[string]*ManagedRuntimeResource{}
-	handles, err := microsandbox.ListSandboxesWith(ctx, microsandbox.NewSandboxFilter().WithLabels(map[string]string{microsandboxManagedLabel: "true"}))
+	handles, err := listMicrosandboxManagedSandboxes(ctx, microsandbox.ListSandboxesWith)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -51,6 +51,36 @@ func ListMicrosandboxManagedResources(ctx context.Context, config *appconfig.Con
 		result = append(result, *resource)
 	}
 	return result, warnings, nil
+}
+
+type microsandboxSandboxPageLister func(context.Context, ...microsandbox.SandboxListOption) (*microsandbox.SandboxPage, error)
+
+func listMicrosandboxManagedSandboxes(ctx context.Context, listPage microsandboxSandboxPageLister) ([]*microsandbox.SandboxHandle, error) {
+	labels := microsandbox.WithListLabels(map[string]string{microsandboxManagedLabel: "true"})
+	var handles []*microsandbox.SandboxHandle
+	var cursor string
+	for {
+		options := []microsandbox.SandboxListOption{labels}
+		if cursor != "" {
+			options = append(options, microsandbox.WithListCursor(cursor))
+		}
+		page, err := listPage(ctx, options...)
+		if err != nil {
+			return nil, fmt.Errorf("list managed microsandbox sandboxes: %w", err)
+		}
+		if page == nil {
+			return nil, fmt.Errorf("list managed microsandbox sandboxes: empty page response")
+		}
+		handles = append(handles, page.Sandboxes...)
+		if page.NextCursor == nil || strings.TrimSpace(*page.NextCursor) == "" {
+			return handles, nil
+		}
+		nextCursor := strings.TrimSpace(*page.NextCursor)
+		if nextCursor == cursor {
+			return nil, fmt.Errorf("list managed microsandbox sandboxes: pagination cursor did not advance")
+		}
+		cursor = nextCursor
+	}
 }
 
 func appendMicrosandboxDiskResources(config *appconfig.Config, bySandbox map[string]*ManagedRuntimeResource, warnings []string) []string {

--- a/pkg/driver/microsandbox_managed_resources_test.go
+++ b/pkg/driver/microsandbox_managed_resources_test.go
@@ -1,0 +1,66 @@
+//go:build linux && cgo && microsandboxcgo
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
+)
+
+func TestListMicrosandboxManagedSandboxesCollectsEveryPage(t *testing.T) {
+	firstCursor := "next"
+	first := &microsandbox.SandboxHandle{}
+	second := &microsandbox.SandboxHandle{}
+	pages := []*microsandbox.SandboxPage{
+		{Sandboxes: []*microsandbox.SandboxHandle{first}, NextCursor: &firstCursor},
+		{Sandboxes: []*microsandbox.SandboxHandle{second}},
+	}
+	calls := 0
+
+	handles, err := listMicrosandboxManagedSandboxes(context.Background(), func(context.Context, ...microsandbox.SandboxListOption) (*microsandbox.SandboxPage, error) {
+		page := pages[calls]
+		calls++
+		return page, nil
+	})
+	if err != nil {
+		t.Fatalf("listMicrosandboxManagedSandboxes() error = %v", err)
+	}
+	if calls != 2 || len(handles) != 2 || handles[0] != first || handles[1] != second {
+		t.Fatalf("listMicrosandboxManagedSandboxes() calls = %d, handles = %#v", calls, handles)
+	}
+}
+
+func TestListMicrosandboxManagedSandboxesRejectsInvalidPagination(t *testing.T) {
+	tests := []struct {
+		name     string
+		listPage microsandboxSandboxPageLister
+		want     string
+	}{
+		{
+			name: "list error",
+			listPage: func(context.Context, ...microsandbox.SandboxListOption) (*microsandbox.SandboxPage, error) {
+				return nil, errors.New("list failed")
+			},
+			want: "list failed",
+		},
+		{
+			name: "nil page",
+			listPage: func(context.Context, ...microsandbox.SandboxListOption) (*microsandbox.SandboxPage, error) {
+				return nil, nil
+			},
+			want: "empty page response",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := listMicrosandboxManagedSandboxes(context.Background(), test.listPage)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("listMicrosandboxManagedSandboxes() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/microsandbox_managed_resources_test.go
+++ b/pkg/driver/microsandbox_managed_resources_test.go
@@ -64,3 +64,20 @@ func TestListMicrosandboxManagedSandboxesRejectsInvalidPagination(t *testing.T) 
 		})
 	}
 }
+
+func TestListMicrosandboxManagedSandboxesRejectsCursorCycle(t *testing.T) {
+	cursors := []string{"cursor-a", "cursor-b", "cursor-a"}
+	calls := 0
+
+	_, err := listMicrosandboxManagedSandboxes(context.Background(), func(context.Context, ...microsandbox.SandboxListOption) (*microsandbox.SandboxPage, error) {
+		page := &microsandbox.SandboxPage{NextCursor: &cursors[calls]}
+		calls++
+		return page, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "pagination cursor repeated") {
+		t.Fatalf("listMicrosandboxManagedSandboxes() error = %v, want repeated cursor error", err)
+	}
+	if calls != len(cursors) {
+		t.Fatalf("listMicrosandboxManagedSandboxes() calls = %d, want %d", calls, len(cursors))
+	}
+}

--- a/pkg/driver/microsandbox_runtime_test.go
+++ b/pkg/driver/microsandbox_runtime_test.go
@@ -71,6 +71,7 @@ func TestMicrosandboxExecStreamPreservesSplitUTF8(t *testing.T) {
 		context.Background(),
 		recv,
 		func() error { return nil },
+		nil,
 		collector,
 		25*time.Millisecond,
 		nil,


### PR DESCRIPTION
## Summary

- upgrade the Microsandbox release artifacts and Go SDK from `v0.6.4` to `v0.6.8`
- adapt managed sandbox discovery to the new paginated SDK API and collect every page
- add regression coverage for pagination and error responses
- verify BoxLite is already on its latest stable release, `v0.9.7`, so no BoxLite version change is needed

Upstream releases checked on 2026-07-30:

- Microsandbox: https://github.com/superradcompany/microsandbox/releases/tag/v0.6.8
- BoxLite: https://github.com/boxlite-ai/boxlite/releases/tag/v0.9.7

## Testing

- `go test -count=1 -tags microsandboxcgo ./pkg/driver`
- `task build`
- `task lint`
- `task test`

The `v0.6.8` amd64 release assets were also downloaded from the GitHub release, verified against `checksums.sha256`, and used for the successful Linux full cgo build.

## Checklist

- [x] Documentation updated when behavior or configuration changed. (Not applicable: no public behavior or configuration changed.)
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
