### PR TITLE
refactor(projects): bundle multi-argument params into structs; split ReconcileSchedulers

### DIFF
--- a/pkg/images/ensure.go
+++ b/pkg/images/ensure.go
@@ -16,20 +16,27 @@ type EnsureRequest struct {
 	AgentName   string
 }
 
-func EnsureProjectAgentImages(ctx context.Context, config *appconfig.Config, backend Backend, projectName string, agents []domain.ProjectAgentRecord) error {
+// ProjectAgentImagesRequest identifies the project and agents to ensure
+// driver images for.
+type ProjectAgentImagesRequest struct {
+	ProjectName string
+	Agents      []domain.ProjectAgentRecord
+}
+
+func EnsureProjectAgentImages(ctx context.Context, config *appconfig.Config, backend Backend, req ProjectAgentImagesRequest) error {
 	if config == nil {
 		return fmt.Errorf("image ensure config is required")
 	}
-	for _, agent := range agents {
+	for _, agent := range req.Agents {
 		driver, err := driverpkg.ResolveSandboxRuntimeDriver(agent.Driver, config.RuntimeDriver)
 		if err != nil {
-			return fmt.Errorf("ensure image for project %s agent %s: %w", projectName, agent.AgentName, err)
+			return fmt.Errorf("ensure image for project %s agent %s: %w", req.ProjectName, agent.AgentName, err)
 		}
 		imageRef := driverpkg.ResolveSandboxGuestImage(agent.Image, driverpkg.DefaultGuestImageForDriver(config, driver))
 		if err := EnsureDriverImage(ctx, config, backend, EnsureRequest{
 			Driver:      driver,
 			ImageRef:    imageRef,
-			ProjectName: projectName,
+			ProjectName: req.ProjectName,
 			AgentName:   agent.AgentName,
 		}); err != nil {
 			return err

--- a/pkg/projects/controller.go
+++ b/pkg/projects/controller.go
@@ -297,7 +297,7 @@ func (c *Controller) applyProject(ctx context.Context, req ApplyRequest, lifecyc
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	agentRecords, agentDefinitions, schedulerRecords, schedulerDefinitions, err := c.projectArtifacts(ctx, project, 0, normalized)
+	agentRecords, agentDefinitions, schedulerRecords, _, err := c.projectArtifacts(ctx, project, 0, normalized)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project %s: %w", ErrInvalidRequest, normalized.Spec.Name, err)
 	}
@@ -307,13 +307,16 @@ func (c *Controller) applyProject(ctx context.Context, req ApplyRequest, lifecyc
 			Revision:     domain.ProjectRevisionRecord{ProjectID: project.ID, SpecHash: normalized.SpecHash},
 			Agents:       agentRecords,
 			Schedulers:   schedulerRecords,
-			Changes:      dryRunChanges(project, agentRecords, agentDefinitions, schedulerRecords, schedulerDefinitions),
+			Changes:      dryRunChanges(project, agentRecords, agentDefinitions, schedulerRecords),
 			Applied:      false,
 			Issues:       append(req.Issues, warnings...),
 			RevisionSpec: normalized.Spec,
 		}, nil
 	}
-	if err := images.EnsureProjectAgentImages(ctx, c.config, c.images, normalized.Spec.Name, agentRecords); err != nil {
+	if err := images.EnsureProjectAgentImages(ctx, c.config, c.images, images.ProjectAgentImagesRequest{
+		ProjectName: normalized.Spec.Name,
+		Agents:      agentRecords,
+	}); err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project %s: %w", ErrUnavailable, normalized.Spec.Name, err)
 	}
 	if err := c.ensureProjectVolumes(ctx, project, normalized.Spec); err != nil {
@@ -345,11 +348,17 @@ func (c *Controller) applyProject(ctx context.Context, req ApplyRequest, lifecyc
 		return ApplyResult{}, fmt.Errorf("apply project %s: reload project: %w", normalized.Spec.Name, err)
 	}
 
-	agentRecords, agentDefinitions, schedulerRecords, schedulerDefinitions, err = c.projectArtifacts(ctx, project, revision.Revision, normalized)
+	agentRecords, agentDefinitions, schedulerRecords, schedulerDefinitions, err := c.projectArtifacts(ctx, project, revision.Revision, normalized)
 	if err != nil {
 		return ApplyResult{}, fmt.Errorf("%w: apply project %s: %w", ErrInvalidRequest, normalized.Spec.Name, err)
 	}
-	changes := applyChanges(project, existingProject, projectFound, revision, revisionCreated)
+	changes := applyChanges(applyChangesInput{
+		Project:         project,
+		Existing:        existingProject,
+		Found:           projectFound,
+		Revision:        revision,
+		RevisionCreated: revisionCreated,
+	})
 	agentsUnchanged := true
 	agentActions := make(map[string]string, len(agentRecords))
 	for _, agent := range agentRecords {
@@ -386,7 +395,11 @@ func (c *Controller) applyProject(ctx context.Context, req ApplyRequest, lifecyc
 			Name:         definition.Name,
 		})
 	}
-	schedulerChanges, schedulersUnchanged, err := ReconcileSchedulers(ctx, c.store, project, schedulerRecords, schedulerDefinitions, ReconcileSchedulerOptions{
+	schedulerChanges, schedulersUnchanged, err := ReconcileSchedulers(ctx, c.store, ReconcileSchedulersRequest{
+		Project:     project,
+		Schedulers:  schedulerRecords,
+		Definitions: schedulerDefinitions,
+	}, ReconcileSchedulerOptions{
 		CleanupFailedScheduler: c.cleanupFailedSchedulerReconcile,
 		RefreshSchedulers:      c.refreshSchedulers,
 	})
@@ -609,7 +622,12 @@ func (c *Controller) resolveProjectRef(ctx context.Context, ref ProjectRef, incl
 	} else if ref.kind != projectRefName {
 		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project selector is required", nil)
 	}
-	return resolveProjectByExactMatch(ctx, c.store, query, true, selectorName, projectValue)
+	return resolveProjectByExactMatch(ctx, c.store, exactMatchRequest{
+		Value:          query,
+		IncludeRemoved: true,
+		SelectorName:   selectorName,
+		FieldValue:     projectValue,
+	})
 }
 
 func (c *Controller) projectArtifacts(ctx context.Context, project domain.ProjectRecord, revision int64, normalized NormalizedProject) ([]domain.ProjectAgentRecord, []domain.AgentDefinition, []domain.ProjectSchedulerRecord, []domain.Scheduler, error) {
@@ -779,25 +797,35 @@ func (c *Controller) getProjectAgentIfExists(ctx context.Context, projectID, age
 	return domain.ProjectAgentRecord{}, false, err
 }
 
-func applyChanges(project, existing domain.ProjectRecord, found bool, revision domain.ProjectRevisionRecord, revisionCreated bool) []Change {
+// applyChangesInput describes the before/after state of a project apply used
+// to compute the resulting Change log.
+type applyChangesInput struct {
+	Project         domain.ProjectRecord
+	Existing        domain.ProjectRecord
+	Found           bool
+	Revision        domain.ProjectRevisionRecord
+	RevisionCreated bool
+}
+
+func applyChanges(in applyChangesInput) []Change {
 	projectAction := ChangeActionCreated
-	if found {
+	if in.Found {
 		projectAction = ChangeActionUnchanged
-		if !ProjectRecordUnchanged(existing, project) {
+		if !ProjectRecordUnchanged(in.Existing, in.Project) {
 			projectAction = ChangeActionUpdated
 		}
 	}
 	revisionAction := ChangeActionUnchanged
-	if revisionCreated {
+	if in.RevisionCreated {
 		revisionAction = ChangeActionCreated
 	}
 	return []Change{
-		{Action: projectAction, ResourceType: "project", ResourceID: project.ID, Name: project.Name},
-		{Action: revisionAction, ResourceType: "project_revision", ResourceID: fmt.Sprintf("%s/%d", revision.ProjectID, revision.Revision), Name: revision.SpecHash},
+		{Action: projectAction, ResourceType: "project", ResourceID: in.Project.ID, Name: in.Project.Name},
+		{Action: revisionAction, ResourceType: "project_revision", ResourceID: fmt.Sprintf("%s/%d", in.Revision.ProjectID, in.Revision.Revision), Name: in.Revision.SpecHash},
 	}
 }
 
-func dryRunChanges(project domain.ProjectRecord, agents []domain.ProjectAgentRecord, agentDefinitions []domain.AgentDefinition, schedulers []domain.ProjectSchedulerRecord, _ []domain.Scheduler) []Change {
+func dryRunChanges(project domain.ProjectRecord, agents []domain.ProjectAgentRecord, agentDefinitions []domain.AgentDefinition, schedulers []domain.ProjectSchedulerRecord) []Change {
 	changes := []Change{{Action: ChangeActionCreated, ResourceType: "project", ResourceID: project.ID, Name: project.Name}}
 	for _, agent := range agents {
 		changes = append(changes, Change{Action: ChangeActionCreated, ResourceType: "project_agent", ResourceID: agent.ID, Name: agent.AgentName})

--- a/pkg/projects/controller_coverage_test.go
+++ b/pkg/projects/controller_coverage_test.go
@@ -114,7 +114,11 @@ func TestControllerRemoveProjectMarksProjectRemovedAndIsIdempotent(t *testing.T)
 	if removed.Project.RemovedAt.IsZero() {
 		t.Fatalf("RemoveProject project was not marked removed: %#v", removed.Project)
 	}
-	assertProjectChange(t, removed.Changes, ChangeActionRemoved, "project", "project-1")
+	assertProjectChange(t, removed.Changes, changeExpectation{
+		Action:       ChangeActionRemoved,
+		ResourceType: "project",
+		ResourceID:   "project-1",
+	})
 	if result, err := store.ListProjects(ctx, domain.ProjectListOptions{}); err != nil || result.TotalCount != 0 {
 		t.Fatalf("ListProjects after remove result=%#v err=%v", result, err)
 	}
@@ -260,10 +264,26 @@ func TestDownProjectSandboxAndSchedulerWorkflows(t *testing.T) {
 	if len(sessionStore.listOptions) != 1 || sessionStore.listOptions[0].ProjectID != "" || sessionStore.listOptions[0].VMStatus != domain.VMStatusRunning {
 		t.Fatalf("sandbox list options = %#v, want all running sandboxes without project prefilter", sessionStore.listOptions)
 	}
-	assertDownChange(t, changes, DownChangeUpdated, "scheduler", "scheduler-1")
-	assertDownChange(t, changes, DownChangeUnchanged, "sandbox", "session-fail")
-	assertDownChange(t, changes, DownChangeUpdated, "sandbox", "session-ok")
-	assertDownChange(t, changes, DownChangeUpdated, "sandbox", "session-legacy")
+	assertDownChange(t, changes, changeExpectation{
+		Action:       DownChangeUpdated,
+		ResourceType: "scheduler",
+		ResourceID:   "scheduler-1",
+	})
+	assertDownChange(t, changes, changeExpectation{
+		Action:       DownChangeUnchanged,
+		ResourceType: "sandbox",
+		ResourceID:   "session-fail",
+	})
+	assertDownChange(t, changes, changeExpectation{
+		Action:       DownChangeUpdated,
+		ResourceType: "sandbox",
+		ResourceID:   "session-ok",
+	})
+	assertDownChange(t, changes, changeExpectation{
+		Action:       DownChangeUpdated,
+		ResourceType: "sandbox",
+		ResourceID:   "session-legacy",
+	})
 	if !DownChangesHaveFailures(changes) || DownChangesHaveFailures(nil) {
 		t.Fatalf("DownChangesHaveFailures(%#v) returned unexpected result", changes)
 	}
@@ -465,14 +485,20 @@ func (m *controllerCoverageVolumeManager) RemoveProjectVolumes(_ context.Context
 	return m.removeErr
 }
 
-func assertProjectChange(t *testing.T, changes []Change, action, resourceType, resourceID string) {
+type changeExpectation struct {
+	Action       string
+	ResourceType string
+	ResourceID   string
+}
+
+func assertProjectChange(t *testing.T, changes []Change, want changeExpectation) {
 	t.Helper()
 	for _, change := range changes {
-		if change.Action == action && change.ResourceType == resourceType && change.ResourceID == resourceID {
+		if change.Action == want.Action && change.ResourceType == want.ResourceType && change.ResourceID == want.ResourceID {
 			return
 		}
 	}
-	t.Fatalf("changes %#v did not contain %s %s %s", changes, action, resourceType, resourceID)
+	t.Fatalf("changes %#v did not contain %s %s %s", changes, want.Action, want.ResourceType, want.ResourceID)
 }
 
 type downCoverageStore struct {
@@ -508,12 +534,12 @@ func (s *downCoverageSessions) ListSandboxes(_ context.Context, options domain.S
 	return domain.SandboxListResult{Sandboxes: s.sessions}, s.err
 }
 
-func assertDownChange(t *testing.T, changes []DownChange, action, resourceType, resourceID string) {
+func assertDownChange(t *testing.T, changes []DownChange, want changeExpectation) {
 	t.Helper()
 	for _, change := range changes {
-		if change.Action == action && change.ResourceType == resourceType && change.ResourceID == resourceID {
+		if change.Action == want.Action && change.ResourceType == want.ResourceType && change.ResourceID == want.ResourceID {
 			return
 		}
 	}
-	t.Fatalf("changes %#v did not contain %s %s %s", changes, action, resourceType, resourceID)
+	t.Fatalf("changes %#v did not contain %s %s %s", changes, want.Action, want.ResourceType, want.ResourceID)
 }

--- a/pkg/projects/project_ref.go
+++ b/pkg/projects/project_ref.go
@@ -66,46 +66,52 @@ func ResolveProjectRef(ctx context.Context, store ProjectRefStore, ref ProjectRe
 	case projectRefID:
 		return store.GetProject(ctx, value)
 	case projectRefName:
-		return resolveProjectByExactMatch(ctx, store, value, false, "name", func(project domain.ProjectRecord) string {
-			return project.Name
+		return resolveProjectByExactMatch(ctx, store, exactMatchRequest{
+			Value:        value,
+			SelectorName: "name",
+			FieldValue:   func(project domain.ProjectRecord) string { return project.Name },
 		})
 	case projectRefSourcePath:
 		value = NormalizeProjectSourcePath(value)
-		return resolveProjectByExactMatch(ctx, store, value, false, "source path", func(project domain.ProjectRecord) string {
-			return NormalizeProjectSourcePath(project.SourcePath)
+		return resolveProjectByExactMatch(ctx, store, exactMatchRequest{
+			Value:        value,
+			SelectorName: "source path",
+			FieldValue:   func(project domain.ProjectRecord) string { return NormalizeProjectSourcePath(project.SourcePath) },
 		})
 	default:
 		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrRequired, "project selector is required", nil)
 	}
 }
 
-func resolveProjectByExactMatch(
-	ctx context.Context,
-	store ProjectRefStore,
-	value string,
-	includeRemoved bool,
-	selectorName string,
-	projectValue func(domain.ProjectRecord) string,
-) (domain.ProjectRecord, error) {
-	if selectorName == "name" {
+// exactMatchRequest describes an exact-match project lookup by a single
+// selector field (name or source path).
+type exactMatchRequest struct {
+	Value          string
+	IncludeRemoved bool
+	SelectorName   string
+	FieldValue     func(domain.ProjectRecord) string
+}
+
+func resolveProjectByExactMatch(ctx context.Context, store ProjectRefStore, req exactMatchRequest) (domain.ProjectRecord, error) {
+	if req.SelectorName == "name" {
 		if nameStore, ok := store.(projectNameStore); ok {
-			return nameStore.GetProjectByName(ctx, value, includeRemoved)
+			return nameStore.GetProjectByName(ctx, req.Value, req.IncludeRemoved)
 		}
 	}
-	if selectorName == "source path" {
+	if req.SelectorName == "source path" {
 		if sourcePathStore, ok := store.(projectSourcePathStore); ok {
-			return sourcePathStore.GetProjectBySourcePath(ctx, value, includeRemoved)
+			return sourcePathStore.GetProjectBySourcePath(ctx, req.Value, req.IncludeRemoved)
 		}
 	}
 	const pageSize = 200
 	var matches []domain.ProjectRecord
 	for offset := 0; ; offset += pageSize {
-		result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: value, IncludeRemoved: includeRemoved, Offset: offset, Limit: pageSize})
+		result, err := store.ListProjects(ctx, domain.ProjectListOptions{Query: req.Value, IncludeRemoved: req.IncludeRemoved, Offset: offset, Limit: pageSize})
 		if err != nil {
 			return domain.ProjectRecord{}, err
 		}
 		for _, project := range result.Projects {
-			if projectValue(project) == value {
+			if req.FieldValue(project) == req.Value {
 				matches = append(matches, project)
 			}
 		}
@@ -114,10 +120,10 @@ func resolveProjectByExactMatch(
 		}
 	}
 	if len(matches) == 0 {
-		return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", value, fmt.Sprintf("project with %s %s not found", selectorName, value), sql.ErrNoRows)
+		return domain.ProjectRecord{}, domain.ResourceError(domain.ErrNotFound, "project", req.Value, fmt.Sprintf("project with %s %s not found", req.SelectorName, req.Value), sql.ErrNoRows)
 	}
 	if len(matches) > 1 {
-		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrAmbiguous, fmt.Sprintf("project %s %s is ambiguous; use project_id", selectorName, value), nil)
+		return domain.ProjectRecord{}, domain.ClassifyError(domain.ErrAmbiguous, fmt.Sprintf("project %s %s is ambiguous; use project_id", req.SelectorName, req.Value), nil)
 	}
 	return matches[0], nil
 }

--- a/pkg/projects/reconcile.go
+++ b/pkg/projects/reconcile.go
@@ -37,13 +37,46 @@ type ReconcileSchedulerOptions struct {
 	RefreshSchedulers      func(ctx context.Context) error
 }
 
-func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, project domain.ProjectRecord, schedulers []domain.ProjectSchedulerRecord, definitions []domain.Scheduler, options ReconcileSchedulerOptions) ([]Change, bool, error) {
+// ReconcileSchedulersRequest describes the project schedulers to reconcile
+// against their scheduler definitions.
+type ReconcileSchedulersRequest struct {
+	Project     domain.ProjectRecord
+	Schedulers  []domain.ProjectSchedulerRecord
+	Definitions []domain.Scheduler
+}
+
+func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, req ReconcileSchedulersRequest, options ReconcileSchedulerOptions) ([]Change, bool, error) {
 	if store == nil {
 		return nil, false, fmt.Errorf("config store is required")
 	}
+	changes, currentByID, unchanged, err := reconcileCurrentSchedulers(ctx, store, req, options)
+	if err != nil {
+		return changes, false, err
+	}
+	removedChanges, removedUnchanged, err := disableRemovedSchedulers(ctx, store, req, currentByID)
+	changes = append(changes, removedChanges...)
+	if err != nil {
+		return changes, false, err
+	}
+	if !removedUnchanged {
+		unchanged = false
+	}
+	if options.RefreshSchedulers != nil {
+		if err := options.RefreshSchedulers(ctx); err != nil {
+			return changes, false, fmt.Errorf("refresh scheduler controller: %w", err)
+		}
+	}
+	return changes, unchanged, nil
+}
+
+// reconcileCurrentSchedulers upserts each scheduler present in req.Schedulers,
+// returning the schedulers seen so disableRemovedSchedulers can identify the
+// ones that dropped out of the spec.
+func reconcileCurrentSchedulers(ctx context.Context, store ReconcileSchedulerStore, req ReconcileSchedulersRequest, options ReconcileSchedulerOptions) ([]Change, map[string]domain.ProjectSchedulerRecord, bool, error) {
+	schedulers := req.Schedulers
 	currentByID := make(map[string]domain.ProjectSchedulerRecord, len(schedulers))
-	definitionsByID := make(map[string]domain.Scheduler, len(definitions))
-	for _, definition := range definitions {
+	definitionsByID := make(map[string]domain.Scheduler, len(req.Definitions))
+	for _, definition := range req.Definitions {
 		definitionsByID[definition.Summary.ID] = definition
 	}
 	changes := make([]Change, 0, len(schedulers))
@@ -52,17 +85,17 @@ func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, pro
 		currentByID[scheduler.SchedulerID] = scheduler
 		existing, found, err := projectSchedulerIfExists(ctx, store, scheduler.ProjectID, scheduler.SchedulerID)
 		if err != nil {
-			return changes, false, fmt.Errorf("load project scheduler %s/%s: %w", scheduler.ProjectID, scheduler.SchedulerID, err)
+			return changes, currentByID, false, fmt.Errorf("load project scheduler %s/%s: %w", scheduler.ProjectID, scheduler.SchedulerID, err)
 		}
 		definition, ok := definitionsByID[scheduler.ID]
 		if !ok {
-			return changes, false, fmt.Errorf("scheduler definition %s for scheduler %s is missing", scheduler.ID, scheduler.SchedulerID)
+			return changes, currentByID, false, fmt.Errorf("scheduler definition %s for scheduler %s is missing", scheduler.ID, scheduler.SchedulerID)
 		}
 		var existingScheduler domain.Scheduler
 		if found {
 			existingScheduler, err = store.GetScheduler(ctx, definition.Summary.ID)
 			if err != nil {
-				return changes, false, fmt.Errorf("load scheduler %s: %w", definition.Summary.ID, err)
+				return changes, currentByID, false, fmt.Errorf("load scheduler %s: %w", definition.Summary.ID, err)
 			}
 		}
 		if found && SchedulerRecordUnchanged(existing, scheduler) && SchedulerDefinitionUnchanged(existingScheduler, definition) {
@@ -78,18 +111,18 @@ func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, pro
 		stagedScheduler.Enabled = false
 		saved, err := store.UpsertProjectScheduler(ctx, stagedScheduler)
 		if err != nil {
-			return changes, false, fmt.Errorf("stage project scheduler %s/%s disabled: %w", scheduler.ProjectID, scheduler.SchedulerID, err)
+			return changes, currentByID, false, fmt.Errorf("stage project scheduler %s/%s disabled: %w", scheduler.ProjectID, scheduler.SchedulerID, err)
 		}
 
 		if _, err := store.ReplaceSchedulerTriggers(ctx, saved.ID, definition.Triggers); err != nil {
 			cleanupFailedScheduler(ctx, options, saved, saved.ID)
-			return changes, false, fmt.Errorf("replace scheduler triggers %s: %w", saved.ID, err)
+			return changes, currentByID, false, fmt.Errorf("replace scheduler triggers %s: %w", saved.ID, err)
 		}
 		if scheduler.Enabled {
 			enabledScheduler, enableErr := store.SetProjectSchedulerEnabled(ctx, scheduler.ProjectID, scheduler.SchedulerID, true)
 			if enableErr != nil {
 				cleanupFailedScheduler(ctx, options, stagedScheduler, saved.ID)
-				return changes, false, fmt.Errorf("enable project scheduler %s/%s: %w", scheduler.ProjectID, scheduler.SchedulerID, enableErr)
+				return changes, currentByID, false, fmt.Errorf("enable project scheduler %s/%s: %w", scheduler.ProjectID, scheduler.SchedulerID, enableErr)
 			}
 			saved = enabledScheduler
 		} else {
@@ -110,10 +143,18 @@ func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, pro
 			Name:         saved.AgentName,
 		})
 	}
-	existingSchedulers, err := store.ListProjectSchedulers(ctx, project.ID)
+	return changes, currentByID, unchanged, nil
+}
+
+// disableRemovedSchedulers disables any project scheduler that is no longer
+// present in currentByID (i.e. dropped from the project spec).
+func disableRemovedSchedulers(ctx context.Context, store ReconcileSchedulerStore, req ReconcileSchedulersRequest, currentByID map[string]domain.ProjectSchedulerRecord) ([]Change, bool, error) {
+	existingSchedulers, err := store.ListProjectSchedulers(ctx, req.Project.ID)
 	if err != nil {
-		return changes, false, fmt.Errorf("list project schedulers: %w", err)
+		return nil, false, fmt.Errorf("list project schedulers: %w", err)
 	}
+	changes := make([]Change, 0, len(existingSchedulers))
+	unchanged := true
 	for _, existing := range existingSchedulers {
 		if _, ok := currentByID[existing.SchedulerID]; ok {
 			continue
@@ -133,11 +174,6 @@ func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, pro
 			Name:         disabled.AgentName,
 			Message:      "disabled because the scheduler is no longer present in the project spec",
 		})
-	}
-	if options.RefreshSchedulers != nil {
-		if err := options.RefreshSchedulers(ctx); err != nil {
-			return changes, false, fmt.Errorf("refresh scheduler controller: %w", err)
-		}
 	}
 	return changes, unchanged, nil
 }

--- a/pkg/projects/reconcile_scheduler_test.go
+++ b/pkg/projects/reconcile_scheduler_test.go
@@ -63,7 +63,7 @@ func TestReconcileSchedulersReportsUnifiedSchedulerStateChanges(t *testing.T) {
 				store.existingRecord = &existingRecord
 			}
 
-			changes, unchanged, err := ReconcileSchedulers(context.Background(), store, project, []domain.ProjectSchedulerRecord{record}, []domain.Scheduler{definition}, ReconcileSchedulerOptions{})
+			changes, unchanged, err := ReconcileSchedulers(context.Background(), store, ReconcileSchedulersRequest{Project: project, Schedulers: []domain.ProjectSchedulerRecord{record}, Definitions: []domain.Scheduler{definition}}, ReconcileSchedulerOptions{})
 			if err != nil {
 				t.Fatalf("ReconcileSchedulers returned error: %v", err)
 			}
@@ -96,7 +96,7 @@ func TestReconcileSchedulersRemovalIsIdempotent(t *testing.T) {
 			existing := record
 			existing.Enabled = tt.enabled
 			store := &schedulerReconcileStateStore{existingRecord: &existing, listedRecords: []domain.ProjectSchedulerRecord{existing}, listConfigured: true}
-			changes, unchanged, err := ReconcileSchedulers(context.Background(), store, project, nil, nil, ReconcileSchedulerOptions{})
+			changes, unchanged, err := ReconcileSchedulers(context.Background(), store, ReconcileSchedulersRequest{Project: project}, ReconcileSchedulerOptions{})
 			if err != nil {
 				t.Fatalf("ReconcileSchedulers returned error: %v", err)
 			}
@@ -140,7 +140,7 @@ func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T)
 				enableErr:          tt.enableErr,
 			}
 			cleanupID := ""
-			changes, unchanged, err := ReconcileSchedulers(context.Background(), store, project, []domain.ProjectSchedulerRecord{currentRecord}, []domain.Scheduler{currentDefinition}, ReconcileSchedulerOptions{
+			changes, unchanged, err := ReconcileSchedulers(context.Background(), store, ReconcileSchedulersRequest{Project: project, Schedulers: []domain.ProjectSchedulerRecord{currentRecord}, Definitions: []domain.Scheduler{currentDefinition}}, ReconcileSchedulerOptions{
 				CleanupFailedScheduler: func(_ context.Context, _ domain.ProjectSchedulerRecord, schedulerID string) {
 					cleanupID = schedulerID
 				},
@@ -291,7 +291,7 @@ func TestReconcileSchedulersSkipsWritesForUnchangedScheduler(t *testing.T) {
 	}
 	store := &unchangedSchedulerReconcileStore{scheduler: scheduler, definition: definition}
 
-	changes, unchanged, err := ReconcileSchedulers(context.Background(), store, project, []domain.ProjectSchedulerRecord{scheduler}, []domain.Scheduler{definition}, ReconcileSchedulerOptions{})
+	changes, unchanged, err := ReconcileSchedulers(context.Background(), store, ReconcileSchedulersRequest{Project: project, Schedulers: []domain.ProjectSchedulerRecord{scheduler}, Definitions: []domain.Scheduler{definition}}, ReconcileSchedulerOptions{})
 	if err != nil {
 		t.Fatalf("ReconcileSchedulers returned error: %v", err)
 	}

--- a/pkg/projects/records.go
+++ b/pkg/projects/records.go
@@ -86,7 +86,7 @@ func NewAgentRecordsFromSpec(projectID string, revision int64, spec *compose.Nor
 func NewAgentDefinitionsFromSpec(project domain.ProjectRecord, revision int64, spec *compose.NormalizedProjectSpec) ([]domain.AgentDefinition, error) {
 	agents := make([]domain.AgentDefinition, 0, len(spec.Agents))
 	for _, agent := range spec.Agents {
-		record, err := NewAgentDefinitionFromSpec(project, revision, agent, spec.MCPServers, spec.OctoBusServers)
+		record, err := NewAgentDefinitionFromSpec(project, revision, agent, AgentDefinitionProjectRefs{MCPServers: spec.MCPServers, OctoBusServers: spec.OctoBusServers})
 		if err != nil {
 			return nil, err
 		}
@@ -95,12 +95,19 @@ func NewAgentDefinitionsFromSpec(project domain.ProjectRecord, revision int64, s
 	return agents, nil
 }
 
-func NewAgentDefinitionFromSpec(project domain.ProjectRecord, revision int64, agent compose.NormalizedAgentSpec, projectMCPServers map[string]compose.NormalizedMCPServerSpec, projectOctoBusServers map[string]compose.NormalizedOctoBusServerSpec) (domain.AgentDefinition, error) {
+// AgentDefinitionProjectRefs holds the project-level MCP/OctoBus server
+// definitions an agent's config may reference by name.
+type AgentDefinitionProjectRefs struct {
+	MCPServers     map[string]compose.NormalizedMCPServerSpec
+	OctoBusServers map[string]compose.NormalizedOctoBusServerSpec
+}
+
+func NewAgentDefinitionFromSpec(project domain.ProjectRecord, revision int64, agent compose.NormalizedAgentSpec, projectRefs AgentDefinitionProjectRefs) (domain.AgentDefinition, error) {
 	projectAgentID, err := StableProjectAgentID(project.ID, agent.Name)
 	if err != nil {
 		return domain.AgentDefinition{}, err
 	}
-	configJSON, err := agentDefinitionConfigJSON(agent, projectMCPServers, projectOctoBusServers)
+	configJSON, err := agentDefinitionConfigJSON(agent, projectRefs.MCPServers, projectRefs.OctoBusServers)
 	if err != nil {
 		return domain.AgentDefinition{}, fmt.Errorf("marshal managed agent %s config: %w", agent.Name, err)
 	}

--- a/pkg/projects/records_test.go
+++ b/pkg/projects/records_test.go
@@ -18,7 +18,7 @@ func TestNewAgentDefinitionFromSpecPreservesJupyterConfig(t *testing.T) {
 		Jupyter:  &compose.JupyterSpec{Enabled: true, GuestPort: 8888},
 	}
 
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestNewAgentDefinitionFromSpecPreservesStoppedRuntimePolicy(t *testing.T) {
 		Name: "reviewer", Enabled: true, Provider: "codex",
 		Sandbox: &compose.NormalizedSandboxSpec{StoppedRuntimePolicy: domain.StoppedRuntimePolicyRemove},
 	}
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestNewAgentDefinitionFromSpecKeepsEmptyConfigWithoutJupyter(t *testing.T) 
 	project := domain.ProjectRecord{ID: "project-1", Name: "project"}
 	agent := compose.NormalizedAgentSpec{Name: "reviewer", Enabled: true, Provider: "codex"}
 
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestNewAgentDefinitionFromSpecKeepsStableNameWithPresentationMetadata(t *te
 		Provider:    "codex",
 	}
 
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestProjectRecordsCarryVolumeMountSpecs(t *testing.T) {
 		},
 		Scheduler: &compose.NormalizedSchedulerSpec{Enabled: true, DisplayName: "缓存巡检", Description: "检查缓存状态", Script: "scheduler.agent('hi')"},
 	}
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestDisabledAgentDisablesManagedAgentAndSchedulerRecords(t *testing.T) {
 		Enabled:   false,
 		Scheduler: &compose.NormalizedSchedulerSpec{Enabled: true, Script: "scheduler.agent('hi')"},
 	}
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestNewAgentDefinitionFromSpecPreservesMCPConfig(t *testing.T) {
 	}
 	projectMCPServers := map[string]compose.NormalizedMCPServerSpec{}
 
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, projectMCPServers, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: projectMCPServers, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestNewAgentDefinitionFromSpecSelectsReferencedOctoBusServers(t *testing.T)
 		"unused":   {URL: "https://unused.example", Token: "unused-token"},
 	}
 
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, servers)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: servers})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestNewAgentDefinitionFromSpecCarriesSkills(t *testing.T) {
 		},
 	}
 
-	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, nil, nil)
+	definition, err := NewAgentDefinitionFromSpec(project, 1, agent, AgentDefinitionProjectRefs{MCPServers: nil, OctoBusServers: nil})
 	if err != nil {
 		t.Fatalf("NewAgentDefinitionFromSpec returned error: %v", err)
 	}

--- a/pkg/projects/revision_agent.go
+++ b/pkg/projects/revision_agent.go
@@ -21,7 +21,7 @@ func AgentDefinitionFromRevision(project domain.ProjectRecord, revision domain.P
 		if agent.Name != agentName {
 			continue
 		}
-		definition, err := NewAgentDefinitionFromSpec(project, revision.Revision, agent, spec.MCPServers, spec.OctoBusServers)
+		definition, err := NewAgentDefinitionFromSpec(project, revision.Revision, agent, AgentDefinitionProjectRefs{MCPServers: spec.MCPServers, OctoBusServers: spec.OctoBusServers})
 		if err != nil {
 			return domain.AgentDefinition{}, fmt.Errorf("derive project revision agent %s: %w", agentName, err)
 		}


### PR DESCRIPTION
## Summary
- Fix `revive` `argument-limit` (max 4 params) and `funlen` (max 100 lines) violations found while enabling those two golangci-lint rules across pkg/ (not yet shipped in `.golangci.yml`; that lands as a separate final PR once all packages are done).
- `resolveProjectByExactMatch` (private, `pkg/projects/project_ref.go`): 6 positional params → `exactMatchRequest` struct.
- `NewAgentDefinitionFromSpec` (`pkg/projects/records.go`, `pkg/projects/revision_agent.go`): the two project-level MCP/OctoBus lookup maps → `AgentDefinitionProjectRefs` struct.
- `EnsureProjectAgentImages` (`pkg/images/ensure.go`, sole caller is `pkg/projects.applyProject`): `projectName`/`agents` → `ProjectAgentImagesRequest` struct.
- Test helpers `assertProjectChange`/`assertDownChange` (`pkg/projects/controller_coverage_test.go`): shared `changeExpectation` struct instead of 3 positional strings each.
- `ReconcileSchedulers` (`pkg/projects/reconcile.go`, 152 lines) split into `reconcileCurrentSchedulers` (upsert schedulers present in the spec) and `disableRemovedSchedulers` (disable schedulers dropped from the spec) — two genuinely distinct phases sharing only a `currentByID` handoff map, fixing the `funlen` violation.
- `StableSchedulerTriggerID`'s `argument-limit` violation is left deferred (5 positional args) — verified real external callers across `cmd/agent-compose`, `pkg/agentcompose`, and `pkg/projects` itself; not part of this package's blast radius to fix alone.
- `applyProject` (`pkg/projects/controller.go`, 187 lines) is left as a visible `funlen` violation, no `nolint` — it's a single-transaction orchestrator (validate → persist project/revision → reconcile agents/schedulers → build result) with heavy shared local-variable state across the whole body; no extraction found that isn't just pushing the same coupling around a function boundary, matching how `CreateSandbox`/`CreateSandboxWithOptions` were left in the pkg/storage PR.
- Dead-code audit of pkg/projects' exported surface found no genuinely unused symbols this pass.
- No `//nolint` comments were added since `.golangci.yml` doesn't enable these rules yet in this PR.

## Test plan
- [x] `go build ./...` (isolated `git worktree` at this branch's tip, generated `proto/` packages copied in since they're gitignored)
- [x] `go vet ./pkg/projects/... ./pkg/images/...`
- [x] `go test ./pkg/projects/... ./pkg/images/...`
- [x] `golangci-lint run --enable funlen --enable revive ./pkg/projects/...` — 4 remaining issues, all expected/deferred (2 coverage-sweep test functions, `applyProject`, `StableSchedulerTriggerID`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)