### PR TITLE
docs(showcase): add agent sample workflows

### DIFF
--- a/docs/pages/showcase.md
+++ b/docs/pages/showcase.md
@@ -1,0 +1,27 @@
+# Showcase
+
+Explore practical agent-compose projects from the [agent-compose-sample repository](https://github.com/kingfs/agent-compose-sample/tree/main/agents).
+
+## Chat Agent
+
+A minimal, stateless chat assistant that can be called from the CLI or Connect RPC HTTP API. Use it to validate provider configuration or add an agent to an existing service.
+
+[View the example →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/chat-agent)
+
+## Dynamic Workflow
+
+An agent-driven workflow that composes multiple steps dynamically, demonstrating how a runtime script can coordinate agents and return structured results.
+
+[View the example →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/dynamic-workflow)
+
+## Event-driven Workflow
+
+An event-triggered workflow that reacts to published events and starts agent work, showing how external signals can become repeatable automation.
+
+[View the example →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/event-driven-workflow)
+
+## Scheduled Agent
+
+A scheduled agent that runs on a recurring trigger, suitable for periodic reports, repository checks, and other unattended tasks.
+
+[View the example →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/scheduled-agent)

--- a/docs/pages/zh-CN/showcase.md
+++ b/docs/pages/zh-CN/showcase.md
@@ -1,0 +1,27 @@
+# 作品集
+
+在 [agent-compose-sample 示例仓库](https://github.com/kingfs/agent-compose-sample/tree/main/agents) 中探索实际可运行的 agent-compose 项目。
+
+## Chat Agent
+
+最小的无状态对话助手，可通过 CLI 或 Connect RPC HTTP API 调用。适合验证 provider 配置，或为现有服务接入 Agent。
+
+[查看示例 →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/chat-agent)
+
+## Dynamic Workflow
+
+动态编排多个步骤的 Agent 工作流，展示运行时脚本如何协调多个 Agent 并返回结构化结果。
+
+[查看示例 →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/dynamic-workflow)
+
+## Event-driven Workflow
+
+由事件触发的工作流，响应已发布事件并启动 Agent 任务，展示如何把外部信号转化为可重复的自动化流程。
+
+[查看示例 →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/event-driven-workflow)
+
+## Scheduled Agent
+
+按周期触发运行的 Agent，适合定期报告、仓库检查及其他无人值守任务。
+
+[查看示例 →](https://github.com/kingfs/agent-compose-sample/tree/main/agents/scheduled-agent)

--- a/tools/genpages/check-pages.mjs
+++ b/tools/genpages/check-pages.mjs
@@ -14,6 +14,7 @@ const manualNames = [
   "command-line-manual.md",
   "connect-transport-matrix.md",
   "guest-image-abi.md",
+  "showcase.md",
 ];
 const expectedOutput = new Set([
   "agent-compose-yaml-manual.html",
@@ -26,6 +27,8 @@ const expectedOutput = new Set([
   "zh-CN/command-line-manual.html",
   "zh-CN/connect-transport-matrix.html",
   "zh-CN/guest-image-abi.html",
+  "showcase.html",
+  "zh-CN/showcase.html",
 ]);
 
 await checkSourceLayout();

--- a/tools/genpages/render-pages.mjs
+++ b/tools/genpages/render-pages.mjs
@@ -45,6 +45,13 @@ const manuals = [
     alternate: "zh-CN/guest-image-abi.html",
   },
   {
+    source: "showcase.md",
+    output: "showcase.html",
+    title: "Showcase",
+    lang: "en",
+    alternate: "zh-CN/showcase.html",
+  },
+  {
     source: "zh-CN/command-line-manual.md",
     output: "zh-CN/command-line-manual.html",
     title: "命令行手册",
@@ -64,6 +71,13 @@ const manuals = [
     title: "自定义 Guest Image ABI",
     lang: "zh-CN",
     alternate: "../guest-image-abi.html",
+  },
+  {
+    source: "zh-CN/showcase.md",
+    output: "zh-CN/showcase.html",
+    title: "作品集",
+    lang: "zh-CN",
+    alternate: "../showcase.html",
   },
 ];
 
@@ -92,13 +106,14 @@ function renderPage(manual, body) {
   const nested = currentPage.includes("/");
   const root = nested ? "../" : "./";
   const labels = lang === "zh-CN"
-    ? ["首页", "命令行手册", "YAML 配置手册", "Connect 传输矩阵"]
-    : ["Home", "CLI Manual", "YAML Manual", "Connect Transport"];
+    ? ["首页", "命令行手册", "YAML 配置手册", "Connect 传输矩阵", "作品集"]
+    : ["Home", "CLI Manual", "YAML Manual", "Connect Transport", "Showcase"];
   const navItems = [
     [root, labels[0], ""],
     ["command-line-manual.html", labels[1], "command-line-manual.html"],
     ["agent-compose-yaml-manual.html", labels[2], "agent-compose-yaml-manual.html"],
     ["connect-transport-matrix.html", labels[3], "connect-transport-matrix.html"],
+    ["showcase.html", labels[4], "showcase.html"],
   ];
   const nav = navItems
     .map(([href, label, page]) => {


### PR DESCRIPTION
## Summary

新增 Showcase 作品集页面，收录 `agent-compose-sample` 中的四个可运行示例：

- `chat-agent`
- `dynamic-workflow`
- `event-driven-workflow`
- `scheduled-agent`

同步添加中英文页面、页面导航、Pages 生成器配置和输出校验规则，方便用户从作品集直接进入对应示例。

## Testing

- `npm run build`（在 `tools/genpages` 下执行）

该命令包含页面测试、页面生成、输出白名单、内部链接、导航和 YAML schema coverage 校验，已全部通过。

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
