### PR TITLE
test(cli): enforce public command and output contracts

### DIFF
--- a/cmd/agent-compose/cli_contract_test.go
+++ b/cmd/agent-compose/cli_contract_test.go
@@ -25,9 +25,10 @@ type cliContract struct {
 }
 
 type cliCommandContract struct {
-	Path  string            `json:"path"`
-	Use   string            `json:"use"`
-	Flags []cliFlagContract `json:"flags,omitempty"`
+	Path    string            `json:"path"`
+	Use     string            `json:"use"`
+	Aliases []string          `json:"aliases,omitempty"`
+	Flags   []cliFlagContract `json:"flags,omitempty"`
 }
 
 type cliFlagContract struct {
@@ -111,14 +112,18 @@ func collectCLICommandContracts(root *cobra.Command) []cliCommandContract {
 		}
 		if path != root.Name() {
 			var flags []cliFlagContract
-			cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+			visitFlag := func(flag *pflag.Flag) {
 				flags = append(flags, cliFlagContract{Name: flag.Name, Shorthand: flag.Shorthand, Type: flag.Value.Type(), Default: flag.DefValue, Optional: flag.NoOptDefVal, Hidden: flag.Hidden})
-			})
+			}
+			cmd.InheritedFlags().VisitAll(visitFlag)
+			cmd.PersistentFlags().VisitAll(visitFlag)
 			cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
 				flags = append(flags, cliFlagContract{Name: flag.Name, Shorthand: flag.Shorthand, Type: flag.Value.Type(), Default: flag.DefValue, Optional: flag.NoOptDefVal, Hidden: flag.Hidden})
 			})
 			sort.Slice(flags, func(i, j int) bool { return flags[i].Name < flags[j].Name })
-			out = append(out, cliCommandContract{Path: path, Use: cmd.Use, Flags: flags})
+			aliases := append([]string(nil), cmd.Aliases...)
+			sort.Strings(aliases)
+			out = append(out, cliCommandContract{Path: path, Use: cmd.Use, Aliases: aliases, Flags: flags})
 		}
 		children := append([]*cobra.Command(nil), cmd.Commands()...)
 		sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })
@@ -177,6 +182,9 @@ func jsonStructFields(value any) map[string]string {
 }
 
 func jsonTypeName(typ reflect.Type) string {
+	if typ == nil {
+		return "null"
+	}
 	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
@@ -196,6 +204,37 @@ func jsonTypeName(typ reflect.Type) string {
 	default:
 		return typ.Kind().String()
 	}
+}
+
+func TestCLIContractCapturesAliasesAndPersistentFlags(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("global", "", "")
+	child := &cobra.Command{Use: "child", Aliases: []string{"c", "kid"}}
+	child.PersistentFlags().Bool("child-global", false, "")
+	root.AddCommand(child)
+
+	contracts := collectCLICommandContracts(root)
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, want 1", len(contracts))
+	}
+	got := contracts[0]
+	if !reflect.DeepEqual(got.Aliases, []string{"c", "kid"}) {
+		t.Fatalf("aliases = %v, want [c kid]", got.Aliases)
+	}
+	names := make(map[string]bool)
+	for _, flag := range got.Flags {
+		names[flag.Name] = true
+	}
+	if !names["global"] || !names["child-global"] {
+		t.Fatalf("persistent flags = %v, want global and child-global", names)
+	}
+}
+
+func TestJSONTypeNameHandlesNull(t *testing.T) {
+	if got := jsonTypeName(nil); got != "null" {
+		t.Fatalf("jsonTypeName(nil) = %q, want null", got)
+	}
+	assertJSONFields(t, map[string]any{"nullable": nil}, map[string]string{"nullable": "null"})
 }
 
 func assertJSONFields(t *testing.T, value map[string]any, schema map[string]string) {

--- a/cmd/agent-compose/cli_contract_test.go
+++ b/cmd/agent-compose/cli_contract_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// cliContract is deliberately limited to values that are part of the public
+// CLI surface. Help text is intentionally not snapshotted: wording can change
+// without breaking scripts, while command names, flags, defaults and aliases
+// cannot.
+type cliContract struct {
+	Commands []cliCommandContract `json:"commands"`
+	ExitCode map[string]int       `json:"exit_codes"`
+	JSON     map[string][]string  `json:"json_fields"`
+}
+
+type cliCommandContract struct {
+	Path    string   `json:"path"`
+	Aliases []string `json:"aliases,omitempty"`
+	Flags   []string `json:"flags,omitempty"`
+}
+
+func TestPublicCLIContractSnapshot(t *testing.T) {
+	root := newRootCommand(nil, nil, func(context.Context) error { return nil })
+	got := cliContract{
+		Commands: collectCLICommandContracts(root),
+		ExitCode: map[string]int{
+			"success":     0,
+			"general":     exitCodeGeneral,
+			"usage":       exitCodeUsage,
+			"unavailable": exitCodeUnavailable,
+			"unsupported": exitCodeUnsupported,
+		},
+		JSON: map[string][]string{
+			"version --json": {"version", "os", "arch", "compiled_drivers"},
+		},
+	}
+	path := filepath.Join("testdata", "cli-contract.json")
+	if os.Getenv("UPDATE_CLI_CONTRACT") == "1" {
+		data, err := json.MarshalIndent(got, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wantData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read CLI contract snapshot %s: %v (run UPDATE_CLI_CONTRACT=1 to update intentionally)", path, err)
+	}
+	var want cliContract
+	if err := json.Unmarshal(wantData, &want); err != nil {
+		t.Fatalf("decode CLI contract snapshot: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("public CLI contract changed\n got: %s\nwant: %s\nIf intentional, review and run UPDATE_CLI_CONTRACT=1", contractJSON(got), string(wantData))
+	}
+}
+
+func collectCLICommandContracts(root *cobra.Command) []cliCommandContract {
+	var out []cliCommandContract
+	var visit func(*cobra.Command, string)
+	visit = func(cmd *cobra.Command, parent string) {
+		path := cmd.Name()
+		if parent != "" {
+			path = parent + " " + path
+		}
+		if path != root.Name() {
+			var flags []string
+			cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+				flags = append(flags, flag.Name+"="+flag.DefValue)
+			})
+			sort.Strings(flags)
+			aliases := append([]string(nil), cmd.Aliases...)
+			sort.Strings(aliases)
+			out = append(out, cliCommandContract{Path: path, Aliases: aliases, Flags: flags})
+		}
+		children := append([]*cobra.Command(nil), cmd.Commands()...)
+		sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })
+		for _, child := range children {
+			visit(child, path)
+		}
+	}
+	visit(root, "")
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+func contractJSON(value any) string {
+	data, _ := json.MarshalIndent(value, "", "  ")
+	return string(data)
+}

--- a/cmd/agent-compose/cli_contract_test.go
+++ b/cmd/agent-compose/cli_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -18,15 +19,24 @@ import (
 // without breaking scripts, while command names, flags, defaults and aliases
 // cannot.
 type cliContract struct {
-	Commands []cliCommandContract `json:"commands"`
-	ExitCode map[string]int       `json:"exit_codes"`
-	JSON     map[string][]string  `json:"json_fields"`
+	Commands []cliCommandContract         `json:"commands"`
+	ExitCode map[string]int               `json:"exit_codes"`
+	JSON     map[string]map[string]string `json:"json_fields"`
 }
 
 type cliCommandContract struct {
-	Path    string   `json:"path"`
-	Aliases []string `json:"aliases,omitempty"`
-	Flags   []string `json:"flags,omitempty"`
+	Path  string            `json:"path"`
+	Use   string            `json:"use"`
+	Flags []cliFlagContract `json:"flags,omitempty"`
+}
+
+type cliFlagContract struct {
+	Name      string `json:"name"`
+	Shorthand string `json:"shorthand,omitempty"`
+	Type      string `json:"type"`
+	Default   string `json:"default"`
+	Optional  string `json:"optional,omitempty"`
+	Hidden    bool   `json:"hidden,omitempty"`
 }
 
 func TestPublicCLIContractSnapshot(t *testing.T) {
@@ -40,9 +50,7 @@ func TestPublicCLIContractSnapshot(t *testing.T) {
 			"unavailable": exitCodeUnavailable,
 			"unsupported": exitCodeUnsupported,
 		},
-		JSON: map[string][]string{
-			"version --json": {"version", "os", "arch", "compiled_drivers"},
-		},
+		JSON: collectCLIJSONContracts(),
 	}
 	path := filepath.Join("testdata", "cli-contract.json")
 	if os.Getenv("UPDATE_CLI_CONTRACT") == "1" {
@@ -65,6 +73,32 @@ func TestPublicCLIContractSnapshot(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("public CLI contract changed\n got: %s\nwant: %s\nIf intentional, review and run UPDATE_CLI_CONTRACT=1", contractJSON(got), string(wantData))
 	}
+	stdout, stderr, _, code := executeCLICommand("--json", "version")
+	if code != 0 || stderr != "" {
+		t.Fatalf("version --json behavior = code %d stderr %q", code, stderr)
+	}
+	var version map[string]any
+	if err := json.Unmarshal([]byte(stdout), &version); err != nil {
+		t.Fatalf("version --json is invalid JSON: %v", err)
+	}
+	assertJSONFields(t, version, got.JSON["build_info"])
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"success", []string{"version"}, 0},
+		{"unknown flag", []string{"--contract-unknown"}, exitCodeUsage},
+		{"invalid global value", []string{"--timeout", "-1s", "version"}, exitCodeUsage},
+	} {
+		t.Run("exit/"+tc.name, func(t *testing.T) {
+			_, _, _, gotCode := executeCLICommand(tc.args...)
+			if gotCode != tc.want {
+				t.Fatalf("exit code = %d, want %d", gotCode, tc.want)
+			}
+		})
+	}
 }
 
 func collectCLICommandContracts(root *cobra.Command) []cliCommandContract {
@@ -76,14 +110,15 @@ func collectCLICommandContracts(root *cobra.Command) []cliCommandContract {
 			path = parent + " " + path
 		}
 		if path != root.Name() {
-			var flags []string
-			cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
-				flags = append(flags, flag.Name+"="+flag.DefValue)
+			var flags []cliFlagContract
+			cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+				flags = append(flags, cliFlagContract{Name: flag.Name, Shorthand: flag.Shorthand, Type: flag.Value.Type(), Default: flag.DefValue, Optional: flag.NoOptDefVal, Hidden: flag.Hidden})
 			})
-			sort.Strings(flags)
-			aliases := append([]string(nil), cmd.Aliases...)
-			sort.Strings(aliases)
-			out = append(out, cliCommandContract{Path: path, Aliases: aliases, Flags: flags})
+			cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+				flags = append(flags, cliFlagContract{Name: flag.Name, Shorthand: flag.Shorthand, Type: flag.Value.Type(), Default: flag.DefValue, Optional: flag.NoOptDefVal, Hidden: flag.Hidden})
+			})
+			sort.Slice(flags, func(i, j int) bool { return flags[i].Name < flags[j].Name })
+			out = append(out, cliCommandContract{Path: path, Use: cmd.Use, Flags: flags})
 		}
 		children := append([]*cobra.Command(nil), cmd.Commands()...)
 		sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })
@@ -94,6 +129,89 @@ func collectCLICommandContracts(root *cobra.Command) []cliCommandContract {
 	visit(root, "")
 	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
 	return out
+}
+
+func collectCLIJSONContracts() map[string]map[string]string {
+	values := map[string]any{
+		"build_info": buildInfo{}, "agent_list": composeAgentListOutput{},
+		"cache_list": composeCacheListOutput{}, "cache_inspect": composeCacheInspectOutput{},
+		"cache_operation": composeCacheOperationOutput{}, "exec": composeExecOutput{},
+		"image_list": composeImageListOutput{}, "image_inspect": composeImageInspectOutput{},
+		"image_pull": composeImagePullOutput{}, "image_build": composeImageBuildOutput{},
+		"image_remove": composeImageRemoveOutput{}, "run_jupyter": composeRunJupyterOutput{},
+		"logs": composeLogsOutput{}, "ps": composePSOutput{}, "up": composeUpOutput{},
+		"down": composeDownOutput{}, "project_list": composeProjectListOutput{},
+		"project": composeProjectOutput{}, "agent_inspect": composeAgentInspectOutput{},
+		"scheduler_prune": composeSchedulerPruneOutput{}, "run": composeRunOutput{},
+		"sandbox_list": composePSSandboxOutput{}, "sandbox_prune": composeSandboxPruneOutput{},
+		"sandbox_logs": composeSandboxLogsOutput{}, "sandbox_action": composeSandboxActionOutput{},
+		"sandbox": composeSandboxOutput{}, "stats": composeStatsOutput{},
+		"project_stats": composeProjectStatsOutput{}, "scheduler_list": composeSchedulerListOutput{},
+		"scheduler_inspect": composeSchedulerInspectOutput{}, "scheduler_runs": composeSchedulerRunsOutput{},
+		"scheduler_logs": composeSchedulerLogsOutput{}, "volume_list": composeVolumeListOutput{},
+		"volume_inspect": composeVolumeInspectOutput{}, "volume_create": composeVolumeCreateOutput{},
+		"volume_remove": composeVolumeRemoveOutput{}, "volume_prune": composeVolumePruneOutput{},
+	}
+	out := make(map[string]map[string]string, len(values))
+	for name, value := range values {
+		out[name] = jsonStructFields(value)
+	}
+	return out
+}
+
+func jsonStructFields(value any) map[string]string {
+	typ := reflect.TypeOf(value)
+	fields := make(map[string]string)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		tag := strings.Split(field.Tag.Get("json"), ",")[0]
+		if tag == "-" {
+			continue
+		}
+		if tag == "" {
+			tag = field.Name
+		}
+		fields[tag] = jsonTypeName(field.Type)
+	}
+	return fields
+}
+
+func jsonTypeName(typ reflect.Type) string {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	switch typ.Kind() {
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.String:
+		return "string"
+	case reflect.Slice, reflect.Array:
+		return "array"
+	case reflect.Map, reflect.Struct, reflect.Interface:
+		return "object"
+	default:
+		return typ.Kind().String()
+	}
+}
+
+func assertJSONFields(t *testing.T, value map[string]any, schema map[string]string) {
+	t.Helper()
+	if len(value) != len(schema) {
+		t.Fatalf("JSON fields = %v, want %v", value, schema)
+	}
+	for name, wantType := range schema {
+		raw, ok := value[name]
+		if !ok {
+			t.Fatalf("JSON missing field %q", name)
+		}
+		if got := jsonTypeName(reflect.TypeOf(raw)); got != wantType {
+			t.Fatalf("JSON field %q type = %s, want %s", name, got, wantType)
+		}
+	}
 }
 
 func contractJSON(value any) string {

--- a/cmd/agent-compose/testdata/cli-contract.json
+++ b/cmd/agent-compose/testdata/cli-contract.json
@@ -2743,6 +2743,9 @@
     {
       "path": "agent-compose volume rm",
       "use": "rm \u003cname\u003e [\u003cname N\u003e]",
+      "aliases": [
+        "remove"
+      ],
       "flags": [
         {
           "name": "file",

--- a/cmd/agent-compose/testdata/cli-contract.json
+++ b/cmd/agent-compose/testdata/cli-contract.json
@@ -1,0 +1,401 @@
+{
+  "commands": [
+    {
+      "path": "agent-compose agent"
+    },
+    {
+      "path": "agent-compose agent ls"
+    },
+    {
+      "path": "agent-compose auth"
+    },
+    {
+      "path": "agent-compose auth login",
+      "flags": [
+        "token="
+      ]
+    },
+    {
+      "path": "agent-compose auth logout"
+    },
+    {
+      "path": "agent-compose auth ls"
+    },
+    {
+      "path": "agent-compose build",
+      "flags": [
+        "build-arg=[]",
+        "dockerfile=",
+        "no-cache=false",
+        "platform=",
+        "pull=false",
+        "tag=[]",
+        "target="
+      ]
+    },
+    {
+      "path": "agent-compose cache"
+    },
+    {
+      "path": "agent-compose cache inspect"
+    },
+    {
+      "path": "agent-compose cache ls",
+      "flags": [
+        "driver=",
+        "status=",
+        "type="
+      ]
+    },
+    {
+      "path": "agent-compose cache prune",
+      "flags": [
+        "driver=",
+        "expired=false",
+        "force=false",
+        "older-than=",
+        "orphaned=false",
+        "status=",
+        "type=",
+        "unused=false"
+      ]
+    },
+    {
+      "path": "agent-compose cache rm",
+      "flags": [
+        "force=false"
+      ]
+    },
+    {
+      "path": "agent-compose config",
+      "flags": [
+        "quiet=false"
+      ]
+    },
+    {
+      "path": "agent-compose daemon"
+    },
+    {
+      "path": "agent-compose down"
+    },
+    {
+      "path": "agent-compose exec",
+      "flags": [
+        "command=",
+        "cwd=",
+        "interactive=false",
+        "prompt=",
+        "run=",
+        "tty=false"
+      ]
+    },
+    {
+      "path": "agent-compose image"
+    },
+    {
+      "path": "agent-compose image build",
+      "flags": [
+        "build-arg=[]",
+        "dockerfile=",
+        "no-cache=false",
+        "platform=",
+        "pull=false",
+        "tag=[]",
+        "target="
+      ]
+    },
+    {
+      "path": "agent-compose image inspect"
+    },
+    {
+      "path": "agent-compose image ls",
+      "flags": [
+        "all=false",
+        "query=",
+        "verbose=false"
+      ]
+    },
+    {
+      "path": "agent-compose image pull",
+      "flags": [
+        "platform="
+      ]
+    },
+    {
+      "path": "agent-compose image rm",
+      "flags": [
+        "force=false",
+        "prune-children=false"
+      ]
+    },
+    {
+      "path": "agent-compose images",
+      "flags": [
+        "all=false",
+        "query=",
+        "verbose=false"
+      ]
+    },
+    {
+      "path": "agent-compose inspect"
+    },
+    {
+      "path": "agent-compose logs",
+      "flags": [
+        "agent=",
+        "follow=false",
+        "run=",
+        "sandbox=",
+        "tail=-1",
+        "timestamp=false"
+      ]
+    },
+    {
+      "path": "agent-compose ls"
+    },
+    {
+      "path": "agent-compose project"
+    },
+    {
+      "path": "agent-compose project down"
+    },
+    {
+      "path": "agent-compose project ls",
+      "flags": [
+        "limit=0",
+        "offset=0",
+        "verbose=false"
+      ]
+    },
+    {
+      "path": "agent-compose project up"
+    },
+    {
+      "path": "agent-compose ps",
+      "flags": [
+        "all=false",
+        "label=[]",
+        "status=",
+        "verbose=false"
+      ]
+    },
+    {
+      "path": "agent-compose pull",
+      "flags": [
+        "platform="
+      ]
+    },
+    {
+      "path": "agent-compose resume"
+    },
+    {
+      "path": "agent-compose rm",
+      "flags": [
+        "force=false"
+      ]
+    },
+    {
+      "path": "agent-compose rmi",
+      "flags": [
+        "force=false",
+        "prune-children=false"
+      ]
+    },
+    {
+      "path": "agent-compose run",
+      "flags": [
+        "command=",
+        "detach=false",
+        "driver=",
+        "interactive=false",
+        "jupyter-expose=false",
+        "jupyter=false",
+        "keep-running=false",
+        "label=[]",
+        "prompt=",
+        "rm=false",
+        "sandbox=",
+        "tty=false"
+      ]
+    },
+    {
+      "path": "agent-compose sandbox"
+    },
+    {
+      "path": "agent-compose sandbox ls",
+      "flags": [
+        "all=false",
+        "label=[]",
+        "status=",
+        "verbose=false"
+      ]
+    },
+    {
+      "path": "agent-compose sandbox prune",
+      "flags": [
+        "agent=",
+        "driver=",
+        "force=false",
+        "include-orphans=false",
+        "older-than=",
+        "status="
+      ]
+    },
+    {
+      "path": "agent-compose sandbox resume"
+    },
+    {
+      "path": "agent-compose sandbox rm",
+      "flags": [
+        "force=false"
+      ]
+    },
+    {
+      "path": "agent-compose sandbox stop",
+      "flags": [
+        "force=false",
+        "grace-period=0s",
+        "graceful=false"
+      ]
+    },
+    {
+      "path": "agent-compose scheduler"
+    },
+    {
+      "path": "agent-compose scheduler inspect",
+      "flags": [
+        "scheduler="
+      ]
+    },
+    {
+      "path": "agent-compose scheduler invoke",
+      "flags": [
+        "payload="
+      ]
+    },
+    {
+      "path": "agent-compose scheduler logs",
+      "flags": [
+        "agent=",
+        "run=",
+        "scheduler=",
+        "tail=-1",
+        "trigger="
+      ]
+    },
+    {
+      "path": "agent-compose scheduler ls",
+      "flags": [
+        "verbose=false"
+      ]
+    },
+    {
+      "path": "agent-compose scheduler prune",
+      "flags": [
+        "force=false",
+        "older-than=",
+        "scheduler=",
+        "status=",
+        "trigger="
+      ]
+    },
+    {
+      "path": "agent-compose scheduler runs",
+      "flags": [
+        "agent=",
+        "limit=0",
+        "status=",
+        "trigger="
+      ]
+    },
+    {
+      "path": "agent-compose scheduler stop",
+      "flags": [
+        "reason="
+      ]
+    },
+    {
+      "path": "agent-compose scheduler trigger",
+      "flags": [
+        "detach=false",
+        "payload="
+      ]
+    },
+    {
+      "path": "agent-compose stats"
+    },
+    {
+      "path": "agent-compose status"
+    },
+    {
+      "path": "agent-compose stop",
+      "flags": [
+        "force=false",
+        "grace-period=0s",
+        "graceful=false"
+      ]
+    },
+    {
+      "path": "agent-compose up"
+    },
+    {
+      "path": "agent-compose version"
+    },
+    {
+      "path": "agent-compose volume"
+    },
+    {
+      "path": "agent-compose volume create",
+      "flags": [
+        "driver=local",
+        "label=[]",
+        "opt=[]"
+      ]
+    },
+    {
+      "path": "agent-compose volume inspect"
+    },
+    {
+      "path": "agent-compose volume ls",
+      "flags": [
+        "driver=",
+        "project-id=",
+        "query=",
+        "verbose=false"
+      ]
+    },
+    {
+      "path": "agent-compose volume prune",
+      "flags": [
+        "driver=",
+        "force=false",
+        "project-id=",
+        "query="
+      ]
+    },
+    {
+      "path": "agent-compose volume rm",
+      "aliases": [
+        "remove"
+      ],
+      "flags": [
+        "force=false"
+      ]
+    }
+  ],
+  "exit_codes": {
+    "general": 1,
+    "success": 0,
+    "unavailable": 3,
+    "unsupported": 4,
+    "usage": 2
+  },
+  "json_fields": {
+    "version --json": [
+      "version",
+      "os",
+      "arch",
+      "compiled_drivers"
+    ]
+  }
+}

--- a/cmd/agent-compose/testdata/cli-contract.json
+++ b/cmd/agent-compose/testdata/cli-contract.json
@@ -1,385 +1,2783 @@
 {
   "commands": [
     {
-      "path": "agent-compose agent"
+      "path": "agent-compose agent",
+      "use": "agent",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose agent ls"
+      "path": "agent-compose agent ls",
+      "use": "ls",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose auth"
+      "path": "agent-compose auth",
+      "use": "auth",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose auth login",
+      "use": "login",
       "flags": [
-        "token="
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "token",
+          "type": "string",
+          "default": ""
+        }
       ]
     },
     {
-      "path": "agent-compose auth logout"
+      "path": "agent-compose auth logout",
+      "use": "logout",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose auth ls"
+      "path": "agent-compose auth ls",
+      "use": "ls",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose build",
+      "use": "build [agent...]",
       "flags": [
-        "build-arg=[]",
-        "dockerfile=",
-        "no-cache=false",
-        "platform=",
-        "pull=false",
-        "tag=[]",
-        "target="
+        {
+          "name": "build-arg",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "dockerfile",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "no-cache",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "platform",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "pull",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "tag",
+          "shorthand": "t",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose cache"
+      "path": "agent-compose cache",
+      "use": "cache",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose cache inspect"
+      "path": "agent-compose cache inspect",
+      "use": "inspect \u003ccache-id\u003e",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose cache ls",
+      "use": "ls",
       "flags": [
-        "driver=",
-        "status=",
-        "type="
+        {
+          "name": "driver",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "default": ""
+        }
       ]
     },
     {
       "path": "agent-compose cache prune",
+      "use": "prune",
       "flags": [
-        "driver=",
-        "expired=false",
-        "force=false",
-        "older-than=",
-        "orphaned=false",
-        "status=",
-        "type=",
-        "unused=false"
+        {
+          "name": "driver",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "expired",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "older-than",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "orphaned",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "unused",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
       "path": "agent-compose cache rm",
+      "use": "rm \u003ccache-id\u003e",
       "flags": [
-        "force=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose config",
+      "use": "config",
       "flags": [
-        "quiet=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "quiet",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose daemon"
+      "path": "agent-compose daemon",
+      "use": "daemon",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose down"
+      "path": "agent-compose down",
+      "use": "down",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose exec",
+      "use": "exec \u003csandbox\u003e (--command \u003cshell-command\u003e | --prompt \u003cprompt\u003e | -- \u003ccommand\u003e [args...])",
       "flags": [
-        "command=",
-        "cwd=",
-        "interactive=false",
-        "prompt=",
-        "run=",
-        "tty=false"
+        {
+          "name": "command",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "cwd",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "interactive",
+          "shorthand": "i",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "prompt",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "run",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "tty",
+          "shorthand": "t",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
-      "path": "agent-compose image"
+      "path": "agent-compose image",
+      "use": "image",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose image build",
+      "use": "build [agent...]",
       "flags": [
-        "build-arg=[]",
-        "dockerfile=",
-        "no-cache=false",
-        "platform=",
-        "pull=false",
-        "tag=[]",
-        "target="
+        {
+          "name": "build-arg",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "dockerfile",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "no-cache",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "platform",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "pull",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "tag",
+          "shorthand": "t",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose image inspect"
+      "path": "agent-compose image inspect",
+      "use": "inspect \u003cimage\u003e",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose image ls",
+      "use": "ls",
       "flags": [
-        "all=false",
-        "query=",
-        "verbose=false"
+        {
+          "name": "all",
+          "shorthand": "a",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "verbose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
       "path": "agent-compose image pull",
+      "use": "pull [image]",
       "flags": [
-        "platform="
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "platform",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose image rm",
+      "use": "rm \u003cimage\u003e",
       "flags": [
-        "force=false",
-        "prune-children=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "prune-children",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose images",
+      "use": "images",
       "flags": [
-        "all=false",
-        "query=",
-        "verbose=false"
+        {
+          "name": "all",
+          "shorthand": "a",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "verbose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
-      "path": "agent-compose inspect"
+      "path": "agent-compose inspect",
+      "use": "inspect \u003cid\u003e|\u003cproject|agent|run|sandbox|image|cache|volume\u003e [name-or-id]",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose logs",
+      "use": "logs [agent-or-id]",
       "flags": [
-        "agent=",
-        "follow=false",
-        "run=",
-        "sandbox=",
-        "tail=-1",
-        "timestamp=false"
+        {
+          "name": "agent",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "follow",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "run",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "sandbox",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "tail",
+          "shorthand": "n",
+          "type": "int",
+          "default": "-1"
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "timestamp",
+          "shorthand": "t",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
-      "path": "agent-compose ls"
+      "path": "agent-compose ls",
+      "use": "ls",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose project"
+      "path": "agent-compose project",
+      "use": "project",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose project down"
+      "path": "agent-compose project down",
+      "use": "down",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose project ls",
+      "use": "ls",
       "flags": [
-        "limit=0",
-        "offset=0",
-        "verbose=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "limit",
+          "type": "uint32",
+          "default": "0"
+        },
+        {
+          "name": "offset",
+          "type": "uint32",
+          "default": "0"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "verbose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
-      "path": "agent-compose project up"
+      "path": "agent-compose project up",
+      "use": "up",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose ps",
+      "use": "ps",
       "flags": [
-        "all=false",
-        "label=[]",
-        "status=",
-        "verbose=false"
+        {
+          "name": "all",
+          "shorthand": "a",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "label",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "verbose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
       "path": "agent-compose pull",
+      "use": "pull [image]",
       "flags": [
-        "platform="
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "platform",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose resume"
+      "path": "agent-compose resume",
+      "use": "resume \u003csandbox\u003e [\u003csandbox N\u003e]",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose rm",
+      "use": "rm \u003csandbox\u003e [\u003csandbox N\u003e]",
       "flags": [
-        "force=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose rmi",
+      "use": "rmi \u003cimage\u003e",
       "flags": [
-        "force=false",
-        "prune-children=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "prune-children",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose run",
+      "use": "run \u003cagent\u003e",
       "flags": [
-        "command=",
-        "detach=false",
-        "driver=",
-        "interactive=false",
-        "jupyter-expose=false",
-        "jupyter=false",
-        "keep-running=false",
-        "label=[]",
-        "prompt=",
-        "rm=false",
-        "sandbox=",
-        "tty=false"
+        {
+          "name": "command",
+          "type": "string",
+          "default": "",
+          "optional": "\u0000agent-compose-run-mode"
+        },
+        {
+          "name": "detach",
+          "shorthand": "d",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "driver",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "interactive",
+          "shorthand": "i",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "jupyter",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "jupyter-expose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "keep-running",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "label",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "prompt",
+          "type": "string",
+          "default": "",
+          "optional": "\u0000agent-compose-run-mode"
+        },
+        {
+          "name": "rm",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "sandbox",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "tty",
+          "shorthand": "t",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
-      "path": "agent-compose sandbox"
+      "path": "agent-compose sandbox",
+      "use": "sandbox",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose sandbox ls",
+      "use": "ls",
       "flags": [
-        "all=false",
-        "label=[]",
-        "status=",
-        "verbose=false"
+        {
+          "name": "all",
+          "shorthand": "a",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "label",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "verbose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
       "path": "agent-compose sandbox prune",
+      "use": "prune",
       "flags": [
-        "agent=",
-        "driver=",
-        "force=false",
-        "include-orphans=false",
-        "older-than=",
-        "status="
+        {
+          "name": "agent",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "driver",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "include-orphans",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "older-than",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose sandbox resume"
+      "path": "agent-compose sandbox resume",
+      "use": "resume \u003csandbox\u003e [\u003csandbox N\u003e]",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose sandbox rm",
+      "use": "rm \u003csandbox\u003e [\u003csandbox N\u003e]",
       "flags": [
-        "force=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose sandbox stop",
+      "use": "stop \u003csandbox\u003e [\u003csandbox N\u003e]",
       "flags": [
-        "force=false",
-        "grace-period=0s",
-        "graceful=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "grace-period",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "graceful",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose scheduler"
+      "path": "agent-compose scheduler",
+      "use": "scheduler",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose scheduler inspect",
+      "use": "inspect \u003cscheduler-or-trigger-or-run-ref\u003e",
       "flags": [
-        "scheduler="
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "scheduler",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose scheduler invoke",
+      "use": "invoke \u003cscheduler-ref\u003e",
       "flags": [
-        "payload="
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "payload",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose scheduler logs",
+      "use": "logs [run-ref]",
       "flags": [
-        "agent=",
-        "run=",
-        "scheduler=",
-        "tail=-1",
-        "trigger="
+        {
+          "name": "agent",
+          "type": "string",
+          "default": "",
+          "hidden": true
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "run",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "scheduler",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "tail",
+          "shorthand": "n",
+          "type": "int",
+          "default": "-1"
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "default": ""
+        }
       ]
     },
     {
       "path": "agent-compose scheduler ls",
+      "use": "ls [agent]",
       "flags": [
-        "verbose=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "verbose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
       "path": "agent-compose scheduler prune",
+      "use": "prune",
       "flags": [
-        "force=false",
-        "older-than=",
-        "scheduler=",
-        "status=",
-        "trigger="
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "older-than",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "scheduler",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "default": ""
+        }
       ]
     },
     {
       "path": "agent-compose scheduler runs",
+      "use": "runs [scheduler-ref]",
       "flags": [
-        "agent=",
-        "limit=0",
-        "status=",
-        "trigger="
+        {
+          "name": "agent",
+          "type": "string",
+          "default": "",
+          "hidden": true
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "limit",
+          "type": "uint32",
+          "default": "0"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "default": ""
+        }
       ]
     },
     {
       "path": "agent-compose scheduler stop",
+      "use": "stop \u003crun\u003e",
       "flags": [
-        "reason="
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose scheduler trigger",
+      "use": "trigger \u003cscheduler-ref\u003e \u003ctrigger-ref\u003e",
       "flags": [
-        "detach=false",
-        "payload="
+        {
+          "name": "detach",
+          "shorthand": "d",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "payload",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose stats"
+      "path": "agent-compose stats",
+      "use": "stats [sandbox]",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose status"
+      "path": "agent-compose status",
+      "use": "status",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose stop",
+      "use": "stop \u003csandbox\u003e [\u003csandbox N\u003e]",
       "flags": [
-        "force=false",
-        "grace-period=0s",
-        "graceful=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "grace-period",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "graceful",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose up"
+      "path": "agent-compose up",
+      "use": "up",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose version"
+      "path": "agent-compose version",
+      "use": "version",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
-      "path": "agent-compose volume"
+      "path": "agent-compose volume",
+      "use": "volume",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose volume create",
+      "use": "create \u003cname\u003e",
       "flags": [
-        "driver=local",
-        "label=[]",
-        "opt=[]"
+        {
+          "name": "driver",
+          "type": "string",
+          "default": "local"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "label",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "opt",
+          "type": "stringArray",
+          "default": "[]"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
-      "path": "agent-compose volume inspect"
+      "path": "agent-compose volume inspect",
+      "use": "inspect \u003cname\u003e",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
     },
     {
       "path": "agent-compose volume ls",
+      "use": "ls",
       "flags": [
-        "driver=",
-        "project-id=",
-        "query=",
-        "verbose=false"
+        {
+          "name": "driver",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-id",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        },
+        {
+          "name": "verbose",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        }
       ]
     },
     {
       "path": "agent-compose volume prune",
+      "use": "prune",
       "flags": [
-        "driver=",
-        "force=false",
-        "project-id=",
-        "query="
+        {
+          "name": "driver",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-id",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     },
     {
       "path": "agent-compose volume rm",
-      "aliases": [
-        "remove"
-      ],
+      "use": "rm \u003cname\u003e [\u003cname N\u003e]",
       "flags": [
-        "force=false"
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "force",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
       ]
     }
   ],
@@ -391,11 +2789,274 @@
     "usage": 2
   },
   "json_fields": {
-    "version --json": [
-      "version",
-      "os",
-      "arch",
-      "compiled_drivers"
-    ]
+    "agent_inspect": {
+      "agent": "object",
+      "latest_run": "object",
+      "project": "object",
+      "running_sandboxes": "array",
+      "schedulers": "array"
+    },
+    "agent_list": {
+      "agents": "array",
+      "project": "object"
+    },
+    "build_info": {
+      "arch": "string",
+      "compiled_drivers": "array",
+      "os": "string",
+      "version": "string"
+    },
+    "cache_inspect": {
+      "cache": "object",
+      "warnings": "array"
+    },
+    "cache_list": {
+      "caches": "array",
+      "total": "number",
+      "warnings": "array"
+    },
+    "cache_operation": {
+      "dry_run": "boolean",
+      "matched": "array",
+      "removed": "array",
+      "skipped": "array",
+      "warnings": "array"
+    },
+    "down": {
+      "changes": "array",
+      "failed_sandbox_stops": "number",
+      "project": "object",
+      "status": "string"
+    },
+    "exec": {
+      "args": "array",
+      "command": "string",
+      "cwd": "string",
+      "error": "string",
+      "exec_id": "string",
+      "exit_code": "number",
+      "output": "string",
+      "run_id": "string",
+      "sandbox_id": "string",
+      "stderr": "string",
+      "stdout": "string",
+      "success": "boolean"
+    },
+    "image_build": {
+      "image": "object",
+      "image_ref": "string",
+      "resolved_ref": "string",
+      "status": "string",
+      "warnings": "array"
+    },
+    "image_inspect": {
+      "image": "object",
+      "store_status": "object"
+    },
+    "image_list": {
+      "images": "array",
+      "store_status": "object",
+      "total": "number"
+    },
+    "image_pull": {
+      "image": "object",
+      "image_ref": "string",
+      "progress": "array",
+      "resolved_ref": "string",
+      "status": "string",
+      "warnings": "array"
+    },
+    "image_remove": {
+      "deleted_ids": "array",
+      "image_ref": "string",
+      "untagged_refs": "array",
+      "warnings": "array"
+    },
+    "logs": {
+      "runs": "array"
+    },
+    "project": {
+      "agents": "array",
+      "project": "object",
+      "schedulers": "array"
+    },
+    "project_list": {
+      "projects": "array",
+      "total": "number"
+    },
+    "project_stats": {
+      "project": "object",
+      "stats": "array"
+    },
+    "ps": {
+      "project": "object",
+      "sandboxes": "array"
+    },
+    "run": {
+      "agent_name": "string",
+      "artifacts_dir": "string",
+      "cleanup_error": "string",
+      "completed_at": "string",
+      "driver": "string",
+      "duration_ms": "number",
+      "error": "string",
+      "exit_code": "number",
+      "id": "string",
+      "image_ref": "string",
+      "jupyter_path": "string",
+      "jupyter_url": "string",
+      "labels": "object",
+      "logs_command": "string",
+      "logs_path": "string",
+      "output": "string",
+      "project_id": "string",
+      "project_name": "string",
+      "prompt": "string",
+      "result_json": "string",
+      "sandbox_id": "string",
+      "sandbox_short_id": "string",
+      "short_id": "string",
+      "source": "string",
+      "started_at": "string",
+      "status": "string",
+      "warnings": "array"
+    },
+    "run_jupyter": {
+      "Path": "string",
+      "URL": "string"
+    },
+    "sandbox": {
+      "cell_count": "number",
+      "created_at": "string",
+      "driver": "string",
+      "event_count": "number",
+      "guest_image": "string",
+      "proxy_path": "string",
+      "sandbox_id": "string",
+      "sandbox_short_id": "string",
+      "stopped_runtime_last_error": "string",
+      "stopped_runtime_policy": "string",
+      "stopped_runtime_released_at": "string",
+      "stopped_runtime_state": "string",
+      "tags": "object",
+      "title": "string",
+      "trigger_source": "string",
+      "updated_at": "string",
+      "vm_status": "string",
+      "workspace_path": "string",
+      "workspace_reclamation": "object"
+    },
+    "sandbox_action": {
+      "results": "array"
+    },
+    "sandbox_list": {
+      "agent": "string",
+      "created_at": "string",
+      "driver": "string",
+      "image": "string",
+      "kind": "string",
+      "run_id": "string",
+      "run_short_id": "string",
+      "runtime_id": "string",
+      "sandbox_id": "string",
+      "sandbox_short_id": "string",
+      "status": "string",
+      "stopped_runtime_policy": "string",
+      "stopped_runtime_state": "string",
+      "updated_at": "string",
+      "workspace": "string"
+    },
+    "sandbox_logs": {
+      "events": "array",
+      "output": "string",
+      "sandbox_id": "string"
+    },
+    "sandbox_prune": {
+      "dry_run": "boolean",
+      "matched": "array",
+      "removed": "array",
+      "skipped": "array",
+      "warnings": "array"
+    },
+    "scheduler_inspect": {
+      "agent_name": "string",
+      "definition": "object",
+      "project": "object",
+      "registered": "object",
+      "resource": "string",
+      "run": "object",
+      "scheduler": "object",
+      "source": "string",
+      "trigger": "object"
+    },
+    "scheduler_list": {
+      "project": "object",
+      "triggers": "array"
+    },
+    "scheduler_logs": {
+      "events": "array",
+      "project": "object",
+      "run": "object"
+    },
+    "scheduler_prune": {
+      "dry_run": "boolean",
+      "matched": "object",
+      "older_than": "string",
+      "project": "object",
+      "record_scope": "string",
+      "removed": "object",
+      "residues": "array",
+      "scheduler": "string",
+      "skipped_runs": "number",
+      "statuses": "array",
+      "trigger_id": "string",
+      "warnings": "array"
+    },
+    "scheduler_runs": {
+      "project": "object",
+      "runs": "array"
+    },
+    "stats": {
+      "block_read_bytes": "object",
+      "block_write_bytes": "object",
+      "cpu_percent": "object",
+      "driver": "string",
+      "memory_limit_bytes": "object",
+      "memory_percent": "object",
+      "memory_usage_bytes": "object",
+      "network_rx_bytes": "object",
+      "network_tx_bytes": "object",
+      "sampled_at": "string",
+      "sandbox_id": "string",
+      "sandbox_short_id": "string",
+      "uptime_seconds": "object"
+    },
+    "up": {
+      "applied": "boolean",
+      "changes": "array",
+      "project": "object",
+      "revision": "object",
+      "unchanged": "boolean"
+    },
+    "volume_create": {
+      "created": "boolean",
+      "volume": "object"
+    },
+    "volume_inspect": {
+      "volume": "object"
+    },
+    "volume_list": {
+      "total": "number",
+      "volumes": "array"
+    },
+    "volume_prune": {
+      "dry_run": "boolean",
+      "matched": "array",
+      "removed": "array",
+      "skipped": "array"
+    },
+    "volume_remove": {
+      "removed": "array"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #393 by adding an explicit snapshot for the stable CLI surface.

- Snapshot public command paths, Use forms, aliases, and local/inherited flags.
- Record flag types, defaults, optional values, shorthands, and hidden status.
- Derive JSON field/type contracts from the public output structs and validate `version --json` at runtime.
- Cover representative success, usage-error, and invalid-value exit codes.
- Require `UPDATE_CLI_CONTRACT=1` for intentional contract updates.

This keeps CLI compatibility changes reviewable without changing production behavior.

## Testing

- `go test ./cmd/agent-compose -run TestPublicCLIContractSnapshot -count=1`
- `go test ./cmd/agent-compose -count=1`
- `git diff --check`

The regression was mutation-tested: changing a version JSON field makes the contract test fail, and restoring it returns the suite to green. The snapshot covers registered CLI output structures; daemon-backed JSON commands are not run as E2E in this change.