### PR TITLE
feat(projects): expose resolved agent models in agent ls

### DIFF
--- a/cmd/agent-compose/cli_project.go
+++ b/cmd/agent-compose/cli_project.go
@@ -182,6 +182,8 @@ type composeProjectAgentOutput struct {
 	ShortID          string `json:"short_id"`
 	Provider         string `json:"provider,omitempty"`
 	Model            string `json:"model,omitempty"`
+	ResolvedModel    string `json:"resolved_model,omitempty"`
+	ModelSource      string `json:"model_source,omitempty"`
 	Image            string `json:"image,omitempty"`
 	Driver           string `json:"driver,omitempty"`
 	SchedulerEnabled bool   `json:"scheduler_enabled"`
@@ -571,9 +573,28 @@ func composeProjectAgentOutputFromProto(agent *agentcomposev2.ProjectAgent) comp
 		ShortID:          shortOpaqueID(agent.GetManagedAgentId()),
 		Provider:         agent.GetProvider(),
 		Model:            agent.GetModel(),
+		ResolvedModel:    agent.GetResolvedModel(),
+		ModelSource:      agentModelSourceOutput(agent.GetModelSource()),
 		Image:            agent.GetImage(),
 		Driver:           agent.GetDriver(),
 		SchedulerEnabled: agent.GetSchedulerEnabled(),
+	}
+}
+
+func agentModelSourceOutput(source agentcomposev2.AgentModelSource) string {
+	switch source {
+	case agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_PROJECT:
+		return "project"
+	case agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_AGENT_ENV:
+		return "agent_env"
+	case agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_DAEMON_DEFAULT:
+		return "daemon_default"
+	case agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_PROVIDER_DEFAULT:
+		return "provider_default"
+	case agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_UNRESOLVED:
+		return "unresolved"
+	default:
+		return ""
 	}
 }
 

--- a/cmd/agent-compose/cli_project_agent_commands.go
+++ b/cmd/agent-compose/cli_project_agent_commands.go
@@ -118,13 +118,33 @@ func runComposeListAgentsCommand(cmd *cobra.Command, options cliOptions) error {
 
 func writeAgentListText(out io.Writer, agents []composeProjectAgentOutput) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "AGENT\tPROVIDER\tMODEL\tIMAGE\tDRIVER\tSCHEDULER"); err != nil {
+	if _, err := fmt.Fprintln(tw, "AGENT\tPROVIDER\tMODEL\tMODEL SOURCE\tIMAGE\tDRIVER\tSCHEDULER"); err != nil {
 		return err
 	}
 	for _, agent := range agents {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%t\n", agent.Name, agent.Provider, agent.Model, agent.Image, agent.Driver, agent.SchedulerEnabled); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%t\n", agent.Name, agent.Provider, agentListModel(agent), agentListModelSource(agent), agent.Image, agent.Driver, agent.SchedulerEnabled); err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
+}
+
+func agentListModel(agent composeProjectAgentOutput) string {
+	if agent.ResolvedModel != "" {
+		return agent.ResolvedModel
+	}
+	if agent.Model != "" {
+		return agent.Model
+	}
+	return "-"
+}
+
+func agentListModelSource(agent composeProjectAgentOutput) string {
+	if agent.ModelSource != "" {
+		return agent.ModelSource
+	}
+	if agent.Model != "" {
+		return "project"
+	}
+	return "unknown"
 }

--- a/cmd/agent-compose/cli_project_agent_commands_test.go
+++ b/cmd/agent-compose/cli_project_agent_commands_test.go
@@ -45,6 +45,9 @@ agents:
     provider: codex
 `)
 	project := testCLIProject("project-test", "agent-list", composePath)
+	project.Agents[1].Model = ""
+	project.Agents[1].ResolvedModel = "dev/gpt-5.5"
+	project.Agents[1].ModelSource = agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_DAEMON_DEFAULT
 	server := newComposeServiceStubServer(t, composeServiceStubs{project: projectServiceStub{
 		getProject: func(_ context.Context, _ *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
 			return connect.NewResponse(&agentcomposev2.GetProjectResponse{Project: project}), nil
@@ -57,7 +60,7 @@ agents:
 		if code != 0 || stderr != "" {
 			t.Fatalf("%s code/stderr = %d / %q", strings.Join(args, " "), code, stderr)
 		}
-		for _, want := range []string{"AGENT", "reviewer", "worker", "gpt-test", "boxlite"} {
+		for _, want := range []string{"AGENT", "MODEL SOURCE", "reviewer", "worker", "gpt-test", "dev/gpt-5.5", "daemon_default", "boxlite"} {
 			if !strings.Contains(stdout, want) {
 				t.Fatalf("%s stdout = %q, want %q", strings.Join(args, " "), stdout, want)
 			}
@@ -74,6 +77,9 @@ agents:
 	}
 	if output.Project.Name != "agent-list" || len(output.Agents) != 2 {
 		t.Fatalf("agent list JSON = %#v", output)
+	}
+	if worker := output.Agents[1]; worker.Model != "" || worker.ResolvedModel != "dev/gpt-5.5" || worker.ModelSource != "daemon_default" {
+		t.Fatalf("worker model output = %#v", worker)
 	}
 }
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -219,6 +219,8 @@ agent-compose ls
 agent-compose agent ls --json
 ```
 
+`MODEL` shows the model selected for a new run without request- or session-level overrides. `MODEL SOURCE` distinguishes a project declaration (`project`), an agent environment value (`agent_env`), a daemon default (`daemon_default`), a provider-owned default (`provider_default`), or an unresolved required selection (`unresolved`). JSON output preserves `model` as the project-declared value and adds `resolved_model` and `model_source`; daemon defaults are not written back into the project.
+
 ## `project up`: Apply a Project
 
 Read the config file and apply the project to the daemon. This starts or updates project schedulers and daemon-managed state.

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -207,6 +207,8 @@ agent-compose ls
 agent-compose agent ls --json
 ```
 
+`MODEL` 显示在没有请求级或 Session 级覆盖时，新一次运行将选择的模型。`MODEL SOURCE` 用于区分项目声明（`project`）、Agent 环境值（`agent_env`）、daemon 默认值（`daemon_default`）、provider 自身默认值（`provider_default`）和缺少必填模型（`unresolved`）。JSON 输出继续用 `model` 表示项目声明值，并新增 `resolved_model` 和 `model_source`；daemon 默认值不会写回项目配置。
+
 ## `project up`：启动或更新 project
 
 读取配置文件，将 project 应用到 daemon，并启动或更新 project 中的 scheduler 和服务。

--- a/examples/agent-compose/docker-minimal/README.md
+++ b/examples/agent-compose/docker-minimal/README.md
@@ -94,8 +94,8 @@ ID            NAME            TYPE     ACTION
 <agent-id>    reviewer        agent    created
 
 $ agent-compose ls
-AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
-reviewer  codex            agent-compose-guest:latest  docker  false
+AGENT     PROVIDER  MODEL  MODEL SOURCE      IMAGE                       DRIVER  SCHEDULER
+reviewer  codex     -      provider_default  agent-compose-guest:latest  docker  false
 ```
 
 ## Optional real run

--- a/examples/agent-compose/docker-minimal/README.zh-CN.md
+++ b/examples/agent-compose/docker-minimal/README.zh-CN.md
@@ -92,8 +92,8 @@ ID            NAME            TYPE     ACTION
 <agent-id>    reviewer        agent    created
 
 $ agent-compose ls
-AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
-reviewer  codex            agent-compose-guest:latest  docker  false
+AGENT     PROVIDER  MODEL  MODEL SOURCE      IMAGE                       DRIVER  SCHEDULER
+reviewer  codex     -      provider_default  agent-compose-guest:latest  docker  false
 ```
 
 ## 可选的真实运行

--- a/examples/agent-compose/docker-scheduler-cron/README.md
+++ b/examples/agent-compose/docker-scheduler-cron/README.md
@@ -103,8 +103,8 @@ ID              NAME                   TYPE       ACTION
 <scheduler-id>  reviewer               scheduler  created
 
 $ agent-compose ls
-AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
-reviewer  codex            agent-compose-guest:latest  docker  true
+AGENT     PROVIDER  MODEL  MODEL SOURCE      IMAGE                       DRIVER  SCHEDULER
+reviewer  codex     -      provider_default  agent-compose-guest:latest  docker  true
 
 $ agent-compose down
 ID              NAME                   TYPE       ACTION   MESSAGE

--- a/examples/agent-compose/docker-scheduler-cron/README.zh-CN.md
+++ b/examples/agent-compose/docker-scheduler-cron/README.zh-CN.md
@@ -102,8 +102,8 @@ ID              NAME                   TYPE       ACTION
 <scheduler-id>  reviewer               scheduler  created
 
 $ agent-compose ls
-AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
-reviewer  codex            agent-compose-guest:latest  docker  true
+AGENT     PROVIDER  MODEL  MODEL SOURCE      IMAGE                       DRIVER  SCHEDULER
+reviewer  codex     -      provider_default  agent-compose-guest:latest  docker  true
 
 $ agent-compose down
 ID              NAME                   TYPE       ACTION   MESSAGE

--- a/examples/agent-compose/docker-scheduler-timeout/README.md
+++ b/examples/agent-compose/docker-scheduler-timeout/README.md
@@ -113,8 +113,8 @@ ID              NAME                      TYPE       ACTION
 <scheduler-id>  reviewer                  scheduler  created
 
 $ agent-compose ls
-AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
-reviewer  codex            agent-compose-guest:latest  docker  true
+AGENT     PROVIDER  MODEL  MODEL SOURCE      IMAGE                       DRIVER  SCHEDULER
+reviewer  codex     -      provider_default  agent-compose-guest:latest  docker  true
 ```
 
 If the outer scheduler run succeeds but the expected transcript is missing,

--- a/examples/agent-compose/docker-scheduler-timeout/README.zh-CN.md
+++ b/examples/agent-compose/docker-scheduler-timeout/README.zh-CN.md
@@ -110,8 +110,8 @@ ID              NAME                      TYPE       ACTION
 <scheduler-id>  reviewer                  scheduler  created
 
 $ agent-compose ls
-AGENT     PROVIDER  MODEL  IMAGE                       DRIVER  SCHEDULER
-reviewer  codex            agent-compose-guest:latest  docker  true
+AGENT     PROVIDER  MODEL  MODEL SOURCE      IMAGE                       DRIVER  SCHEDULER
+reviewer  codex     -      provider_default  agent-compose-guest:latest  docker  true
 ```
 
 如果外层 scheduler run 成功但看不到预期 transcript，请通过 `logs reviewer`

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -730,7 +730,7 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 		},
 		runEvents: []domain.ProjectRunEventRecord{{ID: "event-1", RunID: "run-1", Sequence: 1, Kind: domain.ProjectRunEventKindUserMessage, Text: "hello", CreatedAt: time.Unix(1, 0)}},
 	}
-	projectHandler := NewProjectHandler(nil, store, nil)
+	projectHandler := NewProjectHandler(nil, store, nil, nil)
 	projectResp, err := projectHandler.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_Name{Name: "Project"}}, IncludeSpec: true}))
 	if err != nil {
 		t.Fatalf("GetProject returned error: %v", err)

--- a/pkg/agentcompose/api/project_agent_model.go
+++ b/pkg/agentcompose/api/project_agent_model.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+// ProjectAgentModelResolver supplies read-only model previews for project responses.
+type ProjectAgentModelResolver interface {
+	ResolveProjectAgentModels(context.Context, domain.ProjectRecord) (map[string]llms.AgentModelResolution, error)
+}
+
+func (h *ProjectHandler) enrichProjectAgentModels(ctx context.Context, record domain.ProjectRecord, project *agentcomposev2.Project) error {
+	if h.agentModels == nil || project == nil {
+		return nil
+	}
+	resolutions, err := h.agentModels.ResolveProjectAgentModels(ctx, record)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("resolve project agent models: %w", err))
+	}
+	for _, agent := range project.GetAgents() {
+		resolution, ok := resolutions[agent.GetAgentName()]
+		if !ok {
+			continue
+		}
+		agent.ResolvedModel = resolution.Model
+		agent.ModelSource = agentModelSourceToProto(resolution.Source)
+	}
+	return nil
+}
+
+func agentModelSourceToProto(source llms.AgentModelSource) agentcomposev2.AgentModelSource {
+	switch source {
+	case llms.AgentModelSourceProject:
+		return agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_PROJECT
+	case llms.AgentModelSourceAgentEnv:
+		return agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_AGENT_ENV
+	case llms.AgentModelSourceDaemonDefault:
+		return agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_DAEMON_DEFAULT
+	case llms.AgentModelSourceProviderDefault:
+		return agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_PROVIDER_DEFAULT
+	case llms.AgentModelSourceUnresolved:
+		return agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_UNRESOLVED
+	default:
+		return agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_UNSPECIFIED
+	}
+}

--- a/pkg/agentcompose/api/project_agent_model_test.go
+++ b/pkg/agentcompose/api/project_agent_model_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+type projectAgentModelResolverStub struct {
+	resolutions map[string]llms.AgentModelResolution
+	err         error
+}
+
+func (s projectAgentModelResolverStub) ResolveProjectAgentModels(context.Context, domain.ProjectRecord) (map[string]llms.AgentModelResolution, error) {
+	return s.resolutions, s.err
+}
+
+func TestEnrichProjectAgentModelsMapsResolvedModelAndSource(t *testing.T) {
+	handler := &ProjectHandler{agentModels: projectAgentModelResolverStub{resolutions: map[string]llms.AgentModelResolution{
+		"coder": {Model: "dev/gpt-5.5", Source: llms.AgentModelSourceDaemonDefault},
+		"main":  {Model: "gpt-explicit", Source: llms.AgentModelSourceProject},
+	}}}
+	project := &agentcomposev2.Project{Agents: []*agentcomposev2.ProjectAgent{{AgentName: "coder"}, {AgentName: "main", Model: "gpt-explicit"}}}
+	if err := handler.enrichProjectAgentModels(context.Background(), domain.ProjectRecord{ID: "project"}, project); err != nil {
+		t.Fatal(err)
+	}
+	if coder := project.GetAgents()[0]; coder.GetResolvedModel() != "dev/gpt-5.5" || coder.GetModelSource() != agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_DAEMON_DEFAULT {
+		t.Fatalf("coder = %#v", coder)
+	}
+	if main := project.GetAgents()[1]; main.GetModel() != "gpt-explicit" || main.GetResolvedModel() != "gpt-explicit" || main.GetModelSource() != agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_PROJECT {
+		t.Fatalf("main = %#v", main)
+	}
+}
+
+func TestEnrichProjectAgentModelsReturnsInternalResolverError(t *testing.T) {
+	wantErr := errors.New("resolution failed")
+	handler := &ProjectHandler{agentModels: projectAgentModelResolverStub{err: wantErr}}
+	err := handler.enrichProjectAgentModels(context.Background(), domain.ProjectRecord{ID: "project"}, &agentcomposev2.Project{})
+	if connect.CodeOf(err) != connect.CodeInternal || !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want internal wrapping %v", err, wantErr)
+	}
+}

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -66,17 +66,18 @@ type ProjectHandler struct {
 	agentcomposev2connect.UnimplementedProjectServiceHandler
 	delegate         ProjectDelegate
 	store            ProjectStore
+	agentModels      ProjectAgentModelResolver
 	schedulerRuntime ProjectSchedulerRuntime
 	schedulerRuns    ProjectSchedulerRunRuntime
 	invocations      ProjectSchedulerInvocationRuntime
 	schedulerPrune   ProjectSchedulerPruneRuntime
 }
 
-func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime) *ProjectHandler {
+func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver) *ProjectHandler {
 	schedulerRuns, _ := schedulerRuntime.(ProjectSchedulerRunRuntime)
 	invocations, _ := schedulerRuntime.(ProjectSchedulerInvocationRuntime)
 	schedulerPrune, _ := schedulerRuntime.(ProjectSchedulerPruneRuntime)
-	return &ProjectHandler{delegate: delegate, store: store, schedulerRuntime: schedulerRuntime, schedulerRuns: schedulerRuns, invocations: invocations, schedulerPrune: schedulerPrune}
+	return &ProjectHandler{delegate: delegate, store: store, agentModels: agentModels, schedulerRuntime: schedulerRuntime, schedulerRuns: schedulerRuns, invocations: invocations, schedulerPrune: schedulerPrune}
 }
 
 func (h *ProjectHandler) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {
@@ -374,6 +375,9 @@ func (h *ProjectHandler) GetProject(ctx context.Context, req *connect.Request[ag
 		spec = RedactProjectSpecSecrets(spec)
 	}
 	projectProto := ProjectToProto(project, spec, agents, schedulers)
+	if err := h.enrichProjectAgentModels(ctx, project, projectProto); err != nil {
+		return nil, err
+	}
 	if err := h.enrichProjectAgentRuns(ctx, projectProto); err != nil {
 		return nil, err
 	}

--- a/pkg/agentcompose/api/project_handler_scheduler_runtime_test.go
+++ b/pkg/agentcompose/api/project_handler_scheduler_runtime_test.go
@@ -30,7 +30,7 @@ func TestProjectHandlerSchedulerUpdatesUseSchedulerRuntime(t *testing.T) {
 		Summary:  domain.SchedulerSummary{ID: schedulerID},
 		Triggers: []domain.SchedulerTrigger{{ID: triggerID, Kind: domain.SchedulerTriggerKindInterval, IntervalMs: 3000}},
 	}}
-	handler := NewProjectHandler(nil, store, runtime)
+	handler := NewProjectHandler(nil, store, runtime, nil)
 
 	enabled, err := handler.SetSchedulerEnabled(context.Background(), connect.NewRequest(&agentcomposev2.SetSchedulerEnabledRequest{
 		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},
@@ -70,7 +70,7 @@ func TestProjectHandlerGetSchedulerMapsPersistedNormalizedSpec(t *testing.T) {
 			SpecJSON:    `{"enabled":true,"sandbox_policy":"sticky","concurrency_policy":"parallel","display_name":"Nightly","triggers":[{"name":"heartbeat","kind":"interval","interval":"1m","sandbox_policy":"new"}]}`,
 		},
 	}
-	handler := NewProjectHandler(nil, store, nil)
+	handler := NewProjectHandler(nil, store, nil, nil)
 
 	response, err := handler.GetScheduler(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRequest{
 		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID}},

--- a/pkg/agentcompose/api/project_list_handler_test.go
+++ b/pkg/agentcompose/api/project_list_handler_test.go
@@ -21,7 +21,7 @@ func TestListProjectsUsesAggregatedResourceCounts(t *testing.T) {
 			TotalCount: 1,
 		},
 	}
-	handler := NewProjectHandler(nil, store, nil)
+	handler := NewProjectHandler(nil, store, nil, nil)
 
 	response, err := handler.ListProjects(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectsRequest{
 		Query: "project", IncludeRemoved: true, Offset: 4, Limit: 25,

--- a/pkg/agentcompose/api/project_scheduler_prune_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_prune_handler_test.go
@@ -99,7 +99,7 @@ func TestProjectHandlerPruneSchedulerRunsRejectsInvalidStatusAndDuration(t *test
 
 func TestProjectHandlerPruneSchedulerRunsRuntimeUnavailable(t *testing.T) {
 	store, _, _ := newSchedulerRunHandlerFixture()
-	handler := NewProjectHandler(nil, store, &schedulerRuntimeFake{})
+	handler := NewProjectHandler(nil, store, &schedulerRuntimeFake{}, nil)
 	_, err := handler.PruneSchedulerRuns(context.Background(), connect.NewRequest(&agentcomposev2.PruneSchedulerRunsRequest{
 		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
 	}))

--- a/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_integration_test.go
@@ -99,7 +99,7 @@ func TestIntegrationBatchGetLatestSchedulerRunsFindsRunBeyondFirstPage(t *testin
 		}
 	}
 
-	handler := NewProjectHandler(nil, store, nil)
+	handler := NewProjectHandler(nil, store, nil, nil)
 	mux := http.NewServeMux()
 	path, connectHandler := agentcomposev2connect.NewProjectServiceHandler(handler)
 	mux.Handle(path, connectHandler)

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -282,7 +282,7 @@ func newSchedulerRunHandlerFixture() (*schedulerRunProjectStoreFake, *schedulerR
 		},
 	}
 	runtime := &schedulerRunRuntimeFake{}
-	return store, runtime, NewProjectHandler(nil, store, runtime)
+	return store, runtime, NewProjectHandler(nil, store, runtime, nil)
 }
 
 type schedulerRunProjectStoreFake struct {

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -101,6 +101,7 @@ func RegisterRoutes(di do.Injector) {
 		projectControllerDelegate{controller: do.MustInvoke[*projects.Controller](di)},
 		do.MustInvoke[*configstore.ConfigStore](di),
 		do.MustInvoke[*schedulers.Controller](di),
+		newProjectAgentModelResolver(do.MustInvoke[*appconfig.Config](di), do.MustInvoke[*configstore.ConfigStore](di)),
 	)
 	path, handler := agentcomposev2connect.NewProjectServiceHandler(projectHandler)
 	app.Any(path+"*", echo.WrapHandler(handler))

--- a/pkg/agentcompose/app/project_agent_model_resolver.go
+++ b/pkg/agentcompose/app/project_agent_model_resolver.go
@@ -38,13 +38,13 @@ func (r *projectAgentModelResolver) ResolveProjectAgentModels(ctx context.Contex
 	if err != nil {
 		return nil, fmt.Errorf("derive project agent definitions: %w", err)
 	}
+	resolved, err := llms.ResolveAgentModels(ctx, r.config, r.store, definitions)
+	if err != nil {
+		return nil, fmt.Errorf("resolve project agent models: %w", err)
+	}
 	resolutions := make(map[string]llms.AgentModelResolution, len(definitions))
-	for _, definition := range definitions {
-		resolution, err := llms.ResolveAgentModel(ctx, r.config, r.store, definition)
-		if err != nil {
-			return nil, fmt.Errorf("resolve agent %s model: %w", definition.AgentName, err)
-		}
-		resolutions[definition.AgentName] = resolution
+	for i, definition := range definitions {
+		resolutions[definition.AgentName] = resolved[i]
 	}
 	return resolutions, nil
 }

--- a/pkg/agentcompose/app/project_agent_model_resolver.go
+++ b/pkg/agentcompose/app/project_agent_model_resolver.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"agent-compose/pkg/compose"
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+	"agent-compose/pkg/storage/configstore"
+)
+
+type projectAgentModelResolver struct {
+	config *appconfig.Config
+	store  *configstore.ConfigStore
+}
+
+func newProjectAgentModelResolver(config *appconfig.Config, store *configstore.ConfigStore) *projectAgentModelResolver {
+	return &projectAgentModelResolver{config: config, store: store}
+}
+
+func (r *projectAgentModelResolver) ResolveProjectAgentModels(ctx context.Context, project domain.ProjectRecord) (map[string]llms.AgentModelResolution, error) {
+	if r == nil || r.store == nil || project.CurrentRevision <= 0 {
+		return nil, nil
+	}
+	revision, err := r.store.GetProjectRevision(ctx, project.ID, project.CurrentRevision)
+	if err != nil {
+		return nil, fmt.Errorf("get project revision %s/%d: %w", project.ID, project.CurrentRevision, err)
+	}
+	spec, err := compose.ParseCanonicalJSON([]byte(strings.TrimSpace(revision.SpecJSON)))
+	if err != nil {
+		return nil, fmt.Errorf("decode project revision %s/%d: %w", project.ID, project.CurrentRevision, err)
+	}
+	definitions, err := projects.NewAgentDefinitionsFromSpec(project, project.CurrentRevision, spec)
+	if err != nil {
+		return nil, fmt.Errorf("derive project agent definitions: %w", err)
+	}
+	resolutions := make(map[string]llms.AgentModelResolution, len(definitions))
+	for _, definition := range definitions {
+		resolution, err := llms.ResolveAgentModel(ctx, r.config, r.store, definition)
+		if err != nil {
+			return nil, fmt.Errorf("resolve agent %s model: %w", definition.AgentName, err)
+		}
+		resolutions[definition.AgentName] = resolution
+	}
+	return resolutions, nil
+}

--- a/pkg/agentcompose/app/project_agent_model_resolver_test.go
+++ b/pkg/agentcompose/app/project_agent_model_resolver_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"agent-compose/pkg/compose"
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+func TestProjectAgentModelResolverUsesCurrentRevisionAndDaemonDefault(t *testing.T) {
+	ctx := context.Background()
+	store := newRunSupervisorTestConfigStore(t)
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-model-preview", Name: "model-preview", SourcePath: "/tmp/model-preview/agent-compose.yml", SourceJSON: "{}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := compose.Parse([]byte("name: model-preview\nagents:\n  coder:\n    provider: codex\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalized, err := compose.Normalize(raw, compose.NormalizeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	specJSON, err := normalized.MarshalCanonicalJSON(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{ProjectID: project.ID, SpecHash: "sha256:model-preview", SpecJSON: string(specJSON)}); err != nil {
+		t.Fatal(err)
+	}
+	project, err = store.GetProject(ctx, project.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := newProjectAgentModelResolver(&appconfig.Config{LLMModel: "dev/gpt-5.5"}, store)
+	resolutions, err := resolver.ResolveProjectAgentModels(ctx, project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := resolutions["coder"]
+	if resolution.Model != "dev/gpt-5.5" || resolution.Source != "daemon_default" {
+		t.Fatalf("resolution = %#v", resolution)
+	}
+}

--- a/pkg/llms/agent_model_resolution.go
+++ b/pkg/llms/agent_model_resolution.go
@@ -1,0 +1,192 @@
+package llms
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+// AgentModelSource identifies the configuration layer that selected a model.
+type AgentModelSource string
+
+// Agent model sources distinguish persisted intent from runtime defaults.
+const (
+	AgentModelSourceProject         AgentModelSource = "project"
+	AgentModelSourceAgentEnv        AgentModelSource = "agent_env"
+	AgentModelSourceDaemonDefault   AgentModelSource = "daemon_default"
+	AgentModelSourceProviderDefault AgentModelSource = "provider_default"
+	AgentModelSourceUnresolved      AgentModelSource = "unresolved"
+)
+
+// AgentModelResolution describes the model preview for a new agent run.
+type AgentModelResolution struct {
+	Model  string
+	Source AgentModelSource
+}
+
+// AgentModelResolutionStore is the read-only configuration surface used to
+// preview the model a new agent run would select. It deliberately excludes the
+// bootstrap write capability required by LLMResolverStore so project queries
+// cannot mutate daemon LLM configuration.
+type AgentModelResolutionStore interface {
+	ProviderListStore
+	ProviderModelWireAPIStore
+	GlobalEnvStore
+	ListEnabledLLMModels(context.Context) ([]Model, error)
+}
+
+// ResolveAgentModel previews the model selected for a new run without a
+// request- or session-level override. An empty model with provider_default
+// means the agent provider owns the final selection.
+func ResolveAgentModel(ctx context.Context, config *appconfig.Config, store AgentModelResolutionStore, agent domain.AgentDefinition) (AgentModelResolution, error) {
+	provider := domain.NormalizeAgentKind(agent.Provider)
+	configuredModel := strings.TrimSpace(agent.Model)
+	if configuredModel != "" {
+		return AgentModelResolution{Model: configuredModel, Source: AgentModelSourceProject}, nil
+	}
+	if model := agentEnvironmentModel(provider, agent.EnvItems); model != "" {
+		return AgentModelResolution{Model: model, Source: AgentModelSourceAgentEnv}, nil
+	}
+
+	providerFamily := agentProviderFamily(provider)
+	if providerFamily == "" {
+		source := AgentModelSourceProviderDefault
+		if provider == "opencode" || provider == "pi" {
+			source = AgentModelSourceUnresolved
+		}
+		return AgentModelResolution{Source: source}, nil
+	}
+
+	providers, models, err := enabledLLMConfiguration(ctx, store)
+	if err != nil {
+		return AgentModelResolution{}, err
+	}
+	if hasConfiguredProviderForFamily(providers, providerFamily) {
+		return selectConfiguredDefaultModel(ctx, store, providers, models, providerFamily)
+	}
+
+	model, err := daemonEnvironmentModel(ctx, config, store, providerFamily)
+	if err != nil {
+		return AgentModelResolution{}, err
+	}
+	if model != "" {
+		return AgentModelResolution{Model: model, Source: AgentModelSourceDaemonDefault}, nil
+	}
+
+	resolution, ok, err := selectStoredDefaultModel(ctx, store, providers, models, providerFamily)
+	if err != nil {
+		return AgentModelResolution{}, err
+	}
+	if ok {
+		return resolution, nil
+	}
+	return AgentModelResolution{Source: AgentModelSourceProviderDefault}, nil
+}
+
+func agentEnvironmentModel(provider string, items []domain.SandboxEnvVar) string {
+	switch provider {
+	case "codex":
+		return firstNonEmptyTrimmed(EnvItemValue(items, "CODEX_MODEL"), EnvItemValue(items, "LLM_MODEL"))
+	case "claude":
+		return firstNonEmptyTrimmed(EnvItemValue(items, "ANTHROPIC_MODEL"), EnvItemValue(items, "CLAUDE_MODEL"), EnvItemValue(items, "LLM_MODEL"))
+	case "opencode":
+		return firstNonEmptyTrimmed(EnvItemValue(items, "OPENCODE_MODEL"), EnvItemValue(items, "LLM_MODEL"))
+	default:
+		return ""
+	}
+}
+
+func agentProviderFamily(provider string) string {
+	switch provider {
+	case "codex":
+		return ProviderFamilyOpenAI
+	case "claude":
+		return ProviderFamilyAnthropic
+	default:
+		return ""
+	}
+}
+
+func enabledLLMConfiguration(ctx context.Context, store AgentModelResolutionStore) ([]Provider, []Model, error) {
+	if store == nil {
+		return nil, nil, nil
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list enabled llm providers for agent model preview: %w", err)
+	}
+	models, err := store.ListEnabledLLMModels(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list enabled llm models for agent model preview: %w", err)
+	}
+	return providers, models, nil
+}
+
+func hasConfiguredProviderForFamily(providers []Provider, providerFamily string) bool {
+	for _, provider := range providers {
+		if NormalizeProviderType(provider.ProviderType) == providerFamily && ProviderScopeIsConfigured(provider.Scope) {
+			return true
+		}
+	}
+	return false
+}
+
+func selectConfiguredDefaultModel(ctx context.Context, store AgentModelResolutionStore, providers []Provider, models []Model, providerFamily string) (AgentModelResolution, error) {
+	resolution, ok, err := selectStoredDefaultModel(ctx, store, providers, models, providerFamily)
+	if err != nil {
+		return AgentModelResolution{}, err
+	}
+	if !ok {
+		return AgentModelResolution{Source: AgentModelSourceUnresolved}, nil
+	}
+	return resolution, nil
+}
+
+func selectStoredDefaultModel(ctx context.Context, store AgentModelResolutionStore, providers []Provider, models []Model, providerFamily string) (AgentModelResolution, bool, error) {
+	if store == nil || len(providers) == 0 || len(models) == 0 {
+		return AgentModelResolution{}, false, nil
+	}
+	model, _, _, ok, err := SelectModelAndProvider(ctx, store, models, providers, "", providerFamily, "")
+	if err != nil {
+		return AgentModelResolution{}, false, fmt.Errorf("select default agent model: %w", err)
+	}
+	if !ok {
+		return AgentModelResolution{}, false, nil
+	}
+	return AgentModelResolution{Model: firstNonEmptyTrimmed(model.Name, model.ID), Source: AgentModelSourceDaemonDefault}, true, nil
+}
+
+func daemonEnvironmentModel(ctx context.Context, config *appconfig.Config, store AgentModelResolutionStore, providerFamily string) (string, error) {
+	var global []domain.SandboxEnvVar
+	if store != nil {
+		items, err := store.ListGlobalEnv(ctx)
+		if err != nil {
+			return "", fmt.Errorf("list global environment for agent model preview: %w", err)
+		}
+		global = items
+	}
+	keys := []string{"LLM_MODEL"}
+	if providerFamily == ProviderFamilyAnthropic {
+		keys = []string{"ANTHROPIC_MODEL", "CLAUDE_MODEL", "LLM_MODEL"}
+	}
+	for _, key := range keys {
+		if value := EnvItemValue(global, key); value != "" {
+			return value, nil
+		}
+	}
+	for _, key := range keys {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value, nil
+		}
+	}
+	for _, key := range keys {
+		if value := strings.TrimSpace(configLLMEnvValue(config, key)); value != "" {
+			return value, nil
+		}
+	}
+	return "", nil
+}

--- a/pkg/llms/agent_model_resolution.go
+++ b/pkg/llms/agent_model_resolution.go
@@ -39,6 +39,22 @@ type AgentModelResolutionStore interface {
 	ListEnabledLLMModels(context.Context) ([]Model, error)
 }
 
+// ResolveAgentModels previews multiple agents against one read-only snapshot of
+// daemon LLM configuration. Shared provider, model, global environment, and
+// provider-model lookups are loaded at most once per batch.
+func ResolveAgentModels(ctx context.Context, config *appconfig.Config, store AgentModelResolutionStore, agents []domain.AgentDefinition) ([]AgentModelResolution, error) {
+	cachedStore := newAgentModelResolutionStoreCache(store)
+	resolutions := make([]AgentModelResolution, 0, len(agents))
+	for _, agent := range agents {
+		resolution, err := ResolveAgentModel(ctx, config, cachedStore, agent)
+		if err != nil {
+			return nil, fmt.Errorf("resolve agent %s model: %w", agent.AgentName, err)
+		}
+		resolutions = append(resolutions, resolution)
+	}
+	return resolutions, nil
+}
+
 // ResolveAgentModel previews the model selected for a new run without a
 // request- or session-level override. An empty model with provider_default
 // means the agent provider owns the final selection.
@@ -189,4 +205,72 @@ func daemonEnvironmentModel(ctx context.Context, config *appconfig.Config, store
 		}
 	}
 	return "", nil
+}
+
+type agentModelResolutionStoreCache struct {
+	store AgentModelResolutionStore
+
+	providersLoaded bool
+	providers       []Provider
+	providersErr    error
+	modelsLoaded    bool
+	models          []Model
+	modelsErr       error
+	globalEnvLoaded bool
+	globalEnv       []domain.SandboxEnvVar
+	globalEnvErr    error
+	wireAPIs        map[string]agentModelWireAPIResult
+}
+
+type agentModelWireAPIResult struct {
+	wireAPI string
+	ok      bool
+	err     error
+}
+
+func newAgentModelResolutionStoreCache(store AgentModelResolutionStore) *agentModelResolutionStoreCache {
+	return &agentModelResolutionStoreCache{store: store, wireAPIs: make(map[string]agentModelWireAPIResult)}
+}
+
+func (s *agentModelResolutionStoreCache) ListEnabledLLMProviders(ctx context.Context) ([]Provider, error) {
+	if !s.providersLoaded {
+		s.providersLoaded = true
+		if s.store != nil {
+			s.providers, s.providersErr = s.store.ListEnabledLLMProviders(ctx)
+		}
+	}
+	return s.providers, s.providersErr
+}
+
+func (s *agentModelResolutionStoreCache) ListEnabledLLMModels(ctx context.Context) ([]Model, error) {
+	if !s.modelsLoaded {
+		s.modelsLoaded = true
+		if s.store != nil {
+			s.models, s.modelsErr = s.store.ListEnabledLLMModels(ctx)
+		}
+	}
+	return s.models, s.modelsErr
+}
+
+func (s *agentModelResolutionStoreCache) ListGlobalEnv(ctx context.Context) ([]domain.SandboxEnvVar, error) {
+	if !s.globalEnvLoaded {
+		s.globalEnvLoaded = true
+		if s.store != nil {
+			s.globalEnv, s.globalEnvErr = s.store.ListGlobalEnv(ctx)
+		}
+	}
+	return s.globalEnv, s.globalEnvErr
+}
+
+func (s *agentModelResolutionStoreCache) LLMProviderModelWireAPI(ctx context.Context, providerID, modelID string) (string, bool, error) {
+	key := providerID + "\x00" + modelID
+	if result, ok := s.wireAPIs[key]; ok {
+		return result.wireAPI, result.ok, result.err
+	}
+	result := agentModelWireAPIResult{}
+	if s.store != nil {
+		result.wireAPI, result.ok, result.err = s.store.LLMProviderModelWireAPI(ctx, providerID, modelID)
+	}
+	s.wireAPIs[key] = result
+	return result.wireAPI, result.ok, result.err
 }

--- a/pkg/llms/agent_model_resolution_test.go
+++ b/pkg/llms/agent_model_resolution_test.go
@@ -1,0 +1,97 @@
+package llms
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+type agentModelResolutionStoreStub struct {
+	providers []Provider
+	models    []Model
+	globalEnv []domain.SandboxEnvVar
+	wireAPIs  map[string]string
+	err       error
+}
+
+func (s agentModelResolutionStoreStub) ListEnabledLLMProviders(context.Context) ([]Provider, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return append([]Provider(nil), s.providers...), nil
+}
+
+func (s agentModelResolutionStoreStub) ListEnabledLLMModels(context.Context) ([]Model, error) {
+	return append([]Model(nil), s.models...), nil
+}
+
+func (s agentModelResolutionStoreStub) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
+	return append([]domain.SandboxEnvVar(nil), s.globalEnv...), nil
+}
+
+func (s agentModelResolutionStoreStub) LLMProviderModelWireAPI(_ context.Context, providerID, modelID string) (string, bool, error) {
+	wireAPI, ok := s.wireAPIs[providerID+"\x00"+modelID]
+	return wireAPI, ok, nil
+}
+
+func TestResolveAgentModelPrecedence(t *testing.T) {
+	t.Setenv("LLM_MODEL", "")
+	store := agentModelResolutionStoreStub{
+		providers: []Provider{{ID: "openai", ProviderType: ProviderFamilyOpenAI, Scope: ProviderScopeSystem, Enabled: true}},
+		models:    []Model{{ID: "daemon-model", Name: "daemon-model", DefaultModel: true, Enabled: true}},
+		globalEnv: []domain.SandboxEnvVar{{Name: "LLM_MODEL", Value: "global-model"}},
+		wireAPIs:  map[string]string{"openai\x00daemon-model": APIProtocolResponses},
+	}
+	tests := []struct {
+		name  string
+		agent domain.AgentDefinition
+		want  AgentModelResolution
+	}{
+		{name: "project", agent: domain.AgentDefinition{Provider: "codex", Model: "project-model", EnvItems: []domain.SandboxEnvVar{{Name: "LLM_MODEL", Value: "agent-model"}}}, want: AgentModelResolution{Model: "project-model", Source: AgentModelSourceProject}},
+		{name: "agent env", agent: domain.AgentDefinition{Provider: "codex", EnvItems: []domain.SandboxEnvVar{{Name: "CODEX_MODEL", Value: "agent-model"}}}, want: AgentModelResolution{Model: "agent-model", Source: AgentModelSourceAgentEnv}},
+		{name: "configured daemon", agent: domain.AgentDefinition{Provider: "codex"}, want: AgentModelResolution{Model: "daemon-model", Source: AgentModelSourceDaemonDefault}},
+		{name: "provider default", agent: domain.AgentDefinition{Provider: "gemini"}, want: AgentModelResolution{Source: AgentModelSourceProviderDefault}},
+		{name: "required model unresolved", agent: domain.AgentDefinition{Provider: "pi"}, want: AgentModelResolution{Source: AgentModelSourceUnresolved}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ResolveAgentModel(context.Background(), &appconfig.Config{LLMModel: "config-model"}, store, test.agent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("resolution = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentModelUsesDaemonEnvironmentWithoutConfiguredProvider(t *testing.T) {
+	t.Setenv("LLM_MODEL", "")
+	resolution, err := ResolveAgentModel(context.Background(), &appconfig.Config{LLMModel: "config-model"}, agentModelResolutionStoreStub{}, domain.AgentDefinition{Provider: "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.Model != "config-model" || resolution.Source != AgentModelSourceDaemonDefault {
+		t.Fatalf("resolution = %#v", resolution)
+	}
+
+	resolution, err = ResolveAgentModel(context.Background(), &appconfig.Config{LLMModel: "config-model"}, agentModelResolutionStoreStub{globalEnv: []domain.SandboxEnvVar{{Name: "CLAUDE_MODEL", Value: "global-claude"}}}, domain.AgentDefinition{Provider: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.Model != "global-claude" || resolution.Source != AgentModelSourceDaemonDefault {
+		t.Fatalf("resolution = %#v", resolution)
+	}
+}
+
+func TestResolveAgentModelReturnsReadFailure(t *testing.T) {
+	wantErr := errors.New("read failed")
+	_, err := ResolveAgentModel(context.Background(), nil, agentModelResolutionStoreStub{err: wantErr}, domain.AgentDefinition{Provider: "codex"})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+}

--- a/pkg/llms/agent_model_resolution_test.go
+++ b/pkg/llms/agent_model_resolution_test.go
@@ -15,9 +15,20 @@ type agentModelResolutionStoreStub struct {
 	globalEnv []domain.SandboxEnvVar
 	wireAPIs  map[string]string
 	err       error
+	calls     *agentModelResolutionStoreCalls
+}
+
+type agentModelResolutionStoreCalls struct {
+	providers int
+	models    int
+	globalEnv int
+	wireAPIs  int
 }
 
 func (s agentModelResolutionStoreStub) ListEnabledLLMProviders(context.Context) ([]Provider, error) {
+	if s.calls != nil {
+		s.calls.providers++
+	}
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -25,14 +36,23 @@ func (s agentModelResolutionStoreStub) ListEnabledLLMProviders(context.Context) 
 }
 
 func (s agentModelResolutionStoreStub) ListEnabledLLMModels(context.Context) ([]Model, error) {
+	if s.calls != nil {
+		s.calls.models++
+	}
 	return append([]Model(nil), s.models...), nil
 }
 
 func (s agentModelResolutionStoreStub) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
+	if s.calls != nil {
+		s.calls.globalEnv++
+	}
 	return append([]domain.SandboxEnvVar(nil), s.globalEnv...), nil
 }
 
 func (s agentModelResolutionStoreStub) LLMProviderModelWireAPI(_ context.Context, providerID, modelID string) (string, bool, error) {
+	if s.calls != nil {
+		s.calls.wireAPIs++
+	}
 	wireAPI, ok := s.wireAPIs[providerID+"\x00"+modelID]
 	return wireAPI, ok, nil
 }
@@ -79,12 +99,48 @@ func TestResolveAgentModelUsesDaemonEnvironmentWithoutConfiguredProvider(t *test
 		t.Fatalf("resolution = %#v", resolution)
 	}
 
-	resolution, err = ResolveAgentModel(context.Background(), &appconfig.Config{LLMModel: "config-model"}, agentModelResolutionStoreStub{globalEnv: []domain.SandboxEnvVar{{Name: "CLAUDE_MODEL", Value: "global-claude"}}}, domain.AgentDefinition{Provider: "claude"})
+	resolution, err = ResolveAgentModel(context.Background(), &appconfig.Config{LLMModel: "config-model"}, agentModelResolutionStoreStub{globalEnv: []domain.SandboxEnvVar{{Name: "CLAUDE_MODEL", Value: "  global-claude  "}}}, domain.AgentDefinition{Provider: "claude"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resolution.Model != "global-claude" || resolution.Source != AgentModelSourceDaemonDefault {
 		t.Fatalf("resolution = %#v", resolution)
+	}
+}
+
+func TestResolveAgentModelsCachesSharedConfigurationQueries(t *testing.T) {
+	t.Setenv("LLM_MODEL", "")
+	calls := &agentModelResolutionStoreCalls{}
+	store := agentModelResolutionStoreStub{
+		providers: []Provider{{ID: "openai", ProviderType: ProviderFamilyOpenAI, Scope: ProviderScopeSystem, Enabled: true}},
+		models:    []Model{{ID: "daemon-model", Name: "daemon-model", DefaultModel: true, Enabled: true}},
+		wireAPIs:  map[string]string{"openai\x00daemon-model": APIProtocolResponses},
+		calls:     calls,
+	}
+	resolutions, err := ResolveAgentModels(context.Background(), nil, store, []domain.AgentDefinition{{Provider: "codex"}, {Provider: "codex"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolutions) != 2 || resolutions[0].Model != "daemon-model" || resolutions[1].Model != "daemon-model" {
+		t.Fatalf("resolutions = %#v", resolutions)
+	}
+	if calls.providers != 1 || calls.models != 1 || calls.wireAPIs != 1 || calls.globalEnv != 0 {
+		t.Fatalf("store calls = %#v, want providers/models/wire once and no global env", calls)
+	}
+
+	envCalls := &agentModelResolutionStoreCalls{}
+	resolutions, err = ResolveAgentModels(context.Background(), nil, agentModelResolutionStoreStub{
+		globalEnv: []domain.SandboxEnvVar{{Name: "LLM_MODEL", Value: "global-model"}},
+		calls:     envCalls,
+	}, []domain.AgentDefinition{{Provider: "codex"}, {Provider: "codex"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolutions) != 2 || resolutions[0].Model != "global-model" || resolutions[1].Model != "global-model" {
+		t.Fatalf("global env resolutions = %#v", resolutions)
+	}
+	if envCalls.providers != 1 || envCalls.models != 1 || envCalls.globalEnv != 1 || envCalls.wireAPIs != 0 {
+		t.Fatalf("global env store calls = %#v, want providers/models/global env once and no wire lookup", envCalls)
 	}
 }
 

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -511,6 +511,18 @@ message ProjectAgent {
   ProjectAgentLatestRun latest_run = 13;
   string display_name = 14;
   string description = 15;
+  // Model selected for a new run when no request- or session-level override is present.
+  string resolved_model = 16;
+  AgentModelSource model_source = 17;
+}
+
+enum AgentModelSource {
+  AGENT_MODEL_SOURCE_UNSPECIFIED = 0;
+  AGENT_MODEL_SOURCE_PROJECT = 1;
+  AGENT_MODEL_SOURCE_AGENT_ENV = 2;
+  AGENT_MODEL_SOURCE_DAEMON_DEFAULT = 3;
+  AGENT_MODEL_SOURCE_PROVIDER_DEFAULT = 4;
+  AGENT_MODEL_SOURCE_UNRESOLVED = 5;
 }
 
 message ProjectAgentCurrentRun {


### PR DESCRIPTION
## Summary

- preserve `model` as the project-declared value while exposing `resolved_model` and `model_source` through the v2 API
- resolve project, agent environment, daemon, and provider model defaults through a read-only LLM query path with no bootstrap writes
- show the resolved model and its source in `agent ls` / top-level `ls`, with compatible JSON fallback behavior
- update English and Chinese CLI documentation and representative example output

## Testing

- `task lint`
- `task build`
- `task test`
  - Unit: 75.06%
  - Integration: 60.15%
  - E2E: 60.57%
  - Combined: 79.12%
- `task docs:build`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.