### PR TITLE
docs: document versioned release image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,31 +99,37 @@ preservation, and mirror/private-registry options.
 ### Option B — Pull published images (without the installer)
 
 Published daemon and guest images are available from [Docker
-Hub](https://hub.docker.com/u/chaitin). Pull the stable multi-architecture
-images directly:
+Hub](https://hub.docker.com/u/chaitin). Always use an explicit release tag when
+pulling images. Select `AGENT_COMPOSE_VERSION` from the
+[agent-compose Releases](https://github.com/chaitin/agent-compose/releases)
+page, and select `AGENT_COMPOSE_UI_VERSION` independently from the
+[agent-compose-ui Releases](https://github.com/chaitin/agent-compose-ui/releases)
+page:
 
 ```bash
-docker pull chaitin/agent-compose:latest
-docker pull chaitin/agent-compose-guest:latest
-```
+export AGENT_COMPOSE_VERSION=<agent-compose-release-tag>
+export AGENT_COMPOSE_UI_VERSION=<agent-compose-ui-release-tag>
 
-For a pinned application release, replace `latest` with its release tag (for
-example `v1.2.3`) on both images. The optional frontend is published
-independently and can be pulled with its supported UI tag:
-
-```bash
-docker pull chaitin/agent-compose-ui:latest
+docker pull chaitin/agent-compose:${AGENT_COMPOSE_VERSION}
+docker pull chaitin/agent-compose-guest:${AGENT_COMPOSE_VERSION}
+docker pull chaitin/agent-compose-ui:${AGENT_COMPOSE_UI_VERSION}
 ```
 
 The daemon and standard guest images publish `linux/amd64` and `linux/arm64`
 manifests. The UI tag is selected independently from the daemon release. To
 deploy with Compose, use `docker-compose.yml` and `.env.example` from the
-matching repository tag, copy `.env.example` to `.env`, and fill in the
-required settings. For a pinned deployment, add `AGENT_COMPOSE_IMAGE` and
-`DEFAULT_IMAGE` with the daemon and guest references shown above; add
-`AGENT_COMPOSE_FRONTEND_IMAGE` when pinning the optional UI. Then run
-`docker compose pull` and `docker compose up -d`, adding `--profile with-ui`
-when the frontend is needed.
+matching agent-compose repository tag, copy `.env.example` to `.env`, and fill
+in the required settings. Set the image references in `.env` to the tags you
+selected above:
+
+```dotenv
+AGENT_COMPOSE_IMAGE=chaitin/agent-compose:<agent-compose-release-tag>
+DEFAULT_IMAGE=chaitin/agent-compose-guest:<agent-compose-release-tag>
+AGENT_COMPOSE_FRONTEND_IMAGE=chaitin/agent-compose-ui:<agent-compose-ui-release-tag>
+```
+
+Then run `docker compose pull` and `docker compose up -d`, adding
+`--profile with-ui` when the frontend is needed.
 
 ### Option C — Build from source (for the CLI workflow)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,27 +62,34 @@ installer 还会预先拉取 sandbox guest 镜像，避免首次运行 agent 时
 
 ### 方式 B —— 直接获取发布镜像（无需 install.sh）
 
-daemon 和 guest 镜像发布在 [Docker Hub](https://hub.docker.com/u/chaitin)，可以直接拉取稳定的多架构镜像：
+daemon 和 guest 镜像发布在 [Docker Hub](https://hub.docker.com/u/chaitin)。拉取镜像时必须使用明确的 release tag：先从
+[agent-compose Releases](https://github.com/chaitin/agent-compose/releases)
+页面选择 `AGENT_COMPOSE_VERSION`，再从独立的
+[agent-compose-ui Releases](https://github.com/chaitin/agent-compose-ui/releases)
+页面选择 `AGENT_COMPOSE_UI_VERSION`：
 
 ```bash
-docker pull chaitin/agent-compose:latest
-docker pull chaitin/agent-compose-guest:latest
-```
+export AGENT_COMPOSE_VERSION=<agent-compose-release-tag>
+export AGENT_COMPOSE_UI_VERSION=<agent-compose-ui-release-tag>
 
-需要固定应用版本时，将 `latest` 替换为对应 release tag（例如
-`v1.2.3`），daemon 和 guest 使用相同的应用版本 tag。可选的 Web UI 独立发布，版本号与 daemon 独立：
-
-```bash
-docker pull chaitin/agent-compose-ui:latest
+docker pull chaitin/agent-compose:${AGENT_COMPOSE_VERSION}
+docker pull chaitin/agent-compose-guest:${AGENT_COMPOSE_VERSION}
+docker pull chaitin/agent-compose-ui:${AGENT_COMPOSE_UI_VERSION}
 ```
 
 daemon 和标准 guest 镜像提供 `linux/amd64`、`linux/arm64` manifest。要用
 Compose 手工部署，请使用对应 repository tag 中的 `docker-compose.yml` 和
-`.env.example`，将 `.env.example` 复制为 `.env` 并填写必需配置。固定版本时，
-还要在 `.env` 中增加 `AGENT_COMPOSE_IMAGE` 和 `DEFAULT_IMAGE`，分别使用上面的
-daemon 和 guest 镜像引用；需要固定可选 UI 时再增加
-`AGENT_COMPOSE_FRONTEND_IMAGE`。然后执行 `docker compose pull`、
-`docker compose up -d`；需要 Web UI 时增加 `--profile with-ui`。
+`.env.example`，将 `.env.example` 复制为 `.env` 并填写必需配置。在 `.env` 中
+使用上面选定的 tag 设置镜像引用：
+
+```dotenv
+AGENT_COMPOSE_IMAGE=chaitin/agent-compose:<agent-compose-release-tag>
+DEFAULT_IMAGE=chaitin/agent-compose-guest:<agent-compose-release-tag>
+AGENT_COMPOSE_FRONTEND_IMAGE=chaitin/agent-compose-ui:<agent-compose-ui-release-tag>
+```
+
+然后执行 `docker compose pull`、`docker compose up -d`；需要 Web UI 时增加
+`--profile with-ui`。
 
 ### 方式 C —— 从源码构建（用于 CLI 工作流）
 


### PR DESCRIPTION
## Summary

- document pulling daemon and guest images with explicit release tags
- document selecting the UI image tag from the agent-compose-ui Releases page
- add versioned Docker Compose image settings to English and Chinese READMEs

## Tests

- git diff --check