### PR TITLE
refactor(execution): reuse RuntimeCommandRequest struct in RuntimeCommandRequestPayloadFromCommand

### DIFF
--- a/pkg/agentcompose/api/exec_execution.go
+++ b/pkg/agentcompose/api/exec_execution.go
@@ -55,18 +55,15 @@ func (h *ExecHandler) prepareExecCommand(sandbox *domain.Sandbox, req *agentcomp
 		return execPreparation{}, connect.NewError(connect.CodeInternal, fmt.Errorf("create exec artifact dir: %w", err))
 	}
 	guestExecDir := filepath.Join(h.config.GuestStateRoot, "exec", execID)
-	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(
-		h.config,
-		"exec",
-		strings.TrimSpace(req.GetCommand().GetCommand()),
-		req.GetCommand().GetArgs(),
-		"",
-		cwd,
-		ExecEnvMap(req.GetEnv()),
-		int64(req.GetTimeoutMs()),
-		int64(req.GetMaxOutputBytes()),
-		guestExecDir,
-	)
+	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(h.config, execution.RuntimeCommandSpec{
+		Mode:           "exec",
+		Command:        strings.TrimSpace(req.GetCommand().GetCommand()),
+		Args:           req.GetCommand().GetArgs(),
+		Cwd:            cwd,
+		Env:            ExecEnvMap(req.GetEnv()),
+		TimeoutMs:      int64(req.GetTimeoutMs()),
+		MaxOutputBytes: int64(req.GetMaxOutputBytes()),
+	}, guestExecDir)
 	if err := execution.WriteJSONArtifact(filepath.Join(hostExecDir, "command-request.json"), runtimeRequest); err != nil {
 		return execPreparation{}, connect.NewError(connect.CodeInternal, fmt.Errorf("write exec command request artifact: %w", err))
 	}

--- a/pkg/execution/command_runtime.go
+++ b/pkg/execution/command_runtime.go
@@ -24,8 +24,24 @@ type RuntimeCommandRequest struct {
 	ArtifactDir    string            `json:"artifactDir"`
 }
 
+// RuntimeCommandSpec describes a command to run, independent of where its
+// artifacts land. It intentionally has no ArtifactDir field: that value is
+// always the caller's guest execution/cell state dir and is supplied
+// separately to RuntimeCommandRequestPayloadFromCommand, so it can't be
+// silently dropped if a caller reuses a RuntimeCommandRequest as input.
+type RuntimeCommandSpec struct {
+	Mode           string
+	Command        string
+	Args           []string
+	Script         string
+	Cwd            string
+	Env            map[string]string
+	TimeoutMs      int64
+	MaxOutputBytes int64
+}
+
 func RuntimeCommandRequestPayload(config *appconfig.Config, request domain.SchedulerCommandRequest, guestCellDir string) RuntimeCommandRequest {
-	return RuntimeCommandRequestPayloadFromCommand(config, RuntimeCommandRequest{
+	return RuntimeCommandRequestPayloadFromCommand(config, RuntimeCommandSpec{
 		Mode:           request.Mode,
 		Command:        request.Command,
 		Args:           request.Args,
@@ -37,29 +53,27 @@ func RuntimeCommandRequestPayload(config *appconfig.Config, request domain.Sched
 	}, guestCellDir)
 }
 
-// RuntimeCommandRequestPayloadFromCommand normalizes req's fields (mode
+// RuntimeCommandRequestPayloadFromCommand normalizes spec's fields (mode
 // lowercased, cwd defaulted, max output bytes defaulted) and stamps
-// guestArtifactDir. req's own ArtifactDir field is unused - it is always the
-// caller's guest execution/cell state dir, passed separately since it isn't
-// naturally part of the source command spec.
-func RuntimeCommandRequestPayloadFromCommand(config *appconfig.Config, req RuntimeCommandRequest, guestArtifactDir string) RuntimeCommandRequest {
+// guestArtifactDir onto the result.
+func RuntimeCommandRequestPayloadFromCommand(config *appconfig.Config, spec RuntimeCommandSpec, guestArtifactDir string) RuntimeCommandRequest {
 	appconfig.ApplyDefaultGuestPaths(config)
-	maxOutputBytes := req.MaxOutputBytes
+	maxOutputBytes := spec.MaxOutputBytes
 	if maxOutputBytes <= 0 {
 		maxOutputBytes = DefaultSchedulerCommandMaxOutputBytes
 	}
-	cwd := strings.TrimSpace(req.Cwd)
+	cwd := strings.TrimSpace(spec.Cwd)
 	if cwd == "" {
 		cwd = config.GuestWorkspacePath
 	}
 	return RuntimeCommandRequest{
-		Mode:           strings.ToLower(strings.TrimSpace(req.Mode)),
-		Command:        req.Command,
-		Args:           append([]string(nil), req.Args...),
-		Script:         req.Script,
+		Mode:           strings.ToLower(strings.TrimSpace(spec.Mode)),
+		Command:        spec.Command,
+		Args:           append([]string(nil), spec.Args...),
+		Script:         spec.Script,
 		Cwd:            cwd,
-		Env:            req.Env,
-		TimeoutMs:      req.TimeoutMs,
+		Env:            spec.Env,
+		TimeoutMs:      spec.TimeoutMs,
 		MaxOutputBytes: maxOutputBytes,
 		ArtifactDir:    guestArtifactDir,
 	}

--- a/pkg/execution/command_runtime.go
+++ b/pkg/execution/command_runtime.go
@@ -25,26 +25,41 @@ type RuntimeCommandRequest struct {
 }
 
 func RuntimeCommandRequestPayload(config *appconfig.Config, request domain.SchedulerCommandRequest, guestCellDir string) RuntimeCommandRequest {
-	return RuntimeCommandRequestPayloadFromCommand(config, request.Mode, request.Command, request.Args, request.Script, request.Cwd, request.Env, request.TimeoutMs, request.MaxOutputBytes, guestCellDir)
+	return RuntimeCommandRequestPayloadFromCommand(config, RuntimeCommandRequest{
+		Mode:           request.Mode,
+		Command:        request.Command,
+		Args:           request.Args,
+		Script:         request.Script,
+		Cwd:            request.Cwd,
+		Env:            request.Env,
+		TimeoutMs:      request.TimeoutMs,
+		MaxOutputBytes: request.MaxOutputBytes,
+	}, guestCellDir)
 }
 
-func RuntimeCommandRequestPayloadFromCommand(config *appconfig.Config, mode, command string, args []string, script, cwd string, env map[string]string, timeoutMs, maxOutputBytes int64, guestArtifactDir string) RuntimeCommandRequest {
+// RuntimeCommandRequestPayloadFromCommand normalizes req's fields (mode
+// lowercased, cwd defaulted, max output bytes defaulted) and stamps
+// guestArtifactDir. req's own ArtifactDir field is unused - it is always the
+// caller's guest execution/cell state dir, passed separately since it isn't
+// naturally part of the source command spec.
+func RuntimeCommandRequestPayloadFromCommand(config *appconfig.Config, req RuntimeCommandRequest, guestArtifactDir string) RuntimeCommandRequest {
 	appconfig.ApplyDefaultGuestPaths(config)
+	maxOutputBytes := req.MaxOutputBytes
 	if maxOutputBytes <= 0 {
 		maxOutputBytes = DefaultSchedulerCommandMaxOutputBytes
 	}
-	cwd = strings.TrimSpace(cwd)
+	cwd := strings.TrimSpace(req.Cwd)
 	if cwd == "" {
 		cwd = config.GuestWorkspacePath
 	}
 	return RuntimeCommandRequest{
-		Mode:           strings.ToLower(strings.TrimSpace(mode)),
-		Command:        command,
-		Args:           append([]string(nil), args...),
-		Script:         script,
+		Mode:           strings.ToLower(strings.TrimSpace(req.Mode)),
+		Command:        req.Command,
+		Args:           append([]string(nil), req.Args...),
+		Script:         req.Script,
 		Cwd:            cwd,
-		Env:            env,
-		TimeoutMs:      timeoutMs,
+		Env:            req.Env,
+		TimeoutMs:      req.TimeoutMs,
 		MaxOutputBytes: maxOutputBytes,
 		ArtifactDir:    guestArtifactDir,
 	}

--- a/pkg/runs/command_execution.go
+++ b/pkg/runs/command_execution.go
@@ -54,18 +54,12 @@ func (c *Controller) executeProjectRunCommand(ctx context.Context, run domain.Pr
 		return transition, err
 	}
 	guestArtifactsDir := filepath.Join(c.config.GuestStateRoot, "runs", run.RunID)
-	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(
-		c.config,
-		"shell",
-		"",
-		nil,
-		commandText,
-		c.config.GuestWorkspacePath,
-		execEnvMap(req.Env),
-		0,
-		0,
-		guestArtifactsDir,
-	)
+	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(c.config, execution.RuntimeCommandRequest{
+		Mode:   "shell",
+		Script: commandText,
+		Cwd:    c.config.GuestWorkspacePath,
+		Env:    execEnvMap(req.Env),
+	}, guestArtifactsDir)
 	if err := execution.WriteJSONArtifact(filepath.Join(artifactsDir, "command-request.json"), runtimeRequest); err != nil {
 		transition.ExitCode = 1
 		transition.Error = fmt.Sprintf("command execution failed: %v", err)

--- a/pkg/runs/command_execution.go
+++ b/pkg/runs/command_execution.go
@@ -54,7 +54,7 @@ func (c *Controller) executeProjectRunCommand(ctx context.Context, run domain.Pr
 		return transition, err
 	}
 	guestArtifactsDir := filepath.Join(c.config.GuestStateRoot, "runs", run.RunID)
-	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(c.config, execution.RuntimeCommandRequest{
+	runtimeRequest := execution.RuntimeCommandRequestPayloadFromCommand(c.config, execution.RuntimeCommandSpec{
 		Mode:   "shell",
 		Script: commandText,
 		Cwd:    c.config.GuestWorkspacePath,


### PR DESCRIPTION
## Summary
- Part of the funlen/argument-limit lint sweep across pkg/ (rule not yet enabled in `.golangci.yml`). Found while auditing leftover uncommitted work from earlier in the sweep — this violation only had a `//nolint` marker, never actually fixed.
- `RuntimeCommandRequestPayloadFromCommand` (exported, 10 args) built a `RuntimeCommandRequest` from 8 fields that map 1:1 onto `RuntimeCommandRequest`'s own fields — this is a "reuse existing struct" case (framework category 1), not a mechanical wrapper: the function now takes a `RuntimeCommandRequest` directly instead of exploding its fields as positional args. `guestArtifactDir` stays a separate trailing param since it's always the caller's guest exec/cell state dir, not naturally part of the source command spec.
- Verified real call-site count via `git grep` against `origin/main`: 3 sites across 3 packages (`pkg/agentcompose/api`, `pkg/execution`, `pkg/runs`), matching what the deferred nolint comment itself claimed — updated all of them.

**Note on merge ordering**: this touches `pkg/agentcompose/api/exec_execution.go`'s `RuntimeCommandRequestPayloadFromCommand` call site, which #615 (still open) also touches (it moved that call into a new `prepareExecCommand` helper). Whichever of this PR / #615 merges second will need a small rebase to reconcile — not a design conflict, just overlapping lines.

## Test plan
- [x] `go build ./...` (isolated `git worktree` at this branch's tip against current `main`, generated `proto/` packages copied in since they're gitignored)
- [x] `go vet ./pkg/execution/... ./pkg/agentcompose/... ./pkg/runs/...`
- [x] `go test ./pkg/execution/... ./pkg/runs/... ./pkg/agentcompose/api/...`
- [x] `golangci-lint run ./pkg/execution/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)