### PR TITLE
fix(config): sync env default LLM providers

### DIFF
--- a/pkg/agentcompose/api/config.go
+++ b/pkg/agentcompose/api/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/workspaces"
 )
@@ -23,7 +24,7 @@ func workspaceContentError(err error) error {
 
 type ConfigStore interface {
 	ListGlobalEnv(ctx context.Context) ([]domain.SandboxEnvVar, error)
-	ReplaceGlobalEnv(ctx context.Context, items []domain.SandboxEnvVar) ([]domain.SandboxEnvVar, error)
+	ReplaceGlobalEnvWithProviderCredentials(ctx context.Context, items []domain.SandboxEnvVar, credentials llms.EnvDefaultProviderCredentials) ([]domain.SandboxEnvVar, error)
 	ListWorkspaceConfigs(ctx context.Context) ([]domain.WorkspaceConfig, error)
 	GetWorkspaceConfig(ctx context.Context, id string) (domain.WorkspaceConfig, error)
 	CreateWorkspaceConfig(ctx context.Context, item domain.WorkspaceConfig) (domain.WorkspaceConfig, error)

--- a/pkg/agentcompose/api/settings_v2.go
+++ b/pkg/agentcompose/api/settings_v2.go
@@ -4,23 +4,26 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
 type SettingsV2Handler struct {
+	config     *appconfig.Config
 	store      ConfigStore
 	workspaces *workspaceSettings
 }
 
 func NewSettingsV2Handler(config *appconfig.Config, store ConfigStore) *SettingsV2Handler {
-	return &SettingsV2Handler{store: store, workspaces: newWorkspaceSettings(config, store)}
+	return &SettingsV2Handler{config: config, store: store, workspaces: newWorkspaceSettings(config, store)}
 }
 
 func (h *SettingsV2Handler) GetGlobalEnv(ctx context.Context, _ *connect.Request[agentcomposev2.GetGlobalEnvRequest]) (*connect.Response[agentcomposev2.GetGlobalEnvResponse], error) {
@@ -35,11 +38,32 @@ func (h *SettingsV2Handler) UpdateGlobalEnv(ctx context.Context, req *connect.Re
 	if err != nil {
 		return nil, err
 	}
-	saved, err := h.store.ReplaceGlobalEnv(ctx, items)
+	saved, err := h.store.ReplaceGlobalEnvWithProviderCredentials(ctx, items, h.resolveEnvDefaultProviderCredentials(items))
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&agentcomposev2.UpdateGlobalEnvResponse{Env: envToV2(saved)}), nil
+}
+
+func (h *SettingsV2Handler) resolveEnvDefaultProviderCredentials(items []domain.SandboxEnvVar) llms.EnvDefaultProviderCredentials {
+	process := processLLMEnvItems()
+	config := []domain.SandboxEnvVar{}
+	if h.config != nil {
+		config = append(config, domain.SandboxEnvVar{Name: "LLM_API_KEY", Value: h.config.LLMAPIKey})
+	}
+	layers := [][]domain.SandboxEnvVar{items, process, config}
+	return llms.ResolveEnvDefaultProviderCredentialsFromLayers(layers...)
+}
+
+func processLLMEnvItems() []domain.SandboxEnvVar {
+	keys := []string{"LLM_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"}
+	items := make([]domain.SandboxEnvVar, 0, len(keys))
+	for _, key := range keys {
+		if value, ok := os.LookupEnv(key); ok {
+			items = append(items, domain.SandboxEnvVar{Name: key, Value: value})
+		}
+	}
+	return items
 }
 
 func (h *SettingsV2Handler) globalEnvUpdates(ctx context.Context, updates []*agentcomposev2.EnvVarUpdateSpec) ([]domain.SandboxEnvVar, error) {

--- a/pkg/agentcompose/api/settings_v2_test.go
+++ b/pkg/agentcompose/api/settings_v2_test.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 
 	appconfig "agent-compose/pkg/config"
+	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
@@ -70,7 +71,10 @@ func TestSettingsGlobalEnvEmptyAndOmittedEntriesReplaceCollection(t *testing.T) 
 	}
 }
 
-type settingsStoreFake struct{ env []domain.SandboxEnvVar }
+type settingsStoreFake struct {
+	env         []domain.SandboxEnvVar
+	credentials llms.EnvDefaultProviderCredentials
+}
 
 func (s *settingsStoreFake) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
 	return append([]domain.SandboxEnvVar(nil), s.env...), nil
@@ -78,6 +82,10 @@ func (s *settingsStoreFake) ListGlobalEnv(context.Context) ([]domain.SandboxEnvV
 func (s *settingsStoreFake) ReplaceGlobalEnv(_ context.Context, items []domain.SandboxEnvVar) ([]domain.SandboxEnvVar, error) {
 	s.env = append([]domain.SandboxEnvVar(nil), items...)
 	return s.env, nil
+}
+func (s *settingsStoreFake) ReplaceGlobalEnvWithProviderCredentials(ctx context.Context, items []domain.SandboxEnvVar, credentials llms.EnvDefaultProviderCredentials) ([]domain.SandboxEnvVar, error) {
+	s.credentials = credentials
+	return s.ReplaceGlobalEnv(ctx, items)
 }
 func (*settingsStoreFake) ListWorkspaceConfigs(context.Context) ([]domain.WorkspaceConfig, error) {
 	return nil, nil
@@ -97,4 +105,81 @@ func (*settingsStoreFake) GetCapabilityGateway(context.Context) (domain.Capabili
 }
 func (*settingsStoreFake) SaveCapabilityGateway(_ context.Context, item domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
 	return item, nil
+}
+
+func TestSettingsGlobalEnvProviderCredentialsFallBackToProcessEnvAndConfig(t *testing.T) {
+	t.Setenv("LLM_API_KEY", "process-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "process-token")
+	handler := NewSettingsV2Handler(&appconfig.Config{LLMAPIKey: "config-key"}, &settingsStoreFake{})
+	credentials := handler.resolveEnvDefaultProviderCredentials(nil)
+	if credentials.OpenAIAPIKey != "process-key" {
+		t.Fatalf("OpenAI fallback key = %q, want process-key", credentials.OpenAIAPIKey)
+	}
+	if credentials.AnthropicAPIKey != "process-token" || credentials.AnthropicAuthHeader != "Authorization" || credentials.AnthropicAuthScheme != "Bearer" {
+		t.Fatalf("Anthropic fallback credentials = %#v", credentials)
+	}
+
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	credentials = handler.resolveEnvDefaultProviderCredentials(nil)
+	if credentials.OpenAIAPIKey != "config-key" {
+		t.Fatalf("config fallback key = %q, want config-key", credentials.OpenAIAPIKey)
+	}
+}
+
+func TestSettingsGlobalEnvEmptyCredentialFallsBack(t *testing.T) {
+	t.Setenv("LLM_API_KEY", "process-key")
+	handler := NewSettingsV2Handler(&appconfig.Config{LLMAPIKey: "config-key"}, &settingsStoreFake{})
+	credentials := handler.resolveEnvDefaultProviderCredentials([]domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: ""}})
+	if credentials.OpenAIAPIKey != "process-key" {
+		t.Fatalf("empty credential fallback = %q, want process-key", credentials.OpenAIAPIKey)
+	}
+}
+
+func TestSettingsGlobalEnvEmptyAnthropicCredentialFallsBackToAuthToken(t *testing.T) {
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "process-token")
+	handler := NewSettingsV2Handler(&appconfig.Config{}, &settingsStoreFake{})
+	credentials := handler.resolveEnvDefaultProviderCredentials([]domain.SandboxEnvVar{{Name: "ANTHROPIC_API_KEY", Value: ""}})
+	if credentials.AnthropicAPIKey != "process-token" || credentials.AnthropicAuthHeader != "Authorization" || credentials.AnthropicAuthScheme != "Bearer" {
+		t.Fatalf("empty Anthropic credential fallback = %#v", credentials)
+	}
+}
+
+func TestSettingsGlobalEnvCredentialsFallBackIndependentlyByFamily(t *testing.T) {
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "process-anthropic")
+	t.Setenv("LLM_API_KEY", "process-generic")
+	handler := NewSettingsV2Handler(&appconfig.Config{}, &settingsStoreFake{})
+	credentials := handler.resolveEnvDefaultProviderCredentials([]domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "global-openai"}})
+	if credentials.OpenAIAPIKey != "global-openai" {
+		t.Fatalf("OpenAI credentials = %q, want global-openai", credentials.OpenAIAPIKey)
+	}
+	if credentials.AnthropicAPIKey != "process-anthropic" || credentials.AnthropicAuthHeader != "Authorization" || credentials.AnthropicAuthScheme != "Bearer" {
+		t.Fatalf("Anthropic credentials = %#v", credentials)
+	}
+
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	credentials = handler.resolveEnvDefaultProviderCredentials([]domain.SandboxEnvVar{{Name: "ANTHROPIC_API_KEY", Value: "global-anthropic"}})
+	if credentials.AnthropicAPIKey != "global-anthropic" || credentials.OpenAIAPIKey != "process-generic" {
+		t.Fatalf("reverse family credentials = %#v", credentials)
+	}
+}
+
+func TestSettingsUpdateGlobalEnvPassesEffectiveFallbackToStore(t *testing.T) {
+	t.Setenv("LLM_API_KEY", "process-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "process-token")
+	store := &settingsStoreFake{env: []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "old-key", Secret: true}}}
+	handler := NewSettingsV2Handler(&appconfig.Config{LLMAPIKey: "config-key"}, store)
+
+	if _, err := handler.UpdateGlobalEnv(context.Background(), connect.NewRequest(&agentcomposev2.UpdateGlobalEnvRequest{})); err != nil {
+		t.Fatalf("clear global environment: %v", err)
+	}
+	if len(store.env) != 0 {
+		t.Fatalf("saved environment = %#v, want empty", store.env)
+	}
+	if store.credentials.OpenAIAPIKey != "process-key" {
+		t.Errorf("persisted OpenAI fallback = %q, want process-key", store.credentials.OpenAIAPIKey)
+	}
+	if store.credentials.AnthropicAPIKey != "process-token" || store.credentials.AnthropicAuthHeader != "Authorization" || store.credentials.AnthropicAuthScheme != "Bearer" {
+		t.Errorf("persisted Anthropic fallback = %#v", store.credentials)
+	}
 }

--- a/pkg/llms/provider_bootstrap.go
+++ b/pkg/llms/provider_bootstrap.go
@@ -141,15 +141,3 @@ func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, l
 	}
 	return ensureAnthropicEnvProvider(ctx, store, lookup, credential, providerID, name, scope, requestedModel, defaultModel)
 }
-
-// AnthropicProviderAuthFromLookup derives Anthropic authentication semantics
-// from a lookup whose values belong to one already-selected source layer.
-func AnthropicProviderAuthFromLookup(lookup EnvProviderLookup) (string, string) {
-	if strings.TrimSpace(lookup("ANTHROPIC_API_KEY")) != "" {
-		return "x-api-key", ""
-	}
-	if strings.TrimSpace(lookup("ANTHROPIC_AUTH_TOKEN")) != "" {
-		return "Authorization", "Bearer"
-	}
-	return "x-api-key", ""
-}

--- a/pkg/llms/provider_reconcile.go
+++ b/pkg/llms/provider_reconcile.go
@@ -1,0 +1,55 @@
+package llms
+
+import (
+	domain "agent-compose/pkg/model"
+)
+
+// EnvDefaultProviderCredentials contains credentials derived from global
+// environment values for the automatically managed default providers.
+type EnvDefaultProviderCredentials struct {
+	OpenAIAPIKey        string
+	AnthropicAPIKey     string
+	AnthropicAuthHeader string
+	AnthropicAuthScheme string
+}
+
+// ResolveEnvDefaultProviderCredentials applies the same credential precedence
+// used by environment-provider bootstrap.
+func ResolveEnvDefaultProviderCredentials(items []domain.SandboxEnvVar) EnvDefaultProviderCredentials {
+	return ResolveEnvDefaultProviderCredentialsFromLayers(items)
+}
+
+// ResolveEnvDefaultProviderCredentialsFromLayers resolves credentials from
+// layers in precedence order. Each layer is exhausted before the next layer is
+// considered, preserving the bootstrap source-major precedence.
+func ResolveEnvDefaultProviderCredentialsFromLayers(layers ...[]domain.SandboxEnvVar) EnvDefaultProviderCredentials {
+	openAIKey := resolveFamilyAPIKey(layers, "LLM_API_KEY", "OPENAI_API_KEY")
+	anthropic := resolveFamilyAnthropicCredential(layers)
+	return EnvDefaultProviderCredentials{OpenAIAPIKey: openAIKey, AnthropicAPIKey: anthropic.apiKey, AnthropicAuthHeader: anthropic.authHeader, AnthropicAuthScheme: anthropic.authScheme}
+}
+
+func resolveFamilyAPIKey(layers [][]domain.SandboxEnvVar, keys ...string) string {
+	for _, layer := range layers {
+		if value := firstNonEmptyTrimmed(envValues(layer, keys...)...); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func resolveFamilyAnthropicCredential(layers [][]domain.SandboxEnvVar) anthropicCredential {
+	for _, layer := range layers {
+		if credential, ok := anthropicCredentialFromItems(layer); ok {
+			return credential
+		}
+	}
+	return anthropicCredential{authHeader: "x-api-key"}
+}
+
+func envValues(items []domain.SandboxEnvVar, keys ...string) []string {
+	values := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, EnvItemValue(items, key))
+	}
+	return values
+}

--- a/pkg/llms/provider_reconcile_test.go
+++ b/pkg/llms/provider_reconcile_test.go
@@ -1,0 +1,20 @@
+package llms
+
+import (
+	"testing"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestResolveEnvDefaultProviderCredentialsFromLayersResolvesFamiliesIndependently(t *testing.T) {
+	credentials := ResolveEnvDefaultProviderCredentialsFromLayers(
+		[]domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "global-openai"}},
+		[]domain.SandboxEnvVar{{Name: "ANTHROPIC_AUTH_TOKEN", Value: "process-anthropic"}, {Name: "LLM_API_KEY", Value: "process-generic"}},
+	)
+	if credentials.OpenAIAPIKey != "global-openai" {
+		t.Fatalf("OpenAI key = %q, want global-openai", credentials.OpenAIAPIKey)
+	}
+	if credentials.AnthropicAPIKey != "process-anthropic" || credentials.AnthropicAuthHeader != "Authorization" || credentials.AnthropicAuthScheme != "Bearer" {
+		t.Fatalf("Anthropic credentials = %#v", credentials)
+	}
+}

--- a/pkg/storage/configstore/core_store.go
+++ b/pkg/storage/configstore/core_store.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"agent-compose/pkg/llms"
 	domain "agent-compose/pkg/model"
 )
 
@@ -96,6 +97,15 @@ func (s *coreStore) ListGlobalEnv(ctx context.Context) ([]domain.SandboxEnvVar, 
 }
 
 func (s *coreStore) ReplaceGlobalEnv(ctx context.Context, items []domain.SandboxEnvVar) ([]domain.SandboxEnvVar, error) {
+	credentials := llms.ResolveEnvDefaultProviderCredentials(items)
+	return s.replaceGlobalEnv(ctx, items, &credentials)
+}
+
+func (s *coreStore) ReplaceGlobalEnvWithProviderCredentials(ctx context.Context, items []domain.SandboxEnvVar, credentials llms.EnvDefaultProviderCredentials) ([]domain.SandboxEnvVar, error) {
+	return s.replaceGlobalEnv(ctx, items, &credentials)
+}
+
+func (s *coreStore) replaceGlobalEnv(ctx context.Context, items []domain.SandboxEnvVar, credentials *llms.EnvDefaultProviderCredentials) ([]domain.SandboxEnvVar, error) {
 	normalized := domain.NormalizeEnvItems(items)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -110,6 +120,9 @@ func (s *coreStore) ReplaceGlobalEnv(ctx context.Context, items []domain.Sandbox
 		if _, err := tx.ExecContext(ctx, `INSERT INTO global_env(name, value, secret, updated_at) VALUES(?, ?, ?, ?)`, item.Name, item.Value, BoolToInt(item.Secret), time.Now().UTC().Unix()); err != nil {
 			return nil, fmt.Errorf("insert global env %s: %w", item.Name, err)
 		}
+	}
+	if err := syncEnvDefaultProviderCredentials(ctx, tx, credentials); err != nil {
+		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit global env tx: %w", err)

--- a/pkg/storage/configstore/global_env_llm_sync_test.go
+++ b/pkg/storage/configstore/global_env_llm_sync_test.go
@@ -1,0 +1,162 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	"agent-compose/pkg/llms"
+	domain "agent-compose/pkg/model"
+)
+
+func TestReplaceGlobalEnvSyncsEnvironmentDefaultProviders(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+
+	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{
+		{Name: "LLM_API_KEY", Value: "old-openai", Secret: true},
+		{Name: "ANTHROPIC_API_KEY", Value: "old-anthropic", Secret: true},
+	}); err != nil {
+		t.Fatalf("seed global env: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID: "default", Name: "default", ProviderType: llms.ProviderFamilyOpenAI,
+		APIKey: "old-openai", Scope: llms.ProviderScopeEnvDefault, Enabled: true,
+	}, llms.Model{ID: "openai-model", Name: "openai-model", Scope: llms.ProviderScopeEnvDefault, Enabled: true}); err != nil {
+		t.Fatalf("seed OpenAI provider: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID: "custom-openai", Name: "custom-openai", ProviderType: llms.ProviderFamilyOpenAI,
+		APIKey: "old-openai", Scope: llms.ProviderScopeEnvDefault, Enabled: true,
+	}, llms.Model{ID: "custom-openai-model", Name: "custom-openai-model", Scope: llms.ProviderScopeEnvDefault, Enabled: true}); err != nil {
+		t.Fatalf("seed custom OpenAI provider: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID: "anthropic", Name: "anthropic", ProviderType: llms.ProviderFamilyAnthropic,
+		APIKey: "old-anthropic", AuthHeader: "x-api-key", Scope: llms.ProviderScopeEnvDefault, Enabled: true,
+	}, llms.Model{ID: "anthropic-model", Name: "anthropic-model", Scope: llms.ProviderScopeEnvDefault, Enabled: true}); err != nil {
+		t.Fatalf("seed Anthropic provider: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID: "system-provider", Name: "system-provider", ProviderType: llms.ProviderFamilyAnthropic,
+		APIKey: "system-key", AuthHeader: "x-api-key", Scope: llms.ProviderScopeSystem, Enabled: true,
+	}, llms.Model{ID: "system-model", Name: "system-model", Scope: llms.ProviderScopeSystem, Enabled: true}); err != nil {
+		t.Fatalf("seed system provider: %v", err)
+	}
+
+	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{
+		{Name: "LLM_API_KEY", Value: "new-openai", Secret: true},
+		{Name: "ANTHROPIC_AUTH_TOKEN", Value: "new-anthropic", Secret: true},
+	}); err != nil {
+		t.Fatalf("update global env: %v", err)
+	}
+
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("list providers: %v", err)
+	}
+	byID := make(map[string]llms.Provider, len(providers))
+	for _, provider := range providers {
+		byID[provider.ID] = provider
+	}
+	if got := byID["default"].APIKey; got != "new-openai" {
+		t.Errorf("default provider key = %q, want new-openai", got)
+	}
+	if got := byID["custom-openai"].APIKey; got != "new-openai" {
+		t.Errorf("custom OpenAI provider key = %q, want new-openai", got)
+	}
+	anthropic := byID["anthropic"]
+	if anthropic.APIKey != "new-anthropic" || anthropic.AuthHeader != "Authorization" || anthropic.AuthScheme != "Bearer" {
+		t.Errorf("anthropic credentials = %#v", anthropic)
+	}
+	if got := byID["system-provider"].APIKey; got != "system-key" {
+		t.Errorf("system provider key = %q, want system-key", got)
+	}
+}
+
+func TestReplaceGlobalEnvClearsRemovedEnvironmentDefaultCredential(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{{Name: "ANTHROPIC_API_KEY", Value: "old", Secret: true}}); err != nil {
+		t.Fatalf("seed global env: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID: "anthropic", Name: "anthropic", ProviderType: llms.ProviderFamilyAnthropic,
+		APIKey: "old", AuthHeader: "x-api-key", Scope: llms.ProviderScopeEnvDefault, Enabled: true,
+	}, llms.Model{ID: "model", Name: "model", Scope: llms.ProviderScopeEnvDefault, Enabled: true}); err != nil {
+		t.Fatalf("seed provider: %v", err)
+	}
+	if _, err := store.ReplaceGlobalEnv(ctx, nil); err != nil {
+		t.Fatalf("clear global env: %v", err)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("list providers: %v", err)
+	}
+	if len(providers) != 1 || providers[0].APIKey != "" {
+		t.Fatalf("providers after clear = %#v", providers)
+	}
+}
+
+func TestReplaceGlobalEnvWithProviderCredentialsUsesEffectiveFallback(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.ReplaceGlobalEnv(ctx, []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "global-key", Secret: true}}); err != nil {
+		t.Fatalf("seed global env: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID: "default", Name: "default", ProviderType: llms.ProviderFamilyOpenAI,
+		APIKey: "global-key", Scope: llms.ProviderScopeEnvDefault, Enabled: true,
+	}, llms.Model{ID: "model", Name: "model", Scope: llms.ProviderScopeEnvDefault, Enabled: true}); err != nil {
+		t.Fatalf("seed provider: %v", err)
+	}
+	if _, err := store.ReplaceGlobalEnvWithProviderCredentials(ctx, nil, llms.EnvDefaultProviderCredentials{OpenAIAPIKey: "process-key"}); err != nil {
+		t.Fatalf("replace global env with fallback credentials: %v", err)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("list providers: %v", err)
+	}
+	if len(providers) != 1 || providers[0].APIKey != "process-key" {
+		t.Fatalf("providers after fallback = %#v", providers)
+	}
+}
+
+func TestReplaceGlobalEnvRepairsStaleProviderWithUnchangedGlobalCredential(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	items := []domain.SandboxEnvVar{{Name: "LLM_API_KEY", Value: "current-key", Secret: true}}
+	if _, err := store.ReplaceGlobalEnv(ctx, items); err != nil {
+		t.Fatalf("seed global env: %v", err)
+	}
+	if err := store.UpsertDefaultLLMConfig(ctx, llms.Provider{
+		ID: "default", Name: "default", ProviderType: llms.ProviderFamilyOpenAI,
+		APIKey: "stale-key", Scope: llms.ProviderScopeEnvDefault, Enabled: true,
+	}, llms.Model{ID: "model", Name: "model", Scope: llms.ProviderScopeEnvDefault, Enabled: true}); err != nil {
+		t.Fatalf("seed stale provider: %v", err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `UPDATE llm_provider SET updated_at = 1 WHERE id = 'default'`); err != nil {
+		t.Fatalf("set stale provider timestamp: %v", err)
+	}
+	if _, err := store.ReplaceGlobalEnv(ctx, items); err != nil {
+		t.Fatalf("replace unchanged global env: %v", err)
+	}
+	providers, err := store.ListEnabledLLMProviders(ctx)
+	if err != nil {
+		t.Fatalf("list providers: %v", err)
+	}
+	if len(providers) != 1 || providers[0].APIKey != "current-key" || providers[0].UpdatedAt.Unix() <= 1 {
+		t.Fatalf("repaired provider = %#v", providers)
+	}
+}

--- a/pkg/storage/configstore/global_env_provider_sync.go
+++ b/pkg/storage/configstore/global_env_provider_sync.go
@@ -1,0 +1,24 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"agent-compose/pkg/llms"
+)
+
+func syncEnvDefaultProviderCredentials(ctx context.Context, tx *sql.Tx, resolved *llms.EnvDefaultProviderCredentials) error {
+	if resolved == nil {
+		return nil
+	}
+	now := time.Now().UTC().Unix()
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_provider SET api_key = ?, updated_at = ? WHERE provider_type = ? AND scope = ? AND api_key != ?`, resolved.OpenAIAPIKey, now, llms.ProviderFamilyOpenAI, llms.ProviderScopeEnvDefault, resolved.OpenAIAPIKey); err != nil {
+		return fmt.Errorf("sync default OpenAI provider credentials: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE llm_provider SET api_key = ?, auth_header = ?, auth_scheme = ?, updated_at = ? WHERE provider_type = ? AND scope = ? AND (api_key != ? OR auth_header != ? OR auth_scheme != ?)`, resolved.AnthropicAPIKey, resolved.AnthropicAuthHeader, resolved.AnthropicAuthScheme, now, llms.ProviderFamilyAnthropic, llms.ProviderScopeEnvDefault, resolved.AnthropicAPIKey, resolved.AnthropicAuthHeader, resolved.AnthropicAuthScheme); err != nil {
+		return fmt.Errorf("sync default Anthropic provider credentials: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- fix stale persisted credentials after `SettingsService.UpdateGlobalEnv` changes the global environment
- resolve OpenAI and Anthropic credentials independently using the existing `global_env → process environment → daemon config` precedence
- reconcile all enabled `env_default` providers in the matching provider family, including custom environment-managed provider IDs
- keep `system` and `session_env` providers unchanged
- update the global environment and managed provider credentials atomically in one SQLite transaction
- preserve Anthropic API-key and auth-token header semantics

An `env_default` provider is environment-managed by definition. Therefore, when its provider family is reconciled, all enabled `env_default` providers in that family receive the same effective environment credential. A custom provider that intentionally requires an independent credential should use a different scope rather than `env_default`.

## Testing

- `go test ./...`
- `go vet ./pkg/llms ./pkg/storage/configstore ./pkg/agentcompose/api`
- `git diff --check`
- reproduced the stale persisted-provider credential behavior on the base branch
- verified the same daemon/API/SQLite flow on this branch updates persisted provider credentials
- verified authenticated OpenAI-compatible and Anthropic-compatible requests using the updated credentials
- verified custom `env_default` providers are reconciled
- verified `system` and `session_env` providers remain unchanged
- verified removing global credentials falls back to the next configured source

## Checklist

- [x] Documentation updated when behavior or configuration changed. No documentation change is required because this restores the existing environment-provider behavior and does not add configuration or API surface.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
