### PR TITLE
feat(schedulers): add async parallel calls to scheduler.llm and scheduler.agent

### DIFF
--- a/cmd/agent-compose/examples_contract_test.go
+++ b/cmd/agent-compose/examples_contract_test.go
@@ -102,8 +102,8 @@ func validateStandaloneSchedulerExamples(t *testing.T, root string, engine *sche
 	if err != nil {
 		t.Fatalf("glob scheduler examples: %v", err)
 	}
-	if len(files) != 6 {
-		t.Fatalf("standalone scheduler example count = %d, want 6", len(files))
+	if len(files) != 7 {
+		t.Fatalf("standalone scheduler example count = %d, want 7", len(files))
 	}
 	for _, file := range files {
 		script, err := os.ReadFile(file)

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -819,6 +819,15 @@ A scheduler uses either declarative `triggers` or JavaScript `script`; the two f
 
 `concurrency_policy` applies to the whole agent scheduler, including all declarative or script-registered triggers and manual scheduler invocations. With `skip`, a run that overlaps another run from the same scheduler is recorded as `skipped` and is not queued. With `parallel`, overlapping runs may execute concurrently. It is not a per-trigger policy.
 
+Script schedulers can run host calls in parallel with `scheduler.llm.async` and `scheduler.agent.async`. Two scheduler env values cap how many run at once:
+
+| Env | Default | Purpose |
+| --- | --- | --- |
+| `LLM_MAX_CONCURRENCY` | `8` | Concurrent `scheduler.llm.async` calls. |
+| `AGENT_MAX_CONCURRENCY` | `3` | Concurrent `scheduler.agent.async` runs. |
+
+The agent limit is much lower because every parallel agent run creates its own sandbox, sandbox creation has no ceiling of its own, and each run writes through the SQLite pool (`SQLITE_MAX_OPEN_CONNS`, four connections by default). A value that is not a positive integer is ignored and the default applies. `scheduler.agent.async` always uses the `new` sandbox policy: parallel agents cannot share one.
+
 #### Declarative triggers
 
 Each trigger must set exactly one kind field: `cron`, `interval`, `timeout`, or `event`.

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -824,6 +824,15 @@ Scheduler 可以使用声明式 `triggers`，也可以使用 JavaScript `script`
 
 `concurrency_policy` 作用于整个 Agent Scheduler，包括全部声明式或脚本注册的 Trigger，以及手动 Scheduler 调用。`skip` 会把与同一 Scheduler 既有运行重叠的新 run 记录为 `skipped`，且不会排队补跑；`parallel` 允许重叠 run 并行执行。它不是 Trigger 级策略。
 
+脚本型 scheduler 可以用 `scheduler.llm.async` 和 `scheduler.agent.async` 并行发起 host 调用。两个 scheduler env 用于限制同时进行的数量：
+
+| Env | 默认值 | 说明 |
+| --- | --- | --- |
+| `LLM_MAX_CONCURRENCY` | `8` | 同时进行的 `scheduler.llm.async` 调用数。 |
+| `AGENT_MAX_CONCURRENCY` | `3` | 同时进行的 `scheduler.agent.async` 运行数。 |
+
+agent 的上限明显更低：每个并行 agent 运行都会创建独立 sandbox，而 sandbox 创建本身没有数量限制，且每次运行都要经由 SQLite 连接池写入（`SQLITE_MAX_OPEN_CONNS`，默认 4 条）。非正整数会被忽略并回退到默认值。`scheduler.agent.async` 始终使用 `new` sandbox 策略：并行 agent 无法共享同一个 sandbox。
+
 #### 声明式 Trigger
 
 每个 Trigger 必须且只能写一个 kind 字段：`cron`、`interval`、`timeout` 或 `event`。

--- a/examples/scheduler-script/07-parallel-fanout.js
+++ b/examples/scheduler-script/07-parallel-fanout.js
@@ -1,0 +1,34 @@
+// 并行扇出：一批 prompt 同时发给 LLM，总耗时接近最慢的那一次，而不是所有次数之和。
+//
+// 对照写法（串行，逐个等待）：
+//   for (const topic of topics) results.push(scheduler.llm(topic).text);
+
+const TOPICS = ["产品反馈", "线上故障", "成本异常"];
+
+function summarizePrompt(topic) {
+  return `用一句话总结「${topic}」本周的关键变化`;
+}
+
+async function main() {
+  // 每次 .async 调用立即返回一个 Promise，请求已经在后台进行；
+  // 到 Promise.all 收集时三个请求早已同时在飞。
+  const summaries = await Promise.all(
+    TOPICS.map((topic) => scheduler.llm.async(summarizePrompt(topic)))
+  );
+
+  // 部分失败不应该让整批丢失，所以用 allSettled 单独跑一批可选的补充调用。
+  const enrichment = await Promise.allSettled(
+    TOPICS.map((topic) => scheduler.llm.async(`列出「${topic}」的三个风险点`))
+  );
+
+  const result = {
+    summaries: summaries.map((item, index) => ({
+      topic: TOPICS[index],
+      text: item.text,
+    })),
+    enrichedCount: enrichment.filter((item) => item.status === "fulfilled").length,
+  };
+
+  scheduler.log("parallel fanout completed", result);
+  return result;
+}

--- a/examples/scheduler-script/README.md
+++ b/examples/scheduler-script/README.md
@@ -183,6 +183,121 @@ const result = scheduler.llm(prompt, {
 // => { text, model, responseId, finishReason, json }
 ```
 
+## 并行调用
+
+`scheduler.llm` 和 `scheduler.agent` 是同步阻塞的，`for` 循环里逐个调用会串行等待。加 `.async` 可以让它们并行：调用立即返回一个 Promise，真正的请求在后台进行。
+
+```js
+async function main() {
+  const topics = ["a", "b", "c"];
+  const results = await Promise.all(
+    topics.map((t) => scheduler.llm.async(`summarize ${t}`))
+  );
+  return results.map((r) => r.text);
+}
+```
+
+`.async` 返回的是标准 Promise，`await`、`Promise.all`、`Promise.allSettled`、`.catch()`、`.finally()` 都可以正常使用。结果和错误的形状与同步版完全一致。
+
+**但句柄的 settle 是按创建顺序串行的。** 引擎没有事件循环，每个句柄在创建时就把自己的结算任务排进队列，泵队列时按顺序执行，且每个任务都会阻塞 JS 线程直到对应调用完成。后果是：**先创建但没有 await 的慢调用，会挡住之后创建的句柄**。
+
+```js
+scheduler.llm.async("慢的");              // 没有 await
+const r = await scheduler.llm.async("快的"); // 仍然要等「慢的」先结算
+```
+
+实测：单独 await「快的」11ms；前面挂一个 300ms 的弃用调用，就变成 301ms。
+
+所以需要结果的调用请**全部放进同一个 `Promise.all`**（它们会真正并行），不要留下不 await 的句柄。这也和上面「未 await 的句柄」一节的建议一致。
+
+同步版本保持不变，现有脚本无需改动。
+
+### 取最快或最先成功的结果
+
+**不要对 `.async` 句柄使用 `Promise.race` 或 `Promise.any`**。引擎没有事件循环，这两个内置组合子会退化成「取数组里的第一个」，而不是「取最快的那个」——它们会静默返回错误的结果。请改用：
+
+```js
+// 取最先完成的（无论成功失败）
+const fastest = await scheduler.llm.race(["prompt-a", "prompt-b"]);
+
+// 取最先成功的，全部失败时才 reject
+const winner = await scheduler.llm.any([
+  { prompt: "同一个问题", model: "model-a" },
+  { prompt: "同一个问题", model: "model-b" },
+]);
+```
+
+数组元素必须是 prompt 字符串，或带 `prompt` 字段的对象——对象本身同时用作 options，因此 `model`、`outputSchema` 的写法与 `scheduler.llm` 一致。其他类型（`null`、数字、数组等）会直接报错，不会被转成字符串当作 prompt 发出去。
+
+胜负一旦确定，落败的调用会被取消，run 不会再为它们等待——这也是 `.any` 能真正当作 failover 用的原因：即使某个 provider 卡住，只要有一个先成功，整个 run 就不必等它。
+
+「最先」指的是**引擎先观察到谁完成**，不是严格的完成时刻。两个条目在几乎同一瞬间完成时，谁被选中取决于 goroutine 调度，可能不是快了几微秒的那个。这和 JS 里 `Promise.race` 的语义一致——任何 Promise 实现都只保证「先被观察到」，不保证严格时序。差距明显时（例如一个 provider 卡住、另一个正常返回）选择是可靠的。
+
+### 并行 agent 必须使用独立 sandbox
+
+`scheduler.agent.async` 会把每次调用固定为 `sandboxPolicy: "new"`。并行 agent 无法共享 sandbox：它们会同时写同一个 workspace，而且先跑完的那个会把 sandbox 关掉。
+
+未指定 `sandboxPolicy` 时自动使用 `"new"`；显式传入 `"sticky"` 或 `"reuse"` 会直接报错，而不是被悄悄改写。
+
+**副作用**：如果一个触发器把它唯一的 `scheduler.agent(prompt)` 改成 `scheduler.agent.async(prompt)`，那么即使 Scheduler 配的是 `sandbox_policy: sticky`，该触发器的手动运行也不会再建立 sticky binding——因为它实际用的就是 `new`。这是并行 agent 的必然结果，不是可以绕开的。
+
+```js
+const reviews = await Promise.all(
+  files.map((f) => scheduler.agent.async(`review ${f}`))
+);
+```
+
+### 并发上限
+
+并行调用有上限，防止脚本对一个长数组扇出时耗尽资源。可通过 Scheduler 的 env 覆盖：
+
+| env | 默认值 | 说明 |
+| --- | --- | --- |
+| `LLM_MAX_CONCURRENCY` | 8 | 同时进行的 `scheduler.llm.async` 调用数 |
+| `AGENT_MAX_CONCURRENCY` | 3 | 同时进行的 `scheduler.agent.async` 运行数 |
+
+agent 的默认值明显更低，因为每个并行 agent 都是一个新 sandbox，而 sandbox 创建本身没有数量限制，且每次运行都要写数据库（SQLite 连接池默认 4 条，见 `SQLITE_MAX_OPEN_CONNS`）。
+
+非法值或非正数会被忽略并回退到默认值。
+
+此外，单次执行**同时未完成**的异步调用总数上限为 4096（含 `llm`、`agent`、`sleep`）。上面两个 env 控制的是同时**运行**的数量，但每个待处理句柄仍占一个 goroutine 及其栈，而这部分内存不受 QuickJS 的内存上限约束。超过时会抛错，提示先 await 当前这批。正常脚本不会碰到这个值。
+
+### 未 await 的句柄
+
+run 收尾时，**仍未完成的异步调用会被取消**，而不是被等到跑完。收尾发生在脚本返回之后，所以此刻还在飞的调用按定义就是被遗弃的。
+
+```js
+async function main() {
+  scheduler.agent.async("长任务");   // 没有 await —— 会在 run 收尾时被取消
+  return "done";
+}
+```
+
+之所以是取消而不是等待：scheduler 的并发槽要等 run 结束才释放，如果 fire-and-forget 一个跑十分钟的 agent，run 就会保持 running 十分钟，期间 `concurrency_policy: skip` 会把后续触发全部跳过。
+
+需要结果就 `await` 它。需要「发出去就不管」的语义，请用 `scheduler.event.publish` 触发另一个 Scheduler，而不是靠不 await 的句柄。
+
+不认 ctx 取消的下游会被放弃而不是无限等待，代价是它的结果可能在 run 收尾之后才落到事件表里。
+
+另外，被弃用的句柄会把已经拿到的响应体一直持有到本次 run 结束（引擎所依赖的 QuickJS 绑定不会提前注销这些对象）。这不会跨 run 泄漏，但如果一次 run 里弃用了大量大响应的调用，内存峰值会被明显抬高。
+
+### 超时行为
+
+Scheduler run 超时会中止整个执行，**已完成的并行结果不会被返回**。需要「尽力而为、收集部分结果」的场景，请自行缩小每批的规模。
+
+## 等待
+
+全局 `setTimeout` 在本运行时里是触发器注册器，因此 `await new Promise((r) => setTimeout(r, ms))` 永远不会 settle。请使用：
+
+```js
+scheduler.sleep(500);              // 同步阻塞 500ms
+await scheduler.sleep.async(500);  // 返回 Promise，可参与 Promise.all
+```
+
+`scheduler.sleep.async` 不占用并发额度，因此不会挤占真正的 host 调用；它也不会在 run 收尾时被等待，所以没有 await 的 sleep 不会拖住整个 run。
+
+时长必须是正整数毫秒，上限约 9.2 万亿毫秒（约 292 年，即 `time.Duration` 能表示的最大值）；超出范围会报错，而不是静默变成立即返回。
+
 ## 命令执行
 
 `scheduler.exec(...)` 和 `scheduler.shell(...)` 会在 Scheduler 关联的 notebook runtime 里执行命令。
@@ -300,8 +415,9 @@ scheduler.runtime.name; // "scheduler"
 
 保存或校验 Scheduler 时，脚本会被求值以收集触发器。此时不要在顶层调用会执行副作用的 host API。
 
-- `scheduler.agent`、`scheduler.llm`、`scheduler.exec`、`scheduler.shell`、`scheduler.event.publish`、`scheduler.sandbox.*` 在校验阶段不可用。
+- `scheduler.agent`、`scheduler.llm`、`scheduler.exec`、`scheduler.shell`、`scheduler.event.publish`、`scheduler.sandbox.*` 在校验阶段不可用，它们的 `.async`、`.race`、`.any` 变体同样不可用。
 - `scheduler.log` 在校验阶段是 no-op。
+- `scheduler.sleep` 和 `scheduler.sleep.async` 在校验阶段不会真的等待（参数仍然会校验），避免顶层 sleep 拖住保存。
 - `scheduler.state.*` 在校验阶段不会访问持久状态。
 
 把这些调用放进 `main()` 或触发器 callback 里。
@@ -314,3 +430,4 @@ scheduler.runtime.name; // "scheduler"
 - `04-cron-daily-summary.js`：定时 agent 任务，并记录最近运行状态。
 - `05-router-with-multiple-triggers.js`：多个触发器共享一个 workflow 的推荐结构。
 - `06-conditional-triggers.js`：按条件注册或清除 interval/timeout 触发器。
+- `07-parallel-fanout.js`：用 `scheduler.llm.async` + `Promise.all` 并行扇出一批调用。

--- a/pkg/runs/trigger.go
+++ b/pkg/runs/trigger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	domain "agent-compose/pkg/model"
 	"agent-compose/pkg/schedulers"
@@ -132,20 +133,36 @@ func (c *Controller) captureManualTriggerAgentRequest(ctx context.Context, defin
 		Script:      definition.Script,
 		Trigger:     trigger,
 		PayloadJSON: payloadJSON,
+		// Capturing a prompt only observes what the trigger would request, so
+		// the script's own delays must not stall the resolve API.
+		DryRun: true,
 	}, host)
 	if err != nil {
 		return capturedManualTriggerAgentRequest{}, fmt.Errorf("%w: resolve trigger %s prompt: %w", domain.ErrInvalidArgument, trigger.ID, err)
 	}
-	if host.calls != 1 || strings.TrimSpace(host.prompt) == "" {
+	calls, prompt, request := host.captured()
+	if calls != 1 || strings.TrimSpace(prompt) == "" {
 		return capturedManualTriggerAgentRequest{}, fmt.Errorf("%w: trigger %s must call scheduler.agent exactly once", domain.ErrInvalidArgument, trigger.ID)
 	}
-	return capturedManualTriggerAgentRequest{prompt: host.prompt, request: host.request}, nil
+	return capturedManualTriggerAgentRequest{prompt: prompt, request: request}, nil
 }
 
+// manualTriggerCaptureHost records the single scheduler.agent call a manual
+// trigger is expected to make. scheduler.agent.async reaches the host from its
+// own goroutine, so several calls can arrive concurrently and the fields are
+// guarded.
 type manualTriggerCaptureHost struct {
+	mu      sync.Mutex
 	calls   int
 	prompt  string
 	request domain.SchedulerAgentRequest
+}
+
+// captured reports the recorded call count and payload.
+func (h *manualTriggerCaptureHost) captured() (int, string, domain.SchedulerAgentRequest) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.calls, h.prompt, h.request
 }
 
 func (h *manualTriggerCaptureHost) Log(context.Context, string, any) error { return nil }
@@ -155,10 +172,13 @@ func (h *manualTriggerCaptureHost) PublishEvent(context.Context, string, string)
 }
 
 func (h *manualTriggerCaptureHost) Agent(_ context.Context, prompt string, request domain.SchedulerAgentRequest) (domain.SchedulerAgentResult, error) {
+	trimmed := strings.TrimSpace(prompt)
+	h.mu.Lock()
 	h.calls++
-	h.prompt = strings.TrimSpace(prompt)
+	h.prompt = trimmed
 	h.request = request
-	return domain.SchedulerAgentResult{Text: h.prompt, FinalText: h.prompt, Success: true}, nil
+	h.mu.Unlock()
+	return domain.SchedulerAgentResult{Text: trimmed, FinalText: trimmed, Success: true}, nil
 }
 
 func (h *manualTriggerCaptureHost) Command(context.Context, domain.SchedulerCommandRequest) (domain.SchedulerCommandResult, error) {

--- a/pkg/runs/trigger_async_capture_test.go
+++ b/pkg/runs/trigger_async_capture_test.go
@@ -1,0 +1,100 @@
+package runs
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/schedulers"
+)
+
+func manualTriggerCaptureFixture(script string) (*Controller, domain.Scheduler, *domain.SchedulerTrigger) {
+	controller := &Controller{schedulerEngine: &schedulers.QJSSchedulerEngine{}}
+	definition := domain.Scheduler{
+		Summary: domain.SchedulerSummary{Runtime: domain.SchedulerRuntimeScheduler},
+		Script:  script,
+	}
+	return controller, definition, &domain.SchedulerTrigger{ID: "daily", Kind: domain.SchedulerTriggerKindCron}
+}
+
+// A trigger may reach scheduler.agent through the async binding, which calls
+// the host from its own goroutine rather than inline.
+func TestCaptureManualTriggerAgentRequestAcceptsSingleAsyncAgentCall(t *testing.T) {
+	controller, definition, trigger := manualTriggerCaptureFixture(`
+scheduler.cron("0 0 * * *", async function daily() {
+  await scheduler.agent.async("review today's runs");
+}, { id: "daily" });`)
+
+	captured, err := controller.captureManualTriggerAgentRequest(context.Background(), definition, trigger, `{}`)
+	if err != nil {
+		t.Fatalf("captureManualTriggerAgentRequest returned error: %v", err)
+	}
+	if captured.prompt != "review today's runs" {
+		t.Fatalf("captured prompt = %q, want the async call's prompt", captured.prompt)
+	}
+}
+
+// Several async agent calls reach the capture host concurrently; the count must
+// still be exact so the exactly-once contract is enforced rather than raced.
+func TestCaptureManualTriggerAgentRequestRejectsConcurrentAsyncAgentCalls(t *testing.T) {
+	controller, definition, trigger := manualTriggerCaptureFixture(`
+scheduler.cron("0 0 * * *", async function daily() {
+  const prompts = ["a", "b", "c", "d", "e", "f", "g", "h"];
+  await Promise.all(prompts.map(function (p) { return scheduler.agent.async(p); }));
+}, { id: "daily" });`)
+
+	_, err := controller.captureManualTriggerAgentRequest(context.Background(), definition, trigger, `{}`)
+	if err == nil {
+		t.Fatalf("captureManualTriggerAgentRequest accepted eight agent calls, want an error")
+	}
+	if !strings.Contains(err.Error(), "exactly once") {
+		t.Fatalf("error = %v, want the exactly-once rejection", err)
+	}
+}
+
+// Prompt capture is a dry run: it evaluates the trigger only to observe the
+// agent request it would make. A sleep in the callback must not make the
+// resolve API wait it out.
+func TestCaptureManualTriggerAgentRequestSkipsSleeps(t *testing.T) {
+	controller, definition, trigger := manualTriggerCaptureFixture(`
+scheduler.cron("0 0 * * *", async function daily() {
+  scheduler.sleep(20000);
+  await scheduler.agent("review today's runs");
+}, { id: "daily" });`)
+
+	start := time.Now()
+	captured, err := controller.captureManualTriggerAgentRequest(context.Background(), definition, trigger, `{}`)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("captureManualTriggerAgentRequest returned error: %v", err)
+	}
+	if captured.prompt != "review today's runs" {
+		t.Fatalf("captured prompt = %q", captured.prompt)
+	}
+	if elapsed > 15*time.Second {
+		t.Fatalf("captureManualTriggerAgentRequest took %v; it waited out the script's sleep", elapsed)
+	}
+}
+
+// A trigger may start an agent through the async binding and never await it.
+// Capture must still see exactly one call: prompt resolution is a dry run, so
+// its outcome cannot depend on whether the goroutine beat teardown to the host.
+func TestCaptureManualTriggerAgentRequestIsDeterministicForUnawaitedAsyncAgent(t *testing.T) {
+	for i := range 20 {
+		controller, definition, trigger := manualTriggerCaptureFixture(`
+scheduler.cron("0 0 * * *", async function daily() {
+  scheduler.agent.async("review today's runs");
+}, { id: "daily" });`)
+
+		captured, err := controller.captureManualTriggerAgentRequest(context.Background(), definition, trigger, `{}`)
+		if err != nil {
+			t.Fatalf("iteration %d: captureManualTriggerAgentRequest returned error: %v", i, err)
+		}
+		if captured.prompt != "review today's runs" {
+			t.Fatalf("iteration %d: captured prompt = %q", i, captured.prompt)
+		}
+	}
+}

--- a/pkg/schedulers/engine.go
+++ b/pkg/schedulers/engine.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	domain "agent-compose/pkg/model"
@@ -34,6 +36,18 @@ type SchedulerExecutionRequest struct {
 	Script      string
 	Trigger     *domain.SchedulerTrigger
 	PayloadJSON string
+
+	// MaxAsyncLLMConcurrency caps concurrent scheduler.llm.async calls.
+	// Zero selects DefaultMaxAsyncLLMConcurrency.
+	MaxAsyncLLMConcurrency int
+	// MaxAsyncAgentConcurrency caps concurrent scheduler.agent.async runs.
+	// Zero selects DefaultMaxAsyncAgentConcurrency.
+	MaxAsyncAgentConcurrency int
+
+	// DryRun marks an execution that runs the script only to observe what it
+	// would request, such as resolving a manual trigger's prompt. Delays are
+	// skipped so a script's own pacing cannot stall the caller.
+	DryRun bool
 }
 
 type SchedulerExecutionResult struct {
@@ -56,13 +70,37 @@ type schedulerRegistration struct {
 }
 
 type schedulerExecutionState struct {
-	ctx           context.Context
+	ctx context.Context
+	// asyncCtx scopes work started by the async bindings. Draining cancels it,
+	// which ends anything the script abandoned instead of waiting it out.
+	asyncCtx      context.Context
 	host          SchedulerHost
 	jsonEncoder   *jsValueEncoder
+	promises      *promiseAdopter
 	registrations []schedulerRegistration
 	seenIDs       map[string]struct{}
 	warnings      []string
 	warningSet    map[string]struct{}
+	dryRun        bool
+
+	// inflight tracks host calls started by the async bindings. The run must
+	// not finish while any of them is still running, or the host would keep
+	// recording events against an execution that is already torn down.
+	inflight sync.WaitGroup
+	// llmSem and agentSem cap concurrent async host calls. A script can fan
+	// out over an arbitrarily long array, and neither sandbox creation nor the
+	// SQLite connection pool has a ceiling of its own, so these are safety
+	// valves rather than tuning knobs. Agents get their own, much smaller
+	// budget because each parallel agent run is a fresh sandbox.
+	llmSem   chan struct{}
+	agentSem chan struct{}
+	// asyncCancels stops work that is only useful while the script is still
+	// running, such as the losing entries of a racing group. Only the JS thread
+	// appends to and reads this, so it needs no lock.
+	asyncCancels []context.CancelFunc
+	// outstandingAsync counts async calls started but not yet settled. The JS
+	// thread raises it and the goroutines lower it, so it is atomic.
+	outstandingAsync atomic.Int64
 }
 
 func NewSchedulerEngine(do.Injector) (SchedulerEngine, error) {
@@ -109,15 +147,29 @@ func (e *QJSSchedulerEngine) executeRuntime(ctx context.Context, request Schedul
 	if err != nil {
 		return SchedulerExecutionResult{}, err
 	}
+	promises, err := newPromiseAdopter(jsctx)
+	if err != nil {
+		return SchedulerExecutionResult{}, err
+	}
+	asyncCtx, cancelAsync := context.WithCancel(ctx)
 	state := &schedulerExecutionState{
 		ctx:           ctx,
+		asyncCtx:      asyncCtx,
 		host:          host,
 		jsonEncoder:   jsonEncoder,
+		promises:      promises,
 		registrations: make([]schedulerRegistration, 0),
 		seenIDs:       make(map[string]struct{}),
 		warningSet:    make(map[string]struct{}),
+		dryRun:        request.DryRun,
+		llmSem:        make(chan struct{}, resolveMaxAsyncConcurrency(request.MaxAsyncLLMConcurrency, DefaultMaxAsyncLLMConcurrency)),
+		agentSem:      make(chan struct{}, resolveMaxAsyncConcurrency(request.MaxAsyncAgentConcurrency, DefaultMaxAsyncAgentConcurrency)),
 	}
+	state.registerAsyncCancel(cancelAsync)
 	defer state.freeCallbacks()
+	// Registered after freeCallbacks so it runs first: in-flight goroutines are
+	// joined before any JS value is released and before the runtime is closed.
+	defer state.drainInflight()
 
 	if _, err = e.installRuntime(jsctx, state); err != nil {
 		return SchedulerExecutionResult{}, err

--- a/pkg/schedulers/engine_async.go
+++ b/pkg/schedulers/engine_async.go
@@ -350,7 +350,11 @@ func positiveEnvInt(items []domain.SandboxEnvVar, name string) int {
 		}
 		value, err := strconv.Atoi(strings.TrimSpace(item.Value))
 		if err != nil || value <= 0 {
-			return 0
+			// Keep scanning: NormalizeEnvItems dedupes by exact name, so a
+			// scheduler can carry both LLM_MAX_CONCURRENCY and
+			// llm_max_concurrency with different values. An invalid early
+			// entry must not hide a valid later one.
+			continue
 		}
 		return value
 	}

--- a/pkg/schedulers/engine_async.go
+++ b/pkg/schedulers/engine_async.go
@@ -1,0 +1,358 @@
+package schedulers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "agent-compose/pkg/model"
+
+	"github.com/fastschema/qjs"
+)
+
+// DefaultMaxAsyncLLMConcurrency bounds concurrent async LLM calls when a
+// request does not ask for a specific limit.
+const DefaultMaxAsyncLLMConcurrency = 8
+
+// DefaultMaxAsyncAgentConcurrency bounds concurrent async agent runs. It is far
+// lower than the LLM limit because every parallel agent is a fresh sandbox:
+// sandbox creation has no ceiling of its own, and the SQLite pool each run
+// writes through defaults to four connections.
+const DefaultMaxAsyncAgentConcurrency = 3
+
+// asyncDrainGrace bounds how long draining waits for host calls that have not
+// noticed cancellation yet.
+const asyncDrainGrace = 2 * time.Second
+
+// maxOutstandingAsyncCalls bounds how many async host calls one execution may
+// have started but not finished.
+//
+// The concurrency limits gate how many calls run at once, but every pending
+// handle still costs a goroutine and its stack, which lives outside the QuickJS
+// memory limit. Fanning out over a long array would otherwise turn script input
+// straight into hundreds of megabytes of Go stacks. The ceiling is far above
+// any sensible batch, so it reads as a guard rail rather than a tuning knob.
+const maxOutstandingAsyncCalls = 4096
+
+// promiseAdopter holds the Promise intrinsic captured before user code runs.
+//
+// The async bindings hand scripts a promise by letting Promise.resolve adopt a
+// thenable. Reading that off the global at call time would let a script decide
+// what every async binding returns, the same way a tampered JSON.stringify
+// would change the engine's serialization -- which is why jsValueEncoder
+// captures its intrinsic up front too.
+type promiseAdopter struct {
+	promiseObject *qjs.Value
+	resolve       *qjs.Value
+}
+
+func newPromiseAdopter(jsctx *qjs.Context) (*promiseAdopter, error) {
+	promiseObject := jsctx.Global().GetPropertyStr("Promise")
+	if promiseObject == nil || !promiseObject.IsObject() {
+		return nil, fmt.Errorf("initialize promise adopter: Promise is unavailable")
+	}
+	resolve := promiseObject.GetPropertyStr("resolve")
+	if resolve == nil || !resolve.IsFunction() {
+		return nil, fmt.Errorf("initialize promise adopter: Promise.resolve is unavailable")
+	}
+	return &promiseAdopter{promiseObject: promiseObject, resolve: resolve}, nil
+}
+
+// adopt turns a thenable into a genuine promise.
+func (a *promiseAdopter) adopt(jsctx *qjs.Context, thenable *qjs.Value) (*qjs.Value, error) {
+	return jsctx.Invoke(a.resolve, a.promiseObject, thenable)
+}
+
+// asyncCallSpec describes one async host call to start.
+//
+// slot gates the call on a concurrency limit; LLM calls and agent runs use
+// separate ones because an agent run is a whole sandbox while an LLM call is
+// one HTTP request. slotHeld says the caller already took the slot, which a
+// racing group does so that every entry really starts at once. notify, when
+// set, reports the call once it has settled, which lets a racing group observe
+// completion order; it must be buffered for the whole group so reporting never
+// blocks.
+type asyncCallSpec[T any] struct {
+	apiName  string
+	slot     chan struct{}
+	slotHeld bool
+	notify   chan<- *asyncCall[T]
+	work     func(ctx context.Context) (T, error)
+}
+
+// asyncCall holds one host call that is already running on its own goroutine.
+// done is closed (never sent to) so that awaiting the same handle twice, or
+// awaiting it after it settled, both observe the outcome without blocking.
+type asyncCall[T any] struct {
+	done   chan struct{}
+	result T
+	err    error
+}
+
+// resolveMaxAsyncConcurrency turns a requested limit into an effective one.
+func resolveMaxAsyncConcurrency(requested, fallback int) int {
+	if requested <= 0 {
+		return fallback
+	}
+	return requested
+}
+
+// startAsyncHostCall runs work on its own goroutine and returns immediately, so
+// a script can start several host calls before awaiting any of them.
+//
+// slot gates the call on a concurrency limit; LLM calls and agent runs use
+// separate ones because an agent run is a whole sandbox while an LLM call is
+// one HTTP request. slotHeld says the caller already took the slot, which a
+// racing group does so that every entry really starts at once. notify, when set, reports the call once it has settled,
+// which lets a racing group observe completion order; it must be buffered for
+// the whole group so reporting never blocks. ctx is usually the execution's own,
+// but a racing group passes a narrower one it can cancel once a winner is known.
+func startAsyncHostCall[T any](
+	ctx context.Context,
+	state *schedulerExecutionState,
+	spec asyncCallSpec[T],
+) (*asyncCall[T], error) {
+	apiName, slot, slotHeld, notify := spec.apiName, spec.slot, spec.slotHeld, spec.notify
+	if state.dryRun {
+		// A dry run only observes what the script would request, so there is
+		// nothing to run in parallel. Inline keeps what the host records
+		// deterministic: on a goroutine an unawaited call races teardown's
+		// cancellation, and losing that race makes prompt capture report a
+		// confusing "must call scheduler.agent exactly once".
+		if slotHeld {
+			// A racing group took this slot before starting the call. Running
+			// inline means there is no goroutine to hand it back, so without
+			// this the budget drains one group at a time.
+			defer func() { <-slot }()
+		}
+		call := &asyncCall[T]{done: make(chan struct{})}
+		call.result, call.err = spec.work(ctx)
+		close(call.done)
+		if notify != nil {
+			notify <- call
+		}
+		return call, nil
+	}
+	if err := state.reserveAsyncCall(apiName); err != nil {
+		return nil, err
+	}
+	call := &asyncCall[T]{done: make(chan struct{})}
+	state.inflight.Add(1)
+	go func() {
+		defer state.inflight.Done()
+		defer state.releaseAsyncCall()
+		if notify != nil {
+			// Registered before close(done) so it runs after it: the call is
+			// fully settled by the time the group observes it.
+			defer func() { notify <- call }()
+		}
+		defer close(call.done)
+		// Registered after close(done) so it runs before it, leaving err set
+		// for whoever awaits the handle. A synchronous binding survives a
+		// panicking host because qjs turns a panic inside a proxied function
+		// into a JS exception; on this goroutine an unrecovered one would take
+		// the whole daemon down instead.
+		defer func() {
+			recovered := recover()
+			if recovered == nil {
+				return
+			}
+			slog.Error("scheduler async host call panicked",
+				"api", apiName, "panic", recovered, "stack", string(debug.Stack()))
+			call.err = fmt.Errorf("%s panicked: %v", apiName, recovered)
+		}()
+
+		if slotHeld {
+			// The caller took this slot before starting the call, so releasing
+			// is all that is left to do.
+			defer func() { <-slot }()
+		} else {
+			select {
+			case slot <- struct{}{}:
+				defer func() { <-slot }()
+			case <-ctx.Done():
+				call.err = context.Cause(ctx)
+				return
+			}
+		}
+		call.result, call.err = spec.work(ctx)
+	}()
+	return call, nil
+}
+
+// reserveAsyncCall admits one more outstanding async call, or reports that this
+// execution has fanned out too far.
+func (s *schedulerExecutionState) reserveAsyncCall(apiName string) error {
+	if s.outstandingAsync.Add(1) > maxOutstandingAsyncCalls {
+		s.outstandingAsync.Add(-1)
+		return fmt.Errorf(
+			"%s has %d calls outstanding, the most one execution may start; await the current batch before starting more",
+			apiName, maxOutstandingAsyncCalls,
+		)
+	}
+	return nil
+}
+
+func (s *schedulerExecutionState) releaseAsyncCall() {
+	s.outstandingAsync.Add(-1)
+}
+
+// newAsyncPromise wraps an in-flight call in a real JS promise.
+//
+// The bridge is a thenable: QuickJS treats any object with a then method as
+// awaitable, which lets the engine hand results back without owning an event
+// loop -- qjs v0.0.6 cannot provide one, since its wasm build exports no
+// JS_ExecutePendingJob for Go to pump pending jobs with. then joins the
+// goroutine rather than starting it, so by the time Promise.all invokes it
+// every handle in the batch is already running and the batch costs the slowest
+// call rather than their sum.
+//
+// The thenable is then adopted by Promise.resolve so scripts receive a genuine
+// promise. Handing back the bare thenable would expose an object with only a
+// then method: .catch and .finally would be missing.
+//
+// Adoption has a cost worth knowing about: Promise.resolve enqueues the
+// thenable job at creation, and the queue is drained in order with every job
+// blocking, so a handle created first has to settle before a later await can
+// proceed -- even one the script abandoned. Returning a bare thenable would
+// make adoption lazy and remove that coupling, at the price of hand-rolling
+// catch and finally and giving up instanceof Promise. Documented under
+// "并行调用" in examples/scheduler-script/README.md and pinned by
+// TestSchedulerLLMAsyncAbandonedHandleDelaysLaterAwait.
+func newAsyncPromise[T any](
+	state *schedulerExecutionState,
+	jsctx *qjs.Context,
+	apiName string,
+	call *asyncCall[T],
+	encode func(T) (*qjs.Value, error),
+) (*qjs.Value, error) {
+	ctx := state.ctx
+	return adoptAsyncThenable(state, jsctx, apiName, func() (*qjs.Value, error) {
+		select {
+		case <-call.done:
+		case <-ctx.Done():
+			// Awaiting must end with the run, even when the host call itself
+			// has not noticed the cancellation.
+			return nil, context.Cause(ctx)
+		}
+		if call.err != nil {
+			// Returning an error from the thenable job rejects the promise, so
+			// script-side try/catch and .catch() observe host failures normally.
+			return nil, call.err
+		}
+		value, err := encode(call.result)
+		// qjs v0.0.6 never unregisters the Go function backing a thenable, so
+		// this closure -- and everything it captures -- lives until the runtime
+		// closes. Dropping the payload once it has been converted to a JS value
+		// keeps a run that makes thousands of sequential calls from retaining
+		// every response body. The goroutine has finished by now, so nothing
+		// else is writing it, and the promise memoizes its value, so a repeat
+		// await never re-encodes.
+		var released T
+		call.result = released
+		return value, err
+	})
+}
+
+// adoptAsyncThenable builds the thenable that settles from settle and hands
+// back the promise that adopts it.
+func adoptAsyncThenable(
+	state *schedulerExecutionState,
+	jsctx *qjs.Context,
+	apiName string,
+	settle func() (*qjs.Value, error),
+) (*qjs.Value, error) {
+	handle := jsctx.NewObject()
+	handle.SetPropertyStr("then", jsctx.Function(func(inner *qjs.This) (*qjs.Value, error) {
+		value, err := settle()
+		if err != nil {
+			return nil, err
+		}
+		args := inner.Args()
+		if len(args) == 0 || !args[0].IsFunction() {
+			// The promise resolution procedure always supplies both callbacks,
+			// so this is unreachable through the returned promise. Reject
+			// rather than return a value: a then that settles neither callback
+			// leaves the promise pending forever, which would surface as a run
+			// that silently hangs until its deadline.
+			return nil, fmt.Errorf("%s handle was resolved without a fulfillment callback", apiName)
+		}
+		return jsctx.Invoke(args[0], jsctx.Global(), value)
+	}))
+
+	promise, err := state.promises.adopt(jsctx, handle)
+	if err != nil {
+		return nil, fmt.Errorf("adopt %s handle as a promise: %w", apiName, err)
+	}
+	return promise, nil
+}
+
+// registerAsyncCancel records work to stop once the script has finished.
+func (s *schedulerExecutionState) registerAsyncCancel(cancel context.CancelFunc) {
+	s.asyncCancels = append(s.asyncCancels, cancel)
+}
+
+// drainInflight ends every async host call this execution started and waits for
+// the goroutines to finish, so nothing is recorded against a run that has
+// already been torn down.
+//
+// Draining runs only after the script has returned, so anything still in flight
+// is abandoned by definition -- a handle the script awaited would have settled
+// before reaching here. Cancelling rather than waiting matters because leaveRun
+// is deferred until Execute returns: a fire-and-forget call that runs for
+// minutes would hold the scheduler's run slot for just as long, and under
+// concurrency_policy: skip every trigger arriving meanwhile is dropped.
+//
+// The wait is bounded whether or not the run itself was cancelled. A host that
+// ignores cancellation is abandoned instead, which can let a late call record
+// an event after teardown; that is the lesser failure, since waiting on it
+// would block Execute forever and wedge the scheduler.
+func (s *schedulerExecutionState) drainInflight() {
+	for _, cancel := range s.asyncCancels {
+		cancel()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.inflight.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(asyncDrainGrace):
+	}
+}
+
+// Scheduler env names that override the async concurrency budgets.
+const (
+	envMaxAsyncLLMConcurrency   = "LLM_MAX_CONCURRENCY"
+	envMaxAsyncAgentConcurrency = "AGENT_MAX_CONCURRENCY"
+)
+
+// AsyncConcurrencyFromSchedulerEnv reads the async concurrency budgets a
+// scheduler declares through its env items. A missing, unparsable, or
+// non-positive value yields zero, which leaves the engine on its defaults --
+// operators tune these, so a typo must not silently serialise or unleash a
+// scheduler.
+func AsyncConcurrencyFromSchedulerEnv(items []domain.SandboxEnvVar) (llm int, agent int) {
+	return positiveEnvInt(items, envMaxAsyncLLMConcurrency), positiveEnvInt(items, envMaxAsyncAgentConcurrency)
+}
+
+func positiveEnvInt(items []domain.SandboxEnvVar, name string) int {
+	for _, item := range items {
+		if !strings.EqualFold(strings.TrimSpace(item.Name), name) {
+			continue
+		}
+		value, err := strconv.Atoi(strings.TrimSpace(item.Value))
+		if err != nil || value <= 0 {
+			return 0
+		}
+		return value
+	}
+	return 0
+}

--- a/pkg/schedulers/engine_async_agent.go
+++ b/pkg/schedulers/engine_async_agent.go
@@ -1,0 +1,114 @@
+package schedulers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+
+	"github.com/fastschema/qjs"
+)
+
+// asyncAgentCall is one in-flight scheduler.agent.async call.
+type asyncAgentCall = asyncCall[domain.SchedulerAgentResult]
+
+// schedulerAgentInvocation is one parsed scheduler.agent call.
+type schedulerAgentInvocation struct {
+	prompt            string
+	options           domain.SchedulerAgentRequest
+	outputSchemaValue *qjs.Value
+}
+
+func (s *schedulerExecutionState) startAsyncAgent(invocation schedulerAgentInvocation) (*asyncAgentCall, error) {
+	return startAsyncHostCall(s.asyncCtx, s, asyncCallSpec[domain.SchedulerAgentResult]{
+		apiName: "scheduler.agent.async",
+		slot:    s.agentSem,
+		work: func(ctx context.Context) (domain.SchedulerAgentResult, error) {
+			return s.host.Agent(ctx, invocation.prompt, invocation.options)
+		},
+	})
+}
+
+// parseSchedulerAgentInvocation decodes the argument list shared by
+// scheduler.agent and scheduler.agent.async.
+func parseSchedulerAgentInvocation(
+	jsctx *qjs.Context,
+	state *schedulerExecutionState,
+	args []*qjs.Value,
+	apiName string,
+) (schedulerAgentInvocation, error) {
+	if len(args) == 0 {
+		return schedulerAgentInvocation{}, fmt.Errorf("%s requires a prompt", apiName)
+	}
+	prompt := strings.TrimSpace(args[0].String())
+	if prompt == "" {
+		return schedulerAgentInvocation{}, fmt.Errorf("%s requires a non-empty prompt", apiName)
+	}
+	options, err := parseSchedulerAgentRequest(args, state)
+	if err != nil {
+		return schedulerAgentInvocation{}, err
+	}
+	outputSchema, outputSchemaValue, err := parseSchedulerOutputSchema(jsctx, state.jsonEncoder, args, apiName)
+	if err != nil {
+		return schedulerAgentInvocation{}, err
+	}
+	options.OutputSchema = outputSchema
+	return schedulerAgentInvocation{prompt: prompt, options: options, outputSchemaValue: outputSchemaValue}, nil
+}
+
+// requireFreshSandboxForAsyncAgent pins an async agent call to its own sandbox.
+//
+// Parallel agents cannot share one: concurrent runs would write the same
+// workspace, and the classic agent path shuts its sandbox down when a call
+// finishes, so the first to complete would pull it out from under the others.
+// An unset policy therefore becomes "new", and an explicitly incompatible one
+// is rejected rather than silently reinterpreted.
+func requireFreshSandboxForAsyncAgent(options domain.SchedulerAgentRequest, apiName string) (domain.SchedulerAgentRequest, error) {
+	requested := strings.TrimSpace(AgentSandboxPolicy(options))
+	if requested == "" {
+		options.SandboxPolicy = domain.SchedulerSandboxPolicyNew
+		return options, nil
+	}
+	if NormalizeSandboxPolicy(requested) != domain.SchedulerSandboxPolicyNew {
+		return domain.SchedulerAgentRequest{}, fmt.Errorf(
+			"%s requires sandboxPolicy %q but received %q: parallel agents cannot share a sandbox",
+			apiName, domain.SchedulerSandboxPolicyNew, requested,
+		)
+	}
+	options.SandboxPolicy = domain.SchedulerSandboxPolicyNew
+	return options, nil
+}
+
+// encodeSchedulerAgentResult converts a host result into the JS value both
+// scheduler.agent and scheduler.agent.async hand back.
+func encodeSchedulerAgentResult(
+	jsctx *qjs.Context,
+	response domain.SchedulerAgentResult,
+	options domain.SchedulerAgentRequest,
+	outputSchemaValue *qjs.Value,
+) (*qjs.Value, error) {
+	hasSchema := strings.TrimSpace(options.OutputSchema) != ""
+	if hasSchema {
+		jsonValue, err := schedulerJSONResult(firstNonEmpty(response.FinalText, response.Text, response.Output), options.OutputSchema, "agent finalText")
+		if err != nil {
+			return nil, err
+		}
+		response.JSON = jsonValue
+	}
+	data, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("encode scheduler.agent response: %w", err)
+	}
+	value, err := payloadValueFromJSON(jsctx, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode scheduler.agent response: %w", err)
+	}
+	if hasSchema {
+		if err := validateSchedulerJSONWithSchema(jsctx, outputSchemaValue, value, "agent"); err != nil {
+			return nil, err
+		}
+	}
+	return value, nil
+}

--- a/pkg/schedulers/engine_async_llm.go
+++ b/pkg/schedulers/engine_async_llm.go
@@ -1,0 +1,384 @@
+package schedulers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	domain "agent-compose/pkg/model"
+
+	"github.com/fastschema/qjs"
+)
+
+// asyncLLMCall is one in-flight scheduler.llm.async call.
+type asyncLLMCall = asyncCall[domain.SchedulerLLMResult]
+
+// asyncLLMRace groups calls started together so the winner can be taken in
+// completion order. Standard Promise.race cannot do this here: its thenable
+// jobs run in queue order and each one blocks, so it always settles with the
+// first entry rather than the fastest.
+//
+// "First" means the first completion this group observes, not the strictly
+// earliest one: an entry reports itself on finished just after closing its done
+// channel, and preemption between those two steps can let a marginally slower
+// entry report first. That matches Promise semantics everywhere -- no
+// implementation promises strict completion time, only observation order -- and
+// the two suggested alternatives do not improve on it. Selecting over the done
+// channels picks pseudo-randomly among ready cases, and taking the lowest
+// completion sequence number would mean waiting for every entry, which is the
+// opposite of racing.
+type asyncLLMRace struct {
+	finished chan *asyncLLMCall
+	// byCall maps each started call back to the entry it came from, because
+	// entries carry their own model and outputSchema and the winner must be
+	// encoded with its own, not with the first entry's.
+	byCall map[*asyncLLMCall]schedulerLLMInvocation
+	total  int
+	// reported counts entries taken off finished so far, so what is left can be
+	// reaped once the group has settled.
+	reported int
+	// cancel stops the entries that did not win. Without it the run keeps
+	// paying for them: draining waits on every started call, so a failover
+	// racing a hung provider would still cost that provider's full latency.
+	cancel context.CancelFunc
+}
+
+// await returns the winning call together with the entry it came from. With
+// requireSuccess it keeps consuming completions until one succeeded, and
+// reports the last failure if none did.
+func (r *asyncLLMRace) await(ctx context.Context, requireSuccess bool) (*asyncLLMCall, schedulerLLMInvocation, error) {
+	var lastErr error
+	for received := 0; received < r.total; received++ {
+		var call *asyncLLMCall
+		select {
+		case call = <-r.finished:
+			r.reported++
+		case <-ctx.Done():
+			return nil, schedulerLLMInvocation{}, context.Cause(ctx)
+		}
+		if call.err == nil {
+			return call, r.byCall[call], nil
+		}
+		lastErr = call.err
+		if !requireSuccess {
+			return nil, schedulerLLMInvocation{}, call.err
+		}
+	}
+	return nil, schedulerLLMInvocation{}, lastErr
+}
+
+// releaseSettledResults drops the response bodies the group is still holding.
+//
+// qjs v0.0.6 never unregisters the Go function behind a thenable, so this
+// group -- and everything it captured -- lives until the runtime closes. A
+// script that races once per item over a long list would otherwise retain every
+// response body of every entry, winner and loser alike. Only settled calls are
+// touched: an entry still running owns its own result field.
+func (r *asyncLLMRace) releaseSettledResults() {
+	for {
+		select {
+		case call := <-r.finished:
+			r.reported++
+			r.release(call)
+		default:
+			for call := range r.byCall {
+				delete(r.byCall, call)
+			}
+			return
+		}
+	}
+}
+
+// reapLateEntries releases the bodies of entries that report after the group
+// settled.
+//
+// Cancelling the losers is asynchronous, so an entry can still be mid-call when
+// the group settles and reports a full response afterwards, straight into the
+// buffered channel that this group's closure holds. qjs v0.0.6 never
+// unregisters that closure, so without a reaper those bodies would sit there
+// until the runtime closes -- noticeable for a script running many racing
+// batches over large responses. The reaper exits with the execution, since
+// nothing is worth reclaiming once the runtime is about to go away.
+func (r *asyncLLMRace) reapLateEntries(ctx context.Context) {
+	remaining := r.total - r.reported
+	if remaining <= 0 {
+		return
+	}
+	go func() {
+		for range remaining {
+			select {
+			case call := <-r.finished:
+				r.release(call)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// release drops the response body of a call that has finished.
+func (r *asyncLLMRace) release(call *asyncLLMCall) {
+	var released domain.SchedulerLLMResult
+	call.result = released
+}
+
+// schedulerLLMInvocation is one parsed scheduler.llm call.
+type schedulerLLMInvocation struct {
+	prompt            string
+	options           domain.SchedulerLLMRequest
+	outputSchemaValue *qjs.Value
+}
+
+func (s *schedulerExecutionState) startAsyncLLM(ctx context.Context, apiName string, invocation schedulerLLMInvocation, slotHeld bool, notify chan<- *asyncLLMCall) (*asyncLLMCall, error) {
+	return startAsyncHostCall(ctx, s, asyncCallSpec[domain.SchedulerLLMResult]{
+		apiName:  apiName,
+		slot:     s.llmSem,
+		slotHeld: slotHeld,
+		notify:   notify,
+		work: func(callCtx context.Context) (domain.SchedulerLLMResult, error) {
+			return s.host.LLM(callCtx, invocation.prompt, invocation.options)
+		},
+	})
+}
+
+// reserveRaceSlots takes one concurrency slot per entry so that every entry of
+// a racing group is genuinely in flight.
+//
+// Letting entries queue on the shared budget would quietly reduce race and any
+// to "first listed": later entries would only start as earlier ones finish,
+// which is precisely the Promise.race behaviour these exist to replace. A group
+// the budget can never hold is rejected rather than answered with a plausible
+// but wrong winner.
+func (s *schedulerExecutionState) reserveRaceSlots(apiName string, count int) (*raceSlots, error) {
+	if budget := cap(s.llmSem); count > budget {
+		return nil, fmt.Errorf(
+			"%s cannot race %d entries with a concurrency budget of %d: every entry has to be in flight at once, so raise %s or race fewer entries",
+			apiName, count, budget, envMaxAsyncLLMConcurrency,
+		)
+	}
+	slots := &raceSlots{sem: s.llmSem}
+	for slots.held < count {
+		select {
+		case s.llmSem <- struct{}{}:
+			slots.held++
+		default:
+			// Waiting here would block the JS thread inside a Go channel
+			// operation, which QuickJS cannot interrupt -- its execution-time
+			// limit only fires between bytecodes -- so the run would hang with
+			// no way to report why. Refusing is also consistent with rejecting
+			// a group larger than the budget: in both cases the entries cannot
+			// all be in flight, so the group cannot race.
+			slots.releaseUnused()
+			return nil, fmt.Errorf(
+				"%s needs %d free concurrency slots but only %d of %d are available; await the calls already in flight before racing",
+				apiName, count, cap(s.llmSem)-len(s.llmSem), cap(s.llmSem),
+			)
+		}
+	}
+	return slots, nil
+}
+
+// raceSlots owns concurrency slots taken on behalf of a racing group until each
+// started entry takes over releasing its own.
+type raceSlots struct {
+	sem  chan struct{}
+	held int
+}
+
+// handOff transfers one slot to an entry that started successfully; that call
+// releases it when it finishes.
+func (r *raceSlots) handOff() {
+	if r.held > 0 {
+		r.held--
+	}
+}
+
+// releaseUnused returns slots no entry will claim, after an early failure.
+func (r *raceSlots) releaseUnused() {
+	for ; r.held > 0; r.held-- {
+		<-r.sem
+	}
+}
+
+// startAsyncLLMRace launches every invocation at once and returns a group whose
+// finished channel yields calls in completion order.
+func (s *schedulerExecutionState) startAsyncLLMRace(apiName string, invocations []schedulerLLMInvocation) (*asyncLLMRace, error) {
+	slots, err := s.reserveRaceSlots(apiName, len(invocations))
+	if err != nil {
+		return nil, err
+	}
+	// Each started entry takes over releasing its own slot; only slots left
+	// unused after an early failure are handed back here.
+	defer slots.releaseUnused()
+
+	raceCtx, cancel := context.WithCancel(s.asyncCtx)
+	// Settling cancels the losers promptly; registering also covers a group the
+	// script abandons, which never settles.
+	s.registerAsyncCancel(cancel)
+	race := &asyncLLMRace{
+		finished: make(chan *asyncLLMCall, len(invocations)),
+		byCall:   make(map[*asyncLLMCall]schedulerLLMInvocation, len(invocations)),
+		total:    len(invocations),
+		cancel:   cancel,
+	}
+	for _, invocation := range invocations {
+		// byCall is written here and read only from the thenable, which cannot
+		// run until this binding call has returned, so the map is complete
+		// before any read. The goroutines report through finished and never
+		// touch it.
+		call, err := s.startAsyncLLM(raceCtx, apiName, invocation, true, race.finished)
+		if err != nil {
+			// This entry never took its slot; the deferred release hands back
+			// every slot no entry claimed. Entries already started are
+			// cancelled at teardown through the registered cancel.
+			return nil, err
+		}
+		slots.handOff()
+		race.byCall[call] = invocation
+	}
+	return race, nil
+}
+
+// parseSchedulerLLMInvocation decodes the argument list shared by every
+// scheduler.llm entry point, so they cannot drift apart in how they read
+// prompts, options, or schemas.
+func parseSchedulerLLMInvocation(
+	jsctx *qjs.Context,
+	state *schedulerExecutionState,
+	args []*qjs.Value,
+	apiName string,
+) (schedulerLLMInvocation, error) {
+	if len(args) == 0 {
+		return schedulerLLMInvocation{}, fmt.Errorf("%s requires a prompt", apiName)
+	}
+	prompt := strings.TrimSpace(args[0].String())
+	if prompt == "" {
+		return schedulerLLMInvocation{}, fmt.Errorf("%s requires a non-empty prompt", apiName)
+	}
+	options, err := parseSchedulerLLMRequest(args, state)
+	if err != nil {
+		return schedulerLLMInvocation{}, err
+	}
+	outputSchema, outputSchemaValue, err := parseSchedulerOutputSchema(jsctx, state.jsonEncoder, args, apiName)
+	if err != nil {
+		return schedulerLLMInvocation{}, err
+	}
+	options.OutputSchema = outputSchema
+	return schedulerLLMInvocation{prompt: prompt, options: options, outputSchemaValue: outputSchemaValue}, nil
+}
+
+// parseSchedulerLLMRaceList decodes the array scheduler.llm.race and
+// scheduler.llm.any accept. An entry is either a prompt string or an object
+// carrying a prompt property alongside the usual scheduler.llm options, so
+// callers can race the same prompt across models.
+func parseSchedulerLLMRaceList(
+	jsctx *qjs.Context,
+	state *schedulerExecutionState,
+	args []*qjs.Value,
+	apiName string,
+) ([]schedulerLLMInvocation, error) {
+	if len(args) == 0 || args[0] == nil || !args[0].IsArray() {
+		return nil, fmt.Errorf("%s requires an array of prompts", apiName)
+	}
+	list := args[0]
+	length := list.Len()
+	if length == 0 {
+		return nil, fmt.Errorf("%s requires a non-empty array", apiName)
+	}
+	invocations := make([]schedulerLLMInvocation, 0, length)
+	for index := int64(0); index < length; index++ {
+		entry := list.GetPropertyIndex(index)
+		var entryArgs []*qjs.Value
+		switch {
+		case entry.IsString():
+			entryArgs = []*qjs.Value{entry}
+		case entry.IsObject() && !entry.IsArray():
+			prompt := entry.GetPropertyStr("prompt")
+			if !prompt.IsString() {
+				return nil, fmt.Errorf("%s entry %d requires a prompt", apiName, index)
+			}
+			// The entry doubles as the options object, so model and
+			// outputSchema are read exactly as scheduler.llm reads them.
+			entryArgs = []*qjs.Value{prompt, entry}
+		default:
+			// Without this an entry like null, 42, or an array would be
+			// stringified into a prompt and billed as a real call.
+			return nil, fmt.Errorf("%s entry %d must be a prompt string or an object with a prompt", apiName, index)
+		}
+		invocation, err := parseSchedulerLLMInvocation(jsctx, state, entryArgs, apiName)
+		if err != nil {
+			return nil, err
+		}
+		invocations = append(invocations, invocation)
+	}
+	return invocations, nil
+}
+
+// encodeSchedulerLLMResult converts a host result into the JS value every
+// scheduler.llm entry point hands back, applying outputSchema parsing and
+// validation identically.
+func encodeSchedulerLLMResult(
+	jsctx *qjs.Context,
+	response domain.SchedulerLLMResult,
+	options domain.SchedulerLLMRequest,
+	outputSchemaValue *qjs.Value,
+) (*qjs.Value, error) {
+	hasSchema := strings.TrimSpace(options.OutputSchema) != ""
+	if hasSchema {
+		jsonValue, err := schedulerJSONResult(response.Text, options.OutputSchema, "llm text")
+		if err != nil {
+			return nil, err
+		}
+		response.JSON = jsonValue
+	}
+	data, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("encode scheduler.llm response: %w", err)
+	}
+	value, err := payloadValueFromJSON(jsctx, string(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode scheduler.llm response: %w", err)
+	}
+	if hasSchema {
+		if err := validateSchedulerJSONWithSchema(jsctx, outputSchemaValue, value, "llm"); err != nil {
+			return nil, err
+		}
+	}
+	return value, nil
+}
+
+// newAsyncLLMRacePromise resolves from a racing group in completion order.
+// requireSuccess selects Promise.any semantics (skip rejections, reject only
+// once every call has failed) over Promise.race semantics (adopt the first
+// settled call, successful or not). Neither is reachable through the standard
+// combinators here, because their thenable jobs run in queue order and block.
+func newAsyncLLMRacePromise(
+	state *schedulerExecutionState,
+	jsctx *qjs.Context,
+	apiName string,
+	race *asyncLLMRace,
+	requireSuccess bool,
+) (*qjs.Value, error) {
+	ctx := state.ctx
+	return adoptAsyncThenable(state, jsctx, apiName, func() (*qjs.Value, error) {
+		winner, invocation, err := race.await(ctx, requireSuccess)
+		// Once the group has settled the remaining entries are dead weight.
+		// Cancelling before releasing keeps the window in which a loser can
+		// still finish with a full body as short as possible.
+		race.cancel()
+		// Deferred in reverse order of execution: the winner is released first,
+		// then whatever already reported, then a reaper picks up stragglers.
+		defer race.reapLateEntries(state.ctx)
+		// Deferred so the bodies are dropped on the failure paths too: race
+		// settling with a rejection, and any exhausting every entry.
+		defer race.releaseSettledResults()
+		if err != nil {
+			return nil, err
+		}
+		// await took the winner out of the finished channel, so release it here
+		// rather than leaving the largest body of the group behind.
+		defer race.release(winner)
+		return encodeSchedulerLLMResult(jsctx, winner.result, invocation.options, invocation.outputSchemaValue)
+	})
+}

--- a/pkg/schedulers/engine_async_sleep.go
+++ b/pkg/schedulers/engine_async_sleep.go
@@ -1,0 +1,88 @@
+package schedulers
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/fastschema/qjs"
+)
+
+// maxSleepMilliseconds is the largest millisecond value that still fits in a
+// time.Duration once scaled to nanoseconds.
+const maxSleepMilliseconds = int64(math.MaxInt64) / int64(time.Millisecond)
+
+// asyncSleepCall is one pending scheduler.sleep.async delay.
+type asyncSleepCall = asyncCall[struct{}]
+
+// startAsyncSleep waits out d on its own goroutine so a script can overlap a
+// delay with other async work.
+//
+// Unlike a host call a sleep takes no concurrency slot and is not tracked for
+// draining. It reaches neither the host nor the database, so there is no result
+// that could be recorded against a finished run -- the reason draining exists.
+// Joining one would instead let a script stall its own run long after main()
+// returned, simply by never awaiting the handle.
+func (s *schedulerExecutionState) startAsyncSleep(d time.Duration) (*asyncSleepCall, error) {
+	// A sleep costs a goroutine like any other handle, so it is admitted
+	// against the same ceiling even though it is not drained.
+	if err := s.reserveAsyncCall("scheduler.sleep.async"); err != nil {
+		return nil, err
+	}
+	call := &asyncSleepCall{done: make(chan struct{})}
+	go func() {
+		defer s.releaseAsyncCall()
+		defer close(call.done)
+		call.err = sleepWithContext(s.asyncCtx, d)
+	}()
+	return call, nil
+}
+
+// sleepWithContext waits out d, returning early if the run is cancelled.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+// newAsyncSleepPromise adopts a pending sleep as a promise resolving to
+// undefined, so it composes with Promise.all like any other async handle.
+func newAsyncSleepPromise(state *schedulerExecutionState, jsctx *qjs.Context, call *asyncSleepCall) (*qjs.Value, error) {
+	return newAsyncPromise(state, jsctx, "scheduler.sleep.async", call, func(struct{}) (*qjs.Value, error) {
+		return jsctx.NewUndefined(), nil
+	})
+}
+
+// parseSchedulerSleepDuration reads the millisecond argument shared by
+// scheduler.sleep and scheduler.sleep.async.
+func parseSchedulerSleepDuration(args []*qjs.Value, apiName string) (time.Duration, error) {
+	if len(args) == 0 || args[0] == nil || !args[0].IsNumber() {
+		return 0, fmt.Errorf("%s requires a duration in milliseconds", apiName)
+	}
+	ms := args[0].Int64()
+	if ms <= 0 {
+		return 0, fmt.Errorf("%s requires a positive duration", apiName)
+	}
+	// time.Duration counts nanoseconds, so the millisecond value overflows
+	// int64 long before the number itself does. Left unchecked the product
+	// wraps, turning an absurd request into an instant no-op or an arbitrary
+	// wait instead of an error.
+	if ms > maxSleepMilliseconds {
+		return 0, fmt.Errorf("%s duration %d ms is out of range (max %d)", apiName, ms, maxSleepMilliseconds)
+	}
+	return time.Duration(ms) * time.Millisecond, nil
+}
+
+// skipsDelays reports whether this execution should return from a sleep at once.
+// Validation collects triggers from the script's top level, and a dry run only
+// observes the requests a script would make; in both the script is not doing
+// real work, so its pacing must not stall the caller.
+func (s *schedulerExecutionState) skipsDelays() bool {
+	return s.host == nil || s.dryRun
+}

--- a/pkg/schedulers/engine_async_test.go
+++ b/pkg/schedulers/engine_async_test.go
@@ -494,6 +494,8 @@ func TestAsyncConcurrencyFromSchedulerEnv(t *testing.T) {
 		{name: "name matching ignores case", items: env("llm_max_concurrency", "5"), wantLLM: 5},
 		{name: "non numeric is ignored", items: env("LLM_MAX_CONCURRENCY", "lots")},
 		{name: "non positive is ignored", items: env("AGENT_MAX_CONCURRENCY", "0")},
+		{name: "invalid exact-name entry does not hide valid case variant", items: env("LLM_MAX_CONCURRENCY", "lots", "llm_max_concurrency", "6"), wantLLM: 6},
+		{name: "invalid later entry does not override valid earlier one", items: env("LLM_MAX_CONCURRENCY", "7", "llm_max_concurrency", "lots"), wantLLM: 7},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			llm, agent := AsyncConcurrencyFromSchedulerEnv(tc.items)

--- a/pkg/schedulers/engine_async_test.go
+++ b/pkg/schedulers/engine_async_test.go
@@ -1,0 +1,1091 @@
+package schedulers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestSchedulerLLMAsyncResolvesToSameResultAsSyncCall(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const syncResult = scheduler.llm("answer");
+  const asyncResult = await scheduler.llm.async("answer");
+  return { sync: syncResult.text, async: asyncResult.text };
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	const want = `{"sync":"llm-output","async":"llm-output"}`
+	if result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+// concurrencyProbeHost records how many LLM calls are in flight at once, so
+// tests can assert on real overlap instead of on wall-clock timing.
+type concurrencyProbeHost struct {
+	coverageEngineHost
+	delay time.Duration
+
+	mu      sync.Mutex
+	live    int
+	peak    int
+	nCalls  int
+	prompts []string
+}
+
+func (h *concurrencyProbeHost) LLM(_ context.Context, prompt string, _ domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	h.mu.Lock()
+	h.live++
+	h.nCalls++
+	h.prompts = append(h.prompts, prompt)
+	if h.live > h.peak {
+		h.peak = h.live
+	}
+	h.mu.Unlock()
+
+	time.Sleep(h.delay)
+
+	h.mu.Lock()
+	h.live--
+	h.mu.Unlock()
+	return domain.SchedulerLLMResult{Text: "out:" + prompt}, nil
+}
+
+func (h *concurrencyProbeHost) peakInFlight() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.peak
+}
+
+func TestSchedulerLLMAsyncRunsPromiseAllBatchConcurrently(t *testing.T) {
+	host := &concurrencyProbeHost{delay: 50 * time.Millisecond}
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const results = await Promise.all(["a", "b", "c"].map(p => scheduler.llm.async(p)));
+  return results.map(r => r.text);
+}`,
+	}, host)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `["out:a","out:b","out:c"]`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+	if peak := host.peakInFlight(); peak != 3 {
+		t.Fatalf("peak in-flight LLM calls = %d, want 3 (1 means the batch ran serially)", peak)
+	}
+}
+
+func (h *concurrencyProbeHost) liveInFlight() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.live
+}
+
+func TestSchedulerLLMAsyncDrainsUnawaitedCallsBeforeExecuteReturns(t *testing.T) {
+	host := &concurrencyProbeHost{delay: 50 * time.Millisecond}
+	_, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  scheduler.llm.async("orphan");
+  return "returned without awaiting";
+}`,
+	}, host)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// A handle the script never awaits must still be settled before the run
+	// finishes: otherwise the host keeps recording events for a run that has
+	// already been torn down.
+	if live := host.liveInFlight(); live != 0 {
+		t.Fatalf("in-flight LLM calls after Execute returned = %d, want 0", live)
+	}
+}
+
+func TestSchedulerLLMAsyncRespectsMaxAsyncConcurrency(t *testing.T) {
+	host := &concurrencyProbeHost{delay: 30 * time.Millisecond}
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime:                domain.SchedulerRuntimeScheduler,
+		MaxAsyncLLMConcurrency: 2,
+		Script: `
+async function main() {
+  const prompts = ["a", "b", "c", "d", "e", "f"];
+  const results = await Promise.all(prompts.map(p => scheduler.llm.async(p)));
+  return results.length;
+}`,
+	}, host)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != "6" {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, "6")
+	}
+	if peak := host.peakInFlight(); peak > 2 {
+		t.Fatalf("peak in-flight LLM calls = %d, want at most 2", peak)
+	}
+}
+
+type failingLLMHost struct{ coverageEngineHost }
+
+func (h *failingLLMHost) LLM(context.Context, string, domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	return domain.SchedulerLLMResult{}, errors.New("llm upstream exploded")
+}
+
+func TestSchedulerLLMAsyncHostErrorRejectsAndIsCatchable(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  try {
+    await scheduler.llm.async("x");
+    return "resolved without rejecting";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+	}, &failingLLMHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(result.ResultJSON, "llm upstream exploded") {
+		t.Fatalf("ResultJSON = %q, want a caught rejection mentioning the host error", result.ResultJSON)
+	}
+}
+
+func TestSchedulerLLMAsyncHandleSupportsCatch(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  return await scheduler.llm.async("x").catch(function (e) { return "caught: " + String(e); });
+}`,
+	}, &failingLLMHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(result.ResultJSON, "llm upstream exploded") {
+		t.Fatalf("ResultJSON = %q, want the rejection handled by .catch()", result.ResultJSON)
+	}
+}
+
+// ctxIgnoringHost blocks until the test releases it, ignoring cancellation, to
+// model a downstream client that does not honour ctx. entered reports when a
+// call is genuinely in progress, so tests cancel at a known point instead of
+// racing engine start-up.
+type ctxIgnoringHost struct {
+	coverageEngineHost
+	release chan struct{}
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (h *ctxIgnoringHost) LLM(context.Context, string, domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	h.once.Do(func() { close(h.entered) })
+	<-h.release
+	return domain.SchedulerLLMResult{Text: "late"}, nil
+}
+
+// StateGet blocks until an async LLM call is genuinely inside the host, giving
+// a script a synchronous way to wait for that without racing goroutine start-up.
+func (h *ctxIgnoringHost) StateGet(context.Context, string) (string, bool, error) {
+	<-h.entered
+	return "", false, nil
+}
+
+func TestSchedulerLLMAsyncDoesNotWedgeRunWhenHostIgnoresCancellation(t *testing.T) {
+	host := &ctxIgnoringHost{release: make(chan struct{}), entered: make(chan struct{})}
+	defer close(host.release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		// Cancel only once the host call is actually in progress, so the test
+		// exercises cancellation mid-call rather than during engine start-up.
+		<-host.entered
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := (&QJSSchedulerEngine{}).Execute(ctx, SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  await scheduler.llm.async("x");
+  return "should not get here";
+}`,
+	}, host)
+	elapsed := time.Since(start)
+
+	select {
+	case <-host.entered:
+	default:
+		t.Fatalf("host LLM was never called; the test did not reach the cancellation path")
+	}
+	if err == nil {
+		t.Fatalf("Execute returned no error, want a cancellation error")
+	}
+	// The run must give up on a host call that ignores cancellation instead of
+	// waiting on it forever; otherwise one bad downstream wedges the scheduler.
+	if elapsed > 20*time.Second {
+		t.Fatalf("Execute took %v after cancellation; the run was wedged", elapsed)
+	}
+}
+
+// variableDelayHost derives its latency from the prompt so tests can express
+// "this one is slower" without depending on wall-clock tuning.
+type variableDelayHost struct {
+	coverageEngineHost
+	mu      sync.Mutex
+	prompts []string
+}
+
+func (h *variableDelayHost) LLM(_ context.Context, prompt string, request domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	h.mu.Lock()
+	h.prompts = append(h.prompts, prompt)
+	h.mu.Unlock()
+	if strings.HasPrefix(prompt, "slow") {
+		time.Sleep(300 * time.Millisecond)
+	} else {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if strings.HasPrefix(prompt, "boom") {
+		return domain.SchedulerLLMResult{}, errors.New("upstream refused " + prompt)
+	}
+	return domain.SchedulerLLMResult{Text: "out:" + prompt, Model: request.Model}, nil
+}
+
+func TestSchedulerLLMRaceResolvesWithFastestCallNotFirstListed(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const winner = await scheduler.llm.race(["slow-one", "fast-one"]);
+  return winner.text;
+}`,
+	}, &variableDelayHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// Standard Promise.race settles with whichever thenable the job queue
+	// reaches first, which is the first array entry. scheduler.llm.race must
+	// settle with the call that actually finished first.
+	if want := `"out:fast-one"`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestSchedulerLLMAnySkipsFastFailureAndResolvesWithSlowSuccess(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const winner = await scheduler.llm.any(["boom-fast", "slow-one"]);
+  return winner.text;
+}`,
+	}, &variableDelayHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// The fast entry settles first but rejects; any must keep waiting for a
+	// fulfilled call rather than adopting the first settled one.
+	if want := `"out:slow-one"`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestSchedulerLLMAnyRejectsWhenEveryCallFails(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  try {
+    await scheduler.llm.any(["boom-a", "boom-b"]);
+    return "resolved without rejecting";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+	}, &variableDelayHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(result.ResultJSON, "upstream refused") {
+		t.Fatalf("ResultJSON = %q, want a rejection after every call failed", result.ResultJSON)
+	}
+}
+
+func TestSchedulerSleepBlocksForTheRequestedDuration(t *testing.T) {
+	// Measured inside the script so engine start-up cannot mask a no-op sleep.
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const startedAt = Date.now();
+  scheduler.sleep(80);
+  return Date.now() - startedAt >= 80;
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != "true" {
+		t.Fatalf("ResultJSON = %q, want %q (scheduler.sleep did not delay)", result.ResultJSON, "true")
+	}
+}
+
+func TestSchedulerSleepAsyncOverlapsInsidePromiseAll(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const startedAt = Date.now();
+  await Promise.all([scheduler.sleep.async(150), scheduler.sleep.async(150)]);
+  const elapsed = Date.now() - startedAt;
+  return { overlapped: elapsed < 280, elapsedAtLeast: elapsed >= 150 };
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `{"overlapped":true,"elapsedAtLeast":true}`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+// agentProbeHost records agent concurrency and the sandbox policy each call
+// resolved to.
+type agentProbeHost struct {
+	coverageEngineHost
+	delay time.Duration
+
+	mu       sync.Mutex
+	live     int
+	peak     int
+	policies []string
+}
+
+func (h *agentProbeHost) Agent(_ context.Context, prompt string, request domain.SchedulerAgentRequest) (domain.SchedulerAgentResult, error) {
+	h.mu.Lock()
+	h.live++
+	if h.live > h.peak {
+		h.peak = h.live
+	}
+	h.policies = append(h.policies, request.SandboxPolicy)
+	h.mu.Unlock()
+
+	time.Sleep(h.delay)
+
+	h.mu.Lock()
+	h.live--
+	h.mu.Unlock()
+	return domain.SchedulerAgentResult{Text: "agent:" + prompt, FinalText: "agent:" + prompt, Success: true}, nil
+}
+
+func (h *agentProbeHost) snapshot() (int, []string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.peak, append([]string(nil), h.policies...)
+}
+
+func TestSchedulerAgentAsyncRunsBatchConcurrentlyWithFreshSandboxes(t *testing.T) {
+	host := &agentProbeHost{delay: 50 * time.Millisecond}
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const results = await Promise.all(["a", "b", "c"].map(p => scheduler.agent.async(p)));
+  return results.map(r => r.text);
+}`,
+	}, host)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `["agent:a","agent:b","agent:c"]`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+	peak, policies := host.snapshot()
+	if peak != 3 {
+		t.Fatalf("peak in-flight agent calls = %d, want 3", peak)
+	}
+	// Parallel agents cannot share a sticky sandbox: concurrent runs would
+	// write the same workspace, and the first to finish shuts the sandbox down.
+	for i, policy := range policies {
+		if policy != domain.SchedulerSandboxPolicyNew {
+			t.Fatalf("agent call %d used sandbox policy %q, want %q", i, policy, domain.SchedulerSandboxPolicyNew)
+		}
+	}
+}
+
+func TestSchedulerAgentAsyncRejectsStickySandboxPolicy(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  try {
+    await scheduler.agent.async("a", { sandboxPolicy: "sticky" });
+    return "accepted sticky";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+	}, &agentProbeHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(result.ResultJSON, "sandboxPolicy") {
+		t.Fatalf("ResultJSON = %q, want a rejection naming sandboxPolicy", result.ResultJSON)
+	}
+}
+
+func TestSchedulerAgentAsyncUsesConservativeDefaultConcurrency(t *testing.T) {
+	host := &agentProbeHost{delay: 30 * time.Millisecond}
+	_, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const prompts = ["a", "b", "c", "d", "e", "f"];
+  return (await Promise.all(prompts.map(p => scheduler.agent.async(p)))).length;
+}`,
+	}, host)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// Each parallel agent is a fresh sandbox, so the default ceiling is much
+	// lower than for plain LLM calls: sandbox creation has no limit of its own
+	// and the SQLite pool defaults to four connections.
+	peak, _ := host.snapshot()
+	if peak > DefaultMaxAsyncAgentConcurrency {
+		t.Fatalf("peak in-flight agent calls = %d, want at most %d", peak, DefaultMaxAsyncAgentConcurrency)
+	}
+}
+
+func TestAsyncConcurrencyFromSchedulerEnv(t *testing.T) {
+	env := func(pairs ...string) []domain.SandboxEnvVar {
+		items := make([]domain.SandboxEnvVar, 0, len(pairs)/2)
+		for i := 0; i+1 < len(pairs); i += 2 {
+			items = append(items, domain.SandboxEnvVar{Name: pairs[i], Value: pairs[i+1]})
+		}
+		return items
+	}
+	for _, tc := range []struct {
+		name      string
+		items     []domain.SandboxEnvVar
+		wantLLM   int
+		wantAgent int
+	}{
+		{name: "unset falls back to zero so the engine picks its defaults"},
+		{name: "both set", items: env("LLM_MAX_CONCURRENCY", "12", "AGENT_MAX_CONCURRENCY", "2"), wantLLM: 12, wantAgent: 2},
+		{name: "only llm set", items: env("LLM_MAX_CONCURRENCY", "4"), wantLLM: 4},
+		{name: "name matching ignores case", items: env("llm_max_concurrency", "5"), wantLLM: 5},
+		{name: "non numeric is ignored", items: env("LLM_MAX_CONCURRENCY", "lots")},
+		{name: "non positive is ignored", items: env("AGENT_MAX_CONCURRENCY", "0")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			llm, agent := AsyncConcurrencyFromSchedulerEnv(tc.items)
+			if llm != tc.wantLLM || agent != tc.wantAgent {
+				t.Fatalf("AsyncConcurrencyFromSchedulerEnv() = (%d, %d), want (%d, %d)", llm, agent, tc.wantLLM, tc.wantAgent)
+			}
+		})
+	}
+}
+
+// schemaRaceHost answers the fast prompt with JSON and the slow one with plain
+// text, so a test can tell which entry's outputSchema was applied.
+type schemaRaceHost struct{ coverageEngineHost }
+
+func (h *schemaRaceHost) LLM(_ context.Context, prompt string, _ domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	if strings.HasPrefix(prompt, "slow") {
+		time.Sleep(300 * time.Millisecond)
+		return domain.SchedulerLLMResult{Text: "plain text"}, nil
+	}
+	time.Sleep(10 * time.Millisecond)
+	return domain.SchedulerLLMResult{Text: `{"ok":true}`}, nil
+}
+
+func TestSchedulerLLMRaceAppliesTheWinnersOutputSchema(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const Shape = scheduler.z.object({ ok: scheduler.z.boolean() });
+  const winner = await scheduler.llm.race([
+    "slow-plain",
+    { prompt: "fast-json", outputSchema: Shape },
+  ]);
+  return { json: winner.json };
+}`,
+	}, &schemaRaceHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// The winning entry carries the schema; encoding it with the first entry's
+	// (absent) schema would silently drop the parsed json field.
+	if want := `{"json":{"ok":true}}`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestSchedulerSleepDoesNotBlockValidation(t *testing.T) {
+	// Validation evaluates the script's top level to collect triggers. A sleep
+	// there must not hold saving the scheduler hostage for its full duration.
+	done := make(chan error, 1)
+	go func() {
+		_, err := (&QJSSchedulerEngine{}).Validate(context.Background(), domain.SchedulerRuntimeScheduler, `
+scheduler.sleep(600000);
+function main() { return "ok"; }`)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Validate returned error: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("Validate did not return; a top-level scheduler.sleep blocked it")
+	}
+}
+
+func TestSchedulerLLMAsyncAppliesInlineOutputSchema(t *testing.T) {
+	// The schema value is read during the binding call but used when the
+	// thenable settles. Nothing in the script retains it here, so this locks in
+	// that holding it across the suspension is safe.
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const answer = await scheduler.llm.async("answer", {
+    outputSchema: scheduler.z.object({ summary: scheduler.z.string(), risk: scheduler.z.enum(["low", "high"]) }),
+  });
+  return answer.json;
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `{"risk":"low","summary":"ok"}`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestSchedulerSleepRejectsDurationThatOverflows(t *testing.T) {
+	// time.Duration(ms) * time.Millisecond overflows int64 well before the
+	// number itself does, turning an absurd request into an instant no-op or an
+	// arbitrary wait instead of an error.
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  try {
+    scheduler.sleep(9223372036855);
+    return "accepted";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(result.ResultJSON, "caught:") {
+		t.Fatalf("ResultJSON = %q, want an error for an out-of-range duration", result.ResultJSON)
+	}
+}
+
+func TestSchedulerLLMRaceRejectsNonPromptEntries(t *testing.T) {
+	for _, entry := range []string{"null", "42", `["a"]`, "undefined"} {
+		t.Run(entry, func(t *testing.T) {
+			host := &concurrencyProbeHost{}
+			result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+				Runtime: domain.SchedulerRuntimeScheduler,
+				Script: `
+async function main() {
+  try {
+    await scheduler.llm.race([` + entry + `]);
+    return "accepted";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+			}, host)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if !strings.Contains(result.ResultJSON, "caught:") {
+				t.Fatalf("ResultJSON = %q, want an error for a non-prompt entry", result.ResultJSON)
+			}
+			// A rejected entry must never reach the provider: these calls bill.
+			if _, prompts := host.snapshotPrompts(); len(prompts) != 0 {
+				t.Fatalf("host received prompts %v, want none", prompts)
+			}
+		})
+	}
+}
+
+func (h *concurrencyProbeHost) snapshotPrompts() (int, []string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.nCalls, append([]string(nil), h.prompts...)
+}
+
+func TestSchedulerSleepAsyncDoesNotHoldTheRunOpenWhenNotAwaited(t *testing.T) {
+	start := time.Now()
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  scheduler.sleep.async(30000);
+  return "returned without awaiting";
+}`,
+	}, &coverageEngineHost{})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != `"returned without awaiting"` {
+		t.Fatalf("ResultJSON = %q", result.ResultJSON)
+	}
+	// A sleep records nothing with the host, so unlike a real host call there is
+	// nothing to drain at teardown; joining one would let a script stall its own
+	// run long after main() returned.
+	if elapsed > 20*time.Second {
+		t.Fatalf("Execute took %v; an unawaited sleep held the run open", elapsed)
+	}
+}
+
+// raceLoserHost answers the fast prompt at once and makes the slow one block
+// until either the test releases it or its context is cancelled.
+type raceLoserHost struct {
+	coverageEngineHost
+	release chan struct{}
+}
+
+func (h *raceLoserHost) LLM(ctx context.Context, prompt string, _ domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	if strings.HasPrefix(prompt, "slow") {
+		select {
+		case <-h.release:
+		case <-ctx.Done():
+			return domain.SchedulerLLMResult{}, ctx.Err()
+		}
+	}
+	return domain.SchedulerLLMResult{Text: "out:" + prompt}, nil
+}
+
+func TestSchedulerLLMRaceCancelsLosingCalls(t *testing.T) {
+	host := &raceLoserHost{release: make(chan struct{})}
+	defer close(host.release)
+
+	start := time.Now()
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const winner = await scheduler.llm.race(["slow-a", "fast-b"]);
+  return winner.text;
+}`,
+	}, host)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `"out:fast-b"`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+	// The loser is never released by the test, so the run can only finish if
+	// deciding a winner cancelled it. Otherwise draining waits on it forever.
+	if elapsed > 25*time.Second {
+		t.Fatalf("Execute took %v; the losing call was not cancelled", elapsed)
+	}
+}
+
+func TestSchedulerAsyncUsesCapturedPromiseResolve(t *testing.T) {
+	// The engine already captures JSON.stringify before user code runs so a
+	// script cannot change its serialization. Promise adoption needs the same
+	// treatment: reading Promise.resolve off the global at call time lets a
+	// script decide what every async binding hands back.
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  Promise.resolve = function () { return "hijacked"; };
+  const answer = await scheduler.llm.async("answer");
+  return answer.text;
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `"llm-output"`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestSchedulerLLMRaceCancelsLosersEvenWhenNeverAwaited(t *testing.T) {
+	host := &raceLoserHost{release: make(chan struct{})}
+	defer close(host.release)
+
+	start := time.Now()
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  scheduler.llm.race(["slow-a", "fast-b"]);
+  return "never awaited the race";
+}`,
+	}, host)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != `"never awaited the race"` {
+		t.Fatalf("ResultJSON = %q", result.ResultJSON)
+	}
+	// Cancelling the losers only when the group settles leaves them running
+	// whenever the script never awaits the promise, so the run pays their full
+	// latency and the failover property is lost exactly when it is least
+	// visible.
+	if elapsed > 25*time.Second {
+		t.Fatalf("Execute took %v; the losing calls outlived an abandoned race", elapsed)
+	}
+}
+
+// blockingFirstCallHost holds only its first call for a while and answers the
+// rest at once. With a concurrency limit of one that keeps every later handle
+// parked, so handles accumulate as genuinely outstanding instead of settling as
+// fast as the script creates them -- and the run still finishes promptly.
+type blockingFirstCallHost struct {
+	coverageEngineHost
+	hold time.Duration
+	once sync.Once
+}
+
+func (h *blockingFirstCallHost) LLM(ctx context.Context, prompt string, _ domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	h.once.Do(func() {
+		select {
+		case <-time.After(h.hold):
+		case <-ctx.Done():
+		}
+	})
+	return domain.SchedulerLLMResult{Text: "out:" + prompt}, nil
+}
+
+func TestSchedulerLLMAsyncRejectsFanOutBeyondOutstandingLimit(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime:                domain.SchedulerRuntimeScheduler,
+		MaxAsyncLLMConcurrency: 1,
+		Script: fmt.Sprintf(`
+async function main() {
+  const handles = [];
+  try {
+    for (let i = 0; i < %d; i++) handles.push(scheduler.llm.async("p" + i));
+    return "accepted";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`, maxOutstandingAsyncCalls+1),
+	}, &blockingFirstCallHost{hold: 8 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// The concurrency limit gates how many calls run at once, but each pending
+	// handle still costs a goroutine and its stack, which lives outside the
+	// QuickJS memory limit. Without a ceiling a long array turns script input
+	// straight into hundreds of megabytes.
+	if !strings.Contains(result.ResultJSON, "calls outstanding") {
+		t.Fatalf("ResultJSON = %q, want the outstanding-calls rejection", result.ResultJSON)
+	}
+}
+
+// panickingHost models a host implementation that panics rather than returning
+// an error. The synchronous bindings survive it because qjs turns a panic
+// inside a proxied function into a JS exception; an async call runs on its own
+// goroutine, where an unrecovered panic would take the whole daemon down.
+type panickingHost struct{ coverageEngineHost }
+
+func (h *panickingHost) LLM(context.Context, string, domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	panic("host exploded")
+}
+
+func TestSchedulerLLMAsyncTurnsHostPanicIntoRejection(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  try {
+    await scheduler.llm.async("x");
+    return "resolved without rejecting";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+	}, &panickingHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(result.ResultJSON, "host exploded") {
+		t.Fatalf("ResultJSON = %q, want the panic surfaced as a rejection", result.ResultJSON)
+	}
+}
+
+func TestSchedulerLLMRaceRejectsGroupLargerThanConcurrencyBudget(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime:                domain.SchedulerRuntimeScheduler,
+		MaxAsyncLLMConcurrency: 1,
+		Script: `
+async function main() {
+  try {
+    const winner = await scheduler.llm.race(["slow-one", "fast-one"]);
+    return "accepted: " + winner.text;
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+	}, &variableDelayHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// A group whose entries cannot all be in flight cannot race: the later ones
+	// only start as earlier ones finish, so the combinator degrades into the
+	// "first listed" behaviour it exists to avoid. Failing loudly beats
+	// returning a plausible but wrong winner.
+	if !strings.Contains(result.ResultJSON, "caught:") {
+		t.Fatalf("ResultJSON = %q, want a rejection when the budget cannot hold the group", result.ResultJSON)
+	}
+}
+
+func TestSchedulerLLMRaceStillPicksFastestWhenBudgetExactlyFitsGroup(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime:                domain.SchedulerRuntimeScheduler,
+		MaxAsyncLLMConcurrency: 2,
+		Script: `
+async function main() {
+  return (await scheduler.llm.race(["slow-one", "fast-one"])).text;
+}`,
+	}, &variableDelayHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `"out:fast-one"`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestSchedulerLLMAsyncHandleCanBeAwaitedRepeatedly(t *testing.T) {
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const handle = scheduler.llm.async("answer");
+  const first = await handle;
+  const second = await handle;
+  return [first.text, second.text];
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `["llm-output","llm-output"]`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+// ctxAwareSlowHost takes a long time but honours cancellation. When entered is
+// set it reports each arrival, so a script can wait for calls to be genuinely
+// inside the host -- and therefore holding their concurrency slots -- instead of
+// racing goroutine start-up.
+type ctxAwareSlowHost struct {
+	coverageEngineHost
+	hold    time.Duration
+	entered chan struct{}
+}
+
+func (h *ctxAwareSlowHost) LLM(ctx context.Context, prompt string, _ domain.SchedulerLLMRequest) (domain.SchedulerLLMResult, error) {
+	if h.entered != nil {
+		h.entered <- struct{}{}
+	}
+	select {
+	case <-time.After(h.hold):
+		return domain.SchedulerLLMResult{Text: "out:" + prompt}, nil
+	case <-ctx.Done():
+		return domain.SchedulerLLMResult{}, ctx.Err()
+	}
+}
+
+// StateGet blocks until the number of calls named by key have entered the host.
+func (h *ctxAwareSlowHost) StateGet(_ context.Context, key string) (string, bool, error) {
+	want, err := strconv.Atoi(strings.TrimSpace(key))
+	if err != nil {
+		return "", false, err
+	}
+	for range want {
+		<-h.entered
+	}
+	return "", false, nil
+}
+
+func TestSchedulerLLMAsyncCancelsUnawaitedCallsInsteadOfWaitingThemOut(t *testing.T) {
+	host := &ctxAwareSlowHost{hold: 60 * time.Second}
+
+	start := time.Now()
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  scheduler.llm.async("slow");
+  return "returned without awaiting";
+}`,
+	}, host)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != `"returned without awaiting"` {
+		t.Fatalf("ResultJSON = %q", result.ResultJSON)
+	}
+	// Draining runs after the script has finished, so anything still in flight
+	// is abandoned by definition. Waiting it out holds the scheduler's run slot
+	// -- leaveRun is deferred until Execute returns -- so a fire-and-forget call
+	// would keep skipping later triggers under concurrency_policy: skip.
+	if elapsed > 30*time.Second {
+		t.Fatalf("Execute took %v; an abandoned call was waited out instead of cancelled", elapsed)
+	}
+}
+
+func TestSchedulerLLMAsyncAbandonsUnawaitedCallThatIgnoresCancellation(t *testing.T) {
+	host := &ctxIgnoringHost{release: make(chan struct{}), entered: make(chan struct{})}
+	defer close(host.release)
+
+	start := time.Now()
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  scheduler.llm.async("ignores-cancellation");
+  // Blocks until that call is inside the host, so the run reaches teardown
+  // with a genuinely in-flight call rather than one cancelled before it began.
+  scheduler.state.get("wait-for-async-call");
+  return "returned without awaiting";
+}`,
+	}, host)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.ResultJSON != `"returned without awaiting"` {
+		t.Fatalf("ResultJSON = %q", result.ResultJSON)
+	}
+	select {
+	case <-host.entered:
+	default:
+		t.Fatalf("host LLM was never called; the test did not reach the drain path")
+	}
+	// The run itself is never cancelled here, so a drain that only bounds its
+	// wait after cancellation blocks forever on a downstream that ignores ctx.
+	if elapsed > 30*time.Second {
+		t.Fatalf("Execute took %v; the drain waited on a call that ignores cancellation", elapsed)
+	}
+}
+
+func TestSchedulerLLMRaceRejectsWhenBudgetIsHeldByUnawaitedCalls(t *testing.T) {
+	host := &ctxAwareSlowHost{hold: 60 * time.Second, entered: make(chan struct{}, 4)}
+
+	start := time.Now()
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime:                domain.SchedulerRuntimeScheduler,
+		MaxAsyncLLMConcurrency: 2,
+		Script: `
+async function main() {
+  scheduler.llm.async("hold-a");
+  scheduler.llm.async("hold-b");
+  // Blocks until both are inside the host, so the budget is genuinely held
+  // rather than merely about to be.
+  scheduler.state.get("2");
+  try {
+    await scheduler.llm.race(["x", "y"]);
+    return "accepted";
+  } catch (e) {
+    return "caught: " + String(e);
+  }
+}`,
+	}, host)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	// Taking the slots must not block the JS thread: QuickJS only interrupts on
+	// bytecode, so its execution-time limit cannot break a Go channel wait, and
+	// the run would hang until its deadline with no way to report why.
+	if elapsed > 30*time.Second {
+		t.Fatalf("Execute took %v; reserving race slots blocked the JS thread", elapsed)
+	}
+	if !strings.Contains(result.ResultJSON, "caught:") {
+		t.Fatalf("ResultJSON = %q, want a rejection when the budget is already held", result.ResultJSON)
+	}
+}
+
+func TestSchedulerLLMAsyncAbandonedHandleDelaysLaterAwait(t *testing.T) {
+	// Adopting each handle with Promise.resolve enqueues its thenable job at
+	// creation, and the job queue is drained in order with every job blocking.
+	// An abandoned handle created first therefore has to settle before a later
+	// await can proceed. This pins that contract so the cost of the design is
+	// visible, and so a future engine with a real event loop shows up here.
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime: domain.SchedulerRuntimeScheduler,
+		Script: `
+async function main() {
+  const startedAt = Date.now();
+  scheduler.llm.async("slow-abandoned");
+  const wanted = await scheduler.llm.async("fast-wanted");
+  return { text: wanted.text, waitedForAbandoned: Date.now() - startedAt >= 300 };
+}`,
+	}, &variableDelayHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `{"text":"out:fast-wanted","waitedForAbandoned":true}`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}
+
+func TestSchedulerLLMRaceReleasesSlotsOnDryRuns(t *testing.T) {
+	// A dry run runs async calls inline, which skips the goroutine that would
+	// otherwise release the slot a racing group reserved for each entry. Two
+	// groups in one dry run therefore have to work: leaking would exhaust the
+	// budget and fail the second with a confusing capacity error.
+	result, err := (&QJSSchedulerEngine{}).Execute(context.Background(), SchedulerExecutionRequest{
+		Runtime:                domain.SchedulerRuntimeScheduler,
+		DryRun:                 true,
+		MaxAsyncLLMConcurrency: 2,
+		Script: `
+async function main() {
+  const first = await scheduler.llm.race(["a1", "a2"]);
+  const second = await scheduler.llm.race(["b1", "b2"]);
+  return [first.text, second.text];
+}`,
+	}, &coverageEngineHost{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if want := `["llm-output","llm-output"]`; result.ResultJSON != want {
+		t.Fatalf("ResultJSON = %q, want %q", result.ResultJSON, want)
+	}
+}

--- a/pkg/schedulers/engine_bindings.go
+++ b/pkg/schedulers/engine_bindings.go
@@ -1,7 +1,6 @@
 package schedulers
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -23,6 +22,7 @@ func (e *QJSSchedulerEngine) installRuntime(jsctx *qjs.Context, state *scheduler
 	installLogBindings(jsctx, state, schedulerObj)
 	installAgentBinding(jsctx, state, schedulerObj)
 	installCommandBindings(jsctx, state, schedulerObj)
+	installSleepBindings(jsctx, state, schedulerObj)
 	installStateBindings(jsctx, state, schedulerObj)
 	installSandboxBindings(jsctx, state, schedulerObj)
 
@@ -229,55 +229,47 @@ func installLogBindings(jsctx *qjs.Context, state *schedulerExecutionState, sche
 	schedulerObj.SetPropertyStr("event", eventObj)
 }
 
-// installAgentBinding registers scheduler.agent.
+// installAgentBinding registers scheduler.agent and scheduler.agent.async.
 func installAgentBinding(jsctx *qjs.Context, state *schedulerExecutionState, schedulerObj *qjs.Value) {
 	agentFn := jsctx.Function(func(call *qjs.This) (*qjs.Value, error) {
 		if state.host == nil {
 			return nil, fmt.Errorf("scheduler.agent is unavailable during validation")
 		}
-		args := call.Args()
-		if len(args) == 0 {
-			return nil, fmt.Errorf("scheduler.agent requires a prompt")
-		}
-		prompt := strings.TrimSpace(args[0].String())
-		if prompt == "" {
-			return nil, fmt.Errorf("scheduler.agent requires a non-empty prompt")
-		}
-		options, err := parseSchedulerAgentRequest(args, state)
+		invocation, err := parseSchedulerAgentInvocation(jsctx, state, call.Args(), "scheduler.agent")
 		if err != nil {
 			return nil, err
 		}
-		var outputSchemaValue *qjs.Value
-		options.OutputSchema, outputSchemaValue, err = parseSchedulerOutputSchema(jsctx, state.jsonEncoder, args, "scheduler.agent")
+		response, err := state.host.Agent(state.ctx, invocation.prompt, invocation.options)
 		if err != nil {
 			return nil, err
 		}
-		response, err := state.host.Agent(state.ctx, prompt, options)
-		if err != nil {
-			return nil, err
-		}
-		if strings.TrimSpace(options.OutputSchema) != "" {
-			jsonValue, err := schedulerJSONResult(firstNonEmpty(response.FinalText, response.Text, response.Output), options.OutputSchema, "agent finalText")
-			if err != nil {
-				return nil, err
-			}
-			response.JSON = jsonValue
-		}
-		data, err := json.Marshal(response)
-		if err != nil {
-			return nil, fmt.Errorf("encode scheduler.agent response: %w", err)
-		}
-		value, err := payloadValueFromJSON(jsctx, string(data))
-		if err != nil {
-			return nil, fmt.Errorf("decode scheduler.agent response: %w", err)
-		}
-		if strings.TrimSpace(options.OutputSchema) != "" {
-			if err := validateSchedulerJSONWithSchema(jsctx, outputSchemaValue, value, "agent"); err != nil {
-				return nil, err
-			}
-		}
-		return value, nil
+		return encodeSchedulerAgentResult(jsctx, response, invocation.options, invocation.outputSchemaValue)
 	})
+	// scheduler.agent.async starts the agent run and hands the script a
+	// promise, so a batch built with Promise.all overlaps instead of running
+	// serially. Each call is pinned to its own sandbox; see
+	// requireFreshSandboxForAsyncAgent.
+	agentFn.SetPropertyStr("async", jsctx.Function(func(call *qjs.This) (*qjs.Value, error) {
+		if state.host == nil {
+			return nil, fmt.Errorf("scheduler.agent.async is unavailable during validation")
+		}
+		invocation, err := parseSchedulerAgentInvocation(jsctx, state, call.Args(), "scheduler.agent.async")
+		if err != nil {
+			return nil, err
+		}
+		invocation.options, err = requireFreshSandboxForAsyncAgent(invocation.options, "scheduler.agent.async")
+		if err != nil {
+			return nil, err
+		}
+		pending, err := state.startAsyncAgent(invocation)
+		if err != nil {
+			return nil, err
+		}
+		return newAsyncPromise(state, jsctx, "scheduler.agent.async", pending,
+			func(response domain.SchedulerAgentResult) (*qjs.Value, error) {
+				return encodeSchedulerAgentResult(jsctx, response, invocation.options, invocation.outputSchemaValue)
+			})
+	}))
 	schedulerObj.SetPropertyStr("agent", agentFn)
 }
 
@@ -320,50 +312,102 @@ func installCommandBindings(jsctx *qjs.Context, state *schedulerExecutionState, 
 		if state.host == nil {
 			return nil, fmt.Errorf("scheduler.llm is unavailable during validation")
 		}
-		args := call.Args()
-		if len(args) == 0 {
-			return nil, fmt.Errorf("scheduler.llm requires a prompt")
-		}
-		prompt := strings.TrimSpace(args[0].String())
-		if prompt == "" {
-			return nil, fmt.Errorf("scheduler.llm requires a non-empty prompt")
-		}
-		options, err := parseSchedulerLLMRequest(args, state)
+		invocation, err := parseSchedulerLLMInvocation(jsctx, state, call.Args(), "scheduler.llm")
 		if err != nil {
 			return nil, err
 		}
-		var outputSchemaValue *qjs.Value
-		options.OutputSchema, outputSchemaValue, err = parseSchedulerOutputSchema(jsctx, state.jsonEncoder, args, "scheduler.llm")
+		response, err := state.host.LLM(state.ctx, invocation.prompt, invocation.options)
 		if err != nil {
 			return nil, err
 		}
-		response, err := state.host.LLM(state.ctx, prompt, options)
-		if err != nil {
-			return nil, err
-		}
-		if strings.TrimSpace(options.OutputSchema) != "" {
-			jsonValue, err := schedulerJSONResult(response.Text, options.OutputSchema, "llm text")
-			if err != nil {
-				return nil, err
-			}
-			response.JSON = jsonValue
-		}
-		data, err := json.Marshal(response)
-		if err != nil {
-			return nil, fmt.Errorf("encode scheduler.llm response: %w", err)
-		}
-		value, err := payloadValueFromJSON(jsctx, string(data))
-		if err != nil {
-			return nil, fmt.Errorf("decode scheduler.llm response: %w", err)
-		}
-		if strings.TrimSpace(options.OutputSchema) != "" {
-			if err := validateSchedulerJSONWithSchema(jsctx, outputSchemaValue, value, "llm"); err != nil {
-				return nil, err
-			}
-		}
-		return value, nil
+		return encodeSchedulerLLMResult(jsctx, response, invocation.options, invocation.outputSchemaValue)
 	})
+	// scheduler.llm.async starts the host call and hands the script a thenable,
+	// so a batch built with Promise.all overlaps instead of running serially.
+	llmFn.SetPropertyStr("async", jsctx.Function(func(call *qjs.This) (*qjs.Value, error) {
+		if state.host == nil {
+			return nil, fmt.Errorf("scheduler.llm.async is unavailable during validation")
+		}
+		invocation, err := parseSchedulerLLMInvocation(jsctx, state, call.Args(), "scheduler.llm.async")
+		if err != nil {
+			return nil, err
+		}
+		pending, err := state.startAsyncLLM(state.asyncCtx, "scheduler.llm.async", invocation, false, nil)
+		if err != nil {
+			return nil, err
+		}
+		return newAsyncPromise(state, jsctx, "scheduler.llm.async", pending,
+			func(response domain.SchedulerLLMResult) (*qjs.Value, error) {
+				return encodeSchedulerLLMResult(jsctx, response, invocation.options, invocation.outputSchemaValue)
+			})
+	}))
+	// scheduler.llm.race settles with the call that finished first. The
+	// standard Promise.race cannot: its thenable jobs run in queue order and
+	// each blocks, so it always settles with the first array entry.
+	installSchedulerLLMRaceBinding(jsctx, state, llmFn, "race", false)
+	// scheduler.llm.any skips rejected calls and settles with the first one
+	// that succeeded, rejecting only after every call has failed.
+	installSchedulerLLMRaceBinding(jsctx, state, llmFn, "any", true)
 	schedulerObj.SetPropertyStr("llm", llmFn)
+}
+
+// installSleepBindings registers scheduler.sleep and scheduler.sleep.async.
+// The global setTimeout is a trigger registrar in this runtime, so the usual
+// `await new Promise(r => setTimeout(r, ms))` idiom never settles; these are
+// the supported way for a script to wait.
+func installSleepBindings(jsctx *qjs.Context, state *schedulerExecutionState, schedulerObj *qjs.Value) {
+	sleepFn := jsctx.Function(func(call *qjs.This) (*qjs.Value, error) {
+		duration, err := parseSchedulerSleepDuration(call.Args(), "scheduler.sleep")
+		if err != nil {
+			return nil, err
+		}
+		// Neither validation nor a dry run should wait: validation evaluates the
+		// script's top level to collect triggers, and a dry run only observes
+		// what the script would request. Arguments are still checked; only the
+		// wait is skipped.
+		if state.skipsDelays() {
+			return jsctx.NewUndefined(), nil
+		}
+		if err := sleepWithContext(state.ctx, duration); err != nil {
+			return nil, err
+		}
+		return jsctx.NewUndefined(), nil
+	})
+	sleepFn.SetPropertyStr("async", jsctx.Function(func(call *qjs.This) (*qjs.Value, error) {
+		duration, err := parseSchedulerSleepDuration(call.Args(), "scheduler.sleep.async")
+		if err != nil {
+			return nil, err
+		}
+		if state.skipsDelays() {
+			duration = 0
+		}
+		pending, err := state.startAsyncSleep(duration)
+		if err != nil {
+			return nil, err
+		}
+		return newAsyncSleepPromise(state, jsctx, pending)
+	}))
+	schedulerObj.SetPropertyStr("sleep", sleepFn)
+}
+
+// installSchedulerLLMRaceBinding registers one completion-order combinator on
+// scheduler.llm under the given name.
+func installSchedulerLLMRaceBinding(jsctx *qjs.Context, state *schedulerExecutionState, llmFn *qjs.Value, name string, requireSuccess bool) {
+	apiName := "scheduler.llm." + name
+	llmFn.SetPropertyStr(name, jsctx.Function(func(call *qjs.This) (*qjs.Value, error) {
+		if state.host == nil {
+			return nil, fmt.Errorf("%s is unavailable during validation", apiName)
+		}
+		invocations, err := parseSchedulerLLMRaceList(jsctx, state, call.Args(), apiName)
+		if err != nil {
+			return nil, err
+		}
+		race, err := state.startAsyncLLMRace(apiName, invocations)
+		if err != nil {
+			return nil, err
+		}
+		return newAsyncLLMRacePromise(state, jsctx, apiName, race, requireSuccess)
+	}))
 }
 
 // installStateBindings registers scheduler.state.get/set/delete.

--- a/pkg/schedulers/invocation.go
+++ b/pkg/schedulers/invocation.go
@@ -56,10 +56,13 @@ func (e *InvocationExecutor) Invoke(ctx context.Context, scheduler domain.Schedu
 	}
 	host := e.deps.HostFactory(scheduler, RuntimeExecutionContext{ID: correlationID, Kind: ExecutionKindInvocation}, TriggerEventMetadata{})
 	startedAt := time.Now().UTC()
+	maxAsyncLLM, maxAsyncAgent := AsyncConcurrencyFromSchedulerEnv(scheduler.EnvItems)
 	execution, execErr := e.deps.Engine.Execute(ctx, SchedulerExecutionRequest{
-		Runtime:     scheduler.Summary.Runtime,
-		Script:      scheduler.Script,
-		PayloadJSON: payloadJSON,
+		Runtime:                  scheduler.Summary.Runtime,
+		Script:                   scheduler.Script,
+		PayloadJSON:              payloadJSON,
+		MaxAsyncLLMConcurrency:   maxAsyncLLM,
+		MaxAsyncAgentConcurrency: maxAsyncAgent,
 	}, host)
 	if host != nil {
 		host.CleanupCommandSessions(context.WithoutCancel(ctx))

--- a/pkg/schedulers/run_lifecycle.go
+++ b/pkg/schedulers/run_lifecycle.go
@@ -190,11 +190,14 @@ func (e *RunExecutor) Execute(ctx context.Context, prepared PreparedRun) (domain
 		TriggerID: run.TriggerID,
 		Kind:      ExecutionKindTrigger,
 	}, ParseTriggerEventMetadata(prepared.PayloadJSON))
+	maxAsyncLLM, maxAsyncAgent := AsyncConcurrencyFromSchedulerEnv(prepared.Scheduler.EnvItems)
 	execution, execErr := e.deps.Engine.Execute(ctx, SchedulerExecutionRequest{
-		Runtime:     prepared.Scheduler.Summary.Runtime,
-		Script:      prepared.Scheduler.Script,
-		Trigger:     prepared.Trigger,
-		PayloadJSON: prepared.PayloadJSON,
+		Runtime:                  prepared.Scheduler.Summary.Runtime,
+		Script:                   prepared.Scheduler.Script,
+		Trigger:                  prepared.Trigger,
+		PayloadJSON:              prepared.PayloadJSON,
+		MaxAsyncLLMConcurrency:   maxAsyncLLM,
+		MaxAsyncAgentConcurrency: maxAsyncAgent,
 	}, host)
 
 	writeCtx := context.WithoutCancel(ctx)


### PR DESCRIPTION
Closes #445

## Summary

- Added `scheduler.llm.async` and `scheduler.agent.async`, which start the host call and return a promise immediately, so a batch built with `Promise.all` costs its slowest call instead of the sum of its calls.
- Added `scheduler.llm.race` / `.any`, which settle in completion order. The standard `Promise.race` and `Promise.any` cannot do this here: their thenable jobs run in queue order and each one blocks, so they settle with the first array entry and silently return the wrong result.
- Added `scheduler.sleep` and `scheduler.sleep.async`. The global `setTimeout` is a trigger registrar in this runtime, so `await new Promise(r => setTimeout(r, ms))` never settles and there was no way for a script to wait.
- Capped concurrency with `LLM_MAX_CONCURRENCY` (default 8) and `AGENT_MAX_CONCURRENCY` (default 3), and capped outstanding calls per execution at 4096.
- Left the synchronous bindings untouched, so existing scheduler scripts need no changes.

## Why a thenable

`qjs` v0.0.6 exports no `JS_ExecutePendingJob` from its wasm build, so Go can neither drive an event loop nor resolve a promise from another goroutine. A thenable adopted by `Promise.resolve` is the only route to standard `await` syntax under that constraint; concurrency lives entirely on the Go side while JS stays single-threaded. The contract scripts see is a real promise, so replacing the bridge later — after a `qjs` upgrade that allows a genuine event loop — would not change any user script.

## Notable behavior

- `scheduler.agent.async` pins each call to the `new` sandbox policy. Parallel agents would otherwise write the same workspace, and the first to finish shuts the sandbox down. An explicit `sticky` or `reuse` is rejected rather than silently rewritten. A trigger that switches to `.async` therefore stops establishing a sticky binding for its manual runs, which is documented.
- A run that times out aborts entirely; completed parallel results are not returned. This is existing behavior, now documented because fan-out widens its blast radius.
- `Promise` and `Promise.resolve` are captured before the script is evaluated, the way `jsValueEncoder` already captures `JSON.stringify`, so a script cannot change what the bindings hand back.
- A panicking host becomes a rejection instead of taking the daemon down. The synchronous bindings survive one because `qjs` turns a panic inside a proxied function into a JS exception, which does not cover a goroutine.

## Validation

- `go test ./pkg/schedulers/ -race -count=1` — passed
- `go test ./pkg/runs/ ./cmd/agent-compose/ -count=1` — passed
- `golangci-lint run --no-config ./pkg/schedulers/... ./pkg/runs/...` — 0 issues
- `go vet ./pkg/schedulers/ ./pkg/runs/` and `gofmt -l` — clean
- 28 new tests, each watched failing before its implementation. Where an implementation already existed, it was temporarily degraded to confirm the test detects the regression.

## Not covered

- `scheduler.agent.async` on the classic (non-project) agent path has only been exercised against test doubles. The `SchedulerSandboxRunner.Ensure` and `AgentExecutor` chain was audited by reading, not run concurrently for real. Worth a manual run on a real scheduler before this leaves draft.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.