### PR TITLE
feat(cli): add project name short flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ See the [command line manual](docs/pages/command-line-manual.md) for the full fi
 | `agent-compose down` | Disable managed schedulers and stop sandboxes. |
 | `agent-compose status` | Check daemon status. |
 
-Useful global flags: `--file, -f` (choose a compose file), `--project-name` (select a deployed project by name),
+Useful global flags: `--file, -f` (choose a compose file), `--project-name, -p` (select a deployed project by name),
 `--json` (stable JSON for scripts), `--host` / `AGENT_COMPOSE_HOST` (connect to a
 TCP daemon), and `AGENT_COMPOSE_SOCKET` (Unix socket path). Full reference:
 [docs/pages/command-line-manual.md](docs/pages/command-line-manual.md).

--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -14,7 +14,7 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 		{
 			name: "root",
 			args: []string{"--help"},
-			want: []string{"agent-compose daemon and CLI", "--host", "--file", "--project-name", "--json", "--timeout", "Available Commands"},
+			want: []string{"agent-compose daemon and CLI", "--host", "--file", "-p, --project-name", "--json", "--timeout", "Available Commands"},
 		},
 		{
 			name: "config",

--- a/cmd/agent-compose/cli_project_up_test.go
+++ b/cmd/agent-compose/cli_project_up_test.go
@@ -45,6 +45,10 @@ agents: {}
 			args: []string{"up", "--file", composePath, "--project-name", "file-project", "--host", server.URL},
 		},
 		{
+			name: "project name shorthand is still unsupported",
+			args: []string{"up", "--file", composePath, "-p", "file-project", "--host", server.URL},
+		},
+		{
 			name: "implicit compose source is not read",
 			args: []string{"up", "--project-name", "selected-project", "--host", server.URL},
 		},

--- a/cmd/agent-compose/cli_root.go
+++ b/cmd/agent-compose/cli_root.go
@@ -60,7 +60,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 
 	root.PersistentFlags().StringVar(&options.Host, "host", "", "Daemon HTTP endpoint")
 	root.PersistentFlags().StringVarP(&options.ComposeFile, "file", "f", "", "Path to agent-compose.yml")
-	root.PersistentFlags().StringVar(&options.ProjectName, "project-name", "", "Select a deployed project by name (not supported by up or project up)")
+	root.PersistentFlags().StringVarP(&options.ProjectName, "project-name", "p", "", "Select a deployed project by name (not supported by up or project up)")
 	root.PersistentFlags().BoolVar(&options.JSON, "json", false, "Print machine-readable JSON")
 	root.PersistentFlags().DurationVar(&options.Timeout, "timeout", 0, "Maximum duration of each daemon RPC, including streams; 0 disables the timeout")
 

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -21,7 +21,7 @@ Global options are placed between `agent-compose` and the subcommand, and apply 
 | --- | --- |
 | `-f, --file <path>` | Path to the project config file. Both `agent-compose.yml` and `agent-compose.yaml` are supported. When this option is used, the project root is the config file directory, so you do not need to `cd` into it. |
 | `--host <endpoint>` | Daemon HTTP endpoint. This can target a local daemon or a remote daemon. |
-| `--project-name <name>` | Select an existing daemon project by name. It is not supported by `up` or `project up` and never changes the project name declared by a compose file. |
+| `-p, --project-name <name>` | Select an existing daemon project by name. It is not supported by `up` or `project up` and never changes the project name declared by a compose file. |
 | `--json` | Print machine-readable JSON for scripts, AI agents, and automation. |
 | `--timeout <duration>` | Maximum total duration of each CLI-to-daemon RPC, including streaming responses. The default `0` disables the total RPC timeout. |
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -21,7 +21,7 @@ agent-compose [global options] <command> [command options] [arguments]
 | --- | --- |
 | `-f, --file <path>` | 指定 project 配置文件。支持 `agent-compose.yml` 和 `agent-compose.yaml`。使用该参数后，可以在任意目录操作该 project，project root 为配置文件所在目录。 |
 | `--host <endpoint>` | 指定 daemon 地址。可以连接本机 daemon，也可以连接远程 daemon。 |
-| `--project-name <name>` | 按名称选择 daemon 中已部署的 project；`up` 和 `project up` 不支持该参数，且它不会修改 compose 文件声明的项目名称。 |
+| `-p, --project-name <name>` | 按名称选择 daemon 中已部署的 project；`up` 和 `project up` 不支持该参数，且它不会修改 compose 文件声明的项目名称。 |
 | `--json` | 使用 JSON 输出，供脚本、AI 和自动化系统解析。 |
 | `--timeout <duration>` | 每个 CLI→daemon RPC 的最大总时长，包括读取流式响应；默认值 `0` 表示不设置 RPC 总超时。 |
 


### PR DESCRIPTION
## Summary

- Add `-p` as the shorthand for the global `--project-name` option.
- Cover the shorthand in CLI help and project-selection behavior tests.
- Document the shorthand in the README and the English and Chinese command-line manuals.

## Testing

- `go test ./cmd/agent-compose`
- `task lint`
- `task build`
- `task test`
- `task docs:build`

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.