### PR TITLE
refactor(agentcompose/api): bundle multi-argument params into structs; split funlen violations

### DIFF
--- a/pkg/agentcompose/api/exec.go
+++ b/pkg/agentcompose/api/exec.go
@@ -55,12 +55,20 @@ func (h *ExecHandler) WithLifecycleLocks(locks *sandboxes.LifecycleLocks) *ExecH
 	return h
 }
 
-func NewExecHandler(config *appconfig.Config, store ExecSandboxStore, projects ExecProjectStore, runtime ExecRuntimeResolver, runAttach ...ExecRunAttachDelegate) *ExecHandler {
+// ExecHandlerDeps bundles NewExecHandler's required dependencies.
+type ExecHandlerDeps struct {
+	Config   *appconfig.Config
+	Store    ExecSandboxStore
+	Projects ExecProjectStore
+	Runtime  ExecRuntimeResolver
+}
+
+func NewExecHandler(deps ExecHandlerDeps, runAttach ...ExecRunAttachDelegate) *ExecHandler {
 	handler := &ExecHandler{
-		config:   config,
-		store:    store,
-		projects: projects,
-		runtime:  runtime,
+		config:   deps.Config,
+		store:    deps.Store,
+		projects: deps.Projects,
+		runtime:  deps.Runtime,
 	}
 	if len(runAttach) > 0 {
 		handler.runAttach = runAttach[0]

--- a/pkg/agentcompose/api/exec_attach.go
+++ b/pkg/agentcompose/api/exec_attach.go
@@ -196,7 +196,15 @@ func (s *execAttachState) responseFromRuntimeFrame(frame driverpkg.RuntimeOutput
 		if strings.TrimSpace(result.Error) != "" {
 			accumulated.Success = false
 		}
-		execResult := ExecResultToProto(s.execID, s.sandbox.Summary.ID, s.runID, s.request, s.cwd, accumulated, errorFromString(result.Error))
+		execResult := ExecResultToProto(ExecResultProtoRequest{
+			ExecID:    s.execID,
+			SandboxID: s.sandbox.Summary.ID,
+			RunID:     s.runID,
+			Request:   s.request,
+			Cwd:       s.cwd,
+			Result:    accumulated,
+			ExecErr:   errorFromString(result.Error),
+		})
 		resp.Frame = &agentcomposev2.AttachExecResponse_Result{Result: &agentcomposev2.AttachResult{
 			ExitCode:   int32(result.ExitCode),
 			Success:    result.Success,

--- a/pkg/agentcompose/api/exec_execution.go
+++ b/pkg/agentcompose/api/exec_execution.go
@@ -24,6 +24,99 @@ func errorFromString(text string) error {
 	return errors.New(text)
 }
 
+// execPreparation is the exec context prepareExecCommand assembles before
+// executeProjectCommand runs the command: the resolved cwd, VM state,
+// runtime handle, and the host/guest artifact directories, with the
+// command-request artifact already written to hostExecDir.
+type execPreparation struct {
+	Cwd          string
+	VMState      domain.VMState
+	Runtime      ExecRuntime
+	HostExecDir  string
+	GuestExecDir string
+}
+
+func (h *ExecHandler) prepareExecCommand(sandbox *domain.Sandbox, req *agentcomposev2.ExecRequest, execID string) (execPreparation, error) {
+	appconfig.ApplyDefaultGuestPaths(h.config)
+	cwd := strings.TrimSpace(req.GetCwd())
+	if cwd == "" {
+		cwd = h.config.GuestWorkspacePath
+	}
+	vmState, err := h.store.GetVMState(sandbox.Summary.ID)
+	if err != nil {
+		return execPreparation{}, connect.NewError(connect.CodeInternal, err)
+	}
+	runtime, err := h.runtime(sandbox)
+	if err != nil {
+		return execPreparation{}, ConnectErrorForDomain(err)
+	}
+	hostExecDir := filepath.Join(execution.HostSandboxDir(sandbox), "state", "exec", execID)
+	if err := os.MkdirAll(hostExecDir, 0o755); err != nil {
+		return execPreparation{}, connect.NewError(connect.CodeInternal, fmt.Errorf("create exec artifact dir: %w", err))
+	}
+	guestExecDir := filepath.Join(h.config.GuestStateRoot, "exec", execID)
+	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(
+		h.config,
+		"exec",
+		strings.TrimSpace(req.GetCommand().GetCommand()),
+		req.GetCommand().GetArgs(),
+		"",
+		cwd,
+		ExecEnvMap(req.GetEnv()),
+		int64(req.GetTimeoutMs()),
+		int64(req.GetMaxOutputBytes()),
+		guestExecDir,
+	)
+	if err := execution.WriteJSONArtifact(filepath.Join(hostExecDir, "command-request.json"), runtimeRequest); err != nil {
+		return execPreparation{}, connect.NewError(connect.CodeInternal, fmt.Errorf("write exec command request artifact: %w", err))
+	}
+	return execPreparation{Cwd: cwd, VMState: vmState, Runtime: runtime, HostExecDir: hostExecDir, GuestExecDir: guestExecDir}, nil
+}
+
+// execStreamWriterRequest bundles the identifiers newExecStreamWriter needs
+// to label each streamed output chunk.
+type execStreamWriterRequest struct {
+	TranscriptPath string
+	ExecID         string
+	SandboxID      string
+	RunID          string
+	Send           execStreamSender
+}
+
+// newExecStreamWriter builds the ExecStreamWriter that appends each output
+// chunk to the on-disk transcript and, if req.Send is non-nil, streams it to
+// the caller. The returned pointer holds the first streaming error
+// encountered; the caller checks it after ExecStream returns.
+func newExecStreamWriter(req execStreamWriterRequest) (domain.ExecStreamWriter, *error) {
+	var sendErr error
+	writer := func(chunk domain.ExecChunk) {
+		if sendErr != nil {
+			return
+		}
+		filtered, visible := execution.FilterCommandStreamChunk(chunk)
+		if !visible {
+			return
+		}
+		if err := appendExecTranscriptChunk(req.TranscriptPath, filtered); err != nil {
+			sendErr = err
+			return
+		}
+		if req.Send != nil {
+			createdAt := time.Now().UTC()
+			sendErr = req.Send(&agentcomposev2.StreamExecResponse{
+				EventType:  agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT,
+				ExecId:     req.ExecID,
+				SandboxId:  req.SandboxID,
+				RunId:      req.RunID,
+				Chunk:      filtered.Text,
+				Stream:     StdioStreamToProto(filtered.Stream),
+				Transcript: TranscriptEventFromExecChunk(filtered, createdAt),
+			})
+		}
+	}
+	return writer, &sendErr
+}
+
 func (h *ExecHandler) executeProjectCommand(ctx context.Context, req *agentcomposev2.ExecRequest, execID string, send execStreamSender) (*agentcomposev2.ExecResult, error) {
 	if h.store == nil || h.projects == nil || h.runtime == nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("exec runtime dependencies are required"))
@@ -38,8 +131,7 @@ func (h *ExecHandler) executeProjectCommand(ctx context.Context, req *agentcompo
 	if err != nil {
 		return nil, err
 	}
-	command := strings.TrimSpace(req.GetCommand().GetCommand())
-	if command == "" {
+	if strings.TrimSpace(req.GetCommand().GetCommand()) == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exec command is required"))
 	}
 	if send != nil {
@@ -52,71 +144,22 @@ func (h *ExecHandler) executeProjectCommand(ctx context.Context, req *agentcompo
 			return nil, connect.NewError(connect.CodeUnknown, err)
 		}
 	}
-	appconfig.ApplyDefaultGuestPaths(h.config)
-	cwd := strings.TrimSpace(req.GetCwd())
-	if cwd == "" {
-		cwd = h.config.GuestWorkspacePath
-	}
-	vmState, err := h.store.GetVMState(sandbox.Summary.ID)
+	prep, err := h.prepareExecCommand(sandbox, req, execID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, err
 	}
-	runtime, err := h.runtime(sandbox)
-	if err != nil {
-		return nil, ConnectErrorForDomain(err)
-	}
-	hostExecDir := filepath.Join(execution.HostSandboxDir(sandbox), "state", "exec", execID)
-	if err := os.MkdirAll(hostExecDir, 0o755); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create exec artifact dir: %w", err))
-	}
-	guestExecDir := filepath.Join(h.config.GuestStateRoot, "exec", execID)
-	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(
-		h.config,
-		"exec",
-		command,
-		req.GetCommand().GetArgs(),
-		"",
-		cwd,
-		ExecEnvMap(req.GetEnv()),
-		int64(req.GetTimeoutMs()),
-		int64(req.GetMaxOutputBytes()),
-		guestExecDir,
-	)
-	if err := execution.WriteJSONArtifact(filepath.Join(hostExecDir, "command-request.json"), runtimeRequest); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("write exec command request artifact: %w", err))
-	}
-	transcriptPath := filepath.Join(hostExecDir, "transcript.txt")
-	var sendErr error
-	writer := func(chunk domain.ExecChunk) {
-		if sendErr != nil {
-			return
-		}
-		filtered, visible := execution.FilterCommandStreamChunk(chunk)
-		if !visible {
-			return
-		}
-		if err := appendExecTranscriptChunk(transcriptPath, filtered); err != nil {
-			sendErr = err
-			return
-		}
-		if send != nil {
-			createdAt := time.Now().UTC()
-			sendErr = send(&agentcomposev2.StreamExecResponse{
-				EventType:  agentcomposev2.StreamExecEventType_STREAM_EXEC_EVENT_TYPE_OUTPUT,
-				ExecId:     execID,
-				SandboxId:  sandbox.Summary.ID,
-				RunId:      runID,
-				Chunk:      filtered.Text,
-				Stream:     StdioStreamToProto(filtered.Stream),
-				Transcript: TranscriptEventFromExecChunk(filtered, createdAt),
-			})
-		}
-	}
+	writer, sendErr := newExecStreamWriter(execStreamWriterRequest{
+		TranscriptPath: filepath.Join(prep.HostExecDir, "transcript.txt"),
+		ExecID:         execID,
+		SandboxID:      sandbox.Summary.ID,
+		RunID:          runID,
+		Send:           send,
+	})
 	execCtx, cancel := execution.ExecContext(ctx, req.GetTimeoutMs())
 	defer cancel()
-	result, execErr := runtime.ExecStream(execCtx, sandbox, vmState, execution.BuildRuntimeCommandExecSpec(h.config, sandbox, filepath.Join(guestExecDir, "command-request.json"), h.config.GuestHomePath), writer)
-	if sendErr != nil {
-		return nil, connect.NewError(connect.CodeUnknown, sendErr)
+	result, execErr := prep.Runtime.ExecStream(execCtx, sandbox, prep.VMState, execution.BuildRuntimeCommandExecSpec(h.config, sandbox, filepath.Join(prep.GuestExecDir, "command-request.json"), h.config.GuestHomePath), writer)
+	if *sendErr != nil {
+		return nil, connect.NewError(connect.CodeUnknown, *sendErr)
 	}
 	if execErr != nil {
 		result.ExitCode = execution.FirstNonZeroInt(result.ExitCode, 1)
@@ -124,16 +167,31 @@ func (h *ExecHandler) executeProjectCommand(ctx context.Context, req *agentcompo
 		if strings.TrimSpace(result.Output) == "" {
 			result.Output = firstNonEmpty(result.Stderr, result.Stdout, execErr.Error())
 		}
-		return ExecResultToProto(execID, sandbox.Summary.ID, runID, req, cwd, result, execErr), nil
+		return ExecResultToProto(ExecResultProtoRequest{
+			ExecID:    execID,
+			SandboxID: sandbox.Summary.ID,
+			RunID:     runID,
+			Request:   req,
+			Cwd:       prep.Cwd,
+			Result:    result,
+			ExecErr:   execErr,
+		}), nil
 	}
 	commandResult, err := execution.ParseCommandExecResult(result)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	if err := execution.MirrorRuntimeCommandArtifacts(hostExecDir, commandResult); err != nil {
+	if err := execution.MirrorRuntimeCommandArtifacts(prep.HostExecDir, commandResult); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return ExecResultToProto(execID, sandbox.Summary.ID, runID, req, cwd, execution.RuntimeCommandResultToExecResult(commandResult), nil), nil
+	return ExecResultToProto(ExecResultProtoRequest{
+		ExecID:    execID,
+		SandboxID: sandbox.Summary.ID,
+		RunID:     runID,
+		Request:   req,
+		Cwd:       prep.Cwd,
+		Result:    execution.RuntimeCommandResultToExecResult(commandResult),
+	}), nil
 }
 
 func appendExecTranscriptChunk(path string, chunk domain.ExecChunk) error {

--- a/pkg/agentcompose/api/exec_mapper.go
+++ b/pkg/agentcompose/api/exec_mapper.go
@@ -22,20 +22,33 @@ func ExecEnvMap(items []*agentcomposev2.EnvVarSpec) map[string]string {
 	return result
 }
 
-func ExecResultToProto(execID, sandboxID, runID string, req *agentcomposev2.ExecRequest, cwd string, result domain.ExecResult, execErr error) *agentcomposev2.ExecResult {
+// ExecResultProtoRequest bundles the exec identifiers and originating
+// request ExecResultToProto needs alongside the runtime result itself.
+type ExecResultProtoRequest struct {
+	ExecID    string
+	SandboxID string
+	RunID     string
+	Request   *agentcomposev2.ExecRequest
+	Cwd       string
+	Result    domain.ExecResult
+	ExecErr   error
+}
+
+func ExecResultToProto(req ExecResultProtoRequest) *agentcomposev2.ExecResult {
 	errorText := ""
-	if execErr != nil {
-		errorText = execErr.Error()
+	if req.ExecErr != nil {
+		errorText = req.ExecErr.Error()
 	}
+	result := req.Result
 	return &agentcomposev2.ExecResult{
-		ExecId:    execID,
-		SandboxId: sandboxID,
-		RunId:     runID,
+		ExecId:    req.ExecID,
+		SandboxId: req.SandboxID,
+		RunId:     req.RunID,
 		Command: &agentcomposev2.ExecCommand{
-			Command: req.GetCommand().GetCommand(),
-			Args:    append([]string(nil), req.GetCommand().GetArgs()...),
+			Command: req.Request.GetCommand().GetCommand(),
+			Args:    append([]string(nil), req.Request.GetCommand().GetArgs()...),
 		},
-		Cwd:      cwd,
+		Cwd:      req.Cwd,
 		ExitCode: int32(result.ExitCode),
 		Success:  result.Success,
 		Stdout:   result.Stdout,

--- a/pkg/agentcompose/api/exec_target.go
+++ b/pkg/agentcompose/api/exec_target.go
@@ -121,6 +121,13 @@ func (h *ExecHandler) resolveExecTargetSandbox(ctx context.Context, req *agentco
 	if selector == nil {
 		return nil, "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exec target is required"))
 	}
+	return h.resolveExecTargetBySelector(ctx, selector)
+}
+
+// resolveExecTargetBySelector resolves the single running sandbox matching a
+// project (and optionally agent) selector, erroring if none or more than one
+// candidate is found.
+func (h *ExecHandler) resolveExecTargetBySelector(ctx context.Context, selector *agentcomposev2.ExecSandboxSelector) (*domain.Sandbox, string, error) {
 	projectRef := &agentcomposev2.ProjectRef{}
 	switch project := selector.GetProject().(type) {
 	case *agentcomposev2.ExecSandboxSelector_ProjectId:

--- a/pkg/agentcompose/api/handler_coverage_test.go
+++ b/pkg/agentcompose/api/handler_coverage_test.go
@@ -96,7 +96,12 @@ func TestRemoveSandboxRemoveRaceRemainsInternal(t *testing.T) {
 		session:   &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}},
 		removeErr: os.ErrNotExist,
 	}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 	_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeInternal {
 		t.Fatalf("RemoveSandbox error code = %v, want %v; err=%v", connect.CodeOf(err), connect.CodeInternal, err)
@@ -120,7 +125,12 @@ func TestGetSandboxStatsReturnsRuntimeMetrics(t *testing.T) {
 		CPUPercent:       domain.MetricValue{Value: &value, Unit: "percent", Status: domain.MetricStatusOK},
 		MemoryUsageBytes: domain.MetricValue{Unit: "bytes", Status: domain.MetricStatusUnknown},
 	}}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, nil, nil, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   nil,
+		Dashboard: nil,
+	}, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
 		return runtime, nil
 	})
 	resp, err := handler.GetSandboxStats(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
@@ -143,7 +153,12 @@ func TestGetSandboxStatsRejectsStoppedSandbox(t *testing.T) {
 	store := &apiSandboxStore{
 		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}},
 	}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, nil, nil, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   nil,
+		Dashboard: nil,
+	}, func(*domain.Sandbox) (SandboxStatsRuntime, error) {
 		return &apiStatsRuntime{}, nil
 	})
 	_, err := handler.GetSandboxStats(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
@@ -157,7 +172,12 @@ func TestGetSandboxStatsUnsupportedRuntimeIsUnimplemented(t *testing.T) {
 	store := &apiSandboxStore{
 		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusRunning}},
 	}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, nil, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   nil,
+		Dashboard: nil,
+	})
 	_, err := handler.GetSandboxStats(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxStatsRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeUnimplemented {
 		t.Fatalf("GetSandboxStats unsupported code = %v, err=%v", connect.CodeOf(err), err)
@@ -337,8 +357,13 @@ func TestExecHandlerSandboxTargetWorkflow(t *testing.T) {
 	sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", VMStatus: domain.VMStatusRunning, WorkspacePath: filepath.Join(sandboxRoot, "workspace")}}
 	store := &apiExecSandboxStore{sandbox: sandbox, vm: domain.VMState{Driver: "docker"}}
 	runtime := &apiExecRuntime{}
-	handler := NewExecHandler(&appconfig.Config{}, store, apiExecProjectStore{}, func(*domain.Sandbox) (ExecRuntime, error) {
-		return runtime, nil
+	handler := NewExecHandler(ExecHandlerDeps{
+		Config:   &appconfig.Config{},
+		Store:    store,
+		Projects: apiExecProjectStore{},
+		Runtime: func(*domain.Sandbox) (ExecRuntime, error) {
+			return runtime, nil
+		},
 	})
 	resp, err := handler.Exec(ctx, connect.NewRequest(&agentcomposev2.ExecRequest{
 		Target:  &agentcomposev2.ExecRequest_SandboxId{SandboxId: "sandbox-1"},
@@ -401,8 +426,13 @@ func TestExecHandlerRunSelectorAndStreamSenderWorkflow(t *testing.T) {
 		},
 	}
 	runtime := &apiExecRuntime{}
-	handler := NewExecHandler(&appconfig.Config{}, store, projects, func(*domain.Sandbox) (ExecRuntime, error) {
-		return runtime, nil
+	handler := NewExecHandler(ExecHandlerDeps{
+		Config:   &appconfig.Config{},
+		Store:    store,
+		Projects: projects,
+		Runtime: func(*domain.Sandbox) (ExecRuntime, error) {
+			return runtime, nil
+		},
 	})
 
 	var events []*agentcomposev2.StreamExecResponse
@@ -507,8 +537,13 @@ func TestExecHandlerSelectorRechecksVMStatusAfterSummaryFilter(t *testing.T) {
 			{RunID: "run-stale", ProjectID: "project-1", ProjectName: "Project", AgentName: "worker", SandboxID: "sandbox-stale"},
 		},
 	}
-	handler := NewExecHandler(&appconfig.Config{}, store, projects, func(*domain.Sandbox) (ExecRuntime, error) {
-		return &apiExecRuntime{}, nil
+	handler := NewExecHandler(ExecHandlerDeps{
+		Config:   &appconfig.Config{},
+		Store:    store,
+		Projects: projects,
+		Runtime: func(*domain.Sandbox) (ExecRuntime, error) {
+			return &apiExecRuntime{}, nil
+		},
 	})
 	_, err := handler.executeProjectCommand(ctx, &agentcomposev2.ExecRequest{
 		Target:  &agentcomposev2.ExecRequest_Selector{Selector: &agentcomposev2.ExecSandboxSelector{Project: &agentcomposev2.ExecSandboxSelector_ProjectId{ProjectId: "project-1"}, AgentName: "worker"}},
@@ -520,8 +555,13 @@ func TestExecHandlerSelectorRechecksVMStatusAfterSummaryFilter(t *testing.T) {
 }
 
 func TestExecHandlerSelectorErrors(t *testing.T) {
-	handler := NewExecHandler(&appconfig.Config{}, &apiExecSandboxStore{}, apiExecProjectStore{err: sql.ErrNoRows}, func(*domain.Sandbox) (ExecRuntime, error) {
-		return &apiExecRuntime{}, nil
+	handler := NewExecHandler(ExecHandlerDeps{
+		Config:   &appconfig.Config{},
+		Store:    &apiExecSandboxStore{},
+		Projects: apiExecProjectStore{err: sql.ErrNoRows},
+		Runtime: func(*domain.Sandbox) (ExecRuntime, error) {
+			return &apiExecRuntime{}, nil
+		},
 	})
 	if _, err := handler.Exec(context.Background(), connect.NewRequest(&agentcomposev2.ExecRequest{})); connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("expected target error, got %v", err)
@@ -660,8 +700,13 @@ func TestExecAttachPromptDelegatesToRunAttach(t *testing.T) {
 		RunID: "run-latest", ProjectID: "project-1", AgentName: "worker", SandboxID: "session-attach",
 	}}}
 	delegate := &apiExecPromptRunAttachDelegate{}
-	handler := NewExecHandler(&appconfig.Config{}, store, projects, func(*domain.Sandbox) (ExecRuntime, error) {
-		return &apiExecRuntime{}, nil
+	handler := NewExecHandler(ExecHandlerDeps{
+		Config:   &appconfig.Config{},
+		Store:    store,
+		Projects: projects,
+		Runtime: func(*domain.Sandbox) (ExecRuntime, error) {
+			return &apiExecRuntime{}, nil
+		},
 	}, delegate)
 	var sent []*agentcomposev2.AttachExecResponse
 	err := handler.execAttach(context.Background(), sliceExecAttachReceiver(
@@ -1205,8 +1250,13 @@ func newExecAttachTestHandler(t *testing.T, runtime ExecRuntime) *ExecHandler {
 	t.Helper()
 	session := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-attach", VMStatus: domain.VMStatusRunning}}
 	store := &apiExecSandboxStore{sandbox: session, vm: domain.VMState{Driver: "docker"}}
-	return NewExecHandler(&appconfig.Config{}, store, apiExecProjectStore{}, func(*domain.Sandbox) (ExecRuntime, error) {
-		return runtime, nil
+	return NewExecHandler(ExecHandlerDeps{
+		Config:   &appconfig.Config{},
+		Store:    store,
+		Projects: apiExecProjectStore{},
+		Runtime: func(*domain.Sandbox) (ExecRuntime, error) {
+			return runtime, nil
+		},
 	})
 }
 

--- a/pkg/agentcompose/api/project_agent_model_test.go
+++ b/pkg/agentcompose/api/project_agent_model_test.go
@@ -23,7 +23,7 @@ func (s projectAgentModelResolverStub) ResolveProjectAgentModels(context.Context
 
 func TestNewProjectHandlerWithAgentModelsSetsResolver(t *testing.T) {
 	resolver := projectAgentModelResolverStub{}
-	handler := NewProjectHandlerWithAgentModels(nil, nil, nil, resolver, nil)
+	handler := NewProjectHandlerWithAgentModels(ProjectHandlerDeps{AgentModels: resolver})
 
 	if _, ok := handler.agentModels.(projectAgentModelResolverStub); !ok {
 		t.Fatalf("agent model resolver = %#v", handler.agentModels)

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -81,7 +81,7 @@ func NewProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRu
 	if len(schedulerRuntimes) > 0 {
 		schedulerRuntime = schedulerRuntimes[0]
 	}
-	return newProjectHandler(delegate, store, schedulerRuntime, nil, nil)
+	return newProjectHandler(ProjectHandlerDeps{Delegate: delegate, Store: store, SchedulerRuntime: schedulerRuntime})
 }
 
 // WithSandboxDirs injects the sandbox directory resolver ResolveEventMessage
@@ -104,17 +104,27 @@ func (h *ProjectHandler) WithSandboxDirs(sandboxDirs schedulers.SandboxDirResolv
 	return h
 }
 
-// NewProjectHandlerWithAgentModels constructs a project handler that enriches project responses with resolved agent models
-// and, given sandboxDirs, reconstructs command.completed scheduler_event messages from sandbox cell artifacts.
-func NewProjectHandlerWithAgentModels(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver, sandboxDirs schedulers.SandboxDirResolver) *ProjectHandler {
-	return newProjectHandler(delegate, store, schedulerRuntime, agentModels, sandboxDirs)
+// ProjectHandlerDeps bundles NewProjectHandlerWithAgentModels' (and, via
+// newProjectHandler, NewProjectHandler's) dependencies.
+type ProjectHandlerDeps struct {
+	Delegate         ProjectDelegate
+	Store            ProjectStore
+	SchedulerRuntime ProjectSchedulerRuntime
+	AgentModels      ProjectAgentModelResolver
+	SandboxDirs      schedulers.SandboxDirResolver
 }
 
-func newProjectHandler(delegate ProjectDelegate, store ProjectStore, schedulerRuntime ProjectSchedulerRuntime, agentModels ProjectAgentModelResolver, sandboxDirs schedulers.SandboxDirResolver) *ProjectHandler {
-	schedulerRuns, _ := schedulerRuntime.(ProjectSchedulerRunRuntime)
-	invocations, _ := schedulerRuntime.(ProjectSchedulerInvocationRuntime)
-	schedulerPrune, _ := schedulerRuntime.(ProjectSchedulerPruneRuntime)
-	return &ProjectHandler{delegate: delegate, store: store, agentModels: agentModels, schedulerRuntime: schedulerRuntime, schedulerRuns: schedulerRuns, invocations: invocations, schedulerPrune: schedulerPrune, sandboxDirs: sandboxDirs}
+// NewProjectHandlerWithAgentModels constructs a project handler that enriches project responses with resolved agent models
+// and, given sandboxDirs, reconstructs command.completed scheduler_event messages from sandbox cell artifacts.
+func NewProjectHandlerWithAgentModels(deps ProjectHandlerDeps) *ProjectHandler {
+	return newProjectHandler(deps)
+}
+
+func newProjectHandler(deps ProjectHandlerDeps) *ProjectHandler {
+	schedulerRuns, _ := deps.SchedulerRuntime.(ProjectSchedulerRunRuntime)
+	invocations, _ := deps.SchedulerRuntime.(ProjectSchedulerInvocationRuntime)
+	schedulerPrune, _ := deps.SchedulerRuntime.(ProjectSchedulerPruneRuntime)
+	return &ProjectHandler{delegate: deps.Delegate, store: deps.Store, agentModels: deps.AgentModels, schedulerRuntime: deps.SchedulerRuntime, schedulerRuns: schedulerRuns, invocations: invocations, schedulerPrune: schedulerPrune, sandboxDirs: deps.SandboxDirs}
 }
 
 func (h *ProjectHandler) ValidateProject(ctx context.Context, req *connect.Request[agentcomposev2.ValidateProjectRequest]) (*connect.Response[agentcomposev2.ValidateProjectResponse], error) {

--- a/pkg/agentcompose/api/project_mapper.go
+++ b/pkg/agentcompose/api/project_mapper.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	domain "agent-compose/pkg/model"
-	"agent-compose/pkg/projects"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
 )
 
@@ -150,58 +149,6 @@ func projectSchedulerPresentation(specJSON string) (string, string) {
 		return "", ""
 	}
 	return strings.TrimSpace(presentation.DisplayName), strings.TrimSpace(presentation.Description)
-}
-
-func ProjectApplyChanges(project domain.ProjectRecord, existing domain.ProjectRecord, found bool, revision domain.ProjectRevisionRecord, revisionCreated bool) []*agentcomposev2.ProjectChange {
-	projectAction := agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED
-	if found {
-		projectAction = agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UNCHANGED
-		if !projects.ProjectRecordUnchanged(existing, project) {
-			projectAction = agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_UPDATED
-		}
-	}
-	return []*agentcomposev2.ProjectChange{
-		{
-			Action:       projectAction,
-			ResourceType: "project",
-			ResourceId:   project.ID,
-			Name:         project.Name,
-		},
-	}
-}
-
-func DryRunProjectChanges(project domain.ProjectRecord, agents []domain.ProjectAgentRecord, agentDefinitions []domain.AgentDefinition, schedulers []domain.ProjectSchedulerRecord, _ []domain.Scheduler) []*agentcomposev2.ProjectChange {
-	changes := []*agentcomposev2.ProjectChange{{
-		Action:       agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED,
-		ResourceType: "project",
-		ResourceId:   project.ID,
-		Name:         project.Name,
-	}}
-	for _, agent := range agents {
-		changes = append(changes, &agentcomposev2.ProjectChange{
-			Action:       agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED,
-			ResourceType: "project_agent",
-			ResourceId:   agent.ID,
-			Name:         agent.AgentName,
-		})
-	}
-	for _, agent := range agentDefinitions {
-		changes = append(changes, &agentcomposev2.ProjectChange{
-			Action:       agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED,
-			ResourceType: "agent_definition",
-			ResourceId:   agent.ID,
-			Name:         agent.Name,
-		})
-	}
-	for _, scheduler := range schedulers {
-		changes = append(changes, &agentcomposev2.ProjectChange{
-			Action:       agentcomposev2.ProjectChangeAction_PROJECT_CHANGE_ACTION_CREATED,
-			ResourceType: "scheduler",
-			ResourceId:   scheduler.ID,
-			Name:         scheduler.AgentName,
-		})
-	}
-	return changes
 }
 
 func ProjectServiceSourcePath(source *agentcomposev2.ProjectSource) string {

--- a/pkg/agentcompose/api/project_scheduler_stream_handler.go
+++ b/pkg/agentcompose/api/project_scheduler_stream_handler.go
@@ -59,10 +59,30 @@ func (h *ProjectHandler) StreamProjectSchedulerEvents(ctx context.Context, req *
 			lower = &boundary[0]
 		}
 	}
-	return h.sendSchedulerEventPages(ctx, stream, selection, baseFilter, lower, upper[0], batchSize)
+	return h.sendSchedulerEventPages(ctx, schedulerEventPageStreamRequest{
+		Stream:    stream,
+		Selection: selection,
+		Base:      baseFilter,
+		Lower:     lower,
+		Upper:     upper[0],
+		BatchSize: batchSize,
+	})
 }
 
-func (h *ProjectHandler) sendSchedulerEventPages(ctx context.Context, stream *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse], selection schedulerEventStreamSelection, base schedulers.SchedulerEventPageFilter, lower *domain.SchedulerEvent, upper domain.SchedulerEvent, batchSize int) error {
+// schedulerEventPageStreamRequest bundles the stream, selection, and page
+// window sendSchedulerEventPages needs to page through and send scheduler
+// events in display order.
+type schedulerEventPageStreamRequest struct {
+	Stream    *connect.ServerStream[agentcomposev2.StreamProjectSchedulerEventsResponse]
+	Selection schedulerEventStreamSelection
+	Base      schedulers.SchedulerEventPageFilter
+	Lower     *domain.SchedulerEvent
+	Upper     domain.SchedulerEvent
+	BatchSize int
+}
+
+func (h *ProjectHandler) sendSchedulerEventPages(ctx context.Context, req schedulerEventPageStreamRequest) error {
+	selection, base, lower, upper, batchSize := req.Selection, req.Base, req.Lower, req.Upper, req.BatchSize
 	var after *domain.SchedulerEvent
 	var emitted uint64
 	checkpoint := ""
@@ -96,15 +116,22 @@ func (h *ProjectHandler) sendSchedulerEventPages(ctx context.Context, stream *co
 		last := events[len(events)-1]
 		after = &last
 		emitted += uint64(len(items))
-		checkpoint = encodeProjectSchedulerEventCursor(selection.project.ID, selection.project.CurrentRevision, selection.agentName, selection.triggerID, selection.runID, last)
-		if err := stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Events: items, Checkpoint: checkpoint, EmittedCount: emitted}); err != nil {
+		checkpoint = encodeProjectSchedulerEventCursor(projectSchedulerEventCursorRequest{
+			ProjectID:       selection.project.ID,
+			ProjectRevision: selection.project.CurrentRevision,
+			AgentName:       selection.agentName,
+			TriggerID:       selection.triggerID,
+			RunID:           selection.runID,
+			Event:           last,
+		})
+		if err := req.Stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Events: items, Checkpoint: checkpoint, EmittedCount: emitted}); err != nil {
 			return err
 		}
 		if len(events) < batchSize || sameSchedulerEventKey(last, upper) {
 			break
 		}
 	}
-	return stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Complete: true, Checkpoint: checkpoint, EmittedCount: emitted})
+	return req.Stream.Send(&agentcomposev2.StreamProjectSchedulerEventsResponse{Complete: true, Checkpoint: checkpoint, EmittedCount: emitted})
 }
 
 func (h *ProjectHandler) schedulerEventStreamSelection(ctx context.Context, req *agentcomposev2.StreamProjectSchedulerEventsRequest) (schedulerEventStreamSelection, error) {
@@ -208,7 +235,14 @@ func (h *ProjectHandler) sendSchedulerRunPages(ctx context.Context, stream *conn
 		last := page[len(page)-1]
 		before = &last
 		emitted += uint64(len(items))
-		checkpoint = encodeSchedulerRunCursor(selection.project.ID, selection.project.CurrentRevision, selection.agentName, selection.triggerID, selection.status, last)
+		checkpoint = encodeSchedulerRunCursor(schedulerRunCursorRequest{
+			ProjectID:       selection.project.ID,
+			ProjectRevision: selection.project.CurrentRevision,
+			AgentName:       selection.agentName,
+			TriggerID:       selection.triggerID,
+			Status:          selection.status,
+			Run:             last,
+		})
 		if err := stream.Send(&agentcomposev2.StreamSchedulerRunsResponse{Runs: items, Checkpoint: checkpoint, EmittedCount: emitted}); err != nil {
 			return err
 		}

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -279,13 +279,23 @@ func (h *RunHandler) FollowRunLogs(ctx context.Context, req *connect.Request[age
 			return err
 		}
 	}
+	target := runLogFollowTarget{Run: run, Offset: offset, Stream: stream}
 	if req.Msg.GetFollow() && h.runLogs != nil {
-		return h.followRunLogsWithHub(ctx, req.Msg.GetProjectId(), run, offset, stream)
+		return h.followRunLogsWithHub(ctx, req.Msg.GetProjectId(), target)
 	}
-	return h.followRunLogsByPolling(ctx, req, run, offset, stream)
+	return h.followRunLogsByPolling(ctx, req, target)
 }
 
-func (h *RunHandler) followRunLogsByPolling(ctx context.Context, req *connect.Request[agentcomposev2.FollowRunLogsRequest], run domain.ProjectRunRecord, offset uint64, stream *connect.ServerStream[agentcomposev2.RunLogChunk]) error {
+// runLogFollowTarget bundles the run, log offset, and output stream shared by
+// followRunLogsByPolling and followRunLogsWithHub.
+type runLogFollowTarget struct {
+	Run    domain.ProjectRunRecord
+	Offset uint64
+	Stream *connect.ServerStream[agentcomposev2.RunLogChunk]
+}
+
+func (h *RunHandler) followRunLogsByPolling(ctx context.Context, req *connect.Request[agentcomposev2.FollowRunLogsRequest], target runLogFollowTarget) error {
+	run, offset, stream := target.Run, target.Offset, target.Stream
 	runID := run.RunID
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
@@ -309,10 +319,11 @@ func (h *RunHandler) followRunLogsByPolling(ctx context.Context, req *connect.Re
 	}
 }
 
-func (h *RunHandler) followRunLogsWithHub(ctx context.Context, projectID string, run domain.ProjectRunRecord, offset uint64, stream *connect.ServerStream[agentcomposev2.RunLogChunk]) error {
+func (h *RunHandler) followRunLogsWithHub(ctx context.Context, projectID string, target runLogFollowTarget) error {
+	run, offset, stream := target.Run, target.Offset, target.Stream
 	sub := h.runLogs.Subscribe(run.RunID)
 	if sub == nil {
-		return h.followRunLogsByPolling(ctx, connect.NewRequest(&agentcomposev2.FollowRunLogsRequest{ProjectId: projectID, RunId: run.RunID, Follow: true}), run, offset, stream)
+		return h.followRunLogsByPolling(ctx, connect.NewRequest(&agentcomposev2.FollowRunLogsRequest{ProjectId: projectID, RunId: run.RunID, Follow: true}), target)
 	}
 	defer sub.Close()
 	if err := sendRunLogFileChunks(stream, run, &offset, time.Now().UTC()); err != nil {

--- a/pkg/agentcompose/api/runtime_driver_compiled_boundary_test.go
+++ b/pkg/agentcompose/api/runtime_driver_compiled_boundary_test.go
@@ -29,7 +29,12 @@ func TestRuntimeDriverNotCompiledConnectBoundaries(t *testing.T) {
 			ID: sandboxID, Driver: driverpkg.RuntimeDriverMicrosandbox, VMStatus: domain.VMStatusStopped, RuntimeRef: "original-runtime-ref",
 		}}}
 		remover := &characterizationSandboxRemover{err: unsupported}
-		handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, remover, nil)
+		handler := NewSandboxHandler(SandboxHandlerDeps{
+			Delegate:  &characterizationSessionDelegate{},
+			Store:     store,
+			Remover:   remover,
+			Dashboard: nil,
+		})
 
 		_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 		if connect.CodeOf(err) != connect.CodeUnimplemented || !errors.Is(err, driverpkg.ErrRuntimeDriverNotCompiled) {
@@ -48,8 +53,13 @@ func TestRuntimeDriverNotCompiledConnectBoundaries(t *testing.T) {
 		}}
 		vmState := domain.VMState{Driver: driverpkg.RuntimeDriverMicrosandbox, BoxID: "original-box"}
 		store := &apiExecSandboxStore{sandbox: sandbox, vm: vmState}
-		handler := NewExecHandler(&appconfig.Config{}, store, apiExecProjectStore{}, func(*domain.Sandbox) (ExecRuntime, error) {
-			return nil, unsupported
+		handler := NewExecHandler(ExecHandlerDeps{
+			Config:   &appconfig.Config{},
+			Store:    store,
+			Projects: apiExecProjectStore{},
+			Runtime: func(*domain.Sandbox) (ExecRuntime, error) {
+				return nil, unsupported
+			},
 		})
 		req := &agentcomposev2.ExecRequest{
 			Target:  &agentcomposev2.ExecRequest_SandboxId{SandboxId: sandbox.Summary.ID},

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -110,9 +110,17 @@ func (h *SandboxHandler) WithRunTargetResolver(resolver SandboxRunTargetResolver
 	return h
 }
 
-func NewSandboxHandler(delegate SandboxLifecycleDelegate, store SandboxStore, remover SandboxRuntimeRemover, dashboard SandboxDashboardNotifier, stats ...SandboxStatsRuntimeResolver) *SandboxHandler {
-	handler := &SandboxHandler{delegate: delegate, store: store, remover: remover, dashboard: dashboard}
-	if reconciler, ok := delegate.(SandboxRuntimeReconciler); ok {
+// SandboxHandlerDeps bundles NewSandboxHandler's required dependencies.
+type SandboxHandlerDeps struct {
+	Delegate  SandboxLifecycleDelegate
+	Store     SandboxStore
+	Remover   SandboxRuntimeRemover
+	Dashboard SandboxDashboardNotifier
+}
+
+func NewSandboxHandler(deps SandboxHandlerDeps, stats ...SandboxStatsRuntimeResolver) *SandboxHandler {
+	handler := &SandboxHandler{delegate: deps.Delegate, store: deps.Store, remover: deps.Remover, dashboard: deps.Dashboard}
+	if reconciler, ok := deps.Delegate.(SandboxRuntimeReconciler); ok {
 		handler.reconciler = reconciler
 	}
 	if len(stats) > 0 {

--- a/pkg/agentcompose/api/sandbox_characterization_test.go
+++ b/pkg/agentcompose/api/sandbox_characterization_test.go
@@ -24,7 +24,12 @@ func TestV2SandboxLifecycleActions(t *testing.T) {
 	store := &characterizationSandboxStore{session: &domain.Sandbox{Summary: domain.SandboxSummary{
 		ID: sandboxID, Driver: "docker", VMStatus: domain.VMStatusRunning, CreatedAt: now, UpdatedAt: now, ProxyPath: "/agent-compose/session/" + sandboxID,
 	}}}
-	handler := NewSandboxHandler(delegate, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	got, err := handler.GetSandbox(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxRequest{SandboxId: sandboxID}))
 	if err != nil || got.Msg.GetSandbox().GetStatus() != agentcomposev2.SandboxStatus_SANDBOX_STATUS_RUNNING || got.Msg.GetSandbox().GetProxyPath() == "" || delegate.proxyCalls != 0 {
@@ -44,7 +49,12 @@ func TestV2SandboxLifecycleActions(t *testing.T) {
 func TestV2GetSandboxAcceptsLegacyUUID(t *testing.T) {
 	const sandboxID = "28fed243-4d9d-4e56-96cf-8b2baa8643c8"
 	store := &characterizationSandboxStore{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID}}}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	response, err := handler.GetSandbox(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxRequest{SandboxId: sandboxID}))
 	if err != nil {
@@ -67,7 +77,12 @@ func TestV2GetSandboxIncludesSavedExposedNotebookURL(t *testing.T) {
 		session:    &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusRunning, ProxyPath: "/jupyter/" + sandboxID + "/lab"}},
 		proxyState: domain.ProxyState{Enabled: true, Exposed: true, ProxyPath: "/jupyter/" + sandboxID + "/lab", Token: "token value"},
 	}
-	handler := NewSandboxHandler(delegate, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	response, err := handler.GetSandbox(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxRequest{SandboxId: sandboxID}))
 	if err != nil {
@@ -90,7 +105,12 @@ func TestGetSandboxDoesNotPrepareProxyForStoppedSandbox(t *testing.T) {
 		}},
 		proxyState: domain.ProxyState{Enabled: true, Exposed: true, ProxyPath: "/agent-compose/session/" + sandboxID, Token: "token"},
 	}
-	handler := NewSandboxHandler(delegate, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	response, err := handler.GetSandbox(context.Background(), connect.NewRequest(&agentcomposev2.GetSandboxRequest{SandboxId: sandboxID}))
 	if err != nil {
@@ -115,7 +135,12 @@ func TestV2ListSandboxHistoryReturnsLegacyCellsAndEvents(t *testing.T) {
 		cells:   []domain.NotebookCell{{ID: "cell-1", Type: "agent", Source: "hello", Output: "world", Agent: "codex", CreatedAt: createdAt}},
 		events:  []domain.SandboxEvent{{ID: "event-1", Type: "agent.completed", Level: "info", Message: "done", CreatedAt: createdAt}},
 	}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	response, err := handler.ListSandboxHistory(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxHistoryRequest{SandboxId: sandboxID}))
 	if err != nil {
@@ -154,7 +179,12 @@ func TestV2SandboxLifecycleIsIdempotentAndRejectsInvalidState(t *testing.T) {
 	sandboxID := identity.NewID(identity.ResourceSandbox, "characterization", "idempotent")
 	delegate := &characterizationSessionDelegate{}
 	store := &characterizationSandboxStore{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped}}}
-	handler := NewSandboxHandler(delegate, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	if _, err := handler.StopSandbox(context.Background(), connect.NewRequest(&agentcomposev2.StopSandboxRequest{SandboxId: sandboxID})); err != nil {
 		t.Fatalf("idempotent StopSandbox: %v", err)
@@ -174,7 +204,12 @@ func TestV2ListSandboxesEmptyPageReturnsTotal(t *testing.T) {
 	store := &characterizationSandboxStore{listResults: []domain.SandboxListResult{
 		{Sandboxes: nil, TotalCount: 5, HasMore: true},
 	}}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	resp, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{Limit: 1}))
 	if err != nil {
@@ -196,7 +231,12 @@ func TestV2ListSandboxesUsesOffsetPagination(t *testing.T) {
 		{Sandboxes: []*domain.Sandbox{{Summary: domain.SandboxSummary{ID: firstID, UpdatedAt: firstUpdatedAt}}}, TotalCount: 2},
 		{Sandboxes: []*domain.Sandbox{{Summary: domain.SandboxSummary{ID: secondID, UpdatedAt: firstUpdatedAt.Add(-time.Second)}}}, TotalCount: 2},
 	}}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 	first, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{Limit: 1}))
 	if err != nil || first.Msg.GetSandboxes()[0].GetSandboxId() != firstID || first.Msg.GetTotal() != 2 {
 		t.Fatalf("first ListSandboxes() = %#v, err=%v", first, err)
@@ -212,7 +252,12 @@ func TestV2ListSandboxesUsesOffsetPagination(t *testing.T) {
 
 func TestV2ListSandboxesPassesProjectAndStatusFiltersToStore(t *testing.T) {
 	store := &characterizationSandboxStore{}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	_, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{
 		ProjectId: " project-a ", Status: []agentcomposev2.SandboxStatus{agentcomposev2.SandboxStatus_SANDBOX_STATUS_RUNNING, agentcomposev2.SandboxStatus_SANDBOX_STATUS_STOPPED, agentcomposev2.SandboxStatus_SANDBOX_STATUS_RUNNING},
@@ -233,7 +278,12 @@ func TestV2ListSandboxesRejectsUnknownStatusBeforeStore(t *testing.T) {
 	for _, statuses := range [][]agentcomposev2.SandboxStatus{{agentcomposev2.SandboxStatus_SANDBOX_STATUS_UNSPECIFIED}, {agentcomposev2.SandboxStatus_SANDBOX_STATUS_RUNNING, agentcomposev2.SandboxStatus(99)}} {
 		t.Run(fmt.Sprint(statuses), func(t *testing.T) {
 			store := &characterizationSandboxStore{}
-			handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+			handler := NewSandboxHandler(SandboxHandlerDeps{
+				Delegate:  &characterizationSessionDelegate{},
+				Store:     store,
+				Remover:   &characterizationSandboxRemover{},
+				Dashboard: nil,
+			})
 
 			_, err := handler.ListSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.ListSandboxesRequest{Status: statuses}))
 			if connect.CodeOf(err) != connect.CodeInvalidArgument || !strings.Contains(err.Error(), "unsupported sandbox status") {
@@ -254,7 +304,12 @@ func TestV2SandboxRemoveUsesSandboxIDAndSessionCompatibilityDelegate(t *testing.
 	}
 	remover := &characterizationSandboxRemover{}
 	dashboard := &characterizationDashboard{}
-	handler := NewSandboxHandler(delegate, store, remover, dashboard)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     store,
+		Remover:   remover,
+		Dashboard: dashboard,
+	})
 
 	resp, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{
 		SandboxId: " " + sandboxID + " ",
@@ -285,7 +340,12 @@ func TestV2SandboxRemoveRejectsRunningWithoutForce(t *testing.T) {
 	store := &characterizationSandboxStore{
 		session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusRunning}},
 	}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 
 	_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
@@ -303,7 +363,12 @@ func TestV2SandboxRemoveKeepsMetadataWhenRuntimeRemovalFails(t *testing.T) {
 	}
 	removeErr := errors.New("runtime remove failed")
 	remover := &characterizationSandboxRemover{err: removeErr}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, remover, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   remover,
+		Dashboard: nil,
+	})
 
 	_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeInternal || !errors.Is(err, removeErr) {
@@ -318,7 +383,12 @@ func TestV2SandboxRemoveKeepsMetadataWhenRuntimeRemovalFails(t *testing.T) {
 }
 
 func TestV2SandboxRemoveValidationAndStoreErrors(t *testing.T) {
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{}, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     &characterizationSandboxStore{},
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 	for _, sandboxID := range []string{"", "not an id", "../bad"} {
 		_, err := handler.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: sandboxID}))
 		if connect.CodeOf(err) != connect.CodeInvalidArgument {
@@ -327,17 +397,27 @@ func TestV2SandboxRemoveValidationAndStoreErrors(t *testing.T) {
 	}
 
 	missingID := identity.NewID(identity.ResourceSandbox, "characterization", "missing")
-	missing := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{getErr: errors.New("missing")}, &characterizationSandboxRemover{}, nil)
+	missing := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     &characterizationSandboxStore{getErr: errors.New("missing")},
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 	if _, err := missing.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: missingID})); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("RemoveSandbox missing code = %v, want not found (err=%v)", connect.CodeOf(err), err)
 	}
 
 	removeErr := errors.New("remove failed")
 	removeID := identity.NewID(identity.ResourceSandbox, "characterization", "remove-error")
-	failing := NewSandboxHandler(&characterizationSessionDelegate{}, &characterizationSandboxStore{
-		session:   &domain.Sandbox{Summary: domain.SandboxSummary{ID: removeID, VMStatus: domain.VMStatusStopped}},
-		removeErr: removeErr,
-	}, &characterizationSandboxRemover{}, nil)
+	failing := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate: &characterizationSessionDelegate{},
+		Store: &characterizationSandboxStore{
+			session:   &domain.Sandbox{Summary: domain.SandboxSummary{ID: removeID, VMStatus: domain.VMStatusStopped}},
+			removeErr: removeErr,
+		},
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 	if _, err := failing.RemoveSandbox(context.Background(), connect.NewRequest(&agentcomposev2.RemoveSandboxRequest{SandboxId: removeID})); connect.CodeOf(err) != connect.CodeInternal {
 		t.Fatalf("RemoveSandbox remove error code = %v, want internal (err=%v)", connect.CodeOf(err), err)
 	}

--- a/pkg/agentcompose/api/sandbox_graceful_stop_integration_test.go
+++ b/pkg/agentcompose/api/sandbox_graceful_stop_integration_test.go
@@ -26,7 +26,12 @@ func TestIntegrationGracefulStopPropagatesOptionsOverConnect(t *testing.T) {
 		Preparation:   sandboxes.StopPreparationResult{Outcome: sandboxes.StopPreparationGraceful},
 		DriverStopped: true,
 	}}
-	handler := NewSandboxHandler(delegate, &gracefulStopAPIStore{sandbox: running}, nil, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     &gracefulStopAPIStore{sandbox: running},
+		Remover:   nil,
+		Dashboard: nil,
+	})
 	servicePath, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
 	mux := http.NewServeMux()
 	mux.Handle(servicePath, serviceHandler)

--- a/pkg/agentcompose/api/sandbox_list_integration_test.go
+++ b/pkg/agentcompose/api/sandbox_list_integration_test.go
@@ -15,7 +15,12 @@ import (
 
 func TestIntegrationListSandboxesRejectsInvalidStatusOverConnect(t *testing.T) {
 	store := &characterizationSandboxStore{}
-	handler := NewSandboxHandler(&characterizationSessionDelegate{}, store, &characterizationSandboxRemover{}, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  &characterizationSessionDelegate{},
+		Store:     store,
+		Remover:   &characterizationSandboxRemover{},
+		Dashboard: nil,
+	})
 	path, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
 	mux := http.NewServeMux()
 	mux.Handle(path, serviceHandler)

--- a/pkg/agentcompose/api/sandbox_prune_test.go
+++ b/pkg/agentcompose/api/sandbox_prune_test.go
@@ -24,7 +24,12 @@ func TestPruneSandboxesMapsRequestAndCandidates(t *testing.T) {
 		Skipped:  []sandboxes.PruneCandidate{{Kind: sandboxes.PruneCandidateRuntimeResidue, SandboxID: "sandbox-orphan", Driver: "microsandbox", RuntimeID: "msb-1", Removable: false, BlockedReasons: []string{"ownership incomplete"}}},
 		Warnings: []string{"inventory partial"},
 	}}
-	handler := NewSandboxHandler(nil, nil, nil, nil).WithRemovalCoordinator(coordinator)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  nil,
+		Store:     nil,
+		Remover:   nil,
+		Dashboard: nil,
+	}).WithRemovalCoordinator(coordinator)
 	response, err := handler.PruneSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.PruneSandboxesRequest{
 		ProjectId: " project-1 ", Status: []agentcomposev2.SandboxStatus{agentcomposev2.SandboxStatus_SANDBOX_STATUS_STOPPED}, AgentName: " worker ", Driver: " docker ",
 		OlderThanSeconds: 3600, IncludeOrphans: true, Force: false,
@@ -44,7 +49,12 @@ func TestPruneSandboxesMapsRequestAndCandidates(t *testing.T) {
 }
 
 func TestPruneSandboxesValidatesDurationAndCoordinatorErrors(t *testing.T) {
-	handler := NewSandboxHandler(nil, nil, nil, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  nil,
+		Store:     nil,
+		Remover:   nil,
+		Dashboard: nil,
+	})
 	if _, err := handler.PruneSandboxes(context.Background(), connect.NewRequest(&agentcomposev2.PruneSandboxesRequest{})); connect.CodeOf(err) != connect.CodeUnavailable {
 		t.Fatalf("missing coordinator code = %v, err=%v", connect.CodeOf(err), err)
 	}

--- a/pkg/agentcompose/api/sandbox_stopped_runtime_test.go
+++ b/pkg/agentcompose/api/sandbox_stopped_runtime_test.go
@@ -42,7 +42,12 @@ func TestStopSandboxRetriesPendingRuntimeRelease(t *testing.T) {
 		StoppedRuntimePolicy: domain.StoppedRuntimePolicyRemove,
 		StoppedRuntime:       &domain.StoppedRuntime{State: domain.StoppedRuntimeStateReleasePending},
 	}}
-	handler := NewSandboxHandler(delegate, store, nil, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     store,
+		Remover:   nil,
+		Dashboard: nil,
+	})
 
 	if _, err := handler.StopSandbox(context.Background(), connect.NewRequest(&agentcomposev2.StopSandboxRequest{SandboxId: sandboxID})); err != nil {
 		t.Fatalf("StopSandbox release retry returned error: %v", err)
@@ -59,7 +64,12 @@ func TestStopSandboxDoesNotReleaseUnexpectedRuntimeLoss(t *testing.T) {
 		Summary:              domain.SandboxSummary{ID: sandboxID, VMStatus: domain.VMStatusStopped},
 		StoppedRuntimePolicy: domain.StoppedRuntimePolicyRemove,
 	}}
-	handler := NewSandboxHandler(delegate, store, nil, nil)
+	handler := NewSandboxHandler(SandboxHandlerDeps{
+		Delegate:  delegate,
+		Store:     store,
+		Remover:   nil,
+		Dashboard: nil,
+	})
 
 	_, err := handler.StopSandbox(context.Background(), connect.NewRequest(&agentcomposev2.StopSandboxRequest{SandboxId: sandboxID}))
 	if connect.CodeOf(err) != connect.CodeFailedPrecondition {

--- a/pkg/agentcompose/api/scheduler_event_cursor.go
+++ b/pkg/agentcompose/api/scheduler_event_cursor.go
@@ -20,16 +20,28 @@ type projectSchedulerEventCursor struct {
 	EventID         string    `json:"event_id"`
 }
 
-func encodeProjectSchedulerEventCursor(projectID string, projectRevision int64, agentName, triggerID, runID string, event domain.SchedulerEvent) string {
+// projectSchedulerEventCursorRequest identifies the stream selection
+// encodeProjectSchedulerEventCursor encodes alongside the event to resume
+// from.
+type projectSchedulerEventCursorRequest struct {
+	ProjectID       string
+	ProjectRevision int64
+	AgentName       string
+	TriggerID       string
+	RunID           string
+	Event           domain.SchedulerEvent
+}
+
+func encodeProjectSchedulerEventCursor(req projectSchedulerEventCursorRequest) string {
 	payload, err := json.Marshal(projectSchedulerEventCursor{
-		ProjectID:       strings.TrimSpace(projectID),
-		ProjectRevision: projectRevision,
-		AgentName:       strings.TrimSpace(agentName),
-		TriggerID:       strings.TrimSpace(triggerID),
-		RunID:           strings.TrimSpace(runID),
-		CreatedAt:       event.CreatedAt.UTC(),
-		SchedulerID:     strings.TrimSpace(event.SchedulerID),
-		EventID:         strings.TrimSpace(event.ID),
+		ProjectID:       strings.TrimSpace(req.ProjectID),
+		ProjectRevision: req.ProjectRevision,
+		AgentName:       strings.TrimSpace(req.AgentName),
+		TriggerID:       strings.TrimSpace(req.TriggerID),
+		RunID:           strings.TrimSpace(req.RunID),
+		CreatedAt:       req.Event.CreatedAt.UTC(),
+		SchedulerID:     strings.TrimSpace(req.Event.SchedulerID),
+		EventID:         strings.TrimSpace(req.Event.ID),
 	})
 	if err != nil {
 		// An unencodable timestamp cannot produce a resumable checkpoint; an

--- a/pkg/agentcompose/api/scheduler_run_cursor.go
+++ b/pkg/agentcompose/api/scheduler_run_cursor.go
@@ -20,16 +20,27 @@ type schedulerRunPageCursor struct {
 	RunID           string    `json:"run_id"`
 }
 
-func encodeSchedulerRunCursor(projectID string, projectRevision int64, agentName, triggerID, status string, run domain.SchedulerRunSummary) string {
+// schedulerRunCursorRequest identifies the run-page selection
+// encodeSchedulerRunCursor encodes alongside the run to resume from.
+type schedulerRunCursorRequest struct {
+	ProjectID       string
+	ProjectRevision int64
+	AgentName       string
+	TriggerID       string
+	Status          string
+	Run             domain.SchedulerRunSummary
+}
+
+func encodeSchedulerRunCursor(req schedulerRunCursorRequest) string {
 	payload, err := json.Marshal(schedulerRunPageCursor{
-		ProjectID:       strings.TrimSpace(projectID),
-		ProjectRevision: projectRevision,
-		AgentName:       strings.TrimSpace(agentName),
-		TriggerID:       strings.TrimSpace(triggerID),
-		Status:          strings.TrimSpace(status),
-		StartedAt:       run.StartedAt.UTC(),
-		SchedulerID:     strings.TrimSpace(run.SchedulerID),
-		RunID:           strings.TrimSpace(run.ID),
+		ProjectID:       strings.TrimSpace(req.ProjectID),
+		ProjectRevision: req.ProjectRevision,
+		AgentName:       strings.TrimSpace(req.AgentName),
+		TriggerID:       strings.TrimSpace(req.TriggerID),
+		Status:          strings.TrimSpace(req.Status),
+		StartedAt:       req.Run.StartedAt.UTC(),
+		SchedulerID:     strings.TrimSpace(req.Run.SchedulerID),
+		RunID:           strings.TrimSpace(req.Run.ID),
 	})
 	if err != nil {
 		// An unencodable timestamp cannot produce a resumable page cursor; an

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -97,13 +97,13 @@ func RegisterDependencies(di do.Injector) {
 func RegisterRoutes(di do.Injector) {
 	app := do.MustInvoke[*echo.Echo](di)
 
-	projectHandler := api.NewProjectHandlerWithAgentModels(
-		projectControllerDelegate{controller: do.MustInvoke[*projects.Controller](di)},
-		do.MustInvoke[*configstore.ConfigStore](di),
-		do.MustInvoke[*schedulers.Controller](di),
-		newProjectAgentModelResolver(do.MustInvoke[*appconfig.Config](di), do.MustInvoke[*configstore.ConfigStore](di)),
-		do.MustInvoke[*sandboxstore.Store](di),
-	)
+	projectHandler := api.NewProjectHandlerWithAgentModels(api.ProjectHandlerDeps{
+		Delegate:         projectControllerDelegate{controller: do.MustInvoke[*projects.Controller](di)},
+		Store:            do.MustInvoke[*configstore.ConfigStore](di),
+		SchedulerRuntime: do.MustInvoke[*schedulers.Controller](di),
+		AgentModels:      newProjectAgentModelResolver(do.MustInvoke[*appconfig.Config](di), do.MustInvoke[*configstore.ConfigStore](di)),
+		SandboxDirs:      do.MustInvoke[*sandboxstore.Store](di),
+	})
 	path, handler := agentcomposev2connect.NewProjectServiceHandler(projectHandler)
 	app.Any(path+"*", echo.WrapHandler(handler))
 	runDelegate := runControllerDelegate{
@@ -113,15 +113,14 @@ func RegisterRoutes(di do.Injector) {
 	runHandler := api.NewRunHandlerWithRunLogHub(runDelegate, do.MustInvoke[*configstore.ConfigStore](di), do.MustInvoke[*runs.RunLogHub](di), do.MustInvoke[*RunSupervisor](di))
 	path, handler = agentcomposev2connect.NewRunServiceHandler(runHandler)
 	app.Any(path+"*", echo.WrapHandler(handler))
-	execHandler := api.NewExecHandler(
-		do.MustInvoke[*appconfig.Config](di),
-		do.MustInvoke[*sandboxstore.Store](di),
-		do.MustInvoke[*configstore.ConfigStore](di),
-		func(session *domain.Sandbox) (api.ExecRuntime, error) {
+	execHandler := api.NewExecHandler(api.ExecHandlerDeps{
+		Config:   do.MustInvoke[*appconfig.Config](di),
+		Store:    do.MustInvoke[*sandboxstore.Store](di),
+		Projects: do.MustInvoke[*configstore.ConfigStore](di),
+		Runtime: func(session *domain.Sandbox) (api.ExecRuntime, error) {
 			return do.MustInvoke[adapters.RuntimeProvider](di).ForSession(session)
 		},
-		runDelegate,
-	).WithLifecycleLocks(do.MustInvoke[*sandboxes.LifecycleLocks](di))
+	}, runDelegate).WithLifecycleLocks(do.MustInvoke[*sandboxes.LifecycleLocks](di))
 	path, handler = agentcomposev2connect.NewExecServiceHandler(execHandler)
 	app.Any(path+"*", echo.WrapHandler(handler))
 	imageHandler := api.NewImageHandler(do.MustInvoke[*adapters.ImageBackends](di))
@@ -133,11 +132,12 @@ func RegisterRoutes(di do.Injector) {
 	volumeHandler := api.NewVolumeHandler(do.MustInvoke[*volumes.Manager](di))
 	path, handler = agentcomposev2connect.NewVolumeServiceHandler(volumeHandler)
 	app.Any(path+"*", echo.WrapHandler(handler))
-	sandboxHandler := api.NewSandboxHandler(
-		do.MustInvoke[*adapters.SandboxRPCBridge](di),
-		do.MustInvoke[*sandboxstore.Store](di),
-		do.MustInvoke[*adapters.SandboxDriver](di),
-		do.MustInvoke[*dashboard.Hub](di),
+	sandboxHandler := api.NewSandboxHandler(api.SandboxHandlerDeps{
+		Delegate:  do.MustInvoke[*adapters.SandboxRPCBridge](di),
+		Store:     do.MustInvoke[*sandboxstore.Store](di),
+		Remover:   do.MustInvoke[*adapters.SandboxDriver](di),
+		Dashboard: do.MustInvoke[*dashboard.Hub](di),
+	},
 		func(session *domain.Sandbox) (api.SandboxStatsRuntime, error) {
 			runtime, err := do.MustInvoke[adapters.RuntimeProvider](di).ForSession(session)
 			if err != nil {

--- a/test/e2e/graceful_sandbox_stop_contract_test.go
+++ b/test/e2e/graceful_sandbox_stop_contract_test.go
@@ -60,7 +60,7 @@ func TestGracefulSandboxStopOutcomesUsePublicConnectContract(t *testing.T) {
 				Preparation:   sandboxes.StopPreparationResult{Outcome: test.preparation},
 				DriverStopped: true,
 			}}
-			handler := api.NewSandboxHandler(delegate, &e2eGracefulStopStore{sandbox: stored}, nil, nil)
+			handler := api.NewSandboxHandler(api.SandboxHandlerDeps{Delegate: delegate, Store: &e2eGracefulStopStore{sandbox: stored}})
 			servicePath, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
 			mux := http.NewServeMux()
 			mux.Handle(servicePath, serviceHandler)
@@ -122,7 +122,7 @@ func testCancelledGracefulStopContainment(t *testing.T) {
 		store:  store,
 		result: make(chan e2eLifecycleStopResult, 1),
 	}
-	handler := api.NewSandboxHandler(delegate, store, nil, nil)
+	handler := api.NewSandboxHandler(api.SandboxHandlerDeps{Delegate: delegate, Store: store})
 	servicePath, serviceHandler := agentcomposev2connect.NewSandboxServiceHandler(handler)
 	mux := http.NewServeMux()
 	mux.Handle(servicePath, serviceHandler)


### PR DESCRIPTION
## Summary
- Third of several PRs covering `pkg/agentcompose` (14k lines, split by subpackage: `proxy` #613, `app` #614, `api` here, `adapters` to follow) for the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`).
- Note: this PR also touches `pkg/agentcompose/app/app.go` — it's the sole caller of `NewExecHandler`/`NewProjectHandlerWithAgentModels`/`NewSandboxHandler`, whose signatures changed here. It touches different lines than #614's app.go changes (different functions), so both should merge cleanly regardless of order.

### Argument-limit fixes
- `NewExecHandler`, `NewSandboxHandler` (5 args incl. a trailing variadic optional param each), `NewProjectHandlerWithAgentModels`/`newProjectHandler` (5 args): bundled the required deps into `ExecHandlerDeps`, `SandboxHandlerDeps`, and `ProjectHandlerDeps` respectively, keeping each constructor's existing variadic/optional trailing param as-is.
- `ExecResultToProto` (7 args, 3 call sites): bundled into `ExecResultProtoRequest`.
- `sendSchedulerEventPages` (7 args, 1 call site): bundled into `schedulerEventPageStreamRequest`.
- `encodeProjectSchedulerEventCursor`/`encodeSchedulerRunCursor` (6 args each, 1 call site each): bundled into request structs, reusing the same field names as their existing sibling JSON cursor structs (a "reuse existing struct" case).
- `followRunLogsByPolling`/`followRunLogsWithHub` (5 args each): bundled the run/offset/stream shared between them into `runLogFollowTarget`.

### Funlen fixes
- `executeProjectCommand` (109 lines) split into `prepareExecCommand` (resolve cwd/VM state/runtime/artifact dirs, write the command-request artifact) and `newExecStreamWriter` (build the transcript+stream writer closure) — two genuinely distinct phases.
- `resolveExecTargetSandbox` (107 lines) split out `resolveExecTargetBySelector`, the largest of its three resolution strategies (by sandbox ID / by run ID / by project+agent selector).

### Dead code
- Deleted `ProjectApplyChanges` and `DryRunProjectChanges` — zero callers anywhere in the repo.
- Full dead-code audit of the subpackage's top-level exported surface (~150 symbols) found nothing else unused.

Remaining violations left deferred: 4 coverage-sweep tests, and 2 interface-constrained test fakes (`apiExecRuntime.ExecStream` must match the `ExecRuntime` interface; `apiProjectRunStore.ListProjectRunEventsForSandbox` must match the existing 6-arg interface method).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/agentcompose/...`
- [x] `go test ./pkg/agentcompose/api/... ./pkg/agentcompose/app/...`
- [x] `golangci-lint run ./pkg/agentcompose/api/...` — 6 remaining issues, all deferred as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)