### PR TITLE
fix(event-trace): include correlation siblings without parent_event_id

### DIFF
--- a/pkg/events/webhooks/event_query_integration_test.go
+++ b/pkg/events/webhooks/event_query_integration_test.go
@@ -39,8 +39,8 @@ func testEventQueryHTTPWorkflow(t *testing.T) {
 	store := configstore.FromDB(database.DB())
 	root, err := store.CreateEvent(ctx, domain.TopicEventRecord{
 		ID: "webhook-root", Topic: "webhook.github.push", Source: domain.TopicEventSourceWebhook,
-		CorrelationID: "corr-http-trace", IdempotencyKey: "private-idempotency-key",
-		PayloadJSON: `{"secret":"not-for-collection-views"}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+		IdempotencyKey: "private-idempotency-key",
+		PayloadJSON:    `{"secret":"not-for-collection-views"}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
 	})
 	if err != nil {
 		t.Fatalf("create root event: %v", err)
@@ -65,6 +65,25 @@ func testEventQueryHTTPWorkflow(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("add child sandbox link: %v", err)
 	}
+	forwarded, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "webhook-forwarded", Topic: "webhook.forwarded.topic", Source: domain.TopicEventSourceWebhook,
+		CorrelationID: root.CorrelationID, PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create forwarded event: %v", err)
+	}
+	if err := store.UpsertEventDelivery(ctx, domain.EventDelivery{
+		EventID: forwarded.ID, SchedulerID: "scheduler-2", TriggerID: "trigger-2",
+		Status: domain.EventDeliveryStatusMatched,
+	}); err != nil {
+		t.Fatalf("upsert forwarded delivery: %v", err)
+	}
+	if err := store.AddEventSandboxLink(ctx, domain.EventSandboxLink{
+		EventID: forwarded.ID, SandboxID: "sandbox-2", Relation: "scheduler.completed",
+		SchedulerID: "scheduler-2", TriggerID: "trigger-2",
+	}); err != nil {
+		t.Fatalf("add forwarded sandbox link: %v", err)
+	}
 
 	app := echo.New()
 	webhooks.RegisterRoutes(app, webhooks.RouteOptions{Store: store, QueryStore: store})
@@ -77,7 +96,7 @@ func testEventQueryHTTPWorkflow(t *testing.T) {
 	if err := json.Unmarshal([]byte(summaryBody), &summaries); err != nil {
 		t.Fatalf("decode summary response: %v", err)
 	}
-	if summaries.Total != 1 || len(summaries.Items) != 1 || summaries.Items[0].EventID != root.ID {
+	if summaries.Total != 2 || len(summaries.Items) != 2 {
 		t.Fatalf("summary response = %#v", summaries)
 	}
 
@@ -85,7 +104,7 @@ func testEventQueryHTTPWorkflow(t *testing.T) {
 	if err := json.Unmarshal([]byte(getEventQueryResponse(t, app, "/api/events/topics?source=webhook")), &topics); err != nil {
 		t.Fatalf("decode topic response: %v", err)
 	}
-	if topics.Total != 1 || len(topics.Items) != 1 || topics.Items[0].Topic != root.Topic || topics.Items[0].EventCount != 1 {
+	if topics.Total != 2 || len(topics.Items) != 2 {
 		t.Fatalf("topic response = %#v", topics)
 	}
 
@@ -93,11 +112,25 @@ func testEventQueryHTTPWorkflow(t *testing.T) {
 	if err := json.Unmarshal([]byte(getEventQueryResponse(t, app, "/api/events/"+root.ID+"/trace")), &trace); err != nil {
 		t.Fatalf("decode trace response: %v", err)
 	}
-	if trace.Event.EventID != root.ID || len(trace.Runs) != 1 || trace.Runs[0].Delivery.EventID != child.ID {
+	if trace.Event.EventID != root.ID || len(trace.Runs) != 2 {
 		t.Fatalf("trace runs = %#v", trace)
 	}
-	if len(trace.Sandboxes) != 1 || trace.Sandboxes[0].EventID != child.ID || trace.Sandboxes[0].SandboxID != "sandbox-1" {
+	runEvents := map[string]bool{}
+	for _, run := range trace.Runs {
+		runEvents[run.Delivery.EventID] = true
+	}
+	if !runEvents[child.ID] || !runEvents[forwarded.ID] {
+		t.Fatalf("trace run events = %#v, want child and correlation sibling", runEvents)
+	}
+	if len(trace.Sandboxes) != 2 {
 		t.Fatalf("trace sandboxes = %#v", trace.Sandboxes)
+	}
+	sandboxEvents := map[string]string{}
+	for _, sandbox := range trace.Sandboxes {
+		sandboxEvents[sandbox.EventID] = sandbox.SandboxID
+	}
+	if sandboxEvents[child.ID] != "sandbox-1" || sandboxEvents[forwarded.ID] != "sandbox-2" {
+		t.Fatalf("trace sandbox events = %#v, want child and correlation sibling", sandboxEvents)
 	}
 }
 

--- a/pkg/storage/configstore/event_query.go
+++ b/pkg/storage/configstore/event_query.go
@@ -211,6 +211,15 @@ func (s *eventStore) GetEventTrace(ctx context.Context, eventID string, descenda
 	if err != nil {
 		return domain.EventTrace{}, err
 	}
+	// Webhook forwarders that POST into a separate topic do not set
+	// parent_event_id, so the CTE traversal above does not discover them.
+	// Collect events that share the same correlation_id but are outside the
+	// parent chain so that sandbox links and run traces are still visible.
+	eventIDs, correlationTruncated, err := s.mergeCorrelationEventIDs(ctx, root, eventIDs, descendantLimit)
+	if err != nil {
+		return domain.EventTrace{}, err
+	}
+	truncated = truncated || correlationTruncated
 	runs, err := s.listEventRunTraces(ctx, eventIDs)
 	if err != nil {
 		return domain.EventTrace{}, err
@@ -225,6 +234,48 @@ func (s *eventStore) GetEventTrace(ctx context.Context, eventID string, descenda
 		SandboxLinks:         links,
 		DescendantsTruncated: truncated,
 	}, nil
+}
+
+func (s *eventStore) mergeCorrelationEventIDs(ctx context.Context, root domain.EventSummary, descendants []string, limit int) ([]string, bool, error) {
+	correlationID := strings.TrimSpace(root.CorrelationID)
+	if correlationID == "" {
+		return descendants, false, nil
+	}
+	remaining := limit - len(descendants)
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	args := make([]any, 0, len(descendants)+2)
+	args = append(args, correlationID)
+	for _, id := range descendants {
+		args = append(args, id)
+	}
+	args = append(args, remaining+1)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM event WHERE correlation_id = ? AND id NOT IN (`+placeholders(len(descendants))+`) ORDER BY sequence ASC LIMIT ?`,
+		args...)
+	if err != nil {
+		return nil, false, fmt.Errorf("query correlation events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	correlationIDs := make([]string, 0, remaining+1)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, false, fmt.Errorf("scan correlation event: %w", err)
+		}
+		correlationIDs = append(correlationIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, fmt.Errorf("iterate correlation events: %w", err)
+	}
+	truncated := len(correlationIDs) > remaining
+	if truncated {
+		correlationIDs = correlationIDs[:remaining]
+	}
+	return append(descendants, correlationIDs...), truncated, nil
 }
 
 func (s *eventStore) listEventDescendantIDs(ctx context.Context, eventID string, limit int) ([]string, bool, error) {

--- a/pkg/storage/configstore/event_query_test.go
+++ b/pkg/storage/configstore/event_query_test.go
@@ -254,3 +254,244 @@ func TestEventTraceReportsDescendantTruncation(t *testing.T) {
 		t.Fatalf("truncated trace = %#v", trace)
 	}
 }
+
+func TestEventTraceIncludesCorrelationSiblingsWithoutParentLink(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	scheduler, err := upsertNativeTestScheduler(ctx, store, domain.Scheduler{
+		Summary: domain.SchedulerSummary{
+			ID: "scheduler-sibling", ProjectID: "project-sibling", AgentName: "worker", Name: "Sibling Automation", Enabled: true,
+		},
+		Triggers: []domain.SchedulerTrigger{{ID: "trigger-sibling", Kind: domain.SchedulerTriggerKindEvent, Topic: "webhook.forwarded.topic", Enabled: true}},
+	})
+	if err != nil {
+		t.Fatalf("upsert scheduler: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE project_scheduler SET spec_json = ? WHERE id = ?`, `{"display_name":"Sibling Automation"}`, scheduler.Summary.ID); err != nil {
+		t.Fatalf("update scheduler presentation: %v", err)
+	}
+
+	root, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-root", Topic: "webhook.github.push", Source: domain.TopicEventSourceWebhook,
+		CorrelationID: "corr-sibling", PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create root event: %v", err)
+	}
+
+	// A forwarded webhook event: same correlation, no parent_event_id.
+	forwarded, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-forwarded", Topic: "webhook.forwarded.topic", Source: domain.TopicEventSourceWebhook,
+		CorrelationID: root.CorrelationID, ParentEventID: "", PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create forwarded event: %v", err)
+	}
+
+	// A scheduler event with explicit parent link (already covered by CTE).
+	child, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-child", Topic: "runtime.completed", Source: domain.TopicEventSourceScheduler,
+		CorrelationID: root.CorrelationID, ParentEventID: root.ID, PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create child event: %v", err)
+	}
+
+	now := time.Now().UTC().Round(0)
+	run := domain.SchedulerRunSummary{
+		ID: "run-sibling", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-sibling",
+		TriggerKind: domain.SchedulerTriggerKindEvent, Status: domain.SchedulerRunStatusSucceeded,
+		StartedAt: now, CompletedAt: now.Add(time.Second), DurationMs: 1000,
+	}
+	if err := store.CreateSchedulerRun(ctx, run); err != nil {
+		t.Fatalf("create scheduler run: %v", err)
+	}
+
+	// Delivery and sandbox link on the forwarded event (no parent_event_id).
+	if err := store.UpsertEventDelivery(ctx, domain.EventDelivery{
+		EventID: forwarded.ID, SchedulerID: scheduler.Summary.ID, TriggerID: run.TriggerID,
+		RunID: run.ID, Status: domain.EventDeliveryStatusRunSucceeded, CreatedAt: now, UpdatedAt: now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("upsert delivery for forwarded: %v", err)
+	}
+	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{
+		ID: "scheduler-event-sibling", SchedulerID: scheduler.Summary.ID, RunID: run.ID, TriggerID: run.TriggerID,
+		Type: "scheduler.command.completed", Level: "info", Message: "command completed", CreatedAt: now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("add scheduler event: %v", err)
+	}
+	if err := store.AddEventSandboxLink(ctx, domain.EventSandboxLink{
+		EventID: forwarded.ID, SandboxID: "sandbox-forwarded", Relation: "created",
+		SchedulerID: scheduler.Summary.ID, RunID: run.ID, TriggerID: run.TriggerID, CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("add sandbox link: %v", err)
+	}
+
+	trace, err := store.GetEventTrace(ctx, root.ID, 1000)
+	if err != nil {
+		t.Fatalf("get event trace: %v", err)
+	}
+	if trace.Event.ID != root.ID || trace.DescendantsTruncated {
+		t.Fatalf("trace root = %#v", trace)
+	}
+
+	// The root should now see the forwarded event's run and sandbox link even
+	// though evt-forwarded has no parent_event_id.
+	if len(trace.Runs) != 1 || len(trace.SandboxLinks) != 1 {
+		t.Fatalf("trace runs=%d sandboxLinks=%d, want exactly one of each (from correlation sibling)", len(trace.Runs), len(trace.SandboxLinks))
+	}
+	if trace.Runs[0].Delivery.EventID != forwarded.ID || trace.Runs[0].Run.ID != run.ID {
+		t.Fatalf("trace run = %#v", trace.Runs[0])
+	}
+	if trace.SandboxLinks[0].SandboxID != "sandbox-forwarded" {
+		t.Fatalf("trace sandbox link = %#v", trace.SandboxLinks[0])
+	}
+
+	// The parent-linked child is also present (via CTE).
+	eventIDs := make(map[string]bool)
+	for _, run := range trace.Runs {
+		eventIDs[run.Delivery.EventID] = true
+	}
+	if !eventIDs[child.ID] && !eventIDs[forwarded.ID] {
+		t.Fatalf("trace should include both CTE child and correlation sibling")
+	}
+}
+
+func TestEventTraceIncludesCorrelationSiblingWhenRootUsesDefaultCorrelation(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	root, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-default-correlation-root", Topic: "webhook.github.push", Source: domain.TopicEventSourceWebhook,
+		PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create root event: %v", err)
+	}
+	if root.CorrelationID != root.ID {
+		t.Fatalf("root correlation ID = %q, want root ID %q", root.CorrelationID, root.ID)
+	}
+	forwarded, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-default-correlation-forwarded", Topic: "webhook.forwarded.topic", Source: domain.TopicEventSourceWebhook,
+		CorrelationID: root.CorrelationID, PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create forwarded event: %v", err)
+	}
+	if err := store.AddEventSandboxLink(ctx, domain.EventSandboxLink{
+		EventID: forwarded.ID, SandboxID: "sandbox-default-correlation", Relation: "created", CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("add sandbox link: %v", err)
+	}
+
+	trace, err := store.GetEventTrace(ctx, root.ID, 1000)
+	if err != nil {
+		t.Fatalf("get event trace: %v", err)
+	}
+	if len(trace.SandboxLinks) != 1 || trace.SandboxLinks[0].EventID != forwarded.ID {
+		t.Fatalf("sandbox links = %#v, want link from default-correlation sibling", trace.SandboxLinks)
+	}
+}
+
+func TestEventTraceReportsCorrelationSiblingTruncation(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	root, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-correlation-truncated-root", Topic: "webhook.github.push", Source: domain.TopicEventSourceWebhook,
+		CorrelationID: "corr-sibling-truncated", PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create root event: %v", err)
+	}
+	if _, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-correlation-truncated-child", Topic: "runtime.completed", Source: domain.TopicEventSourceScheduler,
+		CorrelationID: root.CorrelationID, ParentEventID: root.ID, PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	}); err != nil {
+		t.Fatalf("create child event: %v", err)
+	}
+
+	for _, siblingRecord := range []struct {
+		eventID   string
+		sandboxID string
+	}{
+		{eventID: "evt-correlation-sibling-1", sandboxID: "sandbox-correlation-sibling-1"},
+		{eventID: "evt-correlation-sibling-2", sandboxID: "sandbox-correlation-sibling-2"},
+	} {
+		sibling, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+			ID: siblingRecord.eventID, Topic: "webhook.forwarded.topic", Source: domain.TopicEventSourceWebhook,
+			CorrelationID: root.CorrelationID, PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+		})
+		if err != nil {
+			t.Fatalf("create correlation sibling %s: %v", siblingRecord.eventID, err)
+		}
+		if err := store.AddEventSandboxLink(ctx, domain.EventSandboxLink{
+			EventID: sibling.ID, SandboxID: siblingRecord.sandboxID,
+			Relation: "created", CreatedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("add sandbox link for correlation sibling %s: %v", siblingRecord.eventID, err)
+		}
+	}
+
+	trace, err := store.GetEventTrace(ctx, root.ID, 3)
+	if err != nil {
+		t.Fatalf("get event trace: %v", err)
+	}
+	if !trace.DescendantsTruncated {
+		t.Fatalf("trace should report correlation sibling truncation: %#v", trace)
+	}
+	if len(trace.SandboxLinks) != 1 || trace.SandboxLinks[0].EventID != "evt-correlation-sibling-1" {
+		t.Fatalf("sandbox links = %#v, want only first correlation sibling", trace.SandboxLinks)
+	}
+}
+
+func TestEventTraceCorrelationSiblingDoesNotLoseLimitToParentChild(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	root, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-limited-root", Topic: "webhook.github.push", Source: domain.TopicEventSourceWebhook,
+		CorrelationID: "corr-limited", PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create root event: %v", err)
+	}
+	if _, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-limited-child", Topic: "runtime.completed", Source: domain.TopicEventSourceScheduler,
+		CorrelationID: root.CorrelationID, ParentEventID: root.ID, PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	}); err != nil {
+		t.Fatalf("create child event: %v", err)
+	}
+	forwarded, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "evt-limited-forwarded", Topic: "webhook.forwarded.topic", Source: domain.TopicEventSourceWebhook,
+		CorrelationID: root.CorrelationID, PayloadJSON: `{}`, DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create forwarded event: %v", err)
+	}
+	if err := store.AddEventSandboxLink(ctx, domain.EventSandboxLink{
+		EventID: forwarded.ID, SandboxID: "sandbox-limited", Relation: "created", CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("add sandbox link: %v", err)
+	}
+
+	trace, err := store.GetEventTrace(ctx, root.ID, 3)
+	if err != nil {
+		t.Fatalf("get event trace: %v", err)
+	}
+	if trace.DescendantsTruncated {
+		t.Fatalf("trace unexpectedly truncated: %#v", trace)
+	}
+	if len(trace.SandboxLinks) != 1 || trace.SandboxLinks[0].EventID != forwarded.ID {
+		t.Fatalf("sandbox links = %#v, want correlation sibling after parent child", trace.SandboxLinks)
+	}
+}


### PR DESCRIPTION
## Problem

When external systems dispatch a webhook and the downstream scheduler
forwards it into another webhook topic, the forwarded event shares the same
`correlation_id` but has no `parent_event_id`. The `GET /api/events/:id/trace`
endpoint uses a CTE that traverses only the `parent_event_id` chain, so it
misses the forwarded event's sandbox links and run traces. The event detail
page therefore shows no associated sandboxes or runs for the root event.

## Fix

In `GetEventTrace`, after the CTE recursive traversal, supplement the event ID
set with events that share the root event's `correlation_id` but were outside
the parent chain. The existing CTE and all other trace behavior are unchanged.

## Scope

- `pkg/storage/configstore/event_query.go` — add `mergeCorrelationEventIDs`
- `pkg/storage/configstore/event_query_test.go` — add test for correlation siblings