### PR TITLE
refactor(runs): keep attach protocol at transport boundary

### DIFF
--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -242,8 +242,8 @@ func (h *ExecHandler) execPromptAttach(ctx context.Context, start *agentcomposev
 		}},
 	}
 	receiver := newExecPromptRunAttachReceiver(initial, receive)
-	return h.runAttach.RunProjectCommandAttach(ctx, receiver.Receive, func(resp *agentcomposev2.AttachAgentRunResponse) error {
-		return send(execAttachResponseFromRunAttach(resp))
+	return h.runAttach.RunProjectCommandAttach(ctx, receiver.Receive, func(output runs.RunAttachOutput) error {
+		return send(execAttachResponseFromRunAttach(RunAttachOutputToProto(output)))
 	})
 }
 

--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -48,7 +48,7 @@ type ExecInteractionRuntime interface {
 type ExecRuntimeResolver func(*domain.Sandbox) (ExecRuntime, error)
 
 type ExecRunAttachDelegate interface {
-	RunProjectCommandAttach(context.Context, runs.RunAttachReceiver, runs.RunAttachSender) error
+	RunProjectCommandAttach(context.Context, func() (*agentcomposev2.AttachAgentRunRequest, error), runs.RunAttachSender) error
 }
 
 type ExecHandler struct {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -1176,7 +1176,7 @@ type apiExecPromptRunAttachDelegate struct {
 	human *agentcomposev2.AttachHumanMessage
 }
 
-func (d *apiExecPromptRunAttachDelegate) RunProjectCommandAttach(_ context.Context, receive runs.RunAttachReceiver, send runs.RunAttachSender) error {
+func (d *apiExecPromptRunAttachDelegate) RunProjectCommandAttach(_ context.Context, receive func() (*agentcomposev2.AttachAgentRunRequest, error), send runs.RunAttachSender) error {
 	first, err := receive()
 	if err != nil {
 		return err

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -51,6 +51,7 @@ func TestTranscriptEventFromExecChunkMapsStdioStream(t *testing.T) {
 }
 
 func TestPrepareStreamingHeadersPreservesNoTransform(t *testing.T) {
+	PrepareStreamingHeaders(nil)
 	headers := http.Header{}
 	PrepareStreamingHeaders(headers)
 	if got, want := headers.Get("Cache-Control"), "no-cache, no-transform"; got != want {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -1187,10 +1187,10 @@ func (d *apiExecPromptRunAttachDelegate) RunProjectCommandAttach(_ context.Conte
 		return err
 	}
 	d.human = second.GetHumanMessage()
-	if err := send(&agentcomposev2.AttachAgentRunResponse{Frame: &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Text: "agent says hi"}}}); err != nil {
+	if err := send(runs.RunAttachOutput{Kind: runs.RunAttachOutputAgentEvent, Text: "agent says hi"}); err != nil {
 		return err
 	}
-	return send(&agentcomposev2.AttachAgentRunResponse{Frame: &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{Success: true}}})
+	return send(runs.RunAttachOutput{Kind: runs.RunAttachOutputResult, Success: true})
 }
 
 type apiExecRuntime struct {

--- a/pkg/agentcompose/api/run_attach_mapper.go
+++ b/pkg/agentcompose/api/run_attach_mapper.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"time"
+
+	"agent-compose/pkg/runs"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func RunAttachOutputToProto(output runs.RunAttachOutput) *agentcomposev2.AttachAgentRunResponse {
+	createdAt := output.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	response := &agentcomposev2.AttachAgentRunResponse{ServerFrameId: uuid.NewString(), CreatedAt: timestamppb.New(createdAt)}
+	switch output.Kind {
+	case runs.RunAttachOutputStarted:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Started{Started: &agentcomposev2.AttachStarted{OperationId: output.Run.RunID, RunId: output.Run.RunID, SandboxId: output.SandboxID, Run: ProjectRunSummaryToProto(output.Run), Warnings: append([]string(nil), output.Warnings...)}}
+	case runs.RunAttachOutputData:
+		stream := StdioStreamToProto(output.Stream)
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Output{Output: &agentcomposev2.AttachOutput{Data: append([]byte(nil), output.Data...), Stream: stream, Tty: output.TTY, Transcript: &agentcomposev2.TranscriptEvent{Stream: stream, Text: string(output.Data), CreatedAt: response.CreatedAt}}}
+	case runs.RunAttachOutputAgentEvent:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Name: output.Name, Text: output.Text, PayloadJson: output.PayloadJSON, CreatedAt: response.CreatedAt}}
+	case runs.RunAttachOutputAgentTurnCompleted:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: output.Run.RunID, ResultJson: output.ResultJSON, Warnings: append([]string(nil), output.Warnings...)}}
+	case runs.RunAttachOutputResult:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{ExitCode: int32(output.ExitCode), Success: output.Success, Run: ProjectRunSummaryToProto(output.Run), Output: output.Output, ResultJson: output.ResultJSON, Error: output.Error}}
+	case runs.RunAttachOutputError:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Error{Error: &agentcomposev2.AttachError{Code: output.Code, Message: output.Error, Terminal: output.Terminal}}
+	}
+	return response
+}

--- a/pkg/agentcompose/api/run_attach_mapper_test.go
+++ b/pkg/agentcompose/api/run_attach_mapper_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/runs"
+)
+
+func TestRunAttachOutputToProtoMapsFrames(t *testing.T) {
+	run := domain.ProjectRunRecord{RunID: "run-1", ProjectID: "project-1", Status: domain.ProjectRunStatusSucceeded}
+	cases := []struct {
+		name   string
+		output runs.RunAttachOutput
+		check  func(*testing.T, any)
+	}{
+		{name: "started", output: runs.RunAttachOutput{Kind: runs.RunAttachOutputStarted, Run: run, SandboxID: "sandbox-1", Warnings: []string{"warning"}}},
+		{name: "output", output: runs.RunAttachOutput{Kind: runs.RunAttachOutputData, Data: []byte("chunk"), Stream: domain.StdioStderr, TTY: true}},
+		{name: "agent event", output: runs.RunAttachOutput{Kind: runs.RunAttachOutputAgentEvent, Name: "event", Text: "text", PayloadJSON: `{}`}},
+		{name: "turn completed", output: runs.RunAttachOutput{Kind: runs.RunAttachOutputAgentTurnCompleted, Run: run, ResultJSON: `{}`}},
+		{name: "result", output: runs.RunAttachOutput{Kind: runs.RunAttachOutputResult, Run: run, Success: true, ExitCode: 3, Output: "out", ResultJSON: `{}`}},
+		{name: "error", output: runs.RunAttachOutput{Kind: runs.RunAttachOutputError, Code: "failed", Error: "message", Terminal: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			response := RunAttachOutputToProto(tc.output)
+			if response.GetServerFrameId() == "" || response.GetCreatedAt() == nil || response.GetFrame() == nil {
+				t.Fatalf("response = %#v", response)
+			}
+		})
+	}
+}
+
+func TestRunAttachOutputToProtoPreservesCreatedAt(t *testing.T) {
+	createdAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	response := RunAttachOutputToProto(runs.RunAttachOutput{Kind: runs.RunAttachOutputError, CreatedAt: createdAt})
+	if got := response.GetCreatedAt().AsTime(); !got.Equal(createdAt) {
+		t.Fatalf("created at = %s, want %s", got, createdAt)
+	}
+}

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -237,6 +237,10 @@ func runAttachInputFromProto(request *agentcomposev2.AttachAgentRunRequest) runs
 			input.Mode = runs.RunAttachModeCommand
 		case agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT:
 			input.Mode = runs.RunAttachModePrompt
+		case agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_UNSPECIFIED:
+			input.Mode = runs.RunAttachModeUnspecified
+		default:
+			input.Mode = runs.RunAttachModeInvalid
 		}
 	case *agentcomposev2.AttachAgentRunRequest_Stdin:
 		input.Kind = runs.RunAttachInputStdin

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -199,7 +199,9 @@ func (d runControllerDelegate) AttachAgentRun(ctx context.Context, stream *conne
 	if d.controller == nil {
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("run controller is required"))
 	}
-	if err := d.controller.RunProjectCommandAttach(ctx, receiveRunAttachInput(stream.Receive), stream.Send); err != nil {
+	if err := d.controller.RunProjectCommandAttach(ctx, receiveRunAttachInput(stream.Receive), func(output runs.RunAttachOutput) error {
+		return stream.Send(api.RunAttachOutputToProto(output))
+	}); err != nil {
 		var connectErr *connect.Error
 		if errors.As(err, &connectErr) {
 			return connectErr

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -228,6 +228,9 @@ func runAttachInputFromProto(request *agentcomposev2.AttachAgentRunRequest) runs
 		start := frame.Start
 		input.Kind = runs.RunAttachInputStart
 		input.Request = runAgentRequestFromProto(start.GetRequest())
+		// AttachAgentRun historically ignored request-scoped volume mounts. Keep
+		// that compatibility behavior while other run transports map volumes.
+		input.Request.Volumes = nil
 		input.AttachStdin = start.GetAttachStdin()
 		input.TTY = start.GetTty()
 		input.Rows = start.GetTerminalSize().GetRows()

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -88,11 +88,11 @@ type runControllerDelegate struct {
 	supervisor *RunSupervisor
 }
 
-func (d runControllerDelegate) RunProjectCommandAttach(ctx context.Context, receive runs.RunAttachReceiver, send runs.RunAttachSender) error {
+func (d runControllerDelegate) RunProjectCommandAttach(ctx context.Context, receive func() (*agentcomposev2.AttachAgentRunRequest, error), send runs.RunAttachSender) error {
 	if d.supervisor == nil {
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("run supervisor is required"))
 	}
-	return runConnectError(d.supervisor.Attach(ctx, receive, send))
+	return runConnectError(d.supervisor.Attach(ctx, receiveRunAttachInput(receive), send))
 }
 
 func (d runControllerDelegate) RunAgent(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest]) (*connect.Response[agentcomposev2.RunAgentResponse], error) {
@@ -199,7 +199,7 @@ func (d runControllerDelegate) AttachAgentRun(ctx context.Context, stream *conne
 	if d.controller == nil {
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("run controller is required"))
 	}
-	if err := d.controller.RunProjectCommandAttach(ctx, stream.Receive, stream.Send); err != nil {
+	if err := d.controller.RunProjectCommandAttach(ctx, receiveRunAttachInput(stream.Receive), stream.Send); err != nil {
 		var connectErr *connect.Error
 		if errors.As(err, &connectErr) {
 			return connectErr
@@ -207,6 +207,55 @@ func (d runControllerDelegate) AttachAgentRun(ctx context.Context, stream *conne
 		return runConnectError(err)
 	}
 	return nil
+}
+
+func receiveRunAttachInput(receive func() (*agentcomposev2.AttachAgentRunRequest, error)) runs.RunAttachReceiver {
+	return func() (runs.RunAttachInput, error) {
+		request, err := receive()
+		if err != nil {
+			return runs.RunAttachInput{}, err
+		}
+		return runAttachInputFromProto(request), nil
+	}
+}
+
+func runAttachInputFromProto(request *agentcomposev2.AttachAgentRunRequest) runs.RunAttachInput {
+	input := runs.RunAttachInput{ClientFrameID: request.GetClientFrameId()}
+	switch frame := request.GetFrame().(type) {
+	case *agentcomposev2.AttachAgentRunRequest_Start:
+		start := frame.Start
+		input.Kind = runs.RunAttachInputStart
+		input.Request = runAgentRequestFromProto(start.GetRequest())
+		input.AttachStdin = start.GetAttachStdin()
+		input.TTY = start.GetTty()
+		input.Rows = start.GetTerminalSize().GetRows()
+		input.Cols = start.GetTerminalSize().GetCols()
+		switch start.GetMode() {
+		case agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND:
+			input.Mode = runs.RunAttachModeCommand
+		case agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT:
+			input.Mode = runs.RunAttachModePrompt
+		}
+	case *agentcomposev2.AttachAgentRunRequest_Stdin:
+		input.Kind = runs.RunAttachInputStdin
+		input.Data = append([]byte(nil), frame.Stdin.GetData()...)
+	case *agentcomposev2.AttachAgentRunRequest_StdinEof:
+		input.Kind = runs.RunAttachInputStdinEOF
+	case *agentcomposev2.AttachAgentRunRequest_Resize:
+		input.Kind = runs.RunAttachInputResize
+		input.Rows = frame.Resize.GetTerminalSize().GetRows()
+		input.Cols = frame.Resize.GetTerminalSize().GetCols()
+	case *agentcomposev2.AttachAgentRunRequest_Signal:
+		input.Kind = runs.RunAttachInputSignal
+		input.Signal = frame.Signal.GetSignal()
+	case *agentcomposev2.AttachAgentRunRequest_Cancel:
+		input.Kind = runs.RunAttachInputCancel
+		input.Reason = frame.Cancel.GetReason()
+	case *agentcomposev2.AttachAgentRunRequest_HumanMessage:
+		input.Kind = runs.RunAttachInputHumanMessage
+		input.Text = frame.HumanMessage.GetText()
+	}
+	return input
 }
 
 func runAgentRequestFromProto(msg *agentcomposev2.RunAgentRequest) runs.RunAgentRequest {

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -125,7 +125,7 @@ func (d runControllerDelegate) StartAgentRun(ctx context.Context, req *connect.R
 }
 
 func (d runControllerDelegate) StreamAgentRun(ctx context.Context, req *connect.Request[agentcomposev2.RunAgentRequest], stream *connect.ServerStream[agentcomposev2.StreamAgentRunResponse]) error {
-	runs.PrepareStreamingHeaders(stream.ResponseHeader())
+	api.PrepareStreamingHeaders(stream.ResponseHeader())
 	sink := runs.StreamSink{
 		SendStarted: func(run domain.ProjectRunRecord, createdAt time.Time) error {
 			return sendRunAgentStreamStarted(stream, run, createdAt)

--- a/pkg/agentcompose/app/run_controller_projection_test.go
+++ b/pkg/agentcompose/app/run_controller_projection_test.go
@@ -5,8 +5,22 @@ import (
 	"time"
 
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/runs"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
+
+func TestRunAttachInputFromProtoPreservesUnknownModeAsInvalid(t *testing.T) {
+	input := runAttachInputFromProto(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
+			Mode:    agentcomposev2.AttachRunMode(99),
+			Request: &agentcomposev2.RunAgentRequest{Command: "echo hello"},
+		}},
+	})
+
+	if input.Mode != runs.RunAttachModeInvalid {
+		t.Fatalf("mode = %q, want invalid", input.Mode)
+	}
+}
 
 func TestRunAgentStreamStartedProjectionPreservesResponseFields(t *testing.T) {
 	createdAt := time.Date(2026, 7, 10, 8, 9, 10, 123456789, time.FixedZone("CST", 8*60*60))

--- a/pkg/agentcompose/app/run_controller_projection_test.go
+++ b/pkg/agentcompose/app/run_controller_projection_test.go
@@ -22,6 +22,32 @@ func TestRunAttachInputFromProtoPreservesUnknownModeAsInvalid(t *testing.T) {
 	}
 }
 
+func TestRunAttachInputFromProtoPreservesLegacyRequestVolumeBehavior(t *testing.T) {
+	request := &agentcomposev2.RunAgentRequest{
+		Command: "echo hello",
+		Volumes: []*agentcomposev2.VolumeMountSpec{{
+			Type:     agentcomposev2.VolumeMountType_VOLUME_MOUNT_TYPE_BIND,
+			Source:   "/host/source",
+			Target:   "/guest/target",
+			ReadOnly: true,
+		}},
+	}
+	if mapped := runAgentRequestFromProto(request); len(mapped.Volumes) != 1 {
+		t.Fatalf("ordinary run volumes = %#v, want request volume preserved", mapped.Volumes)
+	}
+
+	input := runAttachInputFromProto(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
+			Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND,
+			Request: request,
+		}},
+	})
+
+	if len(input.Request.Volumes) != 0 {
+		t.Fatalf("attach request volumes = %#v, want legacy ignored behavior", input.Request.Volumes)
+	}
+}
+
 func TestRunAgentStreamStartedProjectionPreservesResponseFields(t *testing.T) {
 	createdAt := time.Date(2026, 7, 10, 8, 9, 10, 123456789, time.FixedZone("CST", 8*60*60))
 	run := domain.ProjectRunRecord{

--- a/pkg/runs/attach_input.go
+++ b/pkg/runs/attach_input.go
@@ -16,6 +16,7 @@ type RunAttachMode string
 
 const (
 	RunAttachModeUnspecified RunAttachMode = ""
+	RunAttachModeInvalid     RunAttachMode = "invalid"
 	RunAttachModeCommand     RunAttachMode = "command"
 	RunAttachModePrompt      RunAttachMode = "prompt"
 )

--- a/pkg/runs/attach_input.go
+++ b/pkg/runs/attach_input.go
@@ -1,0 +1,38 @@
+package runs
+
+type RunAttachInputKind string
+
+const (
+	RunAttachInputStart        RunAttachInputKind = "start"
+	RunAttachInputStdin        RunAttachInputKind = "stdin"
+	RunAttachInputStdinEOF     RunAttachInputKind = "stdin_eof"
+	RunAttachInputResize       RunAttachInputKind = "resize"
+	RunAttachInputSignal       RunAttachInputKind = "signal"
+	RunAttachInputCancel       RunAttachInputKind = "cancel"
+	RunAttachInputHumanMessage RunAttachInputKind = "human_message"
+)
+
+type RunAttachMode string
+
+const (
+	RunAttachModeUnspecified RunAttachMode = ""
+	RunAttachModeCommand     RunAttachMode = "command"
+	RunAttachModePrompt      RunAttachMode = "prompt"
+)
+
+type RunAttachInput struct {
+	Kind          RunAttachInputKind
+	Mode          RunAttachMode
+	Request       RunAgentRequest
+	AttachStdin   bool
+	TTY           bool
+	Rows          uint32
+	Cols          uint32
+	Data          []byte
+	Signal        string
+	Reason        string
+	Text          string
+	ClientFrameID string
+}
+
+type RunAttachReceiver func() (RunAttachInput, error)

--- a/pkg/runs/attach_input_test.go
+++ b/pkg/runs/attach_input_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	driverpkg "agent-compose/pkg/driver"
-	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
 func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
@@ -18,8 +17,8 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 
 	t.Run("command", func(t *testing.T) {
 		interaction := &closingRuntimeInteraction{}
-		pumpRunAttachInput(func() (*agentcomposev2.AttachAgentRunRequest, error) {
-			return nil, receiveErr
+		pumpRunAttachInput(func() (RunAttachInput, error) {
+			return RunAttachInput{}, receiveErr
 		}, interaction)
 		if interaction.closeCalls != 1 {
 			t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
@@ -29,8 +28,8 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 	t.Run("prompt", func(t *testing.T) {
 		interaction := &closingRuntimeInteraction{}
 		input := &promptWrapperInput{interaction: interaction}
-		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.AttachAgentRunRequest, error) {
-			return nil, receiveErr
+		pumpRunPromptAttachInput(context.Background(), func() (RunAttachInput, error) {
+			return RunAttachInput{}, receiveErr
 		}, input, nil, nil)
 		if interaction.closeCalls != 1 {
 			t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
@@ -42,7 +41,7 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 }
 
 func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t *testing.T) {
-	requests := make(chan *agentcomposev2.AttachAgentRunRequest, 2)
+	requests := make(chan RunAttachInput, 2)
 	received := make(chan struct{}, 2)
 	interaction := newObservedRuntimeInteraction()
 	input := &promptWrapperInput{interaction: interaction}
@@ -51,10 +50,10 @@ func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t 
 
 	go func() {
 		defer close(done)
-		pumpRunPromptAttachInput(context.Background(), func() (*agentcomposev2.AttachAgentRunRequest, error) {
+		pumpRunPromptAttachInput(context.Background(), func() (RunAttachInput, error) {
 			req, ok := <-requests
 			if !ok {
-				return nil, io.EOF
+				return RunAttachInput{}, io.EOF
 			}
 			received <- struct{}{}
 			return req, nil
@@ -88,7 +87,7 @@ func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t 
 
 func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	requests := make(chan *agentcomposev2.AttachAgentRunRequest, 1)
+	requests := make(chan RunAttachInput, 1)
 	received := make(chan struct{}, 1)
 	interaction := newObservedRuntimeInteraction()
 	input := &promptWrapperInput{interaction: interaction}
@@ -96,7 +95,7 @@ func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
 
 	go func() {
 		defer close(done)
-		pumpRunPromptAttachInput(ctx, func() (*agentcomposev2.AttachAgentRunRequest, error) {
+		pumpRunPromptAttachInput(ctx, func() (RunAttachInput, error) {
 			req := <-requests
 			received <- struct{}{}
 			return req, nil
@@ -117,10 +116,8 @@ func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
 	}
 }
 
-func humanMessageAttachRequest(message string) *agentcomposev2.AttachAgentRunRequest {
-	return &agentcomposev2.AttachAgentRunRequest{Frame: &agentcomposev2.AttachAgentRunRequest_HumanMessage{
-		HumanMessage: &agentcomposev2.AttachHumanMessage{Text: message},
-	}}
+func humanMessageAttachRequest(message string) RunAttachInput {
+	return RunAttachInput{Kind: RunAttachInputHumanMessage, Text: message}
 }
 
 func receiveRuntimeInputFrame(t *testing.T, frames <-chan driverpkg.RuntimeInputFrame) driverpkg.RuntimeInputFrame {

--- a/pkg/runs/attach_output.go
+++ b/pkg/runs/attach_output.go
@@ -1,0 +1,41 @@
+package runs
+
+import (
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+type RunAttachOutputKind string
+
+const (
+	RunAttachOutputStarted            RunAttachOutputKind = "started"
+	RunAttachOutputData               RunAttachOutputKind = "output"
+	RunAttachOutputAgentEvent         RunAttachOutputKind = "agent_event"
+	RunAttachOutputAgentTurnCompleted RunAttachOutputKind = "agent_turn_completed"
+	RunAttachOutputResult             RunAttachOutputKind = "result"
+	RunAttachOutputError              RunAttachOutputKind = "error"
+)
+
+type RunAttachOutput struct {
+	Kind        RunAttachOutputKind
+	CreatedAt   time.Time
+	Run         domain.ProjectRunRecord
+	SandboxID   string
+	Warnings    []string
+	Data        []byte
+	Stream      domain.StdioStream
+	TTY         bool
+	Name        string
+	Text        string
+	PayloadJSON string
+	ResultJSON  string
+	Output      string
+	Error       string
+	Code        string
+	ExitCode    int
+	Success     bool
+	Terminal    bool
+}
+
+type RunAttachSender func(RunAttachOutput) error

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -1251,43 +1251,6 @@ func transitionFromCommandResult(run domain.ProjectRunRecord, sandbox *domain.Sa
 	return req
 }
 
-func runAgentRequestFromAttachStart(start *agentcomposev2.AttachAgentRunStart) RunAgentRequest {
-	msg := start.GetRequest()
-	if msg == nil {
-		return RunAgentRequest{}
-	}
-	return RunAgentRequest{
-		ProjectID:        msg.GetProjectId(),
-		AgentName:        msg.GetAgentName(),
-		Prompt:           msg.GetPrompt(),
-		Command:          msg.GetCommand(),
-		Source:           projectRunSourceFromAttachProto(msg.GetSource()),
-		SchedulerID:      msg.GetSchedulerId(),
-		TriggerID:        msg.GetTriggerId(),
-		PayloadJSON:      msg.GetPayloadJson(),
-		ClientRequestID:  msg.GetClientRequestId(),
-		Env:              msg.GetEnv(),
-		SandboxID:        msg.GetSandboxId(),
-		Driver:           msg.GetDriver(),
-		OutputSchemaJSON: msg.GetOutputSchemaJson(),
-		CleanupPolicy:    msg.GetCleanupPolicy(),
-		Jupyter:          msg.GetJupyter(),
-	}
-}
-
-func projectRunSourceFromAttachProto(source agentcomposev2.RunSource) string {
-	switch source {
-	case agentcomposev2.RunSource_RUN_SOURCE_SCHEDULER:
-		return domain.ProjectRunSourceScheduler
-	case agentcomposev2.RunSource_RUN_SOURCE_API:
-		return domain.ProjectRunSourceAPI
-	case agentcomposev2.RunSource_RUN_SOURCE_MANUAL:
-		return domain.ProjectRunSourceManual
-	default:
-		return domain.ProjectRunSourceManual
-	}
-}
-
 func transitionFromRuntimeResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, commandText, logsPath string, accumulated domain.ExecResult, result driverpkg.RuntimeResult, execErr error) TransitionRequest {
 	accumulated.ExitCode = result.ExitCode
 	accumulated.Success = result.Success

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -223,14 +222,6 @@ type StreamSink struct {
 
 type RunAttachReceiver func() (*agentcomposev2.AttachAgentRunRequest, error)
 type RunAttachSender func(*agentcomposev2.AttachAgentRunResponse) error
-
-func PrepareStreamingHeaders(headers http.Header) {
-	if headers == nil {
-		return
-	}
-	headers.Set("Cache-Control", "no-cache, no-transform")
-	headers.Set("X-Accel-Buffering", "no")
-}
 
 type StartedProjectRun struct {
 	Run      domain.ProjectRunRecord

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -220,7 +220,6 @@ type StreamSink struct {
 	SendChunk   func(runID string, chunk domain.ExecChunk, createdAt time.Time) error
 }
 
-type RunAttachReceiver func() (*agentcomposev2.AttachAgentRunRequest, error)
 type RunAttachSender func(*agentcomposev2.AttachAgentRunResponse) error
 
 type StartedProjectRun struct {
@@ -303,26 +302,25 @@ func (c *Controller) RunProjectCommandAttachRegistered(ctx context.Context, rece
 		}
 		return err
 	}
-	start := first.GetStart()
-	if start == nil {
+	if first.Kind != RunAttachInputStart {
 		return fmt.Errorf("%w: first run attach frame must be start", ErrInvalidRequest)
 	}
-	mode := start.GetMode()
-	req := runAgentRequestFromAttachStart(start)
+	mode := first.Mode
+	req := first.Request
 	commandText := strings.TrimSpace(req.Command)
-	if mode == agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_UNSPECIFIED && commandText != "" {
-		mode = agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND
+	if mode == RunAttachModeUnspecified && commandText != "" {
+		mode = RunAttachModeCommand
 	}
-	if mode == agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_UNSPECIFIED && strings.TrimSpace(req.Prompt) != "" {
-		mode = agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT
+	if mode == RunAttachModeUnspecified && strings.TrimSpace(req.Prompt) != "" {
+		mode = RunAttachModePrompt
 	}
-	if mode != agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND && mode != agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT {
+	if mode != RunAttachModeCommand && mode != RunAttachModePrompt {
 		return fmt.Errorf("%w: run attach command mode is required", ErrInvalidRequest)
 	}
-	if mode == agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND && commandText == "" {
+	if mode == RunAttachModeCommand && commandText == "" {
 		return fmt.Errorf("%w: run attach command is required", ErrInvalidRequest)
 	}
-	if mode == agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT && strings.TrimSpace(req.Prompt) == "" {
+	if mode == RunAttachModePrompt && strings.TrimSpace(req.Prompt) == "" {
 		return fmt.Errorf("%w: run attach prompt is required", ErrInvalidRequest)
 	}
 	started, err := c.StartProjectRun(ctx, req)
@@ -332,7 +330,7 @@ func (c *Controller) RunProjectCommandAttachRegistered(ctx context.Context, rece
 	if onStarted != nil {
 		onStarted(started.Run.RunID)
 	}
-	run, execErr, err := c.executeStartedProjectRunAttach(ctx, started.Run, req, started.Warnings, start, mode, receive, send)
+	run, execErr, err := c.executeStartedProjectRunAttach(ctx, started.Run, req, started.Warnings, first, mode, receive, send)
 	if err != nil {
 		return err
 	}
@@ -685,7 +683,7 @@ func (c *Controller) executeProjectRunCommand(ctx context.Context, run domain.Pr
 	return transition, nil
 }
 
-func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run domain.ProjectRunRecord, req RunAgentRequest, warnings []string, start *agentcomposev2.AttachAgentRunStart, mode agentcomposev2.AttachRunMode, receive RunAttachReceiver, send RunAttachSender) (domain.ProjectRunRecord, error, error) {
+func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run domain.ProjectRunRecord, req RunAgentRequest, warnings []string, start RunAttachInput, mode RunAttachMode, receive RunAttachReceiver, send RunAttachSender) (domain.ProjectRunRecord, error, error) {
 	coordinator := NewCoordinator(c.configDB, domain.StableProjectRunID)
 	commandText := strings.TrimSpace(req.Command)
 	transitionCtx := context.WithoutCancel(ctx)
@@ -718,7 +716,7 @@ func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run dom
 	var transition TransitionRequest
 	var execErr error
 	switch mode {
-	case agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT:
+	case RunAttachModePrompt:
 		transition, execErr = c.runPromptInteraction(ctx, coordinator, run, sandboxResult.Sandbox, req, start, receive, send)
 	default:
 		transition, execErr = c.runCommandInteraction(ctx, coordinator, run, sandboxResult.Sandbox, req, commandText, start, receive, send)
@@ -744,7 +742,7 @@ func (c *Controller) executeStartedProjectRunAttach(ctx context.Context, run dom
 	return run, nil, nil
 }
 
-func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, commandText string, start *agentcomposev2.AttachAgentRunStart, receive RunAttachReceiver, send RunAttachSender) (TransitionRequest, error) {
+func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, commandText string, start RunAttachInput, receive RunAttachReceiver, send RunAttachSender) (TransitionRequest, error) {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	logsPath := filepath.Join(artifactsDir, "transcript.txt")
 	transition := TransitionRequest{RunID: run.RunID, SandboxID: sandbox.Summary.ID, LogsPath: logsPath}
@@ -785,7 +783,6 @@ func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coo
 		transition.Error = fmt.Sprintf("command execution failed: %v", err)
 		return transition, err
 	}
-	size := start.GetTerminalSize()
 	spec := driverpkg.RuntimeStartSpec{
 		OperationID: run.RunID,
 		Kind:        driverpkg.RuntimeOperationCommand,
@@ -798,10 +795,10 @@ func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coo
 		},
 		Cwd:         c.config.GuestWorkspacePath,
 		Env:         execEnvMap(req.Env),
-		AttachStdin: start.GetAttachStdin(),
-		TTY:         start.GetTty(),
-		Rows:        size.GetRows(),
-		Cols:        size.GetCols(),
+		AttachStdin: start.AttachStdin,
+		TTY:         start.TTY,
+		Rows:        start.Rows,
+		Cols:        start.Cols,
 	}
 	interaction, err := interactionRuntime.OpenInteraction(ctx, sandbox, vmState, spec)
 	if err != nil {
@@ -848,7 +845,7 @@ func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coo
 				return transition, err
 			}
 			c.publishRunLogChunk(run.RunID, chunk, offset)
-			if err := send(runAttachOutputResponse(frame.Data, stream, start.GetTty())); err != nil {
+			if err := send(runAttachOutputResponse(frame.Data, stream, start.TTY)); err != nil {
 				transition.ExitCode = 1
 				transition.Error = fmt.Sprintf("command execution failed: %v", err)
 				return transition, err
@@ -887,7 +884,7 @@ func markProjectRunInteractionArtifacts(ctx context.Context, coordinator *Coordi
 	})
 }
 
-func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, start *agentcomposev2.AttachAgentRunStart, receive RunAttachReceiver, send RunAttachSender) (transitionResult TransitionRequest, returnErr error) {
+func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coordinator, run domain.ProjectRunRecord, sandbox *domain.Sandbox, req RunAgentRequest, _ RunAttachInput, receive RunAttachReceiver, send RunAttachSender) (transitionResult TransitionRequest, returnErr error) {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	logsPath := filepath.Join(artifactsDir, "transcript.txt")
 	transition := TransitionRequest{RunID: run.RunID, SandboxID: sandbox.Summary.ID, LogsPath: logsPath}
@@ -1375,19 +1372,18 @@ func pumpRunAttachInput(receive RunAttachReceiver, interaction driverpkg.Runtime
 	}
 }
 
-func runtimeInputFrameFromRunAttach(req *agentcomposev2.AttachAgentRunRequest) (driverpkg.RuntimeInputFrame, bool) {
-	switch frame := req.GetFrame().(type) {
-	case *agentcomposev2.AttachAgentRunRequest_Stdin:
-		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: frame.Stdin.GetData()}, true
-	case *agentcomposev2.AttachAgentRunRequest_StdinEof:
+func runtimeInputFrameFromRunAttach(req RunAttachInput) (driverpkg.RuntimeInputFrame, bool) {
+	switch req.Kind {
+	case RunAttachInputStdin:
+		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: req.Data}, true
+	case RunAttachInputStdinEOF:
 		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdinEOF}, true
-	case *agentcomposev2.AttachAgentRunRequest_Resize:
-		size := frame.Resize.GetTerminalSize()
-		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputResize, Rows: size.GetRows(), Cols: size.GetCols()}, true
-	case *agentcomposev2.AttachAgentRunRequest_Signal:
-		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputSignal, Signal: driverpkg.RuntimeSignal(strings.TrimSpace(frame.Signal.GetSignal()))}, true
-	case *agentcomposev2.AttachAgentRunRequest_Cancel:
-		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputCancel, Message: frame.Cancel.GetReason()}, true
+	case RunAttachInputResize:
+		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputResize, Rows: req.Rows, Cols: req.Cols}, true
+	case RunAttachInputSignal:
+		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputSignal, Signal: driverpkg.RuntimeSignal(strings.TrimSpace(req.Signal))}, true
+	case RunAttachInputCancel:
+		return driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputCancel, Message: req.Reason}, true
 	default:
 		return driverpkg.RuntimeInputFrame{}, false
 	}
@@ -1457,22 +1453,20 @@ func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, in
 			_ = input.EOF()
 			return
 		}
-		switch frame := req.GetFrame().(type) {
-		case *agentcomposev2.AttachAgentRunRequest_HumanMessage:
-			text := frame.HumanMessage.GetText()
-			if !forwardPromptHumanMessage(ctx, input, turnReady, text, req.GetClientFrameId(), onHumanMessage) {
+		switch req.Kind {
+		case RunAttachInputHumanMessage:
+			if !forwardPromptHumanMessage(ctx, input, turnReady, req.Text, req.ClientFrameID, onHumanMessage) {
 				return
 			}
-		case *agentcomposev2.AttachAgentRunRequest_Stdin:
-			text := string(frame.Stdin.GetData())
-			if !forwardPromptHumanMessage(ctx, input, turnReady, text, req.GetClientFrameId(), onHumanMessage) {
+		case RunAttachInputStdin:
+			if !forwardPromptHumanMessage(ctx, input, turnReady, string(req.Data), req.ClientFrameID, onHumanMessage) {
 				return
 			}
-		case *agentcomposev2.AttachAgentRunRequest_StdinEof:
+		case RunAttachInputStdinEOF:
 			_ = input.EOF()
 			return
-		case *agentcomposev2.AttachAgentRunRequest_Cancel:
-			_ = input.Cancel(frame.Cancel.GetReason())
+		case RunAttachInputCancel:
+			_ = input.Cancel(req.Reason)
 			return
 		default:
 			_ = input.Cancel("invalid run prompt attach frame")

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"agent-compose/pkg/capabilities"
 	appconfig "agent-compose/pkg/config"
@@ -219,8 +218,6 @@ type StreamSink struct {
 	SendStarted func(run domain.ProjectRunRecord, createdAt time.Time) error
 	SendChunk   func(runID string, chunk domain.ExecChunk, createdAt time.Time) error
 }
-
-type RunAttachSender func(*agentcomposev2.AttachAgentRunResponse) error
 
 type StartedProjectRun struct {
 	Run      domain.ProjectRunRecord
@@ -835,8 +832,8 @@ func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coo
 				return transition, err
 			}
 		case driverpkg.RuntimeOutputStdout, driverpkg.RuntimeOutputStderr:
-			stream := driverOutputStreamToRunProto(frame.Type)
-			chunk := domain.ExecChunk{Text: string(frame.Data), Stream: protoStreamToRunDomain(stream)}
+			stream := driverOutputStreamToRun(frame.Type)
+			chunk := domain.ExecChunk{Text: string(frame.Data), Stream: stream}
 			accumulator.WriteChunk(chunk)
 			offset, err := appendProjectRunLogChunk(logsPath, chunk)
 			if err != nil {
@@ -1070,7 +1067,7 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 					transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 					return transition, err
 				}
-				if resp.GetAgentTurnCompleted() != nil {
+				if resp.Kind == RunAttachOutputAgentTurnCompleted {
 					releasePromptTurn(turnReady)
 				}
 			}
@@ -1083,7 +1080,7 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 				transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 				return transition, err
 			}
-			if err := send(runAttachOutputResponse(frame.Data, agentcomposev2.StdioStream_STDIO_STREAM_STDERR, false)); err != nil {
+			if err := send(runAttachOutputResponse(frame.Data, domain.StdioStderr, false)); err != nil {
 				transition.ExitCode = 1
 				transition.Error = fmt.Sprintf("agent execution failed: %v", err)
 				return transition, err
@@ -1533,7 +1530,7 @@ func newPromptAttachProjector(run domain.ProjectRunRecord, sandbox *domain.Sandb
 	}
 }
 
-func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.AttachAgentRunResponse, *TransitionRequest, error) {
+func (p *promptAttachProjector) Project(data []byte) ([]RunAttachOutput, *TransitionRequest, error) {
 	p.buffer = append(p.buffer, data...)
 	lines := make([][]byte, 0)
 	for {
@@ -1547,7 +1544,7 @@ func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.AttachAg
 			lines = append(lines, line)
 		}
 	}
-	var responses []*agentcomposev2.AttachAgentRunResponse
+	var responses []RunAttachOutput
 	var transition *TransitionRequest
 	for _, line := range lines {
 		nextResponses, nextTransition, err := p.projectLine(line)
@@ -1562,7 +1559,7 @@ func (p *promptAttachProjector) Project(data []byte) ([]*agentcomposev2.AttachAg
 	return responses, transition, nil
 }
 
-func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.AttachAgentRunResponse, *TransitionRequest, error) {
+func (p *promptAttachProjector) projectLine(line []byte) ([]RunAttachOutput, *TransitionRequest, error) {
 	var frame struct {
 		Type            string                      `json:"type"`
 		Event           json.RawMessage             `json:"event"`
@@ -1580,13 +1577,13 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.Atta
 	}
 	switch frame.Type {
 	case "started":
-		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentEventResponse("started", "", string(line))}, nil, nil
+		return []RunAttachOutput{runAttachAgentEventResponse("started", "", string(line))}, nil, nil
 	case "agent_event":
 		name, text := p.agentEventText(frame.Event)
 		if err := p.appendLogText(text); err != nil {
 			return nil, nil, err
 		}
-		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentEventResponse(firstNonEmpty(name, "agent_event"), text, string(frame.Event))}, nil, nil
+		return []RunAttachOutput{runAttachAgentEventResponse(firstNonEmpty(name, "agent_event"), text, string(frame.Event))}, nil, nil
 	case "agent_turn_completed":
 		if err := p.appendLogFinalText(frame.FinalText); err != nil {
 			return nil, nil, err
@@ -1594,7 +1591,7 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.Atta
 		if err := p.appendAssistantEvent(line, frame.Seq, agentTurnProjection{FinalText: frame.FinalText, FinalTextSource: frame.FinalTextSource, Provider: frame.Provider, StopReason: frame.StopReason}); err != nil {
 			return nil, nil, err
 		}
-		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentTurnCompletedResponse(p.run, string(line), warningsFromRun(p.run))}, nil, nil
+		return []RunAttachOutput{runAttachAgentTurnCompletedResponse(p.run, string(line), warningsFromRun(p.run))}, nil, nil
 	case "result":
 		if err := p.appendLogFinalText(frame.FinalText); err != nil {
 			return nil, nil, err
@@ -1605,9 +1602,9 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]*agentcomposev2.Atta
 	case "error":
 		message := firstNonEmpty(frame.Message, "runtime stream error")
 		transition := transitionFromPromptWrapperResult(p.run, p.sandbox, p.logsPath, line, "", frame.StopReason, message)
-		return []*agentcomposev2.AttachAgentRunResponse{runAttachErrorResponse(firstNonEmpty(frame.Code, "runtime_stream_error"), message, true)}, &transition, nil
+		return []RunAttachOutput{runAttachErrorResponse(firstNonEmpty(frame.Code, "runtime_stream_error"), message, true)}, &transition, nil
 	default:
-		return []*agentcomposev2.AttachAgentRunResponse{runAttachAgentEventResponse(firstNonEmpty(frame.Type, "agent_event"), "", string(line))}, nil, nil
+		return []RunAttachOutput{runAttachAgentEventResponse(firstNonEmpty(frame.Type, "agent_event"), "", string(line))}, nil, nil
 	}
 }
 
@@ -1815,96 +1812,32 @@ func bytesIndexByte(data []byte, needle byte) int {
 	return -1
 }
 
-func runAttachStartedResponse(run domain.ProjectRunRecord, sandbox *domain.Sandbox, warnings []string, startedAt time.Time) *agentcomposev2.AttachAgentRunResponse {
-	resp := newAttachAgentRunResponse()
-	if !startedAt.IsZero() {
-		resp.CreatedAt = timestamppb.New(startedAt)
-	}
-	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Started{Started: &agentcomposev2.AttachStarted{
-		OperationId: run.RunID,
-		RunId:       run.RunID,
-		SandboxId:   sandbox.Summary.ID,
-		Run:         projectRunSummaryForAttach(run),
-		Warnings:    append([]string(nil), warnings...),
-	}}
-	return resp
+func runAttachStartedResponse(run domain.ProjectRunRecord, sandbox *domain.Sandbox, warnings []string, startedAt time.Time) RunAttachOutput {
+	return RunAttachOutput{Kind: RunAttachOutputStarted, CreatedAt: startedAt, Run: run, SandboxID: sandbox.Summary.ID, Warnings: append([]string(nil), warnings...)}
 }
 
-func runAttachOutputResponse(data []byte, stream agentcomposev2.StdioStream, tty bool) *agentcomposev2.AttachAgentRunResponse {
-	resp := newAttachAgentRunResponse()
-	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Output{Output: &agentcomposev2.AttachOutput{
-		Data:   append([]byte(nil), data...),
-		Stream: stream,
-		Tty:    tty,
-		Transcript: &agentcomposev2.TranscriptEvent{
-			Stream:    stream,
-			Text:      string(data),
-			CreatedAt: resp.CreatedAt,
-		},
-	}}
-	return resp
+func runAttachOutputResponse(data []byte, stream domain.StdioStream, tty bool) RunAttachOutput {
+	return RunAttachOutput{Kind: RunAttachOutputData, CreatedAt: time.Now().UTC(), Data: append([]byte(nil), data...), Stream: stream, TTY: tty}
 }
 
-func runAttachAgentEventResponse(name, text, payloadJSON string) *agentcomposev2.AttachAgentRunResponse {
-	resp := newAttachAgentRunResponse()
-	resp.Frame = &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{
-		Name:        name,
-		Text:        text,
-		PayloadJson: payloadJSON,
-		CreatedAt:   resp.CreatedAt,
-	}}
-	return resp
+func runAttachAgentEventResponse(name, text, payloadJSON string) RunAttachOutput {
+	return RunAttachOutput{Kind: RunAttachOutputAgentEvent, CreatedAt: time.Now().UTC(), Name: name, Text: text, PayloadJSON: payloadJSON}
 }
 
-func runAttachAgentTurnCompletedResponse(run domain.ProjectRunRecord, resultJSON string, warnings []string) *agentcomposev2.AttachAgentRunResponse {
-	resp := newAttachAgentRunResponse()
-	resp.Frame = &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{
-		RunId:      run.RunID,
-		ResultJson: resultJSON,
-		Warnings:   append([]string(nil), warnings...),
-	}}
-	return resp
+func runAttachAgentTurnCompletedResponse(run domain.ProjectRunRecord, resultJSON string, warnings []string) RunAttachOutput {
+	return RunAttachOutput{Kind: RunAttachOutputAgentTurnCompleted, CreatedAt: time.Now().UTC(), Run: run, ResultJSON: resultJSON, Warnings: append([]string(nil), warnings...)}
 }
 
-func runAttachResultResponse(run domain.ProjectRunRecord, transition TransitionRequest, success bool) *agentcomposev2.AttachAgentRunResponse {
-	resp := newAttachAgentRunResponse()
-	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{
-		ExitCode:   int32(transition.ExitCode),
-		Success:    success,
-		Run:        projectRunSummaryForAttach(run),
-		Output:     transition.Output,
-		ResultJson: transition.ResultJSON,
-		Error:      transition.Error,
-	}}
-	return resp
+func runAttachResultResponse(run domain.ProjectRunRecord, transition TransitionRequest, success bool) RunAttachOutput {
+	return RunAttachOutput{Kind: RunAttachOutputResult, CreatedAt: time.Now().UTC(), Run: run, ExitCode: transition.ExitCode, Success: success, Output: transition.Output, ResultJSON: transition.ResultJSON, Error: transition.Error}
 }
 
-func runAttachErrorResponse(code, message string, terminal bool) *agentcomposev2.AttachAgentRunResponse {
-	resp := newAttachAgentRunResponse()
-	resp.Frame = &agentcomposev2.AttachAgentRunResponse_Error{Error: &agentcomposev2.AttachError{
-		Code:     code,
-		Message:  message,
-		Terminal: terminal,
-	}}
-	return resp
+func runAttachErrorResponse(code, message string, terminal bool) RunAttachOutput {
+	return RunAttachOutput{Kind: RunAttachOutputError, CreatedAt: time.Now().UTC(), Code: code, Error: message, Terminal: terminal}
 }
 
-func newAttachAgentRunResponse() *agentcomposev2.AttachAgentRunResponse {
-	return &agentcomposev2.AttachAgentRunResponse{
-		ServerFrameId: uuid.NewString(),
-		CreatedAt:     timestamppb.Now(),
-	}
-}
-
-func driverOutputStreamToRunProto(frameType driverpkg.RuntimeOutputFrameType) agentcomposev2.StdioStream {
+func driverOutputStreamToRun(frameType driverpkg.RuntimeOutputFrameType) domain.StdioStream {
 	if frameType == driverpkg.RuntimeOutputStderr {
-		return agentcomposev2.StdioStream_STDIO_STREAM_STDERR
-	}
-	return agentcomposev2.StdioStream_STDIO_STREAM_STDOUT
-}
-
-func protoStreamToRunDomain(stream agentcomposev2.StdioStream) domain.StdioStream {
-	if stream == agentcomposev2.StdioStream_STDIO_STREAM_STDERR {
 		return domain.StdioStderr
 	}
 	return domain.StdioStdout
@@ -1912,35 +1845,6 @@ func protoStreamToRunDomain(stream agentcomposev2.StdioStream) domain.StdioStrea
 
 func warningsFromRun(run domain.ProjectRunRecord) []string {
 	return append([]string(nil), run.Warnings...)
-}
-
-func projectRunSummaryForAttach(run domain.ProjectRunRecord) *agentcomposev2.RunSummary {
-	return &agentcomposev2.RunSummary{
-		RunId:       run.RunID,
-		ProjectId:   run.ProjectID,
-		ProjectName: run.ProjectName,
-		AgentName:   run.AgentName,
-		Status:      projectRunStatusForAttach(run.Status),
-		SandboxId:   run.SandboxID,
-		Warnings:    append([]string(nil), run.Warnings...),
-	}
-}
-
-func projectRunStatusForAttach(status string) agentcomposev2.RunStatus {
-	switch NormalizeStatus(status) {
-	case domain.ProjectRunStatusPending:
-		return agentcomposev2.RunStatus_RUN_STATUS_PENDING
-	case domain.ProjectRunStatusRunning:
-		return agentcomposev2.RunStatus_RUN_STATUS_RUNNING
-	case domain.ProjectRunStatusSucceeded:
-		return agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED
-	case domain.ProjectRunStatusFailed:
-		return agentcomposev2.RunStatus_RUN_STATUS_FAILED
-	case domain.ProjectRunStatusCanceled:
-		return agentcomposev2.RunStatus_RUN_STATUS_CANCELED
-	default:
-		return agentcomposev2.RunStatus_RUN_STATUS_UNSPECIFIED
-	}
 }
 
 func projectRunCommandArtifactsDir(run domain.ProjectRunRecord, sandbox *domain.Sandbox) string {

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -983,23 +983,22 @@ func TestRunsControllerRunProjectPromptAttachGatesQueuedTurnsAndOrdersTranscript
 	interaction := newScriptedRunAttachInteraction()
 	runtime.interactionOverride = interaction
 
-	requests := make(chan *agentcomposev2.AttachAgentRunRequest, 4)
-	requests <- &agentcomposev2.AttachAgentRunRequest{Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
-		Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "human-1"},
-		Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
-	}}}
+	requests := make(chan RunAttachInput, 4)
+	requests <- RunAttachInput{Kind: RunAttachInputStart, Mode: RunAttachModePrompt, Request: RunAgentRequest{
+		ProjectID: "project-1", AgentName: "worker", Prompt: "human-1",
+	}}
 	requests <- humanMessageAttachRequest("human-2")
 	requests <- humanMessageAttachRequest("human-3")
-	requests <- &agentcomposev2.AttachAgentRunRequest{Frame: &agentcomposev2.AttachAgentRunRequest_StdinEof{StdinEof: &agentcomposev2.AttachStdinEOF{}}}
+	requests <- RunAttachInput{Kind: RunAttachInputStdinEOF}
 	close(requests)
 
 	var responses []*agentcomposev2.AttachAgentRunResponse
 	done := make(chan error, 1)
 	go func() {
-		done <- controller.RunProjectCommandAttach(ctx, func() (*agentcomposev2.AttachAgentRunRequest, error) {
+		done <- controller.RunProjectCommandAttach(ctx, func() (RunAttachInput, error) {
 			req, ok := <-requests
 			if !ok {
-				return nil, io.EOF
+				return RunAttachInput{}, io.EOF
 			}
 			return req, nil
 		}, func(resp *agentcomposev2.AttachAgentRunResponse) error {
@@ -2960,14 +2959,53 @@ func (i *fakeRunAttachInteraction) Wait() (driverpkg.RuntimeResult, error) {
 
 func recvAttachAgentRunRequests(requests []*agentcomposev2.AttachAgentRunRequest) RunAttachReceiver {
 	index := 0
-	return func() (*agentcomposev2.AttachAgentRunRequest, error) {
+	return func() (RunAttachInput, error) {
 		if index >= len(requests) {
-			return nil, io.EOF
+			return RunAttachInput{}, io.EOF
 		}
 		req := requests[index]
 		index++
-		return req, nil
+		return runAttachInputFromTestProto(req), nil
 	}
+}
+
+func runAttachInputFromTestProto(request *agentcomposev2.AttachAgentRunRequest) RunAttachInput {
+	input := RunAttachInput{ClientFrameID: request.GetClientFrameId()}
+	switch frame := request.GetFrame().(type) {
+	case *agentcomposev2.AttachAgentRunRequest_Start:
+		start := frame.Start
+		input.Kind = RunAttachInputStart
+		input.Request = runAgentRequestFromAttachStart(start)
+		input.AttachStdin = start.GetAttachStdin()
+		input.TTY = start.GetTty()
+		input.Rows = start.GetTerminalSize().GetRows()
+		input.Cols = start.GetTerminalSize().GetCols()
+		switch start.GetMode() {
+		case agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_COMMAND:
+			input.Mode = RunAttachModeCommand
+		case agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT:
+			input.Mode = RunAttachModePrompt
+		}
+	case *agentcomposev2.AttachAgentRunRequest_Stdin:
+		input.Kind = RunAttachInputStdin
+		input.Data = frame.Stdin.GetData()
+	case *agentcomposev2.AttachAgentRunRequest_StdinEof:
+		input.Kind = RunAttachInputStdinEOF
+	case *agentcomposev2.AttachAgentRunRequest_Resize:
+		input.Kind = RunAttachInputResize
+		input.Rows = frame.Resize.GetTerminalSize().GetRows()
+		input.Cols = frame.Resize.GetTerminalSize().GetCols()
+	case *agentcomposev2.AttachAgentRunRequest_Signal:
+		input.Kind = RunAttachInputSignal
+		input.Signal = frame.Signal.GetSignal()
+	case *agentcomposev2.AttachAgentRunRequest_Cancel:
+		input.Kind = RunAttachInputCancel
+		input.Reason = frame.Cancel.GetReason()
+	case *agentcomposev2.AttachAgentRunRequest_HumanMessage:
+		input.Kind = RunAttachInputHumanMessage
+		input.Text = frame.HumanMessage.GetText()
+	}
+	return input
 }
 
 type fakeControllerImages struct{}

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2300,13 +2299,6 @@ func TestRunsProjectRunLogAppendChunk(t *testing.T) {
 }
 
 func TestRunsControllerHelperEdgeWorkflows(t *testing.T) {
-	PrepareStreamingHeaders(nil)
-	headers := http.Header{}
-	PrepareStreamingHeaders(headers)
-	if headers.Get("Cache-Control") != "no-cache, no-transform" || headers.Get("X-Accel-Buffering") != "no" {
-		t.Fatalf("stream headers = %#v", headers)
-	}
-
 	baseJupyter := sandboxstore.CreateSandboxOptions{JupyterGuestPort: 8888}
 	if options, err := resolveRunJupyterOptions(baseJupyter, nil); err != nil ||
 		options.JupyterEnabled != baseJupyter.JupyterEnabled ||

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -2979,7 +2979,12 @@ func runAttachInputFromTestProto(request *agentcomposev2.AttachAgentRunRequest) 
 	case *agentcomposev2.AttachAgentRunRequest_Start:
 		start := frame.Start
 		input.Kind = RunAttachInputStart
-		input.Request = runAgentRequestFromAttachStart(start)
+		message := start.GetRequest()
+		input.Request = RunAgentRequest{
+			ProjectID: message.GetProjectId(), AgentName: message.GetAgentName(), Prompt: message.GetPrompt(), Command: message.GetCommand(),
+			ClientRequestID: message.GetClientRequestId(), Env: message.GetEnv(), SandboxID: message.GetSandboxId(), Driver: message.GetDriver(),
+			OutputSchemaJSON: message.GetOutputSchemaJson(), CleanupPolicy: message.GetCleanupPolicy(), Jupyter: message.GetJupyter(),
+		}
 		input.AttachStdin = start.GetAttachStdin()
 		input.TTY = start.GetTty()
 		input.Rows = start.GetTerminalSize().GetRows()

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -848,7 +848,8 @@ func TestRunsControllerRunProjectCommandAttachProjectsOutputAndResult(t *testing
 		}},
 	}}
 	var responses []*agentcomposev2.AttachAgentRunResponse
-	err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(resp *agentcomposev2.AttachAgentRunResponse) error {
+	err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(output RunAttachOutput) error {
+		resp := runAttachOutputToTestProto(output)
 		if started := resp.GetStarted(); started != nil {
 			stored, err := configDB.GetProjectRun(ctx, started.GetRunId())
 			if err != nil {
@@ -894,7 +895,7 @@ func TestRunsControllerRunProjectCommandAttachValidatesStartFrame(t *testing.T) 
 	controller, _, _ := newTestRunAttachController(t, nil)
 	err := controller.RunProjectCommandAttach(context.Background(), recvAttachAgentRunRequests([]*agentcomposev2.AttachAgentRunRequest{{
 		Frame: &agentcomposev2.AttachAgentRunRequest_Stdin{Stdin: &agentcomposev2.AttachStdin{Data: []byte("x")}},
-	}}), func(*agentcomposev2.AttachAgentRunResponse) error { return nil })
+	}}), func(RunAttachOutput) error { return nil })
 	if !errors.Is(err, ErrInvalidRequest) {
 		t.Fatalf("RunProjectCommandAttach first frame error = %v, want ErrInvalidRequest", err)
 	}
@@ -918,7 +919,8 @@ func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 		}},
 	}}
 	var responses []*agentcomposev2.AttachAgentRunResponse
-	err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(resp *agentcomposev2.AttachAgentRunResponse) error {
+	err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(output RunAttachOutput) error {
+		resp := runAttachOutputToTestProto(output)
 		if started := resp.GetStarted(); started != nil {
 			stored, err := configDB.GetProjectRun(ctx, started.GetRunId())
 			if err != nil {
@@ -1001,7 +1003,8 @@ func TestRunsControllerRunProjectPromptAttachGatesQueuedTurnsAndOrdersTranscript
 				return RunAttachInput{}, io.EOF
 			}
 			return req, nil
-		}, func(resp *agentcomposev2.AttachAgentRunResponse) error {
+		}, func(output RunAttachOutput) error {
+			resp := runAttachOutputToTestProto(output)
 			responses = append(responses, resp)
 			return nil
 		})
@@ -1327,7 +1330,8 @@ func TestRunsControllerRunProjectPromptAttachUnsupportedProvidersDoNotOpenRuntim
 				}},
 			}}
 			var responses []*agentcomposev2.AttachAgentRunResponse
-			err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(resp *agentcomposev2.AttachAgentRunResponse) error {
+			err := controller.RunProjectCommandAttach(ctx, recvAttachAgentRunRequests(requests), func(output RunAttachOutput) error {
+				resp := runAttachOutputToTestProto(output)
 				responses = append(responses, resp)
 				return nil
 			})
@@ -3131,4 +3135,31 @@ func (s *fakeGuideSandboxStore) SaveProxyState(string, sandboxstore.ProxyState) 
 
 func (s *fakeGuideSandboxStore) AllocateHostPortForJupyter() (int, error) {
 	return 0, errors.New("not implemented")
+}
+
+func runAttachOutputToTestProto(output RunAttachOutput) *agentcomposev2.AttachAgentRunResponse {
+	response := &agentcomposev2.AttachAgentRunResponse{}
+	switch output.Kind {
+	case RunAttachOutputStarted:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Started{Started: &agentcomposev2.AttachStarted{RunId: output.Run.RunID, SandboxId: output.SandboxID}}
+	case RunAttachOutputData:
+		stream := agentcomposev2.StdioStream_STDIO_STREAM_STDOUT
+		if output.Stream == domain.StdioStderr {
+			stream = agentcomposev2.StdioStream_STDIO_STREAM_STDERR
+		}
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Output{Output: &agentcomposev2.AttachOutput{Data: output.Data, Stream: stream, Transcript: &agentcomposev2.TranscriptEvent{Text: string(output.Data)}}}
+	case RunAttachOutputAgentEvent:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_AgentEvent{AgentEvent: &agentcomposev2.AttachAgentEvent{Name: output.Name, Text: output.Text}}
+	case RunAttachOutputAgentTurnCompleted:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{RunId: output.Run.RunID, ResultJson: output.ResultJSON}}
+	case RunAttachOutputResult:
+		status := agentcomposev2.RunStatus_RUN_STATUS_FAILED
+		if output.Run.Status == domain.ProjectRunStatusSucceeded {
+			status = agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED
+		}
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{Success: output.Success, Error: output.Error, Run: &agentcomposev2.RunSummary{RunId: output.Run.RunID, Status: status}}}
+	case RunAttachOutputError:
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Error{Error: &agentcomposev2.AttachError{Code: output.Code, Message: output.Error, Terminal: output.Terminal}}
+	}
+	return response
 }

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -901,6 +901,22 @@ func TestRunsControllerRunProjectCommandAttachValidatesStartFrame(t *testing.T) 
 	}
 }
 
+func TestRunsControllerRunProjectCommandAttachRejectsInvalidMode(t *testing.T) {
+	controller, _, _ := newTestRunAttachController(t, nil)
+	receive := func() (RunAttachInput, error) {
+		return RunAttachInput{
+			Kind:    RunAttachInputStart,
+			Mode:    RunAttachModeInvalid,
+			Request: RunAgentRequest{Command: "echo hello"},
+		}, nil
+	}
+
+	err := controller.RunProjectCommandAttach(context.Background(), receive, func(RunAttachOutput) error { return nil })
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("RunProjectCommandAttach invalid mode error = %v, want ErrInvalidRequest", err)
+	}
+}
+
 func TestRunsControllerRunProjectPromptAttachProjectsAgentFrames(t *testing.T) {
 	ctx := context.Background()
 	controller, configDB, runtime := newTestRunAttachController(t, []driverpkg.RuntimeOutputFrame{

--- a/pkg/runs/dependency_contract_test.go
+++ b/pkg/runs/dependency_contract_test.go
@@ -1,0 +1,47 @@
+package runs
+
+import (
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestProductionCodeDoesNotDependOnTransportPackages(t *testing.T) {
+	t.Parallel()
+
+	_, sourcePath, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve dependency contract source path")
+	}
+	packageDir := filepath.Dir(sourcePath)
+	files, err := filepath.Glob(filepath.Join(packageDir, "*.go"))
+	if err != nil {
+		t.Fatalf("list package files: %v", err)
+	}
+
+	forbidden := []string{"net/http", "connectrpc.com/connect"}
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", filepath.Base(path), err)
+		}
+		for _, imported := range file.Imports {
+			importPath, err := strconv.Unquote(imported.Path.Value)
+			if err != nil {
+				t.Fatalf("decode import in %s: %v", filepath.Base(path), err)
+			}
+			for _, prefix := range forbidden {
+				if importPath == prefix || strings.HasPrefix(importPath, prefix+"/") {
+					t.Errorf("%s imports transport package %q", filepath.Base(path), importPath)
+				}
+			}
+		}
+	}
+}

--- a/pkg/runs/dependency_contract_test.go
+++ b/pkg/runs/dependency_contract_test.go
@@ -1,6 +1,7 @@
 package runs
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 	"strings"
 	"testing"
 )
+
+const generatedProtoImportPrefix = "agent-compose/proto/"
 
 func TestProductionCodeDoesNotDependOnTransportPackages(t *testing.T) {
 	t.Parallel()
@@ -28,7 +31,7 @@ func TestProductionCodeDoesNotDependOnTransportPackages(t *testing.T) {
 		if strings.HasSuffix(path, "_test.go") {
 			continue
 		}
-		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", filepath.Base(path), err)
 		}
@@ -44,4 +47,48 @@ func TestProductionCodeDoesNotDependOnTransportPackages(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestAttachBoundaryDoesNotDependOnGeneratedProto(t *testing.T) {
+	t.Parallel()
+
+	_, sourcePath, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve dependency contract source path")
+	}
+	packageDir := filepath.Dir(sourcePath)
+	for _, name := range []string{"attach_input.go", "attach_output.go"} {
+		file := parseDependencyContractFile(t, filepath.Join(packageDir, name))
+		for _, imported := range file.Imports {
+			importPath, err := strconv.Unquote(imported.Path.Value)
+			if err != nil {
+				t.Fatalf("decode import in %s: %v", name, err)
+			}
+			if strings.HasPrefix(importPath, generatedProtoImportPrefix) {
+				t.Errorf("%s imports generated protobuf package %q", name, importPath)
+			}
+		}
+	}
+
+	controller := parseDependencyContractFile(t, filepath.Join(packageDir, "controller.go"))
+	ast.Inspect(controller, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		identifier, ok := selector.X.(*ast.Ident)
+		if ok && identifier.Name == "agentcomposev2" && strings.HasPrefix(selector.Sel.Name, "Attach") {
+			t.Errorf("controller.go references generated attach type agentcomposev2.%s", selector.Sel.Name)
+		}
+		return true
+	})
+}
+
+func parseDependencyContractFile(t *testing.T, path string) *ast.File {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", filepath.Base(path), err)
+	}
+	return file
 }


### PR DESCRIPTION
## Summary

- keep streaming HTTP header handling at the API transport boundary
- translate attach input and output between protobuf and focused `runs` domain types
- add dependency contract tests that prevent attach logic from regaining HTTP, Connect, or generated attach protobuf dependencies
- preserve the public protobuf schema, persistence formats, run state transitions, and runtime behavior

## Testing

- `go test ./pkg/runs ./pkg/agentcompose/api ./pkg/agentcompose/app -count=1`
- `go test -race ./pkg/runs ./pkg/agentcompose/api ./pkg/agentcompose/app -run 'Attach|RunAttachOutputToProto' -count=1 -timeout=5m`
- `task lint`
- `task test` (combined coverage: 79.42%)
- `CGO_ENABLED=0 go build ./cmd/agent-compose ./pkg/runs ./pkg/agentcompose/api ./pkg/agentcompose/app`

The unrestricted full-package race command was stopped after the existing `pkg/runs` suite did not finish promptly under race instrumentation; the focused attach-related race suite above passed.

## Checklist

- [x] Documentation updated when behavior or configuration changed. (Not applicable: no behavior or configuration change.)
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
