### PR TITLE
Security: restore Jupyter origin and XSRF protection

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ development branch until versioned release support is documented.
 - Treat `HTTP_LISTEN=0.0.0.0:7410` as an internal daemon API. Startup emits a
   warning but still proceeds; use container networking, reverse proxies, VPNs,
   or equivalent controls to avoid direct public access.
-- Do not expose guest Jupyter ports directly. Use the agent-compose proxy.
+- Do not expose guest Jupyter ports directly. Use the agent-compose proxy; the guest keeps same-origin and XSRF protection enabled.
 - Treat workspace uploads, Git credentials, environment variables, webhook
   tokens, and LLM API keys as secrets.
 - Review runtime driver network behavior before running untrusted workloads.

--- a/pkg/agentcompose/proxy/jupyter_coverage_test.go
+++ b/pkg/agentcompose/proxy/jupyter_coverage_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -65,6 +67,45 @@ func TestJupyterProxyRouteCoverage(t *testing.T) {
 
 	if JupyterTargetReachable(domain.ProxyState{}, time.Millisecond) {
 		t.Fatalf("empty proxy state reported reachable")
+	}
+}
+
+func TestJupyterProxyPreservesPublicHostForSameOriginChecks(t *testing.T) {
+	var gotHost, gotOrigin string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		gotOrigin = r.Header.Get("Origin")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(backendURL.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := echo.New()
+	state := domain.ProxyState{Enabled: true, GuestHost: "127.0.0.1", GuestPort: port, HostPort: port, ProxyPath: "/jupyter/session-1"}
+	RegisterJupyterRoutes(e, JupyterOptions{
+		BasePath: "/jupyter",
+		Store:    fakeJupyterStore{state: state},
+		EnsureReady: func(context.Context, string) (domain.ProxyState, error) {
+			return state, nil
+		},
+	})
+	request := httptest.NewRequest(http.MethodPost, "/jupyter/session-1/api/kernels", nil)
+	request.Host = "proxy.example.test"
+	request.Header.Set("Origin", "http://proxy.example.test")
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("proxy status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if gotHost != request.Host || gotOrigin != request.Header.Get("Origin") {
+		t.Fatalf("backend host/origin = %q/%q, want %q/%q", gotHost, gotOrigin, request.Host, request.Header.Get("Origin"))
 	}
 }
 

--- a/pkg/agentcompose/proxy/proxy.go
+++ b/pkg/agentcompose/proxy/proxy.go
@@ -68,7 +68,9 @@ func RegisterJupyterRoutes(app *echo.Echo, opts JupyterOptions) {
 			Rewrite: func(req *httputil.ProxyRequest) {
 				req.SetURL(target)
 				req.SetXForwarded()
-				req.Out.Host = target.Host
+				// Preserve the public proxy host so Jupyter's same-origin and
+				// XSRF checks see the same host as the browser Origin header.
+				req.Out.Host = req.In.Host
 				req.Out.URL.Path = req.In.URL.Path
 				req.Out.URL.RawPath = req.Out.URL.Path
 				req.Out.URL.RawQuery = req.In.URL.RawQuery

--- a/pkg/driver/jupyter_guest.go
+++ b/pkg/driver/jupyter_guest.go
@@ -180,7 +180,7 @@ func jupyterLaunchCommandWithBootstrap(config *appconfig.Config, proxyState Prox
 		" --ServerApp.root_dir=\"" + config.GuestWorkspacePath + "\"" +
 		" --ServerApp.base_url=\"" + strings.TrimRight(jupyterBaseURL(proxyState), "/") + "\"" +
 		" --IdentityProvider.token=\"" + proxyState.Token + "\"" +
-		" --ServerApp.password= --ServerApp.allow_origin='*' --ServerApp.disable_check_xsrf=True" +
+		" --ServerApp.password= --ServerApp.allow_origin='' --ServerApp.disable_check_xsrf=False" +
 		" --allow-root --no-browser"
 	if background {
 		// Keep the trailing ampersand scoped to the Jupyter launch. Without

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -671,6 +671,12 @@ func TestBackgroundJupyterLaunchCommandStartsBeforeJupyterLabImportProbe(t *test
 	}
 
 	backgroundCommand := jupyterLaunchCommand(config, proxyState, true)
+	if strings.Contains(backgroundCommand, "--ServerApp.allow_origin='*'") || strings.Contains(backgroundCommand, "--ServerApp.disable_check_xsrf=True") {
+		t.Fatalf("jupyter command weakens origin or xsrf protection: %s", backgroundCommand)
+	}
+	if !strings.Contains(backgroundCommand, "--ServerApp.allow_origin='' --ServerApp.disable_check_xsrf=False") {
+		t.Fatalf("jupyter command does not explicitly retain origin and xsrf protection: %s", backgroundCommand)
+	}
 	if strings.Contains(backgroundCommand, "python3 -c \"import jupyterlab;") {
 		t.Fatalf("background jupyter command should not block on import probe before nohup: %s", backgroundCommand)
 	}

--- a/pkg/driver/runtime_mount_manifest_test.go
+++ b/pkg/driver/runtime_mount_manifest_test.go
@@ -671,17 +671,25 @@ func TestBackgroundJupyterLaunchCommandStartsBeforeJupyterLabImportProbe(t *test
 	}
 
 	backgroundCommand := jupyterLaunchCommand(config, proxyState, true)
-	if strings.Contains(backgroundCommand, "--ServerApp.allow_origin='*'") || strings.Contains(backgroundCommand, "--ServerApp.disable_check_xsrf=True") {
-		t.Fatalf("jupyter command weakens origin or xsrf protection: %s", backgroundCommand)
-	}
-	if !strings.Contains(backgroundCommand, "--ServerApp.allow_origin='' --ServerApp.disable_check_xsrf=False") {
-		t.Fatalf("jupyter command does not explicitly retain origin and xsrf protection: %s", backgroundCommand)
-	}
 	if strings.Contains(backgroundCommand, "python3 -c \"import jupyterlab;") {
 		t.Fatalf("background jupyter command should not block on import probe before nohup: %s", backgroundCommand)
 	}
 	if !strings.Contains(backgroundCommand, "nohup python3 -m jupyterlab") {
 		t.Fatalf("background jupyter command missing nohup launch: %s", backgroundCommand)
+	}
+}
+
+func TestJupyterLaunchCommandKeepsOriginAndXSRFProtection(t *testing.T) {
+	config := testRuntimeMountConfig()
+	proxyState := ProxyState{Enabled: true, GuestPort: 8888, Token: "test-token"}
+	for _, background := range []bool{false, true} {
+		command := jupyterLaunchCommand(config, proxyState, background)
+		if strings.Contains(command, "--ServerApp.allow_origin='*'") || !strings.Contains(command, "--ServerApp.allow_origin=''") {
+			t.Fatalf("background=%t command origin policy is unsafe: %s", background, command)
+		}
+		if strings.Contains(command, "--ServerApp.disable_check_xsrf=True") || !strings.Contains(command, "--ServerApp.disable_check_xsrf=False") {
+			t.Fatalf("background=%t command xsrf policy is unsafe: %s", background, command)
+		}
 	}
 }
 


### PR DESCRIPTION
## 问题
Jupyter guest 启动参数设置了 `--ServerApp.allow_origin='*'` 和 `--ServerApp.disable_check_xsrf=True`。同时 daemon 的 Jupyter 代理路径不使用 daemon Bearer Token，导致泄露 Jupyter URL Token 后缺少 Origin/XSRF 保护层。

## 影响
恶意站点或被动攻击者在获得 Token 后，可跨站调用 Jupyter API、访问文件或操作 Kernel。涉及 CWE-352、CWE-942。

## 修复内容
- 移除任意 Origin 通配配置，显式使用 Jupyter 默认的同源策略。
- 显式设置 `--ServerApp.disable_check_xsrf=False`。
- 保留 Jupyter URL Token 认证机制。
- 增加回归测试，确保命令不会重新启用通配 Origin 或关闭 XSRF。
- 更新安全部署文档。

## 验证
- `go test ./pkg/driver ./pkg/agentcompose/proxy`
- `git diff --check`
