### PR TITLE
fix(runs): preserve oneof fields when decoding revision spec

### DIFF
--- a/pkg/runs/preparation.go
+++ b/pkg/runs/preparation.go
@@ -2,7 +2,6 @@ package runs
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"agent-compose/pkg/projects"
 	"agent-compose/pkg/storage/sandboxstore"
 	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type PreparationStore interface {
@@ -151,7 +151,8 @@ func DecodeRevisionSpec(raw string) (*agentcomposev2.ProjectSpec, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode project revision spec: %w", err)
 	}
-	if err := json.Unmarshal(normalizedData, &spec); err != nil {
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := opts.Unmarshal(normalizedData, &spec); err != nil {
 		return nil, fmt.Errorf("decode project revision spec: %w", err)
 	}
 	if err := restoreCanonicalRevisionWorkspaces(data, &spec); err != nil {

--- a/pkg/runs/preparation_driver_oneof_test.go
+++ b/pkg/runs/preparation_driver_oneof_test.go
@@ -1,0 +1,25 @@
+package runs
+
+import (
+	"testing"
+
+	agentcomposev2 "agent-compose/proto/agentcompose/v2"
+)
+
+// DecodeRevisionSpec must preserve oneof fields (e.g. driver runtime config).
+// Regression test for the GetProject → PatchProject round-trip where a driver
+// decoded via encoding/json lost its config oneof, so PatchProject rejected the
+// returned spec with "driver requires exactly one runtime config".
+func TestDecodeRevisionSpecPreservesDriverRuntimeConfig(t *testing.T) {
+	spec, err := DecodeRevisionSpec(`{"name":"demo","agents":[{"name":"worker","driver":{"name":"docker","docker":{}}}]}`)
+	if err != nil {
+		t.Fatalf("DecodeRevisionSpec returned error: %v", err)
+	}
+	driver := spec.GetAgents()[0].GetDriver()
+	if driver.GetName() != "docker" {
+		t.Fatalf("driver name = %q, want docker", driver.GetName())
+	}
+	if _, ok := driver.GetConfig().(*agentcomposev2.DriverSpec_Docker); !ok {
+		t.Fatalf("driver config = %T, want *agentcomposev2.DriverSpec_Docker", driver.GetConfig())
+	}
+}


### PR DESCRIPTION
## Problem

`GetProject` returns a project spec whose `driver` field loses its runtime config oneof. A `GetProject → PatchProject` round-trip fails with:

```
driver requires exactly one runtime config
```

Repro: apply a project whose agent has `driver: {docker: {}}`, then `GetProject` (includeSpec) → `PatchProject` the returned spec. The persisted `spec_json` is correct (`{"name":"docker","docker":{}}`), but the returned spec drops `docker: {}`, leaving only `{"name":"docker"}`.

## Root cause

`DecodeRevisionSpec` unmarshals the persisted spec into the generated proto message using `encoding/json`:

```go
json.Unmarshal(normalizedData, &spec)
```

`encoding/json` does not understand proto `oneof` fields. `DriverSpec.Config` is an `isDriverSpec_Config` interface with no `json` tag, so the `docker` key is ignored and `Config` stays `nil`. This silently drops every oneof field, not just driver config.

## Fix

Switch to `protojson.Unmarshal` (with `DiscardUnknown` so the legacy canonical workspace fields — still restored separately by `restoreCanonicalRevisionWorkspaces` — remain tolerated):

```go
opts := protojson.UnmarshalOptions{DiscardUnknown: true}
opts.Unmarshal(normalizedData, &spec)
```

`protojson` understands oneof and enum values, so `DriverSpec.Config` (and other oneofs) round-trip correctly.

## Test

- New regression test `TestDecodeRevisionSpecPreservesDriverRuntimeConfig` asserts the driver oneof survives decoding.
- `go test ./pkg/runs/` → 221 passed
- `go test ./pkg/agentcompose/api/ ./pkg/agentcompose/app/` → 321 passed