### PR TITLE
feat(llm): manage upstream providers through RPC

### DIFF
--- a/cmd/agent-compose/cli_client.go
+++ b/cmd/agent-compose/cli_client.go
@@ -25,6 +25,7 @@ type cliServiceClients struct {
 	image    agentcomposev2connect.ImageServiceClient
 	cache    agentcomposev2connect.CacheServiceClient
 	volume   agentcomposev2connect.VolumeServiceClient
+	llm      agentcomposev2connect.LLMServiceClient
 	sandbox  agentcomposev2connect.SandboxServiceClient
 }
 
@@ -42,6 +43,7 @@ func newCLIServiceClients(cli cliOptions) (cliServiceClients, error) {
 		image:    agentcomposev2connect.NewImageServiceClient(httpClient, clientConfig.BaseURL),
 		cache:    agentcomposev2connect.NewCacheServiceClient(httpClient, clientConfig.BaseURL),
 		volume:   agentcomposev2connect.NewVolumeServiceClient(httpClient, clientConfig.BaseURL),
+		llm:      agentcomposev2connect.NewLLMServiceClient(httpClient, clientConfig.BaseURL),
 		sandbox:  agentcomposev2connect.NewSandboxServiceClient(httpClient, clientConfig.BaseURL),
 	}, nil
 }

--- a/cmd/agent-compose/cli_contract_test.go
+++ b/cmd/agent-compose/cli_contract_test.go
@@ -156,6 +156,9 @@ func collectCLIJSONContracts() map[string]map[string]string {
 		"scheduler_logs": composeSchedulerLogsOutput{}, "volume_list": composeVolumeListOutput{},
 		"volume_inspect": composeVolumeInspectOutput{}, "volume_create": composeVolumeCreateOutput{},
 		"volume_remove": composeVolumeRemoveOutput{}, "volume_prune": composeVolumePruneOutput{},
+		"llm_provider_list": composeLLMProviderListOutput{}, "llm_provider_inspect": composeLLMProviderInspectOutput{},
+		"llm_provider_create": composeLLMProviderCreateOutput{}, "llm_provider_update": composeLLMProviderUpdateOutput{},
+		"llm_provider_remove": composeLLMProviderRemoveOutput{},
 	}
 	out := make(map[string]map[string]string, len(values))
 	for name, value := range values {

--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -117,6 +117,16 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 			want: []string{"Pull an image or all project images", "pull [image]", "--platform"},
 		},
 		{
+			name: "llm provider",
+			args: []string{"llm", "provider", "--help"},
+			want: []string{"Manage API-owned upstream LLM providers", "ls", "create", "inspect", "update", "rm"},
+		},
+		{
+			name: "llm provider create",
+			args: []string{"llm", "provider", "create", "--help"},
+			want: []string{"Create an API-owned upstream LLM provider", "--base-url", "--protocol", "--api-key", "--name", "--enabled"},
+		},
+		{
 			name: "inspect",
 			args: []string{"inspect", "--help"},
 			want: []string{"Inspect project, agent, run, sandbox, image, cache, or volume details"},

--- a/cmd/agent-compose/cli_help_e2e_test.go
+++ b/cmd/agent-compose/cli_help_e2e_test.go
@@ -127,6 +127,16 @@ func TestE2ECLIHelpCoversUserWorkflowCommandSurface(t *testing.T) {
 			want: []string{"Create an API-owned upstream LLM provider", "--base-url", "--protocol", "--api-key", "--name", "--enabled"},
 		},
 		{
+			name: "llm provider update",
+			args: []string{"llm", "provider", "update", "--help"},
+			want: []string{"Update an API-owned upstream LLM provider", "--base-url", "--protocol", "--api-key", "--name", "--enabled"},
+		},
+		{
+			name: "llm provider inspect",
+			args: []string{"llm", "provider", "inspect", "--help"},
+			want: []string{"Inspect an API-owned upstream LLM provider"},
+		},
+		{
 			name: "inspect",
 			args: []string{"inspect", "--help"},
 			want: []string{"Inspect project, agent, run, sandbox, image, cache, or volume details"},

--- a/cmd/agent-compose/cli_llm_provider.go
+++ b/cmd/agent-compose/cli_llm_provider.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+type composeLLMProviderCreateOptions struct {
+	Name     string
+	BaseURL  string
+	Protocol string
+	APIKey   string
+	Enabled  bool
+}
+
+type composeLLMProviderUpdateOptions struct {
+	Name     string
+	BaseURL  string
+	Protocol string
+	APIKey   string
+	Enabled  bool
+}
+
+type composeLLMProviderListOutput struct {
+	Providers []composeLLMProviderOutput `json:"providers"`
+	Total     uint32                     `json:"total"`
+}
+
+type composeLLMProviderInspectOutput struct {
+	Provider composeLLMProviderOutput `json:"provider"`
+}
+
+type composeLLMProviderCreateOutput struct {
+	Provider composeLLMProviderOutput `json:"provider"`
+}
+
+type composeLLMProviderUpdateOutput struct {
+	Provider composeLLMProviderOutput `json:"provider"`
+}
+
+type composeLLMProviderRemoveOutput struct {
+	ID      string `json:"id"`
+	Removed bool   `json:"removed"`
+}
+
+type composeLLMProviderOutput struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	BaseURL   string `json:"base_url"`
+	Protocol  string `json:"protocol"`
+	Enabled   bool   `json:"enabled"`
+	APIKeySet bool   `json:"api_key_set"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+func runComposeLLMProviderListCommand(cmd *cobra.Command, cli cliOptions) error {
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	request := &agentcomposev2.ListProvidersRequest{Limit: 500}
+	response := &agentcomposev2.ListProvidersResponse{}
+	for uint32(len(response.Providers)) < response.GetTotal() || response.GetTotal() == 0 {
+		request.Offset = uint32(len(response.Providers))
+		resp, err := clients.llm.ListProviders(cmd.Context(), connect.NewRequest(request))
+		if err != nil {
+			return commandExitErrorForConnect(fmt.Errorf("list llm providers: %w", err))
+		}
+		response.Total = resp.Msg.GetTotal()
+		response.Providers = append(response.Providers, resp.Msg.GetProviders()...)
+		if uint32(len(response.Providers)) >= response.Total {
+			break
+		}
+		if len(resp.Msg.GetProviders()) == 0 {
+			return fmt.Errorf("llm provider list pagination did not advance")
+		}
+	}
+	output := composeLLMProviderListOutputFromResponse(response)
+	if cli.JSON {
+		return writeLLMProviderJSON(cmd.OutOrStdout(), output)
+	}
+	return writeLLMProviderListText(cmd.OutOrStdout(), output.Providers)
+}
+
+func runComposeLLMProviderCreateCommand(cmd *cobra.Command, cli cliOptions, options composeLLMProviderCreateOptions, id string) error {
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("llm provider create requires a provider id")}
+	}
+	spec := &agentcomposev2.LLMProviderSpec{
+		Id:       id,
+		Name:     strings.TrimSpace(options.Name),
+		BaseUrl:  strings.TrimSpace(options.BaseURL),
+		Protocol: strings.TrimSpace(options.Protocol),
+		ApiKey:   proto.String(options.APIKey),
+		Enabled:  proto.Bool(options.Enabled),
+	}
+	resp, err := clients.llm.CreateProvider(cmd.Context(), connect.NewRequest(&agentcomposev2.CreateProviderRequest{Provider: spec}))
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("create llm provider %s: %w", id, err))
+	}
+	output := composeLLMProviderCreateOutput{Provider: composeLLMProviderOutputFromProto(resp.Msg.GetProvider())}
+	if cli.JSON {
+		return writeLLMProviderJSON(cmd.OutOrStdout(), output)
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), output.Provider.ID)
+	return err
+}
+
+func runComposeLLMProviderInspectCommand(cmd *cobra.Command, cli cliOptions, id string) error {
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("llm provider inspect requires a provider id")}
+	}
+	resp, err := clients.llm.GetProvider(cmd.Context(), connect.NewRequest(&agentcomposev2.GetProviderRequest{Id: id}))
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("inspect llm provider %s: %w", id, err))
+	}
+	output := composeLLMProviderInspectOutput{Provider: composeLLMProviderOutputFromProto(resp.Msg.GetProvider())}
+	if cli.JSON {
+		return writeLLMProviderJSON(cmd.OutOrStdout(), output)
+	}
+	return writeLLMProviderInspectText(cmd.OutOrStdout(), output.Provider)
+}
+
+func runComposeLLMProviderUpdateCommand(cmd *cobra.Command, cli cliOptions, options composeLLMProviderUpdateOptions, id string) error {
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("llm provider update requires a provider id")}
+	}
+	spec := &agentcomposev2.LLMProviderSpec{Id: id}
+	if cmd.Flags().Changed("name") {
+		spec.Name = strings.TrimSpace(options.Name)
+	}
+	if cmd.Flags().Changed("base-url") {
+		spec.BaseUrl = strings.TrimSpace(options.BaseURL)
+	}
+	if cmd.Flags().Changed("protocol") {
+		spec.Protocol = strings.TrimSpace(options.Protocol)
+	}
+	if cmd.Flags().Changed("api-key") {
+		spec.ApiKey = proto.String(options.APIKey)
+	}
+	if cmd.Flags().Changed("enabled") {
+		spec.Enabled = proto.Bool(options.Enabled)
+	}
+	resp, err := clients.llm.UpdateProvider(cmd.Context(), connect.NewRequest(&agentcomposev2.UpdateProviderRequest{Provider: spec}))
+	if err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("update llm provider %s: %w", id, err))
+	}
+	output := composeLLMProviderUpdateOutput{Provider: composeLLMProviderOutputFromProto(resp.Msg.GetProvider())}
+	if cli.JSON {
+		return writeLLMProviderJSON(cmd.OutOrStdout(), output)
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), output.Provider.ID)
+	return err
+}
+
+func runComposeLLMProviderRemoveCommand(cmd *cobra.Command, cli cliOptions, id string) error {
+	clients, err := newCLIServiceClients(cli)
+	if err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return commandExitError{Code: exitCodeUsage, Err: fmt.Errorf("llm provider rm requires a provider id")}
+	}
+	if _, err := clients.llm.DeleteProvider(cmd.Context(), connect.NewRequest(&agentcomposev2.DeleteProviderRequest{Id: id})); err != nil {
+		return commandExitErrorForConnect(fmt.Errorf("remove llm provider %s: %w", id, err))
+	}
+	output := composeLLMProviderRemoveOutput{ID: id, Removed: true}
+	if cli.JSON {
+		return writeLLMProviderJSON(cmd.OutOrStdout(), output)
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), id)
+	return err
+}
+
+func composeLLMProviderListOutputFromResponse(resp *agentcomposev2.ListProvidersResponse) composeLLMProviderListOutput {
+	output := composeLLMProviderListOutput{Providers: make([]composeLLMProviderOutput, 0, len(resp.GetProviders())), Total: resp.GetTotal()}
+	for _, provider := range resp.GetProviders() {
+		output.Providers = append(output.Providers, composeLLMProviderOutputFromProto(provider))
+	}
+	return output
+}
+
+func composeLLMProviderOutputFromProto(provider *agentcomposev2.LLMProvider) composeLLMProviderOutput {
+	if provider == nil {
+		return composeLLMProviderOutput{}
+	}
+	return composeLLMProviderOutput{
+		ID:        provider.GetId(),
+		Name:      provider.GetName(),
+		BaseURL:   provider.GetBaseUrl(),
+		Protocol:  provider.GetProtocol(),
+		Enabled:   provider.GetEnabled(),
+		APIKeySet: provider.GetApiKeySet(),
+		CreatedAt: formatProtoTimestamp(provider.GetCreatedAt()),
+		UpdatedAt: formatProtoTimestamp(provider.GetUpdatedAt()),
+	}
+}
+
+func writeLLMProviderJSON(out io.Writer, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeCommandOutput(out, append(data, '\n'))
+}
+
+func writeLLMProviderListText(out io.Writer, providers []composeLLMProviderOutput) error {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tNAME\tPROTOCOL\tENABLED\tBASE URL"); err != nil {
+		return err
+	}
+	for _, provider := range providers {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%t\t%s\n",
+			firstNonEmptyString(provider.ID, "-"),
+			firstNonEmptyString(provider.Name, "-"),
+			firstNonEmptyString(provider.Protocol, "-"),
+			provider.Enabled,
+			firstNonEmptyString(provider.BaseURL, "-"),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func writeLLMProviderInspectText(out io.Writer, provider composeLLMProviderOutput) error {
+	_, err := fmt.Fprintf(out, "ID: %s\nName: %s\nBase URL: %s\nProtocol: %s\nEnabled: %t\nAPI Key Set: %t\nCreated: %s\nUpdated: %s\n",
+		firstNonEmptyString(provider.ID, "-"),
+		firstNonEmptyString(provider.Name, "-"),
+		firstNonEmptyString(provider.BaseURL, "-"),
+		firstNonEmptyString(provider.Protocol, "-"),
+		provider.Enabled,
+		provider.APIKeySet,
+		firstNonEmptyString(provider.CreatedAt, "-"),
+		firstNonEmptyString(provider.UpdatedAt, "-"),
+	)
+	return err
+}

--- a/cmd/agent-compose/cli_llm_provider_definition.go
+++ b/cmd/agent-compose/cli_llm_provider_definition.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newCLILLMCommand(cli *cliOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "llm", Short: "Manage daemon LLM configuration", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() }}
+	cmd.AddCommand(newCLILLMProviderCommand(cli))
+	return cmd
+}
+
+func newCLILLMProviderCommand(cli *cliOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "provider", Short: "Manage API-owned upstream LLM providers", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() }}
+	listCmd := &cobra.Command{Use: "ls", Short: "List API-owned upstream LLM providers", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
+		return runComposeLLMProviderListCommand(cmd, *cli)
+	}}
+	createOptions := composeLLMProviderCreateOptions{}
+	createCmd := &cobra.Command{Use: "create <id>", Short: "Create an API-owned upstream LLM provider", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		return runComposeLLMProviderCreateCommand(cmd, *cli, createOptions, args[0])
+	}}
+	addLLMProviderCreateFlags(createCmd, &createOptions)
+	inspectCmd := &cobra.Command{Use: "inspect <id>", Short: "Inspect an API-owned upstream LLM provider", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		return runComposeLLMProviderInspectCommand(cmd, *cli, args[0])
+	}}
+	updateOptions := composeLLMProviderUpdateOptions{}
+	updateCmd := &cobra.Command{Use: "update <id>", Short: "Update an API-owned upstream LLM provider", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		return runComposeLLMProviderUpdateCommand(cmd, *cli, updateOptions, args[0])
+	}}
+	addLLMProviderUpdateFlags(updateCmd, &updateOptions)
+	removeCmd := &cobra.Command{Use: "rm <id>", Aliases: []string{"remove"}, Short: "Remove an API-owned upstream LLM provider", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		return runComposeLLMProviderRemoveCommand(cmd, *cli, args[0])
+	}}
+	cmd.AddCommand(listCmd, createCmd, inspectCmd, updateCmd, removeCmd)
+	return cmd
+}
+
+func addLLMProviderCreateFlags(cmd *cobra.Command, options *composeLLMProviderCreateOptions) {
+	cmd.Flags().StringVar(&options.Name, "name", "", "Display name; defaults to the provider id")
+	cmd.Flags().StringVar(&options.BaseURL, "base-url", "", "Absolute HTTP(S) upstream base URL")
+	cmd.Flags().StringVar(&options.Protocol, "protocol", "", "Upstream protocol: responses, chat_completions, or anthropic_messages")
+	cmd.Flags().StringVar(&options.APIKey, "api-key", "", "Literal upstream API key")
+	cmd.Flags().BoolVar(&options.Enabled, "enabled", true, "Whether the provider is enabled")
+	for _, name := range []string{"base-url", "protocol", "api-key"} {
+		if err := cmd.MarkFlagRequired(name); err != nil {
+			panic(fmt.Sprintf("mark %s required: %v", name, err))
+		}
+	}
+}
+
+func addLLMProviderUpdateFlags(cmd *cobra.Command, options *composeLLMProviderUpdateOptions) {
+	cmd.Flags().StringVar(&options.Name, "name", "", "Display name")
+	cmd.Flags().StringVar(&options.BaseURL, "base-url", "", "Absolute HTTP(S) upstream base URL")
+	cmd.Flags().StringVar(&options.Protocol, "protocol", "", "Upstream protocol: responses, chat_completions, or anthropic_messages")
+	cmd.Flags().StringVar(&options.APIKey, "api-key", "", "Literal upstream API key")
+	cmd.Flags().BoolVar(&options.Enabled, "enabled", true, "Whether the provider is enabled")
+}

--- a/cmd/agent-compose/cli_llm_provider_test.go
+++ b/cmd/agent-compose/cli_llm_provider_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+	"github.com/chaitin/agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestIntegrationCLILLMProviderCommands(t *testing.T) {
+	var created *agentcomposev2.LLMProviderSpec
+	var updated *agentcomposev2.LLMProviderSpec
+	var deleted string
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		llm: llmServiceStub{
+			listProviders: func(ctx context.Context, req *connect.Request[agentcomposev2.ListProvidersRequest]) (*connect.Response[agentcomposev2.ListProvidersResponse], error) {
+				if req.Msg.GetLimit() != 500 {
+					t.Fatalf("ListProviders request = %#v", req.Msg)
+				}
+				return connect.NewResponse(&agentcomposev2.ListProvidersResponse{
+					Providers: []*agentcomposev2.LLMProvider{testCLILLMProvider("gateway")},
+					Total:     1,
+				}), nil
+			},
+			createProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.CreateProviderRequest]) (*connect.Response[agentcomposev2.CreateProviderResponse], error) {
+				created = req.Msg.GetProvider()
+				if created.GetId() != "gateway" || created.GetBaseUrl() != "https://example.com/v1" || created.GetProtocol() != "responses" || created.GetApiKey() != "secret" || !created.GetEnabled() {
+					t.Fatalf("CreateProvider request = %#v", created)
+				}
+				return connect.NewResponse(&agentcomposev2.CreateProviderResponse{Provider: testCLILLMProvider("gateway")}), nil
+			},
+			getProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProviderRequest]) (*connect.Response[agentcomposev2.GetProviderResponse], error) {
+				if req.Msg.GetId() != "gateway" {
+					t.Fatalf("GetProvider request = %#v", req.Msg)
+				}
+				return connect.NewResponse(&agentcomposev2.GetProviderResponse{Provider: testCLILLMProvider("gateway")}), nil
+			},
+			updateProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.UpdateProviderRequest]) (*connect.Response[agentcomposev2.UpdateProviderResponse], error) {
+				updated = req.Msg.GetProvider()
+				if updated.GetId() != "gateway" || updated.GetBaseUrl() != "https://rotated.example.com/v1" || updated.Name != "" || updated.Protocol != "" || updated.ApiKey != nil || updated.Enabled != nil {
+					t.Fatalf("UpdateProvider request = %#v", updated)
+				}
+				provider := testCLILLMProvider("gateway")
+				provider.BaseUrl = updated.GetBaseUrl()
+				return connect.NewResponse(&agentcomposev2.UpdateProviderResponse{Provider: provider}), nil
+			},
+			deleteProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.DeleteProviderRequest]) (*connect.Response[agentcomposev2.DeleteProviderResponse], error) {
+				deleted = req.Msg.GetId()
+				return connect.NewResponse(&agentcomposev2.DeleteProviderResponse{}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	textOut, textErr, _, textCode := executeCLICommand("llm", "provider", "ls", "--host", server.URL)
+	if textCode != 0 || textErr != "" || !strings.Contains(textOut, "gateway") || !strings.Contains(textOut, "responses") {
+		t.Fatalf("llm provider ls text code/stdout/stderr = %d / %q / %q", textCode, textOut, textErr)
+	}
+
+	listOut, listErr, _, listCode := executeCLICommand("llm", "provider", "ls", "--host", server.URL, "--json")
+	if listCode != 0 || listErr != "" {
+		t.Fatalf("llm provider ls json code/stderr = %d / %q", listCode, listErr)
+	}
+	var listDecoded composeLLMProviderListOutput
+	if err := json.Unmarshal([]byte(listOut), &listDecoded); err != nil {
+		t.Fatalf("llm provider ls JSON decode failed: %v\n%s", err, listOut)
+	}
+	if len(listDecoded.Providers) != 1 || listDecoded.Providers[0].ID != "gateway" || !listDecoded.Providers[0].APIKeySet {
+		t.Fatalf("llm provider ls JSON = %#v", listDecoded)
+	}
+
+	createOut, createErr, _, createCode := executeCLICommand("llm", "provider", "create", "--host", server.URL, "--base-url", "https://example.com/v1", "--protocol", "responses", "--api-key", "secret", "gateway")
+	if createCode != 0 || createErr != "" || strings.TrimSpace(createOut) != "gateway" || created == nil {
+		t.Fatalf("llm provider create code/stdout/stderr = %d / %q / %q", createCode, createOut, createErr)
+	}
+
+	inspectOut, inspectErr, _, inspectCode := executeCLICommand("llm", "provider", "inspect", "--host", server.URL, "gateway")
+	if inspectCode != 0 || inspectErr != "" || !strings.Contains(inspectOut, "ID: gateway") || !strings.Contains(inspectOut, "API Key Set: true") {
+		t.Fatalf("llm provider inspect code/stdout/stderr = %d / %q / %q", inspectCode, inspectOut, inspectErr)
+	}
+
+	updateOut, updateErr, _, updateCode := executeCLICommand("llm", "provider", "update", "--host", server.URL, "--base-url", "https://rotated.example.com/v1", "gateway")
+	if updateCode != 0 || updateErr != "" || strings.TrimSpace(updateOut) != "gateway" || updated == nil {
+		t.Fatalf("llm provider update code/stdout/stderr = %d / %q / %q", updateCode, updateOut, updateErr)
+	}
+
+	removeOut, removeErr, _, removeCode := executeCLICommand("llm", "provider", "rm", "--host", server.URL, "gateway")
+	if removeCode != 0 || removeErr != "" || strings.TrimSpace(removeOut) != "gateway" || deleted != "gateway" {
+		t.Fatalf("llm provider rm code/stdout/stderr = %d / %q / %q deleted=%q", removeCode, removeOut, removeErr, deleted)
+	}
+}
+
+type llmServiceStub struct {
+	listProviders  func(context.Context, *connect.Request[agentcomposev2.ListProvidersRequest]) (*connect.Response[agentcomposev2.ListProvidersResponse], error)
+	createProvider func(context.Context, *connect.Request[agentcomposev2.CreateProviderRequest]) (*connect.Response[agentcomposev2.CreateProviderResponse], error)
+	getProvider    func(context.Context, *connect.Request[agentcomposev2.GetProviderRequest]) (*connect.Response[agentcomposev2.GetProviderResponse], error)
+	updateProvider func(context.Context, *connect.Request[agentcomposev2.UpdateProviderRequest]) (*connect.Response[agentcomposev2.UpdateProviderResponse], error)
+	deleteProvider func(context.Context, *connect.Request[agentcomposev2.DeleteProviderRequest]) (*connect.Response[agentcomposev2.DeleteProviderResponse], error)
+
+	agentcomposev2connect.UnimplementedLLMServiceHandler
+}
+
+func (s llmServiceStub) ListProviders(ctx context.Context, req *connect.Request[agentcomposev2.ListProvidersRequest]) (*connect.Response[agentcomposev2.ListProvidersResponse], error) {
+	if s.listProviders == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ListProviders stub is not configured"))
+	}
+	return s.listProviders(ctx, req)
+}
+
+func (s llmServiceStub) CreateProvider(ctx context.Context, req *connect.Request[agentcomposev2.CreateProviderRequest]) (*connect.Response[agentcomposev2.CreateProviderResponse], error) {
+	if s.createProvider == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("CreateProvider stub is not configured"))
+	}
+	return s.createProvider(ctx, req)
+}
+
+func (s llmServiceStub) GetProvider(ctx context.Context, req *connect.Request[agentcomposev2.GetProviderRequest]) (*connect.Response[agentcomposev2.GetProviderResponse], error) {
+	if s.getProvider == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("GetProvider stub is not configured"))
+	}
+	return s.getProvider(ctx, req)
+}
+
+func (s llmServiceStub) UpdateProvider(ctx context.Context, req *connect.Request[agentcomposev2.UpdateProviderRequest]) (*connect.Response[agentcomposev2.UpdateProviderResponse], error) {
+	if s.updateProvider == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("UpdateProvider stub is not configured"))
+	}
+	return s.updateProvider(ctx, req)
+}
+
+func (s llmServiceStub) DeleteProvider(ctx context.Context, req *connect.Request[agentcomposev2.DeleteProviderRequest]) (*connect.Response[agentcomposev2.DeleteProviderResponse], error) {
+	if s.deleteProvider == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("DeleteProvider stub is not configured"))
+	}
+	return s.deleteProvider(ctx, req)
+}
+
+func testCLILLMProvider(id string) *agentcomposev2.LLMProvider {
+	return &agentcomposev2.LLMProvider{
+		Id:        id,
+		Name:      id,
+		BaseUrl:   "https://example.com/v1",
+		Protocol:  "responses",
+		Enabled:   true,
+		ApiKeySet: true,
+		CreatedAt: mustProtoTimestamp("2026-07-07T12:00:00Z"),
+		UpdatedAt: mustProtoTimestamp("2026-07-07T12:00:00Z"),
+	}
+}

--- a/cmd/agent-compose/cli_llm_provider_test.go
+++ b/cmd/agent-compose/cli_llm_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -94,6 +95,146 @@ func TestIntegrationCLILLMProviderCommands(t *testing.T) {
 	if removeCode != 0 || removeErr != "" || strings.TrimSpace(removeOut) != "gateway" || deleted != "gateway" {
 		t.Fatalf("llm provider rm code/stdout/stderr = %d / %q / %q deleted=%q", removeCode, removeOut, removeErr, deleted)
 	}
+}
+
+func TestE2ECLILLMProviderCommands(t *testing.T) {
+	TestIntegrationCLILLMProviderCommands(t)
+}
+
+func TestIntegrationCLILLMProviderJSONAndPartialUpdate(t *testing.T) {
+	var created *agentcomposev2.LLMProviderSpec
+	var updated *agentcomposev2.LLMProviderSpec
+	var listOffsets []uint32
+	server := newComposeServiceStubServer(t, composeServiceStubs{
+		llm: llmServiceStub{
+			listProviders: func(ctx context.Context, req *connect.Request[agentcomposev2.ListProvidersRequest]) (*connect.Response[agentcomposev2.ListProvidersResponse], error) {
+				listOffsets = append(listOffsets, req.Msg.GetOffset())
+				if req.Msg.GetOffset() == 0 {
+					return connect.NewResponse(&agentcomposev2.ListProvidersResponse{
+						Providers: []*agentcomposev2.LLMProvider{testCLILLMProvider("gateway")},
+						Total:     2,
+					}), nil
+				}
+				second := testCLILLMProvider("messages")
+				second.Protocol = "anthropic_messages"
+				second.Enabled = false
+				return connect.NewResponse(&agentcomposev2.ListProvidersResponse{
+					Providers: []*agentcomposev2.LLMProvider{second},
+					Total:     2,
+				}), nil
+			},
+			createProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.CreateProviderRequest]) (*connect.Response[agentcomposev2.CreateProviderResponse], error) {
+				created = req.Msg.GetProvider()
+				if created.GetId() != "messages" || created.GetName() != "Claude" || created.GetProtocol() != "anthropic_messages" || created.GetApiKey() != "secret" || created.Enabled == nil || !*created.Enabled {
+					t.Fatalf("CreateProvider request = %#v", created)
+				}
+				provider := testCLILLMProvider("messages")
+				provider.Name = created.GetName()
+				provider.Protocol = created.GetProtocol()
+				return connect.NewResponse(&agentcomposev2.CreateProviderResponse{Provider: provider}), nil
+			},
+			getProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.GetProviderRequest]) (*connect.Response[agentcomposev2.GetProviderResponse], error) {
+				return connect.NewResponse(&agentcomposev2.GetProviderResponse{Provider: testCLILLMProvider(req.Msg.GetId())}), nil
+			},
+			updateProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.UpdateProviderRequest]) (*connect.Response[agentcomposev2.UpdateProviderResponse], error) {
+				updated = req.Msg.GetProvider()
+				if updated.GetId() != "gateway" || updated.GetName() != "renamed" || updated.GetProtocol() != "anthropic_messages" || updated.GetApiKey() != "rotated" || updated.Enabled == nil || *updated.Enabled || updated.GetBaseUrl() != "" {
+					t.Fatalf("UpdateProvider request = %#v", updated)
+				}
+				provider := testCLILLMProvider("gateway")
+				provider.Name = updated.GetName()
+				provider.Protocol = updated.GetProtocol()
+				provider.Enabled = false
+				return connect.NewResponse(&agentcomposev2.UpdateProviderResponse{Provider: provider}), nil
+			},
+			deleteProvider: func(ctx context.Context, req *connect.Request[agentcomposev2.DeleteProviderRequest]) (*connect.Response[agentcomposev2.DeleteProviderResponse], error) {
+				return connect.NewResponse(&agentcomposev2.DeleteProviderResponse{}), nil
+			},
+		},
+	})
+	defer server.Close()
+
+	listOut, listErr, _, listCode := executeCLICommand("llm", "provider", "ls", "--host", server.URL, "--json")
+	if listCode != 0 || listErr != "" {
+		t.Fatalf("paginated ls code/stderr = %d / %q", listCode, listErr)
+	}
+	var listDecoded composeLLMProviderListOutput
+	if err := json.Unmarshal([]byte(listOut), &listDecoded); err != nil {
+		t.Fatalf("paginated ls JSON: %v\n%s", err, listOut)
+	}
+	if listDecoded.Total != 2 || len(listDecoded.Providers) != 2 || listDecoded.Providers[1].Protocol != "anthropic_messages" || !reflect.DeepEqual(listOffsets, []uint32{0, 1}) {
+		t.Fatalf("paginated ls = %#v offsets=%v", listDecoded, listOffsets)
+	}
+
+	createOut, createErr, _, createCode := executeCLICommand("llm", "provider", "create", "--json", "--host", server.URL, "--name", "Claude", "--base-url", "https://api.anthropic.com", "--protocol", "anthropic_messages", "--api-key", "secret", "messages")
+	if createCode != 0 || createErr != "" || created == nil {
+		t.Fatalf("json create code/stdout/stderr = %d / %q / %q", createCode, createOut, createErr)
+	}
+	var createDecoded composeLLMProviderCreateOutput
+	if err := json.Unmarshal([]byte(createOut), &createDecoded); err != nil || createDecoded.Provider.ID != "messages" || createDecoded.Provider.Protocol != "anthropic_messages" {
+		t.Fatalf("json create output = %q err=%v", createOut, err)
+	}
+
+	inspectOut, inspectErr, _, inspectCode := executeCLICommand("llm", "provider", "inspect", "--json", "--host", server.URL, "gateway")
+	if inspectCode != 0 || inspectErr != "" {
+		t.Fatalf("json inspect code/stderr = %d / %q", inspectCode, inspectErr)
+	}
+	var inspectDecoded composeLLMProviderInspectOutput
+	if err := json.Unmarshal([]byte(inspectOut), &inspectDecoded); err != nil || inspectDecoded.Provider.ID != "gateway" || !inspectDecoded.Provider.APIKeySet {
+		t.Fatalf("json inspect = %q err=%v", inspectOut, err)
+	}
+
+	updateOut, updateErr, _, updateCode := executeCLICommand("llm", "provider", "update", "--json", "--host", server.URL, "--name", "renamed", "--protocol", "anthropic_messages", "--api-key", "rotated", "--enabled=false", "gateway")
+	if updateCode != 0 || updateErr != "" || updated == nil {
+		t.Fatalf("json update code/stdout/stderr = %d / %q / %q", updateCode, updateOut, updateErr)
+	}
+	var updateDecoded composeLLMProviderUpdateOutput
+	if err := json.Unmarshal([]byte(updateOut), &updateDecoded); err != nil || updateDecoded.Provider.Name != "renamed" || updateDecoded.Provider.Enabled {
+		t.Fatalf("json update = %q err=%v", updateOut, err)
+	}
+
+	removeOut, removeErr, _, removeCode := executeCLICommand("llm", "provider", "rm", "--json", "--host", server.URL, "gateway")
+	if removeCode != 0 || removeErr != "" {
+		t.Fatalf("json rm code/stderr = %d / %q", removeCode, removeErr)
+	}
+	var removeDecoded composeLLMProviderRemoveOutput
+	if err := json.Unmarshal([]byte(removeOut), &removeDecoded); err != nil || removeDecoded.ID != "gateway" || !removeDecoded.Removed {
+		t.Fatalf("json rm = %q err=%v", removeOut, err)
+	}
+}
+
+func TestE2ECLILLMProviderJSONAndPartialUpdate(t *testing.T) {
+	TestIntegrationCLILLMProviderJSONAndPartialUpdate(t)
+}
+
+func TestCLILLMProviderUsageAndOutputHelpers(t *testing.T) {
+	for _, args := range [][]string{
+		{"llm", "provider", "create", "--base-url", "https://example.com", "--protocol", "responses", "--api-key", "secret"},
+		{"llm", "provider", "inspect"},
+		{"llm", "provider", "update"},
+		{"llm", "provider", "rm"},
+	} {
+		stdout, stderr, runCount, code := executeCLICommand(args...)
+		if code == 0 || stdout != "" || runCount != 0 || stderr == "" {
+			t.Fatalf("%v code/stdout/stderr/runCount = %d / %q / %q / %d", args, code, stdout, stderr, runCount)
+		}
+	}
+	if got := composeLLMProviderOutputFromProto(nil); got != (composeLLMProviderOutput{}) {
+		t.Fatalf("nil provider output = %#v", got)
+	}
+	if err := writeLLMProviderJSON(failingWriter{}, composeLLMProviderListOutput{}); err == nil {
+		t.Fatal("writeLLMProviderJSON failing writer returned nil error")
+	}
+	if err := writeLLMProviderListText(failingWriter{}, []composeLLMProviderOutput{{ID: "gateway"}}); err == nil {
+		t.Fatal("writeLLMProviderListText failing writer returned nil error")
+	}
+	if err := writeLLMProviderInspectText(failingWriter{}, composeLLMProviderOutput{ID: "gateway"}); err == nil {
+		t.Fatal("writeLLMProviderInspectText failing writer returned nil error")
+	}
+}
+
+func TestE2ECLILLMProviderUsageAndOutputHelpers(t *testing.T) {
+	TestCLILLMProviderUsageAndOutputHelpers(t)
 }
 
 type llmServiceStub struct {

--- a/cmd/agent-compose/cli_root.go
+++ b/cmd/agent-compose/cli_root.go
@@ -88,6 +88,7 @@ func newRootCommand(out, errOut io.Writer, runDaemon daemonRunner) *cobra.Comman
 		newCLIImagesCommand(&options),
 		newCLICacheCommand(&options),
 		newCLIVolumeCommand(&options),
+		newCLILLMCommand(&options),
 		newCLIImageCommand(&options),
 	)
 	commands = append(commands, newCLILegacyImageCommands(&options)...)

--- a/cmd/agent-compose/cli_stub_server_test.go
+++ b/cmd/agent-compose/cli_stub_server_test.go
@@ -19,6 +19,7 @@ type composeServiceStubs struct {
 	image    imageServiceStub
 	cache    cacheServiceStub
 	volume   volumeServiceStub
+	llm      llmServiceStub
 	sandbox  sandboxServiceStub
 	session  sessionServiceStub
 }
@@ -58,6 +59,10 @@ func newComposeServiceStubServer(t *testing.T, stubs composeServiceStubs) *httpt
 	}
 	if stubs.volume.listVolumes != nil || stubs.volume.createVolume != nil || stubs.volume.inspectVolume != nil || stubs.volume.removeVolume != nil || stubs.volume.pruneVolumes != nil {
 		path, handler := agentcomposev2connect.NewVolumeServiceHandler(stubs.volume)
+		mux.Handle(path, handler)
+	}
+	if stubs.llm.listProviders != nil || stubs.llm.createProvider != nil || stubs.llm.getProvider != nil || stubs.llm.updateProvider != nil || stubs.llm.deleteProvider != nil {
+		path, handler := agentcomposev2connect.NewLLMServiceHandler(stubs.llm)
 		mux.Handle(path, handler)
 	}
 	effectiveSandbox := sandboxStubWithSessionCompatibility(stubs.sandbox, stubs.session)

--- a/cmd/agent-compose/testdata/cli-contract.json
+++ b/cmd/agent-compose/testdata/cli-contract.json
@@ -1056,6 +1056,299 @@
       ]
     },
     {
+      "path": "agent-compose llm",
+      "use": "llm",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
+    },
+    {
+      "path": "agent-compose llm provider",
+      "use": "provider",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
+    },
+    {
+      "path": "agent-compose llm provider create",
+      "use": "create \u003cid\u003e",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "base-url",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "enabled",
+          "type": "bool",
+          "default": "true",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "protocol",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
+    },
+    {
+      "path": "agent-compose llm provider inspect",
+      "use": "inspect \u003cid\u003e",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
+    },
+    {
+      "path": "agent-compose llm provider ls",
+      "use": "ls",
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
+    },
+    {
+      "path": "agent-compose llm provider rm",
+      "use": "rm \u003cid\u003e",
+      "aliases": [
+        "remove"
+      ],
+      "flags": [
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
+    },
+    {
+      "path": "agent-compose llm provider update",
+      "use": "update \u003cid\u003e",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "base-url",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "enabled",
+          "type": "bool",
+          "default": "true",
+          "optional": "true"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "host",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "optional": "true"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "project-name",
+          "shorthand": "p",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "protocol",
+          "type": "string",
+          "default": ""
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "0s"
+        }
+      ]
+    },
+    {
       "path": "agent-compose logs",
       "use": "logs [agent-or-id]",
       "flags": [
@@ -2874,6 +3167,23 @@
       "image_ref": "string",
       "untagged_refs": "array",
       "warnings": "array"
+    },
+    "llm_provider_create": {
+      "provider": "object"
+    },
+    "llm_provider_inspect": {
+      "provider": "object"
+    },
+    "llm_provider_list": {
+      "providers": "array",
+      "total": "number"
+    },
+    "llm_provider_remove": {
+      "id": "string",
+      "removed": "boolean"
+    },
+    "llm_provider_update": {
+      "provider": "object"
     },
     "logs": {
       "runs": "array"

--- a/docs/design/llm-provider-rpc.md
+++ b/docs/design/llm-provider-rpc.md
@@ -16,12 +16,20 @@ IDs default and anthropic are reserved; session-env IDs cannot match this syntax
 
 Create requires an absolute HTTP(S) base URL, a supported protocol, and a nonempty
 literal API key. Responses contain api_key_set, never the credential. Update
-replaces public fields; absent api_key preserves the current key atomically,
-present nonempty rotates it, and present empty is invalid. An absent enabled
-field means true on both create and replacement update. An empty name defaults
-to the ID. Headers, per-model overrides and default-model management are outside
-this change. Protocol selects the existing OpenAI Bearer or Anthropic x-api-key
-upstream authentication.
+applies explicit fields only; omitted name, base_url, protocol, api_key, and
+enabled preserve stored values. Absent api_key preserves the current key
+atomically, present nonempty rotates it, and present empty is invalid. An absent
+enabled field means true on create and is preserved on update. An empty name
+defaults to the ID on create and is preserved on update. Anthropic Messages
+providers send anthropic-version: 2023-06-01 by default. Per-model overrides,
+custom headers, and default-model management remain outside this change.
+Protocol selects the existing OpenAI Bearer or Anthropic x-api-key upstream
+authentication and refreshes those headers when protocol is updated.
+
+CLI `agent-compose llm provider` exposes ls, create, inspect, update, and rm.
+Create requires --base-url, --protocol, and --api-key. Update sends only flags
+that were set. Environment bootstrap remains last fallback; API CRUD takes
+effect on the next target resolution.
 
 List includes disabled API-owned providers in ID order, using the existing
 offset/limit pagination convention. Get/Update/Delete reject non-API ownership.

--- a/docs/design/llm-provider-rpc.md
+++ b/docs/design/llm-provider-rpc.md
@@ -1,0 +1,74 @@
+# LLM provider management RPC
+
+## Problem and scope
+
+The daemon already persists upstream providers and routes literal provider/model
+references, but models.json is startup-only and no public RPC manages providers.
+Add live CRUD to agentcompose.v2.LLMService for upstream model endpoints and
+credentials. Coding-agent providers such as codex and pi are unrelated.
+
+## Contract
+
+CreateProvider, GetProvider, ListProviders, UpdateProvider and DeleteProvider use
+an immutable caller-chosen ID. IDs are 1–128 ASCII letters, digits, dots,
+underscores or hyphens, beginning with a letter or digit. The environment-owned
+IDs default and anthropic are reserved; session-env IDs cannot match this syntax.
+
+Create requires an absolute HTTP(S) base URL, a supported protocol, and a nonempty
+literal API key. Responses contain api_key_set, never the credential. Update
+replaces public fields; absent api_key preserves the current key atomically,
+present nonempty rotates it, and present empty is invalid. An absent enabled
+field means true on both create and replacement update. An empty name defaults
+to the ID. Headers, per-model overrides and default-model management are outside
+this change. Protocol selects the existing OpenAI Bearer or Anthropic x-api-key
+upstream authentication.
+
+List includes disabled API-owned providers in ID order, using the existing
+offset/limit pagination convention. Get/Update/Delete reject non-API ownership.
+Duplicate IDs return AlreadyExists; missing IDs return NotFound; ownership
+conflicts return FailedPrecondition; invalid configuration returns InvalidArgument.
+There is no upsert, rename or ownership-transfer operation. Concurrent creates
+have one winner; updates use atomic SQL replacement (last completed write wins),
+and omitted keys are preserved in SQL rather than through a read/write race.
+
+## Ownership and persistence
+
+Use scope=api in the existing llm_provider table. No schema migration is needed.
+Catalog synchronization affects only catalog scope, and existing collision checks
+reject models.json entries that collide with API-owned IDs. Restart therefore
+preserves API-owned configuration. Environment bootstrap cannot overwrite it
+because its fixed IDs and session prefix are unavailable to API creation.
+
+API keys follow the existing provider storage contract: application-level
+plaintext in data.db, never returned by the management RPCs. The existing daemon
+API authentication boundary applies to these methods; this change does not add
+a separate provider authorization system.
+
+Delete runs a transaction removing provider-bound facade tokens, model bindings
+and the provider. Shared model identities are not removed. An old facade token
+cannot become valid when an ID is reused. References in project definitions are
+not rewritten, and in-flight upstream requests are not canceled. A disabled
+provider remains stored and can be re-enabled; disabling does not revoke tokens.
+
+## Runtime behavior
+
+No resolver fork is introduced. API providers are configured providers under the
+existing scope rules. Callers select gateway/model with the existing Agent model
+field or model request. Literal models do not require model-table registration.
+The next target resolution reads current provider settings, so address/key
+updates require no restart. Existing in-flight requests use their resolved
+configuration; agent-side model/protocol setup may require restarting a run after
+protocol changes. API CRUD does not change global or catalog defaults. Unknown
+slash prefixes retain the existing literal-model interpretation; clients should
+verify provider existence when constructing a new reference after deletion.
+
+## Validation
+
+Domain tests cover ID/protocol/URL/key validation and input ownership. SQLite
+integration tests cover literal routing, key preservation/rotation, protocol
+mapping, disabled providers, restart/catalog coexistence, collisions, cancellation,
+concurrent create and token invalidation across deletion/recreation. Connect
+integration tests exercise generated clients over HTTP, response redaction,
+pagination and error codes. A local service E2E exercises CreateProvider, Generate,
+URL/key rotation and disabled-provider rejection against an HTTP upstream stub.
+Existing Generate and runtime tests remain applicable.

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -533,9 +533,16 @@ models do not need to be enumerated. Other methods share the service path prefix
 - `apiKey` is literal, without environment interpolation. Create requires a
   nonempty key. On update, omission preserves it, a nonempty value rotates it,
   and an empty value is invalid. Responses expose only `apiKeySet`, never the key.
-- `UpdateProvider` uses the same `provider` object and replaces public settings;
-  it is not a field patch. Omitted `name` defaults to the ID, and omitted
-  `enabled` means `true`, including on updates.
+- Create defaults an empty `name` to the ID and an omitted `enabled` field to
+  `true`. `anthropic_messages` providers send `anthropic-version: 2023-06-01` by
+  default; other protocols send no extra headers.
+- `UpdateProvider` uses the same `provider` object. Omitted `name`, `baseUrl`,
+  `protocol`, `apiKey`, and `enabled` preserve stored values. Present nonempty
+  `apiKey` rotates the key; present empty is invalid. Protocol changes also
+  refresh authentication headers.
+- CLI: `agent-compose llm provider ls|create|inspect|update|rm`. Create requires
+  `--base-url`, `--protocol`, and `--api-key`. Update sends only flags that are
+  set, so `update --base-url ...` does not re-enable a disabled provider.
 - `GetProvider` / `DeleteProvider` take `{"id":"team-gateway"}`.
   `ListProviders` takes `offset` / `limit`, orders by ID, includes disabled entries,
   and returns `providers` and `total`.

--- a/docs/pages/agent-compose-yaml-manual.md
+++ b/docs/pages/agent-compose-yaml-manual.md
@@ -501,6 +501,61 @@ The optional `models` array adds per-model metadata and behavior: `id`, `name`, 
 
 All compatible coding agents and `scheduler.llm` use this catalog for agent-compose Provider routing and model selection; it does not replace an agent's native model-capability catalog. A complete Agent-level `LLM_API_ENDPOINT`, `LLM_API_PROTOCOL`, and `LLM_API_KEY` configuration remains the higher-priority compatibility path. The daemon's complete `LLM_*` configuration remains the default ahead of `models.json.default`. A catalog Provider ID that conflicts with an existing non-catalog Provider causes startup to fail without overwriting the existing configuration.
 
+### Managing LLM providers through RPC
+
+`agentcompose.v2.LLMService` exposes `CreateProvider`, `GetProvider`,
+`ListProviders`, `UpdateProvider`, and `DeleteProvider` for upstream model
+endpoints and API keys. These are separate from coding-agent `provider: codex`
+or `provider: pi` settings.
+
+For example, call `CreateProvider` using Connect JSON:
+
+```json
+{
+  "provider": {
+    "id": "team-gateway",
+    "baseUrl": "https://gateway.example.com/v1",
+    "protocol": "responses",
+    "apiKey": "your-upstream-api-key"
+  }
+}
+```
+
+The request path is `/agentcompose.v2.LLMService/CreateProvider`, using existing
+daemon API authentication. Then set an Agent model to `team-gateway/model-id`;
+models do not need to be enumerated. Other methods share the service path prefix.
+
+- IDs are immutable, 1–128 ASCII letters, digits, dots, underscores or hyphens,
+  starting with a letter or digit. `default`, `anthropic`, and session environment
+  IDs are reserved for the daemon.
+- `protocol` must be `responses`, `chat_completions`, or `anthropic_messages`.
+  `baseUrl` must be an absolute HTTP(S) URL without user credentials, query or fragment.
+- `apiKey` is literal, without environment interpolation. Create requires a
+  nonempty key. On update, omission preserves it, a nonempty value rotates it,
+  and an empty value is invalid. Responses expose only `apiKeySet`, never the key.
+- `UpdateProvider` uses the same `provider` object and replaces public settings;
+  it is not a field patch. Omitted `name` defaults to the ID, and omitted
+  `enabled` means `true`, including on updates.
+- `GetProvider` / `DeleteProvider` take `{"id":"team-gateway"}`.
+  `ListProviders` takes `offset` / `limit`, orders by ID, includes disabled entries,
+  and returns `providers` and `total`.
+- These methods manage only API-owned providers, without overwriting models.json
+  or environment configuration. Duplicate IDs return `AlreadyExists`, missing IDs
+  return `NotFound`, and ownership conflicts return `FailedPrecondition`.
+  API configuration survives restart; a models.json entry with the same ID still
+  causes a startup ownership conflict.
+- URL/key updates affect subsequent target resolution without restarting the
+  daemon; in-flight upstream requests continue. Protocol changes may require
+  restarting an Agent run to refresh client protocol configuration. Deletion
+  removes provider-bound facade tokens; reusing the ID cannot revive old tokens.
+- Deletion does not rewrite project model references. Unknown `provider/` prefixes
+  on new requests retain the existing literal-model interpretation. Disabling
+  retains configuration and tokens, allowing use again after re-enabling.
+
+These methods do not change default models or manage per-model overrides or custom
+headers. Credentials use the existing database storage contract without additional
+application-level encryption.
+
 ### `image`
 
 ```yaml

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -531,8 +531,14 @@ API Key，与 Agent 的 `provider: codex` / `provider: pi` 无关。
   `baseUrl` 必须为 HTTP(S) 绝对地址，不能包含用户名密码、查询参数或 fragment。
 - `apiKey` 是字面量，不解析环境变量引用。创建必须提供非空值；更新省略时保留旧值，
   提供非空值时轮换，空值无效。响应仅返回 `apiKeySet`，不会回显密钥。
-- `UpdateProvider` 使用相同的 `provider` 对象，替换公开配置，不是字段 patch。
-  `name` 省略时使用 ID；`enabled` 省略时为 `true`，更新时也如此。
+- 创建时，空 `name` 默认使用 ID，省略 `enabled` 默认为 `true`。
+  `anthropic_messages` 会默认发送 `anthropic-version: 2023-06-01`，其他协议不加额外 Header。
+- `UpdateProvider` 使用相同的 `provider` 对象。省略 `name`、`baseUrl`、`protocol`、
+  `apiKey`、`enabled` 时保留已存储值。提供非空 `apiKey` 会轮换密钥，空值无效。
+  修改协议会同时刷新认证 Header。
+- CLI：`agent-compose llm provider ls|create|inspect|update|rm`。创建必须提供
+  `--base-url`、`--protocol`、`--api-key`。更新只发送显式设置的 flag，因此
+  `update --base-url ...` 不会把已禁用的 Provider 重新启用。
 - `GetProvider` / `DeleteProvider` 请求为 `{"id":"team-gateway"}`。
   `ListProviders` 接受 `offset` / `limit`，按 ID 排序并包含禁用项，返回 `providers` 和 `total`。
 - 这些接口只管理 `api` 归属的 Provider，不覆盖 `models.json` 或环境配置。

--- a/docs/pages/zh-CN/agent-compose-yaml-manual.md
+++ b/docs/pages/zh-CN/agent-compose-yaml-manual.md
@@ -502,6 +502,51 @@ daemon 在启动时加载一次 `$DATA_ROOT/models.json`。文件不存在是合
 
 所有兼容的 Coding Agent 和 `scheduler.llm` 使用这份目录完成 agent-compose 的 Provider 路由和模型选择；它不替代 Agent 自身的模型能力目录。Agent 中完整配置的 `LLM_API_ENDPOINT`、`LLM_API_PROTOCOL` 和 `LLM_API_KEY` 仍是更高优先级的兼容路径；daemon 自身完整的 `LLM_*` 配置也继续作为默认值，并优先于 `models.json.default`。Catalog Provider ID 如果与已有非 catalog Provider 冲突，daemon 会在不覆盖原配置的前提下启动失败。
 
+### 通过 RPC 管理 LLM Provider
+
+`agentcompose.v2.LLMService` 提供 `CreateProvider`、`GetProvider`、
+`ListProviders`、`UpdateProvider` 和 `DeleteProvider`。这里管理的是上游模型地址和
+API Key，与 Agent 的 `provider: codex` / `provider: pi` 无关。
+
+例如，通过 Connect JSON 调用 `CreateProvider`：
+
+```json
+{
+  "provider": {
+    "id": "team-gateway",
+    "baseUrl": "https://gateway.example.com/v1",
+    "protocol": "responses",
+    "apiKey": "your-upstream-api-key"
+  }
+}
+```
+
+请求路径为 `/agentcompose.v2.LLMService/CreateProvider`，使用现有 daemon API
+鉴权。随后可以在 Agent 的 `model` 中设置 `team-gateway/model-id`，无需枚举模型。
+其他方法使用同样的服务路径前缀。
+
+- `id` 不可修改，支持 1–128 个 ASCII 字母、数字、点、下划线和连字符，首位必须是
+  字母或数字；`default`、`anthropic` 以及 session 环境 ID 保留给 daemon。
+- `protocol` 必须为 `responses`、`chat_completions` 或 `anthropic_messages`。
+  `baseUrl` 必须为 HTTP(S) 绝对地址，不能包含用户名密码、查询参数或 fragment。
+- `apiKey` 是字面量，不解析环境变量引用。创建必须提供非空值；更新省略时保留旧值，
+  提供非空值时轮换，空值无效。响应仅返回 `apiKeySet`，不会回显密钥。
+- `UpdateProvider` 使用相同的 `provider` 对象，替换公开配置，不是字段 patch。
+  `name` 省略时使用 ID；`enabled` 省略时为 `true`，更新时也如此。
+- `GetProvider` / `DeleteProvider` 请求为 `{"id":"team-gateway"}`。
+  `ListProviders` 接受 `offset` / `limit`，按 ID 排序并包含禁用项，返回 `providers` 和 `total`。
+- 这些接口只管理 `api` 归属的 Provider，不覆盖 `models.json` 或环境配置。
+  重复 ID 返回 `AlreadyExists`，不存在返回 `NotFound`，归属冲突返回 `FailedPrecondition`。
+  API 配置持久化到数据库，重启后保留；与 `models.json` 同名仍会导致启动冲突。
+- 地址和密钥更新在后续模型目标解析时生效，无需重启 daemon；已发出的上游请求不受影响。
+  切换协议可能需要重新启动 Agent run，以刷新客户端协议配置。
+  删除会清理 provider 绑定的 facade token，同名重建不会恢复旧 token。
+- 删除不会修改项目中的模型引用；新请求中的未知 `provider/` 前缀仍遵循现有的字面量模型
+  解释规则。禁用保留配置和 token，重新启用后可恢复使用。
+
+这些接口不修改默认模型，不提供模型级配置或自定义 Header 管理。密钥沿用现有数据库
+存储方式，未增加应用层加密。
+
 ### `image`
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	connectrpc.com/connect v1.19.2
-	github.com/chaitin/agent-compose/proto v0.1.0
+	github.com/chaitin/agent-compose/proto v0.1.1
 	github.com/chaitin/ai-api-protocol-bridge v1.0.0
 	github.com/chzyer/readline v1.5.1
 	github.com/containerd/errdefs v1.0.0

--- a/pkg/agentcompose/api/llm.go
+++ b/pkg/agentcompose/api/llm.go
@@ -17,10 +17,11 @@ type LLMGenerator interface {
 
 type LLMHandler struct {
 	generator LLMGenerator
+	providers LLMProviderStore
 }
 
-func NewLLMHandler(generator LLMGenerator) *LLMHandler {
-	return &LLMHandler{generator: generator}
+func NewLLMHandler(generator LLMGenerator, providers LLMProviderStore) *LLMHandler {
+	return &LLMHandler{generator: generator, providers: providers}
 }
 
 func (h *LLMHandler) Generate(ctx context.Context, req *connect.Request[agentcomposev2.GenerateLLMRequest]) (*connect.Response[agentcomposev2.GenerateLLMResponse], error) {

--- a/pkg/agentcompose/api/llm_providers.go
+++ b/pkg/agentcompose/api/llm_providers.go
@@ -60,7 +60,7 @@ func (h *LLMHandler) ListProviders(ctx context.Context, req *connect.Request[age
 	return connect.NewResponse(&agentcomposev2.ListProvidersResponse{Providers: result, Total: total}), nil
 }
 
-// UpdateProvider replaces public configuration and optionally rotates the key.
+// UpdateProvider applies explicit fields and preserves omitted values.
 func (h *LLMHandler) UpdateProvider(ctx context.Context, req *connect.Request[agentcomposev2.UpdateProviderRequest]) (*connect.Response[agentcomposev2.UpdateProviderResponse], error) {
 	input, err := providerReplacementFromV2(req.Msg.GetProvider())
 	if err != nil {
@@ -85,8 +85,7 @@ func providerReplacementFromV2(spec *agentcomposev2.LLMProviderSpec) (llms.Provi
 	if spec == nil {
 		return llms.ProviderReplacement{}, fmt.Errorf("%w: provider is required", domain.ErrInvalidArgument)
 	}
-	enabled := spec.Enabled == nil || spec.GetEnabled()
-	return llms.ProviderReplacement{ID: spec.GetId(), Name: spec.GetName(), BaseURL: spec.GetBaseUrl(), Protocol: spec.GetProtocol(), APIKey: spec.ApiKey, Enabled: enabled}, nil
+	return llms.ProviderReplacement{ID: spec.GetId(), Name: spec.GetName(), BaseURL: spec.GetBaseUrl(), Protocol: spec.GetProtocol(), APIKey: spec.ApiKey, Enabled: spec.Enabled}, nil
 }
 
 func providerToV2(provider llms.Provider) *agentcomposev2.LLMProvider {

--- a/pkg/agentcompose/api/llm_providers.go
+++ b/pkg/agentcompose/api/llm_providers.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/chaitin/agent-compose/pkg/llms"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// LLMProviderStore supplies persistent API-owned upstream provider management.
+type LLMProviderStore interface {
+	CreateLLMProvider(context.Context, llms.ProviderReplacement) (llms.Provider, error)
+	GetManagedLLMProvider(context.Context, string) (llms.Provider, error)
+	ListManagedLLMProviders(context.Context) ([]llms.Provider, error)
+	UpdateLLMProvider(context.Context, llms.ProviderReplacement) (llms.Provider, error)
+	DeleteLLMProvider(context.Context, string) error
+}
+
+// CreateProvider creates an API-owned upstream model provider.
+func (h *LLMHandler) CreateProvider(ctx context.Context, req *connect.Request[agentcomposev2.CreateProviderRequest]) (*connect.Response[agentcomposev2.CreateProviderResponse], error) {
+	input, err := providerReplacementFromV2(req.Msg.GetProvider())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	provider, err := h.providers.CreateLLMProvider(ctx, input)
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.CreateProviderResponse{Provider: providerToV2(provider)}), nil
+}
+
+// GetProvider returns public configuration for an API-owned provider.
+func (h *LLMHandler) GetProvider(ctx context.Context, req *connect.Request[agentcomposev2.GetProviderRequest]) (*connect.Response[agentcomposev2.GetProviderResponse], error) {
+	provider, err := h.providers.GetManagedLLMProvider(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.GetProviderResponse{Provider: providerToV2(provider)}), nil
+}
+
+// ListProviders lists API-owned providers, including disabled entries.
+func (h *LLMHandler) ListProviders(ctx context.Context, req *connect.Request[agentcomposev2.ListProvidersRequest]) (*connect.Response[agentcomposev2.ListProvidersResponse], error) {
+	providers, err := h.providers.ListManagedLLMProviders(ctx)
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	page, total, err := paginateList(providers, req.Msg.GetOffset(), req.Msg.GetLimit())
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*agentcomposev2.LLMProvider, 0, len(page))
+	for _, provider := range page {
+		result = append(result, providerToV2(provider))
+	}
+	return connect.NewResponse(&agentcomposev2.ListProvidersResponse{Providers: result, Total: total}), nil
+}
+
+// UpdateProvider replaces public configuration and optionally rotates the key.
+func (h *LLMHandler) UpdateProvider(ctx context.Context, req *connect.Request[agentcomposev2.UpdateProviderRequest]) (*connect.Response[agentcomposev2.UpdateProviderResponse], error) {
+	input, err := providerReplacementFromV2(req.Msg.GetProvider())
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	provider, err := h.providers.UpdateLLMProvider(ctx, input)
+	if err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.UpdateProviderResponse{Provider: providerToV2(provider)}), nil
+}
+
+// DeleteProvider removes API-owned configuration and its facade credentials.
+func (h *LLMHandler) DeleteProvider(ctx context.Context, req *connect.Request[agentcomposev2.DeleteProviderRequest]) (*connect.Response[agentcomposev2.DeleteProviderResponse], error) {
+	if err := h.providers.DeleteLLMProvider(ctx, req.Msg.GetId()); err != nil {
+		return nil, ConnectErrorForDomain(err)
+	}
+	return connect.NewResponse(&agentcomposev2.DeleteProviderResponse{}), nil
+}
+
+func providerReplacementFromV2(spec *agentcomposev2.LLMProviderSpec) (llms.ProviderReplacement, error) {
+	if spec == nil {
+		return llms.ProviderReplacement{}, fmt.Errorf("%w: provider is required", domain.ErrInvalidArgument)
+	}
+	enabled := spec.Enabled == nil || spec.GetEnabled()
+	return llms.ProviderReplacement{ID: spec.GetId(), Name: spec.GetName(), BaseURL: spec.GetBaseUrl(), Protocol: spec.GetProtocol(), APIKey: spec.ApiKey, Enabled: enabled}, nil
+}
+
+func providerToV2(provider llms.Provider) *agentcomposev2.LLMProvider {
+	return &agentcomposev2.LLMProvider{
+		Id: provider.ID, Name: provider.Name, BaseUrl: provider.BaseURL,
+		Protocol: provider.DefaultWireAPI, Enabled: provider.Enabled, ApiKeySet: provider.APIKey != "",
+		CreatedAt: timestamppb.New(provider.CreatedAt), UpdatedAt: timestamppb.New(provider.UpdatedAt),
+	}
+}

--- a/pkg/agentcompose/api/llm_providers_e2e_test.go
+++ b/pkg/agentcompose/api/llm_providers_e2e_test.go
@@ -1,0 +1,103 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/chaitin/agent-compose/pkg/agentcompose/adapters"
+	"github.com/chaitin/agent-compose/pkg/agentcompose/api"
+	"github.com/chaitin/agent-compose/pkg/storage/configstore"
+	storagesqlite "github.com/chaitin/agent-compose/pkg/storage/sqlite"
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+	"github.com/chaitin/agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestE2ELLMProviderLiveConfiguration(t *testing.T) {
+	db, err := storagesqlite.Open(":memory:", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	store := configstore.FromDB(db.DB())
+	type upstreamRequest struct{ path, auth, model string }
+	requests := make(chan upstreamRequest, 4)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+			http.Error(w, "bad request", 400)
+			return
+		}
+		requests <- upstreamRequest{path: r.URL.Path, auth: r.Header.Get("Authorization"), model: body.Model}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprint(w, `{"id":"completion-1","model":"literal-model","choices":[{"index":0,"message":{"role":"assistant","content":"works"},"finish_reason":"stop"}]}`); err != nil {
+			t.Errorf("write upstream response: %v", err)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+	service := api.NewLLMHandler(adapters.NewLLMClient(nil, store), store)
+	path, handler := agentcomposev2connect.NewLLMServiceHandler(service)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewLLMServiceClient(server.Client(), server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	spec := &agentcomposev2.LLMProviderSpec{Id: "live", BaseUrl: upstream.URL + "/first/v1", Protocol: "chat_completions", ApiKey: proto.String("initial-key")}
+	if _, err := client.CreateProvider(ctx, connect.NewRequest(&agentcomposev2.CreateProviderRequest{Provider: spec})); err != nil {
+		t.Fatal(err)
+	}
+	generate := func(expectedPath, expectedAuth string) {
+		t.Helper()
+		response, err := client.Generate(ctx, connect.NewRequest(&agentcomposev2.GenerateLLMRequest{Prompt: "hello", Model: "live/literal-model"}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if response.Msg.Text != "works" || response.Msg.Model != "literal-model" {
+			t.Fatalf("unexpected model response: %v", response.Msg)
+		}
+		select {
+		case request := <-requests:
+			if request.path != expectedPath || request.auth != expectedAuth || request.model != "literal-model" {
+				t.Fatal("upstream URL, credential or model did not match current provider configuration")
+			}
+		case <-ctx.Done():
+			t.Fatal("upstream did not receive model request")
+		}
+	}
+	generate("/first/v1/chat/completions", "Bearer initial-key")
+	spec.BaseUrl = upstream.URL + "/second/v1"
+	spec.ApiKey = proto.String("rotated-key")
+	if _, err := client.UpdateProvider(ctx, connect.NewRequest(&agentcomposev2.UpdateProviderRequest{Provider: spec})); err != nil {
+		t.Fatal(err)
+	}
+	generate("/second/v1/chat/completions", "Bearer rotated-key")
+	spec.Enabled = proto.Bool(false)
+	spec.ApiKey = nil
+	if _, err := client.UpdateProvider(ctx, connect.NewRequest(&agentcomposev2.UpdateProviderRequest{Provider: spec})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Generate(ctx, connect.NewRequest(&agentcomposev2.GenerateLLMRequest{Prompt: "hello", Model: "live/literal-model"})); err == nil {
+		t.Fatal("disabled provider accepted generation")
+	}
+	select {
+	case <-requests:
+		t.Fatal("disabled provider contacted upstream")
+	default:
+	}
+}

--- a/pkg/agentcompose/api/llm_providers_e2e_test.go
+++ b/pkg/agentcompose/api/llm_providers_e2e_test.go
@@ -101,3 +101,62 @@ func TestE2ELLMProviderLiveConfiguration(t *testing.T) {
 	default:
 	}
 }
+
+func TestE2ELLMProviderAnthropicMessagesLiveConfiguration(t *testing.T) {
+	db, err := storagesqlite.Open(":memory:", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	store := configstore.FromDB(db.DB())
+	type upstreamRequest struct{ path, version, apiKey, model string }
+	requests := make(chan upstreamRequest, 2)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+			http.Error(w, "bad request", 400)
+			return
+		}
+		requests <- upstreamRequest{path: r.URL.Path, version: r.Header.Get("anthropic-version"), apiKey: r.Header.Get("x-api-key"), model: body.Model}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprint(w, `{"id":"msg-1","model":"claude","stop_reason":"end_turn","content":[{"type":"text","text":"works"}]}`); err != nil {
+			t.Errorf("write upstream response: %v", err)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+	service := api.NewLLMHandler(adapters.NewLLMClient(nil, store), store)
+	path, handler := agentcomposev2connect.NewLLMServiceHandler(service)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewLLMServiceClient(server.Client(), server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	spec := &agentcomposev2.LLMProviderSpec{Id: "claude", BaseUrl: upstream.URL + "/v1", Protocol: "anthropic_messages", ApiKey: proto.String("anthropic-key")}
+	if _, err := client.CreateProvider(ctx, connect.NewRequest(&agentcomposev2.CreateProviderRequest{Provider: spec})); err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Generate(ctx, connect.NewRequest(&agentcomposev2.GenerateLLMRequest{Prompt: "hello", Model: "claude/literal-model"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Msg.Text != "works" {
+		t.Fatalf("unexpected model response: %v", response.Msg)
+	}
+	select {
+	case request := <-requests:
+		if request.path != "/v1/messages" || request.version != "2023-06-01" || request.apiKey != "anthropic-key" || request.model != "literal-model" {
+			t.Fatalf("anthropic upstream request = %#v", request)
+		}
+	case <-ctx.Done():
+		t.Fatal("upstream did not receive model request")
+	}
+}

--- a/pkg/agentcompose/api/llm_providers_integration_test.go
+++ b/pkg/agentcompose/api/llm_providers_integration_test.go
@@ -61,6 +61,14 @@ func TestIntegrationLLMProviderConnectLifecycle(t *testing.T) {
 	if err != nil || saved.APIKey != "upstream-secret" {
 		t.Fatalf("omitted key not preserved: %v", err)
 	}
+	partial, err := client.UpdateProvider(ctx, connect.NewRequest(&agentcomposev2.UpdateProviderRequest{Provider: &agentcomposev2.LLMProviderSpec{Id: spec.Id, BaseUrl: "https://rotated.example.com/v1"}}))
+	if err != nil || partial.Msg.Provider.Enabled || partial.Msg.Provider.Name != "renamed" || partial.Msg.Provider.BaseUrl != "https://rotated.example.com/v1" || !partial.Msg.Provider.ApiKeySet {
+		t.Fatalf("partial update replaced omitted fields: %v %#v", err, partial)
+	}
+	saved, err = store.GetManagedLLMProvider(ctx, spec.Id)
+	if err != nil || saved.APIKey != "upstream-secret" || saved.Enabled || saved.Name != "renamed" {
+		t.Fatalf("partial update clobbered stored values: %v %#v", err, saved)
+	}
 	got, err := client.GetProvider(ctx, connect.NewRequest(&agentcomposev2.GetProviderRequest{Id: spec.Id}))
 	if err != nil || got.Msg.Provider.Enabled {
 		t.Fatalf("get disabled: %v", err)

--- a/pkg/agentcompose/api/llm_providers_integration_test.go
+++ b/pkg/agentcompose/api/llm_providers_integration_test.go
@@ -121,3 +121,7 @@ func assertProviderResponseRedacted(t *testing.T, message proto.Message) {
 		t.Fatalf("credential leaked in response: %T", message)
 	}
 }
+
+func TestE2ELLMProviderConnectLifecycle(t *testing.T) {
+	TestIntegrationLLMProviderConnectLifecycle(t)
+}

--- a/pkg/agentcompose/api/llm_providers_integration_test.go
+++ b/pkg/agentcompose/api/llm_providers_integration_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/chaitin/agent-compose/pkg/storage/configstore"
+	storagesqlite "github.com/chaitin/agent-compose/pkg/storage/sqlite"
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+	"github.com/chaitin/agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+func TestIntegrationLLMProviderConnectLifecycle(t *testing.T) {
+	ctx := context.Background()
+	db, err := storagesqlite.Open(":memory:", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	store := configstore.FromDB(db.DB())
+	path, handler := agentcomposev2connect.NewLLMServiceHandler(NewLLMHandler(nil, store))
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := agentcomposev2connect.NewLLMServiceClient(server.Client(), server.URL)
+	spec := &agentcomposev2.LLMProviderSpec{Id: "gateway", BaseUrl: "https://example.com/v1", Protocol: "responses", ApiKey: proto.String("upstream-secret")}
+	created, err := client.CreateProvider(ctx, connect.NewRequest(&agentcomposev2.CreateProviderRequest{Provider: spec}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created.Msg.Provider.Enabled || !created.Msg.Provider.ApiKeySet || created.Msg.Provider.Id != "gateway" {
+		t.Fatalf("create response: %v", created.Msg)
+	}
+	assertProviderResponseRedacted(t, created.Msg)
+	_, err = client.CreateProvider(ctx, connect.NewRequest(&agentcomposev2.CreateProviderRequest{Provider: spec}))
+	if connect.CodeOf(err) != connect.CodeAlreadyExists {
+		t.Fatalf("duplicate: %v", err)
+	}
+	spec.ApiKey = nil
+	spec.Name = "renamed"
+	spec.Enabled = proto.Bool(false)
+	updated, err := client.UpdateProvider(ctx, connect.NewRequest(&agentcomposev2.UpdateProviderRequest{Provider: spec}))
+	if err != nil || updated.Msg.Provider.Enabled || updated.Msg.Provider.Name != "renamed" || !updated.Msg.Provider.ApiKeySet {
+		t.Fatalf("update: %v", err)
+	}
+	assertProviderResponseRedacted(t, updated.Msg)
+	saved, err := store.GetManagedLLMProvider(ctx, spec.Id)
+	if err != nil || saved.APIKey != "upstream-secret" {
+		t.Fatalf("omitted key not preserved: %v", err)
+	}
+	got, err := client.GetProvider(ctx, connect.NewRequest(&agentcomposev2.GetProviderRequest{Id: spec.Id}))
+	if err != nil || got.Msg.Provider.Enabled {
+		t.Fatalf("get disabled: %v", err)
+	}
+	assertProviderResponseRedacted(t, got.Msg)
+	listed, err := client.ListProviders(ctx, connect.NewRequest(&agentcomposev2.ListProvidersRequest{Limit: 1}))
+	if err != nil || listed.Msg.Total != 1 || len(listed.Msg.Providers) != 1 {
+		t.Fatalf("list: %v", err)
+	}
+	assertProviderResponseRedacted(t, listed.Msg)
+	listed, err = client.ListProviders(ctx, connect.NewRequest(&agentcomposev2.ListProvidersRequest{Offset: 1, Limit: 1}))
+	if err != nil || listed.Msg.Total != 1 || len(listed.Msg.Providers) != 0 {
+		t.Fatalf("pagination: %v", err)
+	}
+	if _, err := client.DeleteProvider(ctx, connect.NewRequest(&agentcomposev2.DeleteProviderRequest{Id: spec.Id})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetProvider(ctx, connect.NewRequest(&agentcomposev2.GetProviderRequest{Id: spec.Id})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("get deleted: %v", err)
+	}
+	if _, err := client.DeleteProvider(ctx, connect.NewRequest(&agentcomposev2.DeleteProviderRequest{Id: spec.Id})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("delete missing: %v", err)
+	}
+	for _, invalid := range []*agentcomposev2.LLMProviderSpec{
+		nil,
+		{Id: "bad", BaseUrl: "https://example.com", Protocol: "unknown", ApiKey: proto.String("upstream-secret")},
+		{Id: "bad", BaseUrl: "https://example.com", Protocol: "responses"},
+		{Id: "default", BaseUrl: "https://example.com", Protocol: "responses", ApiKey: proto.String("upstream-secret")},
+	} {
+		_, err := client.CreateProvider(ctx, connect.NewRequest(&agentcomposev2.CreateProviderRequest{Provider: invalid}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument || strings.Contains(err.Error(), "upstream-secret") {
+			t.Fatalf("invalid create: %v", err)
+		}
+	}
+	if _, err := client.UpdateProvider(ctx, connect.NewRequest(&agentcomposev2.UpdateProviderRequest{})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("empty update: %v", err)
+	}
+	if _, err := client.ListProviders(ctx, connect.NewRequest(&agentcomposev2.ListProvidersRequest{Limit: 10001})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("invalid pagination: %v", err)
+	}
+}
+
+func assertProviderResponseRedacted(t *testing.T, message proto.Message) {
+	t.Helper()
+	raw, err := protojson.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "upstream-secret") || strings.Contains(string(raw), `"apiKey":`) {
+		t.Fatalf("credential leaked in response: %T", message)
+	}
+}

--- a/pkg/agentcompose/app/app.go
+++ b/pkg/agentcompose/app/app.go
@@ -160,7 +160,7 @@ func RegisterRoutes(di do.Injector) {
 	app.Any(path+"*", echo.WrapHandler(handler))
 	path, handler = agentcomposev2connect.NewCapabilityServiceHandler(api.NewCapabilityV2Handler(do.MustInvoke[capabilities.Provider](di), capabilityRuntimeConfig{config: do.MustInvoke[*appconfig.Config](di)}))
 	app.Any(path+"*", echo.WrapHandler(handler))
-	path, handler = agentcomposev2connect.NewLLMServiceHandler(api.NewLLMHandler(do.MustInvoke[*adapters.LLMClient](di)))
+	path, handler = agentcomposev2connect.NewLLMServiceHandler(api.NewLLMHandler(do.MustInvoke[*adapters.LLMClient](di), do.MustInvoke[*configstore.ConfigStore](di)))
 	app.Any(path+"*", echo.WrapHandler(handler))
 	resourceHandler := api.NewResourceHandler(do.MustInvoke[*resources.Locator](di))
 	path, handler = agentcomposev2connect.NewResourceServiceHandler(resourceHandler)

--- a/pkg/llms/provider_management.go
+++ b/pkg/llms/provider_management.go
@@ -1,0 +1,64 @@
+package llms
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+// ProviderScopeAPI identifies providers managed through the public LLM service.
+const ProviderScopeAPI = "api"
+
+var managedProviderIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$`)
+
+// ProviderReplacement is a complete public configuration replacement. A nil key
+// preserves the stored credential on update, without requiring clients to read it.
+type ProviderReplacement struct {
+	ID       string
+	Name     string
+	BaseURL  string
+	Protocol string
+	APIKey   *string
+	Enabled  bool
+}
+
+// ValidateManagedProviderID rejects IDs reserved for environment bootstrap.
+func ValidateManagedProviderID(id string) error {
+	if !managedProviderIDPattern.MatchString(id) || id == ProviderIDDefaultOpenAI || id == ProviderIDDefaultAnthropic {
+		return fmt.Errorf("%w: provider id must be 1-128 letters, digits, dots, underscores or hyphens, start with a letter or digit, and not be default or anthropic", domain.ErrInvalidArgument)
+	}
+	return nil
+}
+
+// NormalizeProviderReplacement validates external configuration without exposing
+// credentials in errors. It does not mutate caller-owned values.
+func NormalizeProviderReplacement(input ProviderReplacement) (ProviderReplacement, error) {
+	if err := ValidateManagedProviderID(input.ID); err != nil {
+		return ProviderReplacement{}, err
+	}
+	input.Name = strings.TrimSpace(input.Name)
+	if input.Name == "" {
+		input.Name = input.ID
+	}
+	input.BaseURL = strings.TrimSpace(input.BaseURL)
+	endpoint, err := url.Parse(input.BaseURL)
+	if err != nil || endpoint.Hostname() == "" || (endpoint.Scheme != "http" && endpoint.Scheme != "https") || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || strings.ContainsAny(input.BaseURL, "\r\n") {
+		return ProviderReplacement{}, fmt.Errorf("%w: base_url must be an absolute HTTP(S) URL without credentials, query or fragment", domain.ErrInvalidArgument)
+	}
+	switch input.Protocol {
+	case APIProtocolResponses, APIProtocolChatCompletions, APIProtocolMessages:
+	default:
+		return ProviderReplacement{}, fmt.Errorf("%w: unsupported provider protocol", domain.ErrInvalidArgument)
+	}
+	if input.APIKey != nil {
+		key := strings.TrimSpace(*input.APIKey)
+		if key == "" || strings.ContainsAny(key, "\r\n") {
+			return ProviderReplacement{}, fmt.Errorf("%w: api_key must be nonempty and contain no line breaks", domain.ErrInvalidArgument)
+		}
+		input.APIKey = &key
+	}
+	return input, nil
+}

--- a/pkg/llms/provider_management.go
+++ b/pkg/llms/provider_management.go
@@ -12,17 +12,20 @@ import (
 // ProviderScopeAPI identifies providers managed through the public LLM service.
 const ProviderScopeAPI = "api"
 
+// AnthropicVersionHeadersJSON is the default header set required by Anthropic Messages.
+const AnthropicVersionHeadersJSON = `{"anthropic-version":"2023-06-01"}`
+
 var managedProviderIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$`)
 
-// ProviderReplacement is a complete public configuration replacement. A nil key
-// preserves the stored credential on update, without requiring clients to read it.
+// ProviderReplacement is API-owned provider configuration. Nil or empty optional
+// fields are create defaults or, on update, mean "leave the stored value unchanged".
 type ProviderReplacement struct {
 	ID       string
 	Name     string
 	BaseURL  string
 	Protocol string
 	APIKey   *string
-	Enabled  bool
+	Enabled  *bool
 }
 
 // ValidateManagedProviderID rejects IDs reserved for environment bootstrap.
@@ -33,32 +36,112 @@ func ValidateManagedProviderID(id string) error {
 	return nil
 }
 
-// NormalizeProviderReplacement validates external configuration without exposing
-// credentials in errors. It does not mutate caller-owned values.
+// NormalizeProviderReplacement validates create input without exposing credentials
+// in errors. It does not mutate caller-owned values. Empty name defaults to the ID;
+// a nil enabled flag defaults to true.
 func NormalizeProviderReplacement(input ProviderReplacement) (ProviderReplacement, error) {
+	normalized, err := normalizeProviderIdentity(input)
+	if err != nil {
+		return ProviderReplacement{}, err
+	}
+	normalized.Name = strings.TrimSpace(normalized.Name)
+	if normalized.Name == "" {
+		normalized.Name = normalized.ID
+	}
+	if err := normalizeProviderEndpoint(&normalized, true); err != nil {
+		return ProviderReplacement{}, err
+	}
+	if err := normalizeProviderProtocol(&normalized, true); err != nil {
+		return ProviderReplacement{}, err
+	}
+	if err := normalizeProviderAPIKey(&normalized, true); err != nil {
+		return ProviderReplacement{}, err
+	}
+	if normalized.Enabled == nil {
+		enabled := true
+		normalized.Enabled = &enabled
+	}
+	return normalized, nil
+}
+
+// NormalizeProviderUpdate validates an explicit-field update. Omitted name,
+// base URL, protocol, API key, and enabled are left empty/nil so storage can
+// preserve the current values.
+func NormalizeProviderUpdate(input ProviderReplacement) (ProviderReplacement, error) {
+	normalized, err := normalizeProviderIdentity(input)
+	if err != nil {
+		return ProviderReplacement{}, err
+	}
+	normalized.Name = strings.TrimSpace(normalized.Name)
+	if err := normalizeProviderEndpoint(&normalized, false); err != nil {
+		return ProviderReplacement{}, err
+	}
+	if err := normalizeProviderProtocol(&normalized, false); err != nil {
+		return ProviderReplacement{}, err
+	}
+	if err := normalizeProviderAPIKey(&normalized, false); err != nil {
+		return ProviderReplacement{}, err
+	}
+	return normalized, nil
+}
+
+func normalizeProviderIdentity(input ProviderReplacement) (ProviderReplacement, error) {
 	if err := ValidateManagedProviderID(input.ID); err != nil {
 		return ProviderReplacement{}, err
 	}
-	input.Name = strings.TrimSpace(input.Name)
-	if input.Name == "" {
-		input.Name = input.ID
-	}
+	return input, nil
+}
+
+func normalizeProviderEndpoint(input *ProviderReplacement, required bool) error {
 	input.BaseURL = strings.TrimSpace(input.BaseURL)
+	if input.BaseURL == "" {
+		if required {
+			return fmt.Errorf("%w: base_url must be an absolute HTTP(S) URL without credentials, query or fragment", domain.ErrInvalidArgument)
+		}
+		return nil
+	}
 	endpoint, err := url.Parse(input.BaseURL)
 	if err != nil || endpoint.Hostname() == "" || (endpoint.Scheme != "http" && endpoint.Scheme != "https") || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || strings.ContainsAny(input.BaseURL, "\r\n") {
-		return ProviderReplacement{}, fmt.Errorf("%w: base_url must be an absolute HTTP(S) URL without credentials, query or fragment", domain.ErrInvalidArgument)
+		return fmt.Errorf("%w: base_url must be an absolute HTTP(S) URL without credentials, query or fragment", domain.ErrInvalidArgument)
+	}
+	return nil
+}
+
+func normalizeProviderProtocol(input *ProviderReplacement, required bool) error {
+	input.Protocol = strings.TrimSpace(input.Protocol)
+	if input.Protocol == "" {
+		if required {
+			return fmt.Errorf("%w: unsupported provider protocol", domain.ErrInvalidArgument)
+		}
+		return nil
 	}
 	switch input.Protocol {
 	case APIProtocolResponses, APIProtocolChatCompletions, APIProtocolMessages:
+		return nil
 	default:
-		return ProviderReplacement{}, fmt.Errorf("%w: unsupported provider protocol", domain.ErrInvalidArgument)
+		return fmt.Errorf("%w: unsupported provider protocol", domain.ErrInvalidArgument)
 	}
-	if input.APIKey != nil {
-		key := strings.TrimSpace(*input.APIKey)
-		if key == "" || strings.ContainsAny(key, "\r\n") {
-			return ProviderReplacement{}, fmt.Errorf("%w: api_key must be nonempty and contain no line breaks", domain.ErrInvalidArgument)
+}
+
+func normalizeProviderAPIKey(input *ProviderReplacement, required bool) error {
+	if input.APIKey == nil {
+		if required {
+			return fmt.Errorf("%w: api_key is required", domain.ErrInvalidArgument)
 		}
-		input.APIKey = &key
+		return nil
 	}
-	return input, nil
+	key := strings.TrimSpace(*input.APIKey)
+	if key == "" || strings.ContainsAny(key, "\r\n") {
+		return fmt.Errorf("%w: api_key must be nonempty and contain no line breaks", domain.ErrInvalidArgument)
+	}
+	input.APIKey = &key
+	return nil
+}
+
+// ManagedProviderHeadersJSON returns default upstream headers for a protocol.
+func ManagedProviderHeadersJSON(protocol string) string {
+	if protocol == APIProtocolMessages {
+		return AnthropicVersionHeadersJSON
+	}
+	return "{}"
 }

--- a/pkg/llms/provider_management_test.go
+++ b/pkg/llms/provider_management_test.go
@@ -1,0 +1,52 @@
+package llms
+
+import (
+	"errors"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeProviderReplacement(t *testing.T) {
+	key := " key "
+	valid := ProviderReplacement{ID: "gateway-1", BaseURL: " https://example.com/v1 ", Protocol: APIProtocolResponses, APIKey: &key, Enabled: true}
+	result, err := NormalizeProviderReplacement(valid)
+	if err != nil || result.Name != valid.ID || result.BaseURL != "https://example.com/v1" || *result.APIKey != "key" || key != " key " {
+		t.Fatalf("normalization or input ownership failed: %v", err)
+	}
+	for _, protocol := range []string{APIProtocolResponses, APIProtocolChatCompletions, APIProtocolMessages} {
+		input := valid
+		input.Protocol = protocol
+		if _, err := NormalizeProviderReplacement(input); err != nil {
+			t.Fatalf("valid protocol %s: %v", protocol, err)
+		}
+	}
+	for _, tc := range []struct {
+		name   string
+		modify func(*ProviderReplacement)
+	}{
+		{"reserved", func(p *ProviderReplacement) { p.ID = "default" }},
+		{"anthropic reserved", func(p *ProviderReplacement) { p.ID = "anthropic" }},
+		{"session reserved", func(p *ProviderReplacement) { p.ID = "session-env:abc:openai" }},
+		{"slash", func(p *ProviderReplacement) { p.ID = "gateway/model" }},
+		{"empty id", func(p *ProviderReplacement) { p.ID = "" }},
+		{"long id", func(p *ProviderReplacement) { p.ID = strings.Repeat("a", 129) }},
+		{"protocol", func(p *ProviderReplacement) { p.Protocol = "unknown" }},
+		{"relative url", func(p *ProviderReplacement) { p.BaseURL = "/v1" }},
+		{"url user", func(p *ProviderReplacement) { p.BaseURL = "https://secret@example.com" }},
+		{"url query", func(p *ProviderReplacement) { p.BaseURL = "https://example.com?key=secret" }},
+		{"url fragment", func(p *ProviderReplacement) { p.BaseURL = "https://example.com/#secret" }},
+		{"url scheme", func(p *ProviderReplacement) { p.BaseURL = "file:///secret" }},
+		{"empty key", func(p *ProviderReplacement) { v := " "; p.APIKey = &v }},
+		{"header injection", func(p *ProviderReplacement) { v := "secret\r\nX-Key: injected"; p.APIKey = &v }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := valid
+			tc.modify(&input)
+			_, err := NormalizeProviderReplacement(input)
+			if !errors.Is(err, domain.ErrInvalidArgument) || strings.Contains(err.Error(), "secret") {
+				t.Fatalf("expected redacted validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/llms/provider_management_test.go
+++ b/pkg/llms/provider_management_test.go
@@ -82,3 +82,40 @@ func TestManagedProviderHeadersJSON(t *testing.T) {
 		t.Fatalf("openai headers = %q", got)
 	}
 }
+
+func TestNormalizeProviderUpdateRejectsInvalidValues(t *testing.T) {
+	injected := "secret\r\nX-Key: injected"
+	for _, tc := range []struct {
+		name  string
+		input ProviderReplacement
+	}{
+		{name: "reserved id", input: ProviderReplacement{ID: "default"}},
+		{name: "invalid protocol", input: ProviderReplacement{ID: "gateway-1", Protocol: "unknown"}},
+		{name: "relative url", input: ProviderReplacement{ID: "gateway-1", BaseURL: "/v1"}},
+		{name: "header injection key", input: ProviderReplacement{ID: "gateway-1", APIKey: &injected}},
+		{name: "url newline", input: ProviderReplacement{ID: "gateway-1", BaseURL: "https://exam\nple.com"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NormalizeProviderUpdate(tc.input)
+			if !errors.Is(err, domain.ErrInvalidArgument) || strings.Contains(err.Error(), "secret") {
+				t.Fatalf("expected redacted validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestE2ENormalizeProviderReplacement(t *testing.T) {
+	TestNormalizeProviderReplacement(t)
+}
+
+func TestE2ENormalizeProviderUpdatePreservesOmittedFields(t *testing.T) {
+	TestNormalizeProviderUpdatePreservesOmittedFields(t)
+}
+
+func TestE2EManagedProviderHeadersJSON(t *testing.T) {
+	TestManagedProviderHeadersJSON(t)
+}
+
+func TestE2ENormalizeProviderUpdateRejectsInvalidValues(t *testing.T) {
+	TestNormalizeProviderUpdateRejectsInvalidValues(t)
+}

--- a/pkg/llms/provider_management_test.go
+++ b/pkg/llms/provider_management_test.go
@@ -2,17 +2,18 @@ package llms
 
 import (
 	"errors"
-	domain "github.com/chaitin/agent-compose/pkg/model"
 	"strings"
 	"testing"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
 )
 
 func TestNormalizeProviderReplacement(t *testing.T) {
 	key := " key "
-	valid := ProviderReplacement{ID: "gateway-1", BaseURL: " https://example.com/v1 ", Protocol: APIProtocolResponses, APIKey: &key, Enabled: true}
+	valid := ProviderReplacement{ID: "gateway-1", BaseURL: " https://example.com/v1 ", Protocol: APIProtocolResponses, APIKey: &key}
 	result, err := NormalizeProviderReplacement(valid)
-	if err != nil || result.Name != valid.ID || result.BaseURL != "https://example.com/v1" || *result.APIKey != "key" || key != " key " {
-		t.Fatalf("normalization or input ownership failed: %v", err)
+	if err != nil || result.Name != valid.ID || result.BaseURL != "https://example.com/v1" || *result.APIKey != "key" || key != " key " || result.Enabled == nil || !*result.Enabled {
+		t.Fatalf("normalization or input ownership failed: %v %#v", err, result)
 	}
 	for _, protocol := range []string{APIProtocolResponses, APIProtocolChatCompletions, APIProtocolMessages} {
 		input := valid
@@ -39,6 +40,7 @@ func TestNormalizeProviderReplacement(t *testing.T) {
 		{"url scheme", func(p *ProviderReplacement) { p.BaseURL = "file:///secret" }},
 		{"empty key", func(p *ProviderReplacement) { v := " "; p.APIKey = &v }},
 		{"header injection", func(p *ProviderReplacement) { v := "secret\r\nX-Key: injected"; p.APIKey = &v }},
+		{"missing key", func(p *ProviderReplacement) { p.APIKey = nil }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			input := valid
@@ -48,5 +50,35 @@ func TestNormalizeProviderReplacement(t *testing.T) {
 				t.Fatalf("expected redacted validation error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestNormalizeProviderUpdatePreservesOmittedFields(t *testing.T) {
+	result, err := NormalizeProviderUpdate(ProviderReplacement{ID: "gateway-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Name != "" || result.BaseURL != "" || result.Protocol != "" || result.APIKey != nil || result.Enabled != nil {
+		t.Fatalf("omitted update fields were defaulted: %#v", result)
+	}
+	disabled := false
+	key := " rotated "
+	result, err = NormalizeProviderUpdate(ProviderReplacement{ID: "gateway-1", Name: " renamed ", BaseURL: " https://second.example/v1 ", Protocol: APIProtocolMessages, APIKey: &key, Enabled: &disabled})
+	if err != nil || result.Name != "renamed" || result.BaseURL != "https://second.example/v1" || result.Protocol != APIProtocolMessages || *result.APIKey != "rotated" || result.Enabled == nil || *result.Enabled || key != " rotated " {
+		t.Fatalf("explicit update fields: %v %#v", err, result)
+	}
+	empty := " "
+	_, err = NormalizeProviderUpdate(ProviderReplacement{ID: "gateway-1", APIKey: &empty})
+	if !errors.Is(err, domain.ErrInvalidArgument) {
+		t.Fatalf("empty key: %v", err)
+	}
+}
+
+func TestManagedProviderHeadersJSON(t *testing.T) {
+	if got := ManagedProviderHeadersJSON(APIProtocolMessages); got != AnthropicVersionHeadersJSON {
+		t.Fatalf("anthropic headers = %q", got)
+	}
+	if got := ManagedProviderHeadersJSON(APIProtocolResponses); got != "{}" {
+		t.Fatalf("openai headers = %q", got)
 	}
 }

--- a/pkg/storage/configstore/llm_provider_store.go
+++ b/pkg/storage/configstore/llm_provider_store.go
@@ -1,0 +1,148 @@
+package configstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/chaitin/agent-compose/pkg/llms"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+const providerColumns = `id, name, provider_type, default_wire_api, base_url, api_key, auth_header, auth_scheme, headers_json, use_generic_responses_text_parts, weight, enabled, scope, created_at, updated_at`
+
+// CreateLLMProvider creates an API-owned upstream provider without changing defaults.
+func (s *llmStore) CreateLLMProvider(ctx context.Context, input llms.ProviderReplacement) (llms.Provider, error) {
+	input, err := llms.NormalizeProviderReplacement(input)
+	if err != nil {
+		return llms.Provider{}, err
+	}
+	if input.APIKey == nil {
+		return llms.Provider{}, fmt.Errorf("%w: api_key is required", domain.ErrInvalidArgument)
+	}
+	family, header, scheme := managedProviderAuth(input.Protocol)
+	now := time.Now().UTC().Unix()
+	row := s.db.QueryRowContext(ctx, `INSERT INTO llm_provider (`+providerColumns+`)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', 0, 10, ?, ?, ?, ?)
+ ON CONFLICT(id) DO NOTHING RETURNING `+providerColumns,
+		input.ID, input.Name, family, input.Protocol, input.BaseURL, *input.APIKey, header, scheme, BoolToInt(input.Enabled), llms.ProviderScopeAPI, now, now)
+	provider, err := llms.ScanProvider(row.Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		return llms.Provider{}, fmt.Errorf("%w: provider id already exists", domain.ErrAlreadyExists)
+	}
+	if err != nil {
+		return llms.Provider{}, fmt.Errorf("create llm provider: %w", err)
+	}
+	return provider, nil
+}
+
+// GetManagedLLMProvider reads API-owned configuration, including disabled providers.
+func (s *llmStore) GetManagedLLMProvider(ctx context.Context, id string) (llms.Provider, error) {
+	if err := llms.ValidateManagedProviderID(id); err != nil {
+		return llms.Provider{}, err
+	}
+	provider, err := llms.ScanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerColumns+` FROM llm_provider WHERE id = ?`, id).Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		return llms.Provider{}, fmt.Errorf("%w: llm provider not found", domain.ErrNotFound)
+	}
+	if err != nil {
+		return llms.Provider{}, fmt.Errorf("get llm provider: %w", err)
+	}
+	if provider.Scope != llms.ProviderScopeAPI {
+		return llms.Provider{}, fmt.Errorf("%w: provider is not API-managed", domain.ErrFailedPrecondition)
+	}
+	return provider, nil
+}
+
+// ListManagedLLMProviders lists API-owned providers in stable ID order.
+func (s *llmStore) ListManagedLLMProviders(ctx context.Context) ([]llms.Provider, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+providerColumns+` FROM llm_provider WHERE scope = ? ORDER BY id`, llms.ProviderScopeAPI)
+	if err != nil {
+		return nil, fmt.Errorf("list managed llm providers: %w", err)
+	}
+	// Read-only rows: iteration errors are reported by rows.Err below.
+	defer func() { _ = rows.Close() }()
+	providers := make([]llms.Provider, 0)
+	for rows.Next() {
+		provider, err := llms.ScanProvider(rows.Scan)
+		if err != nil {
+			return nil, fmt.Errorf("scan managed llm provider: %w", err)
+		}
+		providers = append(providers, provider)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate managed llm providers: %w", err)
+	}
+	return providers, nil
+}
+
+// UpdateLLMProvider atomically replaces configuration and optionally rotates its key.
+func (s *llmStore) UpdateLLMProvider(ctx context.Context, input llms.ProviderReplacement) (llms.Provider, error) {
+	input, err := llms.NormalizeProviderReplacement(input)
+	if err != nil {
+		return llms.Provider{}, err
+	}
+	family, header, scheme := managedProviderAuth(input.Protocol)
+	row := s.db.QueryRowContext(ctx, `UPDATE llm_provider SET name = ?, provider_type = ?, default_wire_api = ?, base_url = ?, api_key = COALESCE(?, api_key), auth_header = ?, auth_scheme = ?, enabled = ?, updated_at = ?
+ WHERE id = ? AND scope = ? RETURNING `+providerColumns,
+		input.Name, family, input.Protocol, input.BaseURL, input.APIKey, header, scheme, BoolToInt(input.Enabled), time.Now().UTC().Unix(), input.ID, llms.ProviderScopeAPI)
+	provider, err := llms.ScanProvider(row.Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		_, err = s.GetManagedLLMProvider(ctx, input.ID)
+		if err == nil {
+			err = fmt.Errorf("%w: provider changed during update", domain.ErrConflict)
+		}
+		return llms.Provider{}, err
+	}
+	if err != nil {
+		return llms.Provider{}, fmt.Errorf("update llm provider: %w", err)
+	}
+	return provider, nil
+}
+
+// DeleteLLMProvider removes an API provider and its tokens atomically. Removing
+// tokens ensures reusing an ID cannot revive credentials issued for the old provider.
+func (s *llmStore) DeleteLLMProvider(ctx context.Context, id string) error {
+	if err := llms.ValidateManagedProviderID(id); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin provider deletion: %w", err)
+	}
+	// Rollback after commit is harmless; on errors it releases the transaction.
+	defer func() { _ = tx.Rollback() }()
+	var scope string
+	err = tx.QueryRowContext(ctx, `SELECT scope FROM llm_provider WHERE id = ?`, id).Scan(&scope)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: llm provider not found", domain.ErrNotFound)
+	}
+	if err != nil {
+		return fmt.Errorf("read provider ownership: %w", err)
+	}
+	if scope != llms.ProviderScopeAPI {
+		return fmt.Errorf("%w: provider is not API-managed", domain.ErrFailedPrecondition)
+	}
+	for _, statement := range []string{
+		`DELETE FROM llm_facade_token WHERE provider_id = ?`,
+		`DELETE FROM llm_provider_model WHERE provider_id = ?`,
+		`DELETE FROM llm_provider WHERE id = ?`,
+	} {
+		if _, err := tx.ExecContext(ctx, statement, id); err != nil {
+			return fmt.Errorf("delete llm provider configuration: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit provider deletion: %w", err)
+	}
+	return nil
+}
+
+func managedProviderAuth(protocol string) (family, header, scheme string) {
+	if protocol == llms.APIProtocolMessages {
+		return llms.ProviderFamilyAnthropic, "x-api-key", ""
+	}
+	return llms.ProviderFamilyOpenAI, "Authorization", "Bearer"
+}

--- a/pkg/storage/configstore/llm_provider_store.go
+++ b/pkg/storage/configstore/llm_provider_store.go
@@ -22,12 +22,16 @@ func (s *llmStore) CreateLLMProvider(ctx context.Context, input llms.ProviderRep
 	if input.APIKey == nil {
 		return llms.Provider{}, fmt.Errorf("%w: api_key is required", domain.ErrInvalidArgument)
 	}
+	enabled := true
+	if input.Enabled != nil {
+		enabled = *input.Enabled
+	}
 	family, header, scheme := managedProviderAuth(input.Protocol)
 	now := time.Now().UTC().Unix()
 	row := s.db.QueryRowContext(ctx, `INSERT INTO llm_provider (`+providerColumns+`)
- VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', 0, 10, ?, ?, ?, ?)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 10, ?, ?, ?, ?)
  ON CONFLICT(id) DO NOTHING RETURNING `+providerColumns,
-		input.ID, input.Name, family, input.Protocol, input.BaseURL, *input.APIKey, header, scheme, BoolToInt(input.Enabled), llms.ProviderScopeAPI, now, now)
+		input.ID, input.Name, family, input.Protocol, input.BaseURL, *input.APIKey, header, scheme, llms.ManagedProviderHeadersJSON(input.Protocol), BoolToInt(enabled), llms.ProviderScopeAPI, now, now)
 	provider, err := llms.ScanProvider(row.Scan)
 	if errors.Is(err, sql.ErrNoRows) {
 		return llms.Provider{}, fmt.Errorf("%w: provider id already exists", domain.ErrAlreadyExists)
@@ -78,16 +82,16 @@ func (s *llmStore) ListManagedLLMProviders(ctx context.Context) ([]llms.Provider
 	return providers, nil
 }
 
-// UpdateLLMProvider atomically replaces configuration and optionally rotates its key.
+// UpdateLLMProvider applies explicit fields and preserves omitted values.
 func (s *llmStore) UpdateLLMProvider(ctx context.Context, input llms.ProviderReplacement) (llms.Provider, error) {
-	input, err := llms.NormalizeProviderReplacement(input)
+	input, err := llms.NormalizeProviderUpdate(input)
 	if err != nil {
 		return llms.Provider{}, err
 	}
-	family, header, scheme := managedProviderAuth(input.Protocol)
-	row := s.db.QueryRowContext(ctx, `UPDATE llm_provider SET name = ?, provider_type = ?, default_wire_api = ?, base_url = ?, api_key = COALESCE(?, api_key), auth_header = ?, auth_scheme = ?, enabled = ?, updated_at = ?
+	family, header, scheme, headersJSON := managedProviderUpdateColumns(input.Protocol)
+	row := s.db.QueryRowContext(ctx, `UPDATE llm_provider SET name = COALESCE(NULLIF(?, ''), name), provider_type = COALESCE(?, provider_type), default_wire_api = COALESCE(NULLIF(?, ''), default_wire_api), base_url = COALESCE(NULLIF(?, ''), base_url), api_key = COALESCE(?, api_key), auth_header = COALESCE(?, auth_header), auth_scheme = CASE WHEN ? IS NOT NULL THEN ? ELSE auth_scheme END, headers_json = COALESCE(?, headers_json), enabled = COALESCE(?, enabled), updated_at = ?
  WHERE id = ? AND scope = ? RETURNING `+providerColumns,
-		input.Name, family, input.Protocol, input.BaseURL, input.APIKey, header, scheme, BoolToInt(input.Enabled), time.Now().UTC().Unix(), input.ID, llms.ProviderScopeAPI)
+		input.Name, family, input.Protocol, input.BaseURL, input.APIKey, header, header, scheme, headersJSON, optionalBoolToSQL(input.Enabled), time.Now().UTC().Unix(), input.ID, llms.ProviderScopeAPI)
 	provider, err := llms.ScanProvider(row.Scan)
 	if errors.Is(err, sql.ErrNoRows) {
 		_, err = s.GetManagedLLMProvider(ctx, input.ID)
@@ -145,4 +149,19 @@ func managedProviderAuth(protocol string) (family, header, scheme string) {
 		return llms.ProviderFamilyAnthropic, "x-api-key", ""
 	}
 	return llms.ProviderFamilyOpenAI, "Authorization", "Bearer"
+}
+
+func managedProviderUpdateColumns(protocol string) (family, header, scheme, headersJSON any) {
+	if protocol == "" {
+		return nil, nil, nil, nil
+	}
+	familyName, headerName, schemeName := managedProviderAuth(protocol)
+	return familyName, headerName, schemeName, llms.ManagedProviderHeadersJSON(protocol)
+}
+
+func optionalBoolToSQL(value *bool) any {
+	if value == nil {
+		return nil
+	}
+	return BoolToInt(*value)
 }

--- a/pkg/storage/configstore/llm_provider_store_integration_test.go
+++ b/pkg/storage/configstore/llm_provider_store_integration_test.go
@@ -218,3 +218,15 @@ func TestIntegrationManagedProviderConcurrentCreate(t *testing.T) {
 		t.Fatalf("successful creates = %d, want 1", successes)
 	}
 }
+
+func TestE2EManagedProviderLifecycleAndRouting(t *testing.T) {
+	TestIntegrationManagedProviderLifecycleAndRouting(t)
+}
+
+func TestE2EManagedProviderOwnershipAndCancellation(t *testing.T) {
+	TestIntegrationManagedProviderOwnershipAndCancellation(t)
+}
+
+func TestE2EManagedProviderConcurrentCreate(t *testing.T) {
+	TestIntegrationManagedProviderConcurrentCreate(t)
+}

--- a/pkg/storage/configstore/llm_provider_store_integration_test.go
+++ b/pkg/storage/configstore/llm_provider_store_integration_test.go
@@ -1,0 +1,210 @@
+package configstore
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chaitin/agent-compose/pkg/llms"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	storagesqlite "github.com/chaitin/agent-compose/pkg/storage/sqlite"
+)
+
+func TestIntegrationManagedProviderLifecycleAndRouting(t *testing.T) {
+	clearLLMTestEnvironment(t)
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "data.db")
+	open := func() *storagesqlite.Database {
+		t.Helper()
+		db, err := storagesqlite.Open(path, time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := db.Close(); err != nil {
+				t.Error(err)
+			}
+		})
+		return db
+	}
+	db := open()
+	store := FromDB(db.DB())
+	key := "first-key"
+	input := llms.ProviderReplacement{ID: "gateway", BaseURL: "https://first.example/v1", Protocol: llms.APIProtocolResponses, APIKey: &key, Enabled: true}
+	created, err := store.CreateLLMProvider(ctx, input)
+	if err != nil || created.Scope != llms.ProviderScopeAPI || created.APIKey != key {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.CreateLLMProvider(ctx, input); !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Fatalf("duplicate: %v", err)
+	}
+	resolve := func() llms.ResolvedTarget {
+		t.Helper()
+		target, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, store, llms.RuntimeLLMTargetQuery{RequestedModel: "gateway/literal/model"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return target
+	}
+	target := resolve()
+	if target.Model.ID != "literal/model" || target.Endpoint != "https://first.example/v1/responses" || target.Headers.Get("Authorization") != "Bearer first-key" {
+		t.Fatal("created provider was not used for routing")
+	}
+	input.APIKey = nil
+	input.BaseURL = "https://second.example/v1"
+	if _, err := store.UpdateLLMProvider(ctx, input); err != nil {
+		t.Fatal(err)
+	}
+	target = resolve()
+	if target.Endpoint != "https://second.example/v1/responses" || target.Provider.APIKey != key {
+		t.Fatal("update did not preserve key or replace URL")
+	}
+	rotated := "second-key"
+	input.APIKey = &rotated
+	input.Protocol = llms.APIProtocolMessages
+	if _, err := store.UpdateLLMProvider(ctx, input); err != nil {
+		t.Fatal(err)
+	}
+	target = resolve()
+	if target.Headers.Get("x-api-key") != rotated || target.Headers.Get("Authorization") != "" || target.WireAPI != llms.APIProtocolMessages {
+		t.Fatal("rotated credential/protocol not effective")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store = FromDB(open().DB())
+	if err := store.ApplyModelCatalog(ctx, llms.ModelCatalog{}); err != nil {
+		t.Fatal(err)
+	}
+	if resolve().Provider.APIKey != rotated {
+		t.Fatal("restart/catalog synchronization lost API configuration")
+	}
+	input.Enabled = false
+	if _, err := store.UpdateLLMProvider(ctx, input); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := llms.ResolveRuntimeLLMTargetWithEnv(ctx, store, llms.RuntimeLLMTargetQuery{RequestedModel: "gateway/literal/model"}); err == nil {
+		t.Fatal("disabled provider routed a request")
+	}
+	listed, err := store.ListManagedLLMProviders(ctx)
+	if err != nil || len(listed) != 1 || listed[0].Enabled {
+		t.Fatalf("list disabled provider: %v", err)
+	}
+	hash, fingerprint := llms.HashFacadeToken("facade-key")
+	if err := store.SaveLLMFacadeToken(ctx, llms.FacadeToken{TokenHash: hash, TokenFingerprint: fingerprint, SandboxID: "sandbox", ProviderID: input.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteLLMProvider(ctx, input.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GetManagedLLMProvider(ctx, input.ID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("get deleted: %v", err)
+	}
+	input.Enabled = true
+	if _, err := store.CreateLLMProvider(ctx, input); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GetLLMFacadeToken(ctx, "facade-key"); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("old token survived recreation: %v", err)
+	}
+}
+
+func TestIntegrationManagedProviderOwnershipAndCancellation(t *testing.T) {
+	ctx := context.Background()
+	store := FromDB(newMemoryDB(t))
+	if err := store.InitSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	url, protocol, key := "https://example.com/v1", llms.APIProtocolResponses, "catalog-key"
+	if err := store.ApplyModelCatalog(ctx, llms.ModelCatalog{Providers: map[string]llms.CatalogProvider{"catalog": {BaseURL: &url, Protocol: &protocol, APIKey: &key}}}); err != nil {
+		t.Fatal(err)
+	}
+	input := llms.ProviderReplacement{ID: "catalog", BaseURL: url, Protocol: protocol, APIKey: &key, Enabled: true}
+	if _, err := store.CreateLLMProvider(ctx, input); !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Fatalf("create collision: %v", err)
+	}
+	if _, err := store.UpdateLLMProvider(ctx, input); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("update ownership: %v", err)
+	}
+	if err := store.DeleteLLMProvider(ctx, input.ID); !errors.Is(err, domain.ErrFailedPrecondition) {
+		t.Fatalf("delete ownership: %v", err)
+	}
+	providers, err := store.ListManagedLLMProviders(ctx)
+	if err != nil || len(providers) != 0 {
+		t.Fatalf("catalog leaked into API list: %v", err)
+	}
+	input.ID = "missing"
+	if _, err := store.UpdateLLMProvider(ctx, input); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("update missing: %v", err)
+	}
+	if err := store.DeleteLLMProvider(ctx, input.ID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("delete missing: %v", err)
+	}
+	input.APIKey = nil
+	if _, err := store.CreateLLMProvider(ctx, input); !errors.Is(err, domain.ErrInvalidArgument) {
+		t.Fatalf("create missing key: %v", err)
+	}
+	input.APIKey = &key
+	if _, err := store.CreateLLMProvider(ctx, input); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ApplyModelCatalog(ctx, llms.ModelCatalog{Providers: map[string]llms.CatalogProvider{input.ID: {BaseURL: &url, Protocol: &protocol, APIKey: &key}}}); err == nil {
+		t.Fatal("catalog overwrote API-owned provider")
+	}
+	if provider, err := store.GetManagedLLMProvider(ctx, input.ID); err != nil || provider.APIKey != key {
+		t.Fatalf("collision damaged provider: %v", err)
+	}
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := store.CreateLLMProvider(canceled, input); !errors.Is(err, context.Canceled) {
+		t.Fatalf("create canceled: %v", err)
+	}
+	if _, err := store.UpdateLLMProvider(canceled, input); !errors.Is(err, context.Canceled) {
+		t.Fatalf("update canceled: %v", err)
+	}
+	if _, err := store.GetManagedLLMProvider(canceled, input.ID); !errors.Is(err, context.Canceled) {
+		t.Fatalf("get canceled: %v", err)
+	}
+	if _, err := store.ListManagedLLMProviders(canceled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("list canceled: %v", err)
+	}
+	if err := store.DeleteLLMProvider(canceled, input.ID); !errors.Is(err, context.Canceled) {
+		t.Fatalf("delete canceled: %v", err)
+	}
+}
+
+func TestIntegrationManagedProviderConcurrentCreate(t *testing.T) {
+	db, err := storagesqlite.Open(filepath.Join(t.TempDir(), "data.db"), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	store := FromDB(db.DB())
+	key := "key"
+	input := llms.ProviderReplacement{ID: "concurrent", BaseURL: "https://example.com", Protocol: llms.APIProtocolResponses, APIKey: &key, Enabled: true}
+	var wg sync.WaitGroup
+	results := make(chan error, 8)
+	for range 8 {
+		wg.Go(func() { _, err := store.CreateLLMProvider(context.Background(), input); results <- err })
+	}
+	wg.Wait()
+	close(results)
+	successes := 0
+	for err := range results {
+		if err == nil {
+			successes++
+		} else if !errors.Is(err, domain.ErrAlreadyExists) {
+			t.Errorf("unexpected concurrent create error: %v", err)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful creates = %d, want 1", successes)
+	}
+}

--- a/pkg/storage/configstore/llm_provider_store_integration_test.go
+++ b/pkg/storage/configstore/llm_provider_store_integration_test.go
@@ -13,6 +13,10 @@ import (
 	storagesqlite "github.com/chaitin/agent-compose/pkg/storage/sqlite"
 )
 
+func boolPtr(value bool) *bool {
+	return &value
+}
+
 func TestIntegrationManagedProviderLifecycleAndRouting(t *testing.T) {
 	clearLLMTestEnvironment(t)
 	ctx := context.Background()
@@ -33,7 +37,7 @@ func TestIntegrationManagedProviderLifecycleAndRouting(t *testing.T) {
 	db := open()
 	store := FromDB(db.DB())
 	key := "first-key"
-	input := llms.ProviderReplacement{ID: "gateway", BaseURL: "https://first.example/v1", Protocol: llms.APIProtocolResponses, APIKey: &key, Enabled: true}
+	input := llms.ProviderReplacement{ID: "gateway", BaseURL: "https://first.example/v1", Protocol: llms.APIProtocolResponses, APIKey: &key, Enabled: boolPtr(true)}
 	created, err := store.CreateLLMProvider(ctx, input)
 	if err != nil || created.Scope != llms.ProviderScopeAPI || created.APIKey != key {
 		t.Fatalf("create: %v", err)
@@ -69,7 +73,7 @@ func TestIntegrationManagedProviderLifecycleAndRouting(t *testing.T) {
 		t.Fatal(err)
 	}
 	target = resolve()
-	if target.Headers.Get("x-api-key") != rotated || target.Headers.Get("Authorization") != "" || target.WireAPI != llms.APIProtocolMessages {
+	if target.Headers.Get("x-api-key") != rotated || target.Headers.Get("Authorization") != "" || target.Headers.Get("anthropic-version") != "2023-06-01" || target.WireAPI != llms.APIProtocolMessages {
 		t.Fatal("rotated credential/protocol not effective")
 	}
 	if err := db.Close(); err != nil {
@@ -82,7 +86,7 @@ func TestIntegrationManagedProviderLifecycleAndRouting(t *testing.T) {
 	if resolve().Provider.APIKey != rotated {
 		t.Fatal("restart/catalog synchronization lost API configuration")
 	}
-	input.Enabled = false
+	input.Enabled = boolPtr(false)
 	if _, err := store.UpdateLLMProvider(ctx, input); err != nil {
 		t.Fatal(err)
 	}
@@ -92,6 +96,11 @@ func TestIntegrationManagedProviderLifecycleAndRouting(t *testing.T) {
 	listed, err := store.ListManagedLLMProviders(ctx)
 	if err != nil || len(listed) != 1 || listed[0].Enabled {
 		t.Fatalf("list disabled provider: %v", err)
+	}
+	partial := llms.ProviderReplacement{ID: input.ID, BaseURL: "https://third.example/v1"}
+	updated, err := store.UpdateLLMProvider(ctx, partial)
+	if err != nil || updated.Enabled || updated.Name != input.ID || updated.APIKey != rotated || updated.BaseURL != partial.BaseURL || updated.DefaultWireAPI != llms.APIProtocolMessages {
+		t.Fatalf("omitted update fields were replaced: %v %#v", err, updated)
 	}
 	hash, fingerprint := llms.HashFacadeToken("facade-key")
 	if err := store.SaveLLMFacadeToken(ctx, llms.FacadeToken{TokenHash: hash, TokenFingerprint: fingerprint, SandboxID: "sandbox", ProviderID: input.ID}); err != nil {
@@ -103,9 +112,10 @@ func TestIntegrationManagedProviderLifecycleAndRouting(t *testing.T) {
 	if _, err := store.GetManagedLLMProvider(ctx, input.ID); !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("get deleted: %v", err)
 	}
-	input.Enabled = true
-	if _, err := store.CreateLLMProvider(ctx, input); err != nil {
-		t.Fatal(err)
+	input.Enabled = boolPtr(true)
+	recreated, err := store.CreateLLMProvider(ctx, input)
+	if err != nil || recreated.HeadersJSON != llms.AnthropicVersionHeadersJSON || recreated.AuthHeader != "x-api-key" {
+		t.Fatalf("anthropic recreate headers: %v %#v", err, recreated)
 	}
 	if _, err := store.GetLLMFacadeToken(ctx, "facade-key"); !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("old token survived recreation: %v", err)
@@ -122,7 +132,7 @@ func TestIntegrationManagedProviderOwnershipAndCancellation(t *testing.T) {
 	if err := store.ApplyModelCatalog(ctx, llms.ModelCatalog{Providers: map[string]llms.CatalogProvider{"catalog": {BaseURL: &url, Protocol: &protocol, APIKey: &key}}}); err != nil {
 		t.Fatal(err)
 	}
-	input := llms.ProviderReplacement{ID: "catalog", BaseURL: url, Protocol: protocol, APIKey: &key, Enabled: true}
+	input := llms.ProviderReplacement{ID: "catalog", BaseURL: url, Protocol: protocol, APIKey: &key, Enabled: boolPtr(true)}
 	if _, err := store.CreateLLMProvider(ctx, input); !errors.Is(err, domain.ErrAlreadyExists) {
 		t.Fatalf("create collision: %v", err)
 	}
@@ -188,7 +198,7 @@ func TestIntegrationManagedProviderConcurrentCreate(t *testing.T) {
 	})
 	store := FromDB(db.DB())
 	key := "key"
-	input := llms.ProviderReplacement{ID: "concurrent", BaseURL: "https://example.com", Protocol: llms.APIProtocolResponses, APIKey: &key, Enabled: true}
+	input := llms.ProviderReplacement{ID: "concurrent", BaseURL: "https://example.com", Protocol: llms.APIProtocolResponses, APIKey: &key, Enabled: boolPtr(true)}
 	var wg sync.WaitGroup
 	results := make(chan error, 8)
 	for range 8 {

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -18861,6 +18861,646 @@ func (x *BatchGetLatestSchedulerRunsResponse) GetResults() []*SandboxSchedulerRu
 	return nil
 }
 
+// LLMProvider contains public configuration only; credentials are never returned.
+type LLMProvider struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	BaseUrl       string                 `protobuf:"bytes,3,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
+	Protocol      string                 `protobuf:"bytes,4,opt,name=protocol,proto3" json:"protocol,omitempty"`
+	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	ApiKeySet     bool                   `protobuf:"varint,6,opt,name=api_key_set,json=apiKeySet,proto3" json:"api_key_set,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LLMProvider) Reset() {
+	*x = LLMProvider{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[232]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LLMProvider) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LLMProvider) ProtoMessage() {}
+
+func (x *LLMProvider) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[232]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LLMProvider.ProtoReflect.Descriptor instead.
+func (*LLMProvider) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{232}
+}
+
+func (x *LLMProvider) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *LLMProvider) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *LLMProvider) GetBaseUrl() string {
+	if x != nil {
+		return x.BaseUrl
+	}
+	return ""
+}
+
+func (x *LLMProvider) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
+	}
+	return ""
+}
+
+func (x *LLMProvider) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *LLMProvider) GetApiKeySet() bool {
+	if x != nil {
+		return x.ApiKeySet
+	}
+	return false
+}
+
+func (x *LLMProvider) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *LLMProvider) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+// LLMProviderSpec replaces public configuration on update. ID is immutable.
+type LLMProviderSpec struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Id      string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name    string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	BaseUrl string                 `protobuf:"bytes,3,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
+	// responses, chat_completions, or anthropic_messages; required.
+	Protocol string `protobuf:"bytes,4,opt,name=protocol,proto3" json:"protocol,omitempty"`
+	// Required and nonempty on create. Absent on update preserves the key.
+	// Present empty is invalid. Values are literal, not environment references.
+	ApiKey *string `protobuf:"bytes,5,opt,name=api_key,json=apiKey,proto3,oneof" json:"api_key,omitempty"`
+	// Absent means enabled, including on replacement updates.
+	Enabled       *bool `protobuf:"varint,6,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LLMProviderSpec) Reset() {
+	*x = LLMProviderSpec{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[233]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LLMProviderSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LLMProviderSpec) ProtoMessage() {}
+
+func (x *LLMProviderSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[233]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LLMProviderSpec.ProtoReflect.Descriptor instead.
+func (*LLMProviderSpec) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{233}
+}
+
+func (x *LLMProviderSpec) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *LLMProviderSpec) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *LLMProviderSpec) GetBaseUrl() string {
+	if x != nil {
+		return x.BaseUrl
+	}
+	return ""
+}
+
+func (x *LLMProviderSpec) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
+	}
+	return ""
+}
+
+func (x *LLMProviderSpec) GetApiKey() string {
+	if x != nil && x.ApiKey != nil {
+		return *x.ApiKey
+	}
+	return ""
+}
+
+func (x *LLMProviderSpec) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
+	}
+	return false
+}
+
+type CreateProviderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Provider      *LLMProviderSpec       `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateProviderRequest) Reset() {
+	*x = CreateProviderRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[234]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateProviderRequest) ProtoMessage() {}
+
+func (x *CreateProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[234]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateProviderRequest.ProtoReflect.Descriptor instead.
+func (*CreateProviderRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{234}
+}
+
+func (x *CreateProviderRequest) GetProvider() *LLMProviderSpec {
+	if x != nil {
+		return x.Provider
+	}
+	return nil
+}
+
+type CreateProviderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Provider      *LLMProvider           `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateProviderResponse) Reset() {
+	*x = CreateProviderResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[235]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateProviderResponse) ProtoMessage() {}
+
+func (x *CreateProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[235]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateProviderResponse.ProtoReflect.Descriptor instead.
+func (*CreateProviderResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{235}
+}
+
+func (x *CreateProviderResponse) GetProvider() *LLMProvider {
+	if x != nil {
+		return x.Provider
+	}
+	return nil
+}
+
+type GetProviderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProviderRequest) Reset() {
+	*x = GetProviderRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[236]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProviderRequest) ProtoMessage() {}
+
+func (x *GetProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[236]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProviderRequest.ProtoReflect.Descriptor instead.
+func (*GetProviderRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{236}
+}
+
+func (x *GetProviderRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type GetProviderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Provider      *LLMProvider           `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProviderResponse) Reset() {
+	*x = GetProviderResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[237]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProviderResponse) ProtoMessage() {}
+
+func (x *GetProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[237]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProviderResponse.ProtoReflect.Descriptor instead.
+func (*GetProviderResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{237}
+}
+
+func (x *GetProviderResponse) GetProvider() *LLMProvider {
+	if x != nil {
+		return x.Provider
+	}
+	return nil
+}
+
+// Lists API-owned providers, including disabled providers, ordered by ID.
+type ListProvidersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Offset        uint32                 `protobuf:"varint,1,opt,name=offset,proto3" json:"offset,omitempty"`
+	Limit         uint32                 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListProvidersRequest) Reset() {
+	*x = ListProvidersRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[238]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListProvidersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListProvidersRequest) ProtoMessage() {}
+
+func (x *ListProvidersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[238]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListProvidersRequest.ProtoReflect.Descriptor instead.
+func (*ListProvidersRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{238}
+}
+
+func (x *ListProvidersRequest) GetOffset() uint32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ListProvidersRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type ListProvidersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Providers     []*LLMProvider         `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers,omitempty"`
+	Total         uint32                 `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListProvidersResponse) Reset() {
+	*x = ListProvidersResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[239]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListProvidersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListProvidersResponse) ProtoMessage() {}
+
+func (x *ListProvidersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[239]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListProvidersResponse.ProtoReflect.Descriptor instead.
+func (*ListProvidersResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{239}
+}
+
+func (x *ListProvidersResponse) GetProviders() []*LLMProvider {
+	if x != nil {
+		return x.Providers
+	}
+	return nil
+}
+
+func (x *ListProvidersResponse) GetTotal() uint32 {
+	if x != nil {
+		return x.Total
+	}
+	return 0
+}
+
+type UpdateProviderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Provider      *LLMProviderSpec       `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateProviderRequest) Reset() {
+	*x = UpdateProviderRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[240]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateProviderRequest) ProtoMessage() {}
+
+func (x *UpdateProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[240]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateProviderRequest.ProtoReflect.Descriptor instead.
+func (*UpdateProviderRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{240}
+}
+
+func (x *UpdateProviderRequest) GetProvider() *LLMProviderSpec {
+	if x != nil {
+		return x.Provider
+	}
+	return nil
+}
+
+type UpdateProviderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Provider      *LLMProvider           `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateProviderResponse) Reset() {
+	*x = UpdateProviderResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[241]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateProviderResponse) ProtoMessage() {}
+
+func (x *UpdateProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[241]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateProviderResponse.ProtoReflect.Descriptor instead.
+func (*UpdateProviderResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{241}
+}
+
+func (x *UpdateProviderResponse) GetProvider() *LLMProvider {
+	if x != nil {
+		return x.Provider
+	}
+	return nil
+}
+
+// Deletes API-owned configuration and invalidates provider-bound facade tokens.
+type DeleteProviderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteProviderRequest) Reset() {
+	*x = DeleteProviderRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[242]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteProviderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteProviderRequest) ProtoMessage() {}
+
+func (x *DeleteProviderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[242]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteProviderRequest.ProtoReflect.Descriptor instead.
+func (*DeleteProviderRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{242}
+}
+
+func (x *DeleteProviderRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type DeleteProviderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteProviderResponse) Reset() {
+	*x = DeleteProviderResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[243]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteProviderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteProviderResponse) ProtoMessage() {}
+
+func (x *DeleteProviderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[243]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteProviderResponse.ProtoReflect.Descriptor instead.
+func (*DeleteProviderResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{243}
+}
+
 var File_agentcompose_v2_agentcompose_proto protoreflect.FileDescriptor
 
 const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
@@ -20397,7 +21037,50 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12/\n" +
 	"\x03run\x18\x02 \x01(\v2\x1d.agentcompose.v2.SchedulerRunR\x03run\"e\n" +
 	"#BatchGetLatestSchedulerRunsResponse\x12>\n" +
-	"\aresults\x18\x01 \x03(\v2$.agentcompose.v2.SandboxSchedulerRunR\aresults*\x98\x01\n" +
+	"\aresults\x18\x01 \x03(\v2$.agentcompose.v2.SandboxSchedulerRunR\aresults\"\x98\x02\n" +
+	"\vLLMProvider\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x19\n" +
+	"\bbase_url\x18\x03 \x01(\tR\abaseUrl\x12\x1a\n" +
+	"\bprotocol\x18\x04 \x01(\tR\bprotocol\x12\x18\n" +
+	"\aenabled\x18\x05 \x01(\bR\aenabled\x12\x1e\n" +
+	"\vapi_key_set\x18\x06 \x01(\bR\tapiKeySet\x129\n" +
+	"\n" +
+	"created_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"updated_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xc1\x01\n" +
+	"\x0fLLMProviderSpec\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x19\n" +
+	"\bbase_url\x18\x03 \x01(\tR\abaseUrl\x12\x1a\n" +
+	"\bprotocol\x18\x04 \x01(\tR\bprotocol\x12\x1c\n" +
+	"\aapi_key\x18\x05 \x01(\tH\x00R\x06apiKey\x88\x01\x01\x12\x1d\n" +
+	"\aenabled\x18\x06 \x01(\bH\x01R\aenabled\x88\x01\x01B\n" +
+	"\n" +
+	"\b_api_keyB\n" +
+	"\n" +
+	"\b_enabled\"U\n" +
+	"\x15CreateProviderRequest\x12<\n" +
+	"\bprovider\x18\x01 \x01(\v2 .agentcompose.v2.LLMProviderSpecR\bprovider\"R\n" +
+	"\x16CreateProviderResponse\x128\n" +
+	"\bprovider\x18\x01 \x01(\v2\x1c.agentcompose.v2.LLMProviderR\bprovider\"$\n" +
+	"\x12GetProviderRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"O\n" +
+	"\x13GetProviderResponse\x128\n" +
+	"\bprovider\x18\x01 \x01(\v2\x1c.agentcompose.v2.LLMProviderR\bprovider\"D\n" +
+	"\x14ListProvidersRequest\x12\x16\n" +
+	"\x06offset\x18\x01 \x01(\rR\x06offset\x12\x14\n" +
+	"\x05limit\x18\x02 \x01(\rR\x05limit\"i\n" +
+	"\x15ListProvidersResponse\x12:\n" +
+	"\tproviders\x18\x01 \x03(\v2\x1c.agentcompose.v2.LLMProviderR\tproviders\x12\x14\n" +
+	"\x05total\x18\x02 \x01(\rR\x05total\"U\n" +
+	"\x15UpdateProviderRequest\x12<\n" +
+	"\bprovider\x18\x01 \x01(\v2 .agentcompose.v2.LLMProviderSpecR\bprovider\"R\n" +
+	"\x16UpdateProviderResponse\x128\n" +
+	"\bprovider\x18\x01 \x01(\v2\x1c.agentcompose.v2.LLMProviderR\bprovider\"'\n" +
+	"\x15DeleteProviderRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x18\n" +
+	"\x16DeleteProviderResponse*\x98\x01\n" +
 	"\x19ProjectValidationSeverity\x12+\n" +
 	"'PROJECT_VALIDATION_SEVERITY_UNSPECIFIED\x10\x00\x12'\n" +
 	"#PROJECT_VALIDATION_SEVERITY_WARNING\x10\x01\x12%\n" +
@@ -20666,9 +21349,14 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x11CapabilityService\x12m\n" +
 	"\x13GetCapabilityStatus\x12+.agentcompose.v2.GetCapabilityStatusRequest\x1a).agentcompose.v2.CapabilityStatusResponse\x12m\n" +
 	"\x12ListCapabilitySets\x12*.agentcompose.v2.ListCapabilitySetsRequest\x1a+.agentcompose.v2.ListCapabilitySetsResponse\x12s\n" +
-	"\x14GetCapabilityCatalog\x12,.agentcompose.v2.GetCapabilityCatalogRequest\x1a-.agentcompose.v2.GetCapabilityCatalogResponse2c\n" +
+	"\x14GetCapabilityCatalog\x12,.agentcompose.v2.GetCapabilityCatalogRequest\x1a-.agentcompose.v2.GetCapabilityCatalogResponse2\xc6\x04\n" +
 	"\n" +
-	"LLMService\x12U\n" +
+	"LLMService\x12a\n" +
+	"\x0eCreateProvider\x12&.agentcompose.v2.CreateProviderRequest\x1a'.agentcompose.v2.CreateProviderResponse\x12X\n" +
+	"\vGetProvider\x12#.agentcompose.v2.GetProviderRequest\x1a$.agentcompose.v2.GetProviderResponse\x12^\n" +
+	"\rListProviders\x12%.agentcompose.v2.ListProvidersRequest\x1a&.agentcompose.v2.ListProvidersResponse\x12a\n" +
+	"\x0eUpdateProvider\x12&.agentcompose.v2.UpdateProviderRequest\x1a'.agentcompose.v2.UpdateProviderResponse\x12a\n" +
+	"\x0eDeleteProvider\x12&.agentcompose.v2.DeleteProviderRequest\x1a'.agentcompose.v2.DeleteProviderResponse\x12U\n" +
 	"\bGenerate\x12#.agentcompose.v2.GenerateLLMRequest\x1a$.agentcompose.v2.GenerateLLMResponse2u\n" +
 	"\x0fResourceService\x12b\n" +
 	"\tResolveID\x12).agentcompose.v2.ResolveResourceIDRequest\x1a*.agentcompose.v2.ResolveResourceIDResponseBGZEgithub.com/chaitin/agent-compose/proto/agentcompose/v2;agentcomposev2b\x06proto3"
@@ -20686,7 +21374,7 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 }
 
 var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 34)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 247)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 259)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),                // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),                      // 1: agentcompose.v2.ProjectChangeAction
@@ -20954,23 +21642,35 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*BatchGetLatestSchedulerRunsRequest)(nil),    // 263: agentcompose.v2.BatchGetLatestSchedulerRunsRequest
 	(*SandboxSchedulerRun)(nil),                   // 264: agentcompose.v2.SandboxSchedulerRun
 	(*BatchGetLatestSchedulerRunsResponse)(nil),   // 265: agentcompose.v2.BatchGetLatestSchedulerRunsResponse
-	nil,                           // 266: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                           // 267: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                           // 268: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                           // 269: agentcompose.v2.RunAgentRequest.LabelsEntry
-	nil,                           // 270: agentcompose.v2.ListRunsRequest.LabelsEntry
-	nil,                           // 271: agentcompose.v2.RunDetail.LabelsEntry
-	nil,                           // 272: agentcompose.v2.AttachHumanMessage.MetadataEntry
-	nil,                           // 273: agentcompose.v2.AttachError.DetailsEntry
-	nil,                           // 274: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                           // 275: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                           // 276: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                           // 277: agentcompose.v2.Volume.LabelsEntry
-	nil,                           // 278: agentcompose.v2.Volume.OptionsEntry
-	nil,                           // 279: agentcompose.v2.Image.LabelsEntry
-	nil,                           // 280: agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	(*timestamppb.Timestamp)(nil), // 281: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),   // 282: google.protobuf.Duration
+	(*LLMProvider)(nil),                           // 266: agentcompose.v2.LLMProvider
+	(*LLMProviderSpec)(nil),                       // 267: agentcompose.v2.LLMProviderSpec
+	(*CreateProviderRequest)(nil),                 // 268: agentcompose.v2.CreateProviderRequest
+	(*CreateProviderResponse)(nil),                // 269: agentcompose.v2.CreateProviderResponse
+	(*GetProviderRequest)(nil),                    // 270: agentcompose.v2.GetProviderRequest
+	(*GetProviderResponse)(nil),                   // 271: agentcompose.v2.GetProviderResponse
+	(*ListProvidersRequest)(nil),                  // 272: agentcompose.v2.ListProvidersRequest
+	(*ListProvidersResponse)(nil),                 // 273: agentcompose.v2.ListProvidersResponse
+	(*UpdateProviderRequest)(nil),                 // 274: agentcompose.v2.UpdateProviderRequest
+	(*UpdateProviderResponse)(nil),                // 275: agentcompose.v2.UpdateProviderResponse
+	(*DeleteProviderRequest)(nil),                 // 276: agentcompose.v2.DeleteProviderRequest
+	(*DeleteProviderResponse)(nil),                // 277: agentcompose.v2.DeleteProviderResponse
+	nil,                                           // 278: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                                           // 279: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                                           // 280: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                                           // 281: agentcompose.v2.RunAgentRequest.LabelsEntry
+	nil,                                           // 282: agentcompose.v2.ListRunsRequest.LabelsEntry
+	nil,                                           // 283: agentcompose.v2.RunDetail.LabelsEntry
+	nil,                                           // 284: agentcompose.v2.AttachHumanMessage.MetadataEntry
+	nil,                                           // 285: agentcompose.v2.AttachError.DetailsEntry
+	nil,                                           // 286: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                                           // 287: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                                           // 288: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                                           // 289: agentcompose.v2.Volume.LabelsEntry
+	nil,                                           // 290: agentcompose.v2.Volume.OptionsEntry
+	nil,                                           // 291: agentcompose.v2.Image.LabelsEntry
+	nil,                                           // 292: agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	(*timestamppb.Timestamp)(nil),                 // 293: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),                   // 294: google.protobuf.Duration
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	90,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
@@ -20999,11 +21699,11 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	90,  // 23: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
 	52,  // 24: agentcompose.v2.Project.agents:type_name -> agentcompose.v2.ProjectAgent
 	55,  // 25: agentcompose.v2.Project.schedulers:type_name -> agentcompose.v2.ProjectScheduler
-	281, // 26: agentcompose.v2.ProjectSummary.created_at:type_name -> google.protobuf.Timestamp
-	281, // 27: agentcompose.v2.ProjectSummary.updated_at:type_name -> google.protobuf.Timestamp
-	281, // 28: agentcompose.v2.ProjectSummary.removed_at:type_name -> google.protobuf.Timestamp
+	293, // 26: agentcompose.v2.ProjectSummary.created_at:type_name -> google.protobuf.Timestamp
+	293, // 27: agentcompose.v2.ProjectSummary.updated_at:type_name -> google.protobuf.Timestamp
+	293, // 28: agentcompose.v2.ProjectSummary.removed_at:type_name -> google.protobuf.Timestamp
 	90,  // 29: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
-	281, // 30: agentcompose.v2.ProjectRevision.created_at:type_name -> google.protobuf.Timestamp
+	293, // 30: agentcompose.v2.ProjectRevision.created_at:type_name -> google.protobuf.Timestamp
 	14,  // 31: agentcompose.v2.ProjectAgent.availability:type_name -> agentcompose.v2.ProjectAgentAvailability
 	15,  // 32: agentcompose.v2.ProjectAgent.health:type_name -> agentcompose.v2.ProjectAgentHealth
 	53,  // 33: agentcompose.v2.ProjectAgent.current_run:type_name -> agentcompose.v2.ProjectAgentCurrentRun
@@ -21011,18 +21711,18 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	32,  // 35: agentcompose.v2.ProjectAgent.model_source:type_name -> agentcompose.v2.AgentModelSource
 	3,   // 36: agentcompose.v2.ProjectAgentLatestRun.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 37: agentcompose.v2.ProjectAgentLatestRun.source:type_name -> agentcompose.v2.RunSource
-	281, // 38: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
+	293, // 38: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
 	47,  // 39: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
 	55,  // 40: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	102, // 41: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
 	58,  // 42: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
 	103, // 43: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
-	281, // 44: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
-	281, // 45: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
-	281, // 46: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
+	293, // 44: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
+	293, // 45: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
+	293, // 46: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
 	60,  // 47: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
 	47,  // 48: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	281, // 49: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
+	293, // 49: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
 	63,  // 50: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
 	47,  // 51: agentcompose.v2.ListProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	63,  // 52: agentcompose.v2.ListProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
@@ -21045,8 +21745,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	83,  // 69: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
 	12,  // 70: agentcompose.v2.SchedulerRun.trigger_kind:type_name -> agentcompose.v2.TriggerKind
 	5,   // 71: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
-	281, // 72: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
-	281, // 73: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
+	293, // 72: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
+	293, // 73: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
 	47,  // 74: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
 	55,  // 75: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	47,  // 76: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
@@ -21072,10 +21772,10 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	93,  // 96: agentcompose.v2.AgentSpec.sandbox:type_name -> agentcompose.v2.SandboxSpec
 	99,  // 97: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
 	99,  // 98: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
-	266, // 99: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	267, // 100: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	278, // 99: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	279, // 100: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
 	13,  // 101: agentcompose.v2.VolumeMountSpec.type:type_name -> agentcompose.v2.VolumeMountType
-	268, // 102: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	280, // 102: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
 	103, // 103: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
 	11,  // 104: agentcompose.v2.SchedulerSpec.sandbox_policy:type_name -> agentcompose.v2.SchedulerSandboxPolicy
 	10,  // 105: agentcompose.v2.SchedulerSpec.concurrency_policy:type_name -> agentcompose.v2.SchedulerConcurrencyPolicy
@@ -21091,12 +21791,12 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	18,  // 115: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
 	212, // 116: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
 	97,  // 117: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	269, // 118: agentcompose.v2.RunAgentRequest.labels:type_name -> agentcompose.v2.RunAgentRequest.LabelsEntry
+	281, // 118: agentcompose.v2.RunAgentRequest.labels:type_name -> agentcompose.v2.RunAgentRequest.LabelsEntry
 	150, // 119: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
 	17,  // 120: agentcompose.v2.StreamAgentRunResponse.event_type:type_name -> agentcompose.v2.StreamAgentRunEventType
 	149, // 121: agentcompose.v2.StreamAgentRunResponse.run:type_name -> agentcompose.v2.RunSummary
 	22,  // 122: agentcompose.v2.StreamAgentRunResponse.stream:type_name -> agentcompose.v2.StdioStream
-	281, // 123: agentcompose.v2.StreamAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
+	293, // 123: agentcompose.v2.StreamAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
 	116, // 124: agentcompose.v2.StreamAgentRunResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
 	115, // 125: agentcompose.v2.AttachAgentRunRequest.start:type_name -> agentcompose.v2.AttachAgentRunStart
 	160, // 126: agentcompose.v2.AttachAgentRunRequest.stdin:type_name -> agentcompose.v2.AttachStdin
@@ -21105,7 +21805,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	163, // 129: agentcompose.v2.AttachAgentRunRequest.signal:type_name -> agentcompose.v2.AttachSignal
 	164, // 130: agentcompose.v2.AttachAgentRunRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
 	165, // 131: agentcompose.v2.AttachAgentRunRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	281, // 132: agentcompose.v2.AttachAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
+	293, // 132: agentcompose.v2.AttachAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
 	166, // 133: agentcompose.v2.AttachAgentRunResponse.started:type_name -> agentcompose.v2.AttachStarted
 	167, // 134: agentcompose.v2.AttachAgentRunResponse.output:type_name -> agentcompose.v2.AttachOutput
 	168, // 135: agentcompose.v2.AttachAgentRunResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
@@ -21117,47 +21817,47 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	159, // 141: agentcompose.v2.AttachAgentRunStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
 	21,  // 142: agentcompose.v2.AttachAgentRunStart.disconnect_policy:type_name -> agentcompose.v2.AttachDisconnectPolicy
 	22,  // 143: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
-	281, // 144: agentcompose.v2.TranscriptEvent.created_at:type_name -> google.protobuf.Timestamp
+	293, // 144: agentcompose.v2.TranscriptEvent.created_at:type_name -> google.protobuf.Timestamp
 	150, // 145: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
 	3,   // 146: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 147: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
-	281, // 148: agentcompose.v2.ListRunsRequest.started_from:type_name -> google.protobuf.Timestamp
-	281, // 149: agentcompose.v2.ListRunsRequest.started_to:type_name -> google.protobuf.Timestamp
-	270, // 150: agentcompose.v2.ListRunsRequest.labels:type_name -> agentcompose.v2.ListRunsRequest.LabelsEntry
+	293, // 148: agentcompose.v2.ListRunsRequest.started_from:type_name -> google.protobuf.Timestamp
+	293, // 149: agentcompose.v2.ListRunsRequest.started_to:type_name -> google.protobuf.Timestamp
+	282, // 150: agentcompose.v2.ListRunsRequest.labels:type_name -> agentcompose.v2.ListRunsRequest.LabelsEntry
 	149, // 151: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
 	3,   // 152: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
-	281, // 153: agentcompose.v2.RunLogChunk.created_at:type_name -> google.protobuf.Timestamp
+	293, // 153: agentcompose.v2.RunLogChunk.created_at:type_name -> google.protobuf.Timestamp
 	149, // 154: agentcompose.v2.RunLogChunk.run:type_name -> agentcompose.v2.RunSummary
 	150, // 155: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
 	16,  // 156: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
-	281, // 157: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
+	293, // 157: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
 	126, // 158: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
 	126, // 159: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
 	6,   // 160: agentcompose.v2.PruneSandboxesRequest.status:type_name -> agentcompose.v2.SandboxStatus
 	29,  // 161: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
 	6,   // 162: agentcompose.v2.SandboxPruneCandidate.status:type_name -> agentcompose.v2.SandboxStatus
-	281, // 163: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	293, // 163: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
 	133, // 164: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
 	133, // 165: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
 	148, // 166: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
 	6,   // 167: agentcompose.v2.Sandbox.status:type_name -> agentcompose.v2.SandboxStatus
-	281, // 168: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	281, // 169: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	293, // 168: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	293, // 169: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
 	139, // 170: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
 	9,   // 171: agentcompose.v2.Sandbox.workspace_reclamation_state:type_name -> agentcompose.v2.WorkspaceReclamationState
-	281, // 172: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
-	281, // 173: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
-	281, // 174: agentcompose.v2.Sandbox.stopped_runtime_released_at:type_name -> google.protobuf.Timestamp
+	293, // 172: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
+	293, // 173: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
+	293, // 174: agentcompose.v2.Sandbox.stopped_runtime_released_at:type_name -> google.protobuf.Timestamp
 	6,   // 175: agentcompose.v2.ListSandboxesRequest.status:type_name -> agentcompose.v2.SandboxStatus
 	138, // 176: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
 	138, // 177: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
 	7,   // 178: agentcompose.v2.StopSandboxRequest.mode:type_name -> agentcompose.v2.SandboxStopMode
-	282, // 179: agentcompose.v2.StopSandboxRequest.grace_period:type_name -> google.protobuf.Duration
+	294, // 179: agentcompose.v2.StopSandboxRequest.grace_period:type_name -> google.protobuf.Duration
 	138, // 180: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
 	8,   // 181: agentcompose.v2.StopSandboxResponse.outcome:type_name -> agentcompose.v2.SandboxStopOutcome
 	138, // 182: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
 	26,  // 183: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	281, // 184: agentcompose.v2.SandboxStats.sampled_at:type_name -> google.protobuf.Timestamp
+	293, // 184: agentcompose.v2.SandboxStats.sampled_at:type_name -> google.protobuf.Timestamp
 	147, // 185: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
 	147, // 186: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
 	147, // 187: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
@@ -21169,12 +21869,12 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	147, // 193: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
 	4,   // 194: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
 	3,   // 195: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	281, // 196: agentcompose.v2.RunSummary.started_at:type_name -> google.protobuf.Timestamp
-	281, // 197: agentcompose.v2.RunSummary.completed_at:type_name -> google.protobuf.Timestamp
-	281, // 198: agentcompose.v2.RunSummary.created_at:type_name -> google.protobuf.Timestamp
-	281, // 199: agentcompose.v2.RunSummary.updated_at:type_name -> google.protobuf.Timestamp
+	293, // 196: agentcompose.v2.RunSummary.started_at:type_name -> google.protobuf.Timestamp
+	293, // 197: agentcompose.v2.RunSummary.completed_at:type_name -> google.protobuf.Timestamp
+	293, // 198: agentcompose.v2.RunSummary.created_at:type_name -> google.protobuf.Timestamp
+	293, // 199: agentcompose.v2.RunSummary.updated_at:type_name -> google.protobuf.Timestamp
 	149, // 200: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	271, // 201: agentcompose.v2.RunDetail.labels:type_name -> agentcompose.v2.RunDetail.LabelsEntry
+	283, // 201: agentcompose.v2.RunDetail.labels:type_name -> agentcompose.v2.RunDetail.LabelsEntry
 	152, // 202: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
 	153, // 203: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
 	99,  // 204: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
@@ -21190,7 +21890,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	163, // 214: agentcompose.v2.AttachExecRequest.signal:type_name -> agentcompose.v2.AttachSignal
 	165, // 215: agentcompose.v2.AttachExecRequest.cancel:type_name -> agentcompose.v2.AttachCancel
 	164, // 216: agentcompose.v2.AttachExecRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	281, // 217: agentcompose.v2.AttachExecResponse.created_at:type_name -> google.protobuf.Timestamp
+	293, // 217: agentcompose.v2.AttachExecResponse.created_at:type_name -> google.protobuf.Timestamp
 	166, // 218: agentcompose.v2.AttachExecResponse.started:type_name -> agentcompose.v2.AttachStarted
 	167, // 219: agentcompose.v2.AttachExecResponse.output:type_name -> agentcompose.v2.AttachOutput
 	170, // 220: agentcompose.v2.AttachExecResponse.result:type_name -> agentcompose.v2.AttachResult
@@ -21201,14 +21901,14 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	159, // 225: agentcompose.v2.AttachExecStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
 	20,  // 226: agentcompose.v2.AttachExecStart.mode:type_name -> agentcompose.v2.AttachRunMode
 	159, // 227: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	272, // 228: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	284, // 228: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
 	149, // 229: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
 	22,  // 230: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
 	116, // 231: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	281, // 232: agentcompose.v2.AttachAgentEvent.created_at:type_name -> google.protobuf.Timestamp
+	293, // 232: agentcompose.v2.AttachAgentEvent.created_at:type_name -> google.protobuf.Timestamp
 	172, // 233: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
 	149, // 234: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	273, // 235: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	285, // 235: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
 	153, // 236: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
 	23,  // 237: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
 	205, // 238: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
@@ -21222,7 +21922,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	205, // 246: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
 	207, // 247: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
 	23,  // 248: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	274, // 249: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	286, // 249: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
 	23,  // 250: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
 	206, // 251: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
 	25,  // 252: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
@@ -21239,29 +21939,29 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	192, // 263: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
 	27,  // 264: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
 	30,  // 265: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	281, // 266: agentcompose.v2.CacheItem.last_used_at:type_name -> google.protobuf.Timestamp
+	293, // 266: agentcompose.v2.CacheItem.last_used_at:type_name -> google.protobuf.Timestamp
 	193, // 267: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
 	28,  // 268: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
 	204, // 269: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	275, // 270: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	276, // 271: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	287, // 270: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	288, // 271: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
 	204, // 272: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
 	204, // 273: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
 	204, // 274: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
 	204, // 275: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
 	204, // 276: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	277, // 277: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	278, // 278: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	281, // 279: agentcompose.v2.Volume.created_at:type_name -> google.protobuf.Timestamp
-	281, // 280: agentcompose.v2.Volume.updated_at:type_name -> google.protobuf.Timestamp
+	289, // 277: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	290, // 278: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	293, // 279: agentcompose.v2.Volume.created_at:type_name -> google.protobuf.Timestamp
+	293, // 280: agentcompose.v2.Volume.updated_at:type_name -> google.protobuf.Timestamp
 	23,  // 281: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
 	24,  // 282: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
 	206, // 283: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	281, // 284: agentcompose.v2.Image.created_at:type_name -> google.protobuf.Timestamp
-	281, // 285: agentcompose.v2.Image.inspected_at:type_name -> google.protobuf.Timestamp
+	293, // 284: agentcompose.v2.Image.created_at:type_name -> google.protobuf.Timestamp
+	293, // 285: agentcompose.v2.Image.inspected_at:type_name -> google.protobuf.Timestamp
 	208, // 286: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
 	209, // 287: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	279, // 288: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	291, // 288: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
 	23,  // 289: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
 	110, // 290: agentcompose.v2.StartAgentRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
 	149, // 291: agentcompose.v2.StartAgentRunResponse.run:type_name -> agentcompose.v2.RunSummary
@@ -21269,7 +21969,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	218, // 293: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
 	31,  // 294: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
 	221, // 295: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	281, // 296: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	293, // 296: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
 	222, // 297: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
 	222, // 298: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
 	99,  // 299: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
@@ -21277,16 +21977,16 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	99,  // 301: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
 	230, // 302: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
 	230, // 303: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	281, // 304: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	281, // 305: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	293, // 304: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	293, // 305: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
 	234, // 306: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
 	234, // 307: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
 	245, // 308: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	280, // 309: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	292, // 309: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
 	248, // 310: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
 	249, // 311: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	281, // 312: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	281, // 313: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	293, // 312: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	293, // 313: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
 	252, // 314: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
 	253, // 315: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
 	33,  // 316: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
@@ -21302,159 +22002,177 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	47,  // 326: agentcompose.v2.BatchGetLatestSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	83,  // 327: agentcompose.v2.SandboxSchedulerRun.run:type_name -> agentcompose.v2.SchedulerRun
 	264, // 328: agentcompose.v2.BatchGetLatestSchedulerRunsResponse.results:type_name -> agentcompose.v2.SandboxSchedulerRun
-	34,  // 329: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
-	36,  // 330: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
-	38,  // 331: agentcompose.v2.ProjectService.PatchProject:input_type -> agentcompose.v2.PatchProjectRequest
-	39,  // 332: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
-	41,  // 333: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
-	43,  // 334: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
-	45,  // 335: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
-	56,  // 336: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
-	59,  // 337: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
-	62,  // 338: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
-	65,  // 339: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
-	259, // 340: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:input_type -> agentcompose.v2.StreamProjectSchedulerEventsRequest
-	67,  // 341: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
-	69,  // 342: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
-	71,  // 343: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
-	73,  // 344: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
-	75,  // 345: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
-	263, // 346: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:input_type -> agentcompose.v2.BatchGetLatestSchedulerRunsRequest
-	261, // 347: agentcompose.v2.ProjectService.StreamSchedulerRuns:input_type -> agentcompose.v2.StreamSchedulerRunsRequest
-	77,  // 348: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
-	81,  // 349: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
-	84,  // 350: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
-	86,  // 351: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
-	110, // 352: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
-	213, // 353: agentcompose.v2.RunService.StartAgentRun:input_type -> agentcompose.v2.StartAgentRunRequest
-	110, // 354: agentcompose.v2.RunService.StreamAgentRun:input_type -> agentcompose.v2.RunAgentRequest
-	113, // 355: agentcompose.v2.RunService.AttachAgentRun:input_type -> agentcompose.v2.AttachAgentRunRequest
-	117, // 356: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
-	119, // 357: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
-	121, // 358: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
-	123, // 359: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
-	125, // 360: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
-	128, // 361: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
-	151, // 362: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
-	151, // 363: agentcompose.v2.ExecService.StreamExec:input_type -> agentcompose.v2.ExecRequest
-	156, // 364: agentcompose.v2.ExecService.AttachExec:input_type -> agentcompose.v2.AttachExecRequest
-	173, // 365: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
-	175, // 366: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
-	177, // 367: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
-	179, // 368: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
-	181, // 369: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
-	184, // 370: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
-	186, // 371: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
-	188, // 372: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
-	190, // 373: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
-	194, // 374: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
-	196, // 375: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
-	198, // 376: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
-	200, // 377: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
-	202, // 378: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
-	130, // 379: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
-	132, // 380: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
-	135, // 381: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
-	137, // 382: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
-	143, // 383: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
-	145, // 384: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
-	140, // 385: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	251, // 386: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	255, // 387: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
-	219, // 388: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
-	220, // 389: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
-	225, // 390: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
-	227, // 391: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
-	229, // 392: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
-	232, // 393: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
-	235, // 394: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
-	237, // 395: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
-	238, // 396: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
-	239, // 397: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
-	242, // 398: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
-	244, // 399: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
-	247, // 400: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	257, // 401: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	216, // 402: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	35,  // 403: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	37,  // 404: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	37,  // 405: agentcompose.v2.ProjectService.PatchProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	40,  // 406: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	42,  // 407: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	44,  // 408: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	46,  // 409: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	57,  // 410: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	61,  // 411: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	64,  // 412: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	66,  // 413: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
-	260, // 414: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:output_type -> agentcompose.v2.StreamProjectSchedulerEventsResponse
-	68,  // 415: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
-	70,  // 416: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
-	72,  // 417: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
-	74,  // 418: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
-	76,  // 419: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
-	265, // 420: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:output_type -> agentcompose.v2.BatchGetLatestSchedulerRunsResponse
-	262, // 421: agentcompose.v2.ProjectService.StreamSchedulerRuns:output_type -> agentcompose.v2.StreamSchedulerRunsResponse
-	80,  // 422: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
-	82,  // 423: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
-	85,  // 424: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	87,  // 425: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	111, // 426: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	214, // 427: agentcompose.v2.RunService.StartAgentRun:output_type -> agentcompose.v2.StartAgentRunResponse
-	112, // 428: agentcompose.v2.RunService.StreamAgentRun:output_type -> agentcompose.v2.StreamAgentRunResponse
-	114, // 429: agentcompose.v2.RunService.AttachAgentRun:output_type -> agentcompose.v2.AttachAgentRunResponse
-	118, // 430: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	120, // 431: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	122, // 432: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	124, // 433: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	127, // 434: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	129, // 435: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	154, // 436: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	155, // 437: agentcompose.v2.ExecService.StreamExec:output_type -> agentcompose.v2.StreamExecResponse
-	157, // 438: agentcompose.v2.ExecService.AttachExec:output_type -> agentcompose.v2.AttachExecResponse
-	174, // 439: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	176, // 440: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	178, // 441: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	180, // 442: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	182, // 443: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	185, // 444: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	187, // 445: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	189, // 446: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	191, // 447: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	195, // 448: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	197, // 449: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	199, // 450: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	201, // 451: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	203, // 452: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	131, // 453: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	134, // 454: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	136, // 455: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	142, // 456: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	144, // 457: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	146, // 458: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	141, // 459: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	254, // 460: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	256, // 461: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	223, // 462: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	224, // 463: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	226, // 464: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	228, // 465: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	231, // 466: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	233, // 467: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	236, // 468: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	241, // 469: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	241, // 470: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	240, // 471: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	243, // 472: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	246, // 473: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	250, // 474: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	258, // 475: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	217, // 476: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	403, // [403:477] is the sub-list for method output_type
-	329, // [329:403] is the sub-list for method input_type
-	329, // [329:329] is the sub-list for extension type_name
-	329, // [329:329] is the sub-list for extension extendee
-	0,   // [0:329] is the sub-list for field type_name
+	293, // 329: agentcompose.v2.LLMProvider.created_at:type_name -> google.protobuf.Timestamp
+	293, // 330: agentcompose.v2.LLMProvider.updated_at:type_name -> google.protobuf.Timestamp
+	267, // 331: agentcompose.v2.CreateProviderRequest.provider:type_name -> agentcompose.v2.LLMProviderSpec
+	266, // 332: agentcompose.v2.CreateProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
+	266, // 333: agentcompose.v2.GetProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
+	266, // 334: agentcompose.v2.ListProvidersResponse.providers:type_name -> agentcompose.v2.LLMProvider
+	267, // 335: agentcompose.v2.UpdateProviderRequest.provider:type_name -> agentcompose.v2.LLMProviderSpec
+	266, // 336: agentcompose.v2.UpdateProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
+	34,  // 337: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
+	36,  // 338: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
+	38,  // 339: agentcompose.v2.ProjectService.PatchProject:input_type -> agentcompose.v2.PatchProjectRequest
+	39,  // 340: agentcompose.v2.ProjectService.GetProject:input_type -> agentcompose.v2.GetProjectRequest
+	41,  // 341: agentcompose.v2.ProjectService.ListProjects:input_type -> agentcompose.v2.ListProjectsRequest
+	43,  // 342: agentcompose.v2.ProjectService.RemoveProject:input_type -> agentcompose.v2.RemoveProjectRequest
+	45,  // 343: agentcompose.v2.ProjectService.WatchProject:input_type -> agentcompose.v2.WatchProjectRequest
+	56,  // 344: agentcompose.v2.ProjectService.GetScheduler:input_type -> agentcompose.v2.GetSchedulerRequest
+	59,  // 345: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
+	62,  // 346: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
+	65,  // 347: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
+	259, // 348: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:input_type -> agentcompose.v2.StreamProjectSchedulerEventsRequest
+	67,  // 349: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
+	69,  // 350: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
+	71,  // 351: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
+	73,  // 352: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
+	75,  // 353: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
+	263, // 354: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:input_type -> agentcompose.v2.BatchGetLatestSchedulerRunsRequest
+	261, // 355: agentcompose.v2.ProjectService.StreamSchedulerRuns:input_type -> agentcompose.v2.StreamSchedulerRunsRequest
+	77,  // 356: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
+	81,  // 357: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
+	84,  // 358: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
+	86,  // 359: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:input_type -> agentcompose.v2.SetSchedulerTriggerEnabledRequest
+	110, // 360: agentcompose.v2.RunService.RunAgent:input_type -> agentcompose.v2.RunAgentRequest
+	213, // 361: agentcompose.v2.RunService.StartAgentRun:input_type -> agentcompose.v2.StartAgentRunRequest
+	110, // 362: agentcompose.v2.RunService.StreamAgentRun:input_type -> agentcompose.v2.RunAgentRequest
+	113, // 363: agentcompose.v2.RunService.AttachAgentRun:input_type -> agentcompose.v2.AttachAgentRunRequest
+	117, // 364: agentcompose.v2.RunService.GetRun:input_type -> agentcompose.v2.GetRunRequest
+	119, // 365: agentcompose.v2.RunService.ListRuns:input_type -> agentcompose.v2.ListRunsRequest
+	121, // 366: agentcompose.v2.RunService.FollowRunLogs:input_type -> agentcompose.v2.FollowRunLogsRequest
+	123, // 367: agentcompose.v2.RunService.StopRun:input_type -> agentcompose.v2.StopRunRequest
+	125, // 368: agentcompose.v2.RunService.ListRunEvents:input_type -> agentcompose.v2.ListRunEventsRequest
+	128, // 369: agentcompose.v2.RunService.ListSandboxRunEvents:input_type -> agentcompose.v2.ListSandboxRunEventsRequest
+	151, // 370: agentcompose.v2.ExecService.Exec:input_type -> agentcompose.v2.ExecRequest
+	151, // 371: agentcompose.v2.ExecService.StreamExec:input_type -> agentcompose.v2.ExecRequest
+	156, // 372: agentcompose.v2.ExecService.AttachExec:input_type -> agentcompose.v2.AttachExecRequest
+	173, // 373: agentcompose.v2.ImageService.ListImages:input_type -> agentcompose.v2.ListImagesRequest
+	175, // 374: agentcompose.v2.ImageService.PullImage:input_type -> agentcompose.v2.PullImageRequest
+	177, // 375: agentcompose.v2.ImageService.InspectImage:input_type -> agentcompose.v2.InspectImageRequest
+	179, // 376: agentcompose.v2.ImageService.RemoveImage:input_type -> agentcompose.v2.RemoveImageRequest
+	181, // 377: agentcompose.v2.ImageService.BuildImage:input_type -> agentcompose.v2.BuildImageRequest
+	184, // 378: agentcompose.v2.CacheService.ListCaches:input_type -> agentcompose.v2.ListCachesRequest
+	186, // 379: agentcompose.v2.CacheService.InspectCache:input_type -> agentcompose.v2.InspectCacheRequest
+	188, // 380: agentcompose.v2.CacheService.PruneCaches:input_type -> agentcompose.v2.PruneCachesRequest
+	190, // 381: agentcompose.v2.CacheService.RemoveCache:input_type -> agentcompose.v2.RemoveCacheRequest
+	194, // 382: agentcompose.v2.VolumeService.ListVolumes:input_type -> agentcompose.v2.ListVolumesRequest
+	196, // 383: agentcompose.v2.VolumeService.CreateVolume:input_type -> agentcompose.v2.CreateVolumeRequest
+	198, // 384: agentcompose.v2.VolumeService.InspectVolume:input_type -> agentcompose.v2.InspectVolumeRequest
+	200, // 385: agentcompose.v2.VolumeService.RemoveVolume:input_type -> agentcompose.v2.RemoveVolumeRequest
+	202, // 386: agentcompose.v2.VolumeService.PruneVolumes:input_type -> agentcompose.v2.PruneVolumesRequest
+	130, // 387: agentcompose.v2.SandboxService.RemoveSandbox:input_type -> agentcompose.v2.RemoveSandboxRequest
+	132, // 388: agentcompose.v2.SandboxService.PruneSandboxes:input_type -> agentcompose.v2.PruneSandboxesRequest
+	135, // 389: agentcompose.v2.SandboxService.GetSandboxStats:input_type -> agentcompose.v2.GetSandboxStatsRequest
+	137, // 390: agentcompose.v2.SandboxService.GetSandbox:input_type -> agentcompose.v2.GetSandboxRequest
+	143, // 391: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
+	145, // 392: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
+	140, // 393: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
+	251, // 394: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	255, // 395: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	219, // 396: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
+	220, // 397: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
+	225, // 398: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
+	227, // 399: agentcompose.v2.SettingsService.UpdateGlobalEnv:input_type -> agentcompose.v2.UpdateGlobalEnvRequest
+	229, // 400: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:input_type -> agentcompose.v2.GetCapabilityGatewayConfigRequest
+	232, // 401: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:input_type -> agentcompose.v2.UpdateCapabilityGatewayConfigRequest
+	235, // 402: agentcompose.v2.SettingsService.ListWorkspacePresets:input_type -> agentcompose.v2.ListWorkspacePresetsRequest
+	237, // 403: agentcompose.v2.SettingsService.CreateWorkspacePreset:input_type -> agentcompose.v2.CreateWorkspacePresetRequest
+	238, // 404: agentcompose.v2.SettingsService.UpdateWorkspacePreset:input_type -> agentcompose.v2.UpdateWorkspacePresetRequest
+	239, // 405: agentcompose.v2.SettingsService.DeleteWorkspacePreset:input_type -> agentcompose.v2.DeleteWorkspacePresetRequest
+	242, // 406: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
+	244, // 407: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
+	247, // 408: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
+	268, // 409: agentcompose.v2.LLMService.CreateProvider:input_type -> agentcompose.v2.CreateProviderRequest
+	270, // 410: agentcompose.v2.LLMService.GetProvider:input_type -> agentcompose.v2.GetProviderRequest
+	272, // 411: agentcompose.v2.LLMService.ListProviders:input_type -> agentcompose.v2.ListProvidersRequest
+	274, // 412: agentcompose.v2.LLMService.UpdateProvider:input_type -> agentcompose.v2.UpdateProviderRequest
+	276, // 413: agentcompose.v2.LLMService.DeleteProvider:input_type -> agentcompose.v2.DeleteProviderRequest
+	257, // 414: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	216, // 415: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	35,  // 416: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	37,  // 417: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	37,  // 418: agentcompose.v2.ProjectService.PatchProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	40,  // 419: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	42,  // 420: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	44,  // 421: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	46,  // 422: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	57,  // 423: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	61,  // 424: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	64,  // 425: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	66,  // 426: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
+	260, // 427: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:output_type -> agentcompose.v2.StreamProjectSchedulerEventsResponse
+	68,  // 428: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
+	70,  // 429: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	72,  // 430: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	74,  // 431: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	76,  // 432: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	265, // 433: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:output_type -> agentcompose.v2.BatchGetLatestSchedulerRunsResponse
+	262, // 434: agentcompose.v2.ProjectService.StreamSchedulerRuns:output_type -> agentcompose.v2.StreamSchedulerRunsResponse
+	80,  // 435: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
+	82,  // 436: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	85,  // 437: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	87,  // 438: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	111, // 439: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	214, // 440: agentcompose.v2.RunService.StartAgentRun:output_type -> agentcompose.v2.StartAgentRunResponse
+	112, // 441: agentcompose.v2.RunService.StreamAgentRun:output_type -> agentcompose.v2.StreamAgentRunResponse
+	114, // 442: agentcompose.v2.RunService.AttachAgentRun:output_type -> agentcompose.v2.AttachAgentRunResponse
+	118, // 443: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	120, // 444: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	122, // 445: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	124, // 446: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	127, // 447: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	129, // 448: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	154, // 449: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	155, // 450: agentcompose.v2.ExecService.StreamExec:output_type -> agentcompose.v2.StreamExecResponse
+	157, // 451: agentcompose.v2.ExecService.AttachExec:output_type -> agentcompose.v2.AttachExecResponse
+	174, // 452: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	176, // 453: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	178, // 454: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	180, // 455: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	182, // 456: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	185, // 457: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	187, // 458: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	189, // 459: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	191, // 460: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	195, // 461: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	197, // 462: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	199, // 463: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	201, // 464: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	203, // 465: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	131, // 466: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	134, // 467: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	136, // 468: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	142, // 469: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	144, // 470: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	146, // 471: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	141, // 472: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	254, // 473: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	256, // 474: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	223, // 475: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	224, // 476: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	226, // 477: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	228, // 478: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	231, // 479: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	233, // 480: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	236, // 481: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	241, // 482: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	241, // 483: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	240, // 484: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	243, // 485: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	246, // 486: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	250, // 487: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	269, // 488: agentcompose.v2.LLMService.CreateProvider:output_type -> agentcompose.v2.CreateProviderResponse
+	271, // 489: agentcompose.v2.LLMService.GetProvider:output_type -> agentcompose.v2.GetProviderResponse
+	273, // 490: agentcompose.v2.LLMService.ListProviders:output_type -> agentcompose.v2.ListProvidersResponse
+	275, // 491: agentcompose.v2.LLMService.UpdateProvider:output_type -> agentcompose.v2.UpdateProviderResponse
+	277, // 492: agentcompose.v2.LLMService.DeleteProvider:output_type -> agentcompose.v2.DeleteProviderResponse
+	258, // 493: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	217, // 494: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	416, // [416:495] is the sub-list for method output_type
+	337, // [337:416] is the sub-list for method input_type
+	337, // [337:337] is the sub-list for extension type_name
+	337, // [337:337] is the sub-list for extension extendee
+	0,   // [0:337] is the sub-list for field type_name
 }
 
 func init() { file_agentcompose_v2_agentcompose_proto_init() }
@@ -21520,13 +22238,14 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*AttachExecResponse_AgentTurnCompleted)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[198].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[233].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
 			NumEnums:      34,
-			NumMessages:   247,
+			NumMessages:   259,
 			NumExtensions: 0,
 			NumServices:   12,
 		},

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -146,6 +146,12 @@ service CapabilityService {
 }
 
 service LLMService {
+  // Manage API-owned upstream model providers, not coding-agent providers.
+  rpc CreateProvider(CreateProviderRequest) returns (CreateProviderResponse);
+  rpc GetProvider(GetProviderRequest) returns (GetProviderResponse);
+  rpc ListProviders(ListProvidersRequest) returns (ListProvidersResponse);
+  rpc UpdateProvider(UpdateProviderRequest) returns (UpdateProviderResponse);
+  rpc DeleteProvider(DeleteProviderRequest) returns (DeleteProviderResponse);
   rpc Generate(GenerateLLMRequest) returns (GenerateLLMResponse);
 }
 
@@ -2247,3 +2253,47 @@ message SandboxSchedulerRun {
 message BatchGetLatestSchedulerRunsResponse {
   repeated SandboxSchedulerRun results = 1;
 }
+
+// LLMProvider contains public configuration only; credentials are never returned.
+message LLMProvider {
+  string id = 1;
+  string name = 2;
+  string base_url = 3;
+  string protocol = 4;
+  bool enabled = 5;
+  bool api_key_set = 6;
+  google.protobuf.Timestamp created_at = 7;
+  google.protobuf.Timestamp updated_at = 8;
+}
+
+// LLMProviderSpec replaces public configuration on update. ID is immutable.
+message LLMProviderSpec {
+  string id = 1;
+  string name = 2;
+  string base_url = 3;
+  // responses, chat_completions, or anthropic_messages; required.
+  string protocol = 4;
+  // Required and nonempty on create. Absent on update preserves the key.
+  // Present empty is invalid. Values are literal, not environment references.
+  optional string api_key = 5;
+  // Absent means enabled, including on replacement updates.
+  optional bool enabled = 6;
+}
+message CreateProviderRequest { LLMProviderSpec provider = 1; }
+message CreateProviderResponse { LLMProvider provider = 1; }
+message GetProviderRequest { string id = 1; }
+message GetProviderResponse { LLMProvider provider = 1; }
+// Lists API-owned providers, including disabled providers, ordered by ID.
+message ListProvidersRequest {
+  uint32 offset = 1;
+  uint32 limit = 2;
+}
+message ListProvidersResponse {
+  repeated LLMProvider providers = 1;
+  uint32 total = 2;
+}
+message UpdateProviderRequest { LLMProviderSpec provider = 1; }
+message UpdateProviderResponse { LLMProvider provider = 1; }
+// Deletes API-owned configuration and invalidates provider-bound facade tokens.
+message DeleteProviderRequest { string id = 1; }
+message DeleteProviderResponse {}

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -260,6 +260,20 @@ const (
 	// CapabilityServiceGetCapabilityCatalogProcedure is the fully-qualified name of the
 	// CapabilityService's GetCapabilityCatalog RPC.
 	CapabilityServiceGetCapabilityCatalogProcedure = "/agentcompose.v2.CapabilityService/GetCapabilityCatalog"
+	// LLMServiceCreateProviderProcedure is the fully-qualified name of the LLMService's CreateProvider
+	// RPC.
+	LLMServiceCreateProviderProcedure = "/agentcompose.v2.LLMService/CreateProvider"
+	// LLMServiceGetProviderProcedure is the fully-qualified name of the LLMService's GetProvider RPC.
+	LLMServiceGetProviderProcedure = "/agentcompose.v2.LLMService/GetProvider"
+	// LLMServiceListProvidersProcedure is the fully-qualified name of the LLMService's ListProviders
+	// RPC.
+	LLMServiceListProvidersProcedure = "/agentcompose.v2.LLMService/ListProviders"
+	// LLMServiceUpdateProviderProcedure is the fully-qualified name of the LLMService's UpdateProvider
+	// RPC.
+	LLMServiceUpdateProviderProcedure = "/agentcompose.v2.LLMService/UpdateProvider"
+	// LLMServiceDeleteProviderProcedure is the fully-qualified name of the LLMService's DeleteProvider
+	// RPC.
+	LLMServiceDeleteProviderProcedure = "/agentcompose.v2.LLMService/DeleteProvider"
 	// LLMServiceGenerateProcedure is the fully-qualified name of the LLMService's Generate RPC.
 	LLMServiceGenerateProcedure = "/agentcompose.v2.LLMService/Generate"
 	// ResourceServiceResolveIDProcedure is the fully-qualified name of the ResourceService's ResolveID
@@ -2654,6 +2668,12 @@ func (UnimplementedCapabilityServiceHandler) GetCapabilityCatalog(context.Contex
 
 // LLMServiceClient is a client for the agentcompose.v2.LLMService service.
 type LLMServiceClient interface {
+	// Manage API-owned upstream model providers, not coding-agent providers.
+	CreateProvider(context.Context, *connect.Request[v2.CreateProviderRequest]) (*connect.Response[v2.CreateProviderResponse], error)
+	GetProvider(context.Context, *connect.Request[v2.GetProviderRequest]) (*connect.Response[v2.GetProviderResponse], error)
+	ListProviders(context.Context, *connect.Request[v2.ListProvidersRequest]) (*connect.Response[v2.ListProvidersResponse], error)
+	UpdateProvider(context.Context, *connect.Request[v2.UpdateProviderRequest]) (*connect.Response[v2.UpdateProviderResponse], error)
+	DeleteProvider(context.Context, *connect.Request[v2.DeleteProviderRequest]) (*connect.Response[v2.DeleteProviderResponse], error)
 	Generate(context.Context, *connect.Request[v2.GenerateLLMRequest]) (*connect.Response[v2.GenerateLLMResponse], error)
 }
 
@@ -2668,6 +2688,36 @@ func NewLLMServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 	baseURL = strings.TrimRight(baseURL, "/")
 	lLMServiceMethods := v2.File_agentcompose_v2_agentcompose_proto.Services().ByName("LLMService").Methods()
 	return &lLMServiceClient{
+		createProvider: connect.NewClient[v2.CreateProviderRequest, v2.CreateProviderResponse](
+			httpClient,
+			baseURL+LLMServiceCreateProviderProcedure,
+			connect.WithSchema(lLMServiceMethods.ByName("CreateProvider")),
+			connect.WithClientOptions(opts...),
+		),
+		getProvider: connect.NewClient[v2.GetProviderRequest, v2.GetProviderResponse](
+			httpClient,
+			baseURL+LLMServiceGetProviderProcedure,
+			connect.WithSchema(lLMServiceMethods.ByName("GetProvider")),
+			connect.WithClientOptions(opts...),
+		),
+		listProviders: connect.NewClient[v2.ListProvidersRequest, v2.ListProvidersResponse](
+			httpClient,
+			baseURL+LLMServiceListProvidersProcedure,
+			connect.WithSchema(lLMServiceMethods.ByName("ListProviders")),
+			connect.WithClientOptions(opts...),
+		),
+		updateProvider: connect.NewClient[v2.UpdateProviderRequest, v2.UpdateProviderResponse](
+			httpClient,
+			baseURL+LLMServiceUpdateProviderProcedure,
+			connect.WithSchema(lLMServiceMethods.ByName("UpdateProvider")),
+			connect.WithClientOptions(opts...),
+		),
+		deleteProvider: connect.NewClient[v2.DeleteProviderRequest, v2.DeleteProviderResponse](
+			httpClient,
+			baseURL+LLMServiceDeleteProviderProcedure,
+			connect.WithSchema(lLMServiceMethods.ByName("DeleteProvider")),
+			connect.WithClientOptions(opts...),
+		),
 		generate: connect.NewClient[v2.GenerateLLMRequest, v2.GenerateLLMResponse](
 			httpClient,
 			baseURL+LLMServiceGenerateProcedure,
@@ -2679,7 +2729,37 @@ func NewLLMServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 
 // lLMServiceClient implements LLMServiceClient.
 type lLMServiceClient struct {
-	generate *connect.Client[v2.GenerateLLMRequest, v2.GenerateLLMResponse]
+	createProvider *connect.Client[v2.CreateProviderRequest, v2.CreateProviderResponse]
+	getProvider    *connect.Client[v2.GetProviderRequest, v2.GetProviderResponse]
+	listProviders  *connect.Client[v2.ListProvidersRequest, v2.ListProvidersResponse]
+	updateProvider *connect.Client[v2.UpdateProviderRequest, v2.UpdateProviderResponse]
+	deleteProvider *connect.Client[v2.DeleteProviderRequest, v2.DeleteProviderResponse]
+	generate       *connect.Client[v2.GenerateLLMRequest, v2.GenerateLLMResponse]
+}
+
+// CreateProvider calls agentcompose.v2.LLMService.CreateProvider.
+func (c *lLMServiceClient) CreateProvider(ctx context.Context, req *connect.Request[v2.CreateProviderRequest]) (*connect.Response[v2.CreateProviderResponse], error) {
+	return c.createProvider.CallUnary(ctx, req)
+}
+
+// GetProvider calls agentcompose.v2.LLMService.GetProvider.
+func (c *lLMServiceClient) GetProvider(ctx context.Context, req *connect.Request[v2.GetProviderRequest]) (*connect.Response[v2.GetProviderResponse], error) {
+	return c.getProvider.CallUnary(ctx, req)
+}
+
+// ListProviders calls agentcompose.v2.LLMService.ListProviders.
+func (c *lLMServiceClient) ListProviders(ctx context.Context, req *connect.Request[v2.ListProvidersRequest]) (*connect.Response[v2.ListProvidersResponse], error) {
+	return c.listProviders.CallUnary(ctx, req)
+}
+
+// UpdateProvider calls agentcompose.v2.LLMService.UpdateProvider.
+func (c *lLMServiceClient) UpdateProvider(ctx context.Context, req *connect.Request[v2.UpdateProviderRequest]) (*connect.Response[v2.UpdateProviderResponse], error) {
+	return c.updateProvider.CallUnary(ctx, req)
+}
+
+// DeleteProvider calls agentcompose.v2.LLMService.DeleteProvider.
+func (c *lLMServiceClient) DeleteProvider(ctx context.Context, req *connect.Request[v2.DeleteProviderRequest]) (*connect.Response[v2.DeleteProviderResponse], error) {
+	return c.deleteProvider.CallUnary(ctx, req)
 }
 
 // Generate calls agentcompose.v2.LLMService.Generate.
@@ -2689,6 +2769,12 @@ func (c *lLMServiceClient) Generate(ctx context.Context, req *connect.Request[v2
 
 // LLMServiceHandler is an implementation of the agentcompose.v2.LLMService service.
 type LLMServiceHandler interface {
+	// Manage API-owned upstream model providers, not coding-agent providers.
+	CreateProvider(context.Context, *connect.Request[v2.CreateProviderRequest]) (*connect.Response[v2.CreateProviderResponse], error)
+	GetProvider(context.Context, *connect.Request[v2.GetProviderRequest]) (*connect.Response[v2.GetProviderResponse], error)
+	ListProviders(context.Context, *connect.Request[v2.ListProvidersRequest]) (*connect.Response[v2.ListProvidersResponse], error)
+	UpdateProvider(context.Context, *connect.Request[v2.UpdateProviderRequest]) (*connect.Response[v2.UpdateProviderResponse], error)
+	DeleteProvider(context.Context, *connect.Request[v2.DeleteProviderRequest]) (*connect.Response[v2.DeleteProviderResponse], error)
 	Generate(context.Context, *connect.Request[v2.GenerateLLMRequest]) (*connect.Response[v2.GenerateLLMResponse], error)
 }
 
@@ -2699,6 +2785,36 @@ type LLMServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewLLMServiceHandler(svc LLMServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	lLMServiceMethods := v2.File_agentcompose_v2_agentcompose_proto.Services().ByName("LLMService").Methods()
+	lLMServiceCreateProviderHandler := connect.NewUnaryHandler(
+		LLMServiceCreateProviderProcedure,
+		svc.CreateProvider,
+		connect.WithSchema(lLMServiceMethods.ByName("CreateProvider")),
+		connect.WithHandlerOptions(opts...),
+	)
+	lLMServiceGetProviderHandler := connect.NewUnaryHandler(
+		LLMServiceGetProviderProcedure,
+		svc.GetProvider,
+		connect.WithSchema(lLMServiceMethods.ByName("GetProvider")),
+		connect.WithHandlerOptions(opts...),
+	)
+	lLMServiceListProvidersHandler := connect.NewUnaryHandler(
+		LLMServiceListProvidersProcedure,
+		svc.ListProviders,
+		connect.WithSchema(lLMServiceMethods.ByName("ListProviders")),
+		connect.WithHandlerOptions(opts...),
+	)
+	lLMServiceUpdateProviderHandler := connect.NewUnaryHandler(
+		LLMServiceUpdateProviderProcedure,
+		svc.UpdateProvider,
+		connect.WithSchema(lLMServiceMethods.ByName("UpdateProvider")),
+		connect.WithHandlerOptions(opts...),
+	)
+	lLMServiceDeleteProviderHandler := connect.NewUnaryHandler(
+		LLMServiceDeleteProviderProcedure,
+		svc.DeleteProvider,
+		connect.WithSchema(lLMServiceMethods.ByName("DeleteProvider")),
+		connect.WithHandlerOptions(opts...),
+	)
 	lLMServiceGenerateHandler := connect.NewUnaryHandler(
 		LLMServiceGenerateProcedure,
 		svc.Generate,
@@ -2707,6 +2823,16 @@ func NewLLMServiceHandler(svc LLMServiceHandler, opts ...connect.HandlerOption) 
 	)
 	return "/agentcompose.v2.LLMService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case LLMServiceCreateProviderProcedure:
+			lLMServiceCreateProviderHandler.ServeHTTP(w, r)
+		case LLMServiceGetProviderProcedure:
+			lLMServiceGetProviderHandler.ServeHTTP(w, r)
+		case LLMServiceListProvidersProcedure:
+			lLMServiceListProvidersHandler.ServeHTTP(w, r)
+		case LLMServiceUpdateProviderProcedure:
+			lLMServiceUpdateProviderHandler.ServeHTTP(w, r)
+		case LLMServiceDeleteProviderProcedure:
+			lLMServiceDeleteProviderHandler.ServeHTTP(w, r)
 		case LLMServiceGenerateProcedure:
 			lLMServiceGenerateHandler.ServeHTTP(w, r)
 		default:
@@ -2717,6 +2843,26 @@ func NewLLMServiceHandler(svc LLMServiceHandler, opts ...connect.HandlerOption) 
 
 // UnimplementedLLMServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedLLMServiceHandler struct{}
+
+func (UnimplementedLLMServiceHandler) CreateProvider(context.Context, *connect.Request[v2.CreateProviderRequest]) (*connect.Response[v2.CreateProviderResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.LLMService.CreateProvider is not implemented"))
+}
+
+func (UnimplementedLLMServiceHandler) GetProvider(context.Context, *connect.Request[v2.GetProviderRequest]) (*connect.Response[v2.GetProviderResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.LLMService.GetProvider is not implemented"))
+}
+
+func (UnimplementedLLMServiceHandler) ListProviders(context.Context, *connect.Request[v2.ListProvidersRequest]) (*connect.Response[v2.ListProvidersResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.LLMService.ListProviders is not implemented"))
+}
+
+func (UnimplementedLLMServiceHandler) UpdateProvider(context.Context, *connect.Request[v2.UpdateProviderRequest]) (*connect.Response[v2.UpdateProviderResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.LLMService.UpdateProvider is not implemented"))
+}
+
+func (UnimplementedLLMServiceHandler) DeleteProvider(context.Context, *connect.Request[v2.DeleteProviderRequest]) (*connect.Response[v2.DeleteProviderResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.LLMService.DeleteProvider is not implemented"))
+}
 
 func (UnimplementedLLMServiceHandler) Generate(context.Context, *connect.Request[v2.GenerateLLMRequest]) (*connect.Response[v2.GenerateLLMResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.LLMService.Generate is not implemented"))


### PR DESCRIPTION
## Summary

Add live CRUD for API-owned upstream LLM providers on `LLMService`, with CLI `llm provider` commands. Updates preserve omitted `name` / `api_key` / `enabled` (and `base_url` / `protocol`). Anthropic Messages providers send `anthropic-version: 2023-06-01` by default. Env bootstrap remains last fallback, and post-delete literal model refs are unchanged.

## Testing

- `go test ./pkg/llms ./pkg/storage/configstore ./pkg/agentcompose/api -count=1`
- `go test ./cmd/agent-compose -count=1 -run 'TestIntegrationCLILLMProviderCommands|TestPublicCLIContractSnapshot|TestE2ECLIHelpCoversUserWorkflowCommandSurface'`
- `UPDATE_CLI_CONTRACT=1 go test ./cmd/agent-compose -count=1 -run TestPublicCLIContractSnapshot`
- `task lint` / `task test` / `task docs:build` were not run in this follow-up.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.
