### PR TITLE
refactor(cache): bundle PruneItems/RemoveItem params into ItemRemovalContext

### DIFF
--- a/pkg/cache/controller.go
+++ b/pkg/cache/controller.go
@@ -51,7 +51,7 @@ func (c *Controller) PruneCaches(ctx context.Context, req PruneRequest) (Result,
 	if err != nil {
 		return Result{}, err
 	}
-	result, err := PruneItems(ctx, items, req, c.now(), sourceRemoveFunc(sources))
+	result, err := PruneItems(ctx, ItemRemovalContext{Items: items, Now: c.now(), Remove: sourceRemoveFunc(sources)}, req)
 	if err != nil {
 		return result, err
 	}
@@ -69,7 +69,7 @@ func (c *Controller) RemoveCache(ctx context.Context, req RemoveRequest) (Result
 		return Result{Warnings: warnings}, err
 	}
 	req.CacheID = resolved
-	result, err := RemoveItem(ctx, items, req, c.now(), sourceRemoveFunc(sources))
+	result, err := RemoveItem(ctx, ItemRemovalContext{Items: items, Now: c.now(), Remove: sourceRemoveFunc(sources)}, req)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/cache/materialized_remove_test.go
+++ b/pkg/cache/materialized_remove_test.go
@@ -20,7 +20,7 @@ func TestMaterializedPruneSkipsReferencedByDefault(t *testing.T) {
 	layout := requireItem(t, items, layoutPath)
 	layout.References[0].Policy = ReferencePolicyRequired
 
-	result, err := PruneItems(context.Background(), []Item{layout}, PruneRequest{Force: true}, time.Now(), MaterializedRemover{Cache: cache}.Remove)
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: []Item{layout}, Now: time.Now(), Remove: MaterializedRemover{Cache: cache}.Remove}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestMaterializedPruneAdvisoryReferenceDeletesLayoutAndReadyOnly(t *testing.
 	items := scanMaterializedItems(t, cache)
 	layout := requireItem(t, items, layoutPath)
 
-	result, err := PruneItems(context.Background(), []Item{layout}, PruneRequest{Force: true}, time.Now(), MaterializedRemover{Cache: cache}.Remove)
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: []Item{layout}, Now: time.Now(), Remove: MaterializedRemover{Cache: cache}.Remove}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestMaterializedRemoveRootFSDeletesRootFSReady(t *testing.T) {
 	items := scanMaterializedItems(t, cache)
 	rootfs := requireItem(t, items, rootfsPath)
 
-	result, err := PruneItems(context.Background(), []Item{rootfs}, PruneRequest{Force: true}, time.Now(), MaterializedRemover{Cache: cache}.Remove)
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: []Item{rootfs}, Now: time.Now(), Remove: MaterializedRemover{Cache: cache}.Remove}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestMaterializedRemoveTempDirDoesNotDeleteSiblings(t *testing.T) {
 	items := scanMaterializedItems(t, cache)
 	tmp := requireItem(t, items, tmpPath)
 
-	result, err := PruneItems(context.Background(), []Item{tmp}, PruneRequest{Force: true}, time.Now(), MaterializedRemover{Cache: cache}.Remove)
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: []Item{tmp}, Now: time.Now(), Remove: MaterializedRemover{Cache: cache}.Remove}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestMaterializedRemoveOrphanedAndExpiredItems(t *testing.T) {
 		t.Fatalf("mkdir orphan: %v", err)
 	}
 	orphan := requireItem(t, scanMaterializedItems(t, cache), orphanPath)
-	result, err := PruneItems(context.Background(), []Item{orphan}, PruneRequest{Force: true}, time.Now(), MaterializedRemover{Cache: cache}.Remove)
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: []Item{orphan}, Now: time.Now(), Remove: MaterializedRemover{Cache: cache}.Remove}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems orphan returned error: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestMaterializedRemoveOrphanedAndExpiredItems(t *testing.T) {
 	}
 	expired := requireItem(t, scanMaterializedItems(t, cache), expiredPath)
 	expired.Status = StatusExpired
-	result, err = PruneItems(context.Background(), []Item{expired}, PruneRequest{Force: true}, time.Now(), MaterializedRemover{Cache: cache}.Remove)
+	result, err = PruneItems(context.Background(), ItemRemovalContext{Items: []Item{expired}, Now: time.Now(), Remove: MaterializedRemover{Cache: cache}.Remove}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems expired returned error: %v", err)
 	}

--- a/pkg/cache/prune.go
+++ b/pkg/cache/prune.go
@@ -69,8 +69,17 @@ func HasRequiredReferences(refs []Reference) bool {
 	return false
 }
 
-func PruneItems(ctx context.Context, items []Item, req PruneRequest, now time.Time, remove RemoveFunc) (Result, error) {
-	matched, err := FilterItems(items, req.Filter, now)
+// ItemRemovalContext bundles the item list, current time, and removal
+// callback PruneItems and RemoveItem need, as opposed to req, which
+// describes what to filter/remove.
+type ItemRemovalContext struct {
+	Items  []Item
+	Now    time.Time
+	Remove RemoveFunc
+}
+
+func PruneItems(ctx context.Context, removal ItemRemovalContext, req PruneRequest) (Result, error) {
+	matched, err := FilterItems(removal.Items, req.Filter, removal.Now)
 	if err != nil {
 		return Result{}, err
 	}
@@ -85,10 +94,10 @@ func PruneItems(ctx context.Context, items []Item, req PruneRequest, now time.Ti
 		if result.DryRun {
 			continue
 		}
-		if remove == nil {
+		if removal.Remove == nil {
 			return result, ErrRemoveUnavailable
 		}
-		if err := remove(ctx, item); err != nil {
+		if err := removal.Remove(ctx, item); err != nil {
 			item.Removable = false
 			item.BlockedReasons = AppendWarnings(item.BlockedReasons, "remove failed")
 			result.Skipped = append(result.Skipped, item)
@@ -100,20 +109,20 @@ func PruneItems(ctx context.Context, items []Item, req PruneRequest, now time.Ti
 	return result, nil
 }
 
-func RemoveItem(ctx context.Context, items []Item, req RemoveRequest, now time.Time, remove RemoveFunc) (Result, error) {
-	cacheID, err := ResolveCacheID(items, req.CacheID)
+func RemoveItem(ctx context.Context, removal ItemRemovalContext, req RemoveRequest) (Result, error) {
+	cacheID, err := ResolveCacheID(removal.Items, req.CacheID)
 	if err != nil {
 		return Result{}, err
 	}
 	if _, err := ParseCacheID(cacheID); err != nil {
 		return Result{}, err
 	}
-	result, err := PruneItems(ctx, items, PruneRequest{
+	result, err := PruneItems(ctx, removal, PruneRequest{
 		Filter: Filter{
 			CacheID: cacheID,
 		},
 		Force: req.Force,
-	}, now, remove)
+	})
 	if err != nil {
 		return result, err
 	}

--- a/pkg/cache/prune_test.go
+++ b/pkg/cache/prune_test.go
@@ -50,10 +50,10 @@ func TestPruneItemsDryRunDoesNotRemove(t *testing.T) {
 		mustCacheItem(t, "referenced", StatusReferenced),
 	}
 	calls := 0
-	result, err := PruneItems(context.Background(), items, PruneRequest{}, time.Now(), func(context.Context, Item) error {
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: items, Now: time.Now(), Remove: func(context.Context, Item) error {
 		calls++
 		return nil
-	})
+	}}, PruneRequest{})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -80,10 +80,10 @@ func TestPruneItemsForceKeepsRequiredReferences(t *testing.T) {
 		mustCacheItem(t, "active", StatusActive),
 	}
 	var removed []string
-	result, err := PruneItems(context.Background(), items, PruneRequest{Force: true}, time.Now(), func(_ context.Context, item Item) error {
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: items, Now: time.Now(), Remove: func(_ context.Context, item Item) error {
 		removed = append(removed, item.CacheID)
 		return nil
-	})
+	}}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -98,10 +98,10 @@ func TestPruneItemsForceKeepsRequiredReferences(t *testing.T) {
 
 func TestPruneItemsRequiredReferenceCannotBeForced(t *testing.T) {
 	item := mustCacheItem(t, "referenced", StatusReferenced)
-	result, err := PruneItems(context.Background(), []Item{item}, PruneRequest{Force: true}, time.Now(), func(context.Context, Item) error {
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: []Item{item}, Now: time.Now(), Remove: func(context.Context, Item) error {
 		t.Fatal("remover should not be called")
 		return nil
-	})
+	}}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -113,12 +113,12 @@ func TestPruneItemsRequiredReferenceCannotBeForced(t *testing.T) {
 func TestPruneItemsContinuesAfterRemoveError(t *testing.T) {
 	first := mustCacheItem(t, "first", StatusUnused)
 	second := mustCacheItem(t, "second", StatusUnused)
-	result, err := PruneItems(context.Background(), []Item{first, second}, PruneRequest{Force: true}, time.Now(), func(_ context.Context, item Item) error {
+	result, err := PruneItems(context.Background(), ItemRemovalContext{Items: []Item{first, second}, Now: time.Now(), Remove: func(_ context.Context, item Item) error {
 		if item.CacheID == first.CacheID {
 			return errors.New("disk busy")
 		}
 		return nil
-	})
+	}}, PruneRequest{Force: true})
 	if err != nil {
 		t.Fatalf("PruneItems returned error: %v", err)
 	}
@@ -136,10 +136,10 @@ func TestPruneItemsContinuesAfterRemoveError(t *testing.T) {
 func TestRemoveItem(t *testing.T) {
 	item := mustCacheItem(t, "unused", StatusUnused)
 	calls := 0
-	result, err := RemoveItem(context.Background(), []Item{item}, RemoveRequest{CacheID: item.CacheID}, time.Now(), func(context.Context, Item) error {
+	result, err := RemoveItem(context.Background(), ItemRemovalContext{Items: []Item{item}, Now: time.Now(), Remove: func(context.Context, Item) error {
 		calls++
 		return nil
-	})
+	}}, RemoveRequest{CacheID: item.CacheID})
 	if err != nil {
 		t.Fatalf("RemoveItem dry-run returned error: %v", err)
 	}
@@ -147,10 +147,10 @@ func TestRemoveItem(t *testing.T) {
 		t.Fatalf("dry-run result = %#v calls=%d", result, calls)
 	}
 
-	result, err = RemoveItem(context.Background(), []Item{item}, RemoveRequest{CacheID: item.CacheID, Force: true}, time.Now(), func(context.Context, Item) error {
+	result, err = RemoveItem(context.Background(), ItemRemovalContext{Items: []Item{item}, Now: time.Now(), Remove: func(context.Context, Item) error {
 		calls++
 		return nil
-	})
+	}}, RemoveRequest{CacheID: item.CacheID, Force: true})
 	if err != nil {
 		t.Fatalf("RemoveItem force returned error: %v", err)
 	}
@@ -160,21 +160,21 @@ func TestRemoveItem(t *testing.T) {
 }
 
 func TestRemoveItemInvalidNotFoundAndProtected(t *testing.T) {
-	if _, err := RemoveItem(context.Background(), nil, RemoveRequest{CacheID: "../bad"}, time.Now(), nil); !errors.Is(err, ErrInvalidCacheID) {
+	if _, err := RemoveItem(context.Background(), ItemRemovalContext{Items: nil, Now: time.Now(), Remove: nil}, RemoveRequest{CacheID: "../bad"}); !errors.Is(err, ErrInvalidCacheID) {
 		t.Fatalf("invalid id error = %v, want ErrInvalidCacheID", err)
 	}
 
 	item := mustCacheItem(t, "unused", StatusUnused)
 	missing := mustCacheItem(t, "missing", StatusUnused)
-	if _, err := RemoveItem(context.Background(), []Item{item}, RemoveRequest{CacheID: missing.CacheID}, time.Now(), nil); !errors.Is(err, ErrCacheNotFound) {
+	if _, err := RemoveItem(context.Background(), ItemRemovalContext{Items: []Item{item}, Now: time.Now(), Remove: nil}, RemoveRequest{CacheID: missing.CacheID}); !errors.Is(err, ErrCacheNotFound) {
 		t.Fatalf("missing error = %v, want ErrCacheNotFound", err)
 	}
 
 	active := mustCacheItem(t, "active", StatusActive)
-	result, err := RemoveItem(context.Background(), []Item{active}, RemoveRequest{CacheID: active.CacheID, Force: true}, time.Now(), func(context.Context, Item) error {
+	result, err := RemoveItem(context.Background(), ItemRemovalContext{Items: []Item{active}, Now: time.Now(), Remove: func(context.Context, Item) error {
 		t.Fatal("remover should not be called for active item")
 		return nil
-	})
+	}}, RemoveRequest{CacheID: active.CacheID, Force: true})
 	if err != nil {
 		t.Fatalf("active RemoveItem returned error: %v", err)
 	}

--- a/pkg/driver/boxlite_cache_gc.go
+++ b/pkg/driver/boxlite_cache_gc.go
@@ -99,7 +99,7 @@ func pruneBoxliteRuntimeDerivedCaches(ctx context.Context, boxliteHome string, r
 	if err != nil {
 		return cache.Result{}, err
 	}
-	result, err := cache.PruneItems(ctx, list.Items, req, time.Now().UTC(), boxliteRuntimeDerivedRemover{boxliteHome: boxliteHome}.Remove)
+	result, err := cache.PruneItems(ctx, cache.ItemRemovalContext{Items: list.Items, Now: time.Now().UTC(), Remove: boxliteRuntimeDerivedRemover{boxliteHome: boxliteHome}.Remove}, req)
 	if err != nil {
 		return result, err
 	}
@@ -112,7 +112,7 @@ func removeBoxliteRuntimeDerivedCache(ctx context.Context, boxliteHome string, r
 	if err != nil {
 		return cache.Result{}, err
 	}
-	result, err := cache.RemoveItem(ctx, list.Items, req, time.Now().UTC(), boxliteRuntimeDerivedRemover{boxliteHome: boxliteHome}.Remove)
+	result, err := cache.RemoveItem(ctx, cache.ItemRemovalContext{Items: list.Items, Now: time.Now().UTC(), Remove: boxliteRuntimeDerivedRemover{boxliteHome: boxliteHome}.Remove}, req)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
## Summary
- Part of the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`). This package was found while auditing leftover uncommitted work from earlier in the sweep — an earlier, unfinished pass had already identified these violations and marked them with `//nolint` comments (with inflated call-site counts) but never actually fixed them.
- `PruneItems`/`RemoveItem` (5 args each): both share the same items/now/remove trio, bundled into `ItemRemovalContext`.
- Verified real call-site counts via `git grep` against `origin/main`: 3 for `PruneItems`, 2 for `RemoveItem`, across 2 packages (`pkg/cache`, `pkg/driver`) — not the "13"/"7" the stale nolint comments claimed (same bare-name-grep inflation pattern documented elsewhere in this sweep).
- `mustPolicyItem` (test helper, 5 args incl. trailing variadic) left deferred — self-describing positional test constructor, same pattern as other test helpers left deferred throughout this sweep.
- Note: `pkg/driver/boxlite_cache_gc.go` is gated by a `linux && cgo && boxlitecgo` build tag and could not be compiled/vetted on the (Darwin) machine this was developed on. The edit is a minimal, low-risk mechanical repackaging of the same values into a struct literal, reviewed by hand; CI will be the first real compile of this file.

## Test plan
- [x] `go build ./...` (isolated `git worktree` at this branch's tip against current `main`, generated `proto/` packages copied in since they're gitignored)
- [x] `go vet ./pkg/cache/...`
- [x] `go test ./pkg/cache/...`
- [x] `golangci-lint run ./pkg/cache/...` — 1 remaining issue, the deferred test helper
- [ ] `pkg/driver/boxlite_cache_gc.go` (Linux+cgo-only) — not locally verifiable, relying on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)