### PR TITLE
build(proto): require the published proto module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,26 @@ jobs:
       - name: Run lint
         run: task lint
 
+  proto-version:
+    name: Published proto version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      # Every other job builds through the replace, against the proto/ in the
+      # working tree, so a proto change that was never tagged - or a tag the
+      # require was never moved to - looks fine here and breaks only for
+      # whoever depends on this module. Dropping the replace is the one build
+      # that actually exercises the version in go.mod.
+      - name: Build against the published proto module
+        run: |
+          go mod edit -dropreplace=github.com/chaitin/agent-compose/proto
+          GOFLAGS=-mod=mod go mod download github.com/chaitin/agent-compose/proto
+          go build ./...
+
   go-test:
     name: Go tests
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,7 @@ go 1.26.2
 
 require (
 	connectrpc.com/connect v1.19.2
-	// v0.0.0 resolves only through the replace at the bottom of this file,
-	// which does not reach anyone depending on this module. Point this at a
-	// real proto/vX.Y.Z before cutting the next release tag.
-	github.com/chaitin/agent-compose/proto v0.0.0
+	github.com/chaitin/agent-compose/proto v0.1.0
 	github.com/chaitin/ai-api-protocol-bridge v1.0.0
 	github.com/chzyer/readline v1.5.1
 	github.com/containerd/errdefs v1.0.0


### PR DESCRIPTION
接 #675。`proto/v0.1.0` 已发布,把占位版本换成真实版本。

## 改动

**`go.mod`** — `require .../proto v0.0.0` → `v0.1.0`,移除随之而来的三行警告注释。

`replace => ./proto` 保留:它让 proto 的改动可以先在本仓库开发和构建、之后再打 tag,并且对消费者不可见(消费者用的是 require 的版本)。

**`.github/workflows/ci.yml`** — 新增 `proto-version` job。

## 为什么需要这个 job

`replace` 带来的便利同时是个盲区:所有 job 都通过 replace 构建工作树里的 `proto/`,所以「proto 改了但没打新 tag」或「打了 tag 但 require 没跟着升」在 CI 里一律是绿的,只有下游会炸。丢掉 replace、按 go.mod 真正声明的版本构建,是唯一能验证这个版本号的构建。

```yaml
go mod edit -dropreplace=github.com/chaitin/agent-compose/proto
GOFLAGS=-mod=mod go mod download github.com/chaitin/agent-compose/proto
go build ./...
```

(需要 `go mod download` 是因为 go.sum 里没有 proto 的哈希 —— replace 指向本地路径时不需要。)

## 验证

- 构造偏移验证这条检查会红:在工作树的 proto 里加一个 `v0.1.0` 没有的符号并从根模块引用 —— 带 replace 构建通过(盲区复现),`proto-version` 的命令序列报 `undefined: agentcomposev2.SkewProbe`
- `go build ./...`、`task lint`(三个 module)通过
- CI 契约脚本 `test-{generated-proto,proto-breaking-ci,binary-ci,image-ci,installer-ci}-contract.sh` 全过
- 独立验证过 `proto/v0.1.0` 本身可消费:空模块 `go get github.com/chaitin/agent-compose/proto@v0.1.0` 后能编译并构造 `RunServiceClient`,依赖足迹是 connect + protobuf 两个

## 后续

`google.golang.org/protobuf` 仍钉在伪版本 `v1.36.12-0.20260120151049-f2248ac996af`,现在会传递给每个 proto 的消费者。应换成正式 release,单独处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

