### PR TITLE
refactor(agentcompose/app): bundle multi-argument params into structs

### DIFF
--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -251,17 +251,16 @@ func StartBackground(di do.Injector) error {
 	for _, warning := range do.MustInvoke[*adapters.SandboxRPCBridge](di).RecoverStoppedRuntimeReleases(ctx) {
 		slog.Warn("failed to recover stopped runtime release", "warning", warning)
 	}
-	if err := startBackgroundManagers(
-		ctx,
-		do.MustInvoke[*sandboxstore.Store](di),
-		do.MustInvoke[*configstore.ConfigStore](di),
-		do.MustInvoke[*adapters.SandboxRPCBridge](di),
-		do.MustInvoke[*schedulers.Controller](di),
-		do.MustInvoke[*events.Dispatcher](di),
-		do.MustInvoke[*capproxy.Server](di),
-		do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
-		do.MustInvoke[*runs.CompletionManager](di),
-	); err != nil {
+	if err := startBackgroundManagers(ctx, backgroundManagersDeps{
+		Sandboxes:   do.MustInvoke[*sandboxstore.Store](di),
+		ConfigDB:    do.MustInvoke[*configstore.ConfigStore](di),
+		Bridge:      do.MustInvoke[*adapters.SandboxRPCBridge](di),
+		Schedulers:  do.MustInvoke[*schedulers.Controller](di),
+		Events:      do.MustInvoke[*events.Dispatcher](di),
+		CapProxy:    do.MustInvoke[*capproxy.Server](di),
+		CapTokens:   do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
+		Completions: do.MustInvoke[*runs.CompletionManager](di),
+	}); err != nil {
 		return err
 	}
 	if err := do.MustInvoke[*sandboxes.DeletionRecovery](di).Start(ctx); err != nil {

--- a/pkg/agentcompose/app/app_test.go
+++ b/pkg/agentcompose/app/app_test.go
@@ -406,7 +406,7 @@ func TestStopProjectSandboxUsesInternalStopSemantics(t *testing.T) {
 	driver := &projectStopSandboxDriver{}
 	streams := &projectStopSandboxStreams{}
 
-	if err := stopProjectSandbox(context.Background(), "", nil, store, driver, streams, store.session, nil); err != nil {
+	if err := stopProjectSandbox(context.Background(), stopProjectSandboxDeps{Store: store, Driver: driver, Streams: streams}, store.session); err != nil {
 		t.Fatalf("stopProjectSandbox returned error: %v", err)
 	}
 	if driver.stopCount != 1 {
@@ -434,7 +434,7 @@ func TestStopProjectSandboxRuntimeReleaseFailureFinalizesConfirmedStop(t *testin
 	driver := &projectStopSandboxDriver{releaseErr: releaseErr}
 	streams := &projectStopSandboxStreams{}
 
-	if err := stopProjectSandbox(context.Background(), t.TempDir(), nil, store, driver, streams, store.session, nil); !errors.Is(err, releaseErr) {
+	if err := stopProjectSandbox(context.Background(), stopProjectSandboxDeps{SandboxRoot: t.TempDir(), Store: store, Driver: driver, Streams: streams}, store.session); !errors.Is(err, releaseErr) {
 		t.Fatalf("stopProjectSandbox error = %v, want %v", err, releaseErr)
 	}
 	if driver.stopCount != 1 || driver.releaseCount != 1 {

--- a/pkg/agentcompose/app/background.go
+++ b/pkg/agentcompose/app/background.go
@@ -29,30 +29,43 @@ type backgroundSchedulerController interface {
 	Start()
 }
 
-func startBackgroundManagers(ctx context.Context, sandboxes *sandboxstore.Store, configDB *configstore.ConfigStore, bridge runtimeReconciler, schedulers backgroundSchedulerController, events *events.Dispatcher, capProxy *capproxy.Server, capTokens *adapters.CapabilitySandboxResolver, completions *runs.CompletionManager) error {
+// backgroundManagersDeps bundles the runtime components startBackgroundManagers
+// starts and reconciles on daemon startup.
+type backgroundManagersDeps struct {
+	Sandboxes   *sandboxstore.Store
+	ConfigDB    *configstore.ConfigStore
+	Bridge      runtimeReconciler
+	Schedulers  backgroundSchedulerController
+	Events      *events.Dispatcher
+	CapProxy    *capproxy.Server
+	CapTokens   *adapters.CapabilitySandboxResolver
+	Completions *runs.CompletionManager
+}
+
+func startBackgroundManagers(ctx context.Context, deps backgroundManagersDeps) error {
 	startedAt := time.Now().UTC()
 	reconcileCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := reconcilePersistedSandboxes(reconcileCtx, sandboxes, bridge, startedAt); err != nil {
+	if err := reconcilePersistedSandboxes(reconcileCtx, deps.Sandboxes, deps.Bridge, startedAt); err != nil {
 		slog.Warn("failed to reconcile persisted sandbox state on startup", "error", err)
 	}
-	if capTokens != nil {
-		if err := capTokens.Rebuild(reconcileCtx); err != nil {
+	if deps.CapTokens != nil {
+		if err := deps.CapTokens.Rebuild(reconcileCtx); err != nil {
 			slog.Warn("failed to rebuild capability sandbox token index on startup", "error", err)
 		}
 	}
-	if err := schedulers.RecoverInterruptedRuns(reconcileCtx, startedAt); err != nil {
+	if err := deps.Schedulers.RecoverInterruptedRuns(reconcileCtx, startedAt); err != nil {
 		slog.Warn("failed to recover interrupted scheduler runs", "error", err)
 	}
-	if err := completions.Start(ctx); err != nil {
+	if err := deps.Completions.Start(ctx); err != nil {
 		return err
 	}
-	if err := reconcilePersistedProjectRuns(reconcileCtx, configDB, completions, startedAt); err != nil {
+	if err := reconcilePersistedProjectRuns(reconcileCtx, deps.ConfigDB, deps.Completions, startedAt); err != nil {
 		slog.Warn("failed to reconcile persisted project runs", "error", err)
 	}
-	schedulers.Start()
-	events.Start()
-	return startCapabilityProxy(ctx, capProxy)
+	deps.Schedulers.Start()
+	deps.Events.Start()
+	return startCapabilityProxy(ctx, deps.CapProxy)
 }
 
 func reconcilePersistedSandboxes(ctx context.Context, store *sandboxstore.Store, bridge runtimeReconciler, startedAt time.Time) error {
@@ -110,23 +123,33 @@ func reconcilePendingSandboxState(ctx context.Context, store *sandboxstore.Store
 	return store.GetSandbox(ctx, session.Summary.ID)
 }
 
+// projectRunReconcileContext bundles the store/manager and startup timestamp
+// reconcilePersistedProjectRunsWithStatus needs, shared across every status
+// it's called with.
+type projectRunReconcileContext struct {
+	ConfigDB    *configstore.ConfigStore
+	Completions *runs.CompletionManager
+	StartedAt   time.Time
+}
+
 func reconcilePersistedProjectRuns(ctx context.Context, configDB *configstore.ConfigStore, completions *runs.CompletionManager, startedAt time.Time) error {
 	if configDB == nil {
 		return nil
 	}
+	reconcile := projectRunReconcileContext{ConfigDB: configDB, Completions: completions, StartedAt: startedAt}
 	for _, status := range []string{domain.ProjectRunStatusPending, domain.ProjectRunStatusRunning} {
-		if err := reconcilePersistedProjectRunsWithStatus(ctx, configDB, completions, status, startedAt); err != nil {
+		if err := reconcilePersistedProjectRunsWithStatus(ctx, reconcile, status); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func reconcilePersistedProjectRunsWithStatus(ctx context.Context, configDB *configstore.ConfigStore, completions *runs.CompletionManager, status string, startedAt time.Time) error {
+func reconcilePersistedProjectRunsWithStatus(ctx context.Context, reconcile projectRunReconcileContext, status string) error {
 	var staleRuns []domain.ProjectRunRecord
 	offset := 0
 	for {
-		runs, err := configDB.ListProjectRunsByOptions(ctx, domain.ProjectRunListOptions{
+		runs, err := reconcile.ConfigDB.ListProjectRunsByOptions(ctx, domain.ProjectRunListOptions{
 			Status: status,
 			Limit:  200,
 			Offset: offset,
@@ -138,7 +161,7 @@ func reconcilePersistedProjectRunsWithStatus(ctx context.Context, configDB *conf
 			break
 		}
 		for _, run := range runs {
-			if !run.CreatedAt.Before(startedAt) {
+			if !run.CreatedAt.Before(reconcile.StartedAt) {
 				continue
 			}
 			staleRuns = append(staleRuns, run)
@@ -146,7 +169,7 @@ func reconcilePersistedProjectRunsWithStatus(ctx context.Context, configDB *conf
 		offset += len(runs)
 	}
 	for _, run := range staleRuns {
-		if err := completions.StageInterrupted(ctx, run, staleProjectRunError); err != nil {
+		if err := reconcile.Completions.StageInterrupted(ctx, run, staleProjectRunError); err != nil {
 			slog.Warn("failed to stage stale project run completion", "run_id", run.RunID, "error", err)
 		}
 	}

--- a/pkg/agentcompose/app/controller_helpers_coverage_test.go
+++ b/pkg/agentcompose/app/controller_helpers_coverage_test.go
@@ -168,28 +168,28 @@ func TestAppRunControllerHelperCoverage(t *testing.T) {
 
 func TestStopProjectSandboxCoverage(t *testing.T) {
 	ctx := context.Background()
-	if err := stopProjectSandbox(ctx, "", nil, nil, nil, nil, nil, nil); err != nil {
+	if err := stopProjectSandbox(ctx, stopProjectSandboxDeps{}, nil); err != nil {
 		t.Fatalf("stopProjectSandbox nil sandbox err=%v", err)
 	}
 	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-1"}}
-	if err := stopProjectSandbox(ctx, "", nil, nil, nil, nil, session, nil); err == nil {
+	if err := stopProjectSandbox(ctx, stopProjectSandboxDeps{}, session); err == nil {
 		t.Fatalf("stopProjectSandbox nil store returned nil error")
 	}
 	store := &projectSessionStoreFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-1", VMStatus: domain.VMStatusStopped}}}
-	if err := stopProjectSandbox(ctx, "", nil, store, nil, nil, session, nil); err != nil || store.updated {
+	if err := stopProjectSandbox(ctx, stopProjectSandboxDeps{Store: store}, session); err != nil || store.updated {
 		t.Fatalf("stopProjectSandbox stopped err=%v updated=%v", err, store.updated)
 	}
 	store.session.Summary.VMStatus = domain.VMStatusRunning
-	if err := stopProjectSandbox(ctx, "", nil, store, nil, nil, session, nil); err == nil {
+	if err := stopProjectSandbox(ctx, stopProjectSandboxDeps{Store: store}, session); err == nil {
 		t.Fatalf("stopProjectSandbox nil driver returned nil error")
 	}
 	driver := &projectSandboxDriverFake{err: errors.New("stop failed")}
-	if err := stopProjectSandbox(ctx, "", nil, store, driver, nil, session, nil); err == nil {
+	if err := stopProjectSandbox(ctx, stopProjectSandboxDeps{Store: store, Driver: driver}, session); err == nil {
 		t.Fatalf("stopProjectSandbox driver error returned nil error")
 	}
 	driver.err = nil
 	streams := &projectSessionStreamsFake{}
-	if err := stopProjectSandbox(ctx, "", nil, store, driver, streams, session, nil); err != nil {
+	if err := stopProjectSandbox(ctx, stopProjectSandboxDeps{Store: store, Driver: driver, Streams: streams}, session); err != nil {
 		t.Fatalf("stopProjectSandbox running err=%v", err)
 	}
 	if !store.updated || store.session.Summary.VMStatus != domain.VMStatusStopped || len(store.events) != 1 || streams.updated == 0 || streams.events == 0 {

--- a/pkg/agentcompose/app/project_controller.go
+++ b/pkg/agentcompose/app/project_controller.go
@@ -39,7 +39,14 @@ func NewProjectController(di do.Injector) (*projects.Controller, error) {
 		Volumes:    do.MustInvoke[*volumes.Manager](di),
 		Gateway:    do.MustInvoke[*configstore.ConfigStore](di),
 		StopSandbox: func(ctx context.Context, session *domain.Sandbox) error {
-			return stopProjectSandbox(ctx, do.MustInvoke[*appconfig.Config](di).SandboxRoot, do.MustInvoke[*sessionstream.LifecycleLocks](di), sessionStore, sandboxDriver, streams, session, do.MustInvoke[*adapters.CapabilitySandboxResolver](di))
+			return stopProjectSandbox(ctx, stopProjectSandboxDeps{
+				SandboxRoot:   do.MustInvoke[*appconfig.Config](di).SandboxRoot,
+				Locks:         do.MustInvoke[*sessionstream.LifecycleLocks](di),
+				Store:         sessionStore,
+				Driver:        sandboxDriver,
+				Streams:       streams,
+				AccessRevoker: do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
+			}, session)
 		},
 	}), nil
 }
@@ -49,22 +56,33 @@ type projectSandboxStreams interface {
 	PublishEventAdded(string, domain.SandboxEvent)
 }
 
-func stopProjectSandbox(ctx context.Context, sandboxRoot string, locks *sessionstream.LifecycleLocks, store sessionstream.LifecycleStore, driver sessionstream.SandboxDriver, streams projectSandboxStreams, session *domain.Sandbox, accessRevoker sessionstream.SandboxAccessRevoker) error {
+// stopProjectSandboxDeps bundles the lifecycle dependencies stopProjectSandbox
+// needs, as opposed to session, the sandbox actually being stopped.
+type stopProjectSandboxDeps struct {
+	SandboxRoot   string
+	Locks         *sessionstream.LifecycleLocks
+	Store         sessionstream.LifecycleStore
+	Driver        sessionstream.SandboxDriver
+	Streams       projectSandboxStreams
+	AccessRevoker sessionstream.SandboxAccessRevoker
+}
+
+func stopProjectSandbox(ctx context.Context, deps stopProjectSandboxDeps, session *domain.Sandbox) error {
 	if session == nil {
 		return nil
 	}
-	if store == nil {
+	if deps.Store == nil {
 		return fmt.Errorf("sandbox store is required")
 	}
 	_, err := (sessionstream.Lifecycle{
-		Config:        &appconfig.Config{SandboxRoot: sandboxRoot},
-		Store:         store,
-		Driver:        driver,
-		AccessRevoker: accessRevoker,
+		Config:        &appconfig.Config{SandboxRoot: deps.SandboxRoot},
+		Store:         deps.Store,
+		Driver:        deps.Driver,
+		AccessRevoker: deps.AccessRevoker,
 		Notifier: projectSandboxLifecycleNotifier{
-			streams: streams,
+			streams: deps.Streams,
 		},
-		Locks: locks,
+		Locks: deps.Locks,
 	}).StopLoaded(ctx, session)
 	return err
 }

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -68,7 +68,14 @@ type runCompletionStopper struct {
 }
 
 func (s runCompletionStopper) Stop(ctx context.Context, sandbox *domain.Sandbox) error {
-	return stopProjectSandbox(ctx, s.config.SandboxRoot, s.locks, s.store, s.driver, s.streams, sandbox, s.capTokens)
+	return stopProjectSandbox(ctx, stopProjectSandboxDeps{
+		SandboxRoot:   s.config.SandboxRoot,
+		Locks:         s.locks,
+		Store:         s.store,
+		Driver:        s.driver,
+		Streams:       s.streams,
+		AccessRevoker: s.capTokens,
+	}, sandbox)
 }
 
 func NewRunCompletionManager(di do.Injector) (*runs.CompletionManager, error) {


### PR DESCRIPTION
## Summary
- Second of several PRs covering `pkg/agentcompose` (14k lines, split by subpackage: `proxy` shipped as #613, `app` here, `api`/`adapters` to follow) for the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`).
- `startBackgroundManagers` (9 args, 1 call site): bundled into `backgroundManagersDeps`.
- `reconcilePersistedProjectRunsWithStatus` (5 args, 1 call site, called in a loop over statuses): bundled the store/completion-manager/startup-timestamp shared across every call into `projectRunReconcileContext`.
- `stopProjectSandbox` (8 args, 3 production call sites + heavy test coverage): bundled the lifecycle dependencies into `stopProjectSandboxDeps`, keeping `session` (the sandbox actually being stopped) as its own parameter.
- Dead-code audit of the subpackage's exported surface found no unused symbols — every constructor/type has 2+ references (definition plus real DI wiring or caller).
- No `//nolint` comments added since `.golangci.yml` doesn't enable these rules yet in this PR.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/agentcompose/app/...`
- [x] `go test ./pkg/agentcompose/app/...`
- [x] `golangci-lint run ./pkg/agentcompose/app/...` — 1 remaining issue, a deferred coverage-sweep test (same pattern as every other package this sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)