### PR TITLE
ci(proto): tag the proto module from main automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
 
   proto-version:
     name: Published proto version
+    # Only a release has to name a published proto version. A proto change
+    # merges together with its implementation and is tagged afterwards by the
+    # Proto tag workflow, so on pull requests and main the required version
+    # legitimately trails proto/.
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,10 +71,10 @@ jobs:
           go-version-file: go.mod
           cache: true
       # Every other job builds through the replace, against the proto/ in the
-      # working tree, so a proto change that was never tagged - or a tag the
-      # require was never moved to - looks fine here and breaks only for
-      # whoever depends on this module. Dropping the replace is the one build
-      # that actually exercises the version in go.mod.
+      # working tree, so a require that was never moved to the tag carrying
+      # the contract looks fine there and breaks only for whoever depends on
+      # this module. Dropping the replace is the one build that actually
+      # exercises the version in go.mod.
       - name: Build against the published proto module
         run: |
           go mod edit -dropreplace=github.com/chaitin/agent-compose/proto

--- a/.github/workflows/proto-tag.yml
+++ b/.github/workflows/proto-tag.yml
@@ -1,0 +1,83 @@
+name: Proto tag
+
+# Publishes the proto module. A proto change merges together with its
+# implementation - go.mod replaces the module with ./proto - so the contract
+# reaches main before any version of it exists. Once CI passes on such a main
+# commit, this workflow tags it with the next proto/vX.Y.Z.
+#
+# The tags are made here rather than by hand so they are only ever cut from
+# main and only ever move forward: a hand-made tag on a feature branch once
+# published a version that lacked RPCs an earlier version had.
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One tagger at a time, so two commits never claim the same next version.
+concurrency:
+  group: proto-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Tag proto module
+    # The branch filter also matches a pull request whose head branch is named
+    # main, so require the push run that tested main itself.
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      COMMIT: ${{ github.event.workflow_run.head_sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.COMMIT }}
+          fetch-depth: 0
+      - name: Decide the next proto version
+        id: next
+        run: |
+          tag=$(./scripts/proto-next-tag.sh "$COMMIT")
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+      - name: Push the tag
+        if: steps.next.outputs.tag != ''
+        env:
+          TAG: ${{ steps.next.outputs.tag }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$TAG" -m "$TAG" "$COMMIT"
+          git push origin "refs/tags/$TAG"
+          echo "Tagged \`$TAG\` on \`$COMMIT\`." >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/setup-go@v5
+        if: steps.next.outputs.tag != ''
+        with:
+          go-version-file: proto/go.mod
+          cache: false
+      # Ask the public proxy for the version now: it is recorded in the
+      # checksum database before the first client asks, and a tag that cannot
+      # resolve fails here instead of in someone's go get.
+      - name: Resolve the tag through the module proxy
+        if: steps.next.outputs.tag != ''
+        working-directory: ${{ runner.temp }}
+        env:
+          TAG: ${{ steps.next.outputs.tag }}
+          GOPROXY: https://proxy.golang.org
+        run: |
+          version=${TAG#proto/}
+          for attempt in 1 2 3; do
+            if go list -m -json "github.com/chaitin/agent-compose/proto@$version"; then
+              exit 0
+            fi
+            sleep 20
+          done
+          echo "::error::proxy.golang.org could not resolve $TAG"
+          exit 1

--- a/.github/workflows/proto-tag.yml
+++ b/.github/workflows/proto-tag.yml
@@ -57,8 +57,20 @@ jobs:
           git tag -a "$TAG" -m "$TAG" "$COMMIT"
           git push origin "refs/tags/$TAG"
           echo "Tagged \`$TAG\` on \`$COMMIT\`." >> "$GITHUB_STEP_SUMMARY"
+      # Verify whichever proto tag this commit carries, not only one this run
+      # pushed: a re-run after a failed resolution finds the tag already
+      # published, decides there is nothing to tag, and must still check it.
+      # Deleting the tag on failure instead is not safe - the proxy may have
+      # recorded the version already, and re-cutting it would give one version
+      # two contents.
+      - name: Find the proto tag on this commit
+        id: published
+        run: |
+          tag=$(git tag --points-at "$COMMIT" --list 'proto/v*' |
+            grep -E '^proto/v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@v5
-        if: steps.next.outputs.tag != ''
+        if: steps.published.outputs.tag != ''
         with:
           go-version-file: proto/go.mod
           cache: false
@@ -66,10 +78,10 @@ jobs:
       # checksum database before the first client asks, and a tag that cannot
       # resolve fails here instead of in someone's go get.
       - name: Resolve the tag through the module proxy
-        if: steps.next.outputs.tag != ''
+        if: steps.published.outputs.tag != ''
         working-directory: ${{ runner.temp }}
         env:
-          TAG: ${{ steps.next.outputs.tag }}
+          TAG: ${{ steps.published.outputs.tag }}
           GOPROXY: https://proxy.golang.org
         run: |
           version=${TAG#proto/}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ Compose and environment variable conventions:
 - Edit public manuals under `docs/pages`; keep English and `docs/pages/zh-CN` variants aligned when changing shared behavior. Run `task docs:build` and never edit `build/pages` directly.
 - When changing the compose schema in `pkg/compose/spec.go`, update the YAML manuals and run the documentation build because the renderer validates schema coverage.
 - Change API definitions in `proto/**/*.proto`, run `task generate` (or `task generate:proto`), and commit the regenerated Go and Connect outputs. `buf.yaml` and `buf.gen.yaml` define generation behavior.
+- `proto/` is its own Go module, and the root `go.mod` replaces it with `./proto`: change a contract and its implementation in the same pull request. Do not tag `proto/v*` by hand; once CI passes on a `main` commit that changes `proto/`, the Proto tag workflow tags it with the next patch version. Before a release tag, move the root requirement to the newest proto tag (`go get github.com/chaitin/agent-compose/proto@vX.Y.Z`); the Published proto version job checks it on release tags. `sdk/go` has no replace and moves to a new proto tag only when it needs the new contract.
 
 ## Commits and Pull Requests
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -229,6 +229,7 @@ tasks:
       - ./scripts/tests/test-generated-proto-contract.sh
       - '{{.GO_TOOLCHAIN_ENV}} go -C proto test ./...'
       - ./scripts/tests/test-proto-breaking-ci-contract.sh
+      - ./scripts/tests/test-proto-tag-ci-contract.sh
       - ./scripts/tests/test-build-agent-compose-binary.sh
       - ./scripts/tests/test-task-build-variables.sh
       - ./scripts/tests/test-verify-agent-compose-binary.sh

--- a/scripts/proto-next-tag.sh
+++ b/scripts/proto-next-tag.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decides which proto module tag a main commit should carry. Prints the tag
+# when the commit changes proto/ since the newest proto/vX.Y.Z tag, and prints
+# nothing when there is nothing to publish. The Proto tag workflow creates and
+# pushes the tag; this script only decides, so it can be tested without a
+# remote.
+#
+# Versions only move forward. A commit the newest tag already contains - a CI
+# run for an older commit finishing late - is skipped rather than tagged: a
+# higher version must never carry less of the contract than a lower one.
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <commit>" >&2
+  exit 2
+fi
+
+if ! commit=$(git rev-parse --verify --quiet "$1^{commit}"); then
+  echo "proto-next-tag: unknown commit: $1" >&2
+  exit 1
+fi
+
+latest=$(git tag --list 'proto/v*' --sort=-version:refname |
+  grep -E '^proto/v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+if [[ -z $latest ]]; then
+  echo "proto-next-tag: no proto/vX.Y.Z tag to continue from" >&2
+  exit 1
+fi
+latest_commit=$(git rev-parse "$latest^{commit}")
+
+if ! git merge-base --is-ancestor "$latest_commit" "$commit"; then
+  if git merge-base --is-ancestor "$commit" "$latest_commit"; then
+    echo "proto-next-tag: $latest already contains ${commit:0:12}" >&2
+    exit 0
+  fi
+  echo "proto-next-tag: ${commit:0:12} does not descend from $latest" >&2
+  exit 1
+fi
+
+if git diff --quiet "$latest_commit" "$commit" -- ':(top)proto'; then
+  echo "proto-next-tag: proto/ unchanged since $latest" >&2
+  exit 0
+fi
+
+IFS=. read -r major minor patch <<<"${latest#proto/v}"
+printf 'proto/v%s.%s.%s\n' "$major" "$minor" "$((patch + 1))"

--- a/scripts/tests/test-proto-tag-ci-contract.sh
+++ b/scripts/tests/test-proto-tag-ci-contract.sh
@@ -109,6 +109,17 @@ require "$tag_workflow" 'scripts/proto-next-tag\.sh "\$COMMIT"' 'tag decision fo
 require "$tag_workflow" 'git push origin "refs/tags/\$TAG"' 'tag push'
 require "$tag_workflow" 'GOPROXY: https://proxy\.golang\.org$' 'resolution through the public proxy alone'
 
+# Resolution follows the tag the commit carries rather than the tag this run
+# decided to push, so a re-run after a failed resolution checks it again.
+require "$tag_workflow" 'git tag --points-at "\$COMMIT"' 'lookup of the proto tag on the tested commit'
+resolve_step=$(awk '
+  /^      - name: Resolve the tag through the module proxy$/ { found = 1; print; next }
+  found && /^      - / { exit }
+  found { print }
+' "$TAG_WORKFLOW")
+require "$resolve_step" "if: steps\.published\.outputs\.tag != ''" 'resolution gated on the tag the commit carries'
+require "$resolve_step" 'TAG: \$\{\{ steps\.published\.outputs\.tag \}\}' 'resolution of the tag the commit carries'
+
 proto_version=$(awk '
   $0 == "  proto-version:" { found = 1; print; next }
   found && $0 ~ /^  [[:alnum:]_-]+:[[:space:]]*$/ { exit }

--- a/scripts/tests/test-proto-tag-ci-contract.sh
+++ b/scripts/tests/test-proto-tag-ci-contract.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+NEXT_TAG="$ROOT_DIR/scripts/proto-next-tag.sh"
+TAG_WORKFLOW="$ROOT_DIR/.github/workflows/proto-tag.yml"
+CI_WORKFLOW="$ROOT_DIR/.github/workflows/ci.yml"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+failures=0
+
+fail() {
+  printf 'test-proto-tag-ci-contract: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+# --- proto-next-tag.sh against a scratch repository -------------------------
+
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.com
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.com
+
+repo="$TEST_ROOT/repo"
+git init -q -b main "$repo"
+
+commit_file() { # $1=path $2=content; prints the new commit
+  mkdir -p "$(dirname -- "$repo/$1")"
+  printf '%s\n' "$2" >"$repo/$1"
+  git -C "$repo" add -- "$1"
+  git -C "$repo" commit -q -m "change $1"
+  git -C "$repo" rev-parse HEAD
+}
+
+expect() { # $1=description $2=commit $3=expected-status $4=expected-stdout
+  local out status
+  set +e
+  out=$(cd "$repo" && "$NEXT_TAG" "$2" 2>/dev/null)
+  status=$?
+  set -e
+  if [[ $status -ne $3 || $out != "$4" ]]; then
+    fail "$1: got status $status output '$out', expected status $3 output '$4'"
+  fi
+}
+
+base=$(commit_file proto/api.proto 'v1')
+expect 'no proto tag at all' "$base" 1 ''
+
+git -C "$repo" tag proto/v0.1.2 "$base"
+git -C "$repo" tag proto/v0.1.9 "$base"
+expect 'tagged commit' "$base" 0 ''
+
+docs=$(commit_file README.md 'docs')
+expect 'change outside proto/' "$docs" 0 ''
+
+field=$(commit_file proto/api.proto 'v2')
+expect 'proto change after the newest tag' "$field" 0 'proto/v0.1.10'
+
+git -C "$repo" tag proto/v0.1.10 "$field"
+rpc=$(commit_file proto/api.proto 'v3')
+expect 'numeric rather than lexical version order' "$rpc" 0 'proto/v0.1.11'
+
+git -C "$repo" tag proto/v0.1.11 "$rpc"
+git -C "$repo" tag proto/v0.2.0-rc.1 "$rpc"
+nested=$(commit_file proto/health/v1/health.proto 'v1')
+expect 'pre-release tags ignored' "$nested" 0 'proto/v0.1.12'
+expect 'late run for a commit the newest tag contains' "$field" 0 ''
+
+git -C "$repo" checkout -q -b side "$base"
+side=$(commit_file proto/api.proto 'side')
+expect 'commit that does not descend from the newest tag' "$side" 1 ''
+expect 'unknown commit' 'no-such-commit' 1 ''
+
+# --- workflow wiring ---------------------------------------------------------
+
+tag_workflow=$(<"$TAG_WORKFLOW")
+ci_workflow=$(<"$CI_WORKFLOW")
+
+require() { # $1=text $2=extended-regex $3=description
+  if ! grep -Eq -- "$2" <<<"$1"; then
+    fail "missing $3"
+  fi
+}
+
+# workflow_run names the workflow it follows, so renaming CI would silently
+# stop every proto release.
+require "$ci_workflow" '^name: CI$' 'CI workflow name followed by the proto tag workflow'
+require "$tag_workflow" 'workflows: \[CI\]' 'trigger on CI runs'
+require "$tag_workflow" 'types: \[completed\]' 'trigger on completed CI runs'
+require "$tag_workflow" 'branches: \[main\]' 'main-only trigger'
+require "$tag_workflow" "workflow_run\.event == 'push'" 'guard against pull requests from a branch named main'
+require "$tag_workflow" "workflow_run\.conclusion == 'success'" 'guard against failed CI runs'
+require "$tag_workflow" "github\.ref == 'refs/heads/main'" 'main-only manual dispatch'
+require "$tag_workflow" 'cancel-in-progress: false' 'serialized tagging'
+require "$tag_workflow" 'contents: write' 'tag push permission'
+
+# Write access belongs to the tagging job alone, not the whole workflow.
+top_permissions=$(awk '
+  /^permissions:/ { found = 1; next }
+  found && /^[^[:space:]]/ { exit }
+  found { print }
+' "$TAG_WORKFLOW")
+require "$top_permissions" '^  contents: read$' 'read-only workflow permissions'
+if grep -q 'write' <<<"$top_permissions"; then
+  fail 'forbidden write access in workflow-level permissions'
+fi
+require "$tag_workflow" 'fetch-depth: 0' 'checkout with every tag'
+require "$tag_workflow" 'scripts/proto-next-tag\.sh "\$COMMIT"' 'tag decision for the tested commit'
+require "$tag_workflow" 'git push origin "refs/tags/\$TAG"' 'tag push'
+require "$tag_workflow" 'GOPROXY: https://proxy\.golang\.org$' 'resolution through the public proxy alone'
+
+proto_version=$(awk '
+  $0 == "  proto-version:" { found = 1; print; next }
+  found && $0 ~ /^  [[:alnum:]_-]+:[[:space:]]*$/ { exit }
+  found { print }
+' "$CI_WORKFLOW")
+require "$proto_version" "if: github\.ref_type == 'tag'" 'release-tag-only published proto check'
+require "$proto_version" 'go mod edit -dropreplace=github\.com/chaitin/agent-compose/proto' 'build without the proto replace'
+
+if ((failures > 0)); then
+  printf 'test-proto-tag-ci-contract: %d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'test-proto-tag-ci-contract: all checks passed\n'


### PR DESCRIPTION
## Summary

The **Published proto version** check ran on every pull request. A PR that changes `proto/` together with its implementation fails it until a tag carrying the new contract exists, and such a tag can only be cut after the PR merges. So every contract change became a proto-only PR, then a hand-made tag, then the implementation PR (#691 → #686, #692 → #673). This led to two bad tags:

- `proto/v0.1.1` was tagged on a feature-branch commit (2e2bb5f5).
- `proto/v0.1.2`, cut from main, lacked the LLM provider RPCs that v0.1.1 already had.

This PR changes the flow:

- **Proto and implementation merge together.** `go.mod` already replaces the module with `./proto`, so nothing else is needed for that.
- **New `Proto tag` workflow.** It runs after CI succeeds on a push to `main`, and can also be dispatched manually on `main`. When `proto/` changed since the newest `proto/vX.Y.Z`, it tags that commit with the next patch version, pushes the tag, and resolves it through `proxy.golang.org`.
- **`scripts/proto-next-tag.sh` makes the decision.** Versions only move forward:
  - A commit that the newest tag already contains, for example a CI run finishing late, is skipped.
  - A commit that doesn't descend from the newest tag is refused.
  - Pre-release tags are ignored.
- **Published proto version** now runs only on release tags, the one point where the root `require` has to name a published version.
- `AGENTS.md` documents the flow: don't tag `proto/v*` by hand, and bump the root `require` before a release tag.

## Testing

- `./scripts/tests/test-proto-tag-ci-contract.sh`, added to `task test:scripts`. It covers the tag decision against a scratch repository (no tag, unchanged, outside `proto/`, numeric ordering, pre-release, late run, diverged commit, unknown commit) and the workflow wiring.
- Deliberate regressions make it fail: removing the tag-only `if`, and lexical tag sorting.
- `./scripts/tests/test-binary-ci-contract.sh` and `./scripts/tests/test-proto-breaking-ci-contract.sh` pass.
- `actionlint` v1.7.7 reports no issues on `proto-tag.yml` and `ci.yml`.
- `proto-next-tag.sh` against real history returns no tag for d0bd3c2d (`proto/v0.1.5`), 9c860f53, fbc89af9 and current main.
- Not exercised yet: `workflow_run` only runs from the default branch, so the workflow's first real run will be the first `proto/` change merged after this PR.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

