### PR TITLE
feat(microsandbox): support interactive terminal streams

### DIFF
--- a/docs/design/runtime-bidirectional-stream-design.md
+++ b/docs/design/runtime-bidirectional-stream-design.md
@@ -10,7 +10,7 @@ ExecStream(context.Context, *Session, VMState, ExecSpec, ExecStreamWriter) (Exec
 
 This interface can express "one-shot start parameters plus a runtime-to-daemon output stream", but it cannot express ongoing interaction such as stdin, TTY, terminal resize, signal/cancel, multi-turn agent input, or structured runtime events. As a result, `exec`, `run --command`, scheduler commands, cells, and agent prompts currently rely on file protocols such as `command-request.json`, prompt files, script files, stdout markers, and result files to carry control semantics.
 
-This design upgrades the lower execution boundary to an interactive runtime stream without breaking existing command behavior or artifact layout. The first phase implements the full Docker driver path. Microsandbox and BoxLite are left for later integration through a clear capability contract.
+This design upgrades the lower execution boundary to an interactive runtime stream without breaking existing command behavior or artifact layout. Docker provides the original native attach implementation. Microsandbox command attach is supported through its streaming exec API; BoxLite remains behind the explicit capability contract until its runtime API exposes the required input controls.
 
 ## Goals
 
@@ -26,7 +26,7 @@ This design upgrades the lower execution boundary to an interactive runtime stre
 
 ## Non-Goals
 
-1. Do not implement Microsandbox or BoxLite stdin/TTY/resize in the first phase.
+1. Do not implement BoxLite stdin/TTY/resize until its runtime API exposes the required controls. Microsandbox command attach was added later through its native streaming exec API.
 2. Do not merge workspace files, artifact bodies, or the LLM facade HTTP/SSE protocol into the runtime stream.
 3. Do not implement `run --prompt -it` by making users call `agent-compose exec <sandbox> -it codex` or `run --command "codex" -it`.
 4. Do not remove compatibility artifacts such as `command-request.json`, `command-result.json`, `stdout.txt`, `stderr.txt`, `output.txt`, or `transcript.txt`.
@@ -79,12 +79,12 @@ To reduce risk in the first phase, only `-it` paths need to use the `AttachExec`
 
 ## Driver Capability Matrix
 
-The first phase only requires full interactive support for Docker. Other drivers must report an explicit unsupported capability. They must not silently fall back to the regular `StreamExec` RPC.
+The first phase required full interactive support for Docker. Drivers without the required controls must report an explicit unsupported capability and must not silently fall back to the regular `StreamExec` RPC. Microsandbox now satisfies the command-interaction contract through native streaming exec.
 
-| driver | stdin | stdout/stderr | TTY | resize | first-phase strategy |
+| driver | stdin | stdout/stderr | TTY | resize | current strategy |
 |---|---:|---:|---:|---:|---|
 | Docker | supported | existing basis | supported | supported | full implementation |
-| Microsandbox | TBD | existing output event basis | TBD | TBD | return unsupported |
+| Microsandbox | supported | streaming exec events | supported | supported | native streaming exec |
 | BoxLite | current Go/FFI layer does not expose stdin | existing stdout/stderr callback | FFI has a `tty` field but it is not wired | not exposed | return unsupported |
 
 Suggested driver extension interface:
@@ -551,4 +551,6 @@ Rules:
 4. Add command mode for `AttachAgentRun` and wire `run --command -it`.
 5. Implement prompt interactive turn loop for the Codex provider and wire `run --prompt -it`.
 6. Upgrade `logs --follow` from file polling to "file snapshot plus RunLogHub real-time fanout".
-7. Return explicit unsupported errors for Microsandbox/BoxLite and non-Codex providers.
+7. Return explicit unsupported errors for BoxLite and non-Codex providers.
+
+The follow-on Microsandbox implementation uses native streaming exec for command attach while preserving the same `RuntimeInteraction` and external RPC contracts.

--- a/pkg/driver/interaction_test.go
+++ b/pkg/driver/interaction_test.go
@@ -75,22 +75,18 @@ func TestRuntimeInteractionCapabilitiesValidateStartSpecUnsupported(t *testing.T
 	}
 }
 
-func TestBoxliteAndMicrosandboxNativeExecAttachUnsupported(t *testing.T) {
+func TestBoxliteNativeExecAttachUnsupported(t *testing.T) {
 	spec := RuntimeStartSpec{Kind: RuntimeOperationCommand, AttachStdin: true, TTY: true}
-	for _, driver := range []string{RuntimeDriverBoxlite, RuntimeDriverMicrosandbox} {
-		t.Run(driver, func(t *testing.T) {
-			_, err := UnsupportedRuntimeInteraction(driver, RuntimeInteractionCapabilities{}, spec)
-			if !errors.Is(err, ErrRuntimeInteractionUnsupported) {
-				t.Fatalf("OpenInteraction() error = %v, want ErrRuntimeInteractionUnsupported", err)
-			}
-			var unsupported *RuntimeInteractionUnsupportedError
-			if !errors.As(err, &unsupported) {
-				t.Fatalf("OpenInteraction() error = %T, want RuntimeInteractionUnsupportedError", err)
-			}
-			if unsupported.Driver != driver || unsupported.Operation != RuntimeOperationCommand || unsupported.Capability != RuntimeCapabilityNativeExec {
-				t.Fatalf("unsupported = %#v, want driver=%q operation=%q capability=%q", unsupported, driver, RuntimeOperationCommand, RuntimeCapabilityNativeExec)
-			}
-		})
+	_, err := UnsupportedRuntimeInteraction(RuntimeDriverBoxlite, RuntimeInteractionCapabilities{}, spec)
+	if !errors.Is(err, ErrRuntimeInteractionUnsupported) {
+		t.Fatalf("OpenInteraction() error = %v, want ErrRuntimeInteractionUnsupported", err)
+	}
+	var unsupported *RuntimeInteractionUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("OpenInteraction() error = %T, want RuntimeInteractionUnsupportedError", err)
+	}
+	if unsupported.Driver != RuntimeDriverBoxlite || unsupported.Operation != RuntimeOperationCommand || unsupported.Capability != RuntimeCapabilityNativeExec {
+		t.Fatalf("unsupported = %#v, want driver=%q operation=%q capability=%q", unsupported, RuntimeDriverBoxlite, RuntimeOperationCommand, RuntimeCapabilityNativeExec)
 	}
 }
 

--- a/pkg/driver/microsandbox_interaction.go
+++ b/pkg/driver/microsandbox_interaction.go
@@ -1,11 +1,372 @@
+//go:build linux && cgo && microsandboxcgo
+
 package driver
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
+)
+
+type microsandboxInteractionExec interface {
+	Recv(context.Context) (*microsandbox.ExecEvent, error)
+	Kill(context.Context) error
+	Wait(context.Context) (int, error)
+	Signal(context.Context, int) error
+	Resize(context.Context, uint16, uint16) error
+	Close() error
+}
+
+type microsandboxInteractionStdin interface {
+	WriteCtx(context.Context, []byte) (int, error)
+	Close() error
+}
+
+type microsandboxCommandInteraction struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	handle        microsandboxInteractionExec
+	stdin         microsandboxInteractionStdin
+	release       func()
+	operationID   string
+	tty           bool
+	attachStdin   bool
+	startedAt     time.Time
+	stdoutDecoder utf8StreamDecoder
+	stderrDecoder utf8StreamDecoder
+
+	output chan RuntimeOutputFrame
+	done   chan struct{}
+
+	inputMu       sync.Mutex
+	closeSendOnce sync.Once
+	closeSendErr  error
+	cleanupOnce   sync.Once
+	result        RuntimeResult
+	err           error
+}
 
 func (r *microsandboxRuntime) InteractionCapabilities() RuntimeInteractionCapabilities {
-	return RuntimeInteractionCapabilities{}
+	return RuntimeInteractionCapabilities{
+		NativeExec: true,
+		Stdin:      true,
+		StdinEOF:   true,
+		TTY:        true,
+		Resize:     true,
+		Signal:     true,
+	}
 }
 
 func (r *microsandboxRuntime) OpenInteraction(ctx context.Context, session *Sandbox, vmState VMState, spec RuntimeStartSpec) (RuntimeInteraction, error) {
-	return UnsupportedRuntimeInteraction(RuntimeDriverMicrosandbox, r.InteractionCapabilities(), spec)
+	rows, cols, err := r.validateMicrosandboxInteractionSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	if spec.TimeoutMs > 0 {
+		childCtx, cancel = context.WithTimeout(ctx, time.Duration(spec.TimeoutMs)*time.Millisecond)
+	}
+	if err := r.ensureReady(childCtx); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	name := r.sandboxName(session, vmState)
+	sandbox, err := r.connectSandbox(childCtx, session, vmState, true)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	release := func() { r.releaseSandboxHandle(name, sandbox) }
+	if err := r.ensureDirectoryOnlyGuestSandboxBootstrap(childCtx, sandbox, session, name); err != nil {
+		cancel()
+		release()
+		return nil, err
+	}
+
+	execSpec := ExecSpecFromRuntimeStartSpec(spec)
+	options := r.execOptions(childCtx, execSpec)
+	if spec.AttachStdin {
+		options = append(options, microsandbox.WithExecStdinPipe())
+	}
+	if spec.TTY {
+		options = append(options, microsandbox.WithExecTTY(true))
+	}
+	handle, err := sandbox.ExecStream(childCtx, execSpec.Command, execSpec.Args, options...)
+	if err != nil {
+		cancel()
+		release()
+		return nil, err
+	}
+	var stdin microsandboxInteractionStdin
+	if spec.AttachStdin {
+		stdin = handle.TakeStdin()
+		if stdin == nil {
+			cleanupErr := cleanupMicrosandboxInteractionStart(childCtx, handle, nil, release)
+			cancel()
+			return nil, errors.Join(fmt.Errorf("microsandbox interaction stdin pipe is unavailable"), cleanupErr)
+		}
+	}
+	if rows != 0 || cols != 0 {
+		if err := handle.Resize(childCtx, rows, cols); err != nil {
+			cleanupErr := cleanupMicrosandboxInteractionStart(childCtx, handle, stdin, release)
+			cancel()
+			return nil, errors.Join(fmt.Errorf("resize microsandbox interaction terminal: %w", err), cleanupErr)
+		}
+	}
+
+	interaction := &microsandboxCommandInteraction{
+		ctx:         childCtx,
+		cancel:      cancel,
+		handle:      handle,
+		stdin:       stdin,
+		release:     release,
+		operationID: spec.OperationID,
+		tty:         spec.TTY,
+		attachStdin: spec.AttachStdin,
+		startedAt:   time.Now(),
+		output:      make(chan RuntimeOutputFrame, 64),
+		done:        make(chan struct{}),
+	}
+	go interaction.run()
+	return interaction, nil
+}
+
+func (r *microsandboxRuntime) validateMicrosandboxInteractionSpec(spec RuntimeStartSpec) (uint16, uint16, error) {
+	if err := r.InteractionCapabilities().ValidateStartSpec(RuntimeDriverMicrosandbox, spec); err != nil {
+		return 0, 0, err
+	}
+	if normalizeRuntimeOperationKind(spec.Kind) != RuntimeOperationCommand {
+		return 0, 0, NewRuntimeInteractionUnsupportedError(RuntimeDriverMicrosandbox, spec, RuntimeCapabilityNativeExec, "microsandbox native attach only supports command interactions")
+	}
+	command := RuntimeCommandSpec{}
+	if spec.Command != nil {
+		command = *spec.Command
+	}
+	if strings.TrimSpace(command.Command) == "" {
+		return 0, 0, fmt.Errorf("microsandbox interaction command is required")
+	}
+	return microsandboxTerminalSize(spec.Rows, spec.Cols)
+}
+
+func microsandboxTerminalSize(rows, cols uint32) (uint16, uint16, error) {
+	if rows > math.MaxUint16 || cols > math.MaxUint16 {
+		return 0, 0, fmt.Errorf("microsandbox terminal size exceeds %d rows or columns", uint32(math.MaxUint16))
+	}
+	return uint16(rows), uint16(cols), nil
+}
+
+func cleanupMicrosandboxInteractionStart(ctx context.Context, handle microsandboxInteractionExec, stdin microsandboxInteractionStdin, release func()) error {
+	var stdinErr error
+	if stdin != nil {
+		stdinErr = stdin.Close()
+	}
+	terminationErr := terminateMicrosandboxExec(ctx, handle)
+	closeErr := handle.Close()
+	if release != nil {
+		release()
+	}
+	return errors.Join(stdinErr, terminationErr, closeErr)
+}
+
+func (i *microsandboxCommandInteraction) Send(frame RuntimeInputFrame) error {
+	switch frame.Type {
+	case RuntimeInputStdin:
+		if !i.attachStdin || i.stdin == nil {
+			return ErrRuntimeInteractionUnsupported
+		}
+		if len(frame.Data) == 0 {
+			return nil
+		}
+		i.inputMu.Lock()
+		defer i.inputMu.Unlock()
+		if i.ctx.Err() != nil {
+			return i.ctx.Err()
+		}
+		_, err := i.stdin.WriteCtx(i.ctx, frame.Data)
+		return err
+	case RuntimeInputStdinEOF:
+		return i.CloseSend()
+	case RuntimeInputResize:
+		rows, cols, err := microsandboxTerminalSize(frame.Rows, frame.Cols)
+		if err != nil {
+			return err
+		}
+		if rows == 0 && cols == 0 {
+			return nil
+		}
+		return i.handle.Resize(i.ctx, rows, cols)
+	case RuntimeInputSignal:
+		signal, err := microsandboxRuntimeSignal(frame.Signal)
+		if err != nil {
+			return err
+		}
+		return i.handle.Signal(i.ctx, signal)
+	case RuntimeInputCancel:
+		i.cancel()
+		return nil
+	default:
+		return ErrRuntimeInteractionUnsupported
+	}
+}
+
+func (i *microsandboxCommandInteraction) CloseSend() error {
+	i.closeSendOnce.Do(func() {
+		i.inputMu.Lock()
+		defer i.inputMu.Unlock()
+		if i.stdin != nil {
+			i.closeSendErr = i.stdin.Close()
+		}
+	})
+	return i.closeSendErr
+}
+
+func (i *microsandboxCommandInteraction) Recv() (RuntimeOutputFrame, error) {
+	frame, ok := <-i.output
+	if !ok {
+		return RuntimeOutputFrame{}, io.EOF
+	}
+	return frame, nil
+}
+
+func (i *microsandboxCommandInteraction) Wait() (RuntimeResult, error) {
+	<-i.done
+	return i.result, i.err
+}
+
+func (i *microsandboxCommandInteraction) run() {
+	defer close(i.done)
+	defer close(i.output)
+	defer i.cleanup()
+
+	exitCode := -1
+	sawExit := false
+	var runErr error
+	for runErr == nil {
+		event, err := i.handle.Recv(i.ctx)
+		if err != nil {
+			if i.ctx.Err() != nil {
+				runErr = i.ctx.Err()
+			} else {
+				runErr = err
+			}
+			break
+		}
+		if event == nil || event.Kind == microsandbox.ExecEventDone {
+			if !sawExit {
+				runErr = fmt.Errorf("microsandbox interaction stream ended without reporting a process exit status")
+			}
+			break
+		}
+		switch event.Kind {
+		case microsandbox.ExecEventStarted:
+			i.emit(RuntimeOutputFrame{Type: RuntimeOutputStarted, StartedAt: i.startedAt})
+		case microsandbox.ExecEventStdout:
+			i.emitBytes(event.Data, StdioStdout)
+		case microsandbox.ExecEventStderr:
+			i.emitBytes(event.Data, StdioStderr)
+		case microsandbox.ExecEventExited:
+			exitCode = event.ExitCode
+			sawExit = true
+		case microsandbox.ExecEventFailed:
+			runErr = formatMicrosandboxExecFailure(event.Failure)
+		case microsandbox.ExecEventStdinError:
+			i.emitBytes([]byte(formatMicrosandboxExecFailure(event.Failure).Error()+"\n"), StdioStderr)
+		}
+	}
+	i.flushOutput()
+
+	if runErr != nil && (i.ctx.Err() != nil || !sawExit) {
+		terminationErr := terminateMicrosandboxExec(i.ctx, i.handle)
+		runErr = execTerminationResultError(RuntimeDriverMicrosandbox, i.operationID, runErr, terminationErr)
+	}
+	completedAt := time.Now()
+	i.result = RuntimeResult{
+		OperationID: i.operationID,
+		ExitCode:    exitCode,
+		Success:     runErr == nil && exitCode == 0,
+		StartedAt:   i.startedAt,
+		CompletedAt: completedAt,
+	}
+	if runErr != nil {
+		i.err = runErr
+		i.result.Error = runErr.Error()
+		i.emit(RuntimeOutputFrame{Type: RuntimeOutputError, Error: &RuntimeError{Message: runErr.Error()}})
+	}
+	i.emit(RuntimeOutputFrame{Type: RuntimeOutputResult, Result: &i.result})
+}
+
+func (i *microsandboxCommandInteraction) emitBytes(data []byte, stream StdioStream) {
+	decoder := &i.stdoutDecoder
+	if NormalizeStdioStream(stream) == StdioStderr && !i.tty {
+		decoder = &i.stderrDecoder
+	} else {
+		stream = StdioStdout
+	}
+	i.emitText(decoder.Write(data), stream)
+}
+
+func (i *microsandboxCommandInteraction) flushOutput() {
+	i.emitText(i.stdoutDecoder.Finish(), StdioStdout)
+	stream := StdioStderr
+	if i.tty {
+		stream = StdioStdout
+	}
+	i.emitText(i.stderrDecoder.Finish(), stream)
+}
+
+func (i *microsandboxCommandInteraction) emitText(text string, stream StdioStream) {
+	if text == "" {
+		return
+	}
+	frameType := RuntimeOutputStdout
+	if NormalizeStdioStream(stream) == StdioStderr {
+		frameType = RuntimeOutputStderr
+	}
+	i.emit(RuntimeOutputFrame{Type: frameType, Data: []byte(text)})
+}
+
+func (i *microsandboxCommandInteraction) emit(frame RuntimeOutputFrame) {
+	select {
+	case i.output <- frame:
+	case <-i.ctx.Done():
+	}
+}
+
+func (i *microsandboxCommandInteraction) cleanup() {
+	i.cleanupOnce.Do(func() {
+		if err := i.CloseSend(); err != nil {
+			slog.Warn("failed to close microsandbox interaction stdin", "operation_id", i.operationID, "error", err)
+		}
+		if err := i.handle.Close(); err != nil {
+			slog.Warn("failed to close microsandbox interaction exec handle", "operation_id", i.operationID, "error", err)
+		}
+		if i.release != nil {
+			i.release()
+		}
+		i.cancel()
+	})
+}
+
+func microsandboxRuntimeSignal(signal RuntimeSignal) (int, error) {
+	switch signal {
+	case RuntimeSignalInterrupt:
+		return int(syscall.SIGINT), nil
+	case RuntimeSignalTerminate:
+		return int(syscall.SIGTERM), nil
+	case RuntimeSignalKill:
+		return int(syscall.SIGKILL), nil
+	default:
+		return 0, fmt.Errorf("unsupported microsandbox runtime signal %q", signal)
+	}
 }

--- a/pkg/driver/microsandbox_interaction.go
+++ b/pkg/driver/microsandbox_interaction.go
@@ -32,17 +32,20 @@ type microsandboxInteractionStdin interface {
 }
 
 type microsandboxCommandInteraction struct {
-	ctx           context.Context
-	cancel        context.CancelFunc
-	handle        microsandboxInteractionExec
-	stdin         microsandboxInteractionStdin
-	release       func()
-	operationID   string
-	tty           bool
-	attachStdin   bool
-	startedAt     time.Time
-	stdoutDecoder utf8StreamDecoder
-	stderrDecoder utf8StreamDecoder
+	ctx            context.Context
+	cancel         context.CancelFunc
+	handle         microsandboxInteractionExec
+	stdin          microsandboxInteractionStdin
+	release        func()
+	operationID    string
+	tty            bool
+	attachStdin    bool
+	startedAt      time.Time
+	exitDrainTime  time.Duration
+	probeAlive     microsandboxExecLivenessProbe
+	firstProbeTime time.Duration
+	stdoutDecoder  utf8StreamDecoder
+	stderrDecoder  utf8StreamDecoder
 
 	output chan RuntimeOutputFrame
 	done   chan struct{}
@@ -126,17 +129,20 @@ func (r *microsandboxRuntime) OpenInteraction(ctx context.Context, session *Sand
 	}
 
 	interaction := &microsandboxCommandInteraction{
-		ctx:         childCtx,
-		cancel:      cancel,
-		handle:      handle,
-		stdin:       stdin,
-		release:     release,
-		operationID: spec.OperationID,
-		tty:         spec.TTY,
-		attachStdin: spec.AttachStdin,
-		startedAt:   time.Now(),
-		output:      make(chan RuntimeOutputFrame, 64),
-		done:        make(chan struct{}),
+		ctx:            childCtx,
+		cancel:         cancel,
+		handle:         handle,
+		stdin:          stdin,
+		release:        release,
+		operationID:    spec.OperationID,
+		tty:            spec.TTY,
+		attachStdin:    spec.AttachStdin,
+		startedAt:      time.Now(),
+		exitDrainTime:  microsandboxExecExitIdleGracePeriod,
+		probeAlive:     microsandboxExecLivenessProbeFor(sandbox),
+		firstProbeTime: microsandboxExecExitIdleGracePeriod,
+		output:         make(chan RuntimeOutputFrame, 64),
+		done:           make(chan struct{}),
 	}
 	go interaction.run()
 	return interaction, nil
@@ -249,59 +255,144 @@ func (i *microsandboxCommandInteraction) run() {
 	defer close(i.output)
 	defer i.cleanup()
 
-	exitCode := -1
-	sawExit := false
-	var runErr error
-	for runErr == nil {
-		event, err := i.handle.Recv(i.ctx)
-		if err != nil {
-			if i.ctx.Err() != nil {
-				runErr = i.ctx.Err()
-			} else {
-				runErr = err
-			}
-			break
-		}
-		if event == nil || event.Kind == microsandbox.ExecEventDone {
-			if !sawExit {
-				runErr = fmt.Errorf("microsandbox interaction stream ended without reporting a process exit status")
-			}
-			break
-		}
-		switch event.Kind {
-		case microsandbox.ExecEventStarted:
-			i.emit(RuntimeOutputFrame{Type: RuntimeOutputStarted, StartedAt: i.startedAt})
-		case microsandbox.ExecEventStdout:
-			i.emitBytes(event.Data, StdioStdout)
-		case microsandbox.ExecEventStderr:
-			i.emitBytes(event.Data, StdioStderr)
-		case microsandbox.ExecEventExited:
-			exitCode = event.ExitCode
-			sawExit = true
-		case microsandbox.ExecEventFailed:
-			runErr = formatMicrosandboxExecFailure(event.Failure)
-		case microsandbox.ExecEventStdinError:
-			i.emitBytes([]byte(formatMicrosandboxExecFailure(event.Failure).Error()+"\n"), StdioStderr)
-		}
-	}
+	state := i.consumeOutput()
 	i.flushOutput()
-
-	if runErr != nil && (i.ctx.Err() != nil || !sawExit) {
+	if state.err != nil && !state.processGone && (i.ctx.Err() != nil || !state.sawExit) {
 		terminationErr := terminateMicrosandboxExec(i.ctx, i.handle)
-		runErr = execTerminationResultError(RuntimeDriverMicrosandbox, i.operationID, runErr, terminationErr)
+		state.err = execTerminationResultError(RuntimeDriverMicrosandbox, i.operationID, state.err, terminationErr)
 	}
-	completedAt := time.Now()
+	i.finish(state)
+}
+
+type microsandboxInteractionRunState struct {
+	exitCode    int
+	pid         uint32
+	sawExit     bool
+	processGone bool
+	err         error
+}
+
+func (i *microsandboxCommandInteraction) consumeOutput() microsandboxInteractionRunState {
+	state := microsandboxInteractionRunState{exitCode: -1}
+	receiveCtx, cancelReceive := context.WithCancel(i.ctx)
+	received := receiveMicrosandboxExecEvents(receiveCtx, i.handle.Recv)
+	defer func() {
+		cancelReceive()
+		for range received {
+		}
+	}()
+	drain := newMicrosandboxInteractionExitDrain(i.exitDrainTime)
+	defer drain.stop()
+	probe := newMicrosandboxInteractionExitDrain(i.firstProbeTime)
+	defer probe.stop()
+
+	for state.err == nil {
+		select {
+		case <-i.ctx.Done():
+			state.err = i.ctx.Err()
+			return state
+		case <-drain.wait:
+			slog.Warn(
+				"microsandbox interaction stream timed out waiting for done after process exit; closing handle",
+				"operation_id", i.operationID,
+				"exit_code", state.exitCode,
+				"drain_window", drain.duration,
+			)
+			return state
+		case <-probe.wait:
+			gone, probeErr := microsandboxExecProcessGone(i.ctx, i.probeAlive, state.pid)
+			if probeErr != nil {
+				slog.Warn("failed to probe microsandbox interaction process liveness; continuing to wait", "operation_id", i.operationID, "pid", state.pid, "error", probeErr)
+				probe.duration = microsandboxExecSilenceProbeInterval
+				probe.reset()
+				continue
+			}
+			if !gone {
+				probe.duration = microsandboxExecSilenceProbeInterval
+				probe.reset()
+				continue
+			}
+			slog.Warn("microsandbox interaction process is gone but the stream never reported its exit; closing handle", "operation_id", i.operationID, "pid", state.pid)
+			state.processGone = true
+			state.err = fmt.Errorf("microsandbox interaction process %d exited without reporting its status; a process it started is still holding the output pipes open", state.pid)
+			return state
+		case result, ok := <-received:
+			if !ok {
+				if !state.sawExit {
+					state.err = fmt.Errorf("microsandbox interaction stream ended without reporting a process exit status")
+				}
+				return state
+			}
+			if result.err != nil {
+				if i.ctx.Err() != nil {
+					state.err = i.ctx.Err()
+				} else {
+					state.err = result.err
+				}
+				return state
+			}
+			if i.projectOutputEvent(result.event, &state, drain, probe) {
+				return state
+			}
+		}
+	}
+	return state
+}
+
+func (i *microsandboxCommandInteraction) projectOutputEvent(event *microsandbox.ExecEvent, state *microsandboxInteractionRunState, drain, probe *microsandboxInteractionExitDrain) bool {
+	if event == nil || event.Kind == microsandbox.ExecEventDone {
+		if !state.sawExit {
+			state.err = fmt.Errorf("microsandbox interaction stream ended without reporting a process exit status")
+		}
+		return true
+	}
+	switch event.Kind {
+	case microsandbox.ExecEventStarted:
+		state.pid = event.PID
+		i.emit(RuntimeOutputFrame{Type: RuntimeOutputStarted, StartedAt: i.startedAt})
+		if i.probeAlive != nil && state.pid != 0 {
+			probe.reset()
+		}
+	case microsandbox.ExecEventStdout:
+		i.emitBytes(event.Data, StdioStdout)
+		if state.sawExit {
+			drain.reset()
+		} else if i.probeAlive != nil && state.pid != 0 {
+			probe.reset()
+		}
+	case microsandbox.ExecEventStderr:
+		i.emitBytes(event.Data, StdioStderr)
+		if state.sawExit {
+			drain.reset()
+		} else if i.probeAlive != nil && state.pid != 0 {
+			probe.reset()
+		}
+	case microsandbox.ExecEventExited:
+		state.exitCode = event.ExitCode
+		state.sawExit = true
+		probe.stop()
+		drain.reset()
+	case microsandbox.ExecEventFailed:
+		state.err = formatMicrosandboxExecFailure(event.Failure)
+		return true
+	case microsandbox.ExecEventStdinError:
+		i.emitBytes([]byte(formatMicrosandboxExecFailure(event.Failure).Error()+"\n"), StdioStderr)
+	}
+	return false
+}
+
+func (i *microsandboxCommandInteraction) finish(state microsandboxInteractionRunState) {
 	i.result = RuntimeResult{
 		OperationID: i.operationID,
-		ExitCode:    exitCode,
-		Success:     runErr == nil && exitCode == 0,
+		ExitCode:    state.exitCode,
+		Success:     state.err == nil && state.exitCode == 0,
 		StartedAt:   i.startedAt,
-		CompletedAt: completedAt,
+		CompletedAt: time.Now(),
 	}
-	if runErr != nil {
-		i.err = runErr
-		i.result.Error = runErr.Error()
-		i.emit(RuntimeOutputFrame{Type: RuntimeOutputError, Error: &RuntimeError{Message: runErr.Error()}})
+	if state.err != nil {
+		i.err = state.err
+		i.result.Error = state.err.Error()
+		i.emit(RuntimeOutputFrame{Type: RuntimeOutputError, Error: &RuntimeError{Message: state.err.Error()}})
 	}
 	i.emit(RuntimeOutputFrame{Type: RuntimeOutputResult, Result: &i.result})
 }

--- a/pkg/driver/microsandbox_interaction_stub.go
+++ b/pkg/driver/microsandbox_interaction_stub.go
@@ -1,0 +1,13 @@
+//go:build !linux || !cgo || !microsandboxcgo
+
+package driver
+
+import "context"
+
+func (r *microsandboxRuntime) InteractionCapabilities() RuntimeInteractionCapabilities {
+	return RuntimeInteractionCapabilities{}
+}
+
+func (r *microsandboxRuntime) OpenInteraction(ctx context.Context, session *Sandbox, vmState VMState, spec RuntimeStartSpec) (RuntimeInteraction, error) {
+	return UnsupportedRuntimeInteraction(RuntimeDriverMicrosandbox, r.InteractionCapabilities(), spec)
+}

--- a/pkg/driver/microsandbox_interaction_stub_test.go
+++ b/pkg/driver/microsandbox_interaction_stub_test.go
@@ -1,0 +1,21 @@
+//go:build !linux || !cgo || !microsandboxcgo
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestMicrosandboxInteractionUnsupportedWithoutCompiledDriver(t *testing.T) {
+	runtime := &microsandboxRuntime{}
+	_, err := runtime.OpenInteraction(context.Background(), nil, VMState{}, RuntimeStartSpec{
+		Kind:        RuntimeOperationCommand,
+		AttachStdin: true,
+		TTY:         true,
+	})
+	if !errors.Is(err, ErrRuntimeInteractionUnsupported) {
+		t.Fatalf("OpenInteraction() error = %v, want ErrRuntimeInteractionUnsupported", err)
+	}
+}

--- a/pkg/driver/microsandbox_interaction_test.go
+++ b/pkg/driver/microsandbox_interaction_test.go
@@ -1,0 +1,298 @@
+//go:build linux && cgo && microsandboxcgo
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
+)
+
+func TestMicrosandboxInteractionCapabilities(t *testing.T) {
+	caps := (&microsandboxRuntime{}).InteractionCapabilities()
+	if !caps.NativeExec || !caps.Stdin || !caps.StdinEOF || !caps.TTY || !caps.Resize || !caps.Signal {
+		t.Fatalf("InteractionCapabilities() = %#v, want native command terminal capabilities", caps)
+	}
+	if caps.WrapperStream || caps.Artifacts || caps.AgentTurns {
+		t.Fatalf("InteractionCapabilities() = %#v, want unsupported wrapper and agent capabilities disabled", caps)
+	}
+}
+
+func TestMicrosandboxCommandInteractionProjectsEvents(t *testing.T) {
+	runeBytes := []byte("中")
+	handle := &fakeMicrosandboxInteractionExec{events: []*microsandbox.ExecEvent{
+		{Kind: microsandbox.ExecEventStarted},
+		{Kind: microsandbox.ExecEventStdout, Data: runeBytes[:1]},
+		{Kind: microsandbox.ExecEventStdout, Data: runeBytes[1:]},
+		{Kind: microsandbox.ExecEventStderr, Data: []byte("warn\n")},
+		{Kind: microsandbox.ExecEventExited, ExitCode: 3},
+		{Kind: microsandbox.ExecEventDone},
+	}}
+	stdin := &fakeMicrosandboxInteractionStdin{}
+	released := 0
+	interaction := newTestMicrosandboxInteraction(handle, stdin, false, func() { released++ })
+
+	frames := receiveAllMicrosandboxInteractionFrames(t, interaction)
+	result, err := interaction.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.ExitCode != 3 || result.Success {
+		t.Fatalf("Wait() result = %#v, want exit 3 failure", result)
+	}
+	want := []RuntimeOutputFrameType{RuntimeOutputStarted, RuntimeOutputStdout, RuntimeOutputStderr, RuntimeOutputResult}
+	if got := microsandboxInteractionFrameTypes(frames); !reflect.DeepEqual(got, want) {
+		t.Fatalf("frame types = %#v, want %#v", got, want)
+	}
+	if string(frames[1].Data) != "中" || string(frames[2].Data) != "warn\n" {
+		t.Fatalf("output frames = %#v", frames)
+	}
+	if stdin.closeCalls != 1 || handle.closeCalls != 1 || released != 1 {
+		t.Fatalf("cleanup calls = stdin:%d handle:%d release:%d, want 1 each", stdin.closeCalls, handle.closeCalls, released)
+	}
+}
+
+func TestMicrosandboxCommandInteractionMergesTTYOutput(t *testing.T) {
+	handle := &fakeMicrosandboxInteractionExec{events: []*microsandbox.ExecEvent{
+		{Kind: microsandbox.ExecEventStarted},
+		{Kind: microsandbox.ExecEventStderr, Data: []byte("terminal")},
+		{Kind: microsandbox.ExecEventExited, ExitCode: 0},
+		{Kind: microsandbox.ExecEventDone},
+	}}
+	interaction := newTestMicrosandboxInteraction(handle, nil, true, nil)
+	frames := receiveAllMicrosandboxInteractionFrames(t, interaction)
+	if len(frames) != 3 || frames[1].Type != RuntimeOutputStdout || string(frames[1].Data) != "terminal" {
+		t.Fatalf("TTY frames = %#v, want merged stdout", frames)
+	}
+}
+
+func TestMicrosandboxCommandInteractionHandlesInput(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := &fakeMicrosandboxInteractionExec{}
+	stdin := &fakeMicrosandboxInteractionStdin{}
+	interaction := &microsandboxCommandInteraction{
+		ctx:         ctx,
+		cancel:      cancel,
+		handle:      handle,
+		stdin:       stdin,
+		attachStdin: true,
+	}
+
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputStdin, Data: []byte("pwd\n")}); err != nil {
+		t.Fatalf("Send(stdin) error = %v", err)
+	}
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputResize, Rows: 40, Cols: 120}); err != nil {
+		t.Fatalf("Send(resize) error = %v", err)
+	}
+	for _, signal := range []RuntimeSignal{RuntimeSignalInterrupt, RuntimeSignalTerminate, RuntimeSignalKill} {
+		if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputSignal, Signal: signal}); err != nil {
+			t.Fatalf("Send(%s) error = %v", signal, err)
+		}
+	}
+	if err := interaction.CloseSend(); err != nil {
+		t.Fatalf("CloseSend() error = %v", err)
+	}
+	if err := interaction.CloseSend(); err != nil {
+		t.Fatalf("second CloseSend() error = %v", err)
+	}
+
+	if string(stdin.writes) != "pwd\n" || stdin.closeCalls != 1 {
+		t.Fatalf("stdin = writes:%q closes:%d", stdin.writes, stdin.closeCalls)
+	}
+	if handle.resizeRows != 40 || handle.resizeCols != 120 {
+		t.Fatalf("resize = %dx%d, want 40x120", handle.resizeRows, handle.resizeCols)
+	}
+	wantSignals := []int{int(syscall.SIGINT), int(syscall.SIGTERM), int(syscall.SIGKILL)}
+	if !reflect.DeepEqual(handle.signals, wantSignals) {
+		t.Fatalf("signals = %#v, want %#v", handle.signals, wantSignals)
+	}
+}
+
+func TestMicrosandboxCommandInteractionCancellationTerminatesProcess(t *testing.T) {
+	handle := &fakeMicrosandboxInteractionExec{blockRecv: true}
+	stdin := &fakeMicrosandboxInteractionStdin{}
+	released := 0
+	interaction := newTestMicrosandboxInteraction(handle, stdin, false, func() { released++ })
+
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputCancel}); err != nil {
+		t.Fatalf("Send(cancel) error = %v", err)
+	}
+	result, err := interaction.Wait()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait() error = %v, want context.Canceled", err)
+	}
+	if result.ExitCode != -1 || result.Error == "" {
+		t.Fatalf("Wait() result = %#v, want canceled result", result)
+	}
+	if handle.killCalls != 1 || handle.waitCalls != 1 || handle.closeCalls != 1 || stdin.closeCalls != 1 || released != 1 {
+		t.Fatalf("cleanup calls = kill:%d wait:%d handle:%d stdin:%d release:%d", handle.killCalls, handle.waitCalls, handle.closeCalls, stdin.closeCalls, released)
+	}
+}
+
+func TestMicrosandboxCommandInteractionRejectsInvalidControl(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	interaction := &microsandboxCommandInteraction{ctx: ctx, cancel: cancel, handle: &fakeMicrosandboxInteractionExec{}}
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputSignal, Signal: "unknown"}); err == nil {
+		t.Fatal("Send(unknown signal) returned nil error")
+	}
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputResize, Rows: 1 << 16, Cols: 80}); err == nil {
+		t.Fatal("Send(oversized resize) returned nil error")
+	}
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputStdin, Data: []byte("x")}); !errors.Is(err, ErrRuntimeInteractionUnsupported) {
+		t.Fatalf("Send(unattached stdin) error = %v, want unsupported", err)
+	}
+}
+
+func TestMicrosandboxCommandInteractionPreservesCloseSendError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wantErr := errors.New("close stdin")
+	stdin := &fakeMicrosandboxInteractionStdin{closeErr: wantErr}
+	interaction := &microsandboxCommandInteraction{
+		ctx:         ctx,
+		cancel:      cancel,
+		handle:      &fakeMicrosandboxInteractionExec{},
+		stdin:       stdin,
+		attachStdin: true,
+	}
+	for call := 1; call <= 2; call++ {
+		if err := interaction.CloseSend(); !errors.Is(err, wantErr) {
+			t.Fatalf("CloseSend() call %d error = %v, want %v", call, err, wantErr)
+		}
+	}
+	if stdin.closeCalls != 1 {
+		t.Fatalf("stdin close calls = %d, want 1", stdin.closeCalls)
+	}
+}
+
+func newTestMicrosandboxInteraction(handle microsandboxInteractionExec, stdin microsandboxInteractionStdin, tty bool, release func()) *microsandboxCommandInteraction {
+	ctx, cancel := context.WithCancel(context.Background())
+	interaction := &microsandboxCommandInteraction{
+		ctx:         ctx,
+		cancel:      cancel,
+		handle:      handle,
+		stdin:       stdin,
+		release:     release,
+		operationID: "operation-1",
+		tty:         tty,
+		attachStdin: stdin != nil,
+		startedAt:   time.Now(),
+		output:      make(chan RuntimeOutputFrame, 16),
+		done:        make(chan struct{}),
+	}
+	go interaction.run()
+	return interaction
+}
+
+func receiveAllMicrosandboxInteractionFrames(t *testing.T, interaction RuntimeInteraction) []RuntimeOutputFrame {
+	t.Helper()
+	var frames []RuntimeOutputFrame
+	for {
+		frame, err := interaction.Recv()
+		if errors.Is(err, io.EOF) {
+			return frames
+		}
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		frames = append(frames, frame)
+	}
+}
+
+func microsandboxInteractionFrameTypes(frames []RuntimeOutputFrame) []RuntimeOutputFrameType {
+	types := make([]RuntimeOutputFrameType, 0, len(frames))
+	for _, frame := range frames {
+		types = append(types, frame.Type)
+	}
+	return types
+}
+
+type fakeMicrosandboxInteractionExec struct {
+	mu         sync.Mutex
+	events     []*microsandbox.ExecEvent
+	blockRecv  bool
+	resizeRows uint16
+	resizeCols uint16
+	signals    []int
+	killCalls  int
+	waitCalls  int
+	closeCalls int
+}
+
+func (h *fakeMicrosandboxInteractionExec) Recv(ctx context.Context) (*microsandbox.ExecEvent, error) {
+	h.mu.Lock()
+	if len(h.events) > 0 {
+		event := h.events[0]
+		h.events = h.events[1:]
+		h.mu.Unlock()
+		return event, nil
+	}
+	block := h.blockRecv
+	h.mu.Unlock()
+	if block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return &microsandbox.ExecEvent{Kind: microsandbox.ExecEventDone}, nil
+}
+
+func (h *fakeMicrosandboxInteractionExec) Kill(context.Context) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.killCalls++
+	return nil
+}
+
+func (h *fakeMicrosandboxInteractionExec) Wait(context.Context) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.waitCalls++
+	return -1, nil
+}
+
+func (h *fakeMicrosandboxInteractionExec) Signal(_ context.Context, signal int) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.signals = append(h.signals, signal)
+	return nil
+}
+
+func (h *fakeMicrosandboxInteractionExec) Resize(_ context.Context, rows, cols uint16) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.resizeRows = rows
+	h.resizeCols = cols
+	return nil
+}
+
+func (h *fakeMicrosandboxInteractionExec) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.closeCalls++
+	return nil
+}
+
+type fakeMicrosandboxInteractionStdin struct {
+	writes     []byte
+	closeCalls int
+	closeErr   error
+}
+
+func (s *fakeMicrosandboxInteractionStdin) WriteCtx(_ context.Context, data []byte) (int, error) {
+	s.writes = append(s.writes, data...)
+	return len(data), nil
+}
+
+func (s *fakeMicrosandboxInteractionStdin) Close() error {
+	s.closeCalls++
+	return s.closeErr
+}

--- a/pkg/driver/microsandbox_interaction_test.go
+++ b/pkg/driver/microsandbox_interaction_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -70,6 +71,56 @@ func TestMicrosandboxCommandInteractionMergesTTYOutput(t *testing.T) {
 	frames := receiveAllMicrosandboxInteractionFrames(t, interaction)
 	if len(frames) != 3 || frames[1].Type != RuntimeOutputStdout || string(frames[1].Data) != "terminal" {
 		t.Fatalf("TTY frames = %#v, want merged stdout", frames)
+	}
+}
+
+func TestMicrosandboxCommandInteractionBoundsDrainAfterExit(t *testing.T) {
+	handle := &fakeMicrosandboxInteractionExec{
+		events: []*microsandbox.ExecEvent{
+			{Kind: microsandbox.ExecEventStarted},
+			{Kind: microsandbox.ExecEventExited, ExitCode: 0},
+		},
+		blockRecv: true,
+	}
+	interaction := newTestMicrosandboxInteractionWithDrain(handle, nil, false, nil, 10*time.Millisecond)
+
+	frames := receiveAllMicrosandboxInteractionFrames(t, interaction)
+	result, err := interaction.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if !result.Success || result.ExitCode != 0 {
+		t.Fatalf("Wait() result = %#v, want successful exit after bounded drain", result)
+	}
+	if got := microsandboxInteractionFrameTypes(frames); !reflect.DeepEqual(got, []RuntimeOutputFrameType{RuntimeOutputStarted, RuntimeOutputResult}) {
+		t.Fatalf("frame types = %#v", got)
+	}
+	if handle.killCalls != 0 || handle.waitCalls != 0 || handle.closeCalls != 1 {
+		t.Fatalf("handle calls = kill:%d wait:%d close:%d, want graceful close only", handle.killCalls, handle.waitCalls, handle.closeCalls)
+	}
+}
+
+func TestMicrosandboxCommandInteractionBoundsMissingExitHeldByBackgroundOutputPipe(t *testing.T) {
+	handle := &fakeMicrosandboxInteractionExec{
+		events:    []*microsandbox.ExecEvent{{Kind: microsandbox.ExecEventStarted, PID: 42}},
+		blockRecv: true,
+	}
+	probe := func(context.Context, uint32) (bool, error) { return false, nil }
+	interaction := newTestMicrosandboxInteractionWithTiming(handle, nil, false, nil, 0, 10*time.Millisecond, probe)
+
+	frames := receiveAllMicrosandboxInteractionFrames(t, interaction)
+	result, err := interaction.Wait()
+	if err == nil || !strings.Contains(err.Error(), "still holding the output pipes open") {
+		t.Fatalf("Wait() error = %v, want bounded missing-exit failure", err)
+	}
+	if result.Success || result.ExitCode != -1 {
+		t.Fatalf("Wait() result = %#v, want failed unknown exit", result)
+	}
+	if got := microsandboxInteractionFrameTypes(frames); !reflect.DeepEqual(got, []RuntimeOutputFrameType{RuntimeOutputStarted, RuntimeOutputError, RuntimeOutputResult}) {
+		t.Fatalf("frame types = %#v", got)
+	}
+	if handle.killCalls != 0 || handle.waitCalls != 0 || handle.closeCalls != 1 {
+		t.Fatalf("handle calls = kill:%d wait:%d close:%d, want graceful close only", handle.killCalls, handle.waitCalls, handle.closeCalls)
 	}
 }
 
@@ -175,19 +226,30 @@ func TestMicrosandboxCommandInteractionPreservesCloseSendError(t *testing.T) {
 }
 
 func newTestMicrosandboxInteraction(handle microsandboxInteractionExec, stdin microsandboxInteractionStdin, tty bool, release func()) *microsandboxCommandInteraction {
+	return newTestMicrosandboxInteractionWithDrain(handle, stdin, tty, release, 0)
+}
+
+func newTestMicrosandboxInteractionWithDrain(handle microsandboxInteractionExec, stdin microsandboxInteractionStdin, tty bool, release func(), drainTime time.Duration) *microsandboxCommandInteraction {
+	return newTestMicrosandboxInteractionWithTiming(handle, stdin, tty, release, drainTime, 0, nil)
+}
+
+func newTestMicrosandboxInteractionWithTiming(handle microsandboxInteractionExec, stdin microsandboxInteractionStdin, tty bool, release func(), drainTime, probeTime time.Duration, probe microsandboxExecLivenessProbe) *microsandboxCommandInteraction {
 	ctx, cancel := context.WithCancel(context.Background())
 	interaction := &microsandboxCommandInteraction{
-		ctx:         ctx,
-		cancel:      cancel,
-		handle:      handle,
-		stdin:       stdin,
-		release:     release,
-		operationID: "operation-1",
-		tty:         tty,
-		attachStdin: stdin != nil,
-		startedAt:   time.Now(),
-		output:      make(chan RuntimeOutputFrame, 16),
-		done:        make(chan struct{}),
+		ctx:            ctx,
+		cancel:         cancel,
+		handle:         handle,
+		stdin:          stdin,
+		release:        release,
+		operationID:    "operation-1",
+		tty:            tty,
+		attachStdin:    stdin != nil,
+		startedAt:      time.Now(),
+		exitDrainTime:  drainTime,
+		probeAlive:     probe,
+		firstProbeTime: probeTime,
+		output:         make(chan RuntimeOutputFrame, 16),
+		done:           make(chan struct{}),
 	}
 	go interaction.run()
 	return interaction

--- a/pkg/driver/microsandbox_interaction_timer.go
+++ b/pkg/driver/microsandbox_interaction_timer.go
@@ -1,0 +1,41 @@
+//go:build linux && cgo && microsandboxcgo
+
+package driver
+
+import "time"
+
+type microsandboxInteractionExitDrain struct {
+	duration time.Duration
+	timer    *time.Timer
+	wait     <-chan time.Time
+}
+
+func newMicrosandboxInteractionExitDrain(duration time.Duration) *microsandboxInteractionExitDrain {
+	if duration <= 0 {
+		duration = microsandboxExecExitIdleGracePeriod
+	}
+	return &microsandboxInteractionExitDrain{duration: duration}
+}
+
+func (d *microsandboxInteractionExitDrain) reset() {
+	d.stop()
+	if d.timer == nil {
+		d.timer = time.NewTimer(d.duration)
+	} else {
+		d.timer.Reset(d.duration)
+	}
+	d.wait = d.timer.C
+}
+
+func (d *microsandboxInteractionExitDrain) stop() {
+	if d.timer == nil {
+		return
+	}
+	if !d.timer.Stop() {
+		select {
+		case <-d.timer.C:
+		default:
+		}
+	}
+	d.wait = nil
+}

--- a/pkg/runs/completion_test.go
+++ b/pkg/runs/completion_test.go
@@ -47,11 +47,11 @@ func TestCompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t *te
 		Status: domain.ProjectRunStatusRunning, SandboxID: "sandbox-1", CleanupPolicy: domain.ProjectRunCleanupStopOnCompletion,
 	})
 	sandboxes := completionSandboxStoreFake{sandbox: &domain.Sandbox{Summary: domain.SandboxSummary{ID: run.SandboxID, VMStatus: domain.VMStatusRunning}}}
-	stopper := &completionStopperFake{err: errors.New("stop unavailable")}
+	timeoutCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stopper := &completionStopperFake{err: errors.New("stop unavailable"), onStop: cancel}
 	manager := runs.NewCompletionManager(store, sandboxes, stopper, nil, nil)
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
-	defer cancel()
 	staged, err := manager.Complete(timeoutCtx, runs.TransitionRequest{
 		RunID: run.RunID, Status: domain.ProjectRunStatusSucceeded, Output: "exact output", ResultJSON: `{"ok":true}`,
 		TerminalEvents: []domain.ProjectRunEventRecord{{ID: "final-agent-event", RunID: run.RunID, Kind: domain.ProjectRunEventKindAgentMessage, Text: "done"}},
@@ -115,12 +115,16 @@ func (s completionSandboxStoreFake) GetSandbox(context.Context, string) (*domain
 }
 
 type completionStopperFake struct {
-	err   error
-	calls int
+	err    error
+	calls  int
+	onStop func()
 }
 
 func (s *completionStopperFake) Stop(context.Context, *domain.Sandbox) error {
 	s.calls++
+	if s.onStop != nil {
+		s.onStop()
+	}
 	return s.err
 }
 


### PR DESCRIPTION
## Summary

- implement Microsandbox command interactions with native streaming exec
- support stdin, stdin EOF, TTY resize, signals, UTF-8-safe output, and terminal results
- terminate guest processes and release SDK handles when attach streams are canceled
- bound interaction completion when a background child keeps inherited output pipes open
- preserve explicit unsupported behavior in builds without the Microsandbox driver
- make the completion cleanup coverage test cancel deterministically after cleanup starts
- update the runtime interaction capability documentation and regression coverage

The background-pipe fix uses a separate guest liveness probe after an initial grace period. If the main PID is confirmed gone but Microsandbox has not reported an exit status, the interaction closes its handle and returns an explicit unknown-exit error instead of guessing an exit code or waiting indefinitely. Streams that report `Exited` retain that exit code and use a bounded idle drain while waiting for `Done`.

## Testing

Automated quality gates:

- `task lint`
- `task build`
- `task test`
  - unit coverage: 74.95%
  - integration coverage: 60.86%
  - E2E coverage: 60.27%
  - combined coverage: 79.07%
- `task docs:build`
- `go test -race ./pkg/driver ./pkg/agentcompose/api -count=1`
- `LD_LIBRARY_PATH="$PWD/build/microsandbox/lib:${LD_LIBRARY_PATH:-}" go test -race -tags microsandboxcgo ./pkg/driver -count=1`

Real Microsandbox validation was run on a Linux KVM host with the PR binary and v0.6.8 runtime artifacts in a compatible Linux container using the host `/dev/kvm` device:

- base disk build and cache reuse passed
- runtime stop/resume retention and release passed
- directory-only mount startup passed
- rootfs isolation created independent private overlays; the additional Docker storage assertion could not complete because the locally available DIND guest did not start `dockerd`

The frontend integration used `agent-compose-ui` branch `feat/frontend-redesign` at `9feafe0`. The complete browser path was exercised through the authenticated frontend WebSocket bridge into this PR backend and a real Microsandbox guest:

- authenticated login and terminal auto-connect passed
- stdin, stdin EOF, stdout/stderr, and non-zero exit propagation passed
- UTF-8 output including Chinese text and emoji passed
- TTY resize was observed in the guest (`24x80` to `19x91`)
- Ctrl-C interrupted a long-running command while preserving the shell
- `exit 7` produced the terminal result `exit 7`
- disconnect canceled the interaction; the test workload had no live process or child afterward, and reconnect succeeded

The review-requested background-child cases were also reproduced through the command-interaction entrypoint:

- non-TTY with inherited pipes (`exec ... -i -- sh -c 'sleep 300 &'`) reproduced the missing `Exited`/`Done` stream; after the fix it returned an explicit unknown-exit error in about 2.2 seconds instead of reaching the 15-second client deadline
- non-TTY with redirected stdin/stdout/stderr completed successfully in about 0.2 seconds
- TTY with inherited pipes and TTY with redirected pipes both completed successfully in about 0.2 seconds
- a subsequent interaction completed successfully, and each test-created background process was checked and cleaned up

The cross-driver cancel/timeout final-frame semantics noted in review remain a separate protocol-hardening follow-up; this PR does not change that shared behavior.

The host-native runtime smoke entrypoint was not used because the v0.6.8 `msb` binary requires a newer glibc than the host provides. Running the exact PR test binary and artifacts in the compatible container supplied the newer userspace while retaining real host KVM execution.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] Real Microsandbox terminal behavior validated with the prepared frontend.
- [x] Review-requested inherited-pipe behavior reproduced and bounded.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
