### PR TITLE
refactor(imagecache): split Pull and applyLayerTarArchive

### DIFF
--- a/pkg/imagecache/pull.go
+++ b/pkg/imagecache/pull.go
@@ -18,6 +18,86 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
+// remoteImageDescriptor is the remote image and the metadata Pull needs to
+// append it to the local OCI layout and cache index.
+type remoteImageDescriptor struct {
+	Image          v1.Image
+	ManifestDigest v1.Hash
+	ConfigDigest   v1.Hash
+	MediaType      string
+	SizeBytes      int64
+	ConfigFile     *v1.ConfigFile
+}
+
+// remoteImageFetch bundles the parsed reference, platform, and progress
+// channel fetchRemoteImageDescriptor needs to resolve a remote image.
+type remoteImageFetch struct {
+	Reference    string
+	Ref          name.Reference
+	Platform     Platform
+	V1Platform   v1.Platform
+	ProgressCh   chan v1.Update
+	ProgressDone <-chan []ProgressEvent
+}
+
+// fetchRemoteImageDescriptor resolves the remote image referenced by
+// fetch.Ref and reads back the manifest/config metadata Pull persists. On
+// error it drains fetch.ProgressCh via finishProgress so the caller can still
+// report partial progress alongside the wrapped error.
+func (c *Cache) fetchRemoteImageDescriptor(ctx context.Context, fetch remoteImageFetch) (remoteImageDescriptor, []ProgressEvent, error) {
+	progressCh, progressDone := fetch.ProgressCh, fetch.ProgressDone
+	remoteOptions := []remote.Option{
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		remote.WithPlatform(fetch.V1Platform),
+		remote.WithProgress(progressCh),
+	}
+
+	img, err := remote.Image(fetch.Ref, remoteOptions...)
+	if err != nil {
+		progress := finishProgress(progressCh, progressDone)
+		return remoteImageDescriptor{}, progress, mapPullError("pull", fetch.Reference, fetch.Platform, err)
+	}
+	if err := ctx.Err(); err != nil {
+		progress := finishProgress(progressCh, progressDone)
+		return remoteImageDescriptor{}, progress, NewError(ErrorKindUnavailable, "pull", fetch.Reference, err)
+	}
+
+	manifestDigest, err := img.Digest()
+	if err != nil {
+		progress := finishProgress(progressCh, progressDone)
+		return remoteImageDescriptor{}, progress, NewError(ErrorKindUnavailable, "pull", fetch.Reference, err)
+	}
+	configDigest, err := img.ConfigName()
+	if err != nil {
+		progress := finishProgress(progressCh, progressDone)
+		return remoteImageDescriptor{}, progress, NewError(ErrorKindUnavailable, "pull", fetch.Reference, err)
+	}
+	mediaType, err := img.MediaType()
+	if err != nil {
+		progress := finishProgress(progressCh, progressDone)
+		return remoteImageDescriptor{}, progress, NewError(ErrorKindUnavailable, "pull", fetch.Reference, err)
+	}
+	sizeBytes, err := img.Size()
+	if err != nil {
+		progress := finishProgress(progressCh, progressDone)
+		return remoteImageDescriptor{}, progress, NewError(ErrorKindUnavailable, "pull", fetch.Reference, err)
+	}
+	configFile, err := img.ConfigFile()
+	if err != nil {
+		progress := finishProgress(progressCh, progressDone)
+		return remoteImageDescriptor{}, progress, NewError(ErrorKindUnavailable, "pull", fetch.Reference, err)
+	}
+	return remoteImageDescriptor{
+		Image:          img,
+		ManifestDigest: manifestDigest,
+		ConfigDigest:   configDigest,
+		MediaType:      string(mediaType),
+		SizeBytes:      sizeBytes,
+		ConfigFile:     configFile,
+	}, nil, nil
+}
+
 func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 	if err := ctx.Err(); err != nil {
 		return PullResult{}, NewError(ErrorKindUnavailable, "pull", req.Reference, err)
@@ -31,48 +111,19 @@ func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 
 	progressCh := make(chan v1.Update, 64)
 	progressDone := collectProgress(progressCh)
-	remoteOptions := []remote.Option{
-		remote.WithContext(ctx),
-		remote.WithAuthFromKeychain(authn.DefaultKeychain),
-		remote.WithPlatform(v1Platform),
-		remote.WithProgress(progressCh),
-	}
 
-	img, err := remote.Image(ref, remoteOptions...)
+	descriptor, progress, err := c.fetchRemoteImageDescriptor(ctx, remoteImageFetch{
+		Reference:    req.Reference,
+		Ref:          ref,
+		Platform:     platform,
+		V1Platform:   v1Platform,
+		ProgressCh:   progressCh,
+		ProgressDone: progressDone,
+	})
 	if err != nil {
-		progress := finishProgress(progressCh, progressDone)
-		return PullResult{Progress: progress}, mapPullError("pull", req.Reference, platform, err)
+		return PullResult{Progress: progress}, err
 	}
-	if err := ctx.Err(); err != nil {
-		progress := finishProgress(progressCh, progressDone)
-		return PullResult{Progress: progress}, NewError(ErrorKindUnavailable, "pull", req.Reference, err)
-	}
-
-	manifestDigest, err := img.Digest()
-	if err != nil {
-		progress := finishProgress(progressCh, progressDone)
-		return PullResult{Progress: progress}, NewError(ErrorKindUnavailable, "pull", req.Reference, err)
-	}
-	configDigest, err := img.ConfigName()
-	if err != nil {
-		progress := finishProgress(progressCh, progressDone)
-		return PullResult{Progress: progress}, NewError(ErrorKindUnavailable, "pull", req.Reference, err)
-	}
-	mediaType, err := img.MediaType()
-	if err != nil {
-		progress := finishProgress(progressCh, progressDone)
-		return PullResult{Progress: progress}, NewError(ErrorKindUnavailable, "pull", req.Reference, err)
-	}
-	sizeBytes, err := img.Size()
-	if err != nil {
-		progress := finishProgress(progressCh, progressDone)
-		return PullResult{Progress: progress}, NewError(ErrorKindUnavailable, "pull", req.Reference, err)
-	}
-	configFile, err := img.ConfigFile()
-	if err != nil {
-		progress := finishProgress(progressCh, progressDone)
-		return PullResult{Progress: progress}, NewError(ErrorKindUnavailable, "pull", req.Reference, err)
-	}
+	img, manifestDigest, configFile, sizeBytes := descriptor.Image, descriptor.ManifestDigest, descriptor.ConfigFile, descriptor.SizeBytes
 	metadataPlatform := platformFromConfig(configFile, platform)
 
 	unlock, err := c.Lock()
@@ -98,9 +149,9 @@ func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 	image, err := NewImageMetadata(MetadataInput{
 		RequestedRef:    req.Reference,
 		ManifestDigest:  manifestDigest.String(),
-		ConfigDigest:    configDigest.String(),
+		ConfigDigest:    descriptor.ConfigDigest.String(),
 		Platform:        metadataPlatform,
-		MediaType:       string(mediaType),
+		MediaType:       descriptor.MediaType,
 		Labels:          configFile.Config.Labels,
 		Env:             configFile.Config.Env,
 		SizeBytes:       sizeBytes,
@@ -126,7 +177,7 @@ func (c *Cache) Pull(ctx context.Context, req PullRequest) (PullResult, error) {
 		return PullResult{Progress: progress}, err
 	}
 
-	progress := finishProgress(progressCh, progressDone)
+	progress = finishProgress(progressCh, progressDone)
 	progress = append(progress, ProgressEvent{
 		Message:      "pulled",
 		CurrentBytes: sizeBytes,

--- a/pkg/imagecache/rootfs.go
+++ b/pkg/imagecache/rootfs.go
@@ -164,32 +164,9 @@ func applyLayerTarArchive(ctx context.Context, src io.Reader, dstDir string) err
 			continue
 		}
 
-		base := filepath.Base(relPath)
-		dir := filepath.Dir(relPath)
-		if base == ".wh..wh..opq" {
-			if dir == "." {
-				dir = ""
-			}
-			if err := clearRootFSDirectory(dstDir, dir); err != nil {
-				return fmt.Errorf("apply opaque whiteout for %s: %w", header.Name, err)
-			}
-			continue
-		}
-		if strings.HasPrefix(base, ".wh.") {
-			target := strings.TrimPrefix(base, ".wh.")
-			if target == "" {
-				continue
-			}
-			targetRel := filepath.Join(dir, target)
-			if dir == "." {
-				targetRel = target
-			}
-			targetPath, err := safeRootFSPath(dstDir, targetRel)
+		if handled, err := applyLayerWhiteout(dstDir, header, relPath); handled {
 			if err != nil {
-				return fmt.Errorf("apply whiteout for %s: %w", header.Name, err)
-			}
-			if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("remove whiteout target %s: %w", targetRel, err)
+				return err
 			}
 			continue
 		}
@@ -201,58 +178,122 @@ func applyLayerTarArchive(ctx context.Context, src io.Reader, dstDir string) err
 		if err := ensureSafeParentDir(dstDir, relPath); err != nil {
 			return fmt.Errorf("prepare parent for %s: %w", header.Name, err)
 		}
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := ensureNoSymlinkAt(targetPath); err != nil {
-				return fmt.Errorf("create dir %s: %w", relPath, err)
-			}
-			if err := os.MkdirAll(targetPath, header.FileInfo().Mode().Perm()); err != nil {
-				return fmt.Errorf("create dir %s: %w", relPath, err)
-			}
-		case tar.TypeReg, 0:
-			if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("remove existing file %s: %w", relPath, err)
-			}
-			file, err := os.OpenFile(targetPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, header.FileInfo().Mode().Perm())
-			if err != nil {
-				return fmt.Errorf("create file %s: %w", relPath, err)
-			}
-			if _, err := io.Copy(file, reader); err != nil {
-				_ = file.Close()
-				return fmt.Errorf("write file %s: %w", relPath, err)
-			}
-			if err := file.Close(); err != nil {
-				return fmt.Errorf("close file %s: %w", relPath, err)
-			}
-		case tar.TypeSymlink:
-			if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("remove existing symlink path %s: %w", relPath, err)
-			}
-			if err := os.Symlink(header.Linkname, targetPath); err != nil {
-				return fmt.Errorf("create symlink %s -> %s: %w", relPath, header.Linkname, err)
-			}
-		case tar.TypeLink:
-			linkRel, err := cleanLayerPath(header.Linkname)
-			if err != nil || linkRel == "" {
-				return fmt.Errorf("invalid hardlink target %q: %w", header.Linkname, err)
-			}
-			linkPath, err := safeRootFSPath(dstDir, linkRel)
-			if err != nil {
-				return fmt.Errorf("resolve hardlink target %s: %w", header.Linkname, err)
-			}
-			if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("remove existing hardlink path %s: %w", relPath, err)
-			}
-			if err := os.Link(linkPath, targetPath); err != nil {
-				return fmt.Errorf("create hardlink %s -> %s: %w", relPath, linkRel, err)
-			}
-		case tar.TypeXGlobalHeader, tar.TypeXHeader, tar.TypeGNULongLink, tar.TypeGNULongName:
-			continue
-		default:
-			return fmt.Errorf("unsupported tar entry type %q for %s", string(header.Typeflag), relPath)
+		if err := applyLayerTarEntry(layerTarEntry{
+			Reader:     reader,
+			Header:     header,
+			DstDir:     dstDir,
+			RelPath:    relPath,
+			TargetPath: targetPath,
+		}); err != nil {
+			return err
 		}
 	}
+}
+
+// applyLayerWhiteout applies AUFS/overlay whiteout semantics for a tar entry
+// if it represents one (an opaque-dir marker ".wh..wh..opq" or a regular
+// ".wh.<name>" delete marker). handled is true if the entry was a whiteout,
+// meaning the caller should continue to the next tar entry rather than
+// materializing it as a file.
+func applyLayerWhiteout(dstDir string, header *tar.Header, relPath string) (handled bool, err error) {
+	base := filepath.Base(relPath)
+	dir := filepath.Dir(relPath)
+	if base == ".wh..wh..opq" {
+		if dir == "." {
+			dir = ""
+		}
+		if err := clearRootFSDirectory(dstDir, dir); err != nil {
+			return true, fmt.Errorf("apply opaque whiteout for %s: %w", header.Name, err)
+		}
+		return true, nil
+	}
+	if strings.HasPrefix(base, ".wh.") {
+		target := strings.TrimPrefix(base, ".wh.")
+		if target == "" {
+			return true, nil
+		}
+		targetRel := filepath.Join(dir, target)
+		if dir == "." {
+			targetRel = target
+		}
+		targetPath, err := safeRootFSPath(dstDir, targetRel)
+		if err != nil {
+			return true, fmt.Errorf("apply whiteout for %s: %w", header.Name, err)
+		}
+		if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
+			return true, fmt.Errorf("remove whiteout target %s: %w", targetRel, err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// layerTarEntry bundles the tar reader/header and resolved paths
+// applyLayerTarEntry needs to materialize one non-whiteout tar entry onto
+// disk.
+type layerTarEntry struct {
+	Reader     *tar.Reader
+	Header     *tar.Header
+	DstDir     string
+	RelPath    string
+	TargetPath string
+}
+
+// applyLayerTarEntry materializes a single tar entry (dir, regular file,
+// symlink, or hardlink) at entry.TargetPath.
+func applyLayerTarEntry(entry layerTarEntry) error {
+	header, relPath, targetPath := entry.Header, entry.RelPath, entry.TargetPath
+	switch header.Typeflag {
+	case tar.TypeDir:
+		if err := ensureNoSymlinkAt(targetPath); err != nil {
+			return fmt.Errorf("create dir %s: %w", relPath, err)
+		}
+		if err := os.MkdirAll(targetPath, header.FileInfo().Mode().Perm()); err != nil {
+			return fmt.Errorf("create dir %s: %w", relPath, err)
+		}
+	case tar.TypeReg, 0:
+		if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove existing file %s: %w", relPath, err)
+		}
+		file, err := os.OpenFile(targetPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, header.FileInfo().Mode().Perm())
+		if err != nil {
+			return fmt.Errorf("create file %s: %w", relPath, err)
+		}
+		if _, err := io.Copy(file, entry.Reader); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("write file %s: %w", relPath, err)
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("close file %s: %w", relPath, err)
+		}
+	case tar.TypeSymlink:
+		if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove existing symlink path %s: %w", relPath, err)
+		}
+		if err := os.Symlink(header.Linkname, targetPath); err != nil {
+			return fmt.Errorf("create symlink %s -> %s: %w", relPath, header.Linkname, err)
+		}
+	case tar.TypeLink:
+		linkRel, err := cleanLayerPath(header.Linkname)
+		if err != nil || linkRel == "" {
+			return fmt.Errorf("invalid hardlink target %q: %w", header.Linkname, err)
+		}
+		linkPath, err := safeRootFSPath(entry.DstDir, linkRel)
+		if err != nil {
+			return fmt.Errorf("resolve hardlink target %s: %w", header.Linkname, err)
+		}
+		if err := os.RemoveAll(targetPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove existing hardlink path %s: %w", relPath, err)
+		}
+		if err := os.Link(linkPath, targetPath); err != nil {
+			return fmt.Errorf("create hardlink %s -> %s: %w", relPath, linkRel, err)
+		}
+	case tar.TypeXGlobalHeader, tar.TypeXHeader, tar.TypeGNULongLink, tar.TypeGNULongName:
+		return nil
+	default:
+		return fmt.Errorf("unsupported tar entry type %q for %s", string(header.Typeflag), relPath)
+	}
+	return nil
 }
 
 func cleanLayerPath(value string) (string, error) {


### PR DESCRIPTION
## Summary
- Part of the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`).
- `Pull` (`pkg/imagecache/pull.go`, 118 lines): split out `fetchRemoteImageDescriptor`, a genuinely distinct phase (resolve the remote image, read back its manifest/config metadata) from the rest of `Pull` (append to the local OCI layout, persist to the cache index). Bundled `fetchRemoteImageDescriptor`'s params (ref, platform, progress channel/drain) into a `remoteImageFetch` struct to stay under the 4-arg limit for the new function.
- `applyLayerTarArchive` (`pkg/imagecache/rootfs.go`, 113 lines): split out `applyLayerWhiteout` (AUFS/overlay whiteout marker handling) and `applyLayerTarEntry` (materializing a single dir/file/symlink/hardlink tar entry onto disk) — two previously-interleaved concerns in one loop body. `applyLayerTarEntry`'s params bundled into a `layerTarEntry` struct for the same reason.
- Left deferred: a coverage-sweep test (same pattern as every other package this sweep).

## Test plan
- [x] `go build ./...` (isolated `git worktree` at this branch's tip, generated `proto/` packages copied in since they're gitignored)
- [x] `go vet ./pkg/imagecache/...`
- [x] `go test ./pkg/imagecache/...`
- [x] `golangci-lint run ./pkg/imagecache/...` — 1 remaining issue (the deferred coverage-sweep test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)