### PR TITLE
refactor(storage): bundle multi-argument params into structs; drop dead code

### DIFF
--- a/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
@@ -338,7 +338,7 @@ func TestSchedulerSandboxRunnerResolvesVolumeMounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateVolume returned error: %v", err)
 	}
-	if err := bridge.configDB.UpsertProjectVolume(ctx, "project-1", "request-cache", projectVolume.ID, false); err != nil {
+	if err := bridge.configDB.UpsertProjectVolume(ctx, "project-1", "request-cache", domain.ProjectVolumeLink{VolumeID: projectVolume.ID}); err != nil {
 		t.Fatalf("UpsertProjectVolume returned error: %v", err)
 	}
 	scheduler := domain.Scheduler{

--- a/pkg/storage/configstore/llm_catalog_store.go
+++ b/pkg/storage/configstore/llm_catalog_store.go
@@ -35,7 +35,9 @@ func (s *llmStore) ApplyModelCatalog(ctx context.Context, catalog llms.ModelCata
 	}
 	sort.Strings(providerIDs)
 	for _, providerID := range providerIDs {
-		if err := applyCatalogProvider(ctx, tx, providerID, catalog.Providers[providerID], now); err != nil {
+		if err := applyCatalogProvider(ctx, tx, catalogProviderUpsert{
+			ProviderID: providerID, Definition: catalog.Providers[providerID], Now: now,
+		}); err != nil {
 			return err
 		}
 	}
@@ -48,7 +50,15 @@ func (s *llmStore) ApplyModelCatalog(ctx context.Context, catalog llms.ModelCata
 	return nil
 }
 
-func applyCatalogProvider(ctx context.Context, tx *sql.Tx, providerID string, definition llms.CatalogProvider, now int64) error {
+// catalogProviderUpsert bundles one provider catalog entry and the apply timestamp.
+type catalogProviderUpsert struct {
+	ProviderID string
+	Definition llms.CatalogProvider
+	Now        int64
+}
+
+func applyCatalogProvider(ctx context.Context, tx *sql.Tx, upsert catalogProviderUpsert) error {
+	providerID, definition, now := upsert.ProviderID, upsert.Definition, upsert.Now
 	protocol := llms.NormalizeWireAPI(pointerString(definition.Protocol))
 	providerType, authHeader, authScheme := llms.ProviderFamilyOpenAI, "Authorization", "Bearer"
 	if protocol == llms.APIProtocolMessages {
@@ -87,14 +97,25 @@ func applyCatalogProvider(ctx context.Context, tx *sql.Tx, providerID string, de
 		return fmt.Errorf("replace provider %q model catalog: %w", providerID, err)
 	}
 	for _, model := range definition.Models {
-		if err := applyCatalogModel(ctx, tx, providerID, protocol, model, now); err != nil {
+		if err := applyCatalogModel(ctx, tx, catalogModelUpsert{
+			ProviderID: providerID, ProviderProtocol: protocol, Definition: model, Now: now,
+		}); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func applyCatalogModel(ctx context.Context, tx *sql.Tx, providerID, providerProtocol string, definition llms.CatalogModel, now int64) error {
+// catalogModelUpsert bundles one provider's model catalog entry and the apply timestamp.
+type catalogModelUpsert struct {
+	ProviderID       string
+	ProviderProtocol string
+	Definition       llms.CatalogModel
+	Now              int64
+}
+
+func applyCatalogModel(ctx context.Context, tx *sql.Tx, upsert catalogModelUpsert) error {
+	providerID, providerProtocol, definition, now := upsert.ProviderID, upsert.ProviderProtocol, upsert.Definition, upsert.Now
 	modelID := strings.TrimSpace(definition.ID)
 	if err := ensureCatalogModelIdentity(ctx, tx, modelID, now); err != nil {
 		return fmt.Errorf("upsert provider %q model %q: %w", providerID, modelID, err)

--- a/pkg/storage/configstore/project_list_test.go
+++ b/pkg/storage/configstore/project_list_test.go
@@ -15,12 +15,48 @@ func TestListProjectsFiltersPagesAndCountsCurrentRevision(t *testing.T) {
 		t.Fatalf("init schema: %v", err)
 	}
 
-	seedProjectListProject(t, store, "project-alpha", "Alpha NEEDLE", "/work/alpha", 2, 300, 0)
-	seedProjectListProject(t, store, "project-beta", "Beta", "/work/needle-beta", 1, 200, 0)
-	seedProjectListProject(t, store, "project-needle-removed", "Removed", "/work/removed", 1, 400, 350)
-	seedProjectListResources(t, store, "project-alpha", 1, "old", true)
-	seedProjectListResources(t, store, "project-alpha", 2, "current", true)
-	seedProjectListResources(t, store, "project-beta", 1, "current", false)
+	seedProjectListProject(t, store, projectListSeed{
+		ID:         "project-alpha",
+		Name:       "Alpha NEEDLE",
+		SourcePath: "/work/alpha",
+		Revision:   2,
+		UpdatedAt:  300,
+		RemovedAt:  0,
+	})
+	seedProjectListProject(t, store, projectListSeed{
+		ID:         "project-beta",
+		Name:       "Beta",
+		SourcePath: "/work/needle-beta",
+		Revision:   1,
+		UpdatedAt:  200,
+		RemovedAt:  0,
+	})
+	seedProjectListProject(t, store, projectListSeed{
+		ID:         "project-needle-removed",
+		Name:       "Removed",
+		SourcePath: "/work/removed",
+		Revision:   1,
+		UpdatedAt:  400,
+		RemovedAt:  350,
+	})
+	seedProjectListResources(t, store, projectListResourceSeed{
+		ProjectID: "project-alpha",
+		Revision:  1,
+		Suffix:    "old",
+		Scheduler: true,
+	})
+	seedProjectListResources(t, store, projectListResourceSeed{
+		ProjectID: "project-alpha",
+		Revision:  2,
+		Suffix:    "current",
+		Scheduler: true,
+	})
+	seedProjectListResources(t, store, projectListResourceSeed{
+		ProjectID: "project-beta",
+		Revision:  1,
+		Suffix:    "current",
+		Scheduler: false,
+	})
 
 	result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: "NeEdLe", Limit: 1})
 	if err != nil {
@@ -71,9 +107,30 @@ func TestListProjectsTreatsSearchMetacharactersLiterally(t *testing.T) {
 		t.Fatalf("init schema: %v", err)
 	}
 
-	seedProjectListProject(t, store, "project-percent", "100% Ready", "/work/percent", 0, 100, 0)
-	seedProjectListProject(t, store, "project-underscore", "Under_score", "/work/underscore", 0, 90, 0)
-	seedProjectListProject(t, store, "project-plain", "Plain", "/work/plain", 0, 80, 0)
+	seedProjectListProject(t, store, projectListSeed{
+		ID:         "project-percent",
+		Name:       "100% Ready",
+		SourcePath: "/work/percent",
+		Revision:   0,
+		UpdatedAt:  100,
+		RemovedAt:  0,
+	})
+	seedProjectListProject(t, store, projectListSeed{
+		ID:         "project-underscore",
+		Name:       "Under_score",
+		SourcePath: "/work/underscore",
+		Revision:   0,
+		UpdatedAt:  90,
+		RemovedAt:  0,
+	})
+	seedProjectListProject(t, store, projectListSeed{
+		ID:         "project-plain",
+		Name:       "Plain",
+		SourcePath: "/work/plain",
+		Revision:   0,
+		UpdatedAt:  80,
+		RemovedAt:  0,
+	})
 
 	for _, test := range []struct {
 		query string
@@ -101,7 +158,14 @@ func TestListProjectsReturnsMoreThanLegacyTwoHundredLimit(t *testing.T) {
 	}
 	for index := range 205 {
 		id := fmt.Sprintf("project-%03d", index)
-		seedProjectListProject(t, store, id, id, "/work/"+id, 0, int64(1000-index), 0)
+		seedProjectListProject(t, store, projectListSeed{
+			ID:         id,
+			Name:       id,
+			SourcePath: "/work/" + id,
+			Revision:   0,
+			UpdatedAt:  int64(1000 - index),
+			RemovedAt:  0,
+		})
 	}
 
 	result, err := store.ListProjects(ctx, domain.ProjectListOptions{Limit: 500, Offset: -10})
@@ -113,18 +177,35 @@ func TestListProjectsReturnsMoreThanLegacyTwoHundredLimit(t *testing.T) {
 	}
 }
 
-func seedProjectListProject(t *testing.T, store *ConfigStore, id, name, sourcePath string, revision, updatedAt, removedAt int64) {
+type projectListSeed struct {
+	ID         string
+	Name       string
+	SourcePath string
+	Revision   int64
+	UpdatedAt  int64
+	RemovedAt  int64
+}
+
+func seedProjectListProject(t *testing.T, store *ConfigStore, seed projectListSeed) {
 	t.Helper()
 	_, err := store.db.Exec(`INSERT INTO project(
 		id, name, short_id, source_path, source_json, current_revision, spec_hash, created_at, updated_at, removed_at
-	) VALUES(?, ?, ?, ?, '{}', ?, '', ?, ?, ?)`, id, name, id, sourcePath, revision, updatedAt, updatedAt, removedAt)
+	) VALUES(?, ?, ?, ?, '{}', ?, '', ?, ?, ?)`, seed.ID, seed.Name, seed.ID, seed.SourcePath, seed.Revision, seed.UpdatedAt, seed.UpdatedAt, seed.RemovedAt)
 	if err != nil {
-		t.Fatalf("seed project %s: %v", id, err)
+		t.Fatalf("seed project %s: %v", seed.ID, err)
 	}
 }
 
-func seedProjectListResources(t *testing.T, store *ConfigStore, projectID string, revision int64, suffix string, scheduler bool) {
+type projectListResourceSeed struct {
+	ProjectID string
+	Revision  int64
+	Suffix    string
+	Scheduler bool
+}
+
+func seedProjectListResources(t *testing.T, store *ConfigStore, seed projectListResourceSeed) {
 	t.Helper()
+	projectID, revision, suffix, scheduler := seed.ProjectID, seed.Revision, seed.Suffix, seed.Scheduler
 	agentName := "agent-" + suffix
 	agentID := projectID + "-" + suffix
 	if _, err := store.db.Exec(`INSERT INTO project_agent(

--- a/pkg/storage/configstore/resource_id_lookup.go
+++ b/pkg/storage/configstore/resource_id_lookup.go
@@ -24,8 +24,12 @@ func (s *ConfigStore) FindResourceIDs(ctx context.Context, options resources.Res
 	}
 	var result []resources.Target
 	if allowed[resources.KindProject] {
-		items, err := queryResourceIDs(ctx, s.db, `SELECT id, name FROM project WHERE removed_at = 0 AND `+clause, args, func(values []string) resources.Target {
-			return resources.Target{Kind: resources.KindProject, ID: values[0], ShortID: identity.ShortID(values[0]), ProjectID: values[0], ProjectName: values[1]}
+		items, err := queryResourceIDs(ctx, s.db, resourceIDQuery{
+			Statement: `SELECT id, name FROM project WHERE removed_at = 0 AND ` + clause,
+			Args:      args,
+			Build: func(values []string) resources.Target {
+				return resources.Target{Kind: resources.KindProject, ID: values[0], ShortID: identity.ShortID(values[0]), ProjectID: values[0], ProjectName: values[1]}
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("find project ids: %w", err)
@@ -34,8 +38,12 @@ func (s *ConfigStore) FindResourceIDs(ctx context.Context, options resources.Res
 	}
 	if allowed[resources.KindAgent] {
 		agentClause, agentArgs, _ := resourceIDClause("pa.id", options.ID)
-		items, err := queryResourceIDs(ctx, s.db, `SELECT pa.id, pa.agent_name, pa.project_id, p.name FROM project_agent pa JOIN project p ON p.id = pa.project_id WHERE p.removed_at = 0 AND `+agentClause, agentArgs, func(values []string) resources.Target {
-			return resources.Target{Kind: resources.KindAgent, ID: values[0], ShortID: identity.ShortID(values[0]), AgentName: values[1], ProjectID: values[2], ProjectName: values[3]}
+		items, err := queryResourceIDs(ctx, s.db, resourceIDQuery{
+			Statement: `SELECT pa.id, pa.agent_name, pa.project_id, p.name FROM project_agent pa JOIN project p ON p.id = pa.project_id WHERE p.removed_at = 0 AND ` + agentClause,
+			Args:      agentArgs,
+			Build: func(values []string) resources.Target {
+				return resources.Target{Kind: resources.KindAgent, ID: values[0], ShortID: identity.ShortID(values[0]), AgentName: values[1], ProjectID: values[2], ProjectName: values[3]}
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("find agent ids: %w", err)
@@ -44,8 +52,12 @@ func (s *ConfigStore) FindResourceIDs(ctx context.Context, options resources.Res
 	}
 	if allowed[resources.KindRun] {
 		runClause, runArgs, _ := resourceIDClause("run_id", options.ID)
-		items, err := queryResourceIDs(ctx, s.db, `SELECT run_id, agent_name, project_id, project_name FROM project_run WHERE `+runClause, runArgs, func(values []string) resources.Target {
-			return resources.Target{Kind: resources.KindRun, ID: values[0], ShortID: identity.ShortID(values[0]), AgentName: values[1], ProjectID: values[2], ProjectName: values[3]}
+		items, err := queryResourceIDs(ctx, s.db, resourceIDQuery{
+			Statement: `SELECT run_id, agent_name, project_id, project_name FROM project_run WHERE ` + runClause,
+			Args:      runArgs,
+			Build: func(values []string) resources.Target {
+				return resources.Target{Kind: resources.KindRun, ID: values[0], ShortID: identity.ShortID(values[0]), AgentName: values[1], ProjectID: values[2], ProjectName: values[3]}
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("find run ids: %w", err)
@@ -87,7 +99,16 @@ func nextResourceIDPrefix(prefix string) string {
 	return "g"
 }
 
-func queryResourceIDs(ctx context.Context, db *sql.DB, statement string, args []any, build func([]string) resources.Target) ([]resources.Target, error) {
+// resourceIDQuery describes one resource-ID lookup statement and how to build a
+// resources.Target from each scanned row.
+type resourceIDQuery struct {
+	Statement string
+	Args      []any
+	Build     func([]string) resources.Target
+}
+
+func queryResourceIDs(ctx context.Context, db *sql.DB, query resourceIDQuery) ([]resources.Target, error) {
+	statement, args, build := query.Statement, query.Args, query.Build
 	rows, err := db.QueryContext(ctx, statement, args...)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/configstore/run_event_store_test.go
+++ b/pkg/storage/configstore/run_event_store_test.go
@@ -40,7 +40,7 @@ func TestProjectRunEventsAreOrderedIdempotentAndCascade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
-	agentID := createRunEventTestAgent(t, ctx, store, project.ID, "worker")
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: project.ID, AgentName: "worker"})
 	createdRun, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{RunID: "run-events", ProjectID: project.ID, AgentName: "worker", AgentID: agentID, SandboxID: "sandbox-events", Status: domain.ProjectRunStatusRunning})
 	if err != nil {
 		t.Fatalf("create run: %v", err)
@@ -116,7 +116,7 @@ func TestProjectRunAndEventsCommitAtomically(t *testing.T) {
 	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-atomic", Name: "atomic"}); err != nil {
 		t.Fatalf("create project: %v", err)
 	}
-	agentID := createRunEventTestAgent(t, ctx, store, "project-atomic", "worker")
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-atomic", AgentName: "worker"})
 	if _, err := store.db.ExecContext(ctx, `CREATE TRIGGER fail_run_event BEFORE INSERT ON project_run_event BEGIN SELECT RAISE(ABORT, 'forced event failure'); END`); err != nil {
 		t.Fatalf("create failure trigger: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestCreateProjectRunWithEventsIsIdempotent(t *testing.T) {
 	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-idempotent", Name: "idempotent"}); err != nil {
 		t.Fatalf("create project: %v", err)
 	}
-	agentID := createRunEventTestAgent(t, ctx, store, "project-idempotent", "worker")
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-idempotent", AgentName: "worker"})
 	run := domain.ProjectRunRecord{
 		RunID:     "run-idempotent",
 		ProjectID: "project-idempotent",
@@ -231,7 +231,7 @@ func TestProjectRunEventSequencesAreAtomicAcrossConnections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
-	agentID := createRunEventTestAgent(t, ctx, store, project.ID, "worker")
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: project.ID, AgentName: "worker"})
 	if _, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{RunID: "run-concurrent-events", ProjectID: project.ID, AgentName: "worker", AgentID: agentID, Status: domain.ProjectRunStatusRunning}); err != nil {
 		t.Fatalf("create run: %v", err)
 	}
@@ -279,13 +279,20 @@ func TestProjectRunEventSequencesAreAtomicAcrossConnections(t *testing.T) {
 	}
 }
 
-func createRunEventTestAgent(t *testing.T, ctx context.Context, store *ConfigStore, projectID, agentName string) string {
+type runEventTestAgentSpec struct {
+	Ctx       context.Context
+	Store     *ConfigStore
+	ProjectID string
+	AgentName string
+}
+
+func createRunEventTestAgent(t *testing.T, spec runEventTestAgentSpec) string {
 	t.Helper()
-	agentID, err := projects.StableProjectAgentID(projectID, agentName)
+	agentID, err := projects.StableProjectAgentID(spec.ProjectID, spec.AgentName)
 	if err != nil {
 		t.Fatalf("derive project agent id: %v", err)
 	}
-	if _, err := store.UpsertProjectAgent(ctx, domain.ProjectAgentRecord{ID: agentID, ProjectID: projectID, AgentName: agentName}); err != nil {
+	if _, err := spec.Store.UpsertProjectAgent(spec.Ctx, domain.ProjectAgentRecord{ID: agentID, ProjectID: spec.ProjectID, AgentName: spec.AgentName}); err != nil {
 		t.Fatalf("create project agent: %v", err)
 	}
 	return agentID

--- a/pkg/storage/configstore/scheduler_run_prune_test.go
+++ b/pkg/storage/configstore/scheduler_run_prune_test.go
@@ -32,7 +32,11 @@ func TestSchedulerRunPruneFiltersAndDeletesDirectRunData(t *testing.T) {
 			t.Fatalf("create run %s: %v", run.ID, err)
 		}
 	}
-	addPruneTestRelations(t, store, "scheduler-a", "run-old-success", "trigger-a")
+	addPruneTestRelations(t, store, pruneTestRelations{
+		SchedulerID: "scheduler-a",
+		RunID:       "run-old-success",
+		TriggerID:   "trigger-a",
+	})
 	if _, err := store.CreateEvent(ctx, domain.TopicEventRecord{
 		ID: "topic-event", Topic: "topic.test", Source: domain.TopicEventSourceSystem,
 		CorrelationID: "correlation-test", PayloadJSON: `{}`, CreatedAt: old,
@@ -71,11 +75,27 @@ func TestSchedulerRunPruneFiltersAndDeletesDirectRunData(t *testing.T) {
 		"event_delivery":     "scheduler_id = 'scheduler-a' AND scheduler_run_id = 'run-old-success'",
 		"event_sandbox_link": "scheduler_id = 'scheduler-a' AND scheduler_run_id = 'run-old-success'",
 	} {
-		assertPruneTestRowCount(t, store, table, where, 0)
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: table,
+			Where: where,
+			Want:  0,
+		})
 	}
-	assertPruneTestRowCount(t, store, "event", "id = 'topic-event'", 1)
-	assertPruneTestRowCount(t, store, "scheduler_run", "run_id = 'run-invocation'", 1)
-	assertPruneTestRowCount(t, store, "scheduler_run", "run_id = 'run-running'", 1)
+	assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+		Table: "event",
+		Where: "id = 'topic-event'",
+		Want:  1,
+	})
+	assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+		Table: "scheduler_run",
+		Where: "run_id = 'run-invocation'",
+		Want:  1,
+	})
+	assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+		Table: "scheduler_run",
+		Where: "run_id = 'run-running'",
+		Want:  1,
+	})
 }
 
 func TestDeleteSchedulerRunPruneDataRollsBackWholeTransaction(t *testing.T) {
@@ -90,7 +110,11 @@ func TestDeleteSchedulerRunPruneDataRollsBackWholeTransaction(t *testing.T) {
 		if err := store.CreateSchedulerRun(ctx, domain.SchedulerRunSummary{ID: runID, SchedulerID: "scheduler-a", TriggerID: "trigger-a", Status: domain.SchedulerRunStatusSucceeded, StartedAt: now, CompletedAt: now}); err != nil {
 			t.Fatalf("create run %s: %v", runID, err)
 		}
-		addPruneTestRelations(t, store, "scheduler-a", runID, "trigger-a")
+		addPruneTestRelations(t, store, pruneTestRelations{
+			SchedulerID: "scheduler-a",
+			RunID:       runID,
+			TriggerID:   "trigger-a",
+		})
 	}
 	if _, err := store.db.ExecContext(ctx, `CREATE TRIGGER block_prune_event BEFORE DELETE ON scheduler_event
 		WHEN OLD.scheduler_run_id = 'run-fail' BEGIN SELECT RAISE(ABORT, 'blocked prune'); END`); err != nil {
@@ -101,10 +125,26 @@ func TestDeleteSchedulerRunPruneDataRollsBackWholeTransaction(t *testing.T) {
 		t.Fatal("DeleteSchedulerRunPruneData returned nil error")
 	}
 	for _, runID := range []string{"run-ok", "run-fail"} {
-		assertPruneTestRowCount(t, store, "scheduler_run", "run_id = '"+runID+"'", 1)
-		assertPruneTestRowCount(t, store, "scheduler_event", "scheduler_run_id = '"+runID+"'", 1)
-		assertPruneTestRowCount(t, store, "event_delivery", "scheduler_run_id = '"+runID+"'", 1)
-		assertPruneTestRowCount(t, store, "event_sandbox_link", "scheduler_run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "scheduler_run",
+			Where: "run_id = '" + runID + "'",
+			Want:  1,
+		})
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "scheduler_event",
+			Where: "scheduler_run_id = '" + runID + "'",
+			Want:  1,
+		})
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "event_delivery",
+			Where: "scheduler_run_id = '" + runID + "'",
+			Want:  1,
+		})
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "event_sandbox_link",
+			Where: "scheduler_run_id = '" + runID + "'",
+			Want:  1,
+		})
 	}
 }
 
@@ -122,7 +162,11 @@ func TestDeleteSchedulerRunPruneDataRechecksTerminalTriggerRun(t *testing.T) {
 		if err := store.CreateSchedulerRun(ctx, run); err != nil {
 			t.Fatalf("create run %s: %v", run.ID, err)
 		}
-		addPruneTestRelations(t, store, "scheduler-a", run.ID, run.TriggerID)
+		addPruneTestRelations(t, store, pruneTestRelations{
+			SchedulerID: "scheduler-a",
+			RunID:       run.ID,
+			TriggerID:   run.TriggerID,
+		})
 	}
 	keys := []schedulers.SchedulerRunKey{{SchedulerID: "scheduler-a", RunID: "run-running"}, {SchedulerID: "scheduler-a", RunID: "run-empty-trigger"}}
 	if counted, err := store.CountSchedulerRunPruneData(ctx, keys); err != nil || counted != (schedulers.SchedulerRunPruneDatabaseStats{}) {
@@ -132,10 +176,26 @@ func TestDeleteSchedulerRunPruneDataRechecksTerminalTriggerRun(t *testing.T) {
 		t.Fatalf("removed=%#v err=%v", removed, err)
 	}
 	for _, runID := range []string{"run-running", "run-empty-trigger"} {
-		assertPruneTestRowCount(t, store, "scheduler_run", "run_id = '"+runID+"'", 1)
-		assertPruneTestRowCount(t, store, "scheduler_event", "scheduler_run_id = '"+runID+"'", 1)
-		assertPruneTestRowCount(t, store, "event_delivery", "scheduler_run_id = '"+runID+"'", 1)
-		assertPruneTestRowCount(t, store, "event_sandbox_link", "scheduler_run_id = '"+runID+"'", 1)
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "scheduler_run",
+			Where: "run_id = '" + runID + "'",
+			Want:  1,
+		})
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "scheduler_event",
+			Where: "scheduler_run_id = '" + runID + "'",
+			Want:  1,
+		})
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "event_delivery",
+			Where: "scheduler_run_id = '" + runID + "'",
+			Want:  1,
+		})
+		assertPruneTestRowCount(t, store, pruneTestRowCountCheck{
+			Table: "event_sandbox_link",
+			Where: "scheduler_run_id = '" + runID + "'",
+			Want:  1,
+		})
 	}
 }
 
@@ -152,27 +212,39 @@ func createPruneTestScheduler(t *testing.T, store *ConfigStore, schedulerID stri
 	}
 }
 
-func addPruneTestRelations(t *testing.T, store *ConfigStore, schedulerID, runID, triggerID string) {
+type pruneTestRelations struct {
+	SchedulerID string
+	RunID       string
+	TriggerID   string
+}
+
+func addPruneTestRelations(t *testing.T, store *ConfigStore, rel pruneTestRelations) {
 	t.Helper()
 	ctx := context.Background()
-	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{ID: "scheduler-event-" + runID, SchedulerID: schedulerID, RunID: runID, TriggerID: triggerID, Type: "scheduler.run.completed", CreatedAt: time.Now().UTC()}); err != nil {
+	if err := store.AddSchedulerEvent(ctx, domain.SchedulerEvent{ID: "scheduler-event-" + rel.RunID, SchedulerID: rel.SchedulerID, RunID: rel.RunID, TriggerID: rel.TriggerID, Type: "scheduler.run.completed", CreatedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("add scheduler event: %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `INSERT INTO event_delivery(event_id, scheduler_id, trigger_id, scheduler_run_id, status, created_at, updated_at) VALUES(?, ?, ?, ?, 'run_succeeded', 1, 1)`, "event-"+runID, schedulerID, triggerID, runID); err != nil {
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO event_delivery(event_id, scheduler_id, trigger_id, scheduler_run_id, status, created_at, updated_at) VALUES(?, ?, ?, ?, 'run_succeeded', 1, 1)`, "event-"+rel.RunID, rel.SchedulerID, rel.TriggerID, rel.RunID); err != nil {
 		t.Fatalf("add event delivery: %v", err)
 	}
-	if _, err := store.db.ExecContext(ctx, `INSERT INTO event_sandbox_link(event_id, sandbox_id, relation, scheduler_id, scheduler_run_id, trigger_id, created_at) VALUES(?, ?, 'used', ?, ?, ?, 1)`, "event-"+runID, "sandbox-"+runID, schedulerID, runID, triggerID); err != nil {
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO event_sandbox_link(event_id, sandbox_id, relation, scheduler_id, scheduler_run_id, trigger_id, created_at) VALUES(?, ?, 'used', ?, ?, ?, 1)`, "event-"+rel.RunID, "sandbox-"+rel.RunID, rel.SchedulerID, rel.RunID, rel.TriggerID); err != nil {
 		t.Fatalf("add event sandbox link: %v", err)
 	}
 }
 
-func assertPruneTestRowCount(t *testing.T, store *ConfigStore, table, where string, want int) {
+type pruneTestRowCountCheck struct {
+	Table string
+	Where string
+	Want  int
+}
+
+func assertPruneTestRowCount(t *testing.T, store *ConfigStore, check pruneTestRowCountCheck) {
 	t.Helper()
 	var count int
-	if err := store.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM "+table+" WHERE "+where).Scan(&count); err != nil {
-		t.Fatalf("count %s: %v", table, err)
+	if err := store.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM "+check.Table+" WHERE "+check.Where).Scan(&count); err != nil {
+		t.Fatalf("count %s: %v", check.Table, err)
 	}
-	if count != want {
-		t.Fatalf("%s count=%d, want %d", table, count, want)
+	if count != check.Want {
+		t.Fatalf("%s count=%d, want %d", check.Table, count, check.Want)
 	}
 }

--- a/pkg/storage/configstore/scheduler_store.go
+++ b/pkg/storage/configstore/scheduler_store.go
@@ -476,10 +476,20 @@ func (s *schedulerStore) AddSchedulerEvent(ctx context.Context, event domain.Sch
 }
 
 func (s *schedulerStore) ListSchedulerEvents(ctx context.Context, schedulerID string, limit int) ([]domain.SchedulerEvent, error) {
-	return s.ListSchedulerEventsBefore(ctx, schedulerID, time.Time{}, "", limit)
+	return s.ListSchedulerEventsBefore(ctx, SchedulerEventsBeforeCursor{SchedulerID: schedulerID, Limit: limit})
 }
 
-func (s *schedulerStore) ListSchedulerEventsBefore(ctx context.Context, schedulerID string, before time.Time, beforeID string, limit int) ([]domain.SchedulerEvent, error) {
+// SchedulerEventsBeforeCursor paginates scheduler events strictly before the given
+// (created_at, event_id) position; a zero Before lists from the most recent event.
+type SchedulerEventsBeforeCursor struct {
+	SchedulerID string
+	Before      time.Time
+	BeforeID    string
+	Limit       int
+}
+
+func (s *schedulerStore) ListSchedulerEventsBefore(ctx context.Context, cursor SchedulerEventsBeforeCursor) ([]domain.SchedulerEvent, error) {
+	schedulerID, before, beforeID, limit := cursor.SchedulerID, cursor.Before, cursor.BeforeID, cursor.Limit
 	if limit <= 0 {
 		limit = 100
 	}

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -451,9 +451,6 @@ func testConfigStoreTopicEventCoverageWorkflows(t *testing.T) {
 	if webhook.Name != "GitHub" || webhook.TokenHeader != "x-github-token" {
 		t.Fatalf("webhook source = %#v", webhook)
 	}
-	if !WebhookSourceTopicMatches("webhook.github.push", "webhook.github.") || WebhookSourceTopicMatches("", "webhook.github.") {
-		t.Fatalf("WebhookSourceTopicMatches returned unexpected values")
-	}
 	if enabled, err := store.ListEnabledWebhookSourcesForTopic(ctx, "webhook.github.push"); err != nil || len(enabled) != 1 {
 		t.Fatalf("ListEnabledWebhookSourcesForTopic enabled=%#v err=%v", enabled, err)
 	}

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -510,10 +510,6 @@ func webhookSourceTopicMatches(topic, topicPrefix string) bool {
 	return strings.HasSuffix(topicPrefix, ".") && topic == strings.TrimSuffix(topicPrefix, ".")
 }
 
-func WebhookSourceTopicMatches(topic, topicPrefix string) bool {
-	return webhookSourceTopicMatches(topic, topicPrefix)
-}
-
 func (s *eventStore) ListWebhookSources(ctx context.Context) ([]domain.WebhookSource, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, name, enabled, provider, topic_prefix, token_hash, token_header, signature_type, signature_secret, body_limit_bytes, created_at, updated_at
 		FROM webhook_source ORDER BY id ASC`)

--- a/pkg/storage/configstore/volume_store.go
+++ b/pkg/storage/configstore/volume_store.go
@@ -189,10 +189,10 @@ func (s *volumeStore) DeleteVolume(ctx context.Context, nameOrID string) error {
 	return nil
 }
 
-func (s *volumeStore) UpsertProjectVolume(ctx context.Context, projectID, key, volumeID string, external bool) error {
+func (s *volumeStore) UpsertProjectVolume(ctx context.Context, projectID, key string, link domain.ProjectVolumeLink) error {
 	projectID = strings.TrimSpace(projectID)
 	key = strings.TrimSpace(key)
-	volumeID = strings.TrimSpace(volumeID)
+	volumeID := strings.TrimSpace(link.VolumeID)
 	if projectID == "" || key == "" || volumeID == "" {
 		return fmt.Errorf("project id, volume key, and volume id are required")
 	}
@@ -200,7 +200,7 @@ func (s *volumeStore) UpsertProjectVolume(ctx context.Context, projectID, key, v
 	_, err := s.db.ExecContext(ctx, `INSERT INTO project_volumes(project_id, volume_key, volume_id, external, created_at, updated_at)
 		VALUES(?, ?, ?, ?, ?, ?)
 		ON CONFLICT(project_id, volume_key) DO UPDATE SET volume_id = excluded.volume_id, external = excluded.external, updated_at = excluded.updated_at`,
-		projectID, key, volumeID, BoolToInt(external), now, now)
+		projectID, key, volumeID, BoolToInt(link.External), now, now)
 	if err != nil {
 		return fmt.Errorf("upsert project volume %s/%s: %w", projectID, key, err)
 	}

--- a/pkg/storage/sandboxstore/sandbox_create.go
+++ b/pkg/storage/sandboxstore/sandbox_create.go
@@ -38,26 +38,50 @@ func (s *Store) CreateSandbox(ctx context.Context, title, baseWorkspace, driver,
 }
 
 func (s *Store) CreateSandboxWithOptions(ctx context.Context, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *SandboxWorkspace, envItems []SandboxEnvVar, tags []SandboxTag, options CreateSandboxOptions) (*Sandbox, error) {
-	return s.createSandboxWithCacheDependencyLock(ctx, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, options)
+	return s.createSandboxWithCacheDependencyLock(ctx, sandboxCreateSpec{
+		Title: title, BaseWorkspace: baseWorkspace, Driver: driver, GuestImage: guestImage,
+		WorkspaceID: workspaceID, TriggerSource: triggerSource, Workspace: workspace,
+		EnvItems: envItems, Tags: tags, Options: options,
+	})
 }
 
-func (s *Store) createSandboxWithCacheDependencyLock(ctx context.Context, title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *SandboxWorkspace, envItems []SandboxEnvVar, tags []SandboxTag, options CreateSandboxOptions) (*Sandbox, error) {
+// sandboxCreateSpec groups the fields the sandbox-creation chain
+// (createSandboxWithCacheDependencyLock -> createSandboxWithOptions) needs.
+// The exported CreateSandbox/CreateSandboxWithOptions keep their existing
+// positional signatures since they have many external callers; only the
+// private chain beneath them is bundled here.
+type sandboxCreateSpec struct {
+	Title         string
+	BaseWorkspace string
+	Driver        string
+	GuestImage    string
+	WorkspaceID   string
+	TriggerSource string
+	Workspace     *SandboxWorkspace
+	EnvItems      []SandboxEnvVar
+	Tags          []SandboxTag
+	Options       CreateSandboxOptions
+}
+
+func (s *Store) createSandboxWithCacheDependencyLock(ctx context.Context, spec sandboxCreateSpec) (*Sandbox, error) {
 	s.cacheDependencyMu.RLock()
 	locker := s.cacheDependencyLocker
 	s.cacheDependencyMu.RUnlock()
 	if locker == nil {
-		return s.createSandboxWithOptions(title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, options)
+		return s.createSandboxWithOptions(spec)
 	}
 	var sandbox *Sandbox
 	err := locker.WithLockContext(ctx, func() error {
 		var err error
-		sandbox, err = s.createSandboxWithOptions(title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, options)
+		sandbox, err = s.createSandboxWithOptions(spec)
 		return err
 	})
 	return sandbox, err
 }
 
-func (s *Store) createSandboxWithOptions(title, baseWorkspace, driver, guestImage, workspaceID, triggerSource string, workspace *SandboxWorkspace, envItems []SandboxEnvVar, tags []SandboxTag, options CreateSandboxOptions) (*Sandbox, error) {
+func (s *Store) createSandboxWithOptions(spec sandboxCreateSpec) (*Sandbox, error) {
+	title, baseWorkspace, driver, guestImage, workspaceID, triggerSource, workspace, envItems, tags, options :=
+		spec.Title, spec.BaseWorkspace, spec.Driver, spec.GuestImage, spec.WorkspaceID, spec.TriggerSource, spec.Workspace, spec.EnvItems, spec.Tags, spec.Options
 	localNow := s.currentTime()
 	now := localNow.UTC()
 	workspaceID = strings.TrimSpace(workspaceID)

--- a/pkg/storage/sandboxstore/store.go
+++ b/pkg/storage/sandboxstore/store.go
@@ -76,10 +76,10 @@ func NewWithConfig(config *appconfig.Config) (*Store, error) {
 	}
 	database, err := storagesqlite.OpenWithMaxOpenConns(dbPath, config.DbTimeout, config.EffectiveSQLiteMaxOpenConns())
 	if err != nil {
-		return newStoreWithIndex(config, nil, dbPath, err, nil)
+		return newStoreWithIndex(config, storeIndexInit{DBPath: dbPath, IndexErr: err})
 	}
 	index, _, indexErr := openSandboxCacheDB(context.Background(), database.DB())
-	store, err := newStoreWithIndex(config, index, dbPath, indexErr, nil)
+	store, err := newStoreWithIndex(config, storeIndexInit{Index: index, DBPath: dbPath, IndexErr: indexErr})
 	if err != nil {
 		return nil, errors.Join(err, database.Close())
 	}
@@ -104,10 +104,19 @@ func NewWithDatabase(config *appconfig.Config, db *sql.DB, projectResolvers ...S
 	if len(projectResolvers) > 0 {
 		projectResolver = projectResolvers[0]
 	}
-	return newStoreWithIndex(config, index, config.DbAddr, err, projectResolver)
+	return newStoreWithIndex(config, storeIndexInit{Index: index, DBPath: config.DbAddr, IndexErr: err, ProjectResolver: projectResolver})
 }
 
-func newStoreWithIndex(config *appconfig.Config, index *sandboxCache, dbPath string, indexErr error, projectResolver SandboxProjectResolver) (*Store, error) {
+// storeIndexInit bundles the sandbox listing cache and the outcome of trying to open it.
+type storeIndexInit struct {
+	Index           *sandboxCache
+	DBPath          string
+	IndexErr        error
+	ProjectResolver SandboxProjectResolver
+}
+
+func newStoreWithIndex(config *appconfig.Config, init storeIndexInit) (*Store, error) {
+	index, dbPath, indexErr, projectResolver := init.Index, init.DBPath, init.IndexErr, init.ProjectResolver
 	if err := os.MkdirAll(config.SandboxRoot, 0o755); err != nil {
 		return nil, closeSandboxCacheAfterStoreInitFailure(index, fmt.Errorf("create sandbox root: %w", err))
 	}

--- a/pkg/storage/sandboxstore/store_workspace_provisioning_create_test.go
+++ b/pkg/storage/sandboxstore/store_workspace_provisioning_create_test.go
@@ -50,13 +50,11 @@ func TestStoreCreateSandboxInitializesWorkspaceProvisioning(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := newCoverageStore(t)
-			created := createSandboxForProvisioningTest(
-				t,
-				store,
-				tt.withOptions,
-				tt.workspaceID,
-				tt.workspace,
-			)
+			created := createSandboxForProvisioningTest(t, store, provisioningTestSandboxSpec{
+				WithOptions: tt.withOptions,
+				WorkspaceID: tt.workspaceID,
+				Workspace:   tt.workspace,
+			})
 
 			assertPendingWorkspaceProvisioning(t, "created sandbox", created.WorkspaceProvisioning)
 			assertWorkspacePathState(t, store, created, false)
@@ -72,7 +70,7 @@ func TestStoreCreateSandboxInitializesWorkspaceProvisioning(t *testing.T) {
 
 func TestStoreCreateSandboxWithoutWorkspaceOmitsWorkspaceProvisioning(t *testing.T) {
 	store := newCoverageStore(t)
-	created := createSandboxForProvisioningTest(t, store, false, "", nil)
+	created := createSandboxForProvisioningTest(t, store, provisioningTestSandboxSpec{})
 	if created.WorkspaceProvisioning != nil {
 		t.Fatalf("created sandbox workspace provisioning = %#v, want nil", created.WorkspaceProvisioning)
 	}
@@ -109,14 +107,15 @@ func assertWorkspacePathState(t *testing.T, store *Store, sandbox *Sandbox, want
 	}
 }
 
-func createSandboxForProvisioningTest(
-	t *testing.T,
-	store *Store,
-	withOptions bool,
-	workspaceID string,
-	workspace *SandboxWorkspace,
-) *Sandbox {
+type provisioningTestSandboxSpec struct {
+	WithOptions bool
+	WorkspaceID string
+	Workspace   *SandboxWorkspace
+}
+
+func createSandboxForProvisioningTest(t *testing.T, store *Store, spec provisioningTestSandboxSpec) *Sandbox {
 	t.Helper()
+	withOptions, workspaceID, workspace := spec.WithOptions, spec.WorkspaceID, spec.Workspace
 	ctx := context.Background()
 	if withOptions {
 		created, err := store.CreateSandboxWithOptions(

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -250,7 +250,9 @@ func TestSandboxProjectProjectionMigrationInvalidatesCache(t *testing.T) {
 		t.Fatalf("migrated sandbox projection version rows = %d, want 0 to force rebuild", versionCount)
 	}
 	assertSandboxProjectColumnsExist(t, ctx, db)
-	assertSQLiteIndexColumns(t, db, "idx_sandboxes_project_updated", []string{"project_id_search", "updated_at", "id"}, []bool{false, true, true})
+	assertSQLiteIndexColumns(t, db, sqliteIndexColumnsExpectation{
+		IndexName: "idx_sandboxes_project_updated", Columns: []string{"project_id_search", "updated_at", "id"}, Descending: []bool{false, true, true},
+	})
 }
 
 func TestBaselineIncludesPreviouslyOmittedSchema(t *testing.T) {
@@ -281,7 +283,9 @@ func TestBaselineIncludesPreviouslyOmittedSchema(t *testing.T) {
 		{name: "idx_event_source_correlation_sequence", columns: []string{"source", "correlation_id", "sequence"}, descending: []bool{false, false, true}},
 	}
 	for _, definition := range indexDefinitions {
-		assertSQLiteIndexColumns(t, db, definition.name, definition.columns, definition.descending)
+		assertSQLiteIndexColumns(t, db, sqliteIndexColumnsExpectation{
+			IndexName: definition.name, Columns: definition.columns, Descending: definition.descending,
+		})
 	}
 }
 
@@ -301,8 +305,15 @@ func assertSandboxProjectColumnsExist(t *testing.T, ctx context.Context, db *sql
 	}
 }
 
-func assertSQLiteIndexColumns(t *testing.T, db *sql.DB, indexName string, columns []string, descending []bool) {
+type sqliteIndexColumnsExpectation struct {
+	IndexName  string
+	Columns    []string
+	Descending []bool
+}
+
+func assertSQLiteIndexColumns(t *testing.T, db *sql.DB, want sqliteIndexColumnsExpectation) {
 	t.Helper()
+	indexName, columns, descending := want.IndexName, want.Columns, want.Descending
 	if len(columns) != len(descending) {
 		t.Fatalf("index %s expectation has %d columns and %d sort directions", indexName, len(columns), len(descending))
 	}

--- a/pkg/storage/sqlite/project_name_migration.go
+++ b/pkg/storage/sqlite/project_name_migration.go
@@ -87,14 +87,14 @@ func renameDuplicateProjects(ctx context.Context, conn migrationConn) error {
 
 func renameDuplicateProject(ctx context.Context, conn migrationConn, project projectNameMigrationRow, newName string) error {
 	if project.currentRevision <= 0 {
-		return updateMigratedProject(ctx, conn, project, newName, 0, "")
+		return updateMigratedProject(ctx, conn, project, migratedProjectRename{NewName: newName})
 	}
 
 	revision, specHash, err := createRenamedProjectRevision(ctx, conn, project, newName)
 	if err != nil {
 		return err
 	}
-	if err := updateMigratedProject(ctx, conn, project, newName, revision, specHash); err != nil {
+	if err := updateMigratedProject(ctx, conn, project, migratedProjectRename{NewName: newName, Revision: revision, SpecHash: specHash}); err != nil {
 		return err
 	}
 	for _, table := range []string{"project_agent", "project_scheduler"} {
@@ -181,7 +181,16 @@ func materializeImplicitProjectVolumeNames(ctx context.Context, conn migrationCo
 	return nil
 }
 
-func updateMigratedProject(ctx context.Context, conn migrationConn, project projectNameMigrationRow, newName string, revision int64, specHash string) error {
+// migratedProjectRename describes the new name (and, if known, the revision it was
+// derived from) to apply to a duplicate-named project during migration.
+type migratedProjectRename struct {
+	NewName  string
+	Revision int64
+	SpecHash string
+}
+
+func updateMigratedProject(ctx context.Context, conn migrationConn, project projectNameMigrationRow, rename migratedProjectRename) error {
+	newName, revision, specHash := rename.NewName, rename.Revision, rename.SpecHash
 	query := `UPDATE project SET name = ? WHERE id = ? AND name = ?`
 	args := []any{newName, project.id, project.name}
 	if revision > 0 {


### PR DESCRIPTION
## Summary
- Fixed the two private sandbox-creation helpers (`createSandboxWithCacheDependencyLock`, `createSandboxWithOptions`) by bundling their shared 10-11 positional params into `sandboxCreateSpec`. The exported `CreateSandbox`/`CreateSandboxWithOptions` keep their existing positional signatures — real external callers (~46 and ~15 call sites, mostly test-only) — only the private chain beneath them needed fixing.
- Verified (and corrected) the original nolint claims for that pair: the "76 call sites across 7 packages" figure included `pkg/driver`, which turned out to be a same-name collision with an unrelated `microsandbox` SDK method (`microsandbox.CreateSandbox`), not this `Store` method at all.
- Fixed 7 test helpers (`seedProjectListProject`, `seedProjectListResources`, `createRunEventTestAgent`, `addPruneTestRelations`, `assertPruneTestRowCount`, `createSandboxForProvisioningTest`, `assertSQLiteIndexColumns`) by bundling their non-`t`/`store` params into small spec structs.
- Verified the four remaining exported interface methods with numeric nolint claims (`ListProjectRunEventsForSandbox`, `MarkSchedulerTriggerFired`, `ClaimEvent`, `ReleaseEventClaim`) — all confirmed genuinely cross-package, left deferred.
- Dropped one dead export found while auditing the package's surface (`ac-find-simplifications` pass): `WebhookSourceTopicMatches` was a forwarding wrapper around `webhookSourceTopicMatches` (still used internally) with zero production callers — only its own dedicated test exercised it. Removed both.
- **Not touched here**: `project_run_completion.go`'s `RecordProjectRunCompletionFailure` — already fixed as part of the `pkg/runs` branch (#604, not yet merged) since `pkg/runs/completion.go`'s interface required it; redoing it here would just conflict at merge time.
- Same as prior PRs in this series: `.golangci.yml` isn't included since other packages aren't done yet.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/storage/...`
- [x] `go vet ./pkg/storage/...`
- [x] Verified this branch builds and tests green in a clean isolated `git worktree` checkout of the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)