### PR TITLE
feat(driver): add BoxLite bidirectional interactions

### DIFF
--- a/docs/design/runtime-bidirectional-stream-design.md
+++ b/docs/design/runtime-bidirectional-stream-design.md
@@ -30,7 +30,7 @@ This design upgrades the lower execution boundary to an interactive runtime stre
 
 ## Non-Goals
 
-1. Do not implement BoxLite stdin/TTY/resize until its runtime API exposes the required controls. Microsandbox command attach was added later through its native streaming exec API.
+1. Do not emulate interactive controls in a driver that lacks native support. Docker, Microsandbox, and BoxLite now expose the stdin, TTY, resize, and signal controls required by command attach.
 2. Do not merge workspace files, artifact bodies, or the LLM facade HTTP/SSE protocol into the runtime stream.
 3. Do not implement `run --prompt -it` by making users call `agent-compose exec <sandbox> -it codex` or `run --command "codex" -it`.
 4. Do not remove compatibility artifacts such as `command-request.json`, `command-result.json`, `stdout.txt`, `stderr.txt`, `output.txt`, or `transcript.txt`.
@@ -74,7 +74,7 @@ The implementation should gradually converge:
 external API handlers
   -> daemon AttachEngine
   -> RuntimeInteraction
-  -> Docker native attach or runtime wrapper framed stream
+  -> Docker, Microsandbox, or BoxLite native attach
 ```
 
 To reduce risk in the first phase, only `-it` paths need to use the `AttachExec` / `AttachAgentRun` kernel. Existing unary and server-stream paths may keep their current implementation. In later migrations, handlers should call the same internal Go `AttachEngine` instead of making RPC calls to their own `AttachExec` / `AttachAgentRun` endpoints. This avoids protocol recursion and complicated connection lifecycles.
@@ -83,13 +83,13 @@ To reduce risk in the first phase, only `-it` paths need to use the `AttachExec`
 
 ## Driver Capability Matrix
 
-The first phase required full interactive support for Docker. Drivers without the required controls must report an explicit unsupported capability and must not silently fall back to the regular `StreamExec` RPC. Microsandbox now satisfies the command-interaction contract through native streaming exec.
+Drivers without the required controls must report an explicit unsupported capability and must not silently fall back to the regular `StreamExec` RPC. Docker, Microsandbox, and BoxLite now satisfy the command-interaction contract through their native streaming exec APIs.
 
 | driver | stdin | stdout/stderr | TTY | resize | current strategy |
 |---|---:|---:|---:|---:|---|
 | Docker | supported | existing basis | supported | supported | full implementation |
 | Microsandbox | supported | streaming exec events | supported | supported | native streaming exec |
-| BoxLite | current Go/FFI layer does not expose stdin | existing stdout/stderr callback | FFI has a `tty` field but it is not wired | not exposed | return unsupported |
+| BoxLite | supported | stdout/stderr callbacks | supported | supported | native C FFI execution handle |
 
 Suggested driver extension interface:
 

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -502,11 +502,18 @@ func (r *cgoSandboxRuntime) ExecStream(ctx context.Context, sandbox *Sandbox, vm
 }
 
 func (r *cgoSandboxRuntime) InteractionCapabilities() RuntimeInteractionCapabilities {
-	return RuntimeInteractionCapabilities{}
+	return RuntimeInteractionCapabilities{
+		NativeExec: true,
+		Stdin:      true,
+		StdinEOF:   true,
+		TTY:        true,
+		Resize:     true,
+		Signal:     true,
+	}
 }
 
 func (r *cgoSandboxRuntime) OpenInteraction(ctx context.Context, sandbox *Sandbox, vmState VMState, spec RuntimeStartSpec) (RuntimeInteraction, error) {
-	return UnsupportedRuntimeInteraction(RuntimeDriverBoxlite, r.InteractionCapabilities(), spec)
+	return r.openBoxliteInteraction(ctx, sandbox, vmState, spec)
 }
 
 func (r *cgoSandboxRuntime) Stats(_ context.Context, sandbox *Sandbox, vmState VMState) (SandboxStats, error) {

--- a/pkg/driver/boxlite_cgo.go
+++ b/pkg/driver/boxlite_cgo.go
@@ -177,6 +177,7 @@ type cgoBoxInfo struct {
 type cgoExecCollector struct {
 	stream        ExecStreamWriter
 	filter        *execOutputFilter
+	streamOnly    bool
 	stdoutDecoder utf8StreamDecoder
 	stderrDecoder utf8StreamDecoder
 	stdout        bytes.Buffer
@@ -303,10 +304,13 @@ func (c *cgoExecCollector) writeBytes(data []byte, stream StdioStream) {
 }
 
 func (c *cgoExecCollector) appendChunk(chunk ExecChunk) {
-	c.output.WriteString(chunk.Text)
 	if c.stream != nil {
 		c.stream(chunk)
 	}
+	if c.streamOnly {
+		return
+	}
+	c.output.WriteString(chunk.Text)
 	if NormalizeStdioStream(chunk.Stream) == StdioStderr {
 		c.stderr.WriteString(chunk.Text)
 		return

--- a/pkg/driver/boxlite_interaction_cgo.go
+++ b/pkg/driver/boxlite_interaction_cgo.go
@@ -94,15 +94,19 @@ type boxliteCommandInteraction struct {
 	awaiter       *boxliteExecAwaiter
 	awaiterHandle uintptr
 
-	ctx         context.Context
-	cancel      context.CancelFunc
-	operationID string
-	tty         bool
-	attachStdin bool
-	startedAt   time.Time
-	collector   *cgoExecCollector
-	output      chan RuntimeOutputFrame
-	done        chan struct{}
+	ctx           context.Context
+	cancel        context.CancelFunc
+	operationID   string
+	tty           bool
+	attachStdin   bool
+	startedAt     time.Time
+	collector     *cgoExecCollector
+	output        chan RuntimeOutputFrame
+	done          chan struct{}
+	outputMu      sync.Mutex
+	outputStarted bool
+	startupOutput []RuntimeOutputFrame
+	startupDone   chan struct{}
 
 	inputMu       sync.Mutex
 	stdinClosed   bool
@@ -177,8 +181,9 @@ func (r *cgoSandboxRuntime) openBoxliteInteraction(ctx context.Context, sandbox 
 		startedAt:     time.Now(),
 		output:        make(chan RuntimeOutputFrame, 64),
 		done:          make(chan struct{}),
+		startupDone:   make(chan struct{}),
 	}
-	interaction.collector = &cgoExecCollector{stream: interaction.emitChunk}
+	interaction.collector = &cgoExecCollector{stream: interaction.emitChunk, streamOnly: true}
 	interaction.awaiter = &boxliteExecAwaiter{
 		collector: interaction.collector,
 		waitCh:    make(chan boxliteExecWaitResult, 1),
@@ -196,7 +201,7 @@ func (r *cgoSandboxRuntime) openBoxliteInteraction(ctx context.Context, sandbox 
 			return nil, err
 		}
 	}
-	interaction.emit(RuntimeOutputFrame{Type: RuntimeOutputStarted, StartedAt: interaction.startedAt})
+	interaction.startOutput()
 	go interaction.run()
 	return interaction, nil
 }
@@ -311,7 +316,7 @@ func (i *boxliteCommandInteraction) writeStdin(data []byte) error {
 	if i.stdinClosed {
 		return io.ErrClosedPipe
 	}
-	if err := i.ctx.Err(); err != nil {
+	if err := i.inputStateErrorLocked(); err != nil {
 		return err
 	}
 	var ffiErr C.CBoxliteError
@@ -335,6 +340,9 @@ func (i *boxliteCommandInteraction) CloseSend() error {
 func (i *boxliteCommandInteraction) resize(rows, cols uint32) error {
 	i.inputMu.Lock()
 	defer i.inputMu.Unlock()
+	if err := i.inputStateErrorLocked(); err != nil {
+		return err
+	}
 	if err := validateBoxliteTerminalSize(rows, cols); err != nil {
 		return err
 	}
@@ -352,6 +360,9 @@ func (i *boxliteCommandInteraction) resize(rows, cols uint32) error {
 func (i *boxliteCommandInteraction) signal(signal RuntimeSignal) error {
 	i.inputMu.Lock()
 	defer i.inputMu.Unlock()
+	if err := i.inputStateErrorLocked(); err != nil {
+		return err
+	}
 	sig, err := boxliteRuntimeSignal(signal)
 	if err != nil {
 		return err
@@ -362,6 +373,13 @@ func (i *boxliteCommandInteraction) signal(signal RuntimeSignal) error {
 	return i.runVoidOperation("signal boxlite interaction", func(handle C.uintptr_t, ffiErr *C.CBoxliteError) C.enum_BoxliteErrorCode {
 		return C.agentcompose_boxlite_interaction_signal(i.execution, C.int(sig), handle, ffiErr)
 	})
+}
+
+func (i *boxliteCommandInteraction) inputStateErrorLocked() error {
+	if i.execution == nil {
+		return io.ErrClosedPipe
+	}
+	return i.ctx.Err()
 }
 
 func (i *boxliteCommandInteraction) runVoidOperation(action string, start func(C.uintptr_t, *C.CBoxliteError) C.enum_BoxliteErrorCode) error {
@@ -425,10 +443,49 @@ func (i *boxliteCommandInteraction) finish(exitCode int, err error) {
 }
 
 func (i *boxliteCommandInteraction) emit(frame RuntimeOutputFrame) {
+	i.outputMu.Lock()
+	if !i.outputStarted {
+		i.startupOutput = append(i.startupOutput, frame)
+		i.outputMu.Unlock()
+		return
+	}
+	startupDone := i.startupDone
+	i.outputMu.Unlock()
+
+	select {
+	case <-startupDone:
+	case <-i.ctx.Done():
+		return
+	}
 	select {
 	case i.output <- frame:
 	case <-i.ctx.Done():
 	}
+}
+
+// startOutput establishes the interaction framing boundary before OpenInteraction
+// returns. BoxLite starts the guest before its callbacks can be registered, so
+// callbacks observed during registration or the initial resize are staged. The
+// asynchronous flush lets callers begin receiving before a noisy guest can fill
+// the bounded output channel.
+func (i *boxliteCommandInteraction) startOutput() {
+	i.outputMu.Lock()
+	pending := i.startupOutput
+	i.startupOutput = nil
+	i.outputStarted = true
+	i.output <- RuntimeOutputFrame{Type: RuntimeOutputStarted, StartedAt: i.startedAt}
+	i.outputMu.Unlock()
+
+	go func() {
+		defer close(i.startupDone)
+		for _, frame := range pending {
+			select {
+			case i.output <- frame:
+			case <-i.ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 func (i *boxliteCommandInteraction) cleanupStart() {
@@ -447,7 +504,9 @@ func (i *boxliteCommandInteraction) cleanup() {
 		i.inputMu.Lock()
 		defer i.inputMu.Unlock()
 		globalBoxliteAwaiters.delete(i.awaiterHandle)
-		C.boxlite_execution_free(i.execution)
+		execution := i.execution
+		i.execution = nil
+		C.boxlite_execution_free(execution)
 		i.box.free()
 		i.cancel()
 	})

--- a/pkg/driver/boxlite_interaction_cgo.go
+++ b/pkg/driver/boxlite_interaction_cgo.go
@@ -1,0 +1,469 @@
+//go:build linux && cgo && boxlitecgo
+
+package driver
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../build/boxlite/include
+#cgo LDFLAGS: ${SRCDIR}/../../build/boxlite/lib/libboxlite.a -ldl -lpthread -lm
+#include <stdint.h>
+#include <stdlib.h>
+#include "boxlite.h"
+
+extern void agentcomposeBoxliteVoidCallback(CBoxliteError *err, uintptr_t handle);
+extern void agentcomposeBoxliteExecStdoutCallback(uint8_t *data, size_t len, uintptr_t handle);
+extern void agentcomposeBoxliteExecStderrCallback(uint8_t *data, size_t len, uintptr_t handle);
+extern void agentcomposeBoxliteExecWaitCallback(int exit_code, CBoxliteError *err, uintptr_t handle);
+extern void agentcomposeBoxliteExecExitCallback(int exit_code, uintptr_t handle);
+
+static void agentcomposeBoxliteInteractionVoidCallbackBridge(CBoxliteError *err, void *user_data) {
+	agentcomposeBoxliteVoidCallback(err, (uintptr_t)user_data);
+}
+
+static void agentcomposeBoxliteInteractionStdoutCallbackBridge(const uint8_t *data, size_t len, void *user_data) {
+	agentcomposeBoxliteExecStdoutCallback((uint8_t *)data, len, (uintptr_t)user_data);
+}
+
+static void agentcomposeBoxliteInteractionStderrCallbackBridge(const uint8_t *data, size_t len, void *user_data) {
+	agentcomposeBoxliteExecStderrCallback((uint8_t *)data, len, (uintptr_t)user_data);
+}
+
+static void agentcomposeBoxliteInteractionWaitCallbackBridge(int exit_code, CBoxliteError *err, void *user_data) {
+	agentcomposeBoxliteExecWaitCallback(exit_code, err, (uintptr_t)user_data);
+}
+
+static void agentcomposeBoxliteInteractionExitCallbackBridge(int exit_code, void *user_data) {
+	agentcomposeBoxliteExecExitCallback(exit_code, (uintptr_t)user_data);
+}
+
+static enum BoxliteErrorCode agentcompose_boxlite_interaction_on_stdout(CExecutionHandle *execution, uintptr_t user_handle, CBoxliteError *out_error) {
+	return boxlite_execution_on_stdout(execution, agentcomposeBoxliteInteractionStdoutCallbackBridge, (void *)user_handle, out_error);
+}
+
+static enum BoxliteErrorCode agentcompose_boxlite_interaction_on_stderr(CExecutionHandle *execution, uintptr_t user_handle, CBoxliteError *out_error) {
+	return boxlite_execution_on_stderr(execution, agentcomposeBoxliteInteractionStderrCallbackBridge, (void *)user_handle, out_error);
+}
+
+static enum BoxliteErrorCode agentcompose_boxlite_interaction_on_exit(CExecutionHandle *execution, uintptr_t user_handle, CBoxliteError *out_error) {
+	return boxlite_execution_on_exit(execution, agentcomposeBoxliteInteractionExitCallbackBridge, (void *)user_handle, out_error);
+}
+
+static enum BoxliteErrorCode agentcompose_boxlite_interaction_wait(CExecutionHandle *execution, uintptr_t user_handle, CBoxliteError *out_error) {
+	return boxlite_execution_wait(execution, agentcomposeBoxliteInteractionWaitCallbackBridge, (void *)user_handle, out_error);
+}
+
+static enum BoxliteErrorCode agentcompose_boxlite_interaction_signal(
+	CExecutionHandle *execution,
+	int sig,
+	uintptr_t user_handle,
+	CBoxliteError *out_error
+) {
+	return boxlite_execution_signal(execution, sig, agentcomposeBoxliteInteractionVoidCallbackBridge, (void *)user_handle, out_error);
+}
+
+static enum BoxliteErrorCode agentcompose_boxlite_interaction_resize(
+	CExecutionHandle *execution,
+	int rows,
+	int cols,
+	uintptr_t user_handle,
+	CBoxliteError *out_error
+) {
+	return boxlite_execution_tty_resize(execution, rows, cols, agentcomposeBoxliteInteractionVoidCallbackBridge, (void *)user_handle, out_error);
+}
+*/
+import "C"
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+type boxliteCommandInteraction struct {
+	runtime       *cgoSandboxRuntime
+	runtimeHandle *C.CBoxliteRuntime
+	box           *cgoBoxHandle
+	execution     *C.CExecutionHandle
+	awaiter       *boxliteExecAwaiter
+	awaiterHandle uintptr
+
+	ctx         context.Context
+	cancel      context.CancelFunc
+	operationID string
+	tty         bool
+	attachStdin bool
+	startedAt   time.Time
+	collector   *cgoExecCollector
+	output      chan RuntimeOutputFrame
+	done        chan struct{}
+
+	inputMu       sync.Mutex
+	stdinClosed   bool
+	closeSendOnce sync.Once
+	closeSendErr  error
+	cleanupOnce   sync.Once
+	result        RuntimeResult
+	err           error
+}
+
+func (r *cgoSandboxRuntime) openBoxliteInteraction(ctx context.Context, sandbox *Sandbox, vmState VMState, spec RuntimeStartSpec) (RuntimeInteraction, error) {
+	if err := r.validateBoxliteInteractionSpec(spec); err != nil {
+		return nil, err
+	}
+	if sandbox == nil {
+		return nil, fmt.Errorf("boxlite interaction sandbox is required")
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	if spec.TimeoutMs > 0 {
+		childCtx, cancel = context.WithTimeout(ctx, time.Duration(spec.TimeoutMs)*time.Millisecond)
+	}
+	runtimeHandle, err := r.runtimeHandle()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if strings.TrimSpace(vmState.BoxID) == "" {
+		cancel()
+		return nil, fmt.Errorf("sandbox box is not initialized")
+	}
+	box, err := r.getBox(childCtx, vmState.BoxID)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	info, err := r.boxInfo(box)
+	if err != nil {
+		box.free()
+		cancel()
+		return nil, err
+	}
+	if !info.State.Running {
+		if err := r.startBox(childCtx, box); err != nil {
+			box.free()
+			cancel()
+			return nil, err
+		}
+	}
+	if err := r.ensureDirectoryOnlyGuestSandboxBootstrap(childCtx, box, sandbox); err != nil {
+		box.free()
+		cancel()
+		return nil, err
+	}
+
+	execution, err := boxliteStartInteractionExecution(box, ExecSpecFromRuntimeStartSpec(spec), spec.TTY)
+	if err != nil {
+		box.free()
+		cancel()
+		return nil, err
+	}
+	interaction := &boxliteCommandInteraction{
+		runtime:       r,
+		runtimeHandle: runtimeHandle,
+		box:           box,
+		execution:     execution,
+		ctx:           childCtx,
+		cancel:        cancel,
+		operationID:   spec.OperationID,
+		tty:           spec.TTY,
+		attachStdin:   spec.AttachStdin,
+		startedAt:     time.Now(),
+		output:        make(chan RuntimeOutputFrame, 64),
+		done:          make(chan struct{}),
+	}
+	interaction.collector = &cgoExecCollector{stream: interaction.emitChunk}
+	interaction.awaiter = &boxliteExecAwaiter{
+		collector: interaction.collector,
+		waitCh:    make(chan boxliteExecWaitResult, 1),
+		exitCh:    make(chan int, 1),
+		outputCh:  make(chan struct{}, 1),
+	}
+	interaction.awaiterHandle = globalBoxliteAwaiters.register(interaction.awaiter)
+	if err := interaction.registerCallbacks(); err != nil {
+		interaction.cleanupStart()
+		return nil, err
+	}
+	if spec.Rows != 0 || spec.Cols != 0 {
+		if err := interaction.resize(spec.Rows, spec.Cols); err != nil {
+			interaction.cleanupStart()
+			return nil, err
+		}
+	}
+	interaction.emit(RuntimeOutputFrame{Type: RuntimeOutputStarted, StartedAt: interaction.startedAt})
+	go interaction.run()
+	return interaction, nil
+}
+
+func (r *cgoSandboxRuntime) validateBoxliteInteractionSpec(spec RuntimeStartSpec) error {
+	if err := r.InteractionCapabilities().ValidateStartSpec(RuntimeDriverBoxlite, spec); err != nil {
+		return err
+	}
+	if normalizeRuntimeOperationKind(spec.Kind) != RuntimeOperationCommand {
+		return NewRuntimeInteractionUnsupportedError(RuntimeDriverBoxlite, spec, RuntimeCapabilityNativeExec, "boxlite native attach only supports command interactions")
+	}
+	command := RuntimeCommandSpec{}
+	if spec.Command != nil {
+		command = *spec.Command
+	}
+	if strings.TrimSpace(command.Command) == "" {
+		return fmt.Errorf("boxlite interaction command is required")
+	}
+	return validateBoxliteTerminalSize(spec.Rows, spec.Cols)
+}
+
+func validateBoxliteTerminalSize(rows, cols uint32) error {
+	if rows > math.MaxInt32 || cols > math.MaxInt32 {
+		return fmt.Errorf("boxlite terminal size exceeds %d rows or columns", int64(math.MaxInt32))
+	}
+	return nil
+}
+
+func boxliteStartInteractionExecution(box *cgoBoxHandle, spec ExecSpec, tty bool) (*C.CExecutionHandle, error) {
+	command := C.CString(spec.Command)
+	defer C.free(unsafe.Pointer(command))
+	args, argc, freeArgs := cStringArray(spec.Args)
+	defer freeArgs()
+	envPairs := make([]string, 0, len(spec.Env)*2)
+	keys := make([]string, 0, len(spec.Env))
+	for key := range spec.Env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		envPairs = append(envPairs, key, spec.Env[key])
+	}
+	env, envCount, freeEnv := cStringArray(envPairs)
+	defer freeEnv()
+	var workdir *C.char
+	if strings.TrimSpace(spec.Cwd) != "" {
+		workdir = C.CString(spec.Cwd)
+		defer C.free(unsafe.Pointer(workdir))
+	}
+	ttyFlag := C.int(0)
+	if tty {
+		ttyFlag = 1
+	}
+	cmd := C.struct_BoxliteCommand{
+		command: command, args: args, argc: C.int(argc), env_pairs: env,
+		env_count: C.int(envCount), workdir: workdir, tty: ttyFlag,
+	}
+	var execution *C.CExecutionHandle
+	var ffiErr C.CBoxliteError
+	code := C.boxlite_box_exec(box.ptr, &cmd, &execution, &ffiErr)
+	if err := boxliteStatusError(code, &ffiErr, "start boxlite interaction"); err != nil {
+		return nil, err
+	}
+	if execution == nil {
+		return nil, fmt.Errorf("start boxlite interaction: empty execution handle")
+	}
+	return execution, nil
+}
+
+func (i *boxliteCommandInteraction) registerCallbacks() error {
+	var ffiErr C.CBoxliteError
+	handle := C.uintptr_t(i.awaiterHandle)
+	if err := boxliteStatusError(C.agentcompose_boxlite_interaction_on_stdout(i.execution, handle, &ffiErr), &ffiErr, "register boxlite interaction stdout"); err != nil {
+		return err
+	}
+	if err := boxliteStatusError(C.agentcompose_boxlite_interaction_on_stderr(i.execution, handle, &ffiErr), &ffiErr, "register boxlite interaction stderr"); err != nil {
+		return err
+	}
+	if err := boxliteStatusError(C.agentcompose_boxlite_interaction_on_exit(i.execution, handle, &ffiErr), &ffiErr, "register boxlite interaction exit"); err != nil {
+		return err
+	}
+	return boxliteStatusError(C.agentcompose_boxlite_interaction_wait(i.execution, handle, &ffiErr), &ffiErr, "wait for boxlite interaction")
+}
+
+func (i *boxliteCommandInteraction) Send(frame RuntimeInputFrame) error {
+	switch frame.Type {
+	case RuntimeInputStdin:
+		return i.writeStdin(frame.Data)
+	case RuntimeInputStdinEOF:
+		return i.CloseSend()
+	case RuntimeInputResize:
+		return i.resize(frame.Rows, frame.Cols)
+	case RuntimeInputSignal:
+		return i.signal(frame.Signal)
+	case RuntimeInputCancel:
+		i.cancel()
+		return nil
+	default:
+		return ErrRuntimeInteractionUnsupported
+	}
+}
+
+func (i *boxliteCommandInteraction) writeStdin(data []byte) error {
+	if !i.attachStdin {
+		return ErrRuntimeInteractionUnsupported
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	i.inputMu.Lock()
+	defer i.inputMu.Unlock()
+	if i.stdinClosed {
+		return io.ErrClosedPipe
+	}
+	if err := i.ctx.Err(); err != nil {
+		return err
+	}
+	var ffiErr C.CBoxliteError
+	return boxliteStatusError(C.boxlite_execution_stdin_write(i.execution, (*C.uint8_t)(unsafe.Pointer(&data[0])), C.size_t(len(data)), &ffiErr), &ffiErr, "write boxlite interaction stdin")
+}
+
+func (i *boxliteCommandInteraction) CloseSend() error {
+	i.closeSendOnce.Do(func() {
+		i.inputMu.Lock()
+		defer i.inputMu.Unlock()
+		i.stdinClosed = true
+		if !i.attachStdin {
+			return
+		}
+		var ffiErr C.CBoxliteError
+		i.closeSendErr = boxliteStatusError(C.boxlite_execution_stdin_close(i.execution, &ffiErr), &ffiErr, "close boxlite interaction stdin")
+	})
+	return i.closeSendErr
+}
+
+func (i *boxliteCommandInteraction) resize(rows, cols uint32) error {
+	i.inputMu.Lock()
+	defer i.inputMu.Unlock()
+	if err := validateBoxliteTerminalSize(rows, cols); err != nil {
+		return err
+	}
+	if !i.tty {
+		return ErrRuntimeInteractionUnsupported
+	}
+	if rows == 0 && cols == 0 {
+		return nil
+	}
+	return i.runVoidOperation("resize boxlite interaction terminal", func(handle C.uintptr_t, ffiErr *C.CBoxliteError) C.enum_BoxliteErrorCode {
+		return C.agentcompose_boxlite_interaction_resize(i.execution, C.int(rows), C.int(cols), handle, ffiErr)
+	})
+}
+
+func (i *boxliteCommandInteraction) signal(signal RuntimeSignal) error {
+	i.inputMu.Lock()
+	defer i.inputMu.Unlock()
+	sig, err := boxliteRuntimeSignal(signal)
+	if err != nil {
+		return err
+	}
+	if sig == int(syscall.SIGKILL) {
+		return i.runtime.killExecution(i.ctx, i.runtimeHandle, i.execution)
+	}
+	return i.runVoidOperation("signal boxlite interaction", func(handle C.uintptr_t, ffiErr *C.CBoxliteError) C.enum_BoxliteErrorCode {
+		return C.agentcompose_boxlite_interaction_signal(i.execution, C.int(sig), handle, ffiErr)
+	})
+}
+
+func (i *boxliteCommandInteraction) runVoidOperation(action string, start func(C.uintptr_t, *C.CBoxliteError) C.enum_BoxliteErrorCode) error {
+	awaiter := &boxliteVoidAwaiter{ch: make(chan error, 1)}
+	handle := globalBoxliteAwaiters.register(awaiter)
+	defer globalBoxliteAwaiters.delete(handle)
+	var ffiErr C.CBoxliteError
+	if err := boxliteStatusError(start(C.uintptr_t(handle), &ffiErr), &ffiErr, action); err != nil {
+		return err
+	}
+	return i.runtime.waitForVoidResult(i.ctx, i.runtimeHandle, awaiter.ch)
+}
+
+func (i *boxliteCommandInteraction) Recv() (RuntimeOutputFrame, error) {
+	frame, ok := <-i.output
+	if !ok {
+		return RuntimeOutputFrame{}, io.EOF
+	}
+	return frame, nil
+}
+
+func (i *boxliteCommandInteraction) Wait() (RuntimeResult, error) {
+	<-i.done
+	return i.result, i.err
+}
+
+func (i *boxliteCommandInteraction) run() {
+	defer close(i.done)
+	defer close(i.output)
+	defer i.cleanup()
+	exitCode, err := i.runtime.waitForExecCompletion(i.ctx, i.runtimeHandle, i.awaiter)
+	if err != nil && i.ctx.Err() != nil {
+		terminationErr := i.runtime.killExecution(i.ctx, i.runtimeHandle, i.execution)
+		err = execTerminationResultError(RuntimeDriverBoxlite, i.operationID, i.ctx.Err(), terminationErr)
+	}
+	i.runtime.flushRuntimeCallbacks(i.runtimeHandle)
+	i.collector.finish()
+	i.finish(exitCode, err)
+}
+
+func (i *boxliteCommandInteraction) emitChunk(chunk ExecChunk) {
+	stream := NormalizeStdioStream(chunk.Stream)
+	if i.tty {
+		stream = StdioStdout
+	}
+	frameType := RuntimeOutputStdout
+	if stream == StdioStderr {
+		frameType = RuntimeOutputStderr
+	}
+	i.emit(RuntimeOutputFrame{Type: frameType, Data: []byte(chunk.Text)})
+}
+
+func (i *boxliteCommandInteraction) finish(exitCode int, err error) {
+	i.result = RuntimeResult{OperationID: i.operationID, ExitCode: exitCode, Success: err == nil && exitCode == 0, StartedAt: i.startedAt, CompletedAt: time.Now()}
+	if err != nil {
+		i.err = err
+		i.result.Error = err.Error()
+		i.emit(RuntimeOutputFrame{Type: RuntimeOutputError, Error: &RuntimeError{Message: err.Error()}})
+	}
+	i.emit(RuntimeOutputFrame{Type: RuntimeOutputResult, Result: &i.result})
+}
+
+func (i *boxliteCommandInteraction) emit(frame RuntimeOutputFrame) {
+	select {
+	case i.output <- frame:
+	case <-i.ctx.Done():
+	}
+}
+
+func (i *boxliteCommandInteraction) cleanupStart() {
+	terminationErr := i.runtime.killExecution(i.ctx, i.runtimeHandle, i.execution)
+	if terminationErr != nil {
+		slog.Warn("failed to terminate boxlite interaction after startup error", "operation_id", i.operationID, "error", terminationErr)
+	}
+	i.cleanup()
+}
+
+func (i *boxliteCommandInteraction) cleanup() {
+	i.cleanupOnce.Do(func() {
+		if err := i.CloseSend(); err != nil {
+			slog.Warn("failed to close boxlite interaction stdin", "operation_id", i.operationID, "error", err)
+		}
+		i.inputMu.Lock()
+		defer i.inputMu.Unlock()
+		globalBoxliteAwaiters.delete(i.awaiterHandle)
+		C.boxlite_execution_free(i.execution)
+		i.box.free()
+		i.cancel()
+	})
+}
+
+func boxliteRuntimeSignal(signal RuntimeSignal) (int, error) {
+	switch signal {
+	case RuntimeSignalInterrupt:
+		return int(syscall.SIGINT), nil
+	case RuntimeSignalTerminate:
+		return int(syscall.SIGTERM), nil
+	case RuntimeSignalKill:
+		return int(syscall.SIGKILL), nil
+	default:
+		return 0, fmt.Errorf("unsupported boxlite runtime signal %q", signal)
+	}
+}
+
+var _ RuntimeInteraction = (*boxliteCommandInteraction)(nil)

--- a/pkg/driver/boxlite_interaction_cgo_test.go
+++ b/pkg/driver/boxlite_interaction_cgo_test.go
@@ -1,0 +1,102 @@
+//go:build linux && cgo && boxlitecgo
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"math"
+	"reflect"
+	"syscall"
+	"testing"
+)
+
+func TestBoxliteInteractionCapabilities(t *testing.T) {
+	runtime := &cgoSandboxRuntime{}
+	got := runtime.InteractionCapabilities()
+	want := RuntimeInteractionCapabilities{
+		NativeExec: true,
+		Stdin:      true,
+		StdinEOF:   true,
+		TTY:        true,
+		Resize:     true,
+		Signal:     true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("InteractionCapabilities() = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidateBoxliteInteractionSpec(t *testing.T) {
+	runtime := &cgoSandboxRuntime{}
+	valid := RuntimeStartSpec{
+		Kind: RuntimeOperationCommand,
+		Command: &RuntimeCommandSpec{
+			Command: "sh",
+		},
+		AttachStdin: true,
+		TTY:         true,
+		Rows:        24,
+		Cols:        80,
+	}
+	if err := runtime.validateBoxliteInteractionSpec(valid); err != nil {
+		t.Fatalf("valid spec rejected: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		spec RuntimeStartSpec
+		want error
+	}{
+		{name: "agent", spec: RuntimeStartSpec{Kind: RuntimeOperationAgent}, want: ErrRuntimeInteractionUnsupported},
+		{name: "missing command", spec: RuntimeStartSpec{Kind: RuntimeOperationCommand}, want: nil},
+		{name: "oversized terminal", spec: RuntimeStartSpec{Kind: RuntimeOperationCommand, Command: &RuntimeCommandSpec{Command: "sh"}, Rows: math.MaxUint32}, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runtime.validateBoxliteInteractionSpec(tt.spec)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if tt.want != nil && !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want errors.Is(%v)", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoxliteRuntimeSignal(t *testing.T) {
+	tests := []struct {
+		input RuntimeSignal
+		want  syscall.Signal
+	}{
+		{input: RuntimeSignalInterrupt, want: syscall.SIGINT},
+		{input: RuntimeSignalTerminate, want: syscall.SIGTERM},
+		{input: RuntimeSignalKill, want: syscall.SIGKILL},
+	}
+	for _, tt := range tests {
+		got, err := boxliteRuntimeSignal(tt.input)
+		if err != nil {
+			t.Fatalf("boxliteRuntimeSignal(%q): %v", tt.input, err)
+		}
+		if got != int(tt.want) {
+			t.Fatalf("boxliteRuntimeSignal(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+	if _, err := boxliteRuntimeSignal("unknown"); err == nil {
+		t.Fatal("unknown signal accepted")
+	}
+}
+
+func TestBoxliteInteractionProjectsTTYOutputToStdout(t *testing.T) {
+	interaction := &boxliteCommandInteraction{
+		ctx:    context.Background(),
+		tty:    true,
+		output: make(chan RuntimeOutputFrame, 2),
+	}
+	interaction.emitChunk(ExecChunk{Text: "terminal", Stream: StdioStderr})
+	frame := <-interaction.output
+	if frame.Type != RuntimeOutputStdout || string(frame.Data) != "terminal" {
+		t.Fatalf("frame = %#v", frame)
+	}
+}

--- a/pkg/driver/boxlite_interaction_cgo_test.go
+++ b/pkg/driver/boxlite_interaction_cgo_test.go
@@ -5,10 +5,12 @@ package driver
 import (
 	"context"
 	"errors"
+	"io"
 	"math"
 	"reflect"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestBoxliteInteractionCapabilities(t *testing.T) {
@@ -90,13 +92,92 @@ func TestBoxliteRuntimeSignal(t *testing.T) {
 
 func TestBoxliteInteractionProjectsTTYOutputToStdout(t *testing.T) {
 	interaction := &boxliteCommandInteraction{
-		ctx:    context.Background(),
-		tty:    true,
-		output: make(chan RuntimeOutputFrame, 2),
+		ctx:         context.Background(),
+		tty:         true,
+		startedAt:   time.Now(),
+		output:      make(chan RuntimeOutputFrame, 2),
+		startupDone: make(chan struct{}),
+	}
+	interaction.startOutput()
+	if frame := <-interaction.output; frame.Type != RuntimeOutputStarted {
+		t.Fatalf("first frame = %#v, want started", frame)
 	}
 	interaction.emitChunk(ExecChunk{Text: "terminal", Stream: StdioStderr})
 	frame := <-interaction.output
 	if frame.Type != RuntimeOutputStdout || string(frame.Data) != "terminal" {
 		t.Fatalf("frame = %#v", frame)
+	}
+}
+
+func TestBoxliteInteractionStagesStartupOutputBehindStarted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	interaction := &boxliteCommandInteraction{
+		ctx:         ctx,
+		startedAt:   time.Now(),
+		output:      make(chan RuntimeOutputFrame, 64),
+		startupDone: make(chan struct{}),
+	}
+	for index := 0; index < 128; index++ {
+		interaction.emit(RuntimeOutputFrame{Type: RuntimeOutputStdout, Data: []byte{byte(index)}})
+	}
+
+	started := make(chan struct{})
+	go func() {
+		interaction.startOutput()
+		close(started)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("startOutput blocked before a receiver was available")
+	}
+
+	for index := -1; index < 128; index++ {
+		select {
+		case frame := <-interaction.output:
+			if index == -1 {
+				if frame.Type != RuntimeOutputStarted {
+					t.Fatalf("first frame = %#v, want started", frame)
+				}
+				continue
+			}
+			if frame.Type != RuntimeOutputStdout || len(frame.Data) != 1 || frame.Data[0] != byte(index) {
+				t.Fatalf("frame %d = %#v", index, frame)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out receiving frame %d", index)
+		}
+	}
+}
+
+func TestBoxliteInteractionCollectorDoesNotRetainStreamOutput(t *testing.T) {
+	var chunks []ExecChunk
+	collector := &cgoExecCollector{
+		streamOnly: true,
+		stream: func(chunk ExecChunk) {
+			chunks = append(chunks, chunk)
+		},
+	}
+	collector.writeBytes([]byte("stdout"), StdioStdout)
+	collector.writeBytes([]byte("stderr"), StdioStderr)
+	collector.finish()
+
+	if len(chunks) != 2 || chunks[0].Text != "stdout" || chunks[1].Text != "stderr" {
+		t.Fatalf("chunks = %#v", chunks)
+	}
+	if collector.output.Len() != 0 || collector.stdout.Len() != 0 || collector.stderr.Len() != 0 {
+		t.Fatalf("stream-only collector retained output: output=%d stdout=%d stderr=%d", collector.output.Len(), collector.stdout.Len(), collector.stderr.Len())
+	}
+}
+
+func TestBoxliteInteractionRejectsNativeInputAfterExecutionRelease(t *testing.T) {
+	interaction := &boxliteCommandInteraction{ctx: context.Background(), tty: true}
+
+	if err := interaction.resize(24, 80); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("resize error = %v, want %v", err, io.ErrClosedPipe)
+	}
+	if err := interaction.signal(RuntimeSignalInterrupt); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("signal error = %v, want %v", err, io.ErrClosedPipe)
 	}
 }

--- a/pkg/driver/boxlite_interaction_smoke_test.go
+++ b/pkg/driver/boxlite_interaction_smoke_test.go
@@ -1,0 +1,90 @@
+//go:build linux && cgo && boxlitecgo
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBoxliteCommandInteractionSmokeTTYStdinAndResize(t *testing.T) {
+	runtimeSmokeEnabled(t, RuntimeDriverBoxlite)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	config := newRuntimeSmokeConfig(t, RuntimeDriverBoxlite)
+	runtime, err := newSandboxRuntime(config)
+	if err != nil {
+		t.Fatalf("newSandboxRuntime() error = %v", err)
+	}
+	boxliteRuntime := runtime.(*cgoSandboxRuntime)
+	sandbox, vmState, proxyState := newRuntimeSmokeSandbox(t, ctx, config, RuntimeDriverBoxlite)
+	proxyState.Enabled = false
+	info, err := boxliteRuntime.EnsureSandbox(ctx, sandbox, vmState, proxyState)
+	if err != nil {
+		t.Fatalf("EnsureSandbox() error = %v", err)
+	}
+	vmState.BoxID = info.BoxID
+	cleanupRuntimeSmokeSandbox(t, config, boxliteRuntime, sandbox, vmState)
+
+	interaction, err := boxliteRuntime.OpenInteraction(ctx, sandbox, vmState, RuntimeStartSpec{
+		OperationID: "smoke-boxlite-it",
+		Kind:        RuntimeOperationCommand,
+		AttachStdin: true,
+		TTY:         true,
+		Rows:        24,
+		Cols:        80,
+		Command: &RuntimeCommandSpec{
+			Command: "sh",
+			Args:    []string{"-c", `printf 'ready>'; read value; printf 'received:%s\n' "$value"`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("OpenInteraction() error = %v", err)
+	}
+	if frame, err := interaction.Recv(); err != nil || frame.Type != RuntimeOutputStarted {
+		t.Fatalf("started frame = %#v, err=%v", frame, err)
+	}
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputResize, Rows: 40, Cols: 120}); err != nil {
+		t.Fatalf("Send(resize) error = %v", err)
+	}
+	if err := interaction.Send(RuntimeInputFrame{Type: RuntimeInputStdin, Data: []byte("hello boxlite\n")}); err != nil {
+		t.Fatalf("Send(stdin) error = %v", err)
+	}
+	if err := interaction.CloseSend(); err != nil {
+		t.Fatalf("CloseSend() error = %v", err)
+	}
+
+	var stdout strings.Builder
+	for {
+		frame, err := interaction.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv() error = %v", err)
+		}
+		switch frame.Type {
+		case RuntimeOutputStdout:
+			stdout.Write(frame.Data)
+		case RuntimeOutputStderr:
+			t.Fatalf("TTY output unexpectedly used stderr frame: %#v", frame)
+		case RuntimeOutputError:
+			t.Fatalf("unexpected error frame: %#v", frame)
+		}
+	}
+	result, err := interaction.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if !result.Success || result.ExitCode != 0 {
+		t.Fatalf("Wait() result = %#v", result)
+	}
+	if got := stdout.String(); !strings.Contains(got, "ready>") || !strings.Contains(got, "received:hello boxlite") {
+		t.Fatalf("stdout = %q, want interactive prompt and response", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add native BoxLite command interactions with bidirectional stdin/stdout streaming
- support stdin EOF, TTY allocation, terminal resize, signals, cancellation, exit status, and bounded output draining
- advertise BoxLite interaction capabilities so Docker, Microsandbox, and BoxLite all support command attach flows such as `run/exec -it`
- add focused capability and behavior tests, an opt-in real runtime smoke test, and update the bidirectional-stream design

## Testing

- `task prepare`
- `task lint`
- `task build`
- `env -u LLM_MODEL task test`
- `go test -tags boxlitecgo ./pkg/driver`
- `go test -race -tags boxlitecgo ./pkg/driver -run TestBoxlite`
- deployed `/data/src/git.in.chaitin.net/yongzhen.wang/agent-compose-sample/agents/boxlite-autonomous-dialog/agent-compose.yml` against an isolated daemon built from this branch
- attempted real `run/exec -it` validation in both native-host and privileged daemon-container topologies with `/dev/kvm`; BoxLite v0.9.7 failed before `OpenInteraction` because its shim could not load `libkrunfw.so.5` (`VM failed to start`, status `-2`), so no real guest stream result is claimed

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.