### PR TITLE
fix(llms): inject max_output_tokens into proxied requests to stop silent long-output truncation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,13 @@ DEFAULT_IMAGE=chaitin/agent-compose-guest:latest
 # LLM_API_KEY=
 # OPENAI_API_KEY=
 # LLM_MODEL=
+# Maximum output tokens the runtime LLM facade injects into each proxied
+# upstream request. codex does not send max_output_tokens itself, and the
+# protocol bridge defaults max_completion_tokens to a small value (e.g. 4096),
+# so proxies that honor that field silently truncate long agent outputs.
+# Set this for models served via OpenAI-compatible gateways (DeepSeek, vLLM,
+# Ollama, third-party proxies) to stop mid-response truncation.
+# LLM_MAX_OUTPUT_TOKENS=65536
 # Bounds direct LLM calls and the facade's wait for upstream response headers.
 # Established streaming responses do not have a total duration limit.
 # LLM_TIMEOUT=60s

--- a/demo/agent-compose.yml
+++ b/demo/agent-compose.yml
@@ -1,8 +1,0 @@
-name: demo
-
-agents:
-  hello:
-    provider: codex
-    image: chaitin/agent-compose-guest:latest
-    driver:
-      docker: {}

--- a/demo/agent-compose.yml
+++ b/demo/agent-compose.yml
@@ -1,0 +1,8 @@
+name: demo
+
+agents:
+  hello:
+    provider: codex
+    image: chaitin/agent-compose-guest:latest
+    driver:
+      docker: {}

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -606,7 +606,8 @@ func registerRuntimeLLMFacadeRoutes(app *echo.Echo, di do.Injector) {
 		ResolveTarget: func(ctx context.Context, requestedModel, providerID string) (llms.ResolvedTarget, error) {
 			return llms.ResolveRuntimeLLMTarget(ctx, config, configDB, requestedModel, providerID)
 		},
-		Client: proxy.NewRuntimeLLMHTTPClient(config.LLMTimeout),
+		Client:          proxy.NewRuntimeLLMHTTPClient(config.LLMTimeout),
+		MaxOutputTokens: config.LLMMaxOutputTokens,
 	})
 }
 

--- a/pkg/agentcompose/proxy/runtime_llm.go
+++ b/pkg/agentcompose/proxy/runtime_llm.go
@@ -37,9 +37,9 @@ type RuntimeLLMOptions struct {
 	ResolveTarget RuntimeLLMTargetResolver
 	Client        HTTPDoer
 	// MaxOutputTokens, when > 0, is injected into every proxied upstream LLM
-	// request (max_tokens for chat completions, max_output_tokens for
-	// responses). codex does not send max_output_tokens itself, so without this
-	// API proxies that default to a small limit silently truncate long outputs.
+	// request using the field names supported by the upstream protocol. codex
+	// does not send max_output_tokens itself, so without this API proxies that
+	// default to a small limit silently truncate long outputs.
 	MaxOutputTokens int
 }
 
@@ -185,20 +185,30 @@ func (h runtimeLLMHandler) handle(c echo.Context, inboundProtocol protocolbridge
 // (see openai/codex#36180), and the protocol bridge defaults the chat
 // completions max_completion_tokens to a small value (e.g. 4096); upstream
 // proxies honor that field and silently truncate long agent outputs. Setting
-// both the legacy and modern fields ensures the configured limit wins.
+// both OpenAI Chat field names ensures the configured limit wins. Anthropic
+// Messages receives only max_tokens because it rejects max_completion_tokens.
 func injectMaxOutputTokens(body []byte, upstreamProtocol protocolbridge.Protocol, maxTokens int) []byte {
 	if maxTokens <= 0 || len(body) == 0 {
+		return body
+	}
+	fields := map[string]int{}
+	switch upstreamProtocol {
+	case protocolbridge.ProtocolOpenAIResponses:
+		fields["max_output_tokens"] = maxTokens
+	case protocolbridge.ProtocolOpenAIChat:
+		fields["max_tokens"] = maxTokens
+		fields["max_completion_tokens"] = maxTokens
+	case protocolbridge.ProtocolAnthropicMessages:
+		fields["max_tokens"] = maxTokens
+	default:
 		return body
 	}
 	var obj map[string]any
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return body
 	}
-	if upstreamProtocol == protocolbridge.ProtocolOpenAIResponses {
-		obj["max_output_tokens"] = maxTokens
-	} else {
-		obj["max_tokens"] = maxTokens
-		obj["max_completion_tokens"] = maxTokens
+	for field, value := range fields {
+		obj[field] = value
 	}
 	out, err := json.Marshal(obj)
 	if err != nil {

--- a/pkg/agentcompose/proxy/runtime_llm.go
+++ b/pkg/agentcompose/proxy/runtime_llm.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -35,6 +36,11 @@ type RuntimeLLMOptions struct {
 	Sandboxes     RuntimeLLMSandboxStore
 	ResolveTarget RuntimeLLMTargetResolver
 	Client        HTTPDoer
+	// MaxOutputTokens, when > 0, is injected into every proxied upstream LLM
+	// request (max_tokens for chat completions, max_output_tokens for
+	// responses). codex does not send max_output_tokens itself, so without this
+	// API proxies that default to a small limit silently truncate long outputs.
+	MaxOutputTokens int
 }
 
 func RegisterRuntimeLLMFacadeRoutes(app *echo.Echo, opts RuntimeLLMOptions) {
@@ -126,6 +132,7 @@ func (h runtimeLLMHandler) handle(c echo.Context, inboundProtocol protocolbridge
 			raw, status := inboundAdapter.EncodeError(err)
 			return WriteRuntimeLLMEncodedError(c, raw, status)
 		}
+		upstreamBody = injectMaxOutputTokens(upstreamBody, upstreamProtocol, h.opts.MaxOutputTokens)
 		return h.proxyTransparent(c, upstreamEndpoint, upstreamBody, target, upstreamProtocol)
 	}
 	upstreamBody, err := llms.EncodeRuntimeUpstreamRequest(inboundProtocol, upstreamProtocol, target, llmReq)
@@ -133,6 +140,7 @@ func (h runtimeLLMHandler) handle(c echo.Context, inboundProtocol protocolbridge
 		raw, status := inboundAdapter.EncodeError(err)
 		return WriteRuntimeLLMEncodedError(c, raw, status)
 	}
+	upstreamBody = injectMaxOutputTokens(upstreamBody, upstreamProtocol, h.opts.MaxOutputTokens)
 	upstreamReq, err := http.NewRequestWithContext(c.Request().Context(), http.MethodPost, upstreamEndpoint, bytes.NewReader(upstreamBody))
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "create upstream llm request failed"})
@@ -170,6 +178,33 @@ func (h runtimeLLMHandler) handle(c echo.Context, inboundProtocol protocolbridge
 	c.Response().WriteHeader(resp.StatusCode)
 	_, err = c.Response().Writer.Write(clientBody)
 	return err
+}
+
+// injectMaxOutputTokens adds the configured output-token limit to a proxied
+// upstream LLM request body. codex does not send max_output_tokens itself
+// (see openai/codex#36180), and the protocol bridge defaults the chat
+// completions max_completion_tokens to a small value (e.g. 4096); upstream
+// proxies honor that field and silently truncate long agent outputs. Setting
+// both the legacy and modern fields ensures the configured limit wins.
+func injectMaxOutputTokens(body []byte, upstreamProtocol protocolbridge.Protocol, maxTokens int) []byte {
+	if maxTokens <= 0 || len(body) == 0 {
+		return body
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return body
+	}
+	if upstreamProtocol == protocolbridge.ProtocolOpenAIResponses {
+		obj["max_output_tokens"] = maxTokens
+	} else {
+		obj["max_tokens"] = maxTokens
+		obj["max_completion_tokens"] = maxTokens
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 func (h runtimeLLMHandler) proxyTransparent(c echo.Context, upstreamEndpoint string, body []byte, target llms.ResolvedTarget, upstreamProtocol protocolbridge.Protocol) error {

--- a/pkg/agentcompose/proxy/runtime_llm_output_tokens_test.go
+++ b/pkg/agentcompose/proxy/runtime_llm_output_tokens_test.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	protocolbridge "github.com/chaitin/ai-api-protocol-bridge"
+)
+
+func TestInjectMaxOutputTokensUsesUpstreamProtocolFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		protocol   protocolbridge.Protocol
+		wantFields map[string]int
+		omitFields []string
+	}{
+		{
+			name:     "OpenAI Responses",
+			protocol: protocolbridge.ProtocolOpenAIResponses,
+			wantFields: map[string]int{
+				"max_output_tokens": 65536,
+			},
+			omitFields: []string{"max_tokens", "max_completion_tokens"},
+		},
+		{
+			name:     "OpenAI Chat Completions",
+			protocol: protocolbridge.ProtocolOpenAIChat,
+			wantFields: map[string]int{
+				"max_tokens":            65536,
+				"max_completion_tokens": 65536,
+			},
+			omitFields: []string{"max_output_tokens"},
+		},
+		{
+			name:     "Anthropic Messages",
+			protocol: protocolbridge.ProtocolAnthropicMessages,
+			wantFields: map[string]int{
+				"max_tokens": 65536,
+			},
+			omitFields: []string{"max_output_tokens", "max_completion_tokens"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := injectMaxOutputTokens([]byte(`{"model":"test-model"}`), tc.protocol, 65536)
+			var request map[string]json.RawMessage
+			if err := json.Unmarshal(body, &request); err != nil {
+				t.Fatalf("decode injected request body: %v", err)
+			}
+			for field, want := range tc.wantFields {
+				var got int
+				if err := json.Unmarshal(request[field], &got); err != nil {
+					t.Fatalf("decode %s: %v", field, err)
+				}
+				if got != want {
+					t.Errorf("%s = %d, want %d", field, got, want)
+				}
+			}
+			for _, field := range tc.omitFields {
+				if _, ok := request[field]; ok {
+					t.Errorf("request unexpectedly contains %s: %s", field, body)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectMaxOutputTokensDisabledPreservesBody(t *testing.T) {
+	body := []byte(`{"model":"test-model"}`)
+	got := injectMaxOutputTokens(body, protocolbridge.ProtocolAnthropicMessages, 0)
+	if string(got) != string(body) {
+		t.Fatalf("body = %s, want %s", got, body)
+	}
+}

--- a/pkg/config/codex_runtime.go
+++ b/pkg/config/codex_runtime.go
@@ -58,3 +58,18 @@ func codexIdleTimeoutEnv(logger *slog.Logger, defaultValue time.Duration) time.D
 	}
 	return parsed
 }
+
+// envPositiveInt reads a positive integer environment variable. Returns 0 when
+// unset, so callers can treat 0 as "not configured".
+func envPositiveInt(logger *slog.Logger, name string) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed <= 0 {
+		logger.Warn("invalid positive integer", "name", name, "value", raw, "error", err)
+		return 0
+	}
+	return parsed
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	LLMAPIKey                  string
 	LLMModel                   string
 	LLMTimeout                 time.Duration
+	LLMMaxOutputTokens         int
 	CodexRequestMaxRetries     uint64
 	CodexStreamMaxRetries      uint64
 	CodexStreamIdleTimeout     time.Duration
@@ -176,6 +177,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 	llmAPIKey := getenvFirst("LLM_API_KEY", "OPENAI_API_KEY")
 
 	llmModel := os.Getenv("LLM_MODEL")
+	llmMaxOutputTokens := envPositiveInt(logger, "LLM_MAX_OUTPUT_TOKENS")
 	runtimeBaseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("AGENT_COMPOSE_RUNTIME_BASE_URL")), "/")
 
 	llmTimeout := 60 * time.Second
@@ -495,6 +497,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		LLMAPIKey:                  llmAPIKey,
 		LLMModel:                   llmModel,
 		LLMTimeout:                 llmTimeout,
+		LLMMaxOutputTokens:         llmMaxOutputTokens,
 		CodexRequestMaxRetries:     codexRuntime.requestMaxRetries,
 		CodexStreamMaxRetries:      codexRuntime.streamMaxRetries,
 		CodexStreamIdleTimeout:     codexRuntime.streamIdleTimeout,


### PR DESCRIPTION
## Problem (business-impacting)

When a model is served via an **OpenAI-compatible gateway** (DeepSeek, vLLM, Ollama, third-party proxies), agent-compose's codex sandboxes **silently truncate long agent outputs** mid-response, and the truncated run returns an **empty/missing result**. This is structural (not transient), so retries do not recover it, and it breaks real workloads — e.g. in production SOC pipelines, verbose analysis nodes (a multi-host EDR process-tree analysis) deterministically fail.

## Root cause

Two issues stack:

1. **codex never sends `max_output_tokens`** in its Responses API requests (openai/codex#36180 — the wire struct, ModelInfo, and config all lack the field).
2. agent-compose's protocol bridge therefore falls back to a **small default `max_completion_tokens` (4096)** on the translated chat-completions request, and **upstream proxies honor `max_completion_tokens`** over `max_tokens`.

Result: the model is capped at ~4096 output tokens regardless of the model's real capability, the Responses API returns *"Incomplete response returned, reason: max_output_tokens"*, and the codex runner decodes no result payload → the agent run fails. (Confirmed by capturing the facade's outgoing body: `max_completion_tokens: 4096` even though the model can emit far more — a direct streaming probe returned 2.9 MB with `max_tokens: 65536`.)

Note: a codex `model_catalog_json` does **not** fix this — per openai/codex#36180, `ModelInfo` has no `max_output_tokens` field, so codex ignores any limit declared in a custom catalog.

## Fix

When the operator sets **`LLM_MAX_OUTPUT_TOKENS`**, the runtime LLM facade injects the limit into every proxied upstream request:

- `max_output_tokens` for the responses protocol
- **both** `max_tokens` and `max_completion_tokens` for chat completions (proxies honor `max_completion_tokens`, so both must be overridden to beat the bridge's 4096 default)

Opt-in via env — default behavior is unchanged for built-in models.

### Configuration

```env
LLM_MAX_OUTPUT_TOKENS=65536
```

## Verification

End-to-end against DeepSeek behind an OpenAI-compatible gateway (baizhi cloud). Same 3-host EDR analysis card across fix iterations:

| Build | Failed nodes | Result |
|---|---|---|
| upstream (no fix) | 1 | EDR_Tree truncated → run failed |
| catalog-only attempt | 1 | catalog ignored (codex#36180) |
| facade injects `max_tokens` only | 2 | proxy honors `max_completion_tokens`=4096, still truncated |
| **this PR (injects both fields)** | **0** | **full 22 KB report, zero truncation** |

A direct streaming probe to the same gateway returned 2.9 MB with `max_tokens: 65536`, confirming the model/gateway can emit long outputs once the facade injects the limit.

## Changes

- `pkg/agentcompose/proxy/runtime_llm.go` — `injectMaxOutputTokens` rewrites the proxied upstream body in both the transparent and protocol-bridged paths.
- `pkg/agentcompose/app/app.go` — passes `config.LLMMaxOutputTokens` into the facade handler options.
- `pkg/config/config.go` + `pkg/config/codex_runtime.go` — read `LLM_MAX_OUTPUT_TOKENS`.
- `.env.example` — documents the variable.
