### PR TITLE
fix(runs): separate error message from run transcript in GetRun response

### DIFF
--- a/cmd/agent-compose-migrate/main_test.go
+++ b/cmd/agent-compose-migrate/main_test.go
@@ -46,7 +46,7 @@ func TestE2ELegacyMigratorCLIJSONDryRun(t *testing.T) {
 	if err := reader.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 11 || !report.DryRun {
+	if exitCode != 0 || report.Stage != "eligible" || report.TargetVersion != 12 || !report.DryRun {
 		t.Fatalf("exit=%d report=%+v", exitCode, report)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -91,7 +91,7 @@ func TestE2ELegacyMigratorCLITextDryRun(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", exitCode)
 	}
-	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 11 is eligible"; got != want {
+	if got, want := strings.TrimSpace(string(output)), "legacy migration dry run: source schema version 12 is eligible"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
@@ -153,7 +153,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 	}
 
 	report := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 11 || report.Backup == "" {
+	if report.Stage != "complete" || !report.InPlace || report.TargetVersion != 12 || report.Backup == "" {
 		t.Fatalf("in-place report=%+v", report)
 	}
 	nativeInfo, err := os.Stat(filepath.Join(root, "sandboxes", sandboxID, "state.bin"))
@@ -164,7 +164,7 @@ func TestE2ELegacyMigratorCLIInPlaceWorkflow(t *testing.T) {
 		t.Fatalf("database backup is unavailable: %v", err)
 	}
 	repeated := runMigratorCLIJSON(t, "--source", root, "--target", root, "--json")
-	if repeated.Stage != "complete" || repeated.TargetVersion != 11 {
+	if repeated.Stage != "complete" || repeated.TargetVersion != 12 {
 		t.Fatalf("repeated in-place report=%+v", repeated)
 	}
 }

--- a/cmd/agent-compose-migrate/migrate/migrate.go
+++ b/cmd/agent-compose-migrate/migrate/migrate.go
@@ -22,7 +22,7 @@ const (
 	databaseName         = "data.db"
 	journalName          = ".agent-compose-migrate.json"
 	inPlaceBackupName    = ".agent-compose-migrate-backup"
-	currentSchemaVersion = 11
+	currentSchemaVersion = 12
 )
 
 var knownMigrationChecksums = map[int64]string{
@@ -37,6 +37,7 @@ var knownMigrationChecksums = map[int64]string{
 	9:  "916b84e78f6956ae5af9e38720fa4c6c0c7dfe9d72ddba068790ce44a80e7fb3",
 	10: "63a1d45d94cbd1ade08ee556c7615f2dcbdd4411740f03ed12d93d67a1509d78",
 	11: "8c3ef0d428da031391394df2313d581484f39f8e94a0e8b5435d9947e67ba6ef",
+	12: "47091ab8031b9f8086be4a717c81a414a1094893586b8ebc6064b415b58421d6",
 }
 
 var ErrReported = errors.New("migration failure is included in the report")

--- a/cmd/agent-compose-migrate/migrate/report_test.go
+++ b/cmd/agent-compose-migrate/migrate/report_test.go
@@ -12,11 +12,11 @@ func TestReportTextIncludesWarningsForEverySuccessfulMode(t *testing.T) {
 	if got := (Report{DryRun: true, SourceVersion: 4}).Text(); got != "legacy migration dry run: source schema version 4 is eligible" {
 		t.Fatalf("dry-run report text = %q", got)
 	}
-	if got := (Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v11, 2 files (9 bytes) copied to /target" {
+	if got := (Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, CopiedBytes: 9, Target: "/target"}).Text(); got != "legacy migration complete: schema v12, 2 files (9 bytes) copied to /target" {
 		t.Fatalf("complete report text = %q", got)
 	}
 	warningReport := Report{TargetVersion: currentSchemaVersion, CopiedFiles: 2, Target: "/target", Warnings: []string{"unresolved scheduler link", "  external path retained  ", ""}}
-	if got, want := warningReport.Text(), "legacy migration complete: schema v11, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
+	if got, want := warningReport.Text(), "legacy migration complete: schema v12, 2 files (0 bytes) copied to /target\nwarning: unresolved scheduler link\nwarning: external path retained"; got != want {
 		t.Fatalf("warning report text = %q, want %q", got, want)
 	}
 	for name, report := range map[string]Report{

--- a/pkg/agentcompose/api/run.go
+++ b/pkg/agentcompose/api/run.go
@@ -23,6 +23,7 @@ func ProjectRunDetailToProto(run domain.ProjectRunRecord) *agentcomposev2.RunDet
 		Driver:       run.Driver,
 		ImageRef:     run.ImageRef,
 		Warnings:     append([]string(nil), run.Warnings...),
+		ErrorStack:   run.ErrorStack,
 	}
 }
 

--- a/pkg/model/project_model.go
+++ b/pkg/model/project_model.go
@@ -92,6 +92,7 @@ type ProjectRunRecord struct {
 	SandboxID       string    `json:"sandbox_id,omitempty"`
 	ExitCode        int       `json:"exit_code,omitempty"`
 	Error           string    `json:"error,omitempty"`
+	ErrorStack      string    `json:"error_stack,omitempty"`
 	Prompt          string    `json:"prompt,omitempty"`
 	Output          string    `json:"output,omitempty"`
 	ResultJSON      string    `json:"result_json,omitempty"`

--- a/pkg/projects/scan.go
+++ b/pkg/projects/scan.go
@@ -110,7 +110,7 @@ func ScanProjectRun(scan func(dest ...any) error) (domain.ProjectRunRecord, erro
 	var updatedAtRaw any
 	if err := scan(
 		&item.RunID, &item.ProjectID, &item.ProjectName, &item.ProjectRevision, &item.AgentName, &item.AgentID, &item.Source, &item.SchedulerID, &schedulerRunID, &item.TriggerID, &item.Status,
-		&item.SandboxID, &item.ExitCode, &item.Error, &item.Prompt, &item.Output, &item.ResultJSON, &item.LogsPath, &item.ArtifactsDir, &item.CleanupError, &item.CleanupPolicy, &sandboxCreated, &item.Driver, &item.ImageRef,
+		&item.SandboxID, &item.ExitCode, &item.Error, &item.ErrorStack, &item.Prompt, &item.Output, &item.ResultJSON, &item.LogsPath, &item.ArtifactsDir, &item.CleanupError, &item.CleanupPolicy, &sandboxCreated, &item.Driver, &item.ImageRef,
 		&startedAtRaw, &completedAtRaw, &item.DurationMs, &createdAtRaw, &updatedAtRaw,
 	); err != nil {
 		return domain.ProjectRunRecord{}, fmt.Errorf("scan project run: %w", err)
@@ -214,6 +214,6 @@ func ParseInt64String(value string) (int64, bool) {
 
 func SelectProjectRunSQL() string {
 	return `SELECT run_id, project_id, project_name, project_revision, agent_name, agent_id, source, scheduler_id, scheduler_run_id, trigger_id, status,
-		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
+		sandbox_id, exit_code, error, error_stack, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
 		started_at, completed_at, duration_ms, created_at, updated_at FROM project_run`
 }

--- a/pkg/projects/scheduler_coverage_test.go
+++ b/pkg/projects/scheduler_coverage_test.go
@@ -171,7 +171,7 @@ func TestProjectNormalizeAndScanCoverage(t *testing.T) {
 		t.Fatalf("ScanProject scanned=%#v err=%v", scanned, err)
 	}
 	scannedRun, err := ScanProjectRun(func(dest ...any) error {
-		values := []any{"run-1", "project-1", "Project", int64(1), "worker", "agent-1", "api", "scheduler-1", "scheduler-run-1", "trigger-1", "running", "session-1", 0, "", "prompt", "output", "{}", "logs", "artifacts", "", "stop_on_completion", 0, "docker", "image", int64(1_720_000_000_000), "1720000001000", int64(1000), float64(1720000002), time.Date(2026, 7, 3, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)}
+		values := []any{"run-1", "project-1", "Project", int64(1), "worker", "agent-1", "api", "scheduler-1", "scheduler-run-1", "trigger-1", "running", "session-1", 0, "", "", "prompt", "output", "{}", "logs", "artifacts", "", "stop_on_completion", 0, "docker", "image", int64(1_720_000_000_000), "1720000001000", int64(1000), float64(1720000002), time.Date(2026, 7, 3, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)}
 		for i, value := range values {
 			switch ptr := dest[i].(type) {
 			case *string:

--- a/pkg/runs/coordinator.go
+++ b/pkg/runs/coordinator.go
@@ -33,6 +33,7 @@ type TransitionRequest struct {
 	SandboxID      string
 	ExitCode       int
 	Error          string
+	ErrorStack     string
 	Output         string
 	ResultJSON     string
 	LogsPath       string
@@ -263,6 +264,9 @@ func applyProjectRunTransitionFields(run *domain.ProjectRunRecord, req Transitio
 	}
 	if value := strings.TrimSpace(req.Error); value != "" {
 		run.Error = value
+	}
+	if value := strings.TrimSpace(req.ErrorStack); value != "" {
+		run.ErrorStack = value
 	}
 	if req.Output != "" {
 		run.Output = req.Output

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -113,11 +113,11 @@ func TestRunsCoordinatorAndHelperWorkflows(t *testing.T) {
 	}
 	cell := domain.NotebookCell{ID: "cell-1", Type: execution.CellTypeAgent, Agent: "codex", AgentThreadID: "agent-thread", Output: "output", Success: false, ExitCode: 0, Stderr: "stderr"}
 	transition := TransitionFromAgentCell(run, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: t.TempDir()}}, cell, nil)
-	if transition.ExitCode == 0 || !strings.Contains(transition.Error, "stderr") || transition.ArtifactsDir == "" {
+	if transition.ExitCode == 0 || !strings.Contains(transition.ErrorStack, "stderr") || transition.ArtifactsDir == "" {
 		t.Fatalf("transition from failed cell = %#v", transition)
 	}
 	transition = TransitionFromAgentCell(run, nil, cell, errors.New("boom"))
-	if transition.ExitCode == 0 || !strings.Contains(transition.Error, "boom") {
+	if transition.ExitCode == 0 || !strings.Contains(transition.ErrorStack, "boom") {
 		t.Fatalf("transition from exec error = %#v", transition)
 	}
 	if !CleanupPolicyStopsSandbox(agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION) ||
@@ -1697,7 +1697,7 @@ func TestRunsControllerRunProjectAgentCleanupErrorRecording(t *testing.T) {
 		if err != nil || execErr == nil || !strings.Contains(execErr.Error(), "agent failed") {
 			t.Fatalf("RunProjectAgent err=%v execErr=%v run=%#v", err, execErr, run)
 		}
-		if run.Status != domain.ProjectRunStatusRunning || !strings.Contains(run.Error, "agent failed") || !strings.Contains(run.CleanupError, "stop failed") {
+		if run.Status != domain.ProjectRunStatusRunning || !strings.Contains(run.ErrorStack, "agent failed") || !strings.Contains(run.CleanupError, "stop failed") {
 			t.Fatalf("run = %#v", run)
 		}
 		assertNoTerminalStatusEvent(t, fixture.configDB.events)

--- a/pkg/runs/execution.go
+++ b/pkg/runs/execution.go
@@ -2,7 +2,6 @@ package runs
 
 import (
 	"encoding/json"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -39,14 +38,18 @@ func TransitionFromAgentCell(run domain.ProjectRunRecord, sandbox *domain.Sandbo
 	}
 	if execErr != nil {
 		req.ExitCode = execution.FirstNonZeroInt(req.ExitCode, 1)
-		req.Error = fmt.Sprintf("agent execution failed: %v", execErr)
+		req.Error = "agent execution failed"
+		req.ErrorStack = execErr.Error()
 		return req
 	}
 	if !cell.Success {
 		req.ExitCode = execution.FirstNonZeroInt(req.ExitCode, 1)
 		req.Error = "agent execution failed"
-		if detail := firstNonEmpty(cell.Stderr, cell.Output); strings.TrimSpace(detail) != "" {
-			req.Error += ": " + strings.TrimSpace(detail)
+		if reason := strings.TrimSpace(cell.StopReason); reason != "" {
+			req.Error += ": " + reason
+		}
+		if detail := strings.TrimSpace(cell.Stderr); detail != "" {
+			req.ErrorStack = detail
 		}
 	}
 	return req

--- a/pkg/storage/configstore/project_run_completion.go
+++ b/pkg/storage/configstore/project_run_completion.go
@@ -113,10 +113,10 @@ func (s *projectStore) FinalizeProjectRunCompletion(ctx context.Context, run dom
 	run.CleanupError = ""
 	result, err := tx.ExecContext(ctx, `UPDATE project_run SET
 		project_id=?, project_name=?, project_revision=?, agent_name=?, agent_id=?, source=?, scheduler_id=?, scheduler_run_id=?, trigger_id=?, status=?,
-		sandbox_id=?, exit_code=?, error=?, prompt=?, output=?, result_json=?, logs_path=?, artifacts_dir=?, cleanup_error='', cleanup_policy=?, sandbox_created=?, driver=?, image_ref=?,
+		sandbox_id=?, exit_code=?, error=?, error_stack=?, prompt=?, output=?, result_json=?, logs_path=?, artifacts_dir=?, cleanup_error='', cleanup_policy=?, sandbox_created=?, driver=?, image_ref=?,
 		started_at=?, completed_at=?, duration_ms=?, updated_at=? WHERE run_id=?`,
 		run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.ErrorStack, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, time.Now().UTC().Unix(), run.RunID)
 	if err != nil {
 		return domain.ProjectRunRecord{}, err

--- a/pkg/storage/configstore/project_run_event_transaction.go
+++ b/pkg/storage/configstore/project_run_event_transaction.go
@@ -28,12 +28,12 @@ func (s *projectStore) CreateProjectRunWithEvents(ctx context.Context, run Proje
 	}
 	result, err := tx.ExecContext(ctx, `INSERT INTO project_run(
 		run_id, project_id, project_name, project_revision, agent_name, agent_id, source, scheduler_id, scheduler_run_id, trigger_id, status,
-		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
+		sandbox_id, exit_code, error, error_stack, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
 		started_at, completed_at, duration_ms, created_at, updated_at
-	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON CONFLICT(run_id) DO NOTHING`,
 		run.RunID, run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.ErrorStack, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, run.CreatedAt.Unix(), run.UpdatedAt.Unix())
 	if err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("insert project run %s: %w", run.RunID, err)
@@ -78,10 +78,10 @@ func (s *projectStore) UpdateProjectRunWithEvents(ctx context.Context, run Proje
 	defer func() { _ = tx.Rollback() }()
 	result, err := tx.ExecContext(ctx, `UPDATE project_run SET
 		project_id = ?, project_name = ?, project_revision = ?, agent_name = ?, agent_id = ?, source = ?, scheduler_id = ?, scheduler_run_id = ?, trigger_id = ?, status = ?,
-		sandbox_id = ?, exit_code = ?, error = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, cleanup_policy = ?, sandbox_created = ?, driver = ?, image_ref = ?,
+		sandbox_id = ?, exit_code = ?, error = ?, error_stack = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, cleanup_policy = ?, sandbox_created = ?, driver = ?, image_ref = ?,
 		started_at = ?, completed_at = ?, duration_ms = ?, updated_at = ? WHERE run_id = ?`,
 		run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.ErrorStack, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, now.Unix(), run.RunID)
 	if err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("update project run %s: %w", run.RunID, err)

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -414,11 +414,11 @@ func (s *projectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecor
 	run.UpdatedAt = now
 	if _, err := s.db.ExecContext(ctx, `INSERT INTO project_run(
 		run_id, project_id, project_name, project_revision, agent_name, agent_id, source, scheduler_id, scheduler_run_id, trigger_id, status,
-		sandbox_id, exit_code, error, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
+		sandbox_id, exit_code, error, error_stack, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
 		started_at, completed_at, duration_ms, created_at, updated_at
-	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.RunID, run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.ErrorStack, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, run.CreatedAt.Unix(), run.UpdatedAt.Unix()); err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("insert project run %s: %w", run.RunID, err)
 	}
@@ -433,11 +433,11 @@ func (s *projectStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecor
 	now := time.Now().UTC()
 	result, err := s.db.ExecContext(ctx, `UPDATE project_run SET
 		project_id = ?, project_name = ?, project_revision = ?, agent_name = ?, agent_id = ?, source = ?, scheduler_id = ?, scheduler_run_id = ?, trigger_id = ?, status = ?,
-		sandbox_id = ?, exit_code = ?, error = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, cleanup_policy = ?, sandbox_created = ?, driver = ?, image_ref = ?,
+		sandbox_id = ?, exit_code = ?, error = ?, error_stack = ?, prompt = ?, output = ?, result_json = ?, logs_path = ?, artifacts_dir = ?, cleanup_error = ?, cleanup_policy = ?, sandbox_created = ?, driver = ?, image_ref = ?,
 		started_at = ?, completed_at = ?, duration_ms = ?, updated_at = ?
 		WHERE run_id = ?`,
 		run.ProjectID, run.ProjectName, run.ProjectRevision, run.AgentName, run.AgentID, run.Source, run.SchedulerID, nullableSchedulerRunID(run.SchedulerRunID), run.TriggerID, run.Status,
-		run.SandboxID, run.ExitCode, run.Error, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
+		run.SandboxID, run.ExitCode, run.Error, run.ErrorStack, run.Prompt, run.Output, run.ResultJSON, run.LogsPath, run.ArtifactsDir, run.CleanupError, run.CleanupPolicy, BoolToInt(run.SandboxCreated), run.Driver, run.ImageRef,
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, now.Unix(), run.RunID)
 	if err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("update project run %s: %w", run.RunID, err)

--- a/pkg/storage/sqlite/migrations/000012_run_error_stack.sql
+++ b/pkg/storage/sqlite/migrations/000012_run_error_stack.sql
@@ -1,0 +1,1 @@
+ALTER TABLE project_run ADD COLUMN error_stack TEXT NOT NULL DEFAULT '';

--- a/pkg/storage/sqlite/v2_migration_design_test.go
+++ b/pkg/storage/sqlite/v2_migration_design_test.go
@@ -428,8 +428,8 @@ func loadV2MigrationDesignChain(t *testing.T) []migration {
 	if err != nil {
 		t.Fatalf("load migrations: %v", err)
 	}
-	if len(chain) != 11 {
-		t.Fatalf("migration count = %d, want 11", len(chain))
+	if len(chain) != 12 {
+		t.Fatalf("migration count = %d, want 12", len(chain))
 	}
 	return chain
 }

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -1362,6 +1362,7 @@ message RunDetail {
   string driver = 8;
   string image_ref = 9;
   repeated string warnings = 10;
+  string error_stack = 11;
 }
 
 message ExecRequest {


### PR DESCRIPTION
**Problem**

  When an agent run fails, the `Error` field in `RunSummary` currently receives the
  entire agent execution transcript — including model output, tool-call traces,
  command echo, and debug stacks — making the user-facing error message a multi-
  hundred-line blob that is unreadable in the UI and unusable for downstream systems.

  **Root cause**

  `TransitionFromAgentCell` in `pkg/runs/execution.go` unconditionally appends
  `cell.Stderr` or `cell.Output` to `req.Error` when `!cell.Success`:

  3. req.Error = "agent execution failed"
  if detail := firstNonEmpty(cell.Stderr, cell.Output); ... {
  req.Error += ": " + detail   // cell.Output can be hundreds of lines
  }

  `cell.Output` carries the full stdout transcript from the agent cell. The short
  `cell.StopReason` (e.g. `"exit_code:1"`) was not being used at all.

  **Fix**

  1. **Stop merging transcript content into `Error`.** Use `cell.StopReason` for
     the short reason. `cell.Output` was already set on `req.Output` — it never
     needed to be in the error message.

  2. **Add `error_stack` field end-to-end** so error details useful for
     troubleshooting have a dedicated place:
     - `Error` — short, UI-friendly failure reason
     - `ErrorStack` — `execErr.Error()` or `cell.Stderr`, for diagnostics
     - `Output` / `LogsPath` — full transcript (unchanged, already present)

  3. **DB migration** `000012_run_error_stack.sql` adds the column with
     `DEFAULT ''` so existing data is unaffected.

  ### Verification

  | Scenario | Before | After |
  |----------|--------|-------|
  | Agent cell fails with 500-line output | `Error` = `"agent execution failed: [500 lines…]"` | `Error` = `"agent execution failed"`, `ErrorStack` = stderr |
  | Agent execution returns Go error | `Error` = `"agent execution failed: <err>"` | `Error` = `"agent execution failed"`, `ErrorStack` = `<err>` |
  | Successful run | No change | No change |

  All existing tests pass (`pkg/model`, `pkg/runs`, `pkg/agentcompose/api`,
  `pkg/projects`, `pkg/storage/configstore`, `pkg/storage/sqlite`). Migration
  `000012` applies cleanly in the historical migration chain.

  ### Changes

  - `proto/agentcompose/v2/agentcompose.proto` — add `error_stack` to `RunDetail`
  - `pkg/model/project_model.go` — add `ErrorStack` to `ProjectRunRecord`
  - `pkg/runs/coordinator.go` — add `ErrorStack` to `TransitionRequest` and `applyProjectRunTransitionFields`
  - `pkg/runs/execution.go` — **core fix**: stop appending `cell.Output`/`cell.Stderr` to `Error`; use `cell.StopReason`; populate `ErrorStack` from `execErr` or `cell.Stderr`
  - `pkg/agentcompose/api/run.go` — map `ErrorStack` in `ProjectRunDetailToProto`
  - `pkg/projects/scan.go` — add `error_stack` to `SelectProjectRunSQL` and `ScanProjectRun`
  - `pkg/storage/configstore/project_store.go` — add column to INSERT/UPDATE
  - `pkg/storage/configstore/project_run_event_transaction.go` — add column to INSERT/UPDATE
  - `pkg/storage/configstore/project_run_completion.go` — add column to `FinalizeProjectRunCompletion` UPDATE
  - `pkg/storage/sqlite/migrations/000012_run_error_stack.sql` — **new**: `ALTER TABLE project_run ADD COLUMN error_stack TEXT NOT NULL DEFAULT ''`
  - `pkg/storage/sqlite/v2_migration_design_test.go` — bump expected migration count 11→12
  - `pkg/runs/coverage_shape_workflows_test.go` — assert against `ErrorStack` instead of `Error` for stderr/execErr content
  - `pkg/projects/scheduler_coverage_test.go` — add placeholder for new `ErrorStack` scan column