### PR TITLE
fix(capability): preserve OctoBus error details

### DIFF
--- a/pkg/agentcompose/api/capability_error.go
+++ b/pkg/agentcompose/api/capability_error.go
@@ -81,10 +81,14 @@ func octoBusConnectCode(err *capability.OctoBusError) connect.Code {
 		return connect.CodeFailedPrecondition
 	case http.StatusTooManyRequests:
 		return connect.CodeResourceExhausted
+	case http.StatusInternalServerError:
+		return connect.CodeInternal
+	case http.StatusBadGateway, http.StatusServiceUnavailable:
+		return connect.CodeUnavailable
 	case http.StatusNotImplemented:
 		return connect.CodeUnimplemented
 	case http.StatusGatewayTimeout:
 		return connect.CodeDeadlineExceeded
 	}
-	return connect.CodeUnavailable
+	return connect.CodeUnknown
 }

--- a/pkg/agentcompose/api/capability_error.go
+++ b/pkg/agentcompose/api/capability_error.go
@@ -55,6 +55,16 @@ func octoBusConnectCode(err *capability.OctoBusError) connect.Code {
 		return connect.CodeAlreadyExists
 	case "CANCELED", "CANCELLED":
 		return connect.CodeCanceled
+	case "UNAVAILABLE":
+		return connect.CodeUnavailable
+	case "INTERNAL":
+		return connect.CodeInternal
+	case "OUT_OF_RANGE":
+		return connect.CodeOutOfRange
+	case "DATA_LOSS":
+		return connect.CodeDataLoss
+	case "UNKNOWN":
+		return connect.CodeUnknown
 	}
 	switch err.HTTPStatus {
 	case http.StatusBadRequest:

--- a/pkg/agentcompose/api/capability_error.go
+++ b/pkg/agentcompose/api/capability_error.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"errors"
+	"net/http"
+	"strings"
 
 	"connectrpc.com/connect"
 
@@ -13,12 +15,66 @@ type CapabilityRuntimeConfig interface {
 }
 
 func CapabilityConnectError(err error) error {
+	var upstream *capability.OctoBusError
 	switch {
 	case errors.Is(err, capability.ErrNotConfigured):
 		return connect.NewError(connect.CodeFailedPrecondition, err)
 	case errors.Is(err, capability.ErrInvalidCatalog):
 		return connect.NewError(connect.CodeInvalidArgument, err)
+	case errors.As(err, &upstream):
+		return connect.NewError(octoBusConnectCode(upstream), err)
 	default:
 		return connect.NewError(connect.CodeUnavailable, err)
 	}
+}
+
+func octoBusConnectCode(err *capability.OctoBusError) connect.Code {
+	if err == nil {
+		return connect.CodeUnavailable
+	}
+	switch strings.ToUpper(strings.TrimSpace(err.Code)) {
+	case "INVALID_ARGUMENT":
+		return connect.CodeInvalidArgument
+	case "UNAUTHENTICATED":
+		return connect.CodeUnauthenticated
+	case "PERMISSION_DENIED":
+		return connect.CodePermissionDenied
+	case "NOT_FOUND":
+		return connect.CodeNotFound
+	case "UNIMPLEMENTED":
+		return connect.CodeUnimplemented
+	case "RESOURCE_EXHAUSTED":
+		return connect.CodeResourceExhausted
+	case "DEADLINE_EXCEEDED":
+		return connect.CodeDeadlineExceeded
+	case "FAILED_PRECONDITION":
+		return connect.CodeFailedPrecondition
+	case "ABORTED":
+		return connect.CodeAborted
+	case "ALREADY_EXISTS":
+		return connect.CodeAlreadyExists
+	case "CANCELED", "CANCELLED":
+		return connect.CodeCanceled
+	}
+	switch err.HTTPStatus {
+	case http.StatusBadRequest:
+		return connect.CodeInvalidArgument
+	case http.StatusUnauthorized:
+		return connect.CodeUnauthenticated
+	case http.StatusForbidden:
+		return connect.CodePermissionDenied
+	case http.StatusNotFound:
+		return connect.CodeNotFound
+	case http.StatusConflict:
+		return connect.CodeAborted
+	case http.StatusPreconditionFailed, http.StatusUnprocessableEntity:
+		return connect.CodeFailedPrecondition
+	case http.StatusTooManyRequests:
+		return connect.CodeResourceExhausted
+	case http.StatusNotImplemented:
+		return connect.CodeUnimplemented
+	case http.StatusGatewayTimeout:
+		return connect.CodeDeadlineExceeded
+	}
+	return connect.CodeUnavailable
 }

--- a/pkg/agentcompose/api/capability_error_test.go
+++ b/pkg/agentcompose/api/capability_error_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	"agent-compose/pkg/capability"
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+func TestCapabilityConnectErrorMapsOctoBusHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want connect.Code
+	}{
+		{
+			name: "not found",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "NOT_FOUND", Message: "capset not found"},
+			want: connect.CodeNotFound,
+		},
+		{
+			name: "unauthenticated",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusUnauthorized, Code: "UNAUTHENTICATED", Message: "admin token is required"},
+			want: connect.CodeUnauthenticated,
+		},
+		{
+			name: "invalid argument",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusBadRequest, Code: "INVALID_ARGUMENT", Message: "bad catalog query"},
+			want: connect.CodeInvalidArgument,
+		},
+		{
+			name: "http unauthorized fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusUnauthorized, Message: "admin token is required"},
+			want: connect.CodeUnauthenticated,
+		},
+		{
+			name: "http forbidden fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusForbidden, Message: "forbidden"},
+			want: connect.CodePermissionDenied,
+		},
+		{
+			name: "http not found fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Message: "missing"},
+			want: connect.CodeNotFound,
+		},
+		{
+			name: "http conflict fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusConflict, Message: "already exists"},
+			want: connect.CodeAborted,
+		},
+		{
+			name: "http precondition failed fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusPreconditionFailed, Message: "precondition failed"},
+			want: connect.CodeFailedPrecondition,
+		},
+		{
+			name: "http unprocessable entity fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusUnprocessableEntity, Message: "invalid state"},
+			want: connect.CodeFailedPrecondition,
+		},
+		{
+			name: "http too many requests fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+			want: connect.CodeResourceExhausted,
+		},
+		{
+			name: "http not implemented fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"},
+			want: connect.CodeUnimplemented,
+		},
+		{
+			name: "http gateway timeout fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusGatewayTimeout, Message: "timeout"},
+			want: connect.CodeDeadlineExceeded,
+		},
+		{
+			name: "unknown http status fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusInternalServerError, Message: "upstream failed"},
+			want: connect.CodeUnavailable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CapabilityConnectError(tc.err)
+			if connect.CodeOf(err) != tc.want {
+				t.Fatalf("CapabilityConnectError code = %s, want %s; err=%v", connect.CodeOf(err), tc.want, err)
+			}
+			if !strings.Contains(err.Error(), tc.err.(*capability.OctoBusError).Message) {
+				t.Fatalf("CapabilityConnectError did not preserve upstream message: %v", err)
+			}
+		})
+	}
+}
+
+func TestCapabilityConnectErrorPrefersOctoBusCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want connect.Code
+	}{
+		{
+			name: "deadline exceeded code without matching http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusInternalServerError, Code: "DEADLINE_EXCEEDED", Message: "upstream timed out"},
+			want: connect.CodeDeadlineExceeded,
+		},
+		{
+			name: "aborted code without matching http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusInternalServerError, Code: "ABORTED", Message: "write conflict"},
+			want: connect.CodeAborted,
+		},
+		{
+			name: "canceled code without matching http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusInternalServerError, Code: "CANCELED", Message: "request canceled"},
+			want: connect.CodeCanceled,
+		},
+		{
+			name: "code overrides http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "ABORTED", Message: "transaction conflict"},
+			want: connect.CodeAborted,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CapabilityConnectError(tc.err)
+			if connect.CodeOf(err) != tc.want {
+				t.Fatalf("CapabilityConnectError code = %s, want %s; err=%v", connect.CodeOf(err), tc.want, err)
+			}
+			if !strings.Contains(err.Error(), tc.err.(*capability.OctoBusError).Message) {
+				t.Fatalf("CapabilityConnectError did not preserve upstream message: %v", err)
+			}
+		})
+	}
+}
+
+func TestListCapabilitySetsPreservesOctoBusErrorCode(t *testing.T) {
+	upstream := &capability.OctoBusError{
+		HTTPStatus: http.StatusUnauthorized,
+		Code:       "UNAUTHENTICATED",
+		Message:    "admin token is required",
+	}
+	handler := NewCapabilityV2Handler(&capabilityErrorProvider{listErr: upstream}, nil)
+
+	_, err := handler.ListCapabilitySets(context.Background(), connect.NewRequest(&agentcomposev2.ListCapabilitySetsRequest{}))
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("ListCapabilitySets code = %s, want %s; err=%v", connect.CodeOf(err), connect.CodeUnauthenticated, err)
+	}
+	if !strings.Contains(err.Error(), upstream.Message) {
+		t.Fatalf("ListCapabilitySets did not preserve upstream message: %v", err)
+	}
+}
+
+type capabilityErrorProvider struct {
+	listErr error
+}
+
+func (p *capabilityErrorProvider) Status(context.Context) capability.Status {
+	return capability.Status{}
+}
+
+func (p *capabilityErrorProvider) ListCapsets(context.Context) ([]capability.Capset, error) {
+	return nil, p.listErr
+}
+
+func (p *capabilityErrorProvider) Catalog(context.Context, string) (capability.Catalog, error) {
+	return capability.Catalog{}, nil
+}
+
+func (p *capabilityErrorProvider) CapabilityGuide(context.Context, string) ([]byte, error) {
+	return nil, nil
+}
+
+func (p *capabilityErrorProvider) ProxyTarget() string { return "" }

--- a/pkg/agentcompose/api/capability_error_test.go
+++ b/pkg/agentcompose/api/capability_error_test.go
@@ -79,9 +79,24 @@ func TestCapabilityConnectErrorMapsOctoBusHTTPStatus(t *testing.T) {
 			want: connect.CodeDeadlineExceeded,
 		},
 		{
-			name: "unknown http status fallback",
+			name: "http internal server error fallback",
 			err:  &capability.OctoBusError{HTTPStatus: http.StatusInternalServerError, Message: "upstream failed"},
+			want: connect.CodeInternal,
+		},
+		{
+			name: "http bad gateway fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusBadGateway, Message: "gateway failed"},
 			want: connect.CodeUnavailable,
+		},
+		{
+			name: "http service unavailable fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusServiceUnavailable, Message: "upstream unavailable"},
+			want: connect.CodeUnavailable,
+		},
+		{
+			name: "unknown http status fallback",
+			err:  &capability.OctoBusError{HTTPStatus: 599, Message: "unmapped status"},
+			want: connect.CodeUnknown,
 		},
 	}
 

--- a/pkg/agentcompose/api/capability_error_test.go
+++ b/pkg/agentcompose/api/capability_error_test.go
@@ -124,6 +124,31 @@ func TestCapabilityConnectErrorPrefersOctoBusCode(t *testing.T) {
 			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "ABORTED", Message: "transaction conflict"},
 			want: connect.CodeAborted,
 		},
+		{
+			name: "unavailable code overrides http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "UNAVAILABLE", Message: "upstream unavailable"},
+			want: connect.CodeUnavailable,
+		},
+		{
+			name: "internal code overrides http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "INTERNAL", Message: "upstream internal error"},
+			want: connect.CodeInternal,
+		},
+		{
+			name: "out of range code overrides http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "OUT_OF_RANGE", Message: "value out of range"},
+			want: connect.CodeOutOfRange,
+		},
+		{
+			name: "data loss code overrides http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "DATA_LOSS", Message: "upstream data loss"},
+			want: connect.CodeDataLoss,
+		},
+		{
+			name: "unknown code overrides http fallback",
+			err:  &capability.OctoBusError{HTTPStatus: http.StatusNotFound, Code: "UNKNOWN", Message: "unknown upstream error"},
+			want: connect.CodeUnknown,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/agentcompose/api/capability_error_test.go
+++ b/pkg/agentcompose/api/capability_error_test.go
@@ -15,7 +15,7 @@ import (
 func TestCapabilityConnectErrorMapsOctoBusHTTPStatus(t *testing.T) {
 	tests := []struct {
 		name string
-		err  error
+		err  *capability.OctoBusError
 		want connect.Code
 	}{
 		{
@@ -106,7 +106,7 @@ func TestCapabilityConnectErrorMapsOctoBusHTTPStatus(t *testing.T) {
 			if connect.CodeOf(err) != tc.want {
 				t.Fatalf("CapabilityConnectError code = %s, want %s; err=%v", connect.CodeOf(err), tc.want, err)
 			}
-			if !strings.Contains(err.Error(), tc.err.(*capability.OctoBusError).Message) {
+			if !strings.Contains(err.Error(), tc.err.Message) {
 				t.Fatalf("CapabilityConnectError did not preserve upstream message: %v", err)
 			}
 		})
@@ -116,7 +116,7 @@ func TestCapabilityConnectErrorMapsOctoBusHTTPStatus(t *testing.T) {
 func TestCapabilityConnectErrorPrefersOctoBusCode(t *testing.T) {
 	tests := []struct {
 		name string
-		err  error
+		err  *capability.OctoBusError
 		want connect.Code
 	}{
 		{
@@ -172,7 +172,7 @@ func TestCapabilityConnectErrorPrefersOctoBusCode(t *testing.T) {
 			if connect.CodeOf(err) != tc.want {
 				t.Fatalf("CapabilityConnectError code = %s, want %s; err=%v", connect.CodeOf(err), tc.want, err)
 			}
-			if !strings.Contains(err.Error(), tc.err.(*capability.OctoBusError).Message) {
+			if !strings.Contains(err.Error(), tc.err.Message) {
 				t.Fatalf("CapabilityConnectError did not preserve upstream message: %v", err)
 			}
 		})

--- a/pkg/agentcompose/api/capability_v2.go
+++ b/pkg/agentcompose/api/capability_v2.go
@@ -28,7 +28,7 @@ func (h *CapabilityV2Handler) GetCapabilityStatus(ctx context.Context, _ *connec
 func (h *CapabilityV2Handler) ListCapabilitySets(ctx context.Context, req *connect.Request[agentcomposev2.ListCapabilitySetsRequest]) (*connect.Response[agentcomposev2.ListCapabilitySetsResponse], error) {
 	items, err := h.provider.ListCapsets(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnavailable, err)
+		return nil, CapabilityConnectError(err)
 	}
 	enabled := items[:0]
 	for _, item := range items {

--- a/pkg/capability/client.go
+++ b/pkg/capability/client.go
@@ -106,10 +106,14 @@ func (c *Client) CatalogMarkdown(ctx context.Context, capsetID string) ([]byte, 
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("octobus returned HTTP %d", resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
 	}
-	return io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, octobusHTTPError(resp.StatusCode, body)
+	}
+	return body, nil
 }
 
 func (c *Client) getJSON(ctx context.Context, path string, target any) error {
@@ -126,11 +130,14 @@ func (c *Client) getJSON(ctx context.Context, path string, target any) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("octobus returned HTTP %d", resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
 	}
-	decoder := json.NewDecoder(resp.Body)
-	if err := decoder.Decode(target); err != nil {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return octobusHTTPError(resp.StatusCode, body)
+	}
+	if err := json.Unmarshal(body, target); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/capability/client_test.go
+++ b/pkg/capability/client_test.go
@@ -3,8 +3,10 @@ package capability
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +84,65 @@ func TestClientCatalogUsesAllQueryAndEscapesCapset(t *testing.T) {
 	}
 	if catalog.CapsetID != "dev/tools" {
 		t.Fatalf("unexpected catalog %+v", catalog)
+	}
+}
+
+func TestClientPreservesOctoBusErrorPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    "NOT_FOUND",
+				"message": "capset dev was not found",
+				"details": map[string]any{"capset_id": "dev"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Addr: server.URL})
+	_, err := client.Catalog(context.Background(), "dev")
+	if err == nil {
+		t.Fatal("Catalog returned nil error")
+	}
+	var upstream *OctoBusError
+	if !errors.As(err, &upstream) {
+		t.Fatalf("Catalog error type = %T, want *OctoBusError: %v", err, err)
+	}
+	if upstream.HTTPStatus != http.StatusNotFound || upstream.Code != "NOT_FOUND" || upstream.Message != "capset dev was not found" {
+		t.Fatalf("unexpected OctoBus error: %+v", upstream)
+	}
+	if !strings.Contains(err.Error(), "NOT_FOUND: capset dev was not found") {
+		t.Fatalf("error string did not preserve upstream code/message: %v", err)
+	}
+}
+
+func TestClientCatalogMarkdownPreservesPlainTextOctoBusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/admin/v1/catalog/dev" {
+			t.Fatalf("unexpected path %s", r.URL.EscapedPath())
+		}
+		if r.URL.Query().Get("format") != "md" || r.URL.Query().Get("grpc") != "true" {
+			t.Fatalf("unexpected query %s", r.URL.RawQuery)
+		}
+		if r.Header.Get("Accept") != "text/markdown" {
+			t.Fatalf("unexpected accept header %q", r.Header.Get("Accept"))
+		}
+		http.Error(w, "temporary upstream outage", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Addr: server.URL})
+	_, err := client.CatalogMarkdown(context.Background(), "dev")
+	if err == nil {
+		t.Fatal("CatalogMarkdown returned nil error")
+	}
+	var upstream *OctoBusError
+	if !errors.As(err, &upstream) {
+		t.Fatalf("CatalogMarkdown error type = %T, want *OctoBusError: %v", err, err)
+	}
+	if upstream.HTTPStatus != http.StatusServiceUnavailable || upstream.Code != "HTTP_503" || upstream.Message != http.StatusText(http.StatusServiceUnavailable) {
+		t.Fatalf("unexpected OctoBus error fallback: %+v", upstream)
 	}
 }
 

--- a/pkg/capability/error.go
+++ b/pkg/capability/error.go
@@ -1,0 +1,57 @@
+package capability
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// OctoBusError preserves structured errors returned by the OctoBus admin API.
+type OctoBusError struct {
+	HTTPStatus int
+	Code       string
+	Message    string
+	Details    json.RawMessage
+}
+
+func (e *OctoBusError) Error() string {
+	if e == nil {
+		return ""
+	}
+	code := strings.TrimSpace(e.Code)
+	message := strings.TrimSpace(e.Message)
+	switch {
+	case code != "" && message != "":
+		return fmt.Sprintf("octobus returned HTTP %d: %s: %s", e.HTTPStatus, code, message)
+	case message != "":
+		return fmt.Sprintf("octobus returned HTTP %d: %s", e.HTTPStatus, message)
+	case code != "":
+		return fmt.Sprintf("octobus returned HTTP %d: %s", e.HTTPStatus, code)
+	default:
+		return fmt.Sprintf("octobus returned HTTP %d", e.HTTPStatus)
+	}
+}
+
+func octobusHTTPError(status int, body []byte) error {
+	upstream := &OctoBusError{HTTPStatus: status, Code: fmt.Sprintf("HTTP_%d", status), Message: http.StatusText(status)}
+	var payload struct {
+		Error struct {
+			Code    string          `json:"code"`
+			Message string          `json:"message"`
+			Details json.RawMessage `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil {
+		if code := strings.TrimSpace(payload.Error.Code); code != "" {
+			upstream.Code = code
+		}
+		if message := strings.TrimSpace(payload.Error.Message); message != "" {
+			upstream.Message = message
+		}
+		if len(payload.Error.Details) > 0 {
+			upstream.Details = append(json.RawMessage(nil), payload.Error.Details...)
+		}
+	}
+	return upstream
+}


### PR DESCRIPTION
## Summary
- parse structured OctoBus admin error payloads into a typed capability.OctoBusError
- preserve upstream code/message/details for catalog, guide, and list calls instead of reducing failures to HTTP status only
- map upstream OctoBus codes and HTTP statuses to more accurate Connect error codes

## Root Cause
agent-compose collapsed non-2xx OctoBus admin responses into generic "octobus returned HTTP <status>" errors. API handlers therefore mapped most upstream failures to Unavailable, losing details such as NOT_FOUND or UNAUTHENTICATED.

## Tests
- go test ./pkg/capability ./pkg/agentcompose/api -count=1