### PR TITLE
fix(app): repair project patch integration test

### DIFF
--- a/pkg/agentcompose/app/project_patch_integration_test.go
+++ b/pkg/agentcompose/app/project_patch_integration_test.go
@@ -40,7 +40,7 @@ func TestIntegrationPatchProjectReplacementAndConcurrency(t *testing.T) {
 	controller := projects.NewController(projects.ControllerDependencies{
 		Config: config, Store: store, Volumes: volumes.NewManager(store),
 	})
-	handler := api.NewProjectHandler(projectControllerDelegate{controller: controller}, store, nil)
+	handler := api.NewProjectHandler(projectControllerDelegate{controller: controller}, store, nil, nil)
 	_, connectHandler := agentcomposev2connect.NewProjectServiceHandler(handler)
 	server := httptest.NewServer(connectHandler)
 	t.Cleanup(server.Close)


### PR DESCRIPTION
## Summary

- update the PatchProject integration fixture for the current four-argument NewProjectHandler signature
- restore app package type-checking and CI execution after the agent model resolver dependency was added

## Testing

- `go test ./pkg/agentcompose/app`
- `go build ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect`
- `go run ./cmd/agent-compose --help`
- `git diff --check`
- Full tests were not run because the change only updates test dependency wiring.
- `task lint` was attempted but could not run because the local golangci-lint binary was built with Go 1.25, below the repository target Go 1.26.2.

## Checklist

- [x] Documentation updated when behavior or configuration changed. (Not applicable: test-only wiring fix.)
- [x] Tests added or updated for user-visible behavior. (Not applicable: no user-visible behavior changed; the existing integration test setup was repaired.)
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.