### PR TITLE
docs: govern design docs and published image guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,36 @@ use it at the URL the installer prints when the UI is enabled. See
 [deploy/README.md](deploy/README.md) for install, upgrade, uninstall, data
 preservation, and mirror/private-registry options.
 
-### Option B — Build from source (for the CLI workflow)
+### Option B — Pull published images (without the installer)
+
+Published daemon and guest images are available from [Docker
+Hub](https://hub.docker.com/u/chaitin). Pull the stable multi-architecture
+images directly:
+
+```bash
+docker pull chaitin/agent-compose:latest
+docker pull chaitin/agent-compose-guest:latest
+```
+
+For a pinned application release, replace `latest` with its release tag (for
+example `v1.2.3`) on both images. The optional frontend is published
+independently and can be pulled with its supported UI tag:
+
+```bash
+docker pull chaitin/agent-compose-ui:latest
+```
+
+The daemon and standard guest images publish `linux/amd64` and `linux/arm64`
+manifests. The UI tag is selected independently from the daemon release. To
+deploy with Compose, use `docker-compose.yml` and `.env.example` from the
+matching repository tag, copy `.env.example` to `.env`, and fill in the
+required settings. For a pinned deployment, add `AGENT_COMPOSE_IMAGE` and
+`DEFAULT_IMAGE` with the daemon and guest references shown above; add
+`AGENT_COMPOSE_FRONTEND_IMAGE` when pinning the optional UI. Then run
+`docker compose pull` and `docker compose up -d`, adding `--profile with-ui`
+when the frontend is needed.
+
+### Option C — Build from source (for the CLI workflow)
 
 ```bash
 task build                       # builds ./build/agent-compose
@@ -121,7 +150,7 @@ agent-compose --host http://127.0.0.1:7410 status
 
 ### Run your first agent
 
-With a local daemon running (Option B), create an `agent-compose.yml`:
+With a local daemon running (Option C), create an `agent-compose.yml`:
 
 ```yaml
 name: demo

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@
 - **Runtime LLM Facade**，托管 LLM 凭据，使 provider key 不进入 guest 容器。
 - 每个 agent 可配 **MCP server、可复用 skill、具名 volume**。
 - **Jupyter 代理**，支持 notebook 风格的 guest runtime。
-- **v1/v2 Connect API** 与生成的 TypeScript client。
+- **v2 Connect API** 与生成的 TypeScript client；`health.v1` 仅用于健康检查。
 
 ## 工作原理
 
@@ -60,7 +60,31 @@ docker compose --profile with-ui up -d
 
 installer 还会预先拉取 sandbox guest 镜像，避免首次运行 agent 时卡在大文件下载上；不需要时传 `--skip-guest-pull` 或在 TUI 里选「否」。基础 `docker-compose.yml` 不启用 `privileged`，也不映射 `/dev/kvm`；installer 在新安装时检测 KVM，并在可用时把 `COMPOSE_FILE=docker-compose.yml:docker-compose.kvm.yml` 持久化到安装目录的 `.env`。没有 KVM 时仍可使用默认 Docker driver。安装、升级、卸载、数据保留以及镜像/私有 registry 选项见 [deploy/README.md](deploy/README.md)。
 
-### 方式 B —— 从源码构建（用于 CLI 工作流）
+### 方式 B —— 直接获取发布镜像（无需 install.sh）
+
+daemon 和 guest 镜像发布在 [Docker Hub](https://hub.docker.com/u/chaitin)，可以直接拉取稳定的多架构镜像：
+
+```bash
+docker pull chaitin/agent-compose:latest
+docker pull chaitin/agent-compose-guest:latest
+```
+
+需要固定应用版本时，将 `latest` 替换为对应 release tag（例如
+`v1.2.3`），daemon 和 guest 使用相同的应用版本 tag。可选的 Web UI 独立发布，版本号与 daemon 独立：
+
+```bash
+docker pull chaitin/agent-compose-ui:latest
+```
+
+daemon 和标准 guest 镜像提供 `linux/amd64`、`linux/arm64` manifest。要用
+Compose 手工部署，请使用对应 repository tag 中的 `docker-compose.yml` 和
+`.env.example`，将 `.env.example` 复制为 `.env` 并填写必需配置。固定版本时，
+还要在 `.env` 中增加 `AGENT_COMPOSE_IMAGE` 和 `DEFAULT_IMAGE`，分别使用上面的
+daemon 和 guest 镜像引用；需要固定可选 UI 时再增加
+`AGENT_COMPOSE_FRONTEND_IMAGE`。然后执行 `docker compose pull`、
+`docker compose up -d`；需要 Web UI 时增加 `--profile with-ui`。
+
+### 方式 C —— 从源码构建（用于 CLI 工作流）
 
 ```bash
 task build                       # 产物在 ./build/agent-compose
@@ -77,7 +101,7 @@ agent-compose --host http://127.0.0.1:7410 status
 
 ### 运行第一个 agent
 
-在本地 daemon 运行的前提下（方式 B），创建 `agent-compose.yml`：
+在本地 daemon 运行的前提下（方式 C），创建 `agent-compose.yml`：
 
 ```yaml
 name: demo
@@ -379,7 +403,7 @@ task test          # 或：task test:unit / task test:integration / task test:e2
 
 用 `task image:agent-compose-guest` 和 `task image:agent-compose` 构建 guest 和 daemon 镜像。`task build:agent-compose` 按当前宿主选择原生 profile：Darwin 构建仅支持 Docker 的二进制，Linux 构建同时支持 Docker、BoxLite 和 Microsandbox；Linux full 构建会通过 Docker 准备两种 native runtime artifact。也可通过 `task build:agent-compose:darwin` 或 `task build:agent-compose:linux` 显式选择。旧任务 `build:agent-compose:boxlite` 已废弃，仅作为 Linux full profile 的兼容 alias。JavaScript runtime 组件在 `runtime/` 下。
 
-macOS/Linux daemon 原生二进制只用于本地开发和 CI 验证。独立的 Go installer 以 Linux amd64/arm64 二进制发布在固定的 `installer-latest` prerelease，并读取普通应用 Release 中的部署 bundle；正式部署载体仍是 GHCR 中的 multi-arch daemon/guest 镜像加该 installer。
+macOS/Linux daemon 原生二进制只用于本地开发和 CI 验证。独立的 Go installer 以 Linux amd64/arm64 二进制发布在固定的 `installer-latest` prerelease，并读取普通应用 Release 中的部署 bundle；正式部署载体仍是 Docker Hub 中的 multi-arch daemon/guest 镜像加该 installer。
 
 ## 文档
 

--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -3,18 +3,19 @@
 This document describes the call boundary between the Go host side
 `agent-compose` process and the JavaScript runtime
 `agent-compose-runtime` inside the sandbox. The current runtime is primarily
-used by `AgentService`: the host executes a unified entry command inside the
-sandbox, the JavaScript runtime adapts Codex, Claude, Gemini, OpenCode, and Pi, and structured
-results are returned to the host.
+used by the daemon's agent execution services: the host executes a unified
+entry command inside the sandbox, the JavaScript runtime adapts Codex, Claude,
+Gemini, OpenCode, and Pi, and structured results are returned to the host.
 
 Related code:
 
 - Stream model: `pkg/model/model.go`, `pkg/driver/types.go`
 - Marker parsing and stream filtering: `pkg/execution/parse.go`
 - Host agent calls: `pkg/agentcompose/adapters/agent_runner.go`
-- Host execution and persistence: `pkg/agentcompose/adapters/cell_executor.go`, `pkg/agentcompose/adapters/agent_executor.go`, and `pkg/storage/sessionstore`
+- Host execution and persistence: `pkg/agentcompose/adapters/cell_executor.go`,
+  `pkg/agentcompose/adapters/agent_executor.go`, and `pkg/storage/sandboxstore/`
 - v2 stream API: `proto/agentcompose/v2/agentcompose.proto`
-- CLI stream writer: `cmd/agent-compose/main.go`
+- CLI stream writer: `cmd/agent-compose/cli_run_stream.go`
 - Runtime CLI source: `runtime/javascript/src/cli.ts`
 - Runtime provider adapters: `runtime/javascript/src/runners/`
 - Guest SDK: `runtime/agent-compose-runtime-sdk/`
@@ -193,7 +194,6 @@ Command arguments:
 | `--workspace` | no | Agent working directory; default `WORKSPACE` or `/workspace` |
 | `--home` | no | Agent HOME; default `HOME` or `/root` |
 | `--model` | no | Agent model; consumed by providers that support explicit model selection |
-| `--system-prompt-file` | no | System prompt file path; currently consumed by providers that need prompt-level system instructions |
 | `--skill <name>` | no | Repeatable enabled skill name. Host projects the active set into `/root/.agents/skills` before invoking runtime |
 
 Agent identity uses the fixed convention path documented in §3.2.
@@ -344,9 +344,8 @@ enum StdioStream {
 
 `StreamAgentRunResponse`, `StreamExecResponse`, and `TranscriptEvent` carry a
 `stream` field. `STDIO_STREAM_UNSPECIFIED` is treated as stdout by CLI and host
-consumers. The v1 API keeps its historical `is_stderr` fields for compatibility;
-the conversion to that boolean happens only at v1/session compatibility
-boundaries.
+consumers. No legacy v1 control-plane conversion is performed by the current
+runtime contract.
 
 The protocol deliberately does not add `chunk_type`, `payload_kind`, typed
 payload events, new CLI flags, JSON schema changes, or stdin forwarding for this
@@ -680,8 +679,10 @@ opencode run <prompt> --format json --dir /workspace --dangerously-skip-permissi
 When a model is provided by the host, the runner appends `--model <model>`.
 When a stored provider thread exists, the runner appends
 `--session <stored thread id>`. The `--session` flag is OpenCode's provider-native
-resume flag. The runner sets
-`OPENCODE_DISABLE_AUTOUPDATE=true` unless the environment already defines it.
+resume flag. When `systemContext` is non-empty, the runner prepends it to the
+user prompt separated by a blank line. The runner sets
+`OPENCODE_DISABLE_AUTOUPDATE=true` and `OPENCODE_DISABLE_MODELS_FETCH=1` unless
+the environment already defines them.
 
 OpenCode raw JSON events are converted into a human-readable transcript. The
 runner writes `/data/state/agents/providers/opencode.json` after a successful

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -12,16 +12,17 @@ The current code facts are anchored by these entry points:
 - Compose parsing and normalization: `pkg/compose/`
 - v2 API: `proto/agentcompose/v2/agentcompose.proto`
 - Project/run persistence: `pkg/storage/configstore/project_store.go`,
-  `pkg/storage/configstore/run_coordinator_store.go`; shared storage helpers in
-  `pkg/storage/`
+  `pkg/storage/configstore/project_run_completion.go`, and related focused
+  stores under `pkg/storage/configstore/`
 - Jupyter proxy: `pkg/agentcompose/proxy/proxy.go`
 - Scheduler runtime and scheduling: owner behavior in `pkg/schedulers/`; daemon
   orchestration in `pkg/agentcompose/app/scheduler_controller.go` and
   `pkg/agentcompose/adapters/scheduler_session_runner.go`
 - Domain model helpers: `pkg/model/`
 - Project/run owner helpers: `pkg/projects/` and `pkg/runs/`
-- Sandbox execution owner helpers: `pkg/sessions/` compatibility lifecycle
-  package and `pkg/execution/`
+- Sandbox execution helpers: `pkg/execution/`, with lifecycle orchestration in
+  `pkg/agentcompose/adapters/` and filesystem ownership in
+  `pkg/storage/sandboxstore/`
 - Standalone frontend image: `agent-compose-ui` repository
 
 ## Architecture Goals
@@ -40,9 +41,9 @@ Core boundaries:
   describe an already running sandbox.
 - Web/UI is no longer built into the daemon image or hosted by the daemon
   process. It is deployed as an independent frontend service.
-- The v1 session-centric API remains available for the existing Web/UI and
-  compatibility clients. The v2 API is the primary path for the CLI and newer
-  clients.
+- The public control plane is the v2 Connect API. The removed
+  `agentcompose.v1.SessionService` is not registered; `health.v1` is a separate
+  health-check API, not a legacy control-plane surface.
 
 ```text
 CLI / Web / Connect clients
@@ -51,7 +52,7 @@ CLI / Web / Connect clients
   v
 agent-compose daemon
   |
-  | v1/v2 Connect handlers, HTTP routes, scheduler, store
+  | v2 Connect handlers, HTTP routes, scheduler, store
   v
 project / run / scheduler / sandbox control plane
   |
@@ -77,7 +78,7 @@ Daemon construction has been split into testable app construction:
 
 - Load `.env` and environment configuration.
 - Initialize Echo, structured logging, and DI.
-- Register `/api/version`, v1/v2 Connect handlers, webhook/event routes,
+- Register `/api/version`, v2 and health Connect handlers, webhook/event routes,
   workspace HTTP routes, and Jupyter proxy routes.
 - Register the service graph through `agentcompose.Register(di)`.
 - Start the scheduler controller, event dispatcher, capability proxy, and startup
@@ -162,7 +163,7 @@ agents:
   reviewer:
     provider: codex
     model: gpt-5
-    image: ghcr.io/org/agent-runtime:latest
+    image: chaitin/agent-compose-guest:latest
     driver:
       boxlite:
         kernel: s3://bucket/kernel
@@ -188,7 +189,7 @@ The same scheduler can also declare a scheduler script directly with inline QJS:
 agents:
   reviewer:
     provider: codex
-    image: ghcr.io/org/agent-runtime:latest
+    image: chaitin/agent-compose-guest:latest
     scheduler:
       script: |
         scheduler.interval("hourly-review", function hourlyReview() {
@@ -337,15 +338,14 @@ Besides Connect APIs, the daemon registers these HTTP routes:
 - webhook / event ingress: `/api/webhooks/:topic`, `/api/events...`
 - file workspace helper routes:
   `/api/agent-compose/workspaces/:workspaceID/files`, `upload`, and `download`
-- Jupyter proxy: `<JupyterProxyBasePath>/:sessionID` and
-  `<JupyterProxyBasePath>/:sessionID/*`. The default base path is `/jupyter`.
+- Jupyter proxy: `<JupyterProxyBasePath>/:sandboxID` and
+  `<JupyterProxyBasePath>/:sandboxID/*`. The default base path is `/jupyter`.
 
 The Jupyter proxy implementation lives in `pkg/agentcompose/proxy/proxy.go`.
-`GetSessionProxy` returns only proxy entry information; actual HTTP/WebSocket
-forwarding is handled by the HTTP routes above. When a sandbox is created
-through the v1-compatible API,
-`Config.JupyterProxyBasePath` is written into `proxyPath`; the current code
-default is `/jupyter`.
+`SandboxService.GetSandbox` returns proxy entry information when available;
+actual HTTP/WebSocket forwarding is handled by the HTTP routes above.
+`Config.JupyterProxyBasePath` is written into sandbox proxy state, and the
+current application default is `/jupyter`.
 
 ## Project Apply And Scheduling
 
@@ -440,8 +440,8 @@ file-level debugging.
 
 ### Agent system prompt (Phase 1)
 
-`AgentDefinition.system_prompt` is persisted on agent definitions (manual and
-managed) and exposed through v1/v2 APIs and the Agents UI. At execution time the
+`AgentDefinition.system_prompt` is persisted on agent definitions and exposed
+through the v2 API and Agents UI. At execution time the
 host resolves this field and materializes agent identity for the guest runtime.
 
 Layered prompt model:
@@ -714,7 +714,10 @@ currently supported:
 - `microsandbox`
 
 The default driver is controlled by `RUNTIME_DRIVER`; when empty, it is
-`docker`. The default guest image is `debian:bookworm-slim`.
+`docker`. The native application default guest image is
+`debian:bookworm-slim`; `.env.example` and installer-managed deployments
+override it with `chaitin/agent-compose-guest:latest` or the selected release
+tag.
 
 ### Compiled Driver Capability
 
@@ -795,9 +798,9 @@ internal `workspace_provisioning` field in sandbox `metadata.json`; it is not
 exposed through `SandboxSummary`, the public API, or list filters.
 
 The process-level `Provisioner` is shared by every lifecycle path that can start
-or restart a workspace-backed sandbox: v1 session create/resume,
-`sessions.Lifecycle.ResumeLoaded` and Jupyter `EnsureProxyReady`, scheduler sandbox
-create/sticky resume, and project-run sandbox create/reuse. It reloads persisted
+or restart a workspace-backed sandbox: project/run sandbox creation and reuse,
+`SandboxService.ResumeSandbox`, Jupyter proxy readiness, and scheduler sandbox
+create/sticky resume. It reloads persisted
 metadata and makes the decision from provisioning state, rather than from a
 create/resume flag or workspace directory contents. For `pending` and `failed`,
 it materializes into a same-filesystem staging directory, promotes the result,
@@ -849,8 +852,7 @@ sandboxes. Removing a sandbox deletes its sandbox directory, including the
 writable workspace, provisioning metadata, and any provisioning staging
 attempts.
 
-Current sandbox startup flow, used by v1-compatible `CreateSession` and the
-other creation paths:
+Current sandbox startup flow, used by project/run and scheduler creation paths:
 
 1. Resolve env, tags, workspace id, driver, and guest image from the request.
 2. Merge global env and request env.
@@ -861,17 +863,17 @@ other creation paths:
 5. Prepare managed capability, runtime, state, and home resources.
 6. Start runtime through the driver.
 7. Mark sandbox as `RUNNING`.
-8. Record sandbox-created state. Scheduler lifecycle events use
-   `scheduler.sandbox.*`; the historical `agent-compose.session.*` topic prefix
-   is retained only where the v1 compatibility event bus still emits it.
+8. Record sandbox-created state. Scheduler run events use
+   `scheduler.sandbox.*`; some topic-event publishers still emit the historical
+   `agent-compose.session.*` prefix as an internal event compatibility measure.
 
-`ResumeSession` is the v1-compatible resume method. It loads the same sandbox,
-runs the shared Provisioner, and starts its runtime; a `ready` workspace is left
-untouched. `StopSession` stops runtime and marks the sandbox `STOPPED` without
+`SandboxService.ResumeSandbox` loads the same sandbox, runs the shared
+Provisioner, and starts its runtime; a `ready` workspace is left untouched.
+`SandboxService.StopSandbox` stops runtime and marks the sandbox `STOPPED` without
 changing its workspace or provisioning state.
 
-Startup reconciles persisted sandbox runtime state. `GetSession`,
-`ListSessions`, and `StopSession` also trigger reconciliation logic.
+Startup reconciles persisted sandbox runtime state. Sandbox get, list, and stop
+operations also trigger the relevant reconciliation logic.
 
 Default guest paths:
 
@@ -899,8 +901,8 @@ The current scheduler runtime uses QJS and supports:
 Project compose `scheduler.script` uses the same runtime. Scripts are evaluated
 during validate/apply to collect triggers. APIs with side effects or host
 dependencies, such as `scheduler.agent`, `scheduler.llm`, `scheduler.exec`,
-`scheduler.shell`, `scheduler.event.publish`, and the v1-compatible session RPC
-bridge, should be used in
+`scheduler.shell`, `scheduler.event.publish`, and the sandbox RPC bridge should
+be used in
 `main()` or trigger callbacks.
 
 `scheduler` is the only product-level global object in the scheduler QJS
@@ -969,9 +971,10 @@ create workspace-capable agent sandboxes or grant file, command, or MCP tool
 access. With `outputSchema`, it uses prompt guidance and `json_object` instead
 of Responses API strict JSON Schema.
 
-Guest agent providers (`codex`, `claude`, `gemini`, `opencode`, `pi`) remain separate CLI runners
-inside guest containers with their own API keys and provider-native session
-state.
+Guest agent providers (`codex`, `claude`, `gemini`, `opencode`, `pi`) remain
+separate CLI runners with provider-native session state. Codex, Claude,
+OpenCode, and Pi normally receive scoped Runtime LLM Facade credentials rather
+than daemon provider keys; Gemini uses its CLI-native login flow.
 
 The scheduler's primary sandbox lifecycle API is:
 
@@ -982,20 +985,10 @@ The scheduler's primary sandbox lifecycle API is:
 - `scheduler.sandbox.listSandboxes()`
 - `scheduler.sandbox.getSandboxProxy(request)`
 
-These methods expose sandbox-shaped request and response JSON while currently
-bridging to the compatibility lifecycle service internally. The scheduler also retains these
-deprecated v1 `SessionService` aliases:
-
-- `scheduler.session.createSession(request)`
-- `scheduler.session.resumeSession(request)`
-- `scheduler.session.stopSession(request)`
-- `scheduler.session.getSession(request)`
-- `scheduler.session.listSessions()`
-- `scheduler.session.getSessionProxy(request)`
-
-Method names use lower camel case and also retain PascalCase aliases. New
-scripts should use `scheduler.sandbox.*`; calls through `scheduler.session.*`
-emit deprecation warnings.
+These methods expose sandbox-shaped request and response JSON through the
+sandbox lifecycle bridge. Method names use lower camel case and retain
+PascalCase aliases. The former `scheduler.session.*` object is no longer
+registered.
 
 ## Frontend Service
 
@@ -1016,7 +1009,7 @@ The current Docker deployment provides an independent frontend service:
   and authenticated reverse proxying.
 - `/api/auth/*` and `/oauth/*` belong to the UI server and are no longer
   registered by the daemon.
-- The UI server proxies daemon v1/v2 Connect APIs, the health API,
+- The UI server proxies daemon v2 Connect APIs, the health API,
   workspace/event/webhook HTTP APIs, `/jupyter/*` or the configured
   `JUPYTER_PROXY_BASE`, and the compatible `/agent-compose/session/*` paths to
   the daemon.
@@ -1070,8 +1063,8 @@ For shared playground build, deployment, and verification flow, see
 - `run` is a one-shot execution. It stops runtime by default after completion.
 - `down` disables managed schedulers and stops running project sandboxes.
   It does not delete history by default.
-- The v1 API must remain compatible. The v2 API carries the primary
-  project/run/exec/image path.
+- The v2 API is the public project/run/exec/image/sandbox control plane; legacy
+  v1 storage compatibility does not imply a live v1 RPC surface.
 - Web/UI is deployed as an independent service and is not included in the daemon
   Docker image; browser auth/OAuth belongs to the agent-compose-ui server.
 - The daemon TCP API should not be used as the public browser entrypoint.

--- a/docs/design/agent_system_prompt_design.md
+++ b/docs/design/agent_system_prompt_design.md
@@ -1,6 +1,6 @@
 # Agent System Prompt — Phase 1 Design
 
-**Status:** Phase 1 is **implemented** in the current codebase. Sections through
+Phase 1 is present in the current codebase. Sections through
 [Success Criteria (Phase 1, verified)](#success-criteria-phase-1-verified) document what shipped in
 this change. [Next Steps](#next-steps) lists work that was **not** part of Phase 1.
 
@@ -12,6 +12,10 @@ Before Phase 1, `AgentDefinition.system_prompt` was persisted, exposed through
 API/Proto, and editable in the Agents UI, but the execution path never read it.
 Only the MPI (Model Program Interface) capability catalog reached provider
 system/developer instruction channels.
+
+The Phase 1 provider matrix below is historical. The current runtime has since
+added OpenCode and Pi; all five runners receive the composed context, using
+native system channels where available and prompt/file fallbacks elsewhere.
 
 Phase 1 closed that gap by wiring agent identity into a layered prompt model
 without introducing a full platform runtime brief.
@@ -192,8 +196,9 @@ runtime provider normalization. Discovery mirrors MPI convention-based lookup un
 
 - **Scheduler runs** (`pkg/schedulers/run_host.go`): set from the resolved agent
   definition id or `scheduler.Summary.AgentID` fallback.
-- **Managed project runs** (`run_service.go`): set from `run.ManagedAgentID`.
-- **v1 session chat compatibility runs**: rely on sandbox tags when no explicit
+- **Managed project runs** (`pkg/runs/controller.go`): set from the run's bound
+  agent definition.
+- **Legacy sandbox chat compatibility runs**: rely on sandbox tags when no explicit
   id is passed.
 
 `buildAgentExecSpec` passes `--state-root` only; the guest discovers agent identity
@@ -304,8 +309,8 @@ systemPrompt: {
 
 ### Gemini
 
-Gemini has no native system-instruction channel in the current runner. Phase 1
-shipped an interim fallback:
+Gemini has no native system-instruction channel in the current runner. The
+implemented fallback prepends the composed context to the user prompt:
 
 ```typescript
 const userPrompt = systemContext
@@ -323,7 +328,7 @@ the system prompt wiring scope.
 
 | Run type | How agent identity is resolved |
 | --- | --- |
-| v1 agent session chat compatibility | Sandbox tags `source=agent` + `agent_id` |
+| Legacy agent sandbox compatibility | Sandbox tags `source=agent` + `agent_id` |
 | Scheduler script `agent()` call | `AgentDefinitionID` from scheduler-bound agent |
 | Managed project run (v2) | `run.ManagedAgentID` |
 | Bare provider string, no agent | No agent identity; MPI-only if catalog exists |

--- a/docs/design/octobus_integration.md
+++ b/docs/design/octobus_integration.md
@@ -1,5 +1,8 @@
 # OctoBus Integration Implementation Spec
 
+Project-scoped extensions are documented separately in
+[Project-scoped OctoBus servers](project_octobus_servers_design.md).
+
 OctoBus repository: [chaitin/OctoBus](https://github.com/chaitin/OctoBus).
 
 agent-compose integrates published OctoBus capability sets, injects selected
@@ -259,7 +262,8 @@ is missing, capability injection is skipped and a warning is recorded; creation
 is not blocked.
 
 **Step 2: `writeCapabilityGuide(sandbox, capset_ids)` after the shared
-Workspace Provisioner has established `ready` and before `StartSessionVM`,
+Workspace Provisioner has established `ready` and before the selected runtime
+driver starts,
 best-effort.** For each
 capset, call OctoBus
 `GET /admin/v1/catalog/{capset_id}?format=md&grpc=true` to render capability
@@ -279,23 +283,20 @@ and uses only the `grpc` section. **If OctoBus is
 unreachable or rendering fails, record an event and continue; sandbox/scheduler
 starts normally.**
 
-Coverage: Codex and Claude receive `mpiContext` in system prompt. Gemini runner
-does not currently consume `mpiContext`; this is a known gap and is out of scope
-for this phase.
+Coverage: all five current guest runners receive the composed `systemContext`,
+which contains the MPI catalog. Codex and Claude use native system/developer
+context channels; Gemini and OpenCode prepend it to the user prompt, and Pi
+passes it through an appended system-prompt file.
 
 Timing constraint: env injection runs before `Store.CreateSandbox` and returns
 values that are merged into the create request, when sandbox directory does not
 exist yet. Markdown writing must wait until after `CreateSandbox` creates the
-directory and before `StartSessionVM` mounts it; otherwise the path may not
+directory and before the selected runtime driver mounts it; otherwise the path may not
 exist or the file may miss the mount.
 
-Proto field:
-
-```proto
-message CreateSessionRequest {
-  repeated string capset_ids = 10;
-}
-```
+The current v2 `AgentSpec.capset_ids` field carries these declarations through
+project revision, managed agent definition, scheduler execution, and sandbox
+creation. There is no live v1 `CreateSessionRequest` control-plane message.
 
 Agent definitions, sandbox creation, and schedulers all retain capability set
 selection. `AgentSpec.capset_ids` is persisted in project revision and

--- a/docs/design/opencode_cli_support.md
+++ b/docs/design/opencode_cli_support.md
@@ -19,17 +19,19 @@ Provider handling is split across four layers:
   `runtime/javascript/src/runners/` contains the provider adapters.
 - Guest image: `guest-images/Dockerfile.agent-compose-guest` installs provider
   CLIs and links stable executable paths such as `/usr/bin/codex`.
-- UI and docs: `frontend/src/pages/AgentsPage.svelte`, `README.md`, and design
-  docs list supported providers.
+- UI and docs: the independent `agent-compose-ui` repository, root README, and
+  design docs list supported providers.
 
 The compose schema does not currently restrict provider names in `pkg/compose`;
 daemon-side agent definition validation does. Proto fields are strings, so this
 change should not require protobuf changes.
 
-`model` and `system_prompt` already exist in the compose, v1, v2, and store
-models. The OpenCode integration forwards them through `ExecuteAgentRequest`
-and `agent-compose-runtime prompt`; existing Codex, Claude, and Gemini runners
-keep their previous behavior unless they explicitly consume those fields later.
+`model` and `system_prompt` already exist in the compose, v2, and store
+models. The agent execution request carries the model and agent-definition ID;
+the host resolves the definition and materializes its system prompt under the
+sandbox state root. `agent-compose-runtime prompt` reads that convention path
+and passes the composed context to each provider runner using its supported
+mechanism.
 
 ## OpenCode CLI Facts
 
@@ -130,21 +132,20 @@ Agent execution should:
 
 4. Agent model and system prompt plumbing.
 
-   OpenCode needs `model` to select the target provider/model. The host forwards
-   model and system prompt explicitly instead of relying on stored metadata:
+   OpenCode needs `model` to select the target provider/model. The host carries
+   the model explicitly and resolves the system prompt from the bound agent
+   definition:
 
-   - a small execution-config helper resolves provider, model, and
-     system prompt from an agent definition when a sandbox has agent tags;
-   - `ExecuteAgentRequest` includes `Model` and `SystemPrompt`;
-   - managed project agent definitions set those fields in
-     `runProjectAgent`;
-   - v1 agent definition sandbox compatibility paths set those fields when executing via
-     `SendAgentMessage` / `SendAgentMessageStream`;
-   - schedulers linked to an agent definition set those fields when using
-     `scheduler.agent`;
-   - the runtime CLI accepts `--model` and `--system-prompt-file`;
-   - `PromptCommandOptions` and `RunnerOptions` include `model?: string` and
-     `systemPrompt?: string`.
+   - `ExecuteAgentRequest` includes `Model` and `AgentDefinitionID`;
+   - managed project runs and schedulers pass the bound definition ID and model;
+   - sandbox-tag fallback resolves the same agent definition when no explicit
+     ID is supplied;
+   - the host writes the resolved prompt to
+     `state/agents/system-prompts/system-prompt.txt`;
+   - the runtime CLI accepts `--model` and discovers the prompt below
+     `--state-root`;
+   - `PromptCommandOptions` carries `model`, while `RunnerOptions` carries
+     `model` and the composed `systemContext`.
 
 5. Install the CLI in the guest image.
 
@@ -156,8 +157,7 @@ Agent execution should:
 
 6. Update UI and docs.
 
-   - `frontend/src/pages/AgentsPage.svelte` and `frontend/src/api/agents.ts`
-     accept `opencode`.
+   - the independent `agent-compose-ui` repository accepts `opencode`.
    - `README.md`, SDK docs, and runtime contract docs list the new provider.
    - OpenCode environment-variable guidance notes that the exact provider key depends
      on the selected OpenCode model provider, so document common cases rather

--- a/docs/design/pi_agent_provider_design.md
+++ b/docs/design/pi_agent_provider_design.md
@@ -6,22 +6,26 @@
 
 调研基线：
 
-- agent-compose：`origin/main`，提交 `5ba97ec3`（2026-07-22 拉取）。
+- 调研基线：本文保留原始实现评审基线；当前代码和 guest image 以本仓库
+  `main` 分支为准。
 - Pi：[`earendil-works/pi`](https://github.com/earendil-works/pi)，提交 [`bc41f612`](https://github.com/earendil-works/pi/commit/bc41f612da8c15c4acc5f7ab7a7178a4fe17c942)，发布版 `v0.81.1`。
 - Pi npm 包：`@earendil-works/pi-coding-agent@0.81.1`，要求 Node.js `>=22.19.0`；当前 guest image 使用 Node.js 22，满足要求。
 
 建议将规范 provider 名称定为 `pi`，兼容输入别名 `pi-agent` 和 `pi_agent`。首版使用 Pi 的 JSON event stream 模式，每个 agent-compose prompt turn 启动一个 `pi --mode json` 子进程，并用 Pi session ID 延续上下文。暂不以 RPC 模式作为首版执行通道。
 
-推荐分两个发布级别：
+原始设计曾建议分两个发布级别。当前实现已交付基础主链路和声明式 MCP adapter；下文的分阶段建议仅作历史决策记录：
 
 1. 基础可用：prompt、模型路由、system prompt、skills、session resume、流式日志、取消、镜像和文档全部可用。
-2. 完整可用：补齐 agent-compose 声明式 MCP server 到 Pi tool 的适配后，才宣称与 Codex/Claude/OpenCode provider 功能对等。
+2. 完整可用：补齐 agent-compose 声明式 MCP server 到 Pi tool 的适配。
 
-Pi 官方刻意不内置 MCP。不能在配置了 `mcp_servers` 时静默忽略；基础版本如果尚未交付 MCP adapter，必须在执行前返回清晰的 `failed precondition`。
+Pi 官方刻意不内置 MCP；当前 guest image 通过固定版本的
+`pi-mcp-adapter` extension 提供声明式 MCP 映射。runtime 将控制面已经验证并
+物化的 local/remote server 配置转换为 adapter 配置；extension 缺失或执行
+失败会使本次 run 明确失败。
 
 ## 2. 当前 agent provider 执行链
 
-当前实现实际支持四种 provider：`codex`、`claude`、`gemini`、`opencode`。一次 agent run 的主要链路如下：
+当前实现实际支持五种 provider：`codex`、`claude`、`gemini`、`opencode`、`pi`。一次 agent run 的主要链路如下：
 
 ```text
 AgentDefinition / compose agent
@@ -47,7 +51,7 @@ AgentDefinition / compose agent
 | agent 进程和事件翻译 | `runtime/javascript/src/runners/*` | 新增 `runners/pi.ts` |
 | LLM facade | `pkg/llms/runtimefacade`、`pkg/llms` | 解析 Pi 模型选择并写 `models.json` |
 | skills 投影 | `pkg/execution/agent_files.go`、runtime options | 复用 `~/.agents/skills`，通过显式 `--skill` 限定本次 agent skills |
-| MCP | `AgentRunner.prepareAgentMCPConfig`、guest runtime | 增加 Pi MCP extension；未实现前显式拒绝 |
+| MCP | `AgentRunner.prepareAgentMCPConfig`、guest runtime | 通过固定版本 `pi-mcp-adapter` extension 映射 |
 | guest image | `guest-images/Dockerfile.agent-compose-guest` 等 | 固定版本安装 npm CLI，增加镜像断言 |
 | CLI prompt attach | `cmd/agent-compose/cli_resource_reference.go` | 将 `pi` 加入非交互/交互支持矩阵（按实际完成能力） |
 
@@ -61,7 +65,8 @@ Pi 提供 interactive、print/JSON、RPC 和 SDK 四种模式。首版选择 `--
 
 - 与 `OpenCodeRunner`、`GeminiRunner` 的“一次 turn 一个进程”模型一致。
 - stdout 是 LF 分隔 JSON，第一条是带 `id` 的 session header，后续是稳定的 agent/message/tool 生命周期事件。
-- 支持 `--session-id <id>`：session 不存在时创建，存在时恢复，正好映射 `stateRoot` 下的 provider thread state。
+- `--session-id <id>` 用于恢复已有 session；首次执行省略该参数，让 Pi 走
+  原生 session 创建路径，再把返回的 ID 写入 `stateRoot` 下的 provider state。
 - 进程退出天然定义本次 turn 完成；context cancellation 可通过终止子进程实现。
 - 不需要在 Go/runtime 层新增长生命周期 stdin command multiplexer。
 
@@ -73,8 +78,8 @@ RPC 模式保留为后续交互能力升级选项。只有需要 run 中途 `ste
 
 ```text
 pi --mode json
-   --session-dir <stateRoot>/pi/sessions
-   --session-id <stored-or-generated-thread-id>
+   --session-dir <stateRoot>/agents/providers/pi/sessions
+   [--session-id <stored-thread-id>]
    --model agent-compose/<resolved-model>
    --append-system-prompt <temporary-system-context-file>
    --no-extensions --no-skills --no-prompt-templates --no-themes
@@ -115,8 +120,11 @@ pi --mode json
 复用 `runtime/javascript/src/session-state.ts`：
 
 - provider key 使用 `pi`。
-- 首次执行前生成 64 位小写 SHA-256 形式的随机 ID 作为 `--session-id`，与 agent-compose 新资源 ID 的表示形式一致。Pi 原生只要求 ID 使用安全字符，并不要求 UUID；Pi 的 session header 必须返回同一个 ID，否则以返回值为准并更新 store。
-- session 文件定向到 `<stateRoot>/pi/sessions`，而不是默认 `~/.pi/agent/sessions`，使状态生命周期跟随 sandbox state root。
+- 首次执行不传 `--session-id`，由 Pi 通过原生创建路径生成 session；后续只在
+  stored thread 存在时传入该 ID。
+- session 文件定向到 `<stateRoot>/agents/providers/pi/sessions`，而不是默认
+  `~/.pi/agent/sessions`，使状态生命周期跟随 sandbox state root；恢复 ID
+  继续保存在 `<stateRoot>/agents/providers/pi.json`。
 - 只有进程成功完成且拿到合法 session ID 后才原子写 stored thread；失败不能覆盖上一个可恢复 ID。
 - Pi session 绑定 cwd。agent-compose 恢复 sandbox 时 workspace guest path 应保持稳定；若未来允许 guest workspace path 改变，应新增兼容性测试。
 
@@ -327,14 +335,14 @@ task image:agent-compose-guest
 
 ## 8. 分阶段落地建议
 
-### PR 1：provider 主链路
+### 历史 PR 1：provider 主链路
 
 - provider normalize/validation、PiRunner、JSON event mapping、session、system context、skills。
 - Pi facade config（OpenAI Responses/chat + Anthropic Messages）。
 - guest image、文档、unit/integration/image smoke。
 - MCP 非空 fail-fast。
 
-### PR 2：声明式 MCP adapter
+### 历史 PR 2：声明式 MCP adapter
 
 - runtime-owned Pi extension、stdio/remote transports、schema/content mapping、cleanup。
 - MCP unit/integration/E2E，移除 fail-fast 限制。
@@ -359,4 +367,6 @@ task image:agent-compose-guest
 | npm 依赖增加镜像体积 | 拉取和启动成本 | 记录 size budget；必要时再评估上游 standalone release |
 | structured output | Pi CLI 无等价 schema flag | 首版像 OpenCode/Gemini 一样明确拒绝；后续用受控 extension 实现，不用 prompt 伪约束冒充 schema guarantee |
 
-最终推荐：先落地 JSON mode + facade + session + skills 的完整主链路，并把 MCP 非空 fail-fast 作为安全边界；随后用仓库内固定版本的 Pi extension 补齐 MCP。这个路径对当前架构改动最小，同时保留将来用 RPC 支持更强交互的空间。
+最终实现结论：JSON mode + facade + session + skills 主链路与固定版本的
+Pi MCP extension 均已落地。RPC 仍是未来可选的交互升级，不应与当前普通
+prompt run 混同。

--- a/docs/design/playground_setup.md
+++ b/docs/design/playground_setup.md
@@ -1,9 +1,11 @@
 # Playground Deployment And Verification
 
-This document describes the external shared playground deployment. It is not a
-repository-local development environment.
+This document is an obsolete external-environment snapshot. The repository
+cannot verify the state or paths of the shared playground described here. Use
+the repository Compose files and current v2 CLI/API documentation for supported
+deployments; this is not a repository-local development environment.
 
-Current real environment:
+Historical environment snapshot (not verified by this repository):
 
 - Code directory: `/data/code`
 - Deployment directory: `/data/playground`
@@ -45,7 +47,7 @@ service:
 
 - Listen port: `8000`
 - Uses the independent `agent-compose-ui` image
-- Reverse proxies daemon v1/v2 Connect APIs, `/api/`, and Jupyter proxy routes
+- Reverse proxies daemon v2 Connect APIs, `/api/`, and Jupyter proxy routes
 - Data mount: `./data:/data`, used for frontend service runtime data
 
 The corresponding host data directory is:
@@ -59,9 +61,9 @@ directory backing `SANDBOX_ROOT`.
 
 Web/UI should no longer be validated as embedded static assets inside the daemon
 container. The frontend may be served by nginx, a static file server, or an
-independent container, and should reverse proxy to daemon v1/v2 Connect APIs and
-Jupyter proxy routes. The existing frontend continues to use v1 API; CLI and new
-clients should prefer v2 API.
+independent container, and should reverse proxy to daemon v2 Connect APIs and
+Jupyter proxy routes. The removed v1 control-plane API must not be used as a
+deployment or verification requirement.
 
 ## Build Images
 
@@ -116,17 +118,7 @@ curl -i http://127.0.0.1:8000/ | head
 curl -i http://127.0.0.1:8000/ui/ | head
 ```
 
-### 3. Verify v1 SessionService Compatibility API Access
-
-```bash
-curl -sS -X POST \
-  http://127.0.0.1:7410/agentcompose.v1.SessionService/ListSessions \
-  -H 'Content-Type: application/json' \
-  -H 'Connect-Protocol-Version: 1' \
-  -d '{}'
-```
-
-### 4. Verify v2 ProjectService Main Path Access
+### 3. Verify v2 ProjectService Main Path Access
 
 An empty request should return validation issues, not 404:
 
@@ -138,7 +130,7 @@ curl -sS -X POST \
   -d '{}'
 ```
 
-### 5. Complete Project Smoke With CLI
+### 4. Complete Project Smoke With CLI
 
 Prepare a temporary compose file:
 
@@ -162,55 +154,12 @@ agent-compose --host http://127.0.0.1:7410 -f /tmp/agent-compose-smoke.yml ps
 agent-compose --host http://127.0.0.1:7410 -f /tmp/agent-compose-smoke.yml down
 ```
 
-### 6. Create A v1 Verification Sandbox
+### 5. Verify Sandbox And Jupyter Through v2
 
-A minimal v1 compatibility request is enough; no extra `baseWorkspace` is
-required:
-
-```bash
-curl -sS -X POST \
-  http://127.0.0.1:7410/agentcompose.v1.SessionService/CreateSession \
-  -H 'Content-Type: application/json' \
-  -H 'Connect-Protocol-Version: 1' \
-  -d '{"title":"playground-verify"}'
-```
-
-Notes:
-
-- `base_workspace` is not required for the current playground smoke
-  verification.
-- If you need a real workspace, prefer managing `workspace_id` through
-  `ConfigService`. The currently supported workspace types are `file` and
-  `git`.
-
-### 7. Query Sandbox State Through v1 Compatibility API
-
-```bash
-curl -sS -X POST \
-  http://127.0.0.1:7410/agentcompose.v1.SessionService/ListSessions \
-  -H 'Content-Type: application/json' \
-  -H 'Connect-Protocol-Version: 1' \
-  -d '{}'
-```
-
-### 8. Get Notebook Proxy Entry
-
-Take the v1 `sessionId` field from the previous response, then run:
-
-```bash
-curl -sS -X POST \
-  http://127.0.0.1:7410/agentcompose.v1.SessionService/GetSessionProxy \
-  -H 'Content-Type: application/json' \
-  -H 'Connect-Protocol-Version: 1' \
-  -d '{"sessionId":"<sandbox_id>"}'
-```
-
-Expected fields:
-
-- `proxyPath`, for example `/jupyter/<sandbox_id>/lab`
-- `notebookUrl`, for example `/jupyter/<sandbox_id>/lab?token=...`
-- `driver`
-- `vmStatus`
+Use the CLI `ps` output or the v2 `SandboxService.ListSandboxes` and
+`SandboxService.GetSandbox` RPCs to obtain a sandbox ID and proxy entry. The
+proxy path is normally `/jupyter/<sandbox_id>/lab`; the v2 response carries the
+driver, runtime status, and notebook URL when the proxy is ready.
 
 ## Cold Start Characteristics
 
@@ -220,7 +169,7 @@ If any of these happened:
 - `/data/playground/data/agent-compose` was cleared
 - `image-cache` or `boxlite` cache directories were deleted
 
-then the first v1-compatible `CreateSession` may be noticeably slower. This is usually normal
+then the first sandbox creation may be noticeably slower. This is usually normal
 warmup and does not mean the RPC layer is stuck.
 
 Important cache directories:
@@ -249,7 +198,7 @@ After clearing the data directory, prewarm after deployment:
 
 1. Update and start the `agent-compose` container.
 2. Create a temporary sandbox, for example `playground-prewarm`.
-3. Poll `ListSessions` until it becomes `RUNNING`.
+3. Poll `SandboxService.ListSandboxes` until the sandbox becomes `RUNNING`.
 4. Start formal feature verification.
 
 ## Troubleshooting
@@ -270,7 +219,7 @@ reverse proxy config, and connectivity from it to daemon
 daemon container embeds `/agent-compose.html` as the signal for frontend
 deployment success.
 
-### 2. `CreateSession` Fails Or Stays `PENDING`
+### 2. Sandbox Creation Fails Or Stays `PENDING`
 
 Check:
 
@@ -288,11 +237,11 @@ Confirm first:
   be pulled
 - whether this is only the first cold start rebuilding caches
 
-### 3. `GetSessionProxy` Returns 502 Or Notebook Is Not Reachable
+### 3. Sandbox Proxy Returns 502 Or Notebook Is Not Reachable
 
 Check:
 
-- `vmStatus` in `ListSessions`
+- sandbox runtime status in `SandboxService.GetSandbox`
 - `docker logs --tail 200 agent-compose`
 - proxy / VM state files under the corresponding sandbox directory
 

--- a/docs/design/project_octobus_servers_design.md
+++ b/docs/design/project_octobus_servers_design.md
@@ -2,9 +2,9 @@
 
 ## 1. 背景与目标
 
-agent-compose 当前只支持在 daemon Settings 中配置一个全局 OctoBus
-连接。所有 project、agent 和 sandbox 共享同一个 OctoBus 地址与 token；agent
-只通过 `capset_ids` 声明允许使用的 capability sets。
+agent-compose 同时支持 daemon Settings 中的全局 OctoBus 连接和 project
+声明的具名 `octobus_servers`。未限定的 `capset_ids` 使用全局连接，带
+server 限定的 declaration 在 daemon 运行时解析对应 project server。
 
 单一全局连接限制了以下使用方式：
 
@@ -540,7 +540,7 @@ capset declaration 解析 target 的小接口，而不是让 capproxy 直接依�
 
 ## 12. 文档和发布
 
-实现时需要同步：
+该功能已实现；以下文档是维护和回归检查时需要同步的边界：
 
 - compose YAML 英文和中文手册；
 - project/capability API 文档；

--- a/docs/design/resource_identity_cli_design.md
+++ b/docs/design/resource_identity_cli_design.md
@@ -1,8 +1,8 @@
 # Resource Identity and CLI Display Design
 
-Status: design proposal. This document describes the intended CLI-facing
-resource identity model and output shape. It does not require code changes by
-itself.
+This document is a proposal, not an implementation contract. It describes the
+intended CLI-facing resource identity model and output shape. It does not
+require code changes by itself.
 
 The examples use sanitized project-relative paths:
 

--- a/docs/design/runtime-bidirectional-stream-design.md
+++ b/docs/design/runtime-bidirectional-stream-design.md
@@ -1,11 +1,15 @@
 # Runtime Bidirectional Interaction Stream Design
 
+The Docker command and agent attach paths are implemented. Microsandbox
+supports native command attach but not agent attach; BoxLite interaction
+remains unsupported by the current runtime API.
+
 ## Background
 
 The current execution boundary from the agent-compose daemon to the runtime is centered on `ExecStream`:
 
 ```go
-ExecStream(context.Context, *Session, VMState, ExecSpec, ExecStreamWriter) (ExecResult, error)
+ExecStream(context.Context, *Sandbox, VMState, ExecSpec, ExecStreamWriter) (ExecResult, error)
 ```
 
 This interface can express "one-shot start parameters plus a runtime-to-daemon output stream", but it cannot express ongoing interaction such as stdin, TTY, terminal resize, signal/cancel, multi-turn agent input, or structured runtime events. As a result, `exec`, `run --command`, scheduler commands, cells, and agent prompts currently rely on file protocols such as `command-request.json`, prompt files, script files, stdout markers, and result files to carry control semantics.

--- a/docs/design/webhook_design.md
+++ b/docs/design/webhook_design.md
@@ -2,7 +2,9 @@
 
 This document describes the external event ingress and topic event dispatch
 model currently implemented in code, and records the target design still to be
-completed. Relevant implementation lives mainly in:
+completed. Sections explicitly labeled as current describe implemented behavior;
+target delivery and provider verification sections remain proposals. Relevant
+implementation lives mainly in:
 
 - HTTP handler: `pkg/events/webhooks/http.go`
 - Topic event model: `pkg/model/`


### PR DESCRIPTION
## Summary

- Audit and correct all `docs/design` documents against the current v2 control plane, runtime providers, OctoBus integration, driver capabilities, and deployment behavior.
- Add explicit implementation/proposal/obsolete status markers and remove stale v1 control-plane, deleted frontend, and nonexistent source-path claims.
- Align the root English and Chinese READMEs, including Docker Hub image acquisition without `install.sh`, release tag behavior, multi-architecture image details, and manual Compose pinning.

## Validation

Local:

- `task lint`
- `task --force docs:build`
- Markdown relative-link check
- `git diff --check`

PR CI passed lint, Go tests, coverage, protobuf compatibility, runtime checks, installer binaries, and the maintained Darwin/Linux binary matrix.

Documentation-only change; full `task build` and `task test` were not run locally.