### PR TITLE
test(microsandbox): remove guest Docker dependency from smoke

### DIFF
--- a/pkg/driver/microsandbox_rootfs_smoke_test.go
+++ b/pkg/driver/microsandbox_rootfs_smoke_test.go
@@ -135,6 +135,9 @@ func assertMicrosandboxRootDiskPersistsAcrossRestart(
 	const assertRootDisk = `
 set -eu
 test "$(stat -c %d /)" = "$(stat -c %d /var/lib)"
+if [ -d /var/lib/docker ]; then
+  test "$(stat -c %d /)" = "$(stat -c %d /var/lib/docker)"
+fi
 `
 	writeResult, err := runtimeDriver.Exec(ctx, session, vmState, ExecSpec{
 		Command: "sh",
@@ -142,18 +145,18 @@ test "$(stat -c %d /)" = "$(stat -c %d /var/lib)"
 		Cwd:     "/",
 	})
 	if err != nil || !writeResult.Success {
-		t.Fatalf("verify Docker root disk before restart: result=%#v err=%v", writeResult, err)
+		t.Fatalf("verify root disk before restart: result=%#v err=%v", writeResult, err)
 	}
 
 	missing, err := runtimeDriver.StopSandbox(ctx, session, vmState)
 	if err != nil || missing {
-		t.Fatalf("stop microsandbox for Docker root disk check: missing=%v err=%v", missing, err)
+		t.Fatalf("stop microsandbox for root disk check: missing=%v err=%v", missing, err)
 	}
 	resumeState := vmState
 	resumeState.StoppedAt = time.Now().UTC()
 	info, err := runtimeDriver.EnsureSandbox(ctx, session, resumeState, proxyState)
 	if err != nil {
-		t.Fatalf("resume microsandbox for Docker root disk check: %v", err)
+		t.Fatalf("resume microsandbox for root disk check: %v", err)
 	}
 	if info.BoxID != vmState.BoxID {
 		t.Fatalf("resumed microsandbox = %q, want %q", info.BoxID, vmState.BoxID)
@@ -166,7 +169,7 @@ test "$(stat -c %d /)" = "$(stat -c %d /var/lib)"
 		Cwd:     "/",
 	})
 	if err != nil || !readResult.Success {
-		t.Fatalf("verify Docker root disk after restart: result=%#v err=%v", readResult, err)
+		t.Fatalf("verify root disk after restart: result=%#v err=%v", readResult, err)
 	}
 }
 

--- a/pkg/driver/microsandbox_rootfs_smoke_test.go
+++ b/pkg/driver/microsandbox_rootfs_smoke_test.go
@@ -38,6 +38,7 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 	}
 	secondState.BoxID = secondInfo.BoxID
 	cleanupRuntimeSmokeSandbox(t, config, runtimeDriver, second, secondState)
+	assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t, config.MicrosandboxHome)
 
 	type execution struct {
 		name    string
@@ -99,6 +100,7 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 			t.Fatalf("removed sandbox resource %s remains: %v", path, err)
 		}
 	}
+	assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t, config.MicrosandboxHome)
 
 	third, thirdState, thirdProxy := newRuntimeSmokeSandbox(t, ctx, config, RuntimeDriverMicrosandbox)
 	third.Summary.PullPolicy = "never"
@@ -108,6 +110,7 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 	}
 	thirdState.BoxID = thirdInfo.BoxID
 	cleanupRuntimeSmokeSandbox(t, config, runtimeDriver, third, thirdState)
+	assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t, config.MicrosandboxHome)
 	result, err := runtimeDriver.Exec(ctx, third, thirdState, ExecSpec{Command: "sh", Args: []string{"-lc", "test ! -e /tmp/rootfs-isolation && test ! -e /etc/rootfs-isolation && test ! -e /var/tmp/rootfs-isolation"}, Cwd: "/"})
 	if err != nil || !result.Success {
 		t.Fatalf("new sandbox inherited rootfs pollution: result=%#v err=%v", result, err)
@@ -132,6 +135,9 @@ func assertMicrosandboxRootDiskPersistsAcrossRestart(
 	const assertRootDisk = `
 set -eu
 test "$(stat -c %d /)" = "$(stat -c %d /var/lib)"
+if [ -d /var/lib/docker ]; then
+  test "$(stat -c %d /)" = "$(stat -c %d /var/lib/docker)"
+fi
 `
 	writeResult, err := runtimeDriver.Exec(ctx, session, vmState, ExecSpec{
 		Command: "sh",
@@ -164,5 +170,12 @@ test "$(stat -c %d /)" = "$(stat -c %d /var/lib)"
 	})
 	if err != nil || !readResult.Success {
 		t.Fatalf("verify root disk after restart: result=%#v err=%v", readResult, err)
+	}
+}
+
+func assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t *testing.T, microsandboxHome string) {
+	t.Helper()
+	if _, err := os.Lstat(filepath.Join(microsandboxHome, "docker-disks")); !os.IsNotExist(err) {
+		t.Fatalf("new Microsandbox creation produced docker-disks, err=%v", err)
 	}
 }

--- a/pkg/driver/microsandbox_rootfs_smoke_test.go
+++ b/pkg/driver/microsandbox_rootfs_smoke_test.go
@@ -31,6 +31,7 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 	}
 	firstState.BoxID = firstInfo.BoxID
 	cleanupRuntimeSmokeSandbox(t, config, runtimeDriver, first, firstState)
+	assertMicrosandboxRootDiskPersistsAcrossRestart(t, ctx, runtimeDriver, first, firstState, firstProxy)
 	secondInfo, err := runtimeDriver.EnsureSandbox(ctx, second, secondState, secondProxy)
 	if err != nil {
 		t.Fatalf("create second microsandbox: %v", err)
@@ -77,8 +78,6 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 			t.Fatalf("%s isolated read result=%#v err=%v", item.name, result, err)
 		}
 	}
-	assertMicrosandboxDockerUsesRootDiskAcrossRestart(t, ctx, runtimeDriver, first, firstState, firstProxy)
-
 	firstDisk := runtimeDriver.rootfsDiskPath(first.Summary.ID)
 	secondDisk := runtimeDriver.rootfsDiskPath(second.Summary.ID)
 	for _, path := range []string{firstDisk, firstDisk + ".owner.json", secondDisk, secondDisk + ".owner.json"} {
@@ -123,7 +122,7 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 	t.Logf("microsandbox rootfs isolation: base=%s allocated=%d child_a=%d child_b=%d", baseMatches[0], baseAfter, allocatedBytes(t, secondDisk), allocatedBytes(t, runtimeDriver.rootfsDiskPath(third.Summary.ID)))
 }
 
-func assertMicrosandboxDockerUsesRootDiskAcrossRestart(
+func assertMicrosandboxRootDiskPersistsAcrossRestart(
 	t *testing.T,
 	ctx context.Context,
 	runtimeDriver *microsandboxRuntime,
@@ -132,19 +131,14 @@ func assertMicrosandboxDockerUsesRootDiskAcrossRestart(
 	proxyState ProxyState,
 ) {
 	t.Helper()
-	const marker = "/var/lib/docker/agent-compose-rootfs-smoke-state"
-	const assertDockerRootDisk = `
+	const marker = "/var/lib/agent-compose-rootfs-smoke-state"
+	const assertRootDisk = `
 set -eu
-driver="$(docker info --format '{{.Driver}}')"
-case "$driver" in
-  overlay2|overlayfs) ;;
-  *) echo "unexpected Docker storage driver: $driver" >&2; exit 1 ;;
-esac
-test "$(stat -c %d /)" = "$(stat -c %d /var/lib/docker)"
+test "$(stat -c %d /)" = "$(stat -c %d /var/lib)"
 `
 	writeResult, err := runtimeDriver.Exec(ctx, session, vmState, ExecSpec{
 		Command: "sh",
-		Args:    []string{"-lc", assertDockerRootDisk + "printf %s docker-rootfs-state > " + marker},
+		Args:    []string{"-lc", assertRootDisk + "printf %s rootfs-state > " + marker},
 		Cwd:     "/",
 	})
 	if err != nil || !writeResult.Success {
@@ -168,7 +162,7 @@ test "$(stat -c %d /)" = "$(stat -c %d /var/lib/docker)"
 	resumeState.StoppedAt = time.Time{}
 	readResult, err := runtimeDriver.Exec(ctx, session, resumeState, ExecSpec{
 		Command: "sh",
-		Args:    []string{"-lc", assertDockerRootDisk + "test \"$(cat " + marker + ")\" = docker-rootfs-state"},
+		Args:    []string{"-lc", assertRootDisk + "test \"$(cat " + marker + ")\" = rootfs-state"},
 		Cwd:     "/",
 	})
 	if err != nil || !readResult.Success {

--- a/pkg/driver/microsandbox_rootfs_smoke_test.go
+++ b/pkg/driver/microsandbox_rootfs_smoke_test.go
@@ -38,7 +38,6 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 	}
 	secondState.BoxID = secondInfo.BoxID
 	cleanupRuntimeSmokeSandbox(t, config, runtimeDriver, second, secondState)
-	assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t, config.MicrosandboxHome)
 
 	type execution struct {
 		name    string
@@ -100,7 +99,6 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 			t.Fatalf("removed sandbox resource %s remains: %v", path, err)
 		}
 	}
-	assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t, config.MicrosandboxHome)
 
 	third, thirdState, thirdProxy := newRuntimeSmokeSandbox(t, ctx, config, RuntimeDriverMicrosandbox)
 	third.Summary.PullPolicy = "never"
@@ -110,7 +108,6 @@ func TestSmokeMicrosandboxRootfsIsolation(t *testing.T) {
 	}
 	thirdState.BoxID = thirdInfo.BoxID
 	cleanupRuntimeSmokeSandbox(t, config, runtimeDriver, third, thirdState)
-	assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t, config.MicrosandboxHome)
 	result, err := runtimeDriver.Exec(ctx, third, thirdState, ExecSpec{Command: "sh", Args: []string{"-lc", "test ! -e /tmp/rootfs-isolation && test ! -e /etc/rootfs-isolation && test ! -e /var/tmp/rootfs-isolation"}, Cwd: "/"})
 	if err != nil || !result.Success {
 		t.Fatalf("new sandbox inherited rootfs pollution: result=%#v err=%v", result, err)
@@ -135,9 +132,6 @@ func assertMicrosandboxRootDiskPersistsAcrossRestart(
 	const assertRootDisk = `
 set -eu
 test "$(stat -c %d /)" = "$(stat -c %d /var/lib)"
-if [ -d /var/lib/docker ]; then
-  test "$(stat -c %d /)" = "$(stat -c %d /var/lib/docker)"
-fi
 `
 	writeResult, err := runtimeDriver.Exec(ctx, session, vmState, ExecSpec{
 		Command: "sh",
@@ -170,12 +164,5 @@ fi
 	})
 	if err != nil || !readResult.Success {
 		t.Fatalf("verify root disk after restart: result=%#v err=%v", readResult, err)
-	}
-}
-
-func assertMicrosandboxLegacyDockerDiskDirectoryAbsent(t *testing.T, microsandboxHome string) {
-	t.Helper()
-	if _, err := os.Lstat(filepath.Join(microsandboxHome, "docker-disks")); !os.IsNotExist(err) {
-		t.Fatalf("new Microsandbox creation produced docker-disks, err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Remove the implicit Docker CLI requirement from the Microsandbox rootfs isolation smoke test.
- Verify root-disk placement and persistence directly through `/var/lib`, so the smoke test works with the documented minimal `debian:bookworm-slim` guest image.
- Run the stop/resume persistence assertion before starting the concurrent isolation sandbox, keeping lifecycle persistence and multi-sandbox isolation as independent checks.

The previous test called `docker info` inside the guest even though Docker is not a Microsandbox driver requirement and is not installed in the default smoke image. This produced `docker: not found` after the Microsandbox VM had already started successfully, incorrectly presenting an image/test-fixture problem as a driver failure.

## Testing

```bash
SMOKE_RUNTIME_DRIVERS=microsandbox \
  LD_LIBRARY_PATH="$PWD/build/microsandbox/lib:${LD_LIBRARY_PATH:-}" \
  GOCACHE=/data/src/github.com/chaitin/agent-compose/.cache/go-build \
  ./scripts/with-go-toolchain.sh go test -tags microsandboxcgo ./pkg/driver \
  -run '^TestSmokeMicrosandboxRootfsIsolation$' -count=1 -v

SMOKE_RUNTIME_DRIVERS=microsandbox task test:runtime-smoke
```

Both commands passed on a Linux ARM64 HiSilicon Kunpeng 920 host with KVM enabled.

## Checklist

- [x] Documentation updated when behavior or configuration changed. (Not applicable: test-only change.)
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
