### PR TITLE
refactor(agentcompose/adapters): bundle multi-argument params into structs; split funlen violations

### DIFF
--- a/pkg/agentcompose/adapters/agent_executor.go
+++ b/pkg/agentcompose/adapters/agent_executor.go
@@ -206,7 +206,15 @@ func (e *AgentExecutor) ExecuteAgentRequest(ctx context.Context, session *domain
 	}
 
 	execSession := cloneSessionForAgentExecution(session, request.ProviderEnvItems)
-	execResult, result, err := e.runner.ExecuteAgentRun(execCtx, execSession, agent, request.AgentDefinitionID, model, request.RunID, message, request.OutputSchemaJSON, streamWriter)
+	execResult, result, err := e.runner.ExecuteAgentRun(execCtx, AgentRunRequest{
+		Session:           execSession,
+		Agent:             agent,
+		AgentDefinitionID: request.AgentDefinitionID,
+		Model:             model,
+		RunID:             request.RunID,
+		Message:           message,
+		OutputSchemaJSON:  request.OutputSchemaJSON,
+	}, streamWriter)
 	streamErrMu.Lock()
 	deferredStreamErr := streamErr
 	streamErrMu.Unlock()

--- a/pkg/agentcompose/adapters/agent_executor_test.go
+++ b/pkg/agentcompose/adapters/agent_executor_test.go
@@ -44,7 +44,13 @@ func TestAgentExecutorExecuteAgentRequestPersistsCellAndEvents(t *testing.T) {
 		t.Fatalf("UpdateSession returned error: %v", err)
 	}
 	runtime := &fakeAgentRuntime{}
-	runner := NewAgentRunner(config, store, nil, nil, fakeRuntimeProvider{runtime: runtime})
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents:   nil,
+		Runtimes: fakeRuntimeProvider{runtime: runtime},
+	})
 	executor := NewAgentExecutor(config, store, nil, runner)
 
 	cell, userEvent, assistantEvent, err := executor.ExecuteAgentRequest(ctx, session, execution.ExecuteAgentRequest{
@@ -145,7 +151,13 @@ func TestAgentExecutorStreamsOnlyHumanVisibleAgentOutput(t *testing.T) {
 		},
 		result: domain.ExecResult{Stdout: payload, Output: payload, ExitCode: 0, Success: true},
 	}
-	runner := NewAgentRunner(config, store, nil, nil, fakeRuntimeProvider{runtime: runtime})
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents:   nil,
+		Runtimes: fakeRuntimeProvider{runtime: runtime},
+	})
 	executor := NewAgentExecutor(config, store, nil, runner)
 	var chunks []domain.ExecChunk
 
@@ -217,7 +229,13 @@ func TestAgentExecutorPersistsFailedCellWhenStreamCallbackFails(t *testing.T) {
 		streamChunks: []domain.ExecChunk{{Text: "partial output\n", Stream: domain.StdioStdout}},
 		result:       domain.ExecResult{Stdout: "partial output\n", Output: "partial output\n", ExitCode: 0, Success: true},
 	}
-	runner := NewAgentRunner(config, store, nil, nil, fakeRuntimeProvider{runtime: runtime})
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents:   nil,
+		Runtimes: fakeRuntimeProvider{runtime: runtime},
+	})
 	executor := NewAgentExecutor(config, store, nil, runner)
 
 	cell, userEvent, assistantEvent, err := executor.ExecuteAgentRequest(ctx, session, execution.ExecuteAgentRequest{

--- a/pkg/agentcompose/adapters/agent_runner.go
+++ b/pkg/agentcompose/adapters/agent_runner.go
@@ -42,8 +42,17 @@ func facadeStoreFor(configDB *configstore.ConfigStore) runtimefacade.FacadeStore
 	return configDB
 }
 
-func NewAgentRunner(config *appconfig.Config, store *sandboxstore.Store, configDB *configstore.ConfigStore, agents AgentDefinitionStore, runtimes RuntimeProvider) *AgentRunner {
-	return &AgentRunner{config: config, store: store, configDB: configDB, agents: agents, runtimes: runtimes}
+// AgentRunnerDeps bundles NewAgentRunner's dependencies.
+type AgentRunnerDeps struct {
+	Config   *appconfig.Config
+	Store    *sandboxstore.Store
+	ConfigDB *configstore.ConfigStore
+	Agents   AgentDefinitionStore
+	Runtimes RuntimeProvider
+}
+
+func NewAgentRunner(deps AgentRunnerDeps) *AgentRunner {
+	return &AgentRunner{config: deps.Config, store: deps.Store, configDB: deps.ConfigDB, agents: deps.Agents, runtimes: deps.Runtimes}
 }
 
 func (r *AgentRunner) ValidateSessionRuntime(session *domain.Sandbox) error {
@@ -51,7 +60,21 @@ func (r *AgentRunner) ValidateSessionRuntime(session *domain.Sandbox) error {
 	return err
 }
 
-func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandbox, agent, agentDefinitionID, model, runID, message, outputSchemaJSON string, stream domain.ExecStreamWriter) (domain.ExecResult, domain.AgentRunResult, error) {
+// AgentRunRequest bundles the session and run identifiers/inputs
+// ExecuteAgentRun needs, as opposed to stream, the output callback.
+type AgentRunRequest struct {
+	Session           *domain.Sandbox
+	Agent             string
+	AgentDefinitionID string
+	Model             string
+	RunID             string
+	Message           string
+	OutputSchemaJSON  string
+}
+
+func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, req AgentRunRequest, stream domain.ExecStreamWriter) (domain.ExecResult, domain.AgentRunResult, error) {
+	session, agent, agentDefinitionID := req.Session, req.Agent, req.AgentDefinitionID
+	model, runID, message, outputSchemaJSON := req.Model, req.RunID, req.Message, req.OutputSchemaJSON
 	if session.Summary.VMStatus != domain.VMStatusRunning {
 		return domain.ExecResult{}, domain.AgentRunResult{}, fmt.Errorf("session is not running")
 	}
@@ -99,7 +122,14 @@ func (r *AgentRunner) ExecuteAgentRun(ctx context.Context, session *domain.Sandb
 	if strings.TrimSpace(runtimeConfig.Model) != "" {
 		runtimeModel = strings.TrimSpace(runtimeConfig.Model)
 	}
-	spec := BuildAgentExecSpec(r.config, session, agent, runtimeModel, promptPath, schemaPath, skillNames)
+	spec := BuildAgentExecSpec(r.config, AgentExecSpecRequest{
+		Session:    session,
+		Agent:      agent,
+		Model:      runtimeModel,
+		PromptPath: promptPath,
+		SchemaPath: schemaPath,
+		SkillNames: skillNames,
+	})
 	managedEnv := runtimeConfig.Env
 	retainFacadeToken := false
 	if len(managedEnv) > 0 {
@@ -314,7 +344,20 @@ func (r *AgentRunner) resolveAgentDefinition(ctx context.Context, session *domai
 	return &agentDef, nil
 }
 
-func BuildAgentExecSpec(config *appconfig.Config, session *domain.Sandbox, agent, model, promptPath, schemaPath string, skillNames []string) domain.ExecSpec {
+// AgentExecSpecRequest bundles the session and prompt/schema/skill inputs
+// BuildAgentExecSpec needs to build the guest exec command for an agent run.
+type AgentExecSpecRequest struct {
+	Session    *domain.Sandbox
+	Agent      string
+	Model      string
+	PromptPath string
+	SchemaPath string
+	SkillNames []string
+}
+
+func BuildAgentExecSpec(config *appconfig.Config, req AgentExecSpecRequest) domain.ExecSpec {
+	session, agent, model := req.Session, req.Agent, req.Model
+	promptPath, schemaPath, skillNames := req.PromptPath, req.SchemaPath, req.SkillNames
 	appconfig.ApplyDefaultGuestPaths(config)
 	agentHome := config.GuestHomePath
 	env := execution.BuildSandboxExecEnv(config, session, agentHome)

--- a/pkg/agentcompose/adapters/agent_runner_test.go
+++ b/pkg/agentcompose/adapters/agent_runner_test.go
@@ -95,7 +95,13 @@ func TestAgentRunnerPrepareSandboxAgentEnvironmentUsesOnlyCurrentAgent(t *testin
 		SystemPrompt: "Use the configured agent identity",
 		ConfigJSON:   string(payload),
 	}
-	runner := NewAgentRunner(config, store, configDB, fakeAgentDefinitionStore{agent: *definition}, nil)
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: configDB,
+		Agents:   fakeAgentDefinitionStore{agent: *definition},
+		Runtimes: nil,
+	})
 	if err := runner.PrepareSandboxAgentEnvironmentFromTags(ctx, session); err != nil {
 		t.Fatalf("PrepareSandboxAgentEnvironmentFromTags returned error: %v", err)
 	}
@@ -144,7 +150,13 @@ func TestAgentRunnerPrepareSandboxAgentEnvironmentFromTagsRejectsInvalidDefiniti
 
 	t.Run("definition lookup failure", func(t *testing.T) {
 		lookupErr := errors.New("definition unavailable")
-		runner := NewAgentRunner(nil, nil, nil, fakeAgentDefinitionStore{err: lookupErr}, nil)
+		runner := NewAgentRunner(AgentRunnerDeps{
+			Config:   nil,
+			Store:    nil,
+			ConfigDB: nil,
+			Agents:   fakeAgentDefinitionStore{err: lookupErr},
+			Runtimes: nil,
+		})
 		err := runner.PrepareSandboxAgentEnvironmentFromTags(context.Background(), session)
 		if !errors.Is(err, lookupErr) {
 			t.Fatalf("PrepareSandboxAgentEnvironmentFromTags error = %v, want %v", err, lookupErr)
@@ -152,7 +164,13 @@ func TestAgentRunnerPrepareSandboxAgentEnvironmentFromTagsRejectsInvalidDefiniti
 	})
 
 	t.Run("disabled definition", func(t *testing.T) {
-		runner := NewAgentRunner(nil, nil, nil, fakeAgentDefinitionStore{agent: domain.AgentDefinition{ID: "agent-1", Enabled: false}}, nil)
+		runner := NewAgentRunner(AgentRunnerDeps{
+			Config:   nil,
+			Store:    nil,
+			ConfigDB: nil,
+			Agents:   fakeAgentDefinitionStore{agent: domain.AgentDefinition{ID: "agent-1", Enabled: false}},
+			Runtimes: nil,
+		})
 		err := runner.PrepareSandboxAgentEnvironmentFromTags(context.Background(), session)
 		if err == nil || !strings.Contains(err.Error(), "is disabled") {
 			t.Fatalf("PrepareSandboxAgentEnvironmentFromTags error = %v, want disabled definition", err)
@@ -235,8 +253,22 @@ func TestAgentRunnerRetainsFacadeTokenOnlyWhenExecTerminationIsUnconfirmed(t *te
 				t.Fatalf("SaveVMState returned error: %v", err)
 			}
 			runtime := &fakeAgentRuntime{err: tt.runtimeErr}
-			runner := NewAgentRunner(config, store, configDB, nil, fakeRuntimeProvider{runtime: runtime})
-			_, _, err = runner.ExecuteAgentRun(context.Background(), session, "claude", "", "", "run-1", "wait", "", nil)
+			runner := NewAgentRunner(AgentRunnerDeps{
+				Config:   config,
+				Store:    store,
+				ConfigDB: configDB,
+				Agents:   nil,
+				Runtimes: fakeRuntimeProvider{runtime: runtime},
+			})
+			_, _, err = runner.ExecuteAgentRun(context.Background(), AgentRunRequest{
+				Session:           session,
+				Agent:             "claude",
+				AgentDefinitionID: "",
+				Model:             "",
+				RunID:             "run-1",
+				Message:           "wait",
+				OutputSchemaJSON:  "",
+			}, nil)
 			if !errors.Is(err, tt.runtimeErr) {
 				t.Fatalf("ExecuteAgentRun error = %v, want %v", err, tt.runtimeErr)
 			}
@@ -292,13 +324,27 @@ func TestAgentRunnerExecuteAgentRunWritesSystemPromptAndParsesResult(t *testing.
 	if err := os.WriteFile(filepath.Join(skillSource, "SKILL.md"), []byte("---\nname: pdf\ndescription: PDF skill\n---\n"), 0o644); err != nil {
 		t.Fatalf("write skill source: %v", err)
 	}
-	runner := NewAgentRunner(config, store, nil, fakeAgentDefinitionStore{agent: domain.AgentDefinition{
-		ID:           "agent-1",
-		SystemPrompt: "Reply only in Chinese",
-		Skills:       []domain.AgentSkill{{Name: "pdf", Provider: "file", Path: skillSource}},
-	}}, fakeRuntimeProvider{runtime: runtime})
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents: fakeAgentDefinitionStore{agent: domain.AgentDefinition{
+			ID:           "agent-1",
+			SystemPrompt: "Reply only in Chinese",
+			Skills:       []domain.AgentSkill{{Name: "pdf", Provider: "file", Path: skillSource}},
+		}},
+		Runtimes: fakeRuntimeProvider{runtime: runtime},
+	})
 
-	result, parsed, err := runner.ExecuteAgentRun(ctx, session, "codex", "agent-1", "", "", "hello", "", nil)
+	result, parsed, err := runner.ExecuteAgentRun(ctx, AgentRunRequest{
+		Session:           session,
+		Agent:             "codex",
+		AgentDefinitionID: "agent-1",
+		Model:             "",
+		RunID:             "",
+		Message:           "hello",
+		OutputSchemaJSON:  "",
+	}, nil)
 	if err != nil {
 		t.Fatalf("ExecuteAgentRun returned error: %v", err)
 	}
@@ -351,13 +397,27 @@ func TestAgentRunnerExecuteAgentRunFallsBackToDefinitionModel(t *testing.T) {
 		t.Fatalf("UpdateSession returned error: %v", err)
 	}
 	runtime := &fakeAgentRuntime{}
-	runner := NewAgentRunner(config, store, nil, fakeAgentDefinitionStore{agent: domain.AgentDefinition{
-		ID:       "agent-1",
-		Provider: "opencode",
-		Model:    "openai/qwen3-coder-plus",
-	}}, fakeRuntimeProvider{runtime: runtime})
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents: fakeAgentDefinitionStore{agent: domain.AgentDefinition{
+			ID:       "agent-1",
+			Provider: "opencode",
+			Model:    "openai/qwen3-coder-plus",
+		}},
+		Runtimes: fakeRuntimeProvider{runtime: runtime},
+	})
 
-	if _, _, err := runner.ExecuteAgentRun(ctx, session, "opencode", "agent-1", "", "", "hello", "", nil); err != nil {
+	if _, _, err := runner.ExecuteAgentRun(ctx, AgentRunRequest{
+		Session:           session,
+		Agent:             "opencode",
+		AgentDefinitionID: "agent-1",
+		Model:             "",
+		RunID:             "",
+		Message:           "hello",
+		OutputSchemaJSON:  "",
+	}, nil); err != nil {
 		t.Fatalf("ExecuteAgentRun returned error: %v", err)
 	}
 	if len(runtime.specs) != 1 {
@@ -413,9 +473,23 @@ func TestAgentRunnerExecuteAgentRunUsesResolvedOpenCodeFacadeModel(t *testing.T)
 		t.Fatalf("UpdateSandbox returned error: %v", err)
 	}
 	runtime := &fakeAgentRuntime{}
-	runner := NewAgentRunner(config, store, configDB, nil, fakeRuntimeProvider{runtime: runtime})
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: configDB,
+		Agents:   nil,
+		Runtimes: fakeRuntimeProvider{runtime: runtime},
+	})
 
-	if _, _, err := runner.ExecuteAgentRun(ctx, session, "opencode", "", "baizhi/deepseek-v4-flash", "run-1", "hello", "", nil); err != nil {
+	if _, _, err := runner.ExecuteAgentRun(ctx, AgentRunRequest{
+		Session:           session,
+		Agent:             "opencode",
+		AgentDefinitionID: "",
+		Model:             "baizhi/deepseek-v4-flash",
+		RunID:             "run-1",
+		Message:           "hello",
+		OutputSchemaJSON:  "",
+	}, nil); err != nil {
 		t.Fatalf("ExecuteAgentRun returned error: %v", err)
 	}
 	if len(runtime.specs) != 1 {
@@ -457,9 +531,23 @@ func TestAgentRunnerExecuteAgentRunContinuesWhenDefinitionLookupFails(t *testing
 		t.Fatalf("UpdateSession returned error: %v", err)
 	}
 	runtime := &fakeAgentRuntime{}
-	runner := NewAgentRunner(config, store, nil, fakeAgentDefinitionStore{err: errors.New("store unavailable")}, fakeRuntimeProvider{runtime: runtime})
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents:   fakeAgentDefinitionStore{err: errors.New("store unavailable")},
+		Runtimes: fakeRuntimeProvider{runtime: runtime},
+	})
 
-	result, parsed, err := runner.ExecuteAgentRun(ctx, session, "codex", "agent-1", "", "", "hello", "", nil)
+	result, parsed, err := runner.ExecuteAgentRun(ctx, AgentRunRequest{
+		Session:           session,
+		Agent:             "codex",
+		AgentDefinitionID: "agent-1",
+		Model:             "",
+		RunID:             "",
+		Message:           "hello",
+		OutputSchemaJSON:  "",
+	}, nil)
 	if err != nil {
 		t.Fatalf("ExecuteAgentRun returned error: %v", err)
 	}
@@ -498,7 +586,13 @@ func TestAgentRunnerResolveAgentSystemPromptBranches(t *testing.T) {
 		{Name: domain.AgentSandboxTagID, Value: "agent-tagged"},
 		{Name: domain.AgentSandboxTagSource, Value: domain.AgentSandboxTagSourceVal},
 	}}}
-	runner := NewAgentRunner(nil, nil, nil, fakeAgentDefinitionStore{agent: domain.AgentDefinition{SystemPrompt: "  tagged prompt  "}}, nil)
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   nil,
+		Store:    nil,
+		ConfigDB: nil,
+		Agents:   fakeAgentDefinitionStore{agent: domain.AgentDefinition{SystemPrompt: "  tagged prompt  "}},
+		Runtimes: nil,
+	})
 	if prompt, err := runner.ResolveAgentSystemPrompt(ctx, session, ""); err != nil || prompt != "tagged prompt" {
 		t.Fatalf("tagged prompt = %q err=%v", prompt, err)
 	}
@@ -509,7 +603,13 @@ func TestAgentRunnerResolveAgentSystemPromptBranches(t *testing.T) {
 	if prompt, err := (*AgentRunner)(nil).ResolveAgentSystemPrompt(ctx, session, "agent-tagged"); err != nil || prompt != "" {
 		t.Fatalf("nil runner prompt = %q err=%v", prompt, err)
 	}
-	if prompt, err := NewAgentRunner(nil, nil, nil, nil, nil).ResolveAgentSystemPrompt(ctx, session, "agent-tagged"); err != nil || prompt != "" {
+	if prompt, err := NewAgentRunner(AgentRunnerDeps{
+		Config:   nil,
+		Store:    nil,
+		ConfigDB: nil,
+		Agents:   nil,
+		Runtimes: nil,
+	}).ResolveAgentSystemPrompt(ctx, session, "agent-tagged"); err != nil || prompt != "" {
 		t.Fatalf("nil store prompt = %q err=%v", prompt, err)
 	}
 	if prompt, err := runner.ResolveAgentSystemPrompt(ctx, nil, "agent-tagged"); err != nil || prompt != "" {

--- a/pkg/agentcompose/adapters/cell_executor.go
+++ b/pkg/agentcompose/adapters/cell_executor.go
@@ -29,15 +29,91 @@ func NewCellExecutor(config *appconfig.Config, store *sandboxstore.Store, runtim
 	return &CellExecutor{config: config, store: store, runtimes: runtimes, streams: streams}
 }
 
+// CellExecutionRequest bundles the session, cell content, and output stream
+// executeCell needs.
+type CellExecutionRequest struct {
+	Session  *domain.Sandbox
+	CellType string
+	Source   string
+	Stream   execution.CellExecutionStream
+}
+
 func (e *CellExecutor) ExecuteCell(ctx context.Context, session *domain.Sandbox, cellType, source string) (domain.NotebookCell, error) {
-	return e.executeCell(ctx, session, cellType, source, execution.CellExecutionStream{})
+	return e.executeCell(ctx, CellExecutionRequest{Session: session, CellType: cellType, Source: source})
 }
 
-func (e *CellExecutor) ExecuteCellStream(ctx context.Context, session *domain.Sandbox, cellType, source string, stream execution.CellExecutionStream) (domain.NotebookCell, error) {
-	return e.executeCell(ctx, session, cellType, source, stream)
+func (e *CellExecutor) ExecuteCellStream(ctx context.Context, req CellExecutionRequest) (domain.NotebookCell, error) {
+	return e.executeCell(ctx, req)
 }
 
-func (e *CellExecutor) executeCell(ctx context.Context, session *domain.Sandbox, cellType, source string, stream execution.CellExecutionStream) (domain.NotebookCell, error) {
+// preparedCellExecution is the resolved runtime/state and the initial,
+// already-published cell prepareCellExecution assembles before executeCell
+// runs the command.
+type preparedCellExecution struct {
+	VMState     domain.VMState
+	Runtime     SandboxRuntime
+	CellID      string
+	HostCellDir string
+	Command     string
+	Args        []string
+	StartedCell domain.NotebookCell
+}
+
+// prepareCellExecution resolves the sandbox's VM state and runtime, creates
+// the host cell state dir, writes the cell script, and publishes the started
+// cell (invoking req.Stream.OnStart first, if set).
+func (e *CellExecutor) prepareCellExecution(ctx context.Context, req CellExecutionRequest) (preparedCellExecution, error) {
+	session, cellType, source, stream := req.Session, req.CellType, req.Source, req.Stream
+	vmState, err := e.store.GetVMState(session.Summary.ID)
+	if err != nil {
+		return preparedCellExecution{}, err
+	}
+	runtime, err := e.runtimes.ForSession(session)
+	if err != nil {
+		return preparedCellExecution{}, err
+	}
+
+	cellID := uuid.NewString()
+	hostCellDir := filepath.Join(filepath.Dir(session.Summary.WorkspacePath), "state", "cells", cellID)
+	if err := os.MkdirAll(hostCellDir, 0o755); err != nil {
+		return preparedCellExecution{}, fmt.Errorf("create cell state dir: %w", err)
+	}
+
+	guestCellDir := filepath.Join(e.config.GuestStateRoot, "cells", cellID)
+	scriptName, command, args := execution.CellExecSpec(cellType, guestCellDir)
+	hostScriptPath := filepath.Join(hostCellDir, scriptName)
+	if err := os.WriteFile(hostScriptPath, []byte(source), 0o644); err != nil {
+		return preparedCellExecution{}, fmt.Errorf("write cell script: %w", err)
+	}
+
+	startedCell := domain.NotebookCell{
+		ID:        cellID,
+		Type:      cellType,
+		Source:    source,
+		CreatedAt: time.Now().UTC(),
+		Running:   true,
+	}
+	if stream.OnStart != nil {
+		if err := stream.OnStart(startedCell); err != nil {
+			return preparedCellExecution{}, err
+		}
+	}
+	if e.streams != nil {
+		e.streams.PublishCellStarted(session.Summary.ID, startedCell)
+	}
+	return preparedCellExecution{
+		VMState:     vmState,
+		Runtime:     runtime,
+		CellID:      cellID,
+		HostCellDir: hostCellDir,
+		Command:     command,
+		Args:        args,
+		StartedCell: startedCell,
+	}, nil
+}
+
+func (e *CellExecutor) executeCell(ctx context.Context, req CellExecutionRequest) (domain.NotebookCell, error) {
+	session, cellType, source, stream := req.Session, req.CellType, req.Source, req.Stream
 	appconfig.ApplyDefaultGuestPaths(e.config)
 	source = strings.TrimSpace(source)
 	if source == "" {
@@ -54,44 +130,12 @@ func (e *CellExecutor) executeCell(ctx context.Context, session *domain.Sandbox,
 	execCtx, execCancel := context.WithCancel(ctx)
 	defer execCancel()
 
-	vmState, err := e.store.GetVMState(session.Summary.ID)
+	prepared, err := e.prepareCellExecution(ctx, CellExecutionRequest{Session: session, CellType: cellType, Source: source, Stream: stream})
 	if err != nil {
 		return domain.NotebookCell{}, err
 	}
-	runtime, err := e.runtimes.ForSession(session)
-	if err != nil {
-		return domain.NotebookCell{}, err
-	}
-
-	cellID := uuid.NewString()
-	hostCellDir := filepath.Join(filepath.Dir(session.Summary.WorkspacePath), "state", "cells", cellID)
-	if err := os.MkdirAll(hostCellDir, 0o755); err != nil {
-		return domain.NotebookCell{}, fmt.Errorf("create cell state dir: %w", err)
-	}
-
-	guestCellDir := filepath.Join(e.config.GuestStateRoot, "cells", cellID)
-	scriptName, command, args := execution.CellExecSpec(cellType, guestCellDir)
-	hostScriptPath := filepath.Join(hostCellDir, scriptName)
-	if err := os.WriteFile(hostScriptPath, []byte(source), 0o644); err != nil {
-		return domain.NotebookCell{}, fmt.Errorf("write cell script: %w", err)
-	}
-
-	startedAt := time.Now().UTC()
-	startedCell := domain.NotebookCell{
-		ID:        cellID,
-		Type:      cellType,
-		Source:    source,
-		CreatedAt: startedAt,
-		Running:   true,
-	}
-	if stream.OnStart != nil {
-		if err := stream.OnStart(startedCell); err != nil {
-			return domain.NotebookCell{}, err
-		}
-	}
-	if e.streams != nil {
-		e.streams.PublishCellStarted(session.Summary.ID, startedCell)
-	}
+	vmState, runtime, cellID, hostCellDir := prepared.VMState, prepared.Runtime, prepared.CellID, prepared.HostCellDir
+	command, args, startedAt := prepared.Command, prepared.Args, prepared.StartedCell.CreatedAt
 
 	var streamErrMu sync.Mutex
 	var streamErr error

--- a/pkg/agentcompose/adapters/cell_executor_test.go
+++ b/pkg/agentcompose/adapters/cell_executor_test.go
@@ -97,14 +97,19 @@ func TestCellExecutorExecuteCellPersistsCellAndEvent(t *testing.T) {
 
 	var started bool
 	var chunks []domain.ExecChunk
-	streamed, err := executor.ExecuteCellStream(ctx, session, execution.CellTypePython, "print('hello')", execution.CellExecutionStream{
-		OnStart: func(cell domain.NotebookCell) error {
-			started = cell.Running && cell.Type == execution.CellTypePython
-			return nil
-		},
-		OnChunk: func(_ string, chunk domain.ExecChunk) error {
-			chunks = append(chunks, chunk)
-			return nil
+	streamed, err := executor.ExecuteCellStream(ctx, CellExecutionRequest{
+		Session:  session,
+		CellType: execution.CellTypePython,
+		Source:   "print('hello')",
+		Stream: execution.CellExecutionStream{
+			OnStart: func(cell domain.NotebookCell) error {
+				started = cell.Running && cell.Type == execution.CellTypePython
+				return nil
+			},
+			OnChunk: func(_ string, chunk domain.ExecChunk) error {
+				chunks = append(chunks, chunk)
+				return nil
+			},
 		},
 	})
 	if err != nil || !streamed.Success || !started || len(chunks) != 1 {
@@ -115,16 +120,26 @@ func TestCellExecutorExecuteCellPersistsCellAndEvent(t *testing.T) {
 		t.Fatalf("streamed cells=%#v err=%v", cells, err)
 	}
 
-	if _, err := executor.ExecuteCellStream(ctx, session, execution.CellTypeShell, "echo hello", execution.CellExecutionStream{
-		OnStart: func(domain.NotebookCell) error {
-			return errors.New("start callback failed")
+	if _, err := executor.ExecuteCellStream(ctx, CellExecutionRequest{
+		Session:  session,
+		CellType: execution.CellTypeShell,
+		Source:   "echo hello",
+		Stream: execution.CellExecutionStream{
+			OnStart: func(domain.NotebookCell) error {
+				return errors.New("start callback failed")
+			},
 		},
 	}); err == nil {
 		t.Fatalf("ExecuteCellStream start callback returned nil error")
 	}
-	if _, err := executor.ExecuteCellStream(ctx, session, execution.CellTypeShell, "echo hello", execution.CellExecutionStream{
-		OnChunk: func(string, domain.ExecChunk) error {
-			return errors.New("chunk callback failed")
+	if _, err := executor.ExecuteCellStream(ctx, CellExecutionRequest{
+		Session:  session,
+		CellType: execution.CellTypeShell,
+		Source:   "echo hello",
+		Stream: execution.CellExecutionStream{
+			OnChunk: func(string, domain.ExecChunk) error {
+				return errors.New("chunk callback failed")
+			},
 		},
 	}); err == nil {
 		t.Fatalf("ExecuteCellStream chunk callback returned nil error")

--- a/pkg/agentcompose/adapters/historical_runtime_capability_test.go
+++ b/pkg/agentcompose/adapters/historical_runtime_capability_test.go
@@ -86,7 +86,7 @@ func TestHistoricalUncompiledExecPreflightHasNoArtifactsOrRecords(t *testing.T) 
 	} else {
 		assertRuntimeNotCompiledError(t, err)
 	}
-	scheduler := NewSchedulerCommandExecutor(SchedulerCommandExecutor{Config: config, Store: store, Runtimes: provider})
+	scheduler := NewSchedulerCommandExecutor(SchedulerCommandExecutorDeps{Config: config, Store: store, Runtimes: provider})
 	_, err = scheduler.ExecuteSchedulerCommand(ctx, session, domain.SchedulerCommandRequest{Mode: "shell", Script: "echo history"})
 	assertRuntimeNotCompiledError(t, err)
 

--- a/pkg/agentcompose/adapters/historical_runtime_capability_test.go
+++ b/pkg/agentcompose/adapters/historical_runtime_capability_test.go
@@ -62,17 +62,31 @@ func TestHistoricalUncompiledRuntimeOperationsPreserveState(t *testing.T) {
 func TestHistoricalUncompiledExecPreflightHasNoArtifactsOrRecords(t *testing.T) {
 	ctx := context.Background()
 	config, store, session, provider := newHistoricalUncompiledRuntimeFixture(t)
-	runner := NewAgentRunner(config, store, nil, nil, provider)
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents:   nil,
+		Runtimes: provider,
+	})
 	executor := NewAgentExecutor(config, store, nil, runner)
 
 	_, _, _, err := executor.ExecuteAgentRequest(ctx, session, execution.ExecuteAgentRequest{Agent: "codex", Message: "hello"})
 	assertRuntimeNotCompiledError(t, err)
-	if _, _, err := runner.ExecuteAgentRun(ctx, session, "codex", "", "", "", "hello", "", nil); err == nil {
+	if _, _, err := runner.ExecuteAgentRun(ctx, AgentRunRequest{
+		Session:           session,
+		Agent:             "codex",
+		AgentDefinitionID: "",
+		Model:             "",
+		RunID:             "",
+		Message:           "hello",
+		OutputSchemaJSON:  "",
+	}, nil); err == nil {
 		t.Fatal("ExecuteAgentRun returned nil error for uncompiled historical runtime")
 	} else {
 		assertRuntimeNotCompiledError(t, err)
 	}
-	scheduler := NewSchedulerCommandExecutor(config, store, nil, provider, nil)
+	scheduler := NewSchedulerCommandExecutor(SchedulerCommandExecutor{Config: config, Store: store, Runtimes: provider})
 	_, err = scheduler.ExecuteSchedulerCommand(ctx, session, domain.SchedulerCommandRequest{Mode: "shell", Script: "echo history"})
 	assertRuntimeNotCompiledError(t, err)
 

--- a/pkg/agentcompose/adapters/llm_client.go
+++ b/pkg/agentcompose/adapters/llm_client.go
@@ -31,23 +31,33 @@ func NewLLMClient(config *appconfig.Config, store *configstore.ConfigStore) *LLM
 }
 
 func (c *LLMClient) Generate(ctx context.Context, prompt, model, outputSchemaJSON string) (llms.GenerateResult, error) {
-	return c.GenerateWithEnv(ctx, prompt, model, outputSchemaJSON, "", nil)
+	return c.GenerateWithEnv(ctx, GenerateWithEnvRequest{Prompt: prompt, Model: model, OutputSchemaJSON: outputSchemaJSON})
 }
 
-func (c *LLMClient) GenerateWithEnv(ctx context.Context, prompt, model, outputSchemaJSON, scopeID string, envItems []domain.SandboxEnvVar) (llms.GenerateResult, error) {
+// GenerateWithEnvRequest bundles the prompt/model inputs and scope/env
+// context GenerateWithEnv needs to resolve an LLM target and generate.
+type GenerateWithEnvRequest struct {
+	Prompt           string
+	Model            string
+	OutputSchemaJSON string
+	ScopeID          string
+	EnvItems         []domain.SandboxEnvVar
+}
+
+func (c *LLMClient) GenerateWithEnv(ctx context.Context, req GenerateWithEnvRequest) (llms.GenerateResult, error) {
 	if c == nil {
 		return llms.GenerateResult{}, fmt.Errorf("llm client is unavailable")
 	}
-	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, c.store, scopeID, "", model, "", envItems)
+	target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, c.config, c.store, req.ScopeID, "", req.Model, "", req.EnvItems)
 	if err != nil {
 		return llms.GenerateResult{}, err
 	}
 	return llms.Generate(ctx, c.client, llms.GenerateRequest{
 		Endpoint:         target.Endpoint,
 		Protocol:         target.WireAPI,
-		Prompt:           prompt,
+		Prompt:           req.Prompt,
 		Model:            firstNonEmpty(target.Model.ID, target.Model.Name),
-		OutputSchemaJSON: outputSchemaJSON,
+		OutputSchemaJSON: req.OutputSchemaJSON,
 		Headers:          target.Headers,
 		MaxOutputTokens:  firstPositive(target.MaxOutputTokens, configuredMaxOutputTokens(c.config)),
 	})

--- a/pkg/agentcompose/adapters/scheduler_command_executor.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor.go
@@ -31,8 +31,8 @@ type SchedulerCommandExecutor struct {
 	Streams  *sandboxes.StreamBroker
 }
 
-func NewSchedulerCommandExecutor(config *appconfig.Config, store *sandboxstore.Store, configDB *configstore.ConfigStore, runtimes RuntimeProvider, streams *sandboxes.StreamBroker) *SchedulerCommandExecutor {
-	return &SchedulerCommandExecutor{Config: config, Store: store, ConfigDB: configDB, Runtimes: runtimes, Streams: streams}
+func NewSchedulerCommandExecutor(deps SchedulerCommandExecutor) *SchedulerCommandExecutor {
+	return &deps
 }
 
 func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, session *domain.Sandbox, request domain.SchedulerCommandRequest) (domain.SchedulerCommandResult, error) {

--- a/pkg/agentcompose/adapters/scheduler_command_executor.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor.go
@@ -31,8 +31,18 @@ type SchedulerCommandExecutor struct {
 	Streams  *sandboxes.StreamBroker
 }
 
-func NewSchedulerCommandExecutor(deps SchedulerCommandExecutor) *SchedulerCommandExecutor {
-	return &deps
+// SchedulerCommandExecutorDeps bundles NewSchedulerCommandExecutor's
+// dependencies.
+type SchedulerCommandExecutorDeps struct {
+	Config   *appconfig.Config
+	Store    *sandboxstore.Store
+	ConfigDB *configstore.ConfigStore
+	Runtimes RuntimeProvider
+	Streams  *sandboxes.StreamBroker
+}
+
+func NewSchedulerCommandExecutor(deps SchedulerCommandExecutorDeps) *SchedulerCommandExecutor {
+	return &SchedulerCommandExecutor{Config: deps.Config, Store: deps.Store, ConfigDB: deps.ConfigDB, Runtimes: deps.Runtimes, Streams: deps.Streams}
 }
 
 func (e *SchedulerCommandExecutor) ExecuteSchedulerCommand(ctx context.Context, session *domain.Sandbox, request domain.SchedulerCommandRequest) (domain.SchedulerCommandResult, error) {

--- a/pkg/agentcompose/adapters/scheduler_command_executor_test.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor_test.go
@@ -122,7 +122,7 @@ func TestSchedulerCommandExecutorFiltersCommandPayloadFromStreamingCellOutput(t 
 	streams := sandboxes.NewStreamBrokerForTest()
 	ch, unsubscribe := streams.Subscribe(session.Summary.ID)
 	defer unsubscribe()
-	executor := NewSchedulerCommandExecutor(config, store, nil, fakeRuntimeProvider{runtime: fakeSchedulerCommandRuntime{}}, streams)
+	executor := NewSchedulerCommandExecutor(SchedulerCommandExecutor{Config: config, Store: store, Runtimes: fakeRuntimeProvider{runtime: fakeSchedulerCommandRuntime{}}, Streams: streams})
 
 	result, err := executor.ExecuteSchedulerCommand(ctx, session, domain.SchedulerCommandRequest{
 		Mode:   "shell",
@@ -204,7 +204,7 @@ func TestSchedulerCommandExecutorRebuildsAndOwnsCommandFacadeTokens(t *testing.T
 			}
 
 			runtime := &capturingSchedulerCommandRuntime{err: tt.runtimeErr}
-			executor := NewSchedulerCommandExecutor(config, store, configDB, fakeRuntimeProvider{runtime: runtime}, sandboxes.NewStreamBrokerForTest())
+			executor := NewSchedulerCommandExecutor(SchedulerCommandExecutor{Config: config, Store: store, ConfigDB: configDB, Runtimes: fakeRuntimeProvider{runtime: runtime}, Streams: sandboxes.NewStreamBrokerForTest()})
 			result, err := executor.ExecuteSchedulerCommand(ctx, session, domain.SchedulerCommandRequest{
 				Mode:   "shell",
 				Script: "echo scheduler",

--- a/pkg/agentcompose/adapters/scheduler_command_executor_test.go
+++ b/pkg/agentcompose/adapters/scheduler_command_executor_test.go
@@ -122,7 +122,7 @@ func TestSchedulerCommandExecutorFiltersCommandPayloadFromStreamingCellOutput(t 
 	streams := sandboxes.NewStreamBrokerForTest()
 	ch, unsubscribe := streams.Subscribe(session.Summary.ID)
 	defer unsubscribe()
-	executor := NewSchedulerCommandExecutor(SchedulerCommandExecutor{Config: config, Store: store, Runtimes: fakeRuntimeProvider{runtime: fakeSchedulerCommandRuntime{}}, Streams: streams})
+	executor := NewSchedulerCommandExecutor(SchedulerCommandExecutorDeps{Config: config, Store: store, Runtimes: fakeRuntimeProvider{runtime: fakeSchedulerCommandRuntime{}}, Streams: streams})
 
 	result, err := executor.ExecuteSchedulerCommand(ctx, session, domain.SchedulerCommandRequest{
 		Mode:   "shell",
@@ -204,7 +204,7 @@ func TestSchedulerCommandExecutorRebuildsAndOwnsCommandFacadeTokens(t *testing.T
 			}
 
 			runtime := &capturingSchedulerCommandRuntime{err: tt.runtimeErr}
-			executor := NewSchedulerCommandExecutor(SchedulerCommandExecutor{Config: config, Store: store, ConfigDB: configDB, Runtimes: fakeRuntimeProvider{runtime: runtime}, Streams: sandboxes.NewStreamBrokerForTest()})
+			executor := NewSchedulerCommandExecutor(SchedulerCommandExecutorDeps{Config: config, Store: store, ConfigDB: configDB, Runtimes: fakeRuntimeProvider{runtime: runtime}, Streams: sandboxes.NewStreamBrokerForTest()})
 			result, err := executor.ExecuteSchedulerCommand(ctx, session, domain.SchedulerCommandRequest{
 				Mode:   "shell",
 				Script: "echo scheduler",

--- a/pkg/agentcompose/adapters/scheduler_host.go
+++ b/pkg/agentcompose/adapters/scheduler_host.go
@@ -68,7 +68,13 @@ func (r SchedulerHostLLMRunner) Generate(ctx context.Context, request schedulers
 	if r.Client == nil {
 		return domain.SchedulerLLMResult{}, fmt.Errorf("llm client is unavailable")
 	}
-	result, err := r.Client.GenerateWithEnv(ctx, request.Prompt, request.Model, request.OutputSchema, "scheduler:"+request.SchedulerID, request.EnvItems)
+	result, err := r.Client.GenerateWithEnv(ctx, GenerateWithEnvRequest{
+		Prompt:           request.Prompt,
+		Model:            request.Model,
+		OutputSchemaJSON: request.OutputSchema,
+		ScopeID:          "scheduler:" + request.SchedulerID,
+		EnvItems:         request.EnvItems,
+	})
 	if err != nil {
 		return domain.SchedulerLLMResult{}, err
 	}

--- a/pkg/agentcompose/adapters/scheduler_session_runner.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner.go
@@ -45,8 +45,24 @@ type SchedulerSandboxRunner struct {
 	inlineWorkspaceLocks *sandboxes.LifecycleLocks
 }
 
-func NewSchedulerSandboxRunner(config *appconfig.Config, store *sandboxstore.Store, configDB *configstore.ConfigStore, workspaceEnsurer workspaces.WorkspaceEnsurer, driver sandboxes.SandboxDriver, cap capabilities.Provider, volumeResolver SchedulerVolumeResolver, streams *sandboxes.StreamBroker, publisher schedulers.ControllerPublisher, capTokens *CapabilitySandboxResolver, agentExecutor *AgentExecutor, locks ...*sandboxes.LifecycleLocks) *SchedulerSandboxRunner {
-	runner := &SchedulerSandboxRunner{Config: config, Store: store, ConfigDB: configDB, workspaceEnsurer: workspaceEnsurer, Driver: driver, Cap: cap, Volumes: volumeResolver, Streams: streams, Publisher: publisher, CapTokens: capTokens, AgentExecutor: agentExecutor, inlineWorkspaceLocks: sandboxes.NewLifecycleLocks()}
+// SchedulerSandboxRunnerDeps bundles NewSchedulerSandboxRunner's required
+// dependencies.
+type SchedulerSandboxRunnerDeps struct {
+	Config           *appconfig.Config
+	Store            *sandboxstore.Store
+	ConfigDB         *configstore.ConfigStore
+	WorkspaceEnsurer workspaces.WorkspaceEnsurer
+	Driver           sandboxes.SandboxDriver
+	Cap              capabilities.Provider
+	VolumeResolver   SchedulerVolumeResolver
+	Streams          *sandboxes.StreamBroker
+	Publisher        schedulers.ControllerPublisher
+	CapTokens        *CapabilitySandboxResolver
+	AgentExecutor    *AgentExecutor
+}
+
+func NewSchedulerSandboxRunner(deps SchedulerSandboxRunnerDeps, locks ...*sandboxes.LifecycleLocks) *SchedulerSandboxRunner {
+	runner := &SchedulerSandboxRunner{Config: deps.Config, Store: deps.Store, ConfigDB: deps.ConfigDB, workspaceEnsurer: deps.WorkspaceEnsurer, Driver: deps.Driver, Cap: deps.Cap, Volumes: deps.VolumeResolver, Streams: deps.Streams, Publisher: deps.Publisher, CapTokens: deps.CapTokens, AgentExecutor: deps.AgentExecutor, inlineWorkspaceLocks: sandboxes.NewLifecycleLocks()}
 	if len(locks) > 0 {
 		runner.LifecycleLocks = locks[0]
 	}
@@ -90,10 +106,29 @@ func (r *SchedulerSandboxRunner) stopLifecycle() sandboxes.Lifecycle {
 	}
 }
 
-func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Scheduler, request domain.SchedulerAgentRequest, titleOverridesSession bool) (*domain.Sandbox, string, error) {
+// resolvedSchedulerSandboxConfig is the sandbox configuration
+// resolveSchedulerSandboxConfig derives from a scheduler + agent request,
+// ready to reuse an existing sticky binding or create a new sandbox.
+type resolvedSchedulerSandboxConfig struct {
+	AgentDefinition   *domain.AgentDefinition
+	EffectivePolicy   string
+	ForceNew          bool
+	ProviderEnvItems  []domain.SandboxEnvVar
+	EnvItems          []domain.SandboxEnvVar
+	AgentConfig       execution.AgentConfig
+	WorkspaceSnapshot *domain.SandboxWorkspace
+	WorkspaceID       string
+	Driver            string
+	GuestImage        string
+	VolumeMounts      []domain.SandboxVolumeMount
+	VolumeWarnings    []string
+	ConfigHash        string
+}
+
+func (r *SchedulerSandboxRunner) resolveSchedulerSandboxConfig(ctx context.Context, scheduler domain.Scheduler, request domain.SchedulerAgentRequest, titleOverridesSession bool) (resolvedSchedulerSandboxConfig, error) {
 	agentDefinition, err := r.ResolveSchedulerAgentDefinition(ctx, scheduler)
 	if err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
 	effectivePolicy := schedulers.NormalizeSandboxPolicy(scheduler.Summary.SandboxPolicy)
 	if strings.TrimSpace(schedulers.AgentSandboxPolicy(request)) != "" {
@@ -103,7 +138,7 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 	forceNew := effectivePolicy == domain.SchedulerSandboxPolicyNew || hasOverrides
 	globalEnvItems, err := r.ConfigDB.ListGlobalEnv(ctx)
 	if err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
 	var providerEnvItems []domain.SandboxEnvVar
 	if agentDefinition != nil {
@@ -129,46 +164,66 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 	workspaceID := r.workspaceID(scheduler, request, agentDefinition)
 	workspaceSnapshot, workspaceID, err := r.resolveWorkspaceSnapshot(ctx, request, agentDefinition, workspaceID)
 	if err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
 	driver, err := r.driver(request, scheduler, agentDefinition)
 	if err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
 	if err := validateSchedulerRuntimeDriverCompiled(driver); err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
 	guestImage := r.guestImage(request, scheduler, agentDefinition, driver)
 	volumeMounts, volumeWarnings, err := r.resolveVolumeMounts(ctx, scheduler, request, agentDefinition)
 	if err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
 	baseConfigHash, err := schedulerSandboxConfigHash(scheduler)
 	if err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
-	configHash, err := schedulerRequestSandboxConfigHash(baseConfigHash, request, agentDefinition, providerEnvItems, envItems, workspaceSnapshot, driver, guestImage, volumeMounts)
+	configHash, err := schedulerRequestSandboxConfigHash(schedulerRequestSandboxConfigHashRequest{
+		BaseHash:         baseConfigHash,
+		Request:          request,
+		AgentDefinition:  agentDefinition,
+		ProviderEnvItems: providerEnvItems,
+		EnvItems:         envItems,
+		Workspace:        workspaceSnapshot,
+		Driver:           driver,
+		GuestImage:       guestImage,
+		VolumeMounts:     volumeMounts,
+	})
 	if err != nil {
-		return nil, "", err
+		return resolvedSchedulerSandboxConfig{}, err
 	}
-	var previousBinding *domain.SchedulerBinding
-	if !forceNew {
-		if session, eventType, reused, binding, err := r.reuseCompatibleSchedulerBinding(ctx, scheduler, request.BindingTriggerID, configHash); err != nil {
-			return nil, "", err
-		} else if reused {
-			return session, eventType, nil
-		} else {
-			previousBinding = binding
-		}
-	}
+	return resolvedSchedulerSandboxConfig{
+		AgentDefinition:   agentDefinition,
+		EffectivePolicy:   effectivePolicy,
+		ForceNew:          forceNew,
+		ProviderEnvItems:  providerEnvItems,
+		EnvItems:          envItems,
+		AgentConfig:       agentConfig,
+		WorkspaceSnapshot: workspaceSnapshot,
+		WorkspaceID:       workspaceID,
+		Driver:            driver,
+		GuestImage:        guestImage,
+		VolumeMounts:      volumeMounts,
+		VolumeWarnings:    volumeWarnings,
+		ConfigHash:        configHash,
+	}, nil
+}
 
+// createSchedulerSandbox creates the sandbox for a resolved scheduler sandbox
+// config: builds tags/title, creates the sandbox, persists provider env items
+// and pull policy, and records any volume-resolution warnings.
+func (r *SchedulerSandboxRunner) createSchedulerSandbox(ctx context.Context, scheduler domain.Scheduler, request domain.SchedulerAgentRequest, cfg resolvedSchedulerSandboxConfig) (*domain.Sandbox, error) {
 	capabilityVars, capabilityTags := capabilities.BuildGatewaySandboxVars(capabilities.ProxyTarget(r.Cap), scheduler.Summary.CapsetIDs)
-	envItems = domain.MergeEnvItems(envItems, capabilityVars)
+	envItems := domain.MergeEnvItems(cfg.EnvItems, capabilityVars)
 	tags := []domain.SandboxTag{
 		{Name: "origin", Value: "scheduler"},
 		{Name: "scheduler_id", Value: scheduler.Summary.ID},
 		{Name: "scheduler_name", Value: scheduler.Summary.Name},
-		{Name: domain.AgentSandboxTagProvider, Value: agentConfig.Provider},
+		{Name: domain.AgentSandboxTagProvider, Value: cfg.AgentConfig.Provider},
 	}
 	if strings.TrimSpace(scheduler.Summary.ProjectID) != "" {
 		projectID := strings.TrimSpace(scheduler.Summary.ProjectID)
@@ -180,6 +235,7 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 	}
 	tags = append(tags, capabilityTags...)
 	title := firstNonEmpty(strings.TrimSpace(request.Title), strings.TrimSpace(scheduler.Summary.Name), schedulers.DefaultName(time.Now().UTC()))
+	agentDefinition := cfg.AgentDefinition
 	if agentDefinition != nil {
 		tags = append(tags,
 			domain.SandboxTag{Name: domain.AgentSandboxTagSource, Value: domain.AgentSandboxTagSourceVal},
@@ -187,22 +243,47 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 			domain.SandboxTag{Name: domain.AgentSandboxTagName, Value: agentDefinition.Name},
 		)
 	}
-	session, err := r.Store.CreateSandboxWithOptions(ctx, title, "", driver, guestImage, workspaceID, domain.SandboxTypeScript+":"+scheduler.Summary.ID, workspaceSnapshot, envItems, tags, sandboxstore.CreateSandboxOptions{
+	session, err := r.Store.CreateSandboxWithOptions(ctx, title, "", cfg.Driver, cfg.GuestImage, cfg.WorkspaceID, domain.SandboxTypeScript+":"+scheduler.Summary.ID, cfg.WorkspaceSnapshot, envItems, tags, sandboxstore.CreateSandboxOptions{
 		JupyterEnabled:       request.JupyterEnabled,
-		VolumeMounts:         volumeMounts,
+		VolumeMounts:         cfg.VolumeMounts,
 		StoppedRuntimePolicy: stoppedRuntimePolicyFromAgentDefinition(agentDefinition),
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	llms.SetSandboxProviderEnvItems(session, providerEnvItems)
+	llms.SetSandboxProviderEnvItems(session, cfg.ProviderEnvItems)
 	if request.PullPolicy != "" {
 		session.Summary.PullPolicy = request.PullPolicy
 		if err := r.Store.UpdateSandbox(ctx, session); err != nil {
-			return nil, "", fmt.Errorf("persist sandbox pull policy: %w", err)
+			return nil, fmt.Errorf("persist sandbox pull policy: %w", err)
 		}
 	}
-	r.recordVolumeWarnings(ctx, session.Summary.ID, volumeWarnings)
+	r.recordVolumeWarnings(ctx, session.Summary.ID, cfg.VolumeWarnings)
+	return session, nil
+}
+
+func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Scheduler, request domain.SchedulerAgentRequest, titleOverridesSession bool) (*domain.Sandbox, string, error) {
+	cfg, err := r.resolveSchedulerSandboxConfig(ctx, scheduler, request, titleOverridesSession)
+	if err != nil {
+		return nil, "", err
+	}
+	var previousBinding *domain.SchedulerBinding
+	if !cfg.ForceNew {
+		if session, eventType, reused, binding, err := r.reuseCompatibleSchedulerBinding(ctx, scheduler, request.BindingTriggerID, cfg.ConfigHash); err != nil {
+			return nil, "", err
+		} else if reused {
+			return session, eventType, nil
+		} else {
+			previousBinding = binding
+		}
+	}
+
+	session, err := r.createSchedulerSandbox(ctx, scheduler, request, cfg)
+	if err != nil {
+		return nil, "", err
+	}
+	workspaceSnapshot, agentDefinition, agentConfig := cfg.WorkspaceSnapshot, cfg.AgentDefinition, cfg.AgentConfig
+	effectivePolicy, forceNew, configHash := cfg.EffectivePolicy, cfg.ForceNew, cfg.ConfigHash
 	ensureErr := func() error {
 		unlock := r.fileWorkspaceReadLock(workspaceSnapshot)
 		defer unlock()
@@ -213,7 +294,7 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 		_ = r.Store.UpdateSandbox(ctx, session)
 		return nil, "", ensureErr
 	}
-	writeCapabilityGuide(ctx, r.Cap, r.Store, r.Streams, session, scheduler.Summary.CapsetIDs)
+	writeCapabilityGuide(ctx, writeCapabilityGuideRequest{Provider: r.Cap, Store: r.Store, Streams: r.Streams, Session: session, CapsetIDs: scheduler.Summary.CapsetIDs})
 	if r.AgentExecutor == nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = r.Store.UpdateSandbox(ctx, session)
@@ -242,7 +323,12 @@ func (r *SchedulerSandboxRunner) Ensure(ctx context.Context, scheduler domain.Sc
 		r.Streams.PublishEventAdded(session.Summary.ID, event)
 	}
 	if effectivePolicy == domain.SchedulerSandboxPolicySticky && !forceNew {
-		claimed, err := r.bindSchedulerSandbox(ctx, scheduler, request.BindingTriggerID, session.Summary.ID, configHash, previousBinding)
+		claimed, err := r.bindSchedulerSandbox(ctx, domain.SchedulerBinding{
+			SchedulerID:       scheduler.Summary.ID,
+			TriggerID:         request.BindingTriggerID,
+			SandboxID:         session.Summary.ID,
+			SandboxConfigHash: configHash,
+		}, previousBinding)
 		if err != nil {
 			_ = r.Shutdown(ctx, session.Summary.ID)
 			return nil, "", fmt.Errorf("persist scheduler sticky sandbox binding: %w", err)
@@ -321,7 +407,7 @@ func (r *SchedulerSandboxRunner) loadOrResumeLocked(ctx context.Context, session
 			return nil, "", err
 		}
 	}
-	writeCapabilityGuide(ctx, r.Cap, r.Store, r.Streams, session, capabilities.SandboxCapsets(session))
+	writeCapabilityGuide(ctx, writeCapabilityGuideRequest{Provider: r.Cap, Store: r.Store, Streams: r.Streams, Session: session, CapsetIDs: capabilities.SandboxCapsets(session)})
 	if err := r.Driver.StartSandboxVM(ctx, session); err != nil {
 		return nil, "", err
 	}

--- a/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_coverage_test.go
@@ -27,7 +27,19 @@ func TestSchedulerSandboxRunnerLoadResumeAndShutdownCoverage(t *testing.T) {
 	bridge.config.LLMModel = "gpt-scheduler-retry"
 	bridge.config.LLMAPIProtocol = "responses"
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: bridge.workspaceEnsurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	running, err := bridge.store.CreateSandbox(ctx, "running", "", driverpkg.RuntimeDriverBoxlite, "", "", "scheduler", nil, nil, nil)
 	if err != nil {
@@ -108,7 +120,19 @@ func TestSchedulerSandboxRunnerReleasedRuntimeResumePreparesAgentEnvironment(t *
 	bridge.config.LLMAPIKey = "provider-key"
 	bridge.config.LLMModel = "gpt-scheduler-retry"
 	bridge.config.LLMAPIProtocol = "responses"
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: bridge.workspaceEnsurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        nil,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	released, err := bridge.store.CreateSandbox(ctx, "released", "", driverpkg.RuntimeDriverBoxlite, "", "", "scheduler", nil, nil, []domain.SandboxTag{
 		{Name: domain.AgentSandboxTagProvider, Value: "codex"},
@@ -148,7 +172,19 @@ func TestSchedulerSandboxRunnerRuntimeReleaseFailureFinalizesConfirmedStop(t *te
 	publisher := &schedulerSessionPublisherFake{}
 	resolver := NewCapabilitySandboxResolver(bridge.store)
 	resolver.initialized = true
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, publisher, resolver, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: bridge.workspaceEnsurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        resolver,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	const capabilityToken = "capability-token"
 	sandbox, err := bridge.store.CreateSandbox(ctx, "release failure", "", driverpkg.RuntimeDriverBoxlite, "", "", "scheduler", nil,
@@ -205,7 +241,19 @@ func TestSchedulerSandboxRunnerRuntimeReleaseFailureFinalizesConfirmedStop(t *te
 func TestSchedulerSandboxRunnerRejectsUnsupportedStickyResumeBeforeSideEffects(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: bridge.workspaceEnsurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        nil,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	session, err := bridge.store.CreateSandbox(ctx, "historical sticky", "", driverpkg.RuntimeDriverMicrosandbox, "", "", "scheduler", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
@@ -247,7 +295,19 @@ func TestSchedulerSandboxRunnerRejectsUncompiledDriverBeforePersistence(t *testi
 			ctx := context.Background()
 			bridge, sandboxDriver := newTestSandboxRPCBridge(t)
 			publisher := &schedulerSessionPublisherFake{}
-			runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, sandboxDriver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+			runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+				Config:           bridge.config,
+				Store:            bridge.store,
+				ConfigDB:         bridge.configDB,
+				WorkspaceEnsurer: bridge.workspaceEnsurer,
+				Driver:           sandboxDriver,
+				Cap:              nil,
+				VolumeResolver:   nil,
+				Streams:          bridge.streams,
+				Publisher:        publisher,
+				CapTokens:        nil,
+				AgentExecutor:    bridge.agentExecutor,
+			})
 			scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
 				ID:            "scheduler-uncompiled-" + runtimeDriver,
 				Name:          "Uncompiled " + runtimeDriver,
@@ -328,7 +388,19 @@ func TestSchedulerSandboxRunnerResolvesVolumeMounts(t *testing.T) {
 		}},
 		warnings: []string{"volume target /cache overlaps test path"},
 	}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, resolver, bridge.streams, nil, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: bridge.workspaceEnsurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   resolver,
+		Streams:          bridge.streams,
+		Publisher:        nil,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	projectRoot := t.TempDir()
 	projectPath := filepath.Join(projectRoot, "agent-compose.yml")
 	if _, err := bridge.configDB.UpsertProject(ctx, domain.ProjectRecord{ID: "project-1", Name: "project", SourcePath: projectPath}); err != nil {

--- a/pkg/agentcompose/adapters/scheduler_session_runner_env_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_env_test.go
@@ -31,7 +31,19 @@ func TestSchedulerSandboxRunnerEnvironmentPrecedence(t *testing.T) {
 		},
 	})
 
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, bridge.workspaceEnsurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: bridge.workspaceEnsurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        nil,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{
 		Summary: domain.SchedulerSummary{
 			ID:            "scheduler-env-precedence",

--- a/pkg/agentcompose/adapters/scheduler_session_runner_workspace_ensurer_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_workspace_ensurer_test.go
@@ -84,7 +84,19 @@ func TestSchedulerSandboxRunnerEnsureUsesWorkspaceEnsurerBeforeGuideAndDriver(t 
 		}
 	}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, bridge.cap, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              bridge.cap,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
 		ID:            "scheduler-create",
 		Name:          "Scheduler Create",
@@ -142,7 +154,19 @@ func TestSchedulerSandboxRunnerEnsureWorkspaceEnsurerErrorShortCircuitsDriver(t 
 		return []byte("unexpected guide"), nil
 	}}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              capabilityProvider,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
 		ID:            "scheduler-ensure-error",
 		Name:          "Scheduler Ensure Error",
@@ -197,7 +221,19 @@ func TestSchedulerSandboxRunnerEnsureRuntimeFailurePreservesReadyProvisioning(t 
 	}}
 	startErr := errors.New("scheduler runtime start failed")
 	driver.startErr = startErr
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        nil,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
 		ID:            "scheduler-runtime-error",
 		Name:          "Scheduler Runtime Error",
@@ -280,7 +316,19 @@ func TestSchedulerSandboxRunnerLoadOrResumeUsesWorkspaceEnsurer(t *testing.T) {
 			}
 		}
 		publisher := &schedulerSessionPublisherFake{}
-		runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+		runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+			Config:           bridge.config,
+			Store:            bridge.store,
+			ConfigDB:         bridge.configDB,
+			WorkspaceEnsurer: ensurer,
+			Driver:           driver,
+			Cap:              capabilityProvider,
+			VolumeResolver:   nil,
+			Streams:          bridge.streams,
+			Publisher:        publisher,
+			CapTokens:        nil,
+			AgentExecutor:    bridge.agentExecutor,
+		})
 
 		resumed, eventType, err := runner.LoadOrResume(ctx, stopped.Summary.ID)
 		if err != nil {
@@ -333,7 +381,19 @@ func TestSchedulerSandboxRunnerLoadOrResumeUsesWorkspaceEnsurer(t *testing.T) {
 			return nil, nil
 		}}
 		publisher := &schedulerSessionPublisherFake{}
-		runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, capabilityProvider, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+		runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+			Config:           bridge.config,
+			Store:            bridge.store,
+			ConfigDB:         bridge.configDB,
+			WorkspaceEnsurer: ensurer,
+			Driver:           driver,
+			Cap:              capabilityProvider,
+			VolumeResolver:   nil,
+			Streams:          bridge.streams,
+			Publisher:        publisher,
+			CapTokens:        nil,
+			AgentExecutor:    bridge.agentExecutor,
+		})
 
 		_, _, err = runner.LoadOrResume(ctx, stopped.Summary.ID)
 		if !errors.Is(err, ensureErr) {
@@ -371,7 +431,19 @@ func TestSchedulerSandboxRunnerLoadOrResumeUsesWorkspaceEnsurer(t *testing.T) {
 		}}
 		startErr := errors.New("resume runtime start failed")
 		driver.startErr = startErr
-		runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
+		runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+			Config:           bridge.config,
+			Store:            bridge.store,
+			ConfigDB:         bridge.configDB,
+			WorkspaceEnsurer: ensurer,
+			Driver:           driver,
+			Cap:              nil,
+			VolumeResolver:   nil,
+			Streams:          bridge.streams,
+			Publisher:        nil,
+			CapTokens:        nil,
+			AgentExecutor:    bridge.agentExecutor,
+		})
 
 		_, _, err = runner.LoadOrResume(ctx, stopped.Summary.ID)
 		if !errors.Is(err, startErr) {
@@ -425,7 +497,19 @@ func TestSchedulerSandboxRunnerStickyRunningMatchingConfigSkipsEnsurerAndPreserv
 	request := domain.SchedulerAgentRequest{Agent: "codex", BindingTriggerID: "sticky-trigger"}
 	ensurer := &recordingSchedulerWorkspaceEnsurer{err: errors.New("running sticky path must not ensure workspace")}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	baseConfigHash, err := schedulerSandboxConfigHash(scheduler)
 	if err != nil {
 		t.Fatalf("schedulerSandboxConfigHash returned error: %v", err)
@@ -435,7 +519,17 @@ func TestSchedulerSandboxRunnerStickyRunningMatchingConfigSkipsEnsurerAndPreserv
 		t.Fatalf("ResolveSchedulerAgentDefinition returned error: %v", err)
 	}
 	guestImage := runner.guestImage(request, scheduler, agentDefinition, driverpkg.RuntimeDriverDocker)
-	configHash, err := schedulerRequestSandboxConfigHash(baseConfigHash, request, agentDefinition, nil, nil, originalSnapshot, driverpkg.RuntimeDriverDocker, guestImage, nil)
+	configHash, err := schedulerRequestSandboxConfigHash(schedulerRequestSandboxConfigHashRequest{
+		BaseHash:         baseConfigHash,
+		Request:          request,
+		AgentDefinition:  agentDefinition,
+		ProviderEnvItems: nil,
+		EnvItems:         nil,
+		Workspace:        originalSnapshot,
+		Driver:           driverpkg.RuntimeDriverDocker,
+		GuestImage:       guestImage,
+		VolumeMounts:     nil,
+	})
 	if err != nil {
 		t.Fatalf("schedulerRequestSandboxConfigHash returned error: %v", err)
 	}
@@ -486,7 +580,19 @@ func TestSchedulerSandboxRunnerAdoptsLegacyStickyBindingWithoutStoppingSandbox(t
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			bridge, driver := newTestSandboxRPCBridge(t)
-			runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingSchedulerWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
+			runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+				Config:           bridge.config,
+				Store:            bridge.store,
+				ConfigDB:         bridge.configDB,
+				WorkspaceEnsurer: &recordingSchedulerWorkspaceEnsurer{},
+				Driver:           driver,
+				Cap:              nil,
+				VolumeResolver:   nil,
+				Streams:          bridge.streams,
+				Publisher:        nil,
+				CapTokens:        nil,
+				AgentExecutor:    bridge.agentExecutor,
+			})
 			scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{ID: "legacy-scheduler", SandboxPolicy: domain.SchedulerSandboxPolicySticky}}
 			scheduler = createNativeTestScheduler(t, ctx, bridge.configDB, scheduler)
 			const triggerID = "legacy-trigger"
@@ -524,7 +630,19 @@ func TestSchedulerSandboxRunnerAdoptsLegacyStickyBindingWithoutStoppingSandbox(t
 func TestSchedulerSandboxRunnerConcurrentStickyClaimReusesWinner(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingSchedulerWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, nil, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: &recordingSchedulerWorkspaceEnsurer{},
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        nil,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
 		ID:                "scheduler-concurrent-sticky",
 		Name:              "Concurrent Sticky",
@@ -543,7 +661,17 @@ func TestSchedulerSandboxRunnerConcurrentStickyClaimReusesWinner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("schedulerSandboxConfigHash returned error: %v", err)
 	}
-	configHash, err := schedulerRequestSandboxConfigHash(baseConfigHash, request, agentDefinition, nil, nil, nil, driverpkg.RuntimeDriverDocker, guestImage, nil)
+	configHash, err := schedulerRequestSandboxConfigHash(schedulerRequestSandboxConfigHashRequest{
+		BaseHash:         baseConfigHash,
+		Request:          request,
+		AgentDefinition:  agentDefinition,
+		ProviderEnvItems: nil,
+		EnvItems:         nil,
+		Workspace:        nil,
+		Driver:           driverpkg.RuntimeDriverDocker,
+		GuestImage:       guestImage,
+		VolumeMounts:     nil,
+	})
 	if err != nil {
 		t.Fatalf("schedulerRequestSandboxConfigHash returned error: %v", err)
 	}
@@ -602,7 +730,19 @@ func TestSchedulerSandboxRunnerStickyWorkspaceConfigChangeCreatesReplacement(t *
 	if err != nil {
 		t.Fatalf("CreateWorkspaceConfig returned error: %v", err)
 	}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingSchedulerWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, &schedulerSessionPublisherFake{}, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: &recordingSchedulerWorkspaceEnsurer{},
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        &schedulerSessionPublisherFake{},
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
 		ID:            "scheduler-sticky-workspace-update",
 		Name:          "Scheduler Sticky Workspace Update",
@@ -642,19 +782,19 @@ func TestSchedulerSandboxRunnerStickyRunningConfigChangeCreatesReplacement(t *te
 		},
 	}
 	capTokens := NewCapabilitySandboxResolver(bridge.store)
-	runner := NewSchedulerSandboxRunner(
-		bridge.config,
-		bridge.store,
-		bridge.configDB,
-		&recordingSchedulerWorkspaceEnsurer{},
-		driver,
-		capabilityProvider,
-		nil,
-		bridge.streams,
-		&schedulerSessionPublisherFake{},
-		capTokens,
-		bridge.agentExecutor,
-	)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: &recordingSchedulerWorkspaceEnsurer{},
+		Driver:           driver,
+		Cap:              capabilityProvider,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        &schedulerSessionPublisherFake{},
+		CapTokens:        capTokens,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{
 		Summary: domain.SchedulerSummary{
 			ID:            "scheduler-sticky-update",
@@ -726,7 +866,19 @@ func TestSchedulerSandboxRunnerStickyRunningConfigChangeCreatesReplacement(t *te
 func TestSchedulerSandboxRunnerStickyStoppedConfigChangeDoesNotResume(t *testing.T) {
 	ctx := context.Background()
 	bridge, driver := newTestSandboxRPCBridge(t)
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, &recordingSchedulerWorkspaceEnsurer{}, driver, nil, nil, bridge.streams, &schedulerSessionPublisherFake{}, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: &recordingSchedulerWorkspaceEnsurer{},
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        &schedulerSessionPublisherFake{},
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 	scheduler := domain.Scheduler{
 		Summary: domain.SchedulerSummary{
 			ID:            "scheduler-sticky-stopped-update",

--- a/pkg/agentcompose/adapters/scheduler_session_runner_workspace_resume_integration_test.go
+++ b/pkg/agentcompose/adapters/scheduler_session_runner_workspace_resume_integration_test.go
@@ -58,19 +58,19 @@ func TestIntegrationSchedulerStickyResumePreservesReadyFileWorkspace(t *testing.
 	scheduler = createNativeTestScheduler(t, ctx, bridge.configDB, scheduler)
 	request := domain.SchedulerAgentRequest{BindingTriggerID: triggerID}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(
-		bridge.config,
-		bridge.store,
-		bridge.configDB,
-		bridge.workspaceEnsurer,
-		driver,
-		nil,
-		nil,
-		bridge.streams,
-		publisher,
-		nil,
-		bridge.agentExecutor,
-	)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: bridge.workspaceEnsurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	created, eventType, err := runner.Ensure(ctx, scheduler, request, false)
 	if err != nil {

--- a/pkg/agentcompose/adapters/scheduler_sticky_binding.go
+++ b/pkg/agentcompose/adapters/scheduler_sticky_binding.go
@@ -88,13 +88,8 @@ func (r *SchedulerSandboxRunner) loadOrResumeSchedulerBinding(ctx context.Contex
 	return session, eventType, true, err
 }
 
-func (r *SchedulerSandboxRunner) bindSchedulerSandbox(ctx context.Context, scheduler domain.Scheduler, triggerID, sandboxID, configHash string, expected *domain.SchedulerBinding) (bool, error) {
-	return r.ConfigDB.CompareAndSwapSchedulerBinding(ctx, expected, domain.SchedulerBinding{
-		SchedulerID:       scheduler.Summary.ID,
-		TriggerID:         triggerID,
-		SandboxID:         sandboxID,
-		SandboxConfigHash: configHash,
-	})
+func (r *SchedulerSandboxRunner) bindSchedulerSandbox(ctx context.Context, desired domain.SchedulerBinding, expected *domain.SchedulerBinding) (bool, error) {
+	return r.ConfigDB.CompareAndSwapSchedulerBinding(ctx, expected, desired)
 }
 
 func (r *SchedulerSandboxRunner) claimLegacySchedulerBindingConfigHash(ctx context.Context, binding domain.SchedulerBinding, configHash string) (domain.SchedulerBinding, bool, error) {
@@ -172,7 +167,25 @@ type schedulerAgentSandboxConfig struct {
 	AgentName    string                   `json:"managed_agent_name,omitempty"`
 }
 
-func schedulerRequestSandboxConfigHash(baseHash string, request domain.SchedulerAgentRequest, agentDefinition *domain.AgentDefinition, providerEnvItems, envItems []domain.SandboxEnvVar, workspace *domain.SandboxWorkspace, driver, guestImage string, volumeMounts []domain.SandboxVolumeMount) (string, error) {
+// schedulerRequestSandboxConfigHashRequest bundles the request, agent
+// definition, and resolved environment/workspace/volume inputs
+// schedulerRequestSandboxConfigHash hashes into a sticky sandbox config hash.
+type schedulerRequestSandboxConfigHashRequest struct {
+	BaseHash         string
+	Request          domain.SchedulerAgentRequest
+	AgentDefinition  *domain.AgentDefinition
+	ProviderEnvItems []domain.SandboxEnvVar
+	EnvItems         []domain.SandboxEnvVar
+	Workspace        *domain.SandboxWorkspace
+	Driver           string
+	GuestImage       string
+	VolumeMounts     []domain.SandboxVolumeMount
+}
+
+func schedulerRequestSandboxConfigHash(req schedulerRequestSandboxConfigHashRequest) (string, error) {
+	baseHash, request, agentDefinition := req.BaseHash, req.Request, req.AgentDefinition
+	providerEnvItems, envItems, workspace := req.ProviderEnvItems, req.EnvItems, req.Workspace
+	driver, guestImage, volumeMounts := req.Driver, req.GuestImage, req.VolumeMounts
 	var agentConfig *schedulerAgentSandboxConfig
 	if agentDefinition != nil {
 		current, err := projects.NormalizeAgentDefinition(*agentDefinition, true)

--- a/pkg/agentcompose/adapters/scheduler_sticky_binding_test.go
+++ b/pkg/agentcompose/adapters/scheduler_sticky_binding_test.go
@@ -29,12 +29,32 @@ func TestSchedulerRequestSandboxConfigHashIgnoresVolumeMountOrder(t *testing.T) 
 		{ID: "volume-data", Type: domain.VolumeMountTypeVolume, Source: "data", Target: "/workspace/data", HostPath: "/volumes/data", VolumeID: "volume-1"},
 		{ID: "bind-cache", Type: domain.VolumeMountTypeBind, Source: "./cache", Target: "/workspace/cache", HostPath: "/project/cache", ProjectPath: "/project"},
 	}
-	first, err := schedulerRequestSandboxConfigHash("sha256:scheduler", domain.SchedulerAgentRequest{}, nil, nil, nil, nil, "docker", "guest:v1", mounts)
+	first, err := schedulerRequestSandboxConfigHash(schedulerRequestSandboxConfigHashRequest{
+		BaseHash:         "sha256:scheduler",
+		Request:          domain.SchedulerAgentRequest{},
+		AgentDefinition:  nil,
+		ProviderEnvItems: nil,
+		EnvItems:         nil,
+		Workspace:        nil,
+		Driver:           "docker",
+		GuestImage:       "guest:v1",
+		VolumeMounts:     mounts,
+	})
 	if err != nil {
 		t.Fatalf("schedulerRequestSandboxConfigHash returned error: %v", err)
 	}
 	reordered := []domain.SandboxVolumeMount{mounts[1], mounts[0]}
-	second, err := schedulerRequestSandboxConfigHash("sha256:scheduler", domain.SchedulerAgentRequest{}, nil, nil, nil, nil, "docker", "guest:v1", reordered)
+	second, err := schedulerRequestSandboxConfigHash(schedulerRequestSandboxConfigHashRequest{
+		BaseHash:         "sha256:scheduler",
+		Request:          domain.SchedulerAgentRequest{},
+		AgentDefinition:  nil,
+		ProviderEnvItems: nil,
+		EnvItems:         nil,
+		Workspace:        nil,
+		Driver:           "docker",
+		GuestImage:       "guest:v1",
+		VolumeMounts:     reordered,
+	})
 	if err != nil {
 		t.Fatalf("schedulerRequestSandboxConfigHash reordered returned error: %v", err)
 	}
@@ -98,17 +118,17 @@ func TestSchedulerRequestSandboxConfigHashUsesEffectiveAgentConfigInsteadOfProje
 
 func mustSchedulerRequestSandboxConfigHash(t *testing.T, agentDefinition *domain.AgentDefinition) string {
 	t.Helper()
-	hash, err := schedulerRequestSandboxConfigHash(
-		"sha256:scheduler",
-		domain.SchedulerAgentRequest{},
-		agentDefinition,
-		nil,
-		nil,
-		nil,
-		"docker",
-		"guest:v1",
-		nil,
-	)
+	hash, err := schedulerRequestSandboxConfigHash(schedulerRequestSandboxConfigHashRequest{
+		BaseHash:         "sha256:scheduler",
+		Request:          domain.SchedulerAgentRequest{},
+		AgentDefinition:  agentDefinition,
+		ProviderEnvItems: nil,
+		EnvItems:         nil,
+		Workspace:        nil,
+		Driver:           "docker",
+		GuestImage:       "guest:v1",
+		VolumeMounts:     nil,
+	})
 	if err != nil {
 		t.Fatalf("schedulerRequestSandboxConfigHash returned error: %v", err)
 	}

--- a/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
+++ b/pkg/agentcompose/adapters/scheduler_workspace_inline_test.go
@@ -83,7 +83,19 @@ func TestSchedulerSandboxRunnerEnsureResolvesInlineGitWorkspace(t *testing.T) {
 	bridge, driver := newTestSandboxRPCBridge(t)
 	ensurer := &recordingSchedulerWorkspaceEnsurer{}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	scheduler := domain.Scheduler{Summary: domain.SchedulerSummary{
 		ID:            "scheduler-inline-git",
@@ -132,7 +144,19 @@ func TestSchedulerSandboxRunnerEnsureResolvesInlineFileWorkspace(t *testing.T) {
 	bridge, driver := newTestSandboxRPCBridge(t)
 	ensurer := &recordingSchedulerWorkspaceEnsurer{}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	projectSource := t.TempDir()
 	if err := os.WriteFile(filepath.Join(projectSource, "hello.txt"), []byte("hello from source\n"), 0o644); err != nil {
@@ -192,7 +216,19 @@ func TestSchedulerSandboxRunnerConcurrentInlineFileWorkspaceMaterializationIsSer
 	bridge, driver := newTestSandboxRPCBridge(t)
 	ensurer := &recordingSchedulerWorkspaceEnsurer{}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	projectSource := t.TempDir()
 	for dir := 0; dir < 8; dir++ {
@@ -298,7 +334,19 @@ func TestSchedulerSandboxRunnerConcurrentEnsureSerializesFileWorkspaceReadAgains
 	bridge, driver := newTestSandboxRPCBridge(t)
 	provisioner := workspaces.NewProvisioner(bridge.config, bridge.configDB, bridge.store)
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, provisioner, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: provisioner,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	projectSource := t.TempDir()
 	const dirCount, fileCount = 6, 30
@@ -406,7 +454,19 @@ func TestSchedulerSandboxRunnerEnsureReleasesFileWorkspaceLockOnEnsurerPanic(t *
 		return nil
 	}}
 	publisher := &schedulerSessionPublisherFake{}
-	runner := NewSchedulerSandboxRunner(bridge.config, bridge.store, bridge.configDB, ensurer, driver, nil, nil, bridge.streams, publisher, nil, bridge.agentExecutor)
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           bridge.config,
+		Store:            bridge.store,
+		ConfigDB:         bridge.configDB,
+		WorkspaceEnsurer: ensurer,
+		Driver:           driver,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          bridge.streams,
+		Publisher:        publisher,
+		CapTokens:        nil,
+		AgentExecutor:    bridge.agentExecutor,
+	})
 
 	projectSource := t.TempDir()
 	if err := os.WriteFile(filepath.Join(projectSource, "hello.txt"), []byte("hello\n"), 0o644); err != nil {

--- a/pkg/agentcompose/adapters/session_driver_test.go
+++ b/pkg/agentcompose/adapters/session_driver_test.go
@@ -320,7 +320,13 @@ func TestSandboxDriverFreshStartFailureRevokesPreparedAgentToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
-	runner := NewAgentRunner(config, store, configDB, configDB, nil)
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: configDB,
+		Agents:   configDB,
+		Runtimes: nil,
+	})
 	if err := runner.PrepareSandboxAgentEnvironment(ctx, session, execution.AgentConfig{Provider: "codex", Model: "gpt-test"}, nil); err != nil {
 		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
 	}
@@ -391,7 +397,13 @@ func TestSandboxDriverReleasedRuntimeRecreationFailureRevokesPreparedAgentToken(
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
 	session.StoppedRuntime = &domain.StoppedRuntime{State: domain.StoppedRuntimeStateReleased, ReleasedAt: time.Now().UTC()}
-	runner := NewAgentRunner(config, store, configDB, configDB, nil)
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: configDB,
+		Agents:   configDB,
+		Runtimes: nil,
+	})
 	if err := runner.PrepareSandboxAgentEnvironment(ctx, session, execution.AgentConfig{Provider: "codex", Model: "gpt-test"}, nil); err != nil {
 		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
 	}
@@ -458,7 +470,13 @@ func TestSandboxDriverFailedRunningSandboxCheckKeepsPreparedAgentToken(t *testin
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
-	runner := NewAgentRunner(config, store, configDB, configDB, nil)
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: configDB,
+		Agents:   configDB,
+		Runtimes: nil,
+	})
 	if err := runner.PrepareSandboxAgentEnvironment(ctx, session, execution.AgentConfig{Provider: "codex", Model: "gpt-test"}, nil); err != nil {
 		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
 	}
@@ -515,7 +533,13 @@ func TestSandboxDriverPostStartPersistenceFailureKeepsPreparedAgentToken(t *test
 	if err != nil {
 		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
-	runner := NewAgentRunner(config, store, configDB, configDB, nil)
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: configDB,
+		Agents:   configDB,
+		Runtimes: nil,
+	})
 	if err := runner.PrepareSandboxAgentEnvironment(ctx, session, execution.AgentConfig{Provider: "codex", Model: "gpt-test"}, nil); err != nil {
 		t.Fatalf("PrepareSandboxAgentEnvironment returned error: %v", err)
 	}

--- a/pkg/agentcompose/adapters/session_rpc_bridge.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge.go
@@ -45,20 +45,36 @@ type SandboxRPCBridge struct {
 	lifecycleLocks   *sandboxes.LifecycleLocks
 }
 
-func NewSandboxRPCBridge(config *appconfig.Config, store *sandboxstore.Store, configDB *configstore.ConfigStore, workspaceEnsurer workspaces.WorkspaceEnsurer, driver sandboxes.SandboxDriver, runtimes RuntimeProvider, bus *schedulers.Bus, streams *sandboxes.StreamBroker, cap capabilities.Provider, capTokens *CapabilitySandboxResolver, dashboard *dashboard.Hub, agentExecutor *AgentExecutor, locks ...*sandboxes.LifecycleLocks) *SandboxRPCBridge {
+// SandboxRPCBridgeDeps bundles NewSandboxRPCBridge's required dependencies.
+type SandboxRPCBridgeDeps struct {
+	Config           *appconfig.Config
+	Store            *sandboxstore.Store
+	ConfigDB         *configstore.ConfigStore
+	WorkspaceEnsurer workspaces.WorkspaceEnsurer
+	Driver           sandboxes.SandboxDriver
+	Runtimes         RuntimeProvider
+	Bus              *schedulers.Bus
+	Streams          *sandboxes.StreamBroker
+	Cap              capabilities.Provider
+	CapTokens        *CapabilitySandboxResolver
+	Dashboard        *dashboard.Hub
+	AgentExecutor    *AgentExecutor
+}
+
+func NewSandboxRPCBridge(deps SandboxRPCBridgeDeps, locks ...*sandboxes.LifecycleLocks) *SandboxRPCBridge {
 	bridge := &SandboxRPCBridge{
-		config:           config,
-		store:            store,
-		configDB:         configDB,
-		workspaceEnsurer: workspaceEnsurer,
-		driver:           driver,
-		runtimes:         runtimes,
-		bus:              bus,
-		streams:          streams,
-		cap:              cap,
-		capTokens:        capTokens,
-		dashboard:        dashboard,
-		agentExecutor:    agentExecutor,
+		config:           deps.Config,
+		store:            deps.Store,
+		configDB:         deps.ConfigDB,
+		workspaceEnsurer: deps.WorkspaceEnsurer,
+		driver:           deps.Driver,
+		runtimes:         deps.Runtimes,
+		bus:              deps.Bus,
+		streams:          deps.Streams,
+		cap:              deps.Cap,
+		capTokens:        deps.CapTokens,
+		dashboard:        deps.Dashboard,
+		agentExecutor:    deps.AgentExecutor,
 	}
 	if len(locks) > 0 {
 		bridge.lifecycleLocks = locks[0]
@@ -165,16 +181,31 @@ func (b *SandboxRPCBridge) createSandbox(ctx context.Context, req sandboxRPCCrea
 	return b.createSandboxWithAgent(ctx, req, source, schedulers.SandboxCreationContext{})
 }
 
-func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandboxRPCCreateRequest, source string, creation schedulers.SandboxCreationContext) (*domain.Sandbox, error) {
+// resolvedSandboxCreateAgentConfig is the agent config, tags, env items, and
+// workspace/driver/image resolveSandboxCreateAgentConfig derives before
+// createSandboxWithAgent creates the sandbox.
+type resolvedSandboxCreateAgentConfig struct {
+	AgentConfig       execution.AgentConfig
+	AgentDefinition   *domain.AgentDefinition
+	ProviderEnvItems  []domain.SandboxEnvVar
+	EnvItems          []domain.SandboxEnvVar
+	Tags              []domain.SandboxTag
+	WorkspaceSnapshot *domain.SandboxWorkspace
+	WorkspaceID       string
+	Driver            string
+	GuestImage        string
+}
+
+func (b *SandboxRPCBridge) resolveSandboxCreateAgentConfig(ctx context.Context, req sandboxRPCCreateRequest, creation schedulers.SandboxCreationContext) (resolvedSandboxCreateAgentConfig, error) {
 	agentConfig := execution.AgentConfig{Provider: domain.NormalizeAgentKind(creation.Provider)}
 	var agentDefinition *domain.AgentDefinition
 	if agentID := strings.TrimSpace(creation.AgentDefinitionID); agentID != "" {
 		definition, err := b.configDB.GetAgentDefinition(ctx, agentID)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("resolve sandbox agent definition %s: %w", agentID, err))
+			return resolvedSandboxCreateAgentConfig{}, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("resolve sandbox agent definition %s: %w", agentID, err))
 		}
 		if !definition.Enabled {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sandbox agent definition %s is disabled", agentID))
+			return resolvedSandboxCreateAgentConfig{}, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sandbox agent definition %s is disabled", agentID))
 		}
 		agentDefinition = &definition
 		agentConfig = execution.AgentConfigFromDefinition(definition, domain.DefaultAgentProvider)
@@ -187,7 +218,7 @@ func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandb
 	providerEnvItems := append([]domain.SandboxEnvVar(nil), req.EnvItems...)
 	globalEnvItems, err := b.configDB.ListGlobalEnv(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return resolvedSandboxCreateAgentConfig{}, connect.NewError(connect.CodeInternal, err)
 	}
 	if agentDefinition != nil {
 		providerEnvItems = domain.MergeEnvItems(agentDefinition.EnvItems, providerEnvItems)
@@ -208,20 +239,39 @@ func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandb
 	if workspaceID != "" {
 		workspaceConfig, err := b.configDB.GetWorkspaceConfig(ctx, workspaceID)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+			return resolvedSandboxCreateAgentConfig{}, connect.NewError(connect.CodeInvalidArgument, err)
 		}
 		workspaceSnapshot = toSandboxWorkspaceSnapshot(workspaceConfig)
 	}
 
 	driver, err := driverpkg.ResolveSandboxRuntimeDriver(req.Driver, b.config.RuntimeDriver)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return resolvedSandboxCreateAgentConfig{}, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if err := driverpkg.ValidateCompiledRuntimeDriver(driver); err != nil {
-		return nil, api.ConnectErrorForDomain(classifyRuntimeProviderError(err))
+		return resolvedSandboxCreateAgentConfig{}, api.ConnectErrorForDomain(classifyRuntimeProviderError(err))
 	}
 	guestImage := driverpkg.ResolveSandboxGuestImage(req.GuestImage, driverpkg.DefaultGuestImageForDriver(b.config, driver))
-	session, err := b.store.CreateSandboxWithOptions(ctx, req.Title, req.BaseWorkspace, driver, guestImage, workspaceID, source, workspaceSnapshot, envItems, tags, sandboxstore.CreateSandboxOptions{
+	return resolvedSandboxCreateAgentConfig{
+		AgentConfig:       agentConfig,
+		AgentDefinition:   agentDefinition,
+		ProviderEnvItems:  providerEnvItems,
+		EnvItems:          envItems,
+		Tags:              tags,
+		WorkspaceSnapshot: workspaceSnapshot,
+		WorkspaceID:       workspaceID,
+		Driver:            driver,
+		GuestImage:        guestImage,
+	}, nil
+}
+
+func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandboxRPCCreateRequest, source string, creation schedulers.SandboxCreationContext) (*domain.Sandbox, error) {
+	cfg, err := b.resolveSandboxCreateAgentConfig(ctx, req, creation)
+	if err != nil {
+		return nil, err
+	}
+	agentConfig, agentDefinition, providerEnvItems := cfg.AgentConfig, cfg.AgentDefinition, cfg.ProviderEnvItems
+	session, err := b.store.CreateSandboxWithOptions(ctx, req.Title, req.BaseWorkspace, cfg.Driver, cfg.GuestImage, cfg.WorkspaceID, source, cfg.WorkspaceSnapshot, cfg.EnvItems, cfg.Tags, sandboxstore.CreateSandboxOptions{
 		StoppedRuntimePolicy: stoppedRuntimePolicyFromAgentDefinition(agentDefinition),
 	})
 	if err != nil {
@@ -233,7 +283,7 @@ func (b *SandboxRPCBridge) createSandboxWithAgent(ctx context.Context, req sandb
 		_ = b.store.UpdateSandbox(ctx, session)
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	writeCapabilityGuide(ctx, b.cap, b.store, b.streams, session, req.CapsetIDs)
+	writeCapabilityGuide(ctx, writeCapabilityGuideRequest{Provider: b.cap, Store: b.store, Streams: b.streams, Session: session, CapsetIDs: req.CapsetIDs})
 	if b.agentExecutor == nil {
 		session.Summary.VMStatus = domain.VMStatusFailed
 		_ = b.store.UpdateSandbox(ctx, session)
@@ -429,7 +479,7 @@ func (b *SandboxRPCBridge) sessionLifecycle() sandboxes.Lifecycle {
 			dashboard: b.dashboard,
 		},
 		GuideWriter: func(ctx context.Context, session *domain.Sandbox, capsetIDs []string) {
-			writeCapabilityGuide(ctx, b.cap, b.store, b.streams, session, capsetIDs)
+			writeCapabilityGuide(ctx, writeCapabilityGuideRequest{Provider: b.cap, Store: b.store, Streams: b.streams, Session: session, CapsetIDs: capsetIDs})
 		},
 		PrepareAgentEnvironment: b.agentExecutor.PrepareSandboxAgentEnvironmentFromTags,
 		Locks:                   b.lifecycleLocks,
@@ -484,8 +534,20 @@ func (n sandboxLifecycleNotifier) NotifyDashboard(reason string) {
 	}
 }
 
-func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, store *sandboxstore.Store, streams *sandboxes.StreamBroker, session *domain.Sandbox, capsetIDs []string) {
-	ids := capabilities.NormalizeCapsetIDs(capsetIDs)
+// writeCapabilityGuideRequest bundles the provider, sandbox, capsets, and
+// warning-logging dependencies writeCapabilityGuide needs.
+type writeCapabilityGuideRequest struct {
+	Provider  capabilities.Provider
+	Store     *sandboxstore.Store
+	Streams   *sandboxes.StreamBroker
+	Session   *domain.Sandbox
+	CapsetIDs []string
+}
+
+func writeCapabilityGuide(ctx context.Context, req writeCapabilityGuideRequest) {
+	provider, session := req.Provider, req.Session
+	warnDeps := capabilityGuideWarningRequest{Store: req.Store, Streams: req.Streams}
+	ids := capabilities.NormalizeCapsetIDs(req.CapsetIDs)
 	if len(ids) == 0 || provider == nil || session == nil {
 		return
 	}
@@ -499,7 +561,8 @@ func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, s
 		guide, err := capabilities.CapabilityGuideForScope(ctx, provider, capabilities.GuideScopeFromSandbox(session), id)
 		if err != nil {
 			slog.Warn("capability guide render skipped", "capset", id, "sandbox_id", session.Summary.ID, "error", err)
-			recordCapabilityGuideWarning(ctx, store, streams, session.Summary.ID, fmt.Sprintf("capability guide render skipped for capset %s", id))
+			warnDeps.SessionID, warnDeps.Message = session.Summary.ID, fmt.Sprintf("capability guide render skipped for capset %s", id)
+			recordCapabilityGuideWarning(ctx, warnDeps)
 			continue
 		}
 		if rendered {
@@ -517,32 +580,44 @@ func writeCapabilityGuide(ctx context.Context, provider capabilities.Provider, s
 	}
 	if err := os.MkdirAll(filepath.Dir(catalogPath), 0o755); err != nil {
 		slog.Warn("capability guide dir create failed", "sandbox_id", session.Summary.ID, "error", err)
-		recordCapabilityGuideWarning(ctx, store, streams, session.Summary.ID, "capability guide directory create failed")
+		warnDeps.SessionID, warnDeps.Message = session.Summary.ID, "capability guide directory create failed"
+		recordCapabilityGuideWarning(ctx, warnDeps)
 		return
 	}
 	if err := os.WriteFile(catalogPath, []byte(content), 0o644); err != nil {
 		slog.Warn("capability guide write failed", "sandbox_id", session.Summary.ID, "error", err)
-		recordCapabilityGuideWarning(ctx, store, streams, session.Summary.ID, "capability guide write failed")
+		warnDeps.SessionID, warnDeps.Message = session.Summary.ID, "capability guide write failed"
+		recordCapabilityGuideWarning(ctx, warnDeps)
 	}
 }
 
-func recordCapabilityGuideWarning(ctx context.Context, store *sandboxstore.Store, streams *sandboxes.StreamBroker, sessionID, message string) {
-	if store == nil || strings.TrimSpace(sessionID) == "" {
+// capabilityGuideWarningRequest bundles the store/streams dependencies and
+// event details recordCapabilityGuideWarning needs to record a capability
+// guide failure as a sandbox event.
+type capabilityGuideWarningRequest struct {
+	Store     *sandboxstore.Store
+	Streams   *sandboxes.StreamBroker
+	SessionID string
+	Message   string
+}
+
+func recordCapabilityGuideWarning(ctx context.Context, req capabilityGuideWarningRequest) {
+	if req.Store == nil || strings.TrimSpace(req.SessionID) == "" {
 		return
 	}
 	event := domain.SandboxEvent{
 		ID:        uuid.NewString(),
 		Type:      "capability.guide.warning",
 		Level:     "warning",
-		Message:   message,
+		Message:   req.Message,
 		CreatedAt: time.Now().UTC(),
 	}
-	if err := store.AddEvent(ctx, sessionID, event); err != nil {
-		slog.Warn("capability guide warning event failed", "sandbox_id", sessionID, "error", err)
+	if err := req.Store.AddEvent(ctx, req.SessionID, event); err != nil {
+		slog.Warn("capability guide warning event failed", "sandbox_id", req.SessionID, "error", err)
 		return
 	}
-	if streams != nil {
-		streams.PublishEventAdded(sessionID, event)
+	if req.Streams != nil {
+		req.Streams.PublishEventAdded(req.SessionID, event)
 	}
 }
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_test.go
@@ -559,7 +559,7 @@ func TestSandboxRPCBridgeCapabilityGuideRoutesManagedScopeAndMergesBestEffort(t 
 			{Name: domain.AgentSandboxTagID, Value: "agent-1"},
 		},
 	}}
-	writeCapabilityGuide(ctx, bridge.cap, nil, nil, sandbox, []string{"legacy", "internal/dev", "broken/fail"})
+	writeCapabilityGuide(ctx, writeCapabilityGuideRequest{Provider: bridge.cap, Session: sandbox, CapsetIDs: []string{"legacy", "internal/dev", "broken/fail"}})
 
 	guide, err := os.ReadFile(capabilities.SandboxGuidePath(sandbox))
 	if err != nil {
@@ -634,21 +634,27 @@ func newTestSandboxRPCBridge(t *testing.T) (*SandboxRPCBridge, *fakeRPCSandboxDr
 	}
 	driver := &fakeRPCSandboxDriver{}
 	streams := sandboxes.NewStreamBrokerForTest()
-	agentExecutor := NewAgentExecutor(config, store, streams, NewAgentRunner(config, store, configDB, configDB, nil))
-	return NewSandboxRPCBridge(
-		config,
-		store,
-		configDB,
-		workspaces.NewProvisioner(config, configDB, store),
-		driver,
-		nil,
-		nil,
-		streams,
-		testCapabilityProvider{},
-		nil,
-		nil,
-		agentExecutor,
-	), driver
+	agentExecutor := NewAgentExecutor(config, store, streams, NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: configDB,
+		Agents:   configDB,
+		Runtimes: nil,
+	}))
+	return NewSandboxRPCBridge(SandboxRPCBridgeDeps{
+		Config:           config,
+		Store:            store,
+		ConfigDB:         configDB,
+		WorkspaceEnsurer: workspaces.NewProvisioner(config, configDB, store),
+		Driver:           driver,
+		Runtimes:         nil,
+		Bus:              nil,
+		Streams:          streams,
+		Cap:              testCapabilityProvider{},
+		CapTokens:        nil,
+		Dashboard:        nil,
+		AgentExecutor:    agentExecutor,
+	}), driver
 }
 
 func TestSandboxRPCBridgeCapabilityGuideFromHTTPProvider(t *testing.T) {

--- a/pkg/agentcompose/adapters/workspace_ensurer_injection_test.go
+++ b/pkg/agentcompose/adapters/workspace_ensurer_injection_test.go
@@ -20,8 +20,33 @@ func TestWorkspaceEnsurerConstructorDependencies(t *testing.T) {
 	t.Parallel()
 
 	ensurer := &constructorWorkspaceEnsurer{}
-	bridge := NewSandboxRPCBridge(nil, nil, nil, ensurer, nil, nil, nil, nil, nil, nil, nil, nil)
-	runner := NewSchedulerSandboxRunner(nil, nil, nil, ensurer, nil, nil, nil, nil, nil, nil, nil)
+	bridge := NewSandboxRPCBridge(SandboxRPCBridgeDeps{
+		Config:           nil,
+		Store:            nil,
+		ConfigDB:         nil,
+		WorkspaceEnsurer: ensurer,
+		Driver:           nil,
+		Runtimes:         nil,
+		Bus:              nil,
+		Streams:          nil,
+		Cap:              nil,
+		CapTokens:        nil,
+		Dashboard:        nil,
+		AgentExecutor:    nil,
+	})
+	runner := NewSchedulerSandboxRunner(SchedulerSandboxRunnerDeps{
+		Config:           nil,
+		Store:            nil,
+		ConfigDB:         nil,
+		WorkspaceEnsurer: ensurer,
+		Driver:           nil,
+		Cap:              nil,
+		VolumeResolver:   nil,
+		Streams:          nil,
+		Publisher:        nil,
+		CapTokens:        nil,
+		AgentExecutor:    nil,
+	})
 
 	if bridge.workspaceEnsurer != ensurer {
 		t.Fatalf("SandboxRPCBridge workspace ensurer = %p, want %p", bridge.workspaceEnsurer, ensurer)

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -432,7 +432,7 @@ func NewAgentExecutor(di do.Injector) (*adapters.AgentExecutor, error) {
 }
 
 func NewSchedulerCommandExecutor(di do.Injector) (*adapters.SchedulerCommandExecutor, error) {
-	return adapters.NewSchedulerCommandExecutor(adapters.SchedulerCommandExecutor{
+	return adapters.NewSchedulerCommandExecutor(adapters.SchedulerCommandExecutorDeps{
 		Config:   do.MustInvoke[*appconfig.Config](di),
 		Store:    do.MustInvoke[*sandboxstore.Store](di),
 		ConfigDB: do.MustInvoke[*configstore.ConfigStore](di),

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -413,13 +413,13 @@ func NewCellExecutor(di do.Injector) (*adapters.CellExecutor, error) {
 }
 
 func NewAgentRunner(di do.Injector) (*adapters.AgentRunner, error) {
-	return adapters.NewAgentRunner(
-		do.MustInvoke[*appconfig.Config](di),
-		do.MustInvoke[*sandboxstore.Store](di),
-		do.MustInvoke[*configstore.ConfigStore](di),
-		do.MustInvoke[*configstore.ConfigStore](di),
-		do.MustInvoke[adapters.RuntimeProvider](di),
-	), nil
+	return adapters.NewAgentRunner(adapters.AgentRunnerDeps{
+		Config:   do.MustInvoke[*appconfig.Config](di),
+		Store:    do.MustInvoke[*sandboxstore.Store](di),
+		ConfigDB: do.MustInvoke[*configstore.ConfigStore](di),
+		Agents:   do.MustInvoke[*configstore.ConfigStore](di),
+		Runtimes: do.MustInvoke[adapters.RuntimeProvider](di),
+	}), nil
 }
 
 func NewAgentExecutor(di do.Injector) (*adapters.AgentExecutor, error) {
@@ -432,49 +432,47 @@ func NewAgentExecutor(di do.Injector) (*adapters.AgentExecutor, error) {
 }
 
 func NewSchedulerCommandExecutor(di do.Injector) (*adapters.SchedulerCommandExecutor, error) {
-	return adapters.NewSchedulerCommandExecutor(
-		do.MustInvoke[*appconfig.Config](di),
-		do.MustInvoke[*sandboxstore.Store](di),
-		do.MustInvoke[*configstore.ConfigStore](di),
-		do.MustInvoke[adapters.RuntimeProvider](di),
-		do.MustInvoke[*sandboxes.StreamBroker](di),
-	), nil
+	return adapters.NewSchedulerCommandExecutor(adapters.SchedulerCommandExecutor{
+		Config:   do.MustInvoke[*appconfig.Config](di),
+		Store:    do.MustInvoke[*sandboxstore.Store](di),
+		ConfigDB: do.MustInvoke[*configstore.ConfigStore](di),
+		Runtimes: do.MustInvoke[adapters.RuntimeProvider](di),
+		Streams:  do.MustInvoke[*sandboxes.StreamBroker](di),
+	}), nil
 }
 
 func NewSchedulerSandboxRunner(di do.Injector) (*adapters.SchedulerSandboxRunner, error) {
-	return adapters.NewSchedulerSandboxRunner(
-		do.MustInvoke[*appconfig.Config](di),
-		do.MustInvoke[*sandboxstore.Store](di),
-		do.MustInvoke[*configstore.ConfigStore](di),
-		do.MustInvoke[workspaces.WorkspaceEnsurer](di),
-		do.MustInvoke[*adapters.SandboxDriver](di),
-		do.MustInvoke[capabilities.Provider](di),
-		do.MustInvoke[*volumes.Manager](di),
-		do.MustInvoke[*sandboxes.StreamBroker](di),
-		do.MustInvoke[*schedulers.Bus](di),
-		do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
-		do.MustInvoke[*adapters.AgentExecutor](di),
-		do.MustInvoke[*sandboxes.LifecycleLocks](di),
-	), nil
+	return adapters.NewSchedulerSandboxRunner(adapters.SchedulerSandboxRunnerDeps{
+		Config:           do.MustInvoke[*appconfig.Config](di),
+		Store:            do.MustInvoke[*sandboxstore.Store](di),
+		ConfigDB:         do.MustInvoke[*configstore.ConfigStore](di),
+		WorkspaceEnsurer: do.MustInvoke[workspaces.WorkspaceEnsurer](di),
+		Driver:           do.MustInvoke[*adapters.SandboxDriver](di),
+		Cap:              do.MustInvoke[capabilities.Provider](di),
+		VolumeResolver:   do.MustInvoke[*volumes.Manager](di),
+		Streams:          do.MustInvoke[*sandboxes.StreamBroker](di),
+		Publisher:        do.MustInvoke[*schedulers.Bus](di),
+		CapTokens:        do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
+		AgentExecutor:    do.MustInvoke[*adapters.AgentExecutor](di),
+	}, do.MustInvoke[*sandboxes.LifecycleLocks](di)), nil
 }
 
 func NewSandboxRPCBridge(di do.Injector) (*adapters.SandboxRPCBridge, error) {
 	dashboard, _ := do.Invoke[*dashboard.Hub](di)
-	return adapters.NewSandboxRPCBridge(
-		do.MustInvoke[*appconfig.Config](di),
-		do.MustInvoke[*sandboxstore.Store](di),
-		do.MustInvoke[*configstore.ConfigStore](di),
-		do.MustInvoke[workspaces.WorkspaceEnsurer](di),
-		do.MustInvoke[*adapters.SandboxDriver](di),
-		do.MustInvoke[adapters.RuntimeProvider](di),
-		do.MustInvoke[*schedulers.Bus](di),
-		do.MustInvoke[*sandboxes.StreamBroker](di),
-		do.MustInvoke[capabilities.Provider](di),
-		do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
-		dashboard,
-		do.MustInvoke[*adapters.AgentExecutor](di),
-		do.MustInvoke[*sandboxes.LifecycleLocks](di),
-	), nil
+	return adapters.NewSandboxRPCBridge(adapters.SandboxRPCBridgeDeps{
+		Config:           do.MustInvoke[*appconfig.Config](di),
+		Store:            do.MustInvoke[*sandboxstore.Store](di),
+		ConfigDB:         do.MustInvoke[*configstore.ConfigStore](di),
+		WorkspaceEnsurer: do.MustInvoke[workspaces.WorkspaceEnsurer](di),
+		Driver:           do.MustInvoke[*adapters.SandboxDriver](di),
+		Runtimes:         do.MustInvoke[adapters.RuntimeProvider](di),
+		Bus:              do.MustInvoke[*schedulers.Bus](di),
+		Streams:          do.MustInvoke[*sandboxes.StreamBroker](di),
+		Cap:              do.MustInvoke[capabilities.Provider](di),
+		CapTokens:        do.MustInvoke[*adapters.CapabilitySandboxResolver](di),
+		Dashboard:        dashboard,
+		AgentExecutor:    do.MustInvoke[*adapters.AgentExecutor](di),
+	}, do.MustInvoke[*sandboxes.LifecycleLocks](di)), nil
 }
 
 func NewDatabase(di do.Injector) (*storagesqlite.Database, error) {


### PR DESCRIPTION
## Summary
- Last of the `pkg/agentcompose` subpackage PRs (`proxy` #613, `app` #614, `api` #615, `adapters` here) for the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`; that lands as a separate final PR once the whole sweep is done). This was the largest and most violation-dense subpackage (22 files, started at 22 funlen + 50 revive issues).

### Argument-limit fixes
- `writeCapabilityGuide`/`recordCapabilityGuideWarning` (private, distinct from the already-fixed `pkg/runs` functions of the same name — a same-name-different-package collision, same pitfall documented for this sweep): bundled into `writeCapabilityGuideRequest`/`capabilityGuideWarningRequest`.
- `bindSchedulerSandbox` (private, 1 call site): now takes the desired `domain.SchedulerBinding` directly instead of the 4 fields it built one from — a "reuse existing struct" case, no new type needed.
- `schedulerRequestSandboxConfigHash` (private, 9 args): bundled into `schedulerRequestSandboxConfigHashRequest`.
- `ExecuteCellStream` (5 args): bundled into `CellExecutionRequest`.
- `NewAgentRunner`, `ExecuteAgentRun`, `BuildAgentExecSpec`, `GenerateWithEnv`, `NewSchedulerCommandExecutor` (reuses the `SchedulerCommandExecutor` struct directly — all its fields are already exported), `NewSchedulerSandboxRunner`, `NewSandboxRPCBridge` (13 args, the largest in this sweep): bundled into `*Deps`/`*Request` structs, keeping each constructor's existing variadic optional trailing param as-is.
- `SchedulerHostEvents.Add`/`AddRecord` and `driverRuntimeAdapter.ExecStream` left deferred — interface-constrained by `schedulers.HostEventRecorder` and `driverpkg.Runtime` respectively (verified against the interface definitions).

### Funlen fixes
- `Ensure` (185 lines) split into `resolveSchedulerSandboxConfig` (resolve agent definition/policy/env/workspace/driver/volumes/config hash) and `createSchedulerSandbox` (build tags, create the sandbox, persist provider env/pull policy) — two genuinely distinct phases.
- `executeCell` (130 lines after the argument-limit bundling pushed it over) split out `prepareCellExecution` (resolve VM state/runtime, create the cell dir, write the script, publish the started cell).
- `createSandboxWithAgent` (108 lines) split out `resolveSandboxCreateAgentConfig` (resolve agent config/tags/env items/workspace/driver/guest image).
- `ExecuteAgentRequest` and `ExecuteSchedulerCommand` left deferred — both have closures capturing heavily shared mutable state (`cellMu`, `streamErr`, deferred cleanup tied to a later-mutated flag), the same class of orchestrator as `applyProject`/`CreateSandbox` left deferred in earlier PRs in this sweep.

### Dead code
- Full audit of the subpackage's top-level exported surface found nothing clearly dead — every low-ref-count symbol is either a real single caller or a well-known interface method dispatched reflectively (e.g. `GRPCStatus`, called by the gRPC/connect error-status machinery, not directly).
- Worth flagging separately (not touched here, out of scope for this sweep): `CellExecutor` is registered via `do.Provide` but never `do.MustInvoke`'d anywhere in the codebase — `ExecuteCell`/`ExecuteCellStream` appear to be a fully unused feature. This is a much larger surface (a whole registered component + its dedicated test file) than the single-function dead code removed elsewhere this sweep, so I left the judgment call to a human rather than deleting it unilaterally.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/agentcompose/...`
- [x] `go test ./pkg/agentcompose/...` (all 4 subpackages)
- [x] `golangci-lint run ./pkg/agentcompose/adapters/...` — 29 remaining issues, all deferred as described above (down from 72 across the whole `pkg/agentcompose` package at the start of this 4-PR series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)