### PR TITLE
fix(runs): don't run a human message the run has already recorded

### DIFF
--- a/docs/design/resumable-interactive-session.md
+++ b/docs/design/resumable-interactive-session.md
@@ -35,6 +35,8 @@ Run
 
 第一阶段只允许一个 attachment 持有输入租约，多个 attachment 可订阅输出。输入复用现有 `client_frame_id` 做幂等去重，并由 session 内部单写者队列保证顺序。终态、超时、取消和空闲清理必须由 session manager 统一处理。
 
+去重覆盖落库和执行两侧：已记录过的 human message 不会再次交给 agent。同一 `client_frame_id`、同一文本视为重发，daemon 以非终止的 `AttachError` 回应 `duplicate_message`；同一 `client_frame_id` 对应不同文本时回应 `client_frame_id_reused`，同样不执行，会话继续。两者都在 `details["client_frame_id"]` 中指明所回应的消息。prompt 模式下首帧的 `client_frame_id` 同时是首轮消息的身份，因此首轮消息的重发也能被识别；不带 `client_frame_id` 的消息按位置派生身份，始终视为新消息。
+
 ## 输出恢复
 
 attachment 应支持从事件序号继续订阅。初期可复用现有 `ListRunEvents`/`FollowRunLogs`，后续将历史补发与实时订阅合并，避免刷新时丢事件。

--- a/pkg/agentcompose/api/run_attach_mapper.go
+++ b/pkg/agentcompose/api/run_attach_mapper.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"maps"
+
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"time"
@@ -28,7 +30,7 @@ func RunAttachOutputToProto(output runs.RunAttachOutput) *agentcomposev2.AttachA
 	case runs.RunAttachOutputResult:
 		response.Frame = &agentcomposev2.AttachAgentRunResponse_Result{Result: &agentcomposev2.AttachResult{ExitCode: int32(output.ExitCode), Success: output.Success, Run: ProjectRunSummaryToProto(output.Run), Output: output.Output, ResultJson: output.ResultJSON, Error: output.Error}}
 	case runs.RunAttachOutputError:
-		response.Frame = &agentcomposev2.AttachAgentRunResponse_Error{Error: &agentcomposev2.AttachError{Code: output.Code, Message: output.Error, Terminal: output.Terminal}}
+		response.Frame = &agentcomposev2.AttachAgentRunResponse_Error{Error: &agentcomposev2.AttachError{Code: output.Code, Message: output.Error, Terminal: output.Terminal, Details: maps.Clone(output.Details)}}
 	}
 	return response
 }

--- a/pkg/agentcompose/api/run_attach_mapper_test.go
+++ b/pkg/agentcompose/api/run_attach_mapper_test.go
@@ -40,3 +40,20 @@ func TestRunAttachOutputToProtoPreservesCreatedAt(t *testing.T) {
 		t.Fatalf("created at = %s, want %s", got, createdAt)
 	}
 }
+
+// A declined human message names the client frame it answers in the error's
+// details. Without them a client that has since sent another message could not
+// tell which of its messages the answer is about.
+func TestRunAttachOutputToProtoCarriesErrorDetails(t *testing.T) {
+	details := map[string]string{"client_frame_id": "frame-1"}
+	response := RunAttachOutputToProto(runs.RunAttachOutput{Kind: runs.RunAttachOutputError, Code: "duplicate_message", Details: details})
+	if got := response.GetError().GetDetails()["client_frame_id"]; got != "frame-1" {
+		t.Fatalf("details client_frame_id = %q, want frame-1", got)
+	}
+	// The frame holds its own copy, so a sender that reuses its map cannot
+	// rewrite a frame already on its way out.
+	details["client_frame_id"] = "changed"
+	if got := response.GetError().GetDetails()["client_frame_id"]; got != "frame-1" {
+		t.Fatalf("details followed the sender's map to %q", got)
+	}
+}

--- a/pkg/runs/attach_output.go
+++ b/pkg/runs/attach_output.go
@@ -37,6 +37,9 @@ type RunAttachOutput struct {
 	ExitCode    int
 	Success     bool
 	Terminal    bool
+	// Details carries structured context for an error frame, such as which
+	// client frame it answers.
+	Details map[string]string
 }
 
 type RunAttachSender func(RunAttachOutput) error
@@ -63,6 +66,28 @@ func runAttachResultResponse(run domain.ProjectRunRecord, transition TransitionR
 
 func runAttachErrorResponse(code, message string, terminal bool) RunAttachOutput {
 	return RunAttachOutput{Kind: RunAttachOutputError, CreatedAt: time.Now().UTC(), Code: code, Error: message, Terminal: terminal}
+}
+
+// Attach error codes a prompt run uses to tell a client that a human message
+// it sent was not run. Both are non-terminal — the session carries on — and
+// the frame's details name the client frame the answer is about.
+const (
+	// attachErrorDuplicateMessage answers a message whose client frame ID the
+	// run has already recorded with the same text: a resend of something that
+	// was delivered. Running it again would redo the agent's work.
+	attachErrorDuplicateMessage = "duplicate_message"
+	// attachErrorClientFrameReused answers a message whose client frame ID the
+	// run has already recorded with different text. The ID is the client's
+	// promise that the two are one message, and that promise was broken.
+	attachErrorClientFrameReused = "client_frame_id_reused"
+)
+
+// runAttachRejectedMessageResponse tells the client that the human message it
+// sent as clientFrameID was not handed to the agent, and why.
+func runAttachRejectedMessageResponse(code, message, clientFrameID string) RunAttachOutput {
+	output := runAttachErrorResponse(code, message, false)
+	output.Details = map[string]string{"client_frame_id": clientFrameID}
+	return output
 }
 
 func driverOutputStreamToRun(frameType driverpkg.RuntimeOutputFrameType) domain.StdioStream {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -214,6 +214,11 @@ type RunAgentRequest struct {
 	StickyBindingConfigHash  string
 	Interactive              bool
 	Labels                   map[string]string
+	// PromptFrameID is the client frame ID of the start frame that carried
+	// Prompt, set only for an attached prompt run. It gives the opening message
+	// the identity a later human message with that frame ID would get, so a
+	// client resending the opening message is recognised as doing so.
+	PromptFrameID string
 }
 
 type StreamSink struct {
@@ -262,6 +267,7 @@ func (c *Controller) StartProjectRun(ctx context.Context, req RunAgentRequest) (
 		CleanupPolicy:   CleanupPolicyFromProto(req.CleanupPolicy),
 		ClientRequestID: req.ClientRequestID,
 		Labels:          req.Labels,
+		PromptFrameID:   req.PromptFrameID,
 	})
 	if err != nil {
 		return StartedProjectRun{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
@@ -330,6 +336,11 @@ func (c *Controller) RunProjectCommandAttachRegistered(ctx, inputCtx context.Con
 	}
 	if mode == RunAttachModePrompt && strings.TrimSpace(req.Prompt) == "" {
 		return fmt.Errorf("%w: run attach prompt is required", ErrInvalidRequest)
+	}
+	if mode == RunAttachModePrompt {
+		// The start frame carries the opening message, so its frame ID is that
+		// message's identity.
+		req.PromptFrameID = first.ClientFrameID
 	}
 	started, err := c.StartProjectRun(ctx, req)
 	if err != nil {

--- a/pkg/runs/controller.go
+++ b/pkg/runs/controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/chaitin/agent-compose/internal/projects"
@@ -464,8 +465,17 @@ func interactiveSessionDomainError(err error) error {
 }
 
 func newInteractiveRunOutputSender(session *InteractiveSession, policy AttachDisconnectPolicy, send RunAttachSender) RunAttachSender {
+	// Every writer of an attached run shares this sender: the receive loop, the
+	// prompt input pump declining a message it has already recorded, and the
+	// result frame sent once the interaction returns — while that pump may
+	// still be running. The stream takes one send at a time and detached is
+	// plain state, so the send is serialized here, where that state lives,
+	// rather than by whichever caller happens to know about a second writer.
+	var mu sync.Mutex
 	detached := false
 	return func(output RunAttachOutput) error {
+		mu.Lock()
+		defer mu.Unlock()
 		session.Publish(output)
 		if detached {
 			return nil

--- a/pkg/runs/coordinator.go
+++ b/pkg/runs/coordinator.go
@@ -26,6 +26,9 @@ type StartRequest struct {
 	CleanupPolicy   string
 	ClientRequestID string
 	Labels          map[string]string
+	// PromptFrameID, when set, identifies Prompt by the client frame that
+	// carried it. See RunAgentRequest.PromptFrameID.
+	PromptFrameID string
 }
 
 type TransitionRequest struct {
@@ -156,7 +159,7 @@ func (c *Coordinator) BeginRun(ctx context.Context, req StartRequest) (domain.Pr
 	}
 	var initialEvents []domain.ProjectRunEventRecord
 	if strings.TrimSpace(run.Prompt) != "" {
-		initialEvents = append(initialEvents, domain.ProjectRunEventRecord{ID: initialPromptEventID(run.RunID), RunID: run.RunID, Kind: domain.ProjectRunEventKindUserMessage, Text: run.Prompt, Agent: run.AgentName})
+		initialEvents = append(initialEvents, domain.ProjectRunEventRecord{ID: openingPromptEventID(run.RunID, req.PromptFrameID), RunID: run.RunID, Kind: domain.ProjectRunEventKindUserMessage, Text: run.Prompt, Agent: run.AgentName})
 	}
 	created, err := c.store.CreateProjectRunWithEvents(ctx, run, initialEvents)
 	if err != nil {

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1217,10 +1218,10 @@ func TestPromptAttachProjectorSeparatesHumanMessageFromStderrTail(t *testing.T) 
 func TestPromptAttachProjectorPersistsEachFrameIdempotently(t *testing.T) {
 	store := &projectorEventStore{keys: map[string]struct{}{}}
 	projector := newPersistentPromptAttachProjector(context.Background(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-events", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: store})
-	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
+	if _, err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
-	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
+	if _, err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("retry human frame: %v", err)
 	}
 	activity := []byte(`{"seq":41,"type":"agent_event","event":{"kind":"text_delta","text":"\\n$ curl https://weather.test\\n{\"temperature\":26}\n"}}` + "\n")
@@ -1252,7 +1253,7 @@ func TestPromptAttachProjectorPersistsEachFrameIdempotently(t *testing.T) {
 func TestPromptAttachProjectorProjectsTerminalAgentEventAfterOnlyHumanMessage(t *testing.T) {
 	store := &projectorEventStore{keys: map[string]struct{}{}}
 	projector := newPersistentPromptAttachProjector(context.Background(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-result-only", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: store})
-	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
+	if _, err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
 	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n"))
@@ -1270,7 +1271,7 @@ func TestPromptAttachProjectorProjectsTerminalAgentEventAfterOnlyHumanMessage(t 
 func TestIntegrationPromptAttachProjectorPersistsAssistantTurnBeforeSkippingTerminalEvent(t *testing.T) {
 	store := &projectorEventStore{keys: map[string]struct{}{}}
 	projector := newPersistentPromptAttachProjector(context.Background(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-integration-events", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: store})
-	if err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
+	if _, err := projector.AppendHumanMessageFrame("question", "client-frame-1"); err != nil {
 		t.Fatalf("append human frame: %v", err)
 	}
 	_, transition, err := projector.Project([]byte(`{"seq":43,"type":"result","finalText":"answer","finalTextSource":"provider_message","stopReason":"end_turn"}` + "\n"))
@@ -1303,6 +1304,10 @@ type projectorEventStore struct {
 
 func (s *projectorEventStore) AppendProjectRunEvent(_ context.Context, event domain.ProjectRunEventRecord) (domain.ProjectRunEventRecord, bool, error) {
 	if _, exists := s.keys[event.ID]; exists {
+		// Like the real store, a duplicate answers with what was recorded.
+		if i := slices.IndexFunc(s.events, func(recorded domain.ProjectRunEventRecord) bool { return recorded.ID == event.ID }); i >= 0 {
+			return s.events[i], false, nil
+		}
 		return event, false, nil
 	}
 	s.keys[event.ID] = struct{}{}

--- a/pkg/runs/human_message_dedup_attach_test.go
+++ b/pkg/runs/human_message_dedup_attach_test.go
@@ -1,0 +1,45 @@
+package runs
+
+import (
+	"slices"
+	"testing"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	agentcomposev2 "github.com/chaitin/agent-compose/proto/agentcompose/v2"
+)
+
+// The start frame's client frame ID has to survive the trip from the attach
+// stream to the run's creation, or the opening message is recorded under the
+// run-scoped identity and a resend of it goes unrecognised. The provider is one
+// prompt attach refuses, so the run is created and its opening message recorded
+// without a runtime ever being opened.
+func TestPromptAttachNamesTheOpeningMessageByItsStartFrame(t *testing.T) {
+	controller, configDB, _ := newTestRunAttachController(t, nil)
+	configDB.revision.SpecJSON = `{"agents":[{"name":"worker","provider":"gemini"}]}`
+	requests := []*agentcomposev2.AttachAgentRunRequest{{
+		ClientFrameId: "frame-open",
+		Frame: &agentcomposev2.AttachAgentRunRequest_Start{Start: &agentcomposev2.AttachAgentRunStart{
+			Request: &agentcomposev2.RunAgentRequest{ProjectId: "project-1", AgentName: "worker", Prompt: "hello"},
+			Mode:    agentcomposev2.AttachRunMode_ATTACH_RUN_MODE_PROMPT,
+		}},
+	}}
+	var runID string
+	err := controller.RunProjectCommandAttach(t.Context(), recvAttachAgentRunRequests(requests), func(output RunAttachOutput) error {
+		if output.Kind == RunAttachOutputResult {
+			runID = output.Run.RunID
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunProjectCommandAttach: %v", err)
+	}
+	if runID == "" {
+		t.Fatal("the run never reported its result")
+	}
+	named := attachedHumanEventID(runID, "frame-open", 0, "")
+	if !slices.ContainsFunc(configDB.events, func(event domain.ProjectRunEventRecord) bool {
+		return event.ID == named && event.Text == "hello"
+	}) {
+		t.Fatalf("opening message events = %#v, want it named by the start frame", configDB.events)
+	}
+}

--- a/pkg/runs/human_message_dedup_test.go
+++ b/pkg/runs/human_message_dedup_test.go
@@ -1,0 +1,301 @@
+package runs
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	domain "github.com/chaitin/agent-compose/pkg/model"
+)
+
+// A client resends a message when it lost the stream before the turn's outcome
+// reached it, and it resends under the frame ID the message already had.
+// Recording it again would put the message in the history twice.
+func TestProjectorRecordsAResentMessageOnce(t *testing.T) {
+	store := &projectorEventStore{keys: map[string]struct{}{}}
+	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+	projector := newPersistentPromptAttachProjector(t.Context(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-resend", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: logsPath, EventStore: store})
+
+	if fresh, err := projector.AppendHumanMessageFrame("question", "frame-1"); err != nil || !fresh {
+		t.Fatalf("first delivery = (%v, %v), want a new message", fresh, err)
+	}
+	if fresh, err := projector.AppendHumanMessageFrame("question", "frame-1"); err != nil || fresh {
+		t.Fatalf("resend = (%v, %v), want it recognised as already delivered", fresh, err)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("recorded %d events, want 1", len(store.events))
+	}
+	// The transcript is the other place a message lands, and the resend must
+	// not appear there either.
+	transcript, err := os.ReadFile(logsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if got := strings.Count(string(transcript), "question"); got != 1 {
+		t.Fatalf("transcript shows the message %d times, want once: %q", got, transcript)
+	}
+}
+
+// A frame ID is the client's promise that two messages are one. Different text
+// under an ID already recorded breaks that promise, and treating it as a resend
+// would silently drop what the person actually said.
+func TestProjectorRefusesAFrameIDReusedForADifferentMessage(t *testing.T) {
+	store := &projectorEventStore{keys: map[string]struct{}{}}
+	logsPath := filepath.Join(t.TempDir(), "transcript.txt")
+	projector := newPersistentPromptAttachProjector(t.Context(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-reused", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: logsPath, EventStore: store})
+
+	if _, err := projector.AppendHumanMessageFrame("question", "frame-1"); err != nil {
+		t.Fatalf("first delivery: %v", err)
+	}
+	fresh, err := projector.AppendHumanMessageFrame("something else", "frame-1")
+	if !errors.Is(err, errClientFrameReused) || fresh {
+		t.Fatalf("reused frame ID = (%v, %v), want errClientFrameReused", fresh, err)
+	}
+	if len(store.events) != 1 || store.events[0].Text != "question" {
+		t.Fatalf("recorded events = %#v, want only the original message", store.events)
+	}
+	transcript, err := os.ReadFile(logsPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if strings.Contains(string(transcript), "something else") {
+		t.Fatalf("a refused message reached the transcript: %q", transcript)
+	}
+}
+
+// Without a frame ID a message is identified by its position, which never
+// repeats. That is every client that predates frame IDs, the CLI among them,
+// and a person saying the same thing twice has to be heard twice.
+func TestProjectorTreatsMessagesWithoutAFrameIDAsAlwaysNew(t *testing.T) {
+	store := &projectorEventStore{keys: map[string]struct{}{}}
+	projector := newPersistentPromptAttachProjector(t.Context(), persistentPromptAttachProjectorDeps{Run: domain.ProjectRunRecord{RunID: "run-unnamed", AgentName: "worker"}, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: store})
+
+	for range 2 {
+		if fresh, err := projector.AppendHumanMessageFrame("again", ""); err != nil || !fresh {
+			t.Fatalf("unnamed message = (%v, %v), want a new message every time", fresh, err)
+		}
+	}
+	if len(store.events) != 2 {
+		t.Fatalf("recorded %d events, want 2", len(store.events))
+	}
+}
+
+// A message already delivered is not handed to the agent again, and the turn
+// gate it took is handed straight back: no turn runs for it, so nothing else
+// would ever release that gate.
+func TestPumpDoesNotRunAMessageAlreadyDelivered(t *testing.T) {
+	interaction, answers, done := startPromptPump(t,
+		func(_, clientFrameID string) (bool, error) { return clientFrameID != "frame-delivered", nil },
+		RunAttachInput{Kind: RunAttachInputHumanMessage, Text: "again", ClientFrameID: "frame-delivered"},
+		RunAttachInput{Kind: RunAttachInputHumanMessage, Text: "next", ClientFrameID: "frame-new"},
+	)
+
+	// The next message reaches the agent without anyone releasing the gate a
+	// second time. Had the declined message kept the turn it took, this would
+	// wait for a turn that is never coming.
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "next")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "eof", "")
+	waitForPump(t, done)
+	// A client waiting on the resend would otherwise wait forever: it has to
+	// be told, by name, that this message was not run.
+	assertDeclined(t, answers, attachErrorDuplicateMessage, "frame-delivered")
+}
+
+// A frame ID reused for different text is answered and not run, and — unlike
+// a failure to record — does not end the session: it is the client's mistake,
+// not the daemon's.
+func TestPumpAnswersAReusedFrameIDWithoutRunningIt(t *testing.T) {
+	interaction, answers, done := startPromptPump(t,
+		func(_, clientFrameID string) (bool, error) {
+			if clientFrameID == "frame-reused" {
+				return false, errClientFrameReused
+			}
+			return true, nil
+		},
+		RunAttachInput{Kind: RunAttachInputHumanMessage, Text: "different", ClientFrameID: "frame-reused"},
+		RunAttachInput{Kind: RunAttachInputHumanMessage, Text: "next", ClientFrameID: "frame-new"},
+	)
+
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "human_message", "next")
+	assertPromptRuntimeFrame(t, receiveRuntimeInputFrame(t, interaction.sent), "eof", "")
+	waitForPump(t, done)
+	assertDeclined(t, answers, attachErrorClientFrameReused, "frame-reused")
+}
+
+// A message that could not be recorded still ends the input, as it did before
+// duplicates were told apart. Declining is only for messages known to be
+// delivered.
+func TestPumpStillStopsWhenAMessageCannotBeRecorded(t *testing.T) {
+	interaction, answers, done := startPromptPump(t,
+		func(string, string) (bool, error) { return false, errors.New("disk full") },
+		RunAttachInput{Kind: RunAttachInputHumanMessage, Text: "question", ClientFrameID: "frame-1"},
+	)
+
+	waitForPump(t, done)
+	assertNoRuntimeInputFrame(t, interaction.sent)
+	select {
+	case answer := <-answers:
+		t.Fatalf("a recording failure was answered as a declined message: %#v", answer)
+	default:
+	}
+}
+
+// The opening message travels in the start frame and is recorded when the run
+// is created, well away from the attached-message path that sees a resend. A
+// resend is recognised only because both take their identity from the frame
+// ID the client gave the start frame.
+func TestAResentOpeningMessageIsRecognisedByTheFrameThatCarriedIt(t *testing.T) {
+	store := newOpeningPromptRunStore()
+	coordinator := NewCoordinator(store, func(_, _, _, key string) (string, error) { return "run-" + key, nil })
+	run, err := coordinator.BeginRun(t.Context(), StartRequest{ProjectID: "project-1", AgentName: "worker", Source: domain.ProjectRunSourceAPI, ClientRequestID: "open", Prompt: "hello", PromptFrameID: "frame-open"})
+	if err != nil {
+		t.Fatalf("BeginRun: %v", err)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("recorded %d opening events, want 1", len(store.events))
+	}
+	opening := store.events[0]
+
+	events := &projectorEventStore{keys: map[string]struct{}{opening.ID: {}}, events: []domain.ProjectRunEventRecord{opening}}
+	projector := newPersistentPromptAttachProjector(t.Context(), persistentPromptAttachProjectorDeps{Run: run, Sandbox: &domain.Sandbox{}, LogsPath: filepath.Join(t.TempDir(), "transcript.txt"), EventStore: events})
+	if fresh, err := projector.AppendHumanMessageFrame("hello", "frame-open"); err != nil || fresh {
+		t.Fatalf("resent opening message = (%v, %v), want it recognised as already delivered", fresh, err)
+	}
+}
+
+// Runs started without a frame ID — the CLI, the scheduler, every client that
+// predates this — keep the identity their opening message always had, so no
+// persisted event changes its name.
+func TestAnOpeningMessageWithoutAFrameIDKeepsItsIdentity(t *testing.T) {
+	store := newOpeningPromptRunStore()
+	coordinator := NewCoordinator(store, func(_, _, _, key string) (string, error) { return "run-" + key, nil })
+	run, err := coordinator.BeginRun(t.Context(), StartRequest{ProjectID: "project-1", AgentName: "worker", Source: domain.ProjectRunSourceAPI, ClientRequestID: "plain", Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("BeginRun: %v", err)
+	}
+	if len(store.events) != 1 || store.events[0].ID != initialPromptEventID(run.RunID) {
+		t.Fatalf("opening events = %#v, want the run-scoped identity", store.events)
+	}
+}
+
+// What makes the two paths meet: a named opening message is exactly the
+// attached-message identity for that frame, whatever its position or text.
+func TestOpeningPromptIdentityIsTheAttachedMessageIdentity(t *testing.T) {
+	const runID = "run-identity"
+	named := openingPromptEventID(runID, "frame-open")
+	if named != attachedHumanEventID(runID, "frame-open", 7, "anything") {
+		t.Fatal("a named opening message does not share the attached-message identity for its frame")
+	}
+	if named == initialPromptEventID(runID) {
+		t.Fatal("a named opening message kept the run-scoped identity")
+	}
+	if openingPromptEventID(runID, "  ") != initialPromptEventID(runID) {
+		t.Fatal("a blank frame ID changed the opening message's identity")
+	}
+}
+
+// The receive loop and the input pump now both answer the client. The stream
+// underneath takes one send at a time, so the wrapper has to be what orders
+// them; run under -race this fails if it does not.
+func TestSerializedRunAttachSenderAnswersOneAtATime(t *testing.T) {
+	var answered int
+	send := serializeRunAttachSender(func(RunAttachOutput) error {
+		answered++ // deliberately unsynchronized: the wrapper must serialize it
+		return nil
+	})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 100 {
+				_ = send(RunAttachOutput{})
+			}
+		})
+	}
+	wg.Wait()
+	if answered != 800 {
+		t.Fatalf("answered %d times, want 800", answered)
+	}
+}
+
+// startPromptPump feeds requests to a prompt input pump until they run out,
+// with the gate open as it is once the previous turn has completed, and
+// returns what reached the agent, what the client was answered, and when the
+// pump finished.
+func startPromptPump(t *testing.T, record func(text, clientFrameID string) (bool, error), requests ...RunAttachInput) (*observedRuntimeInteraction, <-chan RunAttachOutput, <-chan struct{}) {
+	t.Helper()
+	interaction := newObservedRuntimeInteraction()
+	turnReady := make(chan struct{}, 1)
+	turnReady <- struct{}{}
+	answers := make(chan RunAttachOutput, len(requests))
+	queue := make(chan RunAttachInput, len(requests))
+	for _, request := range requests {
+		queue <- request
+	}
+	close(queue)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pumpRunPromptAttachInput(t.Context(), func() (RunAttachInput, error) {
+			request, ok := <-queue
+			if !ok {
+				return RunAttachInput{}, io.EOF
+			}
+			return request, nil
+		}, promptInputPump{
+			Input:          &promptWrapperInput{interaction: interaction},
+			TurnReady:      turnReady,
+			OnHumanMessage: record,
+			Send: func(output RunAttachOutput) error {
+				answers <- output
+				return nil
+			},
+		})
+	}()
+	return interaction, answers, done
+}
+
+func waitForPump(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("prompt input pump did not finish")
+	}
+}
+
+// assertDeclined checks that the client was told, once and without ending the
+// session, that the message it sent as clientFrameID was not run.
+func assertDeclined(t *testing.T, answers <-chan RunAttachOutput, code, clientFrameID string) {
+	t.Helper()
+	select {
+	case answer := <-answers:
+		if answer.Kind != RunAttachOutputError || answer.Terminal || answer.Code != code || answer.Details["client_frame_id"] != clientFrameID {
+			t.Fatalf("answer = %#v, want a non-terminal %s naming %s", answer, code, clientFrameID)
+		}
+	default:
+		t.Fatalf("the client was never told its %s message was not run", clientFrameID)
+	}
+	select {
+	case extra := <-answers:
+		t.Fatalf("unexpected further answer %#v", extra)
+	default:
+	}
+}
+
+// newOpeningPromptRunStore is a run store holding one enabled agent, enough for
+// BeginRun to create a run with an opening message.
+func newOpeningPromptRunStore() *fakeRunStore {
+	return &fakeRunStore{
+		project: domain.ProjectRecord{ID: "project-1", Name: "Project", CurrentRevision: 3},
+		revision: domain.ProjectRevisionRecord{ProjectID: "project-1", Revision: 3,
+			SpecJSON: `{"name":"project","agents":[{"name":"worker","provider":"codex","image":"guest:latest","driver":{"name":"docker"},"enabled":true}]}`},
+		projectAgent: domain.ProjectAgentRecord{ProjectID: "project-1", AgentName: "worker", ID: "agent-1", Driver: "docker", Image: "guest:latest"},
+		agent:        domain.AgentDefinition{ID: "agent-1", Enabled: true, Driver: "docker", GuestImage: "guest:latest", ProjectID: "project-1", AgentName: "worker"},
+		runs:         map[string]domain.ProjectRunRecord{},
+	}
+}

--- a/pkg/runs/human_message_dedup_test.go
+++ b/pkg/runs/human_message_dedup_test.go
@@ -1,6 +1,7 @@
 package runs
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -199,27 +200,86 @@ func TestOpeningPromptIdentityIsTheAttachedMessageIdentity(t *testing.T) {
 	}
 }
 
-// The receive loop and the input pump now both answer the client. The stream
-// underneath takes one send at a time, so the wrapper has to be what orders
-// them; run under -race this fails if it does not.
-func TestSerializedRunAttachSenderAnswersOneAtATime(t *testing.T) {
-	var answered int
-	send := serializeRunAttachSender(func(RunAttachOutput) error {
-		answered++ // deliberately unsynchronized: the wrapper must serialize it
+// Several goroutines write to an attached run's sender: the receive loop, the
+// input pump declining a message, and the result frame sent after the
+// interaction returns while the pump may still be alive. The sender itself has
+// to order them — the stream takes one send at a time and its detached flag is
+// plain state — so no caller can end up holding an unserialized one. Under
+// -race this fails if it does not.
+func TestInteractiveRunOutputSenderIsSafeForConcurrentWriters(t *testing.T) {
+	session := NewInteractiveSession("run-concurrent")
+
+	var streamed int
+	attached := newInteractiveRunOutputSender(session, AttachDisconnectCancel, func(RunAttachOutput) error {
+		streamed++ // deliberately unsynchronized: the sender must serialize it
 		return nil
 	})
+	writeConcurrently(attached)
+	if streamed != 800 {
+		t.Fatalf("streamed %d frames, want 800", streamed)
+	}
+
+	// A stream that fails flips the sender to detached: the first failure
+	// writes that flag and every writer reads it.
+	var failed int
+	detaching := newInteractiveRunOutputSender(session, AttachDisconnectDetach, func(RunAttachOutput) error {
+		failed++
+		return errors.New("stream closed")
+	})
+	writeConcurrently(detaching)
+	if failed != 1 {
+		t.Fatalf("wrote to a closed stream %d times, want once before detaching", failed)
+	}
+}
+
+// A pump whose session has just ended can find its turn gate and its context
+// ready together, and select picks either. It must not go on to run or answer
+// the message: its interaction is gone, and the result frame may already be on
+// its way to the client.
+func TestPumpDoesNotAnswerAfterItsSessionEnded(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	interaction := newObservedRuntimeInteraction()
+	turnReady := make(chan struct{}, 1)
+	turnReady <- struct{}{}
+	queue := make(chan RunAttachInput, 1)
+	queue <- RunAttachInput{Kind: RunAttachInputHumanMessage, Text: "again", ClientFrameID: "frame-delivered"}
+	close(queue)
+
+	var answered int
+	pumpRunPromptAttachInput(ctx, func() (RunAttachInput, error) {
+		request, ok := <-queue
+		if !ok {
+			return RunAttachInput{}, io.EOF
+		}
+		return request, nil
+	}, promptInputPump{
+		Input:          &promptWrapperInput{interaction: interaction},
+		TurnReady:      turnReady,
+		OnHumanMessage: func(string, string) (bool, error) { return false, nil },
+		Send: func(RunAttachOutput) error {
+			answered++
+			return nil
+		},
+	})
+
+	if answered != 0 {
+		t.Fatalf("a pump whose session ended answered %d times", answered)
+	}
+	assertNoRuntimeInputFrame(t, interaction.sent)
+}
+
+// writeConcurrently sends through one sender from several goroutines at once.
+func writeConcurrently(send RunAttachSender) {
 	var wg sync.WaitGroup
 	for range 8 {
 		wg.Go(func() {
 			for range 100 {
-				_ = send(RunAttachOutput{})
+				_ = send(RunAttachOutput{Kind: RunAttachOutputData})
 			}
 		})
 	}
 	wg.Wait()
-	if answered != 800 {
-		t.Fatalf("answered %d times, want 800", answered)
-	}
 }
 
 // startPromptPump feeds requests to a prompt input pump until they run out,

--- a/pkg/runs/prompt_attach.go
+++ b/pkg/runs/prompt_attach.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	appconfig "github.com/chaitin/agent-compose/pkg/config"
 	driverpkg "github.com/chaitin/agent-compose/pkg/driver"
@@ -140,9 +139,6 @@ func (c *Controller) runPromptInteractionSession(ctx context.Context, runCtx int
 	sandbox := runCtx.Sandbox
 	logsPath := prepared.LogsPath
 	transition := TransitionRequest{RunID: run.RunID, SandboxID: sandbox.Summary.ID, LogsPath: logsPath}
-	// Two goroutines answer the client from here on: the receive loop, and the
-	// input pump when it declines to run a message it has already recorded.
-	send = serializeRunAttachSender(send)
 	command := strings.Join([]string{
 		"set -e",
 		"cd " + execution.ShellQuote(c.config.GuestWorkspacePath),
@@ -375,7 +371,9 @@ type promptInputPump struct {
 	// OnHumanMessage records a message and reports whether it is new. A
 	// message that is not new has been delivered before and is not run again.
 	OnHumanMessage func(text, clientFrameID string) (bool, error)
-	Send           RunAttachSender
+	// Send answers the client alongside the receive loop, so it must be safe
+	// for concurrent use; the interactive run sender is.
+	Send RunAttachSender
 }
 
 func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, pump promptInputPump) {
@@ -416,6 +414,14 @@ func forwardPromptHumanMessage(ctx context.Context, pump promptInputPump, text, 
 		case <-pump.TurnReady:
 		}
 	}
+	// Both cases can be ready at once when the session has just ended — the
+	// gate released by its last turn, the context by its teardown — and select
+	// picks either. A pump whose session is over must not go on to run or
+	// answer a message: its interaction is gone, and the result frame may
+	// already be on its way to the client.
+	if ctx.Err() != nil {
+		return false
+	}
 	if pump.OnHumanMessage != nil {
 		fresh, err := pump.OnHumanMessage(text, clientFrameID)
 		switch {
@@ -444,18 +450,6 @@ func declinePromptHumanMessage(pump promptInputPump, code, message, clientFrameI
 		// Best effort: a client that cannot hear this has gone, and the
 		// receive loop is the one that finds out.
 		_ = pump.Send(runAttachRejectedMessageResponse(code, message, clientFrameID))
-	}
-}
-
-// serializeRunAttachSender lets several goroutines answer one client. A stream
-// carries one send at a time, and the sender it wraps keeps unsynchronized
-// state of its own.
-func serializeRunAttachSender(send RunAttachSender) RunAttachSender {
-	var mu sync.Mutex
-	return func(output RunAttachOutput) error {
-		mu.Lock()
-		defer mu.Unlock()
-		return send(output)
 	}
 }
 

--- a/pkg/runs/prompt_attach.go
+++ b/pkg/runs/prompt_attach.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	appconfig "github.com/chaitin/agent-compose/pkg/config"
 	driverpkg "github.com/chaitin/agent-compose/pkg/driver"
@@ -139,6 +140,9 @@ func (c *Controller) runPromptInteractionSession(ctx context.Context, runCtx int
 	sandbox := runCtx.Sandbox
 	logsPath := prepared.LogsPath
 	transition := TransitionRequest{RunID: run.RunID, SandboxID: sandbox.Summary.ID, LogsPath: logsPath}
+	// Two goroutines answer the client from here on: the receive loop, and the
+	// input pump when it declines to run a message it has already recorded.
+	send = serializeRunAttachSender(send)
 	command := strings.Join([]string{
 		"set -e",
 		"cd " + execution.ShellQuote(c.config.GuestWorkspacePath),
@@ -190,7 +194,7 @@ func (c *Controller) runPromptInteractionSession(ctx context.Context, runCtx int
 	} else {
 		releasePromptTurn(turnReady)
 	}
-	go pumpRunPromptAttachInput(inputCtx, receive, promptInputPump{Input: input, TurnReady: turnReady, OnHumanMessage: projector.AppendHumanMessageFrame})
+	go pumpRunPromptAttachInput(inputCtx, receive, promptInputPump{Input: input, TurnReady: turnReady, OnHumanMessage: projector.AppendHumanMessageFrame, Send: send})
 	return receivePromptInteractionFrames(run, sandbox, transition, promptInteractionReceiveState{Interaction: interaction, Projector: projector, TurnReady: turnReady}, send)
 }
 
@@ -363,11 +367,15 @@ func (w *promptWrapperInput) send(frame map[string]any) error {
 }
 
 // promptInputPump groups the wrapper input stream, the gate that releases a
-// turn, and the callback notified of each forwarded human message.
+// turn, the callback that records each human message, and the sender used to
+// answer a message it declines to run.
 type promptInputPump struct {
-	Input          *promptWrapperInput
-	TurnReady      <-chan struct{}
-	OnHumanMessage func(string, string) error
+	Input     *promptWrapperInput
+	TurnReady chan struct{}
+	// OnHumanMessage records a message and reports whether it is new. A
+	// message that is not new has been delivered before and is not run again.
+	OnHumanMessage func(text, clientFrameID string) (bool, error)
+	Send           RunAttachSender
 }
 
 func pumpRunPromptAttachInput(ctx context.Context, receive RunAttachReceiver, pump promptInputPump) {
@@ -409,11 +417,46 @@ func forwardPromptHumanMessage(ctx context.Context, pump promptInputPump, text, 
 		}
 	}
 	if pump.OnHumanMessage != nil {
-		if err := pump.OnHumanMessage(text, clientFrameID); err != nil {
+		fresh, err := pump.OnHumanMessage(text, clientFrameID)
+		switch {
+		case errors.Is(err, errClientFrameReused):
+			declinePromptHumanMessage(pump, attachErrorClientFrameReused, "client frame id already names a different message; it was not run", clientFrameID)
+			return true
+		case err != nil:
 			return false
+		case !fresh:
+			declinePromptHumanMessage(pump, attachErrorDuplicateMessage, "message was already delivered; it was not run again", clientFrameID)
+			return true
 		}
 	}
 	return pump.Input.HumanMessage(text) == nil
+}
+
+// declinePromptHumanMessage answers a message the pump will not hand to the
+// agent. No turn runs for it, so the gate it took is handed straight back:
+// nothing else would ever release it, and the next message would wait forever
+// for a turn that is not coming.
+func declinePromptHumanMessage(pump promptInputPump, code, message, clientFrameID string) {
+	if pump.TurnReady != nil {
+		releasePromptTurn(pump.TurnReady)
+	}
+	if pump.Send != nil {
+		// Best effort: a client that cannot hear this has gone, and the
+		// receive loop is the one that finds out.
+		_ = pump.Send(runAttachRejectedMessageResponse(code, message, clientFrameID))
+	}
+}
+
+// serializeRunAttachSender lets several goroutines answer one client. A stream
+// carries one send at a time, and the sender it wraps keeps unsynchronized
+// state of its own.
+func serializeRunAttachSender(send RunAttachSender) RunAttachSender {
+	var mu sync.Mutex
+	return func(output RunAttachOutput) error {
+		mu.Lock()
+		defer mu.Unlock()
+		return send(output)
+	}
 }
 
 func releasePromptTurn(turnReady chan<- struct{}) {

--- a/pkg/runs/prompt_projection.go
+++ b/pkg/runs/prompt_projection.go
@@ -3,6 +3,7 @@ package runs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 
@@ -316,30 +317,54 @@ func streamedFinalTextOverlap(logged, finalText string) int {
 }
 
 func (p *promptAttachProjector) AppendHumanMessage(message string) error {
-	return p.AppendHumanMessageFrame(message, "")
+	_, err := p.AppendHumanMessageFrame(message, "")
+	return err
 }
 
-func (p *promptAttachProjector) AppendHumanMessageFrame(message, clientFrameID string) error {
-	text := promptAttachHumanLogText(message)
+// errClientFrameReused reports a client frame ID the run has already recorded
+// for a different message.
+var errClientFrameReused = errors.New("client frame id already names a different message")
+
+// AppendHumanMessageFrame records one human message and reports whether it is
+// new, which is to say whether the agent should see it.
+//
+// A message whose client frame ID the run has already recorded, with the same
+// text, is a resend of something already delivered: it is neither logged nor
+// recorded again, and the caller must not hand it to the agent a second time.
+// The event is written before the transcript precisely so that this is known
+// before anything is logged. A frame ID already recorded with different text
+// returns errClientFrameReused.
+//
+// Without a client frame ID a message's identity is derived from its position,
+// which never repeats, so such a message is always new.
+func (p *promptAttachProjector) AppendHumanMessageFrame(message, clientFrameID string) (bool, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.events != nil && strings.TrimSpace(message) != "" {
+		index := p.humanIndex + 1
+		recorded, created, err := p.events.AppendProjectRunEvent(p.eventContext(), domain.ProjectRunEventRecord{
+			ID: attachedHumanEventID(p.run.RunID, clientFrameID, index, message), RunID: p.run.RunID, Kind: domain.ProjectRunEventKindUserMessage, Text: message, Agent: p.run.AgentName,
+		})
+		if err != nil {
+			return false, err
+		}
+		if !created {
+			if strings.TrimSpace(recorded.Text) != strings.TrimSpace(message) {
+				return false, errClientFrameReused
+			}
+			return false, nil
+		}
+		p.humanIndex = index
+	}
 	p.persistedAssistantTurn = false
-	if text != "" {
-		if p.hasLoggedText && !p.logEndsWithNewline {
-			text = "\n" + text
-		}
-		if err := p.appendLogChunkLocked(domain.ExecChunk{Text: text}); err != nil {
-			return err
-		}
+	text := promptAttachHumanLogText(message)
+	if text == "" {
+		return true, nil
 	}
-	if p.events == nil || strings.TrimSpace(message) == "" {
-		return nil
+	if p.hasLoggedText && !p.logEndsWithNewline {
+		text = "\n" + text
 	}
-	p.humanIndex++
-	_, _, err := p.events.AppendProjectRunEvent(p.eventContext(), domain.ProjectRunEventRecord{
-		ID: attachedHumanEventID(p.run.RunID, clientFrameID, uint64(p.humanIndex), message), RunID: p.run.RunID, Kind: domain.ProjectRunEventKindUserMessage, Text: message, Agent: p.run.AgentName,
-	})
-	return err
+	return true, p.appendLogChunkLocked(domain.ExecChunk{Text: text})
 }
 
 func (p *promptAttachProjector) AppendStderr(text string) error {

--- a/pkg/runs/run_event.go
+++ b/pkg/runs/run_event.go
@@ -26,6 +26,18 @@ func initialPromptEventID(runID string) string {
 	return stableRunEventID(runID, runEventIdentityInitialPrompt, nil)
 }
 
+// openingPromptEventID identifies a run's opening message. When the client
+// named the frame that carried it, the message takes the identity any attached
+// human message with that frame ID takes, so a client that resends its opening
+// message under the same frame ID is recognised as resending it rather than
+// saying it again. Without one it keeps the run-scoped identity it always had.
+func openingPromptEventID(runID, clientFrameID string) string {
+	if strings.TrimSpace(clientFrameID) == "" {
+		return initialPromptEventID(runID)
+	}
+	return attachedHumanEventID(runID, clientFrameID, 0, "")
+}
+
 func attachedHumanEventID(runID, clientFrameID string, index uint64, message string) string {
 	if frameID := strings.TrimSpace(clientFrameID); frameID != "" {
 		return stableRunEventID(runID, runEventIdentityAttachedHuman, identityToken(attachedEventExplicitToken, []byte(frameID)))


### PR DESCRIPTION
## Summary

Closes #680.

daemon 已经按 `client_frame_id` 对 human message 的落库做了幂等，但 `forwardPromptHumanMessage` 不管消息是否记录过，都会再交给 agent：客户端带同一个 frame ID 重发，历史只记一次，agent 却再跑一遍。`docs/design/resumable-interactive-session.md` 里"输入复用 `client_frame_id` 做幂等去重"的承诺只实现了落库这一半，这个 PR 补上执行这一侧。

- **已记录过的消息不再执行。** `AppendHumanMessageFrame` 先落库再写 transcript，并返回消息是否是新的。同一 frame ID、同一文本视为重发，既不记日志也不交给 agent；同一 frame ID 对应不同文本则拒绝。
- **归还 turn gate。** pump 取到 gate 之后才知道消息重复。不归还的话没有 turn 会结束来释放它，下一条消息会一直等下去。
- **告诉客户端。** 以非终止的 `AttachError` 回应，`details["client_frame_id"]` 指明是哪条消息：`duplicate_message`（已送达，未再执行）或 `client_frame_id_reused`（未执行，会话继续）。复用已有的 `AttachError.details`，不改 proto。pump 因此也会向客户端发帧，`send` 加了串行化。
- **首轮消息也能去重。** 首轮消息在建 run 时落库，原来用 run 作用域的 ID，经 attached message 路径的重发永远对不上。prompt 模式下 start 帧的 `client_frame_id` 现在作为首轮消息的身份，与之后同 frame ID 的消息一致。

**兼容性**

- 不带 frame ID 的客户端（CLI、scheduler 等）不受影响：消息身份按位置派生、不会重复；首轮消息保持原来的 run 作用域 ID，已持久化事件的 ID 不变。
- 需要客户端配合：原 turn 已经结束后才到达的重发，daemon 不会再跑一轮，也就不会有 turn completed。`sdk/go`（#679）需要识别 `duplicate_message` 来结束等待中的 reply，并在 start 帧上带 `client_frame_id`，首轮去重才会生效。

## Testing

- `go test -race ./pkg/runs/ ./pkg/agentcompose/api/ ./pkg/agentcompose/app/`
- `golangci-lint fmt --diff` 和 `golangci-lint run`（`./pkg/runs/... ./pkg/agentcompose/api/...`）

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
