### PR TITLE
feat(proto): add scheduler_id to GetSchedulerRequest

### DIFF
--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -3495,9 +3495,11 @@ func (x *ProjectScheduler) GetDescription() string {
 }
 
 type GetSchedulerRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Project       *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
-	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Project   *ProjectRef            `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	AgentName string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	// Globally unique native scheduler ID. Set this instead of project and agent_name.
+	SchedulerId   string `protobuf:"bytes,3,opt,name=scheduler_id,json=schedulerId,proto3" json:"scheduler_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3542,6 +3544,13 @@ func (x *GetSchedulerRequest) GetProject() *ProjectRef {
 func (x *GetSchedulerRequest) GetAgentName() string {
 	if x != nil {
 		return x.AgentName
+	}
+	return ""
+}
+
+func (x *GetSchedulerRequest) GetSchedulerId() string {
+	if x != nil {
+		return x.SchedulerId
 	}
 	return ""
 }
@@ -19794,11 +19803,12 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\aenabled\x18\x04 \x01(\bR\aenabled\x12#\n" +
 	"\rtrigger_count\x18\x05 \x01(\rR\ftriggerCount\x12!\n" +
 	"\fdisplay_name\x18\x06 \x01(\tR\vdisplayName\x12 \n" +
-	"\vdescription\x18\a \x01(\tR\vdescription\"k\n" +
+	"\vdescription\x18\a \x01(\tR\vdescription\"\x8e\x01\n" +
 	"\x13GetSchedulerRequest\x125\n" +
 	"\aproject\x18\x01 \x01(\v2\x1b.agentcompose.v2.ProjectRefR\aproject\x12\x1d\n" +
 	"\n" +
-	"agent_name\x18\x02 \x01(\tR\tagentName\"\xe9\x01\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\x12!\n" +
+	"\fscheduler_id\x18\x03 \x01(\tR\vschedulerId\"\xe9\x01\n" +
 	"\x14GetSchedulerResponse\x12?\n" +
 	"\tscheduler\x18\x01 \x01(\v2!.agentcompose.v2.ProjectSchedulerR\tscheduler\x122\n" +
 	"\x04spec\x18\x02 \x01(\v2\x1e.agentcompose.v2.SchedulerSpecR\x04spec\x12<\n" +

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -596,6 +596,8 @@ message ProjectScheduler {
 message GetSchedulerRequest {
   ProjectRef project = 1;
   string agent_name = 2;
+  // Globally unique native scheduler ID. Set this instead of project and agent_name.
+  string scheduler_id = 3;
 }
 
 message GetSchedulerResponse {

--- a/proto/agentcompose/v2/field_layout_contract_test.go
+++ b/proto/agentcompose/v2/field_layout_contract_test.go
@@ -22,6 +22,7 @@ func TestV2FieldNumbersHaveNoUnexplainedGaps(t *testing.T) {
 func TestV2FreezeFieldLayout(t *testing.T) {
 	want := map[protoreflect.FullName]map[protoreflect.Name]protoreflect.FieldNumber{
 		"agentcompose.v2.ProjectScheduler":         {"enabled": 4, "description": 7},
+		"agentcompose.v2.GetSchedulerRequest":      {"project": 1, "agent_name": 2, "scheduler_id": 3},
 		"agentcompose.v2.ProjectSpec":              {"agents": 3, "octobus_servers": 7},
 		"agentcompose.v2.RunAgentRequest":          {"env": 5, "payload_json": 16},
 		"agentcompose.v2.StartAgentRunRequest":     {"run": 1, "interactive": 2},


### PR DESCRIPTION
#673 lets `GetScheduler` look up a scheduler by its native ID, which needs a new field on `GetSchedulerRequest`. The root module requires the published `github.com/chaitin/agent-compose/proto v0.1.4`, which does not have it, so #673's Published proto version check fails once CI drops the development `replace`.

This prerequisite separates the additive wire contract from the implementation so it can be merged and published before #673 depends on it. The daemon is unchanged here and still builds against published v0.1.4.

## Contract

- Add `GetSchedulerRequest.scheduler_id = 3`: the globally unique native scheduler ID, set instead of `project` and `agent_name`. Existing field numbers and types are preserved.
- Regenerate the Go protobuf source with the existing Buf configuration (buf 1.68.1). No Connect RPCs change.
- Pin the `GetSchedulerRequest` field layout in `TestV2FreezeFieldLayout`.

Only three proto files change. No runtime behavior, module requirements, or CI rules change.

## Validation

On Go 1.26.5 / macOS arm64:

- Root and proto-module `go build ./...`: passed.
- Proto-module `go vet` and `go test ./...`: passed; golangci-lint: 0 issues.
- `buf generate`: no changes after regeneration.
- `buf breaking` against main `d746a63e`: passed.
- The Published proto steps (drop the replace, download v0.1.4, `go build ./...`): passed.

These are local results; GitHub Actions has not run on this PR yet.

## Release dependency

After merge, publish **`proto/v0.1.5`** from the merge commit. #673 then drops its copy of this change on rebase and moves its root requirement and checksums to v0.1.5. This PR creates no tag.

Prerequisite for #673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

