### PR TITLE
docs: expand agent development and daemon integration guides

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -137,6 +137,8 @@ tasks:
       - '../../build/pages/zh-CN/developing-agents.html'
       - '../../build/pages/zh-CN/scheduler-api.html'
       - '../../build/pages/zh-CN/daemon-integration.html'
+      - '../../build/pages/runtime-sdk.html'
+      - '../../build/pages/zh-CN/runtime-sdk.html'
     cmds:
       - npm ci --no-audit --no-fund
       - npm run build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,9 +128,15 @@ tasks:
       - '../../build/pages/command-line-manual.html'
       - '../../build/pages/agent-compose-yaml-manual.html'
       - '../../build/pages/guest-image-abi.html'
+      - '../../build/pages/developing-agents.html'
+      - '../../build/pages/scheduler-api.html'
+      - '../../build/pages/daemon-integration.html'
       - '../../build/pages/zh-CN/command-line-manual.html'
       - '../../build/pages/zh-CN/agent-compose-yaml-manual.html'
       - '../../build/pages/zh-CN/guest-image-abi.html'
+      - '../../build/pages/zh-CN/developing-agents.html'
+      - '../../build/pages/zh-CN/scheduler-api.html'
+      - '../../build/pages/zh-CN/daemon-integration.html'
     cmds:
       - npm ci --no-audit --no-fund
       - npm run build

--- a/docs/pages/daemon-integration.md
+++ b/docs/pages/daemon-integration.md
@@ -1,0 +1,69 @@
+# Integrating with the agent-compose daemon
+
+The daemon is the control plane for projects, revisions, agents, schedulers,
+runs, sandboxes, events, artifacts, images, caches, and volumes. External
+clients should use the generated Connect RPC client; the CLI and Web UI use the
+same boundary.
+
+## Transport and authentication
+
+The daemon accepts Connect RPC over HTTP. For a TCP deployment, use the
+configured base URL and send:
+
+```text
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+Unix-socket access is intended for local clients. HTTPS and reverse-proxy
+termination belong to the deployment boundary. Do not put bearer tokens in
+URLs, compose files committed to source control, prompts, or logs.
+
+Connect procedure paths are generated from the protobuf service and method
+names, for example:
+
+```text
+/agentcompose.v2.ProjectService/ListProjects
+```
+
+Use generated types and clients instead of hand-writing procedure paths.
+
+## Resource lifecycle
+
+The common project flow is:
+
+1. Validate a compose document with `ProjectService.ValidateProject`.
+2. Apply it with `ProjectService.ApplyProject`, which creates a revision.
+3. Start a run with `RunService.RunAgent` or `StartAgentRun`.
+4. Read events with `ListRunEvents` or follow output with
+   `FollowRunLogs`/`StreamAgentRun`.
+5. Stop a run with `RunService.StopRun` when cancellation is required.
+
+Resource IDs are scoped identifiers, not display names. Resolve user-facing
+references through `ResourceService.ResolveID` when a command accepts more
+than one resource kind.
+
+## Streaming and cancellation
+
+Unary methods return one response. Server-streaming methods deliver events or
+output until completion. Bidirectional methods such as `AttachAgentRun` keep
+an interactive attachment open and require a context cancellation path.
+
+Always set a bounded context deadline, propagate cancellation, close the
+transport, and handle a terminal status. Reconnecting an interactive run
+requires the returned run ID; do not create a second run accidentally.
+
+## Errors and capability boundaries
+
+An RPC may return `CodeUnimplemented` when a concrete runtime capability is not
+compiled or available. This is different from the generated
+`Unimplemented...ServiceHandler` fallback, which indicates a missing route or
+handler. Clients should report the operation, resource, and server error
+without exposing credentials.
+
+The control plane is separate from data-plane routes such as workspace file
+transfer, Jupyter proxy, webhook ingress, and the runtime LLM facade. Do not
+use those routes to manage projects or runs.
+
+For the authoritative CLI-to-RPC mapping and approved HTTP exceptions, see the
+[Connect transport matrix](connect-transport-matrix.html).

--- a/docs/pages/developing-agents.md
+++ b/docs/pages/developing-agents.md
@@ -1,0 +1,112 @@
+# Developing agents with agent-compose
+
+This guide connects the compose file, the daemon, the guest runtime, and the
+execution records into one runnable workflow. Use it when you are building an
+agent rather than only configuring one.
+
+## Three execution environments
+
+agent-compose has three deliberately separate JavaScript surfaces:
+
+| Surface | Runs in | Main purpose |
+| --- | --- | --- |
+| Guest Runtime SDK | A sandbox guest | Run workspace code, commands, agents, and workflows |
+| Scheduler API | The daemon's QuickJS runtime | Register triggers and start agents, LLM calls, commands, and events |
+| Daemon API | An external client over Connect RPC | Manage projects, runs, sandboxes, and events |
+
+Code in one surface is not automatically importable from another. Keep
+workspace automation in the Guest Runtime SDK, scheduling policy in a
+`scheduler.script`, and lifecycle control in the daemon client.
+
+## A minimal project
+
+Create `agent-compose.yml`:
+
+```yaml
+name: review-demo
+agents:
+  reviewer:
+    provider: codex
+    image: chaitin/agent-compose-guest:latest
+    workspace:
+      path: .
+    system_prompt: Review the workspace and summarize the result.
+```
+
+Validate and apply it from the directory containing the file:
+
+```bash
+agent-compose config
+agent-compose up -f agent-compose.yml
+agent-compose project ls
+agent-compose agent ls review-demo
+agent-compose run review-demo/reviewer "Check the README for missing steps."
+agent-compose logs review-demo
+```
+
+`config` parses, validates, normalizes, and redacts local configuration.
+`up` stores a revision in the daemon. A run executes in an isolated sandbox;
+the source workspace is not modified directly.
+
+## Add a scheduler
+
+For simple schedules, use declarative triggers. For shared workflow logic or
+multiple capabilities, use a script:
+
+```yaml
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      script: |
+        scheduler.cron("daily-review", "0 9 * * *", async () => {
+          return scheduler.agent("Review the latest workspace changes.", {
+            sandboxPolicy: "new",
+            timeout: "10m",
+          });
+        }, { timezone: "UTC" });
+
+        function main(payload) {
+          return { accepted: true, payload: payload ?? null };
+        }
+```
+
+Run `agent-compose scheduler inspect review-demo/reviewer` to inspect the
+stored scheduler and `agent-compose scheduler runs review-demo/reviewer` to
+inspect outcomes. Scheduler scripts are evaluated by the daemon; they do not
+support `import` or `require`. See the [Scheduler API guide](scheduler-api.html)
+for trigger IDs, events, concurrency, cancellation, and error behavior.
+
+## Observe and debug a run
+
+Start with the run or scheduler-run record, then inspect its events and logs:
+
+```bash
+agent-compose inspect review-demo/reviewer
+agent-compose logs review-demo
+agent-compose scheduler runs review-demo/reviewer
+```
+
+The useful distinction is:
+
+- `failed`: the operation ran and reported a failure;
+- `stopped`: the operation was explicitly stopped;
+- `skipped`: a scheduler concurrency policy prevented a new run;
+- unsupported capability: the concrete handler rejected an unavailable driver
+  or provider.
+
+Do not treat a healthy daemon or a successful `config` as proof that a provider
+or runtime image can execute. Run a real sandbox task before production use.
+
+## Deployment checklist
+
+Before sharing a project:
+
+1. Pin moving Git sources and guest images to a release or commit where
+   reproducibility matters.
+2. Provide only the provider and guest-image capabilities the project uses.
+3. Keep secrets in secret-marked environment entries; never put tokens in
+   prompts, source control, or logs.
+4. Set an explicit scheduler timeout and concurrency policy for recurring work.
+5. Verify a real run, its persisted events, and its failure path with the
+   selected runtime driver.

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -2647,6 +2647,27 @@
               data-zh="YAML 配置手册"
               data-en="YAML Manual"
             >YAML 配置手册</a>
+            <a
+              href="runtime-sdk.html"
+              data-href-zh="zh-CN/runtime-sdk.html"
+              data-href-en="runtime-sdk.html"
+              data-zh="Runtime SDK"
+              data-en="Runtime SDK"
+            >Runtime SDK</a>
+            <a
+              href="scheduler-api.html"
+              data-href-zh="zh-CN/scheduler-api.html"
+              data-href-en="scheduler-api.html"
+              data-zh="Scheduler API"
+              data-en="Scheduler API"
+            >Scheduler API</a>
+            <a
+              href="daemon-integration.html"
+              data-href-zh="zh-CN/daemon-integration.html"
+              data-href-en="daemon-integration.html"
+              data-zh="Daemon 集成"
+              data-en="Daemon Integration"
+            >Daemon 集成</a>
           </nav>
           <div class="topbar-actions">
             <div class="lang-switch">

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -2651,8 +2651,9 @@
               href="developing-agents.html"
               data-href-zh="zh-CN/developing-agents.html"
               data-href-en="developing-agents.html"
-              >Developing agents</a
-            >
+              data-zh="智能体开发"
+              data-en="Developing agents"
+            >智能体开发</a>
             <a
               href="runtime-sdk.html"
               data-href-zh="zh-CN/runtime-sdk.html"

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -2648,6 +2648,12 @@
               data-en="YAML Manual"
             >YAML 配置手册</a>
             <a
+              href="developing-agents.html"
+              data-href-zh="zh-CN/developing-agents.html"
+              data-href-en="developing-agents.html"
+              >Developing agents</a
+            >
+            <a
               href="runtime-sdk.html"
               data-href-zh="zh-CN/runtime-sdk.html"
               data-href-en="runtime-sdk.html"

--- a/docs/pages/runtime-sdk.md
+++ b/docs/pages/runtime-sdk.md
@@ -44,7 +44,7 @@ and [guest image ABI](guest-image-abi.html) for the image-side requirements.
 ## Complete example
 
 ```js
-import { runtime } from "@chaitin-ai/agent-compose-runtime-sdk";
+import runtime from "@chaitin-ai/agent-compose-runtime-sdk";
 
 const check = await runtime.shell("test -d \"$WORKSPACE\" && pwd", {
   streamOutput: false,

--- a/docs/pages/runtime-sdk.md
+++ b/docs/pages/runtime-sdk.md
@@ -1,0 +1,59 @@
+# Guest Runtime SDK
+
+The `@chaitin-ai/agent-compose-runtime-sdk` package runs inside an
+agent-compose guest. It is the workspace-side API; it is not the daemon
+control-plane client and it cannot manage projects or sandboxes.
+
+## Install and run
+
+```bash
+npm install @chaitin-ai/agent-compose-runtime-sdk
+# Guest images may install the release-matched tarball offline:
+npm install --offline /opt/agent-compose/npm/agent-compose-runtime-sdk.tgz
+```
+
+```js
+import runtime from "@chaitin-ai/agent-compose-runtime-sdk";
+
+const result = await runtime.exec("node", ["--version"], {
+  streamOutput: false,
+});
+runtime.log("runtime ready", { success: result.success });
+```
+
+The package requires the Node.js version declared by its `engines` field. Use
+the SDK from the same release as the daemon/runtime image when compatibility
+matters.
+
+## API map
+
+The exported surfaces are `exec`, `shell`, `agent`, `llm`, `workflow`,
+`workflowFile`, `env`, `paths`, `log`, `report`, and `ssh`. Command results
+include exit status and bounded output; `agent` and `llm` can validate
+structured output with a plain JSON Schema or Zod schema.
+
+`ssh.prepareConfig` writes a private SSH config and optional key with
+restricted file modes. Use its returned config with `ssh.command` or
+`ssh.scpCommand`; do not log private key contents. The SDK's `report` helper
+writes reports beneath the runtime report boundary rather than exposing an
+arbitrary host path.
+
+See the [full package API reference](https://github.com/chaitin/agent-compose/blob/main/runtime/agent-compose-runtime-sdk/README.md)
+and [guest image ABI](guest-image-abi.html) for the image-side requirements.
+
+## Complete example
+
+```js
+import { runtime } from "@chaitin-ai/agent-compose-runtime-sdk";
+
+const check = await runtime.shell("test -d \"$WORKSPACE\" && pwd", {
+  streamOutput: false,
+});
+if (!check.success) {
+  throw new Error(check.stderr || "workspace check failed");
+}
+await runtime.report.writeMarkdown("summary.md", `# Check\n\n${check.stdout}`);
+```
+
+Keep provider credentials in secret-marked environment variables. Treat
+workspace files, command output, and agent responses as untrusted data.

--- a/docs/pages/scheduler-api.md
+++ b/docs/pages/scheduler-api.md
@@ -1,0 +1,64 @@
+# Scheduler JavaScript API
+
+Scheduler scripts run in the daemon's QuickJS environment. The host injects a
+global `scheduler` object; scripts do not use `import`, `require`, or Node.js
+modules.
+
+## Register stable triggers
+
+```js
+scheduler.interval("heartbeat", () => scheduler.agent("Check the workspace."), 60000);
+scheduler.timeout("startup", () => scheduler.log("started"), 1000);
+scheduler.cron("daily", "0 9 * * *", () => scheduler.agent("Prepare a report."), {
+  timezone: "UTC",
+});
+scheduler.on("agent-compose.session.created", "session-created", (event) => {
+  scheduler.log("new session", event);
+});
+```
+
+Trigger IDs are persisted identities, not timer handles. Keep them explicit and
+stable; changing one creates a different trigger. A script scheduler and
+declarative `scheduler.triggers` are mutually exclusive.
+
+## Capabilities and results
+
+Scripts can call `scheduler.agent`, `scheduler.llm`, `scheduler.exec`,
+`scheduler.shell`, `scheduler.log`, and `scheduler.event.publish`. The
+`scheduler.agent` call can select `sandboxPolicy` (`new`, `sticky`, or `reuse`),
+an agent, timeout, driver, guest image, workspace, environment, and an output
+schema. Results include success information, output, sandbox identity, and
+stop reason.
+
+Use `scheduler.state` for JSON-serializable durable state:
+
+```js
+const count = scheduler.state.get("count") ?? 0;
+scheduler.state.set("count", count + 1);
+```
+
+## Validation and execution
+
+Validation registers triggers and checks their shape; it does not execute agent,
+LLM, or shell work. Execution happens when a trigger fires or when a scheduler
+run is invoked. Keep callbacks bounded with timeouts and return
+JSON-serializable values so `result_json` can be persisted.
+
+The scheduler-wide `concurrency_policy` is `skip` or `parallel`. With `skip`,
+an overlapping run is recorded as skipped rather than queued. The policy
+applies to the whole scheduler, not only one trigger. `scheduler.agent.async`
+always uses a new sandbox for parallel work.
+
+## Debugging
+
+Use explicit trigger IDs, `scheduler.log`, and the CLI commands below:
+
+```bash
+agent-compose scheduler inspect <scheduler>
+agent-compose scheduler invoke <scheduler> --payload '{"source":"manual"}'
+agent-compose scheduler runs <scheduler>
+agent-compose scheduler logs <scheduler>
+```
+
+`clearInterval` and `clearTimeout` only affect registrations made during the
+current script evaluation; use the UI or API to persistently disable a trigger.

--- a/docs/pages/zh-CN/daemon-integration.md
+++ b/docs/pages/zh-CN/daemon-integration.md
@@ -1,0 +1,58 @@
+# 集成 agent-compose daemon
+
+daemon 是 project、revision、Agent、scheduler、run、sandbox、event、artifact、
+image、cache 和 volume 的控制面。外部客户端应使用生成的 Connect RPC client；
+CLI 和 Web UI 也使用同一边界。
+
+## 传输和认证
+
+TCP 部署通过 HTTP 提供 Connect RPC，配置 base URL，并发送：
+
+```text
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+Unix socket 适合本地客户端。HTTPS 和反向代理终止属于部署边界。不要把 bearer
+token 放在 URL、提交到源码仓库的 compose 文件、prompt 或日志中。
+
+Connect procedure path 由 protobuf service 和 method 名称生成，例如：
+
+```text
+/agentcompose.v2.ProjectService/ListProjects
+```
+
+应使用生成的类型和 client，不要手写 procedure path。
+
+## 资源生命周期
+
+典型 project 流程如下：
+
+1. 调用 `ProjectService.ValidateProject` 校验 compose。
+2. 调用 `ProjectService.ApplyProject` 应用配置并创建 revision。
+3. 调用 `RunService.RunAgent` 或 `StartAgentRun` 启动运行。
+4. 用 `ListRunEvents` 读取事件，或用 `FollowRunLogs`/`StreamAgentRun` 跟随输出。
+5. 需要取消时调用 `RunService.StopRun`。
+
+资源 ID 是有作用域的标识，不等于展示名称。命令支持多种资源类型时，应通过
+`ResourceService.ResolveID` 解析用户输入。
+
+## Streaming 和取消
+
+Unary 方法返回一个响应；server-streaming 方法持续发送事件或输出；类似
+`AttachAgentRun` 的双向流会保持交互连接，必须支持 context 取消。
+
+始终设置有上限的 context deadline，传递取消信号，关闭 transport，并处理终态。
+恢复交互运行时要使用服务端返回的 run ID，避免误创建第二个 run。
+
+## 错误和能力边界
+
+当具体 runtime 能力未编译或不可用时，RPC 可能返回 `CodeUnimplemented`。这与生成的
+`Unimplemented...ServiceHandler` 不同，后者表示路由或 handler 缺失。客户端应报告
+操作、资源和服务端错误，但不能泄露凭据。
+
+控制面与 workspace 文件传输、Jupyter proxy、webhook ingress、runtime LLM facade
+等 data-plane route 分离。不要用这些 route 管理 project 或 run。
+
+CLI 到 RPC 的权威映射和允许的 HTTP 例外见
+[Connect 传输支持矩阵](connect-transport-matrix.html)。

--- a/docs/pages/zh-CN/developing-agents.md
+++ b/docs/pages/zh-CN/developing-agents.md
@@ -1,0 +1,98 @@
+# 使用 agent-compose 开发 Agent
+
+这份手册把 compose 文件、daemon、guest runtime 和运行记录串成一条可执行流程，适合开发 Agent 时使用。
+
+## 三种执行环境
+
+| 接口 | 运行位置 | 主要用途 |
+| --- | --- | --- |
+| Guest Runtime SDK | sandbox guest 内 | 执行工作区代码、命令、Agent 和 workflow |
+| Scheduler API | daemon 的 QuickJS 环境 | 注册触发器，启动 Agent、LLM、命令和事件 |
+| Daemon API | 外部客户端，通过 Connect RPC | 管理 project、run、sandbox 和事件 |
+
+三种环境彼此隔离，不能直接互相 `import`。工作区自动化放在 Guest Runtime
+SDK，调度策略放在 `scheduler.script`，生命周期控制放在 daemon client。
+
+## 一个最小项目
+
+创建 `agent-compose.yml`：
+
+```yaml
+name: review-demo
+agents:
+  reviewer:
+    provider: codex
+    image: chaitin/agent-compose-guest:latest
+    workspace:
+      path: .
+    system_prompt: Review the workspace and summarize the result.
+```
+
+在该文件所在目录执行：
+
+```bash
+agent-compose config
+agent-compose up -f agent-compose.yml
+agent-compose project ls
+agent-compose agent ls review-demo
+agent-compose run review-demo/reviewer "Check the README for missing steps."
+agent-compose logs review-demo
+```
+
+`config` 负责本地配置的解析、校验、规范化和脱敏；`up` 将 revision 保存到
+daemon。每次运行都在隔离 sandbox 中执行，不会直接修改源工作区。
+
+## 添加调度
+
+简单任务可以使用声明式 trigger；需要共享流程或组合多种能力时使用脚本：
+
+```yaml
+agents:
+  reviewer:
+    provider: codex
+    scheduler:
+      script: |
+        scheduler.cron("daily-review", "0 9 * * *", async () => {
+          return scheduler.agent("Review the latest workspace changes.", {
+            sandboxPolicy: "new",
+            timeout: "10m",
+          });
+        }, { timezone: "UTC" });
+
+        function main(payload) {
+          return { accepted: true, payload: payload ?? null };
+        }
+```
+
+使用 `agent-compose scheduler inspect review-demo/reviewer` 查看已保存的调度，
+使用 `agent-compose scheduler runs review-demo/reviewer` 查看执行结果。调度脚本
+由 daemon 执行，不支持 `import` 或 `require`。触发器 ID、事件、并发、取消和错误
+行为见 [Scheduler API 手册](scheduler-api.html)。
+
+## 观察和排查运行
+
+先查看 run 或 scheduler run，再查看事件和日志：
+
+```bash
+agent-compose inspect review-demo/reviewer
+agent-compose logs review-demo
+agent-compose scheduler runs review-demo/reviewer
+```
+
+几种状态含义不同：
+
+- `failed`：任务确实执行过，但报告了失败；
+- `stopped`：任务被显式停止；
+- `skipped`：调度并发策略阻止了新的运行；
+- 不支持的能力：具体 handler 拒绝了当前不可用的 driver 或 provider。
+
+daemon 健康或 `config` 成功，并不能证明 provider 和 runtime 镜像可以真正执行；
+上线前要用目标 driver 跑一次真实 sandbox 任务。
+
+## 发布前检查
+
+1. 需要可复现时，将移动的 Git source 和 guest image 固定到 release 或 commit。
+2. 只提供项目实际使用的 provider 和 guest-image 能力。
+3. secret 放在标记为 secret 的环境变量中，不要写入 prompt、源码或日志。
+4. 为周期任务设置明确的超时和并发策略。
+5. 使用目标 driver 验证真实运行、持久化事件和失败路径。

--- a/docs/pages/zh-CN/runtime-sdk.md
+++ b/docs/pages/zh-CN/runtime-sdk.md
@@ -1,0 +1,55 @@
+# Guest Runtime SDK
+
+`@chaitin-ai/agent-compose-runtime-sdk` 运行在 agent-compose guest 内，是工作区
+侧的 API；它不是 daemon 控制面 client，也不能管理 project 或 sandbox。
+
+## 安装和运行
+
+```bash
+npm install @chaitin-ai/agent-compose-runtime-sdk
+# guest image 也可以离线安装与版本匹配的 tarball：
+npm install --offline /opt/agent-compose/npm/agent-compose-runtime-sdk.tgz
+```
+
+```js
+import runtime from "@chaitin-ai/agent-compose-runtime-sdk";
+
+const result = await runtime.exec("node", ["--version"], {
+  streamOutput: false,
+});
+runtime.log("runtime ready", { success: result.success });
+```
+
+包要求使用其 `engines` 字段声明的 Node.js 版本。需要兼容性时，应使用与
+daemon/runtime image 同一 release 的 SDK。
+
+## API 总览
+
+导出的能力包括 `exec`、`shell`、`agent`、`llm`、`workflow`、
+`workflowFile`、`env`、`paths`、`log`、`report` 和 `ssh`。命令结果包含退出状态
+和有上限的输出；`agent` 与 `llm` 支持使用普通 JSON Schema 或 Zod Schema 校验
+结构化输出。
+
+`ssh.prepareConfig` 会写入私有 SSH config，并在提供密钥时使用受限文件权限。
+可将返回的 config 交给 `ssh.command` 或 `ssh.scpCommand`；不要记录私钥内容。
+`report` helper 会把报告写在 runtime 报告边界内，不会暴露任意宿主路径。
+
+参见[完整的包 API 文档](https://github.com/chaitin/agent-compose/blob/main/runtime/agent-compose-runtime-sdk/README.md)
+和 [Guest Image ABI](guest-image-abi.html)。
+
+## 完整示例
+
+```js
+import { runtime } from "@chaitin-ai/agent-compose-runtime-sdk";
+
+const check = await runtime.shell('test -d "$WORKSPACE" && pwd', {
+  streamOutput: false,
+});
+if (!check.success) {
+  throw new Error(check.stderr || "workspace check failed");
+}
+await runtime.report.writeMarkdown("summary.md", `# Check\n\n${check.stdout}`);
+```
+
+provider 凭据应放在标记为 secret 的环境变量中。工作区文件、命令输出和 Agent
+返回内容都应按不可信数据处理。

--- a/docs/pages/zh-CN/runtime-sdk.md
+++ b/docs/pages/zh-CN/runtime-sdk.md
@@ -40,7 +40,7 @@ daemon/runtime image 同一 release 的 SDK。
 ## 完整示例
 
 ```js
-import { runtime } from "@chaitin-ai/agent-compose-runtime-sdk";
+import runtime from "@chaitin-ai/agent-compose-runtime-sdk";
 
 const check = await runtime.shell('test -d "$WORKSPACE" && pwd', {
   streamOutput: false,

--- a/docs/pages/zh-CN/scheduler-api.md
+++ b/docs/pages/zh-CN/scheduler-api.md
@@ -1,0 +1,59 @@
+# Scheduler JavaScript API
+
+Scheduler 脚本运行在 daemon 的 QuickJS 环境。宿主会注入全局
+`scheduler` 对象；脚本不能使用 `import`、`require` 或 Node.js 模块。
+
+## 注册稳定的 trigger
+
+```js
+scheduler.interval("heartbeat", () => scheduler.agent("Check the workspace."), 60000);
+scheduler.timeout("startup", () => scheduler.log("started"), 1000);
+scheduler.cron("daily", "0 9 * * *", () => scheduler.agent("Prepare a report."), {
+  timezone: "UTC",
+});
+scheduler.on("agent-compose.session.created", "session-created", (event) => {
+  scheduler.log("new session", event);
+});
+```
+
+trigger ID 是持久化身份，不是 timer handle。应显式设置并保持稳定；修改 ID 会
+产生新的 trigger。脚本 scheduler 与声明式 `scheduler.triggers` 不能同时使用。
+
+## 能力和返回值
+
+脚本可以调用 `scheduler.agent`、`scheduler.llm`、`scheduler.exec`、
+`scheduler.shell`、`scheduler.log` 和 `scheduler.event.publish`。
+`scheduler.agent` 可以设置 sandbox 策略（`new`、`sticky`、`reuse`）、Agent、
+超时、driver、guest image、workspace、环境变量和输出 schema。返回值包含成功
+信息、输出、sandbox 身份和停止原因。
+
+`scheduler.state` 用于保存可 JSON 序列化的状态：
+
+```js
+const count = scheduler.state.get("count") ?? 0;
+scheduler.state.set("count", count + 1);
+```
+
+## 校验和执行
+
+校验阶段只负责注册 trigger 和检查结构，不会执行 Agent、LLM 或 shell。真正执行
+发生在 trigger 触发或手动调用 scheduler run 时。回调应设置边界明确的超时，并返回
+可 JSON 序列化的结果，便于保存到 `result_json`。
+
+Scheduler 级别的 `concurrency_policy` 是 `skip` 或 `parallel`。`skip` 会把重叠
+运行记录为 skipped，不会排队；该策略作用于整个 scheduler，而不是单个 trigger。
+`scheduler.agent.async` 并行执行时总是使用新的 sandbox。
+
+## 调试
+
+使用稳定 trigger ID、`scheduler.log` 和以下命令：
+
+```bash
+agent-compose scheduler inspect <scheduler>
+agent-compose scheduler invoke <scheduler> --payload '{"source":"manual"}'
+agent-compose scheduler runs <scheduler>
+agent-compose scheduler logs <scheduler>
+```
+
+`clearInterval` 和 `clearTimeout` 只影响本次脚本求值期间注册的 trigger；若要持久
+禁用 trigger，应使用 UI 或 API。

--- a/tools/genpages/check-pages.mjs
+++ b/tools/genpages/check-pages.mjs
@@ -15,6 +15,9 @@ const manualNames = [
   "connect-transport-matrix.md",
   "guest-image-abi.md",
   "octobus-quickstart.md",
+  "developing-agents.md",
+  "scheduler-api.md",
+  "daemon-integration.md",
 ];
 const expectedOutput = new Set([
   "agent-compose-yaml-manual.html",
@@ -29,6 +32,12 @@ const expectedOutput = new Set([
   "zh-CN/connect-transport-matrix.html",
   "zh-CN/guest-image-abi.html",
   "zh-CN/octobus-quickstart.html",
+  "developing-agents.html",
+  "scheduler-api.html",
+  "daemon-integration.html",
+  "zh-CN/developing-agents.html",
+  "zh-CN/scheduler-api.html",
+  "zh-CN/daemon-integration.html",
 ]);
 
 await checkSourceLayout();

--- a/tools/genpages/check-pages.mjs
+++ b/tools/genpages/check-pages.mjs
@@ -174,6 +174,13 @@ async function checkNavigation() {
   if (homepage.includes("guest-image-abi")) {
     throw new Error("index.html must not link to Guest Image ABI");
   }
+  for (const nav of homepage.matchAll(/<nav\b[\s\S]*?<\/nav>/g)) {
+    for (const link of nav[0].matchAll(/<a\b([^>]*)>/g)) {
+      if (!/\bdata-zh="[^"]+"/.test(link[1]) || !/\bdata-en="[^"]+"/.test(link[1])) {
+        throw new Error("index.html contains a navigation link without both data-zh and data-en");
+      }
+    }
+  }
 }
 
 async function checkABILanguageSwitch() {

--- a/tools/genpages/check-pages.mjs
+++ b/tools/genpages/check-pages.mjs
@@ -18,6 +18,7 @@ const manualNames = [
   "developing-agents.md",
   "scheduler-api.md",
   "daemon-integration.md",
+  "runtime-sdk.md",
 ];
 const expectedOutput = new Set([
   "agent-compose-yaml-manual.html",
@@ -38,6 +39,8 @@ const expectedOutput = new Set([
   "zh-CN/developing-agents.html",
   "zh-CN/scheduler-api.html",
   "zh-CN/daemon-integration.html",
+  "runtime-sdk.html",
+  "zh-CN/runtime-sdk.html",
 ]);
 
 await checkSourceLayout();

--- a/tools/genpages/render-pages.mjs
+++ b/tools/genpages/render-pages.mjs
@@ -73,6 +73,13 @@ const manuals = [
     alternate: "zh-CN/daemon-integration.html",
   },
   {
+    source: "runtime-sdk.md",
+    output: "runtime-sdk.html",
+    title: "Guest Runtime SDK",
+    lang: "en",
+    alternate: "zh-CN/runtime-sdk.html",
+  },
+  {
     source: "zh-CN/command-line-manual.md",
     output: "zh-CN/command-line-manual.html",
     title: "命令行手册",
@@ -120,6 +127,13 @@ const manuals = [
     title: "Daemon 集成",
     lang: "zh-CN",
     alternate: "../daemon-integration.html",
+  },
+  {
+    source: "zh-CN/runtime-sdk.md",
+    output: "zh-CN/runtime-sdk.html",
+    title: "Guest Runtime SDK",
+    lang: "zh-CN",
+    alternate: "../runtime-sdk.html",
   },
 ];
 

--- a/tools/genpages/render-pages.mjs
+++ b/tools/genpages/render-pages.mjs
@@ -52,6 +52,27 @@ const manuals = [
     alternate: "zh-CN/guest-image-abi.html",
   },
   {
+    source: "developing-agents.md",
+    output: "developing-agents.html",
+    title: "Developing Agents",
+    lang: "en",
+    alternate: "zh-CN/developing-agents.html",
+  },
+  {
+    source: "scheduler-api.md",
+    output: "scheduler-api.html",
+    title: "Scheduler JavaScript API",
+    lang: "en",
+    alternate: "zh-CN/scheduler-api.html",
+  },
+  {
+    source: "daemon-integration.md",
+    output: "daemon-integration.html",
+    title: "Daemon Integration",
+    lang: "en",
+    alternate: "zh-CN/daemon-integration.html",
+  },
+  {
     source: "zh-CN/command-line-manual.md",
     output: "zh-CN/command-line-manual.html",
     title: "命令行手册",
@@ -78,6 +99,27 @@ const manuals = [
     title: "自定义 Guest Image ABI",
     lang: "zh-CN",
     alternate: "../guest-image-abi.html",
+  },
+  {
+    source: "zh-CN/developing-agents.md",
+    output: "zh-CN/developing-agents.html",
+    title: "Agent 开发手册",
+    lang: "zh-CN",
+    alternate: "../developing-agents.html",
+  },
+  {
+    source: "zh-CN/scheduler-api.md",
+    output: "zh-CN/scheduler-api.html",
+    title: "Scheduler JavaScript API",
+    lang: "zh-CN",
+    alternate: "../scheduler-api.html",
+  },
+  {
+    source: "zh-CN/daemon-integration.md",
+    output: "zh-CN/daemon-integration.html",
+    title: "Daemon 集成",
+    lang: "zh-CN",
+    alternate: "../daemon-integration.html",
   },
 ];
 


### PR DESCRIPTION
## 问题

`docs/pages/` 此前只有命令手册、YAML 手册、OctoBus quick start 等页面，
智能体开发、Runtime SDK、Scheduler JavaScript、Daemon/Connect RPC 集成这四块
在文档站上是缺失的：英文和中文都没有对应页面，顶部导航里也没有入口。

要写 agent、写 scheduler 脚本，或从外部接 daemon 的人，只能去读源码和分散的 README，
没有一个面向公开文档站的中英对照入口。

## 影响

新接入的开发者需要自行从源码推断 Runtime SDK 的 API 面、SSH 用法、Scheduler 脚本能力边界
和 daemon 的认证方式。这些恰好是最容易用错、且出错后表现为运行时行为异常的部分，
属于文档缺口导致的上手成本，不是代码缺陷。

## 修复内容

- 新增 4 篇开发者文档，英文与中文各一份：
  `developing-agents`、`runtime-sdk`、`scheduler-api`、`daemon-integration`。
- 在文档站顶部导航中为这 4 篇增加中英双语入口，并接入既有的语言切换机制。
- 明确区分三类边界：Guest Runtime SDK、Scheduler JavaScript、外部 Daemon Client。
- 覆盖认证、流式、取消、错误、兼容性和密钥处理，且不暴露任何凭据。
- 文档构建中保留双语页面与公开页面/链接检查。

## 验证

```text
$ task docs:build
✔ excludes temporary v1 migration fields from documentation coverage
Pages checks passed for 72 YAML schema fields and 20 public files
```

生成的 8 个页面（中英各 4 篇）全部落到实际文件：

```text
developing-agents.html         5707 bytes   zh-CN/developing-agents.html         5326 bytes
runtime-sdk.html               3812 bytes   zh-CN/runtime-sdk.html               3719 bytes
scheduler-api.html             4295 bytes   zh-CN/scheduler-api.html             4206 bytes
daemon-integration.html        4259 bytes   zh-CN/daemon-integration.html        3900 bytes
```

导航链接可达性检查：导航中 7 条带 `data-href-zh`/`data-href-en` 的条目，
除 1 条指向 GitHub README 的外链外，其余目标文件全部存在。

文档描述与代码实际导出面逐项比对（`runtime/agent-compose-runtime-sdk/src/index.ts`）：

```text
文档列出：exec, shell, agent, llm, workflow, workflowFile, env, paths, log, report, ssh
代码导出：exec, shell, agent, llm, env, paths, log, report, ssh, workflow, workflowFile
结果：完全一致
```

中英文页面结构一致性（按标题层级数量比对）：

```text
developing-agents.md     EN=6  ZH=6
runtime-sdk.md           EN=5  ZH=5
scheduler-api.md         EN=5  ZH=5
daemon-integration.md    EN=5  ZH=5
```

`git diff --check` 无输出。

说明：Runtime SDK 示例按文档描述安装发布包后在 sandbox guest 内运行，本次验证做到的是
"文档与 SDK 实际导出面逐项比对 + 文档构建/导航链接检查 + 中英结构一致性"，
未在真实 sandbox 内执行该示例。proto 参考文档沿用仓库既有的 descriptor/transport
生成机制，本 PR 不重复生成。

Closes #554
