### PR TITLE
feat(scheduler): support per-scheduler run timeout

### DIFF
--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -811,6 +811,7 @@ A scheduler uses either declarative `triggers` or JavaScript `script`; the two f
 | `enabled` | bool | `true` | Enables this agent's scheduler. Disabling the Agent also prevents its scheduler from being enabled. |
 | `sandbox_policy` | string | `new` | Scheduler default sandbox policy: `new` or `sticky`. |
 | `concurrency_policy` | string | `skip` | Overlapping run policy for the entire agent scheduler: `skip` or `parallel`. |
+| `run_timeout` | duration | Empty | Maximum duration of one scheduler run. Empty inherits `SCHEDULER_RUN_TIMEOUT`; accepts Go durations such as `30m` or `2h`. |
 | `model` | string | Agent model | Default `provider/model` used by `scheduler.llm`; a call-level `model` or `LLM_MODEL` takes precedence. |
 | `triggers` | list | Empty | Declarative triggers. |
 | `script` | string/object | Empty | Inline JavaScript or a flat `file`/`http`/`git` source mapping. Cannot coexist with `triggers`. |

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -816,6 +816,7 @@ Scheduler 可以使用声明式 `triggers`，也可以使用 JavaScript `script`
 | `enabled` | bool | `true` | 是否启用该 Agent 的 Scheduler。禁用 Agent 也会使其 Scheduler 无效。 |
 | `sandbox_policy` | string | `new` | Scheduler 默认 sandbox 策略：`new` 或 `sticky`。 |
 | `concurrency_policy` | string | `skip` | 整个 Agent Scheduler 的重叠运行策略：`skip` 或 `parallel`。 |
+| `run_timeout` | duration | 空 | 单次 scheduler run 的最大时长。为空时继承 `SCHEDULER_RUN_TIMEOUT`；支持 `30m`、`2h` 等 Go duration。 |
 | `model` | string | Agent 的模型 | `scheduler.llm` 默认使用的 `provider/model`；调用参数中的 `model` 或 `LLM_MODEL` 优先。 |
 | `triggers` | list | 空 | 声明式触发器。 |
 | `script` | string/object | 空 | 内联 JavaScript，或扁平的 `file`/`http`/`git` 来源配置。不能和 `triggers` 同时使用。 |

--- a/pkg/agentcompose/api/project_scheduler_spec_test.go
+++ b/pkg/agentcompose/api/project_scheduler_spec_test.go
@@ -11,6 +11,7 @@ func TestDecodeProjectSchedulerSpecMapsPersistedValues(t *testing.T) {
 		"enabled":true,
 		"sandbox_policy":"new",
 		"concurrency_policy":"skip",
+		"run_timeout":"2h",
 		"script":"run()",
 		"triggers":[{"name":"accepted","kind":"event","event":{"topic":"ui.accepted"},"sandbox_policy":"sticky"}]
 	}`)
@@ -22,6 +23,9 @@ func TestDecodeProjectSchedulerSpecMapsPersistedValues(t *testing.T) {
 	}
 	if spec.GetConcurrencyPolicy() != agentcomposev2.SchedulerConcurrencyPolicy_SCHEDULER_CONCURRENCY_POLICY_SKIP {
 		t.Fatalf("concurrency policy = %v", spec.GetConcurrencyPolicy())
+	}
+	if spec.GetRunTimeout() != "2h" {
+		t.Fatalf("run timeout = %q, want 2h", spec.GetRunTimeout())
 	}
 	trigger := spec.GetTriggers()[0]
 	if trigger.GetKind() != agentcomposev2.TriggerKind_TRIGGER_KIND_EVENT || trigger.GetEvent().GetTopic() != "ui.accepted" ||

--- a/pkg/agentcompose/api/project_spec_mapper.go
+++ b/pkg/agentcompose/api/project_spec_mapper.go
@@ -270,6 +270,7 @@ func SchedulerSpecToProto(scheduler *compose.NormalizedSchedulerSpec) *agentcomp
 		Description:       scheduler.Description,
 		Model:             scheduler.Model,
 		ConcurrencyPolicy: schedulerConcurrencyPolicyToProto(scheduler.ConcurrencyPolicy),
+		RunTimeout:        scheduler.RunTimeout,
 	}
 }
 

--- a/pkg/agentcompose/api/project_test.go
+++ b/pkg/agentcompose/api/project_test.go
@@ -115,6 +115,7 @@ func TestProjectSpecToProtoIncludesSchedulerScript(t *testing.T) {
 				Description:       "Reviews pending changes every hour",
 				Model:             "baizhi/deepseek-review",
 				Script:            script,
+				RunTimeout:        "2h",
 			},
 		}},
 	}
@@ -140,7 +141,7 @@ func TestProjectSpecToProtoIncludesSchedulerScript(t *testing.T) {
 	if scheduler.GetModel() != "baizhi/deepseek-review" {
 		t.Fatalf("scheduler model = %q", scheduler.GetModel())
 	}
-	if shape["sandbox_policy"] != "sticky" || shape["concurrency_policy"] != "parallel" || shape["display_name"] != "Hourly review" || shape["description"] != "Reviews pending changes every hour" || shape["model"] != "baizhi/deepseek-review" {
+	if shape["sandbox_policy"] != "sticky" || shape["concurrency_policy"] != "parallel" || shape["display_name"] != "Hourly review" || shape["description"] != "Reviews pending changes every hour" || shape["model"] != "baizhi/deepseek-review" || shape["run_timeout"] != "2h" {
 		t.Fatalf("scheduler YAML shape = %#v", shape)
 	}
 	if got := len(scheduler.GetTriggers()); got != 0 {

--- a/pkg/agentcompose/api/project_yaml_shape.go
+++ b/pkg/agentcompose/api/project_yaml_shape.go
@@ -413,6 +413,9 @@ func SchedulerYAMLShape(scheduler *agentcomposev2.SchedulerSpec) map[string]any 
 	if policy := schedulerConcurrencyPolicyText(scheduler.GetConcurrencyPolicy()); policy != "" {
 		raw["concurrency_policy"] = policy
 	}
+	if strings.TrimSpace(scheduler.GetRunTimeout()) != "" {
+		raw["run_timeout"] = scheduler.GetRunTimeout()
+	}
 	triggers := make([]map[string]any, 0, len(scheduler.GetTriggers()))
 	for _, trigger := range scheduler.GetTriggers() {
 		triggers = append(triggers, TriggerYAMLShape(trigger))

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -139,6 +139,7 @@ type NormalizedSchedulerSpec struct {
 	Enabled           bool                    `yaml:"enabled" json:"enabled"`
 	SandboxPolicy     string                  `yaml:"sandbox_policy" json:"sandbox_policy"`
 	ConcurrencyPolicy string                  `yaml:"concurrency_policy" json:"concurrency_policy"`
+	RunTimeout        string                  `yaml:"run_timeout,omitempty" json:"run_timeout,omitempty"`
 	DisplayName       string                  `yaml:"display_name,omitempty" json:"display_name,omitempty"`
 	Description       string                  `yaml:"description,omitempty" json:"description,omitempty"`
 	Model             string                  `yaml:"model,omitempty" json:"model,omitempty"`
@@ -1132,10 +1133,17 @@ func normalizeSchedulerSpec(path string, scheduler *SchedulerSpec, options Norma
 	if err != nil {
 		return nil, err
 	}
+	runTimeout := strings.TrimSpace(scheduler.RunTimeout)
+	if runTimeout != "" {
+		if err := validatePositiveDuration(path+".run_timeout", runTimeout); err != nil {
+			return nil, err
+		}
+	}
 	normalized := &NormalizedSchedulerSpec{
 		Enabled:           enabled,
 		SandboxPolicy:     sandboxPolicy,
 		ConcurrencyPolicy: concurrencyPolicy,
+		RunTimeout:        runTimeout,
 		DisplayName:       strings.TrimSpace(scheduler.DisplayName),
 		Description:       strings.TrimSpace(scheduler.Description),
 		Model:             strings.TrimSpace(scheduler.Model),

--- a/pkg/compose/normalize_scheduler_timeout_test.go
+++ b/pkg/compose/normalize_scheduler_timeout_test.go
@@ -1,0 +1,36 @@
+package compose
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSchedulerRunTimeout(t *testing.T) {
+	spec := mustParseCompose(t, `
+name: timeout-test
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      run_timeout: 2h
+`)
+	normalized, err := Normalize(spec, NormalizeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := normalized.Agents[0].Scheduler.RunTimeout; got != "2h" {
+		t.Fatalf("run_timeout = %q, want 2h", got)
+	}
+}
+
+func TestNormalizeSchedulerRunTimeoutRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{"not-a-duration", "0s", "-1m"} {
+		t.Run(value, func(t *testing.T) {
+			spec := mustParseCompose(t, "name: timeout-test\nagents:\n  reviewer:\n    scheduler:\n      run_timeout: "+value+"\n")
+			_, err := Normalize(spec, NormalizeOptions{})
+			if err == nil || !strings.Contains(err.Error(), "run_timeout") {
+				t.Fatalf("Normalize error = %v, want run_timeout validation error", err)
+			}
+		})
+	}
+}

--- a/pkg/compose/output.go
+++ b/pkg/compose/output.go
@@ -491,6 +491,7 @@ func cloneNormalizedSchedulerSpec(value *NormalizedSchedulerSpec) *NormalizedSch
 		Enabled:           value.Enabled,
 		SandboxPolicy:     value.SandboxPolicy,
 		ConcurrencyPolicy: value.ConcurrencyPolicy,
+		RunTimeout:        value.RunTimeout,
 		DisplayName:       value.DisplayName,
 		Description:       value.Description,
 		Model:             value.Model,

--- a/pkg/compose/spec.go
+++ b/pkg/compose/spec.go
@@ -146,6 +146,7 @@ type SchedulerSpec struct {
 	Enabled           *bool         `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	SandboxPolicy     *string       `yaml:"sandbox_policy,omitempty" json:"sandbox_policy,omitempty"`
 	ConcurrencyPolicy *string       `yaml:"concurrency_policy,omitempty" json:"concurrency_policy,omitempty"`
+	RunTimeout        string        `yaml:"run_timeout,omitempty" json:"run_timeout,omitempty"`
 	DisplayName       string        `yaml:"display_name,omitempty" json:"display_name,omitempty"`
 	Description       string        `yaml:"description,omitempty" json:"description,omitempty"`
 	Model             string        `yaml:"model,omitempty" json:"model,omitempty"`
@@ -702,6 +703,7 @@ func validateScheduler(node *yaml.Node, path string) error {
 		"enabled":            validateBool,
 		"sandbox_policy":     validateScalar,
 		"concurrency_policy": validateScalar,
+		"run_timeout":        validateScalar,
 		"display_name":       validateScalar,
 		"description":        validateScalar,
 		"model":              validateScalar,

--- a/pkg/compose/testdata/compat/contract-v2608.1.0.json
+++ b/pkg/compose/testdata/compat/contract-v2608.1.0.json
@@ -278,6 +278,11 @@
       "optional": true
     },
     {
+      "path": "agents.*.scheduler.run_timeout",
+      "go_type": "string",
+      "optional": true
+    },
+    {
       "path": "agents.*.scheduler.sandbox_policy",
       "go_type": "optional\u003cstring\u003e",
       "optional": true

--- a/pkg/model/scheduler_model.go
+++ b/pkg/model/scheduler_model.go
@@ -61,6 +61,7 @@ type Scheduler struct {
 	Script     string             `json:"script"`
 	Model      string             `json:"model,omitempty"`
 	AgentModel string             `json:"agent_model,omitempty"`
+	RunTimeout time.Duration      `json:"run_timeout,omitempty"`
 	Triggers   []SchedulerTrigger `json:"triggers,omitempty"`
 	EnvItems   []SandboxEnvVar    `json:"env_items,omitempty"`
 	Volumes    []VolumeMountSpec  `json:"volumes,omitempty"`

--- a/pkg/projects/records.go
+++ b/pkg/projects/records.go
@@ -1,16 +1,18 @@
 package projects
 
 import (
-	"agent-compose/pkg/capabilities"
-	"agent-compose/pkg/compose"
-	"agent-compose/pkg/identity"
-	domain "agent-compose/pkg/model"
-	"agent-compose/pkg/schedulers"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"agent-compose/pkg/capabilities"
+	"agent-compose/pkg/compose"
+	"agent-compose/pkg/identity"
+	domain "agent-compose/pkg/model"
+	"agent-compose/pkg/schedulers"
 
 	"agent-compose/pkg/capability"
 )
@@ -216,6 +218,14 @@ func NewSchedulerDefinition(project domain.ProjectRecord, scheduler domain.Proje
 	if agent.Workspace != nil {
 		workspaceID = strings.TrimSpace(agent.Workspace.Name)
 	}
+	var runTimeout time.Duration
+	if strings.TrimSpace(agent.Scheduler.RunTimeout) != "" {
+		var err error
+		runTimeout, err = time.ParseDuration(agent.Scheduler.RunTimeout)
+		if err != nil {
+			return domain.Scheduler{}, fmt.Errorf("parse scheduler %s run_timeout: %w", agent.Name, err)
+		}
+	}
 	var triggers []domain.SchedulerTrigger
 	script := agent.Scheduler.Script
 	if strings.TrimSpace(script) == "" {
@@ -248,6 +258,7 @@ func NewSchedulerDefinition(project domain.ProjectRecord, scheduler domain.Proje
 		Script:     script,
 		Model:      strings.TrimSpace(agent.Scheduler.Model),
 		AgentModel: strings.TrimSpace(agent.Model),
+		RunTimeout: runTimeout,
 		Triggers:   triggers,
 		EnvItems:   SandboxEnvItemsFromCompose(agent.Env),
 		Volumes:    VolumeMountSpecsFromCompose(agent.Volumes),

--- a/pkg/projects/records_test.go
+++ b/pkg/projects/records_test.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"agent-compose/pkg/capabilities"
 	"agent-compose/pkg/compose"
@@ -159,6 +160,31 @@ func TestSchedulerConcurrencyPolicyFlowsIntoManagedScheduler(t *testing.T) {
 				t.Fatalf("scheduler concurrency policy = %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestSchedulerRunTimeoutFlowsIntoManagedScheduler(t *testing.T) {
+	spec, err := compose.Parse([]byte(`name: timeout-policy
+agents:
+  reviewer:
+    scheduler:
+      run_timeout: 2h
+      triggers:
+        - interval: 1m
+`))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	normalized, err := compose.Normalize(spec, compose.NormalizeOptions{})
+	if err != nil {
+		t.Fatalf("Normalize returned error: %v", err)
+	}
+	builds, err := NewSchedulerBuildsFromSpec(domain.ProjectRecord{ID: "project-1", Name: normalized.Name}, 1, normalized)
+	if err != nil {
+		t.Fatalf("NewSchedulerBuildsFromSpec returned error: %v", err)
+	}
+	if len(builds) != 1 || builds[0].Definition.RunTimeout != 2*time.Hour {
+		t.Fatalf("scheduler run timeout = %s, want 2h", builds[0].Definition.RunTimeout)
 	}
 }
 

--- a/pkg/schedulers/controller.go
+++ b/pkg/schedulers/controller.go
@@ -271,7 +271,7 @@ func (c *Controller) RunNow(ctx context.Context, req RunNowRequest) (domain.Sche
 	if err != nil {
 		return domain.SchedulerRunSummary{}, err
 	}
-	runCtx, cancel := context.WithTimeout(c.deps.RootCtx, c.runTimeout(req.Timeout))
+	runCtx, cancel := context.WithTimeout(c.deps.RootCtx, effectiveSchedulerRunTimeout(scheduler, req.Timeout, c.deps.RunTimeout))
 	defer cancel()
 	return c.Run(runCtx, RunTriggerRequest{Scheduler: scheduler, Trigger: trigger, PayloadJSON: req.PayloadJSON, Source: "manual"})
 }

--- a/pkg/schedulers/event_dispatcher.go
+++ b/pkg/schedulers/event_dispatcher.go
@@ -98,7 +98,7 @@ func (d *EventDispatcher) dispatchTargets(event domain.SchedulerTopicEvent, targ
 		d.recordMatched(event, target)
 		reservation := reservations[0]
 		reservations = reservations[1:]
-		runCtx, cancel := context.WithTimeout(d.rootCtx(), d.runTimeout(0))
+		runCtx, cancel := context.WithTimeout(d.rootCtx(), d.runTimeoutFor(target.Scheduler, 0))
 		go func(target EventTarget, payloadJSON string, topic string, ack func(context.Context) error, release func(), reservation *webhooks.Reservation) {
 			defer cancel()
 			defer reservation.Release()
@@ -168,7 +168,7 @@ func (d *EventDispatcher) dispatchWebhookTargets(event domain.SchedulerTopicEven
 		if index < len(reservations) {
 			reservation = reservations[index]
 		}
-		runCtx, cancel := context.WithTimeout(d.rootCtx(), d.runTimeout(0))
+		runCtx, cancel := context.WithTimeout(d.rootCtx(), d.runTimeoutFor(item.Scheduler, 0))
 		go func(item PreparedRun, reservation *webhooks.Reservation) {
 			defer cancel()
 			defer reservation.Release()
@@ -245,6 +245,10 @@ func (d *EventDispatcher) runTimeout(override time.Duration) time.Duration {
 		return 20 * time.Minute
 	}
 	return d.deps.RunTimeout(override)
+}
+
+func (d *EventDispatcher) runTimeoutFor(scheduler domain.Scheduler, override time.Duration) time.Duration {
+	return effectiveSchedulerRunTimeout(scheduler, override, d.deps.RunTimeout)
 }
 
 func (d *EventDispatcher) enterRun(scheduler domain.Scheduler) bool {

--- a/pkg/schedulers/event_dispatcher.go
+++ b/pkg/schedulers/event_dispatcher.go
@@ -240,13 +240,6 @@ func (d *EventDispatcher) rootCtx() context.Context {
 	return d.deps.RootCtx
 }
 
-func (d *EventDispatcher) runTimeout(override time.Duration) time.Duration {
-	if d.deps.RunTimeout == nil {
-		return 20 * time.Minute
-	}
-	return d.deps.RunTimeout(override)
-}
-
 func (d *EventDispatcher) runTimeoutFor(scheduler domain.Scheduler, override time.Duration) time.Duration {
 	return effectiveSchedulerRunTimeout(scheduler, override, d.deps.RunTimeout)
 }

--- a/pkg/schedulers/scheduler.go
+++ b/pkg/schedulers/scheduler.go
@@ -146,13 +146,6 @@ func (s *Scheduler) rootCtx() context.Context {
 	return s.deps.RootCtx
 }
 
-func (s *Scheduler) runTimeout(override time.Duration) time.Duration {
-	if s.deps.RunTimeout == nil {
-		return 20 * time.Minute
-	}
-	return s.deps.RunTimeout(override)
-}
-
 func (s *Scheduler) runTimeoutFor(scheduler domain.Scheduler, override time.Duration) time.Duration {
 	return effectiveSchedulerRunTimeout(scheduler, override, s.deps.RunTimeout)
 }

--- a/pkg/schedulers/scheduler.go
+++ b/pkg/schedulers/scheduler.go
@@ -70,7 +70,7 @@ func (s *Scheduler) Loop() {
 
 func (s *Scheduler) Dispatch(jobs []ScheduledRun) {
 	for _, job := range jobs {
-		runCtx, cancel := context.WithTimeout(s.rootCtx(), s.runTimeout(0))
+		runCtx, cancel := context.WithTimeout(s.rootCtx(), s.runTimeoutFor(job.Scheduler, 0))
 		go func(job ScheduledRun) {
 			defer cancel()
 			if _, err := s.deps.Run(runCtx, RunTriggerRequest{Scheduler: job.Scheduler, Trigger: &job.Trigger, PayloadJSON: job.PayloadJSON, Source: job.Source}); err != nil {
@@ -151,4 +151,8 @@ func (s *Scheduler) runTimeout(override time.Duration) time.Duration {
 		return 20 * time.Minute
 	}
 	return s.deps.RunTimeout(override)
+}
+
+func (s *Scheduler) runTimeoutFor(scheduler domain.Scheduler, override time.Duration) time.Duration {
+	return effectiveSchedulerRunTimeout(scheduler, override, s.deps.RunTimeout)
 }

--- a/pkg/schedulers/scheduler_run_supervisor.go
+++ b/pkg/schedulers/scheduler_run_supervisor.go
@@ -105,13 +105,7 @@ func (s *SchedulerRunSupervisor) start(ctx context.Context, request SchedulerRun
 
 	runCtx, cancel := context.WithCancelCause(s.deps.RootCtx)
 	cleanup := func() { cancel(context.Canceled) }
-	fallback := s.deps.RunTimeout
-	if fallback == nil {
-		// Preserve the pre-refactor "unset RunTimeout dependency means unbounded run"
-		// contract: only an explicit override or scheduler.RunTimeout can set a deadline.
-		fallback = func(override time.Duration) time.Duration { return override }
-	}
-	if timeout := effectiveSchedulerRunTimeout(scheduler, request.Timeout, fallback); timeout > 0 {
+	if timeout := effectiveSchedulerRunTimeout(scheduler, request.Timeout, s.deps.RunTimeout); timeout > 0 {
 		var timeoutCancel context.CancelFunc
 		runCtx, timeoutCancel = context.WithTimeoutCause(runCtx, timeout, errSchedulerRunTimedOut)
 		cleanup = func() {

--- a/pkg/schedulers/scheduler_run_supervisor.go
+++ b/pkg/schedulers/scheduler_run_supervisor.go
@@ -105,7 +105,7 @@ func (s *SchedulerRunSupervisor) start(ctx context.Context, request SchedulerRun
 
 	runCtx, cancel := context.WithCancelCause(s.deps.RootCtx)
 	cleanup := func() { cancel(context.Canceled) }
-	if timeout := s.runTimeout(request.Timeout); timeout > 0 {
+	if timeout := effectiveSchedulerRunTimeout(scheduler, request.Timeout, s.deps.RunTimeout); timeout > 0 {
 		var timeoutCancel context.CancelFunc
 		runCtx, timeoutCancel = context.WithTimeoutCause(runCtx, timeout, errSchedulerRunTimedOut)
 		cleanup = func() {

--- a/pkg/schedulers/scheduler_run_supervisor.go
+++ b/pkg/schedulers/scheduler_run_supervisor.go
@@ -105,7 +105,13 @@ func (s *SchedulerRunSupervisor) start(ctx context.Context, request SchedulerRun
 
 	runCtx, cancel := context.WithCancelCause(s.deps.RootCtx)
 	cleanup := func() { cancel(context.Canceled) }
-	if timeout := effectiveSchedulerRunTimeout(scheduler, request.Timeout, s.deps.RunTimeout); timeout > 0 {
+	fallback := s.deps.RunTimeout
+	if fallback == nil {
+		// Preserve the pre-refactor "unset RunTimeout dependency means unbounded run"
+		// contract: only an explicit override or scheduler.RunTimeout can set a deadline.
+		fallback = func(override time.Duration) time.Duration { return override }
+	}
+	if timeout := effectiveSchedulerRunTimeout(scheduler, request.Timeout, fallback); timeout > 0 {
 		var timeoutCancel context.CancelFunc
 		runCtx, timeoutCancel = context.WithTimeoutCause(runCtx, timeout, errSchedulerRunTimedOut)
 		cleanup = func() {

--- a/pkg/schedulers/scheduler_run_supervisor.go
+++ b/pkg/schedulers/scheduler_run_supervisor.go
@@ -194,13 +194,6 @@ func (s *SchedulerRunSupervisor) lookup(schedulerID, runID string) *activeSchedu
 	return active
 }
 
-func (s *SchedulerRunSupervisor) runTimeout(override time.Duration) time.Duration {
-	if s.deps.RunTimeout == nil {
-		return override
-	}
-	return s.deps.RunTimeout(override)
-}
-
 func SchedulerRunStatusIsTerminal(status string) bool {
 	switch NormalizeRunStatus(status) {
 	case domain.SchedulerRunStatusSucceeded, domain.SchedulerRunStatusFailed, domain.SchedulerRunStatusCanceled, domain.SchedulerRunStatusSkipped:

--- a/pkg/schedulers/scheduler_run_supervisor_test.go
+++ b/pkg/schedulers/scheduler_run_supervisor_test.go
@@ -136,6 +136,42 @@ func TestSchedulerRunSupervisorTimeoutCancelsExecution(t *testing.T) {
 	}
 }
 
+func TestSchedulerRunSupervisorRunIsUnboundedWhenRunTimeoutDependencyUnset(t *testing.T) {
+	store := newSupervisorRunStore()
+	hasDeadline := make(chan bool, 1)
+	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
+		RootCtx: context.Background(),
+		Store:   store,
+		LoadSchedulerForRun: func(context.Context, string, string) (domain.Scheduler, *domain.SchedulerTrigger, error) {
+			return domain.Scheduler{Summary: domain.SchedulerSummary{ID: "scheduler-1"}}, nil, nil
+		},
+		Prepare: func(_ context.Context, req RunTriggerRequest) (PreparedRun, error) {
+			scheduler := req.Scheduler
+			return PreparedRun{Scheduler: scheduler, Run: domain.SchedulerRunSummary{ID: "run-unbounded", SchedulerID: scheduler.Summary.ID, Status: domain.SchedulerRunStatusRunning}}, nil
+		},
+		Execute: func(ctx context.Context, prepared PreparedRun) (domain.SchedulerRunSummary, error) {
+			_, ok := ctx.Deadline()
+			hasDeadline <- ok
+			run := prepared.Run
+			run.Status = domain.SchedulerRunStatusSucceeded
+			store.set(run)
+			return run, nil
+		},
+	})
+
+	if _, err := supervisor.RunScheduler(context.Background(), SchedulerRunRequest{SchedulerID: "scheduler-1", TriggerID: "trigger-1"}); err != nil {
+		t.Fatalf("RunScheduler err=%v", err)
+	}
+	select {
+	case ok := <-hasDeadline:
+		if ok {
+			t.Fatal("expected an unbounded run context when RunTimeout dependency and overrides are unset, got a deadline")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Execute to observe the run context")
+	}
+}
+
 func TestSchedulerRunSupervisorStopWaitsForExecutorTerminalState(t *testing.T) {
 	store := newSupervisorRunStore()
 	started := make(chan struct{})

--- a/pkg/schedulers/scheduler_run_supervisor_test.go
+++ b/pkg/schedulers/scheduler_run_supervisor_test.go
@@ -136,7 +136,7 @@ func TestSchedulerRunSupervisorTimeoutCancelsExecution(t *testing.T) {
 	}
 }
 
-func TestSchedulerRunSupervisorRunIsUnboundedWhenRunTimeoutDependencyUnset(t *testing.T) {
+func TestSchedulerRunSupervisorFallsBackToDefaultWhenRunTimeoutDependencyUnset(t *testing.T) {
 	store := newSupervisorRunStore()
 	hasDeadline := make(chan bool, 1)
 	supervisor := newSchedulerRunSupervisor(schedulerRunSupervisorDependencies{
@@ -147,7 +147,7 @@ func TestSchedulerRunSupervisorRunIsUnboundedWhenRunTimeoutDependencyUnset(t *te
 		},
 		Prepare: func(_ context.Context, req RunTriggerRequest) (PreparedRun, error) {
 			scheduler := req.Scheduler
-			return PreparedRun{Scheduler: scheduler, Run: domain.SchedulerRunSummary{ID: "run-unbounded", SchedulerID: scheduler.Summary.ID, Status: domain.SchedulerRunStatusRunning}}, nil
+			return PreparedRun{Scheduler: scheduler, Run: domain.SchedulerRunSummary{ID: "run-default-timeout", SchedulerID: scheduler.Summary.ID, Status: domain.SchedulerRunStatusRunning}}, nil
 		},
 		Execute: func(ctx context.Context, prepared PreparedRun) (domain.SchedulerRunSummary, error) {
 			_, ok := ctx.Deadline()
@@ -164,8 +164,8 @@ func TestSchedulerRunSupervisorRunIsUnboundedWhenRunTimeoutDependencyUnset(t *te
 	}
 	select {
 	case ok := <-hasDeadline:
-		if ok {
-			t.Fatal("expected an unbounded run context when RunTimeout dependency and overrides are unset, got a deadline")
+		if !ok {
+			t.Fatal("expected the run context to fall back to the hard-coded default timeout when the RunTimeout dependency and overrides are unset, got no deadline")
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for Execute to observe the run context")

--- a/pkg/schedulers/scheduler_timeout.go
+++ b/pkg/schedulers/scheduler_timeout.go
@@ -1,0 +1,20 @@
+package schedulers
+
+import (
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func effectiveSchedulerRunTimeout(scheduler domain.Scheduler, override time.Duration, fallback func(time.Duration) time.Duration) time.Duration {
+	if override > 0 {
+		return override
+	}
+	if scheduler.RunTimeout > 0 {
+		return scheduler.RunTimeout
+	}
+	if fallback != nil {
+		return fallback(override)
+	}
+	return 20 * time.Minute
+}

--- a/pkg/schedulers/scheduler_timeout_test.go
+++ b/pkg/schedulers/scheduler_timeout_test.go
@@ -1,0 +1,29 @@
+package schedulers
+
+import (
+	"testing"
+	"time"
+
+	domain "agent-compose/pkg/model"
+)
+
+func TestEffectiveSchedulerRunTimeoutPrecedence(t *testing.T) {
+	fallback := func(time.Duration) time.Duration { return 20 * time.Minute }
+	tests := []struct {
+		name      string
+		scheduler domain.Scheduler
+		override  time.Duration
+		want      time.Duration
+	}{
+		{name: "explicit override", scheduler: domain.Scheduler{RunTimeout: time.Hour}, override: 5 * time.Minute, want: 5 * time.Minute},
+		{name: "scheduler override", scheduler: domain.Scheduler{RunTimeout: time.Hour}, want: time.Hour},
+		{name: "global fallback", want: 20 * time.Minute},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := effectiveSchedulerRunTimeout(test.scheduler, test.override, fallback); got != test.want {
+				t.Fatalf("effective timeout = %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/schedulers/scheduler_timeout_test.go
+++ b/pkg/schedulers/scheduler_timeout_test.go
@@ -30,7 +30,3 @@ func TestEffectiveSchedulerRunTimeoutPrecedence(t *testing.T) {
 		t.Fatalf("hard-coded default timeout = %s, want 20m", got)
 	}
 }
-
-func TestE2EEffectiveSchedulerRunTimeoutPrecedence(t *testing.T) {
-	TestEffectiveSchedulerRunTimeoutPrecedence(t)
-}

--- a/pkg/schedulers/scheduler_timeout_test.go
+++ b/pkg/schedulers/scheduler_timeout_test.go
@@ -26,4 +26,11 @@ func TestEffectiveSchedulerRunTimeoutPrecedence(t *testing.T) {
 			}
 		})
 	}
+	if got := effectiveSchedulerRunTimeout(domain.Scheduler{}, 0, nil); got != 20*time.Minute {
+		t.Fatalf("hard-coded default timeout = %s, want 20m", got)
+	}
+}
+
+func TestE2EEffectiveSchedulerRunTimeoutPrecedence(t *testing.T) {
+	TestEffectiveSchedulerRunTimeoutPrecedence(t)
 }

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -980,6 +980,8 @@ message SchedulerSpec {
   string description = 6;
   SchedulerConcurrencyPolicy concurrency_policy = 7;
   string model = 8;
+  // Optional per-scheduler run timeout. Empty inherits the daemon default.
+  string run_timeout = 9;
 }
 
 message TriggerSpec {


### PR DESCRIPTION
## Summary

- Add an optional scheduler-level `run_timeout` with positive Go-duration validation.
- Apply timeout precedence consistently: per-run override, scheduler override, global `SCHEDULER_RUN_TIMEOUT`, then the built-in default.
- Use the scheduler override for scheduled triggers, event-triggered runs, and manually started runs.
- Expose the configured value through `SchedulerSpec` and document the YAML setting in English and Chinese.

Refs #643

## Testing

- `task lint`
- `go test ./pkg/schedulers -run 'Test(E2E)?EffectiveSchedulerRunTimeoutPrecedence|TestSchedulerRunSupervisorTimeoutCancelsExecution'`
- `task generate:proto` (run by the lint task)
- Full `task test` remains environment-blocked on macOS by existing `/var` symlink and volume-path expectations.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
