### PR TITLE
fix(api): cap the output a sandbox history cell carries

### DIFF
--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -310,7 +310,14 @@ func sandboxHistoryCellToV2(cell *domain.NotebookCell) *agentcomposev2.SandboxHi
 	if cell == nil {
 		return nil
 	}
-	output, truncated := tailBytes(firstNonEmpty(cell.Output, cell.Stdout+cell.Stderr), maxSandboxHistoryCellOutputBytes)
+	// Go evaluates arguments before the call, so folding this into firstNonEmpty
+	// would concatenate and then discard a copy of the very stream this function
+	// exists to keep out of memory.
+	merged := cell.Output
+	if merged == "" {
+		merged = cell.Stdout + cell.Stderr
+	}
+	output, truncated := tailBytes(merged, maxSandboxHistoryCellOutputBytes)
 	return &agentcomposev2.SandboxHistoryCell{
 		Id: cell.ID, Type: cell.Type, Source: cell.Source, Output: output, OutputTruncatedBytes: truncated,
 		ExitCode: int32(cell.ExitCode), Success: cell.Success, Running: cell.Running,

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -298,15 +299,37 @@ func sandboxHistoryTimestamp(value time.Time) *timestamppb.Timestamp {
 	return timestamppb.New(value)
 }
 
+// A cell accumulates every byte its run writes, for as long as the run lasts, so
+// nothing bounds its size: one verbose build an agent reran a dozen times reached
+// 41MB, and because the same bytes travelled in both stdout and output, listing
+// that single cell meant a 75MB response. Carry the newest bytes, which is the
+// end anyone reads, and leave the rest to RunService.FollowRunLogs.
+const maxSandboxHistoryCellOutputBytes = 64 << 10
+
 func sandboxHistoryCellToV2(cell *domain.NotebookCell) *agentcomposev2.SandboxHistoryCell {
 	if cell == nil {
 		return nil
 	}
+	output, truncated := tailBytes(firstNonEmpty(cell.Output, cell.Stdout+cell.Stderr), maxSandboxHistoryCellOutputBytes)
 	return &agentcomposev2.SandboxHistoryCell{
-		Id: cell.ID, Type: cell.Type, Source: cell.Source, Stdout: cell.Stdout, Stderr: cell.Stderr,
-		Output: cell.Output, ExitCode: int32(cell.ExitCode), Success: cell.Success, Running: cell.Running,
+		Id: cell.ID, Type: cell.Type, Source: cell.Source, Output: output, OutputTruncatedBytes: truncated,
+		ExitCode: int32(cell.ExitCode), Success: cell.Success, Running: cell.Running,
 		CreatedAt: sandboxHistoryTimestamp(cell.CreatedAt), Agent: cell.Agent, AgentThreadId: cell.AgentThreadID, StopReason: cell.StopReason,
 	}
+}
+
+// tailBytes keeps the last limit bytes of value and reports how many it dropped.
+// The cut lands on a rune boundary: a proto3 string must be valid UTF-8, and
+// slicing through a multi-byte rune would make the whole response unmarshalable.
+func tailBytes(value string, limit int) (string, uint64) {
+	if len(value) <= limit {
+		return value, 0
+	}
+	tail := value[len(value)-limit:]
+	for len(tail) > 0 && !utf8.RuneStart(tail[0]) {
+		tail = tail[1:]
+	}
+	return tail, uint64(len(value) - len(tail))
 }
 
 func sandboxHistoryEventToV2(event *domain.SandboxEvent) *agentcomposev2.SandboxHistoryEvent {

--- a/pkg/agentcompose/api/sandbox.go
+++ b/pkg/agentcompose/api/sandbox.go
@@ -318,6 +318,14 @@ func sandboxHistoryCellToV2(cell *domain.NotebookCell) *agentcomposev2.SandboxHi
 		merged = cell.Stdout + cell.Stderr
 	}
 	output, truncated := tailBytes(merged, maxSandboxHistoryCellOutputBytes)
+	// A cell carries whatever bytes its run wrote, which for a command that cats a
+	// binary is not text at all. One invalid sequence anywhere fails the marshal for
+	// the entire response, not just the cell that produced it. Scrub after the cut so
+	// the scan covers the tail rather than the whole stream, and so a stream that was
+	// already valid - which is nearly all of them - is returned unchanged without
+	// allocating. A tail that is mostly binary grows to at most three times the cap,
+	// which is still four orders of magnitude below what this function exists to stop.
+	output = strings.ToValidUTF8(output, "\uFFFD")
 	return &agentcomposev2.SandboxHistoryCell{
 		Id: cell.ID, Type: cell.Type, Source: cell.Source, Output: output, OutputTruncatedBytes: truncated,
 		ExitCode: int32(cell.ExitCode), Success: cell.Success, Running: cell.Running,
@@ -326,8 +334,9 @@ func sandboxHistoryCellToV2(cell *domain.NotebookCell) *agentcomposev2.SandboxHi
 }
 
 // tailBytes keeps the last limit bytes of value and reports how many it dropped.
-// The cut lands on a rune boundary: a proto3 string must be valid UTF-8, and
-// slicing through a multi-byte rune would make the whole response unmarshalable.
+// The cut lands on a rune boundary so it does not split a multi-byte rune that
+// survived the cut; whether what the run wrote was valid UTF-8 to begin with is
+// the caller's problem, and it has to scrub for that separately.
 func tailBytes(value string, limit int) (string, uint64) {
 	if len(value) <= limit {
 		return value, 0

--- a/pkg/agentcompose/api/sandbox_characterization_test.go
+++ b/pkg/agentcompose/api/sandbox_characterization_test.go
@@ -175,6 +175,28 @@ func TestV2SandboxWatchEventProjection(t *testing.T) {
 	}
 }
 
+func TestV2SandboxWatchCellCarriesTheSameCappedOutputAsAListing(t *testing.T) {
+	// A completed cell is published with everything its run accumulated, so the
+	// watch stream pushes the same tens of megabytes a listing used to return.
+	// Both go through sandboxHistoryCellToV2 and both are capped; a subscriber
+	// that needs the head of the log reads it from RunService.FollowRunLogs.
+	buildLog := strings.Repeat("a", maxSandboxHistoryCellOutputBytes+4096)
+	cell := domain.NotebookCell{ID: "cell-build", Stdout: buildLog, Output: buildLog}
+
+	for _, eventType := range []sandboxes.WatchEventType{sandboxes.WatchEventTypeCellStarted, sandboxes.WatchEventTypeCellCompleted} {
+		got := sandboxWatchEventToV2(sandboxes.WatchEvent{EventType: eventType, Cell: &cell}).GetCell()
+		if length := len(got.GetOutput()); length != maxSandboxHistoryCellOutputBytes {
+			t.Fatalf("%v output length = %d, want %d", eventType, length, maxSandboxHistoryCellOutputBytes)
+		}
+		if truncated := got.GetOutputTruncatedBytes(); truncated != 4096 {
+			t.Fatalf("%v output_truncated_bytes = %d, want 4096", eventType, truncated)
+		}
+		if got.GetStdout() != "" || got.GetStderr() != "" {
+			t.Fatalf("%v still carries a second copy of the stream", eventType)
+		}
+	}
+}
+
 func TestV2SandboxLifecycleIsIdempotentAndRejectsInvalidState(t *testing.T) {
 	sandboxID := identity.NewID(identity.ResourceSandbox, "characterization", "idempotent")
 	delegate := &characterizationSessionDelegate{}

--- a/pkg/agentcompose/api/sandbox_history_pagination.go
+++ b/pkg/agentcompose/api/sandbox_history_pagination.go
@@ -43,18 +43,10 @@ func paginateSandboxHistory(cells []domain.NotebookCell, events []domain.Sandbox
 	response := &agentcomposev2.ListSandboxHistoryResponse{LegacyHistory: true, Total: total}
 	for _, entry := range page {
 		if entry.cell != nil {
-			cell := entry.cell
-			response.Cells = append(response.Cells, &agentcomposev2.SandboxHistoryCell{
-				Id: cell.ID, Type: cell.Type, Source: cell.Source, Stdout: cell.Stdout, Stderr: cell.Stderr,
-				Output: cell.Output, ExitCode: int32(cell.ExitCode), Success: cell.Success, Running: cell.Running,
-				CreatedAt: sandboxHistoryTimestamp(cell.CreatedAt), Agent: cell.Agent, AgentThreadId: cell.AgentThreadID, StopReason: cell.StopReason,
-			})
+			response.Cells = append(response.Cells, sandboxHistoryCellToV2(entry.cell))
 			continue
 		}
-		event := entry.event
-		response.Events = append(response.Events, &agentcomposev2.SandboxHistoryEvent{
-			Id: event.ID, Type: event.Type, Level: event.Level, Message: event.Message, CreatedAt: sandboxHistoryTimestamp(event.CreatedAt),
-		})
+		response.Events = append(response.Events, sandboxHistoryEventToV2(entry.event))
 	}
 	return response, nil
 }

--- a/pkg/agentcompose/api/sandbox_history_pagination_test.go
+++ b/pkg/agentcompose/api/sandbox_history_pagination_test.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/proto"
 
 	domain "github.com/chaitin/agent-compose/pkg/model"
 )
@@ -52,5 +56,66 @@ func TestPaginateSandboxHistoryBreaksTimestampTiesDeterministically(t *testing.T
 	}
 	if first.GetCells()[0].GetId() != "cell-b" || second.GetCells()[0].GetId() != "cell-a" || third.GetEvents()[0].GetId() != "event-z" {
 		t.Fatalf("tie order = (%v, %v, %v), want cell-b, cell-a, event-z", first, second, third)
+	}
+}
+
+func TestPaginateSandboxHistoryCapsCellOutput(t *testing.T) {
+	buildLog := strings.Repeat("a", maxSandboxHistoryCellOutputBytes+4096)
+	cells := []domain.NotebookCell{{ID: "cell-build", Output: buildLog, Running: true}}
+
+	response, err := paginateSandboxHistory(cells, nil, 0, 0)
+	if err != nil {
+		t.Fatalf("paginateSandboxHistory returned error: %v", err)
+	}
+	cell := response.GetCells()[0]
+	if got := len(cell.GetOutput()); got != maxSandboxHistoryCellOutputBytes {
+		t.Fatalf("output length = %d, want %d", got, maxSandboxHistoryCellOutputBytes)
+	}
+	if got := cell.GetOutputTruncatedBytes(); got != 4096 {
+		t.Fatalf("output_truncated_bytes = %d, want 4096", got)
+	}
+	if !strings.HasSuffix(buildLog, cell.GetOutput()) {
+		t.Fatal("output is not the tail of the captured stream")
+	}
+}
+
+func TestPaginateSandboxHistorySendsOneCopyOfTheCapturedStream(t *testing.T) {
+	cells := []domain.NotebookCell{
+		{ID: "cell-merged", Stdout: "out", Stderr: "err", Output: "outerr"},
+		{ID: "cell-legacy", Stdout: "out", Stderr: "err"},
+	}
+
+	response, err := paginateSandboxHistory(cells, nil, 0, 0)
+	if err != nil {
+		t.Fatalf("paginateSandboxHistory returned error: %v", err)
+	}
+	for _, cell := range response.GetCells() {
+		if cell.GetStdout() != "" || cell.GetStderr() != "" {
+			t.Fatalf("%s still carries a second copy: stdout = %q, stderr = %q", cell.GetId(), cell.GetStdout(), cell.GetStderr())
+		}
+		if cell.GetOutput() != "outerr" {
+			t.Fatalf("%s output = %q, want the merged stream", cell.GetId(), cell.GetOutput())
+		}
+	}
+}
+
+func TestPaginateSandboxHistoryKeepsTruncatedOutputMarshalable(t *testing.T) {
+	// A cut through a multi-byte rune leaves a proto3 string that no longer
+	// marshals, which would fail the whole response rather than one cell.
+	cells := []domain.NotebookCell{{ID: "cell-cjk", Output: strings.Repeat("日", maxSandboxHistoryCellOutputBytes)}}
+
+	response, err := paginateSandboxHistory(cells, nil, 0, 0)
+	if err != nil {
+		t.Fatalf("paginateSandboxHistory returned error: %v", err)
+	}
+	output := response.GetCells()[0].GetOutput()
+	if !utf8.ValidString(output) {
+		t.Fatal("truncated output is not valid UTF-8")
+	}
+	if len(output) > maxSandboxHistoryCellOutputBytes {
+		t.Fatalf("output length = %d, want at most %d", len(output), maxSandboxHistoryCellOutputBytes)
+	}
+	if _, err := proto.Marshal(response); err != nil {
+		t.Fatalf("marshal truncated response: %v", err)
 	}
 }

--- a/pkg/agentcompose/api/sandbox_history_pagination_test.go
+++ b/pkg/agentcompose/api/sandbox_history_pagination_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -117,5 +118,95 @@ func TestPaginateSandboxHistoryKeepsTruncatedOutputMarshalable(t *testing.T) {
 	}
 	if _, err := proto.Marshal(response); err != nil {
 		t.Fatalf("marshal truncated response: %v", err)
+	}
+}
+
+func TestPaginateSandboxHistoryCapsALegacyCellsMergedStreams(t *testing.T) {
+	// A cell recorded before the streams were merged has no Output, so the
+	// concatenation is what gets sent. Nothing exercised that branch against a
+	// stream large enough to truncate, which is the only size that matters here.
+	const halfStream = 40 << 10
+	stdout, stderr := strings.Repeat("a", halfStream), strings.Repeat("e", halfStream)
+	cells := []domain.NotebookCell{{ID: "cell-legacy", Stdout: stdout, Stderr: stderr}}
+
+	response, err := paginateSandboxHistory(cells, nil, 0, 0)
+	if err != nil {
+		t.Fatalf("paginateSandboxHistory returned error: %v", err)
+	}
+	cell := response.GetCells()[0]
+	if got := len(cell.GetOutput()); got != maxSandboxHistoryCellOutputBytes {
+		t.Fatalf("output length = %d, want %d", got, maxSandboxHistoryCellOutputBytes)
+	}
+	if want := uint64(2*halfStream - maxSandboxHistoryCellOutputBytes); cell.GetOutputTruncatedBytes() != want {
+		t.Fatalf("output_truncated_bytes = %d, want %d", cell.GetOutputTruncatedBytes(), want)
+	}
+	// The tail spans the seam, so it proves the two streams were joined in order
+	// rather than one of them being sent alone.
+	if !strings.HasSuffix(stdout+stderr, cell.GetOutput()) {
+		t.Fatal("output is not the tail of the concatenated streams")
+	}
+	if !strings.Contains(cell.GetOutput(), "ae") {
+		t.Fatal("output does not span the stdout/stderr seam")
+	}
+}
+
+func TestSandboxHistoryCellDoesNotCopyAStreamTheMergeDiscards(t *testing.T) {
+	// Go evaluates arguments before the call, so spelling the merge as
+	// firstNonEmpty(cell.Output, cell.Stdout+cell.Stderr) builds the concatenation
+	// for every cell and discards it whenever Output is set - which is every cell
+	// written since the streams were merged. Both halves have to be non-empty for
+	// this to bite: Go returns s unchanged for s + "".
+	const streamBytes = 4 << 20
+	cell := domain.NotebookCell{
+		ID:     "cell-build",
+		Stdout: strings.Repeat("a", streamBytes),
+		Stderr: strings.Repeat("e", streamBytes),
+		Output: strings.Repeat("o", 2*streamBytes),
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	converted := sandboxHistoryCellToV2(&cell)
+	runtime.ReadMemStats(&after)
+
+	if got := len(converted.GetOutput()); got != maxSandboxHistoryCellOutputBytes {
+		t.Fatalf("output length = %d, want %d", got, maxSandboxHistoryCellOutputBytes)
+	}
+	// Converting a cell allocates the response message and nothing stream-sized:
+	// a couple of hundred bytes in practice, against 8MB if the discarded
+	// concatenation comes back. Any threshold between the two would do.
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > streamBytes {
+		t.Fatalf("converting one cell allocated %d bytes, want far less than one stream (%d)", allocated, streamBytes)
+	}
+}
+
+func TestPaginateSandboxHistoryKeepsOutputMarshalableWhenTheRunWroteBinary(t *testing.T) {
+	// A cell holds the bytes its run wrote, and a command that cats a binary
+	// writes bytes that are not text. A proto3 string field rejects those on
+	// marshal, failing the whole response rather than the one cell - the same
+	// blast radius the byte cap exists to contain. Truncation alone does not help:
+	// a stream under the cap is passed through untouched.
+	binary := string([]byte{0xff, 0xfe, 0x00, 0x81}) + "tail-of-log"
+	cells := []domain.NotebookCell{
+		{ID: "cell-small-binary", Output: binary},
+		{ID: "cell-large-binary", Output: strings.Repeat(binary, maxSandboxHistoryCellOutputBytes)},
+		{ID: "cell-legacy-binary", Stdout: binary, Stderr: binary},
+	}
+
+	response, err := paginateSandboxHistory(cells, nil, 0, 0)
+	if err != nil {
+		t.Fatalf("paginateSandboxHistory returned error: %v", err)
+	}
+	for _, cell := range response.GetCells() {
+		if !utf8.ValidString(cell.GetOutput()) {
+			t.Fatalf("%s output is not valid UTF-8", cell.GetId())
+		}
+		if !strings.HasSuffix(cell.GetOutput(), "tail-of-log") {
+			t.Fatalf("%s output = %q, want the readable tail preserved", cell.GetId(), cell.GetOutput())
+		}
+	}
+	if _, err := proto.Marshal(response); err != nil {
+		t.Fatalf("marshal response carrying binary output: %v", err)
 	}
 }

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -17834,12 +17834,20 @@ func (x *ListSandboxHistoryRequest) GetLimit() uint32 {
 }
 
 type SandboxHistoryCell struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	Source        string                 `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
-	Stdout        string                 `protobuf:"bytes,4,opt,name=stdout,proto3" json:"stdout,omitempty"`
-	Stderr        string                 `protobuf:"bytes,5,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Id     string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Type   string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Source string                 `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
+	// Never set. A cell's captured streams reach a reader through output, which
+	// already merges them; keeping a second copy here doubled a response that was
+	// large for the same reason it was worth truncating.
+	Stdout string `protobuf:"bytes,4,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr string `protobuf:"bytes,5,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	// The captured stream, holding the most recent bytes of a long run rather than
+	// all of them: a single build log reaches tens of megabytes and one such cell
+	// is enough to make a page unreadable and its response unloadable.
+	// output_truncated_bytes says how much was dropped; RunService.FollowRunLogs
+	// still serves the complete log.
 	Output        string                 `protobuf:"bytes,6,opt,name=output,proto3" json:"output,omitempty"`
 	ExitCode      int32                  `protobuf:"varint,7,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
 	Success       bool                   `protobuf:"varint,8,opt,name=success,proto3" json:"success,omitempty"`
@@ -17848,8 +17856,10 @@ type SandboxHistoryCell struct {
 	Agent         string                 `protobuf:"bytes,11,opt,name=agent,proto3" json:"agent,omitempty"`
 	AgentThreadId string                 `protobuf:"bytes,12,opt,name=agent_thread_id,json=agentThreadId,proto3" json:"agent_thread_id,omitempty"`
 	StopReason    string                 `protobuf:"bytes,13,opt,name=stop_reason,json=stopReason,proto3" json:"stop_reason,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Bytes dropped from the head of output. Zero means output is complete.
+	OutputTruncatedBytes uint64 `protobuf:"varint,14,opt,name=output_truncated_bytes,json=outputTruncatedBytes,proto3" json:"output_truncated_bytes,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *SandboxHistoryCell) Reset() {
@@ -17971,6 +17981,13 @@ func (x *SandboxHistoryCell) GetStopReason() string {
 		return x.StopReason
 	}
 	return ""
+}
+
+func (x *SandboxHistoryCell) GetOutputTruncatedBytes() uint64 {
+	if x != nil {
+		return x.OutputTruncatedBytes
+	}
+	return 0
 }
 
 type SandboxHistoryEvent struct {
@@ -20300,7 +20317,7 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x16\n" +
 	"\x06offset\x18\x02 \x01(\rR\x06offset\x12\x14\n" +
-	"\x05limit\x18\x03 \x01(\rR\x05limit\"\x83\x03\n" +
+	"\x05limit\x18\x03 \x01(\rR\x05limit\"\xb9\x03\n" +
 	"\x12SandboxHistoryCell\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x16\n" +
@@ -20317,7 +20334,8 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x05agent\x18\v \x01(\tR\x05agent\x12&\n" +
 	"\x0fagent_thread_id\x18\f \x01(\tR\ragentThreadId\x12\x1f\n" +
 	"\vstop_reason\x18\r \x01(\tR\n" +
-	"stopReason\"\xa4\x01\n" +
+	"stopReason\x124\n" +
+	"\x16output_truncated_bytes\x18\x0e \x01(\x04R\x14outputTruncatedBytes\"\xa4\x01\n" +
 	"\x13SandboxHistoryEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x14\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -2125,8 +2125,16 @@ message SandboxHistoryCell {
   string id = 1;
   string type = 2;
   string source = 3;
+  // Never set. A cell's captured streams reach a reader through output, which
+  // already merges them; keeping a second copy here doubled a response that was
+  // large for the same reason it was worth truncating.
   string stdout = 4;
   string stderr = 5;
+  // The captured stream, holding the most recent bytes of a long run rather than
+  // all of them: a single build log reaches tens of megabytes and one such cell
+  // is enough to make a page unreadable and its response unloadable.
+  // output_truncated_bytes says how much was dropped; RunService.FollowRunLogs
+  // still serves the complete log.
   string output = 6;
   int32 exit_code = 7;
   bool success = 8;
@@ -2135,6 +2143,8 @@ message SandboxHistoryCell {
   string agent = 11;
   string agent_thread_id = 12;
   string stop_reason = 13;
+  // Bytes dropped from the head of output. Zero means output is complete.
+  uint64 output_truncated_bytes = 14;
 }
 
 message SandboxHistoryEvent {


### PR DESCRIPTION
## Summary

`ListSandboxHistory` returned a 75MB response for a sandbox that had exactly **one** cell.

A cell accumulates every byte its run writes, for as long as the run lasts, and nothing bounded that. A still-running bootstrap shell whose agent reran a verbose build a dozen times had accumulated a 41.5MB stream. The response carried it twice — `stdout` and `output` hold the same bytes — so one cell became ~75MB on the wire.

The default limit of 100 entries cannot help here: pagination counts entries, and the size was in a single record. Even a well-behaved page of 100 cells has no bound at all today.

This change makes the listing carry the captured stream **once**, as `output`, capped to its most recent 64KB:

- `SandboxHistoryCell.output` is the merged stream (falling back to `stdout + stderr` for a cell recorded before merging); `stdout` and `stderr` are no longer set.
- New `SandboxHistoryCell.output_truncated_bytes` reports the dropped prefix, so a reader can tell it is looking at a tail and say so. `RunService.FollowRunLogs` still serves the complete log.
- The cut lands on a rune boundary. A proto3 string that is not valid UTF-8 fails to marshal, which would fail the entire response rather than one cell.
- `WatchSandbox` shares the converter, so `CELL_STARTED` / `CELL_COMPLETED` frames get the same bound — a completed cell used to arrive at full size there too.

Both consumers in this repository (`cmd/agent-compose` sandbox logs, and the UI) already read `output` first and fall back to `stdout` only when it is empty, so neither loses anything.

`buf breaking` passes: this adds a field and narrows what two existing fields are populated with.

## Out of scope, worth doing next

This fixes the read path. Three related problems remain, each a separate change:

1. `hydrateRunningCellArtifacts` reads a running cell's whole artifact file into memory on every `ListCells`, so the server still allocates ~83MB per request before any of this truncation applies. A bounded tail read fixes it, but it shares `loadCells` with `AddCell`'s read-modify-write, so it needs care not to persist a truncated value.
2. `saveCells` rewrites the entire `cells.json` with `MarshalIndent` on every cell update — for the sandbox above, an 85MB rewrite each time output advanced.
3. `ExecStreamAccumulator` holds the full stream in two `strings.Builder`s with no cap, even though the command request carried `maxOutputBytes: 4MB`. That limit is not applied on the streaming path.

## Testing

```
go test ./pkg/agentcompose/api/... ./cmd/agent-compose/...
go -C proto test ./...
golangci-lint run --allow-parallel-runners ./pkg/agentcompose/api/...
./scripts/tests/test-generated-proto-contract.sh
buf breaking --against '.git#ref=origin/main'
```

All pass.

## Checklist

- [x] Documentation updated when behavior or configuration changed. *(the contract is documented in the `.proto` comments; no manual pages cover this RPC)*
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠️ `Published proto version` is red, and no change in this PR can make it green

```
pkg/agentcompose/api/sandbox.go:315: unknown field OutputTruncatedBytes in struct literal of type agentcomposev2.SandboxHistoryCell
```

That job drops the `replace` and builds against the version `go.mod` requires, `proto v0.1.0`, whose tag points at a commit on `main` from before this branch. Every other job builds through the `replace` and passes.

This is the job working as designed — it exists to catch a proto change that was never tagged — but it makes any PR that adds a proto field red until a tag exists, and a tag should point at a commit on `main`. The sequence has to be:

1. merge this PR,
2. tag `proto/v0.1.1` at the merge commit,
3. bump `require github.com/chaitin/agent-compose/proto` to `v0.1.1`.

Step 3 could ride in this PR only if the tag were cut on this branch first, which puts a permanent module tag on a commit that a squash or rebase would discard. Deciding this is a maintainer call, so leaving the job red and flagged rather than working around it.
