### PR TITLE
fix(webhooks): /stop should also cascade to correlated events

### DIFF
--- a/docs/design/webhook_design.md
+++ b/docs/design/webhook_design.md
@@ -549,6 +549,24 @@ main implementation path for a formal API:
 - Therefore `GET /api/events/:event_id/sandboxes` should not rely on full-table
   JSON scan as the main implementation.
 
+The exact-relation restriction above governs exact attribution in
+relation-oriented read models. It does not define the cancellation scope of
+`POST /api/webhooks/events/:event_id/stop`. That endpoint deliberately treats
+the requested event's `correlation_id` as a group-wide cancellation domain and
+cancels the union of:
+
+- the requested event and its descendants found through `parent_event_id`; and
+- every stored event that shares the requested event's `correlation_id`.
+
+The correlation group has no causal direction, so this cancellation scope can
+include earlier, later, and sibling events, including events submitted through
+different webhook sources. The endpoint authenticates the static token and
+enabled state of the requested event's webhook source only; it does not
+separately authenticate or require an enabled source for every correlated
+event. This is an explicit control-plane policy, not a claim that
+`correlation_id` establishes an exact causal relation, and it must not be reused
+as exact attribution by relation-oriented APIs.
+
 Formal implementation needs explicit relation tables. Event-to-run relation is
 stored in `event_delivery`; event-to-sandbox relation is stored in
 `event_sandbox_link`:
@@ -576,9 +594,11 @@ Write timing:
   `event_delivery(event_id, scheduler_id, trigger_id, scheduler_run_id, status=run_started)`.
 - When the scheduler run host sees `linked_sandbox_id`, also write
   `event_id -> sandbox_id`.
-- When a scheduler derives events, write `parent_event_id`. Query
-  `GET /api/events/:event_id/sandboxes` should expand descendant events by
-  `parent_event_id`, then aggregate `event_sandbox_link` for those events.
+- When a scheduler derives events, write `parent_event_id`. For exact sandbox
+  attribution, `GET /api/events/:event_id/sandboxes` should expand descendant
+  events by `parent_event_id`, then aggregate `event_sandbox_link` for those
+  events. This causal expansion rule does not limit the correlation-wide
+  cancellation scope defined above.
 - If business wants the original webhook event to find sandboxes created by
   derived events, query layer expands descendants; descendants do not need to
   write duplicate ancestor links.

--- a/docs/pages/command-line-manual.md
+++ b/docs/pages/command-line-manual.md
@@ -127,7 +127,11 @@ authentication is enabled.
 #### Stopping webhook-triggered runs
 
 The client that submitted a webhook can later request cancellation of every
-active run associated with that event and its descendant events:
+active run associated with that event, its descendant events, and every event
+that shares the requested event's `correlation_id`. Correlation scope is
+group-wide rather than descendant-only: it includes earlier, later, and sibling
+events, even when those correlated events were submitted through different
+webhook sources.
 
 ```http
 POST /api/webhooks/events/<event-id>/stop
@@ -138,18 +142,20 @@ Content-Type: application/json
 ```
 
 The JSON body is optional. The endpoint authenticates only with the static
-token configured on the event's webhook source, using that source's custom
-token header when one is configured. A GitHub request signature proves the
-authenticity of one delivery; it is not a reusable control credential.
-Consequently, signed and unsigned GitHub sources without a static source token
-can receive events but cannot use this stop endpoint. Configure a separate
-source token when those events must be stoppable; do not reuse the GitHub
-signature secret as the token.
+token configured on the requested event's webhook source, using that source's
+custom token header when one is configured. It does not separately authenticate
+the sources of descendant or correlated events included in the cancellation.
+A GitHub request signature proves the authenticity of one delivery; it is not
+a reusable control credential. Consequently, signed and unsigned GitHub
+sources without a static source token can receive events but cannot use this
+stop endpoint. Configure a separate source token when those events must be
+stoppable; do not reuse the GitHub signature secret as the token.
 
-The request covers both the runs an event already started and the deliveries it
-has not started yet. Events still waiting in the dispatch queue are withdrawn so
-they never start a run, and `canceled_events` counts them. Active runs receive
-an asynchronous cancellation request counted by `requested_runs`.
+For every descendant or correlated event in scope, the request covers both runs
+already started and deliveries not started yet. Events still waiting in the
+dispatch queue are withdrawn so they never start a run, and `canceled_events`
+counts them. Active runs receive an asynchronous cancellation request counted
+by `requested_runs`.
 
 ```json
 {"event_id":"evt_123","stop_requested":true,"requested_runs":2,"pending_runs":0,
@@ -188,14 +194,14 @@ need confirmation must poll `GetSchedulerRun` for known run IDs or
 affected runs report a terminal `succeeded`, `failed`, `canceled`, or `skipped`
 status.
 
-The daemon evaluates at most 1,000 events in one event tree. If the tree is
-larger, it returns `409` with `max_event_count` before stopping any run, rather
-than silently processing a truncated tree. If an individual stop operation
-fails, the daemon still attempts the remaining runs and returns `500` with the
-successful `requested_runs` count plus `failed_runs` and `failed_run_ids`.
-Retrying the whole event is safe and retries only runs that remain active.
-Missing or invalid tokens return `401`; a non-webhook event returns `403`; and
-an unknown event returns `404`.
+The daemon evaluates at most 1,000 distinct events across the descendant tree
+and correlation group. If the combined scope is larger, it returns `409` with
+`max_event_count` before stopping any run, rather than silently processing a
+truncated set. If an individual stop operation fails, the daemon still attempts
+the remaining runs and returns `500` with the successful `requested_runs` count
+plus `failed_runs` and `failed_run_ids`. Retrying the whole event is safe and
+retries only runs that remain active. Missing or invalid tokens return `401`; a
+non-webhook event returns `403`; and an unknown event returns `404`.
 
 ### Project environment files
 

--- a/docs/pages/zh-CN/command-line-manual.md
+++ b/docs/pages/zh-CN/command-line-manual.md
@@ -115,7 +115,10 @@ topic，以及 Bearer、`X-WEBHOOK-TOKEN` 或自定义 header token。
 
 #### 停止 Webhook 事件触发的运行
 
-提交 webhook 的客户端可以在之后请求取消该事件及其后代事件关联的全部活跃 run：
+提交 webhook 的客户端可以在之后请求取消该事件、其后代事件，以及与该请求事件共享
+`correlation_id` 的全部事件所关联的活跃 run。`correlation_id` 的停止范围是整个关联
+组，而不只是因果后代：同组中更早、更晚和同级的事件都会纳入，即使它们由不同的
+webhook source 提交。
 
 ```http
 POST /api/webhooks/events/<event-id>/stop
@@ -125,16 +128,18 @@ Content-Type: application/json
 {"reason":"business canceled"}
 ```
 
-JSON 请求体可以省略。该 endpoint 只接受事件所属 webhook source 配置的静态
-token；source 配置了自定义 token header 时也沿用该 header。GitHub 请求签名只能
+JSON 请求体可以省略。该 endpoint 只接受请求事件所属 webhook source 配置的静态
+token；source 配置了自定义 token header 时也沿用该 header。停止范围内的后代或
+关联事件即使属于其他 source，也不会再分别校验其 source token。GitHub 请求签名只能
 证明单次 delivery 的真实性，不是可复用的控制凭据。因此，没有配置静态 source
 token 的 signed 或 unsigned GitHub source 可以接收事件，但不能调用此停止
 endpoint。若这些事件需要支持停止，应另外配置 source token，不能把 GitHub
 signature secret 当作 token 使用。
 
-该请求同时覆盖事件已经启动的 run 和尚未启动的投递。仍在投递队列中等待的事件会被
-撤回，不会再启动 run，数量记在 `canceled_events`；已经活跃的 run 会收到异步取消
-请求，数量记在 `requested_runs`。
+对于停止范围内的每个后代或关联事件，该请求同时覆盖已经启动的 run 和尚未启动的
+投递。仍在投递队列中等待的事件会被撤回，不会再启动 run，数量记在
+`canceled_events`；已经活跃的 run 会收到异步取消请求，数量记在
+`requested_runs`。
 
 ```json
 {"event_id":"evt_123","stop_requested":true,"requested_runs":2,"pending_runs":0,
@@ -164,12 +169,13 @@ run ID 轮询 `GetSchedulerRun`，或轮询 `ListSchedulerRuns`（CLI 命令
 `agent-compose scheduler runs`），直到受影响的 run 报告终态 `succeeded`、`failed`、
 `canceled` 或 `skipped`。
 
-daemon 单次最多处理同一事件树中的 1,000 个事件。事件树更大时，会在停止任何 run
-之前返回 `409` 和 `max_event_count`，不会把被截断的结果当作成功。如果个别停止操作
-失败，daemon 仍会继续处理其余 run，并返回 `500`；响应中的 `requested_runs`
-记录成功请求取消的数量，`failed_runs` 和 `failed_run_ids` 记录失败项。重新对整个
-事件发起请求是安全的，只会重试仍然活跃的 run。Token 缺失或无效时返回 `401`，
-非 webhook 事件返回 `403`，事件不存在时返回 `404`。
+daemon 单次最多处理后代事件树和 correlation group 合并后的 1,000 个不同事件。合并
+范围更大时，会在停止任何 run 之前返回 `409` 和 `max_event_count`，不会把被截断的
+结果当作成功。如果个别停止操作失败，daemon 仍会继续处理其余 run，并返回 `500`；
+响应中的 `requested_runs` 记录成功请求取消的数量，`failed_runs` 和
+`failed_run_ids` 记录失败项。重新对整个事件发起请求是安全的，只会重试仍然活跃的
+run。Token 缺失或无效时返回 `401`，非 webhook 事件返回 `403`，事件不存在时返回
+`404`。
 
 ### Project 环境文件
 

--- a/pkg/agentcompose/app/webhook_stop_integration_test.go
+++ b/pkg/agentcompose/app/webhook_stop_integration_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -170,32 +171,36 @@ func TestIntegrationWebhookStopCancelsDispatchedSchedulerRun(t *testing.T) {
 
 func seedWebhookStopScheduler(t *testing.T, ctx context.Context, store *configstore.ConfigStore) domain.Scheduler {
 	t.Helper()
-	const (
-		projectID   = "webhook-stop-project"
-		agentName   = "worker"
-		agentID     = "webhook-stop-agent"
-		schedulerID = "webhook-stop-scheduler"
-	)
+	return seedWebhookStopSchedulerNamed(t, ctx, store, "webhook-stop-project", "webhook-stop-agent", "webhook-stop-scheduler", "webhook.stop.run")
+}
+
+// seedWebhookStopSchedulerNamed seeds one project/agent/scheduler that fires
+// on the given topic. Tests that need more than one independently-triggered
+// scheduler (e.g. to reproduce two events published by different webhook
+// sources) call this with distinct IDs and topics.
+func seedWebhookStopSchedulerNamed(t *testing.T, ctx context.Context, store *configstore.ConfigStore, projectID, agentID, schedulerID, topic string) domain.Scheduler {
+	t.Helper()
+	const agentName = "worker"
 	specJSON, err := (&compose.NormalizedProjectSpec{
-		Name: "webhook-stop-project",
+		Name: projectID,
 		Agents: []compose.NormalizedAgentSpec{{
 			Name: agentName, Enabled: true,
 			Scheduler: &compose.NormalizedSchedulerSpec{
 				Enabled: true, SandboxPolicy: domain.SchedulerSandboxPolicyNew,
 				ConcurrencyPolicy: domain.SchedulerConcurrencyPolicyParallel,
-				Script:            "scheduler.on('webhook.stop.run', async function () {});",
+				Script:            fmt.Sprintf("scheduler.on(%q, async function () {});", topic),
 			},
 		}},
 	}).MarshalCanonicalJSON(false)
 	if err != nil {
 		t.Fatalf("marshal project spec: %v", err)
 	}
-	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: projectID, Name: "webhook-stop-project"})
+	project, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: projectID, Name: projectID})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 	revision, _, err := store.SaveProjectRevision(ctx, domain.ProjectRevisionRecord{
-		ProjectID: project.ID, SpecHash: "webhook-stop-spec", SpecJSON: string(specJSON),
+		ProjectID: project.ID, SpecHash: schedulerID + "-spec", SpecJSON: string(specJSON),
 	})
 	if err != nil {
 		t.Fatalf("create project revision: %v", err)
@@ -213,8 +218,8 @@ func seedWebhookStopScheduler(t *testing.T, ctx context.Context, store *configst
 		t.Fatalf("create project scheduler: %v", err)
 	}
 	if _, err := store.ReplaceSchedulerTriggers(ctx, schedulerID, []domain.SchedulerTrigger{{
-		ID: "webhook-stop-trigger", Kind: domain.SchedulerTriggerKindEvent,
-		Topic: "webhook.stop.run", Enabled: true,
+		ID: schedulerID + "-trigger", Kind: domain.SchedulerTriggerKindEvent,
+		Topic: topic, Enabled: true,
 	}}); err != nil {
 		t.Fatalf("create scheduler trigger: %v", err)
 	}
@@ -243,4 +248,269 @@ func (e *blockingWebhookSchedulerEngine) Execute(ctx context.Context, _ schedule
 	e.canceledOnce.Do(func() { close(e.canceled) })
 	<-e.release
 	return schedulers.SchedulerExecutionResult{}, ctx.Err()
+}
+
+// multiBlockingWebhookSchedulerEngine is blockingWebhookSchedulerEngine
+// generalized to more than one concurrently-running scheduler: it keys a
+// started/canceled/release lane by the firing trigger's topic, so two
+// schedulers dispatched at once (e.g. by two events sharing a
+// correlation_id but published through different webhook sources) each get
+// their own independent signal instead of racing on one shared channel.
+type multiBlockingWebhookSchedulerEngine struct {
+	mu    sync.Mutex
+	lanes map[string]*webhookSchedulerLane
+}
+
+type webhookSchedulerLane struct {
+	started      chan struct{}
+	canceled     chan struct{}
+	release      chan struct{}
+	startedOnce  sync.Once
+	canceledOnce sync.Once
+}
+
+func newMultiBlockingWebhookSchedulerEngine() *multiBlockingWebhookSchedulerEngine {
+	return &multiBlockingWebhookSchedulerEngine{lanes: map[string]*webhookSchedulerLane{}}
+}
+
+func (e *multiBlockingWebhookSchedulerEngine) lane(key string) *webhookSchedulerLane {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	lane, ok := e.lanes[key]
+	if !ok {
+		lane = &webhookSchedulerLane{started: make(chan struct{}), canceled: make(chan struct{}), release: make(chan struct{})}
+		e.lanes[key] = lane
+	}
+	return lane
+}
+
+func (*multiBlockingWebhookSchedulerEngine) Validate(context.Context, string, string) (schedulers.SchedulerValidationResult, error) {
+	return schedulers.SchedulerValidationResult{}, nil
+}
+
+func (e *multiBlockingWebhookSchedulerEngine) Execute(ctx context.Context, request schedulers.SchedulerExecutionRequest, _ schedulers.SchedulerHost) (schedulers.SchedulerExecutionResult, error) {
+	key := ""
+	if request.Trigger != nil {
+		key = request.Trigger.Topic
+	}
+	lane := e.lane(key)
+	lane.startedOnce.Do(func() { close(lane.started) })
+	<-ctx.Done()
+	lane.canceledOnce.Do(func() { close(lane.canceled) })
+	<-lane.release
+	return schedulers.SchedulerExecutionResult{}, ctx.Err()
+}
+
+func (e *multiBlockingWebhookSchedulerEngine) waitStarted(t *testing.T, topic string) {
+	t.Helper()
+	select {
+	case <-e.lane(topic).started:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for scheduler run on topic %q to start", topic)
+	}
+}
+
+func (e *multiBlockingWebhookSchedulerEngine) waitCanceled(t *testing.T, topic string) {
+	t.Helper()
+	select {
+	case <-e.lane(topic).canceled:
+	case <-time.After(time.Second):
+		t.Fatalf("scheduler run on topic %q did not receive cancellation", topic)
+	}
+}
+
+func (e *multiBlockingWebhookSchedulerEngine) releaseAll() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, lane := range e.lanes {
+		select {
+		case <-lane.release:
+		default:
+			close(lane.release)
+		}
+	}
+}
+
+// TestIntegrationWebhookStopCascadesToCorrelatedEventAcrossSources reproduces
+// the real production shape reported in the field: a "router" webhook event
+// (source A) finishes and, in a separate HTTP call, publishes a follow-up
+// webhook event (source B) that never sets parent_event_id on itself — only
+// a shared correlation_id links the two. Calling /stop on the router event
+// with only source A's token must still reach source B's dispatched run.
+func TestIntegrationWebhookStopCascadesToCorrelatedEventAcrossSources(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	root := t.TempDir()
+	config := &appconfig.Config{
+		DataRoot:    root,
+		SandboxRoot: filepath.Join(root, "sandboxes"),
+		DbAddr:      filepath.Join(root, "data.db"),
+		DbTimeout:   time.Second,
+	}
+	database, err := sqlite.Open(config.DbAddr, config.DbTimeout)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+	store := configstore.FromDB(database.DB())
+	sandboxStore, err := sandboxstore.NewWithDatabase(config, database.DB())
+	if err != nil {
+		t.Fatalf("open sandbox store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sandboxStore.Close(); err != nil {
+			t.Errorf("close sandbox store: %v", err)
+		}
+	})
+
+	const routerTopic = "webhook.router.task"
+	const workerTopic = "webhook.worker.task"
+	routerScheduler := seedWebhookStopSchedulerNamed(t, ctx, store, "router-project", "router-agent", "router-scheduler", routerTopic)
+	workerScheduler := seedWebhookStopSchedulerNamed(t, ctx, store, "worker-project", "worker-agent", "worker-scheduler", workerTopic)
+
+	engine := newMultiBlockingWebhookSchedulerEngine()
+	t.Cleanup(engine.releaseAll)
+	controller := schedulers.NewController(schedulers.ControllerDependencies{
+		RootCtx: ctx,
+		Store:   store,
+		Engine:  engine,
+		HostFactory: func(scheduler domain.Scheduler, execution schedulers.RuntimeExecutionContext, triggerEvent schedulers.TriggerEventMetadata) schedulers.RunHost {
+			return schedulers.NewRuntimeHost(schedulers.RunHostDependencies{}, scheduler, execution, triggerEvent)
+		},
+		Artifacts: schedulers.FSArtifacts{DataRoot: root},
+		Schedulers: map[string]domain.Scheduler{
+			routerScheduler.Summary.ID: routerScheduler,
+			workerScheduler.Summary.ID: workerScheduler,
+		},
+		RunTimeout: func(time.Duration) time.Duration { return time.Minute },
+	})
+
+	const routerToken = "router-token"
+	const workerToken = "worker-token"
+	if _, err := store.UpsertWebhookSource(ctx, domain.WebhookSource{
+		ID: "router-source", Name: "Router source", Enabled: true, Provider: "generic",
+		TopicPrefix: "webhook.router.", TokenHash: webhooks.TokenHash(routerToken),
+	}); err != nil {
+		t.Fatalf("create router webhook source: %v", err)
+	}
+	if _, err := store.UpsertWebhookSource(ctx, domain.WebhookSource{
+		ID: "worker-source", Name: "Worker source", Enabled: true, Provider: "generic",
+		TopicPrefix: "webhook.worker.", TokenHash: webhooks.TokenHash(workerToken),
+	}); err != nil {
+		t.Fatalf("create worker webhook source: %v", err)
+	}
+
+	const sharedCorrelationID = "devboard-task-integration-test"
+	routerEvent, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "router-event", Topic: routerTopic, Source: domain.TopicEventSourceWebhook,
+		CorrelationID: sharedCorrelationID, PayloadJSON: `{"webhookSourceId":"router-source"}`,
+		DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create router event: %v", err)
+	}
+	// No ParentEventID: this is the "webhook forwarder" pattern — a follow-up
+	// HTTP call into a different topic/source, not an internally-published
+	// child event. Only the shared correlation_id ties it to routerEvent.
+	workerEvent, err := store.CreateEvent(ctx, domain.TopicEventRecord{
+		ID: "worker-event", Topic: workerTopic, Source: domain.TopicEventSourceWebhook,
+		CorrelationID: sharedCorrelationID, PayloadJSON: `{"webhookSourceId":"worker-source"}`,
+		DispatchStatus: domain.TopicEventDispatchPublishedToBus,
+	})
+	if err != nil {
+		t.Fatalf("create worker event: %v", err)
+	}
+
+	app := echo.New()
+	di := do.New()
+	do.ProvideValue(di, app)
+	do.ProvideValue(di, config)
+	do.ProvideValue(di, store)
+	do.ProvideValue(di, sandboxStore)
+	do.ProvideValue(di, controller)
+	registerWebhookRoutes(app, di)
+
+	controller.DispatchEvent(domain.SchedulerTopicEvent{
+		EventID: routerEvent.ID, Topic: routerEvent.Topic, Source: domain.TopicEventSourceWebhook,
+		Payload: map[string]any{"eventId": routerEvent.ID}, CreatedAt: time.Now().UTC(),
+	})
+	controller.DispatchEvent(domain.SchedulerTopicEvent{
+		EventID: workerEvent.ID, Topic: workerEvent.Topic, Source: domain.TopicEventSourceWebhook,
+		Payload: map[string]any{"eventId": workerEvent.ID}, CreatedAt: time.Now().UTC(),
+	})
+	engine.waitStarted(t, routerTopic)
+	engine.waitStarted(t, workerTopic)
+
+	routerDeliveries, err := store.ListEventDeliveries(ctx, []string{routerEvent.ID})
+	if err != nil {
+		t.Fatalf("list router event deliveries: %v", err)
+	}
+	if len(routerDeliveries) != 1 || strings.TrimSpace(routerDeliveries[0].RunID) == "" {
+		t.Fatalf("router event deliveries = %#v", routerDeliveries)
+	}
+	workerDeliveries, err := store.ListEventDeliveries(ctx, []string{workerEvent.ID})
+	if err != nil {
+		t.Fatalf("list worker event deliveries: %v", err)
+	}
+	if len(workerDeliveries) != 1 || strings.TrimSpace(workerDeliveries[0].RunID) == "" {
+		t.Fatalf("worker event deliveries = %#v", workerDeliveries)
+	}
+
+	// Only the router source's token is presented. Before this fix,
+	// ListDescendantEventIDs never found workerEvent (no parent_event_id
+	// link), so its run would be left running.
+	request := httptest.NewRequest(http.MethodPost, "/api/webhooks/events/"+routerEvent.ID+"/stop", strings.NewReader(`{"reason":"integration stop"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+routerToken)
+	recorder := httptest.NewRecorder()
+	responseDone := make(chan struct{})
+	go func() {
+		app.ServeHTTP(recorder, request)
+		close(responseDone)
+	}()
+	select {
+	case <-responseDone:
+	case <-time.After(time.Second):
+		engine.releaseAll()
+		<-responseDone
+		t.Fatal("stop request waited for scheduler execution to reach a terminal state")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stop status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		StopRequested bool `json:"stop_requested"`
+		RequestedRuns int  `json:"requested_runs"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode stop response: %v", err)
+	}
+	if !response.StopRequested || response.RequestedRuns != 2 {
+		t.Fatalf("stop response = %#v, want both the router and the correlated worker run requested", response)
+	}
+
+	engine.waitCanceled(t, routerTopic)
+	engine.waitCanceled(t, workerTopic)
+	engine.releaseAll()
+
+	stopCtx, cancelStop := context.WithTimeout(ctx, time.Second)
+	defer cancelStop()
+	routerRun, _, err := controller.SchedulerRuns().StopSchedulerRun(stopCtx, routerScheduler.Summary.ID, routerDeliveries[0].RunID, "integration stop")
+	if err != nil {
+		t.Fatalf("load stopped router scheduler run: %v", err)
+	}
+	if routerRun.Status != domain.SchedulerRunStatusCanceled || routerRun.Error != "integration stop" {
+		t.Fatalf("stopped router scheduler run = %#v", routerRun)
+	}
+	workerRun, _, err := controller.SchedulerRuns().StopSchedulerRun(stopCtx, workerScheduler.Summary.ID, workerDeliveries[0].RunID, "integration stop")
+	if err != nil {
+		t.Fatalf("load stopped worker scheduler run: %v", err)
+	}
+	if workerRun.Status != domain.SchedulerRunStatusCanceled || workerRun.Error != "integration stop" {
+		t.Fatalf("stopped worker scheduler run = %#v, want it canceled by the correlated stop cascade", workerRun)
+	}
 }

--- a/pkg/events/webhooks/coverage_shape_workflows_test.go
+++ b/pkg/events/webhooks/coverage_shape_workflows_test.go
@@ -391,6 +391,10 @@ func (s *webhookRouteStore) ListDescendantEventIDs(context.Context, string, int)
 	return []string{"event-1"}, nil
 }
 
+func (s *webhookRouteStore) ListCorrelatedEventIDs(context.Context, string, int) ([]string, error) {
+	return []string{"event-1"}, nil
+}
+
 func (s *webhookRouteStore) ListEventSandboxLinks(context.Context, []string) ([]domain.EventSandboxTraceItem, error) {
 	return []domain.EventSandboxTraceItem{{EventID: "event-1", SandboxID: "session-1", Relation: "created"}}, nil
 }

--- a/pkg/events/webhooks/event_stop.go
+++ b/pkg/events/webhooks/event_stop.go
@@ -79,6 +79,11 @@ func (h routeHandler) handleStopEvent(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load event descendants"})
 	}
+	correlatedIDs, err := h.store().ListCorrelatedEventIDs(ctx, eventID, maxStopEventCount+1)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load correlated events"})
+	}
+	eventIDs = mergeEventIDs(eventIDs, correlatedIDs)
 	if len(eventIDs) > maxStopEventCount {
 		return c.JSON(http.StatusConflict, map[string]any{
 			"error":           "event descendant limit exceeded",
@@ -114,6 +119,28 @@ func (h routeHandler) handleStopEvent(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, response)
 	}
 	return c.JSON(http.StatusOK, response)
+}
+
+// mergeEventIDs unions two ID lists, keeping a's order first and appending
+// b's members that a doesn't already contain.
+func mergeEventIDs(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	merged := make([]string, 0, len(a)+len(b))
+	for _, id := range a {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		merged = append(merged, id)
+	}
+	for _, id := range b {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		merged = append(merged, id)
+	}
+	return merged
 }
 
 func stopEventSourceID(payloadJSON string) (string, error) {

--- a/pkg/events/webhooks/event_stop_test.go
+++ b/pkg/events/webhooks/event_stop_test.go
@@ -25,6 +25,7 @@ func TestEventStopHandler(t *testing.T) {
 		body                string
 		bodyLimit           int64
 		eventIDs            []string
+		correlatedIDs       []string
 		deliveries          []domain.EventDelivery
 		stopResults         []bool
 		stopErrs            []error
@@ -183,6 +184,22 @@ func TestEventStopHandler(t *testing.T) {
 			eventIDs: webhookStopEventIDs(maxStopEventCount + 1), deliveries: []domain.EventDelivery{{RunID: "run-1"}},
 			wantStatus: http.StatusConflict, wantDescendantQuery: true,
 		},
+		{
+			name: "correlated event outside the parent chain is stopped too", event: webhookStopEvent("event-1", "github"), token: "token",
+			correlatedIDs: []string{"event-1", "sibling-event"},
+			deliveries:    []domain.EventDelivery{{EventID: "event-1", RunID: "run-1"}, {EventID: "sibling-event", RunID: "run-2"}},
+			stopResults:   []bool{true, true},
+			wantStatus:    http.StatusOK, wantRequested: true, wantRuns: 2, wantStopped: []string{"run-1", "run-2"},
+			wantDescendantQuery: true, wantEventIDs: []string{"event-1", "child-event", "sibling-event"},
+		},
+		{
+			name: "correlated event already in the parent chain is not duplicated", event: webhookStopEvent("event-1", "github"), token: "token",
+			correlatedIDs: []string{"event-1", "child-event"},
+			deliveries:    []domain.EventDelivery{{EventID: "child-event", RunID: "run-1"}},
+			stopResults:   []bool{true},
+			wantStatus:    http.StatusOK, wantRequested: true, wantRuns: 1, wantStopped: []string{"run-1"},
+			wantDescendantQuery: true, wantEventIDs: defaultEventIDs,
+		},
 	}
 
 	for _, tt := range tests {
@@ -201,7 +218,7 @@ func TestEventStopHandler(t *testing.T) {
 				}
 			}
 			store := &webhookStopStore{
-				webhookRouteStore: base, descendantIDs: tt.eventIDs, deliveries: deliveries,
+				webhookRouteStore: base, descendantIDs: tt.eventIDs, correlatedIDs: tt.correlatedIDs, deliveries: deliveries,
 				cancellation: tt.cancellation, cancelErr: tt.cancelErr, deliveryErr: tt.deliveryErr,
 			}
 			stopper := &recordingRunStopper{results: tt.stopResults, errs: tt.stopErrs, store: store}
@@ -224,6 +241,9 @@ func TestEventStopHandler(t *testing.T) {
 			if tt.wantDescendantQuery {
 				if store.gotRootEventID != "event-1" || store.gotDescendantLimit != maxStopEventCount+1 {
 					t.Fatalf("descendant query root=%q limit=%d, want event-1 and %d", store.gotRootEventID, store.gotDescendantLimit, maxStopEventCount+1)
+				}
+				if store.gotCorrelatedLimit != maxStopEventCount+1 {
+					t.Fatalf("correlated query limit=%d, want %d", store.gotCorrelatedLimit, maxStopEventCount+1)
 				}
 			}
 			if !equalStrings(store.gotEventIDs, tt.wantEventIDs) {
@@ -321,12 +341,14 @@ func equalStrings(got, want []string) bool {
 type webhookStopStore struct {
 	*webhookRouteStore
 	descendantIDs       []string
+	correlatedIDs       []string
 	deliveries          []domain.EventDelivery
 	cancellation        domain.EventDispatchCancellation
 	cancelErr           error
 	deliveryErr         error
 	gotRootEventID      string
 	gotDescendantLimit  int
+	gotCorrelatedLimit  int
 	gotEventIDs         []string
 	gotCancelEventIDs   []string
 	gotCancelReason     string
@@ -341,6 +363,17 @@ func (s *webhookStopStore) ListDescendantEventIDs(_ context.Context, rootEventID
 		return []string{"event-1", "child-event"}, nil
 	}
 	return append([]string(nil), s.descendantIDs...), nil
+}
+
+// ListCorrelatedEventIDs defaults to just the root event, matching
+// production's default correlation_id (the event's own ID), so existing
+// tests that don't set correlatedIDs see no change in the merged set.
+func (s *webhookStopStore) ListCorrelatedEventIDs(_ context.Context, rootEventID string, limit int) ([]string, error) {
+	s.gotCorrelatedLimit = limit
+	if s.correlatedIDs == nil {
+		return []string{rootEventID}, nil
+	}
+	return append([]string(nil), s.correlatedIDs...), nil
 }
 
 func (s *webhookStopStore) ListEventDeliveries(_ context.Context, eventIDs []string) ([]domain.EventDelivery, error) {

--- a/pkg/events/webhooks/http.go
+++ b/pkg/events/webhooks/http.go
@@ -23,6 +23,7 @@ type Store interface {
 	GetEvent(context.Context, string) (domain.TopicEventRecord, error)
 	ListEvents(context.Context, domain.TopicEventFilter) ([]domain.TopicEventRecord, int, error)
 	ListDescendantEventIDs(context.Context, string, int) ([]string, error)
+	ListCorrelatedEventIDs(context.Context, string, int) ([]string, error)
 	ListEventSandboxLinks(context.Context, []string) ([]domain.EventSandboxTraceItem, error)
 	ListEventDeliveries(context.Context, []string) ([]domain.EventDelivery, error)
 	CancelEventDispatch(context.Context, []string, string) (domain.EventDispatchCancellation, error)

--- a/pkg/storage/configstore/topic_event_store.go
+++ b/pkg/storage/configstore/topic_event_store.go
@@ -516,6 +516,49 @@ func (s *eventStore) ListDescendantEventIDs(ctx context.Context, rootEventID str
 	return ids, nil
 }
 
+// ListCorrelatedEventIDs returns the IDs of every event sharing eventID's
+// correlation_id, eventID included. A webhook forwarder that POSTs a
+// follow-up event into a separate topic never sets parent_event_id on it, so
+// correlation_id is the only link between such an event and the one that
+// triggered it; ListDescendantEventIDs alone would miss it.
+func (s *eventStore) ListCorrelatedEventIDs(ctx context.Context, eventID string, limit int) ([]string, error) {
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" {
+		return nil, fmt.Errorf("event id is required")
+	}
+	if limit <= 0 || limit > maxDescendantEventIDs {
+		limit = maxDescendantEventIDs
+	}
+	var correlationID string
+	if err := s.db.QueryRowContext(ctx, `SELECT correlation_id FROM event WHERE id = ?`, eventID).Scan(&correlationID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, domain.ResourceError(domain.ErrNotFound, "event", eventID, fmt.Sprintf("event %s not found", eventID), err)
+		}
+		return nil, fmt.Errorf("load event correlation id: %w", err)
+	}
+	correlationID = strings.TrimSpace(correlationID)
+	if correlationID == "" {
+		return []string{eventID}, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id FROM event WHERE correlation_id = ? ORDER BY sequence ASC LIMIT ?`, correlationID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query correlated events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	ids := make([]string, 0, limit)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan correlated event: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate correlated events: %w", err)
+	}
+	return ids, nil
+}
+
 // childEventIDs reads the direct children of one event. The traversal above
 // visits many parents, so the cursor is owned by this call rather than deferred
 // to the end of the walk.


### PR DESCRIPTION
## Summary
- `/api/webhooks/events/:event_id/stop` only walked the `parent_event_id` chain (`ListDescendantEventIDs`), so it never reached an event published as a follow-up webhook call (which never sets `parent_event_id`) even when it shares the same `correlation_id` as the event being stopped.
- Concretely: a router-style agent (e.g. `webhook.devboard.task.created`) that finishes and then POSTs a new webhook to kick off the actual long-running downstream agent (e.g. `webhook.agentkit.devboard.project.dev-board-server.task.created`) produces two sibling events with no parent/child link, only a shared `correlation_id`. Calling `/stop` on the router event was a no-op against the still-running downstream run.
- Added `Store.ListCorrelatedEventIDs` (implemented in `configstore.eventStore`) which returns every event sharing the root event's `correlation_id`, and merged it into the ID set `handleStopEvent` cancels/stops, alongside the existing parent-chain descendants.

## Note on scope
This intentionally does **not** restrict cascading to events published by the same webhook source — `correlation_id` is caller-supplied and, in the observed case, the router event and the downstream event actually come from two different registered webhook sources (`devboard` vs `agentkit-devboard-internal`) that are part of the same trusted internal flow. This was a deliberate simplification discussed with the reviewer; a source-scoped trust model was considered but intentionally deferred.

## Test plan
- [x] `go build ./pkg/... ./cmd/...`
- [x] `go test ./pkg/events/webhooks/... ./pkg/storage/configstore/...`
- [x] `go test ./pkg/agentcompose/... ./pkg/events/... ./pkg/storage/... ./pkg/schedulers/...`
- [x] Unit tests in `event_stop_test.go`: a correlated event outside the parent chain is stopped too; a correlated event already in the parent chain is not duplicated.
- [x] **New real end-to-end regression test** (`TestIntegrationWebhookStopCascadesToCorrelatedEventAcrossSources` in `pkg/agentcompose/app/webhook_stop_integration_test.go`): spins up a real sqlite-backed store + real scheduler controller with two projects/schedulers, dispatches two real (execution-blocked) runs from two events that share a `correlation_id` but come from two different webhook sources and have no `parent_event_id` link — reproducing the exact production shape. Calling `/stop` with only the router source's token cancels both runs.
  - Verified locally that this test **fails** (`requested_runs=1`, the correlated worker run stays running) when the `ListCorrelatedEventIDs` merge is disabled, confirming it actually exercises the fix rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaFrW4iFGfXYUredLVPxiH