### PR TITLE
fix(deploy): separate UI persistent data directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ AGENT_COMPOSE_HTTP_PORT=80
 # Host directory bind-mounted at /data. The installer persists the legacy
 # ./data/agent-compose layout when upgrading an installation that uses it.
 AGENT_COMPOSE_DATA_DIR=./data
+# Separate host directory for the UI server database and UI-side state. Use an
+# absolute path when the UI data should live outside the daemon deployment dir.
+AGENT_COMPOSE_UI_DATA_DIR=./data/agent-compose-ui
 
 # ---------------------------------------------------------------------------
 # Authentication

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Current Docker build behavior:
 
 Current compose behavior:
 
-- `docker-compose.yml` deploys the `agent-compose` service; the optional `agent-compose-frontend` service uses the published `agent-compose-ui` image under the `with-ui` profile
+- `docker-compose.yml` deploys the `agent-compose` service; the optional `agent-compose-ui` service uses the published `agent-compose-ui` image under the `with-ui` profile
 - the daemon listens on container port `7410`, published only on host loopback as `127.0.0.1:7410`; the UI profile publishes `${AGENT_COMPOSE_HTTP_PORT:-80}`
 - data is mounted from `${AGENT_COMPOSE_DATA_DIR:-./data}` to `/data`
 - the user-created `.env` is mounted read-only at `/data/work/.env` for daemon configuration

--- a/cmd/agent-compose/compose_env_e2e_test.go
+++ b/cmd/agent-compose/compose_env_e2e_test.go
@@ -58,6 +58,13 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 	if service.WorkingDir != "/data/work" {
 		t.Fatalf("agent-compose working_dir = %q, want /data/work", service.WorkingDir)
 	}
+	frontend, ok := composeFile.Services["agent-compose-frontend"]
+	if !ok {
+		t.Fatalf("docker-compose.yml missing agent-compose-frontend service")
+	}
+	if !stringSliceContains(frontend.Volumes, "${AGENT_COMPOSE_UI_DATA_DIR:-./data/agent-compose-ui}:/data") {
+		t.Fatalf("agent-compose-frontend volumes = %#v, want persistent UI data mount", frontend.Volumes)
+	}
 
 	for _, want := range []string{
 		"AGENT_COMPOSE_DATA_DIR=./data",

--- a/cmd/agent-compose/compose_env_e2e_test.go
+++ b/cmd/agent-compose/compose_env_e2e_test.go
@@ -58,12 +58,12 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 	if service.WorkingDir != "/data/work" {
 		t.Fatalf("agent-compose working_dir = %q, want /data/work", service.WorkingDir)
 	}
-	frontend, ok := composeFile.Services["agent-compose-frontend"]
+	frontend, ok := composeFile.Services["agent-compose-ui"]
 	if !ok {
-		t.Fatalf("docker-compose.yml missing agent-compose-frontend service")
+		t.Fatalf("docker-compose.yml missing agent-compose-ui service")
 	}
 	if !stringSliceContains(frontend.Volumes, "${AGENT_COMPOSE_UI_DATA_DIR:-./data/agent-compose-ui}:/data") {
-		t.Fatalf("agent-compose-frontend volumes = %#v, want persistent UI data mount", frontend.Volumes)
+		t.Fatalf("agent-compose-ui volumes = %#v, want persistent UI data mount", frontend.Volumes)
 	}
 
 	for _, want := range []string{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
     ports:
       - 127.0.0.1:7410:7410
 
-  agent-compose-frontend:
+  agent-compose-ui:
     image: ${AGENT_COMPOSE_FRONTEND_IMAGE:-chaitin/agent-compose-ui:latest}
-    container_name: agent-compose-frontend
+    container_name: agent-compose-ui
     profiles:
       - with-ui
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - agent-compose
     env_file:
       - ./.env
+    volumes:
+      - ${AGENT_COMPOSE_UI_DATA_DIR:-./data/agent-compose-ui}:/data
     environment:
       JUPYTER_PROXY_BASE: ${JUPYTER_PROXY_BASE:-/jupyter}
       NGINX_JUPYTER_PROXY_BASE: ${JUPYTER_PROXY_BASE:-/jupyter}

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -1007,8 +1007,8 @@ The current Docker deployment provides an independent frontend service:
 
 - The `agent-compose-ui` repository builds and publishes the frontend image.
 - Compose has two services: `agent-compose` daemon and
-  `agent-compose-frontend`.
-- The daemon starts by default; the `agent-compose-frontend` service starts
+  `agent-compose-ui`.
+- The daemon starts by default; the `agent-compose-ui` service starts
   when the `with-ui` profile is enabled.
 - The frontend image runs the agent-compose-ui server behind nginx. Nginx owns
   static assets, access logs, body size limits, timeouts, and WebSocket upgrade

--- a/docs/design/playground_setup.md
+++ b/docs/design/playground_setup.md
@@ -9,7 +9,7 @@ Current real environment:
 - Deployment directory: `/data/playground`
 - Compose file: `/data/playground/docker-compose.yml`
 - Current shared compose deploys the `agent-compose` daemon and the independent
-  `agent-compose-frontend` frontend service
+  `agent-compose-ui` frontend service
 
 For local integration testing, use the repository-root `docker-compose.yml`.
 Do not mix this shared playground document with the local compose setup inside
@@ -40,7 +40,7 @@ service:
 - Data mount: `./data/agent-compose:/data`
 - Extra runtime mount: `/var/run/docker.sock:/var/run/docker.sock`
 
-Current key configuration for the shared playground `agent-compose-frontend`
+Current key configuration for the shared playground `agent-compose-ui`
 service:
 
 - Listen port: `8000`
@@ -78,13 +78,13 @@ task image:agent-compose
 Start or update daemon and independent frontend service:
 
 ```bash
-docker compose -f /data/playground/docker-compose.yml up -d agent-compose agent-compose-frontend
+docker compose -f /data/playground/docker-compose.yml up -d agent-compose agent-compose-ui
 ```
 
 Force recreate containers after image updates:
 
 ```bash
-docker compose -f /data/playground/docker-compose.yml up -d --force-recreate agent-compose agent-compose-frontend
+docker compose -f /data/playground/docker-compose.yml up -d --force-recreate agent-compose agent-compose-ui
 ```
 
 Check status:
@@ -92,7 +92,7 @@ Check status:
 ```bash
 docker compose -f /data/playground/docker-compose.yml ps
 docker logs --tail 200 agent-compose
-docker logs --tail 200 agent-compose-frontend
+docker logs --tail 200 agent-compose-ui
 ```
 
 ## Basic Verification
@@ -261,7 +261,7 @@ Check:
 ```bash
 docker compose -f /data/playground/docker-compose.yml ps
 docker logs --tail 200 agent-compose
-docker logs --tail 200 agent-compose-frontend
+docker logs --tail 200 agent-compose-ui
 ```
 
 If the independent frontend cannot be opened, first verify the frontend service,
@@ -313,5 +313,5 @@ Rebuild images and force recreate containers:
 cd /data/code
 task image:agent-compose-guest
 task image:agent-compose
-docker compose -f /data/playground/docker-compose.yml up -d --force-recreate agent-compose agent-compose-frontend
+docker compose -f /data/playground/docker-compose.yml up -d --force-recreate agent-compose agent-compose-ui
 ```


### PR DESCRIPTION
## Summary

- Keep daemon persistent data configurable through `AGENT_COMPOSE_DATA_DIR` (default: `./data`)
- Add a separate `AGENT_COMPOSE_UI_DATA_DIR` for UI server state (default: `./data/agent-compose-ui`)
- Mount the UI data directory at `/data` in the `agent-compose-ui` service
- Rename the Compose service and container from `agent-compose-frontend` to `agent-compose-ui` to match the image name
- Keep the existing nginx-to-Go-server layout and public UI port `8000` unchanged

## Verification

- `go test ./cmd/agent-compose -run TestE2EDockerComposeSandboxEnvContract -count=1`
- `docker compose --env-file .env.example --profile with-ui config --quiet`
- `git diff --check`

Not run: installer asset validation, because the host macOS Bash 3.2 does not support the Bash 4 associative arrays used by the script.