### PR TITLE
feat(sdk): add a conversational Go SDK for agent-compose

### DIFF
--- a/pkg/storage/configstore/project_run_order_test.go
+++ b/pkg/storage/configstore/project_run_order_test.go
@@ -1,0 +1,75 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+// The run list's order is a contract, not an implementation detail. Clients
+// read the newest run of a conversation by asking for the first row — the Go
+// chat SDK's Lookup and EndSession both do, and EndSession stopping a stale
+// run would leave the live one, and its sandbox, behind. Pin the order here so
+// a change to the query has to come past this test.
+func TestListProjectRunsByOptionsReturnsNewestFirstAcrossPages(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.initSchema(ctx); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if _, err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-order", Name: "order"}); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	agentID := createRunEventTestAgent(t, runEventTestAgentSpec{Ctx: ctx, Store: store, ProjectID: "project-order", AgentName: "worker"})
+
+	// Insert oldest first, so a query that preserved insertion order would fail
+	// this test rather than pass it by accident. CreateProjectRun stamps
+	// created_at itself, so the ages are written afterwards; the column holds
+	// Unix seconds.
+	ages := map[string]int64{"run-oldest": 1_700_000_000, "run-middle": 1_700_000_060, "run-newest": 1_700_000_120}
+	for _, runID := range []string{"run-oldest", "run-middle", "run-newest"} {
+		if _, err := store.CreateProjectRun(ctx, domain.ProjectRunRecord{
+			RunID: runID, ProjectID: "project-order", AgentName: "worker", AgentID: agentID,
+			Status: domain.ProjectRunStatusRunning,
+		}); err != nil {
+			t.Fatalf("create %s: %v", runID, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE project_run SET created_at = ? WHERE run_id = ?`, ages[runID], runID); err != nil {
+			t.Fatalf("age %s: %v", runID, err)
+		}
+	}
+
+	all, err := store.ListProjectRunsByOptions(ctx, domain.ProjectRunListOptions{ProjectID: "project-order"})
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	want := []string{"run-newest", "run-middle", "run-oldest"}
+	if len(all) != len(want) {
+		t.Fatalf("listed %d runs, want %d", len(all), len(want))
+	}
+	for index, runID := range want {
+		if all[index].RunID != runID {
+			t.Fatalf("run %d = %s, want %s: the list must be newest first", index, all[index].RunID, runID)
+		}
+	}
+
+	// A client that wants only the newest run asks for one row, so the first
+	// page of one has to be the newest and not merely some matching run.
+	first, err := store.ListProjectRunsByOptions(ctx, domain.ProjectRunListOptions{ProjectID: "project-order", Limit: 1})
+	if err != nil {
+		t.Fatalf("list newest run: %v", err)
+	}
+	if len(first) != 1 || first[0].RunID != "run-newest" {
+		t.Fatalf("first page = %#v, want just run-newest", first)
+	}
+
+	// Paging continues in the same order, so a walk sees every run once.
+	page, err := store.ListProjectRunsByOptions(ctx, domain.ProjectRunListOptions{ProjectID: "project-order", Offset: 1, Limit: 1})
+	if err != nil {
+		t.Fatalf("list second page: %v", err)
+	}
+	if len(page) != 1 || page[0].RunID != "run-middle" {
+		t.Fatalf("second page = %#v, want just run-middle", page)
+	}
+}

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -280,6 +280,9 @@ and allows one `Reply` in flight at a time; a second `Send` returns `ErrBusy`.
   conversation's label, but a `Close` fast enough to beat the daemon's own
   creation of that run finds nothing to stop — closing that sliver means the
   daemon not keeping a run whose client left before the handshake finished.
+  `Close` bounds its own daemon calls to a few seconds so an unresponsive
+  daemon cannot hang a shutdown; when it gives up it says so, and the run it
+  could not stop is still reachable through `EndSession`.
 - **Resending a lost turn is deduplicated in history, not in execution.** The
   message carries a client frame ID the daemon keys its persisted identity on,
   so the resend is recorded once. The daemon still hands the message to the

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,276 @@
+# agent-compose chat SDK for Go
+
+A client for holding a conversation with an agent-compose Agent.
+
+```go
+client, err := chat.New(chat.Config{
+    BaseURL: "http://127.0.0.1:7410",
+    Token:   chat.StaticToken(os.Getenv("AGENT_COMPOSE_AUTH_TOKEN")),
+})
+if err != nil {
+    return err
+}
+agent := client.Agent("review-project", "reviewer")
+
+conversation := agent.Start()
+defer func() { _ = conversation.Close(ctx) }()
+
+reply, err := conversation.Send(ctx, "check this PR")
+if err != nil {
+    return err
+}
+for event, err := range reply.Events(ctx) {
+    if err != nil {
+        return err
+    }
+    if delta, ok := event.(*chat.TextDeltaEvent); ok {
+        fmt.Print(delta.Text)
+    }
+}
+```
+
+Or, when only the answer matters:
+
+```go
+message, err := conversation.Ask(ctx, "check this PR")
+```
+
+## Finding an agent
+
+`Agent` takes a project ID and an agent name. `Projects` is how a product
+learns them, so a chooser does not need them configured out of band:
+
+```go
+projects, err := client.Projects(ctx)
+for _, project := range projects {
+    for _, agent := range project.Agents {
+        if agent.Available {
+            fmt.Println(project.ID, agent.Name, agent.DisplayName)
+        }
+    }
+}
+```
+
+An agent that is disabled, or whose configuration did not validate, is listed
+with `Available` false and a `Unavailable` reason rather than hidden: someone
+looking for it should see that it exists.
+
+## The model
+
+A `Conversation` is a durable thread of turns with one Agent. `Send`
+contributes a message and returns a `Reply` that streams while the agent works.
+Persist `conversation.ID()`; `agent.Open(ctx, id)` resumes the thread later,
+from another process or another replica.
+
+Nothing in this package exposes the daemon's Run, Sandbox, or attach-frame
+vocabulary. The SDK owns the three things the daemon deliberately does not
+model: the conversation's identity, the ordering of its turns, and the
+continuity of the environment they run in.
+
+## Finding conversations again
+
+`Open` needs an ID, which a product normally already has against its own thread
+record. Two questions come up when it does not, and they cost very different
+things.
+
+**Is this conversation this user's?** `Lookup` answers in one call, because the
+run list's label filter answers it without reading a single label back:
+
+```go
+conversation := agent.Start(chat.WithLabels(map[string]string{"user": "alice"}))
+...
+info, ok, err := client.Lookup(ctx, id, map[string]string{"user": "alice"})
+```
+
+`ok` is false when no run carries both labels — the conversation does not exist,
+or is not hers, and the caller cannot tell which. That is the right answer for
+an authorization check, and it means a product does not have to trust its own
+record of who owns what.
+
+**Which conversations does this user have?** `Conversations` answers it, but a
+run summary deliberately carries no labels — they belong to a run's detail — so
+discovering which conversation each run belongs to costs one read per run:
+
+```go
+found, err := client.Conversations(ctx, chat.Search{
+    Labels: map[string]string{"user": "alice"},
+})
+```
+
+Keep your own index of the IDs you created and call `Open` directly; use this to
+rebuild that index, not to draw a list on every page load. A conversation that
+has been rebuilt occupies several runs and is folded into one entry described by
+the most recent, with `Live` reporting whether that environment is still up.
+
+What comes back either way is only what the server holds. A title, an unread
+marker, or anything else a product invents about a conversation stays the
+product's to keep: run labels are fixed when a run starts, so they cannot carry
+a name that has to be changeable.
+
+## Continuity
+
+Turns share one environment, and that environment is what carries the agent's
+context forward. A run ending stops that environment, but stopping is not
+losing it: the sandbox keeps the workspace and the directories a provider
+stores its session in, so every new run asks the daemon to resume the sandbox
+the conversation last had rather than starting from nothing. `Continuity()` reports `Restarted`
+only once that resume actually fails to happen, not merely because a new run
+was needed:
+
+```go
+if conversation.Continuity() == chat.Restarted {
+    ui.Notice("this conversation's context was reset")
+}
+```
+
+Losing the network is not losing the environment. A dropped stream fails the
+turn in flight but keeps the conversation `Continuous`, and the next `Send`
+reattaches to the same session.
+
+## Ending a session
+
+`Close(ctx)` releases everything the handle is holding: its stream, and the run
+behind it, whose environment the daemon then stops. The conversation itself
+survives — its durable history and identity are untouched, `Lookup` and
+`Conversations` keep finding it, and `Agent.Open` resumes it later.
+
+Closing has to end the run. A conversation attaches with the detach disconnect
+policy, because a turn must survive the browser tab that started it going
+away; the cost is that a dropped stream leaves the run — and the sandbox it
+holds — alive, and nothing on the daemon side expires it. A `Close` that only
+dropped the stream would leave one running environment per conversation ever
+opened. `defer conversation.Close(ctx)` is the right default precisely because
+it does not.
+
+Resuming after a close asks the daemon to reuse the conversation's last
+sandbox. `Continuity` reports `Continuous` when that succeeds and `Restarted`
+when the sandbox is gone and a replacement is built. Nothing here makes a
+conversation's history or identity irrecoverable.
+
+`Client.EndSession(ctx, id)` does the same thing addressed by ID, for a
+conversation no handle of yours is attached to — after a restart, say, when
+your own sessions are gone but the daemon's runs are not. It finds the run
+through the label every conversation's runs carry. Ending a session that has
+already ended is not an error.
+
+A handle that never attached holds no run, so closing it is free, and in
+particular it cannot end a run some other handle is holding — which matters
+when two handles race to attach to the same conversation and the loser is
+discarded.
+
+## Reading history
+
+`History(ctx)` fetches every message the conversation has ever had, which is
+fine for a short thread but costs one request per page of every run the
+conversation has occupied. `HistoryPage` fetches events in bounded pages and
+walks backward from the most recent message; it still discovers the
+conversation's run list first, so a conversation with many historical runs is
+not free to open:
+
+```go
+page, err := conversation.HistoryPage(ctx, chat.HistoryOptions{Limit: 30})
+// page.Messages is the 30 most recent, oldest first.
+older, err := conversation.HistoryPage(ctx, chat.HistoryOptions{Limit: 30, Before: page.Cursor})
+// page.Cursor is "" once there is nothing older.
+```
+
+Use `HistoryPage` for a chat UI that loads recent messages first and fetches
+further back only when the reader scrolls up; `History` remains the
+convenience for a caller that genuinely wants the whole thread at once.
+
+## Events
+
+`Reply.Events` yields the provider-neutral agent event model, so the same code
+handles every provider:
+
+```go
+switch typed := event.(type) {
+case *chat.TextDeltaEvent:   ui.Append(typed.Text)
+case *chat.ToolCallEvent:    ui.ToolCard(typed.ID, typed.Name, typed.ToolKind)
+case *chat.ToolResultEvent:  ui.ToolDone(typed.ID, typed.OK, typed.Output)
+case *chat.UsageEvent:       meter.Add(typed.Scope, typed.InputTokens, typed.OutputTokens)
+}
+```
+
+Two rules the event model carries, both measured against real provider runs:
+
+- **`UsageEvent.Scope` differs between providers.** Some report per step, some
+  per turn, some per run. Never sum records of differing scope.
+- **Group tool events by `Step`, never by the `step_start`/`step_end`
+  interval.** Some providers close a step before its tool events arrive.
+- **A `StepEndEvent` with `Scope == StepEndScopeRun` closes the turn/run, not
+  an individual step.** Consumers pairing step boundaries must ignore it.
+
+An optional field a provider does not report stays nil rather than becoming a
+zero value, so `Step == nil` and `Step` pointing at `0` stay distinguishable.
+Event kinds this build does not know are exposed as `RawEvent`, preserving the
+daemon's name, display text, and payload so provider extensions are not lost.
+
+Events are retained on the `Reply`: `Wait` and `Events` can be used together,
+in either order, and a second `Events` pass replays from the start.
+
+## Requirements
+
+Go 1.24 or newer. The SDK depends on `connectrpc.com/connect` and on
+`github.com/chaitin/agent-compose/proto`, the wire contract as its own module —
+so taking this SDK does not mean taking the daemon's dependencies. Requests are
+binary Protobuf over Connect; the daemon accepts JSON too, and
+`connect.WithProtoJSON()` on a hand-built client is how you would ask for it,
+usually only to read a capture.
+
+Conversations need **HTTP/2**, which the Connect protocol requires for
+bidirectional streams. The default HTTP client handles both h2c (plaintext, as
+the daemon serves it) and TLS. An HTTP/1-only proxy between the client and the
+daemon will break conversations, and the SDK says so rather than failing
+obscurely.
+
+## Errors
+
+Classify with `errors.Is` against `ErrInvalidArgument`, `ErrNotFound`,
+`ErrPermission`, `ErrUnavailable`, `ErrConflict`, `ErrBusy` and `ErrClosed`.
+`*Error` carries the daemon's own `Code`, `Status` and `Message` for logging.
+
+`ErrConflict` is the daemon refusing to hand over something it gives to one
+holder at a time, a run's input being the one this SDK meets: reattaching just
+after losing a stream can arrive before the previous attachment has let go.
+Retrying shortly is usually right.
+
+## Concurrency
+
+A `Client` and an `Agent` are safe for concurrent use. A `Conversation` is not,
+and allows one `Reply` in flight at a time; a second `Send` returns `ErrBusy`.
+
+## Known gaps
+
+- **`Reply.Interrupt` ends the conversation's session, not just the turn.** The
+  daemon's cancel cancels the whole interactive execution, so the next `Send`
+  needs a new run — which asks to resume the same sandbox, same as any other
+  run boundary. A turn-scoped cancel needs daemon support.
+- **Provider event vocabularies differ.** The SDK has typed variants for the
+  provider-neutral schema and treats the legacy generic `output` event as a
+  text delta. Other provider-defined Attach events are returned as `RawEvent`;
+  the daemon does not rewrite them for a particular provider.
+- **A detached run never expires on its own.** The daemon keeps a run alive
+  when its client disconnects and has no idle timeout for one, so a process
+  that exits without closing its conversations leaves a run — and a sandbox —
+  behind for each of them. Close them on the way out; recovering the ones a
+  crash left behind means finding them through their labels.
+- **`History` and `HistoryPage` return only user and assistant text.** Tool
+  calls, reasoning, usage, and every other event kind are turn-scoped and not
+  durable messages; replaying a turn's full activity trace after a reload
+  needs the live stream, not history.
+
+## Examples
+
+A terminal client:
+
+```bash
+export AGENT_COMPOSE_AUTH_TOKEN=optional-token
+go run ./examples/chat -project my-project -agent my-agent
+go run ./examples/chat -project my-project -agent my-agent -conversation conv_1a2b3c
+```
+
+A browser chat UI lives in [`chatui`](../../chatui), which is also the answer
+to "why not talk to the daemon from the browser directly": a browser cannot,
+because Connect needs HTTP/2 bidirectional streaming for a multi-turn session
+and a `fetch()` with a streaming request body is half duplex.

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -94,8 +94,17 @@ discovering which conversation each run belongs to costs one read per run:
 ```go
 found, err := client.Conversations(ctx, chat.Search{
     Labels: map[string]string{"user": "alice"},
+    Limit:  500, // a budget over the whole walk; omit it to read every match
 })
+if err != nil && !errors.Is(err, chat.ErrIncomplete) {
+    return err
+}
 ```
+
+An unbounded search walks every matching run, one detail read each, so on a
+long-lived daemon it costs one request per run. `Search.Limit` is how you refuse
+to pay that, and a search that runs out of budget returns what it found
+alongside `ErrIncomplete` — a subset is never passed off as the whole list.
 
 Keep your own index of the IDs you created and call `Open` directly; use this to
 rebuild that index, not to draw a list on every page load. A conversation that
@@ -227,8 +236,13 @@ obscurely.
 ## Errors
 
 Classify with `errors.Is` against `ErrInvalidArgument`, `ErrNotFound`,
-`ErrPermission`, `ErrUnavailable`, `ErrConflict`, `ErrBusy` and `ErrClosed`.
-`*Error` carries the daemon's own `Code`, `Status` and `Message` for logging.
+`ErrPermission`, `ErrUnavailable`, `ErrConflict`, `ErrBusy`, `ErrClosed` and
+`ErrIncomplete`. `*Error` carries the daemon's own `Code`, `Status` and
+`Message` for logging.
+
+`ErrIncomplete` is the one that comes back with a usable result: `Conversations`
+returns it when `Search.Limit` ran out before the matching runs did, so the list
+is real but partial.
 
 `ErrConflict` is the daemon refusing to hand over something it gives to one
 holder at a time, a run's input being the one this SDK meets: reattaching just

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -275,7 +275,11 @@ and allows one `Reply` in flight at a time; a second `Send` returns `ErrBusy`.
   when its client disconnects and has no idle timeout for one, so a process
   that exits without closing its conversations leaves a run — and a sandbox —
   behind for each of them. Close them on the way out; recovering the ones a
-  crash left behind means finding them through their labels.
+  crash left behind means finding them through their labels. `Close` covers the
+  run whose start frame had not arrived yet by looking it up under the
+  conversation's label, but a `Close` fast enough to beat the daemon's own
+  creation of that run finds nothing to stop — closing that sliver means the
+  daemon not keeping a run whose client left before the handshake finished.
 - **Resending a lost turn is deduplicated in history, not in execution.** The
   message carries a client frame ID the daemon keys its persisted identity on,
   so the resend is recorded once. The daemon still hands the message to the

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -235,6 +235,13 @@ holder at a time, a run's input being the one this SDK meets: reattaching just
 after losing a stream can arrive before the previous attachment has let go.
 Retrying shortly is usually right.
 
+A `Reply` that fails because the stream broke leaves the turn's **outcome
+unknown**: the run was asked to survive its viewer, so the agent may well have
+finished. Resending the same text is how to recover, and resending it
+immediately does not record the message twice — it travels under the identity
+the lost turn already had. What it does not yet prevent is the agent working
+through that message a second time; see Known gaps.
+
 ## Concurrency
 
 A `Client` and an `Agent` are safe for concurrent use. A `Conversation` is not,
@@ -255,6 +262,14 @@ and allows one `Reply` in flight at a time; a second `Send` returns `ErrBusy`.
   that exits without closing its conversations leaves a run — and a sandbox —
   behind for each of them. Close them on the way out; recovering the ones a
   crash left behind means finding them through their labels.
+- **Resending a lost turn is deduplicated in history, not in execution.** The
+  message carries a client frame ID the daemon keys its persisted identity on,
+  so the resend is recorded once. The daemon still hands the message to the
+  agent again, so the turn can run twice; suppressing that needs the daemon to
+  stop forwarding a human message it has already recorded. The exception is a
+  run's **opening** turn, whose message is recorded under an identity derived
+  from the run rather than from a frame ID: resending that one does duplicate.
+  A caller that cares reads `History` before resending.
 - **`History` and `HistoryPage` return only user and assistant text.** Tool
   calls, reasoning, usage, and every other event kind are turn-scoped and not
   durable messages; replaying a turn's full activity trace after a reload

--- a/sdk/go/chat/catalog.go
+++ b/sdk/go/chat/catalog.go
@@ -1,0 +1,143 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// catalogPageSize bounds one page of a project listing.
+const catalogPageSize = 200
+
+// Project is one project and the agents it offers, as a chat product needs
+// them: enough to let someone pick a counterpart, and nothing about how the
+// project is configured or deployed.
+type Project struct {
+	// ID is what [Client.Agent] takes as its project.
+	ID string
+	// Name is the project's own name, for display.
+	Name string
+	// Agents are the counterparts this project offers, in the order the daemon
+	// reports them.
+	Agents []AgentInfo
+}
+
+// AgentInfo describes one agent a conversation can be held with.
+type AgentInfo struct {
+	// Name is what [Client.Agent] takes as its agent.
+	Name string
+	// DisplayName and Description are for presentation, and may be empty.
+	DisplayName string
+	Description string
+	// Available reports whether a conversation can be started with this agent
+	// right now. An agent that is disabled, or whose image or model does not
+	// resolve, is listed but not available: a product usually shows it greyed
+	// out rather than hiding it, so the person can see it exists.
+	Available bool
+	// Unavailable, when Available is false, says why in the daemon's own
+	// terms. It is empty when the agent is available.
+	Unavailable string
+}
+
+// Projects lists the projects and agents this daemon can hold conversations
+// with.
+//
+// [Client.Agent] takes a project ID and an agent name, and until now the SDK
+// gave no way to learn either: a product had to be told them, or go around the
+// SDK to the daemon. This is that missing half.
+//
+// Agent detail lives on the project, not on the summary a listing returns, so
+// this makes one call per project. A project that disappears between the
+// listing and its expansion is skipped rather than failing the whole catalog:
+// projects come and go, and a chooser missing one entry is more useful than a
+// chooser that will not open.
+func (c *Client) Projects(ctx context.Context) ([]Project, error) {
+	var summaries []*agentcomposev2.ProjectSummary
+	for offset := uint32(0); ; {
+		listed, err := c.transport.projects.ListProjects(ctx, connect.NewRequest(&agentcomposev2.ListProjectsRequest{
+			Offset: offset, Limit: catalogPageSize,
+		}))
+		if err != nil {
+			return nil, fromConnect("Projects", err)
+		}
+		page := listed.Msg.GetProjects()
+		summaries = append(summaries, page...)
+		if len(page) == 0 || offset+uint32(len(page)) >= listed.Msg.GetTotal() {
+			break
+		}
+		offset += uint32(len(page))
+	}
+	projects := make([]Project, 0, len(summaries))
+	for _, summary := range summaries {
+		project, err := c.project(ctx, summary.GetProjectId())
+		if err != nil {
+			if isNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		project.Name = summary.GetName()
+		projects = append(projects, project)
+	}
+	return projects, nil
+}
+
+func (c *Client) project(ctx context.Context, projectID string) (Project, error) {
+	detail, err := c.transport.projects.GetProject(ctx, connect.NewRequest(&agentcomposev2.GetProjectRequest{
+		Project: &agentcomposev2.ProjectRef{
+			Selector: &agentcomposev2.ProjectRef_ProjectId{ProjectId: projectID},
+		},
+	}))
+	if err != nil {
+		return Project{}, fromConnect("Projects", err)
+	}
+	found := detail.Msg.GetProject()
+	project := Project{
+		ID:     projectID,
+		Name:   found.GetSummary().GetName(),
+		Agents: make([]AgentInfo, 0, len(found.GetAgents())),
+	}
+	for _, agent := range found.GetAgents() {
+		name := strings.TrimSpace(agent.GetAgentName())
+		if name == "" {
+			continue
+		}
+		project.Agents = append(project.Agents, agentInfoOf(agent))
+	}
+	return project, nil
+}
+
+// agentInfoOf decides whether an agent can be conversed with. Availability is
+// an enum rather than a string on purpose: matching text for "available" also
+// matches "unavailable", which is the sort of mistake every caller would
+// otherwise have to avoid on its own.
+func agentInfoOf(agent *agentcomposev2.ProjectAgent) AgentInfo {
+	info := AgentInfo{
+		Name:        strings.TrimSpace(agent.GetAgentName()),
+		DisplayName: strings.TrimSpace(agent.GetDisplayName()),
+		Description: strings.TrimSpace(agent.GetDescription()),
+	}
+	switch {
+	case !agent.GetEnabled():
+		info.Unavailable = "the agent is disabled"
+	case agent.GetAvailability() == agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_UNAVAILABLE:
+		info.Unavailable = "the agent is unavailable"
+	case agent.GetAvailability() == agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_VALIDATION_FAILED:
+		info.Unavailable = "the agent's configuration did not validate"
+	default:
+		// UNSPECIFIED included: a daemon that does not report availability is
+		// not saying the agent is broken.
+		info.Available = true
+	}
+	return info
+}
+
+// isNotFound reports whether err is the daemon saying something is not there.
+func isNotFound(err error) bool {
+	var failure *Error
+	return errors.As(err, &failure) && strings.EqualFold(strings.TrimSpace(failure.Code), "not_found")
+}

--- a/sdk/go/chat/catalog_test.go
+++ b/sdk/go/chat/catalog_test.go
@@ -1,0 +1,145 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+func projectAgent(name string, enabled bool, availability agentcomposev2.ProjectAgentAvailability) *agentcomposev2.ProjectAgent {
+	return &agentcomposev2.ProjectAgent{
+		AgentName:    name,
+		DisplayName:  name + " display",
+		Description:  name + " description",
+		Enabled:      enabled,
+		Availability: availability,
+	}
+}
+
+// A product cannot call Agent(projectID, agentName) without knowing both, and
+// the SDK used to offer no way to learn either. This is that half.
+func TestProjectsListsEveryAgentAConversationCanBeHeldWith(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listProjects = func(*agentcomposev2.ListProjectsRequest) (*agentcomposev2.ListProjectsResponse, error) {
+		return &agentcomposev2.ListProjectsResponse{Projects: []*agentcomposev2.ProjectSummary{
+			{ProjectId: "p1", Name: "first"},
+			{ProjectId: "p2", Name: "second"},
+		}, Total: 2}, nil
+	}
+	daemon.getProject = func(request *agentcomposev2.GetProjectRequest) (*agentcomposev2.GetProjectResponse, error) {
+		agents := map[string][]*agentcomposev2.ProjectAgent{
+			"p1": {projectAgent("reviewer", true, agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_AVAILABLE)},
+			"p2": {projectAgent("writer", true, agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_AVAILABLE)},
+		}
+		id := request.GetProject().GetProjectId()
+		return &agentcomposev2.GetProjectResponse{Project: &agentcomposev2.Project{
+			Summary: &agentcomposev2.ProjectSummary{ProjectId: id},
+			Agents:  agents[id],
+		}}, nil
+	}
+
+	projects, err := daemon.client(t).Projects(context.Background())
+	if err != nil {
+		t.Fatalf("Projects: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("projects = %d, want 2", len(projects))
+	}
+	if projects[0].ID != "p1" || projects[0].Name != "first" {
+		t.Errorf("first project = %+v, want p1/first", projects[0])
+	}
+	if len(projects[0].Agents) != 1 || projects[0].Agents[0].Name != "reviewer" {
+		t.Fatalf("first project agents = %+v, want one named reviewer", projects[0].Agents)
+	}
+	agent := projects[0].Agents[0]
+	if !agent.Available || agent.Unavailable != "" {
+		t.Errorf("agent = %+v, want available", agent)
+	}
+	if agent.DisplayName != "reviewer display" || agent.Description != "reviewer description" {
+		t.Errorf("agent presentation = %+v, want the daemon's own display fields", agent)
+	}
+}
+
+// Availability is an enum, and matching it as text is a trap: "unavailable"
+// contains "available". An agent the daemon calls unavailable must not be
+// reported as one a conversation can start with.
+func TestProjectsReportsWhyAnAgentCannotBeUsed(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listProjects = func(*agentcomposev2.ListProjectsRequest) (*agentcomposev2.ListProjectsResponse, error) {
+		return &agentcomposev2.ListProjectsResponse{Projects: []*agentcomposev2.ProjectSummary{{ProjectId: "p1"}}}, nil
+	}
+	daemon.getProject = func(*agentcomposev2.GetProjectRequest) (*agentcomposev2.GetProjectResponse, error) {
+		return &agentcomposev2.GetProjectResponse{Project: &agentcomposev2.Project{Agents: []*agentcomposev2.ProjectAgent{
+			projectAgent("off", false, agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_AVAILABLE),
+			projectAgent("gone", true, agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_UNAVAILABLE),
+			projectAgent("broken", true, agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_VALIDATION_FAILED),
+			projectAgent("quiet", true, agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_UNSPECIFIED),
+		}}}, nil
+	}
+
+	projects, err := daemon.client(t).Projects(context.Background())
+	if err != nil {
+		t.Fatalf("Projects: %v", err)
+	}
+	want := map[string]bool{"off": false, "gone": false, "broken": false, "quiet": true}
+	for _, agent := range projects[0].Agents {
+		if agent.Available != want[agent.Name] {
+			t.Errorf("%s available = %v, want %v", agent.Name, agent.Available, want[agent.Name])
+		}
+		if !agent.Available && agent.Unavailable == "" {
+			t.Errorf("%s is unavailable but says nothing about why", agent.Name)
+		}
+		if agent.Available && agent.Unavailable != "" {
+			t.Errorf("%s is available but carries a reason %q", agent.Name, agent.Unavailable)
+		}
+	}
+}
+
+// Projects come and go. One that is gone by the time its agents are read must
+// not take the whole chooser down with it.
+func TestProjectsSkipsAProjectThatDisappearsMidListing(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listProjects = func(*agentcomposev2.ListProjectsRequest) (*agentcomposev2.ListProjectsResponse, error) {
+		return &agentcomposev2.ListProjectsResponse{Projects: []*agentcomposev2.ProjectSummary{
+			{ProjectId: "gone"}, {ProjectId: "here", Name: "here"},
+		}}, nil
+	}
+	daemon.getProject = func(request *agentcomposev2.GetProjectRequest) (*agentcomposev2.GetProjectResponse, error) {
+		if request.GetProject().GetProjectId() == "gone" {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no such project"))
+		}
+		return &agentcomposev2.GetProjectResponse{Project: &agentcomposev2.Project{
+			Agents: []*agentcomposev2.ProjectAgent{
+				projectAgent("reviewer", true, agentcomposev2.ProjectAgentAvailability_PROJECT_AGENT_AVAILABILITY_AVAILABLE),
+			},
+		}}, nil
+	}
+
+	projects, err := daemon.client(t).Projects(context.Background())
+	if err != nil {
+		t.Fatalf("Projects: %v", err)
+	}
+	if len(projects) != 1 || projects[0].ID != "here" {
+		t.Fatalf("projects = %+v, want only the one that still exists", projects)
+	}
+}
+
+// A daemon that is failing for some other reason is not a missing project,
+// and must not be quietly dropped from the catalog.
+func TestProjectsReportsAFailureThatIsNotAMissingProject(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listProjects = func(*agentcomposev2.ListProjectsRequest) (*agentcomposev2.ListProjectsResponse, error) {
+		return &agentcomposev2.ListProjectsResponse{Projects: []*agentcomposev2.ProjectSummary{{ProjectId: "p1"}}}, nil
+	}
+	daemon.getProject = func(*agentcomposev2.GetProjectRequest) (*agentcomposev2.GetProjectResponse, error) {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("the store is down"))
+	}
+
+	if _, err := daemon.client(t).Projects(context.Background()); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Projects error = %v, want ErrUnavailable", err)
+	}
+}

--- a/sdk/go/chat/client.go
+++ b/sdk/go/chat/client.go
@@ -1,0 +1,146 @@
+package chat
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"maps"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// conversationLabel is the run label carrying a conversation's identity. It is
+// how a conversation is found again from another process.
+const conversationLabel = "chat.conversation"
+
+// defaultUserAgent identifies this client to the daemon.
+const defaultUserAgent = "agent-compose-chat-go/0.1"
+
+// TokenSource resolves a bearer token for one request. It is called per
+// request, so it can refresh a short-lived credential.
+type TokenSource func(context.Context) (string, error)
+
+// StaticToken returns a TokenSource that always yields token.
+func StaticToken(token string) TokenSource {
+	return func(context.Context) (string, error) { return token, nil }
+}
+
+// Config configures a [Client].
+type Config struct {
+	// BaseURL is the daemon's HTTP address, such as "http://127.0.0.1:7410".
+	BaseURL string
+	// Token authenticates each request. It may be nil for an unauthenticated
+	// daemon.
+	Token TokenSource
+	// HTTPClient replaces the default. It must reach the daemon over HTTP/2,
+	// which conversations require; the default handles both h2c and TLS.
+	HTTPClient *http.Client
+	// UserAgent is appended to this package's own User-Agent.
+	UserAgent string
+}
+
+// Client connects to one agent-compose daemon. It is safe for concurrent use.
+type Client struct {
+	transport *transport
+}
+
+// New validates cfg and returns a Client.
+func New(cfg Config) (*Client, error) {
+	raw := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	base, err := url.Parse(raw)
+	if err != nil || base.Host == "" {
+		return nil, invalidArgument("New", "base URL %q is not an absolute HTTP URL", cfg.BaseURL)
+	}
+	if base.Scheme != "http" && base.Scheme != "https" {
+		return nil, invalidArgument("New", "base URL scheme must be http or https, got %q", base.Scheme)
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = defaultHTTPClient(base)
+	}
+	agent := defaultUserAgent
+	if extra := strings.TrimSpace(cfg.UserAgent); extra != "" {
+		agent += " " + extra
+	}
+	return &Client{transport: newTransport(raw, client, cfg.Token, agent)}, nil
+}
+
+// Agent returns a handle for conversing with one Agent of one Project.
+func (c *Client) Agent(projectID, agentName string) *Agent {
+	return &Agent{
+		client:    c,
+		projectID: strings.TrimSpace(projectID),
+		name:      strings.TrimSpace(agentName),
+	}
+}
+
+// Agent is one conversational counterpart. It is safe for concurrent use.
+type Agent struct {
+	client    *Client
+	projectID string
+	name      string
+}
+
+// ProjectID reports the Project this Agent belongs to.
+func (a *Agent) ProjectID() string { return a.projectID }
+
+// Name reports the Agent's name.
+func (a *Agent) Name() string { return a.name }
+
+// Option adjusts how a conversation is created or resumed.
+type Option func(*options)
+
+type options struct {
+	id            string
+	labels        map[string]string
+	restartIfGone bool
+}
+
+// WithID sets the conversation's identity instead of generating one. Pass a
+// value the product already owns, such as its own thread ID.
+func WithID(id string) Option {
+	return func(o *options) { o.id = strings.TrimSpace(id) }
+}
+
+// WithLabels attaches additional labels, which [Agent.Open] and the daemon's
+// own tooling can filter on. The key naming this package uses for identity is
+// reserved and ignored here.
+func WithLabels(labels map[string]string) Option {
+	return func(o *options) {
+		o.labels = maps.Clone(labels)
+		delete(o.labels, conversationLabel)
+	}
+}
+
+// WithRestartIfGone controls what [Agent.Open] does when the conversation's
+// environment no longer exists. The default rebuilds it and reports
+// [Restarted]; false makes Open return [ErrNotFound] instead.
+func WithRestartIfGone(restart bool) Option {
+	return func(o *options) { o.restartIfGone = restart }
+}
+
+func newOptions(opts []Option) *options {
+	resolved := &options{restartIfGone: true}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(resolved)
+		}
+	}
+	if resolved.id == "" {
+		resolved.id = newConversationID()
+	}
+	return resolved
+}
+
+// newConversationID returns an identifier unlikely to collide with one another
+// product chose, since the daemon's label space is shared.
+func newConversationID() string {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "conv_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return "conv_" + hex.EncodeToString(raw[:])
+}

--- a/sdk/go/chat/client.go
+++ b/sdk/go/chat/client.go
@@ -144,3 +144,13 @@ func newConversationID() string {
 	}
 	return "conv_" + hex.EncodeToString(raw[:])
 }
+
+// newFrameID returns the identity one turn's message travels under, which the
+// daemon uses to recognise a resent message as one it already recorded.
+func newFrameID() string {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "turn_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return "turn_" + hex.EncodeToString(raw[:])
+}

--- a/sdk/go/chat/conversation.go
+++ b/sdk/go/chat/conversation.go
@@ -48,6 +48,12 @@ type Conversation struct {
 	sentText     string
 	retryFrameID string
 	retryText    string
+	// pendingRun records that this handle asked the daemon to start a run and
+	// has not yet been told its ID. The daemon reports that ID asynchronously,
+	// in the start frame, so between the request and that frame there is a run
+	// — holding a sandbox, and asked to survive a disconnect — that this handle
+	// cannot yet name. Close has to end it anyway.
+	pendingRun bool
 }
 
 // Start returns a new conversation with this Agent.
@@ -277,13 +283,21 @@ func (c *Conversation) History(ctx context.Context) ([]Message, error) {
 // ever ends it. A Close that only dropped the stream therefore left a run —
 // and the sandbox it holds — alive for every conversation ever opened.
 //
+// A run this handle started but was never named is stopped too. The daemon
+// reports a run's ID asynchronously, in the start frame, while [Conversation.Send]
+// returns as soon as the request is away — so a Close right after a Send can
+// arrive with a run already running and no ID to stop it by. Such a run is
+// found through the conversation's identity label instead.
+//
 // A handle that never attached holds no run, so closing it is free — in
 // particular it cannot end a run some other handle is holding. Use
 // [Client.EndSession] to end a session no handle of yours is attached to.
 func (c *Conversation) Close(ctx context.Context) error {
 	c.mu.Lock()
 	opened, current, cancel, runID := c.stream, c.current, c.cancel, c.runID
+	pending := c.pendingRun
 	c.stream, c.current, c.cancel = nil, nil, nil
+	c.pendingRun = false
 	c.closed = true
 	c.mu.Unlock()
 
@@ -293,22 +307,26 @@ func (c *Conversation) Close(ctx context.Context) error {
 	if cancel != nil {
 		cancel()
 	}
-	if opened == nil {
-		if runID == "" {
-			return nil
-		}
-		err := c.stopRun(ctx, runID)
-		if err == nil {
-			c.clearRunID(runID)
-		}
-		return err
-	}
-	// Deliberately not waiting for the reader: a daemon that has stopped
-	// answering must not be able to hold Close up. Cancelling the stream's
-	// context is what lets the reader finish.
+
 	var failures []error
-	if err := opened.CloseRequest(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
-		failures = append(failures, fromConnect("Close", err))
+	if opened != nil {
+		// Deliberately not waiting for the reader: a daemon that has stopped
+		// answering must not be able to hold Close up. Cancelling the stream's
+		// context is what lets the reader finish.
+		if err := opened.CloseRequest(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
+			failures = append(failures, fromConnect("Close", err))
+		}
+	}
+	// A lost stream is not a stopped run either: dropStream keeps a known run
+	// ID precisely because the run outlives its viewer, and a run whose start
+	// frame never arrived leaves nothing behind to keep. Both still need
+	// stopping, so the run to end is decided here rather than per branch.
+	if runID == "" && pending {
+		found, err := c.unnamedRun(ctx)
+		if err != nil {
+			failures = append(failures, err)
+		}
+		runID = found
 	}
 	if runID != "" {
 		if err := c.stopRun(ctx, runID); err != nil {
@@ -318,6 +336,30 @@ func (c *Conversation) Close(ctx context.Context) error {
 		}
 	}
 	return errors.Join(failures...)
+}
+
+// unnamedRun finds the run this handle started before the daemon said what it
+// was called, and returns an empty ID when there is none to find.
+//
+// The run carries this conversation's identity label, so it can be asked for
+// by that instead, and the newest run under the label is this one: the only
+// way to reach here is to have just asked for a new run, which by construction
+// is the most recent.
+//
+// One sliver stays open. A Close fast enough to beat the daemon's own creation
+// of the run finds either nothing, or the previous session's run — already
+// terminal, since a new run was being started in its place, and stopping a run
+// that has finished changes nothing. Closing that sliver properly means the
+// daemon not keeping a run whose client left before the handshake finished,
+// which is its call to make, not this package's.
+func (c *Conversation) unnamedRun(ctx context.Context) (string, error) {
+	run, err := c.agent.client.latestMatchingRun(ctx, "Close", Search{
+		Labels: map[string]string{conversationLabel: c.id},
+	})
+	if err != nil || run == nil {
+		return "", err
+	}
+	return run.GetRunId(), nil
 }
 
 func (c *Conversation) clearRunID(runID string) {
@@ -411,6 +453,10 @@ func (c *Conversation) attach(ctx context.Context, op, prompt string) error {
 	}
 	c.stream = opened
 	c.cancel = cancel
+	// The frame is away, so from the daemon's side a run may now exist. Only a
+	// start frame carrying a request creates one; a reattach names a run this
+	// handle already knows.
+	c.pendingRun = start.Request != nil
 	go c.readLoop(opened)
 	return nil
 }
@@ -459,6 +505,7 @@ func (c *Conversation) handle(stream *attachStream, frame *agentcomposev2.Attach
 		requested := c.sandboxID
 		c.runID = started.GetRunId()
 		c.sandboxID = started.GetSandboxId()
+		c.pendingRun = false
 		// A run starting is not by itself a restart: what matters is whether
 		// the sandbox this run got is the one the prior run used. requested
 		// is empty for a conversation's very first run, which is not a
@@ -559,6 +606,7 @@ func (c *Conversation) finishSession(stream *attachStream, err error, resultJSON
 	}
 	reply, cancel := c.current, c.cancel
 	c.current, c.stream, c.cancel, c.runID = nil, nil, nil, ""
+	c.pendingRun = false
 	c.sentFrameID, c.sentText = "", ""
 	c.retryFrameID, c.retryText = "", ""
 	c.mu.Unlock()

--- a/sdk/go/chat/conversation.go
+++ b/sdk/go/chat/conversation.go
@@ -20,6 +20,18 @@ import (
 // above 500.
 const historyPageSize = 200
 
+// closeCallBound caps how long [Conversation.Close] will wait on the daemon.
+//
+// Close promises that a daemon which has stopped answering cannot hold it up,
+// and it has daemon calls to make: stopping the run, and finding that run when
+// its start frame never arrived. Those two are correlated — a daemon too wedged
+// to name a run is a daemon that may not answer the lookup either — so the
+// promise needs a bound of its own rather than whatever context the caller
+// happened to pass. A caller's own deadline still wins when it is shorter.
+//
+// A variable so a test can shorten it; nothing outside this package sets it.
+var closeCallBound = 10 * time.Second
+
 // Conversation is a durable thread of turns with one Agent.
 //
 // It is not safe for concurrent use and allows one [Reply] in flight at a
@@ -292,6 +304,12 @@ func (c *Conversation) History(ctx context.Context) ([]Message, error) {
 // A handle that never attached holds no run, so closing it is free — in
 // particular it cannot end a run some other handle is holding. Use
 // [Client.EndSession] to end a session no handle of yours is attached to.
+//
+// Close talks to the daemon, and bounds itself doing so: its calls give up
+// after a few seconds, or sooner if ctx says so. A Close that gives up reports
+// the failure and may leave the run running — [Client.EndSession] reaches it
+// later by ID, which is also how a run outliving a crashed process is
+// recovered.
 func (c *Conversation) Close(ctx context.Context) error {
 	c.mu.Lock()
 	opened, current, cancel, runID := c.stream, c.current, c.cancel, c.runID
@@ -307,6 +325,12 @@ func (c *Conversation) Close(ctx context.Context) error {
 	if cancel != nil {
 		cancel()
 	}
+
+	// Everything below talks to the daemon. Bound it: the run this is trying to
+	// stop may be unnamed precisely because the daemon went quiet, and a
+	// cleanup call must not become the thing that hangs a shutdown.
+	ctx, giveUp := context.WithTimeout(ctx, closeCallBound)
+	defer giveUp()
 
 	var failures []error
 	if opened != nil {

--- a/sdk/go/chat/conversation.go
+++ b/sdk/go/chat/conversation.go
@@ -40,6 +40,14 @@ type Conversation struct {
 	continuity Continuity
 	current    *Reply
 	closed     bool
+	// sentFrameID identifies the message of the turn in flight, and
+	// retryFrameID that of a turn dropStream ended without an outcome.
+	// Resending the latter verbatim reuses its ID, which is what tells the
+	// daemon the second copy is the same message.
+	sentFrameID  string
+	sentText     string
+	retryFrameID string
+	retryText    string
 }
 
 // Start returns a new conversation with this Agent.
@@ -102,6 +110,10 @@ func (a *Agent) Open(ctx context.Context, id string, opts ...Option) (*Conversat
 	}
 	conversation.runID = run.GetRunId()
 	conversation.sandboxID = run.GetSandboxId()
+	// attach starts the read loop, and the frames it handles write these same
+	// fields. Everything from here on is shared state.
+	conversation.mu.Lock()
+	defer conversation.mu.Unlock()
 	if err := conversation.attach(ctx, "Open", ""); err != nil {
 		if !resolved.restartIfGone {
 			return nil, err
@@ -141,6 +153,14 @@ func (c *Conversation) RunID() string {
 
 // Send contributes a message and returns the agent's [Reply], which streams
 // while the agent works.
+//
+// A Reply that fails because the stream broke leaves the turn's outcome
+// unknown: the daemon was asked to keep the run alive without a viewer, so the
+// agent may well have finished the turn. Resending the same text is the way to
+// recover, and doing so immediately does not record the message twice — it
+// travels under the identity the lost turn already had. The agent can still
+// work through it a second time, so a caller that cares should read
+// [Conversation.History] before resending.
 func (c *Conversation) Send(ctx context.Context, text string) (*Reply, error) {
 	if strings.TrimSpace(text) == "" {
 		return nil, invalidArgument("Send", "message text is required")
@@ -156,6 +176,7 @@ func (c *Conversation) Send(ctx context.Context, text string) (*Reply, error) {
 	if c.current != nil && !c.current.Done() {
 		return nil, ErrBusy
 	}
+	frameID := c.turnFrameID(text)
 	if c.stream == nil {
 		// No live stream: either this is the conversation's first message, or
 		// an earlier one was lost. attach reattaches when a run survived and
@@ -171,16 +192,44 @@ func (c *Conversation) Send(ctx context.Context, text string) (*Reply, error) {
 			}
 			// A reattach start frame carries no prompt, so the message still
 			// has to be sent.
-			if err := c.stream.Send(humanMessage(text)); err != nil {
+			if err := c.stream.Send(humanMessage(text, frameID)); err != nil {
 				return nil, fromConnect("Send", err)
 			}
+		} else {
+			// The message went out as the new run's opening prompt, which the
+			// daemon records under an identity derived from the run itself.
+			// There is nothing for a frame ID to key, and no earlier copy for
+			// a resend to collide with: a resend of a turn that never reached
+			// a run starts a run of its own.
+			frameID = ""
 		}
-	} else if err := c.stream.Send(humanMessage(text)); err != nil {
+	} else if err := c.stream.Send(humanMessage(text, frameID)); err != nil {
 		return nil, fromConnect("Send", err)
 	}
+	c.sentFrameID, c.sentText = frameID, text
+	c.retryFrameID, c.retryText = "", ""
 	reply := newReply(c)
 	c.current = reply
 	return reply, nil
+}
+
+// turnFrameID returns the client frame ID this turn's message carries.
+//
+// The daemon keys a human message's persisted identity on this value, so a
+// turn that ended without an outcome and is then resent verbatim can reuse the
+// ID it already had: the daemon recognises the second copy as the message it
+// already recorded instead of writing it down twice.
+//
+// Only the Send immediately after such a break qualifies, and only for the
+// same text. Reuse is what collapses two copies into one message, so widening
+// it any further would start swallowing messages a person really did repeat.
+//
+// Callers must hold c.mu.
+func (c *Conversation) turnFrameID(text string) string {
+	if c.retryFrameID != "" && c.retryText == text {
+		return c.retryFrameID
+	}
+	return newFrameID()
 }
 
 // Ask sends a message and waits for the complete answer.
@@ -305,8 +354,7 @@ func (c *Conversation) interrupt(ctx context.Context, reply *Reply) error {
 // attach opens the interactive session. prompt is the opening message when
 // starting a new one, and empty when reattaching to an existing run.
 //
-// Callers must hold c.mu, except in Open where the conversation is not yet
-// shared.
+// Callers must hold c.mu.
 func (c *Conversation) attach(ctx context.Context, op, prompt string) error {
 	// The stream belongs to the conversation, not to this call: a Send whose
 	// context is a single HTTP request's must not take the session down with
@@ -385,8 +433,9 @@ func (c *Conversation) readLoop(stream *attachStream) {
 }
 
 // humanMessage builds the frame carrying one turn's message.
-func humanMessage(text string) *agentcomposev2.AttachAgentRunRequest {
+func humanMessage(text, frameID string) *agentcomposev2.AttachAgentRunRequest {
 	return &agentcomposev2.AttachAgentRunRequest{
+		ClientFrameId: frameID,
 		Frame: &agentcomposev2.AttachAgentRunRequest_HumanMessage{
 			HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text},
 		},
@@ -487,6 +536,10 @@ func (c *Conversation) takeReply() *Reply {
 	defer c.mu.Unlock()
 	reply := c.current
 	c.current = nil
+	// The turn reached its outcome, so there is nothing left to resend: the
+	// same text arriving later is a person saying it again, and must be
+	// recorded as its own message.
+	c.sentFrameID, c.sentText = "", ""
 	return reply
 }
 
@@ -506,6 +559,8 @@ func (c *Conversation) finishSession(stream *attachStream, err error, resultJSON
 	}
 	reply, cancel := c.current, c.cancel
 	c.current, c.stream, c.cancel, c.runID = nil, nil, nil, ""
+	c.sentFrameID, c.sentText = "", ""
+	c.retryFrameID, c.retryText = "", ""
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -532,6 +587,11 @@ func (c *Conversation) dropStream(stream *attachStream, err error) {
 	}
 	reply, cancel := c.current, c.cancel
 	c.current, c.stream, c.cancel = nil, nil, nil
+	// The turn's message may or may not have been recorded, so keep its frame
+	// ID: a resend of the same text is the same message, and reusing the ID is
+	// what stops the daemon from writing it down a second time.
+	c.retryFrameID, c.retryText = c.sentFrameID, c.sentText
+	c.sentFrameID, c.sentText = "", ""
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()

--- a/sdk/go/chat/conversation.go
+++ b/sdk/go/chat/conversation.go
@@ -1,0 +1,611 @@
+package chat
+
+import (
+	"cmp"
+	"connectrpc.com/connect"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// historyPageSize bounds one page of a history read. The daemon rejects pages
+// above 500.
+const historyPageSize = 200
+
+// Conversation is a durable thread of turns with one Agent.
+//
+// It is not safe for concurrent use and allows one [Reply] in flight at a
+// time; a [Conversation.Send] issued while an earlier Reply is still streaming
+// returns [ErrBusy].
+type Conversation struct {
+	agent  *Agent
+	id     string
+	labels map[string]string
+
+	mu     sync.Mutex
+	stream *attachStream
+	// cancel tears down the stream's own context. The stream outlives any one
+	// Send, so it must not borrow that call's context.
+	cancel     context.CancelFunc
+	runID      string
+	sandboxID  string
+	continuity Continuity
+	current    *Reply
+	closed     bool
+}
+
+// Start returns a new conversation with this Agent.
+//
+// It performs no I/O: the agent's environment is provisioned by the first
+// [Conversation.Send], whose message opens the session. A product can
+// therefore create a Conversation per UI thread and pay for it only once
+// someone actually writes something.
+func (a *Agent) Start(opts ...Option) *Conversation {
+	resolved := newOptions(opts)
+	return &Conversation{
+		agent:      a,
+		id:         resolved.id,
+		labels:     resolved.labels,
+		continuity: Continuous,
+	}
+}
+
+// Open resumes the conversation identified by id.
+//
+// When its environment is still alive, Open reattaches and
+// [Conversation.Continuity] reports [Continuous]. When the environment is
+// gone, Open by default returns a conversation that will rebuild it on the
+// next Send and reports [Restarted]; [WithRestartIfGone] set to false makes
+// Open return [ErrNotFound] instead. Earlier turns stay readable through
+// [Conversation.History] either way.
+func (a *Agent) Open(ctx context.Context, id string, opts ...Option) (*Conversation, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, invalidArgument("Open", "conversation ID is required")
+	}
+	resolved := newOptions(append([]Option{WithID(id)}, opts...))
+	conversation := &Conversation{agent: a, id: id, labels: resolved.labels}
+
+	run, err := conversation.latestRun(ctx, "Open")
+	if err != nil {
+		return nil, err
+	}
+	if run == nil || !runIsLive(run) {
+		if !resolved.restartIfGone {
+			return nil, &Error{Op: "Open", Code: "not_found", Message: "conversation " + id + " is no longer running"}
+		}
+		// A conversation whose last run has ended is the ordinary case, not a
+		// lost one: runs end whenever a client closes, and the sandbox they
+		// used survives with the workspace and the directories a provider
+		// keeps its session in. Carrying that sandbox forward is what lets the
+		// next run resume the conversation instead of building a new
+		// environment beside it.
+		//
+		// Whether the resume actually happened is not decided here: the
+		// daemon's start frame reports which sandbox the new run got, and
+		// handle compares it against the one asked for.
+		if run != nil {
+			conversation.sandboxID = run.GetSandboxId()
+		}
+		if conversation.sandboxID == "" {
+			conversation.continuity = Restarted
+		}
+		return conversation, nil
+	}
+	conversation.runID = run.GetRunId()
+	conversation.sandboxID = run.GetSandboxId()
+	if err := conversation.attach(ctx, "Open", ""); err != nil {
+		if !resolved.restartIfGone {
+			return nil, err
+		}
+		// The run could not be attached to, but the sandbox it used is still
+		// the one to resume; only the run is given up on.
+		conversation.runID = ""
+		return conversation, nil
+	}
+	conversation.continuity = Continuous
+	return conversation, nil
+}
+
+// ID reports the conversation's identity. Persist it to resume the
+// conversation later through [Agent.Open].
+func (c *Conversation) ID() string { return c.id }
+
+// Continuity reports whether this conversation kept the environment its
+// earlier turns ran in.
+func (c *Conversation) Continuity() Continuity {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.continuity == "" {
+		return Continuous
+	}
+	return c.continuity
+}
+
+// RunID reports the daemon-side identifier backing this conversation, for
+// correlating with daemon logs. It is empty before the first Send and changes
+// whenever the conversation restarts.
+func (c *Conversation) RunID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.runID
+}
+
+// Send contributes a message and returns the agent's [Reply], which streams
+// while the agent works.
+func (c *Conversation) Send(ctx context.Context, text string) (*Reply, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, invalidArgument("Send", "message text is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, ErrClosed
+	}
+	if c.current != nil && !c.current.Done() {
+		return nil, ErrBusy
+	}
+	if c.stream == nil {
+		// No live stream: either this is the conversation's first message, or
+		// an earlier one was lost. attach reattaches when a run survived and
+		// otherwise provisions a new environment, carrying this message as the
+		// opening prompt.
+		reattached := c.runID != ""
+		if err := c.attach(ctx, "Send", text); err != nil {
+			return nil, err
+		}
+		if reattached {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			// A reattach start frame carries no prompt, so the message still
+			// has to be sent.
+			if err := c.stream.Send(humanMessage(text)); err != nil {
+				return nil, fromConnect("Send", err)
+			}
+		}
+	} else if err := c.stream.Send(humanMessage(text)); err != nil {
+		return nil, fromConnect("Send", err)
+	}
+	reply := newReply(c)
+	c.current = reply
+	return reply, nil
+}
+
+// Ask sends a message and waits for the complete answer.
+func (c *Conversation) Ask(ctx context.Context, text string) (Message, error) {
+	reply, err := c.Send(ctx, text)
+	if err != nil {
+		return Message{}, err
+	}
+	return reply.Wait(ctx)
+}
+
+// History returns every message of the conversation, oldest first, including
+// turns that ran while no client was attached. Only user and assistant text
+// comes back; tool calls, reasoning, usage and every other event kind are
+// turn-scoped and not durable messages.
+//
+// This fetches the whole conversation, at a cost proportional to how many
+// runs it has occupied. A caller that wants a bounded, incremental read —
+// the common case for a chat UI's initial load — should use
+// [Conversation.HistoryPage] instead.
+func (c *Conversation) History(ctx context.Context) ([]Message, error) {
+	runs, err := c.runs(ctx, "History")
+	if err != nil {
+		return nil, err
+	}
+	messages := make([]Message, 0, len(runs)*4)
+	for _, run := range runs {
+		page, err := c.runMessages(ctx, run.GetRunId())
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, page...)
+	}
+	return messages, nil
+}
+
+// Close releases everything this handle is holding: its stream, and the run
+// behind it whose environment the daemon then stops. The conversation itself
+// survives — its history and identity are untouched, and a later
+// [Agent.Open] resumes it with the agent's context intact.
+//
+// Closing has to end the run. A conversation attaches with a disconnect
+// policy that deliberately keeps the run alive when the stream drops, because
+// a turn must survive its viewer going away; the cost is that nothing else
+// ever ends it. A Close that only dropped the stream therefore left a run —
+// and the sandbox it holds — alive for every conversation ever opened.
+//
+// A handle that never attached holds no run, so closing it is free — in
+// particular it cannot end a run some other handle is holding. Use
+// [Client.EndSession] to end a session no handle of yours is attached to.
+func (c *Conversation) Close(ctx context.Context) error {
+	c.mu.Lock()
+	opened, current, cancel, runID := c.stream, c.current, c.cancel, c.runID
+	c.stream, c.current, c.cancel = nil, nil, nil
+	c.closed = true
+	c.mu.Unlock()
+
+	if current != nil {
+		current.finish(nil, time.Time{}, ErrClosed)
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if opened == nil {
+		if runID == "" {
+			return nil
+		}
+		err := c.stopRun(ctx, runID)
+		if err == nil {
+			c.clearRunID(runID)
+		}
+		return err
+	}
+	// Deliberately not waiting for the reader: a daemon that has stopped
+	// answering must not be able to hold Close up. Cancelling the stream's
+	// context is what lets the reader finish.
+	var failures []error
+	if err := opened.CloseRequest(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		failures = append(failures, fromConnect("Close", err))
+	}
+	if runID != "" {
+		if err := c.stopRun(ctx, runID); err != nil {
+			failures = append(failures, err)
+		} else {
+			c.clearRunID(runID)
+		}
+	}
+	return errors.Join(failures...)
+}
+
+func (c *Conversation) clearRunID(runID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.runID == runID {
+		c.runID = ""
+	}
+}
+
+// interrupt stops the agent mid-turn.
+//
+// The daemon's cancel ends the whole interactive session, not just the
+// current turn, so the next Send needs a new run. That run asks to resume
+// the same sandbox, the same as any other run boundary; Continuity reports
+// whether it actually did.
+func (c *Conversation) interrupt(ctx context.Context, reply *Reply) error {
+	c.mu.Lock()
+	stream := c.stream
+	current := c.current
+	c.mu.Unlock()
+	if current != reply || reply.Done() {
+		return nil
+	}
+	if stream == nil {
+		return ErrClosed
+	}
+	_ = ctx
+	return fromConnect("Interrupt", stream.Send(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Cancel{Cancel: &agentcomposev2.AttachCancel{}},
+	}))
+}
+
+// attach opens the interactive session. prompt is the opening message when
+// starting a new one, and empty when reattaching to an existing run.
+//
+// Callers must hold c.mu, except in Open where the conversation is not yet
+// shared.
+func (c *Conversation) attach(ctx context.Context, op, prompt string) error {
+	// The stream belongs to the conversation, not to this call: a Send whose
+	// context is a single HTTP request's must not take the session down with
+	// it when that request ends. Values are kept, cancellation is not.
+	streamCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	opened := c.agent.client.transport.runs.AttachAgentRun(streamCtx)
+	start := &agentcomposev2.AttachAgentRunStart{
+		Mode:             agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
+		AttachStdin:      true,
+		DisconnectPolicy: agentcomposev2.AttachDisconnectPolicy_ATTACH_DISCONNECT_POLICY_DETACH,
+	}
+	if c.runID != "" {
+		start.RunId = c.runID
+	} else {
+		labels := maps.Clone(c.labels)
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[conversationLabel] = c.id
+		start.Request = &agentcomposev2.RunAgentRequest{
+			ProjectId: c.agent.projectID,
+			AgentName: c.agent.name,
+			Prompt:    prompt,
+			// One run serves every turn of an open session, so the
+			// environment already outlives a turn without being pinned:
+			// stopping it when the run itself ends is enough. Keeping it
+			// running instead left an environment alive for every
+			// conversation that had ever been opened, since a conversation
+			// ends far more often than it is archived.
+			//
+			// The sandbox survives the stop — the daemon keeps its metadata,
+			// workspace, and the mounted home directories where a provider
+			// stores the session it resumes from — so the next run asks for
+			// this same sandbox by ID and picks the conversation back up.
+			CleanupPolicy: agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION,
+			// A prior run's sandbox may still be alive even though that run
+			// ended — ask the daemon to resume it rather than starting from
+			// nothing. handle's Started case reports whether this actually
+			// happened.
+			SandboxId: c.sandboxID,
+			Labels:    labels,
+		}
+	}
+	// The opening frame is what makes the daemon answer: a Connect handler
+	// writes no response headers until it has received one, so a failure to
+	// open the stream surfaces here rather than at AttachAgentRun.
+	if err := opened.Send(&agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: start},
+	}); err != nil {
+		cancel()
+		_ = opened.CloseRequest()
+		_ = opened.CloseResponse()
+		return fromConnect(op, err)
+	}
+	c.stream = opened
+	c.cancel = cancel
+	go c.readLoop(opened)
+	return nil
+}
+
+// readLoop translates server frames until the stream ends.
+func (c *Conversation) readLoop(stream *attachStream) {
+	for {
+		frame, err := stream.Receive()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				err = nil
+			} else {
+				err = fromConnect("Send", err)
+			}
+			c.endSession(stream, err)
+			return
+		}
+		c.handle(stream, frame)
+	}
+}
+
+// humanMessage builds the frame carrying one turn's message.
+func humanMessage(text string) *agentcomposev2.AttachAgentRunRequest {
+	return &agentcomposev2.AttachAgentRunRequest{
+		Frame: &agentcomposev2.AttachAgentRunRequest_HumanMessage{
+			HumanMessage: &agentcomposev2.AttachHumanMessage{Text: text},
+		},
+	}
+}
+
+// stopRun ends the run backing this conversation.
+func (c *Conversation) stopRun(ctx context.Context, runID string) error {
+	_, err := c.agent.client.transport.runs.StopRun(ctx, connect.NewRequest(&agentcomposev2.StopRunRequest{
+		RunId:  runID,
+		Reason: "conversation closed",
+	}))
+	return fromConnect("Close", err)
+}
+
+func (c *Conversation) handle(stream *attachStream, frame *agentcomposev2.AttachAgentRunResponse) {
+	switch body := frame.GetFrame().(type) {
+	case *agentcomposev2.AttachAgentRunResponse_Started:
+		started := body.Started
+		c.mu.Lock()
+		requested := c.sandboxID
+		c.runID = started.GetRunId()
+		c.sandboxID = started.GetSandboxId()
+		// A run starting is not by itself a restart: what matters is whether
+		// the sandbox this run got is the one the prior run used. requested
+		// is empty for a conversation's very first run, which is not a
+		// restart either — there is nothing yet for it to have lost.
+		if requested != "" && started.GetSandboxId() != "" {
+			if started.GetSandboxId() == requested {
+				c.continuity = Continuous
+			} else {
+				c.continuity = Restarted
+			}
+		}
+		c.mu.Unlock()
+
+	case *agentcomposev2.AttachAgentRunResponse_AgentEvent:
+		at := c.eventTime(frame)
+		agentEvent := body.AgentEvent
+		event, err := decodeEvent(agentEvent.GetName(), []byte(agentEvent.GetPayloadJson()), at)
+		if err != nil || event == nil {
+			// A malformed typed payload is still a valid Attach event. Preserve
+			// its wire fields instead of losing it or failing the whole turn.
+			event = &RawEvent{eventAt: eventAt{Time: at}, Name: agentEvent.GetName()}
+		}
+		if raw, ok := event.(*RawEvent); ok {
+			raw.Text = agentEvent.GetText()
+			raw.PayloadJSON = agentEvent.GetPayloadJson()
+		}
+		if reply := c.reply(); reply != nil {
+			reply.add(event)
+		}
+
+	case *agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted:
+		if reply := c.takeReply(); reply != nil {
+			reply.finish(json.RawMessage(body.AgentTurnCompleted.GetResultJson()), c.eventTime(frame), nil)
+		}
+
+	case *agentcomposev2.AttachAgentRunResponse_Result:
+		var err error
+		if !body.Result.GetSuccess() {
+			err = &Error{Op: "Send", Message: cmp.Or(strings.TrimSpace(body.Result.GetError()), "the agent run failed")}
+		}
+		c.finishSession(stream, err, body.Result.GetResultJson(), c.eventTime(frame))
+
+	case *agentcomposev2.AttachAgentRunResponse_Error:
+		failure := &Error{Op: "Send", Code: body.Error.GetCode(), Message: body.Error.GetMessage()}
+		if body.Error.GetTerminal() {
+			c.endSession(stream, failure)
+			return
+		}
+		if reply := c.reply(); reply != nil {
+			reply.add(&ErrorEvent{
+				eventAt:  eventAt{Time: c.eventTime(frame)},
+				Severity: SeverityError,
+				Code:     body.Error.GetCode(),
+				Message:  body.Error.GetMessage(),
+			})
+		}
+	}
+}
+
+func (c *Conversation) eventTime(frame *agentcomposev2.AttachAgentRunResponse) time.Time {
+	if at := frame.GetCreatedAt(); at.IsValid() {
+		return at.AsTime()
+	}
+	return time.Now().UTC()
+}
+
+func (c *Conversation) reply() *Reply {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.current
+}
+
+func (c *Conversation) takeReply() *Reply {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	reply := c.current
+	c.current = nil
+	return reply
+}
+
+// finishSession records that the run itself reached a terminal state, so the
+// next Send must start a new one. The sandbox this run used is not
+// necessarily gone — CleanupPolicy asked the daemon to keep it running, and
+// the next attach asks to resume it — so Continuity is left as it was here;
+// handle's Started case sets it once that next attach reports whether the
+// resume actually happened.
+func (c *Conversation) finishSession(stream *attachStream, err error, resultJSON string, at time.Time) {
+	c.mu.Lock()
+	if c.stream != stream {
+		// A later attach already replaced this one. Its turn is not this
+		// loop's to end.
+		c.mu.Unlock()
+		return
+	}
+	reply, cancel := c.current, c.cancel
+	c.current, c.stream, c.cancel, c.runID = nil, nil, nil, ""
+	c.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if reply != nil {
+		reply.finish(json.RawMessage(resultJSON), at, err)
+	}
+}
+
+// dropStream records that this client lost the stream while the run may well
+// still be alive, which is what a network blip looks like. The run ID is kept
+// so the next Send reattaches to the same session rather than abandoning an
+// environment that still holds the conversation's context.
+//
+// A turn in flight still fails: its outcome is genuinely unknown here.
+func (c *Conversation) dropStream(stream *attachStream, err error) {
+	c.mu.Lock()
+	if c.stream != stream {
+		// This loop's stream is already gone — finished, closed, or replaced
+		// by a later attach. Tearing down what is there now would end a turn
+		// this loop has nothing to do with.
+		c.mu.Unlock()
+		return
+	}
+	reply, cancel := c.current, c.cancel
+	c.current, c.stream, c.cancel = nil, nil, nil
+	c.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if reply != nil {
+		reply.finish(nil, time.Time{}, err)
+	}
+}
+
+// endSession handles the stream ending, whether cleanly or in error.
+func (c *Conversation) endSession(stream *attachStream, err error) {
+	if err == nil {
+		err = &Error{Op: "Send", Code: "unavailable", Message: "the conversation stream ended before the turn completed"}
+	}
+	c.dropStream(stream, err)
+}
+
+// runs returns every run this conversation has occupied, oldest first.
+func (c *Conversation) runs(ctx context.Context, op string) ([]*agentcomposev2.RunSummary, error) {
+	var runs []*agentcomposev2.RunSummary
+	for offset := uint32(0); ; {
+		response, err := c.agent.client.transport.runs.ListRuns(ctx, connect.NewRequest(&agentcomposev2.ListRunsRequest{
+			ProjectId: c.agent.projectID, AgentName: c.agent.name,
+			Labels: map[string]string{conversationLabel: c.id},
+			Offset: offset, Limit: historyPageSize,
+		}))
+		if err != nil {
+			return nil, fromConnect(op, err)
+		}
+		page := response.Msg.GetRuns()
+		runs = append(runs, page...)
+		if len(page) == 0 || offset+uint32(len(page)) >= response.Msg.GetTotal() {
+			break
+		}
+		offset += uint32(len(page))
+	}
+	slices.SortStableFunc(runs, func(a, b *agentcomposev2.RunSummary) int {
+		return a.GetCreatedAt().AsTime().Compare(b.GetCreatedAt().AsTime())
+	})
+	return runs, nil
+}
+
+// latestRun returns the conversation's most recent run, or nil when it has
+// none.
+func (c *Conversation) latestRun(ctx context.Context, op string) (*agentcomposev2.RunSummary, error) {
+	runs, err := c.runs(ctx, op)
+	if err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	return runs[len(runs)-1], nil
+}
+
+// runMessages reads one run's durable messages, oldest first.
+func (c *Conversation) runMessages(ctx context.Context, runID string) ([]Message, error) {
+	messages := make([]Message, 0, historyPageSize)
+	for offset := uint32(0); ; {
+		response, err := c.agent.client.transport.runs.ListRunEvents(ctx, connect.NewRequest(&agentcomposev2.ListRunEventsRequest{
+			RunId: runID, Offset: offset, Limit: historyPageSize,
+		}))
+		if err != nil {
+			return nil, fromConnect("History", err)
+		}
+		events := response.Msg.GetEvents()
+		for _, event := range events {
+			if message, ok := messageFromEvent(event); ok {
+				messages = append(messages, message)
+			}
+		}
+		offset += uint32(len(events))
+		if len(events) == 0 || offset >= response.Msg.GetTotal() {
+			return messages, nil
+		}
+	}
+}

--- a/sdk/go/chat/conversation_test.go
+++ b/sdk/go/chat/conversation_test.go
@@ -118,36 +118,82 @@ func TestCloseReturnsEvenWhenTheDaemonStopsAnswering(t *testing.T) {
 		<-stream.hold
 	}
 
-	// Nothing answers, including the lookup Close makes for a run whose start
-	// frame never arrived — a daemon too wedged to name a run is exactly the
-	// one that will not answer that lookup either.
-	daemon.listRuns = func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
-		<-daemon.hold
-		return &agentcomposev2.ListRunsResponse{}, nil
-	}
-	daemon.stopRun = func(*agentcomposev2.StopRunRequest) (*agentcomposev2.StopRunResponse, error) {
-		<-daemon.hold
-		return &agentcomposev2.StopRunResponse{}, nil
-	}
-	shortenCloseBound(t, 100*time.Millisecond)
+	// The lookup Close makes for a run whose start frame never arrived goes
+	// unanswered too: a daemon too wedged to name a run is exactly the one that
+	// will not answer that lookup either.
+	daemon.listRuns = blockingListRuns(daemon)
+	bound := 100 * time.Millisecond
+	shortenCloseBound(t, bound)
 
 	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
 	if _, err := conversation.Send(context.Background(), "hi"); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	closed := make(chan error, 1)
 	// context.Background() on purpose: the bound has to be Close's own, not one
 	// the caller was careful enough to supply.
-	go func() { closed <- conversation.Close(context.Background()) }()
-	select {
-	case err := <-closed:
-		// Giving up is reported rather than passed off as a clean close: the
-		// run may still be running, and EndSession is how it gets stopped.
-		if err == nil {
-			t.Fatal("Close reported success while the daemon never answered its cleanup")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Close blocked on a daemon that stopped answering")
+	took, err := closeUnbounded(t, conversation, 5*time.Second)
+
+	// Giving up is reported rather than passed off as a clean close: the run
+	// may still be running, and EndSession is how it gets stopped.
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Close err = %v, want ErrUnavailable from giving up on the daemon", err)
+	}
+	// Returning before the bound would mean Close never really waited on the
+	// lookup — an error raised instead of the cleanup being attempted passes a
+	// bare non-nil check just as well.
+	if took < bound {
+		t.Errorf("Close returned after %s, inside its own %s bound: the lookup cannot have been attempted", took, bound)
+	}
+	if lookups := daemon.count("ListRuns"); lookups != 1 {
+		t.Errorf("looked the run up %d times, want 1", lookups)
+	}
+}
+
+// The ordinary close path — the run's ID is known, and StopRun is the one call
+// standing between the caller and a returned Close. It has to be bounded for
+// the same reason, and it is the path every well-behaved caller takes, so
+// losing the context binding here would go unnoticed by the unnamed-run test.
+func TestCloseGivesUpOnAStopRunThatNeverAnswers(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		// The run is named, so Close knows exactly what to stop.
+		stream.send(started("run-1", "sandbox-1"))
+		stream.send(turnCompleted(""))
+		<-stream.hold
+	}
+	daemon.stopRun = func(*agentcomposev2.StopRunRequest) (*agentcomposev2.StopRunResponse, error) {
+		<-daemon.hold
+		return &agentcomposev2.StopRunResponse{}, nil
+	}
+	bound := 100 * time.Millisecond
+	shortenCloseBound(t, bound)
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if conversation.RunID() != "run-1" {
+		t.Fatalf("run ID = %q, want the named run this test is about", conversation.RunID())
+	}
+
+	took, closeErr := closeUnbounded(t, conversation, 5*time.Second)
+	if !errors.Is(closeErr, ErrUnavailable) {
+		t.Fatalf("Close err = %v, want ErrUnavailable from giving up on StopRun", closeErr)
+	}
+	if took < bound {
+		t.Errorf("Close returned after %s, inside its own %s bound: StopRun cannot have been attempted", took, bound)
+	}
+	if stops := daemon.count("StopRun"); stops != 1 {
+		t.Errorf("issued %d stops, want 1: Close must try before it gives up", stops)
+	}
+	// No lookup: the run was named, so there was nothing to look up.
+	if lookups := daemon.count("ListRuns"); lookups != 0 {
+		t.Errorf("looked up %d runs for a named run, want 0", lookups)
 	}
 }
 
@@ -158,6 +204,39 @@ func shortenCloseBound(t *testing.T, bound time.Duration) {
 	previous := closeCallBound
 	closeCallBound = bound
 	t.Cleanup(func() { closeCallBound = previous })
+}
+
+// closeUnbounded closes with a context that imposes no deadline of its own, so
+// what bounds the call is Close, and reports how long that took. It fails the
+// test rather than hanging it when Close never returns.
+func closeUnbounded(t *testing.T, conversation *Conversation, guard time.Duration) (time.Duration, error) {
+	t.Helper()
+	type outcome struct {
+		took time.Duration
+		err  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		start := time.Now()
+		err := conversation.Close(context.Background())
+		done <- outcome{took: time.Since(start), err: err}
+	}()
+	select {
+	case got := <-done:
+		return got.took, got.err
+	case <-time.After(guard):
+		t.Fatal("Close blocked on a daemon that stopped answering")
+		return 0, nil
+	}
+}
+
+// blockingListRuns is a daemon that accepts a run list request and never
+// answers it, the way an unresponsive one does.
+func blockingListRuns(daemon *fakeDaemon) func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+	return func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+		<-daemon.hold
+		return &agentcomposev2.ListRunsResponse{}, nil
+	}
 }
 
 func TestSendStreamsATurnAndAccumulatesTheAnswer(t *testing.T) {

--- a/sdk/go/chat/conversation_test.go
+++ b/sdk/go/chat/conversation_test.go
@@ -118,24 +118,46 @@ func TestCloseReturnsEvenWhenTheDaemonStopsAnswering(t *testing.T) {
 		<-stream.hold
 	}
 
-	// A daemon that never answers still started a run, and Close now goes
-	// looking for it by label, so the lookup has to be answerable.
-	daemon.listRuns = listRunsReturning(runSummary("run-1", "RUN_STATUS_RUNNING", "sandbox-1"))
+	// Nothing answers, including the lookup Close makes for a run whose start
+	// frame never arrived — a daemon too wedged to name a run is exactly the
+	// one that will not answer that lookup either.
+	daemon.listRuns = func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+		<-daemon.hold
+		return &agentcomposev2.ListRunsResponse{}, nil
+	}
+	daemon.stopRun = func(*agentcomposev2.StopRunRequest) (*agentcomposev2.StopRunResponse, error) {
+		<-daemon.hold
+		return &agentcomposev2.StopRunResponse{}, nil
+	}
+	shortenCloseBound(t, 100*time.Millisecond)
 
 	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
 	if _, err := conversation.Send(context.Background(), "hi"); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	closed := make(chan error, 1)
+	// context.Background() on purpose: the bound has to be Close's own, not one
+	// the caller was careful enough to supply.
 	go func() { closed <- conversation.Close(context.Background()) }()
 	select {
 	case err := <-closed:
-		if err != nil {
-			t.Fatalf("Close: %v", err)
+		// Giving up is reported rather than passed off as a clean close: the
+		// run may still be running, and EndSession is how it gets stopped.
+		if err == nil {
+			t.Fatal("Close reported success while the daemon never answered its cleanup")
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Close blocked on a daemon that stopped answering")
 	}
+}
+
+// shortenCloseBound makes Close give up quickly so a test can watch it do so
+// without waiting out the real bound.
+func shortenCloseBound(t *testing.T, bound time.Duration) {
+	t.Helper()
+	previous := closeCallBound
+	closeCallBound = bound
+	t.Cleanup(func() { closeCallBound = previous })
 }
 
 func TestSendStreamsATurnAndAccumulatesTheAnswer(t *testing.T) {

--- a/sdk/go/chat/conversation_test.go
+++ b/sdk/go/chat/conversation_test.go
@@ -1,0 +1,720 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"strings"
+	"testing"
+	"time"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+func TestSendDoesNotWaitForResponseHeadersBeforeOpening(t *testing.T) {
+	// A Connect handler writes response headers only after receiving the
+	// client's first message. Waiting for headers before sending the opening
+	// frame deadlocks: the daemon never answers and the turn never starts.
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		// Nothing is written until the opening frame has arrived, exactly as
+		// the daemon behaves.
+		if _, ok := stream.recv(); !ok {
+			return
+		}
+		stream.send(turnCompleted(""))
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	reply, err := conversation.Send(ctx, "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(ctx); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+func TestSendReportsAnUnreachableDaemonRatherThanBlocking(t *testing.T) {
+	client, err := New(Config{BaseURL: "http://127.0.0.1:1"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	conversation := client.Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	reply, err := conversation.Send(ctx, "hi")
+	if err == nil {
+		if _, err = reply.Wait(ctx); err == nil {
+			t.Fatal("the turn succeeded against a closed port")
+		}
+	}
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("error = %v, want ErrUnavailable", err)
+	}
+}
+
+func TestTheSessionOutlivesTheContextOfTheSendThatOpenedIt(t *testing.T) {
+	// A server handling an HTTP request sends on the request's context. That
+	// context ends with the request, but the conversation does not: the next
+	// message must still land on the same session, with the agent's context
+	// intact.
+	daemon := newFakeDaemon(t)
+	frames := make(chan *agentcomposev2.AttachAgentRunRequest, 2)
+	daemon.attach = func(stream *fakeStream) {
+		for range 2 {
+			frame, ok := stream.recv()
+			if !ok {
+				return
+			}
+			frames <- frame
+			stream.send(turnCompleted(""))
+		}
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+
+	first, cancelFirst := context.WithCancel(context.Background())
+	reply, err := conversation.Send(first, "first")
+	if err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	if _, err := reply.Wait(first); err != nil {
+		t.Fatalf("first Wait: %v", err)
+	}
+	cancelFirst()
+
+	second, err := conversation.Send(context.Background(), "second")
+	if err != nil {
+		t.Fatalf("second Send after the first context ended: %v", err)
+	}
+	if _, err := second.Wait(context.Background()); err != nil {
+		t.Fatalf("second Wait: %v", err)
+	}
+	<-frames
+	followUp := <-frames
+	if followUp.GetHumanMessage() == nil || followUp.GetHumanMessage().GetText() != "second" {
+		t.Fatalf("second frame = %#v, want a human message on the same session", followUp)
+	}
+	if attaches := daemon.count("AttachAgentRun"); attaches != 1 {
+		t.Errorf("attach count = %d, want 1: the session must survive the first context", attaches)
+	}
+}
+
+func TestCloseReturnsEvenWhenTheDaemonStopsAnswering(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		// Accept the opening frame and then go silent, never answering.
+		_, _ = stream.recv()
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	if _, err := conversation.Send(context.Background(), "hi"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	closed := make(chan error, 1)
+	go func() { closed <- conversation.Close(context.Background()) }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close blocked on a daemon that stopped answering")
+	}
+}
+
+func TestSendStreamsATurnAndAccumulatesTheAnswer(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	starts := make(chan *agentcomposev2.AttachAgentRunStart, 1)
+	daemon.attach = func(stream *fakeStream) {
+		frame, _ := stream.recv()
+		starts <- frame.GetStart()
+		stream.send(started("run-1", "sandbox-1"))
+		stream.agentEvent("step_start", map[string]any{"step": 0})
+		stream.agentEvent("text_delta", map[string]any{"text": "Hello, "})
+		stream.agentEvent("tool_call", map[string]any{"id": "t1", "name": "bash", "toolKind": "execute", "status": "completed", "command": "ls"})
+		stream.agentEvent("text_delta", map[string]any{"text": "world"})
+		stream.send(turnCompleted(`{"ok":true}`))
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+
+	reply, err := conversation.Send(context.Background(), "check this PR")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	message, err := reply.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if message.Text != "Hello, world" {
+		t.Errorf("answer = %q, want %q", message.Text, "Hello, world")
+	}
+	if message.Role != RoleAssistant {
+		t.Errorf("role = %q, want %q", message.Role, RoleAssistant)
+	}
+	if string(message.Result) != `{"ok":true}` {
+		t.Errorf("result = %s, want {\"ok\":true}", message.Result)
+	}
+	if got := conversation.RunID(); got != "run-1" {
+		t.Errorf("run ID = %q, want run-1", got)
+	}
+
+	// The opening message provisions the session, so it travels in the start
+	// frame rather than as a separate human message.
+	start := <-starts
+	if start == nil || start.GetRequest() == nil {
+		t.Fatalf("start frame = %#v, want one carrying a run request", start)
+	}
+	if start.GetRequest().GetPrompt() != "check this PR" {
+		t.Errorf("start prompt = %q, want the opening message", start.GetRequest().GetPrompt())
+	}
+	if start.GetRequest().GetLabels()[conversationLabel] != conversation.ID() {
+		t.Errorf("start labels = %v, want one identifying the conversation", start.GetRequest().GetLabels())
+	}
+	if start.GetDisconnectPolicy() != agentcomposev2.AttachDisconnectPolicy_ATTACH_DISCONNECT_POLICY_DETACH {
+		t.Errorf("disconnect policy = %v, want DETACH", start.GetDisconnectPolicy())
+	}
+	// A conversation's environment must not outlive the run that serves it:
+	// one run covers every turn of a session, and pinning the sandbox past
+	// that leaves one running for every conversation ever opened.
+	if start.GetRequest().GetCleanupPolicy() != agentcomposev2.RunSandboxCleanupPolicy_RUN_SANDBOX_CLEANUP_POLICY_STOP_ON_COMPLETION {
+		t.Errorf("cleanup policy = %v, want the environment stopped when the run ends", start.GetRequest().GetCleanupPolicy())
+	}
+}
+
+func TestEventsReplayForEveryCaller(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		stream.agentEvent("text_delta", map[string]any{"text": "one"})
+		stream.agentEvent("usage", map[string]any{"scope": "turn", "inputTokens": 10, "outputTokens": 4})
+		stream.send(turnCompleted(""))
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	// Wait consumed nothing, and a second pass sees the same events as the
+	// first: the Reply retains them rather than draining a channel.
+	for pass := range 2 {
+		var kinds []EventKind
+		for event, err := range reply.Events(context.Background()) {
+			if err != nil {
+				t.Fatalf("pass %d events: %v", pass, err)
+			}
+			kinds = append(kinds, event.Kind())
+		}
+		if len(kinds) != 2 || kinds[0] != KindTextDelta || kinds[1] != KindUsage {
+			t.Fatalf("pass %d kinds = %v, want [text_delta usage]", pass, kinds)
+		}
+	}
+}
+
+func TestEventsPreserveProviderExtensions(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		stream.send(&agentcomposev2.AttachAgentRunResponse{
+			Frame: &agentcomposev2.AttachAgentRunResponse_AgentEvent{
+				AgentEvent: &agentcomposev2.AttachAgentEvent{
+					Name: "item.completed", Text: "provider text",
+					PayloadJson: `{"item":{"type":"agent_message","text":"provider text"}}`,
+				},
+			},
+		})
+		stream.send(turnCompleted(""))
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	var event Event
+	for got, err := range reply.Events(context.Background()) {
+		if err != nil {
+			t.Fatalf("Events: %v", err)
+		}
+		event = got
+	}
+	raw, ok := event.(*RawEvent)
+	if !ok || raw.Name != "item.completed" || raw.Text != "provider text" || raw.PayloadJSON == "" {
+		t.Fatalf("event = %#v, want preserved provider event", event)
+	}
+}
+
+func TestSendWhileAReplyIsStreamingReportsBusy(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	release := make(chan struct{})
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		<-release
+		stream.send(turnCompleted(""))
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	first, err := conversation.Send(context.Background(), "first")
+	if err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	if _, err := conversation.Send(context.Background(), "second"); !errors.Is(err, ErrBusy) {
+		t.Fatalf("second Send error = %v, want ErrBusy", err)
+	}
+	close(release)
+	if _, err := first.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+func TestFollowUpTurnsTravelAsMessagesOnTheSameSession(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	frames := make(chan *agentcomposev2.AttachAgentRunRequest, 2)
+	daemon.attach = func(stream *fakeStream) {
+		for range 2 {
+			frame, ok := stream.recv()
+			if !ok {
+				return
+			}
+			frames <- frame
+			stream.send(turnCompleted(""))
+		}
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	for _, text := range []string{"first", "second"} {
+		reply, err := conversation.Send(context.Background(), text)
+		if err != nil {
+			t.Fatalf("Send %q: %v", text, err)
+		}
+		if _, err := reply.Wait(context.Background()); err != nil {
+			t.Fatalf("Wait %q: %v", text, err)
+		}
+	}
+	if opening := <-frames; opening.GetStart() == nil {
+		t.Fatalf("first frame = %#v, want a start", opening)
+	}
+	followUp := <-frames
+	if followUp.GetHumanMessage() == nil || followUp.GetHumanMessage().GetText() != "second" {
+		t.Fatalf("second frame = %#v, want the follow-up as a human message", followUp)
+	}
+	// One session served both turns, so the environment carried context across
+	// them.
+	if attaches := daemon.count("AttachAgentRun"); attaches != 1 {
+		t.Errorf("attach count = %d, want 1", attaches)
+	}
+}
+
+func TestOpenResumesALiveConversation(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(runSummary("run-7", "RUN_STATUS_RUNNING", "sandbox-7",
+		timestamppb.New(time.Now().Add(-time.Hour))))
+	starts := make(chan *agentcomposev2.AttachAgentRunStart, 1)
+	daemon.attach = func(stream *fakeStream) {
+		frame, _ := stream.recv()
+		starts <- frame.GetStart()
+		<-stream.hold
+	}
+
+	conversation, err := daemon.client(t).Agent("project-1", "reviewer").Open(context.Background(), "conv-abc")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = conversation.Close(context.Background()) }()
+	if conversation.Continuity() != Continuous {
+		t.Errorf("continuity = %q, want %q", conversation.Continuity(), Continuous)
+	}
+	start := <-starts
+	if start == nil || start.GetRunId() != "run-7" {
+		t.Fatalf("start frame = %#v, want a reattach to run-7", start)
+	}
+	if start.GetRequest() != nil {
+		t.Errorf("reattach carried a run request %#v, want none", start.GetRequest())
+	}
+}
+
+func TestOpenReportsRestartedWhenTheEnvironmentIsGone(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(runSummary("run-7", "RUN_STATUS_SUCCEEDED", ""))
+
+	conversation, err := daemon.client(t).Agent("project-1", "reviewer").Open(context.Background(), "conv-abc")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if conversation.Continuity() != Restarted {
+		t.Errorf("continuity = %q, want %q", conversation.Continuity(), Restarted)
+	}
+	if attaches := daemon.count("AttachAgentRun"); attaches != 0 {
+		t.Errorf("attach count = %d, want none before the next message", attaches)
+	}
+}
+
+func TestOpenCanRefuseToRestart(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning()
+
+	_, err := daemon.client(t).Agent("project-1", "reviewer").Open(context.Background(), "conv-abc", WithRestartIfGone(false))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestClosingEndsTheRunAndEndSessionReachesItByID(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		stream.send(started("run-1", ""))
+		stream.send(turnCompleted(""))
+		// Hold the session open the way a detached daemon would.
+		<-stream.hold
+	}
+
+	agent := daemon.client(t).Agent("project-1", "reviewer")
+	conversation := agent.Start()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := conversation.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Closing ends the run this handle held. The disconnect policy keeps a run
+	// alive when a stream merely drops, so if Close did not end it nothing
+	// would, and every conversation ever opened would keep an environment.
+	if stops := daemon.count("StopRun"); stops != 1 {
+		t.Fatalf("Close issued %d stops, want 1: closing must end the run it holds", stops)
+	}
+	if _, err := conversation.Send(context.Background(), "again"); !errors.Is(err, ErrClosed) {
+		t.Errorf("Send after Close = %v, want ErrClosed", err)
+	}
+
+	// Ending the session again by ID, the way a product retires a conversation
+	// it holds no handle for, reaches the same run through its label.
+	daemon.listRuns = listRunsReturning(runSummary("run-1", "RUN_STATUS_RUNNING", "sandbox-1"))
+	if err := daemon.client(t).EndSession(context.Background(), conversation.ID()); err != nil {
+		t.Fatalf("EndSession: %v", err)
+	}
+	if stops := daemon.count("StopRun"); stops != 2 {
+		t.Errorf("stops = %d, want 2 (one per session ended)", stops)
+	}
+}
+
+func TestALostStreamFailsTheTurnAndReattachesToTheSameSession(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	starts := make(chan *agentcomposev2.AttachAgentRunStart, 2)
+	attaches := 0
+	daemon.attach = func(stream *fakeStream) {
+		frame, _ := stream.recv()
+		starts <- frame.GetStart()
+		attaches++
+		if attaches == 1 {
+			stream.send(started("run-1", ""))
+			stream.agentEvent("text_delta", map[string]any{"text": "partial"})
+			// Drop the stream mid-turn, the way a network blip does. The run
+			// itself is untouched.
+			return
+		}
+		stream.send(turnCompleted(""))
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(context.Background()); err == nil {
+		t.Fatal("Wait succeeded, want the turn to fail when its stream is lost")
+	}
+	<-starts
+
+	// The run outlived the stream, so nothing was lost and the caller must not
+	// be told otherwise.
+	if conversation.Continuity() != Continuous {
+		t.Errorf("continuity = %q, want %q: losing a stream is not losing the environment", conversation.Continuity(), Continuous)
+	}
+
+	second, err := conversation.Send(context.Background(), "again")
+	if err != nil {
+		t.Fatalf("second Send: %v", err)
+	}
+	if _, err := second.Wait(context.Background()); err != nil {
+		t.Fatalf("second Wait: %v", err)
+	}
+	reattach := <-starts
+	if reattach == nil || reattach.GetRunId() != "run-1" {
+		t.Fatalf("second start frame = %#v, want a reattach to run-1", reattach)
+	}
+	if reattach.Request != nil {
+		t.Errorf("reattach carried a run request %#v, want none", reattach.Request)
+	}
+}
+
+// TestATerminalRunClearsTheRunButNotContinuity checks that a terminal run by
+// itself does not declare a restart: the sandbox it used may still be
+// resumable, and Continuity is decided by whether the next attach actually
+// gets it back, not by the mere fact that a run ended.
+func TestATerminalRunClearsTheRunButNotContinuity(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		stream.send(started("run-1", "sandbox-1"))
+		stream.send(runResult(true, ""))
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if conversation.Continuity() != Continuous {
+		t.Errorf("continuity = %q, want %q: nothing has attempted a restart yet", conversation.Continuity(), Continuous)
+	}
+	if conversation.RunID() != "" {
+		t.Errorf("run ID = %q, want it cleared once the run is terminal", conversation.RunID())
+	}
+}
+
+// TestNextRunAsksToReuseTheSandboxAndReportsContinuous checks that once a
+// run ends, the next one asks the daemon to resume the same sandbox rather
+// than starting from nothing — and that a successful resume reports
+// Continuous even though it took a new run to get there.
+func TestNextRunAsksToReuseTheSandboxAndReportsContinuous(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	starts := make(chan *agentcomposev2.AttachAgentRunStart, 2)
+	daemon.attach = func(stream *fakeStream) {
+		frame, _ := stream.recv()
+		starts <- frame.GetStart()
+		stream.send(started("run", "sandbox-1"))
+		stream.send(runResult(true, ""))
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+
+	first, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	if _, err := first.Wait(context.Background()); err != nil {
+		t.Fatalf("first Wait: %v", err)
+	}
+	opening := <-starts
+	if opening.Request == nil || opening.Request.GetSandboxId() != "" {
+		t.Fatalf("opening run asked to reuse a sandbox it never had: %#v", opening.Request)
+	}
+
+	second, err := conversation.Send(context.Background(), "again")
+	if err != nil {
+		t.Fatalf("second Send: %v", err)
+	}
+	if _, err := second.Wait(context.Background()); err != nil {
+		t.Fatalf("second Wait: %v", err)
+	}
+	reopened := <-starts
+	if reopened.Request == nil || reopened.Request.GetSandboxId() != "sandbox-1" {
+		t.Fatalf("second run did not ask to reuse the prior sandbox: %#v", reopened.Request)
+	}
+	if conversation.Continuity() != Continuous {
+		t.Errorf("continuity = %q, want %q: the daemon reused the same sandbox", conversation.Continuity(), Continuous)
+	}
+}
+
+// TestSandboxReuseFailingReportsRestarted checks the other side: when the
+// daemon does not honor the reuse request and hands back a different
+// sandbox, that is a genuine restart and must be reported as one.
+func TestSandboxReuseFailingReportsRestarted(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	attempt := 0
+	daemon.attach = func(stream *fakeStream) {
+		attempt++
+		_, _ = stream.recv()
+		sandboxID := "sandbox-1"
+		if attempt > 1 {
+			sandboxID = "sandbox-2" // a different sandbox: the reuse request was not honored
+		}
+		stream.send(started("run", sandboxID))
+		stream.send(runResult(true, ""))
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+
+	first, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	if _, err := first.Wait(context.Background()); err != nil {
+		t.Fatalf("first Wait: %v", err)
+	}
+
+	second, err := conversation.Send(context.Background(), "again")
+	if err != nil {
+		t.Fatalf("second Send: %v", err)
+	}
+	if _, err := second.Wait(context.Background()); err != nil {
+		t.Fatalf("second Wait: %v", err)
+	}
+	if conversation.Continuity() != Restarted {
+		t.Errorf("continuity = %q, want %q: the daemon did not reuse the sandbox it was asked to", conversation.Continuity(), Restarted)
+	}
+}
+
+func TestAFailedRunSurfacesItsError(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		stream.send(runResult(false, "image pull failed"))
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	if _, err := conversation.Ask(context.Background(), "hi"); err == nil || !strings.Contains(err.Error(), "image pull failed") {
+		t.Fatalf("Ask error = %v, want the daemon's reason", err)
+	}
+}
+
+func TestWaitHonorsContextCancellation(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		_, _ = stream.recv()
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := reply.Wait(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Wait error = %v, want DeadlineExceeded", err)
+	}
+}
+
+func TestHistoryReadsBothRolesAcrossRestarts(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(
+		&agentcomposev2.RunSummary{RunId: "run-2", CreatedAt: timestamppb.New(time.Unix(200, 0))},
+		&agentcomposev2.RunSummary{RunId: "run-1", CreatedAt: timestamppb.New(time.Unix(100, 0))},
+	)
+	daemon.listRunEvents = listEventsReturning(
+		runEvent("e1", agentcomposev2.RunEventKind_RUN_EVENT_KIND_USER_MESSAGE, "question"),
+		runEvent("e2", agentcomposev2.RunEventKind_RUN_EVENT_KIND_STATUS, "running"),
+		runEvent("e3", agentcomposev2.RunEventKind_RUN_EVENT_KIND_AGENT_MESSAGE, "answer"),
+	)
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start(WithID("conv-abc"))
+	messages, err := conversation.History(context.Background())
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	// Both runs are read, oldest first, and lifecycle events are not messages.
+	if len(messages) != 4 {
+		t.Fatalf("history = %d messages, want 4", len(messages))
+	}
+	if messages[0].Role != RoleUser || messages[0].Text != "question" {
+		t.Errorf("first message = %#v", messages[0])
+	}
+	if messages[1].Role != RoleAssistant || messages[1].Text != "answer" {
+		t.Errorf("second message = %#v", messages[1])
+	}
+}
+
+// A handle that never attached holds no run, so closing it must not go looking
+// for one. Two handles can name the same conversation — a server that races to
+// attach discards the loser — and a discarded handle that ended the winner's
+// run would kill a live session.
+func TestClosingAHandleThatNeverAttachedEndsNothing(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(runSummary("run-live", "RUN_STATUS_RUNNING", "sandbox-a"))
+
+	spare := daemon.client(t).Agent("project-1", "reviewer").Start(WithID("conv-1"))
+	if err := spare.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if stops := daemon.count("StopRun"); stops != 0 {
+		t.Fatalf("closing an unattached handle issued %d stops, want none", stops)
+	}
+	if lists := daemon.count("ListRuns"); lists != 0 {
+		t.Errorf("closing an unattached handle read the run list %d times, want none", lists)
+	}
+}
+
+// Reopening a conversation whose last run has ended must still ask for that
+// run's sandbox. Runs end every time a client closes, so this is the ordinary
+// path back into a conversation — and dropping the sandbox here builds a new
+// environment beside the old one, losing the context the agent had persisted.
+func TestOpeningAfterTheLastRunEndedStillResumesItsSandbox(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(runSummary("run-done", "RUN_STATUS_FAILED", "sandbox-a"))
+	starts := make(chan *agentcomposev2.AttachAgentRunStart, 1)
+	daemon.attach = func(stream *fakeStream) {
+		frame, _ := stream.recv()
+		starts <- frame.GetStart()
+		stream.send(started("run-2", "sandbox-a"))
+		stream.send(turnCompleted(""))
+		<-stream.hold
+	}
+
+	agent := daemon.client(t).Agent("project-1", "reviewer")
+	conversation, err := agent.Open(context.Background(), "conv-1")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	reply, err := conversation.Send(context.Background(), "still there?")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := reply.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	start := <-starts
+	if start.Request.GetSandboxId() != "sandbox-a" {
+		t.Fatalf("resumed sandbox %q, want the one the ended run used", start.Request.GetSandboxId())
+	}
+	// The daemon gave back the sandbox that was asked for, so nothing was lost.
+	if got := conversation.Continuity(); got != Continuous {
+		t.Errorf("Continuity = %q, want %q", got, Continuous)
+	}
+}

--- a/sdk/go/chat/conversation_test.go
+++ b/sdk/go/chat/conversation_test.go
@@ -118,6 +118,10 @@ func TestCloseReturnsEvenWhenTheDaemonStopsAnswering(t *testing.T) {
 		<-stream.hold
 	}
 
+	// A daemon that never answers still started a run, and Close now goes
+	// looking for it by label, so the lookup has to be answerable.
+	daemon.listRuns = listRunsReturning(runSummary("run-1", "RUN_STATUS_RUNNING", "sandbox-1"))
+
 	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
 	if _, err := conversation.Send(context.Background(), "hi"); err != nil {
 		t.Fatalf("Send: %v", err)
@@ -803,5 +807,113 @@ func TestResendingALostTurnCarriesTheIdentityItAlreadyHad(t *testing.T) {
 	if repeated.GetClientFrameId() == original.GetClientFrameId() {
 		t.Errorf("a repeat after a completed turn reused %q, and would be swallowed as a duplicate",
 			repeated.GetClientFrameId())
+	}
+}
+
+// A run is created by the request, but named only by the start frame that
+// follows it, and Send returns as soon as the request is away. A Close landing
+// in that gap has a run to end and no ID to end it by — and the disconnect
+// policy means nothing else ever will, so the run and its sandbox would be
+// stranded.
+func TestClosingBeforeTheRunIsNamedStillStopsIt(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		// Take the request and withhold the start frame, the way a daemon that
+		// is still building the environment does.
+		_, _ = stream.recv()
+		<-stream.hold
+	}
+	// The daemon did create the run; it just has not said so yet. It carries
+	// the conversation's identity label, which is how Close finds it.
+	daemon.listRuns = listRunsReturning(runSummary("run-unnamed", "RUN_STATUS_RUNNING", "sandbox-1"))
+	stopped := make(chan string, 1)
+	daemon.stopRun = func(request *agentcomposev2.StopRunRequest) (*agentcomposev2.StopRunResponse, error) {
+		stopped <- request.GetRunId()
+		return &agentcomposev2.StopRunResponse{}, nil
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	if _, err := conversation.Send(context.Background(), "hi"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := conversation.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case runID := <-stopped:
+		if runID != "run-unnamed" {
+			t.Errorf("stopped %q, want the run this handle started", runID)
+		}
+	default:
+		t.Fatal("Close stopped nothing: a run started but not yet named was left running")
+	}
+	// The label is what identifies it, since the run ID never arrived.
+	if lookups := daemon.count("ListRuns"); lookups != 1 {
+		t.Errorf("looked the run up %d times, want 1", lookups)
+	}
+}
+
+// A handle that never sent anything started no run, so Close must not go
+// hunting for one — it would find a run belonging to some other holder of the
+// same conversation and stop that instead.
+func TestClosingAHandleThatSentNothingLooksForNoRun(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	if err := conversation.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if lookups := daemon.count("ListRuns"); lookups != 0 {
+		t.Errorf("looked up %d runs for a handle that never attached, want 0", lookups)
+	}
+	if stops := daemon.count("StopRun"); stops != 0 {
+		t.Errorf("issued %d stops for a handle that never attached, want 0", stops)
+	}
+}
+
+// The daemon may answer the opening frame with the whole turn before Send has
+// returned. Those frames must land on the turn's Reply rather than falling
+// into the gap between sending and installing it — a dropped first event, or
+// a Wait that never ends, would be the shape of that mistake.
+func TestATurnAnsweredBeforeSendReturnsLosesNothing(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.attach = func(stream *fakeStream) {
+		if _, ok := stream.recv(); !ok {
+			return
+		}
+		// Everything at once, as fast as the wire allows.
+		stream.send(started("run-1", "sandbox-1"))
+		stream.agentEvent("text_delta", map[string]any{"text": "instant"})
+		stream.send(turnCompleted(""))
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	reply, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	answer, err := reply.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if answer.Text != "instant" {
+		t.Errorf("answer = %q, want the event that arrived before Send returned", answer.Text)
+	}
+	var seen int
+	for event, err := range reply.Events(context.Background()) {
+		if err != nil {
+			t.Fatalf("Events: %v", err)
+		}
+		if _, ok := event.(*TextDeltaEvent); ok {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Errorf("replayed %d text events, want 1", seen)
+	}
+	if conversation.RunID() != "run-1" {
+		t.Errorf("run ID = %q, want run-1 from the start frame", conversation.RunID())
 	}
 }

--- a/sdk/go/chat/conversation_test.go
+++ b/sdk/go/chat/conversation_test.go
@@ -718,3 +718,90 @@ func TestOpeningAfterTheLastRunEndedStillResumesItsSandbox(t *testing.T) {
 		t.Errorf("Continuity = %q, want %q", got, Continuous)
 	}
 }
+
+// A turn whose stream broke leaves its outcome unknown, so a caller recovers by
+// resending. The daemon must be able to tell that resend apart from a person
+// typing the same thing twice, and the only thing that can tell them apart is
+// the identity the message travels under.
+func TestResendingALostTurnCarriesTheIdentityItAlreadyHad(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	messages := make(chan *agentcomposev2.AttachAgentRunRequest, 3)
+	attaches := 0
+	daemon.attach = func(stream *fakeStream) {
+		attaches++
+		if attaches == 1 {
+			// The opening turn travels as the run's prompt, not as a message.
+			if _, ok := stream.recv(); !ok {
+				return
+			}
+			stream.send(started("run-1", ""))
+			stream.send(turnCompleted(""))
+			frame, ok := stream.recv()
+			if !ok {
+				return
+			}
+			messages <- frame
+			// Drop the stream while that turn is in flight. The run survives,
+			// and so does the message it already took.
+			return
+		}
+		if _, ok := stream.recv(); !ok {
+			return
+		}
+		for range 2 {
+			frame, ok := stream.recv()
+			if !ok {
+				return
+			}
+			messages <- frame
+			stream.send(turnCompleted(""))
+		}
+		<-stream.hold
+	}
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start()
+	defer func() { _ = conversation.Close(context.Background()) }()
+	opening, err := conversation.Send(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := opening.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	lost, err := conversation.Send(context.Background(), "again")
+	if err != nil {
+		t.Fatalf("second Send: %v", err)
+	}
+	if _, err := lost.Wait(context.Background()); err == nil {
+		t.Fatal("the turn succeeded, want it to fail when its stream is lost")
+	}
+	for _, step := range []string{"resend", "repeat"} {
+		reply, err := conversation.Send(context.Background(), "again")
+		if err != nil {
+			t.Fatalf("%s Send: %v", step, err)
+		}
+		if _, err := reply.Wait(context.Background()); err != nil {
+			t.Fatalf("%s Wait: %v", step, err)
+		}
+	}
+
+	original, resent, repeated := <-messages, <-messages, <-messages
+	for _, frame := range []*agentcomposev2.AttachAgentRunRequest{original, resent, repeated} {
+		if text := frame.GetHumanMessage().GetText(); text != "again" {
+			t.Fatalf("frame carried %q, want the message under test", text)
+		}
+	}
+	if original.GetClientFrameId() == "" {
+		t.Fatal("the message carried no identity, so a resend of it cannot be recognised")
+	}
+	if resent.GetClientFrameId() != original.GetClientFrameId() {
+		t.Errorf("the resend travelled as %q, want the lost turn's %q: it is the same message",
+			resent.GetClientFrameId(), original.GetClientFrameId())
+	}
+	// The turn before it completed, so this one is a person saying the same
+	// thing again and has to be recorded on its own.
+	if repeated.GetClientFrameId() == original.GetClientFrameId() {
+		t.Errorf("a repeat after a completed turn reused %q, and would be swallowed as a duplicate",
+			repeated.GetClientFrameId())
+	}
+}

--- a/sdk/go/chat/directory.go
+++ b/sdk/go/chat/directory.go
@@ -1,0 +1,226 @@
+package chat
+
+import (
+	"connectrpc.com/connect"
+	"context"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// listPageSize bounds one page of a conversation search. The daemon rejects
+// pages above 500.
+const listPageSize = 200
+
+// ConversationInfo describes a conversation found on the server, without
+// opening it.
+//
+// It is a summary of what the server knows: which Agent the conversation is
+// with, when it was last active, and the labels it was created with. A title,
+// an unread marker, or anything else a product invents about a conversation is
+// the product's to keep — this package only reports what the daemon holds.
+type ConversationInfo struct {
+	// ID is the conversation's identity, the value [Agent.Open] takes.
+	ID string
+	// ProjectID and AgentName identify the counterpart, so a caller listing
+	// across several Agents can reopen each conversation with the right one.
+	ProjectID string
+	AgentName string
+	// Labels are the labels the conversation was created with, minus the one
+	// this package uses for identity. It is nil for a conversation reached
+	// through [Client.Lookup], which does not read them.
+	Labels map[string]string
+	// LastActive is when the conversation's most recent session started.
+	LastActive time.Time
+	// Live reports whether that session is still running, which is what
+	// separates a conversation that can be resumed with its context intact
+	// from one that would be rebuilt.
+	Live bool
+}
+
+// Lookup reports what the server knows about one conversation, and nothing if
+// it has never run or does not match every label in mustMatch.
+//
+// This is the cheap question, and the one authorization needs: "is there a
+// conversation with this ID carrying these labels?" is answered by the run
+// list's label filter alone, in a single call, without reading any label back.
+// A product can therefore check that a conversation belongs to the user in
+// front of it without keeping its own record of who owns what.
+func (c *Client) Lookup(ctx context.Context, id string, mustMatch map[string]string) (ConversationInfo, bool, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ConversationInfo{}, false, invalidArgument("Lookup", "conversation ID is required")
+	}
+	labels := maps.Clone(mustMatch)
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[conversationLabel] = id
+
+	runs, err := c.matchingRuns(ctx, "Lookup", Search{Labels: labels})
+	if err != nil {
+		return ConversationInfo{}, false, err
+	}
+	if len(runs) == 0 {
+		return ConversationInfo{}, false, nil
+	}
+	latest := runs[0]
+	for _, run := range runs[1:] {
+		if run.GetCreatedAt().AsTime().After(latest.GetCreatedAt().AsTime()) {
+			latest = run
+		}
+	}
+	// The ID is what was asked for, so it needs no confirming: a run came back
+	// only because it carries that label.
+	return ConversationInfo{
+		ID:         id,
+		ProjectID:  latest.GetProjectId(),
+		AgentName:  latest.GetAgentName(),
+		LastActive: latest.GetCreatedAt().AsTime(),
+		Live:       runIsLive(latest),
+	}, true, nil
+}
+
+// Search selects which conversations [Client.Conversations] returns.
+//
+// An empty Search matches every conversation this package created. Fields
+// combine with AND.
+type Search struct {
+	// ProjectID and AgentName narrow the search to one counterpart. Empty
+	// means any.
+	ProjectID string
+	AgentName string
+	// Labels narrows to conversations carrying every one of these labels,
+	// which is how a product finds the conversations belonging to one of its
+	// users.
+	Labels map[string]string
+	// Limit caps how many runs are examined, not how many conversations come
+	// back: a conversation that was rebuilt occupies several runs. Zero uses a
+	// sensible default.
+	Limit int
+}
+
+// Conversations lists the conversations matching search, most recently active
+// first.
+//
+// This is the expensive question. The daemon's run list returns summaries
+// without labels — labels belong to a run's detail — so discovering which
+// conversation each run belongs to costs one detail read per run. A product
+// that shows a chat list on every page load should keep its own index of the
+// conversation IDs it created and call [Agent.Open] directly; this is for
+// rebuilding such an index, or for tools that never had one.
+func (c *Client) Conversations(ctx context.Context, search Search) ([]ConversationInfo, error) {
+	runs, err := c.matchingRuns(ctx, "Conversations", search)
+	if err != nil {
+		return nil, err
+	}
+	found := make(map[string]ConversationInfo, len(runs))
+	for _, run := range runs {
+		labels, err := c.runLabels(ctx, run.GetRunId())
+		if err != nil {
+			return nil, err
+		}
+		id := labels[conversationLabel]
+		if id == "" {
+			// A run this package did not start. It has no conversation
+			// identity, and inventing one from its run ID would produce an ID
+			// that Open cannot resume.
+			continue
+		}
+		if seen, ok := found[id]; ok && seen.LastActive.After(run.GetCreatedAt().AsTime()) {
+			continue
+		}
+		remaining := maps.Clone(labels)
+		delete(remaining, conversationLabel)
+		found[id] = ConversationInfo{
+			ID:         id,
+			ProjectID:  run.GetProjectId(),
+			AgentName:  run.GetAgentName(),
+			Labels:     remaining,
+			LastActive: run.GetCreatedAt().AsTime(),
+			Live:       runIsLive(run),
+		}
+	}
+
+	conversations := slices.Collect(maps.Values(found))
+	slices.SortStableFunc(conversations, func(a, b ConversationInfo) int {
+		if order := b.LastActive.Compare(a.LastActive); order != 0 {
+			return order
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+	return conversations, nil
+}
+
+// matchingRuns runs one filtered run list.
+func (c *Client) matchingRuns(ctx context.Context, op string, search Search) ([]*agentcomposev2.RunSummary, error) {
+	limit := search.Limit
+	if limit <= 0 || limit > listPageSize {
+		limit = listPageSize
+	}
+	response, err := c.transport.runs.ListRuns(ctx, connect.NewRequest(&agentcomposev2.ListRunsRequest{
+		ProjectId: strings.TrimSpace(search.ProjectID),
+		AgentName: strings.TrimSpace(search.AgentName),
+		Labels:    maps.Clone(search.Labels),
+		Limit:     uint32(limit),
+	}))
+	if err != nil {
+		return nil, fromConnect(op, err)
+	}
+	return response.Msg.GetRuns(), nil
+}
+
+// runLabels reads one run's labels, which only the detail view carries.
+func (c *Client) runLabels(ctx context.Context, runID string) (map[string]string, error) {
+	response, err := c.transport.runs.GetRun(ctx, connect.NewRequest(&agentcomposev2.GetRunRequest{RunId: runID}))
+	if err != nil {
+		return nil, fromConnect("Conversations", err)
+	}
+	return response.Msg.GetRun().GetLabels(), nil
+}
+
+// EndSession ends whatever run a conversation currently has, releasing the
+// environment that run was holding. It is addressed by ID and needs no
+// attached handle, which is what a product needs to retire a conversation it
+// is not holding open — after a restart, say, when its own sessions are gone
+// but the daemon's runs are not.
+//
+// The conversation itself is untouched: its history and identity survive, and
+// [Agent.Open] resumes it, reporting [Restarted] because the environment is
+// gone. Ending a session that has already ended is not an error.
+//
+// [Conversation.Close] is the right call when you do hold the handle; closing
+// already ends the run it holds.
+func (c *Client) EndSession(ctx context.Context, id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return invalidArgument("EndSession", "conversation ID is required")
+	}
+	runs, err := c.matchingRuns(ctx, "EndSession", Search{
+		Labels: map[string]string{conversationLabel: id},
+	})
+	if err != nil {
+		return err
+	}
+	if len(runs) == 0 {
+		return nil
+	}
+	latest := runs[0]
+	for _, run := range runs[1:] {
+		if run.GetCreatedAt().AsTime().After(latest.GetCreatedAt().AsTime()) {
+			latest = run
+		}
+	}
+	// The run's status is not consulted: stopping one that has already
+	// finished answers plainly and changes nothing, while trusting a status
+	// string the daemon might spell differently would leave a live run — and
+	// its environment — behind.
+	_, err = c.transport.runs.StopRun(ctx, connect.NewRequest(&agentcomposev2.StopRunRequest{
+		RunId:  latest.GetRunId(),
+		Reason: "conversation session ended",
+	}))
+	return fromConnect("EndSession", err)
+}

--- a/sdk/go/chat/directory.go
+++ b/sdk/go/chat/directory.go
@@ -60,18 +60,12 @@ func (c *Client) Lookup(ctx context.Context, id string, mustMatch map[string]str
 	}
 	labels[conversationLabel] = id
 
-	runs, err := c.matchingRuns(ctx, "Lookup", Search{Labels: labels})
+	latest, err := c.latestMatchingRun(ctx, "Lookup", Search{Labels: labels})
 	if err != nil {
 		return ConversationInfo{}, false, err
 	}
-	if len(runs) == 0 {
+	if latest == nil {
 		return ConversationInfo{}, false, nil
-	}
-	latest := runs[0]
-	for _, run := range runs[1:] {
-		if run.GetCreatedAt().AsTime().After(latest.GetCreatedAt().AsTime()) {
-			latest = run
-		}
 	}
 	// The ID is what was asked for, so it needs no confirming: a run came back
 	// only because it carries that label.
@@ -98,8 +92,10 @@ type Search struct {
 	// users.
 	Labels map[string]string
 	// Limit caps how many runs are examined, not how many conversations come
-	// back: a conversation that was rebuilt occupies several runs. Zero uses a
-	// sensible default.
+	// back: a conversation that was rebuilt occupies several runs. It is a
+	// budget across every page read, so a conversation whose runs all fall
+	// beyond it is not reported at all. Zero examines every matching run,
+	// which is what makes an empty Search mean every conversation.
 	Limit int
 }
 
@@ -155,22 +151,67 @@ func (c *Client) Conversations(ctx context.Context, search Search) ([]Conversati
 	return conversations, nil
 }
 
-// matchingRuns runs one filtered run list.
+// matchingRuns reads the runs matching search, walking as many pages as
+// search.Limit allows.
+//
+// The daemon caps a page well below what a busy conversation accumulates, so
+// reading one page and stopping would silently drop every conversation whose
+// runs fall outside it. Limit bounds the walk instead, and what it excludes is
+// excluded by the caller's own choice.
 func (c *Client) matchingRuns(ctx context.Context, op string, search Search) ([]*agentcomposev2.RunSummary, error) {
-	limit := search.Limit
-	if limit <= 0 || limit > listPageSize {
-		limit = listPageSize
+	budget := search.Limit
+	var runs []*agentcomposev2.RunSummary
+	for offset := uint32(0); budget <= 0 || len(runs) < budget; {
+		size := uint32(listPageSize)
+		if budget > 0 {
+			size = min(uint32(budget-len(runs)), listPageSize)
+		}
+		page, total, err := c.listRunsPage(ctx, op, search, offset, size)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, page...)
+		offset += uint32(len(page))
+		if len(page) == 0 || offset >= total {
+			break
+		}
 	}
+	return runs, nil
+}
+
+// latestMatchingRun returns the most recent run matching search, or nil when
+// there is none.
+//
+// A single row answers this. The daemon orders a run list by creation time,
+// newest first, so the first row is the latest run however many the
+// conversation has accumulated; reading a page to pick the newest out of it
+// would cost more for the same answer, and reading only the first page of a
+// long list would risk a wrong one.
+func (c *Client) latestMatchingRun(ctx context.Context, op string, search Search) (*agentcomposev2.RunSummary, error) {
+	runs, _, err := c.listRunsPage(ctx, op, search, 0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	return runs[0], nil
+}
+
+// listRunsPage reads one page of the filtered run list, and how many runs match
+// it in total.
+func (c *Client) listRunsPage(ctx context.Context, op string, search Search, offset, limit uint32) ([]*agentcomposev2.RunSummary, uint32, error) {
 	response, err := c.transport.runs.ListRuns(ctx, connect.NewRequest(&agentcomposev2.ListRunsRequest{
 		ProjectId: strings.TrimSpace(search.ProjectID),
 		AgentName: strings.TrimSpace(search.AgentName),
 		Labels:    maps.Clone(search.Labels),
-		Limit:     uint32(limit),
+		Offset:    offset,
+		Limit:     limit,
 	}))
 	if err != nil {
-		return nil, fromConnect(op, err)
+		return nil, 0, fromConnect(op, err)
 	}
-	return response.Msg.GetRuns(), nil
+	return response.Msg.GetRuns(), response.Msg.GetTotal(), nil
 }
 
 // runLabels reads one run's labels, which only the detail view carries.
@@ -199,20 +240,14 @@ func (c *Client) EndSession(ctx context.Context, id string) error {
 	if id == "" {
 		return invalidArgument("EndSession", "conversation ID is required")
 	}
-	runs, err := c.matchingRuns(ctx, "EndSession", Search{
+	latest, err := c.latestMatchingRun(ctx, "EndSession", Search{
 		Labels: map[string]string{conversationLabel: id},
 	})
 	if err != nil {
 		return err
 	}
-	if len(runs) == 0 {
+	if latest == nil {
 		return nil
-	}
-	latest := runs[0]
-	for _, run := range runs[1:] {
-		if run.GetCreatedAt().AsTime().After(latest.GetCreatedAt().AsTime()) {
-			latest = run
-		}
 	}
 	// The run's status is not consulted: stopping one that has already
 	// finished answers plainly and changes nothing, while trusting a status

--- a/sdk/go/chat/directory.go
+++ b/sdk/go/chat/directory.go
@@ -93,41 +93,48 @@ type Search struct {
 	Labels map[string]string
 	// Limit caps how many runs are examined, not how many conversations come
 	// back: a conversation that was rebuilt occupies several runs. It is a
-	// budget across every page read, so a conversation whose runs all fall
-	// beyond it is not reported at all. Zero examines every matching run,
-	// which is what makes an empty Search mean every conversation.
+	// budget across every page read, and reaching it returns what was found
+	// so far together with [ErrIncomplete], never a subset passed off as the
+	// whole. Zero examines every matching run, which is what makes an empty
+	// Search mean every conversation — and what makes an unbounded Search
+	// cost what the daemon's run count says it costs.
 	Limit int
 }
 
 // Conversations lists the conversations matching search, most recently active
 // first.
 //
-// This is the expensive question. The daemon's run list returns summaries
-// without labels — labels belong to a run's detail — so discovering which
-// conversation each run belongs to costs one detail read per run. A product
-// that shows a chat list on every page load should keep its own index of the
-// conversation IDs it created and call [Agent.Open] directly; this is for
-// rebuilding such an index, or for tools that never had one.
+// This is the expensive question, and worth being plain about how expensive:
+// the daemon's run list returns summaries without labels — labels belong to a
+// run's detail — so discovering which conversation each run belongs to costs
+// one detail read per run. An unbounded search of a long-lived daemon is
+// therefore one request per matching run, in sequence. That is the price of
+// the answer being complete, and [Search.Limit] is how a caller refuses to pay
+// it; a bounded search that runs out reports [ErrIncomplete] rather than
+// quietly returning less.
+//
+// A product that shows a chat list on every page load should keep its own
+// index of the conversation IDs it created and call [Agent.Open] directly;
+// this is for rebuilding such an index, or for tools that never had one.
 func (c *Client) Conversations(ctx context.Context, search Search) ([]ConversationInfo, error) {
-	runs, err := c.matchingRuns(ctx, "Conversations", search)
-	if err != nil {
-		return nil, err
-	}
-	found := make(map[string]ConversationInfo, len(runs))
-	for _, run := range runs {
+	found := map[string]ConversationInfo{}
+	// Fold each page as it arrives rather than collecting every run first: what
+	// this holds is then one page plus the conversations themselves, not one
+	// summary for every run the daemon has ever recorded.
+	truncated, err := c.walkMatchingRuns(ctx, "Conversations", search, func(run *agentcomposev2.RunSummary) error {
 		labels, err := c.runLabels(ctx, run.GetRunId())
 		if err != nil {
-			return nil, err
+			return err
 		}
 		id := labels[conversationLabel]
 		if id == "" {
 			// A run this package did not start. It has no conversation
 			// identity, and inventing one from its run ID would produce an ID
 			// that Open cannot resume.
-			continue
+			return nil
 		}
 		if seen, ok := found[id]; ok && seen.LastActive.After(run.GetCreatedAt().AsTime()) {
-			continue
+			return nil
 		}
 		remaining := maps.Clone(labels)
 		delete(remaining, conversationLabel)
@@ -139,6 +146,10 @@ func (c *Client) Conversations(ctx context.Context, search Search) ([]Conversati
 			LastActive: run.GetCreatedAt().AsTime(),
 			Live:       runIsLive(run),
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	conversations := slices.Collect(maps.Values(found))
@@ -148,45 +159,58 @@ func (c *Client) Conversations(ctx context.Context, search Search) ([]Conversati
 		}
 		return strings.Compare(a.ID, b.ID)
 	})
+	if truncated {
+		// The budget ran out with runs still unread, so this is a subset. Say
+		// so: what the caller does about a partial chat list — raise the
+		// budget, or use what came back — is theirs to decide, but they cannot
+		// decide it if a subset is indistinguishable from the whole.
+		return conversations, ErrIncomplete
+	}
 	return conversations, nil
 }
 
-// matchingRuns reads the runs matching search, walking as many pages as
-// search.Limit allows.
+// walkMatchingRuns visits the runs matching search, a page at a time, and
+// reports whether search.Limit stopped the walk with matches still unread.
 //
-// The daemon caps a page well below what a busy conversation accumulates, so
-// reading one page and stopping would silently drop every conversation whose
-// runs fall outside it. Limit bounds the walk instead, and what it excludes is
-// excluded by the caller's own choice.
-func (c *Client) matchingRuns(ctx context.Context, op string, search Search) ([]*agentcomposev2.RunSummary, error) {
+// The daemon caps a page well below what a busy daemon accumulates, so reading
+// one page and stopping would drop conversations from an enumeration that says
+// it returns every one. Limit is what bounds the walk instead — and when it is
+// what ended the walk, the caller is told.
+func (c *Client) walkMatchingRuns(ctx context.Context, op string, search Search, visit func(*agentcomposev2.RunSummary) error) (bool, error) {
 	budget := search.Limit
-	var runs []*agentcomposev2.RunSummary
-	for offset := uint32(0); budget <= 0 || len(runs) < budget; {
+	for offset := uint32(0); budget <= 0 || int(offset) < budget; {
 		size := uint32(listPageSize)
 		if budget > 0 {
-			size = min(uint32(budget-len(runs)), listPageSize)
+			size = min(uint32(budget-int(offset)), listPageSize)
 		}
 		page, total, err := c.listRunsPage(ctx, op, search, offset, size)
 		if err != nil {
-			return nil, err
+			return false, err
 		}
-		runs = append(runs, page...)
+		for _, run := range page {
+			if err := visit(run); err != nil {
+				return false, err
+			}
+		}
 		offset += uint32(len(page))
 		if len(page) == 0 || offset >= total {
-			break
+			return false, nil
 		}
 	}
-	return runs, nil
+	return true, nil
 }
 
 // latestMatchingRun returns the most recent run matching search, or nil when
 // there is none.
 //
-// A single row answers this. The daemon orders a run list by creation time,
-// newest first, so the first row is the latest run however many the
-// conversation has accumulated; reading a page to pick the newest out of it
-// would cost more for the same answer, and reading only the first page of a
-// long list would risk a wrong one.
+// A single row answers this. The daemon returns a run list newest first — a
+// contract pinned by TestListProjectRunsByOptionsReturnsNewestFirstAcrossPages
+// in pkg/storage/configstore, because these two callers depend on it — so the
+// first row is the latest run however many the conversation has accumulated.
+// Reading a page to pick the newest out of it would cost more for the same
+// answer, and would be no safer: if the order were not newest first, the
+// newest run could sit outside that page just as easily as outside a page of
+// one.
 func (c *Client) latestMatchingRun(ctx context.Context, op string, search Search) (*agentcomposev2.RunSummary, error) {
 	runs, _, err := c.listRunsPage(ctx, op, search, 0, 1)
 	if err != nil {

--- a/sdk/go/chat/directory_test.go
+++ b/sdk/go/chat/directory_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"strconv"
 	"testing"
@@ -194,9 +195,30 @@ func TestConversationsWalksPastTheFirstPageOfRuns(t *testing.T) {
 	}
 }
 
+// An unbounded walk that reaches the end is complete, and must not carry the
+// incomplete signal.
+func TestConversationsWithNoLimitReportsComplete(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	var runs []*agentcomposev2.RunSummary
+	for index := range listPageSize + 5 {
+		runs = append(runs, &agentcomposev2.RunSummary{
+			RunId: "run_" + strconv.Itoa(index), ProjectId: "p", AgentName: "a",
+			CreatedAt: timestamppb.New(time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)),
+		})
+	}
+	daemon.listRuns = listRunsPaged(runs...)
+	daemon.getRun = getRunLabelled(map[string]string{conversationLabel: "conv_1"})
+
+	if _, err := daemon.client(t).Conversations(context.Background(), Search{}); err != nil {
+		t.Fatalf("Conversations: %v", err)
+	}
+}
+
 // A caller's Limit is a budget over the whole walk. It bounds the cost of an
-// enumeration, and what it leaves out is left out by the caller's own choice.
-func TestConversationsHonorsLimitAsABudgetAcrossPages(t *testing.T) {
+// enumeration — and running out of it is reported, because a subset that
+// cannot be told apart from the whole is the bug this budget would otherwise
+// reintroduce.
+func TestConversationsHonorsLimitAsABudgetAndReportsWhatItLeftOut(t *testing.T) {
 	daemon := newFakeDaemon(t)
 	var runs []*agentcomposev2.RunSummary
 	for index := range listPageSize * 2 {
@@ -208,8 +230,13 @@ func TestConversationsHonorsLimitAsABudgetAcrossPages(t *testing.T) {
 	daemon.listRuns = listRunsPaged(runs...)
 	daemon.getRun = getRunLabelled(map[string]string{conversationLabel: "conv_1"})
 
-	if _, err := daemon.client(t).Conversations(context.Background(), Search{Limit: listPageSize + 1}); err != nil {
-		t.Fatalf("Conversations: %v", err)
+	found, err := daemon.client(t).Conversations(context.Background(), Search{Limit: listPageSize + 1})
+	if !errors.Is(err, ErrIncomplete) {
+		t.Fatalf("Conversations err = %v, want ErrIncomplete: the budget ran out with runs unread", err)
+	}
+	// The partial answer still comes back: it is usable, just not the whole.
+	if len(found) != 1 || found[0].ID != "conv_1" {
+		t.Errorf("got %+v, want the conversations found before the budget ran out", found)
 	}
 	// A budget of one page plus one run costs two pages, not the whole list.
 	if calls := daemon.count("ListRuns"); calls != 2 {
@@ -217,6 +244,25 @@ func TestConversationsHonorsLimitAsABudgetAcrossPages(t *testing.T) {
 	}
 	if calls := daemon.count("GetRun"); calls != listPageSize+1 {
 		t.Errorf("examined %d runs, want the budget of %d", calls, listPageSize+1)
+	}
+}
+
+// A budget large enough to reach the end is not "incomplete": the signal has
+// to mean something was left out, or callers will learn to ignore it.
+func TestConversationsReportsCompleteWhenTheBudgetIsEnough(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsPaged(&agentcomposev2.RunSummary{
+		RunId: "run_1", ProjectId: "p", AgentName: "a",
+		CreatedAt: timestamppb.New(time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)),
+	})
+	daemon.getRun = getRunLabelled(map[string]string{conversationLabel: "conv_1"})
+
+	found, err := daemon.client(t).Conversations(context.Background(), Search{Limit: 50})
+	if err != nil {
+		t.Fatalf("Conversations: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("got %d conversations, want 1", len(found))
 	}
 }
 

--- a/sdk/go/chat/directory_test.go
+++ b/sdk/go/chat/directory_test.go
@@ -1,0 +1,135 @@
+package chat
+
+import (
+	"context"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"testing"
+	"time"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// Lookup is the question authorization asks, and it must not need a label
+// read: the run list's own filter already answers "is there a conversation
+// with this ID carrying these labels?".
+func TestLookupAnswersFromTheFilterAloneWithoutReadingRunDetail(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(&agentcomposev2.RunSummary{
+		RunId: "run_1", ProjectId: "p", AgentName: "a",
+		Status:    agentcomposev2.RunStatus_RUN_STATUS_RUNNING,
+		CreatedAt: timestamppb.New(time.Now().UTC()),
+	})
+	found, ok, err := daemon.client(t).Lookup(context.Background(), "conv_1",
+		map[string]string{"chat.user": "alice"})
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if !ok {
+		t.Fatal("a conversation with a matching run was reported absent")
+	}
+	if found.ID != "conv_1" || found.ProjectID != "p" || found.AgentName != "a" {
+		t.Errorf("Lookup returned %+v", found)
+	}
+	if !found.Live {
+		t.Error("a conversation whose run is still running was not reported live")
+	}
+	if calls := daemon.count("GetRun"); calls != 0 {
+		t.Errorf("Lookup read run detail %d times; the filter is enough", calls)
+	}
+}
+
+// No run matching both labels means the conversation is not this user's, or
+// does not exist. The caller cannot tell which, which is the point.
+func TestLookupReportsNothingWhenNoRunMatches(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning()
+	_, ok, err := daemon.client(t).Lookup(context.Background(), "conv_1",
+		map[string]string{"chat.user": "mallory"})
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if ok {
+		t.Fatal("a conversation was reported for a user with no matching run")
+	}
+}
+
+func TestLookupRequiresAnID(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	if _, _, err := daemon.client(t).Lookup(context.Background(), "  ", nil); err == nil {
+		t.Fatal("an empty conversation ID was accepted")
+	}
+}
+
+// Enumeration is the expensive one: a run summary carries no labels, so the
+// conversation each run belongs to costs one detail read per run. A rebuilt
+// conversation occupies several runs and must still appear once.
+func TestConversationsReadsRunDetailAndFoldsARebuiltConversation(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	early := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	late := early.Add(2 * time.Hour)
+	daemon.listRuns = listRunsReturning(
+		&agentcomposev2.RunSummary{
+			RunId: "run_old", ProjectId: "p", AgentName: "a",
+			Status:    agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
+			CreatedAt: timestamppb.New(early),
+		},
+		&agentcomposev2.RunSummary{
+			RunId: "run_new", ProjectId: "p", AgentName: "a",
+			Status:    agentcomposev2.RunStatus_RUN_STATUS_RUNNING,
+			CreatedAt: timestamppb.New(late),
+		},
+	)
+	daemon.getRun = getRunLabelled(map[string]string{conversationLabel: "conv_1", "chat.user": "alice"})
+
+	found, err := daemon.client(t).Conversations(context.Background(), Search{
+		Labels: map[string]string{"chat.user": "alice"},
+	})
+	if err != nil {
+		t.Fatalf("Conversations: %v", err)
+	}
+	if len(found) != 1 || found[0].ID != "conv_1" {
+		t.Fatalf("got %+v, want one conv_1", found)
+	}
+	if !found[0].LastActive.Equal(late) {
+		t.Errorf("the conversation was described by the wrong run: %v", found[0].LastActive)
+	}
+	if !found[0].Live {
+		t.Error("a conversation whose latest run is running was not reported live")
+	}
+	if _, present := found[0].Labels[conversationLabel]; present {
+		t.Errorf("the identity label leaked into the caller's labels: %v", found[0].Labels)
+	}
+	if found[0].Labels["chat.user"] != "alice" {
+		t.Errorf("the caller's own labels were lost: %v", found[0].Labels)
+	}
+	if calls := daemon.count("GetRun"); calls != 2 {
+		t.Errorf("read run detail %d times for 2 runs", calls)
+	}
+}
+
+// The daemon's run list is shared with everything else that starts runs. A run
+// with no conversation identity has no ID that Open could resume, so it is not
+// a conversation and must not be reported as one.
+func TestConversationsIgnoresRunsThisPackageDidNotStart(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(&agentcomposev2.RunSummary{
+		RunId: "run_cli", ProjectId: "p", AgentName: "a",
+		Status: agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
+	})
+	daemon.getRun = getRunLabelled(map[string]string{"scheduler": "nightly"})
+	found, err := daemon.client(t).Conversations(context.Background(), Search{})
+	if err != nil {
+		t.Fatalf("Conversations: %v", err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("runs without a conversation identity were listed: %+v", found)
+	}
+}
+
+// getRunLabelled answers every GetRun with the same labels, which is the only
+// field the conversation directory reads from a run's detail.
+func getRunLabelled(labels map[string]string) func(*agentcomposev2.GetRunRequest) (*agentcomposev2.GetRunResponse, error) {
+	return func(*agentcomposev2.GetRunRequest) (*agentcomposev2.GetRunResponse, error) {
+		return &agentcomposev2.GetRunResponse{Run: &agentcomposev2.RunDetail{Labels: labels}}, nil
+	}
+}

--- a/sdk/go/chat/directory_test.go
+++ b/sdk/go/chat/directory_test.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"strconv"
 	"testing"
 	"time"
 
@@ -131,5 +132,126 @@ func TestConversationsIgnoresRunsThisPackageDidNotStart(t *testing.T) {
 func getRunLabelled(labels map[string]string) func(*agentcomposev2.GetRunRequest) (*agentcomposev2.GetRunResponse, error) {
 	return func(*agentcomposev2.GetRunRequest) (*agentcomposev2.GetRunResponse, error) {
 		return &agentcomposev2.GetRunResponse{Run: &agentcomposev2.RunDetail{Labels: labels}}, nil
+	}
+}
+
+// listRunsPaged emulates the daemon's run pagination over a fixed list,
+// honoring the request's offset and limit. listRunsReturning hands back
+// everything at once, which cannot show whether a caller walks past the first
+// page.
+func listRunsPaged(runs ...*agentcomposev2.RunSummary) func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+	return func(request *agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+		total := uint32(len(runs))
+		start := min(request.GetOffset(), total)
+		end := total
+		if limit := request.GetLimit(); limit > 0 {
+			end = min(start+limit, total)
+		}
+		return &agentcomposev2.ListRunsResponse{Runs: runs[start:end], Total: total}, nil
+	}
+}
+
+// A conversation is found through the runs it occupied, and a busy daemon has
+// far more runs than one page holds. Stopping at the first page would hide
+// whole conversations from an enumeration that claims to return every one.
+func TestConversationsWalksPastTheFirstPageOfRuns(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	created := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	labels := map[string]map[string]string{}
+	var runs []*agentcomposev2.RunSummary
+	// One conversation hogs the first page and then some; the other is reachable
+	// only by asking for a second one.
+	for index := range listPageSize + 5 {
+		runID := "run_" + strconv.Itoa(index)
+		conversation := "conv_loud"
+		if index >= listPageSize+3 {
+			conversation = "conv_quiet"
+		}
+		runs = append(runs, &agentcomposev2.RunSummary{
+			RunId: runID, ProjectId: "p", AgentName: "a",
+			Status:    agentcomposev2.RunStatus_RUN_STATUS_SUCCEEDED,
+			CreatedAt: timestamppb.New(created.Add(-time.Duration(index) * time.Minute)),
+		})
+		labels[runID] = map[string]string{conversationLabel: conversation}
+	}
+	daemon.listRuns = listRunsPaged(runs...)
+	daemon.getRun = func(request *agentcomposev2.GetRunRequest) (*agentcomposev2.GetRunResponse, error) {
+		return &agentcomposev2.GetRunResponse{Run: &agentcomposev2.RunDetail{Labels: labels[request.GetRunId()]}}, nil
+	}
+
+	found, err := daemon.client(t).Conversations(context.Background(), Search{})
+	if err != nil {
+		t.Fatalf("Conversations: %v", err)
+	}
+	if len(found) != 2 {
+		t.Fatalf("got %d conversations, want both", len(found))
+	}
+	if found[0].ID != "conv_loud" || found[1].ID != "conv_quiet" {
+		t.Errorf("got %q and %q, want conv_loud then conv_quiet by last activity", found[0].ID, found[1].ID)
+	}
+	if calls := daemon.count("ListRuns"); calls != 2 {
+		t.Errorf("listed runs %d times, want 2 pages for %d runs", calls, len(runs))
+	}
+}
+
+// A caller's Limit is a budget over the whole walk. It bounds the cost of an
+// enumeration, and what it leaves out is left out by the caller's own choice.
+func TestConversationsHonorsLimitAsABudgetAcrossPages(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	var runs []*agentcomposev2.RunSummary
+	for index := range listPageSize * 2 {
+		runs = append(runs, &agentcomposev2.RunSummary{
+			RunId: "run_" + strconv.Itoa(index), ProjectId: "p", AgentName: "a",
+			CreatedAt: timestamppb.New(time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)),
+		})
+	}
+	daemon.listRuns = listRunsPaged(runs...)
+	daemon.getRun = getRunLabelled(map[string]string{conversationLabel: "conv_1"})
+
+	if _, err := daemon.client(t).Conversations(context.Background(), Search{Limit: listPageSize + 1}); err != nil {
+		t.Fatalf("Conversations: %v", err)
+	}
+	// A budget of one page plus one run costs two pages, not the whole list.
+	if calls := daemon.count("ListRuns"); calls != 2 {
+		t.Errorf("listed runs %d times, want 2", calls)
+	}
+	if calls := daemon.count("GetRun"); calls != listPageSize+1 {
+		t.Errorf("examined %d runs, want the budget of %d", calls, listPageSize+1)
+	}
+}
+
+// Lookup and EndSession want the conversation's newest run and nothing else.
+// The daemon returns a run list newest first, so one row answers both however
+// many runs the conversation has piled up — and asking for one row is what
+// keeps a long-lived conversation from making the cheap question expensive.
+func TestLookupAsksTheDaemonForOnlyTheNewestRun(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	var asked *agentcomposev2.ListRunsRequest
+	daemon.listRuns = func(request *agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+		asked = request
+		return &agentcomposev2.ListRunsResponse{
+			Runs: []*agentcomposev2.RunSummary{{
+				RunId: "run_newest", ProjectId: "p", AgentName: "a",
+				Status:    agentcomposev2.RunStatus_RUN_STATUS_RUNNING,
+				CreatedAt: timestamppb.New(time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)),
+			}},
+			Total: 1200,
+		}, nil
+	}
+
+	found, ok, err := daemon.client(t).Lookup(context.Background(), "conv_1", nil)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if !ok || !found.Live {
+		t.Fatalf("Lookup returned %+v (ok=%v), want the live newest run", found, ok)
+	}
+	if asked.GetLimit() != 1 || asked.GetOffset() != 0 {
+		t.Errorf("asked for offset %d limit %d, want the single newest run", asked.GetOffset(), asked.GetLimit())
+	}
+	// 1200 matching runs, one request: the answer does not get more expensive
+	// as a conversation ages.
+	if calls := daemon.count("ListRuns"); calls != 1 {
+		t.Errorf("listed runs %d times, want 1", calls)
 	}
 }

--- a/sdk/go/chat/doc.go
+++ b/sdk/go/chat/doc.go
@@ -1,0 +1,29 @@
+// Package chat is a client for holding a conversation with an agent-compose
+// Agent.
+//
+// The vocabulary is conversational on purpose. A [Conversation] is a durable
+// thread of turns with one Agent; [Conversation.Send] contributes a message and
+// returns a [Reply] that streams the agent's answer. Nothing in this package
+// exposes the daemon's Run, Sandbox, or attach-frame vocabulary; code that
+// needs those should use the lower level run client instead.
+//
+// A Conversation keeps its environment across turns, so the agent retains
+// whatever context it persisted there. When that environment is gone and the
+// conversation had to be rebuilt, [Conversation.Continuity] reports
+// [Restarted] rather than silently starting over.
+//
+// # Lifetime
+//
+// [Conversation.Close] releases everything the handle holds — its stream and
+// the run behind it, whose environment the daemon then stops — while the
+// conversation's history and identity remain, so a later [Agent.Open] resumes
+// it, reporting [Restarted]. [Client.EndSession] does the same addressed by
+// ID, for a conversation no handle is attached to. Disconnecting without
+// closing never cancels work in progress:
+// an agent that is still working when the caller goes away keeps working, and
+// the events it produced meanwhile are available from
+// [Conversation.History] on return.
+//
+// A Client is safe for concurrent use. A Conversation is not, and permits one
+// Reply in flight at a time.
+package chat

--- a/sdk/go/chat/errors.go
+++ b/sdk/go/chat/errors.go
@@ -28,6 +28,12 @@ var (
 	ErrBusy = errors.New("chat: a reply is already in progress")
 	// ErrClosed reports use of a Conversation after Close.
 	ErrClosed = errors.New("chat: conversation is closed")
+	// ErrIncomplete reports an enumeration that stopped at the caller's own
+	// budget while matches were still unread. What was found is returned
+	// alongside it and is usable; it is just not the whole answer. An
+	// enumeration must never quietly stand in for a complete one, so a
+	// [Search.Limit] that runs out says so rather than returning a subset.
+	ErrIncomplete = errors.New("chat: result is incomplete")
 )
 
 // Error reports a failed agent-compose request.

--- a/sdk/go/chat/errors.go
+++ b/sdk/go/chat/errors.go
@@ -1,0 +1,126 @@
+package chat
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+)
+
+// Sentinel errors reported through [Error.Unwrap], so callers can classify a
+// failure with errors.Is without matching on message text.
+var (
+	// ErrInvalidArgument reports a request the server or this package rejected.
+	ErrInvalidArgument = errors.New("chat: invalid argument")
+	// ErrNotFound reports a conversation or agent that does not exist.
+	ErrNotFound = errors.New("chat: not found")
+	// ErrPermission reports a request the caller is not authorized to make.
+	ErrPermission = errors.New("chat: permission denied")
+	// ErrUnavailable reports a daemon that could not be reached or is failing.
+	ErrUnavailable = errors.New("chat: service unavailable")
+	// ErrConflict reports a request that lost a race for something the daemon
+	// hands to one holder at a time, such as a run's input. Retrying shortly
+	// is usually the right response: the holder is normally on its way out.
+	ErrConflict = errors.New("chat: conflicting request")
+	// ErrBusy reports a Send issued while an earlier Reply is still streaming.
+	ErrBusy = errors.New("chat: a reply is already in progress")
+	// ErrClosed reports use of a Conversation after Close.
+	ErrClosed = errors.New("chat: conversation is closed")
+)
+
+// Error reports a failed agent-compose request.
+type Error struct {
+	// Op names the package operation that failed, such as "Send".
+	Op string
+	// Code is the server's error code, empty when the failure was local.
+	Code string
+	// Status is the HTTP status, zero when the failure was local.
+	Status int
+	// Message is the server's human-readable description.
+	Message string
+}
+
+func (e *Error) Error() string {
+	message := cmp.Or(e.Message, "request failed")
+	switch {
+	case e.Code != "":
+		return fmt.Sprintf("chat: %s: %s: %s", e.Op, e.Code, message)
+	case e.Status != 0:
+		return fmt.Sprintf("chat: %s: HTTP %d: %s", e.Op, e.Status, message)
+	default:
+		return fmt.Sprintf("chat: %s: %s", e.Op, message)
+	}
+}
+
+// Unwrap maps the server's error code onto one of this package's sentinels.
+func (e *Error) Unwrap() error {
+	if e.conflict() {
+		return ErrConflict
+	}
+	switch strings.ToLower(strings.TrimSpace(e.Code)) {
+	case "invalid_argument", "out_of_range", "failed_precondition":
+		return ErrInvalidArgument
+	case "not_found":
+		return ErrNotFound
+	case "permission_denied", "unauthenticated":
+		return ErrPermission
+	case "unavailable", "deadline_exceeded", "resource_exhausted", "internal", "unknown":
+		return ErrUnavailable
+	}
+	switch e.Status {
+	case 400, 412, 416:
+		return ErrInvalidArgument
+	case 401, 403:
+		return ErrPermission
+	case 404:
+		return ErrNotFound
+	case 429, 500, 502, 503, 504:
+		return ErrUnavailable
+	}
+	return nil
+}
+
+func invalidArgument(op, format string, args ...any) error {
+	return &Error{Op: op, Code: "invalid_argument", Message: fmt.Sprintf(format, args...)}
+}
+
+func unavailable(op string, err error) error {
+	return &Error{Op: op, Code: "unavailable", Message: err.Error()}
+}
+
+// conflict reports whether this is the daemon losing a race for something it
+// hands to one holder at a time.
+//
+// The daemon renders its conflicts as FAILED_PRECONDITION with a "conflict:"
+// prefix rather than as ABORTED, so the prefix is what separates them from a
+// genuine precondition failure. Both spellings are accepted, so this keeps
+// working once the daemon uses the code the condition deserves.
+func (e *Error) conflict() bool {
+	switch strings.ToLower(strings.TrimSpace(e.Code)) {
+	case "aborted", "already_exists":
+		return true
+	case "failed_precondition":
+		return strings.HasPrefix(strings.TrimSpace(e.Message), "conflict:")
+	}
+	return false
+}
+
+// fromConnect names a Connect failure in this package's terms. A failure that
+// never reached the daemon - a dial that did not connect, a context that
+// ended - carries no code, and is reported as unavailable.
+func fromConnect(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var already *Error
+	if errors.As(err, &already) {
+		return already
+	}
+	var failure *connect.Error
+	if !errors.As(err, &failure) {
+		return unavailable(op, err)
+	}
+	return &Error{Op: op, Code: failure.Code().String(), Message: failure.Message()}
+}

--- a/sdk/go/chat/event.go
+++ b/sdk/go/chat/event.go
@@ -1,0 +1,384 @@
+package chat
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// EventKind identifies an [Event] variant without a type switch.
+type EventKind string
+
+// Event kinds, mirroring the provider-neutral agent event model every runner
+// maps its provider onto.
+const (
+	KindStepStart      EventKind = "step_start"
+	KindStepEnd        EventKind = "step_end"
+	KindTextDelta      EventKind = "text_delta"
+	KindReasoningDelta EventKind = "reasoning_delta"
+	KindToolCall       EventKind = "tool_call"
+	KindToolResult     EventKind = "tool_result"
+	KindTodo           EventKind = "todo"
+	KindUsage          EventKind = "usage"
+	KindRetry          EventKind = "retry"
+	KindCompaction     EventKind = "compaction"
+	KindError          EventKind = "error"
+)
+
+// Event is one observation from an agent working on a turn. Known
+// provider-neutral variants have concrete types; provider extensions use
+// [RawEvent]. Switch on the concrete type to handle them.
+//
+// A provider that structurally cannot report a kind emits no event of that
+// kind at all, and an optional field a provider does not report stays nil.
+// Neither is ever filled in with a zero value, so a caller can always tell
+// "did not happen" from "this provider never reports it".
+type Event interface {
+	// Kind reports which variant this is.
+	Kind() EventKind
+	// At reports when the daemon recorded the event.
+	At() time.Time
+	isEvent()
+}
+
+// RawEvent preserves an AttachAgentEvent whose provider-defined name is not
+// part of this SDK's typed, provider-neutral schema. The daemon's event name,
+// display text, and JSON payload are kept intact so clients can evolve their
+// own handling without waiting for an SDK release.
+type RawEvent struct {
+	eventAt
+	Name        string `json:"name"`
+	Text        string `json:"text,omitempty"`
+	PayloadJSON string `json:"payloadJson,omitempty"`
+}
+
+// Kind reports the daemon-provided event name, including provider extensions.
+func (e *RawEvent) Kind() EventKind { return EventKind(e.Name) }
+
+// ToolKind categorizes what a tool does.
+type ToolKind string
+
+// Tool categories.
+const (
+	ToolRead    ToolKind = "read"
+	ToolEdit    ToolKind = "edit"
+	ToolDelete  ToolKind = "delete"
+	ToolMove    ToolKind = "move"
+	ToolSearch  ToolKind = "search"
+	ToolExecute ToolKind = "execute"
+	ToolThink   ToolKind = "think"
+	ToolFetch   ToolKind = "fetch"
+	ToolOther   ToolKind = "other"
+)
+
+// StopReason explains why a step ended.
+type StopReason string
+
+// Stop reasons.
+const (
+	StopEnd       StopReason = "stop"
+	StopToolUse   StopReason = "tool_use"
+	StopMaxTokens StopReason = "max_tokens"
+	StopCancelled StopReason = "cancelled"
+	StopError     StopReason = "error"
+)
+
+// ToolCallStatus is the lifecycle state of a tool call.
+type ToolCallStatus string
+
+// Tool call states.
+const (
+	ToolPending    ToolCallStatus = "pending"
+	ToolInProgress ToolCallStatus = "in_progress"
+	ToolCompleted  ToolCallStatus = "completed"
+	ToolFailed     ToolCallStatus = "failed"
+)
+
+// UsageScope is the aggregation level a [UsageEvent] covers.
+//
+// Providers disagree: some report per turn, some per run, most per step.
+// Records of differing scope must never be summed.
+type UsageScope string
+
+// Usage aggregation levels.
+const (
+	ScopeStep UsageScope = "step"
+	ScopeTurn UsageScope = "turn"
+	ScopeRun  UsageScope = "run"
+)
+
+// RetryReason explains why the provider retried.
+type RetryReason string
+
+// Retry reasons.
+const (
+	RetryRateLimit  RetryReason = "rate_limit"
+	RetryOverloaded RetryReason = "overloaded"
+	RetryNetwork    RetryReason = "network"
+	RetryOther      RetryReason = "other"
+)
+
+// Severity grades an [ErrorEvent].
+type Severity string
+
+// Error severities.
+const (
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+	SeverityFatal   Severity = "fatal"
+)
+
+// CompactionPhase marks the boundaries of a context compaction.
+type CompactionPhase string
+
+// Compaction phases.
+const (
+	CompactionStart CompactionPhase = "start"
+	CompactionEnd   CompactionPhase = "end"
+)
+
+// FileChange is one path a tool call touched.
+type FileChange struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+}
+
+// TodoItem is one entry of an agent's plan.
+type TodoItem struct {
+	Text      string `json:"text"`
+	Completed bool   `json:"completed"`
+}
+
+type eventAt struct {
+	Time time.Time `json:"-"`
+}
+
+func (e eventAt) At() time.Time { return e.Time }
+func (eventAt) isEvent()        {}
+
+// StepStartEvent reports that the agent began a step.
+type StepStartEvent struct {
+	eventAt
+	Step *int `json:"step,omitempty"`
+}
+
+// Kind reports [KindStepStart].
+func (*StepStartEvent) Kind() EventKind { return KindStepStart }
+
+// StepEndScope identifies what a [StepEndEvent] closes.
+type StepEndScope string
+
+// Step-end scopes.
+const (
+	StepEndScopeStep StepEndScope = "step"
+	StepEndScopeRun  StepEndScope = "run"
+)
+
+// StepEndEvent reports that the agent finished a step.
+type StepEndEvent struct {
+	eventAt
+	Step *int `json:"step,omitempty"`
+	// Scope is [StepEndScopeRun] for a turn/run terminator that does not close
+	// an individual step. Empty means the provider did not report a scope.
+	Scope StepEndScope `json:"scope,omitempty"`
+	// StopReason is empty when the provider does not report one.
+	StopReason StopReason `json:"stopReason,omitempty"`
+	// RawStopReason preserves the provider's own spelling.
+	RawStopReason string `json:"rawStopReason,omitempty"`
+}
+
+// Kind reports [KindStepEnd].
+func (*StepEndEvent) Kind() EventKind { return KindStepEnd }
+
+// TextDeltaEvent carries a fragment of the agent's answer.
+type TextDeltaEvent struct {
+	eventAt
+	Step       *int   `json:"step,omitempty"`
+	BlockIndex *int   `json:"blockIndex,omitempty"`
+	Text       string `json:"text"`
+}
+
+// Kind reports [KindTextDelta].
+func (*TextDeltaEvent) Kind() EventKind { return KindTextDelta }
+
+// ReasoningDeltaEvent carries a fragment of the agent's reasoning. It is not
+// part of the answer and is absent for providers that do not expose it.
+type ReasoningDeltaEvent struct {
+	eventAt
+	Step       *int   `json:"step,omitempty"`
+	BlockIndex *int   `json:"blockIndex,omitempty"`
+	Text       string `json:"text"`
+}
+
+// Kind reports [KindReasoningDelta].
+func (*ReasoningDeltaEvent) Kind() EventKind { return KindReasoningDelta }
+
+// ToolCallEvent reports a tool the agent invoked. Correlate it with its
+// [ToolResultEvent] through ID.
+type ToolCallEvent struct {
+	eventAt
+	Step            *int            `json:"step,omitempty"`
+	ParentToolUseID string          `json:"parentToolUseId,omitempty"`
+	ID              string          `json:"id"`
+	Name            string          `json:"name"`
+	ToolKind        ToolKind        `json:"toolKind"`
+	Status          ToolCallStatus  `json:"status"`
+	Input           json.RawMessage `json:"input,omitempty"`
+	// Command is present when ToolKind is [ToolExecute].
+	Command  string `json:"command,omitempty"`
+	ExitCode *int32 `json:"exitCode,omitempty"`
+	// Changes is present when the call applied a patch.
+	Changes []FileChange `json:"changes,omitempty"`
+}
+
+// Kind reports [KindToolCall].
+func (*ToolCallEvent) Kind() EventKind { return KindToolCall }
+
+// ToolResultEvent reports what a tool returned.
+type ToolResultEvent struct {
+	eventAt
+	Step            *int   `json:"step,omitempty"`
+	ParentToolUseID string `json:"parentToolUseId,omitempty"`
+	ID              string `json:"id"`
+	OK              bool   `json:"ok"`
+	Output          string `json:"output,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+// Kind reports [KindToolResult].
+func (*ToolResultEvent) Kind() EventKind { return KindToolResult }
+
+// TodoEvent reports the agent's current plan.
+type TodoEvent struct {
+	eventAt
+	Items []TodoItem `json:"items"`
+}
+
+// Kind reports [KindTodo].
+func (*TodoEvent) Kind() EventKind { return KindTodo }
+
+// UsageEvent reports token accounting.
+//
+// Sum only records sharing a Scope. InputTokens always excludes cached tokens,
+// and OutputTokens always includes reasoning tokens.
+type UsageEvent struct {
+	eventAt
+	Step  *int       `json:"step,omitempty"`
+	Scope UsageScope `json:"scope"`
+	Model string     `json:"model,omitempty"`
+	// InputTokens always excludes cached tokens.
+	InputTokens int64 `json:"inputTokens"`
+	// OutputTokens includes reasoning tokens.
+	OutputTokens     int64    `json:"outputTokens"`
+	ReasoningTokens  *int64   `json:"reasoningTokens,omitempty"`
+	CachedTokens     *int64   `json:"cachedTokens,omitempty"`
+	CacheWriteTokens *int64   `json:"cacheWriteTokens,omitempty"`
+	CostUSD          *float64 `json:"costUsd,omitempty"`
+}
+
+// Kind reports [KindUsage].
+func (*UsageEvent) Kind() EventKind { return KindUsage }
+
+// RetryEvent reports that the provider retried a request.
+type RetryEvent struct {
+	eventAt
+	Reason      RetryReason `json:"reason"`
+	Attempt     int         `json:"attempt"`
+	MaxAttempts *int        `json:"maxAttempts,omitempty"`
+	Message     string      `json:"message,omitempty"`
+}
+
+// Kind reports [KindRetry].
+func (*RetryEvent) Kind() EventKind { return KindRetry }
+
+// CompactionEvent marks the agent compacting its context.
+type CompactionEvent struct {
+	eventAt
+	Phase CompactionPhase `json:"phase"`
+}
+
+// Kind reports [KindCompaction].
+func (*CompactionEvent) Kind() EventKind { return KindCompaction }
+
+// ErrorEvent reports a problem the agent hit. A [SeverityFatal] event ends the
+// turn; the others do not.
+type ErrorEvent struct {
+	eventAt
+	Severity  Severity `json:"severity"`
+	Code      string   `json:"code,omitempty"`
+	Retryable *bool    `json:"retryable,omitempty"`
+	Message   string   `json:"message"`
+}
+
+// Kind reports [KindError].
+func (*ErrorEvent) Kind() EventKind { return KindError }
+
+// decodeEvent maps one agent event frame onto its variant. An unrecognized
+// kind becomes RawEvent: the daemon may add provider extensions this build
+// does not know, and callers should still be able to inspect them.
+func decodeEvent(name string, payload []byte, at time.Time) (Event, error) {
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	var target Event
+	switch EventKind(name) {
+	case KindStepStart:
+		target = &StepStartEvent{}
+	case KindStepEnd:
+		target = &StepEndEvent{}
+	case KindTextDelta, EventKind("output"):
+		// Older prompt-based runtimes used the generic output name for
+		// incremental assistant text. Keep accepting it so clients can attach
+		// to guests built before the provider-neutral text_delta name landed.
+		target = &TextDeltaEvent{}
+	case KindReasoningDelta:
+		target = &ReasoningDeltaEvent{}
+	case KindToolCall:
+		target = &ToolCallEvent{}
+	case KindToolResult:
+		target = &ToolResultEvent{}
+	case KindTodo:
+		target = &TodoEvent{}
+	case KindUsage:
+		target = &UsageEvent{}
+	case KindRetry:
+		target = &RetryEvent{}
+	case KindCompaction:
+		target = &CompactionEvent{}
+	case KindError:
+		target = &ErrorEvent{}
+	default:
+		return &RawEvent{eventAt: eventAt{Time: at}, Name: name, PayloadJSON: string(payload)}, nil
+	}
+	if err := json.Unmarshal(payload, target); err != nil {
+		return nil, err
+	}
+	setEventTime(target, at)
+	return target, nil
+}
+
+func setEventTime(event Event, at time.Time) {
+	switch typed := event.(type) {
+	case *StepStartEvent:
+		typed.Time = at
+	case *StepEndEvent:
+		typed.Time = at
+	case *TextDeltaEvent:
+		typed.Time = at
+	case *ReasoningDeltaEvent:
+		typed.Time = at
+	case *ToolCallEvent:
+		typed.Time = at
+	case *ToolResultEvent:
+		typed.Time = at
+	case *TodoEvent:
+		typed.Time = at
+	case *UsageEvent:
+		typed.Time = at
+	case *RetryEvent:
+		typed.Time = at
+	case *CompactionEvent:
+		typed.Time = at
+	case *ErrorEvent:
+		typed.Time = at
+	}
+}

--- a/sdk/go/chat/event_test.go
+++ b/sdk/go/chat/event_test.go
@@ -1,0 +1,237 @@
+package chat
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestDecodeEventKeepsAbsentFieldsAbsent(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+
+	// A provider that does not report step numbers must not be made to look
+	// like one reporting step 0.
+	event, err := decodeEvent("text_delta", []byte(`{"text":"hi"}`), at)
+	if err != nil {
+		t.Fatalf("decode text_delta: %v", err)
+	}
+	delta, ok := event.(*TextDeltaEvent)
+	if !ok {
+		t.Fatalf("event = %T, want *TextDeltaEvent", event)
+	}
+	if delta.Step != nil {
+		t.Errorf("step = %d, want nil for a provider that does not report it", *delta.Step)
+	}
+	if delta.Text != "hi" || delta.At() != at {
+		t.Errorf("event = %#v", delta)
+	}
+
+	event, err = decodeEvent("text_delta", []byte(`{"text":"hi","step":0}`), at)
+	if err != nil {
+		t.Fatalf("decode text_delta with step: %v", err)
+	}
+	if step := event.(*TextDeltaEvent).Step; step == nil || *step != 0 {
+		t.Errorf("step = %v, want an explicit 0", step)
+	}
+}
+
+func TestDecodeEventTreatsLegacyOutputAsTextDelta(t *testing.T) {
+	event, err := decodeEvent("output", []byte(`{"provider":"claude","text":"partial"}`), time.Unix(1000, 0).UTC())
+	if err != nil {
+		t.Fatalf("decode legacy output: %v", err)
+	}
+	delta, ok := event.(*TextDeltaEvent)
+	if !ok {
+		t.Fatalf("event = %T, want *TextDeltaEvent", event)
+	}
+	if delta.Text != "partial" {
+		t.Errorf("text = %q, want partial", delta.Text)
+	}
+}
+
+func TestDecodeEventVariants(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	for _, testCase := range []struct {
+		name    string
+		kind    string
+		payload string
+		verify  func(*testing.T, Event)
+	}{
+		{
+			name:    "tool call",
+			kind:    "tool_call",
+			payload: `{"id":"t1","name":"bash","toolKind":"execute","status":"completed","command":"ls","exitCode":0,"input":{"cmd":"ls"}}`,
+			verify: func(t *testing.T, event Event) {
+				call := event.(*ToolCallEvent)
+				if call.ToolKind != ToolExecute || call.Status != ToolCompleted || call.Command != "ls" {
+					t.Errorf("call = %#v", call)
+				}
+				if call.ExitCode == nil || *call.ExitCode != 0 {
+					t.Errorf("exit code = %v, want an explicit 0", call.ExitCode)
+				}
+				if string(call.Input) != `{"cmd":"ls"}` {
+					t.Errorf("input = %s, want the raw payload preserved", call.Input)
+				}
+			},
+		},
+		{
+			name:    "tool result",
+			kind:    "tool_result",
+			payload: `{"id":"t1","ok":false,"error":"boom"}`,
+			verify: func(t *testing.T, event Event) {
+				result := event.(*ToolResultEvent)
+				if result.ID != "t1" || result.OK || result.Error != "boom" {
+					t.Errorf("result = %#v", result)
+				}
+			},
+		},
+		{
+			name:    "usage",
+			kind:    "usage",
+			payload: `{"scope":"turn","inputTokens":120,"outputTokens":30,"cachedTokens":90}`,
+			verify: func(t *testing.T, event Event) {
+				usage := event.(*UsageEvent)
+				if usage.Scope != ScopeTurn || usage.InputTokens != 120 || usage.OutputTokens != 30 {
+					t.Errorf("usage = %#v", usage)
+				}
+				if usage.CachedTokens == nil || *usage.CachedTokens != 90 {
+					t.Errorf("cached tokens = %v, want 90", usage.CachedTokens)
+				}
+				if usage.CostUSD != nil {
+					t.Errorf("cost = %v, want nil for a provider that does not price runs", *usage.CostUSD)
+				}
+			},
+		},
+		{
+			name:    "step end",
+			kind:    "step_end",
+			payload: `{"step":2,"scope":"step","stopReason":"tool_use","rawStopReason":"toolUse"}`,
+			verify: func(t *testing.T, event Event) {
+				end := event.(*StepEndEvent)
+				if end.Scope != StepEndScopeStep || end.StopReason != StopToolUse || end.RawStopReason != "toolUse" {
+					t.Errorf("step end = %#v", end)
+				}
+			},
+		},
+		{
+			name:    "run end",
+			kind:    "step_end",
+			payload: `{"scope":"run","stopReason":"stop"}`,
+			verify: func(t *testing.T, event Event) {
+				end := event.(*StepEndEvent)
+				if end.Scope != StepEndScopeRun || end.Step != nil || end.StopReason != StopEnd {
+					t.Errorf("run end = %#v", end)
+				}
+			},
+		},
+		{
+			name:    "todo",
+			kind:    "todo",
+			payload: `{"items":[{"text":"read the diff","completed":true}]}`,
+			verify: func(t *testing.T, event Event) {
+				todo := event.(*TodoEvent)
+				if len(todo.Items) != 1 || !todo.Items[0].Completed {
+					t.Errorf("todo = %#v", todo)
+				}
+			},
+		},
+		{
+			name:    "error",
+			kind:    "error",
+			payload: `{"severity":"warning","message":"slow","retryable":true}`,
+			verify: func(t *testing.T, event Event) {
+				failure := event.(*ErrorEvent)
+				if failure.Severity != SeverityWarning || failure.Retryable == nil || !*failure.Retryable {
+					t.Errorf("error = %#v", failure)
+				}
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			event, err := decodeEvent(testCase.kind, []byte(testCase.payload), at)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if event == nil {
+				t.Fatal("decode returned no event")
+			}
+			if string(event.Kind()) != testCase.kind {
+				t.Errorf("kind = %q, want %q", event.Kind(), testCase.kind)
+			}
+			if event.At() != at {
+				t.Errorf("time = %v, want %v", event.At(), at)
+			}
+			testCase.verify(t, event)
+		})
+	}
+}
+
+func TestDecodeEventPreservesKindsThisBuildDoesNotKnow(t *testing.T) {
+	event, err := decodeEvent("some_future_kind", []byte(`{"whatever":1}`), time.Now())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw, ok := event.(*RawEvent)
+	if !ok || raw.Name != "some_future_kind" || raw.PayloadJSON != `{"whatever":1}` {
+		t.Errorf("event = %#v, want preserved raw event", event)
+	}
+}
+
+func TestErrorUnwrapsToSentinels(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		err    *Error
+		target error
+	}{
+		{"code wins over status", &Error{Code: "not_found", Status: http.StatusInternalServerError}, ErrNotFound},
+		{"permission from code", &Error{Code: "permission_denied"}, ErrPermission},
+		{"invalid from code", &Error{Code: "invalid_argument"}, ErrInvalidArgument},
+		{"unavailable from code", &Error{Code: "unavailable"}, ErrUnavailable},
+		{"status when no code", &Error{Status: http.StatusForbidden}, ErrPermission},
+		{"gateway status", &Error{Status: http.StatusBadGateway}, ErrUnavailable},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if !errors.Is(testCase.err, testCase.target) {
+				t.Errorf("%v does not match %v", testCase.err, testCase.target)
+			}
+		})
+	}
+}
+
+func TestNewRejectsUnusableBaseURLs(t *testing.T) {
+	for _, testCase := range []struct{ name, baseURL string }{
+		{"empty", ""},
+		{"relative", "/agentcompose"},
+		{"unsupported scheme", "unix:///var/run/agent-compose.sock"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := New(Config{BaseURL: testCase.baseURL}); !errors.Is(err, ErrInvalidArgument) {
+				t.Errorf("New(%q) error = %v, want ErrInvalidArgument", testCase.baseURL, err)
+			}
+		})
+	}
+	if _, err := New(Config{BaseURL: "http://127.0.0.1:7410/"}); err != nil {
+		t.Errorf("New: %v", err)
+	}
+}
+
+func TestWithLabelsCannotOverrideConversationIdentity(t *testing.T) {
+	resolved := newOptions([]Option{
+		WithID("conv-1"),
+		WithLabels(map[string]string{"team": "platform", conversationLabel: "someone-elses"}),
+	})
+	if resolved.labels[conversationLabel] != "" {
+		t.Errorf("labels = %v, want the identity label reserved", resolved.labels)
+	}
+	if resolved.labels["team"] != "platform" {
+		t.Errorf("labels = %v, want the caller's own labels kept", resolved.labels)
+	}
+}
+
+func TestConversationIDsAreGeneratedWhenNotSupplied(t *testing.T) {
+	first, second := newOptions(nil).id, newOptions(nil).id
+	if first == "" || first == second {
+		t.Errorf("generated IDs %q and %q, want two distinct values", first, second)
+	}
+}

--- a/sdk/go/chat/fake_daemon_test.go
+++ b/sdk/go/chat/fake_daemon_test.go
@@ -1,0 +1,269 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+	"github.com/chaitin/agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+// fakeDaemon is a stand-in for agent-compose. It serves the generated Connect
+// handler rather than imitating the protocol, so the framing, codec and
+// procedure paths under test are the real ones. It serves h2c because Connect
+// needs HTTP/2 for bidirectional streams.
+type fakeDaemon struct {
+	agentcomposev2connect.UnimplementedRunServiceHandler
+
+	t      *testing.T
+	server *httptest.Server
+
+	// The hooks below answer one procedure each. A procedure with no hook
+	// answers NotFound, which is what an unconfigured expectation should look
+	// like rather than a nil dereference.
+	listRuns      func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error)
+	getRun        func(*agentcomposev2.GetRunRequest) (*agentcomposev2.GetRunResponse, error)
+	listRunEvents func(*agentcomposev2.ListRunEventsRequest) (*agentcomposev2.ListRunEventsResponse, error)
+	stopRun       func(*agentcomposev2.StopRunRequest) (*agentcomposev2.StopRunResponse, error)
+	listProjects  func(*agentcomposev2.ListProjectsRequest) (*agentcomposev2.ListProjectsResponse, error)
+	getProject    func(*agentcomposev2.GetProjectRequest) (*agentcomposev2.GetProjectResponse, error)
+	attach        func(*fakeStream)
+
+	// hold keeps handlers that emulate a detached session parked until the
+	// test ends.
+	hold chan struct{}
+
+	mu    sync.Mutex
+	calls []string
+}
+
+func newFakeDaemon(t *testing.T) *fakeDaemon {
+	t.Helper()
+	daemon := &fakeDaemon{t: t, hold: make(chan struct{})}
+	mux := http.NewServeMux()
+	mux.Handle(agentcomposev2connect.NewRunServiceHandler(daemon))
+	mux.Handle(agentcomposev2connect.NewProjectServiceHandler(&fakeProjects{daemon: daemon}))
+	daemon.server = httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	t.Cleanup(daemon.server.Close)
+	// Registered second so it runs first: Close waits on outstanding handlers,
+	// and a parked one would never return.
+	t.Cleanup(func() { close(daemon.hold) })
+	return daemon
+}
+
+func (d *fakeDaemon) client(t *testing.T) *Client {
+	t.Helper()
+	client, err := New(Config{BaseURL: d.server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return client
+}
+
+func (d *fakeDaemon) record(procedure string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls = append(d.calls, procedure)
+}
+
+// count reports how many times a procedure was called.
+func (d *fakeDaemon) count(procedure string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	total := 0
+	for _, call := range d.calls {
+		if call == procedure {
+			total++
+		}
+	}
+	return total
+}
+
+func unconfigured(procedure string) error {
+	return connect.NewError(connect.CodeNotFound, errors.New(procedure+" is not configured"))
+}
+
+func (d *fakeDaemon) ListRuns(_ context.Context, request *connect.Request[agentcomposev2.ListRunsRequest]) (*connect.Response[agentcomposev2.ListRunsResponse], error) {
+	d.record("ListRuns")
+	if d.listRuns == nil {
+		return nil, unconfigured("ListRuns")
+	}
+	response, err := d.listRuns(request.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (d *fakeDaemon) GetRun(_ context.Context, request *connect.Request[agentcomposev2.GetRunRequest]) (*connect.Response[agentcomposev2.GetRunResponse], error) {
+	d.record("GetRun")
+	if d.getRun == nil {
+		return nil, unconfigured("GetRun")
+	}
+	response, err := d.getRun(request.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (d *fakeDaemon) ListRunEvents(_ context.Context, request *connect.Request[agentcomposev2.ListRunEventsRequest]) (*connect.Response[agentcomposev2.ListRunEventsResponse], error) {
+	d.record("ListRunEvents")
+	if d.listRunEvents == nil {
+		return nil, unconfigured("ListRunEvents")
+	}
+	response, err := d.listRunEvents(request.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (d *fakeDaemon) StopRun(_ context.Context, request *connect.Request[agentcomposev2.StopRunRequest]) (*connect.Response[agentcomposev2.StopRunResponse], error) {
+	d.record("StopRun")
+	if d.stopRun == nil {
+		return connect.NewResponse(&agentcomposev2.StopRunResponse{}), nil
+	}
+	response, err := d.stopRun(request.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (d *fakeDaemon) AttachAgentRun(_ context.Context, stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]) error {
+	d.record("AttachAgentRun")
+	if d.attach == nil {
+		return nil
+	}
+	d.attach(&fakeStream{t: d.t, stream: stream, hold: d.hold})
+	return nil
+}
+
+// fakeStream is one attach, as the test script sees it.
+type fakeStream struct {
+	t      *testing.T
+	stream *connect.BidiStream[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]
+	// hold blocks a handler that should keep the session open the way a
+	// detached daemon does. It is closed when the test's server shuts down.
+	hold chan struct{}
+}
+
+// recv reads the next client frame, reporting false once the client stops
+// sending. It never fails the test itself: this runs on the server's
+// goroutine, which may outlive the test.
+func (s *fakeStream) recv() (*agentcomposev2.AttachAgentRunRequest, bool) {
+	frame, err := s.stream.Receive()
+	if err != nil {
+		return nil, false
+	}
+	return frame, true
+}
+
+func (s *fakeStream) send(frame *agentcomposev2.AttachAgentRunResponse) {
+	_ = s.stream.Send(frame)
+}
+
+// agentEvent sends one provider-neutral agent event.
+func (s *fakeStream) agentEvent(kind string, payload any) {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	s.send(&agentcomposev2.AttachAgentRunResponse{
+		Frame: &agentcomposev2.AttachAgentRunResponse_AgentEvent{
+			AgentEvent: &agentcomposev2.AttachAgentEvent{Name: kind, PayloadJson: string(encoded)},
+		},
+	})
+}
+
+// The constructors below keep a test's intent - "the daemon says the run
+// started" - from being buried under the oneof wrapper the wire needs.
+
+func started(runID, sandboxID string) *agentcomposev2.AttachAgentRunResponse {
+	return &agentcomposev2.AttachAgentRunResponse{
+		Frame: &agentcomposev2.AttachAgentRunResponse_Started{
+			Started: &agentcomposev2.AttachStarted{RunId: runID, SandboxId: sandboxID},
+		},
+	}
+}
+
+func turnCompleted(resultJSON string) *agentcomposev2.AttachAgentRunResponse {
+	return &agentcomposev2.AttachAgentRunResponse{
+		Frame: &agentcomposev2.AttachAgentRunResponse_AgentTurnCompleted{
+			AgentTurnCompleted: &agentcomposev2.AttachAgentTurnCompleted{ResultJson: resultJSON},
+		},
+	}
+}
+
+func runResult(success bool, failure string) *agentcomposev2.AttachAgentRunResponse {
+	return &agentcomposev2.AttachAgentRunResponse{
+		Frame: &agentcomposev2.AttachAgentRunResponse_Result{
+			Result: &agentcomposev2.AttachResult{Success: success, Error: failure},
+		},
+	}
+}
+
+func attachFailure(code, message string, terminal bool) *agentcomposev2.AttachAgentRunResponse {
+	return &agentcomposev2.AttachAgentRunResponse{
+		Frame: &agentcomposev2.AttachAgentRunResponse_Error{
+			Error: &agentcomposev2.AttachError{Code: code, Message: message, Terminal: terminal},
+		},
+	}
+}
+
+// runSummary builds a summary with the fields these tests actually assert on.
+func runSummary(runID, status, sandboxID string, created ...*timestamppb.Timestamp) *agentcomposev2.RunSummary {
+	summary := &agentcomposev2.RunSummary{
+		RunId:     runID,
+		SandboxId: sandboxID,
+		Status:    agentcomposev2.RunStatus(agentcomposev2.RunStatus_value[strings.ToUpper(status)]),
+	}
+	if len(created) > 0 {
+		summary.CreatedAt = created[0]
+	}
+	return summary
+}
+
+// fakeProjects serves the catalog half of the daemon. It is a type of its own
+// because a handler value implements one service.
+type fakeProjects struct {
+	agentcomposev2connect.UnimplementedProjectServiceHandler
+
+	daemon *fakeDaemon
+}
+
+func (p *fakeProjects) ListProjects(_ context.Context, request *connect.Request[agentcomposev2.ListProjectsRequest]) (*connect.Response[agentcomposev2.ListProjectsResponse], error) {
+	p.daemon.record("ListProjects")
+	if p.daemon.listProjects == nil {
+		return nil, unconfigured("ListProjects")
+	}
+	response, err := p.daemon.listProjects(request.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (p *fakeProjects) GetProject(_ context.Context, request *connect.Request[agentcomposev2.GetProjectRequest]) (*connect.Response[agentcomposev2.GetProjectResponse], error) {
+	p.daemon.record("GetProject")
+	if p.daemon.getProject == nil {
+		return nil, unconfigured("GetProject")
+	}
+	response, err := p.daemon.getProject(request.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}

--- a/sdk/go/chat/history.go
+++ b/sdk/go/chat/history.go
@@ -1,0 +1,194 @@
+package chat
+
+import (
+	"connectrpc.com/connect"
+	"context"
+	"encoding/base64"
+	"errors"
+	"slices"
+	"strconv"
+	"strings"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// HistoryOptions bounds one page of a [Conversation.HistoryPage] read.
+type HistoryOptions struct {
+	// Limit caps how many messages the page returns. Zero uses a sensible
+	// default.
+	Limit int
+	// Before resumes a walk started by an earlier call's [HistoryPage.Cursor],
+	// continuing further into the conversation's past. Empty starts from the
+	// most recent message.
+	Before string
+}
+
+// HistoryPage is one page of a conversation's transcript, oldest message
+// first.
+type HistoryPage struct {
+	// Messages is this page, oldest first.
+	Messages []Message
+	// Cursor resumes the walk further into the past via
+	// [HistoryOptions.Before]. Empty means there is nothing older.
+	Cursor string
+}
+
+// HistoryPage returns one page of the conversation's transcript, walking
+// backward from the most recent message.
+//
+// Unlike [Conversation.History], which fetches every turn the conversation
+// has ever had, HistoryPage fetches only what a page needs: opening a long
+// conversation should cost a bounded number of requests, not one proportional
+// to how many turns it has accumulated. A chat UI that loads the most recent
+// messages and reaches further back only when the reader scrolls up should
+// use this instead of History.
+func (c *Conversation) HistoryPage(ctx context.Context, opts HistoryOptions) (HistoryPage, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = historyPageSize
+	}
+	runs, err := c.runs(ctx, "History")
+	if err != nil {
+		return HistoryPage{}, err
+	}
+
+	runIndex, upto, fresh := len(runs)-1, uint32(0), true
+	if opts.Before != "" {
+		decodedIndex, decodedUpto, decodeErr := decodeHistoryCursor(opts.Before)
+		if decodeErr != nil || decodedIndex < 0 || decodedIndex >= len(runs) {
+			return HistoryPage{}, invalidArgument("History", "cursor does not match this conversation")
+		}
+		runIndex, upto, fresh = decodedIndex, decodedUpto, false
+	}
+
+	var page []Message
+	for runIndex >= 0 && len(page) < limit {
+		runID := runs[runIndex].GetRunId()
+		bound := upto
+		if fresh {
+			if bound, err = c.runEventTotal(ctx, runID); err != nil {
+				return HistoryPage{}, err
+			}
+		}
+		if bound == 0 {
+			// Nothing left in this run; move to the one before it.
+			runIndex, fresh = runIndex-1, true
+			continue
+		}
+		found, resumeAt, err := c.runMessagesBefore(ctx, runID, bound, limit-len(page))
+		if err != nil {
+			return HistoryPage{}, err
+		}
+		page = append(found, page...)
+		if len(page) >= limit {
+			if resumeAt > 0 || runIndex > 0 {
+				return HistoryPage{Messages: page, Cursor: encodeHistoryCursor(runIndex, resumeAt)}, nil
+			}
+			return HistoryPage{Messages: page}, nil
+		}
+		runIndex, fresh = runIndex-1, true
+	}
+	return HistoryPage{Messages: page}, nil
+}
+
+// runEventTotal reads how many events a run has recorded, without fetching
+// them.
+func (c *Conversation) runEventTotal(ctx context.Context, runID string) (uint32, error) {
+	response, err := c.agent.client.transport.runs.ListRunEvents(ctx, connect.NewRequest(&agentcomposev2.ListRunEventsRequest{
+		RunId: runID, Limit: 1,
+	}))
+	if err != nil {
+		return 0, fromConnect("History", err)
+	}
+	return response.Msg.GetTotal(), nil
+}
+
+// runMessagesBefore returns up to want messages taken from the tail of one
+// run's events, considering only events before the exclusive offset bound,
+// oldest first. The second result is the offset a later call should treat as
+// its own bound to continue further into this run's past; it is 0 once the
+// run's start has been reached.
+//
+// The scanned window doubles until it holds enough messages or reaches the
+// run's start, so a run thick with non-conversational events (tool calls,
+// usage, status transitions) is not mistaken for one with too few messages
+// after a single small probe.
+func (c *Conversation) runMessagesBefore(ctx context.Context, runID string, bound uint32, want int) ([]Message, uint32, error) {
+	for window := uint32(historyPageSize); ; window *= 2 {
+		start := uint32(0)
+		if window < bound {
+			start = bound - window
+		}
+		events, err := c.runEventsInRange(ctx, runID, start, bound)
+		if err != nil {
+			return nil, 0, err
+		}
+		messages := make([]Message, 0, want)
+		resumeAt := start
+		for i := len(events) - 1; i >= 0 && len(messages) < want; i-- {
+			message, ok := messageFromEvent(events[i])
+			if !ok {
+				continue
+			}
+			messages = append(messages, message)
+			resumeAt = start + uint32(i)
+		}
+		if len(messages) >= want || start == 0 {
+			slices.Reverse(messages)
+			return messages, resumeAt, nil
+		}
+	}
+}
+
+// runEventsInRange reads one run's raw durable events in [start, end), oldest
+// first, paging through the daemon's own per-request limit.
+func (c *Conversation) runEventsInRange(ctx context.Context, runID string, start, end uint32) ([]*agentcomposev2.RunEvent, error) {
+	events := make([]*agentcomposev2.RunEvent, 0, end-start)
+	for offset := start; offset < end; {
+		limit := end - offset
+		if limit > historyPageSize {
+			limit = historyPageSize
+		}
+		response, err := c.agent.client.transport.runs.ListRunEvents(ctx, connect.NewRequest(&agentcomposev2.ListRunEventsRequest{
+			RunId: runID, Offset: offset, Limit: limit,
+		}))
+		if err != nil {
+			return nil, fromConnect("History", err)
+		}
+		page := response.Msg.GetEvents()
+		if len(page) == 0 {
+			break
+		}
+		events = append(events, page...)
+		offset += uint32(len(page))
+	}
+	return events, nil
+}
+
+// encodeHistoryCursor and decodeHistoryCursor keep HistoryPage.Cursor opaque
+// to callers: which run and how far into it is this package's own bookkeeping,
+// not a contract to keep stable.
+func encodeHistoryCursor(runIndex int, upto uint32) string {
+	raw := strconv.Itoa(runIndex) + ":" + strconv.FormatUint(uint64(upto), 10)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func decodeHistoryCursor(cursor string) (runIndex int, upto uint32, err error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, 0, err
+	}
+	left, right, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		return 0, 0, errors.New("malformed cursor")
+	}
+	index, err := strconv.Atoi(left)
+	if err != nil {
+		return 0, 0, err
+	}
+	offset, err := strconv.ParseUint(right, 10, 32)
+	if err != nil {
+		return 0, 0, err
+	}
+	return index, uint32(offset), nil
+}

--- a/sdk/go/chat/history_test.go
+++ b/sdk/go/chat/history_test.go
@@ -1,0 +1,124 @@
+package chat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// TestHistoryPageWalksBackwardAcrossRuns pages one message at a time across
+// two runs, oldest last, and checks the cursor round-trips correctly.
+func TestHistoryPageWalksBackwardAcrossRuns(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(
+		&agentcomposev2.RunSummary{RunId: "run-1", CreatedAt: timestamppb.New(time.Unix(100, 0))},
+		&agentcomposev2.RunSummary{RunId: "run-2", CreatedAt: timestamppb.New(time.Unix(200, 0))},
+	)
+
+	events := map[string][]*agentcomposev2.RunEvent{
+		"run-1": {
+			runEvent("e0", agentcomposev2.RunEventKind_RUN_EVENT_KIND_USER_MESSAGE, "q0"),
+			runEvent("e1", agentcomposev2.RunEventKind_RUN_EVENT_KIND_AGENT_MESSAGE, "a0"),
+		},
+		"run-2": {
+			runEvent("e2", agentcomposev2.RunEventKind_RUN_EVENT_KIND_USER_MESSAGE, "q1"),
+			runEvent("e3", agentcomposev2.RunEventKind_RUN_EVENT_KIND_AGENT_MESSAGE, "a1"),
+		},
+	}
+	daemon.listRunEvents = listEventsPage(events)
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start(WithID("conv-abc"))
+	ctx := context.Background()
+
+	want := []string{"a1", "q1", "a0", "q0"}
+	var cursor string
+	for i, expect := range want {
+		page, err := conversation.HistoryPage(ctx, HistoryOptions{Limit: 1, Before: cursor})
+		if err != nil {
+			t.Fatalf("HistoryPage[%d]: %v", i, err)
+		}
+		if len(page.Messages) != 1 || page.Messages[0].Text != expect {
+			t.Fatalf("HistoryPage[%d] = %#v, want a single message %q", i, page.Messages, expect)
+		}
+		last := i == len(want)-1
+		if last && page.Cursor != "" {
+			t.Errorf("HistoryPage[%d] cursor = %q, want empty at the start of history", i, page.Cursor)
+		}
+		if !last && page.Cursor == "" {
+			t.Fatalf("HistoryPage[%d] cursor is empty, want more history to walk", i)
+		}
+		cursor = page.Cursor
+	}
+}
+
+// TestHistoryPageGrowsItsWindowPastNonMessageEvents forces the run's tail
+// probe to come up short and verifies HistoryPage still finds a message
+// buried near the start of a long run instead of reporting too few.
+func TestHistoryPageGrowsItsWindowPastNonMessageEvents(t *testing.T) {
+	daemon := newFakeDaemon(t)
+	daemon.listRuns = listRunsReturning(&agentcomposev2.RunSummary{RunId: "run-1"})
+
+	total := historyPageSize + 50
+	all := make([]*agentcomposev2.RunEvent, total)
+	all[0] = runEvent("first", agentcomposev2.RunEventKind_RUN_EVENT_KIND_USER_MESSAGE, "buried")
+	for i := 1; i < total-1; i++ {
+		all[i] = runEvent("filler", agentcomposev2.RunEventKind_RUN_EVENT_KIND_STATUS, "running")
+	}
+	all[total-1] = runEvent("last", agentcomposev2.RunEventKind_RUN_EVENT_KIND_AGENT_MESSAGE, "recent")
+
+	daemon.listRunEvents = listEventsPage(map[string][]*agentcomposev2.RunEvent{"run-1": all})
+
+	conversation := daemon.client(t).Agent("project-1", "reviewer").Start(WithID("conv-abc"))
+	page, err := conversation.HistoryPage(context.Background(), HistoryOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("HistoryPage: %v", err)
+	}
+	if len(page.Messages) != 2 {
+		t.Fatalf("history = %d messages, want 2 (the initial window only covers the run's tail)", len(page.Messages))
+	}
+	if page.Messages[0].Text != "buried" || page.Messages[1].Text != "recent" {
+		t.Errorf("messages = %#v, want [buried, recent]", page.Messages)
+	}
+	if page.Cursor != "" {
+		t.Errorf("cursor = %q, want empty: the whole run was scanned", page.Cursor)
+	}
+}
+
+// runEvent builds one durable event with the fields these tests assert on.
+func runEvent(id string, kind agentcomposev2.RunEventKind, text string) *agentcomposev2.RunEvent {
+	return &agentcomposev2.RunEvent{Id: id, Kind: kind, Text: text}
+}
+
+// listRunsReturning answers every ListRuns with the same runs.
+func listRunsReturning(runs ...*agentcomposev2.RunSummary) func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+	return func(*agentcomposev2.ListRunsRequest) (*agentcomposev2.ListRunsResponse, error) {
+		return &agentcomposev2.ListRunsResponse{Runs: runs, Total: uint32(len(runs))}, nil
+	}
+}
+
+// listEventsPage emulates the daemon's ListRunEvents pagination over a fixed
+// event log, honoring the request's run, offset and limit.
+func listEventsPage(events map[string][]*agentcomposev2.RunEvent) func(*agentcomposev2.ListRunEventsRequest) (*agentcomposev2.ListRunEventsResponse, error) {
+	return func(request *agentcomposev2.ListRunEventsRequest) (*agentcomposev2.ListRunEventsResponse, error) {
+		all := events[request.GetRunId()]
+		total := uint32(len(all))
+		start := min(request.GetOffset(), total)
+		limit := request.GetLimit()
+		if limit == 0 {
+			limit = total
+		}
+		end := min(start+limit, total)
+		return &agentcomposev2.ListRunEventsResponse{Events: all[start:end], Total: total}, nil
+	}
+}
+
+// listEventsReturning answers every ListRunEvents with the same events.
+func listEventsReturning(events ...*agentcomposev2.RunEvent) func(*agentcomposev2.ListRunEventsRequest) (*agentcomposev2.ListRunEventsResponse, error) {
+	return func(*agentcomposev2.ListRunEventsRequest) (*agentcomposev2.ListRunEventsResponse, error) {
+		return &agentcomposev2.ListRunEventsResponse{Events: events, Total: uint32(len(events))}, nil
+	}
+}

--- a/sdk/go/chat/message.go
+++ b/sdk/go/chat/message.go
@@ -1,0 +1,46 @@
+package chat
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Role identifies who produced a [Message].
+type Role string
+
+// Message roles.
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+)
+
+// Message is one contribution to a conversation.
+type Message struct {
+	// ID is stable for a message read back from history and empty for one just
+	// streamed.
+	ID string
+	// Role is who produced the message.
+	Role Role
+	// Text is the message's content.
+	Text string
+	// Result carries the agent's structured output when its Agent declares an
+	// output schema, and is nil otherwise. Assistant messages only.
+	Result json.RawMessage
+	// Time is when the daemon recorded the message.
+	Time time.Time
+}
+
+// Continuity reports whether a conversation kept the environment its earlier
+// turns ran in.
+type Continuity string
+
+const (
+	// Continuous means the conversation resumed its original environment, so
+	// whatever context the agent persisted there is still available.
+	Continuous Continuity = "continuous"
+	// Restarted means the environment was gone and had to be rebuilt. Earlier
+	// turns remain readable through [Conversation.History], but the agent no
+	// longer has the context it had accumulated. Products normally tell the
+	// user about this.
+	Restarted Continuity = "restarted"
+)

--- a/sdk/go/chat/reply.go
+++ b/sdk/go/chat/reply.go
@@ -1,0 +1,162 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Reply is one turn of a conversation: the agent's answer to a single message.
+//
+// Events and Wait may both be used on the same Reply, in either order and any
+// number of times; events are retained, so a later call replays them from the
+// start rather than seeing only what has not been consumed yet.
+type Reply struct {
+	conversation *Conversation
+
+	mu     sync.Mutex
+	events []Event
+	notify chan struct{}
+	text   strings.Builder
+	result json.RawMessage
+	at     time.Time
+	done   bool
+	err    error
+}
+
+func newReply(conversation *Conversation) *Reply {
+	return &Reply{conversation: conversation, notify: make(chan struct{})}
+}
+
+// Events yields the agent's observations as they arrive, ending when the turn
+// completes. A failed turn yields its error as the final pair.
+func (r *Reply) Events(ctx context.Context) iter.Seq2[Event, error] {
+	return func(yield func(Event, error) bool) {
+		for index := 0; ; {
+			r.mu.Lock()
+			if index < len(r.events) {
+				event := r.events[index]
+				r.mu.Unlock()
+				index++
+				if !yield(event, nil) {
+					return
+				}
+				continue
+			}
+			if r.done {
+				err := r.err
+				r.mu.Unlock()
+				if err != nil {
+					yield(nil, err)
+				}
+				return
+			}
+			wait := r.notify
+			r.mu.Unlock()
+			select {
+			case <-wait:
+			case <-ctx.Done():
+				yield(nil, ctx.Err())
+				return
+			}
+		}
+	}
+}
+
+// Wait blocks until the turn completes and returns the agent's message. It
+// does not require the caller to have consumed Events.
+func (r *Reply) Wait(ctx context.Context) (Message, error) {
+	for {
+		r.mu.Lock()
+		if r.done {
+			message := Message{Role: RoleAssistant, Text: r.text.String(), Result: r.result, Time: r.at}
+			err := r.err
+			r.mu.Unlock()
+			return message, err
+		}
+		wait := r.notify
+		r.mu.Unlock()
+		select {
+		case <-wait:
+		case <-ctx.Done():
+			return Message{}, ctx.Err()
+		}
+	}
+}
+
+// Text reports the answer accumulated so far. It is safe to call while the
+// turn is still streaming.
+func (r *Reply) Text() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.text.String()
+}
+
+// Done reports whether the turn has finished.
+func (r *Reply) Done() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.done
+}
+
+// Err reports why the turn failed, or nil while it is running or once it
+// succeeded.
+func (r *Reply) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}
+
+// Interrupt stops the agent mid-turn.
+//
+// The daemon cancels the whole interactive session rather than the single
+// turn, so this Reply ends and the next [Conversation.Send] needs a new run.
+// That run asks to resume the same sandbox; [Conversation.Continuity] reports
+// [Restarted] only if that does not happen. Either way the agent keeps the
+// conversation's durable history.
+func (r *Reply) Interrupt(ctx context.Context) error {
+	return r.conversation.interrupt(ctx, r)
+}
+
+// add records one event and wakes every waiter.
+func (r *Reply) add(event Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.done {
+		return
+	}
+	if delta, ok := event.(*TextDeltaEvent); ok {
+		r.text.WriteString(delta.Text)
+	}
+	r.events = append(r.events, event)
+	r.wake()
+}
+
+// finish completes the turn. Only the first call takes effect, so a stream
+// error arriving after a turn already completed cannot overwrite its result.
+func (r *Reply) finish(result json.RawMessage, at time.Time, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.done {
+		return
+	}
+	r.done = true
+	r.err = err
+	if len(result) > 0 && string(result) != "null" {
+		r.result = result
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	r.at = at
+	r.wake()
+}
+
+// wake must be called with r.mu held.
+func (r *Reply) wake() {
+	close(r.notify)
+	r.notify = make(chan struct{})
+}

--- a/sdk/go/chat/runsummary.go
+++ b/sdk/go/chat/runsummary.go
@@ -1,0 +1,41 @@
+package chat
+
+import (
+	"strings"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// runIsLive reports whether a run can still accept an attach.
+func runIsLive(run *agentcomposev2.RunSummary) bool {
+	switch run.GetStatus() {
+	case agentcomposev2.RunStatus_RUN_STATUS_PENDING, agentcomposev2.RunStatus_RUN_STATUS_RUNNING:
+		return true
+	default:
+		return false
+	}
+}
+
+// messageFromEvent maps one durable run event onto a Message. It returns false
+// for events that are not conversational, such as lifecycle transitions.
+func messageFromEvent(event *agentcomposev2.RunEvent) (Message, bool) {
+	kind := strings.ToUpper(strings.TrimSpace(event.GetKind().String()))
+	var role Role
+	switch {
+	case strings.HasSuffix(kind, "USER_MESSAGE"):
+		role = RoleUser
+	case strings.HasSuffix(kind, "AGENT_MESSAGE"):
+		role = RoleAssistant
+	default:
+		return Message{}, false
+	}
+	if strings.TrimSpace(event.GetText()) == "" {
+		return Message{}, false
+	}
+	return Message{
+		ID:   event.GetId(),
+		Role: role,
+		Text: event.GetText(),
+		Time: event.GetCreatedAt().AsTime(),
+	}, true
+}

--- a/sdk/go/chat/transport.go
+++ b/sdk/go/chat/transport.go
@@ -1,0 +1,98 @@
+package chat
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"connectrpc.com/connect"
+	"golang.org/x/net/http2"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+	"github.com/chaitin/agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+// transport carries this package's calls to one daemon. The wire format,
+// framing and procedure paths belong to the generated Connect client; what is
+// left here is the per-request credential and the naming of failures.
+type transport struct {
+	runs     agentcomposev2connect.RunServiceClient
+	projects agentcomposev2connect.ProjectServiceClient
+}
+
+func newTransport(baseURL string, client *http.Client, token TokenSource, userAgent string) *transport {
+	identify := connect.WithInterceptors(&credentials{token: token, userAgent: userAgent})
+	return &transport{
+		runs:     agentcomposev2connect.NewRunServiceClient(client, baseURL, identify),
+		projects: agentcomposev2connect.NewProjectServiceClient(client, baseURL, identify),
+	}
+}
+
+// credentials puts the caller's identity on every request, unary and streaming
+// alike. The token is resolved per request rather than once, so a short-lived
+// credential can be refreshed underneath a long conversation.
+type credentials struct {
+	token     TokenSource
+	userAgent string
+}
+
+func (c *credentials) apply(ctx context.Context, header http.Header) error {
+	header.Set("User-Agent", c.userAgent)
+	if c.token == nil {
+		return nil
+	}
+	token, err := c.token(ctx)
+	if err != nil {
+		return connect.NewError(connect.CodeUnauthenticated, err)
+	}
+	if token = strings.TrimSpace(token); token != "" {
+		header.Set("Authorization", "Bearer "+token)
+	}
+	return nil
+}
+
+func (c *credentials) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
+		if err := c.apply(ctx, request.Header()); err != nil {
+			return nil, err
+		}
+		return next(ctx, request)
+	}
+}
+
+func (c *credentials) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		// A failure here cannot be returned: the conn is the only value this
+		// hook may yield. Leaving the header unset makes the daemon reject the
+		// stream, which surfaces as an authentication error on the first
+		// receive rather than being swallowed.
+		_ = c.apply(ctx, conn.RequestHeader())
+		return conn
+	}
+}
+
+func (c *credentials) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}
+
+// attachStream is one live conversation with the daemon.
+type attachStream = connect.BidiStreamForClient[agentcomposev2.AttachAgentRunRequest, agentcomposev2.AttachAgentRunResponse]
+
+// defaultHTTPClient returns a client able to carry Connect bidirectional
+// streams to baseURL: plaintext bases need h2c, since Go's standard transport
+// only negotiates HTTP/2 over TLS.
+func defaultHTTPClient(base *url.URL) *http.Client {
+	if base.Scheme == "https" {
+		return &http.Client{Transport: &http.Transport{ForceAttemptHTTP2: true}}
+	}
+	return &http.Client{Transport: &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}}
+}

--- a/sdk/go/examples/chat/main.go
+++ b/sdk/go/examples/chat/main.go
@@ -1,0 +1,113 @@
+// Command chat holds a conversation with an agent-compose Agent from the
+// terminal, resuming an earlier one when given its ID.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/chaitin/agent-compose/sdk/go/chat"
+)
+
+func main() {
+	baseURL := flag.String("base-url", "http://127.0.0.1:7410", "agent-compose HTTP address")
+	project := flag.String("project", "", "project ID (required)")
+	agentName := flag.String("agent", "", "agent name (required)")
+	resume := flag.String("conversation", "", "conversation ID to resume; a new one is started when empty")
+	flag.Parse()
+	if *project == "" || *agentName == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	client, err := chat.New(chat.Config{
+		BaseURL: *baseURL,
+		Token:   chat.StaticToken(os.Getenv("AGENT_COMPOSE_TOKEN")),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	agent := client.Agent(*project, *agentName)
+
+	conversation := agent.Start()
+	if *resume != "" {
+		conversation, err = agent.Open(ctx, *resume)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := replayHistory(ctx, conversation); err != nil {
+			log.Fatal(err)
+		}
+		if conversation.Continuity() == chat.Restarted {
+			fmt.Println("note: this conversation's environment was rebuilt, so the agent no longer has its earlier context")
+		}
+	}
+	// Close ends this session and stops its environment; the conversation
+	// itself stays resumable by ID.
+	defer func() { _ = conversation.Close(ctx) }()
+	fmt.Printf("conversation %s\n", conversation.ID())
+
+	input := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("\n> ")
+		if !input.Scan() {
+			return
+		}
+		text := strings.TrimSpace(input.Text())
+		if text == "" {
+			continue
+		}
+		if err := turn(ctx, conversation, text); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+// turn sends one message and renders the agent's work as it arrives.
+func turn(ctx context.Context, conversation *chat.Conversation, text string) error {
+	reply, err := conversation.Send(ctx, text)
+	if err != nil {
+		return err
+	}
+	for event, err := range reply.Events(ctx) {
+		if err != nil {
+			return err
+		}
+		switch typed := event.(type) {
+		case *chat.TextDeltaEvent:
+			fmt.Print(typed.Text)
+		case *chat.ToolCallEvent:
+			fmt.Printf("\n  [%s %s]", typed.ToolKind, typed.Name)
+		case *chat.ToolResultEvent:
+			if !typed.OK {
+				fmt.Printf(" failed: %s", typed.Error)
+			}
+		case *chat.UsageEvent:
+			fmt.Printf("\n  [%s: %d in, %d out]", typed.Scope, typed.InputTokens, typed.OutputTokens)
+		case *chat.ErrorEvent:
+			fmt.Printf("\n  [%s: %s]", typed.Severity, typed.Message)
+		}
+	}
+	fmt.Println()
+	return nil
+}
+
+func replayHistory(ctx context.Context, conversation *chat.Conversation) error {
+	messages, err := conversation.History(ctx)
+	if err != nil {
+		return err
+	}
+	for _, message := range messages {
+		fmt.Printf("%s: %s\n", message.Role, message.Text)
+	}
+	return nil
+}

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,0 +1,12 @@
+module github.com/chaitin/agent-compose/sdk/go
+
+go 1.24.0
+
+require (
+	connectrpc.com/connect v1.19.2
+	github.com/chaitin/agent-compose/proto v0.1.0
+	golang.org/x/net v0.38.0
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+)
+
+require golang.org/x/text v0.23.0 // indirect

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -1,0 +1,12 @@
+connectrpc.com/connect v1.19.2 h1:McQ83FGdzL+t60peksi0gXC7MQ/iLKgLduAnThbM0mo=
+connectrpc.com/connect v1.19.2/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+github.com/chaitin/agent-compose/proto v0.1.0 h1:0J4E8C9KqGY4ZkccvBo4ItJSDTN/iZAQU64FRmqNPQA=
+github.com/chaitin/agent-compose/proto v0.1.0/go.mod h1:sgEGuy3xcx0uneY7QeNdCd6CP8DJ+GuxblSAwvyt3wg=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
+google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=


### PR DESCRIPTION
## 这是什么

`sdk/go` —— 一个用来和 agent-compose Agent 对话的 Go 客户端,独立 module。

在此之前,想做聊天类产品就得自己驱动 `RunService`:开双向 attach、跨轮次维持 run、判断流断了意味着什么、再把散落在多个 run 里的消息拼回一条时间线。这个包把这些做一次。

```go
client, _ := chat.New(chat.Config{
    BaseURL: "http://127.0.0.1:7410",
    Token:   chat.StaticToken(os.Getenv("AGENT_COMPOSE_AUTH_TOKEN")),
})
conversation := client.Agent("review-project", "reviewer").Start()
reply, _ := conversation.Send(ctx, "check this PR")
for event, err := range reply.Events(ctx) { ... }
```

## 抽象边界

`Conversation` 是持久的对话线,`Reply` 是其中一轮的流。**run / sandbox / attach 策略留在下面**:`Continuity` 只回答"环境是否幸存",聊天需要的默认值(断开即 detach、run 结束就停 sandbox)不用调用方去 proto 里翻。

`Projects` 回答 `Agent(projectID, agentName)` 隐含的那个问题——这两个字符串从哪来。不可用的 agent 是**列出并给出原因**而非隐藏,因为找它的人应该看到它存在。

## 传输层用生成的 Connect 客户端

不是手写的。procedure 路径、分帧、codec 全部来自 `proto` module(独立发布,依赖只有 connect + protobuf),所以 proto 改字段名会**编译报错**,而不是运行时静默丢值。

SDK 自己的公开面**不泄漏任何 protobuf 类型**——外部看到的是 `Conversation` / `Reply` / `Message` / `Event`。

## 验证

- `go test -race` 全绿
- 测试桩用生成的 `NewRunServiceHandler` / `NewProjectServiceHandler`,所以测的是真协议往返(h2c + 二进制 proto),不是模拟
- 一个真实消费者已在跑:浏览器聊天 UI(已剥离到独立仓库),覆盖会话恢复、空闲回收、多标签页共享、鉴权

