### PR TITLE
fix(schedulers): resolve inline agent workspace instead of a nonexistent preset id

### DIFF
--- a/pkg/agentcompose/adapters/scheduler_session_runner.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner.go
@@ -203,10 +203,13 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 		}
 	}
 	r.recordVolumeWarnings(ctx, session.Summary.ID, volumeWarnings)
-	if err := r.workspaceEnsurer.Ensure(ctx, session); err != nil {
+	unlockWorkspaceRead := r.fileWorkspaceReadLock(workspaceSnapshot)
+	ensureErr := r.workspaceEnsurer.Ensure(ctx, session)
+	unlockWorkspaceRead()
+	if ensureErr != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = r.Store.UpdateSandbox(ctx, session)
-		return nil, "", err
+		return nil, "", ensureErr
 	}
 	writeCapabilityGuide(ctx, r.Cap, r.Store, r.Streams, session, scheduler.Summary.CapsetIDs)
 	if r.AgentExecutor == nil {
@@ -299,8 +302,11 @@ func (r *SchedulerSandboxRunner) loadOrResumeLocked(ctx context.Context, session
 			return nil, "", err
 		}
 	}
-	if err := r.workspaceEnsurer.Ensure(ctx, session); err != nil {
-		return nil, "", err
+	unlockWorkspaceRead := r.fileWorkspaceReadLock(session.Workspace)
+	ensureErr := r.workspaceEnsurer.Ensure(ctx, session)
+	unlockWorkspaceRead()
+	if ensureErr != nil {
+		return nil, "", ensureErr
 	}
 	vmState, err := r.Store.GetVMState(session.Summary.ID)
 	if err != nil {
@@ -397,6 +403,25 @@ func (r *SchedulerSandboxRunner) resolveWorkspaceSnapshot(ctx context.Context, r
 		return nil, "", err
 	}
 	return snapshot, workspaceID, nil
+}
+
+// fileWorkspaceReadLock holds the same per-workspace-id lock
+// materializeInlineFileWorkspace uses while resetting and recopying its
+// shared content directory (workspaces/<id>/content under the data root).
+// workspaceEnsurer.Ensure reads that same shared directory (see
+// pkg/workspaces file workspace Prepare) to populate the sandbox's own
+// workspace path, at both sandbox creation (Ensure) and resume
+// (loadOrResumeLocked) time. Without holding this lock across that read, a
+// concurrent Ensure call for the same workspace id could RemoveAll/recopy
+// the shared directory while this read is in flight, surfacing as ENOENT or
+// partial content copied into the sandbox. Settings-managed file presets
+// share this lock key too; their content is static outside of Settings
+// edits, so the extra serialization there is harmless.
+func (r *SchedulerSandboxRunner) fileWorkspaceReadLock(workspace *domain.SandboxWorkspace) func() {
+	if workspace == nil || workspace.Type != "file" || strings.TrimSpace(workspace.ID) == "" {
+		return func() {}
+	}
+	return r.inlineWorkspaceLocks.Lock(workspace.ID)
 }
 
 func (r *SchedulerSandboxRunner) workspaceSnapshot(ctx context.Context, workspaceID string) (*domain.SandboxWorkspace, error) {

--- a/pkg/agentcompose/adapters/scheduler_session_runner.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner.go
@@ -30,22 +30,23 @@ type SchedulerVolumeResolver interface {
 }
 
 type SchedulerSandboxRunner struct {
-	Config           *appconfig.Config
-	Store            *sandboxstore.Store
-	ConfigDB         *configstore.ConfigStore
-	workspaceEnsurer workspaces.WorkspaceEnsurer
-	Driver           sandboxes.SandboxDriver
-	Cap              capabilities.Provider
-	Volumes          SchedulerVolumeResolver
-	Streams          *sandboxes.StreamBroker
-	Publisher        schedulers.ControllerPublisher
-	CapTokens        *CapabilitySandboxResolver
-	AgentExecutor    *AgentExecutor
-	LifecycleLocks   *sandboxes.LifecycleLocks
+	Config               *appconfig.Config
+	Store                *sandboxstore.Store
+	ConfigDB             *configstore.ConfigStore
+	workspaceEnsurer     workspaces.WorkspaceEnsurer
+	Driver               sandboxes.SandboxDriver
+	Cap                  capabilities.Provider
+	Volumes              SchedulerVolumeResolver
+	Streams              *sandboxes.StreamBroker
+	Publisher            schedulers.ControllerPublisher
+	CapTokens            *CapabilitySandboxResolver
+	AgentExecutor        *AgentExecutor
+	LifecycleLocks       *sandboxes.LifecycleLocks
+	inlineWorkspaceLocks *sandboxes.LifecycleLocks
 }
 
 func NewSchedulerSandboxRunner(config *appconfig.Config, store *sandboxstore.Store, configDB *configstore.ConfigStore, workspaceEnsurer workspaces.WorkspaceEnsurer, driver sandboxes.SandboxDriver, cap capabilities.Provider, volumeResolver SchedulerVolumeResolver, streams *sandboxes.StreamBroker, publisher schedulers.ControllerPublisher, capTokens *CapabilitySandboxResolver, agentExecutor *AgentExecutor, locks ...*sandboxes.LifecycleLocks) *SchedulerSandboxRunner {
-	runner := &SchedulerSandboxRunner{Config: config, Store: store, ConfigDB: configDB, workspaceEnsurer: workspaceEnsurer, Driver: driver, Cap: cap, Volumes: volumeResolver, Streams: streams, Publisher: publisher, CapTokens: capTokens, AgentExecutor: agentExecutor}
+	runner := &SchedulerSandboxRunner{Config: config, Store: store, ConfigDB: configDB, workspaceEnsurer: workspaceEnsurer, Driver: driver, Cap: cap, Volumes: volumeResolver, Streams: streams, Publisher: publisher, CapTokens: capTokens, AgentExecutor: agentExecutor, inlineWorkspaceLocks: sandboxes.NewLifecycleLocks()}
 	if len(locks) > 0 {
 		runner.LifecycleLocks = locks[0]
 	}

--- a/pkg/agentcompose/adapters/scheduler_session_runner.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner.go
@@ -203,9 +203,11 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 		}
 	}
 	r.recordVolumeWarnings(ctx, session.Summary.ID, volumeWarnings)
-	unlockWorkspaceRead := r.fileWorkspaceReadLock(workspaceSnapshot)
-	ensureErr := r.workspaceEnsurer.Ensure(ctx, session)
-	unlockWorkspaceRead()
+	ensureErr := func() error {
+		unlock := r.fileWorkspaceReadLock(workspaceSnapshot)
+		defer unlock()
+		return r.workspaceEnsurer.Ensure(ctx, session)
+	}()
 	if ensureErr != nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = r.Store.UpdateSandbox(ctx, session)
@@ -302,9 +304,11 @@ func (r *SchedulerSandboxRunner) loadOrResumeLocked(ctx context.Context, session
 			return nil, "", err
 		}
 	}
-	unlockWorkspaceRead := r.fileWorkspaceReadLock(session.Workspace)
-	ensureErr := r.workspaceEnsurer.Ensure(ctx, session)
-	unlockWorkspaceRead()
+	ensureErr := func() error {
+		unlock := r.fileWorkspaceReadLock(session.Workspace)
+		defer unlock()
+		return r.workspaceEnsurer.Ensure(ctx, session)
+	}()
 	if ensureErr != nil {
 		return nil, "", ensureErr
 	}

--- a/pkg/agentcompose/adapters/scheduler_session_runner.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner.go
@@ -126,7 +126,7 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 	envItems := domain.MergeEnvItems(globalEnvItems, providerEnvItems)
 	envItems = llms.FilterPersistedRuntimeEnv(envItems)
 	workspaceID := r.workspaceID(scheduler, request, agentDefinition)
-	workspaceSnapshot, err := r.workspaceSnapshot(ctx, workspaceID)
+	workspaceSnapshot, workspaceID, err := r.resolveWorkspaceSnapshot(ctx, request, agentDefinition, workspaceID)
 	if err != nil {
 		return nil, "", err
 	}
@@ -369,6 +369,33 @@ func (r *SchedulerSandboxRunner) workspaceID(scheduler domain.Scheduler, request
 		workspaceID = firstNonEmpty(strings.TrimSpace(request.WorkspaceID), strings.TrimSpace(scheduler.Summary.WorkspaceID), strings.TrimSpace(agentDefinition.WorkspaceID))
 	}
 	return workspaceID
+}
+
+// resolveWorkspaceSnapshot resolves the sandbox workspace snapshot for a
+// scheduler run. request.WorkspaceID is an explicit session override (e.g.
+// scheduler.agent(prompt, { workspaceId }) or scheduler.shell/exec) and is
+// always treated as a Settings-managed workspace_config preset id. Absent
+// that override, an agent's yaml `workspace:` declaration is resolved
+// inline instead of being looked up as a preset (see issue #599: the yaml
+// `name` label was never a real preset id, so that lookup always failed).
+func (r *SchedulerSandboxRunner) resolveWorkspaceSnapshot(ctx context.Context, request domain.SchedulerAgentRequest, agentDefinition *domain.AgentDefinition, workspaceID string) (*domain.SandboxWorkspace, string, error) {
+	if strings.TrimSpace(request.WorkspaceID) == "" {
+		if spec := agentDefinitionInlineWorkspace(agentDefinition); spec != nil {
+			snapshot, resolvedID, err := r.inlineWorkspaceSnapshot(ctx, agentDefinition, spec)
+			if err != nil {
+				return nil, "", err
+			}
+			return snapshot, resolvedID, nil
+		}
+	}
+	if workspaceID == "" {
+		return nil, "", nil
+	}
+	snapshot, err := r.workspaceSnapshot(ctx, workspaceID)
+	if err != nil {
+		return nil, "", err
+	}
+	return snapshot, workspaceID, nil
 }
 
 func (r *SchedulerSandboxRunner) workspaceSnapshot(ctx context.Context, workspaceID string) (*domain.SandboxWorkspace, error) {

--- a/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -410,10 +411,13 @@ func TestE2ESchedulerSandboxRunnerLoadResumeAndShutdownCoverage(t *testing.T) {
 }
 
 type schedulerSessionPublisherFake struct {
+	mu     sync.Mutex
 	events []domain.SchedulerTopicEvent
 }
 
 func (p *schedulerSessionPublisherFake) Publish(event domain.SchedulerTopicEvent) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.events = append(p.events, event)
 	return true
 }

--- a/pkg/agentcompose/adapters/scheduler_workspace_inline.go
+++ b/pkg/agentcompose/adapters/scheduler_workspace_inline.go
@@ -1,0 +1,181 @@
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"agent-compose/pkg/compose"
+	appconfig "agent-compose/pkg/config"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/projects"
+	"agent-compose/pkg/runs"
+	"agent-compose/pkg/sources"
+	"agent-compose/pkg/workspaces"
+)
+
+// agentDefinitionInlineWorkspace decodes the yaml `workspace:` declaration
+// that pkg/projects.NewAgentDefinitionFromSpec embeds in ConfigJSON. It is
+// nil for agents without a yaml-declared workspace and for workspaces
+// managed as Settings presets (referenced only by AgentDefinition.WorkspaceID
+// / SchedulerSummary.WorkspaceID). Compose normalization always resolves a
+// yaml `workspace:` block to a spec with a non-empty Provider (either
+// authored inline or copied from a project-level `workspaces:` entry), so a
+// decoded spec without one is not a real inline declaration.
+func agentDefinitionInlineWorkspace(definition *domain.AgentDefinition) *compose.WorkspaceSpec {
+	if definition == nil {
+		return nil
+	}
+	var config struct {
+		Workspace *compose.WorkspaceSpec `json:"workspace"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(definition.ConfigJSON)), &config); err != nil {
+		return nil
+	}
+	if config.Workspace == nil || strings.TrimSpace(config.Workspace.Provider) == "" {
+		return nil
+	}
+	return config.Workspace
+}
+
+// inlineWorkspaceID derives a stable identifier for an agent's yaml-declared
+// workspace. It intentionally does not depend on WorkspaceSpec.Name: that
+// field is blank whenever the agent workspace references a project-level
+// `workspaces:` entry (pkg/compose.resolveAgentWorkspace clears it), so the
+// agent definition id is the only value guaranteed to be present and stable
+// across scheduler runs sharing the same sandbox.
+func inlineWorkspaceID(agentDefinition *domain.AgentDefinition, provider string) string {
+	seed := strings.TrimSpace(agentDefinition.ID) + "|workspace|" + provider
+	return projects.StableReadableID("workspace", strings.TrimSpace(agentDefinition.Name)+"-"+provider, seed)
+}
+
+// inlineWorkspaceSnapshot resolves a scheduler sandbox workspace snapshot
+// directly from the agent's yaml `workspace:` spec, mirroring how project
+// runs resolve AgentSpec.Workspace in pkg/runs.prepareProjectRunWorkspace.
+//
+// Before this existed, scheduler.shell/scheduler.exec (and scheduler.agent
+// calls that pass a session-override argument) resolved workspaces by
+// treating the yaml workspace name as a workspace_config preset id and
+// querying the database for it. Project apply never creates such a preset,
+// so that lookup always failed at run time (see issue #599). Building the
+// snapshot from the inline spec instead keeps this path in sync with the
+// project-run path without requiring project apply to write workspace_config
+// rows.
+func (r *SchedulerSandboxRunner) inlineWorkspaceSnapshot(ctx context.Context, agentDefinition *domain.AgentDefinition, spec *compose.WorkspaceSpec) (*domain.SandboxWorkspace, string, error) {
+	provider := strings.ToLower(strings.TrimSpace(spec.Provider))
+	workspaceID := inlineWorkspaceID(agentDefinition, provider)
+	switch provider {
+	case sources.ProviderGit:
+		config, err := inlineGitWorkspaceConfig(workspaceID, spec)
+		if err != nil {
+			return nil, "", err
+		}
+		return toSandboxWorkspaceSnapshot(config), workspaceID, nil
+	case sources.ProviderFile:
+		config, err := r.materializeInlineFileWorkspace(ctx, agentDefinition, workspaceID, spec)
+		if err != nil {
+			return nil, "", err
+		}
+		return toSandboxWorkspaceSnapshot(config), workspaceID, nil
+	case "":
+		return nil, "", fmt.Errorf("workspace provider is required")
+	default:
+		return nil, "", fmt.Errorf("unsupported workspace provider %q", spec.Provider)
+	}
+}
+
+func inlineGitWorkspaceConfig(workspaceID string, spec *compose.WorkspaceSpec) (domain.WorkspaceConfig, error) {
+	if strings.TrimSpace(spec.URL) == "" {
+		return domain.WorkspaceConfig{}, fmt.Errorf("git workspace url is required")
+	}
+	if _, err := workspaces.NormalizeWorkspaceTarget(workspaceID, spec.Target); err != nil {
+		return domain.WorkspaceConfig{}, err
+	}
+	payload, err := json.Marshal(workspaces.GitWorkspaceConfig{
+		Source: spec.ContentSource(),
+		Target: strings.TrimSpace(spec.Target),
+	})
+	if err != nil {
+		return domain.WorkspaceConfig{}, fmt.Errorf("encode git workspace config: %w", err)
+	}
+	return domain.WorkspaceConfig{
+		ID:         workspaceID,
+		Name:       firstNonEmpty(strings.TrimSpace(spec.Name), workspaceID),
+		Type:       "git",
+		ConfigJSON: string(payload),
+		Comment:    "agent yaml workspace snapshot",
+	}, nil
+}
+
+func (r *SchedulerSandboxRunner) materializeInlineFileWorkspace(ctx context.Context, agentDefinition *domain.AgentDefinition, workspaceID string, spec *compose.WorkspaceSpec) (domain.WorkspaceConfig, error) {
+	projectID := strings.TrimSpace(agentDefinition.ProjectID)
+	if projectID == "" {
+		return domain.WorkspaceConfig{}, fmt.Errorf("file workspace requires a project-managed agent")
+	}
+	project, err := r.ConfigDB.GetProject(ctx, projectID)
+	if err != nil {
+		return domain.WorkspaceConfig{}, fmt.Errorf("get agent project %s: %w", projectID, err)
+	}
+	sourceDir, err := runs.ResolveLocalProjectWorkspacePath(project, spec.Path)
+	if err != nil {
+		return domain.WorkspaceConfig{}, err
+	}
+	configJSON := workspaces.DefaultFileConfigJSON(r.Config, workspaceID)
+	if _, err := workspaces.ValidateFileWorkspaceConfig(r.Config, workspaceID, configJSON); err != nil {
+		return domain.WorkspaceConfig{}, err
+	}
+	if err := resetInlineFileWorkspaceContent(r.Config, workspaceID); err != nil {
+		return domain.WorkspaceConfig{}, err
+	}
+	config := domain.WorkspaceConfig{
+		ID:         workspaceID,
+		Name:       firstNonEmpty(strings.TrimSpace(spec.Name), workspaceID),
+		Type:       "file",
+		ConfigJSON: configJSON,
+		Comment:    "agent yaml workspace snapshot",
+	}
+	content, err := workspaces.OpenFileWorkspaceContent(r.Config, config)
+	if err != nil {
+		return domain.WorkspaceConfig{}, err
+	}
+	defer func() { _ = content.Root.Close() }()
+	sourceRoot, err := os.OpenRoot(sourceDir)
+	if err != nil {
+		return domain.WorkspaceConfig{}, fmt.Errorf("open agent workspace source %s: %w", sourceDir, err)
+	}
+	defer func() { _ = sourceRoot.Close() }()
+	target, err := workspaces.NormalizeWorkspaceTarget(workspaceID, spec.Target)
+	if err != nil {
+		return domain.WorkspaceConfig{}, err
+	}
+	destination := content.AbsRoot
+	if target != "." {
+		destination = filepath.Join(content.AbsRoot, target)
+		if err := os.MkdirAll(destination, 0o755); err != nil {
+			return domain.WorkspaceConfig{}, fmt.Errorf("create agent workspace target %s: %w", target, err)
+		}
+	}
+	if err := workspaces.CopyRootDirectoryContents(sourceRoot, destination); err != nil {
+		return domain.WorkspaceConfig{}, fmt.Errorf("materialize agent workspace snapshot: %w", err)
+	}
+	return config, nil
+}
+
+func resetInlineFileWorkspaceContent(config *appconfig.Config, workspaceID string) error {
+	dataRoot, err := workspaces.OpenFileWorkspaceDataRoot(config)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dataRoot.Close() }()
+	relRoot, err := workspaces.FileWorkspaceContentRelRoot(workspaceID)
+	if err != nil {
+		return err
+	}
+	if err := dataRoot.RemoveAll(relRoot); err != nil {
+		return fmt.Errorf("reset agent workspace snapshot %s: %w", workspaceID, err)
+	}
+	return nil
+}

--- a/pkg/agentcompose/adapters/scheduler_workspace_inline.go
+++ b/pkg/agentcompose/adapters/scheduler_workspace_inline.go
@@ -110,7 +110,19 @@ func inlineGitWorkspaceConfig(workspaceID string, spec *compose.WorkspaceSpec) (
 	}, nil
 }
 
+// materializeInlineFileWorkspace resets and repopulates the shared content
+// directory for an agent's inline file workspace (keyed by the stable
+// inlineWorkspaceID, not a per-run id, since scheduler sandboxes reuse and
+// reference the same agent workspace across runs). Concurrent scheduler
+// calls for the same agent (parallel triggers, or scheduler.shell/exec/agent
+// racing each other) can reach Ensure at the same time, so the reset+copy is
+// serialized per workspace id to prevent one call's CopyRootDirectoryContents
+// from reading a directory another call is concurrently RemoveAll-ing,
+// which would otherwise surface as intermittent ENOENT failures or leave the
+// shared directory with interleaved content from two different callers.
 func (r *SchedulerSandboxRunner) materializeInlineFileWorkspace(ctx context.Context, agentDefinition *domain.AgentDefinition, workspaceID string, spec *compose.WorkspaceSpec) (domain.WorkspaceConfig, error) {
+	unlock := r.inlineWorkspaceLocks.Lock(workspaceID)
+	defer unlock()
 	projectID := strings.TrimSpace(agentDefinition.ProjectID)
 	if projectID == "" {
 		return domain.WorkspaceConfig{}, fmt.Errorf("file workspace requires a project-managed agent")

--- a/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
+++ b/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
@@ -3,10 +3,13 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"agent-compose/pkg/compose"
 	driverpkg "agent-compose/pkg/driver"
@@ -171,5 +174,108 @@ func TestSchedulerSandboxRunnerEnsureResolvesInlineFileWorkspace(t *testing.T) {
 	}
 	if string(copied) != "hello from source\n" {
 		t.Fatalf("materialized workspace content = %q, want copied source content", copied)
+	}
+}
+
+// TestSchedulerSandboxRunnerConcurrentInlineFileWorkspaceMaterializationIsSerialized
+// covers a race a reviewer flagged on this fix: materializeInlineFileWorkspace
+// resets and repopulates a shared content directory keyed by the agent's
+// stable inlineWorkspaceID (not a per-run id), on every Ensure call.
+// Scheduler calls for the same agent can run concurrently (parallel
+// triggers, or scheduler.shell/exec/agent racing each other), so without
+// serialization one goroutine's CopyRootDirectoryContents can read a
+// directory another goroutine is concurrently RemoveAll-ing, surfacing as
+// ENOENT. Every concurrent Ensure call here must succeed.
+func TestSchedulerSandboxRunnerConcurrentInlineFileWorkspaceMaterializationIsSerialized(t *testing.T) {
+	ctx := context.Background()
+	bridge, driver := newTestSandboxRPCBridge(t)
+	ensurer := &recordingSchedulerWorkspaceEnsurer{}
+	publisher := &schedulerSessionPublisherFake{}
+	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+
+	projectSource := t.TempDir()
+	for dir := 0; dir < 8; dir++ {
+		subdir := filepath.Join(projectSource, fmt.Sprintf("dir-%d", dir))
+		if err := os.MkdirAll(subdir, 0o755); err != nil {
+			t.Fatalf("create source subdir %d: %v", dir, err)
+		}
+		for file := 0; file < 40; file++ {
+			content := strings.Repeat(fmt.Sprintf("dir-%d-file-%d\n", dir, file), 64)
+			if err := os.WriteFile(filepath.Join(subdir, fmt.Sprintf("file-%d.txt", file)), []byte(content), 0o644); err != nil {
+				t.Fatalf("write source fixture dir=%d file=%d: %v", dir, file, err)
+			}
+		}
+	}
+
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
+		ID:            "scheduler-inline-file-concurrent",
+		Name:          "Scheduler Inline File Concurrent",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		SandboxPolicy: domain.SchedulerSandboxPolicySticky,
+	}}
+	scheduler = createNativeTestSchedulerWithWorkspace(t, ctx, bridge.configDB, scheduler, projectSource, &compose.WorkspaceSpec{
+		Provider: "file",
+		Path:     ".",
+		Name:     "my-local-workspace-concurrent",
+	})
+	agentDefinition, err := runner.ResolveSchedulerAgentDefinition(ctx, scheduler)
+	if err != nil {
+		t.Fatalf("ResolveSchedulerAgentDefinition returned error: %v", err)
+	}
+	spec := agentDefinitionInlineWorkspace(agentDefinition)
+	if spec == nil {
+		t.Fatalf("agentDefinitionInlineWorkspace returned nil, want the inline file workspace spec")
+	}
+
+	const callerCount = 16
+	const timeout = 10 * time.Second
+	type result struct {
+		index int
+		err   error
+	}
+	results := make(chan result, callerCount)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(callerCount)
+	for index := 0; index < callerCount; index++ {
+		go func(index int) {
+			ready.Done()
+			<-start
+			runCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			_, _, err := runner.inlineWorkspaceSnapshot(runCtx, agentDefinition, spec)
+			results <- result{index: index, err: err}
+		}(index)
+	}
+	ready.Wait()
+	close(start)
+
+	for i := 0; i < callerCount; i++ {
+		select {
+		case r := <-results:
+			if r.err != nil {
+				t.Fatalf("concurrent inlineWorkspaceSnapshot call %d returned error: %v, want the shared content directory reset+copy to be serialized", r.index, r.err)
+			}
+		case <-time.After(timeout):
+			t.Fatalf("timed out waiting for concurrent inlineWorkspaceSnapshot calls (%d/%d returned)", i, callerCount)
+		}
+	}
+
+	workspaceID := inlineWorkspaceID(agentDefinition, "file")
+	contentRoot, err := workspaces.FileWorkspaceContentRoot(bridge.config, domain.WorkspaceConfig{ID: workspaceID, Type: "file", ConfigJSON: workspaces.DefaultFileConfigJSON(bridge.config, workspaceID)})
+	if err != nil {
+		t.Fatalf("resolve materialized file workspace content root: %v", err)
+	}
+	for dir := 0; dir < 8; dir++ {
+		for file := 0; file < 40; file++ {
+			want := strings.Repeat(fmt.Sprintf("dir-%d-file-%d\n", dir, file), 64)
+			got, err := os.ReadFile(filepath.Join(contentRoot, fmt.Sprintf("dir-%d", dir), fmt.Sprintf("file-%d.txt", file)))
+			if err != nil {
+				t.Fatalf("read materialized workspace content dir=%d file=%d: %v", dir, file, err)
+			}
+			if string(got) != want {
+				t.Fatalf("materialized workspace content dir=%d file=%d = %q, want %q", dir, file, got, want)
+			}
+		}
 	}
 }

--- a/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
+++ b/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
@@ -279,3 +279,106 @@ func TestSchedulerSandboxRunnerConcurrentInlineFileWorkspaceMaterializationIsSer
 		}
 	}
 }
+
+// TestSchedulerSandboxRunnerConcurrentEnsureSerializesFileWorkspaceReadAgainstMaterialize
+// covers a second race a reviewer flagged after the first fix landed: the
+// inlineWorkspaceLocks lock only spanned materializeInlineFileWorkspace's
+// own reset+copy, released as soon as resolveWorkspaceSnapshot returned.
+// Later in Ensure, workspaceEnsurer.Ensure reads that same shared content
+// directory to populate the new sandbox's own workspace path (see
+// pkg/workspaces file workspace Prepare / materializeSessionWorkspace) with
+// no lock held at all. A concurrent Ensure call for the same agent could
+// start resetting/recopying the shared directory while another call's
+// workspaceEnsurer.Ensure was mid-read from it. This exercises the full
+// Ensure path (not just inlineWorkspaceSnapshot) with a real, file-copying
+// WorkspaceEnsurer so that read is actually reached.
+func TestSchedulerSandboxRunnerConcurrentEnsureSerializesFileWorkspaceReadAgainstMaterialize(t *testing.T) {
+	ctx := context.Background()
+	bridge, driver := newTestSandboxRPCBridge(t)
+	provisioner := workspaces.NewProvisioner(bridge.config, bridge.configDB, bridge.store)
+	publisher := &schedulerSessionPublisherFake{}
+	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, provisioner, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+
+	projectSource := t.TempDir()
+	const dirCount, fileCount = 6, 30
+	for dir := 0; dir < dirCount; dir++ {
+		subdir := filepath.Join(projectSource, fmt.Sprintf("dir-%d", dir))
+		if err := os.MkdirAll(subdir, 0o755); err != nil {
+			t.Fatalf("create source subdir %d: %v", dir, err)
+		}
+		for file := 0; file < fileCount; file++ {
+			content := strings.Repeat(fmt.Sprintf("dir-%d-file-%d\n", dir, file), 64)
+			if err := os.WriteFile(filepath.Join(subdir, fmt.Sprintf("file-%d.txt", file)), []byte(content), 0o644); err != nil {
+				t.Fatalf("write source fixture dir=%d file=%d: %v", dir, file, err)
+			}
+		}
+	}
+
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
+		ID:            "scheduler-inline-file-ensure-race",
+		Name:          "Scheduler Inline File Ensure Race",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		SandboxPolicy: domain.SchedulerSandboxPolicyNew,
+	}}
+	scheduler = createNativeTestSchedulerWithWorkspace(t, ctx, bridge.configDB, scheduler, projectSource, &compose.WorkspaceSpec{
+		Provider: "file",
+		Path:     ".",
+		Name:     "my-local-workspace-ensure-race",
+	})
+
+	const callerCount = 12
+	const timeout = 20 * time.Second
+	type result struct {
+		index   int
+		sandbox *domain.Sandbox
+		err     error
+	}
+	results := make(chan result, callerCount)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(callerCount)
+	for index := 0; index < callerCount; index++ {
+		go func(index int) {
+			ready.Done()
+			<-start
+			runCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			request := domain.SchedulerAgentRequest{
+				BindingTriggerID: fmt.Sprintf("trigger-ensure-race-%d", index),
+				SandboxPolicy:    domain.SchedulerSandboxPolicyNew,
+			}
+			sandbox, _, err := runner.Ensure(runCtx, scheduler, request, false)
+			results <- result{index: index, sandbox: sandbox, err: err}
+		}(index)
+	}
+	ready.Wait()
+	close(start)
+
+	var sandboxes []*domain.Sandbox
+	for i := 0; i < callerCount; i++ {
+		select {
+		case r := <-results:
+			if r.err != nil {
+				t.Fatalf("concurrent Ensure call %d returned error: %v, want the shared file workspace directory read (workspaceEnsurer.Ensure) to be serialized against concurrent materialization", r.index, r.err)
+			}
+			sandboxes = append(sandboxes, r.sandbox)
+		case <-time.After(timeout):
+			t.Fatalf("timed out waiting for concurrent Ensure calls (%d/%d returned)", i, callerCount)
+		}
+	}
+
+	for _, sandbox := range sandboxes {
+		for dir := 0; dir < dirCount; dir++ {
+			for file := 0; file < fileCount; file++ {
+				want := strings.Repeat(fmt.Sprintf("dir-%d-file-%d\n", dir, file), 64)
+				got, err := os.ReadFile(filepath.Join(sandbox.Summary.WorkspacePath, fmt.Sprintf("dir-%d", dir), fmt.Sprintf("file-%d.txt", file)))
+				if err != nil {
+					t.Fatalf("sandbox %s: read copied workspace content dir=%d file=%d: %v", sandbox.Summary.ID, dir, file, err)
+				}
+				if string(got) != want {
+					t.Fatalf("sandbox %s: copied workspace content dir=%d file=%d = %q, want %q", sandbox.Summary.ID, dir, file, got, want)
+				}
+			}
+		}
+	}
+}

--- a/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
+++ b/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -380,5 +381,71 @@ func TestSchedulerSandboxRunnerConcurrentEnsureSerializesFileWorkspaceReadAgains
 				}
 			}
 		}
+	}
+}
+
+// TestSchedulerSandboxRunnerEnsureReleasesFileWorkspaceLockOnEnsurerPanic
+// covers a third finding from the same review: fileWorkspaceReadLock's
+// unlock was called manually right after workspaceEnsurer.Ensure instead of
+// via defer. If that call panics (an unexpected error from the underlying
+// copy/driver/store layers), the manual unlock never runs and the
+// per-workspace-id lock stays held forever — every later scheduler
+// Ensure/Resume for that agent's inline file workspace would then block on
+// the lock permanently, a lasting availability failure. This drives an
+// ensurer that panics on its first call, recovers (as the caller would),
+// and asserts a second Ensure call for the same workspace still completes
+// instead of hanging on the leaked lock.
+func TestSchedulerSandboxRunnerEnsureReleasesFileWorkspaceLockOnEnsurerPanic(t *testing.T) {
+	ctx := context.Background()
+	bridge, driver := newTestSandboxRPCBridge(t)
+	var calls int32
+	ensurer := &recordingSchedulerWorkspaceEnsurer{ensure: func(context.Context, *domain.Sandbox) error {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			panic("simulated workspaceEnsurer.Ensure panic")
+		}
+		return nil
+	}}
+	publisher := &schedulerSessionPublisherFake{}
+	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+
+	projectSource := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectSource, "hello.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write source fixture file: %v", err)
+	}
+
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
+		ID:            "scheduler-inline-file-panic",
+		Name:          "Scheduler Inline File Panic",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		SandboxPolicy: domain.SchedulerSandboxPolicyNew,
+	}}
+	scheduler = createNativeTestSchedulerWithWorkspace(t, ctx, bridge.configDB, scheduler, projectSource, &compose.WorkspaceSpec{
+		Provider: "file",
+		Path:     ".",
+		Name:     "my-local-workspace-panic",
+	})
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected first Ensure call's workspaceEnsurer.Ensure to panic")
+			}
+		}()
+		_, _, _ = runner.Ensure(ctx, scheduler, domain.SchedulerAgentRequest{BindingTriggerID: "trigger-panic-1", SandboxPolicy: domain.SchedulerSandboxPolicyNew}, false)
+		t.Fatalf("Ensure returned instead of panicking")
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := runner.Ensure(ctx, scheduler, domain.SchedulerAgentRequest{BindingTriggerID: "trigger-panic-2", SandboxPolicy: domain.SchedulerSandboxPolicyNew}, false)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("second Ensure call after ensurer panic returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("second Ensure call for the same workspace hung, want the per-workspace lock released after the first call's ensurer panic")
 	}
 }

--- a/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
+++ b/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
@@ -1,0 +1,175 @@
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"agent-compose/pkg/compose"
+	driverpkg "agent-compose/pkg/driver"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/storage/configstore"
+	"agent-compose/pkg/workspaces"
+)
+
+// createNativeTestSchedulerWithWorkspace mirrors createNativeTestScheduler
+// but attaches a full inline agent.Workspace spec (provider/url/path/target)
+// instead of a bare {Name: workspaceID} label, matching what project apply
+// actually produces for a yaml `workspace:` block (see pkg/compose
+// normalizeInlineWorkspaceSpec, which always sets Provider).
+func createNativeTestSchedulerWithWorkspace(t testing.TB, ctx context.Context, store *configstore.ConfigStore, scheduler domain.Scheduler, sourcePath string, workspace *compose.WorkspaceSpec) domain.Scheduler {
+	t.Helper()
+	projectID := "test-project-" + scheduler.Summary.ID
+	agentName := "worker"
+	agent := compose.NormalizedAgentSpec{
+		Name: agentName, Enabled: true, Provider: scheduler.Summary.DefaultAgent, Image: scheduler.Summary.GuestImage,
+		CapsetIDs: append([]string(nil), scheduler.Summary.CapsetIDs...),
+		Workspace: workspace,
+		Scheduler: &compose.NormalizedSchedulerSpec{
+			Enabled: scheduler.Summary.Enabled, SandboxPolicy: scheduler.Summary.SandboxPolicy,
+			ConcurrencyPolicy: scheduler.Summary.ConcurrencyPolicy, DisplayName: scheduler.Summary.Name,
+			Description: scheduler.Summary.Description, Script: scheduler.Script,
+		},
+	}
+	if driver := strings.TrimSpace(scheduler.Summary.Driver); driver != "" {
+		agent.Driver = &compose.NormalizedDriverSpec{Name: driver}
+	}
+	specJSON, err := (&compose.NormalizedProjectSpec{Name: "test-project", Agents: []compose.NormalizedAgentSpec{agent}}).MarshalCanonicalJSON(false)
+	if err != nil {
+		t.Fatalf("marshal native scheduler fixture: %v", err)
+	}
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: projectID, Name: "test-project", SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("upsert native scheduler project: %v", err)
+	}
+	revision, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{ProjectID: project.ID, SpecHash: "fixture-" + scheduler.Summary.ID, SpecJSON: string(specJSON)})
+	if err != nil {
+		t.Fatalf("save native scheduler revision: %v", err)
+	}
+	if _, err := store.UpsertProjectAgent(ctx, domain.ProjectAgentRecord{ProjectID: project.ID, AgentName: agentName, Revision: revision.Revision, SchedulerEnabled: true, SpecJSON: "{}"}); err != nil {
+		t.Fatalf("upsert scheduler project agent: %v", err)
+	}
+	if _, err := store.UpsertProjectScheduler(ctx, domain.ProjectSchedulerRecord{ID: scheduler.Summary.ID, ProjectID: project.ID, SchedulerID: scheduler.Summary.ID, AgentName: agentName, Revision: revision.Revision, Enabled: scheduler.Summary.Enabled, TriggerCount: len(scheduler.Triggers), SpecJSON: "{}"}); err != nil {
+		t.Fatalf("upsert native scheduler: %v", err)
+	}
+	if _, err := store.ReplaceSchedulerTriggers(ctx, scheduler.Summary.ID, scheduler.Triggers); err != nil {
+		t.Fatalf("replace native scheduler triggers: %v", err)
+	}
+	loaded, err := store.GetScheduler(ctx, scheduler.Summary.ID)
+	if err != nil {
+		t.Fatalf("load native scheduler: %v", err)
+	}
+	return loaded
+}
+
+// TestSchedulerSandboxRunnerEnsureResolvesInlineGitWorkspace reproduces
+// issue #599: an agent-compose.yaml agent declares a scheduler-enabled
+// `workspace: {provider: git, url: ...}` and the scheduler is run via a path
+// that used to look the yaml `name` label up as a workspace_config preset id
+// (scheduler.shell/scheduler.exec, or scheduler.agent with a session
+// override). Since project apply never creates such a preset, Ensure used to
+// fail with "workspace config <id> not found" even though the full workspace
+// spec was declared in yaml. Ensure must now resolve the git workspace
+// directly from the inline spec.
+func TestSchedulerSandboxRunnerEnsureResolvesInlineGitWorkspace(t *testing.T) {
+	ctx := context.Background()
+	bridge, driver := newTestSandboxRPCBridge(t)
+	ensurer := &recordingSchedulerWorkspaceEnsurer{}
+	publisher := &schedulerSessionPublisherFake{}
+	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
+		ID:            "scheduler-inline-git",
+		Name:          "Scheduler Inline Git",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		SandboxPolicy: domain.SchedulerSandboxPolicySticky,
+	}}
+	scheduler = createNativeTestSchedulerWithWorkspace(t, ctx, bridge.configDB, scheduler, "", &compose.WorkspaceSpec{
+		Provider: "git",
+		URL:      "https://example.com/some/repo.git",
+		Name:     "my-repo",
+	})
+
+	sandbox, eventType, err := runner.Ensure(ctx, scheduler, domain.SchedulerAgentRequest{BindingTriggerID: "trigger-inline-git"}, false)
+	if err != nil {
+		t.Fatalf("Ensure returned error: %v, want the inline git workspace to resolve without a workspace_config lookup", err)
+	}
+	if eventType != "scheduler.sandbox.created" {
+		t.Fatalf("Ensure event type = %q, want scheduler.sandbox.created", eventType)
+	}
+	if len(ensurer.initialWorkspaces) != 1 || ensurer.initialWorkspaces[0] == nil {
+		t.Fatalf("workspace Ensure snapshot = %#v, want one non-nil snapshot", ensurer.initialWorkspaces)
+	}
+	snapshot := ensurer.initialWorkspaces[0]
+	if snapshot.Type != "git" {
+		t.Fatalf("resolved workspace type = %q, want git", snapshot.Type)
+	}
+	var decoded workspaces.GitWorkspaceConfig
+	if err := json.Unmarshal([]byte(snapshot.ConfigJSON), &decoded); err != nil {
+		t.Fatalf("decode resolved git workspace config: %v", err)
+	}
+	if decoded.URL != "https://example.com/some/repo.git" {
+		t.Fatalf("resolved git workspace url = %q, want https://example.com/some/repo.git", decoded.URL)
+	}
+	if sandbox.Summary.ID == "" {
+		t.Fatalf("expected sandbox to be created")
+	}
+}
+
+// TestSchedulerSandboxRunnerEnsureResolvesInlineFileWorkspace covers the
+// `provider: file` variant of issue #599: the agent's local workspace
+// content must be materialized directly from the project source path
+// instead of being looked up as a workspace_config preset.
+func TestSchedulerSandboxRunnerEnsureResolvesInlineFileWorkspace(t *testing.T) {
+	ctx := context.Background()
+	bridge, driver := newTestSandboxRPCBridge(t)
+	ensurer := &recordingSchedulerWorkspaceEnsurer{}
+	publisher := &schedulerSessionPublisherFake{}
+	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+
+	projectSource := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectSource, "hello.txt"), []byte("hello from source\n"), 0o644); err != nil {
+		t.Fatalf("write source fixture file: %v", err)
+	}
+
+	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
+		ID:            "scheduler-inline-file",
+		Name:          "Scheduler Inline File",
+		Driver:        driverpkg.RuntimeDriverDocker,
+		SandboxPolicy: domain.SchedulerSandboxPolicySticky,
+	}}
+	scheduler = createNativeTestSchedulerWithWorkspace(t, ctx, bridge.configDB, scheduler, projectSource, &compose.WorkspaceSpec{
+		Provider: "file",
+		Path:     ".",
+		Name:     "my-local-workspace",
+	})
+
+	_, eventType, err := runner.Ensure(ctx, scheduler, domain.SchedulerAgentRequest{BindingTriggerID: "trigger-inline-file"}, false)
+	if err != nil {
+		t.Fatalf("Ensure returned error: %v, want the inline file workspace to materialize without a workspace_config lookup", err)
+	}
+	if eventType != "scheduler.sandbox.created" {
+		t.Fatalf("Ensure event type = %q, want scheduler.sandbox.created", eventType)
+	}
+	if len(ensurer.initialWorkspaces) != 1 || ensurer.initialWorkspaces[0] == nil {
+		t.Fatalf("workspace Ensure snapshot = %#v, want one non-nil snapshot", ensurer.initialWorkspaces)
+	}
+	snapshot := ensurer.initialWorkspaces[0]
+	if snapshot.Type != "file" {
+		t.Fatalf("resolved workspace type = %q, want file", snapshot.Type)
+	}
+	contentRoot, err := workspaces.FileWorkspaceContentRoot(bridge.config, domain.WorkspaceConfig{ID: snapshot.ID, Type: "file", ConfigJSON: snapshot.ConfigJSON})
+	if err != nil {
+		t.Fatalf("resolve materialized file workspace content root: %v", err)
+	}
+	copied, err := os.ReadFile(filepath.Join(contentRoot, "hello.txt"))
+	if err != nil {
+		t.Fatalf("read materialized workspace content: %v", err)
+	}
+	if string(copied) != "hello from source\n" {
+		t.Fatalf("materialized workspace content = %q, want copied source content", copied)
+	}
+}

--- a/pkg/projects/records.go
+++ b/pkg/projects/records.go
@@ -139,6 +139,13 @@ type agentDefinitionConfig struct {
 	Sandbox        *compose.NormalizedSandboxSpec                 `json:"sandbox,omitempty"`
 	MCPServers     map[string]compose.NormalizedMCPServerSpec     `json:"mcp_servers,omitempty"`
 	OctoBusServers map[string]compose.NormalizedOctoBusServerSpec `json:"octobus_servers,omitempty"`
+	// Workspace carries the full yaml `workspace:` declaration (provider,
+	// url/path, ref, target, credentials). AgentDefinition.WorkspaceID only
+	// keeps the yaml `name` label, which is not a workspace_config preset id
+	// (see issue #599), so runtime code must read the inline spec from here
+	// to actually resolve the declared workspace instead of looking it up as
+	// a preset.
+	Workspace *compose.WorkspaceSpec `json:"workspace,omitempty"`
 }
 
 func agentDefinitionConfigJSON(agent compose.NormalizedAgentSpec, projectMCPServers map[string]compose.NormalizedMCPServerSpec, projectOctoBusServers map[string]compose.NormalizedOctoBusServerSpec) (string, error) {
@@ -147,8 +154,9 @@ func agentDefinitionConfigJSON(agent compose.NormalizedAgentSpec, projectMCPServ
 		Sandbox:        agent.Sandbox,
 		MCPServers:     selectedAgentMCPServers(agent, projectMCPServers),
 		OctoBusServers: selectedAgentOctoBusServers(agent, projectOctoBusServers),
+		Workspace:      agent.Workspace,
 	}
-	if payload.Jupyter == nil && payload.Sandbox == nil && len(payload.MCPServers) == 0 && len(payload.OctoBusServers) == 0 {
+	if payload.Jupyter == nil && payload.Sandbox == nil && payload.Workspace == nil && len(payload.MCPServers) == 0 && len(payload.OctoBusServers) == 0 {
 		return "{}", nil
 	}
 	data, err := MarshalCanonicalJSON(payload)


### PR DESCRIPTION
## Summary

Fixes #599.

`scheduler.shell` / `scheduler.exec`, and `scheduler.agent` calls that pass any session-override argument (`workspaceId`/`driver`/`guestImage`/`env`/`volumes`/`title`), treated an agent's yaml `workspace:` `name` as a `workspace_config` preset id and queried the database for it. Project apply never creates that row (only the Settings `CreateWorkspacePreset` RPC does), so every such call failed at run time with `workspace config <id> not found`, even though the full workspace spec was declared in `agent-compose.yaml`.

Only `scheduler.agent(prompt)` with no override arguments was unaffected, because it goes through a separate `ProjectAgent()` path that already resolves the full `compose.WorkspaceSpec` directly (git clone / local file copy) without touching the database.

## Fix

- `pkg/projects/records.go` — embed the full `compose.WorkspaceSpec` (provider/url/path/ref/target/credentials) into `AgentDefinition.ConfigJSON` at apply time, alongside the existing `sandbox`/`jupyter`/`mcp_servers` fields. The plain `WorkspaceID` string field is left as-is (still just a label).
- `pkg/agentcompose/adapters/scheduler_workspace_inline.go` (new) — decode that inline spec at run time and resolve it directly into a sandbox workspace snapshot (git: build config JSON; file: materialize content from the project source path), mirroring how `pkg/runs/workspace.go` already resolves `AgentSpec.Workspace` for project runs.
- `pkg/agentcompose/adapters/scheduler_session_runner.go` — `Ensure()` now only falls back to the `workspace_config` DB lookup when the caller passes an explicit `WorkspaceID` override (a genuine reference to a Settings-managed preset). Otherwise it resolves the agent's inline yaml workspace, so `scheduler.shell`/`scheduler.exec` and overridden `scheduler.agent` calls now behave the same as the no-override `scheduler.agent(prompt)` path.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/agentcompose/... ./pkg/projects/... ./pkg/schedulers/... ./pkg/workspaces/... ./pkg/runs/...`
- [x] New regression tests (`pkg/agentcompose/adapters/scheduler_workspace_inline_test.go`) cover both `provider: git` and `provider: file`; verified against pre-fix code (via `git stash`) that they reproduce the exact reported error, and pass with the fix.
- [x] Real end-to-end verification: built two isolated local daemons (base commit `d6d29cf3` vs. this branch), applied the issue's minimal repro yaml, and invoked the scheduler through real Docker sandboxes for all four affected call shapes:
  - `scheduler.shell` + `provider: file`
  - `scheduler.shell` + `provider: git`
  - `scheduler.exec` + `provider: file`
  - `scheduler.agent(prompt, { title })` (session override)

  Baseline reproduces `workspace config <id> not found` in all four cases; this branch resolves the workspace correctly in all four (the last one then proceeds to a real codex agent invocation, only failing downstream on an unrelated missing-LLM-credential error in the test environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)