### PR TITLE
feat(installer): show release images in TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ TUI. The default installation directory is `/opt/agent-compose`; use `sudo`
 when the current user cannot write there. For automation, run
 `install --yes` and pass options explicitly.
 
+The TUI resolves the selected Release and shows its exact backend, frontend,
+and guest image defaults. Changing the application version refreshes those
+defaults; entering a complete image reference overrides only that image.
+
 The base stack starts the daemon. The frontend is defined under the `with-ui`
 profile, which the installer leaves off unless you answer yes to **Install web
 UI** (or pass `--with-ui`). Enabling it there persists `COMPOSE_PROFILES` in

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,6 +49,8 @@ bootstrap 会自动选择 Linux amd64/arm64 installer 并打开中英文 TUI。�
 `/opt/agent-compose`；当前用户无写权限时请使用 `sudo`。自动化场景使用
 `install --yes` 并显式传入所需参数。
 
+TUI 会解析所选 Release，并展示其后端、前端和 guest 镜像的精确缺省值。修改应用版本会刷新这些缺省值；输入完整镜像引用只会覆盖对应的单个镜像。
+
 首次运行会生成 `admin` 密码并打印一次，同时打印安装目录；启用 Web UI 时还会打印浏览器 URL（地址取本机主网卡 IP，不是 `localhost`）。安装时选择启用会把 `COMPOSE_PROFILES` 持久化进 `.env`，之后普通的 `docker compose up -d` 也会带上前端。事后再启用：
 
 ```bash

--- a/cmd/installer/internal/core/release.go
+++ b/cmd/installer/internal/core/release.go
@@ -1,0 +1,226 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	backendImageKey  = "AGENT_COMPOSE_IMAGE"
+	frontendImageKey = "AGENT_COMPOSE_FRONTEND_IMAGE"
+	guestImageKey    = "DEFAULT_IMAGE"
+)
+
+// ImageSource identifies why an image will be effective after an operation.
+type ImageSource string
+
+const (
+	ImageSourceRelease   ImageSource = "release"
+	ImageSourceOverride  ImageSource = "override"
+	ImageSourcePreserved ImageSource = "preserved"
+)
+
+// ImageSelection is an effective image reference and the policy that chose it.
+type ImageSelection struct {
+	Value  string
+	Source ImageSource
+}
+
+// ImagePreview contains the effective images for a proposed operation.
+type ImagePreview struct {
+	Backend  ImageSelection
+	Frontend ImageSelection
+	Guest    ImageSelection
+}
+
+// ImageReferences contains the three image defaults published by a release.
+type ImageReferences struct {
+	Backend  string
+	Frontend string
+	Guest    string
+}
+
+// Release owns a verified deployment bundle and its image defaults.
+type Release struct {
+	bundle  *bundle
+	version string
+	Images  ImageReferences
+}
+
+// Close releases temporary files owned by the resolved release.
+func (r *Release) Close() {
+	if r == nil || r.bundle == nil {
+		return
+	}
+	r.bundle.Close()
+	r.bundle = nil
+}
+
+// ResolveRelease loads and verifies the selected release without modifying an
+// installation. The caller must close the returned release.
+func (s Service) ResolveRelease(ctx context.Context, options Options) (*Release, error) {
+	loaded, err := (bundleLoader{client: s.HTTPClient}).Load(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	release := &Release{bundle: loaded, version: options.Version}
+	envData, err := os.ReadFile(filepath.Join(loaded.Dir, ".env.example"))
+	if err != nil {
+		release.Close()
+		return nil, fmt.Errorf("read release environment defaults: %w", err)
+	}
+	env := parseEnvFile(envData)
+	state := parseEnvFile(nil)
+	defaultOptions := options
+	defaultOptions.BackendImage, defaultOptions.BackendImageSet = "", false
+	defaultOptions.FrontendImage, defaultOptions.FrontendImageSet = "", false
+	defaultOptions.GuestImage, defaultOptions.GuestImageSet = "", false
+	plan := planImageReferences(env, state, loaded.Manifest, defaultOptions, "install")
+	if err := applyPlannedImageReferences(env, state, plan); err != nil {
+		release.Close()
+		return nil, err
+	}
+	release.Images = imageReferences(env)
+	return release, nil
+}
+
+// PreviewImages reports the values that the selected release would make
+// effective, including existing operator-owned values preserved on upgrade.
+func (s Service) PreviewImages(operation Operation, options Options, release *Release) (ImagePreview, error) {
+	if release == nil || release.bundle == nil {
+		return ImagePreview{}, fmt.Errorf("resolved release is required")
+	}
+	envData, envExists, err := readOptionalFile(filepath.Join(options.InstallDir, ".env"))
+	if err != nil {
+		return ImagePreview{}, err
+	}
+	if !envExists {
+		envData, err = os.ReadFile(filepath.Join(release.bundle.Dir, ".env.example"))
+		if err != nil {
+			return ImagePreview{}, fmt.Errorf("read release environment defaults: %w", err)
+		}
+	}
+	stateData, _, err := readOptionalFile(filepath.Join(options.InstallDir, ".installer-state.env"))
+	if err != nil {
+		return ImagePreview{}, err
+	}
+	mode := "set-missing"
+	if !envExists {
+		mode = "install"
+	} else if operation == OperationUpgrade {
+		mode = "upgrade"
+	}
+	plan := planImageReferences(parseEnvFile(envData), parseEnvFile(stateData), release.bundle.Manifest, options, mode)
+	return ImagePreview{
+		Backend:  plan.selection(backendImageKey),
+		Frontend: plan.selection(frontendImageKey),
+		Guest:    plan.selection(guestImageKey),
+	}, nil
+}
+
+type plannedImage struct {
+	value     string
+	set       bool
+	selection ImageSelection
+}
+
+type imageReferencePlan map[string]plannedImage
+
+func (p imageReferencePlan) selection(key string) ImageSelection { return p[key].selection }
+
+func planImageReferences(env, state, manifest *envFile, options Options, mode string) imageReferencePlan {
+	desired := desiredImageReferences(manifest, options)
+	explicit := map[string]bool{
+		backendImageKey:  options.BackendImageSet,
+		frontendImageKey: options.FrontendImageSet,
+		guestImageKey:    options.GuestImageSet,
+	}
+	plan := imageReferencePlan{}
+	for _, key := range []string{backendImageKey, "AGENT_COMPOSE_FRONTEND_VERSION", frontendImageKey, guestImageKey} {
+		value, desiredExists := desired[key]
+		current, currentExists := env.Get(key)
+		managed, managedExists := state.Get(key)
+		shouldSet := explicit[key] || mode == "install" || !currentExists || current == ""
+		if mode == "upgrade" && managedExists && current == managed {
+			shouldSet = true
+		}
+		item := plannedImage{value: value, set: desiredExists && shouldSet}
+		switch {
+		case item.set && explicit[key]:
+			item.selection = ImageSelection{Value: value, Source: ImageSourceOverride}
+		case item.set:
+			item.selection = ImageSelection{Value: value, Source: ImageSourceRelease}
+		case mode == "install" && currentExists:
+			item.selection = ImageSelection{Value: strings.TrimSpace(current), Source: ImageSourceRelease}
+		case currentExists:
+			item.selection = ImageSelection{Value: strings.TrimSpace(current), Source: ImageSourcePreserved}
+		}
+		plan[key] = item
+	}
+	return plan
+}
+
+func desiredImageReferences(manifest *envFile, options Options) map[string]string {
+	desired := map[string]string{}
+	if options.ImagePrefix != "" {
+		version := options.Version
+		if image, ok := manifest.Get(backendImageKey); ok {
+			if colon := strings.LastIndex(image, ":"); colon > strings.LastIndex(image, "/") {
+				version = image[colon+1:]
+			}
+		}
+		frontendVersion := options.FrontendVersion
+		if frontendVersion == "" {
+			frontendVersion = DefaultVersion
+		}
+		desired[backendImageKey] = options.ImagePrefix + "/agent-compose:" + version
+		desired["AGENT_COMPOSE_FRONTEND_VERSION"] = frontendVersion
+		desired[frontendImageKey] = options.ImagePrefix + "/agent-compose-ui:" + frontendVersion
+		desired[guestImageKey] = options.ImagePrefix + "/agent-compose-guest:" + version
+	} else {
+		for _, key := range []string{backendImageKey, "AGENT_COMPOSE_FRONTEND_VERSION", frontendImageKey, guestImageKey} {
+			if value, ok := manifest.Get(key); ok {
+				desired[key] = value
+			}
+		}
+	}
+	if options.BackendImageSet {
+		desired[backendImageKey] = strings.TrimSpace(options.BackendImage)
+	}
+	if options.FrontendImageSet {
+		desired[frontendImageKey] = strings.TrimSpace(options.FrontendImage)
+	}
+	if options.GuestImageSet {
+		desired[guestImageKey] = strings.TrimSpace(options.GuestImage)
+	}
+	return desired
+}
+
+func applyImageReferences(env, state, manifest *envFile, options Options, mode string) error {
+	return applyPlannedImageReferences(env, state, planImageReferences(env, state, manifest, options, mode))
+}
+
+func applyPlannedImageReferences(env, state *envFile, plan imageReferencePlan) error {
+	for key, item := range plan {
+		if !item.set {
+			continue
+		}
+		if err := env.Set(key, item.value); err != nil {
+			return err
+		}
+		if err := state.Set(key, item.value); err != nil {
+			return err
+		}
+	}
+	return state.Set("INSTALLER_PAYLOAD_VERSION", "1")
+}
+
+func imageReferences(env *envFile) ImageReferences {
+	backend, _ := env.Get(backendImageKey)
+	frontend, _ := env.Get(frontendImageKey)
+	guest, _ := env.Get(guestImageKey)
+	return ImageReferences{Backend: strings.TrimSpace(backend), Frontend: strings.TrimSpace(frontend), Guest: strings.TrimSpace(guest)}
+}

--- a/cmd/installer/internal/core/release_test.go
+++ b/cmd/installer/internal/core/release_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveReleaseReportsManifestImages(t *testing.T) {
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundle(t, "v2")
+	options.InstallDir = filepath.Join(t.TempDir(), "install")
+	service := Service{}
+
+	release, err := service.ResolveRelease(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release.Close()
+
+	want := ImageReferences{
+		Backend:  "registry.example/agent-compose:v2",
+		Frontend: "registry.example/agent-compose-ui:latest",
+		Guest:    "registry.example/agent-compose-guest:v2",
+	}
+	if release.Images != want {
+		t.Fatalf("release images = %#v, want %#v", release.Images, want)
+	}
+	preview, err := service.PreviewImages(OperationInstall, options, release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Backend.Value != want.Backend || preview.Backend.Source != ImageSourceRelease ||
+		preview.Frontend.Value != want.Frontend || preview.Guest.Value != want.Guest {
+		t.Fatalf("install preview = %#v", preview)
+	}
+}
+
+func TestPreviewImagesMatchesUpgradePreservation(t *testing.T) {
+	root := t.TempDir()
+	installDir := filepath.Join(root, "install")
+	writeTestFile(t, filepath.Join(installDir, ".env"), "AGENT_COMPOSE_IMAGE=operator.example/backend:keep\nAGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:v1\nDEFAULT_IMAGE=registry.example/agent-compose-guest:v1\n", 0o600)
+	writeTestFile(t, filepath.Join(installDir, ".installer-state.env"), "AGENT_COMPOSE_IMAGE=registry.example/agent-compose:v1\nAGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:v1\nDEFAULT_IMAGE=registry.example/agent-compose-guest:v1\n", 0o600)
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundle(t, "v2")
+	options.InstallDir = installDir
+	service := Service{}
+	release, err := service.ResolveRelease(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release.Close()
+
+	preview, err := service.PreviewImages(OperationUpgrade, options, release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Backend != (ImageSelection{Value: "operator.example/backend:keep", Source: ImageSourcePreserved}) {
+		t.Fatalf("backend preview = %#v", preview.Backend)
+	}
+	if preview.Frontend != (ImageSelection{Value: "registry.example/agent-compose-ui:latest", Source: ImageSourceRelease}) {
+		t.Fatalf("frontend preview = %#v", preview.Frontend)
+	}
+	if preview.Guest != (ImageSelection{Value: "registry.example/agent-compose-guest:v2", Source: ImageSourceRelease}) {
+		t.Fatalf("guest preview = %#v", preview.Guest)
+	}
+}
+
+func TestApplyReleaseReusesResolvedBundle(t *testing.T) {
+	root := t.TempDir()
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundle(t, "v1")
+	options.InstallDir = filepath.Join(root, "install")
+	options.KVMPath = filepath.Join(root, "missing-kvm")
+	options.NoStart = true
+	service := Service{Runner: &fakeRunner{}}
+	release, err := service.ResolveRelease(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release.Close()
+
+	options.BundleDir = filepath.Join(root, "bundle-was-removed")
+	result, err := service.ApplyRelease(context.Background(), OperationInstall, options, release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.GuestImage != "registry.example/agent-compose-guest:v1" {
+		t.Fatalf("guest image = %q", result.GuestImage)
+	}
+	if _, err := os.Stat(filepath.Join(options.InstallDir, ".env")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/installer/internal/core/service.go
+++ b/cmd/installer/internal/core/service.go
@@ -63,7 +63,23 @@ func (s Service) Apply(ctx context.Context, operation Operation, options Options
 	if operation == OperationUninstall {
 		return s.uninstall(ctx, options)
 	}
-	return s.installOrUpgrade(ctx, operation, options)
+	return s.installOrUpgrade(ctx, operation, options, nil)
+}
+
+// ApplyRelease applies an install or upgrade using a release that was already
+// resolved for an interactive preview. Reusing it keeps a moving "latest"
+// release consistent between confirmation and execution.
+func (s Service) ApplyRelease(ctx context.Context, operation Operation, options Options, release *Release) (Result, error) {
+	if operation == OperationUninstall {
+		return s.uninstall(ctx, options)
+	}
+	if release == nil || release.bundle == nil {
+		return Result{}, fmt.Errorf("resolved release is required")
+	}
+	if release.version != options.Version {
+		return Result{}, fmt.Errorf("resolved release version %q does not match requested version %q", release.version, options.Version)
+	}
+	return s.installOrUpgrade(ctx, operation, options, release.bundle)
 }
 
 func (s Service) report(kind EventKind, message string) {
@@ -108,7 +124,7 @@ func randomPassword() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(data), nil
 }
 
-func (s Service) installOrUpgrade(ctx context.Context, operation Operation, options Options) (result Result, resultErr error) {
+func (s Service) installOrUpgrade(ctx context.Context, operation Operation, options Options, resolved *bundle) (result Result, resultErr error) {
 	if err := options.Validate(operation); err != nil {
 		return result, err
 	}
@@ -120,12 +136,15 @@ func (s Service) installOrUpgrade(ctx context.Context, operation Operation, opti
 	if err := s.checkCompose(ctx); err != nil {
 		return result, err
 	}
-	s.report(EventStep, "Loading deployment bundle")
-	loadedBundle, err := (bundleLoader{client: s.HTTPClient}).Load(ctx, options)
-	if err != nil {
-		return result, err
+	loadedBundle := resolved
+	if loadedBundle == nil {
+		s.report(EventStep, "Loading deployment bundle")
+		loadedBundle, err = (bundleLoader{client: s.HTTPClient}).Load(ctx, options)
+		if err != nil {
+			return result, err
+		}
+		defer loadedBundle.Close()
 	}
-	defer loadedBundle.Close()
 
 	plan, err := prepareInstallPlan(operation, options, loadedBundle)
 	if err != nil {
@@ -410,64 +429,6 @@ func ensureSecrets(env *envFile) (string, error) {
 		return "", err
 	}
 	return password, nil
-}
-
-func applyImageReferences(env, state, manifest *envFile, options Options, mode string) error {
-	desired := map[string]string{}
-	explicit := map[string]bool{
-		"AGENT_COMPOSE_IMAGE":          options.BackendImageSet,
-		"AGENT_COMPOSE_FRONTEND_IMAGE": options.FrontendImageSet,
-		"DEFAULT_IMAGE":                options.GuestImageSet,
-	}
-	if options.ImagePrefix != "" {
-		version := options.Version
-		if image, ok := manifest.Get("AGENT_COMPOSE_IMAGE"); ok {
-			if colon := strings.LastIndex(image, ":"); colon > strings.LastIndex(image, "/") {
-				version = image[colon+1:]
-			}
-		}
-		frontendVersion := options.FrontendVersion
-		if frontendVersion == "" {
-			frontendVersion = DefaultVersion
-		}
-		desired["AGENT_COMPOSE_IMAGE"] = options.ImagePrefix + "/agent-compose:" + version
-		desired["AGENT_COMPOSE_FRONTEND_VERSION"] = frontendVersion
-		desired["AGENT_COMPOSE_FRONTEND_IMAGE"] = options.ImagePrefix + "/agent-compose-ui:" + frontendVersion
-		desired["DEFAULT_IMAGE"] = options.ImagePrefix + "/agent-compose-guest:" + version
-	} else {
-		for _, key := range []string{"AGENT_COMPOSE_IMAGE", "AGENT_COMPOSE_FRONTEND_VERSION", "AGENT_COMPOSE_FRONTEND_IMAGE", "DEFAULT_IMAGE"} {
-			if value, ok := manifest.Get(key); ok {
-				desired[key] = value
-			}
-		}
-	}
-	if options.BackendImageSet {
-		desired["AGENT_COMPOSE_IMAGE"] = strings.TrimSpace(options.BackendImage)
-	}
-	if options.FrontendImageSet {
-		desired["AGENT_COMPOSE_FRONTEND_IMAGE"] = strings.TrimSpace(options.FrontendImage)
-	}
-	if options.GuestImageSet {
-		desired["DEFAULT_IMAGE"] = strings.TrimSpace(options.GuestImage)
-	}
-	for key, value := range desired {
-		current, currentExists := env.Get(key)
-		managed, managedExists := state.Get(key)
-		shouldSet := explicit[key] || mode == "install" || !currentExists || current == ""
-		if mode == "upgrade" && managedExists && current == managed {
-			shouldSet = true
-		}
-		if !shouldSet {
-			continue
-		}
-		if err := env.Set(key, value); err != nil {
-			return err
-		}
-		if err := state.Set(key, value); err != nil {
-			return err
-		}
-	}
-	return state.Set("INSTALLER_PAYLOAD_VERSION", "1")
 }
 
 func selectDataDir(installDir string, env *envFile, existingEnv bool) (string, string, error) {

--- a/cmd/installer/internal/tui/form.go
+++ b/cmd/installer/internal/tui/form.go
@@ -26,10 +26,11 @@ const (
 // expressed as a textinput.Model, and the port field has to render as disabled
 // rather than disappear, so the form tracks fields instead of raw inputs.
 type formField struct {
-	id     fieldID
-	toggle bool
-	on     bool
-	input  textinput.Model
+	id             fieldID
+	toggle         bool
+	on             bool
+	followsRelease bool
+	input          textinput.Model
 }
 
 func newTextField(id fieldID, value string) formField {
@@ -44,14 +45,20 @@ func newToggleField(id fieldID, on bool) formField {
 	return formField{id: id, toggle: true, on: on}
 }
 
+func newImageField(id fieldID, value string, explicitlySet bool) formField {
+	field := newTextField(id, value)
+	field.followsRelease = !explicitlySet
+	return field
+}
+
 func (m *model) buildFields() {
 	m.fields = []formField{newTextField(fieldInstallDir, m.options.InstallDir)}
 	if m.operation != core.OperationUninstall {
 		m.fields = append(m.fields,
 			newTextField(fieldVersion, m.options.Version),
-			newTextField(fieldBackendImage, m.options.BackendImage),
-			newTextField(fieldFrontendImage, m.options.FrontendImage),
-			newTextField(fieldGuestImage, m.options.GuestImage),
+			newImageField(fieldBackendImage, m.options.BackendImage, m.options.BackendImageSet),
+			newImageField(fieldFrontendImage, m.options.FrontendImage, m.options.FrontendImageSet),
+			newImageField(fieldGuestImage, m.options.GuestImage, m.options.GuestImageSet),
 			newToggleField(fieldWithUI, m.options.WithUI),
 			newTextField(fieldPort, strconv.Itoa(m.options.Port)),
 			newToggleField(fieldGuestPull, !m.options.SkipGuestPull),
@@ -120,14 +127,11 @@ func (m *model) readFields() error {
 		case fieldVersion:
 			m.options.Version = strings.TrimSpace(field.input.Value())
 		case fieldBackendImage:
-			m.options.BackendImage = strings.TrimSpace(field.input.Value())
-			m.options.BackendImageSet = m.options.BackendImage != ""
+			m.readImageField(i, &m.options.BackendImage, &m.options.BackendImageSet)
 		case fieldFrontendImage:
-			m.options.FrontendImage = strings.TrimSpace(field.input.Value())
-			m.options.FrontendImageSet = m.options.FrontendImage != ""
+			m.readImageField(i, &m.options.FrontendImage, &m.options.FrontendImageSet)
 		case fieldGuestImage:
-			m.options.GuestImage = strings.TrimSpace(field.input.Value())
-			m.options.GuestImageSet = m.options.GuestImage != ""
+			m.readImageField(i, &m.options.GuestImage, &m.options.GuestImageSet)
 		case fieldWithUI:
 			m.options.WithUI = field.on
 			m.options.WithUISet = true
@@ -153,6 +157,21 @@ func (m *model) readFields() error {
 		m.options.InstallerPath = m.installerPath
 	}
 	return m.options.Validate(m.operation)
+}
+
+func (m *model) readImageField(index int, value *string, explicitlySet *bool) {
+	field := &m.fields[index]
+	trimmed := strings.TrimSpace(field.input.Value())
+	if trimmed == "" {
+		field.followsRelease = true
+	}
+	if field.followsRelease {
+		*value = ""
+		*explicitlySet = false
+		return
+	}
+	*value = trimmed
+	*explicitlySet = true
 }
 
 func (m *model) fieldLabel(id fieldID) string {
@@ -183,6 +202,9 @@ func (m *model) renderForm(body *strings.Builder) {
 	body.WriteString(mutedStyle.Render(description) + "\n\n")
 	for i := range m.fields {
 		m.renderFormField(body, i)
+	}
+	if m.resolving {
+		body.WriteString(mutedStyle.Render(m.spinner.View()+" "+m.text("正在解析版本 ", "Resolving release ")+m.resolvingVersion) + "\n")
 	}
 	if m.err != nil {
 		body.WriteString(warnStyle.Render("! "+m.err.Error()) + "\n")

--- a/cmd/installer/internal/tui/model.go
+++ b/cmd/installer/internal/tui/model.go
@@ -38,25 +38,33 @@ type operationResult struct {
 type eventMessage core.Event
 
 type model struct {
-	service       core.Service
-	ctx           context.Context
-	cancel        context.CancelFunc
-	options       core.Options
-	installerPath string
-	program       *tea.Program
-	screen        screen
-	language      language
-	cursor        int
-	operation     core.Operation
-	fields        []formField
-	focus         int
-	spinner       spinner.Model
-	cancelling    bool
-	events        []logEntry
-	result        core.Result
-	err           error
-	width         int
-	height        int
+	service              core.Service
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	options              core.Options
+	installerPath        string
+	program              *tea.Program
+	screen               screen
+	language             language
+	cursor               int
+	operation            core.Operation
+	fields               []formField
+	focus                int
+	spinner              spinner.Model
+	cancelling           bool
+	events               []logEntry
+	result               core.Result
+	err                  error
+	release              *core.Release
+	releaseVersion       string
+	preview              core.ImagePreview
+	resolving            bool
+	resolvingVersion     string
+	resolveID            uint64
+	resolveCancel        context.CancelFunc
+	continueAfterResolve bool
+	width                int
+	height               int
 }
 
 var (
@@ -82,7 +90,10 @@ const productTagline = ":: DECLARATIVE AGENT RUNTIME :: INSTALLER ::"
 
 func Run(service core.Service, defaults core.Options, installerPath string) error {
 	m := newModel(service, defaults, installerPath)
-	defer m.cancel()
+	defer func() {
+		m.cancel()
+		m.closeRelease()
+	}()
 	switch m.service.Runner.(type) {
 	case nil, core.ExecRunner:
 		m.service.Runner = core.ExecRunner{Output: newCommandOutputWriter(func(line string) {
@@ -128,6 +139,8 @@ func (m *model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case operationResult:
 		m.result, m.err, m.screen = msg.result, msg.err, screenDone
 		return m, nil
+	case releaseResolvedMessage:
+		return m.handleResolvedRelease(msg)
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -162,7 +175,8 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cursor, m.screen = 0, screenAction
 		})
 	case screenAction:
-		return m.updateMenu(key, 4, func(choice int) {
+		previousScreen := m.screen
+		updated, cmd := m.updateMenu(key, 4, func(choice int) {
 			if choice == 3 {
 				m.err = nil
 				m.screen = screenDone
@@ -172,13 +186,21 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.buildFields()
 			m.cursor, m.screen = 0, screenForm
 		})
+		if previousScreen != screenForm && m.screen == screenForm && m.operation != core.OperationUninstall {
+			return updated, tea.Batch(cmd, m.resolveRelease(m.options.Version, false))
+		}
+		return updated, cmd
 	case screenForm:
 		if key.String() == "tab" || key.String() == "down" || key.String() == "shift+tab" || key.String() == "up" {
+			leavingVersion := m.fields[m.focus].id == fieldVersion
 			delta := 1
 			if key.String() == "shift+tab" || key.String() == "up" {
 				delta = -1
 			}
 			m.moveFocus(delta)
+			if leavingVersion && m.fields[m.focus].id != fieldVersion {
+				return m, m.resolveRelease(strings.TrimSpace(m.field(fieldVersion).input.Value()), false)
+			}
 			return m, nil
 		}
 		if key.String() == "left" || key.String() == "right" || key.String() == " " {
@@ -194,16 +216,27 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.err = nil
 			if m.operation == core.OperationUninstall {
 				m.screen = screenPurge
-			} else {
-				m.screen = screenConfirm
+				return m, nil
 			}
-			return m, nil
+			if m.release != nil && m.releaseVersion == m.options.Version && !m.resolving {
+				m.showConfirmation()
+				return m, nil
+			}
+			if m.resolving && m.resolvingVersion == m.options.Version {
+				m.continueAfterResolve = true
+				return m, nil
+			}
+			return m, m.resolveRelease(m.options.Version, true)
 		}
 		if m.fields[m.focus].toggle {
 			return m, nil
 		}
 		var cmd tea.Cmd
+		before := m.fields[m.focus].input.Value()
 		m.fields[m.focus].input, cmd = m.fields[m.focus].input.Update(key)
+		if isImageField(m.fields[m.focus].id) && m.fields[m.focus].input.Value() != before {
+			m.fields[m.focus].followsRelease = false
+		}
 		return m, cmd
 	case screenPurge:
 		return m.updateMenu(key, 2, func(choice int) { m.options.Purge = choice == 1; m.cursor, m.screen = 0, screenConfirm })
@@ -224,6 +257,10 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func isImageField(id fieldID) bool {
+	return id == fieldBackendImage || id == fieldFrontendImage || id == fieldGuestImage
 }
 
 func (m *model) updateMenu(key tea.KeyMsg, count int, selectFn func(int)) (tea.Model, tea.Cmd) {
@@ -249,7 +286,7 @@ func (m *model) runOperation() tea.Cmd {
 				m.program.Send(eventMessage(event))
 			}
 		})
-		result, err := service.Apply(m.ctx, m.operation, m.options)
+		result, err := service.ApplyRelease(m.ctx, m.operation, m.options, m.release)
 		return operationResult{result: result, err: err}
 	}
 }
@@ -338,9 +375,9 @@ func (m *model) renderConfirm(body *strings.Builder) {
 		fmt.Fprintf(body, "  %s: %t\n", m.text("删除数据", "Purge data"), m.options.Purge)
 	} else {
 		fmt.Fprintf(body, "  %s: %s\n", m.text("版本", "Version"), m.options.Version)
-		fmt.Fprintf(body, "  %s: %s\n", m.text("后端镜像", "Backend image"), m.imageSelection(m.options.BackendImageSet, m.options.BackendImage))
-		fmt.Fprintf(body, "  %s: %s\n", m.text("前端镜像", "Frontend image"), m.imageSelection(m.options.FrontendImageSet, m.options.FrontendImage))
-		fmt.Fprintf(body, "  %s: %s\n", m.text("Guest 镜像", "Guest image"), m.imageSelection(m.options.GuestImageSet, m.options.GuestImage))
+		fmt.Fprintf(body, "  %s: %s\n", m.text("后端镜像", "Backend image"), m.imageSelection(m.preview.Backend))
+		fmt.Fprintf(body, "  %s: %s\n", m.text("前端镜像", "Frontend image"), m.imageSelection(m.preview.Frontend))
+		fmt.Fprintf(body, "  %s: %s\n", m.text("Guest 镜像", "Guest image"), m.imageSelection(m.preview.Guest))
 		fmt.Fprintf(body, "  %s: %s\n", m.text("安装 Web UI", "Install web UI"), m.yesNo(m.options.WithUI))
 		if m.options.WithUI {
 			fmt.Fprintf(body, "  %s: %d\n", m.text("Web UI 端口", "Web UI port"), m.options.Port)
@@ -351,14 +388,15 @@ func (m *model) renderConfirm(body *strings.Builder) {
 	m.renderMenu(body, m.text("确认继续？", "Continue?"), []string{m.text("继续", "Continue"), m.text("返回", "Back")})
 }
 
-func (m *model) imageSelection(set bool, image string) string {
-	if set {
-		return image
+func (m *model) imageSelection(selection core.ImageSelection) string {
+	label := m.text("发布默认值", "release default")
+	switch selection.Source {
+	case core.ImageSourceOverride:
+		label = m.text("显式覆盖", "explicit override")
+	case core.ImageSourcePreserved:
+		label = m.text("保留现有值", "preserved existing value")
 	}
-	if m.operation == core.OperationUpgrade {
-		return m.text("保留自定义值，否则使用发布默认值", "Preserve custom value, otherwise use release default")
-	}
-	return m.text("使用发布默认值", "Use release default")
+	return selection.Value + "  " + mutedStyle.Render("("+label+")")
 }
 
 func (m *model) renderDone(body *strings.Builder) {

--- a/cmd/installer/internal/tui/model_test.go
+++ b/cmd/installer/internal/tui/model_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,6 +25,7 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 	if m.operation != core.OperationInstall || m.screen != screenForm || len(m.fields) != 8 {
 		t.Fatalf("install form = %q, %d, %d fields", m.operation, m.screen, len(m.fields))
 	}
+	attachTestRelease(t, m, "v1", "ui-v3")
 	form := m.View()
 	for _, expected := range []string{"Configure installation", "Install directory", "Application version", "Backend image (optional)", "Frontend image (optional)", "Guest image (optional)", "Install web UI", "Web UI port", "Pre-pull guest image", "╭", "Tab / ↑↓ move"} {
 		if !strings.Contains(form, expected) {
@@ -37,13 +40,14 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 	if m.err == nil || !strings.Contains(m.View(), "absolute") {
 		t.Fatalf("expected path validation in view: %v\n%s", m.err, m.View())
 	}
-	m.fields[0].input.SetValue("/opt/agent-compose")
+	installDir := t.TempDir()
+	m.fields[0].input.SetValue(installDir)
 	press(t, m, "enter")
 	if m.screen != screenConfirm {
 		t.Fatalf("screen = %d, want confirmation", m.screen)
 	}
 	confirmation := m.View()
-	for _, expected := range []string{"/opt/agent-compose", "latest", "Backend image: Use release default", "Frontend image: Use release default", "Guest image: Use release default", "Install web UI: No", "Pre-pull guest image: Yes"} {
+	for _, expected := range []string{installDir, "latest", "Backend image: registry.example/agent-compose:v1", "Frontend image: registry.example/agent-compose-ui:ui-v3", "Guest image: registry.example/agent-compose-guest:v1", "release default", "Install web UI: No", "Pre-pull guest image: Yes"} {
 		if !strings.Contains(confirmation, expected) {
 			t.Fatalf("confirmation missing %q:\n%s", expected, confirmation)
 		}
@@ -55,9 +59,9 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 
 func TestModelReadsExplicitImageOverrides(t *testing.T) {
 	m := installForm(t)
-	m.field(fieldBackendImage).input.SetValue(" registry.example/backend:v1 ")
-	m.field(fieldFrontendImage).input.SetValue("registry.example/frontend@sha256:abc")
-	m.field(fieldGuestImage).input.SetValue("registry.example/guest:v2")
+	setExplicitImage(t, m, fieldBackendImage, " registry.example/backend:v1 ")
+	setExplicitImage(t, m, fieldFrontendImage, "registry.example/frontend@sha256:abc")
+	setExplicitImage(t, m, fieldGuestImage, "registry.example/guest:v2")
 
 	press(t, m, "enter")
 	if !m.options.BackendImageSet || m.options.BackendImage != "registry.example/backend:v1" {
@@ -74,6 +78,88 @@ func TestModelReadsExplicitImageOverrides(t *testing.T) {
 		if !strings.Contains(confirmation, image) {
 			t.Fatalf("confirmation missing %q:\n%s", image, confirmation)
 		}
+	}
+}
+
+func TestModelResolvesImagesWhenVersionLosesFocus(t *testing.T) {
+	m := installForm(t)
+	if got := m.field(fieldGuestImage).input.Value(); got != "registry.example/agent-compose-guest:v1" {
+		t.Fatalf("guest image field = %q", got)
+	}
+	if view := m.View(); !strings.Contains(view, "registry.example/agent-compose-guest:v1") {
+		t.Fatalf("initial release image is missing from the form:\n%s", view)
+	}
+
+	m.options.BundleDir = makeTUITestBundle(t, "v2", "ui-v4")
+	m.focus = indexOfField(t, m, fieldVersion)
+	m.focusFields()
+	m.field(fieldVersion).input.SetValue("v2")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if updated != m || cmd == nil || !m.resolving || m.resolvingVersion != "v2" {
+		t.Fatalf("version change did not start resolution: resolving=%t version=%q cmd=%v", m.resolving, m.resolvingVersion, cmd)
+	}
+	if view := m.View(); !strings.Contains(view, "Resolving release v2") {
+		t.Fatalf("resolution status is missing:\n%s", view)
+	}
+	message := cmd()
+	m.Update(message)
+	view := m.View()
+	for _, image := range []string{
+		"registry.example/agent-compose:v2",
+		"registry.example/agent-compose-ui:ui-v4",
+		"registry.example/agent-compose-guest:v2",
+	} {
+		if !strings.Contains(view, image) {
+			t.Fatalf("resolved form is missing %q:\n%s", image, view)
+		}
+	}
+}
+
+func TestModelVersionChangePreservesExplicitImage(t *testing.T) {
+	m := installForm(t)
+	setExplicitImage(t, m, fieldGuestImage, "operator.example/guest:keep")
+	m.options.BundleDir = makeTUITestBundle(t, "v2", "ui-v4")
+	m.focus = indexOfField(t, m, fieldVersion)
+	m.focusFields()
+	m.field(fieldVersion).input.SetValue("v2")
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if cmd == nil {
+		t.Fatal("version change did not start resolution")
+	}
+	m.Update(cmd())
+
+	if got := m.field(fieldBackendImage).input.Value(); got != "registry.example/agent-compose:v2" {
+		t.Fatalf("backend image = %q", got)
+	}
+	guest := m.field(fieldGuestImage)
+	if got := guest.input.Value(); got != "operator.example/guest:keep" || guest.followsRelease {
+		t.Fatalf("guest image = %q, follows release = %t", got, guest.followsRelease)
+	}
+}
+
+func setExplicitImage(t *testing.T, m *model, id fieldID, value string) {
+	t.Helper()
+	field := m.field(id)
+	if field == nil {
+		t.Fatalf("image field %d is missing", id)
+	}
+	field.input.SetValue(value)
+	field.followsRelease = false
+}
+
+func TestModelStaysInFormWhenReleaseResolutionFails(t *testing.T) {
+	m := installForm(t)
+	m.options.BundleDir = filepath.Join(t.TempDir(), "missing")
+	m.focus = indexOfField(t, m, fieldVersion)
+	m.focusFields()
+	m.field(fieldVersion).input.SetValue("missing")
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if cmd == nil {
+		t.Fatal("version change did not start resolution")
+	}
+	m.Update(cmd())
+	if m.screen != screenForm || m.err == nil || !strings.Contains(m.View(), "resolve release missing") {
+		t.Fatalf("resolution failure did not remain in the form: screen=%d err=%v\n%s", m.screen, m.err, m.View())
 	}
 }
 
@@ -173,7 +259,49 @@ func installForm(t *testing.T) *model {
 	if m.screen != screenForm {
 		t.Fatalf("screen = %d, want the install form", m.screen)
 	}
+	attachTestRelease(t, m, "v1", "ui-v1")
 	return m
+}
+
+func attachTestRelease(t *testing.T, m *model, version, frontendVersion string) {
+	t.Helper()
+	dir := makeTUITestBundle(t, version, frontendVersion)
+	options := m.options
+	options.BundleDir = dir
+	release, err := m.service.ResolveRelease(m.ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.closeRelease()
+	m.release = release
+	m.releaseVersion = options.Version
+	m.syncReleaseImageFields()
+	m.options.BundleDir = dir
+	t.Cleanup(m.closeRelease)
+}
+
+func makeTUITestBundle(t *testing.T, version, frontendVersion string) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeTUITestFile(t, filepath.Join(dir, "docker-compose.yml"), "services: {}\n")
+	writeTUITestFile(t, filepath.Join(dir, ".env.example"), "AUTH_PASSWORD=\nAUTH_SECRET=\n")
+	manifest := "INSTALLER_PAYLOAD_VERSION=1\n" +
+		"AGENT_COMPOSE_IMAGE=registry.example/agent-compose:" + version + "\n" +
+		"AGENT_COMPOSE_FRONTEND_VERSION=" + frontendVersion + "\n" +
+		"AGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:" + frontendVersion + "\n" +
+		"DEFAULT_IMAGE=registry.example/agent-compose-guest:" + version + "\n"
+	writeTUITestFile(t, filepath.Join(dir, "images", "manifest.env"), manifest)
+	return dir
+}
+
+func writeTUITestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func indexOfField(t *testing.T, m *model, id fieldID) int {

--- a/cmd/installer/internal/tui/release.go
+++ b/cmd/installer/internal/tui/release.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chaitin/agent-compose/cmd/installer/internal/core"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type releaseResolvedMessage struct {
+	id      uint64
+	version string
+	release *core.Release
+	err     error
+}
+
+func (m *model) resolveRelease(version string, continueAfter bool) tea.Cmd {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		m.err = fmt.Errorf("%s", m.text("版本不能为空", "version must not be empty"))
+		return nil
+	}
+	if m.release != nil && m.releaseVersion == version {
+		m.syncReleaseImageFields()
+		if continueAfter {
+			m.showConfirmation()
+		}
+		return nil
+	}
+	if m.resolving && m.resolvingVersion == version {
+		m.continueAfterResolve = m.continueAfterResolve || continueAfter
+		return nil
+	}
+	if m.resolveCancel != nil {
+		m.resolveCancel()
+	}
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.resolveCancel = cancel
+	m.resolveID++
+	id := m.resolveID
+	m.resolving = true
+	m.resolvingVersion = version
+	m.continueAfterResolve = continueAfter
+	m.err = nil
+	options := m.options
+	options.Version = version
+	service := m.service
+	return func() tea.Msg {
+		release, err := service.ResolveRelease(ctx, options)
+		if err == nil {
+			select {
+			case <-ctx.Done():
+				release.Close()
+				return releaseResolvedMessage{id: id, version: version, err: ctx.Err()}
+			default:
+			}
+		}
+		return releaseResolvedMessage{id: id, version: version, release: release, err: err}
+	}
+}
+
+func (m *model) handleResolvedRelease(msg releaseResolvedMessage) (tea.Model, tea.Cmd) {
+	if msg.id != m.resolveID {
+		if msg.release != nil {
+			msg.release.Close()
+		}
+		return m, nil
+	}
+	m.resolving = false
+	m.resolvingVersion = ""
+	m.resolveCancel = nil
+	continueAfter := m.continueAfterResolve
+	m.continueAfterResolve = false
+	if msg.err != nil {
+		m.err = fmt.Errorf("%s %s: %w", m.text("无法解析版本", "resolve release"), msg.version, msg.err)
+		return m, nil
+	}
+	m.closeRelease()
+	m.release = msg.release
+	m.releaseVersion = msg.version
+	m.syncReleaseImageFields()
+	m.err = nil
+	if continueAfter {
+		m.showConfirmation()
+	}
+	return m, nil
+}
+
+func (m *model) syncReleaseImageFields() {
+	if m.release == nil {
+		return
+	}
+	for _, item := range []struct {
+		id    fieldID
+		value string
+	}{
+		{id: fieldBackendImage, value: m.release.Images.Backend},
+		{id: fieldFrontendImage, value: m.release.Images.Frontend},
+		{id: fieldGuestImage, value: m.release.Images.Guest},
+	} {
+		field := m.field(item.id)
+		if field == nil || (!field.followsRelease && strings.TrimSpace(field.input.Value()) != "") {
+			continue
+		}
+		field.input.SetValue(item.value)
+		field.followsRelease = true
+	}
+}
+
+func (m *model) showConfirmation() {
+	preview, err := m.service.PreviewImages(m.operation, m.options, m.release)
+	if err != nil {
+		m.err = err
+		return
+	}
+	m.preview = preview
+	m.err = nil
+	m.screen = screenConfirm
+}
+
+func (m *model) closeRelease() {
+	if m.resolveCancel != nil {
+		m.resolveCancel()
+		m.resolveCancel = nil
+	}
+	m.resolveID++
+	m.resolving = false
+	m.resolvingVersion = ""
+	m.continueAfterResolve = false
+	if m.release != nil {
+		m.release.Close()
+	}
+	m.release = nil
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -95,11 +95,13 @@ The interactive form and non-interactive CLI can independently override the
 backend (`--backend-image`), frontend (`--frontend-image`), and sandbox guest
 (`--guest-image`) image with a complete tag or digest reference. An explicit
 image always replaces that one value and becomes installer-managed, including
-during upgrade. Images omitted from the command retain the normal upgrade
-protection above. If the deprecated `--image-prefix` is combined with complete
-image options, the complete option wins for its image and the prefix supplies
-the omitted images. Without either form of override, the Docker Hub references
-from the selected Release bundle are used.
+during upgrade. The TUI displays the exact defaults from the selected Release
+manifest and refreshes them when the version field loses focus; an empty image
+field continues to follow that Release. Images omitted from the command retain
+the normal upgrade protection above. If the deprecated `--image-prefix` is
+combined with complete image options, the complete option wins for its image
+and the prefix supplies the omitted images. Without either form of override,
+the Docker Hub references from the selected Release bundle are used.
 
 New installations persist `AGENT_COMPOSE_DATA_DIR=./data`. If an older database
 exists only under `./data/agent-compose`, that path is retained. When databases


### PR DESCRIPTION
## Summary

- resolve the selected release bundle before TUI confirmation and show exact backend, frontend, and guest image references in editable fields
- refresh release-managed images when the application version changes while preserving explicit operator overrides and existing upgrade protection
- reuse the verified bundle between preview and apply so a moving `latest` release cannot drift, and document the interactive behavior

## Testing

- `task lint`
- `task build`
- `task test`
- `task test:deploy`
- `go test -race ./internal/core ./internal/tui` (from `cmd/installer`)

Coverage summary: unit 74.90%, integration 60.92%, E2E 60.34%, combined 79.07%.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.