### PR TITLE
refactor(runs): bundle multi-argument params into structs

### DIFF
--- a/pkg/agentcompose/app/background_coverage_test.go
+++ b/pkg/agentcompose/app/background_coverage_test.go
@@ -107,7 +107,7 @@ func TestReconcilePersistedProjectRunsMarksInterruptedRunsFailed(t *testing.T) {
 			t.Fatalf("CreateProjectRun(%s) returned error: %v", run.RunID, err)
 		}
 	}
-	completions := runs.NewCompletionManager(store, nil, nil, nil, nil)
+	completions := runs.NewCompletionManager(runs.CompletionManagerDeps{Store: store})
 	if err := reconcilePersistedProjectRuns(ctx, store, completions, time.Now().Add(2*time.Second)); err != nil {
 		t.Fatalf("reconcilePersistedProjectRuns returned error: %v", err)
 	}

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -77,10 +77,13 @@ func NewRunCompletionManager(di do.Injector) (*runs.CompletionManager, error) {
 		driver: do.MustInvoke[*adapters.SandboxDriver](di), streams: do.MustInvoke[*sandboxes.StreamBroker](di),
 		locks: do.MustInvoke[*sandboxes.LifecycleLocks](di), capTokens: do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
 	}
-	return runs.NewCompletionManager(
-		do.MustInvoke[*configstore.ConfigStore](di), do.MustInvoke[*sandboxstore.Store](di), stopper,
-		do.MustInvoke[*sandboxes.RemovalCoordinator](di), do.MustInvoke[*slog.Logger](di),
-	), nil
+	return runs.NewCompletionManager(runs.CompletionManagerDeps{
+		Store:     do.MustInvoke[*configstore.ConfigStore](di),
+		Sandboxes: do.MustInvoke[*sandboxstore.Store](di),
+		Lifecycle: stopper,
+		Removal:   do.MustInvoke[*sandboxes.RemovalCoordinator](di),
+		Logger:    do.MustInvoke[*slog.Logger](di),
+	}), nil
 }
 
 type runControllerDelegate struct {

--- a/pkg/model/project_model.go
+++ b/pkg/model/project_model.go
@@ -126,6 +126,15 @@ type ProjectRunCompletionRecord struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
+// ProjectRunCompletionFailure describes one failed completion attempt to record
+// against a project run, including when the next retry should occur.
+type ProjectRunCompletionFailure struct {
+	RunID         string
+	Message       string
+	Attempt       int
+	NextAttemptAt time.Time
+}
+
 type ProjectRunEventKind string
 
 const (

--- a/pkg/runs/attach_input_test.go
+++ b/pkg/runs/attach_input_test.go
@@ -30,7 +30,7 @@ func TestAttachInputPumpsCloseRuntimeInputOnReceiveError(t *testing.T) {
 		input := &promptWrapperInput{interaction: interaction}
 		pumpRunPromptAttachInput(context.Background(), func() (RunAttachInput, error) {
 			return RunAttachInput{}, receiveErr
-		}, input, nil, nil)
+		}, promptInputPump{Input: input})
 		if interaction.closeCalls != 1 {
 			t.Fatalf("CloseSend calls = %d, want 1", interaction.closeCalls)
 		}
@@ -57,7 +57,7 @@ func TestPromptAttachInputWaitsForCompletedTurnBeforeForwardingQueuedMessages(t 
 			}
 			received <- struct{}{}
 			return req, nil
-		}, input, turnReady, nil)
+		}, promptInputPump{Input: input, TurnReady: turnReady})
 	}()
 
 	requests <- humanMessageAttachRequest("human-2")
@@ -99,7 +99,7 @@ func TestPromptAttachInputCancellationUnblocksTurnWait(t *testing.T) {
 			req := <-requests
 			received <- struct{}{}
 			return req, nil
-		}, input, make(chan struct{}, 1), nil)
+		}, promptInputPump{Input: input, TurnReady: make(chan struct{}, 1)})
 	}()
 
 	requests <- humanMessageAttachRequest("queued")

--- a/pkg/runs/capability_guide.go
+++ b/pkg/runs/capability_guide.go
@@ -15,9 +15,17 @@ import (
 	"github.com/google/uuid"
 )
 
-func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, store SandboxRuntimeStore, streams *sandboxes.StreamBroker, sandbox *domain.Sandbox, capsetIDs []string) {
+// capabilityGuideDeps groups the dependencies writeCapabilityGuide and
+// recordCapabilityGuideWarning need to render a guide and report failures.
+type capabilityGuideDeps struct {
+	Provider capabilities.Provider
+	Store    SandboxRuntimeStore
+	Streams  *sandboxes.StreamBroker
+}
+
+func writeCapabilityGuide(ctx context.Context, deps capabilityGuideDeps, sandbox *domain.Sandbox, capsetIDs []string) {
 	ids := capabilities.NormalizeCapsetIDs(capsetIDs)
-	if len(ids) == 0 || provider == nil || sandbox == nil {
+	if len(ids) == 0 || deps.Provider == nil || sandbox == nil {
 		return
 	}
 	catalogPath := capabilities.SandboxGuidePath(sandbox)
@@ -27,10 +35,10 @@ func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, s
 	var b strings.Builder
 	rendered := false
 	for _, id := range ids {
-		guide, err := capabilities.CapabilityGuideForScope(ctx, provider, capabilities.GuideScopeFromSandbox(sandbox), id)
+		guide, err := capabilities.CapabilityGuideForScope(ctx, deps.Provider, capabilities.GuideScopeFromSandbox(sandbox), id)
 		if err != nil {
 			slog.Warn("capability guide render skipped", "capset", id, "sandbox_id", sandbox.Summary.ID, "error", err)
-			recordCapabilityGuideWarning(ctx, store, streams, sandbox.Summary.ID, fmt.Sprintf("capability guide render skipped for capset %s", id))
+			recordCapabilityGuideWarning(ctx, deps, sandbox.Summary.ID, fmt.Sprintf("capability guide render skipped for capset %s", id))
 			continue
 		}
 		if rendered {
@@ -43,22 +51,22 @@ func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, s
 		return
 	}
 	content := b.String()
-	if preamble := capabilities.GuidePreamble(capabilities.ProxyTarget(provider)); preamble != "" {
+	if preamble := capabilities.GuidePreamble(capabilities.ProxyTarget(deps.Provider)); preamble != "" {
 		content = preamble + content
 	}
 	if err := os.MkdirAll(filepath.Dir(catalogPath), 0o755); err != nil {
 		slog.Warn("capability guide dir create failed", "sandbox_id", sandbox.Summary.ID, "error", err)
-		recordCapabilityGuideWarning(ctx, store, streams, sandbox.Summary.ID, "capability guide directory create failed")
+		recordCapabilityGuideWarning(ctx, deps, sandbox.Summary.ID, "capability guide directory create failed")
 		return
 	}
 	if err := os.WriteFile(catalogPath, []byte(content), 0o644); err != nil {
 		slog.Warn("capability guide write failed", "sandbox_id", sandbox.Summary.ID, "error", err)
-		recordCapabilityGuideWarning(ctx, store, streams, sandbox.Summary.ID, "capability guide write failed")
+		recordCapabilityGuideWarning(ctx, deps, sandbox.Summary.ID, "capability guide write failed")
 	}
 }
 
-func recordCapabilityGuideWarning(ctx context.Context, store SandboxRuntimeStore, streams *sandboxes.StreamBroker, sandboxID, message string) {
-	if store == nil || strings.TrimSpace(sandboxID) == "" {
+func recordCapabilityGuideWarning(ctx context.Context, deps capabilityGuideDeps, sandboxID, message string) {
+	if deps.Store == nil || strings.TrimSpace(sandboxID) == "" {
 		return
 	}
 	event := domain.SandboxEvent{
@@ -68,11 +76,11 @@ func recordCapabilityGuideWarning(ctx context.Context, store SandboxRuntimeStore
 		Message:   message,
 		CreatedAt: time.Now().UTC(),
 	}
-	if err := store.AddEvent(ctx, sandboxID, event); err != nil {
+	if err := deps.Store.AddEvent(ctx, sandboxID, event); err != nil {
 		slog.Warn("capability guide warning event failed", "sandbox_id", sandboxID, "error", err)
 		return
 	}
-	if streams != nil {
-		streams.PublishEventAdded(sandboxID, event)
+	if deps.Streams != nil {
+		deps.Streams.PublishEventAdded(sandboxID, event)
 	}
 }

--- a/pkg/runs/capability_guide_routing_test.go
+++ b/pkg/runs/capability_guide_routing_test.go
@@ -47,7 +47,7 @@ func TestProjectRunCapabilityGuideRoutesManagedScopeAndMergesBestEffort(t *testi
 		},
 	}}
 
-	writeCapabilityGuide(context.Background(), provider, nil, nil, sandbox, []string{"legacy", "internal/dev", "public/fail"})
+	writeCapabilityGuide(context.Background(), capabilityGuideDeps{Provider: provider}, sandbox, []string{"legacy", "internal/dev", "public/fail"})
 	guide, err := os.ReadFile(capabilities.SandboxGuidePath(sandbox))
 	if err != nil {
 		t.Fatalf("read merged guide: %v", err)

--- a/pkg/runs/command_execution.go
+++ b/pkg/runs/command_execution.go
@@ -104,7 +104,7 @@ func (c *Controller) executeProjectRunCommand(ctx context.Context, run domain.Pr
 		if strings.TrimSpace(result.Output) == "" {
 			result.Output = firstNonEmpty(result.Stderr, result.Stdout, execErr.Error())
 		}
-		transition = transitionFromCommandResult(run, sandbox, commandText, result, execErr)
+		transition = transitionFromCommandResult(run, sandbox, commandOutcome{Command: commandText, Result: result, Err: execErr})
 		transition.LogsPath = logsPath
 		return transition, execErr
 	}
@@ -119,7 +119,7 @@ func (c *Controller) executeProjectRunCommand(ctx context.Context, run domain.Pr
 		transition.Error = fmt.Sprintf("command execution failed: %v", err)
 		return transition, err
 	}
-	transition = transitionFromCommandResult(run, sandbox, commandText, execution.RuntimeCommandResultToExecResult(commandResult), nil)
+	transition = transitionFromCommandResult(run, sandbox, commandOutcome{Command: commandText, Result: execution.RuntimeCommandResultToExecResult(commandResult)})
 	transition.LogsPath = logsPath
 	return transition, nil
 }

--- a/pkg/runs/completion.go
+++ b/pkg/runs/completion.go
@@ -23,7 +23,7 @@ type CompletionStore interface {
 	StageProjectRunCompletion(context.Context, domain.ProjectRunCompletionRecord, []domain.ProjectRunEventRecord) (domain.ProjectRunCompletionRecord, bool, error)
 	GetProjectRunCompletion(context.Context, string) (domain.ProjectRunCompletionRecord, error)
 	ListDueProjectRunCompletions(context.Context, time.Time, int) ([]domain.ProjectRunCompletionRecord, error)
-	RecordProjectRunCompletionFailure(context.Context, string, string, int, time.Time) error
+	RecordProjectRunCompletionFailure(context.Context, domain.ProjectRunCompletionFailure) error
 	FinalizeProjectRunCompletion(context.Context, domain.ProjectRunRecord, domain.ProjectRunEventRecord) (domain.ProjectRunRecord, error)
 	ProjectRunCompletionForSandbox(context.Context, string) (string, bool, error)
 }
@@ -52,12 +52,23 @@ type CompletionManager struct {
 	started bool
 }
 
-func NewCompletionManager(store CompletionStore, sandboxStore CompletionSandboxStore, lifecycle CompletionSandboxLifecycle, removal SandboxRemoval, logger *slog.Logger) *CompletionManager {
+// CompletionManagerDeps groups CompletionManager's constructor dependencies.
+// Logger is optional; a nil value falls back to slog.Default().
+type CompletionManagerDeps struct {
+	Store     CompletionStore
+	Sandboxes CompletionSandboxStore
+	Lifecycle CompletionSandboxLifecycle
+	Removal   SandboxRemoval
+	Logger    *slog.Logger
+}
+
+func NewCompletionManager(deps CompletionManagerDeps) *CompletionManager {
+	logger := deps.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &CompletionManager{
-		store: store, sandboxes: sandboxStore, lifecycle: lifecycle, removal: removal, logger: logger,
+		store: deps.Store, sandboxes: deps.Sandboxes, lifecycle: deps.Lifecycle, removal: deps.Removal, logger: logger,
 		now: func() time.Time { return time.Now().UTC() }, locks: map[string]*sync.Mutex{}, wake: make(chan struct{}, 1),
 	}
 }
@@ -237,7 +248,9 @@ func (m *CompletionManager) process(ctx context.Context, runID string) (domain.P
 	if err := m.cleanup(ctx, run, completion.CleanupAction); err != nil {
 		attempt := completion.Attempt + 1
 		next := m.nowUTC().Add(completionRetryDelay(attempt))
-		if recordErr := m.store.RecordProjectRunCompletionFailure(context.WithoutCancel(ctx), runID, err.Error(), attempt, next); recordErr != nil {
+		if recordErr := m.store.RecordProjectRunCompletionFailure(context.WithoutCancel(ctx), domain.ProjectRunCompletionFailure{
+			RunID: runID, Message: err.Error(), Attempt: attempt, NextAttemptAt: next,
+		}); recordErr != nil {
 			return run, errors.Join(err, recordErr)
 		}
 		m.logger.Warn("project run sandbox cleanup failed", "run_id", runID, "sandbox_id", run.SandboxID, "action", completion.CleanupAction, "attempt", attempt, "next_attempt_at", next, "error", err)

--- a/pkg/runs/completion_test.go
+++ b/pkg/runs/completion_test.go
@@ -50,7 +50,7 @@ func TestCompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t *te
 	timeoutCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	stopper := &completionStopperFake{err: errors.New("stop unavailable"), onStop: cancel}
-	manager := runs.NewCompletionManager(store, sandboxes, stopper, nil, nil)
+	manager := runs.NewCompletionManager(runs.CompletionManagerDeps{Store: store, Sandboxes: sandboxes, Lifecycle: stopper})
 
 	staged, err := manager.Complete(timeoutCtx, runs.TransitionRequest{
 		RunID: run.RunID, Status: domain.ProjectRunStatusSucceeded, Output: "exact output", ResultJSON: `{"ok":true}`,
@@ -75,7 +75,9 @@ func TestCompletionManagerPersistsEventsBeforeCleanupAndRetriesFirstResult(t *te
 	}
 
 	stopper.err = nil
-	if err := store.RecordProjectRunCompletionFailure(ctx, run.RunID, journal.LastError, journal.Attempt, time.Now().Add(-time.Second)); err != nil {
+	if err := store.RecordProjectRunCompletionFailure(ctx, domain.ProjectRunCompletionFailure{
+		RunID: run.RunID, Message: journal.LastError, Attempt: journal.Attempt, NextAttemptAt: time.Now().Add(-time.Second),
+	}); err != nil {
 		t.Fatal(err)
 	}
 	completed, err := manager.Complete(ctx, runs.TransitionRequest{RunID: run.RunID, Status: domain.ProjectRunStatusCanceled, Error: "late cancellation"})

--- a/pkg/runs/controller_completion.go
+++ b/pkg/runs/controller_completion.go
@@ -103,6 +103,12 @@ func (c *Controller) completionManager() (*CompletionManager, error) {
 	if removal == nil {
 		removal = controllerCompletionRemoval{controller: c}
 	}
-	c.completion = NewCompletionManager(store, c.store, controllerCompletionStopper{controller: c}, removal, slog.Default())
+	c.completion = NewCompletionManager(CompletionManagerDeps{
+		Store:     store,
+		Sandboxes: c.store,
+		Lifecycle: controllerCompletionStopper{controller: c},
+		Removal:   removal,
+		Logger:    slog.Default(),
+	})
 	return c.completion, nil
 }

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -155,7 +155,7 @@ func TestRunsPreparationWorkspaceAndStatusWorkflows(t *testing.T) {
 	}
 	controller := &Controller{config: &appconfig.Config{DataRoot: root}}
 	run := domain.ProjectRunRecord{RunID: "run-1", ProjectID: "project-1", ProjectRevision: 1, ProjectName: "Project", AgentName: "worker", AgentID: "agent-1"}
-	prepared, err := PrepareProjectRun(ctx, store, projectRunWorkspaceResolver{controller: controller}, run, []*agentcomposev2.EnvVarSpec{{Name: "REQUEST_VAR", Value: "request"}})
+	prepared, err := PrepareProjectRun(ctx, PreparationDeps{Store: store, Resolver: projectRunWorkspaceResolver{controller: controller}}, run, []*agentcomposev2.EnvVarSpec{{Name: "REQUEST_VAR", Value: "request"}})
 	if err != nil {
 		t.Fatalf("PrepareProjectRun returned error: %v", err)
 	}
@@ -202,20 +202,20 @@ func TestRunsPreparationWorkspaceAndStatusWorkflows(t *testing.T) {
 	if _, err := projectRunGitWorkspaceConfig(run, &compose.WorkspaceSpec{Provider: "git"}); err == nil {
 		t.Fatalf("expected git workspace url error")
 	}
-	if workspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, nil, nil); err != nil || workspace != nil {
+	if workspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, WorkspaceRequest{}); err != nil || workspace != nil {
 		t.Fatalf("nil workspace = %#v/%v", workspace, err)
 	}
-	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, nil, &compose.WorkspaceSpec{}); err == nil || !strings.Contains(err.Error(), "provider is required") {
+	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, WorkspaceRequest{Agent: &compose.WorkspaceSpec{}}); err == nil || !strings.Contains(err.Error(), "provider is required") {
 		t.Fatalf("missing provider err=%v", err)
 	}
-	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, nil, &compose.WorkspaceSpec{Provider: "s3"}); err == nil || !strings.Contains(err.Error(), "unsupported") {
+	if _, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, WorkspaceRequest{Agent: &compose.WorkspaceSpec{Provider: "s3"}}); err == nil || !strings.Contains(err.Error(), "unsupported") {
 		t.Fatalf("unsupported provider err=%v", err)
 	}
-	localWorkspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, nil, &compose.WorkspaceSpec{Provider: "file", Path: "."})
+	localWorkspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, WorkspaceRequest{Agent: &compose.WorkspaceSpec{Provider: "file", Path: "."}})
 	if err != nil || localWorkspace == nil || localWorkspace.Type != "file" {
 		t.Fatalf("agent local workspace = %#v/%v", localWorkspace, err)
 	}
-	targetedWorkspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, nil, &compose.WorkspaceSpec{Provider: "file", Path: ".", Target: "nested"})
+	targetedWorkspace, err := controller.prepareProjectRunWorkspace(ctx, run, store.project, WorkspaceRequest{Agent: &compose.WorkspaceSpec{Provider: "file", Path: ".", Target: "nested"}})
 	if err != nil || targetedWorkspace == nil {
 		t.Fatalf("targeted local workspace = %#v/%v", targetedWorkspace, err)
 	}
@@ -1216,7 +1216,7 @@ func TestPromptAttachProjectorSeparatesHumanMessageFromStderrTail(t *testing.T) 
 
 func TestPromptAttachProjectorPersistsEachFrameIdempotently(t *testing.T) {
 	store := &projectorEventStore{keys: map[string]struct{}{}}
-	projector := newPersistentPromptAttachProjector(context.Background(), domain.ProjectRunRecord{RunID: "run-events", AgentName: "worker"}, &domain.Sandbox{}, filepath.Join(t.TempDir(), "transcript.txt"), nil, store)
+	projector := newPersistentPromptAttachProjector(context.Background(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-events", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: store})
 	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
@@ -1251,7 +1251,7 @@ func TestPromptAttachProjectorPersistsEachFrameIdempotently(t *testing.T) {
 
 func TestPromptAttachProjectorProjectsTerminalAgentEventAfterOnlyHumanMessage(t *testing.T) {
 	store := &projectorEventStore{keys: map[string]struct{}{}}
-	projector := newPersistentPromptAttachProjector(context.Background(), domain.ProjectRunRecord{RunID: "run-result-only", AgentName: "worker"}, &domain.Sandbox{}, filepath.Join(t.TempDir(), "transcript.txt"), nil, store)
+	projector := newPersistentPromptAttachProjector(context.Background(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-result-only", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: store})
 	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
@@ -1269,7 +1269,7 @@ func TestPromptAttachProjectorProjectsTerminalAgentEventAfterOnlyHumanMessage(t 
 
 func TestIntegrationPromptAttachProjectorPersistsAssistantTurnBeforeSkippingTerminalEvent(t *testing.T) {
 	store := &projectorEventStore{keys: map[string]struct{}{}}
-	projector := newPersistentPromptAttachProjector(context.Background(), domain.ProjectRunRecord{RunID: "run-integration-events", AgentName: "worker"}, &domain.Sandbox{}, filepath.Join(t.TempDir(), "transcript.txt"), nil, store)
+	projector := newPersistentPromptAttachProjector(context.Background(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-integration-events", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: store})
 	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
@@ -2356,15 +2356,15 @@ func TestRunsControllerHelperEdgeWorkflows(t *testing.T) {
 	root := t.TempDir()
 	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-1", "workspace")}}
 	run := domain.ProjectRunRecord{RunID: "run-1"}
-	success := transitionFromCommandResult(run, session, "echo ok", domain.ExecResult{Output: "ok\n", ExitCode: 0, Success: true}, nil)
+	success := transitionFromCommandResult(run, session, commandOutcome{Command: "echo ok", Result: domain.ExecResult{Output: "ok\n", ExitCode: 0, Success: true}})
 	if success.ExitCode != 0 || success.Error != "" || success.Output != "ok\n" || success.ArtifactsDir == "" || !strings.Contains(success.ResultJSON, `"success":true`) {
 		t.Fatalf("success transition = %#v", success)
 	}
-	failed := transitionFromCommandResult(run, session, "exit 7", domain.ExecResult{Stderr: "stderr detail\n", Output: "output detail\n", Stdout: "stdout detail\n", ExitCode: 7, Success: false}, nil)
+	failed := transitionFromCommandResult(run, session, commandOutcome{Command: "exit 7", Result: domain.ExecResult{Stderr: "stderr detail\n", Output: "output detail\n", Stdout: "stdout detail\n", ExitCode: 7, Success: false}})
 	if failed.ExitCode != 7 || !strings.Contains(failed.Error, "stderr detail") {
 		t.Fatalf("failed transition = %#v", failed)
 	}
-	execFailed := transitionFromCommandResult(run, session, "boom", domain.ExecResult{ExitCode: 0, Success: false}, errors.New("exec boom"))
+	execFailed := transitionFromCommandResult(run, session, commandOutcome{Command: "boom", Result: domain.ExecResult{ExitCode: 0, Success: false}, Err: errors.New("exec boom")})
 	if execFailed.ExitCode != 1 || !strings.Contains(execFailed.Error, "exec boom") {
 		t.Fatalf("exec failed transition = %#v", execFailed)
 	}
@@ -2418,7 +2418,7 @@ func TestRunsControllerHelperEdgeWorkflows(t *testing.T) {
 	streams := sandboxes.NewStreamBrokerForTest()
 	ch, unsubscribe := streams.Subscribe(session.Summary.ID)
 	defer unsubscribe()
-	writeCapabilityGuide(context.Background(), provider, guideStore, streams, session, capabilities.SandboxCapsets(session))
+	writeCapabilityGuide(context.Background(), capabilityGuideDeps{Provider: provider, Store: guideStore, Streams: streams}, session, capabilities.SandboxCapsets(session))
 	guidePath := capabilities.SandboxGuidePath(session)
 	data, err := os.ReadFile(guidePath)
 	if err != nil {
@@ -2438,8 +2438,8 @@ func TestRunsControllerHelperEdgeWorkflows(t *testing.T) {
 	default:
 		t.Fatalf("missing guide warning stream event")
 	}
-	recordCapabilityGuideWarning(context.Background(), nil, streams, session.Summary.ID, "ignored")
-	recordCapabilityGuideWarning(context.Background(), guideStore, streams, " ", "ignored")
+	recordCapabilityGuideWarning(context.Background(), capabilityGuideDeps{Streams: streams}, session.Summary.ID, "ignored")
+	recordCapabilityGuideWarning(context.Background(), capabilityGuideDeps{Store: guideStore, Streams: streams}, " ", "ignored")
 }
 
 func TestIntegrationRunsControllerHelperEdgeWorkflows(t *testing.T) {

--- a/pkg/runs/execution_transition.go
+++ b/pkg/runs/execution_transition.go
@@ -12,68 +12,98 @@ import (
 	"strings"
 )
 
-func transitionFromCommandResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, commandText string, result domain.ExecResult, execErr error) TransitionRequest {
+// commandOutcome is the result of a one-shot command execution, as reported
+// back to transitionFromCommandResult.
+type commandOutcome struct {
+	Command string
+	Result  domain.ExecResult
+	Err     error
+}
+
+func transitionFromCommandResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, outcome commandOutcome) TransitionRequest {
 	artifactsDir := projectRunCommandArtifactsDir(run, sandbox)
 	req := TransitionRequest{
 		RunID:        run.RunID,
 		SandboxID:    sandbox.Summary.ID,
-		ExitCode:     result.ExitCode,
-		Output:       result.Output,
+		ExitCode:     outcome.Result.ExitCode,
+		Output:       outcome.Result.Output,
 		ArtifactsDir: artifactsDir,
 		LogsPath:     filepath.Join(artifactsDir, "output.txt"),
 	}
 	resultJSON, err := json.Marshal(map[string]any{
 		"mode":     "command",
-		"command":  commandText,
-		"success":  result.Success,
-		"exitCode": result.ExitCode,
+		"command":  outcome.Command,
+		"success":  outcome.Result.Success,
+		"exitCode": outcome.Result.ExitCode,
 	})
 	if err == nil {
 		req.ResultJSON = string(resultJSON)
 	}
-	if execErr != nil {
+	if outcome.Err != nil {
 		req.ExitCode = execution.FirstNonZeroInt(req.ExitCode, 1)
-		req.Error = fmt.Sprintf("command execution failed: %v", execErr)
+		req.Error = fmt.Sprintf("command execution failed: %v", outcome.Err)
 		return req
 	}
-	if !result.Success {
+	if !outcome.Result.Success {
 		req.ExitCode = execution.FirstNonZeroInt(req.ExitCode, 1)
 		req.Error = "command execution failed"
-		if detail := firstNonEmpty(result.Stderr, result.Output, result.Stdout); strings.TrimSpace(detail) != "" {
+		if detail := firstNonEmpty(outcome.Result.Stderr, outcome.Result.Output, outcome.Result.Stdout); strings.TrimSpace(detail) != "" {
 			req.Error += ": " + strings.TrimSpace(detail)
 		}
 	}
 	return req
 }
 
-func transitionFromRuntimeResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, commandText, logsPath string, accumulated domain.ExecResult, result driverpkg.RuntimeResult, execErr error) TransitionRequest {
-	accumulated.ExitCode = result.ExitCode
-	accumulated.Success = result.Success
-	if strings.TrimSpace(result.Error) != "" {
+// runtimeOutcome is the result of a driver-executed runtime command, as
+// reported back to transitionFromRuntimeResult.
+type runtimeOutcome struct {
+	Command     string
+	LogsPath    string
+	Accumulated domain.ExecResult
+	Result      driverpkg.RuntimeResult
+	Err         error
+}
+
+func transitionFromRuntimeResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, outcome runtimeOutcome) TransitionRequest {
+	accumulated := outcome.Accumulated
+	accumulated.ExitCode = outcome.Result.ExitCode
+	accumulated.Success = outcome.Result.Success
+	if strings.TrimSpace(outcome.Result.Error) != "" {
 		accumulated.Success = false
 	}
-	if execErr == nil && strings.TrimSpace(result.Error) != "" {
-		execErr = errors.New(result.Error)
+	execErr := outcome.Err
+	if execErr == nil && strings.TrimSpace(outcome.Result.Error) != "" {
+		execErr = errors.New(outcome.Result.Error)
 	}
-	transition := transitionFromCommandResult(run, sandbox, commandText, accumulated, execErr)
-	transition.LogsPath = logsPath
+	transition := transitionFromCommandResult(run, sandbox, commandOutcome{Command: outcome.Command, Result: accumulated, Err: execErr})
+	transition.LogsPath = outcome.LogsPath
 	return transition
 }
 
-func transitionFromPromptWrapperResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, logsPath string, payload []byte, finalText, stopReason, message string) TransitionRequest {
+// promptWrapperOutcome is the result of one prompt-attach wrapper frame, as
+// reported back to transitionFromPromptWrapperResult.
+type promptWrapperOutcome struct {
+	LogsPath   string
+	Payload    []byte
+	FinalText  string
+	StopReason string
+	Message    string
+}
+
+func transitionFromPromptWrapperResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, outcome promptWrapperOutcome) TransitionRequest {
 	transition := TransitionRequest{
 		RunID:      run.RunID,
 		SandboxID:  sandbox.Summary.ID,
-		Output:     finalText,
-		ResultJSON: string(payload),
-		LogsPath:   logsPath,
+		Output:     outcome.FinalText,
+		ResultJSON: string(outcome.Payload),
+		LogsPath:   outcome.LogsPath,
 	}
-	if strings.TrimSpace(message) != "" {
+	if strings.TrimSpace(outcome.Message) != "" {
 		transition.ExitCode = 1
-		transition.Error = fmt.Sprintf("agent execution failed: %s", strings.TrimSpace(message))
+		transition.Error = fmt.Sprintf("agent execution failed: %s", strings.TrimSpace(outcome.Message))
 		return transition
 	}
-	if strings.EqualFold(strings.TrimSpace(stopReason), "cancelled") {
+	if strings.EqualFold(strings.TrimSpace(outcome.StopReason), "cancelled") {
 		transition.ExitCode = 1
 		transition.Error = "agent execution cancelled"
 	}
@@ -87,17 +117,25 @@ func promptWrapperTransitionError(transition TransitionRequest) error {
 	return errors.New(firstNonEmpty(transition.Error, "agent execution failed"))
 }
 
-func transitionFromPromptRuntimeResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, logsPath string, result driverpkg.RuntimeResult, execErr error) TransitionRequest {
+// promptRuntimeOutcome is the result of a driver-executed prompt runtime
+// command, as reported back to transitionFromPromptRuntimeResult.
+type promptRuntimeOutcome struct {
+	LogsPath string
+	Result   driverpkg.RuntimeResult
+	Err      error
+}
+
+func transitionFromPromptRuntimeResult(run domain.ProjectRunRecord, sandbox *domain.Sandbox, outcome promptRuntimeOutcome) TransitionRequest {
 	transition := TransitionRequest{
 		RunID:     run.RunID,
 		SandboxID: sandbox.Summary.ID,
-		LogsPath:  logsPath,
-		ExitCode:  result.ExitCode,
-		Error:     result.Error,
+		LogsPath:  outcome.LogsPath,
+		ExitCode:  outcome.Result.ExitCode,
+		Error:     outcome.Result.Error,
 	}
-	if execErr != nil {
+	if outcome.Err != nil {
 		transition.ExitCode = execution.FirstNonZeroInt(transition.ExitCode, 1)
-		transition.Error = fmt.Sprintf("agent execution failed: %v", execErr)
+		transition.Error = fmt.Sprintf("agent execution failed: %v", outcome.Err)
 	}
 	return transition
 }

--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -25,7 +25,7 @@ type PreparationStore interface {
 }
 
 type WorkspaceResolver interface {
-	ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, projectWorkspace, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SandboxWorkspace, error)
+	ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, req WorkspaceRequest) (*domain.WorkspaceConfig, *domain.SandboxWorkspace, error)
 }
 
 type Preparation struct {
@@ -41,7 +41,16 @@ type Preparation struct {
 	SandboxOptions   sandboxstore.CreateSandboxOptions
 }
 
-func PrepareProjectRun(ctx context.Context, store PreparationStore, resolver WorkspaceResolver, run domain.ProjectRunRecord, requestEnv []*agentcomposev2.EnvVarSpec) (Preparation, error) {
+// PreparationDeps groups the store and workspace resolver PrepareProjectRun
+// needs to prepare a run.
+type PreparationDeps struct {
+	Store    PreparationStore
+	Resolver WorkspaceResolver
+}
+
+func PrepareProjectRun(ctx context.Context, deps PreparationDeps, run domain.ProjectRunRecord, requestEnv []*agentcomposev2.EnvVarSpec) (Preparation, error) {
+	store := deps.Store
+	resolver := deps.Resolver
 	if store == nil {
 		return Preparation{}, fmt.Errorf("config store is required")
 	}
@@ -97,7 +106,7 @@ func PrepareProjectRun(ctx context.Context, store PreparationStore, resolver Wor
 	if err != nil {
 		return Preparation{}, err
 	}
-	workspaceConfig, workspaceSnapshot, err := resolver.ResolveProjectRunWorkspace(ctx, run, project, projectWorkspace, agentWorkspace)
+	workspaceConfig, workspaceSnapshot, err := resolver.ResolveProjectRunWorkspace(ctx, run, project, WorkspaceRequest{Project: projectWorkspace, Agent: agentWorkspace})
 	if err != nil {
 		return Preparation{}, err
 	}

--- a/pkg/runs/preparation_provider_env_test.go
+++ b/pkg/runs/preparation_provider_env_test.go
@@ -25,7 +25,7 @@ func TestPrepareProjectRunKeepsGlobalEnvOutOfSandboxProviderOverrides(t *testing
 			{Name: "LLM_API_KEY", Value: "global-key", Secret: true},
 		},
 	}
-	prepared, err := PrepareProjectRun(context.Background(), store, nil, domain.ProjectRunRecord{
+	prepared, err := PrepareProjectRun(context.Background(), PreparationDeps{Store: store}, domain.ProjectRunRecord{
 		ProjectID:       "project-1",
 		ProjectRevision: 1,
 		AgentName:       "worker",

--- a/pkg/runs/project_run_capability_token_test.go
+++ b/pkg/runs/project_run_capability_token_test.go
@@ -45,7 +45,7 @@ func TestProjectRunCapabilityTokenLifecycle(t *testing.T) {
 		fixture.controller.capTokens = indexer
 		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusStopped)
 
-		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed", nil); err != nil {
+		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, sandboxStartEvent{Type: "sandbox.resumed", Message: "resumed"}, nil); err != nil {
 			t.Fatalf("startProjectRunSandbox: %v", err)
 		}
 		if len(indexer.indexed) != 1 {
@@ -71,7 +71,7 @@ func TestProjectRunCapabilityTokenLifecycle(t *testing.T) {
 		fixture.driver.startErr = errors.New("start failed")
 		sandbox := newProjectRunCapabilitySandbox(t, fixture, domain.VMStatusStopped)
 
-		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, "sandbox.resumed", "resumed", nil); !errors.Is(err, fixture.driver.startErr) {
+		if err := fixture.controller.startProjectRunSandbox(fixture.ctx, sandbox, sandboxStartEvent{Type: "sandbox.resumed", Message: "resumed"}, nil); !errors.Is(err, fixture.driver.startErr) {
 			t.Fatalf("startProjectRunSandbox error = %v", err)
 		}
 		if len(indexer.indexed) != 0 || len(indexer.revoked) != 0 {

--- a/pkg/runs/project_workspace_resume_integration_test.go
+++ b/pkg/runs/project_workspace_resume_integration_test.go
@@ -62,8 +62,8 @@ func TestIntegrationProjectLocalWorkspaceExistingAndNewSandboxState(t *testing.T
 	if err != nil {
 		t.Fatalf("derive project agent id: %v", err)
 	}
-	revisionV1 := saveProjectWorkspaceRevision(t, ctx, configDB, projectID, "v1")
-	upsertProjectWorkspaceAgent(t, ctx, configDB, project, agentID, revisionV1.Revision)
+	revisionV1 := saveProjectWorkspaceRevision(t, projectWorkspaceStoreHarness{Ctx: ctx, Store: configDB}, projectID, "v1")
+	upsertProjectWorkspaceAgent(t, projectWorkspaceStoreHarness{Ctx: ctx, Store: configDB}, projectWorkspaceAgentSpec{Project: project, AgentID: agentID, Revision: revisionV1.Revision})
 
 	driver := &projectWorkspaceManifestDriver{store: sandboxStore}
 	controller := runs.NewController(runs.ControllerDependencies{
@@ -93,9 +93,21 @@ func TestIntegrationProjectLocalWorkspaceExistingAndNewSandboxState(t *testing.T
 	if len(driver.starts) != 1 || driver.starts[0].sandboxID != runA.SandboxID {
 		t.Fatalf("driver starts after run A = %#v", driver.starts)
 	}
-	assertProjectWorkspaceManifestFile(t, driver.starts[0].manifest, "editable.txt", "template v1\n", 0o644)
-	assertProjectWorkspaceManifestFile(t, driver.starts[0].manifest, "deleted.txt", "delete from sandbox\n", 0o640)
-	assertProjectWorkspaceManifestFile(t, driver.starts[0].manifest, "v1-only.txt", "source v1 only\n", 0o600)
+	assertProjectWorkspaceManifestFile(t, driver.starts[0].manifest, projectWorkspaceManifestFileExpectation{
+		Path:    "editable.txt",
+		Content: "template v1\n",
+		Mode:    0o644,
+	})
+	assertProjectWorkspaceManifestFile(t, driver.starts[0].manifest, projectWorkspaceManifestFileExpectation{
+		Path:    "deleted.txt",
+		Content: "delete from sandbox\n",
+		Mode:    0o640,
+	})
+	assertProjectWorkspaceManifestFile(t, driver.starts[0].manifest, projectWorkspaceManifestFileExpectation{
+		Path:    "v1-only.txt",
+		Content: "source v1 only\n",
+		Mode:    0o600,
+	})
 
 	sandboxA, err := sandboxStore.GetSandbox(ctx, runA.SandboxID)
 	if err != nil {
@@ -131,8 +143,16 @@ func TestIntegrationProjectLocalWorkspaceExistingAndNewSandboxState(t *testing.T
 		t.Fatalf("create run A workspace symlink: %v", err)
 	}
 	manifestBeforeReuse := mustProjectWorkspaceManifest(t, workspaceRootA)
-	assertProjectWorkspaceManifestFile(t, manifestBeforeReuse, "editable.txt", "user edit\n", 0o600)
-	assertProjectWorkspaceManifestFile(t, manifestBeforeReuse, "generated/result.txt", "run A output\n", 0o640)
+	assertProjectWorkspaceManifestFile(t, manifestBeforeReuse, projectWorkspaceManifestFileExpectation{
+		Path:    "editable.txt",
+		Content: "user edit\n",
+		Mode:    0o600,
+	})
+	assertProjectWorkspaceManifestFile(t, manifestBeforeReuse, projectWorkspaceManifestFileExpectation{
+		Path:    "generated/result.txt",
+		Content: "run A output\n",
+		Mode:    0o640,
+	})
 	assertProjectWorkspaceManifestMissing(t, manifestBeforeReuse, "deleted.txt")
 	assertProjectWorkspaceManifestSymlink(t, manifestBeforeReuse, "result-link", filepath.Join("generated", "result.txt"))
 
@@ -142,8 +162,8 @@ func TestIntegrationProjectLocalWorkspaceExistingAndNewSandboxState(t *testing.T
 		t.Fatalf("remove v1-only source file: %v", err)
 	}
 	writeProjectWorkspaceFile(t, filepath.Join(sourceRoot, "source-v2.txt"), "new source v2 file\n", 0o644)
-	revisionV2 := saveProjectWorkspaceRevision(t, ctx, configDB, projectID, "v2")
-	upsertProjectWorkspaceAgent(t, ctx, configDB, project, agentID, revisionV2.Revision)
+	revisionV2 := saveProjectWorkspaceRevision(t, projectWorkspaceStoreHarness{Ctx: ctx, Store: configDB}, projectID, "v2")
+	upsertProjectWorkspaceAgent(t, projectWorkspaceStoreHarness{Ctx: ctx, Store: configDB}, projectWorkspaceAgentSpec{Project: project, AgentID: agentID, Revision: revisionV2.Revision})
 	if got := mustProjectWorkspaceManifest(t, snapshotRootA); !reflect.DeepEqual(got, snapshotManifestA) {
 		t.Fatalf("run A source snapshot changed after project source v2 update:\n got: %#v\nwant: %#v", got, snapshotManifestA)
 	}
@@ -220,9 +240,21 @@ func TestIntegrationProjectLocalWorkspaceExistingAndNewSandboxState(t *testing.T
 	if startB.provisioningStatus != domain.SandboxWorkspaceProvisioningStatusReady || startB.readyAt.IsZero() {
 		t.Fatalf("run B driver provisioning = status %q timestamp %v, want ready", startB.provisioningStatus, startB.readyAt)
 	}
-	assertProjectWorkspaceManifestFile(t, startB.manifest, "editable.txt", "template v2\n", 0o644)
-	assertProjectWorkspaceManifestFile(t, startB.manifest, "deleted.txt", "source v2 replacement\n", 0o644)
-	assertProjectWorkspaceManifestFile(t, startB.manifest, "source-v2.txt", "new source v2 file\n", 0o644)
+	assertProjectWorkspaceManifestFile(t, startB.manifest, projectWorkspaceManifestFileExpectation{
+		Path:    "editable.txt",
+		Content: "template v2\n",
+		Mode:    0o644,
+	})
+	assertProjectWorkspaceManifestFile(t, startB.manifest, projectWorkspaceManifestFileExpectation{
+		Path:    "deleted.txt",
+		Content: "source v2 replacement\n",
+		Mode:    0o644,
+	})
+	assertProjectWorkspaceManifestFile(t, startB.manifest, projectWorkspaceManifestFileExpectation{
+		Path:    "source-v2.txt",
+		Content: "new source v2 file\n",
+		Mode:    0o644,
+	})
 	assertProjectWorkspaceManifestMissing(t, startB.manifest, "v1-only.txt")
 	assertProjectWorkspaceManifestMissing(t, startB.manifest, "generated")
 	assertProjectWorkspaceManifestMissing(t, startB.manifest, "generated/result.txt")
@@ -269,9 +301,16 @@ const projectWorkspaceRevisionSpec = `{
   ]
 }`
 
-func saveProjectWorkspaceRevision(t *testing.T, ctx context.Context, store *configstore.ConfigStore, projectID, version string) domain.ProjectRevisionRecord {
+// projectWorkspaceStoreHarness groups the store/context pair shared by this
+// file's project-workspace test helpers.
+type projectWorkspaceStoreHarness struct {
+	Ctx   context.Context
+	Store *configstore.ConfigStore
+}
+
+func saveProjectWorkspaceRevision(t *testing.T, h projectWorkspaceStoreHarness, projectID, version string) domain.ProjectRevisionRecord {
 	t.Helper()
-	revision, created, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{
+	revision, created, err := h.Store.SaveProjectRevision(h.Ctx, domain.ProjectRevisionRecord{
 		ProjectID: projectID,
 		SpecHash:  "project-local-" + version,
 		SpecJSON:  fmt.Sprintf(projectWorkspaceRevisionSpec, version),
@@ -282,20 +321,26 @@ func saveProjectWorkspaceRevision(t *testing.T, ctx context.Context, store *conf
 	return revision
 }
 
-func upsertProjectWorkspaceAgent(t *testing.T, ctx context.Context, store *configstore.ConfigStore, project domain.ProjectRecord, agentID string, revision int64) {
+type projectWorkspaceAgentSpec struct {
+	Project  domain.ProjectRecord
+	AgentID  string
+	Revision int64
+}
+
+func upsertProjectWorkspaceAgent(t *testing.T, h projectWorkspaceStoreHarness, spec projectWorkspaceAgentSpec) {
 	t.Helper()
-	if _, err := store.UpsertProjectAgent(ctx, domain.ProjectAgentRecord{
-		ID:        agentID,
+	if _, err := h.Store.UpsertProjectAgent(h.Ctx, domain.ProjectAgentRecord{
+		ID:        spec.AgentID,
 		Name:      "worker",
-		ProjectID: project.ID,
+		ProjectID: spec.Project.ID,
 		AgentName: "worker",
-		Revision:  revision,
+		Revision:  spec.Revision,
 		Provider:  "codex",
 		Image:     "guest:latest",
 		Driver:    driverpkg.RuntimeDriverDocker,
 		SpecJSON:  `{"name":"worker"}`,
 	}); err != nil {
-		t.Fatalf("upsert project agent revision %d: %v", revision, err)
+		t.Fatalf("upsert project agent revision %d: %v", spec.Revision, err)
 	}
 }
 
@@ -430,18 +475,24 @@ func projectWorkspaceSnapshotRoot(t *testing.T, config *appconfig.Config, worksp
 	return root
 }
 
-func assertProjectWorkspaceManifestFile(t *testing.T, manifest []testutil.WorkspaceManifestEntry, path, content string, mode os.FileMode) {
+type projectWorkspaceManifestFileExpectation struct {
+	Path    string
+	Content string
+	Mode    os.FileMode
+}
+
+func assertProjectWorkspaceManifestFile(t *testing.T, manifest []testutil.WorkspaceManifestEntry, want projectWorkspaceManifestFileExpectation) {
 	t.Helper()
 	for _, entry := range manifest {
-		if entry.Path != path {
+		if entry.Path != want.Path {
 			continue
 		}
-		if entry.Type != testutil.WorkspaceManifestEntryTypeFile || entry.Mode != mode || entry.ContentSHA256 != projectWorkspaceFileSHA256(content) {
-			t.Fatalf("manifest entry %q = %#v, want regular file mode=%v content=%q", path, entry, mode, content)
+		if entry.Type != testutil.WorkspaceManifestEntryTypeFile || entry.Mode != want.Mode || entry.ContentSHA256 != projectWorkspaceFileSHA256(want.Content) {
+			t.Fatalf("manifest entry %q = %#v, want regular file mode=%v content=%q", want.Path, entry, want.Mode, want.Content)
 		}
 		return
 	}
-	t.Fatalf("manifest entry %q is missing: %#v", path, manifest)
+	t.Fatalf("manifest entry %q is missing: %#v", want.Path, manifest)
 }
 
 func assertProjectWorkspaceManifestMissing(t *testing.T, manifest []testutil.WorkspaceManifestEntry, path string) {

--- a/pkg/runs/prompt_attach.go
+++ b/pkg/runs/prompt_attach.go
@@ -133,7 +133,7 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 	}
 	interaction = driverpkg.GuardRuntimeInteractionInput(interaction)
 	defer func() { _ = interaction.CloseSend() }()
-	projector := newPersistentPromptAttachProjector(context.WithoutCancel(ctx), run, sandbox, logsPath, c.runLogs, c.configDB)
+	projector := newPersistentPromptAttachProjector(context.WithoutCancel(ctx), persistentPromptAttachProjectorDeps{Run: run, Sandbox: sandbox, LogsPath: logsPath, Hub: c.runLogs, EventStore: c.configDB})
 	input := &promptWrapperInput{interaction: interaction}
 	if err := input.Start(agentConfig, c.config, schemaPath); err != nil {
 		transition.ExitCode = 1
@@ -152,7 +152,7 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 	} else {
 		releasePromptTurn(turnReady)
 	}
-	go pumpRunPromptAttachInput(inputCtx, receive, input, turnReady, projector.AppendHumanMessageFrame)
+	go pumpRunPromptAttachInput(inputCtx, receive, promptInputPump{Input: input, TurnReady: turnReady, OnHumanMessage: projector.AppendHumanMessageFrame})
 	var promptTransition *TransitionRequest
 	for {
 		frame, err := interaction.Recv()
@@ -175,7 +175,7 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 					}
 					return *promptTransition, nil
 				}
-				return transitionFromPromptRuntimeResult(run, sandbox, logsPath, result, errorFromRuntimeResult(result)), errorFromRuntimeResult(result)
+				return transitionFromPromptRuntimeResult(run, sandbox, promptRuntimeOutcome{LogsPath: logsPath, Result: result, Err: errorFromRuntimeResult(result)}), errorFromRuntimeResult(result)
 			}
 			transition.ExitCode = 1
 			transition.Error = fmt.Sprintf("agent execution failed: %v", err)
@@ -237,7 +237,7 @@ func (c *Controller) runPromptInteraction(ctx context.Context, coordinator *Coor
 				}
 				return *promptTransition, nil
 			}
-			return transitionFromPromptRuntimeResult(run, sandbox, logsPath, *result, errorFromRuntimeResult(*result)), errorFromRuntimeResult(*result)
+			return transitionFromPromptRuntimeResult(run, sandbox, promptRuntimeOutcome{LogsPath: logsPath, Result: *result, Err: errorFromRuntimeResult(*result)}), errorFromRuntimeResult(*result)
 		case driverpkg.RuntimeOutputError:
 			code := "runtime_error"
 			message := "runtime interaction failed"
@@ -309,50 +309,58 @@ func (w *promptWrapperInput) send(frame map[string]any) error {
 	return w.interaction.Send(driverpkg.RuntimeInputFrame{Type: driverpkg.RuntimeInputStdin, Data: data})
 }
 
-func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, input *promptWrapperInput, turnReady <-chan struct{}, onHumanMessage func(string, string) error) {
-	defer func() { _ = input.interaction.CloseSend() }()
+// promptInputPump groups the wrapper input stream, the gate that releases a
+// turn, and the callback notified of each forwarded human message.
+type promptInputPump struct {
+	Input          *promptWrapperInput
+	TurnReady      <-chan struct{}
+	OnHumanMessage func(string, string) error
+}
+
+func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, pump promptInputPump) {
+	defer func() { _ = pump.Input.interaction.CloseSend() }()
 	for {
 		req, err := receive()
 		if err != nil {
-			_ = input.EOF()
+			_ = pump.Input.EOF()
 			return
 		}
 		switch req.Kind {
 		case RunAttachInputHumanMessage:
-			if !forwardPromptHumanMessage(ctx, input, turnReady, req.Text, req.ClientFrameID, onHumanMessage) {
+			if !forwardPromptHumanMessage(ctx, pump, req.Text, req.ClientFrameID) {
 				return
 			}
 		case RunAttachInputStdin:
-			if !forwardPromptHumanMessage(ctx, input, turnReady, string(req.Data), req.ClientFrameID, onHumanMessage) {
+			if !forwardPromptHumanMessage(ctx, pump, string(req.Data), req.ClientFrameID) {
 				return
 			}
 		case RunAttachInputStdinEOF:
-			_ = input.EOF()
+			_ = pump.Input.EOF()
 			return
 		case RunAttachInputCancel:
-			_ = input.Cancel(req.Reason)
+			_ = pump.Input.Cancel(req.Reason)
 			return
 		default:
-			_ = input.Cancel("invalid run prompt attach frame")
+			_ = pump.Input.Cancel("invalid run prompt attach frame")
 			return
 		}
 	}
 }
 
-func forwardPromptHumanMessage(ctx context.Context, input *promptWrapperInput, turnReady <-chan struct{}, text, clientFrameID string, onHumanMessage func(string, string) error) bool {
-	if turnReady != nil {
+func forwardPromptHumanMessage(ctx context.Context, pump promptInputPump, text, clientFrameID string) bool {
+	if pump.TurnReady != nil {
 		select {
 		case <-ctx.Done():
 			return false
-		case <-turnReady:
+		case <-pump.TurnReady:
 		}
 	}
-	if onHumanMessage != nil {
-		if err := onHumanMessage(text, clientFrameID); err != nil {
+	if pump.OnHumanMessage != nil {
+		if err := pump.OnHumanMessage(text, clientFrameID); err != nil {
 			return false
 		}
 	}
-	return input.HumanMessage(text) == nil
+	return pump.Input.HumanMessage(text) == nil
 }
 
 func releasePromptTurn(turnReady chan<- struct{}) {

--- a/pkg/runs/prompt_projection.go
+++ b/pkg/runs/prompt_projection.go
@@ -27,10 +27,20 @@ type promptAttachProjector struct {
 	humanIndex             uint64
 }
 
-func newPersistentPromptAttachProjector(ctx context.Context, run domain.ProjectRunRecord, sandbox *domain.Sandbox, logsPath string, hub *RunLogHub, store any) *promptAttachProjector {
-	projector := newPromptAttachProjector(run, sandbox, logsPath, hub)
+// persistentPromptAttachProjectorDeps groups the dependencies needed to build
+// a promptAttachProjector that also persists structured events.
+type persistentPromptAttachProjectorDeps struct {
+	Run        domain.ProjectRunRecord
+	Sandbox    *domain.Sandbox
+	LogsPath   string
+	Hub        *RunLogHub
+	EventStore any
+}
+
+func newPersistentPromptAttachProjector(ctx context.Context, deps persistentPromptAttachProjectorDeps) *promptAttachProjector {
+	projector := newPromptAttachProjector(deps.Run, deps.Sandbox, deps.LogsPath, deps.Hub)
 	projector.eventCtx = ctx
-	projector.events, _ = store.(structuredEventStore)
+	projector.events, _ = deps.EventStore.(structuredEventStore)
 	return projector
 }
 
@@ -110,12 +120,12 @@ func (p *promptAttachProjector) projectLine(line []byte) ([]RunAttachOutput, *Tr
 		if err := p.appendLogFinalText(frame.FinalText); err != nil {
 			return nil, nil, err
 		}
-		transition := transitionFromPromptWrapperResult(p.run, p.sandbox, p.logsPath, line, frame.FinalText, frame.StopReason, "")
+		transition := transitionFromPromptWrapperResult(p.run, p.sandbox, promptWrapperOutcome{LogsPath: p.logsPath, Payload: line, FinalText: frame.FinalText, StopReason: frame.StopReason})
 		transition.TerminalEvents = p.terminalTurnEvents(agentTurnProjection{FinalText: frame.FinalText, FinalTextSource: frame.FinalTextSource, Provider: frame.Provider, StopReason: frame.StopReason})
 		return nil, &transition, nil
 	case "error":
 		message := firstNonEmpty(frame.Message, "runtime stream error")
-		transition := transitionFromPromptWrapperResult(p.run, p.sandbox, p.logsPath, line, "", frame.StopReason, message)
+		transition := transitionFromPromptWrapperResult(p.run, p.sandbox, promptWrapperOutcome{LogsPath: p.logsPath, Payload: line, StopReason: frame.StopReason, Message: message})
 		return []RunAttachOutput{runAttachErrorResponse(firstNonEmpty(frame.Code, "runtime_stream_error"), message, true)}, &transition, nil
 	default:
 		return []RunAttachOutput{runAttachAgentEventResponse(firstNonEmpty(frame.Type, "agent_event"), "", string(line))}, nil, nil

--- a/pkg/runs/run_attach.go
+++ b/pkg/runs/run_attach.go
@@ -153,7 +153,7 @@ func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coo
 					transition.Error = fmt.Sprintf("command execution failed: %v", waitErr)
 					return transition, waitErr
 				}
-				return transitionFromRuntimeResult(run, sandbox, commandText, logsPath, accumulator.Result(result.ExitCode, result.Success), result, nil), nil
+				return transitionFromRuntimeResult(run, sandbox, runtimeOutcome{Command: commandText, LogsPath: logsPath, Accumulated: accumulator.Result(result.ExitCode, result.Success), Result: result}), nil
 			}
 			transition.ExitCode = 1
 			transition.Error = fmt.Sprintf("command execution failed: %v", err)
@@ -188,7 +188,7 @@ func (c *Controller) runCommandInteraction(ctx context.Context, coordinator *Coo
 			if result == nil {
 				result = &driverpkg.RuntimeResult{OperationID: run.RunID, Success: true}
 			}
-			return transitionFromRuntimeResult(run, sandbox, commandText, logsPath, accumulator.Result(result.ExitCode, result.Success), *result, errorFromRuntimeResult(*result)), nil
+			return transitionFromRuntimeResult(run, sandbox, runtimeOutcome{Command: commandText, LogsPath: logsPath, Accumulated: accumulator.Result(result.ExitCode, result.Success), Result: *result, Err: errorFromRuntimeResult(*result)}), nil
 		case driverpkg.RuntimeOutputError:
 			code := "runtime_error"
 			message := "runtime interaction failed"

--- a/pkg/runs/sandbox_preparation.go
+++ b/pkg/runs/sandbox_preparation.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (c *Controller) prepareProjectRun(ctx context.Context, run domain.ProjectRunRecord, requestEnv []*agentcomposev2.EnvVarSpec) (Preparation, error) {
-	return PrepareProjectRun(ctx, c.configDB, projectRunWorkspaceResolver{controller: c}, run, requestEnv)
+	return PrepareProjectRun(ctx, PreparationDeps{Store: c.configDB, Resolver: projectRunWorkspaceResolver{controller: c}}, run, requestEnv)
 }
 
 func resolveRunJupyterOptions(base sandboxstore.CreateSandboxOptions, override *agentcomposev2.RunJupyterSpec) (sandboxstore.CreateSandboxOptions, error) {
@@ -80,7 +80,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 		jupyterOptions.VolumeMounts = volumeMounts
 		volumesResolved = true
 	}
-	stickyConfigHash, err := stickyProjectRunConfigHash(req.StickyBindingConfigHash, run, prepared, driver, guestImage, volumeMounts, jupyterOptions)
+	stickyConfigHash, err := stickyProjectRunConfigHash(req.StickyBindingConfigHash, run, prepared, stickySandboxSpec{Driver: driver, GuestImage: guestImage, VolumeMounts: volumeMounts, Jupyter: jupyterOptions})
 	if err != nil {
 		return SandboxResult{}, fmt.Errorf("hash sticky project sandbox configuration: %w", err)
 	}
@@ -105,7 +105,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 		if !hasBindingStore {
 			return SandboxResult{}, fmt.Errorf("sticky sandbox binding store is required")
 		}
-		sandboxID, binding, bindingWarnings, err := c.resolveStickySchedulerBinding(ctx, bindingStore, stickySchedulerID, stickyTriggerID, stickyConfigHash)
+		sandboxID, binding, bindingWarnings, err := c.resolveStickySchedulerBinding(ctx, bindingStore, stickyBindingKey{SchedulerID: stickySchedulerID, TriggerID: stickyTriggerID, ConfigHash: stickyConfigHash})
 		if err != nil {
 			return SandboxResult{}, err
 		}
@@ -197,7 +197,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 			}
 			sandbox.EnvItems = domain.MergeEnvItems(sandbox.EnvItems, capabilityVars)
 			sandbox.Summary.Tags = MergeSandboxTags(sandbox.Summary.Tags, tags)
-			if err := c.startProjectRunSandbox(ctx, sandbox, "sandbox.resumed", "sandbox resumed for project run", trustedHeaders); err != nil {
+			if err := c.startProjectRunSandbox(ctx, sandbox, sandboxStartEvent{Type: "sandbox.resumed", Message: "sandbox resumed for project run"}, trustedHeaders); err != nil {
 				return SandboxResult{Sandbox: sandbox}, err
 			}
 			return SandboxResult{Sandbox: sandbox, Warnings: warnings}, nil
@@ -265,7 +265,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 		_ = c.store.UpdateSandbox(ctx, sandbox)
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
 	}
-	if err := c.startProjectRunSandboxRuntime(ctx, sandbox, "sandbox.created", "sandbox started for project run", trustedHeaders); err != nil {
+	if err := c.startProjectRunSandboxRuntime(ctx, sandbox, sandboxStartEvent{Type: "sandbox.created", Message: "sandbox started for project run"}, trustedHeaders); err != nil {
 		return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, err
 	}
 	if stickySchedulerID != "" {
@@ -283,7 +283,7 @@ func (c *Controller) ensureProjectRunSandbox(ctx context.Context, run domain.Pro
 			if err := c.stopProjectRunSandbox(ctx, sandbox); err != nil {
 				return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, fmt.Errorf("retire unclaimed sticky sandbox: %w", err)
 			}
-			winner, compatible, err := loadCompatibleStickySchedulerBinding(ctx, bindingStore, stickySchedulerID, stickyTriggerID, stickyConfigHash)
+			winner, compatible, err := loadCompatibleStickySchedulerBinding(ctx, bindingStore, stickyBindingKey{SchedulerID: stickySchedulerID, TriggerID: stickyTriggerID, ConfigHash: stickyConfigHash})
 			if err != nil {
 				return SandboxResult{Sandbox: sandbox, Created: true, Warnings: volumeWarnings}, fmt.Errorf("load concurrently claimed sticky sandbox: %w", err)
 			}
@@ -382,7 +382,14 @@ func (c *Controller) applyJupyterOptionsToSandbox(sandbox *domain.Sandbox, optio
 	return c.store.SaveProxyState(sandbox.Summary.ID, proxyState)
 }
 
-func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain.Sandbox, eventType, eventMessage string, trustedHeaders []domain.TrustedHeader) error {
+// sandboxStartEvent is the sandbox-start event recorded when a project run's
+// sandbox transitions to running, either freshly created or resumed.
+type sandboxStartEvent struct {
+	Type    string
+	Message string
+}
+
+func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain.Sandbox, event sandboxStartEvent, trustedHeaders []domain.TrustedHeader) error {
 	if sandbox == nil {
 		return fmt.Errorf("sandbox is required")
 	}
@@ -397,7 +404,7 @@ func (c *Controller) startProjectRunSandbox(ctx context.Context, sandbox *domain
 		_ = c.store.UpdateSandbox(ctx, sandbox)
 		return err
 	}
-	return c.startProjectRunSandboxRuntime(ctx, sandbox, eventType, eventMessage, trustedHeaders)
+	return c.startProjectRunSandboxRuntime(ctx, sandbox, event, trustedHeaders)
 }
 
 func (c *Controller) ensureProjectRunSandboxWorkspace(ctx context.Context, sandbox *domain.Sandbox) error {
@@ -426,8 +433,8 @@ func (c *Controller) prepareFreshStartAgentEnvironment(ctx context.Context, sand
 	return c.executor.PrepareSandboxAgentEnvironmentFromTags(ctx, sandbox)
 }
 
-func (c *Controller) startProjectRunSandboxRuntime(ctx context.Context, sandbox *domain.Sandbox, eventType, eventMessage string, trustedHeaders []domain.TrustedHeader) error {
-	writeCapabilityGuide(ctx, c.cap, c.store, c.streams, sandbox, capabilities.SandboxCapsets(sandbox))
+func (c *Controller) startProjectRunSandboxRuntime(ctx context.Context, sandbox *domain.Sandbox, event sandboxStartEvent, trustedHeaders []domain.TrustedHeader) error {
+	writeCapabilityGuide(ctx, capabilityGuideDeps{Provider: c.cap, Store: c.store, Streams: c.streams}, sandbox, capabilities.SandboxCapsets(sandbox))
 	if sandbox.Summary.VMStatus != domain.VMStatusRunning {
 		if err := c.driver.StartSandboxVM(ctx, sandbox); err != nil {
 			sandbox.Summary.VMStatus = domain.VMStatusFailed
@@ -440,7 +447,7 @@ func (c *Controller) startProjectRunSandboxRuntime(ctx context.Context, sandbox 
 	if err := c.store.UpdateSandbox(ctx, sandbox); err != nil {
 		return err
 	}
-	c.publishProjectRunSandboxStarted(ctx, sandbox, eventType, eventMessage)
+	c.publishProjectRunSandboxStarted(ctx, sandbox, event.Type, event.Message)
 	loaded, err := c.store.GetSandbox(ctx, sandbox.Summary.ID)
 	if err != nil {
 		return err

--- a/pkg/runs/sticky_scheduler_binding.go
+++ b/pkg/runs/sticky_scheduler_binding.go
@@ -61,27 +61,36 @@ func stickyProjectSandboxOptionsFrom(options sandboxstore.CreateSandboxOptions) 
 	}
 }
 
-func stickyProjectRunConfigHash(baseHash string, run domain.ProjectRunRecord, prepared Preparation, driver, guestImage string, volumeMounts []domain.SandboxVolumeMount, jupyter sandboxstore.CreateSandboxOptions) (string, error) {
+// stickySandboxSpec is the effective sandbox spec folded into a sticky
+// scheduler binding's config hash.
+type stickySandboxSpec struct {
+	Driver       string
+	GuestImage   string
+	VolumeMounts []domain.SandboxVolumeMount
+	Jupyter      sandboxstore.CreateSandboxOptions
+}
+
+func stickyProjectRunConfigHash(baseHash string, run domain.ProjectRunRecord, prepared Preparation, spec stickySandboxSpec) (string, error) {
 	baseHash = strings.TrimSpace(baseHash)
 	if baseHash == "" {
 		return "", nil
 	}
 	capsetIDs := capabilities.NormalizeCapsetIDs(prepared.CapsetIDs)
 	sort.Strings(capsetIDs)
-	volumeMounts = schedulers.NormalizeStickySandboxVolumeMounts(volumeMounts)
+	volumeMounts := schedulers.NormalizeStickySandboxVolumeMounts(spec.VolumeMounts)
 	payload, err := json.Marshal(stickyProjectRunSandboxConfig{
 		SchedulerConfigHash: baseHash,
 		ProjectID:           run.ProjectID,
 		ProjectRevision:     run.ProjectRevision,
 		AgentName:           run.AgentName,
 		AgentID:             run.AgentID,
-		Driver:              strings.TrimSpace(driver),
-		ImageRef:            strings.TrimSpace(guestImage),
+		Driver:              strings.TrimSpace(spec.Driver),
+		ImageRef:            strings.TrimSpace(spec.GuestImage),
 		EnvItems:            domain.NormalizeEnvItems(prepared.EnvItems),
 		CapsetIDs:           capsetIDs,
 		Workspace:           prepared.Workspace,
 		VolumeMounts:        volumeMounts,
-		Jupyter:             stickyProjectSandboxOptionsFrom(jupyter),
+		Jupyter:             stickyProjectSandboxOptionsFrom(spec.Jupyter),
 	})
 	if err != nil {
 		return "", err
@@ -90,7 +99,16 @@ func stickyProjectRunConfigHash(baseHash string, run domain.ProjectRunRecord, pr
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-func (c *Controller) resolveStickySchedulerBinding(ctx context.Context, store stickyBindingStore, schedulerID, triggerID, configHash string) (string, *domain.SchedulerBinding, []string, error) {
+// stickyBindingKey identifies the scheduler binding a sticky sandbox is
+// being resolved or claimed against.
+type stickyBindingKey struct {
+	SchedulerID string
+	TriggerID   string
+	ConfigHash  string
+}
+
+func (c *Controller) resolveStickySchedulerBinding(ctx context.Context, store stickyBindingStore, key stickyBindingKey) (string, *domain.SchedulerBinding, []string, error) {
+	schedulerID, triggerID, configHash := key.SchedulerID, key.TriggerID, key.ConfigHash
 	for range 3 {
 		binding, found, err := store.GetSchedulerBinding(ctx, schedulerID, triggerID)
 		if err != nil {
@@ -159,7 +177,8 @@ func claimLegacyStickySchedulerBindingConfigHash(ctx context.Context, store stic
 	return replacement, claimed, nil
 }
 
-func loadCompatibleStickySchedulerBinding(ctx context.Context, store stickyBindingStore, schedulerID, triggerID, configHash string) (domain.SchedulerBinding, bool, error) {
+func loadCompatibleStickySchedulerBinding(ctx context.Context, store stickyBindingStore, key stickyBindingKey) (domain.SchedulerBinding, bool, error) {
+	schedulerID, triggerID, configHash := key.SchedulerID, key.TriggerID, key.ConfigHash
 	for range 3 {
 		binding, found, err := store.GetSchedulerBinding(ctx, schedulerID, triggerID)
 		if err != nil || !found {

--- a/pkg/runs/sticky_scheduler_binding_test.go
+++ b/pkg/runs/sticky_scheduler_binding_test.go
@@ -46,40 +46,70 @@ func TestStickyProjectRunConfigHashTracksEffectiveSandboxSpec(t *testing.T) {
 		{ID: "volume-v2", Type: "volume", Source: "data", Target: "/workspace/data", HostPath: "/host/v2"},
 		{ID: "volume-cache", Type: "bind", Source: "./cache", Target: "/workspace/cache", HostPath: "/host/cache"},
 	}
-	first, err := stickyProjectRunConfigHash(baseHash, run, prepared, "docker", "guest:v1", volumeMounts, sandboxstore.CreateSandboxOptions{})
+	first, err := stickyProjectRunConfigHash(baseHash, run, prepared, stickySandboxSpec{
+		Driver:       "docker",
+		GuestImage:   "guest:v1",
+		VolumeMounts: volumeMounts,
+		Jupyter:      sandboxstore.CreateSandboxOptions{},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash returned error: %v", err)
 	}
 
 	reordered := prepared
 	reordered.CapsetIDs = []string{"b", "a", "a"}
-	same, err := stickyProjectRunConfigHash(baseHash, run, reordered, "docker", "guest:v1", volumeMounts, sandboxstore.CreateSandboxOptions{})
+	same, err := stickyProjectRunConfigHash(baseHash, run, reordered, stickySandboxSpec{
+		Driver:       "docker",
+		GuestImage:   "guest:v1",
+		VolumeMounts: volumeMounts,
+		Jupyter:      sandboxstore.CreateSandboxOptions{},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash reordered returned error: %v", err)
 	}
 	if same != first {
 		t.Fatalf("capset ordering changed effective hash: got %q want %q", same, first)
 	}
-	retain, err := stickyProjectRunConfigHash(baseHash, run, prepared, "docker", "guest:v1", volumeMounts, sandboxstore.CreateSandboxOptions{StoppedRuntimePolicy: domain.StoppedRuntimePolicyRetain})
+	retain, err := stickyProjectRunConfigHash(baseHash, run, prepared, stickySandboxSpec{
+		Driver:       "docker",
+		GuestImage:   "guest:v1",
+		VolumeMounts: volumeMounts,
+		Jupyter:      sandboxstore.CreateSandboxOptions{StoppedRuntimePolicy: domain.StoppedRuntimePolicyRetain},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash explicit retain returned error: %v", err)
 	}
 	if retain == first {
 		t.Fatal("explicit retain did not change default remove sticky hash")
 	}
-	remove, err := stickyProjectRunConfigHash(baseHash, run, prepared, "docker", "guest:v1", volumeMounts, sandboxstore.CreateSandboxOptions{StoppedRuntimePolicy: domain.StoppedRuntimePolicyRemove})
+	remove, err := stickyProjectRunConfigHash(baseHash, run, prepared, stickySandboxSpec{
+		Driver:       "docker",
+		GuestImage:   "guest:v1",
+		VolumeMounts: volumeMounts,
+		Jupyter:      sandboxstore.CreateSandboxOptions{StoppedRuntimePolicy: domain.StoppedRuntimePolicyRemove},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash remove returned error: %v", err)
 	}
 	if remove != first {
 		t.Fatalf("explicit remove changed default sticky hash: got %q want %q", remove, first)
 	}
-	jupyterFirst, err := stickyProjectRunConfigHash(baseHash, run, prepared, "docker", "guest:v1", volumeMounts, sandboxstore.CreateSandboxOptions{VolumeMounts: volumeMounts})
+	jupyterFirst, err := stickyProjectRunConfigHash(baseHash, run, prepared, stickySandboxSpec{
+		Driver:       "docker",
+		GuestImage:   "guest:v1",
+		VolumeMounts: volumeMounts,
+		Jupyter:      sandboxstore.CreateSandboxOptions{VolumeMounts: volumeMounts},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash with Jupyter mounts returned error: %v", err)
 	}
 	reorderedMounts := []domain.SandboxVolumeMount{volumeMounts[1], volumeMounts[0]}
-	same, err = stickyProjectRunConfigHash(baseHash, run, prepared, "docker", "guest:v1", reorderedMounts, sandboxstore.CreateSandboxOptions{VolumeMounts: reorderedMounts})
+	same, err = stickyProjectRunConfigHash(baseHash, run, prepared, stickySandboxSpec{
+		Driver:       "docker",
+		GuestImage:   "guest:v1",
+		VolumeMounts: reorderedMounts,
+		Jupyter:      sandboxstore.CreateSandboxOptions{VolumeMounts: reorderedMounts},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash reordered mounts returned error: %v", err)
 	}
@@ -89,7 +119,12 @@ func TestStickyProjectRunConfigHashTracksEffectiveSandboxSpec(t *testing.T) {
 
 	changed := prepared
 	changed.EnvItems = []domain.SandboxEnvVar{{Name: "BUG_VALUE", Value: "B"}}
-	second, err := stickyProjectRunConfigHash(baseHash, run, changed, "docker", "guest:v1", volumeMounts, sandboxstore.CreateSandboxOptions{})
+	second, err := stickyProjectRunConfigHash(baseHash, run, changed, stickySandboxSpec{
+		Driver:       "docker",
+		GuestImage:   "guest:v1",
+		VolumeMounts: volumeMounts,
+		Jupyter:      sandboxstore.CreateSandboxOptions{},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash changed returned error: %v", err)
 	}
@@ -107,7 +142,12 @@ func TestStickyProjectRunConfigHashTracksEffectiveSandboxSpec(t *testing.T) {
 		"volume source": {driver: "docker", guestImage: "guest:v1", volumeMounts: []domain.SandboxVolumeMount{{ID: "volume-v2", Type: "volume", Target: "/workspace/data", HostPath: "/host/remapped"}}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			got, err := stickyProjectRunConfigHash(baseHash, run, prepared, args.driver, args.guestImage, args.volumeMounts, sandboxstore.CreateSandboxOptions{})
+			got, err := stickyProjectRunConfigHash(baseHash, run, prepared, stickySandboxSpec{
+				Driver:       args.driver,
+				GuestImage:   args.guestImage,
+				VolumeMounts: args.volumeMounts,
+				Jupyter:      sandboxstore.CreateSandboxOptions{},
+			})
 			if err != nil {
 				t.Fatalf("stickyProjectRunConfigHash returned error: %v", err)
 			}
@@ -139,7 +179,11 @@ func TestResolveStickySchedulerBindingInvalidatesBeforeRuntimeStop(t *testing.T)
 		return nil
 	}
 
-	gotSandboxID, previous, _, err := fixture.controller.resolveStickySchedulerBinding(fixture.ctx, fixture.configDB, "scheduler-1", "trigger-1", "sha256:new")
+	gotSandboxID, previous, _, err := fixture.controller.resolveStickySchedulerBinding(fixture.ctx, fixture.configDB, stickyBindingKey{
+		SchedulerID: "scheduler-1",
+		TriggerID:   "trigger-1",
+		ConfigHash:  "sha256:new",
+	})
 	if err != nil {
 		t.Fatalf("resolveStickySchedulerBinding returned error: %v", err)
 	}
@@ -165,7 +209,11 @@ func TestResolveStickySchedulerBindingAdoptsLegacyConfigHashWithoutStoppingSandb
 		"scheduler-1/trigger-1": {SchedulerID: "scheduler-1", TriggerID: "trigger-1", SandboxID: sandbox.Summary.ID},
 	}
 
-	gotSandboxID, binding, warnings, err := fixture.controller.resolveStickySchedulerBinding(fixture.ctx, fixture.configDB, "scheduler-1", "trigger-1", "sha256:current")
+	gotSandboxID, binding, warnings, err := fixture.controller.resolveStickySchedulerBinding(fixture.ctx, fixture.configDB, stickyBindingKey{
+		SchedulerID: "scheduler-1",
+		TriggerID:   "trigger-1",
+		ConfigHash:  "sha256:current",
+	})
 	if err != nil {
 		t.Fatalf("resolveStickySchedulerBinding returned error: %v", err)
 	}
@@ -196,7 +244,11 @@ func TestResolveStickySchedulerBindingDoesNotReuseRetiringLegacyBinding(t *testi
 	}, "sha256:new")
 	fixture.configDB.bindings = map[string]domain.SchedulerBinding{"scheduler-1/trigger-1": retiring}
 
-	gotSandboxID, previous, _, err := fixture.controller.resolveStickySchedulerBinding(fixture.ctx, fixture.configDB, "scheduler-1", "trigger-1", "")
+	gotSandboxID, previous, _, err := fixture.controller.resolveStickySchedulerBinding(fixture.ctx, fixture.configDB, stickyBindingKey{
+		SchedulerID: "scheduler-1",
+		TriggerID:   "trigger-1",
+		ConfigHash:  "",
+	})
 	if err != nil {
 		t.Fatalf("resolveStickySchedulerBinding returned error: %v", err)
 	}
@@ -216,7 +268,11 @@ func TestEnsureProjectRunSandboxConcurrentStickyClaimReusesWinner(t *testing.T) 
 	}
 	prepared := Preparation{}
 	baseHash := "sha256:scheduler"
-	configHash, err := stickyProjectRunConfigHash(baseHash, run, prepared, "docker", "guest:latest", nil, sandboxstore.CreateSandboxOptions{})
+	configHash, err := stickyProjectRunConfigHash(baseHash, run, prepared, stickySandboxSpec{
+		Driver:     "docker",
+		GuestImage: "guest:latest",
+		Jupyter:    sandboxstore.CreateSandboxOptions{},
+	})
 	if err != nil {
 		t.Fatalf("stickyProjectRunConfigHash returned error: %v", err)
 	}

--- a/pkg/runs/workspace.go
+++ b/pkg/runs/workspace.go
@@ -19,19 +19,26 @@ type projectRunWorkspaceResolver struct {
 	controller *Controller
 }
 
-func (r projectRunWorkspaceResolver) ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, projectWorkspace, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, *domain.SandboxWorkspace, error) {
-	workspace, err := r.controller.prepareProjectRunWorkspace(ctx, run, project, projectWorkspace, agentWorkspace)
+// WorkspaceRequest is the pair of candidate workspace specs a run can resolve
+// from: the project-level default and an agent-level override.
+type WorkspaceRequest struct {
+	Project *compose.WorkspaceSpec
+	Agent   *compose.WorkspaceSpec
+}
+
+func (r projectRunWorkspaceResolver) ResolveProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, req WorkspaceRequest) (*domain.WorkspaceConfig, *domain.SandboxWorkspace, error) {
+	workspace, err := r.controller.prepareProjectRunWorkspace(ctx, run, project, req)
 	if err != nil || workspace == nil {
 		return workspace, nil, err
 	}
 	return workspace, toSandboxWorkspaceSnapshot(*workspace), nil
 }
 
-func (c *Controller) prepareProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, projectWorkspace, agentWorkspace *compose.WorkspaceSpec) (*domain.WorkspaceConfig, error) {
+func (c *Controller) prepareProjectRunWorkspace(ctx context.Context, run domain.ProjectRunRecord, project domain.ProjectRecord, req WorkspaceRequest) (*domain.WorkspaceConfig, error) {
 	_ = ctx
-	workspace := projectWorkspace
-	if agentWorkspace != nil {
-		workspace = agentWorkspace
+	workspace := req.Project
+	if req.Agent != nil {
+		workspace = req.Agent
 	}
 	if workspace == nil {
 		return nil, nil

--- a/pkg/storage/configstore/project_run_completion.go
+++ b/pkg/storage/configstore/project_run_completion.go
@@ -82,7 +82,8 @@ func (s *projectStore) ListDueProjectRunCompletions(ctx context.Context, now tim
 	return items, rows.Err()
 }
 
-func (s *projectStore) RecordProjectRunCompletionFailure(ctx context.Context, runID, message string, attempt int, next time.Time) error {
+func (s *projectStore) RecordProjectRunCompletionFailure(ctx context.Context, failure domain.ProjectRunCompletionFailure) error {
+	runID, message, attempt, next := failure.RunID, failure.Message, failure.Attempt, failure.NextAttemptAt
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin record project run completion failure: %w", err)


### PR DESCRIPTION
## Summary
- `writeCapabilityGuide`/`recordCapabilityGuideWarning` (private, `pkg/runs` only) bundled into `capabilityGuideDeps`. Their original `nolint` reason claimed "9 call sites across 2 packages (pkg/agentcompose, pkg/runs)" — verified that was a same-name collision with an unrelated, separately-defined private function of the same name in `pkg/agentcompose/adapters/{scheduler_session_runner,session_rpc_bridge}.go` (different signature, different type), not this function's real call graph. Real count: 3 + 5 call sites, all in `pkg/runs`.
- `NewCompletionManager` (exported, called from `pkg/agentcompose/app` in 2 files) bundled into `CompletionManagerDeps`; both external call sites are included in this commit so it stays self-contained and buildable in isolation.
- Three test helpers (`upsertProjectWorkspaceAgent`, `assertProjectWorkspaceManifestFile`, `saveProjectWorkspaceRevision`) bundled into small per-file spec structs.
- **Deliberately not touched**: the started-run execution call chain (`executeStartedProjectRun` → `executeProjectRunCommand`/`runPromptInteraction`/`runCommandInteraction`/`executeStartedProjectRunAttach` and friends — ~7 private `Controller` methods sharing `ctx`/`coordinator`/`run`/`sandbox`/`req`). All private (zero external risk) but genuinely needs a coordinated redesign of the whole chain rather than a param bundle — tracked as follow-up, not done here. Also not touched: `prompt_attach_facade.go`'s `Ensure*FacadeEnv` (mirrors the already-deferred `pkg/llms` facade family) and `sandbox_preparation.go`'s `ensureProjectRunSandbox` (a single cohesive sticky-binding CAS/retry state machine — funlen violation, but splitting it needs dedicated review of the retry/lock/CAS correctness, not a lint-driven restructure).
- Audited the package's exported surface (30 funcs + 50 types) for dead code (`ac-find-simplifications` pass) — found none.
- Same as `pkg/driver`/`pkg/schedulers`/`pkg/sandboxes`: `.golangci.yml` isn't included since other packages aren't done yet.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/runs/... ./pkg/agentcompose/app/...`
- [x] `go vet ./pkg/runs/...`
- [x] Verified via `git grep <commit-sha>` that `NewCompletionManager`/`CompletionManagerDeps` have zero references outside `pkg/runs` + the 2 `pkg/agentcompose/app` files included here, and that `writeCapabilityGuide`/`recordCapabilityGuideWarning` in `pkg/agentcompose/adapters` are confirmed-separate functions, not the same symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)