### PR TITLE
docs: refresh project readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ preservation, and mirror/private-registry options.
 
 ### Option B — Pull published images (without the installer)
 
-Published daemon and guest images are available from [Docker
-Hub](https://hub.docker.com/u/chaitin). Pull the latest published images:
+Published daemon, guest, and UI images are available from [Docker
+Hub](https://hub.docker.com/u/chaitin):
 
 ```bash
 docker pull chaitin/agent-compose:latest
@@ -106,7 +106,7 @@ docker pull chaitin/agent-compose-ui:latest
 
 The daemon and standard guest images publish `linux/amd64` and `linux/arm64`
 manifests. To deploy with Compose, copy `.env.example` to `.env`, fill in the
-required settings, and use the latest image tags:
+required settings, and use these image references:
 
 ```dotenv
 AGENT_COMPOSE_IMAGE=chaitin/agent-compose:latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center">
   <img src="images/agent-compose-logo.png" alt="Agent-compose" width="384">
-  <div align="center">
+</p>
+<p align="center">
   <a href="https://github.com/chaitin/agent-compose/actions/workflows/ci.yml">
     <img src="https://github.com/chaitin/agent-compose/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI">
   </a>
@@ -10,14 +11,14 @@
   <a href="LICENSE.txt">
     <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL v3">
   </a>
-</div>
+</p>
+<p align="center">
+  <a href="https://agent-compose.ai">Website</a> ·
+  <a href="https://demo.agent-compose.ai">Demo</a> ·
+  <a href="README.zh-CN.md">中文文档</a>
 </p>
 
 **agent-compose is a daemon + CLI control plane that runs AI coding agents in isolated sandboxes.** You describe your agents in an `agent-compose.yml` file, and a long-lived daemon builds, runs, schedules, and proxies an isolated runtime for each one.
-
-> Public preview. APIs, runtime packaging, and deployment defaults may still change. It is suitable for experimentation, local development, and preview deployments — not yet a stable production platform.
-
-📖 中文文档：[中文 README](README.zh-CN.md)
 
 ## What is agent-compose?
 
@@ -25,8 +26,7 @@ If you know Docker Compose, the mental model is familiar: instead of declaring
 containers, you declare **agents**. Each agent picks a provider CLI — `codex`,
 `claude` (Claude Code), `gemini`, `opencode`, or `pi` — and the daemon gives it its own
 isolated sandbox with a workspace, then runs it on a prompt, a shell command, a
-schedule, or an event. Provider API keys stay on the daemon and are never exposed
-inside the guest.
+schedule, or an event.
 
 You manage the whole lifecycle with a Compose-style CLI (`up`, `run`, `ps`,
 `logs`, `down`), and everything is driven by one declarative file.
@@ -39,15 +39,12 @@ Concretely, agent-compose provides:
 - A **scheduler** with `cron`, `interval`, `timeout`, and `event` triggers — or full inline JavaScript scheduler scripts.
 - **Event triggers and webhooks** for event-driven agent runs.
 - **Workspaces** provisioned from a local directory or a Git repository.
-- A **Runtime LLM Facade** that brokers LLM credentials so provider keys never enter guest containers.
 - **MCP servers, reusable skills, and named volumes** per agent.
-- A **Jupyter proxy** for notebook-style guest runtimes.
-- **v2 Connect APIs**; the separate web UI repository tracks generated TypeScript clients.
 
 ## How it works
 
 The **daemon** is the single source of truth: it owns persistence, scheduler
-execution, runtime lifecycle, the Connect/HTTP APIs, and Jupyter proxying. The
+execution, runtime lifecycle, and control-plane APIs. The
 **CLI** is a thin client — it reads your local `agent-compose.yml`, validates it,
 and calls the daemon. The compose file describes *projects and agents*, not
 already-running sandboxes. The **web UI** is a separate service
@@ -99,33 +96,22 @@ preservation, and mirror/private-registry options.
 ### Option B — Pull published images (without the installer)
 
 Published daemon and guest images are available from [Docker
-Hub](https://hub.docker.com/u/chaitin). Always use an explicit release tag when
-pulling images. Select `AGENT_COMPOSE_VERSION` from the
-[agent-compose Releases](https://github.com/chaitin/agent-compose/releases)
-page, and select `AGENT_COMPOSE_UI_VERSION` independently from the
-[agent-compose-ui Releases](https://github.com/chaitin/agent-compose-ui/releases)
-page:
+Hub](https://hub.docker.com/u/chaitin). Pull the latest published images:
 
 ```bash
-export AGENT_COMPOSE_VERSION=<agent-compose-release-tag>
-export AGENT_COMPOSE_UI_VERSION=<agent-compose-ui-release-tag>
-
-docker pull chaitin/agent-compose:${AGENT_COMPOSE_VERSION}
-docker pull chaitin/agent-compose-guest:${AGENT_COMPOSE_VERSION}
-docker pull chaitin/agent-compose-ui:${AGENT_COMPOSE_UI_VERSION}
+docker pull chaitin/agent-compose:latest
+docker pull chaitin/agent-compose-guest:latest
+docker pull chaitin/agent-compose-ui:latest
 ```
 
 The daemon and standard guest images publish `linux/amd64` and `linux/arm64`
-manifests. The UI tag is selected independently from the daemon release. To
-deploy with Compose, use `docker-compose.yml` and `.env.example` from the
-matching agent-compose repository tag, copy `.env.example` to `.env`, and fill
-in the required settings. Set the image references in `.env` to the tags you
-selected above:
+manifests. To deploy with Compose, copy `.env.example` to `.env`, fill in the
+required settings, and use the latest image tags:
 
 ```dotenv
-AGENT_COMPOSE_IMAGE=chaitin/agent-compose:<agent-compose-release-tag>
-DEFAULT_IMAGE=chaitin/agent-compose-guest:<agent-compose-release-tag>
-AGENT_COMPOSE_FRONTEND_IMAGE=chaitin/agent-compose-ui:<agent-compose-ui-release-tag>
+AGENT_COMPOSE_IMAGE=chaitin/agent-compose:latest
+DEFAULT_IMAGE=chaitin/agent-compose-guest:latest
+AGENT_COMPOSE_FRONTEND_IMAGE=chaitin/agent-compose-ui:latest
 ```
 
 Then run `docker compose pull` and `docker compose up -d`, adding
@@ -181,102 +167,6 @@ agent-compose down                                # stop sandboxes, disable sche
 
 More runnable examples (cron, timeout, scheduler scripts) live in
 [examples/agent-compose/](examples/agent-compose/).
-
-## One-time V2 storage migration
-
-`agent-compose-v2-storage-migrator` is a transitional, one-time tool for data
-roots created by the legacy storage layout. It is intentionally not included
-in daemon images or the default `task build`.
-
-Databases with a valid, versioned migration prefix and only project-managed
-agents and schedulers upgrade normally when opened by the new daemon. Use the
-migrator for legacy or unversioned roots, including standalone or mixed
-agent/loader layouts.
-
-### Stop running sandboxes
-
-Do not use `agent-compose down` for migration cutover. In legacy releases,
-`down` also marks the project removed, disables its schedulers, and removes
-its volume associations. Without the original compose file, the migrated
-project cannot be restored safely from those changes.
-
-Keep the old daemon running and stop every running sandbox by its full ID:
-
-```bash
-agent-compose stop <sandbox-id> [<sandbox-id>...]
-```
-
-Using a full ID does not require a compose file or project selection and also
-works for legacy standalone sandboxes. The dry run below reports all sandbox
-IDs whose persisted metadata is still `running`.
-
-Dry-run only inspects the source and uses a temporary database copy. It does
-not modify either data root, create the target, copy sandbox workspaces, or
-create an in-place backup.
-
-Immediately after the last `stop` command, stop the old daemon and keep it
-stopped. A scheduler may create another sandbox in the short interval before
-daemon shutdown, so the post-shutdown dry run is the authority: if it reports
-any running IDs, restart the old daemon, stop every reported ID, stop the
-daemon again, and repeat the dry run. Do not use `docker stop` for sandboxes;
-the old daemon must persist their stopped state.
-
-### Build and run from source
-
-Build the migrator explicitly from the repository root, then select the
-resulting binary:
-
-```bash
-task build:migrator
-MIGRATOR=./build/agent-compose-migrate
-```
-
-The migrator is not built by the default `task build`.
-
-### Run a published binary
-
-Download `SHASUMS256.txt` and the matching manually published Linux release
-asset:
-
-- `agent-compose-v2-storage-migrator-linux-amd64`
-- `agent-compose-v2-storage-migrator-linux-arm64`
-
-Verify it, make it executable, and select it. For example, on amd64:
-
-```bash
-grep '  agent-compose-v2-storage-migrator-linux-amd64$' SHASUMS256.txt | sha256sum -c -
-chmod +x agent-compose-v2-storage-migrator-linux-amd64
-MIGRATOR=./agent-compose-v2-storage-migrator-linux-amd64
-```
-
-### Perform the migration
-
-Set `DATA_ROOT` to the deployment's data directory. Set `RUNTIME_ROOT` to the
-path that the new daemon will see (`/data` for the standard container
-deployment, or the same path as `DATA_ROOT` for a native daemon). You may run
-the read-only dry run while the old daemon is still available to discover all
-running sandbox IDs, then stop those IDs with the old CLI as described above.
-After stopping the old daemon, run the same dry run again before migration:
-
-```bash
-DATA_ROOT=/opt/agent-compose/data
-RUNTIME_ROOT=/data
-"$MIGRATOR" --source "$DATA_ROOT" --target "$DATA_ROOT" \
-  --runtime-root "$RUNTIME_ROOT" --dry-run
-```
-
-The post-shutdown dry run must succeed. Back up the complete data root, then
-run the migration without `--dry-run`:
-
-```bash
-"$MIGRATOR" --source "$DATA_ROOT" --target "$DATA_ROOT" \
-  --runtime-root "$RUNTIME_ROOT" --json
-```
-
-Keep the old daemon stopped until migration and validation finish. When a
-separate rollback copy is required, pass different `--source` and `--target`
-directories and set `--runtime-root` to the target path visible to the new
-daemon.
 
 ## The compose file
 
@@ -395,15 +285,6 @@ Each agent sets a `provider`, which selects the CLI it runs inside the sandbox:
 | `opencode` | OpenCode CLI |
 | `pi` | Pi coding agent CLI |
 
-You configure LLM credentials once, on the daemon (in `.env`) — not per guest.
-For Codex, Claude, OpenCode, and Pi, the daemon's **Runtime LLM Facade** hands each
-sandbox a scoped token instead of your real API key, so provider keys never enter
-the guest. When that token pins an upstream provider, the model in each runtime
-request is forwarded to that provider and does not need to be listed in
-agent-compose first; an unsupported model returns the upstream provider's error.
-Compatibility tokens without a provider keep the existing configured
-model/provider resolution behavior.
-
 Set the variables for the backend family your agents use. **OpenAI-family**
 (Codex, plus the daemon's own `LLMService` and scheduler LLM calls):
 
@@ -425,17 +306,12 @@ ANTHROPIC_MODEL=claude-...
 Set `LLM_API_PROTOCOL=chat_completions` to target any OpenAI-compatible endpoint
 (DeepSeek, vLLM, Ollama).
 
-**Per-provider notes.** OpenCode picks its upstream family from the agent's
-`model` (`provider/model`, e.g. `anthropic/…` or `openai/…`) and gets a facade
-token for it; only OpenCode's own native provider uses OpenCode's login instead.
-**Gemini is the exception** — it is never handed an LLM key (`GEMINI_API_KEY` /
+**Gemini** is never handed an LLM key (`GEMINI_API_KEY` /
 `GOOGLE_API_KEY` are filtered out of the guest) and authenticates through the
 Gemini CLI's own login, persisted under the sandbox home (`~/.gemini`).
 
 See [`.env.example`](.env.example) for the full list (timeouts, endpoint aliases,
-`OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) and the
-[daemon LLM client design](docs/design/agent-compose_design.md#daemon-llm-client)
-for how brokering works.
+`OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN`).
 
 ## Deployment & configuration
 
@@ -475,18 +351,14 @@ configuration reference.** At minimum, review these before exposing a deployment
 - `AUTH_PASSWORD`, `AUTH_SECRET` — UI server login secrets (replace the examples).
 - `AGENT_COMPOSE_AUTH_TOKEN` — optional shared Bearer token for daemon HTTP(S) control-plane access.
 - `AGENT_COMPOSE_HTTP_PORT` — host port for the web UI / reverse proxy (`with-ui`).
-- `AGENT_COMPOSE_RUNTIME_BASE_URL` — guest-reachable daemon URL used for the LLM facade.
 - `RUNTIME_DRIVER` — default runtime driver.
 
 ## Web UI
 
 The web UI lives in a separate repository,
-[agent-compose-ui](https://github.com/chaitin/agent-compose-ui). It directly tracks
-the generated `agentcompose/v2` and `health/v1` TypeScript clients built from this
-repository's `proto/`; the generated files are reviewed together with protocol
-changes. The daemon does not host the UI or browser
+[agent-compose-ui](https://github.com/chaitin/agent-compose-ui). The daemon does not host the UI or browser
 login flows; the UI image runs nginx in front of a Go UI server that owns
-auth/OAuth and proxies API and Jupyter routes to the daemon.
+auth/OAuth and proxies API routes to the daemon.
 
 ## Security
 
@@ -497,7 +369,6 @@ deployment to a network:
 - Set a stable, high-entropy `AUTH_SECRET`, and terminate HTTPS in production.
 - Keep the daemon TCP API (`HTTP_LISTEN`) behind container networking, a reverse proxy, or a VPN.
 - When daemon token authentication is enabled, use HTTPS or another protected tunnel across machines; plain HTTP does not prevent token capture and replay.
-- Do not expose guest Jupyter ports directly — reach them through the agent-compose proxy.
 - Treat Git credentials, uploaded workspaces, environment variables, and LLM API keys as secrets.
 
 See [SECURITY.md](SECURITY.md) for vulnerability reporting and hardening notes.
@@ -544,6 +415,102 @@ components live under `runtime/`.
 - [Documentation homepage](https://chaitin.github.io/agent-compose/)
 - [Command line manual](docs/pages/command-line-manual.md)
 - [agent-compose.yml manual](docs/pages/agent-compose-yaml-manual.md)
+
+## One-time V2 storage migration
+
+`agent-compose-v2-storage-migrator` is a transitional, one-time tool for data
+roots created by the legacy storage layout. It is intentionally not included
+in daemon images or the default `task build`.
+
+Databases with a valid, versioned migration prefix and only project-managed
+agents and schedulers upgrade normally when opened by the new daemon. Use the
+migrator for legacy or unversioned roots, including standalone or mixed
+agent/loader layouts.
+
+### Stop running sandboxes
+
+Do not use `agent-compose down` for migration cutover. In legacy releases,
+`down` also marks the project removed, disables its schedulers, and removes
+its volume associations. Without the original compose file, the migrated
+project cannot be restored safely from those changes.
+
+Keep the old daemon running and stop every running sandbox by its full ID:
+
+```bash
+agent-compose stop <sandbox-id> [<sandbox-id>...]
+```
+
+Using a full ID does not require a compose file or project selection and also
+works for legacy standalone sandboxes. The dry run below reports all sandbox
+IDs whose persisted metadata is still `running`.
+
+Dry-run only inspects the source and uses a temporary database copy. It does
+not modify either data root, create the target, copy sandbox workspaces, or
+create an in-place backup.
+
+Immediately after the last `stop` command, stop the old daemon and keep it
+stopped. A scheduler may create another sandbox in the short interval before
+daemon shutdown, so the post-shutdown dry run is the authority: if it reports
+any running IDs, restart the old daemon, stop every reported ID, stop the
+daemon again, and repeat the dry run. Do not use `docker stop` for sandboxes;
+the old daemon must persist their stopped state.
+
+### Build and run from source
+
+Build the migrator explicitly from the repository root, then select the
+resulting binary:
+
+```bash
+task build:migrator
+MIGRATOR=./build/agent-compose-migrate
+```
+
+The migrator is not built by the default `task build`.
+
+### Run a published binary
+
+Download `SHASUMS256.txt` and the matching manually published Linux release
+asset:
+
+- `agent-compose-v2-storage-migrator-linux-amd64`
+- `agent-compose-v2-storage-migrator-linux-arm64`
+
+Verify it, make it executable, and select it. For example, on amd64:
+
+```bash
+grep '  agent-compose-v2-storage-migrator-linux-amd64$' SHASUMS256.txt | sha256sum -c -
+chmod +x agent-compose-v2-storage-migrator-linux-amd64
+MIGRATOR=./agent-compose-v2-storage-migrator-linux-amd64
+```
+
+### Perform the migration
+
+Set `DATA_ROOT` to the deployment's data directory. Set `RUNTIME_ROOT` to the
+path that the new daemon will see (`/data` for the standard container
+deployment, or the same path as `DATA_ROOT` for a native daemon). You may run
+the read-only dry run while the old daemon is still available to discover all
+running sandbox IDs, then stop those IDs with the old CLI as described above.
+After stopping the old daemon, run the same dry run again before migration:
+
+```bash
+DATA_ROOT=/opt/agent-compose/data
+RUNTIME_ROOT=/data
+"$MIGRATOR" --source "$DATA_ROOT" --target "$DATA_ROOT" \
+  --runtime-root "$RUNTIME_ROOT" --dry-run
+```
+
+The post-shutdown dry run must succeed. Back up the complete data root, then
+run the migration without `--dry-run`:
+
+```bash
+"$MIGRATOR" --source "$DATA_ROOT" --target "$DATA_ROOT" \
+  --runtime-root "$RUNTIME_ROOT" --json
+```
+
+Keep the old daemon stopped until migration and validation finish. When a
+separate rollback copy is required, pass different `--source` and `--target`
+directories and set `--runtime-root` to the target path visible to the new
+daemon.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,17 @@
   <img src="images/agent-compose-logo.png" alt="Agent-compose" width="384">
 </p>
 <p align="center">
+  <a href="https://github.com/chaitin/agent-compose/actions/workflows/ci.yml">
+    <img src="https://github.com/chaitin/agent-compose/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI">
+  </a>
+  <a href="https://github.com/chaitin/agent-compose/actions/workflows/images.yml">
+    <img src="https://github.com/chaitin/agent-compose/actions/workflows/images.yml/badge.svg?branch=main" alt="Images & Release">
+  </a>
+  <a href="LICENSE.txt">
+    <img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License: AGPL v3">
+  </a>
+</p>
+<p align="center">
   <a href="https://agent-compose.ai">官网</a> ·
   <a href="https://demo.agent-compose.ai">Demo</a> ·
   <a href="README.md">English</a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ installer 还会预先拉取 sandbox guest 镜像，避免首次运行 agent 时
 
 ### 方式 B —— 直接获取发布镜像（无需 install.sh）
 
-daemon 和 guest 镜像发布在 [Docker Hub](https://hub.docker.com/u/chaitin)。直接拉取最新发布的镜像：
+daemon、guest 和 UI 镜像发布在 [Docker Hub](https://hub.docker.com/u/chaitin)：
 
 ```bash
 docker pull chaitin/agent-compose:latest
@@ -70,7 +70,7 @@ docker pull chaitin/agent-compose-ui:latest
 
 daemon 和标准 guest 镜像提供 `linux/amd64`、`linux/arm64` manifest。要用
 Compose 手工部署，请将 `.env.example` 复制为 `.env` 并填写必需配置，然后在
-`.env` 中使用 latest 镜像：
+`.env` 中使用以下镜像引用：
 
 ```dotenv
 AGENT_COMPOSE_IMAGE=chaitin/agent-compose:latest

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,18 +1,19 @@
 <p align="center">
   <img src="images/agent-compose-logo.png" alt="Agent-compose" width="384">
 </p>
+<p align="center">
+  <a href="https://agent-compose.ai">官网</a> ·
+  <a href="https://demo.agent-compose.ai">Demo</a> ·
+  <a href="README.md">English</a>
+</p>
 
 # agent-compose 中文文档
 
 **agent-compose 是一个 daemon + CLI 形态的控制面，用于在隔离 sandbox 中运行 AI coding agent。** 你在 `agent-compose.yml` 里声明 agent，一个常驻 daemon 负责为每个 agent 构建、运行、调度并代理一个隔离的 runtime。
 
-> 公开预览阶段。API、运行时打包和部署默认值仍可能调整。适合实验、本地开发和预览部署，尚未达到稳定生产平台。
-
-英文首页见 [README.md](README.md)。
-
 ## agent-compose 是什么？
 
-如果你了解 Docker Compose，这里的心智模型很类似：你声明的不是容器，而是 **agent**。每个 agent 选择一个 provider CLI —— `codex`、`claude`（Claude Code）、`gemini`、`opencode` 或 `pi` —— daemon 给它一个带 workspace 的隔离 sandbox，然后按 prompt、shell 命令、定时或事件来运行它。真实的 provider API key 留在 daemon 上，不会进入 guest。
+如果你了解 Docker Compose，这里的心智模型很类似：你声明的不是容器，而是 **agent**。每个 agent 选择一个 provider CLI —— `codex`、`claude`（Claude Code）、`gemini`、`opencode` 或 `pi` —— daemon 给它一个带 workspace 的隔离 sandbox，然后按 prompt、shell 命令、定时或事件来运行它。
 
 你用 Compose 风格的 CLI（`up`、`run`、`ps`、`logs`、`down`）管理整个生命周期，一切由一个声明式文件驱动。
 
@@ -24,14 +25,11 @@
 - **scheduler**：`cron`、`interval`、`timeout`、`event` 四种 trigger，或内联 JavaScript scheduler 脚本。
 - **事件触发与 webhook**，支持事件驱动的 agent run。
 - **workspace** 从本地目录或 Git 仓库拉取。
-- **Runtime LLM Facade**，托管 LLM 凭据，使 provider key 不进入 guest 容器。
 - 每个 agent 可配 **MCP server、可复用 skill、具名 volume**。
-- **Jupyter 代理**，支持 notebook 风格的 guest runtime。
-- **v2 Connect API** 与生成的 TypeScript client；`health.v1` 仅用于健康检查。
 
 ## 工作原理
 
-**daemon** 是唯一的状态权威：负责持久化、scheduler 执行、runtime 生命周期、Connect/HTTP API 和 Jupyter 代理。**CLI** 是一个轻客户端 —— 读取本地 `agent-compose.yml`，做本地校验，再调用 daemon。compose 文件描述的是 *project 和 agent*，不是已经在跑的 sandbox。**Web UI** 是独立服务（[agent-compose-ui](https://github.com/chaitin/agent-compose-ui)），不由 daemon 托管。
+**daemon** 是唯一的状态权威：负责持久化、scheduler 执行、runtime 生命周期和控制面 API。**CLI** 是一个轻客户端 —— 读取本地 `agent-compose.yml`，做本地校验，再调用 daemon。compose 文件描述的是 *project 和 agent*，不是已经在跑的 sandbox。**Web UI** 是独立服务（[agent-compose-ui](https://github.com/chaitin/agent-compose-ui)），不由 daemon 托管。
 
 完整架构见 [docs/design/agent-compose_design.md](docs/design/agent-compose_design.md)。
 
@@ -62,30 +60,22 @@ installer 还会预先拉取 sandbox guest 镜像，避免首次运行 agent 时
 
 ### 方式 B —— 直接获取发布镜像（无需 install.sh）
 
-daemon 和 guest 镜像发布在 [Docker Hub](https://hub.docker.com/u/chaitin)。拉取镜像时必须使用明确的 release tag：先从
-[agent-compose Releases](https://github.com/chaitin/agent-compose/releases)
-页面选择 `AGENT_COMPOSE_VERSION`，再从独立的
-[agent-compose-ui Releases](https://github.com/chaitin/agent-compose-ui/releases)
-页面选择 `AGENT_COMPOSE_UI_VERSION`：
+daemon 和 guest 镜像发布在 [Docker Hub](https://hub.docker.com/u/chaitin)。直接拉取最新发布的镜像：
 
 ```bash
-export AGENT_COMPOSE_VERSION=<agent-compose-release-tag>
-export AGENT_COMPOSE_UI_VERSION=<agent-compose-ui-release-tag>
-
-docker pull chaitin/agent-compose:${AGENT_COMPOSE_VERSION}
-docker pull chaitin/agent-compose-guest:${AGENT_COMPOSE_VERSION}
-docker pull chaitin/agent-compose-ui:${AGENT_COMPOSE_UI_VERSION}
+docker pull chaitin/agent-compose:latest
+docker pull chaitin/agent-compose-guest:latest
+docker pull chaitin/agent-compose-ui:latest
 ```
 
 daemon 和标准 guest 镜像提供 `linux/amd64`、`linux/arm64` manifest。要用
-Compose 手工部署，请使用对应 repository tag 中的 `docker-compose.yml` 和
-`.env.example`，将 `.env.example` 复制为 `.env` 并填写必需配置。在 `.env` 中
-使用上面选定的 tag 设置镜像引用：
+Compose 手工部署，请将 `.env.example` 复制为 `.env` 并填写必需配置，然后在
+`.env` 中使用 latest 镜像：
 
 ```dotenv
-AGENT_COMPOSE_IMAGE=chaitin/agent-compose:<agent-compose-release-tag>
-DEFAULT_IMAGE=chaitin/agent-compose-guest:<agent-compose-release-tag>
-AGENT_COMPOSE_FRONTEND_IMAGE=chaitin/agent-compose-ui:<agent-compose-ui-release-tag>
+AGENT_COMPOSE_IMAGE=chaitin/agent-compose:latest
+DEFAULT_IMAGE=chaitin/agent-compose-guest:latest
+AGENT_COMPOSE_FRONTEND_IMAGE=chaitin/agent-compose-ui:latest
 ```
 
 然后执行 `docker compose pull`、`docker compose up -d`；需要 Web UI 时增加
@@ -132,6 +122,205 @@ agent-compose down                                # 停止 sandbox、禁用 sche
 ```
 
 更多可运行示例（cron、timeout、scheduler 脚本）见 [examples/agent-compose/](examples/agent-compose/)。
+
+## Compose 配置
+
+**顶层字段：** `name`、`env_file`、`variables`、`workspaces`、`agents`、`mcp_servers`、`volumes`。
+
+**agent 常用字段：** `provider`、`model`、`system_prompt`、`image`、`driver`、
+`env`（scalar 或 `{ value, secret }`）、`workspace`、`scheduler`、`mcp_servers`、`skills`、`volumes`。
+
+为 agent 从本地路径（`provider: file`）或 Git 仓库（`provider: git`）配置 workspace：
+
+```yaml
+agents:
+  reviewer:
+    workspace:
+      provider: git
+      url: https://github.com/example/repo.git
+      ref: main
+      target: .
+```
+
+Scheduler 脚本可以是内联 JavaScript，也可以通过 `provider: file`、
+`provider: http` 或 `provider: git` 配置外部来源。`config` 和 `up` 会在本地
+读取外部脚本，并把内联内容快照发送给 daemon。例如，通过 HTTP 加载脚本：
+
+```yaml
+agents:
+  reviewer:
+    scheduler:
+      enabled: true
+      script:
+        provider: http
+        url: https://example.com/scheduler.js
+```
+
+添加定时或事件驱动的 run。`scheduler.triggers` 与内联 `scheduler.script` 在同一 scheduler 中二选一：
+
+```yaml
+agents:
+  reviewer:
+    scheduler:
+      enabled: true
+      triggers:
+        - name: hourly-review
+          cron: "0 * * * *"
+          prompt: "Review the current project state and summarize changes."
+```
+
+完整字段说明见[命令行使用手册](docs/pages/zh-CN/command-line-manual.md)。
+
+## CLI 概览
+
+| 命令 | 用途 |
+| --- | --- |
+| `agent-compose daemon` | 启动 HTTP/Connect daemon。 |
+| `agent-compose up` | 读取 `agent-compose.yml` 并应用 project。 |
+| `agent-compose run <agent> --prompt/--command` | 以 agent 身份执行 prompt 或 shell 命令。 |
+| `agent-compose exec <sandbox>` | 在运行中的 sandbox 内执行命令或 prompt。 |
+| `agent-compose ps` / `stats` | 列出 project sandbox / 查看 sandbox 资源统计。 |
+| `agent-compose logs` | 查看 project run 日志；可直接传入 project、agent、run 或 sandbox ID，无需指定资源类型。 |
+| `agent-compose scheduler ls\|runs\|logs\|trigger\|inspect` | 查看 trigger 和 run、读取 scheduler 日志、手动执行 trigger 或检查 scheduler 资源。 |
+| `agent-compose sandbox ls\|stop\|resume\|rm\|prune` | 管理 project sandbox。 |
+| `agent-compose images\|pull\|build\|rmi\|inspect` | 管理 daemon 镜像并构建 agent 镜像。 |
+| `agent-compose volume ls\|create\|inspect\|rm\|prune` | 管理 daemon volume。 |
+| `agent-compose cache ls\|inspect\|prune\|rm` | 查看并清理 daemon runtime cache。 |
+| `agent-compose auth login\|logout\|ls` | 验证、删除或列出已保存的 daemon Bearer Token。 |
+| `agent-compose down` | 禁用受管 scheduler 并停止 sandbox。 |
+| `agent-compose status` | 查看 daemon 状态。 |
+
+常用全局参数：`--file, -f`（指定 compose 文件）、`--project-name`（按名称选择已部署项目）、`--json`
+（脚本用的稳定 JSON 输出）、`--host` / `AGENT_COMPOSE_HOST`（连接 TCP daemon）、
+`AGENT_COMPOSE_SOCKET`（Unix socket 路径）。完整参考见[命令行使用手册](docs/pages/zh-CN/command-line-manual.md)。
+
+`scheduler.script` 支持内联 JavaScript，或使用显式的 `{ url: ... }` 来源
+（本地路径、`file://`、`http://`、`https://`）。`config` 和 `up` 在 CLI 本机
+获取来源并向 daemon 发送内联快照；同一 scheduler 中 `scheduler.script` 和
+`scheduler.triggers` 二选一。
+
+## Daemon 认证
+
+在 daemon 环境中设置 `AGENT_COMPOSE_AUTH_TOKEN` 后，HTTP(S) 控制面请求必须携带共享 Bearer Token；配置为空或未配置时，认证保持关闭。受信任的本地 Unix socket 连接不需要此 Token。
+
+Health RPC 和 webhook ingestion 继续使用各自已有的认证或信任边界，不使用 daemon Token。
+
+为一个 daemon 站点验证并保存 Token：
+
+```bash
+export AGENT_COMPOSE_AUTH_TOKEN='your-token'
+export HTTP_LISTEN='127.0.0.1:7410'
+agent-compose daemon
+
+agent-compose --host http://127.0.0.1:7410 auth login --token 'your-token'
+agent-compose --host http://127.0.0.1:7410 status
+```
+
+登录命令会先向 daemon 验证 Token，成功后将凭据保存到当前平台的用户配置目录；标准 Linux 路径为 `~/.config/agent-compose/config.yml`，且仅当前用户可读写。后续通过相同的 `--host` 或 `AGENT_COMPOSE_HOST` 连接时，CLI 会自动携带对应 Token。使用 `agent-compose auth ls` 查看已保存站点，使用 `agent-compose --host <site> auth logout` 删除站点凭据。
+
+Bearer Token 不会加密网络流量。跨机器连接时，请使用 HTTPS、SSH 隧道、VPN 或其他受保护网络；明文 HTTP 中的 Token 可能被监听并重放。UI server 或反向代理若调用受保护的 daemon 控制面 API，也必须注入相同的 `Authorization: Bearer <token>` 请求头。
+
+## Runtime Driver
+
+- **`docker`**（默认）：使用 Docker 容器运行 guest，需要可用的 Docker daemon。
+- **`boxlite`**：使用 BoxLite runtime artifact 以 microVM 运行 guest。
+- **`microsandbox`**：使用 Microsandbox VM runtime 运行 guest。
+
+产物的平台能力并不相同：macOS 原生二进制只编译 `docker`；Linux 原生二进制和发布的 Linux daemon 镜像编译 `docker`、`boxlite`、`microsandbox`。`agent-compose --json version` 和 `/api/version` 中的 `compiled_drivers` 只表示真实 driver 实现已编入当前产物，不代表 Docker daemon、KVM、native artifact 或 runtime 本身当前可用或健康。BoxLite 和 Microsandbox 的真实运行仍要求 Linux/KVM 及对应 runtime artifact；完整 Linux 镜像可以在 macOS Docker Desktop 中以 Docker driver 运行，但不承诺在该环境运行两种 KVM driver。
+
+镜像处理由 `IMAGE_STORE_MODE` 选择（`auto` / `docker` / `oci`，其中 `oci` 使用无 daemon 的镜像缓存）。新 sandbox 使用 `DEFAULT_IMAGE` 指定的镜像；自带的 `.env.example` 和安装脚本将其设为 `chaitin/agent-compose-guest:latest`，该镜像内置 agent runtime 和各 provider CLI。
+
+## Agent Provider
+
+每个 agent 设置一个 `provider`，决定 sandbox 内运行的 CLI：
+
+| Provider | 运行 |
+| --- | --- |
+| `codex` | Codex CLI |
+| `claude` | Claude Code CLI |
+| `gemini` | Gemini CLI |
+| `opencode` | OpenCode CLI |
+| `pi` | Pi coding agent CLI |
+
+按你的 agent 使用的后端家族设置变量。**OpenAI 家族**（Codex，以及 daemon 自身的 `LLMService` 和 scheduler LLM 调用）：
+
+```env
+LLM_API_ENDPOINT=https://api.openai.com
+LLM_API_PROTOCOL=responses    # DeepSeek / vLLM / Ollama 用 chat_completions
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-...
+```
+
+**Anthropic 家族**（Claude）：
+
+```env
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_MODEL=claude-...
+```
+
+设置 `LLM_API_PROTOCOL=chat_completions` 可对接任意 OpenAI 兼容 endpoint（DeepSeek、vLLM、Ollama）。
+
+**Gemini** 不会拿到任何 LLM key（`GEMINI_API_KEY` / `GOOGLE_API_KEY` 会从 guest 中过滤），而是通过 Gemini CLI 自身登录，凭据持久化在 sandbox home（`~/.gemini`）。
+
+完整变量（超时、endpoint 别名、`OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN` 等）见 [`.env.example`](.env.example)。
+
+## 部署与配置
+
+使用已发布镜像部署到服务器：
+
+```bash
+cp .env.example .env
+openssl rand -base64 24   # 用于 AUTH_PASSWORD
+openssl rand -hex 32      # 用于 AUTH_SECRET
+docker compose pull && docker compose up -d
+docker compose --profile with-ui up -d   # 同时启动 Web UI
+```
+
+以上命令默认使用不含 KVM 权限的基础 Compose。需要在 Linux KVM 主机显式启用 BoxLite/Microsandbox 时，把 `COMPOSE_FILE=docker-compose.yml:docker-compose.kvm.yml` 写入部署目录的 `.env`；`docker-compose.kvm.yml` 只增加 `privileged` 和 `/dev/kvm` 能力，不是本地 build override。
+
+Daemon 还会以只读方式挂载 Linux 宿主机的 `/etc/localtime`，因此未显式设置 `timezone` 的 cron trigger 会跟随宿主机时区。仅在需要覆盖宿主机时区时才在 `.env` 中设置 `TZ`，修改后需要重启 daemon。
+
+**[`.env.example`](.env.example) 是权威的、带完整注释的配置参考。** 对外部署前至少检查这些：
+
+- `AUTH_PASSWORD`、`AUTH_SECRET` —— UI server 登录 secret（务必替换示例值）。
+- `AGENT_COMPOSE_AUTH_TOKEN` —— daemon HTTP(S) 控制面可选的共享 Bearer Token。
+- `AGENT_COMPOSE_HTTP_PORT` —— 启用 `with-ui` 时 Web UI / 反向代理的宿主机端口。
+- `RUNTIME_DRIVER` —— 默认 runtime driver。
+
+## Web UI
+
+Web UI 在独立仓库 [agent-compose-ui](https://github.com/chaitin/agent-compose-ui)。daemon 不托管 UI 或浏览器登录流程；UI 镜像用 nginx 前置一个 Go UI server，由后者处理 auth/OAuth 并把 API 路由代理到 daemon。
+
+## 安全提醒
+
+默认配置面向本地开发。对外部署前请加固：
+
+- 浏览器入口通过 agent-compose-ui server 暴露，不要直连 daemon。
+- 设置稳定、高熵的 `AUTH_SECRET`；生产环境使用 HTTPS 终止。
+- daemon TCP API（`HTTP_LISTEN`）应置于容器网络、反向代理或 VPN 之后。
+- 启用 daemon Token 认证时，跨机器连接使用 HTTPS 或其他受保护隧道；明文 HTTP 无法防止 Token 被截获和重放。
+- 把 Git 凭据、上传的 workspace、环境变量和 LLM API key 都当作 secret。
+
+更多说明见 [SECURITY.md](SECURITY.md)。
+
+## 构建与测试
+
+```bash
+task lint
+task build
+task test          # 或：task test:unit / task test:integration / task test:e2e
+```
+
+用 `task image:agent-compose-guest` 和 `task image:agent-compose` 构建 guest 和 daemon 镜像。`task build:agent-compose` 按当前宿主选择原生 profile：Darwin 构建仅支持 Docker 的二进制，Linux 构建同时支持 Docker、BoxLite 和 Microsandbox；Linux full 构建会通过 Docker 准备两种 native runtime artifact。也可通过 `task build:agent-compose:darwin` 或 `task build:agent-compose:linux` 显式选择。旧任务 `build:agent-compose:boxlite` 已废弃，仅作为 Linux full profile 的兼容 alias。JavaScript runtime 组件在 `runtime/` 下。
+
+macOS/Linux daemon 原生二进制只用于本地开发和 CI 验证。独立的 Go installer 以 Linux amd64/arm64 二进制发布在固定的 `installer-latest` prerelease，并读取普通应用 Release 中的部署 bundle；正式部署载体仍是 Docker Hub 中的 multi-arch daemon/guest 镜像加该 installer。
+
+## 文档
+
+- [英文文档索引](README.md)
+- [命令行使用手册](docs/pages/zh-CN/command-line-manual.md)
+- [架构说明](docs/design/agent-compose_design.md)
 
 ## 一次性 V2 存储迁移
 
@@ -214,209 +403,6 @@ RUNTIME_ROOT=/data
 ```
 
 完成迁移和验证前保持旧 daemon 停止。如需保留独立回滚副本，可为 `--source` 和 `--target` 指定不同目录，并将 `--runtime-root` 设为新 daemon 能看到的 target 路径。
-
-## Compose 配置
-
-**顶层字段：** `name`、`env_file`、`variables`、`workspaces`、`agents`、`mcp_servers`、`volumes`。
-
-**agent 常用字段：** `provider`、`model`、`system_prompt`、`image`、`driver`、
-`env`（scalar 或 `{ value, secret }`）、`workspace`、`scheduler`、`mcp_servers`、`skills`、`volumes`。
-
-为 agent 从本地路径（`provider: file`）或 Git 仓库（`provider: git`）配置 workspace：
-
-```yaml
-agents:
-  reviewer:
-    workspace:
-      provider: git
-      url: https://github.com/example/repo.git
-      ref: main
-      target: .
-```
-
-Scheduler 脚本可以是内联 JavaScript，也可以通过 `provider: file`、
-`provider: http` 或 `provider: git` 配置外部来源。`config` 和 `up` 会在本地
-读取外部脚本，并把内联内容快照发送给 daemon。例如，通过 HTTP 加载脚本：
-
-```yaml
-agents:
-  reviewer:
-    scheduler:
-      enabled: true
-      script:
-        provider: http
-        url: https://example.com/scheduler.js
-```
-
-添加定时或事件驱动的 run。`scheduler.triggers` 与内联 `scheduler.script` 在同一 scheduler 中二选一：
-
-```yaml
-agents:
-  reviewer:
-    scheduler:
-      enabled: true
-      triggers:
-        - name: hourly-review
-          cron: "0 * * * *"
-          prompt: "Review the current project state and summarize changes."
-```
-
-完整字段说明见[命令行使用手册](docs/pages/zh-CN/command-line-manual.md)。
-
-## CLI 概览
-
-| 命令 | 用途 |
-| --- | --- |
-| `agent-compose daemon` | 启动 HTTP/Connect daemon。 |
-| `agent-compose up` | 读取 `agent-compose.yml` 并应用 project。 |
-| `agent-compose run <agent> --prompt/--command` | 以 agent 身份执行 prompt 或 shell 命令。 |
-| `agent-compose exec <sandbox>` | 在运行中的 sandbox 内执行命令或 prompt。 |
-| `agent-compose ps` / `stats` | 列出 project sandbox / 查看 sandbox 资源统计。 |
-| `agent-compose logs` | 查看 project run 日志；可直接传入 project、agent、run 或 sandbox ID，无需指定资源类型。 |
-| `agent-compose scheduler ls\|runs\|logs\|trigger\|inspect` | 查看 trigger 和 run、读取 scheduler 日志、手动执行 trigger 或检查 scheduler 资源。 |
-| `agent-compose sandbox ls\|stop\|resume\|rm\|prune` | 管理 project sandbox。 |
-| `agent-compose images\|pull\|build\|rmi\|inspect` | 管理 daemon 镜像并构建 agent 镜像。 |
-| `agent-compose volume ls\|create\|inspect\|rm\|prune` | 管理 daemon volume。 |
-| `agent-compose cache ls\|inspect\|prune\|rm` | 查看并清理 daemon runtime cache。 |
-| `agent-compose auth login\|logout\|ls` | 验证、删除或列出已保存的 daemon Bearer Token。 |
-| `agent-compose down` | 禁用受管 scheduler 并停止 sandbox。 |
-| `agent-compose status` | 查看 daemon 状态。 |
-
-常用全局参数：`--file, -f`（指定 compose 文件）、`--project-name`（按名称选择已部署项目）、`--json`
-（脚本用的稳定 JSON 输出）、`--host` / `AGENT_COMPOSE_HOST`（连接 TCP daemon）、
-`AGENT_COMPOSE_SOCKET`（Unix socket 路径）。完整参考见[命令行使用手册](docs/pages/zh-CN/command-line-manual.md)。
-
-`scheduler.script` 支持内联 JavaScript，或使用显式的 `{ url: ... }` 来源
-（本地路径、`file://`、`http://`、`https://`）。`config` 和 `up` 在 CLI 本机
-获取来源并向 daemon 发送内联快照；同一 scheduler 中 `scheduler.script` 和
-`scheduler.triggers` 二选一。
-
-## Daemon 认证
-
-在 daemon 环境中设置 `AGENT_COMPOSE_AUTH_TOKEN` 后，HTTP(S) 控制面请求必须携带共享 Bearer Token；配置为空或未配置时，认证保持关闭。受信任的本地 Unix socket 连接不需要此 Token。
-
-Health RPC、Runtime LLM Facade、Jupyter proxy 和 webhook ingestion 继续使用各自已有的认证或信任边界，不使用 daemon Token。
-
-为一个 daemon 站点验证并保存 Token：
-
-```bash
-export AGENT_COMPOSE_AUTH_TOKEN='your-token'
-export HTTP_LISTEN='127.0.0.1:7410'
-agent-compose daemon
-
-agent-compose --host http://127.0.0.1:7410 auth login --token 'your-token'
-agent-compose --host http://127.0.0.1:7410 status
-```
-
-登录命令会先向 daemon 验证 Token，成功后将凭据保存到当前平台的用户配置目录；标准 Linux 路径为 `~/.config/agent-compose/config.yml`，且仅当前用户可读写。后续通过相同的 `--host` 或 `AGENT_COMPOSE_HOST` 连接时，CLI 会自动携带对应 Token。使用 `agent-compose auth ls` 查看已保存站点，使用 `agent-compose --host <site> auth logout` 删除站点凭据。
-
-Bearer Token 不会加密网络流量。跨机器连接时，请使用 HTTPS、SSH 隧道、VPN 或其他受保护网络；明文 HTTP 中的 Token 可能被监听并重放。UI server 或反向代理若调用受保护的 daemon 控制面 API，也必须注入相同的 `Authorization: Bearer <token>` 请求头。
-
-## Runtime Driver
-
-- **`docker`**（默认）：使用 Docker 容器运行 guest，需要可用的 Docker daemon。
-- **`boxlite`**：使用 BoxLite runtime artifact 以 microVM 运行 guest。
-- **`microsandbox`**：使用 Microsandbox VM runtime 运行 guest。
-
-产物的平台能力并不相同：macOS 原生二进制只编译 `docker`；Linux 原生二进制和发布的 Linux daemon 镜像编译 `docker`、`boxlite`、`microsandbox`。`agent-compose --json version` 和 `/api/version` 中的 `compiled_drivers` 只表示真实 driver 实现已编入当前产物，不代表 Docker daemon、KVM、native artifact 或 runtime 本身当前可用或健康。BoxLite 和 Microsandbox 的真实运行仍要求 Linux/KVM 及对应 runtime artifact；完整 Linux 镜像可以在 macOS Docker Desktop 中以 Docker driver 运行，但不承诺在该环境运行两种 KVM driver。
-
-镜像处理由 `IMAGE_STORE_MODE` 选择（`auto` / `docker` / `oci`，其中 `oci` 使用无 daemon 的镜像缓存）。新 sandbox 使用 `DEFAULT_IMAGE` 指定的镜像；自带的 `.env.example` 和安装脚本将其设为 `chaitin/agent-compose-guest:latest`，该镜像内置 agent runtime 和各 provider CLI。
-
-## Agent Provider
-
-每个 agent 设置一个 `provider`，决定 sandbox 内运行的 CLI：
-
-| Provider | 运行 |
-| --- | --- |
-| `codex` | Codex CLI |
-| `claude` | Claude Code CLI |
-| `gemini` | Gemini CLI |
-| `opencode` | OpenCode CLI |
-| `pi` | Pi coding agent CLI |
-
-LLM 凭据只在 daemon（`.env`）配置一次，而不是每个 guest 各配。对 Codex、Claude、OpenCode 和 Pi，daemon 的 **Runtime LLM Facade** 给每个 sandbox 一个受限的 scoped token，而不是你的真实 API key，因此 provider key 不会进入 guest。当 token 已固定上游 provider 时，runtime 每次请求中的模型会透传给该 provider，无需预先登记到 agent-compose；provider 不支持模型时返回其上游错误。未绑定 provider 的兼容 token 保持既有的已配置 model/provider 解析行为。
-
-按你的 agent 使用的后端家族设置变量。**OpenAI 家族**（Codex，以及 daemon 自身的 `LLMService` 和 scheduler LLM 调用）：
-
-```env
-LLM_API_ENDPOINT=https://api.openai.com
-LLM_API_PROTOCOL=responses    # DeepSeek / vLLM / Ollama 用 chat_completions
-LLM_API_KEY=sk-...
-LLM_MODEL=gpt-...
-```
-
-**Anthropic 家族**（Claude）：
-
-```env
-ANTHROPIC_BASE_URL=https://api.anthropic.com
-ANTHROPIC_API_KEY=sk-ant-...
-ANTHROPIC_MODEL=claude-...
-```
-
-设置 `LLM_API_PROTOCOL=chat_completions` 可对接任意 OpenAI 兼容 endpoint（DeepSeek、vLLM、Ollama）。
-
-**各 provider 说明。** OpenCode 从 agent 的 `model`（`provider/model`，如 `anthropic/…` 或 `openai/…`）选择上游家族并获得对应的 facade token；只有 OpenCode 自带的原生 provider 才走 OpenCode 自身登录。**Gemini 是例外** —— 它不会拿到任何 LLM key（`GEMINI_API_KEY` / `GOOGLE_API_KEY` 会从 guest 中过滤），而是通过 Gemini CLI 自身登录，凭据持久化在 sandbox home（`~/.gemini`）。
-
-完整变量（超时、endpoint 别名、`OPENAI_API_KEY` / `ANTHROPIC_AUTH_TOKEN` 等）见 [`.env.example`](.env.example)；facade 的托管机制见 [docs/design/agent-compose_design.md#daemon-llm-client](docs/design/agent-compose_design.md#daemon-llm-client)。
-
-## 部署与配置
-
-使用已发布镜像部署到服务器：
-
-```bash
-cp .env.example .env
-openssl rand -base64 24   # 用于 AUTH_PASSWORD
-openssl rand -hex 32      # 用于 AUTH_SECRET
-docker compose pull && docker compose up -d
-docker compose --profile with-ui up -d   # 同时启动 Web UI
-```
-
-以上命令默认使用不含 KVM 权限的基础 Compose。需要在 Linux KVM 主机显式启用 BoxLite/Microsandbox 时，把 `COMPOSE_FILE=docker-compose.yml:docker-compose.kvm.yml` 写入部署目录的 `.env`；`docker-compose.kvm.yml` 只增加 `privileged` 和 `/dev/kvm` 能力，不是本地 build override。
-
-Daemon 还会以只读方式挂载 Linux 宿主机的 `/etc/localtime`，因此未显式设置 `timezone` 的 cron trigger 会跟随宿主机时区。仅在需要覆盖宿主机时区时才在 `.env` 中设置 `TZ`，修改后需要重启 daemon。
-
-**[`.env.example`](.env.example) 是权威的、带完整注释的配置参考。** 对外部署前至少检查这些：
-
-- `AUTH_PASSWORD`、`AUTH_SECRET` —— UI server 登录 secret（务必替换示例值）。
-- `AGENT_COMPOSE_AUTH_TOKEN` —— daemon HTTP(S) 控制面可选的共享 Bearer Token。
-- `AGENT_COMPOSE_HTTP_PORT` —— 启用 `with-ui` 时 Web UI / 反向代理的宿主机端口。
-- `AGENT_COMPOSE_RUNTIME_BASE_URL` —— guest 可达的 daemon URL，用于 LLM facade。
-- `RUNTIME_DRIVER` —— 默认 runtime driver。
-
-## Web UI
-
-Web UI 在独立仓库 [agent-compose-ui](https://github.com/chaitin/agent-compose-ui)。它直接跟踪由本仓库 `proto/` 生成的 `agentcompose/v2` 和 `health/v1` TypeScript 客户端，协议与生成文件同步评审。daemon 不托管 UI 或浏览器登录流程；UI 镜像用 nginx 前置一个 Go UI server，由后者处理 auth/OAuth 并把 API、Jupyter 路由代理到 daemon。
-
-## 安全提醒
-
-默认配置面向本地开发。对外部署前请加固：
-
-- 浏览器入口通过 agent-compose-ui server 暴露，不要直连 daemon。
-- 设置稳定、高熵的 `AUTH_SECRET`；生产环境使用 HTTPS 终止。
-- daemon TCP API（`HTTP_LISTEN`）应置于容器网络、反向代理或 VPN 之后。
-- 启用 daemon Token 认证时，跨机器连接使用 HTTPS 或其他受保护隧道；明文 HTTP 无法防止 Token 被截获和重放。
-- 不要直接暴露 guest Jupyter 端口 —— 通过 agent-compose proxy 访问。
-- 把 Git 凭据、上传的 workspace、环境变量和 LLM API key 都当作 secret。
-
-更多说明见 [SECURITY.md](SECURITY.md)。
-
-## 构建与测试
-
-```bash
-task lint
-task build
-task test          # 或：task test:unit / task test:integration / task test:e2e
-```
-
-用 `task image:agent-compose-guest` 和 `task image:agent-compose` 构建 guest 和 daemon 镜像。`task build:agent-compose` 按当前宿主选择原生 profile：Darwin 构建仅支持 Docker 的二进制，Linux 构建同时支持 Docker、BoxLite 和 Microsandbox；Linux full 构建会通过 Docker 准备两种 native runtime artifact。也可通过 `task build:agent-compose:darwin` 或 `task build:agent-compose:linux` 显式选择。旧任务 `build:agent-compose:boxlite` 已废弃，仅作为 Linux full profile 的兼容 alias。JavaScript runtime 组件在 `runtime/` 下。
-
-macOS/Linux daemon 原生二进制只用于本地开发和 CI 验证。独立的 Go installer 以 Linux amd64/arm64 二进制发布在固定的 `installer-latest` prerelease，并读取普通应用 Release 中的部署 bundle；正式部署载体仍是 Docker Hub 中的 multi-arch daemon/guest 镜像加该 installer。
-
-## 文档
-
-- [英文文档索引](README.md)
-- [命令行使用手册](docs/pages/zh-CN/command-line-manual.md)
-- [架构说明](docs/design/agent-compose_design.md)
 
 ## 贡献
 


### PR DESCRIPTION
## Summary

- add centered website, demo, and language links to the English and Chinese READMEs
- remove public-preview, Runtime LLM Facade, v2 Connect API, and Jupyter proxy descriptions
- simplify published-image instructions to use the `latest` tag
- move the one-time V2 storage migration guide between Documentation and Contributing

## Testing

- `git diff --check`
- `task docs:build`
- `task lint`, `task build`, and `task test` not run because this is a README-only change

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior. (Not applicable: documentation-only change.)
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.