### PR TITLE
perf(api): reduce GetProject latency

### DIFF
--- a/pkg/agentcompose/api/project_agent_model.go
+++ b/pkg/agentcompose/api/project_agent_model.go
@@ -13,14 +13,14 @@ import (
 
 // ProjectAgentModelResolver supplies read-only model previews for project responses.
 type ProjectAgentModelResolver interface {
-	ResolveProjectAgentModels(context.Context, domain.ProjectRecord) (map[string]llms.AgentModelResolution, error)
+	ResolveProjectAgentModels(context.Context, domain.ProjectRecord, []domain.ProjectAgentRecord) (map[string]llms.AgentModelResolution, error)
 }
 
-func (h *ProjectHandler) enrichProjectAgentModels(ctx context.Context, record domain.ProjectRecord, project *agentcomposev2.Project) error {
+func (h *ProjectHandler) enrichProjectAgentModels(ctx context.Context, record domain.ProjectRecord, agents []domain.ProjectAgentRecord, project *agentcomposev2.Project) error {
 	if h.agentModels == nil || project == nil {
 		return nil
 	}
-	resolutions, err := h.agentModels.ResolveProjectAgentModels(ctx, record)
+	resolutions, err := h.agentModels.ResolveProjectAgentModels(ctx, record, agents)
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("resolve project agent models: %w", err))
 	}

--- a/pkg/agentcompose/api/project_agent_model_test.go
+++ b/pkg/agentcompose/api/project_agent_model_test.go
@@ -17,7 +17,7 @@ type projectAgentModelResolverStub struct {
 	err         error
 }
 
-func (s projectAgentModelResolverStub) ResolveProjectAgentModels(context.Context, domain.ProjectRecord) (map[string]llms.AgentModelResolution, error) {
+func (s projectAgentModelResolverStub) ResolveProjectAgentModels(context.Context, domain.ProjectRecord, []domain.ProjectAgentRecord) (map[string]llms.AgentModelResolution, error) {
 	return s.resolutions, s.err
 }
 
@@ -36,7 +36,7 @@ func TestEnrichProjectAgentModelsMapsResolvedModelAndSource(t *testing.T) {
 		"main":  {Model: "gpt-explicit", Source: llms.AgentModelSourceProject},
 	}}}
 	project := &agentcomposev2.Project{Agents: []*agentcomposev2.ProjectAgent{{AgentName: "coder"}, {AgentName: "main", Model: "gpt-explicit"}}}
-	if err := handler.enrichProjectAgentModels(context.Background(), domain.ProjectRecord{ID: "project"}, project); err != nil {
+	if err := handler.enrichProjectAgentModels(context.Background(), domain.ProjectRecord{ID: "project"}, nil, project); err != nil {
 		t.Fatal(err)
 	}
 	if coder := project.GetAgents()[0]; coder.GetResolvedModel() != "dev/gpt-5.5" || coder.GetModelSource() != agentcomposev2.AgentModelSource_AGENT_MODEL_SOURCE_DAEMON_DEFAULT {
@@ -50,7 +50,7 @@ func TestEnrichProjectAgentModelsMapsResolvedModelAndSource(t *testing.T) {
 func TestEnrichProjectAgentModelsReturnsInternalResolverError(t *testing.T) {
 	wantErr := errors.New("resolution failed")
 	handler := &ProjectHandler{agentModels: projectAgentModelResolverStub{err: wantErr}}
-	err := handler.enrichProjectAgentModels(context.Background(), domain.ProjectRecord{ID: "project"}, &agentcomposev2.Project{})
+	err := handler.enrichProjectAgentModels(context.Background(), domain.ProjectRecord{ID: "project"}, nil, &agentcomposev2.Project{})
 	if connect.CodeOf(err) != connect.CodeInternal || !errors.Is(err, wantErr) {
 		t.Fatalf("error = %v, want internal wrapping %v", err, wantErr)
 	}

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -375,7 +375,7 @@ func (h *ProjectHandler) GetProject(ctx context.Context, req *connect.Request[ag
 		spec = RedactProjectSpecSecrets(spec)
 	}
 	projectProto := ProjectToProto(project, spec, agents, schedulers)
-	if err := h.enrichProjectAgentModels(ctx, project, projectProto); err != nil {
+	if err := h.enrichProjectAgentModels(ctx, project, agents, projectProto); err != nil {
 		return nil, err
 	}
 	if err := h.enrichProjectAgentRuns(ctx, projectProto); err != nil {

--- a/pkg/agentcompose/app/project_agent_model_resolver.go
+++ b/pkg/agentcompose/app/project_agent_model_resolver.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -22,21 +23,24 @@ func newProjectAgentModelResolver(config *appconfig.Config, store *configstore.C
 	return &projectAgentModelResolver{config: config, store: store}
 }
 
-func (r *projectAgentModelResolver) ResolveProjectAgentModels(ctx context.Context, project domain.ProjectRecord) (map[string]llms.AgentModelResolution, error) {
+// ResolveProjectAgentModels previews the model each current agent would select.
+// It derives the minimal agent definition (provider, model, env) from the
+// already-loaded project agent records instead of re-loading and re-parsing the
+// whole project spec.
+func (r *projectAgentModelResolver) ResolveProjectAgentModels(ctx context.Context, project domain.ProjectRecord, agents []domain.ProjectAgentRecord) (map[string]llms.AgentModelResolution, error) {
 	if r == nil || r.store == nil || project.CurrentRevision <= 0 {
 		return nil, nil
 	}
-	revision, err := r.store.GetProjectRevision(ctx, project.ID, project.CurrentRevision)
-	if err != nil {
-		return nil, fmt.Errorf("get project revision %s/%d: %w", project.ID, project.CurrentRevision, err)
-	}
-	spec, err := compose.ParseCanonicalJSON([]byte(strings.TrimSpace(revision.SpecJSON)))
-	if err != nil {
-		return nil, fmt.Errorf("decode project revision %s/%d: %w", project.ID, project.CurrentRevision, err)
-	}
-	definitions, err := projects.NewAgentDefinitionsFromSpec(project, project.CurrentRevision, spec)
-	if err != nil {
-		return nil, fmt.Errorf("derive project agent definitions: %w", err)
+	definitions := make([]domain.AgentDefinition, 0, len(agents))
+	for _, agent := range agents {
+		if agent.Revision != project.CurrentRevision {
+			continue
+		}
+		definition, err := agentDefinitionForModelResolution(agent)
+		if err != nil {
+			return nil, err
+		}
+		definitions = append(definitions, definition)
 	}
 	resolved, err := llms.ResolveAgentModels(ctx, r.config, r.store, definitions)
 	if err != nil {
@@ -47,4 +51,24 @@ func (r *projectAgentModelResolver) ResolveProjectAgentModels(ctx context.Contex
 		resolutions[definition.AgentName] = resolved[i]
 	}
 	return resolutions, nil
+}
+
+// agentDefinitionForModelResolution builds the subset of an agent definition
+// that model resolution needs. Provider and model come from the agent record;
+// env items are decoded from the agent's own canonical spec JSON.
+func agentDefinitionForModelResolution(record domain.ProjectAgentRecord) (domain.AgentDefinition, error) {
+	raw := strings.TrimSpace(record.SpecJSON)
+	if raw == "" {
+		raw = "{}"
+	}
+	var spec compose.NormalizedAgentSpec
+	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
+		return domain.AgentDefinition{}, fmt.Errorf("decode project agent %s spec: %w", record.AgentName, err)
+	}
+	return domain.AgentDefinition{
+		AgentName: record.AgentName,
+		Provider:  record.Provider,
+		Model:     record.Model,
+		EnvItems:  projects.SandboxEnvItemsFromCompose(spec.Env),
+	}, nil
 }

--- a/pkg/agentcompose/app/project_agent_model_resolver_test.go
+++ b/pkg/agentcompose/app/project_agent_model_resolver_test.go
@@ -7,16 +7,19 @@ import (
 	"agent-compose/pkg/compose"
 	appconfig "agent-compose/pkg/config"
 	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
 )
 
-func TestProjectAgentModelResolverUsesCurrentRevisionAndDaemonDefault(t *testing.T) {
+func newProjectAgentModelResolverFixture(t *testing.T, yaml string, config appconfig.Config) (domain.ProjectRecord, []domain.ProjectAgentRecord, *projectAgentModelResolver) {
+	t.Helper()
 	ctx := context.Background()
-	store := newRunSupervisorTestConfigStore(t)
-	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-model-preview", Name: "model-preview", SourcePath: "/tmp/model-preview/agent-compose.yml", SourceJSON: "{}"})
-	if err != nil {
-		t.Fatal(err)
+	// Model resolution consults os.Getenv as a fallback; clear ambient LLM
+	// environment so the assertions depend only on the injected config.
+	for _, key := range []string{"LLM_MODEL", "LLM_API_KEY", "LLM_API_ENDPOINT", "LLM_API_PROTOCOL", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} {
+		t.Setenv(key, "")
 	}
-	raw, err := compose.Parse([]byte("name: model-preview\nagents:\n  coder:\n    provider: codex\n"))
+	store := newRunSupervisorTestConfigStore(t)
+	raw, err := compose.Parse([]byte(yaml))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,29 +27,65 @@ func TestProjectAgentModelResolverUsesCurrentRevisionAndDaemonDefault(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-model-preview", Name: normalized.Name, SourcePath: "/tmp/model-preview/agent-compose.yml", SourceJSON: "{}"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	specJSON, err := normalized.MarshalCanonicalJSON(false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{ProjectID: project.ID, SpecHash: "sha256:model-preview", SpecJSON: string(specJSON)}); err != nil {
+	revision, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{ProjectID: project.ID, SpecHash: "sha256:model-preview", SpecJSON: string(specJSON)})
+	if err != nil {
 		t.Fatal(err)
 	}
 	project, err = store.GetProject(ctx, project.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolver := newProjectAgentModelResolver(&appconfig.Config{
-		LLMAPIEndpoint: "https://daemon.example.test/v1",
-		LLMAPIProtocol: "responses",
-		LLMAPIKey:      "daemon-key",
-		LLMModel:       "dev/gpt-5.5",
-	}, store)
-	resolutions, err := resolver.ResolveProjectAgentModels(ctx, project)
+	agents, err := projects.NewAgentRecordsFromSpec(project.ID, revision.Revision, normalized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return project, agents, newProjectAgentModelResolver(&config, store)
+}
+
+func TestProjectAgentModelResolverUsesCurrentRevisionAndDaemonDefault(t *testing.T) {
+	ctx := context.Background()
+	project, agents, resolver := newProjectAgentModelResolverFixture(t,
+		"name: model-preview\nagents:\n  coder:\n    provider: codex\n",
+		appconfig.Config{
+			LLMAPIEndpoint: "https://daemon.example.test/v1",
+			LLMAPIProtocol: "responses",
+			LLMAPIKey:      "daemon-key",
+			LLMModel:       "dev/gpt-5.5",
+		})
+	resolutions, err := resolver.ResolveProjectAgentModels(ctx, project, agents)
 	if err != nil {
 		t.Fatal(err)
 	}
 	resolution := resolutions["coder"]
 	if resolution.Model != "dev/gpt-5.5" || resolution.Source != "daemon_default" {
+		t.Fatalf("resolution = %#v", resolution)
+	}
+}
+
+func TestProjectAgentModelResolverUsesAgentRecordEnv(t *testing.T) {
+	ctx := context.Background()
+	project, agents, resolver := newProjectAgentModelResolverFixture(t,
+		"name: model-env\nagents:\n  coder:\n    provider: codex\n    env:\n      CODEX_MODEL: gpt-env-model\n",
+		appconfig.Config{
+			LLMAPIEndpoint: "https://daemon.example.test/v1",
+			LLMAPIProtocol: "responses",
+			LLMAPIKey:      "daemon-key",
+			LLMModel:       "dev/gpt-5.5",
+		})
+	resolutions, err := resolver.ResolveProjectAgentModels(ctx, project, agents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := resolutions["coder"]
+	if resolution.Model != "gpt-env-model" || resolution.Source != "agent_env" {
 		t.Fatalf("resolution = %#v", resolution)
 	}
 }

--- a/pkg/storage/configstore/project_agent_run_state_store.go
+++ b/pkg/storage/configstore/project_agent_run_state_store.go
@@ -2,6 +2,7 @@ package configstore
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -20,16 +21,27 @@ type agentRunningCounts struct {
 // project agent. It replaces a single window-function query — which scanned and
 // partitioned every run for the project — with two narrow queries: one that only
 // touches the running rows, and one that resolves the latest run per agent
-// through the (project_id, agent_name, created_at) index.
+// through the (project_id, agent_name, created_at) index. The two queries share
+// a read transaction so a run completing or starting between them cannot make
+// the running counts disagree with the reported latest run.
 func (s *projectStore) ListProjectAgentRunStates(ctx context.Context, projectID string) ([]domain.ProjectAgentRunState, error) {
 	projectID = strings.TrimSpace(projectID)
-	running, err := s.projectAgentRunningCounts(ctx, projectID)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("begin project agent run state transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	running, err := s.projectAgentRunningCounts(ctx, tx, projectID)
 	if err != nil {
 		return nil, err
 	}
-	latest, err := s.projectAgentLatestRuns(ctx, projectID)
+	latest, err := s.projectAgentLatestRuns(ctx, tx, projectID)
 	if err != nil {
 		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit project agent run state transaction: %w", err)
 	}
 	states := make([]domain.ProjectAgentRunState, 0, len(latest))
 	for _, item := range latest {
@@ -42,8 +54,8 @@ func (s *projectStore) ListProjectAgentRunStates(ctx context.Context, projectID 
 	return states, nil
 }
 
-func (s *projectStore) projectAgentRunningCounts(ctx context.Context, projectID string) (map[string]agentRunningCounts, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT agent_name,
+func (s *projectStore) projectAgentRunningCounts(ctx context.Context, tx *sql.Tx, projectID string) (map[string]agentRunningCounts, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT agent_name,
 		SUM(CASE WHEN source = ? THEN 0 ELSE 1 END),
 		SUM(CASE WHEN source = ? THEN 1 ELSE 0 END)
 	FROM project_run
@@ -69,8 +81,8 @@ func (s *projectStore) projectAgentRunningCounts(ctx context.Context, projectID 
 	return result, nil
 }
 
-func (s *projectStore) projectAgentLatestRuns(ctx context.Context, projectID string) ([]domain.ProjectAgentRunState, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT r.agent_name, 0, 0, r.run_id, r.status, r.source,
+func (s *projectStore) projectAgentLatestRuns(ctx context.Context, tx *sql.Tx, projectID string) ([]domain.ProjectAgentRunState, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT r.agent_name, 0, 0, r.run_id, r.status, r.source,
 		CASE WHEN r.completed_at != 0 THEN r.completed_at WHEN r.started_at != 0 THEN r.started_at ELSE r.created_at END
 	FROM project_run r
 	WHERE r.project_id = ? AND r.agent_name != ''

--- a/pkg/storage/configstore/project_agent_run_state_store.go
+++ b/pkg/storage/configstore/project_agent_run_state_store.go
@@ -9,31 +9,91 @@ import (
 	"agent-compose/pkg/projects"
 )
 
+// agentRunningCounts tracks the non-scheduler and scheduler runs currently in
+// flight for one project agent.
+type agentRunningCounts struct {
+	running          uint32
+	runningScheduler uint32
+}
+
+// ListProjectAgentRunStates returns the latest run plus running counts for each
+// project agent. It replaces a single window-function query — which scanned and
+// partitioned every run for the project — with two narrow queries: one that only
+// touches the running rows, and one that resolves the latest run per agent
+// through the (project_id, agent_name, created_at) index.
 func (s *projectStore) ListProjectAgentRunStates(ctx context.Context, projectID string) ([]domain.ProjectAgentRunState, error) {
-	rows, err := s.db.QueryContext(ctx, `WITH ranked AS (
-		SELECT agent_name, run_id, status, source, started_at, completed_at, created_at,
-			ROW_NUMBER() OVER (PARTITION BY agent_name ORDER BY created_at DESC, run_id DESC) AS position,
-			SUM(CASE WHEN status = ? AND source = ? THEN 1 ELSE 0 END) OVER (PARTITION BY agent_name) AS running_scheduler_count,
-			SUM(CASE WHEN status = ? AND source != ? THEN 1 ELSE 0 END) OVER (PARTITION BY agent_name) AS running_count
-		FROM project_run WHERE project_id = ? AND agent_name != ''
-	)
-	SELECT agent_name, running_count, running_scheduler_count, run_id, status, source,
-		CASE WHEN completed_at != 0 THEN completed_at WHEN started_at != 0 THEN started_at ELSE created_at END
-	FROM ranked WHERE position = 1 ORDER BY agent_name`, domain.ProjectRunStatusRunning, domain.ProjectRunSourceScheduler, domain.ProjectRunStatusRunning, domain.ProjectRunSourceScheduler, strings.TrimSpace(projectID))
+	projectID = strings.TrimSpace(projectID)
+	running, err := s.projectAgentRunningCounts(ctx, projectID)
 	if err != nil {
-		return nil, fmt.Errorf("query project agent run states: %w", err)
+		return nil, err
+	}
+	latest, err := s.projectAgentLatestRuns(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	states := make([]domain.ProjectAgentRunState, 0, len(latest))
+	for _, item := range latest {
+		if counts, ok := running[item.AgentName]; ok {
+			item.RunningRunCount = counts.running
+			item.RunningSchedulerRunCount = counts.runningScheduler
+		}
+		states = append(states, item)
+	}
+	return states, nil
+}
+
+func (s *projectStore) projectAgentRunningCounts(ctx context.Context, projectID string) (map[string]agentRunningCounts, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT agent_name,
+		SUM(CASE WHEN source = ? THEN 0 ELSE 1 END),
+		SUM(CASE WHEN source = ? THEN 1 ELSE 0 END)
+	FROM project_run
+	WHERE project_id = ? AND status = ? AND agent_name != ''
+	GROUP BY agent_name`,
+		domain.ProjectRunSourceScheduler, domain.ProjectRunSourceScheduler, projectID, domain.ProjectRunStatusRunning)
+	if err != nil {
+		return nil, fmt.Errorf("query project agent running counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make(map[string]agentRunningCounts)
+	for rows.Next() {
+		var name string
+		var running, runningScheduler int64
+		if err := rows.Scan(&name, &running, &runningScheduler); err != nil {
+			return nil, err
+		}
+		result[name] = agentRunningCounts{running: uint32(running), runningScheduler: uint32(runningScheduler)}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate project agent running counts: %w", err)
+	}
+	return result, nil
+}
+
+func (s *projectStore) projectAgentLatestRuns(ctx context.Context, projectID string) ([]domain.ProjectAgentRunState, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT r.agent_name, 0, 0, r.run_id, r.status, r.source,
+		CASE WHEN r.completed_at != 0 THEN r.completed_at WHEN r.started_at != 0 THEN r.started_at ELSE r.created_at END
+	FROM project_run r
+	WHERE r.project_id = ? AND r.agent_name != ''
+		AND r.run_id = (
+			SELECT run_id FROM project_run
+			WHERE project_id = r.project_id AND agent_name = r.agent_name
+			ORDER BY created_at DESC, run_id DESC LIMIT 1
+		)
+	ORDER BY r.agent_name`, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("query project agent latest runs: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var states []domain.ProjectAgentRunState
 	for rows.Next() {
-		state, scanErr := projects.ScanProjectAgentRunState(rows.Scan)
-		if scanErr != nil {
-			return nil, scanErr
+		item, err := projects.ScanProjectAgentRunState(rows.Scan)
+		if err != nil {
+			return nil, err
 		}
-		states = append(states, state)
+		states = append(states, item)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate project agent run states: %w", err)
+		return nil, fmt.Errorf("iterate project agent latest runs: %w", err)
 	}
 	return states, nil
 }

--- a/pkg/storage/configstore/project_agent_run_state_store_test.go
+++ b/pkg/storage/configstore/project_agent_run_state_store_test.go
@@ -81,3 +81,42 @@ func TestListProjectAgentRunStatesAggregatesAllAgentRuns(t *testing.T) {
 		t.Fatalf("agent-b state = %#v", agentB)
 	}
 }
+
+func TestListProjectAgentRunStatesLatestRunTiebreak(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-run-tiebreak", Name: "run-tiebreak"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID, err := projects.StableProjectAgentID(project.ID, "agent-a")
+	if err != nil {
+		t.Fatalf("derive agent id: %v", err)
+	}
+	if _, err := store.UpsertProjectAgent(ctx, domain.ProjectAgentRecord{ID: agentID, ProjectID: project.ID, AgentName: "agent-a"}); err != nil {
+		t.Fatalf("create project agent: %v", err)
+	}
+	for _, run := range []domain.ProjectRunRecord{
+		{RunID: "run-a", ProjectID: project.ID, AgentName: "agent-a", AgentID: agentID, Status: domain.ProjectRunStatusSucceeded, Source: domain.ProjectRunSourceManual},
+		{RunID: "run-b", ProjectID: project.ID, AgentName: "agent-a", AgentID: agentID, Status: domain.ProjectRunStatusFailed, Source: domain.ProjectRunSourceAPI},
+	} {
+		if _, err := store.CreateProjectRun(ctx, run); err != nil {
+			t.Fatalf("create run %s: %v", run.RunID, err)
+		}
+	}
+	// Give both runs the same created_at so the (created_at DESC, run_id DESC)
+	// ordering must break the tie toward the lexicographically larger run_id.
+	if _, err := store.db.ExecContext(ctx, `UPDATE project_run SET created_at = 1700000000 WHERE project_id = ?`, project.ID); err != nil {
+		t.Fatalf("set equal created_at: %v", err)
+	}
+	states, err := store.ListProjectAgentRunStates(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("list agent run states: %v", err)
+	}
+	if len(states) != 1 || states[0].AgentName != "agent-a" || states[0].LatestRunID != "run-b" || states[0].LatestStatus != domain.ProjectRunStatusFailed || states[0].LatestSource != domain.ProjectRunSourceAPI {
+		t.Fatalf("states = %#v, want run-b as latest via run_id tiebreak", states)
+	}
+}


### PR DESCRIPTION
## Summary

`GetProject` fires ~10+ sequential SQLite queries per request, including two redundant passes over the project spec and a window-function query that scans every run for the project. This PR removes the two largest costs:

- `pkg/storage/configstore`: replace the single `ROW_NUMBER`/`SUM ... OVER` window query in `ListProjectAgentRunStates` with two narrow queries — one that only touches `running` rows (via the `(project_id, status, created_at)` index) and one that resolves the latest run per agent (via the `(project_id, agent_name, created_at)` index). Preserves the existing `(created_at DESC, run_id DESC)` tiebreak.

- `pkg/agentcompose/api` + `app`: stop re-loading the project revision and re-parsing the whole project spec inside the agent-model preview. The handler already fetched the project agents, so the resolver now derives the minimal agent definition (provider, model, env) from those records instead.

No observable behavior change: both paths preserve the existing response shape and model-resolution semantics.

## Testing

```bash
go test ./pkg/storage/configstore/... ./pkg/agentcompose/api/... ./pkg/agentcompose/app/...
go build ./...
go vet ./pkg/storage/configstore/... ./pkg/agentcompose/api/... ./pkg/agentcompose/app/...
```

Added a tiebreak regression test for the split run-state query and an env-source regression test for the record-derived model resolution.

## Checklist

- [x] Documentation updated when behavior or configuration changed. (N/A — no behavior change)
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.