### PR TITLE
[codex] chore(runtime): bump packages to 0.10.0

### DIFF
--- a/docs/spec/dynamic-workflow-spec.md
+++ b/docs/spec/dynamic-workflow-spec.md
@@ -634,7 +634,7 @@ SDK behavior：
 
 `runtime/javascript/package-lock.json` 更新。
 
-`runtime/javascript` 和 `runtime/agent-compose-runtime-sdk` package version 从当前 `0.8.0` 升到 `0.9.0`。`dist/` 不在 Git 跟踪文件内，不手工提交。
+`runtime/javascript` 和 `runtime/agent-compose-runtime-sdk` package version 从当前 `0.9.0` 升到 `0.10.0`。`dist/` 不在 Git 跟踪文件内，不手工提交。
 
 ## 工作流和失败语义
 

--- a/runtime/agent-compose-runtime-sdk/package-lock.json
+++ b/runtime/agent-compose-runtime-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime-sdk",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "zod": "^4.4.3"

--- a/runtime/agent-compose-runtime-sdk/package.json
+++ b/runtime/agent-compose-runtime-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Node.js SDK for scripts running inside an agent-compose guest runtime.",
   "license": "LGPL-3.0-only",
   "type": "module",

--- a/runtime/javascript/package-lock.json
+++ b/runtime/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.206",

--- a/runtime/javascript/package.json
+++ b/runtime/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Guest-side runtime CLI for agent-compose agent sessions.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump `@chaitin-ai/agent-compose-runtime` to `0.10.0`
- bump `@chaitin-ai/agent-compose-runtime-sdk` to `0.10.0`
- keep both package-lock files and the runtime design specification aligned

## Why

Runtime command execution fixes landed after `runtime-v0.9.0`, including structured reporting for spawn and timeout failures and consistent non-zero exit codes for timed-out commands. This prepares the next runtime package release as `runtime-v0.10.0`.

## Validation

- version consistency check passed
- `git diff --check` passed
- SDK typecheck passed
- runtime typecheck remains blocked locally because `node_modules` is missing `acorn` type declarations
