### PR TITLE
fix(cli): probe h2c capability before attach streams (issue #413)

### DIFF
--- a/cmd/agent-compose/cli_client.go
+++ b/cmd/agent-compose/cli_client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+	"context"
 	"os"
 	"strings"
 	"time"
@@ -26,6 +27,12 @@ type cliServiceClients struct {
 	cache    agentcomposev2connect.CacheServiceClient
 	volume   agentcomposev2connect.VolumeServiceClient
 	sandbox  agentcomposev2connect.SandboxServiceClient
+
+	// attachBidiProbe is a side-effect-free pre-attach h2c capability check,
+	// or nil when probing does not apply (unix socket, https). It runs before
+	// any AttachAgentRun/AttachExec bidi stream is opened so an HTTP/1-only
+	// proxy is reported before resources are prepared.
+	attachBidiProbe func(context.Context) error
 }
 
 func newCLIServiceClients(cli cliOptions) (cliServiceClients, error) {
@@ -35,14 +42,15 @@ func newCLIServiceClients(cli cliOptions) (cliServiceClients, error) {
 	}
 	httpClient := newDaemonHTTPClient(clientConfig)
 	return cliServiceClients{
-		project:  agentcomposev2connect.NewProjectServiceClient(httpClient, clientConfig.BaseURL),
-		run:      agentcomposev2connect.NewRunServiceClient(httpClient, clientConfig.BaseURL),
-		exec:     agentcomposev2connect.NewExecServiceClient(httpClient, clientConfig.BaseURL),
-		resource: agentcomposev2connect.NewResourceServiceClient(httpClient, clientConfig.BaseURL),
-		image:    agentcomposev2connect.NewImageServiceClient(httpClient, clientConfig.BaseURL),
-		cache:    agentcomposev2connect.NewCacheServiceClient(httpClient, clientConfig.BaseURL),
-		volume:   agentcomposev2connect.NewVolumeServiceClient(httpClient, clientConfig.BaseURL),
-		sandbox:  agentcomposev2connect.NewSandboxServiceClient(httpClient, clientConfig.BaseURL),
+		project:         agentcomposev2connect.NewProjectServiceClient(httpClient, clientConfig.BaseURL),
+		run:             agentcomposev2connect.NewRunServiceClient(httpClient, clientConfig.BaseURL),
+		exec:            agentcomposev2connect.NewExecServiceClient(httpClient, clientConfig.BaseURL),
+		resource:        agentcomposev2connect.NewResourceServiceClient(httpClient, clientConfig.BaseURL),
+		image:           agentcomposev2connect.NewImageServiceClient(httpClient, clientConfig.BaseURL),
+		cache:           agentcomposev2connect.NewCacheServiceClient(httpClient, clientConfig.BaseURL),
+		volume:          agentcomposev2connect.NewVolumeServiceClient(httpClient, clientConfig.BaseURL),
+		sandbox:         agentcomposev2connect.NewSandboxServiceClient(httpClient, clientConfig.BaseURL),
+		attachBidiProbe: newAttachBidiProbe(clientConfig),
 	}, nil
 }
 

--- a/cmd/agent-compose/cli_daemon.go
+++ b/cmd/agent-compose/cli_daemon.go
@@ -522,7 +522,19 @@ func newDaemonBaseRoundTripper(clientConfig cliClientConfig) http.RoundTripper {
 	if !clientConfig.UseUnixSocket && !strings.HasPrefix(strings.ToLower(strings.TrimSpace(clientConfig.BaseURL)), "http://") {
 		return transport
 	}
-	h2cTransport := &http2.Transport{
+	return daemonAttachRoundTripper{
+		defaultTransport: transport,
+		attachTransport:  newDaemonH2CTransport(clientConfig),
+	}
+}
+
+// newDaemonH2CTransport builds the h2c (HTTP/2 cleartext) transport used for
+// attach RPCs and the pre-attach h2c capability probe. Over an HTTP/1-only
+// reverse proxy, requests made through this transport fail with
+// "http2: frame too large ... HTTP/1.1 header", which is how the CLI detects
+// that bidi attach is unsupported on the connection.
+func newDaemonH2CTransport(clientConfig cliClientConfig) *http2.Transport {
+	return &http2.Transport{
 		AllowHTTP: true,
 		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
 			if clientConfig.UseUnixSocket {
@@ -533,9 +545,41 @@ func newDaemonBaseRoundTripper(clientConfig cliClientConfig) http.RoundTripper {
 			return dialer.DialContext(ctx, network, addr)
 		},
 	}
-	return daemonAttachRoundTripper{
-		defaultTransport: transport,
-		attachTransport:  h2cTransport,
+}
+
+// newAttachBidiProbe returns a pre-attach h2c capability probe, or nil when
+// probing does not apply. Unix sockets guarantee h2c (the daemon dials the
+// socket directly), and non-http:// base URLs use the plain transport path, so
+// neither can sit behind an HTTP/1-only proxy. For a plain http:// TCP
+// connection the probe issues GET {baseURL}/api/version through a raw h2c
+// transport — the same negotiation attach RPCs require — and propagates only
+// the HTTP/2-vs-HTTP/1 transport mismatch. Transient, timeout, and connection
+// errors return nil so the real attach stream reports them as it does today.
+func newAttachBidiProbe(clientConfig cliClientConfig) func(context.Context) error {
+	if clientConfig.UseUnixSocket {
+		return nil
+	}
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(clientConfig.BaseURL)), "http://") {
+		return nil
+	}
+	probeClient := &http.Client{Transport: newDaemonH2CTransport(clientConfig)}
+	probeURL := clientConfig.BaseURL + "/api/version"
+	return func(ctx context.Context) error {
+		requestCtx, cancel := context.WithTimeout(ctx, daemonStatusTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, probeURL, nil)
+		if err != nil {
+			return nil // local construction error is not an h2c mismatch
+		}
+		resp, err := probeClient.Do(req)
+		if err != nil {
+			if isAttachHTTP2TransportMismatch(err) {
+				return err // only the h2c/HTTP/1 mismatch is propagated
+			}
+			return nil
+		}
+		_ = resp.Body.Close()
+		return nil // h2c negotiated; application-level status is irrelevant
 	}
 }
 

--- a/cmd/agent-compose/cli_daemon_http_test.go
+++ b/cmd/agent-compose/cli_daemon_http_test.go
@@ -264,13 +264,13 @@ func TestNewAttachBidiProbeDetectsHTTP1OnlyServerMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		buf := make([]byte, 1024)
 		_, _ = conn.Read(buf) // drain the h2c preface and request frames
 		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"))

--- a/cmd/agent-compose/cli_daemon_http_test.go
+++ b/cmd/agent-compose/cli_daemon_http_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -237,5 +238,161 @@ func TestBrowserBaseURLForCLIUnixSocketDoesNotGuessHTTPAddress(t *testing.T) {
 	}
 	if got := joinBaseURLAndPath(baseURL, "/agent-compose/session/sandbox/lab?token=socket-token"); got != "/agent-compose/session/sandbox/lab?token=socket-token" {
 		t.Fatalf("Unix socket notebook URL = %q, want relative URL with token", got)
+	}
+}
+
+func TestNewAttachBidiProbeSkipsUnixSocket(t *testing.T) {
+	if probe := newAttachBidiProbe(cliClientConfig{BaseURL: "http://agent-compose", SocketPath: "/tmp/agent-compose.sock", UseUnixSocket: true}); probe != nil {
+		t.Fatal("newAttachBidiProbe(unix socket) = non-nil probe, want nil")
+	}
+}
+
+func TestNewAttachBidiProbeSkipsHTTPS(t *testing.T) {
+	if probe := newAttachBidiProbe(cliClientConfig{BaseURL: "https://example.com"}); probe != nil {
+		t.Fatal("newAttachBidiProbe(https) = non-nil probe, want nil")
+	}
+}
+
+func TestNewAttachBidiProbeDetectsHTTP1OnlyServerMismatch(t *testing.T) {
+	// Simulate an HTTP/1-only reverse proxy with a raw TCP listener: read the
+	// h2c client's prior-knowledge preface, then answer with a plain HTTP/1.1
+	// status line. The h2c client mis-parses that head as a frame header and
+	// surfaces the http2/HTTP/1 transport mismatch. (httptest.NewServer is not
+	// used here: its handling of the malformed `PRI *` request can reset the
+	// connection before the client reads the response, making the test flaky.)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 1024)
+		_, _ = conn.Read(buf) // drain the h2c preface and request frames
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"))
+		time.Sleep(200 * time.Millisecond) // hold open so the client reads the head
+	}()
+
+	baseURL := "http://" + ln.Addr().String()
+	probe := newAttachBidiProbe(cliClientConfig{BaseURL: baseURL})
+	if probe == nil {
+		t.Fatalf("newAttachBidiProbe(%q) = nil, want a probe", baseURL)
+	}
+	err = probe(context.Background())
+	if err == nil {
+		t.Fatal("probe over HTTP/1-only server returned nil, want transport mismatch")
+	}
+	if !isAttachHTTP2TransportMismatch(err) {
+		t.Fatalf("probe error = %v, want h2c/HTTP/1 transport mismatch", err)
+	}
+}
+
+func TestNewAttachBidiProbeSucceedsOverH2C(t *testing.T) {
+	seen := make(chan string, 1)
+	server := httptest.NewServer(h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:staticcheck // Tests required h2c transport compatibility.
+		if r.URL.Path == "/api/version" {
+			seen <- r.Proto
+		}
+		w.WriteHeader(http.StatusOK)
+	}), &http2.Server{}))
+	defer server.Close()
+
+	probe := newAttachBidiProbe(cliClientConfig{BaseURL: server.URL})
+	if probe == nil {
+		t.Fatalf("newAttachBidiProbe(%q) = nil, want a probe", server.URL)
+	}
+	if err := probe(context.Background()); err != nil {
+		t.Fatalf("probe over h2c server returned error = %v, want nil", err)
+	}
+	if got, want := <-seen, "HTTP/2.0"; got != want {
+		t.Fatalf("probe request protocol = %q, want %q", got, want)
+	}
+}
+
+func TestNewAttachBidiProbeReturnsNilOnConnectionError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	url := server.URL
+	server.Close() // now dialing fails with connection refused
+
+	probe := newAttachBidiProbe(cliClientConfig{BaseURL: url})
+	if probe == nil {
+		t.Fatalf("newAttachBidiProbe(%q) = nil, want a probe", url)
+	}
+	if err := probe(context.Background()); err != nil {
+		t.Fatalf("probe over closed server returned error = %v, want nil (transient error left for attach)", err)
+	}
+}
+
+func TestNewAttachBidiProbeReturnsNilOnTimeout(t *testing.T) {
+	blocked := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	defer func() {
+		close(blocked)
+		server.Close()
+	}()
+
+	probe := newAttachBidiProbe(cliClientConfig{BaseURL: server.URL})
+	if probe == nil {
+		t.Fatalf("newAttachBidiProbe(%q) = nil, want a probe", server.URL)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := probe(ctx); err != nil {
+		t.Fatalf("probe timeout returned error = %v, want nil (deadline exceeded is not a mismatch)", err)
+	}
+}
+
+func TestAttachRunProbePassThroughOpensRealStream(t *testing.T) {
+	mux := http.NewServeMux()
+	path, handler := agentcomposev2connect.NewRunServiceHandler(runServiceStub{
+		runAttach: func(_ context.Context, stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
+			req, err := stream.Receive()
+			if err != nil {
+				return err
+			}
+			if req.GetStart() == nil {
+				return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("start frame is required"))
+			}
+			return stream.Send(&agentcomposev2.AttachAgentRunResponse{
+				Frame: &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}},
+			})
+		},
+	})
+	mux.Handle(path, handler)
+	server := httptest.NewServer(h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:staticcheck // Tests required h2c transport compatibility.
+		mux.ServeHTTP(w, r)
+	}), &http2.Server{}))
+	defer server.Close()
+
+	client := connectAttachAgentRunClient{
+		client: agentcomposev2connect.NewRunServiceClient(newDaemonHTTPClient(cliClientConfig{BaseURL: server.URL}), server.URL),
+		probe:  func(context.Context) error { return nil },
+	}
+	stream := client.AttachAgentRun(context.Background())
+	if err := stream.Send(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
+			Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "dialog", Command: "bash"},
+			Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND,
+		}},
+	}); err != nil {
+		t.Fatalf("AttachAgentRun Send() error = %v", err)
+	}
+	if err := stream.CloseRequest(); err != nil {
+		t.Fatalf("AttachAgentRun CloseRequest() error = %v", err)
+	}
+	resp, err := stream.Receive()
+	if err != nil {
+		t.Fatalf("AttachAgentRun Receive() error = %v", err)
+	}
+	if !resp.GetResult().GetSuccess() {
+		t.Fatalf("AttachAgentRun result = %#v, want success", resp)
 	}
 }

--- a/cmd/agent-compose/cli_exec_attach.go
+++ b/cmd/agent-compose/cli_exec_attach.go
@@ -93,10 +93,32 @@ type runAttachStream interface {
 
 type connectAttachAgentRunClient struct {
 	client agentcomposev2connect.RunServiceClient
+	probe  func(context.Context) error
 }
 
 func (c connectAttachAgentRunClient) AttachAgentRun(ctx context.Context) runAttachStream {
+	if c.probe != nil {
+		if err := c.probe(ctx); err != nil {
+			return failRunAttachStream{err: err}
+		}
+	}
 	return c.client.AttachAgentRun(ctx)
+}
+
+// failRunAttachStream is returned when the pre-attach h2c probe fails. Its
+// Send surfaces the probe error through the entry function's existing
+// commandExitErrorForConnect path, so an HTTP/1-only proxy is reported before
+// any bidi stream is opened on the daemon.
+type failRunAttachStream struct{ err error }
+
+func (s failRunAttachStream) Send(*agentcomposev2.AttachAgentRunRequest) error {
+	return s.err
+}
+func (s failRunAttachStream) Receive() (*agentcomposev2.AttachAgentRunResponse, error) {
+	return nil, s.err
+}
+func (s failRunAttachStream) CloseRequest() error {
+	return s.err
 }
 
 func runComposeAttachAgentRunCommand(cmd *cobra.Command, projectName string, client runAttachClient, req *agentcomposev2.RunAgentRequest, options composeRunOptions) (err error) {
@@ -379,10 +401,31 @@ type execAttachStream interface {
 
 type connectAttachExecClient struct {
 	client agentcomposev2connect.ExecServiceClient
+	probe  func(context.Context) error
 }
 
 func (c connectAttachExecClient) AttachExec(ctx context.Context) execAttachStream {
+	if c.probe != nil {
+		if err := c.probe(ctx); err != nil {
+			return failExecAttachStream{err: err}
+		}
+	}
 	return c.client.AttachExec(ctx)
+}
+
+// failExecAttachStream is the exec counterpart of failRunAttachStream: it
+// surfaces a failed pre-attach h2c probe through the existing attach error
+// mapping before any bidi stream is opened on the daemon.
+type failExecAttachStream struct{ err error }
+
+func (s failExecAttachStream) Send(*agentcomposev2.AttachExecRequest) error {
+	return s.err
+}
+func (s failExecAttachStream) Receive() (*agentcomposev2.AttachExecResponse, error) {
+	return nil, s.err
+}
+func (s failExecAttachStream) CloseRequest() error {
+	return s.err
 }
 
 func runComposeAttachExecCommand(cmd *cobra.Command, projectName string, client execAttachClient, req *agentcomposev2.ExecRequest, options composeExecOptions) (err error) {
@@ -731,7 +774,16 @@ func isAttachHTTP2TransportMismatch(err error) bool {
 		return false
 	}
 	message := err.Error()
-	return strings.Contains(message, "http2: frame too large") && strings.Contains(message, "HTTP/1.1 header")
+	// A prior-knowledge h2c request answered by an HTTP/1-only peer (e.g. an
+	// HTTP/1 reverse proxy) surfaces one of two x/net/http2 errors: the h2c
+	// client mis-parses the HTTP/1.1 status line as a frame header ("frame too
+	// large ... HTTP/1.1 header"), or the connection is torn down during
+	// establishment before the first stream is registered ("client conn could
+	// not be established"). Both mean the peer does not speak h2c on this path.
+	if strings.Contains(message, "http2: frame too large") && strings.Contains(message, "HTTP/1.1 header") {
+		return true
+	}
+	return strings.Contains(message, "http2: client conn could not be established")
 }
 
 func isAttachRPCPath(path string) bool {

--- a/cmd/agent-compose/cli_exec_attach_test.go
+++ b/cmd/agent-compose/cli_exec_attach_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -436,4 +438,54 @@ func (s execServiceStub) AttachExec(ctx context.Context, stream *connect.BidiStr
 		return connect.NewError(connect.CodeUnimplemented, fmt.Errorf("AttachExec stub is not configured"))
 	}
 	return s.execAttach(ctx, stream)
+}
+
+func TestAttachRunProbeFailureSurfacesExitCodeUnavailable(t *testing.T) {
+	failingProbe := func(context.Context) error {
+		return fmt.Errorf("Get %q: http2: failed reading the frame payload: http2: frame too large, note that the frame header looked like an HTTP/1.1 header", "http://proxy/api/version")
+	}
+	client := connectAttachAgentRunClient{
+		client: agentcomposev2connect.NewRunServiceClient(http.DefaultClient, "http://proxy"),
+		probe:  failingProbe,
+	}
+	cmd := &cobra.Command{Use: "run"}
+	cmd.SetContext(context.Background())
+	cmd.SetIn(strings.NewReader("x\n"))
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := runComposeAttachAgentRunCommand(cmd, "proj", client, &agentcomposev2.RunAgentRequest{ProjectId: "proj", AgentName: "agent"}, composeRunOptions{Interactive: true})
+	if got := commandExitCode(err); got != exitCodeUnavailable {
+		t.Fatalf("exit code = %d, want %d; err=%v", got, exitCodeUnavailable, err)
+	}
+	for _, want := range []string{"attach RPCs require HTTP/2 h2c", "HTTP/1 proxy"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestAttachExecProbeFailureSurfacesExitCodeUnavailable(t *testing.T) {
+	failingProbe := func(context.Context) error {
+		return fmt.Errorf("Get %q: http2: failed reading the frame payload: http2: frame too large, note that the frame header looked like an HTTP/1.1 header", "http://proxy/api/version")
+	}
+	client := connectAttachExecClient{
+		client: agentcomposev2connect.NewExecServiceClient(http.DefaultClient, "http://proxy"),
+		probe:  failingProbe,
+	}
+	cmd := &cobra.Command{Use: "exec"}
+	cmd.SetContext(context.Background())
+	cmd.SetIn(strings.NewReader("x\n"))
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := runComposeAttachExecCommand(cmd, "proj", client, &agentcomposev2.ExecRequest{
+		Target: &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-1"},
+	}, composeExecOptions{Interactive: true})
+	if got := commandExitCode(err); got != exitCodeUnavailable {
+		t.Fatalf("exit code = %d, want %d; err=%v", got, exitCodeUnavailable, err)
+	}
+	for _, want := range []string{"attach RPCs require HTTP/2 h2c", "HTTP/1 proxy"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
 }

--- a/cmd/agent-compose/cli_exec_attach_test.go
+++ b/cmd/agent-compose/cli_exec_attach_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"agent-compose/proto/agentcompose/v2/agentcomposev2connect"
 	"bytes"
 	"context"
 	"errors"

--- a/cmd/agent-compose/cli_exec_command.go
+++ b/cmd/agent-compose/cli_exec_command.go
@@ -121,12 +121,12 @@ func runComposeExecCommand(cmd *cobra.Command, cli cliOptions, options composeEx
 	}
 	if options.Interactive {
 		if strings.TrimSpace(options.Prompt) != "" {
-			return runComposeExecPromptAttachCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec}, req, options)
+			return runComposeExecPromptAttachCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec, probe: clients.attachBidiProbe}, req, options)
 		}
-		return runComposeAttachExecCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec}, req, options)
+		return runComposeAttachExecCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec, probe: clients.attachBidiProbe}, req, options)
 	}
 	if strings.TrimSpace(options.Prompt) != "" {
-		return runComposeExecPromptOnceCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec}, req, options, cli.JSON)
+		return runComposeExecPromptOnceCommand(cmd, runtimeProject.name(), connectAttachExecClient{client: clients.exec, probe: clients.attachBidiProbe}, req, options, cli.JSON)
 	}
 	stream, err := clients.exec.StreamExec(cmd.Context(), connect.NewRequest(req))
 	if err != nil {

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -352,11 +352,11 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 			if promptFlagChanged {
 				runReq.Prompt = prompt
 				runReq.Command = ""
-				return runComposeRunPromptAttachCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: clients.run}, runReq)
+				return runComposeRunPromptAttachCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: clients.run, probe: clients.attachBidiProbe}, runReq)
 			}
 			runReq.Prompt = ""
 			runReq.Command = commandText
-			return runComposeAttachAgentRunCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: clients.run}, runReq, normalizedOptions)
+			return runComposeAttachAgentRunCommand(cmd, runtimeProject.name(), connectAttachAgentRunClient{client: clients.run, probe: clients.attachBidiProbe}, runReq, normalizedOptions)
 		}
 		runReq.Prompt = ""
 		runReq.Command = ""


### PR DESCRIPTION
## Summary
  - Add a side-effect-free pre-attach h2c capability probe: before opening an AttachAgentRun / AttachExec bidi stream, issue `GET {baseURL}/api/version` over a raw h2c transport (matching the existing health-check URL construction) and propagate only the HTTP/2-vs-HTTP/1 transport mismatch, so an HTTP/1-only
  reverse proxy is reported with exit code 3 and guidance instead of failing mid-attach.
  - Skip probing entirely for unix sockets and non-`http://` base URLs, keeping the default local daemon path and the https path byte-for-byte unchanged.
  - Extract `newDaemonH2CTransport` from `newDaemonBaseRoundTripper` for reuse by the probe (behavior-equivalent refactor).
  - Extend `isAttachHTTP2TransportMismatch` to also recognize the x/net/http2 `http2: client conn could not be established` race variant, where the connection is torn down before the first stream is registered.
  - Add unit tests T1–T9 covering probe skip cases, HTTP/1-only mismatch detection, h2c success, transient/timeout pass-through, entry-function exit-code mapping, and real-stream pass-through.

## Testing
  - `go vet ./cmd/agent-compose/...` — clean
  - `go build ./...` — clean
  - `go test ./cmd/agent-compose/...` — all pass, incl. probe tests under `-race`
  - `go test -cover ./cmd/agent-compose/` — 80.4% of statements
  - `go test ./...` — `cmd/agent-compose` passes; `pkg/compose` and `pkg/volumes` have pre-existing macOS path-symlink / timezone failures, confirmed unchanged on a clean tree via `git stash`


## Checklist
  - [x] Documentation updated when behavior or configuration changed.
  - [x] Tests added or updated for user-visible behavior.
  - [x] No secrets, private endpoints, internal certificates, or local runtime state included.

