### PR TITLE
chore(runtime): bump packages to 0.8.0

### DIFF
--- a/runtime/agent-compose-runtime-sdk/package-lock.json
+++ b/runtime/agent-compose-runtime-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime-sdk",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "zod": "^4.4.3"

--- a/runtime/agent-compose-runtime-sdk/package.json
+++ b/runtime/agent-compose-runtime-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Node.js SDK for scripts running inside an agent-compose guest runtime.",
   "license": "LGPL-3.0-only",
   "type": "module",

--- a/runtime/javascript/package-lock.json
+++ b/runtime/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.206",

--- a/runtime/javascript/package.json
+++ b/runtime/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Guest-side runtime CLI for agent-compose agent sessions.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `@chaitin-ai/agent-compose-runtime` from `0.7.0` to `0.8.0`.
- Bump `@chaitin-ai/agent-compose-runtime-sdk` from `0.7.0` to `0.8.0`.
- Synchronize both package lockfiles for the runtime release.

## Testing

- `cd runtime/javascript && npm run typecheck` — passed.
- `cd runtime/javascript && TEST_SHAPE=unit npm run test:unit` — 171 passed, 1 Pi runner argument assertion failed; unrelated to the version-only diff.
- `cd runtime/agent-compose-runtime-sdk && npm test` — passed, 34 tests.
- `cd runtime/agent-compose-runtime-sdk && npm run test:packaging` — passed.

## Checklist

- [ ] Documentation updated when behavior or configuration changed — not applicable to this version-only change.
- [ ] Tests added or updated for user-visible behavior — not applicable to this version-only change.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.