### PR TITLE
fix(deploy): mount sandboxes in web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ AGENT_COMPOSE_HTTP_PORT=80
 AGENT_COMPOSE_DATA_DIR=./data
 # Separate host directory for the UI server database and UI-side state. Use an
 # absolute path when the UI data should live outside the daemon deployment dir.
+# The UI also reads <AGENT_COMPOSE_DATA_DIR>/sandboxes through a separate
+# read-only mount so it can display Codex and Claude agent records.
 AGENT_COMPOSE_UI_DATA_DIR=./data/agent-compose-ui
 
 # ---------------------------------------------------------------------------

--- a/cmd/agent-compose/compose_env_e2e_test.go
+++ b/cmd/agent-compose/compose_env_e2e_test.go
@@ -68,9 +68,6 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 	if !stringSliceContains(frontend.Volumes, "${AGENT_COMPOSE_DATA_DIR:-./data}/sandboxes:/data/sandboxes:ro") {
 		t.Fatalf("agent-compose-ui volumes = %#v, want read-only daemon sandbox mount", frontend.Volumes)
 	}
-	if frontend.Environment["SANDBOX_ROOT"] != "/data/sandboxes" {
-		t.Fatalf("agent-compose-ui SANDBOX_ROOT = %q, want /data/sandboxes", frontend.Environment["SANDBOX_ROOT"])
-	}
 
 	for _, want := range []string{
 		"AGENT_COMPOSE_DATA_DIR=./data",

--- a/cmd/agent-compose/compose_env_e2e_test.go
+++ b/cmd/agent-compose/compose_env_e2e_test.go
@@ -65,6 +65,12 @@ func TestE2EDockerComposeSandboxEnvContract(t *testing.T) {
 	if !stringSliceContains(frontend.Volumes, "${AGENT_COMPOSE_UI_DATA_DIR:-./data/agent-compose-ui}:/data") {
 		t.Fatalf("agent-compose-ui volumes = %#v, want persistent UI data mount", frontend.Volumes)
 	}
+	if !stringSliceContains(frontend.Volumes, "${AGENT_COMPOSE_DATA_DIR:-./data}/sandboxes:/data/sandboxes:ro") {
+		t.Fatalf("agent-compose-ui volumes = %#v, want read-only daemon sandbox mount", frontend.Volumes)
+	}
+	if frontend.Environment["SANDBOX_ROOT"] != "/data/sandboxes" {
+		t.Fatalf("agent-compose-ui SANDBOX_ROOT = %q, want /data/sandboxes", frontend.Environment["SANDBOX_ROOT"])
+	}
 
 	for _, want := range []string{
 		"AGENT_COMPOSE_DATA_DIR=./data",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
       - ./.env
     volumes:
       - ${AGENT_COMPOSE_UI_DATA_DIR:-./data/agent-compose-ui}:/data
+      - ${AGENT_COMPOSE_DATA_DIR:-./data}/sandboxes:/data/sandboxes:ro
     environment:
+      SANDBOX_ROOT: /data/sandboxes
       JUPYTER_PROXY_BASE: ${JUPYTER_PROXY_BASE:-/jupyter}
       NGINX_JUPYTER_PROXY_BASE: ${JUPYTER_PROXY_BASE:-/jupyter}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - ${AGENT_COMPOSE_UI_DATA_DIR:-./data/agent-compose-ui}:/data
       - ${AGENT_COMPOSE_DATA_DIR:-./data}/sandboxes:/data/sandboxes:ro
     environment:
-      SANDBOX_ROOT: /data/sandboxes
       JUPYTER_PROXY_BASE: ${JUPYTER_PROXY_BASE:-/jupyter}
       NGINX_JUPYTER_PROXY_BASE: ${JUPYTER_PROXY_BASE:-/jupyter}
     ports:

--- a/scripts/tests/test-compose-kvm-config.sh
+++ b/scripts/tests/test-compose-kvm-config.sh
@@ -46,7 +46,6 @@ jq -e --arg data_source "$ROOT_DIR/data" '
 
 jq -e --arg data_source "$ROOT_DIR/data" --arg ui_data_source "$ROOT_DIR/data/agent-compose-ui" '
   .services["agent-compose-ui"] as $service |
-  $service.environment.SANDBOX_ROOT == "/data/sandboxes" and
   any($service.volumes[]; .source == $ui_data_source and .target == "/data") and
   any($service.volumes[]; .source == ($data_source + "/sandboxes") and .target == "/data/sandboxes" and .read_only == true)
 ' >/dev/null <<<"$ui_json"

--- a/scripts/tests/test-compose-kvm-config.sh
+++ b/scripts/tests/test-compose-kvm-config.sh
@@ -20,6 +20,7 @@ compose_config() {
     -u AGENT_COMPOSE_FRONTEND_IMAGE \
     -u AGENT_COMPOSE_RUNTIME_BASE_URL \
     -u AGENT_COMPOSE_DATA_DIR \
+    -u AGENT_COMPOSE_UI_DATA_DIR \
     docker compose \
       --project-directory "$ROOT_DIR" \
       --env-file "$ROOT_DIR/.env.example" \
@@ -28,6 +29,7 @@ compose_config() {
 }
 
 base_json=$(compose_config -f "$ROOT_DIR/docker-compose.yml")
+ui_json=$(compose_config -f "$ROOT_DIR/docker-compose.yml" --profile with-ui)
 kvm_json=$(compose_config -f "$ROOT_DIR/docker-compose.yml" -f "$ROOT_DIR/docker-compose.kvm.yml")
 local_json=$(compose_config -f "$ROOT_DIR/docker-compose.yml" -f "$ROOT_DIR/docker-compose.override.yml.example")
 
@@ -42,17 +44,40 @@ jq -e --arg data_source "$ROOT_DIR/data" '
   any($service.ports[]; .host_ip == "127.0.0.1" and .target == 7410 and .published == "7410")
 ' >/dev/null <<<"$base_json"
 
+jq -e --arg data_source "$ROOT_DIR/data" --arg ui_data_source "$ROOT_DIR/data/agent-compose-ui" '
+  .services["agent-compose-ui"] as $service |
+  $service.environment.SANDBOX_ROOT == "/data/sandboxes" and
+  any($service.volumes[]; .source == $ui_data_source and .target == "/data") and
+  any($service.volumes[]; .source == ($data_source + "/sandboxes") and .target == "/data/sandboxes" and .read_only == true)
+' >/dev/null <<<"$ui_json"
+
 jq -e '
   .services["agent-compose"] as $service |
   $service.privileged == true and
   (($service.devices // []) | length == 1) and
-  $service.devices[0].source == "/dev/kvm" and
-  $service.devices[0].target == "/dev/kvm" and
-  $service.devices[0].permissions == "rwm"
+  (
+    $service.devices[0] == "/dev/kvm:/dev/kvm" or
+    (
+      $service.devices[0].source == "/dev/kvm" and
+      $service.devices[0].target == "/dev/kvm" and
+      $service.devices[0].permissions == "rwm"
+    )
+  )
 ' >/dev/null <<<"$kvm_json"
 
-base_without_kvm=$(jq -cS 'del(.services["agent-compose"].privileged, .services["agent-compose"].devices)' <<<"$base_json")
-kvm_without_kvm=$(jq -cS 'del(.services["agent-compose"].privileged, .services["agent-compose"].devices)' <<<"$kvm_json")
+normalize_compose=$(cat <<'JQ'
+del(.services["agent-compose"].privileged, .services["agent-compose"].devices) |
+.services |= with_entries(
+  if (.value.volumes? | type) == "array" then
+    .value.volumes |= sort_by(.source, .target)
+  else
+    .
+  end
+)
+JQ
+)
+base_without_kvm=$(jq -cS "$normalize_compose" <<<"$base_json")
+kvm_without_kvm=$(jq -cS "$normalize_compose" <<<"$kvm_json")
 if [[ "$base_without_kvm" != "$kvm_without_kvm" ]]; then
   printf 'KVM overlay changes rendered Compose fields beyond privileged and devices\n' >&2
   diff -u <(jq -S . <<<"$base_without_kvm") <(jq -S . <<<"$kvm_without_kvm") >&2 || true


### PR DESCRIPTION
## Summary

- mount the daemon's `${AGENT_COMPOSE_DATA_DIR}/sandboxes` directory into the web UI at `/data/sandboxes` as read-only
- document the shared sandbox-data requirement and extend Compose contract coverage

The UI server reads Codex and Claude JSONL agent records directly from the daemon sandbox tree. Its existing `/data` mount is reserved for UI-owned persistent state, so without this separate mount those records are unavailable in Compose deployments. The container continues to rely on the UI server's existing `/data/sandboxes` default for `SANDBOX_ROOT`.

## Testing

- `bash scripts/tests/test-compose-kvm-config.sh`
- `docker compose --env-file .env.example -f docker-compose.yml --profile with-ui config`
- `git diff --check`

The focused Go test command was attempted but the current branch has a pre-existing generated protobuf mismatch: `agentcomposev2.SchedulerSpec` is missing the `Model` field referenced by `pkg/agentcompose/api/project.go`.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.