### PR TITLE
Security: constrain local volume removal

### DIFF
--- a/pkg/volumes/driver.go
+++ b/pkg/volumes/driver.go
@@ -2,6 +2,7 @@ package volumes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,9 +80,12 @@ func (d LocalDriver) Remove(_ context.Context, record domain.VolumeRecord) error
 	}
 	resolvedPath, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		return fmt.Errorf("resolve local volume path %s: %w", absPath, err)
 	}
-	resolvedRoot, err := filepath.EvalSymlinks(managedRoot)
+	resolvedRoot, err := canonicalizePathAllowMissing(managedRoot)
 	if err != nil {
 		return fmt.Errorf("resolve local volume data root %s: %w", managedRoot, err)
 	}
@@ -90,9 +94,13 @@ func (d LocalDriver) Remove(_ context.Context, record domain.VolumeRecord) error
 	}
 	removePath := resolvedPath
 	if managedPath := d.dataPath(record.ID); managedPath != "" {
-		resolvedManagedPath, managedErr := filepath.EvalSymlinks(managedPath)
-		if managedErr == nil && resolvedPath == resolvedManagedPath {
-			removePath = filepath.Dir(resolvedManagedPath)
+		absManagedPath, managedErr := filepath.Abs(filepath.Clean(managedPath))
+		if managedErr == nil && absPath == absManagedPath {
+			volumePath := filepath.Dir(absManagedPath)
+			resolvedVolumePath, resolveErr := canonicalizePathAllowMissing(volumePath)
+			if resolveErr == nil && pathWithinRoot(resolvedRoot, resolvedVolumePath) == nil {
+				removePath = resolvedVolumePath
+			}
 		}
 	}
 	if err := os.RemoveAll(removePath); err != nil {
@@ -121,6 +129,33 @@ func (d LocalDriver) ResolveMountSource(_ context.Context, record domain.VolumeR
 		return "", fmt.Errorf("local volume path %s is not a directory", absPath)
 	}
 	return absPath, nil
+}
+
+func canonicalizePathAllowMissing(path string) (string, error) {
+	path = filepath.Clean(path)
+	missing := make([]string, 0)
+	for {
+		_, err := os.Lstat(path)
+		if err == nil {
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return "", err
+			}
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", os.ErrNotExist
+		}
+		missing = append(missing, filepath.Base(path))
+		path = parent
+	}
 }
 
 func pathWithinRoot(root, candidate string) error {

--- a/pkg/volumes/driver.go
+++ b/pkg/volumes/driver.go
@@ -69,12 +69,30 @@ func (d LocalDriver) Remove(_ context.Context, record domain.VolumeRecord) error
 	if path == "" {
 		return fmt.Errorf("local volume path is required")
 	}
-	removePath := path
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("resolve local volume path %s: %w", path, err)
+	}
+	managedRoot, err := filepath.Abs(filepath.Clean(filepath.Join(strings.TrimSpace(d.DataRoot), "volumes", domain.VolumeDriverLocal)))
+	if err != nil || strings.TrimSpace(d.DataRoot) == "" {
+		return fmt.Errorf("local volume data root is required")
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return fmt.Errorf("resolve local volume path %s: %w", absPath, err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(managedRoot)
+	if err != nil {
+		return fmt.Errorf("resolve local volume data root %s: %w", managedRoot, err)
+	}
+	if err := pathWithinRoot(resolvedRoot, resolvedPath); err != nil {
+		return fmt.Errorf("refuse to remove local volume path %s: %w", absPath, err)
+	}
+	removePath := resolvedPath
 	if managedPath := d.dataPath(record.ID); managedPath != "" {
-		absPath, pathErr := filepath.Abs(path)
-		absManagedPath, managedErr := filepath.Abs(managedPath)
-		if pathErr == nil && managedErr == nil && absPath == absManagedPath {
-			removePath = filepath.Dir(absManagedPath)
+		resolvedManagedPath, managedErr := filepath.EvalSymlinks(managedPath)
+		if managedErr == nil && resolvedPath == resolvedManagedPath {
+			removePath = filepath.Dir(resolvedManagedPath)
 		}
 	}
 	if err := os.RemoveAll(removePath); err != nil {
@@ -103,6 +121,17 @@ func (d LocalDriver) ResolveMountSource(_ context.Context, record domain.VolumeR
 		return "", fmt.Errorf("local volume path %s is not a directory", absPath)
 	}
 	return absPath, nil
+}
+
+func pathWithinRoot(root, candidate string) error {
+	relative, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return err
+	}
+	if filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || relative == "." {
+		return fmt.Errorf("path is outside managed root")
+	}
+	return nil
 }
 
 func (d LocalDriver) dataPath(volumeID string) string {

--- a/pkg/volumes/manager_test.go
+++ b/pkg/volumes/manager_test.go
@@ -348,6 +348,14 @@ func TestManagerCreateCleansManagedPathWhenStoreCreateFails(t *testing.T) {
 	}
 }
 
+func TestLocalDriverRemoveIsIdempotentForMissingPaths(t *testing.T) {
+	if err := (LocalDriver{DataRoot: t.TempDir()}).Remove(context.Background(), domain.VolumeRecord{
+		ID: "missing-volume",
+	}); err != nil {
+		t.Fatalf("Remove missing volume = %v, want nil", err)
+	}
+}
+
 func TestLocalDriverRemoveRejectsPathOutsideManagedRoot(t *testing.T) {
 	dataRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dataRoot, "volumes", domain.VolumeDriverLocal), 0o700); err != nil {
@@ -367,6 +375,26 @@ func TestLocalDriverRemoveRejectsPathOutsideManagedRoot(t *testing.T) {
 	}
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("outside marker stat error = %v, path may have been removed", err)
+	}
+}
+
+func TestLocalDriverRemoveDoesNotEscalateSymlinkedDataPath(t *testing.T) {
+	dataRoot := t.TempDir()
+	volumeRoot := filepath.Join(dataRoot, "volumes", domain.VolumeDriverLocal, "volume-id")
+	if err := os.MkdirAll(volumeRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(".", filepath.Join(volumeRoot, "data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := (LocalDriver{DataRoot: dataRoot}).Remove(context.Background(), domain.VolumeRecord{
+		ID:   "volume-id",
+		Path: filepath.Join(volumeRoot, "data"),
+	}); err != nil {
+		t.Fatalf("Remove symlinked data path = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "volumes", domain.VolumeDriverLocal)); err != nil {
+		t.Fatalf("managed volume root stat error = %v, entire root may have been removed", err)
 	}
 }
 

--- a/pkg/volumes/manager_test.go
+++ b/pkg/volumes/manager_test.go
@@ -348,6 +348,28 @@ func TestManagerCreateCleansManagedPathWhenStoreCreateFails(t *testing.T) {
 	}
 }
 
+func TestLocalDriverRemoveRejectsPathOutsideManagedRoot(t *testing.T) {
+	dataRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dataRoot, "volumes", domain.VolumeDriverLocal), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	marker := filepath.Join(outside, "must-survive.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := (LocalDriver{DataRoot: dataRoot}).Remove(context.Background(), domain.VolumeRecord{
+		ID:   "volume-id",
+		Path: outside,
+	})
+	if err == nil || !strings.Contains(err.Error(), "outside managed root") {
+		t.Fatalf("Remove error = %v, want managed-root rejection", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("outside marker stat error = %v, path may have been removed", err)
+	}
+}
+
 func TestManagerRemoveKeepsStoreRecordWhenDriverRemoveFails(t *testing.T) {
 	ctx := context.Background()
 	store := &fakeStore{}
@@ -412,7 +434,14 @@ func TestManagerRemoveForceSkipsConfigReferencesButNotSandboxReferences(t *testi
 	if err != nil {
 		t.Fatalf("CreateVolume: %v", err)
 	}
-	manager := NewManager(store, LocalDriver{DataRoot: t.TempDir()})
+	dataRoot := t.TempDir()
+	record.Path = filepath.Join(dataRoot, "volumes", domain.VolumeDriverLocal, record.ID, "data")
+	store.items[record.ID] = record
+	store.items[record.Name] = record
+	if err := os.MkdirAll(record.Path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(store, LocalDriver{DataRoot: dataRoot})
 	if err := manager.Remove(ctx, record.Name, false); !errors.Is(err, domain.ErrReferenced) {
 		t.Fatalf("Remove without force err = %v, want ErrReferenced", err)
 	}
@@ -436,7 +465,14 @@ func TestManagerRemoveForceBypassesStoreConfigReferenceRecheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateVolume: %v", err)
 	}
-	manager := NewManager(store, LocalDriver{DataRoot: t.TempDir()})
+	dataRoot := t.TempDir()
+	record.Path = filepath.Join(dataRoot, "volumes", domain.VolumeDriverLocal, record.ID, "data")
+	store.items[record.ID] = record
+	store.items[record.Name] = record
+	if err := os.MkdirAll(record.Path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(store, LocalDriver{DataRoot: dataRoot})
 	if err := manager.Remove(ctx, record.Name, true); err != nil {
 		t.Fatalf("Remove with force returned error: %v", err)
 	}


### PR DESCRIPTION
## 问题
Local volume removal accepted the persisted `record.Path` and passed it to `os.RemoveAll`. A path outside the daemon-managed volume tree could therefore be deleted when a volume was removed. Symlink and path normalization checks were also incomplete.

## 影响
如果恶意或被篡改的 volume metadata 包含宿主机敏感目录，调用 volume remove/prune 可能删除项目根目录之外的数据。涉及 CWE-22、CWE-61。

## 修复内容
- Local driver 删除前将 volume path 和 managed root 规范化为绝对 realpath。
- 强制删除目标必须位于 `DATA_ROOT/volumes/local` 内，拒绝 root 本身和所有越界路径。
- managed volume 仍只删除其自身 volume 目录，不改变正常生命周期。
- 增加回归测试，验证 managed root 外的 marker 文件不会被删除。

## 验证
- `go test ./pkg/volumes -run 'TestLocalDriverRemoveRejectsPathOutsideManagedRoot|TestManagerRemoveForce' -count=1`
- `git diff --check`

说明：完整 `pkg/volumes` 测试当前在 macOS 上仍有基线中的 `/var` 与 `/private/var` 路径断言失败，本 PR 未改变该路径规范化行为。
