### PR TITLE
chore(runtime): bump packages to 0.11.0

### DIFF
--- a/runtime/agent-compose-runtime-sdk/package-lock.json
+++ b/runtime/agent-compose-runtime-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime-sdk",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "zod": "^4.4.3"

--- a/runtime/agent-compose-runtime-sdk/package.json
+++ b/runtime/agent-compose-runtime-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime-sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Node.js SDK for scripts running inside an agent-compose guest runtime.",
   "license": "LGPL-3.0-only",
   "type": "module",

--- a/runtime/javascript/package-lock.json
+++ b/runtime/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaitin-ai/agent-compose-runtime",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.206",

--- a/runtime/javascript/package.json
+++ b/runtime/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaitin-ai/agent-compose-runtime",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Guest-side runtime CLI for agent-compose agent sessions.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## 为什么

上一次 runtime 发版是 `runtime-v0.10.0`（2026-08-13）。此后主干已经出了 `v2609.1.0`、`v2609.2.0` 两个应用版本，但两个 npm 包一次都没跟着 bump。

自 `runtime-v0.10.0` 以来的未发布变更：

**`runtime/javascript`**（25 个文件，+2506/-51）
- `feat(dsh)`：新增 DSH agent provider（`src/runners/dsh.ts`）+ skill/MCP 支持，`normalizeProvider` 新增 `dsh`/`deepseek`/`deepseek-harness`/`deepseek_harness` 别名
- `feat(runtime): publish provider-neutral agent events`：新增 `src/agent-event.ts`，六个 runner 全部接入中立事件映射
- 一串 dsh 修复：环境变量清理、stderr 隔离与原始字节保留、persona 改用 agent-scoped section 注入、reasoning effort 默认值与 final-text tail

**`runtime/agent-compose-runtime-sdk`**（+4/-4，但都是公开类型）
- `RuntimeAgentOptions.provider` 与 `RuntimeWorkflowProvider` 联合类型加上 `"dsh"`

不发版的三个实际问题：

1. **类型不发就用不了**：npm 上的 0.10.0 类型里没有 `"dsh"`，外部用户写 `agent({ provider: "dsh" })` 会直接 TS 报错——即使 Go 控制面和 guest 镜像里的 runtime 都已经支持了。
2. **同版本号内容不一致**：guest 镜像从源码 COPY 构建并 pack 出离线 tarball，现在打出来的 tarball 标着 0.10.0，内容却和 registry 上的 0.10.0 不同。`docs/pages/zh-CN/guest-image-abi.md` 要求离线 tarball 与 release 匹配，这条已经破了。
3. **`agent_event` 帧格式变了**：`src/interactive.ts` 不再转发原始 SDK event、也不再合成 `{type:"output"}`，改由 runner 的 `onEvent` sink 发中立事件。这是 runtime ↔ daemon 的协议变更，需要一个明确的版本号标记 lockstep 边界。

## 版本号

选 minor `0.11.0`。改动都是向后兼容的新增（`Provider` 联合类型扩展、`RunnerOptions.onEvent` 可选字段）；`agent_event` 帧变更属于 runtime↔daemon 内部协议，0.x 阶段 minor 即是该语义，也和历史（0.6→0.7→…→0.10 全走 minor）一致。

## 改动范围

只有 4 个文件、6 行版本号，与上次 bump（`616483ad`）形状一致。lock 用 `npm install --package-lock-only` 重新生成，除版本号外无其他变化。

未改 `docs/spec/dynamic-workflow-spec.md:637`：那行是 dynamic-workflow 特性自己的设计要求（"从 0.9.0 升到 0.10.0"），该特性已在 0.10.0 交付，本次发的是 dsh + neutral events，跟着改会让那份历史记录失真。

## 验证

跑了 publish workflow 的全部 gate：

- `runtime/javascript`：`npm run build` ✅，`npm run test:unit` → 271 passed / 3 failed
- `runtime/agent-compose-runtime-sdk`：`npm run build` ✅，`npm test` → 40 passed / 1 failed，`npm run test:packaging` ✅

4 个 failure **全部是本机 macOS 环境导致，与本次改动无关**，已逐一确认：

- `pi-runner`、`workflow-worktree`（3 个）：macOS `/var` → `/private/var` symlink 解析，路径断言与 `isLinkedWorktree` 比较失败。CI 跑 `ubuntu-latest`，无此问题。
- SDK `workflow.test.ts` 的 timeout 用例：`timeoutMs: 100` 与本机 node 启动耗时竞争。在 `runtime-v0.10.0` 的 worktree 上以同样方式复现了同一 failure——而那个 commit 当时是成功发布的，说明 CI 上通过。

另外把 bump 前后的 tree 各跑了一遍做对照，failure 集合完全相同。

## 合入后

打 tag `runtime-v0.11.0` 并 push，`publish-runtime.yml` 会校验两包版本一致且等于 tag，然后带 provenance 发到 npm。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

