### PR TITLE
fix(ci): prevent non-release tags updating latest

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -321,6 +321,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
+          # Stable tags are selected explicitly below. The action's automatic
+          # latest flavor would otherwise publish latest for every Git tag.
+          flavor: latest=false
           tags: |
             type=ref,event=branch,suffix=${{ matrix.tag_suffix }}
             type=ref,event=tag,suffix=${{ matrix.tag_suffix }}

--- a/scripts/tests/test-image-ci-contract.sh
+++ b/scripts/tests/test-image-ci-contract.sh
@@ -384,6 +384,13 @@ if [[ -n $merge_job ]]; then
   require_regex "$merge_job" 'docker buildx imagetools create' 'multi-arch manifest creation'
   require_regex "$merge_job" 'type=ref,event=tag,suffix=\$\{\{[[:space:]]*matrix\.tag_suffix' \
     'variant-aware pushed Git tag image metadata'
+  metadata_step=$(step_containing "$merge_job" 'docker/metadata-action@v5')
+  if [[ -z $metadata_step ]]; then
+    fail 'manifest Docker metadata step'
+  else
+    require_regex "$metadata_step" 'flavor:[[:space:]]*latest=false' \
+      'disabled automatic latest tag metadata'
+  fi
   require_regex "$merge_job" "type=raw,value=\\$\\{\\{[[:space:]]*matrix\.stable_tag[[:space:]]*\\}\\},enable=\\$\\{\\{[[:space:]]*startsWith\\(github\\.ref,[[:space:]]*['\"]refs/tags/v['\"]\\)[[:space:]]*\\}\\}" \
     'version-tag-only stable image metadata'
   require_regex "$merge_job" 'username:[[:space:]]*\$\{\{[[:space:]]*secrets\.DOCKERIO_USERNAME' \


### PR DESCRIPTION
## Summary

- disable docker/metadata-action automatic latest tag generation in the manifest merge job
- keep stable latest and archlinux tags controlled exclusively by the existing v-prefixed release-tag condition
- add an image CI contract regression check for the disabled automatic latest flavor

This prevents tags such as runtime-v0.8.0 from overwriting the published latest daemon and guest manifests.

## Testing

- `./scripts/tests/test-image-ci-contract.sh`
- `bash -n scripts/tests/test-image-ci-contract.sh`
- `git diff --check`

Not run: `task test:deploy` because Task and Go are unavailable in the current environment. ShellCheck and actionlint are also unavailable.

## Checklist

- [x] Documentation updated when behavior or configuration changed. No public documentation change is required for this CI-only correction.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.