### PR TITLE
build(sdk): prepare the Go chat SDK for versioned releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,25 @@ jobs:
           readelf -h installer-assets/agent-compose-installer-linux-amd64 | grep -F 'Advanced Micro Devices X86-64'
           readelf -h installer-assets/agent-compose-installer-linux-arm64 | grep -F 'AArch64'
 
+  go-sdk:
+    name: Go chat SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # The SDK's own go.mod, not the daemon's: it has no replace, so this
+      # builds against the proto version it requires, on the oldest Go its
+      # README promises.
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: sdk/go/go.mod
+          cache: true
+          cache-dependency-path: sdk/go/go.sum
+      - name: Test the SDK module
+        working-directory: sdk/go
+        run: |
+          go vet ./...
+          go test -race ./...
+
   coverage:
     name: Coverage gate
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -179,7 +179,7 @@ tasks:
 
   lint:
     desc: Lint/format code
-    deps: ['lint:go', 'lint:installer', 'lint:proto']
+    deps: ['lint:go', 'lint:installer', 'lint:proto', 'lint:sdk']
     cmds:
       - echo "lint all done"
 
@@ -213,12 +213,23 @@ tasks:
       - GOCACHE={{.GO_BUILD_CACHE_DIR}} GOLANGCI_LINT_CACHE={{.GOLANGCI_LINT_CACHE_DIR}} {{.GO_TOOLCHAIN_ENV}} golangci-lint fmt -c {{.TASKFILE_DIR}}/.golangci.yml --diff ./...
       - GOCACHE={{.GO_BUILD_CACHE_DIR}} GOLANGCI_LINT_CACHE={{.GOLANGCI_LINT_CACHE_DIR}} {{.GO_TOOLCHAIN_ENV}} golangci-lint run -c {{.TASKFILE_DIR}}/.golangci.yml --allow-parallel-runners ./...
 
+  lint:sdk:
+    desc: Lint and format the standalone Go chat SDK module
+    dir: '{{.TASKFILE_DIR}}/sdk/go'
+    cmds:
+      - mkdir -p {{.GOLANGCI_LINT_CACHE_DIR}} {{.GO_BUILD_CACHE_DIR}}
+      # The SDK is a separate module, so the repository config is passed
+      # explicitly rather than discovered by walking up from this directory.
+      - GOCACHE={{.GO_BUILD_CACHE_DIR}} GOLANGCI_LINT_CACHE={{.GOLANGCI_LINT_CACHE_DIR}} {{.GO_TOOLCHAIN_ENV}} golangci-lint fmt -c {{.TASKFILE_DIR}}/.golangci.yml --diff ./...
+      - GOCACHE={{.GO_BUILD_CACHE_DIR}} GOLANGCI_LINT_CACHE={{.GOLANGCI_LINT_CACHE_DIR}} {{.GO_TOOLCHAIN_ENV}} golangci-lint run -c {{.TASKFILE_DIR}}/.golangci.yml --allow-parallel-runners ./...
+
   test:
     desc: Run all test shapes with coverage quality gates
     deps: ['generate:proto']
     cmds:
       - task: test:scripts
       - task: test:deploy
+      - task: test:sdk
       - GOCACHE={{.GO_BUILD_CACHE_DIR}} {{.GO_TOOLCHAIN_ENV}} ./scripts/test-coverage.sh
 
   test:scripts:
@@ -249,6 +260,12 @@ tasks:
       - ./scripts/tests/test-compose-kvm-config.sh
       - ./scripts/tests/test-installer-assets.sh
       - ./scripts/tests/test-installer-binaries.sh
+
+  test:sdk:
+    desc: Test the standalone Go chat SDK module against the proto version it requires
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - '{{.GO_TOOLCHAIN_ENV}} go -C sdk/go test ./...'
 
   demo:installer-docker:
     desc: Run and retain an isolated real-Docker installer lifecycle demo

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -238,11 +238,12 @@ daemon release that serves that contract:
 The client reports its version to the daemon in its `User-Agent`, taken from
 the module version the program was built with.
 
-Maintainers tag releases from `main` by hand. Unlike the proto module, whose
-tags only ever record additions, an SDK version is a judgement about what the
-API change means to callers; `gorelease -base=sdk/go/<previous tag>` reports
-the API difference and the version it implies. A release that moves to a newer
-proto contract or relies on newer daemon behavior adds a row above.
+Maintainers tag releases from `main` by hand. Unlike the proto module, which
+CI tags automatically, an SDK version is a judgement about what the API change
+means to callers. Run `gorelease` (`golang.org/x/exp/cmd/gorelease`) in
+`sdk/go` on a clean checkout of `main`: it compares the API with the latest
+release and suggests the next version and its tag. A release that moves to a
+newer proto contract or relies on newer daemon behavior adds a row above.
 
 ## Requirements
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -218,6 +218,32 @@ daemon's name, display text, and payload so provider extensions are not lost.
 Events are retained on the `Reply`: `Wait` and `Events` can be used together,
 in either order, and a second `Events` pass replays from the start.
 
+## Versions
+
+```bash
+go get github.com/chaitin/agent-compose/sdk/go@latest
+```
+
+Releases are tagged `sdk/go/vX.Y.Z`. While the major version is `v0` the API
+can still change: a release that breaks callers raises the minor version, and
+anything else raises the patch version. Pin the version you tested against.
+
+Each release line names the proto contract it is built on and the oldest
+daemon release that serves that contract:
+
+| SDK | proto | daemon |
+| --- | --- | --- |
+| v0.1.x | v0.1.0 | v2609.2.0 or newer |
+
+The client reports its version to the daemon in its `User-Agent`, taken from
+the module version the program was built with.
+
+Maintainers tag releases from `main` by hand. Unlike the proto module, whose
+tags only ever record additions, an SDK version is a judgement about what the
+API change means to callers; `gorelease -base=sdk/go/<previous tag>` reports
+the API difference and the version it implies. A release that moves to a newer
+proto contract or relies on newer daemon behavior adds a row above.
+
 ## Requirements
 
 Go 1.24 or newer. The SDK depends on `connectrpc.com/connect` and on
@@ -306,7 +332,7 @@ go run ./examples/chat -project my-project -agent my-agent
 go run ./examples/chat -project my-project -agent my-agent -conversation conv_1a2b3c
 ```
 
-A browser chat UI lives in [`chatui`](../../chatui), which is also the answer
-to "why not talk to the daemon from the browser directly": a browser cannot,
-because Connect needs HTTP/2 bidirectional streaming for a multi-turn session
-and a `fetch()` with a streaming request body is half duplex.
+A browser cannot hold a conversation with the daemon directly: Connect needs
+HTTP/2 bidirectional streaming for a multi-turn session, and a `fetch()` with a
+streaming request body is half duplex. A browser chat UI goes through a server
+that holds the conversation with this SDK on its behalf.

--- a/sdk/go/chat/client.go
+++ b/sdk/go/chat/client.go
@@ -16,9 +16,6 @@ import (
 // how a conversation is found again from another process.
 const conversationLabel = "chat.conversation"
 
-// defaultUserAgent identifies this client to the daemon.
-const defaultUserAgent = "agent-compose-chat-go/0.1"
-
 // TokenSource resolves a bearer token for one request. It is called per
 // request, so it can refresh a short-lived credential.
 type TokenSource func(context.Context) (string, error)
@@ -61,7 +58,7 @@ func New(cfg Config) (*Client, error) {
 	if client == nil {
 		client = defaultHTTPClient(base)
 	}
-	agent := defaultUserAgent
+	agent := userAgent()
 	if extra := strings.TrimSpace(cfg.UserAgent); extra != "" {
 		agent += " " + extra
 	}

--- a/sdk/go/chat/fake_daemon_test.go
+++ b/sdk/go/chat/fake_daemon_test.go
@@ -215,14 +215,6 @@ func runResult(success bool, failure string) *agentcomposev2.AttachAgentRunRespo
 	}
 }
 
-func attachFailure(code, message string, terminal bool) *agentcomposev2.AttachAgentRunResponse {
-	return &agentcomposev2.AttachAgentRunResponse{
-		Frame: &agentcomposev2.AttachAgentRunResponse_Error{
-			Error: &agentcomposev2.AttachError{Code: code, Message: message, Terminal: terminal},
-		},
-	}
-}
-
 // runSummary builds a summary with the fields these tests actually assert on.
 func runSummary(runID, status, sandboxID string, created ...*timestamppb.Timestamp) *agentcomposev2.RunSummary {
 	summary := &agentcomposev2.RunSummary{

--- a/sdk/go/chat/version.go
+++ b/sdk/go/chat/version.go
@@ -1,0 +1,47 @@
+package chat
+
+import (
+	"runtime/debug"
+	"slices"
+	"sync"
+)
+
+// modulePath is this SDK's module, whose version names the client in its
+// User-Agent.
+const modulePath = "github.com/chaitin/agent-compose/sdk/go"
+
+// develVersion stands in for a build that records no SDK version.
+const develVersion = "devel"
+
+// userAgent identifies this client to the daemon by the SDK version the
+// program was built with, so the daemon can tell releases apart without a
+// constant here having to be kept in step with the tags.
+var userAgent = sync.OnceValue(func() string {
+	info, _ := debug.ReadBuildInfo()
+	return "agent-compose-chat-go/" + moduleVersion(info)
+})
+
+// moduleVersion reports the SDK version recorded in info: the version a
+// program depending on the SDK required, or the one a replace substituted.
+// A build that records none - a replace pointing at a directory, the SDK's own
+// tests, a binary built without module support - reports [develVersion].
+func moduleVersion(info *debug.BuildInfo) string {
+	if info == nil {
+		return develVersion
+	}
+	module := &info.Main
+	if module.Path != modulePath {
+		i := slices.IndexFunc(info.Deps, func(dep *debug.Module) bool { return dep.Path == modulePath })
+		if i < 0 {
+			return develVersion
+		}
+		module = info.Deps[i]
+	}
+	if module.Replace != nil {
+		module = module.Replace
+	}
+	if module.Version == "" || module.Version == "(devel)" {
+		return develVersion
+	}
+	return module.Version
+}

--- a/sdk/go/chat/version_test.go
+++ b/sdk/go/chat/version_test.go
@@ -1,0 +1,71 @@
+package chat
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestModuleVersion(t *testing.T) {
+	sdk := func(version string, replace *debug.Module) *debug.Module {
+		return &debug.Module{Path: modulePath, Version: version, Replace: replace}
+	}
+	other := &debug.Module{Path: "example.com/other", Version: "v1.2.3"}
+
+	for _, tc := range []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{name: "no build info", info: nil, want: develVersion},
+		{
+			name: "tagged dependency",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}, Deps: []*debug.Module{other, sdk("v0.1.0", nil)}},
+			want: "v0.1.0",
+		},
+		{
+			name: "pseudo-version dependency",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}, Deps: []*debug.Module{sdk("v0.0.0-20260911074743-142bf085afdd", nil)}},
+			want: "v0.0.0-20260911074743-142bf085afdd",
+		},
+		{
+			name: "replaced by a directory",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}, Deps: []*debug.Module{sdk("v0.1.0", &debug.Module{Path: "../sdk/go"})}},
+			want: develVersion,
+		},
+		{
+			name: "replaced by another version",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}, Deps: []*debug.Module{sdk("v0.1.0", &debug.Module{Path: modulePath, Version: "v0.1.1"})}},
+			want: "v0.1.1",
+		},
+		{
+			name: "SDK is the main module",
+			info: &debug.BuildInfo{Main: debug.Module{Path: modulePath, Version: "(devel)"}},
+			want: develVersion,
+		},
+		{
+			name: "SDK is the main module with a stamped version",
+			info: &debug.BuildInfo{Main: debug.Module{Path: modulePath, Version: "v0.2.0"}},
+			want: "v0.2.0",
+		},
+		{
+			name: "SDK absent",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/app"}, Deps: []*debug.Module{other}},
+			want: develVersion,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := moduleVersion(tc.info); got != tc.want {
+				t.Fatalf("moduleVersion() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUserAgentNamesTheSDK(t *testing.T) {
+	agent := userAgent()
+	version, ok := strings.CutPrefix(agent, "agent-compose-chat-go/")
+	if !ok || version == "" {
+		t.Fatalf("userAgent() = %q, want agent-compose-chat-go/<version>", agent)
+	}
+}


### PR DESCRIPTION
## Summary

`sdk/go` is a standalone module meant for external programs, but it has no tags. `go get` resolves it to a pseudo-version of main's latest commit (currently `v0.0.0-20260911074743-142bf085afdd`, i.e. #673, which doesn't touch the SDK). There is also no way to say which daemon a given SDK release works with. This PR prepares the first tag:

- **CI:** a new `Go chat SDK` job runs `go vet` and `go test -race`. It uses the SDK's own `go.mod`, so it runs on Go 1.24.0 (the minimum the README promises) and builds against the proto version the SDK requires, with no replace. Until now nothing built, vetted, linted or tested this module.
- **Taskfile:** `lint:sdk` is added to `task lint` and `test:sdk` to `task test`. The single lint finding, an unused test helper, is removed.
- **User-Agent:** the hand-kept `agent-compose-chat-go/0.1` is replaced by the SDK module version read from the consuming program's build info, falling back to `devel`.
- **README:** new sections cover installing, v0 versioning rules (a breaking change bumps minor), a compatibility table (SDK / proto / daemon), and how maintainers cut a release. It also removes the `chatui` link, since that directory doesn't exist on main.

The daemon floor in the table (`v2609.2.0`) rests on the wire contract: `agentcompose.proto` at `v2609.2.0` is identical to proto `v0.1.0`, which the SDK requires, and #679 changed only a test on the daemon side. It has not been exercised end to end against that release.

After merge, a maintainer tags `sdk/go/v0.1.0` on main. Consider adding `Go chat SDK` to main's required checks.

## Testing

- `GOTOOLCHAIN=go1.24.0 go vet ./... && go test -race ./...` in `sdk/go` passes, including the new `TestModuleVersion` and `TestUserAgentNamesTheSDK`.
- `task lint:sdk` reports 0 issues and `task test:sdk` passes.
- `./scripts/tests/test-binary-ci-contract.sh` passes, and `actionlint` v1.7.7 reports no issues on `ci.yml`.

## Checklist

- [x] Documentation updated when behavior or configuration changed.
- [x] Tests added or updated for user-visible behavior.
- [x] No secrets, private endpoints, internal certificates, or local runtime state included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

