### PR TITLE
docs(pages): add user-facing OctoBus integration quick start

### DIFF
--- a/docs/pages/octobus-quickstart.md
+++ b/docs/pages/octobus-quickstart.md
@@ -1,0 +1,214 @@
+# OctoBus Integration Quick Start
+
+This guide walks you through connecting agent-compose to [OctoBus](https://github.com/chaitin/OctoBus) — a local gateway that exposes approved enterprise APIs, tools, and services to AI agents — and verifying that an agent can call a capability from inside its sandbox. It takes about 15 minutes.
+
+For configuration field reference, see the [agent-compose.yml Manual](https://github.com/chaitin/agent-compose/blob/main/docs/pages/agent-compose-yaml-manual.md) (`octobus_servers`, `capset_ids`). For internal architecture, see the [OctoBus integration design](https://github.com/chaitin/agent-compose/blob/main/docs/design/octobus_integration.md).
+
+## Concepts in one minute
+
+| Concept | What it is | Who owns it |
+| --- | --- | --- |
+| **Capability Gateway** | The OctoBus connection configured in the agent-compose settings page (`addr` + `token`). | agent-compose daemon |
+| **capset** | A named set of capabilities published by OctoBus, composed of `capset -> service -> instance -> method` bindings. | OctoBus |
+| **`capset_ids`** | The agent field that declares which capsets its sandboxes may use. | Your `agent-compose.yml` |
+| **capability proxy (capproxy)** | A gRPC proxy inside the daemon. Sandboxes never talk to OctoBus directly; capproxy checks authorization and forwards calls. | agent-compose daemon |
+| **`CAP_GRPC_LISTEN`** | Daemon startup variable: where capproxy listens for guest gRPC calls. | Daemon deployment |
+| **`CAP_GRPC_TARGET`** | Daemon startup variable: the capproxy address as reachable *from inside sandboxes*; injected into sandboxes as an env var. | Daemon deployment |
+| **`CAP_TOKEN`** | A per-sandbox credential generated at sandbox creation; capproxy uses it to resolve which capsets a calling sandbox is allowed to use. | Injected automatically |
+
+The data flow at runtime:
+
+```text
+guest agent ──gRPC──▶ capproxy (CAP_GRPC_TARGET) ──gRPC──▶ OctoBus daemon
+```
+
+The guest only ever sees `CAP_GRPC_TARGET` and `CAP_TOKEN`. The OctoBus address and token stay inside the daemon and never enter the sandbox.
+
+## Prerequisites
+
+- A running **agent-compose daemon** (Docker driver is enough; see the repository [Quick start](https://github.com/chaitin/agent-compose)).
+- The **`agent-compose` CLI** connected to that daemon (`--host` or the default endpoint).
+- **Docker** to run OctoBus (or Node.js 20+ to run it from npm).
+- The **web UI** (`with-ui` profile) for the settings-page step. If you run daemon-only, configure the daemon-wide gateway through the Settings API instead.
+
+## Step 1 — Start OctoBus
+
+Run OctoBus on the same Docker network as the agent-compose daemon so the daemon can reach it by container name. The repository's default Compose deployment uses the network created by the root `docker-compose.yml`:
+
+```bash
+docker run -d --name octobus \
+  --network agent-compose_default \
+  -v octobus-data:/var/lib/octobus \
+  ghcr.io/chaitin/octobus:latest
+```
+
+OctoBus listens on `0.0.0.0:9000` in the container. If you prefer running it directly on the host instead:
+
+```bash
+npx @chaitin-ai/octobus serve
+```
+
+In that case, note the address the daemon container can use to reach the host (for example `host.docker.internal` on Docker Desktop, or the host's LAN IP on Linux).
+
+## Step 2 — Publish a capset from OctoBus
+
+OctoBus ships a calculator example service. Use the OctoBus CLI inside the container (or your local `octobus` binary) to import it, create an instance, and expose its methods through a capset named `dev`:
+
+```bash
+# Import the example service (OctoBus repository checkout shown here).
+octobus service import calculator ./examples/calculator-js
+
+# Create and start an instance of it.
+octobus instance create calculator-test \
+  --service calculator \
+  --config-json '{"label":"primary"}'
+
+# Create the "dev" capset and expose the instance's methods in it.
+octobus capset create dev --name DevAgent
+octobus capset add-instance dev calculator-test
+
+# Confirm the catalog exposes the calculator methods.
+octobus catalog dev --all --json
+```
+
+If you run OctoBus in Docker, execute these with `docker exec -it octobus octobus <args>` against a checkout of the [OctoBus repository](https://github.com/chaitin/OctoBus). Any other service package works the same way — the only thing agent-compose needs later is the capset id (`dev`).
+
+> Access tokens on the capset are optional. If you add one (`octobus capset add-token dev local --token-stdin`), record it for Step 3 — the daemon sends it as `Authorization: Bearer <token>` on every upstream call.
+
+## Step 3 — Point agent-compose at OctoBus
+
+Two independent things must both be configured:
+
+1. **The Capability Gateway connection** (control plane: how the daemon reads capsets from OctoBus), and
+2. **The capability proxy address pair** (data plane: how sandbox guests place calls).
+
+### 3a. Capability Gateway (control plane)
+
+Open the web UI, go to **Settings → Capability Gateway**, and set:
+
+- **Address**: the OctoBus admin API address as reachable from the daemon container, e.g. `http://octobus:9000` (Docker network) or `http://host.docker.internal:9000` (OctoBus on the host).
+- **Token**: the capset/daemon token if you configured one in Step 2; leave empty otherwise.
+
+The settings page immediately probes `GET /admin/v1/status` on OctoBus and shows the connection status and the number of published capability sets. A green status with your `dev` capset listed means the control plane is wired correctly.
+
+The token is stored by the daemon only: it is redacted on read-back, never written into sandbox metadata, never injected into guest env, and never logged.
+
+### 3b. Capability proxy (data plane)
+
+Capability calls from inside sandboxes go through capproxy, which is bound at **daemon startup** from two environment variables. Add them to the daemon service in your deployment (for the repository Compose stack, add to the `agent-compose` service environment in `docker-compose.yml` or an override file):
+
+```yaml
+services:
+  agent-compose:
+    environment:
+      # Where capproxy listens inside the daemon container.
+      CAP_GRPC_LISTEN: 0.0.0.0:7411
+      # The same listener as reachable from sandbox containers.
+      CAP_GRPC_TARGET: agent-compose:7411
+```
+
+| Variable | Meaning | Example |
+| --- | --- | --- |
+| `CAP_GRPC_LISTEN` | Listen address of the daemon-internal gRPC capability proxy. | `0.0.0.0:7411` |
+| `CAP_GRPC_TARGET` | Guest-reachable address of that proxy; injected into sandboxes as env var `CAP_GRPC_TARGET`. | `agent-compose:7411` |
+
+Both must be set when the daemon starts. If either is missing, the settings page still shows OctoBus as connected, but new sandboxes will not receive usable capability connection variables. **Restart the daemon after changing these values**, and create a *new* sandbox to pick them up — existing sandboxes keep the env they were created with.
+
+The listen port only needs to be reachable from sandbox containers; do not publish it to the host unless you have a specific reason.
+
+## Step 4 — Bind capsets in your project
+
+Declare the capset in the agent's `capset_ids` in `agent-compose.yml`:
+
+```yaml
+name: octobus-demo
+
+agents:
+  coder:
+    provider: claude
+    image: chaitin/agent-compose-guest:latest
+    workspace:
+      provider: file
+      path: .
+    capset_ids:
+      - dev
+```
+
+Validate and apply:
+
+```bash
+agent-compose config --quiet
+agent-compose up
+```
+
+### Optional: project-scoped OctoBus servers
+
+The unqualified `dev` entry uses the daemon-wide gateway from Step 3a. If different projects need different OctoBus deployments, declare named servers at the top level and qualify the capset id:
+
+```yaml
+octobus_servers:
+  internal:
+    url: http://octobus:9000
+    token: ${OCTOBUS_INTERNAL_TOKEN}
+
+agents:
+  coder:
+    capset_ids:
+      - dev              # daemon-wide gateway
+      - internal/dev     # project server "internal"
+```
+
+A qualified entry `internal/dev` routes through the project server named `internal`, while OctoBus still receives `dev` as the capset id. Mixing qualified and unqualified entries is fine, and declaring `octobus_servers` never changes how unqualified entries resolve. See the [agent-compose.yml Manual](https://github.com/chaitin/agent-compose/blob/main/docs/pages/agent-compose-yaml-manual.md) for the full routing matrix.
+
+## Step 5 — Verify the sandbox injection
+
+Create a sandbox (or let a scheduler run create one) and inspect what the agent sees:
+
+```bash
+agent-compose sandbox ls
+agent-compose inspect <sandbox-id> --json
+```
+
+A sandbox created with `capset_ids: [dev]` has:
+
+- Env var **`CAP_GRPC_TARGET`** — the capproxy address from Step 3b.
+- Env var **`CAP_TOKEN`** — a per-sandbox credential (marked secret; it is an agent-compose-issued token, *not* the OctoBus token).
+- A **`capset=dev`** tag recording the authorization.
+- A capability guide rendered into the MPI catalog at `runtime/mpi/catalog.md` (guest path `/data/runtime/mpi/catalog.md`), listing each gRPC method with the `x-octobus-capset` / `x-octobus-instance` metadata to send. The agent runtime reads this catalog into the agent's system context automatically, so the agent knows its capabilities at startup without reading any file itself.
+
+Injection is **best-effort by design**: if OctoBus is temporarily unreachable when the sandbox is created, the sandbox still starts; the failure is recorded as a sandbox event, and capability calls simply error at runtime until OctoBus is back.
+
+## Step 6 — Call a capability
+
+Now just ask the agent to use the calculator:
+
+```bash
+agent-compose run coder "Use the calculator capability to add 20 and 22, and tell me the result."
+```
+
+Under the hood, the agent:
+
+1. Connects to `$CAP_GRPC_TARGET` (plaintext HTTP/2 gRPC).
+2. Sends metadata `x-capability-sandbox-token: $CAP_TOKEN`, plus the per-method `x-octobus-capset: dev` and `x-octobus-instance: calculator-test` from the capability guide.
+3. Uses gRPC server reflection with the same capset metadata to discover request/response schemas.
+
+capproxy resolves the token to the sandbox, checks that `dev` is in its authorized capset set, injects the OctoBus token server-side, and forwards the call. The expected outcome is the agent answering `42`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Settings shows "not configured" | Gateway address empty | Set the address in Settings → Capability Gateway |
+| Settings shows connection error | Address unreachable from the daemon container, or wrong token | `docker exec agent-compose wget -qO- http://octobus:9000/admin/v1/status` to test reachability; re-check the token |
+| Control plane green, but sandboxes have no `CAP_GRPC_TARGET` env | `CAP_GRPC_LISTEN` / `CAP_GRPC_TARGET` missing at daemon startup | Set both, restart the daemon, create a new sandbox |
+| Agent can't reach the proxy | `CAP_GRPC_TARGET` is a host address the sandbox can't resolve | Use the daemon's container name (Compose network) as the host part of `CAP_GRPC_TARGET` |
+| gRPC `FailedPrecondition` on a business call | Missing `x-octobus-instance` metadata | The agent must send the instance id from the capability guide; check `catalog.md` content |
+| gRPC permission error mentioning capset | Sandbox called a capset outside its authorized set | Add the capset to the agent's `capset_ids` and create a new sandbox |
+| Capability calls fail but everything looks configured | OctoBus down at call time | Check `octobus status`; capability errors at runtime never block the sandbox itself |
+
+## Security notes
+
+- The OctoBus token never leaves the daemon: it is not returned to the frontend in plaintext, not injected into guest env, not written into sandbox metadata, and not logged.
+- `CAP_TOKEN` only proves "this caller is this sandbox" to capproxy. It cannot call OctoBus by itself.
+- The capset set bound at sandbox creation is the isolation boundary enforced by capproxy; a guest can only choose instances *within* an authorized capset.
+- Capabilities are exposed to guests over gRPC only. MCP / Connect RPC / REST endpoints of OctoBus are not proxied into sandboxes.

--- a/docs/pages/zh-CN/octobus-quickstart.md
+++ b/docs/pages/zh-CN/octobus-quickstart.md
@@ -1,0 +1,214 @@
+# OctoBus 集成快速开始
+
+本指南带你完成 agent-compose 与 [OctoBus](https://github.com/chaitin/OctoBus)（一个把企业内部 API、工具和服务安全暴露给 AI Agent 的本地网关）的对接，并验证 Agent 能在自己的沙箱内成功调用一个能力。全程约 15 分钟。
+
+配置字段参考见 [agent-compose.yml 配置手册](https://github.com/chaitin/agent-compose/blob/main/docs/pages/zh-CN/agent-compose-yaml-manual.md)（`octobus_servers`、`capset_ids`）；内部实现原理见 [OctoBus 集成设计文档](https://github.com/chaitin/agent-compose/blob/main/docs/design/octobus_integration.md)。
+
+## 一分钟理解核心概念
+
+| 概念 | 含义 | 归属方 |
+| --- | --- | --- |
+| **Capability Gateway（能力网关）** | 在 agent-compose 设置页配置的 OctoBus 连接（`addr` + `token`）。 | agent-compose daemon |
+| **capset（能力集）** | OctoBus 发布的一组能力，由 `capset -> service -> instance -> method` 绑定构成。 | OctoBus |
+| **`capset_ids`** | Agent 配置字段，声明其沙箱允许使用哪些能力集。 | 你的 `agent-compose.yml` |
+| **capability proxy（capproxy）** | daemon 内部的 gRPC 代理。沙箱从不直接连接 OctoBus，由 capproxy 做鉴权检查并转发调用。 | agent-compose daemon |
+| **`CAP_GRPC_LISTEN`** | daemon 启动变量：capproxy 监听 guest gRPC 调用的地址。 | daemon 部署配置 |
+| **`CAP_GRPC_TARGET`** | daemon 启动变量：从沙箱内部视角看到的 capproxy 地址，以环境变量形式注入沙箱。 | daemon 部署配置 |
+| **`CAP_TOKEN`** | 沙箱创建时生成的凭据，capproxy 用它解析调用方沙箱被授权的能力集。 | 自动注入 |
+
+运行时数据流：
+
+```text
+guest agent ──gRPC──▶ capproxy (CAP_GRPC_TARGET) ──gRPC──▶ OctoBus daemon
+```
+
+guest 只能看到 `CAP_GRPC_TARGET` 和 `CAP_TOKEN`。OctoBus 的地址和 token 始终留在 daemon 内，不会进入沙箱。
+
+## 前置条件
+
+- 一个运行中的 **agent-compose daemon**（Docker 驱动即可，见[快速开始](https://github.com/chaitin/agent-compose/blob/main/README.zh-CN.md)）。
+- 已连接该 daemon 的 **`agent-compose` CLI**（通过 `--host` 或默认端点）。
+- **Docker**（用于运行 OctoBus；或者用 Node.js 20+ 从 npm 运行）。
+- **Web UI**（`with-ui` profile），用于设置页配置步骤。如果只跑 daemon，可以通过 Settings API 配置全局网关。
+
+## 第 1 步 — 启动 OctoBus
+
+把 OctoBus 跑在与 agent-compose daemon 相同的 Docker 网络里，让 daemon 可以用容器名访问它。仓库根目录 `docker-compose.yml` 默认创建的网络是 `agent-compose_default`：
+
+```bash
+docker run -d --name octobus \
+  --network agent-compose_default \
+  -v octobus-data:/var/lib/octobus \
+  ghcr.io/chaitin/octobus:latest
+```
+
+OctoBus 在容器内监听 `0.0.0.0:9000`。如果你更想直接在宿主机上跑：
+
+```bash
+npx @chaitin-ai/octobus serve
+```
+
+这种情况下，记下 daemon 容器访问宿主机可用的地址（Docker Desktop 上通常是 `host.docker.internal`，Linux 上是宿主机 LAN IP）。
+
+## 第 2 步 — 从 OctoBus 发布一个能力集
+
+OctoBus 自带一个计算器示例服务。用 OctoBus CLI（容器内或本地 `octobus` 命令）导入它、创建实例，并通过名为 `dev` 的能力集暴露它的方法：
+
+```bash
+# 导入示例服务（此处以 OctoBus 仓库检出目录为例）。
+octobus service import calculator ./examples/calculator-js
+
+# 创建并启动一个实例。
+octobus instance create calculator-test \
+  --service calculator \
+  --config-json '{"label":"primary"}'
+
+# 创建 "dev" 能力集，并把该实例的方法暴露进去。
+octobus capset create dev --name DevAgent
+octobus capset add-instance dev calculator-test
+
+# 确认 catalog 中已经暴露了计算器方法。
+octobus catalog dev --all --json
+```
+
+如果 OctoBus 跑在 Docker 里，先克隆 [OctoBus 仓库](https://github.com/chaitin/OctoBus)，再用 `docker exec -it octobus octobus <args>` 执行上述命令。换任何其他服务包流程都一样——agent-compose 后面只需要能力集 id（`dev`）。
+
+> 能力集的访问 token 是可选的。如果你添加了（`octobus capset add-token dev local --token-stdin`），记下它供第 3 步使用——daemon 会在每次上游调用时携带 `Authorization: Bearer <token>`。
+
+## 第 3 步 — 把 agent-compose 指向 OctoBus
+
+需要分别配置两件互相独立的事：
+
+1. **Capability Gateway 连接**（控制面：daemon 如何从 OctoBus 读取能力集），以及
+2. **能力代理地址对**（数据面：沙箱内 guest 如何发起调用）。
+
+### 3a. Capability Gateway（控制面）
+
+打开 Web UI，进入 **Settings → Capability Gateway**，设置：
+
+- **地址（Address）**：从 daemon 容器视角可达的 OctoBus admin API 地址，例如 `http://octobus:9000`（Docker 网络）或 `http://host.docker.internal:9000`（OctoBus 跑在宿主机）。
+- **Token**：如果你在第 2 步配置了能力集 token 就填上，否则留空。
+
+设置页会立即探测 OctoBus 的 `GET /admin/v1/status`，并显示连接状态和已发布能力集数量。状态为绿色且能看到 `dev` 能力集，说明控制面已经接通。
+
+token 只保存在 daemon：读取时会被脱敏，不会写入沙箱元数据、不会注入 guest 环境变量、不会进入日志。
+
+### 3b. 能力代理（数据面）
+
+沙箱内发起的能力调用经过 capproxy，它由 **daemon 启动时**的两个环境变量决定。把这两个变量加到 daemon 服务的部署配置里（仓库 Compose 部署的话，加到 `docker-compose.yml` 或 override 文件中 `agent-compose` 服务的 environment 下）：
+
+```yaml
+services:
+  agent-compose:
+    environment:
+      # capproxy 在 daemon 容器内的监听地址。
+      CAP_GRPC_LISTEN: 0.0.0.0:7411
+      # 同一个监听器在沙箱容器视角下的地址。
+      CAP_GRPC_TARGET: agent-compose:7411
+```
+
+| 变量 | 含义 | 示例 |
+| --- | --- | --- |
+| `CAP_GRPC_LISTEN` | daemon 内部 gRPC 能力代理的监听地址。 | `0.0.0.0:7411` |
+| `CAP_GRPC_TARGET` | guest 可达的代理地址；作为环境变量 `CAP_GRPC_TARGET` 注入沙箱。 | `agent-compose:7411` |
+
+两个变量必须在 daemon 启动时都设置。缺了任何一个，设置页仍会显示 OctoBus 已连接，但新建沙箱拿不到可用的能力连接变量。**修改后需要重启 daemon**，并且只有*新建*沙箱才会带上这些配置——已有沙箱保留创建时的环境变量。
+
+这个监听端口只需对沙箱容器可达，除非有明确理由，不要把它发布到宿主机。
+
+## 第 4 步 — 在项目中绑定能力集
+
+在 `agent-compose.yml` 中给 agent 声明 `capset_ids`：
+
+```yaml
+name: octobus-demo
+
+agents:
+  coder:
+    provider: claude
+    image: chaitin/agent-compose-guest:latest
+    workspace:
+      provider: file
+      path: .
+    capset_ids:
+      - dev
+```
+
+校验并应用：
+
+```bash
+agent-compose config --quiet
+agent-compose up
+```
+
+### 可选：项目级 OctoBus 服务器
+
+未限定的 `dev` 使用第 3a 步配置的 daemon 全局网关。如果不同项目需要连接不同的 OctoBus 部署，可以在顶层声明具名服务器，并用限定写法选择能力集：
+
+```yaml
+octobus_servers:
+  internal:
+    url: http://octobus:9000
+    token: ${OCTOBUS_INTERNAL_TOKEN}
+
+agents:
+  coder:
+    capset_ids:
+      - dev              # daemon 全局网关
+      - internal/dev     # 项目服务器 "internal"
+```
+
+限定写法 `internal/dev` 会走名为 `internal` 的项目服务器，而 OctoBus 收到的能力集 id 仍然是 `dev`。限定与未限定条目可以混用，声明 `octobus_servers` 不会改变未限定条目的路由。完整路由矩阵见 [agent-compose.yml 配置手册](https://github.com/chaitin/agent-compose/blob/main/docs/pages/zh-CN/agent-compose-yaml-manual.md)。
+
+## 第 5 步 — 验证沙箱注入
+
+创建一个沙箱（或等调度器运行创建），检查 agent 实际看到的内容：
+
+```bash
+agent-compose sandbox ls
+agent-compose inspect <sandbox-id> --json
+```
+
+一个带 `capset_ids: [dev]` 创建的沙箱会有：
+
+- 环境变量 **`CAP_GRPC_TARGET`** —— 第 3b 步配置的 capproxy 地址。
+- 环境变量 **`CAP_TOKEN`** —— 每个沙箱独立的凭据（标记为 secret；它是 agent-compose 签发的 token，*不是* OctoBus token）。
+- 一个 **`capset=dev`** 标签，记录授权关系。
+- 一份渲染好的能力指南，写入 MPI catalog 的 `runtime/mpi/catalog.md`（guest 内路径 `/data/runtime/mpi/catalog.md`），列出每个 gRPC 方法以及调用时要带的 `x-octobus-capset` / `x-octobus-instance` 元数据。Agent 运行时会自动把这份 catalog 读进系统上下文，所以 agent 一启动就知道自己有哪些能力，不需要自己去读文件。
+
+注入在设计上**尽力而为（best-effort）**：如果创建沙箱时 OctoBus 暂时不可达，沙箱仍会正常启动；失败会记录为沙箱事件，能力调用在 OctoBus 恢复前会在运行时报错。
+
+## 第 6 步 — 调用一个能力
+
+直接让 agent 用计算器即可：
+
+```bash
+agent-compose run coder "Use the calculator capability to add 20 and 22, and tell me the result."
+```
+
+底层发生的调用过程：
+
+1. Agent 连接 `$CAP_GRPC_TARGET`（明文 HTTP/2 gRPC）。
+2. 携带元数据 `x-capability-sandbox-token: $CAP_TOKEN`，以及能力指南中给出的 `x-octobus-capset: dev` 和 `x-octobus-instance: calculator-test`。
+3. 用相同的 capset 元数据通过 gRPC server reflection 发现请求/响应结构。
+
+capproxy 把 token 解析为沙箱，检查 `dev` 在它的授权能力集范围内，在服务端注入 OctoBus token，然后转发调用。预期结果是 agent 回答 `42`。
+
+## 故障排查
+
+| 现象 | 可能原因 | 处理 |
+| --- | --- | --- |
+| 设置页显示"未配置" | 网关地址为空 | 在 Settings → Capability Gateway 填写地址 |
+| 设置页显示连接错误 | daemon 容器访问不到该地址，或 token 不对 | 用 `docker exec agent-compose wget -qO- http://octobus:9000/admin/v1/status` 测试可达性；重新核对 token |
+| 控制面正常，但沙箱没有 `CAP_GRPC_TARGET` 环境变量 | daemon 启动时缺少 `CAP_GRPC_LISTEN` / `CAP_GRPC_TARGET` | 两个都配上，重启 daemon，新建沙箱 |
+| Agent 连不上代理 | `CAP_GRPC_TARGET` 用了沙箱解析不了的宿主机地址 | 把 `CAP_GRPC_TARGET` 的主机部分改成 daemon 容器名（Compose 网络） |
+| 业务调用返回 gRPC `FailedPrecondition` | 缺少 `x-octobus-instance` 元数据 | Agent 必须带上能力指南中的实例 id；检查 `catalog.md` 内容 |
+| gRPC 报能力集相关权限错误 | 沙箱调用了授权集之外的能力集 | 把该能力集加进 agent 的 `capset_ids`，新建沙箱 |
+| 配置看起来都对但调用失败 | 调用时刻 OctoBus 不可用 | 检查 `octobus status`；运行时能力错误不会阻塞沙箱本身 |
+
+## 安全说明
+
+- OctoBus token 不会离开 daemon：不会以明文返回给前端、不会注入 guest 环境变量、不会写入沙箱元数据、不会进入日志。
+- `CAP_TOKEN` 只能向 capproxy 证明"调用方是这个沙箱"，它本身不能调用 OctoBus。
+- 沙箱创建时绑定的能力集就是 capproxy 强制执行的隔离边界；guest 只能在已授权的能力集内部选择实例。
+- 能力只通过 gRPC 暴露给 guest。OctoBus 的 MCP / Connect RPC / REST 端点不会代理进沙箱。

--- a/tools/genpages/check-pages.mjs
+++ b/tools/genpages/check-pages.mjs
@@ -14,6 +14,7 @@ const manualNames = [
   "command-line-manual.md",
   "connect-transport-matrix.md",
   "guest-image-abi.md",
+  "octobus-quickstart.md",
 ];
 const expectedOutput = new Set([
   "agent-compose-yaml-manual.html",
@@ -21,11 +22,13 @@ const expectedOutput = new Set([
   "connect-transport-matrix.html",
   "guest-image-abi.html",
   "index.html",
+  "octobus-quickstart.html",
   "manual.css",
   "zh-CN/agent-compose-yaml-manual.html",
   "zh-CN/command-line-manual.html",
   "zh-CN/connect-transport-matrix.html",
   "zh-CN/guest-image-abi.html",
+  "zh-CN/octobus-quickstart.html",
 ]);
 
 await checkSourceLayout();

--- a/tools/genpages/render-pages.mjs
+++ b/tools/genpages/render-pages.mjs
@@ -31,18 +31,18 @@ const manuals = [
     alternate: "../connect-transport-matrix.html",
   },
   {
-    source: "octobus-quickstart.md",
-    output: "octobus-quickstart.html",
-    title: "OctoBus Integration Quick Start",
-    lang: "en",
-    alternate: "zh-CN/octobus-quickstart.html",
-  },
-  {
     source: "agent-compose-yaml-manual.md",
     output: "agent-compose-yaml-manual.html",
     title: "agent-compose.yml Manual",
     lang: "en",
     alternate: "zh-CN/agent-compose-yaml-manual.html",
+  },
+  {
+    source: "octobus-quickstart.md",
+    output: "octobus-quickstart.html",
+    title: "OctoBus Integration Quick Start",
+    lang: "en",
+    alternate: "zh-CN/octobus-quickstart.html",
   },
   {
     source: "guest-image-abi.md",
@@ -59,18 +59,18 @@ const manuals = [
     alternate: "../command-line-manual.html",
   },
   {
-    source: "zh-CN/octobus-quickstart.md",
-    output: "zh-CN/octobus-quickstart.html",
-    title: "OctoBus 集成快速开始",
-    lang: "zh-CN",
-    alternate: "../octobus-quickstart.html",
-  },
-  {
     source: "zh-CN/agent-compose-yaml-manual.md",
     output: "zh-CN/agent-compose-yaml-manual.html",
     title: "agent-compose.yml 配置手册",
     lang: "zh-CN",
     alternate: "../agent-compose-yaml-manual.html",
+  },
+  {
+    source: "zh-CN/octobus-quickstart.md",
+    output: "zh-CN/octobus-quickstart.html",
+    title: "OctoBus 集成快速开始",
+    lang: "zh-CN",
+    alternate: "../octobus-quickstart.html",
   },
   {
     source: "zh-CN/guest-image-abi.md",
@@ -106,13 +106,14 @@ function renderPage(manual, body) {
   const nested = currentPage.includes("/");
   const root = nested ? "../" : "./";
   const labels = lang === "zh-CN"
-    ? ["首页", "命令行手册", "YAML 配置手册", "Connect 传输矩阵"]
-    : ["Home", "CLI Manual", "YAML Manual", "Connect Transport"];
+    ? ["首页", "命令行手册", "YAML 配置手册", "OctoBus 快速开始", "Connect 传输矩阵"]
+    : ["Home", "CLI Manual", "YAML Manual", "OctoBus Quick Start", "Connect Transport"];
   const navItems = [
     [root, labels[0], ""],
     ["command-line-manual.html", labels[1], "command-line-manual.html"],
     ["agent-compose-yaml-manual.html", labels[2], "agent-compose-yaml-manual.html"],
-    ["connect-transport-matrix.html", labels[3], "connect-transport-matrix.html"],
+    ["octobus-quickstart.html", labels[3], "octobus-quickstart.html"],
+    ["connect-transport-matrix.html", labels[4], "connect-transport-matrix.html"],
   ];
   const nav = navItems
     .map(([href, label, page]) => {

--- a/tools/genpages/render-pages.mjs
+++ b/tools/genpages/render-pages.mjs
@@ -31,6 +31,13 @@ const manuals = [
     alternate: "../connect-transport-matrix.html",
   },
   {
+    source: "octobus-quickstart.md",
+    output: "octobus-quickstart.html",
+    title: "OctoBus Integration Quick Start",
+    lang: "en",
+    alternate: "zh-CN/octobus-quickstart.html",
+  },
+  {
     source: "agent-compose-yaml-manual.md",
     output: "agent-compose-yaml-manual.html",
     title: "agent-compose.yml Manual",
@@ -50,6 +57,13 @@ const manuals = [
     title: "命令行手册",
     lang: "zh-CN",
     alternate: "../command-line-manual.html",
+  },
+  {
+    source: "zh-CN/octobus-quickstart.md",
+    output: "zh-CN/octobus-quickstart.html",
+    title: "OctoBus 集成快速开始",
+    lang: "zh-CN",
+    alternate: "../octobus-quickstart.html",
   },
   {
     source: "zh-CN/agent-compose-yaml-manual.md",


### PR DESCRIPTION
# PR: docs: add OctoBus integration quick start guide

<!-- What changed and why? -->

Closes #80

## Summary

Adds a user-facing **OctoBus Integration Quick Start** guide (English + 中文) to the
GitHub Pages documentation site, walking a new user from a local agent-compose +
OctoBus deployment all the way to a verified capability call from inside a sandbox.

The existing documentation under `docs/design/` describes the internal architecture;
this guide is the operational tutorial issue #80 asks for.

## What the guide covers

All seven points requested in #80:

| #80 requirement | Where |
| --- | --- |
| How to start agent-compose and OctoBus locally | Step 1 |
| Daemon env vars, esp. `CAP_GRPC_LISTEN` / `CAP_GRPC_TARGET` | Step 3b + concepts table |
| How to configure the Capability Gateway in the settings page | Step 3a |
| How to confirm a capset is readable by agent-compose | Step 3a (status probe), Step 5 |
| How to bind a capset when creating a session/agent | Step 4 (`capset_ids`, incl. project-scoped servers) |
| How to confirm capability config was injected into the session | Step 5 (env vars, tags, `catalog.md`) |
| Minimal verification example (see capset + call a simple capability) | Step 2 (publish `dev` capset) + Step 6 (call calculator, expect `42`) |

Plus: a concepts table mapping OctoBus ↔ agent-compose terminology, the data-plane
diagram, a troubleshooting matrix for the 7 most common misconfigurations, and the
security boundary notes (token never leaves the daemon; `CAP_TOKEN` vs OctoBus token).

## Accuracy

Every command, env var, path, and behavior in the guide was verified against:

- `docs/design/octobus_integration.md` and `docs/design/project_octobus_servers_design.md`
- `pkg/capabilities/gateway.go` (`CAP_GRPC_TARGET` / `CAP_TOKEN` injection, guide rendering)
- `pkg/capability/client.go` (`/admin/v1/*` control-plane probes)
- `pkg/agentcompose/api/capability_v2.go` (status response fields)
- `docs/pages/agent-compose-yaml-manual.md` (`octobus_servers`, `capset_ids` semantics)
- the OctoBus repository README (service import / instance / capset workflow)

## Files changed

| File | Change |
| --- | --- |
| `docs/pages/octobus-quickstart.md` | New. English quick start  |
| `docs/pages/zh-CN/octobus-quickstart.md` | New. 中文版. |
| `tools/genpages/render-pages.mjs` | Register both pages in the manual list + top navigation. |
| `tools/genpages/check-pages.mjs` | Add the two pages to `manualNames` / `expectedOutput` whitelists. |

The two script edits are required: `check-pages.mjs` asserts the exact set of files
in `docs/pages/`, so any new page must be whitelisted or CI fails.

## Testing

```
cd tools/genpages
npm ci --no-audit --no-fund
npm run build   # node --test && render-pages && check-pages
```

Result: `Pages checks passed for 69 YAML schema fields and 12 public files` (was 10
files before this change). This is the same command the `pages.yml` workflow runs.

## Notes for reviewers

- Internal cross-links use `.html` targets because the Pages link checker resolves
  links against the rendered output; links to `README` / `docs/design/` use GitHub
  absolute URLs (skipped by the checker), matching the existing convention in
  `guest-image-abi.md`.
- No anchor fragments in cross-links: marked does not emit heading `id`s, so
  fragment links would fail the checker's anchor validation.
- `Taskfile.yml` `docs:build.generates` does not list the new HTML outputs; it also
  omits the pre-existing `connect-transport-matrix.html`, so this PR leaves it
  untouched to keep the change scoped. Happy to add all missing entries if preferred.

