### PR TITLE
build(images): use official dependency sources

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -38,7 +38,7 @@ env:
   REGISTRY: docker.io
   IMAGE_PREFIX: chaitin
   REGISTRY_MIRROR: docker.io
-  GOPROXY: https://goproxy.cn,direct
+  GOPROXY: https://proxy.golang.org,direct
 
 jobs:
   # Emit the build matrix as JSON: amd64 only on pull requests (fast Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY_MIRROR=docker.io
-ARG GOPROXY=https://goproxy.cn,direct
+ARG GOPROXY=https://proxy.golang.org,direct
 ARG GITHUB_MIRROR=https://github.com
 
 FROM ${REGISTRY_MIRROR}/library/golang:1-alpine AS golang-toolchain
@@ -17,7 +17,6 @@ ENV HTTPS_PROXY=${HTTPS_PROXY}
 ENV ALL_PROXY=${ALL_PROXY}
 ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl python3 tar &&     rm -rf /var/lib/apt/lists/*
 RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     case "${target_arch}" in       amd64) BOXLITE_ARCH=x64 ;;       arm64) BOXLITE_ARCH=arm64 ;;       *) echo "unsupported BoxLite target arch: ${target_arch}" >&2; exit 1 ;;     esac;     mkdir -p /tmp/boxlite/runtime /tmp/boxlite/sdk /out/include /out/lib /out/runtime &&     BOXLITE_RUNTIME_NAME=boxlite-runtime-${BOXLITE_VERSION}-linux-${BOXLITE_ARCH}-gnu.tar.gz &&     BOXLITE_C_NAME=boxlite-c-${BOXLITE_VERSION}-linux-${BOXLITE_ARCH}-gnu.tar.gz &&     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -o /tmp/boxlite/${BOXLITE_RUNTIME_NAME} ${GITHUB_MIRROR}/boxlite-ai/boxlite/releases/download/${BOXLITE_VERSION}/${BOXLITE_RUNTIME_NAME} &&     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -o /tmp/boxlite/${BOXLITE_C_NAME} ${GITHUB_MIRROR}/boxlite-ai/boxlite/releases/download/${BOXLITE_VERSION}/${BOXLITE_C_NAME} &&     tar -xzf /tmp/boxlite/${BOXLITE_RUNTIME_NAME} -C /tmp/boxlite/runtime &&     tar -xzf /tmp/boxlite/${BOXLITE_C_NAME} -C /tmp/boxlite/sdk &&     cp -a /tmp/boxlite/runtime/boxlite-runtime/. /out/runtime/ &&     cp /tmp/boxlite/sdk/*/include/boxlite.h /out/include/boxlite.h &&     cp -a /tmp/boxlite/sdk/*/lib/libboxlite.* /out/lib/
 
@@ -40,7 +39,6 @@ ENV HTTPS_PROXY=${HTTPS_PROXY}
 ENV ALL_PROXY=${ALL_PROXY}
 ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl binutils tar &&     rm -rf /var/lib/apt/lists/*
 RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     case "${target_arch}" in       amd64) MICROSANDBOX_ARCH=x86_64 ;;       arm64) MICROSANDBOX_ARCH=aarch64 ;;       *) echo "unsupported Microsandbox target arch: ${target_arch}" >&2; exit 1 ;;     esac;     base="${GITHUB_MIRROR}/superradcompany/microsandbox/releases/download/${MICROSANDBOX_VERSION}";     mkdir -p /tmp/microsandbox/extract /out/bin /out/lib;     cd /tmp/microsandbox;     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/agentd-${MICROSANDBOX_ARCH}";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/libmicrosandbox_go_ffi-linux-${target_arch}.so";     curl --http1.1 --retry 5 --retry-all-errors --retry-delay 2 -fsSL -O "${base}/checksums.sha256";     sha256sum -c --ignore-missing checksums.sha256;     tar -xzf "microsandbox-linux-${MICROSANDBOX_ARCH}.tar.gz" -C /tmp/microsandbox/extract;     install -m755 /tmp/microsandbox/extract/msb /out/bin/msb;     install -m755 "agentd-${MICROSANDBOX_ARCH}" /out/bin/agentd;     krunfw="$(find /tmp/microsandbox/extract -maxdepth 1 -type f -name 'libkrunfw.so.*' | sort | tail -n 1)";     test -n "${krunfw}";     krunfw_name="$(basename "${krunfw}")";     install -m644 "${krunfw}" "/out/lib/${krunfw_name}";     ln -sf "${krunfw_name}" /out/lib/libkrunfw.so.5;     ln -sf libkrunfw.so.5 /out/lib/libkrunfw.so;     install -m644 "libmicrosandbox_go_ffi-linux-${target_arch}.so" /out/lib/libmicrosandbox_go_ffi.so;     strip --strip-unneeded /out/lib/libmicrosandbox_go_ffi.so 2>/dev/null || true
 
@@ -55,7 +53,6 @@ ENV HTTPS_PROXY=${HTTPS_PROXY}
 ENV ALL_PROXY=${ALL_PROXY}
 ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates curl git tar && rm -rf /var/lib/apt/lists/*
 COPY --from=golang-toolchain /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:${PATH}
@@ -86,7 +83,6 @@ FROM scratch AS agent-compose-artifact
 COPY --from=go-build /out/agent-compose /out/agent-compose
 
 FROM ${REGISTRY_MIRROR}/library/debian:trixie-slim
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update &&     apt-get install -y --no-install-recommends ca-certificates git python3 tini tzdata e2fsprogs qemu-utils &&     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=go-build /out/agent-compose /app/agent-compose

--- a/Dockerfile.agent-compose-local
+++ b/Dockerfile.agent-compose-local
@@ -1,5 +1,5 @@
 ARG REGISTRY_MIRROR=docker.io
-ARG GOPROXY=https://goproxy.cn,direct
+ARG GOPROXY=https://proxy.golang.org,direct
 
 FROM ${REGISTRY_MIRROR}/library/golang:1-alpine AS golang-toolchain
 
@@ -14,7 +14,6 @@ ENV HTTPS_PROXY=${HTTPS_PROXY}
 ENV ALL_PROXY=${ALL_PROXY}
 ENV NO_PROXY=${NO_PROXY}
 ENV no_proxy=${NO_PROXY}
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates curl git tar && rm -rf /var/lib/apt/lists/*
 COPY --from=golang-toolchain /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:${PATH}
@@ -49,7 +48,6 @@ FROM scratch AS agent-compose-artifact
 COPY --from=go-build /out/agent-compose /out/agent-compose
 
 FROM ${REGISTRY_MIRROR}/library/debian:trixie-slim
-RUN if [ -f /etc/apt/sources.list ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list;     fi &&     if [ -f /etc/apt/sources.list.d/debian.sources ]; then       sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources &&       sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources;     fi
 RUN apt-get update &&     apt-get install -y --no-install-recommends ca-certificates git python3 tini tzdata e2fsprogs qemu-utils &&     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=go-build /out/agent-compose /app/agent-compose

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -7,7 +7,7 @@ services:
       args:
         VERSION: ${VERSION:-dev}
         REGISTRY_MIRROR: ${REGISTRY_MIRROR:-docker.io}
-        GOPROXY: ${GOPROXY:-https://goproxy.cn,direct}
+        GOPROXY: ${GOPROXY:-https://proxy.golang.org,direct}
         HTTP_PROXY: ${HTTP_PROXY:-}
         HTTPS_PROXY: ${HTTPS_PROXY:-}
         ALL_PROXY: ${ALL_PROXY:-}

--- a/docs/pages/guest-image-abi.md
+++ b/docs/pages/guest-image-abi.md
@@ -304,9 +304,10 @@ task image:agent-compose-guest-archlinux
 
 The resulting tag is `agent-compose-guest:archlinux`. The task explicitly
 targets `linux/amd64`, so it also works through emulation on an Arm development
-host. Override the tag with `IMAGE_TAG`, and use `ARCHLINUX_TAG` or
-`ARCHLINUX_MIRROR` when a deployment needs a pinned base tag or another package
-mirror:
+host. By default, builds use the upstream Arch mirrorlist and the official Go,
+PyPI, and npm registries. Override the tag with `IMAGE_TAG`, and use
+`ARCHLINUX_TAG` or `ARCHLINUX_MIRROR` when a deployment needs a pinned base tag
+or another package mirror:
 
 ```bash
 IMAGE_TAG=registry.example.com/team/agent-compose-guest:vX.Y.Z-archlinux \

--- a/docs/pages/zh-CN/guest-image-abi.md
+++ b/docs/pages/zh-CN/guest-image-abi.md
@@ -208,7 +208,7 @@ daemon 会自行使用配置的 port、root directory、base URL 和 token 启�
 task image:agent-compose-guest-archlinux
 ```
 
-生成的 tag 为 `agent-compose-guest:archlinux`。该 task 会显式构建 `linux/amd64`，因此也可以在 Arm 开发主机上通过模拟执行。可通过 `IMAGE_TAG` 覆盖 tag；如果部署需要固定 base tag 或使用其他软件包镜像，可设置 `ARCHLINUX_TAG` 或 `ARCHLINUX_MIRROR`：
+生成的 tag 为 `agent-compose-guest:archlinux`。该 task 会显式构建 `linux/amd64`，因此也可以在 Arm 开发主机上通过模拟执行。构建默认使用上游 Arch mirrorlist 以及 Go、PyPI 和 npm 官方 registry。可通过 `IMAGE_TAG` 覆盖 tag；如果部署需要固定 base tag 或使用其他软件包镜像，可设置 `ARCHLINUX_TAG` 或 `ARCHLINUX_MIRROR`：
 
 ```bash
 IMAGE_TAG=registry.example.com/team/agent-compose-guest:vX.Y.Z-archlinux \

--- a/guest-images/Dockerfile.agent-compose-guest
+++ b/guest-images/Dockerfile.agent-compose-guest
@@ -1,9 +1,9 @@
 ARG REGISTRY_MIRROR=docker.io
-ARG GOPROXY=https://goproxy.cn,direct
+ARG GOPROXY=https://proxy.golang.org,direct
 ARG GO_VERSION=1.26.4
 ARG GRPCURL_VERSION=v1.9.3
-ARG PYPI_INDEX_URL=https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
-ARG PYPI_TRUSTED_HOST=mirrors.tuna.tsinghua.edu.cn
+ARG PYPI_INDEX_URL=https://pypi.org/simple
+ARG PYPI_TRUSTED_HOST
 ARG NODE_MAJOR=22
 ARG CODEX_VERSION=0.146.0
 ARG CLAUDE_CODE_VERSION=2.1.220
@@ -35,15 +35,6 @@ ARG TARGETARCH
 
 COPY --from=grpcurl-builder /out/grpcurl /usr/local/bin/grpcurl
 
-RUN if [ -f /etc/apt/sources.list ]; then \
-      sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list && \
-      sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list; \
-    fi && \
-    if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
-      sed -i -e 's|deb.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources && \
-      sed -i -e 's|security.debian.org|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list.d/debian.sources; \
-    fi
-
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip git curl ca-certificates tini gnupg build-essential pkg-config protobuf-compiler && \
     mkdir -p /etc/apt/keyrings && \
@@ -51,7 +42,7 @@ RUN apt-get update && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
-    npm config set registry https://registry.npmmirror.com --global && \
+    npm config set registry https://registry.npmjs.org --global && \
     npm config set fund false --global && \
     npm config set update-notifier false --global && \
     apt-get purge -y --auto-remove gnupg dirmngr && \
@@ -63,8 +54,6 @@ ENV PIP_TRUSTED_HOST=${PYPI_TRUSTED_HOST}
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 RUN PIP_REQUIRE_HASHES=0 python3 -m pip install --break-system-packages --no-cache-dir --no-input \
-    --index-url ${PYPI_INDEX_URL} \
-    --trusted-host ${PYPI_TRUSTED_HOST} \
     jupyterlab bash_kernel && \
     python3 -m bash_kernel.install --sys-prefix
 

--- a/guest-images/Dockerfile.agent-compose-guest-archlinux
+++ b/guest-images/Dockerfile.agent-compose-guest-archlinux
@@ -1,11 +1,11 @@
 ARG REGISTRY_MIRROR=docker.io
-ARG GOPROXY=https://goproxy.cn,direct
+ARG GOPROXY=https://proxy.golang.org,direct
 ARG GO_VERSION=1.26.4
 ARG GRPCURL_VERSION=v1.9.3
 ARG ARCHLINUX_TAG=latest
-ARG ARCHLINUX_MIRROR=https://mirrors.aliyun.com/archlinux
-ARG PYPI_INDEX_URL=https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
-ARG PYPI_TRUSTED_HOST=mirrors.tuna.tsinghua.edu.cn
+ARG ARCHLINUX_MIRROR
+ARG PYPI_INDEX_URL=https://pypi.org/simple
+ARG PYPI_TRUSTED_HOST
 ARG CODEX_VERSION=0.146.0
 ARG CLAUDE_CODE_VERSION=2.1.220
 ARG GEMINI_CLI_VERSION=0.53.0
@@ -59,7 +59,7 @@ RUN if [ -n "${BUILDPLATFORM}" ] && [ "${BUILDPLATFORM}" != "${TARGETPLATFORM}" 
       protobuf \
       python \
       python-pip && \
-    npm config set registry https://registry.npmmirror.com --global && \
+    npm config set registry https://registry.npmjs.org --global && \
     npm config set fund false --global && \
     npm config set update-notifier false --global && \
     pacman -Scc --noconfirm && \
@@ -71,8 +71,6 @@ ENV PIP_TRUSTED_HOST=${PYPI_TRUSTED_HOST}
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 RUN PIP_REQUIRE_HASHES=0 python -m pip install --break-system-packages --no-cache-dir --no-input \
-    --index-url ${PYPI_INDEX_URL} \
-    --trusted-host ${PYPI_TRUSTED_HOST} \
     jupyterlab bash_kernel && \
     python -m bash_kernel.install --sys-prefix
 

--- a/guest-images/Dockerfile.devbox-archlinux
+++ b/guest-images/Dockerfile.devbox-archlinux
@@ -2,7 +2,8 @@ ARG REGISTRY_MIRROR=docker.io
 
 FROM ${REGISTRY_MIRROR}/library/archlinux:latest
 
-ARG GOPROXY=https://goproxy.cn
+ARG GOPROXY=https://proxy.golang.org
+ARG ARCHLINUX_MIRROR
 ARG CODEX_VERSION=0.146.0
 ARG CLAUDE_CODE_VERSION=2.1.220
 ARG GEMINI_CLI_VERSION=0.53.0
@@ -13,7 +14,11 @@ ARG QWEN_CODE_VERSION=0.19.8
 
 RUN ln -sfv /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
-RUN printf 'Server = http://mirrors.tuna.tsinghua.edu.cn/archlinux/$repo/os/$arch\n' > /etc/pacman.d/mirrorlist
+RUN if [ -n "${ARCHLINUX_MIRROR}" ]; then \
+      printf 'Server = %s/$repo/os/$arch\n' "${ARCHLINUX_MIRROR%/}" > /tmp/pacman-mirrorlist && \
+      cat /etc/pacman.d/mirrorlist >> /tmp/pacman-mirrorlist && \
+      mv /tmp/pacman-mirrorlist /etc/pacman.d/mirrorlist; \
+    fi
 RUN pacman -Syu --disable-download-timeout --noconfirm git git-lfs git-delta tig lazygit npm go rsync python python-pip less pre-commit the_silver_searcher ripgrep vim bash-completion tmux which openbsd-netcat socat podman podman-compose jq yq ed zip protobuf buf uv proxychains-ng
 
 RUN go env -w GOPROXY=${GOPROXY},direct &&\

--- a/scripts/tests/test-image-ci-contract.sh
+++ b/scripts/tests/test-image-ci-contract.sh
@@ -12,6 +12,9 @@ GUEST_BUILDER="$ROOT_DIR/scripts/build-agent-compose-guest.sh"
 GUEST_DOCKERFILE="$ROOT_DIR/guest-images/Dockerfile.agent-compose-guest"
 ARCHLINUX_GUEST_DOCKERFILE="$ROOT_DIR/guest-images/Dockerfile.agent-compose-guest-archlinux"
 DEVBOX_DOCKERFILE="$ROOT_DIR/guest-images/Dockerfile.devbox-archlinux"
+DAEMON_DOCKERFILE="$ROOT_DIR/Dockerfile"
+LOCAL_DAEMON_DOCKERFILE="$ROOT_DIR/Dockerfile.agent-compose-local"
+COMPOSE_OVERRIDE="$ROOT_DIR/docker-compose.override.yml.example"
 
 failures=0
 TEST_ROOT=$(mktemp -d)
@@ -33,6 +36,49 @@ forbid_regex() { # $1=text $2=extended-regex $3=description
     fail "forbidden $3"
   fi
 }
+
+public_build_sources=''
+for source_file in \
+  "$DAEMON_DOCKERFILE" \
+  "$LOCAL_DAEMON_DOCKERFILE" \
+  "$GUEST_DOCKERFILE" \
+  "$ARCHLINUX_GUEST_DOCKERFILE" \
+  "$DEVBOX_DOCKERFILE" \
+  "$WORKFLOW" \
+  "$COMPOSE_OVERRIDE"; do
+  public_build_sources+=$(<"$source_file")
+  public_build_sources+=$'\n'
+done
+
+for regional_mirror in \
+  'mirrors\.tuna\.tsinghua\.edu\.cn' \
+  'goproxy\.cn' \
+  'mirrors\.aliyun\.com' \
+  'registry\.npmmirror\.com'; do
+  forbid_regex "$public_build_sources" "$regional_mirror" \
+    "regional mirror default $regional_mirror in public build configuration"
+done
+
+for daemon_dockerfile in "$DAEMON_DOCKERFILE" "$LOCAL_DAEMON_DOCKERFILE"; do
+  require_regex "$(<"$daemon_dockerfile")" \
+    '^ARG[[:space:]]+GOPROXY=https://proxy\.golang\.org,direct$' \
+    "official Go proxy default in $(basename "$daemon_dockerfile")"
+done
+
+require_regex "$(<"$GUEST_DOCKERFILE")" \
+  '^ARG[[:space:]]+PYPI_INDEX_URL=https://pypi\.org/simple$' \
+  'official PyPI default in Debian guest Dockerfile'
+require_regex "$(<"$ARCHLINUX_GUEST_DOCKERFILE")" \
+  '^ARG[[:space:]]+ARCHLINUX_MIRROR[[:space:]]*$' \
+  'upstream mirrorlist default in Arch Linux guest Dockerfile'
+for guest_dockerfile in "$GUEST_DOCKERFILE" "$ARCHLINUX_GUEST_DOCKERFILE"; do
+  require_regex "$(<"$guest_dockerfile")" \
+    'npm[[:space:]]+config[[:space:]]+set[[:space:]]+registry[[:space:]]+https://registry\.npmjs\.org' \
+    "official npm registry in $(basename "$guest_dockerfile")"
+  require_regex "$(<"$guest_dockerfile")" \
+    '^ARG[[:space:]]+PYPI_TRUSTED_HOST[[:space:]]*$' \
+    "empty trusted PyPI host default in $(basename "$guest_dockerfile")"
+done
 
 job_block() { # $1=job-id
   awk -v job="$1" '


### PR DESCRIPTION
## Summary

- remove regional default mirrors from daemon and guest image builds
- use official Debian, Arch, Go, PyPI, and npm upstreams by default
- retain explicit mirror override build arguments
- add CI contract checks to prevent regional mirror defaults from returning

The public chaitin GitHub, Docker Hub, npm, and Go module coordinates are intentionally unchanged; no private Chaitin domain was found in the repository.

## Validation

- `./scripts/tests/test-image-ci-contract.sh`
- `task test:deploy`
- `task docs:build`
- `git diff --check`

The repository-wide compile gates were not completed: `task lint` stopped with `no space left on device`, and the user requested stopping compilation afterward. The image build attempt was not completed because the environment could not complete dependency installation. CI should run the full compile and image checks.

## Checklist

- [x] Changes are isolated to a dedicated worktree and branch from latest origin/main
- [x] Documentation updated in English and Chinese
- [x] Focused tests passed
- [ ] Full compile/test/image gates pending in CI