### PR TITLE
refactor(model): remove dead AgentRunSummaries/ValidateAgentWorkspaceValue

### DIFF
--- a/pkg/model/agent_model.go
+++ b/pkg/model/agent_model.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -71,18 +70,6 @@ type AgentDefinitionListResult struct {
 	TotalCount int
 	HasMore    bool
 	NextOffset int
-}
-
-type AgentCurrentRunSummary struct {
-	RunningSessionCount int
-}
-
-type AgentLatestRunSummary struct {
-	RunType string
-	Status  string
-	RunID   string
-	Title   string
-	At      time.Time
 }
 
 func NormalizeAgentKind(agent string) string {
@@ -174,46 +161,4 @@ func SandboxHasAgentTag(session *Sandbox, agentID string) bool {
 		}
 	}
 	return hasSource && hasAgentID
-}
-
-func AgentRunSummaries(agentID string, sessions []*Sandbox) (AgentCurrentRunSummary, *AgentLatestRunSummary) {
-	current := AgentCurrentRunSummary{}
-	var latest *AgentLatestRunSummary
-	for _, session := range sessions {
-		if !SandboxHasAgentTag(session, agentID) {
-			continue
-		}
-		switch session.Summary.VMStatus {
-		case VMStatusPending, VMStatusRunning:
-			current.RunningSessionCount++
-		}
-		if latest == nil || session.Summary.UpdatedAt.After(latest.At) {
-			latest = &AgentLatestRunSummary{
-				RunType: "work_session",
-				Status:  session.Summary.VMStatus,
-				RunID:   session.Summary.ID,
-				Title:   session.Summary.Title,
-				At:      session.Summary.UpdatedAt,
-			}
-		}
-	}
-	return current, latest
-}
-
-func ValidateAgentWorkspaceValue(workspaceID string, workspace *WorkspaceConfig, lookupErr error) error {
-	if strings.TrimSpace(workspaceID) == "" {
-		return nil
-	}
-	if lookupErr != nil {
-		return lookupErr
-	}
-	if workspace == nil {
-		return fmt.Errorf("workspace config %s not found", strings.TrimSpace(workspaceID))
-	}
-	switch strings.ToLower(strings.TrimSpace(workspace.Type)) {
-	case "file", "git":
-		return nil
-	default:
-		return fmt.Errorf("unsupported agent workspace type %q", workspace.Type)
-	}
 }


### PR DESCRIPTION
## Summary
- Last package in the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`; that lands as a separate final PR once all packages are done).
- pkg/model only had 2 violations, and both are legitimately left deferred rather than fixed:
  - `testModelBranchCoverageWorkflows` (funlen, 215 lines): a coverage-sweep integration test exercising one scenario end-to-end, same pattern left unaddressed in every other package this sweep.
  - `ResourceError` (revive argument-limit, 5 args): verified 61 call sites across 9 packages (`cmd/agent-compose`, `pkg/agentcompose`, `pkg/events/webhooks`, `pkg/model`, `pkg/projects`, `pkg/runs`, `pkg/schedulers`, `pkg/storage/configstore`, `pkg/volumes`) — the same "not worth the churn" judgment applied to `CreateSandbox`/`CreateSandboxWithOptions` in the pkg/storage PR (#606).
- The dead-code audit bonus pass on pkg/model's exported surface found two genuinely unused functions with zero callers anywhere in the repo: `AgentRunSummaries` and `ValidateAgentWorkspaceValue` (`pkg/model/agent_model.go`). Deleted both, plus the `AgentCurrentRunSummary`/`AgentLatestRunSummary` types that existed solely to support them.
- No `//nolint` comments added since `.golangci.yml` doesn't enable these rules yet in this PR.

## Test plan
- [x] `go build ./...` (isolated `git worktree` at this branch's tip, generated `proto/` packages copied in since they're gitignored) — confirms no other package referenced the deleted symbols
- [x] `go vet ./pkg/model/...`
- [x] `go test ./pkg/model/...`
- [x] `golangci-lint run --enable funlen --enable revive ./pkg/model/...` — 2 remaining issues, both expected/deferred as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)