### PR TITLE
refactor(events): bundle BuildPayload params; split handleWebhook

### DIFF
--- a/cmd/agent-compose/daemon_trusted_headers_webhook_test.go
+++ b/cmd/agent-compose/daemon_trusted_headers_webhook_test.go
@@ -16,10 +16,15 @@ func TestDaemonTrustedHeadersReachWebhookPayload(t *testing.T) {
 	app := echo.New()
 	app.Use(newDaemonTrustedHeadersMiddleware())
 	app.POST("/api/webhooks/:topic", func(c echo.Context) error {
-		payload := webhooks.BuildPayload(
-			c.Request(), "event-1", 1, c.Param("topic"), "correlation-1", "idempotency-1",
-			domain.WebhookSource{}, map[string]any{"intent": "push"},
-		)
+		payload := webhooks.BuildPayload(c.Request(), webhooks.WebhookPayloadRequest{
+			EventID:        "event-1",
+			Sequence:       1,
+			Topic:          c.Param("topic"),
+			CorrelationID:  "correlation-1",
+			IdempotencyKey: "idempotency-1",
+			Source:         domain.WebhookSource{},
+			Body:           map[string]any{"intent": "push"},
+		})
 		return c.JSON(http.StatusAccepted, payload)
 	})
 

--- a/pkg/events/webhooks/coverage_shape_workflows_test.go
+++ b/pkg/events/webhooks/coverage_shape_workflows_test.go
@@ -50,7 +50,15 @@ func TestWebhookHelpersAndQueueCoverageWorkflows(t *testing.T) {
 	if ExtractCorrelationID(req, body) != "corr-header" || ExtractIdempotencyKey(req) != "delivery-1" || ExtractDeliveryID(req) != "delivery-1" {
 		t.Fatalf("request id helpers failed")
 	}
-	payload := BuildPayload(req, "event-1", 7, "webhook.github.push", "corr", "idem", domain.WebhookSource{ID: "github", Provider: "github"}, body)
+	payload := BuildPayload(req, WebhookPayloadRequest{
+		EventID:        "event-1",
+		Sequence:       7,
+		Topic:          "webhook.github.push",
+		CorrelationID:  "corr",
+		IdempotencyKey: "idem",
+		Source:         domain.WebhookSource{ID: "github", Provider: "github"},
+		Body:           body,
+	})
 	if payload["eventId"] != "event-1" || payload["provider"] != "github" || len(QueryValuesToMap(req)) != 2 {
 		t.Fatalf("payload = %#v", payload)
 	}

--- a/pkg/events/webhooks/helpers.go
+++ b/pkg/events/webhooks/helpers.go
@@ -164,26 +164,38 @@ func webhookPayloadHeaders(r *http.Request) map[string]string {
 	return out
 }
 
-func BuildPayload(r *http.Request, eventID string, sequence int64, topic, correlationID, idempotencyKey string, source domain.WebhookSource, body map[string]any) map[string]any {
+// WebhookPayloadRequest describes the event metadata BuildPayload assembles
+// alongside the inbound HTTP request into a delivery payload.
+type WebhookPayloadRequest struct {
+	EventID        string
+	Sequence       int64
+	Topic          string
+	CorrelationID  string
+	IdempotencyKey string
+	Source         domain.WebhookSource
+	Body           map[string]any
+}
+
+func BuildPayload(r *http.Request, req WebhookPayloadRequest) map[string]any {
 	payload := map[string]any{
-		"eventId":        eventID,
-		"sequence":       sequence,
+		"eventId":        req.EventID,
+		"sequence":       req.Sequence,
 		"source":         domain.TopicEventSourceWebhook,
-		"provider":       firstNonEmpty(source.Provider, ProviderFromTopic(topic)),
-		"intent":         IntentFromBody(body),
+		"provider":       firstNonEmpty(req.Source.Provider, ProviderFromTopic(req.Topic)),
+		"intent":         IntentFromBody(req.Body),
 		"method":         r.Method,
 		"path":           r.URL.Path,
-		"topic":          topic,
-		"correlationId":  correlationID,
-		"idempotencyKey": idempotencyKey,
+		"topic":          req.Topic,
+		"correlationId":  req.CorrelationID,
+		"idempotencyKey": req.IdempotencyKey,
 		"deliveryId":     ExtractDeliveryID(r),
 		"remoteAddr":     r.RemoteAddr,
 		"headers":        webhookPayloadHeaders(r),
 		"query":          QueryValuesToMap(r),
-		"body":           body,
+		"body":           req.Body,
 	}
-	if source.ID != "" {
-		payload["webhookSourceId"] = source.ID
+	if req.Source.ID != "" {
+		payload["webhookSourceId"] = req.Source.ID
 	}
 	return payload
 }

--- a/pkg/events/webhooks/http.go
+++ b/pkg/events/webhooks/http.go
@@ -90,73 +90,114 @@ func (h routeHandler) handleWebhook(c echo.Context) error {
 	if h.store() == nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "webhook store is required"})
 	}
-	topic := strings.TrimSpace(c.Param("topic"))
-	if err := ValidateExternalTopic(topic); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
-	}
-	sources, bodyLimit, handled, err := h.webhookSources(c, topic)
+	resolved, handled, err := h.resolveWebhookEvent(c)
 	if handled {
 		return err
 	}
+	return h.storeWebhookEvent(c, resolved)
+}
+
+// resolvedWebhookEvent carries the topic, source, and decoded body that
+// survived validation and authorization, ready to be built into a stored
+// event.
+type resolvedWebhookEvent struct {
+	Topic          string
+	Source         domain.WebhookSource
+	Body           map[string]any
+	CompactBody    string
+	IdempotencyKey string
+}
+
+// resolveWebhookEvent validates, authorizes, and decodes the inbound webhook
+// request. If handled is true, the caller must return err as-is (a response
+// has already been written, whether that's an error or an accepted/idempotent
+// duplicate).
+func (h routeHandler) resolveWebhookEvent(c echo.Context) (resolvedWebhookEvent, bool, error) {
+	topic := strings.TrimSpace(c.Param("topic"))
+	if err := ValidateExternalTopic(topic); err != nil {
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+	sources, bodyLimit, handled, err := h.webhookSources(c, topic)
+	if handled {
+		return resolvedWebhookEvent{}, true, err
+	}
 	bodyFormat := detectRequestBodyFormat(c.Request())
 	if bodyFormat == requestBodyFormatUnsupported {
-		return c.JSON(http.StatusUnsupportedMediaType, map[string]string{"error": "content-type must be application/json or application/x-www-form-urlencoded"})
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusUnsupportedMediaType, map[string]string{"error": "content-type must be application/json or application/x-www-form-urlencoded"})
 	}
 	rawBody, err := ReadBody(c.Request(), bodyLimit)
 	if err != nil {
 		if errors.Is(err, domain.ErrBodyTooLarge) {
-			return c.JSON(http.StatusRequestEntityTooLarge, map[string]string{"error": "request body is too large"})
+			return resolvedWebhookEvent{}, true, c.JSON(http.StatusRequestEntityTooLarge, map[string]string{"error": "request body is too large"})
 		}
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
 	}
 	source, handled, err := h.authorizeWebhookRequest(c, sources, rawBody)
 	if handled {
-		return err
+		return resolvedWebhookEvent{}, true, err
 	}
 	if limit := h.sourceBodyLimit(source); limit > 0 && int64(len(rawBody)) > limit {
-		return c.JSON(http.StatusRequestEntityTooLarge, map[string]string{"error": "request body is too large"})
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusRequestEntityTooLarge, map[string]string{"error": "request body is too large"})
 	}
 	githubMode, err := domain.GitHubWebhookModeForSource(source)
 	if err != nil {
-		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid webhook source configuration"})
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid webhook source configuration"})
 	}
 	if githubMode != domain.GitHubWebhookModeGeneric {
 		var ok bool
 		topic, ok = githubTopic(c.Request())
 		if !ok {
-			return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid or missing X-GitHub-Event header"})
+			return resolvedWebhookEvent{}, true, c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid or missing X-GitHub-Event header"})
 		}
 	}
 	if bodyFormat == requestBodyFormatForm && githubMode == domain.GitHubWebhookModeGeneric {
-		return c.JSON(http.StatusUnsupportedMediaType, map[string]string{"error": "application/x-www-form-urlencoded is supported only for GitHub webhooks"})
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusUnsupportedMediaType, map[string]string{"error": "application/x-www-form-urlencoded is supported only for GitHub webhooks"})
 	}
 	decodedBody := rawBody
 	if bodyFormat == requestBodyFormatForm {
 		decodedBody, err = decodeGitHubFormPayload(rawBody)
 		if err != nil {
-			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return resolvedWebhookEvent{}, true, c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 		}
 	}
 	body, compactBody, err := DecodeJSONObject(decodedBody)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	idempotencyKey := ExtractIdempotencyKey(c.Request())
 	if existing, ok, err := h.store().FindEventByIdempotencyKey(c.Request().Context(), topic, idempotencyKey); err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load webhook event"})
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load webhook event"})
 	} else if ok {
 		if ExistingBodyHash(existing.PayloadJSON) != events.PayloadSHA256(compactBody) {
-			return c.JSON(http.StatusConflict, idempotencyConflictResponseFor(existing))
+			return resolvedWebhookEvent{}, true, c.JSON(http.StatusConflict, idempotencyConflictResponseFor(existing))
 		}
-		return c.JSON(http.StatusAccepted, acceptedResponseFor(existing))
+		return resolvedWebhookEvent{}, true, c.JSON(http.StatusAccepted, acceptedResponseFor(existing))
 	}
+	return resolvedWebhookEvent{
+		Topic:          topic,
+		Source:         source,
+		Body:           body,
+		CompactBody:    compactBody,
+		IdempotencyKey: idempotencyKey,
+	}, false, nil
+}
 
+// storeWebhookEvent builds the delivery payload for a resolved webhook event,
+// persists it, and writes the HTTP response.
+func (h routeHandler) storeWebhookEvent(c echo.Context, resolved resolvedWebhookEvent) error {
 	eventID := h.newEventID()
-	correlationID := ExtractCorrelationID(c.Request(), body)
+	correlationID := ExtractCorrelationID(c.Request(), resolved.Body)
 	if correlationID == "" {
 		correlationID = eventID
 	}
-	payload := BuildPayload(c.Request(), eventID, 0, topic, correlationID, idempotencyKey, source, body)
+	payload := BuildPayload(c.Request(), WebhookPayloadRequest{
+		EventID:        eventID,
+		Topic:          resolved.Topic,
+		CorrelationID:  correlationID,
+		IdempotencyKey: resolved.IdempotencyKey,
+		Source:         resolved.Source,
+		Body:           resolved.Body,
+	})
 	payloadJSON, err := h.marshalJSONCompact(payload)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to encode webhook payload"})
@@ -164,12 +205,12 @@ func (h routeHandler) handleWebhook(c echo.Context) error {
 	payloadHash := events.PayloadSHA256(payloadJSON)
 	created, err := h.store().CreateEvent(c.Request().Context(), domain.TopicEventRecord{
 		ID:             eventID,
-		Topic:          topic,
+		Topic:          resolved.Topic,
 		Source:         domain.TopicEventSourceWebhook,
-		Provider:       firstNonEmpty(source.Provider, ProviderFromTopic(topic)),
-		Intent:         IntentFromBody(body),
+		Provider:       firstNonEmpty(resolved.Source.Provider, ProviderFromTopic(resolved.Topic)),
+		Intent:         IntentFromBody(resolved.Body),
 		CorrelationID:  correlationID,
-		IdempotencyKey: idempotencyKey,
+		IdempotencyKey: resolved.IdempotencyKey,
 		DeliveryID:     ExtractDeliveryID(c.Request()),
 		PayloadHash:    payloadHash,
 		PayloadJSON:    payloadJSON,
@@ -180,10 +221,10 @@ func (h routeHandler) handleWebhook(c echo.Context) error {
 		var conflict *domain.TopicEventIdempotencyConflictError
 		if errors.As(err, &conflict) {
 			existing := conflict.Existing
-			if strings.TrimSpace(existing.ID) == "" || strings.TrimSpace(existing.Topic) != topic {
+			if strings.TrimSpace(existing.ID) == "" || strings.TrimSpace(existing.Topic) != resolved.Topic {
 				return c.JSON(http.StatusInternalServerError, map[string]string{"error": "invalid conflicting webhook event"})
 			}
-			if ExistingBodyHash(existing.PayloadJSON) == events.PayloadSHA256(compactBody) {
+			if ExistingBodyHash(existing.PayloadJSON) == events.PayloadSHA256(resolved.CompactBody) {
 				return c.JSON(http.StatusAccepted, acceptedResponseFor(existing))
 			}
 			return c.JSON(http.StatusConflict, idempotencyConflictResponseFor(existing))


### PR DESCRIPTION
## Summary
- Part of the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`).
- `BuildPayload` (`pkg/events/webhooks/helpers.go`, exported): 8 positional params → `WebhookPayloadRequest` struct. Verified 3 real call sites across 2 packages (`cmd/agent-compose`, `pkg/events/webhooks`) — small enough blast radius to fix directly rather than defer.
- `handleWebhook` (`pkg/events/webhooks/http.go`, 107 lines) split into `resolveWebhookEvent` (validate, authorize, decode, idempotency check) and `storeWebhookEvent` (build payload, persist, respond) — two genuinely distinct phases already following the file's existing `handled bool, err error` early-return convention used by its sibling helpers.
- Left deferred (no `nolint`, since the rule isn't shipped in this PR): a coverage-sweep test, `ReleaseEventClaim`'s test fake (must match the `Store` interface's existing 6-arg signature, same as the already-deferred production implementation in pkg/storage), and two widely-used self-describing test helpers (`deliverGitHubWebhook`/`deliverGitHubWebhookWithContentType`, used across 10+ table-driven test call sites).

## Test plan
- [x] `go build ./...` (isolated `git worktree` at this branch's tip, generated `proto/` packages copied in since they're gitignored)
- [x] `go vet ./pkg/events/... ./cmd/agent-compose/...`
- [x] `go test ./pkg/events/... ./cmd/agent-compose/...`
- [x] `golangci-lint run ./pkg/events/...` — 4 remaining issues, all expected/deferred as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)