### PR TITLE
refactor(llms): bundle multi-argument params into structs; drop dead code

### DIFF
--- a/pkg/llms/agent_model_resolution.go
+++ b/pkg/llms/agent_model_resolution.go
@@ -98,10 +98,10 @@ func ResolveAgentModel(ctx context.Context, config *appconfig.Config, store Agen
 		return resolution, nil
 	}
 	if hasConfiguredProviderForFamily(providers, providerFamily) {
-		return selectConfiguredDefaultModel(ctx, store, providers, models, providerFamily)
+		return selectConfiguredDefaultModel(ctx, defaultModelSelection{Store: store, Providers: providers, Models: models, ProviderFamily: providerFamily})
 	}
 
-	resolution, ok, err = selectStoredDefaultModel(ctx, store, providers, models, providerFamily)
+	resolution, ok, err = selectStoredDefaultModel(ctx, defaultModelSelection{Store: store, Providers: providers, Models: models, ProviderFamily: providerFamily})
 	if err != nil {
 		return AgentModelResolution{}, err
 	}
@@ -159,8 +159,17 @@ func hasConfiguredProviderForFamily(providers []Provider, providerFamily string)
 	return false
 }
 
-func selectConfiguredDefaultModel(ctx context.Context, store AgentModelResolutionStore, providers []Provider, models []Model, providerFamily string) (AgentModelResolution, error) {
-	resolution, ok, err := selectStoredDefaultModel(ctx, store, providers, models, providerFamily)
+// defaultModelSelection groups the shared inputs for selectConfiguredDefaultModel
+// and selectStoredDefaultModel.
+type defaultModelSelection struct {
+	Store          AgentModelResolutionStore
+	Providers      []Provider
+	Models         []Model
+	ProviderFamily string
+}
+
+func selectConfiguredDefaultModel(ctx context.Context, sel defaultModelSelection) (AgentModelResolution, error) {
+	resolution, ok, err := selectStoredDefaultModel(ctx, sel)
 	if err != nil {
 		return AgentModelResolution{}, err
 	}
@@ -189,11 +198,12 @@ func selectCatalogDefaultModel(ctx context.Context, store AgentModelResolutionSt
 	return AgentModelResolution{}, false, nil
 }
 
-func selectStoredDefaultModel(ctx context.Context, store AgentModelResolutionStore, providers []Provider, models []Model, providerFamily string) (AgentModelResolution, bool, error) {
+func selectStoredDefaultModel(ctx context.Context, sel defaultModelSelection) (AgentModelResolution, bool, error) {
+	store, providers, models, providerFamily := sel.Store, sel.Providers, sel.Models, sel.ProviderFamily
 	if store == nil || len(providers) == 0 || len(models) == 0 {
 		return AgentModelResolution{}, false, nil
 	}
-	model, _, _, ok, err := SelectModelAndProvider(ctx, store, models, providers, "", providerFamily, "")
+	model, _, _, ok, err := SelectModelAndProvider(ctx, store, ModelProviderSelection{Models: models, Providers: providers, ProviderFamily: providerFamily})
 	if err != nil {
 		return AgentModelResolution{}, false, fmt.Errorf("select default agent model: %w", err)
 	}

--- a/pkg/llms/client.go
+++ b/pkg/llms/client.go
@@ -146,17 +146,30 @@ func Generate(ctx context.Context, client *http.Client, req GenerateRequest) (Ge
 	}
 	switch NormalizeWireAPI(req.Protocol) {
 	case APIProtocolChatCompletions:
-		return generateChatCompletions(ctx, client, endpoint, prompt, model, req.OutputSchemaJSON, req.Headers, req.MaxOutputTokens)
+		return generateChatCompletions(ctx, generateCallParams{Client: client, Endpoint: endpoint, Prompt: prompt, Model: model, OutputSchemaJSON: req.OutputSchemaJSON, Headers: req.Headers, MaxOutputTokens: req.MaxOutputTokens})
 	case APIProtocolResponses:
-		return generateResponses(ctx, client, endpoint, prompt, model, req.OutputSchemaJSON, req.Headers, req.MaxOutputTokens)
+		return generateResponses(ctx, generateCallParams{Client: client, Endpoint: endpoint, Prompt: prompt, Model: model, OutputSchemaJSON: req.OutputSchemaJSON, Headers: req.Headers, MaxOutputTokens: req.MaxOutputTokens})
 	case APIProtocolMessages:
-		return generateMessages(ctx, client, endpoint, prompt, model, req.OutputSchemaJSON, req.Headers, req.MaxOutputTokens)
+		return generateMessages(ctx, generateCallParams{Client: client, Endpoint: endpoint, Prompt: prompt, Model: model, OutputSchemaJSON: req.OutputSchemaJSON, Headers: req.Headers, MaxOutputTokens: req.MaxOutputTokens})
 	default:
 		return GenerateResult{}, fmt.Errorf("unsupported llm api protocol %q", NormalizeWireAPI(req.Protocol))
 	}
 }
 
-func generateMessages(ctx context.Context, client *http.Client, endpoint, prompt, model, outputSchemaJSON string, headers http.Header, maxOutputTokens int) (GenerateResult, error) {
+// generateCallParams groups the wire-call inputs shared by generateMessages,
+// generateResponses, and generateChatCompletions.
+type generateCallParams struct {
+	Client           *http.Client
+	Endpoint         string
+	Prompt           string
+	Model            string
+	OutputSchemaJSON string
+	Headers          http.Header
+	MaxOutputTokens  int
+}
+
+func generateMessages(ctx context.Context, p generateCallParams) (GenerateResult, error) {
+	client, endpoint, prompt, model, outputSchemaJSON, headers, maxOutputTokens := p.Client, p.Endpoint, p.Prompt, p.Model, p.OutputSchemaJSON, p.Headers, p.MaxOutputTokens
 	if maxOutputTokens <= 0 {
 		maxOutputTokens = 4096
 	}
@@ -215,7 +228,8 @@ func generateMessages(ctx context.Context, client *http.Client, endpoint, prompt
 	return GenerateResult{Text: text, Model: firstNonEmpty(strings.TrimSpace(parsed.Model), model), ResponseID: strings.TrimSpace(parsed.ID), FinishReason: strings.TrimSpace(parsed.StopReason)}, nil
 }
 
-func generateResponses(ctx context.Context, client *http.Client, endpoint, prompt, model, outputSchemaJSON string, headers http.Header, maxOutputTokens int) (GenerateResult, error) {
+func generateResponses(ctx context.Context, p generateCallParams) (GenerateResult, error) {
+	client, endpoint, prompt, model, outputSchemaJSON, headers, maxOutputTokens := p.Client, p.Endpoint, p.Prompt, p.Model, p.OutputSchemaJSON, p.Headers, p.MaxOutputTokens
 	request := apiRequest{Model: model, Input: prompt, MaxOutputTokens: maxOutputTokens}
 	if schema := strings.TrimSpace(outputSchemaJSON); schema != "" {
 		if !json.Valid([]byte(schema)) {
@@ -277,7 +291,8 @@ func generateResponses(ctx context.Context, client *http.Client, endpoint, promp
 
 // generateChatCompletions calls an OpenAI-compatible Chat Completions backend
 // for unary prompt-to-response text generation.
-func generateChatCompletions(ctx context.Context, client *http.Client, endpoint, prompt, model, outputSchemaJSON string, headers http.Header, maxOutputTokens int) (GenerateResult, error) {
+func generateChatCompletions(ctx context.Context, p generateCallParams) (GenerateResult, error) {
+	client, endpoint, prompt, model, outputSchemaJSON, headers, maxOutputTokens := p.Client, p.Endpoint, p.Prompt, p.Model, p.OutputSchemaJSON, p.Headers, p.MaxOutputTokens
 	messages := []chatCompletionsMessage{{Role: "user", Content: prompt}}
 	request := chatCompletionsRequest{Model: model, Messages: messages, MaxCompletionTokens: maxOutputTokens}
 	if schema := strings.TrimSpace(outputSchemaJSON); schema != "" {

--- a/pkg/llms/codex_facade.go
+++ b/pkg/llms/codex_facade.go
@@ -47,7 +47,7 @@ func EnsureCodexFacadeConfig(ctx context.Context, config *appconfig.Config, stor
 		return nil, err
 	}
 	openAIBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/openai/v1"
-	if err := WriteCodexRuntimeConfig(sandbox, target.Model.Name, openAIBaseURL, APIProtocolResponses, CodexRuntimePolicyFromConfig(config)); err != nil {
+	if err := WriteCodexRuntimeConfig(sandbox, CodexRuntimeConfig{Model: target.Model.Name, BaseURL: openAIBaseURL, WireAPI: APIProtocolResponses, Policy: CodexRuntimePolicyFromConfig(config)}); err != nil {
 		return nil, err
 	}
 	return map[string]string{

--- a/pkg/llms/config_helpers_coverage_test.go
+++ b/pkg/llms/config_helpers_coverage_test.go
@@ -18,10 +18,10 @@ func TestRuntimeConfigAndEnvHelperWorkflows(t *testing.T) {
 	root := t.TempDir()
 	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: filepath.Join(root, "workspace")}}
 	policy := CodexRuntimePolicyFromConfig(nil)
-	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolChatCompletions, policy); err == nil {
+	if err := WriteCodexRuntimeConfig(session, CodexRuntimeConfig{Model: "gpt", BaseURL: "http://runtime/openai/v1/", WireAPI: APIProtocolChatCompletions, Policy: policy}); err == nil {
 		t.Fatal("WriteCodexRuntimeConfig accepted unsupported Chat Completions")
 	}
-	if err := WriteCodexRuntimeConfig(session, "gpt", "http://runtime/openai/v1/", APIProtocolResponses, policy); err != nil {
+	if err := WriteCodexRuntimeConfig(session, CodexRuntimeConfig{Model: "gpt", BaseURL: "http://runtime/openai/v1/", WireAPI: APIProtocolResponses, Policy: policy}); err != nil {
 		t.Fatalf("WriteCodexRuntimeConfig returned error: %v", err)
 	}
 	codexConfig, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(session), ".codex", "config.toml"))
@@ -38,7 +38,7 @@ func TestRuntimeConfigAndEnvHelperWorkflows(t *testing.T) {
 	if err != nil || !strings.Contains(string(openCodeConfig), "@ai-sdk/anthropic") || !strings.Contains(string(openCodeConfig), "AGENT_COMPOSE_SANDBOX_TOKEN") {
 		t.Fatalf("opencode config=%q err=%v", string(openCodeConfig), err)
 	}
-	if err := WriteCodexRuntimeConfig(nil, "gpt", "http://runtime", "", CodexRuntimePolicyFromConfig(nil)); err != nil {
+	if err := WriteCodexRuntimeConfig(nil, CodexRuntimeConfig{Model: "gpt", BaseURL: "http://runtime", Policy: CodexRuntimePolicyFromConfig(nil)}); err != nil {
 		t.Fatalf("nil session codex config returned error: %v", err)
 	}
 	mcps := map[string]compose.NormalizedMCPServerSpec{
@@ -117,9 +117,6 @@ func TestRuntimeConfigAndEnvHelperWorkflows(t *testing.T) {
 	}
 	if env := RuntimeEnvMap([]domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "secret"}, {Name: "VISIBLE", Value: "1"}}); env["VISIBLE"] != "1" || env["OPENAI_API_KEY"] != "" {
 		t.Fatalf("runtime env = %#v", env)
-	}
-	if env := ManagedRuntimeEnvMap([]domain.SandboxEnvVar{{Name: "OPENAI_API_KEY", Value: "secret"}}); env["OPENAI_API_KEY"] != "secret" {
-		t.Fatalf("managed env = %#v", env)
 	}
 	if provider, model, err := SplitOpenCodeModel(" custom/gpt "); err != nil || provider != "custom" || model != "gpt" {
 		t.Fatalf("SplitOpenCodeModel provider=%q model=%q err=%v", provider, model, err)
@@ -278,11 +275,11 @@ func TestClientConfigAndSelectionWorkflows(t *testing.T) {
 
 	models := []Model{{ID: "m1", Name: "gpt-1"}, {ID: "m2", Name: "gpt-2", DefaultModel: true}}
 	providers := []Provider{{ID: "p2", ProviderType: ProviderFamilyOpenAI, Scope: ProviderScopeEnvDefault, Weight: 10}, {ID: "p1", ProviderType: ProviderFamilyOpenAI, Weight: 1}}
-	selected, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, llmCoverageWireStore{ok: true, wireAPI: APIProtocolResponses}, models, providers, "", ProviderFamilyOpenAI, "")
+	selected, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, llmCoverageWireStore{ok: true, wireAPI: APIProtocolResponses}, ModelProviderSelection{Models: models, Providers: providers, ProviderFamily: ProviderFamilyOpenAI})
 	if err != nil || !ok || selected.ID != "m2" || provider.ID != "p2" || wireAPI != APIProtocolResponses {
 		t.Fatalf("selected=%#v provider=%#v wire=%q ok=%v err=%v", selected, provider, wireAPI, ok, err)
 	}
-	if _, _, _, ok, err := SelectModelAndProvider(ctx, llmCoverageWireStore{}, models, providers, "missing", "", ""); err != nil || ok {
+	if _, _, _, ok, err := SelectModelAndProvider(ctx, llmCoverageWireStore{}, ModelProviderSelection{Models: models, Providers: providers, RequestedModel: "missing"}); err != nil || ok {
 		t.Fatalf("expected missing model ok=false err=%v", err)
 	}
 	if priority := ProviderSelectionPriority(ProviderScopeSessionEnv); priority != 0 {

--- a/pkg/llms/custom_openai_facade_target.go
+++ b/pkg/llms/custom_openai_facade_target.go
@@ -9,7 +9,18 @@ import (
 	domain "agent-compose/pkg/model"
 )
 
-func resolveCustomOpenAIFacadeTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sandbox *domain.Sandbox, providerID, model string) (ResolvedTarget, error) {
+// customOpenAIFacadeTargetRequest groups resolveCustomOpenAIFacadeTarget's
+// inputs.
+type customOpenAIFacadeTargetRequest struct {
+	Config     *appconfig.Config
+	Store      LLMResolverStore
+	Sandbox    *domain.Sandbox
+	ProviderID string
+	Model      string
+}
+
+func resolveCustomOpenAIFacadeTarget(ctx context.Context, req customOpenAIFacadeTargetRequest) (ResolvedTarget, error) {
+	config, store, sandbox, providerID, model := req.Config, req.Store, req.Sandbox, req.ProviderID, req.Model
 	envItems, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyOpenAI)
 	if err != nil {
 		return ResolvedTarget{}, err
@@ -19,7 +30,9 @@ func resolveCustomOpenAIFacadeTarget(ctx context.Context, config *appconfig.Conf
 		sandboxID = sandbox.Summary.ID
 	}
 	if sandboxID != "" && HasOpenAIEnvProviderInput(envItems) {
-		sessionProviderID, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sandboxID, model, envItems)
+		sessionProviderID, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, store, SessionEnvProviderQuery{
+			Config: config, SessionID: sandboxID, RequestedModel: model, EnvItems: envItems,
+		})
 		if err != nil {
 			return ResolvedTarget{}, err
 		}

--- a/pkg/llms/custom_openai_facade_target_test.go
+++ b/pkg/llms/custom_openai_facade_target_test.go
@@ -21,7 +21,13 @@ func TestResolveCustomOpenAIFacadeTargetFailsLocallyInsteadOfBorrowingDaemonDefa
 	}
 	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}}
 
-	if _, err := resolveCustomOpenAIFacadeTarget(ctx, config, store, sandbox, "unavailable-catalog-provider", "some-model"); err == nil {
+	if _, err := resolveCustomOpenAIFacadeTarget(ctx, customOpenAIFacadeTargetRequest{
+		Config:     config,
+		Store:      store,
+		Sandbox:    sandbox,
+		ProviderID: "unavailable-catalog-provider",
+		Model:      "some-model",
+	}); err == nil {
 		t.Fatal("resolveCustomOpenAIFacadeTarget returned nil error for an unknown/unavailable provider")
 	}
 	if len(store.providers) != 0 {
@@ -46,7 +52,13 @@ func TestResolveCustomOpenAIFacadeTargetUsesEnabledCatalogProvider(t *testing.T)
 	store.models = []Model{{ID: "deepseek-v4-flash", Name: "deepseek-v4-flash", Enabled: true, Scope: ProviderScopeSystem}}
 	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}}
 
-	target, err := resolveCustomOpenAIFacadeTarget(ctx, &appconfig.Config{}, store, sandbox, "baizhi", "deepseek-v4-flash")
+	target, err := resolveCustomOpenAIFacadeTarget(ctx, customOpenAIFacadeTargetRequest{
+		Config:     &appconfig.Config{},
+		Store:      store,
+		Sandbox:    sandbox,
+		ProviderID: "baizhi",
+		Model:      "deepseek-v4-flash",
+	})
 	if err != nil {
 		t.Fatalf("resolveCustomOpenAIFacadeTarget returned error: %v", err)
 	}

--- a/pkg/llms/dsh_facade.go
+++ b/pkg/llms/dsh_facade.go
@@ -27,14 +27,27 @@ func SplitDshModel(value string) (string, string, error) {
 	return providerID, model, nil
 }
 
+// DshFacadeConfigRequest groups EnsureDshFacadeConfig's inputs: the
+// environment to resolve against (Config/Store/Sandbox) plus the specific
+// call's provider/model selection and token attribution.
+type DshFacadeConfigRequest struct {
+	Config  *appconfig.Config
+	Store   DshFacadeStore
+	Sandbox *domain.Sandbox
+	Model   string
+	Source  string
+	RunID   string
+}
+
 // EnsureDshFacadeConfig resolves DSH's explicit provider/model selection and
 // returns run-scoped facade credentials. Unlike Pi, DSH's llm-deepseek
 // adapter only ever speaks chat completions on the wire (its own upstream
 // protocol is irrelevant: the facade bridges), so the issued token's WireAPI
 // is unconditionally APIProtocolChatCompletions and the guest is always
 // routed to /llm/openai/v1 (see docs/design/dsh_agent_provider_design.md §4.1).
-func EnsureDshFacadeConfig(ctx context.Context, config *appconfig.Config, store DshFacadeStore, sandbox *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	providerID, modelName, err := SplitDshModel(model)
+func EnsureDshFacadeConfig(ctx context.Context, req DshFacadeConfigRequest) (map[string]string, error) {
+	config, store, sandbox := req.Config, req.Store, req.Sandbox
+	providerID, modelName, err := SplitDshModel(req.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -43,12 +56,12 @@ func EnsureDshFacadeConfig(ctx context.Context, config *appconfig.Config, store 
 		return nil, nil
 	}
 
-	target, err := resolveDshFacadeTarget(ctx, config, store, sandbox, providerID, modelName)
+	target, err := resolveDshFacadeTarget(ctx, dshFacadeTargetInput{Config: config, Store: store, Sandbox: sandbox, ProviderID: providerID, Model: modelName})
 	if err != nil {
 		return nil, err
 	}
 	facadeBaseURL := strings.TrimRight(baseURL, "/") + "/api/runtime/sandboxes/" + sandbox.Summary.ID + "/llm/openai/v1"
-	tokenValue, token, err := NewFacadeToken(sandbox.Summary.ID, target.Model.Name, target.Provider.ID, APIProtocolChatCompletions, source, runID)
+	tokenValue, token, err := NewFacadeToken(sandbox.Summary.ID, target.Model.Name, target.Provider.ID, APIProtocolChatCompletions, req.Source, req.RunID)
 	if err != nil {
 		return nil, err
 	}
@@ -66,18 +79,28 @@ func EnsureDshFacadeConfig(ctx context.Context, config *appconfig.Config, store 
 	}, nil
 }
 
+// dshFacadeTargetInput groups resolveDshFacadeTarget's inputs.
+type dshFacadeTargetInput struct {
+	Config     *appconfig.Config
+	Store      DshFacadeStore
+	Sandbox    *domain.Sandbox
+	ProviderID string
+	Model      string
+}
+
 // resolveDshFacadeTarget mirrors resolvePiFacadeTarget's branch structure
 // (configured provider id -> family -> custom OpenAI), but DSH has no
 // Anthropic-family route: llm-deepseek always speaks chat completions, so
 // there is no Anthropic branch to mirror.
-func resolveDshFacadeTarget(ctx context.Context, config *appconfig.Config, store DshFacadeStore, sandbox *domain.Sandbox, providerID, model string) (ResolvedTarget, error) {
+func resolveDshFacadeTarget(ctx context.Context, in dshFacadeTargetInput) (ResolvedTarget, error) {
+	config, store, sandbox, providerID, model := in.Config, in.Store, in.Sandbox, in.ProviderID, in.Model
 	sandboxID := sandbox.Summary.ID
 	envItems, err := SandboxProviderEnvItems(ctx, store, sandbox, "")
 	if err != nil {
 		return ResolvedTarget{}, err
 	}
 	if HasSessionEnvProviderInput(envItems) {
-		providerID, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sandboxID, model, envItems)
+		providerID, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, store, SessionEnvProviderQuery{Config: config, SessionID: sandboxID, RequestedModel: model, EnvItems: envItems})
 		if err != nil {
 			return ResolvedTarget{}, err
 		}
@@ -90,6 +113,12 @@ func resolveDshFacadeTarget(ctx context.Context, config *appconfig.Config, store
 	case ProviderFamilyOpenAI, ProviderIDDefaultOpenAI:
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, ProviderFamilyOpenAI, model, "", envItems)
 	default:
-		return resolveCustomOpenAIFacadeTarget(ctx, config, store, sandbox, providerID, model)
+		return resolveCustomOpenAIFacadeTarget(ctx, customOpenAIFacadeTargetRequest{
+			Config:     config,
+			Store:      store,
+			Sandbox:    sandbox,
+			ProviderID: providerID,
+			Model:      model,
+		})
 	}
 }

--- a/pkg/llms/dsh_facade_test.go
+++ b/pkg/llms/dsh_facade_test.go
@@ -32,13 +32,12 @@ func TestEnsureDshFacadeConfigBindsConfiguredProviderToken(t *testing.T) {
 	store.models = []Model{{ID: "model-id", Name: "org/deepseek-v4", Enabled: true}}
 	store.wire["deepseek-catalog\x00model-id"] = APIProtocolResponses
 
-	env, err := EnsureDshFacadeConfig(
-		context.Background(),
-		&appconfig.Config{RuntimeBaseURL: "http://runtime.test/base/"},
-		store,
-		&domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}},
-		"deepseek-catalog/org/deepseek-v4", "agent", "run-1",
-	)
+	env, err := EnsureDshFacadeConfig(context.Background(), DshFacadeConfigRequest{
+		Config:  &appconfig.Config{RuntimeBaseURL: "http://runtime.test/base/"},
+		Store:   store,
+		Sandbox: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}},
+		Model:   "deepseek-catalog/org/deepseek-v4", Source: "agent", RunID: "run-1",
+	})
 	if err != nil {
 		t.Fatalf("EnsureDshFacadeConfig returned error: %v", err)
 	}
@@ -72,13 +71,12 @@ func TestEnsureDshFacadeConfigUsesOpenAIFamilyAndPropagatesSaveFailure(t *testin
 	store.wire[ProviderIDDefaultOpenAI+"\x00deepseek-v4"] = APIProtocolChatCompletions
 	store.saveErr = errors.New("save token failed")
 
-	_, err := EnsureDshFacadeConfig(
-		context.Background(),
-		&appconfig.Config{RuntimeBaseURL: "http://runtime.test"},
-		store,
-		&domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}},
-		"openai/deepseek-v4", "scheduler", "run-2",
-	)
+	_, err := EnsureDshFacadeConfig(context.Background(), DshFacadeConfigRequest{
+		Config:  &appconfig.Config{RuntimeBaseURL: "http://runtime.test"},
+		Store:   store,
+		Sandbox: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}},
+		Model:   "openai/deepseek-v4", Source: "scheduler", RunID: "run-2",
+	})
 	if !errors.Is(err, store.saveErr) {
 		t.Fatalf("EnsureDshFacadeConfig error = %v", err)
 	}
@@ -96,13 +94,12 @@ func TestEnsureDshFacadeConfigUsesSessionEnvProvider(t *testing.T) {
 		},
 	}
 
-	env, err := EnsureDshFacadeConfig(
-		context.Background(),
-		&appconfig.Config{RuntimeBaseURL: "http://runtime.test"},
-		store,
-		sandbox,
-		"ignored-provider/org/deepseek-v4", "agent", "run-env",
-	)
+	env, err := EnsureDshFacadeConfig(context.Background(), DshFacadeConfigRequest{
+		Config:  &appconfig.Config{RuntimeBaseURL: "http://runtime.test"},
+		Store:   store,
+		Sandbox: sandbox,
+		Model:   "ignored-provider/org/deepseek-v4", Source: "agent", RunID: "run-env",
+	})
 	if err != nil {
 		t.Fatalf("EnsureDshFacadeConfig returned error: %v", err)
 	}
@@ -120,13 +117,12 @@ func TestEnsureDshFacadeConfigUsesSessionEnvProvider(t *testing.T) {
 
 func TestEnsureDshFacadeConfigRejectsUnknownCustomProvider(t *testing.T) {
 	isolateLLMEnv(t)
-	_, err := EnsureDshFacadeConfig(
-		context.Background(),
-		&appconfig.Config{RuntimeBaseURL: "http://runtime.test"},
-		newDshFacadeTestStore(),
-		&domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}},
-		"unconfigured/deepseek-v4", "agent", "run-1",
-	)
+	_, err := EnsureDshFacadeConfig(context.Background(), DshFacadeConfigRequest{
+		Config:  &appconfig.Config{RuntimeBaseURL: "http://runtime.test"},
+		Store:   newDshFacadeTestStore(),
+		Sandbox: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1"}},
+		Model:   "unconfigured/deepseek-v4", Source: "agent", RunID: "run-1",
+	})
 	if err == nil || !strings.Contains(err.Error(), "is not configured") {
 		t.Fatalf("EnsureDshFacadeConfig error = %v", err)
 	}

--- a/pkg/llms/env.go
+++ b/pkg/llms/env.go
@@ -70,18 +70,3 @@ func RuntimeEnvMap(items []domain.SandboxEnvVar) map[string]string {
 	}
 	return env
 }
-
-func ManagedRuntimeEnvMap(items []domain.SandboxEnvVar) map[string]string {
-	env := make(map[string]string, len(items))
-	for _, item := range domain.NormalizeEnvItems(items) {
-		name := strings.TrimSpace(item.Name)
-		if name == "" {
-			continue
-		}
-		env[name] = item.Value
-	}
-	if len(env) == 0 {
-		return nil
-	}
-	return env
-}

--- a/pkg/llms/opencode_facade.go
+++ b/pkg/llms/opencode_facade.go
@@ -15,6 +15,21 @@ type OpenCodeFacadeStore interface {
 	SaveLLMFacadeToken(context.Context, FacadeToken) error
 }
 
+// openCodeFacadeCall groups the environment (Config/Store/Sandbox) and
+// per-call attribution (Source/RunID) shared by every OpenCode facade
+// resolution helper below, plus whichever of ProviderID/Model/Target the
+// specific step needs.
+type openCodeFacadeCall struct {
+	Config     *appconfig.Config
+	Store      OpenCodeFacadeStore
+	Sandbox    *domain.Sandbox
+	ProviderID string
+	Model      string
+	Target     ResolvedTarget
+	Source     string
+	RunID      string
+}
+
 // EnsureOpenCodeFacadeConfig resolves an OpenCode provider/model pair, writes
 // its guest runtime config, and returns the managed facade environment.
 func EnsureOpenCodeFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, model, source, runID string) (map[string]string, error) {
@@ -29,25 +44,27 @@ func EnsureOpenCodeFacadeConfig(ctx context.Context, config *appconfig.Config, s
 	if providerID == "opencode" {
 		return nil, nil
 	}
+	call := openCodeFacadeCall{Config: config, Store: store, Sandbox: sandbox, ProviderID: providerID, Model: modelName, Source: source, RunID: runID}
 	if HasEnabledLLMProviderID(ctx, store, providerID) {
-		return ensureOpenCodeConfiguredFacadeConfig(ctx, config, store, sandbox, providerID, modelName, source, runID)
+		return ensureOpenCodeConfiguredFacadeConfig(ctx, call)
 	}
 	switch providerID {
 	case ProviderFamilyAnthropic:
-		return ensureOpenCodeAnthropicFacadeConfig(ctx, config, store, sandbox, modelName, source, runID)
+		return ensureOpenCodeAnthropicFacadeConfig(ctx, call)
 	case ProviderFamilyOpenAI:
-		return ensureOpenCodeOpenAIFacadeConfig(ctx, config, store, sandbox, modelName, source, runID)
+		return ensureOpenCodeOpenAIFacadeConfig(ctx, call)
 	default:
-		return ensureOpenCodeCustomFacadeConfig(ctx, config, store, sandbox, providerID, modelName, source, runID)
+		return ensureOpenCodeCustomFacadeConfig(ctx, call)
 	}
 }
 
-func ensureOpenCodeConfiguredFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, providerID, model, source, runID string) (map[string]string, error) {
+func ensureOpenCodeConfiguredFacadeConfig(ctx context.Context, call openCodeFacadeCall) (map[string]string, error) {
+	config, store, sandbox := call.Config, call.Store, call.Sandbox
 	providerEnv, err := SandboxProviderEnvItems(ctx, store, sandbox, "")
 	if err != nil {
 		return nil, err
 	}
-	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, "", model, providerID, providerEnv)
+	target, err := ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandbox.Summary.ID, "", call.Model, call.ProviderID, providerEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +75,7 @@ func ensureOpenCodeConfiguredFacadeConfig(ctx context.Context, config *appconfig
 			return nil, err
 		}
 		if HasOpenAIEnvProviderInput(familyEnv) {
-			return ensureOpenCodeOpenAIFacadeConfig(ctx, config, store, sandbox, model, source, runID)
+			return ensureOpenCodeOpenAIFacadeConfig(ctx, call)
 		}
 	case ProviderFamilyAnthropic:
 		familyEnv, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyAnthropic)
@@ -66,13 +83,15 @@ func ensureOpenCodeConfiguredFacadeConfig(ctx context.Context, config *appconfig
 			return nil, err
 		}
 		if HasAnthropicEnvProviderInput(familyEnv) {
-			return ensureOpenCodeAnthropicFacadeConfig(ctx, config, store, sandbox, model, source, runID)
+			return ensureOpenCodeAnthropicFacadeConfig(ctx, call)
 		}
 	}
-	return ensureOpenCodeResolvedFacadeConfig(ctx, config, store, sandbox, target, source, runID)
+	call.Target = target
+	return ensureOpenCodeResolvedFacadeConfig(ctx, call)
 }
 
-func ensureOpenCodeResolvedFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, target ResolvedTarget, source, runID string) (map[string]string, error) {
+func ensureOpenCodeResolvedFacadeConfig(ctx context.Context, call openCodeFacadeCall) (map[string]string, error) {
+	config, store, sandbox, target, source, runID := call.Config, call.Store, call.Sandbox, call.Target, call.Source, call.RunID
 	baseURL := GuestRuntimeBaseURL(config, sandbox)
 	providerFamily := NormalizeProviderType(target.Provider.ProviderType)
 	if providerFamily == ProviderFamilyAnthropic {
@@ -119,7 +138,8 @@ func ensureOpenCodeResolvedFacadeConfig(ctx context.Context, config *appconfig.C
 	return env, nil
 }
 
-func ensureOpenCodeAnthropicFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, model, source, runID string) (map[string]string, error) {
+func ensureOpenCodeAnthropicFacadeConfig(ctx context.Context, call openCodeFacadeCall) (map[string]string, error) {
+	config, store, sandbox, model, source, runID := call.Config, call.Store, call.Sandbox, call.Model, call.Source, call.RunID
 	providerEnv, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyAnthropic)
 	if err != nil {
 		return nil, err
@@ -154,7 +174,8 @@ func ensureOpenCodeAnthropicFacadeConfig(ctx context.Context, config *appconfig.
 	}, nil
 }
 
-func ensureOpenCodeOpenAIFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, model, source, runID string) (map[string]string, error) {
+func ensureOpenCodeOpenAIFacadeConfig(ctx context.Context, call openCodeFacadeCall) (map[string]string, error) {
+	config, store, sandbox, model, source, runID := call.Config, call.Store, call.Sandbox, call.Model, call.Source, call.RunID
 	providerEnv, err := SandboxProviderEnvItems(ctx, store, sandbox, ProviderFamilyOpenAI)
 	if err != nil {
 		return nil, err
@@ -181,8 +202,15 @@ func ensureOpenCodeOpenAIFacadeConfig(ctx context.Context, config *appconfig.Con
 	return env, nil
 }
 
-func ensureOpenCodeCustomFacadeConfig(ctx context.Context, config *appconfig.Config, store OpenCodeFacadeStore, sandbox *domain.Sandbox, providerID, model, source, runID string) (map[string]string, error) {
-	target, err := resolveCustomOpenAIFacadeTarget(ctx, config, store, sandbox, providerID, model)
+func ensureOpenCodeCustomFacadeConfig(ctx context.Context, call openCodeFacadeCall) (map[string]string, error) {
+	config, store, sandbox, providerID, model, source, runID := call.Config, call.Store, call.Sandbox, call.ProviderID, call.Model, call.Source, call.RunID
+	target, err := resolveCustomOpenAIFacadeTarget(ctx, customOpenAIFacadeTargetRequest{
+		Config:     config,
+		Store:      store,
+		Sandbox:    sandbox,
+		ProviderID: providerID,
+		Model:      model,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/llms/pi_facade.go
+++ b/pkg/llms/pi_facade.go
@@ -39,7 +39,7 @@ func EnsurePiFacadeConfig(ctx context.Context, config *appconfig.Config, store P
 		return nil, nil
 	}
 
-	target, err := resolvePiFacadeTarget(ctx, config, store, sandbox, providerID, modelName)
+	target, err := resolvePiFacadeTarget(ctx, piFacadeTargetInput{Config: config, Store: store, Sandbox: sandbox, ProviderID: providerID, Model: modelName})
 	if err != nil {
 		return nil, err
 	}
@@ -73,14 +73,24 @@ func EnsurePiFacadeConfig(ctx context.Context, config *appconfig.Config, store P
 	return env, nil
 }
 
-func resolvePiFacadeTarget(ctx context.Context, config *appconfig.Config, store PiFacadeStore, sandbox *domain.Sandbox, providerID, model string) (ResolvedTarget, error) {
+// piFacadeTargetInput groups resolvePiFacadeTarget's inputs.
+type piFacadeTargetInput struct {
+	Config     *appconfig.Config
+	Store      PiFacadeStore
+	Sandbox    *domain.Sandbox
+	ProviderID string
+	Model      string
+}
+
+func resolvePiFacadeTarget(ctx context.Context, in piFacadeTargetInput) (ResolvedTarget, error) {
+	config, store, sandbox, providerID, model := in.Config, in.Store, in.Sandbox, in.ProviderID, in.Model
 	sandboxID := sandbox.Summary.ID
 	envItems, err := SandboxProviderEnvItems(ctx, store, sandbox, "")
 	if err != nil {
 		return ResolvedTarget{}, err
 	}
 	if HasSessionEnvProviderInput(envItems) {
-		return resolvePiEnvFacadeTarget(ctx, config, store, sandboxID, providerID, model, envItems)
+		return resolvePiEnvFacadeTarget(ctx, piEnvFacadeTargetInput{Config: config, Store: store, SandboxID: sandboxID, RequestedProviderID: providerID, Model: model, EnvItems: envItems})
 	}
 	if HasEnabledLLMProviderID(ctx, store, providerID) {
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, "", model, providerID, envItems)
@@ -91,20 +101,37 @@ func resolvePiFacadeTarget(ctx context.Context, config *appconfig.Config, store 
 	case ProviderFamilyOpenAI, ProviderIDDefaultOpenAI:
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, ProviderFamilyOpenAI, model, "", envItems)
 	default:
-		return resolveCustomOpenAIFacadeTarget(ctx, config, store, sandbox, providerID, model)
+		return resolveCustomOpenAIFacadeTarget(ctx, customOpenAIFacadeTargetRequest{
+			Config:     config,
+			Store:      store,
+			Sandbox:    sandbox,
+			ProviderID: providerID,
+			Model:      model,
+		})
 	}
 }
 
-func resolvePiEnvFacadeTarget(ctx context.Context, config *appconfig.Config, store PiFacadeStore, sandboxID, requestedProviderID, model string, envItems []domain.SandboxEnvVar) (ResolvedTarget, error) {
-	family := piEnvProviderFamily(ctx, store, requestedProviderID, envItems)
+// piEnvFacadeTargetInput groups resolvePiEnvFacadeTarget's inputs.
+type piEnvFacadeTargetInput struct {
+	Config              *appconfig.Config
+	Store               PiFacadeStore
+	SandboxID           string
+	RequestedProviderID string
+	Model               string
+	EnvItems            []domain.SandboxEnvVar
+}
+
+func resolvePiEnvFacadeTarget(ctx context.Context, in piEnvFacadeTargetInput) (ResolvedTarget, error) {
+	config, store, sandboxID, model, envItems := in.Config, in.Store, in.SandboxID, in.Model, in.EnvItems
+	family := piEnvProviderFamily(ctx, store, in.RequestedProviderID, envItems)
 	if family == ProviderFamilyAnthropic {
-		providerID, err := ensureSessionAnthropicEnvProviderWithConfig(ctx, config, store, sandboxID, model, envItems)
+		providerID, err := ensureSessionAnthropicEnvProviderWithConfig(ctx, store, SessionEnvProviderQuery{Config: config, SessionID: sandboxID, RequestedModel: model, EnvItems: envItems})
 		if err != nil {
 			return ResolvedTarget{}, err
 		}
 		return ResolveRuntimeLLMTargetWithEnv(ctx, config, store, sandboxID, family, model, providerID, envItems)
 	}
-	providerID, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sandboxID, model, envItems)
+	providerID, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, store, SessionEnvProviderQuery{Config: config, SessionID: sandboxID, RequestedModel: model, EnvItems: envItems})
 	if err != nil {
 		return ResolvedTarget{}, err
 	}

--- a/pkg/llms/provider_bootstrap.go
+++ b/pkg/llms/provider_bootstrap.go
@@ -69,7 +69,19 @@ func HasConfiguredProviderForFamily(ctx context.Context, store ProviderListStore
 	return false
 }
 
-func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+// EnvProviderRegistration groups the identity/model fields shared by the
+// Ensure*EnvProvider family: which provider/model to register, under which
+// scope, and whether it becomes the default.
+type EnvProviderRegistration struct {
+	ProviderID     string
+	Name           string
+	Scope          string
+	RequestedModel string
+	DefaultModel   bool
+}
+
+func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, reg EnvProviderRegistration) (string, error) {
+	providerID, name, scope, requestedModel, defaultModel := reg.ProviderID, reg.Name, reg.Scope, reg.RequestedModel, reg.DefaultModel
 	endpoint := firstNonEmpty(lookup("LLM_API_ENDPOINT"), "https://api.openai.com")
 	protocol := NormalizeWireAPI(lookup("LLM_API_PROTOCOL"))
 	if protocol == APIProtocolMessages {
@@ -96,7 +108,16 @@ func EnsureOpenAIEnvProvider(ctx context.Context, store DefaultConfigStore, look
 	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
 }
 
-func ensureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, credential anthropicCredential, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+// anthropicEnvProviderInput groups ensureAnthropicEnvProvider's credential
+// and registration inputs.
+type anthropicEnvProviderInput struct {
+	Credential anthropicCredential
+	EnvProviderRegistration
+}
+
+func ensureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, in anthropicEnvProviderInput) (string, error) {
+	credential, reg := in.Credential, in.EnvProviderRegistration
+	providerID, name, scope, requestedModel, defaultModel := reg.ProviderID, reg.Name, reg.Scope, reg.RequestedModel, reg.DefaultModel
 	anthropicEndpoint := lookup("ANTHROPIC_BASE_URL", "ANTHROPIC_API_ENDPOINT")
 	genericEndpoint := lookup("LLM_API_ENDPOINT")
 	anthropicModel := lookup("ANTHROPIC_MODEL", "CLAUDE_MODEL")
@@ -127,29 +148,26 @@ func ensureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, l
 	}, Model{ID: model, Name: model, DefaultModel: defaultModel, Enabled: true, Scope: scope})
 }
 
+// AnthropicEnvProviderRequest groups EnsureAnthropicEnvProvider's inputs:
+// caller-selected authentication semantics plus the shared registration
+// fields (which provider/model to register, under which scope).
+type AnthropicEnvProviderRequest struct {
+	AuthHeader string
+	AuthScheme string
+	EnvProviderRegistration
+}
+
 // EnsureAnthropicEnvProvider persists an environment-backed Anthropic
 // provider using caller-selected authentication semantics. Resolver paths use
 // layeredAnthropicCredential so the key and semantics share a source layer.
-func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, authHeader, authScheme, providerID, name, scope, requestedModel string, defaultModel bool) (string, error) {
+func EnsureAnthropicEnvProvider(ctx context.Context, store DefaultConfigStore, lookup EnvProviderLookup, req AnthropicEnvProviderRequest) (string, error) {
 	credential := anthropicCredential{
 		apiKey: firstNonEmpty(
 			lookup("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
 			lookup("LLM_API_KEY"),
 		),
-		authHeader: authHeader,
-		authScheme: authScheme,
+		authHeader: req.AuthHeader,
+		authScheme: req.AuthScheme,
 	}
-	return ensureAnthropicEnvProvider(ctx, store, lookup, credential, providerID, name, scope, requestedModel, defaultModel)
-}
-
-// AnthropicProviderAuthFromLookup derives Anthropic authentication semantics
-// from a lookup whose values belong to one already-selected source layer.
-func AnthropicProviderAuthFromLookup(lookup EnvProviderLookup) (string, string) {
-	if strings.TrimSpace(lookup("ANTHROPIC_API_KEY")) != "" {
-		return "x-api-key", ""
-	}
-	if strings.TrimSpace(lookup("ANTHROPIC_AUTH_TOKEN")) != "" {
-		return "Authorization", "Bearer"
-	}
-	return "x-api-key", ""
+	return ensureAnthropicEnvProvider(ctx, store, lookup, anthropicEnvProviderInput{Credential: credential, EnvProviderRegistration: req.EnvProviderRegistration})
 }

--- a/pkg/llms/provider_bootstrap_test.go
+++ b/pkg/llms/provider_bootstrap_test.go
@@ -24,7 +24,9 @@ func TestOpenAIEnvProviderUsesProtocolInsteadOfEndpointShape(t *testing.T) {
 				"LLM_API_KEY":      "generic-key",
 				"LLM_MODEL":        "test-model",
 			}
-			id, err := EnsureOpenAIEnvProvider(context.Background(), store, mapLookup(values), "openai-env", "openai-env", ProviderScopeSessionEnv, "", false)
+			id, err := EnsureOpenAIEnvProvider(context.Background(), store, mapLookup(values), EnvProviderRegistration{
+				ProviderID: "openai-env", Name: "openai-env", Scope: ProviderScopeSessionEnv,
+			})
 			if err != nil {
 				t.Fatalf("EnsureOpenAIEnvProvider() error = %v", err)
 			}
@@ -48,7 +50,12 @@ func TestAnthropicEnvProviderUsesGenericBaseURLForExplicitFamily(t *testing.T) {
 		"LLM_API_KEY":      "generic-key",
 		"LLM_MODEL":        "test-model",
 	}
-	id, err := EnsureAnthropicEnvProvider(context.Background(), store, mapLookup(values), "x-api-key", "", "anthropic-env", "anthropic-env", ProviderScopeSessionEnv, "", false)
+	id, err := EnsureAnthropicEnvProvider(context.Background(), store, mapLookup(values), AnthropicEnvProviderRequest{
+		AuthHeader: "x-api-key",
+		EnvProviderRegistration: EnvProviderRegistration{
+			ProviderID: "anthropic-env", Name: "anthropic-env", Scope: ProviderScopeSessionEnv,
+		},
+	})
 	if err != nil {
 		t.Fatalf("EnsureAnthropicEnvProvider() error = %v", err)
 	}

--- a/pkg/llms/resolver.go
+++ b/pkg/llms/resolver.go
@@ -123,19 +123,34 @@ func configLLMEnvValue(config *appconfig.Config, key string) string {
 }
 
 func ensureDefaultOpenAIEnvProvider(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
-	_, err := EnsureOpenAIEnvProvider(ctx, store, defaultLLMEnvProviderLookup(ctx, config, store), ProviderIDDefaultOpenAI, "default", ProviderScopeEnvDefault, requestedModel, true)
+	_, err := EnsureOpenAIEnvProvider(ctx, store, defaultLLMEnvProviderLookup(ctx, config, store), EnvProviderRegistration{
+		ProviderID: ProviderIDDefaultOpenAI, Name: "default", Scope: ProviderScopeEnvDefault, RequestedModel: requestedModel, DefaultModel: true,
+	})
 	return err
 }
 
 func resolveLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) (ResolvedTarget, error) {
-	return resolveLLMTargetForProviderFamily(ctx, config, store, ProviderFamilyOpenAI, requestedModel)
+	return resolveLLMTargetForProviderFamily(ctx, store, llmTargetForProviderFamilyQuery{Config: config, ProviderFamily: ProviderFamilyOpenAI, RequestedModel: requestedModel})
 }
 
 func ResolveLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) (ResolvedTarget, error) {
 	return resolveLLMTarget(ctx, config, store, requestedModel)
 }
 
-func resolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel, providerID string) (ResolvedTarget, error) {
+// runtimeLLMTargetQuery groups the shared inputs for resolving a runtime LLM
+// target: which model/provider was requested, from which session/family, and
+// (for the WithEnv variant) the session's own provider env items.
+type runtimeLLMTargetQuery struct {
+	Config                  *appconfig.Config
+	SessionID               string
+	PreferredProviderFamily string
+	RequestedModel          string
+	ProviderID              string
+	EnvItems                []domain.SandboxEnvVar
+}
+
+func resolveRuntimeLLMTarget(ctx context.Context, store LLMResolverStore, q runtimeLLMTargetQuery) (ResolvedTarget, error) {
+	config, requestedModel, providerID := q.Config, q.RequestedModel, q.ProviderID
 	if strings.TrimSpace(providerID) == "" {
 		if selectedProvider, selectedModel, ok := SplitProviderModelReference(requestedModel); ok && hasEnabledLLMProviderID(ctx, store, selectedProvider) {
 			providerID, requestedModel = selectedProvider, selectedModel
@@ -153,49 +168,150 @@ func resolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, stor
 			return target, nil
 		}
 	}
-	return resolveRuntimeLLMTargetWithEnv(ctx, config, store, "", "", requestedModel, providerID, nil)
+	return resolveRuntimeLLMTargetWithEnv(ctx, store, runtimeLLMTargetQuery{Config: config, RequestedModel: requestedModel, ProviderID: providerID})
 }
 
 func ResolveRuntimeLLMTarget(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel, providerID string) (ResolvedTarget, error) {
-	return resolveRuntimeLLMTarget(ctx, config, store, requestedModel, providerID)
+	return resolveRuntimeLLMTarget(ctx, store, runtimeLLMTargetQuery{Config: config, RequestedModel: requestedModel, ProviderID: providerID})
 }
 
-func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []domain.SandboxEnvVar) (ResolvedTarget, error) {
-	sessionID = strings.TrimSpace(sessionID)
-	preferredProviderFamily = NormalizeOptionalProviderType(preferredProviderFamily)
-	requestedModel = strings.TrimSpace(requestedModel)
-	providerID = strings.TrimSpace(providerID)
-	explicitProvider := providerID != ""
-	sessionRequestedModel := requestedModel
-	if _, modelID, ok := SplitProviderModelReference(sessionRequestedModel); ok {
-		sessionRequestedModel = modelID
+// providerBootstrapContext groups the routing signals
+// bootstrapSessionOrDefaultProviders needs to decide which env-backed
+// provider(s), if any, to ensure exist for this request.
+type providerBootstrapContext struct {
+	Config                       *appconfig.Config
+	SessionID                    string
+	EnvItems                     []domain.SandboxEnvVar
+	RequestedModel               string
+	ProviderID                   string
+	PreferredProviderFamily      string
+	GenericSessionProviderFamily string
+	HasSessionEnvProvider        bool
+	ExplicitProvider             bool
+	DefaultLookup                EnvProviderLookup
+}
+
+// bootstrapSessionOrDefaultProviders ensures the OpenAI and/or Anthropic
+// env-backed provider(s) implied by bc exist (session-scoped when the
+// session supplies its own credentials, otherwise the daemon default),
+// unless the request already names a provider that exists. It returns the
+// session-scoped provider id chosen along the way, if any.
+func bootstrapSessionOrDefaultProviders(ctx context.Context, store LLMResolverStore, bc providerBootstrapContext) (string, error) {
+	config, sessionID, envItems, requestedModel, providerID := bc.Config, bc.SessionID, bc.EnvItems, bc.RequestedModel, bc.ProviderID
+	preferredProviderFamily, hasSessionEnvProvider, defaultLookup := bc.PreferredProviderFamily, bc.HasSessionEnvProvider, bc.DefaultLookup
+	// Skip the env/default bootstrap entirely when the request already names a
+	// provider that exists. The facade hot path always passes a concrete
+	// provider id from the token scope, so this avoids a redundant pair of
+	// idempotent provider upserts on every LLM request.
+	bootstrapProviders := !bc.ExplicitProvider && (providerID == "" || !IsSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
+	sessionProviderID := ""
+	bootstrapOpenAI := preferredProviderFamily == "" ||
+		preferredProviderFamily == ProviderFamilyOpenAI ||
+		bc.GenericSessionProviderFamily == ProviderFamilyOpenAI
+	if bootstrapProviders && bootstrapOpenAI {
+		openAIModel := firstNonEmptyTrimmed(requestedModel, EnvItemValue(envItems, "LLM_MODEL"))
+		hasOpenAIEnvProvider := HasOpenAIEnvProviderInput(envItems)
+		if hasSessionEnvProvider && hasOpenAIEnvProvider {
+			id, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, store, SessionEnvProviderQuery{Config: config, SessionID: sessionID, RequestedModel: openAIModel, EnvItems: envItems})
+			if err != nil {
+				return "", err
+			}
+			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyOpenAI, preferredProviderFamily)
+		} else if hasCompleteDefaultOpenAIProvider(defaultLookup) && (preferredProviderFamily == ProviderFamilyOpenAI || !hasSessionEnvProvider) {
+			if err := ensureDefaultOpenAIEnvProvider(ctx, config, store, openAIModel); err != nil {
+				return "", err
+			}
+		}
 	}
-	hasSessionEnvProvider := sessionID != "" && HasSessionEnvProviderInput(envItems) && firstNonEmptyTrimmed(
-		SessionAnthropicEnvModel(envItems), EnvItemValue(envItems, "LLM_MODEL"), sessionRequestedModel,
-	) != ""
-	defaultLookup := defaultLLMEnvProviderLookup(ctx, config, store)
-	if hasSessionEnvProvider && providerID == "" {
-		if envModel := firstNonEmptyTrimmed(SessionAnthropicEnvModel(envItems), EnvItemValue(envItems, "LLM_MODEL")); envModel != "" {
+	bootstrapAnthropic := preferredProviderFamily == "" ||
+		preferredProviderFamily == ProviderFamilyAnthropic ||
+		bc.GenericSessionProviderFamily == ProviderFamilyAnthropic
+	if bootstrapProviders && bootstrapAnthropic {
+		anthropicModel := firstNonEmptyTrimmed(requestedModel, SessionAnthropicEnvModel(envItems))
+		hasAnthropicEnvProvider := HasAnthropicEnvProviderInput(envItems)
+		if hasSessionEnvProvider && hasAnthropicEnvProvider {
+			id, err := ensureSessionAnthropicEnvProviderWithConfig(ctx, store, SessionEnvProviderQuery{Config: config, SessionID: sessionID, RequestedModel: anthropicModel, EnvItems: envItems})
+			if err != nil {
+				return "", err
+			}
+			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyAnthropic, preferredProviderFamily)
+		} else if hasCompleteDefaultAnthropicProvider(defaultLookup) && (preferredProviderFamily == ProviderFamilyAnthropic || !hasSessionEnvProvider) {
+			if err := ensureDefaultAnthropicEnvProvider(ctx, config, store, anthropicModel); err != nil {
+				return "", err
+			}
+		}
+	}
+	return sessionProviderID, nil
+}
+
+// providerModelRefinementInput groups refineProviderAndModelFromReference's inputs.
+type providerModelRefinementInput struct {
+	HasSessionEnvProvider bool
+	ProviderID            string
+	RequestedModel        string
+	EnvItems              []domain.SandboxEnvVar
+	DefaultLookup         EnvProviderLookup
+}
+
+// refineProviderAndModelFromReference splits a legacy <provider>/<model>
+// reference out of requestedModel when no explicit provider was given,
+// preferring the session's own env-backed provider when the session
+// supplies one. It returns the (possibly updated) providerID/requestedModel
+// and whether a provider is now explicit.
+func refineProviderAndModelFromReference(ctx context.Context, store LLMResolverStore, in providerModelRefinementInput) (providerID, requestedModel string, explicitProvider bool) {
+	providerID, requestedModel = in.ProviderID, in.RequestedModel
+	explicitProvider = providerID != ""
+	if in.HasSessionEnvProvider && providerID == "" {
+		if envModel := firstNonEmptyTrimmed(SessionAnthropicEnvModel(in.EnvItems), EnvItemValue(in.EnvItems, "LLM_MODEL")); envModel != "" {
 			requestedModel = envModel
 		} else if _, selectedModel, ok := SplitProviderModelReference(requestedModel); ok {
 			requestedModel = selectedModel
 		}
-	} else if providerID == "" {
-		if selectedProvider, selectedModel, ok := SplitProviderModelReference(requestedModel); ok {
-			switch {
-			case legacyReferenceUsesDefaultEnv(selectedProvider, defaultLookup):
-				requestedModel = selectedModel
-			case hasEnabledLLMProviderID(ctx, store, selectedProvider) || hasConfiguredProviderID(ctx, store, selectedProvider):
-				providerID, requestedModel = selectedProvider, selectedModel
-				explicitProvider = true
-			}
+		return providerID, requestedModel, explicitProvider
+	}
+	if providerID != "" {
+		return providerID, requestedModel, explicitProvider
+	}
+	if selectedProvider, selectedModel, ok := SplitProviderModelReference(requestedModel); ok {
+		switch {
+		case legacyReferenceUsesDefaultEnv(selectedProvider, in.DefaultLookup):
+			requestedModel = selectedModel
+		case hasEnabledLLMProviderID(ctx, store, selectedProvider) || hasConfiguredProviderID(ctx, store, selectedProvider):
+			providerID, requestedModel = selectedProvider, selectedModel
+			explicitProvider = true
 		}
 	}
+	return providerID, requestedModel, explicitProvider
+}
+
+// sessionHasEnvProvider reports whether the session supplies its own
+// env-backed provider input for the (legacy-reference-stripped) requested model.
+func sessionHasEnvProvider(sessionID, requestedModel string, envItems []domain.SandboxEnvVar) bool {
+	if sessionID == "" || !HasSessionEnvProviderInput(envItems) {
+		return false
+	}
+	sessionRequestedModel := requestedModel
+	if _, modelID, ok := SplitProviderModelReference(sessionRequestedModel); ok {
+		sessionRequestedModel = modelID
+	}
+	return firstNonEmptyTrimmed(SessionAnthropicEnvModel(envItems), EnvItemValue(envItems, "LLM_MODEL"), sessionRequestedModel) != ""
+}
+
+func resolveRuntimeLLMTargetWithEnv(ctx context.Context, store LLMResolverStore, q runtimeLLMTargetQuery) (ResolvedTarget, error) {
+	config, requestedModel, providerID, envItems := q.Config, q.RequestedModel, q.ProviderID, q.EnvItems
+	sessionID := strings.TrimSpace(q.SessionID)
+	preferredProviderFamily := NormalizeOptionalProviderType(q.PreferredProviderFamily)
+	requestedModel = strings.TrimSpace(requestedModel)
+	providerID = strings.TrimSpace(providerID)
+	hasSessionEnvProvider := sessionHasEnvProvider(sessionID, requestedModel, envItems)
+	defaultLookup := defaultLLMEnvProviderLookup(ctx, config, store)
+	providerID, requestedModel, explicitProvider := refineProviderAndModelFromReference(ctx, store, providerModelRefinementInput{
+		HasSessionEnvProvider: hasSessionEnvProvider, ProviderID: providerID, RequestedModel: requestedModel, EnvItems: envItems, DefaultLookup: defaultLookup,
+	})
 	genericSessionProviderFamily := ""
 	if sessionID != "" {
 		genericSessionProviderFamily = genericLLMEnvProviderFamily(envItems)
 	}
-	sessionProviderID := ""
 	// Reuse an already-persisted session-env provider when this session can no
 	// longer supply a key from env. The raw key env (Session.ProviderEnvItems) is
 	// intentionally not persisted, so after a stop/resume the only durable home
@@ -209,46 +325,13 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 			providerID = candidate
 		}
 	}
-	// Skip the env/default bootstrap entirely when the request already names a
-	// provider that exists. The facade hot path always passes a concrete
-	// provider id from the token scope, so this avoids a redundant pair of
-	// idempotent provider upserts on every LLM request.
-	bootstrapProviders := !explicitProvider && (providerID == "" || !IsSessionEnvProviderID(providerID)) && !hasEnabledLLMProviderID(ctx, store, providerID)
-	bootstrapOpenAI := preferredProviderFamily == "" ||
-		preferredProviderFamily == ProviderFamilyOpenAI ||
-		genericSessionProviderFamily == ProviderFamilyOpenAI
-	if bootstrapProviders && bootstrapOpenAI {
-		openAIModel := firstNonEmptyTrimmed(requestedModel, EnvItemValue(envItems, "LLM_MODEL"))
-		hasOpenAIEnvProvider := HasOpenAIEnvProviderInput(envItems)
-		if hasSessionEnvProvider && hasOpenAIEnvProvider {
-			id, err := ensureSessionOpenAIEnvProviderWithConfig(ctx, config, store, sessionID, openAIModel, envItems)
-			if err != nil {
-				return ResolvedTarget{}, err
-			}
-			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyOpenAI, preferredProviderFamily)
-		} else if hasCompleteDefaultOpenAIProvider(defaultLookup) && (preferredProviderFamily == ProviderFamilyOpenAI || !hasSessionEnvProvider) {
-			if err := ensureDefaultOpenAIEnvProvider(ctx, config, store, openAIModel); err != nil {
-				return ResolvedTarget{}, err
-			}
-		}
-	}
-	bootstrapAnthropic := preferredProviderFamily == "" ||
-		preferredProviderFamily == ProviderFamilyAnthropic ||
-		genericSessionProviderFamily == ProviderFamilyAnthropic
-	if bootstrapProviders && bootstrapAnthropic {
-		anthropicModel := firstNonEmptyTrimmed(requestedModel, SessionAnthropicEnvModel(envItems))
-		hasAnthropicEnvProvider := HasAnthropicEnvProviderInput(envItems)
-		if hasSessionEnvProvider && hasAnthropicEnvProvider {
-			id, err := ensureSessionAnthropicEnvProviderWithConfig(ctx, config, store, sessionID, anthropicModel, envItems)
-			if err != nil {
-				return ResolvedTarget{}, err
-			}
-			sessionProviderID = ChooseSessionEnvProviderID(sessionProviderID, id, ProviderFamilyAnthropic, preferredProviderFamily)
-		} else if hasCompleteDefaultAnthropicProvider(defaultLookup) && (preferredProviderFamily == ProviderFamilyAnthropic || !hasSessionEnvProvider) {
-			if err := ensureDefaultAnthropicEnvProvider(ctx, config, store, anthropicModel); err != nil {
-				return ResolvedTarget{}, err
-			}
-		}
+	sessionProviderID, err := bootstrapSessionOrDefaultProviders(ctx, store, providerBootstrapContext{
+		Config: config, SessionID: sessionID, EnvItems: envItems, RequestedModel: requestedModel, ProviderID: providerID,
+		PreferredProviderFamily: preferredProviderFamily, GenericSessionProviderFamily: genericSessionProviderFamily,
+		HasSessionEnvProvider: hasSessionEnvProvider, ExplicitProvider: explicitProvider, DefaultLookup: defaultLookup,
+	})
+	if err != nil {
+		return ResolvedTarget{}, err
 	}
 	if explicitProvider && !hasEnabledLLMProviderID(ctx, store, providerID) {
 		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, fmt.Sprintf("llm provider %q is not configured", providerID), nil)
@@ -303,7 +386,7 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 	if len(providers) == 0 {
 		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
 	}
-	model, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, store, models, providers, requestedModel, preferredProviderFamily, providerID)
+	model, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, store, ModelProviderSelection{Models: models, Providers: providers, RequestedModel: requestedModel, ProviderFamily: preferredProviderFamily, ProviderID: providerID})
 	if err != nil {
 		return ResolvedTarget{}, err
 	}
@@ -319,7 +402,7 @@ func resolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Confi
 		}
 		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
 	}
-	return BuildResolvedTarget(ctx, store, provider, model, wireAPI)
+	return BuildResolvedTarget(ctx, store, ResolvedTargetInput{Provider: provider, Model: model, WireAPI: wireAPI})
 }
 
 func hasCompleteDefaultOpenAIProvider(lookup EnvProviderLookup) bool {
@@ -356,7 +439,9 @@ func legacyReferenceUsesDefaultEnv(providerID string, lookup EnvProviderLookup) 
 }
 
 func ResolveRuntimeLLMTargetWithEnv(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, preferredProviderFamily, requestedModel, providerID string, envItems []domain.SandboxEnvVar) (ResolvedTarget, error) {
-	return resolveRuntimeLLMTargetWithEnv(ctx, config, store, sessionID, preferredProviderFamily, requestedModel, providerID, envItems)
+	return resolveRuntimeLLMTargetWithEnv(ctx, store, runtimeLLMTargetQuery{
+		Config: config, SessionID: sessionID, PreferredProviderFamily: preferredProviderFamily, RequestedModel: requestedModel, ProviderID: providerID, EnvItems: envItems,
+	})
 }
 
 func bootstrapAnthropicLLMConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, requestedModel string) error {
@@ -376,36 +461,50 @@ func ensureDefaultAnthropicEnvProvider(ctx context.Context, config *appconfig.Co
 		return nil
 	}
 	credential := layeredAnthropicCredential(ctx, config, store, nil)
-	_, err := ensureAnthropicEnvProvider(ctx, store, lookup, credential, ProviderIDDefaultAnthropic, "anthropic", ProviderScopeEnvDefault, requestedModel, false)
+	_, err := ensureAnthropicEnvProvider(ctx, store, lookup, anthropicEnvProviderInput{
+		Credential: credential,
+		EnvProviderRegistration: EnvProviderRegistration{
+			ProviderID: ProviderIDDefaultAnthropic, Name: "anthropic", Scope: ProviderScopeEnvDefault, RequestedModel: requestedModel,
+		},
+	})
 	return err
 }
 
-func ensureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
-	return ensureSessionOpenAIEnvProviderWithConfig(ctx, nil, store, sessionID, requestedModel, envItems)
-}
-
-func ensureSessionOpenAIEnvProviderWithConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
+func ensureSessionOpenAIEnvProviderWithConfig(ctx context.Context, store LLMResolverStore, in SessionEnvProviderQuery) (string, error) {
+	sessionID, requestedModel, envItems := in.SessionID, in.RequestedModel, in.EnvItems
 	providerID := SessionEnvProviderID(sessionID, ProviderFamilyOpenAI)
-	return EnsureOpenAIEnvProvider(ctx, store, sessionLLMEnvProviderLookup(envItems), providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+	return EnsureOpenAIEnvProvider(ctx, store, sessionLLMEnvProviderLookup(envItems), EnvProviderRegistration{
+		ProviderID: providerID, Name: providerID, Scope: ProviderScopeSessionEnv, RequestedModel: requestedModel,
+	})
 }
 
-func EnsureSessionOpenAIEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
-	return ensureSessionOpenAIEnvProvider(ctx, store, sessionID, requestedModel, envItems)
+func ensureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, q SessionEnvProviderQuery) (string, error) {
+	return ensureSessionAnthropicEnvProviderWithConfig(ctx, store, q)
 }
 
-func ensureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
-	return ensureSessionAnthropicEnvProviderWithConfig(ctx, nil, store, sessionID, requestedModel, envItems)
+// SessionEnvProviderQuery groups ensureSessionAnthropicEnvProviderWithConfig's inputs.
+type SessionEnvProviderQuery struct {
+	Config         *appconfig.Config
+	SessionID      string
+	RequestedModel string
+	EnvItems       []domain.SandboxEnvVar
 }
 
-func ensureSessionAnthropicEnvProviderWithConfig(ctx context.Context, config *appconfig.Config, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
+func ensureSessionAnthropicEnvProviderWithConfig(ctx context.Context, store LLMResolverStore, in SessionEnvProviderQuery) (string, error) {
+	sessionID, requestedModel, envItems := in.SessionID, in.RequestedModel, in.EnvItems
 	providerID := SessionEnvProviderID(sessionID, ProviderFamilyAnthropic)
 	lookup := sessionLLMEnvProviderLookup(envItems)
 	credential, _ := anthropicCredentialFromItems(envItems)
-	return ensureAnthropicEnvProvider(ctx, store, lookup, credential, providerID, providerID, ProviderScopeSessionEnv, requestedModel, false)
+	return ensureAnthropicEnvProvider(ctx, store, lookup, anthropicEnvProviderInput{
+		Credential: credential,
+		EnvProviderRegistration: EnvProviderRegistration{
+			ProviderID: providerID, Name: providerID, Scope: ProviderScopeSessionEnv, RequestedModel: requestedModel,
+		},
+	})
 }
 
-func EnsureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, sessionID, requestedModel string, envItems []domain.SandboxEnvVar) (string, error) {
-	return ensureSessionAnthropicEnvProvider(ctx, store, sessionID, requestedModel, envItems)
+func EnsureSessionAnthropicEnvProvider(ctx context.Context, store LLMResolverStore, q SessionEnvProviderQuery) (string, error) {
+	return ensureSessionAnthropicEnvProvider(ctx, store, q)
 }
 
 func hasEnabledLLMProviderID(ctx context.Context, store LLMResolverStore, providerID string) bool {
@@ -429,7 +528,15 @@ func hasConfiguredLLMProviderForFamily(ctx context.Context, store LLMResolverSto
 	return HasConfiguredProviderForFamily(ctx, store, providerFamily)
 }
 
-func resolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store LLMResolverStore, providerFamily, requestedModel string) (ResolvedTarget, error) {
+// llmTargetForProviderFamilyQuery groups resolveLLMTargetForProviderFamily's inputs.
+type llmTargetForProviderFamilyQuery struct {
+	Config         *appconfig.Config
+	ProviderFamily string
+	RequestedModel string
+}
+
+func resolveLLMTargetForProviderFamily(ctx context.Context, store LLMResolverStore, q llmTargetForProviderFamilyQuery) (ResolvedTarget, error) {
+	config, providerFamily, requestedModel := q.Config, q.ProviderFamily, q.RequestedModel
 	if strings.TrimSpace(providerFamily) != "" {
 		providerFamily = NormalizeProviderType(providerFamily)
 	}
@@ -457,7 +564,7 @@ func resolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Co
 	if len(providers) == 0 {
 		return ResolvedTarget{}, domain.ClassifyError(domain.ErrFailedPrecondition, "llm provider is not configured", nil)
 	}
-	model, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, store, models, providers, requestedModel, providerFamily, "")
+	model, provider, wireAPI, ok, err := SelectModelAndProvider(ctx, store, ModelProviderSelection{Models: models, Providers: providers, RequestedModel: requestedModel, ProviderFamily: providerFamily})
 	if err != nil {
 		return ResolvedTarget{}, err
 	}
@@ -476,7 +583,7 @@ func resolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Co
 }
 
 func ResolveLLMTargetForProviderFamily(ctx context.Context, config *appconfig.Config, store LLMResolverStore, providerFamily, requestedModel string) (ResolvedTarget, error) {
-	return resolveLLMTargetForProviderFamily(ctx, config, store, providerFamily, requestedModel)
+	return resolveLLMTargetForProviderFamily(ctx, store, llmTargetForProviderFamilyQuery{Config: config, ProviderFamily: providerFamily, RequestedModel: requestedModel})
 }
 
 func lookupEnvValue(ctx context.Context, store LLMResolverStore, key string) string {

--- a/pkg/llms/runtime_config.go
+++ b/pkg/llms/runtime_config.go
@@ -57,12 +57,22 @@ func normalizeCodexRuntimePolicy(policy CodexRuntimePolicy) CodexRuntimePolicy {
 	return policy
 }
 
-func WriteCodexRuntimeConfig(session *domain.Sandbox, model, baseURL, wireAPI string, policy CodexRuntimePolicy) error {
+// CodexRuntimeConfig groups WriteCodexRuntimeConfig's model/endpoint/retry inputs.
+type CodexRuntimeConfig struct {
+	Model   string
+	BaseURL string
+	WireAPI string
+	Policy  CodexRuntimePolicy
+}
+
+func WriteCodexRuntimeConfig(session *domain.Sandbox, cfg CodexRuntimeConfig) error {
 	if session == nil {
 		return nil
 	}
-	model = strings.TrimSpace(model)
-	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	model := strings.TrimSpace(cfg.Model)
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	wireAPI := cfg.WireAPI
+	policy := cfg.Policy
 	if model == "" || baseURL == "" {
 		return nil
 	}

--- a/pkg/llms/runtime_config_test.go
+++ b/pkg/llms/runtime_config_test.go
@@ -16,7 +16,7 @@ func TestWriteCodexRuntimeConfigRendersRetryPolicy(t *testing.T) {
 	root := t.TempDir()
 	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: filepath.Join(root, "workspace")}}
 	policy := CodexRuntimePolicy{RequestMaxRetries: 0, StreamMaxRetries: 2, StreamIdleTimeout: 1500 * time.Millisecond}
-	if err := WriteCodexRuntimeConfig(sandbox, "gpt-test", "http://runtime/openai/v1/", APIProtocolResponses, policy); err != nil {
+	if err := WriteCodexRuntimeConfig(sandbox, CodexRuntimeConfig{Model: "gpt-test", BaseURL: "http://runtime/openai/v1/", WireAPI: APIProtocolResponses, Policy: policy}); err != nil {
 		t.Fatalf("WriteCodexRuntimeConfig returned error: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(sandbox), ".codex", "config.toml"))

--- a/pkg/llms/runtime_facade_target.go
+++ b/pkg/llms/runtime_facade_target.go
@@ -49,7 +49,7 @@ func resolveRuntimeLLMProviderTarget(ctx context.Context, store runtimeLLMProvid
 		}
 	}
 
-	target, err := BuildResolvedTarget(ctx, store, provider, Model{ID: requestedModel, Name: requestedModel, Enabled: true}, wireAPI)
+	target, err := BuildResolvedTarget(ctx, store, ResolvedTargetInput{Provider: provider, Model: Model{ID: requestedModel, Name: requestedModel, Enabled: true}, WireAPI: wireAPI})
 	if err != nil {
 		return ResolvedTarget{}, false, err
 	}

--- a/pkg/llms/runtimefacade/config.go
+++ b/pkg/llms/runtimefacade/config.go
@@ -51,23 +51,38 @@ func EnsureSessionAgentRuntimeConfig(ctx context.Context, config *appconfig.Conf
 		env, err := llms.EnsureCodexFacadeConfig(ctx, config, store, session, model, source, runID)
 		return AgentRuntimeConfig{Env: env}, err
 	case "claude":
-		env, err := ensureSessionClaudeConfig(ctx, config, store, session, model, source, runID)
+		env, err := ensureSessionClaudeConfig(ctx, sessionFacadeCall{Config: config, Store: store, Session: session, Model: model, Source: source, RunID: runID})
 		return AgentRuntimeConfig{Env: env}, err
 	case "opencode":
-		env, err := ensureSessionOpenCodeConfig(ctx, config, store, session, model, source, runID)
+		env, err := ensureSessionOpenCodeConfig(ctx, sessionFacadeCall{Config: config, Store: store, Session: session, Model: model, Source: source, RunID: runID})
 		return AgentRuntimeConfig{Env: env, Model: strings.TrimSpace(env["OPENCODE_MODEL"])}, err
 	case "pi":
 		env, err := llms.EnsurePiFacadeConfig(ctx, config, store, session, model, source, runID)
 		return AgentRuntimeConfig{Env: env}, err
 	case "dsh":
-		env, err := llms.EnsureDshFacadeConfig(ctx, config, store, session, model, source, runID)
+		env, err := llms.EnsureDshFacadeConfig(ctx, llms.DshFacadeConfigRequest{
+			Config: config, Store: store, Sandbox: session, Model: model, Source: source, RunID: runID,
+		})
 		return AgentRuntimeConfig{Env: env}, err
 	default:
 		return AgentRuntimeConfig{}, nil
 	}
 }
 
-func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
+// sessionFacadeCall groups the environment (Config/Store/Session) and
+// per-call attribution (Model/Source/RunID) shared by the session facade
+// config helpers below.
+type sessionFacadeCall struct {
+	Config  *appconfig.Config
+	Store   FacadeStore
+	Session *domain.Sandbox
+	Model   string
+	Source  string
+	RunID   string
+}
+
+func ensureSessionClaudeConfig(ctx context.Context, call sessionFacadeCall) (map[string]string, error) {
+	config, store, session, model, source, runID := call.Config, call.Store, call.Session, call.Model, call.Source, call.RunID
 	baseURL := llms.GuestRuntimeBaseURL(config, session)
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, nil
@@ -111,8 +126,8 @@ func ensureSessionClaudeConfig(ctx context.Context, config *appconfig.Config, st
 	return env, nil
 }
 
-func ensureSessionOpenCodeConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, model, source, runID string) (map[string]string, error) {
-	return llms.EnsureOpenCodeFacadeConfig(ctx, config, store, session, model, source, runID)
+func ensureSessionOpenCodeConfig(ctx context.Context, call sessionFacadeCall) (map[string]string, error) {
+	return llms.EnsureOpenCodeFacadeConfig(ctx, call.Config, call.Store, call.Session, call.Model, call.Source, call.RunID)
 }
 
 func isOptionalConfigError(err error) bool {
@@ -120,10 +135,6 @@ func isOptionalConfigError(err error) bool {
 		return false
 	}
 	return errors.Is(err, domain.ErrRequired) || errors.Is(err, domain.ErrFailedPrecondition)
-}
-
-func IsOptionalConfigError(err error) bool {
-	return isOptionalConfigError(err)
 }
 
 func HasAnthropicProviderKey(ctx context.Context, config *appconfig.Config, store FacadeStore) bool {

--- a/pkg/llms/runtimefacade/provider_environment_e2e_test.go
+++ b/pkg/llms/runtimefacade/provider_environment_e2e_test.go
@@ -52,7 +52,14 @@ func TestE2EClaudeModelProviderOverrideSurvivesSandboxReload(t *testing.T) {
 		slices.Contains(sandbox.ProviderEnvOverrideNames, "CLAUDE_CODE_PATH") {
 		t.Fatalf("provider provenance names = %#v", sandbox.ProviderEnvOverrideNames)
 	}
-	requireClaudeFacadeModel(t, ctx, config, configStore, sandbox, "run-before-reload", model)
+	requireClaudeFacadeModel(t, claudeFacadeModelCheck{
+		Ctx:       ctx,
+		Config:    config,
+		Store:     configStore,
+		Sandbox:   sandbox,
+		RunID:     "run-before-reload",
+		WantModel: model,
+	})
 	if err := sandboxStore.UpdateSandbox(ctx, sandbox); err != nil {
 		t.Fatalf("persist sandbox: %v", err)
 	}
@@ -85,7 +92,14 @@ func TestE2EClaudeModelProviderOverrideSurvivesSandboxReload(t *testing.T) {
 		t.Fatal("OpenAI provider environment contains CLAUDE_MODEL")
 	}
 
-	rawToken := requireClaudeFacadeModel(t, ctx, config, configStore, reloaded, "run-after-reload", model)
+	rawToken := requireClaudeFacadeModel(t, claudeFacadeModelCheck{
+		Ctx:       ctx,
+		Config:    config,
+		Store:     configStore,
+		Sandbox:   reloaded,
+		RunID:     "run-after-reload",
+		WantModel: model,
+	})
 	token, err := configStore.GetLLMFacadeToken(ctx, rawToken)
 	if err != nil {
 		t.Fatalf("load facade token: %v", err)
@@ -158,7 +172,14 @@ func TestE2EClaudeKeepsGenericResponsesProviderAcrossSandboxReload(t *testing.T)
 		t.Fatal("generic OpenAI session provider or its credential is missing")
 	}
 
-	rawToken := requireClaudeFacadeModel(t, ctx, config, configStore, sandbox, "run-generic-before-reload", model)
+	rawToken := requireClaudeFacadeModel(t, claudeFacadeModelCheck{
+		Ctx:       ctx,
+		Config:    config,
+		Store:     configStore,
+		Sandbox:   sandbox,
+		RunID:     "run-generic-before-reload",
+		WantModel: model,
+	})
 	requireTokenScope(rawToken)
 	if err := sandboxStore.UpdateSandbox(ctx, sandbox); err != nil {
 		t.Fatalf("persist sandbox: %v", err)
@@ -170,7 +191,14 @@ func TestE2EClaudeKeepsGenericResponsesProviderAcrossSandboxReload(t *testing.T)
 	if len(reloaded.ProviderEnvItems) != 0 || llms.EnvItemValue(reloaded.EnvItems, "LLM_API_KEY") != "" {
 		t.Fatal("reloaded sandbox retained transient generic provider credentials")
 	}
-	rawToken = requireClaudeFacadeModel(t, ctx, config, configStore, reloaded, "run-generic-after-reload", model)
+	rawToken = requireClaudeFacadeModel(t, claudeFacadeModelCheck{
+		Ctx:       ctx,
+		Config:    config,
+		Store:     configStore,
+		Sandbox:   reloaded,
+		RunID:     "run-generic-after-reload",
+		WantModel: model,
+	})
 	requireTokenScope(rawToken)
 }
 
@@ -187,8 +215,18 @@ func e2eRuntimeFacadeConfig(root string) *appconfig.Config {
 	}
 }
 
-func requireClaudeFacadeModel(t *testing.T, ctx context.Context, config *appconfig.Config, store FacadeStore, sandbox *domain.Sandbox, runID, wantModel string) string {
+type claudeFacadeModelCheck struct {
+	Ctx       context.Context
+	Config    *appconfig.Config
+	Store     FacadeStore
+	Sandbox   *domain.Sandbox
+	RunID     string
+	WantModel string
+}
+
+func requireClaudeFacadeModel(t *testing.T, check claudeFacadeModelCheck) string {
 	t.Helper()
+	ctx, config, store, sandbox, runID, wantModel := check.Ctx, check.Config, check.Store, check.Sandbox, check.RunID, check.WantModel
 	runtimeConfig, err := EnsureSessionAgentRuntimeConfig(ctx, config, store, sandbox, "claude", "", TokenSourceAgent, runID)
 	if err != nil {
 		t.Fatalf("configure Claude facade: %v", err)

--- a/pkg/llms/runtimefacade/startup_config.go
+++ b/pkg/llms/runtimefacade/startup_config.go
@@ -27,7 +27,7 @@ func EnsureSessionStartupFacadeConfig(ctx context.Context, config *appconfig.Con
 
 	env := make(map[string]string)
 	for _, family := range []string{llms.ProviderFamilyAnthropic, llms.ProviderFamilyOpenAI} {
-		familyEnv, err := ensureStartupFamilyConfig(ctx, config, store, session, family, source, runID, baseURL)
+		familyEnv, err := ensureStartupFamilyConfig(ctx, startupFamilyCall{Config: config, Store: store, Session: session, Family: family, Source: source, RunID: runID, BaseURL: baseURL})
 		if err != nil {
 			return nil, err
 		}
@@ -41,7 +41,19 @@ func EnsureSessionStartupFacadeConfig(ctx context.Context, config *appconfig.Con
 	return env, nil
 }
 
-func ensureStartupFamilyConfig(ctx context.Context, config *appconfig.Config, store FacadeStore, session *domain.Sandbox, family, source, runID, baseURL string) (map[string]string, error) {
+// startupFamilyCall groups ensureStartupFamilyConfig's inputs.
+type startupFamilyCall struct {
+	Config  *appconfig.Config
+	Store   FacadeStore
+	Session *domain.Sandbox
+	Family  string
+	Source  string
+	RunID   string
+	BaseURL string
+}
+
+func ensureStartupFamilyConfig(ctx context.Context, call startupFamilyCall) (map[string]string, error) {
+	config, store, session, family, source, runID, baseURL := call.Config, call.Store, call.Session, call.Family, call.Source, call.RunID, call.BaseURL
 	provider, available, err := llms.SelectRuntimeFacadeProvider(ctx, store, session.Summary.ID, family)
 	if err != nil {
 		return nil, fmt.Errorf("select %s startup facade provider: %w", family, err)
@@ -50,7 +62,8 @@ func ensureStartupFamilyConfig(ctx context.Context, config *appconfig.Config, st
 	if err != nil {
 		return nil, fmt.Errorf("load %s startup facade environment: %w", family, err)
 	}
-	if !available && !startupFamilyHasInput(ctx, config, store, family, providerEnv) {
+	famEnv := startupFamilyEnv{Config: config, Store: store, Family: family, ProviderEnv: providerEnv}
+	if !available && !startupFamilyHasInput(ctx, famEnv) {
 		return nil, nil
 	}
 	if !available {
@@ -60,7 +73,7 @@ func ensureStartupFamilyConfig(ctx context.Context, config *appconfig.Config, st
 			store,
 			session.Summary.ID,
 			family,
-			startupFamilyModel(ctx, config, store, family, providerEnv),
+			startupFamilyModel(ctx, famEnv),
 			"",
 			providerEnv,
 		)
@@ -97,7 +110,17 @@ func ensureStartupFamilyConfig(ctx context.Context, config *appconfig.Config, st
 	}, nil
 }
 
-func startupFamilyHasInput(ctx context.Context, config *appconfig.Config, store FacadeStore, family string, providerEnv []domain.SandboxEnvVar) bool {
+// startupFamilyEnv groups the config/store plus which provider family and
+// its already-loaded env items, shared by the startup-family helpers below.
+type startupFamilyEnv struct {
+	Config      *appconfig.Config
+	Store       FacadeStore
+	Family      string
+	ProviderEnv []domain.SandboxEnvVar
+}
+
+func startupFamilyHasInput(ctx context.Context, in startupFamilyEnv) bool {
+	config, store, family, providerEnv := in.Config, in.Store, in.Family, in.ProviderEnv
 	if family == llms.ProviderFamilyAnthropic && llms.HasAnthropicEnvProviderInput(providerEnv) {
 		return true
 	}
@@ -129,7 +152,8 @@ func startupGenericInput(ctx context.Context, config *appconfig.Config, store Fa
 	) != ""
 }
 
-func startupFamilyModel(ctx context.Context, config *appconfig.Config, store FacadeStore, family string, providerEnv []domain.SandboxEnvVar) string {
+func startupFamilyModel(ctx context.Context, in startupFamilyEnv) string {
+	config, store, family, providerEnv := in.Config, in.Store, in.Family, in.ProviderEnv
 	if family == llms.ProviderFamilyAnthropic {
 		return firstNonEmpty(
 			llms.SessionAnthropicEnvModel(providerEnv),

--- a/pkg/llms/selection.go
+++ b/pkg/llms/selection.go
@@ -28,13 +28,25 @@ func SelectModel(models []Model, requested string) Model {
 	return models[0]
 }
 
-func SelectModelAndProvider(ctx context.Context, store ProviderModelWireAPIStore, models []Model, providers []Provider, requestedModel, providerFamily, providerID string) (Model, Provider, string, bool, error) {
+// ModelProviderSelection groups SelectModelAndProvider's selection inputs:
+// the candidate models/providers and which model/family/provider was
+// requested.
+type ModelProviderSelection struct {
+	Models         []Model
+	Providers      []Provider
+	RequestedModel string
+	ProviderFamily string
+	ProviderID     string
+}
+
+func SelectModelAndProvider(ctx context.Context, store ProviderModelWireAPIStore, sel ModelProviderSelection) (Model, Provider, string, bool, error) {
+	models, providers, requestedModel, providerFamily, providerID := sel.Models, sel.Providers, sel.RequestedModel, sel.ProviderFamily, sel.ProviderID
 	if strings.TrimSpace(requestedModel) != "" {
 		requested := SelectModel(models, requestedModel)
 		if strings.TrimSpace(requested.ID) == "" {
 			return Model{}, Provider{}, "", false, nil
 		}
-		provider, wireAPI, ok, err := SelectProviderForModel(ctx, store, providers, requested.ID, providerFamily, providerID)
+		provider, wireAPI, ok, err := SelectProviderForModel(ctx, store, ProviderForModelSelection{Providers: providers, ModelID: requested.ID, ProviderFamily: providerFamily, ProviderID: providerID})
 		return requested, provider, wireAPI, ok, err
 	}
 	ordered := append([]Model(nil), models...)
@@ -45,7 +57,7 @@ func SelectModelAndProvider(ctx context.Context, store ProviderModelWireAPIStore
 		return ordered[i].ID < ordered[j].ID
 	})
 	for _, model := range ordered {
-		provider, wireAPI, ok, err := SelectProviderForModel(ctx, store, providers, model.ID, providerFamily, providerID)
+		provider, wireAPI, ok, err := SelectProviderForModel(ctx, store, ProviderForModelSelection{Providers: providers, ModelID: model.ID, ProviderFamily: providerFamily, ProviderID: providerID})
 		if err != nil {
 			return Model{}, Provider{}, "", false, err
 		}
@@ -56,12 +68,21 @@ func SelectModelAndProvider(ctx context.Context, store ProviderModelWireAPIStore
 	return Model{}, Provider{}, "", false, nil
 }
 
-func SelectProviderForModel(ctx context.Context, store ProviderModelWireAPIStore, providers []Provider, modelID, providerFamily, providerID string) (Provider, string, bool, error) {
+// ProviderForModelSelection groups SelectProviderForModel's selection inputs.
+type ProviderForModelSelection struct {
+	Providers      []Provider
+	ModelID        string
+	ProviderFamily string
+	ProviderID     string
+}
+
+func SelectProviderForModel(ctx context.Context, store ProviderModelWireAPIStore, sel ProviderForModelSelection) (Provider, string, bool, error) {
 	type candidate struct {
 		provider Provider
 		wireAPI  string
 		priority int
 	}
+	providers, modelID, providerFamily, providerID := sel.Providers, sel.ModelID, sel.ProviderFamily, sel.ProviderID
 	if strings.TrimSpace(providerFamily) != "" {
 		providerFamily = NormalizeProviderType(providerFamily)
 	}

--- a/pkg/llms/target.go
+++ b/pkg/llms/target.go
@@ -11,10 +11,18 @@ type ProviderModelConfigStore interface {
 	LLMProviderModelConfig(ctx context.Context, providerID, modelID string) (ProviderModelConfig, bool, error)
 }
 
+// ResolvedTargetInput groups BuildResolvedTarget's provider/model/wireAPI selection.
+type ResolvedTargetInput struct {
+	Provider Provider
+	Model    Model
+	WireAPI  string
+}
+
 // BuildResolvedTarget applies provider defaults followed by per-model catalog
 // overrides when the selected model has metadata.
-func BuildResolvedTarget(ctx context.Context, store ProviderModelWireAPIStore, provider Provider, model Model, wireAPI string) (ResolvedTarget, error) {
-	wireAPI = firstNonEmptyTrimmed(wireAPI, provider.DefaultWireAPI)
+func BuildResolvedTarget(ctx context.Context, store ProviderModelWireAPIStore, in ResolvedTargetInput) (ResolvedTarget, error) {
+	provider, model := in.Provider, in.Model
+	wireAPI := firstNonEmptyTrimmed(in.WireAPI, provider.DefaultWireAPI)
 	config := ProviderModelConfig{}
 	if configStore, ok := store.(ProviderModelConfigStore); ok {
 		resolved, found, err := configStore.LLMProviderModelConfig(ctx, provider.ID, model.ID)

--- a/pkg/llms/target_test.go
+++ b/pkg/llms/target_test.go
@@ -35,7 +35,7 @@ func TestBuildResolvedTargetDropsForbiddenPerModelHeaders(t *testing.T) {
 	}
 	model := Model{ID: "model-1", Name: "model-1"}
 
-	target, err := BuildResolvedTarget(context.Background(), store, provider, model, "")
+	target, err := BuildResolvedTarget(context.Background(), store, ResolvedTargetInput{Provider: provider, Model: model})
 	if err != nil {
 		t.Fatalf("BuildResolvedTarget returned error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestBuildResolvedTargetDropsForbiddenPerModelHeaderCaseAndWhitespaceVariant
 			}
 			model := Model{ID: "model-1", Name: "model-1"}
 
-			target, err := BuildResolvedTarget(context.Background(), store, provider, model, "")
+			target, err := BuildResolvedTarget(context.Background(), store, ResolvedTargetInput{Provider: provider, Model: model})
 			if err != nil {
 				t.Fatalf("BuildResolvedTarget returned error: %v", err)
 			}

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -764,10 +764,10 @@ func testConfigStoreLLMBootstrapResolveCoverage(t *testing.T, ctx context.Contex
 	if anthropicTarget.Provider.ProviderType != llms.ProviderFamilyAnthropic || anthropicTarget.WireAPI != llms.APIProtocolMessages || anthropicTarget.Model.ID != "claude-test" {
 		t.Fatalf("Anthropic target = %#v", anthropicTarget)
 	}
-	sessionAnthropicID, err := llms.EnsureSessionAnthropicEnvProvider(ctx, anthropicStore, "session-2", "claude-session", []domain.SandboxEnvVar{
+	sessionAnthropicID, err := llms.EnsureSessionAnthropicEnvProvider(ctx, anthropicStore, llms.SessionEnvProviderQuery{SessionID: "session-2", RequestedModel: "claude-session", EnvItems: []domain.SandboxEnvVar{
 		{Name: "ANTHROPIC_API_KEY", Value: "session-anthropic-key", Secret: true},
 		{Name: "ANTHROPIC_MODEL", Value: "claude-session"},
-	})
+	}})
 	if err != nil || sessionAnthropicID == "" {
 		t.Fatalf("EnsureSessionAnthropicEnvProvider id=%q err=%v", sessionAnthropicID, err)
 	}


### PR DESCRIPTION
## Summary
- Fixed the two private, single-package argument-limit findings that were incorrectly deferred alongside the exported facade family they call into:
  - `resolveCustomOpenAIFacadeTarget` bundled into `customOpenAIFacadeTargetRequest`.
  - `ensureSessionOpenAIEnvProviderWithConfig` now takes the existing `SessionEnvProviderQuery` struct (already used by its Anthropic sibling) instead of inventing a new type — same shape, one less type.
  - `requireClaudeFacadeModel` (test helper) bundled into `claudeFacadeModelCheck`.
  
  Both non-test functions were originally deferred with reasoning copied from the exported family (`EnsureOpenAIEnvProvider` etc.) they call into, but being private and single-package themselves, they don't share that family's cross-package blast radius.

- Dead code found while auditing the package's exported surface (`ac-find-simplifications` pass, 116 funcs + 39 types) — all confirmed zero callers anywhere in the repo:
  - `EnsureSessionOpenAIEnvProvider` + its sole private caller `ensureSessionOpenAIEnvProvider` (dead forwarding wrapper).
  - `IsOptionalConfigError` (dead forwarding wrapper around `isOptionalConfigError`, which is still used internally).
  - `AnthropicProviderAuthFromLookup`.
  - `ManagedRuntimeEnvMap` — had a dedicated test assertion but zero production callers; removed the function and that assertion.

- **Deliberately not touched**: the exported `Ensure*FacadeConfig`/`Resolve*Target`/`NewFacadeToken` family — real cross-package callers in `pkg/agentcompose`, `pkg/runs`, `pkg/storage`. Spot-checked `ResolveRuntimeLLMTargetWithEnv`'s "36 call sites across 4 packages" nolint claim and confirmed it's accurate (14 files across those 4 packages), unlike the false-positive counts found in other packages this pass.
- Same as `pkg/driver`/`pkg/schedulers`/`pkg/sandboxes`/`pkg/runs`: `.golangci.yml` isn't included since other packages aren't done yet.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/llms/...`
- [x] `go vet ./pkg/llms/...`
- [x] Verified via `rg` that all 4 deleted symbols have zero references anywhere in the repo
- [x] Verified this branch builds and tests green in a clean isolated `git worktree` checkout of the commit (not just the local working tree, which has other uncommitted packages coexisting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)