### PR TITLE
fix(api): remove scheduler list N+1 hydration

### DIFF
--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -767,21 +767,32 @@ func TestProjectAndRunHandlersStoreBackedWorkflows(t *testing.T) {
 	if err != nil || scheduler.Msg.GetScheduler().GetSchedulerId() != "scheduler-1" || scheduler.Msg.GetScheduler().GetDisplayName() != "每日巡检" || scheduler.Msg.GetSpec().GetScript() != "run()" || scheduler.Msg.GetSpec().GetDescription() != "每天汇总巡检结果" {
 		t.Fatalf("GetScheduler resp=%#v err=%v", scheduler, err)
 	}
+	// GetScheduler hydrates scheduler-1 as disabled, diverging from the
+	// project_scheduler page row (Enabled: true), so the calls below can
+	// prove ListSchedulers treats the page row as authoritative instead of
+	// re-hydrating each item via GetScheduler.
+	getSchedulerCallsBeforeList := store.getSchedulerCalls
 	firstSchedulers, err := projectHandler.ListSchedulers(ctx, connect.NewRequest(&agentcomposev2.ListSchedulersRequest{Limit: 1}))
 	if err != nil || len(firstSchedulers.Msg.GetSchedulers()) != 1 || firstSchedulers.Msg.GetTotal() != 2 {
 		t.Fatalf("ListSchedulers first page=%#v err=%v", firstSchedulers, err)
 	}
-	if summary := firstSchedulers.Msg.GetSchedulers()[0]; summary.GetEnabled() || summary.GetRunCount() != 3 || !summary.GetLatestRunAt().AsTime().Equal(time.Unix(10, 0)) || summary.GetLastError() != "failed" || summary.GetDisplayName() != "每日巡检" || summary.GetDescription() != "每天汇总巡检结果" {
+	if summary := firstSchedulers.Msg.GetSchedulers()[0]; !summary.GetEnabled() || summary.GetRunCount() != 3 || !summary.GetLatestRunAt().AsTime().Equal(time.Unix(10, 0)) || summary.GetLastError() != "failed" || summary.GetDisplayName() != "每日巡检" || summary.GetDescription() != "每天汇总巡检结果" {
 		t.Fatalf("ListSchedulers summary=%#v", summary)
 	}
 	secondSchedulers, err := projectHandler.ListSchedulers(ctx, connect.NewRequest(&agentcomposev2.ListSchedulersRequest{Limit: 1, Offset: 1}))
 	if err != nil || len(secondSchedulers.Msg.GetSchedulers()) != 1 || secondSchedulers.Msg.GetSchedulers()[0].GetSchedulerId() != "scheduler-2" {
 		t.Fatalf("ListSchedulers second page=%#v err=%v", secondSchedulers, err)
 	}
+	if store.getSchedulerCalls != getSchedulerCallsBeforeList {
+		t.Fatalf("ListSchedulers must not call GetScheduler per item, calls before=%d after=%d", getSchedulerCallsBeforeList, store.getSchedulerCalls)
+	}
 	delete(store.schedulerDefinitions, "scheduler-2")
 	missingSchedulerSchedulers, err := projectHandler.ListSchedulers(ctx, connect.NewRequest(&agentcomposev2.ListSchedulersRequest{Limit: 10}))
 	if err != nil || len(missingSchedulerSchedulers.Msg.GetSchedulers()) != 2 || !missingSchedulerSchedulers.Msg.GetSchedulers()[1].GetEnabled() {
 		t.Fatalf("ListSchedulers missing scheduler fallback=%#v err=%v", missingSchedulerSchedulers, err)
+	}
+	if store.getSchedulerCalls != getSchedulerCallsBeforeList {
+		t.Fatalf("ListSchedulers must not call GetScheduler even when scheduler definitions are missing, calls before=%d after=%d", getSchedulerCallsBeforeList, store.getSchedulerCalls)
 	}
 	store.schedulerDefinitions["scheduler-2"] = domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-2", Enabled: true}}
 	store.projects = append(store.projects, domain.ProjectRecord{ID: "project-2", Name: "Project"})
@@ -1295,6 +1306,7 @@ type apiProjectRunStore struct {
 	lastRunListOptions   domain.ProjectRunListOptions
 	runEvents            []domain.ProjectRunEventRecord
 	schedulerDefinitions map[string]domain.Scheduler
+	getSchedulerCalls    int
 }
 
 func (s *apiProjectRunStore) GetProject(_ context.Context, projectID string) (domain.ProjectRecord, error) {
@@ -1359,6 +1371,7 @@ func (s *apiProjectRunStore) GetManagedAgentDefinition(context.Context, string) 
 }
 
 func (s *apiProjectRunStore) GetScheduler(_ context.Context, schedulerID string) (domain.Scheduler, error) {
+	s.getSchedulerCalls++
 	scheduler, ok := s.schedulerDefinitions[schedulerID]
 	if !ok {
 		return domain.Scheduler{}, sql.ErrNoRows

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -147,16 +147,12 @@ func (h *ProjectHandler) ListSchedulers(ctx context.Context, req *connect.Reques
 	}
 	summaries := make([]*agentcomposev2.SchedulerSummary, 0, len(schedulers))
 	for _, scheduler := range schedulers {
-		enabled, err := h.effectiveSchedulerEnabled(ctx, scheduler)
-		if err != nil {
-			return nil, err
-		}
 		displayName, description := projectSchedulerPresentation(scheduler.SpecJSON)
 		summary := &agentcomposev2.SchedulerSummary{
 			ProjectId:    scheduler.ProjectID,
 			AgentName:    scheduler.AgentName,
 			SchedulerId:  scheduler.SchedulerID,
-			Enabled:      enabled,
+			Enabled:      scheduler.Enabled,
 			TriggerCount: uint32(scheduler.TriggerCount),
 			DisplayName:  displayName,
 			Description:  description,
@@ -167,21 +163,6 @@ func (h *ProjectHandler) ListSchedulers(ctx context.Context, req *connect.Reques
 		summaries = append(summaries, summary)
 	}
 	return connect.NewResponse(&agentcomposev2.ListSchedulersResponse{Schedulers: summaries, Total: uint32(total)}), nil
-}
-
-func (h *ProjectHandler) effectiveSchedulerEnabled(ctx context.Context, scheduler domain.ProjectSchedulerRecord) (bool, error) {
-	schedulerStore, ok := h.store.(ProjectSchedulerStore)
-	if !ok || scheduler.ID == "" {
-		return scheduler.Enabled, nil
-	}
-	definition, err := schedulerStore.GetScheduler(ctx, scheduler.ID)
-	if err != nil {
-		if errors.Is(err, domain.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
-			return scheduler.Enabled, nil
-		}
-		return false, connect.NewError(connect.CodeInternal, err)
-	}
-	return definition.Summary.Enabled, nil
 }
 
 func (h *ProjectHandler) ListSchedulerEvents(ctx context.Context, req *connect.Request[agentcomposev2.ListSchedulerEventsRequest]) (*connect.Response[agentcomposev2.ListSchedulerEventsResponse], error) {

--- a/pkg/storage/configstore/project_scheduler_page_test.go
+++ b/pkg/storage/configstore/project_scheduler_page_test.go
@@ -79,3 +79,62 @@ func TestProjectSchedulerPageUsesStableCursorAndProjectQuery(t *testing.T) {
 		t.Fatalf("filtered page = %#v, err = %v", filtered, err)
 	}
 }
+
+func TestProjectSchedulerPageScalesWithRunHistory(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	const (
+		projectID      = "project-scale"
+		schedulerCount = 120
+	)
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: projectID, Name: "scale"}); err != nil {
+		t.Fatalf("upsert project: %v", err)
+	}
+	for index := range schedulerCount {
+		agentName := fmt.Sprintf("agent-%03d", index)
+		schedulerID := fmt.Sprintf("scheduler-%03d", index)
+		agentID, err := domain.StableProjectAgentID(projectID, agentName)
+		if err != nil {
+			t.Fatalf("derive agent id %s: %v", agentName, err)
+		}
+		if _, err := store.UpsertProjectAgent(ctx, domain.ProjectAgentRecord{ID: agentID, ProjectID: projectID, AgentName: agentName}); err != nil {
+			t.Fatalf("upsert agent %s: %v", agentName, err)
+		}
+		if _, err := store.UpsertProjectScheduler(ctx, domain.ProjectSchedulerRecord{
+			ProjectID: projectID,
+			AgentName: agentName,
+			ID:        schedulerID,
+			Enabled:   index%2 == 0,
+		}); err != nil {
+			t.Fatalf("upsert scheduler %s: %v", schedulerID, err)
+		}
+		for runIndex := range 3 {
+			startedAt := int64(1700000000 + index*10 + runIndex)
+			if _, err := store.db.ExecContext(ctx, `INSERT INTO scheduler_run(scheduler_id, run_id, trigger_id, started_at) VALUES(?, ?, ?, ?)`, schedulerID, fmt.Sprintf("run-%03d-%d", index, runIndex), "trigger-1", startedAt); err != nil {
+				t.Fatalf("insert scheduler run %s/%d: %v", schedulerID, runIndex, err)
+			}
+		}
+		if _, err := store.db.ExecContext(ctx, `INSERT INTO scheduler_run(scheduler_id, run_id, started_at) VALUES(?, ?, ?)`, schedulerID, fmt.Sprintf("legacy-%03d", index), int64(1800000000+index)); err != nil {
+			t.Fatalf("insert legacy scheduler invocation %s: %v", schedulerID, err)
+		}
+	}
+
+	first, err := store.ListProjectSchedulersPage(ctx, "scale", 0, 100)
+	if err != nil || len(first) != 100 {
+		t.Fatalf("first page length = %d, err = %v", len(first), err)
+	}
+	second, err := store.ListProjectSchedulersPage(ctx, "scale", 100, 100)
+	if err != nil || len(second) != 20 {
+		t.Fatalf("second page length = %d, err = %v", len(second), err)
+	}
+	for index, scheduler := range append(first, second...) {
+		wantID := fmt.Sprintf("scheduler-%03d", index)
+		wantLatest := time.Unix(int64(1700000000+index*10+2), 0).UTC()
+		if scheduler.ID != wantID || scheduler.Enabled != (index%2 == 0) || scheduler.RunCount != 3 || !scheduler.LatestRunAt.Equal(wantLatest) {
+			t.Fatalf("scheduler %d = %#v, want id=%s enabled=%v run_count=3 latest=%s", index, scheduler, wantID, index%2 == 0, wantLatest)
+		}
+	}
+}

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -361,18 +361,25 @@ func (s *projectStore) ListProjectSchedulersPage(ctx context.Context, query stri
 	query = strings.ToLower(strings.TrimSpace(query))
 	likeQuery := "%" + query + "%"
 	rows, err := s.db.QueryContext(ctx, `WITH page AS (
-		SELECT s.id, s.short_id, s.project_id, s.id, s.agent_name, s.revision, s.enabled, s.trigger_count, s.spec_json, s.created_at, s.updated_at
+		SELECT s.id, s.short_id, s.project_id, s.id, s.agent_name, s.revision, s.enabled, s.trigger_count, s.spec_json, s.created_at, s.updated_at, s.last_error
 		FROM project_scheduler s JOIN project p ON p.id = s.project_id
 		WHERE p.removed_at = 0
 		AND s.revision = p.current_revision
 		AND (? = '' OR lower(p.id) LIKE ? OR lower(p.name) LIKE ? OR lower(p.source_path) LIKE ?)
 		ORDER BY s.project_id ASC, s.agent_name ASC, s.id ASC LIMIT ? OFFSET ?
+	), run_stats AS (
+		SELECT sr.scheduler_id AS id, COUNT(*) AS run_count, MAX(sr.started_at) AS latest_run_at
+		FROM scheduler_run sr
+		JOIN page ON page.id = sr.scheduler_id
+		WHERE sr.trigger_id <> ''
+		GROUP BY sr.scheduler_id
 	)
 	SELECT page.id, page.short_id, page.project_id, page.id, page.agent_name, page.revision, page.enabled, page.trigger_count, page.spec_json, page.created_at, page.updated_at,
-		(SELECT COUNT(*) FROM scheduler_run sr WHERE sr.scheduler_id = page.id AND sr.trigger_id <> ''),
-		(SELECT MAX(started_at) FROM scheduler_run sr WHERE sr.scheduler_id = page.id AND sr.trigger_id <> ''),
-		COALESCE((SELECT last_error FROM project_scheduler WHERE id = page.id), '')
+		COALESCE(run_stats.run_count, 0),
+		run_stats.latest_run_at,
+		COALESCE(page.last_error, '')
 	FROM page
+	LEFT JOIN run_stats ON run_stats.id = page.id
 	ORDER BY page.project_id ASC, page.agent_name ASC, page.id ASC`, query, likeQuery, likeQuery, likeQuery, limit, max(offset, 0))
 	if err != nil {
 		return nil, fmt.Errorf("query project scheduler page: %w", err)


### PR DESCRIPTION
## Summary

- use the scheduler page record as the authoritative enabled state
- remove per-item `GetScheduler` hydration from `ListSchedulers`
- aggregate scheduler run counts and latest run times once for the requested page
- add a regression assertion against per-item hydration and a 120-scheduler history test

Fixes #586

## Tests

- `task lint`
- `task build`
- `go test ./pkg/agentcompose/api ./pkg/storage/configstore`
- `go test ./cmd/... ./pkg/... ./proto/health/v1 ./proto/health/v1/healthv1connect ./proto/agentcompose/v2 ./proto/agentcompose/v2/agentcomposev2connect` *(scheduler-related packages pass; existing unrelated failures remain in `pkg/compose` timezone validation and `pkg/volumes` macOS `/var` vs `/private/var` path expectations)*
- `task test` *(blocked in installer deployment tests because macOS resolves `/var` through the `/private/var` symlink, producing `refusing install path with symlink component: /var`)*

## Checklist

- [x] Focused regression coverage added
- [x] Scale coverage includes at least 100 schedulers with run history
- [x] No public API or documentation changes
