### PR TITLE
feat(webhooks): propagate trusted MPI headers

### DIFF
--- a/cmd/agent-compose/daemon_trusted_headers_webhook_test.go
+++ b/cmd/agent-compose/daemon_trusted_headers_webhook_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"agent-compose/pkg/events/webhooks"
+	domain "agent-compose/pkg/model"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestDaemonTrustedHeadersReachWebhookPayload(t *testing.T) {
+	app := echo.New()
+	app.Use(newDaemonTrustedHeadersMiddleware())
+	app.POST("/api/webhooks/:topic", func(c echo.Context) error {
+		payload := webhooks.BuildPayload(
+			c.Request(), "event-1", 1, c.Param("topic"), "correlation-1", "idempotency-1",
+			domain.WebhookSource{}, map[string]any{"intent": "push"},
+		)
+		return c.JSON(http.StatusAccepted, payload)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", nil)
+	req.Header.Add("X-MPI-Role", "admin")
+	req.Header.Add("X-MPI-Role", "auditor")
+	req.Header.Set("X-MPI-User-ID", "user-1")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Headers map[string]string `json:"headers"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode webhook payload: %v", err)
+	}
+	if payload.Headers["x-mpi-role"] != "admin,auditor" || payload.Headers["x-mpi-user-id"] != "user-1" {
+		t.Fatalf("trusted headers = %#v", payload.Headers)
+	}
+}

--- a/pkg/events/webhooks/helpers.go
+++ b/pkg/events/webhooks/helpers.go
@@ -146,6 +146,23 @@ func SanitizeHeaders(headers http.Header) map[string]string {
 	return out
 }
 
+func webhookPayloadHeaders(r *http.Request) map[string]string {
+	out := SanitizeHeaders(r.Header)
+	for _, header := range domain.TrustedHeadersFromContext(r.Context()) {
+		name := strings.ToLower(strings.TrimSpace(header.Name))
+		if !strings.HasPrefix(name, "x-mpi-") {
+			continue
+		}
+		value := strings.TrimSpace(header.Value)
+		if existing := out[name]; existing != "" {
+			out[name] = existing + "," + value
+			continue
+		}
+		out[name] = value
+	}
+	return out
+}
+
 func BuildPayload(r *http.Request, eventID string, sequence int64, topic, correlationID, idempotencyKey string, source domain.WebhookSource, body map[string]any) map[string]any {
 	payload := map[string]any{
 		"eventId":        eventID,
@@ -160,7 +177,7 @@ func BuildPayload(r *http.Request, eventID string, sequence int64, topic, correl
 		"idempotencyKey": idempotencyKey,
 		"deliveryId":     ExtractDeliveryID(r),
 		"remoteAddr":     r.RemoteAddr,
-		"headers":        SanitizeHeaders(r.Header),
+		"headers":        webhookPayloadHeaders(r),
 		"query":          QueryValuesToMap(r),
 		"body":           body,
 	}

--- a/pkg/events/webhooks/trusted_headers_test.go
+++ b/pkg/events/webhooks/trusted_headers_test.go
@@ -1,0 +1,81 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestWebhookPayloadIncludesTrustedMPIHeaders(t *testing.T) {
+	store := newWebhookRouteStore()
+	app := newWebhookTestApp(store)
+	ctx := domain.NewContextWithTrustedHeaders(context.Background(), []domain.TrustedHeader{
+		{Name: "x-mpi-user-id", Value: "user-1"},
+		{Name: "X-MPI-ROLE", Value: "admin"},
+		{Name: "x-mpi-role", Value: "auditor"},
+		{Name: "x-not-mpi", Value: "ignored"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", strings.NewReader(`{"intent":"push"}`)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("stored events = %d, want 1", len(store.events))
+	}
+	var payload struct {
+		Headers map[string]string `json:"headers"`
+	}
+	if err := json.Unmarshal([]byte(store.events["event-trusted-headers"].PayloadJSON), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if payload.Headers["x-mpi-user-id"] != "user-1" || payload.Headers["x-mpi-role"] != "admin,auditor" {
+		t.Fatalf("trusted headers = %#v", payload.Headers)
+	}
+	if _, ok := payload.Headers["x-not-mpi"]; ok {
+		t.Fatalf("non-MPI trusted header was persisted: %#v", payload.Headers)
+	}
+}
+
+func TestWebhookPayloadRejectsUntrustedMPIHeaders(t *testing.T) {
+	store := newWebhookRouteStore()
+	app := newWebhookTestApp(store)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/webhook.github.push", strings.NewReader(`{"intent":"push"}`))
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-MPI-User-ID", "forged-user")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Headers map[string]string `json:"headers"`
+	}
+	if err := json.Unmarshal([]byte(store.events["event-trusted-headers"].PayloadJSON), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if _, ok := payload.Headers["x-mpi-user-id"]; ok {
+		t.Fatalf("untrusted MPI header was persisted: %#v", payload.Headers)
+	}
+}
+
+func newWebhookTestApp(store *webhookRouteStore) *echo.Echo {
+	app := echo.New()
+	RegisterRoutes(app, RouteOptions{
+		Store: store, WebhookBodyLimit: 1 << 20, NewEventID: func() string { return "event-trusted-headers" },
+	})
+	return app
+}


### PR DESCRIPTION
## Problem

The daemon validates trusted `x-mpi-*` headers and stores them in the request context, but webhook event construction only persists a fixed header allowlist. As a result, schedulers triggered asynchronously by webhook events cannot access the trusted MPI identity metadata after the HTTP request ends.

## Solution

- merge request-scoped trusted `x-mpi-*` headers into the webhook event payload's existing `headers` object
- normalize names to lowercase and preserve repeated values as comma-separated values
- continue rejecting raw client-supplied `x-mpi-*` headers that were not placed in trusted context by the daemon middleware
- ignore non-MPI entries even if present in trusted context

The deployment trust boundary is unchanged: trusted ingress must strip client-provided `x-mpi-*` headers before injecting authoritative values, and direct daemon access must remain restricted.

## Tests

- `go test ./pkg/events/webhooks ./cmd/agent-compose -count=1`
- `go test -race ./pkg/events/webhooks ./cmd/agent-compose -run 'TestWebhookPayload.*MPIHeaders|TestDaemonTrustedHeadersReachWebhookPayload|TestDaemonTrustedHeadersMiddleware' -count=1`
- `go test ./... -count=1`
