### PR TITLE
[codex] fix(ci): initialize DingTalk request before debug logging

### DIFF
--- a/.github/workflows/notify-dingtalk-release.yml
+++ b/.github/workflows/notify-dingtalk-release.yml
@@ -90,12 +90,6 @@ jobs:
             release_body="(This release has no release notes.)"
           fi
 
-          echo "::group::Debug LLM request"
-          echo "release_tag=${release_tag}"
-          echo "release_body_chars=${#release_body}"
-          echo "request_body_chars=${#request_body}"
-          echo "::endgroup::"
-
           temporary_response="$(mktemp)"
           trap 'rm -f "$temporary_response"' EXIT
 
@@ -113,6 +107,12 @@ jobs:
                 {role: "user", content: ("Translate the following release notes:\n\n--- BEGIN RELEASE NOTES ---\n" + $release_body + "\n--- END RELEASE NOTES ---")}
               ]
             }')"
+
+          echo "::group::Debug LLM request"
+          echo "release_tag=${release_tag}"
+          echo "release_body_chars=${#release_body}"
+          echo "request_body_chars=${#request_body}"
+          echo "::endgroup::"
 
           if ! curl -fsS \
             --retry 2 \


### PR DESCRIPTION
## Summary

- Move the DingTalk LLM request debug output after `request_body` is initialized.
- Prevent the release notification workflow from exiting under `set -u` before the LLM request is sent.

The failure was introduced when `${#request_body}` was logged before the variable assignment, producing `request_body: unbound variable`.

## Testing

- Extracted the embedded workflow Bash and validated it with `bash -n`.
- Ran the complete embedded script locally with mocked GitHub release, LLM, and DingTalk responses.
- Ran `git diff --check`.

## Checklist

- [x] Documentation updated when behavior or configuration changed (not applicable; no documented behavior changed).
- [ ] Tests added or updated for user-visible behavior (no repository test added; validated with a local mocked workflow smoke test).
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
