### PR TITLE
feat(api): support scheduler lookup by ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	connectrpc.com/connect v1.19.2
-	github.com/chaitin/agent-compose/proto v0.1.4
+	github.com/chaitin/agent-compose/proto v0.1.5
 	github.com/chaitin/ai-api-protocol-bridge v1.0.0
 	github.com/chzyer/readline v1.5.1
 	github.com/containerd/errdefs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chaitin/agent-compose/proto v0.1.4 h1:SCOKbG9Zu2tkysIGYKSq/Aw6g9vf9aoVnXlT3tF+wtw=
-github.com/chaitin/agent-compose/proto v0.1.4/go.mod h1:sgEGuy3xcx0uneY7QeNdCd6CP8DJ+GuxblSAwvyt3wg=
+github.com/chaitin/agent-compose/proto v0.1.5 h1:tX7R88AiA4cycvpiTxELPDjQZ2HD0PXSE+4i6xiTcWE=
+github.com/chaitin/agent-compose/proto v0.1.5/go.mod h1:sgEGuy3xcx0uneY7QeNdCd6CP8DJ+GuxblSAwvyt3wg=
 github.com/chaitin/ai-api-protocol-bridge v1.0.0 h1:JKV+KRIzSe2ZlM0BxUdvPhVxroCc/cLQbILJR/iAvig=
 github.com/chaitin/ai-api-protocol-bridge v1.0.0/go.mod h1:hSbqFEyrkL/j6r4k9NooMaV3gkjXzMR96GddRH/AObA=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=

--- a/pkg/agentcompose/api/project_handler.go
+++ b/pkg/agentcompose/api/project_handler.go
@@ -189,11 +189,10 @@ func (h *ProjectHandler) WatchProject(ctx context.Context, req *connect.Request[
 }
 
 func (h *ProjectHandler) GetScheduler(ctx context.Context, req *connect.Request[agentcomposev2.GetSchedulerRequest]) (*connect.Response[agentcomposev2.GetSchedulerResponse], error) {
-	project, scheduler, err := h.resolveProjectScheduler(ctx, req.Msg.GetProject(), req.Msg.GetAgentName())
+	scheduler, err := h.resolveGetScheduler(ctx, req.Msg)
 	if err != nil {
 		return nil, projectConnectError(err)
 	}
-	_ = project
 	response, err := h.schedulerResponse(ctx, scheduler)
 	if err != nil {
 		return nil, err

--- a/pkg/agentcompose/api/project_scheduler_lookup.go
+++ b/pkg/agentcompose/api/project_scheduler_lookup.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chaitin/agent-compose/pkg/model"
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+type projectSchedulerByIDStore interface {
+	GetProjectSchedulerByID(context.Context, string) (model.ProjectSchedulerRecord, error)
+}
+
+func (h *ProjectHandler) resolveGetScheduler(ctx context.Context, request *agentcomposev2.GetSchedulerRequest) (model.ProjectSchedulerRecord, error) {
+	schedulerID := strings.TrimSpace(request.GetSchedulerId())
+	if schedulerID == "" {
+		_, scheduler, err := h.resolveProjectScheduler(ctx, request.GetProject(), request.GetAgentName())
+		return scheduler, err
+	}
+	if request.GetProject() != nil || strings.TrimSpace(request.GetAgentName()) != "" {
+		return model.ProjectSchedulerRecord{}, model.ClassifyError(model.ErrAmbiguous, "provide scheduler_id or project and agent_name, not both", nil)
+	}
+	store, ok := h.store.(projectSchedulerByIDStore)
+	if !ok {
+		return model.ProjectSchedulerRecord{}, fmt.Errorf("scheduler ID lookup store is required")
+	}
+	return store.GetProjectSchedulerByID(ctx, schedulerID)
+}

--- a/pkg/agentcompose/api/project_scheduler_lookup_test.go
+++ b/pkg/agentcompose/api/project_scheduler_lookup_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+func TestGetSchedulerSupportsGlobalSchedulerID(t *testing.T) {
+	store := &schedulerIDLookupStore{
+		project: domain.ProjectRecord{ID: "project-1"},
+		scheduler: domain.ProjectSchedulerRecord{
+			ID:          "scheduler-1",
+			ProjectID:   "project-1",
+			AgentName:   "worker",
+			SchedulerID: "scheduler-1",
+			SpecJSON:    `{"enabled":true,"script":"run()"}`,
+		},
+	}
+	handler := NewProjectHandler(nil, store)
+
+	response, err := handler.GetScheduler(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRequest{SchedulerId: " scheduler-1 "}))
+	if err != nil {
+		t.Fatalf("GetScheduler by scheduler ID returned error: %v", err)
+	}
+	if got := response.Msg.GetScheduler(); got.GetSchedulerId() != "scheduler-1" || got.GetProjectId() != "project-1" || got.GetAgentName() != "worker" {
+		t.Fatalf("GetScheduler by scheduler ID = %#v", got)
+	}
+	if response.Msg.GetSpec().GetScript() != "run()" {
+		t.Fatalf("GetScheduler spec = %#v", response.Msg.GetSpec())
+	}
+	if store.schedulerIDLookups != 1 || store.lastSchedulerID != "scheduler-1" || store.schedulerLists != 0 {
+		t.Fatalf("lookup calls=%d id=%q list calls=%d", store.schedulerIDLookups, store.lastSchedulerID, store.schedulerLists)
+	}
+}
+
+func TestGetSchedulerRejectsAmbiguousLookup(t *testing.T) {
+	store := &schedulerIDLookupStore{}
+	handler := NewProjectHandler(nil, store)
+
+	_, err := handler.GetScheduler(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRequest{
+		Project:     &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: "project-1"}},
+		AgentName:   "worker",
+		SchedulerId: "scheduler-1",
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("GetScheduler ambiguous lookup error = %v, want invalid_argument", err)
+	}
+	if store.schedulerIDLookups != 0 || store.schedulerLists != 0 {
+		t.Fatalf("ambiguous lookup accessed store: ID lookups=%d list calls=%d", store.schedulerIDLookups, store.schedulerLists)
+	}
+}
+
+func TestGetSchedulerKeepsProjectAgentLookup(t *testing.T) {
+	store := &schedulerIDLookupStore{
+		project: domain.ProjectRecord{ID: "project-1"},
+		scheduler: domain.ProjectSchedulerRecord{
+			ID:          "scheduler-1",
+			ProjectID:   "project-1",
+			AgentName:   "worker",
+			SchedulerID: "scheduler-1",
+			SpecJSON:    `{}`,
+		},
+	}
+	handler := NewProjectHandler(nil, store)
+
+	response, err := handler.GetScheduler(context.Background(), connect.NewRequest(&agentcomposev2.GetSchedulerRequest{
+		Project:   &agentcomposev2.ProjectRef{Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: "project-1"}},
+		AgentName: "worker",
+	}))
+	if err != nil || response.Msg.GetScheduler().GetSchedulerId() != "scheduler-1" {
+		t.Fatalf("GetScheduler by project and agent response=%#v err=%v", response, err)
+	}
+	if store.schedulerLists != 1 || store.schedulerIDLookups != 0 {
+		t.Fatalf("project-agent lookup list calls=%d ID lookups=%d", store.schedulerLists, store.schedulerIDLookups)
+	}
+}
+
+type schedulerIDLookupStore struct {
+	project            domain.ProjectRecord
+	scheduler          domain.ProjectSchedulerRecord
+	schedulerIDLookups int
+	lastSchedulerID    string
+	schedulerLists     int
+}
+
+func (s *schedulerIDLookupStore) GetProject(_ context.Context, projectID string) (domain.ProjectRecord, error) {
+	if s.project.ID != projectID {
+		return domain.ProjectRecord{}, sql.ErrNoRows
+	}
+	return s.project, nil
+}
+
+func (s *schedulerIDLookupStore) ListProjects(context.Context, domain.ProjectListOptions) (domain.ProjectListResult, error) {
+	return domain.ProjectListResult{Projects: []domain.ProjectRecord{s.project}}, nil
+}
+
+func (s *schedulerIDLookupStore) ListProjectAgents(context.Context, string) ([]domain.ProjectAgentRecord, error) {
+	return nil, nil
+}
+
+func (s *schedulerIDLookupStore) ListProjectSchedulers(context.Context, string) ([]domain.ProjectSchedulerRecord, error) {
+	s.schedulerLists++
+	return []domain.ProjectSchedulerRecord{s.scheduler}, nil
+}
+
+func (s *schedulerIDLookupStore) GetProjectSchedulerByID(_ context.Context, schedulerID string) (domain.ProjectSchedulerRecord, error) {
+	s.schedulerIDLookups++
+	s.lastSchedulerID = schedulerID
+	if s.scheduler.ID != schedulerID {
+		return domain.ProjectSchedulerRecord{}, domain.ResourceError(domain.ErrNotFound, "project scheduler", schedulerID, "scheduler not found", sql.ErrNoRows)
+	}
+	return s.scheduler, nil
+}
+
+func (s *schedulerIDLookupStore) GetProjectRevision(context.Context, string, int64) (domain.ProjectRevisionRecord, error) {
+	return domain.ProjectRevisionRecord{}, nil
+}

--- a/pkg/storage/configstore/project_scheduler_lookup.go
+++ b/pkg/storage/configstore/project_scheduler_lookup.go
@@ -1,0 +1,29 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chaitin/agent-compose/internal/projects"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+// GetProjectSchedulerByID returns an active project scheduler by its globally unique native ID.
+func (s *projectStore) GetProjectSchedulerByID(ctx context.Context, schedulerID string) (domain.ProjectSchedulerRecord, error) {
+	schedulerID = strings.TrimSpace(schedulerID)
+	row := s.db.QueryRowContext(ctx, `SELECT s.id, s.short_id, s.project_id, s.id, s.agent_name, s.revision, s.enabled, s.trigger_count, s.spec_json, s.created_at, s.updated_at
+		FROM project_scheduler s
+		JOIN project p ON p.id = s.project_id
+		WHERE s.id = ? AND p.removed_at = 0 AND s.revision = p.current_revision`, schedulerID)
+	item, err := projects.ScanProjectScheduler(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.ProjectSchedulerRecord{}, domain.ResourceError(domain.ErrNotFound, "project scheduler", schedulerID, fmt.Sprintf("project scheduler %s not found", schedulerID), err)
+		}
+		return domain.ProjectSchedulerRecord{}, fmt.Errorf("get project scheduler %s: %w", schedulerID, err)
+	}
+	return item, nil
+}

--- a/pkg/storage/configstore/project_scheduler_page_test.go
+++ b/pkg/storage/configstore/project_scheduler_page_test.go
@@ -46,8 +46,15 @@ func TestProjectSchedulerPageUsesStableCursorAndProjectQuery(t *testing.T) {
 	if err != nil || loaded.ID != "scheduler-record-a" || loaded.SchedulerID != loaded.ID {
 		t.Fatalf("get scheduler by native id = %#v, err = %v", loaded, err)
 	}
+	loadedByID, err := store.GetProjectSchedulerByID(ctx, "scheduler-record-a")
+	if err != nil || loadedByID.ID != "scheduler-record-a" || loadedByID.ProjectID != "project-a" || loadedByID.SchedulerID != loadedByID.ID {
+		t.Fatalf("get scheduler by global native id = %#v, err = %v", loadedByID, err)
+	}
 	if _, err := store.GetProjectScheduler(ctx, "project-a", "legacy-alias-a"); err == nil {
 		t.Fatal("get scheduler unexpectedly used compatibility scheduler_id")
+	}
+	if _, err := store.GetProjectSchedulerByID(ctx, "legacy-alias-a"); err == nil {
+		t.Fatal("global scheduler lookup unexpectedly used compatibility scheduler_id")
 	}
 	if loaded, err = store.SetProjectSchedulerEnabled(ctx, "project-a", "scheduler-record-a", false); err != nil || loaded.Enabled {
 		t.Fatalf("disable scheduler by native id = %#v, err = %v", loaded, err)


### PR DESCRIPTION
## Summary

- extend `GetScheduler` with an optional global `scheduler_id` lookup
- query `project_scheduler.id` directly instead of using `ListSchedulers` for single-scheduler lookup
- preserve the existing `project + agent_name` request shape and reject ambiguous requests

This allows the UI to resolve scheduler detail routes and actions by ID without fetching and paginating the entire scheduler list.

## Proto dependency

The `GetSchedulerRequest.scheduler_id` field landed separately in #692 and is published as `proto/v0.1.5`. This PR only moves the root requirement to `v0.1.5`; it no longer changes anything under `proto/`.

## Validation

- `go build ./...` and `go test ./pkg/agentcompose/api ./pkg/storage/configstore -run Scheduler` on the rebased head.
- Published proto steps (drop the replace, download `v0.1.5`, `go build ./...`): passed; `go mod verify`: all modules verified.
- `task lint` and `task build` were run before the rebase.

Full e2e was not run.
