### PR TITLE
fix(scheduler): stop collapsing agent finalText into the raw transcript

### DIFF
--- a/pkg/agentcompose/adapters/adapter_helpers_coverage_test.go
+++ b/pkg/agentcompose/adapters/adapter_helpers_coverage_test.go
@@ -22,7 +22,7 @@ func TestAdapterHelperCoverage(t *testing.T) {
 		if _, err := (SchedulerHostEvents{}).AddRecord(context.Background(), schedulers.SchedulerEventInput{}); err == nil {
 			t.Fatalf("SchedulerHostEvents.AddRecord returned nil error")
 		}
-		if _, err := (SchedulerHostAgentExecutor{}).ExecuteAgent(context.Background(), nil, schedulers.HostAgentExecutionRequest{}); err == nil {
+		if _, _, err := (SchedulerHostAgentExecutor{}).ExecuteAgent(context.Background(), nil, schedulers.HostAgentExecutionRequest{}); err == nil {
 			t.Fatalf("SchedulerHostAgentExecutor.ExecuteAgent returned nil error")
 		}
 		if _, err := (SchedulerHostCommandExecutor{}).ExecuteSchedulerCommand(context.Background(), nil, domain.SchedulerCommandRequest{}); err == nil {

--- a/pkg/agentcompose/adapters/scheduler_host.go
+++ b/pkg/agentcompose/adapters/scheduler_host.go
@@ -33,11 +33,11 @@ type SchedulerHostAgentExecutor struct {
 	Executor *AgentExecutor
 }
 
-func (e SchedulerHostAgentExecutor) ExecuteAgent(ctx context.Context, session *domain.Sandbox, request schedulers.HostAgentExecutionRequest) (domain.NotebookCell, error) {
+func (e SchedulerHostAgentExecutor) ExecuteAgent(ctx context.Context, session *domain.Sandbox, request schedulers.HostAgentExecutionRequest) (domain.NotebookCell, string, error) {
 	if e.Executor == nil {
-		return domain.NotebookCell{}, fmt.Errorf("agent executor is unavailable")
+		return domain.NotebookCell{}, "", fmt.Errorf("agent executor is unavailable")
 	}
-	cell, _, _, err := e.Executor.ExecuteAgentRequest(ctx, session, execution.ExecuteAgentRequest{
+	cell, _, assistantEvent, err := e.Executor.ExecuteAgentRequest(ctx, session, execution.ExecuteAgentRequest{
 		Agent:             request.Provider,
 		AgentDefinitionID: request.AgentDefinitionID,
 		Model:             request.Model,
@@ -46,7 +46,7 @@ func (e SchedulerHostAgentExecutor) ExecuteAgent(ctx context.Context, session *d
 		Timeout:           request.Timeout,
 		OutputSchemaJSON:  request.OutputSchemaJSON,
 	})
-	return cell, err
+	return cell, assistantEvent.Message, err
 }
 
 type SchedulerHostCommandExecutor struct {

--- a/pkg/agentcompose/adapters/scheduler_host_test.go
+++ b/pkg/agentcompose/adapters/scheduler_host_test.go
@@ -1,0 +1,70 @@
+package adapters
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	appconfig "github.com/chaitin/agent-compose/pkg/config"
+	driverpkg "github.com/chaitin/agent-compose/pkg/driver"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	"github.com/chaitin/agent-compose/pkg/schedulers"
+	"github.com/chaitin/agent-compose/pkg/storage/sandboxstore"
+)
+
+// TestSchedulerHostAgentExecutorReturnsAssistantMessage guards against
+// SchedulerHostAgentExecutor.ExecuteAgent silently discarding the provider's
+// final assistant message (as it did before this fix), which forced
+// RuntimeHost.Agent to fall back to the raw transcript for both Text and
+// FinalText.
+func TestSchedulerHostAgentExecutorReturnsAssistantMessage(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:             root,
+		SandboxRoot:          filepath.Join(root, "sandboxes"),
+		RuntimeDriver:        driverpkg.RuntimeDriverBoxlite,
+		DefaultImage:         "guest:latest",
+		GuestWorkspacePath:   "/workspace",
+		GuestStateRoot:       "/data/state",
+		GuestHomePath:        "/root",
+		JupyterProxyBasePath: "/agent-compose/session",
+		SandboxStartTimeout:  2 * time.Second,
+		AgentTimeout:         2 * time.Second,
+	}
+	store, err := sandboxstore.NewWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewWithConfig returned error: %v", err)
+	}
+	session, err := store.CreateSandbox(ctx, "scheduler host session", "", driverpkg.RuntimeDriverBoxlite, "guest:latest", "", domain.SandboxTypeManual, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	session.Summary.VMStatus = domain.VMStatusRunning
+	if err := store.UpdateSandbox(ctx, session); err != nil {
+		t.Fatalf("UpdateSession returned error: %v", err)
+	}
+	runner := NewAgentRunner(AgentRunnerDeps{
+		Config:   config,
+		Store:    store,
+		ConfigDB: nil,
+		Agents:   nil,
+		Runtimes: fakeRuntimeProvider{runtime: &fakeAgentRuntime{}},
+	})
+	executor := SchedulerHostAgentExecutor{Executor: NewAgentExecutor(config, store, nil, runner)}
+
+	cell, assistantMessage, err := executor.ExecuteAgent(ctx, session, schedulers.HostAgentExecutionRequest{
+		Provider: "codex",
+		Prompt:   "hello",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteAgent returned error: %v", err)
+	}
+	if assistantMessage != "done" {
+		t.Fatalf("assistantMessage = %q, want the provider's final message %q", assistantMessage, "done")
+	}
+	if assistantMessage == cell.Output {
+		t.Fatalf("assistantMessage must not equal the raw transcript cell.Output (%q)", cell.Output)
+	}
+}

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -660,7 +660,7 @@ func (c *Controller) completeProjectRunAgent(ctx context.Context, sandboxed sand
 			Hub:         c.runLogs,
 		}),
 	})
-	transition := TransitionFromAgentCell(run, sandboxed.Sandbox, cell, execErr)
+	transition := TransitionFromAgentCell(run, sandboxed.Sandbox, cell, assistantEvent.Message, execErr)
 	transition.TerminalEvents = projectAgentTerminalEvents(run, cell, assistantEvent, execErr)
 	if execErr != nil || !cell.Success {
 		run, err = c.completeProjectRunError(sandboxed.TransitionCtx, ctx, transition, execErr)

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -111,11 +111,11 @@ func TestRunsCoordinatorAndHelperWorkflows(t *testing.T) {
 		t.Fatalf("session helpers title=%q tags=%#v", title, tags)
 	}
 	cell := domain.NotebookCell{ID: "cell-1", Type: execution.CellTypeAgent, Agent: "codex", AgentThreadID: "agent-thread", Output: "output", Success: false, ExitCode: 0, Stderr: "stderr"}
-	transition := TransitionFromAgentCell(run, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: t.TempDir()}}, cell, nil)
+	transition := TransitionFromAgentCell(run, &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-1", WorkspacePath: t.TempDir()}}, cell, "", nil)
 	if transition.ExitCode == 0 || !strings.Contains(transition.ErrorStack, "stderr") || transition.ArtifactsDir == "" {
 		t.Fatalf("transition from failed cell = %#v", transition)
 	}
-	transition = TransitionFromAgentCell(run, nil, cell, errors.New("boom"))
+	transition = TransitionFromAgentCell(run, nil, cell, "", errors.New("boom"))
 	if transition.ExitCode == 0 || !strings.Contains(transition.ErrorStack, "boom") {
 		t.Fatalf("transition from exec error = %#v", transition)
 	}

--- a/pkg/runs/execution.go
+++ b/pkg/runs/execution.go
@@ -10,7 +10,13 @@ import (
 	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
 )
 
-func TransitionFromAgentCell(run domain.ProjectRunRecord, sandbox *domain.Sandbox, cell domain.NotebookCell, execErr error) TransitionRequest {
+// TransitionFromAgentCell builds the completion transition for a finished
+// agent cell. assistantMessage is the provider's final assistant message
+// (from ExecuteAgentRequest's assistant event), "" when the provider gave no
+// message distinct from the transcript; it rides along in ResultJSON so
+// AgentResultFromProjectRun can recover it later without access to the
+// project run's event stream.
+func TransitionFromAgentCell(run domain.ProjectRunRecord, sandbox *domain.Sandbox, cell domain.NotebookCell, assistantMessage string, execErr error) TransitionRequest {
 	req := TransitionRequest{
 		RunID:    run.RunID,
 		ExitCode: cell.ExitCode,
@@ -32,6 +38,7 @@ func TransitionFromAgentCell(run domain.ProjectRunRecord, sandbox *domain.Sandbo
 		"stopReason":    cell.StopReason,
 		"success":       cell.Success,
 		"exitCode":      cell.ExitCode,
+		"finalText":     assistantMessage,
 	})
 	if err == nil {
 		req.ResultJSON = string(resultJSON)

--- a/pkg/runs/execution_test.go
+++ b/pkg/runs/execution_test.go
@@ -1,0 +1,28 @@
+package runs
+
+import (
+	"encoding/json"
+	"testing"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+func TestTransitionFromAgentCellRecordsFinalTextMetadata(t *testing.T) {
+	run := domain.ProjectRunRecord{RunID: "run-final-text"}
+	cell := domain.NotebookCell{ID: "cell-1", Output: "thinking...\ncat SKILL.md\n{...}", Success: true}
+
+	transition := TransitionFromAgentCell(run, nil, cell, "here is the answer", nil)
+
+	var metadata struct {
+		FinalText string `json:"finalText"`
+	}
+	if err := json.Unmarshal([]byte(transition.ResultJSON), &metadata); err != nil {
+		t.Fatalf("unmarshal ResultJSON: %v", err)
+	}
+	if metadata.FinalText != "here is the answer" {
+		t.Fatalf("ResultJSON finalText = %q, want the assistant message", metadata.FinalText)
+	}
+	if transition.Output != cell.Output {
+		t.Fatalf("Output = %q, want the untouched transcript %q", transition.Output, cell.Output)
+	}
+}

--- a/pkg/schedulers/project_run_result.go
+++ b/pkg/schedulers/project_run_result.go
@@ -11,16 +11,18 @@ type ProjectRunResultFields struct {
 	Agent         string `json:"agent"`
 	AgentThreadID string `json:"agentThreadId"`
 	StopReason    string `json:"stopReason"`
+	FinalText     string `json:"finalText"`
 }
 
 func AgentResultFromProjectRun(run domain.ProjectRunRecord, outputSchemaJSON string) (domain.SchedulerAgentResult, error) {
 	metadata := ProjectRunResultMetadata(run.ResultJSON)
-	text := firstNonEmpty(run.Output, run.Error)
+	finalText := firstNonEmpty(metadata.FinalText, run.Output)
+	text := firstNonEmpty(finalText, run.Error)
 	jsonValue, jsonErr := JSONResult(text, outputSchemaJSON, "project run output")
 	return domain.SchedulerAgentResult{
 		Text:          text,
 		Output:        run.Output,
-		FinalText:     run.Output,
+		FinalText:     finalText,
 		JSON:          jsonValue,
 		SandboxID:     run.SandboxID,
 		CellID:        metadata.CellID,

--- a/pkg/schedulers/project_run_result.go
+++ b/pkg/schedulers/project_run_result.go
@@ -16,7 +16,15 @@ type ProjectRunResultFields struct {
 
 func AgentResultFromProjectRun(run domain.ProjectRunRecord, outputSchemaJSON string) (domain.SchedulerAgentResult, error) {
 	metadata := ProjectRunResultMetadata(run.ResultJSON)
-	finalText := firstNonEmpty(metadata.FinalText, run.Output)
+	succeeded := run.Status == domain.ProjectRunStatusSucceeded
+	// metadata.FinalText may hold a synthesized failure summary (see
+	// agentAssistantMessage) rather than provider text; trust it only once
+	// the run actually succeeded, or a failed run's real transcript/error
+	// gets displaced by that placeholder.
+	finalText := run.Output
+	if succeeded {
+		finalText = firstNonEmpty(metadata.FinalText, run.Output)
+	}
 	text := firstNonEmpty(finalText, run.Error)
 	jsonValue, jsonErr := JSONResult(text, outputSchemaJSON, "project run output")
 	return domain.SchedulerAgentResult{
@@ -29,7 +37,7 @@ func AgentResultFromProjectRun(run domain.ProjectRunRecord, outputSchemaJSON str
 		Agent:         firstNonEmpty(metadata.Agent, run.AgentName),
 		AgentThreadID: metadata.AgentThreadID,
 		StopReason:    metadata.StopReason,
-		Success:       run.Status == domain.ProjectRunStatusSucceeded,
+		Success:       succeeded,
 		ExitCode:      run.ExitCode,
 	}, jsonErr
 }

--- a/pkg/schedulers/project_run_result_test.go
+++ b/pkg/schedulers/project_run_result_test.go
@@ -45,6 +45,25 @@ func TestAgentResultFromProjectRunFallsBackToOutputWithoutFinalTextMetadata(t *t
 	}
 }
 
+func TestAgentResultFromProjectRunIgnoresFinalTextMetadataOnFailure(t *testing.T) {
+	// A failed run's ResultJSON.finalText may hold a synthesized failure
+	// summary (see agentAssistantMessage), not provider text. It must not
+	// displace run.Output, which carries the real failure diagnostics.
+	run := domain.ProjectRunRecord{
+		RunID:      "project-run-4",
+		Status:     domain.ProjectRunStatusFailed,
+		Output:     "tool call failed: ENOENT /workspace/build.sh\nstack: ...",
+		ResultJSON: `{"cellId":"cell-4","finalText":"codex run failed: exit status 1"}`,
+	}
+	result, err := AgentResultFromProjectRun(run, "")
+	if err != nil {
+		t.Fatalf("AgentResultFromProjectRun returned error: %v", err)
+	}
+	if result.FinalText != run.Output || result.Text != run.Output {
+		t.Fatalf("FinalText/Text = %q/%q, want the real transcript %q, not the synthesized failure summary", result.FinalText, result.Text, run.Output)
+	}
+}
+
 func TestAgentResultFromProjectRunFallsBackToErrorWhenEmpty(t *testing.T) {
 	run := domain.ProjectRunRecord{
 		RunID:  "project-run-3",

--- a/pkg/schedulers/project_run_result_test.go
+++ b/pkg/schedulers/project_run_result_test.go
@@ -1,0 +1,64 @@
+package schedulers
+
+import (
+	"testing"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+func TestAgentResultFromProjectRunPrefersFinalTextMetadataOverOutput(t *testing.T) {
+	run := domain.ProjectRunRecord{
+		RunID:      "project-run-1",
+		AgentName:  "reviewer",
+		Status:     domain.ProjectRunStatusSucceeded,
+		Output:     "thinking...\ncat SKILL.md\n{...}",
+		ResultJSON: `{"cellId":"cell-1","agent":"codex","finalText":"here is the answer"}`,
+	}
+	result, err := AgentResultFromProjectRun(run, "")
+	if err != nil {
+		t.Fatalf("AgentResultFromProjectRun returned error: %v", err)
+	}
+	if result.FinalText != "here is the answer" || result.Text != "here is the answer" {
+		t.Fatalf("FinalText/Text = %q/%q, want the recorded assistant message", result.FinalText, result.Text)
+	}
+	if result.Output != run.Output {
+		t.Fatalf("Output = %q, want the untouched transcript %q", result.Output, run.Output)
+	}
+	if result.FinalText == result.Output {
+		t.Fatalf("FinalText must not equal the transcript Output when finalText metadata exists")
+	}
+}
+
+func TestAgentResultFromProjectRunFallsBackToOutputWithoutFinalTextMetadata(t *testing.T) {
+	run := domain.ProjectRunRecord{
+		RunID:      "project-run-2",
+		Status:     domain.ProjectRunStatusSucceeded,
+		Output:     "plain transcript",
+		ResultJSON: `{"cellId":"cell-2"}`,
+	}
+	result, err := AgentResultFromProjectRun(run, "")
+	if err != nil {
+		t.Fatalf("AgentResultFromProjectRun returned error: %v", err)
+	}
+	if result.FinalText != "plain transcript" || result.Output != "plain transcript" {
+		t.Fatalf("FinalText/Output = %q/%q, want both to fall back to the transcript", result.FinalText, result.Output)
+	}
+}
+
+func TestAgentResultFromProjectRunFallsBackToErrorWhenEmpty(t *testing.T) {
+	run := domain.ProjectRunRecord{
+		RunID:  "project-run-3",
+		Status: domain.ProjectRunStatusFailed,
+		Error:  "sandbox start failed",
+	}
+	result, err := AgentResultFromProjectRun(run, "")
+	if err != nil {
+		t.Fatalf("AgentResultFromProjectRun returned error: %v", err)
+	}
+	if result.Text != "sandbox start failed" {
+		t.Fatalf("Text = %q, want the run error", result.Text)
+	}
+	if result.FinalText != "" {
+		t.Fatalf("FinalText = %q, want empty when there is no output or finalText metadata", result.FinalText)
+	}
+}

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -46,8 +46,11 @@ type HostAgentExecutionRequest struct {
 	OutputSchemaJSON  string
 }
 
+// ExecuteAgent returns the cell (full transcript) plus the provider's final
+// assistant message, when the provider emitted one distinct from the
+// transcript; the message is "" when no such message exists.
 type HostAgentExecutor interface {
-	ExecuteAgent(ctx context.Context, session *domain.Sandbox, request HostAgentExecutionRequest) (domain.NotebookCell, error)
+	ExecuteAgent(ctx context.Context, session *domain.Sandbox, request HostAgentExecutionRequest) (domain.NotebookCell, string, error)
 }
 
 type HostCommandExecutor interface {
@@ -261,7 +264,7 @@ func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.S
 		agentConfig.Provider = "codex"
 	}
 
-	cell, execErr := h.deps.AgentExecutor.ExecuteAgent(ctx, session, HostAgentExecutionRequest{
+	cell, assistantMessage, execErr := h.deps.AgentExecutor.ExecuteAgent(ctx, session, HostAgentExecutionRequest{
 		Provider:          agentConfig.Provider,
 		AgentDefinitionID: agentDefinitionID,
 		Model:             agentConfig.Model,
@@ -270,7 +273,7 @@ func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.S
 		Timeout:           request.Timeout,
 		OutputSchemaJSON:  request.OutputSchema,
 	})
-	finalText := firstHostNonEmpty(cell.Output, cell.Stdout, cell.Stderr)
+	finalText := firstHostNonEmpty(assistantMessage, cell.Output, cell.Stdout, cell.Stderr)
 	jsonValue, jsonErr := JSONResult(finalText, request.OutputSchema, "agent finalText")
 	if jsonErr != nil && execErr == nil {
 		execErr = jsonErr

--- a/pkg/schedulers/run_host.go
+++ b/pkg/schedulers/run_host.go
@@ -48,7 +48,10 @@ type HostAgentExecutionRequest struct {
 
 // ExecuteAgent returns the cell (full transcript) plus the provider's final
 // assistant message, when the provider emitted one distinct from the
-// transcript; the message is "" when no such message exists.
+// transcript; the message is "" when no such message exists. On a failed
+// run the message may instead be a synthesized failure summary (not
+// provider text) — callers must check cell.Success before preferring it
+// over the transcript.
 type HostAgentExecutor interface {
 	ExecuteAgent(ctx context.Context, session *domain.Sandbox, request HostAgentExecutionRequest) (domain.NotebookCell, string, error)
 }
@@ -273,6 +276,13 @@ func (h *RuntimeHost) Agent(ctx context.Context, prompt string, request domain.S
 		Timeout:           request.Timeout,
 		OutputSchemaJSON:  request.OutputSchema,
 	})
+	if execErr != nil || !cell.Success {
+		// assistantMessage may be a synthesized failure summary (see
+		// agentAssistantMessage), not provider text; trust it only on
+		// success, or a failed run's real transcript gets displaced by
+		// that placeholder.
+		assistantMessage = ""
+	}
 	finalText := firstHostNonEmpty(assistantMessage, cell.Output, cell.Stdout, cell.Stderr)
 	jsonValue, jsonErr := JSONResult(finalText, request.OutputSchema, "agent finalText")
 	if jsonErr != nil && execErr == nil {

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -121,6 +121,57 @@ func TestRuntimeHostAgentCommandLLMAndSessionRPC(t *testing.T) {
 	}
 }
 
+func TestRuntimeHostAgentPrefersAssistantMessageOverTranscript(t *testing.T) {
+	ctx := context.Background()
+	scheduler := domain.Scheduler{
+		Summary: domain.SchedulerSummary{ID: "scheduler-final-text", Runtime: domain.SchedulerRuntimeScheduler, DefaultAgent: "codex"},
+	}
+	run := &domain.SchedulerRunSummary{ID: "run-final-text", SchedulerID: scheduler.Summary.ID, TriggerID: "trigger-final-text"}
+	newHost := func(agentExecutor *hostAgentExecutorFake) *schedulers.RuntimeHost {
+		return schedulers.NewRuntimeHost(schedulers.RunHostDependencies{
+			Store:            &hostStoreFake{},
+			Events:           &hostEventsFake{},
+			Sessions:         &hostSessionsFake{session: &domain.Sandbox{Summary: domain.SandboxSummary{ID: "session-final-text", VMStatus: domain.VMStatusRunning}}},
+			AgentDefinitions: hostAgentDefinitionsFake{},
+			AgentExecutor:    agentExecutor,
+			Publisher:        &hostPublisherFake{},
+		}, scheduler, triggerExecution(run), schedulers.TriggerEventMetadata{EventID: "topic-event"})
+	}
+
+	// A provider that emits a distinct final assistant message: Text/FinalText
+	// must carry that message, not the raw transcript in cell.Output.
+	withMessage := &hostAgentExecutorFake{
+		cell:          domain.NotebookCell{ID: "cell-1", Output: "thinking...\ncat SKILL.md\n{...}", Success: true},
+		assistantText: "here is the answer",
+	}
+	result, err := newHost(withMessage).Agent(ctx, "prompt", domain.SchedulerAgentRequest{})
+	if err != nil {
+		t.Fatalf("Agent returned error: %v", err)
+	}
+	if result.FinalText != "here is the answer" || result.Text != "here is the answer" {
+		t.Fatalf("FinalText/Text = %q/%q, want the assistant message", result.FinalText, result.Text)
+	}
+	if result.Output != withMessage.cell.Output {
+		t.Fatalf("Output = %q, want the untouched transcript %q", result.Output, withMessage.cell.Output)
+	}
+	if result.FinalText == result.Output {
+		t.Fatalf("FinalText must not equal the transcript Output when a distinct assistant message exists")
+	}
+
+	// No distinct assistant message (e.g. transcript-fallback source): FinalText
+	// keeps falling back to the transcript, same as before this fix.
+	withoutMessage := &hostAgentExecutorFake{
+		cell: domain.NotebookCell{ID: "cell-2", Output: "plain transcript", Success: true},
+	}
+	result, err = newHost(withoutMessage).Agent(ctx, "prompt", domain.SchedulerAgentRequest{})
+	if err != nil {
+		t.Fatalf("Agent returned error: %v", err)
+	}
+	if result.FinalText != "plain transcript" || result.Output != "plain transcript" {
+		t.Fatalf("FinalText/Output = %q/%q, want both to fall back to the transcript", result.FinalText, result.Output)
+	}
+}
+
 func TestRuntimeHostLLMModelPriorityAndEnvironmentPropagation(t *testing.T) {
 	for _, test := range []struct {
 		name           string
@@ -730,14 +781,15 @@ func (hostAgentDefinitionsFake) ResolveSchedulerAgentDefinition(context.Context,
 }
 
 type hostAgentExecutorFake struct {
-	request schedulers.HostAgentExecutionRequest
-	cell    domain.NotebookCell
-	err     error
+	request       schedulers.HostAgentExecutionRequest
+	cell          domain.NotebookCell
+	assistantText string
+	err           error
 }
 
-func (e *hostAgentExecutorFake) ExecuteAgent(_ context.Context, _ *domain.Sandbox, request schedulers.HostAgentExecutionRequest) (domain.NotebookCell, error) {
+func (e *hostAgentExecutorFake) ExecuteAgent(_ context.Context, _ *domain.Sandbox, request schedulers.HostAgentExecutionRequest) (domain.NotebookCell, string, error) {
 	e.request = request
-	return e.cell, e.err
+	return e.cell, e.assistantText, e.err
 }
 
 type hostCommandExecutorFake struct {

--- a/pkg/schedulers/run_host_test.go
+++ b/pkg/schedulers/run_host_test.go
@@ -170,6 +170,22 @@ func TestRuntimeHostAgentPrefersAssistantMessageOverTranscript(t *testing.T) {
 	if result.FinalText != "plain transcript" || result.Output != "plain transcript" {
 		t.Fatalf("FinalText/Output = %q/%q, want both to fall back to the transcript", result.FinalText, result.Output)
 	}
+
+	// On a failed run, agentAssistantMessage synthesizes a placeholder like
+	// "<agent> failed without output" instead of returning "" — that must
+	// not displace the real transcript, which carries the actual failure
+	// diagnostics.
+	failed := &hostAgentExecutorFake{
+		cell:          domain.NotebookCell{ID: "cell-3", Output: "tool call failed: ENOENT /workspace/build.sh\nstack: ...", Success: false},
+		assistantText: "codex failed without output",
+	}
+	result, err = newHost(failed).Agent(ctx, "prompt", domain.SchedulerAgentRequest{})
+	if err != nil {
+		t.Fatalf("Agent returned error: %v", err)
+	}
+	if result.FinalText != failed.cell.Output || result.Text != failed.cell.Output {
+		t.Fatalf("FinalText/Text = %q/%q, want the real transcript %q, not the synthesized failure summary", result.FinalText, result.Text, failed.cell.Output)
+	}
 }
 
 func TestRuntimeHostLLMModelPriorityAndEnvironmentPropagation(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes #663: `scheduler.agent()` always set `text`/`finalText`/`output` to the same transcript string, so a script preferring `reply.finalText` got the raw process output (thinking, tool calls, JSON) instead of the provider's final message.
- `SchedulerHostAgentExecutor.ExecuteAgent` was discarding `ExecuteAgentRequest`'s assistant-message return value (`_, _`), leaving `RuntimeHost.Agent` (the bare-sandbox `scheduler.agent()` path) nothing but `cell.Output` to fall back on.
- Same bug, second occurrence: `AgentResultFromProjectRun` (used when the scheduler is bound to a managed project agent) only receives a `domain.ProjectRunRecord`, which never carried the assistant message at all — it echoed `run.Output` into `FinalText` too. Threaded the assistant message through `TransitionFromAgentCell`'s `ResultJSON` so this path can recover it.
- Both fixes keep `Output` untouched (still the full transcript) and only change what `Text`/`FinalText` resolve to.

## Test plan
- [x] `go test ./pkg/schedulers/... ./pkg/agentcompose/adapters/... ./pkg/runs/...` — new regression tests added:
  - `TestRuntimeHostAgentPrefersAssistantMessageOverTranscript`
  - `TestSchedulerHostAgentExecutorReturnsAssistantMessage`
  - `TestAgentResultFromProjectRunPrefersFinalTextMetadataOverOutput` / `...FallsBackToOutputWithoutFinalTextMetadata` / `...FallsBackToErrorWhenEmpty`
  - `TestTransitionFromAgentCellRecordsFinalTextMetadata`
- [x] Verified against a real running daemon (real Docker sandboxes, real LLM call via `chaitin/agent-compose-guest:latest` + configured `LLM_API_*`), exercising both `scheduler.agent()` paths through a manually-triggered scheduler script:
  - bare path (`RuntimeHost.Agent`): `reply.finalText` == `reply.text` == the clean provider answer, `reply.output` carries the raw transcript, `finalText !== output`.
  - project-agent path (`RuntimeHost.ProjectAgent` → `AgentResultFromProjectRun`): same result, and confirmed the new `finalText` field is actually persisted in the `project_run.result_json` DB column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QK1vvtPw374pVzpN8pG6AJ