### PR TITLE
chore(deps): bump microsandbox to v0.6.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -e;     target_arch="${TARGETARCH:-$(dpkg --print-architecture)}";     c
 # published checksums. This keeps the FFI lib in lockstep with the
 # microsandbox/sdk/go module pinned in go.mod.
 FROM ${REGISTRY_MIRROR}/library/debian:bookworm AS microsandbox-fetch
-ARG MICROSANDBOX_VERSION=v0.6.8
+ARG MICROSANDBOX_VERSION=v0.6.14
 ARG GITHUB_MIRROR
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl binutils tar &&     rm -rf /var/lib/apt/lists/*

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/samber/oops v1.21.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
-	github.com/superradcompany/microsandbox/sdk/go v0.6.8
+	github.com/superradcompany/microsandbox/sdk/go v0.6.14
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/superradcompany/microsandbox/sdk/go v0.6.8 h1:NlRVtRGhWmTQ/Pix4Uht4C2GMsEO+F6w+ufUCdy7A2Y=
-github.com/superradcompany/microsandbox/sdk/go v0.6.8/go.mod h1:p7Tm/p9zkO7sHO3N8A1fiTVeLB2w/fQoKdYlpN/5neA=
+github.com/superradcompany/microsandbox/sdk/go v0.6.14 h1:cXGbpLhUVFgqj6seFeCMicmkwNfDGp+XixAAAch9638=
+github.com/superradcompany/microsandbox/sdk/go v0.6.14/go.mod h1:p7Tm/p9zkO7sHO3N8A1fiTVeLB2w/fQoKdYlpN/5neA=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=


### PR DESCRIPTION
## Summary
- Bump `github.com/superradcompany/microsandbox/sdk/go` from v0.6.8 to v0.6.14 in go.mod/go.sum
- Bump the `MICROSANDBOX_VERSION` Dockerfile build arg from v0.6.8 to v0.6.14 so the downloaded msb/agentd/libkrunfw/FFI binaries stay in lockstep with the Go SDK

## Test plan
- [x] `go build ./...` succeeds
- [x] `go mod tidy` produces no unexpected diff
- [ ] CI image build (downloads and checksum-verifies the v0.6.14 release assets)

