### PR TITLE
fix(execution): harden command result decoding and reporting

### DIFF
--- a/pkg/execution/parse.go
+++ b/pkg/execution/parse.go
@@ -185,12 +185,38 @@ func findCommandExecPayload(raw string) (domain.RuntimeCommandResult, bool) {
 		if line == "" {
 			continue
 		}
-		if idx := strings.LastIndex(line, CommandResultPrefix); idx >= 0 {
-			line = strings.TrimSpace(line[idx+len(CommandResultPrefix):])
+		if payload, ok := parseCommandExecLine(line); ok {
+			return payload, true
 		}
-		if !strings.HasPrefix(line, "{") {
-			continue
+	}
+	return domain.RuntimeCommandResult{}, false
+}
+
+// parseCommandExecLine locates CommandResultPrefix within a single line and
+// decodes the JSON that follows it. The prefix can legitimately appear more
+// than once on a line: the command's own output may quote the prefix, and
+// that occurrence sits to the right of the real one once the wrapper embeds
+// the captured output inside the result JSON. Trying every occurrence (and
+// requiring the remainder to actually decode) avoids latching onto a quoted
+// occurrence instead of the genuine marker.
+func parseCommandExecLine(line string) (domain.RuntimeCommandResult, bool) {
+	searchFrom := 0
+	for {
+		idx := strings.Index(line[searchFrom:], CommandResultPrefix)
+		if idx < 0 {
+			break
 		}
+		idx += searchFrom
+		candidate := strings.TrimSpace(line[idx+len(CommandResultPrefix):])
+		if strings.HasPrefix(candidate, "{") {
+			var payload domain.RuntimeCommandResult
+			if json.Unmarshal([]byte(candidate), &payload) == nil {
+				return payload, true
+			}
+		}
+		searchFrom = idx + len(CommandResultPrefix)
+	}
+	if strings.HasPrefix(line, "{") {
 		var payload domain.RuntimeCommandResult
 		if json.Unmarshal([]byte(line), &payload) == nil {
 			return payload, true

--- a/pkg/execution/parse_coverage_test.go
+++ b/pkg/execution/parse_coverage_test.go
@@ -54,6 +54,25 @@ func TestParseAgentAndCommandExecResultWorkflows(t *testing.T) {
 	}
 }
 
+// TestParseCommandExecResultIgnoresPrefixQuotedInsidePayload guards against a
+// regression where the command's own captured output legitimately quotes
+// CommandResultPrefix (e.g. a GitHub issue body describing this protocol).
+// The genuine marker is always the leftmost occurrence on the line, because
+// the wrapper prints its own prefix before embedding the captured output;
+// picking the rightmost occurrence (as a naive strings.LastIndex scan would)
+// lands inside the quoted text instead of the real JSON payload.
+func TestParseCommandExecResultIgnoresPrefixQuotedInsidePayload(t *testing.T) {
+	quotedOutput := "docs mention " + CommandResultPrefix + " twice, " + CommandResultPrefix + " here too"
+	payload := CommandResultPrefix + `{"stdout":"` + quotedOutput + `","stderr":"","output":"","exitCode":0,"success":true}`
+	command, err := ParseCommandExecResult(domain.ExecResult{Stdout: "prep\n" + payload})
+	if err != nil {
+		t.Fatalf("ParseCommandExecResult returned error: %v", err)
+	}
+	if !command.Success || command.ExitCode != 0 || command.Stdout != quotedOutput {
+		t.Fatalf("command result = %#v", command)
+	}
+}
+
 func TestParseAgentExecResultClassifiesFinalTextFallback(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -196,4 +215,12 @@ func TestIntegrationParseAgentAndCommandExecResultWorkflows(t *testing.T) {
 
 func TestE2EParseAgentAndCommandExecResultWorkflows(t *testing.T) {
 	TestParseAgentAndCommandExecResultWorkflows(t)
+}
+
+func TestIntegrationParseCommandExecResultIgnoresPrefixQuotedInsidePayload(t *testing.T) {
+	TestParseCommandExecResultIgnoresPrefixQuotedInsidePayload(t)
+}
+
+func TestE2EParseCommandExecResultIgnoresPrefixQuotedInsidePayload(t *testing.T) {
+	TestParseCommandExecResultIgnoresPrefixQuotedInsidePayload(t)
 }

--- a/runtime/javascript/src/command.ts
+++ b/runtime/javascript/src/command.ts
@@ -285,7 +285,11 @@ async function runProcess(
       stdout: finalizeCapture(stdoutCapture),
       stderr: finalizeCapture(stderrCapture),
       output: finalizeCapture(outputCapture),
-      exitCode,
+      // A child that catches SIGTERM and exits 0 (or that finishes right as
+      // the timer fires) would otherwise report exitCode 0 alongside a
+      // "command timed out" stderr message - force a non-zero exit code so
+      // `success` (computed from exitCode alone) stays consistent with it.
+      exitCode: timedOut && exitCode === 0 ? 124 : exitCode,
       cancelled,
     };
   } finally {

--- a/runtime/javascript/src/command.ts
+++ b/runtime/javascript/src/command.ts
@@ -259,15 +259,26 @@ async function runProcess(
     appendCapture(outputCapture, chunk);
   });
 
+  // Surface spawn/timeout failures as regular stderr output instead of
+  // throwing, so the caller always gets a decodable RuntimeCommandResult
+  // (see runtime/javascript/src/cli.ts, which only prints the
+  // COMMAND_RESULT_PREFIX marker when this function returns normally).
+  const recordFailureMessage = (message: string) => {
+    const chunk = Buffer.from(message);
+    options.stderr?.write(chunk);
+    stderrFile.write(chunk);
+    outputFile.write(chunk);
+    appendCapture(stderrCapture, chunk);
+    appendCapture(outputCapture, chunk);
+  };
+
   try {
     const { exitCode, spawnError } = await processExit;
     if (spawnError && !options.signal?.aborted) {
-      throw spawnError;
-    }
-    if (timedOut) {
-      throw new Error(`command timed out after ${request.timeoutMs}ms`);
-    }
-    if (exitCode !== 0) {
+      recordFailureMessage(`spawn failed: ${spawnError.message}\n`);
+    } else if (timedOut) {
+      recordFailureMessage(`command timed out after ${request.timeoutMs}ms\n`);
+    } else if (exitCode !== 0) {
       options.stderr?.write(`command exited with code ${exitCode}\n`);
     }
     return {

--- a/runtime/javascript/test/command.test.ts
+++ b/runtime/javascript/test/command.test.ts
@@ -268,6 +268,26 @@ describe("runtime command execution", () => {
     });
   });
 
+  it("still reports failure when a timed-out child catches SIGTERM and exits 0", async () => {
+    await withTempSession(async (root) => {
+      const requestFile = await writeRequest(root, {
+        mode: "exec",
+        command: "node",
+        args: ["-e", "process.on('SIGTERM', () => process.exit(0)); setTimeout(() => {}, 10000)"],
+        timeoutMs: 25,
+        artifactDir: path.join(root, "artifacts"),
+      });
+
+      const result = await runExecCommand({ requestFile, workspace: root });
+      // exitCode 0 alongside a "timed out" stderr message would be a
+      // self-contradictory result - success must stay false regardless of
+      // what exit code the child reported once it was killed for timeout.
+      expect(result.exitCode).not.toBe(0);
+      expect(result.success).toBe(false);
+      expect(result.stderr).toContain("command timed out after 25ms");
+    });
+  });
+
   it("reports spawn failures as a structured result instead of throwing", async () => {
     await withTempSession(async (root) => {
       const requestFile = await writeRequest(root, {

--- a/runtime/javascript/test/command.test.ts
+++ b/runtime/javascript/test/command.test.ts
@@ -246,7 +246,7 @@ describe("runtime command execution", () => {
     });
   });
 
-  it("terminates commands that exceed timeout", async () => {
+  it("terminates commands that exceed timeout and reports a structured failure", async () => {
     await withTempSession(async (root) => {
       const requestFile = await writeRequest(root, {
         mode: "exec",
@@ -256,7 +256,34 @@ describe("runtime command execution", () => {
         artifactDir: path.join(root, "artifacts"),
       });
 
-      await expect(runExecCommand({ requestFile, workspace: root })).rejects.toThrow("command timed out");
+      // Callers (e.g. the exec CLI action) only get a decodable result when
+      // this resolves instead of rejecting - see runtime/javascript/src/cli.ts.
+      const result = await runExecCommand({ requestFile, workspace: root });
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("command timed out after 25ms");
+      const savedResult = JSON.parse(await fs.readFile(result.artifacts.result, "utf8"));
+      expect(savedResult).toMatchObject({ success: false });
+      expect(savedResult.stderr).toContain("command timed out after 25ms");
+    });
+  });
+
+  it("reports spawn failures as a structured result instead of throwing", async () => {
+    await withTempSession(async (root) => {
+      const requestFile = await writeRequest(root, {
+        mode: "exec",
+        command: "agent-compose-runtime-test-missing-binary-xyz",
+        args: [],
+        artifactDir: path.join(root, "artifacts"),
+      });
+
+      const result = await runExecCommand({ requestFile, workspace: root });
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("spawn failed");
+      const savedResult = JSON.parse(await fs.readFile(result.artifacts.result, "utf8"));
+      expect(savedResult).toMatchObject({ success: false });
+      expect(savedResult.stderr).toContain("spawn failed");
     });
   });
 


### PR DESCRIPTION
## Summary
- `runProcess()`(`runtime/javascript/src/command.ts`) no longer `throw`s on spawn failure (e.g. `E2BIG`) or timeout. It now returns a structured `RuntimeCommandResult` (`success:false`, non-zero `exitCode`, descriptive `stderr`), so the `exec` CLI action always gets to print the `COMMAND_RESULT_PREFIX` marker instead of the process exiting with the real error visible only on stderr. Fixes #581.
- `findCommandExecPayload()`(`pkg/execution/parse.go`) no longer assumes `CommandResultPrefix` appears exactly once per line. It tries every occurrence (leftmost first) and accepts the first one whose remainder decodes as valid JSON — so a command whose own legitimate output happens to quote the prefix text (e.g. fetching a GitHub issue that describes this exact protocol) no longer gets misreported as `decode command result: no result payload found`. Fixes #582.

Both bugs were found while investigating the same underlying symptom (`decode command result: no result payload found` with no diagnostic info) on two different schedulers (`zz-ingress-router` DevBoard webhook ingress, and `engineering-agent-workflows/issue-triage`) — they're independent root causes in different code paths (guest-side spawn handling vs. daemon-side marker parsing), bundled here since they're both small and touch the same reliability surface.

## Test plan
- [x] `go test ./pkg/execution/... ./pkg/agentcompose/adapters/... ./pkg/agentcompose/api/... ./pkg/runs/...`
- [x] `go vet ./pkg/execution/...`, `gofmt -l` clean
- [x] `npx tsc --noEmit` (runtime/javascript)
- [x] `npx vitest run` (runtime/javascript) — all relevant suites pass; 3 pre-existing unrelated failures (macOS `/private/var` symlink path assertion in `pi-runner.test.ts`, git worktree integration flakiness) confirmed present on `main` too, unaffected by this change
- [x] Added regression tests: spawn-failure and timeout no longer throw (`test/command.test.ts`); `ParseCommandExecResult` correctly ignores a `CommandResultPrefix` occurrence quoted inside the legitimate payload (`pkg/execution/parse_coverage_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)