### PR TITLE
feat(installer): redesign registry and frontend selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,12 +9,9 @@
 
 # ---------------------------------------------------------------------------
 # Published services
-# These variables are consumed by docker-compose.yml before the daemon starts.
-# Override images to pin versions or use a mirror/private registry.
+# The installer manages release image references internally. Docker registry
+# mirrors are configured in dockerd and do not change those references.
 # ---------------------------------------------------------------------------
-AGENT_COMPOSE_IMAGE=chaitin/agent-compose:latest
-# Used only when the with-ui profile is enabled.
-AGENT_COMPOSE_FRONTEND_IMAGE=chaitin/agent-compose-ui:latest
 # Host port published by the web UI and reverse proxy when the with-ui profile
 # is enabled.
 AGENT_COMPOSE_HTTP_PORT=80

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -374,6 +374,8 @@ jobs:
       - name: Build installer assets
         env:
           VERSION: ${{ github.ref_name }}
+          AGENT_COMPOSE_FRONTEND_VERSION: ${{ vars.AGENT_COMPOSE_FRONTEND_VERSION || 'latest' }}
+          AGENT_COMPOSE_FRONTEND_VERSIONS: ${{ vars.AGENT_COMPOSE_FRONTEND_VERSIONS || vars.AGENT_COMPOSE_FRONTEND_VERSION || 'latest' }}
         run: ./scripts/build-installer-assets.sh ./upload
       - name: Publish release
         env:

--- a/cmd/installer/command.go
+++ b/cmd/installer/command.go
@@ -25,7 +25,10 @@ func newRootCommand(out, errOut io.Writer) *cobra.Command {
 	defaults.InstallDir = envOrDefault("AGENT_COMPOSE_INSTALL_DIR", defaults.InstallDir)
 	defaults.Repository = envOrDefault("AGENT_COMPOSE_REPO", defaults.Repository)
 	defaults.ReleaseBaseURL = strings.TrimSpace(os.Getenv("AGENT_COMPOSE_RELEASE_BASE_URL"))
-	defaults.FrontendVersion = envOrDefault("AGENT_COMPOSE_FRONTEND_VERSION", defaults.FrontendVersion)
+	if frontendVersion := strings.TrimSpace(os.Getenv("AGENT_COMPOSE_FRONTEND_VERSION")); frontendVersion != "" {
+		defaults.FrontendVersion = frontendVersion
+		defaults.FrontendVersionSet = true
+	}
 	defaults.KVMPath = envOrDefault("AGENT_COMPOSE_KVM_DETECT_PATH", defaults.KVMPath)
 	options := &commandOptions{Options: defaults, yes: truthy(os.Getenv("AGENT_COMPOSE_YES"))}
 	root := &cobra.Command{
@@ -62,6 +65,8 @@ func newRootCommand(out, errOut io.Writer) *cobra.Command {
 	flags.BoolVar(&options.WithUI, "with-ui", options.WithUI, "also publish the web UI")
 	flags.BoolVar(&options.SkipGuestPull, "skip-guest-pull", false, "do not pre-pull the sandbox guest image")
 	flags.StringVar(&options.Version, "version", options.Version, "application release version")
+	flags.StringVar(&options.Registry, "registry", "", "registry host for release images")
+	flags.StringVar(&options.FrontendVersion, "frontend-version", options.FrontendVersion, "supported web UI version")
 	flags.StringVar(&options.ImagePrefix, "image-prefix", "", "image registry prefix")
 	flags.StringVar(&options.BackendImage, "backend-image", "", "complete backend image reference")
 	flags.StringVar(&options.FrontendImage, "frontend-image", "", "complete frontend image reference")
@@ -70,7 +75,9 @@ func newRootCommand(out, errOut io.Writer) *cobra.Command {
 	flags.BoolVarP(&options.yes, "yes", "y", options.yes, "skip confirmation prompts")
 	flags.BoolVar(&options.legacyUpgrade, "upgrade", false, "upgrade an existing installation (legacy form)")
 	_ = flags.MarkHidden("upgrade")
-	_ = flags.MarkDeprecated("image-prefix", "use --backend-image, --frontend-image, and --guest-image instead")
+	_ = flags.MarkHidden("image-prefix")
+	_ = flags.MarkHidden("backend-image")
+	_ = flags.MarkHidden("frontend-image")
 
 	root.AddCommand(newOperationCommand(core.OperationInstall, options, out, errOut))
 	root.AddCommand(newOperationCommand(core.OperationUpgrade, options, out, errOut))
@@ -104,6 +111,8 @@ func newOperationCommand(operation core.Operation, options *commandOptions, out,
 func markExplicitOptions(cmd *cobra.Command, options *commandOptions) {
 	options.PortSet = cmd.Flags().Changed("port")
 	options.WithUISet = cmd.Flags().Changed("with-ui")
+	options.RegistrySet = cmd.Flags().Changed("registry")
+	options.FrontendVersionSet = options.FrontendVersionSet || cmd.Flags().Changed("frontend-version")
 	options.BackendImageSet = cmd.Flags().Changed("backend-image")
 	options.FrontendImageSet = cmd.Flags().Changed("frontend-image")
 	options.GuestImageSet = cmd.Flags().Changed("guest-image")
@@ -212,7 +221,7 @@ func writeResult(out io.Writer, operation core.Operation, result core.Result, pu
 }
 
 func hasInstallerFlags(cmd *cobra.Command) bool {
-	for _, name := range []string{"dir", "port", "version", "image-prefix", "backend-image", "frontend-image", "guest-image", "no-start", "yes", "with-ui", "skip-guest-pull"} {
+	for _, name := range []string{"dir", "port", "version", "registry", "frontend-version", "image-prefix", "backend-image", "frontend-image", "guest-image", "no-start", "yes", "with-ui", "skip-guest-pull"} {
 		if cmd.Flags().Changed(name) {
 			return true
 		}

--- a/cmd/installer/command_test.go
+++ b/cmd/installer/command_test.go
@@ -24,9 +24,14 @@ func TestRootHelpDocumentsOperationsAndDefaultDirectory(t *testing.T) {
 	if err := command.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	for _, expected := range []string{"install", "upgrade", "uninstall", "/opt/agent-compose", "--backend-image", "--frontend-image", "--guest-image"} {
+	for _, expected := range []string{"install", "upgrade", "uninstall", "/opt/agent-compose", "--registry", "--frontend-version", "--guest-image"} {
 		if !strings.Contains(output.String(), expected) {
 			t.Fatalf("help missing %q:\n%s", expected, output.String())
+		}
+	}
+	for _, hidden := range []string{"--backend-image", "--frontend-image", "--image-prefix"} {
+		if strings.Contains(output.String(), hidden) {
+			t.Fatalf("help exposed compatibility flag %q:\n%s", hidden, output.String())
 		}
 	}
 }

--- a/cmd/installer/internal/core/options.go
+++ b/cmd/installer/internal/core/options.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -23,38 +25,40 @@ const (
 )
 
 type Options struct {
-	InstallDir       string
-	Repository       string
-	ReleaseBaseURL   string
-	Version          string
-	ImagePrefix      string
-	BackendImage     string
-	BackendImageSet  bool
-	FrontendImage    string
-	FrontendImageSet bool
-	GuestImage       string
-	GuestImageSet    bool
-	FrontendVersion  string
-	Port             int
-	PortSet          bool
-	WithUI           bool
-	WithUISet        bool
-	SkipGuestPull    bool
-	NoStart          bool
-	Purge            bool
-	KVMPath          string
-	BundleDir        string
-	InstallerPath    string
+	InstallDir         string
+	Repository         string
+	ReleaseBaseURL     string
+	Version            string
+	Registry           string
+	RegistrySet        bool
+	ImagePrefix        string
+	BackendImage       string
+	BackendImageSet    bool
+	FrontendImage      string
+	FrontendImageSet   bool
+	GuestImage         string
+	GuestImageSet      bool
+	FrontendVersion    string
+	FrontendVersionSet bool
+	Port               int
+	PortSet            bool
+	WithUI             bool
+	WithUISet          bool
+	SkipGuestPull      bool
+	NoStart            bool
+	Purge              bool
+	KVMPath            string
+	BundleDir          string
+	InstallerPath      string
 }
 
 func DefaultOptions() Options {
 	return Options{
-		InstallDir:      DefaultInstallDir,
-		Repository:      DefaultRepository,
-		Version:         DefaultVersion,
-		FrontendVersion: DefaultVersion,
-		Port:            DefaultPort,
-		KVMPath:         "/dev/kvm",
+		InstallDir: DefaultInstallDir,
+		Repository: DefaultRepository,
+		Version:    DefaultVersion,
+		Port:       DefaultPort,
+		KVMPath:    "/dev/kvm",
 	}
 }
 
@@ -75,6 +79,14 @@ func (o Options) Validate(operation Operation) error {
 		if o.Port < 1 || o.Port > 65535 {
 			return fmt.Errorf("port must be between 1 and 65535")
 		}
+		if o.RegistrySet {
+			if err := validateRegistry(o.Registry); err != nil {
+				return err
+			}
+		}
+		if o.RegistrySet && strings.TrimSpace(o.ImagePrefix) != "" {
+			return fmt.Errorf("registry and legacy image prefix cannot be used together")
+		}
 		for _, image := range []struct {
 			name  string
 			value string
@@ -90,6 +102,75 @@ func (o Options) Validate(operation Operation) error {
 		}
 	}
 	return nil
+}
+
+func validateRegistry(value string) error {
+	registry := strings.TrimSpace(value)
+	if registry == "" {
+		return fmt.Errorf("registry must not be empty")
+	}
+	if strings.ContainsAny(registry, "/@?#") || strings.Contains(registry, "://") {
+		return fmt.Errorf("registry must be a host or host:port without a scheme or path")
+	}
+	for _, char := range registry {
+		if unicode.IsSpace(char) {
+			return fmt.Errorf("registry must not contain whitespace")
+		}
+	}
+
+	host := registry
+	if strings.HasPrefix(registry, "[") {
+		end := strings.IndexByte(registry, ']')
+		if end < 0 || net.ParseIP(registry[1:end]) == nil {
+			return fmt.Errorf("registry contains an invalid IPv6 host")
+		}
+		host = registry[1:end]
+		remainder := registry[end+1:]
+		if remainder != "" {
+			if !strings.HasPrefix(remainder, ":") || !validRegistryPort(remainder[1:]) {
+				return fmt.Errorf("registry contains an invalid port")
+			}
+		}
+	} else {
+		if strings.Count(registry, ":") > 1 {
+			return fmt.Errorf("registry IPv6 hosts must be enclosed in brackets")
+		}
+		if candidate, port, ok := strings.Cut(registry, ":"); ok {
+			host = candidate
+			if !validRegistryPort(port) {
+				return fmt.Errorf("registry contains an invalid port")
+			}
+		}
+		if net.ParseIP(host) == nil && !validRegistryHostname(host) {
+			return fmt.Errorf("registry contains an invalid host")
+		}
+	}
+	if host == "" {
+		return fmt.Errorf("registry host must not be empty")
+	}
+	return nil
+}
+
+func validRegistryPort(value string) bool {
+	port, err := strconv.Atoi(value)
+	return err == nil && port >= 1 && port <= 65535
+}
+
+func validRegistryHostname(value string) bool {
+	if value == "" || len(value) > 253 || strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") {
+		return false
+	}
+	for label := range strings.SplitSeq(value, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, char := range label {
+			if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') && (char < '0' || char > '9') && char != '-' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func ParsePort(value string) (int, error) {

--- a/cmd/installer/internal/core/options.go
+++ b/cmd/installer/internal/core/options.go
@@ -79,7 +79,7 @@ func (o Options) Validate(operation Operation) error {
 		if o.Port < 1 || o.Port > 65535 {
 			return fmt.Errorf("port must be between 1 and 65535")
 		}
-		if o.RegistrySet {
+		if o.RegistrySet && strings.TrimSpace(o.Registry) != "" {
 			if err := validateRegistry(o.Registry); err != nil {
 				return err
 			}
@@ -152,6 +152,14 @@ func validateRegistry(value string) error {
 }
 
 func validRegistryPort(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
 	port, err := strconv.Atoi(value)
 	return err == nil && port >= 1 && port <= 65535
 }

--- a/cmd/installer/internal/core/release.go
+++ b/cmd/installer/internal/core/release.go
@@ -5,14 +5,22 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
 const (
-	backendImageKey  = "AGENT_COMPOSE_IMAGE"
-	frontendImageKey = "AGENT_COMPOSE_FRONTEND_IMAGE"
-	guestImageKey    = "DEFAULT_IMAGE"
+	backendImageKey             = "AGENT_COMPOSE_IMAGE"
+	frontendImageKey            = "AGENT_COMPOSE_FRONTEND_IMAGE"
+	guestImageKey               = "DEFAULT_IMAGE"
+	frontendVersionKey          = "AGENT_COMPOSE_FRONTEND_VERSION"
+	frontendVersionsKey         = "AGENT_COMPOSE_FRONTEND_VERSIONS"
+	installerRegistryKey        = "INSTALLER_REGISTRY"
+	installerImagePrefixKey     = "INSTALLER_IMAGE_PREFIX"
+	installerFrontendVersionKey = "INSTALLER_FRONTEND_VERSION"
 )
+
+var frontendTagPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
 
 // ImageSource identifies why an image will be effective after an operation.
 type ImageSource string
@@ -31,9 +39,11 @@ type ImageSelection struct {
 
 // ImagePreview contains the effective images for a proposed operation.
 type ImagePreview struct {
-	Backend  ImageSelection
-	Frontend ImageSelection
-	Guest    ImageSelection
+	Backend         ImageSelection
+	Frontend        ImageSelection
+	Guest           ImageSelection
+	Registry        string
+	FrontendVersion string
 }
 
 // ImageReferences contains the three image defaults published by a release.
@@ -45,9 +55,11 @@ type ImageReferences struct {
 
 // Release owns a verified deployment bundle and its image defaults.
 type Release struct {
-	bundle  *bundle
-	version string
-	Images  ImageReferences
+	bundle                 *bundle
+	version                string
+	Images                 ImageReferences
+	FrontendVersions       []string
+	DefaultFrontendVersion string
 }
 
 // Close releases temporary files owned by the resolved release.
@@ -67,6 +79,13 @@ func (s Service) ResolveRelease(ctx context.Context, options Options) (*Release,
 		return nil, err
 	}
 	release := &Release{bundle: loaded, version: options.Version}
+	frontendVersions, defaultFrontendVersion, err := supportedFrontendVersions(loaded.Manifest)
+	if err != nil {
+		release.Close()
+		return nil, err
+	}
+	release.FrontendVersions = frontendVersions
+	release.DefaultFrontendVersion = defaultFrontendVersion
 	envData, err := os.ReadFile(filepath.Join(loaded.Dir, ".env.example"))
 	if err != nil {
 		release.Close()
@@ -78,6 +97,10 @@ func (s Service) ResolveRelease(ctx context.Context, options Options) (*Release,
 	defaultOptions.BackendImage, defaultOptions.BackendImageSet = "", false
 	defaultOptions.FrontendImage, defaultOptions.FrontendImageSet = "", false
 	defaultOptions.GuestImage, defaultOptions.GuestImageSet = "", false
+	defaultOptions.Registry, defaultOptions.RegistrySet = "", false
+	defaultOptions.ImagePrefix = ""
+	defaultOptions.FrontendVersion = defaultFrontendVersion
+	defaultOptions.FrontendVersionSet = true
 	plan := planImageReferences(env, state, loaded.Manifest, defaultOptions, "install")
 	if err := applyPlannedImageReferences(env, state, plan); err != nil {
 		release.Close()
@@ -113,11 +136,19 @@ func (s Service) PreviewImages(operation Operation, options Options, release *Re
 	} else if operation == OperationUpgrade {
 		mode = "upgrade"
 	}
-	plan := planImageReferences(parseEnvFile(envData), parseEnvFile(stateData), release.bundle.Manifest, options, mode)
+	env := parseEnvFile(envData)
+	state := parseEnvFile(stateData)
+	effective, err := effectiveImageOptions(env, state, release.bundle.Manifest, options)
+	if err != nil {
+		return ImagePreview{}, err
+	}
+	plan := planImageReferences(env, state, release.bundle.Manifest, effective, mode)
 	return ImagePreview{
-		Backend:  plan.selection(backendImageKey),
-		Frontend: plan.selection(frontendImageKey),
-		Guest:    plan.selection(guestImageKey),
+		Backend:         plan.selection(backendImageKey),
+		Frontend:        plan.selection(frontendImageKey),
+		Guest:           plan.selection(guestImageKey),
+		Registry:        strings.TrimSpace(effective.Registry),
+		FrontendVersion: effective.FrontendVersion,
 	}, nil
 }
 
@@ -139,7 +170,7 @@ func planImageReferences(env, state, manifest *envFile, options Options, mode st
 		guestImageKey:    options.GuestImageSet,
 	}
 	plan := imageReferencePlan{}
-	for _, key := range []string{backendImageKey, "AGENT_COMPOSE_FRONTEND_VERSION", frontendImageKey, guestImageKey} {
+	for _, key := range []string{backendImageKey, frontendVersionKey, frontendImageKey, guestImageKey} {
 		value, desiredExists := desired[key]
 		current, currentExists := env.Get(key)
 		managed, managedExists := state.Get(key)
@@ -173,19 +204,27 @@ func desiredImageReferences(manifest *envFile, options Options) map[string]strin
 			}
 		}
 		frontendVersion := options.FrontendVersion
-		if frontendVersion == "" {
-			frontendVersion = DefaultVersion
-		}
 		desired[backendImageKey] = options.ImagePrefix + "/agent-compose:" + version
-		desired["AGENT_COMPOSE_FRONTEND_VERSION"] = frontendVersion
+		desired[frontendVersionKey] = frontendVersion
 		desired[frontendImageKey] = options.ImagePrefix + "/agent-compose-ui:" + frontendVersion
 		desired[guestImageKey] = options.ImagePrefix + "/agent-compose-guest:" + version
 	} else {
-		for _, key := range []string{backendImageKey, "AGENT_COMPOSE_FRONTEND_VERSION", frontendImageKey, guestImageKey} {
+		for _, key := range []string{backendImageKey, frontendVersionKey, frontendImageKey, guestImageKey} {
 			if value, ok := manifest.Get(key); ok {
 				desired[key] = value
 			}
 		}
+		if options.RegistrySet {
+			for _, key := range []string{backendImageKey, frontendImageKey, guestImageKey} {
+				if value, ok := desired[key]; ok {
+					desired[key] = replaceImageRegistry(value, options.Registry)
+				}
+			}
+		}
+		if frontend, ok := desired[frontendImageKey]; ok {
+			desired[frontendImageKey] = replaceImageTag(frontend, options.FrontendVersion)
+		}
+		desired[frontendVersionKey] = options.FrontendVersion
 	}
 	if options.BackendImageSet {
 		desired[backendImageKey] = strings.TrimSpace(options.BackendImage)
@@ -200,7 +239,29 @@ func desiredImageReferences(manifest *envFile, options Options) map[string]strin
 }
 
 func applyImageReferences(env, state, manifest *envFile, options Options, mode string) error {
-	return applyPlannedImageReferences(env, state, planImageReferences(env, state, manifest, options, mode))
+	effective, err := effectiveImageOptions(env, state, manifest, options)
+	if err != nil {
+		return err
+	}
+	if err := applyPlannedImageReferences(env, state, planImageReferences(env, state, manifest, effective, mode)); err != nil {
+		return err
+	}
+	if effective.ImagePrefix != "" {
+		if err := state.Set(installerImagePrefixKey, effective.ImagePrefix); err != nil {
+			return err
+		}
+		if err := state.Set(installerRegistryKey, ""); err != nil {
+			return err
+		}
+	} else {
+		if err := state.Set(installerRegistryKey, effective.Registry); err != nil {
+			return err
+		}
+		if err := state.Set(installerImagePrefixKey, ""); err != nil {
+			return err
+		}
+	}
+	return state.Set(installerFrontendVersionKey, effective.FrontendVersion)
 }
 
 func applyPlannedImageReferences(env, state *envFile, plan imageReferencePlan) error {
@@ -223,4 +284,140 @@ func imageReferences(env *envFile) ImageReferences {
 	frontend, _ := env.Get(frontendImageKey)
 	guest, _ := env.Get(guestImageKey)
 	return ImageReferences{Backend: strings.TrimSpace(backend), Frontend: strings.TrimSpace(frontend), Guest: strings.TrimSpace(guest)}
+}
+
+func effectiveImageOptions(env, state, manifest *envFile, options Options) (Options, error) {
+	if !options.RegistrySet && strings.TrimSpace(options.ImagePrefix) == "" {
+		if registry, ok := state.Get(installerRegistryKey); ok && strings.TrimSpace(registry) != "" {
+			options.Registry = strings.TrimSpace(registry)
+			options.RegistrySet = true
+		} else if prefix, ok := state.Get(installerImagePrefixKey); ok && strings.TrimSpace(prefix) != "" {
+			options.ImagePrefix = strings.TrimSpace(prefix)
+		} else if _, registryKnown := state.Get(installerRegistryKey); !registryKnown {
+			if _, prefixKnown := state.Get(installerImagePrefixKey); !prefixKnown {
+				options.ImagePrefix = inferLegacyImagePrefix(state)
+			}
+		}
+	}
+	if options.RegistrySet {
+		if err := validateRegistry(options.Registry); err != nil {
+			return options, err
+		}
+	}
+	versions, defaultVersion, err := supportedFrontendVersions(manifest)
+	if err != nil {
+		return options, err
+	}
+	if !options.FrontendVersionSet {
+		if selected, ok := state.Get(installerFrontendVersionKey); ok && strings.TrimSpace(selected) != "" {
+			options.FrontendVersion = strings.TrimSpace(selected)
+		} else if selected, ok := env.Get(frontendVersionKey); ok && strings.TrimSpace(selected) != "" {
+			options.FrontendVersion = strings.TrimSpace(selected)
+		} else {
+			options.FrontendVersion = defaultVersion
+		}
+	}
+	if options.FrontendImageSet {
+		return options, nil
+	}
+	if !containsString(versions, options.FrontendVersion) {
+		return options, fmt.Errorf("frontend version %q is not supported by release %q; choose one of %s", options.FrontendVersion, options.Version, strings.Join(versions, ", "))
+	}
+	return options, nil
+}
+
+func supportedFrontendVersions(manifest *envFile) ([]string, string, error) {
+	defaultVersion, ok := manifest.Get(frontendVersionKey)
+	defaultVersion = strings.TrimSpace(defaultVersion)
+	if !ok || defaultVersion == "" || !frontendTagPattern.MatchString(defaultVersion) {
+		return nil, "", fmt.Errorf("release manifest contains an invalid default frontend version %q", defaultVersion)
+	}
+	configured, ok := manifest.Get(frontendVersionsKey)
+	if !ok || strings.TrimSpace(configured) == "" {
+		return []string{defaultVersion}, defaultVersion, nil
+	}
+	versions := make([]string, 0)
+	seen := map[string]bool{}
+	for item := range strings.SplitSeq(configured, ",") {
+		version := strings.TrimSpace(item)
+		if !frontendTagPattern.MatchString(version) {
+			return nil, "", fmt.Errorf("release manifest contains an invalid frontend version %q", version)
+		}
+		if seen[version] {
+			return nil, "", fmt.Errorf("release manifest contains duplicate frontend version %q", version)
+		}
+		seen[version] = true
+		versions = append(versions, version)
+	}
+	if !seen[defaultVersion] {
+		return nil, "", fmt.Errorf("release manifest default frontend version %q is not in the supported list", defaultVersion)
+	}
+	return versions, defaultVersion, nil
+}
+
+func replaceImageRegistry(reference, registry string) string {
+	first, remainder, found := strings.Cut(reference, "/")
+	if !found {
+		return strings.TrimSpace(registry) + "/" + reference
+	}
+	if strings.ContainsAny(first, ".:") || first == "localhost" || strings.HasPrefix(first, "[") {
+		return strings.TrimSpace(registry) + "/" + remainder
+	}
+	return strings.TrimSpace(registry) + "/" + reference
+}
+
+func replaceImageTag(reference, version string) string {
+	if at := strings.IndexByte(reference, '@'); at >= 0 {
+		reference = reference[:at]
+	}
+	lastSlash := strings.LastIndexByte(reference, '/')
+	if colon := strings.LastIndexByte(reference, ':'); colon > lastSlash {
+		reference = reference[:colon]
+	}
+	return reference + ":" + version
+}
+
+func containsString(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func inferLegacyImagePrefix(state *envFile) string {
+	var common string
+	for key, basename := range map[string]string{
+		backendImageKey:  "agent-compose",
+		frontendImageKey: "agent-compose-ui",
+		guestImageKey:    "agent-compose-guest",
+	} {
+		reference, ok := state.Get(key)
+		if !ok {
+			return ""
+		}
+		repository := imageRepository(strings.TrimSpace(reference))
+		suffix := "/" + basename
+		if !strings.HasSuffix(repository, suffix) {
+			return ""
+		}
+		prefix := strings.TrimSuffix(repository, suffix)
+		if prefix == "" || (common != "" && prefix != common) {
+			return ""
+		}
+		common = prefix
+	}
+	return common
+}
+
+func imageRepository(reference string) string {
+	if at := strings.IndexByte(reference, '@'); at >= 0 {
+		return reference[:at]
+	}
+	lastSlash := strings.LastIndexByte(reference, '/')
+	if colon := strings.LastIndexByte(reference, ':'); colon > lastSlash {
+		return reference[:colon]
+	}
+	return reference
 }

--- a/cmd/installer/internal/core/release.go
+++ b/cmd/installer/internal/core/release.go
@@ -215,7 +215,7 @@ func desiredImageReferences(manifest *envFile, options Options) map[string]strin
 				desired[key] = value
 			}
 		}
-		if options.RegistrySet {
+		if options.RegistrySet && strings.TrimSpace(options.Registry) != "" {
 			for _, key := range []string{backendImageKey, frontendImageKey, guestImageKey} {
 				if value, ok := desired[key]; ok {
 					desired[key] = replaceImageRegistry(value, options.Registry)
@@ -301,7 +301,7 @@ func effectiveImageOptions(env, state, manifest *envFile, options Options) (Opti
 			}
 		}
 	}
-	if options.RegistrySet {
+	if options.RegistrySet && strings.TrimSpace(options.Registry) != "" {
 		if err := validateRegistry(options.Registry); err != nil {
 			return options, err
 		}

--- a/cmd/installer/internal/core/release.go
+++ b/cmd/installer/internal/core/release.go
@@ -165,9 +165,10 @@ func (p imageReferencePlan) selection(key string) ImageSelection { return p[key]
 func planImageReferences(env, state, manifest *envFile, options Options, mode string) imageReferencePlan {
 	desired := desiredImageReferences(manifest, options)
 	explicit := map[string]bool{
-		backendImageKey:  options.BackendImageSet,
-		frontendImageKey: options.FrontendImageSet,
-		guestImageKey:    options.GuestImageSet,
+		backendImageKey:    options.BackendImageSet,
+		frontendVersionKey: options.FrontendVersionSet,
+		frontendImageKey:   options.FrontendImageSet,
+		guestImageKey:      options.GuestImageSet,
 	}
 	plan := imageReferencePlan{}
 	for _, key := range []string{backendImageKey, frontendVersionKey, frontendImageKey, guestImageKey} {
@@ -221,7 +222,8 @@ func desiredImageReferences(manifest *envFile, options Options) map[string]strin
 				}
 			}
 		}
-		if frontend, ok := desired[frontendImageKey]; ok {
+		defaultFrontendVersion, _ := manifest.Get(frontendVersionKey)
+		if frontend, ok := desired[frontendImageKey]; ok && options.FrontendVersion != strings.TrimSpace(defaultFrontendVersion) {
 			desired[frontendImageKey] = replaceImageTag(frontend, options.FrontendVersion)
 		}
 		desired[frontendVersionKey] = options.FrontendVersion

--- a/cmd/installer/internal/core/release_test.go
+++ b/cmd/installer/internal/core/release_test.go
@@ -4,8 +4,168 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestReplaceImageRegistryPreservesRepositoryAndIdentifier(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		reference string
+		registry  string
+		want      string
+	}{
+		{name: "implicit Docker Hub", reference: "chaitin/agent-compose:v1", registry: "registry.example.com", want: "registry.example.com/chaitin/agent-compose:v1"},
+		{name: "explicit Docker Hub", reference: "docker.io/chaitin/agent-compose:v1", registry: "registry.example.com:5000", want: "registry.example.com:5000/chaitin/agent-compose:v1"},
+		{name: "other registry digest", reference: "old.example/team/guest@sha256:abc", registry: "new.example", want: "new.example/team/guest@sha256:abc"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := replaceImageRegistry(testCase.reference, testCase.registry); got != testCase.want {
+				t.Fatalf("replaceImageRegistry() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestSupportedFrontendVersions(t *testing.T) {
+	manifest := parseEnvFile([]byte("AGENT_COMPOSE_FRONTEND_VERSION=v2\nAGENT_COMPOSE_FRONTEND_VERSIONS=v2,v1\n"))
+	versions, defaultVersion, err := supportedFrontendVersions(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if defaultVersion != "v2" || !reflect.DeepEqual(versions, []string{"v2", "v1"}) {
+		t.Fatalf("versions = %#v, default = %q", versions, defaultVersion)
+	}
+
+	for name, content := range map[string]string{
+		"default missing":          "AGENT_COMPOSE_FRONTEND_VERSIONS=v1,v2\n",
+		"default absent from list": "AGENT_COMPOSE_FRONTEND_VERSION=v3\nAGENT_COMPOSE_FRONTEND_VERSIONS=v1,v2\n",
+		"duplicate":                "AGENT_COMPOSE_FRONTEND_VERSION=v1\nAGENT_COMPOSE_FRONTEND_VERSIONS=v1,v1\n",
+		"invalid tag":              "AGENT_COMPOSE_FRONTEND_VERSION=v1\nAGENT_COMPOSE_FRONTEND_VERSIONS=v1,bad/tag\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := supportedFrontendVersions(parseEnvFile([]byte(content))); err == nil {
+				t.Fatal("expected invalid frontend version manifest")
+			}
+		})
+	}
+}
+
+func TestPreviewAppliesRegistryAndSelectedFrontendVersion(t *testing.T) {
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v2", "v2", "v2,v1")
+	options.InstallDir = filepath.Join(t.TempDir(), "install")
+	options.Registry = "mirror.example.com"
+	options.RegistrySet = true
+	options.FrontendVersion = "v1"
+	options.FrontendVersionSet = true
+	service := Service{}
+	release, err := service.ResolveRelease(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release.Close()
+
+	preview, err := service.PreviewImages(OperationInstall, options, release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Registry != "mirror.example.com" || preview.FrontendVersion != "v1" {
+		t.Fatalf("preview settings = %#v", preview)
+	}
+	for _, selection := range []ImageSelection{preview.Backend, preview.Frontend, preview.Guest} {
+		if !strings.HasPrefix(selection.Value, "mirror.example.com/") {
+			t.Fatalf("image did not use registry: %#v", selection)
+		}
+	}
+	if !strings.HasSuffix(preview.Frontend.Value, ":v1") {
+		t.Fatalf("frontend image = %q", preview.Frontend.Value)
+	}
+
+	options.FrontendVersion = "unsupported"
+	if _, err := service.PreviewImages(OperationInstall, options, release); err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("unsupported frontend version error = %v", err)
+	}
+}
+
+func TestInstallPersistsRegistryAndFrontendVersion(t *testing.T) {
+	root := t.TempDir()
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v2", "v2", "v2,v1")
+	options.InstallDir = filepath.Join(root, "install")
+	options.KVMPath = filepath.Join(root, "missing-kvm")
+	options.NoStart = true
+	options.Registry = "mirror.example.com:5000"
+	options.RegistrySet = true
+	options.FrontendVersion = "v1"
+	options.FrontendVersionSet = true
+
+	if _, err := (Service{Runner: &fakeRunner{}}).Apply(context.Background(), OperationInstall, options); err != nil {
+		t.Fatal(err)
+	}
+	state := readTestEnv(t, filepath.Join(options.InstallDir, ".installer-state.env"))
+	assertTestEnv(t, state, installerRegistryKey, "mirror.example.com:5000")
+	assertTestEnv(t, state, installerImagePrefixKey, "")
+	assertTestEnv(t, state, installerFrontendVersionKey, "v1")
+	env := readTestEnv(t, filepath.Join(options.InstallDir, ".env"))
+	assertTestEnv(t, env, backendImageKey, "mirror.example.com:5000/agent-compose:v2")
+	assertTestEnv(t, env, frontendImageKey, "mirror.example.com:5000/agent-compose-ui:v1")
+	assertTestEnv(t, env, guestImageKey, "mirror.example.com:5000/agent-compose-guest:v2")
+}
+
+func TestEffectiveOptionsMigratesLegacyImagePrefix(t *testing.T) {
+	state := parseEnvFile([]byte(
+		"AGENT_COMPOSE_IMAGE=legacy.example/team/agent-compose:v1\n" +
+			"AGENT_COMPOSE_FRONTEND_IMAGE=legacy.example/team/agent-compose-ui:v1\n" +
+			"DEFAULT_IMAGE=legacy.example/team/agent-compose-guest:v1\n",
+	))
+	manifest := parseEnvFile([]byte(
+		"AGENT_COMPOSE_FRONTEND_VERSION=v2\n" +
+			"AGENT_COMPOSE_FRONTEND_VERSIONS=v2,v1\n",
+	))
+	env := parseEnvFile([]byte("AGENT_COMPOSE_FRONTEND_VERSION=v1\n"))
+	effective, err := effectiveImageOptions(env, state, manifest, DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effective.ImagePrefix != "legacy.example/team" || effective.FrontendVersion != "v1" {
+		t.Fatalf("legacy settings = %#v", effective)
+	}
+}
+
+func TestUpgradePreservesSupportedFrontendVersionAndRejectsRemovedVersion(t *testing.T) {
+	root := t.TempDir()
+	installDir := filepath.Join(root, "install")
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v1", "v2", "v2,v1")
+	options.InstallDir = installDir
+	options.KVMPath = filepath.Join(root, "missing-kvm")
+	options.NoStart = true
+	options.Registry = "mirror.example.com"
+	options.RegistrySet = true
+	options.FrontendVersion = "v1"
+	options.FrontendVersionSet = true
+	service := Service{Runner: &fakeRunner{}}
+	if _, err := service.Apply(context.Background(), OperationInstall, options); err != nil {
+		t.Fatal(err)
+	}
+
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v2", "v3", "v3,v1")
+	options.Registry, options.RegistrySet = "", false
+	options.FrontendVersion, options.FrontendVersionSet = "", false
+	if _, err := service.Apply(context.Background(), OperationUpgrade, options); err != nil {
+		t.Fatal(err)
+	}
+	env := readTestEnv(t, filepath.Join(installDir, ".env"))
+	assertTestEnv(t, env, frontendVersionKey, "v1")
+	assertTestEnv(t, env, frontendImageKey, "mirror.example.com/agent-compose-ui:v1")
+
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v3", "v3", "v3,v2")
+	if _, err := service.Apply(context.Background(), OperationUpgrade, options); err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("removed frontend version error = %v", err)
+	}
+}
 
 func TestResolveReleaseReportsManifestImages(t *testing.T) {
 	options := DefaultOptions()
@@ -92,4 +252,28 @@ func TestApplyReleaseReusesResolvedBundle(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(options.InstallDir, ".env")); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func makeTestBundleWithFrontendVersions(t *testing.T, releaseVersion, defaultVersion, versions string) string {
+	t.Helper()
+	dir := makeTestBundle(t, releaseVersion)
+	path := filepath.Join(dir, "images", "manifest.env")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := parseEnvFile(data)
+	for key, value := range map[string]string{
+		frontendVersionKey:  defaultVersion,
+		frontendVersionsKey: versions,
+		frontendImageKey:    "registry.example/agent-compose-ui:" + defaultVersion,
+	} {
+		if err := manifest.Set(key, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(path, manifest.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }

--- a/cmd/installer/internal/core/release_test.go
+++ b/cmd/installer/internal/core/release_test.go
@@ -89,6 +89,38 @@ func TestPreviewAppliesRegistryAndSelectedFrontendVersion(t *testing.T) {
 	}
 }
 
+func TestPreviewPreservesDigestPinnedDefaultFrontendImage(t *testing.T) {
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v2", "v2", "v2,v1")
+	options.InstallDir = filepath.Join(t.TempDir(), "install")
+	pinned := "registry.example/agent-compose-ui@sha256:abcdef"
+	setTestBundleManifestValue(t, options.BundleDir, frontendImageKey, pinned)
+	service := Service{}
+	release, err := service.ResolveRelease(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release.Close()
+
+	preview, err := service.PreviewImages(OperationInstall, options, release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.Images.Frontend != pinned || preview.Frontend.Value != pinned {
+		t.Fatalf("default frontend images = release %q, preview %q; want %q", release.Images.Frontend, preview.Frontend.Value, pinned)
+	}
+
+	options.FrontendVersion = "v1"
+	options.FrontendVersionSet = true
+	preview, err = service.PreviewImages(OperationInstall, options, release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Frontend.Value != "registry.example/agent-compose-ui:v1" {
+		t.Fatalf("selected frontend image = %q", preview.Frontend.Value)
+	}
+}
+
 func TestInstallPersistsRegistryAndFrontendVersion(t *testing.T) {
 	root := t.TempDir()
 	options := DefaultOptions()
@@ -165,6 +197,43 @@ func TestUpgradePreservesSupportedFrontendVersionAndRejectsRemovedVersion(t *tes
 	if _, err := service.Apply(context.Background(), OperationUpgrade, options); err == nil || !strings.Contains(err.Error(), "not supported") {
 		t.Fatalf("removed frontend version error = %v", err)
 	}
+}
+
+func TestUpgradeExplicitFrontendVersionOverridesOperatorEditedValue(t *testing.T) {
+	root := t.TempDir()
+	installDir := filepath.Join(root, "install")
+	options := DefaultOptions()
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v1", "v1", "v1,v2")
+	options.InstallDir = installDir
+	options.KVMPath = filepath.Join(root, "missing-kvm")
+	options.NoStart = true
+	options.FrontendVersion = "v1"
+	options.FrontendVersionSet = true
+	service := Service{Runner: &fakeRunner{}}
+	if _, err := service.Apply(context.Background(), OperationInstall, options); err != nil {
+		t.Fatal(err)
+	}
+
+	envPath := filepath.Join(installDir, ".env")
+	env := readTestEnv(t, envPath)
+	if err := env.Set(frontendVersionKey, "operator-edited"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envPath, env.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v2", "v2", "v2,v1")
+	options.FrontendVersion = "v2"
+	if _, err := service.Apply(context.Background(), OperationUpgrade, options); err != nil {
+		t.Fatal(err)
+	}
+	env = readTestEnv(t, envPath)
+	assertTestEnv(t, env, frontendVersionKey, "v2")
+	assertTestEnv(t, env, frontendImageKey, "registry.example/agent-compose-ui:v2")
+	state := readTestEnv(t, filepath.Join(installDir, ".installer-state.env"))
+	assertTestEnv(t, state, frontendVersionKey, "v2")
+	assertTestEnv(t, state, installerFrontendVersionKey, "v2")
 }
 
 func TestResolveReleaseReportsManifestImages(t *testing.T) {
@@ -276,4 +345,16 @@ func makeTestBundleWithFrontendVersions(t *testing.T, releaseVersion, defaultVer
 		t.Fatal(err)
 	}
 	return dir
+}
+
+func setTestBundleManifestValue(t *testing.T, dir, key, value string) {
+	t.Helper()
+	path := filepath.Join(dir, "images", "manifest.env")
+	manifest := readTestEnv(t, path)
+	if err := manifest.Set(key, value); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, manifest.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/cmd/installer/internal/core/release_test.go
+++ b/cmd/installer/internal/core/release_test.go
@@ -121,7 +121,7 @@ func TestPreviewPreservesDigestPinnedDefaultFrontendImage(t *testing.T) {
 	}
 }
 
-func TestInstallPersistsRegistryAndFrontendVersion(t *testing.T) {
+func TestInstallPersistsAndUpgradeClearsRegistry(t *testing.T) {
 	root := t.TempDir()
 	options := DefaultOptions()
 	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v2", "v2", "v2,v1")
@@ -144,6 +144,18 @@ func TestInstallPersistsRegistryAndFrontendVersion(t *testing.T) {
 	assertTestEnv(t, env, backendImageKey, "mirror.example.com:5000/agent-compose:v2")
 	assertTestEnv(t, env, frontendImageKey, "mirror.example.com:5000/agent-compose-ui:v1")
 	assertTestEnv(t, env, guestImageKey, "mirror.example.com:5000/agent-compose-guest:v2")
+
+	options.BundleDir = makeTestBundleWithFrontendVersions(t, "v3", "v2", "v2,v1")
+	options.Registry = ""
+	if _, err := (Service{Runner: &fakeRunner{}}).Apply(context.Background(), OperationUpgrade, options); err != nil {
+		t.Fatal(err)
+	}
+	state = readTestEnv(t, filepath.Join(options.InstallDir, ".installer-state.env"))
+	assertTestEnv(t, state, installerRegistryKey, "")
+	env = readTestEnv(t, filepath.Join(options.InstallDir, ".env"))
+	assertTestEnv(t, env, backendImageKey, "registry.example/agent-compose:v3")
+	assertTestEnv(t, env, frontendImageKey, "registry.example/agent-compose-ui:v1")
+	assertTestEnv(t, env, guestImageKey, "registry.example/agent-compose-guest:v3")
 }
 
 func TestEffectiveOptionsMigratesLegacyImagePrefix(t *testing.T) {

--- a/cmd/installer/internal/core/service_integration_test.go
+++ b/cmd/installer/internal/core/service_integration_test.go
@@ -200,6 +200,10 @@ func TestOptionsRejectExplicitInvalidImages(t *testing.T) {
 			options.Registry = "https://registry.example"
 			options.RegistrySet = true
 		}, wantErr: "without a scheme or path"},
+		{name: "signed registry port", set: func(options *Options) {
+			options.Registry = "registry.example:+5000"
+			options.RegistrySet = true
+		}, wantErr: "invalid port"},
 		{name: "registry and prefix", set: func(options *Options) {
 			options.Registry = "registry.example"
 			options.RegistrySet = true

--- a/cmd/installer/internal/core/service_integration_test.go
+++ b/cmd/installer/internal/core/service_integration_test.go
@@ -192,6 +192,19 @@ func TestOptionsRejectExplicitInvalidImages(t *testing.T) {
 			options.GuestImage = "  "
 			options.GuestImageSet = true
 		}, wantErr: "guest image"},
+		{name: "registry path", set: func(options *Options) {
+			options.Registry = "registry.example/team"
+			options.RegistrySet = true
+		}, wantErr: "without a scheme or path"},
+		{name: "registry scheme", set: func(options *Options) {
+			options.Registry = "https://registry.example"
+			options.RegistrySet = true
+		}, wantErr: "without a scheme or path"},
+		{name: "registry and prefix", set: func(options *Options) {
+			options.Registry = "registry.example"
+			options.RegistrySet = true
+			options.ImagePrefix = "legacy.example/team"
+		}, wantErr: "cannot be used together"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			options := DefaultOptions()

--- a/cmd/installer/internal/tui/form.go
+++ b/cmd/installer/internal/tui/form.go
@@ -69,6 +69,7 @@ func (m *model) buildFields() {
 	m.fields = []formField{newTextField(fieldInstallDir, m.options.InstallDir)}
 	if m.operation != core.OperationUninstall {
 		registry := newTextField(fieldRegistry, m.options.Registry)
+		registry.followsRelease = !m.options.RegistrySet
 		registry.input.Placeholder = m.text("docker.io（默认）", "docker.io (default)")
 		m.fields = append(m.fields,
 			newTextField(fieldVersion, m.options.Version),
@@ -150,7 +151,7 @@ func (m *model) readFields() error {
 			m.options.Version = strings.TrimSpace(field.input.Value())
 		case fieldRegistry:
 			m.options.Registry = strings.TrimSpace(field.input.Value())
-			m.options.RegistrySet = m.options.Registry != ""
+			m.options.RegistrySet = !field.followsRelease
 		case fieldGuestImage:
 			m.readImageField(i, &m.options.GuestImage, &m.options.GuestImageSet)
 		case fieldGuestPull:

--- a/cmd/installer/internal/tui/form.go
+++ b/cmd/installer/internal/tui/form.go
@@ -14,21 +14,24 @@ type fieldID int
 const (
 	fieldInstallDir fieldID = iota
 	fieldVersion
-	fieldBackendImage
-	fieldFrontendImage
+	fieldRegistry
 	fieldGuestImage
-	fieldWithUI
-	fieldPort
 	fieldGuestPull
+	fieldWithUI
+	fieldFrontendVersion
+	fieldPort
 )
 
-// formField is either a text input or an on/off toggle. Toggles cannot be
-// expressed as a textinput.Model, and the port field has to render as disabled
-// rather than disappear, so the form tracks fields instead of raw inputs.
+// formField is a text input, an on/off toggle, or a release-backed choice.
+// Non-text controls and disabled fields cannot be expressed as textinput.Model,
+// so the form tracks fields instead of raw inputs.
 type formField struct {
 	id             fieldID
 	toggle         bool
 	on             bool
+	choiceField    bool
+	choices        []string
+	choice         int
 	followsRelease bool
 	input          textinput.Model
 }
@@ -45,6 +48,17 @@ func newToggleField(id fieldID, on bool) formField {
 	return formField{id: id, toggle: true, on: on}
 }
 
+func newChoiceField(id fieldID, choices []string, selected string) formField {
+	field := formField{id: id, choiceField: true, choices: append([]string(nil), choices...), followsRelease: true}
+	for index, choice := range choices {
+		if choice == selected {
+			field.choice = index
+			break
+		}
+	}
+	return field
+}
+
 func newImageField(id fieldID, value string, explicitlySet bool) formField {
 	field := newTextField(id, value)
 	field.followsRelease = !explicitlySet
@@ -54,14 +68,16 @@ func newImageField(id fieldID, value string, explicitlySet bool) formField {
 func (m *model) buildFields() {
 	m.fields = []formField{newTextField(fieldInstallDir, m.options.InstallDir)}
 	if m.operation != core.OperationUninstall {
+		registry := newTextField(fieldRegistry, m.options.Registry)
+		registry.input.Placeholder = m.text("docker.io（默认）", "docker.io (default)")
 		m.fields = append(m.fields,
 			newTextField(fieldVersion, m.options.Version),
-			newImageField(fieldBackendImage, m.options.BackendImage, m.options.BackendImageSet),
-			newImageField(fieldFrontendImage, m.options.FrontendImage, m.options.FrontendImageSet),
+			registry,
 			newImageField(fieldGuestImage, m.options.GuestImage, m.options.GuestImageSet),
-			newToggleField(fieldWithUI, m.options.WithUI),
-			newTextField(fieldPort, strconv.Itoa(m.options.Port)),
 			newToggleField(fieldGuestPull, !m.options.SkipGuestPull),
+			newToggleField(fieldWithUI, m.options.WithUI),
+			newChoiceField(fieldFrontendVersion, nil, m.options.FrontendVersion),
+			newTextField(fieldPort, strconv.Itoa(m.options.Port)),
 		)
 	}
 	m.focus = 0
@@ -81,16 +97,16 @@ func (m *model) field(id fieldID) *formField {
 // matters when the frontend publishes it, so leaving it greyed out shows the
 // dependency without the form jumping around as the toggle flips.
 func (m *model) fieldDisabled(index int) bool {
-	if m.fields[index].id != fieldPort {
+	if m.fields[index].id != fieldPort && m.fields[index].id != fieldFrontendVersion {
 		return false
 	}
 	ui := m.field(fieldWithUI)
-	return ui != nil && !ui.on
+	return ui != nil && (!ui.on || (m.fields[index].id == fieldFrontendVersion && len(m.fields[index].choices) == 0))
 }
 
 func (m *model) focusFields() {
 	for i := range m.fields {
-		if i == m.focus && !m.fields[i].toggle {
+		if i == m.focus && !m.fields[i].toggle && !m.fields[i].choiceField {
 			m.fields[i].input.Focus()
 			continue
 		}
@@ -108,12 +124,18 @@ func (m *model) moveFocus(delta int) {
 	m.focusFields()
 }
 
-func (m *model) toggleFocusedField() bool {
+func (m *model) toggleFocusedField(delta int) bool {
 	if m.fields[m.focus].toggle {
 		m.fields[m.focus].on = !m.fields[m.focus].on
 		// Flipping the UI toggle can disable the field under the cursor only
 		// when focus is already elsewhere, so refreshing focus is enough.
 		m.focusFields()
+		return true
+	}
+	if m.fields[m.focus].choiceField && len(m.fields[m.focus].choices) > 0 {
+		field := &m.fields[m.focus]
+		field.choice = (field.choice + delta + len(field.choices)) % len(field.choices)
+		field.followsRelease = false
 		return true
 	}
 	return false
@@ -126,15 +148,22 @@ func (m *model) readFields() error {
 			m.options.InstallDir = strings.TrimSpace(field.input.Value())
 		case fieldVersion:
 			m.options.Version = strings.TrimSpace(field.input.Value())
-		case fieldBackendImage:
-			m.readImageField(i, &m.options.BackendImage, &m.options.BackendImageSet)
-		case fieldFrontendImage:
-			m.readImageField(i, &m.options.FrontendImage, &m.options.FrontendImageSet)
+		case fieldRegistry:
+			m.options.Registry = strings.TrimSpace(field.input.Value())
+			m.options.RegistrySet = m.options.Registry != ""
 		case fieldGuestImage:
 			m.readImageField(i, &m.options.GuestImage, &m.options.GuestImageSet)
+		case fieldGuestPull:
+			m.options.SkipGuestPull = !field.on
 		case fieldWithUI:
 			m.options.WithUI = field.on
 			m.options.WithUISet = true
+		case fieldFrontendVersion:
+			if field.followsRelease || len(field.choices) == 0 {
+				continue
+			}
+			m.options.FrontendVersion = field.choices[field.choice]
+			m.options.FrontendVersionSet = true
 		case fieldPort:
 			// A disabled port publishes nothing. Reading it would validate a
 			// value the operator cannot even edit, and marking it as set would
@@ -149,8 +178,6 @@ func (m *model) readFields() error {
 			}
 			m.options.Port = port
 			m.options.PortSet = true
-		case fieldGuestPull:
-			m.options.SkipGuestPull = !field.on
 		}
 	}
 	if m.operation != core.OperationUninstall {
@@ -180,18 +207,18 @@ func (m *model) fieldLabel(id fieldID) string {
 		return m.text("安装目录", "Install directory")
 	case fieldVersion:
 		return m.text("应用版本", "Application version")
-	case fieldBackendImage:
-		return m.text("后端镜像（可选）", "Backend image (optional)")
-	case fieldFrontendImage:
-		return m.text("前端镜像（可选）", "Frontend image (optional)")
+	case fieldRegistry:
+		return m.text("镜像 Registry（可选）", "Image registry (optional)")
 	case fieldGuestImage:
 		return m.text("Guest 镜像（可选）", "Guest image (optional)")
-	case fieldWithUI:
-		return m.text("安装 Web UI", "Install web UI")
-	case fieldPort:
-		return m.text("Web UI 端口", "Web UI port")
 	case fieldGuestPull:
 		return m.text("预拉取 guest 镜像", "Pre-pull guest image")
+	case fieldWithUI:
+		return m.text("安装 Web UI", "Install web UI")
+	case fieldFrontendVersion:
+		return m.text("Web UI 版本", "Web UI version")
+	case fieldPort:
+		return m.text("Web UI 端口", "Web UI port")
 	}
 	return ""
 }
@@ -231,6 +258,10 @@ func (m *model) renderFormField(body *strings.Builder, index int) {
 		body.WriteString("  " + m.renderToggle(field.on, focused) + "\n\n")
 		return
 	}
+	if field.choiceField {
+		body.WriteString("  " + m.renderChoice(field, focused && !disabled) + "\n\n")
+		return
+	}
 	boxStyle := fieldStyle
 	if disabled {
 		boxStyle = disabledField
@@ -245,6 +276,18 @@ func (m *model) renderFormField(body *strings.Builder, index int) {
 		value = mutedStyle.Render(field.input.Value())
 	}
 	body.WriteString(boxStyle.Width(width).Render(value) + "\n\n")
+}
+
+func (m *model) renderChoice(field formField, focused bool) string {
+	if len(field.choices) == 0 {
+		return mutedStyle.Render("‹ " + m.text("正在解析...", "resolving...") + " ›")
+	}
+	value := field.choices[field.choice]
+	rendered := "‹ " + value + " ›"
+	if focused {
+		return selectedStyle.Render(rendered) + mutedStyle.Render("  "+m.text("←→ / 空格切换", "←→ / space selects"))
+	}
+	return mutedStyle.Render(rendered)
 }
 
 func (m *model) renderToggle(on, focused bool) string {

--- a/cmd/installer/internal/tui/model.go
+++ b/cmd/installer/internal/tui/model.go
@@ -204,7 +204,11 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if key.String() == "left" || key.String() == "right" || key.String() == " " {
-			if m.toggleFocusedField() {
+			delta := 1
+			if key.String() == "left" {
+				delta = -1
+			}
+			if m.toggleFocusedField(delta) {
 				return m, nil
 			}
 		}
@@ -228,7 +232,7 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.resolveRelease(m.options.Version, true)
 		}
-		if m.fields[m.focus].toggle {
+		if m.fields[m.focus].toggle || m.fields[m.focus].choiceField {
 			return m, nil
 		}
 		var cmd tea.Cmd
@@ -260,7 +264,7 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func isImageField(id fieldID) bool {
-	return id == fieldBackendImage || id == fieldFrontendImage || id == fieldGuestImage
+	return id == fieldGuestImage
 }
 
 func (m *model) updateMenu(key tea.KeyMsg, count int, selectFn func(int)) (tea.Model, tea.Cmd) {
@@ -360,11 +364,11 @@ func (m *model) renderMenu(body *strings.Builder, title string, choices []string
 func (m *model) formHeading() (string, string) {
 	switch m.operation {
 	case core.OperationUpgrade:
-		return m.text("配置升级", "Configure upgrade"), m.text("确认安装位置、目标版本和可选镜像覆盖", "Review the location, target version, and optional image overrides")
+		return m.text("配置升级", "Configure upgrade"), m.text("确认安装位置、目标版本、Registry 和可选镜像覆盖", "Review the location, target version, registry, and optional image overrides")
 	case core.OperationUninstall:
 		return m.text("选择安装位置", "Select installation"), m.text("指定要卸载的 agent-compose 目录", "Choose the agent-compose directory to uninstall")
 	default:
-		return m.text("配置安装", "Configure installation"), m.text("确认安装位置、发布版本、镜像和 Web UI", "Review the location, release, images, and web UI")
+		return m.text("配置安装", "Configure installation"), m.text("确认安装位置、发布版本、Registry 和 Web UI", "Review the location, release, registry, and web UI")
 	}
 }
 
@@ -375,11 +379,17 @@ func (m *model) renderConfirm(body *strings.Builder) {
 		fmt.Fprintf(body, "  %s: %t\n", m.text("删除数据", "Purge data"), m.options.Purge)
 	} else {
 		fmt.Fprintf(body, "  %s: %s\n", m.text("版本", "Version"), m.options.Version)
+		registry := m.preview.Registry
+		if registry == "" {
+			registry = m.text("docker.io（默认）", "docker.io (default)")
+		}
+		fmt.Fprintf(body, "  %s: %s\n", m.text("镜像 Registry", "Image registry"), registry)
 		fmt.Fprintf(body, "  %s: %s\n", m.text("后端镜像", "Backend image"), m.imageSelection(m.preview.Backend))
-		fmt.Fprintf(body, "  %s: %s\n", m.text("前端镜像", "Frontend image"), m.imageSelection(m.preview.Frontend))
 		fmt.Fprintf(body, "  %s: %s\n", m.text("Guest 镜像", "Guest image"), m.imageSelection(m.preview.Guest))
 		fmt.Fprintf(body, "  %s: %s\n", m.text("安装 Web UI", "Install web UI"), m.yesNo(m.options.WithUI))
 		if m.options.WithUI {
+			fmt.Fprintf(body, "  %s: %s\n", m.text("Web UI 版本", "Web UI version"), m.preview.FrontendVersion)
+			fmt.Fprintf(body, "  %s: %s\n", m.text("前端镜像", "Frontend image"), m.imageSelection(m.preview.Frontend))
 			fmt.Fprintf(body, "  %s: %d\n", m.text("Web UI 端口", "Web UI port"), m.options.Port)
 		}
 		fmt.Fprintf(body, "  %s: %s\n", m.text("预拉取 guest 镜像", "Pre-pull guest image"), m.yesNo(!m.options.SkipGuestPull))

--- a/cmd/installer/internal/tui/model.go
+++ b/cmd/installer/internal/tui/model.go
@@ -238,7 +238,7 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		before := m.fields[m.focus].input.Value()
 		m.fields[m.focus].input, cmd = m.fields[m.focus].input.Update(key)
-		if isImageField(m.fields[m.focus].id) && m.fields[m.focus].input.Value() != before {
+		if tracksExplicitInput(m.fields[m.focus].id) && m.fields[m.focus].input.Value() != before {
 			m.fields[m.focus].followsRelease = false
 		}
 		return m, cmd
@@ -263,8 +263,8 @@ func (m *model) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func isImageField(id fieldID) bool {
-	return id == fieldGuestImage
+func tracksExplicitInput(id fieldID) bool {
+	return id == fieldRegistry || id == fieldGuestImage
 }
 
 func (m *model) updateMenu(key tea.KeyMsg, count int, selectFn func(int)) (tea.Model, tea.Cmd) {

--- a/cmd/installer/internal/tui/model_test.go
+++ b/cmd/installer/internal/tui/model_test.go
@@ -66,7 +66,9 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 
 func TestModelReadsRegistryGuestAndFrontendVersion(t *testing.T) {
 	m := installForm(t)
-	m.field(fieldRegistry).input.SetValue(" registry.example.com ")
+	registry := m.field(fieldRegistry)
+	registry.input.SetValue(" registry.example.com ")
+	registry.followsRelease = false
 	setExplicitImage(t, m, fieldGuestImage, "registry.example/guest:v2")
 	m.field(fieldWithUI).on = true
 	frontend := m.field(fieldFrontendVersion)
@@ -89,6 +91,37 @@ func TestModelReadsRegistryGuestAndFrontendVersion(t *testing.T) {
 		if !strings.Contains(confirmation, value) {
 			t.Fatalf("confirmation missing %q:\n%s", value, confirmation)
 		}
+	}
+}
+
+func TestModelCanClearPersistedRegistry(t *testing.T) {
+	m := installForm(t)
+	m.operation = core.OperationUpgrade
+	installDir := m.options.InstallDir
+	writeTUITestFile(t, filepath.Join(installDir, ".env"), "AGENT_COMPOSE_IMAGE=mirror.example/agent-compose:v1\nAGENT_COMPOSE_FRONTEND_VERSION=ui-v1\nAGENT_COMPOSE_FRONTEND_IMAGE=mirror.example/agent-compose-ui:ui-v1\nDEFAULT_IMAGE=mirror.example/agent-compose-guest:v1\n")
+	writeTUITestFile(t, filepath.Join(installDir, ".installer-state.env"), "INSTALLER_REGISTRY=mirror.example\nINSTALLER_FRONTEND_VERSION=ui-v1\nAGENT_COMPOSE_IMAGE=mirror.example/agent-compose:v1\nAGENT_COMPOSE_FRONTEND_VERSION=ui-v1\nAGENT_COMPOSE_FRONTEND_IMAGE=mirror.example/agent-compose-ui:ui-v1\nDEFAULT_IMAGE=mirror.example/agent-compose-guest:v1\n")
+	m.syncReleaseImageFields()
+	registry := m.field(fieldRegistry)
+	if got := registry.input.Value(); got != "mirror.example" || !registry.followsRelease {
+		t.Fatalf("persisted registry = %q, follows release = %t", got, registry.followsRelease)
+	}
+
+	m.focus = indexOfField(t, m, fieldRegistry)
+	m.focusFields()
+	m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	if registry.input.Value() != "" || registry.followsRelease {
+		t.Fatalf("cleared registry = %q, follows release = %t", registry.input.Value(), registry.followsRelease)
+	}
+	press(t, m, "enter")
+
+	if !m.options.RegistrySet || m.options.Registry != "" {
+		t.Fatalf("registry reset = %q, set = %t", m.options.Registry, m.options.RegistrySet)
+	}
+	if m.err != nil || m.screen != screenConfirm {
+		t.Fatalf("registry reset did not reach confirmation: screen=%d err=%v", m.screen, m.err)
+	}
+	if m.preview.Registry != "" || m.preview.Backend.Value != "registry.example/agent-compose:v1" {
+		t.Fatalf("registry reset preview = %#v", m.preview)
 	}
 }
 

--- a/cmd/installer/internal/tui/model_test.go
+++ b/cmd/installer/internal/tui/model_test.go
@@ -148,6 +148,64 @@ func TestModelVersionChangePreservesExplicitImage(t *testing.T) {
 	}
 }
 
+func TestModelVersionChangePreservesSupportedExplicitFrontendVersion(t *testing.T) {
+	m := installForm(t)
+	frontend := m.field(fieldFrontendVersion)
+	frontend.choice = 1
+	frontend.followsRelease = false
+	m.options.BundleDir = makeTUITestBundleWithFrontendVersions(t, "v2", "ui-v2", "ui-v2", "ui-v1-legacy")
+
+	resolveVersionChange(t, m, "v2")
+
+	if got := selectedChoice(frontend); got != "ui-v1-legacy" || frontend.followsRelease {
+		t.Fatalf("frontend version = %q, follows release = %t", got, frontend.followsRelease)
+	}
+	if !m.options.FrontendVersionSet || m.options.FrontendVersion != "ui-v1-legacy" {
+		t.Fatalf("frontend option = %q, set = %t", m.options.FrontendVersion, m.options.FrontendVersionSet)
+	}
+}
+
+func TestModelVersionChangeReplacesUnsupportedExplicitFrontendVersion(t *testing.T) {
+	m := installForm(t)
+	m.field(fieldWithUI).on = true
+	frontend := m.field(fieldFrontendVersion)
+	frontend.choice = 1
+	frontend.followsRelease = false
+	if err := m.readFields(); err != nil {
+		t.Fatal(err)
+	}
+	m.options.BundleDir = makeTUITestBundle(t, "v2", "ui-v2")
+	m.field(fieldVersion).input.SetValue("v2")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("version change did not start resolution")
+	}
+	m.Update(cmd())
+
+	if got := selectedChoice(frontend); got != "ui-v2" || frontend.followsRelease {
+		t.Fatalf("frontend version = %q, follows release = %t", got, frontend.followsRelease)
+	}
+	if !m.options.FrontendVersionSet || m.options.FrontendVersion != "ui-v2" {
+		t.Fatalf("frontend option = %q, set = %t", m.options.FrontendVersion, m.options.FrontendVersionSet)
+	}
+	if m.err != nil || m.screen != screenConfirm {
+		t.Fatalf("fallback frontend version did not reach confirmation: screen=%d err=%v", m.screen, m.err)
+	}
+}
+
+func resolveVersionChange(t *testing.T, m *model, version string) {
+	t.Helper()
+	m.focus = indexOfField(t, m, fieldVersion)
+	m.focusFields()
+	m.field(fieldVersion).input.SetValue(version)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if cmd == nil {
+		t.Fatal("version change did not start resolution")
+	}
+	m.Update(cmd())
+}
+
 func setExplicitImage(t *testing.T, m *model, id fieldID, value string) {
 	t.Helper()
 	field := m.field(id)
@@ -325,13 +383,18 @@ func attachTestRelease(t *testing.T, m *model, version, frontendVersion string) 
 
 func makeTUITestBundle(t *testing.T, version, frontendVersion string) string {
 	t.Helper()
+	return makeTUITestBundleWithFrontendVersions(t, version, frontendVersion, frontendVersion, frontendVersion+"-legacy")
+}
+
+func makeTUITestBundleWithFrontendVersions(t *testing.T, version, frontendVersion string, frontendVersions ...string) string {
+	t.Helper()
 	dir := t.TempDir()
 	writeTUITestFile(t, filepath.Join(dir, "docker-compose.yml"), "services: {}\n")
 	writeTUITestFile(t, filepath.Join(dir, ".env.example"), "AUTH_PASSWORD=\nAUTH_SECRET=\n")
 	manifest := "INSTALLER_PAYLOAD_VERSION=1\n" +
 		"AGENT_COMPOSE_IMAGE=registry.example/agent-compose:" + version + "\n" +
 		"AGENT_COMPOSE_FRONTEND_VERSION=" + frontendVersion + "\n" +
-		"AGENT_COMPOSE_FRONTEND_VERSIONS=" + frontendVersion + "," + frontendVersion + "-legacy\n" +
+		"AGENT_COMPOSE_FRONTEND_VERSIONS=" + strings.Join(frontendVersions, ",") + "\n" +
 		"AGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:" + frontendVersion + "\n" +
 		"DEFAULT_IMAGE=registry.example/agent-compose-guest:" + version + "\n"
 	writeTUITestFile(t, filepath.Join(dir, "images", "manifest.env"), manifest)

--- a/cmd/installer/internal/tui/model_test.go
+++ b/cmd/installer/internal/tui/model_test.go
@@ -27,13 +27,15 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 	}
 	attachTestRelease(t, m, "v1", "ui-v3")
 	form := m.View()
-	for _, expected := range []string{"Configure installation", "Install directory", "Application version", "Backend image (optional)", "Frontend image (optional)", "Guest image (optional)", "Install web UI", "Web UI port", "Pre-pull guest image", "╭", "Tab / ↑↓ move"} {
+	for _, expected := range []string{"Configure installation", "Install directory", "Application version", "Image registry (optional)", "Guest image (optional)", "Pre-pull guest image", "Install web UI", "Web UI version", "Web UI port", "╭", "Tab / ↑↓ move"} {
 		if !strings.Contains(form, expected) {
 			t.Fatalf("install form missing %q:\n%s", expected, form)
 		}
 	}
-	if strings.Contains(form, "Image prefix") {
-		t.Fatalf("advanced image prefix rendered in TUI:\n%s", form)
+	for _, hidden := range []string{"Image prefix", "Backend image (optional)", "Frontend image (optional)"} {
+		if strings.Contains(form, hidden) {
+			t.Fatalf("hidden image control %q rendered in TUI:\n%s", hidden, form)
+		}
 	}
 	m.fields[0].input.SetValue("relative")
 	press(t, m, "enter")
@@ -47,36 +49,45 @@ func TestModelSelectsLanguageAndInstallFlow(t *testing.T) {
 		t.Fatalf("screen = %d, want confirmation", m.screen)
 	}
 	confirmation := m.View()
-	for _, expected := range []string{installDir, "latest", "Backend image: registry.example/agent-compose:v1", "Frontend image: registry.example/agent-compose-ui:ui-v3", "Guest image: registry.example/agent-compose-guest:v1", "release default", "Install web UI: No", "Pre-pull guest image: Yes"} {
+	for _, expected := range []string{installDir, "latest", "Image registry: docker.io (default)", "Backend image: registry.example/agent-compose:v1", "Guest image: registry.example/agent-compose-guest:v1", "release default", "Install web UI: No", "Pre-pull guest image: Yes"} {
 		if !strings.Contains(confirmation, expected) {
 			t.Fatalf("confirmation missing %q:\n%s", expected, confirmation)
 		}
 	}
-	if strings.Contains(confirmation, "Web UI port") {
-		t.Fatalf("confirmation offered a port without the web UI:\n%s", confirmation)
+	if m.options.RegistrySet {
+		t.Fatal("default Registry hint was treated as an explicit image rewrite")
+	}
+	for _, absent := range []string{"Web UI port", "Frontend image", "Web UI version"} {
+		if strings.Contains(confirmation, absent) {
+			t.Fatalf("confirmation offered %q without the web UI:\n%s", absent, confirmation)
+		}
 	}
 }
 
-func TestModelReadsExplicitImageOverrides(t *testing.T) {
+func TestModelReadsRegistryGuestAndFrontendVersion(t *testing.T) {
 	m := installForm(t)
-	setExplicitImage(t, m, fieldBackendImage, " registry.example/backend:v1 ")
-	setExplicitImage(t, m, fieldFrontendImage, "registry.example/frontend@sha256:abc")
+	m.field(fieldRegistry).input.SetValue(" registry.example.com ")
 	setExplicitImage(t, m, fieldGuestImage, "registry.example/guest:v2")
+	m.field(fieldWithUI).on = true
+	frontend := m.field(fieldFrontendVersion)
+	frontend.choices = []string{"ui-v3", "ui-v3-legacy"}
+	frontend.choice = 1
+	frontend.followsRelease = false
 
 	press(t, m, "enter")
-	if !m.options.BackendImageSet || m.options.BackendImage != "registry.example/backend:v1" {
-		t.Fatalf("backend image = %q, set=%t", m.options.BackendImage, m.options.BackendImageSet)
-	}
-	if !m.options.FrontendImageSet || m.options.FrontendImage != "registry.example/frontend@sha256:abc" {
-		t.Fatalf("frontend image = %q, set=%t", m.options.FrontendImage, m.options.FrontendImageSet)
+	if !m.options.RegistrySet || m.options.Registry != "registry.example.com" {
+		t.Fatalf("registry = %q, set=%t", m.options.Registry, m.options.RegistrySet)
 	}
 	if !m.options.GuestImageSet || m.options.GuestImage != "registry.example/guest:v2" {
 		t.Fatalf("guest image = %q, set=%t", m.options.GuestImage, m.options.GuestImageSet)
 	}
+	if !m.options.FrontendVersionSet || m.options.FrontendVersion != "ui-v3-legacy" {
+		t.Fatalf("frontend version = %q, set=%t", m.options.FrontendVersion, m.options.FrontendVersionSet)
+	}
 	confirmation := m.View()
-	for _, image := range []string{m.options.BackendImage, m.options.FrontendImage, m.options.GuestImage} {
-		if !strings.Contains(confirmation, image) {
-			t.Fatalf("confirmation missing %q:\n%s", image, confirmation)
+	for _, value := range []string{"registry.example.com", m.options.GuestImage, "ui-v3-legacy"} {
+		if !strings.Contains(confirmation, value) {
+			t.Fatalf("confirmation missing %q:\n%s", value, confirmation)
 		}
 	}
 }
@@ -104,13 +115,12 @@ func TestModelResolvesImagesWhenVersionLosesFocus(t *testing.T) {
 	message := cmd()
 	m.Update(message)
 	view := m.View()
-	for _, image := range []string{
-		"registry.example/agent-compose:v2",
-		"registry.example/agent-compose-ui:ui-v4",
+	for _, value := range []string{
+		"ui-v4",
 		"registry.example/agent-compose-guest:v2",
 	} {
-		if !strings.Contains(view, image) {
-			t.Fatalf("resolved form is missing %q:\n%s", image, view)
+		if !strings.Contains(view, value) {
+			t.Fatalf("resolved form is missing %q:\n%s", value, view)
 		}
 	}
 }
@@ -128,12 +138,13 @@ func TestModelVersionChangePreservesExplicitImage(t *testing.T) {
 	}
 	m.Update(cmd())
 
-	if got := m.field(fieldBackendImage).input.Value(); got != "registry.example/agent-compose:v2" {
-		t.Fatalf("backend image = %q", got)
-	}
 	guest := m.field(fieldGuestImage)
 	if got := guest.input.Value(); got != "operator.example/guest:keep" || guest.followsRelease {
 		t.Fatalf("guest image = %q, follows release = %t", got, guest.followsRelease)
+	}
+	frontend := m.field(fieldFrontendVersion)
+	if frontend.choices[frontend.choice] != "ui-v4" || !frontend.followsRelease {
+		t.Fatalf("frontend choice = %#v, index=%d, follows=%t", frontend.choices, frontend.choice, frontend.followsRelease)
 	}
 }
 
@@ -175,11 +186,11 @@ func TestModelPortFollowsWebUIToggle(t *testing.T) {
 		t.Fatalf("disabled port is not marked in the form:\n%s", form)
 	}
 
-	// Tab from the UI toggle must land past the disabled port.
+	// Tab from the UI toggle must land past both disabled frontend fields.
 	m.focus = indexOfField(t, m, fieldWithUI)
 	m.moveFocus(1)
-	if m.fields[m.focus].id != fieldGuestPull {
-		t.Fatalf("focus stopped on field %d, want the guest toggle", m.fields[m.focus].id)
+	if m.fields[m.focus].id != fieldInstallDir {
+		t.Fatalf("focus stopped on field %d, want the first enabled field", m.fields[m.focus].id)
 	}
 
 	m.focus = indexOfField(t, m, fieldWithUI)
@@ -188,8 +199,8 @@ func TestModelPortFollowsWebUIToggle(t *testing.T) {
 		t.Fatal("port stayed disabled after enabling the web UI")
 	}
 	m.moveFocus(1)
-	if m.fields[m.focus].id != fieldPort {
-		t.Fatalf("focus skipped the re-enabled port, landed on %d", m.fields[m.focus].id)
+	if m.fields[m.focus].id != fieldFrontendVersion {
+		t.Fatalf("focus skipped the re-enabled frontend version, landed on %d", m.fields[m.focus].id)
 	}
 
 	press(t, m, "enter")
@@ -198,6 +209,36 @@ func TestModelPortFollowsWebUIToggle(t *testing.T) {
 	}
 	if confirmation := m.View(); !strings.Contains(confirmation, "Web UI port") {
 		t.Fatalf("confirmation hid the port with the web UI enabled:\n%s", confirmation)
+	}
+}
+
+func TestModelFrontendVersionChoiceUsesReleaseOrder(t *testing.T) {
+	m := installForm(t)
+	m.field(fieldWithUI).on = true
+	frontend := m.field(fieldFrontendVersion)
+	if got := frontend.choices[frontend.choice]; got != "ui-v1" {
+		t.Fatalf("default frontend version = %q", got)
+	}
+	m.focus = indexOfField(t, m, fieldFrontendVersion)
+	press(t, m, "right")
+	if got := frontend.choices[frontend.choice]; got != "ui-v1-legacy" || frontend.followsRelease {
+		t.Fatalf("next frontend version = %q, follows=%t", got, frontend.followsRelease)
+	}
+	press(t, m, "left")
+	if got := frontend.choices[frontend.choice]; got != "ui-v1" {
+		t.Fatalf("previous frontend version = %q", got)
+	}
+}
+
+func TestModelKeepsFrontendVersionChosenBeforeDisablingUI(t *testing.T) {
+	m := installForm(t)
+	m.field(fieldWithUI).on = true
+	m.focus = indexOfField(t, m, fieldFrontendVersion)
+	press(t, m, "right")
+	m.field(fieldWithUI).on = false
+	press(t, m, "enter")
+	if m.options.WithUI || !m.options.FrontendVersionSet || m.options.FrontendVersion != "ui-v1-legacy" {
+		t.Fatalf("WithUI=%t frontend=%q set=%t", m.options.WithUI, m.options.FrontendVersion, m.options.FrontendVersionSet)
 	}
 }
 
@@ -253,12 +294,14 @@ func TestModelEnabledPortIsValidated(t *testing.T) {
 func installForm(t *testing.T) *model {
 	t.Helper()
 	m := newModel(core.Service{}, core.DefaultOptions(), "/tmp/installer")
+	m.options.InstallDir = t.TempDir()
 	press(t, m, "down")
 	press(t, m, "enter")
 	press(t, m, "enter")
 	if m.screen != screenForm {
 		t.Fatalf("screen = %d, want the install form", m.screen)
 	}
+	m.field(fieldInstallDir).input.SetValue(m.options.InstallDir)
 	attachTestRelease(t, m, "v1", "ui-v1")
 	return m
 }
@@ -288,6 +331,7 @@ func makeTUITestBundle(t *testing.T, version, frontendVersion string) string {
 	manifest := "INSTALLER_PAYLOAD_VERSION=1\n" +
 		"AGENT_COMPOSE_IMAGE=registry.example/agent-compose:" + version + "\n" +
 		"AGENT_COMPOSE_FRONTEND_VERSION=" + frontendVersion + "\n" +
+		"AGENT_COMPOSE_FRONTEND_VERSIONS=" + frontendVersion + "," + frontendVersion + "-legacy\n" +
 		"AGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose-ui:" + frontendVersion + "\n" +
 		"DEFAULT_IMAGE=registry.example/agent-compose-guest:" + version + "\n"
 	writeTUITestFile(t, filepath.Join(dir, "images", "manifest.env"), manifest)

--- a/cmd/installer/internal/tui/release.go
+++ b/cmd/installer/internal/tui/release.go
@@ -92,13 +92,16 @@ func (m *model) syncReleaseImageFields() {
 	if m.release == nil {
 		return
 	}
+	preview, previewErr := m.service.PreviewImages(m.operation, m.options, m.release)
+	guestImage := m.release.Images.Guest
+	if previewErr == nil && preview.Guest.Value != "" {
+		guestImage = preview.Guest.Value
+	}
 	for _, item := range []struct {
 		id    fieldID
 		value string
 	}{
-		{id: fieldBackendImage, value: m.release.Images.Backend},
-		{id: fieldFrontendImage, value: m.release.Images.Frontend},
-		{id: fieldGuestImage, value: m.release.Images.Guest},
+		{id: fieldGuestImage, value: guestImage},
 	} {
 		field := m.field(item.id)
 		if field == nil || (!field.followsRelease && strings.TrimSpace(field.input.Value()) != "") {
@@ -107,6 +110,26 @@ func (m *model) syncReleaseImageFields() {
 		field.input.SetValue(item.value)
 		field.followsRelease = true
 	}
+	if registry := m.field(fieldRegistry); registry != nil && previewErr == nil && strings.TrimSpace(registry.input.Value()) == "" {
+		registry.input.SetValue(preview.Registry)
+	}
+	frontend := m.field(fieldFrontendVersion)
+	if frontend == nil {
+		return
+	}
+	selected := m.release.DefaultFrontendVersion
+	if previewErr == nil && preview.FrontendVersion != "" {
+		selected = preview.FrontendVersion
+	}
+	frontend.choices = append(frontend.choices[:0], m.release.FrontendVersions...)
+	frontend.choice = 0
+	for index, version := range frontend.choices {
+		if version == selected {
+			frontend.choice = index
+			break
+		}
+	}
+	frontend.followsRelease = true
 }
 
 func (m *model) showConfirmation() {

--- a/cmd/installer/internal/tui/release.go
+++ b/cmd/installer/internal/tui/release.go
@@ -110,7 +110,7 @@ func (m *model) syncReleaseImageFields() {
 		field.input.SetValue(item.value)
 		field.followsRelease = true
 	}
-	if registry := m.field(fieldRegistry); registry != nil && previewErr == nil && strings.TrimSpace(registry.input.Value()) == "" {
+	if registry := m.field(fieldRegistry); registry != nil && registry.followsRelease && previewErr == nil && strings.TrimSpace(registry.input.Value()) == "" {
 		registry.input.SetValue(preview.Registry)
 	}
 	frontend := m.field(fieldFrontendVersion)

--- a/cmd/installer/internal/tui/release.go
+++ b/cmd/installer/internal/tui/release.go
@@ -117,19 +117,59 @@ func (m *model) syncReleaseImageFields() {
 	if frontend == nil {
 		return
 	}
+	previousSelection := selectedChoice(frontend)
+	previousExplicit := !frontend.followsRelease
 	selected := m.release.DefaultFrontendVersion
 	if previewErr == nil && preview.FrontendVersion != "" {
 		selected = preview.FrontendVersion
 	}
 	frontend.choices = append(frontend.choices[:0], m.release.FrontendVersions...)
-	frontend.choice = 0
-	for index, version := range frontend.choices {
-		if version == selected {
-			frontend.choice = index
-			break
-		}
+	frontend.choice = choiceIndex(frontend.choices, selected)
+	if frontend.choice < 0 {
+		frontend.choice = 0
 	}
 	frontend.followsRelease = true
+
+	if previousExplicit {
+		if index := choiceIndex(frontend.choices, previousSelection); index >= 0 {
+			frontend.choice = index
+			frontend.followsRelease = false
+			m.options.FrontendVersion = previousSelection
+			m.options.FrontendVersionSet = true
+			return
+		}
+		m.fallbackToDefaultFrontendVersion(frontend)
+		return
+	}
+	if previewErr != nil && m.options.FrontendVersionSet && choiceIndex(frontend.choices, m.options.FrontendVersion) < 0 {
+		m.fallbackToDefaultFrontendVersion(frontend)
+	}
+}
+
+func (m *model) fallbackToDefaultFrontendVersion(frontend *formField) {
+	frontend.choice = choiceIndex(frontend.choices, m.release.DefaultFrontendVersion)
+	if frontend.choice < 0 {
+		frontend.choice = 0
+	}
+	frontend.followsRelease = false
+	m.options.FrontendVersion = m.release.DefaultFrontendVersion
+	m.options.FrontendVersionSet = true
+}
+
+func selectedChoice(field *formField) string {
+	if field.choice < 0 || field.choice >= len(field.choices) {
+		return ""
+	}
+	return field.choices[field.choice]
+}
+
+func choiceIndex(choices []string, selected string) int {
+	for index, choice := range choices {
+		if choice == selected {
+			return index
+		}
+	}
+	return -1
 }
 
 func (m *model) showConfirmation() {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,14 +34,14 @@ The bootstrap forwards all arguments to the downloaded binary:
 curl -fsSL https://github.com/chaitin/agent-compose/releases/download/installer-latest/install.sh | \
   sudo bash -s -- install --yes
 
-# Select a release, directory, UI port, or complete image references.
+# Select a release, directory, registry, supported UI version, or guest image.
 sudo /opt/agent-compose/installer install \
   --version v1.2.3 \
   --dir /srv/agent-compose \
+  --registry registry.example.com \
   --with-ui \
+  --frontend-version v2 \
   --port 8080 \
-  --backend-image registry.example.com/team/agent-compose:v1.2.3 \
-  --frontend-image registry.example.com/team/agent-compose-ui:v1.2.3 \
   --guest-image registry.example.com/team/agent-compose-guest:v1.2.3 \
   --yes
 
@@ -56,16 +56,19 @@ sudo /opt/agent-compose/installer install --no-start --yes
 ```
 
 The legacy top-level form, including `--upgrade`, `--dir`, `--version`,
-`--image-prefix`, `--no-start`, and `--yes`, remains accepted. `--image-prefix`
-is deprecated; use the three complete image options when selecting a mirror or
-custom image. New automation should use the explicit `install`, `upgrade`, and
-`uninstall` subcommands.
+`--image-prefix`, `--backend-image`, `--frontend-image`, `--no-start`, and
+`--yes`, remains accepted for existing automation. These compatibility image
+flags are hidden from help. New automation should use `--registry`,
+`--frontend-version`, `--guest-image`, and the explicit `install`, `upgrade`,
+and `uninstall` subcommands. `--registry` and `--image-prefix` are mutually
+exclusive.
 
 Environment overrides retained for automation are:
 
 - `AGENT_COMPOSE_REPO`: GitHub repository used for downloads;
 - `AGENT_COMPOSE_INSTALL_DIR`: default installation directory;
-- `AGENT_COMPOSE_FRONTEND_VERSION`: frontend tag used with an image prefix;
+- `AGENT_COMPOSE_FRONTEND_VERSION`: supported frontend tag selected by legacy
+  automation;
 - `AGENT_COMPOSE_YES=1`: skip confirmation;
 - `AGENT_COMPOSE_INSTALLER_RELEASE`: bootstrap release tag, primarily for
   mirrors and release verification.
@@ -91,17 +94,28 @@ password. The password is printed once and stored in `.env`. Existing settings
 are preserved. During upgrade, image references advance only when their current
 value still matches `.installer-state.env`; user overrides are never replaced.
 
-The interactive form and non-interactive CLI can independently override the
-backend (`--backend-image`), frontend (`--frontend-image`), and sandbox guest
-(`--guest-image`) image with a complete tag or digest reference. An explicit
-image always replaces that one value and becomes installer-managed, including
-during upgrade. The TUI displays the exact defaults from the selected Release
-manifest and refreshes them when the version field loses focus; an empty image
-field continues to follow that Release. Images omitted from the command retain
-the normal upgrade protection above. If the deprecated `--image-prefix` is
-combined with complete image options, the complete option wins for its image
-and the prefix supplies the omitted images. Without either form of override,
-the Docker Hub references from the selected Release bundle are used.
+The interactive form accepts one optional registry host. It replaces only the
+registry component of all Release-managed references and preserves the full
+repository path, tag, or digest. For example, `chaitin/agent-compose:v1`
+becomes `registry.example.com/chaitin/agent-compose:v1`. This is not a Docker
+registry mirror: transparent mirrors require separate dockerd configuration
+and do not change image references.
+When the field is empty, the TUI displays Docker Hub (`docker.io`) as a hint
+but leaves the Release image references unchanged.
+
+The Release manifest declares a default frontend version and an ordered list
+of supported versions. The TUI presents that list beside the Web UI toggle;
+`--frontend-version` provides the same validated selection for automation. An
+upgrade preserves the selected version while the new Release still supports
+it and stops for an explicit choice otherwise. Releases without a list expose
+their default as the only choice.
+
+The sandbox guest image remains independently configurable with
+`--guest-image`. Hidden compatibility options can still override complete
+backend and frontend references, and a complete reference wins over Registry
+or version-derived values. The legacy `--image-prefix` retains its old
+namespace-prefix behavior. Installer choices are recorded in
+`.installer-state.env` so later upgrades preserve them.
 
 New installations persist `AGENT_COMPOSE_DATA_DIR=./data`. If an older database
 exists only under `./data/agent-compose`, that path is retained. When databases
@@ -178,6 +192,9 @@ application Release.
 Normal application releases contain the architecture-independent deployment
 bundle, bootstrap copy, and bundle checksum. The installer binary need not be
 rebuilt for ordinary application releases unless the payload protocol changes.
+The release workflow reads the optional repository variables
+`AGENT_COMPOSE_FRONTEND_VERSION` and `AGENT_COMPOSE_FRONTEND_VERSIONS`; when
+unset, both default to the single `latest` frontend choice.
 
 ## Contributor verification
 

--- a/scripts/build-installer-assets.sh
+++ b/scripts/build-installer-assets.sh
@@ -8,7 +8,8 @@ usage() {
 usage: build-installer-assets.sh [OUTPUT_DIR]
 
 Build the three GitHub Release installer assets. VERSION and IMAGE_PREFIX must
-be set; AGENT_COMPOSE_FRONTEND_VERSION defaults to latest.
+be set. AGENT_COMPOSE_FRONTEND_VERSION defaults to latest, and
+AGENT_COMPOSE_FRONTEND_VERSIONS defaults to that single version.
 EOF
 }
 
@@ -26,15 +27,29 @@ fi
 VERSION=${VERSION:-}
 IMAGE_PREFIX=${IMAGE_PREFIX:-}
 FRONTEND_VERSION=${AGENT_COMPOSE_FRONTEND_VERSION:-latest}
+FRONTEND_VERSIONS=${AGENT_COMPOSE_FRONTEND_VERSIONS:-$FRONTEND_VERSION}
 OUTPUT_DIR=${1:-"$ROOT_DIR/upload"}
 
 [[ -n $VERSION ]] || die 'VERSION is required'
 [[ -n $IMAGE_PREFIX ]] || die 'IMAGE_PREFIX is required'
-for value_name in VERSION IMAGE_PREFIX FRONTEND_VERSION; do
+for value_name in VERSION IMAGE_PREFIX FRONTEND_VERSION FRONTEND_VERSIONS; do
   value=${!value_name}
   [[ $value != *$'\n'* && $value != *$'\r'* ]] \
     || die "$value_name must not contain a newline"
 done
+
+frontend_default_found=false
+IFS=',' read -r -a frontend_versions <<<"$FRONTEND_VERSIONS"
+declare -A seen_frontend_versions=()
+for frontend_version in "${frontend_versions[@]}"; do
+  [[ $frontend_version =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]] \
+    || die "invalid frontend version: $frontend_version"
+  [[ -z ${seen_frontend_versions[$frontend_version]:-} ]] \
+    || die "duplicate frontend version: $frontend_version"
+  seen_frontend_versions[$frontend_version]=1
+  [[ $frontend_version != "$FRONTEND_VERSION" ]] || frontend_default_found=true
+done
+$frontend_default_found || die 'AGENT_COMPOSE_FRONTEND_VERSION must be listed in AGENT_COMPOSE_FRONTEND_VERSIONS'
 
 for command_name in gzip sha256sum tar; do
   command -v "$command_name" >/dev/null 2>&1 \
@@ -71,6 +86,7 @@ install -m 0644 "$ROOT_DIR/.env.example" "$payload/.env.example"
   printf 'INSTALLER_PAYLOAD_VERSION=1\n'
   printf 'AGENT_COMPOSE_IMAGE=%s/agent-compose:%s\n' "$IMAGE_PREFIX" "$VERSION"
   printf 'AGENT_COMPOSE_FRONTEND_VERSION=%s\n' "$FRONTEND_VERSION"
+  printf 'AGENT_COMPOSE_FRONTEND_VERSIONS=%s\n' "$FRONTEND_VERSIONS"
   printf 'AGENT_COMPOSE_FRONTEND_IMAGE=%s/agent-compose-ui:%s\n' "$IMAGE_PREFIX" "$FRONTEND_VERSION"
   printf 'DEFAULT_IMAGE=%s/agent-compose-guest:%s\n' "$IMAGE_PREFIX" "$VERSION"
 } >"$payload/images/manifest.env"

--- a/scripts/build-installer-assets.sh
+++ b/scripts/build-installer-assets.sh
@@ -39,6 +39,8 @@ for value_name in VERSION IMAGE_PREFIX FRONTEND_VERSION FRONTEND_VERSIONS; do
 done
 
 frontend_default_found=false
+[[ $FRONTEND_VERSIONS != ,* && $FRONTEND_VERSIONS != *, && $FRONTEND_VERSIONS != *,,* ]] \
+  || die 'AGENT_COMPOSE_FRONTEND_VERSIONS must not contain empty entries'
 IFS=',' read -r -a frontend_versions <<<"$FRONTEND_VERSIONS"
 declare -A seen_frontend_versions=()
 for frontend_version in "${frontend_versions[@]}"; do

--- a/scripts/demo-installer-docker.sh
+++ b/scripts/demo-installer-docker.sh
@@ -86,6 +86,7 @@ build_bundle() {
     printf 'INSTALLER_PAYLOAD_VERSION=1\n'
     printf 'AGENT_COMPOSE_IMAGE=%s\n' "$image"
     printf 'AGENT_COMPOSE_FRONTEND_VERSION=%s\n' "$version"
+    printf 'AGENT_COMPOSE_FRONTEND_VERSIONS=%s\n' "$version"
     printf 'AGENT_COMPOSE_FRONTEND_IMAGE=%s\n' "$image"
     printf 'DEFAULT_IMAGE=%s\n' "$image"
   } >"$payload/images/manifest.env"

--- a/scripts/tests/test-image-ci-contract.sh
+++ b/scripts/tests/test-image-ci-contract.sh
@@ -365,6 +365,10 @@ if [[ -n $release_job ]]; then
     'version-tag-only release guard'
   require_regex "$release_job" '\./scripts/build-installer-assets\.sh[[:space:]]+\./upload' \
     'shared installer asset builder in release job'
+  require_regex "$release_job" 'AGENT_COMPOSE_FRONTEND_VERSION:.*vars\.AGENT_COMPOSE_FRONTEND_VERSION' \
+    'release frontend default version input'
+  require_regex "$release_job" 'AGENT_COMPOSE_FRONTEND_VERSIONS:.*vars\.AGENT_COMPOSE_FRONTEND_VERSIONS' \
+    'release supported frontend versions input'
   require_regex "$release_job" 'gh release (upload|create).*upload/\*' \
     'release publication from installer output only'
   forbid_regex "$release_job" 'build/agent-compose|build-agent-compose-binary|agent-compose-(darwin|linux)-(amd64|arm64)' \

--- a/scripts/tests/test-installer-assets.sh
+++ b/scripts/tests/test-installer-assets.sh
@@ -23,6 +23,7 @@ build_assets() {
   VERSION=v9.8.7 \
     IMAGE_PREFIX=registry.example/agent-compose \
     AGENT_COMPOSE_FRONTEND_VERSION=v-ui-test \
+    AGENT_COMPOSE_FRONTEND_VERSIONS=v-ui-test,v-ui-legacy \
     "$BUILDER" "$output" >/dev/null
 }
 
@@ -89,7 +90,7 @@ grep -Fxq 'AUTH_PASSWORD=' "$payload/.env.example" \
 grep -Fxq 'AUTH_SECRET=' "$payload/.env.example" \
   || fail '.env.example must keep AUTH_SECRET empty'
 
-expected_manifest=$'INSTALLER_PAYLOAD_VERSION=1\nAGENT_COMPOSE_IMAGE=registry.example/agent-compose/agent-compose:v9.8.7\nAGENT_COMPOSE_FRONTEND_VERSION=v-ui-test\nAGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose/agent-compose-ui:v-ui-test\nDEFAULT_IMAGE=registry.example/agent-compose/agent-compose-guest:v9.8.7'
+expected_manifest=$'INSTALLER_PAYLOAD_VERSION=1\nAGENT_COMPOSE_IMAGE=registry.example/agent-compose/agent-compose:v9.8.7\nAGENT_COMPOSE_FRONTEND_VERSION=v-ui-test\nAGENT_COMPOSE_FRONTEND_VERSIONS=v-ui-test,v-ui-legacy\nAGENT_COMPOSE_FRONTEND_IMAGE=registry.example/agent-compose/agent-compose-ui:v-ui-test\nDEFAULT_IMAGE=registry.example/agent-compose/agent-compose-guest:v9.8.7'
 actual_manifest=$(<"$payload/images/manifest.env")
 [[ $actual_manifest == "$expected_manifest" ]] \
   || fail "image manifest differs: $actual_manifest"
@@ -105,5 +106,14 @@ if build_assets "$nonempty" >/dev/null 2>&1; then
   fail 'builder accepted a pre-existing output path with stale assets'
 fi
 [[ -f $nonempty/stale-binary ]] || fail 'builder modified rejected output path'
+
+invalid_versions="$TEST_ROOT/invalid-versions"
+if VERSION=v9.8.7 IMAGE_PREFIX=registry.example \
+  AGENT_COMPOSE_FRONTEND_VERSION=v3 \
+  AGENT_COMPOSE_FRONTEND_VERSIONS=v1,v2 \
+  "$BUILDER" "$invalid_versions" >/dev/null 2>&1; then
+  fail 'builder accepted a frontend default outside the supported list'
+fi
+[[ ! -e $invalid_versions ]] || fail 'invalid frontend versions left an output directory'
 
 printf 'test-installer-assets: all checks passed\n'

--- a/scripts/tests/test-installer-assets.sh
+++ b/scripts/tests/test-installer-assets.sh
@@ -116,4 +116,15 @@ if VERSION=v9.8.7 IMAGE_PREFIX=registry.example \
 fi
 [[ ! -e $invalid_versions ]] || fail 'invalid frontend versions left an output directory'
 
+for invalid_list in ',v1' 'v1,' 'v1,,v2'; do
+  invalid_output="$TEST_ROOT/invalid-list-${invalid_list//,/_}"
+  if VERSION=v9.8.7 IMAGE_PREFIX=registry.example \
+    AGENT_COMPOSE_FRONTEND_VERSION=v1 \
+    AGENT_COMPOSE_FRONTEND_VERSIONS="$invalid_list" \
+    "$BUILDER" "$invalid_output" >/dev/null 2>&1; then
+    fail "builder accepted an empty frontend version in $invalid_list"
+  fi
+  [[ ! -e $invalid_output ]] || fail "invalid frontend list $invalid_list left an output directory"
+done
+
 printf 'test-installer-assets: all checks passed\n'


### PR DESCRIPTION
## Summary

- replace editable backend images with a host-only Registry setting that preserves release repository paths
- add release-backed Web UI version choices and group them with the UI toggle and port in the TUI
- preserve hidden image-prefix and complete-image CLI compatibility while persisting upgrade selections
- extend release assets, deployment documentation, and migration/interaction coverage

## Testing

- task lint
- task build
- task test
- task test:deploy
- task test:scripts
- generated and verified Linux amd64/arm64 installer binaries with scripts/build-installer-binaries.sh

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.