### PR TITLE
fix(llms): inject all startup facade environments

### DIFF
--- a/pkg/agentcompose/adapters/agent_runner.go
+++ b/pkg/agentcompose/adapters/agent_runner.go
@@ -146,7 +146,17 @@ func (r *AgentRunner) PrepareSandboxAgentEnvironment(ctx context.Context, sessio
 			return err
 		}
 	}
+	startupEnv, err := runtimefacade.EnsureSessionStartupFacadeConfig(ctx, r.config, facadeStoreFor(r.configDB), session, runtimefacade.TokenSourceAgent, "")
+	if err != nil {
+		if r.configDB != nil {
+			_ = r.configDB.RevokeLLMFacadeTokensForSandbox(context.WithoutCancel(ctx), session.Summary.ID)
+		}
+		return err
+	}
 	if _, err := r.prepareAgentFiles(ctx, session, agent, definition); err != nil {
+		if r.configDB != nil {
+			_ = r.configDB.RevokeLLMFacadeTokensForSandbox(context.WithoutCancel(ctx), session.Summary.ID)
+		}
 		return err
 	}
 	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, r.config, facadeStoreFor(r.configDB), session, agent.Provider, agent.Model, "session", "")
@@ -162,8 +172,11 @@ func (r *AgentRunner) PrepareSandboxAgentEnvironment(ctx context.Context, sessio
 		}
 		return err
 	}
+	if len(startupEnv) > 0 {
+		session.RuntimeEnvItems = domain.MergeEnvItems(session.RuntimeEnvItems, llms.EnvItemsFromMap(startupEnv, true))
+	}
 	if len(managedEnv) > 0 {
-		session.RuntimeEnvItems = domain.MergeEnvItems(session.RuntimeEnvItems, llms.EnvItemsFromMap(managedEnv, false))
+		session.RuntimeEnvItems = domain.MergeEnvItems(session.RuntimeEnvItems, llms.EnvItemsFromMap(managedEnv, true))
 	}
 	return nil
 }

--- a/pkg/agentcompose/adapters/agent_runner_test.go
+++ b/pkg/agentcompose/adapters/agent_runner_test.go
@@ -14,6 +14,7 @@ import (
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
 	"agent-compose/pkg/internal/testutil"
+	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/storage/sandboxstore"
 )
@@ -61,6 +62,16 @@ func TestAgentRunnerPrepareSandboxAgentEnvironmentUsesOnlyCurrentAgent(t *testin
 	if err != nil {
 		t.Fatalf("OpenStores returned error: %v", err)
 	}
+	if err := configDB.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:           "anthropic-primary",
+		Name:         "Anthropic",
+		ProviderType: llms.ProviderFamilyAnthropic,
+		BaseURL:      "https://anthropic.upstream.test",
+		APIKey:       "anthropic-upstream-secret",
+		Scope:        llms.ProviderScopeSystem,
+	}, llms.Model{ID: "claude-agent", Name: "claude-agent", Enabled: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save Anthropic provider: %v", err)
+	}
 	session, err := store.CreateSandbox(ctx, "agent environment", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, []domain.SandboxTag{
 		{Name: domain.AgentSandboxTagSource, Value: domain.AgentSandboxTagSourceVal},
 		{Name: domain.AgentSandboxTagID, Value: "agent-1"},
@@ -93,8 +104,8 @@ func TestAgentRunnerPrepareSandboxAgentEnvironmentUsesOnlyCurrentAgent(t *testin
 	if env["OPENAI_API_KEY"] == "" || env["OPENAI_BASE_URL"] == "" {
 		t.Fatalf("missing current Codex environment: %#v", env)
 	}
-	if env["ANTHROPIC_API_KEY"] != "" || env["ANTHROPIC_BASE_URL"] != "" {
-		t.Fatalf("unexpected Claude environment: %#v", env)
+	if env["ANTHROPIC_API_KEY"] == "" || env["ANTHROPIC_BASE_URL"] == "" || env["ANTHROPIC_API_KEY"] == "anthropic-upstream-secret" {
+		t.Fatalf("missing or leaked Claude environment: %#v", env)
 	}
 	if data, err := os.ReadFile(execution.HostAgentSystemPromptPath(session)); err != nil || string(data) != definition.SystemPrompt {
 		t.Fatalf("system prompt = %q err=%v", string(data), err)
@@ -111,6 +122,16 @@ func TestAgentRunnerPrepareSandboxAgentEnvironmentUsesOnlyCurrentAgent(t *testin
 	}
 	if token.Model != "gpt-agent" || token.Source != "session" || token.RunID != "" {
 		t.Fatalf("sandbox token = %#v", token)
+	}
+	if err := store.UpdateSandbox(ctx, session); err != nil {
+		t.Fatalf("UpdateSandbox returned error: %v", err)
+	}
+	reloaded, err := store.GetSandbox(ctx, session.Summary.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox returned error: %v", err)
+	}
+	if len(reloaded.RuntimeEnvItems) != 0 || domain.SandboxEnvMap(reloaded.EnvItems)["ANTHROPIC_API_KEY"] != "" || domain.SandboxEnvMap(reloaded.EnvItems)["OPENAI_API_KEY"] != "" {
+		t.Fatalf("transient facade environment persisted: %#v", reloaded)
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -306,6 +306,16 @@ func TestSandboxDriverFreshStartFailureRevokesPreparedAgentToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenStores returned error: %v", err)
 	}
+	if err := configDB.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:           "anthropic-startup",
+		Name:         "Anthropic",
+		ProviderType: llms.ProviderFamilyAnthropic,
+		BaseURL:      "https://anthropic.upstream.test",
+		APIKey:       "anthropic-upstream-secret",
+		Scope:        llms.ProviderScopeSystem,
+	}, llms.Model{ID: "claude-startup", Name: "claude-startup", Enabled: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save Anthropic provider: %v", err)
+	}
 	session, err := store.CreateSandbox(ctx, "failed start", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
@@ -315,8 +325,12 @@ func TestSandboxDriverFreshStartFailureRevokesPreparedAgentToken(t *testing.T) {
 		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
 	}
 	rawToken := domain.SandboxEnvMap(session.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	anthropicToken := domain.SandboxEnvMap(session.RuntimeEnvItems)["ANTHROPIC_API_KEY"]
 	if rawToken == "" {
 		t.Fatal("prepared sandbox token is empty")
+	}
+	if anthropicToken == "" || anthropicToken == "anthropic-upstream-secret" {
+		t.Fatalf("prepared Anthropic token = %q", anthropicToken)
 	}
 	startErr := errors.New("runtime start failed")
 	driver := NewSandboxDriver(config, store, configDB, fakeRuntimeProvider{runtime: fakeSessionRuntime{ensureErr: startErr}})
@@ -329,6 +343,13 @@ func TestSandboxDriverFreshStartFailureRevokesPreparedAgentToken(t *testing.T) {
 	}
 	if token.RevokedAt.IsZero() {
 		t.Fatalf("failed fresh start token remains active: %#v", token)
+	}
+	anthropicFacadeToken, err := configDB.GetLLMFacadeToken(ctx, anthropicToken)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken Anthropic token: %v", err)
+	}
+	if anthropicFacadeToken.RevokedAt.IsZero() {
+		t.Fatalf("failed fresh start Anthropic token remains active: %#v", anthropicFacadeToken)
 	}
 }
 
@@ -355,6 +376,16 @@ func TestSandboxDriverReleasedRuntimeRecreationFailureRevokesPreparedAgentToken(
 	if err != nil {
 		t.Fatalf("OpenStores returned error: %v", err)
 	}
+	if err := configDB.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:           "anthropic-recreation",
+		Name:         "Anthropic",
+		ProviderType: llms.ProviderFamilyAnthropic,
+		BaseURL:      "https://anthropic.upstream.test",
+		APIKey:       "anthropic-upstream-secret",
+		Scope:        llms.ProviderScopeSystem,
+	}, llms.Model{ID: "claude-recreation", Name: "claude-recreation", Enabled: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save Anthropic provider: %v", err)
+	}
 	session, err := store.CreateSandbox(ctx, "failed released runtime recreation", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
@@ -365,8 +396,12 @@ func TestSandboxDriverReleasedRuntimeRecreationFailureRevokesPreparedAgentToken(
 		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
 	}
 	rawToken := domain.SandboxEnvMap(session.RuntimeEnvItems)["AGENT_COMPOSE_SANDBOX_TOKEN"]
+	anthropicToken := domain.SandboxEnvMap(session.RuntimeEnvItems)["ANTHROPIC_API_KEY"]
 	if rawToken == "" {
 		t.Fatal("prepared sandbox token is empty")
+	}
+	if anthropicToken == "" || anthropicToken == "anthropic-upstream-secret" {
+		t.Fatalf("prepared Anthropic token = %q", anthropicToken)
 	}
 	if err := store.SaveVMState(session.Summary.ID, domain.VMState{
 		Driver:    driverpkg.RuntimeDriverBoxlite,
@@ -386,6 +421,13 @@ func TestSandboxDriverReleasedRuntimeRecreationFailureRevokesPreparedAgentToken(
 	}
 	if token.RevokedAt.IsZero() {
 		t.Fatalf("failed runtime recreation token remains active: %#v", token)
+	}
+	anthropicFacadeToken, err := configDB.GetLLMFacadeToken(ctx, anthropicToken)
+	if err != nil {
+		t.Fatalf("GetLLMFacadeToken Anthropic token: %v", err)
+	}
+	if anthropicFacadeToken.RevokedAt.IsZero() {
+		t.Fatalf("failed runtime recreation Anthropic token remains active: %#v", anthropicFacadeToken)
 	}
 }
 

--- a/pkg/agentcompose/proxy/runtime_llm_coverage_test.go
+++ b/pkg/agentcompose/proxy/runtime_llm_coverage_test.go
@@ -68,6 +68,36 @@ func TestRuntimeLLMFacadeRoutesCoverageWorkflow(t *testing.T) {
 	}
 }
 
+func TestRuntimeLLMFacadeOpenAIStartupTokenAllowsBothIngressProtocols(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "responses", path: "/api/runtime/sandboxes/sandbox-1/llm/openai/v1/responses", body: `{"model":"gpt","input":"hi"}`},
+		{name: "chat completions", path: "/api/runtime/sandboxes/sandbox-1/llm/openai/v1/chat/completions", body: `{"model":"gpt","messages":[{"role":"user","content":"hi"}]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			e := echo.New()
+			client := &fakeRuntimeLLMHTTPClient{status: http.StatusOK, body: `{"id":"resp-1","model":"gpt","output":[]}`}
+			RegisterRuntimeLLMFacadeRoutes(e, RuntimeLLMOptions{
+				Tokens:        fakeRuntimeLLMTokens{token: llms.FacadeToken{SandboxID: "sandbox-1", ProviderID: "provider-1", WireAPI: "", ExpiresAt: time.Now().Add(time.Hour)}},
+				Sandboxes:     fakeRuntimeLLMSessions{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", VMStatus: domain.VMStatusRunning}}},
+				ResolveTarget: fakeRuntimeLLMTargetResolver("http://upstream.test/v1"),
+				Client:        client,
+			})
+			req := httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(test.body))
+			req.Header.Set("Authorization", "Bearer raw-token")
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK || client.calls != 1 {
+				t.Fatalf("startup token status=%d body=%s calls=%d", rec.Code, rec.Body.String(), client.calls)
+			}
+		})
+	}
+}
+
 func TestRuntimeLLMFacadeProtocolAndStreamCoverage(t *testing.T) {
 	t.Run("anthropic transparent proxy", func(t *testing.T) {
 		e := echo.New()

--- a/pkg/llms/runtime_facade_provider.go
+++ b/pkg/llms/runtime_facade_provider.go
@@ -1,0 +1,54 @@
+package llms
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// SelectRuntimeFacadeProvider chooses the provider that a startup-compatible
+// facade token should bind to. A provider created from this sandbox's env wins
+// over global providers; other session-env providers are not eligible.
+func SelectRuntimeFacadeProvider(ctx context.Context, store ProviderListStore, sandboxID, providerFamily string) (Provider, bool, error) {
+	if store == nil {
+		return Provider{}, false, nil
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return Provider{}, false, err
+	}
+	providerFamily = NormalizeProviderType(providerFamily)
+	preferredID := SessionEnvProviderID(sandboxID, providerFamily)
+	candidates := make([]Provider, 0, len(providers))
+	for _, provider := range providers {
+		if NormalizeProviderType(provider.ProviderType) != providerFamily {
+			continue
+		}
+		if IsSessionEnvProviderID(provider.ID) && provider.ID != preferredID {
+			continue
+		}
+		candidates = append(candidates, provider)
+	}
+	if len(candidates) == 0 {
+		return Provider{}, false, nil
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		left, right := candidates[i], candidates[j]
+		if left.ID == preferredID && right.ID != preferredID {
+			return true
+		}
+		if right.ID == preferredID && left.ID != preferredID {
+			return false
+		}
+		leftPriority := ProviderSelectionPriority(left.Scope)
+		rightPriority := ProviderSelectionPriority(right.Scope)
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		if left.Weight != right.Weight {
+			return left.Weight < right.Weight
+		}
+		return strings.TrimSpace(left.ID) < strings.TrimSpace(right.ID)
+	})
+	return candidates[0], true, nil
+}

--- a/pkg/llms/runtimefacade/config_test.go
+++ b/pkg/llms/runtimefacade/config_test.go
@@ -86,6 +86,116 @@ func TestEnsureSessionLLMFacadeConfigCreatesCodexEnvAndToken(t *testing.T) {
 	}
 }
 
+func TestEnsureSessionStartupFacadeConfigIncludesAllAvailableFamilies(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		DbAddr:         filepath.Join(root, "data.db"),
+		RuntimeBaseURL: "http://agent-compose.test:7410",
+		GuestHomePath:  "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:             "anthropic-primary",
+		Name:           "Anthropic",
+		ProviderType:   llms.ProviderFamilyAnthropic,
+		DefaultWireAPI: llms.APIProtocolMessages,
+		BaseURL:        "https://anthropic.upstream.test",
+		APIKey:         "anthropic-upstream-secret",
+		Scope:          llms.ProviderScopeSystem,
+		Weight:         1,
+	}, llms.Model{ID: "claude-model", Name: "claude-model", Enabled: true, DefaultModel: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save Anthropic provider: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:             "openai-primary",
+		Name:           "OpenAI",
+		ProviderType:   llms.ProviderFamilyOpenAI,
+		DefaultWireAPI: llms.APIProtocolResponses,
+		BaseURL:        "https://openai.upstream.test",
+		APIKey:         "openai-upstream-secret",
+		Scope:          llms.ProviderScopeSystem,
+		Weight:         2,
+	}, llms.Model{ID: "openai-model", Name: "openai-model", Enabled: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save OpenAI provider: %v", err)
+	}
+
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-startup-facades", Driver: driverpkg.RuntimeDriverDocker}}
+	env, err := EnsureSessionStartupFacadeConfig(ctx, config, store, session, TokenSourceAgent, "")
+	if err != nil {
+		t.Fatalf("EnsureSessionStartupFacadeConfig returned error: %v", err)
+	}
+	if env["ANTHROPIC_API_KEY"] == "" || env["ANTHROPIC_AUTH_TOKEN"] != env["ANTHROPIC_API_KEY"] || env["ANTHROPIC_BASE_URL"] == "" {
+		t.Fatalf("Anthropic startup environment = %#v", env)
+	}
+	if env["OPENAI_API_KEY"] == "" || env["OPENAI_BASE_URL"] == "" {
+		t.Fatalf("OpenAI startup environment = %#v", env)
+	}
+	if env["AGENT_COMPOSE_SANDBOX_TOKEN"] != "" || env["LLM_API_KEY"] != "" {
+		t.Fatalf("startup environment unexpectedly contains common facade variables = %#v", env)
+	}
+	if env["ANTHROPIC_API_KEY"] == "anthropic-upstream-secret" || env["OPENAI_API_KEY"] == "openai-upstream-secret" {
+		t.Fatalf("startup environment leaked an upstream credential = %#v", env)
+	}
+
+	anthropicToken, err := store.GetLLMFacadeToken(ctx, env["ANTHROPIC_API_KEY"])
+	if err != nil {
+		t.Fatalf("load Anthropic startup token: %v", err)
+	}
+	if anthropicToken.ProviderID != "anthropic-primary" || anthropicToken.WireAPI != llms.APIProtocolMessages {
+		t.Fatalf("Anthropic startup token = %#v", anthropicToken)
+	}
+	openAIToken, err := store.GetLLMFacadeToken(ctx, env["OPENAI_API_KEY"])
+	if err != nil {
+		t.Fatalf("load OpenAI startup token: %v", err)
+	}
+	if openAIToken.ProviderID != "openai-primary" || openAIToken.WireAPI != "" {
+		t.Fatalf("OpenAI startup token = %#v", openAIToken)
+	}
+}
+
+func TestEnsureSessionStartupFacadeConfigSkipsUnavailableFamily(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{DataRoot: root, DbAddr: filepath.Join(root, "data.db"), RuntimeBaseURL: "http://agent-compose.test:7410"}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:           "anthropic-only",
+		Name:         "Anthropic",
+		ProviderType: llms.ProviderFamilyAnthropic,
+		BaseURL:      "https://anthropic.upstream.test",
+		APIKey:       "anthropic-upstream-secret",
+		Scope:        llms.ProviderScopeSystem,
+	}, llms.Model{ID: "claude-only", Name: "claude-only", Enabled: true, DefaultModel: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save Anthropic provider: %v", err)
+	}
+
+	env, err := EnsureSessionStartupFacadeConfig(ctx, config, store, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-anthropic-only"}}, TokenSourceAgent, "")
+	if err != nil {
+		t.Fatalf("EnsureSessionStartupFacadeConfig returned error: %v", err)
+	}
+	if env["ANTHROPIC_API_KEY"] == "" || env["OPENAI_API_KEY"] != "" || env["OPENAI_BASE_URL"] != "" {
+		t.Fatalf("single-family startup environment = %#v", env)
+	}
+}
+
 func TestEnsureSessionLLMFacadeConfigRejectsManagedCodexWithoutReachableFacade(t *testing.T) {
 	isolateLLMEnv(t)
 

--- a/pkg/llms/runtimefacade/startup_config.go
+++ b/pkg/llms/runtimefacade/startup_config.go
@@ -1,0 +1,166 @@
+package runtimefacade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+// EnsureSessionStartupFacadeConfig creates the short-lived environment needed
+// by commands that may run before the selected agent's exact facade config is
+// applied. Each provider family gets its own provider-bound token. The common
+// facade variables are intentionally left to EnsureSessionAgentRuntimeConfig,
+// because one process environment cannot represent two different common
+// facade tokens at once.
+func EnsureSessionStartupFacadeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, source, runID string) (map[string]string, error) {
+	if config == nil || store == nil || session == nil {
+		return nil, nil
+	}
+	baseURL := llms.GuestRuntimeBaseURL(config, session)
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, nil
+	}
+
+	env := make(map[string]string)
+	for _, family := range []string{llms.ProviderFamilyAnthropic, llms.ProviderFamilyOpenAI} {
+		familyEnv, err := ensureStartupFamilyConfig(ctx, config, store, session, family, source, runID, baseURL)
+		if err != nil {
+			return nil, err
+		}
+		for name, value := range familyEnv {
+			env[name] = value
+		}
+	}
+	if len(env) == 0 {
+		return nil, nil
+	}
+	return env, nil
+}
+
+func ensureStartupFamilyConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, family, source, runID, baseURL string) (map[string]string, error) {
+	provider, available, err := llms.SelectRuntimeFacadeProvider(ctx, store, session.Summary.ID, family)
+	if err != nil {
+		return nil, fmt.Errorf("select %s startup facade provider: %w", family, err)
+	}
+	providerEnv, err := llms.SandboxProviderEnvItems(ctx, store, session, family)
+	if err != nil {
+		return nil, fmt.Errorf("load %s startup facade environment: %w", family, err)
+	}
+	if !available && !startupFamilyHasInput(ctx, config, store, family, providerEnv) {
+		return nil, nil
+	}
+	if !available {
+		target, resolveErr := llms.ResolveRuntimeLLMTargetWithEnv(
+			ctx,
+			config,
+			store,
+			session.Summary.ID,
+			family,
+			startupFamilyModel(ctx, config, store, family, providerEnv),
+			"",
+			providerEnv,
+		)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("resolve %s startup facade provider: %w", family, resolveErr)
+		}
+		provider = target.Provider
+	}
+
+	wireAPI := ""
+	if family == llms.ProviderFamilyAnthropic {
+		wireAPI = llms.APIProtocolMessages
+	}
+	rawToken, token, err := llms.NewFacadeToken(session.Summary.ID, "", provider.ID, wireAPI, source, runID)
+	if err != nil {
+		return nil, fmt.Errorf("issue %s startup facade token: %w", family, err)
+	}
+	if err := store.SaveLLMFacadeToken(ctx, token); err != nil {
+		return nil, fmt.Errorf("save %s startup facade token: %w", family, err)
+	}
+
+	familyBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + session.Summary.ID
+	if family == llms.ProviderFamilyAnthropic {
+		familyBaseURL += "/llm/anthropic"
+		return map[string]string{
+			"ANTHROPIC_API_KEY":    rawToken,
+			"ANTHROPIC_AUTH_TOKEN": rawToken,
+			"ANTHROPIC_BASE_URL":   familyBaseURL,
+		}, nil
+	}
+	return map[string]string{
+		"OPENAI_API_KEY":  rawToken,
+		"OPENAI_BASE_URL": familyBaseURL + "/llm/openai/v1",
+	}, nil
+}
+
+func startupFamilyHasInput(ctx context.Context, config *appconfig.Config, store FacadeStore, family string, providerEnv []domain.SandboxEnvVar) bool {
+	if family == llms.ProviderFamilyAnthropic && llms.HasAnthropicEnvProviderInput(providerEnv) {
+		return true
+	}
+	if family == llms.ProviderFamilyOpenAI && llms.HasOpenAIEnvProviderInput(providerEnv) {
+		return true
+	}
+	protocol := startupEnvValue(ctx, config, store, "LLM_API_PROTOCOL")
+	switch family {
+	case llms.ProviderFamilyAnthropic:
+		return firstNonEmpty(
+			startupEnvValue(ctx, config, store, "ANTHROPIC_API_KEY"),
+			startupEnvValue(ctx, config, store, "ANTHROPIC_AUTH_TOKEN"),
+			startupEnvValue(ctx, config, store, "ANTHROPIC_BASE_URL"),
+		) != "" || (llms.NormalizeWireAPI(protocol) == llms.APIProtocolMessages && startupGenericInput(ctx, config, store))
+	case llms.ProviderFamilyOpenAI:
+		return firstNonEmpty(
+			startupEnvValue(ctx, config, store, "OPENAI_API_KEY"),
+			startupEnvValue(ctx, config, store, "OPENAI_BASE_URL"),
+		) != "" || (llms.NormalizeWireAPI(protocol) != llms.APIProtocolMessages && startupGenericInput(ctx, config, store))
+	default:
+		return false
+	}
+}
+
+func startupGenericInput(ctx context.Context, config *appconfig.Config, store FacadeStore) bool {
+	return firstNonEmpty(
+		startupEnvValue(ctx, config, store, "LLM_API_ENDPOINT"),
+		startupEnvValue(ctx, config, store, "LLM_API_KEY"),
+	) != ""
+}
+
+func startupFamilyModel(ctx context.Context, config *appconfig.Config, store FacadeStore, family string, providerEnv []domain.SandboxEnvVar) string {
+	if family == llms.ProviderFamilyAnthropic {
+		return firstNonEmpty(
+			llms.SessionAnthropicEnvModel(providerEnv),
+			startupEnvValue(ctx, config, store, "ANTHROPIC_MODEL"),
+			startupEnvValue(ctx, config, store, "CLAUDE_MODEL"),
+			startupEnvValue(ctx, config, store, "LLM_MODEL"),
+		)
+	}
+	return firstNonEmpty(
+		llms.EnvItemValue(providerEnv, "LLM_MODEL"),
+		startupEnvValue(ctx, config, store, "LLM_MODEL"),
+	)
+}
+
+func startupEnvValue(ctx context.Context, config *appconfig.Config, store FacadeStore, key string) string {
+	if value := llms.LookupEnvValue(ctx, store, key); value != "" {
+		return value
+	}
+	if config == nil {
+		return ""
+	}
+	switch strings.ToUpper(strings.TrimSpace(key)) {
+	case "LLM_API_ENDPOINT":
+		return config.LLMAPIEndpoint
+	case "LLM_API_PROTOCOL":
+		return config.LLMAPIProtocol
+	case "LLM_API_KEY":
+		return config.LLMAPIKey
+	case "LLM_MODEL":
+		return config.LLMModel
+	default:
+		return ""
+	}
+}

--- a/pkg/llms/token.go
+++ b/pkg/llms/token.go
@@ -16,13 +16,17 @@ func NewFacadeToken(sandboxID, model, providerID, wireAPI, source, runID string)
 	tokenValue := "ac_llm_" + hex.EncodeToString(raw)
 	hash, fingerprint := HashFacadeToken(tokenValue)
 	now := time.Now().UTC()
+	normalizedWireAPI := strings.TrimSpace(wireAPI)
+	if normalizedWireAPI != "" {
+		normalizedWireAPI = NormalizeWireAPI(normalizedWireAPI)
+	}
 	return tokenValue, FacadeToken{
 		SandboxID:        strings.TrimSpace(sandboxID),
 		TokenHash:        hash,
 		TokenFingerprint: fingerprint,
 		Model:            strings.TrimSpace(model),
 		ProviderID:       strings.TrimSpace(providerID),
-		WireAPI:          NormalizeWireAPI(wireAPI),
+		WireAPI:          normalizedWireAPI,
 		Source:           strings.TrimSpace(source),
 		RunID:            strings.TrimSpace(runID),
 		IssuedAt:         now,


### PR DESCRIPTION
## Summary

Inject all currently available LLM facade startup environments into sandboxes instead of selecting a single family by agent name.

- Anthropic and OpenAI-compatible facade startup tokens are sandbox-scoped and provider-bound.
- Exact selected-agent facade configuration overrides common/current-family variables.
- Other available family-specific variables remain available to custom image entrypoints.
- Startup tokens are revoked on startup/recreation failures and sandbox stop/remove lifecycle paths.
- RuntimeEnvItems remain transient and are regenerated after restart recovery.
- Upstream provider credentials are never injected into the guest.

## Validation

- Focused package tests passed.
- `go test -race ./pkg/llms/runtimefacade ./pkg/agentcompose/proxy ./pkg/agentcompose/adapters` passed.
- `task lint` passed.
- `task build` passed.
- `task test` was attempted but stopped at installer tests because the environment refused the `/var` install path due to a symlink component; the full gate did not complete.

The untracked upgrade document was intentionally excluded.