### PR TITLE
fix(cli): warn on deprecated image commands

### DIFF
--- a/cmd/agent-compose/cli_image_definition.go
+++ b/cmd/agent-compose/cli_image_definition.go
@@ -12,11 +12,11 @@ func newCLIImageCommand(cli *cliOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 	}
 	cmd.AddCommand(
-		newCLIImageListCommand(cli, "ls", "List daemon images"),
-		newCLIImagePullCommand(cli, "pull [image]"),
+		newCLIImageListCommand(cli, "ls", "List daemon images", "image ls", "images"),
+		newCLIImagePullCommand(cli, "pull [image]", "image pull [image]", "pull [image]"),
 		newCLIImageBuildCommand(cli, "build [agent...]"),
-		newCLIImageRemoveCommand(cli, "rm <image>"),
-		newCLIImageInspectCommand(cli),
+		newCLIImageRemoveCommand(cli, "rm <image>", "image rm <image>", "rmi <image>"),
+		newCLIImageInspectCommandWithWarning(cli, "inspect <image>", "image inspect <image>", "inspect image <image>"),
 	)
 	return cmd
 }
@@ -29,18 +29,28 @@ func newCLILegacyImageCommands(cli *cliOptions) []*cobra.Command {
 	}
 }
 
-func newCLIImageListCommand(cli *cliOptions, use, short string) *cobra.Command {
+func newCLIImageListCommand(cli *cliOptions, use, short string, warning ...string) *cobra.Command {
 	options := composeImageListOptions{}
 	cmd := &cobra.Command{Use: use, Short: short, Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
+		if len(warning) == 2 {
+			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), warning[0], warning[1]); err != nil {
+				return err
+			}
+		}
 		return runComposeImageListCommand(cmd, *cli, options)
 	}}
 	addImageListFlags(cmd, &options)
 	return cmd
 }
 
-func newCLIImagePullCommand(cli *cliOptions, use string) *cobra.Command {
+func newCLIImagePullCommand(cli *cliOptions, use string, warning ...string) *cobra.Command {
 	options := composeImagePullOptions{}
 	cmd := &cobra.Command{Use: use, Short: "Pull an image or all project images", Args: cobra.RangeArgs(0, 1), RunE: func(cmd *cobra.Command, args []string) error {
+		if len(warning) == 2 {
+			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), warning[0], warning[1]); err != nil {
+				return err
+			}
+		}
 		return runComposePullCommand(cmd, *cli, options, args)
 	}}
 	addImagePullFlags(cmd, &options)
@@ -56,9 +66,14 @@ func newCLIImageBuildCommand(cli *cliOptions, use string) *cobra.Command {
 	return cmd
 }
 
-func newCLIImageRemoveCommand(cli *cliOptions, use string) *cobra.Command {
+func newCLIImageRemoveCommand(cli *cliOptions, use string, warning ...string) *cobra.Command {
 	options := composeImageRemoveOptions{}
 	cmd := &cobra.Command{Use: use, Short: "Remove an image", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		if len(warning) == 2 {
+			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), warning[0], warning[1]); err != nil {
+				return err
+			}
+		}
 		return runComposeImageRemoveCommand(cmd, *cli, options, args[0])
 	}}
 	addImageRemoveFlags(cmd, &options)
@@ -66,7 +81,16 @@ func newCLIImageRemoveCommand(cli *cliOptions, use string) *cobra.Command {
 }
 
 func newCLIImageInspectCommand(cli *cliOptions) *cobra.Command {
-	return &cobra.Command{Use: "inspect <image>", Short: "Inspect an image", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+	return newCLIImageInspectCommandWithWarning(cli, "inspect <image>")
+}
+
+func newCLIImageInspectCommandWithWarning(cli *cliOptions, use string, warning ...string) *cobra.Command {
+	return &cobra.Command{Use: use, Short: "Inspect an image", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		if len(warning) == 2 {
+			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), warning[0], warning[1]); err != nil {
+				return err
+			}
+		}
 		return runComposeImageInspectCommand(cmd, *cli, args[0])
 	}}
 }

--- a/cmd/agent-compose/cli_image_definition.go
+++ b/cmd/agent-compose/cli_image_definition.go
@@ -14,7 +14,7 @@ func newCLIImageCommand(cli *cliOptions) *cobra.Command {
 	cmd.AddCommand(
 		newCLIImageListCommand(cli, "ls", "List daemon images", "image ls", "images"),
 		newCLIImagePullCommand(cli, "pull [image]", "image pull [image]", "pull [image]"),
-		newCLIImageBuildCommand(cli, "build [agent...]"),
+		newCLIImageBuildCommand(cli, "build [agent...]", "image build [agent...]", "build [agent...]"),
 		newCLIImageRemoveCommand(cli, "rm <image>", "image rm <image>", "rmi <image>"),
 		newCLIImageInspectCommandWithWarning(cli, "inspect <image>", "image inspect <image>", "inspect image <image>"),
 	)
@@ -57,9 +57,14 @@ func newCLIImagePullCommand(cli *cliOptions, use string, warning ...string) *cob
 	return cmd
 }
 
-func newCLIImageBuildCommand(cli *cliOptions, use string) *cobra.Command {
+func newCLIImageBuildCommand(cli *cliOptions, use string, warning ...string) *cobra.Command {
 	options := composeImageBuildOptions{}
 	cmd := &cobra.Command{Use: use, Short: "Build project agent images", Args: cobra.ArbitraryArgs, RunE: func(cmd *cobra.Command, args []string) error {
+		if len(warning) == 2 {
+			if err := writeDeprecatedWarning(cmd.ErrOrStderr(), warning[0], warning[1]); err != nil {
+				return err
+			}
+		}
 		return runComposeBuildCommand(cmd, *cli, options, args)
 	}}
 	addImageBuildFlags(cmd, &options)

--- a/cmd/agent-compose/cli_image_definition.go
+++ b/cmd/agent-compose/cli_image_definition.go
@@ -85,10 +85,6 @@ func newCLIImageRemoveCommand(cli *cliOptions, use string, warning ...string) *c
 	return cmd
 }
 
-func newCLIImageInspectCommand(cli *cliOptions) *cobra.Command {
-	return newCLIImageInspectCommandWithWarning(cli, "inspect <image>")
-}
-
 func newCLIImageInspectCommandWithWarning(cli *cliOptions, use string, warning ...string) *cobra.Command {
 	return &cobra.Command{Use: use, Short: "Inspect an image", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 		if len(warning) == 2 {

--- a/cmd/agent-compose/cli_image_test.go
+++ b/cmd/agent-compose/cli_image_test.go
@@ -52,7 +52,7 @@ func TestIntegrationCLIImagesAliasesAndJSON(t *testing.T) {
 	}
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "ls", "--host", server.URL)
-	if textCode != 0 || textErr != "" {
+	if textCode != 0 || !strings.Contains(textErr, "image ls is deprecated") || !strings.Contains(textErr, "use images instead") {
 		t.Fatalf("image ls code/stderr = %d / %q", textCode, textErr)
 	}
 	for _, want := range []string{"IMAGE ID", "REF", "DISK USAGE", "abc123456789", "agent:latest", "1.0KB"} {
@@ -121,7 +121,7 @@ func TestIntegrationCLIImagePullAliasesAndJSON(t *testing.T) {
 	}
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "pull", "--host", server.URL, "agent:latest")
-	if textCode != 0 || textErr != "" {
+	if textCode != 0 || !strings.Contains(textErr, "image pull [image] is deprecated") || !strings.Contains(textErr, "use pull [image] instead") {
 		t.Fatalf("image pull code/stderr = %d / %q", textCode, textErr)
 	}
 	if !strings.Contains(textOut, "Pulled agent:latest") || !strings.Contains(textOut, "agent@sha256:def") {
@@ -213,7 +213,8 @@ agents:
 			args := append([]string{}, command.args...)
 			args = append(args, "--host", server.URL, "--file", composePath, "--platform", "linux/amd64")
 			stdout, stderr, _, exitCode := executeCLICommand(args...)
-			if exitCode != 0 || stderr != "" {
+			wantWarning := command.name == "image command"
+			if exitCode != 0 || (wantWarning && !strings.Contains(stderr, "image pull [image] is deprecated")) || (!wantWarning && stderr != "") {
 				t.Fatalf("pull project code/stderr = %d / %q", exitCode, stderr)
 			}
 			for _, want := range []string{"Pulled agent:v2", "agent:v2@sha256:def", "Pulled agent:v1", "agent:v1@sha256:def"} {
@@ -465,7 +466,7 @@ func TestIntegrationCLIImageRemoveAliasesAndJSON(t *testing.T) {
 	}
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "rm", "--host", server.URL, "--prune-children", "agent:old")
-	if textCode != 0 || textErr != "" {
+	if textCode != 0 || !strings.Contains(textErr, "image rm <image> is deprecated") || !strings.Contains(textErr, "use rmi <image> instead") {
 		t.Fatalf("image rm code/stderr = %d / %q", textCode, textErr)
 	}
 	if !strings.Contains(textOut, "Untagged: agent:old") || !strings.Contains(textOut, "Deleted: old") {
@@ -536,7 +537,7 @@ func TestIntegrationCLIImageInspectJSON(t *testing.T) {
 	}
 
 	imageOut, imageErr, _, imageCode := executeCLICommand("image", "inspect", "--host", server.URL, "agent:latest")
-	if imageCode != 0 || imageErr != "" {
+	if imageCode != 0 || !strings.Contains(imageErr, "image inspect <image> is deprecated") || !strings.Contains(imageErr, "use inspect image <image> instead") {
 		t.Fatalf("image inspect code/stderr = %d / %q", imageCode, imageErr)
 	}
 	var imageDecoded composeImageInspectOutput

--- a/cmd/agent-compose/cli_image_test.go
+++ b/cmd/agent-compose/cli_image_test.go
@@ -338,7 +338,7 @@ agents:
 	defer server.Close()
 
 	textOut, textErr, _, textCode := executeCLICommand("image", "build", "--host", server.URL, "--file", composePath, "-t", "reviewer:ci", "--dockerfile", "Dockerfile.agent", "--target", "runtime", "--build-arg", "NODE_ENV=development", "--platform", "linux/amd64", "--no-cache", "--pull", "reviewer")
-	if textCode != 0 || textErr != "" {
+	if textCode != 0 || !strings.Contains(textErr, "image build [agent...] is deprecated") || !strings.Contains(textErr, "use build [agent...] instead") {
 		t.Fatalf("image build code/stderr = %d / %q", textCode, textErr)
 	}
 	if !strings.Contains(textOut, "build step") || !strings.Contains(textOut, "Built reviewer:dev") {


### PR DESCRIPTION
## 问题

顶层命令 `images`、`pull`、`build`、`rmi`、`inspect image` 已经是推荐写法，但历史写法
`agent-compose image ls / pull / build / rm / inspect` 仍然可用，而且执行时没有任何提示。
用户按旧文档或旧习惯调用这些子命令时，既不知道它们已被替代，也不知道该迁移到哪个命令。

## 影响

旧写法会在用户无感知的情况下长期留在脚本和 CI 里。一旦后续版本真正移除这些子命令，
这些脚本会在升级后直接失败，而失败点离这次弃用决策很远，排查成本高。
属于兼容性迁移风险，不是运行时缺陷。

## 修复内容

- 为 `image ls / pull / build / rm / inspect` 五个旧子命令补充弃用告警，
  并给出对应的顶层替代命令（`images` / `pull` / `build` / `rmi` / `inspect image`）。
- 告警统一写入 stderr，保证 `--json` 的 stdout 仍是可直接解析的机器可读输出。
- 调整 CLI 回归测试，覆盖五个旧别名的告警文案、替代命令提示，以及新写法不产生告警。

## 验证

先证明问题真实存在（把生产代码退回修复前、保留测试）：

```text
$ go test ./cmd/agent-compose -count=1 -run 'TestIntegrationCLIImagesAliasesAndJSON|TestIntegrationCLIImagePullAliasesAndJSON|TestIntegrationCLIImageBuildLegacyProject|TestIntegrationCLIImageRemoveAliasesAndJSON|TestIntegrationCLIImageInspectJSON'
--- FAIL: TestIntegrationCLIImagesAliasesAndJSON (0.01s)
    cli_image_test.go:56: image ls code/stderr = 0 / ""
--- FAIL: TestIntegrationCLIImagePullAliasesAndJSON (0.00s)
    cli_image_test.go:125: image pull code/stderr = 0 / ""
--- FAIL: TestIntegrationCLIImageBuildLegacyProject (0.01s)
    cli_image_test.go:342: image build code/stderr = 0 / ""
--- FAIL: TestIntegrationCLIImageRemoveAliasesAndJSON (0.01s)
    cli_image_test.go:470: image rm code/stderr = 0 / ""
--- FAIL: TestIntegrationCLIImageInspectJSON (0.01s)
    cli_image_test.go:541: image inspect code/stderr = 0 / ""
FAIL	github.com/chaitin/agent-compose/cmd/agent-compose	1.104s
```

`code/stderr = 0 / ""` 表示修复前这些旧别名退出码正常、stderr 完全为空，即完全没有弃用提示。

恢复修复代码后，同一组断言转绿：

```text
$ go test ./cmd/agent-compose -count=1 -run '<同一组>'
ok  	github.com/chaitin/agent-compose/cmd/agent-compose	0.863s
```

本包全量测试：

```text
$ go test ./cmd/agent-compose -count=1
ok  	github.com/chaitin/agent-compose/cmd/agent-compose	10.028s
```

真实二进制 + 真实 daemon 端到端（daemon 监听 `127.0.0.1:18410`）。重点是
旧写法在输出告警的同时，`--json` 的 stdout 必须仍然是完整可解析的 JSON：

```text
$ agent-compose images --host http://127.0.0.1:18410 --json
exit=0   stderr=0 字节
stdout:
{
  "images": [],
  "total": 0,
  "store_status": { "store": "oci-cache", "available": true, "endpoint": ".../images/oci" }
}

$ agent-compose image ls --host http://127.0.0.1:18410 --json
exit=0
stderr: Warning: image ls is deprecated and will be removed in a future release; use images instead.
stdout:
{
  "images": [],
  "total": 0,
  "store_status": { "store": "oci-cache", "available": true, "endpoint": ".../images/oci" }
}
```

两个 stdout 均为合法 JSON 且内容一致，告警只出现在 stderr。

五个旧别名的真实告警文案，以及新写法不产生告警：

```text
Warning: image ls is deprecated and will be removed in a future release; use images instead.
Warning: image pull [image] is deprecated and will be removed in a future release; use pull [image] instead.
Warning: image build [agent...] is deprecated and will be removed in a future release; use build [agent...] instead.
Warning: image rm <image> is deprecated and will be removed in a future release; use rmi <image> instead.
Warning: image inspect <image> is deprecated and will be removed in a future release; use inspect image <image> instead.

$ agent-compose build --help      ->  exit=0, stderr=0 字节
$ agent-compose images --host ... ->  stderr 只有连接错误，没有告警
```

`git diff --check` 无输出。

说明：本 PR 只改动 `cmd/agent-compose`，验证范围是该包全量测试加真实二进制端到端；
daemon 未运行时旧别名会先打印告警、再报连接错误，属预期行为。本次未运行 `go test ./...`。

Closes #409
