### PR TITLE
feat(sandboxes): add graceful guest runtime stop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,6 +197,9 @@ DEFAULT_IMAGE=chaitin/agent-compose-guest:latest
 # Deprecated compatibility fallback: LOADER_RUN_TIMEOUT=20m
 # SANDBOX_START_TIMEOUT=30m
 # SANDBOX_STOP_TIMEOUT=30s
+# Grace period used by explicit graceful sandbox stops when the request does
+# not provide --grace-period. Must be a positive Go duration; default: 10s.
+# SANDBOX_GRACEFUL_STOP_TIMEOUT=10s
 # Max time to wait for Jupyter to become ready inside a guest before failing the
 # sandbox start. Raise this on busy/cold hosts where guest boot exceeds 30s.
 # Non-positive or unparseable values fall back to the 30s default.

--- a/TESTING.md
+++ b/TESTING.md
@@ -84,6 +84,26 @@ a new sandbox receives the latest Workspace Source without state leaking back
 to that source. It also checks resource cleanup. Inspect verbose test output and
 daemon logs when it fails.
 
+Graceful sandbox stop has an opt-in host-daemon E2E that exercises the public
+project, run, exec, and sandbox APIs against real runtimes:
+
+```bash
+task image:agent-compose-guest
+task test:e2e:graceful-stop
+```
+
+By default it verifies successful guest cleanup on Docker, BoxLite, and
+Microsandbox, plus timeout escalation and explicit force stop on Docker. Set
+`AGENT_COMPOSE_E2E_GRACEFUL_STOP_IMAGE` to select another compatible local
+guest image or `AGENT_COMPOSE_E2E_GRACEFUL_STOP_DRIVERS` to run a comma-separated
+subset. BoxLite and Microsandbox require a prepared Linux/KVM host. The success
+cases prove that the guest TERM hook, partial output, and command result artifact
+are persisted before the sandbox reaches `STOPPED`.
+
+Set `AGENT_COMPOSE_E2E_GRACEFUL_STOP_LEGACY_IMAGE` to an older guest image that
+does not publish runtime signal readiness. The Docker compatibility case verifies
+that it safely escalates after the grace timeout and still reaches `STOPPED`.
+
 To exercise an upgrade boundary, build a baseline binary and the candidate
 binary separately, then run the same test directly with the baseline in
 `AGENT_COMPOSE_E2E_BINARY` and the candidate in

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -227,6 +227,23 @@ tasks:
           GOCACHE={{.GO_BUILD_CACHE_DIR}} \
           {{.GO_TOOLCHAIN_ENV}} go test ./test/e2e -run '^TestE2EDockerJupyterHostDaemonStopResume$' -count=1 -v
 
+  test:e2e:graceful-stop:
+    desc: Run the opt-in host-daemon graceful sandbox stop E2E test
+    dir: '{{.TASKFILE_DIR}}'
+    deps: ['build:agent-compose']
+    cmds:
+      - |
+        image="${AGENT_COMPOSE_E2E_GRACEFUL_STOP_IMAGE:-agent-compose-guest:latest}"
+        if ! docker image inspect "$image" >/dev/null 2>&1; then
+          echo "Graceful-stop guest image $image is unavailable; run 'task image:agent-compose-guest' or set AGENT_COMPOSE_E2E_GRACEFUL_STOP_IMAGE" >&2
+          exit 1
+        fi
+        AGENT_COMPOSE_E2E_BINARY="$PWD/build/agent-compose" \
+          AGENT_COMPOSE_E2E_GRACEFUL_STOP_IMAGE="$image" \
+          AGENT_COMPOSE_E2E_GRACEFUL_STOP_DRIVERS="${AGENT_COMPOSE_E2E_GRACEFUL_STOP_DRIVERS:-docker,boxlite,microsandbox}" \
+          GOCACHE={{.GO_BUILD_CACHE_DIR}} \
+          {{.GO_TOOLCHAIN_ENV}} go test ./test/e2e -run '^TestE2EGracefulSandboxStopHostDaemon$' -count=1 -timeout 25m -v
+
   test:e2e:docker-workspace-resume:
     desc: Run the opt-in host-daemon Docker file-workspace restart/resume E2E test
     dir: '{{.TASKFILE_DIR}}'

--- a/cmd/agent-compose/cli_sandbox_definition.go
+++ b/cmd/agent-compose/cli_sandbox_definition.go
@@ -1,6 +1,16 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type composeSandboxStopOptions struct {
+	Graceful    bool
+	Force       bool
+	GracePeriod time.Duration
+}
 
 func newCLISandboxCommand(cli *cliOptions) *cobra.Command {
 	cmd := &cobra.Command{
@@ -30,12 +40,20 @@ func newCLILegacySandboxCommands(cli *cliOptions) []*cobra.Command {
 }
 
 func newCLISandboxActionCommand(cli *cliOptions, use, short, action, status string) *cobra.Command {
-	return &cobra.Command{
+	options := composeSandboxStopOptions{}
+	cmd := &cobra.Command{
 		Use: use + " <sandbox> [<sandbox N>]", Short: short, Args: sandboxActionArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runComposeSandboxActionCommand(cmd, *cli, action, status, args)
+			return runComposeSandboxActionCommand(cmd, *cli, action, status, options, args)
 		},
 	}
+	if action == "stop" {
+		cmd.Flags().BoolVar(&options.Graceful, "graceful", false, "Ask active guest executions to finish before stopping the sandbox")
+		cmd.Flags().BoolVar(&options.Force, "force", false, "Stop immediately without waiting for guest execution cleanup")
+		cmd.Flags().DurationVar(&options.GracePeriod, "grace-period", 0, "Maximum time to wait for graceful guest execution cleanup")
+		cmd.MarkFlagsMutuallyExclusive("graceful", "force")
+	}
+	return cmd
 }
 
 func newCLISandboxRemoveCommand(cli *cliOptions) *cobra.Command {

--- a/cmd/agent-compose/cli_sandbox_integration_list_test.go
+++ b/cmd/agent-compose/cli_sandbox_integration_list_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 )
@@ -119,6 +120,68 @@ func TestIntegrationCLIStopSandbox(t *testing.T) {
 	}
 	if len(stopped) != 1 || stopped[0] != "sandbox-stop" {
 		t.Fatalf("stopped sandboxes = %#v", stopped)
+	}
+}
+
+func TestIntegrationCLIGracefulStopSandbox(t *testing.T) {
+	var request *agentcomposev2.StopSandboxRequest
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		session: sessionServiceStub{
+			stopSession: func(_ context.Context, req *connect.Request[agentcomposev2.StopSandboxRequest]) (*connect.Response[agentcomposev2.StopSandboxResponse], error) {
+				request = req.Msg
+				return connect.NewResponse(&agentcomposev2.StopSandboxResponse{Outcome: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	stdout, stderr, _, exitCode := executeCLICommand("stop", "--host", server.URL, "--graceful", "--grace-period", "2s", "sandbox-graceful")
+	if exitCode != 0 || stderr != "" || stdout != "stopped sandbox sandbox-graceful (graceful)\n" {
+		t.Fatalf("graceful stop code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+	}
+	if request == nil || request.GetMode() != agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL || request.GetGracePeriod().AsDuration() != 2*time.Second {
+		t.Fatalf("graceful stop request = %#v", request)
+	}
+}
+
+func TestIntegrationCLIGracefulStopEscalationReturnsSuccessWithOutcome(t *testing.T) {
+	tests := []struct {
+		name        string
+		outcome     agentcomposev2.SandboxStopOutcome
+		outcomeText string
+	}{
+		{name: "timeout", outcome: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT, outcomeText: "forced-after-grace-timeout"},
+		{name: "preparation error", outcome: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_ERROR, outcomeText: "forced-after-grace-error"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newComposeServiceStubServer(t, composeServiceStubs{
+				session: sessionServiceStub{
+					stopSession: func(_ context.Context, _ *connect.Request[agentcomposev2.StopSandboxRequest]) (*connect.Response[agentcomposev2.StopSandboxResponse], error) {
+						return connect.NewResponse(&agentcomposev2.StopSandboxResponse{Outcome: test.outcome}), nil
+					},
+				},
+			})
+			defer server.Close()
+
+			stdout, stderr, _, exitCode := executeCLICommand("stop", "--host", server.URL, "--graceful", "sandbox-escalated")
+			wantStdout := "stopped sandbox sandbox-escalated (" + test.outcomeText + ")\n"
+			if exitCode != 0 || stdout != wantStdout || stderr != "" {
+				t.Fatalf("escalated stop code/stdout/stderr = %d / %q / %q", exitCode, stdout, stderr)
+			}
+
+			jsonOut, jsonErr, _, jsonCode := executeCLICommand("stop", "--host", server.URL, "--graceful", "--json", "sandbox-escalated")
+			if jsonCode != 0 || jsonErr != "" {
+				t.Fatalf("escalated JSON stop code/stderr = %d / %q", jsonCode, jsonErr)
+			}
+			var decoded composeSandboxActionOutput
+			if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
+				t.Fatalf("escalated stop JSON decode failed: %v\n%s", err, jsonOut)
+			}
+			if len(decoded.Results) != 1 || decoded.Results[0].Status != "stopped" || decoded.Results[0].Outcome != test.outcomeText {
+				t.Fatalf("escalated stop JSON = %#v", decoded)
+			}
+		})
 	}
 }
 

--- a/cmd/agent-compose/cli_sandbox_lifecycle.go
+++ b/cmd/agent-compose/cli_sandbox_lifecycle.go
@@ -12,6 +12,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type composeSandboxActionOutput struct {
@@ -21,6 +22,7 @@ type composeSandboxActionOutput struct {
 type composeSandboxActionResult struct {
 	SandboxID string `json:"sandbox_id"`
 	Status    string `json:"status"`
+	Outcome   string `json:"outcome,omitempty"`
 }
 
 type composeSandboxRemoveOptions struct {
@@ -34,7 +36,16 @@ func sandboxActionArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runComposeSandboxActionCommand(cmd *cobra.Command, cli cliOptions, action, status string, sandboxes []string) error {
+func runComposeSandboxActionCommand(cmd *cobra.Command, cli cliOptions, action, status string, options composeSandboxStopOptions, sandboxes []string) error {
+	gracePeriodSet := action == "stop" && cmd.Flags().Changed("grace-period")
+	if gracePeriodSet {
+		if options.GracePeriod <= 0 {
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("--grace-period must be greater than zero")}
+		}
+		if !options.Graceful {
+			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("--grace-period requires --graceful")}
+		}
+	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
@@ -53,7 +64,20 @@ func runComposeSandboxActionCommand(cmd *cobra.Command, cli cliOptions, action, 
 		}
 		switch action {
 		case "stop":
-			_, err = clients.sandbox.StopSandbox(cmd.Context(), connect.NewRequest(&agentcomposev2.StopSandboxRequest{SandboxId: sandbox}))
+			request := &agentcomposev2.StopSandboxRequest{SandboxId: sandbox, Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE}
+			if options.Graceful {
+				request.Mode = agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL
+				if gracePeriodSet {
+					request.GracePeriod = durationpb.New(options.GracePeriod)
+				}
+			}
+			var response *connect.Response[agentcomposev2.StopSandboxResponse]
+			response, err = clients.sandbox.StopSandbox(cmd.Context(), connect.NewRequest(request))
+			if err == nil {
+				outcome := sandboxStopOutcomeText(response.Msg.GetOutcome())
+				output.Results = append(output.Results, composeSandboxActionResult{SandboxID: sandbox, Status: status, Outcome: outcome})
+				continue
+			}
 		case "resume":
 			_, err = clients.sandbox.ResumeSandbox(cmd.Context(), connect.NewRequest(&agentcomposev2.ResumeSandboxRequest{SandboxId: sandbox}))
 		default:
@@ -72,14 +96,34 @@ func runComposeSandboxActionCommand(cmd *cobra.Command, cli cliOptions, action, 
 		if err != nil {
 			return err
 		}
-		return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
+		if err := writeCommandOutput(cmd.OutOrStdout(), append(data, '\n')); err != nil {
+			return err
+		}
+		return nil
 	}
 	for _, result := range output.Results {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s sandbox %s\n", result.Status, result.SandboxID); err != nil {
+		suffix := ""
+		if options.Graceful {
+			suffix = " (" + result.Outcome + ")"
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s sandbox %s%s\n", result.Status, result.SandboxID, suffix); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func sandboxStopOutcomeText(outcome agentcomposev2.SandboxStopOutcome) string {
+	switch outcome {
+	case agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL:
+		return "graceful"
+	case agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT:
+		return "forced-after-grace-timeout"
+	case agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_ERROR:
+		return "forced-after-grace-error"
+	default:
+		return "force"
+	}
 }
 
 func runComposeSandboxRemoveCommand(cmd *cobra.Command, cli cliOptions, options composeSandboxRemoveOptions, sandboxes []string) error {

--- a/cmd/agent-compose/cli_sandbox_lifecycle_test.go
+++ b/cmd/agent-compose/cli_sandbox_lifecycle_test.go
@@ -111,6 +111,27 @@ func TestCLIStopRequiresSandboxUsageError(t *testing.T) {
 	}
 }
 
+func TestCLIStopRejectsInvalidExplicitGracePeriod(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "zero", args: []string{"stop", "--graceful", "--grace-period", "0s", "sandbox-1"}, want: "--grace-period must be greater than zero"},
+		{name: "negative", args: []string{"stop", "--graceful", "--grace-period", "-1s", "sandbox-1"}, want: "--grace-period must be greater than zero"},
+		{name: "zero without graceful", args: []string{"stop", "--grace-period", "0s", "sandbox-1"}, want: "--grace-period must be greater than zero"},
+		{name: "positive without graceful", args: []string{"stop", "--grace-period", "1s", "sandbox-1"}, want: "--grace-period requires --graceful"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr, _, exitCode := executeCLICommand(test.args...)
+			if exitCode != exitCodeUsage || stdout != "" || !strings.Contains(stderr, test.want) {
+				t.Fatalf("stop args=%v code/stdout/stderr = %d / %q / %q", test.args, exitCode, stdout, stderr)
+			}
+		})
+	}
+}
+
 func TestCLIResumeRejectsEmptySandboxUsageError(t *testing.T) {
 	stdout, stderr, _, exitCode := executeCLICommand("resume", " ")
 	if exitCode != exitCodeUsage {

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -383,6 +383,7 @@ Use the `sandbox` command group to manage project sandboxes from a single namesp
 agent-compose sandbox ls
 agent-compose sandbox ls --all --json
 agent-compose sandbox stop <sandbox>
+agent-compose sandbox stop --graceful --grace-period 10s <sandbox>
 agent-compose sandbox resume <sandbox>
 agent-compose sandbox rm <sandbox>
 agent-compose sandbox rm --force <sandbox>
@@ -398,7 +399,7 @@ Subcommands:
 | Command | Description |
 | --- | --- |
 | `sandbox ls` | Equivalent to `ps`; supports `--all/-a`, `--status`, `--verbose`, and `--json`. |
-| `sandbox stop <sandbox...>` | Equivalent to `stop`; stops one or more sandboxes. |
+| `sandbox stop <sandbox...>` | Equivalent to `stop`; stops one or more sandboxes. The default remains force; use `--graceful` to terminate active guest JS runtime executions first. |
 | `sandbox resume <sandbox...>` | Equivalent to `resume`; resumes one or more stopped sandboxes. |
 | `sandbox rm <sandbox...>` | Equivalent to `rm`; removes one or more sandboxes. Use `--force` only when intentionally removing running sandboxes. |
 | `sandbox prune` | Dry-run cleanup for stopped or failed sandboxes in the current project. Use `--force` to remove matched sandboxes. |
@@ -422,7 +423,11 @@ Rules:
 - `sandbox prune` calls the daemon `SandboxService.PruneSandboxes` use case. It removes sandbox-owned runtime/data state, not shared cache artifacts; use `cache prune` or `cache rm` for cache inventory.
 - If a forced prune fails to remove one matched sandbox, it continues with later matches, writes the skipped item, and exits non-zero.
 
-`sandbox stop` applies the stopped-runtime policy snapshotted when the sandbox was created. `retain` preserves resumable driver state; `remove` first confirms the latest start has stopped and then releases the private runtime while keeping durable sandbox data. Use `agent-compose inspect sandbox <sandbox> --json` to inspect the effective policy and release state. `sandbox rm` writes a durable deletion journal under `<SANDBOX_ROOT>/.lifecycle`, rejects a running sandbox unless `--force` is supplied, and removes the driver resource, sandbox accessories, sandbox directory, and metadata in restart-safe stages. A sandbox in `DELETING` cannot be resumed or used for new exec/run work; daemon startup resumes only incomplete deletion journals and never guesses that an ordinary historical resource is orphaned.
+`sandbox stop` applies the stopped-runtime policy snapshotted when the sandbox was created. `retain` preserves resumable driver state; `remove` first confirms the latest start has stopped and then releases the private runtime while keeping durable sandbox data. The compatibility default is an immediate force stop. With `--graceful`, the daemon rejects new executions, sends `SIGTERM` to each active `agent-compose-runtime` process, and waits for the JS runtime to cancel its provider, run `finally` cleanup, persist partial output, and exit. The default grace period is 10 seconds and can be changed with `SANDBOX_GRACEFUL_STOP_TIMEOUT`; `--grace-period` overrides it for one request, up to 5 minutes. After timeout or signaling failure, the daemon force-terminates tracked executions before stopping the sandbox. Text and JSON output include `graceful`, `forced-after-grace-timeout`, or `forced-after-grace-error`. Escalation is a successful stop when the sandbox is ultimately stopped, so both the API and CLI return success while preserving the outcome for observability; an error is returned only if the sandbox itself cannot be stopped.
+
+Graceful stop covers active guest executions launched and tracked by the current daemon process. It does not register persistent cleanup hooks, recover an in-progress graceful stop after daemon restart, or manage out-of-band guest processes.
+
+Use `agent-compose inspect sandbox <sandbox> --json` to inspect the effective policy and release state. `sandbox rm` writes a durable deletion journal under `<SANDBOX_ROOT>/.lifecycle`, rejects a running sandbox unless `--force` is supplied, and removes the driver resource, sandbox accessories, sandbox directory, and metadata in restart-safe stages. A sandbox in `DELETING` cannot be resumed or used for new exec/run work; daemon startup resumes only incomplete deletion journals and never guesses that an ordinary historical resource is orphaned.
 
 New sandbox directories are stored under `<SANDBOX_ROOT>/<year>/<month>/<day>/<sandbox-id>`, using the daemon's local calendar date at creation time. Metadata timestamps remain UTC. Existing flat `<SANDBOX_ROOT>/<sandbox-id>` directories are not migrated and remain usable after upgrade. Because older daemon versions do not scan the date-partitioned layout, downgrading makes newly created sandboxes unavailable until the newer version is restored. Set a consistent daemon `TZ` when deployments require stable calendar boundaries.
 
@@ -449,6 +454,8 @@ Stop one or more sandboxes.
 ```bash
 agent-compose stop <sandbox>
 agent-compose stop <sandbox> [<sandbox N>]
+agent-compose stop --graceful [--grace-period 10s] <sandbox>
+agent-compose stop --force <sandbox>
 ```
 
 Examples:
@@ -456,7 +463,10 @@ Examples:
 ```bash
 agent-compose stop sandbox_123
 agent-compose stop sandbox_123 sandbox_456
+agent-compose stop --graceful --grace-period 20s sandbox_123
 ```
+
+`--graceful` and `--force` are mutually exclusive. Unspecified stop mode and explicit `--force` preserve the existing force behavior. See the `sandbox stop` section above for graceful outcomes and limitations.
 
 ## `resume`: Resume Sandboxes
 

--- a/docs/pages/guest-image-abi.md
+++ b/docs/pages/guest-image-abi.md
@@ -196,6 +196,39 @@ replacement runtime **MUST** implement the matching release protocol. Reusing
 the repository runtime is strongly recommended; see
 [agent-compose and runtime call contract](https://github.com/chaitin/agent-compose/blob/main/docs/design/agent-compose-runtime_contract.md).
 
+### 4.1 Graceful-stop capability
+
+When graceful sandbox stop is requested, the daemon signals only the tracked
+outer `agent-compose-runtime` process. It does not discover, retain, or signal
+the runtime's child-process tree. A release-matched runtime owns cancellation,
+child cleanup, partial-result persistence, and its eventual process exit.
+
+The daemon injects these private variables into each managed runtime execution:
+
+| Variable | Value |
+| --- | --- |
+| `AGENT_COMPOSE_INTERNAL_EXECUTION_ID` | A unique execution UUID |
+| `AGENT_COMPOSE_INTERNAL_EXECUTION_READY_FILE` | `/tmp/agent-compose-runtime-ready/<execution-id>` |
+
+After installing its `SIGTERM` handler, the runtime **MUST** write its decimal
+PID to the ready file with mode `0600`. It **SHOULD** remove the file when the
+handler is disposed. The matching repository runtime implements this protocol.
+
+The daemon opens a separate driver control execution, reads the exact ready
+file, verifies the PID's execution ID, executable, and command line through
+`/proc`, and sends `SIGTERM` only to that PID. A guest that supports this
+capability **MUST** mount a readable procfs and provide `sh`, `cat`, `tr`,
+`grep`, `readlink`, and a shell `kill` implementation. The runtime executable
+must currently resolve to `node` or `nodejs`, and its command line must identify
+`agent-compose-runtime`.
+
+An older runtime that ignores these variables remains compatible for normal
+execution. Its ready file never appears, so graceful stop waits for the grace
+period and then safely escalates to sandbox stop. Incomplete or stale readiness
+also eventually times out, while a missing control utility is treated as a
+signaling failure. Both outcomes escalate safely; neither causes the daemon to
+scan or manage arbitrary guest processes.
+
 ## 5. Optional Capability Requirements
 
 ### 5.1 Agent providers

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -375,6 +375,7 @@ agent-compose ps --json
 agent-compose sandbox ls
 agent-compose sandbox ls --all --json
 agent-compose sandbox stop <sandbox>
+agent-compose sandbox stop --graceful --grace-period 10s <sandbox>
 agent-compose sandbox resume <sandbox>
 agent-compose sandbox rm <sandbox>
 agent-compose sandbox rm --force <sandbox>
@@ -390,7 +391,7 @@ agent-compose sandbox prune --include-orphans
 | 命令 | 说明 |
 | --- | --- |
 | `sandbox ls` | 等价于 `ps`；支持 `--all/-a`、`--status`、`--verbose` 和 `--json`。 |
-| `sandbox stop <sandbox...>` | 等价于 `stop`；停止一个或多个 sandbox。 |
+| `sandbox stop <sandbox...>` | 等价于 `stop`；停止一个或多个 sandbox。默认仍为 force；使用 `--graceful` 时会先终止 active guest JS runtime execution。 |
 | `sandbox resume <sandbox...>` | 等价于 `resume`；恢复一个或多个 stopped sandbox。 |
 | `sandbox rm <sandbox...>` | 等价于 `rm`；删除一个或多个 sandbox。仅在确认要删除 running sandbox 时使用 `--force`。 |
 | `sandbox prune` | 对当前 project 中 stopped 或 failed sandbox 做 dry-run 清理预览；使用 `--force` 才会删除匹配项。 |
@@ -414,7 +415,11 @@ agent-compose sandbox prune --include-orphans
 - `sandbox prune` 调用 daemon 的 `SandboxService.PruneSandboxes` use case，删除 sandbox 自有 runtime/data，不删除共享 cache artifact；cache inventory 仍由 `cache prune` 或 `cache rm` 管理。
 - forced prune 中某个 sandbox 删除失败时，命令会继续处理后续匹配项，输出 skipped 项，并以非零退出码结束。
 
-`sandbox stop` 会应用 sandbox 创建时快照的 stopped-runtime 策略：`retain` 保留可恢复的 driver state；`remove` 先确认最近一次启动已经停止，再释放私有 runtime，同时保留 sandbox 的持久数据。可使用 `agent-compose inspect sandbox <sandbox> --json` 查看有效策略和 release 状态。`sandbox rm` 在 `<SANDBOX_ROOT>/.lifecycle` 写入持久 deletion journal；running sandbox 必须显式使用 `--force`，删除会按可恢复阶段清理 driver resource、sandbox accessories、sandbox 目录和 metadata。处于 `DELETING` 的 sandbox 不能 resume，也不能接收新的 exec/run；daemon 启动时只继续未完成的 deletion journal，不会猜测或自动删除普通历史残留。
+`sandbox stop` 会应用 sandbox 创建时快照的 stopped-runtime 策略：`retain` 保留可恢复的 driver state；`remove` 先确认最近一次启动已经停止，再释放私有 runtime，同时保留 sandbox 的持久数据。为保持兼容，默认行为是立即 force stop。使用 `--graceful` 时，daemon 会拒绝新的 execution，向每个 active `agent-compose-runtime` 进程发送 `SIGTERM`，等待 JS runtime 取消 provider、执行已有的 `finally` 清理、持久化部分输出并退出。默认 grace period 为 10 秒，可通过 `SANDBOX_GRACEFUL_STOP_TIMEOUT` 修改；单次请求可用 `--grace-period` 覆盖，最大 5 分钟。等待超时或发送信号失败时，daemon 会先强制终止已跟踪 execution，再停止 sandbox。文本与 JSON 输出会给出 `graceful`、`forced-after-grace-timeout` 或 `forced-after-grace-error`。只要 sandbox 最终成功停止，升级为 force 仍属于成功的停止操作，因此 API 和 CLI 都返回成功，并保留 outcome 用于观测；只有 sandbox 本身无法停止时才返回错误。
+
+Graceful stop 只覆盖由当前 daemon 进程启动并跟踪的 active guest execution；它不提供持久 cleanup hook、daemon 重启后的进行中 stop 恢复，也不管理 guest 内的 out-of-band process。
+
+可使用 `agent-compose inspect sandbox <sandbox> --json` 查看有效策略和 release 状态。`sandbox rm` 在 `<SANDBOX_ROOT>/.lifecycle` 写入持久 deletion journal；running sandbox 必须显式使用 `--force`，删除会按可恢复阶段清理 driver resource、sandbox accessories、sandbox 目录和 metadata。处于 `DELETING` 的 sandbox 不能 resume，也不能接收新的 exec/run；daemon 启动时只继续未完成的 deletion journal，不会猜测或自动删除普通历史残留。
 
 新建 sandbox 的目录位于 `<SANDBOX_ROOT>/<年>/<月>/<日>/<sandbox-id>`，日期取创建时 daemon 的本地日历时间，metadata 时间戳仍使用 UTC。升级时不会迁移已有的扁平 `<SANDBOX_ROOT>/<sandbox-id>` 目录，新版本仍可继续使用这些目录。旧版 daemon 不会扫描日期分层布局，因此降级后无法发现升级后新建的 sandbox，恢复新版本后可重新使用。如部署要求稳定的日期边界，应为 daemon 配置一致的 `TZ`。
 
@@ -441,6 +446,8 @@ driver 没有稳定 stats 能力入口时，命令会返回 unsupported，而不
 ```bash
 agent-compose stop <sandbox>
 agent-compose stop <sandbox> [<sandbox N>]
+agent-compose stop --graceful [--grace-period 10s] <sandbox>
+agent-compose stop --force <sandbox>
 ```
 
 示例：
@@ -448,7 +455,10 @@ agent-compose stop <sandbox> [<sandbox N>]
 ```bash
 agent-compose stop sandbox_123
 agent-compose stop sandbox_123 sandbox_456
+agent-compose stop --graceful --grace-period 20s sandbox_123
 ```
+
+`--graceful` 与 `--force` 互斥。不指定模式或显式使用 `--force` 都保留原有 force 行为。graceful outcome 与限制见上方 `sandbox stop` 说明。
 
 ## `resume`：恢复 sandbox
 

--- a/docs/pages/zh-CN/guest-image-abi.md
+++ b/docs/pages/zh-CN/guest-image-abi.md
@@ -137,6 +137,37 @@ daemon 会显式传递 workspace、state 和 home 路径，并注入：
 
 `prompt` 和 `exec` 的 stdout payload、stream 分离、artifact 文件以及交互式 NDJSON frame 都属于协议，而不仅是 CLI 展示。自行替换 runtime 时，必须实现对应 release 的完整协议。强烈建议直接复用仓库 runtime，协议详见 [agent-compose 与 runtime 调用约定](https://github.com/chaitin/agent-compose/blob/main/docs/design/agent-compose-runtime_contract.md)。
 
+### 4.1 Graceful-stop 能力
+
+请求 graceful sandbox stop 时，daemon 只向已跟踪的外层
+`agent-compose-runtime` 进程发送信号。daemon 不会发现、持有或发送信号给
+runtime 的子进程树。与 daemon release 匹配的 runtime 负责取消任务、清理
+子进程、持久化部分结果并最终退出自身进程。
+
+daemon 会为每个受管 runtime execution 注入以下私有变量：
+
+| 变量 | 内容 |
+| --- | --- |
+| `AGENT_COMPOSE_INTERNAL_EXECUTION_ID` | 唯一的 execution UUID |
+| `AGENT_COMPOSE_INTERNAL_EXECUTION_READY_FILE` | `/tmp/agent-compose-runtime-ready/<execution-id>` |
+
+runtime 安装 `SIGTERM` handler 后，**必须**以十进制形式将自身 PID 写入
+ready file，并将文件 mode 设为 `0600`；handler dispose 时**应该**删除该
+文件。同版本的仓库 runtime 已实现此协议。
+
+daemon 会打开独立的 driver control execution，读取准确的 ready file，
+通过 `/proc` 校验 PID 的 execution ID、可执行文件和 command line，并且只向
+该 PID 发送 `SIGTERM`。支持此能力的 guest **必须**挂载可读 procfs，并提供
+`sh`、`cat`、`tr`、`grep`、`readlink` 和 shell `kill`。当前 runtime
+可执行文件必须解析为 `node` 或 `nodejs`，command line 必须能识别出
+`agent-compose-runtime`。
+
+忽略这些变量的旧 runtime 在普通执行场景中仍保持兼容。由于 ready file
+不会出现，graceful stop 会等待完整 grace period，再安全升级为 sandbox
+stop。不完整或已失效的 readiness 最终也会超时；缺少 control utility 则会
+被视为信号发送失败。两种结果都会安全升级，daemon 都不会扫描或管理任意
+guest 进程。
+
 ## 5. 可选能力要求
 
 ### 5.1 Agent Provider

--- a/pkg/agentcompose/adapters/agent_runner.go
+++ b/pkg/agentcompose/adapters/agent_runner.go
@@ -121,6 +121,9 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 	if err != nil {
 		return execution.SanitizeAgentExecResult(result), domain.AgentRunResult{}, err
 	}
+	if strings.EqualFold(strings.TrimSpace(parsed.StopReason), "cancelled") {
+		return execution.SanitizeAgentExecResult(result), parsed, context.Canceled
+	}
 	return execution.SanitizeAgentExecResult(result), parsed, nil
 }
 

--- a/pkg/agentcompose/adapters/runtime_graceful_stop.go
+++ b/pkg/agentcompose/adapters/runtime_graceful_stop.go
@@ -1,0 +1,367 @@
+package adapters
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"agent-compose/pkg/driver"
+	"agent-compose/pkg/execution"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sandboxes"
+
+	"github.com/google/uuid"
+)
+
+const (
+	guestRuntimeSignalInitialRetryDelay = 50 * time.Millisecond
+	guestRuntimeSignalMaxRetryDelay     = 500 * time.Millisecond
+)
+
+var errGracefulStopTimedOut = errors.New("guest execution graceful stop timed out")
+
+type guestRuntimeSignaler interface {
+	SignalGuestRuntime(context.Context, *driver.Sandbox, driver.VMState, string, driver.RuntimeSignal) error
+}
+
+type activeExecution struct {
+	id     string
+	cancel context.CancelFunc
+}
+
+type sandboxExecutions struct {
+	mu       sync.Mutex
+	active   map[string]map[string]activeExecution
+	stopping map[string]int
+	changed  chan struct{}
+}
+
+func newSandboxExecutions() *sandboxExecutions {
+	return &sandboxExecutions{active: map[string]map[string]activeExecution{}, stopping: map[string]int{}, changed: make(chan struct{})}
+}
+
+func (e *sandboxExecutions) begin(ctx context.Context, sandboxID string) (context.Context, string, func(), error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stopping[sandboxID] > 0 {
+		return nil, "", nil, domain.ClassifyError(domain.ErrFailedPrecondition, "sandbox is stopping and cannot accept new work", nil)
+	}
+	id := uuid.NewString()
+	execCtx, cancel := context.WithCancel(ctx)
+	if e.active[sandboxID] == nil {
+		e.active[sandboxID] = map[string]activeExecution{}
+	}
+	e.active[sandboxID][id] = activeExecution{id: id, cancel: cancel}
+	e.broadcastLocked()
+	return execCtx, id, func() { e.finish(sandboxID, id, cancel) }, nil
+}
+
+func (e *sandboxExecutions) finish(sandboxID, id string, cancel context.CancelFunc) {
+	cancel()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.active[sandboxID], id)
+	if len(e.active[sandboxID]) == 0 {
+		delete(e.active, sandboxID)
+	}
+	e.broadcastLocked()
+}
+
+func (e *sandboxExecutions) block(sandboxID string) []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stopping[sandboxID]++
+	ids := e.activeIDsLocked(sandboxID)
+	e.broadcastLocked()
+	return ids
+}
+
+func (e *sandboxExecutions) ensureBlocked(sandboxID string) []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stopping[sandboxID] == 0 {
+		e.stopping[sandboxID] = 1
+	}
+	ids := e.activeIDsLocked(sandboxID)
+	e.broadcastLocked()
+	return ids
+}
+
+func (e *sandboxExecutions) activeIDsLocked(sandboxID string) []string {
+	ids := make([]string, 0, len(e.active[sandboxID]))
+	for id := range e.active[sandboxID] {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (e *sandboxExecutions) cancel(sandboxID string) {
+	e.mu.Lock()
+	items := make([]activeExecution, 0, len(e.active[sandboxID]))
+	for _, item := range e.active[sandboxID] {
+		items = append(items, item)
+	}
+	e.mu.Unlock()
+	for _, item := range items {
+		item.cancel()
+	}
+}
+
+func (e *sandboxExecutions) wait(ctx context.Context, sandboxID string) error {
+	for {
+		e.mu.Lock()
+		if len(e.active[sandboxID]) == 0 {
+			e.mu.Unlock()
+			return nil
+		}
+		changed := e.changed
+		e.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-changed:
+		}
+	}
+}
+
+func (e *sandboxExecutions) activeAmong(sandboxID string, ids []string) []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	active := e.active[sandboxID]
+	remaining := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := active[id]; ok {
+			remaining = append(remaining, id)
+		}
+	}
+	return remaining
+}
+
+func (e *sandboxExecutions) waitForChange(ctx context.Context, retryAfter time.Duration) error {
+	e.mu.Lock()
+	changed := e.changed
+	e.mu.Unlock()
+	timer := time.NewTimer(retryAfter)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-changed:
+		return nil
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (e *sandboxExecutions) release(sandboxID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stopping[sandboxID] <= 1 {
+		delete(e.stopping, sandboxID)
+	} else {
+		e.stopping[sandboxID]--
+	}
+	e.broadcastLocked()
+}
+
+func (e *sandboxExecutions) broadcastLocked() {
+	close(e.changed)
+	e.changed = make(chan struct{})
+}
+
+func (r driverRuntimeAdapter) beginExecution(ctx context.Context, session *domain.Sandbox, spec domain.ExecSpec) (context.Context, domain.ExecSpec, func(), error) {
+	if r.executions == nil || session == nil {
+		return ctx, spec, func() {}, nil
+	}
+	execCtx, id, finish, err := r.executions.begin(ctx, session.Summary.ID)
+	if err != nil {
+		return nil, domain.ExecSpec{}, nil, err
+	}
+	marked := spec
+	marked.Env = driver.GuestRuntimeControlEnv(spec.Env, id)
+	return execCtx, marked, finish, nil
+}
+
+func (r driverRuntimeAdapter) beginInteraction(ctx context.Context, session *domain.Sandbox, spec driver.RuntimeStartSpec) (context.Context, driver.RuntimeStartSpec, func(), error) {
+	if r.executions == nil || session == nil {
+		return ctx, spec, func() {}, nil
+	}
+	execCtx, id, finish, err := r.executions.begin(ctx, session.Summary.ID)
+	if err != nil {
+		return nil, driver.RuntimeStartSpec{}, nil, err
+	}
+	marked := spec
+	marked.Env = driver.GuestRuntimeControlEnv(spec.Env, id)
+	if spec.Command != nil {
+		command := *spec.Command
+		command.Env = driver.GuestRuntimeControlEnv(spec.Command.Env, id)
+		marked.Command = &command
+	}
+	return execCtx, marked, finish, nil
+}
+
+func (r driverRuntimeAdapter) PrepareSandboxStop(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, gracePeriod time.Duration) (sandboxes.StopPreparationResult, error) {
+	if r.executions == nil || session == nil {
+		return sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationGraceful}, nil
+	}
+	ids := r.executions.block(session.Summary.ID)
+	if len(ids) == 0 {
+		return sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationGraceful}, nil
+	}
+	graceCtx, cancel := context.WithTimeout(ctx, gracePeriod)
+	defer cancel()
+	if err := r.signalManagedExecutions(graceCtx, session, vmState, ids); err != nil {
+		r.executions.cancel(session.Summary.ID)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationFailed, Error: ctxErr}, nil
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationTimeout, Error: errors.Join(errGracefulStopTimedOut, err)}, nil
+		}
+		return sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationFailed, Error: err}, nil
+	}
+	return sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationGraceful}, nil
+}
+
+func (r driverRuntimeAdapter) BeginSandboxForceStop(session *domain.Sandbox) {
+	if r.executions == nil || session == nil {
+		return
+	}
+	r.executions.block(session.Summary.ID)
+	r.executions.cancel(session.Summary.ID)
+}
+
+func (r driverRuntimeAdapter) FinishSandboxStop(session *domain.Sandbox) {
+	if r.executions != nil && session != nil {
+		r.executions.release(session.Summary.ID)
+	}
+}
+
+func (r driverRuntimeAdapter) signalManagedExecutions(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, ids []string) error {
+	pending := append([]string(nil), ids...)
+	retryAttempt := 0
+	for len(pending) > 0 {
+		pending = r.executions.activeAmong(session.Summary.ID, pending)
+		if len(pending) == 0 {
+			return r.executions.wait(ctx, session.Summary.ID)
+		}
+		signaled, err := r.signalReadyManagedExecutions(ctx, session, vmState, pending)
+		if err != nil {
+			return err
+		}
+		pending = unsignaledActiveExecutions(r.executions.activeAmong(session.Summary.ID, pending), signaled)
+		if len(pending) == 0 {
+			return r.executions.wait(ctx, session.Summary.ID)
+		}
+		if err := r.executions.waitForChange(ctx, guestRuntimeSignalRetryDelay(retryAttempt)); err != nil {
+			return err
+		}
+		retryAttempt++
+	}
+	return nil
+}
+
+func guestRuntimeSignalRetryDelay(attempt int) time.Duration {
+	delay := guestRuntimeSignalInitialRetryDelay
+	for range attempt {
+		if delay >= guestRuntimeSignalMaxRetryDelay/2 {
+			return guestRuntimeSignalMaxRetryDelay
+		}
+		delay *= 2
+	}
+	return delay
+}
+
+func (r driverRuntimeAdapter) signalReadyManagedExecutions(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, ids []string) (map[string]struct{}, error) {
+	signaler, ok := r.runtime.(guestRuntimeSignaler)
+	if !ok {
+		return nil, fmt.Errorf("runtime driver does not support guest runtime signals")
+	}
+	type signalResult struct {
+		id  string
+		err error
+	}
+	driverSandbox := execution.ToDriverSandbox(session)
+	driverVMState := execution.ToDriverVMState(vmState)
+	results := make(chan signalResult, len(ids))
+	for _, id := range ids {
+		go func() {
+			results <- signalResult{
+				id: id,
+				err: signaler.SignalGuestRuntime(
+					ctx,
+					driverSandbox,
+					driverVMState,
+					id,
+					driver.RuntimeSignalTerminate,
+				),
+			}
+		}()
+	}
+	signaled := make(map[string]struct{}, len(ids))
+	var signalErrors []error
+	for range ids {
+		result := <-results
+		switch {
+		case result.err == nil, errors.Is(result.err, driver.ErrGuestRuntimeGone):
+			signaled[result.id] = struct{}{}
+		case errors.Is(result.err, driver.ErrGuestRuntimeNotReady):
+			// Readiness is published only after the runtime's TERM handler exists.
+		default:
+			signalErrors = append(signalErrors, fmt.Errorf("signal guest execution %s: %w", result.id, result.err))
+		}
+	}
+	return signaled, errors.Join(signalErrors...)
+}
+
+func unsignaledActiveExecutions(active []string, signaled map[string]struct{}) []string {
+	remaining := make([]string, 0, len(active))
+	for _, id := range active {
+		if _, ok := signaled[id]; !ok {
+			remaining = append(remaining, id)
+		}
+	}
+	return remaining
+}
+
+type trackedRuntimeInteraction struct {
+	driver.RuntimeInteraction
+	finishOnce sync.Once
+	finish     func()
+	done       chan struct{}
+}
+
+func (i *trackedRuntimeInteraction) Recv() (driver.RuntimeOutputFrame, error) {
+	frame, err := i.RuntimeInteraction.Recv()
+	if err != nil {
+		i.complete()
+	}
+	return frame, err
+}
+
+func (i *trackedRuntimeInteraction) Wait() (driver.RuntimeResult, error) {
+	result, err := i.RuntimeInteraction.Wait()
+	i.complete()
+	return result, err
+}
+
+func (i *trackedRuntimeInteraction) complete() {
+	i.finishOnce.Do(func() {
+		if i.done != nil {
+			close(i.done)
+		}
+		i.finish()
+	})
+}
+
+func (i *trackedRuntimeInteraction) finishWhenContextEnds(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		i.complete()
+	case <-i.done:
+	}
+}

--- a/pkg/agentcompose/adapters/runtime_graceful_stop_test.go
+++ b/pkg/agentcompose/adapters/runtime_graceful_stop_test.go
@@ -1,0 +1,515 @@
+package adapters
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"agent-compose/pkg/driver"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sandboxes"
+)
+
+func TestSandboxExecutionsBlockAndRelease(t *testing.T) {
+	executions := newSandboxExecutions()
+	ctx, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil || ctx == nil {
+		t.Fatalf("begin() ctx=%v err=%v", ctx, err)
+	}
+	executions.block("sandbox-1")
+	if _, _, _, err := executions.begin(context.Background(), "sandbox-1"); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("begin() while blocked error = %v, want ErrFailedPrecondition", err)
+	}
+	finish()
+	if err := executions.wait(context.Background(), "sandbox-1"); err != nil {
+		t.Fatalf("wait() error = %v", err)
+	}
+	executions.release("sandbox-1")
+	_, _, finish, err = executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatalf("begin() after release error = %v", err)
+	}
+	finish()
+}
+
+func TestOverlappingSandboxStopsKeepExecutionGateClosedUntilBothFinish(t *testing.T) {
+	executions := newSandboxExecutions()
+	adapter := driverRuntimeAdapter{runtime: &gracefulStopRuntimeFake{exec: successfulControlExec}, executions: executions}
+	sandbox := testGracefulSandbox()
+
+	for stop := 0; stop < 2; stop++ {
+		result, err := adapter.PrepareSandboxStop(context.Background(), sandbox, domain.VMState{}, time.Second)
+		if err != nil || result.Outcome != sandboxes.StopPreparationGraceful {
+			t.Fatalf("PrepareSandboxStop() stop %d result=%#v err=%v", stop+1, result, err)
+		}
+	}
+
+	if _, err := adapter.StopSandbox(context.Background(), sandbox, domain.VMState{}); err != nil {
+		t.Fatalf("first StopSandbox() error = %v", err)
+	}
+	adapter.FinishSandboxStop(sandbox)
+	if _, _, _, err := executions.begin(context.Background(), sandbox.Summary.ID); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("begin() after first stop finished error = %v, want ErrFailedPrecondition", err)
+	}
+
+	if _, err := adapter.StopSandbox(context.Background(), sandbox, domain.VMState{}); err != nil {
+		t.Fatalf("second StopSandbox() error = %v", err)
+	}
+	adapter.FinishSandboxStop(sandbox)
+	_, _, finish, err := executions.begin(context.Background(), sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("begin() after both stops finished error = %v", err)
+	}
+	finish()
+}
+
+func TestEnsureSandboxDoesNotReopenGateDuringGracefulStop(t *testing.T) {
+	executions := newSandboxExecutions()
+	_, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finishOnce := sync.OnceFunc(finish)
+	t.Cleanup(finishOnce)
+	controlStarted := make(chan struct{})
+	allowSignal := make(chan struct{})
+	adapter := driverRuntimeAdapter{
+		runtime: &gracefulStopRuntimeFake{signal: func(context.Context, string) error {
+			close(controlStarted)
+			<-allowSignal
+			finishOnce()
+			return nil
+		}},
+		executions: executions,
+	}
+	sandbox := testGracefulSandbox()
+	resultCh := make(chan sandboxes.StopPreparationResult, 1)
+	go func() {
+		result, _ := adapter.PrepareSandboxStop(context.Background(), sandbox, domain.VMState{}, time.Second)
+		resultCh <- result
+	}()
+	<-controlStarted
+
+	if _, err := adapter.EnsureSandbox(context.Background(), sandbox, domain.VMState{}, domain.ProxyState{}); err != nil {
+		t.Fatalf("EnsureSandbox() error = %v", err)
+	}
+	if _, _, _, err := executions.begin(context.Background(), sandbox.Summary.ID); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("begin() during graceful stop after ensure error = %v, want ErrFailedPrecondition", err)
+	}
+	close(allowSignal)
+	if result := <-resultCh; result.Outcome != sandboxes.StopPreparationGraceful {
+		t.Fatalf("PrepareSandboxStop() result = %#v", result)
+	}
+	adapter.FinishSandboxStop(sandbox)
+}
+
+func TestPrepareSandboxStopWaitsForGracefulExecutionExit(t *testing.T) {
+	executions := newSandboxExecutions()
+	_, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := &gracefulStopRuntimeFake{signal: func(context.Context, string) error {
+		finish()
+		return nil
+	}}
+	adapter := driverRuntimeAdapter{runtime: runtime, executions: executions}
+
+	result, err := adapter.PrepareSandboxStop(context.Background(), testGracefulSandbox(), domain.VMState{}, time.Second)
+	if err != nil || result.Outcome != sandboxes.StopPreparationGraceful {
+		t.Fatalf("PrepareSandboxStop() result=%#v err=%v", result, err)
+	}
+	if runtime.signalCalls.Load() != 1 {
+		t.Fatalf("managed execution signal calls = %d, want 1", runtime.signalCalls.Load())
+	}
+}
+
+func TestPrepareSandboxStopRetriesUntilRuntimeShutdownIsReady(t *testing.T) {
+	executions := newSandboxExecutions()
+	execCtx, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finishOnce := sync.OnceFunc(finish)
+	go func() {
+		<-execCtx.Done()
+		finishOnce()
+	}()
+	controlCalls := 0
+	runtime := &gracefulStopRuntimeFake{signal: func(context.Context, string) error {
+		controlCalls++
+		if controlCalls == 1 {
+			return driver.ErrGuestRuntimeNotReady
+		}
+		finishOnce()
+		return nil
+	}}
+	adapter := driverRuntimeAdapter{runtime: runtime, executions: executions}
+
+	result, err := adapter.PrepareSandboxStop(context.Background(), testGracefulSandbox(), domain.VMState{}, 250*time.Millisecond)
+	if err != nil || result.Outcome != sandboxes.StopPreparationGraceful {
+		t.Fatalf("PrepareSandboxStop() result=%#v err=%v", result, err)
+	}
+	if controlCalls != 2 {
+		t.Fatalf("signal control exec calls = %d, want 2", controlCalls)
+	}
+}
+
+func TestGuestRuntimeSignalRetryDelayIsExponentiallyBounded(t *testing.T) {
+	want := []time.Duration{
+		50 * time.Millisecond,
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		500 * time.Millisecond,
+		500 * time.Millisecond,
+	}
+	for attempt, wantDelay := range want {
+		if got := guestRuntimeSignalRetryDelay(attempt); got != wantDelay {
+			t.Fatalf("guestRuntimeSignalRetryDelay(%d) = %s, want %s", attempt, got, wantDelay)
+		}
+	}
+}
+
+func TestPrepareSandboxStopSignalsManagedExecutionsConcurrently(t *testing.T) {
+	executions := newSandboxExecutions()
+	_, firstID, firstFinish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, secondID, secondFinish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finishes := map[string]func(){firstID: firstFinish, secondID: secondFinish}
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	runtime := &gracefulStopRuntimeFake{signal: func(_ context.Context, executionID string) error {
+		started <- executionID
+		<-release
+		finishes[executionID]()
+		return nil
+	}}
+	adapter := driverRuntimeAdapter{runtime: runtime, executions: executions}
+	resultCh := make(chan sandboxes.StopPreparationResult, 1)
+	go func() {
+		result, _ := adapter.PrepareSandboxStop(context.Background(), testGracefulSandbox(), domain.VMState{}, time.Second)
+		resultCh <- result
+	}()
+
+	seen := map[string]bool{}
+	for range 2 {
+		select {
+		case id := <-started:
+			seen[id] = true
+		case <-time.After(250 * time.Millisecond):
+			t.Fatal("managed execution signals were serialized")
+		}
+	}
+	if !seen[firstID] || !seen[secondID] {
+		t.Fatalf("signaled execution IDs = %v, want both active IDs", seen)
+	}
+	close(release)
+	if result := <-resultCh; result.Outcome != sandboxes.StopPreparationGraceful {
+		t.Fatalf("PrepareSandboxStop() result = %#v", result)
+	}
+}
+
+func TestPrepareSandboxStopTimeoutCancelsExecutionWithoutWaitingForIt(t *testing.T) {
+	executions := newSandboxExecutions()
+	execCtx, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(finish)
+	adapter := driverRuntimeAdapter{
+		runtime:    &gracefulStopRuntimeFake{},
+		executions: executions,
+	}
+
+	result, err := adapter.PrepareSandboxStop(context.Background(), testGracefulSandbox(), domain.VMState{}, 5*time.Millisecond)
+	if err != nil || result.Outcome != sandboxes.StopPreparationTimeout || !errors.Is(result.Error, errGracefulStopTimedOut) {
+		t.Fatalf("PrepareSandboxStop() result=%#v err=%v", result, err)
+	}
+	if execCtx.Err() == nil {
+		t.Fatal("execution context was not cancelled after grace period")
+	}
+}
+
+func TestPrepareSandboxStopPreservesRequestCancellation(t *testing.T) {
+	executions := newSandboxExecutions()
+	execCtx, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(finish)
+	controlStarted := make(chan struct{})
+	adapter := driverRuntimeAdapter{
+		runtime: &gracefulStopRuntimeFake{signal: func(ctx context.Context, _ string) error {
+			close(controlStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		}},
+		executions: executions,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan sandboxes.StopPreparationResult, 1)
+	go func() {
+		result, _ := adapter.PrepareSandboxStop(ctx, testGracefulSandbox(), domain.VMState{}, time.Hour)
+		resultCh <- result
+	}()
+	<-controlStarted
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		if result.Outcome != sandboxes.StopPreparationFailed || !errors.Is(result.Error, context.Canceled) {
+			t.Fatalf("PrepareSandboxStop() result = %#v, want cancelled failure", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("PrepareSandboxStop() ignored request cancellation")
+	}
+	if execCtx.Err() == nil {
+		t.Fatal("execution context was not cancelled with stop request")
+	}
+}
+
+func TestPrepareSandboxStopSignalErrorForcesExecution(t *testing.T) {
+	executions := newSandboxExecutions()
+	execCtx, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		<-execCtx.Done()
+		finish()
+	}()
+	wantErr := errors.New("control exec failed")
+	adapter := driverRuntimeAdapter{
+		runtime: &gracefulStopRuntimeFake{signal: func(context.Context, string) error {
+			return wantErr
+		}},
+		executions: executions,
+	}
+
+	result, err := adapter.PrepareSandboxStop(context.Background(), testGracefulSandbox(), domain.VMState{}, time.Second)
+	if err != nil || result.Outcome != sandboxes.StopPreparationFailed || !errors.Is(result.Error, wantErr) {
+		t.Fatalf("PrepareSandboxStop() result=%#v err=%v", result, err)
+	}
+}
+
+func TestPrepareSandboxStopIntegrationSignalUsesGraceDeadline(t *testing.T) {
+	executions := newSandboxExecutions()
+	execCtx, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		<-execCtx.Done()
+		finish()
+	}()
+	adapter := driverRuntimeAdapter{
+		runtime: &gracefulStopRuntimeFake{signal: func(ctx context.Context, _ string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}},
+		executions: executions,
+	}
+
+	result, err := adapter.PrepareSandboxStop(context.Background(), testGracefulSandbox(), domain.VMState{}, 5*time.Millisecond)
+	if err != nil || result.Outcome != sandboxes.StopPreparationTimeout || !errors.Is(result.Error, errGracefulStopTimedOut) {
+		t.Fatalf("PrepareSandboxStop() result=%#v err=%v", result, err)
+	}
+	if err := executions.wait(context.Background(), "sandbox-1"); err != nil {
+		t.Fatalf("active execution remained after signal timeout: %v", err)
+	}
+}
+
+func TestBeginSandboxForceStopCancelsActiveExecutionAndClosesGate(t *testing.T) {
+	executions := newSandboxExecutions()
+	execCtx, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := driverRuntimeAdapter{runtime: &gracefulStopRuntimeFake{exec: successfulControlExec}, executions: executions}
+	adapter.BeginSandboxForceStop(testGracefulSandbox())
+
+	select {
+	case <-execCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("force stop did not cancel the active execution")
+	}
+	if _, _, _, err := executions.begin(context.Background(), "sandbox-1"); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("begin() after force stop error = %v, want ErrFailedPrecondition", err)
+	}
+	finish()
+}
+
+func TestTrackedRuntimeInteractionFinishesOnEOF(t *testing.T) {
+	finished := 0
+	interaction := &trackedRuntimeInteraction{
+		RuntimeInteraction: eofRuntimeInteraction{},
+		finish:             func() { finished++ },
+		done:               make(chan struct{}),
+	}
+	if _, err := interaction.Recv(); !errors.Is(err, io.EOF) {
+		t.Fatalf("Recv() error = %v, want EOF", err)
+	}
+	if _, err := interaction.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if finished != 1 {
+		t.Fatalf("finish calls = %d, want 1", finished)
+	}
+}
+
+func TestTrackedRuntimeInteractionFinishesOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	finished := make(chan struct{})
+	interaction := &trackedRuntimeInteraction{
+		RuntimeInteraction: eofRuntimeInteraction{},
+		finish:             func() { close(finished) },
+		done:               make(chan struct{}),
+	}
+	go interaction.finishWhenContextEnds(ctx)
+	cancel()
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("interaction remained tracked after its context was cancelled")
+	}
+}
+
+func TestRuntimeAdapterKeepsExecutionGateClosedUntilStopFinalizedAndAcrossEnsure(t *testing.T) {
+	executions := newSandboxExecutions()
+	adapter := driverRuntimeAdapter{runtime: &gracefulStopRuntimeFake{exec: successfulControlExec}, executions: executions}
+	sandbox := testGracefulSandbox()
+	if _, err := adapter.StopSandbox(context.Background(), sandbox, domain.VMState{}); err != nil {
+		t.Fatalf("StopSandbox() error = %v", err)
+	}
+	if _, _, _, err := executions.begin(context.Background(), sandbox.Summary.ID); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("execution gate after driver stop error = %v, want ErrFailedPrecondition", err)
+	}
+	adapter.FinishSandboxStop(sandbox)
+	_, _, finish, err := executions.begin(context.Background(), sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("begin() after stop finalization error = %v", err)
+	}
+	finish()
+
+	executions.block(sandbox.Summary.ID)
+	executions.block(sandbox.Summary.ID)
+	if _, err := adapter.EnsureSandbox(context.Background(), sandbox, domain.VMState{}, domain.ProxyState{}); err != nil {
+		t.Fatalf("EnsureSandbox() error = %v", err)
+	}
+	if _, _, _, err := executions.begin(context.Background(), sandbox.Summary.ID); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("begin() after ensure error = %v, want ErrFailedPrecondition", err)
+	}
+	executions.release(sandbox.Summary.ID)
+	if _, _, _, err := executions.begin(context.Background(), sandbox.Summary.ID); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("begin() after first stop finalization error = %v, want ErrFailedPrecondition", err)
+	}
+	executions.release(sandbox.Summary.ID)
+	_, _, finish, err = executions.begin(context.Background(), sandbox.Summary.ID)
+	if err != nil {
+		t.Fatalf("begin() after both stops finalized error = %v", err)
+	}
+	finish()
+}
+
+func TestRuntimeAdapterPreservesStopDeadlineForRuntimeContainment(t *testing.T) {
+	executions := newSandboxExecutions()
+	_, _, finish, err := executions.begin(context.Background(), "sandbox-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := &gracefulStopRuntimeFake{exec: successfulControlExec}
+	adapter := driverRuntimeAdapter{runtime: runtime, executions: executions}
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	executionFinished := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		finish()
+		close(executionFinished)
+	}()
+
+	if _, err := adapter.StopSandbox(ctx, testGracefulSandbox(), domain.VMState{}); err != nil {
+		t.Fatalf("StopSandbox() error = %v", err)
+	}
+	if runtime.stopContextErr != nil {
+		t.Fatalf("runtime stop received exhausted context: %v", runtime.stopContextErr)
+	}
+	cancel()
+	select {
+	case <-executionFinished:
+	case <-time.After(time.Second):
+		t.Fatal("active execution did not finish after stop context cancellation")
+	}
+}
+
+func successfulControlExec(driver.ExecSpec) (driver.ExecResult, error) {
+	return driver.ExecResult{Success: true}, nil
+}
+
+func testGracefulSandbox() *domain.Sandbox {
+	return &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}}
+}
+
+type gracefulStopRuntimeFake struct {
+	exec           func(driver.ExecSpec) (driver.ExecResult, error)
+	execContext    func(context.Context, driver.ExecSpec) (driver.ExecResult, error)
+	execCalls      int
+	signal         func(context.Context, string) error
+	signalCalls    atomic.Int32
+	stopContextErr error
+}
+
+func (*gracefulStopRuntimeFake) EnsureSandbox(context.Context, *driver.Sandbox, driver.VMState, driver.ProxyState) (driver.SandboxVMInfo, error) {
+	return driver.SandboxVMInfo{}, nil
+}
+
+func (r *gracefulStopRuntimeFake) StopSandbox(ctx context.Context, _ *driver.Sandbox, _ driver.VMState) (bool, error) {
+	r.stopContextErr = ctx.Err()
+	return false, nil
+}
+
+func (*gracefulStopRuntimeFake) RemoveSandbox(context.Context, *driver.Sandbox, driver.VMState) error {
+	return nil
+}
+
+func (r *gracefulStopRuntimeFake) Exec(ctx context.Context, _ *driver.Sandbox, _ driver.VMState, spec driver.ExecSpec) (driver.ExecResult, error) {
+	r.execCalls++
+	if r.execContext != nil {
+		return r.execContext(ctx, spec)
+	}
+	return r.exec(spec)
+}
+
+func (r *gracefulStopRuntimeFake) ExecStream(ctx context.Context, sandbox *driver.Sandbox, state driver.VMState, spec driver.ExecSpec, _ driver.ExecStreamWriter) (driver.ExecResult, error) {
+	return r.Exec(ctx, sandbox, state, spec)
+}
+
+func (r *gracefulStopRuntimeFake) SignalGuestRuntime(ctx context.Context, _ *driver.Sandbox, _ driver.VMState, executionID string, signal driver.RuntimeSignal) error {
+	if signal != driver.RuntimeSignalTerminate {
+		return errors.New("unexpected managed execution signal")
+	}
+	r.signalCalls.Add(1)
+	if r.signal != nil {
+		return r.signal(ctx, executionID)
+	}
+	return nil
+}
+
+type eofRuntimeInteraction struct{}
+
+func (eofRuntimeInteraction) Send(driver.RuntimeInputFrame) error { return nil }
+func (eofRuntimeInteraction) CloseSend() error                    { return nil }
+func (eofRuntimeInteraction) Recv() (driver.RuntimeOutputFrame, error) {
+	return driver.RuntimeOutputFrame{}, io.EOF
+}
+func (eofRuntimeInteraction) Wait() (driver.RuntimeResult, error) { return driver.RuntimeResult{}, nil }

--- a/pkg/agentcompose/adapters/runtime_provider.go
+++ b/pkg/agentcompose/adapters/runtime_provider.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sandboxes"
 )
 
 type SandboxRuntime interface {
@@ -23,6 +25,10 @@ type SandboxStatsRuntime interface {
 	Stats(context.Context, *domain.Sandbox, domain.VMState) (domain.SandboxStats, error)
 }
 
+type SandboxGracefulStopRuntime interface {
+	PrepareSandboxStop(context.Context, *domain.Sandbox, domain.VMState, time.Duration) (sandboxes.StopPreparationResult, error)
+}
+
 type RuntimeProvider interface {
 	ForDriver(string) (SandboxRuntime, error)
 	ForSession(*domain.Sandbox) (SandboxRuntime, error)
@@ -34,7 +40,8 @@ type runtimeProvider struct {
 }
 
 type driverRuntimeAdapter struct {
-	runtime driverpkg.SandboxRuntime
+	runtime    driverpkg.SandboxRuntime
+	executions *sandboxExecutions
 }
 
 func NewRuntimeProvider(config *appconfig.Config) (RuntimeProvider, error) {
@@ -57,12 +64,13 @@ func NewRuntimeProvider(config *appconfig.Config) (RuntimeProvider, error) {
 	if err != nil {
 		return nil, err
 	}
+	executions := newSandboxExecutions()
 	return &runtimeProvider{
 		config: config,
 		runtimes: map[string]SandboxRuntime{
-			driverpkg.RuntimeDriverBoxlite:      driverRuntimeAdapter{runtime: boxliteRuntime},
-			driverpkg.RuntimeDriverDocker:       driverRuntimeAdapter{runtime: dockerRuntime},
-			driverpkg.RuntimeDriverMicrosandbox: driverRuntimeAdapter{runtime: microsandboxRuntime},
+			driverpkg.RuntimeDriverBoxlite:      driverRuntimeAdapter{runtime: boxliteRuntime, executions: executions},
+			driverpkg.RuntimeDriverDocker:       driverRuntimeAdapter{runtime: dockerRuntime, executions: executions},
+			driverpkg.RuntimeDriverMicrosandbox: driverRuntimeAdapter{runtime: microsandboxRuntime, executions: executions},
 		},
 	}, nil
 }
@@ -109,7 +117,15 @@ func (r driverRuntimeAdapter) EnsureSandbox(ctx context.Context, session *domain
 }
 
 func (r driverRuntimeAdapter) StopSandbox(ctx context.Context, session *domain.Sandbox, vmState domain.VMState) (bool, error) {
-	return r.runtime.StopSandbox(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState))
+	if r.executions != nil {
+		r.executions.ensureBlocked(session.Summary.ID)
+		// Preserve the runtime driver's complete stop deadline. The sandbox stop
+		// is the final containment boundary for executions that have not yet
+		// returned after cancellation.
+		r.executions.cancel(session.Summary.ID)
+	}
+	missing, err := r.runtime.StopSandbox(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState))
+	return missing, err
 }
 
 func (r driverRuntimeAdapter) RemoveSandbox(ctx context.Context, session *domain.Sandbox, vmState domain.VMState) error {
@@ -117,17 +133,27 @@ func (r driverRuntimeAdapter) RemoveSandbox(ctx context.Context, session *domain
 }
 
 func (r driverRuntimeAdapter) Exec(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, spec domain.ExecSpec) (domain.ExecResult, error) {
-	result, err := r.runtime.Exec(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), execution.ToDriverExecSpec(spec))
+	execCtx, marked, finish, err := r.beginExecution(ctx, session, spec)
+	if err != nil {
+		return domain.ExecResult{}, err
+	}
+	defer finish()
+	result, err := r.runtime.Exec(execCtx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), execution.ToDriverExecSpec(marked))
 	return execution.FromDriverExecResult(result), classifyExecTerminationError(err)
 }
 
 func (r driverRuntimeAdapter) ExecStream(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, spec domain.ExecSpec, stream domain.ExecStreamWriter) (domain.ExecResult, error) {
+	execCtx, marked, finish, err := r.beginExecution(ctx, session, spec)
+	if err != nil {
+		return domain.ExecResult{}, err
+	}
+	defer finish()
 	driverStream := func(chunk driverpkg.ExecChunk) {
 		if stream != nil {
 			stream(domain.ExecChunk{Text: chunk.Text, Stream: domainStreamFromDriver(chunk.Stream)})
 		}
 	}
-	result, err := r.runtime.ExecStream(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), execution.ToDriverExecSpec(spec), driverStream)
+	result, err := r.runtime.ExecStream(execCtx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), execution.ToDriverExecSpec(marked), driverStream)
 	return execution.FromDriverExecResult(result), classifyExecTerminationError(err)
 }
 
@@ -143,7 +169,22 @@ func (r driverRuntimeAdapter) OpenInteraction(ctx context.Context, session *doma
 	if !ok {
 		return driverpkg.UnsupportedRuntimeInteraction(vmState.Driver, driverpkg.RuntimeInteractionCapabilities{}, spec)
 	}
-	return interactor.OpenInteraction(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), spec)
+	execCtx, marked, finish, err := r.beginInteraction(ctx, session, spec)
+	if err != nil {
+		return nil, err
+	}
+	interaction, err := interactor.OpenInteraction(execCtx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState), marked)
+	if err != nil {
+		finish()
+		return nil, err
+	}
+	tracked := &trackedRuntimeInteraction{
+		RuntimeInteraction: interaction,
+		finish:             finish,
+		done:               make(chan struct{}),
+	}
+	go tracked.finishWhenContextEnds(execCtx)
+	return tracked, nil
 }
 
 func domainStreamFromDriver(stream driverpkg.StdioStream) domain.StdioStream {
@@ -169,7 +210,7 @@ func (r driverRuntimeAdapter) IsSandboxAlive(ctx context.Context, session *domai
 		IsSandboxAlive(context.Context, *driverpkg.Sandbox, driverpkg.VMState) (bool, error)
 	})
 	if !ok {
-		return false, fmt.Errorf("runtime does not support session liveness checks")
+		return false, domain.ClassifyError(domain.ErrUnsupported, "runtime does not support sandbox liveness checks", nil)
 	}
 	return aliveRuntime.IsSandboxAlive(ctx, execution.ToDriverSandbox(session), execution.ToDriverVMState(vmState))
 }

--- a/pkg/agentcompose/adapters/session_driver.go
+++ b/pkg/agentcompose/adapters/session_driver.go
@@ -190,6 +190,39 @@ func (d *SandboxDriver) StopSandboxVM(ctx context.Context, session *domain.Sandb
 	return d.Store.SaveVMState(session.Summary.ID, vmState)
 }
 
+func (d *SandboxDriver) PrepareSandboxStop(ctx context.Context, session *domain.Sandbox, vmState domain.VMState, gracePeriod time.Duration) (sandboxes.StopPreparationResult, error) {
+	_, runtime, err := d.runtimeForSession(session)
+	if err != nil {
+		return sandboxes.StopPreparationResult{}, err
+	}
+	preparer, ok := runtime.(SandboxGracefulStopRuntime)
+	if !ok {
+		return sandboxes.StopPreparationResult{}, domain.ClassifyError(domain.ErrUnsupported, "runtime does not support graceful sandbox stop", nil)
+	}
+	return preparer.PrepareSandboxStop(ctx, session, vmState, gracePeriod)
+}
+
+func (d *SandboxDriver) BeginSandboxForceStop(session *domain.Sandbox) error {
+	_, runtime, err := d.runtimeForSession(session)
+	if err != nil {
+		return err
+	}
+	if initiator, ok := runtime.(interface{ BeginSandboxForceStop(*domain.Sandbox) }); ok {
+		initiator.BeginSandboxForceStop(session)
+	}
+	return nil
+}
+
+func (d *SandboxDriver) FinishSandboxStop(session *domain.Sandbox) {
+	_, runtime, err := d.runtimeForSession(session)
+	if err != nil {
+		return
+	}
+	if finalizer, ok := runtime.(interface{ FinishSandboxStop(*domain.Sandbox) }); ok {
+		finalizer.FinishSandboxStop(session)
+	}
+}
+
 func (d *SandboxDriver) RemoveSandboxVM(ctx context.Context, session *domain.Sandbox) error {
 	driver, runtime, err := d.runtimeForSession(session)
 	if err != nil {

--- a/pkg/agentcompose/adapters/session_rpc_bridge.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -315,27 +316,40 @@ func (b *SandboxRPCBridge) RecoverStoppedRuntimeReleases(ctx context.Context) []
 }
 
 func (b *SandboxRPCBridge) StopSandbox(ctx context.Context, sandboxID string) (*domain.Sandbox, error) {
-	return b.stopSandbox(ctx, sandboxID, domain.SandboxTypeManual)
+	outcome, err := b.stopSandboxWithOptions(ctx, sandboxID, domain.SandboxTypeManual, sandboxes.StopOptions{Mode: sandboxes.StopModeForce})
+	return outcome.Sandbox, err
+}
+
+func (b *SandboxRPCBridge) StopSandboxWithOptions(ctx context.Context, sandboxID string, options sandboxes.StopOptions) (sandboxes.StopOutcome, error) {
+	return b.stopSandboxWithOptions(ctx, sandboxID, domain.SandboxTypeManual, options)
 }
 
 func (b *SandboxRPCBridge) stopSandbox(ctx context.Context, sandboxID, source string) (*domain.Sandbox, error) {
+	outcome, err := b.stopSandboxWithOptions(ctx, sandboxID, source, sandboxes.StopOptions{Mode: sandboxes.StopModeForce})
+	return outcome.Sandbox, err
+}
+
+func (b *SandboxRPCBridge) stopSandboxWithOptions(ctx context.Context, sandboxID, source string, options sandboxes.StopOptions) (sandboxes.StopOutcome, error) {
 	session, err := b.store.GetSandbox(ctx, sandboxID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return sandboxes.StopOutcome{}, connect.NewError(connect.CodeNotFound, err)
 	}
 	if reconciled, recErr := b.ReconcileRuntimeState(ctx, session); recErr != nil {
 		slog.Warn("failed to reconcile sandbox runtime state before stop", "sandbox_id", session.Summary.ID, "error", recErr)
 	} else {
 		session = reconciled
 	}
-	outcome, stopErr := b.sessionLifecycle().StopLoaded(ctx, session)
+	outcome, stopErr := b.sessionLifecycle().StopLoadedWithOptions(ctx, session, options)
+	if outcome.Preparation.Error != nil {
+		slog.Warn("graceful sandbox stop escalated to force", "sandbox_id", session.Summary.ID, "outcome", outcome.Preparation.Outcome, "error", outcome.Preparation.Error)
+	}
 	if outcome.DriverStopped && outcome.Sandbox != nil {
 		b.publishSchedulerTopic("agent-compose.session.stopped", schedulers.SessionTopicPayload(outcome.Sandbox, source))
 	}
 	if stopErr != nil {
-		return nil, api.ConnectErrorForDomain(stopErr)
+		return outcome, api.ConnectErrorForDomain(stopErr)
 	}
-	return outcome.Sandbox, nil
+	return outcome, nil
 }
 
 func (b *SandboxRPCBridge) indexCapabilitySandbox(session *domain.Sandbox) {
@@ -441,6 +455,9 @@ func (p sandboxRuntimeLiveness) IsSandboxAlive(ctx context.Context, driver strin
 		return false, false, nil
 	}
 	alive, err := aliveRuntime.IsSandboxAlive(ctx, session, vmState)
+	if errors.Is(err, domain.ErrUnsupported) {
+		return false, false, nil
+	}
 	return alive, true, err
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_test.go
@@ -38,6 +38,17 @@ type fakeRPCSandboxDriver struct {
 	releaseErr    error
 }
 
+type cancellationAwareRPCSandboxDriver struct {
+	*fakeRPCSandboxDriver
+	preparationStarted chan struct{}
+}
+
+func (d *cancellationAwareRPCSandboxDriver) PrepareSandboxStop(ctx context.Context, _ *domain.Sandbox, _ domain.VMState, _ time.Duration) (sandboxes.StopPreparationResult, error) {
+	close(d.preparationStarted)
+	<-ctx.Done()
+	return sandboxes.StopPreparationResult{}, ctx.Err()
+}
+
 func (d *fakeRPCSandboxDriver) ValidateSandboxRuntime(*domain.Sandbox) error {
 	return d.validateErr
 }
@@ -187,6 +198,36 @@ func TestSandboxRPCBridgeCallJSONSupportsSandboxRPCs(t *testing.T) {
 	}
 	if _, err := bridge.CallJSON(ctx, "GetSandbox", `{bad json`); err == nil || !strings.Contains(err.Error(), "decode sandbox rpc request") {
 		t.Fatalf("bad json error = %v", err)
+	}
+}
+
+func TestSandboxRPCBridgeGracefulStopPreservesRequestCancellation(t *testing.T) {
+	bridge, baseDriver := newTestSandboxRPCBridge(t)
+	sandbox, err := bridge.createSandbox(context.Background(), sandboxRPCCreateRequest{Title: "cancel graceful stop"}, domain.SandboxTypeManual)
+	if err != nil {
+		t.Fatalf("createSandbox() error = %v", err)
+	}
+	driver := &cancellationAwareRPCSandboxDriver{
+		fakeRPCSandboxDriver: baseDriver,
+		preparationStarted:   make(chan struct{}),
+	}
+	bridge.driver = driver
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, stopErr := bridge.StopSandboxWithOptions(ctx, sandbox.Summary.ID, sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful, GracePeriod: time.Hour})
+		resultCh <- stopErr
+	}()
+	<-driver.preparationStarted
+	cancel()
+
+	select {
+	case stopErr := <-resultCh:
+		if !errors.Is(stopErr, context.Canceled) && connect.CodeOf(stopErr) != connect.CodeCanceled {
+			t.Fatalf("StopSandboxWithOptions() error = %v, want request cancellation", stopErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StopSandboxWithOptions() ignored request cancellation")
 	}
 }
 
@@ -544,6 +585,10 @@ func TestSandboxRuntimeLivenessAndNotifierBranches(t *testing.T) {
 	runtime := driverRuntimeAdapter{runtime: fakeDriverRuntime{alive: true}}
 	if alive, checked, err := (sandboxRuntimeLiveness{runtimes: fakeRuntimeProvider{runtime: runtime}}).IsSandboxAlive(ctx, "microsandbox", session, domain.VMState{}); err != nil || !alive || !checked {
 		t.Fatalf("driver runtime adapter liveness = alive %v checked %v err %v", alive, checked, err)
+	}
+	unsupported := driverRuntimeAdapter{runtime: &gracefulStopRuntimeFake{exec: successfulControlExec}}
+	if alive, checked, err := (sandboxRuntimeLiveness{runtimes: fakeRuntimeProvider{runtime: unsupported}}).IsSandboxAlive(ctx, "boxlite", session, domain.VMState{}); err != nil || alive || checked {
+		t.Fatalf("unsupported driver runtime liveness = alive %v checked %v err %v", alive, checked, err)
 	}
 
 	streams := sandboxes.NewStreamBrokerForTest()

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -74,6 +74,10 @@ type SandboxLifecycleDelegate interface {
 	GetSandboxProxy(context.Context, string) (SandboxProxy, error)
 }
 
+type SandboxGracefulLifecycleDelegate interface {
+	StopSandboxWithOptions(context.Context, string, sandboxes.StopOptions) (sandboxes.StopOutcome, error)
+}
+
 type SandboxProxy struct {
 	ProxyPath   string
 	NotebookURL string
@@ -305,6 +309,10 @@ func sandboxHistoryEventToV2(event *domain.SandboxEvent) *agentcomposev2.Sandbox
 }
 
 func (h *SandboxHandler) StopSandbox(ctx context.Context, req *connect.Request[agentcomposev2.StopSandboxRequest]) (*connect.Response[agentcomposev2.StopSandboxResponse], error) {
+	options, err := sandboxStopOptions(req.Msg)
+	if err != nil {
+		return nil, err
+	}
 	sandbox, err := h.loadSandbox(ctx, req.Msg.GetSandboxId())
 	if err != nil {
 		return nil, err
@@ -313,18 +321,71 @@ func (h *SandboxHandler) StopSandbox(ctx context.Context, req *connect.Request[a
 	state := domain.EffectiveStoppedRuntimeState(sandbox)
 	if sandbox.Summary.VMStatus == domain.VMStatusStopped &&
 		(policy == domain.StoppedRuntimePolicyRetain || state == domain.StoppedRuntimeStateReleased) {
-		return connect.NewResponse(&agentcomposev2.StopSandboxResponse{Sandbox: h.sandboxToV2(ctx, sandbox)}), nil
+		outcome := agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE
+		if options.Mode == sandboxes.StopModeGraceful {
+			outcome = agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL
+		}
+		return connect.NewResponse(&agentcomposev2.StopSandboxResponse{Sandbox: h.sandboxToV2(ctx, sandbox), Outcome: outcome}), nil
 	}
 	retryRelease := sandbox.Summary.VMStatus == domain.VMStatusStopped &&
 		policy == domain.StoppedRuntimePolicyRemove && state == domain.StoppedRuntimeStateReleasePending
 	if sandbox.Summary.VMStatus != domain.VMStatusRunning && !retryRelease {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sandbox %s cannot be stopped from state %s", sandbox.Summary.ID, sandbox.Summary.VMStatus))
 	}
-	stopped, err := h.delegate.StopSandbox(ctx, sandbox.Summary.ID)
-	if err != nil {
-		return nil, err
+	if options.Mode != sandboxes.StopModeGraceful {
+		stopped, stopErr := h.delegate.StopSandbox(ctx, sandbox.Summary.ID)
+		if stopErr != nil {
+			return nil, stopErr
+		}
+		return connect.NewResponse(&agentcomposev2.StopSandboxResponse{Sandbox: h.sandboxToV2(ctx, stopped), Outcome: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE}), nil
 	}
-	return connect.NewResponse(&agentcomposev2.StopSandboxResponse{Sandbox: h.sandboxToV2(ctx, stopped)}), nil
+	graceful, ok := h.delegate.(SandboxGracefulLifecycleDelegate)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("graceful sandbox stop is unsupported"))
+	}
+	outcome, stopErr := graceful.StopSandboxWithOptions(ctx, sandbox.Summary.ID, options)
+	if stopErr != nil {
+		return nil, stopErr
+	}
+	return connect.NewResponse(&agentcomposev2.StopSandboxResponse{Sandbox: h.sandboxToV2(ctx, outcome.Sandbox), Outcome: sandboxStopOutcomeToProto(outcome)}), nil
+}
+
+const maxSandboxGracePeriod = 5 * time.Minute
+
+func sandboxStopOptions(request *agentcomposev2.StopSandboxRequest) (sandboxes.StopOptions, error) {
+	mode := sandboxes.StopModeForce
+	if request.GetMode() == agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL {
+		mode = sandboxes.StopModeGraceful
+	} else if request.GetMode() != agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_UNSPECIFIED && request.GetMode() != agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE {
+		return sandboxes.StopOptions{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unsupported sandbox stop mode %s", request.GetMode()))
+	}
+	gracePeriod := time.Duration(0)
+	if request.GetGracePeriod() != nil {
+		if err := request.GetGracePeriod().CheckValid(); err != nil {
+			return sandboxes.StopOptions{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid grace period: %w", err))
+		}
+		gracePeriod = request.GetGracePeriod().AsDuration()
+		if gracePeriod <= 0 || gracePeriod > maxSandboxGracePeriod {
+			return sandboxes.StopOptions{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("grace period must be greater than zero and at most %s", maxSandboxGracePeriod))
+		}
+	}
+	if gracePeriod > 0 && mode != sandboxes.StopModeGraceful {
+		return sandboxes.StopOptions{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("grace period requires graceful stop mode"))
+	}
+	return sandboxes.StopOptions{Mode: mode, GracePeriod: gracePeriod}, nil
+}
+
+func sandboxStopOutcomeToProto(outcome sandboxes.StopOutcome) agentcomposev2.SandboxStopOutcome {
+	switch outcome.Preparation.Outcome {
+	case sandboxes.StopPreparationGraceful:
+		return agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL
+	case sandboxes.StopPreparationTimeout:
+		return agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT
+	case sandboxes.StopPreparationFailed:
+		return agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_ERROR
+	default:
+		return agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE
+	}
 }
 
 func (h *SandboxHandler) ResumeSandbox(ctx context.Context, req *connect.Request[agentcomposev2.ResumeSandboxRequest]) (*connect.Response[agentcomposev2.ResumeSandboxResponse], error) {

--- a/pkg/agentcompose/api/sandbox_graceful_stop_integration_test.go
+++ b/pkg/agentcompose/api/sandbox_graceful_stop_integration_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"agent-compose/pkg/identity"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sandboxes"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestIntegrationGracefulStopPropagatesOptionsOverConnect(t *testing.T) {
+	sandboxID := identity.NewID(identity.ResourceSandbox, "graceful-stop", "integration")
+	running := &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusRunning}}
+	stopped := &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}}
+	delegate := &gracefulStopAPIDelegate{outcome: sandboxes.StopOutcome{
+		Sandbox:       stopped,
+		Preparation:   sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationGraceful},
+		DriverStopped: true,
+	}}
+	handler := NewSandboxHandler(delegate, &gracefulStopAPIStore{sandbox: running}, nil, nil)
+	servicePath, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
+	mux := http.NewServeMux()
+	mux.Handle(servicePath, serviceHandler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewSandboxServiceClient(server.Client(), server.URL)
+
+	response, err := client.StopSandbox(context.Background(), connect.NewRequest(&agentcomposev2.StopSandboxRequest{
+		SandboxId:   sandboxID,
+		Mode:        agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL,
+		GracePeriod: durationpb.New(12 * time.Second),
+	}))
+	if err != nil {
+		t.Fatalf("StopSandbox() error = %v", err)
+	}
+	if response.Msg.GetOutcome() != agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL ||
+		response.Msg.GetSandbox().GetStatus() != agentcomposev2.SandboxStatus_SANDBOX_STATUS_STOPPED {
+		t.Fatalf("StopSandbox() response = %#v", response.Msg)
+	}
+	if delegate.sandboxID != sandboxID || delegate.options != (sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful, GracePeriod: 12 * time.Second}) {
+		t.Fatalf("delegate call = id %q options %#v", delegate.sandboxID, delegate.options)
+	}
+}
+
+type gracefulStopAPIDelegate struct {
+	outcome   sandboxes.StopOutcome
+	sandboxID string
+	options   sandboxes.StopOptions
+}
+
+func (*gracefulStopAPIDelegate) ResumeSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return nil, nil
+}
+
+func (*gracefulStopAPIDelegate) StopSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return nil, nil
+}
+
+func (*gracefulStopAPIDelegate) GetSandboxProxy(context.Context, string) (SandboxProxy, error) {
+	return SandboxProxy{}, nil
+}
+
+func (d *gracefulStopAPIDelegate) StopSandboxWithOptions(_ context.Context, sandboxID string, options sandboxes.StopOptions) (sandboxes.StopOutcome, error) {
+	d.sandboxID = sandboxID
+	d.options = options
+	return d.outcome, nil
+}
+
+type gracefulStopAPIStore struct {
+	sandbox *domain.Sandbox
+}
+
+func (s *gracefulStopAPIStore) GetSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return s.sandbox, nil
+}
+
+func (*gracefulStopAPIStore) RemoveSandbox(context.Context, string) error {
+	return nil
+}

--- a/pkg/agentcompose/api/sandbox_stop_options_test.go
+++ b/pkg/agentcompose/api/sandbox_stop_options_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"agent-compose/pkg/sandboxes"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestSandboxStopOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  *agentcomposev2.StopSandboxRequest
+		want     sandboxes.StopOptions
+		wantCode connect.Code
+	}{
+		{name: "unspecified remains force", request: &agentcomposev2.StopSandboxRequest{}, want: sandboxes.StopOptions{Mode: sandboxes.StopModeForce}},
+		{name: "explicit force", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE}, want: sandboxes.StopOptions{Mode: sandboxes.StopModeForce}},
+		{name: "graceful default", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL}, want: sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful}},
+		{name: "graceful request period", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL, GracePeriod: durationpb.New(12 * time.Second)}, want: sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful, GracePeriod: 12 * time.Second}},
+		{name: "force rejects grace period", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE, GracePeriod: durationpb.New(time.Second)}, wantCode: connect.CodeInvalidArgument},
+		{name: "rejects zero period", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL, GracePeriod: durationpb.New(0)}, wantCode: connect.CodeInvalidArgument},
+		{name: "rejects period above maximum", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL, GracePeriod: durationpb.New(maxSandboxGracePeriod + time.Second)}, wantCode: connect.CodeInvalidArgument},
+		{name: "rejects unknown mode", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode(99)}, wantCode: connect.CodeInvalidArgument},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := sandboxStopOptions(test.request)
+			if test.wantCode != 0 {
+				if connect.CodeOf(err) != test.wantCode {
+					t.Fatalf("sandboxStopOptions() error = %v, code = %s, want %s", err, connect.CodeOf(err), test.wantCode)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("sandboxStopOptions() = %#v, %v; want %#v", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestSandboxStopOutcomeToProto(t *testing.T) {
+	tests := map[sandboxes.StopPreparationOutcome]agentcomposev2.SandboxStopOutcome{
+		sandboxes.StopPreparationSkipped:  agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE,
+		sandboxes.StopPreparationGraceful: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL,
+		sandboxes.StopPreparationTimeout:  agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT,
+		sandboxes.StopPreparationFailed:   agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_ERROR,
+	}
+	for preparation, want := range tests {
+		got := sandboxStopOutcomeToProto(sandboxes.StopOutcome{Preparation: sandboxes.StopPreparationResult{Outcome: preparation}})
+		if got != want {
+			t.Fatalf("sandboxStopOutcomeToProto(%q) = %s, want %s", preparation, got, want)
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	JupyterGuestPort           int
 	SandboxStartTimeout        time.Duration
 	SandboxStopTimeout         time.Duration
+	SandboxGracefulStopTimeout time.Duration
 	JupyterReadyTimeout        time.Duration
 	JupyterProxyBasePath       string
 	CapGRPCListen              string
@@ -386,6 +387,16 @@ func NewConfig(di do.Injector) (*Config, error) {
 			stopTimeout = parsed
 		}
 	}
+	gracefulStopTimeout := 10 * time.Second
+	if raw := os.Getenv("SANDBOX_GRACEFUL_STOP_TIMEOUT"); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err != nil {
+			logger.Warn("failed to parse SANDBOX_GRACEFUL_STOP_TIMEOUT", "value", raw, "error", err)
+		} else if parsed <= 0 {
+			logger.Warn("SANDBOX_GRACEFUL_STOP_TIMEOUT must be positive", "value", raw)
+		} else {
+			gracefulStopTimeout = parsed
+		}
+	}
 
 	jupyterReadyTimeout := 30 * time.Second
 	if raw := os.Getenv("JUPYTER_READY_TIMEOUT"); raw != "" {
@@ -539,6 +550,7 @@ func NewConfig(di do.Injector) (*Config, error) {
 		JupyterGuestPort:           jupyterGuestPort,
 		SandboxStartTimeout:        startTimeout,
 		SandboxStopTimeout:         stopTimeout,
+		SandboxGracefulStopTimeout: gracefulStopTimeout,
 		JupyterReadyTimeout:        jupyterReadyTimeout,
 		JupyterProxyBasePath:       jupyterProxyBase,
 		CapGRPCListen:              strings.TrimSpace(os.Getenv("CAP_GRPC_LISTEN")),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -132,6 +132,23 @@ func TestNewConfigDefaultsSandboxArchiveRootWithoutChangingWorkspaceCleanupTTL(t
 	if config.SandboxArchiveRoot != filepath.Join(config.DataRoot, "archives", "sandboxes") {
 		t.Fatalf("SandboxArchiveRoot = %q", config.SandboxArchiveRoot)
 	}
+	if config.SandboxGracefulStopTimeout != 10*time.Second {
+		t.Fatalf("SandboxGracefulStopTimeout = %s, want 10s", config.SandboxGracefulStopTimeout)
+	}
+}
+
+func TestNewConfigRejectsNonPositiveSandboxGracefulStopTimeout(t *testing.T) {
+	t.Setenv("DATA_ROOT", filepath.Join(t.TempDir(), "data"))
+	t.Setenv("SANDBOX_GRACEFUL_STOP_TIMEOUT", "0s")
+	di := do.New()
+	do.ProvideValue(di, slog.Default())
+	config, err := NewConfig(di)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.SandboxGracefulStopTimeout != 10*time.Second {
+		t.Fatalf("SandboxGracefulStopTimeout = %s, want 10s fallback", config.SandboxGracefulStopTimeout)
+	}
 }
 
 func testNewConfigParsesEnvironment(t *testing.T) {
@@ -173,6 +190,7 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	t.Setenv("JUPYTER_PROXY_BASE", "/agent-compose/jupyter/")
 	t.Setenv("SANDBOX_START_TIMEOUT", "9s")
 	t.Setenv("SANDBOX_STOP_TIMEOUT", "10s")
+	t.Setenv("SANDBOX_GRACEFUL_STOP_TIMEOUT", "12s")
 	t.Setenv("JUPYTER_READY_TIMEOUT", "45s")
 	t.Setenv("WEBHOOK_BODY_LIMIT_BYTES", "1234")
 	t.Setenv("WEBHOOK_QUEUE_RULES_JSON", `[{"name":"repo-a","workers":2,"match":{"topic":"webhook.github.push"}}]`)
@@ -216,7 +234,7 @@ func testNewConfigParsesEnvironment(t *testing.T) {
 	if config.ImageStoreMode != ImageStoreModeOCI || config.ImageCacheRoot != filepath.Join(root, "custom-images") {
 		t.Fatalf("image store config = %#v", config)
 	}
-	if config.JupyterGuestPort != 9999 || config.SandboxStartTimeout != 9*time.Second || config.SandboxStopTimeout != 10*time.Second {
+	if config.JupyterGuestPort != 9999 || config.SandboxStartTimeout != 9*time.Second || config.SandboxStopTimeout != 10*time.Second || config.SandboxGracefulStopTimeout != 12*time.Second {
 		t.Fatalf("session config = %#v", config)
 	}
 	if config.JupyterReadyTimeout != 45*time.Second {

--- a/pkg/driver/boxlite_guest_runtime_signal.go
+++ b/pkg/driver/boxlite_guest_runtime_signal.go
@@ -1,0 +1,39 @@
+//go:build linux && cgo && boxlitecgo
+
+package driver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// SignalGuestRuntime sends a signal through a short BoxLite control exec. It uses
+// a separately attached box handle so signaling can proceed concurrently with
+// the execution being stopped.
+func (r *cgoSandboxRuntime) SignalGuestRuntime(ctx context.Context, _ *Sandbox, vmState VMState, executionID string, signal RuntimeSignal) error {
+	command, err := guestRuntimeSignalCommand(executionID, signal)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(vmState.BoxID) == "" {
+		return ErrGuestRuntimeGone
+	}
+	box, err := r.getBox(ctx, vmState.BoxID)
+	if err != nil {
+		return fmt.Errorf("attach BoxLite guest runtime signal control: %w", err)
+	}
+	defer box.free()
+	info, err := r.boxInfo(box)
+	if err != nil {
+		return err
+	}
+	if !info.State.Running {
+		return ErrGuestRuntimeGone
+	}
+	result, err := r.executeBox(ctx, box, ExecSpec{Command: command[0], Args: command[1:], Cwd: "/"}, nil)
+	if err != nil {
+		return fmt.Errorf("run BoxLite guest runtime signal control: %w", err)
+	}
+	return guestRuntimeSignalExitError(result.ExitCode)
+}

--- a/pkg/driver/docker_exec_lifecycle.go
+++ b/pkg/driver/docker_exec_lifecycle.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	dockerExecMarkerEnv = "AGENT_COMPOSE_INTERNAL_EXECUTION_ID"
+	dockerExecMarkerEnv = "AGENT_COMPOSE_INTERNAL_DOCKER_EXEC_ID"
 )
 
 // Docker has no kill-exec API. Every exec therefore carries a driver-owned

--- a/pkg/driver/docker_guest_runtime_signal.go
+++ b/pkg/driver/docker_guest_runtime_signal.go
@@ -1,0 +1,51 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+
+	containerapi "github.com/docker/docker/api/types/container"
+)
+
+// SignalGuestRuntime sends a signal to one ready guest runtime through a Docker
+// control exec that is independent of the execution being stopped.
+func (r *dockerRuntime) SignalGuestRuntime(ctx context.Context, sandbox *Sandbox, vmState VMState, executionID string, signal RuntimeSignal) error {
+	command, err := guestRuntimeSignalCommand(executionID, signal)
+	if err != nil {
+		return err
+	}
+	dockerClient, err := r.newClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dockerClient.Close() }()
+	containerInfo, ok, err := r.findContainer(ctx, dockerClient, sandbox, vmState)
+	if err != nil {
+		return err
+	}
+	if !ok || containerInfo.State == nil || !containerInfo.State.Running {
+		return ErrGuestRuntimeGone
+	}
+	control, err := dockerClient.ContainerExecCreate(ctx, containerInfo.ID, containerapi.ExecOptions{
+		AttachStdout: true,
+		AttachStderr: true,
+		Cmd:          command,
+		User:         "0",
+		WorkingDir:   "/",
+	})
+	if err != nil {
+		return fmt.Errorf("create Docker guest runtime signal control: %w", err)
+	}
+	attach, err := dockerClient.ContainerExecAttach(ctx, control.ID, containerapi.ExecAttachOptions{})
+	if err != nil {
+		return fmt.Errorf("start Docker guest runtime signal control %s: %w", control.ID, err)
+	}
+	if err := drainDockerControlExec(attach); err != nil {
+		return fmt.Errorf("read Docker guest runtime signal control %s: %w", control.ID, err)
+	}
+	controlInfo, err := r.waitForExecExit(ctx, dockerClient, control.ID)
+	if err != nil {
+		return fmt.Errorf("wait for Docker guest runtime signal control %s: %w", control.ID, err)
+	}
+	return guestRuntimeSignalExitError(controlInfo.ExitCode)
+}

--- a/pkg/driver/docker_runtime_test.go
+++ b/pkg/driver/docker_runtime_test.go
@@ -178,9 +178,10 @@ func TestDockerCommandExecOptionsNonTTYAttachesStderr(t *testing.T) {
 }
 
 func TestDockerExecEnvMarkerIsDriverOwnedAndIsolatesExecutions(t *testing.T) {
-	first := dockerExecEnvWithMarker([]string{"B=2", dockerExecMarkerEnv + "=caller", "A=1"}, "exec-1")
+	guestRuntimeID := executionIDEnv + "=guest-runtime-1"
+	first := dockerExecEnvWithMarker([]string{"B=2", dockerExecMarkerEnv + "=caller", guestRuntimeID, "A=1"}, "exec-1")
 	second := dockerExecEnvWithMarker([]string{"A=1"}, "exec-2")
-	if !reflect.DeepEqual(first, []string{"A=1", dockerExecMarkerEnv + "=exec-1", "B=2"}) {
+	if !reflect.DeepEqual(first, []string{"A=1", dockerExecMarkerEnv + "=exec-1", guestRuntimeID, "B=2"}) {
 		t.Fatalf("first marked env = %#v", first)
 	}
 	if !reflect.DeepEqual(second, []string{"A=1", dockerExecMarkerEnv + "=exec-2"}) {

--- a/pkg/driver/guest_runtime_signal.go
+++ b/pkg/driver/guest_runtime_signal.go
@@ -1,0 +1,106 @@
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	executionIDEnv        = "AGENT_COMPOSE_INTERNAL_EXECUTION_ID"
+	executionReadyFileEnv = "AGENT_COMPOSE_INTERNAL_EXECUTION_READY_FILE"
+	guestRuntimeReadyRoot = "/tmp/agent-compose-runtime-ready"
+)
+
+const guestRuntimeSignalScript = `
+ready_file=$1
+execution_id=$2
+signal=$3
+[ -r "$ready_file" ] || exit 75
+pid=$(cat "$ready_file" 2>/dev/null) || exit 75
+case $pid in
+  ''|*[!0-9]*) exit 75 ;;
+esac
+environ=/proc/$pid/environ
+[ -r "$environ" ] || exit 76
+tr '\000' '\n' <"$environ" 2>/dev/null | grep -Fqx 'AGENT_COMPOSE_INTERNAL_EXECUTION_ID='"$execution_id" || exit 76
+exe=$(readlink "/proc/$pid/exe" 2>/dev/null) || exit 76
+case ${exe##*/} in
+  node|nodejs) ;;
+  *) exit 76 ;;
+esac
+tr '\000' '\n' <"/proc/$pid/cmdline" 2>/dev/null | grep -Fq agent-compose-runtime || exit 76
+kill "-$signal" "$pid" 2>/dev/null || exit 76
+`
+
+var (
+	// ErrGuestRuntimeNotReady means the guest runtime has not installed its
+	// signal handler and published its PID yet.
+	ErrGuestRuntimeNotReady = errors.New("guest runtime is not ready for signals")
+	// ErrGuestRuntimeGone means the ready file no longer identifies the
+	// tracked agent-compose-runtime process.
+	ErrGuestRuntimeGone = errors.New("guest runtime is no longer running")
+)
+
+func guestRuntimeSignalCommand(executionID string, signal RuntimeSignal) ([]string, error) {
+	executionID = strings.TrimSpace(executionID)
+	if _, err := uuid.Parse(executionID); err != nil {
+		return nil, fmt.Errorf("guest runtime execution ID is invalid")
+	}
+	signalName, err := guestRuntimeSignalName(signal)
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		"sh",
+		"-c",
+		guestRuntimeSignalScript,
+		"agent-compose-execution-signal",
+		path.Join(guestRuntimeReadyRoot, executionID),
+		executionID,
+		signalName,
+	}, nil
+}
+
+// GuestRuntimeControlEnv copies env and installs the private host/guest runtime
+// identity used by graceful-stop control operations.
+func GuestRuntimeControlEnv(env map[string]string, executionID string) map[string]string {
+	marked := make(map[string]string, len(env)+2)
+	for name, value := range env {
+		if name != executionIDEnv && name != executionReadyFileEnv {
+			marked[name] = value
+		}
+	}
+	marked[executionIDEnv] = executionID
+	marked[executionReadyFileEnv] = path.Join(guestRuntimeReadyRoot, executionID)
+	return marked
+}
+
+func guestRuntimeSignalName(signal RuntimeSignal) (string, error) {
+	switch signal {
+	case RuntimeSignalInterrupt:
+		return "INT", nil
+	case RuntimeSignalTerminate:
+		return "TERM", nil
+	case RuntimeSignalKill:
+		return "KILL", nil
+	default:
+		return "", fmt.Errorf("unsupported guest runtime signal %q", signal)
+	}
+}
+
+func guestRuntimeSignalExitError(exitCode int) error {
+	switch exitCode {
+	case 0:
+		return nil
+	case 75:
+		return ErrGuestRuntimeNotReady
+	case 76:
+		return ErrGuestRuntimeGone
+	default:
+		return fmt.Errorf("guest runtime signal control exited with code %d", exitCode)
+	}
+}

--- a/pkg/driver/guest_runtime_signal_integration_test.go
+++ b/pkg/driver/guest_runtime_signal_integration_test.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestIntegrationGuestRuntimeSignalRequiresExactRuntimeReadiness(t *testing.T) {
+	executionID := uuid.NewString()
+	readyFile := filepath.Join(guestRuntimeReadyRoot, executionID)
+	if err := os.MkdirAll(filepath.Dir(readyFile), 0o700); err != nil {
+		t.Fatalf("create readiness root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(readyFile) })
+
+	testRoot := t.TempDir()
+	nodePath := filepath.Join(testRoot, "node")
+	shell, err := os.ReadFile("/bin/sh")
+	if err != nil {
+		t.Fatalf("read shell executable: %v", err)
+	}
+	if err := os.WriteFile(nodePath, shell, 0o755); err != nil {
+		t.Fatalf("create node-named test process: %v", err)
+	}
+	startedPath := filepath.Join(testRoot, "started")
+	installHandlerPath := filepath.Join(testRoot, "install-handler")
+	handledPath := filepath.Join(testRoot, "handled")
+	process := exec.Command(nodePath, "-c", testGuestRuntimeProcessScript, "agent-compose-runtime", startedPath, installHandlerPath, handledPath, readyFile)
+	controlEnv := GuestRuntimeControlEnv(map[string]string{
+		"PATH":                os.Getenv("PATH"),
+		executionIDEnv:        "stale-execution-id",
+		executionReadyFileEnv: "/tmp/stale-ready-file",
+	}, executionID)
+	process.Env = make([]string, 0, len(controlEnv))
+	for name, value := range controlEnv {
+		process.Env = append(process.Env, name+"="+value)
+	}
+	if err := process.Start(); err != nil {
+		t.Fatalf("start node-named test process: %v", err)
+	}
+	processDone := make(chan error, 1)
+	go func() { processDone <- process.Wait() }()
+	waited := false
+	t.Cleanup(func() {
+		if waited {
+			return
+		}
+		_ = process.Process.Kill()
+		<-processDone
+	})
+	waitForGuestRuntimeTestFile(t, startedPath)
+
+	if err := os.WriteFile(readyFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write stale runtime readiness: %v", err)
+	}
+	if err := runGuestRuntimeSignalCommand(executionID); !errors.Is(err, ErrGuestRuntimeGone) {
+		t.Fatalf("stale runtime readiness error = %v, want ErrGuestRuntimeGone", err)
+	}
+	if err := os.Remove(readyFile); err != nil {
+		t.Fatalf("remove stale runtime readiness: %v", err)
+	}
+	if err := runGuestRuntimeSignalCommand(executionID); !errors.Is(err, ErrGuestRuntimeNotReady) {
+		t.Fatalf("signal before runtime readiness error = %v, want ErrGuestRuntimeNotReady", err)
+	}
+	select {
+	case err := <-processDone:
+		waited = true
+		t.Fatalf("managed execution exited before installing SIGTERM handler: %v", err)
+	default:
+	}
+	if err := os.WriteFile(installHandlerPath, []byte("install"), 0o600); err != nil {
+		t.Fatalf("request SIGTERM handler installation: %v", err)
+	}
+	waitForGuestRuntimeTestFile(t, readyFile)
+
+	if err := runGuestRuntimeSignalCommand(executionID); err != nil {
+		t.Fatalf("signal ready managed execution: %v", err)
+	}
+	select {
+	case err := <-processDone:
+		waited = true
+		if err != nil {
+			t.Fatalf("managed execution exit after SIGTERM: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("managed execution did not handle SIGTERM")
+	}
+	if _, err := os.Stat(handledPath); err != nil {
+		t.Fatalf("SIGTERM handler result: %v", err)
+	}
+}
+
+func runGuestRuntimeSignalCommand(executionID string) error {
+	command, err := guestRuntimeSignalCommand(executionID, RuntimeSignalTerminate)
+	if err != nil {
+		return err
+	}
+	err = exec.CommandContext(context.Background(), command[0], command[1:]...).Run()
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return guestRuntimeSignalExitError(exitErr.ExitCode())
+	}
+	return err
+}
+
+func waitForGuestRuntimeTestFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("wait for %s: %v", filepath.Base(path), err)
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %s", filepath.Base(path))
+		case <-ticker.C:
+		}
+	}
+}
+
+const testGuestRuntimeProcessScript = `
+printf started >"$1"
+while [ ! -e "$2" ]; do sleep 0.01; done
+trap 'printf handled >"$3"; exit 0' TERM
+printf '%s' "$$" >"$4"
+while :; do sleep 1; done
+`

--- a/pkg/driver/guest_runtime_signal_test.go
+++ b/pkg/driver/guest_runtime_signal_test.go
@@ -1,0 +1,61 @@
+package driver
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+const guestRuntimeSignalTestID = "9a497cd5-d990-46db-a01c-13bbed138c30"
+
+func TestGuestRuntimeControlEnvCopiesAndReplacesPrivateValues(t *testing.T) {
+	input := map[string]string{
+		"USER_VALUE":          "preserved",
+		executionIDEnv:        "caller-id",
+		executionReadyFileEnv: "/caller/path",
+	}
+	got := GuestRuntimeControlEnv(input, guestRuntimeSignalTestID)
+	want := map[string]string{
+		"USER_VALUE":          "preserved",
+		executionIDEnv:        guestRuntimeSignalTestID,
+		executionReadyFileEnv: guestRuntimeReadyRoot + "/" + guestRuntimeSignalTestID,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GuestRuntimeControlEnv() = %#v, want %#v", got, want)
+	}
+	got["USER_VALUE"] = "changed"
+	if input["USER_VALUE"] != "preserved" {
+		t.Fatal("GuestRuntimeControlEnv() mutated caller-owned input")
+	}
+}
+
+func TestGuestRuntimeSignalCommandTargetsOneReadyFile(t *testing.T) {
+	command, err := guestRuntimeSignalCommand(guestRuntimeSignalTestID, RuntimeSignalTerminate)
+	if err != nil {
+		t.Fatalf("guestRuntimeSignalCommand() error = %v", err)
+	}
+	if len(command) != 7 || command[0] != "sh" || command[4] != guestRuntimeReadyRoot+"/"+guestRuntimeSignalTestID || command[5] != guestRuntimeSignalTestID || command[6] != "TERM" {
+		t.Fatalf("guestRuntimeSignalCommand() = %#v", command)
+	}
+	if _, err := guestRuntimeSignalCommand("../escape", RuntimeSignalTerminate); err == nil {
+		t.Fatal("guestRuntimeSignalCommand() accepted a path-like execution ID")
+	}
+	if _, err := guestRuntimeSignalCommand(guestRuntimeSignalTestID, RuntimeSignal("unknown")); err == nil {
+		t.Fatal("guestRuntimeSignalCommand() accepted an unknown signal")
+	}
+}
+
+func TestGuestRuntimeSignalExitErrorClassifiesRetryAndGone(t *testing.T) {
+	if err := guestRuntimeSignalExitError(0); err != nil {
+		t.Fatalf("guestRuntimeSignalExitError(0) = %v", err)
+	}
+	if err := guestRuntimeSignalExitError(75); !errors.Is(err, ErrGuestRuntimeNotReady) {
+		t.Fatalf("guestRuntimeSignalExitError(75) = %v", err)
+	}
+	if err := guestRuntimeSignalExitError(76); !errors.Is(err, ErrGuestRuntimeGone) {
+		t.Fatalf("guestRuntimeSignalExitError(76) = %v", err)
+	}
+	if err := guestRuntimeSignalExitError(2); err == nil {
+		t.Fatal("guestRuntimeSignalExitError(2) returned nil")
+	}
+}

--- a/pkg/driver/microsandbox_guest_runtime_signal.go
+++ b/pkg/driver/microsandbox_guest_runtime_signal.go
@@ -1,0 +1,36 @@
+//go:build linux && cgo && microsandboxcgo
+
+package driver
+
+import (
+	"context"
+	"fmt"
+
+	microsandbox "github.com/superradcompany/microsandbox/sdk/go"
+)
+
+// SignalGuestRuntime sends a signal through a short Microsandbox control exec. It
+// intentionally does not retain or manage the execution's process tree.
+func (r *microsandboxRuntime) SignalGuestRuntime(ctx context.Context, session *Sandbox, vmState VMState, executionID string, signal RuntimeSignal) error {
+	command, err := guestRuntimeSignalCommand(executionID, signal)
+	if err != nil {
+		return err
+	}
+	if err := r.ensureReady(ctx); err != nil {
+		return err
+	}
+	name := r.sandboxName(session, vmState)
+	sandbox, err := r.connectSandbox(ctx, session, vmState, false)
+	if err != nil {
+		return fmt.Errorf("connect Microsandbox guest runtime signal control: %w", err)
+	}
+	defer r.releaseSandboxHandle(name, sandbox)
+	output, err := sandbox.Exec(ctx, command[0], command[1:], microsandbox.WithExecCwd("/"))
+	if err != nil {
+		return fmt.Errorf("run Microsandbox guest runtime signal control: %w", err)
+	}
+	if output == nil {
+		return fmt.Errorf("run Microsandbox guest runtime signal control: empty result")
+	}
+	return guestRuntimeSignalExitError(output.ExitCode())
+}

--- a/pkg/execution/parse.go
+++ b/pkg/execution/parse.go
@@ -50,6 +50,12 @@ func ParseAgentExecResult(agent string, result domain.ExecResult) (domain.AgentR
 	}
 	finalText := strings.TrimSpace(payload.FinalText)
 	transcript := strings.TrimSpace(payload.Transcript)
+	exitCode := result.ExitCode
+	success := result.Success
+	if strings.EqualFold(strings.TrimSpace(payload.StopReason), "cancelled") {
+		exitCode = FirstNonZeroInt(exitCode, 1)
+		success = false
+	}
 	return domain.AgentRunResult{
 		Agent:           firstNonEmpty(strings.TrimSpace(payload.Provider), domain.NormalizeAgentKind(agent)),
 		DisplayOutput:   humanOutput,
@@ -59,8 +65,8 @@ func ParseAgentExecResult(agent string, result domain.ExecResult) (domain.AgentR
 		Transcript:      transcript,
 		ThreadID:        strings.TrimSpace(payload.ThreadID),
 		StopReason:      strings.TrimSpace(payload.StopReason),
-		ExitCode:        result.ExitCode,
-		Success:         result.Success,
+		ExitCode:        exitCode,
+		Success:         success,
 	}, nil
 }
 

--- a/pkg/execution/parse_coverage_test.go
+++ b/pkg/execution/parse_coverage_test.go
@@ -79,6 +79,20 @@ func TestParseAgentExecResultClassifiesFinalTextFallback(t *testing.T) {
 	}
 }
 
+func TestParseAgentExecResultClassifiesCancelledResultAsUnsuccessful(t *testing.T) {
+	result, err := ParseAgentExecResult("codex", domain.ExecResult{
+		Stdout:   AgentResultPrefix + `{"provider":"codex","threadId":"thread-1","stopReason":"cancelled","finalText":"partial","transcript":"partial"}`,
+		ExitCode: 0,
+		Success:  true,
+	})
+	if err != nil {
+		t.Fatalf("ParseAgentExecResult() error = %v", err)
+	}
+	if result.Success || result.ExitCode == 0 || result.StopReason != "cancelled" || result.FinalText != "partial" || result.ThreadID != "thread-1" {
+		t.Fatalf("ParseAgentExecResult() = %#v", result)
+	}
+}
+
 func TestSummarizeAgentExecFailurePreservesUTF8(t *testing.T) {
 	detail := SummarizeAgentExecFailure(domain.ExecResult{Stderr: strings.Repeat("界", 241)})
 	if !strings.HasSuffix(detail, "...") {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1043,10 +1043,10 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 					if result.ExitCode != 0 || !result.Success {
 						promptTransition.ExitCode = execution.FirstNonZeroInt(result.ExitCode, promptTransition.ExitCode)
 						promptTransition.Error = firstNonEmpty(promptTransition.Error, result.Error, "agent execution failed")
-						return *promptTransition, errors.New(promptTransition.Error)
+						return *promptTransition, promptWrapperTransitionError(*promptTransition)
 					}
 					if promptTransition.ExitCode != 0 || strings.TrimSpace(promptTransition.Error) != "" {
-						return *promptTransition, errors.New(firstNonEmpty(promptTransition.Error, "agent execution failed"))
+						return *promptTransition, promptWrapperTransitionError(*promptTransition)
 					}
 					return *promptTransition, nil
 				}
@@ -1105,10 +1105,10 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 				if result.ExitCode != 0 || !result.Success {
 					promptTransition.ExitCode = execution.FirstNonZeroInt(result.ExitCode, promptTransition.ExitCode)
 					promptTransition.Error = firstNonEmpty(promptTransition.Error, result.Error, "agent execution failed")
-					return *promptTransition, errors.New(promptTransition.Error)
+					return *promptTransition, promptWrapperTransitionError(*promptTransition)
 				}
 				if promptTransition.ExitCode != 0 || strings.TrimSpace(promptTransition.Error) != "" {
-					return *promptTransition, errors.New(firstNonEmpty(promptTransition.Error, "agent execution failed"))
+					return *promptTransition, promptWrapperTransitionError(*promptTransition)
 				}
 				return *promptTransition, nil
 			}
@@ -1331,6 +1331,13 @@ func transitionFromPromptWrapperResult(run domain.ProjectRunRecord, sandbox *dom
 		transition.Error = "agent execution cancelled"
 	}
 	return transition
+}
+
+func promptWrapperTransitionError(transition TransitionRequest) error {
+	if strings.EqualFold(strings.TrimSpace(transition.Error), "agent execution cancelled") {
+		return context.Canceled
+	}
+	return errors.New(firstNonEmpty(transition.Error, "agent execution failed"))
 }
 
 func transitionFromPromptRuntimeResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, logsPath string, result driverpkg.RuntimeResult, execErr error) TransitionRequest {

--- a/pkg/sandboxes/graceful_stop_integration_test.go
+++ b/pkg/sandboxes/graceful_stop_integration_test.go
@@ -1,0 +1,172 @@
+package sandboxes
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+)
+
+func TestIntegrationLifecycleGracefulStopPreparesBeforeDriverStop(t *testing.T) {
+	sandbox := lifecycleTestSession("sandbox-graceful", "docker", domain.VMStatusRunning)
+	vmState := domain.VMState{BoxID: "container-1"}
+	store := &fakeLifecycleStore{session: sandbox, vmState: vmState}
+	driver := &gracefulLifecycleDriver{order: []string{}}
+	lifecycle := Lifecycle{
+		Config: &appconfig.Config{SandboxGracefulStopTimeout: 7 * time.Second},
+		Store:  store,
+		Driver: driver,
+		Locks:  NewLifecycleLocks(),
+	}
+
+	outcome, err := lifecycle.StopLoadedWithOptions(context.Background(), sandbox, StopOptions{Mode: StopModeGraceful})
+	if err != nil {
+		t.Fatalf("StopLoadedWithOptions() error = %v", err)
+	}
+	if outcome.Preparation.Outcome != StopPreparationGraceful || !outcome.DriverStopped {
+		t.Fatalf("StopLoadedWithOptions() outcome = %#v", outcome)
+	}
+	if driver.gracePeriod != 7*time.Second || driver.vmState != vmState {
+		t.Fatalf("preparation grace period/state = %s/%#v", driver.gracePeriod, driver.vmState)
+	}
+	if got, want := driver.order, []string{"prepare", "stop", "finish"}; !slices.Equal(got, want) {
+		t.Fatalf("driver call order = %v, want %v", got, want)
+	}
+}
+
+func TestIntegrationLifecycleForceStopInitiatesBeforeDriverStop(t *testing.T) {
+	sandbox := lifecycleTestSession("sandbox-force", "docker", domain.VMStatusRunning)
+	driver := &gracefulLifecycleDriver{order: []string{}}
+	lifecycle := Lifecycle{
+		Store:  &fakeLifecycleStore{session: sandbox},
+		Driver: driver,
+		Locks:  NewLifecycleLocks(),
+	}
+
+	outcome, err := lifecycle.StopLoaded(context.Background(), sandbox)
+	if err != nil {
+		t.Fatalf("StopLoaded() error = %v", err)
+	}
+	if outcome.Preparation.Outcome != StopPreparationSkipped || !outcome.DriverStopped {
+		t.Fatalf("StopLoaded() outcome = %#v", outcome)
+	}
+	if got, want := driver.order, []string{"begin-force", "stop", "finish"}; !slices.Equal(got, want) {
+		t.Fatalf("driver call order = %v, want %v", got, want)
+	}
+}
+
+func TestIntegrationLifecycleLockedStopFinalizesAfterDriverFailure(t *testing.T) {
+	stopErr := errors.New("transient runtime stop failure")
+	sandbox := lifecycleTestSession("sandbox-locked", "docker", domain.VMStatusRunning)
+	driver := &gracefulLifecycleDriver{order: []string{}, stopErr: stopErr}
+	lifecycle := Lifecycle{
+		Store:  &fakeLifecycleStore{session: sandbox},
+		Driver: driver,
+	}
+
+	_, err := lifecycle.StopLoadedWhileLocked(context.Background(), sandbox)
+	if !errors.Is(err, stopErr) {
+		t.Fatalf("StopLoadedWhileLocked() error = %v, want %v", err, stopErr)
+	}
+	if got, want := driver.order, []string{"begin-force", "stop", "finish"}; !slices.Equal(got, want) {
+		t.Fatalf("driver call order = %v, want %v", got, want)
+	}
+}
+
+func TestIntegrationLifecycleGracefulPreparationFailureDoesNotFinalize(t *testing.T) {
+	loadErr := errors.New("load VM state")
+	sandbox := lifecycleTestSession("sandbox-preparation-failure", "docker", domain.VMStatusRunning)
+	driver := &gracefulLifecycleDriver{order: []string{}}
+	lifecycle := Lifecycle{
+		Store:  &fakeLifecycleStore{session: sandbox, vmStateErr: loadErr},
+		Driver: driver,
+		Locks:  NewLifecycleLocks(),
+	}
+
+	_, err := lifecycle.StopLoadedWithOptions(context.Background(), sandbox, StopOptions{Mode: StopModeGraceful})
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("StopLoadedWithOptions() error = %v, want %v", err, loadErr)
+	}
+	if len(driver.order) != 0 {
+		t.Fatalf("driver calls = %v, want none", driver.order)
+	}
+}
+
+func TestIntegrationLifecycleGracefulStopUsesDaemonContextAfterCancellation(t *testing.T) {
+	sandbox := lifecycleTestSession("sandbox-cancelled", "docker", domain.VMStatusRunning)
+	ctx, cancel := context.WithCancel(context.Background())
+	driver := &cancelDuringGracefulPreparationDriver{
+		gracefulLifecycleDriver: gracefulLifecycleDriver{order: []string{}},
+		cancel:                  cancel,
+	}
+	lifecycle := Lifecycle{
+		Config: &appconfig.Config{SandboxStopTimeout: time.Second},
+		Store:  &fakeLifecycleStore{session: sandbox},
+		Driver: driver,
+		Locks:  NewLifecycleLocks(),
+	}
+
+	outcome, err := lifecycle.StopLoadedWithOptions(ctx, sandbox, StopOptions{Mode: StopModeGraceful})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StopLoadedWithOptions() error = %v, want request cancellation", err)
+	}
+	if !outcome.DriverStopped || driver.stopCtxErr != nil {
+		t.Fatalf("stop outcome/context = %#v/%v, want stopped with a live daemon context", outcome, driver.stopCtxErr)
+	}
+}
+
+type cancelDuringGracefulPreparationDriver struct {
+	gracefulLifecycleDriver
+	cancel     context.CancelFunc
+	stopCtxErr error
+}
+
+func (d *cancelDuringGracefulPreparationDriver) PrepareSandboxStop(context.Context, *domain.Sandbox, domain.VMState, time.Duration) (StopPreparationResult, error) {
+	d.order = append(d.order, "prepare")
+	d.cancel()
+	return StopPreparationResult{Outcome: StopPreparationFailed, Error: context.Canceled}, nil
+}
+
+func (d *cancelDuringGracefulPreparationDriver) StopSandboxVM(ctx context.Context, session *domain.Sandbox) error {
+	d.stopCtxErr = ctx.Err()
+	if d.stopCtxErr != nil {
+		return d.stopCtxErr
+	}
+	return d.gracefulLifecycleDriver.StopSandboxVM(ctx, session)
+}
+
+type gracefulLifecycleDriver struct {
+	order       []string
+	vmState     domain.VMState
+	gracePeriod time.Duration
+	stopErr     error
+}
+
+func (d *gracefulLifecycleDriver) StartSandboxVM(context.Context, *domain.Sandbox) error {
+	return nil
+}
+
+func (d *gracefulLifecycleDriver) StopSandboxVM(context.Context, *domain.Sandbox) error {
+	d.order = append(d.order, "stop")
+	return d.stopErr
+}
+
+func (d *gracefulLifecycleDriver) PrepareSandboxStop(_ context.Context, _ *domain.Sandbox, vmState domain.VMState, gracePeriod time.Duration) (StopPreparationResult, error) {
+	d.order = append(d.order, "prepare")
+	d.vmState = vmState
+	d.gracePeriod = gracePeriod
+	return StopPreparationResult{Outcome: StopPreparationGraceful}, nil
+}
+
+func (d *gracefulLifecycleDriver) BeginSandboxForceStop(*domain.Sandbox) error {
+	d.order = append(d.order, "begin-force")
+	return nil
+}
+
+func (d *gracefulLifecycleDriver) FinishSandboxStop(*domain.Sandbox) {
+	d.order = append(d.order, "finish")
+}

--- a/pkg/sandboxes/lifecycle.go
+++ b/pkg/sandboxes/lifecycle.go
@@ -28,6 +28,18 @@ type SandboxDriver interface {
 	StopSandboxVM(context.Context, *domain.Sandbox) error
 }
 
+type SandboxStopPreparer interface {
+	PrepareSandboxStop(context.Context, *domain.Sandbox, domain.VMState, time.Duration) (StopPreparationResult, error)
+}
+
+type SandboxForceStopInitiator interface {
+	BeginSandboxForceStop(*domain.Sandbox) error
+}
+
+type SandboxStopFinalizer interface {
+	FinishSandboxStop(*domain.Sandbox)
+}
+
 type SandboxRuntimeValidator interface {
 	ValidateSandboxRuntime(*domain.Sandbox) error
 }
@@ -284,7 +296,10 @@ type StopOutcome struct {
 	Sandbox         *domain.Sandbox
 	DriverStopped   bool
 	RuntimeReleased bool
+	Preparation     StopPreparationResult
 }
+
+const defaultSandboxForceStopTimeout = 30 * time.Second
 
 // Changed reports whether the driver was stopped or its private runtime was
 // released by this operation.
@@ -296,15 +311,90 @@ func (o StopOutcome) Changed() bool {
 // sandbox, including policy application, persistence, events, and access
 // revocation.
 func (l Lifecycle) StopLoaded(ctx context.Context, session *domain.Sandbox) (StopOutcome, error) {
+	return l.StopLoadedWithOptions(ctx, session, StopOptions{Mode: StopModeForce})
+}
+
+func (l Lifecycle) StopLoadedWithOptions(ctx context.Context, session *domain.Sandbox, options StopOptions) (StopOutcome, error) {
 	if session == nil {
 		return StopOutcome{}, fmt.Errorf("sandbox is required")
 	}
+	finalizer, canFinalize := l.Driver.(SandboxStopFinalizer)
+	stopAcquired := false
+	defer func() {
+		if stopAcquired && canFinalize {
+			finalizer.FinishSandboxStop(session)
+		}
+	}()
+	preparation := StopPreparationResult{Outcome: StopPreparationSkipped}
+	stopCtx := ctx
+	if options.Mode == StopModeGraceful {
+		prepared, err := l.prepareSandboxStop(ctx, session, options.GracePeriod)
+		if err != nil {
+			return StopOutcome{}, err
+		}
+		preparation = prepared
+		stopAcquired = true
+		// Graceful preparation is request-scoped, but runtime containment must
+		// complete even when that request is cancelled. Keep the request's
+		// values for logging/tracing while removing its cancellation and
+		// deadline, then apply the daemon-owned stop timeout.
+		stopTimeout := defaultSandboxForceStopTimeout
+		if l.Config != nil && l.Config.SandboxStopTimeout > 0 {
+			stopTimeout = l.Config.SandboxStopTimeout
+		}
+		runtimeDriver := session.Summary.Driver
+		if runtimeDriver == "" && l.Config != nil {
+			runtimeDriver = l.Config.RuntimeDriver
+		}
+		stopTimeout = driverpkg.SandboxStopContextTimeout(runtimeDriver, stopTimeout)
+		var cancel context.CancelFunc
+		stopCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), stopTimeout)
+		defer cancel()
+	} else if initiator, ok := l.Driver.(SandboxForceStopInitiator); ok {
+		// Exec handlers hold the same lifecycle lock while guest work is active.
+		// Cancellation must therefore start before waiting for that lock; the
+		// locked stop path remains the boundary that waits and stops the runtime.
+		if err := initiator.BeginSandboxForceStop(session); err != nil {
+			return StopOutcome{}, err
+		}
+		stopAcquired = true
+	} else {
+		stopAcquired = true
+	}
 	if l.Locks == nil {
-		return l.stopLoadedWhileLocked(ctx, session)
+		outcome, err := l.stopLoadedWhileLocked(stopCtx, session)
+		outcome.Preparation = preparation
+		if err == nil && ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		return outcome, err
 	}
 	unlock := l.Locks.Lock(session.Summary.ID)
 	defer unlock()
-	return l.stopLoadedWhileLocked(ctx, session)
+	outcome, err := l.stopLoadedWhileLocked(stopCtx, session)
+	outcome.Preparation = preparation
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return outcome, err
+}
+
+func (l Lifecycle) prepareSandboxStop(ctx context.Context, session *domain.Sandbox, gracePeriod time.Duration) (StopPreparationResult, error) {
+	preparer, ok := l.Driver.(SandboxStopPreparer)
+	if !ok {
+		return StopPreparationResult{}, domain.ClassifyError(domain.ErrUnsupported, "sandbox driver does not support graceful stop", nil)
+	}
+	if gracePeriod <= 0 && l.Config != nil {
+		gracePeriod = l.Config.SandboxGracefulStopTimeout
+	}
+	if gracePeriod <= 0 {
+		gracePeriod = 10 * time.Second
+	}
+	vmState, err := l.Store.GetVMState(session.Summary.ID)
+	if err != nil {
+		return StopPreparationResult{}, fmt.Errorf("load sandbox VM state before graceful stop: %w", err)
+	}
+	return preparer.PrepareSandboxStop(ctx, session, vmState, gracePeriod)
 }
 
 // StopLoadedWhileLocked performs the complete stop lifecycle while the caller
@@ -312,6 +402,14 @@ func (l Lifecycle) StopLoaded(ctx context.Context, session *domain.Sandbox) (Sto
 func (l Lifecycle) StopLoadedWhileLocked(ctx context.Context, session *domain.Sandbox) (StopOutcome, error) {
 	if session == nil {
 		return StopOutcome{}, fmt.Errorf("sandbox is required")
+	}
+	if initiator, ok := l.Driver.(SandboxForceStopInitiator); ok {
+		if err := initiator.BeginSandboxForceStop(session); err != nil {
+			return StopOutcome{}, err
+		}
+	}
+	if finalizer, ok := l.Driver.(SandboxStopFinalizer); ok {
+		defer finalizer.FinishSandboxStop(session)
 	}
 	return l.stopLoadedWhileLocked(ctx, session)
 }

--- a/pkg/sandboxes/lifecycle_coverage_test.go
+++ b/pkg/sandboxes/lifecycle_coverage_test.go
@@ -649,6 +649,7 @@ func lifecycleTestSession(id, driver, status string) *domain.Sandbox {
 type fakeLifecycleStore struct {
 	session    *domain.Sandbox
 	vmState    domain.VMState
+	vmStateErr error
 	savedVM    domain.VMState
 	proxyState domain.ProxyState
 	updated    int
@@ -672,7 +673,7 @@ func (s *fakeLifecycleStore) UpdateSandbox(_ context.Context, session *domain.Sa
 }
 
 func (s *fakeLifecycleStore) GetVMState(string) (domain.VMState, error) {
-	return s.vmState, nil
+	return s.vmState, s.vmStateErr
 }
 
 func (s *fakeLifecycleStore) SaveVMState(_ string, state domain.VMState) error {

--- a/pkg/sandboxes/stop_options.go
+++ b/pkg/sandboxes/stop_options.go
@@ -1,0 +1,29 @@
+package sandboxes
+
+import "time"
+
+type StopMode string
+
+const (
+	StopModeForce    StopMode = "force"
+	StopModeGraceful StopMode = "graceful"
+)
+
+type StopOptions struct {
+	Mode        StopMode
+	GracePeriod time.Duration
+}
+
+type StopPreparationOutcome string
+
+const (
+	StopPreparationSkipped  StopPreparationOutcome = "skipped"
+	StopPreparationGraceful StopPreparationOutcome = "graceful"
+	StopPreparationTimeout  StopPreparationOutcome = "timeout"
+	StopPreparationFailed   StopPreparationOutcome = "failed"
+)
+
+type StopPreparationResult struct {
+	Outcome StopPreparationOutcome
+	Error   error
+}

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package agentcompose.v2;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 option go_package = "agent-compose/proto/agentcompose/v2;agentcomposev2";
 
@@ -205,6 +206,20 @@ enum SandboxStatus {
   SANDBOX_STATUS_STOPPED = 3;
   SANDBOX_STATUS_FAILED = 4;
   SANDBOX_STATUS_DELETING = 5;
+}
+
+enum SandboxStopMode {
+  SANDBOX_STOP_MODE_UNSPECIFIED = 0;
+  SANDBOX_STOP_MODE_FORCE = 1;
+  SANDBOX_STOP_MODE_GRACEFUL = 2;
+}
+
+enum SandboxStopOutcome {
+  SANDBOX_STOP_OUTCOME_UNSPECIFIED = 0;
+  SANDBOX_STOP_OUTCOME_FORCE = 1;
+  SANDBOX_STOP_OUTCOME_GRACEFUL = 2;
+  SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT = 3;
+  SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_ERROR = 4;
 }
 
 enum WorkspaceReclamationState {
@@ -1319,10 +1334,13 @@ message GetSandboxResponse {
 
 message StopSandboxRequest {
   string sandbox_id = 1;
+  SandboxStopMode mode = 2;
+  google.protobuf.Duration grace_period = 3;
 }
 
 message StopSandboxResponse {
   Sandbox sandbox = 1;
+  SandboxStopOutcome outcome = 2;
 }
 
 message ResumeSandboxRequest {

--- a/runtime/javascript/src/child-process.ts
+++ b/runtime/javascript/src/child-process.ts
@@ -1,0 +1,22 @@
+import type { ChildProcess } from "node:child_process";
+
+export interface ChildExit {
+  exitCode: number;
+  spawnError?: Error;
+}
+
+export function waitForChildExit(child: ChildProcess, signal?: AbortSignal, event: "close" | "exit" = "close"): Promise<ChildExit> {
+  return new Promise((resolve) => {
+    let spawnError: Error | undefined;
+    child.once("error", (error) => {
+      spawnError = error;
+      if (!signal?.aborted) {
+        resolve({ exitCode: 1, spawnError });
+      }
+    });
+    child.once(event, (code) => resolve({
+      exitCode: code ?? (signal?.aborted ? 143 : 1),
+      spawnError,
+    }));
+  });
+}

--- a/runtime/javascript/src/cli.ts
+++ b/runtime/javascript/src/cli.ts
@@ -9,6 +9,7 @@ import { COMMAND_RESULT_PREFIX, RESULT_PREFIX } from "./constants.js";
 import { formatError } from "./errors.js";
 import { runPromptCommand } from "./prompt.js";
 import { runStreamCommand } from "./stream.js";
+import { RuntimeShutdownController } from "./shutdown.js";
 
 function collectRepeated(value: string, previous: string[] = []): string[] {
   return [...previous, value];
@@ -44,8 +45,13 @@ export function createProgram(options: { exitOverride?: boolean } = {}): Command
       skill?: string[];
     }) => {
       const { skill, ...promptOptions } = options;
-      const result = await runPromptCommand({ ...promptOptions, skills: skill });
-      process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(result)}\n`);
+      const shutdown = new RuntimeShutdownController();
+      try {
+        const result = await runPromptCommand({ ...promptOptions, skills: skill, abortController: shutdown.abortController });
+        process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(result)}\n`);
+      } finally {
+        shutdown.dispose();
+      }
     });
 
   program
@@ -60,15 +66,25 @@ export function createProgram(options: { exitOverride?: boolean } = {}): Command
       workspace?: string;
       home?: string;
     }) => {
-      const result = await runExecCommand(options);
-      process.stdout.write(`${COMMAND_RESULT_PREFIX}${JSON.stringify(result)}\n`);
+      const shutdown = new RuntimeShutdownController();
+      try {
+        const result = await runExecCommand({ ...options, signal: shutdown.abortController.signal });
+        process.stdout.write(`${COMMAND_RESULT_PREFIX}${JSON.stringify(result)}\n`);
+      } finally {
+        shutdown.dispose();
+      }
     });
 
   program
     .command("stream")
     .description("run the runtime NDJSON stream protocol on stdin/stdout")
     .action(async () => {
-      await runStreamCommand();
+      const shutdown = new RuntimeShutdownController();
+      try {
+        await runStreamCommand({ abortController: shutdown.abortController });
+      } finally {
+        shutdown.dispose();
+      }
     });
 
   return program;

--- a/runtime/javascript/src/command.ts
+++ b/runtime/javascript/src/command.ts
@@ -4,6 +4,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runtimeRootForStateRoot } from "./paths.js";
+import { waitForChildExit } from "./child-process.js";
 
 export const DEFAULT_COMMAND_MAX_OUTPUT_BYTES = 1024 * 1024;
 
@@ -36,6 +37,7 @@ export interface RuntimeCommandResult {
   output: string;
   exitCode: number;
   success: boolean;
+  cancelled: boolean;
   stdoutTruncated: boolean;
   stderrTruncated: boolean;
   outputTruncated: boolean;
@@ -53,6 +55,7 @@ interface RunProcessResult {
   stderr: StreamCapture;
   output: StreamCapture;
   exitCode: number;
+  cancelled: boolean;
 }
 
 export interface RunRuntimeCommandOptions {
@@ -66,6 +69,7 @@ export interface RunRuntimeCommandOptions {
   onStdout?: (chunk: Buffer) => void;
   onStderr?: (chunk: Buffer) => void;
   onOutput?: (chunk: Buffer, stream: "stdout" | "stderr") => void;
+  signal?: AbortSignal;
 }
 
 export async function runExecCommand(options: {
@@ -73,6 +77,7 @@ export async function runExecCommand(options: {
   stateRoot?: string;
   workspace?: string;
   home?: string;
+  signal?: AbortSignal;
 }): Promise<RuntimeCommandResult> {
   const requestPath = path.resolve(options.requestFile);
   const request = await readCommandRequest(requestPath);
@@ -85,6 +90,7 @@ export async function runExecCommand(options: {
     home: options.home,
     stdout: process.stdout,
     stderr: process.stderr,
+    signal: options.signal,
   });
 }
 
@@ -114,13 +120,15 @@ export async function runRuntimeCommand(options: RunRuntimeCommandOptions): Prom
     onStdout: options.onStdout,
     onStderr: options.onStderr,
     onOutput: options.onOutput,
+    signal: options.signal,
   });
   const result: RuntimeCommandResult = {
     stdout: processResult.stdout.text,
     stderr: processResult.stderr.text,
     output: processResult.output.text,
     exitCode: processResult.exitCode,
-    success: processResult.exitCode === 0,
+    success: processResult.exitCode === 0 && !processResult.cancelled,
+    cancelled: processResult.cancelled,
     stdoutTruncated: processResult.stdout.truncated,
     stderrTruncated: processResult.stderr.truncated,
     outputTruncated: processResult.output.truncated,
@@ -179,7 +187,7 @@ export function normalizeCommandRequest(
 async function runProcess(
   request: ReturnType<typeof normalizeCommandRequest>,
   artifacts: Pick<RuntimeCommandArtifacts, "stdout" | "stderr" | "output">,
-  options: Pick<RunRuntimeCommandOptions, "stdout" | "stderr" | "onStdout" | "onStderr" | "onOutput"> = {},
+  options: Pick<RunRuntimeCommandOptions, "stdout" | "stderr" | "onStdout" | "onStderr" | "onOutput" | "signal"> = {},
 ): Promise<RunProcessResult> {
   await Promise.all([
     fsp.mkdir(path.dirname(artifacts.stdout), { recursive: true }),
@@ -206,15 +214,29 @@ async function runProcess(
       ...request.env,
     },
     shell: false,
+    detached: process.platform !== "win32",
   });
 
+  const processExit = waitForChildExit(child, options.signal);
+  let cancelled = options.signal?.aborted === true;
+  const handleAbort = () => {
+    cancelled = true;
+    signalCommand(child, "SIGTERM");
+  };
+  options.signal?.addEventListener("abort", handleAbort, { once: true });
+  if (cancelled) {
+    signalCommand(child, "SIGTERM");
+  }
+
   let timeout: NodeJS.Timeout | undefined;
+  let timeoutEscalation: NodeJS.Timeout | undefined;
   let timedOut = false;
   if (request.timeoutMs && request.timeoutMs > 0) {
     timeout = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
-      setTimeout(() => child.kill("SIGKILL"), 1000).unref();
+      signalCommand(child, "SIGTERM");
+      timeoutEscalation = setTimeout(() => signalCommand(child, "SIGKILL"), 1000);
+      timeoutEscalation.unref();
     }, request.timeoutMs);
   }
 
@@ -238,7 +260,10 @@ async function runProcess(
   });
 
   try {
-    const exitCode = await waitForProcess(child);
+    const { exitCode, spawnError } = await processExit;
+    if (spawnError && !options.signal?.aborted) {
+      throw spawnError;
+    }
     if (timedOut) {
       throw new Error(`command timed out after ${request.timeoutMs}ms`);
     }
@@ -250,10 +275,15 @@ async function runProcess(
       stderr: finalizeCapture(stderrCapture),
       output: finalizeCapture(outputCapture),
       exitCode,
+      cancelled,
     };
   } finally {
+    options.signal?.removeEventListener("abort", handleAbort);
     if (timeout) {
       clearTimeout(timeout);
+    }
+    if (timeoutEscalation) {
+      clearTimeout(timeoutEscalation);
     }
     await Promise.all([
       closeWritable(stdoutFile),
@@ -263,11 +293,22 @@ async function runProcess(
   }
 }
 
-function waitForProcess(child: ReturnType<typeof spawn>): Promise<number> {
-  return new Promise((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (code) => resolve(code ?? 1));
-  });
+function signalCommand(child: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
+  if (!child.pid) {
+    return;
+  }
+  try {
+    if (process.platform === "win32") {
+      child.kill(signal);
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      // The child exit event remains the source of truth. Signal delivery can
+      // race with process-group exit, so there is no actionable error here.
+    }
+  }
 }
 
 function createStreamCapture(limit: number) {

--- a/runtime/javascript/src/interactive.ts
+++ b/runtime/javascript/src/interactive.ts
@@ -23,6 +23,7 @@ export interface InteractiveStartOptions {
   home?: string;
   model?: string;
   outputSchemaFile?: string;
+  abortController?: AbortController;
 }
 
 export type EmitInteractiveFrame = (type: string, fields?: object) => void;
@@ -109,14 +110,26 @@ export class CodexInteractiveSession implements InteractiveSession {
     this.turnCount++;
     this.result.finalText = "";
     this.result.finalTextSource = "none";
-    const { events } = await this.thread.runStreamed(
-      message,
-      this.options.outputSchema ? { outputSchema: this.options.outputSchema } : undefined,
-    );
-    for await (const event of events) {
-      const sdkEvent = event as Record<string, unknown>;
-      this.emit("agent_event", { event: sdkEvent });
-      this.runner.handleEvent(sdkEvent, this.result);
+    try {
+      const turnOptions = this.options.outputSchema || this.options.abortController
+        ? {
+          ...(this.options.outputSchema ? { outputSchema: this.options.outputSchema } : {}),
+          ...(this.options.abortController ? { signal: this.options.abortController.signal } : {}),
+        }
+        : undefined;
+      const { events } = await this.thread.runStreamed(message, turnOptions);
+      for await (const event of events) {
+        const sdkEvent = event as Record<string, unknown>;
+        this.emit("agent_event", { event: sdkEvent });
+        this.runner.handleEvent(sdkEvent, this.result);
+      }
+    } catch (error) {
+      if (!this.options.abortController?.signal.aborted) {
+        throw error;
+      }
+    }
+    if (this.options.abortController?.signal.aborted) {
+      this.result.stopReason = "cancelled";
     }
     this.result.threadId = this.thread.id || this.result.threadId;
     this.result.transcript = this.runner.transcript();

--- a/runtime/javascript/src/prompt.ts
+++ b/runtime/javascript/src/prompt.ts
@@ -22,6 +22,7 @@ export interface PromptCommandOptions {
   model?: string;
   outputSchemaFile?: string;
   skills?: string[];
+  abortController?: AbortController;
 }
 
 export async function buildPromptRuntimeOptions(commandOptions: Omit<PromptCommandOptions, "messageFile">) {
@@ -52,6 +53,7 @@ export async function buildPromptRuntimeOptions(commandOptions: Omit<PromptComma
     mcpConfig: mcpConfig.mcp_servers,
     skills,
     outputSchema,
+    abortController: commandOptions.abortController,
   };
 }
 

--- a/runtime/javascript/src/runners/claude.ts
+++ b/runtime/javascript/src/runners/claude.ts
@@ -5,6 +5,7 @@ import { readStoredThread, writeStoredThread } from "../session-state.js";
 import { jsonString } from "../text.js";
 import { TranscriptWriter, type TranscriptTextWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions, StoredThread } from "../types.js";
+import { cancellationRequested } from "../shutdown.js";
 
 type PendingToolUse = {
   name: string;
@@ -116,6 +117,7 @@ export class ClaudeRunner {
           append: this.options.systemContext,
         },
       } : {}),
+      ...(this.options.abortController ? { abortController: this.options.abortController } : {}),
     };
   }
 
@@ -272,8 +274,17 @@ export class ClaudeRunner {
             break;
         }
       }
+    } catch (error) {
+      if (!cancellationRequested(this.options.abortController?.signal)) {
+        throw error;
+      }
+      result.stopReason = "cancelled";
     } finally {
       stream.close?.();
+    }
+
+    if (cancellationRequested(this.options.abortController?.signal)) {
+      result.stopReason = "cancelled";
     }
 
     result.transcript = this.writer.transcript();
@@ -281,7 +292,9 @@ export class ClaudeRunner {
       result.finalText = result.transcript;
       result.finalTextSource = "transcript_fallback";
     }
-    await writeStoredThread(this.options.stateRoot, "claude", result.threadId);
+    if (result.threadId) {
+      await writeStoredThread(this.options.stateRoot, "claude", result.threadId);
+    }
     return result;
   }
 }

--- a/runtime/javascript/src/runners/codex.ts
+++ b/runtime/javascript/src/runners/codex.ts
@@ -12,6 +12,7 @@ import { readStoredThread, writeStoredThread } from "../session-state.js";
 import { extractText, jsonString } from "../text.js";
 import { appendDelta, TranscriptWriter, type TextWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions } from "../types.js";
+import { cancellationRequested } from "../shutdown.js";
 
 interface CodexItemState {
   commandStarted?: boolean;
@@ -231,12 +232,25 @@ export class CodexRunner {
       stderr: "",
     };
 
-    const { events } = await thread.runStreamed(
-      promptText,
-      this.options.outputSchema ? { outputSchema: this.options.outputSchema } : undefined,
-    );
-    for await (const event of events) {
-      this.handleEvent(event as Record<string, unknown>, result);
+    try {
+      const turnOptions = this.options.outputSchema || this.options.abortController
+        ? {
+          ...(this.options.outputSchema ? { outputSchema: this.options.outputSchema } : {}),
+          ...(this.options.abortController ? { signal: this.options.abortController.signal } : {}),
+        }
+        : undefined;
+      const { events } = await thread.runStreamed(promptText, turnOptions);
+      for await (const event of events) {
+        this.handleEvent(event as Record<string, unknown>, result);
+      }
+    } catch (error) {
+      if (!cancellationRequested(this.options.abortController?.signal)) {
+        throw error;
+      }
+      result.stopReason = "cancelled";
+    }
+    if (cancellationRequested(this.options.abortController?.signal)) {
+      result.stopReason = "cancelled";
     }
     result.threadId = thread.id || result.threadId;
     result.transcript = this.writer.transcript();
@@ -244,13 +258,15 @@ export class CodexRunner {
       result.finalText = result.transcript;
       result.finalTextSource = "transcript_fallback";
     }
-    await writeStoredThread(
-      this.options.stateRoot,
-      "codex",
-      result.threadId,
-      new Date(),
-      codexThreadStateMetadata(systemContextHash),
-    );
+    if (result.threadId) {
+      await writeStoredThread(
+        this.options.stateRoot,
+        "codex",
+        result.threadId,
+        new Date(),
+        codexThreadStateMetadata(systemContextHash),
+      );
+    }
     return result;
   }
 }

--- a/runtime/javascript/src/runners/gemini.ts
+++ b/runtime/javascript/src/runners/gemini.ts
@@ -6,6 +6,8 @@ import { flattenEnvMap } from "../mcp-config.js";
 import { extractText, jsonString } from "../text.js";
 import { TranscriptWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions } from "../types.js";
+import { cancellationRequested } from "../shutdown.js";
+import { waitForChildExit } from "../child-process.js";
 
 export class GeminiRunner {
   private readonly writer = new TranscriptWriter();
@@ -78,7 +80,9 @@ export class GeminiRunner {
       cwd: this.options.workspace,
       env: { ...process.env },
       stdio: ["ignore", "pipe", "pipe"],
+      signal: this.options.abortController?.signal,
     });
+    const exit = waitForChildExit(child, this.options.abortController?.signal, "exit");
 
     const stderrChunks: string[] = [];
     child.stderr?.on("data", (chunk) => {
@@ -88,7 +92,8 @@ export class GeminiRunner {
     });
 
     const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
-    for await (const line of rl) {
+    try {
+      for await (const line of rl) {
       if (!line.trim()) {
         continue;
       }
@@ -136,14 +141,23 @@ export class GeminiRunner {
         }
         result.stopReason = event?.error ? "error" : "completed";
       }
+      }
+    } catch (error) {
+      if (!cancellationRequested(this.options.abortController?.signal)) {
+        throw error;
+      }
     }
 
-    const exitCode = await new Promise<number>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("exit", (code) => resolve(code ?? 1));
-    });
-    if (exitCode !== 0) {
-      throw new Error(`gemini exited with code ${exitCode}: ${stderrChunks.join("")}`);
+    const processResult = await exit;
+    const cancelled = cancellationRequested(this.options.abortController?.signal);
+    if (processResult.spawnError && !cancelled) {
+      throw processResult.spawnError;
+    }
+    if (processResult.exitCode !== 0 && !cancelled) {
+      throw new Error(`gemini exited with code ${processResult.exitCode}: ${stderrChunks.join("")}`);
+    }
+    if (cancelled) {
+      result.stopReason = "cancelled";
     }
 
     result.transcript = this.writer.transcript();

--- a/runtime/javascript/src/runners/opencode.ts
+++ b/runtime/javascript/src/runners/opencode.ts
@@ -9,6 +9,8 @@ import { extractText, jsonString } from "../text.js";
 import { TranscriptWriter, type TranscriptTextWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions, StoredThread } from "../types.js";
 import { flattenEnvMap } from "../mcp-config.js";
+import { cancellationRequested } from "../shutdown.js";
+import { waitForChildExit } from "../child-process.js";
 
 export class OpenCodeRunner {
   private skillsConfigDir?: string;
@@ -219,7 +221,9 @@ export class OpenCodeRunner {
         cwd: this.options.workspace,
         env: await this.environment(),
         stdio: ["ignore", "pipe", "pipe"],
+        signal: this.options.abortController?.signal,
       });
+      const exit = waitForChildExit(child, this.options.abortController?.signal, "exit");
 
       const stderrChunks: string[] = [];
       child.stderr?.on("data", (chunk) => {
@@ -244,16 +248,22 @@ export class OpenCodeRunner {
           this.handleEvent(event, result);
         }
       } catch (error) {
-        child.kill("SIGTERM");
-        throw error;
+        if (!cancellationRequested(this.options.abortController?.signal)) {
+          child.kill("SIGTERM");
+          throw error;
+        }
       }
 
-      const exitCode = await new Promise<number>((resolve, reject) => {
-        child.once("error", reject);
-        child.once("exit", (code) => resolve(code ?? 1));
-      });
-      if (exitCode !== 0) {
-        throw new Error(`opencode exited with code ${exitCode}: ${stderrChunks.join("")}`);
+      const processResult = await exit;
+      const cancelled = cancellationRequested(this.options.abortController?.signal);
+      if (processResult.spawnError && !cancelled) {
+        throw processResult.spawnError;
+      }
+      if (processResult.exitCode !== 0 && !cancelled) {
+        throw new Error(`opencode exited with code ${processResult.exitCode}: ${stderrChunks.join("")}`);
+      }
+      if (cancelled) {
+        result.stopReason = "cancelled";
       }
     } finally {
       await this.cleanupSkillsConfig();
@@ -264,7 +274,9 @@ export class OpenCodeRunner {
       result.finalText = result.transcript;
       result.finalTextSource = "transcript_fallback";
     }
-    await writeStoredThread(this.options.stateRoot, "opencode", result.threadId);
+    if (result.threadId) {
+      await writeStoredThread(this.options.stateRoot, "opencode", result.threadId);
+    }
     return result;
   }
 }

--- a/runtime/javascript/src/runners/pi.ts
+++ b/runtime/javascript/src/runners/pi.ts
@@ -7,6 +7,8 @@ import { readStoredThread, writeStoredThread } from "../session-state.js";
 import { TranscriptWriter, type TranscriptTextWriter } from "../transcript.js";
 import type { AgentResult, RunnerOptions } from "../types.js";
 import { piMCPAdapterExtension, writePiMCPConfig } from "./pi-mcp.js";
+import { cancellationRequested } from "../shutdown.js";
+import { waitForChildExit } from "../child-process.js";
 
 const maxDiagnosticBytes = 64 * 1024;
 
@@ -31,6 +33,15 @@ export class PiRunner {
     await fs.mkdir(sessionDir, { recursive: true });
     await fs.mkdir(tempRoot, { recursive: true });
     const invocationDir = await fs.mkdtemp(path.join(tempRoot, "prompt-"));
+    const result: AgentResult = {
+      provider: "pi",
+      threadId: "",
+      stopReason: "completed",
+      finalText: "",
+      finalTextSource: "none",
+      transcript: "",
+      stderr: "",
+    };
 
     try {
       // Let Pi create the first session so its CLI follows the native creation
@@ -48,11 +59,12 @@ export class PiRunner {
           PI_TELEMETRY: "0",
         },
         stdio: ["ignore", "pipe", "pipe"],
+        signal: this.options.abortController?.signal,
       });
       // Attach the process error handler immediately. A failed spawn may emit
       // before stdout iteration completes, and an unhandled child "error"
       // event would otherwise terminate the runtime process.
-      const exit = waitForExit(child);
+      const exit = waitForChildExit(child, this.options.abortController?.signal);
 
       let stderrBytes: Buffer = Buffer.alloc(0);
       child.stderr?.on("data", (chunk) => {
@@ -61,15 +73,6 @@ export class PiRunner {
         this.writer.write(text);
       });
 
-      const result: AgentResult = {
-        provider: "pi",
-        threadId: "",
-        stopReason: "completed",
-        finalText: "",
-        finalTextSource: "none",
-        transcript: "",
-        stderr: "",
-      };
       let protocolError: Error | null = null;
       const lines = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
       for await (const line of lines) {
@@ -89,21 +92,27 @@ export class PiRunner {
       const processResult = await exit;
       const stderr = stderrBytes.toString("utf8");
       result.stderr = stderr;
-      if (processResult.spawnError) throw processResult.spawnError;
-      if (protocolError) throw protocolError;
-      if (this.reportedError) throw this.reportedError;
-      if (processResult.exitCode !== 0) {
+      const cancelled = cancellationRequested(this.options.abortController?.signal);
+      if (processResult.spawnError && !cancelled) throw processResult.spawnError;
+      if (protocolError && !cancelled) throw protocolError;
+      if (this.reportedError && !cancelled) throw this.reportedError;
+      if (processResult.exitCode !== 0 && !cancelled) {
         throw new Error(`pi exited with code ${processResult.exitCode}${stderr ? `: ${stderr}` : ""}`);
       }
-      if (!result.threadId) {
+      if (!result.threadId && !cancelled) {
         throw new Error("pi completed without emitting a session id");
+      }
+      if (cancelled) {
+        result.stopReason = "cancelled";
       }
       result.transcript = this.writer.transcript();
       if (!result.finalText && result.transcript) {
         result.finalText = lastAssistantTextFromTranscript(result.transcript);
         result.finalTextSource = "transcript_fallback";
       }
-      await writeStoredThread(this.options.stateRoot, "pi", result.threadId);
+      if (result.threadId) {
+        await writeStoredThread(this.options.stateRoot, "pi", result.threadId);
+      }
       return result;
     } finally {
       await fs.rm(invocationDir, { recursive: true, force: true });
@@ -222,13 +231,6 @@ function piFacadeModel(model: string): string {
   if (normalized.startsWith("agent-compose/")) return normalized;
   const separator = normalized.indexOf("/");
   return `agent-compose/${separator >= 0 ? normalized.slice(separator + 1) : normalized}`;
-}
-
-function waitForExit(child: ReturnType<typeof spawn>): Promise<{ exitCode: number; spawnError?: Error }> {
-  return new Promise((resolve) => {
-    child.once("error", (error) => resolve({ exitCode: 1, spawnError: new Error("failed to start pi", { cause: error }) }));
-    child.once("close", (code) => resolve({ exitCode: code ?? 1 }));
-  });
 }
 
 function appendBounded(current: Buffer, next: Buffer, limit: number): Buffer {

--- a/runtime/javascript/src/shutdown.ts
+++ b/runtime/javascript/src/shutdown.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+type SignalTarget = Pick<NodeJS.Process, "on" | "off">;
+
+export const RUNTIME_READY_FILE_ENV = "AGENT_COMPOSE_INTERNAL_EXECUTION_READY_FILE";
+
+interface RuntimeReadinessOptions {
+  filePath?: string;
+  pid?: number;
+}
+
+export class RuntimeShutdownController {
+  readonly abortController = new AbortController();
+  private disposed = false;
+  private readonly readyFile: string | undefined;
+  private readonly pid: number;
+
+  constructor(
+    private readonly target: SignalTarget = process,
+    readiness: RuntimeReadinessOptions = {},
+  ) {
+    this.readyFile = readiness.filePath ?? process.env[RUNTIME_READY_FILE_ENV];
+    this.pid = readiness.pid ?? process.pid;
+    this.target.on("SIGTERM", this.handleSIGTERM);
+    try {
+      this.publishReadiness();
+    } catch (error) {
+      this.target.off("SIGTERM", this.handleSIGTERM);
+      throw error;
+    }
+  }
+
+  request(): void {
+    if (!this.abortController.signal.aborted) {
+      this.abortController.abort();
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.removeReadiness();
+    this.target.off("SIGTERM", this.handleSIGTERM);
+  }
+
+  private publishReadiness(): void {
+    if (!this.readyFile) {
+      return;
+    }
+    fs.mkdirSync(path.dirname(this.readyFile), { recursive: true });
+    fs.writeFileSync(this.readyFile, String(this.pid), { encoding: "utf8", mode: 0o600 });
+  }
+
+  private removeReadiness(): void {
+    if (!this.readyFile) {
+      return;
+    }
+    try {
+      if (fs.readFileSync(this.readyFile, "utf8").trim() === String(this.pid)) {
+        fs.unlinkSync(this.readyFile);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        // Readiness cleanup is best effort during process teardown. Execution
+        // IDs are unique, and the PID check prevents stale files signalling a
+        // different runtime process.
+      }
+    }
+  }
+
+  private readonly handleSIGTERM = () => {
+    this.request();
+  };
+}
+
+export function cancellationRequested(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}

--- a/runtime/javascript/src/stream.ts
+++ b/runtime/javascript/src/stream.ts
@@ -8,6 +8,7 @@ export interface RunStreamOptions {
   stdin?: Readable;
   stdout?: Writable;
   stderr?: Writable;
+  abortController?: AbortController;
 }
 
 export async function runStreamCommand(options: RunStreamOptions = {}): Promise<void> {
@@ -26,27 +27,34 @@ export async function runStreamCommand(options: RunStreamOptions = {}): Promise<
   };
 
   const lines = createInterface({ input: stdin, crlfDelay: Infinity });
-  for await (const line of lines) {
-    if (!line.trim()) {
-      continue;
-    }
-    let frame: StreamFrame;
-    try {
-      frame = decodeFrame(line);
-    } catch (error) {
-      emitError(error);
-      continue;
-    }
+  const signal = options.abortController?.signal;
+  const closeOnAbort = () => lines.close();
+  signal?.addEventListener("abort", closeOnAbort, { once: true });
+  if (signal?.aborted) {
+    lines.close();
+  }
+  try {
+    for await (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      let frame: StreamFrame;
+      try {
+        frame = decodeFrame(line);
+      } catch (error) {
+        emitError(error);
+        continue;
+      }
 
-    try {
-      switch (frame.type) {
+      try {
+        switch (frame.type) {
         case "start":
           if (session) {
             throw new Error("stream has already been started");
           }
           if (frame.mode === "command") {
             emit("started", { mode: "command" });
-            emit("result", await runCommandFrame(frame, emit));
+            emit("result", await runCommandFrame(frame, emit, signal));
             finished = true;
             lines.close();
             break;
@@ -58,6 +66,7 @@ export async function runStreamCommand(options: RunStreamOptions = {}): Promise<
             home: stringField(frame, "home"),
             model: stringField(frame, "model"),
             outputSchemaFile: stringField(frame, "outputSchemaFile"),
+            abortController: options.abortController,
           }, emit);
           break;
         case "human_message":
@@ -71,7 +80,7 @@ export async function runStreamCommand(options: RunStreamOptions = {}): Promise<
             throw new Error("command frames are not supported after interactive start");
           }
           emit("started", { mode: "command" });
-          emit("result", await runCommandFrame(frame, emit));
+          emit("result", await runCommandFrame(frame, emit, signal));
           finished = true;
           lines.close();
           break;
@@ -86,31 +95,37 @@ export async function runStreamCommand(options: RunStreamOptions = {}): Promise<
           lines.close();
           break;
         }
-        default:
-          throw new Error(`unsupported input frame type ${frame.type}`);
-      }
-    } catch (error) {
-      emitError(error, frame.seq);
-      if (error instanceof UnsupportedProviderError) {
-        finished = true;
-        lines.close();
+          default:
+            throw new Error(`unsupported input frame type ${frame.type}`);
+        }
+      } catch (error) {
+        emitError(error, frame.seq);
+        if (error instanceof UnsupportedProviderError) {
+          finished = true;
+          lines.close();
+        }
       }
     }
+  } finally {
+    signal?.removeEventListener("abort", closeOnAbort);
   }
 
   if (!finished && session) {
     try {
-      emit("result", await session.finish("eof"));
+      emit("result", await session.finish(signal?.aborted ? "cancelled" : "eof"));
     } catch (error) {
       stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
       emitError(error);
     }
+  } else if (!finished && signal?.aborted) {
+    emit("result", { stopReason: "cancelled" });
   }
 }
 
 async function runCommandFrame(
   frame: StreamFrame,
   emit: (type: string, fields?: object) => void,
+  signal?: AbortSignal,
 ) {
   const request = commandRequest(frame);
   return runRuntimeCommand({
@@ -127,6 +142,7 @@ async function runCommandFrame(
       emitTextFrame(emit, "stderr", chunk);
       emitOutputFrame(emit, "stderr", chunk);
     },
+    signal,
   });
 }
 

--- a/runtime/javascript/src/types.ts
+++ b/runtime/javascript/src/types.ts
@@ -23,6 +23,7 @@ export interface RunnerOptions {
   mcpConfig?: Record<string, unknown>;
   skills?: string[];
   outputSchema?: RuntimeJsonSchema;
+  abortController?: AbortController;
 }
 
 export interface StoredThread {

--- a/runtime/javascript/test/cli.test.ts
+++ b/runtime/javascript/test/cli.test.ts
@@ -62,6 +62,7 @@ describe("commander CLI", () => {
       model: "anthropic/claude-sonnet-4-5",
       outputSchemaFile: "/tmp/schema.json",
       skills: ["pdf", "docx"],
+      abortController: expect.any(AbortController),
     });
     expect(stdio.stdout).toBe(`${RESULT_PREFIX}{"provider":"codex","threadId":"s1","stopReason":"completed","finalText":"done","json":null,"transcript":"done","stderr":""}\n`);
     expect(stdio.stderr).toBe("");
@@ -106,6 +107,7 @@ describe("commander CLI", () => {
       output: "ok\n",
       exitCode: 0,
       success: true,
+      cancelled: false,
       stdoutTruncated: false,
       stderrTruncated: false,
       outputTruncated: false,
@@ -141,8 +143,9 @@ describe("commander CLI", () => {
       stateRoot: "/data/state",
       workspace: "/data/workspace",
       home: "/data/home",
+      signal: expect.any(AbortSignal),
     });
-    expect(stdio.stdout).toBe(`${COMMAND_RESULT_PREFIX}{"stdout":"ok\\n","stderr":"","output":"ok\\n","exitCode":0,"success":true,"stdoutTruncated":false,"stderrTruncated":false,"outputTruncated":false,"artifacts":{"stdout":"/tmp/stdout.txt","stderr":"/tmp/stderr.txt","output":"/tmp/output.txt","request":"/tmp/request.json","result":"/tmp/result.json"}}\n`);
+    expect(stdio.stdout).toBe(`${COMMAND_RESULT_PREFIX}{"stdout":"ok\\n","stderr":"","output":"ok\\n","exitCode":0,"success":true,"cancelled":false,"stdoutTruncated":false,"stderrTruncated":false,"outputTruncated":false,"artifacts":{"stdout":"/tmp/stdout.txt","stderr":"/tmp/stderr.txt","output":"/tmp/output.txt","request":"/tmp/request.json","result":"/tmp/result.json"}}\n`);
     expect(stdio.stderr).toBe("");
   });
 
@@ -153,6 +156,7 @@ describe("commander CLI", () => {
       output: "out\nerr\n",
       exitCode: 9,
       success: false,
+      cancelled: false,
       stdoutTruncated: false,
       stderrTruncated: false,
       outputTruncated: false,
@@ -197,7 +201,7 @@ describe("commander CLI", () => {
       stdio.restore();
     }
 
-    expect(runStream).toHaveBeenCalledWith();
+    expect(runStream).toHaveBeenCalledWith({ abortController: expect.any(AbortController) });
     expect(stdio.stdout).toBe("");
     expect(stdio.stderr).toBe("");
   });

--- a/runtime/javascript/test/command.test.ts
+++ b/runtime/javascript/test/command.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeCommandRequest,
   readCommandRequest,
   runExecCommand,
+  runRuntimeCommand,
 } from "../src/command.js";
 import { captureStdio, withTempSession } from "./helpers.js";
 
@@ -258,6 +259,98 @@ describe("runtime command execution", () => {
       await expect(runExecCommand({ requestFile, workspace: root })).rejects.toThrow("command timed out");
     });
   });
+
+  it("forwards cancellation to the child and persists partial command artifacts", async () => {
+    await withTempSession(async (root) => {
+      const abortController = new AbortController();
+      const artifactDir = path.join(root, "artifacts");
+      let requested = false;
+      const result = await runRuntimeCommand({
+        request: {
+          mode: "exec",
+          command: "node",
+          args: ["-e", [
+            "process.on('SIGTERM', () => { process.stdout.write('cleanup\\n'); process.exit(0); });",
+            "process.stdout.write('partial\\n');",
+            "setInterval(() => {}, 1000);",
+          ].join(" ")],
+          artifactDir,
+        },
+        workspace: root,
+        signal: abortController.signal,
+        onStdout(chunk) {
+          if (!requested && chunk.toString("utf8").includes("partial")) {
+            requested = true;
+            abortController.abort();
+          }
+        },
+      });
+
+      expect(result).toMatchObject({ success: false, cancelled: true, exitCode: 0 });
+      expect(result.stdout).toContain("partial");
+      expect(result.stdout).toContain("cleanup");
+      expect(JSON.parse(await fs.readFile(result.artifacts.result, "utf8"))).toMatchObject({
+        success: false,
+        cancelled: true,
+        exitCode: 0,
+        stdout: expect.stringContaining("cleanup"),
+      });
+    });
+  });
+
+  it("signals the owned command process group so descendants cannot delay cleanup", async () => {
+    await withTempSession(async (root) => {
+      const abortController = new AbortController();
+      let childPID = 0;
+      let requested = false;
+      const resultPromise = runRuntimeCommand({
+        request: {
+          mode: "shell",
+          script: [
+            "trap 'printf cleanup\\n; exit 0' TERM",
+            "sleep 60 &",
+            "child=$!",
+            "printf 'child:%s\\n' \"$child\"",
+            "wait \"$child\"",
+          ].join("\n"),
+          artifactDir: path.join(root, "artifacts"),
+        },
+        workspace: root,
+        signal: abortController.signal,
+        onStdout(chunk) {
+          const match = /child:(\d+)/.exec(chunk.toString("utf8"));
+          if (match && !requested) {
+            requested = true;
+            childPID = Number(match[1]);
+            abortController.abort();
+          }
+        },
+      });
+      let fallbackUsed = false;
+      let fallbackError: unknown;
+      const fallback = setTimeout(() => {
+        fallbackUsed = true;
+        if (childPID > 0) {
+          try {
+            process.kill(childPID, "SIGKILL");
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+              fallbackError = error;
+            }
+          }
+        }
+      }, 2_000);
+      try {
+        const result = await resultPromise;
+        expect(fallbackUsed).toBe(false);
+        expect(fallbackError).toBeUndefined();
+        expect(result).toMatchObject({ success: false, cancelled: true, exitCode: 0 });
+        expect(result.stdout).toContain("cleanup");
+      } finally {
+        clearTimeout(fallback);
+      }
+    });
+  }, 5_000);
 
   it("truncates returned output while keeping full artifact files", async () => {
     await withTempSession(async (root) => {

--- a/runtime/javascript/test/runner-execution.test.ts
+++ b/runtime/javascript/test/runner-execution.test.ts
@@ -187,6 +187,30 @@ describe("runner execution", () => {
     });
   });
 
+  it("returns a cancelled Codex result with partial transcript and thread state", async () => {
+    const { CodexRunner } = await import("../src/runners/codex.js");
+    await withTempSession(async (root) => {
+      codexState.events = [
+        { type: "thread.started", thread_id: "thread-partial" },
+        { type: "item.completed", item: { id: "a1", type: "agent_message", text: "partial answer" } },
+      ];
+      const abortController = new AbortController();
+      abortController.abort();
+
+      const result = await new CodexRunner({ ...runnerOptions(root), abortController }).runPrompt("prompt");
+
+      expect(result).toMatchObject({
+        threadId: "thread-new",
+        stopReason: "cancelled",
+        finalText: "partial answer",
+        transcript: "partial answer",
+      });
+      expect(codexState.runStreamedCalls.at(-1)?.options).toMatchObject({ signal: abortController.signal });
+      const stored = JSON.parse(await fs.readFile(path.join(root, "state", "agents", "providers", "codex.json"), "utf8"));
+      expect(stored.threadId).toBe("thread-new");
+    });
+  });
+
   it("passes MCP servers to Claude SDK options", async () => {
     const { ClaudeRunner } = await import("../src/runners/claude.js");
     await withTempSession(async (root) => {

--- a/runtime/javascript/test/shape-workflows.integration.test.ts
+++ b/runtime/javascript/test/shape-workflows.integration.test.ts
@@ -69,6 +69,7 @@ describe("runtime shape integration workflows", () => {
       const geminiSpy = vi.spyOn(await import("../src/runners/gemini.js"), "GeminiRunner").mockImplementation(function mockGemini(this: unknown, options: unknown) {
         Object.assign(this as object, { options, runPrompt });
       } as never);
+      const abortController = new AbortController();
       const stdio = captureStdio();
       try {
         await createProgram({ exitOverride: true }).parseAsync([
@@ -92,8 +93,10 @@ describe("runtime shape integration workflows", () => {
           stateRoot: path.join(root, "state"),
           workspace: path.join(root, "workspace"),
           home: path.join(root, "home"),
+          abortController,
         });
         expect(result.threadId).toBe("shape-session");
+        expect(geminiSpy).toHaveBeenLastCalledWith(expect.objectContaining({ abortController }));
       } finally {
         stdio.restore();
         geminiSpy.mockRestore();

--- a/runtime/javascript/test/shutdown.test.ts
+++ b/runtime/javascript/test/shutdown.test.ts
@@ -1,0 +1,36 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { RuntimeShutdownController } from "../src/shutdown.js";
+
+describe("runtime shutdown", () => {
+  it("turns repeated SIGTERM requests into one abort and removes its listener", () => {
+    const target = new EventEmitter();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-compose-runtime-shutdown-"));
+    const readyFile = path.join(root, "ready", "execution-id");
+    try {
+      const shutdown = new RuntimeShutdownController(
+        target as Pick<NodeJS.Process, "on" | "off">,
+        { filePath: readyFile, pid: 1234 },
+      );
+      const aborted = vi.fn();
+      shutdown.abortController.signal.addEventListener("abort", aborted);
+
+      expect(fs.readFileSync(readyFile, "utf8")).toBe("1234");
+      expect(target.listenerCount("SIGTERM")).toBe(1);
+      target.emit("SIGTERM");
+      target.emit("SIGTERM");
+
+      expect(shutdown.abortController.signal.aborted).toBe(true);
+      expect(aborted).toHaveBeenCalledTimes(1);
+      shutdown.dispose();
+      shutdown.dispose();
+      expect(target.listenerCount("SIGTERM")).toBe(0);
+      expect(fs.existsSync(readyFile)).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/test-coverage-contract.sh
+++ b/scripts/tests/test-coverage-contract.sh
@@ -139,7 +139,7 @@ fi
 
 listed_e2e_tests="$(go test -list '^Test' ./test/e2e | awk '/^Test/ { print }')"
 listed_e2e_count="$(printf '%s\n' "$listed_e2e_tests" | awk 'NF { count++ } END { print count + 0 }')"
-assert_equal 12 "$listed_e2e_count" "unexpected test/e2e package test count"
+assert_equal 14 "$listed_e2e_count" "unexpected test/e2e package test count"
 
 e2e_output="$(go test -run '^Test' -v ./test/e2e)"
 while IFS= read -r test_name; do

--- a/test/e2e/graceful_sandbox_stop_contract_test.go
+++ b/test/e2e/graceful_sandbox_stop_contract_test.go
@@ -1,0 +1,299 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"agent-compose/pkg/agentcompose/api"
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/identity"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/sandboxes"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestGracefulSandboxStopOutcomesUsePublicConnectContract(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *agentcomposev2.StopSandboxRequest
+		preparation sandboxes.StopPreparationOutcome
+		want        agentcomposev2.SandboxStopOutcome
+		wantOptions sandboxes.StopOptions
+		wantCode    connect.Code
+		sandboxVM   string
+		wantForce   bool
+		wantNoCall  bool
+	}{
+		{name: "graceful", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL}, preparation: sandboxes.StopPreparationGraceful, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL, wantOptions: sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful}},
+		{name: "explicit grace period", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL, GracePeriod: durationpb.New(12 * time.Second)}, preparation: sandboxes.StopPreparationGraceful, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL, wantOptions: sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful, GracePeriod: 12 * time.Second}},
+		{name: "timeout escalation", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL}, preparation: sandboxes.StopPreparationTimeout, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT, wantOptions: sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful}},
+		{name: "error escalation", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL}, preparation: sandboxes.StopPreparationFailed, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_ERROR, wantOptions: sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful}},
+		{name: "force fallback", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL}, preparation: sandboxes.StopPreparationSkipped, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE, wantOptions: sandboxes.StopOptions{Mode: sandboxes.StopModeGraceful}},
+		{name: "explicit force", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE}, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE, wantForce: true},
+		{name: "stopped graceful is idempotent", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL}, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL, sandboxVM: domain.VMStatusStopped, wantNoCall: true},
+		{name: "stopped force is idempotent", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE}, want: agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE, sandboxVM: domain.VMStatusStopped, wantNoCall: true},
+		{name: "force rejects grace period", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE, GracePeriod: durationpb.New(time.Second)}, wantCode: connect.CodeInvalidArgument},
+		{name: "graceful rejects zero period", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL, GracePeriod: durationpb.New(0)}, wantCode: connect.CodeInvalidArgument},
+		{name: "graceful rejects invalid duration", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL, GracePeriod: &durationpb.Duration{Seconds: 315576000001}}, wantCode: connect.CodeInvalidArgument},
+		{name: "rejects unknown mode", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode(99)}, wantCode: connect.CodeInvalidArgument},
+		{name: "pending sandbox cannot stop", request: &agentcomposev2.StopSandboxRequest{Mode: agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL}, wantCode: connect.CodeFailedPrecondition, sandboxVM: domain.VMStatusPending},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sandboxID := identity.NewID(identity.ResourceSandbox, "graceful-stop-contract", test.name)
+			sandboxVM := test.sandboxVM
+			if sandboxVM == "" {
+				sandboxVM = domain.VMStatusRunning
+			}
+			stored := &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: sandboxVM}}
+			stopped := &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}}
+			delegate := &e2eGracefulStopDelegate{outcome: sandboxes.StopOutcome{
+				Sandbox:       stopped,
+				Preparation:   sandboxes.StopPreparationResult{Outcome: test.preparation},
+				DriverStopped: true,
+			}}
+			handler := api.NewSandboxHandler(delegate, &e2eGracefulStopStore{sandbox: stored}, nil, nil)
+			servicePath, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
+			mux := http.NewServeMux()
+			mux.Handle(servicePath, serviceHandler)
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+			client := agentcomposev2connect.NewSandboxServiceClient(server.Client(), server.URL)
+
+			request := *test.request
+			request.SandboxId = sandboxID
+			response, err := client.StopSandbox(context.Background(), connect.NewRequest(&request))
+			if test.wantCode != 0 {
+				if connect.CodeOf(err) != test.wantCode {
+					t.Fatalf("StopSandbox() error = %v, code = %s, want %s", err, connect.CodeOf(err), test.wantCode)
+				}
+				if delegate.sandboxID != "" || delegate.forceSandboxID != "" {
+					t.Fatalf("invalid request reached delegate: graceful=%q force=%q", delegate.sandboxID, delegate.forceSandboxID)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("StopSandbox() error = %v", err)
+			}
+			if response.Msg.GetOutcome() != test.want || response.Msg.GetSandbox().GetStatus() != agentcomposev2.SandboxStatus_SANDBOX_STATUS_STOPPED {
+				t.Fatalf("StopSandbox() outcome/status = %s/%s, want %s/STOPPED", response.Msg.GetOutcome(), response.Msg.GetSandbox().GetStatus(), test.want)
+			}
+			if test.wantNoCall {
+				if delegate.sandboxID != "" || delegate.forceSandboxID != "" {
+					t.Fatalf("idempotent stop reached delegate: graceful=%q force=%q", delegate.sandboxID, delegate.forceSandboxID)
+				}
+				return
+			}
+			if test.wantForce {
+				if delegate.forceSandboxID != sandboxID || delegate.sandboxID != "" {
+					t.Fatalf("force delegate call = force %q graceful %q", delegate.forceSandboxID, delegate.sandboxID)
+				}
+				return
+			}
+			if delegate.sandboxID != sandboxID || delegate.options != test.wantOptions {
+				t.Fatalf("delegate call = id %q options %#v", delegate.sandboxID, delegate.options)
+			}
+		})
+	}
+	t.Run("request cancellation still contains runtime", testCancelledGracefulStopContainment)
+}
+
+func testCancelledGracefulStopContainment(t *testing.T) {
+	t.Helper()
+	sandboxID := identity.NewID(identity.ResourceSandbox, "graceful-stop-contract", "cancelled-request")
+	store := &e2eLifecycleStopStore{sandbox: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, Driver: "docker", VMStatus: domain.VMStatusRunning}}}
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	driver := &e2eCancellationStopDriver{preparationStarted: make(chan struct{})}
+	delegate := &e2eLifecycleStopDelegate{
+		lifecycle: sandboxes.Lifecycle{
+			Config: &appconfig.Config{SandboxStopTimeout: time.Second},
+			Store:  store,
+			Driver: driver,
+			Locks:  sandboxes.NewLifecycleLocks(),
+		},
+		store:  store,
+		result: make(chan e2eLifecycleStopResult, 1),
+	}
+	handler := api.NewSandboxHandler(delegate, store, nil, nil)
+	servicePath, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
+	mux := http.NewServeMux()
+	mux.Handle(servicePath, serviceHandler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewSandboxServiceClient(server.Client(), server.URL)
+	clientResult := make(chan error, 1)
+	go func() {
+		_, err := client.StopSandbox(requestCtx, connect.NewRequest(&agentcomposev2.StopSandboxRequest{
+			SandboxId: sandboxID,
+			Mode:      agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL,
+		}))
+		clientResult <- err
+	}()
+
+	select {
+	case <-driver.preparationStarted:
+		cancelRequest()
+	case <-time.After(time.Second):
+		t.Fatal("graceful stop preparation did not start")
+	}
+
+	select {
+	case result := <-delegate.result:
+		if !errors.Is(result.err, context.Canceled) || !result.outcome.DriverStopped {
+			t.Fatalf("lifecycle stop result = %#v, %v; want stopped with request cancellation", result.outcome, result.err)
+		}
+		if driver.stopCtxErr != nil || !driver.finished || store.sandbox.Summary.VMStatus != domain.VMStatusStopped {
+			t.Fatalf("containment state = context %v, finished %v, status %s", driver.stopCtxErr, driver.finished, store.sandbox.Summary.VMStatus)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("daemon containment did not finish after request cancellation")
+	}
+
+	select {
+	case err := <-clientResult:
+		if !errors.Is(err, context.Canceled) && connect.CodeOf(err) != connect.CodeCanceled {
+			t.Fatalf("client StopSandbox() error = %v, want cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled client call did not return")
+	}
+}
+
+type e2eGracefulStopDelegate struct {
+	outcome        sandboxes.StopOutcome
+	sandboxID      string
+	forceSandboxID string
+	options        sandboxes.StopOptions
+}
+
+func (*e2eGracefulStopDelegate) ResumeSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return nil, nil
+}
+
+func (d *e2eGracefulStopDelegate) StopSandbox(_ context.Context, sandboxID string) (*domain.Sandbox, error) {
+	d.forceSandboxID = sandboxID
+	return d.outcome.Sandbox, nil
+}
+
+func (*e2eGracefulStopDelegate) GetSandboxProxy(context.Context, string) (api.SandboxProxy, error) {
+	return api.SandboxProxy{}, nil
+}
+
+func (d *e2eGracefulStopDelegate) StopSandboxWithOptions(_ context.Context, sandboxID string, options sandboxes.StopOptions) (sandboxes.StopOutcome, error) {
+	d.sandboxID = sandboxID
+	d.options = options
+	return d.outcome, nil
+}
+
+type e2eGracefulStopStore struct {
+	sandbox *domain.Sandbox
+}
+
+func (s *e2eGracefulStopStore) GetSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return s.sandbox, nil
+}
+
+func (*e2eGracefulStopStore) RemoveSandbox(context.Context, string) error {
+	return nil
+}
+
+type e2eLifecycleStopResult struct {
+	outcome sandboxes.StopOutcome
+	err     error
+}
+
+type e2eLifecycleStopDelegate struct {
+	lifecycle sandboxes.Lifecycle
+	store     *e2eLifecycleStopStore
+	result    chan e2eLifecycleStopResult
+}
+
+func (*e2eLifecycleStopDelegate) ResumeSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return nil, nil
+}
+
+func (*e2eLifecycleStopDelegate) StopSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return nil, nil
+}
+
+func (*e2eLifecycleStopDelegate) GetSandboxProxy(context.Context, string) (api.SandboxProxy, error) {
+	return api.SandboxProxy{}, nil
+}
+
+func (d *e2eLifecycleStopDelegate) StopSandboxWithOptions(ctx context.Context, sandboxID string, options sandboxes.StopOptions) (sandboxes.StopOutcome, error) {
+	sandbox, err := d.store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return sandboxes.StopOutcome{}, err
+	}
+	outcome, err := d.lifecycle.StopLoadedWithOptions(ctx, sandbox, options)
+	d.result <- e2eLifecycleStopResult{outcome: outcome, err: err}
+	return outcome, err
+}
+
+type e2eLifecycleStopStore struct {
+	sandbox *domain.Sandbox
+	vmState domain.VMState
+}
+
+func (s *e2eLifecycleStopStore) GetSandbox(context.Context, string) (*domain.Sandbox, error) {
+	return s.sandbox, nil
+}
+
+func (s *e2eLifecycleStopStore) UpdateSandbox(_ context.Context, sandbox *domain.Sandbox) error {
+	s.sandbox = sandbox
+	return nil
+}
+
+func (s *e2eLifecycleStopStore) GetVMState(string) (domain.VMState, error) {
+	return s.vmState, nil
+}
+
+func (s *e2eLifecycleStopStore) SaveVMState(_ string, vmState domain.VMState) error {
+	s.vmState = vmState
+	return nil
+}
+
+func (*e2eLifecycleStopStore) GetProxyState(string) (domain.ProxyState, error) {
+	return domain.ProxyState{}, nil
+}
+
+func (*e2eLifecycleStopStore) AddEvent(context.Context, string, domain.SandboxEvent) error {
+	return nil
+}
+
+func (*e2eLifecycleStopStore) RemoveSandbox(context.Context, string) error {
+	return nil
+}
+
+type e2eCancellationStopDriver struct {
+	preparationStarted chan struct{}
+	stopCtxErr         error
+	finished           bool
+}
+
+func (*e2eCancellationStopDriver) StartSandboxVM(context.Context, *domain.Sandbox) error {
+	return nil
+}
+
+func (d *e2eCancellationStopDriver) StopSandboxVM(ctx context.Context, _ *domain.Sandbox) error {
+	d.stopCtxErr = ctx.Err()
+	return d.stopCtxErr
+}
+
+func (d *e2eCancellationStopDriver) PrepareSandboxStop(ctx context.Context, _ *domain.Sandbox, _ domain.VMState, _ time.Duration) (sandboxes.StopPreparationResult, error) {
+	close(d.preparationStarted)
+	<-ctx.Done()
+	return sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationFailed, Error: ctx.Err()}, nil
+}
+
+func (d *e2eCancellationStopDriver) FinishSandboxStop(*domain.Sandbox) {
+	d.finished = true
+}

--- a/test/e2e/graceful_sandbox_stop_host_daemon_test.go
+++ b/test/e2e/graceful_sandbox_stop_host_daemon_test.go
@@ -1,0 +1,399 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+const (
+	gracefulStopE2EDriversEnv     = "AGENT_COMPOSE_E2E_GRACEFUL_STOP_DRIVERS"
+	gracefulStopE2EImageEnv       = "AGENT_COMPOSE_E2E_GRACEFUL_STOP_IMAGE"
+	gracefulStopE2ELegacyImageEnv = "AGENT_COMPOSE_E2E_GRACEFUL_STOP_LEGACY_IMAGE"
+)
+
+func TestE2EGracefulSandboxStopHostDaemon(t *testing.T) {
+	drivers := gracefulStopE2EDrivers(t)
+	image := strings.TrimSpace(os.Getenv(gracefulStopE2EImageEnv))
+	if image == "" {
+		t.Fatalf("%s is required when %s is set", gracefulStopE2EImageEnv, gracefulStopE2EDriversEnv)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+	repoRoot := e2eRepoRoot(t)
+	testRoot, err := os.MkdirTemp(repoRoot, ".graceful-stop-e2e-")
+	if err != nil {
+		t.Fatalf("create runtime-visible test root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(testRoot) })
+
+	binary := e2eDaemonBinary(t, ctx, repoRoot, testRoot)
+	listenAddress := unusedLoopbackAddress(t)
+	baseURL := "http://" + listenAddress
+	daemon := startE2EDaemonWithEnv(t, binary, repoRoot, testRoot, listenAddress, image, map[string]string{
+		"SANDBOX_START_TIMEOUT": "10m",
+	})
+	waitForE2EDaemon(t, ctx, daemon, baseURL)
+
+	httpClient := newE2EHTTPClient()
+	httpClient.Timeout = 5 * time.Minute
+	clients := gracefulStopE2EClients{
+		projects:  agentcomposev2connect.NewProjectServiceClient(httpClient, baseURL),
+		runs:      agentcomposev2connect.NewRunServiceClient(httpClient, baseURL),
+		execs:     agentcomposev2connect.NewExecServiceClient(httpClient, baseURL),
+		sandboxes: agentcomposev2connect.NewSandboxServiceClient(httpClient, baseURL),
+	}
+
+	for _, driver := range drivers {
+		driver := driver
+		t.Run(driver+"/success", func(t *testing.T) {
+			fixture := newGracefulStopE2ESandbox(t, ctx, clients, testRoot, image, driver, "success", daemon)
+			result := fixture.startExec(ctx, gracefulStopSuccessScript)
+			fixture.waitForWorkspaceFile(t, "ready")
+
+			response, err := clients.sandboxes.StopSandbox(ctx, connect.NewRequest(&agentcomposev2.StopSandboxRequest{
+				SandboxId:   fixture.sandboxID,
+				Mode:        agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL,
+				GracePeriod: durationpb.New(15 * time.Second),
+			}))
+			if err != nil {
+				t.Fatalf("graceful StopSandbox: %v\ndaemon log:\n%s", err, daemon.logs.String())
+			}
+			if got := response.Msg.GetOutcome(); got != agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_GRACEFUL {
+				t.Fatalf("graceful StopSandbox outcome = %s, want GRACEFUL", got)
+			}
+			assertGracefulStopE2EStopped(t, response.Msg.GetSandbox())
+			fixture.assertWorkspaceFile(t, "cleanup-complete", "cleanup-complete")
+
+			execResult := waitForGracefulStopE2EExec(t, result)
+			if execResult.err != nil {
+				t.Fatalf("Exec RPC returned error: %v", execResult.err)
+			}
+			if execResult.result.GetSuccess() || execResult.result.GetExitCode() != 0 || !strings.Contains(execResult.result.GetOutput(), "cleanup-output") {
+				t.Fatalf("gracefully cancelled Exec result: %s", e2eExecResultSummary(execResult.result))
+			}
+			fixture.assertCommandArtifacts(t, "partial-output", "cleanup-output")
+		})
+	}
+
+	if slices.Contains(drivers, "docker") {
+		t.Run("docker/timeout_escalates", func(t *testing.T) {
+			fixture := newGracefulStopE2ESandbox(t, ctx, clients, testRoot, image, "docker", "timeout", daemon)
+			result := fixture.startExec(ctx, gracefulStopIgnoreTermScript)
+			fixture.waitForWorkspaceFile(t, "ready")
+
+			response, err := clients.sandboxes.StopSandbox(ctx, connect.NewRequest(&agentcomposev2.StopSandboxRequest{
+				SandboxId:   fixture.sandboxID,
+				Mode:        agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL,
+				GracePeriod: durationpb.New(time.Second),
+			}))
+			if err != nil {
+				t.Fatalf("timeout StopSandbox: %v\ndaemon log:\n%s", err, daemon.logs.String())
+			}
+			if got := response.Msg.GetOutcome(); got != agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT {
+				t.Fatalf("timeout StopSandbox outcome = %s, want FORCE_AFTER_GRACE_TIMEOUT", got)
+			}
+			assertGracefulStopE2EStopped(t, response.Msg.GetSandbox())
+			_ = waitForGracefulStopE2EExec(t, result)
+		})
+
+		if legacyImage := strings.TrimSpace(os.Getenv(gracefulStopE2ELegacyImageEnv)); legacyImage != "" {
+			t.Run("docker/legacy_guest_escalates", func(t *testing.T) {
+				fixture := newGracefulStopE2ESandbox(t, ctx, clients, testRoot, legacyImage, "docker", "legacy", daemon)
+				result := fixture.startExec(ctx, gracefulStopSuccessScript)
+				fixture.waitForWorkspaceFile(t, "ready")
+
+				response, err := clients.sandboxes.StopSandbox(ctx, connect.NewRequest(&agentcomposev2.StopSandboxRequest{
+					SandboxId:   fixture.sandboxID,
+					Mode:        agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_GRACEFUL,
+					GracePeriod: durationpb.New(time.Second),
+				}))
+				if err != nil {
+					t.Fatalf("legacy guest StopSandbox: %v\ndaemon log:\n%s", err, daemon.logs.String())
+				}
+				if got := response.Msg.GetOutcome(); got != agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE_AFTER_GRACE_TIMEOUT {
+					t.Fatalf("legacy guest StopSandbox outcome = %s, want FORCE_AFTER_GRACE_TIMEOUT", got)
+				}
+				assertGracefulStopE2EStopped(t, response.Msg.GetSandbox())
+				_ = waitForGracefulStopE2EExec(t, result)
+			})
+		}
+
+		t.Run("docker/explicit_force", func(t *testing.T) {
+			fixture := newGracefulStopE2ESandbox(t, ctx, clients, testRoot, image, "docker", "force", daemon)
+			result := fixture.startExec(ctx, gracefulStopIgnoreTermScript)
+			fixture.waitForWorkspaceFile(t, "ready")
+
+			response, err := clients.sandboxes.StopSandbox(ctx, connect.NewRequest(&agentcomposev2.StopSandboxRequest{
+				SandboxId: fixture.sandboxID,
+				Mode:      agentcomposev2.SandboxStopMode_SANDBOX_STOP_MODE_FORCE,
+			}))
+			if err != nil {
+				t.Fatalf("force StopSandbox: %v\ndaemon log:\n%s", err, daemon.logs.String())
+			}
+			if got := response.Msg.GetOutcome(); got != agentcomposev2.SandboxStopOutcome_SANDBOX_STOP_OUTCOME_FORCE {
+				t.Fatalf("force StopSandbox outcome = %s, want FORCE", got)
+			}
+			assertGracefulStopE2EStopped(t, response.Msg.GetSandbox())
+			_ = waitForGracefulStopE2EExec(t, result)
+		})
+	}
+}
+
+const gracefulStopSuccessScript = `
+set -u
+trap 'sleep 1; printf %s cleanup-complete > cleanup-complete; printf %s\\n cleanup-output; exit 0' TERM
+printf %s ready > ready
+printf %s\\n partial-output
+sleep 60
+`
+
+const gracefulStopIgnoreTermScript = `
+set -u
+trap '' TERM
+printf %s ready > ready
+printf %s\\n partial-output
+while :; do sleep 1; done
+`
+
+type gracefulStopE2EClients struct {
+	projects  agentcomposev2connect.ProjectServiceClient
+	runs      agentcomposev2connect.RunServiceClient
+	execs     agentcomposev2connect.ExecServiceClient
+	sandboxes agentcomposev2connect.SandboxServiceClient
+}
+
+type gracefulStopE2EFixture struct {
+	sandboxID string
+	hostRoot  string
+	clients   gracefulStopE2EClients
+}
+
+type gracefulStopE2EExecResult struct {
+	result *agentcomposev2.ExecResult
+	err    error
+}
+
+func gracefulStopE2EDrivers(t *testing.T) []string {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(gracefulStopE2EDriversEnv))
+	if raw == "" {
+		t.Skipf("set %s to docker, boxlite, microsandbox, or a comma-separated subset", gracefulStopE2EDriversEnv)
+	}
+	seen := map[string]bool{}
+	var drivers []string
+	for _, item := range strings.Split(raw, ",") {
+		driver := strings.ToLower(strings.TrimSpace(item))
+		switch driver {
+		case "docker", "boxlite", "microsandbox":
+		default:
+			t.Fatalf("unsupported %s entry %q", gracefulStopE2EDriversEnv, item)
+		}
+		if !seen[driver] {
+			seen[driver] = true
+			drivers = append(drivers, driver)
+		}
+	}
+	if len(drivers) == 0 {
+		t.Fatalf("%s did not select a driver", gracefulStopE2EDriversEnv)
+	}
+	return drivers
+}
+
+func newGracefulStopE2ESandbox(
+	t *testing.T,
+	ctx context.Context,
+	clients gracefulStopE2EClients,
+	testRoot string,
+	image string,
+	driver string,
+	scenario string,
+	daemon *e2eDaemonProcess,
+) gracefulStopE2EFixture {
+	t.Helper()
+	name := fmt.Sprintf("graceful-stop-%s-%s-%d", driver, scenario, time.Now().UnixNano())
+	project, err := clients.projects.ApplyProject(ctx, connect.NewRequest(&agentcomposev2.ApplyProjectRequest{
+		Spec: &agentcomposev2.ProjectSpec{
+			Name: name,
+			Agents: []*agentcomposev2.AgentSpec{{
+				Name:     "worker",
+				Provider: "codex",
+				Image:    image,
+				Driver:   gracefulStopE2EDriverSpec(driver),
+			}},
+		},
+		Source: &agentcomposev2.ProjectSource{
+			ComposePath: filepath.Join(testRoot, name+".yml"),
+			ProjectDir:  testRoot,
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ApplyProject for %s: %v", driver, err)
+	}
+	if !project.Msg.GetApplied() {
+		t.Fatalf("ApplyProject for %s was rejected: %s", driver, formatE2EProjectIssues(project.Msg.GetIssues()))
+	}
+	projectID := project.Msg.GetProject().GetSummary().GetProjectId()
+	run, err := clients.runs.RunAgent(ctx, connect.NewRequest(&agentcomposev2.RunAgentRequest{
+		ProjectId:       projectID,
+		AgentName:       "worker",
+		Command:         "printf sandbox-ready",
+		Source:          agentcomposev2.RunSource_RUN_SOURCE_API,
+		CleanupPolicy:   agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_KEEP_RUNNING,
+		ClientRequestId: name,
+	}))
+	if err != nil {
+		t.Fatalf("RunAgent for %s: %v\ndaemon log:\n%s", driver, err, daemon.logs.String())
+	}
+	detail := run.Msg.GetRun()
+	sandboxID := detail.GetSummary().GetSandboxId()
+	if sandboxID == "" || detail.GetSummary().GetStatus() != agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED {
+		t.Fatalf(
+			"RunAgent for %s returned sandbox_id=%q status=%s error=%q\ndaemon log:\n%s",
+			driver,
+			sandboxID,
+			detail.GetSummary().GetStatus(),
+			detail.GetSummary().GetError(),
+			daemon.logs.String(),
+		)
+	}
+	hostRoot := gracefulStopE2EHostRoot(t, testRoot, sandboxID)
+	fixture := gracefulStopE2EFixture{sandboxID: sandboxID, hostRoot: hostRoot, clients: clients}
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		_, _ = clients.sandboxes.RemoveSandbox(cleanupCtx, connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID, Force: true}))
+	})
+	return fixture
+}
+
+func gracefulStopE2EHostRoot(t *testing.T, testRoot string, sandboxID string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(testRoot, "sandboxes", "*", "*", "*", sandboxID))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("host sandbox roots for %s = %v, error = %v", sandboxID, matches, err)
+	}
+	return matches[0]
+}
+
+func gracefulStopE2EDriverSpec(driver string) *agentcomposev2.DriverSpec {
+	spec := &agentcomposev2.DriverSpec{Name: driver}
+	switch driver {
+	case "boxlite":
+		spec.Config = &agentcomposev2.DriverSpec_Boxlite{Boxlite: &agentcomposev2.BoxliteDriverSpec{}}
+	case "microsandbox":
+		spec.Config = &agentcomposev2.DriverSpec_Microsandbox{Microsandbox: &agentcomposev2.MicrosandboxDriverSpec{}}
+	default:
+		spec.Config = &agentcomposev2.DriverSpec_Docker{Docker: &agentcomposev2.DockerDriverSpec{}}
+	}
+	return spec
+}
+
+func (f gracefulStopE2EFixture) startExec(ctx context.Context, script string) <-chan gracefulStopE2EExecResult {
+	result := make(chan gracefulStopE2EExecResult, 1)
+	go func() {
+		response, err := f.clients.execs.Exec(ctx, connect.NewRequest(&agentcomposev2.ExecRequest{
+			Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: f.sandboxID},
+			Command: &agentcomposev2.ExecCommand{
+				Command: "sh",
+				Args:    []string{"-c", script},
+			},
+			Cwd:            "/workspace",
+			TimeoutMs:      uint32((5 * time.Minute).Milliseconds()),
+			MaxOutputBytes: 64 << 10,
+		}))
+		if response == nil || response.Msg == nil {
+			result <- gracefulStopE2EExecResult{err: err}
+			return
+		}
+		result <- gracefulStopE2EExecResult{result: response.Msg.GetResult(), err: err}
+	}()
+	return result
+}
+
+func (f gracefulStopE2EFixture) waitForWorkspaceFile(t *testing.T, name string) {
+	t.Helper()
+	path := filepath.Join(f.hostRoot, "workspace", name)
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("workspace file %s did not appear", name)
+}
+
+func (f gracefulStopE2EFixture) assertWorkspaceFile(t *testing.T, name string, want string) {
+	t.Helper()
+	if got := f.workspaceFile(t, name); got != want {
+		t.Fatalf("workspace file %s = %q, want %q", name, got, want)
+	}
+}
+
+func (f gracefulStopE2EFixture) workspaceFile(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(f.hostRoot, "workspace", name))
+	if err != nil {
+		t.Fatalf("read workspace file %s: %v", name, err)
+	}
+	return string(data)
+}
+
+func (f gracefulStopE2EFixture) assertCommandArtifacts(t *testing.T, fragments ...string) {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(f.hostRoot, "state", "exec", "*", "command-result.json"))
+	if err != nil || len(paths) != 1 {
+		t.Fatalf("command result artifacts = %v, error = %v", paths, err)
+	}
+	data, err := os.ReadFile(paths[0])
+	if err != nil {
+		t.Fatalf("read command result artifact: %v", err)
+	}
+	var artifact struct {
+		Output  string `json:"output"`
+		Success bool   `json:"success"`
+	}
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		t.Fatalf("decode command result artifact: %v", err)
+	}
+	if artifact.Success {
+		t.Fatal("gracefully cancelled command artifact unexpectedly reports success")
+	}
+	for _, fragment := range fragments {
+		if !strings.Contains(artifact.Output, fragment) {
+			t.Fatalf("command result artifact output does not contain %q", fragment)
+		}
+	}
+}
+
+func waitForGracefulStopE2EExec(t *testing.T, result <-chan gracefulStopE2EExecResult) gracefulStopE2EExecResult {
+	t.Helper()
+	select {
+	case completed := <-result:
+		return completed
+	case <-time.After(30 * time.Second):
+		t.Fatal("Exec RPC did not finish after sandbox stop")
+		return gracefulStopE2EExecResult{}
+	}
+}
+
+func assertGracefulStopE2EStopped(t *testing.T, sandbox *agentcomposev2.Sandbox) {
+	t.Helper()
+	if sandbox == nil || sandbox.GetStatus() != agentcomposev2.SandboxStatus_SANDBOX_STATUS_STOPPED {
+		t.Fatalf("StopSandbox status = %v, want STOPPED", sandbox.GetStatus())
+	}
+}


### PR DESCRIPTION
## Summary

- add graceful sandbox stop with a configurable grace period and explicit stop outcomes across the CLI and v2 API
- track each outer guest runtime execution and signal only its validated PID through a driver-owned control execution; agent-compose does not traverse or manage guest child process trees
- keep existing guest images compatible: guests that do not publish readiness continue running normally and fall back to runtime containment when the grace period expires
- define and document the guest readiness ABI, use bounded signal retries, and cover Docker, BoxLite, and Microsandbox behavior

Closes #539

## Testing

- focused Go adapter, driver, and host-daemon E2E tests: PASS
- full Go test suite: PASS
- adapter and driver race tests: PASS
- JavaScript unit, integration, and E2E suites: PASS
- lint, build, and documentation validation: PASS
- real Docker regression matrix covering graceful completion, grace-timeout escalation, legacy guest compatibility, and explicit force stop: PASS
- real BoxLite graceful-stop regression on a KVM-capable host: PASS
- real Microsandbox graceful-stop regression on a KVM-capable host: PASS

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] Existing guest images remain compatible without requiring an agentkit update.
- [x] No secrets, private endpoints, internal certificates, test image identifiers, or local runtime state included.