### PR TITLE
Fix: fail closed after project reconcile errors

### DIFF
--- a/internal/projects/apply_reconcile_failure_test.go
+++ b/internal/projects/apply_reconcile_failure_test.go
@@ -1,0 +1,79 @@
+package projects
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	"github.com/chaitin/agent-compose/pkg/schedulers"
+)
+
+func TestDisableProjectSchedulersAfterReconcileFailureFailsClosed(t *testing.T) {
+	store := &reconcileFailureStore{items: []domain.ProjectSchedulerRecord{
+		{ProjectID: "project-a", SchedulerID: "enabled-a", Enabled: true},
+		{ProjectID: "project-a", SchedulerID: "disabled", Enabled: false},
+		{ProjectID: "project-a", SchedulerID: "enabled-b", Enabled: true},
+	}}
+	validator := &reconcileFailureValidator{}
+	controller := &Controller{store: store, schedulers: validator}
+
+	if err := controller.disableProjectSchedulersAfterReconcileFailure(context.Background(), "project-a"); err != nil {
+		t.Fatalf("disableProjectSchedulersAfterReconcileFailure returned error: %v", err)
+	}
+	if len(store.disabled) != 2 || store.disabled[0] != "enabled-a" || store.disabled[1] != "enabled-b" {
+		t.Fatalf("disabled schedulers = %v, want [enabled-a enabled-b]", store.disabled)
+	}
+	if validator.refreshes != 1 {
+		t.Fatalf("scheduler refreshes = %d, want 1", validator.refreshes)
+	}
+}
+
+func TestDisableProjectSchedulersAfterReconcileFailureReportsCompensationErrors(t *testing.T) {
+	store := &reconcileFailureStore{
+		items:      []domain.ProjectSchedulerRecord{{ProjectID: "project-a", SchedulerID: "enabled", Enabled: true}},
+		disableErr: errors.New("disable failed"),
+	}
+	validator := &reconcileFailureValidator{err: errors.New("refresh failed")}
+	controller := &Controller{store: store, schedulers: validator}
+
+	err := controller.disableProjectSchedulersAfterReconcileFailure(context.Background(), "project-a")
+	if err == nil || !errors.Is(err, store.disableErr) || !errors.Is(err, validator.err) {
+		t.Fatalf("compensation error = %v, want joined disable and refresh errors", err)
+	}
+}
+
+type reconcileFailureStore struct {
+	ControllerStore
+	items      []domain.ProjectSchedulerRecord
+	disabled   []string
+	disableErr error
+}
+
+func (s *reconcileFailureStore) ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error) {
+	return append([]domain.ProjectSchedulerRecord(nil), s.items...), nil
+}
+
+func (s *reconcileFailureStore) SetProjectSchedulerEnabled(_ context.Context, _, schedulerID string, enabled bool) (domain.ProjectSchedulerRecord, error) {
+	if s.disableErr != nil {
+		return domain.ProjectSchedulerRecord{}, s.disableErr
+	}
+	if !enabled {
+		s.disabled = append(s.disabled, schedulerID)
+	}
+	return domain.ProjectSchedulerRecord{SchedulerID: schedulerID, Enabled: enabled}, nil
+}
+
+type reconcileFailureValidator struct {
+	refreshes int
+	err       error
+}
+
+func (*reconcileFailureValidator) Validate(context.Context, string, string) (schedulers.SchedulerValidationResult, error) {
+	return schedulers.SchedulerValidationResult{}, nil
+}
+
+func (v *reconcileFailureValidator) Refresh(context.Context) error {
+	v.refreshes++
+	return v.err
+}

--- a/internal/projects/controller.go
+++ b/internal/projects/controller.go
@@ -406,8 +406,10 @@ func (c *Controller) applyProject(ctx context.Context, req ApplyRequest, lifecyc
 	})
 	if err != nil {
 		changes = append(changes, schedulerChanges...)
-		if failClosedErr := c.disableProjectSchedulersAfterReconcileFailure(ctx, project.ID); failClosedErr != nil {
-			err = errors.Join(err, failClosedErr)
+		if schedulerReconcileNeedsFailClosed(err) {
+			if failClosedErr := c.disableProjectSchedulersAfterReconcileFailure(ctx, project.ID); failClosedErr != nil {
+				err = errors.Join(err, failClosedErr)
+			}
 		}
 		agents, listAgentsErr := c.store.ListProjectAgents(ctx, project.ID)
 		if listAgentsErr != nil {

--- a/internal/projects/controller.go
+++ b/internal/projects/controller.go
@@ -406,6 +406,9 @@ func (c *Controller) applyProject(ctx context.Context, req ApplyRequest, lifecyc
 	})
 	if err != nil {
 		changes = append(changes, schedulerChanges...)
+		if failClosedErr := c.disableProjectSchedulersAfterReconcileFailure(ctx, project.ID); failClosedErr != nil {
+			err = errors.Join(err, failClosedErr)
+		}
 		agents, listAgentsErr := c.store.ListProjectAgents(ctx, project.ID)
 		if listAgentsErr != nil {
 			// The listing failure is reported for diagnosis only and is formatted
@@ -785,6 +788,33 @@ func (c *Controller) refreshSchedulers(ctx context.Context) error {
 		return nil
 	}
 	return c.schedulers.Refresh(ctx)
+}
+
+// disableProjectSchedulersAfterReconcileFailure makes a partially applied
+// project fail closed. Without this compensation, schedulers that were enabled
+// before a later scheduler failed could continue running against a revision
+// whose complete scheduler set was never reconciled.
+func (c *Controller) disableProjectSchedulersAfterReconcileFailure(ctx context.Context, projectID string) error {
+	schedulers, err := c.store.ListProjectSchedulers(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("list schedulers while failing closed: %w", err)
+	}
+	var disableErr error
+	for _, scheduler := range schedulers {
+		if !scheduler.Enabled {
+			continue
+		}
+		if _, err := c.store.SetProjectSchedulerEnabled(ctx, projectID, scheduler.SchedulerID, false); err != nil {
+			disableErr = errors.Join(disableErr, fmt.Errorf("disable scheduler %s: %w", scheduler.SchedulerID, err))
+		}
+	}
+	if err := c.refreshSchedulers(ctx); err != nil {
+		disableErr = errors.Join(disableErr, fmt.Errorf("refresh scheduler controller after fail-closed compensation: %w", err))
+	}
+	if disableErr != nil {
+		return fmt.Errorf("fail-closed scheduler compensation: %w", disableErr)
+	}
+	return nil
 }
 
 func (c *Controller) getProjectAgentIfExists(ctx context.Context, projectID, agentName string) (domain.ProjectAgentRecord, bool, error) {

--- a/internal/projects/reconcile.go
+++ b/internal/projects/reconcile.go
@@ -38,9 +38,10 @@ type ReconcileSchedulerOptions struct {
 }
 
 type schedulerReconcileError struct {
-	err          error
-	storeChanged bool
-	refreshOnly  bool
+	err                    error
+	storeChanged           bool
+	storeMutationUncertain bool
+	refreshOnly            bool
 }
 
 func (e schedulerReconcileError) Error() string { return e.err.Error() }
@@ -48,18 +49,21 @@ func (e schedulerReconcileError) Unwrap() error { return e.err }
 
 func schedulerReconcileNeedsFailClosed(err error) bool {
 	var reconcileErr schedulerReconcileError
-	return errors.As(err, &reconcileErr) && reconcileErr.storeChanged && !reconcileErr.refreshOnly
+	return errors.As(err, &reconcileErr) && (reconcileErr.storeChanged || reconcileErr.storeMutationUncertain) && !reconcileErr.refreshOnly
 }
 
 type mutationTrackingSchedulerStore struct {
 	ReconcileSchedulerStore
-	changed bool
+	changed   bool
+	uncertain bool
 }
 
 func (s *mutationTrackingSchedulerStore) UpsertProjectScheduler(ctx context.Context, scheduler domain.ProjectSchedulerRecord) (domain.ProjectSchedulerRecord, error) {
 	record, err := s.ReconcileSchedulerStore.UpsertProjectScheduler(ctx, scheduler)
 	if err == nil {
 		s.changed = true
+	} else {
+		s.uncertain = true
 	}
 	return record, err
 }
@@ -68,6 +72,8 @@ func (s *mutationTrackingSchedulerStore) SetProjectSchedulerEnabled(ctx context.
 	record, err := s.ReconcileSchedulerStore.SetProjectSchedulerEnabled(ctx, projectID, schedulerID, enabled)
 	if err == nil {
 		s.changed = true
+	} else {
+		s.uncertain = true
 	}
 	return record, err
 }
@@ -76,6 +82,8 @@ func (s *mutationTrackingSchedulerStore) ReplaceSchedulerTriggers(ctx context.Co
 	records, err := s.ReconcileSchedulerStore.ReplaceSchedulerTriggers(ctx, schedulerID, triggers)
 	if err == nil {
 		s.changed = true
+	} else {
+		s.uncertain = true
 	}
 	return records, err
 }
@@ -95,12 +103,12 @@ func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, req
 	trackedStore := &mutationTrackingSchedulerStore{ReconcileSchedulerStore: store}
 	changes, currentByID, unchanged, err := reconcileCurrentSchedulers(ctx, trackedStore, req, options)
 	if err != nil {
-		return changes, false, schedulerReconcileError{err: err, storeChanged: trackedStore.changed}
+		return changes, false, schedulerReconcileError{err: err, storeChanged: trackedStore.changed, storeMutationUncertain: trackedStore.uncertain}
 	}
 	removedChanges, removedUnchanged, err := disableRemovedSchedulers(ctx, trackedStore, req, currentByID)
 	changes = append(changes, removedChanges...)
 	if err != nil {
-		return changes, false, schedulerReconcileError{err: err, storeChanged: trackedStore.changed}
+		return changes, false, schedulerReconcileError{err: err, storeChanged: trackedStore.changed, storeMutationUncertain: trackedStore.uncertain}
 	}
 	if !removedUnchanged {
 		unchanged = false
@@ -108,9 +116,10 @@ func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, req
 	if options.RefreshSchedulers != nil {
 		if err := options.RefreshSchedulers(ctx); err != nil {
 			return changes, false, schedulerReconcileError{
-				err:          fmt.Errorf("refresh scheduler controller: %w", err),
-				storeChanged: trackedStore.changed,
-				refreshOnly:  true,
+				err:                    fmt.Errorf("refresh scheduler controller: %w", err),
+				storeChanged:           trackedStore.changed,
+				storeMutationUncertain: trackedStore.uncertain,
+				refreshOnly:            true,
 			}
 		}
 	}

--- a/internal/projects/reconcile.go
+++ b/internal/projects/reconcile.go
@@ -72,7 +72,7 @@ func (s *mutationTrackingSchedulerStore) SetProjectSchedulerEnabled(ctx context.
 	record, err := s.ReconcileSchedulerStore.SetProjectSchedulerEnabled(ctx, projectID, schedulerID, enabled)
 	if err == nil {
 		s.changed = true
-	} else if !(errors.Is(err, domain.ErrNotFound) && !enabled) {
+	} else if !errors.Is(err, domain.ErrNotFound) || enabled {
 		s.uncertain = true
 	}
 	return record, err

--- a/internal/projects/reconcile.go
+++ b/internal/projects/reconcile.go
@@ -37,6 +37,49 @@ type ReconcileSchedulerOptions struct {
 	RefreshSchedulers      func(ctx context.Context) error
 }
 
+type schedulerReconcileError struct {
+	err          error
+	storeChanged bool
+	refreshOnly  bool
+}
+
+func (e schedulerReconcileError) Error() string { return e.err.Error() }
+func (e schedulerReconcileError) Unwrap() error { return e.err }
+
+func schedulerReconcileNeedsFailClosed(err error) bool {
+	var reconcileErr schedulerReconcileError
+	return errors.As(err, &reconcileErr) && reconcileErr.storeChanged && !reconcileErr.refreshOnly
+}
+
+type mutationTrackingSchedulerStore struct {
+	ReconcileSchedulerStore
+	changed bool
+}
+
+func (s *mutationTrackingSchedulerStore) UpsertProjectScheduler(ctx context.Context, scheduler domain.ProjectSchedulerRecord) (domain.ProjectSchedulerRecord, error) {
+	record, err := s.ReconcileSchedulerStore.UpsertProjectScheduler(ctx, scheduler)
+	if err == nil {
+		s.changed = true
+	}
+	return record, err
+}
+
+func (s *mutationTrackingSchedulerStore) SetProjectSchedulerEnabled(ctx context.Context, projectID, schedulerID string, enabled bool) (domain.ProjectSchedulerRecord, error) {
+	record, err := s.ReconcileSchedulerStore.SetProjectSchedulerEnabled(ctx, projectID, schedulerID, enabled)
+	if err == nil {
+		s.changed = true
+	}
+	return record, err
+}
+
+func (s *mutationTrackingSchedulerStore) ReplaceSchedulerTriggers(ctx context.Context, schedulerID string, triggers []domain.SchedulerTrigger) ([]domain.SchedulerTrigger, error) {
+	records, err := s.ReconcileSchedulerStore.ReplaceSchedulerTriggers(ctx, schedulerID, triggers)
+	if err == nil {
+		s.changed = true
+	}
+	return records, err
+}
+
 // ReconcileSchedulersRequest describes the project schedulers to reconcile
 // against their scheduler definitions.
 type ReconcileSchedulersRequest struct {
@@ -49,21 +92,26 @@ func ReconcileSchedulers(ctx context.Context, store ReconcileSchedulerStore, req
 	if store == nil {
 		return nil, false, fmt.Errorf("config store is required")
 	}
-	changes, currentByID, unchanged, err := reconcileCurrentSchedulers(ctx, store, req, options)
+	trackedStore := &mutationTrackingSchedulerStore{ReconcileSchedulerStore: store}
+	changes, currentByID, unchanged, err := reconcileCurrentSchedulers(ctx, trackedStore, req, options)
 	if err != nil {
-		return changes, false, err
+		return changes, false, schedulerReconcileError{err: err, storeChanged: trackedStore.changed}
 	}
-	removedChanges, removedUnchanged, err := disableRemovedSchedulers(ctx, store, req, currentByID)
+	removedChanges, removedUnchanged, err := disableRemovedSchedulers(ctx, trackedStore, req, currentByID)
 	changes = append(changes, removedChanges...)
 	if err != nil {
-		return changes, false, err
+		return changes, false, schedulerReconcileError{err: err, storeChanged: trackedStore.changed}
 	}
 	if !removedUnchanged {
 		unchanged = false
 	}
 	if options.RefreshSchedulers != nil {
 		if err := options.RefreshSchedulers(ctx); err != nil {
-			return changes, false, fmt.Errorf("refresh scheduler controller: %w", err)
+			return changes, false, schedulerReconcileError{
+				err:          fmt.Errorf("refresh scheduler controller: %w", err),
+				storeChanged: trackedStore.changed,
+				refreshOnly:  true,
+			}
 		}
 	}
 	return changes, unchanged, nil

--- a/internal/projects/reconcile.go
+++ b/internal/projects/reconcile.go
@@ -72,7 +72,7 @@ func (s *mutationTrackingSchedulerStore) SetProjectSchedulerEnabled(ctx context.
 	record, err := s.ReconcileSchedulerStore.SetProjectSchedulerEnabled(ctx, projectID, schedulerID, enabled)
 	if err == nil {
 		s.changed = true
-	} else {
+	} else if !(errors.Is(err, domain.ErrNotFound) && !enabled) {
 		s.uncertain = true
 	}
 	return record, err
@@ -221,6 +221,17 @@ func disableRemovedSchedulers(ctx context.Context, store ReconcileSchedulerStore
 		}
 		disabled, err := store.SetProjectSchedulerEnabled(ctx, existing.ProjectID, existing.SchedulerID, false)
 		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				unchanged = false
+				changes = append(changes, Change{
+					Action:       ChangeActionRemoved,
+					ResourceType: "scheduler",
+					ResourceID:   existing.ID,
+					Name:         existing.AgentName,
+					Message:      "already absent while disabling removed scheduler",
+				})
+				continue
+			}
 			return changes, false, fmt.Errorf("disable removed project scheduler %s/%s: %w", existing.ProjectID, existing.SchedulerID, err)
 		}
 		unchanged = false

--- a/internal/projects/reconcile_scheduler_test.go
+++ b/internal/projects/reconcile_scheduler_test.go
@@ -122,6 +122,7 @@ func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T)
 	tests := []struct {
 		name           string
 		getErr         error
+		upsertErr      error
 		replaceErr     error
 		enableErr      error
 		refreshErr     error
@@ -130,6 +131,7 @@ func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T)
 		wantFailClosed bool
 	}{
 		{name: "read before mutation", getErr: errors.New("read failed")},
+		{name: "ambiguous scheduler write", upsertErr: errors.New("write result unknown"), wantFailClosed: true},
 		{name: "trigger replacement", replaceErr: replaceErr, wantCleanup: true, wantFailClosed: true},
 		{name: "scheduler enable", enableErr: enableErr, wantCleanup: true, wantFailClosed: true},
 		{name: "controller refresh", refreshErr: refreshErr, wantChanges: 1},
@@ -140,6 +142,7 @@ func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T)
 				existingRecord:     &existingRecord,
 				existingDefinition: currentDefinition,
 				getErr:             tt.getErr,
+				upsertErr:          tt.upsertErr,
 				replaceErr:         tt.replaceErr,
 				enableErr:          tt.enableErr,
 			}
@@ -212,6 +215,7 @@ type schedulerReconcileStateStore struct {
 	listConfigured     bool
 	savedRecord        domain.ProjectSchedulerRecord
 	getErr             error
+	upsertErr          error
 	replaceErr         error
 	enableErr          error
 	enableWrites       int
@@ -229,6 +233,9 @@ func (s *schedulerReconcileStateStore) GetProjectScheduler(context.Context, stri
 
 func (s *schedulerReconcileStateStore) UpsertProjectScheduler(_ context.Context, item domain.ProjectSchedulerRecord) (domain.ProjectSchedulerRecord, error) {
 	s.savedRecord = item
+	if s.upsertErr != nil {
+		return item, s.upsertErr
+	}
 	return item, nil
 }
 

--- a/internal/projects/reconcile_scheduler_test.go
+++ b/internal/projects/reconcile_scheduler_test.go
@@ -110,6 +110,50 @@ func TestReconcileSchedulersRemovalIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestReconcileSchedulersPreservesPartialMutationSignalAcrossSchedulers(t *testing.T) {
+	project, first, firstDefinition := schedulerReconcileTestState()
+	first.Revision = 3
+	firstDefinition.Summary.ProjectRevision = 3
+	second := first
+	second.ID = "scheduler-2"
+	second.SchedulerID = "scheduler-2"
+	second.AgentName = "worker-2"
+	secondDefinition := firstDefinition
+	secondDefinition.Summary.ID = second.ID
+	secondDefinition.Summary.ProjectSchedulerID = second.SchedulerID
+	secondDefinition.Summary.AgentName = second.AgentName
+	store := &schedulerReconcileStateStore{
+		existingRecord:     &domain.ProjectSchedulerRecord{ID: first.ID, ProjectID: project.ID, SchedulerID: first.SchedulerID, Revision: 2, Enabled: true, SpecJSON: first.SpecJSON},
+		existingDefinition: firstDefinition,
+		getErrOnCall:       2,
+	}
+	_, _, err := ReconcileSchedulers(context.Background(), store, ReconcileSchedulersRequest{
+		Project:     project,
+		Schedulers:  []domain.ProjectSchedulerRecord{first, second},
+		Definitions: []domain.Scheduler{firstDefinition, secondDefinition},
+	}, ReconcileSchedulerOptions{})
+	if err == nil || !schedulerReconcileNeedsFailClosed(err) {
+		t.Fatalf("partial multi-scheduler error = %v, want fail-closed signal", err)
+	}
+}
+
+func TestReconcileSchedulersTreatsMissingRemovedSchedulerAsConverged(t *testing.T) {
+	project, record, _ := schedulerReconcileTestState()
+	store := &schedulerReconcileStateStore{
+		existingRecord: &record,
+		listedRecords:  []domain.ProjectSchedulerRecord{record},
+		listConfigured: true,
+		setEnabledErr:  domain.ResourceError(domain.ErrNotFound, "scheduler", record.SchedulerID, "scheduler already removed", nil),
+	}
+	changes, unchanged, err := ReconcileSchedulers(context.Background(), store, ReconcileSchedulersRequest{Project: project}, ReconcileSchedulerOptions{})
+	if err != nil {
+		t.Fatalf("ReconcileSchedulers returned error: %v", err)
+	}
+	if unchanged || len(changes) != 1 || changes[0].Action != ChangeActionRemoved {
+		t.Fatalf("unchanged/changes = %t/%#v, want false/one removed change", unchanged, changes)
+	}
+}
+
 func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T) {
 	t.Parallel()
 
@@ -218,12 +262,19 @@ type schedulerReconcileStateStore struct {
 	upsertErr          error
 	replaceErr         error
 	enableErr          error
+	setEnabledErr      error
+	getErrOnCall       int
+	getCalls           int
 	enableWrites       int
 }
 
 func (s *schedulerReconcileStateStore) GetProjectScheduler(context.Context, string, string) (domain.ProjectSchedulerRecord, error) {
-	if s.getErr != nil {
-		return domain.ProjectSchedulerRecord{}, s.getErr
+	s.getCalls++
+	if s.getErr != nil || (s.getErrOnCall > 0 && s.getCalls == s.getErrOnCall) {
+		if s.getErr != nil {
+			return domain.ProjectSchedulerRecord{}, s.getErr
+		}
+		return domain.ProjectSchedulerRecord{}, errors.New("scheduler read failed after partial mutation")
 	}
 	if s.existingRecord == nil {
 		return domain.ProjectSchedulerRecord{}, domain.ResourceError(domain.ErrNotFound, "scheduler", "scheduler-1", "scheduler not found", nil)
@@ -241,6 +292,9 @@ func (s *schedulerReconcileStateStore) UpsertProjectScheduler(_ context.Context,
 
 func (s *schedulerReconcileStateStore) SetProjectSchedulerEnabled(_ context.Context, _, _ string, enabled bool) (domain.ProjectSchedulerRecord, error) {
 	s.enableWrites++
+	if s.setEnabledErr != nil {
+		return domain.ProjectSchedulerRecord{}, s.setEnabledErr
+	}
 	if s.enableErr != nil {
 		return domain.ProjectSchedulerRecord{}, s.enableErr
 	}

--- a/internal/projects/reconcile_scheduler_test.go
+++ b/internal/projects/reconcile_scheduler_test.go
@@ -137,6 +137,21 @@ func TestReconcileSchedulersPreservesPartialMutationSignalAcrossSchedulers(t *te
 	}
 }
 
+func TestReconcileSchedulersFailsClosedOnRemovedSchedulerWriteError(t *testing.T) {
+	project, record, _ := schedulerReconcileTestState()
+	writeErr := errors.New("disable removed scheduler failed")
+	store := &schedulerReconcileStateStore{
+		existingRecord: &record,
+		listedRecords:  []domain.ProjectSchedulerRecord{record},
+		listConfigured: true,
+		setEnabledErr:  writeErr,
+	}
+	_, _, err := ReconcileSchedulers(context.Background(), store, ReconcileSchedulersRequest{Project: project}, ReconcileSchedulerOptions{})
+	if err == nil || !errors.Is(err, writeErr) || !schedulerReconcileNeedsFailClosed(err) {
+		t.Fatalf("removed scheduler write error = %v, want fail-closed error", err)
+	}
+}
+
 func TestReconcileSchedulersTreatsMissingRemovedSchedulerAsConverged(t *testing.T) {
 	project, record, _ := schedulerReconcileTestState()
 	store := &schedulerReconcileStateStore{

--- a/internal/projects/reconcile_scheduler_test.go
+++ b/internal/projects/reconcile_scheduler_test.go
@@ -120,15 +120,18 @@ func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T)
 	enableErr := errors.New("enable failed")
 	refreshErr := errors.New("refresh failed")
 	tests := []struct {
-		name        string
-		replaceErr  error
-		enableErr   error
-		refreshErr  error
-		wantCleanup bool
-		wantChanges int
+		name           string
+		getErr         error
+		replaceErr     error
+		enableErr      error
+		refreshErr     error
+		wantCleanup    bool
+		wantChanges    int
+		wantFailClosed bool
 	}{
-		{name: "trigger replacement", replaceErr: replaceErr, wantCleanup: true},
-		{name: "scheduler enable", enableErr: enableErr, wantCleanup: true},
+		{name: "read before mutation", getErr: errors.New("read failed")},
+		{name: "trigger replacement", replaceErr: replaceErr, wantCleanup: true, wantFailClosed: true},
+		{name: "scheduler enable", enableErr: enableErr, wantCleanup: true, wantFailClosed: true},
 		{name: "controller refresh", refreshErr: refreshErr, wantChanges: 1},
 	}
 	for _, tt := range tests {
@@ -136,6 +139,7 @@ func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T)
 			store := &schedulerReconcileStateStore{
 				existingRecord:     &existingRecord,
 				existingDefinition: currentDefinition,
+				getErr:             tt.getErr,
 				replaceErr:         tt.replaceErr,
 				enableErr:          tt.enableErr,
 			}
@@ -151,6 +155,9 @@ func TestReconcileSchedulersFailureReportsCleanupAndPartialChanges(t *testing.T)
 			}
 			if unchanged || len(changes) != tt.wantChanges {
 				t.Fatalf("unchanged/changes = %t/%#v, want false/%d", unchanged, changes, tt.wantChanges)
+			}
+			if got := schedulerReconcileNeedsFailClosed(err); got != tt.wantFailClosed {
+				t.Fatalf("schedulerReconcileNeedsFailClosed = %t, want %t for %v", got, tt.wantFailClosed, err)
 			}
 			if (cleanupID != "") != tt.wantCleanup {
 				t.Fatalf("cleanup scheduler id = %q, want cleanup %t", cleanupID, tt.wantCleanup)
@@ -204,12 +211,16 @@ type schedulerReconcileStateStore struct {
 	listedRecords      []domain.ProjectSchedulerRecord
 	listConfigured     bool
 	savedRecord        domain.ProjectSchedulerRecord
+	getErr             error
 	replaceErr         error
 	enableErr          error
 	enableWrites       int
 }
 
 func (s *schedulerReconcileStateStore) GetProjectScheduler(context.Context, string, string) (domain.ProjectSchedulerRecord, error) {
+	if s.getErr != nil {
+		return domain.ProjectSchedulerRecord{}, s.getErr
+	}
 	if s.existingRecord == nil {
 		return domain.ProjectSchedulerRecord{}, domain.ResourceError(domain.ErrNotFound, "scheduler", "scheduler-1", "scheduler not found", nil)
 	}


### PR DESCRIPTION
## 问题
Project Apply 会先持久化新 revision、agent 和 scheduler projection，再执行 scheduler reconcile。若后续 scheduler trigger 更新、启用或 controller refresh 失败，之前已成功启用的 project scheduler 可能继续运行，而 Apply 已返回失败。

## 影响
系统会同时存在“Apply 失败”与“部分新配置仍在运行”的状态：旧 scheduler 或已部分更新的 scheduler 可能执行不完整 revision，造成调度配置与持久化期望状态不一致。该问题属于状态机一致性缺陷。

## 修复内容
- 在 scheduler reconcile 失败后，对该 project 的所有已启用 scheduler 执行 fail-closed 补偿，将其禁用。
- 补偿后再次刷新 scheduler controller，确保内存中的调度状态与持久化禁用状态一致。
- 使用 `errors.Join` 保留原始 reconcile 错误及补偿/刷新错误，便于诊断。
- 增加成功补偿和多错误聚合的回归测试。

## 验证
- `go test ./internal/projects -run 'TestDisableProjectSchedulersAfterReconcileFailure' -count=1`
- `git diff --check`

说明：完整项目测试当前仍受 main 基线中 Protobuf 生成文件与 `.proto` 源码不同步影响，未在本 PR 中处理该独立问题。
