### PR TITLE
feat(runs): support arbitrary key/value labels on project runs

### DIFF
--- a/cmd/agent-compose/cli_format.go
+++ b/cmd/agent-compose/cli_format.go
@@ -20,6 +20,7 @@ type composePSOptions struct {
 	All     bool
 	Status  string
 	Verbose bool
+	Labels  []string
 }
 
 func formatDurationMs(value int64) string {

--- a/cmd/agent-compose/cli_output_test.go
+++ b/cmd/agent-compose/cli_output_test.go
@@ -10,8 +10,8 @@ import (
 
 // Run labels ride along on RunDetail, so every detail-derived output (inspect
 // run, exec, latest run) must surface them without a second request. Summary
-// derived output has no labels to report and must omit the key entirely rather
-// than render an empty map that reads as "this run has no labels".
+// derived output has none to report and leaves the field nil, which omitempty
+// drops the same way it drops a detail-derived run with no labels at all.
 func TestComposeRunOutputCarriesLabelsFromDetailOnly(t *testing.T) {
 	detail := testRunDetail("project-1", "run-labeled", "reviewer", "sandbox-1", agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, 0, "ok\n")
 	detail.Labels = map[string]string{"env": "prod", "team": "platform"}

--- a/cmd/agent-compose/cli_output_test.go
+++ b/cmd/agent-compose/cli_output_test.go
@@ -2,10 +2,49 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
 	"strings"
 	"testing"
 )
+
+// Run labels ride along on RunDetail, so every detail-derived output (inspect
+// run, exec, latest run) must surface them without a second request. Summary
+// derived output has no labels to report and must omit the key entirely rather
+// than render an empty map that reads as "this run has no labels".
+func TestComposeRunOutputCarriesLabelsFromDetailOnly(t *testing.T) {
+	detail := testRunDetail("project-1", "run-labeled", "reviewer", "sandbox-1", agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, 0, "ok\n")
+	detail.Labels = map[string]string{"env": "prod", "team": "platform"}
+
+	output := composeRunOutputFromDetail(detail)
+	if len(output.Labels) != 2 || output.Labels["env"] != "prod" || output.Labels["team"] != "platform" {
+		t.Fatalf("detail output labels = %#v, want env=prod team=platform", output.Labels)
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("marshal detail output: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"labels":{"env":"prod","team":"platform"}`) {
+		t.Fatalf("detail output json = %s", encoded)
+	}
+
+	unlabeled := composeRunOutputFromDetail(testRunDetail("project-1", "run-plain", "reviewer", "sandbox-1", agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED, 0, "ok\n"))
+	if unlabeled.Labels != nil {
+		t.Fatalf("unlabeled detail output labels = %#v, want nil", unlabeled.Labels)
+	}
+	encoded, err = json.Marshal(unlabeled)
+	if err != nil {
+		t.Fatalf("marshal unlabeled output: %v", err)
+	}
+	if strings.Contains(string(encoded), `"labels"`) {
+		t.Fatalf("unlabeled output json must omit labels, got %s", encoded)
+	}
+
+	summaryOutput := composeRunOutputFromSummary(detail.GetSummary(), "project-1", "agent-compose logs")
+	if summaryOutput.Labels != nil {
+		t.Fatalf("summary output labels = %#v, want nil", summaryOutput.Labels)
+	}
+}
 
 func TestPrefixedRunOutputStreamWriterPreservesLinesAcrossChunks(t *testing.T) {
 	summary := &agentcomposev2.RunSummary{RunId: "run-stream-boundary", AgentName: "reviewer"}

--- a/cmd/agent-compose/cli_project.go
+++ b/cmd/agent-compose/cli_project.go
@@ -458,8 +458,12 @@ func composePSOutputFromProject(ctx context.Context, clients cliServiceClients, 
 	if err != nil {
 		return composePSOutput{}, err
 	}
+	labels, err := parseCLIStringMap(options.Labels, "--label")
+	if err != nil {
+		return composePSOutput{}, commandExitError{Code: exitCodeUsage, Err: err}
+	}
 	projectID := project.GetSummary().GetProjectId()
-	runs, err := listProjectRuns(ctx, clients.run, projectID)
+	runs, err := listProjectRuns(ctx, clients.run, projectID, labels)
 	if err != nil {
 		return composePSOutput{}, err
 	}
@@ -474,6 +478,13 @@ func composePSOutputFromProject(ctx context.Context, clients cliServiceClients, 
 	}
 	for _, session := range sessions {
 		if !composePSSessionBelongsToProject(session, project, runBySandbox) {
+			continue
+		}
+		// A label filter is only meaningful against a run that actually
+		// carries the matching labels. Without this, a sandbox with no run in
+		// runBySandbox would still surface via composePSSessionBelongsToProject's
+		// tag-based fallback, silently defeating the filter.
+		if len(labels) > 0 && runBySandbox[session.GetSandboxId()] == nil {
 			continue
 		}
 		status := sandboxStatusText(session.GetStatus())

--- a/cmd/agent-compose/cli_ps_command.go
+++ b/cmd/agent-compose/cli_ps_command.go
@@ -20,5 +20,6 @@ func newCLISandboxListCommand(cli *cliOptions, use, short string, options *compo
 	cmd.Flags().BoolVarP(&options.All, "all", "a", false, "Show current project sandboxes in all statuses")
 	cmd.Flags().StringVar(&options.Status, "status", "", "Filter sandboxes by status: pending, running, stopped, failed, or deleting (comma-separated)")
 	cmd.Flags().BoolVar(&options.Verbose, "verbose", false, "Show more sandbox details")
+	cmd.Flags().StringArrayVar(&options.Labels, "label", nil, "Filter runs by label key=value (repeatable, ANDed)")
 	return cmd
 }

--- a/cmd/agent-compose/cli_run_command.go
+++ b/cmd/agent-compose/cli_run_command.go
@@ -34,6 +34,7 @@ type composeRunOptions struct {
 	Detach        bool
 	Interactive   bool
 	TTY           bool
+	Labels        []string
 }
 
 func composeRunArgs(_ *cobra.Command, args []string) error {
@@ -332,6 +333,10 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 			Expose:  normalizedOptions.JupyterExpose,
 		}
 	}
+	labels, err := parseCLIStringMap(normalizedOptions.Labels, "--label")
+	if err != nil {
+		return commandExitError{Code: exitCodeUsage, Err: err}
+	}
 	runReq := &agentcomposev2.RunAgentRequest{
 		ProjectId:       projectID,
 		AgentName:       agentName,
@@ -343,6 +348,7 @@ func runComposeRunCommand(cmd *cobra.Command, cli cliOptions, options composeRun
 		CleanupPolicy:   cleanupPolicy,
 		ClientRequestId: manualRunClientRequestID(runtimeProject.name(), agentName, firstNonEmptyString(prompt, commandText)),
 		Jupyter:         jupyter,
+		Labels:          labels,
 	}
 	if normalizedOptions.Detach {
 		return startDetachedRun(cmd, cli, runtimeProject.name(), client, runReq)
@@ -616,7 +622,7 @@ func runComposeInspectCommand(cmd *cobra.Command, cli cliOptions, args []string)
 	return writeCommandOutput(cmd.OutOrStdout(), append(data, '\n'))
 }
 
-func listProjectRuns(ctx context.Context, client agentcomposev2connect.RunServiceClient, projectID string) ([]*agentcomposev2.RunSummary, error) {
+func listProjectRuns(ctx context.Context, client agentcomposev2connect.RunServiceClient, projectID string, labels map[string]string) ([]*agentcomposev2.RunSummary, error) {
 	var result []*agentcomposev2.RunSummary
 	var offset uint32
 	const limit uint32 = 100
@@ -625,6 +631,7 @@ func listProjectRuns(ctx context.Context, client agentcomposev2connect.RunServic
 			ProjectId: projectID,
 			Offset:    offset,
 			Limit:     limit,
+			Labels:    labels,
 		}))
 		if err != nil {
 			return nil, err

--- a/cmd/agent-compose/cli_run_definition.go
+++ b/cmd/agent-compose/cli_run_definition.go
@@ -23,6 +23,7 @@ func newCLIRunCommand(cli *cliOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.Detach, "detach", "d", false, "Start the run in the daemon and return immediately")
 	cmd.Flags().BoolVarP(&options.Interactive, "interactive", "i", false, "Reserved for future interactive runs")
 	cmd.Flags().BoolVarP(&options.TTY, "tty", "t", false, "Allocate a TTY for interactive command runs")
+	cmd.Flags().StringArrayVar(&options.Labels, "label", nil, "Attach a key=value label to this run (repeatable)")
 	cmd.Flags().Lookup("prompt").NoOptDefVal = optionalRunModeFlagNoValue
 	cmd.Flags().Lookup("command").NoOptDefVal = optionalRunModeFlagNoValue
 	hideOptionalFlagNoValueInUsage(cmd, "prompt", "command")

--- a/cmd/agent-compose/cli_run_output.go
+++ b/cmd/agent-compose/cli_run_output.go
@@ -85,9 +85,13 @@ type composeRunOutput struct {
 	Driver         string   `json:"driver,omitempty"`
 	ImageRef       string   `json:"image_ref,omitempty"`
 	Warnings       []string `json:"warnings,omitempty"`
-	LogsCommand    string   `json:"logs_command,omitempty"`
-	JupyterURL     string   `json:"jupyter_url,omitempty"`
-	JupyterPath    string   `json:"jupyter_path,omitempty"`
+	// Labels is only populated from a RunDetail. Summary-derived output omits it
+	// because RunSummary carries no labels, so an absent field means "not
+	// reported here", never "this run has no labels".
+	Labels      map[string]string `json:"labels,omitempty"`
+	LogsCommand string            `json:"logs_command,omitempty"`
+	JupyterURL  string            `json:"jupyter_url,omitempty"`
+	JupyterPath string            `json:"jupyter_path,omitempty"`
 }
 
 func latestRunOutput(ctx context.Context, client agentcomposev2connect.RunServiceClient, projectID, agentName string) (*composeRunOutput, error) {
@@ -163,6 +167,7 @@ func composeRunOutputFromDetailWithOptions(run *agentcomposev2.RunDetail, option
 		Driver:         run.GetDriver(),
 		ImageRef:       run.GetImageRef(),
 		Warnings:       appendUniqueStrings(append([]string(nil), summary.GetWarnings()...), run.GetWarnings()...),
+		Labels:         run.GetLabels(),
 	}
 }
 

--- a/cmd/agent-compose/cli_run_output.go
+++ b/cmd/agent-compose/cli_run_output.go
@@ -85,9 +85,12 @@ type composeRunOutput struct {
 	Driver         string   `json:"driver,omitempty"`
 	ImageRef       string   `json:"image_ref,omitempty"`
 	Warnings       []string `json:"warnings,omitempty"`
-	// Labels is only populated from a RunDetail. Summary-derived output omits it
-	// because RunSummary carries no labels, so an absent field means "not
-	// reported here", never "this run has no labels".
+	// Labels is only populated from a RunDetail; summary-derived output leaves
+	// it nil because RunSummary carries no labels. omitempty drops a nil and an
+	// empty map alike, so an absent field means "no label information here" —
+	// it covers both a summary-derived output and a detail-derived run that
+	// genuinely has no labels, and the two cannot be told apart. That matches
+	// the API, where proto3 JSON omits an empty labels map on GetRun too.
 	Labels      map[string]string `json:"labels,omitempty"`
 	LogsCommand string            `json:"logs_command,omitempty"`
 	JupyterURL  string            `json:"jupyter_url,omitempty"`

--- a/pkg/agentcompose/api/run.go
+++ b/pkg/agentcompose/api/run.go
@@ -24,6 +24,7 @@ func ProjectRunDetailToProto(run domain.ProjectRunRecord) *agentcomposev2.RunDet
 		ImageRef:     run.ImageRef,
 		Warnings:     append([]string(nil), run.Warnings...),
 		ErrorStack:   run.ErrorStack,
+		Labels:       run.Labels,
 	}
 }
 

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -223,6 +223,14 @@ func (h *RunHandler) ListRuns(ctx context.Context, req *connect.Request[agentcom
 	if err != nil {
 		return nil, err
 	}
+	// Normalize with the same rules the write path applies, so a filter key
+	// matches the stored form and an oversized label set is refused as a client
+	// error instead of reaching SQLite and failing its expression-depth limit
+	// as an internal error.
+	labels, err := domain.NormalizeProjectRunLabels(req.Msg.GetLabels())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
 	options := domain.ProjectRunListOptions{
 		ProjectID:      req.Msg.GetProjectId(),
 		AgentName:      req.Msg.GetAgentName(),
@@ -235,7 +243,7 @@ func (h *RunHandler) ListRuns(ctx context.Context, req *connect.Request[agentcom
 		StartedTo:      startedTo,
 		Offset:         offset,
 		Limit:          limit,
-		Labels:         req.Msg.GetLabels(),
+		Labels:         labels,
 	}
 	runs, err := h.store.ListProjectRunsByOptions(ctx, options)
 	if err != nil {

--- a/pkg/agentcompose/api/run_handler.go
+++ b/pkg/agentcompose/api/run_handler.go
@@ -235,6 +235,7 @@ func (h *RunHandler) ListRuns(ctx context.Context, req *connect.Request[agentcom
 		StartedTo:      startedTo,
 		Offset:         offset,
 		Limit:          limit,
+		Labels:         req.Msg.GetLabels(),
 	}
 	runs, err := h.store.ListProjectRunsByOptions(ctx, options)
 	if err != nil {

--- a/pkg/agentcompose/api/run_list_filter_test.go
+++ b/pkg/agentcompose/api/run_list_filter_test.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
+	domain "github.com/chaitin/agent-compose/pkg/model"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -59,5 +61,58 @@ func assertOptionalInstant(t *testing.T, name string, got, want *time.Time) {
 	}
 	if !got.Equal(*want) {
 		t.Fatalf("%s = %v, want instant %v", name, got, want)
+	}
+}
+
+func TestListRunsLabelFilterNormalization(t *testing.T) {
+	overLimit := make(map[string]string, domain.MaxProjectRunLabels+1)
+	for index := range domain.MaxProjectRunLabels + 1 {
+		overLimit[fmt.Sprintf("k%d", index)] = "v"
+	}
+	atLimit := make(map[string]string, domain.MaxProjectRunLabels)
+	for index := range domain.MaxProjectRunLabels {
+		atLimit[fmt.Sprintf("k%d", index)] = "v"
+	}
+
+	tests := []struct {
+		name      string
+		labels    map[string]string
+		want      map[string]string
+		wantError bool
+	}{
+		{name: "no labels"},
+		{name: "at limit", labels: atLimit, want: atLimit},
+		// Without a bound this reaches SQLite and fails its expression-tree
+		// depth limit as an internal error instead of a client error.
+		{name: "over limit", labels: overLimit, wantError: true},
+		{name: "padded key trimmed", labels: map[string]string{"  env  ": "prod"}, want: map[string]string{"env": "prod"}},
+		{name: "colliding keys", labels: map[string]string{"env": "prod", " env ": "staging"}, wantError: true},
+		{name: "empty key", labels: map[string]string{"  ": "prod"}, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := domain.NormalizeProjectRunLabels(tt.labels)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("normalize %#v succeeded, want rejection", tt.labels)
+				}
+				if code := connect.CodeOf(connect.NewError(connect.CodeInvalidArgument, err)); code != connect.CodeInvalidArgument {
+					t.Fatalf("mapped code = %v, want %v", code, connect.CodeInvalidArgument)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalize %#v: %v", tt.labels, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("normalized = %#v, want %#v", got, tt.want)
+			}
+			for key, value := range tt.want {
+				if got[key] != value {
+					t.Fatalf("normalized[%q] = %q, want %q", key, got[key], value)
+				}
+			}
+		})
 	}
 }

--- a/pkg/agentcompose/app/run_controller.go
+++ b/pkg/agentcompose/app/run_controller.go
@@ -295,6 +295,7 @@ func runAgentRequestFromProto(msg *agentcomposev2.RunAgentRequest) runs.RunAgent
 		CleanupPolicy:    msg.GetCleanupPolicy(),
 		Jupyter:          msg.GetJupyter(),
 		Volumes:          volumeMountSpecsFromProto(msg.GetVolumes()),
+		Labels:           msg.GetLabels(),
 	}
 }
 

--- a/pkg/model/project_model.go
+++ b/pkg/model/project_model.go
@@ -1,6 +1,67 @@
 package model
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	// MaxProjectRunLabels caps how many labels one run may carry and how many
+	// may be ANDed into a single run list filter. Both directions need a bound.
+	// Unbounded writes let a single run grow project_run_label without limit,
+	// and the filter path emits one EXISTS subquery per label, which trips
+	// SQLite's expression-tree depth limit of 1000 somewhere past 900 labels
+	// and surfaces to the caller as an opaque internal error. The cap sits far
+	// below that ceiling because labels identify a run rather than describe it.
+	MaxProjectRunLabels = 64
+	// MaxProjectRunLabelKeyBytes and MaxProjectRunLabelValueBytes are byte
+	// counts, not rune counts, so a multi-byte key reaches the limit sooner
+	// than its character count suggests.
+	MaxProjectRunLabelKeyBytes   = 128
+	MaxProjectRunLabelValueBytes = 256
+)
+
+// ValidateProjectRunLabelCount bounds a label set without normalizing it, for
+// the list filter path where labels are matched rather than stored.
+func ValidateProjectRunLabelCount(labels map[string]string) error {
+	if len(labels) > MaxProjectRunLabels {
+		return fmt.Errorf("run labels exceed the %d label limit (got %d)", MaxProjectRunLabels, len(labels))
+	}
+	return nil
+}
+
+// NormalizeProjectRunLabels validates a label set and returns it with keys
+// trimmed, so a direct API caller sending " env " and a CLI caller sending
+// "env" converge on one label instead of two that silently miss each other at
+// filter time. Two raw keys that trim to the same key are rejected rather than
+// resolved by map iteration order, which would pick a winner at random.
+func NormalizeProjectRunLabels(labels map[string]string) (map[string]string, error) {
+	if err := ValidateProjectRunLabelCount(labels); err != nil {
+		return nil, err
+	}
+	if len(labels) == 0 {
+		return nil, nil
+	}
+	normalized := make(map[string]string, len(labels))
+	for key, value := range labels {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			return nil, fmt.Errorf("run label key must not be empty")
+		}
+		if len(trimmed) > MaxProjectRunLabelKeyBytes {
+			return nil, fmt.Errorf("run label key %q exceeds %d bytes", trimmed, MaxProjectRunLabelKeyBytes)
+		}
+		if len(value) > MaxProjectRunLabelValueBytes {
+			return nil, fmt.Errorf("run label value for key %q exceeds %d bytes", trimmed, MaxProjectRunLabelValueBytes)
+		}
+		if _, exists := normalized[trimmed]; exists {
+			return nil, fmt.Errorf("run label key %q is specified more than once after trimming surrounding whitespace", trimmed)
+		}
+		normalized[trimmed] = value
+	}
+	return normalized, nil
+}
 
 const (
 	ProjectRunStatusPending   = "pending"

--- a/pkg/model/project_model.go
+++ b/pkg/model/project_model.go
@@ -109,6 +109,11 @@ type ProjectRunRecord struct {
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
 	Warnings        []string  `json:"warnings,omitempty"`
+	// Labels holds user-defined key/value pairs attached to the run at start
+	// time. It is not a column on project_run; it is populated by GetProjectRun
+	// from the project_run_label table on read, and by Coordinator.BeginRun on
+	// write for the store layer to persist into project_run_label.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // ProjectRunCompletionRecord is the durable intent to finish a run after its
@@ -188,6 +193,9 @@ type ProjectRunListOptions struct {
 	StartedTo      *time.Time
 	Offset         int
 	Limit          int
+	// Labels filters to runs carrying every given key/value pair (AND semantics).
+	// An empty map applies no filter.
+	Labels map[string]string
 }
 
 type ProjectAgentRunState struct {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -213,6 +213,7 @@ type RunAgentRequest struct {
 	StickyBindingTriggerID   string
 	StickyBindingConfigHash  string
 	Interactive              bool
+	Labels                   map[string]string
 }
 
 type StreamSink struct {
@@ -260,6 +261,7 @@ func (c *Controller) StartProjectRun(ctx context.Context, req RunAgentRequest) (
 		Driver:          req.Driver,
 		CleanupPolicy:   CleanupPolicyFromProto(req.CleanupPolicy),
 		ClientRequestID: req.ClientRequestID,
+		Labels:          req.Labels,
 	})
 	if err != nil {
 		return StartedProjectRun{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)

--- a/pkg/runs/coordinator.go
+++ b/pkg/runs/coordinator.go
@@ -25,6 +25,7 @@ type StartRequest struct {
 	Driver          string
 	CleanupPolicy   string
 	ClientRequestID string
+	Labels          map[string]string
 }
 
 type TransitionRequest struct {
@@ -151,6 +152,7 @@ func (c *Coordinator) BeginRun(ctx context.Context, req StartRequest) (domain.Pr
 		ImageRef:        firstNonEmpty(agent.GuestImage, projectAgent.Image),
 		CleanupPolicy:   NormalizeCleanupPolicy(req.CleanupPolicy),
 		ResultJSON:      "{}",
+		Labels:          req.Labels,
 	}
 	var initialEvents []domain.ProjectRunEventRecord
 	if strings.TrimSpace(run.Prompt) != "" {

--- a/pkg/storage/configstore/project_run_event_transaction.go
+++ b/pkg/storage/configstore/project_run_event_transaction.go
@@ -48,6 +48,8 @@ func (s *projectStore) CreateProjectRunWithEvents(ctx context.Context, run Proje
 			return ProjectRunRecord{}, fmt.Errorf("load existing project run %s: %w", run.RunID, loadErr)
 		}
 		run = existing
+	} else if err := insertProjectRunLabelsTx(ctx, tx, run.RunID, run.Labels); err != nil {
+		return ProjectRunRecord{}, err
 	}
 	if _, _, err := appendProjectRunEventsTx(ctx, tx, events); err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("append create project run events: %w", err)
@@ -116,5 +118,14 @@ func validateRunEventBatch(runID string, events []domain.ProjectRunEventRecord) 
 }
 
 func getProjectRunTx(ctx context.Context, tx *sql.Tx, runID string) (ProjectRunRecord, error) {
-	return projects.ScanProjectRun(tx.QueryRowContext(ctx, projects.SelectProjectRunSQL()+` WHERE run_id = ?`, runID).Scan)
+	item, err := projects.ScanProjectRun(tx.QueryRowContext(ctx, projects.SelectProjectRunSQL()+` WHERE run_id = ?`, runID).Scan)
+	if err != nil {
+		return ProjectRunRecord{}, err
+	}
+	labels, err := loadProjectRunLabels(ctx, tx, item.RunID)
+	if err != nil {
+		return ProjectRunRecord{}, err
+	}
+	item.Labels = labels
+	return item, nil
 }

--- a/pkg/storage/configstore/project_run_filter.go
+++ b/pkg/storage/configstore/project_run_filter.go
@@ -1,6 +1,8 @@
 package configstore
 
 import (
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/chaitin/agent-compose/internal/projects"
@@ -49,6 +51,12 @@ func projectRunFilter(options model.ProjectRunListOptions) ([]string, []any) {
 	if options.StartedTo != nil {
 		where = append(where, "started_at <= ?")
 		args = append(args, options.StartedTo.UnixMilli())
+	}
+	// Sort keys first so the generated SQL text (and therefore its prepared
+	// statement cache key) is stable across calls with the same filter set.
+	for _, key := range slices.Sorted(maps.Keys(options.Labels)) {
+		where = append(where, "EXISTS (SELECT 1 FROM project_run_label WHERE run_id = project_run.run_id AND key = ? AND value = ?)")
+		args = append(args, key, options.Labels[key])
 	}
 	return where, args
 }

--- a/pkg/storage/configstore/project_run_label.go
+++ b/pkg/storage/configstore/project_run_label.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
 )
 
 const (
-	maxProjectRunLabelKeyLen   = 128
-	maxProjectRunLabelValueLen = 256
+	maxProjectRunLabelKeyLen   = domain.MaxProjectRunLabelKeyBytes
+	maxProjectRunLabelValueLen = domain.MaxProjectRunLabelValueBytes
 )
 
 // rowQueryer is satisfied by both *sql.DB and *sql.Tx, letting label reads run
@@ -53,16 +54,11 @@ func loadProjectRunLabels(ctx context.Context, q rowQueryer, runID string) (map[
 // the CLI's --label flag or a direct RunAgent API call, is validated here and
 // only here.
 func insertProjectRunLabelsTx(ctx context.Context, tx *sql.Tx, runID string, labels map[string]string) error {
-	for key, value := range labels {
-		if strings.TrimSpace(key) == "" {
-			return fmt.Errorf("run label key must not be empty")
-		}
-		if len(key) > maxProjectRunLabelKeyLen {
-			return fmt.Errorf("run label key %q exceeds %d characters", key, maxProjectRunLabelKeyLen)
-		}
-		if len(value) > maxProjectRunLabelValueLen {
-			return fmt.Errorf("run label value for key %q exceeds %d characters", key, maxProjectRunLabelValueLen)
-		}
+	normalized, err := domain.NormalizeProjectRunLabels(labels)
+	if err != nil {
+		return err
+	}
+	for key, value := range normalized {
 		if _, err := tx.ExecContext(ctx, `INSERT INTO project_run_label(run_id, key, value) VALUES(?, ?, ?)
 			ON CONFLICT(run_id, key) DO UPDATE SET value = excluded.value`, runID, key, value); err != nil {
 			return fmt.Errorf("insert project run label %q for run %s: %w", key, runID, err)

--- a/pkg/storage/configstore/project_run_label.go
+++ b/pkg/storage/configstore/project_run_label.go
@@ -1,0 +1,72 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const (
+	maxProjectRunLabelKeyLen   = 128
+	maxProjectRunLabelValueLen = 256
+)
+
+// rowQueryer is satisfied by both *sql.DB and *sql.Tx, letting label reads run
+// either standalone or inside an already-open transaction.
+type rowQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// loadProjectRunLabels aggregates the full label set for one run from
+// project_run_label. There is no redundant column on project_run, so this
+// query is the only way to reconstruct a run's labels for detail-view reads
+// (GetProjectRun and the transactional helpers that back RunAgent/GetRun).
+// ListProjectRunsByOptions never calls this: labels live on RunDetail, not
+// RunSummary, so the high-frequency list/stream path stays free of it.
+func loadProjectRunLabels(ctx context.Context, q rowQueryer, runID string) (map[string]string, error) {
+	rows, err := q.QueryContext(ctx, `SELECT key, value FROM project_run_label WHERE run_id = ?`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("load project run labels %s: %w", runID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var labels map[string]string
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, fmt.Errorf("scan project run label %s: %w", runID, err)
+		}
+		if labels == nil {
+			labels = make(map[string]string, 4)
+		}
+		labels[key] = value
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate project run labels %s: %w", runID, err)
+	}
+	return labels, nil
+}
+
+// insertProjectRunLabelsTx validates and persists labels into
+// project_run_label inside an already-open transaction. This is the single
+// write path for run labels: every caller, whether it reached here through
+// the CLI's --label flag or a direct RunAgent API call, is validated here and
+// only here.
+func insertProjectRunLabelsTx(ctx context.Context, tx *sql.Tx, runID string, labels map[string]string) error {
+	for key, value := range labels {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("run label key must not be empty")
+		}
+		if len(key) > maxProjectRunLabelKeyLen {
+			return fmt.Errorf("run label key %q exceeds %d characters", key, maxProjectRunLabelKeyLen)
+		}
+		if len(value) > maxProjectRunLabelValueLen {
+			return fmt.Errorf("run label value for key %q exceeds %d characters", key, maxProjectRunLabelValueLen)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO project_run_label(run_id, key, value) VALUES(?, ?, ?)
+			ON CONFLICT(run_id, key) DO UPDATE SET value = excluded.value`, runID, key, value); err != nil {
+			return fmt.Errorf("insert project run label %q for run %s: %w", key, runID, err)
+		}
+	}
+	return nil
+}

--- a/pkg/storage/configstore/project_run_label_test.go
+++ b/pkg/storage/configstore/project_run_label_test.go
@@ -1,0 +1,253 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+func TestCreateProjectRunPersistsAndRoundTripsLabels(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-labels", Name: "labels"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-labels", AgentName: "worker"})
+
+	labels := map[string]string{"env": "prod", "team": "platform"}
+	created, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+		RunID: "run-labeled", ProjectID: "project-labels", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning, Labels: labels,
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if len(created.Labels) != 2 || created.Labels["env"] != "prod" || created.Labels["team"] != "platform" {
+		t.Fatalf("created run labels = %#v, want %#v", created.Labels, labels)
+	}
+
+	fetched, err := store.GetProjectRun(ctx, "run-labeled")
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if len(fetched.Labels) != 2 || fetched.Labels["env"] != "prod" || fetched.Labels["team"] != "platform" {
+		t.Fatalf("fetched run labels = %#v, want %#v", fetched.Labels, labels)
+	}
+
+	unlabeled, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+		RunID: "run-unlabeled", ProjectID: "project-labels", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning,
+	})
+	if err != nil {
+		t.Fatalf("create unlabeled run: %v", err)
+	}
+	if unlabeled.Labels != nil {
+		t.Fatalf("unlabeled created run labels = %#v, want nil", unlabeled.Labels)
+	}
+	fetchedUnlabeled, err := store.GetProjectRun(ctx, "run-unlabeled")
+	if err != nil {
+		t.Fatalf("get unlabeled run: %v", err)
+	}
+	if fetchedUnlabeled.Labels != nil {
+		t.Fatalf("fetched unlabeled run labels = %#v, want nil", fetchedUnlabeled.Labels)
+	}
+}
+
+func TestListProjectRunsByOptionsFiltersByLabelsWithAndSemantics(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-label-filter", Name: "label-filter"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-label-filter", AgentName: "worker"})
+
+	runs := map[string]map[string]string{
+		"run-prod-platform": {"env": "prod", "team": "platform"},
+		"run-prod-search":   {"env": "prod", "team": "search"},
+		"run-staging":       {"env": "staging", "team": "platform"},
+		"run-no-labels":     nil,
+	}
+	for runID, labels := range runs {
+		if _, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+			RunID: runID, ProjectID: "project-label-filter", AgentName: "worker", AgentID: agentID,
+			Status: domain.ProjectRunStatusRunning, Labels: labels,
+		}); err != nil {
+			t.Fatalf("create run %s: %v", runID, err)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]bool
+	}{
+		{name: "no filter", labels: nil, want: runIDs("run-prod-platform", "run-prod-search", "run-staging", "run-no-labels")},
+		{name: "single label", labels: map[string]string{"env": "prod"}, want: runIDs("run-prod-platform", "run-prod-search")},
+		{name: "multi label AND", labels: map[string]string{"env": "prod", "team": "platform"}, want: runIDs("run-prod-platform")},
+		{name: "no match", labels: map[string]string{"team": "search", "env": "staging"}, want: map[string]bool{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := domain.ProjectRunListOptions{ProjectID: "project-label-filter", Labels: tt.labels, Limit: 50}
+			got, err := store.ListProjectRunsByOptions(ctx, options)
+			if err != nil {
+				t.Fatalf("list runs: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("run count = %d, want %d: %#v", len(got), len(tt.want), got)
+			}
+			for _, run := range got {
+				if !tt.want[run.RunID] {
+					t.Errorf("unexpected run %q", run.RunID)
+				}
+			}
+			total, err := store.CountProjectRuns(ctx, options)
+			if err != nil || total != len(tt.want) {
+				t.Fatalf("count = %d, want %d (err=%v)", total, len(tt.want), err)
+			}
+		})
+	}
+}
+
+func TestInsertProjectRunLabelsTxRejectsInvalidKeysAndValues(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-invalid-labels", Name: "invalid-labels"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-invalid-labels", AgentName: "worker"})
+
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		wantErr string
+	}{
+		{name: "empty key", labels: map[string]string{"": "value"}, wantErr: "must not be empty"},
+		{name: "whitespace key", labels: map[string]string{"   ": "value"}, wantErr: "must not be empty"},
+		{name: "oversized key", labels: map[string]string{strings.Repeat("k", maxProjectRunLabelKeyLen+1): "value"}, wantErr: "exceeds"},
+		{name: "oversized value", labels: map[string]string{"key": strings.Repeat("v", maxProjectRunLabelValueLen+1)}, wantErr: "exceeds"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runID := "run-invalid-labels"
+			_, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+				RunID: runID, ProjectID: "project-invalid-labels", AgentName: "worker", AgentID: agentID,
+				Status: domain.ProjectRunStatusRunning, Labels: tt.labels,
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("create run error = %v, want substring %q", err, tt.wantErr)
+			}
+			if _, err := store.GetProjectRun(ctx, runID); !errors.Is(err, domain.ErrNotFound) {
+				t.Fatalf("run survived rejected label insert: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateProjectRunWithEventsRetryPreservesOriginalLabels(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-retry-labels", Name: "retry-labels"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-retry-labels", AgentName: "worker"})
+
+	run := domain.ProjectRunRecord{
+		RunID: "run-retry-labels", ProjectID: "project-retry-labels", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning, Labels: map[string]string{"attempt": "first"},
+	}
+	first, err := store.CreateProjectRunWithEvents(ctx, run, nil)
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if first.Labels["attempt"] != "first" {
+		t.Fatalf("first create labels = %#v, want attempt=first", first.Labels)
+	}
+
+	retry := run
+	retry.Labels = map[string]string{"attempt": "second"}
+	second, err := store.CreateProjectRunWithEvents(ctx, retry, nil)
+	if err != nil {
+		t.Fatalf("retry create: %v", err)
+	}
+	if second.Labels["attempt"] != "first" {
+		t.Fatalf("retry create labels = %#v, want original attempt=first preserved", second.Labels)
+	}
+
+	stored, err := store.GetProjectRun(ctx, run.RunID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if len(stored.Labels) != 1 || stored.Labels["attempt"] != "first" {
+		t.Fatalf("stored labels = %#v, want only attempt=first", stored.Labels)
+	}
+}
+
+func TestInsertProjectRunLabelsTxUpsertsOnConflict(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	store := FromDB(db)
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-upsert-labels", Name: "upsert-labels"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-upsert-labels", AgentName: "worker"})
+	if _, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+		RunID: "run-upsert-labels", ProjectID: "project-upsert-labels", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning, Labels: map[string]string{"env": "staging"},
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	if err := withTx(ctx, db, func(tx *sql.Tx) error {
+		return insertProjectRunLabelsTx(ctx, tx, "run-upsert-labels", map[string]string{"env": "prod"})
+	}); err != nil {
+		t.Fatalf("upsert label: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM project_run_label WHERE run_id = ? AND key = ?`, "run-upsert-labels", "env").Scan(&count); err != nil {
+		t.Fatalf("count label rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("label row count = %d, want 1 (no duplicate row on conflict)", count)
+	}
+
+	stored, err := store.GetProjectRun(ctx, "run-upsert-labels")
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if stored.Labels["env"] != "prod" {
+		t.Fatalf("label after upsert = %q, want prod", stored.Labels["env"])
+	}
+}
+
+func withTx(ctx context.Context, db *sql.DB, fn func(tx *sql.Tx) error) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/pkg/storage/configstore/project_run_label_test.go
+++ b/pkg/storage/configstore/project_run_label_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -275,4 +276,93 @@ func withTx(ctx context.Context, db *sql.DB, fn func(tx *sql.Tx) error) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+func TestInsertProjectRunLabelsTxEnforcesLabelCountLimit(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-label-count", Name: "label-count"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-label-count", AgentName: "worker"})
+
+	labels := func(count int) map[string]string {
+		result := make(map[string]string, count)
+		for index := range count {
+			result[fmt.Sprintf("k%d", index)] = "v"
+		}
+		return result
+	}
+
+	atLimit, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+		RunID: "run-at-limit", ProjectID: "project-label-count", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning, Labels: labels(domain.MaxProjectRunLabels),
+	})
+	if err != nil {
+		t.Fatalf("create run at limit: %v", err)
+	}
+	if len(atLimit.Labels) != domain.MaxProjectRunLabels {
+		t.Fatalf("labels at limit = %d, want %d", len(atLimit.Labels), domain.MaxProjectRunLabels)
+	}
+
+	_, err = store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+		RunID: "run-over-limit", ProjectID: "project-label-count", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning, Labels: labels(domain.MaxProjectRunLabels + 1),
+	})
+	if err == nil || !strings.Contains(err.Error(), "label limit") {
+		t.Fatalf("create run over limit error = %v, want label limit rejection", err)
+	}
+	if _, err := store.GetProjectRun(ctx, "run-over-limit"); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("run survived rejected oversized label set: %v", err)
+	}
+}
+
+func TestInsertProjectRunLabelsTxTrimsKeys(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-label-trim", Name: "label-trim"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-label-trim", AgentName: "worker"})
+
+	// A padded key must land in the same slot a CLI caller's trimmed key would,
+	// otherwise the two forms become separate labels that miss each other.
+	created, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+		RunID: "run-padded-key", ProjectID: "project-label-trim", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning, Labels: map[string]string{"  env  ": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if created.Labels["env"] != "prod" || len(created.Labels) != 1 {
+		t.Fatalf("created labels = %#v, want {env: prod}", created.Labels)
+	}
+	matched, err := store.ListProjectRunsByOptions(ctx, domain.ProjectRunListOptions{
+		ProjectID: "project-label-trim", Labels: map[string]string{"env": "prod"}, Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("list by trimmed label: %v", err)
+	}
+	if len(matched) != 1 || matched[0].RunID != "run-padded-key" {
+		t.Fatalf("trimmed filter matched %#v, want run-padded-key", matched)
+	}
+
+	// Two raw keys collapsing to one must be refused rather than resolved by
+	// map iteration order.
+	_, err = store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+		RunID: "run-colliding-keys", ProjectID: "project-label-trim", AgentName: "worker", AgentID: agentID,
+		Status: domain.ProjectRunStatusRunning, Labels: map[string]string{"env": "prod", " env ": "staging"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "more than once") {
+		t.Fatalf("colliding keys error = %v, want duplicate-key rejection", err)
+	}
+	if _, err := store.GetProjectRun(ctx, "run-colliding-keys"); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("run survived rejected colliding label keys: %v", err)
+	}
 }

--- a/pkg/storage/configstore/project_run_label_test.go
+++ b/pkg/storage/configstore/project_run_label_test.go
@@ -132,26 +132,51 @@ func TestInsertProjectRunLabelsTxRejectsInvalidKeysAndValues(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		runID   string
 		labels  map[string]string
-		wantErr string
+		wantErr string // empty means the labels must be accepted as-is
 	}{
-		{name: "empty key", labels: map[string]string{"": "value"}, wantErr: "must not be empty"},
-		{name: "whitespace key", labels: map[string]string{"   ": "value"}, wantErr: "must not be empty"},
-		{name: "oversized key", labels: map[string]string{strings.Repeat("k", maxProjectRunLabelKeyLen+1): "value"}, wantErr: "exceeds"},
-		{name: "oversized value", labels: map[string]string{"key": strings.Repeat("v", maxProjectRunLabelValueLen+1)}, wantErr: "exceeds"},
+		{name: "empty key", runID: "run-empty-key", labels: map[string]string{"": "value"}, wantErr: "must not be empty"},
+		{name: "whitespace key", runID: "run-whitespace-key", labels: map[string]string{"   ": "value"}, wantErr: "must not be empty"},
+		{name: "oversized key", runID: "run-oversized-key", labels: map[string]string{strings.Repeat("k", maxProjectRunLabelKeyLen+1): "value"}, wantErr: "exceeds"},
+		{name: "oversized value", runID: "run-oversized-value", labels: map[string]string{"key": strings.Repeat("v", maxProjectRunLabelValueLen+1)}, wantErr: "exceeds"},
+		{name: "max length key accepted", runID: "run-max-key", labels: map[string]string{strings.Repeat("k", maxProjectRunLabelKeyLen): "value"}},
+		{name: "max length value accepted", runID: "run-max-value", labels: map[string]string{"key": strings.Repeat("v", maxProjectRunLabelValueLen)}},
+		{name: "empty value accepted", runID: "run-empty-value", labels: map[string]string{"key": ""}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runID := "run-invalid-labels"
-			_, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
-				RunID: runID, ProjectID: "project-invalid-labels", AgentName: "worker", AgentID: agentID,
+			created, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+				RunID: tt.runID, ProjectID: "project-invalid-labels", AgentName: "worker", AgentID: agentID,
 				Status: domain.ProjectRunStatusRunning, Labels: tt.labels,
 			})
-			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("create run error = %v, want substring %q", err, tt.wantErr)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("create run error = %v, want substring %q", err, tt.wantErr)
+				}
+				if _, err := store.GetProjectRun(ctx, tt.runID); !errors.Is(err, domain.ErrNotFound) {
+					t.Fatalf("run survived rejected label insert: %v", err)
+				}
+				return
 			}
-			if _, err := store.GetProjectRun(ctx, runID); !errors.Is(err, domain.ErrNotFound) {
-				t.Fatalf("run survived rejected label insert: %v", err)
+			if err != nil {
+				t.Fatalf("create run: %v", err)
+			}
+			for key, value := range tt.labels {
+				got, ok := created.Labels[key]
+				if !ok || got != value {
+					t.Fatalf("created run label %q = (%q, present=%v), want (%q, present=true)", key, got, ok, value)
+				}
+			}
+			fetched, err := store.GetProjectRun(ctx, tt.runID)
+			if err != nil {
+				t.Fatalf("get run: %v", err)
+			}
+			for key, value := range tt.labels {
+				got, ok := fetched.Labels[key]
+				if !ok || got != value {
+					t.Fatalf("fetched run label %q = (%q, present=%v), want (%q, present=true)", key, got, ok, value)
+				}
 			}
 		})
 	}

--- a/pkg/storage/configstore/project_store.go
+++ b/pkg/storage/configstore/project_store.go
@@ -420,7 +420,12 @@ func (s *projectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecor
 	now := time.Now().UTC()
 	run.CreatedAt = now
 	run.UpdatedAt = now
-	if _, err := s.db.ExecContext(ctx, `INSERT INTO project_run(
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ProjectRunRecord{}, fmt.Errorf("begin create project run transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `INSERT INTO project_run(
 		run_id, project_id, project_name, project_revision, agent_name, agent_id, source, scheduler_id, scheduler_run_id, trigger_id, status,
 		sandbox_id, exit_code, error, error_stack, prompt, output, result_json, logs_path, artifacts_dir, cleanup_error, cleanup_policy, sandbox_created, driver, image_ref,
 		started_at, completed_at, duration_ms, created_at, updated_at
@@ -430,7 +435,17 @@ func (s *projectStore) CreateProjectRun(ctx context.Context, run ProjectRunRecor
 		domain.NonZeroTimeUnixMilli(run.StartedAt), domain.NonZeroTimeUnixMilli(run.CompletedAt), run.DurationMs, run.CreatedAt.Unix(), run.UpdatedAt.Unix()); err != nil {
 		return ProjectRunRecord{}, fmt.Errorf("insert project run %s: %w", run.RunID, err)
 	}
-	return s.GetProjectRun(ctx, run.RunID)
+	if err := insertProjectRunLabelsTx(ctx, tx, run.RunID, run.Labels); err != nil {
+		return ProjectRunRecord{}, err
+	}
+	stored, err := getProjectRunTx(ctx, tx, run.RunID)
+	if err != nil {
+		return ProjectRunRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ProjectRunRecord{}, fmt.Errorf("commit create project run transaction: %w", err)
+	}
+	return stored, nil
 }
 
 func (s *projectStore) UpdateProjectRun(ctx context.Context, run ProjectRunRecord) (ProjectRunRecord, error) {
@@ -474,6 +489,11 @@ func (s *projectStore) GetProjectRun(ctx context.Context, runID string) (Project
 		}
 		return ProjectRunRecord{}, err
 	}
+	labels, err := loadProjectRunLabels(ctx, s.db, item.RunID)
+	if err != nil {
+		return ProjectRunRecord{}, err
+	}
+	item.Labels = labels
 	return item, nil
 }
 

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -822,6 +822,7 @@ func assertProjectSchema(t *testing.T, store *ConfigStore) {
 		"project_run": {"run_id", "project_id", "project_name", "project_revision", "agent_name", "agent_id", "source", "scheduler_id", "scheduler_run_id", "trigger_id", "status",
 			"sandbox_id", "exit_code", "error", "prompt", "output", "result_json", "logs_path", "artifacts_dir", "cleanup_error", "driver", "image_ref", "started_at",
 			"completed_at", "duration_ms", "created_at", "updated_at"},
+		"project_run_label": {"run_id", "key", "value"},
 		"scheduler_trigger": {"scheduler_id", "trigger_id", "kind", "spec_json"},
 		"scheduler_run":     {"scheduler_id", "run_id", "status", "started_at"},
 		"scheduler_event":   {"scheduler_id", "scheduler_run_id", "event_id", "type"},
@@ -840,6 +841,8 @@ func assertProjectSchema(t *testing.T, store *ConfigStore) {
 		"idx_project_run_scheduler",
 		"idx_project_run_scheduler_run",
 		"idx_scheduler_run_started",
+		"idx_project_run_label_key_value",
+		"idx_project_run_label_run_id",
 	} {
 		assertSQLiteIndexExists(t, store.db, index)
 	}

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -841,8 +841,6 @@ func assertProjectSchema(t *testing.T, store *ConfigStore) {
 		"idx_project_run_scheduler",
 		"idx_project_run_scheduler_run",
 		"idx_scheduler_run_started",
-		"idx_project_run_label_key_value",
-		"idx_project_run_label_run_id",
 	} {
 		assertSQLiteIndexExists(t, store.db, index)
 	}

--- a/pkg/storage/sqlite/migrations/000014_run_label.sql
+++ b/pkg/storage/sqlite/migrations/000014_run_label.sql
@@ -1,0 +1,10 @@
+CREATE TABLE project_run_label (
+    run_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    FOREIGN KEY(run_id) REFERENCES project_run(run_id) ON DELETE CASCADE,
+    UNIQUE(run_id, key)
+);
+
+CREATE INDEX idx_project_run_label_key_value ON project_run_label(key, value);
+CREATE INDEX idx_project_run_label_run_id ON project_run_label(run_id);

--- a/pkg/storage/sqlite/migrations/000014_run_label.sql
+++ b/pkg/storage/sqlite/migrations/000014_run_label.sql
@@ -6,5 +6,7 @@ CREATE TABLE project_run_label (
     UNIQUE(run_id, key)
 );
 
-CREATE INDEX idx_project_run_label_key_value ON project_run_label(key, value);
-CREATE INDEX idx_project_run_label_run_id ON project_run_label(run_id);
+-- No explicit indexes: the implicit UNIQUE(run_id, key) index already serves
+-- both query shapes. The label filter searches it on (run_id, key), and
+-- loadProjectRunLabels searches it on the run_id prefix, so a separate
+-- run_id index would only duplicate that prefix and add write amplification.

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -73,7 +73,6 @@ func TestMigrationBaseline(t *testing.T) {
 		"idx_project_run_event_sequence", "idx_project_run_project_status", "idx_project_run_sandbox",
 		"idx_project_run_completion_retry",
 		"idx_project_run_scheduler", "idx_project_scheduler_agent",
-		"idx_project_run_label_key_value", "idx_project_run_label_run_id",
 		"idx_project_run_scheduler_run", "idx_project_short_id", "idx_project_source_path",
 		"idx_project_volumes_volume", "idx_sandboxes_project_updated", "idx_sandboxes_type_updated", "idx_sandboxes_updated",
 		"idx_sandboxes_vm_status_updated", "idx_volumes_driver", "idx_volumes_project",

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -39,7 +39,7 @@ func TestMigrationBaseline(t *testing.T) {
 		"capability_gateway", "volumes", "project_volumes", "scheduler_trigger",
 		"scheduler_run", "scheduler_event", "scheduler_state", "scheduler_sandbox_binding", "project",
 		"project_revision", "project_agent", "project_scheduler", "project_run",
-		"project_run_event", "project_run_completion", "event", "webhook_source", "event_delivery", "event_sandbox_link",
+		"project_run_event", "project_run_completion", "project_run_label", "event", "webhook_source", "event_delivery", "event_sandbox_link",
 		"sandbox_projection_meta", "sandboxes",
 	}
 	for _, table := range tables {
@@ -73,6 +73,7 @@ func TestMigrationBaseline(t *testing.T) {
 		"idx_project_run_event_sequence", "idx_project_run_project_status", "idx_project_run_sandbox",
 		"idx_project_run_completion_retry",
 		"idx_project_run_scheduler", "idx_project_scheduler_agent",
+		"idx_project_run_label_key_value", "idx_project_run_label_run_id",
 		"idx_project_run_scheduler_run", "idx_project_short_id", "idx_project_source_path",
 		"idx_project_volumes_volume", "idx_sandboxes_project_updated", "idx_sandboxes_type_updated", "idx_sandboxes_updated",
 		"idx_sandboxes_vm_status_updated", "idx_volumes_driver", "idx_volumes_project",

--- a/pkg/storage/sqlite/v2_migration_design_test.go
+++ b/pkg/storage/sqlite/v2_migration_design_test.go
@@ -428,8 +428,8 @@ func loadV2MigrationDesignChain(t *testing.T) []migration {
 	if err != nil {
 		t.Fatalf("load migrations: %v", err)
 	}
-	if len(chain) != 13 {
-		t.Fatalf("migration count = %d, want 13", len(chain))
+	if len(chain) != 14 {
+		t.Fatalf("migration count = %d, want 14", len(chain))
 	}
 	return chain
 }

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -1059,6 +1059,8 @@ message RunAgentRequest {
   string sandbox_id = 14;
   repeated VolumeMountSpec volumes = 15;
   string payload_json = 16;
+  // Optional user-defined key/value labels attached to the run at start time.
+  map<string, string> labels = 17;
 }
 
 message RunAgentResponse {
@@ -1160,6 +1162,8 @@ message ListRunsRequest {
   string sandbox_id = 10;
   // Optional exact scheduler run association for automation-originated Agent Runs.
   string scheduler_run_id = 11;
+  // Optional exact-match label filters, ANDed together. An empty map applies no filter.
+  map<string, string> labels = 12;
 }
 
 message ListRunsResponse {
@@ -1432,6 +1436,8 @@ message RunDetail {
   string image_ref = 9;
   repeated string warnings = 10;
   string error_stack = 11;
+  // User-defined key/value labels attached to the run at start time.
+  map<string, string> labels = 12;
 }
 
 message ExecRequest {


### PR DESCRIPTION
## Summary
- Add a `--label` flag to the CLI run command and a `Labels` field on the `RunAgent` API/proto request
- Persist labels in a new `project_run_label` table (migration `000014_run_label.sql`), with a store-layer validation/insert path (`insertProjectRunLabelsTx`) enforcing key/value length and non-empty keys, and a `UNIQUE(run_id, key)` constraint with upsert-on-conflict semantics
- Support filtering runs by label in `project_run_filter.go`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` (pre-existing, unrelated warning in `test/e2e/graceful_sandbox_stop_contract_test.go`)
- [x] `go test ./pkg/storage/configstore/... ./pkg/runs/... ./pkg/agentcompose/... ./cmd/agent-compose/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

