### PR TITLE
perf(api): fix remaining list-endpoint N+1 hydration

### DIFF
--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -751,6 +751,9 @@ func (h *ExecHandler) resolveExecTargetSandbox(ctx context.Context, req *agentco
 	if err != nil {
 		return nil, "", connect.NewError(connect.CodeNotFound, fmt.Errorf("sandbox %s not found: %w", candidates[0].sandboxID, err))
 	}
+	if sandbox.Summary.VMStatus != domain.VMStatusRunning {
+		return nil, "", connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sandbox %s is not running", candidates[0].sandboxID))
+	}
 	return sandbox, candidates[0].run.RunID, nil
 }
 

--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -28,6 +28,7 @@ import (
 type ExecSandboxStore interface {
 	GetSandbox(context.Context, string) (*domain.Sandbox, error)
 	GetVMState(string) (domain.VMState, error)
+	ListSandboxSummaries(context.Context, []string) (map[string]domain.SandboxSummary, error)
 }
 
 type ExecProjectStore interface {
@@ -695,7 +696,7 @@ func (h *ExecHandler) resolveExecTargetSandbox(ctx context.Context, req *agentco
 		}
 		return nil, "", connect.NewError(connect.CodeInternal, err)
 	}
-	statuses, err := runs.ListProjectSandboxStatuses(ctx, h.projects, h.store, domain.ProjectSandboxRelationFilter{
+	projectRuns, err := h.projects.ListProjectSandboxRuns(ctx, domain.ProjectSandboxRelationFilter{
 		ProjectID: project.ID,
 		AgentName: selector.GetAgentName(),
 	})
@@ -703,15 +704,32 @@ func (h *ExecHandler) resolveExecTargetSandbox(ctx context.Context, req *agentco
 		return nil, "", connect.NewError(connect.CodeInternal, err)
 	}
 	type candidate struct {
-		sandbox *domain.Sandbox
-		run     domain.ProjectRunRecord
+		sandboxID string
+		run       domain.ProjectRunRecord
 	}
-	var candidates []candidate
-	for _, status := range statuses {
-		if status.Sandbox == nil || status.Sandbox.Summary.VMStatus != domain.VMStatusRunning {
+	runBySandbox := make(map[string]domain.ProjectRunRecord, len(projectRuns))
+	sandboxIDs := make([]string, 0, len(projectRuns))
+	for _, run := range projectRuns {
+		sandboxID := strings.TrimSpace(run.SandboxID)
+		if sandboxID == "" {
 			continue
 		}
-		candidates = append(candidates, candidate{sandbox: status.Sandbox, run: status.Run})
+		if _, seen := runBySandbox[sandboxID]; seen {
+			continue
+		}
+		runBySandbox[sandboxID] = run
+		sandboxIDs = append(sandboxIDs, sandboxID)
+	}
+	summaries, err := h.store.ListSandboxSummaries(ctx, sandboxIDs)
+	if err != nil {
+		return nil, "", connect.NewError(connect.CodeInternal, err)
+	}
+	var candidates []candidate
+	for _, sandboxID := range sandboxIDs {
+		if summaries[sandboxID].VMStatus != domain.VMStatusRunning {
+			continue
+		}
+		candidates = append(candidates, candidate{sandboxID: sandboxID, run: runBySandbox[sandboxID]})
 	}
 	contextParts := []string{fmt.Sprintf("project %s", project.Name)}
 	if agentName := strings.TrimSpace(selector.GetAgentName()); agentName != "" {
@@ -724,12 +742,16 @@ func (h *ExecHandler) resolveExecTargetSandbox(ctx context.Context, req *agentco
 	if len(candidates) > 1 {
 		ids := make([]string, 0, len(candidates))
 		for _, item := range candidates {
-			ids = append(ids, item.sandbox.Summary.ID)
+			ids = append(ids, item.sandboxID)
 		}
 		slices.Sort(ids)
 		return nil, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("multiple runningsandboxs found for %s: %s", contextText, strings.Join(ids, ", ")))
 	}
-	return candidates[0].sandbox, candidates[0].run.RunID, nil
+	sandbox, err := h.store.GetSandbox(ctx, candidates[0].sandboxID)
+	if err != nil {
+		return nil, "", connect.NewError(connect.CodeNotFound, fmt.Errorf("sandbox %s not found: %w", candidates[0].sandboxID, err))
+	}
+	return sandbox, candidates[0].run.RunID, nil
 }
 
 func (h *ExecHandler) sandboxForProjectRun(ctx context.Context, run domain.ProjectRunRecord) (*domain.Sandbox, error) {

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -486,6 +486,39 @@ func TestExecHandlerRunSelectorAndStreamSenderWorkflow(t *testing.T) {
 	}
 }
 
+// TestExecHandlerSelectorRechecksVMStatusAfterSummaryFilter guards against a
+// TOCTOU regression: candidate filtering uses a (possibly stale/cached)
+// summary, but the sandbox actually returned comes from a later GetSandbox
+// disk read. If that reload disagrees with the summary, the stale reading
+// must not be trusted as the exec target.
+func TestExecHandlerSelectorRechecksVMStatusAfterSummaryFilter(t *testing.T) {
+	ctx := context.Background()
+	stopped := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-stale", VMStatus: domain.VMStatusStopped}}
+	store := &apiExecWorkflowSandboxStore{
+		sandboxes: map[string]*domain.Sandbox{"sandbox-stale": stopped},
+		summaries: map[string]domain.SandboxSummary{
+			"sandbox-stale": {ID: "sandbox-stale", VMStatus: domain.VMStatusRunning},
+		},
+		vm: domain.VMState{Driver: "docker"},
+	}
+	projects := &apiExecWorkflowProjectStore{
+		projects: []domain.ProjectRecord{{ID: "project-1", Name: "Project", SourcePath: "/repo/one"}},
+		runs: []domain.ProjectRunRecord{
+			{RunID: "run-stale", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", SandboxID: "sandbox-stale"},
+		},
+	}
+	handler := NewExecHandler(&appconfig.Config{}, store, projects, func(*domain.Sandbox) (ExecRuntime, error) {
+		return &apiExecRuntime{}, nil
+	})
+	_, err := handler.executeProjectCommand(ctx, &agentcomposev2.ExecRequest{
+		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{Project: &agentcomposev2.ExecSandboxSelector_ProjectId{ProjectId: "project-1"}, AgentName: "worker"}},
+		Command: &agentcomposev2.ExecCommand{Command: "echo"},
+	}, "exec-stale", nil)
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("expected stale summary to be rejected with FailedPrecondition, got %v", err)
+	}
+}
+
 func TestExecHandlerSelectorErrors(t *testing.T) {
 	handler := NewExecHandler(&appconfig.Config{}, &apiExecSandboxStore{}, apiExecProjectStore{err: sql.ErrNoRows}, func(*domain.Sandbox) (ExecRuntime, error) {
 		return &apiExecRuntime{}, nil
@@ -1085,6 +1118,10 @@ func (s apiExecProjectStore) ListProjectSandboxRuns(context.Context, domain.Proj
 
 type apiExecWorkflowSandboxStore struct {
 	sandboxes map[string]*domain.Sandbox
+	// summaries overrides ListSandboxSummaries results for the given IDs,
+	// letting tests simulate a stale/cached summary diverging from what
+	// GetSandbox subsequently reloads from disk.
+	summaries map[string]domain.SandboxSummary
 	vm        domain.VMState
 }
 
@@ -1103,6 +1140,10 @@ func (s *apiExecWorkflowSandboxStore) GetVMState(string) (domain.VMState, error)
 func (s *apiExecWorkflowSandboxStore) ListSandboxSummaries(_ context.Context, ids []string) (map[string]domain.SandboxSummary, error) {
 	summaries := make(map[string]domain.SandboxSummary, len(ids))
 	for _, id := range ids {
+		if override, ok := s.summaries[id]; ok {
+			summaries[id] = override
+			continue
+		}
 		if sandbox, ok := s.sandboxes[id]; ok {
 			summaries[id] = sandbox.Summary
 		}

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -1051,6 +1051,18 @@ func (s *apiExecSandboxStore) GetVMState(string) (domain.VMState, error) {
 	return s.vm, nil
 }
 
+func (s *apiExecSandboxStore) ListSandboxSummaries(_ context.Context, ids []string) (map[string]domain.SandboxSummary, error) {
+	summaries := make(map[string]domain.SandboxSummary, len(ids))
+	if s.sandbox != nil {
+		for _, id := range ids {
+			if id == s.sandbox.Summary.ID {
+				summaries[id] = s.sandbox.Summary
+			}
+		}
+	}
+	return summaries, nil
+}
+
 type apiExecProjectStore struct {
 	err error
 }
@@ -1086,6 +1098,16 @@ func (s *apiExecWorkflowSandboxStore) GetSandbox(_ context.Context, id string) (
 
 func (s *apiExecWorkflowSandboxStore) GetVMState(string) (domain.VMState, error) {
 	return s.vm, nil
+}
+
+func (s *apiExecWorkflowSandboxStore) ListSandboxSummaries(_ context.Context, ids []string) (map[string]domain.SandboxSummary, error) {
+	summaries := make(map[string]domain.SandboxSummary, len(ids))
+	for _, id := range ids {
+		if sandbox, ok := s.sandboxes[id]; ok {
+			summaries[id] = sandbox.Summary
+		}
+	}
+	return summaries, nil
 }
 
 type apiExecWorkflowProjectStore struct {

--- a/pkg/storage/configstore/project_list.go
+++ b/pkg/storage/configstore/project_list.go
@@ -47,17 +47,34 @@ func (s *projectStore) ListProjects(ctx context.Context, options ProjectListOpti
 	}
 
 	pageArgs := append(append([]any(nil), args...), limit, offset)
-	rows, err := tx.QueryContext(ctx, `SELECT
-		p.id, p.name, p.short_id, p.source_path, p.source_json,
-		p.current_revision, p.spec_hash, p.created_at, p.updated_at, p.removed_at,
-		(SELECT COUNT(*) FROM project_agent a
-			WHERE a.project_id = p.id AND (p.current_revision <= 0 OR a.revision = p.current_revision)),
-		(SELECT COUNT(*) FROM project_scheduler s
-			WHERE s.project_id = p.id AND (p.current_revision <= 0 OR s.revision = p.current_revision))
+	rows, err := tx.QueryContext(ctx, `WITH page AS (
+		SELECT p.id, p.name, p.short_id, p.source_path, p.source_json,
+			p.current_revision, p.spec_hash, p.created_at, p.updated_at, p.removed_at
 		FROM project p
 		WHERE `+where+`
 		ORDER BY p.updated_at DESC, p.created_at DESC, p.id ASC
-		LIMIT ? OFFSET ?`, pageArgs...)
+		LIMIT ? OFFSET ?
+	), agent_counts AS (
+		SELECT a.project_id AS id, COUNT(*) AS agent_count
+		FROM project_agent a
+		JOIN page ON page.id = a.project_id
+		WHERE page.current_revision <= 0 OR a.revision = page.current_revision
+		GROUP BY a.project_id
+	), scheduler_counts AS (
+		SELECT s.project_id AS id, COUNT(*) AS scheduler_count
+		FROM project_scheduler s
+		JOIN page ON page.id = s.project_id
+		WHERE page.current_revision <= 0 OR s.revision = page.current_revision
+		GROUP BY s.project_id
+	)
+	SELECT page.id, page.name, page.short_id, page.source_path, page.source_json,
+		page.current_revision, page.spec_hash, page.created_at, page.updated_at, page.removed_at,
+		COALESCE(agent_counts.agent_count, 0),
+		COALESCE(scheduler_counts.scheduler_count, 0)
+	FROM page
+	LEFT JOIN agent_counts ON agent_counts.id = page.id
+	LEFT JOIN scheduler_counts ON scheduler_counts.id = page.id
+	ORDER BY page.updated_at DESC, page.created_at DESC, page.id ASC`, pageArgs...)
 	if err != nil {
 		return ProjectListResult{}, fmt.Errorf("query project page: %w", err)
 	}

--- a/pkg/storage/sandboxstore/store.go
+++ b/pkg/storage/sandboxstore/store.go
@@ -593,9 +593,10 @@ func (s *Store) ListSandboxes(ctx context.Context, options SandboxListOptions) (
 		if len(indexed) == 0 {
 			break
 		}
+		loaded := s.loadSandboxesConcurrently(indexed)
 		ghosts := 0
-		for _, item := range indexed {
-			full, loadErr := s.loadSandbox(item.Summary.ID)
+		for i, item := range indexed {
+			full, loadErr := loaded[i].sandbox, loaded[i].err
 			if loadErr != nil {
 				if err := s.deleteIndexRow(item.Summary.ID); err != nil {
 					return SandboxListResult{}, fmt.Errorf("prune unreadable sandbox listing cache row %s: %w", item.Summary.ID, err)
@@ -623,6 +624,38 @@ func (s *Store) ListSandboxes(ctx context.Context, options SandboxListOptions) (
 		HasMore:    nextOffset < total,
 		NextOffset: nextOffset,
 	}, nil
+}
+
+// sandboxLoadConcurrency bounds how many metadata.json reads ListSandboxes
+// issues at once per page batch, so a large page doesn't open unbounded
+// concurrent file descriptors.
+const sandboxLoadConcurrency = 8
+
+type sandboxLoadResult struct {
+	sandbox *Sandbox
+	err     error
+}
+
+// loadSandboxesConcurrently hydrates each indexed row's full Sandbox from
+// disk in parallel, preserving input order so callers can still apply
+// offset/skip logic positionally. loadSandbox and the layout registration it
+// performs are safe for concurrent use.
+func (s *Store) loadSandboxesConcurrently(indexed []*Sandbox) []sandboxLoadResult {
+	results := make([]sandboxLoadResult, len(indexed))
+	sem := make(chan struct{}, sandboxLoadConcurrency)
+	var wg sync.WaitGroup
+	for i, item := range indexed {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, id string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			full, err := s.loadSandbox(id)
+			results[i] = sandboxLoadResult{sandbox: full, err: err}
+		}(i, item.Summary.ID)
+	}
+	wg.Wait()
+	return results
 }
 
 func listRowsNeeded(skip, page int) int {


### PR DESCRIPTION
## Summary
Closes #589. Follow-up to the scheduler list N+1 fix (#588) — same anti-pattern (per-row hydration in list-shaped code paths) found in three other places, all fixed here:

- `pkg/storage/configstore/project_list.go` `ListProjects` — two correlated subqueries per row (agent/scheduler counts) rewritten as `WITH page AS (...)` + `LEFT JOIN` aggregate CTEs, same shape as the scheduler fix. No schema change.
- `pkg/storage/sandboxstore/store.go` `Store.ListSandboxes` — the per-row `loadSandbox` disk read (`metadata.json`) is now issued through a bounded (8-way) worker pool instead of sequentially, cutting wall-clock latency roughly proportional to page size. No schema change; still one disk read per row, just parallelized.
- `pkg/agentcompose/api/exec.go` `resolveExecTargetSandbox` (project/agent selector path) — previously called `runs.ListProjectSandboxStatuses`, which did a full `GetSandbox` disk read per run's sandbox just to check `VMStatus`. Now batches a single `ListSandboxSummaries` SQL lookup to filter running candidates, and only calls `GetSandbox` once for the single winning candidate.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/storage/configstore/...`
- [x] `go test ./pkg/storage/sandboxstore/...` and `-race`
- [x] `go test ./pkg/agentcompose/api/...` (incl. exec selector ambiguous/no-running/single-match cases)
- [x] `go test ./pkg/runs/...`
- [x] `go vet ./...` (one pre-existing unrelated warning in test/e2e, confirmed present on main too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)