### PR TITLE
refactor(cli)!: remove unlisted compatibility entries

### DIFF
--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -155,3 +155,19 @@ func TestE2ECLILegacyRunIDFlagIsRejected(t *testing.T) {
 		}
 	}
 }
+
+func TestE2ECLIRemovedCompatibilityEntriesAreRejected(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"inspect", "session", "sandbox-1"}, want: "unsupported inspect target"},
+		{args: []string{"scheduler", "runs", "--agent", "reviewer"}, want: "unknown flag: --agent"},
+		{args: []string{"scheduler", "logs", "--agent", "reviewer"}, want: "unknown flag: --agent"},
+	} {
+		stdout, stderr, runCount, exitCode := executeCLICommand(tc.args...)
+		if exitCode != exitCodeUsage || stdout != "" || runCount != 0 || !strings.Contains(stderr, tc.want) {
+			t.Fatalf("%v code/stdout/stderr/runCount = %d / %q / %q / %d, want usage error containing %q", tc.args, exitCode, stdout, stderr, runCount, tc.want)
+		}
+	}
+}

--- a/cmd/agent-compose/cli_misc_helpers_test.go
+++ b/cmd/agent-compose/cli_misc_helpers_test.go
@@ -256,7 +256,7 @@ agents:
 			{args: []string{"inspect", "--file", composePath, "agent"}, code: exitCodeUsage, want: "requires an agent name"},
 			{args: []string{"inspect", "--file", composePath, "run"}, code: exitCodeUsage, want: "requires a run id"},
 			{args: []string{"inspect", "--file", composePath, "sandbox"}, code: exitCodeUsage, want: "requires a sandbox"},
-			{args: []string{"inspect", "--file", composePath, "session"}, code: exitCodeUsage, want: "requires a sandbox"},
+			{args: []string{"inspect", "--file", composePath, "session"}, code: exitCodeUsage, want: "unsupported inspect target"},
 			{args: []string{"inspect", "--file", composePath, "unknown"}, code: exitCodeUsage, want: "unsupported inspect target"},
 			{args: []string{"inspect", "--host", server.URL, "--file", composePath, "project"}, code: exitCodeUsage, want: "has not been started"},
 			{args: []string{"inspect", "--host", server.URL, "--file", composePath, "run", "missing"}, code: exitCodeUsage, want: "has not been started"},

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -527,12 +527,10 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect run requires a run id")}
 		case "sandbox":
 			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect sandbox requires a sandbox")}
-		case "session":
-			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect session requires a sandbox")}
 		}
 	}
 	switch kind {
-	case "project", "agent", "run", "sandbox", "session":
+	case "project", "agent", "run", "sandbox":
 	default:
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("unsupported inspect target %q", kind)}
 	}
@@ -574,22 +572,6 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 	case "sandbox":
 		if target == "" {
 			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect sandbox requires a sandbox")}
-		}
-		target, err = resolveComposeSandboxRefWithProject(cmd.Context(), clients, projectID, target)
-		if err != nil {
-			return err
-		}
-		output, err = composeSandboxInspectOutputFor(cmd.Context(), clients, target)
-		if err != nil {
-			return commandExitErrorForConnect(fmt.Errorf("inspect sandbox %s: %w", target, err))
-		}
-	case "session":
-
-		if err := writeDeprecatedWarning(cmd.ErrOrStderr(), "agent-compose inspect session", "agent-compose inspect sandbox"); err != nil {
-			return err
-		}
-		if target == "" {
-			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("inspect session requires a sandbox")}
 		}
 		target, err = resolveComposeSandboxRefWithProject(cmd.Context(), clients, projectID, target)
 		if err != nil {

--- a/cmd/agent-compose/cli_sandbox_integration_lifecycle_test.go
+++ b/cmd/agent-compose/cli_sandbox_integration_lifecycle_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -741,20 +740,7 @@ agents:
 	}
 
 	sessionOut, sessionErr, _, sessionCode := executeCLICommand("inspect", "--host", server.URL, "--file", composePath, "--json", "session", "session-inspect")
-	if sessionCode != 0 {
-		t.Fatalf("inspect session code = %d; stderr = %q", sessionCode, sessionErr)
-	}
-	if !strings.Contains(sessionErr, "deprecated") || !strings.Contains(sessionErr, "will be removed") || !strings.Contains(sessionErr, "agent-compose inspect sandbox") {
-		t.Fatalf("inspect session stderr missing deprecated warning: %q", sessionErr)
-	}
-	var sessionDecoded composeSandboxOutput
-	if err := json.Unmarshal([]byte(sessionOut), &sessionDecoded); err != nil {
-		t.Fatalf("inspect session JSON decode failed: %v\n%s", err, sessionOut)
-	}
-	if sessionDecoded.SandboxID != "session-inspect" || sessionDecoded.VMStatus != "running" || sessionDecoded.Tags["project"] == "" {
-		t.Fatalf("inspect session JSON = %#v", sessionDecoded)
-	}
-	if !reflect.DeepEqual(sessionDecoded, sandboxDecoded) {
-		t.Fatalf("inspect session alias JSON differs from sandbox JSON:\nsession=%#v\nsandbox=%#v", sessionDecoded, sandboxDecoded)
+	if sessionCode != exitCodeUsage || sessionOut != "" || !strings.Contains(sessionErr, `unsupported inspect target "session"`) {
+		t.Fatalf("inspect removed session target code/stdout/stderr = %d / %q / %q", sessionCode, sessionOut, sessionErr)
 	}
 }

--- a/cmd/agent-compose/cli_sandbox_workflows_e2e_test.go
+++ b/cmd/agent-compose/cli_sandbox_workflows_e2e_test.go
@@ -24,7 +24,7 @@ func TestE2ECLISandboxNamingUserWorkflows(t *testing.T) {
 			run:  TestIntegrationCLILogsFiltersRunAgentSessionAndJSON,
 		},
 		{
-			name: "inspect sandbox and deprecated inspect session",
+			name: "inspect sandbox and reject removed inspect session",
 			run:  TestIntegrationCLIInspectProjectAgentRunSandboxSessionJSON,
 		},
 		{

--- a/cmd/agent-compose/cli_scheduler_command.go
+++ b/cmd/agent-compose/cli_scheduler_command.go
@@ -25,10 +25,9 @@ type composeSchedulerTriggerOptions struct {
 }
 
 type composeSchedulerRunsOptions struct {
-	AgentName string
-	Trigger   string
-	Status    string
-	Limit     uint32
+	Trigger string
+	Status  string
+	Limit   uint32
 }
 
 type composeSchedulerInvokeOptions struct {
@@ -37,7 +36,6 @@ type composeSchedulerInvokeOptions struct {
 
 type composeSchedulerLogsOptions struct {
 	SchedulerRef string
-	AgentName    string
 	Trigger      string
 	RunID        string
 	Tail         int
@@ -52,9 +50,6 @@ func runComposeSchedulerTriggerCommand(cmd *cobra.Command, cli cliOptions, optio
 }
 
 func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerRunsOptions, args []string) error {
-	if err := writeDeprecatedSchedulerAgentFlagWarning(cmd, "use the scheduler positional argument instead"); err != nil {
-		return err
-	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
@@ -65,11 +60,8 @@ func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options 
 	}
 	normalized := runtimeProject.spec
 	projectID := runtimeProject.id()
-	agentRef := options.AgentName
+	agentRef := ""
 	if len(args) > 0 {
-		if agentRef != "" {
-			return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler runs accepts either a scheduler argument or --agent, not both")}
-		}
 		agentRef = args[0]
 	}
 	if cli.JSON {
@@ -91,9 +83,6 @@ func runComposeSchedulerRunsCommand(cmd *cobra.Command, cli cliOptions, options 
 }
 
 func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerLogsOptions, args []string) error {
-	if err := writeDeprecatedSchedulerAgentFlagWarning(cmd, "use --scheduler instead"); err != nil {
-		return err
-	}
 	clients, err := newCLIServiceClients(cli)
 	if err != nil {
 		return err
@@ -115,12 +104,6 @@ func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options 
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs --tail must be -1 or greater")}
 	}
 	schedulerRef := strings.TrimSpace(options.SchedulerRef)
-	if schedulerRef != "" && strings.TrimSpace(options.AgentName) != "" {
-		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs accepts either --scheduler or deprecated --agent, not both")}
-	}
-	if schedulerRef == "" {
-		schedulerRef = strings.TrimSpace(options.AgentName)
-	}
 	if runRef != "" && (schedulerRef != "" || strings.TrimSpace(options.Trigger) != "") {
 		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("scheduler logs run filters cannot be combined with --scheduler or --trigger")}
 	}
@@ -172,14 +155,6 @@ func runComposeSchedulerLogsCommand(cmd *cobra.Command, cli cliOptions, options 
 		return err
 	}
 	return nil
-}
-
-func writeDeprecatedSchedulerAgentFlagWarning(cmd *cobra.Command, guidance string) error {
-	if !cmd.Flags().Changed("agent") {
-		return nil
-	}
-	_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Warning: --agent is deprecated; %s\n", guidance)
-	return err
 }
 
 func runComposeSchedulerInspectCommand(cmd *cobra.Command, cli cliOptions, options composeSchedulerInspectOptions, rawRef string) error {

--- a/cmd/agent-compose/cli_scheduler_definition.go
+++ b/cmd/agent-compose/cli_scheduler_definition.go
@@ -50,8 +50,6 @@ func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 			return runComposeSchedulerRunsCommand(cmd, *cli, runsOptions, args)
 		},
 	}
-	runsCmd.Flags().StringVar(&runsOptions.AgentName, "agent", "", "Filter by scheduler owner (deprecated)")
-	_ = runsCmd.Flags().MarkHidden("agent")
 	runsCmd.Flags().StringVar(&runsOptions.Trigger, "trigger", "", "Filter by trigger name or id")
 	runsCmd.Flags().StringVar(&runsOptions.Status, "status", "", "Filter by run status")
 	runsCmd.Flags().Uint32Var(&runsOptions.Limit, "limit", 0, "Maximum runs to show; 0 means all")
@@ -65,8 +63,6 @@ func newCLISchedulerCommand(cli *cliOptions) *cobra.Command {
 		},
 	}
 	logsCmd.Flags().StringVar(&logsOptions.SchedulerRef, "scheduler", "", "Filter by scheduler name or ID")
-	logsCmd.Flags().StringVar(&logsOptions.AgentName, "agent", "", "Filter by scheduler owner (deprecated)")
-	_ = logsCmd.Flags().MarkHidden("agent")
 	logsCmd.Flags().StringVar(&logsOptions.Trigger, "trigger", "", "Filter by trigger name or id")
 	logsCmd.Flags().StringVar(&logsOptions.RunID, "run", "", "Filter by scheduler run id")
 	logsCmd.Flags().IntVarP(&logsOptions.Tail, "tail", "n", -1, "Show the last N log events")

--- a/cmd/agent-compose/cli_scheduler_test.go
+++ b/cmd/agent-compose/cli_scheduler_test.go
@@ -407,23 +407,6 @@ func TestNormalizeComposeSchedulerTriggerOptionsPayload(t *testing.T) {
 	}
 }
 
-func TestDeprecatedSchedulerAgentFlagWarningUsesStderr(t *testing.T) {
-	cmd := &cobra.Command{}
-	cmd.Flags().String("agent", "", "")
-	if err := cmd.Flags().Set("agent", "reviewer"); err != nil {
-		t.Fatalf("Set agent flag returned error: %v", err)
-	}
-	var stdout, stderr strings.Builder
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
-	if err := writeDeprecatedSchedulerAgentFlagWarning(cmd, "use --scheduler instead"); err != nil {
-		t.Fatalf("writeDeprecatedSchedulerAgentFlagWarning returned error: %v", err)
-	}
-	if stdout.String() != "" || !strings.Contains(stderr.String(), "--agent is deprecated") || !strings.Contains(stderr.String(), "use --scheduler instead") {
-		t.Fatalf("stdout/stderr = %q / %q", stdout.String(), stderr.String())
-	}
-}
-
 func TestIntegrationCLISchedulerRunsLogsAndInspectResources(t *testing.T) {
 	composePath := writeComposeFile(t, t.TempDir(), `
 name: cli-scheduler-observability
@@ -537,7 +520,7 @@ agents:
 		t.Fatalf("scheduler logs invalid tail code/stderr = %d / %q", exitCode, stderr)
 	}
 
-	_, stderr, _, exitCode = executeCLICommand("scheduler", "logs", runID, "--agent", "reviewer", "--host", server.URL, "--file", composePath)
+	_, stderr, _, exitCode = executeCLICommand("scheduler", "logs", runID, "--scheduler", "reviewer", "--host", server.URL, "--file", composePath)
 	if exitCode != exitCodeUsage || !strings.Contains(stderr, "cannot be combined") {
 		t.Fatalf("scheduler logs explicit run filters code/stderr = %d / %q", exitCode, stderr)
 	}

--- a/docs/design/agent-compose_design.md
+++ b/docs/design/agent-compose_design.md
@@ -135,7 +135,6 @@ Current main commands:
   to list, inspect, dry-run, and explicitly remove daemon runtime cache items.
   The CLI never reads or deletes daemon cache paths directly.
 - `inspect <project|agent|run|sandbox>`: inspect project-related objects.
-  `inspect session` remains a deprecated compatibility alias.
 
 ## `agent-compose.yml` Model
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `inspect session` compatibility target; use `inspect sandbox` instead.
- Remove the hidden deprecated `--agent` filters from `scheduler runs` and `scheduler logs`; use the scheduler positional argument and `--scheduler` respectively.
- Keep all documented compatibility commands and flags unchanged, including `exec --run` and the `image ls`, `image pull`, `image rm`, and `image inspect` command forms.
- Add regression coverage that verifies only the removed, unlisted compatibility entries are rejected before RPC execution.

These three entries are absent from both the `origin/main` CLI manuals and the published Chinese command-line manual. Related to #409.

## Testing

- `go test ./cmd/agent-compose`
- `task lint`
- `task build`
- `env -u LLM_MODEL task test`

## Checklist

- [x] Scope is limited to compatibility entries absent from the official CLI manuals.
- [x] Documented deprecated commands and flags remain supported.
- [x] Tests cover rejection before daemon/RPC execution.
- [x] No secrets or local runtime state included.