### PR TITLE
feat(capproxy): forward MPI metadata to OctoBus

### DIFF
--- a/cmd/agent-compose/cli_daemon.go
+++ b/cmd/agent-compose/cli_daemon.go
@@ -157,6 +157,7 @@ func installDaemonMiddleware(app *echo.Echo, conf *config.Config) {
 	app.Use(middleware.RequestLogger())
 	app.Use(middleware.Recover())
 	app.Use(newDaemonAuthMiddleware(conf))
+	app.Use(newDaemonTrustedHeadersMiddleware())
 }
 
 func (a *DaemonApp) StartBackground() error {

--- a/cmd/agent-compose/daemon_trusted_headers.go
+++ b/cmd/agent-compose/daemon_trusted_headers.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	domain "agent-compose/pkg/model"
+)
+
+const xMPIPrefix = "x-mpi-"
+
+// newDaemonTrustedHeadersMiddleware reads x-mpi-* headers injected by the
+// deployment's trusted ingress, validates values, and stores them in the
+// request context. The ingress must prevent direct daemon access and strip
+// client-supplied x-mpi-* values before injecting its own.
+func newDaemonTrustedHeadersMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			headers, err := translateTrustedHeaders(c.Request())
+			if err != nil {
+				return err
+			}
+			if len(headers) == 0 {
+				return next(c)
+			}
+			ctx := domain.NewContextWithTrustedHeaders(c.Request().Context(), headers)
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	}
+}
+
+func translateTrustedHeaders(r *http.Request) ([]domain.TrustedHeader, error) {
+	names := make([]string, 0, len(r.Header))
+	for name := range r.Header {
+		lower := strings.ToLower(name)
+		if strings.HasPrefix(lower, xMPIPrefix) {
+			names = append(names, name)
+		}
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return strings.ToLower(names[i]) < strings.ToLower(names[j])
+	})
+
+	var out []domain.TrustedHeader
+	for _, name := range names {
+		lower := strings.ToLower(name)
+		if err := validateTrustedHeaderName(lower); err != nil {
+			return nil, err
+		}
+		for _, val := range r.Header.Values(name) {
+			val = strings.TrimSpace(val)
+			if err := validateTrustedHeaderValue(val); err != nil {
+				return nil, err
+			}
+			out = append(out, domain.TrustedHeader{Name: lower, Value: val})
+		}
+	}
+	return out, nil
+}
+
+func validateTrustedHeaderName(name string) error {
+	suffix := strings.TrimPrefix(strings.ToLower(name), xMPIPrefix)
+	if suffix == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "trusted header name must include a suffix")
+	}
+	for i := 0; i < len(suffix); i++ {
+		b := suffix[i]
+		if (b < 'a' || b > 'z') && (b < '0' || b > '9') && b != '-' && b != '_' && b != '.' {
+			return echo.NewHTTPError(http.StatusBadRequest, "trusted header name contains characters unsupported by gRPC metadata")
+		}
+	}
+	return nil
+}
+
+func validateTrustedHeaderValue(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "trusted header value must not be empty")
+	}
+	if len(value) < 1 || len(value) > 256 {
+		return echo.NewHTTPError(http.StatusBadRequest, "trusted header value must be 1-256 bytes")
+	}
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		if b < 0x20 || b > 0x7e {
+			return echo.NewHTTPError(http.StatusBadRequest, "trusted header value must contain printable ASCII only")
+		}
+	}
+	return nil
+}

--- a/cmd/agent-compose/daemon_trusted_headers_test.go
+++ b/cmd/agent-compose/daemon_trusted_headers_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestDaemonTrustedHeadersMiddleware(t *testing.T) {
+	tests := []struct {
+		name        string
+		headers     map[string]string
+		wantHeaders []domain.TrustedHeader
+		wantStatus  int
+	}{
+		{
+			name:       "no mpi headers",
+			headers:    map[string]string{"X-Custom": "val"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:        "single mpi header",
+			headers:     map[string]string{"X-Mpi-User-Id": "u1"},
+			wantHeaders: []domain.TrustedHeader{{Name: "x-mpi-user-id", Value: "u1"}},
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name: "multiple mpi headers",
+			headers: map[string]string{
+				"X-Mpi-User-Id":  "u1",
+				"X-Mpi-Username": "alice",
+			},
+			wantHeaders: []domain.TrustedHeader{
+				{Name: "x-mpi-user-id", Value: "u1"},
+				{Name: "x-mpi-username", Value: "alice"},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "non-mpi prefix ignored",
+			headers:    map[string]string{"X-Mpi": "val"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "control char rejected",
+			headers:    map[string]string{"X-Mpi-User-Id": "u\x001"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty value rejected",
+			headers:    map[string]string{"X-Mpi-Empty": "  "},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "value over 256 bytes rejected",
+			headers:    map[string]string{"X-Mpi-Long": string(make([]byte, 257))},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing suffix rejected",
+			headers:    map[string]string{"X-Mpi-": "value"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "grpc invalid suffix rejected",
+			headers:    map[string]string{"X-Mpi-Role!": "admin"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non ascii value rejected",
+			headers:    map[string]string{"X-Mpi-Username": "张三"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:        "mpi header value is trimmed",
+			headers:     map[string]string{"X-Mpi-Role": " admin ", "X-Other": "x"},
+			wantHeaders: []domain.TrustedHeader{{Name: "x-mpi-role", Value: "admin"}},
+			wantStatus:  http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := echo.New()
+			app.Use(newDaemonTrustedHeadersMiddleware())
+			app.Any("/*", func(c echo.Context) error {
+				got := domain.TrustedHeadersFromContext(c.Request().Context())
+				if !reflect.DeepEqual(got, test.wantHeaders) {
+					t.Errorf("trusted headers = %v, want %v", got, test.wantHeaders)
+				}
+				return c.NoContent(http.StatusOK)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			for k, v := range test.headers {
+				req.Header.Set(k, v)
+			}
+			rec := httptest.NewRecorder()
+			app.ServeHTTP(rec, req)
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, test.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestTranslateTrustedHeadersEmpty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Custom", "val")
+	headers, err := translateTrustedHeaders(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(headers) != 0 {
+		t.Fatalf("expected empty trusted headers, got %v", headers)
+	}
+}
+
+func TestTranslateTrustedHeadersPreservesRepeatedValues(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header["X-Mpi-Role"] = []string{"admin", "auditor"}
+	headers, err := translateTrustedHeaders(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []domain.TrustedHeader{
+		{Name: "x-mpi-role", Value: "admin"},
+		{Name: "x-mpi-role", Value: "auditor"},
+	}
+	if !reflect.DeepEqual(headers, want) {
+		t.Fatalf("trusted headers = %#v, want %#v", headers, want)
+	}
+}
+
+func TestValidateTrustedHeaderValue(t *testing.T) {
+	tests := []struct {
+		value string
+		ok    bool
+	}{
+		{"hello", true},
+		{"", false},
+		{"  ", false},
+		{string(make([]byte, 257)), false},
+		{"a\x00b", false},
+		{"a\x1fb", false},
+		{"a\x7fb", false},
+		{"a\x80b", false},
+		{"张三", false},
+		{"a\nb", false},
+		{"~", true},
+	}
+	for _, test := range tests {
+		err := validateTrustedHeaderValue(test.value)
+		if (err == nil) != test.ok {
+			t.Errorf("validateTrustedHeaderValue(%q) = %v, want ok=%v", test.value, err, test.ok)
+		}
+	}
+}

--- a/pkg/agentcompose/adapters/adapter_helpers_coverage_test.go
+++ b/pkg/agentcompose/adapters/adapter_helpers_coverage_test.go
@@ -257,7 +257,7 @@ func TestCapabilitySandboxResolverCoverage(t *testing.T) {
 	if _, err := resolver.ResolveCapabilitySandbox(ctx, "token-2"); err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("revoked token error = %v", err)
 	}
-	resolver.IndexSandbox(running)
+	resolver.IndexSandbox(running, nil)
 	binding, err = resolver.ResolveCapabilitySandbox(ctx, "token-2")
 	if err != nil || binding.SandboxID != "sandbox-running" {
 		t.Fatalf("indexed binding = %#v err=%v", binding, err)

--- a/pkg/agentcompose/adapters/capability_sandbox.go
+++ b/pkg/agentcompose/adapters/capability_sandbox.go
@@ -46,7 +46,7 @@ func (r *CapabilitySandboxResolver) Rebuild(ctx context.Context) error {
 			return err
 		}
 		for _, sandbox := range result.Sandboxes {
-			indexCapabilitySandbox(tokens, tokensBySandbox, sandbox)
+			indexCapabilitySandbox(tokens, tokensBySandbox, sandbox, nil)
 		}
 		if !result.HasMore {
 			break
@@ -61,7 +61,10 @@ func (r *CapabilitySandboxResolver) Rebuild(ctx context.Context) error {
 	return nil
 }
 
-func (r *CapabilitySandboxResolver) IndexSandbox(sandbox *domain.Sandbox) {
+// IndexSandbox replaces a sandbox binding with request-scoped trusted headers.
+// The headers live only in this resolver and are lost on rebuild or daemon
+// restart. Passing nil explicitly clears headers from an earlier binding.
+func (r *CapabilitySandboxResolver) IndexSandbox(sandbox *domain.Sandbox, headers []domain.TrustedHeader) {
 	if r == nil || sandbox == nil {
 		return
 	}
@@ -69,7 +72,7 @@ func (r *CapabilitySandboxResolver) IndexSandbox(sandbox *domain.Sandbox) {
 	defer r.mu.Unlock()
 	r.ensureMapsLocked()
 	r.revokeSandboxLocked(sandbox.Summary.ID)
-	indexCapabilitySandbox(r.tokens, r.tokensBySandbox, sandbox)
+	indexCapabilitySandbox(r.tokens, r.tokensBySandbox, sandbox, headers)
 }
 
 func (r *CapabilitySandboxResolver) RevokeSandbox(sandboxID string) {
@@ -133,7 +136,7 @@ func (r *CapabilitySandboxResolver) revokeSandboxLocked(sandboxID string) {
 	delete(r.tokensBySandbox, sandboxID)
 }
 
-func indexCapabilitySandbox(tokens map[string]capproxy.SandboxBinding, tokensBySandbox map[string]map[string]struct{}, sandbox *domain.Sandbox) {
+func indexCapabilitySandbox(tokens map[string]capproxy.SandboxBinding, tokensBySandbox map[string]map[string]struct{}, sandbox *domain.Sandbox, headers []domain.TrustedHeader) {
 	if sandbox == nil || sandbox.Summary.VMStatus != domain.VMStatusRunning {
 		return
 	}
@@ -147,10 +150,11 @@ func indexCapabilitySandbox(tokens map[string]capproxy.SandboxBinding, tokensByS
 	}
 	scope := capabilities.GuideScopeFromSandbox(sandbox)
 	binding := capproxy.SandboxBinding{
-		SandboxID: sandbox.Summary.ID,
-		ProjectID: scope.ProjectID,
-		AgentID:   scope.AgentID,
-		CapsetIDs: capsetIDs,
+		SandboxID:      sandbox.Summary.ID,
+		ProjectID:      scope.ProjectID,
+		AgentID:        scope.AgentID,
+		CapsetIDs:      capsetIDs,
+		TrustedHeaders: translateTrustedHeaders(headers),
 	}
 	tokens[token] = binding
 	tokenSet := tokensBySandbox[sandbox.Summary.ID]
@@ -159,4 +163,22 @@ func indexCapabilitySandbox(tokens map[string]capproxy.SandboxBinding, tokensByS
 		tokensBySandbox[sandbox.Summary.ID] = tokenSet
 	}
 	tokenSet[token] = struct{}{}
+}
+
+const (
+	xMPIPrefix        = "x-mpi-"
+	xOctobusExtPrefix = "x-octobus-ext-"
+)
+
+func translateTrustedHeaders(headers []domain.TrustedHeader) []domain.TrustedHeader {
+	var out []domain.TrustedHeader
+	for _, header := range headers {
+		name := strings.ToLower(header.Name)
+		if !strings.HasPrefix(name, xMPIPrefix) {
+			continue
+		}
+		key := xOctobusExtPrefix + strings.TrimPrefix(name, xMPIPrefix)
+		out = append(out, domain.TrustedHeader{Name: key, Value: header.Value})
+	}
+	return out
 }

--- a/pkg/agentcompose/adapters/capability_sandbox_trusted_headers_test.go
+++ b/pkg/agentcompose/adapters/capability_sandbox_trusted_headers_test.go
@@ -1,0 +1,76 @@
+package adapters
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"agent-compose/pkg/capabilities"
+	domain "agent-compose/pkg/model"
+)
+
+type trustedHeaderSandboxStore struct {
+	sandbox *domain.Sandbox
+}
+
+func (s trustedHeaderSandboxStore) ListSandboxes(context.Context, domain.SandboxListOptions) (domain.SandboxListResult, error) {
+	return domain.SandboxListResult{Sandboxes: []*domain.Sandbox{s.sandbox}}, nil
+}
+
+func TestCapabilitySandboxTrustedHeadersAreTransient(t *testing.T) {
+	sandbox := &domain.Sandbox{
+		Summary: domain.SandboxSummary{
+			ID:       "sandbox-1",
+			VMStatus: domain.VMStatusRunning,
+			Tags: []domain.SandboxTag{
+				{Name: capabilities.CapsetTagName, Value: "dev"},
+			},
+		},
+		EnvItems: []domain.SandboxEnvVar{
+			{Name: capabilities.SandboxTokenEnvName, Value: "sandbox-token", Secret: true},
+		},
+	}
+	resolver := NewCapabilitySandboxResolver(trustedHeaderSandboxStore{sandbox: sandbox})
+	if err := resolver.Rebuild(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	trusted := []domain.TrustedHeader{
+		{Name: "x-mpi-user-id", Value: "user-1"},
+		{Name: "x-mpi-role", Value: "admin"},
+		{Name: "x-other", Value: "ignored"},
+	}
+	resolver.IndexSandbox(sandbox, trusted)
+	binding, err := resolver.ResolveCapabilitySandbox(context.Background(), "sandbox-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []domain.TrustedHeader{
+		{Name: "x-octobus-ext-user-id", Value: "user-1"},
+		{Name: "x-octobus-ext-role", Value: "admin"},
+	}
+	if !reflect.DeepEqual(binding.TrustedHeaders, want) {
+		t.Fatalf("trusted headers = %#v, want %#v", binding.TrustedHeaders, want)
+	}
+
+	resolver.IndexSandbox(sandbox, nil)
+	binding, err = resolver.ResolveCapabilitySandbox(context.Background(), "sandbox-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(binding.TrustedHeaders) != 0 {
+		t.Fatalf("ordinary re-index retained trusted headers: %#v", binding.TrustedHeaders)
+	}
+
+	resolver.IndexSandbox(sandbox, trusted)
+	if err := resolver.Rebuild(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	binding, err = resolver.ResolveCapabilitySandbox(context.Background(), "sandbox-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(binding.TrustedHeaders) != 0 {
+		t.Fatalf("resolver rebuild retained trusted headers: %#v", binding.TrustedHeaders)
+	}
+}

--- a/pkg/agentcompose/adapters/scheduler_session_runner.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner.go
@@ -344,7 +344,7 @@ func (r *SchedulerSandboxRunner) loadOrResumeLocked(ctx context.Context, session
 
 func (r *SchedulerSandboxRunner) indexCapabilitySandbox(session *domain.Sandbox) {
 	if r != nil && r.CapTokens != nil {
-		r.CapTokens.IndexSandbox(session)
+		r.CapTokens.IndexSandbox(session, nil)
 	}
 }
 

--- a/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
@@ -161,7 +161,7 @@ func TestSchedulerSandboxRunnerRuntimeReleaseFailureFinalizesConfirmedStop(t *te
 	if err := bridge.store.UpdateSandbox(ctx, sandbox); err != nil {
 		t.Fatalf("UpdateSandbox returned error: %v", err)
 	}
-	resolver.IndexSandbox(sandbox)
+	resolver.IndexSandbox(sandbox, nil)
 	if _, ok := resolver.tokens[capabilityToken]; !ok {
 		t.Fatal("capability token was not indexed before shutdown")
 	}

--- a/pkg/agentcompose/adapters/session_rpc_bridge.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge.go
@@ -340,7 +340,7 @@ func (b *SandboxRPCBridge) stopSandbox(ctx context.Context, sandboxID, source st
 
 func (b *SandboxRPCBridge) indexCapabilitySandbox(session *domain.Sandbox) {
 	if b != nil && b.capTokens != nil {
-		b.capTokens.IndexSandbox(session)
+		b.capTokens.IndexSandbox(session, nil)
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_test.go
@@ -289,7 +289,7 @@ func TestSandboxRPCBridgeRuntimeReleaseFailureRevokesCapabilityAfterConfirmedSto
 	if err := bridge.store.UpdateSandbox(ctx, sandbox); err != nil {
 		t.Fatalf("UpdateSandbox returned error: %v", err)
 	}
-	resolver.IndexSandbox(sandbox)
+	resolver.IndexSandbox(sandbox, nil)
 	if _, ok := resolver.tokens[capabilityToken]; !ok {
 		t.Fatal("capability token was not indexed before stop")
 	}

--- a/pkg/capproxy/proxy.go
+++ b/pkg/capproxy/proxy.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 
+	domain "agent-compose/pkg/model"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -35,6 +37,10 @@ type SandboxBinding struct {
 	// CapsetIDs is the set of capsets the sandbox is allowed to use. The guest
 	// picks one per call (x-octobus-capset); capproxy validates membership.
 	CapsetIDs []string
+	// TrustedHeaders carries request-scoped x-octobus-ext-* headers. They are
+	// injected into outgoing calls after all guest-supplied values with that
+	// prefix have been stripped.
+	TrustedHeaders []domain.TrustedHeader
 }
 
 type SandboxResolver interface {
@@ -120,7 +126,7 @@ func (s *Server) handleUnknown(_ any, stream grpc.ServerStream) error {
 	if err != nil {
 		return err
 	}
-	outgoing := buildOutgoingMetadata(stream.Context(), target.CapsetID)
+	outgoing := buildOutgoingMetadata(stream.Context(), target.CapsetID, binding)
 	if !isReflectionMethod(method) {
 		// Business calls route by capset + instance + method. The instance comes
 		// from the injected guide.
@@ -163,13 +169,29 @@ func containsString(values []string, target string) bool {
 // auth is injected in proxyStream).
 // x-octobus-capset is forced to the resolved, sandbox-allowed value so the guest
 // cannot reach a capset outside its set.
-func buildOutgoingMetadata(ctx context.Context, capset string) metadata.MD {
+// Trusted x-octobus-ext-* headers from the sandbox binding replace any values
+// the guest may have supplied.
+func buildOutgoingMetadata(ctx context.Context, capset string, binding SandboxBinding) metadata.MD {
 	incoming, _ := metadata.FromIncomingContext(ctx)
 	outgoing := incoming.Copy()
 	outgoing.Delete(SandboxTokenMetadata)
 	outgoing.Delete(deprecatedSessionTokenMetadata)
 	outgoing.Delete("authorization")
 	outgoing.Set("x-octobus-capset", capset)
+
+	// Strip every guest-supplied extension value, including names that the
+	// trusted ingress did not provide for this sandbox.
+	for name := range outgoing {
+		if strings.HasPrefix(strings.ToLower(name), "x-octobus-ext-") {
+			outgoing.Delete(name)
+		}
+	}
+
+	// Preserve repeated trusted values in their original HTTP order.
+	for _, h := range binding.TrustedHeaders {
+		outgoing.Append(h.Name, h.Value)
+	}
+
 	return outgoing
 }
 

--- a/pkg/capproxy/proxy_test.go
+++ b/pkg/capproxy/proxy_test.go
@@ -6,8 +6,11 @@ import (
 	"crypto/x509"
 	"net"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
+
+	domain "agent-compose/pkg/model"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -111,6 +114,59 @@ func TestProxyForwardsGuestInstance(t *testing.T) {
 		if got := firstMetadata(received, key); got != want {
 			t.Fatalf("metadata %s = %q, want %q", key, got, want)
 		}
+	}
+}
+
+func TestProxyStripsAllGuestExtensionMetadata(t *testing.T) {
+	var received metadata.MD
+	octoAddr, stopOcto := startTestRawGRPC(t, func(_ any, stream grpc.ServerStream) error {
+		received, _ = metadata.FromIncomingContext(stream.Context())
+		req := rawFrame(nil)
+		if err := stream.RecvMsg(&req); err != nil {
+			return err
+		}
+		return stream.SendMsg(rawFrame("ok"))
+	})
+	defer stopOcto()
+
+	binding := SandboxBinding{
+		SandboxID: "s1",
+		CapsetIDs: []string{"dev"},
+		TrustedHeaders: []domain.TrustedHeader{
+			{Name: "x-octobus-ext-user-id", Value: "trusted-user"},
+			{Name: "x-octobus-ext-role", Value: "admin"},
+			{Name: "x-octobus-ext-role", Value: "auditor"},
+		},
+	}
+	proxyAddr, stopProxy := startTestProxy(t, Config{
+		Listen:  "127.0.0.1:0",
+		OctoBus: staticOctoBus(octoAddr, ""),
+	}, testResolver{binding: binding})
+	defer stopProxy()
+
+	conn, err := grpc.NewClient(proxyAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.ForceCodec(rawCodec{})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		SandboxTokenMetadata, "sandbox-token",
+		"x-octobus-instance", "inst",
+		"x-octobus-ext-user-id", "forged-user",
+		"x-octobus-ext-admin", "true",
+	))
+	out := rawFrame(nil)
+	if err := conn.Invoke(ctx, "/pkg.Service/Call", rawFrame("ping"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if got := firstMetadata(received, "x-octobus-ext-user-id"); got != "trusted-user" {
+		t.Fatalf("trusted user metadata = %q, want trusted-user", got)
+	}
+	if got := firstMetadata(received, "x-octobus-ext-admin"); got != "" {
+		t.Fatalf("guest-supplied extension metadata reached OctoBus: %q", got)
+	}
+	if got := received.Get("x-octobus-ext-role"); !reflect.DeepEqual(got, []string{"admin", "auditor"}) {
+		t.Fatalf("trusted repeated metadata = %#v", got)
 	}
 }
 
@@ -255,7 +311,7 @@ func TestCapsetResolutionAndOutgoingMetadataHelpers(t *testing.T) {
 		"authorization":                []string{"Bearer guest-token"},
 		"x-octobus-capset":             []string{"old"},
 		"x-custom":                     []string{"kept"},
-	}), "new")
+	}), "new", SandboxBinding{})
 	if got := firstMetadata(outgoing, SandboxTokenMetadata); got != "" {
 		t.Fatalf("sandbox token metadata was forwarded: %q", got)
 	}

--- a/pkg/model/trusted_headers.go
+++ b/pkg/model/trusted_headers.go
@@ -1,0 +1,31 @@
+package model
+
+import "context"
+
+type trustedHeadersContextKey struct{}
+
+// TrustedHeader is metadata accepted from the deployment's trusted ingress.
+// It is request-scoped and must not be persisted with sandbox state.
+type TrustedHeader struct {
+	Name  string
+	Value string
+}
+
+// NewContextWithTrustedHeaders stores a private copy of trusted headers in ctx.
+func NewContextWithTrustedHeaders(ctx context.Context, items []TrustedHeader) context.Context {
+	return context.WithValue(ctx, trustedHeadersContextKey{}, cloneTrustedHeaders(items))
+}
+
+// TrustedHeadersFromContext retrieves a copy of the trusted headers.
+// Returns nil when no items were stored.
+func TrustedHeadersFromContext(ctx context.Context) []TrustedHeader {
+	items, _ := ctx.Value(trustedHeadersContextKey{}).([]TrustedHeader)
+	return cloneTrustedHeaders(items)
+}
+
+func cloneTrustedHeaders(items []TrustedHeader) []TrustedHeader {
+	if len(items) == 0 {
+		return nil
+	}
+	return append([]TrustedHeader(nil), items...)
+}

--- a/pkg/model/trusted_headers_test.go
+++ b/pkg/model/trusted_headers_test.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTrustedHeadersContextCopiesValues(t *testing.T) {
+	original := []TrustedHeader{{Name: "x-mpi-user-id", Value: "user-1"}}
+	ctx := NewContextWithTrustedHeaders(context.Background(), original)
+	original[0].Value = "mutated-input"
+
+	first := TrustedHeadersFromContext(ctx)
+	if len(first) != 1 || first[0].Value != "user-1" {
+		t.Fatalf("trusted headers = %#v", first)
+	}
+	first[0].Value = "mutated-output"
+	second := TrustedHeadersFromContext(ctx)
+	if len(second) != 1 || second[0].Value != "user-1" {
+		t.Fatalf("stored trusted headers were mutated: %#v", second)
+	}
+}

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -69,7 +69,7 @@ type DashboardNotifier interface {
 }
 
 type CapabilitySandboxIndexer interface {
-	IndexSandbox(*domain.Sandbox)
+	IndexSandbox(*domain.Sandbox, []domain.TrustedHeader)
 	RevokeSandbox(string)
 }
 
@@ -242,6 +242,7 @@ func (c *Controller) StartProjectRun(ctx context.Context, req RunAgentRequest) (
 	if c.configDB == nil {
 		return StartedProjectRun{}, fmt.Errorf("config store is required")
 	}
+	trustedHeaders := domain.TrustedHeadersFromContext(ctx)
 	commandText := strings.TrimSpace(req.Command)
 	if commandText != "" && (strings.TrimSpace(req.Prompt) != "" || strings.TrimSpace(req.TriggerID) != "") {
 		return StartedProjectRun{}, fmt.Errorf("%w: run requires only one of command, prompt, or trigger", ErrInvalidRequest)
@@ -280,6 +281,9 @@ func (c *Controller) StartProjectRun(ctx context.Context, req RunAgentRequest) (
 		Run:      run,
 		Warnings: warnings,
 		Execute: func(execCtx context.Context, stream *StreamSink) (domain.ProjectRunRecord, error, error) {
+			// Async runs execute from the daemon root context. Restore only the
+			// request metadata they need instead of retaining the transport context.
+			execCtx = domain.NewContextWithTrustedHeaders(execCtx, trustedHeaders)
 			return c.executeStartedProjectRun(execCtx, coordinator, run, req, warnings, stream)
 		},
 	}, nil
@@ -2093,6 +2097,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 	tags = append(tags, domain.SandboxTag{Name: domain.AgentSandboxTagProvider, Value: agentConfig.Provider})
 	capabilityVars, capabilityTags := capabilities.BuildGatewaySandboxVars(capabilities.ProxyTarget(c.cap), prepared.CapsetIDs)
 	tags = append(tags, capabilityTags...)
+	trustedHeaders := domain.TrustedHeadersFromContext(ctx)
 	bindingStore, hasBindingStore := c.configDB.(stickyBindingStore)
 	var previousStickyBinding *domain.SchedulerBinding
 	boundSandbox := false
@@ -2193,7 +2198,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 			}
 			sandbox.EnvItems = domain.MergeEnvItems(sandbox.EnvItems, capabilityVars)
 			sandbox.Summary.Tags = MergeSandboxTags(sandbox.Summary.Tags, tags)
-			if err := c.startProjectRunSandbox(ctx, sandbox, "sandbox.resumed", "sandbox resumed for project run"); err != nil {
+			if err := c.startProjectRunSandbox(ctx, sandbox, "sandbox.resumed", "sandbox resumed for project run", trustedHeaders); err != nil {
 				return SandboxResult{Sandbox: sandbox}, err
 			}
 			return SandboxResult{Sandbox: sandbox, Warnings: warnings}, nil
@@ -2261,7 +2266,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 		_ = c.store.UpdateSandbox(ctx, sandbox)
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
 	}
-	if err := c.startProjectRunSandboxRuntime(ctx, sandbox, "sandbox.created", "sandbox started for project run"); err != nil {
+	if err := c.startProjectRunSandboxRuntime(ctx, sandbox, "sandbox.created", "sandbox started for project run", trustedHeaders); err != nil {
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
 	}
 	if stickySchedulerID != "" {
@@ -2378,7 +2383,7 @@ func (c *Controller) applyJupyterOptionsToSandbox(sandbox *domain.Sandbox, optio
 	return c.store.SaveProxyState(sandbox.Summary.ID, proxyState)
 }
 
-func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain.Sandbox, eventType, eventMessage string) error {
+func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain.Sandbox, eventType, eventMessage string, trustedHeaders []domain.TrustedHeader) error {
 	if sandbox == nil {
 		return fmt.Errorf("sandbox is required")
 	}
@@ -2393,7 +2398,7 @@ func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain
 		_ = c.store.UpdateSandbox(ctx, sandbox)
 		return err
 	}
-	return c.startProjectRunSandboxRuntime(ctx, sandbox, eventType, eventMessage)
+	return c.startProjectRunSandboxRuntime(ctx, sandbox, eventType, eventMessage, trustedHeaders)
 }
 
 func (c *Controller) ensureProjectRunSandboxWorkspace(ctx context.Context, sandbox *domain.Sandbox) error {
@@ -2422,7 +2427,7 @@ func (c *Controller) prepareFreshStartAgentEnvironment(ctx context.Context, sand
 	return c.executor.PrepareSandboxAgentEnvironmentFromTags(ctx, sandbox)
 }
 
-func (c *Controller) startProjectRunSandboxRuntime(ctx context.Context, sandbox *domain.Sandbox, eventType, eventMessage string) error {
+func (c *Controller) startProjectRunSandboxRuntime(ctx context.Context, sandbox *domain.Sandbox, eventType, eventMessage string, trustedHeaders []domain.TrustedHeader) error {
 	writeCapabilityGuide(ctx, c.cap, c.store, c.streams, sandbox, capabilities.SandboxCapsets(sandbox))
 	if sandbox.Summary.VMStatus != domain.VMStatusRunning {
 		if err := c.driver.StartSandboxVM(ctx, sandbox); err != nil {
@@ -2444,7 +2449,7 @@ func (c *Controller) startProjectRunSandboxRuntime(ctx context.Context, sandbox 
 	domain.RestoreSandboxTransientFields(loaded, sandbox)
 	*sandbox = *loaded
 	if c.capTokens != nil {
-		c.capTokens.IndexSandbox(loaded)
+		c.capTokens.IndexSandbox(loaded, trustedHeaders)
 	}
 	return nil
 }

--- a/pkg/runs/project_run_capability_token_test.go
+++ b/pkg/runs/project_run_capability_token_test.go
@@ -3,6 +3,8 @@ package runs
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	"agent-compose/pkg/capabilities"
@@ -13,12 +15,14 @@ import (
 )
 
 type recordingCapabilitySandboxIndexer struct {
-	indexed []*domain.Sandbox
-	revoked []string
+	indexed        []*domain.Sandbox
+	trustedHeaders [][]domain.TrustedHeader
+	revoked        []string
 }
 
-func (i *recordingCapabilitySandboxIndexer) IndexSandbox(sandbox *domain.Sandbox) {
+func (i *recordingCapabilitySandboxIndexer) IndexSandbox(sandbox *domain.Sandbox, headers []domain.TrustedHeader) {
 	i.indexed = append(i.indexed, sandbox)
+	i.trustedHeaders = append(i.trustedHeaders, append([]domain.TrustedHeader(nil), headers...))
 }
 
 func (i *recordingCapabilitySandboxIndexer) RevokeSandbox(sandboxID string) {
@@ -41,7 +45,7 @@ func TestProjectRunCapabilityTokenLifecycle(t *testing.T) {
 		fixture.controller.capTokens = indexer
 		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusStopped)
 
-		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed"); err != nil {
+		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed", nil); err != nil {
 			t.Fatalf("startProjectRunSandbox: %v", err)
 		}
 		if len(indexer.indexed) != 1 {
@@ -67,7 +71,7 @@ func TestProjectRunCapabilityTokenLifecycle(t *testing.T) {
 		fixture.driver.startErr = errors.New("start failed")
 		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusStopped)
 
-		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed"); !errors.Is(err, fixture.driver.startErr) {
+		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed", nil); !errors.Is(err, fixture.driver.startErr) {
 			t.Fatalf("startProjectRunSandbox error = %v", err)
 		}
 		if len(indexer.indexed) != 0 || len(indexer.revoked) != 0 {
@@ -189,6 +193,102 @@ func TestProjectRunCapabilityTokenLifecycle(t *testing.T) {
 			t.Fatal("removed sandbox is still present")
 		}
 	})
+}
+
+func TestProjectRunTrustedHeadersRemainTransientAndClearOnReuse(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	indexer := &recordingCapabilitySandboxIndexer{}
+	fixture.controller.capTokens = indexer
+	run := persistControllerFixtureRun(t, fixture, domain.ProjectRunRecord{
+		RunID:       "run-trusted-headers",
+		ProjectID:   "project-1",
+		ProjectName: "Project",
+		AgentID:     "agent-1",
+		AgentName:   "worker",
+		Driver:      driverpkg.RuntimeDriverDocker,
+		ImageRef:    "guest:latest",
+	})
+	tags := append(SandboxTags(run), domain.SandboxTag{Name: capabilities.CapsetTagName, Value: "dev"})
+	sandbox, err := fixture.store.CreateSandbox(
+		fixture.ctx,
+		"trusted headers",
+		"",
+		driverpkg.RuntimeDriverDocker,
+		"guest:latest",
+		"",
+		domain.SandboxTypeManual,
+		nil,
+		[]domain.SandboxEnvVar{{Name: capabilities.SandboxTokenEnvName, Value: "sandbox-token", Secret: true}},
+		tags,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sandbox.Summary.VMStatus = domain.VMStatusRunning
+	if err := fixture.store.UpdateSandbox(fixture.ctx, sandbox); err != nil {
+		t.Fatal(err)
+	}
+
+	trusted := []domain.TrustedHeader{{Name: "x-mpi-user-id", Value: "user-1"}}
+	ctx := domain.NewContextWithTrustedHeaders(fixture.ctx, trusted)
+	result, err := fixture.controller.ensureProjectRunSandbox(ctx, run, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(indexer.trustedHeaders) != 1 || !reflect.DeepEqual(indexer.trustedHeaders[0], trusted) {
+		t.Fatalf("indexed trusted headers = %#v, want %#v", indexer.trustedHeaders, trusted)
+	}
+	for _, tag := range result.Sandbox.Summary.Tags {
+		if strings.HasPrefix(strings.ToLower(tag.Name), "x-mpi-") {
+			t.Fatalf("trusted header persisted as sandbox tag: %#v", tag)
+		}
+	}
+	persisted, err := fixture.store.LoadSandbox(sandbox.Summary.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tag := range persisted.Summary.Tags {
+		if strings.HasPrefix(strings.ToLower(tag.Name), "x-mpi-") {
+			t.Fatalf("trusted header persisted in sandbox store: %#v", tag)
+		}
+	}
+
+	if _, err := fixture.controller.ensureProjectRunSandbox(fixture.ctx, run, Preparation{}, RunAgentRequest{SandboxID: sandbox.Summary.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if len(indexer.trustedHeaders) != 2 || len(indexer.trustedHeaders[1]) != 0 {
+		t.Fatalf("reused sandbox retained prior trusted headers: %#v", indexer.trustedHeaders)
+	}
+}
+
+func TestStartProjectRunPreservesTrustedHeadersForDetachedExecution(t *testing.T) {
+	fixture := newControllerRunFixture(t)
+	indexer := &recordingCapabilitySandboxIndexer{}
+	fixture.controller.capTokens = indexer
+	trusted := []domain.TrustedHeader{{Name: "x-mpi-user-id", Value: "user-1"}}
+	requestCtx := domain.NewContextWithTrustedHeaders(fixture.ctx, trusted)
+
+	started, err := fixture.controller.StartProjectRun(requestCtx, RunAgentRequest{
+		ProjectID: "project-1",
+		AgentName: "worker",
+		Prompt:    "do work",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// RunSupervisor.StartRun executes with a daemon-root-derived context so the
+	// started run must carry the request metadata across that async boundary.
+	execCtx, cancel := context.WithCancelCause(fixture.ctx)
+	defer cancel(nil)
+	_, _, _ = started.Execute(execCtx, nil)
+
+	if len(indexer.trustedHeaders) == 0 {
+		t.Fatal("sandbox was not indexed")
+	}
+	if !reflect.DeepEqual(indexer.trustedHeaders[0], trusted) {
+		t.Fatalf("indexed trusted headers = %#v, want %#v", indexer.trustedHeaders[0], trusted)
+	}
 }
 
 func sandboxEventTypeExists(events []domain.SandboxEvent, eventType string) bool {


### PR DESCRIPTION
## Summary

由部署侧可信网关注入 `x-mpi-*` header。agent-compose 只负责在请求边界校验其是否可安全转换为 gRPC metadata，并将其放入对应 sandbox 的内存 capability binding；capproxy 翻译为 `x-octobus-ext-*` 后注入 OctoBus 出站调用。

这些 header 是由可信请求建立的 sandbox-scoped transient metadata，不是 daemon 的认证凭据，也不是 run-scoped identity。

## Trust and authorization boundary

- daemon 必须部署在可信网关后面，不能允许不受信任的客户端绕过网关直接访问。
- 网关负责认证调用方、剥离客户端自带的 `x-mpi-*`，再注入经过验证的值。
- 网关负责限制调用方能够创建、指定和复用哪些 sandbox，包括对显式 `SandboxID`、sticky sandbox 和并发复用的授权。
- `AGENT_COMPOSE_AUTH_TOKEN` 只保护 daemon API，不证明 MPI header 的来源，不能替代上述网关边界。
- agent-compose 不解释 user、tenant、role 等 MPI 身份语义，也不基于这些 header 实现用户级 RBAC 或 sandbox ownership。
- 支持的 `HTTP_LISTEN` 部署仍必须满足该信任边界；不能把 daemon 直接暴露给可自行构造 `x-mpi-*` 的客户端。

## Why no persisted identity hash

本 PR 不根据 `x-mpi-*` 计算或持久化 sandbox identity hash：

- hash 只能比较两组 metadata 是否相同，不能认证当前调用方，也不能证明请求经过可信网关。
- daemon 无法通用判断哪些 `x-mpi-*` 字段代表稳定身份；role、display name 等字段变化会错误阻止同一主体复用。
- webhook、脚本和内部 scheduler 可能没有 MPI metadata，单独增加 hash 无法定义这些调用方的身份或授权关系。
- hash 不能从根本上解决直接访问、跨用户 `SandboxID` 使用、并发复用或完整 RBAC 问题，反而会在 daemon 中形成不完整的身份系统。

如果未来需要 daemon 直接支持多租户访问，应完整设计 principal、sandbox ownership、RBAC 和迁移策略，而不是从透传 header 推导身份。

## Metadata lifecycle

- capability token 和 `SandboxBinding` 本来就是 sandbox-scoped；trusted metadata 使用相同作用域。
- 创建或复用 project-run sandbox 时，当前可信请求的 metadata 会替换该 sandbox 内存 binding 中的旧值。
- `KEEP_RUNNING` 和 sticky sandbox 在 run 结束后可以继续运行，因此其进程继续使用当前 sandbox binding 中的 metadata，这是 sandbox capability 生命周期的一部分。
- 后续无 `x-mpi-*` 的可信复用会清空旧 metadata；携带新 metadata 的可信复用会替换旧值。
- manual/scheduler re-index、resolver rebuild、binding revoke 和 daemon restart 都不会恢复 trusted metadata。
- 原始 trusted headers 不进入 sandbox tags、SQLite、protobuf 或公开 API。

## Validation and proxy behavior

- header 后缀只允许 gRPC metadata 支持的 `[0-9a-z-_.]`。
- 值必须为 1-256 bytes 的 printable ASCII。
- 非法名称、空值、控制字符、非 ASCII 值和超长值返回 HTTP 400，避免在 capproxy 出站时才失败为 gRPC `Internal`。
- capproxy 先删除 guest 提供的全部 `x-octobus-ext-*`，再注入 sandbox binding 中的可信值。
- header 名称规范化为小写，重复值按原始顺序保留。
- `StartAgentRun` 在脱离 HTTP request context 前只复制 trusted metadata，不保留整个 transport context。

## Data flow

```text
trusted gateway authenticates and authorizes sandbox access
  -> strips client x-mpi-* and injects verified x-mpi-*
  -> daemon validates metadata encoding only
  -> in-memory sandbox capability binding
  -> capproxy strips guest x-octobus-ext-*
  -> prefix translation and trusted injection
  -> OctoBus
```

## Regression coverage

- middleware extraction, deterministic ordering, repeated values and HTTP 400 validation
- rejection of metadata names and values that gRPC cannot send
- context slice ownership/copy isolation
- detached `StartAgentRun` execution preserves request-originated metadata
- full gRPC proxy verification that guest extension metadata is stripped
- resolver re-index/rebuild clearing and non-persistence
- controller + filesystem store verification that trusted headers do not enter sandbox tags or metadata
- reused sandbox verification that a later headerless trusted request clears prior values

## Local verification

Passed with Go 1.26.2:

```bash
task lint
go test ./... -count=1
go test -race ./cmd/agent-compose ./pkg/capproxy ./pkg/agentcompose/adapters ./pkg/runs -count=1
go build ./cmd/agent-compose
```

The exact tree was also verified against the real merge result of latest `origin/main` plus PR 557:

```bash
go test ./cmd/agent-compose ./pkg/agentcompose/app ./pkg/agentcompose/adapters ./pkg/capproxy ./pkg/runs -count=1
go build ./cmd/agent-compose
```

Environment-limited full gates from the previous PR verification remain unchanged:

- `task test`: local Docker Compose v2.25 returns YAML for `config --format json`, so the deployment jq check stops before coverage collection.
- `task build`: Linux native artifact preparation depends on Docker Hub metadata and previously stopped on a `debian:bookworm` metadata timeout.