### PR TITLE
feat(schedulers): stop persisting command output in scheduler_event.message

### DIFF
--- a/cmd/agent-compose/e2e_docker_scheduler_test.go
+++ b/cmd/agent-compose/e2e_docker_scheduler_test.go
@@ -284,11 +284,11 @@ func waitForScheduledHelloRun(t *testing.T, projectClient agentcomposev2connect.
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		// ListProjectSchedulerEvents (not the UI-only ListSchedulerEvents) is used here
-		// because scheduler.command.completed rows now write an empty DB message and
-		// only ListProjectSchedulerEvents/StreamProjectSchedulerEvents reconstruct the
-		// full text from the sandbox cell artifact (see
-		// docs/design/scheduler_event_storage_design.md §6).
+		// ListProjectSchedulerEvents is used here because it's what `scheduler
+		// logs` actually calls; ListSchedulerEvents (UI-only, unused by any
+		// current caller) also reconstructs command.completed output from the
+		// sandbox cell artifact and is covered separately by
+		// TestListSchedulerEventsResolvesCommandCompletedFromArtifact.
 		eventsResp, err := projectClient.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
 			Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: scheduler.GetProjectId()}},
 			AgentName: scheduler.GetAgentName(),

--- a/cmd/agent-compose/e2e_docker_scheduler_test.go
+++ b/cmd/agent-compose/e2e_docker_scheduler_test.go
@@ -284,7 +284,12 @@ func waitForScheduledHelloRun(t *testing.T, projectClient agentcomposev2connect.
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		eventsResp, err := projectClient.ListSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
+		// ListProjectSchedulerEvents (not the UI-only ListSchedulerEvents) is used here
+		// because scheduler.command.completed rows now write an empty DB message and
+		// only ListProjectSchedulerEvents/StreamProjectSchedulerEvents reconstruct the
+		// full text from the sandbox cell artifact (see
+		// docs/design/scheduler_event_storage_design.md §6).
+		eventsResp, err := projectClient.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
 			Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: scheduler.GetProjectId()}},
 			AgentName: scheduler.GetAgentName(),
 			Limit:     100,

--- a/pkg/agentcompose/api/project_agent_model_test.go
+++ b/pkg/agentcompose/api/project_agent_model_test.go
@@ -23,7 +23,7 @@ func (s projectAgentModelResolverStub) ResolveProjectAgentModels(context.Context
 
 func TestNewProjectHandlerWithAgentModelsSetsResolver(t *testing.T) {
 	resolver := projectAgentModelResolverStub{}
-	handler := NewProjectHandlerWithAgentModels(nil, nil, nil, resolver)
+	handler := NewProjectHandlerWithAgentModels(nil, nil, nil, resolver, nil)
 
 	if _, ok := handler.agentModels.(projectAgentModelResolverStub); !ok {
 		t.Fatalf("agent model resolver = %#v", handler.agentModels)

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -91,6 +91,14 @@ func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRu
 // caller that needs it — beyond NewProjectHandlerWithAgentModels, which
 // takes it directly — chains this instead of silently falling back to the
 // "artifact not accessible" placeholder for every new command.completed row.
+//
+// Like the package's other With* injectors (WithLifecycleLocks,
+// WithRemovalCoordinator, WithRunTargetResolver), this must be called once,
+// immediately after construction, before the handler is registered with the
+// RPC server. h.sandboxDirs is read without synchronization by every
+// concurrent ListSchedulerEvents/ListProjectSchedulerEvents/
+// StreamProjectSchedulerEvents request; calling this after the handler has
+// started serving traffic is a data race.
 func (h *ProjectHandler) WithSandboxDirs(sandboxDirs schedulers.SandboxDirResolver) *ProjectHandler {
 	h.sandboxDirs = sandboxDirs
 	return h

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -84,6 +84,18 @@ func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRu
 	return newProjectHandler(delegate, store, schedulerRuntime, nil, nil)
 }
 
+// WithSandboxDirs injects the sandbox directory resolver ResolveEventMessage
+// needs to reconstruct command.completed scheduler_event messages from
+// sandbox cell artifacts. NewProjectHandler has no dedicated parameter for
+// it (schedulerRuntimes is already the trailing variadic slot), so any
+// caller that needs it — beyond NewProjectHandlerWithAgentModels, which
+// takes it directly — chains this instead of silently falling back to the
+// "artifact not accessible" placeholder for every new command.completed row.
+func (h *ProjectHandler) WithSandboxDirs(sandboxDirs schedulers.SandboxDirResolver) *ProjectHandler {
+	h.sandboxDirs = sandboxDirs
+	return h
+}
+
 // NewProjectHandlerWithAgentModels constructs a project handler that enriches project responses with resolved agent models
 // and, given sandboxDirs, reconstructs command.completed scheduler_event messages from sandbox cell artifacts.
 func NewProjectHandlerWithAgentModels(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver, sandboxDirs schedulers.SandboxDirResolver) *ProjectHandler {
@@ -194,6 +206,7 @@ func (h *ProjectHandler) ListSchedulerEvents(ctx context.Context, req *connect.R
 	for _, event := range events {
 		response.Events = append(response.Events, schedulerEventToProto(event, scheduler))
 	}
+	resolveSchedulerEventMessages(ctx, events, response.Events, h.sandboxDirs)
 	return connect.NewResponse(response), nil
 }
 

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -73,6 +73,7 @@ type ProjectHandler struct {
 	schedulerRuns    ProjectSchedulerRunRuntime
 	invocations      ProjectSchedulerInvocationRuntime
 	schedulerPrune   ProjectSchedulerPruneRuntime
+	sandboxDirs      schedulers.SandboxDirResolver
 }
 
 func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRuntimes ...ProjectSchedulerRuntime) *ProjectHandler {
@@ -80,19 +81,20 @@ func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRu
 	if len(schedulerRuntimes) > 0 {
 		schedulerRuntime = schedulerRuntimes[0]
 	}
-	return newProjectHandler(delegate, store, schedulerRuntime, nil)
+	return newProjectHandler(delegate, store, schedulerRuntime, nil, nil)
 }
 
-// NewProjectHandlerWithAgentModels constructs a project handler that enriches project responses with resolved agent models.
-func NewProjectHandlerWithAgentModels(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver) *ProjectHandler {
-	return newProjectHandler(delegate, store, schedulerRuntime, agentModels)
+// NewProjectHandlerWithAgentModels constructs a project handler that enriches project responses with resolved agent models
+// and, given sandboxDirs, reconstructs command.completed scheduler_event messages from sandbox cell artifacts.
+func NewProjectHandlerWithAgentModels(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver, sandboxDirs schedulers.SandboxDirResolver) *ProjectHandler {
+	return newProjectHandler(delegate, store, schedulerRuntime, agentModels, sandboxDirs)
 }
 
-func newProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver) *ProjectHandler {
+func newProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver, sandboxDirs schedulers.SandboxDirResolver) *ProjectHandler {
 	schedulerRuns, _ := schedulerRuntime.(ProjectSchedulerRunRuntime)
 	invocations, _ := schedulerRuntime.(ProjectSchedulerInvocationRuntime)
 	schedulerPrune, _ := schedulerRuntime.(ProjectSchedulerPruneRuntime)
-	return &ProjectHandler{delegate: delegate, store: store, agentModels: agentModels, schedulerRuntime: schedulerRuntime, schedulerRuns: schedulerRuns, invocations: invocations, schedulerPrune: schedulerPrune}
+	return &ProjectHandler{delegate: delegate, store: store, agentModels: agentModels, schedulerRuntime: schedulerRuntime, schedulerRuns: schedulerRuns, invocations: invocations, schedulerPrune: schedulerPrune, sandboxDirs: sandboxDirs}
 }
 
 func (h *ProjectHandler) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {

--- a/pkg/agentcompose/api/project_scheduler_event_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_event_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"connectrpc.com/connect"
 
@@ -76,14 +77,53 @@ func (h *ProjectHandler) ListProjectSchedulerEvents(ctx context.Context, req *co
 		return nil, ConnectErrorForDomain(err)
 	}
 	response := &agentcomposev2.ListProjectSchedulerEventsResponse{Events: make([]*agentcomposev2.SchedulerEvent, 0, len(events)), Total: uint32(total)}
+	matched := make([]domain.SchedulerEvent, 0, len(events))
 	for _, event := range events {
 		scheduler, ok := bySchedulerID[event.SchedulerID]
 		if !ok {
 			continue
 		}
+		matched = append(matched, event)
 		response.Events = append(response.Events, schedulerEventToProto(event, scheduler))
 	}
+	resolveSchedulerEventMessages(ctx, matched, response.Events, h.sandboxDirs)
 	return connect.NewResponse(response), nil
+}
+
+// maxConcurrentEventMessageResolves bounds how many ResolveEventMessage calls
+// that actually read a sandbox cell artifact run in parallel for a single
+// response page. New command.completed rows (empty DB message) are the only
+// ones that pay this cost (see docs/design/scheduler_event_storage_design.md
+// §4/§6); a small bounded pool trades a handful of goroutines for lower
+// wall-clock time without unbounded fan-out against the filesystem.
+const maxConcurrentEventMessageResolves = 8
+
+// resolveSchedulerEventMessages fills in item.Message for each item from its
+// index-aligned source event. events and items must be the same length and
+// in the same order. Events that ResolveEventMessage can answer without I/O
+// (every non-command.completed event, and any command.completed event whose
+// DB message is already non-empty — see EventMessageNeedsArtifactRead) are
+// resolved inline; only events that need an artifact read are dispatched to
+// the bounded worker pool, since that's the only case worth the goroutine
+// overhead. Each dispatched goroutine only touches its own index, so no
+// synchronization beyond the WaitGroup is needed.
+func resolveSchedulerEventMessages(ctx context.Context, events []domain.SchedulerEvent, items []*agentcomposev2.SchedulerEvent, sandboxDirs schedulers.SandboxDirResolver) {
+	sem := make(chan struct{}, maxConcurrentEventMessageResolves)
+	var wg sync.WaitGroup
+	for i := range items {
+		if !schedulers.EventMessageNeedsArtifactRead(events[i]) {
+			items[i].Message, _ = schedulers.ResolveEventMessage(ctx, events[i], sandboxDirs)
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			items[i].Message, _ = schedulers.ResolveEventMessage(ctx, events[i], sandboxDirs)
+		}(i)
+	}
+	wg.Wait()
 }
 
 func schedulerEventToProto(event domain.SchedulerEvent, scheduler domain.ProjectSchedulerRecord) *agentcomposev2.SchedulerEvent {

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -258,32 +258,41 @@ func TestListSchedulerEventsResolvesCommandCompletedFromArtifact(t *testing.T) {
 	}
 }
 
+// TestNewProjectHandlerWithSandboxDirsInjectsResolver builds two separate
+// handlers from independent fixtures — one left plain, one with
+// WithSandboxDirs chained immediately after construction — rather than
+// mutating a single already-constructed handler between requests. Calling
+// WithSandboxDirs after a handler has started serving requests races with
+// every concurrent handler that reads h.sandboxDirs (see its doc comment),
+// so this test must not model that pattern even sequentially.
 func TestNewProjectHandlerWithSandboxDirsInjectsResolver(t *testing.T) {
-	store, _, handler := newSchedulerRunHandlerFixture() // built via plain NewProjectHandler, no sandboxDirs
 	sandboxDir := t.TempDir()
 	writeSchedulerCommandCellArtifact(t, sandboxDir, "cell-1", "resolved after WithSandboxDirs")
 
-	createdAt := time.Unix(1100, 0).UTC()
-	store.events = []domain.SchedulerEvent{
-		{
-			ID: "event-1", SchedulerID: store.scheduler.ID, TriggerID: "trigger-1",
-			Type: "scheduler.command.completed", Message: "",
-			LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1", CreatedAt: createdAt,
-		},
-	}
-	req := connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
-		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, AgentName: store.scheduler.AgentName,
-	})
-
-	before, err := handler.ListSchedulerEvents(context.Background(), req)
-	if err != nil || len(before.Msg.GetEvents()) != 1 || !strings.Contains(before.Msg.GetEvents()[0].GetMessage(), "content unavailable") {
-		t.Fatalf("before WithSandboxDirs: message = %#v err=%v, want an unavailable placeholder (no resolver injected)", before, err)
+	newRequestWithEvent := func(store *schedulerRunProjectStoreFake) *connect.Request[agentcomposev2.ListSchedulerEventsRequest] {
+		store.events = []domain.SchedulerEvent{
+			{
+				ID: "event-1", SchedulerID: store.scheduler.ID, TriggerID: "trigger-1",
+				Type: "scheduler.command.completed", Message: "",
+				LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1", CreatedAt: time.Unix(1100, 0).UTC(),
+			},
+		}
+		return connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
+			Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, AgentName: store.scheduler.AgentName,
+		})
 	}
 
-	handler.WithSandboxDirs(projectHandlerSandboxDirsFake{"sandbox-1": sandboxDir})
-	after, err := handler.ListSchedulerEvents(context.Background(), req)
-	if err != nil || len(after.Msg.GetEvents()) != 1 || after.Msg.GetEvents()[0].GetMessage() != "resolved after WithSandboxDirs" {
-		t.Fatalf("after WithSandboxDirs: message = %#v err=%v, want reconstructed artifact content", after, err)
+	withoutStore, _, withoutHandler := newSchedulerRunHandlerFixture() // plain NewProjectHandler, sandboxDirs never injected
+	without, err := withoutHandler.ListSchedulerEvents(context.Background(), newRequestWithEvent(withoutStore))
+	if err != nil || len(without.Msg.GetEvents()) != 1 || !strings.Contains(without.Msg.GetEvents()[0].GetMessage(), "content unavailable") {
+		t.Fatalf("without WithSandboxDirs: message = %#v err=%v, want an unavailable placeholder", without, err)
+	}
+
+	withStore, _, withHandler := newSchedulerRunHandlerFixture()
+	withHandler.WithSandboxDirs(projectHandlerSandboxDirsFake{"sandbox-1": sandboxDir}) // chained immediately after construction, before any request
+	with, err := withHandler.ListSchedulerEvents(context.Background(), newRequestWithEvent(withStore))
+	if err != nil || len(with.Msg.GetEvents()) != 1 || with.Msg.GetEvents()[0].GetMessage() != "resolved after WithSandboxDirs" {
+		t.Fatalf("with WithSandboxDirs: message = %#v err=%v, want reconstructed artifact content", with, err)
 	}
 }
 

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -224,6 +226,45 @@ func TestProjectHandlerListsProjectSchedulerEventsWithIdentityAndOffset(t *testi
 	}))
 	if err != nil || len(second.Msg.GetEvents()) != 1 || second.Msg.GetEvents()[0].GetId() != "event-1" || second.Msg.GetTotal() != 2 {
 		t.Fatalf("second event page=%#v err=%v", second, err)
+	}
+}
+
+// projectHandlerSandboxDirsFake is a minimal schedulers.SandboxDirResolver for
+// exercising ResolveEventMessage end-to-end through the RPC handlers.
+type projectHandlerSandboxDirsFake map[string]string
+
+func (f projectHandlerSandboxDirsFake) SandboxDir(id string) string { return f[id] }
+
+func writeSchedulerCommandCellArtifact(t *testing.T, sandboxDir, cellID, content string) {
+	t.Helper()
+	cellDir := filepath.Join(sandboxDir, "state", "cells", cellID)
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatalf("mkdir cell dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cellDir, "output.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write output.txt: %v", err)
+	}
+}
+
+func TestListProjectSchedulerEventsResolvesCommandCompletedFromArtifact(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	sandboxDir := t.TempDir()
+	writeSchedulerCommandCellArtifact(t, sandboxDir, "cell-1", "full reconstructed output")
+	handler.sandboxDirs = projectHandlerSandboxDirsFake{"sandbox-1": sandboxDir}
+
+	createdAt := time.Unix(700, 0).UTC()
+	store.events = []domain.SchedulerEvent{
+		{
+			ID: "event-1", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1",
+			Type: "scheduler.command.completed", Message: "", // §4: new rows always write an empty message
+			PayloadJSON: `{"outputBytes":26}`, LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1", CreatedAt: createdAt,
+		},
+	}
+	resp, err := handler.ListProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListProjectSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
+	}))
+	if err != nil || len(resp.Msg.GetEvents()) != 1 || resp.Msg.GetEvents()[0].GetMessage() != "full reconstructed output" {
+		t.Fatalf("ListProjectSchedulerEvents = %#v err=%v", resp, err)
 	}
 }
 

--- a/pkg/agentcompose/api/project_scheduler_run_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_run_handler_test.go
@@ -235,6 +235,58 @@ type projectHandlerSandboxDirsFake map[string]string
 
 func (f projectHandlerSandboxDirsFake) SandboxDir(id string) string { return f[id] }
 
+func TestListSchedulerEventsResolvesCommandCompletedFromArtifact(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	sandboxDir := t.TempDir()
+	writeSchedulerCommandCellArtifact(t, sandboxDir, "cell-1", "ui endpoint full output")
+	handler.WithSandboxDirs(projectHandlerSandboxDirsFake{"sandbox-1": sandboxDir})
+
+	createdAt := time.Unix(1000, 0).UTC()
+	store.events = []domain.SchedulerEvent{
+		{
+			ID: "event-1", SchedulerID: store.scheduler.ID, TriggerID: "trigger-1",
+			Type: "scheduler.command.completed", Message: "",
+			LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1", CreatedAt: createdAt,
+		},
+	}
+	resp, err := handler.ListSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
+		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
+		AgentName: store.scheduler.AgentName,
+	}))
+	if err != nil || len(resp.Msg.GetEvents()) != 1 || resp.Msg.GetEvents()[0].GetMessage() != "ui endpoint full output" {
+		t.Fatalf("ListSchedulerEvents = %#v err=%v", resp, err)
+	}
+}
+
+func TestNewProjectHandlerWithSandboxDirsInjectsResolver(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture() // built via plain NewProjectHandler, no sandboxDirs
+	sandboxDir := t.TempDir()
+	writeSchedulerCommandCellArtifact(t, sandboxDir, "cell-1", "resolved after WithSandboxDirs")
+
+	createdAt := time.Unix(1100, 0).UTC()
+	store.events = []domain.SchedulerEvent{
+		{
+			ID: "event-1", SchedulerID: store.scheduler.ID, TriggerID: "trigger-1",
+			Type: "scheduler.command.completed", Message: "",
+			LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1", CreatedAt: createdAt,
+		},
+	}
+	req := connect.NewRequest(&agentcomposev2.ListSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}}, AgentName: store.scheduler.AgentName,
+	})
+
+	before, err := handler.ListSchedulerEvents(context.Background(), req)
+	if err != nil || len(before.Msg.GetEvents()) != 1 || !strings.Contains(before.Msg.GetEvents()[0].GetMessage(), "content unavailable") {
+		t.Fatalf("before WithSandboxDirs: message = %#v err=%v, want an unavailable placeholder (no resolver injected)", before, err)
+	}
+
+	handler.WithSandboxDirs(projectHandlerSandboxDirsFake{"sandbox-1": sandboxDir})
+	after, err := handler.ListSchedulerEvents(context.Background(), req)
+	if err != nil || len(after.Msg.GetEvents()) != 1 || after.Msg.GetEvents()[0].GetMessage() != "resolved after WithSandboxDirs" {
+		t.Fatalf("after WithSandboxDirs: message = %#v err=%v, want reconstructed artifact content", after, err)
+	}
+}
+
 func writeSchedulerCommandCellArtifact(t *testing.T, sandboxDir, cellID, content string) {
 	t.Helper()
 	cellDir := filepath.Join(sandboxDir, "state", "cells", cellID)

--- a/pkg/agentcompose/api/project_scheduler_stream_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_stream_handler.go
@@ -82,13 +82,17 @@ func (h *ProjectHandler) sendSchedulerEventPages(ctx context.Context, stream *co
 		if len(events) == 0 {
 			break
 		}
+		matched := make([]domain.SchedulerEvent, 0, len(events))
 		items := make([]*agentcomposev2.SchedulerEvent, 0, len(events))
 		for _, event := range events {
 			scheduler, ok := selection.schedulers[event.SchedulerID]
-			if ok {
-				items = append(items, schedulerEventToProto(event, scheduler))
+			if !ok {
+				continue
 			}
+			matched = append(matched, event)
+			items = append(items, schedulerEventToProto(event, scheduler))
 		}
+		resolveSchedulerEventMessages(ctx, matched, items, h.sandboxDirs)
 		last := events[len(events)-1]
 		after = &last
 		emitted += uint64(len(items))

--- a/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
+++ b/pkg/agentcompose/api/project_scheduler_stream_handler_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,6 +79,87 @@ func TestStreamProjectSchedulerEventsTailsInDisplayOrder(t *testing.T) {
 		t.Fatalf("event ids/completion = %#v / %#v", eventIDs, completed)
 	}
 	assertSchedulerStreamHeaders(t, stream.ResponseHeader())
+}
+
+func TestStreamProjectSchedulerEventsResolvesCommandCompletedFromArtifact(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	sandboxDir := t.TempDir()
+	writeSchedulerCommandCellArtifact(t, sandboxDir, "cell-1", "streamed full output")
+	handler.sandboxDirs = projectHandlerSandboxDirsFake{"sandbox-1": sandboxDir}
+
+	createdAt := time.Unix(800, 0).UTC()
+	store.events = []domain.SchedulerEvent{
+		{
+			ID: "event-1", SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1",
+			Type: "scheduler.command.completed", Message: "",
+			LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1", CreatedAt: createdAt,
+		},
+	}
+	client, closeServer := schedulerStreamTestClient(t, handler)
+	defer closeServer()
+	stream, err := client.StreamProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
+	}))
+	if err != nil {
+		t.Fatalf("StreamProjectSchedulerEvents returned error: %v", err)
+	}
+	var messages []string
+	for stream.Receive() {
+		for _, event := range stream.Msg().GetEvents() {
+			messages = append(messages, event.GetMessage())
+		}
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamProjectSchedulerEvents receive error: %v", err)
+	}
+	if len(messages) != 1 || messages[0] != "streamed full output" {
+		t.Fatalf("messages = %#v, want reconstructed artifact content", messages)
+	}
+}
+
+func TestStreamProjectSchedulerEventsResolvesManyCommandCompletedEventsInOrder(t *testing.T) {
+	store, _, handler := newSchedulerRunHandlerFixture()
+	sandboxDir := t.TempDir()
+	handler.sandboxDirs = projectHandlerSandboxDirsFake{"sandbox-1": sandboxDir}
+
+	const eventCount = 20 // exceeds maxConcurrentEventMessageResolves, exercising the bounded pool
+	createdAt := time.Unix(900, 0).UTC()
+	store.events = make([]domain.SchedulerEvent, 0, eventCount)
+	for i := 0; i < eventCount; i++ {
+		cellID := fmt.Sprintf("cell-%d", i)
+		writeSchedulerCommandCellArtifact(t, sandboxDir, cellID, fmt.Sprintf("output-%d", i))
+		store.events = append(store.events, domain.SchedulerEvent{
+			ID: fmt.Sprintf("event-%d", i), SchedulerID: store.scheduler.ID, RunID: "run-1", TriggerID: "trigger-1",
+			Type: "scheduler.command.completed", Message: "",
+			LinkedSandboxID: "sandbox-1", LinkedCellID: cellID, CreatedAt: createdAt.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	client, closeServer := schedulerStreamTestClient(t, handler)
+	defer closeServer()
+	stream, err := client.StreamProjectSchedulerEvents(context.Background(), connect.NewRequest(&agentcomposev2.StreamProjectSchedulerEventsRequest{
+		Project: &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: store.project.ID}},
+	}))
+	if err != nil {
+		t.Fatalf("StreamProjectSchedulerEvents returned error: %v", err)
+	}
+	var messages []string
+	for stream.Receive() {
+		for _, event := range stream.Msg().GetEvents() {
+			messages = append(messages, event.GetMessage())
+		}
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("StreamProjectSchedulerEvents receive error: %v", err)
+	}
+	if len(messages) != eventCount {
+		t.Fatalf("messages count = %d, want %d", len(messages), eventCount)
+	}
+	for i, message := range messages {
+		if want := fmt.Sprintf("output-%d", i); message != want {
+			t.Fatalf("messages[%d] = %q, want %q (concurrent resolution must preserve display order)", i, message, want)
+		}
+	}
 }
 
 func schedulerStreamTestClient(t *testing.T, handler *ProjectHandler) (agentcomposev2connect.ProjectServiceClient, func()) {

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -102,6 +102,7 @@ func RegisterRoutes(di do.Injector) {
 		do.MustInvoke[*configstore.ConfigStore](di),
 		do.MustInvoke[*schedulers.Controller](di),
 		newProjectAgentModelResolver(do.MustInvoke[*appconfig.Config](di), do.MustInvoke[*configstore.ConfigStore](di)),
+		do.MustInvoke[*sandboxstore.Store](di),
 	)
 	path, handler := agentcomposev2connect.NewProjectServiceHandler(projectHandler)
 	app.Any(path+"*", echo.WrapHandler(handler))

--- a/pkg/schedulers/event_message.go
+++ b/pkg/schedulers/event_message.go
@@ -1,0 +1,114 @@
+package schedulers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+)
+
+// SandboxDirResolver resolves a sandbox ID to its host-side state directory.
+// *sandboxstore.Store satisfies this via its existing SandboxDir method; it is
+// declared narrowly here so ResolveEventMessage can be exercised in tests
+// without a full sandbox store.
+type SandboxDirResolver interface {
+	SandboxDir(id string) string
+}
+
+// ResolveEventMessage returns the display text for a scheduler_event and
+// whether that text came from a live artifact read, per
+// docs/design/scheduler_event_storage_design.md §6.
+//
+// For (loader|scheduler).command.completed events, event.Message is the
+// discriminator between old and new rows: rows written before this event
+// type started clearing its message (see §4) still carry the full text
+// there, so a non-empty message is returned as-is with no I/O — the DB and
+// the sandbox cell artifact were written from the same in-memory result at
+// the same time, so there is nothing for a fresh artifact read to correct.
+// Only a genuinely empty message (a row written after §4) triggers an
+// artifact read; if that also fails (sandbox archived, artifact never
+// written, or the event has no linked sandbox/cell) it synthesizes a
+// "content unavailable" placeholder from the payload's outputBytes.
+//
+// Every other event type returns event.Message as-is with no I/O.
+func ResolveEventMessage(ctx context.Context, event domain.SchedulerEvent, sandboxDirs SandboxDirResolver) (text string, artifactAvailable bool) {
+	if !EventMessageNeedsArtifactRead(event) {
+		return event.Message, true
+	}
+	if text, ok := readCommandCompletedArtifact(ctx, event, sandboxDirs); ok {
+		return text, true
+	}
+	return commandArtifactUnavailableMessage(event), false
+}
+
+// EventMessageNeedsArtifactRead reports whether ResolveEventMessage would
+// need to read the sandbox cell artifact for this event, i.e. whether it's
+// worth scheduling onto a bounded worker pool rather than resolving inline.
+// Every non-command.completed event and every command.completed event with
+// a non-empty message (see ResolveEventMessage's doc comment) is a cheap,
+// I/O-free lookup — only a command.completed row with an empty message
+// (written after §4) needs the read.
+func EventMessageNeedsArtifactRead(event domain.SchedulerEvent) bool {
+	return isCommandCompletedEventType(event.Type) && event.Message == ""
+}
+
+func isCommandCompletedEventType(eventType string) bool {
+	switch eventType {
+	case "scheduler.command.completed", "loader.command.completed":
+		return true
+	default:
+		return false
+	}
+}
+
+func readCommandCompletedArtifact(ctx context.Context, event domain.SchedulerEvent, sandboxDirs SandboxDirResolver) (string, bool) {
+	if sandboxDirs == nil || ctx.Err() != nil {
+		return "", false
+	}
+	sandboxID := strings.TrimSpace(event.LinkedSandboxID)
+	cellID := strings.TrimSpace(event.LinkedCellID)
+	if sandboxID == "" || cellID == "" {
+		return "", false
+	}
+	cellDir := filepath.Join(sandboxDirs.SandboxDir(sandboxID), "state", "cells", cellID)
+
+	// output.txt already holds the write path's chosen content in the common
+	// case (firstHostNonEmpty below picks it first too, so a non-empty read
+	// here always wins regardless of what stdout.txt/stderr.txt contain).
+	// Check it before paying for two more reads whose result would just be
+	// discarded.
+	output, outputErr := os.ReadFile(filepath.Join(cellDir, "output.txt"))
+	if outputErr == nil && strings.TrimSpace(string(output)) != "" {
+		return string(output), true
+	}
+
+	stdout, stdoutErr := os.ReadFile(filepath.Join(cellDir, "stdout.txt"))
+	stderr, stderrErr := os.ReadFile(filepath.Join(cellDir, "stderr.txt"))
+	if outputErr != nil && stdoutErr != nil && stderrErr != nil {
+		return "", false
+	}
+	return firstHostNonEmpty(string(output), string(stdout), string(stderr), "scheduler command completed"), true
+}
+
+func commandArtifactUnavailableMessage(event domain.SchedulerEvent) string {
+	return fmt.Sprintf("content unavailable (artifact not accessible, %d bytes)", commandEventOutputBytes(event))
+}
+
+func commandEventOutputBytes(event domain.SchedulerEvent) int {
+	if event.PayloadJSON == "" {
+		return 0
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(event.PayloadJSON), &payload); err != nil {
+		return 0
+	}
+	value, ok := payload["outputBytes"].(float64)
+	if !ok {
+		return 0
+	}
+	return int(value)
+}

--- a/pkg/schedulers/event_message_test.go
+++ b/pkg/schedulers/event_message_test.go
@@ -1,0 +1,198 @@
+package schedulers_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/schedulers"
+)
+
+type fakeSandboxDirResolver struct {
+	t      *testing.T
+	dirs   map[string]string
+	forbid bool
+}
+
+func (f *fakeSandboxDirResolver) SandboxDir(id string) string {
+	if f.forbid {
+		f.t.Fatalf("SandboxDir(%q) called for an event type that must not do artifact I/O", id)
+	}
+	return f.dirs[id]
+}
+
+func writeCellArtifact(t *testing.T, sandboxDir, cellID, name, content string) {
+	t.Helper()
+	cellDir := filepath.Join(sandboxDir, "state", "cells", cellID)
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatalf("mkdir cell dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cellDir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestResolveEventMessageNonCommandTypeReturnsMessageWithoutIO(t *testing.T) {
+	event := domain.SchedulerEvent{Type: "scheduler.run.started", Message: "run started"}
+	resolver := &fakeSandboxDirResolver{t: t, forbid: true}
+
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if text != "run started" || !ok {
+		t.Fatalf("ResolveEventMessage = %q,%v want %q,true", text, ok, "run started")
+	}
+}
+
+func TestResolveEventMessageNewRowReadsArtifact(t *testing.T) {
+	dir := t.TempDir()
+	writeCellArtifact(t, dir, "cell-1", "output.txt", "full command output")
+	resolver := &fakeSandboxDirResolver{t: t, dirs: map[string]string{"sandbox-1": dir}}
+
+	event := domain.SchedulerEvent{
+		Type:            "scheduler.command.completed",
+		Message:         "", // §4: new rows always write an empty message
+		LinkedSandboxID: "sandbox-1",
+		LinkedCellID:    "cell-1",
+	}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if text != "full command output" || !ok {
+		t.Fatalf("ResolveEventMessage = %q,%v want artifact content,true", text, ok)
+	}
+}
+
+func TestResolveEventMessageOutputTxtTakesPriorityOverStdoutStderr(t *testing.T) {
+	dir := t.TempDir()
+	writeCellArtifact(t, dir, "cell-1", "output.txt", "output.txt wins")
+	writeCellArtifact(t, dir, "cell-1", "stdout.txt", "stdout.txt loses")
+	writeCellArtifact(t, dir, "cell-1", "stderr.txt", "stderr.txt loses")
+	resolver := &fakeSandboxDirResolver{t: t, dirs: map[string]string{"sandbox-1": dir}}
+
+	event := domain.SchedulerEvent{Type: "scheduler.command.completed", LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1"}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if text != "output.txt wins" || !ok {
+		t.Fatalf("ResolveEventMessage = %q,%v want output.txt content to take priority (matches the write-path firstHostNonEmpty order)", text, ok)
+	}
+}
+
+func TestResolveEventMessageFallsBackToStdoutWhenOutputTxtEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeCellArtifact(t, dir, "cell-1", "output.txt", "")
+	writeCellArtifact(t, dir, "cell-1", "stdout.txt", "stdout content")
+	writeCellArtifact(t, dir, "cell-1", "stderr.txt", "stderr content")
+	resolver := &fakeSandboxDirResolver{t: t, dirs: map[string]string{"sandbox-1": dir}}
+
+	event := domain.SchedulerEvent{Type: "scheduler.command.completed", LinkedSandboxID: "sandbox-1", LinkedCellID: "cell-1"}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if text != "stdout content" || !ok {
+		t.Fatalf("ResolveEventMessage = %q,%v want stdout.txt content when output.txt is empty", text, ok)
+	}
+}
+
+func TestResolveEventMessageLegacyLoaderTypeReadsArtifact(t *testing.T) {
+	dir := t.TempDir()
+	writeCellArtifact(t, dir, "cell-1", "output.txt", "legacy artifact output")
+	resolver := &fakeSandboxDirResolver{t: t, dirs: map[string]string{"sandbox-1": dir}}
+
+	event := domain.SchedulerEvent{
+		Type:            "loader.command.completed",
+		Message:         "",
+		LinkedSandboxID: "sandbox-1",
+		LinkedCellID:    "cell-1",
+	}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if text != "legacy artifact output" || !ok {
+		t.Fatalf("ResolveEventMessage = %q,%v want artifact content,true", text, ok)
+	}
+}
+
+func TestResolveEventMessageNewRowArtifactUnavailableProducesPlaceholder(t *testing.T) {
+	resolver := &fakeSandboxDirResolver{t: t, dirs: map[string]string{"sandbox-1": t.TempDir()}} // no cell dir written: sandbox archived / never flushed
+
+	event := domain.SchedulerEvent{
+		Type:            "scheduler.command.completed",
+		Message:         "",
+		PayloadJSON:     `{"outputBytes":4153756}`,
+		LinkedSandboxID: "sandbox-1",
+		LinkedCellID:    "cell-missing",
+	}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if ok {
+		t.Fatalf("artifactAvailable = true, want false when artifact cannot be read")
+	}
+	if !strings.Contains(text, "4153756") {
+		t.Fatalf("placeholder text = %q, want it to include outputBytes from payload_json", text)
+	}
+}
+
+func TestResolveEventMessageHistoricalRowSkipsArtifactReadWhenMessagePresent(t *testing.T) {
+	// The DB message and the sandbox cell artifact are written from the same
+	// in-memory result at the same time, so a non-empty message means this is
+	// a row written before §4 started clearing it — there is nothing for a
+	// fresh artifact read to correct. Pin this with a forbidding resolver so
+	// the test fails loudly if a future change reintroduces the read: even
+	// though a *different* artifact exists on disk (as it never legitimately
+	// would in production), it must never be consulted, let alone win.
+	dir := t.TempDir()
+	writeCellArtifact(t, dir, "cell-1", "output.txt", "an artifact must never be consulted here")
+	resolver := &fakeSandboxDirResolver{t: t, forbid: true, dirs: map[string]string{"sandbox-1": dir}}
+
+	event := domain.SchedulerEvent{
+		Type:            "scheduler.command.completed",
+		Message:         "full output written before this event type started clearing message",
+		LinkedSandboxID: "sandbox-1",
+		LinkedCellID:    "cell-1",
+	}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if !ok {
+		t.Fatalf("artifactAvailable = false, want true (returned DB message without I/O)")
+	}
+	if text != event.Message {
+		t.Fatalf("text = %q, want historical DB message %q unchanged", text, event.Message)
+	}
+}
+
+func TestResolveEventMessageMissingLinkedIDsSkipsIOAndFallsBackToMessage(t *testing.T) {
+	resolver := &fakeSandboxDirResolver{t: t, forbid: true}
+
+	event := domain.SchedulerEvent{Type: "scheduler.command.completed", Message: "no linked sandbox/cell on this row"}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, resolver)
+	if text != event.Message || !ok {
+		t.Fatalf("ResolveEventMessage = %q,%v want %q,true", text, ok, event.Message)
+	}
+}
+
+func TestEventMessageNeedsArtifactRead(t *testing.T) {
+	cases := []struct {
+		name  string
+		event domain.SchedulerEvent
+		want  bool
+	}{
+		{"non-command type, empty message", domain.SchedulerEvent{Type: "scheduler.run.started", Message: ""}, false},
+		{"non-command type, non-empty message", domain.SchedulerEvent{Type: "scheduler.log", Message: "hi"}, false},
+		{"command.completed, empty message (new row)", domain.SchedulerEvent{Type: "scheduler.command.completed", Message: ""}, true},
+		{"command.completed, non-empty message (historical row)", domain.SchedulerEvent{Type: "scheduler.command.completed", Message: "content"}, false},
+		{"legacy loader.command.completed, empty message", domain.SchedulerEvent{Type: "loader.command.completed", Message: ""}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := schedulers.EventMessageNeedsArtifactRead(tc.event); got != tc.want {
+				t.Fatalf("EventMessageNeedsArtifactRead(%#v) = %v, want %v", tc.event, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveEventMessageNilSandboxDirsFallsBackToMessage(t *testing.T) {
+	event := domain.SchedulerEvent{
+		Type:            "scheduler.command.completed",
+		Message:         "historical content, no resolver wired",
+		LinkedSandboxID: "sandbox-1",
+		LinkedCellID:    "cell-1",
+	}
+	text, ok := schedulers.ResolveEventMessage(context.Background(), event, nil)
+	if text != event.Message || !ok {
+		t.Fatalf("ResolveEventMessage = %q,%v want %q,true", text, ok, event.Message)
+	}
+}

--- a/pkg/schedulers/payload.go
+++ b/pkg/schedulers/payload.go
@@ -45,6 +45,7 @@ func CommandEventPayload(request domain.SchedulerCommandRequest, result domain.S
 		"success":         result.Success,
 		"stdoutTruncated": result.StdoutTruncated,
 		"stderrTruncated": result.StderrTruncated,
+		"outputBytes":     commandOutputBytes(result),
 		"sandboxId":       result.SandboxID,
 		"cellId":          result.CellID,
 	}
@@ -52,4 +53,22 @@ func CommandEventPayload(request domain.SchedulerCommandRequest, result domain.S
 		payload["command"] = ""
 	}
 	return payload
+}
+
+// commandOutputBytes reports the size of whichever field addLinkedSchedulerEvent
+// would have used as the scheduler_event.message before this event type started
+// clearing it (see docs/design/scheduler_event_storage_design.md §4/§6): the
+// first non-blank of Output/Stdout/Stderr. It backs the "content unavailable"
+// placeholder ResolveEventMessage produces when the artifact can't be read.
+func commandOutputBytes(result domain.SchedulerCommandResult) int {
+	switch {
+	case strings.TrimSpace(result.Output) != "":
+		return len(result.Output)
+	case strings.TrimSpace(result.Stdout) != "":
+		return len(result.Stdout)
+	case strings.TrimSpace(result.Stderr) != "":
+		return len(result.Stderr)
+	default:
+		return 0
+	}
 }

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -310,7 +310,10 @@ func (h *RuntimeHost) Command(ctx context.Context, request domain.SchedulerComma
 	if !result.Success {
 		level = "error"
 	}
-	_ = h.addLinkedSchedulerEvent(ctx, "scheduler.command.completed", level, firstHostNonEmpty(result.Output, result.Stdout, result.Stderr, "scheduler command completed"), CommandEventPayload(request, result), result.SandboxID, result.CellID, "")
+	// message is always empty for this event type: full output lives in the
+	// sandbox cell artifact and is reconstructed on read by ResolveEventMessage
+	// (see docs/design/scheduler_event_storage_design.md §4/§6).
+	_ = h.addLinkedSchedulerEvent(ctx, "scheduler.command.completed", level, "", CommandEventPayload(request, result), result.SandboxID, result.CellID, "")
 	return result, nil
 }
 

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -2,6 +2,7 @@ package schedulers_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -383,6 +384,60 @@ func TestRuntimeHostCommandPersistsRunSandboxLinkBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestRuntimeHostCommandCompletedMessageAlwaysEmpty(t *testing.T) {
+	ctx := context.Background()
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-empty-message"}}
+	run := &domain.SchedulerRunSummary{ID: "run-empty-message", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-empty-message"}
+
+	largeOutput := strings.Repeat("x", 200_000)
+	cases := []struct {
+		name   string
+		result domain.SchedulerCommandResult
+	}{
+		{"small output", domain.SchedulerCommandResult{Output: "ok", Success: true, SandboxID: "sandbox-small", CellID: "cell-small"}},
+		{"large output", domain.SchedulerCommandResult{Output: largeOutput, Success: true, SandboxID: "sandbox-large", CellID: "cell-large"}},
+		{"empty output", domain.SchedulerCommandResult{Success: true, SandboxID: "sandbox-none", CellID: "cell-none"}},
+		{"failed exit code", domain.SchedulerCommandResult{Output: "boom", Success: false, SandboxID: "sandbox-fail", CellID: "cell-fail"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			events := &hostEventsFake{}
+			host := schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
+				Events:          events,
+				Sessions:        &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: tc.result.SandboxID, VMStatus: domain.VMStatusRunning}}},
+				CommandExecutor: &hostCommandExecutorFake{result: tc.result},
+			}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{})
+
+			if _, err := host.Command(ctx, domain.SchedulerCommandRequest{Mode: "shell", Command: "echo"}); err != nil {
+				t.Fatalf("Command returned error: %v", err)
+			}
+			event, ok := events.find("scheduler.command.completed")
+			if !ok {
+				t.Fatalf("scheduler.command.completed event not recorded, events = %#v", events.types())
+			}
+			if event.Message != "" {
+				t.Fatalf("message = %q, want empty regardless of output size (§4)", event.Message)
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(event.PayloadJSON), &payload); err != nil {
+				t.Fatalf("unmarshal payload_json: %v", err)
+			}
+			if _, ok := payload["messageTruncated"]; ok {
+				t.Fatalf("payload_json contains messageTruncated, which was never introduced: %#v", payload)
+			}
+			gotBytes, ok := payload["outputBytes"].(float64)
+			if !ok {
+				t.Fatalf("payload_json missing numeric outputBytes: %#v", payload)
+			}
+			if int(gotBytes) != len(tc.result.Output) {
+				t.Fatalf("outputBytes = %v, want %d", gotBytes, len(tc.result.Output))
+			}
+		})
+	}
+}
+
 func TestRuntimeHostCommandDoesNotExecuteWhenRunSandboxLinkFails(t *testing.T) {
 	ctx := context.Background()
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-link-failure"}}
@@ -580,9 +635,15 @@ func (e *hostEventsFake) Add(ctx context.Context, schedulerID, runID, triggerID,
 	return err
 }
 
-func (e *hostEventsFake) AddRecord(_ context.Context, schedulerID, runID, triggerID, eventType, level, message string, _ any, linkedSandboxID, linkedCellID, linkedAgentThreadID string) (domain.SchedulerEvent, error) {
+func (e *hostEventsFake) AddRecord(_ context.Context, schedulerID, runID, triggerID, eventType, level, message string, payload any, linkedSandboxID, linkedCellID, linkedAgentThreadID string) (domain.SchedulerEvent, error) {
 	if e.addRecordErr != nil && (e.failType == "" || e.failType == eventType) {
 		return domain.SchedulerEvent{}, e.addRecordErr
+	}
+	payloadJSON := ""
+	if payload != nil {
+		if data, err := json.Marshal(payload); err == nil {
+			payloadJSON = string(data)
+		}
 	}
 	event := domain.SchedulerEvent{
 		ID:                  fmt.Sprintf("event-%d", len(e.items)+1),
@@ -592,6 +653,7 @@ func (e *hostEventsFake) AddRecord(_ context.Context, schedulerID, runID, trigge
 		Type:                eventType,
 		Level:               level,
 		Message:             message,
+		PayloadJSON:         payloadJSON,
 		LinkedSandboxID:     linkedSandboxID,
 		LinkedCellID:        linkedCellID,
 		LinkedAgentThreadID: linkedAgentThreadID,
@@ -608,6 +670,15 @@ func (e *hostEventsFake) contains(eventType string) bool {
 		}
 	}
 	return false
+}
+
+func (e *hostEventsFake) find(eventType string) (domain.SchedulerEvent, bool) {
+	for _, item := range e.items {
+		if item.Type == eventType {
+			return item, true
+		}
+	}
+	return domain.SchedulerEvent{}, false
 }
 
 func (e *hostEventsFake) types() []string {


### PR DESCRIPTION
## Summary
Code implementation of the plan documented (and tracked separately) in `docs/design/scheduler_event_storage_design.md` (issue #565; supersedes #594 and #596, both closed). `scheduler.command.completed` events no longer write full command output into `scheduler_event.message`; the daemon reconstructs it on read from the sandbox cell artifact when serving `scheduler logs`.

- `pkg/schedulers/run_host.go` / `payload.go`: `scheduler.command.completed` now writes `message=""` unconditionally; `payload_json` gains `outputBytes`.
- `pkg/schedulers/event_message.go` (new): `ResolveEventMessage(ctx, event, sandboxDirs)`. A non-empty DB message (row written before this change) is returned as-is with zero I/O. An empty message (new row) reads the sandbox cell artifact, checking `output.txt` first and only falling back to `stdout.txt`/`stderr.txt` when needed; if the artifact is unavailable it synthesizes an `outputBytes`-sized placeholder. `EventMessageNeedsArtifactRead` exposes the same predicate to callers.
- `pkg/agentcompose/api`: wires `ResolveEventMessage` into `ListProjectSchedulerEvents`, `StreamProjectSchedulerEvents`, and now `ListSchedulerEvents` via a shared, bounded-concurrency `resolveSchedulerEventMessages` helper — only events that actually need the artifact read are scheduled onto a worker pool (capped at 8), everything else resolves inline. `ProjectHandler` now takes a `schedulers.SandboxDirResolver`; the default `NewProjectHandler` exposes it via a new `WithSandboxDirs` chained setter (documented as construction-time-only, matching the existing `WithLifecycleLocks`/`WithRemovalCoordinator`/`WithRunTargetResolver` pattern), while `NewProjectHandlerWithAgentModels` still takes it directly. Wired from `*sandboxstore.Store` in `app.go`.
- `cmd/agent-compose/e2e_docker_scheduler_test.go`: switched the docker e2e assertion from `ListSchedulerEvents` to `ListProjectSchedulerEvents`.

Review follow-ups (addressed in later commits on this branch):
- `ListSchedulerEvents` was initially left unresolved (UI-only, believed to have no callers) — wired into the same resolver so new `command.completed` rows don't show up empty there either.
- `WithSandboxDirs` writes `h.sandboxDirs` without synchronization while requests read it concurrently — doc'd as must-call-before-serving-traffic, consistent with the package's other post-construction injectors; the injection test was rewritten to stop modeling the unsafe "inject after serving" pattern.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/schedulers/... ./pkg/agentcompose/...`
- [x] `go test ./pkg/schedulers/... ./pkg/agentcompose/api/... ./pkg/agentcompose/app/...` (including `-race`)
- [x] `go build/vet -tags docker_e2e ./cmd/agent-compose/...`
- [x] Manual end-to-end verification against a locally built daemon (real docker sandbox, real scheduler run): confirmed the `scheduler_event` DB row's `message` is empty while `scheduler logs`/`scheduler logs --json` return the full reconstructed output, and `payload_json` carries `outputBytes` with no `messageTruncated`.
- [x] Added `TestListSchedulerEventsResolvesCommandCompletedFromArtifact` and `TestNewProjectHandlerWithSandboxDirsInjectsResolver` to pin the `ListSchedulerEvents` and `WithSandboxDirs` fixes.
- [ ] `docker_e2e`-tagged `TestSchedulerE2E...` run in CI (needs the tagged runner; only compile-checked locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
