### PR TITLE
fix(scheduler): preserve sticky command runtime contracts

### DIFF
--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -461,6 +461,7 @@ Scheduler command host parsing flow:
 ```text
 RuntimeHost.Command
   -> ensure scheduler sandbox
+  -> persist scheduler.command.started with linked sandbox id
   -> SchedulerCommandExecutor.ExecuteSchedulerCommand
   -> Store.AddCell(running SHELL)
   -> write command-request.json
@@ -470,6 +471,25 @@ RuntimeHost.Command
   -> Store.AddCell(completed SHELL)
   -> scheduler.command.completed / scheduler.command.failed
 ```
+
+For trigger runs, the linked `scheduler.command.started` event is committed before
+the command executor starts. That event is the durable SchedulerRun-to-sandbox
+association returned by `ListSchedulerRuns.runs[].sandboxIds`; if it cannot be
+persisted, the command is not started. Direct scheduler invocations have no
+SchedulerRun record and therefore do not write this association.
+
+Every command reconstructs its transient LLM facade environment on an in-memory
+Sandbox clone instead of relying on fields that are intentionally absent from
+the persisted Sandbox record. Startup Anthropic and OpenAI family facades are
+created first; the selected provider facade is merged last so its exact provider
+variables win. Those managed values also override same-name values in the guest
+child request environment, while unrelated request environment remains intact.
+The executor tracks every token hash persisted by this command. Partial setup
+failure and confirmed command termination delete all of them; an
+`ErrExecTerminationUnconfirmed` result retains them for later Sandbox lifecycle
+revocation because the guest process may still be running. This command-scoped
+path must not rerun full Sandbox agent preparation, which would revoke tokens and
+rewrite configuration used by other work in a reusable Sandbox.
 
 After parsing succeeds, the guest runtime has already written
 `command-result.json` in the shared cell directory. The host does not rewrite

--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -482,8 +482,14 @@ Every command reconstructs its transient LLM facade environment on an in-memory
 Sandbox clone instead of relying on fields that are intentionally absent from
 the persisted Sandbox record. Startup Anthropic and OpenAI family facades are
 created first; the selected provider facade is merged last so its exact provider
-variables win. Those managed values also override same-name values in the guest
-child request environment, while unrelated request environment remains intact.
+variables win. The managed values are passed through the outer runtime process
+environment. An explicit `scheduler.shell`/`scheduler.exec` request environment
+is preserved unchanged in `command-request.json` and, per the guest runtime
+contract, overrides same-name outer values only for that workload child; raw
+managed facade tokens are therefore not copied into the request artifact.
+Commands for which no supported facade agent is selected do not perform facade
+reconstruction, so that command path is not coupled to LLM provider
+configuration health.
 The executor tracks every token hash persisted by this command. Partial setup
 failure and confirmed command termination delete all of them; an
 `ErrExecTerminationUnconfirmed` result retains them for later Sandbox lifecycle

--- a/docs/design/agent-compose-runtime_contract.md
+++ b/docs/design/agent-compose-runtime_contract.md
@@ -472,11 +472,14 @@ RuntimeHost.Command
   -> scheduler.command.completed / scheduler.command.failed
 ```
 
-For trigger runs, the linked `scheduler.command.started` event is committed before
-the command executor starts. That event is the durable SchedulerRun-to-sandbox
-association returned by `ListSchedulerRuns.runs[].sandboxIds`; if it cannot be
-persisted, the command is not started. Direct scheduler invocations have no
-SchedulerRun record and therefore do not write this association.
+For trigger runs with an event recorder, the linked `scheduler.command.started`
+event is committed before the command executor starts. That event is the durable
+SchedulerRun-to-sandbox association returned by
+`ListSchedulerRuns.runs[].sandboxIds`; if an available recorder cannot persist
+it, the command is not started. A trigger host without an event recorder keeps
+the legacy best-effort behavior and executes the command without this event
+association. Direct scheduler invocations have no SchedulerRun record and
+therefore do not write this association.
 
 Every command reconstructs its transient LLM facade environment on an in-memory
 Sandbox clone instead of relying on fields that are intentionally absent from

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -241,6 +241,16 @@ Normalization rules:
   payload. Renaming it would change every existing binding hash; the one-shot
   migrator carries those hashes forward but cannot reconstruct their original
   runtime inputs.
+- Sticky compatibility hashes the effective sandbox inputs for the selected
+  Agent and Scheduler, including resolved driver, image, environment, volumes,
+  workspace snapshot, capsets, and agent configuration. The enclosing Project's
+  monotonically increasing revision number is deliberately excluded: changing an
+  unrelated Agent in the same Project must not retire this Scheduler's sandbox,
+  while changing any effective input still does.
+  Existing managed sticky bindings created by an older release that included the
+  Project revision in this hash are replaced once on their first post-upgrade
+  run; subsequent unrelated Project revisions leave the replacement binding
+  compatible.
 - `scheduler.script` is either an inline QJS scalar or an explicit mapping with
   the single non-empty field `url`. URL content is normalized into the same
   inline managed-scheduler `script` snapshot. Blank inline scripts are unset;

--- a/pkg/agentcompose/adapters/scheduler_command_executor.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor.go
@@ -72,15 +72,18 @@ func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, 
 		CreatedAt: startedAt,
 		Running:   true,
 	}
-	execSession, facadeToken, err := e.prepareSchedulerCommandLLMFacadeEnv(ctx, session, request, cellID)
+	execSession, managedFacadeEnv, facadeTokenHashes, err := e.prepareSchedulerCommandLLMFacadeEnv(ctx, session, request, cellID)
 	if err != nil {
 		return domain.SchedulerCommandResult{}, err
 	}
-	retainFacadeToken := false
-	if e.ConfigDB != nil && facadeToken != "" {
+	retainFacadeTokens := false
+	if e.ConfigDB != nil && len(facadeTokenHashes) > 0 {
 		defer func() {
-			if !retainFacadeToken {
-				_ = e.ConfigDB.DeleteLLMFacadeToken(context.WithoutCancel(ctx), facadeToken)
+			if !retainFacadeTokens {
+				cleanupCtx := context.WithoutCancel(ctx)
+				for _, tokenHash := range facadeTokenHashes {
+					_ = e.ConfigDB.DeleteLLMFacadeTokenHash(cleanupCtx, tokenHash)
+				}
 			}
 		}()
 	}
@@ -161,7 +164,12 @@ func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, 
 		return buildSchedulerCommandResult(recovered), finalErr
 	}
 
-	runtimeRequest := execution.RuntimeCommandRequestPayload(e.Config, request, guestCellDir)
+	runtimeCommandRequest := request
+	// The guest runtime applies request.Env after the outer command process
+	// environment. Carry the same facade values into the request so stale
+	// provider variables cannot replace them in the actual workload child.
+	runtimeCommandRequest.Env = mergeSchedulerCommandRuntimeEnv(request.Env, managedFacadeEnv)
+	runtimeRequest := execution.RuntimeCommandRequestPayload(e.Config, runtimeCommandRequest, guestCellDir)
 	hostRequestPath := filepath.Join(hostCellDir, "command-request.json")
 	if err := execution.WriteJSONArtifact(hostRequestPath, runtimeRequest); err != nil {
 		return domain.SchedulerCommandResult{}, fmt.Errorf("write scheduler command request artifact: %w", err)
@@ -191,7 +199,7 @@ func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, 
 	}
 	commandHome := e.Config.GuestHomePath
 	execResult, err := runtime.ExecStream(execCtx, execSession, vmState, execution.BuildSchedulerCommandExecSpec(e.Config, execSession, filepath.Join(guestCellDir, "command-request.json"), commandHome), streamWriter)
-	retainFacadeToken = errors.Is(err, domain.ErrExecTerminationUnconfirmed)
+	retainFacadeTokens = errors.Is(err, domain.ErrExecTerminationUnconfirmed)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()
@@ -253,14 +261,11 @@ func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, 
 	}, nil
 }
 
-func (e *SchedulerCommandExecutor) prepareSchedulerCommandLLMFacadeEnv(ctx context.Context, session *domain.Sandbox, request domain.SchedulerCommandRequest, runID string) (*domain.Sandbox, string, error) {
+func (e *SchedulerCommandExecutor) prepareSchedulerCommandLLMFacadeEnv(ctx context.Context, session *domain.Sandbox, request domain.SchedulerCommandRequest, runID string) (*domain.Sandbox, map[string]string, []string, error) {
 	if e == nil || e.Config == nil || e.ConfigDB == nil || session == nil {
-		return session, "", nil
+		return session, nil, nil, nil
 	}
 	agent, model := llms.SchedulerCommandFacadeAgentModel(request.Env)
-	if agent == "" {
-		return session, "", nil
-	}
 
 	execSession := *session
 	execSession.EnvItems = append([]domain.SandboxEnvVar(nil), session.EnvItems...)
@@ -273,12 +278,33 @@ func (e *SchedulerCommandExecutor) prepareSchedulerCommandLLMFacadeEnv(ctx conte
 	}
 	execSession.ProviderEnvItems = domain.MergeEnvItems(execSession.ProviderEnvItems, domain.SchedulerCommandSandboxEnv(request))
 
-	managedEnv, err := runtimefacade.EnsureSessionLLMFacadeConfig(ctx, e.Config, facadeStoreFor(e.ConfigDB), &execSession, agent, model, runtimefacade.TokenSourceSchedulerCommand, runID)
+	managedConfig, err := runtimefacade.EnsureSessionCommandFacadeConfig(ctx, e.Config, commandFacadeStoreFor(e.ConfigDB), &execSession, agent, model, runtimefacade.TokenSourceSchedulerCommand, runID)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, nil, err
 	}
-	if len(managedEnv) > 0 {
-		execSession.RuntimeEnvItems = domain.MergeEnvItems(execSession.RuntimeEnvItems, llms.EnvItemsFromMap(managedEnv, false))
+	if len(managedConfig.Env) > 0 {
+		execSession.RuntimeEnvItems = domain.MergeEnvItems(execSession.RuntimeEnvItems, llms.EnvItemsFromMap(managedConfig.Env, true))
 	}
-	return &execSession, managedEnv["AGENT_COMPOSE_SANDBOX_TOKEN"], nil
+	return &execSession, managedConfig.Env, managedConfig.TokenHashes, nil
+}
+
+func commandFacadeStoreFor(configDB *configstore.ConfigStore) runtimefacade.CommandFacadeStore {
+	if configDB == nil {
+		return nil
+	}
+	return configDB
+}
+
+func mergeSchedulerCommandRuntimeEnv(requestEnv, managedFacadeEnv map[string]string) map[string]string {
+	if len(requestEnv) == 0 && len(managedFacadeEnv) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(requestEnv)+len(managedFacadeEnv))
+	for name, value := range requestEnv {
+		merged[name] = value
+	}
+	for name, value := range managedFacadeEnv {
+		merged[name] = value
+	}
+	return merged
 }

--- a/pkg/agentcompose/adapters/scheduler_command_executor.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor.go
@@ -72,7 +72,7 @@ func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, 
 		CreatedAt: startedAt,
 		Running:   true,
 	}
-	execSession, managedFacadeEnv, facadeTokenHashes, err := e.prepareSchedulerCommandLLMFacadeEnv(ctx, session, request, cellID)
+	execSession, facadeTokenHashes, err := e.prepareSchedulerCommandLLMFacadeEnv(ctx, session, request, cellID)
 	if err != nil {
 		return domain.SchedulerCommandResult{}, err
 	}
@@ -164,12 +164,10 @@ func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, 
 		return buildSchedulerCommandResult(recovered), finalErr
 	}
 
-	runtimeCommandRequest := request
-	// The guest runtime applies request.Env after the outer command process
-	// environment. Carry the same facade values into the request so stale
-	// provider variables cannot replace them in the actual workload child.
-	runtimeCommandRequest.Env = mergeSchedulerCommandRuntimeEnv(request.Env, managedFacadeEnv)
-	runtimeRequest := execution.RuntimeCommandRequestPayload(e.Config, runtimeCommandRequest, guestCellDir)
+	// request.Env is an explicit command option and the guest runtime applies it
+	// last to the workload child process. Preserve it unchanged; the freshly
+	// rebuilt managed facade values live only in execSession.RuntimeEnvItems.
+	runtimeRequest := execution.RuntimeCommandRequestPayload(e.Config, request, guestCellDir)
 	hostRequestPath := filepath.Join(hostCellDir, "command-request.json")
 	if err := execution.WriteJSONArtifact(hostRequestPath, runtimeRequest); err != nil {
 		return domain.SchedulerCommandResult{}, fmt.Errorf("write scheduler command request artifact: %w", err)
@@ -261,11 +259,14 @@ func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, 
 	}, nil
 }
 
-func (e *SchedulerCommandExecutor) prepareSchedulerCommandLLMFacadeEnv(ctx context.Context, session *domain.Sandbox, request domain.SchedulerCommandRequest, runID string) (*domain.Sandbox, map[string]string, []string, error) {
+func (e *SchedulerCommandExecutor) prepareSchedulerCommandLLMFacadeEnv(ctx context.Context, session *domain.Sandbox, request domain.SchedulerCommandRequest, runID string) (*domain.Sandbox, []string, error) {
 	if e == nil || e.Config == nil || e.ConfigDB == nil || session == nil {
-		return session, nil, nil, nil
+		return session, nil, nil
 	}
 	agent, model := llms.SchedulerCommandFacadeAgentModel(request.Env)
+	if agent == "" {
+		return session, nil, nil
+	}
 
 	execSession := *session
 	execSession.EnvItems = append([]domain.SandboxEnvVar(nil), session.EnvItems...)
@@ -280,12 +281,12 @@ func (e *SchedulerCommandExecutor) prepareSchedulerCommandLLMFacadeEnv(ctx conte
 
 	managedConfig, err := runtimefacade.EnsureSessionCommandFacadeConfig(ctx, e.Config, commandFacadeStoreFor(e.ConfigDB), &execSession, agent, model, runtimefacade.TokenSourceSchedulerCommand, runID)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 	if len(managedConfig.Env) > 0 {
 		execSession.RuntimeEnvItems = domain.MergeEnvItems(execSession.RuntimeEnvItems, llms.EnvItemsFromMap(managedConfig.Env, true))
 	}
-	return &execSession, managedConfig.Env, managedConfig.TokenHashes, nil
+	return &execSession, managedConfig.TokenHashes, nil
 }
 
 func commandFacadeStoreFor(configDB *configstore.ConfigStore) runtimefacade.CommandFacadeStore {
@@ -293,18 +294,4 @@ func commandFacadeStoreFor(configDB *configstore.ConfigStore) runtimefacade.Comm
 		return nil
 	}
 	return configDB
-}
-
-func mergeSchedulerCommandRuntimeEnv(requestEnv, managedFacadeEnv map[string]string) map[string]string {
-	if len(requestEnv) == 0 && len(managedFacadeEnv) == 0 {
-		return nil
-	}
-	merged := make(map[string]string, len(requestEnv)+len(managedFacadeEnv))
-	for name, value := range requestEnv {
-		merged[name] = value
-	}
-	for name, value := range managedFacadeEnv {
-		merged[name] = value
-	}
-	return merged
 }

--- a/pkg/agentcompose/adapters/scheduler_command_executor_test.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor_test.go
@@ -3,6 +3,8 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,12 +13,21 @@ import (
 	appconfig "agent-compose/pkg/config"
 	driverpkg "agent-compose/pkg/driver"
 	"agent-compose/pkg/execution"
+	"agent-compose/pkg/internal/testutil"
+	"agent-compose/pkg/llms"
+	"agent-compose/pkg/llms/runtimefacade"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/sandboxes"
+	"agent-compose/pkg/storage/configstore"
 	"agent-compose/pkg/storage/sandboxstore"
 )
 
 type fakeSchedulerCommandRuntime struct{}
+
+type capturingSchedulerCommandRuntime struct {
+	session *domain.Sandbox
+	err     error
+}
 
 func (r fakeSchedulerCommandRuntime) EnsureSandbox(context.Context, *domain.Sandbox, domain.VMState, domain.ProxyState) (domain.SandboxVMInfo, error) {
 	return domain.SandboxVMInfo{}, nil
@@ -56,6 +67,30 @@ func (r fakeSchedulerCommandRuntime) ExecStream(_ context.Context, _ *domain.San
 		ExitCode: 0,
 		Success:  true,
 	}, nil
+}
+
+func (r *capturingSchedulerCommandRuntime) EnsureSandbox(context.Context, *domain.Sandbox, domain.VMState, domain.ProxyState) (domain.SandboxVMInfo, error) {
+	return domain.SandboxVMInfo{}, nil
+}
+
+func (r *capturingSchedulerCommandRuntime) StopSandbox(context.Context, *domain.Sandbox, domain.VMState) (bool, error) {
+	return false, nil
+}
+
+func (r *capturingSchedulerCommandRuntime) RemoveSandbox(context.Context, *domain.Sandbox, domain.VMState) error {
+	return nil
+}
+
+func (r *capturingSchedulerCommandRuntime) Exec(context.Context, *domain.Sandbox, domain.VMState, domain.ExecSpec) (domain.ExecResult, error) {
+	return domain.ExecResult{}, nil
+}
+
+func (r *capturingSchedulerCommandRuntime) ExecStream(ctx context.Context, session *domain.Sandbox, state domain.VMState, spec domain.ExecSpec, stream domain.ExecStreamWriter) (domain.ExecResult, error) {
+	r.session = session
+	if r.err != nil {
+		return domain.ExecResult{}, r.err
+	}
+	return (fakeSchedulerCommandRuntime{}).ExecStream(ctx, session, state, spec, stream)
 }
 
 func TestSchedulerCommandExecutorFiltersCommandPayloadFromStreamingCellOutput(t *testing.T) {
@@ -130,5 +165,160 @@ drained:
 		if strings.Contains(cell.Output, execution.CommandResultPrefix) {
 			t.Fatalf("cell leaked command payload: %#v", cell)
 		}
+	}
+}
+
+func TestSchedulerCommandExecutorRebuildsAndOwnsCommandFacadeTokens(t *testing.T) {
+	tests := []struct {
+		name            string
+		runtimeErr      error
+		wantTokenCount  int
+		wantTokenExists bool
+	}{
+		{name: "normal completion cleans every command token"},
+		{name: "unconfirmed termination retains every command token", runtimeErr: domain.ErrExecTerminationUnconfirmed, wantTokenCount: 3, wantTokenExists: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			root := t.TempDir()
+			config := schedulerCommandFacadeTestConfig(root)
+			configDB, store, err := testutil.OpenStores(t, config)
+			if err != nil {
+				t.Fatalf("OpenStores returned error: %v", err)
+			}
+			seedSchedulerCommandFacadeProviders(t, ctx, configDB)
+			session, err := store.CreateSandbox(ctx, "scheduler facade command", "", driverpkg.RuntimeDriverDocker, "guest:latest", "", domain.SandboxTypeScript, nil, []domain.SandboxEnvVar{
+				{Name: "ANTHROPIC_BASE_URL", Value: "https://anthropic.persisted.test"},
+				{Name: "ANTHROPIC_API_KEY", Value: "persisted-upstream-key", Secret: true},
+			}, nil)
+			if err != nil {
+				t.Fatalf("CreateSandbox returned error: %v", err)
+			}
+			session.Summary.VMStatus = domain.VMStatusRunning
+			if err := store.UpdateSandbox(ctx, session); err != nil {
+				t.Fatalf("UpdateSandbox returned error: %v", err)
+			}
+			if err := store.SaveVMState(session.Summary.ID, domain.VMState{Driver: driverpkg.RuntimeDriverDocker, BoxID: "container-1"}); err != nil {
+				t.Fatalf("SaveVMState returned error: %v", err)
+			}
+
+			runtime := &capturingSchedulerCommandRuntime{err: tt.runtimeErr}
+			executor := NewSchedulerCommandExecutor(config, store, configDB, fakeRuntimeProvider{runtime: runtime}, sandboxes.NewStreamBrokerForTest())
+			result, err := executor.ExecuteSchedulerCommand(ctx, session, domain.SchedulerCommandRequest{
+				Mode:   "shell",
+				Script: "echo scheduler",
+				Env: map[string]string{
+					"PROJECT_AGENT_LLM_PROVIDER":  "codex",
+					"CODEX_MODEL":                 "openai-model",
+					"ANTHROPIC_API_KEY":           "request-upstream-anthropic-key",
+					"ANTHROPIC_BASE_URL":          "https://anthropic.request.test",
+					"OPENAI_API_KEY":              "request-upstream-openai-key",
+					"OPENAI_BASE_URL":             "https://openai.request.test/v1",
+					"AGENT_COMPOSE_SANDBOX_TOKEN": "stale-request-facade-token",
+					"CUSTOM_REQUEST_ENV":          "preserved",
+					"GOOGLE_API_KEY":              "preserved-google-key",
+				},
+			})
+			if tt.runtimeErr == nil && err != nil {
+				t.Fatalf("ExecuteSchedulerCommand returned error: %v", err)
+			}
+			if tt.runtimeErr != nil && !errors.Is(err, tt.runtimeErr) {
+				t.Fatalf("ExecuteSchedulerCommand error = %v, want %v", err, tt.runtimeErr)
+			}
+			if runtime.session == nil {
+				t.Fatal("runtime did not receive command Sandbox clone")
+			}
+			env := domain.SandboxEnvMap(runtime.session.RuntimeEnvItems)
+			if env["ANTHROPIC_API_KEY"] == "" || env["ANTHROPIC_API_KEY"] == "persisted-upstream-key" || env["ANTHROPIC_BASE_URL"] == "https://anthropic.persisted.test" {
+				t.Fatalf("command did not reconstruct Anthropic startup facade environment: %#v", env)
+			}
+			if env["OPENAI_API_KEY"] == "" || env["OPENAI_API_KEY"] != env["AGENT_COMPOSE_SANDBOX_TOKEN"] {
+				t.Fatalf("selected Codex facade environment = %#v", env)
+			}
+			requestBytes, readErr := os.ReadFile(result.Artifacts["request"])
+			if readErr != nil {
+				t.Fatalf("read runtime command request: %v", readErr)
+			}
+			var runtimeRequest execution.RuntimeCommandRequest
+			if err := json.Unmarshal(requestBytes, &runtimeRequest); err != nil {
+				t.Fatalf("decode runtime command request: %v", err)
+			}
+			if runtimeRequest.Env["ANTHROPIC_API_KEY"] != env["ANTHROPIC_API_KEY"] || runtimeRequest.Env["ANTHROPIC_BASE_URL"] != env["ANTHROPIC_BASE_URL"] || runtimeRequest.Env["OPENAI_API_KEY"] != env["OPENAI_API_KEY"] {
+				t.Fatalf("runtime child request did not preserve managed facade precedence: request=%#v managed=%#v", runtimeRequest.Env, env)
+			}
+			if runtimeRequest.Env["AGENT_COMPOSE_SANDBOX_TOKEN"] != env["AGENT_COMPOSE_SANDBOX_TOKEN"] || runtimeRequest.Env["CUSTOM_REQUEST_ENV"] != "preserved" || runtimeRequest.Env["GOOGLE_API_KEY"] != "preserved-google-key" {
+				t.Fatalf("runtime child request token/custom environment = %#v", runtimeRequest.Env)
+			}
+			if got := countSchedulerCommandFacadeTokens(t, ctx, configDB); got != tt.wantTokenCount {
+				t.Fatalf("persisted scheduler command tokens = %d, want %d", got, tt.wantTokenCount)
+			}
+			assertSchedulerCommandTokenState(t, ctx, configDB, env["ANTHROPIC_API_KEY"], tt.wantTokenExists)
+			assertSchedulerCommandTokenState(t, ctx, configDB, env["AGENT_COMPOSE_SANDBOX_TOKEN"], tt.wantTokenExists)
+		})
+	}
+}
+
+func schedulerCommandFacadeTestConfig(root string) *appconfig.Config {
+	return &appconfig.Config{
+		DataRoot:             root,
+		DbAddr:               filepath.Join(root, "data.db"),
+		SandboxRoot:          filepath.Join(root, "sandboxes"),
+		RuntimeDriver:        driverpkg.RuntimeDriverDocker,
+		DefaultImage:         "guest:latest",
+		GuestWorkspacePath:   "/workspace",
+		GuestStateRoot:       "/data/state",
+		GuestHomePath:        "/root",
+		RuntimeBaseURL:       "http://agent-compose.test:7410",
+		JupyterProxyBasePath: "/agent-compose/session",
+		SandboxStartTimeout:  2 * time.Second,
+	}
+}
+
+func seedSchedulerCommandFacadeProviders(t *testing.T, ctx context.Context, store *configstore.ConfigStore) {
+	t.Helper()
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:             "anthropic-primary",
+		Name:           "Anthropic",
+		ProviderType:   llms.ProviderFamilyAnthropic,
+		DefaultWireAPI: llms.APIProtocolMessages,
+		BaseURL:        "https://anthropic.upstream.test",
+		APIKey:         "anthropic-upstream-secret",
+		Scope:          llms.ProviderScopeSystem,
+		Weight:         1,
+	}, llms.Model{ID: "claude-model", Name: "claude-model", Enabled: true, DefaultModel: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save Anthropic provider: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:             "openai-primary",
+		Name:           "OpenAI",
+		ProviderType:   llms.ProviderFamilyOpenAI,
+		DefaultWireAPI: llms.APIProtocolResponses,
+		BaseURL:        "https://openai.upstream.test",
+		APIKey:         "openai-upstream-secret",
+		Scope:          llms.ProviderScopeSystem,
+		Weight:         2,
+	}, llms.Model{ID: "openai-model", Name: "openai-model", Enabled: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save OpenAI provider: %v", err)
+	}
+}
+
+func countSchedulerCommandFacadeTokens(t *testing.T, ctx context.Context, store *configstore.ConfigStore) int {
+	t.Helper()
+	var count int
+	if err := store.DB().QueryRowContext(ctx, `SELECT COUNT(1) FROM llm_facade_token WHERE source = ?`, runtimefacade.TokenSourceSchedulerCommand).Scan(&count); err != nil {
+		t.Fatalf("count scheduler command facade tokens: %v", err)
+	}
+	return count
+}
+
+func assertSchedulerCommandTokenState(t *testing.T, ctx context.Context, store *configstore.ConfigStore, rawToken string, wantPresent bool) {
+	t.Helper()
+	_, err := store.GetLLMFacadeToken(ctx, rawToken)
+	if wantPresent && err != nil {
+		t.Fatalf("scheduler command facade token was removed: %v", err)
+	}
+	if !wantPresent && !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("scheduler command facade token error = %v, want not found", err)
 	}
 }

--- a/pkg/agentcompose/adapters/scheduler_command_executor_test.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor_test.go
@@ -244,10 +244,10 @@ func TestSchedulerCommandExecutorRebuildsAndOwnsCommandFacadeTokens(t *testing.T
 			if err := json.Unmarshal(requestBytes, &runtimeRequest); err != nil {
 				t.Fatalf("decode runtime command request: %v", err)
 			}
-			if runtimeRequest.Env["ANTHROPIC_API_KEY"] != env["ANTHROPIC_API_KEY"] || runtimeRequest.Env["ANTHROPIC_BASE_URL"] != env["ANTHROPIC_BASE_URL"] || runtimeRequest.Env["OPENAI_API_KEY"] != env["OPENAI_API_KEY"] {
-				t.Fatalf("runtime child request did not preserve managed facade precedence: request=%#v managed=%#v", runtimeRequest.Env, env)
+			if runtimeRequest.Env["ANTHROPIC_API_KEY"] != "request-upstream-anthropic-key" || runtimeRequest.Env["ANTHROPIC_BASE_URL"] != "https://anthropic.request.test" || runtimeRequest.Env["OPENAI_API_KEY"] != "request-upstream-openai-key" {
+				t.Fatalf("runtime child request did not preserve explicit request environment: %#v", runtimeRequest.Env)
 			}
-			if runtimeRequest.Env["AGENT_COMPOSE_SANDBOX_TOKEN"] != env["AGENT_COMPOSE_SANDBOX_TOKEN"] || runtimeRequest.Env["CUSTOM_REQUEST_ENV"] != "preserved" || runtimeRequest.Env["GOOGLE_API_KEY"] != "preserved-google-key" {
+			if runtimeRequest.Env["AGENT_COMPOSE_SANDBOX_TOKEN"] != "stale-request-facade-token" || runtimeRequest.Env["CUSTOM_REQUEST_ENV"] != "preserved" || runtimeRequest.Env["GOOGLE_API_KEY"] != "preserved-google-key" {
 				t.Fatalf("runtime child request token/custom environment = %#v", runtimeRequest.Env)
 			}
 			if got := countSchedulerCommandFacadeTokens(t, ctx, configDB); got != tt.wantTokenCount {
@@ -256,6 +256,27 @@ func TestSchedulerCommandExecutorRebuildsAndOwnsCommandFacadeTokens(t *testing.T
 			assertSchedulerCommandTokenState(t, ctx, configDB, env["ANTHROPIC_API_KEY"], tt.wantTokenExists)
 			assertSchedulerCommandTokenState(t, ctx, configDB, env["AGENT_COMPOSE_SANDBOX_TOKEN"], tt.wantTokenExists)
 		})
+	}
+}
+
+func TestSchedulerCommandExecutorSkipsFacadeReconstructionWithoutSupportedAgentOverride(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	root := t.TempDir()
+	config := schedulerCommandFacadeTestConfig(root)
+	configDB, _, err := testutil.OpenStores(t, config)
+	if err != nil {
+		t.Fatalf("OpenStores returned error: %v", err)
+	}
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-shell-only"}}
+	got, tokenHashes, err := (&SchedulerCommandExecutor{Config: config, ConfigDB: configDB}).prepareSchedulerCommandLLMFacadeEnv(ctx, session, domain.SchedulerCommandRequest{
+		Mode: "shell", Script: "echo shell", Env: map[string]string{"AGENT_PROVIDER": "opencode"},
+	}, "cell-shell-only")
+	if err != nil {
+		t.Fatalf("prepareSchedulerCommandLLMFacadeEnv returned error: %v", err)
+	}
+	if got != session || len(tokenHashes) != 0 {
+		t.Fatalf("shell-only facade preparation = session %p/%p, token hashes %#v; want original session and no tokens", got, session, tokenHashes)
 	}
 }
 

--- a/pkg/agentcompose/adapters/scheduler_sticky_binding.go
+++ b/pkg/agentcompose/adapters/scheduler_sticky_binding.go
@@ -155,21 +155,20 @@ type schedulerEffectiveSandboxConfig struct {
 }
 
 type schedulerAgentSandboxConfig struct {
-	ID              string                   `json:"id"`
-	Provider        string                   `json:"provider"`
-	Model           string                   `json:"model,omitempty"`
-	SystemPrompt    string                   `json:"system_prompt,omitempty"`
-	Driver          string                   `json:"driver,omitempty"`
-	GuestImage      string                   `json:"guest_image,omitempty"`
-	WorkspaceID     string                   `json:"workspace_id,omitempty"`
-	EnvItems        []domain.SandboxEnvVar   `json:"env_items,omitempty"`
-	Volumes         []domain.VolumeMountSpec `json:"volumes,omitempty"`
-	ConfigJSON      string                   `json:"config_json"`
-	CapsetIDs       []string                 `json:"capset_ids,omitempty"`
-	Skills          []domain.AgentSkill      `json:"skills,omitempty"`
-	ProjectID       string                   `json:"managed_project_id,omitempty"`
-	ProjectRevision int64                    `json:"managed_project_revision,omitempty"`
-	AgentName       string                   `json:"managed_agent_name,omitempty"`
+	ID           string                   `json:"id"`
+	Provider     string                   `json:"provider"`
+	Model        string                   `json:"model,omitempty"`
+	SystemPrompt string                   `json:"system_prompt,omitempty"`
+	Driver       string                   `json:"driver,omitempty"`
+	GuestImage   string                   `json:"guest_image,omitempty"`
+	WorkspaceID  string                   `json:"workspace_id,omitempty"`
+	EnvItems     []domain.SandboxEnvVar   `json:"env_items,omitempty"`
+	Volumes      []domain.VolumeMountSpec `json:"volumes,omitempty"`
+	ConfigJSON   string                   `json:"config_json"`
+	CapsetIDs    []string                 `json:"capset_ids,omitempty"`
+	Skills       []domain.AgentSkill      `json:"skills,omitempty"`
+	ProjectID    string                   `json:"managed_project_id,omitempty"`
+	AgentName    string                   `json:"managed_agent_name,omitempty"`
 }
 
 func schedulerRequestSandboxConfigHash(baseHash string, request domain.SchedulerAgentRequest, agentDefinition *domain.AgentDefinition, providerEnvItems, envItems []domain.SandboxEnvVar, workspace *domain.SandboxWorkspace, driver, guestImage string, volumeMounts []domain.SandboxVolumeMount) (string, error) {
@@ -184,21 +183,20 @@ func schedulerRequestSandboxConfigHash(baseHash string, request domain.Scheduler
 		volumes := append([]domain.VolumeMountSpec(nil), current.Volumes...)
 		sort.Slice(volumes, func(i, j int) bool { return volumes[i].Target < volumes[j].Target })
 		agentConfig = &schedulerAgentSandboxConfig{
-			ID:              current.ID,
-			Provider:        current.Provider,
-			Model:           current.Model,
-			SystemPrompt:    current.SystemPrompt,
-			Driver:          current.Driver,
-			GuestImage:      current.GuestImage,
-			WorkspaceID:     current.WorkspaceID,
-			EnvItems:        current.EnvItems,
-			Volumes:         volumes,
-			ConfigJSON:      current.ConfigJSON,
-			CapsetIDs:       capsetIDs,
-			Skills:          current.Skills,
-			ProjectID:       current.ProjectID,
-			ProjectRevision: current.ProjectRevision,
-			AgentName:       current.AgentName,
+			ID:           current.ID,
+			Provider:     current.Provider,
+			Model:        current.Model,
+			SystemPrompt: current.SystemPrompt,
+			Driver:       current.Driver,
+			GuestImage:   current.GuestImage,
+			WorkspaceID:  current.WorkspaceID,
+			EnvItems:     current.EnvItems,
+			Volumes:      volumes,
+			ConfigJSON:   current.ConfigJSON,
+			CapsetIDs:    capsetIDs,
+			Skills:       current.Skills,
+			ProjectID:    current.ProjectID,
+			AgentName:    current.AgentName,
 		}
 	}
 	payload, err := json.Marshal(schedulerEffectiveSandboxConfig{

--- a/pkg/agentcompose/adapters/scheduler_sticky_binding_test.go
+++ b/pkg/agentcompose/adapters/scheduler_sticky_binding_test.go
@@ -42,3 +42,75 @@ func TestSchedulerRequestSandboxConfigHashIgnoresVolumeMountOrder(t *testing.T) 
 		t.Fatalf("volume mount ordering changed scheduler sandbox hash: got %q want %q", second, first)
 	}
 }
+
+func TestSchedulerRequestSandboxConfigHashUsesEffectiveAgentConfigInsteadOfProjectRevision(t *testing.T) {
+	base := domain.AgentDefinition{
+		ID:              "agent-1",
+		Name:            "worker",
+		Provider:        "codex",
+		Model:           "model-1",
+		SystemPrompt:    "prompt-1",
+		Driver:          "docker",
+		GuestImage:      "guest:v1",
+		WorkspaceID:     "workspace-1",
+		EnvItems:        []domain.SandboxEnvVar{{Name: "A", Value: "1"}},
+		Volumes:         []domain.VolumeMountSpec{{Type: domain.VolumeMountTypeVolume, Source: "data", Target: "/data"}},
+		ConfigJSON:      `{"jupyter":{"enabled":true}}`,
+		CapsetIDs:       []string{"capset-1"},
+		Skills:          []domain.AgentSkill{{Name: "skill-1", Provider: "git", URL: "https://example.invalid/repo", Ref: "v1"}},
+		ProjectID:       "project-1",
+		ProjectRevision: 1,
+		AgentName:       "worker",
+	}
+	baseHash := mustSchedulerRequestSandboxConfigHash(t, &base)
+	revisionOnly := base
+	revisionOnly.ProjectRevision = 2
+	if got := mustSchedulerRequestSandboxConfigHash(t, &revisionOnly); got != baseHash {
+		t.Fatalf("unrelated project revision changed effective agent hash: got %q want %q", got, baseHash)
+	}
+
+	for name, mutate := range map[string]func(*domain.AgentDefinition){
+		"provider":      func(item *domain.AgentDefinition) { item.Provider = "claude" },
+		"model":         func(item *domain.AgentDefinition) { item.Model = "model-2" },
+		"system prompt": func(item *domain.AgentDefinition) { item.SystemPrompt = "prompt-2" },
+		"driver":        func(item *domain.AgentDefinition) { item.Driver = "boxlite" },
+		"guest image":   func(item *domain.AgentDefinition) { item.GuestImage = "guest:v2" },
+		"workspace":     func(item *domain.AgentDefinition) { item.WorkspaceID = "workspace-2" },
+		"environment":   func(item *domain.AgentDefinition) { item.EnvItems = []domain.SandboxEnvVar{{Name: "A", Value: "2"}} },
+		"volumes": func(item *domain.AgentDefinition) {
+			item.Volumes = []domain.VolumeMountSpec{{Type: domain.VolumeMountTypeVolume, Source: "cache", Target: "/data"}}
+		},
+		"agent config": func(item *domain.AgentDefinition) { item.ConfigJSON = `{"jupyter":{"enabled":false}}` },
+		"capsets":      func(item *domain.AgentDefinition) { item.CapsetIDs = []string{"capset-2"} },
+		"skills": func(item *domain.AgentDefinition) {
+			item.Skills = []domain.AgentSkill{{Name: "skill-1", Provider: "git", URL: "https://example.invalid/repo", Ref: "v2"}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			mutate(&changed)
+			if got := mustSchedulerRequestSandboxConfigHash(t, &changed); got == baseHash {
+				t.Fatalf("effective agent config hash did not change for %s", name)
+			}
+		})
+	}
+}
+
+func mustSchedulerRequestSandboxConfigHash(t *testing.T, agentDefinition *domain.AgentDefinition) string {
+	t.Helper()
+	hash, err := schedulerRequestSandboxConfigHash(
+		"sha256:scheduler",
+		domain.SchedulerAgentRequest{},
+		agentDefinition,
+		nil,
+		nil,
+		nil,
+		"docker",
+		"guest:v1",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("schedulerRequestSandboxConfigHash returned error: %v", err)
+	}
+	return hash
+}

--- a/pkg/llms/runtimefacade/command_config.go
+++ b/pkg/llms/runtimefacade/command_config.go
@@ -1,0 +1,96 @@
+package runtimefacade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+// CommandFacadeStore adds precise token deletion to the normal facade store.
+// A command can create multiple family-specific tokens before it starts, so
+// cleanup must target exactly the tokens created by that command.
+type CommandFacadeStore interface {
+	FacadeStore
+	DeleteLLMFacadeTokenHash(context.Context, string) error
+}
+
+type CommandFacadeConfig struct {
+	Env         map[string]string
+	TokenHashes []string
+}
+
+type trackingCommandFacadeStore struct {
+	CommandFacadeStore
+	tokenHashes []string
+}
+
+func (s *trackingCommandFacadeStore) SaveLLMFacadeToken(ctx context.Context, token llms.FacadeToken) error {
+	if err := s.CommandFacadeStore.SaveLLMFacadeToken(ctx, token); err != nil {
+		return err
+	}
+	s.tokenHashes = append(s.tokenHashes, token.TokenHash)
+	return nil
+}
+
+// EnsureSessionCommandFacadeConfig reconstructs the transient facade
+// environment on the command's in-memory Sandbox clone. Startup family
+// variables are applied first and the selected agent variables are applied
+// last, so the selected provider remains authoritative for overlapping names.
+//
+// Any failure removes every token successfully persisted by this invocation.
+// Successful callers own the returned token hashes until command termination.
+func EnsureSessionCommandFacadeConfig(
+	ctx context.Context,
+	config *appconfig.Config,
+	store CommandFacadeStore,
+	session *domain.Sandbox,
+	agent, model, source, runID string,
+) (result CommandFacadeConfig, returnErr error) {
+	if config == nil || store == nil || session == nil {
+		return CommandFacadeConfig{}, nil
+	}
+
+	tracker := &trackingCommandFacadeStore{CommandFacadeStore: store}
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		cleanupCtx := context.WithoutCancel(ctx)
+		var cleanupErr error
+		for _, tokenHash := range tracker.tokenHashes {
+			if err := store.DeleteLLMFacadeTokenHash(cleanupCtx, tokenHash); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete command facade token: %w", err))
+			}
+		}
+		result = CommandFacadeConfig{}
+		returnErr = errors.Join(returnErr, cleanupErr)
+	}()
+
+	startupEnv, err := EnsureSessionStartupFacadeConfig(ctx, config, tracker, session, source, runID)
+	if err != nil {
+		return CommandFacadeConfig{}, err
+	}
+	selectedEnv, err := EnsureSessionLLMFacadeConfig(ctx, config, tracker, session, agent, model, source, runID)
+	if err != nil {
+		return CommandFacadeConfig{}, err
+	}
+
+	managedEnv := make(map[string]string, len(startupEnv)+len(selectedEnv))
+	for name, value := range startupEnv {
+		managedEnv[name] = value
+	}
+	for name, value := range selectedEnv {
+		managedEnv[name] = value
+	}
+	if len(managedEnv) == 0 {
+		managedEnv = nil
+	}
+	return CommandFacadeConfig{
+		Env:         managedEnv,
+		TokenHashes: append([]string(nil), tracker.tokenHashes...),
+	}, nil
+}

--- a/pkg/llms/runtimefacade/command_config_test.go
+++ b/pkg/llms/runtimefacade/command_config_test.go
@@ -1,0 +1,141 @@
+package runtimefacade
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/samber/do/v2"
+
+	appconfig "agent-compose/pkg/config"
+	driverpkg "agent-compose/pkg/driver"
+	"agent-compose/pkg/internal/testutil"
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/configstore"
+)
+
+func TestEnsureSessionCommandFacadeConfigRebuildsStartupAndSelectedEnvironment(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config, store := commandFacadeTestStore(t, ctx, root)
+	seedCommandFacadeProviders(t, ctx, store)
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{
+		ID:            "sandbox-command-facades",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-command-facades", "workspace"),
+	}}
+
+	result, err := EnsureSessionCommandFacadeConfig(ctx, config, store, session, "codex", "openai-model", TokenSourceSchedulerCommand, "run-command")
+	if err != nil {
+		t.Fatalf("EnsureSessionCommandFacadeConfig returned error: %v", err)
+	}
+	if result.Env["ANTHROPIC_API_KEY"] == "" || result.Env["ANTHROPIC_AUTH_TOKEN"] != result.Env["ANTHROPIC_API_KEY"] || result.Env["ANTHROPIC_BASE_URL"] == "" {
+		t.Fatalf("command Anthropic startup environment = %#v", result.Env)
+	}
+	if result.Env["AGENT_COMPOSE_SANDBOX_TOKEN"] == "" || result.Env["OPENAI_API_KEY"] != result.Env["AGENT_COMPOSE_SANDBOX_TOKEN"] {
+		t.Fatalf("selected Codex environment did not override startup OpenAI values = %#v", result.Env)
+	}
+	if result.Env["ANTHROPIC_API_KEY"] == result.Env["AGENT_COMPOSE_SANDBOX_TOKEN"] {
+		t.Fatalf("Anthropic and selected Codex tokens unexpectedly match")
+	}
+	if len(result.TokenHashes) != 3 {
+		t.Fatalf("command token hashes = %#v, want startup Anthropic, startup OpenAI, and selected Codex", result.TokenHashes)
+	}
+	anthropicHash, _ := llms.HashFacadeToken(result.Env["ANTHROPIC_API_KEY"])
+	selectedHash, _ := llms.HashFacadeToken(result.Env["AGENT_COMPOSE_SANDBOX_TOKEN"])
+	if result.TokenHashes[0] != anthropicHash || result.TokenHashes[len(result.TokenHashes)-1] != selectedHash {
+		t.Fatalf("command token hash ordering = %#v", result.TokenHashes)
+	}
+	if got := countCommandFacadeTokens(t, ctx, store, "run-command"); got != 3 {
+		t.Fatalf("persisted command facade tokens = %d, want 3", got)
+	}
+}
+
+func TestEnsureSessionCommandFacadeConfigCleansAllTokensAfterPartialFailure(t *testing.T) {
+	isolateLLMEnv(t)
+
+	ctx := context.Background()
+	root := t.TempDir()
+	config, store := commandFacadeTestStore(t, ctx, root)
+	seedCommandFacadeProviders(t, ctx, store)
+	blockedSandboxDir := filepath.Join(root, "blocked-sandbox")
+	if err := os.WriteFile(blockedSandboxDir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write blocked sandbox path: %v", err)
+	}
+	session := &domain.Sandbox{Summary: domain.SandboxSummary{
+		ID:            "sandbox-command-partial-failure",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		WorkspacePath: filepath.Join(blockedSandboxDir, "workspace"),
+	}}
+
+	result, err := EnsureSessionCommandFacadeConfig(ctx, config, store, session, "codex", "openai-model", TokenSourceSchedulerCommand, "run-partial-failure")
+	if err == nil || !strings.Contains(err.Error(), "codex config") {
+		t.Fatalf("EnsureSessionCommandFacadeConfig error = %v, want Codex config write failure", err)
+	}
+	if len(result.Env) != 0 || len(result.TokenHashes) != 0 {
+		t.Fatalf("partial result = %#v, want empty", result)
+	}
+	if got := countCommandFacadeTokens(t, ctx, store, "run-partial-failure"); got != 0 {
+		t.Fatalf("persisted command facade tokens after partial failure = %d, want 0", got)
+	}
+}
+
+func commandFacadeTestStore(t *testing.T, ctx context.Context, root string) (*appconfig.Config, *configstore.ConfigStore) {
+	t.Helper()
+	config := &appconfig.Config{
+		DataRoot:       root,
+		DbAddr:         filepath.Join(root, "data.db"),
+		RuntimeBaseURL: "http://agent-compose.test:7410",
+		GuestHomePath:  "/root",
+	}
+	di := do.New()
+	do.ProvideValue(di, ctx)
+	do.ProvideValue(di, config)
+	store, err := testutil.OpenConfigStore(t, di)
+	if err != nil {
+		t.Fatalf("OpenConfigStore returned error: %v", err)
+	}
+	return config, store
+}
+
+func seedCommandFacadeProviders(t *testing.T, ctx context.Context, store *configstore.ConfigStore) {
+	t.Helper()
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:             "anthropic-primary",
+		Name:           "Anthropic",
+		ProviderType:   llms.ProviderFamilyAnthropic,
+		DefaultWireAPI: llms.APIProtocolMessages,
+		BaseURL:        "https://anthropic.upstream.test",
+		APIKey:         "anthropic-upstream-secret",
+		Scope:          llms.ProviderScopeSystem,
+		Weight:         1,
+	}, llms.Model{ID: "claude-model", Name: "claude-model", Enabled: true, DefaultModel: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save Anthropic provider: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID:             "openai-primary",
+		Name:           "OpenAI",
+		ProviderType:   llms.ProviderFamilyOpenAI,
+		DefaultWireAPI: llms.APIProtocolResponses,
+		BaseURL:        "https://openai.upstream.test",
+		APIKey:         "openai-upstream-secret",
+		Scope:          llms.ProviderScopeSystem,
+		Weight:         2,
+	}, llms.Model{ID: "openai-model", Name: "openai-model", Enabled: true, Scope: llms.ProviderScopeSystem}); err != nil {
+		t.Fatalf("save OpenAI provider: %v", err)
+	}
+}
+
+func countCommandFacadeTokens(t *testing.T, ctx context.Context, store *configstore.ConfigStore, runID string) int {
+	t.Helper()
+	var count int
+	if err := store.DB().QueryRowContext(ctx, `SELECT COUNT(1) FROM llm_facade_token WHERE source = ? AND run_id = ?`, TokenSourceSchedulerCommand, runID).Scan(&count); err != nil {
+		t.Fatalf("count command facade tokens: %v", err)
+	}
+	return count
+}

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -289,6 +289,9 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.SchedulerComma
 		_ = h.addLinkedSchedulerEvent(ctx, eventType, "info", "scheduler command sandbox ready", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 	h.trackCommandSession(session.Summary.ID, cleanupSession)
+	if err := h.persistCommandSandboxLink(ctx, session.Summary.ID); err != nil {
+		return domain.SchedulerCommandResult{}, err
+	}
 
 	result, err := h.deps.CommandExecutor.ExecuteSchedulerCommand(ctx, session, request)
 	if err != nil {
@@ -301,6 +304,19 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.SchedulerComma
 	}
 	_ = h.addLinkedSchedulerEvent(ctx, "scheduler.command.completed", level, firstHostNonEmpty(result.Output, result.Stdout, result.Stderr, "scheduler command completed"), CommandEventPayload(request, result), result.SandboxID, result.CellID, "")
 	return result, nil
+}
+
+func (h *RuntimeHost) persistCommandSandboxLink(ctx context.Context, sandboxID string) error {
+	if h.execution.Kind != ExecutionKindTrigger {
+		return nil
+	}
+	if h.deps.Events == nil {
+		return fmt.Errorf("persist scheduler command sandbox link: scheduler event recorder is unavailable")
+	}
+	if err := h.addLinkedSchedulerEvent(ctx, "scheduler.command.started", "info", "scheduler command started", map[string]any{"sandboxId": sandboxID}, sandboxID, "", ""); err != nil {
+		return fmt.Errorf("persist scheduler command sandbox link: %w", err)
+	}
+	return nil
 }
 
 func (h *RuntimeHost) LLM(ctx context.Context, prompt string, request domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -289,7 +289,7 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.SchedulerComma
 		_ = h.addLinkedSchedulerEvent(ctx, eventType, "info", "scheduler command sandbox ready", map[string]any{"sandboxId": session.Summary.ID}, session.Summary.ID, "", "")
 	}
 	h.trackCommandSession(session.Summary.ID, cleanupSession)
-	if err := h.persistCommandSandboxLink(ctx, session.Summary.ID); err != nil {
+	if err := h.persistCommandSandboxLink(ctx, request, session.Summary.ID); err != nil {
 		return domain.SchedulerCommandResult{}, err
 	}
 
@@ -306,15 +306,36 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.SchedulerComma
 	return result, nil
 }
 
-func (h *RuntimeHost) persistCommandSandboxLink(ctx context.Context, sandboxID string) error {
+func (h *RuntimeHost) persistCommandSandboxLink(ctx context.Context, request domain.SchedulerCommandRequest, sandboxID string) error {
 	if h.execution.Kind != ExecutionKindTrigger {
 		return nil
 	}
 	if h.deps.Events == nil {
-		return fmt.Errorf("persist scheduler command sandbox link: scheduler event recorder is unavailable")
+		persistErr := fmt.Errorf("persist scheduler command sandbox link: scheduler event recorder is unavailable")
+		failedEventErr := h.addLinkedSchedulerEvent(ctx, "scheduler.command.failed", "error", persistErr.Error(), CommandEventPayload(request, domain.SchedulerCommandResult{SandboxID: sandboxID}), sandboxID, "", "")
+		if failedEventErr != nil {
+			slog.Error("failed to persist scheduler command failure event", "scheduler_id", h.scheduler.Summary.ID, "run_id", h.execution.ID, "sandbox_id", sandboxID, "error", failedEventErr)
+		}
+		slog.Error("scheduler command sandbox link persistence failed", "scheduler_id", h.scheduler.Summary.ID, "run_id", h.execution.ID, "sandbox_id", sandboxID, "error", persistErr)
+		return persistErr
 	}
 	if err := h.addLinkedSchedulerEvent(ctx, "scheduler.command.started", "info", "scheduler command started", map[string]any{"sandboxId": sandboxID}, sandboxID, "", ""); err != nil {
-		return fmt.Errorf("persist scheduler command sandbox link: %w", err)
+		persistErr := fmt.Errorf("persist scheduler command sandbox link: %w", err)
+		failedEventErr := h.addLinkedSchedulerEvent(
+			ctx,
+			"scheduler.command.failed",
+			"error",
+			persistErr.Error(),
+			CommandEventPayload(request, domain.SchedulerCommandResult{SandboxID: sandboxID}),
+			sandboxID,
+			"",
+			"",
+		)
+		if failedEventErr != nil {
+			slog.Error("failed to persist scheduler command failure event", "scheduler_id", h.scheduler.Summary.ID, "run_id", h.execution.ID, "sandbox_id", sandboxID, "error", failedEventErr)
+		}
+		slog.Error("scheduler command sandbox link persistence failed", "scheduler_id", h.scheduler.Summary.ID, "run_id", h.execution.ID, "sandbox_id", sandboxID, "error", persistErr)
+		return persistErr
 	}
 	return nil
 }

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -312,10 +312,6 @@ func (h *RuntimeHost) persistCommandSandboxLink(ctx context.Context, request dom
 	}
 	if h.deps.Events == nil {
 		persistErr := fmt.Errorf("persist scheduler command sandbox link: scheduler event recorder is unavailable")
-		failedEventErr := h.addLinkedSchedulerEvent(ctx, "scheduler.command.failed", "error", persistErr.Error(), CommandEventPayload(request, domain.SchedulerCommandResult{SandboxID: sandboxID}), sandboxID, "", "")
-		if failedEventErr != nil {
-			slog.Error("failed to persist scheduler command failure event", "scheduler_id", h.scheduler.Summary.ID, "run_id", h.execution.ID, "sandbox_id", sandboxID, "error", failedEventErr)
-		}
 		slog.Error("scheduler command sandbox link persistence failed", "scheduler_id", h.scheduler.Summary.ID, "run_id", h.execution.ID, "sandbox_id", sandboxID, "error", persistErr)
 		return persistErr
 	}
@@ -422,7 +418,7 @@ func (h *RuntimeHost) addLinkedSchedulerEvent(ctx context.Context, eventType, le
 }
 
 func (h *RuntimeHost) addEventSandboxLink(ctx context.Context, event domain.SchedulerEvent, sandboxID, relation string) {
-	if h.deps.Store == nil || strings.TrimSpace(sandboxID) == "" || h.triggerEvent.EventID == "" {
+	if h.deps.Store == nil || strings.TrimSpace(sandboxID) == "" || strings.TrimSpace(event.ID) == "" || strings.TrimSpace(relation) == "" || h.triggerEvent.EventID == "" {
 		return
 	}
 	if err := h.deps.Store.AddEventSandboxLink(ctx, domain.EventSandboxLink{

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -307,13 +307,8 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.SchedulerComma
 }
 
 func (h *RuntimeHost) persistCommandSandboxLink(ctx context.Context, request domain.SchedulerCommandRequest, sandboxID string) error {
-	if h.execution.Kind != ExecutionKindTrigger {
+	if h.execution.Kind != ExecutionKindTrigger || h.deps.Events == nil {
 		return nil
-	}
-	if h.deps.Events == nil {
-		persistErr := fmt.Errorf("persist scheduler command sandbox link: scheduler event recorder is unavailable")
-		slog.Error("scheduler command sandbox link persistence failed", "scheduler_id", h.scheduler.Summary.ID, "run_id", h.execution.ID, "sandbox_id", sandboxID, "error", persistErr)
-		return persistErr
 	}
 	if err := h.addLinkedSchedulerEvent(ctx, "scheduler.command.started", "info", "scheduler command started", map[string]any{"sandboxId": sandboxID}, sandboxID, "", ""); err != nil {
 		persistErr := fmt.Errorf("persist scheduler command sandbox link: %w", err)

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -90,7 +90,7 @@ func TestRuntimeHostAgentCommandLLMAndSessionRPC(t *testing.T) {
 	if len(sandboxes.shutdowns) != 2 || sandboxes.shutdowns[1] != "session-host" {
 		t.Fatalf("shutdowns after cleanup = %#v", sandboxes.shutdowns)
 	}
-	if !events.contains("scheduler.command.completed") {
+	if !events.contains("scheduler.command.started") || !events.contains("scheduler.command.completed") {
 		t.Fatalf("command events = %#v", events.types())
 	}
 
@@ -321,6 +321,89 @@ func TestRuntimeHostErrorBranches(t *testing.T) {
 	}
 }
 
+func TestRuntimeHostCommandPersistsRunSandboxLinkBeforeExecution(t *testing.T) {
+	ctx := context.Background()
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-link"}}
+	run := &domain.SchedulerRunSummary{ID: "run-link", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-link"}
+	events := &hostEventsFake{}
+	executor := &hostCommandExecutorFake{}
+	executor.onExecute = func() {
+		if len(events.items) == 0 {
+			t.Fatal("command executed before its sandbox link was persisted")
+		}
+		linked := events.items[len(events.items)-1]
+		if linked.Type != "scheduler.command.started" || linked.RunID != run.ID || linked.LinkedSandboxID != "sandbox-link" {
+			t.Fatalf("last pre-execution event = %#v, want linked scheduler.command.started", linked)
+		}
+	}
+	host := schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
+		Events:          events,
+		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-link", VMStatus: domain.VMStatusRunning}}},
+		CommandExecutor: executor,
+	}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{})
+
+	if _, err := host.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "echo linked"}); err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("command executor calls = %d, want 1", executor.calls)
+	}
+}
+
+func TestRuntimeHostCommandDoesNotExecuteWhenRunSandboxLinkFails(t *testing.T) {
+	ctx := context.Background()
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-link-failure"}}
+	run := &domain.SchedulerRunSummary{ID: "run-link-failure", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-link-failure"}
+	persistErr := errors.New("event persistence failed")
+	events := &hostEventsFake{failType: "scheduler.command.started", addRecordErr: persistErr}
+	executor := &hostCommandExecutorFake{}
+	host := schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
+		Events:          events,
+		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-link-failure", VMStatus: domain.VMStatusRunning}}},
+		CommandExecutor: executor,
+	}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{})
+
+	if _, err := host.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "must not run"}); !errors.Is(err, persistErr) {
+		t.Fatalf("Command error = %v, want wrapped persistence error", err)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("command executor calls = %d, want 0", executor.calls)
+	}
+}
+
+func TestRuntimeHostTriggerCommandRequiresSchedulerEventRecorder(t *testing.T) {
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-link-missing-recorder"}}
+	run := &domain.SchedulerRunSummary{ID: "run-link-missing-recorder", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-link-missing-recorder"}
+	executor := &hostCommandExecutorFake{}
+	host := schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
+		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-link-missing-recorder", VMStatus: domain.VMStatusRunning}}},
+		CommandExecutor: executor,
+	}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{})
+
+	if _, err := host.Command(context.Background(), domain.SchedulerCommandRequest{Mode: "shell", Command: "must not run"}); err == nil || !strings.Contains(err.Error(), "scheduler event recorder is unavailable") {
+		t.Fatalf("Command error = %v, want missing event recorder", err)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("command executor calls = %d, want 0", executor.calls)
+	}
+}
+
+func TestRuntimeHostInvocationCommandDoesNotRequireSchedulerRunLink(t *testing.T) {
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-invocation"}}
+	executor := &hostCommandExecutorFake{}
+	host := schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
+		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-invocation", VMStatus: domain.VMStatusRunning}}},
+		CommandExecutor: executor,
+	}, scheduler, schedulers.RuntimeExecutionContext{ID: "invocation", Kind: schedulers.ExecutionKindInvocation}, schedulers.TriggerEventMetadata{})
+
+	if _, err := host.Command(context.Background(), domain.SchedulerCommandRequest{Mode: "shell", Command: "echo invocation"}); err != nil {
+		t.Fatalf("invocation Command returned error: %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("command executor calls = %d, want 1", executor.calls)
+	}
+}
+
 func TestRuntimeHostLogPublishEventAndState(t *testing.T) {
 	ctx := context.Background()
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-state", Name: "State Scheduler"}}
@@ -446,7 +529,9 @@ func (s *hostStoreFake) containsLink(sessionID, relation string) bool {
 }
 
 type hostEventsFake struct {
-	items []domain.SchedulerEvent
+	items        []domain.SchedulerEvent
+	failType     string
+	addRecordErr error
 }
 
 func (e *hostEventsFake) Add(ctx context.Context, schedulerID, runID, triggerID, eventType, level, message string, payload any, linkedSandboxID, linkedCellID, linkedAgentThreadID string) error {
@@ -455,6 +540,9 @@ func (e *hostEventsFake) Add(ctx context.Context, schedulerID, runID, triggerID,
 }
 
 func (e *hostEventsFake) AddRecord(_ context.Context, schedulerID, runID, triggerID, eventType, level, message string, _ any, linkedSandboxID, linkedCellID, linkedAgentThreadID string) (domain.SchedulerEvent, error) {
+	if e.addRecordErr != nil && (e.failType == "" || e.failType == eventType) {
+		return domain.SchedulerEvent{}, e.addRecordErr
+	}
 	event := domain.SchedulerEvent{
 		ID:                  fmt.Sprintf("event-%d", len(e.items)+1),
 		SchedulerID:         schedulerID,
@@ -541,13 +629,17 @@ func (e *hostAgentExecutorFake) ExecuteAgent(_ context.Context, _ *domain.Sandbo
 }
 
 type hostCommandExecutorFake struct {
-	calls  int
-	result domain.SchedulerCommandResult
-	err    error
+	calls     int
+	result    domain.SchedulerCommandResult
+	err       error
+	onExecute func()
 }
 
 func (e *hostCommandExecutorFake) ExecuteSchedulerCommand(context.Context, *domain.Sandbox, domain.SchedulerCommandRequest) (domain.SchedulerCommandResult, error) {
 	e.calls++
+	if e.onExecute != nil {
+		e.onExecute()
+	}
 	return e.result, e.err
 }
 

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -369,6 +369,9 @@ func TestRuntimeHostCommandDoesNotExecuteWhenRunSandboxLinkFails(t *testing.T) {
 	if executor.calls != 0 {
 		t.Fatalf("command executor calls = %d, want 0", executor.calls)
 	}
+	if !events.contains("scheduler.command.failed") {
+		t.Fatalf("events after sandbox link failure = %#v, want scheduler.command.failed", events.types())
+	}
 }
 
 func TestRuntimeHostTriggerCommandRequiresSchedulerEventRecorder(t *testing.T) {

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -374,7 +374,7 @@ func TestRuntimeHostCommandDoesNotExecuteWhenRunSandboxLinkFails(t *testing.T) {
 	}
 }
 
-func TestRuntimeHostTriggerCommandRequiresSchedulerEventRecorder(t *testing.T) {
+func TestRuntimeHostTriggerCommandWithoutSchedulerEventRecorderStillExecutes(t *testing.T) {
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-link-missing-recorder"}}
 	run := &domain.SchedulerRunSummary{ID: "run-link-missing-recorder", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-link-missing-recorder"}
 	executor := &hostCommandExecutorFake{}
@@ -385,11 +385,11 @@ func TestRuntimeHostTriggerCommandRequiresSchedulerEventRecorder(t *testing.T) {
 		CommandExecutor: executor,
 	}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{EventID: "trigger-event-link-missing-recorder"})
 
-	if _, err := host.Command(context.Background(), domain.SchedulerCommandRequest{Mode: "shell", Command: "must not run"}); err == nil || !strings.Contains(err.Error(), "scheduler event recorder is unavailable") {
-		t.Fatalf("Command error = %v, want missing event recorder", err)
+	if _, err := host.Command(context.Background(), domain.SchedulerCommandRequest{Mode: "shell", Command: "run without events"}); err != nil {
+		t.Fatalf("Command returned error: %v", err)
 	}
-	if executor.calls != 0 {
-		t.Fatalf("command executor calls = %d, want 0", executor.calls)
+	if executor.calls != 1 {
+		t.Fatalf("command executor calls = %d, want 1", executor.calls)
 	}
 	if len(store.links) != 0 {
 		t.Fatalf("event sandbox links = %#v, want none when event recorder is unavailable", store.links)

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -378,16 +378,21 @@ func TestRuntimeHostTriggerCommandRequiresSchedulerEventRecorder(t *testing.T) {
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-link-missing-recorder"}}
 	run := &domain.SchedulerRunSummary{ID: "run-link-missing-recorder", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-link-missing-recorder"}
 	executor := &hostCommandExecutorFake{}
+	store := &hostStoreFake{}
 	host := schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
+		Store:           store,
 		Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-link-missing-recorder", VMStatus: domain.VMStatusRunning}}},
 		CommandExecutor: executor,
-	}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{})
+	}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{EventID: "trigger-event-link-missing-recorder"})
 
 	if _, err := host.Command(context.Background(), domain.SchedulerCommandRequest{Mode: "shell", Command: "must not run"}); err == nil || !strings.Contains(err.Error(), "scheduler event recorder is unavailable") {
 		t.Fatalf("Command error = %v, want missing event recorder", err)
 	}
 	if executor.calls != 0 {
 		t.Fatalf("command executor calls = %d, want 0", executor.calls)
+	}
+	if len(store.links) != 0 {
+		t.Fatalf("event sandbox links = %#v, want none when event recorder is unavailable", store.links)
 	}
 }
 

--- a/pkg/schedulers/sticky_compatibility.go
+++ b/pkg/schedulers/sticky_compatibility.go
@@ -23,7 +23,6 @@ type schedulerSandboxConfig struct {
 	EnvItems           []domain.SandboxEnvVar   `json:"env_items,omitempty"`
 	Volumes            []domain.VolumeMountSpec `json:"volumes,omitempty"`
 	ProjectID          string                   `json:"managed_project_id,omitempty"`
-	ProjectRevision    int64                    `json:"managed_project_revision,omitempty"`
 	AgentName          string                   `json:"managed_agent_name,omitempty"`
 	ProjectSchedulerID string                   `json:"managed_scheduler_id,omitempty"`
 }
@@ -107,7 +106,6 @@ func SchedulerSandboxConfigHash(scheduler domain.Scheduler) (string, error) {
 		EnvItems:           domain.NormalizeEnvItems(scheduler.EnvItems),
 		Volumes:            volumes,
 		ProjectID:          strings.TrimSpace(scheduler.Summary.ProjectID),
-		ProjectRevision:    scheduler.Summary.ProjectRevision,
 		AgentName:          strings.TrimSpace(scheduler.Summary.AgentName),
 		ProjectSchedulerID: strings.TrimSpace(scheduler.Summary.ProjectSchedulerID),
 	})

--- a/pkg/schedulers/sticky_compatibility_test.go
+++ b/pkg/schedulers/sticky_compatibility_test.go
@@ -52,11 +52,10 @@ func TestSchedulerSandboxConfigHashTracksSandboxSemantics(t *testing.T) {
 		"volumes": func(item *domain.Scheduler) {
 			item.Volumes = []domain.VolumeMountSpec{{Type: domain.VolumeMountTypeBind, Source: "/tmp/source", Target: "/workspace/data"}}
 		},
-		"managed revision": func(item *domain.Scheduler) {
+		"managed identity": func(item *domain.Scheduler) {
 			item.Summary.ProjectID = "project-1"
 			item.Summary.AgentName = "worker"
 			item.Summary.ProjectSchedulerID = "scheduler-1"
-			item.Summary.ProjectRevision = 2
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -66,6 +65,24 @@ func TestSchedulerSandboxConfigHashTracksSandboxSemantics(t *testing.T) {
 				t.Fatalf("sandbox config hash did not change for %s", name)
 			}
 		})
+	}
+}
+
+func TestSchedulerSandboxConfigHashIgnoresManagedProjectRevision(t *testing.T) {
+	base := domain.Scheduler{Summary: domain.SchedulerSummary{
+		ID:                 "scheduler-1",
+		DefaultAgent:       "codex",
+		SandboxPolicy:      domain.SchedulerSandboxPolicySticky,
+		ProjectID:          "project-1",
+		ProjectRevision:    1,
+		AgentName:          "worker",
+		ProjectSchedulerID: "scheduler-1",
+	}}
+	changed := CloneScheduler(base)
+	changed.Summary.ProjectRevision = 2
+
+	if got, want := mustSchedulerSandboxConfigHash(t, changed), mustSchedulerSandboxConfigHash(t, base); got != want {
+		t.Fatalf("unrelated managed project revision changed config hash: got %q want %q", got, want)
 	}
 }
 

--- a/pkg/storage/configstore/llm_config.go
+++ b/pkg/storage/configstore/llm_config.go
@@ -148,7 +148,19 @@ func (s *llmStore) DeleteLLMFacadeToken(ctx context.Context, rawToken string) er
 		return nil
 	}
 	hash, _ := llms.HashFacadeToken(rawToken)
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE token_hash = ?`, hash); err != nil {
+	return s.DeleteLLMFacadeTokenHash(ctx, hash)
+}
+
+// DeleteLLMFacadeTokenHash removes one facade token by its already-computed
+// hash. Command-time facade setup tracks hashes at the persistence boundary so
+// it can clean up every token created by one command, including tokens issued
+// before a later provider configuration step fails.
+func (s *llmStore) DeleteLLMFacadeTokenHash(ctx context.Context, tokenHash string) error {
+	tokenHash = strings.TrimSpace(tokenHash)
+	if tokenHash == "" {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM llm_facade_token WHERE token_hash = ?`, tokenHash); err != nil {
 		return fmt.Errorf("delete llm facade token: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

- rebuild the command-scoped startup and selected-provider LLM facade environment whenever a Scheduler command uses a loaded or reused Sandbox
- persist `scheduler.command.started` with the linked Sandbox before executing a trigger command, replacing the extra `scheduler.shell("true")` prelink
- derive sticky compatibility from the selected Agent and Scheduler's effective Sandbox inputs instead of the enclosing Project revision

The original failure came from relying on transient facade environment fields that are intentionally absent from persisted Sandbox metadata. A later command or a sticky reuse could load the Sandbox without the startup Anthropic/OpenAI facade environment, producing an endpoint/token mismatch. The command path now reconstructs that managed environment for the child process and owns the tokens created for that command.

For a reused sticky Sandbox there may be no new `sandbox.created` or `sandbox.resumed` event. The new pre-execution Scheduler event makes the SchedulerRun-to-Sandbox association durable without running a separate `true` command. Failure to persist the association prevents the command from starting.

Sticky bindings created with the older hash schema may be replaced once after upgrading because the old hash included the Project revision. Subsequent changes to unrelated Agents in the same Project no longer invalidate the replacement binding; changes to effective image, driver, environment, volumes, workspace, capsets, or Agent configuration still do.

## Testing

Passed on `a447c8ce`:

- `GOTOOLCHAIN=go1.26.2 go test ./pkg/agentcompose/adapters ./pkg/llms/runtimefacade ./pkg/schedulers ./pkg/storage/configstore -count=1`
- targeted `-race -count=1` tests for command facade reconstruction/token ownership, pre-command Run-to-Sandbox linking/failure behavior, and sticky hash semantics
- `GOTOOLCHAIN=go1.26.2 task lint`
- `GOTOOLCHAIN=go1.26.2 task build`
- `GOTOOLCHAIN=go1.26.2 task --force docs:build`
- `git diff --check origin/main...HEAD`

`GOTOOLCHAIN=go1.26.2 task test` reaches `test:deploy` and then fails in the installer suite because macOS exposes `/var` as a symlink. The same `go -C cmd/installer test ./...` failure was reproduced on the unchanged `origin/main@b874e660`; this PR does not modify installer code.

## Scope

This Draft intentionally excludes:

- webhook parent Event lineage, fallback/root trace changes, and webhook header/idempotency hardening
- opt-in `.git/index.lock` cleanup during Sandbox resume
- the separate late-`AddCell` STOPPED-state persistence fix
- AgentKit loader changes

Before marking ready, the exact PR build still needs the dev180 sticky E2E: two sequential runs reuse one Sandbox, the second run reaches the facade without a 401, the active run exposes its Sandbox ID before command completion, unrelated Agent changes do not replace the binding, and effective Sandbox configuration changes do.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
