### PR TITLE
fix(opencode): make an opencode agent's configured model and provider protocol work on prompt attach

### DIFF
--- a/pkg/execution/agent_config.go
+++ b/pkg/execution/agent_config.go
@@ -19,7 +19,11 @@ func AgentConfigFromDefinition(agent domain.AgentDefinition, fallbackProvider st
 		provider = domain.NormalizeAgentKind(fallbackProvider)
 	}
 	model := strings.TrimSpace(agent.Model)
-	if provider == "opencode" {
+	if provider == "opencode" && model == "" {
+		// Compatibility fallback. `model:` used to be discarded outright for
+		// opencode, so agents written against that behaviour carry their model
+		// only as an OPENCODE_MODEL env item. Those keep working; a configured
+		// `model:` now wins, as it does for every other provider.
 		model = strings.TrimSpace(domain.SandboxEnvMap(agent.EnvItems)["OPENCODE_MODEL"])
 	}
 	return AgentConfig{

--- a/pkg/execution/artifacts_coverage_test.go
+++ b/pkg/execution/artifacts_coverage_test.go
@@ -45,8 +45,14 @@ func TestCellArtifactsAndAgentFilesWorkflows(t *testing.T) {
 	if config := AgentConfigFromDefinition(domain.AgentDefinition{ID: " agent-1 ", Provider: " ", Model: " model "}, " codex "); config.Provider != "codex" || config.AgentDefinitionID != "agent-1" || config.Model != "model" {
 		t.Fatalf("AgentConfigFromDefinition fallback = %#v", config)
 	}
-	if config := AgentConfigFromDefinition(domain.AgentDefinition{Provider: "opencode", Model: "ignored", EnvItems: []domain.SandboxEnvVar{{Name: "OPENCODE_MODEL", Value: "env-model"}}}, "codex"); config.Model != "env-model" {
+	// A configured `model:` wins for opencode as it does for every other
+	// provider; OPENCODE_MODEL is only the fallback for agents written before
+	// `model:` was read at all.
+	if config := AgentConfigFromDefinition(domain.AgentDefinition{Provider: "opencode", Model: "configured-model", EnvItems: []domain.SandboxEnvVar{{Name: "OPENCODE_MODEL", Value: "env-model"}}}, "codex"); config.Model != "configured-model" {
 		t.Fatalf("AgentConfigFromDefinition opencode = %#v", config)
+	}
+	if config := AgentConfigFromDefinition(domain.AgentDefinition{Provider: "opencode", EnvItems: []domain.SandboxEnvVar{{Name: "OPENCODE_MODEL", Value: "env-model"}}}, "codex"); config.Model != "env-model" {
+		t.Fatalf("AgentConfigFromDefinition opencode env fallback = %#v", config)
 	}
 	ApplyAgentProviderEnv(nil, []domain.SandboxEnvVar{{Name: "A", Value: "1"}})
 	sessionEnvTarget := &domain.Sandbox{EnvItems: []domain.SandboxEnvVar{{Name: "A", Value: "session"}}}

--- a/pkg/llms/opencode_facade.go
+++ b/pkg/llms/opencode_facade.go
@@ -135,12 +135,14 @@ func ensureOpenCodeResolvedFacadeConfig(ctx context.Context, call openCodeFacade
 	if providerFamily != ProviderFamilyOpenAI {
 		return nil, domain.ClassifyError(domain.ErrFailedPrecondition, "opencode requires an OpenAI-compatible or Anthropic model", nil)
 	}
-	protocol := NormalizeWireAPI(target.WireAPI)
-	if protocol != APIProtocolResponses && protocol != APIProtocolChatCompletions {
+	// The guard still rejects a provider the facade could not proxy to, so an
+	// unroutable target fails at run start rather than on the first request.
+	// It does not decide the token's wire api: see openCodeGuestWireAPI.
+	if upstream := NormalizeWireAPI(target.WireAPI); upstream != APIProtocolResponses && upstream != APIProtocolChatCompletions {
 		return nil, domain.ClassifyError(domain.ErrFailedPrecondition, "opencode model uses an unsupported wire protocol", nil)
 	}
 	tokenValue, token, err := NewFacadeToken(NewFacadeTokenRequest{
-		SandboxID: sandbox.Summary.ID, Model: target.Model.Name, ProviderID: target.Provider.ID, WireAPI: protocol, Source: source, RunID: runID,
+		SandboxID: sandbox.Summary.ID, Model: target.Model.Name, ProviderID: target.Provider.ID, WireAPI: openCodeGuestWireAPI, Source: source, RunID: runID,
 	})
 	if err != nil {
 		return nil, err
@@ -152,7 +154,7 @@ func ensureOpenCodeResolvedFacadeConfig(ctx context.Context, call openCodeFacade
 	if err := WriteOpenCodeRuntimeConfig(sandbox, "agent-compose", target.Model.Name, openAIBaseURL); err != nil {
 		return nil, err
 	}
-	env := openCodeOpenAIEnv(tokenValue, openAIBaseURL, protocol, config)
+	env := openCodeOpenAIEnv(tokenValue, openAIBaseURL, openCodeGuestWireAPI, config)
 	env["LLM_MODEL"] = "agent-compose/" + target.Model.Name
 	env["OPENCODE_MODEL"] = "agent-compose/" + target.Model.Name
 	return env, nil
@@ -212,7 +214,7 @@ func ensureOpenCodeOpenAIFacadeConfig(ctx context.Context, call openCodeFacadeCa
 	}
 	baseURL := GuestRuntimeBaseURL(config, sandbox)
 	tokenValue, token, err := NewFacadeToken(NewFacadeTokenRequest{
-		SandboxID: sandbox.Summary.ID, Model: target.Model.Name, ProviderID: target.Provider.ID, WireAPI: APIProtocolResponses, Source: source, RunID: runID,
+		SandboxID: sandbox.Summary.ID, Model: target.Model.Name, ProviderID: target.Provider.ID, WireAPI: openCodeGuestWireAPI, Source: source, RunID: runID,
 	})
 	if err != nil {
 		return nil, err
@@ -224,7 +226,7 @@ func ensureOpenCodeOpenAIFacadeConfig(ctx context.Context, call openCodeFacadeCa
 	if err := WriteOpenCodeRuntimeConfig(sandbox, "agent-compose", target.Model.Name, openAIBaseURL); err != nil {
 		return nil, err
 	}
-	env := openCodeOpenAIEnv(tokenValue, openAIBaseURL, APIProtocolResponses, config)
+	env := openCodeOpenAIEnv(tokenValue, openAIBaseURL, openCodeGuestWireAPI, config)
 	env["LLM_MODEL"] = "agent-compose/" + target.Model.Name
 	env["OPENCODE_MODEL"] = "agent-compose/" + target.Model.Name
 	return env, nil
@@ -244,7 +246,7 @@ func ensureOpenCodeCustomFacadeConfig(ctx context.Context, call openCodeFacadeCa
 	}
 	baseURL := GuestRuntimeBaseURL(config, sandbox)
 	tokenValue, token, err := NewFacadeToken(NewFacadeTokenRequest{
-		SandboxID: sandbox.Summary.ID, Model: target.Model.Name, ProviderID: target.Provider.ID, WireAPI: APIProtocolChatCompletions, Source: source, RunID: runID,
+		SandboxID: sandbox.Summary.ID, Model: target.Model.Name, ProviderID: target.Provider.ID, WireAPI: openCodeGuestWireAPI, Source: source, RunID: runID,
 	})
 	if err != nil {
 		return nil, err
@@ -256,8 +258,21 @@ func ensureOpenCodeCustomFacadeConfig(ctx context.Context, call openCodeFacadeCa
 	if err := WriteOpenCodeRuntimeConfig(sandbox, providerID, target.Model.Name, openAIBaseURL); err != nil {
 		return nil, err
 	}
-	return openCodeOpenAIEnv(tokenValue, openAIBaseURL, APIProtocolChatCompletions, config), nil
+	return openCodeOpenAIEnv(tokenValue, openAIBaseURL, openCodeGuestWireAPI, config), nil
 }
+
+// openCodeGuestWireAPI is the protocol opencode speaks to the facade, which is
+// a property of the guest client rather than of the upstream provider.
+// WriteOpenCodeRuntimeConfig registers the facade with `@ai-sdk/openai-compatible`
+// (and `@ai-sdk/openai` in its default mode), both of which post chat
+// completions whatever the provider behind the facade speaks. Minting the token
+// for the provider's wire api instead made every responses-only provider
+// unusable from opencode: the guest's chat-completions request was refused with
+// "llm facade token wire api mismatch" before it could be proxied. The facade
+// bridges the two protocols itself — UpstreamProtocolAndEndpoint still derives
+// the upstream call from the resolved target — so the token only has to describe
+// the inbound half.
+const openCodeGuestWireAPI = APIProtocolChatCompletions
 
 func openCodeOpenAIEnv(tokenValue, baseURL, protocol string, config *appconfig.Config) map[string]string {
 	return map[string]string{

--- a/pkg/llms/opencode_facade_test.go
+++ b/pkg/llms/opencode_facade_test.go
@@ -1,0 +1,41 @@
+package llms
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chaitin/agent-compose/pkg/execution"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+// Every opencode OpenAI-family path must mint the same ingress protocol,
+// because they all hand the guest the same kind of client. Before this was
+// unified the three paths disagreed — the configured-provider path followed the
+// upstream provider, the env-provider path pinned responses, and only the custom
+// path matched what opencode actually sends — so a responses-only provider was
+// unusable from opencode: its chat-completions request was rejected with
+// "llm facade token wire api mismatch" before the facade could proxy it.
+func TestOpenCodeGuestWireAPIMatchesTheClientOpenCodeIsGiven(t *testing.T) {
+	if openCodeGuestWireAPI != APIProtocolChatCompletions {
+		t.Fatalf("opencode guest wire api = %q, want %q", openCodeGuestWireAPI, APIProtocolChatCompletions)
+	}
+	// WriteOpenCodeRuntimeConfig picks the ai-sdk package the guest talks
+	// through; both of its branches post chat completions, so neither can be
+	// served by a responses-scoped token.
+	for _, providerID := range []string{"agent-compose", "openai"} {
+		root := t.TempDir()
+		sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-wire", WorkspacePath: filepath.Join(root, "workspace")}}
+		if err := WriteOpenCodeRuntimeConfig(sandbox, providerID, "gpt-test", "http://facade.test/llm/openai/v1"); err != nil {
+			t.Fatalf("WriteOpenCodeRuntimeConfig(%q) returned error: %v", providerID, err)
+		}
+		raw, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(sandbox), ".config", "opencode", "opencode.json"))
+		if err != nil {
+			t.Fatalf("read opencode config for %q: %v", providerID, err)
+		}
+		if !strings.Contains(string(raw), "@ai-sdk/openai") {
+			t.Fatalf("opencode config for %q does not name an ai-sdk package: %s", providerID, raw)
+		}
+	}
+}

--- a/pkg/llms/opencode_facade_test.go
+++ b/pkg/llms/opencode_facade_test.go
@@ -1,9 +1,9 @@
 package llms
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chaitin/agent-compose/pkg/execution"
@@ -17,25 +17,58 @@ import (
 // path matched what opencode actually sends — so a responses-only provider was
 // unusable from opencode: its chat-completions request was rejected with
 // "llm facade token wire api mismatch" before the facade could proxy it.
+//
+// The package assertions below are exact rather than substring matches: the
+// whole reason chat completions is the right ingress is that these two specific
+// ai-sdk packages post chat completions, so a test that cannot tell them apart
+// (note "@ai-sdk/openai" is a prefix of "@ai-sdk/openai-compatible") would keep
+// passing if a branch were switched to a responses-capable client — readmitting
+// exactly the token/guest mismatch this pins down.
 func TestOpenCodeGuestWireAPIMatchesTheClientOpenCodeIsGiven(t *testing.T) {
 	if openCodeGuestWireAPI != APIProtocolChatCompletions {
 		t.Fatalf("opencode guest wire api = %q, want %q", openCodeGuestWireAPI, APIProtocolChatCompletions)
 	}
-	// WriteOpenCodeRuntimeConfig picks the ai-sdk package the guest talks
-	// through; both of its branches post chat completions, so neither can be
-	// served by a responses-scoped token.
-	for _, providerID := range []string{"agent-compose", "openai"} {
-		root := t.TempDir()
-		sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-wire", WorkspacePath: filepath.Join(root, "workspace")}}
-		if err := WriteOpenCodeRuntimeConfig(sandbox, providerID, "gpt-test", "http://facade.test/llm/openai/v1"); err != nil {
-			t.Fatalf("WriteOpenCodeRuntimeConfig(%q) returned error: %v", providerID, err)
-		}
-		raw, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(sandbox), ".config", "opencode", "opencode.json"))
-		if err != nil {
-			t.Fatalf("read opencode config for %q: %v", providerID, err)
-		}
-		if !strings.Contains(string(raw), "@ai-sdk/openai") {
-			t.Fatalf("opencode config for %q does not name an ai-sdk package: %s", providerID, raw)
-		}
+	for _, test := range []struct {
+		providerID string
+		wantNPM    string
+	}{
+		{providerID: "agent-compose", wantNPM: "@ai-sdk/openai-compatible"},
+		{providerID: "openai", wantNPM: "@ai-sdk/openai"},
+	} {
+		t.Run(test.providerID, func(t *testing.T) {
+			root := t.TempDir()
+			sandbox := &domain.Sandbox{Summary: domain.SandboxSummary{ID: "sandbox-wire", WorkspacePath: filepath.Join(root, "workspace")}}
+			if err := WriteOpenCodeRuntimeConfig(sandbox, test.providerID, "gpt-test", "http://facade.test/llm/openai/v1"); err != nil {
+				t.Fatalf("WriteOpenCodeRuntimeConfig returned error: %v", err)
+			}
+			raw, err := os.ReadFile(filepath.Join(execution.HostSandboxHome(sandbox), ".config", "opencode", "opencode.json"))
+			if err != nil {
+				t.Fatalf("read opencode config: %v", err)
+			}
+			var config struct {
+				Provider map[string]struct {
+					NPM     string `json:"npm"`
+					Options struct {
+						BaseURL string `json:"baseURL"`
+					} `json:"options"`
+				} `json:"provider"`
+			}
+			if err := json.Unmarshal(raw, &config); err != nil {
+				t.Fatalf("decode opencode config: %v\n%s", err, raw)
+			}
+			entry, ok := config.Provider[test.providerID]
+			if !ok {
+				t.Fatalf("opencode config has no %q provider entry: %s", test.providerID, raw)
+			}
+			if entry.NPM != test.wantNPM {
+				t.Fatalf("opencode provider npm = %q, want %q", entry.NPM, test.wantNPM)
+			}
+			// The guest is pointed at the facade's OpenAI base, from which
+			// opencode derives /chat/completions — the path the token has to
+			// authorise.
+			if entry.Options.BaseURL != "http://facade.test/llm/openai/v1" {
+				t.Fatalf("opencode provider baseURL = %q", entry.Options.BaseURL)
+			}
+		})
 	}
 }

--- a/pkg/llms/runtimefacade/config_protocol_test.go
+++ b/pkg/llms/runtimefacade/config_protocol_test.go
@@ -14,7 +14,13 @@ import (
 	domain "github.com/chaitin/agent-compose/pkg/model"
 )
 
-func TestIntegrationEnsureSessionOpenCodeKeepsResponsesIngressForChatUpstream(t *testing.T) {
+// The guest's ingress protocol is decided by the client opencode is configured
+// with, not by the upstream provider: WriteOpenCodeRuntimeConfig registers the
+// facade with an ai-sdk package that posts chat completions. The facade bridges
+// to whatever the upstream speaks, so ingress stays chat completions here even
+// though this provider's own wire api is also chat completions — and equally
+// when it is responses (see TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows).
+func TestIntegrationEnsureSessionOpenCodePinsChatIngressIndependentOfUpstream(t *testing.T) {
 	isolateLLMEnv(t)
 
 	ctx := context.Background()
@@ -49,8 +55,8 @@ func TestIntegrationEnsureSessionOpenCodeKeepsResponsesIngressForChatUpstream(t 
 		t.Fatalf("EnsureSessionAgentRuntimeConfig returned error: %v", err)
 	}
 	env := runtimeConfig.Env
-	if env["LLM_API_PROTOCOL"] != llms.APIProtocolResponses {
-		t.Fatalf("OpenCode ingress protocol = %q, want responses", env["LLM_API_PROTOCOL"])
+	if env["LLM_API_PROTOCOL"] != llms.APIProtocolChatCompletions {
+		t.Fatalf("OpenCode ingress protocol = %q, want chat completions", env["LLM_API_PROTOCOL"])
 	}
 	if runtimeConfig.Model != "agent-compose/gpt-chat" {
 		t.Fatalf("OpenCode runtime model = %q, want facade model", runtimeConfig.Model)
@@ -59,8 +65,8 @@ func TestIntegrationEnsureSessionOpenCodeKeepsResponsesIngressForChatUpstream(t 
 	if err != nil {
 		t.Fatalf("GetLLMFacadeToken returned error: %v", err)
 	}
-	if token.WireAPI != llms.APIProtocolResponses {
-		t.Fatalf("facade token wire API = %q, want responses", token.WireAPI)
+	if token.WireAPI != llms.APIProtocolChatCompletions {
+		t.Fatalf("facade token wire API = %q, want chat completions", token.WireAPI)
 	}
 	providers, err := store.ListEnabledLLMProviders(ctx)
 	if err != nil {
@@ -139,14 +145,14 @@ func TestIntegrationEnsureSessionOpenCodeKeepsConfiguredProviderInMixedEnvironme
 	}
 
 	sessionProviderID := llms.SessionEnvProviderID(session.Summary.ID, llms.ProviderFamilyOpenAI)
-	assertTarget(session, "openai/gpt-test", "legacy-gpt", llms.APIProtocolResponses, sessionProviderID, "run-openai-env")
-	assertTarget(session, "baizhi/deepseek-v4-flash", "legacy-gpt", llms.APIProtocolResponses, sessionProviderID, "run-baizhi-env")
+	assertTarget(session, "openai/gpt-test", "legacy-gpt", llms.APIProtocolChatCompletions, sessionProviderID, "run-openai-env")
+	assertTarget(session, "baizhi/deepseek-v4-flash", "legacy-gpt", llms.APIProtocolChatCompletions, sessionProviderID, "run-baizhi-env")
 
 	exactSession := &domain.Sandbox{Summary: domain.SandboxSummary{
 		ID:            "sandbox-opencode-configured-provider",
 		Driver:        driverpkg.RuntimeDriverDocker,
 		WorkspacePath: filepath.Join(root, "sandboxes", "sandbox-opencode-configured-provider", "workspace"),
 	}}
-	assertTarget(exactSession, "openai/gpt-test", "gpt-test", llms.APIProtocolResponses, "openai", "run-openai-configured")
+	assertTarget(exactSession, "openai/gpt-test", "gpt-test", llms.APIProtocolChatCompletions, "openai", "run-openai-configured")
 	assertTarget(exactSession, "baizhi/deepseek-v4-flash", "deepseek-v4-flash", llms.APIProtocolChatCompletions, "baizhi", "run-baizhi-configured")
 }

--- a/pkg/llms/runtimefacade/config_test.go
+++ b/pkg/llms/runtimefacade/config_test.go
@@ -317,7 +317,7 @@ func TestEnsureSessionAgentRuntimeConfigClaudeAndOpenCodeWorkflows(t *testing.T)
 	if err != nil {
 		t.Fatalf("EnsureSessionAgentRuntimeConfig opencode openai returned error: %v", err)
 	}
-	if openAI.Env["LLM_API_PROTOCOL"] != llms.APIProtocolResponses || openAI.Env["OPENCODE_CONFIG"] == "" {
+	if openAI.Env["LLM_API_PROTOCOL"] != llms.APIProtocolChatCompletions || openAI.Env["OPENCODE_CONFIG"] == "" {
 		t.Fatalf("opencode openai env = %#v", openAI.Env)
 	}
 

--- a/pkg/runs/prompt_attach.go
+++ b/pkg/runs/prompt_attach.go
@@ -102,6 +102,7 @@ func (c *Controller) preparePromptInteractionRuntime(ctx context.Context, runCtx
 	}
 	if len(managedEnv) > 0 {
 		env = llms.MergeManagedExecEnv(env, managedEnv)
+		agentConfig.Model = promptAttachRuntimeModel(agentConfig, managedEnv)
 	}
 	return preparedPromptInteraction{
 		Run:                run,

--- a/pkg/runs/prompt_attach_facade.go
+++ b/pkg/runs/prompt_attach_facade.go
@@ -130,3 +130,26 @@ func (c *Controller) deletePromptAttachLLMFacadeToken(ctx context.Context, token
 	}
 	_ = store.DeleteLLMFacadeToken(ctx, token)
 }
+
+// promptAttachRuntimeModel returns the model the guest runner should be told to
+// use, which is not always the one the agent configured.
+//
+// The facade resolves an agent-compose provider/model pair and then republishes
+// it in whatever namespace the guest agent addresses models by. opencode is the
+// only provider where the two namespaces differ: its model must carry the
+// provider key WriteOpenCodeRuntimeConfig writes into the guest's opencode.json,
+// so EnsureOpenCodeFacadeConfig exports the resolved pair as OPENCODE_MODEL.
+// Forwarding the configured model instead would hand opencode a provider name it
+// has no entry for, and it exits without diagnosing the failure.
+//
+// The one-shot run path performs the same substitution through
+// runtimefacade.AgentRuntimeConfig.Model; this is its prompt-attach counterpart.
+func promptAttachRuntimeModel(agent execution.AgentConfig, managedEnv map[string]string) string {
+	if domain.NormalizeAgentKind(agent.Provider) != "opencode" {
+		return agent.Model
+	}
+	if model := strings.TrimSpace(managedEnv["OPENCODE_MODEL"]); model != "" {
+		return model
+	}
+	return agent.Model
+}

--- a/pkg/runs/prompt_attach_facade_test.go
+++ b/pkg/runs/prompt_attach_facade_test.go
@@ -376,3 +376,36 @@ func TestPromptAttachProvidersAllHaveFacadeCases(t *testing.T) {
 		}
 	}
 }
+// The start frame's model becomes opencode's --model, which overrides the
+// OPENCODE_MODEL env the facade just exported. It therefore has to carry the
+// facade's namespace-corrected model, not the agent-compose provider/model pair
+// the agent configured — opencode has no entry for the latter and exits without
+// reporting why.
+func TestPromptAttachRuntimeModelUsesFacadeOpenCodeModel(t *testing.T) {
+	managedEnv := map[string]string{"OPENCODE_MODEL": "agent-compose/gpt-test"}
+	agent := execution.AgentConfig{Provider: "opencode", Model: "openai/gpt-test"}
+	if model := promptAttachRuntimeModel(agent, managedEnv); model != "agent-compose/gpt-test" {
+		t.Fatalf("opencode runtime model = %q", model)
+	}
+}
+
+// Every other provider addresses models in agent-compose's own namespace, so
+// their configured model must reach the runner untouched.
+func TestPromptAttachRuntimeModelLeavesOtherProvidersUntouched(t *testing.T) {
+	managedEnv := map[string]string{"OPENCODE_MODEL": "agent-compose/gpt-test"}
+	for _, provider := range []string{"codex", "claude", "pi", "dsh"} {
+		agent := execution.AgentConfig{Provider: provider, Model: "openai/gpt-test"}
+		if model := promptAttachRuntimeModel(agent, managedEnv); model != "openai/gpt-test" {
+			t.Fatalf("%s runtime model = %q", provider, model)
+		}
+	}
+}
+
+// A facade that resolved no opencode model must not blank out the configured
+// one; the run should still get as far as opencode's own error reporting.
+func TestPromptAttachRuntimeModelKeepsConfiguredModelWithoutFacadeModel(t *testing.T) {
+	agent := execution.AgentConfig{Provider: "opencode", Model: "openai/gpt-test"}
+	if model := promptAttachRuntimeModel(agent, map[string]string{}); model != "openai/gpt-test" {
+		t.Fatalf("opencode runtime model without facade model = %q", model)
+	}
+}

--- a/pkg/runs/prompt_attach_facade_test.go
+++ b/pkg/runs/prompt_attach_facade_test.go
@@ -189,7 +189,7 @@ func TestEnsurePromptAttachLLMFacadeEnvOpenCodeUsesSharedRuntimeConfig(t *testin
 	if err != nil {
 		t.Fatalf("ensurePromptAttachLLMFacadeEnv returned error: %v", err)
 	}
-	if env["LLM_API_PROTOCOL"] != llms.APIProtocolResponses ||
+	if env["LLM_API_PROTOCOL"] != llms.APIProtocolChatCompletions ||
 		env["OPENCODE_CONFIG"] != "/root/.config/opencode/opencode.json" ||
 		env["LLM_MODEL"] != "agent-compose/gpt-test" ||
 		env["OPENCODE_MODEL"] != "agent-compose/gpt-test" {
@@ -376,6 +376,7 @@ func TestPromptAttachProvidersAllHaveFacadeCases(t *testing.T) {
 		}
 	}
 }
+
 // The start frame's model becomes opencode's --model, which overrides the
 // OPENCODE_MODEL env the facade just exported. It therefore has to carry the
 // facade's namespace-corrected model, not the agent-compose provider/model pair


### PR DESCRIPTION
## Problem

`provider: opencode` 的 agent 在 prompt-attach 路径上无法通过 `model:` 指定模型。两个缺陷叠加(详见 #669):

1. **`model:` 被静默丢弃** —— `AgentConfigFromDefinition`(`pkg/execution/agent_config.go:22`)对 opencode 直接丢掉 `agent.Model`,只读 `OPENCODE_MODEL` env item。按其他 provider 的常规写法配置的 agent 在启动时失败于 `opencode model must be in provider/model format` —— 报错指向格式,真实原因是配置的模型从未被读取。

2. **attach 覆盖 facade 翻译好的模型** —— attach 路径把该值原样塞进 start 帧(`prompt_attach.go:322`),runner 转成 opencode 的 `--model`(`opencode.ts:74`),覆盖掉 facade 刚导出的 `OPENCODE_MODEL`。两者不可互换:opencode 按 `WriteOpenCodeRuntimeConfig`(`runtime_config.go:246`)写进 guest `opencode.json` 的 provider key 寻址模型,而配置里的模型名指的是一个 agent-compose provider。拿到没有对应条目的名字,opencode **不报错直接退出** —— 它自己的日志停在 session 创建后、不记任何 error,运行侧只看到 `UnknownError: Unexpected server error`。

## Solution

**`model:` 现在优先。** `OPENCODE_MODEL` env item 保留为回退,让按旧行为写的 agent 继续可用。

**start 帧改带 facade 解析后的模型。** 新增 `promptAttachRuntimeModel`,与一次性 run 路径已有的做法对齐 —— 后者通过 `runtimefacade.AgentRuntimeConfig.Model`(`runtimefacade/config.go:75` → `agent_runner.go:128`)做同样的替换,attach 之前没有对应逻辑。opencode 是唯一两套命名空间不一致的 provider,其余 provider 的模型原样透传。

## Verification

`go build ./...` 通过;`pkg/execution`、`pkg/runs`、`pkg/llms`、`pkg/llms/runtimefacade`、`pkg/agentcompose/adapters`、`pkg/schedulers` 全部通过。

**变异测试**(两个缺陷各自还原,确认测试确实咬得住):
- 还原 `AgentConfigFromDefinition` 为「env 永远覆盖」→ `TestCellArtifactsAndAgentFilesWorkflows` 失败
- 移除 `promptAttachRuntimeModel` 的 facade 查找 → `TestPromptAttachRuntimeModelUsesFacadeOpenCodeModel` 失败

`pkg/execution/artifacts_coverage_test.go` 里原有一处断言固化了旧行为(`Model: "ignored"` + env 覆盖),已更新,并补了 env 回退这一侧的断言。

**实盘验证**:用本分支重建 daemon,agent 只配 `model: default/feature/gpt-5.6-sol`(不加任何 env workaround)走 `AttachAgentRun`。修复前 opencode 在发出任何 LLM 请求之前就退出;修复后它解析出 provider 并发出了真实的 LLM 请求。

## 第二个提交:facade token 按 opencode 实际说的协议铸造

修好模型之后 opencode 能走到第一次 LLM 调用,然后撞上第二个缺陷:

```
403 {"error":"llm facade token wire api mismatch"}
POST .../llm/openai/v1/chat/completions
```

token 的 wire api 描述的是 facade 的**入向**半边 —— guest 发什么 —— 但它是按**上游 provider** 铸的,而且三条 opencode 路径各说各话:

| 铸造点 | 原本的 token wire api |
| --- | --- |
| `ensureOpenCodeConfiguredFacadeConfig` | 跟随 provider |
| `ensureOpenCodeOpenAIFacadeConfig` | 硬编码 `responses` |
| `ensureOpenCodeCustomFacadeConfig` | 硬编码 `chat_completions` |

guest 实际发什么由 `WriteOpenCodeRuntimeConfig` 决定,它的两个分支(`@ai-sdk/openai-compatible` 和 `@ai-sdk/openai`)都发 chat completions。所以只有第三条是对的。三条现已统一。

**这不改变上游用什么协议调用**:`UpstreamProtocolAndEndpoint` 仍从 resolved target 推导,facade 本来就具备双向桥接(含流式)。

### 关于反转一个刻意的决定

`TestIntegrationEnsureSessionOpenCodeKeepsResponsesIngressForChatUpstream` 明确把 responses ingress 断言为刻意设计,所以这个提交推翻了一个有记录的决定。理由是**该决定在实践中不可达**:opencode 被配置的任何 ai-sdk 客户端都发不出 responses 请求,所以 responses 作用域的 token 只可能被拒。该测试已改名为陈述真正成立的不变量(ingress 跟随 guest 客户端,与上游无关),并新增一个测试把常量钉在 `WriteOpenCodeRuntimeConfig` 实际写入的包上。

`pkg/runs` 里 pi 的协议断言**未改动** —— pi 的 ingress 确实跟随 provider,它的客户端支持 responses。

## 端到端验证

用本分支重建 daemon,agent 只配 `model: default/feature/gpt-5.6-sol`(无任何 env workaround),对一个 `responses` 协议的 provider 走 `AttachAgentRun`:

| | 修复前 | 修复后 |
| --- | --- | --- |
| 第一个提交前 | 静默 `UnknownError`,零 facade 调用 | — |
| 仅第一个提交 | — | 到达 provider,`403 wire api mismatch` |
| 两个提交 | — | **完整跑通** |

最终事件流:`step_start, tool_call, tool_result, text_delta, usage, step_end` × 3 个 step,零 error。

## 已知的既存失败(与本 PR 无关)

全量 `go test ./pkg/...` 有几个失败,已确认在干净的 main 上同样复现:`TestNormalizeCronTimezone`、`TestManagerResolveBindAndNamedVolumeMounts`、`TestBindResolverResolvesRelativeAbsoluteAndSymlinkDirectories`。另有 `TestSchedulerSandboxRunnerConcurrentInlineFileWorkspaceMaterializationIsSerialized` 在全量负载下偶发,单独 `-count=3` 稳定通过。

Fixes #669

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
